### PR TITLE
Rename environment config option to saltenv, introduce lock_saltenv option

### DIFF
--- a/doc/ref/configuration/minion.rst
+++ b/doc/ref/configuration/minion.rst
@@ -1725,9 +1725,15 @@ enabled and can be disabled by changing this value to ``False``.
     If ``extmod_whitelist`` is specified, modules which are not whitelisted will also be cleaned here.
 
 .. conf_minion:: environment
+.. conf_minion:: saltenv
 
-``environment``
----------------
+``saltenv``
+-----------
+
+.. versionchanged:: Oxygen
+    Renamed from ``environment`` to ``saltenv``. If ``environment`` is used,
+    ``saltenv`` will take its value. If both are used, ``environment`` will be
+    ignored and ``saltenv`` will be used.
 
 Normally the minion is not isolated to any single environment on the master
 when running states, but the environment can be isolated on the minion side
@@ -1736,7 +1742,25 @@ environments is to isolate via the top file.
 
 .. code-block:: yaml
 
-    environment: dev
+    saltenv: dev
+
+.. conf_minion:: lock_saltenv
+
+``lock_saltenv``
+----------------
+
+.. versionadded:: Oxygen
+
+Default: ``False``
+
+For purposes of running states, this option prevents using the ``saltenv``
+argument to manually set the environment. This is useful to keep a minion which
+has the :conf_minion:`saltenv` option set to ``dev`` from running states from
+an environment other than ``dev``.
+
+.. code-block:: yaml
+
+    lock_saltenv: True
 
 .. conf_minion:: snapper_states
 

--- a/doc/topics/releases/oxygen.rst
+++ b/doc/topics/releases/oxygen.rst
@@ -46,6 +46,25 @@ noon PST so the Stormpath external authentication module has been removed.
 
 https://stormpath.com/oktaplusstormpath
 
+:conf_minion:`environment` config option renamed to :conf_minion:`saltenv`
+--------------------------------------------------------------------------
+
+The :conf_minion:`environment` config option predates referring to a salt
+fileserver environment as a **saltenv**. To pin a minion to a single
+environment for running states, one would use :conf_minion:`environment`, but
+overriding that environment would be done with the ``saltenv`` argument. For
+consistency, :conf_minion:`environment` is now simply referred to as
+:conf_minion:`saltenv`. There are no plans to deprecate or remove
+:conf_minion:`environment`, if used it will log a warning and its value will be
+used as :conf_minion:`saltenv`.
+
+:conf_minion:`lock_saltenv` config option added
+-----------------------------------------------
+
+If set to ``True``, this option will prevent a minion from allowing the
+``saltenv`` argument to override the value set in :conf_minion:`saltenv` when
+running states.
+
 New Grains
 ----------
 

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -1050,7 +1050,7 @@ class Single(object):
                     popts,
                     opts_pkg[u'grains'],
                     opts_pkg[u'id'],
-                    opts_pkg.get(u'environment', u'base')
+                    opts_pkg.get(u'saltenv', u'base')
                     )
             pillar_data = pillar.compile_pillar()
 

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -242,7 +242,10 @@ VALID_OPTS = {
     'autoload_dynamic_modules': bool,
 
     # Force the minion into a single environment when it fetches files from the master
-    'environment': str,
+    'saltenv': str,
+
+    # Prevent saltenv from being overriden on the command line
+    'lock_saltenv': bool,
 
     # Force the minion into a single pillar root when it fetches pillar data from the master
     'pillarenv': str,
@@ -1177,7 +1180,8 @@ DEFAULT_MINION_OPTS = {
     'random_startup_delay': 0,
     'failhard': False,
     'autoload_dynamic_modules': True,
-    'environment': None,
+    'saltenv': None,
+    'lock_saltenv': False,
     'pillarenv': None,
     'pillarenv_from_saltenv': False,
     'pillar_opts': False,
@@ -1454,7 +1458,8 @@ DEFAULT_MASTER_OPTS = {
         },
     'top_file_merging_strategy': 'merge',
     'env_order': [],
-    'environment': None,
+    'saltenv': None,
+    'lock_saltenv': False,
     'default_top': 'base',
     'file_client': 'local',
     'git_pillar_base': 'master',
@@ -3590,6 +3595,24 @@ def apply_minion_config(overrides=None,
     if overrides:
         opts.update(overrides)
 
+    if u'environment' in opts:
+        if u'saltenv' in opts:
+            log.warning(
+                u'The \'saltenv\' and \'environment\' minion config options '
+                u'cannot both be used. Ignoring \'environment\' in favor of '
+                u'\'saltenv\'.',
+            )
+            # Set environment to saltenv in case someone's custom module is
+            # refrencing __opts__['environment']
+            opts[u'environment'] = opts[u'saltenv']
+        else:
+            log.warning(
+                u'The \'environment\' minion config option has been renamed '
+                u'to \'saltenv\'. Using %s as the \'saltenv\' config value.',
+                opts[u'environment']
+            )
+            opts[u'saltenv'] = opts[u'environment']
+
     opts['__cli'] = os.path.basename(sys.argv[0])
 
     # No ID provided. Will getfqdn save us?
@@ -3741,6 +3764,24 @@ def apply_master_config(overrides=None, defaults=None):
     _adjust_log_file_override(overrides, defaults['log_file'])
     if overrides:
         opts.update(overrides)
+
+    if u'environment' in opts:
+        if u'saltenv' in opts:
+            log.warning(
+                u'The \'saltenv\' and \'environment\' master config options '
+                u'cannot both be used. Ignoring \'environment\' in favor of '
+                u'\'saltenv\'.',
+            )
+            # Set environment to saltenv in case someone's custom runner is
+            # refrencing __opts__['environment']
+            opts[u'environment'] = opts[u'saltenv']
+        else:
+            log.warning(
+                u'The \'environment\' master config option has been renamed '
+                u'to \'saltenv\'. Using %s as the \'saltenv\' config value.',
+                opts[u'environment']
+            )
+            opts[u'saltenv'] = opts[u'environment']
 
     if len(opts['sock_dir']) > len(opts['cachedir']) + 10:
         opts['sock_dir'] = os.path.join(opts['cachedir'], '.salt-unix')

--- a/salt/daemons/flo/core.py
+++ b/salt/daemons/flo/core.py
@@ -737,7 +737,7 @@ class SaltLoadPillar(ioflo.base.deeding.Deed):
                  'dst': (master.name, None, 'remote_cmd')}
         load = {'id': self.opts.value['id'],
                 'grains': self.grains.value,
-                'saltenv': self.opts.value['environment'],
+                'saltenv': self.opts.value['saltenv'],
                 'ver': '2',
                 'cmd': '_pillar'}
         self.road_stack.value.transmit({'route': route, 'load': load},

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -736,8 +736,8 @@ class SMinion(MinionBase):
             if not os.path.isdir(pdir):
                 os.makedirs(pdir, 0o700)
             ptop = os.path.join(pdir, u'top.sls')
-            if self.opts[u'environment'] is not None:
-                penv = self.opts[u'environment']
+            if self.opts[u'saltenv'] is not None:
+                penv = self.opts[u'saltenv']
             else:
                 penv = u'base'
             cache_top = {penv: {self.opts[u'id']: [u'cache']}}
@@ -773,7 +773,7 @@ class SMinion(MinionBase):
             self.opts,
             self.opts[u'grains'],
             self.opts[u'id'],
-            self.opts[u'environment'],
+            self.opts[u'saltenv'],
             pillarenv=self.opts.get(u'pillarenv'),
         ).compile_pillar()
 
@@ -1144,7 +1144,7 @@ class Minion(MinionBase):
                 self.opts,
                 self.opts[u'grains'],
                 self.opts[u'id'],
-                self.opts[u'environment'],
+                self.opts[u'saltenv'],
                 pillarenv=self.opts.get(u'pillarenv')
             ).compile_pillar()
 
@@ -2032,7 +2032,7 @@ class Minion(MinionBase):
                     self.opts,
                     self.opts[u'grains'],
                     self.opts[u'id'],
-                    self.opts[u'environment'],
+                    self.opts[u'saltenv'],
                     pillarenv=self.opts.get(u'pillarenv'),
                 ).compile_pillar()
             except SaltClientError:
@@ -3349,7 +3349,7 @@ class ProxyMinion(Minion):
                 self.opts,
                 self.opts[u'grains'],
                 self.opts[u'id'],
-                saltenv=self.opts[u'environment'],
+                saltenv=self.opts[u'saltenv'],
                 pillarenv=self.opts.get(u'pillarenv'),
             ).compile_pillar()
 
@@ -3391,7 +3391,7 @@ class ProxyMinion(Minion):
         # we can then sync any proxymodules down from the master
         # we do a sync_all here in case proxy code was installed by
         # SPM or was manually placed in /srv/salt/_modules etc.
-        self.functions[u'saltutil.sync_all'](saltenv=self.opts[u'environment'])
+        self.functions[u'saltutil.sync_all'](saltenv=self.opts[u'saltenv'])
 
         # Pull in the utils
         self.utils = salt.loader.utils(self.opts)

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -219,7 +219,7 @@ def _gather_pillar(pillarenv, pillar_override):
         __opts__,
         __grains__,
         __opts__['id'],
-        __opts__['environment'],
+        __opts__['saltenv'],
         pillar_override=pillar_override,
         pillarenv=pillarenv
     )

--- a/salt/modules/cp.py
+++ b/salt/modules/cp.py
@@ -49,7 +49,7 @@ def _gather_pillar(pillarenv, pillar_override):
         __opts__,
         __grains__,
         __opts__['id'],
-        __opts__['environment'],
+        __opts__['saltenv'],
         pillar_override=pillar_override,
         pillarenv=pillarenv
     )

--- a/salt/modules/dockermod.py
+++ b/salt/modules/dockermod.py
@@ -5290,7 +5290,7 @@ def _gather_pillar(pillarenv, pillar_override, **grains):
         grains,
         # Not sure if these two are correct
         __opts__['id'],
-        __opts__['environment'],
+        __opts__['saltenv'],
         pillar_override=pillar_override,
         pillarenv=pillarenv
     )

--- a/salt/modules/event.py
+++ b/salt/modules/event.py
@@ -225,7 +225,7 @@ def send(tag,
             data_dict['pillar'] = __pillar__
 
     if with_env_opts:
-        data_dict['saltenv'] = __opts__.get('environment', 'base')
+        data_dict['saltenv'] = __opts__.get('saltenv', 'base')
         data_dict['pillarenv'] = __opts__.get('pillarenv')
 
     if kwargs:

--- a/salt/modules/pillar.py
+++ b/salt/modules/pillar.py
@@ -237,7 +237,7 @@ def items(*args, **kwargs):
     pillarenv = kwargs.get('pillarenv')
     if pillarenv is None:
         if __opts__.get('pillarenv_from_saltenv', False):
-            pillarenv = kwargs.get('saltenv') or __opts__['environment']
+            pillarenv = kwargs.get('saltenv') or __opts__['saltenv']
         else:
             pillarenv = __opts__['pillarenv']
 
@@ -468,7 +468,7 @@ def ext(external, pillar=None):
         __opts__,
         __grains__,
         __opts__['id'],
-        __opts__['environment'],
+        __opts__['saltenv'],
         ext=external,
         pillar_override=pillar)
 

--- a/salt/modules/saltcheck.py
+++ b/salt/modules/saltcheck.py
@@ -509,7 +509,7 @@ class SaltCheck(object):
         # state cache should be updated before running this method
         search_list = []
         cachedir = __opts__.get('cachedir', None)
-        environment = __opts__['environment']
+        environment = __opts__['saltenv']
         if environment:
             path = cachedir + os.sep + "files" + os.sep + environment
             search_list.append(path)

--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -275,7 +275,7 @@ def _get_opts(**kwargs):
                 saltenv = six.text_type(saltenv)
             if opts['lock_saltenv'] and saltenv != opts['saltenv']:
                 raise CommandExecutionError(
-                    'saltenv is locked and cannot be changed'
+                    'lock_saltenv is enabled, saltenv cannot be changed'
                 )
             opts['saltenv'] = kwargs['saltenv']
 

--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -270,9 +270,13 @@ def _get_opts(**kwargs):
 
     if 'saltenv' in kwargs:
         saltenv = kwargs['saltenv']
-        if saltenv is not None and not isinstance(saltenv, six.string_types):
-            opts['saltenv'] = str(kwargs['saltenv'])
-        else:
+        if saltenv is not None:
+            if not isinstance(saltenv, six.string_types):
+                saltenv = six.text_type(saltenv)
+            if opts['lock_saltenv'] and saltenv != opts['saltenv']:
+                raise CommandExecutionError(
+                    'saltenv is locked and cannot be changed'
+                )
             opts['saltenv'] = kwargs['saltenv']
 
     if 'pillarenv' in kwargs or opts.get('pillarenv_from_saltenv', False):

--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -1598,7 +1598,7 @@ def show_sls(mods, test=None, queue=False, **kwargs):
 
     .. code-block:: bash
 
-        salt '*' state.show_sls core,edit.vim dev
+        salt '*' state.show_sls core,edit.vim saltenv=dev
     '''
     if 'env' in kwargs:
         # "env" is not supported; Use "saltenv".
@@ -1814,6 +1814,7 @@ def pkg(pkg_path,
         salt '*' state.pkg /tmp/salt_state.tgz 760a9353810e36f6d81416366fc426dc md5
     '''
     # TODO - Add ability to download from salt master or other source
+    popts = _get_opts(**kwargs)
     if not os.path.isfile(pkg_path):
         return {}
     if not salt.utils.hashutils.get_hash(pkg_path, hash_type) == pkg_sum:
@@ -1848,7 +1849,6 @@ def pkg(pkg_path,
         with salt.utils.files.fopen(roster_grains_json, 'r') as fp_:
             roster_grains = json.load(fp_, object_hook=salt.utils.data.decode_dict)
 
-    popts = _get_opts(**kwargs)
     if os.path.isfile(roster_grains_json):
         popts['grains'] = roster_grains
     popts['fileclient'] = 'local'

--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -271,9 +271,9 @@ def _get_opts(**kwargs):
     if 'saltenv' in kwargs:
         saltenv = kwargs['saltenv']
         if saltenv is not None and not isinstance(saltenv, six.string_types):
-            opts['environment'] = str(kwargs['saltenv'])
+            opts['saltenv'] = str(kwargs['saltenv'])
         else:
-            opts['environment'] = kwargs['saltenv']
+            opts['saltenv'] = kwargs['saltenv']
 
     if 'pillarenv' in kwargs or opts.get('pillarenv_from_saltenv', False):
         pillarenv = kwargs.get('pillarenv') or kwargs.get('saltenv')
@@ -840,7 +840,7 @@ def highstate(test=None, queue=False, **kwargs):
         kwargs.pop('env')
 
     if 'saltenv' in kwargs:
-        opts['environment'] = kwargs['saltenv']
+        opts['saltenv'] = kwargs['saltenv']
 
     if 'pillarenv' in kwargs:
         opts['pillarenv'] = kwargs['pillarenv']
@@ -1032,8 +1032,8 @@ def sls(mods, test=None, exclude=None, queue=False, **kwargs):
 
     # Since this is running a specific SLS file (or files), fall back to the
     # 'base' saltenv if none is configured and none was passed.
-    if opts['environment'] is None:
-        opts['environment'] = 'base'
+    if opts['saltenv'] is None:
+        opts['saltenv'] = 'base'
 
     pillar_override = kwargs.get('pillar')
     pillar_enc = kwargs.get('pillar_enc')
@@ -1089,7 +1089,7 @@ def sls(mods, test=None, exclude=None, queue=False, **kwargs):
     st_.push_active()
     ret = {}
     try:
-        high_, errors = st_.render_highstate({opts['environment']: mods})
+        high_, errors = st_.render_highstate({opts['saltenv']: mods})
 
         if errors:
             __context__['retcode'] = 1
@@ -1411,8 +1411,8 @@ def sls_id(id_, mods, test=None, queue=False, **kwargs):
 
     # Since this is running a specific ID within a specific SLS file, fall back
     # to the 'base' saltenv if none is configured and none was passed.
-    if opts['environment'] is None:
-        opts['environment'] = 'base'
+    if opts['saltenv'] is None:
+        opts['saltenv'] = 'base'
 
     pillar_override = kwargs.get('pillar')
     pillar_enc = kwargs.get('pillar_enc')
@@ -1446,7 +1446,7 @@ def sls_id(id_, mods, test=None, queue=False, **kwargs):
         split_mods = mods.split(',')
     st_.push_active()
     try:
-        high_, errors = st_.render_highstate({opts['environment']: split_mods})
+        high_, errors = st_.render_highstate({opts['saltenv']: split_mods})
     finally:
         st_.pop_active()
     errors += st_.state.verify_high(high_)
@@ -1472,7 +1472,7 @@ def sls_id(id_, mods, test=None, queue=False, **kwargs):
     if not ret:
         raise SaltInvocationError(
             'No matches for ID \'{0}\' found in SLS \'{1}\' within saltenv '
-            '\'{2}\''.format(id_, mods, opts['environment'])
+            '\'{2}\''.format(id_, mods, opts['saltenv'])
         )
     return ret
 
@@ -1523,8 +1523,8 @@ def show_low_sls(mods, test=None, queue=False, **kwargs):
 
     # Since this is dealing with a specific SLS file (or files), fall back to
     # the 'base' saltenv if none is configured and none was passed.
-    if opts['environment'] is None:
-        opts['environment'] = 'base'
+    if opts['saltenv'] is None:
+        opts['saltenv'] = 'base'
 
     pillar_override = kwargs.get('pillar')
     pillar_enc = kwargs.get('pillar_enc')
@@ -1555,7 +1555,7 @@ def show_low_sls(mods, test=None, queue=False, **kwargs):
         mods = mods.split(',')
     st_.push_active()
     try:
-        high_, errors = st_.render_highstate({opts['environment']: mods})
+        high_, errors = st_.render_highstate({opts['saltenv']: mods})
     finally:
         st_.pop_active()
     errors += st_.state.verify_high(high_)
@@ -1610,8 +1610,8 @@ def show_sls(mods, test=None, queue=False, **kwargs):
 
     # Since this is dealing with a specific SLS file (or files), fall back to
     # the 'base' saltenv if none is configured and none was passed.
-    if opts['environment'] is None:
-        opts['environment'] = 'base'
+    if opts['saltenv'] is None:
+        opts['saltenv'] = 'base'
 
     pillar_override = kwargs.get('pillar')
     pillar_enc = kwargs.get('pillar_enc')
@@ -1644,7 +1644,7 @@ def show_sls(mods, test=None, queue=False, **kwargs):
         mods = mods.split(',')
     st_.push_active()
     try:
-        high_, errors = st_.render_highstate({opts['environment']: mods})
+        high_, errors = st_.render_highstate({opts['saltenv']: mods})
     finally:
         st_.pop_active()
     errors += st_.state.verify_high(high_)

--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -138,7 +138,7 @@ class AsyncRemotePillar(RemotePillarMixin):
     def __init__(self, opts, grains, minion_id, saltenv, ext=None, functions=None,
                  pillar_override=None, pillarenv=None, extra_minion_data=None):
         self.opts = opts
-        self.opts['environment'] = saltenv
+        self.opts['saltenv'] = saltenv
         self.ext = ext
         self.grains = grains
         self.minion_id = minion_id
@@ -165,7 +165,7 @@ class AsyncRemotePillar(RemotePillarMixin):
         '''
         load = {'id': self.minion_id,
                 'grains': self.grains,
-                'saltenv': self.opts['environment'],
+                'saltenv': self.opts['saltenv'],
                 'pillarenv': self.opts['pillarenv'],
                 'pillar_override': self.pillar_override,
                 'extra_minion_data': self.extra_minion_data,
@@ -198,7 +198,7 @@ class RemotePillar(RemotePillarMixin):
     def __init__(self, opts, grains, minion_id, saltenv, ext=None, functions=None,
                  pillar_override=None, pillarenv=None, extra_minion_data=None):
         self.opts = opts
-        self.opts['environment'] = saltenv
+        self.opts['saltenv'] = saltenv
         self.ext = ext
         self.grains = grains
         self.minion_id = minion_id
@@ -224,7 +224,7 @@ class RemotePillar(RemotePillarMixin):
         '''
         load = {'id': self.minion_id,
                 'grains': self.grains,
-                'saltenv': self.opts['environment'],
+                'saltenv': self.opts['saltenv'],
                 'pillarenv': self.opts['pillarenv'],
                 'pillar_override': self.pillar_override,
                 'extra_minion_data': self.extra_minion_data,
@@ -445,9 +445,9 @@ class Pillar(object):
         else:
             opts['grains'] = grains
         # Allow minion/CLI saltenv/pillarenv to take precedence over master
-        opts['environment'] = saltenv \
+        opts['saltenv'] = saltenv \
             if saltenv is not None \
-            else opts.get('environment')
+            else opts.get('saltenv')
         opts['pillarenv'] = pillarenv \
             if pillarenv is not None \
             else opts.get('pillarenv')

--- a/salt/pillar/git_pillar.py
+++ b/salt/pillar/git_pillar.py
@@ -404,7 +404,7 @@ def ext_pillar(minion_id, pillar, *repos):  # pylint: disable=unused-argument
         # Map env if env == '__env__' before checking the env value
         if env == '__env__':
             env = opts.get('pillarenv') \
-                or opts.get('environment') \
+                or opts.get('saltenv') \
                 or opts.get('git_pillar_base')
             log.debug('__env__ maps to %s', env)
 

--- a/salt/state.py
+++ b/salt/state.py
@@ -1892,20 +1892,27 @@ class State(object):
                     (u'onlyif' in low and u'{0[state]}.mod_run_check'.format(low) not in self.states):
                 ret.update(self._run_check(low))
 
-            if u'saltenv' in low:
-                inject_globals[u'__env__'] = six.text_type(low[u'saltenv'])
-            elif isinstance(cdata[u'kwargs'].get(u'env', None), six.string_types):
-                # User is using a deprecated env setting which was parsed by
-                # format_call.
-                # We check for a string type since module functions which
-                # allow setting the OS environ also make use of the "env"
-                # keyword argument, which is not a string
-                inject_globals[u'__env__'] = six.text_type(cdata[u'kwargs'][u'env'])
-            elif u'__env__' in low:
-                # The user is passing an alternative environment using __env__
-                # which is also not the appropriate choice, still, handle it
-                inject_globals[u'__env__'] = six.text_type(low[u'__env__'])
-            else:
+            if not self.opts.get(u'lock_saltenv', False):
+                # NOTE: Overriding the saltenv when lock_saltenv is blocked in
+                # salt/modules/state.py, before we ever get here, but this
+                # additional check keeps use of the State class outside of the
+                # salt/modules/state.py from getting around this setting.
+                if u'saltenv' in low:
+                    inject_globals[u'__env__'] = six.text_type(low[u'saltenv'])
+                elif isinstance(cdata[u'kwargs'].get(u'env', None), six.string_types):
+                    # User is using a deprecated env setting which was parsed by
+                    # format_call.
+                    # We check for a string type since module functions which
+                    # allow setting the OS environ also make use of the "env"
+                    # keyword argument, which is not a string
+                    inject_globals[u'__env__'] = six.text_type(cdata[u'kwargs'][u'env'])
+                elif u'__env__' in low:
+                    # The user is passing an alternative environment using
+                    # __env__ which is also not the appropriate choice, still,
+                    # handle it
+                    inject_globals[u'__env__'] = six.text_type(low[u'__env__'])
+
+            if u'__env__' not in inject_globals:
                 # Let's use the default environment
                 inject_globals[u'__env__'] = u'base'
 

--- a/salt/state.py
+++ b/salt/state.py
@@ -763,7 +763,7 @@ class State(object):
                 self.opts,
                 self.opts[u'grains'],
                 self.opts[u'id'],
-                self.opts[u'environment'],
+                self.opts[u'saltenv'],
                 pillar_override=self._pillar_override,
                 pillarenv=self.opts.get(u'pillarenv'))
         return pillar.compile_pillar()
@@ -2900,32 +2900,32 @@ class BaseHighState(object):
         found = 0  # did we find any contents in the top files?
         # Gather initial top files
         merging_strategy = self.opts[u'top_file_merging_strategy']
-        if merging_strategy == u'same' and not self.opts[u'environment']:
+        if merging_strategy == u'same' and not self.opts[u'saltenv']:
             if not self.opts[u'default_top']:
                 raise SaltRenderError(
                     u'top_file_merging_strategy set to \'same\', but no '
                     u'default_top configuration option was set'
                 )
 
-        if self.opts[u'environment']:
+        if self.opts[u'saltenv']:
             contents = self.client.cache_file(
                 self.opts[u'state_top'],
-                self.opts[u'environment']
+                self.opts[u'saltenv']
             )
             if contents:
                 found = 1
-                tops[self.opts[u'environment']] = [
+                tops[self.opts[u'saltenv']] = [
                     compile_template(
                         contents,
                         self.state.rend,
                         self.state.opts[u'renderer'],
                         self.state.opts[u'renderer_blacklist'],
                         self.state.opts[u'renderer_whitelist'],
-                        saltenv=self.opts[u'environment']
+                        saltenv=self.opts[u'saltenv']
                     )
                 ]
             else:
-                tops[self.opts[u'environment']] = [{}]
+                tops[self.opts[u'saltenv']] = [{}]
 
         else:
             found = 0
@@ -3257,8 +3257,8 @@ class BaseHighState(object):
         matches = DefaultOrderedDict(OrderedDict)
         # pylint: disable=cell-var-from-loop
         for saltenv, body in six.iteritems(top):
-            if self.opts[u'environment']:
-                if saltenv != self.opts[u'environment']:
+            if self.opts[u'saltenv']:
+                if saltenv != self.opts[u'saltenv']:
                     continue
             for match, data in six.iteritems(body):
                 def _filter_matches(_match, _data, _opts):

--- a/salt/utils/gitfs.py
+++ b/salt/utils/gitfs.py
@@ -910,7 +910,7 @@ class GitProvider(object):
         '''
         if self.branch == '__env__':
             target = self.opts.get('pillarenv') \
-                or self.opts.get('environment') \
+                or self.opts.get('saltenv') \
                 or 'base'
             return self.opts['{0}_base'.format(self.role)] \
                 if target == 'base' \

--- a/tests/saltsh.py
+++ b/tests/saltsh.py
@@ -90,7 +90,7 @@ def get_salt_vars():
             __opts__,
             __grains__,
             __opts__.get('id'),
-            __opts__.get('environment'),
+            __opts__.get('saltenv'),
         ).compile_pillar()
     else:
         __pillar__ = {}

--- a/tests/unit/modules/test_state.py
+++ b/tests/unit/modules/test_state.py
@@ -25,7 +25,7 @@ import salt.utils.hashutils
 import salt.utils.odict
 import salt.utils.platform
 import salt.modules.state as state
-from salt.exceptions import SaltInvocationError
+from salt.exceptions import CommandExecutionError, SaltInvocationError
 from salt.ext import six
 
 
@@ -362,7 +362,7 @@ class StateTestCase(TestCase, LoaderModuleMockMixin):
             state: {
                 '__opts__': {
                     'cachedir': '/D',
-                    'environment': None,
+                    'saltenv': None,
                     '__cli': 'salt',
                 },
                 '__utils__': utils,
@@ -632,7 +632,7 @@ class StateTestCase(TestCase, LoaderModuleMockMixin):
             with patch.dict(state.__opts__, {"test": "A"}):
                 mock = MagicMock(
                     return_value={'test': True,
-                                  'environment': None}
+                                  'saltenv': None}
                 )
                 with patch.object(state, '_get_opts', mock):
                     mock = MagicMock(return_value=True)
@@ -659,7 +659,7 @@ class StateTestCase(TestCase, LoaderModuleMockMixin):
             with patch.dict(state.__opts__, {"test": "A"}):
                 mock = MagicMock(
                     return_value={'test': True,
-                                  'environment': None}
+                                  'saltenv': None}
                 )
                 with patch.object(state, '_get_opts', mock):
                     MockState.State.flag = True
@@ -681,7 +681,7 @@ class StateTestCase(TestCase, LoaderModuleMockMixin):
             with patch.dict(state.__opts__, {"test": "A"}):
                 mock = MagicMock(
                     return_value={'test': True,
-                                  'environment': None}
+                                  'saltenv': None}
                 )
                 with patch.object(state, '_get_opts', mock):
                     mock = MagicMock(return_value=True)
@@ -881,7 +881,7 @@ class StateTestCase(TestCase, LoaderModuleMockMixin):
 
                     with patch.dict(state.__opts__, {"test": None}):
                         mock = MagicMock(return_value={"test": "",
-                                                       "environment": None})
+                                                       "saltenv": None})
                         with patch.object(state, '_get_opts', mock):
                             mock = MagicMock(return_value=True)
                             with patch.object(salt.utils,
@@ -993,3 +993,82 @@ class StateTestCase(TestCase, LoaderModuleMockMixin):
                 else:
                     with patch('salt.utils.files.fopen', mock_open()):
                         self.assertTrue(state.pkg(tar_file, 0, "md5"))
+
+    def test_lock_saltenv(self):
+        '''
+        Tests lock_saltenv in each function which accepts saltenv on the CLI
+        '''
+        lock_msg = 'saltenv is locked and cannot be changed'
+        empty_list_mock = MagicMock(return_value=[])
+        with patch.dict(state.__opts__, {'lock_saltenv': True}), \
+                patch.dict(state.__salt__, {'grains.get': empty_list_mock}), \
+                patch.object(state, 'running', empty_list_mock):
+
+            # Test high
+            with self.assertRaisesRegex(CommandExecutionError, lock_msg):
+                state.high(
+                    [{"vim": {"pkg": ["installed"]}}], saltenv='base')
+
+            # Test template
+            with self.assertRaisesRegex(CommandExecutionError, lock_msg):
+                state.template('foo', saltenv='base')
+
+            # Test template_str
+            with self.assertRaisesRegex(CommandExecutionError, lock_msg):
+                state.template_str('foo', saltenv='base')
+
+            # Test apply_ with SLS
+            with self.assertRaisesRegex(CommandExecutionError, lock_msg):
+                state.apply_('foo', saltenv='base')
+
+            # Test apply_ with Highstate
+            with self.assertRaisesRegex(CommandExecutionError, lock_msg):
+                state.apply_(saltenv='base')
+
+            # Test highstate
+            with self.assertRaisesRegex(CommandExecutionError, lock_msg):
+                state.highstate(saltenv='base')
+
+            # Test sls
+            with self.assertRaisesRegex(CommandExecutionError, lock_msg):
+                state.sls('foo', saltenv='base')
+
+            # Test top
+            with self.assertRaisesRegex(CommandExecutionError, lock_msg):
+                state.top('foo.sls', saltenv='base')
+
+            # Test show_highstate
+            with self.assertRaisesRegex(CommandExecutionError, lock_msg):
+                state.show_highstate(saltenv='base')
+
+            # Test show_lowstate
+            with self.assertRaisesRegex(CommandExecutionError, lock_msg):
+                state.show_lowstate(saltenv='base')
+
+            # Test sls_id
+            with self.assertRaisesRegex(CommandExecutionError, lock_msg):
+                state.sls_id('foo', 'bar', saltenv='base')
+
+            # Test show_low_sls
+            with self.assertRaisesRegex(CommandExecutionError, lock_msg):
+                state.show_low_sls('foo', saltenv='base')
+
+            # Test show_sls
+            with self.assertRaisesRegex(CommandExecutionError, lock_msg):
+                state.show_sls('foo', saltenv='base')
+
+            # Test show_top
+            with self.assertRaisesRegex(CommandExecutionError, lock_msg):
+                state.show_top(saltenv='base')
+
+            # Test single
+            with self.assertRaisesRegex(CommandExecutionError, lock_msg):
+                state.single('foo.bar', name='baz', saltenv='base')
+
+            # Test pkg
+            with self.assertRaisesRegex(CommandExecutionError, lock_msg):
+                state.pkg(
+                    '/tmp/salt_state.tgz',
+                    '760a9353810e36f6d81416366fc426dc',
+                    'md5',
+                    saltenv='base')

--- a/tests/unit/modules/test_state.py
+++ b/tests/unit/modules/test_state.py
@@ -998,7 +998,7 @@ class StateTestCase(TestCase, LoaderModuleMockMixin):
         '''
         Tests lock_saltenv in each function which accepts saltenv on the CLI
         '''
-        lock_msg = 'saltenv is locked and cannot be changed'
+        lock_msg = 'lock_saltenv is enabled, saltenv cannot be changed'
         empty_list_mock = MagicMock(return_value=[])
         with patch.dict(state.__opts__, {'lock_saltenv': True}), \
                 patch.dict(state.__salt__, {'grains.get': empty_list_mock}), \

--- a/tests/unit/test_pillar.py
+++ b/tests/unit/test_pillar.py
@@ -55,7 +55,7 @@ class PillarTestCase(TestCase):
                 'os': 'Ubuntu',
             }
             pillar = salt.pillar.Pillar(opts, grains, 'mocked-minion', 'dev')
-            self.assertEqual(pillar.opts['environment'], 'dev')
+            self.assertEqual(pillar.opts['saltenv'], 'dev')
             self.assertEqual(pillar.opts['pillarenv'], 'dev')
 
     def test_ext_pillar_no_extra_minion_data_val_dict(self):
@@ -416,7 +416,7 @@ class PillarTestCase(TestCase):
                 'state_top': '',
                 'pillar_roots': [],
                 'extension_modules': '',
-                'environment': 'base',
+                'saltenv': 'base',
                 'file_roots': [],
             }
             grains = {
@@ -584,7 +584,7 @@ class RemotePillarTestCase(TestCase):
 
             salt.pillar.RemotePillar({}, self.grains, 'mocked-minion', 'dev')
         mock_get_extra_minion_data.assert_called_once_with(
-            {'environment': 'dev'})
+            {'saltenv': 'dev'})
 
     def test_multiple_keys_in_opts_added_to_pillar(self):
         opts = {
@@ -702,7 +702,7 @@ class AsyncRemotePillarTestCase(TestCase):
 
             salt.pillar.RemotePillar({}, self.grains, 'mocked-minion', 'dev')
         mock_get_extra_minion_data.assert_called_once_with(
-            {'environment': 'dev'})
+            {'saltenv': 'dev'})
 
     def test_pillar_send_extra_minion_data_from_config(self):
         opts = {


### PR DESCRIPTION
This PR does two things:

1. Renames the `environment` config option to `saltenv`. The name `environment` predates the `saltenv` nomenclature introduced a couple years ago. Additionally, we now have a config option to pin the pillarenv, called `pillarenv`, which can be overridden in states using the `pillarenv` CLI argument. On the other hand, we have the `environment` config option to pin the saltenv, which is overridden using the `saltenv` CLI argument. So there's some asymmetry there. Per @thatch45 we are not putting `environment` on a deprecation path, it will just have its value copied to `saltenv` if used.

2. Introduces a new config option called `lock_saltenv` which can be used to
keep states from overriding the saltenv set in the `saltenv` (née
`environment`) config option.

A unit test has been added to confirm that attempting to override the saltenv will raise an exception.

Refs: https://github.com/saltstack/salt/issues/36275