### PR TITLE
Win chocolatey

### DIFF
--- a/salt/modules/chocolatey.py
+++ b/salt/modules/chocolatey.py
@@ -369,7 +369,6 @@ def install(name,
             force_x86=False,
             package_args=None,
             allow_multiple=False,
-            no_progress=False,
             execution_timeout=None):
     '''
     Instructs Chocolatey to install a package.
@@ -426,9 +425,6 @@ def install(name,
 
             .. versionadded:: 2017.7.0
 
-        no_progress
-            Do not show download progress percentages. Defaults to False.
-
         execution_timeout (str):
         Chocolatey execution timeout value you want to pass to the installation process. Default is None.
 
@@ -472,11 +468,13 @@ def install(name,
         cmd.extend(['--packageparameters', package_args])
     if allow_multiple:
         cmd.append('--allow-multiple')
-    if no_progress:
-        cmd.append(_no_progress(__context__))
     if execution_timeout:
         cmd.extend(['--execution-timeout', execution_timeout])
+
+    # Salt doesn't need to see the progress
+    cmd.extend(_no_progress(__context__))
     cmd.extend(_yes(__context__))
+
     result = __salt__['cmd.run_all'](cmd, python_shell=False)
 
     if result['retcode'] not in [0, 1641, 3010]:
@@ -746,13 +744,12 @@ def upgrade(name,
             install_args=None,
             override_args=False,
             force_x86=False,
-            package_args=None,
-            no_progress=False):
+            package_args=None):
     '''
     .. versionadded:: 2016.3.4
 
     Instructs Chocolatey to upgrade packages on the system. (update is being
-    deprecated)
+    deprecated). This command will install the package if not installed.
 
     Args:
 
@@ -790,9 +787,6 @@ def upgrade(name,
         package_args
             A list of arguments you want to pass to the package
 
-        no_progress
-            Do not show download progress percentages. Defaults to False.
-
     Returns:
         str: Results of the ``chocolatey`` command
 
@@ -807,7 +801,7 @@ def upgrade(name,
     choc_path = _find_chocolatey(__context__, __salt__)
     cmd = [choc_path, 'upgrade', name]
     if version:
-        cmd.extend(['-version', version])
+        cmd.extend(['--version', version])
     if source:
         cmd.extend(['--source', source])
     if salt.utils.data.is_true(force):
@@ -822,9 +816,9 @@ def upgrade(name,
         cmd.append('--forcex86')
     if package_args:
         cmd.extend(['--packageparameters', package_args])
-    if no_progress:
-        cmd.append(_no_progress(__context__))
 
+    # Salt doesn't need to see the progress
+    cmd.extend(_no_progress(__context__))
     cmd.extend(_yes(__context__))
 
     result = __salt__['cmd.run_all'](cmd, python_shell=False)
@@ -836,7 +830,7 @@ def upgrade(name,
     return result['stdout']
 
 
-def update(name, source=None, pre_versions=False, no_progress=False):
+def update(name, source=None, pre_versions=False):
     '''
     Instructs Chocolatey to update packages on the system.
 
@@ -850,9 +844,6 @@ def update(name, source=None, pre_versions=False, no_progress=False):
 
     pre_versions
         Include pre-release packages in comparison. Defaults to False.
-
-    no_progress
-        Do not show download progress percentages. Defaults to False.
 
     CLI Example:
 
@@ -872,9 +863,11 @@ def update(name, source=None, pre_versions=False, no_progress=False):
         cmd.extend(['--source', source])
     if salt.utils.data.is_true(pre_versions):
         cmd.append('--prerelease')
-    if no_progress:
-        cmd.append(_no_progress(__context__))
+
+    # Salt doesn't need to see the progress
+    cmd.extend(_no_progress(__context__))
     cmd.extend(_yes(__context__))
+
     result = __salt__['cmd.run_all'](cmd, python_shell=False)
 
     if result['retcode'] not in [0, 1641, 3010]:

--- a/salt/states/chocolatey.py
+++ b/salt/states/chocolatey.py
@@ -276,7 +276,7 @@ def upgraded(name,
     '''
     Upgrades a package. Will install the package if not installed.
 
-    .. versionadded: 2017.7.3
+    .. versionadded: Oxygen
 
     Args:
 

--- a/salt/states/chocolatey.py
+++ b/salt/states/chocolatey.py
@@ -3,6 +3,12 @@
 '''
 Manage Chocolatey package installs
 .. versionadded:: 2016.3.0
+
+.. note::
+    Chocolatey pulls data from the Chocolatey internet database to determine
+    current versions, find available versions, etc. This is normally a slow
+    operation and may be optimized by specifying a local, smaller chocolatey
+    repo.
 '''
 
 # Import Python libs
@@ -276,7 +282,7 @@ def upgraded(name,
     '''
     Upgrades a package. Will install the package if not installed.
 
-    .. versionadded: Oxygen
+    .. versionadded: 2017.7.3
 
     Args:
 
@@ -331,7 +337,6 @@ def upgraded(name,
            'comment': ''}
 
     # Get list of currently installed packages
-    # This should be relatively fast as it's local only
     pre_install = __salt__['chocolatey.list'](local_only=True)
 
     # Determine if there are changes
@@ -404,7 +409,6 @@ def upgraded(name,
         return ret
 
     # Install the package
-    # This could take a while
     result = __salt__['chocolatey.upgrade'](name=name,
                                             version=version,
                                             source=source,
@@ -423,7 +427,6 @@ def upgraded(name,
         ret['result'] = False
 
     # Get list of installed packages after 'chocolatey.install'
-    # This should be relatively fast as it's local only
     post_install = __salt__['chocolatey.list'](local_only=True)
 
     ret['changes'] = salt.utils.compare_dicts(pre_install, post_install)

--- a/salt/states/chocolatey.py
+++ b/salt/states/chocolatey.py
@@ -331,6 +331,7 @@ def upgraded(name,
            'comment': ''}
 
     # Get list of currently installed packages
+    # This should be relatively fast as it's local only
     pre_install = __salt__['chocolatey.list'](local_only=True)
 
     # Determine if there are changes
@@ -403,6 +404,7 @@ def upgraded(name,
         return ret
 
     # Install the package
+    # This could take a while
     result = __salt__['chocolatey.upgrade'](name=name,
                                             version=version,
                                             source=source,
@@ -421,6 +423,7 @@ def upgraded(name,
         ret['result'] = False
 
     # Get list of installed packages after 'chocolatey.install'
+    # This should be relatively fast as it's local only
     post_install = __salt__['chocolatey.list'](local_only=True)
 
     ret['changes'] = salt.utils.compare_dicts(pre_install, post_install)

--- a/salt/states/chocolatey.py
+++ b/salt/states/chocolatey.py
@@ -282,7 +282,7 @@ def upgraded(name,
     '''
     Upgrades a package. Will install the package if not installed.
 
-    .. versionadded: 2017.7.3
+    .. versionadded: Oxygen
 
     Args:
 

--- a/salt/states/chocolatey.py
+++ b/salt/states/chocolatey.py
@@ -262,3 +262,167 @@ def uninstalled(name, version=None, uninstall_args=None, override_args=False):
     ret['changes'] = salt.utils.data.compare_dicts(pre_uninstall, post_uninstall)
 
     return ret
+
+
+def upgraded(name,
+             version=None,
+             source=None,
+             force=False,
+             pre_versions=False,
+             install_args=None,
+             override_args=False,
+             force_x86=False,
+             package_args=None):
+    '''
+    Upgrades a package. Will install the package if not installed.
+
+    .. versionadded: 2017.7.3
+
+    Args:
+
+        name (str):
+            The name of the package to be installed. Required.
+
+        version (str):
+            Install a specific version of the package. Defaults to latest
+            version. If the version is greater than the one installed then the
+            specified version will be installed. Default is None.
+
+        source (str):
+            Chocolatey repository (directory, share or remote URL, feed).
+            Defaults to the official Chocolatey feed. Default is None.
+
+        force (bool):
+            Reinstall the current version of an existing package. Do not use
+            with ``allow_multiple``. Default is False.
+
+        pre_versions (bool):
+            Include pre-release packages. Default is False.
+
+        install_args (str):
+            Install arguments you want to pass to the installation process, i.e
+            product key or feature list. Default is None.
+
+        override_args (bool):
+            Set to True if you want to override the original install arguments
+            (for the native installer) in the package and use your own. When
+            this is set to False install_args will be appended to the end of the
+            default arguments. Default is False.
+
+        force_x86 (bool):
+            Force x86 (32bit) installation on 64 bit systems. Default is False.
+
+        package_args (str):
+            Arguments you want to pass to the package. Default is None.
+
+    .. code-block:: yaml
+
+        Installsomepackage:
+          chocolatey.installed:
+            - name: packagename
+            - version: '12.04'
+            - source: 'mychocolatey/source'
+            - force: True
+    '''
+    ret = {'name': name,
+           'result': True,
+           'changes': {},
+           'pchanges': {},
+           'comment': ''}
+
+    # Get list of currently installed packages
+    pre_install = __salt__['chocolatey.list'](local_only=True)
+
+    # Determine if there are changes
+    # Package not installed
+    if name.lower() not in [package.lower() for package in pre_install.keys()]:
+        if version:
+            ret['pchanges'] = {name: 'Version {0} will be installed'
+                                     ''.format(version)}
+        else:
+            ret['pchanges'] = {name: 'Latest version will be installed'}
+
+    # Package installed
+    else:
+        version_info = __salt__['chocolatey.version'](name, check_remote=True)
+
+        # Get the actual full name out of version_info
+        full_name = name
+        for pkg in version_info:
+            if name.lower() == pkg.lower():
+                full_name = pkg
+
+        installed_version = version_info[full_name]['installed'][0]
+
+        # If version is not passed, use available... if available is available
+        if not version:
+            if 'available' in version_info[full_name]:
+                version = version_info[full_name]['available'][0]
+
+        if version:
+
+            # If installed version and new version are the same
+            if salt.utils.compare_versions(
+                    ver1=installed_version,
+                    oper="==",
+                    ver2=version):
+                if force:
+                    ret['pchanges'] = {
+                        name: 'Version {0} will be reinstalled'.format(version)}
+                    ret['comment'] = 'Reinstall {0} {1}' \
+                                     ''.format(full_name, version)
+                else:
+                    ret['comment'] = '{0} {1} is already installed' \
+                                     ''.format(name, version)
+            else:
+                # If installed version is older than new version
+                if salt.utils.compare_versions(
+                        ver1=installed_version, oper="<", ver2=version):
+                    ret['pchanges'] = {
+                        name: 'Version {0} will be upgraded to Version {1} '
+                              ''.format(installed_version, version)}
+                    ret['comment'] = 'Upgrade {0} {1} to {2}' \
+                                     ''.format(full_name, installed_version, version)
+                # If installed version is newer than new version
+                else:
+                    ret['comment'] = '{0} {1} is already installed (newer)' \
+                                     ''.format(name, version)
+
+        # Catch all for a condition where version is not passed and there is no
+        # available version
+        else:
+            ret['comment'] = 'No version found to install'
+
+    # Return if there are no changes to be made
+    if not ret['pchanges']:
+        ret['result'] = True
+        return ret
+
+    # Return if `test=True`
+    if __opts__['test']:
+        return ret
+
+    # Install the package
+    result = __salt__['chocolatey.upgrade'](name=name,
+                                            version=version,
+                                            source=source,
+                                            force=force,
+                                            pre_versions=pre_versions,
+                                            install_args=install_args,
+                                            override_args=override_args,
+                                            force_x86=force_x86,
+                                            package_args=package_args)
+
+    if 'Running chocolatey failed' not in result:
+        ret['comment'] = 'Package {0} upgraded successfully'.format(name)
+        ret['result'] = True
+    else:
+        ret['comment'] = 'Failed to upgrade the package {0}'.format(name)
+        ret['result'] = False
+
+    # Get list of installed packages after 'chocolatey.install'
+    post_install = __salt__['chocolatey.list'](local_only=True)
+
+    ret['changes'] = salt.utils.compare_dicts(pre_install, post_install)
+
+    return ret

--- a/tests/integration/states/test_chocolatey.py
+++ b/tests/integration/states/test_chocolatey.py
@@ -50,45 +50,57 @@ class ChocolateyTest(ModuleCase, SaltReturnAssertsMixin):
         target = 'firefox'
         pre_version = '52.0.2'
         upg_version = '57.0.2'
+        log.debug('Making sure {0} is not installed'.format(target))
         self.assertFalse(
             self.run_function('chocolatey.version', [target]))
 
-        ####################################################
-        # Test `chocolatey.installed`
-        ####################################################
-        # Install the package
-        ret = self.run_state(
-            'chocolatey.installed',
-            name=target,
-            version=pre_version)
-        self.assertSaltTrueReturn(ret)
+        try:
+            ####################################################
+            # Test `chocolatey.installed`
+            ####################################################
+            # Install the package
+            log.debug('Testing chocolatey.installed')
+            ret = self.run_state(
+                'chocolatey.installed',
+                name=target,
+                version=pre_version)
+            self.assertSaltTrueReturn(ret)
 
-        # Verify the package is installed
-        ret = self.run_function('chocolatey.version', [target])
-        self.assertEqual(ret, {'Firefox': pre_version})
+            # Verify the package is installed
+            log.debug('Verifying install success')
+            ret = self.run_function('chocolatey.version', [target])
+            self.assertEqual(ret, {'Firefox': [pre_version]})
 
-        ####################################################
-        # Test `chocolatey.upgraded`
-        ####################################################
-        # Upgrade the package
-        ret = self.run_state(
-            'chocolatey.upgraded',
-            name=target,
-            version=upg_version)
-        self.assertSaltTrueReturn(ret)
+            ####################################################
+            # Test `chocolatey.upgraded`
+            ####################################################
+            # Upgrade the package
+            log.debug('Testing chocolatey.upgraded')
+            ret = self.run_state(
+                'chocolatey.upgraded',
+                name=target,
+                version=upg_version)
+            self.assertSaltTrueReturn(ret)
 
-        # Verify the package is upgraded
-        ret = self.run_function('chocolatey.version', [target])
-        self.assertEqual(ret, {'Firefox': upg_version})
+            # Verify the package is upgraded
+            log.debug('Verifying upgrade success')
+            ret = self.run_function('chocolatey.version', [target])
+            self.assertEqual(ret, {'Firefox': [upg_version]})
 
-        ####################################################
-        # Test `chocolatey.uninstalled`
-        ####################################################
-        # uninstall the package
-        ret = self.run_state('chocolatey.uninstalled', name=target)
-        self.assertSaltTrueReturn(ret)
+            ####################################################
+            # Test `chocolatey.uninstalled`
+            ####################################################
+            # uninstall the package
+            log.debug('Testing chocolatey.uninstalled')
+            ret = self.run_state('chocolatey.uninstalled', name=target)
+            self.assertSaltTrueReturn(ret)
 
-        # Verify the package is uninstalled
-        ret = self.run_function('chocolatey.version', [target])
-        self.assertEqual(ret, {})
+            # Verify the package is uninstalled
+            log.debug('Verifying uninstall success')
+            ret = self.run_function('chocolatey.version', [target])
+            self.assertEqual(ret, {})
 
+        finally:
+            # Always uninstall
+            log.debug('Uninstalling {0}'.format(target))
+            self.run_function('chocolatey.uninstall', [target])

--- a/tests/integration/states/test_chocolatey.py
+++ b/tests/integration/states/test_chocolatey.py
@@ -1,0 +1,122 @@
+# -*- coding: utf-8 -*-
+'''
+Tests for the Chocolatey State
+'''
+# Import Python libs
+from __future__ import absolute_import
+import logging
+
+# Import Salt Testing libs
+from tests.support.case import ModuleCase
+from tests.support.mixins import SaltReturnAssertsMixin
+from tests.support.unit import skipIf
+from tests.support.helpers import destructiveTest
+
+# Import Salt libs
+import salt.utils.platform
+
+log = logging.getLogger(__name__)
+
+__testcontext__ = {}
+
+
+@destructiveTest
+@skipIf(not salt.utils.platform.is_windows(), 'Windows Specific Test')
+class ChocolateyTest(ModuleCase, SaltReturnAssertsMixin):
+    '''
+    Chocolatey State Tests
+    These tests are destructive as the install and remove software
+    '''
+
+    def setUp(self):
+        '''
+        Ensure that Chocolatey is installed
+        '''
+        super(ChocolateyTest, self).setUp()
+        if 'chocolatey' not in __testcontext__:
+            self.run_function('chocolatey.bootstrap')
+            __testcontext__['chocolatey'] = True
+
+    def test_installed(self):
+        '''
+        Test `chocolatey.installed`
+        '''
+
+        # If this assert fails, we need to find new targets, this test needs to
+        # be able to test successful installation of packages, so this package
+        # needs to NOT be installed before we run the states below
+        target = 'firefox'
+        self.assertFalse(
+            self.run_function('chocolatey.version', [target]))
+
+        try:
+            # Install the package
+            ret = self.run_state('chocolatey.installed', name=target)
+            self.assertSaltTrueReturn(ret)
+
+            # Verify the package is installed
+            self.assertTrue(
+                self.run_function('chocolatey.version', [target]))
+
+        finally:
+            # Uninstall the package (cleanup)
+            ret = self.run_state('chocolatey.uninstalled', name=target)
+            self.assertSaltTrueReturn(ret)
+
+    def test_uninstalled(self):
+        '''
+        Test `chocolatey.uninstalled`
+        '''
+
+        # Make sure firefox is installed by chocolatey
+        target = 'firefox'
+        if not self.run_function('chocolatey.version', [target]):
+            self.assertTrue(
+                self.run_function('chocolatey.install', [target]))
+
+        # uninstall the package
+        ret = self.run_state('chocolatey.uninstalled', name=target)
+        self.assertSaltTrueReturn(ret)
+
+        # Verify the package is uninstalled
+        self.assertFalse(
+            self.run_function('chocolatey.version', [target]))
+
+    def test_upgraded(self):
+        '''
+        Test `chocolatey.upgraded`
+        '''
+
+        # If this assert fails, we need to find new targets, this test needs to
+        # be able to test successful installation of packages, so this package
+        # needs to NOT be installed before we run the states below
+        target = 'firefox'
+        self.assertFalse(
+            self.run_function('chocolatey.version', [target]))
+
+        # Make sure firefox is installed by chocolatey
+        target = 'firefox'
+        pre_version = '52.0.2'
+        upg_version = '57.0.2'
+        self.assertTrue(
+            self.run_function('chocolatey.install', [target, pre_version]))
+
+        ret = self.run_function('chocolatey.version', [target])
+        self.assertEqual(ret, {'Firefox': pre_version})
+
+        try:
+            # upgrade the package
+            ret = self.run_state(
+                'chocolatey.upgraded',
+                name=target,
+                version=upg_version)
+            self.assertSaltTrueReturn(ret)
+
+            # Verify the package is upgraded
+            ret = self.run_function('chocolatey.version', [target])
+            self.assertEqual(ret, {'Firefox': upg_version})
+
+        finally:
+            # Uninstall the package (cleanup)
+            ret = self.run_state('chocolatey.uninstalled', name=target)
+            self.assertSaltTrueReturn(ret)


### PR DESCRIPTION
### What does this PR do?
Adds `chocolatey.upgraded` to the chocolatey state module.

Removes `no_progress` option from the install and upgrade functions. Sets the `--no-progress` flag for all runs as salt doesn't need to see the progress.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/44377

### Previous Behavior
Could only install and remove

### New Behavior
Now you can upgrade

### Tests written?
No
Test suite not working on develop on Windows... I know it's no excuse...
https://github.com/saltstack/salt/issues/44774

### Commits signed with GPG?
Yes