### PR TITLE
Add new neutron module and states based on shade

### DIFF
--- a/salt/modules/neutronng.py
+++ b/salt/modules/neutronng.py
@@ -26,8 +26,6 @@ Example configuration
 
 from __future__ import absolute_import
 
-import salt.utils
-
 HAS_SHADE = False
 try:
     import shade
@@ -68,11 +66,7 @@ def _clean_kwargs(keep_name=False, **kwargs):
     if 'name' in kwargs and not keep_name:
         kwargs['name_or_id'] = kwargs.pop('name')
 
-    try:
-        clean_func = __utils__['args.clean_kwargs']
-    except KeyError:
-        clean_func = salt.utils.clean_kwargs
-    return clean_func(**kwargs)
+    return __utils__['args.clean_kwargs'](**kwargs)
 
 
 def setup_clouds(auth=None):

--- a/salt/modules/neutronng.py
+++ b/salt/modules/neutronng.py
@@ -60,6 +60,7 @@ def compare_changes(obj, **kwargs):
                 changes[key] = kwargs[key]
     return changes
 
+
 def _clean_kwargs(keep_name=False, **kwargs):
     '''
     Sanatize the the arguments for use with shade
@@ -142,6 +143,7 @@ def network_create(auth=None, **kwargs):
     kwargs = _clean_kwargs(keep_name=True, **kwargs)
     return cloud.create_network(**kwargs)
 
+
 def network_delete(auth=None, **kwargs):
     '''
     Delete a network
@@ -161,6 +163,7 @@ def network_delete(auth=None, **kwargs):
     cloud = get_operator_cloud(auth)
     kwargs = _clean_kwargs(**kwargs)
     return cloud.delete_network(**kwargs)
+
 
 def list_networks(auth=None, **kwargs):
     '''
@@ -184,6 +187,7 @@ def list_networks(auth=None, **kwargs):
     kwargs = _clean_kwargs(**kwargs)
     return cloud.list_networks(**kwargs)
 
+
 def network_get(auth=None, **kwargs):
     '''
     Get a single network
@@ -203,6 +207,7 @@ def network_get(auth=None, **kwargs):
     cloud = get_operator_cloud(auth)
     kwargs = _clean_kwargs(**kwargs)
     return cloud.get_network(**kwargs)
+
 
 def subnet_create(auth=None, **kwargs):
     '''
@@ -242,6 +247,7 @@ def subnet_create(auth=None, **kwargs):
     kwargs = _clean_kwargs(**kwargs)
     return cloud.create_subnet(**kwargs)
 
+
 def subnet_update(auth=None, **kwargs):
     '''
     Update a subnet
@@ -265,6 +271,7 @@ def subnet_update(auth=None, **kwargs):
     kwargs = _clean_kwargs(**kwargs)
     return cloud.update_subnet(**kwargs)
 
+
 def subnet_delete(auth=None, **kwargs):
     '''
     Delete a subnet
@@ -284,6 +291,7 @@ def subnet_delete(auth=None, **kwargs):
     cloud = get_operator_cloud(auth)
     kwargs = _clean_kwargs(**kwargs)
     return cloud.delete_subnet(**kwargs)
+
 
 def list_subnets(auth=None, **kwargs):
     '''
@@ -307,6 +315,7 @@ def list_subnets(auth=None, **kwargs):
     kwargs = _clean_kwargs(**kwargs)
     return cloud.list_subnets(**kwargs)
 
+
 def subnet_get(auth=None, **kwargs):
     '''
     Get a single subnet
@@ -326,6 +335,7 @@ def subnet_get(auth=None, **kwargs):
     cloud = get_operator_cloud(auth)
     kwargs = _clean_kwargs(**kwargs)
     return cloud.get_subnet(**kwargs)
+
 
 def security_group_create(auth=None, **kwargs):
     '''
@@ -348,6 +358,7 @@ def security_group_create(auth=None, **kwargs):
     cloud = get_operator_cloud(auth)
     kwargs = _clean_kwargs(keep_name=True, **kwargs)
     return cloud.create_security_group(**kwargs)
+
 
 def security_group_update(secgroup=None, auth=None, **kwargs):
     '''
@@ -372,6 +383,7 @@ def security_group_update(secgroup=None, auth=None, **kwargs):
     kwargs = _clean_kwargs(keep_name=True, **kwargs)
     return cloud.update_security_group(secgroup, **kwargs)
 
+
 def security_group_delete(auth=None, **kwargs):
     '''
     Delete a security group
@@ -389,6 +401,7 @@ def security_group_delete(auth=None, **kwargs):
     cloud = get_operator_cloud(auth)
     kwargs = _clean_kwargs(**kwargs)
     return cloud.delete_security_group(**kwargs)
+
 
 def security_group_get(auth=None, **kwargs):
     '''
@@ -414,6 +427,7 @@ def security_group_get(auth=None, **kwargs):
     cloud = get_operator_cloud(auth)
     kwargs = _clean_kwargs(**kwargs)
     return cloud.get_security_group(**kwargs)
+
 
 def security_group_rule_create(auth=None, **kwargs):
     '''
@@ -449,6 +463,7 @@ def security_group_rule_create(auth=None, **kwargs):
     kwargs = _clean_kwargs(**kwargs)
     return cloud.create_security_group_rule(**kwargs)
 
+
 def security_group_rule_delete(auth=None, **kwargs):
     '''
     Delete a security group
@@ -467,4 +482,3 @@ def security_group_rule_delete(auth=None, **kwargs):
     cloud = get_operator_cloud(auth)
     kwargs = _clean_kwargs(**kwargs)
     return cloud.delete_security_group_rule(**kwargs)
-

--- a/salt/modules/neutronng.py
+++ b/salt/modules/neutronng.py
@@ -1,0 +1,470 @@
+# -*- coding: utf-8 -*-
+'''
+Neutron module for interacting with OpenStack Neutron
+
+.. versionadded:: Nitrogen
+
+:depends:shade
+
+Example configuration
+
+.. code-block:: yaml
+    neutron:
+      cloud: default
+
+.. code-block:: yaml
+    neutron:
+      auth:
+        username: admin
+        password: password123
+        user_domain_name: mydomain
+        project_name: myproject
+        project_domain_name: myproject
+        auth_url: https://example.org:5000/v3
+      identity_api_version: 3
+'''
+
+from __future__ import absolute_import
+
+import salt.utils
+
+HAS_SHADE = False
+try:
+    import shade
+    HAS_SHADE = True
+except ImportError:
+    pass
+
+__virtualname__ = 'neutronng'
+
+
+def __virtual__():
+    '''
+    Only load this module if shade python module is installed
+    '''
+    if HAS_SHADE:
+        return __virtualname__
+    return (False, 'The neutronng execution module failed to \
+                    load: shade python module is not available')
+
+
+def compare_changes(obj, **kwargs):
+    '''
+    Compare two dicts returning only keys that exist in the first dict and are
+    different in the second one
+    '''
+    changes = {}
+    for key, value in obj.items():
+        if key in kwargs:
+            if value != kwargs[key]:
+                changes[key] = kwargs[key]
+    return changes
+
+def _clean_kwargs(keep_name=False, **kwargs):
+    '''
+    Sanatize the the arguments for use with shade
+    '''
+    if 'name' in kwargs and not keep_name:
+        kwargs['name_or_id'] = kwargs.pop('name')
+
+    try:
+        clean_func = salt.utils.args.clean_kwargs
+    except AttributeError:
+        clean_func = salt.utils.clean_kwargs
+    return clean_func(**kwargs)
+
+
+def setup_clouds(auth=None):
+    '''
+    Call functions to create Shade cloud objects in __context__ to take
+    advantage of Shade's in-memory caching across several states
+    '''
+    get_operator_cloud(auth)
+    get_openstack_cloud(auth)
+
+
+def get_operator_cloud(auth=None):
+    '''
+    Return an operator_cloud
+    '''
+    if auth is None:
+        auth = __salt__['config.option']('neutron', {})
+    if 'shade_opcloud' in __context__:
+        if __context__['shade_opcloud'].auth == auth:
+            return __context__['shade_opcloud']
+    __context__['shade_opcloud'] = shade.operator_cloud(**auth)
+    return __context__['shade_opcloud']
+
+
+def get_openstack_cloud(auth=None):
+    '''
+    Return an openstack_cloud
+    '''
+    if auth is None:
+        auth = __salt__['config.option']('neutron', {})
+    if 'shade_oscloud' in __context__:
+        if __context__['shade_oscloud'].auth == auth:
+            return __context__['shade_oscloud']
+    __context__['shade_oscloud'] = shade.openstack_cloud(**auth)
+    return __context__['shade_oscloud']
+
+
+def network_create(auth=None, **kwargs):
+    '''
+    Create a network
+
+    Parameters:
+    Defaults: shared=False, admin_state_up=True, external=False,
+              provider=None, project_id=None
+
+    name (string): Name of the network being created.
+    shared (bool): Set the network as shared.
+    admin_state_up (bool): Set the network administrative state to up.
+    external (bool): Whether this network is externally accessible.
+    provider (dict): A dict of network provider options.
+    project_id (string): Specify the project ID this network will be created on.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' neutronng.network_create name=network2 \
+          shared=True admin_state_up=True external=True
+
+        salt '*' neutronng.network_create name=network3 \
+          provider='{"network_type": "vlan",\
+                     "segmentation_id": "4010",\
+                     "physical_network": "provider"}' \
+          project_id=1dcac318a83b4610b7a7f7ba01465548
+
+    '''
+    cloud = get_operator_cloud(auth)
+    kwargs = _clean_kwargs(keep_name=True, **kwargs)
+    return cloud.create_network(**kwargs)
+
+def network_delete(auth=None, **kwargs):
+    '''
+    Delete a network
+
+    Parameters:
+    name: Name or ID of the network being deleted.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' neutronng.network_delete name=network1
+        salt '*' neutronng.network_delete \
+          name=1dcac318a83b4610b7a7f7ba01465548
+
+    '''
+    cloud = get_operator_cloud(auth)
+    kwargs = _clean_kwargs(**kwargs)
+    return cloud.delete_network(**kwargs)
+
+def list_networks(auth=None, **kwargs):
+    '''
+    List networks
+
+    Parameters:
+    Defaults: filters=None
+
+    filters (dict): dict of filter conditions to push down
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' neutronng.list_networks
+        salt '*' neutronng.list_networks \
+          filters='{"tenant_id": "1dcac318a83b4610b7a7f7ba01465548"}'
+
+    '''
+    cloud = get_operator_cloud(auth)
+    kwargs = _clean_kwargs(**kwargs)
+    return cloud.list_networks(**kwargs)
+
+def network_get(auth=None, **kwargs):
+    '''
+    Get a single network
+
+    Parameters:
+    Defaults: filters=None
+
+    filters (dict): dict of filter conditions to push down
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' neutronng.network_get name=XLB4
+
+    '''
+    cloud = get_operator_cloud(auth)
+    kwargs = _clean_kwargs(**kwargs)
+    return cloud.get_network(**kwargs)
+
+def subnet_create(auth=None, **kwargs):
+    '''
+    Create a subnet
+
+    Parameters:
+    Defaults: cidr=None, ip_version=4, enable_dhcp=False, subnet_name=None,
+              tenant_id=None, allocation_pools=None, gateway_ip=None,
+              disable_gateway_ip=False, dns_nameservers=None, host_routes=None,
+              ipv6_ra_mode=None, ipv6_address_mode=None,
+              use_default_subnetpool=False
+
+    allocation_pools:
+    A list of dictionaries of the start and end addresses for allocation pools.
+
+    dns_nameservers: A list of DNS name servers for the subnet.
+    host_routes: A list of host route dictionaries for the subnet.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' neutronng.subnet_create network_name_or_id=network1
+          subnet_name=subnet1
+
+        salt '*' neutronng.subnet_create subnet_name=subnet2\
+          network_name_or_id=network2 enable_dhcp=True \
+          allocation_pools='[{"start": "192.168.199.2",\
+                              "end": "192.168.199.254"}]'\
+          gateway_ip='192.168.199.1' cidr=192.168.199.0/24
+
+        salt '*' neutronng.subnet_create network_name_or_id=network1 \
+          subnet_name=subnet1 dns_nameservers='["8.8.8.8", "8.8.8.7"]'
+
+    '''
+    cloud = get_operator_cloud(auth)
+    kwargs = _clean_kwargs(**kwargs)
+    return cloud.create_subnet(**kwargs)
+
+def subnet_update(auth=None, **kwargs):
+    '''
+    Update a subnet
+
+    Parameters:
+    Defaults: subnet_name=None, enable_dhcp=None, gateway_ip=None,\
+              disable_gateway_ip=None, allocation_pools=None, \
+              dns_nameservers=None, host_routes=None
+
+    name: Name or ID of the subnet to update.
+    subnet_name: The new name of the subnet.
+
+    .. code-block:: bash
+
+        salt '*' neutronng.subnet_update name=subnet1 subnet_name=subnet2
+        salt '*' neutronng.subnet_update name=subnet1\
+          dns_nameservers='["8.8.8.8", "8.8.8.7"]'
+
+    '''
+    cloud = get_operator_cloud(auth)
+    kwargs = _clean_kwargs(**kwargs)
+    return cloud.update_subnet(**kwargs)
+
+def subnet_delete(auth=None, **kwargs):
+    '''
+    Delete a subnet
+
+    Parameters:
+    name: Name or ID of the subnet to update.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' neutronng.subnet_delete name=subnet1
+        salt '*' neutronng.subnet_delete \
+          name=1dcac318a83b4610b7a7f7ba01465548
+
+    '''
+    cloud = get_operator_cloud(auth)
+    kwargs = _clean_kwargs(**kwargs)
+    return cloud.delete_subnet(**kwargs)
+
+def list_subnets(auth=None, **kwargs):
+    '''
+    List subnets
+
+    Parameters:
+    Defaults: filters=None
+
+    filters (dict): dict of filter conditions to push down
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' neutronng.list_subnets
+        salt '*' neutronng.list_subnets \
+          filters='{"tenant_id": "1dcac318a83b4610b7a7f7ba01465548"}'
+
+    '''
+    cloud = get_operator_cloud(auth)
+    kwargs = _clean_kwargs(**kwargs)
+    return cloud.list_subnets(**kwargs)
+
+def subnet_get(auth=None, **kwargs):
+    '''
+    Get a single subnet
+
+    Parameters:
+    Defaults: filters=None
+
+    filters (dict): dict of filter conditions to push down
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' neutronng.subnet_get name=subnet1
+
+    '''
+    cloud = get_operator_cloud(auth)
+    kwargs = _clean_kwargs(**kwargs)
+    return cloud.get_subnet(**kwargs)
+
+def security_group_create(auth=None, **kwargs):
+    '''
+    Create a security group. Use security_group_get to create default.
+
+    Parameters:
+    Defaults: project_id=None
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' neutronng.security_group_create name=secgroup1 \
+          description="Very secure security group"
+        salt '*' neutronng.security_group_create name=secgroup1 \
+          description="Very secure security group" \
+          project_id=1dcac318a83b4610b7a7f7ba01465548
+
+    '''
+    cloud = get_operator_cloud(auth)
+    kwargs = _clean_kwargs(keep_name=True, **kwargs)
+    return cloud.create_security_group(**kwargs)
+
+def security_group_update(secgroup=None, auth=None, **kwargs):
+    '''
+    Update a security group
+
+    secgroup: Name, ID or Raw Object of the security group to update.
+    name: New name for the security group.
+    description: New description for the security group.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' neutronng.security_group_update secgroup=secgroup1 \
+          description="Very secure security group"
+        salt '*' neutronng.security_group_update secgroup=secgroup1 \
+          description="Very secure security group" \
+          project_id=1dcac318a83b4610b7a7f7ba01465548
+
+    '''
+    cloud = get_operator_cloud(auth)
+    kwargs = _clean_kwargs(keep_name=True, **kwargs)
+    return cloud.update_security_group(secgroup, **kwargs)
+
+def security_group_delete(auth=None, **kwargs):
+    '''
+    Delete a security group
+
+    Parameters:
+    name: The name or unique ID of the security group.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' neutronng.security_group_delete name=secgroup1
+
+    '''
+    cloud = get_operator_cloud(auth)
+    kwargs = _clean_kwargs(**kwargs)
+    return cloud.delete_security_group(**kwargs)
+
+def security_group_get(auth=None, **kwargs):
+    '''
+    Get a single security group. This will create a default security group
+    if one does not exist yet for a particular project id.
+
+    Parameters:
+    Defaults: filters=None
+
+    filters (dict): dict of filter conditions to push down
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' neutronng.security_group_get \
+          name=1dcac318a83b4610b7a7f7ba01465548
+
+        salt '*' neutronng.security_group_get \
+          name=default\
+          filters='{"tenant_id":"2e778bb64ca64a199eb526b5958d8710"}'
+    '''
+    cloud = get_operator_cloud(auth)
+    kwargs = _clean_kwargs(**kwargs)
+    return cloud.get_security_group(**kwargs)
+
+def security_group_rule_create(auth=None, **kwargs):
+    '''
+    Create a rule in a security group
+
+    Parameters:
+    Defaults: port_range_min=None, port_range_max=None, protocol=None,
+              remote_ip_prefix=None, remote_group_id=None, direction='ingress',
+              ethertype='IPv4', project_id=None
+
+    secgroup_name_or_id:
+        This is the Name or Id of security group you want to create a rule in.
+        However, it throws errors on non-unique security group names like
+        'default' even when you supply a project_id
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' neutronng.security_group_rule_create\
+          secgroup_name_or_id=secgroup1
+
+        salt '*' neutronng.security_group_rule_create\
+          secgroup_name_or_id=secgroup2 port_range_min=8080\
+          port_range_max=8080 direction='egress'
+
+        salt '*' neutronng.security_group_rule_create\
+          secgroup_name_or_id=c0e1d1ce-7296-405e-919d-1c08217be529\
+          protocol=icmp project_id=1dcac318a83b4610b7a7f7ba01465548
+
+    '''
+    cloud = get_operator_cloud(auth)
+    kwargs = _clean_kwargs(**kwargs)
+    return cloud.create_security_group_rule(**kwargs)
+
+def security_group_rule_delete(auth=None, **kwargs):
+    '''
+    Delete a security group
+
+    Parameters:
+    rule_id (string): The unique ID of the security group rule.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' neutronng.security_group_rule_delete\
+          rule_id=1dcac318a83b4610b7a7f7ba01465548
+
+    '''
+    cloud = get_operator_cloud(auth)
+    kwargs = _clean_kwargs(**kwargs)
+    return cloud.delete_security_group_rule(**kwargs)
+

--- a/salt/modules/neutronng.py
+++ b/salt/modules/neutronng.py
@@ -69,8 +69,8 @@ def _clean_kwargs(keep_name=False, **kwargs):
         kwargs['name_or_id'] = kwargs.pop('name')
 
     try:
-        clean_func = salt.utils.args.clean_kwargs
-    except AttributeError:
+        clean_func = __utils__['args.clean_kwargs']
+    except KeyError:
         clean_func = salt.utils.clean_kwargs
     return clean_func(**kwargs)
 

--- a/salt/states/neutron_network.py
+++ b/salt/states/neutron_network.py
@@ -1,0 +1,161 @@
+# -*- coding: utf-8 -*-
+'''
+Management of OpenStack Neutron Networks
+=========================================
+
+.. versionadded:: Nitrogen
+
+:depends: shade
+:configuration: see :py:mod:`salt.modules.neutronng` for setup instructions
+
+Example States
+
+.. code-block:: yaml
+
+    create network:
+      neutron_network.present:
+        - name: network1
+
+    delete network:
+      neutron_network.absent:
+        - name: network1
+
+    create network with optional params:
+      neutron_network.present:
+        - name: network1
+        - vlan: 200
+        - shared: False
+        - external: False
+        - project: project1
+'''
+
+from __future__ import absolute_import
+
+__virtualname__ = 'neutron_network'
+
+
+def __virtual__():
+    if 'neutronng.list_networks' in __salt__:
+        return __virtualname__
+    return (False, 'The neutronng execution module failed to load:\
+                    shade python module is not available')
+
+
+def present(name, auth=None, **kwargs):
+    '''
+    Ensure a network exists and is up-to-date
+
+    name
+        Name of the network
+
+    provider
+        A dict of network provider options.
+
+    shared
+        Set the network as shared.
+
+    external
+        Whether this network is externally accessible.
+
+    admin_state_up
+         Set the network administrative state to up.
+
+    vlan
+        Vlan ID. Alias for
+        provider:
+          - physical_network: provider
+          - network_type: vlan
+          - segmentation_id: (vlan id)
+
+    '''
+    ret = {'name': name,
+           'changes': {},
+           'result': True,
+           'comment': ''}
+
+    __salt__['neutronng.setup_clouds'](auth)
+
+    kwargs['name'] = name
+    network = __salt__['neutronng.network_get'](name=name)
+
+    if network is None:
+        if __opts__['test'] is True:
+            ret['result'] = None
+            ret['changes'] = kwargs
+            ret['pchanges'] = ret['changes']
+            ret['comment'] = 'Network will be created.'
+            return ret
+
+        if 'vlan' in kwargs:
+            kwargs['provider'] = {"physical_network": "provider",
+                                  "network_type": "vlan",
+                                  "segmentation_id": kwargs['vlan']}
+            del kwargs['vlan']
+
+        if 'project' in kwargs:
+            projectname = kwargs['project']
+            project = __salt__['keystoneng.project_get'](name=projectname)
+            if project:
+                kwargs['project_id'] = project.id
+                del kwargs['project']
+            else:
+                ret['result'] = False
+                ret['comment'] = "Project:{} not found.".format(projectname)
+                return ret
+
+        network = __salt__['neutronng.network_create'](**kwargs)
+        ret['changes'] = network
+        ret['comment'] = 'Created network'
+        return ret
+
+    changes = __salt__['neutronng.compare_changes'](network, **kwargs)
+
+    # there's no method for network update in shade right now;
+    # can only delete and recreate
+    if changes:
+        if __opts__['test'] is True:
+            ret['result'] = None
+            ret['changes'] = changes
+            ret['pchanges'] = ret['changes']
+            ret['comment'] = 'Project will be updated.'
+            return ret
+
+        __salt__['neutronng.network_delete'](name=network)
+        __salt__['neutronng.network_create'](**kwargs)
+        ret['changes'].update(changes)
+        ret['comment'] = 'Updated network'
+
+    return ret
+
+
+def absent(name, auth=None, **kwargs):
+    '''
+    Ensure a network does not exists
+
+    name
+        Name of the network
+
+    '''
+    ret = {'name': name,
+           'changes': {},
+           'result': True,
+           'comment': ''}
+
+    __salt__['neutronng.setup_clouds'](auth)
+
+    kwargs['name'] = name
+    network = __salt__['neutronng.network_get'](name=name)
+
+    if network:
+        if __opts__['test'] is True:
+            ret['result'] = None
+            ret['changes'] = {'id': network.id}
+            ret['pchanges'] = ret['changes']
+            ret['comment'] = 'Network will be deleted.'
+            return ret
+
+        __salt__['neutronng.network_delete'](name=network)
+        ret['changes']['id'] = network.id
+        ret['comment'] = 'Deleted network'
+
+    return ret

--- a/salt/states/neutron_network.py
+++ b/salt/states/neutron_network.py
@@ -3,7 +3,7 @@
 Management of OpenStack Neutron Networks
 =========================================
 
-.. versionadded:: Nitrogen
+.. versionadded:: Oxygen
 
 :depends: shade
 :configuration: see :py:mod:`salt.modules.neutronng` for setup instructions

--- a/salt/states/neutron_secgroup.py
+++ b/salt/states/neutron_secgroup.py
@@ -3,7 +3,7 @@
 Management of OpenStack Neutron Security Groups
 =========================================
 
-.. versionadded:: Nitrogen
+.. versionadded:: Oxygen
 
 :depends: shade
 :configuration: see :py:mod:`salt.modules.neutronng` for setup instructions

--- a/salt/states/neutron_secgroup.py
+++ b/salt/states/neutron_secgroup.py
@@ -139,7 +139,9 @@ def absent(name, auth=None, **kwargs):
         name=kwargs['project_name'])
 
     secgroup = __salt__['neutronng.security_group_get'](
-        name=name, filters={'project_id':kwargs['project_id']})
+        name=name,
+        filters={'project_id': kwargs['project_id']}
+    )
 
     if secgroup:
         if __opts__['test'] is True:

--- a/salt/states/neutron_secgroup.py
+++ b/salt/states/neutron_secgroup.py
@@ -1,0 +1,156 @@
+# -*- coding: utf-8 -*-
+'''
+Management of OpenStack Neutron Security Groups
+=========================================
+
+.. versionadded:: Nitrogen
+
+:depends: shade
+:configuration: see :py:mod:`salt.modules.neutronng` for setup instructions
+
+Example States
+
+.. code-block:: yaml
+
+    create security group;
+      neutron_secgroup.present:
+        - name: security_group1
+        - description: "Very Secure Security Group"
+
+    delete security group:
+      neutron_secgroup.absent:
+        - name_or_id: security_group1
+        - project_name: Project1
+
+    create security group with optional params:
+      neutron_secgroup.present:
+        - name: security_group1
+        - description: "Very Secure Security Group"
+        - project_id: 1dcac318a83b4610b7a7f7ba01465548
+
+    create security group with optional params:
+      neutron_secgroup.present:
+        - name: security_group1
+        - description: "Very Secure Security Group"
+        - project_name: Project1
+'''
+
+from __future__ import absolute_import
+
+__virtualname__ = 'neutron_secgroup'
+
+
+def __virtual__():
+    if 'neutronng.list_subnets' in __salt__:
+        return __virtualname__
+    return (False, 'The neutronng execution module failed to load:\
+                    shade python module is not available')
+
+
+def present(name, auth=None, **kwargs):
+    '''
+    Ensure a security group exists.
+
+    You can supply either project_name or project_id.
+
+    Creating a default security group will not show up as a change;
+    it gets created through the lookup process.
+
+    name
+        Name of the security group
+
+    description
+        Description of the security group
+
+    project_name
+        Name of Project
+
+    project_id
+        ID of Project
+
+    '''
+    ret = {'name': name,
+           'changes': {},
+           'result': True,
+           'comment': ''}
+
+    __salt__['neutronng.setup_clouds'](auth)
+
+    if 'project_name' in kwargs:
+        kwargs['project_id'] = kwargs['project_name']
+        del kwargs['project_name']
+
+    project = __salt__['keystoneng.project_get'](
+        name=kwargs['project_id'])
+
+    if project is None:
+        ret['result'] = False
+        ret['comment'] = "project does not exist"
+        return ret
+
+    secgroup = __salt__['neutronng.security_group_get'](
+        name=name, filters={'tenant_id': project.id})
+
+    if secgroup is None:
+        if __opts__['test'] is True:
+            ret['result'] = None
+            ret['changes'] = kwargs
+            ret['pchanges'] = ret['changes']
+            ret['comment'] = 'Security Group will be created.'
+            return ret
+
+        secgroup = __salt__['neutronng.security_group_create'](**kwargs)
+        ret['changes'] = secgroup
+        ret['comment'] = 'Created security group'
+        return ret
+
+    changes = __salt__['neutronng.compare_changes'](secgroup, **kwargs)
+    if changes:
+        if __opts__['test'] is True:
+            ret['result'] = None
+            ret['changes'] = changes
+            ret['pchanges'] = ret['changes']
+            ret['comment'] = 'Security Group will be updated.'
+            return ret
+
+        __salt__['neutronng.security_group_update'](secgroup=secgroup, **changes)
+        ret['changes'].update(changes)
+        ret['comment'] = 'Updated security group'
+
+    return ret
+
+
+def absent(name, auth=None, **kwargs):
+    '''
+    Ensure a security group does not exist
+
+    name
+        Name of the security group
+
+    '''
+    ret = {'name': name,
+           'changes': {},
+           'result': True,
+           'comment': ''}
+
+    __salt__['neutronng.setup_clouds'](auth)
+
+    kwargs['project_id'] = __salt__['keystoneng.project_get'](
+        name=kwargs['project_name'])
+
+    secgroup = __salt__['neutronng.security_group_get'](
+        name=name, filters={'project_id':kwargs['project_id']})
+
+    if secgroup:
+        if __opts__['test'] is True:
+            ret['result'] = None
+            ret['changes'] = {'id': secgroup.id}
+            ret['pchanges'] = ret['changes']
+            ret['comment'] = 'Security group will be deleted.'
+            return ret
+
+        __salt__['neutronng.security_group_delete'](name=secgroup)
+        ret['changes']['id'] = name
+        ret['comment'] = 'Deleted security group'
+
+    return ret

--- a/salt/states/neutron_secgroup_rule.py
+++ b/salt/states/neutron_secgroup_rule.py
@@ -40,6 +40,7 @@ def __virtual__():
     return (False, 'The neutronng execution module failed to load:\
                     shade python module is not available')
 
+
 def _rule_compare(rule1, rule2):
     '''
     Compare the common keys between security group rules against eachother
@@ -50,6 +51,7 @@ def _rule_compare(rule1, rule2):
         if rule1[key] != rule2[key]:
             return False
     return True
+
 
 def present(name, auth=None, **kwargs):
     '''
@@ -89,8 +91,10 @@ def present(name, auth=None, **kwargs):
         ret['comment'] = "Project does not exist"
         return ret
 
-    secgroup = __salt__['neutronng.security_group_get'](name=name,\
-        filters={'tenant_id': project.id})
+    secgroup = __salt__['neutronng.security_group_get'](
+        name=name,
+        filters={'tenant_id': project.id}
+    )
 
     if secgroup is None:
         ret['result'] = False
@@ -112,7 +116,7 @@ def present(name, auth=None, **kwargs):
             ret['comment'] = 'Security Group rule will be created.'
             return ret
 
-        #the variable differences are a little clumsy right now
+        # The variable differences are a little clumsy right now
         kwargs['secgroup_name_or_id'] = secgroup
 
         new_rule = __salt__['neutronng.security_group_rule_create'](**kwargs)
@@ -144,8 +148,10 @@ def absent(name, auth=None, **kwargs):
 
     __salt__['neutronng.setup_clouds'](auth)
 
-    secgroup = __salt__['neutronng.security_group_get'](name=name,\
-        filters={'tenant_id': kwargs['project_id']})
+    secgroup = __salt__['neutronng.security_group_get'](
+        name=name,
+        filters={'tenant_id': kwargs['project_id']}
+    )
 
     # no need to delete a rule if the security group doesn't exist
     if secgroup is None:

--- a/salt/states/neutron_secgroup_rule.py
+++ b/salt/states/neutron_secgroup_rule.py
@@ -1,0 +1,174 @@
+# -*- coding: utf-8 -*-
+'''
+Management of OpenStack Neutron Security Group Rules
+=========================================
+
+.. versionadded:: Nitrogen
+
+:depends: shade
+:configuration: see :py:mod:`salt.modules.neutronng` for setup instructions
+
+Example States
+
+.. code-block:: yaml
+
+    create security group rule:
+      neutron_secgroup_rule.present:
+        - name: security_group1
+        - project_name: Project1
+        - protocol: icmp
+
+    delete security group:
+      neutron_secgroup_rule.absent:
+        - name_or_id: security_group1
+
+    create security group with optional params:
+      neutron_secgroup_rule.present:
+        - name: security_group1
+        - description: "Very Secure Security Group"
+        - project_id: 1dcac318a83b4610b7a7f7ba01465548
+'''
+
+from __future__ import absolute_import
+
+__virtualname__ = 'neutron_secgroup_rule'
+
+
+def __virtual__():
+    if 'neutronng.list_subnets' in __salt__:
+        return __virtualname__
+    return (False, 'The neutronng execution module failed to load:\
+                    shade python module is not available')
+
+def _rule_compare(rule1, rule2):
+    '''
+    Compare the common keys between security group rules against eachother
+    '''
+
+    commonkeys = set(rule1.keys()).intersection(rule2.keys())
+    for key in commonkeys:
+        if rule1[key] != rule2[key]:
+            return False
+    return True
+
+def present(name, auth=None, **kwargs):
+    '''
+    Ensure a security group rule exists
+
+    defaults: port_range_min=None, port_range_max=None, protocol=None,
+              remote_ip_prefix=None, remote_group_id=None, direction='ingress',
+              ethertype='IPv4', project_id=None
+
+    name
+        Name of the security group to associate with this rule
+
+    project_name
+        Name of the project associated with the security group
+
+    protocol
+        The protocol that is matched by the security group rule.
+        Valid values are None, tcp, udp, and icmp.
+
+    '''
+    ret = {'name': name,
+           'changes': {},
+           'result': True,
+           'comment': ''}
+
+    __salt__['neutronng.setup_clouds'](auth)
+
+    if 'project_name' in kwargs:
+        kwargs['project_id'] = kwargs['project_name']
+        del kwargs['project_name']
+
+    project = __salt__['keystoneng.project_get'](
+        name=kwargs['project_id'])
+
+    if project is None:
+        ret['result'] = False
+        ret['comment'] = "Project does not exist"
+        return ret
+
+    secgroup = __salt__['neutronng.security_group_get'](name=name,\
+        filters={'tenant_id': project.id})
+
+    if secgroup is None:
+        ret['result'] = False
+        ret['changes'] = {},
+        ret['comment'] = 'Security Group does not exist {}'.format(name)
+        return ret
+
+    # we have to search through all secgroup rules for a possible match
+    rule_exists = None
+    for rule in secgroup['security_group_rules']:
+        if _rule_compare(rule, kwargs) is True:
+            rule_exists = True
+
+    if rule_exists is None:
+        if __opts__['test'] is True:
+            ret['result'] = None
+            ret['changes'] = kwargs
+            ret['pchanges'] = ret['changes']
+            ret['comment'] = 'Security Group rule will be created.'
+            return ret
+
+        #the variable differences are a little clumsy right now
+        kwargs['secgroup_name_or_id'] = secgroup
+
+        new_rule = __salt__['neutronng.security_group_rule_create'](**kwargs)
+        ret['changes'] = new_rule
+        ret['comment'] = 'Created security group rule'
+        return ret
+
+    return ret
+
+
+def absent(name, auth=None, **kwargs):
+    '''
+    Ensure a security group rule does not exist
+
+    name
+        name or id of the security group rule to delete
+
+    rule_id
+        uuid of the rule to delete
+
+    project_id
+        id of project to delete rule from
+    '''
+    rule_id = kwargs['rule_id']
+    ret = {'name': rule_id,
+           'changes': {},
+           'result': True,
+           'comment': ''}
+
+    __salt__['neutronng.setup_clouds'](auth)
+
+    secgroup = __salt__['neutronng.security_group_get'](name=name,\
+        filters={'tenant_id': kwargs['project_id']})
+
+    # no need to delete a rule if the security group doesn't exist
+    if secgroup is None:
+        ret['comment'] = "security group does not exist"
+        return ret
+
+    # This should probably be done with compare on fields instead of
+    # rule_id in the future
+    rule_exists = None
+    for rule in secgroup['security_group_rules']:
+        if _rule_compare(rule, {"id": rule_id}) is True:
+            rule_exists = True
+
+    if rule_exists:
+        if __opts__['test'] is True:
+            ret['result'] = None
+            ret['changes'] = {'id': kwargs['rule_id']}
+            ret['pchanges'] = ret['changes']
+            ret['comment'] = 'Security group rule will be deleted.'
+            return ret
+
+        __salt__['neutronng.security_group_rule_delete'](rule_id=rule_id)
+        ret['changes']['id'] = rule_id
+        ret['comment'] = 'Deleted security group rule'
+
+    return ret

--- a/salt/states/neutron_secgroup_rule.py
+++ b/salt/states/neutron_secgroup_rule.py
@@ -3,7 +3,7 @@
 Management of OpenStack Neutron Security Group Rules
 =========================================
 
-.. versionadded:: Nitrogen
+.. versionadded:: Oxygen
 
 :depends: shade
 :configuration: see :py:mod:`salt.modules.neutronng` for setup instructions

--- a/salt/states/neutron_subnet.py
+++ b/salt/states/neutron_subnet.py
@@ -3,7 +3,7 @@
 Management of OpenStack Neutron Subnets
 =========================================
 
-.. versionadded:: Nitrogen
+.. versionadded:: Oxygen
 
 :depends: shade
 :configuration: see :py:mod:`salt.modules.neutronng` for setup instructions

--- a/salt/states/neutron_subnet.py
+++ b/salt/states/neutron_subnet.py
@@ -1,0 +1,171 @@
+# -*- coding: utf-8 -*-
+'''
+Management of OpenStack Neutron Subnets
+=========================================
+
+.. versionadded:: Nitrogen
+
+:depends: shade
+:configuration: see :py:mod:`salt.modules.neutronng` for setup instructions
+
+Example States
+
+.. code-block:: yaml
+
+    create subnet:
+      neutron_subnet.present:
+        - name: subnet1
+        - network_name_or_id: network1
+        - cidr: 192.168.199.0/24
+
+
+    delete subnet:
+      neutron_subnet.absent:
+        - name: subnet2
+
+    create subnet with optional params:
+      neutron_subnet.present:
+        - name: subnet1
+        - network_name_or_id: network1
+        - enable_dhcp: True
+        - cidr: 192.168.199.0/24
+        - allocation_pools:
+          - start: 192.168.199.5
+            end: 192.168.199.250
+        - host_routes:
+          - destination: 192.168..0.0/24
+            nexthop: 192.168.0.1
+        - gateway_ip: 192.168.199.1
+        - dns_nameservers:
+          - 8.8.8.8
+          - 8.8.8.7
+
+    create ipv6 subnet:
+      neutron_subnet.present:
+        - name: v6subnet1
+        - network_name_or_id: network1
+        - ip_version: 6
+'''
+
+from __future__ import absolute_import
+
+__virtualname__ = 'neutron_subnet'
+
+
+def __virtual__():
+    if 'neutronng.list_subnets' in __salt__:
+        return __virtualname__
+    return (False, 'The neutronng execution module failed to load:\
+                    shade python module is not available')
+
+
+def present(name, auth=None, **kwargs):
+    '''
+    Ensure a subnet exists and is up-to-date
+
+    name
+        Name of the subnet
+
+    network_name_or_id
+        The unique name or ID of the attached network.
+        If a non-unique name is supplied, an exception is raised.
+
+    allocation_pools
+        A list of dictionaries of the start and end addresses
+        for the allocation pools
+
+    gateway_ip
+        The gateway IP address.
+
+    dns_nameservers
+        A list of DNS name servers for the subnet.
+
+    host_routes
+        A list of host route dictionaries for the subnet.
+
+    ipv6_ra_mode
+        IPv6 Router Advertisement mode.
+        Valid values are: ‘dhcpv6-stateful’, ‘dhcpv6-stateless’, or ‘slaac’.
+
+    ipv6_address_mode
+        IPv6 address mode.
+        Valid values are: ‘dhcpv6-stateful’, ‘dhcpv6-stateless’, or ‘slaac’.
+    '''
+    ret = {'name': name,
+           'changes': {},
+           'result': True,
+           'comment': ''}
+
+    __salt__['neutronng.setup_clouds'](auth)
+
+    kwargs['subnet_name'] = name
+    subnet = __salt__['neutronng.subnet_get'](name=name)
+
+    if subnet is None:
+        if __opts__['test'] is True:
+            ret['result'] = None
+            ret['changes'] = kwargs
+            ret['pchanges'] = ret['changes']
+            ret['comment'] = 'Subnet will be created.'
+            return ret
+
+        new_subnet = __salt__['neutronng.subnet_create'](**kwargs)
+        ret['changes'] = new_subnet
+        ret['comment'] = 'Created subnet'
+        return ret
+
+    changes = __salt__['neutronng.compare_changes'](subnet, **kwargs)
+    if changes:
+        if __opts__['test'] is True:
+            ret['result'] = None
+            ret['changes'] = changes
+            ret['pchanges'] = ret['changes']
+            ret['comment'] = 'Project will be updated.'
+            return ret
+
+        # update_subnet does not support changing cidr,
+        # so we have to delete and recreate the subnet in this case.
+        if 'cidr' in changes or 'tenant_id' in changes:
+            __salt__['neutronng.subnet_delete'](name=name)
+            new_subnet = __salt__['neutronng.subnet_create'](**kwargs)
+            ret['changes'] = new_subnet
+            ret['comment'] = 'Deleted and recreated subnet'
+            return ret
+
+        __salt__['neutronng.subnet_update'](**kwargs)
+        ret['changes'].update(changes)
+        ret['comment'] = 'Updated subnet'
+
+    return ret
+
+
+def absent(name, auth=None):
+    '''
+    Ensure a subnet does not exists
+
+    name
+        Name of the subnet
+
+    '''
+    ret = {'name': name,
+           'changes': {},
+           'result': True,
+           'comment': ''}
+
+    __salt__['neutronng.setup_clouds'](auth)
+
+    subnet = __salt__['neutronng.subnet_get'](name=name)
+
+    if subnet:
+        if __opts__['test'] is True:
+            ret['result'] = None
+            ret['changes'] = {'id': subnet.id}
+            ret['pchanges'] = ret['changes']
+            ret['comment'] = 'Project will be deleted.'
+            return ret
+
+        __salt__['neutronng.subnet_delete'](name=subnet)
+        ret['changes']['id'] = name
+        ret['comment'] = 'Deleted subnet'
+
+    return ret


### PR DESCRIPTION
### What does this PR do?
This PR adds a new module (neutronng.py) to supercede neutron.py as well as related states. It utilizes the shade library from the openstack project (https://github.com/openstack-infra/shade.git). 

Tried to stick with the styles and conventions of the keystoneng module introduced here (https://github.com/saltstack/salt/pull/43207).

### What issues does this PR fix or reference?
N/A

### Tests written?

Not Yet

### Commits signed with GPG?

Yes
