### PR TITLE
Correct the thorium runner

### DIFF
--- a/salt/thorium/runner.py
+++ b/salt/thorium/runner.py
@@ -40,9 +40,14 @@ def cmd(
            'result': True}
     if func is None:
         func = name
-    client = salt.runner.RunnerClient(__opts__)
-    low = {'fun': func,
-           'arg': arg,
-           'kwarg': kwargs}
-    client.cmd_async(low)
+    local_opts = {}
+    local_opts.update(__opts__)
+    local_opts['async'] = True  # ensure this will be run async
+    local_opts.update({
+        'fun': func,
+        'arg': arg,
+        'kwarg': kwargs
+    })
+    runner = salt.runner.Runner(local_opts)
+    runner.run()
     return ret

--- a/salt/thorium/runner.py
+++ b/salt/thorium/runner.py
@@ -10,7 +10,7 @@ import salt.runner
 
 def cmd(
         name,
-        fun=None,
+        func=None,
         arg=(),
         **kwargs):
     '''
@@ -22,14 +22,14 @@ def cmd(
 
         run_cloud:
           runner.cmd:
-            - fun: cloud.create
+            - func: cloud.create
             - arg:
                 - my-ec2-config
                 - myinstance
 
         run_cloud:
           runner.cmd:
-            - fun: cloud.create
+            - func: cloud.create
             - kwargs:
                 provider: my-ec2-config
                 instances: myinstance
@@ -38,11 +38,11 @@ def cmd(
            'changes': {},
            'comment': '',
            'result': True}
-    if fun is None:
-        fun = name
+    if func is None:
+        func = name
     client = salt.runner.RunnerClient(__opts__)
-    low = {'fun': fun,
-            'arg': arg,
-            'kwargs': kwargs}
+    low = {'fun': func,
+           'arg': arg,
+           'kwarg': kwargs}
     client.cmd_async(low)
     return ret


### PR DESCRIPTION
Opening this PR for discussion, there are some delicate details:

- The `fun` argument needs to be renamed to `func` (explained below why). Shall we do this in a dot release? If we don't, this `runner.cmd` is unusable anyway.
- Thorium is executed on the master, which uses the State system. When invoking the runner system from the State, it doesn't like the the options from the master side, and it chokes and throws the following exception:

```python
[ERROR   ] An exception occurred in this state: Traceback (most recent call last):
  File "/home/admin/salt/salt/state.py", line 1851, in call
    **cdata['kwargs'])
  File "/home/admin/salt/salt/loader.py", line 1795, in wrapper
    return f(*args, **kwargs)
  File "/home/admin/salt/salt/thorium/runner.py", line 63, in cmd
    rclient.cmd_async(low)
  File "/home/admin/salt/salt/runner.py", line 123, in cmd_async
    return mixins.AsyncClientMixin.cmd_async(self, reformatted_low)
  File "/home/admin/salt/salt/client/mixins.py", line 487, in cmd_async
    return self.master_call(**low)
  File "/home/admin/salt/salt/client/mixins.py", line 134, in master_call
    usage='master_call')
  File "/home/admin/salt/salt/transport/__init__.py", line 53, in factory
    return ReqChannel.factory(opts, **kwargs)
  File "/home/admin/salt/salt/transport/client.py", line 25, in factory
    sync = SyncWrapper(AsyncReqChannel.factory, (opts,), kwargs)
  File "/home/admin/salt/salt/utils/async.py", line 60, in __init__
    self.async = method(*args, **kwargs)
  File "/home/admin/salt/salt/transport/client.py", line 108, in factory
    return salt.transport.zeromq.AsyncZeroMQReqChannel(opts, **kwargs)
  File "/home/admin/salt/salt/transport/zeromq.py", line 90, in __new__
    obj.__singleton_init__(opts, **kwargs)
  File "/home/admin/salt/salt/transport/zeromq.py", line 151, in __singleton_init__
    args=(self.opts, self.master_uri,),
  File "/home/admin/salt/salt/transport/zeromq.py", line 166, in master_uri
    return self.opts['master_uri']
KeyError: 'master_uri'
```

I still need to investigate this further.

### `fun` to `func` rename

The Thorium system is currently unable to invoke any runner (at all): #41869
This is due to the fact that we go thorough the State system
which builds the "chunks" from the state-formatted data:
https://github.com/saltstack/salt/blob/develop/salt/thorium/__init__.py#L166

For example, the following Thorium state:

```yaml
dummy:
  runner.cmd
    - fun: test.sleep
    - kwargs:
         s_time: 1
```
Will produce the following state chunks:

```python
[{'name': 'dummy', 'state': 'runner', '__id__': 'dummy', 'kwargs': OrderedDict([('s_time', 1)]), 'fun': 'cmd', '__env__': 'base', '__sls__': u'dummy', 'order': 10000}]
```

The value of the `fun` field from the state chunks will override
the value specified in the Thorisum state. For the example above,
instead of execution the `test.sleep` runner function, it will
try instead to execute the `cmd` runner function, which will,
of course, fail.
In order to preserve the value of the actual function requested by
the user, we must rename `fun` to `func` to avoid this collision,
which is also in-line with the equivalent `local.cmd` for local
functions: https://github.com/saltstack/salt/blob/develop/salt/thorium/local.py#L14
The state chunks in this case will be:

```python
[{'name': 'dummy', 'state': 'runner', '__id__': 'dummy', 'func': 'test.sleep', 'kwargs': OrderedDict([('s_time', 1)]), 'fun': 'cmd', '__env__': 'base', '__sls__': u'dummy', 'order': 10000}]
```

Which will correctly try to execute the requested runner function.
