### PR TITLE
GroupAdd test: Add destructive test decorator to entire class

### DIFF
--- a/tests/integration/modules/test_groupadd.py
+++ b/tests/integration/modules/test_groupadd.py
@@ -14,6 +14,7 @@ from salt.ext.six.moves import range
 
 
 @skip_if_not_root
+@destructiveTest
 class GroupModuleTest(ModuleCase):
     '''
     Validate the linux group system module
@@ -39,7 +40,6 @@ class GroupModuleTest(ModuleCase):
                 )
             )
 
-    @destructiveTest
     def tearDown(self):
         '''
         Reset to original settings
@@ -57,33 +57,30 @@ class GroupModuleTest(ModuleCase):
             for x in range(size)
         )
 
-    @destructiveTest
     def test_add(self):
         '''
         Test the add group function
         '''
-        #add a new group
+        # add a new group
         self.assertTrue(self.run_function('group.add', [self._group, self._gid]))
         group_info = self.run_function('group.info', [self._group])
         self.assertEqual(group_info['name'], self._group)
         self.assertEqual(group_info['gid'], self._gid)
-        #try adding the group again
+        # try adding the group again
         self.assertFalse(self.run_function('group.add', [self._group, self._gid]))
 
-    @destructiveTest
     def test_delete(self):
         '''
         Test the delete group function
         '''
         self.assertTrue(self.run_function('group.add', [self._group]))
 
-        #correct functionality
+        # correct functionality
         self.assertTrue(self.run_function('group.delete', [self._group]))
 
-        #group does not exist
+        # group does not exist
         self.assertFalse(self.run_function('group.delete', [self._no_group]))
 
-    @destructiveTest
     def test_info(self):
         '''
         Test the info group function
@@ -97,7 +94,6 @@ class GroupModuleTest(ModuleCase):
         self.assertEqual(group_info['gid'], self._gid)
         self.assertIn(self._user, group_info['members'])
 
-    @destructiveTest
     def test_chgid(self):
         '''
         Test the change gid function
@@ -107,7 +103,6 @@ class GroupModuleTest(ModuleCase):
         group_info = self.run_function('group.info', [self._group])
         self.assertEqual(group_info['gid'], self._new_gid)
 
-    @destructiveTest
     def test_adduser(self):
         '''
         Test the add user to group function
@@ -117,14 +112,13 @@ class GroupModuleTest(ModuleCase):
         self.assertTrue(self.run_function('group.adduser', [self._group, self._user]))
         group_info = self.run_function('group.info', [self._group])
         self.assertIn(self._user, group_info['members'])
-        #try add a non existing user
+        # try add a non existing user
         self.assertFalse(self.run_function('group.adduser', [self._group, self._no_user]))
-        #try add a user to non existing group
+        # try add a user to non existing group
         self.assertFalse(self.run_function('group.adduser', [self._no_group, self._user]))
-        #try add a non existing user to a non existing group
+        # try add a non existing user to a non existing group
         self.assertFalse(self.run_function('group.adduser', [self._no_group, self._no_user]))
 
-    @destructiveTest
     def test_deluser(self):
         '''
         Test the delete user from group function
@@ -136,7 +130,6 @@ class GroupModuleTest(ModuleCase):
         group_info = self.run_function('group.info', [self._group])
         self.assertNotIn(self._user, group_info['members'])
 
-    @destructiveTest
     def test_members(self):
         '''
         Test the members function
@@ -150,7 +143,6 @@ class GroupModuleTest(ModuleCase):
         self.assertIn(self._user, group_info['members'])
         self.assertIn(self._user1, group_info['members'])
 
-    @destructiveTest
     def test_getent(self):
         '''
         Test the getent function


### PR DESCRIPTION
### What does this PR do?
Because the destructive test decorator was applied to the tearDown function, the tests show a stacktrace instead of a nice skip message when running without the `--run-destructive` flag. By applying the decorator to the test class (since all tests are destructive anyway), we can keep the output clean and still skip tests appropriately.

### What issues does this PR fix or reference?
None. Found while debugging another test.

### Previous Behavior
```
======================================================================
ERROR: test_getent (integration.modules.test_groupadd.GroupModuleTest)
[CPU:0.0%|MEM:48.6%]
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/root/SaltStack/salt/tests/support/helpers.py", line 87, in wrap
    cls.skipTest('Destructive tests are disabled')
  File "/usr/lib/python2.7/unittest/case.py", line 408, in skipTest
    raise SkipTest(reason)
SkipTest: Destructive tests are disabled
```

### New Behavior
```
-> integration.modules.test_groupadd.GroupModuleTest.test_getent                ->  Destructive tests are disabled
```

### Tests written?

N/A

### Commits signed with GPG?

Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
