### PR TITLE
Add ability to reset file system object perms

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -5203,13 +5203,18 @@ def manage_file(name,
                 'Replace symbolic link with regular file'
 
         if salt.utils.platform.is_windows():
-            ret = check_perms(name,
-                              ret,
-                              kwargs.get('win_owner'),
-                              kwargs.get('win_perms'),
-                              kwargs.get('win_deny_perms'),
-                              None,
-                              kwargs.get('win_inheritance'))
+            # This function resides in win_file.py and will be available
+            # on Windows. The local function will be overridden
+            # pylint: disable=E1120,E1121,E1123
+            ret = check_perms(
+               path=name,
+                ret=ret,
+                owner=kwargs.get('win_owner'),
+                grant_perms=kwargs.get('win_perms'),
+                deny_perms=kwargs.get('win_deny_perms'),
+                inheritance=kwargs.get('win_inheritance', True),
+                reset=kwargs.get('win_perms_reset', False))
+            # pylint: enable=E1120,E1121,E1123
         else:
             ret, _ = check_perms(name, ret, user, group, mode, attrs, follow_symlinks)
 
@@ -5250,13 +5255,15 @@ def manage_file(name,
             if salt.utils.platform.is_windows():
                 # This function resides in win_file.py and will be available
                 # on Windows. The local function will be overridden
-                # pylint: disable=E1121
-                makedirs_(name,
-                          kwargs.get('win_owner'),
-                          kwargs.get('win_perms'),
-                          kwargs.get('win_deny_perms'),
-                          kwargs.get('win_inheritance'))
-                # pylint: enable=E1121
+                # pylint: disable=E1120,E1121,E1123
+                makedirs_(
+                    path=name,
+                    owner=kwargs.get('win_owner'),
+                    grant_perms=kwargs.get('win_perms'),
+                    deny_perms=kwargs.get('win_deny_perms'),
+                    inheritance=kwargs.get('win_inheritance', True),
+                    reset=kwargs.get('win_perms_reset', False))
+                # pylint: enable=E1120,E1121,E1123
             else:
                 makedirs_(name, user=user, group=group, mode=dir_mode)
 
@@ -5369,13 +5376,18 @@ def manage_file(name,
             mode = oct((0o777 ^ mask) & 0o666)
 
         if salt.utils.platform.is_windows():
-            ret = check_perms(name,
-                              ret,
-                              kwargs.get('win_owner'),
-                              kwargs.get('win_perms'),
-                              kwargs.get('win_deny_perms'),
-                              None,
-                              kwargs.get('win_inheritance'))
+            # This function resides in win_file.py and will be available
+            # on Windows. The local function will be overridden
+            # pylint: disable=E1120,E1121,E1123
+            ret = check_perms(
+               path=name,
+                ret=ret,
+                owner=kwargs.get('win_owner'),
+                grant_perms=kwargs.get('win_perms'),
+                deny_perms=kwargs.get('win_deny_perms'),
+                inheritance=kwargs.get('win_inheritance', True),
+                reset=kwargs.get('win_perms_reset', False))
+            # pylint: enable=E1120,E1121,E1123
         else:
             ret, _ = check_perms(name, ret, user, group, mode, attrs)
 

--- a/tests/unit/states/test_file.py
+++ b/tests/unit/states/test_file.py
@@ -815,7 +815,7 @@ class TestFileState(TestCase, LoaderModuleMockMixin):
                             'comment': comt,
                             'result': None,
                             'pchanges': p_chg,
-                            'changes': {'/etc/grub.conf': {'directory': 'new'}}
+                            'changes': {}
                         })
                         self.assertDictEqual(filestate.directory(name,
                                                                  user=user,
@@ -841,6 +841,11 @@ class TestFileState(TestCase, LoaderModuleMockMixin):
                                                  ret)
 
                         recurse = ['ignore_files', 'ignore_dirs']
+                        ret.update({'comment': 'Must not specify "recurse" '
+                                               'options "ignore_files" and '
+                                               '"ignore_dirs" at the same '
+                                               'time.',
+                                    'pchanges': {}})
                         with patch.object(os.path, 'isdir', mock_t):
                             self.assertDictEqual(filestate.directory
                                                  (name, user=user,


### PR DESCRIPTION
### What does this PR do? 
Supersedes: https://github.com/saltstack/salt/pull/44724

Adds the ability to set the DACL of a file or directory object to be exactly what is specified in the CLI call or the state.

Adds the `reset` option to the following execution module functions in `win_file.py`:
- `mkdir`
- `makedirs_`
- `makedirs_perms`
- `check_perms`
- `set_perms`

Adds the `win_perms_reset` option to the following state module functions in `file.py`:
- `managed`
- `directory`
- `_check_directory_win`

Fixes some documentation issues (copy & paste errors that were not corrected)

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/44460

### Previous Behavior
Could only add/remove entries to the DACL. Could not pass a list of permissions and say... Make these the permissions

### New Behavior
Now you can explicitly define the permissions for a file system object

### Tests written?
Yes

### Commits signed with GPG?
Yes