### PR TITLE
Fix sanitize_win_path function

### DIFF
--- a/salt/utils/path.py
+++ b/salt/utils/path.py
@@ -337,12 +337,12 @@ def sanitize_win_path(winpath):
     Remove illegal path characters for windows
     '''
     intab = '<>:|?*'
-    outtab = '_' * len(intab)
-    trantab = ''.maketrans(intab, outtab) if six.PY3 else string.maketrans(intab, outtab)  # pylint: disable=no-member
-    if isinstance(winpath, six.string_types):
-        winpath = winpath.translate(trantab)
-    elif isinstance(winpath, six.text_type):
+    if isinstance(winpath, six.text_type):
         winpath = winpath.translate(dict((ord(c), u'_') for c in intab))
+    elif isinstance(winpath, six.string_types):
+        outtab = '_' * len(intab)
+        trantab = ''.maketrans(intab, outtab) if six.PY3 else string.maketrans(intab, outtab)  # pylint: disable=no-member
+        winpath = winpath.translate(trantab)
     return winpath
 
 


### PR DESCRIPTION
### What does this PR do?
Fixes problem where the `salt.utils.path.sanitize_win_path` function would fail if it received a Unicode value. This was a problem as the `fileclient` started sending Unicode values on the develop branch. This would cause any state run to fail with the following stacktrace:

```
Traceback (most recent call last):
  File "c:\salt-dev\salt\salt\minion.py", line 1536, in _thread_return
    return_data = minion_instance.executors[fname](opts, data, func, args, kwargs)
  File "c:\salt-dev\salt\salt\executors\direct_call.py", line 12, in execute
    return func(*args, **kwargs)
  File "c:\salt-dev\salt\salt\modules\state.py", line 1186, in sls
    high_, errors = st_.render_highstate({opts['environment']: mods})
  File "c:\salt-dev\salt\salt\state.py", line 3728, in render_highstate
    sls, saltenv, mods, matches)
  File "c:\salt-dev\salt\salt\state.py", line 3382, in render_state
    state_data = self.client.get_state(sls, saltenv)
  File "c:\salt-dev\salt\salt\fileclient.py", line 406, in get_state
    sls_url = salt.utils.url.create(sls + u'.sls')
  File "c:\salt-dev\salt\salt\utils\url.py", line 48, in create
    path = salt.utils.path.sanitize_win_path(path)
  File "c:\salt-dev\salt\salt\utils\path.py", line 343, in sanitize_win_path
    winpath = winpath.translate(trantab)
TypeError: character mapping must return integer, None or unicode
```

### What issues does this PR fix or reference?
Found while trying to test another issue

### Tests written?
No

### Commits signed with GPG?
Yes