### PR TITLE
Fix swap grains for Solaris-like operating systems

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -474,8 +474,14 @@ def _sunos_memdata():
             grains['mem_total'] = int(comps[2].strip())
 
     swap_cmd = salt.utils.path.which('swap')
-    swap_total = __salt__['cmd.run']('{0} -s'.format(swap_cmd)).split()[1]
-    grains['swap_total'] = int(swap_total) // 1024
+    swap_data = __salt__['cmd.run']('{0} -s'.format(swap_cmd)).split()
+    try:
+        swap_avail = int(swap_data[-2][:-1])
+        swap_used = int(swap_data[-4][:-1])
+        swap_total = (swap_avail + swap_used) // 1024
+    except ValueError:
+        swap_total = None
+    grains['swap_total'] = swap_total
     return grains
 
 


### PR DESCRIPTION
### What does this PR do?
The output of ```swap -s``` is the same on atleast the following:
- Solaris 11.3
- Solaris 10
- OmniOS
- OpenIndiana
- SmartOS

```
total: 3251464k bytes allocated + 827664k reserved = 4079128k used,
181507256k available
```

The first value is the current allocate mount of swap without
reservations, the 2nd value is the reservation, the 3rd value is the
current used (allocate + reservation) the last value is the amount of
currently available swap.

We want available + used to get the total.

### What issues does this PR fix or reference?
#44797

### Previous Behavior
Drops a stack trace and quits super early in salt startup

### New Behavior
Does not stack trace and get the expected data.

### Tests written?
No

### Commits signed with GPG?
No