### PR TITLE
Note in doc for s/file.exists that doesn't modify

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -1488,6 +1488,9 @@ def exists(name,
     (e.g., keytabs, private keys, etc.) have been previously satisfied before
     deployment.
 
+    This function does not create the file if it doesn't exist, it will return
+    an error.
+
     name
         Absolute path which must exist
     '''


### PR DESCRIPTION
### What does this PR do?
Expand the documentation to clarify that the states/file.exists function will
not create a file when it doesn't exist and returns an error instead.

### What issues does this PR fix or reference?
Fixes #44546.

### Tests written?

No

### Commits signed with GPG?

Yes