### PR TITLE
documentation: use term 'execution modules' instead of just 'modules'…

### DIFF
--- a/doc/ref/configuration/minion.rst
+++ b/doc/ref/configuration/minion.rst
@@ -1181,7 +1181,7 @@ The password used for HTTP proxy access.
 
     proxy_password: obolus
 
-Minion Module Management
+Minion Execution Module Management
 ========================
 
 .. conf_minion:: disable_modules
@@ -1189,11 +1189,12 @@ Minion Module Management
 ``disable_modules``
 -------------------
 
-Default: ``[]`` (all modules are enabled by default)
+Default: ``[]`` (all execution modules are enabled by default)
 
 The event may occur in which the administrator desires that a minion should not
-be able to execute a certain module. The ``sys`` module is built into the minion
-and cannot be disabled.
+be able to execute a certain module. 
+
+However, the ``sys`` module is built into the minion and cannot be disabled.
 
 This setting can also tune the minion. Because all modules are loaded into system
 memory, disabling modules will lower the minion's memory footprint.
@@ -1232,7 +1233,8 @@ Default: ``[]`` (Module whitelisting is disabled.  Adding anything to the config
 will cause only the listed modules to be enabled.  Modules not in the list will
 not be loaded.)
 
-This option is the reverse of disable_modules.
+This option is the reverse of disable_modules. If enabled, only execution modules in this
+list will be loaded and executed on the minion.
 
 Note that this is a very large hammer and it can be quite difficult to keep the minion working
 the way you think it should since Salt uses many modules internally itself.  At a bare minimum


### PR DESCRIPTION
### What does this PR do?

This PR is a **documentation only change**.

It replaces the term 'modules' with 'execution modules'  in the description of some options of the minion configuration.

### What issues does this PR fix or reference?

It addresses issue #44707

### Commits signed with GPG?

No
