### PR TITLE
make status.cpuinfo work on non-FreeBSD

### DIFF
--- a/salt/modules/status.py
+++ b/salt/modules/status.py
@@ -593,6 +593,9 @@ def cpuinfo():
     .. versionchanged:: 2016.11.4
         Added support for AIX
 
+    .. versionchanged:: Oxygen
+        Added support for NetBSD and OpenBSD
+
     CLI Example:
 
     .. code-block:: bash
@@ -623,14 +626,19 @@ def cpuinfo():
 
     def bsd_cpuinfo():
         '''
-        freebsd specific cpuinfo implementation
+        bsd specific cpuinfo implementation
         '''
-        freebsd_cmd = 'sysctl hw.model hw.ncpu'
+        bsd_cmd = 'sysctl hw.model hw.ncpu'
         ret = {}
-        for line in __salt__['cmd.run'](freebsd_cmd).splitlines():
+        if __grains__['kernel'].lower() in ['netbsd', 'openbsd']:
+            sep = '='
+        else:
+            sep = ':'
+
+        for line in __salt__['cmd.run'](bsd_cmd).splitlines():
             if not line:
                 continue
-            comps = line.split(':')
+            comps = line.split(sep)
             comps[0] = comps[0].strip()
             ret[comps[0]] = comps[1].strip()
         return ret
@@ -775,6 +783,7 @@ def cpuinfo():
     get_version = {
         'Linux': linux_cpuinfo,
         'FreeBSD': bsd_cpuinfo,
+        'NetBSD': bsd_cpuinfo,
         'OpenBSD': bsd_cpuinfo,
         'SunOS': sunos_cpuinfo,
         'AIX': aix_cpuinfo,

--- a/salt/states/boto_elb.py
+++ b/salt/states/boto_elb.py
@@ -396,6 +396,9 @@ def present(name, listeners, availability_zones=None, subnets=None,
     ret['result'] = ret['result'] if _ret['result'] else _ret['result']
     if ret['result'] is False:
         return ret
+    exists = __salt__['boto_elb.exists'](name, region, key, keyid, profile)
+    if not exists and __opts__['test']:
+        return ret
 
     if attributes:
         _ret = _attributes_present(name, attributes, region, key, keyid, profile)

--- a/tests/unit/modules/test_status.py
+++ b/tests/unit/modules/test_status.py
@@ -202,3 +202,36 @@ class StatusTestCase(TestCase, LoaderModuleMockMixin):
                     patch.dict(status.__salt__, {'cmd.run': MagicMock(return_value=systat)}):
             ret = status.cpustats()
             self.assertDictEqual(ret, m.ret)
+
+    def _set_up_test_cpuinfo_bsd(self):
+        class MockData(object):
+            '''
+            Store mock data
+            '''
+
+        m = MockData()
+        m.ret = {
+          'hw.model': 'Intel(R) Core(TM) i5-7287U CPU @ 3.30GHz',
+          'hw.ncpu': '4',
+        }
+
+        return m
+
+    def test_cpuinfo_freebsd(self):
+        m = self._set_up_test_cpuinfo_bsd()
+        sysctl = 'hw.model:Intel(R) Core(TM) i5-7287U CPU @ 3.30GHz\nhw.ncpu:4'
+
+        with patch.dict(status.__grains__, {'kernel': 'FreeBSD'}):
+            with patch.dict(status.__salt__, {'cmd.run': MagicMock(return_value=sysctl)}):
+                ret = status.cpuinfo()
+                self.assertDictEqual(ret, m.ret)
+
+    def test_cpuinfo_openbsd(self):
+        m = self._set_up_test_cpuinfo_bsd()
+        sysctl = 'hw.model=Intel(R) Core(TM) i5-7287U CPU @ 3.30GHz\nhw.ncpu=4'
+
+        for bsd in ['NetBSD', 'OpenBSD']:
+            with patch.dict(status.__grains__, {'kernel': bsd}):
+                with patch.dict(status.__salt__, {'cmd.run': MagicMock(return_value=sysctl)}):
+                    ret = status.cpuinfo()
+                    self.assertDictEqual(ret, m.ret)


### PR DESCRIPTION
### What does this PR do?

Unbreak `status.cpuinfo` on OpenBSD, the field separator on OpenBSD and NetBSD is '=', not ':'.
Verified on OpenBSD, assuming this now works on NetBSD based on upstream documentation for sysctl(8).

### What issues does this PR fix or reference?



### Previous Behavior

```
salt.localdomain:
    The minion function caused an exception: Traceback (most recent call last):
      File "/usr/local/lib/python2.7/site-packages/salt/minion.py", line 1470, in _thread_return
        return_data = executor.execute()
      File "/usr/local/lib/python2.7/site-packages/salt/executors/direct_call.py", line 28, in execute
        return self.func(*self.args, **self.kwargs)
      File "/usr/local/lib/python2.7/site-packages/salt/modules/status.py", line 762, in cpuinfo
        return get_version.get(__grains__['kernel'], lambda: errmsg)()
      File "/usr/local/lib/python2.7/site-packages/salt/modules/status.py", line 613, in bsd_cpuinfo
        ret[comps[0]] = comps[1].strip()
    IndexError: list index out of range
```

### New Behavior

```
salt.localdomain:
    ----------
    hw.model:
        Intel Xeon E3-12xx v2 (Ivy Bridge)
    hw.ncpu:
        1
```

### Tests written?

No

### Commits signed with GPG?

Yes

Please cherry-pick this to the `2017.7` branch too.