### PR TITLE
Implement variable fileserver update intervals

### DIFF
--- a/doc/ref/configuration/master.rst
+++ b/doc/ref/configuration/master.rst
@@ -2088,8 +2088,8 @@ The default options are:
       variable_end_string: '}}'
       comment_start_string: '{#'
       comment_end_string: '#}'
-      line_statement_prefix: 
-      line_comment_prefix: 
+      line_statement_prefix:
+      line_comment_prefix:
       trim_blocks: False
       lstrip_blocks: False
       newline_sequence: '\n'
@@ -2119,8 +2119,8 @@ The default options are:
       variable_end_string: '}}'
       comment_start_string: '{#'
       comment_end_string: '#}'
-      line_statement_prefix: 
-      line_comment_prefix: 
+      line_statement_prefix:
+      line_comment_prefix:
       trim_blocks: False
       lstrip_blocks: False
       newline_sequence: '\n'
@@ -2355,7 +2355,7 @@ Example:
 
     fileserver_backend:
       - roots
-      - git
+      - gitfs
 
 .. note::
     For masterless Salt, this parameter must be specified in the minion config
@@ -2538,6 +2538,19 @@ nothing is ignored.
     fileserver, it is good practice to include ``'\*.swp'`` in the
     :conf_master:`file_ignore_glob`.
 
+.. conf_master:: master_roots
+
+``master_roots``
+----------------
+
+Default: ``/srv/salt-master``
+
+A master-only copy of the :conf_master:`file_roots` dictionary, used by the
+state compiler.
+
+.. code-block:: yaml
+
+    master_roots: /srv/salt-master
 
 roots: Master's Local File Server
 ---------------------------------
@@ -2581,21 +2594,28 @@ Example:
     For masterless Salt, this parameter must be specified in the minion config
     file.
 
-.. conf_master:: master_roots
+.. conf_master:: roots_update_interval
 
-``master_roots``
-----------------
+``roots_update_interval``
+*************************
 
-Default: ``/srv/salt-master``
+.. versionadded:: Oxygen
 
-A master-only copy of the file_roots dictionary, used by the state compiler.
+Default: ``60``
+
+This option defines the update interval (in seconds) for
+:conf_master:`file_roots`.
+
+.. note::
+    Since ``file_roots`` consists of files local to the minion, the update
+    process for this fileserver backend just reaps the cache for this backend.
 
 .. code-block:: yaml
 
-    master_roots: /srv/salt-master
+    roots_update_interval: 120
 
-git: Git Remote File Server Backend
------------------------------------
+gitfs: Git Remote File Server Backend
+-------------------------------------
 
 .. conf_master:: gitfs_remotes
 
@@ -2891,6 +2911,22 @@ they were created by a different master.
 
 .. __: http://www.gluster.org/
 
+.. conf_master:: gitfs_update_interval
+
+``gitfs_update_interval``
+*************************
+
+.. versionadded:: Oxygen
+
+Default: ``60``
+
+This option defines the default update interval (in seconds) for gitfs remotes.
+The update interval can also be set for a single repository via a
+:ref:`per-remote config option <gitfs-per-remote-config>`
+
+.. code-block:: yaml
+
+    gitfs_update_interval: 120
 
 GitFS Authentication Options
 ****************************
@@ -3049,8 +3085,8 @@ can be found in the :ref:`GitFS Walkthrough <gitfs-custom-refspecs>`.
       - '+refs/pull/*/head:refs/remotes/origin/pr/*'
       - '+refs/pull/*/merge:refs/remotes/origin/merge/*'
 
-hg: Mercurial Remote File Server Backend
-----------------------------------------
+hgfs: Mercurial Remote File Server Backend
+------------------------------------------
 
 .. conf_master:: hgfs_remotes
 
@@ -3249,8 +3285,24 @@ blacklist will be exposed as fileserver environments.
       - v1.*
       - 'mybranch\d+'
 
-svn: Subversion Remote File Server Backend
-------------------------------------------
+.. conf_master:: hgfs_update_interval
+
+``hgfs_update_interval``
+************************
+
+.. versionadded:: Oxygen
+
+Default: ``60``
+
+This option defines the update interval (in seconds) for
+:conf_master:`hgfs_remotes`.
+
+.. code-block:: yaml
+
+    hgfs_update_interval: 120
+
+svnfs: Subversion Remote File Server Backend
+--------------------------------------------
 
 .. conf_master:: svnfs_remotes
 
@@ -3460,8 +3512,24 @@ will be exposed as fileserver environments.
       - v1.*
       - 'mybranch\d+'
 
-minion: MinionFS Remote File Server Backend
--------------------------------------------
+.. conf_master:: svnfs_update_interval
+
+``svnfs_update_interval``
+*************************
+
+.. versionadded:: Oxygen
+
+Default: ``60``
+
+This option defines the update interval (in seconds) for
+:conf_master:`svnfs_remotes`.
+
+.. code-block:: yaml
+
+    svnfs_update_interval: 120
+
+minionfs: MinionFS Remote File Server Backend
+---------------------------------------------
 
 .. conf_master:: minionfs_env
 
@@ -3549,6 +3617,72 @@ exposed.
       - server01
       - dev*
       - 'mail\d+.mydomain.tld'
+
+.. conf_master:: minionfs_update_interval
+
+``minionfs_update_interval``
+****************************
+
+.. versionadded:: Oxygen
+
+Default: ``60``
+
+This option defines the update interval (in seconds) for :ref:`MinionFS
+<tutorial-minionfs>`.
+
+.. note::
+    Since :ref:`MinionFS <tutorial-minionfs>` consists of files local to the
+    master, the update process for this fileserver backend just reaps the cache
+    for this backend.
+
+.. code-block:: yaml
+
+    minionfs_update_interval: 120
+
+azurefs: Azure File Server Backend
+----------------------------------
+
+.. versionadded:: 2015.8.0
+
+See the :mod:`azurefs documentation <salt.fileserver.azurefs>` for usage
+examples.
+
+.. conf_master:: azurefs_update_interval
+
+``azurefs_update_interval``
+***************************
+
+.. versionadded:: Oxygen
+
+Default: ``60``
+
+This option defines the update interval (in seconds) for azurefs.
+
+.. code-block:: yaml
+
+    azurefs_update_interval: 120
+
+s3fs: S3 File Server Backend
+----------------------------
+
+.. versionadded:: 0.16.0
+
+See the :mod:`s3fs documentation <salt.fileserver.s3fs>` for usage examples.
+
+.. conf_master:: s3fs_update_interval
+
+``s3fs_update_interval``
+************************
+
+.. versionadded:: Oxygen
+
+Default: ``60``
+
+This option defines the update interval (in seconds) for s3fs.
+
+.. code-block:: yaml
+
+    s3fs_update_interval: 120
 
 
 .. _pillar-configuration-master:

--- a/doc/topics/releases/oxygen.rst
+++ b/doc/topics/releases/oxygen.rst
@@ -167,8 +167,39 @@ they failed. Here's some example pseudocode:
             __context__['retcode'] = 1
         return result
 
+Variable Update Intervals for Fileserver Backends
+-------------------------------------------------
+
+Prior to this release, fileservers would be updated as part of a dedicated
+"maintenance" process, in which various routine maintenance tasks were
+performed. This tied the update interval to the :conf_master:`loop_interval`
+config option, and also forced all fileservers to update at the same interval.
+
+Oxygen adds the following configuration options for the various fileserver
+backends:
+
+- :conf_master:`roots_update_interval`
+- :conf_master:`azurefs_update_interval`
+- :conf_master:`gitfs_update_interval`
+- :conf_master:`hgfs_update_interval`
+- :conf_master:`minionfs_update_interval`
+- :conf_master:`s3fs_update_interval`
+- :conf_master:`svnfs_update_interval`
+
+These allow for update intervals to be set for each individual backend. The
+default value for each of these is 60 seconds.
+
+In addition, for :ref:`GitFS <tutorial-gitfs>` it is also possible to apply
+intervals to individual remotes. See :ref:`here <gitfs-update-intervals>` for
+examples.
+
+.. note::
+    git_pillar does not yet support variable update intervals, this is targeted
+    for the next feature release (Fluorine).
+
 LDAP via External Authentication Changes
 ----------------------------------------
+
 In this release of Salt, if LDAP Bind Credentials are supplied, then
 these credentials will be used for all LDAP access except the first
 authentication when a job is submitted.  The first authentication will

--- a/doc/topics/tutorials/gitfs.rst
+++ b/doc/topics/tutorials/gitfs.rst
@@ -209,13 +209,17 @@ Simple Configuration
 To use the gitfs backend, only two configuration changes are required on the
 master:
 
-1. Include ``git`` in the :conf_master:`fileserver_backend` list in the master
-   config file:
+1. Include ``gitfs`` in the :conf_master:`fileserver_backend` list in the
+   master config file:
 
    .. code-block:: yaml
 
        fileserver_backend:
-         - git
+         - gitfs
+
+   .. note::
+       ``git`` also works here. Prior to the Oxygen release, *only* ``git``
+       would work.
 
 2. Specify one or more ``git://``, ``https://``, ``file://``, or ``ssh://``
    URLs in :conf_master:`gitfs_remotes` to configure which repositories to
@@ -334,6 +338,7 @@ configured gitfs remotes):
 * :conf_master:`gitfs_refspecs` (new in 2017.7.0)
 * :conf_master:`gitfs_disable_saltenv_mapping` (new in Oxygen)
 * :conf_master:`gitfs_ref_types` (new in Oxygen)
+* :conf_master:`gitfs_update_interval` (new in Oxygen)
 
 .. note::
     pygit2 only supports disabling SSL verification in versions 0.23.2 and
@@ -354,6 +359,7 @@ tremendous amount of customization. Here's some example usage:
         - mountpoint: salt://bar
         - base: salt-base
         - ssl_verify: False
+        - update_interval: 120
       - https://foo.com/bar.git:
         - name: second_bar_repo
         - root: other/salt
@@ -426,6 +432,8 @@ In the example configuration above, the following is true:
        *only* because authentication is not being used. Otherwise, the
        ``insecure_auth`` parameter must be used (as in the fourth remote) to
        force Salt to authenticate to an ``http://`` remote.
+
+9. The first remote will wait 120 seconds between updates instead of 60.
 
 .. _gitfs-per-saltenv-config:
 
@@ -561,6 +569,32 @@ single branch.
     gitfs_remotes:
       - http://foo.com/quux.git:
         - all_saltenvs: anything
+
+.. _gitfs-update-intervals:
+
+Update Intervals
+================
+
+Prior to the Oxygen release, GitFS would update its fileserver backends as part
+of a dedicated "maintenance" process, in which various routine maintenance
+tasks were performed. This tied the update interval to the
+:conf_master:`loop_interval` config option, and also forced all fileservers to
+update at the same interval.
+
+Now it is possible to make GitFS update at its own interval, using
+:conf_master:`gitfs_update_interval`:
+
+.. code-block:: yaml
+
+    gitfs_update_interval: 180
+
+    gitfs_remotes:
+      - https://foo.com/foo.git
+      - https://foo.com/bar.git:
+        - update_interval: 120
+
+Using the above configuration, the first remote would update every three
+minutes, while the second remote would update every two minutes.
 
 Configuration Order of Precedence
 =================================

--- a/doc/topics/tutorials/minionfs.rst
+++ b/doc/topics/tutorials/minionfs.rst
@@ -73,7 +73,7 @@ pushed files are made available.
 Simple Configuration
 --------------------
 
-To use the :mod:`minionfs <salt.fileserver.minionfs>` backend, add ``minion``
+To use the :mod:`minionfs <salt.fileserver.minionfs>` backend, add ``minionfs``
 to the list of backends in the :conf_master:`fileserver_backend` configuration
 option on the master:
 
@@ -83,10 +83,13 @@ option on the master:
 
     fileserver_backend:
       - roots
-      - minion
+      - minionfs
 
 .. note::
-    As described earlier, ``file_recv: True`` is also needed to enable the
+    ``minion`` also works here. Prior to the Oxygen release, *only* ``minion``
+    would work.
+
+    Also, as described earlier, ``file_recv: True`` is needed to enable the
     master to receive files pushed from minions. As always, changes to the
     master configuration require a restart of the ``salt-master`` service.
 
@@ -127,7 +130,7 @@ blacklist, can be found below:
 
     fileserver_backend:
       - roots
-      - minion
+      - minionfs
 
     minionfs_mountpoint: salt://minionfs
 

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -57,6 +57,7 @@ _DFLT_LOG_FMT_LOGFILE = (
     '%(asctime)s,%(msecs)03d [%(name)-17s:%(lineno)-4d][%(levelname)-8s][%(process)d] %(message)s'
 )
 _DFLT_REFSPECS = ['+refs/heads/*:refs/remotes/origin/*', '+refs/tags/*:refs/tags/*']
+DEFAULT_INTERVAL = 60
 
 if salt.utils.platform.is_windows():
     # Since an 'ipc_mode' of 'ipc' will never work on Windows due to lack of
@@ -643,6 +644,16 @@ VALID_OPTS = {
 
     # Frequency of the proxy_keep_alive, in minutes
     'proxy_keep_alive_interval': int,
+
+    # Update intervals
+    'roots_update_interval': int,
+    'azurefs_update_interval': int,
+    'gitfs_update_interval': int,
+    'hgfs_update_interval': int,
+    'minionfs_update_interval': int,
+    's3fs_update_interval': int,
+    'svnfs_update_interval': int,
+
     'git_pillar_base': six.string_types,
     'git_pillar_branch': six.string_types,
     'git_pillar_env': six.string_types,
@@ -1275,6 +1286,16 @@ DEFAULT_MINION_OPTS = {
     'decrypt_pillar_delimiter': ':',
     'decrypt_pillar_default': 'gpg',
     'decrypt_pillar_renderers': ['gpg'],
+
+    # Update intervals
+    'roots_update_interval': DEFAULT_INTERVAL,
+    'azurefs_update_interval': DEFAULT_INTERVAL,
+    'gitfs_update_interval': DEFAULT_INTERVAL,
+    'hgfs_update_interval': DEFAULT_INTERVAL,
+    'minionfs_update_interval': DEFAULT_INTERVAL,
+    's3fs_update_interval': DEFAULT_INTERVAL,
+    'svnfs_update_interval': DEFAULT_INTERVAL,
+
     'git_pillar_base': 'master',
     'git_pillar_branch': 'master',
     'git_pillar_env': '',
@@ -1525,6 +1546,16 @@ DEFAULT_MASTER_OPTS = {
     'pillarenv': None,
     'default_top': 'base',
     'file_client': 'local',
+
+    # Update intervals
+    'roots_update_interval': DEFAULT_INTERVAL,
+    'azurefs_update_interval': DEFAULT_INTERVAL,
+    'gitfs_update_interval': DEFAULT_INTERVAL,
+    'hgfs_update_interval': DEFAULT_INTERVAL,
+    'minionfs_update_interval': DEFAULT_INTERVAL,
+    's3fs_update_interval': DEFAULT_INTERVAL,
+    'svnfs_update_interval': DEFAULT_INTERVAL,
+
     'git_pillar_base': 'master',
     'git_pillar_branch': 'master',
     'git_pillar_env': '',
@@ -3677,6 +3708,15 @@ def apply_minion_config(overrides=None,
             )
             opts['saltenv'] = opts['environment']
 
+    for idx, val in enumerate(opts['fileserver_backend']):
+        if val in ('git', 'hg', 'svn', 'minion'):
+            new_val = val + 'fs'
+            log.debug(
+                'Changed %s to %s in minion opts\' fileserver_backend list',
+                val, new_val
+            )
+            opts['fileserver_backend'][idx] = new_val
+
     opts['__cli'] = os.path.basename(sys.argv[0])
 
     # No ID provided. Will getfqdn save us?
@@ -3842,6 +3882,15 @@ def apply_master_config(overrides=None, defaults=None):
                 opts['environment']
             )
             opts['saltenv'] = opts['environment']
+
+    for idx, val in enumerate(opts['fileserver_backend']):
+        if val in ('git', 'hg', 'svn', 'minion'):
+            new_val = val + 'fs'
+            log.debug(
+                'Changed %s to %s in master opts\' fileserver_backend list',
+                val, new_val
+            )
+            opts['fileserver_backend'][idx] = new_val
 
     if len(opts['sock_dir']) > len(opts['cachedir']) + 10:
         opts['sock_dir'] = os.path.join(opts['cachedir'], '.salt-unix')

--- a/salt/daemons/masterapi.py
+++ b/salt/daemons/masterapi.py
@@ -252,8 +252,8 @@ def access_keys(opts):
 
 def fileserver_update(fileserver):
     '''
-    Update the fileserver backends, requires that a built fileserver object
-    be passed in
+    Update the fileserver backends, requires that a salt.fileserver.Fileserver
+    object be passed in
     '''
     try:
         if not fileserver.servers:

--- a/salt/fileserver/azurefs.py
+++ b/salt/fileserver/azurefs.py
@@ -2,6 +2,8 @@
 '''
 The backend for serving files from the Azure blob storage service.
 
+.. versionadded:: 2015.8.0
+
 To enable, add ``azurefs`` to the :conf_master:`fileserver_backend` option in
 the Master config file.
 

--- a/salt/fileserver/gitfs.py
+++ b/salt/fileserver/gitfs.py
@@ -5,13 +5,17 @@ Git Fileserver Backend
 With this backend, branches and tags in a remote git repository are exposed to
 salt as different environments.
 
-To enable, add ``git`` to the :conf_master:`fileserver_backend` option in the
+To enable, add ``gitfs`` to the :conf_master:`fileserver_backend` option in the
 Master config file.
 
 .. code-block:: yaml
 
     fileserver_backend:
-      - git
+      - gitfs
+
+.. note::
+    ``git`` also works here. Prior to the Oxygen release, *only* ``git``
+    would work.
 
 The Git fileserver backend supports both pygit2_ and GitPython_, to provide the
 Python interface to git. If both are present, the order of preference for which
@@ -52,7 +56,7 @@ PER_REMOTE_OVERRIDES = (
     'base', 'mountpoint', 'root', 'ssl_verify',
     'saltenv_whitelist', 'saltenv_blacklist',
     'env_whitelist', 'env_blacklist', 'refspecs',
-    'disable_saltenv_mapping', 'ref_types'
+    'disable_saltenv_mapping', 'ref_types', 'update_interval',
 )
 PER_REMOTE_ONLY = ('all_saltenvs', 'name', 'saltenv')
 
@@ -68,7 +72,7 @@ from salt.exceptions import FileserverConfigError
 log = logging.getLogger(__name__)
 
 # Define the module's virtual name
-__virtualname__ = 'git'
+__virtualname__ = 'gitfs'
 
 
 def _gitfs(init_remotes=True):
@@ -122,11 +126,18 @@ def lock(remote=None):
     return _gitfs().lock(remote=remote)
 
 
-def update():
+def update(remotes=None):
     '''
     Execute a git fetch on all of the repos
     '''
-    _gitfs().update()
+    _gitfs().update(remotes)
+
+
+def update_intervals():
+    '''
+    Returns the update intervals for each configured remote
+    '''
+    return _gitfs().update_intervals()
 
 
 def envs(ignore_cache=False):

--- a/salt/fileserver/hgfs.py
+++ b/salt/fileserver/hgfs.py
@@ -2,13 +2,17 @@
 '''
 Mercurial Fileserver Backend
 
-To enable, add ``hg`` to the :conf_master:`fileserver_backend` option in the
+To enable, add ``hgfs`` to the :conf_master:`fileserver_backend` option in the
 Master config file.
 
 .. code-block:: yaml
 
     fileserver_backend:
-      - hg
+      - hgfs
+
+.. note::
+    ``hg`` also works here. Prior to the Oxygen release, *only* ``hg`` would
+    work.
 
 After enabling this backend, branches, bookmarks, and tags in a remote
 mercurial repository are exposed to salt as different environments. This

--- a/salt/fileserver/minionfs.py
+++ b/salt/fileserver/minionfs.py
@@ -6,15 +6,19 @@ The :mod:`cp.push <salt.modules.cp.push>` function allows Minions to push files
 up to the Master. Using this backend, these pushed files are exposed to other
 Minions via the Salt fileserver.
 
-To enable minionfs, :conf_master:`file_recv` needs to be set to ``True`` in
-the master config file (otherwise :mod:`cp.push <salt.modules.cp.push>` will
-not be allowed to push files to the Master), and ``minion`` must be added to
-the :conf_master:`fileserver_backends` list.
+To enable minionfs, :conf_master:`file_recv` needs to be set to ``True`` in the
+master config file (otherwise :mod:`cp.push <salt.modules.cp.push>` will not be
+allowed to push files to the Master), and ``minionfs`` must be added to the
+:conf_master:`fileserver_backends` list.
 
 .. code-block:: yaml
 
     fileserver_backend:
-      - minion
+      - minionfs
+
+.. note::
+    ``minion`` also works here. Prior to the Oxygen release, *only* ``minion``
+    would work.
 
 Other minionfs settings include: :conf_master:`minionfs_whitelist`,
 :conf_master:`minionfs_blacklist`, :conf_master:`minionfs_mountpoint`, and
@@ -46,7 +50,7 @@ log = logging.getLogger(__name__)
 
 
 # Define the module's virtual name
-__virtualname__ = 'minion'
+__virtualname__ = 'minionfs'
 
 
 def __virtual__():

--- a/salt/fileserver/s3fs.py
+++ b/salt/fileserver/s3fs.py
@@ -2,6 +2,8 @@
 '''
 Amazon S3 Fileserver Backend
 
+.. versionadded:: 0.16.0
+
 This backend exposes directories in S3 buckets as Salt environments. To enable
 this backend, add ``s3fs`` to the :conf_master:`fileserver_backend` option in the
 Master config file.

--- a/salt/fileserver/svnfs.py
+++ b/salt/fileserver/svnfs.py
@@ -4,13 +4,17 @@ Subversion Fileserver Backend
 
 After enabling this backend, branches and tags in a remote subversion
 repository are exposed to salt as different environments. To enable this
-backend, add ``svn`` to the :conf_master:`fileserver_backend` option in the
+backend, add ``svnfs`` to the :conf_master:`fileserver_backend` option in the
 Master config file.
 
 .. code-block:: yaml
 
     fileserver_backend:
-      - svn
+      - svnfs
+
+.. note::
+    ``svn`` also works here. Prior to the Oxygen release, *only* ``svn`` would
+    work.
 
 This backend assumes a standard svn layout with directories for ``branches``,
 ``tags``, and ``trunk``, at the repository root.

--- a/salt/utils/gitfs.py
+++ b/salt/utils/gitfs.py
@@ -138,6 +138,7 @@ def enforce_types(key, val):
         'saltenv_blacklist': 'stringlist',
         'refspecs': 'stringlist',
         'ref_types': 'stringlist',
+        'update_interval': int,
     }
 
     def _find_global(key):
@@ -160,14 +161,21 @@ def enforce_types(key, val):
             return six.text_type(val)
 
     expected = non_string_params[key]
-    if expected is bool:
-        return val
-    elif expected == 'stringlist':
+    if expected == 'stringlist':
         if not isinstance(val, (six.string_types, list)):
             val = six.text_type(val)
         if isinstance(val, six.string_types):
             return [x.strip() for x in val.split(',')]
         return [six.text_type(x) for x in val]
+    else:
+        try:
+            return expected(val)
+        except Exception as exc:
+            log.error(
+                'Failed to enforce type for key=%s with val=%s, falling back '
+                'to a string', key, val
+            )
+            return six.text_type(val)
 
 
 def failhard(role):
@@ -398,7 +406,8 @@ class GitProvider(object):
 
         hash_type = getattr(hashlib, self.opts.get('hash_type', 'md5'))
         if six.PY3:
-            # We loaded this data from yaml configuration files, so, its safe to use UTF-8
+            # We loaded this data from yaml configuration files, so, its safe
+            # to use UTF-8
             self.hash = hash_type(self.id.encode('utf-8')).hexdigest()
         else:
             self.hash = hash_type(self.id).hexdigest()
@@ -2166,16 +2175,15 @@ class GitBase(object):
         cachedir_map = {}
         for repo in self.remotes:
             cachedir_map.setdefault(repo.cachedir, []).append(repo.id)
+
         collisions = [x for x in cachedir_map if len(cachedir_map[x]) > 1]
         if collisions:
             for dirname in collisions:
                 log.critical(
-                    'The following {0} remotes have conflicting cachedirs: '
-                    '{1}. Resolve this using a per-remote parameter called '
-                    '\'name\'.'.format(
-                        self.role,
-                        ', '.join(cachedir_map[dirname])
-                    )
+                    'The following %s remotes have conflicting cachedirs: '
+                    '%s. Resolve this using a per-remote parameter called '
+                    '\'name\'.',
+                    self.role, ', '.join(cachedir_map[dirname])
                 )
                 failhard(self.role)
 
@@ -2262,27 +2270,39 @@ class GitBase(object):
             errors.extend(failed)
         return cleared, errors
 
-    def fetch_remotes(self):
+    def fetch_remotes(self, remotes=None):
         '''
         Fetch all remotes and return a boolean to let the calling function know
         whether or not any remotes were updated in the process of fetching
         '''
+        if remotes is None:
+            remotes = []
+        elif not isinstance(remotes, list):
+            log.error(
+                'Invalid \'remotes\' argument (%s) for fetch_remotes. '
+                'Must be a list of strings', remotes
+            )
+            remotes = []
+
         changed = False
         for repo in self.remotes:
-            try:
-                if repo.fetch():
-                    # We can't just use the return value from repo.fetch()
-                    # because the data could still have changed if old remotes
-                    # were cleared above. Additionally, we're running this in a
-                    # loop and later remotes without changes would override
-                    # this value and make it incorrect.
-                    changed = True
-            except Exception as exc:
-                log.error(
-                    'Exception caught while fetching %s remote \'%s\': %s',
-                    self.role, repo.id, exc,
-                    exc_info=True
-                )
+            name = getattr(repo, 'name', None)
+            if not remotes or (repo.id, name) in remotes:
+                try:
+                    if repo.fetch():
+                        # We can't just use the return value from repo.fetch()
+                        # because the data could still have changed if old
+                        # remotes were cleared above. Additionally, we're
+                        # running this in a loop and later remotes without
+                        # changes would override this value and make it
+                        # incorrect.
+                        changed = True
+                except Exception as exc:
+                    log.error(
+                        'Exception caught while fetching %s remote \'%s\': %s',
+                        self.role, repo.id, exc,
+                        exc_info=True
+                    )
         return changed
 
     def lock(self, remote=None):
@@ -2307,8 +2327,13 @@ class GitBase(object):
             errors.extend(failed)
         return locked, errors
 
-    def update(self):
+    def update(self, remotes=None):
         '''
+        .. versionchanged:: Oxygen
+            The remotes argument was added. This being a list of remote URLs,
+            it will only update matching remotes. This actually matches on
+            repo.id
+
         Execute a git fetch on all of the repos and perform maintenance on the
         fileserver cache.
         '''
@@ -2317,7 +2342,7 @@ class GitBase(object):
                 'backend': 'gitfs'}
 
         data['changed'] = self.clear_old_remotes()
-        if self.fetch_remotes():
+        if self.fetch_remotes(remotes=remotes):
             data['changed'] = True
 
         # A masterless minion will need a new env cache file even if no changes
@@ -2357,6 +2382,18 @@ class GitBase(object):
         except (OSError, IOError):
             # Hash file won't exist if no files have yet been served up
             pass
+
+    def update_intervals(self):
+        '''
+        Returns a dictionary mapping remote IDs to their intervals, designed to
+        be used for variable update intervals in salt.master.FileserverUpdate.
+
+        A remote's ID is defined here as a tuple of the GitPython/Pygit2
+        object's "id" and "name" attributes, with None being assumed as the
+        "name" value if the attribute is not present.
+        '''
+        return {(repo.id, getattr(repo, 'name', None)): repo.update_interval
+                for repo in self.remotes}
 
     def verify_provider(self):
         '''

--- a/tests/unit/config/test_config.py
+++ b/tests/unit/config/test_config.py
@@ -13,6 +13,7 @@ import logging
 import os
 import shutil
 import tempfile
+import textwrap
 
 # Import Salt Testing libs
 from tests.support.mixins import AdaptedConfigurationTestCaseMixin
@@ -76,7 +77,7 @@ def _salt_configuration_error(filename):
 class ConfigTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
 
     def test_sha256_is_default_for_master(self):
-        fpath = tempfile.mktemp()
+        fpath = salt.utils.files.mkstemp(dir=TMP)
         try:
             with salt.utils.files.fopen(fpath, 'w') as wfh:
                 wfh.write(
@@ -90,7 +91,7 @@ class ConfigTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
                 os.unlink(fpath)
 
     def test_sha256_is_default_for_minion(self):
-        fpath = tempfile.mktemp()
+        fpath = salt.utils.files.mkstemp(dir=TMP)
         try:
             with salt.utils.files.fopen(fpath, 'w') as wfh:
                 wfh.write(
@@ -104,7 +105,7 @@ class ConfigTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
                 os.unlink(fpath)
 
     def test_proper_path_joining(self):
-        fpath = tempfile.mktemp()
+        fpath = salt.utils.files.mkstemp(dir=TMP)
         temp_config = 'root_dir: /\n'\
                       'key_logfile: key\n'
         if salt.utils.platform.is_windows():
@@ -388,7 +389,7 @@ class ConfigTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
 
     def test_master_file_roots_glob(self):
         # Config file and stub file_roots.
-        fpath = tempfile.mktemp()
+        fpath = salt.utils.files.mkstemp()
         tempdir = tempfile.mkdtemp(dir=TMP)
         try:
             # Create some kown files.
@@ -418,7 +419,7 @@ class ConfigTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
 
     def test_master_pillar_roots_glob(self):
         # Config file and stub pillar_roots.
-        fpath = tempfile.mktemp()
+        fpath = salt.utils.files.mkstemp()
         tempdir = tempfile.mkdtemp(dir=TMP)
         try:
             # Create some kown files.
@@ -472,7 +473,7 @@ class ConfigTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
 
     def test_minion_file_roots_glob(self):
         # Config file and stub file_roots.
-        fpath = tempfile.mktemp()
+        fpath = salt.utils.files.mkstemp()
         tempdir = tempfile.mkdtemp(dir=TMP)
         try:
             # Create some kown files.
@@ -502,7 +503,7 @@ class ConfigTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
 
     def test_minion_pillar_roots_glob(self):
         # Config file and stub pillar_roots.
-        fpath = tempfile.mktemp()
+        fpath = salt.utils.files.mkstemp()
         tempdir = tempfile.mkdtemp(dir=TMP)
         try:
             # Create some kown files.
@@ -552,6 +553,31 @@ class ConfigTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
         finally:
             if os.path.isdir(tempdir):
                 shutil.rmtree(tempdir)
+
+    def test_backend_rename(self):
+        '''
+        This tests that we successfully rename git, hg, svn, and minion to
+        gitfs, hgfs, svnfs, and minionfs in the master and minion opts.
+        '''
+        tempdir = tempfile.mkdtemp(dir=TMP)
+        fpath = salt.utils.files.mkstemp(dir=tempdir)
+        self.addCleanup(shutil.rmtree, tempdir, ignore_errors=True)
+        with salt.utils.files.fopen(fpath, 'w') as fp_:
+            fp_.write(textwrap.dedent('''\
+                fileserver_backend:
+                  - roots
+                  - git
+                  - hg
+                  - svn
+                  - minion
+                '''))
+
+        master_config = sconfig.master_config(fpath)
+        minion_config = sconfig.minion_config(fpath)
+        expected = ['roots', 'gitfs', 'hgfs', 'svnfs', 'minionfs']
+
+        self.assertEqual(master_config['fileserver_backend'], expected)
+        self.assertEqual(minion_config['fileserver_backend'], expected)
 
     def test_syndic_config(self):
         syndic_conf_path = self.get_config_file_path('syndic')

--- a/tests/unit/fileserver/test_gitfs.py
+++ b/tests/unit/fileserver/test_gitfs.py
@@ -63,7 +63,7 @@ class GitfsConfigTestCase(TestCase, LoaderModuleMockMixin):
                     'cachedir': self.tmp_cachedir,
                     'sock_dir': TMP_SOCK_DIR,
                     'gitfs_root': 'salt',
-                    'fileserver_backend': ['git'],
+                    'fileserver_backend': ['gitfs'],
                     'gitfs_base': 'master',
                     'fileserver_events': True,
                     'transport': 'zeromq',
@@ -86,6 +86,7 @@ class GitfsConfigTestCase(TestCase, LoaderModuleMockMixin):
                     'gitfs_ssl_verify': True,
                     'gitfs_disable_saltenv_mapping': False,
                     'gitfs_ref_types': ['branch', 'tag', 'sha'],
+                    'gitfs_update_interval': 60,
                     '__role': 'master',
                 }
             }
@@ -195,7 +196,7 @@ class GitFSTest(TestCase, LoaderModuleMockMixin):
                     'sock_dir': TMP_SOCK_DIR,
                     'gitfs_remotes': ['file://' + TMP_REPO_DIR],
                     'gitfs_root': '',
-                    'fileserver_backend': ['git'],
+                    'fileserver_backend': ['gitfs'],
                     'gitfs_base': 'master',
                     'fileserver_events': True,
                     'transport': 'zeromq',
@@ -218,6 +219,7 @@ class GitFSTest(TestCase, LoaderModuleMockMixin):
                     'gitfs_ssl_verify': True,
                     'gitfs_disable_saltenv_mapping': False,
                     'gitfs_ref_types': ['branch', 'tag', 'sha'],
+                    'gitfs_update_interval': 60,
                     '__role': 'master',
                 }
             }


### PR DESCRIPTION
This PR moves fileserver updates out of the maintenance process and into their own separate process. Within that process, backends/remotes being updated for a given unique interval are all bunched together, so we end up with one thread spawned for each unique interval.

In the process of implementing this, the virtual names for ``gitfs``, ``hgfs``, ``svnfs``, and ``minionfs`` have all been changed to normalize them with the other non-roots backends, which all end in "fs". To accommodate this change, when the master/minion config is loaded, the fileserver backends are examined and ``git``, ``hg``, ``svn``, ``minion`` are replaced with ``gitfs``, ``hgfs``, etc. This allows old configuration to continue to work, while the examples in the docs now reference the new virtual names.

Renaming the virtual names makes it easier for the ``FileserverUpdate`` process to get the update interval for each of the fileserver backends from the master opts, as we'll be able to look for an option named ``<backend>_update_interval>`` and expect it will be there.

My main concern is that I'm not sure yet how our signal handlers will treat the threads spawned for the different variable intervals. I've only tested this in Docker thus far, so I need to test it in an environment where I have an init system and can see what happens when I shut down the service.

Resolves #40776.

CC: @jmalerbsjr, this should satisfy your concerns with update intervals, as we discussed in #44384.