### PR TITLE
win_pkg: Merge full copy of 2016.11 with many fixes and improvements to 2017.7

### DIFF
--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -195,7 +195,6 @@ def upgrade_available(name, **kwargs):
     # Refresh before looking for the latest version available,
     # same default as latest_version
     refresh = salt.utils.is_true(kwargs.get('refresh', True))
-
     # if latest_version returns blank, the latest version is already installed or
     # their is no package definition. This is a salt standard which could be improved.
     return latest_version(name, saltenv=saltenv, refresh=refresh) != ''
@@ -315,8 +314,9 @@ def version(*names, **kwargs):
         refresh (bool): Refresh package metadata. Default ``False``.
 
     Returns:
-        str: version string when a single package is specified.
+        str: version string when a single packge is specified.
         dict: The package name(s) with the installed versions.
+
 
     .. code-block:: cfg
         {['<version>', '<version>', ]} OR
@@ -331,13 +331,13 @@ def version(*names, **kwargs):
 
     '''
     # Standard is return empty string even if not a valid name
-    # TODO: Look at returning an error across all platforms with
+    # TODO: Look at returning an error accross all platforms with
     # CommandExecutionError(msg,info={'errors': errors })
     # available_pkgs = get_repo_data(saltenv).get('repo')
     # for name in names:
     #    if name in available_pkgs:
     #        ret[name] = installed_pkgs.get(name, '')
-
+    #
     saltenv = kwargs.get('saltenv', 'base')
     installed_pkgs = list_pkgs(saltenv=saltenv, refresh=kwargs.get('refresh', False))
 
@@ -355,6 +355,7 @@ def list_pkgs(versions_as_list=False, **kwargs):
     List the packages currently installed
 
     Args:
+        version_as_list (bool): Returns the versions as a list
 
     Kwargs:
         saltenv (str): The salt environment to use. Default ``base``.
@@ -632,17 +633,6 @@ def _get_repo_details(saltenv):
     if contextkey in __context__:
         (winrepo_source_dir, local_dest, winrepo_file) = __context__[contextkey]
     else:
-        ### Remove these warning lines in 2017.7
-        ###if 'win_repo_source_dir' in __opts__:
-        ###    salt.utils.warn_until(
-        ###        'Nitrogen',
-        ###        'The \'win_repo_source_dir\' config option is deprecated, '
-        ###        'please use \'winrepo_source_dir\' instead.'
-        ###    )
-        ###    winrepo_source_dir = __opts__['win_repo_source_dir']
-        ###else:
-        ###    winrepo_source_dir = __opts__['winrepo_source_dir']
-        winrepo_source_dir = __opts__['winrepo_source_dir']
         winrepo_source_dir = __opts__['winrepo_source_dir']
         dirs = [__opts__['cachedir'], 'files', saltenv]
         url_parts = _urlparse(winrepo_source_dir)
@@ -1341,12 +1331,11 @@ def install(name=None, refresh=False, pkgs=None, **kwargs):
                     ret[pkg_name] = {'install status': 'failed'}
         else:
             # Launch the command
-            result = __salt__['cmd.run_all'](
-                '"{0}" /s /c "{1}"'.format(cmd_shell, arguments),
-                cache_path,
-                output_loglevel='trace',
-                python_shell=False,
-                redirect_stderr=True)
+            result = __salt__['cmd.run_all']('"{0}" /s /c "{1}"'.format(cmd_shell, arguments),
+                                             cache_path,
+                                             output_loglevel='trace',
+                                             python_shell=False,
+                                             redirect_stderr=True)
             if not result['retcode']:
                 ret[pkg_name] = {'install status': 'success'}
                 changed.append(pkg_name)
@@ -1594,10 +1583,6 @@ def remove(name=None, pkgs=None, version=None, **kwargs):
             cached_pkg = cached_pkg.replace('/', '\\')
             cache_path, _ = os.path.split(cached_pkg)
 
-            # Get parameters for cmd
-            expanded_cached_pkg = str(os.path.expandvars(cached_pkg))
-            expanded_cache_path = str(os.path.expandvars(cache_path))
-
             # Get uninstall flags
             uninstall_flags = pkginfo[target].get('uninstall_flags', '')
 
@@ -1608,13 +1593,13 @@ def remove(name=None, pkgs=None, version=None, **kwargs):
             # Compute msiexec string
             use_msiexec, msiexec = _get_msiexec(pkginfo[target].get('msiexec', False))
             cmd_shell = os.getenv('ComSpec', '{0}\\system32\\cmd.exe'.format(os.getenv('WINDIR')))
-
-            # Build cmd and arguments
-            # cmd and arguments must be separated for use with the task scheduler
+            # Build Scheduled Task Parameters
             if use_msiexec:
-                arguments = '"{0}" /X "{1}"'.format(msiexec, uninstaller if uninstaller else expanded_cached_pkg)
+                # Check if uninstaller is set to {guid}, if not we assume its a remote msi file.
+                # which has already been downloaded.
+                arguments = '"{0}" /X "{1}"'.format(msiexec, cached_pkg)
             else:
-                arguments = '"{0}"'.format(expanded_cached_pkg)
+                arguments = '"{0}"'.format(cached_pkg)
 
             if uninstall_flags:
                 arguments = '{0} {1}'.format(arguments, uninstall_flags)
@@ -1629,7 +1614,7 @@ def remove(name=None, pkgs=None, version=None, **kwargs):
                                              action_type='Execute',
                                              cmd=cmd_shell,
                                              arguments='/s /c "{0}"'.format(arguments),
-                                             start_in=expanded_cache_path,
+                                             start_in=cache_path,
                                              trigger_type='Once',
                                              start_date='1975-01-01',
                                              start_time='01:00',
@@ -1644,7 +1629,6 @@ def remove(name=None, pkgs=None, version=None, **kwargs):
                 # Launch the command
                 result = __salt__['cmd.run_all'](
                         '"{0}" /s /c "{1}"'.format(cmd_shell, arguments),
-                        expanded_cache_path,
                         output_loglevel='trace',
                         python_shell=False,
                         redirect_stderr=True)

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -195,6 +195,7 @@ def upgrade_available(name, **kwargs):
     # Refresh before looking for the latest version available,
     # same default as latest_version
     refresh = salt.utils.is_true(kwargs.get('refresh', True))
+
     # if latest_version returns blank, the latest version is already installed or
     # their is no package definition. This is a salt standard which could be improved.
     return latest_version(name, saltenv=saltenv, refresh=refresh) != ''
@@ -314,7 +315,7 @@ def version(*names, **kwargs):
         refresh (bool): Refresh package metadata. Default ``False``.
 
     Returns:
-        str: version string when a single packge is specified.
+        str: version string when a single package is specified.
         dict: The package name(s) with the installed versions.
 
     .. code-block:: cfg
@@ -330,13 +331,13 @@ def version(*names, **kwargs):
 
     '''
     # Standard is return empty string even if not a valid name
-    # TODO: Look at returning an error accross all platforms with
+    # TODO: Look at returning an error across all platforms with
     # CommandExecutionError(msg,info={'errors': errors })
     # available_pkgs = get_repo_data(saltenv).get('repo')
     # for name in names:
     #    if name in available_pkgs:
     #        ret[name] = installed_pkgs.get(name, '')
-    #
+
     saltenv = kwargs.get('saltenv', 'base')
     installed_pkgs = list_pkgs(saltenv=saltenv, refresh=kwargs.get('refresh', False))
 
@@ -1582,6 +1583,8 @@ def remove(name=None, pkgs=None, version=None, **kwargs):
             cached_pkg = cached_pkg.replace('/', '\\')
             cache_path, _ = os.path.split(cached_pkg)
 
+            # os.path.expandvars is not required as we run everything through cmd.exe /s /c
+
             # Get uninstall flags
             uninstall_flags = pkginfo[target].get('uninstall_flags', '')
 
@@ -1592,7 +1595,9 @@ def remove(name=None, pkgs=None, version=None, **kwargs):
             # Compute msiexec string
             use_msiexec, msiexec = _get_msiexec(pkginfo[target].get('msiexec', False))
             cmd_shell = os.getenv('ComSpec', '{0}\\system32\\cmd.exe'.format(os.getenv('WINDIR')))
-            # Build Scheduled Task Parameters
+
+            # Build cmd and arguments
+            # cmd and arguments must be separated for use with the task scheduler
             if use_msiexec:
                 # Check if uninstaller is set to {guid}, if not we assume its a remote msi file.
                 # which has already been downloaded.


### PR DESCRIPTION
### What does this PR do?
I back-ported develop version of win_pkg.py and applied a long list of fixes to 2016.11 this brings these fixes into 2017.7.  As the normal Merge forward from 2016.11 to 2017.7 left out a large number of fixes/changes. Their is about 15 lines difference between this and 2016.11 and most of that is due do some of the code in 2017.7 being moving into utils/path.py

- Software was not always being removed, general if `&` was in the string or msi was downloaded to uninstall the software
- pkg.list_upgrades failed. Added support for 'latest' and 'Not Found' for version_cmp() to fix this.
- Output fixes
- pkg.list_available no longer forces a pkg.refresh_db this is no longer required, as by default it will update if older than 6 hours
- cmd /s /c is prefixed for all commands i.e. installs and removes.
- cmd are now strings, instead of a list when using cmd.run. As windows only supports strings. And the `"` were being broken
### What issues does this PR fix or reference?
win_pkg: pkg.install and pkg.remove general issues #43417

### Tests written?

No

### Commits signed with GPG?

No


### Behaviour Changes
pkg.list_available do longer forces a refresh_db
You will see differances with octopus-tentacle, this is due to the old code failing to remove it.
```
#### pkg.version grepwin

New Results DIFFERENT   3  Original Results 3
{                          {
    "local": ""         |      "local": {
                        >          "grepwin": ""
                        >      }
}                          }
```
```
#### pkg.version grepwin saltenv=does_not_exist
New Results DIFFERENT   3  Original Results 3
{                          {
    "local": ""         |      "local": {
                        >          "grepwin": ""
                        >      }
}                          }
```
```
#### pkg.list_upgrades
New Results DIFFERENT  31                                    Original Results 30
                                                           > [ERROR   ] __init__.version_cmp LooseVersion instance has 
                                                           > no attribute 'version'
                                                           > Traceback (most recent call last):
                                                           >   File 
                                                           > "C:\salt\bin\lib\site-packages\salt\utils\__init__.py", 
                                                           > line 2584, in version_cmp
                                                           >     if _LooseVersion(pkg1) < _LooseVersion(pkg2):
                                                           ------- CUT -------
                                                           > "C:\salt\bin\lib\site-packages\salt\utils\__init__.py", 
                                                           > line 2584, in version_cmp
                                                           >     if _LooseVersion(pkg1) < _LooseVersion(pkg2):
                                                           >   File "C:\salt\bin\lib\distutils\version.py", line 296, 
                                                           > in __cmp__
                                                           >     return cmp(self.version, other.version)
                                                           > AttributeError: LooseVersion instance has no attribute 
                                                           > 'version'
                                                           > [ERROR   ] __init__.version_cmp LooseVersion instance has 
                                                           > no attribute 'version'
                                                           > Traceback (most recent call last):
                                                           >   File 
                                                           > "C:\salt\bin\lib\site-packages\salt\utils\__init__.py", 
                                                           > line 2584, in version_cmp
                                                           >     if _LooseVersion(pkg1) < _LooseVersion(pkg2):
                                                           >   File "C:\salt\bin\lib\distutils\version.py", line 296, 
                                                           > in __cmp__
                                                           >     return cmp(self.version, other.version)
                                                           > AttributeError: LooseVersion instance has no attribute 
                                                           > 'version'
{                                                            {
    "local": {                                                   "local": {
        "chrome": "latest",                                <
        "nsis": "3.0b2",                                   <
        "git": "2.13.1.2",                                           "git": "2.13.1.2", 
        "adobeshockwaveplayer": "latest",                            "adobeshockwaveplayer": "latest", 
        "grepwin": "1.6.682"                               |         "chrome": "latest", 
                                                           >         "grepwin": "1.6.682", 
                                                           >         "nsis": "3.0b2", 
                                                           >         "octopus-tentacle": "latest"
    }                                                            }
}                                                            }
```

pkg.upgrade_available ignores saltenv in current code this update fixes it.
```
#### pkg.upgrade_available grepwin saltenv=does_not_exist
New Results DIFFERENT   6                                    Original Results 30
[INFO    ] win_pkg.refresh_db Removing all *.sls files       [INFO    ] win_pkg.refresh_db Removing all *.sls files 
under                                                        under 
'c:\salt\var\cache\salt\minion\files\does_not_exist\win\re | 'c:\salt\var\cache\salt\minion\files\base\win\repo-ng'
po-ng'                                                     <
[INFO    ] fileclient.cache_dir Caching directory            [INFO    ] fileclient.cache_dir Caching directory 
'win/repo-ng/' for environment 'does_not_exist'            | 'win/repo-ng/' for environment 'base'
{                                                            {
    "local": false                                         |     "local": true
}
```
```                                                            }
#### pkg.version grepwin
New Results DIFFERENT   3                Original Results 3
{                                         {
    "local": "1.6.646"                 |      "local": {
                                       >          "grepwin": "1.6.646"
                                       >      }
} 
```
```                                        }
#### pkg.version grepwin saltenv=does_not_exist
New Results DIFFERENT   3                Original Results 3
{                                         {
    "local": ""                        |      "local": {
                                       >          "grepwin": "1.6.646"
                                       >      }
}  
```
```                                       }
#### pkg.install grepwin version=1.6.673
New Results DIFFERENT   6                                    Original Results 6
[INFO    ] cmdmod._run Executing command                   | [INFO    ] cmdmod._run Executing command [u'msiexec', 
'"C:\Windows\system32\cmd.exe" /s /c ""msiexec" /I         | u'/i', 
"c:\salt\var\cache\salt\minion\extrn_files\base\netassist. | u'c:\\salt\\var\\cache\\salt\\minion\\extrn_files\\base\\n
dl.sourceforge.net\project\grepwin\1.6.14\grepWin-1.6.14-x | etassist.dl.sourceforge.net\\project\\grepwin\\1.6.14\\gre
64.msi" ALLUSERS=1 /qn ALLUSERS=1 /norestart"' in          | pWin-1.6.14-x64.msi', u'ALLUSERS="1"', '/qn', 
directory                                                  | 'ALLUSERS=1', '/norestart'] in directory 
'c:\salt\var\cache\salt\minion\extrn_files\base\netassist.   'c:\salt\var\cache\salt\minion\extrn_files\base\netassist.
dl.sourceforge.net\project\grepwin\1.6.14'                   dl.sourceforge.net\project\grepwin\1.6.14'
{                                                            {
    "local": {                                                   "local": {
        "grepwin": {                                                 "grepwin": {
            "new": "1.6.673",                                            "new": "1.6.673", 
            "old": "1.6.646"                                             "old": "1.6.646"
        }                                                            }
    }                                                            }
}  
```
```                                                          }
#### pkg.list_upgrades refresh=false
New Results DIFFERENT   4                                    Original Results 4
                                                           > [ERROR   ] __init__.version_cmp LooseVersion instance has 
                                                           > no attribute 'version'
                                                           > Traceback (most recent call last):
                                                           >   File 
                                                           > "C:\salt\bin\lib\site-packages\salt\utils\__init__.py", 
                                                           > line 2584, in version_cmp
                                                           >     if _LooseVersion(pkg1) < _LooseVersion(pkg2):
                                                           >   File "C:\salt\bin\lib\distutils\version.py", line 296, 
                                                           > in __cmp__
                                                           >     return cmp(self.version, other.version)
                                                           > AttributeError: LooseVersion instance has no attribute 
                                                           > 'version'
                                                           > [ERROR   ] __init__.version_cmp LooseVersion instance has 
                                                           > no attribute 'version'
                                                           ----------- CUT --------
                                                           >   File "C:\salt\bin\lib\distutils\version.py", line 296, 
                                                           > in __cmp__
                                                           >     return cmp(self.version, other.version)
                                                           > AttributeError: LooseVersion instance has no attribute 
                                                           > 'version'
                                                           > [ERROR   ] __init__.version_cmp LooseVersion instance has 
                                                           > no attribute 'version'
                                                           > Traceback (most recent call last):
                                                           >   File 
                                                           > "C:\salt\bin\lib\site-packages\salt\utils\__init__.py", 
                                                           > line 2584, in version_cmp
                                                           >     if _LooseVersion(pkg1) < _LooseVersion(pkg2):
                                                           >   File "C:\salt\bin\lib\distutils\version.py", line 296, 
                                                           > in __cmp__
                                                           >     return cmp(self.version, other.version)
                                                           > AttributeError: LooseVersion instance has no attribute 
                                                           > 'version'
{                                                            {
    "local": {                                                   "local": {
        "chrome": "latest",                                <
        "nsis": "3.0b2",                                   <
        "git": "2.13.1.2",                                           "git": "2.13.1.2", 
        "adobeshockwaveplayer": "latest",                            "adobeshockwaveplayer": "latest", 
        "grepwin": "1.6.682"                               |         "chrome": "latest", 
                                                           >         "grepwin": "1.6.682", 
                                                           >         "nsis": "3.0b2", 
                                                           >         "octopus-tentacle": "latest"
    }                                                            }
}  
```
```                                                          }
#### pkg.version grepwin
New Results DIFFERENT   3                Original Results 3
{                                         {
    "local": "1.6.673"                 |      "local": {
                                       >          "grepwin": "1.6.673"
                                       >      }
}  
```
```                                       }
#### pkg.remove grepwin version=1.6.646 # current code fails to remove, new code removes
New Results DIFFERENT   4                                    Original Results 4
[INFO    ] cmdmod._run Executing command                   | [INFO    ] cmdmod._run Executing command [u'msiexec', 
'"C:\Windows\system32\cmd.exe" /s /c ""msiexec" /X         | u'/x', '/qn', '/norestart'] in directory 'C:\Users\root'
"c:\salt\var\cache\salt\minion\extrn_files\base\netassist. | [ERROR   ] cmdmod.run_all Command '[u'msiexec', u'/x', 
dl.sourceforge.net\project\grepwin\1.6.14\grepWin-1.6.14-x | '/qn', '/norestart']' failed with return code: 1619
64.msi" /qn /norestart"' in directory 'C:\Users\root'      | [ERROR   ] cmdmod.run_all stdout: This 
                                                           > installation package could 
                                                           > not be opened.  Verify that 
                                                           > the package exists and that 
                                                           > you can access it or contact 
                                                           > the application vendor to 
                                                           > verify that this is a valid 
                                                           > Windows Installer package.
                                                           > 
                                                             
                                                           > [ERROR   ] cmdmod.run_all retcode: 1619
                                                           > [ERROR   ] win_pkg.remove Failed to remove grepwin
                                                           > [ERROR   ] win_pkg.remove retcode 1619
                                                           > [ERROR   ] win_pkg.remove uninstaller output: This 
                                                           > installation package could 
                                                           > not be opened.  Verify that 
                                                           > the package exists and that 
                                                           > you can access it or contact 
                                                           > the application vendor to 
                                                           > verify that this is a valid 
                                                           > Windows Installer package.
                                                           > 
                                                             
{                                                            {
    "local": {                                                   "local": {
        "grepwin": {                                                 "grepwin": {
            "new": "",                                     |             "uninstall status": "failed"
            "old": "1.6.673"                               <
        }                                                            }
    }                                                            }
}  
```
```                                                          }
#### pkg.remove grepwin  # its already been removed above
New Results DIFFERENT   4                                    Original Results 3
[ERROR   ] win_pkg.remove grepwin None not installed       | [INFO    ] cmdmod._run Executing command [u'msiexec', 
                                                           > u'/x', '/qn', '/norestart'] in directory 'C:\Users\root'
                                                           > [ERROR   ] cmdmod.run_all Command '[u'msiexec', u'/x', 
                                                           > '/qn', '/norestart']' failed with return code: 1619
                                                           > [ERROR   ] cmdmod.run_all stdout: This 
                                                           > installation package could 
                                                           > not be opened.  Verify that 
                                                           > the package exists and that 
                                                           > you can access it or contact 
                                                           > the application vendor to 
                                                           > verify that this is a valid 
                                                           > Windows Installer package.
                                                           > 
                                                             
                                                           > [ERROR   ] cmdmod.run_all retcode: 1619
                                                           > [ERROR   ] win_pkg.remove Failed to remove grepwin
                                                           > [ERROR   ] win_pkg.remove retcode 1619
                                                           > [ERROR   ] win_pkg.remove uninstaller output: This 
                                                           > installation package could 
                                                           > not be opened.  Verify that 
                                                           > the package exists and that 
                                                           > you can access it or contact 
                                                           > the application vendor to 
                                                           > verify that this is a valid 
                                                           > Windows Installer package.
                                                           > 
                                                             
{                                                            {
    "local": {                                                   "local": {
        "grepwin": {                                                 "grepwin": {
            "current": "not installed"                     |             "uninstall status": "failed"
        }                                                            }
    }                                                            }
}                                                            }
```
```
#### pkg.version grepwin
New Results DIFFERENT   4                Original Results 6
{                                         {
    "local": ""                        |      "local": {
                                       >          "grepwin": "1.6.673"
                                       >      }
}                                         }
```
```
#### pkg.install nmap
New Results DIFFERENT  10                                    Original Results 14
[INFO    ] cmdmod._run Executing command                     [INFO    ] cmdmod._run Executing command 
'"C:\Windows\system32\cmd.exe" /s /c                       | [u'c:\\salt\\var\\cache\\salt\\minion\\extrn_files\\base\\
""c:\salt\var\cache\salt\minion\extrn_files\base\nmap.org\ | nmap.org\\dist\\nmap-7.01-setup.exe', '/S'] in directory 
dist\nmap-7.01-setup.exe" /S"' in directory                <
'c:\salt\var\cache\salt\minion\extrn_files\base\nmap.org\d   'c:\salt\var\cache\salt\minion\extrn_files\base\nmap.org\d
ist'                                                         ist'
{                                                            {
    "local": {                                                   "local": {
        "nmap": {                                                    "nmap": {
            "new": "Not Found",                                          "new": "Not Found", 
            "old": ""                                                    "old": ""
        }                                                            }
    }                                                            }
}  
```
```                                                          }
#### pkg.version nmap
New Results DIFFERENT   6      Original Results 9
{                               {
    "local": "Not Found"     |      "local": {
                             >          "nmap": "Not Found"
                             >      }
}  
```
```                             }
#### pkg.list_upgrades
New Results DIFFERENT  32                                    Original Results 32
                                                           > [ERROR   ] __init__.version_cmp LooseVersion instance has 
                                                           > no attribute 'version'
                                                           > Traceback (most recent call last):
                                                           >   File 
                                                           > "C:\salt\bin\lib\site-packages\salt\utils\__init__.py", 
                                                           > line 2584, in version_cmp
                                                           >     if _LooseVersion(pkg1) < _LooseVersion(pkg2):
                                                           >   File "C:\salt\bin\lib\distutils\version.py", line 296, 
                                                           ---- CUT ----
                                                           >   File 
                                                           > "C:\salt\bin\lib\site-packages\salt\utils\__init__.py", 
                                                           > line 2584, in version_cmp
                                                           >     if _LooseVersion(pkg1) < _LooseVersion(pkg2):
                                                           >   File "C:\salt\bin\lib\distutils\version.py", line 296, 
                                                           > in __cmp__
                                                           >     return cmp(self.version, other.version)
                                                           > AttributeError: LooseVersion instance has no attribute 
                                                           > 'version'
{                                                            {
    "local": {                                                   "local": {
                                                           >         "git": "2.13.1.2", 
                                                           >         "adobeshockwaveplayer": "latest", 
        "chrome": "latest",                                          "chrome": "latest", 
                                                           >         "grepwin": "1.6.682", 
        "nsis": "3.0b2",                                             "nsis": "3.0b2", 
        "git": "2.13.1.2",                                 |         "octopus-tentacle": "latest"
        "adobeshockwaveplayer": "latest"                   <
    }                                                            }
}  
```
```                                                          }
#### pkg.version nmap
New Results DIFFERENT   2      Original Results 3
{                               {
    "local": "Not Found"     |      "local": {
                             >          "nmap": "Not Found"
                             >      }
}  
                             }
```
```
#### pkg.list_upgrades
New Results DIFFERENT  30                                    Original Results 30
                                                           > [ERROR   ] __init__.version_cmp LooseVersion instance has 
                                                           > no attribute 'version'
                                                           > Traceback (most recent call last):
                                                           >   File 
                                                           --- CUT ---
                                                           > no attribute 'version'
                                                           > Traceback (most recent call last):
                                                           >   File 
                                                           > "C:\salt\bin\lib\site-packages\salt\utils\__init__.py", 
                                                           > line 2584, in version_cmp
                                                           >     if _LooseVersion(pkg1) < _LooseVersion(pkg2):
                                                           >   File "C:\salt\bin\lib\distutils\version.py", line 296, 
                                                           > in __cmp__
                                                           >     return cmp(self.version, other.version)
                                                           > AttributeError: LooseVersion instance has no attribute 
                                                           > 'version'
{                                                            {
    "local": {                                                   "local": {
                                                           >         "git": "2.13.1.2", 
                                                           >         "adobeshockwaveplayer": "latest", 
        "chrome": "latest",                                          "chrome": "latest", 
                                                           >         "grepwin": "1.6.682", 
        "nsis": "3.0b2",                                             "nsis": "3.0b2", 
        "git": "2.13.1.2",                                 |         "octopus-tentacle": "latest"
        "adobeshockwaveplayer": "latest"                   <
    }                                                            }
}  
```
```                                                          }
#### pkg.remove nmap
New Results DIFFERENT   4                                    Original Results 5
[INFO    ] cmdmod._run Executing command                   | [INFO    ] cmdmod._run Executing command ['C:\\Program 
'"C:\Windows\system32\cmd.exe" /s /c ""C:\Program Files    | Files (x86)\\Nmap\\uninstall.exe', '/S'] in directory 
(x86)\Nmap\uninstall.exe" /S"' in directory                <
'C:\Users\root'                                              'C:\Users\root'
{                                                            {
    "local": {                                                   "local": {
        "nmap": {                                                    "nmap": {
            "new": "",                                                   "new": "", 
            "old": "Not Found"                                           "old": "Not Found"
        }                                                            }
    }                                                            }
}  
```
```                                                          }
#### pkg.version nmap
New Results DIFFERENT   3  Original Results 3
{                          {
    "local": ""         |      "local": {
                        >          "nmap": ""
                        >      }
}                          }
```
```
#### pkg.list_upgrades
New Results DIFFERENT  31                                    Original Results 30
                                                           > [ERROR   ] __init__.version_cmp LooseVersion instance has 
                                                           > no attribute 'version'
                                                           > Traceback (most recent call last):
                                                           >   File 
                                                           > "C:\salt\bin\lib\site-packages\salt\utils\__init__.py", 
                                                           > line 2584, in version_cmp
                                                           >     if _LooseVersion(pkg1) < _LooseVersion(pkg2):
                                                           >   File "C:\salt\bin\lib\distutils\version.py", line 296, 
                                                           > in __cmp__
                                                           >     return cmp(self.version, other.version)
                                                           > AttributeError: LooseVersion instance has no attribute 
                                                           > 'version'
                                                           ---- CUT -----
                                                           > Traceback (most recent call last):
                                                           >   File 
                                                           > "C:\salt\bin\lib\site-packages\salt\utils\__init__.py", 
                                                           > line 2584, in version_cmp
                                                           >     if _LooseVersion(pkg1) < _LooseVersion(pkg2):
                                                           >   File "C:\salt\bin\lib\distutils\version.py", line 296, 
                                                           > in __cmp__
                                                           >     return cmp(self.version, other.version)
                                                           > AttributeError: LooseVersion instance has no attribute 
                                                           > 'version'
{                                                            {
    "local": {                                                   "local": {
                                                           >         "git": "2.13.1.2", 
                                                           >         "adobeshockwaveplayer": "latest", 
        "chrome": "latest",                                          "chrome": "latest", 
                                                           >         "grepwin": "1.6.682", 
        "nsis": "3.0b2",                                             "nsis": "3.0b2", 
        "git": "2.13.1.2",                                 |         "octopus-tentacle": "latest"
        "adobeshockwaveplayer": "latest"                   <
    }                                                            }
}                                                            }
```
```
#### pkg.list_available octopus-tentacle
New Results DIFFERENT   3                                    Original Results 29
{                                                           {
    "local": [                                                  "local": [
        "3.3.16",                                                   "3.3.16", 
        "3.3.17",                                                   "3.3.17", 
        "latest"                                                    "latest"
    ]                                                           ]
}                                                           }
```
The original had this installed at start of testings. For the new code it was not installed.
```
#### pkg.version octopus-tentacle
New Results DIFFERENT   3                Original Results 4
{                                         {
    "local": ""                        |      "local": {
                                       >          "octopus-tentacle": "3.16.1"
                                       >      }
}                                         }
```
```
#### pkg.install octopus-tentacle version=3.3.16
New Results DIFFERENT   4                                    Original Results 5
[INFO    ] cmdmod._run Executing command                   | [INFO    ] cmdmod._run Executing command [u'msiexec', 
'"C:\Windows\system32\cmd.exe" /s /c ""msiexec" /I         | u'/i', 
"c:\salt\var\cache\salt\minion\extrn_files\base\download.o | u'c:\\salt\\var\\cache\\salt\\minion\\extrn_files\\base\\d
ctopusdeploy.com\octopus\Octopus.Tentacle.3.3.16-x64.msi"  | ownload.octopusdeploy.com\\octopus\\Octopus.Tentacle.3.3.1
ALLUSERS=1 /qn ALLUSERS=1 /norestart"' in directory        | 6-x64.msi', u'ALLUSERS="1"', '/qn', 'ALLUSERS=1', 
                                                           > '/norestart'] in directory 
'c:\salt\var\cache\salt\minion\extrn_files\base\download.o   'c:\salt\var\cache\salt\minion\extrn_files\base\download.o
ctopusdeploy.com\octopus'                                    ctopusdeploy.com\octopus'
{                                                            {
    "local": {                                                   "local": {
        "octopus-tentacle": {                                        "octopus-tentacle": {
            "new": "3.3.16",                                             "new": "3.3.16", 
            "old": ""                                      |             "old": "3.16.1"
        }                                                            }
    }                                                            }
}                                                            }
```
```
#### pkg.version octopus-tentacle
New Results DIFFERENT   3                Original Results 7
{                                         {
    "local": "3.3.16"                  |      "local": {
                                       >          "octopus-tentacle": "3.3.16"
                                       >      }
}                                         }
```
```
#### pkg.install octopus-tentacle
New Results DIFFERENT   4                                    Original Results 5
[INFO    ] cmdmod._run Executing command                   | [INFO    ] cmdmod._run Executing command [u'msiexec', 
'"C:\Windows\system32\cmd.exe" /s /c ""msiexec" /I         | u'/i', 
"c:\salt\var\cache\salt\minion\extrn_files\base\octopus.co | u'c:\\salt\\var\\cache\\salt\\minion\\extrn_files\\base\\o
m\downloads\latest\OctopusTentacle64" ALLUSERS=1 /qn       | ctopus.com\\downloads\\latest\\OctopusTentacle64', 
ALLUSERS=1 /norestart"' in directory                       | u'ALLUSERS="1"', '/qn', 'ALLUSERS=1', '/norestart'] in 
                                                           > directory 
'c:\salt\var\cache\salt\minion\extrn_files\base\octopus.co   'c:\salt\var\cache\salt\minion\extrn_files\base\octopus.co
m\downloads\latest'                                          m\downloads\latest'
{                                                            {
    "local": {                                                   "local": {
        "octopus-tentacle": {                                        "octopus-tentacle": {
            "new": "3.16.1",                                             "new": "3.16.1", 
            "old": "3.3.16"                                              "old": "3.3.16"
        }                                                            }
    }                                                            }
}                                                            }
```
```
#### pkg.install octopus-tentacle version=3.3.17
New Results DIFFERENT   5                                    Original Results 12
[INFO    ] cmdmod._run Executing command                   | [INFO    ] cmdmod._run Executing command [u'msiexec', 
'"C:\Windows\system32\cmd.exe" /s /c ""msiexec" /I         | u'/i', 
"c:\salt\var\cache\salt\minion\extrn_files\base\download.o | u'c:\\salt\\var\\cache\\salt\\minion\\extrn_files\\base\\d
ctopusdeploy.com\octopus\Octopus.Tentacle.3.3.17-x64.msi"  | ownload.octopusdeploy.com\\octopus\\Octopus.Tentacle.3.3.1
ALLUSERS=1 /qn ALLUSERS=1 /norestart"' in directory        | 7-x64.msi', u'ALLUSERS="1"', '/qn', 'ALLUSERS=1', 
                                                           > '/norestart'] in directory 
'c:\salt\var\cache\salt\minion\extrn_files\base\download.o   'c:\salt\var\cache\salt\minion\extrn_files\base\download.o
ctopusdeploy.com\octopus'                                    ctopusdeploy.com\octopus'
{                                                            {
    "local": {                                                   "local": {
        "octopus-tentacle": {                                        "octopus-tentacle": {
            "new": "3.3.17",                                             "new": "3.3.17", 
            "old": "3.16.1"                                              "old": "3.16.1"
        }                                                            }
    }                                                            }
}                                                            }
```
```
#### pkg.install octopus-tentacle version=latest
New Results DIFFERENT   5                                    Original Results 8
[INFO    ] cmdmod._run Executing command                   | [INFO    ] cmdmod._run Executing command [u'msiexec', 
'"C:\Windows\system32\cmd.exe" /s /c ""msiexec" /I         | u'/i', 
"c:\salt\var\cache\salt\minion\extrn_files\base\octopus.co | u'c:\\salt\\var\\cache\\salt\\minion\\extrn_files\\base\\o
m\downloads\latest\OctopusTentacle64" ALLUSERS=1 /qn       | ctopus.com\\downloads\\latest\\OctopusTentacle64', 
ALLUSERS=1 /norestart"' in directory                       | u'ALLUSERS="1"', '/qn', 'ALLUSERS=1', '/norestart'] in 
                                                           > directory 
'c:\salt\var\cache\salt\minion\extrn_files\base\octopus.co   'c:\salt\var\cache\salt\minion\extrn_files\base\octopus.co
m\downloads\latest'                                          m\downloads\latest'
{                                                            {
    "local": {                                                   "local": {
        "octopus-tentacle": {                                        "octopus-tentacle": {
            "new": "3.16.1",                                             "new": "3.16.1", 
            "old": "3.3.17"                                              "old": "3.3.17"
        }                                                            }
    }                                                            }
}                                                            }
```
 As you can see the remove fails in the original code, hence it was still installed on the next test run. The new code removes it correctly.
```
#### pkg.remove octopus-tentacle version=3.3.16
New Results DIFFERENT   4                                    Original Results 8
[INFO    ] cmdmod._run Executing command                   | [INFO    ] cmdmod._run Executing command [u'msiexec', 
'"C:\Windows\system32\cmd.exe" /s /c ""msiexec" /X         | u'/x', '/qn', '/norestart'] in directory 'C:\Users\root'
"c:\salt\var\cache\salt\minion\extrn_files\base\octopus.co | [ERROR   ] cmdmod.run_all Command '[u'msiexec', u'/x', 
m\downloads\latest\OctopusTentacle64" /qn /norestart"' in  | '/qn', '/norestart']' failed with return code: 1619
directory 'C:\Users\root'                                  | [ERROR   ] cmdmod.run_all stdout: This 
                                                           > installation package could 
                                                           > not be opened.  Verify that 
                                                           > the package exists and that 
                                                           > you can access it or contact 
                                                           > the application vendor to 
                                                           > verify that this is a valid 
                                                           > Windows Installer package.
                                                           > 
                                                             
                                                           > [ERROR   ] cmdmod.run_all retcode: 1619
                                                           > [ERROR   ] win_pkg.remove Failed to remove 
                                                           > octopus-tentacle
                                                           > [ERROR   ] win_pkg.remove retcode 1619
                                                           > [ERROR   ] win_pkg.remove uninstaller output: This 
                                                           > installation package could 
                                                           > not be opened.  Verify that 
                                                           > the package exists and that 
                                                           > you can access it or contact 
                                                           > the application vendor to 
                                                           > verify that this is a valid 
                                                           > Windows Installer package.
                                                           > 
                                                             
{                                                            {
    "local": {                                                   "local": {
        "octopus-tentacle": {                                        "octopus-tentacle": {
            "new": "",                                     |             "uninstall status": "failed"
            "old": "3.16.1"                                <
        }                                                            }
    }                                                            }
}                                                            }
```
It should not be installed, as you see orginal code fails to remove it again.
```
#### pkg.remove octopus-tentacle
New Results DIFFERENT   3                                    Original Results 5
[ERROR   ] win_pkg.remove octopus-tentacle None not        | [INFO    ] cmdmod._run Executing command [u'msiexec', 
installed                                                  | u'/x', '/qn', '/norestart'] in directory 'C:\Users\root'
                                                           > [ERROR   ] cmdmod.run_all Command '[u'msiexec', u'/x', 
                                                           > '/qn', '/norestart']' failed with return code: 1619
                                                           > [ERROR   ] cmdmod.run_all stdout: This 
                                                           > installation package could 
                                                           > not be opened.  Verify that 
                                                           > the package exists and that 
                                                           > you can access it or contact 
                                                           > the application vendor to 
                                                           > verify that this is a valid 
                                                           > Windows Installer package.
                                                           > 
                                                             
                                                           > [ERROR   ] cmdmod.run_all retcode: 1619
                                                           > [ERROR   ] win_pkg.remove Failed to remove 
                                                           > octopus-tentacle
                                                           > [ERROR   ] win_pkg.remove retcode 1619
                                                           > [ERROR   ] win_pkg.remove uninstaller output: This 
                                                           > installation package could 
                                                           > not be opened.  Verify that 
                                                           > the package exists and that 
                                                           > you can access it or contact 
                                                           > the application vendor to 
                                                           > verify that this is a valid 
                                                           > Windows Installer package.
                                                           > 
                                                             
{                                                            {
    "local": {                                                   "local": {
        "octopus-tentacle": {                                        "octopus-tentacle": {
            "current": "not installed"                     |             "uninstall status": "failed"
        }                                                            }
    }                                                            }
}                                                            }
```
 It needs to be installed. New code shows correct results, because the above removed failed in the original code
```
#### pkg.install octopus-tentacle extra_install_flags=//Qn
New Results DIFFERENT   5                                    Original Results 9
[INFO    ] cmdmod._run Executing command                   | [INFO    ] cmdmod._run Executing command [u'msiexec', 
'"C:\Windows\system32\cmd.exe" /s /c ""msiexec" /I         | u'/i', 
"c:\salt\var\cache\salt\minion\extrn_files\base\octopus.co | u'c:\\salt\\var\\cache\\salt\\minion\\extrn_files\\base\\o
m\downloads\latest\OctopusTentacle64" ALLUSERS=1 /qn       | ctopus.com\\downloads\\latest\\OctopusTentacle64', 
ALLUSERS=1 /norestart /Qn"' in directory                   | u'ALLUSERS="1"', '/qn', 'ALLUSERS=1', '/norestart', 
                                                           > '/Qn'] in directory 
'c:\salt\var\cache\salt\minion\extrn_files\base\octopus.co   'c:\salt\var\cache\salt\minion\extrn_files\base\octopus.co
m\downloads\latest'                                          m\downloads\latest'
{                                                            {
    "local": {                                                   "local": {
        "octopus-tentacle": {                                        "octopus-tentacle": {
            "new": "3.16.1",                               |             "current": "3.16.1"
            "old": ""                                      <
        }                                                            }
    }                                                            }
}                                                            }
```
New code shows correct results
```
#### pkg.remove octopus-tentacle extra_uninstall_flags=//Qn
New Results DIFFERENT   4                                    Original Results 6
[INFO    ] cmdmod._run Executing command                   | [INFO    ] cmdmod._run Executing command [u'msiexec', 
'"C:\Windows\system32\cmd.exe" /s /c ""msiexec" /X         | u'/x', '/qn', '/norestart', '/Qn'] in directory 
"c:\salt\var\cache\salt\minion\extrn_files\base\octopus.co | 'C:\Users\root'
m\downloads\latest\OctopusTentacle64" /qn /norestart       | [ERROR   ] cmdmod.run_all Command '[u'msiexec', u'/x', 
/Qn"' in directory 'C:\Users\root'                         | '/qn', '/norestart', '/Qn']' failed with return code: 1619
                                                           > [ERROR   ] cmdmod.run_all stdout: This 
                                                           > installation package could 
                                                           > not be opened.  Verify that 
                                                           > the package exists and that 
                                                           > you can access it or contact 
                                                           > the application vendor to 
                                                           > verify that this is a valid 
                                                           > Windows Installer package.
                                                           > 
                                                             
                                                           > [ERROR   ] cmdmod.run_all retcode: 1619
                                                           > [ERROR   ] win_pkg.remove Failed to remove 
                                                           > octopus-tentacle
                                                           > [ERROR   ] win_pkg.remove retcode 1619
                                                           > [ERROR   ] win_pkg.remove uninstaller output: This 
                                                           > installation package could 
                                                           > not be opened.  Verify that 
                                                           > the package exists and that 
                                                           > you can access it or contact 
                                                           > the application vendor to 
                                                           > verify that this is a valid 
                                                           > Windows Installer package.
                                                           > 
                                                             
{                                                            {
    "local": {                                                   "local": {
        "octopus-tentacle": {                                        "octopus-tentacle": {
            "new": "",                                     |             "uninstall status": "failed"
            "old": "3.16.1"                                <
        }                                                            }
    }                                                            }
}                                                            }
```
 New code shows correct results.
```
#### pkg.remove grepwin
New Results DIFFERENT   4                                    Original Results 9
[ERROR   ] win_pkg.remove grepwin None not installed       | [INFO    ] cmdmod._run Executing command [u'msiexec', 
                                                           > u'/x', '/qn', '/norestart'] in directory 'C:\Users\root'
                                                           > [ERROR   ] cmdmod.run_all Command '[u'msiexec', u'/x', 
                                                           > '/qn', '/norestart']' failed with return code: 1619
                                                           > [ERROR   ] cmdmod.run_all stdout: This 
                                                           > installation package could 
                                                           > not be opened.  Verify that 
                                                           > the package exists and that 
                                                           > you can access it or contact 
                                                           > the application vendor to 
                                                           > verify that this is a valid 
                                                           > Windows Installer package.
                                                           > 
                                                             
                                                           > [ERROR   ] cmdmod.run_all retcode: 1619
                                                           > [ERROR   ] win_pkg.remove Failed to remove grepwin
                                                           > [ERROR   ] win_pkg.remove retcode 1619
                                                           > [ERROR   ] win_pkg.remove uninstaller output: This 
                                                           > installation package could 
                                                           > not be opened.  Verify that 
                                                           > the package exists and that 
                                                           > you can access it or contact 
                                                           > the application vendor to 
                                                           > verify that this is a valid 
                                                           > Windows Installer package.
                                                           > 
                                                             
{                                                            {
    "local": {                                                   "local": {
        "grepwin": {                                                 "grepwin": {
            "current": "not installed"                     |             "uninstall status": "failed"
        }                                                            }
    }                                                            }
}                                                            }
```
 The old code says its installed because the old code failed to remove it.
```
#### state.high {grepwin:{pkg:[installed]}}
New Results DIFFERENT  32                                    Original Results 35
[INFO    ] state.call Running state [grepwin] at time        [INFO    ] state.call Running state [grepwin] at time 
01:37:22.153000                                            | 01:21:20.124000
[INFO    ] state.call Executing state pkg.installed for      [INFO    ] state.call Executing state pkg.installed for 
[grepwin]                                                    [grepwin]
[INFO    ] win_pkg.refresh_db Removing all *.sls files       [INFO    ] win_pkg.refresh_db Removing all *.sls files 
under                                                        under 
'c:\salt\var\cache\salt\minion\files\base\win\repo-ng'       'c:\salt\var\cache\salt\minion\files\base\win\repo-ng'
[INFO    ] fileclient.cache_dir Caching directory            [INFO    ] fileclient.cache_dir Caching directory 
'win/repo-ng/' for environment 'base'                        'win/repo-ng/' for environment 'base'
[ERROR   ] win_pkg._repo_process_pkg_sls package             [ERROR   ] win_pkg._repo_process_pkg_sls package 
[INFO    ] cmdmod._run Executing command                   | [INFO    ] state.format_log All specified packages are 
'"C:\Windows\system32\cmd.exe" /s /c ""msiexec" /I         | already installed
"c:\salt\var\cache\salt\minion\extrn_files\base\netassist. <
dl.sourceforge.net\project\grepwin\1.6.15\grepWin-1.6.15-x <
64.msi" ALLUSERS=1 /qn ALLUSERS=1 /norestart"' in          <
directory                                                  <
'c:\salt\var\cache\salt\minion\extrn_files\base\netassist. <
dl.sourceforge.net\project\grepwin\1.6.15'                 <
[INFO    ] state.format_log Made the following changes:    <
'grepwin' changed from 'absent' to '1.6.682'               <
                                                           <
[INFO    ] state.load_modules Loading fresh modules for    <
state activity                                             <
[INFO    ] state.call Completed state [grepwin] at time      [INFO    ] state.call Completed state [grepwin] at time 
01:37:50.337000 duration_in_ms=28184.0                     | 01:21:47.068000 duration_in_ms=26944.0
{                                                            {
    "local": {                                                   "local": {
        "pkg_|-grepwin_|-grepwin_|-installed": {                     "pkg_|-grepwin_|-grepwin_|-installed": {
            "comment": "The following packages were        |             "comment": "All specified packages are 
installed/updated: grepwin",                               | already installed", 
            "name": "grepwin",                                           "name": "grepwin", 
            "start_time": "01:37:22.153000",               |             "start_time": "01:21:20.124000", 
            "result": true,                                              "result": true, 
            "duration": 28184.0,                           |             "duration": 26944.0, 
            "__run_num__": 0,                                            "__run_num__": 0, 
            "__sls__": null,                                             "__sls__": null, 
            "changes": {                                   |             "changes": {}, 
                "grepwin": {                               <
                    "new": "1.6.682",                      <
                    "old": ""                              <
                }                                          <
            },                                             <
            "__id__": "grepwin"                                          "__id__": "grepwin"
        }                                                            }
    }                                                            }
}                                                            }
```
```
#### state.high {grepwin:{pkg:[removed]}}
New Results DIFFERENT   4                                    Original Results 8
[INFO    ] state.load_modules Loading fresh modules for      [INFO    ] state.load_modules Loading fresh modules for 
state activity                                               state activity
[WARNING ] __init__.warn_until                               [WARNING ] __init__.warn_until 
C:\salt\bin\lib\site-packages\salt\modules\win_update.py:9   C:\salt\bin\lib\site-packages\salt\modules\win_update.py:9
1: DeprecationWarning: The 'win_update' module is being      1: DeprecationWarning: The 'win_update' module is being 
deprecated and will be removed in Salt Fluorine              deprecated and will be removed in Salt Fluorine 
(Unreleased). Please use the 'win_wua' module instead.       (Unreleased). Please use the 'win_wua' module instead.

[INFO    ] state.call Running state [grepwin] at time        [INFO    ] state.call Running state [grepwin] at time 
01:37:54.398000                                            | 01:21:54.768000
[INFO    ] state.call Executing state pkg.removed for        [INFO    ] state.call Executing state pkg.removed for 
[grepwin]                                                    [grepwin]
[INFO    ] cmdmod._run Executing command                   | [INFO    ] cmdmod._run Executing command [u'msiexec', 
'"C:\Windows\system32\cmd.exe" /s /c ""msiexec" /X         | u'/x', '/qn', '/norestart'] in directory 'C:\Users\root'
"c:\salt\var\cache\salt\minion\extrn_files\base\netassist. | [ERROR   ] cmdmod.run_all Command '[u'msiexec', u'/x', 
dl.sourceforge.net\project\grepwin\1.6.15\grepWin-1.6.15-x | '/qn', '/norestart']' failed with return code: 1619
64.msi" /qn /norestart"' in directory 'C:\Users\root'      | [ERROR   ] cmdmod.run_all stdout: This 
[INFO    ] state.format_log Made the following changes:    | installation package could 
'grepwin' changed from '1.6.682' to 'absent'               | not be opened.  Verify that 
                                                           | the package exists and that 
                                                           > you can access it or contact 
                                                           > the application vendor to 
                                                           > verify that this is a valid 
                                                           > Windows Installer package.
                                                           > 
                                                             
                                                           > [ERROR   ] cmdmod.run_all retcode: 1619
                                                           > [ERROR   ] win_pkg.remove Failed to remove grepwin
                                                           > [ERROR   ] win_pkg.remove retcode 1619
                                                           > [ERROR   ] win_pkg.remove uninstaller output: This 
                                                           > installation package could 
                                                           > not be opened.  Verify that 
                                                           > the package exists and that 
                                                           > you can access it or contact 
                                                           > the application vendor to 
                                                           > verify that this is a valid 
                                                           > Windows Installer package.
                                                           > 
                                                             
                                                           > [ERROR   ] state.format_log {'grepwin': {u'uninstall 
                                                           > status': u'failed'}}
[INFO    ] state.load_modules Loading fresh modules for      [INFO    ] state.load_modules Loading fresh modules for 
state activity                                               state activity
[INFO    ] state.call Completed state [grepwin] at time      [INFO    ] state.call Completed state [grepwin] at time 
01:37:54.851000 duration_in_ms=453.0                       | 01:21:55.225000 duration_in_ms=457.0
{                                                            {
    "local": {                                                   "local": {
        "pkg_|-grepwin_|-grepwin_|-removed": {                       "pkg_|-grepwin_|-grepwin_|-removed": {
            "comment": "All targeted packages were         |             "comment": "The following packages failed to 
removed.",                                                 | remove: grepwin.", 
            "name": "grepwin",                                           "name": "grepwin", 
            "start_time": "01:37:54.398000",               |             "start_time": "01:21:54.768000", 
            "result": true,                                |             "result": false, 
            "duration": 453.0,                             |             "duration": 457.0, 
            "__run_num__": 0,                                            "__run_num__": 0, 
            "__sls__": null,                                             "__sls__": null, 
            "changes": {                                                 "changes": {
                "grepwin": {                                                 "grepwin": {
                    "new": "",                             |                     "uninstall status": "failed"
                    "old": "1.6.682"                       <
                }                                                            }
            },                                                           }, 
            "__id__": "grepwin"                                          "__id__": "grepwin"
        }                                                            }
    }                                                            }
}                                                            }

