### PR TITLE
fixed saltify documentation to refer to 'driver' instead of 'provider…

### DIFF
--- a/doc/topics/cloud/saltify.rst
+++ b/doc/topics/cloud/saltify.rst
@@ -29,7 +29,7 @@ the salt-master:
     my-saltify-config:
       minion:
         master: 111.222.333.444
-      provider: saltify
+      driver: saltify
 
 However, if you wish to use the more advanced capabilities of salt-cloud, such as
 rebooting, listing, and disconnecting machines, then the salt master must fill


### PR DESCRIPTION
…' in provider example

### What does this PR do?

When using the Saltify provider for salt-cloud, I discovered the documentation incorrectly specifies setting `provider: saltify` instead of `driver: saltify` in the [provider section](https://docs.saltstack.com/en/latest/topics/cloud/saltify.html#configuration)
 
### What issues does this PR fix or reference?
Did not find any open issues for this issue

### Tests written?

No, its a documentation change

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
