### PR TITLE
Fix for parsing tags in boto_rds create function

### DIFF
--- a/salt/modules/boto_rds.py
+++ b/salt/modules/boto_rds.py
@@ -115,7 +115,7 @@ boto3_param_map = {
     'publicly_accessible': ('PubliclyAccessible', bool),
     'storage_encrypted': ('StorageEncrypted', bool),
     'storage_type': ('StorageType', str),
-    'taglist': ('Tags', list),
+    'tags': ('Tags', list),
     'tde_credential_arn': ('TdeCredentialArn', str),
     'tde_credential_password': ('TdeCredentialPassword', str),
     'vpc_security_group_ids': ('VpcSecurityGroupIds', list),
@@ -276,13 +276,13 @@ def create(name, allocated_storage, db_instance_class, engine,
         kwargs = {}
         boto_params = set(boto3_param_map.keys())
         keys = set(locals().keys())
+        tags = _tag_doc(tags)
+
         for param_key in keys.intersection(boto_params):
             val = locals()[param_key]
             if val is not None:
                 mapped = boto3_param_map[param_key]
                 kwargs[mapped[0]] = mapped[1](val)
-
-        taglist = _tag_doc(tags)
 
         # Validation doesn't want parameters that are None
         # https://github.com/boto/boto3/issues/400


### PR DESCRIPTION
### What does this PR do?
Fixes a bug in `boto_rds` where tags passed to the create function would not get parsed correctly.

### What issues does this PR fix or reference?
[Issue #38936](https://github.com/saltstack/salt/issues/38936)

### Previous Behavior
The new RDS instance is created without any tags, even though tags are passed to the boto_rds state/module.

### New Behavior
The new RDS instance is created *with* tags if tags are passed to the state/module.

### Tests written?

No

### Commits signed with GPG?
Yes
