### PR TITLE
Win fix lgpo unicode on Py3 issue

### DIFF
--- a/salt/modules/win_lgpo.py
+++ b/salt/modules/win_lgpo.py
@@ -4242,9 +4242,8 @@ def _writeAdminTemplateRegPolFile(admtemplate_data,
         for adm_namespace in admtemplate_data:
             for adm_policy in admtemplate_data[adm_namespace]:
                 if str(admtemplate_data[adm_namespace][adm_policy]).lower() == 'not configured':
-                    if adm_policy in base_policy_settings.get(adm_namespace, {}):
+                    if base_policy_settings.get(adm_namespace, {}).pop(adm_policy, None) is not None:
                         log.debug('Policy "{0}" removed'.format(adm_policy))
-                        base_policy_settings[adm_namespace].pop(adm_policy)
                 else:
                     log.debug('adding {0} to base_policy_settings'.format(adm_policy))
                     if adm_namespace not in base_policy_settings:

--- a/salt/modules/win_lgpo.py
+++ b/salt/modules/win_lgpo.py
@@ -3502,7 +3502,7 @@ def _processValueItem(element, reg_key, reg_valuename, policy, parent_element,
                                     reg_key,
                                     reg_valuename,
                                     chr(registry.vtype[this_vtype]),
-                                    six.unichr(len(this_element_value.encode('utf-16-le'))),
+                                    six.unichr(len(this_element_value.encode('utf-16-le', '' if six.PY2 else 'surrogatepass'))),
                                     this_element_value)
     return expected_string
 
@@ -4242,7 +4242,8 @@ def _writeAdminTemplateRegPolFile(admtemplate_data,
         for adm_namespace in admtemplate_data:
             for adm_policy in admtemplate_data[adm_namespace]:
                 if str(admtemplate_data[adm_namespace][adm_policy]).lower() == 'not configured':
-                    if adm_policy in base_policy_settings[adm_namespace]:
+                    if adm_policy in base_policy_settings.get(adm_namespace, {}):
+                        log.debug('Policy "{0}" removed'.format(adm_policy))
                         base_policy_settings[adm_namespace].pop(adm_policy)
                 else:
                     log.debug('adding {0} to base_policy_settings'.format(adm_policy))


### PR DESCRIPTION
### What does this PR do?
Fixes issue with the way Python 3 handles decoding `utf-16-le`. Python 3 requires `surrogate_pass` when decoding, which isn't available in Py2.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/44516

### Previous Behavior
Failed saying it couldn't decode a character.

### New Behavior
Doesn't fail.

### Tests written?
No

### Commits signed with GPG?
Yes