### PR TITLE
Adding link to salt.modules.saltutil on salt.runners.saltutil

### DIFF
--- a/salt/runners/saltutil.py
+++ b/salt/runners/saltutil.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 '''
-Sync custom types to the Master
+The Saltutil runner is used to sync custom types to the Master. See the
+:mod:`saltutil module <salt.modules.saltutil>` for documentation on
+managing updates to minions.
 
 .. versionadded:: 2016.3.0
 '''


### PR DESCRIPTION
Just clarifying for anyone who ends up on the `salt.runners.saltutil` page trying to sync a minion.

### What does this PR do?
Adds docs

### Tests written?

No

### Commits signed with GPG?

No

