### PR TITLE
Add defaults.deepcopy function.

### DIFF
--- a/salt/modules/defaults.py
+++ b/salt/modules/defaults.py
@@ -5,6 +5,7 @@ Module to work with salt formula defaults files
 '''
 
 from __future__ import absolute_import
+import copy
 import json
 import logging
 import os
@@ -121,3 +122,17 @@ def merge(dest, upd):
     instead of directly on the command-line.
     '''
     return dictupdate.update(dest, upd)
+
+
+def deepcopy(source):
+    '''
+    defaults.deepcopy
+        Allows deep copy of objects in formulas.
+
+        By default, Python does not copy objects,
+        it creates bindings between a target and an object.
+
+    It is more typical to use this in a templating language in formulas,
+    instead of directly on the command-line.
+    '''
+    return copy.deepcopy(source)

--- a/tests/unit/modules/test_defaults.py
+++ b/tests/unit/modules/test_defaults.py
@@ -37,3 +37,25 @@ class DefaultsTestCase(TestCase, LoaderModuleMockMixin):
                       MagicMock(return_value={'users': {'root': [0]}})):
             self.assertEqual(defaults.get('core:users:root'),
                              {'users': {'root': [0]}})
+
+    def test_deepcopy(self):
+        '''
+        Test a deep copy of object.
+        '''
+
+        src = {
+            'A': 'A',
+            'B': 'B'
+        }
+
+        dist = defaults.deepcopy(src)
+        dist.update({'C': 'C'})
+
+        result = {
+            'A': 'A',
+            'B': 'B',
+            'C': 'C'
+        }
+
+        self.assertFalse(src == dist)
+        self.assertTrue(dist == result)


### PR DESCRIPTION
### What does this PR do?
Expose `copy.deepcopy` as `defaults.deepcopy` function.

### What issues does this PR fix or reference?
In many case there are multi level of defaults, e.g. global, group, and specific.
And since Python does not copy objects by default but creates bindings, so deep copy is necessary for that cases. 

Here is an arbitrary example:

**Yaml**
```
vars:
  hosts:
    defaults:
      enabled: True
      aggregate: source
      extra:
        - test
        - stage
    list:
      hos01:
        index: foo
        upstream: bar
      hos02:
        index: foo2
        upstream: bar2
```

**Jinja**
```
{% for host, vars in vars.hosts.list.items() %}
  {% set defaults = salt['defaults.deepcopy'](vars.hosts.defaults) %}
  {% set host_vars = salt['defaults.merge'](defaults, vars) %}
  ....
{% endfor %}
```

**Output**
```
hos01:
  index: foo
  upstream: bar
  enabled: True
  aggregate: source
  extra:
    - test
    - stage
```

### New Behavior
Allow to make deepcopy of objects.

### Tests written?
Yes

### Commits signed with GPG?
Not yet.