### PR TITLE
remove not from vault utils

### DIFF
--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -2150,7 +2150,8 @@ def minion_config(path,
                   defaults=None,
                   cache_minion_id=False,
                   ignore_config_errors=True,
-                  minion_id=None):
+                  minion_id=None,
+                  role='minion'):
     '''
     Reads in the minion configuration file and sets up special options
 
@@ -2190,6 +2191,7 @@ def minion_config(path,
     opts = apply_minion_config(overrides, defaults,
                                cache_minion_id=cache_minion_id,
                                minion_id=minion_id)
+    opts['__role'] = role
     apply_sdb(opts)
     _validate_opts(opts)
     return opts

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -739,7 +739,11 @@ class MasterMinion(object):
             matcher=True,
             whitelist=None,
             ignore_config_errors=True):
-        self.opts = salt.config.minion_config(opts['conf_file'], ignore_config_errors=ignore_config_errors)
+        self.opts = salt.config.minion_config(
+            opts['conf_file'],
+            ignore_config_errors=ignore_config_errors,
+            role='master'
+        )
         self.opts.update(opts)
         self.whitelist = whitelist
         self.opts['grains'] = salt.loader.grains(opts)

--- a/salt/utils/sdb.py
+++ b/salt/utils/sdb.py
@@ -25,7 +25,7 @@ def sdb_get(uri, opts, utils=None):
         return uri
 
     if utils is None:
-        utils = {}
+        utils = salt.loader.utils(opts)
 
     sdlen = len('sdb://')
     indx = uri.find('/', sdlen)
@@ -56,7 +56,7 @@ def sdb_set(uri, value, opts, utils=None):
         return False
 
     if utils is None:
-        utils = {}
+        utils = salt.loader.utils(opts)
 
     sdlen = len('sdb://')
     indx = uri.find('/', sdlen)
@@ -87,7 +87,7 @@ def sdb_delete(uri, opts, utils=None):
         return False
 
     if utils is None:
-        utils = {}
+        utils = salt.loader.utils(opts)
 
     sdlen = len('sdb://')
     indx = uri.find('/', sdlen)
@@ -122,7 +122,7 @@ def sdb_get_or_set_hash(uri,
         return False
 
     if utils is None:
-        utils = {}
+        utils = salt.loader.utils(opts)
 
     ret = sdb_get(uri, opts, utils=utils)
 

--- a/salt/utils/vault.py
+++ b/salt/utils/vault.py
@@ -98,7 +98,7 @@ def _get_vault_connection():
     Get the connection details for calling Vault, from local configuration if
     it exists, or from the master otherwise
     '''
-    if 'vault' in __opts__ and not __opts__.get('__role', 'minion') == 'master':
+    if 'vault' in __opts__ and __opts__.get('__role', 'minion') == 'master':
         log.debug('Using Vault connection details from local config')
         try:
             return {


### PR DESCRIPTION
### What does this PR do?
If the role is 'master' then the vault configs should just be pulled from the
opts dictionary

### What issues does this PR fix or reference?
Unable to use salt-run or salt-cloud with vault

### Tests written?

No

### Commits signed with GPG?

Yes