### PR TITLE
Don't pass master opts as pub kwargs into RunnerClient or salt.key's WheelClient instance

### DIFF
--- a/salt/key.py
+++ b/salt/key.py
@@ -162,9 +162,7 @@ class KeyCLI(object):
                     args.append(self.opts.get(arg))
         args, kwargs = salt.minion.load_args_and_kwargs(
             fun,
-            args,
-            self.opts,
-        )
+            args)
         return args, kwargs
 
     def _run_cmd(self, cmd, args=None):

--- a/salt/runner.py
+++ b/salt/runner.py
@@ -100,7 +100,6 @@ class RunnerClient(mixins.SyncClientMixin, mixins.AsyncClientMixin, object):
         arg, kwarg = salt.minion.load_args_and_kwargs(
             self.functions[fun],
             munged,
-            self.opts,
             ignore_invalid=True)
 
         return dict(fun=fun, kwarg={u'kwarg': kwarg, u'arg': arg},
@@ -199,9 +198,7 @@ class Runner(RunnerClient):
                 verify_fun(self.functions, low[u'fun'])
                 args, kwargs = salt.minion.load_args_and_kwargs(
                     self.functions[low[u'fun']],
-                    fun_args,
-                    self.opts,
-                )
+                    fun_args)
                 low[u'arg'] = args
                 low[u'kwarg'] = kwargs
 


### PR DESCRIPTION
For starters, none of the wheel funcs in the key module even accept `**kwargs`, so we're not actually passing them as pub kwargs. In the case of the RunnerClient, we're not doing anything with these values, and `__opts__` is available to runner functions anyway.