### PR TITLE
Fix integration tests on Windows

### DIFF
--- a/tests/support/parser/__init__.py
+++ b/tests/support/parser/__init__.py
@@ -456,7 +456,7 @@ class SaltTestingParser(optparse.OptionParser):
                 logging_level = logging.INFO
             else:
                 logging_level = logging.ERROR
-            os.environ['TESTS_LOG_LEVEL'] = six.text_type(self.options.verbosity)
+            os.environ['TESTS_LOG_LEVEL'] = six.binary_type(self.options.verbosity)
             consolehandler.setLevel(logging_level)
             logging.root.addHandler(consolehandler)
             log.info('Runtests logging has been setup')


### PR DESCRIPTION
### What does this PR do?
Fixes an issue with integration tests on Windows where a Unicode value was being used to set an environment variable. For some reason, Windows didn't like it and threw an error.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/44774

### Tests written?
No

### Commits signed with GPG?
Yes