### PR TITLE
Fix win_lgpo for unknown values

### DIFF
--- a/salt/modules/win_lgpo.py
+++ b/salt/modules/win_lgpo.py
@@ -2435,15 +2435,18 @@ class _policy_info(object):
         '''
         converts a binary 0/1 to Disabled/Enabled
         '''
-        if val is not None:
-            if ord(val) == 0:
-                return 'Disabled'
-            elif ord(val) == 1:
-                return 'Enabled'
+        try:
+            if val is not None:
+                if ord(val) == 0:
+                    return 'Disabled'
+                elif ord(val) == 1:
+                    return 'Enabled'
+                else:
+                    return 'Invalid Value'
             else:
-                return 'Invalid Value'
-        else:
-            return 'Not Defined'
+                return 'Not Defined'
+        except TypeError:
+            return 'Invalid Value'
 
     @classmethod
     def _binary_enable_zero_disable_one_reverse_conversion(cls, val, **kwargs):


### PR DESCRIPTION
### What does this PR do?
Check for values other than 0 or 1 and return `Invalid Value`. In this case, the setting causing failure was a REG_BINARY value of `30 00`. Valid values are `00` and `01`.

Adds a Try/Except block to handle unexpected values.

### What issues does this PR fix or reference?
https://saltstack.zendesk.com/agent/tickets/1542

### Previous Behavior
```
Traceback (most recent call last): 
File "c:\salt\bin\lib\site-packages\salt\state.py", line 1837, in call 
**cdata['kwargs']) 
File "c:\salt\bin\lib\site-packages\salt\loader.py", line 1794, in wrapper 
return f(*args, **kwargs) 
File "c:\salt\bin\lib\site-packages\salt\states\win_lgpo.py", line 244, in set_ 
hierarchical_return=False) 
File "c:\salt\bin\lib\site-packages\salt\modules\win_lgpo.py", line 4993, in get 
'Get') 
File "c:\salt\bin\lib\site-packages\salt\modules\win_lgpo.py", line 2934, in _transformValue 
return getattr(_policydata, policy['Transform'][transform_type])(value, **t_kwargs) 
File "c:\salt\bin\lib\site-packages\salt\modules\win_lgpo.py", line 2426, in _binary_enable_zero_disable_one_conversion 
if ord(val) == 0: 
TypeError: ord() expected a character, but string of length 2 found 
```

### New Behavior
Completes successfully

### Tests written?
No

### Commits signed with GPG?
Yes