### PR TITLE
Slots: use execution function return as a state arg value

### DIFF
--- a/doc/contents.rst
+++ b/doc/contents.rst
@@ -25,6 +25,7 @@ Salt Table of Contents
     topics/api
     topics/topology/index
     topics/cache/index
+    topics/slots/index
     topics/windows/index
     topics/development/index
     topics/releases/index

--- a/doc/topics/releases/oxygen.rst
+++ b/doc/topics/releases/oxygen.rst
@@ -240,7 +240,7 @@ The new grains added are:
 
 * ``fc_wwn``: Show all fibre channel world wide port names for a host
 * ``iscsi_iqn``: Show the iSCSI IQN name for a host
-* ``swap_total``: Show the configured swap_total for Linux, *BSD, OS X and Solaris/SunOS
+* ``swap_total``: Show the configured swap_total for Linux, \*BSD, OS X and Solaris/SunOS
 
 Salt Minion Autodiscovery
 ------------------------
@@ -1257,6 +1257,24 @@ executing a second attempt to set up a service or begin to execute a separate
 thread of states because of a failure.
 
 The ``onfail_any`` requisite is applied in the same way as ``require_any`` and ``watch_any``:
+
+Basic Slots support in states compiler
+--------------------------------------
+
+Slots extend the state syntax and allows you to do things right before the
+state function is executed. So you can make a decision in the last moment right
+before a state is executed.
+
+Slot syntax looks close to the simple python function call. Here is a simple example:
+
+.. code-block:: yaml
+
+    copy-some-file:
+      file.copy:
+        - name: __slot__:salt:test.echo(text=/tmp/some_file)
+        - source: __slot__:salt:test.echo(/etc/hosts)
+
+Read more :ref:`here <slots-subsystem>`.
 
 Deprecations
 ------------

--- a/doc/topics/slots/index.rst
+++ b/doc/topics/slots/index.rst
@@ -1,0 +1,48 @@
+.. _slots-subsystem:
+
+=====
+Slots
+=====
+
+.. versionadded:: Oxygen
+
+.. note:: This functionality is under development and could be changed in the
+    future releases
+
+Many times it is useful to store the results of a command during the course of
+an execution. Salt Slots is designed to allow to store this information and use
+it later during the highstate or other job execution.
+
+Slots extends the state syntax and allows to do things right before the state
+function be executed. So you can make a decision in the last moment right before
+a state is executed.
+
+Execution functions
+-------------------
+
+.. note:: Using execution modules return data as a state values is a first step
+    of Slots development. Other functionality is under development.
+
+Slots allow to use minion execution module return as an argument value in
+states.
+
+Slot syntax looks close to the simple python function call.
+
+.. code-block::
+
+    __slot__:salt:<module>.<function>(<args>, ..., <kwargs...>, ...)
+
+
+Simple example is here:
+
+.. code-block:: yaml
+
+    copy-some-file:
+      file.copy:
+        - name: __slot__:salt:test.echo(text=/tmp/some_file)
+        - source: __slot__:salt:test.echo(/etc/hosts)
+
+This will execute the `test.echo` execution functions right before calling the
+state. The functions in the example will return `/tmp/some_file` and
+`/etc/hosts` strings that will be used as a target and source arguments in the
+state function `file.copy`.

--- a/doc/topics/slots/index.rst
+++ b/doc/topics/slots/index.rst
@@ -10,12 +10,13 @@ Slots
     future releases
 
 Many times it is useful to store the results of a command during the course of
-an execution. Salt Slots is designed to allow to store this information and use
-it later during the highstate or other job execution.
+an execution. Salt Slots are designed to allow to store this information and
+use it later during the :ref:`highstate <running-highstate>` or other job
+execution.
 
-Slots extends the state syntax and allows to do things right before the state
-function be executed. So you can make a decision in the last moment right before
-a state is executed.
+Slots extend the state syntax and allows you to do things right before the
+state function is executed. So you can make a decision in the last moment right
+before a state is executed.
 
 Execution functions
 -------------------
@@ -23,8 +24,8 @@ Execution functions
 .. note:: Using execution modules return data as a state values is a first step
     of Slots development. Other functionality is under development.
 
-Slots allow to use minion execution module return as an argument value in
-states.
+Slots allow you to use the return from a remote-execution function as an
+argument value in states.
 
 Slot syntax looks close to the simple python function call.
 
@@ -32,8 +33,12 @@ Slot syntax looks close to the simple python function call.
 
     __slot__:salt:<module>.<function>(<args>, ..., <kwargs...>, ...)
 
+Also there are some specifics in the syntax coming from the execution functions
+nature and a desire to simplify the user experience. First one is that you
+don't need to quote the strings passed to the slots functions. The second one
+is that all arguments handled as strings.
 
-Simple example is here:
+Here is a simple example:
 
 .. code-block:: yaml
 
@@ -42,7 +47,7 @@ Simple example is here:
         - name: __slot__:salt:test.echo(text=/tmp/some_file)
         - source: __slot__:salt:test.echo(/etc/hosts)
 
-This will execute the `test.echo` execution functions right before calling the
-state. The functions in the example will return `/tmp/some_file` and
-`/etc/hosts` strings that will be used as a target and source arguments in the
-state function `file.copy`.
+This will execute the :py:func:`test.echo <salt.modules.test.echo>` execution
+functions right before calling the state. The functions in the example will
+return `/tmp/some_file` and `/etc/hosts` strings that will be used as a target
+and source arguments in the state function `file.copy`.

--- a/salt/state.py
+++ b/salt/state.py
@@ -2070,6 +2070,7 @@ class State(object):
                ('kwargs', cdata['kwargs'].items()))
         for atype, avalues in ctx:
             for ind, arg in avalues:
+                arg = sdecode(arg)
                 if not isinstance(arg, six.string_types) or not arg.startswith('__slot__:'):
                     # Not a slot, skip it
                     continue

--- a/salt/state.py
+++ b/salt/state.py
@@ -2041,23 +2041,23 @@ class State(object):
         return ret
 
     def __eval_slot(self, slot):
-        log.debug(u'Evaluating slot: %s', slot)
-        fmt = slot.split(u':', 2)
+        log.debug('Evaluating slot: %s', slot)
+        fmt = slot.split(':', 2)
         if len(fmt) != 3:
-            log.warning(u'Malformed slot: %s', slot)
+            log.warning('Malformed slot: %s', slot)
             return slot
-        if fmt[1] != u'salt':
-            log.warning(u'Malformed slot: %s', slot)
-            log.warning(u'Only execution modules are currently supported in slots. This means slot '
-                        u'should start with "__slot__:salt:"')
+        if fmt[1] != 'salt':
+            log.warning('Malformed slot: %s', slot)
+            log.warning('Only execution modules are currently supported in slots. This means slot '
+                        'should start with "__slot__:salt:"')
             return slot
         fun, args, kwargs = salt.utils.args.parse_function(fmt[2])
         if not fun or fun not in self.functions:
-            log.warning(u'Malformed slot: %s', slot)
-            log.warning(u'Execution module should be specified in a function call format: '
-                        u'test.arg(\'arg\', kw=\'kwarg\')')
+            log.warning('Malformed slot: %s', slot)
+            log.warning('Execution module should be specified in a function call format: '
+                        'test.arg(\'arg\', kw=\'kwarg\')')
             return slot
-        log.debug(u'Calling slot: %s(%s, %s)', fun, args, kwargs)
+        log.debug('Calling slot: %s(%s, %s)', fun, args, kwargs)
         return self.functions[fun](*args, **kwargs)
 
     def format_slots(self, cdata):
@@ -2066,11 +2066,11 @@ class State(object):
         minute runtime call to gather relevant data for the specific routine
         '''
         # __slot__:salt.cmd.run(foo, bar, baz=qux)
-        ctx = ((u'args', enumerate(cdata[u'args'])),
-               (u'kwargs', cdata[u'kwargs'].items()))
+        ctx = (('args', enumerate(cdata['args'])),
+               ('kwargs', cdata['kwargs'].items()))
         for atype, avalues in ctx:
             for ind, arg in avalues:
-                if not isinstance(arg, six.string_types) or not arg.startswith(u'__slot__:'):
+                if not isinstance(arg, six.string_types) or not arg.startswith('__slot__:'):
                     # Not a slot, skip it
                     continue
                 cdata[atype][ind] = self.__eval_slot(arg)

--- a/salt/state.py
+++ b/salt/state.py
@@ -1930,6 +1930,7 @@ class State(object):
                         # run the state call in parallel, but only if not in a prereq
                         ret = self.call_parallel(cdata, low)
                     else:
+                        self.format_slots(cdata)
                         ret = self.states[cdata['full']](*cdata['args'],
                                                           **cdata['kwargs'])
                 self.states.inject_globals = {}
@@ -2038,6 +2039,25 @@ class State(object):
                                                 low['retry']['until'],
                                                 low['retry']['splay'])])
         return ret
+
+    def format_slots(self, cdata):
+        '''
+        Read in the arguments from the low level slot syntax to make a last
+        minute runtime call to gather relevant data for the specific routine
+        '''
+        # __slot__:salt.cmd.run(foo, bar, baz=qux)
+        for ind in range(len(cdata['args'])):
+            arg = cdata['args'][ind]
+            if arg.startswith('__slot__:'):
+                # Call the slot
+                fmt = arg.split(':')
+                if len(fmt) < 2:
+                    # Impropperly formated slot
+                    continue
+                fun = fmt[1]
+                comps = fun.split('(')
+                if len(comps) < 3:
+                    continue
 
     def verify_retry_data(self, retry_data):
         '''

--- a/salt/utils/args.py
+++ b/salt/utils/args.py
@@ -12,7 +12,7 @@ import re
 import shlex
 
 # Import salt libs
-from salt.exceptions import SaltInvocationError, TemplateError
+from salt.exceptions import SaltInvocationError
 from salt.ext import six
 from salt.ext.six.moves import zip  # pylint: disable=import-error,redefined-builtin
 import salt.utils.data
@@ -522,6 +522,7 @@ def parse_function(s):
     kwargs = {}
     brackets = []
     key = None
+    token = None
     for token in sh:
         if token == '(':
             break


### PR DESCRIPTION
### What does this PR do?
Adds an ability to use an execution function return as a state argument value.

### What issues does this PR fix or reference?
Implements #42136

### New Behavior
Allows to use `__slot__` like this:
```slsf
do-something:
  file.copy:
    - name: __slot__:salt:test.echo(/tmp/file-c)
    - source: __slot__:salt:test.echo(text=/etc/hosts)
```

### Tests written?
Yes

### Commits signed with GPG?
Yes