### PR TITLE
older logrotate need su directive

### DIFF
--- a/pkg/suse/salt-common.logrotate
+++ b/pkg/suse/salt-common.logrotate
@@ -8,6 +8,7 @@
 }
 
 /var/log/salt/minion {
+	su root root
 	weekly
 	missingok
 	rotate 7


### PR DESCRIPTION
### What does this PR do?

On older SUSE distributions logrotate will not work without su directive set for the minion log

