### PR TITLE
PoC: Standalone Proxy Minion

### DIFF
--- a/salt/cli/daemons.py
+++ b/salt/cli/daemons.py
@@ -423,8 +423,13 @@ class ProxyMinion(salt.utils.parsers.ProxyMinionOptionParser, DaemonsMixin):  # 
         '''
         super(ProxyMinion, self).prepare()
 
-        if not self.values.proxyid:
+        if not self.values.proxyid and not hasattr(self, 'proxyid'):
             self.error('salt-proxy requires --proxyid')
+
+        if hasattr(self, 'proxyid'):
+            self.config['id'] = self.proxyid
+        if hasattr(self, 'standalone'):
+            self.config['standalone_proxy'] = self.standalone
 
         # Proxies get their ID from the command line.  This may need to change in
         # the future.
@@ -475,13 +480,11 @@ class ProxyMinion(salt.utils.parsers.ProxyMinionOptionParser, DaemonsMixin):  # 
                 )
         except OSError as error:
             self.environment_failure(error)
-
         self.setup_logfile_logger()
         verify_log(self.config)
         self.action_log_info('Setting up "{0}"'.format(self.config['id']))
 
         migrations.migrate_paths(self.config)
-
         # Bail out if we find a process running and it matches out pidfile
         if self.check_running():
             self.action_log_info('An instance is already running. Exiting')

--- a/salt/cli/standalone_proxy.py
+++ b/salt/cli/standalone_proxy.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+
+# Import python libs
+from __future__ import absolute_import, print_function
+import sys
+sys.modules['pkg_resources'] = None
+import multiprocessing
+
+# Import Salt libs
+# We import log ASAP because we NEED to make sure that any logger instance salt
+# instantiates is using salt.log.setup.SaltLoggingClass
+import salt.log.setup
+from salt.cli.salt import SaltCMD
+from salt.scripts import salt_proxy
+from salt.cli.daemons import ProxyMinion
+from salt.utils.verify import verify_log
+
+# Let's instantiate log using salt.log.setup.logging.getLogger() so pylint
+# leaves us alone and stops complaining about an un-used import
+log = salt.log.setup.logging.getLogger(__name__)
+
+
+class StandaloneProxyMinionCMD(SaltCMD):
+    '''
+    The execution of a salt-proxy-standalone command happens here
+    '''
+
+    def run(self):
+        '''
+        Execute the salt command line
+        '''
+        import salt.client
+        self.parse_args()
+
+        # Setup file logging!
+        self.setup_logfile_logger()
+        verify_log(self.config)
+        try:
+            # We don't need to bail on config file permission errors
+            # if the CLI process is run with the -a flag
+            skip_perm_errors = self.options.eauth != ''
+
+            self.local_client = salt.client.get_local_client(
+                self.get_config_file_path(),
+                skip_perm_errors=skip_perm_errors,
+                auto_reconnect=True)
+        except SaltClientError as exc:
+            self.exit(2, '{0}\n'.format(exc))
+            return
+        # Determine what minions should execute against,
+        # Eventually using cached data.
+        preview_target = self.local_client.gather_minions(self.config['tgt'],
+                                                          self.selected_target_option or 'glob')
+        log.error(preview_target)
+        log.debug('Starting a process for each of the targeted:')
+        for targeted_minion in preview_target:
+            log.debug('Starting process for %s', targeted_minion)
+            process = multiprocessing.Process(target=salt_proxy,
+                                              kwargs={'proxy_id': targeted_minion,
+                                                      'standalone': True})
+            process.start()

--- a/salt/cli/standalone_proxy.py
+++ b/salt/cli/standalone_proxy.py
@@ -4,14 +4,15 @@
 from __future__ import absolute_import, print_function
 import sys
 sys.modules['pkg_resources'] = None
+import time
 import multiprocessing
 
 # Import Salt libs
 # We import log ASAP because we NEED to make sure that any logger instance salt
 # instantiates is using salt.log.setup.SaltLoggingClass
 import salt.log.setup
-from salt.cli.salt import SaltCMD
-from salt.scripts import salt_proxy
+import salt.utils.parsers
+from salt.scripts import standalone_proxy_process
 from salt.cli.daemons import ProxyMinion
 from salt.utils.verify import verify_log
 
@@ -20,7 +21,7 @@ from salt.utils.verify import verify_log
 log = salt.log.setup.logging.getLogger(__name__)
 
 
-class StandaloneProxyMinionCMD(SaltCMD):
+class StandaloneProxyMinionCMD(salt.utils.parsers.SaltCMDOptionParser):
     '''
     The execution of a salt-proxy-standalone command happens here
     '''
@@ -55,7 +56,6 @@ class StandaloneProxyMinionCMD(SaltCMD):
         log.debug('Starting a process for each of the targeted:')
         for targeted_minion in preview_target:
             log.debug('Starting process for %s', targeted_minion)
-            process = multiprocessing.Process(target=salt_proxy,
-                                              kwargs={'proxy_id': targeted_minion,
-                                                      'standalone': True})
+            process = multiprocessing.Process(target=standalone_proxy_process,
+                                              args=(targeted_minion,))
             process.start()

--- a/salt/cli/standalone_proxy.py
+++ b/salt/cli/standalone_proxy.py
@@ -4,26 +4,32 @@
 from __future__ import absolute_import, print_function
 import sys
 sys.modules['pkg_resources'] = None
+import os
 import time
 import multiprocessing
 
 # Import Salt libs
-# We import log ASAP because we NEED to make sure that any logger instance salt
-# instantiates is using salt.log.setup.SaltLoggingClass
-import salt.log.setup
+import salt.utils.job
 import salt.utils.parsers
+import salt.utils.stringutils
 from salt.scripts import standalone_proxy_process
-from salt.cli.daemons import ProxyMinion
+from salt.utils.args import yamlify_arg
 from salt.utils.verify import verify_log
+from salt.exceptions import (
+    EauthAuthenticationError,
+    LoaderError,
+    SaltClientError,
+    SaltInvocationError,
+    SaltSystemExit
+)
 
-# Let's instantiate log using salt.log.setup.logging.getLogger() so pylint
-# leaves us alone and stops complaining about an un-used import
-log = salt.log.setup.logging.getLogger(__name__)
+# Import 3rd-party libs
+from salt.ext import six
 
 
 class StandaloneProxyMinionCMD(salt.utils.parsers.SaltCMDOptionParser):
     '''
-    The execution of a salt-proxy-standalone command happens here
+    The execution of a salt command happens here
     '''
 
     def run(self):
@@ -36,6 +42,7 @@ class StandaloneProxyMinionCMD(salt.utils.parsers.SaltCMDOptionParser):
         # Setup file logging!
         self.setup_logfile_logger()
         verify_log(self.config)
+
         try:
             # We don't need to bail on config file permission errors
             # if the CLI process is run with the -a flag
@@ -48,14 +55,394 @@ class StandaloneProxyMinionCMD(salt.utils.parsers.SaltCMDOptionParser):
         except SaltClientError as exc:
             self.exit(2, '{0}\n'.format(exc))
             return
+
+        minion_list = self._preview_target()
+        if self.options.preview_target:
+            self._output_ret(minion_list, self.config.get('output', 'nested'))
+            return
+
+        if self.options.batch or self.options.static:
+            # _run_batch() will handle all output and
+            # exit with the appropriate error condition
+            # Execution will not continue past this point
+            # in batch mode.
+            self._run_batch()
+            return
+
         # Determine what minions should execute against,
         # Eventually using cached data.
-        preview_target = self.local_client.gather_minions(self.config['tgt'],
-                                                          self.selected_target_option or 'glob')
-        log.error(preview_target)
-        log.debug('Starting a process for each of the targeted:')
-        for targeted_minion in preview_target:
-            log.debug('Starting process for %s', targeted_minion)
+        self.processes = []
+        for proxy_id in minion_list:
             process = multiprocessing.Process(target=standalone_proxy_process,
-                                              args=(targeted_minion,))
+                                              args=(proxy_id,))
             process.start()
+            self.processes.append(process)
+
+        time.sleep(self.config.get('standalone_proxy_wait_time', 5))
+
+        if self.options.timeout <= 0:
+            self.options.timeout = self.local_client.opts['timeout']
+
+        kwargs = {
+            'tgt': self.config['tgt'],
+            'fun': self.config['fun'],
+            'arg': self.config['arg'],
+            'timeout': self.options.timeout,
+            'show_timeout': self.options.show_timeout,
+            'show_jid': self.options.show_jid}
+
+        if 'token' in self.config:
+            import salt.utils.files
+            try:
+                with salt.utils.files.fopen(os.path.join(self.config['key_dir'], '.root_key'), 'r') as fp_:
+                    kwargs['key'] = fp_.readline()
+            except IOError:
+                kwargs['token'] = self.config['token']
+
+        kwargs['delimiter'] = self.options.delimiter
+
+        if self.selected_target_option:
+            kwargs['tgt_type'] = self.selected_target_option
+        else:
+            kwargs['tgt_type'] = 'glob'
+
+        # If batch_safe_limit is set, check minions matching target and
+        # potentially switch to batch execution
+        if self.options.batch_safe_limit > 1:
+            if len(self._preview_target()) >= self.options.batch_safe_limit:
+                salt.utils.stringutils.print_cli('\nNOTICE: Too many minions targeted, switching to batch execution.')
+                self.options.batch = self.options.batch_safe_size
+                self._run_batch()
+                return
+
+        if getattr(self.options, 'return'):
+            kwargs['ret'] = getattr(self.options, 'return')
+
+        if getattr(self.options, 'return_config'):
+            kwargs['ret_config'] = getattr(self.options, 'return_config')
+
+        if getattr(self.options, 'return_kwargs'):
+            kwargs['ret_kwargs'] = yamlify_arg(
+                    getattr(self.options, 'return_kwargs'))
+
+        if getattr(self.options, 'module_executors'):
+            kwargs['module_executors'] = yamlify_arg(getattr(self.options, 'module_executors'))
+
+        if getattr(self.options, 'executor_opts'):
+            kwargs['executor_opts'] = yamlify_arg(getattr(self.options, 'executor_opts'))
+
+        if getattr(self.options, 'metadata'):
+            kwargs['metadata'] = yamlify_arg(
+                    getattr(self.options, 'metadata'))
+
+        # If using eauth and a token hasn't already been loaded into
+        # kwargs, prompt the user to enter auth credentials
+        if 'token' not in kwargs and 'key' not in kwargs and self.options.eauth:
+            # This is expensive. Don't do it unless we need to.
+            import salt.auth
+            resolver = salt.auth.Resolver(self.config)
+            res = resolver.cli(self.options.eauth)
+            if self.options.mktoken and res:
+                tok = resolver.token_cli(
+                        self.options.eauth,
+                        res
+                        )
+                if tok:
+                    kwargs['token'] = tok.get('token', '')
+            if not res:
+                sys.stderr.write('ERROR: Authentication failed\n')
+                sys.exit(2)
+            kwargs.update(res)
+            kwargs['eauth'] = self.options.eauth
+
+        if self.config['async']:
+            jid = self.local_client.cmd_async(**kwargs)
+            salt.utils.stringutils.print_cli('Executed command with job ID: {0}'.format(jid))
+            return
+
+        # local will be None when there was an error
+        if not self.local_client:
+            return
+
+        retcodes = []
+        errors = []
+
+        try:
+            if self.options.subset:
+                cmd_func = self.local_client.cmd_subset
+                kwargs['sub'] = self.options.subset
+                kwargs['cli'] = True
+            else:
+                cmd_func = self.local_client.cmd_cli
+
+            if self.options.progress:
+                kwargs['progress'] = True
+                self.config['progress'] = True
+                ret = {}
+                for progress in cmd_func(**kwargs):
+                    out = 'progress'
+                    try:
+                        self._progress_ret(progress, out)
+                    except LoaderError as exc:
+                        raise SaltSystemExit(exc)
+                    if 'return_count' not in progress:
+                        ret.update(progress)
+                self._progress_end(out)
+                self._print_returns_summary(ret)
+            elif self.config['fun'] == 'sys.doc':
+                ret = {}
+                out = ''
+                for full_ret in self.local_client.cmd_cli(**kwargs):
+                    ret_, out, retcode = self._format_ret(full_ret)
+                    ret.update(ret_)
+                self._output_ret(ret, out)
+            else:
+                _ret = cmd_func(**kwargs)
+                if self.options.verbose:
+                    kwargs['verbose'] = True
+                ret = {}
+                for full_ret in _ret:
+                    try:
+                        ret_, out, retcode = self._format_ret(full_ret)
+                        retcodes.append(retcode)
+                        self._output_ret(ret_, out)
+                        ret.update(full_ret)
+                    except KeyError:
+                        errors.append(full_ret)
+
+            # Returns summary
+            if self.config['cli_summary'] is True:
+                if self.config['fun'] != 'sys.doc':
+                    if self.options.output is None:
+                        self._print_returns_summary(ret)
+                        self._print_errors_summary(errors)
+
+            # NOTE: Return code is set here based on if all minions
+            # returned 'ok' with a retcode of 0.
+            # This is the final point before the 'salt' cmd returns,
+            # which is why we set the retcode here.
+            if retcodes.count(0) < len(retcodes):
+                sys.stderr.write('ERROR: Minions returned with non-zero exit code\n')
+                sys.exit(11)
+
+        except (SaltInvocationError, EauthAuthenticationError, SaltClientError) as exc:
+            ret = str(exc)
+            self._output_ret(ret, '')
+        finally:
+            for process in self.processes:
+                process.terminate()
+
+
+    def _preview_target(self):
+        '''
+        Return a list of minions from a given target
+        '''
+        return self.local_client.gather_minions(self.config['tgt'], self.selected_target_option or 'glob')
+
+    def _run_batch(self):
+        import salt.cli.batch
+        eauth = {}
+        if 'token' in self.config:
+            eauth['token'] = self.config['token']
+
+        # If using eauth and a token hasn't already been loaded into
+        # kwargs, prompt the user to enter auth credentials
+        if 'token' not in eauth and self.options.eauth:
+            # This is expensive. Don't do it unless we need to.
+            import salt.auth
+            resolver = salt.auth.Resolver(self.config)
+            res = resolver.cli(self.options.eauth)
+            if self.options.mktoken and res:
+                tok = resolver.token_cli(
+                        self.options.eauth,
+                        res
+                        )
+                if tok:
+                    eauth['token'] = tok.get('token', '')
+            if not res:
+                sys.stderr.write('ERROR: Authentication failed\n')
+                sys.exit(2)
+            eauth.update(res)
+            eauth['eauth'] = self.options.eauth
+
+        if self.options.static:
+
+            if not self.options.batch:
+                self.config['batch'] = '100%'
+
+            try:
+                batch = salt.cli.batch.Batch(self.config, eauth=eauth, quiet=True)
+            except SaltClientError:
+                sys.exit(2)
+
+            ret = {}
+
+            for res in batch.run():
+                ret.update(res)
+
+            self._output_ret(ret, '')
+
+        else:
+            try:
+                self.config['batch'] = self.options.batch
+                batch = salt.cli.batch.Batch(self.config, eauth=eauth, parser=self.options)
+            except SaltClientError:
+                # We will print errors to the console further down the stack
+                sys.exit(1)
+            # Printing the output is already taken care of in run() itself
+            retcode = 0
+            for res in batch.run():
+                for ret in six.itervalues(res):
+                    job_retcode = salt.utils.job.get_retcode(ret)
+                    if job_retcode > retcode:
+                        # Exit with the highest retcode we find
+                        retcode = job_retcode
+            sys.exit(retcode)
+
+    def _print_errors_summary(self, errors):
+        if errors:
+            salt.utils.stringutils.print_cli('\n')
+            salt.utils.stringutils.print_cli('---------------------------')
+            salt.utils.stringutils.print_cli('Errors')
+            salt.utils.stringutils.print_cli('---------------------------')
+            for error in errors:
+                salt.utils.stringutils.print_cli(self._format_error(error))
+
+    def _print_returns_summary(self, ret):
+        '''
+        Display returns summary
+        '''
+        return_counter = 0
+        not_return_counter = 0
+        not_return_minions = []
+        not_response_minions = []
+        not_connected_minions = []
+        failed_minions = []
+        for each_minion in ret:
+            minion_ret = ret[each_minion]
+            if isinstance(minion_ret, dict) and 'ret' in minion_ret:
+                minion_ret = ret[each_minion].get('ret')
+            if (
+                    isinstance(minion_ret, six.string_types)
+                    and minion_ret.startswith("Minion did not return")
+                    ):
+                if "Not connected" in minion_ret:
+                    not_connected_minions.append(each_minion)
+                elif "No response" in minion_ret:
+                    not_response_minions.append(each_minion)
+                not_return_counter += 1
+                not_return_minions.append(each_minion)
+            else:
+                return_counter += 1
+                if self._get_retcode(ret[each_minion]):
+                    failed_minions.append(each_minion)
+        salt.utils.stringutils.print_cli('\n')
+        salt.utils.stringutils.print_cli('-------------------------------------------')
+        salt.utils.stringutils.print_cli('Summary')
+        salt.utils.stringutils.print_cli('-------------------------------------------')
+        salt.utils.stringutils.print_cli('# of minions targeted: {0}'.format(return_counter + not_return_counter))
+        salt.utils.stringutils.print_cli('# of minions returned: {0}'.format(return_counter))
+        salt.utils.stringutils.print_cli('# of minions that did not return: {0}'.format(not_return_counter))
+        salt.utils.stringutils.print_cli('# of minions with errors: {0}'.format(len(failed_minions)))
+        if self.options.verbose:
+            if not_connected_minions:
+                salt.utils.stringutils.print_cli('Minions not connected: {0}'.format(" ".join(not_connected_minions)))
+            if not_response_minions:
+                salt.utils.stringutils.print_cli('Minions not responding: {0}'.format(" ".join(not_response_minions)))
+            if failed_minions:
+                salt.utils.stringutils.print_cli('Minions with failures: {0}'.format(" ".join(failed_minions)))
+        salt.utils.stringutils.print_cli('-------------------------------------------')
+
+    def _progress_end(self, out):
+        import salt.output
+        salt.output.progress_end(self.progress_bar)
+
+    def _progress_ret(self, progress, out):
+        '''
+        Print progress events
+        '''
+        import salt.output
+        # Get the progress bar
+        if not hasattr(self, 'progress_bar'):
+            try:
+                self.progress_bar = salt.output.get_progress(self.config, out, progress)
+            except Exception:
+                raise LoaderError('\nWARNING: Install the `progressbar` python package. '
+                                  'Requested job was still run but output cannot be displayed.\n')
+        salt.output.update_progress(self.config, progress, self.progress_bar, out)
+
+    def _output_ret(self, ret, out):
+        '''
+        Print the output from a single return to the terminal
+        '''
+        import salt.output
+        # Handle special case commands
+        if self.config['fun'] == 'sys.doc' and not isinstance(ret, Exception):
+            self._print_docs(ret)
+        else:
+            # Determine the proper output method and run it
+            salt.output.display_output(ret, out, self.config)
+        if not ret:
+            sys.stderr.write('ERROR: No return received\n')
+            sys.exit(2)
+
+    def _format_ret(self, full_ret):
+        '''
+        Take the full return data and format it to simple output
+        '''
+        ret = {}
+        out = ''
+        retcode = 0
+        for key, data in six.iteritems(full_ret):
+            ret[key] = data['ret']
+            if 'out' in data:
+                out = data['out']
+            ret_retcode = self._get_retcode(data)
+            if ret_retcode > retcode:
+                retcode = ret_retcode
+        return ret, out, retcode
+
+    def _get_retcode(self, ret):
+        '''
+        Determine a retcode for a given return
+        '''
+        retcode = 0
+        # if there is a dict with retcode, use that
+        if isinstance(ret, dict) and ret.get('retcode', 0) != 0:
+            return ret['retcode']
+        # if its a boolean, False means 1
+        elif isinstance(ret, bool) and not ret:
+            return 1
+        return retcode
+
+    def _format_error(self, minion_error):
+        for minion, error_doc in six.iteritems(minion_error):
+            error = 'Minion [{0}] encountered exception \'{1}\''.format(minion, error_doc['message'])
+        return error
+
+    def _print_docs(self, ret):
+        '''
+        Print out the docstrings for all of the functions on the minions
+        '''
+        import salt.output
+        docs = {}
+        if not ret:
+            self.exit(2, 'No minions found to gather docs from\n')
+        if isinstance(ret, six.string_types):
+            self.exit(2, '{0}\n'.format(ret))
+        for host in ret:
+            if isinstance(ret[host], six.string_types) \
+                    and (ret[host].startswith("Minion did not return")
+                         or ret[host] == 'VALUE TRIMMED'):
+                continue
+            for fun in ret[host]:
+                if fun not in docs and ret[host][fun]:
+                    docs[fun] = ret[host][fun]
+        if self.options.output:
+            for fun in sorted(docs):
+                salt.output.display_output({fun: docs[fun]}, 'nested', self.config)
+        else:
+            for fun in sorted(docs):
+                salt.utils.stringutils.print_cli('{0}:'.format(fun))
+                salt.utils.stringutils.print_cli(docs[fun])
+                salt.utils.stringutils.print_cli('')

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -614,6 +614,8 @@ VALID_OPTS = {
     # False in 2016.3.0
     'add_proxymodule_to_opts': bool,
 
+    'standalone_proxy': bool,
+
     # Merge pillar data into configuration opts.
     # As multiple proxies can run on the same server, we may need different
     # configuration options for each, while there's one single configuration file.
@@ -1764,6 +1766,7 @@ DEFAULT_PROXY_MINION_OPTS = {
     'append_minionid_config_dirs': ['cachedir', 'pidfile', 'default_include', 'extension_modules'],
     'default_include': 'proxy.d/*.conf',
 
+    'standalone_proxy': False,
     'proxy_merge_pillar_in_opts': False,
     'proxy_deep_merge_pillar_in_opts': False,
     'proxy_merge_pillar_in_opts_strategy': 'smart',

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -615,6 +615,7 @@ VALID_OPTS = {
     'add_proxymodule_to_opts': bool,
 
     'standalone_proxy': bool,
+    'standalone_proxy_wait_time': int,
 
     # Merge pillar data into configuration opts.
     # As multiple proxies can run on the same server, we may need different
@@ -1767,6 +1768,7 @@ DEFAULT_PROXY_MINION_OPTS = {
     'default_include': 'proxy.d/*.conf',
 
     'standalone_proxy': False,
+    'standalone_proxy_wait_time': 5,
     'proxy_merge_pillar_in_opts': False,
     'proxy_deep_merge_pillar_in_opts': False,
     'proxy_merge_pillar_in_opts_strategy': 'smart',

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -893,7 +893,6 @@ class MinionManager(MinionBase):
         self.max_auth_wait = self.opts[u'acceptance_wait_time_max']
         self.minions = []
         self.jid_queue = []
-
         if HAS_ZMQ:
             zmq.eventloop.ioloop.install()
         self.io_loop = LOOP_CLASS.current()
@@ -2039,8 +2038,9 @@ class Minion(MinionBase):
         log.debug(u'Refreshing modules. Notify=%s', notify)
         self.functions, self.returners, _, self.executors = self._load_modules(force_refresh, notify=notify)
 
-        self.schedule.functions = self.functions
-        self.schedule.returners = self.returners
+        if not self.opts.get('standalone_proxy', False):
+            self.schedule.functions = self.functions
+            self.schedule.returners = self.returners
 
     def beacons_refresh(self):
         '''
@@ -3469,99 +3469,105 @@ class ProxyMinion(Minion):
         self.serial = salt.payload.Serial(self.opts)
         self.mod_opts = self._prep_mod_opts()
         self.matcher = Matcher(self.opts, self.functions)
-        self.beacons = salt.beacons.Beacon(self.opts, self.functions)
+        if self.opts.get('standalone_proxy', False):
+            log.info('Dont need Beacons for this standalone proxy (%s)', self.opts['id'])
+            self.beacons = {}
+        else:
+            self.beacons = salt.beacons.Beacon(self.opts, self.functions)
         uid = salt.utils.user.get_uid(user=self.opts.get(u'user', None))
         self.proc_dir = get_proc_dir(self.opts[u'cachedir'], uid=uid)
 
-        if self.connected and self.opts[u'pillar']:
-            # The pillar has changed due to the connection to the master.
-            # Reload the functions so that they can use the new pillar data.
-            self.functions, self.returners, self.function_errors, self.executors = self._load_modules()
-            if hasattr(self, u'schedule'):
-                self.schedule.functions = self.functions
-                self.schedule.returners = self.returners
+        if not self.opts.get('standalone_proxy', False):
+            if self.connected and self.opts[u'pillar']:
+                # The pillar has changed due to the connection to the master.
+                # Reload the functions so that they can use the new pillar data.
+                self.functions, self.returners, self.function_errors, self.executors = self._load_modules()
+                if hasattr(self, u'schedule'):
+                    self.schedule.functions = self.functions
+                    self.schedule.returners = self.returners
 
-        if not hasattr(self, u'schedule'):
-            self.schedule = salt.utils.schedule.Schedule(
-                self.opts,
-                self.functions,
-                self.returners,
-                cleanup=[master_event(type=u'alive')],
-                proxy=self.proxy)
+            if not hasattr(self, u'schedule'):
+                self.schedule = salt.utils.schedule.Schedule(
+                    self.opts,
+                    self.functions,
+                    self.returners,
+                    cleanup=[master_event(type=u'alive')],
+                    proxy=self.proxy)
 
-        # add default scheduling jobs to the minions scheduler
-        if self.opts[u'mine_enabled'] and u'mine.update' in self.functions:
-            self.schedule.add_job({
-                u'__mine_interval':
-                    {
-                        u'function': u'mine.update',
-                        u'minutes': self.opts[u'mine_interval'],
-                        u'jid_include': True,
-                        u'maxrunning': 2,
-                        u'return_job': self.opts.get(u'mine_return_job', False)
-                    }
-            }, persist=True)
-            log.info(u'Added mine.update to scheduler')
-        else:
-            self.schedule.delete_job(u'__mine_interval', persist=True)
 
-        # add master_alive job if enabled
-        if (self.opts[u'transport'] != u'tcp' and
-                self.opts[u'master_alive_interval'] > 0):
-            self.schedule.add_job({
-                master_event(type=u'alive', master=self.opts[u'master']):
-                    {
-                        u'function': u'status.master',
-                        u'seconds': self.opts[u'master_alive_interval'],
-                        u'jid_include': True,
-                        u'maxrunning': 1,
-                        u'return_job': False,
-                        u'kwargs': {u'master': self.opts[u'master'],
-                                    u'connected': True}
-                    }
-            }, persist=True)
-            if self.opts[u'master_failback'] and \
-                    u'master_list' in self.opts and \
-                    self.opts[u'master'] != self.opts[u'master_list'][0]:
+            # add default scheduling jobs to the minions scheduler
+            if self.opts[u'mine_enabled'] and u'mine.update' in self.functions:
                 self.schedule.add_job({
-                    master_event(type=u'failback'):
+                    u'__mine_interval':
+                        {
+                            u'function': u'mine.update',
+                            u'minutes': self.opts[u'mine_interval'],
+                            u'jid_include': True,
+                            u'maxrunning': 2,
+                            u'return_job': self.opts.get(u'mine_return_job', False)
+                        }
+                }, persist=True)
+                log.info(u'Added mine.update to scheduler')
+            else:
+                self.schedule.delete_job(u'__mine_interval', persist=True)
+
+            # add master_alive job if enabled
+            if (self.opts[u'transport'] != u'tcp' and
+                    self.opts[u'master_alive_interval'] > 0):
+                self.schedule.add_job({
+                    master_event(type=u'alive', master=self.opts[u'master']):
+                        {
+                            u'function': u'status.master',
+                            u'seconds': self.opts[u'master_alive_interval'],
+                            u'jid_include': True,
+                            u'maxrunning': 1,
+                            u'return_job': False,
+                            u'kwargs': {u'master': self.opts[u'master'],
+                                        u'connected': True}
+                        }
+                }, persist=True)
+                if self.opts[u'master_failback'] and \
+                        u'master_list' in self.opts and \
+                        self.opts[u'master'] != self.opts[u'master_list'][0]:
+                    self.schedule.add_job({
+                        master_event(type=u'failback'):
+                        {
+                            u'function': u'status.ping_master',
+                            u'seconds': self.opts[u'master_failback_interval'],
+                            u'jid_include': True,
+                            u'maxrunning': 1,
+                            u'return_job': False,
+                            u'kwargs': {u'master': self.opts[u'master_list'][0]}
+                        }
+                    }, persist=True)
+                else:
+                    self.schedule.delete_job(master_event(type=u'failback'), persist=True)
+            else:
+                self.schedule.delete_job(master_event(type=u'alive', master=self.opts[u'master']), persist=True)
+                self.schedule.delete_job(master_event(type=u'failback'), persist=True)
+
+            # proxy keepalive
+            proxy_alive_fn = fq_proxyname+u'.alive'
+            if (proxy_alive_fn in self.proxy
+                and u'status.proxy_reconnect' in self.functions
+                and self.opts.get(u'proxy_keep_alive', True)):
+                # if `proxy_keep_alive` is either not specified, either set to False does not retry reconnecting
+                self.schedule.add_job({
+                    u'__proxy_keepalive':
                     {
-                        u'function': u'status.ping_master',
-                        u'seconds': self.opts[u'master_failback_interval'],
+                        u'function': u'status.proxy_reconnect',
+                        u'minutes': self.opts.get(u'proxy_keep_alive_interval', 1),  # by default, check once per minute
                         u'jid_include': True,
                         u'maxrunning': 1,
                         u'return_job': False,
-                        u'kwargs': {u'master': self.opts[u'master_list'][0]}
+                        u'kwargs': {
+                            u'proxy_name': fq_proxyname
+                        }
                     }
                 }, persist=True)
+                self.schedule.enable_schedule()
             else:
-                self.schedule.delete_job(master_event(type=u'failback'), persist=True)
-        else:
-            self.schedule.delete_job(master_event(type=u'alive', master=self.opts[u'master']), persist=True)
-            self.schedule.delete_job(master_event(type=u'failback'), persist=True)
-
-        # proxy keepalive
-        proxy_alive_fn = fq_proxyname+u'.alive'
-        if (proxy_alive_fn in self.proxy
-            and u'status.proxy_reconnect' in self.functions
-            and self.opts.get(u'proxy_keep_alive', True)):
-            # if `proxy_keep_alive` is either not specified, either set to False does not retry reconnecting
-            self.schedule.add_job({
-                u'__proxy_keepalive':
-                {
-                    u'function': u'status.proxy_reconnect',
-                    u'minutes': self.opts.get(u'proxy_keep_alive_interval', 1),  # by default, check once per minute
-                    u'jid_include': True,
-                    u'maxrunning': 1,
-                    u'return_job': False,
-                    u'kwargs': {
-                        u'proxy_name': fq_proxyname
-                    }
-                }
-            }, persist=True)
-            self.schedule.enable_schedule()
-        else:
-            self.schedule.delete_job(u'__proxy_keepalive', persist=True)
+                self.schedule.delete_job(u'__proxy_keepalive', persist=True)
 
         #  Sync the grains here so the proxy can communicate them to the master
         self.functions[u'saltutil.sync_grains'](saltenv=u'base')

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -896,8 +896,7 @@ class MinionManager(MinionBase):
         if HAS_ZMQ:
             zmq.eventloop.ioloop.install()
         if 'standalone_proxy' in opts and opts['standalone_proxy']:
-            # anyway deprecated as of pyzm
-            self.io_loop = tornado.ioloop.IOLoop.current()
+            self.io_loop = tornado.ioloop.IOLoop.instance()
         else:
             self.io_loop = LOOP_CLASS.current()
         self.process_manager = ProcessManager(name=u'MultiMinionProcessManager')

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -895,7 +895,11 @@ class MinionManager(MinionBase):
         self.jid_queue = []
         if HAS_ZMQ:
             zmq.eventloop.ioloop.install()
-        self.io_loop = LOOP_CLASS.current()
+        if 'standalone_proxy' in opts and opts['standalone_proxy']:
+            # anyway deprecated as of pyzm
+            self.io_loop = tornado.ioloop.IOLoop.current()
+        else:
+            self.io_loop = LOOP_CLASS.current()
         self.process_manager = ProcessManager(name=u'MultiMinionProcessManager')
         self.io_loop.spawn_callback(self.process_manager.run, async=True)
 

--- a/salt/proxy/dummy.py
+++ b/salt/proxy/dummy.py
@@ -49,7 +49,7 @@ def _load_state():
     try:
         with salt.utils.files.fopen(FILENAME, 'r') as pck:
             DETAILS = pickle.load(pck)
-    except IOError:
+    except EOFError:
         DETAILS = {}
         DETAILS['initialized'] = False
         _save_state(DETAILS)

--- a/salt/scripts.py
+++ b/salt/scripts.py
@@ -337,9 +337,7 @@ def salt_proxy(proxy_id=None, standalone=False):
             proxyminion.start()
             return
         process = multiprocessing.Process(target=proxy_minion_process,
-                                          args=(queue,),
-                                          kwargs={'proxy_id': proxy_id,
-                                                  'standalone': True})
+                                          args=(queue,))
         process.start()
         try:
             process.join()

--- a/scripts/salt-standalone-proxy
+++ b/scripts/salt-standalone-proxy
@@ -1,0 +1,10 @@
+#!/usr/bin/env python
+'''
+Publish commands to the salt system from the command line on the master.
+'''
+
+from salt.scripts import salt_proxy_standalone
+
+
+if __name__ == '__main__':
+    salt_proxy_standalone()

--- a/setup.py
+++ b/setup.py
@@ -1112,6 +1112,7 @@ class SaltDistribution(distutils.dist.Distribution):
                         'scripts/salt-syndic',
                         'scripts/salt-unity',
                         'scripts/salt-proxy',
+                        'scripts/salt-standalone-proxy',
                         'scripts/spm'])
         return scripts
 


### PR DESCRIPTION
### What does this PR do?

This is just the very beginning of an idea to add a standalone version of the Proxy Minion. In networking (but not limited to) there are environments that are not very dynamic, or don't need the event driven infra (bad! though I can understand that), and so on. For example, if you only want to push a configuration change once per year you probably don't want a Proxy process running always there.
These are a couple of reasons why we probably should introduce a different flavour of Proxy Minions that are able to control network devices and execute arbitrary commands on demand. Actually there are a couple of approaches:

- An extension to the existing proxy, so we can reuse everything that already exists, and all the proxy modules.
- "Extend the transport-layer abstraction so that it can, as you say, "connect to remote devices over an arbitrary channel" instead of just being something that's designed to be initialized on master/minion startup." @cachedout 
- Provide a completely separate tool that simply invokes the command on the Minions, without having a Master (which may be derived from the first approach, like forcing the command execution without going through the Master).

For the time being I picked the first one, simplifying the Proxy startup by removing the Beacons and the Scheduler (as they don't make sense if you only want a one time command).
The second step was to extend the existing `salt` bin as a `salt-standalone-proxy` that does the same + starts up the lighter Proxy as sub-processes (based on the educated guess to determine what Minions match the target).

The command runs like that (very noisy, will solve that later):

```bash
admin@ip-172-31-9-203:~$ sudo salt-standalone-proxy '*' test.ping
[WARNING ] Temporary logging is already configured
[WARNING ] Temporary logging is already configured
[WARNING ] Console logging already configured
[WARNING ] Console logging already configured
[WARNING ] Logfile logging already configured
[WARNING ] Insecure logging configuration detected! Sensitive data may be logged.
[WARNING ] Logfile logging already configured
[WARNING ] Insecure logging configuration detected! Sensitive data may be logged.
The Salt ProxyMinion is shutdown.
dummy:
    True
ip-172-31-9-203.us-east-2.compute.internal:
    True
vmx1:
    Minion did not return. [No response]
[WARNING ] ProxyMinion received a SIGTERM. Exiting.
The Salt ProxyMinion is shutdown. ProxyMinion received a SIGTERM. Exited.
```

(`vmx1` was on purpose tested as down, as it couldn't establish the connection to the remote device)

And the process tree is:

```
root     19821  0.0  0.0  40544  3432 pts/0    S+   14:04   0:00  |           \_ sudo salt-standalone-proxy * test.ping
root     19822 16.0  1.0 206100 41704 pts/0    S+   14:04   0:00  |               \_ /usr/bin/python /usr/local/bin/salt-standalone-proxy * test.ping
root     19832 38.0  1.1 452388 47804 pts/0    Sl+  14:04   0:00  |                   \_ /usr/bin/python /usr/local/bin/salt-standalone-proxy * test.ping
root     19833 43.0  1.2 453476 49236 pts/0    Sl+  14:04   0:00  |                   \_ /usr/bin/python /usr/local/bin/salt-standalone-proxy * test.ping
```

I know it's not ideal, but I wanted to discuss first and hear your thoughts.

Pinging @thatch45 @cro @cachedout 

Thanks!