### PR TITLE
Add grains (and optionally pillar) to salt.cmd runner

### DIFF
--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -1520,6 +1520,7 @@ DEFAULT_MASTER_OPTS = {
     'env_order': [],
     'saltenv': None,
     'lock_saltenv': False,
+    'pillarenv': None,
     'default_top': 'base',
     'file_client': 'local',
     'git_pillar_base': 'master',

--- a/salt/runners/salt.py
+++ b/salt/runners/salt.py
@@ -31,11 +31,14 @@ Execution modules are also available to salt runners:
 '''
 # import python libs
 from __future__ import absolute_import, print_function, unicode_literals
+import copy
 import logging
 
 # import salt libs
 import salt.client
-from salt.loader import minion_mods, utils
+import salt.loader
+import salt.pillar
+import salt.utils.args
 from salt.exceptions import SaltClientError
 
 log = logging.getLogger(__name__)  # pylint: disable=invalid-name
@@ -43,12 +46,29 @@ log = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
 def cmd(fun, *args, **kwargs):
     '''
-    Execute ``fun`` with the given ``args`` and ``kwargs``.
-    Parameter ``fun`` should be the string :ref:`name <all-salt.modules>`
-    of the execution module to call.
+    .. versionchanged:: Oxygen
+        Added ``with_pillar`` argument
 
-    Note that execution modules will be *loaded every time*
-    this function is called.
+    Execute ``fun`` with the given ``args`` and ``kwargs``.  Parameter ``fun``
+    should be the string :ref:`name <all-salt.modules>` of the execution module
+    to call.
+
+    .. note::
+        Execution modules will be loaded *every time* this function is called.
+        Additionally, keep in mind that since runners execute on the master,
+        custom execution modules will need to be synced to the master using
+        :py:func:`salt-run saltutil.sync_modules
+        <salt.runners.saltutil.sync_modules>`, otherwise they will not be
+        available.
+
+    with_pillar : False
+        If ``True``, pillar data will be compiled for the master
+
+        .. note::
+            To target the master in pillar data, keep in mind that the
+            default ``id`` for the master is ``<hostname>_master``. This can be
+            overridden by setting an ``id`` configuration parameter in the
+            master config file.
 
     CLI example:
 
@@ -57,15 +77,33 @@ def cmd(fun, *args, **kwargs):
         salt-run salt.cmd test.ping
         # call functions with arguments and keyword arguments
         salt-run salt.cmd test.arg 1 2 3 a=1
+        salt-run salt.cmd mymod.myfunc with_pillar=True
     '''
     log.debug('Called salt.cmd runner with minion function %s', fun)
 
-    kws = dict((k, v) for k, v in kwargs.items() if not k.startswith('__'))
+    kwargs = salt.utils.args.clean_kwargs(**kwargs)
+    with_pillar = kwargs.pop('with_pillar', False)
 
-    # pylint: disable=undefined-variable
-    return minion_mods(
-        __opts__,
-        utils=utils(__opts__)).get(fun)(*args, **kws)
+    opts = copy.deepcopy(__opts__)
+    opts['grains'] = salt.loader.grains(opts)
+
+    if with_pillar:
+        opts['pillar'] = salt.pillar.get_pillar(
+            opts,
+            opts['grains'],
+            opts['id'],
+            saltenv=opts['saltenv'],
+            pillarenv=opts.get('pillarenv')).compile_pillar()
+    else:
+        opts['pillar'] = {}
+
+    functions = salt.loader.minion_mods(
+        opts,
+        utils=salt.loader.utils(opts))
+
+    return functions[fun](*args, **kwargs) \
+        if fun in functions \
+        else '\'{0}\' is not available.'.format(fun)
 
 
 def execute(tgt,

--- a/salt/runners/salt.py
+++ b/salt/runners/salt.py
@@ -65,7 +65,7 @@ def cmd(fun, *args, **kwargs):
         If ``True``, pillar data will be compiled for the master
 
         .. note::
-            To target the master in pillar data, keep in mind that the
+            To target the master in the pillar top file, keep in mind that the
             default ``id`` for the master is ``<hostname>_master``. This can be
             overridden by setting an ``id`` configuration parameter in the
             master config file.

--- a/salt/utils/minions.py
+++ b/salt/utils/minions.py
@@ -228,7 +228,7 @@ class CkMinions(object):
         Retreive complete minion list from PKI dir.
         Respects cache if configured
         '''
-        if self.opts.get('__role') == 'master':
+        if self.opts.get('__role') == 'master' and self.opts.get('__cli') == 'salt-run':
             # Compiling pillar directly on the master, just return the master's
             # ID as that is the only one that is available.
             return [self.opts['id']]

--- a/salt/utils/minions.py
+++ b/salt/utils/minions.py
@@ -228,6 +228,10 @@ class CkMinions(object):
         Retreive complete minion list from PKI dir.
         Respects cache if configured
         '''
+        if self.opts.get('__role') == 'master':
+            # Compiling pillar directly on the master, just return the master's
+            # ID as that is the only one that is available.
+            return [self.opts['id']]
         minions = []
         pki_cache_fn = os.path.join(self.opts['pki_dir'], self.acc, '.key_cache')
         try:
@@ -241,7 +245,10 @@ class CkMinions(object):
                         minions.append(fn_)
             return minions
         except OSError as exc:
-            log.error('Encountered OSError while evaluating  minions in PKI dir: {0}'.format(exc))
+            log.error(
+                'Encountered OSError while evaluating minions in PKI dir: %s',
+                exc
+            )
             return minions
 
     def _check_cache_minions(self,


### PR DESCRIPTION
Not having grains was an oversight, it causes a lot of errors in processing the `__virtual__` functions. Additionally, the `__pillar__` dunder did not exist, so anything that referenced it would result in a traceback.