### PR TITLE
Fix issue with unsafe path in Windows jenkins tests

### DIFF
--- a/salt/utils/verify.py
+++ b/salt/utils/verify.py
@@ -536,7 +536,14 @@ def win_verify_env(path, dirs, permissive=False, pki_dir='', skip_extra=False):
 
     # Make sure the file_roots is not set to something unsafe since permissions
     # on that directory are reset
-    if not salt.utils.path.safe_path(path=path):
+
+    # `salt.utils.path.safe_path` will consider anything inside `C:\Windows` to
+    # be unsafe. In some instances the test suite uses
+    # `C:\Windows\Temp\salt-tests-tmpdir\rootdir` as the file_roots. So, we need
+    # to consider anything in `C:\Windows\Temp` to be safe
+    system_root = os.environ.get('SystemRoot', r'C:\Windows')
+    allow_path = '\\'.join([system_root, 'TEMP'])
+    if not salt.utils.path.safe_path(path=path, allow_path=allow_path):
         raise CommandExecutionError(
             '`file_roots` set to a possibly unsafe location: {0}'.format(path)
         )


### PR DESCRIPTION
### What does this PR do?
Considers directories in `C:\Windows\Temp` to be safe for modification.

The test suite was failing to start for Windows because the test suite places the `root_dir` in the temp directory. This is fine when run manually as it is place in the User's temp dir. However, in some cases, the temp dir is actually `C:\Windows\Temp`. This was causing integration tests to fail to start because the root_dir was in an 'unsafe' location (`C:\Windows\Temp\salt-tests-tmpdir\root_dir`) and the Master/Minion/Syndic/etc couldn't start.

### Jenkins tests will not run on Windows until this is in.

### What issues does this PR fix or reference?
Found in testing.

### Previous Behavior
Master/Minion/etc would not start...

### New Behavior
Master/Minion/etc now start...

### Tests written?
No

### Commits signed with GPG?
Yes