### PR TITLE
Force Salt's YAML loader to load all strings as unicode types

### DIFF
--- a/salt/utils/yamlloader.py
+++ b/salt/utils/yamlloader.py
@@ -5,10 +5,9 @@ Custom YAML loading in Salt
 
 # Import python libs
 from __future__ import absolute_import, print_function, unicode_literals
+import re
 import warnings
 
-# Import third party libs
-import re
 import yaml  # pylint: disable=blacklisted-import
 from yaml.nodes import MappingNode, SequenceNode
 from yaml.constructor import ConstructorError
@@ -17,6 +16,8 @@ try:
     yaml.Dumper = yaml.CDumper
 except Exception:
     pass
+
+import salt.utils.stringutils
 
 __all__ = ['SaltYamlSafeLoader', 'load', 'safe_load']
 
@@ -46,6 +47,9 @@ class SaltYamlSafeLoader(yaml.SafeLoader, object):
             self.add_constructor(
                 'tag:yaml.org,2002:omap',
                 type(self).construct_yaml_map)
+        self.add_constructor(
+            'tag:yaml.org,2002:str',
+            type(self).construct_yaml_str)
         self.add_constructor(
             'tag:yaml.org,2002:python/unicode',
             type(self).construct_unicode)
@@ -118,6 +122,10 @@ class SaltYamlSafeLoader(yaml.SafeLoader, object):
             if re.match(r'^u([\'"]).+\1$', node.value, flags=re.IGNORECASE):
                 node.value = eval(node.value, {}, {})  # pylint: disable=W0123
         return super(SaltYamlSafeLoader, self).construct_scalar(node)
+
+    def construct_yaml_str(self, node):
+        value = self.construct_scalar(node)
+        return salt.utils.stringutils.to_unicode(value)
 
     def flatten_mapping(self, node):
         merge = []

--- a/tests/unit/utils/test_yamlloader.py
+++ b/tests/unit/utils/test_yamlloader.py
@@ -5,6 +5,7 @@
 
 # Import python libs
 from __future__ import absolute_import, print_function, unicode_literals
+import collections
 import textwrap
 
 # Import Salt Libs
@@ -17,6 +18,9 @@ from salt.ext import six
 from tests.support.unit import TestCase, skipIf
 from tests.support.mock import patch, NO_MOCK, NO_MOCK_REASON, mock_open
 
+# Import 3rd-party libs
+from salt.ext import six
+
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
 class YamlLoaderTestCase(TestCase):
@@ -25,7 +29,7 @@ class YamlLoaderTestCase(TestCase):
     '''
 
     @staticmethod
-    def _render_yaml(data):
+    def render_yaml(data):
         '''
         Takes a YAML string, puts it into a mock file, passes that to the YAML
         SaltYamlSafeLoader and then returns the rendered/parsed YAML data
@@ -41,12 +45,37 @@ class YamlLoaderTestCase(TestCase):
             with salt.utils.files.fopen(mocked_file) as mocked_stream:
                 return SaltYamlSafeLoader(mocked_stream).get_data()
 
+    @staticmethod
+    def raise_error(value):
+        raise TypeError('{0!r} is not a unicode string'.format(value))  # pylint: disable=repr-flag-used-in-string
+
+    def assert_unicode(self, value):
+        '''
+        Make sure the entire data structure is unicode
+        '''
+        if six.PY3:
+            return
+        if isinstance(value, six.string_types):
+            if not isinstance(value, six.text_type):
+                self.raise_error(value)
+        elif isinstance(value, collections.Mapping):
+            for k, v in six.iteritems(value):
+                self.assert_unicode(k)
+                self.assert_unicode(v)
+        elif isinstance(value, collections.Iterable):
+            for item in value:
+                self.assert_unicode(item)
+
+    def assert_matches(self, ret, expected):
+        self.assertEqual(ret, expected)
+        self.assert_unicode(ret)
+
     def test_yaml_basics(self):
         '''
         Test parsing an ordinary path
         '''
-        self.assertEqual(
-            self._render_yaml(textwrap.dedent('''\
+        self.assert_matches(
+            self.render_yaml(textwrap.dedent('''\
                 p1:
                   - alpha
                   - beta''')),
@@ -58,8 +87,8 @@ class YamlLoaderTestCase(TestCase):
         Test YAML anchors
         '''
         # Simple merge test
-        self.assertEqual(
-            self._render_yaml(textwrap.dedent('''\
+        self.assert_matches(
+            self.render_yaml(textwrap.dedent('''\
                 p1: &p1
                   v1: alpha
                 p2:
@@ -69,8 +98,8 @@ class YamlLoaderTestCase(TestCase):
         )
 
         # Test that keys/nodes are overwritten
-        self.assertEqual(
-            self._render_yaml(textwrap.dedent('''\
+        self.assert_matches(
+            self.render_yaml(textwrap.dedent('''\
                 p1: &p1
                   v1: alpha
                 p2:
@@ -80,8 +109,8 @@ class YamlLoaderTestCase(TestCase):
         )
 
         # Test merging of lists
-        self.assertEqual(
-            self._render_yaml(textwrap.dedent('''\
+        self.assert_matches(
+            self.render_yaml(textwrap.dedent('''\
                 p1: &p1
                   v1: &v1
                     - t1
@@ -96,12 +125,12 @@ class YamlLoaderTestCase(TestCase):
         Test that duplicates still throw an error
         '''
         with self.assertRaises(ConstructorError):
-            self._render_yaml(textwrap.dedent('''\
+            self.render_yaml(textwrap.dedent('''\
                 p1: alpha
                 p1: beta'''))
 
         with self.assertRaises(ConstructorError):
-            self._render_yaml(textwrap.dedent('''\
+            self.render_yaml(textwrap.dedent('''\
                 p1: &p1
                   v1: alpha
                 p2:
@@ -113,8 +142,8 @@ class YamlLoaderTestCase(TestCase):
         '''
         Test proper loading of unicode literals
         '''
-        self.assertEqual(
-            self._render_yaml(textwrap.dedent('''\
+        self.assert_matches(
+            self.render_yaml(textwrap.dedent('''\
                 foo:
                   a: Д
                   b: {'a': u'\\u0414'}''')),


### PR DESCRIPTION
This reduces the likelihood that non-unicode strings make their way into Salt and cause str/unicode mismatches resulting in UnicodeDecodeErrors.