### PR TITLE
Fix TypeError during rbenv ruby installation when rbenv is not found

### DIFF
--- a/salt/modules/rbenv.py
+++ b/salt/modules/rbenv.py
@@ -245,7 +245,7 @@ def install_ruby(ruby, runas=None):
 
     ret = {}
     ret = _rbenv_exec(['install', ruby], env=env, runas=runas, ret=ret)
-    if ret['retcode'] == 0:
+    if ret is not False and ret['retcode'] == 0:
         rehash(runas=runas)
         return ret['stderr']
     else:


### PR DESCRIPTION
### What does this PR do?

This PR fixes the `TypeError: 'bool' object has no attribute '__getitem__'` error during execution of **rbenv.installed** state. Error occurred when salt couldn't find rbenv. Now state execution finishes with "Failed to install ruby" message in that case.

### What issues does this PR fix or reference?

Related to #44811.

### Tests written?

No

### Commits signed with GPG?

No