### PR TITLE
change beacons.enable_job to beacons.enable_beacon

### DIFF
--- a/salt/states/beacon.py
+++ b/salt/states/beacon.py
@@ -173,7 +173,7 @@ def enabled(name, **kwargs):
             result = __salt__['beacons.enable_beacon'](name, **kwargs)
             ret['comment'].append(result['comment'])
         else:
-            result = __salt__['beacons.enable_job'](name, **kwargs)
+            result = __salt__['beacons.enable_beacon'](name, **kwargs)
             if not result['result']:
                 ret['result'] = result['result']
                 ret['comment'] = result['comment']


### PR DESCRIPTION
### What does this PR do?
There was an error in beacon state module that invoke missing beacons.enable_job execution function. 
this PR correct it by invoking beacons.enable_beacon instead.

### Tests written?

No

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
