### PR TITLE
Distinguish between Authorization and Authentication errors

### DIFF
--- a/doc/topics/releases/oxygen.rst
+++ b/doc/topics/releases/oxygen.rst
@@ -284,6 +284,16 @@ master config file, the master will create a SaltSSH client process which
 connects to the minion and returns the output for the `salt` commandline to use
 like a regular minion. This can be used anywhere the LocalClient is used.
 
+Exceptions Raised for Authentication/Authorization Errors
+---------------------------------------------------------
+
+When sending ``publish`` commands via ``master.py`` and ``masterapi.py`` and an
+authorization or authentication problem is encountered, Salt will now raise the
+appropriate exceptions instead of returning an empty string: ``''``.
+
+The reasoning behind this change is to make it easier to debug various scenarios
+surrounding authentication and authorization issues more effectively.
+
 Comparison Operators in Package Installation
 --------------------------------------------
 

--- a/salt/cli/salt.py
+++ b/salt/cli/salt.py
@@ -13,6 +13,8 @@ import salt.utils.stringutils
 from salt.utils.args import yamlify_arg
 from salt.utils.verify import verify_log
 from salt.exceptions import (
+    AuthenticationError,
+    AuthorizationError,
     EauthAuthenticationError,
     LoaderError,
     SaltClientError,
@@ -210,7 +212,11 @@ class SaltCMD(salt.utils.parsers.SaltCMDOptionParser):
                 sys.stderr.write('ERROR: Minions returned with non-zero exit code\n')
                 sys.exit(11)
 
-        except (SaltInvocationError, EauthAuthenticationError, SaltClientError) as exc:
+        except (AuthenticationError,
+                AuthorizationError,
+                SaltInvocationError,
+                EauthAuthenticationError,
+                SaltClientError) as exc:
             ret = six.text_type(exc)
             self._output_ret(ret, '', retcode=1)
 

--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -45,8 +45,13 @@ import salt.utils.versions
 import salt.utils.zeromq
 import salt.syspaths as syspaths
 from salt.exceptions import (
-    EauthAuthenticationError, SaltInvocationError, SaltReqTimeoutError,
-    SaltClientError, PublishError
+    AuthenticationError,
+    AuthorizationError,
+    EauthAuthenticationError,
+    PublishError,
+    SaltInvocationError,
+    SaltReqTimeoutError,
+    SaltClientError
 )
 
 # Import third party libs
@@ -1830,6 +1835,14 @@ class LocalClient(object):
 
         error = payload.pop('error', None)
         if error is not None:
+            if isinstance(error, dict):
+                err_name = error.get('name', '')
+                err_msg = error.get('message', '')
+                if err_name == 'AuthenticationError':
+                    raise AuthenticationError(err_msg)
+                elif err_name == 'AuthorizationError':
+                    raise AuthorizationError(err_msg)
+
             raise PublishError(error)
 
         if not payload:
@@ -1939,6 +1952,14 @@ class LocalClient(object):
 
         error = payload.pop('error', None)
         if error is not None:
+            if isinstance(error, dict):
+                err_name = error.get('name', '')
+                err_msg = error.get('message', '')
+                if err_name == 'AuthenticationError':
+                    raise AuthenticationError(err_msg)
+                elif err_name == 'AuthorizationError':
+                    raise AuthorizationError(err_msg)
+
             raise PublishError(error)
 
         if not payload:

--- a/salt/master.py
+++ b/salt/master.py
@@ -51,6 +51,7 @@ import tornado.gen  # pylint: disable=F0401
 import salt.crypt
 import salt.client
 import salt.client.ssh.client
+import salt.exceptions
 import salt.payload
 import salt.pillar
 import salt.state
@@ -85,7 +86,6 @@ import salt.utils.verify
 import salt.utils.zeromq
 from salt.config import DEFAULT_INTERVAL
 from salt.defaults import DEFAULT_TARGET_DELIM
-from salt.exceptions import FileserverConfigError
 from salt.transport import iter_transport_opts
 from salt.utils.debug import (
     enable_sigusr1_handler, enable_sigusr2_handler, inspect_stack
@@ -596,7 +596,7 @@ class Master(SMaster):
                 # double-check configuration
                 try:
                     fileserver.init()
-                except FileserverConfigError as exc:
+                except salt.exceptions.FileserverConfigError as exc:
                     critical_errors.append('{0}'.format(exc))
 
         if not self.opts['fileserver_backend']:
@@ -629,7 +629,7 @@ class Master(SMaster):
                                 repo['git'],
                                 per_remote_overrides=salt.pillar.git_pillar.PER_REMOTE_OVERRIDES,
                                 per_remote_only=salt.pillar.git_pillar.PER_REMOTE_ONLY)
-                        except FileserverConfigError as exc:
+                        except salt.exceptions.FileserverConfigError as exc:
                             critical_errors.append(exc.strerror)
                 finally:
                     del new_opts
@@ -2021,7 +2021,8 @@ class ClearFuncs(object):
                 'your local administrator if you believe this is in '
                 'error.\n', clear_load['user'], clear_load['fun']
             )
-            return ''
+            return {'error': {'name': 'AuthorizationError',
+                              'message': 'Authorization error occurred.'}}
 
         # Retrieve the minions list
         delimiter = clear_load.get('kwargs', {}).get('delimiter', DEFAULT_TARGET_DELIM)
@@ -2047,7 +2048,8 @@ class ClearFuncs(object):
         if auth_check.get('error'):
             # Authentication error occurred: do not continue.
             log.warning(err_msg)
-            return ''
+            return {'error': {'name': 'AuthenticationError',
+                              'message': 'Authentication error occurred.'}}
 
         # All Token, Eauth, and non-root users must pass the authorization check
         if auth_type != 'user' or (auth_type == 'user' and auth_list):
@@ -2066,7 +2068,8 @@ class ClearFuncs(object):
             if not authorized:
                 # Authorization error occurred. Do not continue.
                 log.warning(err_msg)
-                return ''
+                return {'error': {'name': 'AuthorizationError',
+                                  'message': 'Authorization error occurred.'}}
 
             # Perform some specific auth_type tasks after the authorization check
             if auth_type == 'token':

--- a/salt/netapi/rest_cherrypy/app.py
+++ b/salt/netapi/rest_cherrypy/app.py
@@ -856,7 +856,9 @@ def hypermedia_handler(*args, **kwargs):
     try:
         cherrypy.response.processors = dict(ct_out_map)
         ret = cherrypy.serving.request._hypermedia_inner_handler(*args, **kwargs)
-    except (salt.exceptions.EauthAuthenticationError,
+    except (salt.exceptions.AuthenticationError,
+            salt.exceptions.AuthorizationError,
+            salt.exceptions.EauthAuthenticationError,
             salt.exceptions.TokenAuthenticationError):
         raise cherrypy.HTTPError(401)
     except salt.exceptions.SaltInvocationError:

--- a/salt/netapi/rest_tornado/saltnado.py
+++ b/salt/netapi/rest_tornado/saltnado.py
@@ -219,7 +219,11 @@ from salt.utils.event import tagify
 import salt.client
 import salt.runner
 import salt.auth
-from salt.exceptions import EauthAuthenticationError
+from salt.exceptions import (
+    AuthenticationError,
+    AuthorizationError,
+    EauthAuthenticationError
+)
 
 json = salt.utils.json.import_json()
 log = logging.getLogger(__name__)
@@ -899,7 +903,7 @@ class SaltAPIHandler(BaseSaltAPIHandler, SaltClientsMixIn):  # pylint: disable=W
             try:
                 chunk_ret = yield getattr(self, '_disbatch_{0}'.format(low['client']))(low)
                 ret.append(chunk_ret)
-            except EauthAuthenticationError as exc:
+            except (AuthenticationError, AuthorizationError, EauthAuthenticationError):
                 ret.append('Failed to authenticate')
                 break
             except Exception as ex:

--- a/tests/integration/netapi/rest_tornado/test_app.py
+++ b/tests/integration/netapi/rest_tornado/test_app.py
@@ -238,7 +238,7 @@ class TestSaltAPIHandler(_SaltnadoIntegrationTestCase):
         self.assertEqual(len(ret), 3)  # make sure we got 3 responses
         self.assertIn('jid', ret[0])  # the first 2 are regular returns
         self.assertIn('jid', ret[1])
-        self.assertIn('Failed to authenticate', ret[2])  # bad auth
+        self.assertIn('Authentication error occurred.', ret[2])  # bad auth
         self.assertEqual(ret[0]['minions'], sorted(['minion', 'sub_minion']))
         self.assertEqual(ret[1]['minions'], sorted(['minion', 'sub_minion']))
 

--- a/tests/integration/shell/test_auth.py
+++ b/tests/integration/shell/test_auth.py
@@ -115,7 +115,7 @@ class AuthTest(ShellCase):
                '--username nouser --password {0}'.format('abcd1234'))
         resp = self.run_salt(cmd)
         self.assertTrue(
-            'Failed to authenticate' in ''.join(resp)
+            'Authentication error occurred.' in ''.join(resp)
         )
 
     def test_pam_auth_valid_group(self):

--- a/tests/unit/daemons/test_masterapi.py
+++ b/tests/unit/daemons/test_masterapi.py
@@ -65,7 +65,7 @@ class AutoKeyTest(TestCase):
 
     def setUp(self):
         opts = salt.config.master_config(None)
-        opts[u'user'] = u'test_user'
+        opts['user'] = 'test_user'
         self.auto_key = masterapi.AutoKey(opts)
         self.stats = {}
 
@@ -153,9 +153,9 @@ class AutoKeyTest(TestCase):
 
     def _test_check_autosign_grains(self,
                                     test_func,
-                                    file_content=u'test_value',
-                                    file_name=u'test_grain',
-                                    autosign_grains_dir=u'test_dir',
+                                    file_content='test_value',
+                                    file_name='test_grain',
+                                    autosign_grains_dir='test_dir',
                                     permissions_ret=True):
         '''
         Helper function for testing autosign_grains().
@@ -166,7 +166,7 @@ class AutoKeyTest(TestCase):
         are passed to the function as arguments.
         '''
         if autosign_grains_dir:
-            self.auto_key.opts[u'autosign_grains_dir'] = autosign_grains_dir
+            self.auto_key.opts['autosign_grains_dir'] = autosign_grains_dir
         mock_file = io.StringIO(file_content)
         mock_dirs = [(None, None, [file_name])]
 
@@ -199,7 +199,7 @@ class AutoKeyTest(TestCase):
         is undefined.
         '''
         def test_func(mock_walk, mock_open, mock_permissions):
-            self.assertFalse(self.auto_key.check_autosign_grains({u'test_grain': u'test_value'}))
+            self.assertFalse(self.auto_key.check_autosign_grains({'test_grain': 'test_value'}))
             self.assertEqual(mock_walk.call_count, 0)
             self.assertEqual(mock_open.call_count, 0)
             self.assertEqual(mock_permissions.call_count, 0)
@@ -212,9 +212,9 @@ class AutoKeyTest(TestCase):
         autosign_grain file.
         '''
         def test_func(*args):
-            self.assertTrue(self.auto_key.check_autosign_grains({u'test_grain': u'test_value'}))
+            self.assertTrue(self.auto_key.check_autosign_grains({'test_grain': 'test_value'}))
 
-        file_content = u'#test_ignore\ntest_value'
+        file_content = '#test_ignore\ntest_value'
         self._test_check_autosign_grains(test_func, file_content=file_content)
 
     def test_check_autosign_grains_accept_not(self):
@@ -223,9 +223,9 @@ class AutoKeyTest(TestCase):
         autosign_grain files.
         '''
         def test_func(*args):
-            self.assertFalse(self.auto_key.check_autosign_grains({u'test_grain': u'test_invalid'}))
+            self.assertFalse(self.auto_key.check_autosign_grains({'test_grain': 'test_invalid'}))
 
-        file_content = u'#test_invalid\ntest_value'
+        file_content = '#test_invalid\ntest_value'
         self._test_check_autosign_grains(test_func, file_content=file_content)
 
     def test_check_autosign_grains_invalid_file_permissions(self):
@@ -233,9 +233,9 @@ class AutoKeyTest(TestCase):
         Asserts that autosigning from grains fails when the grain file has the wrong permissions.
         '''
         def test_func(*args):
-            self.assertFalse(self.auto_key.check_autosign_grains({u'test_grain': u'test_value'}))
+            self.assertFalse(self.auto_key.check_autosign_grains({'test_grain': 'test_value'}))
 
-        file_content = u'#test_ignore\ntest_value'
+        file_content = '#test_ignore\ntest_value'
         self._test_check_autosign_grains(test_func, file_content=file_content, permissions_ret=False)
 
 
@@ -255,9 +255,9 @@ class LocalFuncsTestCase(TestCase):
         '''
         Asserts that a TokenAuthenticationError is returned when the token can't authenticate.
         '''
-        mock_ret = {u'error': {u'name': u'TokenAuthenticationError',
-                               u'message': u'Authentication failure of type "token" occurred.'}}
-        ret = self.local_funcs.runner({u'token': u'asdfasdfasdfasdf'})
+        mock_ret = {'error': {'name': 'TokenAuthenticationError',
+                              'message': 'Authentication failure of type "token" occurred.'}}
+        ret = self.local_funcs.runner({'token': 'asdfasdfasdfasdf'})
         self.assertDictEqual(mock_ret, ret)
 
     def test_runner_token_authorization_error(self):
@@ -265,12 +265,12 @@ class LocalFuncsTestCase(TestCase):
         Asserts that a TokenAuthenticationError is returned when the token authenticates, but is
         not authorized.
         '''
-        token = u'asdfasdfasdfasdf'
-        load = {u'token': token, u'fun': u'test.arg', u'kwarg': {}}
-        mock_token = {u'token': token, u'eauth': u'foo', u'name': u'test'}
-        mock_ret = {u'error': {u'name': u'TokenAuthenticationError',
-                               u'message': u'Authentication failure of type "token" occurred '
-                                           u'for user test.'}}
+        token = 'asdfasdfasdfasdf'
+        load = {'token': token, 'fun': 'test.arg', 'kwarg': {}}
+        mock_token = {'token': token, 'eauth': 'foo', 'name': 'test'}
+        mock_ret = {'error': {'name': 'TokenAuthenticationError',
+                              'message': 'Authentication failure of type "token" occurred '
+                                         'for user test.'}}
 
         with patch('salt.auth.LoadAuth.authenticate_token', MagicMock(return_value=mock_token)), \
              patch('salt.auth.LoadAuth.get_auth_list', MagicMock(return_value=[])):
@@ -283,11 +283,11 @@ class LocalFuncsTestCase(TestCase):
         Asserts that a SaltInvocationError is returned when the token authenticates, but the
         command is malformed.
         '''
-        token = u'asdfasdfasdfasdf'
-        load = {u'token': token, u'fun': u'badtestarg', u'kwarg': {}}
-        mock_token = {u'token': token, u'eauth': u'foo', u'name': u'test'}
-        mock_ret = {u'error': {u'name': u'SaltInvocationError',
-                               u'message': u'A command invocation error occurred: Check syntax.'}}
+        token = 'asdfasdfasdfasdf'
+        load = {'token': token, 'fun': 'badtestarg', 'kwarg': {}}
+        mock_token = {'token': token, 'eauth': 'foo', 'name': 'test'}
+        mock_ret = {'error': {'name': 'SaltInvocationError',
+                              'message': 'A command invocation error occurred: Check syntax.'}}
 
         with patch('salt.auth.LoadAuth.authenticate_token', MagicMock(return_value=mock_token)), \
              patch('salt.auth.LoadAuth.get_auth_list', MagicMock(return_value=['testing'])):
@@ -299,10 +299,10 @@ class LocalFuncsTestCase(TestCase):
         '''
         Asserts that an EauthAuthenticationError is returned when the user can't authenticate.
         '''
-        mock_ret = {u'error': {u'name': u'EauthAuthenticationError',
-                               u'message': u'Authentication failure of type "eauth" occurred for '
-                                           u'user UNKNOWN.'}}
-        ret = self.local_funcs.runner({u'eauth': u'foo'})
+        mock_ret = {'error': {'name': 'EauthAuthenticationError',
+                              'message': 'Authentication failure of type "eauth" occurred for '
+                                         'user UNKNOWN.'}}
+        ret = self.local_funcs.runner({'eauth': 'foo'})
         self.assertDictEqual(mock_ret, ret)
 
     def test_runner_eauth_authorization_error(self):
@@ -310,10 +310,10 @@ class LocalFuncsTestCase(TestCase):
         Asserts that an EauthAuthenticationError is returned when the user authenticates, but is
         not authorized.
         '''
-        load = {u'eauth': u'foo', u'username': u'test', u'fun': u'test.arg', u'kwarg': {}}
-        mock_ret = {u'error': {u'name': u'EauthAuthenticationError',
-                               u'message': u'Authentication failure of type "eauth" occurred for '
-                                           u'user test.'}}
+        load = {'eauth': 'foo', 'username': 'test', 'fun': 'test.arg', 'kwarg': {}}
+        mock_ret = {'error': {'name': 'EauthAuthenticationError',
+                              'message': 'Authentication failure of type "eauth" occurred for '
+                                         'user test.'}}
         with patch('salt.auth.LoadAuth.authenticate_eauth', MagicMock(return_value=True)), \
              patch('salt.auth.LoadAuth.get_auth_list', MagicMock(return_value=[])):
             ret = self.local_funcs.runner(load)
@@ -325,9 +325,9 @@ class LocalFuncsTestCase(TestCase):
         Asserts that an EauthAuthenticationError is returned when the user authenticates, but the
         command is malformed.
         '''
-        load = {u'eauth': u'foo', u'username': u'test', u'fun': u'bad.test.arg.func', u'kwarg': {}}
-        mock_ret = {u'error': {u'name': u'SaltInvocationError',
-                               u'message': u'A command invocation error occurred: Check syntax.'}}
+        load = {'eauth': 'foo', 'username': 'test', 'fun': 'bad.test.arg.func', 'kwarg': {}}
+        mock_ret = {'error': {'name': 'SaltInvocationError',
+                              'message': 'A command invocation error occurred: Check syntax.'}}
         with patch('salt.auth.LoadAuth.authenticate_eauth', MagicMock(return_value=True)), \
              patch('salt.auth.LoadAuth.get_auth_list', MagicMock(return_value=['testing'])):
             ret = self.local_funcs.runner(load)
@@ -340,9 +340,9 @@ class LocalFuncsTestCase(TestCase):
         '''
         Asserts that a TokenAuthenticationError is returned when the token can't authenticate.
         '''
-        mock_ret = {u'error': {u'name': u'TokenAuthenticationError',
-                               u'message': u'Authentication failure of type "token" occurred.'}}
-        ret = self.local_funcs.wheel({u'token': u'asdfasdfasdfasdf'})
+        mock_ret = {'error': {'name': 'TokenAuthenticationError',
+                              'message': 'Authentication failure of type "token" occurred.'}}
+        ret = self.local_funcs.wheel({'token': 'asdfasdfasdfasdf'})
         self.assertDictEqual(mock_ret, ret)
 
     def test_wheel_token_authorization_error(self):
@@ -350,12 +350,12 @@ class LocalFuncsTestCase(TestCase):
         Asserts that a TokenAuthenticationError is returned when the token authenticates, but is
         not authorized.
         '''
-        token = u'asdfasdfasdfasdf'
-        load = {u'token': token, u'fun': u'test.arg', u'kwarg': {}}
-        mock_token = {u'token': token, u'eauth': u'foo', u'name': u'test'}
-        mock_ret = {u'error': {u'name': u'TokenAuthenticationError',
-                               u'message': u'Authentication failure of type "token" occurred '
-                                           u'for user test.'}}
+        token = 'asdfasdfasdfasdf'
+        load = {'token': token, 'fun': 'test.arg', 'kwarg': {}}
+        mock_token = {'token': token, 'eauth': 'foo', 'name': 'test'}
+        mock_ret = {'error': {'name': 'TokenAuthenticationError',
+                              'message': 'Authentication failure of type "token" occurred '
+                                         'for user test.'}}
 
         with patch('salt.auth.LoadAuth.authenticate_token', MagicMock(return_value=mock_token)), \
              patch('salt.auth.LoadAuth.get_auth_list', MagicMock(return_value=[])):
@@ -368,11 +368,11 @@ class LocalFuncsTestCase(TestCase):
         Asserts that a SaltInvocationError is returned when the token authenticates, but the
         command is malformed.
         '''
-        token = u'asdfasdfasdfasdf'
-        load = {u'token': token, u'fun': u'badtestarg', u'kwarg': {}}
-        mock_token = {u'token': token, u'eauth': u'foo', u'name': u'test'}
-        mock_ret = {u'error': {u'name': u'SaltInvocationError',
-                               u'message': u'A command invocation error occurred: Check syntax.'}}
+        token = 'asdfasdfasdfasdf'
+        load = {'token': token, 'fun': 'badtestarg', 'kwarg': {}}
+        mock_token = {'token': token, 'eauth': 'foo', 'name': 'test'}
+        mock_ret = {'error': {'name': 'SaltInvocationError',
+                              'message': 'A command invocation error occurred: Check syntax.'}}
 
         with patch('salt.auth.LoadAuth.authenticate_token', MagicMock(return_value=mock_token)), \
              patch('salt.auth.LoadAuth.get_auth_list', MagicMock(return_value=['testing'])):
@@ -384,10 +384,10 @@ class LocalFuncsTestCase(TestCase):
         '''
         Asserts that an EauthAuthenticationError is returned when the user can't authenticate.
         '''
-        mock_ret = {u'error': {u'name': u'EauthAuthenticationError',
-                               u'message': u'Authentication failure of type "eauth" occurred for '
-                                           u'user UNKNOWN.'}}
-        ret = self.local_funcs.wheel({u'eauth': u'foo'})
+        mock_ret = {'error': {'name': 'EauthAuthenticationError',
+                              'message': 'Authentication failure of type "eauth" occurred for '
+                                         'user UNKNOWN.'}}
+        ret = self.local_funcs.wheel({'eauth': 'foo'})
         self.assertDictEqual(mock_ret, ret)
 
     def test_wheel_eauth_authorization_error(self):
@@ -395,10 +395,10 @@ class LocalFuncsTestCase(TestCase):
         Asserts that an EauthAuthenticationError is returned when the user authenticates, but is
         not authorized.
         '''
-        load = {u'eauth': u'foo', u'username': u'test', u'fun': u'test.arg', u'kwarg': {}}
-        mock_ret = {u'error': {u'name': u'EauthAuthenticationError',
-                               u'message': u'Authentication failure of type "eauth" occurred for '
-                                           u'user test.'}}
+        load = {'eauth': 'foo', 'username': 'test', 'fun': 'test.arg', 'kwarg': {}}
+        mock_ret = {'error': {'name': 'EauthAuthenticationError',
+                              'message': 'Authentication failure of type "eauth" occurred for '
+                                         'user test.'}}
         with patch('salt.auth.LoadAuth.authenticate_eauth', MagicMock(return_value=True)), \
              patch('salt.auth.LoadAuth.get_auth_list', MagicMock(return_value=[])):
             ret = self.local_funcs.wheel(load)
@@ -410,9 +410,9 @@ class LocalFuncsTestCase(TestCase):
         Asserts that an EauthAuthenticationError is returned when the user authenticates, but the
         command is malformed.
         '''
-        load = {u'eauth': u'foo', u'username': u'test', u'fun': u'bad.test.arg.func', u'kwarg': {}}
-        mock_ret = {u'error': {u'name': u'SaltInvocationError',
-                               u'message': u'A command invocation error occurred: Check syntax.'}}
+        load = {'eauth': 'foo', 'username': 'test', 'fun': 'bad.test.arg.func', 'kwarg': {}}
+        mock_ret = {'error': {'name': 'SaltInvocationError',
+                              'message': 'A command invocation error occurred: Check syntax.'}}
         with patch('salt.auth.LoadAuth.authenticate_eauth', MagicMock(return_value=True)), \
              patch('salt.auth.LoadAuth.get_auth_list', MagicMock(return_value=['testing'])):
             ret = self.local_funcs.wheel(load)
@@ -423,9 +423,9 @@ class LocalFuncsTestCase(TestCase):
         '''
         Asserts that an UserAuthenticationError is returned when the user can't authenticate.
         '''
-        mock_ret = {u'error': {u'name': u'UserAuthenticationError',
-                               u'message': u'Authentication failure of type "user" occurred for '
-                                           u'user UNKNOWN.'}}
+        mock_ret = {'error': {'name': 'UserAuthenticationError',
+                              'message': 'Authentication failure of type "user" occurred for '
+                                         'user UNKNOWN.'}}
         ret = self.local_funcs.wheel({})
         self.assertDictEqual(mock_ret, ret)
 
@@ -433,103 +433,121 @@ class LocalFuncsTestCase(TestCase):
 
     def test_publish_user_is_blacklisted(self):
         '''
-        Asserts that an empty string is returned when the user has been blacklisted.
+        Asserts that an AuthorizationError is returned when the user has been blacklisted.
         '''
+        mock_ret = {'error': {'name': 'AuthorizationError',
+                              'message': 'Authorization error occurred.'}}
         with patch('salt.acl.PublisherACL.user_is_blacklisted', MagicMock(return_value=True)):
-            self.assertEqual(u'', self.local_funcs.publish({u'user': u'foo', u'fun': u'test.arg'}))
+            self.assertEqual(mock_ret, self.local_funcs.publish({'user': 'foo', 'fun': 'test.arg'}))
 
     def test_publish_cmd_blacklisted(self):
         '''
-        Asserts that an empty string returned when the command has been blacklisted.
+        Asserts that an AuthorizationError is returned when the command has been blacklisted.
         '''
+        mock_ret = {'error': {'name': 'AuthorizationError',
+                              'message': 'Authorization error occurred.'}}
         with patch('salt.acl.PublisherACL.user_is_blacklisted', MagicMock(return_value=False)), \
                 patch('salt.acl.PublisherACL.cmd_is_blacklisted', MagicMock(return_value=True)):
-            self.assertEqual(u'', self.local_funcs.publish({u'user': u'foo', u'fun': u'test.arg'}))
+            self.assertEqual(mock_ret, self.local_funcs.publish({'user': 'foo', 'fun': 'test.arg'}))
 
     def test_publish_token_not_authenticated(self):
         '''
-        Asserts that an empty string is returned when the token can't authenticate.
+        Asserts that an AuthenticationError is returned when the token can't authenticate.
         '''
-        load = {u'user': u'foo', u'fun': u'test.arg', u'tgt': u'test_minion',
-                u'kwargs': {u'token': u'asdfasdfasdfasdf'}}
+        load = {'user': 'foo', 'fun': 'test.arg', 'tgt': 'test_minion',
+                'kwargs': {'token': 'asdfasdfasdfasdf'}}
+        mock_ret = {'error': {'name': 'AuthenticationError',
+                              'message': 'Authentication error occurred.'}}
         with patch('salt.acl.PublisherACL.user_is_blacklisted', MagicMock(return_value=False)), \
                 patch('salt.acl.PublisherACL.cmd_is_blacklisted', MagicMock(return_value=False)):
-            self.assertEqual(u'', self.local_funcs.publish(load))
+            self.assertEqual(mock_ret, self.local_funcs.publish(load))
 
     def test_publish_token_authorization_error(self):
         '''
-        Asserts that an empty string is returned when the token authenticates, but is not
+        Asserts that an AuthorizationError is returned when the token authenticates, but is not
         authorized.
         '''
-        token = u'asdfasdfasdfasdf'
-        load = {u'user': u'foo', u'fun': u'test.arg', u'tgt': u'test_minion',
-                u'arg': u'bar', u'kwargs': {u'token': token}}
-        mock_token = {u'token': token, u'eauth': u'foo', u'name': u'test'}
+        token = 'asdfasdfasdfasdf'
+        load = {'user': 'foo', 'fun': 'test.arg', 'tgt': 'test_minion',
+                'arg': 'bar', 'kwargs': {'token': token}}
+        mock_token = {'token': token, 'eauth': 'foo', 'name': 'test'}
+        mock_ret = {'error': {'name': 'AuthorizationError',
+                              'message': 'Authorization error occurred.'}}
 
         with patch('salt.acl.PublisherACL.user_is_blacklisted', MagicMock(return_value=False)), \
                 patch('salt.acl.PublisherACL.cmd_is_blacklisted', MagicMock(return_value=False)), \
                 patch('salt.auth.LoadAuth.authenticate_token', MagicMock(return_value=mock_token)), \
                 patch('salt.auth.LoadAuth.get_auth_list', MagicMock(return_value=[])):
-            self.assertEqual(u'', self.local_funcs.publish(load))
+            self.assertEqual(mock_ret, self.local_funcs.publish(load))
 
     def test_publish_eauth_not_authenticated(self):
         '''
-        Asserts that an empty string is returned when the user can't authenticate.
+        Asserts that an AuthenticationError is returned when the user can't authenticate.
         '''
-        load = {u'user': u'test', u'fun': u'test.arg', u'tgt': u'test_minion',
-                u'kwargs': {u'eauth': u'foo'}}
+        load = {'user': 'test', 'fun': 'test.arg', 'tgt': 'test_minion',
+                'kwargs': {'eauth': 'foo'}}
+        mock_ret = {'error': {'name': 'AuthenticationError',
+                              'message': 'Authentication error occurred.'}}
         with patch('salt.acl.PublisherACL.user_is_blacklisted', MagicMock(return_value=False)), \
                 patch('salt.acl.PublisherACL.cmd_is_blacklisted', MagicMock(return_value=False)):
-            self.assertEqual(u'', self.local_funcs.publish(load))
+            self.assertEqual(mock_ret, self.local_funcs.publish(load))
 
     def test_publish_eauth_authorization_error(self):
         '''
-        Asserts that an empty string is returned when the user authenticates, but is not
+        Asserts that an AuthorizationError is returned when the user authenticates, but is not
         authorized.
         '''
-        load = {u'user': u'test', u'fun': u'test.arg', u'tgt': u'test_minion',
-                u'kwargs': {u'eauth': u'foo'}, u'arg': u'bar'}
+        load = {'user': 'test', 'fun': 'test.arg', 'tgt': 'test_minion',
+                'kwargs': {'eauth': 'foo'}, 'arg': 'bar'}
+        mock_ret = {'error': {'name': 'AuthorizationError',
+                              'message': 'Authorization error occurred.'}}
         with patch('salt.acl.PublisherACL.user_is_blacklisted', MagicMock(return_value=False)), \
                 patch('salt.acl.PublisherACL.cmd_is_blacklisted', MagicMock(return_value=False)), \
                 patch('salt.auth.LoadAuth.authenticate_eauth', MagicMock(return_value=True)), \
                 patch('salt.auth.LoadAuth.get_auth_list', MagicMock(return_value=[])):
-            self.assertEqual(u'', self.local_funcs.publish(load))
+            self.assertEqual(mock_ret, self.local_funcs.publish(load))
 
     def test_publish_user_not_authenticated(self):
         '''
-        Asserts that an empty string is returned when the user can't authenticate.
+        Asserts that an AuthenticationError is returned when the user can't authenticate.
         '''
-        load = {u'user': u'test', u'fun': u'test.arg', u'tgt': u'test_minion'}
+        load = {'user': 'test', 'fun': 'test.arg', 'tgt': 'test_minion'}
+        mock_ret = {'error': {'name': 'AuthenticationError',
+                              'message': 'Authentication error occurred.'}}
         with patch('salt.acl.PublisherACL.user_is_blacklisted', MagicMock(return_value=False)), \
                 patch('salt.acl.PublisherACL.cmd_is_blacklisted', MagicMock(return_value=False)):
-            self.assertEqual(u'', self.local_funcs.publish(load))
+            self.assertEqual(mock_ret, self.local_funcs.publish(load))
 
     def test_publish_user_authenticated_missing_auth_list(self):
         '''
-        Asserts that an empty string is returned when the user has an effective user id and is
+        Asserts that an AuthenticationError is returned when the user has an effective user id and is
         authenticated, but the auth_list is empty.
         '''
-        load = {u'user': u'test', u'fun': u'test.arg', u'tgt': u'test_minion',
-                u'kwargs': {u'user': u'test'}, u'arg': u'foo'}
+        load = {'user': 'test', 'fun': 'test.arg', 'tgt': 'test_minion',
+                'kwargs': {'user': 'test'}, 'arg': 'foo'}
+        mock_ret = {'error': {'name': 'AuthenticationError',
+                              'message': 'Authentication error occurred.'}}
         with patch('salt.acl.PublisherACL.user_is_blacklisted', MagicMock(return_value=False)), \
                 patch('salt.acl.PublisherACL.cmd_is_blacklisted', MagicMock(return_value=False)), \
                 patch('salt.auth.LoadAuth.authenticate_key', MagicMock(return_value='fake-user-key')), \
                 patch('salt.utils.master.get_values_of_matching_keys', MagicMock(return_value=[])):
-            self.assertEqual(u'', self.local_funcs.publish(load))
+            self.assertEqual(mock_ret, self.local_funcs.publish(load))
 
     def test_publish_user_authorization_error(self):
         '''
-        Asserts that an empty string is returned when the user authenticates, but is not
+        Asserts that an AuthorizationError is returned when the user authenticates, but is not
         authorized.
         '''
-        load = {u'user': u'test', u'fun': u'test.arg', u'tgt': u'test_minion',
-                u'kwargs': {u'user': u'test'}, u'arg': u'foo'}
+        load = {'user': 'test', 'fun': 'test.arg', 'tgt': 'test_minion',
+                'kwargs': {'user': 'test'}, 'arg': 'foo'}
+        mock_ret = {'error': {'name': 'AuthorizationError',
+                              'message': 'Authorization error occurred.'}}
         with patch('salt.acl.PublisherACL.user_is_blacklisted', MagicMock(return_value=False)), \
                 patch('salt.acl.PublisherACL.cmd_is_blacklisted', MagicMock(return_value=False)), \
                 patch('salt.auth.LoadAuth.authenticate_key', MagicMock(return_value='fake-user-key')), \
                 patch('salt.utils.master.get_values_of_matching_keys', MagicMock(return_value=['test'])), \
                 patch('salt.utils.minions.CkMinions.auth_check', MagicMock(return_value=False)):
-            self.assertEqual(u'', self.local_funcs.publish(load))
+            self.assertEqual(mock_ret, self.local_funcs.publish(load))
 
 
 class FakeCache(object):

--- a/tests/unit/test_master.py
+++ b/tests/unit/test_master.py
@@ -216,100 +216,118 @@ class ClearFuncsTestCase(TestCase):
 
     def test_publish_user_is_blacklisted(self):
         '''
-        Asserts that an empty string is returned when the user has been blacklisted.
+        Asserts that an AuthorizationError is returned when the user has been blacklisted.
         '''
+        mock_ret = {'error': {'name': 'AuthorizationError',
+                              'message': 'Authorization error occurred.'}}
         with patch('salt.acl.PublisherACL.user_is_blacklisted', MagicMock(return_value=True)):
-            self.assertEqual('', self.clear_funcs.publish({'user': 'foo', 'fun': 'test.arg'}))
+            self.assertEqual(mock_ret, self.clear_funcs.publish({'user': 'foo', 'fun': 'test.arg'}))
 
     def test_publish_cmd_blacklisted(self):
         '''
-        Asserts that an empty string returned when the command has been blacklisted.
+        Asserts that an AuthorizationError is returned when the command has been blacklisted.
         '''
+        mock_ret = {'error': {'name': 'AuthorizationError',
+                              'message': 'Authorization error occurred.'}}
         with patch('salt.acl.PublisherACL.user_is_blacklisted', MagicMock(return_value=False)), \
                 patch('salt.acl.PublisherACL.cmd_is_blacklisted', MagicMock(return_value=True)):
-            self.assertEqual('', self.clear_funcs.publish({'user': 'foo', 'fun': 'test.arg'}))
+            self.assertEqual(mock_ret, self.clear_funcs.publish({'user': 'foo', 'fun': 'test.arg'}))
 
     def test_publish_token_not_authenticated(self):
         '''
-        Asserts that an empty string is returned when the token can't authenticate.
+        Asserts that an AuthenticationError is returned when the token can't authenticate.
         '''
+        mock_ret = {'error': {'name': 'AuthenticationError',
+                              'message': 'Authentication error occurred.'}}
         load = {'user': 'foo', 'fun': 'test.arg', 'tgt': 'test_minion',
                 'kwargs': {'token': 'asdfasdfasdfasdf'}}
         with patch('salt.acl.PublisherACL.user_is_blacklisted', MagicMock(return_value=False)), \
                 patch('salt.acl.PublisherACL.cmd_is_blacklisted', MagicMock(return_value=False)):
-            self.assertEqual('', self.clear_funcs.publish(load))
+            self.assertEqual(mock_ret, self.clear_funcs.publish(load))
 
     def test_publish_token_authorization_error(self):
         '''
-        Asserts that an empty string is returned when the token authenticates, but is not
+        Asserts that an AuthorizationError is returned when the token authenticates, but is not
         authorized.
         '''
         token = 'asdfasdfasdfasdf'
         load = {'user': 'foo', 'fun': 'test.arg', 'tgt': 'test_minion',
                 'arg': 'bar', 'kwargs': {'token': token}}
         mock_token = {'token': token, 'eauth': 'foo', 'name': 'test'}
+        mock_ret = {'error': {'name': 'AuthorizationError',
+                              'message': 'Authorization error occurred.'}}
 
         with patch('salt.acl.PublisherACL.user_is_blacklisted', MagicMock(return_value=False)), \
                 patch('salt.acl.PublisherACL.cmd_is_blacklisted', MagicMock(return_value=False)), \
                 patch('salt.auth.LoadAuth.authenticate_token', MagicMock(return_value=mock_token)), \
                 patch('salt.auth.LoadAuth.get_auth_list', MagicMock(return_value=[])):
-            self.assertEqual('', self.clear_funcs.publish(load))
+            self.assertEqual(mock_ret, self.clear_funcs.publish(load))
 
     def test_publish_eauth_not_authenticated(self):
         '''
-        Asserts that an empty string is returned when the user can't authenticate.
+        Asserts that an AuthenticationError is returned when the user can't authenticate.
         '''
         load = {'user': 'test', 'fun': 'test.arg', 'tgt': 'test_minion',
                 'kwargs': {'eauth': 'foo'}}
+        mock_ret = {'error': {'name': 'AuthenticationError',
+                               'message': 'Authentication error occurred.'}}
         with patch('salt.acl.PublisherACL.user_is_blacklisted', MagicMock(return_value=False)), \
                 patch('salt.acl.PublisherACL.cmd_is_blacklisted', MagicMock(return_value=False)):
-            self.assertEqual('', self.clear_funcs.publish(load))
+            self.assertEqual(mock_ret, self.clear_funcs.publish(load))
 
     def test_publish_eauth_authorization_error(self):
         '''
-        Asserts that an empty string is returned when the user authenticates, but is not
+        Asserts that an AuthorizationError is returned when the user authenticates, but is not
         authorized.
         '''
         load = {'user': 'test', 'fun': 'test.arg', 'tgt': 'test_minion',
                 'kwargs': {'eauth': 'foo'}, 'arg': 'bar'}
+        mock_ret = {'error': {'name': 'AuthorizationError',
+                               'message': 'Authorization error occurred.'}}
         with patch('salt.acl.PublisherACL.user_is_blacklisted', MagicMock(return_value=False)), \
                 patch('salt.acl.PublisherACL.cmd_is_blacklisted', MagicMock(return_value=False)), \
                 patch('salt.auth.LoadAuth.authenticate_eauth', MagicMock(return_value=True)), \
                 patch('salt.auth.LoadAuth.get_auth_list', MagicMock(return_value=[])):
-            self.assertEqual('', self.clear_funcs.publish(load))
+            self.assertEqual(mock_ret, self.clear_funcs.publish(load))
 
     def test_publish_user_not_authenticated(self):
         '''
-        Asserts that an empty string is returned when the user can't authenticate.
+        Asserts that an AuthenticationError is returned when the user can't authenticate.
         '''
         load = {'user': 'test', 'fun': 'test.arg', 'tgt': 'test_minion'}
+        mock_ret = {'error': {'name': 'AuthenticationError',
+                              'message': 'Authentication error occurred.'}}
         with patch('salt.acl.PublisherACL.user_is_blacklisted', MagicMock(return_value=False)), \
                 patch('salt.acl.PublisherACL.cmd_is_blacklisted', MagicMock(return_value=False)):
-            self.assertEqual('', self.clear_funcs.publish(load))
+            self.assertEqual(mock_ret, self.clear_funcs.publish(load))
 
     def test_publish_user_authenticated_missing_auth_list(self):
         '''
-        Asserts that an empty string is returned when the user has an effective user id and is
+        Asserts that an AuthenticationError is returned when the user has an effective user id and is
         authenticated, but the auth_list is empty.
         '''
         load = {'user': 'test', 'fun': 'test.arg', 'tgt': 'test_minion',
                 'kwargs': {'user': 'test'}, 'arg': 'foo'}
+        mock_ret = {'error': {'name': 'AuthenticationError',
+                              'message': 'Authentication error occurred.'}}
         with patch('salt.acl.PublisherACL.user_is_blacklisted', MagicMock(return_value=False)), \
                 patch('salt.acl.PublisherACL.cmd_is_blacklisted', MagicMock(return_value=False)), \
                 patch('salt.auth.LoadAuth.authenticate_key', MagicMock(return_value='fake-user-key')), \
                 patch('salt.utils.master.get_values_of_matching_keys', MagicMock(return_value=[])):
-            self.assertEqual('', self.clear_funcs.publish(load))
+            self.assertEqual(mock_ret, self.clear_funcs.publish(load))
 
     def test_publish_user_authorization_error(self):
         '''
-        Asserts that an empty string is returned when the user authenticates, but is not
+        Asserts that an AuthorizationError is returned when the user authenticates, but is not
         authorized.
         '''
         load = {'user': 'test', 'fun': 'test.arg', 'tgt': 'test_minion',
                 'kwargs': {'user': 'test'}, 'arg': 'foo'}
+        mock_ret = {'error': {'name': 'AuthorizationError',
+                              'message': 'Authorization error occurred.'}}
         with patch('salt.acl.PublisherACL.user_is_blacklisted', MagicMock(return_value=False)), \
                 patch('salt.acl.PublisherACL.cmd_is_blacklisted', MagicMock(return_value=False)), \
                 patch('salt.auth.LoadAuth.authenticate_key', MagicMock(return_value='fake-user-key')), \
                 patch('salt.utils.master.get_values_of_matching_keys', MagicMock(return_value=['test'])), \
                 patch('salt.utils.minions.CkMinions.auth_check', MagicMock(return_value=False)):
-            self.assertEqual('', self.clear_funcs.publish(load))
+            self.assertEqual(mock_ret, self.clear_funcs.publish(load))


### PR DESCRIPTION
### What does this PR do?
And handle the error distinction being returned from the publish function instead of sending empty strings.

I ran some basic tests on this already, but I want to see how the test suite does.

### What issues does this PR fix or reference?
Issues:
- #6420
- #34750
- #35160

PRs:
- #43203
- #43703

### Previous Behavior
The publish functions in master.py and masterapi.py would return an empty string whenever authentication or authorization errors occurred. This makes it difficult to debug various scenarios surrounding authentication vs authorization. This change paves the way for being able to start distinguishing the scenarios and issues more effectively.

### New Behavior
When auth errors occur, a dictionary is returned that contains the error information. This is consistent with what the runner and wheel functions do as well. This error is then handled in the LocalClient's `pub` and `pub_async` functions.

### Tests written?

Yes

### Commits signed with GPG?

Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
