### PR TITLE
make status.version work on OpenBSD

### DIFF
--- a/salt/modules/status.py
+++ b/salt/modules/status.py
@@ -1438,6 +1438,9 @@ def version():
     .. versionchanged:: 2016.11.4
         Added support for AIX
 
+    .. versionchanged:: Oxygen
+        Added support for OpenBSD
+
     CLI Example:
 
     .. code-block:: bash
@@ -1454,10 +1457,17 @@ def version():
         except IOError:
             return {}
 
+    def bsd_version():
+        '''
+        bsd specific implementation of version
+        '''
+        return __salt__['cmd.run']('sysctl -n kern.version')
+
     # dict that returns a function that does the right thing per platform
     get_version = {
         'Linux': linux_version,
-        'FreeBSD': lambda: __salt__['cmd.run']('sysctl -n kern.version'),
+        'FreeBSD': bsd_version,
+        'OpenBSD': bsd_version,
         'AIX': lambda: __salt__['cmd.run']('oslevel -s'),
     }
 


### PR DESCRIPTION
### What does this PR do?

It fixes `status.version` for OpenBSD

### Previous Behavior

```
salt# salt \* status.version
salt.localdomain:
    This method is unsupported on the current operating system!
```

### New Behavior

```
salt# salt \* status.version
salt.localdomain:
    OpenBSD 6.2-current (GENERIC) #236: Fri Dec  1 08:34:19 MST 2017
        deraadt@amd64.openbsd.org:/usr/src/sys/arch/amd64/compile/GENERIC
```

### Tests written?

No

### Commits signed with GPG?

Yes

Please cherry-pick this to the `2017.7` branch too.