### PR TITLE
status.meminfo: add OpenBSD support

### DIFF
--- a/salt/modules/status.py
+++ b/salt/modules/status.py
@@ -447,6 +447,9 @@ def meminfo():
     .. versionchanged:: 2016.11.4
         Added support for AIX
 
+    .. versionchanged:: Oxygen
+        Added support for OpenBSD
+
     CLI Example:
 
     .. code-block:: bash
@@ -574,10 +577,25 @@ def meminfo():
 
         return ret
 
+    def openbsd_meminfo():
+        '''
+        openbsd specific implementation of meminfo
+        '''
+        vmstat = __salt__['cmd.run']('vmstat').splitlines()
+        # We're only interested in memory and page values which are printed
+        # as subsequent fields.
+        fields = ['active virtual pages', 'free list size', 'page faults',
+                  'pages reclaimed', 'pages paged in', 'pages paged out',
+                  'pages freed', 'pages scanned']
+        data = vmstat[2].split()[2:10]
+        ret = dict(zip(fields, data))
+        return ret
+
     # dict that return a function that does the right thing per platform
     get_version = {
         'Linux': linux_meminfo,
         'FreeBSD': freebsd_meminfo,
+        'OpenBSD': openbsd_meminfo,
         'AIX': aix_meminfo,
     }
 

--- a/tests/unit/modules/test_status.py
+++ b/tests/unit/modules/test_status.py
@@ -235,3 +235,34 @@ class StatusTestCase(TestCase, LoaderModuleMockMixin):
                 with patch.dict(status.__salt__, {'cmd.run': MagicMock(return_value=sysctl)}):
                     ret = status.cpuinfo()
                     self.assertDictEqual(ret, m.ret)
+
+    def _set_up_test_meminfo_openbsd(self):
+        class MockData(object):
+            '''
+            Store mock data
+            '''
+
+        m = MockData()
+        m.ret = {
+            'active virtual pages': '355M',
+            'free list size': '305M',
+            'page faults': '845',
+            'pages reclaimed': '1',
+            'pages paged in': '2',
+            'pages paged out': '3',
+            'pages freed': '4',
+            'pages scanned': '5'
+        }
+
+        return m
+
+    def test_meminfo_openbsd(self):
+        m = self._set_up_test_meminfo_openbsd()
+        vmstat = ' procs    memory       page                    disks    traps          cpu\n' \
+                 ' r   s   avm     fre  flt  re  pi  po  fr  sr cd0 sd0  int   sys   cs us sy id\n' \
+                 ' 2 103  355M    305M  845   1   2   3   4   5   0   1   21   682   86  1  1 98'
+
+        with patch.dict(status.__grains__, {'kernel': 'OpenBSD'}):
+            with patch.dict(status.__salt__, {'cmd.run': MagicMock(return_value=vmstat)}):
+                ret = status.meminfo()
+                self.assertDictEqual(ret, m.ret)


### PR DESCRIPTION

### What does this PR do?

Add OpenBSD support to `status.meminfo`

### Previous Behavior

```
salt# salt \* status.meminfo
salt.localdomain:
    This method is unsupported on the current operating system!
```

### New Behavior

```
salt# salt \* status.meminfo
salt.localdomain:
    ----------
    avm:
        379M
    flt:
        601
    fr:
        0
    fre:
        220M
    pi:
        0
    po:
        0
    re:
        0
    sr:
        0
```

These fields are documented in `vmstat(8)` however I could also display them as somewhat more descriptive fields (`active virtual pages`, `page faults`, etc).

### Tests written?

No

### Commits signed with GPG?

Yes

Please cherry-pick this to the `2017.7` branch too.