### PR TITLE
joyent: fix default image_url in documentation

### DIFF
--- a/salt/cloud/clouds/joyent.py
+++ b/salt/cloud/clouds/joyent.py
@@ -821,7 +821,7 @@ def avail_images(call=None):
 
     .. code-block:: yaml
 
-        image_url: images.joyent.com/image
+        image_url: images.joyent.com/images
     '''
     if call == 'action':
         raise SaltCloudSystemExit(


### PR DESCRIPTION
### What does this PR do?

Sync the documentation for `image_url` with the actual default as used in the code.

### Tests written?

No

### Commits signed with GPG?

Yes