### PR TITLE
Fix salt-master for old psutil

### DIFF
--- a/salt/utils/psutil_compat.py
+++ b/salt/utils/psutil_compat.py
@@ -26,7 +26,7 @@ else:
     # Psuedo "from psutil import *"
     _globals = globals()
     for attr in psutil.__all__:
-        _temp = __import__('psutil', globals(), locals(), [attr], -1)
+        _temp = __import__('psutil', globals(), locals(), [attr], -1 if six.PY2 else 0)
         try:
             _globals[attr] = getattr(_temp, attr)
         except AttributeError:


### PR DESCRIPTION
### What does this PR do?

Reopening PR https://github.com/saltstack/salt/pull/44885 (closed by me with a wrong rebase)

salt-master wouldn't start with old psutil version (<2) when python3 is used

```
Traceback (most recent call last):
  File "/usr/bin/salt-master", line 22, in <module>
    salt_master()
  File "/usr/lib/python3.4/site-packages/salt/scripts.py", line 92, in salt_master
    master.start()
  File "/usr/lib/python3.4/site-packages/salt/cli/daemons.py", line 204, in start
    super(Master, self).start()
  File "/usr/lib/python3.4/site-packages/salt/utils/parsers.py", line 1032, in start
    self.prepare()
  File "/usr/lib/python3.4/site-packages/salt/cli/daemons.py", line 184, in prepare
    import salt.master
  File "/usr/lib/python3.4/site-packages/salt/master.py", line 53, in <module>
    import salt.pillar
  File "/usr/lib/python3.4/site-packages/salt/pillar/__init__.py", line 19, in <module>
    import salt.minion
  File "/usr/lib/python3.4/site-packages/salt/minion.py", line 59, in <module>
    import salt.utils.psutil_compat as psutil
  File "/usr/lib/python3.4/site-packages/salt/utils/psutil_compat.py", line 29, in <module>
    _temp = __import__('psutil', globals(), locals(), [attr], -1)
ValueError: level must be >= 0
```

### What issues does this PR fix or reference?

According to python documentation, __import__ is different in PY2 and PY3

PY2: `spam = __import__('spam', globals(), locals(), [], -1)` https://docs.python.org/2.7/library/functions.html#__import__
PY3: `spam = __import__('spam', globals(), locals(), [], 0)` https://docs.python.org/3.5/library/functions.html#__import__

### Tests written?

No

### Commits signed with GPG?

No