### PR TITLE
Libcloud dns fixes

### DIFF
--- a/salt/modules/libcloud_dns.py
+++ b/salt/modules/libcloud_dns.py
@@ -70,7 +70,7 @@ def __init__(opts):
 def _get_driver(profile):
     config = __salt__['config.option']('libcloud_dns')[profile]
     cls = get_driver(config['driver'])
-    args = config
+    args = config.copy()
     del args['driver']
     args['key'] = config.get('key')
     args['secret'] = config.get('secret', None)

--- a/salt/states/libcloud_dns.py
+++ b/salt/states/libcloud_dns.py
@@ -59,8 +59,13 @@ def __init__(opts):
     salt.utils.compat.pack_dunder(__name__)
 
 
-def state_result(result, message):
-    return {'result': result, 'comment': message}
+def state_result(name, result, message):
+    return {
+        'name': name,
+        'result': result,
+        'changes': {},
+        'comment': message
+    }
 
 
 def zone_present(domain, type, profile):
@@ -84,7 +89,7 @@ def zone_present(domain, type, profile):
         return state_result(True, "Zone already exists")
     else:
         result = __salt__['libcloud_dns.create_zone'](domain, profile, type)
-        return state_result(result, "Created new zone")
+        return state_result(domain, result, "Created new zone")
 
 
 def zone_absent(domain, profile):
@@ -103,7 +108,7 @@ def zone_absent(domain, profile):
         return state_result(True, "Zone already absent")
     else:
         result = __salt__['libcloud_dns.delete_zone'](matching_zone[0].id, profile)
-        return state_result(result, "Deleted zone")
+        return state_result(domain, result, "Deleted zone")
 
 
 def record_present(name, zone, type, data, profile):
@@ -142,9 +147,9 @@ def record_present(name, zone, type, data, profile):
         result = __salt__['libcloud_dns.create_record'](
             name, matching_zone.id,
             type, data, profile)
-        return state_result(result, "Created new record")
+        return state_result(name, result, "Created new record")
     else:
-        return state_result(True, "Record already exists")
+        return state_result(name, True, "Record already exists")
 
 
 def record_absent(name, zone, type, data, profile):
@@ -186,6 +191,6 @@ def record_absent(name, zone, type, data, profile):
                 matching_zone.id,
                 record.id,
                 profile))
-        return state_result(all(result), "Removed {0} records".format(len(result)))
+        return state_result(name, all(result), "Removed {0} records".format(len(result)))
     else:
-        return state_result(True, "Records already absent")
+        return state_result(name, True, "Records already absent")

--- a/salt/states/libcloud_dns.py
+++ b/salt/states/libcloud_dns.py
@@ -86,7 +86,7 @@ def zone_present(domain, type, profile):
         type = 'master'
     matching_zone = [z for z in zones if z.domain == domain]
     if len(matching_zone) > 0:
-        return state_result(True, "Zone already exists")
+        return state_result(domain, True, 'Zone already exists')
     else:
         result = __salt__['libcloud_dns.create_zone'](domain, profile, type)
         return state_result(domain, result, 'Created new zone')

--- a/salt/states/libcloud_dns.py
+++ b/salt/states/libcloud_dns.py
@@ -89,7 +89,7 @@ def zone_present(domain, type, profile):
         return state_result(True, "Zone already exists")
     else:
         result = __salt__['libcloud_dns.create_zone'](domain, profile, type)
-        return state_result(domain, result, "Created new zone")
+        return state_result(domain, result, 'Created new zone')
 
 
 def zone_absent(domain, profile):
@@ -105,10 +105,10 @@ def zone_absent(domain, profile):
     zones = __salt__['libcloud_dns.list_zones'](profile)
     matching_zone = [z for z in zones if z.domain == domain]
     if len(matching_zone) == 0:
-        return state_result(True, "Zone already absent")
+        return state_result(domain, True, 'Zone already absent')
     else:
         result = __salt__['libcloud_dns.delete_zone'](matching_zone[0].id, profile)
-        return state_result(domain, result, "Deleted zone")
+        return state_result(domain, result, 'Deleted zone')
 
 
 def record_present(name, zone, type, data, profile):
@@ -137,7 +137,7 @@ def record_present(name, zone, type, data, profile):
     try:
         matching_zone = [z for z in zones if z.domain == zone][0]
     except IndexError:
-        return state_result(False, "Could not locate zone")
+        return state_result(zone, False, 'Could not locate zone')
     records = __salt__['libcloud_dns.list_records'](matching_zone.id, profile)
     matching_records = [record for record in records
                         if record.name == name and
@@ -147,9 +147,9 @@ def record_present(name, zone, type, data, profile):
         result = __salt__['libcloud_dns.create_record'](
             name, matching_zone.id,
             type, data, profile)
-        return state_result(name, result, "Created new record")
+        return state_result(name, result, 'Created new record')
     else:
-        return state_result(name, True, "Record already exists")
+        return state_result(name, True, 'Record already exists')
 
 
 def record_absent(name, zone, type, data, profile):
@@ -178,7 +178,7 @@ def record_absent(name, zone, type, data, profile):
     try:
         matching_zone = [z for z in zones if z.domain == zone][0]
     except IndexError:
-        return state_result(False, "Zone could not be found")
+        return state_result(zone, False, 'Zone could not be found')
     records = __salt__['libcloud_dns.list_records'](matching_zone.id, profile)
     matching_records = [record for record in records
                         if record.name == name and
@@ -191,6 +191,6 @@ def record_absent(name, zone, type, data, profile):
                 matching_zone.id,
                 record.id,
                 profile))
-        return state_result(name, all(result), "Removed {0} records".format(len(result)))
+        return state_result(name, all(result), 'Removed {0} records'.format(len(result)))
     else:
-        return state_result(name, True, "Records already absent")
+        return state_result(name, True, 'Records already absent')


### PR DESCRIPTION
### What does this PR do?
Fixes `libcloud_dns` 

### Previous Behavior
* Multiple records bug out with KeyError 'driver' while one exists in the config
* State always bugs out because output is missing `name` and `changes`

