### PR TITLE
Fix for wrong version processing

### DIFF
--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -1513,17 +1513,19 @@ def install(name=None,
             else:
                 pkgstr = pkgpath
 
+            # Lambda to trim the epoch from the currently-installed version if
+            # no epoch is specified in the specified version
+            norm_epoch = lambda x, y: x.split(':', 1)[-1] \
+                if ':' not in y \
+                else x
+
             cver = old_as_list.get(pkgname, [])
             if reinstall and cver:
                 for ver in cver:
-                    if diff_attr:
-                        # Since diff_attr was provided, the version info
-                        # is a dict.
-                        ver2 = ver['version']
-                    else:
-                        # No diff_attr was provided, so version is directly
-                        # in ver.
-                        ver2 = ver
+                    # if diff_attr was provided, version number is directly
+                    # in ver, otherwise its a dict.
+                    ver2 = ver['version'] if diff_attr else ver
+                    ver2 = norm_epoch(ver2, version_num)
                     if salt.utils.compare_versions(ver1=version_num,
                                                    oper='==',
                                                    ver2=ver2,
@@ -1537,14 +1539,10 @@ def install(name=None,
                     to_install.append((pkgname, pkgstr))
                 else:
                     for ver in cver:
-                        if diff_attr:
-                            # Since diff_attr was provided, the version info
-                            # is a dict.
-                            ver2 = ver['version']
-                        else:
-                            # No diff_attr was provided, so version is directly
-                            # in ver.
-                            ver2 = ver
+                        # if diff_attr was provided, version number is directly
+                        # in ver, otherwise its a dict.
+                        ver2 = ver['version'] if diff_attr else ver
+                        ver2 = norm_epoch(ver2, version_num)
                         if salt.utils.compare_versions(ver1=version_num,
                                                        oper='>=',
                                                        ver2=ver2,

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -1513,18 +1513,20 @@ def install(name=None,
             else:
                 pkgstr = pkgpath
 
-            # Lambda to trim the epoch from the currently-installed version if
-            # no epoch is specified in the specified version
-            norm_epoch = lambda x, y: x.split(':', 1)[-1] \
-                if ':' not in y \
-                else x
             cver = old_as_list.get(pkgname, [])
             if reinstall and cver:
                 for ver in cver:
-                    ver = norm_epoch(ver, version_num)
-                    if salt.utils.versions.compare(ver1=version_num,
+                    if diff_attr:
+                        # Since diff_attr was provided, the version info
+                        # is a dict.
+                        ver2 = ver['version']
+                    else:
+                        # No diff_attr was provided, so version is directly
+                        # in ver.
+                        ver2 = ver
+                    if salt.utils.compare_versions(ver1=version_num,
                                                    oper='==',
-                                                   ver2=ver,
+                                                   ver2=ver2,
                                                    cmp_func=version_cmp):
                         # This version is already installed, so we need to
                         # reinstall.
@@ -1535,10 +1537,17 @@ def install(name=None,
                     to_install.append((pkgname, pkgstr))
                 else:
                     for ver in cver:
-                        ver = norm_epoch(ver, version_num)
-                        if salt.utils.versions.compare(ver1=version_num,
+                        if diff_attr:
+                            # Since diff_attr was provided, the version info
+                            # is a dict.
+                            ver2 = ver['version']
+                        else:
+                            # No diff_attr was provided, so version is directly
+                            # in ver.
+                            ver2 = ver
+                        if salt.utils.compare_versions(ver1=version_num,
                                                        oper='>=',
-                                                       ver2=ver,
+                                                       ver2=ver2,
                                                        cmp_func=version_cmp):
                             to_install.append((pkgname, pkgstr))
                             break

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -1526,7 +1526,7 @@ def install(name=None,
                     # in ver, otherwise its a dict.
                     ver2 = ver['version'] if diff_attr else ver
                     ver2 = norm_epoch(ver2, version_num)
-                    if salt.utils.compare_versions(ver1=version_num,
+                    if salt.utils.versions.compare(ver1=version_num,
                                                    oper='==',
                                                    ver2=ver2,
                                                    cmp_func=version_cmp):
@@ -1543,7 +1543,7 @@ def install(name=None,
                         # in ver, otherwise its a dict.
                         ver2 = ver['version'] if diff_attr else ver
                         ver2 = norm_epoch(ver2, version_num)
-                        if salt.utils.compare_versions(ver1=version_num,
+                        if salt.utils.versions.compare(ver1=version_num,
                                                        oper='>=',
                                                        ver2=ver2,
                                                        cmp_func=version_cmp):

--- a/tests/unit/modules/test_yumpkg.py
+++ b/tests/unit/modules/test_yumpkg.py
@@ -27,6 +27,78 @@ class YumTestCase(TestCase, LoaderModuleMockMixin):
     def setup_loader_modules(self):
         return {yumpkg: {'rpm': None}}
 
+    def test_install_pkg(self):
+        '''
+        Test package installation.
+
+        :return:
+        '''
+        def _add_data(data, key, value):
+            data.setdefault(key, []).append(value)
+
+        rpm_out = [
+            'python-urlgrabber_|-(none)_|-3.10_|-8.el7_|-noarch_|-(none)_|-1487838471',
+            'alsa-lib_|-(none)_|-1.1.1_|-1.el7_|-x86_64_|-(none)_|-1487838475',
+            'gnupg2_|-(none)_|-2.0.22_|-4.el7_|-x86_64_|-(none)_|-1487838477',
+            'rpm-python_|-(none)_|-4.11.3_|-21.el7_|-x86_64_|-(none)_|-1487838477',
+            'pygpgme_|-(none)_|-0.3_|-9.el7_|-x86_64_|-(none)_|-1487838478',
+            'yum_|-(none)_|-3.4.3_|-150.el7.centos_|-noarch_|-(none)_|-1487838479',
+            'lzo_|-(none)_|-2.06_|-8.el7_|-x86_64_|-(none)_|-1487838479',
+            'qrencode-libs_|-(none)_|-3.4.1_|-3.el7_|-x86_64_|-(none)_|-1487838480',
+            'ustr_|-(none)_|-1.0.4_|-16.el7_|-x86_64_|-(none)_|-1487838480',
+            'shadow-utils_|-2_|-4.1.5.1_|-24.el7_|-x86_64_|-(none)_|-1487838481',
+            'util-linux_|-(none)_|-2.23.2_|-33.el7_|-x86_64_|-(none)_|-1487838484',
+            'openssh_|-(none)_|-6.6.1p1_|-33.el7_3_|-x86_64_|-(none)_|-1487838485',
+            'virt-what_|-(none)_|-1.13_|-8.el7_|-x86_64_|-(none)_|-1487838486',
+        ]
+        with patch.dict(yumpkg.__grains__, {'osarch': 'x86_64', 'os': 'RedHat'}), \
+             patch.dict(yumpkg.__salt__, {'cmd.run': MagicMock(return_value=os.linesep.join(rpm_out))}), \
+             patch.dict(yumpkg.__salt__, {'cmd.run_all': MagicMock(return_value={'retcode': 0})}), \
+             patch.dict(yumpkg.__salt__, {'pkg_resource.add_pkg': _add_data}), \
+             patch.dict(yumpkg.__salt__, {'pkg_resource.parse_targets': MagicMock(return_value=({'python-urlgrabber': '0.0.1'} , 'repository'))}), \
+             patch.dict(yumpkg.__salt__, {'pkg_resource.format_pkg_list': pkg_resource.format_pkg_list}), \
+             patch.dict(yumpkg.__salt__, {'config.get': MagicMock()}), \
+             patch.dict(yumpkg.__salt__, {'lowpkg.version_cmp': MagicMock(return_value=-1)}):
+            pkgs = yumpkg.install(name='python-urlgrabber')
+            self.assertEqual(pkgs, {})
+
+
+    def test_install_pkg_with_diff_attr(self):
+        '''
+        Test package installation with diff_attr.
+
+        :return:
+        '''
+        def _add_data(data, key, value):
+            data.setdefault(key, []).append(value)
+
+        rpm_out = [
+            'python-urlgrabber_|-(none)_|-3.10_|-8.el7_|-noarch_|-(none)_|-1487838471',
+            'alsa-lib_|-(none)_|-1.1.1_|-1.el7_|-x86_64_|-(none)_|-1487838475',
+            'gnupg2_|-(none)_|-2.0.22_|-4.el7_|-x86_64_|-(none)_|-1487838477',
+            'rpm-python_|-(none)_|-4.11.3_|-21.el7_|-x86_64_|-(none)_|-1487838477',
+            'pygpgme_|-(none)_|-0.3_|-9.el7_|-x86_64_|-(none)_|-1487838478',
+            'yum_|-(none)_|-3.4.3_|-150.el7.centos_|-noarch_|-(none)_|-1487838479',
+            'lzo_|-(none)_|-2.06_|-8.el7_|-x86_64_|-(none)_|-1487838479',
+            'qrencode-libs_|-(none)_|-3.4.1_|-3.el7_|-x86_64_|-(none)_|-1487838480',
+            'ustr_|-(none)_|-1.0.4_|-16.el7_|-x86_64_|-(none)_|-1487838480',
+            'shadow-utils_|-2_|-4.1.5.1_|-24.el7_|-x86_64_|-(none)_|-1487838481',
+            'util-linux_|-(none)_|-2.23.2_|-33.el7_|-x86_64_|-(none)_|-1487838484',
+            'openssh_|-(none)_|-6.6.1p1_|-33.el7_3_|-x86_64_|-(none)_|-1487838485',
+            'virt-what_|-(none)_|-1.13_|-8.el7_|-x86_64_|-(none)_|-1487838486',
+        ]
+        with patch.dict(yumpkg.__grains__, {'osarch': 'x86_64', 'os': 'RedHat'}), \
+             patch.dict(yumpkg.__salt__, {'cmd.run': MagicMock(return_value=os.linesep.join(rpm_out))}), \
+             patch.dict(yumpkg.__salt__, {'cmd.run_all': MagicMock(return_value={'retcode': 0})}), \
+             patch.dict(yumpkg.__salt__, {'pkg_resource.add_pkg': _add_data}), \
+             patch.dict(yumpkg.__salt__, {'pkg_resource.parse_targets': MagicMock(return_value=({'python-urlgrabber': '0.0.1'} , 'repository'))}), \
+             patch.dict(yumpkg.__salt__, {'pkg_resource.format_pkg_list': pkg_resource.format_pkg_list}), \
+             patch.dict(yumpkg.__salt__, {'config.get': MagicMock()}), \
+             patch.dict(yumpkg.__salt__, {'lowpkg.version_cmp': MagicMock(return_value=-1)}):
+            pkgs = yumpkg.install(name='python-urlgrabber', diff_attr=['version', 'epoch', 'release', 'arch'])
+            self.assertEqual(pkgs, {})
+
+
     def test_list_pkgs(self):
         '''
         Test packages listing.

--- a/tests/unit/modules/test_yumpkg.py
+++ b/tests/unit/modules/test_yumpkg.py
@@ -55,13 +55,12 @@ class YumTestCase(TestCase, LoaderModuleMockMixin):
              patch.dict(yumpkg.__salt__, {'cmd.run': MagicMock(return_value=os.linesep.join(rpm_out))}), \
              patch.dict(yumpkg.__salt__, {'cmd.run_all': MagicMock(return_value={'retcode': 0})}), \
              patch.dict(yumpkg.__salt__, {'pkg_resource.add_pkg': _add_data}), \
-             patch.dict(yumpkg.__salt__, {'pkg_resource.parse_targets': MagicMock(return_value=({'python-urlgrabber': '0.0.1'} , 'repository'))}), \
+             patch.dict(yumpkg.__salt__, {'pkg_resource.parse_targets': MagicMock(return_value=({'python-urlgrabber': '0.0.1'}, 'repository'))}), \
              patch.dict(yumpkg.__salt__, {'pkg_resource.format_pkg_list': pkg_resource.format_pkg_list}), \
              patch.dict(yumpkg.__salt__, {'config.get': MagicMock()}), \
              patch.dict(yumpkg.__salt__, {'lowpkg.version_cmp': MagicMock(return_value=-1)}):
             pkgs = yumpkg.install(name='python-urlgrabber')
             self.assertEqual(pkgs, {})
-
 
     def test_install_pkg_with_diff_attr(self):
         '''
@@ -91,13 +90,12 @@ class YumTestCase(TestCase, LoaderModuleMockMixin):
              patch.dict(yumpkg.__salt__, {'cmd.run': MagicMock(return_value=os.linesep.join(rpm_out))}), \
              patch.dict(yumpkg.__salt__, {'cmd.run_all': MagicMock(return_value={'retcode': 0})}), \
              patch.dict(yumpkg.__salt__, {'pkg_resource.add_pkg': _add_data}), \
-             patch.dict(yumpkg.__salt__, {'pkg_resource.parse_targets': MagicMock(return_value=({'python-urlgrabber': '0.0.1'} , 'repository'))}), \
+             patch.dict(yumpkg.__salt__, {'pkg_resource.parse_targets': MagicMock(return_value=({'python-urlgrabber': '0.0.1'}, 'repository'))}), \
              patch.dict(yumpkg.__salt__, {'pkg_resource.format_pkg_list': pkg_resource.format_pkg_list}), \
              patch.dict(yumpkg.__salt__, {'config.get': MagicMock()}), \
              patch.dict(yumpkg.__salt__, {'lowpkg.version_cmp': MagicMock(return_value=-1)}):
-            pkgs = yumpkg.install(name='python-urlgrabber', diff_attr=['version', 'epoch', 'release', 'arch'])
+            pkgs = yumpkg.install(name='python-urlgrabber', diff_attr=['epoch', 'release', 'arch'], reinstall=True)
             self.assertEqual(pkgs, {})
-
 
     def test_list_pkgs(self):
         '''


### PR DESCRIPTION
### What does this PR do?

Since version and epoch seem to be split by default now, the yum pkg info
processing should have changed.

* Fixes the version info processing for pkg installation.
* Test for installation with and without diff_attr.

### What issues does this PR fix or reference?
-
### Previous Behavior

Installation of packages failed due to wrong version/epoch processing.

### New Behavior

Installation of pkgs works via yum.

### Tests written?

Yes

### Commits signed with GPG?

Yes