### PR TITLE
win_lgpo registry.pol encoding updates

### DIFF
--- a/salt/modules/win_lgpo.py
+++ b/salt/modules/win_lgpo.py
@@ -3597,9 +3597,9 @@ def _checkAllAdmxPolicies(policy_class,
     full_names = {}
     if policy_filedata:
         log.debug('POLICY CLASS {0} has file data'.format(policy_class))
-        policy_filedata_split = re.sub(b'\]\00$',
+        policy_filedata_split = re.sub(salt.utils.to_bytes(r'\]{0}$'.format(chr(0))),
                                        b'',
-                                       re.sub(b'^\[\00',
+                                       re.sub(salt.utils.to_bytes(r'^\[{0}'.format(chr(0))),
                                               b'',
                                               re.sub(re.escape(module_policy_data.reg_pol_header.encode('utf-16-le')), b'', policy_filedata))
                                        ).split(']['.encode('utf-16-le'))
@@ -3915,7 +3915,7 @@ def _checkAllAdmxPolicies(policy_class,
                                                                                       admx_policy,
                                                                                       elements_item,
                                                                                       check_deleted=False)
-                                                                    ) + b'(?!\*\*delvals\.)',
+                                                                    ) + salt.utils.to_bytes(r'(?!\*\*delvals\.)'),
                                                           policy_filedata):
                                     configured_value = _getDataFromRegPolData(_processValueItem(child_item,
                                                                                                 child_key,
@@ -4117,8 +4117,8 @@ def _regexSearchKeyValueCombo(policy_data, policy_regpath, policy_regkey):
     for a policy_regpath and policy_regkey combo
     '''
     if policy_data:
-        specialValueRegex = b'(\*\*Del\.|\*\*DelVals\.){0,1}'
-        _thisSearch = b''.join([b'\[',
+        specialValueRegex = salt.utils.to_bytes(r'(\*\*Del\.|\*\*DelVals\.){0,1}')
+        _thisSearch = b''.join([salt.utils.to_bytes(r'\['),
                                re.escape(policy_regpath),
                                b'\00;',
                                specialValueRegex,
@@ -4234,7 +4234,7 @@ def _policyFileReplaceOrAppendList(string_list, policy_data):
     if not policy_data:
         policy_data = b''
     # we are going to clean off the special pre-fixes, so we get only the valuename
-    specialValueRegex = b'(\*\*Del\.|\*\*DelVals\.){0,1}'
+    specialValueRegex = salt.utils.to_bytes(r'(\*\*Del\.|\*\*DelVals\.){0,1}')
     for this_string in string_list:
         list_item_key = this_string.split(b'\00;')[0].lstrip(b'[')
         list_item_value_name = re.sub(specialValueRegex,
@@ -4262,7 +4262,7 @@ def _policyFileReplaceOrAppend(this_string, policy_data, append_only=False):
     # we are going to clean off the special pre-fixes, so we get only the valuename
     if not policy_data:
         policy_data = b''
-    specialValueRegex = b'(\*\*Del\.|\*\*DelVals\.){0,1}'
+    specialValueRegex = salt.utils.to_bytes(r'(\*\*Del\.|\*\*DelVals\.){0,1}')
     item_key = None
     item_value_name = None
     data_to_replace = None

--- a/salt/modules/win_lgpo.py
+++ b/salt/modules/win_lgpo.py
@@ -3131,8 +3131,8 @@ def _getDataFromRegPolData(search_string, policy_data, return_value_name=False):
         values = {}
     if search_string:
         registry = Registry()
-        if len(search_string.split('{0};'.format(chr(0)))) >= 3:
-            vtype = registry.vtype_reverse[ord(search_string.split('{0};'.format(chr(0)))[2])]
+        if len(search_string.split(';'.encode('utf-16-le'))) >= 3:
+            vtype = registry.vtype_reverse[ord(search_string.split(';'.encode('utf-16-le'))[2].decode('utf-32-le'))]
         else:
             vtype = None
         search_string = re.escape(search_string)
@@ -3140,29 +3140,29 @@ def _getDataFromRegPolData(search_string, policy_data, return_value_name=False):
         matches = [m for m in matches]
         if matches:
             for match in matches:
-                pol_entry = policy_data[match.start():(policy_data.index(']',
+                pol_entry = policy_data[match.start():(policy_data.index(']'.encode('utf-16-le'),
                                                                          match.end())
                                                        )
-                                        ].split('{0};'.format(chr(0)))
+                                        ].split(';'.encode('utf-16-le'))
                 if len(pol_entry) >= 2:
                     valueName = pol_entry[1]
                 if len(pol_entry) >= 5:
                     value = pol_entry[4]
                     if vtype == 'REG_DWORD' or vtype == 'REG_QWORD':
                         if value:
-                            vlist = list(ord(v) for v in value)
+                            #vlist = list(ord(v) for v in value)
                             if vtype == 'REG_DWORD':
-                                for v in struct.unpack('I', struct.pack('2H', *vlist)):
+                                for v in struct.unpack('I', value):
                                     value = v
                             elif vtype == 'REG_QWORD':
-                                for v in struct.unpack('I', struct.pack('4H', *vlist)):
+                                for v in struct.unpack('Q', value):
                                     value = v
                         else:
                             value = 0
                     elif vtype == 'REG_MULTI_SZ':
-                        value = value.rstrip(chr(0)).split(chr(0))
+                        value = value.decode('utf-16-le').rstrip(chr(0)).split(chr(0))
                     else:
-                        value = value.rstrip(chr(0))
+                        value = value.decode('utf-16-le').rstrip(chr(0))
                 if return_value_name:
                     log.debug('we want value names and the value')
                     values[valueName] = value
@@ -3273,35 +3273,50 @@ def _buildKnownDataSearchString(reg_key, reg_valueName, reg_vtype, reg_data,
     '''
     registry = Registry()
     this_element_value = None
-    expected_string = ''
+    expected_string = b''
+    if reg_key:
+        reg_key = reg_key.encode('utf-16-le')
+    if reg_valueName:
+        reg_valueName = reg_valueName.encode('utf-16-le')
     if reg_data and not check_deleted:
         if reg_vtype == 'REG_DWORD':
-            this_element_value = ''
-            for v in struct.unpack('2H', struct.pack('I', int(reg_data))):
-                this_element_value = this_element_value + six.unichr(v)
-        elif reg_vtype == 'REG_QWORD':
-            this_element_value = ''
-            for v in struct.unpack('4H', struct.pack('I', int(reg_data))):
-                this_element_value = this_element_value + six.unichr(v)
+            this_element_value = struct.pack('I', int(reg_data))
+        elif reg_vtype == "REG_QWORD":
+            this_element_value = struct.pack('Q', int(reg_data))
         elif reg_vtype == 'REG_SZ':
-            this_element_value = '{0}{1}'.format(reg_data, chr(0))
+            this_element_value = b''.join([reg_data.encode('utf-16-le'),
+                                           chr(0).encode('utf-16-le')])
     if check_deleted:
         reg_vtype = 'REG_SZ'
-        expected_string = u'[{1}{0};**del.{2}{0};{3}{0};{4}{0};{5}{0}]'.format(
-                                chr(0),
-                                reg_key,
-                                reg_valueName,
-                                chr(registry.vtype[reg_vtype]),
-                                six.unichr(len(' {0}'.format(chr(0)).encode('utf-16-le'))),
-                                ' ')
+        expected_string = b''.join(['['.encode('utf-16-le'),
+                                    reg_key,
+                                    chr(0).encode('utf-16-le'),
+                                    ';'.encode('utf-16-le'),
+                                    '**del.'.encode('utf-16-le'),
+                                    reg_valueName,
+                                    chr(0).encode('utf-16-le'),
+                                    ';'.encode('utf-16-le'),
+                                    chr(registry.vtype[reg_vtype]).encode('utf-32-le'),
+                                    ';'.encode('utf-16-le'),
+                                    six.unichr(len(' {0}'.format(chr(0)).encode('utf-16-le'))).encode('utf-32-le'),
+                                    ';'.encode('utf-16-le'),
+                                    ' '.encode('utf-16-le'),
+                                    chr(0).encode('utf-16-le'),
+                                    ']'.encode('utf-16-le')])
     else:
-        expected_string = u'[{1}{0};{2}{0};{3}{0};{4}{0};{5}]'.format(
-                                chr(0),
-                                reg_key,
-                                reg_valueName,
-                                chr(registry.vtype[reg_vtype]),
-                                six.unichr(len(this_element_value.encode('utf-16-le'))),
-                                this_element_value)
+        expected_string = b''.join(['['.encode('utf-16-le'),
+                                    reg_key,
+                                    chr(0).encode('utf-16-le'),
+                                    ';'.encode('utf-16-le'),
+                                    reg_valueName,
+                                    chr(0).encode('utf-16-le'),
+                                    ';'.encode('utf-16-le'),
+                                    chr(registry.vtype[reg_vtype]).encode('utf-32-le'),
+                                    ';'.encode('utf-16-le'),
+                                    six.unichr(len(this_element_value)).encode('utf-32-le'),
+                                    ';'.encode('utf-16-le'),
+                                    this_element_value,
+                                    ']'.encode('utf-16-le')])
     return expected_string
 
 
@@ -3329,13 +3344,14 @@ def _processValueItem(element, reg_key, reg_valuename, policy, parent_element,
     expected_string = None
     # https://msdn.microsoft.com/en-us/library/dn606006(v=vs.85).aspx
     this_vtype = 'REG_SZ'
-    standard_layout = u'[{1}{0};{2}{0};{3}{0};{4}{0};{5}]'
+    if reg_key:
+        reg_key = reg_key.encode('utf-16-le')
+    if reg_valuename:
+        reg_valuename = reg_valuename.encode('utf-16-le')
     if etree.QName(element).localname == 'decimal' and etree.QName(parent_element).localname != 'elements':
         this_vtype = 'REG_DWORD'
         if 'value' in element.attrib:
-            this_element_value = ''
-            for val in struct.unpack('2H', struct.pack('I', int(element.attrib['value']))):
-                this_element_value = this_element_value + six.unichr(val)
+            this_element_value = struct.pack('I', int(element.attrib['value']))
         else:
             msg = ('The {2} child {1} element for the policy with attributes: '
                    '{0} does not have the required "value" attribute. The '
@@ -3350,9 +3366,7 @@ def _processValueItem(element, reg_key, reg_valuename, policy, parent_element,
         # server, so untested/assumed
         this_vtype = 'REG_QWORD'
         if 'value' in element.attrib:
-            this_element_value = ''
-            for val in struct.unpack('4H', struct.pack('I', int(element.attrib['value']))):
-                this_element_value = this_element_value + six.unichr(val)
+            this_element_value = struct.pack('Q', int(element.attrib['value']))
         else:
             msg = ('The {2} child {1} element for the policy with attributes: '
                    '{0} does not have the required "value" attribute. The '
@@ -3364,7 +3378,8 @@ def _processValueItem(element, reg_key, reg_valuename, policy, parent_element,
             return None
     elif etree.QName(element).localname == 'string':
         this_vtype = 'REG_SZ'
-        this_element_value = '{0}{1}'.format(element.text, chr(0))
+        this_element_value = b''.join([element.text.encode('utf-16-le'),
+                                       chr(0).encode('utf-16-le')])
     elif etree.QName(parent_element).localname == 'elements':
         standard_element_expected_string = True
         if etree.QName(element).localname == 'boolean':
@@ -3375,22 +3390,19 @@ def _processValueItem(element, reg_key, reg_valuename, policy, parent_element,
                 check_deleted = True
             if not check_deleted:
                 this_vtype = 'REG_DWORD'
-            this_element_value = chr(1)
+            this_element_value = chr(1).encode('utf-16-le')
             standard_element_expected_string = False
         elif etree.QName(element).localname == 'decimal':
             # https://msdn.microsoft.com/en-us/library/dn605987(v=vs.85).aspx
             this_vtype = 'REG_DWORD'
             requested_val = this_element_value
             if this_element_value is not None:
-                temp_val = ''
-                for v in struct.unpack('2H', struct.pack('I', int(this_element_value))):
-                    temp_val = temp_val + six.unichr(v)
-                this_element_value = temp_val
+                this_element_value = struct.pack('I', int(this_element_value))
             if 'storeAsText' in element.attrib:
                 if element.attrib['storeAsText'].lower() == 'true':
                     this_vtype = 'REG_SZ'
                     if requested_val is not None:
-                        this_element_value = str(requested_val)
+                        this_element_value = str(requested_val).encode('utf-16-le')
             if check_deleted:
                 this_vtype = 'REG_SZ'
         elif etree.QName(element).localname == 'longDecimal':
@@ -3398,15 +3410,12 @@ def _processValueItem(element, reg_key, reg_valuename, policy, parent_element,
             this_vtype = 'REG_QWORD'
             requested_val = this_element_value
             if this_element_value is not None:
-                temp_val = ''
-                for v in struct.unpack('4H', struct.pack('I', int(this_element_value))):
-                    temp_val = temp_val + six.unichr(v)
-                this_element_value = temp_val
+                this_element_value = struct.pack('Q', int(this_element_value))
             if 'storeAsText' in element.attrib:
                 if element.attrib['storeAsText'].lower() == 'true':
                     this_vtype = 'REG_SZ'
                     if requested_val is not None:
-                        this_element_value = str(requested_val)
+                        this_element_value = str(requested_val).encode('utf-16-le')
         elif etree.QName(element).localname == 'text':
             # https://msdn.microsoft.com/en-us/library/dn605969(v=vs.85).aspx
             this_vtype = 'REG_SZ'
@@ -3414,14 +3423,15 @@ def _processValueItem(element, reg_key, reg_valuename, policy, parent_element,
                 if element.attrib['expandable'].lower() == 'true':
                     this_vtype = 'REG_EXPAND_SZ'
             if this_element_value is not None:
-                this_element_value = '{0}{1}'.format(this_element_value, chr(0))
+                this_element_value = b''.join([this_element_value.encode('utf-16-le'),
+                                               chr(0).encode('utf-16-le')])
         elif etree.QName(element).localname == 'multiText':
             this_vtype = 'REG_MULTI_SZ'
             if this_element_value is not None:
                 this_element_value = '{0}{1}{1}'.format(chr(0).join(this_element_value), chr(0))
         elif etree.QName(element).localname == 'list':
             standard_element_expected_string = False
-            del_keys = ''
+            del_keys = b''
             element_valuenames = []
             element_values = this_element_value
             if this_element_value is not None:
@@ -3430,12 +3440,20 @@ def _processValueItem(element, reg_key, reg_valuename, policy, parent_element,
                 if element.attrib['additive'].lower() == 'false':
                     # a delete values will be added before all the other
                     # value = data pairs
-                    del_keys = u'[{1}{0};**delvals.{0};{2}{0};{3}{0};{4}{0}]'.format(
-                                    chr(0),
-                                    reg_key,
-                                    chr(registry.vtype[this_vtype]),
-                                    chr(len(' {0}'.format(chr(0)).encode('utf-16-le'))),
-                                    ' ')
+                    del_keys = b''.join(['['.encode('utf-16-le'),
+                                         reg_key,
+                                         chr(0).encode('utf-16-le'),
+                                         ';'.encode('utf-16-le'),
+                                         '**delvals.'.encode('utf-16-le'),
+                                         chr(0).encode('utf-16-le'),
+                                         ';'.encode('utf-16-le'),
+                                         chr(registry.vtype[this_vtype]).encode('utf-32-le'),
+                                         ';'.encode('utf-16-le'),
+                                         chr(len(' {0}'.format(chr(0)).encode('utf-16-le'))).encode('utf-32-le'),
+                                         ';'.encode('utf-16-le'),
+                                         ' '.encode('utf-16-le'),
+                                         chr(0).encode('utf-16-le'),
+                                         ']'.encode('utf-16-le')])
             if 'expandable' in element.attrib:
                 this_vtype = 'REG_EXPAND_SZ'
             if 'explicitValue' in element.attrib and element.attrib['explicitValue'].lower() == 'true':
@@ -3454,61 +3472,103 @@ def _processValueItem(element, reg_key, reg_valuename, policy, parent_element,
                     log.debug('element_valuenames == {0} and element_values == {1}'.format(element_valuenames,
                                                                                            element_values))
                     for i, item in enumerate(element_valuenames):
-                        expected_string = expected_string + standard_layout.format(
-                                                chr(0),
-                                                reg_key,
-                                                element_valuenames[i],
-                                                chr(registry.vtype[this_vtype]),
-                                                six.unichr(len('{0}{1}'.format(element_values[i],
-                                                                           chr(0)).encode('utf-16-le'))),
-                                                '{0}{1}'.format(element_values[i], chr(0)))
+                        expected_string = expected_string + b''.join(['['.encode('utf-16-le'),
+                                                                      reg_key,
+                                                                      chr(0).encode('utf-16-le'),
+                                                                      ';'.encode('utf-16-le'),
+                                                                      element_valuenames[i].encode('utf-16-le'),
+                                                                      chr(0).encode('utf-16-le'),
+                                                                      ';'.encode('utf-16-le'),
+                                                                      chr(registry.vtype[this_vtype]).encode('utf-32-le'),
+                                                                      ';'.encode('utf-16-le'),
+                                                                      six.unichr(len('{0}{1}'.format(element_values[i],
+                                                                                 chr(0)).encode('utf-16-le'))).encode('utf-32-le'),
+                                                                      ';'.encode('utf-16-le'),
+                                                                      b''.join([element_values[i].encode('utf-16-le'),
+                                                                               chr(0).encode('utf-16-le')]),
+                                                                      ']'.encode('utf-16-le')])
                 else:
-                    expected_string = del_keys + r'[{1}{0};'.format(chr(0),
-                                                                    reg_key)
+                    expected_string = del_keys + b''.join(['['.encode('utf-16-le'),
+                                                           reg_key,
+                                                           chr(0).encode('utf-16-le'),
+                                                           ';'.encode('utf-16-le')])
             else:
-                expected_string = u'[{1}{0};**delvals.{0};{2}{0};{3}{0};{4}{0}]'.format(
-                                        chr(0),
-                                        reg_key,
-                                        chr(registry.vtype[this_vtype]),
-                                        chr(len(' {0}'.format(chr(0)).encode('utf-16-le'))),
-                                        ' ')
+                expected_string = b''.join(['['.encode('utf-16-le'),
+                                            reg_key,
+                                            chr(0).encode('utf-16-le'),
+                                            ';'.encode('utf-16-le'),
+                                            '**delvals.'.encode('utf-16-le'),
+                                            chr(0).encode('utf-16-le'),
+                                            ';'.encode('utf-16-le'),
+                                            chr(registry.vtype[this_vtype]).encode('utf-32-le'),
+                                            ';'.encode('utf-16-le'),
+                                            chr(len(' {0}'.format(chr(0)))).encode('utf-32-le'),
+                                            ';'.encode('utf-16-le'),
+                                            ' '.encode('utf-16-le'),
+                                            chr(0).encode('utf-16-le'),
+                                            ']'.encode('utf-16-le')])
         elif etree.QName(element).localname == 'enum':
             if this_element_value is not None:
                 pass
 
         if standard_element_expected_string and not check_deleted:
             if this_element_value is not None:
-                expected_string = standard_layout.format(
-                                        chr(0),
-                                        reg_key,
-                                        reg_valuename,
-                                        chr(registry.vtype[this_vtype]),
-                                        six.unichr(len(this_element_value.encode('utf-16-le'))),
-                                        this_element_value)
+                expected_string = b''.join(['['.encode('utf-16-le'),
+                                            reg_key,
+                                            chr(0).encode('utf-16-le'),
+                                            ';'.encode('utf-16-le'),
+                                            reg_valuename,
+                                            chr(0).encode('utf-16-le'),
+                                            ';'.encode('utf-16-le'),
+                                            chr(registry.vtype[this_vtype]).encode('utf-32-le'),
+                                            ';'.encode('utf-16-le'),
+                                            six.unichr(len(this_element_value)).encode('utf-32-le'),
+                                            ';'.encode('utf-16-le'),
+                                            this_element_value,
+                                            ']'.encode('utf-16-le')])
             else:
-                expected_string = u'[{1}{0};{2}{0};{3}{0};'.format(chr(0),
-                                                                   reg_key,
-                                                                   reg_valuename,
-                                                                   chr(registry.vtype[this_vtype]))
+                expected_string = b''.join(['['.encode('utf-16-le'),
+                                            reg_key,
+                                            chr(0).encode('utf-16-le'),
+                                            ';'.encode('utf-16-le'),
+                                            reg_valuename,
+                                            chr(0).encode('utf-16-le'),
+                                            ';'.encode('utf-16-le'),
+                                            chr(registry.vtype[this_vtype]).encode('utf-32-le'),
+                                            ';'.encode('utf-16-le')])
 
     if not expected_string:
         if etree.QName(element).localname == "delete" or check_deleted:
             # delete value
-            expected_string = u'[{1}{0};**del.{2}{0};{3}{0};{4}{0};{5}{0}]'.format(
-                                    chr(0),
-                                    reg_key,
-                                    reg_valuename,
-                                    chr(registry.vtype[this_vtype]),
-                                    six.unichr(len(' {0}'.format(chr(0)).encode('utf-16-le'))),
-                                    ' ')
+            expected_string = b''.join(['['.encode('utf-16-le'),
+                                        reg_key,
+                                        chr(0).encode('utf-16-le'),
+                                        ';'.encode('utf-16-le'),
+                                        '**del.'.encode('utf-16-le'),
+                                        reg_valuename,
+                                        chr(0).encode('utf-16-le'),
+                                        ';'.encode('utf-16-le'),
+                                        chr(registry.vtype[this_vtype]).encode('utf-32-le'),
+                                        ';'.encode('utf-16-le'),
+                                        six.unichr(len(' {0}'.format(chr(0)).encode('utf-16-le'))).encode('utf-32-le'),
+                                        ';'.encode('utf-16-le'),
+                                        ' '.encode('utf-16-le'),
+                                        chr(0).encode('utf-16-le'),
+                                        ']'.encode('utf-16-le')])
         else:
-            expected_string = standard_layout.format(
-                                    chr(0),
-                                    reg_key,
-                                    reg_valuename,
-                                    chr(registry.vtype[this_vtype]),
-                                    six.unichr(len(this_element_value.encode('utf-16-le', '' if six.PY2 else 'surrogatepass'))),
-                                    this_element_value)
+           expected_string = b''.join(['['.encode('utf-16-le'),
+                                       reg_key,
+                                       chr(0).encode('utf-16-le'),
+                                       ';'.encode('utf-16-le'),
+                                       reg_valuename,
+                                       chr(0).encode('utf-16-le'),
+                                       ';'.encode('utf-16-le'),
+                                       chr(registry.vtype[this_vtype]).encode('utf-32-le'),
+                                       ';'.encode('utf-16-le'),
+                                       six.unichr(len(this_element_value)).encode('utf-32-le'),
+                                       ';'.encode('utf-16-le'),
+                                       this_element_value,
+                                       ']'.encode('utf-16-le')])
     return expected_string
 
 
@@ -3533,17 +3593,16 @@ def _checkAllAdmxPolicies(policy_class,
     full_names = {}
     if policy_filedata:
         log.debug('POLICY CLASS {0} has file data'.format(policy_class))
-        policy_filedata_split = re.sub(r'\]$',
-                                       '',
-                                       re.sub(r'^\[',
-                                              '',
-                                              policy_filedata.replace(module_policy_data.reg_pol_header, ''))
-                                       ).split('][')
-
+        policy_filedata_split = re.sub(b'\]\00$',
+                                       b'',
+                                       re.sub(b'^\[\00',
+                                              b'',
+                                              re.sub(re.escape(module_policy_data.reg_pol_header.encode('utf-16-le')), b'', policy_filedata))
+                                       ).split(']['.encode('utf-16-le'))
         for policy_item in policy_filedata_split:
-            policy_item_key = policy_item.split('{0};'.format(chr(0)))[0]
+            policy_item_key = policy_item.split('{0};'.format(chr(0)).encode('utf-16-le'))[0].decode('utf-16-le').lower()
             if policy_item_key:
-                for admx_item in REGKEY_XPATH(admx_policy_definitions, keyvalue=policy_item_key.lower()):
+                for admx_item in REGKEY_XPATH(admx_policy_definitions, keyvalue=policy_item_key):
                     if etree.QName(admx_item).localname == 'policy':
                         if admx_item not in admx_policies:
                             admx_policies.append(admx_item)
@@ -3606,8 +3665,11 @@ def _checkAllAdmxPolicies(policy_class,
                 break
             this_policynamespace = admx_policy.nsmap[admx_policy.prefix]
             if ENABLED_VALUE_XPATH(admx_policy) and this_policy_setting == 'Not Configured':
-                element_only_enabled_disabled = False
-                explicit_enable_disable_value_setting = True
+                # some policies have a disabled list but not an enabled list
+                # added this to address those issues
+                if DISABLED_LIST_XPATH(admx_policy):
+                    element_only_enabled_disabled = False
+                    explicit_enable_disable_value_setting = True
                 if _checkValueItemParent(admx_policy,
                                          this_policyname,
                                          this_key,
@@ -3620,8 +3682,11 @@ def _checkAllAdmxPolicies(policy_class,
                         policy_vals[this_policynamespace] = {}
                     policy_vals[this_policynamespace][this_policyname] = this_policy_setting
             if DISABLED_VALUE_XPATH(admx_policy) and this_policy_setting == 'Not Configured':
-                element_only_enabled_disabled = False
-                explicit_enable_disable_value_setting = True
+                # some policies have a disabled list but not an enabled list
+                # added this to address those issues
+                if ENABLED_LIST_XPATH(admx_policy):
+                    element_only_enabled_disabled = False
+                    explicit_enable_disable_value_setting = True
                 if _checkValueItemParent(admx_policy,
                                          this_policyname,
                                          this_key,
@@ -3846,7 +3911,7 @@ def _checkAllAdmxPolicies(policy_class,
                                                                                       admx_policy,
                                                                                       elements_item,
                                                                                       check_deleted=False)
-                                                                    ) + r'(?!\*\*delvals\.)',
+                                                                    ) + b'(?!\*\*delvals\.)',
                                                           policy_filedata):
                                     configured_value = _getDataFromRegPolData(_processValueItem(child_item,
                                                                                                 child_key,
@@ -4039,7 +4104,6 @@ def _read_regpol_file(reg_pol_path):
     if os.path.exists(reg_pol_path):
         with salt.utils.fopen(reg_pol_path, 'rb') as pol_file:
             returndata = pol_file.read()
-        returndata = returndata.decode('utf-16-le')
     return returndata
 
 
@@ -4049,12 +4113,13 @@ def _regexSearchKeyValueCombo(policy_data, policy_regpath, policy_regkey):
     for a policy_regpath and policy_regkey combo
     '''
     if policy_data:
-        specialValueRegex = r'(\*\*Del\.|\*\*DelVals\.){0,1}'
-        _thisSearch = r'\[{1}{0};{3}{2}{0};'.format(
-                chr(0),
-                re.escape(policy_regpath),
-                re.escape(policy_regkey),
-                specialValueRegex)
+        specialValueRegex = b'(\*\*Del\.|\*\*DelVals\.){0,1}'
+        _thisSearch = b''.join([b'\[',
+                               re.escape(policy_regpath),
+                               b'\00;',
+                               specialValueRegex,
+                               re.escape(policy_regkey),
+                               b'\00;',])
         match = re.search(_thisSearch, policy_data, re.IGNORECASE)
         if match:
             return policy_data[match.start():(policy_data.index(']', match.end())) + 1]
@@ -4085,9 +4150,9 @@ def _write_regpol_data(data_to_write,
         if not os.path.exists(policy_file_path):
             ret = __salt__['file.makedirs'](policy_file_path)
         with salt.utils.fopen(policy_file_path, 'wb') as pol_file:
-            if not data_to_write.startswith(reg_pol_header):
+            if not data_to_write.startswith(reg_pol_header.encode('utf-16-le')):
                 pol_file.write(reg_pol_header.encode('utf-16-le'))
-            pol_file.write(data_to_write.encode('utf-16-le'))
+            pol_file.write(data_to_write)
         try:
             gpt_ini_data = ''
             if os.path.exists(gpt_ini_path):
@@ -4163,13 +4228,14 @@ def _policyFileReplaceOrAppendList(string_list, policy_data):
     update existing strings or append the strings
     '''
     if not policy_data:
-        policy_data = ''
+        policy_data = b''
     # we are going to clean off the special pre-fixes, so we get only the valuename
-    specialValueRegex = r'(\*\*Del\.|\*\*DelVals\.){0,1}'
+    specialValueRegex = b'(\*\*Del\.|\*\*DelVals\.){0,1}'
     for this_string in string_list:
-        list_item_key = this_string.split('{0};'.format(chr(0)))[0].lstrip('[')
+        list_item_key = this_string.split(b'\00;')[0].lstrip(b'[')
         list_item_value_name = re.sub(specialValueRegex,
-                                      '', this_string.split('{0};'.format(chr(0)))[1],
+                                      b'',
+                                      this_string.split(b'\00;')[1],
                                       flags=re.IGNORECASE)
         log.debug('item value name is {0}'.format(list_item_value_name))
         data_to_replace = _regexSearchKeyValueCombo(policy_data,
@@ -4180,7 +4246,7 @@ def _policyFileReplaceOrAppendList(string_list, policy_data):
             policy_data = policy_data.replace(data_to_replace, this_string)
         else:
             log.debug('appending {0}'.format([this_string]))
-            policy_data = ''.join([policy_data, this_string])
+            policy_data = b''.join([policy_data, this_string])
     return policy_data
 
 
@@ -4191,16 +4257,16 @@ def _policyFileReplaceOrAppend(this_string, policy_data, append_only=False):
     '''
     # we are going to clean off the special pre-fixes, so we get only the valuename
     if not policy_data:
-        policy_data = ''
-    specialValueRegex = r'(\*\*Del\.|\*\*DelVals\.){0,1}'
+        policy_data = b''
+    specialValueRegex = b'(\*\*Del\.|\*\*DelVals\.){0,1}'
     item_key = None
     item_value_name = None
     data_to_replace = None
     if not append_only:
-        item_key = this_string.split('{0};'.format(chr(0)))[0].lstrip('[')
+        item_key = this_string.split(b'\00;')[0].lstrip(b'[')
         item_value_name = re.sub(specialValueRegex,
-                                 '',
-                                 this_string.split('{0};'.format(chr(0)))[1],
+                                 b'',
+                                 this_string.split(b'\00;')[1],
                                  flags=re.IGNORECASE)
         log.debug('item value name is {0}'.format(item_value_name))
         data_to_replace = _regexSearchKeyValueCombo(policy_data, item_key, item_value_name)
@@ -4209,7 +4275,7 @@ def _policyFileReplaceOrAppend(this_string, policy_data, append_only=False):
         policy_data = policy_data.replace(data_to_replace, this_string)
     else:
         log.debug('appending {0}'.format([this_string]))
-        policy_data = ''.join([policy_data, this_string])
+        policy_data = b''.join([policy_data, this_string])
 
     return policy_data
 
@@ -4227,9 +4293,10 @@ def _writeAdminTemplateRegPolFile(admtemplate_data,
     REGISTRY_FILE_VERSION (u'\x01\00')
 
     https://msdn.microsoft.com/en-us/library/aa374407(VS.85).aspx
-    [Registry Path<NULL>;Reg Value<NULL>;Reg Type<NULL>;SizeInBytes<NULL>;Data<NULL>]
+    +    https://msdn.microsoft.com/en-us/library/cc232696.aspx
+    [Registry Path<NULL>;Reg Value<NULL>;Reg Type;SizeInBytes;Data<NULL>]
     '''
-    existing_data = ''
+    existing_data = b''
     base_policy_settings = {}
     policy_data = _policy_info()
     policySearchXpath = '//ns1:*[@id = "{0}" or @name = "{0}"]'
@@ -4855,7 +4922,7 @@ def get_policy_info(policy_name,
                 policy_class,
                 ', '.join(policy_data.policies.keys()))
         return ret
-    if policy_name in policy_data.policies[policy_class]:
+    if policy_name in policy_data.policies[policy_class]['policies']:
         ret['policy_aliases'].append(policy_data.policies[policy_class]['policies'][policy_name]['Policy'])
         ret['policy_found'] = True
         ret['message'] = ''

--- a/salt/modules/win_lgpo.py
+++ b/salt/modules/win_lgpo.py
@@ -3127,12 +3127,13 @@ def _getDataFromRegPolData(search_string, policy_data, return_value_name=False):
     '''
     value = None
     values = []
+    encoded_semicolon = ';'.encode('utf-16-le')
     if return_value_name:
         values = {}
     if search_string:
         registry = Registry()
-        if len(search_string.split(';'.encode('utf-16-le'))) >= 3:
-            vtype = registry.vtype_reverse[ord(search_string.split(';'.encode('utf-16-le'))[2].decode('utf-32-le'))]
+        if len(search_string.split(encoded_semicolon)) >= 3:
+            vtype = registry.vtype_reverse[ord(search_string.split(encoded_semicolon)[2].decode('utf-32-le'))]
         else:
             vtype = None
         search_string = re.escape(search_string)
@@ -3143,14 +3144,13 @@ def _getDataFromRegPolData(search_string, policy_data, return_value_name=False):
                 pol_entry = policy_data[match.start():(policy_data.index(']'.encode('utf-16-le'),
                                                                          match.end())
                                                        )
-                                        ].split(';'.encode('utf-16-le'))
+                                        ].split(encoded_semicolon)
                 if len(pol_entry) >= 2:
                     valueName = pol_entry[1]
                 if len(pol_entry) >= 5:
                     value = pol_entry[4]
                     if vtype == 'REG_DWORD' or vtype == 'REG_QWORD':
                         if value:
-                            #vlist = list(ord(v) for v in value)
                             if vtype == 'REG_DWORD':
                                 for v in struct.unpack('I', value):
                                     value = v
@@ -3274,6 +3274,8 @@ def _buildKnownDataSearchString(reg_key, reg_valueName, reg_vtype, reg_data,
     registry = Registry()
     this_element_value = None
     expected_string = b''
+    encoded_semicolon = ';'.encode('utf-16-le')
+    encoded_null = chr(0).encode('utf-16-le')
     if reg_key:
         reg_key = reg_key.encode('utf-16-le')
     if reg_valueName:
@@ -3285,36 +3287,36 @@ def _buildKnownDataSearchString(reg_key, reg_valueName, reg_vtype, reg_data,
             this_element_value = struct.pack('Q', int(reg_data))
         elif reg_vtype == 'REG_SZ':
             this_element_value = b''.join([reg_data.encode('utf-16-le'),
-                                           chr(0).encode('utf-16-le')])
+                                           encoded_null])
     if check_deleted:
         reg_vtype = 'REG_SZ'
         expected_string = b''.join(['['.encode('utf-16-le'),
                                     reg_key,
-                                    chr(0).encode('utf-16-le'),
-                                    ';'.encode('utf-16-le'),
+                                    encoded_null,
+                                    encoded_semicolon,
                                     '**del.'.encode('utf-16-le'),
                                     reg_valueName,
-                                    chr(0).encode('utf-16-le'),
-                                    ';'.encode('utf-16-le'),
+                                    encoded_null,
+                                    encoded_semicolon,
                                     chr(registry.vtype[reg_vtype]).encode('utf-32-le'),
-                                    ';'.encode('utf-16-le'),
+                                    encoded_semicolon,
                                     six.unichr(len(' {0}'.format(chr(0)).encode('utf-16-le'))).encode('utf-32-le'),
-                                    ';'.encode('utf-16-le'),
+                                    encoded_semicolon,
                                     ' '.encode('utf-16-le'),
-                                    chr(0).encode('utf-16-le'),
+                                    encoded_null,
                                     ']'.encode('utf-16-le')])
     else:
         expected_string = b''.join(['['.encode('utf-16-le'),
                                     reg_key,
-                                    chr(0).encode('utf-16-le'),
-                                    ';'.encode('utf-16-le'),
+                                    encoded_null,
+                                    encoded_semicolon,
                                     reg_valueName,
-                                    chr(0).encode('utf-16-le'),
-                                    ';'.encode('utf-16-le'),
+                                    encoded_null,
+                                    encoded_semicolon,
                                     chr(registry.vtype[reg_vtype]).encode('utf-32-le'),
-                                    ';'.encode('utf-16-le'),
+                                    encoded_semicolon,
                                     six.unichr(len(this_element_value)).encode('utf-32-le'),
-                                    ';'.encode('utf-16-le'),
+                                    encoded_semicolon,
                                     this_element_value,
                                     ']'.encode('utf-16-le')])
     return expected_string
@@ -3344,6 +3346,8 @@ def _processValueItem(element, reg_key, reg_valuename, policy, parent_element,
     expected_string = None
     # https://msdn.microsoft.com/en-us/library/dn606006(v=vs.85).aspx
     this_vtype = 'REG_SZ'
+    encoded_semicolon = ';'.encode('utf-16-le')
+    encoded_null = chr(0).encode('utf-16-le')
     if reg_key:
         reg_key = reg_key.encode('utf-16-le')
     if reg_valuename:
@@ -3379,7 +3383,7 @@ def _processValueItem(element, reg_key, reg_valuename, policy, parent_element,
     elif etree.QName(element).localname == 'string':
         this_vtype = 'REG_SZ'
         this_element_value = b''.join([element.text.encode('utf-16-le'),
-                                       chr(0).encode('utf-16-le')])
+                                       encoded_null])
     elif etree.QName(parent_element).localname == 'elements':
         standard_element_expected_string = True
         if etree.QName(element).localname == 'boolean':
@@ -3424,7 +3428,7 @@ def _processValueItem(element, reg_key, reg_valuename, policy, parent_element,
                     this_vtype = 'REG_EXPAND_SZ'
             if this_element_value is not None:
                 this_element_value = b''.join([this_element_value.encode('utf-16-le'),
-                                               chr(0).encode('utf-16-le')])
+                                               encoded_null])
         elif etree.QName(element).localname == 'multiText':
             this_vtype = 'REG_MULTI_SZ'
             if this_element_value is not None:
@@ -3442,17 +3446,17 @@ def _processValueItem(element, reg_key, reg_valuename, policy, parent_element,
                     # value = data pairs
                     del_keys = b''.join(['['.encode('utf-16-le'),
                                          reg_key,
-                                         chr(0).encode('utf-16-le'),
-                                         ';'.encode('utf-16-le'),
+                                         encoded_null,
+                                         encoded_semicolon,
                                          '**delvals.'.encode('utf-16-le'),
-                                         chr(0).encode('utf-16-le'),
-                                         ';'.encode('utf-16-le'),
+                                         encoded_null,
+                                         encoded_semicolon,
                                          chr(registry.vtype[this_vtype]).encode('utf-32-le'),
-                                         ';'.encode('utf-16-le'),
+                                         encoded_semicolon,
                                          chr(len(' {0}'.format(chr(0)).encode('utf-16-le'))).encode('utf-32-le'),
-                                         ';'.encode('utf-16-le'),
+                                         encoded_semicolon,
                                          ' '.encode('utf-16-le'),
-                                         chr(0).encode('utf-16-le'),
+                                         encoded_null,
                                          ']'.encode('utf-16-le')])
             if 'expandable' in element.attrib:
                 this_vtype = 'REG_EXPAND_SZ'
@@ -3474,38 +3478,38 @@ def _processValueItem(element, reg_key, reg_valuename, policy, parent_element,
                     for i, item in enumerate(element_valuenames):
                         expected_string = expected_string + b''.join(['['.encode('utf-16-le'),
                                                                       reg_key,
-                                                                      chr(0).encode('utf-16-le'),
-                                                                      ';'.encode('utf-16-le'),
+                                                                      encoded_null,
+                                                                      encoded_semicolon,
                                                                       element_valuenames[i].encode('utf-16-le'),
-                                                                      chr(0).encode('utf-16-le'),
-                                                                      ';'.encode('utf-16-le'),
+                                                                      encoded_null,
+                                                                      encoded_semicolon,
                                                                       chr(registry.vtype[this_vtype]).encode('utf-32-le'),
-                                                                      ';'.encode('utf-16-le'),
+                                                                      encoded_semicolon,
                                                                       six.unichr(len('{0}{1}'.format(element_values[i],
                                                                                  chr(0)).encode('utf-16-le'))).encode('utf-32-le'),
-                                                                      ';'.encode('utf-16-le'),
+                                                                      encoded_semicolon,
                                                                       b''.join([element_values[i].encode('utf-16-le'),
-                                                                               chr(0).encode('utf-16-le')]),
+                                                                               encoded_null]),
                                                                       ']'.encode('utf-16-le')])
                 else:
                     expected_string = del_keys + b''.join(['['.encode('utf-16-le'),
                                                            reg_key,
-                                                           chr(0).encode('utf-16-le'),
-                                                           ';'.encode('utf-16-le')])
+                                                           encoded_null,
+                                                           encoded_semicolon])
             else:
                 expected_string = b''.join(['['.encode('utf-16-le'),
                                             reg_key,
-                                            chr(0).encode('utf-16-le'),
-                                            ';'.encode('utf-16-le'),
+                                            encoded_null,
+                                            encoded_semicolon,
                                             '**delvals.'.encode('utf-16-le'),
-                                            chr(0).encode('utf-16-le'),
-                                            ';'.encode('utf-16-le'),
+                                            encoded_null,
+                                            encoded_semicolon,
                                             chr(registry.vtype[this_vtype]).encode('utf-32-le'),
-                                            ';'.encode('utf-16-le'),
+                                            encoded_semicolon,
                                             chr(len(' {0}'.format(chr(0)))).encode('utf-32-le'),
-                                            ';'.encode('utf-16-le'),
+                                            encoded_semicolon,
                                             ' '.encode('utf-16-le'),
-                                            chr(0).encode('utf-16-le'),
+                                            encoded_null,
                                             ']'.encode('utf-16-le')])
         elif etree.QName(element).localname == 'enum':
             if this_element_value is not None:
@@ -3515,60 +3519,60 @@ def _processValueItem(element, reg_key, reg_valuename, policy, parent_element,
             if this_element_value is not None:
                 expected_string = b''.join(['['.encode('utf-16-le'),
                                             reg_key,
-                                            chr(0).encode('utf-16-le'),
-                                            ';'.encode('utf-16-le'),
+                                            encoded_null,
+                                            encoded_semicolon,
                                             reg_valuename,
-                                            chr(0).encode('utf-16-le'),
-                                            ';'.encode('utf-16-le'),
+                                            encoded_null,
+                                            encoded_semicolon,
                                             chr(registry.vtype[this_vtype]).encode('utf-32-le'),
-                                            ';'.encode('utf-16-le'),
+                                            encoded_semicolon,
                                             six.unichr(len(this_element_value)).encode('utf-32-le'),
-                                            ';'.encode('utf-16-le'),
+                                            encoded_semicolon,
                                             this_element_value,
                                             ']'.encode('utf-16-le')])
             else:
                 expected_string = b''.join(['['.encode('utf-16-le'),
                                             reg_key,
-                                            chr(0).encode('utf-16-le'),
-                                            ';'.encode('utf-16-le'),
+                                            encoded_null,
+                                            encoded_semicolon,
                                             reg_valuename,
-                                            chr(0).encode('utf-16-le'),
-                                            ';'.encode('utf-16-le'),
+                                            encoded_null,
+                                            encoded_semicolon,
                                             chr(registry.vtype[this_vtype]).encode('utf-32-le'),
-                                            ';'.encode('utf-16-le')])
+                                            encoded_semicolon])
 
     if not expected_string:
         if etree.QName(element).localname == "delete" or check_deleted:
             # delete value
             expected_string = b''.join(['['.encode('utf-16-le'),
                                         reg_key,
-                                        chr(0).encode('utf-16-le'),
-                                        ';'.encode('utf-16-le'),
+                                        encoded_null,
+                                        encoded_semicolon,
                                         '**del.'.encode('utf-16-le'),
                                         reg_valuename,
-                                        chr(0).encode('utf-16-le'),
-                                        ';'.encode('utf-16-le'),
+                                        encoded_null,
+                                        encoded_semicolon,
                                         chr(registry.vtype[this_vtype]).encode('utf-32-le'),
-                                        ';'.encode('utf-16-le'),
+                                        encoded_semicolon,
                                         six.unichr(len(' {0}'.format(chr(0)).encode('utf-16-le'))).encode('utf-32-le'),
-                                        ';'.encode('utf-16-le'),
+                                        encoded_semicolon,
                                         ' '.encode('utf-16-le'),
-                                        chr(0).encode('utf-16-le'),
+                                        encoded_null,
                                         ']'.encode('utf-16-le')])
         else:
-           expected_string = b''.join(['['.encode('utf-16-le'),
-                                       reg_key,
-                                       chr(0).encode('utf-16-le'),
-                                       ';'.encode('utf-16-le'),
-                                       reg_valuename,
-                                       chr(0).encode('utf-16-le'),
-                                       ';'.encode('utf-16-le'),
-                                       chr(registry.vtype[this_vtype]).encode('utf-32-le'),
-                                       ';'.encode('utf-16-le'),
-                                       six.unichr(len(this_element_value)).encode('utf-32-le'),
-                                       ';'.encode('utf-16-le'),
-                                       this_element_value,
-                                       ']'.encode('utf-16-le')])
+            expected_string = b''.join(['['.encode('utf-16-le'),
+                                        reg_key,
+                                        encoded_null,
+                                        encoded_semicolon,
+                                        reg_valuename,
+                                        encoded_null,
+                                        encoded_semicolon,
+                                        chr(registry.vtype[this_vtype]).encode('utf-32-le'),
+                                        encoded_semicolon,
+                                        six.unichr(len(this_element_value)).encode('utf-32-le'),
+                                        encoded_semicolon,
+                                        this_element_value,
+                                        ']'.encode('utf-16-le')])
     return expected_string
 
 
@@ -4119,7 +4123,7 @@ def _regexSearchKeyValueCombo(policy_data, policy_regpath, policy_regkey):
                                b'\00;',
                                specialValueRegex,
                                re.escape(policy_regkey),
-                               b'\00;',])
+                               b'\00;'])
         match = re.search(_thisSearch, policy_data, re.IGNORECASE)
         if match:
             return policy_data[match.start():(policy_data.index(']', match.end())) + 1]


### PR DESCRIPTION
### What does this PR do?
Updates win_lgpo to not decode the registry.pol file wholesale, but instead decode the items of the file as necessary while processing.  Some columns of a registry entry where not encoded properly (i.e. the size and type fields were a utf-16-le encoded number and a null character as opposed to being utf-32-le encoded to have the proper raw length in the registry.pol file).

Uses byte objects for all registry.pol items/etc to be py2/py3 compatible.

See https://msdn.microsoft.com/en-us/library/cc232696.aspx for additional information on the encodings of the "columns" of a registry.pol entry.

Also fixes an issue in get_policy_info where items from the static _policy_info class would not be found if the short name was used (i.e. the key name in the policies dict)

### What issues does this PR fix or reference?
#44516 - this should be a more complete fix

@twangboy - please test this out on your end, my tests came back successful on both 2016.11 and 2017.7 py2 and py3 (though this will need to be properly backported to 2016.11 and to develop).

### Previous Behavior
Encoding errors would be returned on py3 for items whose data item where a unicode surrogate when attempting to encode, the same would happen on py2 when attempting to decode a surrogate value that existed in the registry.pol file.

### New Behavior
Data items are not encoded/decoded unless necessary resulting in no need to ignore surrogates/etc (i.e. data is compared as byte objects instead of converting to more human friendly/readable objects)

### Tests written?
No

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
