### PR TITLE
boto_route53 return true after PENDING status #44947

### DIFF
--- a/salt/modules/boto_route53.py
+++ b/salt/modules/boto_route53.py
@@ -660,7 +660,7 @@ def _wait_for_sync(status, conn, wait_for_sync):
         log.info('Getting route53 status (attempt {0})'.format(i + 1))
         change = conn.get_change(status)
         log.debug(change.GetChangeResponse.ChangeInfo.Status)
-        if change.GetChangeResponse.ChangeInfo.Status == 'INSYNC':
+        if change.GetChangeResponse.ChangeInfo.Status == 'PENDING':
             return True
         i = i + 1
         time.sleep(20)


### PR DESCRIPTION
### What does this PR do?
have boto_route53.add_record return after successful creating instead of waiting for record to sync across all DNS servers (which takes around 40 seconds).

### What issues does this PR fix or reference?
#44947

### Tests written?

No

### Commits signed with GPG?

No
