### PR TITLE
[oxygen] Scheduler run after skip

### DIFF
--- a/salt/modules/schedule.py
+++ b/salt/modules/schedule.py
@@ -59,6 +59,7 @@ SCHEDULE_CONF = [
         'return_kwargs',
         'run_on_start'
         'skip_during_range',
+        'run_after_skip_range',
 ]
 
 
@@ -100,8 +101,11 @@ def list_(show_all=False,
         log.debug('Event module not available. Schedule list failed.')
         return ret
 
+    _hidden = ['enabled',
+               'skip_function',
+               'skip_during_range']
     for job in list(schedule.keys()):  # iterate over a copy since we will mutate it
-        if job == 'enabled':
+        if job in _hidden:
             continue
 
         # Default jobs added by salt begin with __

--- a/salt/states/schedule.py
+++ b/salt/states/schedule.py
@@ -79,6 +79,23 @@ Management of the Salt scheduler
     to return the results of the scheduled job, with the alternative configuration
     options found in the xmpp_state_run section.
 
+    job1:
+      schedule.present:
+        - function: state.sls
+        - job_args:
+          - httpd
+        - job_kwargs:
+            test: True
+        - hours: 1
+        - skip_during_range:
+            - start: 2pm
+            - end: 3pm
+        - run_after_skip_range: True
+
+    This will schedule the command: state.sls httpd test=True at 5pm on Monday,
+    Wednesday and Friday, and 3pm on Tuesday and Thursday.  Requires that
+    python-dateutil is installed on the minion.
+
 '''
 
 
@@ -178,6 +195,16 @@ def present(name,
 
     persist
         Whether the job should persist between minion restarts, defaults to True.
+
+    skip_during_range
+        This will ensure that the scheduled command does not run within the
+        range specified.  The range parameter must be a dictionary with the
+        date strings using the dateutil format. Requires python-dateutil.
+
+    run_after_skip_range
+        Whether the job should run immediately after the skip_during_range time
+        period ends.
+
     '''
 
     ret = {'name': name,

--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -1530,6 +1530,19 @@ class Schedule(object):
                                 log.error('Invalid date string for end in skip_during_range. Ignoring job {0}.'.format(job))
                                 log.error(data)
                                 continue
+
+                            # Check to see if we should run the job immediately
+                            # after the skip_during_range is over
+                            if 'run_after_skip_range' in data and \
+                               data['run_after_skip_range']:
+                                if 'run_explicit' not in data:
+                                    data['run_explicit'] = []
+                                # Add a run_explicit for immediately after the
+                                # skip_during_range ends
+                                _run_immediate = end + self.opts['loop_interval']
+                                if _run_immediate not in data['run_explicit']:
+                                    data['run_explicit'].append(_run_immediate)
+
                             if end > start:
                                 if start <= now <= end:
                                     if self.skip_function:

--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -1121,13 +1121,16 @@ class Schedule(object):
             self.skip_function = schedule['skip_function']
         if 'skip_during_range' in schedule:
             self.skip_during_range = schedule['skip_during_range']
+
+        _hidden = ['enabled',
+                   'skip_function',
+                   'skip_during_range']
         for job, data in six.iteritems(schedule):
             run = False
 
-            if job == 'enabled' or not data:
+            if job in _hidden and not data:
                 continue
-            if job == 'skip_function' or not data:
-                continue
+
             if not isinstance(data, dict):
                 log.error('Scheduled job "{0}" should have a dict value, not {1}'.format(job, type(data)))
                 continue

--- a/tests/integration/scheduler/test_skip.py
+++ b/tests/integration/scheduler/test_skip.py
@@ -136,3 +136,36 @@ class SchedulerSkipTest(ModuleCase, SaltReturnAssertsMixin):
         self.schedule.eval(now=run_time)
         ret = self.schedule.job_status('job1')
         self.assertEqual(ret['_last_run'], run_time)
+
+    def test_run_after_skip_range(self):
+        '''
+        verify that scheduled job is skipped during the specified range
+        '''
+        job = {
+          'schedule': {
+            'job1': {
+              'function': 'test.ping',
+              'when': '11/29/2017 2:30pm',
+              'run_after_skip_range': True,
+              'skip_during_range': {
+                  'start': '11/29/2017 2pm',
+                  'end': '11/29/2017 3pm'
+              }
+            }
+          }
+        }
+
+        # Add job to schedule
+        self.schedule.opts.update(job)
+
+        # eval at 2:30pm, will not run during range.
+        run_time = int(time.mktime(dateutil_parser.parse('11/29/2017 2:30pm').timetuple()))
+        self.schedule.eval(now=run_time)
+        ret = self.schedule.job_status('job1')
+        self.assertNotIn('_last_run', ret)
+
+        # eval at 3:00:01pm, will run.
+        run_time = int(time.mktime(dateutil_parser.parse('11/29/2017 3:00:01pm').timetuple()))
+        self.schedule.eval(now=run_time)
+        ret = self.schedule.job_status('job1')
+        self.assertEqual(ret['_last_run'], run_time)


### PR DESCRIPTION
### What does this PR do?
Adds the ability to specify whether a scheduled job which was previously skipped because of `skip_during_range` should immediately run once the range has ended.  Also adding some documentation for new scheduler features which was previously missing.

### What issues does this PR fix or reference?
N/A

### Tests written?
Yes

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
