### PR TITLE
added-highstate-output-to-slack-engine

### DIFF
--- a/salt/engines/slack.py
+++ b/salt/engines/slack.py
@@ -272,7 +272,7 @@ def start(token,
                                     ret = local.cmd('{0}'.format(target), cmd, arg=args, kwarg=kwargs, tgt_type='{0}'.format(tgt_type))
 
                                 if ret:
-                                    salt.output.highstate.__opts__ =  __opts__
+                                    salt.output.highstate.__opts__ = __opts__
                                     if 'color' not in salt.output.highstate.__opts__:
                                         salt.output.highstate.__opts__.update({"color": ""})
                                     return_text = salt.output.highstate.output(ret)

--- a/salt/engines/slack.py
+++ b/salt/engines/slack.py
@@ -272,9 +272,9 @@ def start(token,
                                     ret = local.cmd('{0}'.format(target), cmd, arg=args, kwarg=kwargs, tgt_type='{0}'.format(tgt_type))
 
                                 if ret:
-                                    salt.output.highstate.__opts__= __opts__
+                                    salt.output.highstate.__opts__ =  __opts__
                                     if 'color' not in salt.output.highstate.__opts__:
-                                        salt.output.highstate.__opts__.update({"color":""})
+                                        salt.output.highstate.__opts__.update({"color": ""})
                                     return_text = salt.output.highstate.output(ret)
                                     ts = time.time()
                                     st = datetime.datetime.fromtimestamp(ts).strftime('%Y%m%d%H%M%S%f')

--- a/salt/engines/slack.py
+++ b/salt/engines/slack.py
@@ -77,6 +77,7 @@ import salt.utils
 import salt.utils.event
 import salt.utils.http
 import salt.utils.slack
+import salt.output.highstate
 
 
 def __virtual__():
@@ -271,7 +272,10 @@ def start(token,
                                     ret = local.cmd('{0}'.format(target), cmd, arg=args, kwarg=kwargs, tgt_type='{0}'.format(tgt_type))
 
                                 if ret:
-                                    return_text = json.dumps(ret, sort_keys=True, indent=1)
+                                    salt.output.highstate.__opts__= __opts__
+                                    if 'color' not in salt.output.highstate.__opts__:
+                                        salt.output.highstate.__opts__.update({"color":""})
+                                    return_text = salt.output.highstate.output(ret)
                                     ts = time.time()
                                     st = datetime.datetime.fromtimestamp(ts).strftime('%Y%m%d%H%M%S%f')
                                     filename = 'salt-results-{0}.yaml'.format(st)


### PR DESCRIPTION
### What does this PR do?

Return the command result for slack engine in Highstate format and ordered for operation number

### Previous Behavior

Output state returned in Slack was unordered and in json format (not readable)

### New Behavior

Output state returned in Slack is ordered by run_num value and Highstate format (more readable)

### Tests written?

No

### Commits signed with GPG?

No
