### PR TITLE
check if VALUE is a string_type

### DIFF
--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -273,7 +273,7 @@ def _get_extra_options(**kwargs):
     ret = []
     kwargs = salt.utils.clean_kwargs(**kwargs)
     for key, value in six.iteritems(kwargs):
-        if isinstance(key, six.string_types):
+        if isinstance(value, six.string_types):
             ret.append('--{0}=\'{1}\''.format(key, value))
         elif value is True:
             ret.append('--{0}'.format(key))


### PR DESCRIPTION
### What does this PR do?
key should always be a stringtype, we want to exclude booleans in the value.

### What issues does this PR fix or reference?
Reported in the salt community slack
Thanks @robert-stojan

### Commits signed with GPG?

Yes