### PR TITLE
Backport #44958 to 2016.11 branch

### DIFF
--- a/salt/runners/manage.py
+++ b/salt/runners/manage.py
@@ -36,6 +36,7 @@ log = logging.getLogger(__name__)
 
 def _ping(tgt, expr_form, timeout, gather_job_timeout):
     client = salt.client.get_local_client(__opts__['conf_file'])
+    client.event.connect_pub(timeout=timeout)
     pub_data = client.run_job(tgt, 'test.ping', (), expr_form, '', timeout, '')
 
     if not pub_data:

--- a/salt/runners/manage.py
+++ b/salt/runners/manage.py
@@ -36,8 +36,7 @@ log = logging.getLogger(__name__)
 
 def _ping(tgt, expr_form, timeout, gather_job_timeout):
     client = salt.client.get_local_client(__opts__['conf_file'])
-    client.event.connect_pub(timeout=timeout)
-    pub_data = client.run_job(tgt, 'test.ping', (), expr_form, '', timeout, '')
+    pub_data = client.run_job(tgt, 'test.ping', (), expr_form, '', timeout, '', listen=True)
 
     if not pub_data:
         return pub_data


### PR DESCRIPTION
@rallytime this will conflict with 2017.7 when merged forward due to the deprecation of `expr_form` (it's `tgt_type` in 2017.7 and later). The 2017.7 side of the conflict will be the correct one in that conflict.

Refs #44958.