### PR TITLE
Skip test_log_created on Windows

### DIFF
--- a/tests/unit/utils/test_parsers.py
+++ b/tests/unit/utils/test_parsers.py
@@ -489,6 +489,7 @@ class LogSettingsParserTests(TestCase):
         # Check log file logger
         self.assertEqual(self.log_setup.log_level_logfile, log_level_logfile)
 
+    @skipIf(salt.utils.is_windows(), 'Windows uses a logging listener')
     def test_log_created(self):
         '''
         Tests that log file is created


### PR DESCRIPTION
### What does this PR do?
Skips the `test_log_created` tests on Windows. Windows uses a logging listener.

### What issues does this PR fix or reference?
Failed in branch tests.

### Tests written?
Yes

### Commits signed with GPG?
Yes