### PR TITLE
Ref:44961 - Modified archive.tar to add dest at the end of the tar cmd

### DIFF
--- a/salt/modules/archive.py
+++ b/salt/modules/archive.py
@@ -533,14 +533,14 @@ def tar(options, tarfile, sources=None, dest=None,
         raise SaltInvocationError('Tar options can not be empty')
 
     cmd = ['tar']
-    if dest:
-        cmd.extend(['-C', '{0}'.format(dest)])
-
     if options:
         cmd.extend(options.split())
 
     cmd.extend(['{0}'.format(tarfile)])
     cmd.extend(_expand_sources(sources))
+    if dest:
+        cmd.extend(['-C', '{0}'.format(dest)])
+
     return __salt__['cmd.run'](cmd,
                                cwd=cwd,
                                template=template,


### PR DESCRIPTION
### What does this PR do?
The salt execution module function archive.tar now works when dest argument is specified

### What issues does this PR fix or reference?
#44961

### Tests written?
No

### Commits signed with GPG?
No