### PR TITLE
Fix `unit.modules.test_file` for Windows

### DIFF
--- a/salt/utils/atomicfile.py
+++ b/salt/utils/atomicfile.py
@@ -15,6 +15,7 @@ import random
 import shutil
 import salt.ext.six as six
 
+# Import salt libs
 import salt.utils.win_dacl
 
 

--- a/salt/utils/atomicfile.py
+++ b/salt/utils/atomicfile.py
@@ -15,6 +15,8 @@ import random
 import shutil
 import salt.ext.six as six
 
+import salt.utils.win_dacl
+
 
 CAN_RENAME_OPEN_FILE = False
 if os.name == 'nt':  # pragma: no cover
@@ -120,8 +122,12 @@ class _AtomicWFile(object):
         self._fh.close()
         if os.path.isfile(self._filename):
             shutil.copymode(self._filename, self._tmp_filename)
-            st = os.stat(self._filename)
-            os.chown(self._tmp_filename, st.st_uid, st.st_gid)
+            if salt.utils.win_dacl.HAS_WIN32:
+                owner = salt.utils.win_dacl.get_owner(self._filename)
+                salt.utils.win_dacl.set_owner(self._tmp_filename, owner)
+            else:
+                st = os.stat(self._filename)
+                os.chown(self._tmp_filename, st.st_uid, st.st_gid)
         atomic_rename(self._tmp_filename, self._filename)
 
     def __exit__(self, exc_type, exc_value, traceback):


### PR DESCRIPTION
### What does this PR do?
Fixes an issue in `salt.utils.atomicfile.py` where it tries to set the owner of a file in Windows using `os.chown`. This PR uses `salt.utils.win_dacl` to set the owner on Windows.

### What issues does this PR fix or reference?
Found while investigating failed branch tests on Windows. This was causing a failure in the `unit.modules.test_file.FileBlockReplaceTestCase` because there is no `os.chown` in Windows.

https://github.com/saltstack/salt-jenkins/issues/439

### Tests written?
No

### Commits signed with GPG?
Yes