### PR TITLE
reduce data gather unless need for wildcard matching

### DIFF
--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -1281,7 +1281,6 @@ def install(name=None,
     if pkg_type == 'repository':
         has_wildcards = [x for x, y in six.iteritems(pkg_params)
                          if y is not None and '*' in y]
-        _available = list_repo_pkgs(*has_wildcards, byrepo=False, **kwargs)
         pkg_params_items = six.iteritems(pkg_params)
     elif pkg_type == 'advisory':
         pkg_params_items = []
@@ -1363,6 +1362,9 @@ def install(name=None,
 
                 if '*' in version_num:
                     # Resolve wildcard matches
+                    if 'byrepo' in kwargs:
+                        _ = kwargs.pop('byrepo')
+                    _available = list_repo_pkgs(*has_wildcards, byrepo=False, **kwargs)
                     candidates = _available.get(pkgname, [])
                     match = salt.utils.fnmatch_multiple(candidates, version_num)
                     if match is not None:
@@ -1412,7 +1414,7 @@ def install(name=None,
                             to_install.append((pkgname, pkgstr))
                             break
                     else:
-                        if re.match('kernel(-.+)?', name):
+                        if name and re.match('kernel(-.+)?', name):
                             # kernel and its subpackages support multiple
                             # installs as their paths do not conflict.
                             # Performing a yum/dnf downgrade will be a no-op


### PR DESCRIPTION
### What does this PR do?
This moves the yum list data collection to just before it is needed, thus speeding up most package installs by 5s*number of repos to search.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/44305


### Previous Behavior
A yum list was run for each repo listed, even if the data wasn't used, this took ~ 5s per repo.

Given the following state config:

```
installspecificversion:
  pkg.installed:
    - pkgs:
      - iperf: 2.0.8-1.el7

installspecificversionbyrepo:
  pkg.installed:
    - pkgs:
      - iperf3: 3.1.3-1.el7
    - byrepo: True

installanyversion:
  pkg.installed:
    - pkgs:
      - bash-completion

installanyversionbyrepo:
  pkg.installed:
    - pkgs:
      - mytop
    - byrepo: True

installwildcard:
  pkg.installed:
    - pkgs:
      - iftop: '*'
    
installwildcardbyrepo:
  pkg.installed:
    - pkgs:
      - bash-doc: '4*'
    - byrepo: True

```

```
Summary for local
------------
Succeeded: 6 (changed=6)
Failed:    0
------------
Total states run:     6
Total run time: 244.047 s

real	4m9.437s
user	3m50.493s
sys	0m17.214s
```

### New Behavior
Only run yum list when needed to match on glob, thus speeding up the salt run significantly.

```
Summary for local
------------
Succeeded: 6 (changed=6)
Failed:    0
------------
Total states run:     6
Total run time: 126.603 s

real	2m12.127s
user	1m57.790s
sys	0m11.090s

```

And without version globing at all, run even faster.

```
Summary for local
------------
Succeeded: 6 (changed=6)
Failed:    0
------------
Total states run:     6
Total run time:  38.238 s

real	0m40.459s
user	0m36.040s
sys	0m2.764s
```

### Tests written?

No

### Commits signed with GPG?

No

