### PR TITLE
Installation Fails on headless machines.

### DIFF
--- a/pkg/windows/installer/Salt-Minion-Setup.nsi
+++ b/pkg/windows/installer/Salt-Minion-Setup.nsi
@@ -362,7 +362,7 @@ Section -Prerequisites
             # /qb! used by 2008 installer
             # It just ignores the unrecognized switches...
             ClearErrors
-            ExecWait '"$INSTDIR\vcredist.exe" /qb! /passive /norestart' $0
+            ExecWait '"$INSTDIR\vcredist.exe" /qb! /quiet /norestart' $0
             IfErrors 0 CheckVcRedistErrorCode
                 MessageBox MB_OK \
                     "$VcRedistName failed to install. Try installing the package manually." \


### PR DESCRIPTION
Installation fails on headless machines if `/passive` is set, `/passive` will display an installation progress bar on windows desktop. `/quiet` suppresses the GUI and does not fail when there is no desktop session available. Fixes #45036.

### What does this PR do?
One line change to suppress installation dialogs.

### What issues does this PR fix or reference?
#45036 

### Previous Behavior
Progress bar on installation of redistributable VC

### New Behavior
No progressbar

### Tests written?

No

### Commits signed with GPG?

Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
