### PR TITLE
[PY3] Add print_function import to files with unicode_literals already added

### DIFF
--- a/salt/__init__.py
+++ b/salt/__init__.py
@@ -4,7 +4,7 @@ Salt package
 '''
 
 # Import Python libs
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 import warnings
 
 # All salt related deprecation warnings should be shown once each!

--- a/salt/client/api.py
+++ b/salt/client/api.py
@@ -16,7 +16,7 @@ client applications.
 '''
 
 # Import Python libs
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 import os
 
 # Import Salt libs

--- a/salt/client/netapi.py
+++ b/salt/client/netapi.py
@@ -3,7 +3,7 @@
 The main entry point for salt-api
 '''
 # Import python libs
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 import signal
 import logging
 

--- a/salt/client/raet/__init__.py
+++ b/salt/client/raet/__init__.py
@@ -2,7 +2,7 @@
 '''
 The client libs to communicate with the salt master when running raet
 '''
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 
 # Import python libs
 import os

--- a/salt/client/ssh/client.py
+++ b/salt/client/ssh/client.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 # Import Python libs
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 import os
 import copy
 import logging

--- a/salt/client/ssh/shell.py
+++ b/salt/client/ssh/shell.py
@@ -2,7 +2,7 @@
 '''
 Manage transport commands via ssh
 '''
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 
 # Import python libs
 import re

--- a/salt/client/ssh/ssh_py_shim.py
+++ b/salt/client/ssh/ssh_py_shim.py
@@ -8,7 +8,7 @@ helper script used by salt.client.ssh.Single.  It is here, in a
 separate file, for convenience of development.
 '''
 
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 
 import hashlib
 import tarfile

--- a/salt/client/ssh/state.py
+++ b/salt/client/ssh/state.py
@@ -2,7 +2,7 @@
 '''
 Create ssh executor system
 '''
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 # Import python libs
 import logging
 import os

--- a/salt/client/ssh/wrapper/__init__.py
+++ b/salt/client/ssh/wrapper/__init__.py
@@ -7,7 +7,7 @@ as ZeroMQ salt, but via ssh.
 '''
 
 # Import python libs
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 import json
 import copy
 

--- a/salt/client/ssh/wrapper/config.py
+++ b/salt/client/ssh/wrapper/config.py
@@ -4,7 +4,7 @@ Return config information
 '''
 
 # Import python libs
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 import re
 import os
 

--- a/salt/client/ssh/wrapper/cp.py
+++ b/salt/client/ssh/wrapper/cp.py
@@ -3,7 +3,7 @@
 Wrap the cp module allowing for managed ssh file transfers
 '''
 # Import Python libs
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 import logging
 import os
 

--- a/salt/client/ssh/wrapper/grains.py
+++ b/salt/client/ssh/wrapper/grains.py
@@ -4,7 +4,7 @@ Return/control aspects of the grains data
 '''
 
 # Import python libs
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 import collections
 import copy
 import math

--- a/salt/client/ssh/wrapper/mine.py
+++ b/salt/client/ssh/wrapper/mine.py
@@ -7,7 +7,7 @@ Wrapper function for mine operations for salt-ssh
 '''
 
 # Import python libs
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 import copy
 
 # Import salt libs

--- a/salt/client/ssh/wrapper/pillar.py
+++ b/salt/client/ssh/wrapper/pillar.py
@@ -2,7 +2,7 @@
 '''
 Extract the pillar data for this minion
 '''
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 
 # Import python libs
 import collections

--- a/salt/client/ssh/wrapper/publish.py
+++ b/salt/client/ssh/wrapper/publish.py
@@ -10,7 +10,7 @@ salt-ssh calls and return the data from them.
 No access control is needed because calls cannot originate from the minions.
 '''
 # Import python libs
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 import copy
 import logging
 

--- a/salt/client/ssh/wrapper/state.py
+++ b/salt/client/ssh/wrapper/state.py
@@ -3,7 +3,7 @@
 Create ssh executor system
 '''
 
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 # Import python libs
 import os
 import time

--- a/salt/exceptions.py
+++ b/salt/exceptions.py
@@ -2,7 +2,7 @@
 '''
 This module is a central location for all salt exceptions
 '''
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 
 # Import python libs
 import copy

--- a/salt/fileclient.py
+++ b/salt/fileclient.py
@@ -2,7 +2,7 @@
 '''
 Classes that manage file clients
 '''
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 
 # Import python libs
 import contextlib

--- a/salt/fileserver/roots.py
+++ b/salt/fileserver/roots.py
@@ -15,7 +15,7 @@ be in the :conf_master:`fileserver_backend` list to enable this backend.
 Fileserver environments are defined using the :conf_master:`file_roots`
 configuration option.
 '''
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 
 # Import python libs
 import os

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -6,7 +6,7 @@ plugin interfaces used by Salt.
 '''
 
 # Import python libs
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 import os
 import sys
 import time

--- a/salt/master.py
+++ b/salt/master.py
@@ -5,7 +5,7 @@ involves preparing the three listeners and the workers needed by the master.
 '''
 
 # Import python libs
-from __future__ import absolute_import, with_statement, unicode_literals
+from __future__ import absolute_import, with_statement, print_function, unicode_literals
 import copy
 import ctypes
 import os

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -5,7 +5,7 @@ A module for shelling out.
 Keep in mind that this module is insecure, in that it can give whomever has
 access to the master root execution access to all salt minions.
 '''
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 
 # Import python libs
 import functools

--- a/salt/modules/dockercompose.py
+++ b/salt/modules/dockercompose.py
@@ -100,7 +100,7 @@ Detailed Function Documentation
 -------------------------------
 '''
 
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 
 import inspect
 import logging

--- a/salt/modules/win_iis.py
+++ b/salt/modules/win_iis.py
@@ -11,7 +11,7 @@ Microsoft IIS site management via WebAdministration powershell module
 '''
 
 # Import python libs
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 import json
 import logging
 import os

--- a/salt/modules/win_psget.py
+++ b/salt/modules/win_psget.py
@@ -8,7 +8,7 @@ Module for managing PowerShell through PowerShellGet (PSGet)
 
 Support for PowerShell
 '''
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 
 # Import Python libs
 import copy

--- a/salt/output/highstate.py
+++ b/salt/output/highstate.py
@@ -103,7 +103,7 @@ Example output with no special settings in configuration files:
 '''
 
 # Import python libs
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 import pprint
 import textwrap
 

--- a/salt/output/json_out.py
+++ b/salt/output/json_out.py
@@ -29,7 +29,7 @@ single-line output format and to parse each line individually. Example output
     {"phill": {"en0": {"hwaddr": "02:1d:cc:a2:33:55", ...}}}
     {"stuart": {"en0": {"hwaddr": "02:9a:e0:ea:9e:3c", ...}}}
 '''
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 
 # Import python libs
 import json

--- a/salt/output/key.py
+++ b/salt/output/key.py
@@ -5,7 +5,7 @@ Display salt-key output
 
 The ``salt-key`` command makes use of this outputter to format its output.
 '''
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 
 # Import salt libs
 import salt.output

--- a/salt/output/nested.py
+++ b/salt/output/nested.py
@@ -23,7 +23,7 @@ Example output::
                 - Hello
                 - World
 '''
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 # Import python libs
 from numbers import Number
 

--- a/salt/output/newline_values_only.py
+++ b/salt/output/newline_values_only.py
@@ -70,7 +70,7 @@ Output
 '''
 
 # Import python libs
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 
 # Import 3rd-party libs
 from salt.ext import six

--- a/salt/output/no_return.py
+++ b/salt/output/no_return.py
@@ -12,7 +12,7 @@ Example output::
     virtucentos:
         Minion did not return
 '''
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 
 # Import salt libs
 import salt.utils.color

--- a/salt/output/overstatestage.py
+++ b/salt/output/overstatestage.py
@@ -8,7 +8,7 @@ and should not be called directly.
 '''
 
 # Import python libs
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 
 # Import Salt libs
 import salt.utils.color

--- a/salt/output/pony.py
+++ b/salt/output/pony.py
@@ -42,7 +42,7 @@ Example output:
 '''
 
 # Import Python libs
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 import subprocess
 
 # Import Salt libs

--- a/salt/output/pprint_out.py
+++ b/salt/output/pprint_out.py
@@ -12,7 +12,7 @@ Example output::
                           'dictionary': {'abc': 123, 'def': 456},
                           'list': ['Hello', 'World']}}}
 '''
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 
 # Import python libs
 import pprint

--- a/salt/output/profile.py
+++ b/salt/output/profile.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 import salt.output.table_out as table_out
 
 __virtualname__ = 'profile'

--- a/salt/output/progress.py
+++ b/salt/output/progress.py
@@ -4,7 +4,7 @@ Display return data as a progress bar
 '''
 
 # Import Python libs
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 
 # Import 3rd-party libs
 try:

--- a/salt/output/raw.py
+++ b/salt/output/raw.py
@@ -17,7 +17,7 @@ Example output::
 '''
 
 # Import Python libs
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 
 # Import Salt libs
 import salt.utils.stringutils

--- a/salt/output/table_out.py
+++ b/salt/output/table_out.py
@@ -35,7 +35,7 @@ Example output::
 '''
 
 # Import Python libs
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 
 import operator
 from functools import reduce  # pylint: disable=redefined-builtin

--- a/salt/output/txt.py
+++ b/salt/output/txt.py
@@ -7,7 +7,7 @@ The txt outputter has been developed to make the output from shell
 commands on minions appear as they do when the command is executed
 on the minion.
 '''
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 
 # Import python libs
 import pprint

--- a/salt/output/virt_query.py
+++ b/salt/output/virt_query.py
@@ -8,7 +8,7 @@ runner.
 '''
 
 # Import python libs
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 
 # Import 3rd-party libs
 from salt.ext import six

--- a/salt/output/yaml_out.py
+++ b/salt/output/yaml_out.py
@@ -17,7 +17,7 @@ Example output::
           - Hello
           - World
 '''
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 
 # Import third party libs
 import logging

--- a/salt/payload.py
+++ b/salt/payload.py
@@ -6,7 +6,7 @@ in here
 '''
 
 # Import python libs
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 # import sys  # Use if sys is commented out below
 import logging
 import gc

--- a/salt/serializers/json.py
+++ b/salt/serializers/json.py
@@ -8,7 +8,7 @@
     It's just a wrapper around json (or simplejson if available).
 '''
 
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 
 try:
     import simplejson as json

--- a/salt/serializers/python.py
+++ b/salt/serializers/python.py
@@ -8,7 +8,7 @@
     Implements a Python serializer (via pprint.format)
 '''
 
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 
 try:
     import simplejson as json

--- a/salt/serializers/yaml.py
+++ b/salt/serializers/yaml.py
@@ -9,7 +9,7 @@
     It also use C bindings if they are available.
 '''
 
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 import datetime
 
 import yaml

--- a/salt/state.py
+++ b/salt/state.py
@@ -13,7 +13,7 @@ The data sent to the state calls is as follows:
 '''
 
 # Import python libs
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 import os
 import sys
 import copy

--- a/salt/states/cmd.py
+++ b/salt/states/cmd.py
@@ -232,7 +232,7 @@ To use it, one may pass it like this. Example:
 '''
 
 # Import python libs
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 
 import os
 import copy

--- a/salt/states/docker.py
+++ b/salt/states/docker.py
@@ -55,7 +55,7 @@ States to manage Docker containers, images, volumes, and networks
     The old syntax will continue to work until the **Fluorine** release of
     Salt.
 '''
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 import copy
 import logging
 

--- a/salt/states/docker_container.py
+++ b/salt/states/docker_container.py
@@ -45,7 +45,7 @@ configuration remains unchanged.
     :ref:`here <docker-authentication>` for more information on how to
     configure access to docker registries in :ref:`Pillar <pillar>` data.
 '''
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 import copy
 import logging
 import os

--- a/salt/states/docker_image.py
+++ b/salt/states/docker_image.py
@@ -35,7 +35,7 @@ module (formerly called **dockerng**) in the 2017.7.0 release.
     :ref:`here <docker-authentication>` for more information on how to
     configure access to docker registries in :ref:`Pillar <pillar>` data.
 '''
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 import logging
 
 # Import salt libs

--- a/salt/states/docker_network.py
+++ b/salt/states/docker_network.py
@@ -30,7 +30,7 @@ Management of Docker networks
 These states were moved from the :mod:`docker <salt.states.docker>` state
 module (formerly called **dockerng**) in the 2017.7.0 release.
 '''
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 import copy
 import logging
 import random

--- a/salt/states/docker_volume.py
+++ b/salt/states/docker_volume.py
@@ -30,7 +30,7 @@ Management of Docker volumes
 These states were moved from the :mod:`docker <salt.states.docker>` state
 module (formerly called **dockerng**) in the 2017.7.0 release.
 '''
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 import logging
 
 # Import salt libs

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -265,7 +265,7 @@ For example:
 '''
 
 # Import python libs
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 import difflib
 import itertools
 import logging

--- a/salt/syspaths.py
+++ b/salt/syspaths.py
@@ -18,7 +18,7 @@
 '''
 
 # Import python libs
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 import sys
 import os.path
 

--- a/salt/template.py
+++ b/salt/template.py
@@ -3,7 +3,7 @@
 Manage basic template commands
 '''
 
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 
 # Import Python libs
 import time

--- a/salt/textformat.py
+++ b/salt/textformat.py
@@ -3,7 +3,7 @@
 ANSI escape code utilities, see
 http://www.ecma-international.org/publications/files/ECMA-ST/Ecma-048.pdf
 '''
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 
 # Import 3rd-party libs
 from salt.ext import six

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -9,7 +9,7 @@ consult the dev team if you are unsure where a new function should go.
 '''
 
 # Import Python libs
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 
 # Import Salt libs
 from salt.defaults import DEFAULT_TARGET_DELIM

--- a/salt/utils/configparser.py
+++ b/salt/utils/configparser.py
@@ -3,7 +3,7 @@
 Custom configparser classes
 '''
 # Import Python libs
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 import re
 
 # Import Salt libs

--- a/salt/utils/context.py
+++ b/salt/utils/context.py
@@ -9,7 +9,7 @@
 
     Context managers used throughout Salt's source code.
 '''
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 
 # Import python libs
 import copy

--- a/salt/utils/data.py
+++ b/salt/utils/data.py
@@ -4,7 +4,7 @@ Functions for manipulating, inspecting, or otherwise working with data types
 and data structures.
 '''
 
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 
 # Import Python libs
 import collections

--- a/salt/utils/docker/__init__.py
+++ b/salt/utils/docker/__init__.py
@@ -7,7 +7,7 @@ input as formatted by states.
 '''
 
 # Import Python libs
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 import logging
 import os
 

--- a/salt/utils/docker/translate/container.py
+++ b/salt/utils/docker/translate/container.py
@@ -3,7 +3,7 @@
 Functions to translate input for container creation
 '''
 # Import Python libs
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 import os
 
 # Import Salt libs

--- a/salt/utils/docker/translate/helpers.py
+++ b/salt/utils/docker/translate/helpers.py
@@ -4,7 +4,7 @@ Functions to translate input in the docker CLI format to the format desired by
 by the API.
 '''
 # Import Python libs
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 import os
 
 # Import Salt libs

--- a/salt/utils/docker/translate/network.py
+++ b/salt/utils/docker/translate/network.py
@@ -3,7 +3,7 @@
 Functions to translate input for network creation
 '''
 # Import Python libs
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 
 # Import Salt libs
 from salt.exceptions import SaltInvocationError

--- a/salt/utils/templates.py
+++ b/salt/utils/templates.py
@@ -3,7 +3,7 @@
 Template render systems
 '''
 
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 
 # Import Python libs
 import codecs

--- a/salt/wheel/__init__.py
+++ b/salt/wheel/__init__.py
@@ -4,7 +4,7 @@ Modules used to control the master itself
 '''
 
 # Import Python libs
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 import collections
 
 # Import salt libs

--- a/salt/wheel/config.py
+++ b/salt/wheel/config.py
@@ -2,7 +2,7 @@
 '''
 Manage the master configuration file
 '''
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 
 # Import python libs
 import logging

--- a/salt/wheel/error.py
+++ b/salt/wheel/error.py
@@ -3,7 +3,7 @@
 Error generator to enable integration testing of salt wheel error handling
 
 '''
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 
 # Import python libs
 

--- a/salt/wheel/file_roots.py
+++ b/salt/wheel/file_roots.py
@@ -4,7 +4,7 @@ Read in files from the file_root and save files to the file root
 '''
 
 # Import python libs
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 import os
 
 # Import salt libs

--- a/salt/wheel/key.py
+++ b/salt/wheel/key.py
@@ -28,7 +28,7 @@ using the :ref:`saltutil execution module <salt.modules.saltutil>`.
 '''
 
 # Import python libs
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 import os
 import hashlib
 import logging

--- a/salt/wheel/minions.py
+++ b/salt/wheel/minions.py
@@ -4,7 +4,7 @@ Wheel system wrapper for connected minions
 '''
 
 # Import Python libs
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 
 # Import Salt libs
 from salt.utils.cache import CacheCli

--- a/salt/wheel/pillar_roots.py
+++ b/salt/wheel/pillar_roots.py
@@ -5,7 +5,7 @@ directories on the master server.
 '''
 
 # Import python libs
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 import os
 
 # Import salt libs

--- a/tests/integration/client/test_kwarg.py
+++ b/tests/integration/client/test_kwarg.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 # Import python libs
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 
 # Import Salt Testing libs
 from tests.support.case import ModuleCase

--- a/tests/integration/client/test_runner.py
+++ b/tests/integration/client/test_runner.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 
 # Import python libs
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 
 # Import Salt Testing libs
 from tests.support.unit import TestCase

--- a/tests/integration/client/test_standard.py
+++ b/tests/integration/client/test_standard.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 # Import python libs
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 import os
 
 # Import Salt Testing libs

--- a/tests/integration/client/test_syndic.py
+++ b/tests/integration/client/test_syndic.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 # Import Python libs
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 
 # Import Salt Testing libs
 from tests.support.case import SyndicCase

--- a/tests/integration/files/file/base/_wheel/runtests_helpers.py
+++ b/tests/integration/files/file/base/_wheel/runtests_helpers.py
@@ -4,7 +4,7 @@ Wheel functions for integration tests
 '''
 
 # Import python libs
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 
 
 def failure():

--- a/tests/integration/loader/test_ext_grains.py
+++ b/tests/integration/loader/test_ext_grains.py
@@ -7,7 +7,7 @@
 '''
 
 # Import Python libs
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 import os
 import time
 

--- a/tests/integration/loader/test_ext_modules.py
+++ b/tests/integration/loader/test_ext_modules.py
@@ -10,7 +10,7 @@
 '''
 
 # Import Python libs
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 import os
 import time
 

--- a/tests/integration/modules/test_cmdmod.py
+++ b/tests/integration/modules/test_cmdmod.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 # Import python libs
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 import os
 import sys
 import textwrap

--- a/tests/integration/modules/test_dockermod.py
+++ b/tests/integration/modules/test_dockermod.py
@@ -4,7 +4,7 @@ Integration tests for the docker_container states
 '''
 
 # Import Python Libs
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 import functools
 import random
 import string

--- a/tests/integration/modules/test_file.py
+++ b/tests/integration/modules/test_file.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 # Import python libs
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 import getpass
 import os
 import shutil

--- a/tests/integration/netapi/test_client.py
+++ b/tests/integration/netapi/test_client.py
@@ -1,7 +1,7 @@
 # encoding: utf-8
 
 # Import Python libs
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 import os
 
 # Import Salt Testing libs

--- a/tests/integration/output/test_output.py
+++ b/tests/integration/output/test_output.py
@@ -4,7 +4,7 @@
 '''
 
 # Import Salt Libs
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 import os
 import traceback
 

--- a/tests/integration/shell/test_key.py
+++ b/tests/integration/shell/test_key.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 # Import Python libs
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 import os
 import shutil
 import tempfile

--- a/tests/integration/ssh/test_deploy.py
+++ b/tests/integration/ssh/test_deploy.py
@@ -3,7 +3,7 @@
 salt-ssh testing
 '''
 # Import Python libs
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 import os
 import shutil
 

--- a/tests/integration/ssh/test_grains.py
+++ b/tests/integration/ssh/test_grains.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 # Import Python libs
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 
 # Import Salt Testing Libs
 from tests.support.case import SSHCase

--- a/tests/integration/ssh/test_mine.py
+++ b/tests/integration/ssh/test_mine.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 # Import Python libs
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 import os
 import shutil
 

--- a/tests/integration/ssh/test_pillar.py
+++ b/tests/integration/ssh/test_pillar.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 # Import Python libs
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 
 # Import Salt Testing Libs
 from tests.support.case import SSHCase

--- a/tests/integration/ssh/test_raw.py
+++ b/tests/integration/ssh/test_raw.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 # Import Python libs
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 
 # Import Salt Testing Libs
 from tests.support.case import SSHCase

--- a/tests/integration/ssh/test_state.py
+++ b/tests/integration/ssh/test_state.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 # Import Python libs
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 import os
 import shutil
 

--- a/tests/integration/states/test_cmd.py
+++ b/tests/integration/states/test_cmd.py
@@ -3,7 +3,7 @@
 Tests for the file state
 '''
 # Import Python libs
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 import errno
 import os
 import textwrap

--- a/tests/integration/states/test_docker_container.py
+++ b/tests/integration/states/test_docker_container.py
@@ -3,7 +3,7 @@
 Integration tests for the docker_container states
 '''
 # Import Python Libs
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 import errno
 import functools
 import logging

--- a/tests/integration/states/test_docker_network.py
+++ b/tests/integration/states/test_docker_network.py
@@ -3,7 +3,7 @@
 Integration tests for the docker_network states
 '''
 # Import Python Libs
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 import errno
 import functools
 import logging

--- a/tests/integration/states/test_file.py
+++ b/tests/integration/states/test_file.py
@@ -5,7 +5,7 @@ Tests for the file state
 '''
 
 # Import Python libs
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 import errno
 import glob
 import logging

--- a/tests/integration/wheel/test_client.py
+++ b/tests/integration/wheel/test_client.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 # Import Python libs
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 
 # Import Salt Testing libs
 from tests.support.unit import TestCase, skipIf

--- a/tests/integration/wheel/test_key.py
+++ b/tests/integration/wheel/test_key.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 
 # Import python libs
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 
 # Import Salt Testing libs
 from tests.support.unit import TestCase

--- a/tests/support/docker.py
+++ b/tests/support/docker.py
@@ -3,7 +3,7 @@
 Common code used in Docker integration tests
 '''
 # Import Python libs
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 import functools
 import random
 import string

--- a/tests/support/unit.py
+++ b/tests/support/unit.py
@@ -22,7 +22,7 @@
 # pylint: disable=unused-import,blacklisted-module,deprecated-method
 
 # Import python libs
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 import os
 import sys
 import logging

--- a/tests/unit/loader/test_globals.py
+++ b/tests/unit/loader/test_globals.py
@@ -7,7 +7,7 @@
 '''
 
 # Import Python libs
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 
 # Import Salt Testing libs
 from tests.support.case import ModuleCase

--- a/tests/unit/loader/test_interfaces.py
+++ b/tests/unit/loader/test_interfaces.py
@@ -7,7 +7,7 @@
 '''
 
 # Import Python libs
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 
 # Import Salt Testing libs
 from tests.support.unit import TestCase

--- a/tests/unit/loader/test_loader.py
+++ b/tests/unit/loader/test_loader.py
@@ -7,7 +7,7 @@
 '''
 
 # Import Python libs
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 import inspect
 import logging
 import tempfile

--- a/tests/unit/modules/test_cmdmod.py
+++ b/tests/unit/modules/test_cmdmod.py
@@ -4,7 +4,7 @@
 '''
 
 # Import python libs
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 import os
 import sys
 import tempfile

--- a/tests/unit/modules/test_dockermod.py
+++ b/tests/unit/modules/test_dockermod.py
@@ -4,7 +4,7 @@ Unit tests for the docker module
 '''
 
 # Import Python Libs
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 
 # Import Salt Testing Libs
 from tests.support.mixins import LoaderModuleMockMixin

--- a/tests/unit/modules/test_file.py
+++ b/tests/unit/modules/test_file.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 # Import python libs
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 import os
 import shutil
 import tempfile

--- a/tests/unit/modules/test_key.py
+++ b/tests/unit/modules/test_key.py
@@ -4,7 +4,7 @@
 '''
 
 # Import Python libs
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 import os.path
 
 # Import Salt Testing Libs

--- a/tests/unit/serializers/test_serializers.py
+++ b/tests/unit/serializers/test_serializers.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 # Import python libs
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 from textwrap import dedent
 
 # Import Salt Testing libs

--- a/tests/unit/states/test_cmd.py
+++ b/tests/unit/states/test_cmd.py
@@ -3,7 +3,7 @@
     :codeauthor: :email:`Jayesh Kariya <jayeshk@saltstack.com>`
 '''
 # Import Python libs
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 import os.path
 
 # Import Salt Testing Libs

--- a/tests/unit/states/test_docker_image.py
+++ b/tests/unit/states/test_docker_image.py
@@ -4,7 +4,7 @@ Unit tests for the docker state
 '''
 
 # Import Python Libs
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 
 # Import Salt Testing Libs
 from tests.support.mixins import LoaderModuleMockMixin

--- a/tests/unit/states/test_docker_volume.py
+++ b/tests/unit/states/test_docker_volume.py
@@ -4,7 +4,7 @@ Unit tests for the docker state
 '''
 
 # Import Python Libs
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 
 # Import Salt Testing Libs
 from tests.support.mixins import LoaderModuleMockMixin

--- a/tests/unit/states/test_file.py
+++ b/tests/unit/states/test_file.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 # Import python libs
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 from datetime import datetime
 import os
 import json

--- a/tests/unit/templates/test_jinja.py
+++ b/tests/unit/templates/test_jinja.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 # Import python libs
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 from jinja2 import Environment, DictLoader, exceptions
 import ast
 import copy

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -4,7 +4,7 @@
 '''
 
 # Import python libs
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 
 # Import Salt Testing libs
 import tests.integration as integration

--- a/tests/unit/test_payload.py
+++ b/tests/unit/test_payload.py
@@ -8,7 +8,7 @@
 '''
 
 # Import Salt libs
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 import time
 import errno
 import threading

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -4,7 +4,7 @@
 '''
 
 # Import Python libs
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 import copy
 import os
 import tempfile

--- a/tests/unit/test_template.py
+++ b/tests/unit/test_template.py
@@ -4,7 +4,7 @@
 '''
 
 # Import Python libs
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 
 # Import Salt Testing libs
 from tests.support.unit import skipIf, TestCase

--- a/tests/unit/utils/test_configparser.py
+++ b/tests/unit/utils/test_configparser.py
@@ -6,7 +6,7 @@ tests.unit.utils.test_configparser
 Test the funcs in the custom parsers in salt.utils.configparser
 '''
 # Import Python Libs
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 import copy
 import errno
 import logging

--- a/tests/unit/utils/test_docker.py
+++ b/tests/unit/utils/test_docker.py
@@ -6,7 +6,7 @@ tests.unit.utils.test_docker
 Test the funcs in salt.utils.docker and salt.utils.docker.translate
 '''
 # Import Python Libs
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 import copy
 import functools
 import logging

--- a/tests/unit/utils/test_templates.py
+++ b/tests/unit/utils/test_templates.py
@@ -4,7 +4,7 @@ Tests for salt.utils.data
 '''
 
 # Import Python libs
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 import textwrap
 
 # Import Salt libs


### PR DESCRIPTION
This makes the 2.x usage invalid syntax and forces the use of print as a
function. This adds the import to the files which I've updated in the
last couple of days but forgot to add it.