### PR TITLE
Fix a couple of PY3 test failures in the rsync module

### DIFF
--- a/salt/modules/rsync.py
+++ b/salt/modules/rsync.py
@@ -7,7 +7,7 @@ Wrapper for rsync
 This data can also be passed into :ref:`pillar <pillar-walk-through>`.
 Options passed into opts will overwrite options passed into pillar.
 '''
-from __future__ import absolute_import
+from __future__ import absolute_import, unicode_literals
 
 # Import python libs
 import errno

--- a/tests/unit/modules/test_rsync.py
+++ b/tests/unit/modules/test_rsync.py
@@ -3,7 +3,7 @@
     :codeauthor: :email:`Jayesh Kariya <jayeshk@saltstack.com>`
 '''
 # Import Python libs
-from __future__ import absolute_import
+from __future__ import absolute_import, unicode_literals
 
 # Import Salt Testing Libs
 from tests.support.mixins import LoaderModuleMockMixin
@@ -37,7 +37,7 @@ class RsyncTestCase(TestCase, LoaderModuleMockMixin):
 
         with patch.dict(rsync.__salt__,
                         {'config.option': MagicMock(return_value='A'),
-                         'cmd.run_all': MagicMock(side_effect=[IOError('f'),
+                         'cmd.run_all': MagicMock(side_effect=[OSError(1, 'f'),
                                                                'A'])}):
             with patch.object(rsync, '_check', return_value=['A']):
                 self.assertRaises(CommandExecutionError, rsync.rsync, 'a', 'b')
@@ -48,7 +48,7 @@ class RsyncTestCase(TestCase, LoaderModuleMockMixin):
         '''
         Test for return rsync version
         '''
-        mock = MagicMock(side_effect=[IOError('f'), 'A B C\n'])
+        mock = MagicMock(side_effect=[OSError(1, 'f'), 'A B C\n'])
         with patch.dict(rsync.__salt__, {'cmd.run_stdout': mock}):
             self.assertRaises(CommandExecutionError, rsync.version)
 


### PR DESCRIPTION
Fixes the following test failures:
  - unit.modules.test_rsync.RsyncTestCase.test_rsync
  - unit.modules.test_rsync.RsyncTestCase.test_version

Fixes https://github.com/saltstack/salt-jenkins/issues/612