### PR TITLE
Fix swap_total for macosx grain detection

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -425,14 +425,14 @@ def _osx_memdata():
     sysctl = salt.utils.path.which('sysctl')
     if sysctl:
         mem = __salt__['cmd.run']('{0} -n hw.memsize'.format(sysctl))
-        swap_total = __salt__['cmd.run']('{0} -n vm.swapusage').split()[2]
+        swap_total = __salt__['cmd.run']('{0} -n vm.swapusage'.format(sysctl)).split()[2]
         if swap_total.endswith('K'):
             _power = 2**10
         elif swap_total.endswith('M'):
             _power = 2**20
         elif swap_total.endswith('G'):
             _power = 2**30
-        swap_total = swap_total[:-1] * _power
+        swap_total = float(swap_total[:-1]) * _power
 
         grains['mem_total'] = int(mem) // 1024 // 1024
         grains['swap_total'] = int(swap_total) // 1024 // 1024


### PR DESCRIPTION
### What does this PR do?
Currently the mac tests cannot start the salt master and stack traces. Stack trace is in issue below. Whats happening is its trying to run the cmd: `{0} -n vm.swapusage` and it can't.

Also found that `swap_total = swap_total[:-1] * _power` was a string so had to convert to float since its a number similar to 1024.0.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt-jenkins/issues/611
