### PR TITLE
Add defaults.update function.

### DIFF
--- a/salt/modules/defaults.py
+++ b/salt/modules/defaults.py
@@ -147,3 +147,65 @@ def deepcopy(source):
     instead of directly on the command-line.
     '''
     return copy.deepcopy(source)
+
+
+def update(dest, defaults, merge_lists=True, in_place=True):
+    '''
+    defaults.update
+        Allows to set defaults for group of data set e.g. group for nodes.
+
+        This function is a combination of defaults.merge
+        and defaults.deepcopy to avoid redundant in jinja.
+
+        Example:
+        .. code-block:: yaml
+
+        group01:
+          defaults:
+            enabled: True
+            extra:
+              - test
+              - stage
+          nodes:
+            host01:
+              index: foo
+              upstream: bar
+            host02:
+              index: foo2
+              upstream: bar2
+
+        .. code-block::
+        {% do salt['defaults.update'](group01.nodes, group01.defaults) %}
+
+        Each node will look like the following:
+        .. code-block:: yaml
+        host01:
+          enabled: True
+          index: foo
+          upstream: bar
+          extra:
+            - test
+            - stage
+
+    merge_lists : True
+        If True, it will also merge lists instead of replace their items.
+
+    in_place : True
+        If True, it will merge into dest dict.
+        if not it will make a new copy from that dict and return it.
+
+    It is more typical to use this in a templating language in formulas,
+    instead of directly on the command-line.
+    '''
+
+    if in_place:
+        nodes = dest
+    else:
+        nodes = deepcopy(dest)
+
+    for node_name, node_vars in nodes.items():
+        defaults_vars = deepcopy(defaults)
+        node_vars = merge(defaults_vars, node_vars, merge_lists=merge_lists)
+        nodes[node_name] = node_vars
+
+    return nodes

--- a/tests/unit/modules/test_defaults.py
+++ b/tests/unit/modules/test_defaults.py
@@ -172,3 +172,37 @@ class DefaultsTestCase(TestCase, LoaderModuleMockMixin):
 
         self.assertFalse(src == dist)
         self.assertTrue(dist == result)
+
+    def test_update_in_place(self):
+        '''
+        Test update with defaults values in place.
+        '''
+
+        group01 = {
+            'defaults': {
+                'enabled': True,
+                'extra': [
+                    'test',
+                    'stage'
+                ]
+            },
+            'nodes': {
+                'host01': {
+                    'index': 'foo',
+                    'upstream': 'bar'
+                }
+            }
+        }
+
+        host01 = {
+            'enabled': True,
+            'index': 'foo',
+            'upstream': 'bar',
+            'extra': [
+                'test',
+                'stage'
+            ],
+        }
+
+        defaults.update(group01['nodes'], group01['defaults'])
+        self.assertEqual(group01['nodes']['host01'], host01)


### PR DESCRIPTION
### What does this PR do?
Add `defaults.update` function.

### What issues does this PR fix or reference?
After enhancing `defaults` module with PR no. #44851 and #44850 

I found that we have a lot of redundant in jinja, so this function is a combination of `defaults.merge` and `defaults.deepcopy` to avoid redundancy.

Here is an arbitrary example:

**Yaml**
```
group01:
  defaults:
    enabled: True
    extra:
      - test
      - stage
  nodes:
    host01:
      index: foo
      upstream: bar
    host02:
      index: foo2
      upstream: bar2
```

Expected output of `group01.nodes.host01`:
```
host01:
  index: foo
  upstream: bar
  enabled: True
  aggregate: source
  extra:
    - test
    - stage
```

Old style that done with Jinja:
```
{% for host, vars in group01.nodes.items() %}
  {% set defaults = salt['defaults.deepcopy'](group01.defaults) %}
  {% set host_vars = salt['defaults.merge'](defaults, vars) %}
  ....
{% endfor %}
```

The same thing with the new function `defaults.update`:
```
{% do salt['defaults.update'](group01.nodes, group01.defaults) %}
```

### New Behavior
Better merge of defaults for groups. 

### Tests written?
Yes

### Commits signed with GPG?
Yes