### PR TITLE
Add TOML serializer.

### DIFF
--- a/salt/serializers/toml.py
+++ b/salt/serializers/toml.py
@@ -13,6 +13,7 @@ from __future__ import absolute_import
 # Import Salt libs
 try:
     import pytoml as toml
+    available = True
 except ImportError:
     available = False
 
@@ -23,8 +24,6 @@ from salt.serializers import DeserializationError, SerializationError
 from salt.ext import six
 
 __all__ = ['deserialize', 'serialize', 'available']
-
-available = True
 
 
 def deserialize(stream_or_string, **options):

--- a/salt/serializers/toml.py
+++ b/salt/serializers/toml.py
@@ -14,7 +14,7 @@ from __future__ import absolute_import
 try:
     import pytoml as toml
 except ImportError:
-    sys.exit('Could not import pytoml Python module.')
+    available = False
 
 # Import Salt libs
 from salt.serializers import DeserializationError, SerializationError

--- a/salt/serializers/toml.py
+++ b/salt/serializers/toml.py
@@ -28,9 +28,9 @@ __all__ = ['deserialize', 'serialize', 'available']
 
 def deserialize(stream_or_string, **options):
     '''
-    Deserialize any string or stream like object into a Python data structure.
+    Deserialize from TOML into Python data structure.
 
-    :param stream_or_string: stream or string to deserialize.
+    :param stream_or_string: toml stream or string to deserialize.
     :param options: options given to lower pytoml module.
     '''
 

--- a/salt/serializers/toml.py
+++ b/salt/serializers/toml.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
-'''
+"""
     salt.serializers.toml
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
     Implements TOML serializer.
 
     It's just a wrapper around pytoml module.
-'''
+"""
 
 from __future__ import absolute_import
 
@@ -26,13 +26,14 @@ __all__ = ['deserialize', 'serialize', 'available']
 
 available = True
 
+
 def deserialize(stream_or_string, **options):
-    '''
+    """
     Deserialize any string or stream like object into a Python data structure.
 
     :param stream_or_string: stream or string to deserialize.
     :param options: options given to lower pytoml module.
-    '''
+    """
 
     try:
         if not isinstance(stream_or_string, (bytes, six.string_types)):
@@ -47,12 +48,12 @@ def deserialize(stream_or_string, **options):
 
 
 def serialize(obj, **options):
-    '''
+    """
     Serialize Python data to TOML.
 
     :param obj: the data structure to serialize.
     :param options: options given to lower pytoml module.
-    '''
+    """
 
     try:
         if 'file_out' in options:

--- a/salt/serializers/toml.py
+++ b/salt/serializers/toml.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+'''
+    salt.serializers.toml
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    Implements TOML serializer.
+
+    It's just a wrapper around pytoml module.
+'''
+
+from __future__ import absolute_import
+
+# Import Salt libs
+try:
+    import pytoml as toml
+except ImportError:
+    sys.exit('Could not import pytoml Python module.')
+
+# Import Salt libs
+from salt.serializers import DeserializationError, SerializationError
+
+# Import 3rd-party libs
+from salt.ext import six
+
+__all__ = ['deserialize', 'serialize', 'available']
+
+available = True
+
+def deserialize(stream_or_string, **options):
+    '''
+    Deserialize any string or stream like object into a Python data structure.
+
+    :param stream_or_string: stream or string to deserialize.
+    :param options: options given to lower pytoml module.
+    '''
+
+    try:
+        if not isinstance(stream_or_string, (bytes, six.string_types)):
+            return toml.load(stream_or_string, **options)
+
+        if isinstance(stream_or_string, bytes):
+            stream_or_string = stream_or_string.decode('utf-8')
+
+        return toml.loads(stream_or_string)
+    except Exception as error:
+        raise DeserializationError(error)
+
+
+def serialize(obj, **options):
+    '''
+    Serialize Python data to TOML.
+
+    :param obj: the data structure to serialize.
+    :param options: options given to lower pytoml module.
+    '''
+
+    try:
+        if 'file_out' in options:
+            return toml.dump(obj, options['file_out'], **options)
+        else:
+            return toml.dumps(obj, **options)
+    except Exception as error:
+        raise SerializationError(error)

--- a/salt/serializers/toml.py
+++ b/salt/serializers/toml.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
-"""
+'''
     salt.serializers.toml
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
     Implements TOML serializer.
 
     It's just a wrapper around pytoml module.
-"""
+'''
 
 from __future__ import absolute_import
 
@@ -27,12 +27,12 @@ __all__ = ['deserialize', 'serialize', 'available']
 
 
 def deserialize(stream_or_string, **options):
-    """
+    '''
     Deserialize any string or stream like object into a Python data structure.
 
     :param stream_or_string: stream or string to deserialize.
     :param options: options given to lower pytoml module.
-    """
+    '''
 
     try:
         if not isinstance(stream_or_string, (bytes, six.string_types)):
@@ -47,12 +47,12 @@ def deserialize(stream_or_string, **options):
 
 
 def serialize(obj, **options):
-    """
+    '''
     Serialize Python data to TOML.
 
     :param obj: the data structure to serialize.
     :param options: options given to lower pytoml module.
-    """
+    '''
 
     try:
         if 'file_out' in options:

--- a/salt/serializers/toml.py
+++ b/salt/serializers/toml.py
@@ -10,7 +10,7 @@
 
 from __future__ import absolute_import
 
-# Import Salt libs
+# Import pytoml
 try:
     import pytoml as toml
     available = True

--- a/tests/unit/serializers/test_serializers.py
+++ b/tests/unit/serializers/test_serializers.py
@@ -18,6 +18,7 @@ import salt.serializers.yaml as yaml
 import salt.serializers.yamlex as yamlex
 import salt.serializers.msgpack as msgpack
 import salt.serializers.python as python
+import salt.serializers.toml as toml
 from salt.serializers.yaml import EncryptedString
 from salt.serializers import SerializationError
 from salt.utils.odict import OrderedDict
@@ -347,4 +348,15 @@ class TestSerializers(TestCase):
         assert serialized == "[foo]\nbar = baz", serialized
 
         deserialized = configparser.deserialize(serialized)
+        assert deserialized == data, deserialized
+
+    @skipIf(not toml.available, SKIP_MESSAGE % 'toml')
+    def test_serialize_toml(self):
+        data = {
+            "foo": "bar"
+        }
+        serialized = toml.serialize(data)
+        assert serialized == 'foo = "bar"\n', serialized
+
+        deserialized = toml.deserialize(serialized)
         assert deserialized == data, deserialized


### PR DESCRIPTION
### Note
This the same PR #44647 after old repo had been overwritten by mistake.

### What does this PR do?
Add TOML as serializer to be used with `file.serialize` without make a hard dependency on `pytoml`.
This serializer using the same of `json` serializer.

An example:
```
create_toml_file:
  file.serialize:
    - name: /etc/dummy_package.toml
    - formatter: toml
    - dataset:
        serializer:
          name: toml
          description: a toml serializer
          note: no hard dependency on pytoml
```


If `pytoml` is available:
```
$ cat /etc/dummy_package.toml
[serializer]
name = "toml"
description = "a toml serializer"
note = "no hard dependency on pytoml"
```


If `pytoml` is **not** available (which is the normal behavior for `file.serialize`):
```
          ID: create_toml_file
    Function: file.serialize
        Name: /etc/dummy_package.toml
      Result: False
     Comment: Toml format is not supported
     Started: 16:20:22.451944
    Duration: 5.993 ms
     Changes: 
```

### What issues does this PR fix or reference?
PR no. #41946 and issue no. #43905

### Tests written?
Yes

Thanks.