### PR TITLE
Add fqdns grain to list all known FQDNs

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1887,6 +1887,7 @@ def append_domain():
         grain['append_domain'] = __opts__['append_domain']
     return grain
 
+
 def fqdns():
     '''
     Return all known FQDNs for the system by enumerating all interfaces and
@@ -1908,10 +1909,11 @@ def fqdns():
             fqdns.add(socket.gethostbyaddr(ip)[0])
         except (socket.error, socket.herror,
             socket.gaierror, socket.timeout) as e:
-                log.error("Exception during resolving address: " + str(e))
-    
+            log.error("Exception during resolving address: " + str(e))
+
     grains['fqdns'] = list(fqdns)
     return grains
+
 
 def ip_fqdn():
     '''

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1887,6 +1887,31 @@ def append_domain():
         grain['append_domain'] = __opts__['append_domain']
     return grain
 
+def fqdns():
+    '''
+    Return all known FQDNs for the system by enumerating all interfaces and
+    then trying to reverse resolve them (excluding 'lo' interface).
+    '''
+    # Provides:
+    # fqdns
+
+    grains = {}
+    fqdns = set()
+
+    addresses = salt.utils.network.ip_addrs(include_loopback=False,
+        interface_data=_INTERFACES)
+    addresses.extend(salt.utils.network.ip_addrs6(include_loopback=False,
+        interface_data=_INTERFACES))
+
+    for ip in addresses:
+        try:
+            fqdns.add(socket.gethostbyaddr(ip)[0])
+        except (socket.error, socket.herror,
+            socket.gaierror, socket.timeout) as e:
+                log.error("Exception during resolving address: " + str(e))
+    
+    grains['fqdns'] = list(fqdns)
+    return grains
 
 def ip_fqdn():
     '''

--- a/tests/integration/modules/test_grains.py
+++ b/tests/integration/modules/test_grains.py
@@ -51,6 +51,7 @@ class TestModulesGrains(ModuleCase):
             'cpuarch',
             'domain',
             'fqdn',
+            'fqdns',
             'gid',
             'groupname',
             'host',

--- a/tests/unit/grains/test_core.py
+++ b/tests/unit/grains/test_core.py
@@ -5,6 +5,7 @@
 
 # Import Python libs
 from __future__ import absolute_import
+import socket
 import os
 
 # Import Salt Testing Libs
@@ -19,6 +20,7 @@ from tests.support.mock import (
 )
 
 # Import Salt Libs
+import salt.utils.network
 import salt.utils.platform
 import salt.grains.core as core
 
@@ -806,3 +808,20 @@ SwapTotal:       4789244 kB'''
                                   MagicMock(return_value=resolv_mock)):
                     get_dns = core.dns()
                     self.assertEqual(get_dns, ret)
+
+    @skipIf(not salt.utils.platform.is_linux(), 'System is not Linux')
+    def test_fqdns_return(self):
+        '''
+        test the return for a dns grain. test for issue:
+        https://github.com/saltstack/salt/issues/41230
+        '''
+        fqdns_mock = ('foo.bar.baz', [], ['1.2.3.4'])
+        ret = {'fqdns': ['foo.bar.baz']}
+        self._run_fqdns_test(fqdns_mock, ret)
+
+    def _run_fqdns_test(self, fqdns_mock, ret):
+        with patch.object(salt.utils, 'is_windows', MagicMock(return_value=False)):
+            with patch('salt.utils.network.ip_addrs', MagicMock(return_value=['1.2.3.4', '5.6.7.8'])), patch('salt.utils.network.ip_addrs6', MagicMock(return_value=['fe80::a8b2:93ff:fe00:0', 'fe80::a8b2:93ff:dead:beef'])):
+                with patch.object(socket, 'gethostbyaddr', return_value=fqdns_mock):
+                    fqdns = core.fqdns()
+                    self.assertEqual(fqdns, ret)


### PR DESCRIPTION
### What does this PR do?

This PR adds a grain named `fqdns` to the grains.
`fqdns` represents all the FQDNs known for the system on all available interfaces (excluding `lo`).

*Note*: `hostname != FQDN`

`hostname` is the UNIX name of the machine. A machine can have one and only one hostname.
`FQDN` is `host.domain` that resolves to an IP address that the machines is answering to.
A machine can have 1+ `FQDN`s.

### New Behavior
A grain called `fqdns` contains all FQDN for the system.

### Tests written?

Yes

### Commits signed with GPG?

Yes
