### PR TITLE
fix 'TypeError: a bytes-like object is required, not 'str' in python 3

### DIFF
--- a/salt/utils/http.py
+++ b/salt/utils/http.py
@@ -429,6 +429,8 @@ def query(url,
                     'charset' in res_params and \
                     not isinstance(result_text, six.text_type):
                 result_text = result_text.decode(res_params['charset'])
+        if isinstance(result_text, bytes):
+            result_text = result.body.decode('utf-8')
         ret['body'] = result_text
     else:
         # Tornado


### PR DESCRIPTION
When running in python 3, I always got the following error:

'''An exception occurred in this state: Traceback (most recent call last):
                File "/usr/local/lib/python3.6/site-packages/salt/state.py", line 1843, in call
                  **cdata['kwargs'])
                File "/usr/local/lib/python3.6/site-packages/salt/loader.py", line 1795, in wrapper
                  return f(*args, **kwargs)
                File "/usr/local/lib/python3.6/site-packages/salt/states/http.py", line 153, in wait_for_successful_query
                  raise caught_exception  # pylint: disable=E0702
                File "/usr/local/lib/python3.6/site-packages/salt/states/http.py", line 144, in wait_for_successful_query
                  ret = query(name, wait_for=wait_for, **kwargs)
                File "/usr/local/lib/python3.6/site-packages/salt/states/http.py", line 96, in query
                  if match in data.get('text', ''):
              TypeError: a bytes-like object is required, not 'str'
'''
