### PR TITLE
Force gce cloud test name to be lowercase

### DIFF
--- a/tests/integration/cloud/providers/test_gce.py
+++ b/tests/integration/cloud/providers/test_gce.py
@@ -36,7 +36,7 @@ class GCETest(ShellCase):
         provider = 'gce'
         providers = self.run_cloud('--list-providers')
         # Create the cloud instance name to be used throughout the tests
-        self.INSTANCE_NAME = generate_random_name('CLOUD-TEST-')
+        self.INSTANCE_NAME = generate_random_name('cloud-test-')
 
         if profile_str not in providers:
             self.skipTest(


### PR DESCRIPTION
### What does this PR do?
Change gce cloud test name to be lowercase. This is required by gce/libcloud google component.


### What issues does this PR fix or reference?
https://github.com/saltstack/salt-jenkins/issues/626

