### PR TITLE
fix websocket support with python3

### DIFF
--- a/salt/netapi/rest_cherrypy/tools/websockets.py
+++ b/salt/netapi/rest_cherrypy/tools/websockets.py
@@ -54,6 +54,6 @@ class SynchronizingWebsocket(WebSocket):
         This ensures completion of the underlying websocket connection
         and can be used to synchronize parallel senders.
         '''
-        if message.data == 'websocket client ready':
+        if message.data.decode('utf-8') == 'websocket client ready':
             self.pipe.send(message)
         self.send('server received message', False)


### PR DESCRIPTION
### What does this PR do?

Fix websocket support with python3.
With python3 message.data has type 'bytes' and the compare do not match.

### Previous Behavior

nothing was reported when you connect to the websocket.

### New Behavior

we get again events.

### Tests written?

No

### Commits signed with GPG?

No
