### PR TITLE
Added salt-cloud support for ssh keys with Scaleway.

### DIFF
--- a/salt/cloud/clouds/scaleway.py
+++ b/salt/cloud/clouds/scaleway.py
@@ -28,6 +28,7 @@ from __future__ import absolute_import
 import json
 import logging
 import pprint
+import os
 import time
 
 # Import Salt Libs
@@ -234,6 +235,21 @@ def create(server_):
         'commercial_type', server_, __opts__, default='C1'
     )
 
+    key_filename = config.get_cloud_config_value(
+        'ssh_key_file', server_, __opts__, search_global=False, default=None
+    )
+
+    if key_filename is not None and not os.path.isfile(key_filename):
+        raise SaltCloudConfigError(
+            'The defined key_filename \'{0}\' does not exist'.format(
+                key_filename
+            )
+        )
+
+    ssh_password = config.get_cloud_config_value(
+        'ssh_password', server_, __opts__
+    )
+
     kwargs = {
         'name': server_['name'],
         'organization': access_key,
@@ -294,9 +310,8 @@ def create(server_):
             raise SaltCloudSystemExit(str(exc))
 
     server_['ssh_host'] = data['public_ip']['address']
-    server_['ssh_password'] = config.get_cloud_config_value(
-        'ssh_password', server_, __opts__
-    )
+    server_['ssh_password'] = ssh_password
+    server_['key_filename'] = key_filename
     ret = __utils__['cloud.bootstrap'](server_, __opts__)
 
     ret.update(data)

--- a/salt/cloud/clouds/scaleway.py
+++ b/salt/cloud/clouds/scaleway.py
@@ -36,6 +36,7 @@ from salt.ext.six.moves import range
 import salt.utils.cloud
 import salt.config as config
 from salt.exceptions import (
+    SaltCloudConfigError,
     SaltCloudNotFound,
     SaltCloudSystemExit,
     SaltCloudExecutionFailure,


### PR DESCRIPTION
### What does this PR do?
Modifies the clouds.scaleway module to support SSH keys for deploying salt to newly-created hosts.  The key file location is specified in the config key "ssh_key_file" (similar to Digital Ocean).

### What issues does this PR fix or reference?
None

### Previous Behavior
The scaleway module only supported SSH with passwords.

### New Behavior
SSH keys are now supported in addition to passwords.

### Tests written?
No

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
