### PR TITLE
Fix integration.states.test_pip.PipStateTest.test_pip_installed_weird_install

### DIFF
--- a/tests/integration/files/file/base/pip-installed-weird-install.sls
+++ b/tests/integration/files/file/base/pip-installed-weird-install.sls
@@ -29,7 +29,7 @@ setup_test_virtualenv:
 
 carbon-weird-setup:
   pip.installed:
-    - name: carbon
+    - name: 'carbon < 1.1'
     - no_deps: True
     - bin_env: {{ virtualenv_test }}
     - onchanges:

--- a/tests/integration/states/test_pip.py
+++ b/tests/integration/states/test_pip.py
@@ -161,19 +161,19 @@ class PipStateTest(ModuleCase, SaltReturnAssertsMixin):
             # some of the state return parts
             for key in six.iterkeys(ret):
                 self.assertTrue(ret[key]['result'])
-                if ret[key]['name'] != 'carbon':
+                if ret[key]['name'] != 'carbon < 1.1':
                     continue
                 self.assertEqual(
                     ret[key]['comment'],
-                    'There was no error installing package \'carbon\' '
+                    'There was no error installing package \'carbon < 1.1\' '
                     'although it does not show when calling \'pip.freeze\'.'
                 )
                 break
             else:
                 raise Exception('Expected state did not run')
         finally:
-            if os.path.isdir('/opt/graphite'):
-                shutil.rmtree('/opt/graphite')
+            if os.path.isdir(ographite):
+                shutil.rmtree(ographite)
 
     def test_issue_2028_pip_installed_state(self):
         ret = self.run_function('state.sls', mods='issue-2028-pip-installed')


### PR DESCRIPTION
Carbon 1.1.1 for some reason added six to their setup.py, which breaks
this test since it's not installed into the virtualenv. This PR forces
this test to use a version of carbon which does not dep on six in its
setup.py.