### PR TITLE
priority for minion_blackout_whitelist by grains

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1594,7 +1594,7 @@ class Minion(MinionBase):
                     # this minion is blacked out. Only allow saltutil.refresh_pillar and the whitelist
                     if function_name != 'saltutil.refresh_pillar' and function_name not in whitelist:
                         minion_blackout_violation = True
-                # minion_blackout_whitelist by grains has higher priority than by pillar
+                # use minion_blackout_whitelist from grains if it exists
                 if minion_instance.opts['grains'].get('minion_blackout', False):
                     whitelist = minion_instance.opts['grains'].get('minion_blackout_whitelist', [])
                     if function_name != 'saltutil.refresh_pillar' and function_name not in whitelist:

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1594,7 +1594,8 @@ class Minion(MinionBase):
                     # this minion is blacked out. Only allow saltutil.refresh_pillar and the whitelist
                     if function_name != 'saltutil.refresh_pillar' and function_name not in whitelist:
                         minion_blackout_violation = True
-                elif minion_instance.opts['grains'].get('minion_blackout', False):
+                # minion_blackout_whitelist by grains has higher priority than by pillar
+                if minion_instance.opts['grains'].get('minion_blackout', False):
                     whitelist = minion_instance.opts['grains'].get('minion_blackout_whitelist', [])
                     if function_name != 'saltutil.refresh_pillar' and function_name not in whitelist:
                         minion_blackout_violation = True


### PR DESCRIPTION
### What does this PR do?
For a purpose to make blackout_mode managed by minion not by master, I need that pillar config for `minion_blackout_whitelist` couldn't manage the same option on minion. So I changed `elif` to `if`, so I **also**  check grains.

### Previous Behavior
Master can add option `minion_blackout` for given minion in a **pillar** data, so the minion.py will check `minion_blackout_whitelist` from a **pillar** dict and won't check in **grains**

### New Behavior
Even if it is the `minion_blackout` options in a **pillar**, minion.py will check these options in **grains** then..

### Tests written?

No

### Commits signed with GPG?

No
