### PR TITLE
Fix spm big file build test to check /tmp

### DIFF
--- a/tests/integration/spm/test_build.py
+++ b/tests/integration/spm/test_build.py
@@ -42,9 +42,9 @@ class SPMBuildTest(SPMCase, ModuleCase):
         test spm build with a big file
         '''
         # check to make sure there is enough space to run this test
-        check_space = self.run_function('status.diskusage', ['/'])
-        space = check_space['/']['available']
-        if space < 2000000:
+        check_space = self.run_function('status.diskusage', ['/tmp'])
+        space = check_space['/tmp']['available']
+        if space < 3000000000:
             self.skipTest('Not enough space on host to run this test')
 
         big_file = self.run_function('cmd.run',


### PR DESCRIPTION
### What does this PR do?
Since we are writing to /tmp in the spm test we need to check the space in /tmp instead of root. Also increase the size check to atleast 3GB since we are adding 1Gb file and installing a 1Gb file.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt-jenkins/issues/545

