### PR TITLE
Fix a stack trace in grains.core

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -2550,7 +2550,7 @@ def _windows_wwns():
     '''
     Return Fibre Channel port WWNs from a Windows host.
     '''
-    ps_cmd = r'Get-WmiObject -class MSFC_FibrePortHBAAttributes -namespace "root\WMI" | Select -Expandproperty Attributes | %{($_.PortWWN | % {"{0:x2}" -f $_}) -join ""}'
+    ps_cmd = r'Get-WmiObject -ErrorAction Stop -class MSFC_FibrePortHBAAttributes -namespace "root\WMI" | Select -Expandproperty Attributes | %{($_.PortWWN | % {"{0:x2}" -f $_}) -join ""}'
 
     ret = []
 

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -3241,6 +3241,13 @@ def powershell(cmd,
     else:
         encoded_cmd = False
 
+    # Put the whole command inside a try / catch block
+    # Some errors in PowerShell are not "Terminating Errors" and will not be
+    # caught in a try/catch block. For example, the `Get-WmiObject` command will
+    # often return a "Non Terminating Error". To fix this, make sure
+    # `-ErrorAction Stop` is set in the powershell command
+    cmd = 'try {' + cmd + '} catch { "{}" | ConvertTo-JSON}'
+
     # Retrieve the response, while overriding shell with 'powershell'
     response = run(cmd,
                    cwd=cwd,


### PR DESCRIPTION
### What does this PR do?
On Windows machines that do not have fiber channel cards, core.py was throwing a stack trace every time it tried to populate the fiber channel port for grains. Here is the stack trace:

```
14:23:13,137 [salt.modules.cmdmod                        :998 ][ERROR   ] Command 'try {Get-WmiObject -class MSFC_Fibr
ePortHBAAttributes -namespace "root\WMI" | Select -Expandproperty Attributes | %{($_.PortWWN | % {"{0:x2}" -f $_}) -jo
in ""} | ConvertTo-JSON} catch { "" | ConvertTo-JSON}' failed with return code: 1
14:23:13,137 [salt.modules.cmdmod                        :1003][ERROR   ] output: Get-WmiObject : Not supported
At line:1 char:6
+ try {Get-WmiObject -class MSFC_FibrePortHBAAttributes -namespace "roo ...
+      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (:) [Get-WmiObject], ManagementException
    + FullyQualifiedErrorId : GetWMIManagementException,Microsoft.PowerShell.Commands.GetWmiObjectCommand
14:23:13,139 [salt.modules.cmdmod                        :3277][ERROR   ] Error converting PowerShell JSON return
Traceback (most recent call last):
  File "c:\salt-dev\salt\salt\modules\cmdmod.py", line 3275, in powershell
    return json.loads(response)
  File "C:\Python27\lib\json\__init__.py", line 339, in loads
    return _default_decoder.decode(s)
  File "C:\Python27\lib\json\decoder.py", line 364, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "C:\Python27\lib\json\decoder.py", line 382, in raw_decode
    raise ValueError("No JSON object could be decoded")
ValueError: No JSON object could be decoded
```

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/44894

### Previous Behavior
Stack trace on non-fiber channel machines

### New Behavior
Clean log

### Tests written?
No

### Commits signed with GPG?
Yes