### PR TITLE
Move pam library load to try/except block

### DIFF
--- a/salt/auth/pam.py
+++ b/salt/auth/pam.py
@@ -43,7 +43,6 @@ from ctypes.util import find_library
 from salt.utils import get_group_list
 from salt.ext.six.moves import range  # pylint: disable=import-error,redefined-builtin
 
-LIBPAM = CDLL(find_library('pam'))
 LIBC = CDLL(find_library('c'))
 
 CALLOC = LIBC.calloc
@@ -116,6 +115,7 @@ class PamConv(Structure):
 
 
 try:
+    LIBPAM = CDLL(find_library('pam'))
     PAM_START = LIBPAM.pam_start
     PAM_START.restype = c_int
     PAM_START.argtypes = [c_char_p, c_char_p, POINTER(PamConv),


### PR DESCRIPTION
### What does this PR do?
This was throwing an error because there is no pam library in Windows.

Stacktrace:
```
[CPU:58.2%|MEM:69.9%]  ... 14:41:42,114 [salt.loader                                :1452][ERROR   ] Failed to import
auth pam, this is due most likely to a syntax error:
Traceback (most recent call last):
  File "c:\salt-dev\salt\salt\loader.py", line 1435, in _load_module
    mod = imp.load_module(mod_namespace, fn_, fpath, desc)
  File "c:\salt-dev\salt\salt\auth\pam.py", line 51, in <module>
    LIBPAM = CDLL(find_library('pam'))
  File "C:\Python27\lib\ctypes\__init__.py", line 362, in __init__
    self._handle = _dlopen(self._name, mode)
TypeError: LoadLibrary() argument 1 must be string, not None
```

### What issues does this PR fix or reference?
Found in test suite run

### Previous Behavior
Loader throws a stack trace in Windows

### New Behavior
No stack trace

### Tests written?
No

### Commits signed with GPG?
Yes