### PR TITLE
Set pyzmq version to 16.0.3

### DIFF
--- a/pkg/windows/req.txt
+++ b/pkg/windows/req.txt
@@ -25,7 +25,7 @@ pyOpenSSL==17.5.0
 python-dateutil==2.6.1
 python-gnupg==0.4.1
 pyyaml==3.12
-pyzmq==17.0.0b3
+pyzmq==16.0.3
 requests==2.18.4
 singledispatch==3.4.0.3
 six==1.11.0


### PR DESCRIPTION
### What does this PR do?
Rolls back the version of pyzmq from 17.0.3b to 16.0.3.

### What issues does this PR fix or reference?
Found in testing windows builds

### Previous Behavior
Minion would not connect to master.

### New Behavior
Connection occurs correctly

### Tests written?
No

### Commits signed with GPG?
Yes