### PR TITLE
fix adding parameters to http.query from sdb yaml

### DIFF
--- a/salt/sdb/rest.py
+++ b/salt/sdb/rest.py
@@ -119,10 +119,15 @@ def query(key, value=None, service=None, profile=None):  # pylint: disable=W0613
         **key_vars
     )
 
+    extras = {}
+    for item in profile[key]:
+        if item not in ('backend', 'url'):
+            extras[item] = profile[key][item]
+
     result = http.query(
         url,
         decode=True,
-        **key_vars
+        **extras
     )
 
     return result['dict']


### PR DESCRIPTION
### What does this PR do?

Fixes an issue, where, if you specify the sdb rest, it will not pick up parameters such as username, password, etc, from what salt.utils.http.query() can accept 

### What issues does this PR fix or reference?

There is no issue open, as I was working on a live system, and created the PE

### Previous Behavior

While specifying the username and password in the sdb config file, it would not use these values to authenticate against the REST API

### New Behavior

Now that these variables are being picked up, the auth works, and we are able to enumerate all the info from the REST API 

### Tests written?

No

### Commits signed with GPG?

Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
