### PR TITLE
Support seed_cmd in virt.init (runner)

### DIFF
--- a/salt/runners/virt.py
+++ b/salt/runners/virt.py
@@ -172,7 +172,8 @@ def init(
         start=True,
         disk='default',
         saltenv='base',
-        enable_vnc=False):
+        enable_vnc=False,
+        seed_cmd='seed.apply'):
     '''
     This routine is used to create a new virtual machine. This routines takes
     a number of options to determine what the newly created virtual machine
@@ -217,6 +218,9 @@ def init(
 
     saltenv
         The Salt environment to use
+
+    seed_cmd
+        The command to use if 'seed=True' (default: 'seed.apply').
     '''
     __jid_event__.fire_event({'message': 'Searching for hosts'}, 'progress')
     data = query(host, quiet=True)
@@ -273,6 +277,7 @@ def init(
                     install,
                     pub_key,
                     priv_key,
+                    seed_cmd,
                     enable_vnc,
                 ],
                 timeout=600)


### PR DESCRIPTION
### What does this PR do?
Accepts a `seed_cmd` parameter for the virt.init runner and forwards to the underlying virt.init module. If no `seed_cmd` parameter is supplied, the default `seed.apply` will be used.
Also fixes the case where the `enable_vnc` parameter wouln't be passed on the the virt modules `enable_vnc` parameter.

### What issues does this PR fix or reference?
Fixes https://github.com/saltstack/salt/issues/43928.

### Previous Behavior
The virt.init runner set `seed_cmd=False` (as default) instead of setting `enable_vnc=False`.

### New Behavior
Passes on correct parameters (`enable_vnc` and `seed_cmd`).

### Tests written?
No

### Commits signed with GPG?
Yes