### PR TITLE
Fix issue with 1641 return code

### DIFF
--- a/salt/modules/reg.py
+++ b/salt/modules/reg.py
@@ -234,7 +234,7 @@ def list_keys(hive, key=None, use_32bit_registry=False):
         for i in range(win32api.RegQueryInfoKey(handle)[0]):
             subkey = win32api.RegEnumKey(handle, i)
             if PY2:
-                subkeys.append(_to_unicode(subkey))
+                subkeys.append(_to_mbcs(subkey))
             else:
                 subkeys.append(subkey)
 

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -154,9 +154,9 @@ def latest_version(*names, **kwargs):
 
             # check, whether latest available version
             # is newer than latest installed version
-            if compare_versions(ver1=str(latest_available),
-                                oper='>',
-                                ver2=str(latest_installed)):
+            if compare_versions(ver1=six.text_type(latest_available),
+                                oper=six.text_type('>'),
+                                ver2=six.text_type(latest_installed)):
                 log.debug('Upgrade of {0} from {1} to {2} '
                           'is available'.format(name,
                                                 latest_installed,
@@ -466,7 +466,7 @@ def _get_reg_software():
         if d_name not in ignore_list:
             # some MS Office updates don't register a product name which means
             # their information is useless
-            reg_software.update({d_name: str(d_vers)})
+            reg_software.update({d_name: six.text_type(d_vers)})
 
     for reg_key in __salt__['reg.list_keys'](hive, key):
         update(hive, key, reg_key, False)
@@ -909,7 +909,7 @@ def _get_source_sum(source_hash, file_path, saltenv):
     schemes = ('salt', 'http', 'https', 'ftp', 'swift', 's3', 'file')
     invalid_hash_msg = ("Source hash '{0}' format is invalid. It must be in "
                         "the format <hash type>=<hash>").format(source_hash)
-    source_hash = str(source_hash)
+    source_hash = six.text_type(source_hash)
     source_hash_scheme = _urlparse(source_hash).scheme
 
     if source_hash_scheme in schemes:
@@ -1161,7 +1161,7 @@ def install(name=None, refresh=False, pkgs=None, **kwargs):
             #  as a float it must be converted to a string in order for
             #  string matching to work.
             if not isinstance(version_num, six.string_types) and version_num is not None:
-                version_num = str(version_num)
+                version_num = six.text_type(version_num)
 
         if not version_num:
             # following can be version number or latest
@@ -1380,6 +1380,10 @@ def install(name=None, refresh=False, pkgs=None, **kwargs):
                     __salt__['system.set_reboot_required_witnessed']()
                 ret[pkg_name] = {'install status': 'success, reboot required'}
                 changed.append(pkg_name)
+            elif result['retcode'] == 1641:
+                # 1641 is ERROR_SUCCESS_REBOOT_INITIATED
+                ret[pkg_name] = {'install status': 'success, reboot initiated'}
+                changed.append(pkg_name)
             else:
                 log.error('Failed to install {0}'.format(pkg_name))
                 log.error('retcode {0}'.format(result['retcode']))
@@ -1518,7 +1522,7 @@ def remove(name=None, pkgs=None, version=None, **kwargs):
             #  as a float it must be converted to a string in order for
             #  string matching to work.
             if not isinstance(version_num, six.string_types) and version_num is not None:
-                version_num = str(version_num)
+                version_num = six.text_type(version_num)
             if version_num not in pkginfo and 'latest' in pkginfo:
                 version_num = 'latest'
         elif 'latest' in pkginfo:
@@ -1671,6 +1675,18 @@ def remove(name=None, pkgs=None, version=None, **kwargs):
                         redirect_stderr=True)
                 if not result['retcode']:
                     ret[pkgname] = {'uninstall status': 'success'}
+                    changed.append(pkgname)
+                elif result['retcode'] == 3010:
+                    # 3010 is ERROR_SUCCESS_REBOOT_REQUIRED
+                    report_reboot_exit_codes = kwargs.pop(
+                        'report_reboot_exit_codes', True)
+                    if report_reboot_exit_codes:
+                        __salt__['system.set_reboot_required_witnessed']()
+                    ret[pkgname] = {'uninstall status': 'success, reboot required'}
+                    changed.append(pkgname)
+                elif result['retcode'] == 1641:
+                    # 1641 is ERROR_SUCCESS_REBOOT_INITIATED
+                    ret[pkgname] = {'uninstall status': 'success, reboot initiated'}
                     changed.append(pkgname)
                 else:
                     log.error('Failed to remove %s', pkgname)
@@ -1859,9 +1875,9 @@ def compare_versions(ver1='', oper='==', ver2=''):
 
     # Support version being the special meaning of 'latest'
     if ver1 == 'latest':
-        ver1 = str(sys.maxsize)
+        ver1 = six.text_type(sys.maxsize)
     if ver2 == 'latest':
-        ver2 = str(sys.maxsize)
+        ver2 = six.text_type(sys.maxsize)
     # Support version being the special meaning of 'Not Found'
     if ver1 == 'Not Found':
         ver1 = '0.0.0.0.0'


### PR DESCRIPTION
### What does this PR do?
Accepts retcode 1641 as a successful install. 1641 just means that installed correctly and initiated a reboot.
Fixes an issue in `reg.py` where it was encoding to unicode instead of mbcs... causing an error on certain packages.
Uses `six.text_type` instead of `str` for py2/py3 compatability.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/44389

### Previous Behavior
Though the software would install/uninstall successfully, salt would report failure

### New Behavior
Salt reports success

### Tests written?
No

### Commits signed with GPG?
Yes