### PR TITLE
Attempt to prevent exception caused by an unknown SID on a folder/file

### DIFF
--- a/salt/modules/win_file.py
+++ b/salt/modules/win_file.py
@@ -1584,8 +1584,13 @@ def check_perms(path,
                     ret['comment'].append(
                         'Failed to change owner to "{0}"'.format(owner))
 
-    # Check permissions
-    cur_perms = salt.utils.win_dacl.get_permissions(path)
+    # Permissions will only be set on first call of _get_permissions.
+    # Afterwards the variable from the outer scope will just be retrieved.
+    check_perms.cur_perms = None
+    def _get_permissions():
+        if not check_perms.cur_perms:
+            check_perms.cur_perms = salt.utils.win_dacl.get_permissions(path)
+        return check_perms.cur_perms
 
     # Verify Deny Permissions
     changes = {}
@@ -1608,7 +1613,7 @@ def check_perms(path,
             else:
                 applies_to = None
 
-            if user_name not in cur_perms:
+            if user_name not in _get_permissions():
                 changes[user] = {'perms': deny_perms[user]['perms']}
                 if applies_to:
                     changes[user]['applies_to'] = applies_to
@@ -1631,9 +1636,9 @@ def check_perms(path,
                 # Check if applies_to was passed
                 if applies_to:
                     # Is there a deny permission set
-                    if 'deny' in cur_perms[user_name]:
+                    if 'deny' in _get_permissions()[user_name]:
                         # If the applies to settings are different, use the new one
-                        if not cur_perms[user_name]['deny']['applies to'] == applies_to_text:
+                        if not _get_permissions()[user_name]['deny']['applies to'] == applies_to_text:
                             if user not in changes:
                                 changes[user] = {}
                             changes[user]['applies_to'] = applies_to
@@ -1650,10 +1655,10 @@ def check_perms(path,
                 applies_to = None
                 if 'applies_to' not in changes[user]:
                     # Get current "applies to" settings from the file
-                    if user_name in cur_perms and 'deny' in cur_perms[user_name]:
+                    if user_name in _get_permissions() and 'deny' in _get_permissions()[user_name]:
                         for flag in salt.utils.win_dacl.flags().ace_prop['file']:
                             if salt.utils.win_dacl.flags().ace_prop['file'][flag] == \
-                                    cur_perms[user_name]['deny']['applies to']:
+                                    _get_permissions()[user_name]['deny']['applies to']:
                                 at_flag = flag
                                 for flag1 in salt.utils.win_dacl.flags().ace_prop['file']:
                                     if salt.utils.win_dacl.flags().ace_prop['file'][flag1] == at_flag:
@@ -1667,7 +1672,7 @@ def check_perms(path,
                 if 'perms' not in changes[user]:
                     # Get current perms
                     # Check for basic perms
-                    for perm in cur_perms[user_name]['deny']['permissions']:
+                    for perm in _get_permissions()[user_name]['deny']['permissions']:
                         for flag in salt.utils.win_dacl.flags().ace_perms['file']['basic']:
                             if salt.utils.win_dacl.flags().ace_perms['file']['basic'][flag] == perm:
                                 perm_flag = flag
@@ -1676,7 +1681,7 @@ def check_perms(path,
                                         perms = flag1
                     # Make a list of advanced perms
                     if not perms:
-                        for perm in cur_perms[user_name]['deny']['permissions']:
+                        for perm in _get_permissions()[user_name]['deny']['permissions']:
                             for flag in salt.utils.win_dacl.flags().ace_perms['file']['advanced']:
                                 if salt.utils.win_dacl.flags().ace_perms['file']['advanced'][flag] == perm:
                                     perm_flag = flag
@@ -1717,7 +1722,7 @@ def check_perms(path,
             else:
                 applies_to = None
 
-            if user_name not in cur_perms:
+            if user_name not in _get_permissions():
 
                 changes[user] = {'perms': grant_perms[user]['perms']}
                 if applies_to:
@@ -1741,9 +1746,9 @@ def check_perms(path,
                 # Check if applies_to was passed
                 if applies_to:
                     # Is there a deny permission set
-                    if 'grant' in cur_perms[user_name]:
+                    if 'grant' in _get_permissions()[user_name]:
                         # If the applies to settings are different, use the new one
-                        if not cur_perms[user_name]['grant']['applies to'] == applies_to_text:
+                        if not _get_permissions()[user_name]['grant']['applies to'] == applies_to_text:
                             if user not in changes:
                                 changes[user] = {}
                             changes[user]['applies_to'] = applies_to
@@ -1758,10 +1763,10 @@ def check_perms(path,
                 applies_to = None
                 if 'applies_to' not in changes[user]:
                     # Get current "applies_to" settings from the file
-                    if user_name in cur_perms and 'grant' in cur_perms[user_name]:
+                    if user_name in _get_permissions() and 'grant' in _get_permissions()[user_name]:
                         for flag in salt.utils.win_dacl.flags().ace_prop['file']:
                             if salt.utils.win_dacl.flags().ace_prop['file'][flag] == \
-                                    cur_perms[user_name]['grant']['applies to']:
+                                    _get_permissions()[user_name]['grant']['applies to']:
                                 at_flag = flag
                                 for flag1 in salt.utils.win_dacl.flags().ace_prop['file']:
                                     if salt.utils.win_dacl.flags().ace_prop['file'][flag1] == at_flag:
@@ -1774,7 +1779,7 @@ def check_perms(path,
                 perms = []
                 if 'perms' not in changes[user]:
                     # Check for basic perms
-                    for perm in cur_perms[user_name]['grant']['permissions']:
+                    for perm in _get_permissions()[user_name]['grant']['permissions']:
                         for flag in salt.utils.win_dacl.flags().ace_perms['file']['basic']:
                             if salt.utils.win_dacl.flags().ace_perms['file']['basic'][flag] == perm:
                                 perm_flag = flag
@@ -1783,7 +1788,7 @@ def check_perms(path,
                                         perms = flag1
                     # Make a list of advanced perms
                     if not perms:
-                        for perm in cur_perms[user_name]['grant']['permissions']:
+                        for perm in _get_permissions()[user_name]['grant']['permissions']:
                             for flag in salt.utils.win_dacl.flags().ace_perms['file']['advanced']:
                                 if salt.utils.win_dacl.flags().ace_perms['file']['advanced'][flag] == perm:
                                     perm_flag = flag
@@ -1896,8 +1901,13 @@ def set_perms(path, grant_perms=None, deny_perms=None, inheritance=True):
     # Get the DACL for the directory
     dacl = salt.utils.win_dacl.dacl(path)
 
-    # Get current file/folder permissions
-    cur_perms = salt.utils.win_dacl.get_permissions(path)
+    # Permissions will only be set on first call of _get_permissions.
+    # Afterwards the variable from the outer scope will just be retrieved.
+    set_perms.cur_perms = None
+    def _get_permissions():
+        if not set_perms.cur_perms:
+            set_perms.cur_perms = salt.utils.win_dacl.get_permissions(path)
+        return set_perms.cur_perms
 
     # Set 'deny' perms if any
     if deny_perms is not None:
@@ -1914,10 +1924,10 @@ def set_perms(path, grant_perms=None, deny_perms=None, inheritance=True):
             applies_to = None
             if 'applies_to' not in deny_perms[user]:
                 # Get current "applies to" settings from the file
-                if user_name in cur_perms and 'deny' in cur_perms[user_name]:
+                if user_name in _get_permissions() and 'deny' in _get_permissions()[user_name]:
                     for flag in salt.utils.win_dacl.flags().ace_prop['file']:
                         if salt.utils.win_dacl.flags().ace_prop['file'][flag] == \
-                                cur_perms[user_name]['deny']['applies to']:
+                                _get_permissions()[user_name]['deny']['applies to']:
                             at_flag = flag
                             for flag1 in salt.utils.win_dacl.flags().ace_prop['file']:
                                 if salt.utils.win_dacl.flags().ace_prop['file'][flag1] == at_flag:
@@ -1947,10 +1957,10 @@ def set_perms(path, grant_perms=None, deny_perms=None, inheritance=True):
             applies_to = None
             if 'applies_to' not in grant_perms[user]:
                 # Get current "applies to" settings from the file
-                if user_name in cur_perms and 'grant' in cur_perms[user_name]:
+                if user_name in _get_permissions() and 'grant' in _get_permissions()[user_name]:
                     for flag in salt.utils.win_dacl.flags().ace_prop['file']:
                         if salt.utils.win_dacl.flags().ace_prop['file'][flag] == \
-                                cur_perms[user_name]['grant']['applies to']:
+                                _get_permissions()[user_name]['grant']['applies to']:
                             at_flag = flag
                             for flag1 in salt.utils.win_dacl.flags().ace_prop['file']:
                                 if salt.utils.win_dacl.flags().ace_prop['file'][flag1] == at_flag:


### PR DESCRIPTION
### What does this PR do?
This PR attempts to prevent a failure happening when unknown SIDs are encountered on a folder that is managed via the win_file execution module. In addition to that it permissions are also tried to be loaded as late as possible.

### What issues does this PR fix or reference?
#45126 

### Previous Behavior
1.) get_perms and set_perms always get the current permissions of a file or a folder.
2.) A winerror.ERROR_NONE_MAPPED exception bubbles up all the way and leads to a failure of state

### New Behavior
1.) get_perms and set_perms always only get the current permissions of a file or a folder if the logic actually requires it.
2.) A winerror.ERROR_NONE_MAPPED exception is intercepted in list_aces. The entry is skipped

### Tests written?
No

### Commits signed with GPG?
No