### PR TITLE
[2017.7] fix to cmd.script for cwd with space

### DIFF
--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -2146,6 +2146,9 @@ def script(source,
     if not salt.utils.is_windows():
         os.chmod(path, 320)
         os.chown(path, __salt__['file.user_to_uid'](runas), -1)
+
+    path = _cmd_quote(path)
+
     ret = _run(path + ' ' + str(args) if args else path,
                cwd=cwd,
                stdin=stdin,

--- a/tests/integration/modules/test_cmdmod.py
+++ b/tests/integration/modules/test_cmdmod.py
@@ -4,6 +4,7 @@
 from __future__ import absolute_import
 import os
 import sys
+import tempfile
 import textwrap
 
 # Import Salt Testing libs
@@ -13,13 +14,13 @@ from tests.support.helpers import (
     skip_if_binaries_missing,
     skip_if_not_root
 )
+from tests.support.paths import TMP
 
 # Import salt libs
 import salt.utils
 
 # Import 3rd-party libs
 import salt.ext.six as six
-
 
 AVAILABLE_PYTHON_EXECUTABLE = salt.utils.which_bin([
     'python',
@@ -138,6 +139,28 @@ class CMDModuleTest(ModuleCase):
         script = 'salt://script.py'
         ret = self.run_function('cmd.script_retcode', [script])
         self.assertEqual(ret, 0)
+
+    def test_script_cwd(self):
+        '''
+        cmd.script with cwd
+        '''
+        tmp_cwd = tempfile.mkdtemp(dir=TMP)
+        args = 'saltines crackers biscuits=yes'
+        script = 'salt://script.py'
+        ret = self.run_function('cmd.script', [script, args], cwd=tmp_cwd)
+        self.assertEqual(ret['stdout'], args)
+
+    def test_script_cwd_with_space(self):
+        '''
+        cmd.script with cwd
+        '''
+        tmp_cwd = "{0}{1}test 2".format(tempfile.mkdtemp(dir=TMP), os.path.sep)
+        os.mkdir(tmp_cwd)
+
+        args = 'saltines crackers biscuits=yes'
+        script = 'salt://script.py'
+        ret = self.run_function('cmd.script', [script, args], cwd=tmp_cwd)
+        self.assertEqual(ret['stdout'], args)
 
     @destructiveTest
     def test_tty(self):


### PR DESCRIPTION
### What does this PR do?
Fix for the situation when using cmd.script and the CWD (current working directory) contains a space.

### What issues does this PR fix or reference?
#44315 

### Previous Behavior
Previously if the `cwd` argument contains a space then the call to `cmd.script` would fail because the internal function that can the command with the generated path did not take spaces in the cmd into account.

### New Behavior
This change runs the path through `_cmd_quote_ before it is passed along to ensure that spaces are safely accounted for.

### Tests written?
Yes

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
