### PR TITLE
Catch correct error type in list_keys and list_values

### DIFF
--- a/salt/modules/reg.py
+++ b/salt/modules/reg.py
@@ -240,7 +240,7 @@ def list_keys(hive, key=None, use_32bit_registry=False):
 
         handle.Close()
 
-    except WindowsError as exc:  # pylint: disable=E0602
+    except pywintypes.error as exc:  # pylint: disable=E0602
         log.debug(exc)
         log.debug('Cannot find key: {0}\\{1}'.format(hive, key))
         return False, 'Cannot find key: {0}\\{1}'.format(hive, key)
@@ -300,7 +300,7 @@ def list_values(hive, key=None, use_32bit_registry=False, include_default=True):
                      'vtype':  registry.vtype_reverse[vtype],
                      'success': True}
             values.append(value)
-    except WindowsError as exc:  # pylint: disable=E0602
+    except pywintypes.error as exc:  # pylint: disable=E0602
         log.debug(exc)
         log.debug(r'Cannot find key: {0}\{1}'.format(hive, key))
         return False, r'Cannot find key: {0}\{1}'.format(hive, key)


### PR DESCRIPTION
### What does this PR do?
Fixes a problem with the except in `list_keys` and `list_values` that was causing some test failures in Oxygen. It was detecting a `WindowsError` when it needed to detect a `pywintypes.error`.

https://jenkins.saltstack.com/job/Oxygen/job/oxygen-salt-windows-py2/8/testReport/junit/unit.modules.test_reg_win/RegWinTestCase/test_list_keys_fail/
https://jenkins.saltstack.com/job/Oxygen/job/oxygen-salt-windows-py2/8/testReport/junit/unit.modules.test_reg_win/RegWinTestCase/test_list_values_fail/


### What issues does this PR fix or reference?
https://github.com/saltstack/salt-jenkins/issues/439

### Tests written?
Yes

### Commits signed with GPG?
Yes