### PR TITLE
update the default configuration for joyent with a keyname

### DIFF
--- a/conf/cloud.providers.d/joyent.conf
+++ b/conf/cloud.providers.d/joyent.conf
@@ -3,3 +3,4 @@
 #    user: fred
 #    password: saltybacon
 #    private_key: /root/joyent.pem
+#    keyname: saltstack


### PR DESCRIPTION
this parameter is mandatory as otherwise the user is presented with a puzzling HTTP 401

### Tests written?

No (tests are already testing for `keyname` presence)

### Commits signed with GPG?

Yes