### PR TITLE
openbsdpkg.upgrade: implement pkg.upgrade for OpenBSD

### DIFF
--- a/salt/modules/openbsdpkg.py
+++ b/salt/modules/openbsdpkg.py
@@ -341,3 +341,72 @@ def purge(name=None, pkgs=None, **kwargs):
         salt '*' pkg.purge pkgs='["foo", "bar"]'
     '''
     return remove(name=name, pkgs=pkgs, purge=True)
+
+
+def upgrade_available(name):
+    '''
+    Check whether or not an upgrade is available for a given package
+
+    .. versionadded:: Fluorine
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' pkg.upgrade_available <package name>
+    '''
+    return latest_version(name) != ''
+
+
+def upgrade(name=None,
+            pkgs=None,
+            **kwargs):
+    '''
+    Run a full package upgrade (``pkg_add -u``), or upgrade a specific package
+    if ``name`` or ``pkgs`` is provided.
+    ``name`` is ignored when ``pkgs`` is specified.
+
+    Returns a dictionary containing the changes:
+
+    .. versionadded:: Fluorine
+
+    .. code-block:: python
+
+        {'<package>': {'old': '<old-version>',
+                       'new': '<new-version>'}}
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' pkg.upgrade
+        salt '*' pkg.upgrade python%2.7
+    '''
+    old = list_pkgs()
+
+    cmd = ['pkg_add', '-Ix', '-u']
+
+    if kwargs.get('noop', False):
+        cmd.append('-n')
+
+    if pkgs:
+        cmd.extend(pkgs)
+    elif name:
+        cmd.append(name)
+
+    # Now run the upgrade, compare the list of installed packages before and
+    # after and we have all the info we need.
+    result = __salt__['cmd.run_all'](cmd, output_loglevel='trace',
+                                     python_shell=False)
+
+    __context__.pop('pkg.list_pkgs', None)
+    new = list_pkgs()
+    ret = salt.utils.data.compare_dicts(old, new)
+
+    if result['retcode'] != 0:
+        raise CommandExecutionError(
+                'Problem encountered upgrading packages',
+                info={'changes': ret, 'result': result}
+        )
+
+    return ret

--- a/tests/unit/modules/test_openbsdpkg.py
+++ b/tests/unit/modules/test_openbsdpkg.py
@@ -21,6 +21,20 @@ from tests.support.mock import (
 import salt.modules.openbsdpkg as openbsdpkg
 
 
+class ListPackages(object):
+    def __init__(self):
+        self._iteration = 0
+
+    def __call__(self):
+        pkg_lists = [
+             {'vim': '7.4.1467p1-gtk2'},
+             {'png': '1.6.23', 'vim': '7.4.1467p1-gtk2', 'ruby': '2.3.1p1'}
+        ]
+        pkgs = pkg_lists[self._iteration]
+        self._iteration += 1
+        return pkgs
+
+
 @skipIf(NO_MOCK, NO_MOCK_REASON)
 class OpenbsdpkgTestCase(TestCase, LoaderModuleMockMixin):
     '''
@@ -64,18 +78,6 @@ class OpenbsdpkgTestCase(TestCase, LoaderModuleMockMixin):
         - a flavor is specified ('vim--gtk2')
         - a branch is specified ('ruby%2.3')
         '''
-        class ListPackages(object):
-            def __init__(self):
-                self._iteration = 0
-
-            def __call__(self):
-                pkg_lists = [
-                     {'vim': '7.4.1467p1-gtk2'},
-                     {'png': '1.6.23', 'vim': '7.4.1467p1-gtk2', 'ruby': '2.3.1p1'}
-                ]
-                pkgs = pkg_lists[self._iteration]
-                self._iteration += 1
-                return pkgs
 
         parsed_targets = (
             {'vim--gtk2': None, 'png': None, 'ruby%2.3': None},
@@ -109,3 +111,40 @@ class OpenbsdpkgTestCase(TestCase, LoaderModuleMockMixin):
         ]
         run_all_mock.assert_has_calls(expected_calls, any_order=True)
         self.assertEqual(run_all_mock.call_count, 3)
+
+    def test_upgrade_available(self):
+        '''
+        Test upgrade_available when an update is available.
+        '''
+        ret = MagicMock(return_value='5.4.2p0')
+        with patch('salt.modules.openbsdpkg.latest_version', ret):
+            self.assertTrue(openbsdpkg.upgrade_available('zsh'))
+
+    def test_upgrade_not_available(self):
+        '''
+        Test upgrade_available when an update is not available.
+        '''
+        ret = MagicMock(return_value='')
+        with patch('salt.modules.openbsdpkg.latest_version', ret):
+            self.assertFalse(openbsdpkg.upgrade_available('zsh'))
+
+    def test_upgrade(self):
+        '''
+        Test upgrading packages.
+        '''
+        ret = {}
+        pkg_add_u_stdout = [
+            'quirks-2.402 signed on 2018-01-02T16:30:59Z',
+            'Read shared items: ok'
+        ]
+        ret['stdout'] = '\n'.join(pkg_add_u_stdout)
+        ret['retcode'] = 0
+        run_all_mock = MagicMock(return_value=ret)
+        with patch.dict(openbsdpkg.__salt__, {'cmd.run_all': run_all_mock}):
+            with patch('salt.modules.openbsdpkg.list_pkgs', ListPackages()):
+                upgraded = openbsdpkg.upgrade()
+                expected = {
+                    'png': {'new': '1.6.23', 'old': ''},
+                    'ruby': {'new': '2.3.1p1', 'old': ''}
+                }
+                self.assertDictEqual(upgraded, expected)


### PR DESCRIPTION
### What does this PR do?

This allows to upgrade all packages, a single package or a selection of packages

### Previous Behavior

`pkg.upgrade` was not supported.

### New Behavior
```
# salt salt.localdomain pkg.upgrade name=libsodium
salt.localdomain:
    ----------
    libsodium:
        ----------
        new:
            1.0.16p0
        old:
            1.0.15
```

Full upgrade including error reporting:

```
# salt salt.localdomain pkg.upgrade
salt.localdomain:
    ERROR: Problem encountered upgrading packages. Additional info follows:

    changes:
        ----------
        nghttp2:
            ----------
            new:
                1.28.0
            old:
                1.27.0
    result:
        ----------
        pid:
            23339
        retcode:
            1
        stderr:
            Can't install python-2.7.14p0 because of libraries
            |library util.13.0 not found
        stdout:
            quirks-2.402 signed on 2017-12-19T15:56:16Z
            | /usr/lib/libutil.so.12.2 (system): bad major
            Direct dependencies for python-2.7.14p0->2.7.14p0 resolve to sqlite3-3.21.0 gettext-0.19.8.1p1 libffi-3.2.1p2 bzip2-1.0.6p8
            Full dependency tree is gettext-0.19.8.1p1 libffi-3.2.1p2 sqlite3-3.21.0 bzip2-1.0.6p8 libiconv-1.14p3
            Couldn't find updates for python-2.7.14p0
```

### Tests written?

No

### Commits signed with GPG?

Yes