### PR TITLE
#45147 - postgresql returner fails to connect to db when salt-ssh exe runs a command

### DIFF
--- a/salt/returners/__init__.py
+++ b/salt/returners/__init__.py
@@ -137,7 +137,7 @@ def _fetch_option(cfg, ret_config, virtualname, attr_name):
     if not ret_config:
         # Using the default configuration key
         if isinstance(cfg, dict):
-            return c_cfg.get(attr_name, cfg.get(default_cfg_key))
+            return c_cfg.get(default_cfg_key, cfg.get(attr_name))
         else:
             return c_cfg.get(attr_name, cfg(default_cfg_key))
 


### PR DESCRIPTION
### What does this PR do?
Modifies _fetch_option in returner/__init__.py to look for returner specific key (returner.postgres.user) before looking for generic key (e.g. user) in cfg (when it's a dict) 

### What issues does this PR fix or reference?
Issue #45147

### Tests written?

No
Though I'm in the process of testing the returners with scheduler

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
