### PR TITLE
Fix integration.modules.test_state.StateModuleTest.test_exclude

### DIFF
--- a/tests/integration/files/file/base/exclude-test.sls
+++ b/tests/integration/files/file/base/exclude-test.sls
@@ -4,7 +4,6 @@ exclude:
 include:
   - include-test
 
-{{ salt['runtests_helpers.get_salt_temp_dir_for_path']('exclude-test') }}:
-  file:
-    - managed
+{{ pillar['exclude-test'] }}:
+  file.managed:
     - source: salt://testfile

--- a/tests/integration/files/file/base/include-test.sls
+++ b/tests/integration/files/file/base/include-test.sls
@@ -1,7 +1,6 @@
 include:
   - to-include-test
 
-{{ salt['runtests_helpers.get_salt_temp_dir_for_path']('include-test') }}:
-  file:
-    - managed
+{{ pillar['include-test'] }}:
+  file.managed:
     - source: salt://testfile

--- a/tests/integration/files/file/base/orch/target-doesnt-exists.sls
+++ b/tests/integration/files/file/base/orch/target-doesnt-exists.sls
@@ -8,7 +8,7 @@ test-state:
   salt.state:
     - tgt: '*'
     - sls:
-      - include-test
+      - orch.target-test
 
 cmd.run:
   salt.function:

--- a/tests/integration/files/file/base/orch/target-exists.sls
+++ b/tests/integration/files/file/base/orch/target-exists.sls
@@ -8,7 +8,7 @@ test-state:
   salt.state:
     - tgt: '*'
     - sls:
-      - include-test
+      - orch.target-test
 
 cmd.run:
   salt.function:

--- a/tests/integration/files/file/base/orch/target-test.sls
+++ b/tests/integration/files/file/base/orch/target-test.sls
@@ -1,0 +1,2 @@
+always_true:
+  test.succeed_without_changes

--- a/tests/integration/files/file/base/to-include-test.sls
+++ b/tests/integration/files/file/base/to-include-test.sls
@@ -1,4 +1,3 @@
-{{ salt['runtests_helpers.get_salt_temp_dir_for_path']('to-include-test') }}:
-  file:
-    - managed
+{{ pillar['to-include-test'] }}:
+  file.managed:
     - source: salt://testfile

--- a/tests/integration/modules/test_state.py
+++ b/tests/integration/modules/test_state.py
@@ -4,6 +4,7 @@
 from __future__ import absolute_import
 import os
 import shutil
+import tempfile
 import textwrap
 import threading
 import time
@@ -330,44 +331,28 @@ class StateModuleTest(ModuleCase, SaltReturnAssertsMixin):
                 os.unlink(testfile)
 
     def test_include(self):
-        fnames = (
-            os.path.join(TMP, 'include-test'),
-            os.path.join(TMP, 'to-include-test')
-        )
-        exclude_test_file = os.path.join(
-            TMP, 'exclude-test'
-        )
-        try:
-            ret = self.run_function('state.sls', mods='include-test')
-            self.assertSaltTrueReturn(ret)
-
-            for fname in fnames:
-                self.assertTrue(os.path.isfile(fname))
-            self.assertFalse(os.path.isfile(exclude_test_file))
-        finally:
-            for fname in list(fnames) + [exclude_test_file]:
-                if os.path.isfile(fname):
-                    os.remove(fname)
+        tempdir = tempfile.mkdtemp(dir=TMP)
+        self.addCleanup(shutil.rmtree, tempdir, ignore_errors=True)
+        pillar = {}
+        for path in ('include-test', 'to-include-test', 'exclude-test'):
+            pillar[path] = os.path.join(tempdir, path)
+        ret = self.run_function('state.sls', mods='include-test', pillar=pillar)
+        self.assertSaltTrueReturn(ret)
+        self.assertTrue(os.path.isfile(pillar['include-test']))
+        self.assertTrue(os.path.isfile(pillar['to-include-test']))
+        self.assertFalse(os.path.isfile(pillar['exclude-test']))
 
     def test_exclude(self):
-        fnames = (
-            os.path.join(TMP, 'include-test'),
-            os.path.join(TMP, 'exclude-test')
-        )
-        to_include_test_file = os.path.join(
-            TMP, 'to-include-test'
-        )
-        try:
-            ret = self.run_function('state.sls', mods='exclude-test')
-            self.assertSaltTrueReturn(ret)
-
-            for fname in fnames:
-                self.assertTrue(os.path.isfile(fname))
-            self.assertFalse(os.path.isfile(to_include_test_file))
-        finally:
-            for fname in list(fnames) + [to_include_test_file]:
-                if os.path.isfile(fname):
-                    os.remove(fname)
+        tempdir = tempfile.mkdtemp(dir=TMP)
+        self.addCleanup(shutil.rmtree, tempdir, ignore_errors=True)
+        pillar = {}
+        for path in ('include-test', 'exclude-test', 'to-include-test'):
+            pillar[path] = os.path.join(tempdir, path)
+        ret = self.run_function('state.sls', mods='exclude-test', pillar=pillar)
+        self.assertSaltTrueReturn(ret)
+        self.assertTrue(os.path.isfile(pillar['include-test']))
+        self.assertTrue(os.path.isfile(pillar['exclude-test']))
+        self.assertFalse(os.path.isfile(pillar['to-include-test']))
 
     @skipIf(salt.utils.path.which_bin(KNOWN_BINARY_NAMES) is None, 'virtualenv not installed')
     def test_issue_2068_template_str(self):


### PR DESCRIPTION
test_exclude shares file paths with test_include, and while I can't
reproduce the failures, it is likely that improperly cleaned-up files
from test_include are causing the failures in test_exclude. This is
backed up by the fact that the state.sls return data from the
salt-runtests.log shows no trace of the "to-include-test" file
(suggesting it was excluded as expected), yet os.path.isfile() returns
True for this path, causing the test to fail.

This commit uses a distinct base dir for both tests, which should keep
this sort of failure from happening.

**EDIT: Found the reason for the failure: there was an orchestration
test using the "include-test" SLS which was leaving that file there.**