### PR TITLE
Fix Void having ipv4 iptable settings in wrong file

### DIFF
--- a/salt/modules/iptables.py
+++ b/salt/modules/iptables.py
@@ -110,7 +110,7 @@ def _conf(family='ipv4'):
         # SuSE does not seem to use separate files for IPv4 and IPv6
         return '/etc/sysconfig/scripts/SuSEfirewall2-custom'
     elif __grains__['os_family'] == 'Void':
-        if family == 'ipv6':
+        if family == 'ipv4':
             return '/etc/iptables/iptables.rules'
         else:
             return '/etc/iptables/ip6tables.rules'


### PR DESCRIPTION
### What does this PR do?

### What issues does this PR fix or reference?

### Previous Behavior

Currently it's ipv4 settings are saved in the ipv6 tables file `/etc/iptables/ip6tables.rules` and the other way around

### New Behavior

ipv4 settings get saved in `/etc/iptables/iptables.rules` and ipv6 settings in `/etc/iptables/ip6tables.rules`

### Tests written?

No

### Commits signed with GPG?

Yes?

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
