### PR TITLE
Pkg uptodate

### DIFF
--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -92,7 +92,7 @@ from salt.exceptions import (
 from salt.modules.pkg_resource import _repack_pkgs
 
 # Import 3rd-party libs
-import salt.ext.six as six
+from salt.ext import six
 
 # pylint: disable=invalid-name
 _repack_pkgs = _namespaced_function(_repack_pkgs, globals())
@@ -2846,10 +2846,10 @@ def uptodate(name, refresh=False, pkgs=None, **kwargs):
         try:
             packages = __salt__['pkg.list_upgrades'](refresh=refresh, **kwargs)
             expected = {pkgname: {'new': pkgver, 'old': __salt__['pkg.version'](pkgname)}
-                        for pkgname, pkgver in packages.iteritems()}
+                        for pkgname, pkgver in six.iteritems(packages)}
             if isinstance(pkgs, list):
                 packages = [pkg for pkg in packages if pkg in pkgs]
-                expected = {pkgname: pkgver for pkgname, pkgver in expected.iteritems() if pkgname in pkgs}
+                expected = {pkgname: pkgver for pkgname, pkgver in six.iteritems(expected) if pkgname in pkgs}
         except Exception as exc:
             ret['comment'] = str(exc)
             return ret

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -2845,8 +2845,11 @@ def uptodate(name, refresh=False, pkgs=None, **kwargs):
     if isinstance(refresh, bool):
         try:
             packages = __salt__['pkg.list_upgrades'](refresh=refresh, **kwargs)
+            expected = {pkgname: {'new': pkgver, 'old': __salt__['pkg.version'](pkgname)}
+                        for pkgname, pkgver in six.iteritems(packages)}
             if isinstance(pkgs, list):
                 packages = [pkg for pkg in packages if pkg in pkgs]
+                expected = {pkgname: pkgver for pkgname, pkgver in six.iteritems(expected) if pkgname in pkgs}
         except Exception as exc:
             ret['comment'] = str(exc)
             return ret
@@ -2860,6 +2863,7 @@ def uptodate(name, refresh=False, pkgs=None, **kwargs):
         return ret
     elif __opts__['test']:
         ret['comment'] = 'System update will be performed'
+        ret['changes'] = expected
         ret['result'] = None
         return ret
 

--- a/tests/unit/states/test_pkg.py
+++ b/tests/unit/states/test_pkg.py
@@ -1,0 +1,145 @@
+# -*- coding: utf-8 -*-
+
+# Import Python libs
+from __future__ import absolute_import
+
+# Import Salt Testing Libs
+from tests.support.mixins import LoaderModuleMockMixin
+from tests.support.unit import skipIf, TestCase
+from tests.support.mock import (
+    NO_MOCK,
+    NO_MOCK_REASON,
+    MagicMock,
+    patch)
+
+# Import Salt Libs
+from salt.ext import six
+import salt.states.pkg as pkg
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class PkgTestCase(TestCase, LoaderModuleMockMixin):
+    '''
+    Test cases for salt.states.pkg
+    '''
+    pkgs = {
+        'pkga': {'old': '1.0.1', 'new': '2.0.1'},
+        'pkgb': {'old': '1.0.2', 'new': '2.0.2'},
+        'pkgc': {'old': '1.0.3', 'new': '2.0.3'}
+    }
+
+    def setup_loader_modules(self):
+        return {
+            pkg: {
+                '__grains__': {
+                    'os': 'CentOS'
+                }
+            }
+        }
+
+    def test_uptodate_with_changes(self):
+        '''
+        Test pkg.uptodate with simulated changes
+        '''
+        list_upgrades = MagicMock(return_value={
+            pkgname: pkgver['new'] for pkgname, pkgver in six.iteritems(self.pkgs)
+        })
+        upgrade = MagicMock(return_value=self.pkgs)
+        version = MagicMock(side_effect=lambda pkgname: self.pkgs[pkgname]['old'])
+
+        with patch.dict(pkg.__salt__,
+                        {'pkg.list_upgrades': list_upgrades,
+                         'pkg.upgrade': upgrade,
+                         'pkg.version': version}):
+
+            # Run state with test=false
+            with patch.dict(pkg.__opts__, {'test': False}):
+
+                ret = pkg.uptodate('dummy', test=True)
+                self.assertTrue(ret['result'])
+                self.assertDictEqual(ret['changes'], self.pkgs)
+
+            # Run state with test=true
+            with patch.dict(pkg.__opts__, {'test': True}):
+                ret = pkg.uptodate('dummy', test=True)
+                self.assertIsNone(ret['result'])
+                self.assertDictEqual(ret['changes'], self.pkgs)
+
+    def test_uptodate_with_pkgs_with_changes(self):
+        '''
+        Test pkg.uptodate with simulated changes
+        '''
+
+        pkgs = {
+            'pkga': {'old': '1.0.1', 'new': '2.0.1'},
+            'pkgb': {'old': '1.0.2', 'new': '2.0.2'},
+            'pkgc': {'old': '1.0.3', 'new': '2.0.3'}
+        }
+
+        list_upgrades = MagicMock(return_value={
+            pkgname: pkgver['new'] for pkgname, pkgver in six.iteritems(self.pkgs)
+        })
+        upgrade = MagicMock(return_value=self.pkgs)
+        version = MagicMock(side_effect=lambda pkgname: pkgs[pkgname]['old'])
+
+        with patch.dict(pkg.__salt__,
+                        {'pkg.list_upgrades': list_upgrades,
+                         'pkg.upgrade': upgrade,
+                         'pkg.version': version}):
+            # Run state with test=false
+            with patch.dict(pkg.__opts__, {'test': False}):
+                ret = pkg.uptodate('dummy', test=True, pkgs=[pkgname for pkgname in six.iterkeys(self.pkgs)])
+                self.assertTrue(ret['result'])
+                self.assertDictEqual(ret['changes'], pkgs)
+
+            # Run state with test=true
+            with patch.dict(pkg.__opts__, {'test': True}):
+                ret = pkg.uptodate('dummy', test=True, pkgs=[pkgname for pkgname in six.iterkeys(self.pkgs)])
+                self.assertIsNone(ret['result'])
+                self.assertDictEqual(ret['changes'], pkgs)
+
+    def test_uptodate_no_changes(self):
+        '''
+        Test pkg.uptodate with no changes
+        '''
+        list_upgrades = MagicMock(return_value={})
+        upgrade = MagicMock(return_value={})
+
+        with patch.dict(pkg.__salt__,
+                        {'pkg.list_upgrades': list_upgrades,
+                         'pkg.upgrade': upgrade}):
+
+            # Run state with test=false
+            with patch.dict(pkg.__opts__, {'test': False}):
+
+                ret = pkg.uptodate('dummy', test=True)
+                self.assertTrue(ret['result'])
+                self.assertDictEqual(ret['changes'], {})
+
+            # Run state with test=true
+            with patch.dict(pkg.__opts__, {'test': True}):
+                ret = pkg.uptodate('dummy', test=True)
+                self.assertTrue(ret['result'])
+                self.assertDictEqual(ret['changes'], {})
+
+    def test_uptodate_with_pkgs_no_changes(self):
+        '''
+        Test pkg.uptodate with no changes
+        '''
+        list_upgrades = MagicMock(return_value={})
+        upgrade = MagicMock(return_value={})
+
+        with patch.dict(pkg.__salt__,
+                        {'pkg.list_upgrades': list_upgrades,
+                         'pkg.upgrade': upgrade}):
+            # Run state with test=false
+            with patch.dict(pkg.__opts__, {'test': False}):
+                ret = pkg.uptodate('dummy', test=True, pkgs=[pkgname for pkgname in six.iterkeys(self.pkgs)])
+                self.assertTrue(ret['result'])
+                self.assertDictEqual(ret['changes'], {})
+
+            # Run state with test=true
+            with patch.dict(pkg.__opts__, {'test': True}):
+                ret = pkg.uptodate('dummy', test=True, pkgs=[pkgname for pkgname in six.iterkeys(self.pkgs)])
+                self.assertTrue(ret['result'])
+                self.assertDictEqual(ret['changes'], {})


### PR DESCRIPTION
### What does this PR do?
Return a `changes` dictionary from `pkg.uptodate` when `test=true`

### What issues does this PR fix or reference?
According to the documentation, a state run with `test=true` should return a non-empty dictionary of changes that would have been made if it was run with `test=false`.

### Previous Behavior
1) If `pkg.uptodate` is run with `test=true`, the state module returns an empty `changes` dictionary. This causes various problems, namely that the `prereq` requisite does not work.
2) When called with an explicit package list, `pkg.uptodate` does check to see if the requested packages were actually upgraded.

### New Behavior
1) If `pkg.uptodate` is run with `test=true`, the state module returns a dictionary of the expected changes.
2) When called with an explicit package list, `pkg.uptodate` will fail if the requested packages were not successfully upgraded.

### Tests written?
Yes

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
