### PR TITLE
Fix state status.process Fixes #45188

### DIFF
--- a/salt/states/status.py
+++ b/salt/states/status.py
@@ -66,13 +66,13 @@ def process(name):
            'data': {}}  # Data field for monitoring state
 
     data = __salt__['status.pid'](name)
-    if name not in data:
+    # Check if there was output from status.pid, fail if no output
+    if len(data) == 0:
         ret['result'] = False
         ret['comment'] += 'Process signature "{0}" not found '.format(
             name
         )
         return ret
-    ret['data'] = data
     ret['comment'] += 'Process signature "{0}" was found '.format(
         name
     )


### PR DESCRIPTION
status.process should check if there was any output from status.pid in order to tell whether the provided name matched any running processes.

status.process should not return a list of pids to the caller when successful.  This result should be  true or false.

### What does this PR do?
This PR addresses an incorrect check for whether status.pid was successful.  It also fixes the output returned, so a list of pids is not displayed in the state report.

### What issues does this PR fix or reference?
45188


### Tests written?

No

### Commits signed with GPG?

No
