### PR TITLE
Use correct path when cleaning old jobs in local_cache returner

### DIFF
--- a/salt/returners/local_cache.py
+++ b/salt/returners/local_cache.py
@@ -420,16 +420,16 @@ def clean_old_jobs():
             for final in t_path_dirs:
                 f_path = os.path.join(t_path, final)
                 jid_file = os.path.join(f_path, 'jid')
-                if not os.path.isfile(jid_file) and os.path.exists(t_path):
+                if not os.path.isfile(jid_file) and os.path.exists(f_path):
                     # No jid file means corrupted cache entry, scrub it
-                    # by removing the entire t_path directory
-                    shutil.rmtree(t_path)
+                    # by removing the entire f_path directory
+                    shutil.rmtree(f_path)
                 elif os.path.isfile(jid_file):
                     jid_ctime = os.stat(jid_file).st_ctime
                     hours_difference = (time.time()- jid_ctime) / 3600.0
                     if hours_difference > __opts__['keep_jobs'] and os.path.exists(t_path):
-                        # Remove the entire t_path from the original JID dir
-                        shutil.rmtree(t_path)
+                        # Remove the entire f_path from the original JID dir
+                        shutil.rmtree(f_path)
 
         # Remove empty JID dirs from job cache, if they're old enough.
         # JID dirs may be empty either from a previous cache-clean with the bug

--- a/tests/unit/returners/test_local_cache.py
+++ b/tests/unit/returners/test_local_cache.py
@@ -123,8 +123,13 @@ class LocalCacheCleanOldJobsTestCase(TestCase, LoaderModuleMockMixin):
         with patch('os.path.isfile', MagicMock(return_value=False)) as mock:
             local_cache.clean_old_jobs()
 
-        # Assert that the JID dir was removed
-        self.assertEqual([], os.listdir(TMP_JID_DIR))
+        # there should be only 1 dir in TMP_JID_DIR
+        self.assertEqual(1, len(os.listdir(TMP_JID_DIR)))
+        # top level dir should still be present
+        self.assertEqual(True, os.path.exists(jid_dir))
+        self.assertEqual(True, os.path.isdir(jid_dir))
+        # while the 'jid' dir inside it should be gone
+        self.assertEqual(False, os.path.exists(jid_dir_name))
 
     def test_clean_old_jobs_jid_file_is_cleaned(self):
         '''
@@ -142,13 +147,25 @@ class LocalCacheCleanOldJobsTestCase(TestCase, LoaderModuleMockMixin):
         with patch.dict(local_cache.__opts__, {'keep_jobs': 0.00000001}):
             local_cache.clean_old_jobs()
 
-        # Assert that the JID dir was removed
-        self.assertEqual([], os.listdir(TMP_JID_DIR))
+        # there should be only 1 dir in TMP_JID_DIR
+        self.assertEqual(1, len(os.listdir(TMP_JID_DIR)))
+        # top level dir should still be present
+        self.assertEqual(True, os.path.exists(jid_dir))
+        self.assertEqual(True, os.path.isdir(jid_dir))
+        # while the 'jid' dir inside it should be gone
+        self.assertEqual(False, os.path.exists(jid_dir_name))
 
     def _make_tmp_jid_dirs(self, create_files=True):
         '''
         Helper function to set up temporary directories and files used for
         testing the clean_old_jobs function.
+
+        This emulates salt.utils.jid.jid_dir() by creating this structure:
+
+        TMP_JID_DIR dir/
+          random dir from tempfile.mkdtemp/
+            'jid' directory/
+              'jid' file
 
         Returns a temp_dir name and a jid_file_path. If create_files is False,
         the jid_file_path will be None.


### PR DESCRIPTION
local_cache returner uses 2 level directory structure:
upper: first 2 chars of the string generated by hashing the JID of the returning job
lower: remaining chars from the JID hash
This is done by running salt.utils.jid.jid_dir().
Upper dir contains lower dirs, lower dir contains job return data for the hashed JID.
clean_old_jobs() implemented here checks for return data files older than keep_jobs value, but when if finds such file it removes the upper dir instead of the lower dir. This means that any old job will result in the removal of all other jobs with JIDs that are hashed to a string with the same first two chars.
This PR corrects clean_old_jobs() to use the lower level dir when purging old jobs, which means that only specific job that was is old will be removed.
Fixes #45071

### What does this PR do?

### What issues does this PR fix or reference?

### Previous Behavior
Remove this section if not relevant

### New Behavior
Remove this section if not relevant

### Tests written?

Yes/No

### Commits signed with GPG?

Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
