### PR TITLE
status.pid returns pid ids not process names

### DIFF
--- a/salt/states/status.py
+++ b/salt/states/status.py
@@ -66,7 +66,7 @@ def process(name):
            'data': {}}  # Data field for monitoring state
 
     data = __salt__['status.pid'](name)
-    if name not in data:
+    if not data:
         ret['result'] = False
         ret['comment'] += 'Process signature "{0}" not found '.format(
             name


### PR DESCRIPTION
### What does this PR do?
As the title says, status.pid returns the pids of processes with the requested name, so when the status.process state looks up the pids, and checks if the name is in them, it will always fail.

### What issues does this PR fix or reference?
Fixes #45188

### Tests written?

No

### Commits signed with GPG?

Yes