### PR TITLE
[2017.7] Fix docstring integration test failure

### DIFF
--- a/tests/integration/files/file/base/_modules/runtests_helpers.py
+++ b/tests/integration/files/file/base/_modules/runtests_helpers.py
@@ -67,6 +67,7 @@ def get_invalid_docs():
         'nspawn.stop',
         'pkg.expand_repo_def',
         'pip.iteritems',
+        'pip.parse_version',
         'runtests_decorators.depends',
         'runtests_decorators.depends_will_fallback',
         'runtests_decorators.missing_depends',


### PR DESCRIPTION
### What does this PR do?
Fixes the following test failure:
- integration.modules.test_sysmod.SysModuleTest.test_valid_docs

### What issues does this PR fix or reference?
This was introduced with #44552.
