### PR TITLE
[2017.7] Check for running on python3 before decoding bytes

### DIFF
--- a/salt/utils/http.py
+++ b/salt/utils/http.py
@@ -429,7 +429,7 @@ def query(url,
                     'charset' in res_params and \
                     not isinstance(result_text, six.text_type):
                 result_text = result_text.decode(res_params['charset'])
-        if isinstance(result_text, bytes):
+        if six.PY3 and isinstance(result_text, bytes):
             result_text = result.body.decode('utf-8')
         ret['body'] = result_text
     else:


### PR DESCRIPTION
Fixes a test failure caused by #45090:

- unit.templates.test_jinja.TestCustomExtensions.test_http_query
