### PR TITLE
enable UsePAM for ssh tests

### DIFF
--- a/tests/integration/files/conf/_ssh/sshd_config
+++ b/tests/integration/files/conf/_ssh/sshd_config
@@ -54,4 +54,4 @@ AcceptEnv LANG LC_*
 
 Subsystem sftp /usr/lib/openssh/sftp-server
 
-#UsePAM yes
+UsePAM yes


### PR DESCRIPTION
### What does this PR do?
Enable PAM on sshd tests

It looks like no password is set on the root user by default in the amis, so with UsePAM set to no, sshd thinks the user is locked because it doesn’t have a password, so it fails before checking the ssh key

### What issues does this PR fix or reference?
Fixes saltstack/salt-jenkins#598

### Tests written?

Yes

### Commits signed with GPG?

Yes