### PR TITLE
Add ignore_retcode=True to the mdata commands

### DIFF
--- a/salt/grains/mdata.py
+++ b/salt/grains/mdata.py
@@ -29,7 +29,6 @@ import salt.modules.cmdmod
 __virtualname__ = 'mdata'
 __salt__ = {
     'cmd.run': salt.modules.cmdmod.run,
-    'cmd.run_all': salt.modules.cmdmod.run_all,
 }
 
 log = logging.getLogger(__name__)
@@ -63,8 +62,8 @@ def _user_mdata(mdata_list=None, mdata_get=None):
     if not mdata_list or not mdata_get:
         return grains
 
-    for mdata_grain in __salt__['cmd.run'](mdata_list).splitlines():
-        mdata_value = __salt__['cmd.run']('{0} {1}'.format(mdata_get, mdata_grain))
+    for mdata_grain in __salt__['cmd.run'](mdata_list, ignore_retcode=True).splitlines():
+        mdata_value = __salt__['cmd.run']('{0} {1}'.format(mdata_get, mdata_grain, ignore_retcode=True))
 
         if not mdata_grain.startswith('sdc:'):
             if 'mdata' not in grains:
@@ -107,7 +106,7 @@ def _sdc_mdata(mdata_list=None, mdata_get=None):
         return grains
 
     for mdata_grain in sdc_text_keys+sdc_json_keys:
-        mdata_value = __salt__['cmd.run']('{0} sdc:{1}'.format(mdata_get, mdata_grain))
+        mdata_value = __salt__['cmd.run']('{0} sdc:{1}'.format(mdata_get, mdata_grain, ignore_retcode=True))
 
         if not mdata_value.startswith('No metadata for '):
             if 'mdata' not in grains:

--- a/salt/modules/mdata.py
+++ b/salt/modules/mdata.py
@@ -91,7 +91,7 @@ def list_():
     mdata = _check_mdata_list()
     if mdata:
         cmd = '{0}'.format(mdata)
-        return __salt__['cmd.run'](cmd).splitlines()
+        return __salt__['cmd.run'](cmd, ignore_retcode=True).splitlines()
     return {}
 
 
@@ -122,7 +122,7 @@ def get_(*keyname):
     for k in keyname:
         if mdata:
             cmd = '{0} {1}'.format(mdata, k)
-            res = __salt__['cmd.run_all'](cmd)
+            res = __salt__['cmd.run_all'](cmd, ignore_retcode=True)
             ret[k] = res['stdout'] if res['retcode'] == 0 else ''
         else:
             ret[k] = ''
@@ -150,7 +150,7 @@ def put_(keyname, val):
 
     if mdata:
         cmd = 'echo {2} | {0} {1}'.format(mdata, keyname, val)
-        ret = __salt__['cmd.run_all'](cmd, python_shell=True)
+        ret = __salt__['cmd.run_all'](cmd, python_shell=True, ignore_retcode=True)
 
     return ret['retcode'] == 0
 
@@ -176,7 +176,7 @@ def delete_(*keyname):
     for k in keyname:
         if mdata and k in valid_keynames:
             cmd = '{0} {1}'.format(mdata, k)
-            ret[k] = __salt__['cmd.run_all'](cmd)['retcode'] == 0
+            ret[k] = __salt__['cmd.run_all'](cmd, ignore_retcode=True)['retcode'] == 0
         else:
             ret[k] = True
 


### PR DESCRIPTION
### What does this PR do?
We handle the failure of these commands in the code, we can ignore the
return code.

### What issues does this PR fix or reference?
N/A

### Previous Behavior
cmd.run was not told to ignore non-zero return codes

### New Behavior
We tell cmd.run to ignore the return codes

### Tests written?
No

### Commits signed with GPG?
No