### PR TITLE
aptpkg: apt-add-repository: Use proxy for PPA

### DIFF
--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -2205,12 +2205,18 @@ def mod_repo(repo, saltenv='base', **kwargs):
                 if repo_info:
                     return {repo: repo_info}
                 else:
+                    env = None
+                    http_proxy_url = _get_http_proxy_url()
+                    if http_proxy_url:
+                        env = {'http_proxy': http_proxy_url,
+                               'https_proxy': http_proxy_url}
                     if float(__grains__['osrelease']) < 12.04:
                         cmd = ['apt-add-repository', repo]
                     else:
                         cmd = ['apt-add-repository', '-y', repo]
                     out = __salt__['cmd.run_all'](cmd,
                                                   python_shell=False,
+                                                  env=env,
                                                   **kwargs)
                     if out['retcode']:
                         raise CommandExecutionError(


### PR DESCRIPTION
### What does this PR do?
Extend proxy support for APT repository handling to PPA addition
via `apt-add-repository`.

### What issues does this PR fix or reference?
Adding 'ppa: repo' behind a proxy fails.

### Previous Behavior
Proxy support works for all APT repos, as long as they are not added in 'ppa: repo' form.
When 'ppa: repo' is used, `apt-add-repository` is called without the proper http(s)_proxy env vars set and fails (after a very long timeout).

### New Behavior
Works as expected.

### Tests written?
No

### Commits signed with GPG?
Yes