### PR TITLE
Update kitchen to use runtests verifier on 2017.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,7 +92,8 @@ tests/integration/cloud/providers/pki/minions
 # Ignore tox virtualenvs
 /.tox/
 
-# Ignore kitchen stuff
-.kitchen
-.bundle
+# Kitchen tests files
+.kitchen.local.yml
+.kitchen/
+.bundle/
 Gemfile.lock

--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,4 @@ tests/integration/cloud/providers/pki/minions
 .kitchen/
 .bundle/
 Gemfile.lock
+/artifacts/

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -3,6 +3,7 @@
 <% version = '2017.7.1' %>
 <% platformsfile = ENV['SALT_KITCHEN_PLATFORMS'] || '.kitchen/platforms.yml' %>
 <% driverfile = ENV['SALT_KITCHEN_DRIVER'] || '.kitchen/driver.yml' %>
+<% verifierfile = ENV['SALT_KITCHEN_VERIFIER'] || '.kitchen/verifier.yml' %>
 
 <% if File.exists?(driverfile) %>
 <%= ERB.new(File.read(driverfile)).result %>
@@ -156,6 +157,8 @@ platforms:
 <% end %>
 suites:
   - name: py2
+    verifier:
+      python_bin: python2.7
     provisioner:
       pillars:
         top.sls:
@@ -170,6 +173,8 @@ suites:
     excludes:
       - centos-6
       - ubuntu-14.04
+    verifier:
+      python_bin: python3
     provisioner:
       pillars:
         top.sls:
@@ -181,12 +186,18 @@ suites:
           clone_repo: false
           py3: true
           salttesting_namespec: salttesting==2017.6.1
-verifier:
-  name: shell
-  remote_exec: true
-  live_stream: {}
-<% if ENV['TESTOPTS'].nil? %>
-  command: 'sudo -E $(kitchen) /tmp/kitchen/testing/tests/runtests.py -v --run-destructive --sysinfo --transport=zeromq --output-columns=80 --ssh --coverage-xml=/tmp/coverage.xml --xml=/tmp/xml-unittests-output'
+
+<% if File.exists?(verifierfile) %>
+<%= ERB.new(File.read(verifierfile)).result %>
 <% else %>
-  command: 'sudo -E $(kitchen) /tmp/kitchen/testing/tests/runtests.py -v --run-destructive --output-columns 80 <%= ENV["TESTOPTS"] %>'
+verifier:
+  name: runtests
+  sudo: true
+  verbose: true
+  run_destructive: true
+  transport: zeromq
+  types:
+    - ssh
+  xml: /tmp/xml-unittests
+  coverage_xml: /tmp/coverage.xml
 <% end %>

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -200,7 +200,7 @@ verifier:
   xml: /tmp/xml-unittests-output/
   coverage_xml: /tmp/coverage.xml
   save:
-    /tmp/xml-unittests-output/: artifacts/unittests
+    /tmp/xml-unittests-output: artifacts/
     /tmp/coverage.xml: artifacts/coverage/coverage.xml
     /var/log/salt/minion: artifacts/logs/minion
     /tmp/salt-runtests.log: artifacts/logs/salt-runtests.log

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -53,7 +53,6 @@ provisioner:
     base:
       "*":
         - git.salt
-        - kitchen
 <% if File.exists?(platformsfile) %>
 <%= ERB.new(File.read(platformsfile)).result %>
 <% else %>
@@ -198,6 +197,11 @@ verifier:
   transport: zeromq
   types:
     - ssh
-  xml: /tmp/xml-unittests
+  xml: /tmp/xml-unittests-output/
   coverage_xml: /tmp/coverage.xml
+  save:
+    /tmp/xml-unittests-output/: artifacts/unittests
+    /tmp/coverage.xml: artifacts/coverage/coverage.xml
+    /var/log/salt/minion: artifacts/logs/minion
+    /tmp/salt-runtests.log: artifacts/logs/salt-runtests.log
 <% end %>

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 
 source 'https://rubygems.org'
 
-gem 'test-kitchen'
+gem 'test-kitchen', :git => 'https://github.com/test-kitchen/test-kitchen.git'
 gem 'kitchen-salt', :git => 'https://github.com/saltstack/kitchen-salt.git'
 gem 'kitchen-sync'
 gem 'git'


### PR DESCRIPTION
### What does this PR do?
Backport changes to oxygen for runtests verifier in 2017.7


### Commits signed with GPG?

Yes