### PR TITLE
Backport #27160 to 2016.11

### DIFF
--- a/salt/modules/mount.py
+++ b/salt/modules/mount.py
@@ -82,7 +82,7 @@ def _active_mountinfo(ret):
                              'root': comps[3],
                              'opts': _resolve_user_group_names(comps[5].split(',')),
                              'fstype': comps[_sep + 1],
-                             'device': device_name,
+                             'device': device_name.replace('\\040', '\\ '),
                              'alt_device': _list.get(comps[4], None),
                              'superopts': _resolve_user_group_names(comps[_sep + 3].split(',')),
                              'device_uuid': device_uuid,
@@ -539,7 +539,7 @@ def set_fstab(
     # preserve arguments for updating
     entry_args = {
         'name': name,
-        'device': device,
+        'device': device.replace('\\ ', '\\040'),
         'fstype': fstype,
         'opts': opts,
         'dump': dump,


### PR DESCRIPTION
### What does this PR do?
Backports the space escape fixes for fstab from #27160 in to 2016.11 branch

### What issues does this PR fix or reference?
#27160

### Previous Behavior
An invalid entry is made into fstab, potentially causing later startup issues ... 
```
//server/DATA/Factura Electronica/Factura Nacion          /mnt/documents  cifs    credentials=/etc/credentials/srvprocess_user,iocharset=utf8,sec=ntlm 0 0
```

### New Behavior
Spaces in the mount path are escaped with `\040` 
```
//srvgoogle3/DATA/Factura\040Electronica/Factura\040Nacion          /mnt/documents  cifs    credentials=/etc/credentials/srvprocess_user,iocharset=utf8,sec=ntlm 0 0
```

### Tests written?
No

### Commits signed with GPG?
No
