### PR TITLE
Roll cffi dep back to version 1.10.0

### DIFF
--- a/pkg/windows/req.txt
+++ b/pkg/windows/req.txt
@@ -1,7 +1,7 @@
 backports-abc==0.5
 backports.ssl-match-hostname==3.5.0.1
 certifi
-cffi==1.11.2
+cffi==1.10.0
 cryptography==2.1.4
 enum34==1.1.6
 futures==3.1.1


### PR DESCRIPTION
### What does this PR do?
Fixes a stack traced caused by the newer version of CFFI by rolling it back to version 1.10.0.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/45241
https://github.com/saltstack/salt/issues/45242

### Tests written?
NA

### Commits signed with GPG?
Yes