### PR TITLE
Fix #23454 : make pydsl work with salt-ssh

### DIFF
--- a/salt/client/ssh/state.py
+++ b/salt/client/ssh/state.py
@@ -72,6 +72,12 @@ class SSHHighState(salt.state.BaseHighState):
         self.matcher = salt.minion.Matcher(self.opts)
         self.tops = salt.loader.tops(self.opts)
 
+        self._pydsl_all_decls = {}
+        self._pydsl_render_stack = []
+
+    def push_active(self):
+        salt.state.HighState.stack.append(self)
+
     def load_dynamic(self, matches):
         '''
         Stub out load_dynamic


### PR DESCRIPTION
### What does this PR do?
pydsl renderer needs to reference currently running highstate using ```HighState.get_active()```. ```SSHHighState```instances created during salt-ssh runs were not registered/pushed to ```HighState.stack```.

This PR 
 -  adds ```_pydsl_all_decls, _pydsl_render_stack``` variable initializations to ```SSHHighState``` as required by ```pydsl``` renderer 
 -  adds ```push_active()``` method to ```SSHHighstate```.
 -  calls ```st_.push_active()``` in the right places to register ```SSHHighState``` instances to ```HighState.stack``` 
- sets ```slsmod``` references to ```None``` in rendered ```pydsl``` low_data/high_data to make it JSON serializable 

### What issues does this PR fix or reference?
#23454
### Previous Behavior
When trying to execute/render pydsl states, salt-ssh would throw the following error
```AttributeError: 'NoneType' object has no attribute 'building_highstate'```

### New Behavior
pydsl states now work correctly

### Tests written?
No

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
