### PR TITLE
Fix MacOSX Service Status Check and integration test

### DIFF
--- a/salt/modules/mac_service.py
+++ b/salt/modules/mac_service.py
@@ -421,7 +421,7 @@ def status(name, sig=None, runas=None):
     for line in output.splitlines():
         if 'PID' in line:
             continue
-        if re.search(name, line):
+        if re.search(name, line.split()[-1]):
             if line.split()[0].isdigit():
                 if pids:
                     pids += '\n'

--- a/tests/integration/modules/test_service.py
+++ b/tests/integration/modules/test_service.py
@@ -25,6 +25,8 @@ class ServiceModuleTest(ModuleCase):
         elif os_family == 'Arch':
             self.service_name = 'systemd-journald'
             cmd_name = 'systemctl'
+        elif os_family == 'MacOS':
+            self.service_name = 'org.ntp.ntpd'
 
         if salt.utils.which(cmd_name) is None:
             self.skipTest('{0} is not installed'.format(cmd_name))


### PR DESCRIPTION
### What does this PR do?
Fixes a bug in the mac_service execution modue status method and fixes the test for it as well.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt-jenkins/issues/640

### Previous Behavior
Previously when trying to get the status of a service it wouldn't return anything:

```
jk-sierra-base:testing root# salt-call --local service.status org.ntp.ntpd
local:
jk-sierra-base:testing root# 
```

This is because when running `launchctl list` to grab the status it returns something similar to teh following: `-\t0\tcom.apple.storedownloadd.daemon`, so we need to split to ensure the tab is not included in the service name when we then do the check to see if they match.

### New Behavior
Now the pid returns: 

```
jk-sierra-base:testing root# salt-call --local service.status org.ntp.ntpd
local:
    217
jk-sierra-base:testing root# 
```

This also fixes the test for MacOSX which was previously failing.

### Tests written?

Yes

### Commits signed with GPG?

Yes