### PR TITLE
Make some kitchen-salt tests blue

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -13,7 +13,7 @@ driver:
   use_sudo: false
   hostname: salt
   privileged: true
-  username: root
+  username: kitchen
   volume:
     - /var/run/docker.sock:/docker.sock
   cap_add:
@@ -21,11 +21,8 @@ driver:
   disable_upstart: false
   provision_command:
     - echo 'L /run/docker.sock - - - - /docker.sock' > /etc/tmpfiles.d/docker.conf
-transport:
-  name: sftp
 <% end %>
 
-sudo: true
 provisioner:
   name: salt_solo
   salt_install: bootstrap
@@ -33,6 +30,7 @@ provisioner:
   salt_bootstrap_url: https://bootstrap.saltstack.com
   salt_bootstrap_options: -X stable <%= version %>
   log_level: info
+  sudo: true
   require_chef: false
   remote_states:
     name: git://github.com/saltstack/salt-jenkins.git

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -21,6 +21,8 @@ driver:
   disable_upstart: false
   provision_command:
     - echo 'L /run/docker.sock - - - - /docker.sock' > /etc/tmpfiles.d/docker.conf
+transport:
+  name: rsync
 <% end %>
 
 provisioner:
@@ -28,7 +30,7 @@ provisioner:
   salt_install: bootstrap
   salt_version: latest
   salt_bootstrap_url: https://bootstrap.saltstack.com
-  salt_bootstrap_options: -X stable <%= version %>
+  salt_bootstrap_options: -X -p rsync stable <%= version %>
   log_level: info
   sudo: true
   require_chef: false
@@ -60,7 +62,7 @@ platforms:
       image: fedora:latest
       run_command: /usr/lib/systemd/systemd
     provisioner:
-      salt_bootstrap_options: -X git v<%= version %> >/dev/null
+      salt_bootstrap_options: -X -p rsync git v<%= version %> >/dev/null
   - name: centos-7
     driver_config:
       run_command: /usr/lib/systemd/systemd
@@ -70,7 +72,7 @@ platforms:
       provision_command:
         - yum install -y upstart
     provisioner:
-      salt_bootstrap_options: -P -y -x python2.7 -X git v<%= version %> >/dev/null
+      salt_bootstrap_options: -P -p rsync -y -x python2.7 -X git v<%= version %> >/dev/null
   - name: ubuntu-rolling
     driver_config:
       image: ubuntu:rolling
@@ -104,7 +106,7 @@ platforms:
         - systemctl enable sshd
         - echo 'L /run/docker.sock - - - - /docker.sock' > /etc/tmpfiles.d/docker.conf
     provisioner:
-      salt_bootstrap_options: -X git v<%= version %> >/dev/null
+      salt_bootstrap_options: -X -p rsync git v<%= version %> >/dev/null
   - name: opensuse
     driver_config:
       run_command: /usr/lib/systemd/systemd
@@ -112,7 +114,7 @@ platforms:
         - systemctl enable sshd.service
         - echo 'L /run/docker.sock - - - - /docker.sock' > /etc/tmpfiles.d/docker.conf
     provisioner:
-      salt_bootstrap_options: -X git v<%= version %> >/dev/null
+      salt_bootstrap_options: -X -p rsync git v<%= version %> >/dev/null
 <% if vagrant != false %>
   - name: windows-2012r2
     driver:

--- a/tests/integration/runners/test_runner_returns.py
+++ b/tests/integration/runners/test_runner_returns.py
@@ -125,6 +125,10 @@ class RunnerReturnsTest(ShellCase):
         self.clean_return(deserialized['return'])
 
         # Now we have something sane we can reliably compare in an assert.
+        if 'SUDO_USER' in os.environ:
+            user = 'sudo_{0}'.format(os.environ['SUDO_USER'])
+        else:
+            user = RUNTIME_VARS.RUNNING_TESTS_USER
         self.assertEqual(
             deserialized,
             {'return': {'fun': 'runner.test.arg',
@@ -132,5 +136,5 @@ class RunnerReturnsTest(ShellCase):
                         'jid': jid,
                         'return': {'args': ['foo'], 'kwargs': {'bar': 'hello world!'}},
                         'success': True,
-                        'user': RUNTIME_VARS.RUNNING_TESTS_USER if 'SUDO_USER' not in os.environ else 'root'}}
+                        'user': user}}
         )


### PR DESCRIPTION
### What does this PR do?
Use rsync transport so that when uploading symlinks they get preserved.

Also, when running the test suite as `sudo python testing/tests/runtests.py` check for the correct user in salt-run

### Tests written?

Yes

### Commits signed with GPG?

Yes