### PR TITLE
encode environment with 'backslashreplace' fix #45266

### DIFF
--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -445,7 +445,7 @@ def _run(cmd,
             fse = sys.getfilesystemencoding()
             for key, val in six.iteritems(env):
                 if isinstance(val, six.text_type):
-                    env[key] = val.encode(fse)
+                    env[key] = val.encode(fse, 'backslashreplace')
         except ValueError:
             raise CommandExecutionError(
                 'Environment could not be retrieved for User \'{0}\''.format(


### PR DESCRIPTION
### What does this PR do?
If environment variables contain non-ascii chars, do not fail.



### What issues does this PR fix or reference?
fix #45266

### Previous Behavior

See issue on github

No. If you give me a hint how to write a test for this, then I will write one.

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
