### PR TITLE
Fix pkg.install packagename version=latest i.e. if on an old version is installed

### DIFF
--- a/doc/topics/releases/2016.11.9.rst
+++ b/doc/topics/releases/2016.11.9.rst
@@ -14,7 +14,8 @@ Significate changes (PR #43708, damon-atkins) have been made to the pkg executio
 - ``pkg.list_available`` no longer defaults to refreshing the winrepo meta database.
 - ``pkg.install`` without a ``version`` parameter no longer upgrades software if the software is already installed. Use ``pkg.install version=latest`` or in a state use ``pkg.latest`` to get the old behavior. 
 - Documentation was update for the execution module to match the style in new versions, some corrections as well.
-- All install/remove commands are prefix with cmd.exe shell and cmdmod is called with a command line string instead of a list. Some sls files in saltstack/salt-winrepo-ng expected the commands to be prefixed with cmd.exe (i.e. the use of ``&``). (
+- All install/remove commands are prefix with cmd.exe shell and cmdmod is called with a command line string instead of a list. Some sls files in saltstack/salt-winrepo-ng expected the commands to be prefixed with cmd.exe (i.e. the use of ``&``).
+- Some execution module functions results, now behavour more like their Unix/Linux versions.
 Execution module cmdmod
 --------------------
 Windows cmdmod forcing cmd to be a list (issue #43522) resolved by "cmdmod: Don't list-ify string commands on Windows" PR #43807. Linux/Unix OS command & arguments requires a list. Windows was being treated the same. Windows requires commands & arguments to be a string, which this PR fixes.  

--- a/doc/topics/releases/2016.11.9.rst
+++ b/doc/topics/releases/2016.11.9.rst
@@ -9,12 +9,12 @@ Windows
 =======
 Execution module pkg
 --------------------
-Significate changes (PR #43708) have been made to the pkg execution module. Users should test this release against their existing package sls definition files.
+Significate changes (PR #43708, damon-atkins) have been made to the pkg execution module. Users should test this release against their existing package sls definition files.
 
 - ``pkg.list_available`` no longer defaults to refreshing the winrepo meta database.
 - ``pkg.install`` without a ``version`` parameter no longer upgrades software if the software is already installed. Use ``pkg.install version=latest`` or in a state use ``pkg.latest`` to get the old behavior. 
 - Documentation was update for the execution module to match the style in new versions, some corrections as well.
-- All install/remove commands are prefix with cmd.exe shell and cmdmod is called with a command line string instead of a list. Some sls files in saltstack/salt-winrepo-ng expected the commands to be prefixed with cmd.exe (i.e. the use of ``&``).
+- All install/remove commands are prefix with cmd.exe shell and cmdmod is called with a command line string instead of a list. Some sls files in saltstack/salt-winrepo-ng expected the commands to be prefixed with cmd.exe (i.e. the use of ``&``). (
 Execution module cmdmod
 --------------------
 Windows cmdmod forcing cmd to be a list (issue #43522) resolved by "cmdmod: Don't list-ify string commands on Windows" PR #43807. Linux/Unix OS command & arguments to be a list. Windows was being treated the same. Windows requires commands & arguments to be a string, which this PR fixes.  

--- a/doc/topics/releases/2016.11.9.rst
+++ b/doc/topics/releases/2016.11.9.rst
@@ -17,5 +17,5 @@ Significate changes (PR #43708, damon-atkins) have been made to the pkg executio
 - All install/remove commands are prefix with cmd.exe shell and cmdmod is called with a command line string instead of a list. Some sls files in saltstack/salt-winrepo-ng expected the commands to be prefixed with cmd.exe (i.e. the use of ``&``). (
 Execution module cmdmod
 --------------------
-Windows cmdmod forcing cmd to be a list (issue #43522) resolved by "cmdmod: Don't list-ify string commands on Windows" PR #43807. Linux/Unix OS command & arguments to be a list. Windows was being treated the same. Windows requires commands & arguments to be a string, which this PR fixes.  
+Windows cmdmod forcing cmd to be a list (issue #43522) resolved by "cmdmod: Don't list-ify string commands on Windows" PR #43807. Linux/Unix OS command & arguments requires a list. Windows was being treated the same. Windows requires commands & arguments to be a string, which this PR fixes.  
 

--- a/doc/topics/releases/2016.11.9.rst
+++ b/doc/topics/releases/2016.11.9.rst
@@ -4,3 +4,18 @@ Salt 2016.11.9 Release Notes
 
 Version 2016.11.9 is a bugfix release for :ref:`2016.11.0 <release-2016-11-0>`.]
 
+
+Windows
+=======
+Execution module pkg
+--------------------
+Significate changes (PR #43708) have been made to the pkg execution module. Users should test this release against their existing package sls definition files.
+
+- ``pkg.list_available`` no longer defaults to refreshing the winrepo meta database.
+- ``pkg.install`` without a ``version`` parameter no longer upgrades software if the software is already installed. Use ``pkg.install version=latest`` or in a state use ``pkg.latest`` to get the old behavior. 
+- Documentation was update for the execution module to match the style in new versions, some corrections as well.
+- All install/remove commands are prefix with cmd.exe shell and cmdmod is called with a command line string instead of a list. Some sls files in saltstack/salt-winrepo-ng expected the commands to be prefixed with cmd.exe (i.e. the use of ``&``).
+Execution module cmdmod
+--------------------
+Windows cmdmod forcing cmd to be a list (issue #43522) resolved by "cmdmod: Don't list-ify string commands on Windows" PR #43807. Linux/Unix OS command & arguments to be a list. Windows was being treated the same. Windows requires commands & arguments to be a string, which this PR fixes.  
+

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -155,7 +155,7 @@ def latest_version(*names, **kwargs):
             # check, whether latest available version
             # is newer than latest installed version
             if compare_versions(ver1=six.text_type(latest_available),
-                                oper=six.text_type('>'),
+                                oper='>',
                                 ver2=six.text_type(latest_installed)):
                 log.debug('Upgrade of {0} from {1} to {2} '
                           'is available'.format(name,
@@ -1164,7 +1164,10 @@ def install(name=None, refresh=False, pkgs=None, **kwargs):
                 version_num = six.text_type(version_num)
 
         if not version_num:
-            # following can be version number or latest
+            # following can be version number or latest or Not Found
+            version_num = _get_latest_pkg_version(pkginfo)
+
+        if version_num == 'latest' and 'latest' not in pkginfo:
             version_num = _get_latest_pkg_version(pkginfo)
 
         # Check if the version is already installed
@@ -1173,9 +1176,8 @@ def install(name=None, refresh=False, pkgs=None, **kwargs):
             # Desired version number already installed
             ret[pkg_name] = {'current': version_num}
             continue
-
         # If version number not installed, is the version available?
-        elif version_num not in pkginfo:
+        elif version_num != 'latest' and version_num not in pkginfo:
             log.error('Version {0} not found for package '
                       '{1}'.format(version_num, pkg_name))
             ret[pkg_name] = {'not found': version_num}


### PR DESCRIPTION
### What does this PR do?
While comparing pkg_win (too big) against existing win_pkg (2k lines) discovered a bug in pkg.install handling of version=latest

### Previous Behaviour
version=latest was not handled well.

### New Behaviour

version=latest results in
* a installation of the latest version if current version is old
* if latest is used as the version number in the sls definition software will be download and install every-time. Unfortunately there is no alternative.

### Tests written?

No

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.

  