### PR TITLE
[develop] Updates to scheduler for disabled jobs

### DIFF
--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -803,9 +803,6 @@ class Schedule(object):
             if not isinstance(data, dict):
                 log.error('Scheduled job "{0}" should have a dict value, not {1}'.format(job, type(data)))
                 continue
-            # Job is disabled, continue
-            if 'enabled' in data and not data['enabled']:
-                continue
             if 'function' in data:
                 func = data['function']
             elif 'func' in data:
@@ -1168,6 +1165,7 @@ class Schedule(object):
                                     if now <= start or now >= end:
                                         run = True
                                     else:
+                                        data['_skip_reason'] = 'in_skip_range'
                                         run = False
                                 else:
                                     if start <= now <= end:
@@ -1177,6 +1175,7 @@ class Schedule(object):
                                             run = True
                                             func = self.skip_function
                                         else:
+                                            data['_skip_reason'] = 'not_in_range'
                                             run = False
                             else:
                                 log.error('schedule.handle_func: Invalid range, end must be larger than start. \
@@ -1228,6 +1227,7 @@ class Schedule(object):
                                         run = True
                                         func = self.skip_function
                                     else:
+                                        data['_skip_reason'] = 'in_skip_range'
                                         run = False
                                 else:
                                     run = True
@@ -1258,6 +1258,7 @@ class Schedule(object):
                                 func = self.skip_function
                             else:
                                 run = False
+                                data['_skip_reason'] = 'skip_explicit'
                         else:
                             run = True
 
@@ -1294,22 +1295,28 @@ class Schedule(object):
                 returners = self.returners
                 self.returners = {}
             try:
-                if multiprocessing_enabled:
-                    thread_cls = salt.utils.process.SignalHandlingMultiprocessingProcess
+                # Job is disabled, continue
+                if 'enabled' in data and not data['enabled']:
+                    log.debug('Job: %s is disabled', job)
+                    data['_skip_reason'] = 'disabled'
+                    continue
                 else:
-                    thread_cls = threading.Thread
-                proc = thread_cls(target=self.handle_func, args=(multiprocessing_enabled, func, data))
+                    if multiprocessing_enabled:
+                        thread_cls = salt.utils.process.SignalHandlingMultiprocessingProcess
+                    else:
+                        thread_cls = threading.Thread
+                    proc = thread_cls(target=self.handle_func, args=(multiprocessing_enabled, func, data))
 
-                if multiprocessing_enabled:
-                    with salt.utils.process.default_signals(signal.SIGINT, signal.SIGTERM):
-                        # Reset current signals before starting the process in
-                        # order not to inherit the current signal handlers
+                    if multiprocessing_enabled:
+                        with salt.utils.process.default_signals(signal.SIGINT, signal.SIGTERM):
+                            # Reset current signals before starting the process in
+                            # order not to inherit the current signal handlers
+                            proc.start()
+                    else:
                         proc.start()
-                else:
-                    proc.start()
 
-                if multiprocessing_enabled:
-                    proc.join()
+                    if multiprocessing_enabled:
+                        proc.join()
             finally:
                 if '_seconds' in data:
                     data['_next_fire_time'] = now + data['_seconds']


### PR DESCRIPTION
### What does this PR do?
Moving the logic for when a job is disabled further down into the try_finally block so the _next_fire_time is updated even when a job is disabled.  Adding a hidden attribute to keep track of the reason a job was skipped.

### What issues does this PR fix or reference?
N/A

### Tests written?
Tests exist for scheduler

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
