### PR TITLE
Fix issue with zfs_support grain on Windows

### DIFF
--- a/salt/grains/zfs.py
+++ b/salt/grains/zfs.py
@@ -19,7 +19,13 @@ import logging
 import salt.utils.dictupdate
 import salt.utils.path
 import salt.utils.platform
-from salt.modules.zfs import _conform_value
+try:
+    # The zfs_support grain will only be set to True if this module is supported
+    # This allows the grain to be set to False on systems that don't support zfs
+    # _conform_value is only called if zfs_support is set to True
+    from salt.modules.zfs import _conform_value
+except ImportError:
+    pass
 
 # Solve the Chicken and egg problem where grains need to run before any
 # of the modules are loaded and are generally available for any usage.
@@ -38,7 +44,7 @@ def __virtual__():
     Load zfs grains
     '''
     # NOTE: we always load this grain so we can properly export
-    #       atleast the zfs_support grain
+    #       at least the zfs_support grain
     return __virtualname__
 
 


### PR DESCRIPTION
### What does this PR do?
Allows the `zfs_support` grain to be set even when the zfs module fails to load. The grain will be set to `False` of course

### What issues does this PR fix or reference?
Found in testing

### Previous Behavior
Grain not set and a Stack Trace (Py3):
```
[DEBUG   ] Failed to import grains zfs:
Traceback (most recent call last):
  File "C:\salt\bin\lib\site-packages\salt\loader.py", line 1451, in _load_module
    mod = spec.loader.load_module()
  File "<frozen importlib._bootstrap_external>", line 396, in _check_name_wrapper
  File "<frozen importlib._bootstrap_external>", line 817, in load_module
  File "<frozen importlib._bootstrap_external>", line 676, in load_module
  File "<frozen importlib._bootstrap>", line 268, in _load_module_shim
  File "<frozen importlib._bootstrap>", line 693, in _load
  File "<frozen importlib._bootstrap>", line 673, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 673, in exec_module
  File "<frozen importlib._bootstrap>", line 222, in _call_with_frames_removed
  File "C:\salt\bin\lib\site-packages\salt\grains\zfs.py", line 22, in <module>
    from salt.modules.zfs import _conform_value
ImportError: No module named 'salt.modules.zfs'
```
Py2:
```
[DEBUG   ] Failed to import grains zfs:
Traceback (most recent call last):
  File "C:\salt\bin\lib\site-packages\salt\loader.py", line 1458, in _load_module
    mod = imp.load_module(mod_namespace, fn_, fpath, desc)
  File "C:\salt\bin\lib\site-packages\salt\grains\zfs.py", line 22, in <module>
    from salt.modules.zfs import _conform_value
ImportError: No module named zfs
```

### New Behavior
Grain is now set. No stack trace.

### Tests written?
No

### Commits signed with GPG?
Yes
  