### PR TITLE
Put pywin32 dlls in correct location in buildenv scripts

### DIFF
--- a/pkg/windows/build_env_2.ps1
+++ b/pkg/windows/build_env_2.ps1
@@ -248,7 +248,7 @@ Start_Process_and_test_exitcode "$($ini['Settings']['Scripts2Dir'])\pip.exe" "in
 # Move DLL's to Python Root
 Write-Output " - $script_name :: Moving PyWin32 DLLs . . ."
 # The dlls have to be in Python directory and the site-packages\win32 directory
-Move-Item "$($ini['Settings']['SitePkgs2Dir'])\pywin32_system32\*.dll" "$($ini['Settings']['Python2Dir'])" -Force
+Copy-Item "$($ini['Settings']['SitePkgs2Dir'])\pywin32_system32\*.dll" "$($ini['Settings']['Python2Dir'])" -Force
 Move-Item "$($ini['Settings']['SitePkgs2Dir'])\pywin32_system32\*.dll" "$($ini['Settings']['SitePkgs2Dir'])\win32" -Force
 
 # Create gen_py directory

--- a/pkg/windows/build_env_2.ps1
+++ b/pkg/windows/build_env_2.ps1
@@ -247,7 +247,7 @@ Start_Process_and_test_exitcode "$($ini['Settings']['Scripts2Dir'])\pip.exe" "in
 
 # Move DLL's to Python Root
 Write-Output " - $script_name :: Moving PyWin32 DLLs . . ."
-Move-Item "$($ini['Settings']['SitePkgs2Dir'])\pywin32_system32\*.dll" "$($ini['Settings']['Python2Dir'])" -Force
+Move-Item "$($ini['Settings']['SitePkgs2Dir'])\pywin32_system32\*.dll" "$($ini['Settings']['SitePkgs2Dir'])\win32" -Force
 
 # Create gen_py directory
 Write-Output " - $script_name :: Creating gen_py Directory . . ."

--- a/pkg/windows/build_env_2.ps1
+++ b/pkg/windows/build_env_2.ps1
@@ -247,6 +247,8 @@ Start_Process_and_test_exitcode "$($ini['Settings']['Scripts2Dir'])\pip.exe" "in
 
 # Move DLL's to Python Root
 Write-Output " - $script_name :: Moving PyWin32 DLLs . . ."
+# The dlls have to be in Python directory and the site-packages\win32 directory
+Move-Item "$($ini['Settings']['SitePkgs2Dir'])\pywin32_system32\*.dll" "$($ini['Settings']['Python2Dir'])" -Force
 Move-Item "$($ini['Settings']['SitePkgs2Dir'])\pywin32_system32\*.dll" "$($ini['Settings']['SitePkgs2Dir'])\win32" -Force
 
 # Create gen_py directory

--- a/pkg/windows/build_env_3.ps1
+++ b/pkg/windows/build_env_3.ps1
@@ -246,8 +246,10 @@ DownloadFileWithProgress $url $file
 Start_Process_and_test_exitcode "$($ini['Settings']['Scripts3Dir'])\pip.exe" "install $file " "pip install PyWin32"
 
 # Move DLL's to Python Root
+# In Python 3 the dlls have to be in Python directory and the site-packages\win32 directory
 Write-Output " - $script_name :: Moving PyWin32 DLLs . . ."
-Move-Item "$($ini['Settings']['SitePkgs3Dir'])\pywin32_system32\*.dll" "$($ini['Settings']['Python3Dir'])" -Force
+Copy-Item "$($ini['Settings']['SitePkgs3Dir'])\pywin32_system32\*.dll" "$($ini['Settings']['Python3Dir'])" -Force
+Move-Item "$($ini['Settings']['SitePkgs3Dir'])\pywin32_system32\*.dll" "$($ini['Settings']['SitePkgs3Dir'])\win32" -Force
 
 # Create gen_py directory
 Write-Output " - $script_name :: Creating gen_py Directory . . ."

--- a/pkg/windows/build_env_3.ps1
+++ b/pkg/windows/build_env_3.ps1
@@ -246,7 +246,7 @@ DownloadFileWithProgress $url $file
 Start_Process_and_test_exitcode "$($ini['Settings']['Scripts3Dir'])\pip.exe" "install $file " "pip install PyWin32"
 
 # Move DLL's to Python Root
-# In Python 3 the dlls have to be in Python directory and the site-packages\win32 directory
+# The dlls have to be in Python directory and the site-packages\win32 directory
 Write-Output " - $script_name :: Moving PyWin32 DLLs . . ."
 Copy-Item "$($ini['Settings']['SitePkgs3Dir'])\pywin32_system32\*.dll" "$($ini['Settings']['Python3Dir'])" -Force
 Move-Item "$($ini['Settings']['SitePkgs3Dir'])\pywin32_system32\*.dll" "$($ini['Settings']['SitePkgs3Dir'])\win32" -Force


### PR DESCRIPTION
Py2 dlls go in site-packages\win32
Py3 dlls go in site-packages\win32 and the root of python

### What issues does this PR fix or reference?
Found in testing

### Tests written?
NA

### Commits signed with GPG?
Yes