### PR TITLE
include backports_abc

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -11,7 +11,7 @@ profile=no
 
 # Add files or directories to the blacklist. They should be base names, not
 # paths.
-ignore=CVS
+ignore=CVS,ext
 
 # Pickle collected data for later comparisons.
 persistent=yes

--- a/.testing.pylintrc
+++ b/.testing.pylintrc
@@ -8,7 +8,7 @@
 
 # Add files or directories to the blacklist. They should be base names, not
 # paths.
-ignore=CVS
+ignore=CVS,ext
 
 # Pickle collected data for later comparisons.
 persistent=no

--- a/salt/ext/backports_abc.py
+++ b/salt/ext/backports_abc.py
@@ -1,0 +1,216 @@
+"""
+Patch recently added ABCs into the standard lib module
+``collections.abc`` (Py3) or ``collections`` (Py2).
+
+Usage::
+
+    import backports_abc
+    backports_abc.patch()
+
+or::
+
+    try:
+        from collections.abc import Generator
+    except ImportError:
+        from backports_abc import Generator
+"""
+
+try:
+    import collections.abc as _collections_abc
+except ImportError:
+    import collections as _collections_abc
+
+
+def get_mro(cls):
+    try:
+        return cls.__mro__
+    except AttributeError:
+        return old_style_mro(cls)
+
+
+def old_style_mro(cls):
+    yield cls
+    for base in cls.__bases__:
+        for c in old_style_mro(base):
+            yield c
+
+
+def mk_gen():
+    from abc import abstractmethod
+
+    required_methods = (
+        '__iter__', '__next__' if hasattr(iter(()), '__next__') else 'next',
+         'send', 'throw', 'close')
+
+    class Generator(_collections_abc.Iterator):
+        __slots__ = ()
+
+        if '__next__' in required_methods:
+            def __next__(self):
+                return self.send(None)
+        else:
+            def next(self):
+                return self.send(None)
+
+        @abstractmethod
+        def send(self, value):
+            raise StopIteration
+
+        @abstractmethod
+        def throw(self, typ, val=None, tb=None):
+            if val is None:
+                if tb is None:
+                    raise typ
+                val = typ()
+            if tb is not None:
+                val = val.with_traceback(tb)
+            raise val
+
+        def close(self):
+            try:
+                self.throw(GeneratorExit)
+            except (GeneratorExit, StopIteration):
+                pass
+            else:
+                raise RuntimeError('generator ignored GeneratorExit')
+
+        @classmethod
+        def __subclasshook__(cls, C):
+            if cls is Generator:
+                mro = get_mro(C)
+                for method in required_methods:
+                    for base in mro:
+                        if method in base.__dict__:
+                            break
+                    else:
+                        return NotImplemented
+                return True
+            return NotImplemented
+
+    generator = type((lambda: (yield))())
+    Generator.register(generator)
+    return Generator
+
+
+def mk_awaitable():
+    from abc import abstractmethod, ABCMeta
+
+    @abstractmethod
+    def __await__(self):
+        yield
+
+    @classmethod
+    def __subclasshook__(cls, C):
+        if cls is Awaitable:
+            for B in get_mro(C):
+                if '__await__' in B.__dict__:
+                    if B.__dict__['__await__']:
+                        return True
+                    break
+        return NotImplemented
+
+    # calling metaclass directly as syntax differs in Py2/Py3
+    Awaitable = ABCMeta('Awaitable', (), {
+        '__slots__': (),
+        '__await__': __await__,
+        '__subclasshook__': __subclasshook__,
+    })
+
+    return Awaitable
+
+
+def mk_coroutine():
+    from abc import abstractmethod
+
+    class Coroutine(Awaitable):
+        __slots__ = ()
+
+        @abstractmethod
+        def send(self, value):
+            """Send a value into the coroutine.
+            Return next yielded value or raise StopIteration.
+            """
+            raise StopIteration
+
+        @abstractmethod
+        def throw(self, typ, val=None, tb=None):
+            """Raise an exception in the coroutine.
+            Return next yielded value or raise StopIteration.
+            """
+            if val is None:
+                if tb is None:
+                    raise typ
+                val = typ()
+            if tb is not None:
+                val = val.with_traceback(tb)
+            raise val
+
+        def close(self):
+            """Raise GeneratorExit inside coroutine.
+            """
+            try:
+                self.throw(GeneratorExit)
+            except (GeneratorExit, StopIteration):
+                pass
+            else:
+                raise RuntimeError('coroutine ignored GeneratorExit')
+
+        @classmethod
+        def __subclasshook__(cls, C):
+            if cls is Coroutine:
+                mro = get_mro(C)
+                for method in ('__await__', 'send', 'throw', 'close'):
+                    for base in mro:
+                        if method in base.__dict__:
+                            break
+                    else:
+                        return NotImplemented
+                return True
+            return NotImplemented
+
+    return Coroutine
+
+
+###
+#  make all ABCs available in this module
+
+try:
+    Generator = _collections_abc.Generator
+except AttributeError:
+    Generator = mk_gen()
+
+try:
+    Awaitable = _collections_abc.Awaitable
+except AttributeError:
+    Awaitable = mk_awaitable()
+
+try:
+    Coroutine = _collections_abc.Coroutine
+except AttributeError:
+    Coroutine = mk_coroutine()
+
+try:
+    from inspect import isawaitable
+except ImportError:
+    def isawaitable(obj):
+        return isinstance(obj, Awaitable)
+
+
+###
+#  allow patching the stdlib
+
+PATCHED = {}
+
+
+def patch(patch_inspect=True):
+    """
+    Main entry point for patching the ``collections.abc`` and ``inspect``
+    standard library modules.
+    """
+    PATCHED['collections.abc.Generator'] = _collections_abc.Generator = Generator
+    PATCHED['collections.abc.Coroutine'] = _collections_abc.Coroutine = Coroutine
+    PATCHED['collections.abc.Awaitable'] = _collections_abc.Awaitable = Awaitable
+
+    if patch_inspect:
+        import inspect
+        PATCHED['inspect.isawaitable'] = inspect.isawaitable = isawaitable

--- a/salt/utils/thin.py
+++ b/salt/utils/thin.py
@@ -43,9 +43,8 @@ except ImportError:
 
 try:
     import backports_abc
-    HAS_BACKPORTS_ABC = True
 except ImportError:
-    HAS_BACKPORTS_ABC = False
+    import salt.ext.backports_abc as backports_abc
 
 try:
     import markupsafe
@@ -108,6 +107,7 @@ def get_tops(extra_mods='', so_mods=''):
             ]
 
     tops.append(_six.__file__.replace('.pyc', '.py'))
+    tops.append(backports_abc.__file__.replace('.pyc', '.py'))
 
     if HAS_CERTIFI:
         tops.append(os.path.dirname(certifi.__file__))
@@ -117,9 +117,6 @@ def get_tops(extra_mods='', so_mods=''):
 
     if HAS_SINGLEDISPATCH_HELPERS:
         tops.append(singledispatch_helpers.__file__.replace('.pyc', '.py'))
-
-    if HAS_BACKPORTS_ABC:
-        tops.append(backports_abc.__file__.replace('.pyc', '.py'))
 
     if HAS_SSL_MATCH_HOSTNAME:
         tops.append(os.path.dirname(os.path.dirname(ssl_match_hostname.__file__)))


### PR DESCRIPTION
### What does this PR do?
Older version of python need this file to work with tornado when using
salt-ssh.  Since you can run a newer version of python3 that has the file as
collections.abc, it won't be installed, but it still needs to be included in
the thin tarball if the salt-ssh minion is < 3.5

### What issues does this PR fix or reference?
Fixes #44107 

### Tests written?

No

### Commits signed with GPG?

Yes