### PR TITLE
test directory that doesn't exist

### DIFF
--- a/tests/unit/states/test_file.py
+++ b/tests/unit/states/test_file.py
@@ -814,7 +814,7 @@ class TestFileState(TestCase, LoaderModuleMockMixin):
                             'comment': comt,
                             'result': None,
                             'pchanges': p_chg,
-                            'changes': {'/etc/grub.conf': {'directory': 'new'}}
+                            'changes': {'/etc/testdir': {'directory': 'new'}}
                         })
                         self.assertDictEqual(filestate.directory(name,
                                                                  user=user,

--- a/tests/unit/states/test_file.py
+++ b/tests/unit/states/test_file.py
@@ -710,7 +710,7 @@ class TestFileState(TestCase, LoaderModuleMockMixin):
         '''
         Test to ensure that a named directory is present and has the right perms
         '''
-        name = '/etc/grub.conf'
+        name = '/etc/testdir'
         user = 'salt'
         group = 'saltstack'
 
@@ -809,7 +809,7 @@ class TestFileState(TestCase, LoaderModuleMockMixin):
                         else:
                             comt = ('The following files will be changed:\n{0}:'
                                     ' directory - new\n'.format(name))
-                        p_chg = {'/etc/grub.conf': {'directory': 'new'}}
+                        p_chg = {'/etc/testdir': {'directory': 'new'}}
                         ret.update({
                             'comment': comt,
                             'result': None,


### PR DESCRIPTION
### What does this PR do?
sometimes /etc/grub.conf exists and is a symlink to /boot/grub/grub.conf, and
this won't do the right thing.

Fixes saltstack/salt-jenkins#675

### Tests written?

Yes

### Commits signed with GPG?

Yes
  
  