### PR TITLE
Communicate kwarg force=True to allow reinstall of packages

### DIFF
--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -1652,6 +1652,7 @@ def installed(
             pkg_ret = __salt__['pkg.install'](name=None,
                                               refresh=refresh,
                                               version=version,
+                                              force=force,
                                               fromrepo=fromrepo,
                                               skip_verify=skip_verify,
                                               pkgs=pkgs,


### PR DESCRIPTION
### What does this PR do?

Exact behavior is platform-specific.  On FreeBSD where force is required to downgrade a package.

### What issues does this PR fix or reference?

#44913

### Tests written?

No, manually tested on FreeBSD 11

    $ time sudo salt-call --local pkg.install perl5 version=5.24.1
    local:
        ----------
            5.47 real         2.76 user         2.14 sys

    $ time sudo salt-call --local pkg.install perl5 version=5.24.1 force=True
    local:
        ----------
           18.34 real         9.78 user         4.90 sys

Logs confirm that the force option reinstalls a package

    $ sudo tail -f /var/log/messages
    ....
    Jan  5 17:34:40 digitalocean pkg: perl5 reinstalled: 5.24.1 -> 5.24.1


### Commits signed with GPG?

Yes

  
