### PR TITLE
[2017.7] config gate auth_events

### DIFF
--- a/doc/ref/configuration/master.rst
+++ b/doc/ref/configuration/master.rst
@@ -956,6 +956,22 @@ The TCP port for ``mworkers`` to connect to on the master.
 
     tcp_master_workers: 4515
 
+.. conf_master:: master_job_cache
+
+``auth_events``
+--------------------
+
+.. versionadded:: 2017.7.0
+
+Default: ``True``
+
+Determines whether the master will fire authentication events.
+:ref:`Authentication events <event-master_auth>` are fired when
+a minion performs an authentication check with the master.
+
+.. code-block:: yaml
+
+    auth_events: True
 
 .. _salt-ssh-configuration:
 

--- a/doc/ref/configuration/master.rst
+++ b/doc/ref/configuration/master.rst
@@ -956,12 +956,12 @@ The TCP port for ``mworkers`` to connect to on the master.
 
     tcp_master_workers: 4515
 
-.. conf_master:: master_job_cache
+.. conf_master:: auth_events
 
 ``auth_events``
 --------------------
 
-.. versionadded:: 2017.7.0
+.. versionadded:: 2017.7.3
 
 Default: ``True``
 

--- a/doc/topics/event/master_events.rst
+++ b/doc/topics/event/master_events.rst
@@ -7,6 +7,8 @@ Salt Master Events
 These events are fired on the Salt Master event bus. This list is **not**
 comprehensive.
 
+.. _event-master_auth:
+
 Authentication events
 =====================
 

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -1084,6 +1084,9 @@ VALID_OPTS = {
 
     # Scheduler should be a dictionary
     'schedule': dict,
+
+    # Wheter to fire auth events
+    'auth_events': bool,
 }
 
 # default configurations
@@ -1650,6 +1653,7 @@ DEFAULT_MASTER_OPTS = {
     'require_minion_sign_messages': False,
     'drop_messages_signature_fail': False,
     'schedule': {},
+    'auth_events': True,
 }
 
 

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -1085,7 +1085,7 @@ VALID_OPTS = {
     # Scheduler should be a dictionary
     'schedule': dict,
 
-    # Wheter to fire auth events
+    # Whether to fire auth events
     'auth_events': bool,
 }
 

--- a/salt/crypt.py
+++ b/salt/crypt.py
@@ -551,8 +551,9 @@ class AsyncAuth(object):
             self._crypticle = Crypticle(self.opts, creds['aes'])
             self._authenticate_future.set_result(True)  # mark the sign-in as complete
             # Notify the bus about creds change
-            event = salt.utils.event.get_event(self.opts.get('__role'), opts=self.opts, listen=False)
-            event.fire_event({'key': key, 'creds': creds}, salt.utils.event.tagify(prefix='auth', suffix='creds'))
+            if self.opts.get('auth_events') is True:
+                event = salt.utils.event.get_event(self.opts.get('__role'), opts=self.opts, listen=False)
+                event.fire_event({'key': key, 'creds': creds}, salt.utils.event.tagify(prefix='auth', suffix='creds'))
 
     @tornado.gen.coroutine
     def sign_in(self, timeout=60, safe=True, tries=1, channel=None):

--- a/salt/transport/mixins/auth.py
+++ b/salt/transport/mixins/auth.py
@@ -201,7 +201,8 @@ class AESReqServerMixin(object):
                              'id': load['id'],
                              'pub': load['pub']}
 
-                    self.event.fire_event(eload, salt.utils.event.tagify(prefix='auth'))
+                    if self.opts.get('auth_events') is True:
+                        self.event.fire_event(eload, salt.utils.event.tagify(prefix='auth'))
                     return {'enc': 'clear',
                             'load': {'ret': 'full'}}
 
@@ -232,7 +233,8 @@ class AESReqServerMixin(object):
             eload = {'result': False,
                      'id': load['id'],
                      'pub': load['pub']}
-            self.event.fire_event(eload, salt.utils.event.tagify(prefix='auth'))
+            if self.opts.get('auth_events') is True:
+                self.event.fire_event(eload, salt.utils.event.tagify(prefix='auth'))
             return {'enc': 'clear',
                     'load': {'ret': False}}
 
@@ -252,7 +254,8 @@ class AESReqServerMixin(object):
                              'id': load['id'],
                              'act': 'denied',
                              'pub': load['pub']}
-                    self.event.fire_event(eload, salt.utils.event.tagify(prefix='auth'))
+                    if self.opts.get('auth_events') is True:
+                        self.event.fire_event(eload, salt.utils.event.tagify(prefix='auth'))
                     return {'enc': 'clear',
                             'load': {'ret': False}}
 
@@ -266,7 +269,8 @@ class AESReqServerMixin(object):
                 eload = {'result': False,
                          'id': load['id'],
                          'pub': load['pub']}
-                self.event.fire_event(eload, salt.utils.event.tagify(prefix='auth'))
+                if self.opts.get('auth_events') is True:
+                    self.event.fire_event(eload, salt.utils.event.tagify(prefix='auth'))
                 return {'enc': 'clear',
                         'load': {'ret': False}}
 
@@ -297,7 +301,8 @@ class AESReqServerMixin(object):
                          'act': key_act,
                          'id': load['id'],
                          'pub': load['pub']}
-                self.event.fire_event(eload, salt.utils.event.tagify(prefix='auth'))
+                if self.opts.get('auth_events') is True:
+                    self.event.fire_event(eload, salt.utils.event.tagify(prefix='auth'))
                 return ret
 
         elif os.path.isfile(pubfn_pend):
@@ -318,7 +323,8 @@ class AESReqServerMixin(object):
                          'act': 'reject',
                          'id': load['id'],
                          'pub': load['pub']}
-                self.event.fire_event(eload, salt.utils.event.tagify(prefix='auth'))
+                if self.opts.get('auth_events') is True:
+                    self.event.fire_event(eload, salt.utils.event.tagify(prefix='auth'))
                 return ret
 
             elif not auto_sign:
@@ -341,7 +347,8 @@ class AESReqServerMixin(object):
                                  'id': load['id'],
                                  'act': 'denied',
                                  'pub': load['pub']}
-                        self.event.fire_event(eload, salt.utils.event.tagify(prefix='auth'))
+                        if self.opts.get('auth_events') is True:
+                            self.event.fire_event(eload, salt.utils.event.tagify(prefix='auth'))
                         return {'enc': 'clear',
                                 'load': {'ret': False}}
                     else:
@@ -354,7 +361,8 @@ class AESReqServerMixin(object):
                                  'act': 'pend',
                                  'id': load['id'],
                                  'pub': load['pub']}
-                        self.event.fire_event(eload, salt.utils.event.tagify(prefix='auth'))
+                        if self.opts.get('auth_events') is True:
+                            self.event.fire_event(eload, salt.utils.event.tagify(prefix='auth'))
                         return {'enc': 'clear',
                                 'load': {'ret': True}}
             else:
@@ -376,7 +384,8 @@ class AESReqServerMixin(object):
                         eload = {'result': False,
                                  'id': load['id'],
                                  'pub': load['pub']}
-                        self.event.fire_event(eload, salt.utils.event.tagify(prefix='auth'))
+                        if self.opts.get('auth_events') is True:
+                            self.event.fire_event(eload, salt.utils.event.tagify(prefix='auth'))
                         return {'enc': 'clear',
                                 'load': {'ret': False}}
                     else:
@@ -388,7 +397,8 @@ class AESReqServerMixin(object):
             eload = {'result': False,
                      'id': load['id'],
                      'pub': load['pub']}
-            self.event.fire_event(eload, salt.utils.event.tagify(prefix='auth'))
+            if self.opts.get('auth_events') is True:
+                self.event.fire_event(eload, salt.utils.event.tagify(prefix='auth'))
             return {'enc': 'clear',
                     'load': {'ret': False}}
 
@@ -478,5 +488,6 @@ class AESReqServerMixin(object):
                  'act': 'accept',
                  'id': load['id'],
                  'pub': load['pub']}
-        self.event.fire_event(eload, salt.utils.event.tagify(prefix='auth'))
+        if self.opts.get('auth_events') is True:
+            self.event.fire_event(eload, salt.utils.event.tagify(prefix='auth'))
         return ret


### PR DESCRIPTION
### What does this PR do?
Adding some code to config gate whether `auth_events` are sent to the event bus

### What issues does this PR fix or reference?
N/A

### Previous Behavior
Auth events are always sent.

### New Behavior
Adds a new master configuration option to disable sending the auth events.

### Tests written?
Pending

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
