### PR TITLE
Fix `comment_line` for Py3 in Windows

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -1525,7 +1525,7 @@ def comment_line(path,
                                 # Write the existing line (no change)
                                 wline = line
                             wline = salt.utils.stringutils.to_bytes(wline) \
-                                if salt.utils.platform.is_windows() \
+                                if six.PY2 and salt.utils.platform.is_windows() \
                                 else salt.utils.stringutils.to_str(wline)
                             w_file.write(wline)
                         except (OSError, IOError) as exc:


### PR DESCRIPTION
### What does this PR do?
Make wline a bytestring if py2 and windows, otherwise use a string

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/45329
Caused by: https://github.com/saltstack/salt/pull/45038

### Tests written?
No

### Commits signed with GPG?
Yes