### PR TITLE
Skip test_load_match on Windows

### DIFF
--- a/tests/unit/beacons/test_load_beacon.py
+++ b/tests/unit/beacons/test_load_beacon.py
@@ -10,6 +10,7 @@ from tests.support.mixins import LoaderModuleMockMixin
 
 # Salt libs
 import salt.beacons.load as load
+import salt.utils.platform
 
 import logging
 log = logging.getLogger(__name__)
@@ -45,6 +46,8 @@ class LoadBeaconTestCase(TestCase, LoaderModuleMockMixin):
         self.assertEqual(ret, (False, 'Averages configuration is required'
                                       ' for load beacon.'))
 
+    @skipIf(salt.utils.platform.is_windows(),
+            'os.getloadavg not available on Windows')
     def test_load_match(self):
         with patch('os.getloadavg',
                    MagicMock(return_value=(1.82, 1.84, 1.56))):


### PR DESCRIPTION
### What does this PR do?
Skips `unit.beacons.test_load_beacon.LoadBeaconTestCase.test_load_match` because it requires `os.getloadavg` which is not available on Windows

### What issues does this PR fix or reference?
https://github.com/saltstack/salt-jenkins/issues/439

### Tests written?
Yes

### Commits signed with GPG?
Yes