### PR TITLE
Fix `unit.modules.test_beacons` for Windows

### DIFF
--- a/salt/modules/beacons.py
+++ b/salt/modules/beacons.py
@@ -353,8 +353,9 @@ def save():
     beacons = list_(return_yaml=False, include_pillar=False)
 
     # move this file into an configurable opt
-    sfn = '{0}/{1}/beacons.conf'.format(__opts__['config_dir'],
-                                        os.path.dirname(__opts__['default_include']))
+    sfn = os.path.join(__opts__['config_dir'],
+                       os.path.dirname(__opts__['default_include']),
+                       'beacons.conf')
     if beacons:
         tmp = {'beacons': beacons}
         yaml_out = salt.utils.yaml.safe_dump(tmp, default_flow_style=False)

--- a/tests/unit/modules/test_beacons.py
+++ b/tests/unit/modules/test_beacons.py
@@ -81,9 +81,9 @@ class BeaconsTestCase(TestCase, LoaderModuleMockMixin):
         '''
         Test saving beacons.
         '''
-        comm1 = 'Beacons saved to //tmp/beacons.conf.'
+        comm1 = 'Beacons saved to {0}beacons.conf.'.format(TMP + os.sep)
         with patch.dict(beacons.__opts__, {'config_dir': '', 'beacons': {},
-                                           'default_include': '/tmp/',
+                                           'default_include': TMP + os.sep,
                                            'sock_dir': SOCK_DIR}):
 
             mock = MagicMock(return_value=True)


### PR DESCRIPTION
### What does this PR do?
Accounts for paths in Windows. Even though Windows understands forward slashes in paths `/` python on Windows doesn't. Uses `os.path.join` to put in the correct path separators.

Places the dummy config for the test in a directory that will exist on the system.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt-jenkins/issues/439

### Tests written?
Yes

### Commits signed with GPG?
Yes