### PR TITLE
Replace resolv.conf if nameserver is 127.0.0.1

### DIFF
--- a/salt/modules/seed.py
+++ b/salt/modules/seed.py
@@ -278,6 +278,8 @@ def _check_resolv(mpt):
             conts = fp_.read()
             if 'nameserver' not in conts:
                 replace = True
+            if 'nameserver 127.0.0.1' in conts:
+                replace = True
     if replace:
         shutil.copy('/etc/resolv.conf', resolv)
 


### PR DESCRIPTION
Debian OpenStack images has resolv.conf with "nameserver 127.0.0.1". If not overwritten minion seeding will fail (after a long period of time - network timeout) as no name lookups can be made.
Upon VM boot DHCP settings will overwrite resolv.conf again.

A more elegant approach which probably deserves an issue would be to inject a temporal resolv.conf to the mounted volume and roll back to the original after seeding has finished.

### What does this PR do?
Modified `_check_resolv` to also replace resolv.conf with the minions resolv.conf if the mount point has a resolv.conf with `nameserver 127.0.0.1`

### What issues does this PR fix or reference?

### Previous Behavior
Only replace resolv.conf with the mount points' resolv.conf does not contain any `nameserver` lines.

### New Behavior
Also replace resolv.conf if there is a `nameserver 127.0.0.1` line.

### Tests written?
No

### Commits signed with GPG?
No