### PR TITLE
Update debbuild to explicitly include source code for Debian, Ubuntu

### DIFF
--- a/salt/modules/debbuild.py
+++ b/salt/modules/debbuild.py
@@ -359,7 +359,7 @@ def make_src_pkg(dest_dir, spec, sources, env=None, template=None, saltenv='base
     __salt__['cmd.run'](cmd, cwd=abspath_debname)
     cmd = 'rm -f {0}'.format(os.path.basename(spec_pathfile))
     __salt__['cmd.run'](cmd, cwd=abspath_debname)
-    cmd = 'debuild -S -uc -us'
+    cmd = 'debuild -S -uc -us -sa'
     __salt__['cmd.run'](cmd, cwd=abspath_debname, python_shell=True)
 
     cmd = 'rm -fR {0}'.format(abspath_debname)


### PR DESCRIPTION
### What does this PR do?
Ensures that the source is included when building Debian or Ubuntu packages

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/45350

### Previous Behavior
Source was included due to typically using '-0' and '-1' (default mode of operation), but during Oxygen development is was noticed when some packages were updated to '-2' that the source was not included

### New Behavior
Source is now explicitly included by using '-sa' flag when building

### Tests written?
No, building packages was sufficient.

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
