### PR TITLE
gate the minion data cache refresh events.

### DIFF
--- a/doc/ref/configuration/master.rst
+++ b/doc/ref/configuration/master.rst
@@ -973,6 +973,22 @@ a minion performs an authentication check with the master.
 
     auth_events: True
 
+.. conf_master:: minion_data_cache_events
+
+``minion_data_cache_events``
+--------------------
+
+.. versionadded:: 2017.7.3
+
+Default: ``True``
+
+Determines whether the master will fire minion data cache events.  Minion data
+cache events are fired when a minion requests a minion data cache refresh.
+
+.. code-block:: yaml
+
+    minion_data_cache_events: True
+
 .. _salt-ssh-configuration:
 
 Salt-SSH Configuration

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -1087,6 +1087,9 @@ VALID_OPTS = {
 
     # Whether to fire auth events
     'auth_events': bool,
+
+    # Whether to fire Minion data cache refresh events
+    'minion_data_cache_events': bool,
 }
 
 # default configurations
@@ -1654,6 +1657,7 @@ DEFAULT_MASTER_OPTS = {
     'drop_messages_signature_fail': False,
     'schedule': {},
     'auth_events': True,
+    'minion_data_cache_events': True,
 }
 
 

--- a/salt/daemons/masterapi.py
+++ b/salt/daemons/masterapi.py
@@ -741,7 +741,8 @@ class RemoteFuncs(object):
             self.cache.store('minions/{0}'.format(load['id']),
                              'data',
                              {'grains': load['grains'], 'pillar': data})
-            self.event.fire_event('Minion data cache refresh', tagify(load['id'], 'refresh', 'minion'))
+            if self.opts.get('minion_data_cache_events') is True:
+                self.event.fire_event('Minion data cache refresh', tagify(load['id'], 'refresh', 'minion'))
         return data
 
     def _minion_event(self, load):

--- a/salt/master.py
+++ b/salt/master.py
@@ -1355,7 +1355,7 @@ class AESFuncs(object):
                                        'data',
                                        {'grains': load['grains'],
                                         'pillar': data})
-            if salt.opts.get('minion_data_cache_events') is True:
+            if self.opts.get('minion_data_cache_events') is True:
                 self.event.fire_event({'Minion data cache refresh': load['id']}, tagify(load['id'], 'refresh', 'minion'))
         return data
 

--- a/salt/master.py
+++ b/salt/master.py
@@ -1355,7 +1355,8 @@ class AESFuncs(object):
                                        'data',
                                        {'grains': load['grains'],
                                         'pillar': data})
-            self.event.fire_event({'Minion data cache refresh': load['id']}, tagify(load['id'], 'refresh', 'minion'))
+            if salt.opts.get('minion_data_cache_events') is True:
+                self.event.fire_event({'Minion data cache refresh': load['id']}, tagify(load['id'], 'refresh', 'minion'))
         return data
 
     def _minion_event(self, load):


### PR DESCRIPTION
### What does this PR do?
Adds `minion_data_cache_events` config option to the master config to gate sending minion data cache events when the minion data cache is refreshed.

This is similar to #45299 that gates minion auth events.

### Previous Behavior
Thousands of `minion_data_cache_events` were being sent across the event bus. This lessens the load tremendously.

### New Behavior
If `minion_data_cache_events` is set to `False` then no minion_data_cache_events are sent on the event bus.

### Tests written?

No

### Commits signed with GPG?

Yes

