### PR TITLE
Return an error when "gid_from_name" is set but group does not exist

### DIFF
--- a/salt/states/user.py
+++ b/salt/states/user.py
@@ -88,10 +88,6 @@ def _changes(name,
     attributes supported as integers only.
     '''
 
-    # Set gid to None in cases an empty string is passed
-    if gid == '':
-        gid = None
-
     if 'shadow.info' in __salt__:
         lshad = __salt__['shadow.info'](name)
 
@@ -460,9 +456,8 @@ def present(name,
 
     if gid_from_name:
         gid = __salt__['file.group_to_gid'](name)
-        if not gid:
-            ret['comment'] = 'Default group with name "{0}" ' \
-                             'is not present'.format(name)
+        if gid == '':
+            ret['comment'] = 'Default group with name "{0}" is not present'.format(name)
             ret['result'] = False
             return ret
 

--- a/salt/states/user.py
+++ b/salt/states/user.py
@@ -244,7 +244,8 @@ def present(name,
 
     gid_from_name
         If True, the default group id will be set to the id of the group with
-        the same name as the user, Default is ``False``.
+        the same name as the user. If the group does not exist the state will
+        fail. Default is ``False``.
 
     groups
         A list of groups to assign the user to, pass a list object. If a group

--- a/salt/states/user.py
+++ b/salt/states/user.py
@@ -459,6 +459,11 @@ def present(name,
 
     if gid_from_name:
         gid = __salt__['file.group_to_gid'](name)
+        if not gid:
+            ret['comment'] = 'Default group with name "{0}" ' \
+                             'is not present'.format(name)
+            ret['result'] = False
+            return ret
 
     changes = _changes(name,
                        uid,

--- a/salt/states/user.py
+++ b/salt/states/user.py
@@ -88,6 +88,10 @@ def _changes(name,
     attributes supported as integers only.
     '''
 
+    # Set gid to None in cases an empty string is passed
+    if gid == '':
+       gid = None
+
     if 'shadow.info' in __salt__:
         lshad = __salt__['shadow.info'](name)
 

--- a/salt/states/user.py
+++ b/salt/states/user.py
@@ -90,7 +90,7 @@ def _changes(name,
 
     # Set gid to None in cases an empty string is passed
     if gid == '':
-       gid = None
+        gid = None
 
     if 'shadow.info' in __salt__:
         lshad = __salt__['shadow.info'](name)


### PR DESCRIPTION
### What does this PR do?
This PR reports an error running `user.present` state in cases where `gid_from_name` is set to True but there is no group on the system with that name.

Also this prevents from wrongly take an empty string as a possible value for a group. It should be handled as `None` on that case.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/45345

### Previous Behavior
Given this SLS file:
```yaml
test:
  user.present:
    - gid_from_name: True
```
Applying the state:
```
local:
----------
          ID: test
    Function: user.present
      Result: True
     Comment: New user test created
     Started: 12:50:46.306964
    Duration: 251.407 ms
     Changes:   
              ----------
              fullname:
              gid:
                  100
              groups:
                  - users
              home:
                  /home/test
              homephone:
              name:
                  test
              passwd:
                  x
              roomnumber:
              shell:
                  /bin/bash
              uid:
                  1000
              workphone:

Summary for local
------------
Succeeded: 1 (changed=1)
Failed:    0
------------
Total states run:     1
Total run time: 251.407 ms
```
As you see, the user is created but the group `test` doesn't. It set the gid to `users` groups instead of a group called `test` (according to the SLS definition).

If I run it again the state I got this failure as Salt tries to handle an empty string as a gid:
```
          ID: test
    Function: user.present
      Result: False
     Comment: These values could not be changed: {'gid': ''}
     Started: 13:39:51.155928
    Duration: 18.243 ms
     Changes:
```

### New Behavior
With the new behavior, the state will fail initially as the `test` group is not available on the system:

```
local:
----------
          ID: test
    Function: user.present
      Result: False
     Comment: Default group with name "test" is not present
     Started: 12:54:16.301860
    Duration: 8.197 ms
     Changes:   

Summary for local
------------
Succeeded: 0
Failed:    1
------------
Total states run:     1
Total run time:   8.197 ms
```

Here we follow the general behavior of `user.present`, which is not creating groups in case they don't exist but reporting an error telling the groups don't exist.

### Tests written?

Yes

### Commits signed with GPG?

Yes
