### PR TITLE
Fix group auth logic for FreeIPA LDAP

### DIFF
--- a/salt/auth/ldap.py
+++ b/salt/auth/ldap.py
@@ -363,9 +363,7 @@ def groups(username, **kwargs):
                                            [_config('accountattributename'), 'cn'])
 
             for entry, result in search_results:
-                for user in result[_config('accountattributename')]:
-                    if username == user.split(',')[0].split('=')[-1]:
-                        group_list.append(entry.split(',')[0].split('=')[-1])
+                group_list.extend(result[_config('accountattributename')])
 
             log.debug('User {0} is a member of groups: {1}'.format(username, group_list))
 


### PR DESCRIPTION
### What does this PR do?
Fix group membership retrieval for FreeIPA in the LDAP auth module

### What issues does this PR fix or reference?
None

### Previous Behavior
Group membership was not retrieved from FreeIPA LDAP server

### New Behavior
Group membership is retrieved from FreeIPA LDAP server

### Tests written?
No

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
