### PR TITLE
Skip flaky test on 2017.7 branch

### DIFF
--- a/tests/integration/ssh/test_state.py
+++ b/tests/integration/ssh/test_state.py
@@ -9,6 +9,7 @@ import time
 # Import Salt Testing Libs
 from tests.support.case import SSHCase
 from tests.support.paths import TMP
+from tests.support.unit import skipIf
 
 # Import Salt Libs
 from salt.ext import six
@@ -63,12 +64,13 @@ class SSHStateTest(SSHCase):
         check_file = self.run_function('file.file_exists', [SSH_SLS_FILE], wipe=False)
         self.assertFalse(check_file)
 
+    @skipIf(six.PY3, 'Skipped on Python3 for 2017.7 branch only')
     def test_state_show_top(self):
         '''
         test state.show_top with salt-ssh
         '''
         ret = self.run_function('state.show_top')
-        self.assertEqual(ret, {u'base': list(set([u'master_tops_test']).union([u'core']))})
+        self.assertEqual(ret, {'base': list(set(['master_tops_test']).union(['core']))})
 
     def test_state_single(self):
         '''


### PR DESCRIPTION
The behavior of the set union used to combine ext_nodes and top file
matches is not consistent on Python 3 (well, 3.5 at least), and this
produces flaky test results.

Since we do not change things like the state compiler in point
releases, the method used to combine the ext_nodes and top file matches
has been changed for Oxygen and is now fully deterministic. This test
will therefore be skipped for the remainder of the 2017.7 release cycle
on Python 3.

Fixes https://github.com/saltstack/salt-jenkins/issues/686.