### PR TITLE
Instruct systemd to always restart services on failure

### DIFF
--- a/pkg/salt-api.service
+++ b/pkg/salt-api.service
@@ -9,6 +9,7 @@ NotifyAccess=all
 LimitNOFILE=8192
 ExecStart=/usr/bin/salt-api
 TimeoutStopSec=3
+Restart=on-failure
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/salt-api.service
+++ b/pkg/salt-api.service
@@ -10,6 +10,7 @@ LimitNOFILE=8192
 ExecStart=/usr/bin/salt-api
 TimeoutStopSec=3
 Restart=on-failure
+RestartSec=1m
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/salt-master.service
+++ b/pkg/salt-master.service
@@ -9,6 +9,7 @@ Type=notify
 NotifyAccess=all
 ExecStart=/usr/bin/salt-master
 Restart=on-failure
+RestartSec=1m
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/salt-master.service
+++ b/pkg/salt-master.service
@@ -8,6 +8,7 @@ LimitNOFILE=16384
 Type=notify
 NotifyAccess=all
 ExecStart=/usr/bin/salt-master
+Restart=on-failure
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/salt-minion.service
+++ b/pkg/salt-minion.service
@@ -10,6 +10,7 @@ NotifyAccess=all
 LimitNOFILE=8192
 ExecStart=/usr/bin/salt-minion
 Restart=on-failure
+RestartSec=1m
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/salt-minion.service
+++ b/pkg/salt-minion.service
@@ -9,6 +9,7 @@ Type=notify
 NotifyAccess=all
 LimitNOFILE=8192
 ExecStart=/usr/bin/salt-minion
+Restart=on-failure
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/salt-syndic.service
+++ b/pkg/salt-syndic.service
@@ -8,6 +8,7 @@ Type=notify
 NotifyAccess=all
 LimitNOFILE=8192
 ExecStart=/usr/bin/salt-syndic
+Restart=on-failure
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/salt-syndic.service
+++ b/pkg/salt-syndic.service
@@ -9,6 +9,7 @@ NotifyAccess=all
 LimitNOFILE=8192
 ExecStart=/usr/bin/salt-syndic
 Restart=on-failure
+RestartSec=1m
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
If salt-minion or any other service crashes it should be restarted by systemd

### What does this PR do?

Adds `Restart=on-failure` option to all systemd unit files. 

### What issues does this PR fix or reference?

It allows systemd to restart all salt services if they experience a crash or any other even resulting in marking service as failed (like timeout on stopping the service).

### Tests written?

No

### Commits signed with GPG?

Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
