### PR TITLE
Set SHELL environment variable

### DIFF
--- a/pkg/suse/salt-api.service
+++ b/pkg/suse/salt-api.service
@@ -6,6 +6,7 @@ After=network.target
 [Service]
 User=salt
 Type=simple
+Environment=SHELL=/bin/bash
 LimitNOFILE=8192
 ExecStart=/usr/bin/salt-api
 TimeoutStopSec=3


### PR DESCRIPTION
### What does this PR do?

When passing a ProxyCommand option to salt-ssh a valid $SHELL is needed to execute the given command. This patch passes in `/bin/bash` as the `salt` user does not have a valid shell assigned.

**Please forward-port** this patch to `oxygen` and `develop`, or let me know if you want me to open separate PRs.

### What issues does this PR fix or reference?

This PR is actually a missing forward-port of a change that was already introduced with #40620, see #40630 that was closed without being merged.

### Previous Behavior

A given ProxyCommand fails to be executed as ssh would try to use the exec directive of the (salt) user's shell.

### New Behavior

The ProxyCommand is successfully executed using `/bin/bash`.

### Tests written?

No

### Commits signed with GPG?

Yes
