### PR TITLE
Docs update for function args limit in pub acl.

### DIFF
--- a/doc/ref/publisheracl.rst
+++ b/doc/ref/publisheracl.rst
@@ -11,8 +11,8 @@ The publisher ACL system is configured in the master configuration file via the
 ``publisher_acl`` configuration option. Under the ``publisher_acl``
 configuration option the users open to send commands are specified and then a
 list of regular expressions which specify the minion functions which will be
-made available to specified user. This configuration is much like the ``peer``
-configuration:
+made available to specified user. This configuration is much like the
+:ref:`external_auth <acl-eauth>` configuration:
 
 .. code-block:: yaml
 
@@ -28,6 +28,16 @@ configuration:
       # Allow managers to use saltutil module functions
       manager_.*:
         - saltutil.*
+      # Allow users to use only my_mod functions on "web*" minions with specific arguments.
+      user_.*:
+        - web*:
+          - 'my_mod.*':
+              args:
+                - 'a.*'
+                - 'b.*'
+              kwargs:
+                'kwa': 'kwa.*'
+                'kwb': 'kwb'
 
 Permission Issues
 -----------------

--- a/doc/ref/publisheracl.rst
+++ b/doc/ref/publisheracl.rst
@@ -10,9 +10,10 @@ to have access to execute select salt commands on minions from the master.
 The publisher ACL system is configured in the master configuration file via the
 ``publisher_acl`` configuration option. Under the ``publisher_acl``
 configuration option the users open to send commands are specified and then a
-list of regular expressions which specify the minion functions which will be
-made available to specified user. This configuration is much like the
-:ref:`external_auth <acl-eauth>` configuration:
+list of the minion functions which will be made available to specified user.
+Both users and functions could be specified by exact match, shell glob or
+regular expression. This configuration is much like the :ref:`external_auth
+<acl-eauth>` configuration:
 
 .. code-block:: yaml
 
@@ -25,8 +26,8 @@ made available to specified user. This configuration is much like the
         - web*:
           - test.*
           - pkg.*
-      # Allow managers to use saltutil module functions
-      manager_.*:
+      # Allow admin and managers to use saltutil module functions
+      admin|manager_.*:
         - saltutil.*
       # Allow users to use only my_mod functions on "web*" minions with specific arguments.
       user_.*:

--- a/doc/topics/eauth/index.rst
+++ b/doc/topics/eauth/index.rst
@@ -27,12 +27,13 @@ in the master configuration file and uses the :ref:`access control system
           - 'web*':
             - test.*
             - network.*
-        steve:
+        steve|admin.*:
           - .*
 
-The above configuration allows the user ``thatch`` to execute functions
-in the test and network modules on the minions that match the web* target.
-User ``steve`` is given unrestricted access to minion commands.
+The above configuration allows the user ``thatch`` to execute functions in the
+test and network modules on the minions that match the web* target.  User
+``steve`` and the users whose logins start with ``admin``, are granted
+unrestricted access to minion commands.
 
 Salt respects the current PAM configuration in place, and uses the 'login'
 service to authenticate.
@@ -71,8 +72,8 @@ Matching syntax
 ---------------
 
 The structure of the ``external_auth`` dictionary can take the following
-shapes. Function matches are regular expressions; minion matches are compound
-targets.
+shapes. User and function matches are exact matches, shell glob patterns or
+regular expressions; minion matches are compound targets.
 
 By user:
 

--- a/doc/topics/eauth/index.rst
+++ b/doc/topics/eauth/index.rst
@@ -122,8 +122,8 @@ Positional arguments or keyword arguments to functions can also be whitelisted.
           - '*':
             - 'my_mod.*':
                 args:
-                - 'a.*'
-                - 'b.*'
+                  - 'a.*'
+                  - 'b.*'
                 kwargs:
                   'kwa': 'kwa.*'
                   'kwb': 'kwb'


### PR DESCRIPTION
### What does this PR do?
Updates `publisher_acl` documentation adding an example of function arguments restrictions and a reference to the `external_auth` documentation that has the same syntax and feature list.

### What issues does this PR fix or reference?
Fix #42626

### Tests written?
No

### Commits signed with GPG?
Yes