### PR TITLE
add __context__ to salt-runner for passthrough

### DIFF
--- a/salt/runners/salt.py
+++ b/salt/runners/salt.py
@@ -99,7 +99,8 @@ def cmd(fun, *args, **kwargs):
 
     functions = salt.loader.minion_mods(
         opts,
-        utils=salt.loader.utils(opts))
+        utils=salt.loader.utils(opts),
+        context=__context__)
 
     return functions[fun](*args, **kwargs) \
         if fun in functions \


### PR DESCRIPTION
minion modules are provided a __context__ to indicate success/failure outside
the contents of their response. runners also are provided this, so we pass it
down.

### Tests written?

No

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
