### PR TITLE
Fix cluster_ CLI examples

### DIFF
--- a/salt/modules/elasticsearch.py
+++ b/salt/modules/elasticsearch.py
@@ -232,7 +232,7 @@ def cluster_health(index=None, level='cluster', local=False, hosts=None, profile
 
     CLI example::
 
-        salt myminion elasticsearch.health
+        salt myminion elasticsearch.cluster_health
     '''
     es = _get_instance(hosts, profile)
 
@@ -253,7 +253,7 @@ def cluster_stats(nodes=None, hosts=None, profile=None):
 
     CLI example::
 
-        salt myminion elasticsearch.stats
+        salt myminion elasticsearch.cluster_stats
     '''
     es = _get_instance(hosts, profile)
 


### PR DESCRIPTION
Add missing "cluster_" to cluster_health, cluster_stats method doc

### What does this PR do?

Add missing prefix "cluster_" to cluster_health and cluster_stats method documentation CLI example.


### What issues does this PR fix or reference?

Minor doc fix. Not reported as issue


### Tests written?

No. Changes only in doc.


### Commits signed with GPG?

No.

