### PR TITLE
Change rackspace provider name for >=oxygen cloud tests

### DIFF
--- a/tests/integration/cloud/providers/test_rackspace.py
+++ b/tests/integration/cloud/providers/test_rackspace.py
@@ -25,7 +25,7 @@ except ImportError:
 
 # Create the cloud instance name to be used throughout the tests
 INSTANCE_NAME = generate_random_name('CLOUD-TEST-')
-PROVIDER_NAME = 'rackspace'
+PROVIDER_NAME = 'openstack'
 DRIVER_NAME = 'openstack'
 
 
@@ -43,7 +43,7 @@ class RackspaceTest(ShellCase):
         super(RackspaceTest, self).setUp()
 
         # check if appropriate cloud provider and profile files are present
-        profile_str = 'rackspace-config'
+        profile_str = 'openstack-config'
         providers = self.run_cloud('--list-providers')
         if profile_str + ':' not in providers:
             self.skipTest(

--- a/tests/integration/files/conf/cloud.profiles.d/rackspace.conf
+++ b/tests/integration/files/conf/cloud.profiles.d/rackspace.conf
@@ -1,5 +1,5 @@
 rackspace-test:
-  provider: rackspace-config
+  provider: openstack-config
   size: 2 GB Performance
   image: Ubuntu 14.04 LTS (Trusty Tahr) (PVHVM)
   script_args: '-P -Z'

--- a/tests/integration/files/conf/cloud.providers.d/rackspace.conf
+++ b/tests/integration/files/conf/cloud.providers.d/rackspace.conf
@@ -1,9 +1,10 @@
 openstack-config:
-  identity_url: 'https://identity.api.rackspacecloud.com/v2.0/tokens'
-  compute_name: cloudServersOpenStack
-  protocol: ipv4
-  compute_region: DFW
-  user: ''
-  tenant: ''
-  apikey: ''
   driver: openstack
+  profile: rackspace
+  auth:
+    username: ''
+    api_key: ''
+  region_name: ''
+  minion:
+    master_type: str
+  auth_type: ''

--- a/tests/integration/files/conf/cloud.providers.d/rackspace.conf
+++ b/tests/integration/files/conf/cloud.providers.d/rackspace.conf
@@ -1,4 +1,4 @@
-rackspace-config:
+openstack-config:
   identity_url: 'https://identity.api.rackspacecloud.com/v2.0/tokens'
   compute_name: cloudServersOpenStack
   protocol: ipv4


### PR DESCRIPTION
### What issues does this PR fix or reference?
https://github.com/saltstack/salt-jenkins/issues/695

We are adding a new config openstack-provider for the new rackspace configuration in oxygen as shown here: https://github.com/saltstack/salt-jenkins/pull/700 and keeping the old rackspace-provider for tests in <=2017.7