### PR TITLE
Gate docker inside __init__

### DIFF
--- a/salt/modules/swarm.py
+++ b/salt/modules/swarm.py
@@ -45,8 +45,9 @@ def __virtual__():
 
 
 def __init__(self):
-    __context__['client'] = docker.from_env()
-    __context__['server_name'] = __grains__['id']
+    if HAS_DOCKER:
+        __context__['client'] = docker.from_env()
+        __context__['server_name'] = __grains__['id']
 
 
 def swarm_tokens():


### PR DESCRIPTION
### What does this PR do?
`__init__()` loads before `__virtual__()`, which means that it won't be gated the same as other functions; it needs to have its own gating.

### What issues does this PR fix or reference?
None known.

### Previous Behavior
When `docker` support is not available in Python, the following error shows up in the debug logs:
```
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/salt/loader.py", line 1504, in _load_module
    module_init(self.opts)
  File "/usr/lib/python2.7/site-packages/salt/modules/swarm.py", line 48, in __init__
    __context__['client'] = docker.from_env()
NameError: name 'docker' is not defined
```
### New Behavior
Error goes away.

### Tests written?
No

### Commits signed with GPG?
Yes