### PR TITLE
Fix stack trace on machines without docker

### DIFF
--- a/salt/modules/swarm.py
+++ b/salt/modules/swarm.py
@@ -29,10 +29,6 @@ import salt.utils.json
 try:
     import docker
     HAS_DOCKER = True
-    def __init__(self):
-        __context__['client'] = docker.from_env()
-        __context__['server_name'] = __grains__['id']
-
 except ImportError:
     HAS_DOCKER = False
 
@@ -46,6 +42,12 @@ def __virtual__():
     if HAS_DOCKER:
         return __virtualname__
     return False, 'The swarm module failed to load: Docker python module is not avaialble.'
+
+
+def __init__(self):
+    if HAS_DOCKER:
+        __context__['client'] = docker.from_env()
+    __context__['server_name'] = __grains__['id']
 
 
 def swarm_tokens():

--- a/salt/modules/swarm.py
+++ b/salt/modules/swarm.py
@@ -29,6 +29,10 @@ import salt.utils.json
 try:
     import docker
     HAS_DOCKER = True
+    def __init__(self):
+        __context__['client'] = docker.from_env()
+        __context__['server_name'] = __grains__['id']
+
 except ImportError:
     HAS_DOCKER = False
 
@@ -42,11 +46,6 @@ def __virtual__():
     if HAS_DOCKER:
         return __virtualname__
     return False, 'The swarm module failed to load: Docker python module is not avaialble.'
-
-
-def __init__(self):
-    __context__['client'] = docker.from_env()
-    __context__['server_name'] = __grains__['id']
 
 
 def swarm_tokens():


### PR DESCRIPTION
### What does this PR do?
Fixes a stack trace that was occurring on machines without docker.

### What issues does this PR fix or reference?
Found in testing

### Previous Behavior
The following stack trace would show in debug:
```
[DEBUG   ] Error loading module.swarm: __init__ failed
Traceback (most recent call last):
  File "c:\salt-dev\salt\salt\loader.py", line 1504, in _load_module
    module_init(self.opts)
  File "c:\salt-dev\salt\salt\modules\swarm.py", line 48, in __init__
    __context__['client'] = docker.from_env()
NameError: global name 'docker' is not defined
```

### New Behavior
No stacktrace

### Tests written?
No

### Commits signed with GPG?
Yes