### PR TITLE
[PY3] Add unicode_literals to salt.utils modules (P)

### DIFF
--- a/salt/utils/pagerduty.py
+++ b/salt/utils/pagerduty.py
@@ -16,7 +16,7 @@ Library for interacting with PagerDuty API
             pagerduty.subdomain: mysubdomain
             pagerduty.api_key: F3Rbyjbve43rfFWf2214
 '''
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function, unicode_literals
 
 import logging
 import salt.utils.http

--- a/salt/utils/path.py
+++ b/salt/utils/path.py
@@ -5,7 +5,7 @@ lack of support for reading NTFS links.
 '''
 
 # Import python libs
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function, unicode_literals
 import collections
 import errno
 import logging
@@ -238,7 +238,10 @@ def which(exe=None):
                     # safely rely on that behavior
                     if _is_executable_file_or_link(full_path + ext):
                         return full_path + ext
-        log.trace('\'{0}\' could not be found in the following search path: \'{1}\''.format(exe, search_path))
+        log.trace(
+            '\'%s\' could not be found in the following search path: \'%s\'',
+            exe, search_path
+        )
     else:
         log.error('No executable was passed to be searched by salt.utils.path.which()')
 

--- a/salt/utils/pbm.py
+++ b/salt/utils/pbm.py
@@ -39,7 +39,7 @@ version currently listed in PyPi, run the following:
 '''
 
 # Import Python Libs
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function, unicode_literals
 import logging
 
 # Import Salt Libs
@@ -201,7 +201,7 @@ def get_storage_policies(profile_manager, policy_names=None,
     except vmodl.RuntimeFault as exc:
         log.exception(exc)
         raise VMwareRuntimeError(exc.msg)
-    log.trace('policy_ids = {0}'.format(policy_ids))
+    log.trace('policy_ids = %s', policy_ids)
     # More policies are returned so we need to filter again
     policies = [p for p in get_policies_by_id(profile_manager, policy_ids)
                 if p.resourceType.resourceType ==
@@ -277,7 +277,7 @@ def get_default_storage_policy_of_datastore(profile_manager, datastore):
     # Retrieve all datastores visible
     hub = pbm.placement.PlacementHub(
         hubId=datastore._moId, hubType='Datastore')
-    log.trace('placement_hub = {0}'.format(hub))
+    log.trace('placement_hub = %s', hub)
     try:
         policy_id = profile_manager.QueryDefaultRequirementProfile(hub)
     except vim.fault.NoPermission as exc:
@@ -313,7 +313,7 @@ def assign_default_storage_policy_to_datastore(profile_manager, policy,
     '''
     placement_hub = pbm.placement.PlacementHub(
         hubId=datastore._moId, hubType='Datastore')
-    log.trace('placement_hub = {0}'.format(placement_hub))
+    log.trace('placement_hub = %s', placement_hub)
     try:
         profile_manager.AssignDefaultRequirementProfile(policy.profileId,
                                                         [placement_hub])

--- a/salt/utils/pkg/__init__.py
+++ b/salt/utils/pkg/__init__.py
@@ -3,7 +3,7 @@
 Common functions for managing package refreshes during states
 '''
 # Import python libs
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function, unicode_literals
 import errno
 import logging
 import os

--- a/salt/utils/pkg/deb.py
+++ b/salt/utils/pkg/deb.py
@@ -4,7 +4,7 @@ Common functions for working with deb packages
 '''
 
 # Import python libs
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function, unicode_literals
 
 # Import 3rd-party libs
 from salt.ext import six
@@ -19,10 +19,10 @@ def combine_comments(comments):
     if isinstance(comments, list):
         for idx in range(len(comments)):
             if not isinstance(comments[idx], six.string_types):
-                comments[idx] = str(comments[idx])
+                comments[idx] = six.text_type(comments[idx])
     else:
         if not isinstance(comments, six.string_types):
-            comments = [str(comments)]
+            comments = [six.text_type(comments)]
         else:
             comments = [comments]
     return ' '.join(comments).strip()

--- a/salt/utils/pkg/rpm.py
+++ b/salt/utils/pkg/rpm.py
@@ -4,7 +4,7 @@ Common functions for working with RPM packages
 '''
 
 # Import python libs
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function, unicode_literals
 import collections
 import datetime
 import logging
@@ -124,7 +124,7 @@ def combine_comments(comments):
         comments = [comments]
     for idx in range(len(comments)):
         if not isinstance(comments[idx], six.string_types):
-            comments[idx] = str(comments[idx])
+            comments[idx] = six.text_type(comments[idx])
         comments[idx] = comments[idx].strip()
         if not comments[idx].startswith('#'):
             comments[idx] = '#' + comments[idx]
@@ -149,7 +149,7 @@ def version_to_evr(verstring):
     idx_e = verstring.find(':')
     if idx_e != -1:
         try:
-            epoch = str(int(verstring[:idx_e]))
+            epoch = six.text_type(int(verstring[:idx_e]))
         except ValueError:
             # look, garbage in the epoch field, how fun, kill it
             epoch = '0'  # this is our fallback, deal

--- a/salt/utils/pkg/win.py
+++ b/salt/utils/pkg/win.py
@@ -33,8 +33,7 @@ Known Issue: install_date may not match Control Panel\Programs\Programs and Feat
 
 # Import _future_ python libs first & before any other code
 # pylint: disable=incompatible-py3-code
-from __future__ import absolute_import
-from __future__ import unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 __version__ = '0.1'
 # Import Standard libs
 import sys
@@ -196,8 +195,9 @@ class RegSoftwareInfo(object):
         except pywintypes.error as exc:  # pylint: disable=no-member
             if exc.winerror == winerror.ERROR_FILE_NOT_FOUND:
                 log.error(
-                    ('Software/Component Not Found  key_guid: \'{0}\', sid: \'{1}\''
-                     ', use_32bit: \'{2}\''.format(key_guid, sid, use_32bit))
+                    'Software/Component Not Found  key_guid: \'%s\', '
+                    'sid: \'%s\' , use_32bit: \'%s\'',
+                    key_guid, sid, use_32bit
                 )
             raise  # This must exist or have no errors
 
@@ -213,9 +213,9 @@ class RegSoftwareInfo(object):
             except pywintypes.error as exc:  # pylint: disable=no-member
                 if exc.winerror == winerror.ERROR_FILE_NOT_FOUND:
                     log.debug(
-                        ('Software/Component Not Found in Products section of registry '
-                         'key_guid: \'{0}\', sid: \'{1}\', use_32bit: \'{2}\''
-                         .format(key_guid, sid, use_32bit))
+                        'Software/Component Not Found in Products section of registry '
+                        'key_guid: \'%s\', sid: \'%s\', use_32bit: \'%s\'',
+                        key_guid, sid, use_32bit
                     )
                     self.__squid = None  # mark it as not a SQUID
                 else:
@@ -275,7 +275,7 @@ class RegSoftwareInfo(object):
             return True
         elif (isinstance(value, six.string_types) and
               re.match(r'\d+', value, flags=re.IGNORECASE + re.UNICODE) is not None and
-              str(value) == 1):
+              six.text_type(value) == '1'):
             return True
         return False
 
@@ -445,9 +445,12 @@ class RegSoftwareInfo(object):
             except pywintypes.error as exc:  # pylint: disable=no-member
                 if exc.winerror == winerror.ERROR_FILE_NOT_FOUND:
                     # Not Found
-                    log.warning('Not Found {0}\\{1} 32bit {2}'.format(self.__reg_hive,
-                                                                      self.__reg_upgradecode_path,
-                                                                      self.__reg_32bit))
+                    log.warning(
+                        'Not Found %s\\%s 32bit %s',
+                        self.__reg_hive,
+                        self.__reg_upgradecode_path,
+                        self.__reg_32bit
+                    )
                     return ''
                 raise
             squid_upgrade_code_all, _, _, suc_pytime = zip(*win32api.RegEnumKeyEx(uc_handle))  # pylint: disable=no-member
@@ -503,9 +506,12 @@ class RegSoftwareInfo(object):
             except pywintypes.error as exc:  # pylint: disable=no-member
                 if exc.winerror == winerror.ERROR_FILE_NOT_FOUND:
                     # Not Found
-                    log.warning('Not Found {0}\\{1} 32bit {2}'.format(self.__reg_hive,
-                                                                      self.__reg_patches_path,
-                                                                      self.__reg_32bit))
+                    log.warning(
+                        'Not Found %s\\%s 32bit %s',
+                        self.__reg_hive,
+                        self.__reg_patches_path,
+                        self.__reg_32bit
+                    )
                     return []
                 raise
 
@@ -535,7 +541,7 @@ class RegSoftwareInfo(object):
                     ret.append(patch_display_name)
                 except pywintypes.error as exc:  # pylint: disable=no-member
                     if exc.winerror == winerror.ERROR_FILE_NOT_FOUND:
-                        log.debug('skipped patch, not found {}'.format(patch_squid))
+                        log.debug('skipped patch, not found %s', patch_squid)
                         continue
                     raise
 
@@ -967,7 +973,7 @@ class WinSoftware(object):
                 raise ValueError(
                     'version capture within object \'{0}\' failed '
                     'for pkg id: \'{1}\' it returned \'{2}\' \'{3}\' '
-                    '\'{4}\''.format(str(self.__pkg_obj), pkg_id, version_str, src, version_user_str)
+                    '\'{4}\''.format(six.text_type(self.__pkg_obj), pkg_id, version_str, src, version_user_str)
                     )
 
         # If self.__pkg_obj.version_capture() not defined defaults to using
@@ -1007,7 +1013,7 @@ class WinSoftware(object):
         if (re.match(r'^{.*\}\.KB\d{6,}$', key_software, flags=re.IGNORECASE + re.UNICODE) is not None or
                 (default_value and default_value.startswith(('KB', 'kb', 'Kb'))) or
                 (release_type and release_type in ('Hotfix', 'Update Rollup', 'Security Update', 'ServicePack'))):
-            log.debug('skipping hotfix/update/service pack {0}'.format(key_software))
+            log.debug('skipping hotfix/update/service pack %s', key_software)
             return
 
         # if NoRemove exists we would expect their to be no UninstallString
@@ -1071,10 +1077,11 @@ class WinSoftware(object):
                 else:
                     # This code is here as it can happen, especially if the
                     # package id provided by pkg_obj is simple.
-                    log.debug((
-                               'Found extra entries for \'{0}\' with same version \'{1}\' '
-                               'skipping entry \'{2}\''.format(dict_key, version_text, key_software)
-                               ))
+                    log.debug(
+                        'Found extra entries for \'%s\' with same version '
+                        '\'%s\', skipping entry \'%s\'',
+                        dict_key, version_text, key_software
+                    )
             else:
                 self.__reg_software[dict_key] = [version_text]
 
@@ -1231,7 +1238,7 @@ class WinSoftware(object):
         # Process software installed for the machine i.e. all users.
         for arch_flag in arch_list:
             key_search = 'Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall'
-            log.debug('SYSTEM processing 32bit:{0}'.format(arch_flag))
+            log.debug('SYSTEM processing 32bit:%s', arch_flag)
             handle = win32api.RegOpenKeyEx(  # pylint: disable=no-member
                         win32con.HKEY_LOCAL_MACHINE,
                         key_search,
@@ -1269,14 +1276,14 @@ class WinSoftware(object):
                 except pywintypes.error as exc:  # pylint: disable=no-member
                     if exc.winerror == winerror.ERROR_FILE_NOT_FOUND:
                         # Not Found Uninstall under SID
-                        log.debug('Not Found {}'.format(user_uninstall_path))
+                        log.debug('Not Found %s', user_uninstall_path)
                         continue
                     else:
                         raise
                 try:
                     reg_key_all, _, _, _ = zip(*win32api.RegEnumKeyEx(handle))  # pylint: disable=no-member
                 except ValueError:
-                    log.debug(('No Entries Found {}').format(user_uninstall_path))
+                    log.debug('No Entries Found %s', user_uninstall_path)
                     reg_key_all = []
                 win32api.RegCloseKey(handle)  # pylint: disable=no-member
                 for reg_key in reg_key_all:
@@ -1296,9 +1303,9 @@ def __main():
         sys.exit(64)
     user_pkgs = False
     version_only = False
-    if str(sys.argv[1]) == 'list':
+    if six.text_type(sys.argv[1]) == 'list':
         version_only = True
-    if str(sys.argv[2]) == 'system+user':
+    if six.text_type(sys.argv[2]) == 'system+user':
         user_pkgs = True
     import salt.utils.json
     import timeit

--- a/salt/utils/platform.py
+++ b/salt/utils/platform.py
@@ -3,7 +3,7 @@
 Functions for identifying which platform a machine is
 '''
 # Import Python libs
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function, unicode_literals
 import os
 import subprocess
 import sys

--- a/salt/utils/powershell.py
+++ b/salt/utils/powershell.py
@@ -9,7 +9,7 @@ Common functions for working with powershell
     pointing to all locations of your Powershell modules.
 '''
 # Import Python libs
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function, unicode_literals
 import logging
 import os
 

--- a/salt/utils/preseed.py
+++ b/salt/utils/preseed.py
@@ -4,9 +4,10 @@ Utilities for managing Debian preseed
 
 .. versionadded:: Beryllium
 '''
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function, unicode_literals
 import shlex
 import salt.utils.files
+import salt.utils.stringutils
 import salt.utils.yaml
 
 
@@ -17,6 +18,7 @@ def mksls(src, dst=None):
     ps_opts = {}
     with salt.utils.files.fopen(src, 'r') as fh_:
         for line in fh_:
+            line = salt.utils.stringutils.to_unicode(line)
             if line.startswith('#'):
                 continue
             if not line.strip():

--- a/salt/utils/process.py
+++ b/salt/utils/process.py
@@ -4,7 +4,7 @@ Functions for daemonizing and otherwise modifying running processes
 '''
 
 # Import python libs
-from __future__ import absolute_import, with_statement
+from __future__ import absolute_import, with_statement, print_function, unicode_literals
 import copy
 import os
 import sys
@@ -73,9 +73,7 @@ def daemonize(redirect_out=True):
             salt.utils.crypt.reinit_crypto()
             sys.exit(salt.defaults.exitcodes.EX_OK)
     except OSError as exc:
-        log.error(
-            'fork #1 failed: {0} ({1})'.format(exc.errno, exc.strerror)
-        )
+        log.error('fork #1 failed: %s (%s)', exc.errno, exc)
         sys.exit(salt.defaults.exitcodes.EX_GENERIC)
 
     # decouple from parent environment
@@ -91,11 +89,7 @@ def daemonize(redirect_out=True):
             salt.utils.crypt.reinit_crypto()
             sys.exit(salt.defaults.exitcodes.EX_OK)
     except OSError as exc:
-        log.error(
-            'fork #2 failed: {0} ({1})'.format(
-                exc.errno, exc.strerror
-            )
-        )
+        log.error('fork #2 failed: %s (%s)', exc.errno, exc)
         sys.exit(salt.defaults.exitcodes.EX_GENERIC)
 
     salt.utils.crypt.reinit_crypto()
@@ -179,11 +173,11 @@ def set_pidfile(pidfile, user):
         os.makedirs(pdir)
     try:
         with salt.utils.files.fopen(pidfile, 'w+') as ofile:
-            ofile.write(str(os.getpid()))
+            ofile.write(str(os.getpid()))  # future lint: disable=blacklisted-function
     except IOError:
         pass
 
-    log.debug(('Created pidfile: {0}').format(pidfile))
+    log.debug('Created pidfile: %s', pidfile)
     if salt.utils.platform.is_windows():
         return True
 
@@ -215,10 +209,10 @@ def set_pidfile(pidfile, user):
                 pidfile, user
             )
         )
-        log.debug('{0} Traceback follows:\n'.format(msg), exc_info=True)
+        log.debug('%s Traceback follows:', msg, exc_info=True)
         sys.stderr.write('{0}\n'.format(msg))
         sys.exit(err.errno)
-    log.debug('Chowned pidfile: {0} to user: {1}'.format(pidfile, user))
+    log.debug('Chowned pidfile: %s to user: %s', pidfile, user)
 
 
 def check_pidfile(pidfile):
@@ -254,11 +248,7 @@ def clean_proc(proc, wait_for_kill=10):
             waited += 1
             time.sleep(0.1)
             if proc.is_alive() and (waited >= wait_for_kill):
-                log.error(
-                    'Process did not die with terminate(): {0}'.format(
-                        proc.pid
-                    )
-                )
+                log.error('Process did not die with terminate(): %s', proc.pid)
                 os.kill(proc.pid, signal.SIGKILL)
     except (AssertionError, AttributeError):
         # Catch AssertionError when the proc is evaluated inside the child
@@ -345,8 +335,10 @@ class ThreadPool(object):
                 # order to avoid an unclean shutdown. Le sigh.
                 continue
             try:
-                log.debug('ThreadPool executing func: {0} with args:{1}'
-                          ' kwargs{2}'.format(func, args, kwargs))
+                log.debug(
+                    'ThreadPool executing func: %s with args=%s kwargs=%s',
+                    func, args, kwargs
+                )
                 func(*args, **kwargs)
             except Exception as err:
                 log.debug(err, exc_info=True)
@@ -409,7 +401,7 @@ class ProcessManager(object):
             else:
                 name = '{0}{1}.{2}'.format(
                     tgt.__module__,
-                    '.{0}'.format(tgt.__class__) if str(tgt.__class__) != "<type 'type'>" else '',
+                    '.{0}'.format(tgt.__class__) if six.text_type(tgt.__class__) != "<type 'type'>" else '',
                     tgt.__name__,
                 )
 
@@ -423,7 +415,7 @@ class ProcessManager(object):
                 process.start()
         else:
             process.start()
-        log.debug("Started '{0}' with pid {1}".format(name, process.pid))
+        log.debug("Started '%s' with pid %s", name, process.pid)
         self._process_map[process.pid] = {'tgt': tgt,
                                           'args': args,
                                           'kwargs': kwargs,
@@ -436,10 +428,12 @@ class ProcessManager(object):
         '''
         if self._restart_processes is False:
             return
-        log.info('Process {0} ({1}) died with exit status {2},'
-                 ' restarting...'.format(self._process_map[pid]['tgt'],
-                                         pid,
-                                         self._process_map[pid]['Process'].exitcode))
+        log.info(
+            'Process %s (%s) died with exit status %s, restarting...',
+            self._process_map[pid]['tgt'],
+            pid,
+            self._process_map[pid]['Process'].exitcode
+        )
         # don't block, the process is already dead
         self._process_map[pid]['Process'].join(1)
 
@@ -524,7 +518,7 @@ class ProcessManager(object):
         if self._restart_processes is True:
             for pid, mapping in six.iteritems(self._process_map):
                 if not mapping['Process'].is_alive():
-                    log.trace('Process restart of {0}'.format(pid))
+                    log.trace('Process restart of %s', pid)
                     self.restart_process(pid)
 
     def kill_children(self, *args, **kwargs):
@@ -557,13 +551,13 @@ class ProcessManager(object):
                     # On Windows, we need to explicitly terminate sub-processes
                     # because the processes don't have a sigterm handler.
                     subprocess.call(
-                        ['taskkill', '/F', '/T', '/PID', str(pid)],
+                        ['taskkill', '/F', '/T', '/PID', six.text_type(pid)],
                         stdout=devnull, stderr=devnull
                         )
                     p_map['Process'].terminate()
         else:
             for pid, p_map in six.iteritems(self._process_map.copy()):
-                log.trace('Terminating pid {0}: {1}'.format(pid, p_map['Process']))
+                log.trace('Terminating pid %s: %s', pid, p_map['Process'])
                 if args:
                     # escalate the signal to the process
                     try:
@@ -587,7 +581,7 @@ class ProcessManager(object):
         log.trace('Waiting to kill process manager children')
         while self._process_map and time.time() < end_time:
             for pid, p_map in six.iteritems(self._process_map.copy()):
-                log.trace('Joining pid {0}: {1}'.format(pid, p_map['Process']))
+                log.trace('Joining pid %s: %s', pid, p_map['Process'])
                 p_map['Process'].join(0)
 
                 if not p_map['Process'].is_alive():
@@ -611,7 +605,7 @@ class ProcessManager(object):
                         # This is a race condition if a signal was passed to all children
                         pass
                     continue
-                log.trace('Killing pid {0}: {1}'.format(pid, p_map['Process']))
+                log.trace('Killing pid %s: %s', pid, p_map['Process'])
                 try:
                     os.kill(pid, signal.SIGKILL)
                 except OSError as exc:
@@ -632,7 +626,7 @@ class ProcessManager(object):
                 log.info(
                     'Some processes failed to respect the KILL signal: %s',
                         '; '.join(
-                            'Process: {0} (Pid: {1})'.format(v['Process'], k) for
+                            'Process: {0} (Pid: {1})'.format(v['Process'], k) for  # pylint: disable=str-format-in-logging
                             (k, v) in self._process_map.items()
                         )
                 )
@@ -643,7 +637,7 @@ class ProcessManager(object):
                 log.warning(
                     'Failed to kill the following processes: %s',
                     '; '.join(
-                        'Process: {0} (Pid: {1})'.format(v['Process'], k) for
+                        'Process: {0} (Pid: {1})'.format(v['Process'], k) for  # pylint: disable=str-format-in-logging
                         (k, v) in self._process_map.items()
                     )
                 )

--- a/salt/utils/profile.py
+++ b/salt/utils/profile.py
@@ -3,7 +3,7 @@
 Decorator and functions to profile Salt using cProfile
 '''
 
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function, unicode_literals
 
 # Import Python libs
 import datetime

--- a/salt/utils/psutil_compat.py
+++ b/salt/utils/psutil_compat.py
@@ -11,7 +11,7 @@ Built off of http://grodola.blogspot.com/2014/01/psutil-20-porting.html
 '''
 
 # Import Python libs
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function, unicode_literals
 
 # Import Salt libs
 from salt.ext import six

--- a/salt/utils/pushover.py
+++ b/salt/utils/pushover.py
@@ -15,7 +15,7 @@ Library for interacting with Slack API
         slack:
           api_key: peWcBiMOS9HrZG15peWcBiMOS9HrZG15
 '''
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function, unicode_literals
 
 import logging
 # Import 3rd-party libs

--- a/salt/utils/pycrypto.py
+++ b/salt/utils/pycrypto.py
@@ -4,7 +4,7 @@ Use pycrypto to generate random passwords on the fly.
 '''
 
 # Import python libraries
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function, unicode_literals
 import re
 import string
 import random

--- a/salt/utils/pydsl.py
+++ b/salt/utils/pydsl.py
@@ -84,7 +84,7 @@ Example of a ``cmd`` state calling a python function::
 #
 
 # Import python libs
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function, unicode_literals
 from uuid import uuid4 as _uuid
 
 # Import salt libs
@@ -445,7 +445,7 @@ class StateFunction(object):
                     mod, ref
                 )
             )
-        self.args.append({req_type: [{str(mod): str(ref)}]})
+        self.args.append({req_type: [{six.text_type(mod): six.text_type(ref)}]})
 
     ns = locals()
     for req_type in REQUISITES:

--- a/salt/utils/pyobjects.py
+++ b/salt/utils/pyobjects.py
@@ -5,7 +5,7 @@
 Pythonic object interface to creating state data, see the pyobjects renderer
 for more documentation.
 '''
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function, unicode_literals
 import inspect
 import logging
 

--- a/tests/unit/utils/test_parsers.py
+++ b/tests/unit/utils/test_parsers.py
@@ -4,7 +4,7 @@
 '''
 
 # Import python libs
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function, unicode_literals
 import logging
 import os
 
@@ -500,21 +500,20 @@ class LogSettingsParserTests(TestCase):
         log_file_name = self.logfile_config_setting_name
         opts = self.default_config.copy()
         opts.update({'log_file': log_file})
-        if log_file_name is not 'log_file':
-            opts.update({log_file_name:
-                         getattr(self, log_file_name)})
+        if log_file_name != 'log_file':
+            opts.update({log_file_name: log_file})
 
-        if log_file_name is 'key_logfile':
+        if log_file_name == 'key_logfile':
             self.skipTest('salt-key creates log file outside of parse_args.')
 
         parser = self.parser()
         with patch(self.config_func, MagicMock(return_value=opts)):
             parser.parse_args(args)
 
-        if log_file_name is 'log_file':
+        if log_file_name == 'log_file':
             self.assertEqual(os.path.getsize(log_file), 0)
         else:
-            self.assertEqual(os.path.getsize(getattr(self, log_file_name)), 0)
+            self.assertEqual(os.path.getsize(getattr(self, 'log_file')), 0)
 
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)

--- a/tests/unit/utils/test_parsers.py
+++ b/tests/unit/utils/test_parsers.py
@@ -501,7 +501,7 @@ class LogSettingsParserTests(TestCase):
         opts = self.default_config.copy()
         opts.update({'log_file': log_file})
         if log_file_name != 'log_file':
-            opts.update({log_file_name: log_file})
+            opts.update({log_file_name: getattr(self, log_file_name)})
 
         if log_file_name == 'key_logfile':
             self.skipTest('salt-key creates log file outside of parse_args.')
@@ -513,7 +513,7 @@ class LogSettingsParserTests(TestCase):
         if log_file_name == 'log_file':
             self.assertEqual(os.path.getsize(log_file), 0)
         else:
-            self.assertEqual(os.path.getsize(getattr(self, 'log_file')), 0)
+            self.assertEqual(os.path.getsize(getattr(self, log_file_name)), 0)
 
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)

--- a/tests/unit/utils/test_path.py
+++ b/tests/unit/utils/test_path.py
@@ -8,7 +8,7 @@
 '''
 
 # Import Python libs
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function, unicode_literals
 import os
 import sys
 import posixpath

--- a/tests/unit/utils/test_pbm.py
+++ b/tests/unit/utils/test_pbm.py
@@ -6,7 +6,7 @@
 '''
 
 # Import python libraries
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function, unicode_literals
 import logging
 
 # Import Salt testing libraries

--- a/tests/unit/utils/test_process.py
+++ b/tests/unit/utils/test_process.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 # Import python libs
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function, unicode_literals
 import os
 import sys
 import time


### PR DESCRIPTION
@Ch3LL can you take a look at `test_log_created()` in `test/unit/utils/test_parsers.py`? I was getting failures, so I investigated it and found some things that I think may have been inadvertently implemented incorrectly. Firstly, the `is` operator was used to compare strings. The `is` operator doesn't do an `==` comparison, it checks that the two things being compared are the _same exact instance_. In Python 2, as an optimization, the memory address of two `str` types with the same content is the same (i.e. only one string is allocated in memory and both instances point to that same string).

```python
>>> x = 'log_file'
>>> x is 'log_file'
True
```

The behavior of `unicode` types is different though:

```python
>>> from __future__ import unicode_literals
>>> x = 'log_file'
>>> x is 'log_file'
False
```

After making my edits to this test, it now is successfully skipped in the salt-key instance of that test (it was no longer being skipped, and thus failed, when I turned on `unicode_literals`).

I believe my edits are correct, but I would appreciate it if you could check my work and make sure I didn't do anything wrong, since you were the original author of the test.