### PR TITLE
update states kmod

### DIFF
--- a/salt/states/kmod.py
+++ b/salt/states/kmod.py
@@ -120,12 +120,18 @@ def present(name, persist=False, mods=None):
     # The remaining modules are not loaded and are available for loading
     available = list(set(not_loaded) - set(unavailable))
     loaded = {'yes': [], 'no': [], 'failed': []}
+    loaded_by_dependency = []
     for mod in available:
+        if mod in loaded_by_dependency:
+            loaded['yes'].append(mod)
+            continue
         load_result = __salt__['kmod.load'](mod, persist)
         if isinstance(load_result, (list, tuple)):
             if len(load_result) > 0:
                 for module in load_result:
                     ret['changes'][module] = 'loaded'
+                    if module != mod:
+                        loaded_by_dependency.append(module)
                 loaded['yes'].append(mod)
             else:
                 ret['result'] = False


### PR DESCRIPTION
  * track list of loaded by dependency modules

### What does this PR do?
fix #45177 
### What issues does this PR fix or reference?

### Previous Behavior
```
# salt-call state.sls issue
[ERROR   ] {'nf_nat': 'loaded', 'nf_nat_ipv4': 'loaded', 'nf_conntrack': 'loaded', 'nf_conntrack_ipv4': 'loaded', 'nf_defrag_ipv4': 'loaded', 'loop': 'loaded'}
local:
----------
          ID: Ensure nf_conntrack loaded
    Function: kmod.present
      Result: False
     Comment: Loaded kernel modules nf_nat_ipv4, loop
              Failed to load kernel module nf_conntrack                                                                                
     Started: 14:34:47.080137
    Duration: 343.128 ms
     Changes:   
              ----------
              loop:
                  loaded
              nf_conntrack:
                  loaded
              nf_conntrack_ipv4:
                  loaded
              nf_defrag_ipv4:
                  loaded
              nf_nat:
                  loaded
              nf_nat_ipv4:
                  loaded

Summary for local                                                                                                                      
------------                                                                                                                           
Succeeded: 0 (changed=1)
Failed:    1
------------
Total states run:     1                                                                                                                
Total run time: 343.128 ms
```
### New Behavior
```
# salt-call state.sls issue
local:
----------
          ID: Ensure nf_conntrack loaded
    Function: kmod.present
      Result: True
     Comment: Kernel module loop is already present
              Loaded kernel modules nf_nat_ipv4, nf_conntrack, nf_conntrack_ipv4, nf_nat                                               
     Started: 14:49:14.231246
    Duration: 298.853 ms
     Changes:   
              ----------                                                                                                               
              nf_conntrack:
                  loaded
              nf_conntrack_ipv4:
                  loaded
              nf_defrag_ipv4:
                  loaded
              nf_nat:
                  loaded
              nf_nat_ipv4:
                  loaded

Summary for local
------------
Succeeded: 1 (changed=1)
Failed:    0
------------
Total states run:     1
Total run time: 298.853 ms

```

### Tests written?

No
Checked on local env

### Commits signed with GPG?

Yes
