### PR TITLE
[2016.11] Salt Cloud: fix loading UTF-8 cached data

### DIFF
--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -2508,7 +2508,7 @@ def cachedir_index_add(minion_id, profile, driver, provider, base=None):
 
     if os.path.exists(index_file):
         with salt.utils.fopen(index_file, 'r') as fh_:
-            index = msgpack.load(fh_)
+            index = msgpack.load(fh_, encoding='utf-8')
     else:
         index = {}
 
@@ -2540,7 +2540,7 @@ def cachedir_index_del(minion_id, base=None):
 
     if os.path.exists(index_file):
         with salt.utils.fopen(index_file, 'r') as fh_:
-            index = msgpack.load(fh_)
+            index = msgpack.load(fh_, encoding='utf-8')
     else:
         return
 
@@ -2637,7 +2637,7 @@ def change_minion_cachedir(
     path = os.path.join(base, cachedir, fname)
 
     with salt.utils.fopen(path, 'r') as fh_:
-        cache_data = msgpack.load(fh_)
+        cache_data = msgpack.load(fh_, encoding='utf-8')
 
     cache_data.update(data)
 
@@ -2713,7 +2713,7 @@ def list_cache_nodes_full(opts, provider=None, base=None):
                 fname = '{0}.p'.format(minion_id)
                 fpath = os.path.join(min_dir, fname)
                 with salt.utils.fopen(fpath, 'r') as fh_:
-                    minions[driver][prov][minion_id] = msgpack.load(fh_)
+                    minions[driver][prov][minion_id] = msgpack.load(fh_, encoding='utf-8')
 
     return minions
 
@@ -2992,7 +2992,7 @@ def diff_node_cache(prov_dir, node, new_data, opts):
 
     with salt.utils.fopen(path, 'r') as fh_:
         try:
-            cache_data = msgpack.load(fh_)
+            cache_data = msgpack.load(fh_, encoding='utf-8')
         except ValueError:
             log.warning('Cache for {0} was corrupt: Deleting'.format(node))
             cache_data = {}

--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -88,6 +88,10 @@ try:
 except ImportError:
     HAS_GETPASS = False
 
+# This is required to support international characters in AWS EC2 tags or any
+# other kind of metadata provided by particular Cloud vendor.
+MSGPACK_ENCODING = 'utf-8'
+
 NSTATES = {
     0: 'running',
     1: 'rebooting',
@@ -2508,7 +2512,7 @@ def cachedir_index_add(minion_id, profile, driver, provider, base=None):
 
     if os.path.exists(index_file):
         with salt.utils.fopen(index_file, 'r') as fh_:
-            index = msgpack.load(fh_, encoding='utf-8')
+            index = msgpack.load(fh_, encoding=MSGPACK_ENCODING)
     else:
         index = {}
 
@@ -2524,7 +2528,7 @@ def cachedir_index_add(minion_id, profile, driver, provider, base=None):
     })
 
     with salt.utils.fopen(index_file, 'w') as fh_:
-        msgpack.dump(index, fh_)
+        msgpack.dump(index, fh_, encoding=MSGPACK_ENCODING)
 
     unlock_file(index_file)
 
@@ -2540,7 +2544,7 @@ def cachedir_index_del(minion_id, base=None):
 
     if os.path.exists(index_file):
         with salt.utils.fopen(index_file, 'r') as fh_:
-            index = msgpack.load(fh_, encoding='utf-8')
+            index = msgpack.load(fh_, encoding=MSGPACK_ENCODING)
     else:
         return
 
@@ -2548,7 +2552,7 @@ def cachedir_index_del(minion_id, base=None):
         del index[minion_id]
 
     with salt.utils.fopen(index_file, 'w') as fh_:
-        msgpack.dump(index, fh_)
+        msgpack.dump(index, fh_, encoding=MSGPACK_ENCODING)
 
     unlock_file(index_file)
 
@@ -2605,7 +2609,7 @@ def request_minion_cachedir(
     fname = '{0}.p'.format(minion_id)
     path = os.path.join(base, 'requested', fname)
     with salt.utils.fopen(path, 'w') as fh_:
-        msgpack.dump(data, fh_)
+        msgpack.dump(data, fh_, encoding=MSGPACK_ENCODING)
 
 
 def change_minion_cachedir(
@@ -2637,12 +2641,12 @@ def change_minion_cachedir(
     path = os.path.join(base, cachedir, fname)
 
     with salt.utils.fopen(path, 'r') as fh_:
-        cache_data = msgpack.load(fh_, encoding='utf-8')
+        cache_data = msgpack.load(fh_, encoding=MSGPACK_ENCODING)
 
     cache_data.update(data)
 
     with salt.utils.fopen(path, 'w') as fh_:
-        msgpack.dump(cache_data, fh_)
+        msgpack.dump(cache_data, fh_, encoding=MSGPACK_ENCODING)
 
 
 def activate_minion_cachedir(minion_id, base=None):
@@ -2713,7 +2717,7 @@ def list_cache_nodes_full(opts, provider=None, base=None):
                 fname = '{0}.p'.format(minion_id)
                 fpath = os.path.join(min_dir, fname)
                 with salt.utils.fopen(fpath, 'r') as fh_:
-                    minions[driver][prov][minion_id] = msgpack.load(fh_, encoding='utf-8')
+                    minions[driver][prov][minion_id] = msgpack.load(fh_, encoding=MSGPACK_ENCODING)
 
     return minions
 
@@ -2892,7 +2896,7 @@ def cache_node_list(nodes, provider, opts):
         diff_node_cache(prov_dir, node, nodes[node], opts)
         path = os.path.join(prov_dir, '{0}.p'.format(node))
         with salt.utils.fopen(path, 'w') as fh_:
-            msgpack.dump(nodes[node], fh_)
+            msgpack.dump(nodes[node], fh_, encoding=MSGPACK_ENCODING)
 
 
 def cache_node(node, provider, opts):
@@ -2917,7 +2921,7 @@ def cache_node(node, provider, opts):
         os.makedirs(prov_dir)
     path = os.path.join(prov_dir, '{0}.p'.format(node['name']))
     with salt.utils.fopen(path, 'w') as fh_:
-        msgpack.dump(node, fh_)
+        msgpack.dump(node, fh_, encoding=MSGPACK_ENCODING)
 
 
 def missing_node_cache(prov_dir, node_list, provider, opts):
@@ -2992,7 +2996,7 @@ def diff_node_cache(prov_dir, node, new_data, opts):
 
     with salt.utils.fopen(path, 'r') as fh_:
         try:
-            cache_data = msgpack.load(fh_, encoding='utf-8')
+            cache_data = msgpack.load(fh_, encoding=MSGPACK_ENCODING)
         except ValueError:
             log.warning('Cache for {0} was corrupt: Deleting'.format(node))
             cache_data = {}


### PR DESCRIPTION
### What does this PR do?
It makes sure that msgpack loads previously cached cloud event data in UTF-8. According to the API it always dumps the data in the `utf-8` encoding, but reads as raw (read ASCII) by default.
https://msgpack-python.readthedocs.io/en/latest/api.html#msgpack.Packer
https://msgpack-python.readthedocs.io/en/latest/api.html#msgpack.Unpacker

### What issues does this PR fix or reference?
Should finally fix #20823.

### Previous Behavior
Salt Cloud was unable to compare cached data which contains unicode symbols with actual data read from an event.

### New Behavior
Salt Cloud successfully loads and works with cached data stored in UTF-8.

### Tests written?
No

### Commits signed with GPG?
Yes
