### PR TITLE
grains/core.py: use ascii strings when reading init system information

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1462,16 +1462,24 @@ def os_data():
                         try:
                             with salt.utils.files.fopen(init_bin, 'rb') as fp_:
                                 buf = True
-                                edge = six.b('')
+                                if six.PY3:
+                                    edge = six.b('')
+                                else:
+                                    edge = str('')
                                 buf = fp_.read(buf_size).lower()
                                 while buf:
                                     buf = edge + buf
                                     for item in supported_inits:
+                                        if six.PY2:
+                                            item = str(item)
                                         if item in buf:
                                             if six.PY3:
                                                 item = item.decode('utf-8')
                                             grains['init'] = item
-                                            buf = six.b('')
+                                            if six.PY3:
+                                                buf = six.b('')
+                                            else:
+                                                buf = str('')
                                             break
                                     edge = buf[-edge_len:]
                                     buf = fp_.read(buf_size).lower()


### PR DESCRIPTION
grains/core.py has the default string enconding set to unicode, via:

from _future_ import unicode_literals

however, on the os_data function, we read binary data using the function
salt.utils.files.fopen, which returns an ascii string. In PY2, explicity
convert literals to str to avoid unicode decode exceptions on the binary
data.

Signed-off-by: Alejandro del Castillo <alejandro.delcastillo@ni.com>

### What does this PR do?

Fix broken os_data grains

### Tests written?

No

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
