### PR TITLE
aptpkg: force additional environment variables to be str types

### DIFF
--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -85,12 +85,12 @@ LP_PVT_SRC_FORMAT = 'deb https://{0}private-ppa.launchpad.net/{1}/{2}/ubuntu' \
 
 _MODIFY_OK = frozenset(['uri', 'comps', 'architectures', 'disabled',
                         'file', 'dist'])
-DPKG_ENV_VARS = {
+DPKG_ENV_VARS = salt.utils.data.encode({
     'APT_LISTBUGS_FRONTEND': 'none',
     'APT_LISTCHANGES_FRONTEND': 'none',
     'DEBIAN_FRONTEND': 'noninteractive',
     'UCF_FORCE_CONFFOLD': '1',
-}
+})
 
 # Define the module's virtual name
 __virtualname__ = 'pkg'


### PR DESCRIPTION
This prevents tracebacks in subprocess due to unicode values in
the dict merged into os.environ via the module's `__init__` func.