### PR TITLE
Fix if statement in __init__()

### DIFF
--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -104,7 +104,7 @@ def __init__(opts):
     a few env variables to keep apt happy and
     non-interactive.
     '''
-    if __virtual__():
+    if __virtual__() == __virtualname__:
         # Export these puppies so they persist
         os.environ.update(DPKG_ENV_VARS)
 


### PR DESCRIPTION
### What does this PR do?
Fixes an issue where the `aptpkg.py` execution module was modifying the environment on non-debian machines. This was causing a stack trace in recent releases of salt due to using Unicode literals.

### What issues does this PR fix or reference?
Exposed by: #45440

### Previous Behavior
The following stack trace occurs on the head of oxygen:
```
[ERROR   ] Failed to import module minion, this is due most likely to a syntax error:
Traceback (most recent call last):
  File "c:\dev\salt\salt\loader.py", line 1458, in _load_module
    mod = imp.load_module(mod_namespace, fn_, fpath, desc)
  File "c:\dev\salt\salt\modules\minion.py", line 14, in <module>
    import salt.key
  File "c:\dev\salt\salt\key.py", line 21, in <module>
    import salt.daemons.masterapi
  File "c:\dev\salt\salt\daemons\masterapi.py", line 35, in <module>
    import salt.utils.gitfs
  File "c:\dev\salt\salt\utils\gitfs.py", line 92, in <module>
    import git
  File "c:\python27\lib\site-packages\git\__init__.py", line 82, in <module>
    refresh()
  File "c:\python27\lib\site-packages\git\__init__.py", line 73, in refresh
    if not Git.refresh(path=path):
  File "c:\python27\lib\site-packages\git\cmd.py", line 230, in refresh
    cls().version()
  File "c:\python27\lib\site-packages\git\cmd.py", line 551, in <lambda>
    return lambda *args, **kwargs: self._call_process(name, *args, **kwargs)
  File "c:\python27\lib\site-packages\git\cmd.py", line 1010, in _call_process
    return self.execute(call, **exec_kwargs)
  File "c:\python27\lib\site-packages\git\cmd.py", line 732, in execute
    **subprocess_kwargs
  File "c:\python27\lib\subprocess.py", line 390, in __init__
    errread, errwrite)
  File "c:\python27\lib\subprocess.py", line 640, in _execute_child
    startupinfo)
TypeError: environment can only contain strings
```

### Tests written?
No

### Commits signed with GPG?
Yes