### PR TITLE
[PY2] timed_subprocess: ensure custom env vars do not contain unicode

### DIFF
--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -490,7 +490,7 @@ def _run(cmd,
 
     kwargs = {'cwd': cwd,
               'shell': python_shell,
-              'env': run_env,
+              'env': run_env if six.PY3 else salt.utils.data.encode(run_env),
               'stdin': six.text_type(stdin) if stdin is not None else stdin,
               'stdout': stdout,
               'stderr': stderr,

--- a/salt/utils/timed_subprocess.py
+++ b/salt/utils/timed_subprocess.py
@@ -43,7 +43,7 @@ class TimedProc(object):
 
         try:
             self.process = subprocess.Popen(args, **kwargs)
-        except TypeError:
+        except (AttributeError, TypeError):
             if not kwargs.get('shell', False):
                 if not isinstance(args, (list, tuple)):
                     try:

--- a/salt/utils/timed_subprocess.py
+++ b/salt/utils/timed_subprocess.py
@@ -8,6 +8,7 @@ import shlex
 import subprocess
 import threading
 import salt.exceptions
+import salt.utils.data
 from salt.ext import six
 
 
@@ -66,6 +67,10 @@ class TimedProc(object):
                     kwargs['env'][key] = str(val)
                 if not isinstance(key, six.string_types):
                     kwargs['env'][str(key)] = kwargs['env'].pop(key)
+            if six.PY2 and 'env' in kwargs:
+                # Ensure no unicode in custom env dict, as it can cause
+                # problems with subprocess.
+                kwargs['env'] = salt.utils.data.encode_dict(kwargs['env'])
             self.process = subprocess.Popen(args, **kwargs)
         self.command = args
 


### PR DESCRIPTION
subprocess will use `ascii` to encode them which will cause trouble if
any actual unicode content is present.