### PR TITLE
Improve PY3 compatibility of salt.utils.data.decode and encode

### DIFF
--- a/salt/utils/data.py
+++ b/salt/utils/data.py
@@ -67,143 +67,177 @@ def compare_lists(old=None, new=None):
     return ret
 
 
-def decode(data, preserve_dict_class=False, preserve_tuples=False):
+def decode(data, encoding=None, errors='strict', preserve_dict_class=False, preserve_tuples=False):
     '''
     Generic function which will decode whichever type is passed, if necessary
     '''
-    if isinstance(data, six.string_types):
-        if six.PY2 and isinstance(data, str):
-            return data.decode('utf-8')
-        else:
-            return data
-    elif isinstance(data, collections.Mapping):
-        return decode_dict(data, preserve_dict_class, preserve_tuples)
+    if isinstance(data, collections.Mapping):
+        return decode_dict(data, encoding, errors, preserve_dict_class, preserve_tuples)
     elif isinstance(data, list):
-        return decode_list(data, preserve_dict_class, preserve_tuples)
+        return decode_list(data, encoding, errors, preserve_dict_class, preserve_tuples)
     elif isinstance(data, tuple):
-        return decode_tuple(data, preserve_dict_class) if preserve_tuples \
-            else decode_list(data, preserve_dict_class, preserve_tuples)
+        return decode_tuple(data, encoding, errors, preserve_dict_class) \
+            if preserve_tuples \
+            else decode_list(data, encoding, errors, preserve_dict_class, preserve_tuples)
     else:
-        return data
+        try:
+            return salt.utils.stringutils.to_unicode(data, encoding, errors)
+        except TypeError:
+            return data
 
 
-def decode_dict(data, preserve_dict_class=False, preserve_tuples=False):
+def decode_dict(data, encoding=None, errors='strict', preserve_dict_class=False, preserve_tuples=False):
     '''
     Decode all string values to Unicode
     '''
     # Make sure we preserve OrderedDicts
     rv = data.__class__() if preserve_dict_class else {}
     for key, value in six.iteritems(data):
-        if six.PY2 and isinstance(key, str):
-            key = key.decode('utf-8')
-        if six.PY2 and isinstance(value, str):
-            value = value.decode('utf-8')
-        elif isinstance(value, list):
-            value = decode_list(value, preserve_dict_class, preserve_tuples)
+        if isinstance(key, tuple):
+            key = decode_tuple(key, encoding, errors, preserve_dict_class) \
+                if preserve_tuples \
+                else decode_list(key, encoding, errors, preserve_dict_class, preserve_tuples)
+        else:
+            try:
+                key = salt.utils.stringutils.to_unicode(key, encoding, errors)
+            except TypeError:
+                pass
+
+        if isinstance(value, list):
+            value = decode_list(value, encoding, errors, preserve_dict_class, preserve_tuples)
         elif isinstance(value, tuple):
-            value = decode_tuple(value, preserve_dict_class) if preserve_tuples \
-                else decode_list(value, preserve_dict_class, preserve_tuples)
+            value = decode_tuple(value, encoding, errors, preserve_dict_class) \
+                if preserve_tuples \
+                else decode_list(value, encoding, errors, preserve_dict_class, preserve_tuples)
         elif isinstance(value, collections.Mapping):
-            value = decode_dict(value, preserve_dict_class, preserve_tuples)
+            value = decode_dict(value, encoding, errors, preserve_dict_class, preserve_tuples)
+        else:
+            try:
+                value = salt.utils.stringutils.to_unicode(value, encoding, errors)
+            except TypeError:
+                pass
+
         rv[key] = value
     return rv
 
 
-def decode_list(data, preserve_dict_class=False, preserve_tuples=False):
+def decode_list(data, encoding=None, errors='strict', preserve_dict_class=False, preserve_tuples=False):
     '''
     Decode all string values to Unicode
     '''
     rv = []
     for item in data:
-        if six.PY2 and isinstance(item, str):
-            item = item.decode('utf-8')
-        elif isinstance(item, list):
-            item = decode_list(item, preserve_dict_class, preserve_tuples)
+        if isinstance(item, list):
+            item = decode_list(item, encoding, errors, preserve_dict_class, preserve_tuples)
         elif isinstance(item, tuple):
-            item = decode_tuple(item, preserve_dict_class) if preserve_tuples \
-                else decode_list(item, preserve_dict_class, preserve_tuples)
+            item = decode_tuple(item, encoding, errors, preserve_dict_class) \
+                if preserve_tuples \
+                else decode_list(item, encoding, errors, preserve_dict_class, preserve_tuples)
         elif isinstance(item, collections.Mapping):
-            item = decode_dict(item, preserve_dict_class, preserve_tuples)
+            item = decode_dict(item, encoding, errors, preserve_dict_class, preserve_tuples)
+        else:
+            try:
+                item = salt.utils.stringutils.to_unicode(item, encoding, errors)
+            except TypeError:
+                pass
+
         rv.append(item)
     return rv
 
 
-def decode_tuple(data, preserve_dict_class=False):
+def decode_tuple(data, encoding=None, errors='strict', preserve_dict_class=False):
     '''
     Decode all string values to Unicode
     '''
-    return tuple(decode_list(data, preserve_dict_class, True))
+    return tuple(decode_list(data, encoding, errors, preserve_dict_class, True))
 
 
-def encode(data, preserve_dict_class=False, preserve_tuples=False):
+def encode(data, encoding=None, errors='strict', preserve_dict_class=False, preserve_tuples=False):
     '''
     Generic function which will encode whichever type is passed, if necessary
     '''
-    if isinstance(data, six.string_types):
-        if six.PY2 and isinstance(data, six.text_type):
-            return data.encode('utf-8')
-        else:
-            return data
-    elif isinstance(data, collections.Mapping):
-        return encode_dict(data, preserve_dict_class, preserve_tuples)
+    if isinstance(data, collections.Mapping):
+        return encode_dict(data, encoding, errors, preserve_dict_class, preserve_tuples)
     elif isinstance(data, list):
-        return encode_list(data, preserve_dict_class, preserve_tuples)
+        return encode_list(data, encoding, errors, preserve_dict_class, preserve_tuples)
     elif isinstance(data, tuple):
-        return encode_tuple(data, preserve_dict_class) if preserve_tuples \
-            else encode_list(data, preserve_dict_class, preserve_tuples)
+        return encode_tuple(data, encoding, errors, preserve_dict_class) \
+            if preserve_tuples \
+            else encode_list(data, encoding, errors, preserve_dict_class, preserve_tuples)
     else:
-        return data
+        try:
+            return salt.utils.stringutils.to_bytes(data, encoding, errors)
+        except TypeError:
+            return data
 
 
 @jinja_filter('json_decode_dict')  # Remove this for Neon
 @jinja_filter('json_encode_dict')
-def encode_dict(data, preserve_dict_class=False, preserve_tuples=False):
+def encode_dict(data, encoding=None, errors='strict', preserve_dict_class=False, preserve_tuples=False):
     '''
     Encode all string values to bytes
     '''
     rv = data.__class__() if preserve_dict_class else {}
     for key, value in six.iteritems(data):
-        if six.PY2 and isinstance(key, six.text_type):
-            key = key.encode('utf-8')
-        if six.PY2 and isinstance(value, six.text_type):
-            value = value.encode('utf-8')
-        elif isinstance(value, list):
-            value = encode_list(value, preserve_dict_class, preserve_tuples)
+        if isinstance(key, tuple):
+            key = encode_tuple(key, encoding, errors, preserve_dict_class) \
+                if preserve_tuples \
+                else encode_list(key, encoding, errors, preserve_dict_class, preserve_tuples)
+        else:
+            try:
+                key = salt.utils.stringutils.to_bytes(key, encoding, errors)
+            except TypeError:
+                pass
+
+        if isinstance(value, list):
+            value = encode_list(value, encoding, errors, preserve_dict_class, preserve_tuples)
         elif isinstance(value, tuple):
-            value = encode_tuple(value, preserve_dict_class) if preserve_tuples \
-                else encode_list(value, preserve_dict_class, preserve_tuples)
+            value = encode_tuple(value, encoding, errors, preserve_dict_class) \
+                if preserve_tuples \
+                else encode_list(value, encoding, errors, preserve_dict_class, preserve_tuples)
         elif isinstance(value, collections.Mapping):
-            value = encode_dict(value, preserve_dict_class, preserve_tuples)
+            value = encode_dict(value, encoding, errors, preserve_dict_class, preserve_tuples)
+        else:
+            try:
+                value = salt.utils.stringutils.to_bytes(value, encoding, errors)
+            except TypeError:
+                pass
+
         rv[key] = value
     return rv
 
 
 @jinja_filter('json_decode_list')  # Remove this for Neon
 @jinja_filter('json_encode_list')
-def encode_list(data, preserve_dict_class=False, preserve_tuples=False):
+def encode_list(data, encoding=None, errors='strict', preserve_dict_class=False, preserve_tuples=False):
     '''
     Encode all string values to bytes
     '''
     rv = []
     for item in data:
-        if six.PY2 and isinstance(item, six.text_type):
-            item = item.encode('utf-8')
-        elif isinstance(item, list):
-            item = encode_list(item, preserve_dict_class, preserve_tuples)
+        if isinstance(item, list):
+            item = encode_list(item, encoding, errors, preserve_dict_class, preserve_tuples)
         elif isinstance(item, tuple):
-            item = encode_tuple(item, preserve_dict_class) if preserve_tuples \
-                else encode_list(item, preserve_dict_class, preserve_tuples)
+            item = encode_tuple(item, encoding, errors, preserve_dict_class) \
+                if preserve_tuples \
+                else encode_list(item, encoding, errors, preserve_dict_class, preserve_tuples)
         elif isinstance(item, collections.Mapping):
-            item = encode_dict(item, preserve_dict_class, preserve_tuples)
+            item = encode_dict(item, encoding, errors, preserve_dict_class, preserve_tuples)
+        else:
+            try:
+                item = salt.utils.stringutils.to_bytes(item, encoding, errors)
+            except TypeError:
+                pass
+
         rv.append(item)
     return rv
 
 
-def encode_tuple(data, preserve_dict_class=False):
+def encode_tuple(data, encoding=None, errors='strict', preserve_dict_class=False):
     '''
     Encode all string values to Unicode
     '''
-    return tuple(encode_list(data, preserve_dict_class, True))
+    return tuple(encode_list(data, encoding, errors, preserve_dict_class, True))
 
 
 @jinja_filter('exactly_n_true')

--- a/salt/utils/locales.py
+++ b/salt/utils/locales.py
@@ -50,7 +50,7 @@ def sdecode(string_):
                 # Make sure unicode string ops work
                 u' ' + decoded  # pylint: disable=W0104
             return decoded
-        except UnicodeDecodeError:
+        except (TypeError, UnicodeDecodeError):
             continue
     return string_
 

--- a/salt/utils/stringutils.py
+++ b/salt/utils/stringutils.py
@@ -24,7 +24,7 @@ log = logging.getLogger(__name__)
 
 
 @jinja_filter('to_bytes')
-def to_bytes(s, encoding=None):
+def to_bytes(s, encoding=None, errors='strict'):
     '''
     Given bytes, bytearray, str, or unicode (python 2), return bytes (str for
     python 2)
@@ -36,19 +36,19 @@ def to_bytes(s, encoding=None):
             return bytes(s)
         if isinstance(s, six.string_types):
             if encoding:
-                return s.encode(encoding)
+                return s.encode(encoding, errors)
             else:
                 try:
-                    return s.encode(__salt_system_encoding__)
+                    return s.encode(__salt_system_encoding__, errors)
                 except UnicodeEncodeError:
                     # Fall back to UTF-8
-                    return s.encode('utf-8')
+                    return s.encode('utf-8', errors)
         raise TypeError('expected bytes, bytearray, or str')
     else:
-        return to_str(s, encoding)
+        return to_str(s, encoding, errors)
 
 
-def to_str(s, encoding=None):
+def to_str(s, encoding=None, errors='strict'):
     '''
     Given str, bytes, bytearray, or unicode (py2), return str
     '''
@@ -58,55 +58,56 @@ def to_str(s, encoding=None):
         return s
     if six.PY3:
         if isinstance(s, (bytes, bytearray)):
-            # https://docs.python.org/3/howto/unicode.html#the-unicode-type
-            # replace error with U+FFFD, REPLACEMENT CHARACTER
             if encoding:
-                return s.decode(encoding, 'replace')
+                return s.decode(encoding, errors)
             else:
                 try:
-                    return s.decode(__salt_system_encoding__, 'replace')
+                    return s.decode(__salt_system_encoding__, errors)
                 except UnicodeDecodeError:
                     # Fall back to UTF-8
-                    return s.decode('utf-8', 'replace')
+                    return s.decode('utf-8', errors)
         raise TypeError('expected str, bytes, or bytearray not {}'.format(type(s)))
     else:
         if isinstance(s, bytearray):
             return str(s)  # future lint: disable=blacklisted-function
         if isinstance(s, unicode):  # pylint: disable=incompatible-py3-code,undefined-variable
             if encoding:
-                return s.encode(encoding)
+                return s.encode(encoding, errors)
             else:
                 try:
-                    return s.encode(__salt_system_encoding__)
+                    return s.encode(__salt_system_encoding__, errors)
                 except UnicodeEncodeError:
                     # Fall back to UTF-8
-                    return s.encode('utf-8')
+                    return s.encode('utf-8', errors)
         raise TypeError('expected str, bytearray, or unicode')
 
 
-def to_unicode(s, encoding=None):
+def to_unicode(s, encoding=None, errors='strict'):
     '''
     Given str or unicode, return unicode (str for python 3)
     '''
-    if not isinstance(s, (bytes, bytearray, six.string_types)):
-        return s
     if six.PY3:
-        if isinstance(s, (bytes, bytearray)):
-            return to_str(s, encoding)
+        if isinstance(s, str):
+            return s
+        elif isinstance(s, (bytes, bytearray)):
+            return to_str(s, encoding, errors)
+        raise TypeError('expected str, bytes, or bytearray')
     else:
         # This needs to be str and not six.string_types, since if the string is
         # already a unicode type, it does not need to be decoded (and doing so
         # will raise an exception).
-        if isinstance(s, str):
+        if isinstance(s, unicode):  # pylint: disable=incompatible-py3-code
+            return s
+        elif isinstance(s, (str, bytearray)):
             if encoding:
-                return s.decode(encoding)
+                return s.decode(encoding, errors)
             else:
                 try:
-                    return s.decode(__salt_system_encoding__)
+                    return s.decode(__salt_system_encoding__, errors)
                 except UnicodeDecodeError:
                     # Fall back to UTF-8
-                    return s.decode('utf-8')
-    return s
+                    return s.decode('utf-8', errors)
+        raise TypeError('expected str or bytearray')
 
 
 @jinja_filter('str_to_num')  # Remove this for Neon

--- a/tests/unit/utils/test_data.py
+++ b/tests/unit/utils/test_data.py
@@ -5,13 +5,38 @@ Tests for salt.utils.data
 
 # Import Python libs
 from __future__ import absolute_import, print_function, unicode_literals
+import logging
 
 # Import Salt libs
 import salt.utils.data
-from tests.support.unit import TestCase, LOREM_IPSUM
+from salt.utils.odict import OrderedDict
+from tests.support.unit import TestCase, skipIf, LOREM_IPSUM
+from tests.support.mock import patch, NO_MOCK, NO_MOCK_REASON
+from salt.ext.six.moves import builtins  # pylint: disable=import-error,redefined-builtin
+
+log = logging.getLogger(__name__)
+_b = lambda x: x.encode('utf-8')
 
 
 class DataTestCase(TestCase):
+    test_data = [
+        'unicode_str',
+        _b('питон'),
+        123,
+        456.789,
+        True,
+        False,
+        None,
+        [123, 456.789, _b('спам'), True, False, None],
+        (987, 654.321, _b('яйца'), None, (True, False)),
+        {_b('str_key'): _b('str_val'),
+         None: True, 123: 456.789,
+         _b('subdict'): {'unicode_key': 'unicode_val',
+                         _b('tuple'): (123, 'hello', _b('world'), True),
+                         _b('list'): [456, _b('спам'), False]}},
+        OrderedDict([(_b('foo'), 'bar'), (123, 456)])
+    ]
+
     def test_sorted_ignorecase(self):
         test_list = ['foo', 'Foo', 'bar', 'Bar']
         expected_list = ['bar', 'Bar', 'foo', 'Foo']
@@ -176,21 +201,115 @@ class DataTestCase(TestCase):
         expected_ret = {'foo': {'new': 'woz', 'old': 'bar'}}
         self.assertDictEqual(ret, expected_ret)
 
-    def test_decode_list(self):
-        test_data = ['unicode_str', ['unicode_item_in_list', 'second_item_in_list'], {'dict_key': 'dict_val'}]
-        expected_ret = ['unicode_str', ['unicode_item_in_list', 'second_item_in_list'], {'dict_key': 'dict_val'}]
-        ret = salt.utils.data.decode_list(test_data)
-        self.assertEqual(ret, expected_ret)
+    def test_decode(self):
+        '''
+        NOTE: This uses the lambda "_b" defined above in the global scope,
+        which encodes a string to a bytestring, assuming utf-8.
+        '''
+        expected = [
+            'unicode_str',
+            'питон',
+            123,
+            456.789,
+            True,
+            False,
+            None,
+            [123, 456.789, 'спам', True, False, None],
+            (987, 654.321, 'яйца', None, (True, False)),
+            {'str_key': 'str_val',
+             None: True, 123: 456.789,
+             'subdict': {'unicode_key': 'unicode_val',
+                         'tuple': (123, 'hello', 'world', True),
+                         'list': [456, 'спам', False]}},
+            OrderedDict([('foo', 'bar'), (123, 456)])
+        ]
 
-    def test_decode_dict(self):
-        test_data = {'test_unicode_key': 'test_unicode_val',
-                     'test_list_key': ['list_1', 'unicode_list_two'],
-                     'test_dict_key': {'test_sub_dict_key': 'test_sub_dict_val'}}
-        expected_ret = {'test_unicode_key': 'test_unicode_val',
-                        'test_list_key': ['list_1', 'unicode_list_two'],
-                        'test_dict_key': {'test_sub_dict_key': 'test_sub_dict_val'}}
-        ret = salt.utils.data.decode_dict(test_data)
-        self.assertDictEqual(ret, expected_ret)
+        ret = salt.utils.data.decode(
+            self.test_data, preserve_dict_class=True, preserve_tuples=True)
+        self.assertEqual(ret, expected)
+
+        # Now munge the expected data so that we get what we would expect if we
+        # disable preservation of dict class and tuples
+        expected[8] = [987, 654.321, 'яйца', None, [True, False]]
+        expected[9]['subdict']['tuple'] = [123, 'hello', 'world', True]
+        expected[10] = {'foo': 'bar', 123: 456}
+        ret = salt.utils.data.decode(
+            self.test_data, preserve_dict_class=False, preserve_tuples=False)
+        self.assertEqual(ret, expected)
+
+        # Now test single non-string, non-data-structure items, these should
+        # return the same value when passed to this function
+        for item in (123, 4.56, True, False, None):
+            log.debug('Testing decode of %s', item)
+            self.assertEqual(salt.utils.data.decode(item), item)
+
+        # Test single strings (not in a data structure)
+        self.assertEqual(salt.utils.data.decode('foo'), 'foo')
+        self.assertEqual(salt.utils.data.decode(_b('bar')), 'bar')
+
+    @skipIf(NO_MOCK, NO_MOCK_REASON)
+    def test_decode_fallback(self):
+        '''
+        Test fallback to utf-8
+        '''
+        with patch.object(builtins, '__salt_system_encoding__', 'ascii'):
+            self.assertEqual(salt.utils.data.decode(_b('яйца')), 'яйца')
+
+    def test_encode(self):
+        '''
+        NOTE: This uses the lambda "_b" defined above in the global scope,
+        which encodes a string to a bytestring, assuming utf-8.
+        '''
+        expected = [
+            _b('unicode_str'),
+            _b('питон'),
+            123,
+            456.789,
+            True,
+            False,
+            None,
+            [123, 456.789, _b('спам'), True, False, None],
+            (987, 654.321, _b('яйца'), None, (True, False)),
+            {_b('str_key'): _b('str_val'),
+             None: True, 123: 456.789,
+             _b('subdict'): {_b('unicode_key'): _b('unicode_val'),
+                             _b('tuple'): (123, _b('hello'), _b('world'), True),
+                             _b('list'): [456, _b('спам'), False]}},
+            OrderedDict([(_b('foo'), _b('bar')), (123, 456)])
+        ]
+
+        ret = salt.utils.data.encode(
+            self.test_data, preserve_dict_class=True, preserve_tuples=True)
+        self.assertEqual(ret, expected)
+
+        # Now munge the expected data so that we get what we would expect if we
+        # disable preservation of dict class and tuples
+        expected[8] = [987, 654.321, _b('яйца'), None, [True, False]]
+        expected[9][_b('subdict')][_b('tuple')] = [123, _b('hello'), _b('world'), True]
+        expected[10] = {_b('foo'): _b('bar'), 123: 456}
+        ret = salt.utils.data.encode(
+            self.test_data, preserve_dict_class=False, preserve_tuples=False)
+        self.assertEqual(ret, expected)
+
+        # Now test single non-string, non-data-structure items, these should
+        # return the same value when passed to this function
+        for item in (123, 4.56, True, False, None):
+            log.debug('Testing encode of %s', item)
+            self.assertEqual(salt.utils.data.encode(item), item)
+
+        # Test single strings (not in a data structure)
+        self.assertEqual(salt.utils.data.encode('foo'), _b('foo'))
+        self.assertEqual(salt.utils.data.encode(_b('bar')), _b('bar'))
+
+    @skipIf(NO_MOCK, NO_MOCK_REASON)
+    def test_encode_fallback(self):
+        '''
+        Test fallback to utf-8
+        '''
+        with patch.object(builtins, '__salt_system_encoding__', 'ascii'):
+            self.assertEqual(salt.utils.data.encode('яйца'), _b('яйца'))
+        with patch.object(builtins, '__salt_system_encoding__', 'CP1252'):
+            self.assertEqual(salt.utils.data.encode('Ψ'), _b('Ψ'))
 
     def test_repack_dict(self):
         list_of_one_element_dicts = [{'dict_key_1': 'dict_val_1'},

--- a/tests/unit/utils/test_stringutils.py
+++ b/tests/unit/utils/test_stringutils.py
@@ -57,8 +57,10 @@ class StringutilsTestCase(TestCase):
             self.assertEqual(salt.utils.stringutils.to_str(bytearray(BYTES), 'utf-8'), UNICODE)
             # Test situation when a minion returns incorrect utf-8 string because of... million reasons
             ut2 = b'\x9c'
-            self.assertEqual(salt.utils.stringutils.to_str(ut2, 'utf-8'), u'\ufffd')
-            self.assertEqual(salt.utils.stringutils.to_str(bytearray(ut2), 'utf-8'), u'\ufffd')
+            self.assertRaises(UnicodeDecodeError, salt.utils.stringutils.to_str, ut2, 'utf-8')
+            self.assertEqual(salt.utils.stringutils.to_str(ut2, 'utf-8', 'replace'), u'\ufffd')
+            self.assertRaises(UnicodeDecodeError, salt.utils.stringutils.to_str, bytearray(ut2), 'utf-8')
+            self.assertEqual(salt.utils.stringutils.to_str(bytearray(ut2), 'utf-8', 'replace'), u'\ufffd')
         else:
             self.assertEqual(salt.utils.stringutils.to_str('plugh'), str('plugh'))  # future lint: disable=blacklisted-function
             self.assertEqual(salt.utils.stringutils.to_str('áéíóúý', 'utf-8'), 'áéíóúý'.encode('utf-8'))


### PR DESCRIPTION
This adds the ability to specify the encoding and error behavior. It
also adds the "errors" argument to the salt.utils.stringutils funcs for
converting between str, unicode, and bytes.

Tests have also been updated to properly test the recursive behavior of
salt.utils.data.decode/encode.