### PR TITLE
win_pkg: pkg.refresh_db report an issue if a sls pkg definition does not contain a dict instead of aborting

### DIFF
--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -868,8 +868,8 @@ def _repo_process_pkg_sls(filename, short_path_name, ret, successful_verbose):
     renderers = salt.loader.render(__opts__, __salt__)
 
     def _failed_compile(prefix_msg, error_msg):
-        log.error('{} \'{}\': {} '.format(prefix_msg, short_path_name, error_msg))
-        ret.setdefault('errors', {})[short_path_name] = ['{}, {} '.format(prefix_msg, error_msg)]
+        log.error('{0} \'{1}\': {2} '.format(prefix_msg, short_path_name, error_msg))
+        ret.setdefault('errors', {})[short_path_name] = ['{0}, {1} '.format(prefix_msg, error_msg)]
         return False
 
     try:

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -868,7 +868,7 @@ def _repo_process_pkg_sls(filename, short_path_name, ret, successful_verbose):
     renderers = salt.loader.render(__opts__, __salt__)
 
     def _failed_compile(prefix_msg, error_msg):
-        log.error('{} \`{}\`: {} '.format(prefix_msg, short_path_name, error_msg))
+        log.error('{} \'{}\': {} '.format(prefix_msg, short_path_name, error_msg))
         ret.setdefault('errors', {})[short_path_name] = ['{}, {} '.format(prefix_msg, error_msg)]
         return False
 

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -884,7 +884,7 @@ def _repo_process_pkg_sls(filename, short_path_name, ret, successful_verbose):
     except Exception as exc:
         return _failed_compile('Failed to read', exc)
 
-    if config and isinstance(config,dict):
+    if config and isinstance(config, dict):
         revmap = {}
         errors = []
         for pkgname, version_list in six.iteritems(config):


### PR DESCRIPTION
### What does this PR do?

### What issues does this PR fix or reference?
#45432 pkg definition contained a string instead of a dict, which caused the pkg.refresh_db to abort with an unhanded exception.

### Previous Behavior

Aborted with an unhanded exception.

### New Behavior

Reports the issue, and continue. i.e. "Compiled contents, not a dictionary/hash"
```
salt win10test pkg.refresh_db

win10test:
    ERROR: Error occurred while generating repo db. Additional info follows:

    failed:
        2
    failed_list:
        ----------
        bad-file.sls:
            - Compiled contents, not a dictionary/hash
        dvscheduler2.sls:
            - package 'dvschedulerX', version number 1 is not a string
            - package 'dvschedulerX', version number 2 is not a string
    success:
        240
    total:
        242
```

### Tests written?

No

### Commits signed with GPG?

No
