### PR TITLE
[DOC] Suggest to upgrade pygit2 and deps

### DIFF
--- a/doc/topics/tutorials/gitfs.rst
+++ b/doc/topics/tutorials/gitfs.rst
@@ -103,8 +103,8 @@ RedHat Pygit2 Issues
 
 The release of RedHat/CentOS 7.3 upgraded both ``python-cffi`` and
 ``http-parser``, both of which are dependencies for pygit2_/libgit2_. Both
-pygit2_ and libgit2_ (which are from the EPEL repository and not managed
-directly by RedHat) need to be rebuilt against these updated dependencies.
+``pygit2`` and ``libgit2`` packages (which are from the EPEL repository) should
+be upgraded to the most recent versions, at least to ``0.24.2``.
 
 The below errors will show up in the master log if an incompatible
 ``python-pygit2`` package is installed:
@@ -123,30 +123,8 @@ package is installed:
 
     2017-02-15 18:04:45,211 [salt.utils.gitfs ][ERROR   ][6211] Error occurred fetching gitfs remote 'https://foo.com/bar.git': No Content-Type header in response
 
-As of 15 February 2017, ``python-pygit2`` has been rebuilt and is in the stable
-EPEL repository. However, ``libgit2`` remains broken (a `bug report`_ has been
-filed to get it rebuilt).
-
-In the meantime, you can work around this by downgrading ``http-parser``. To do
-this, go to `this page`_ and download the appropriate ``http-parser`` RPM for
-the OS architecture you are using (x86_64, etc.). Then downgrade using the
-``rpm`` command. For example:
-
-.. code-block:: bash
-
-    [root@784e8a8c5028 /]# curl --silent -O https://kojipkgs.fedoraproject.org//packages/http-parser/2.0/5.20121128gitcd01361.el7/x86_64/http-parser-2.0-5.20121128gitcd01361.el7.x86_64.rpm
-    [root@784e8a8c5028 /]# rpm -Uvh --oldpackage http-parser-2.0-5.20121128gitcd01361.el7.x86_64.rpm
-    Preparing...                          ################################# [100%]
-    Updating / installing...
-       1:http-parser-2.0-5.20121128gitcd01################################# [ 50%]
-    Cleaning up / removing...
-       2:http-parser-2.7.1-3.el7          ################################# [100%]
-
-A restart of the salt-master daemon may be required to allow http(s)
-repositories to continue to be fetched.
-
-.. _`this page`: https://koji.fedoraproject.org/koji/buildinfo?buildID=703753
-.. _`bug report`: https://bugzilla.redhat.com/show_bug.cgi?id=1422583
+A restart of the ``salt-master`` daemon and gitfs cache directory clean up may
+be required to allow http(s) repositories to continue to be fetched.
 
 
 GitPython


### PR DESCRIPTION
### What does this PR do?
It convinces user to upgrade to latest `pygit2` version and its dependencies in order to resolve issues with `http[s]://` GitFS endpoints on RHEL 7. Mentioned issues in EPEL have been fixed, so the downgrading workaround no longer nesessary.
Confirmed with following versions:
```
Salt Version:
           Salt: 2016.11.8
 
Dependency Versions:
           cffi: 1.6.0
       cherrypy: unknown
       dateutil: 1.5
      docker-py: Not Installed
          gitdb: Not Installed
      gitpython: Not Installed
          ioflo: Not Installed
         Jinja2: 2.7.2
        libgit2: 0.24.6
        libnacl: Not Installed
       M2Crypto: 0.21.1
           Mako: Not Installed
   msgpack-pure: Not Installed
 msgpack-python: 0.4.8
   mysql-python: Not Installed
      pycparser: 2.14
       pycrypto: 2.6.1
   pycryptodome: Not Installed
         pygit2: 0.24.2
         Python: 2.7.5 (default, Nov 20 2015, 02:00:19)
   python-gnupg: 0.3.8
         PyYAML: 3.11
          PyZMQ: 15.3.0
           RAET: Not Installed
          smmap: Not Installed
        timelib: Not Installed
        Tornado: 4.2.1
            ZMQ: 4.1.4
 
System Versions:
           dist: centos 7.4.1708 Core
        machine: x86_64
```

### Commits signed with GPG?
Yes.