### PR TITLE
Deprecate RAET

### DIFF
--- a/doc/topics/releases/oxygen.rst
+++ b/doc/topics/releases/oxygen.rst
@@ -1681,3 +1681,11 @@ Sentry Log Handler
 Configuring sentry raven python client via ``project``, ``servers``, ``public_key
 and ``secret_key`` is deprecated and won't work with sentry clients > 3.0.
 Instead, the ``dsn`` config param must be used.
+
+RAET transport
+--------------
+
+We haven't been doing development on RAET for quite some time and decided that
+Oxygen is the time to announce the deprecation. RAET support will be removed in
+Neon. Please consider to move to ``zeromq`` or ``tcp`` transport instead of
+``raet``.

--- a/salt/daemons/flo/__init__.py
+++ b/salt/daemons/flo/__init__.py
@@ -19,7 +19,7 @@ opts['caller_floscript']
 '''
 
 # Import Python libs
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, print_function, unicode_literals
 import os
 
 # Import modules
@@ -35,21 +35,22 @@ __all__ = ['core', 'worker', 'maint', 'zero', 'dummy', 'jobber', 'reactor']
 
 # Import salt libs
 import salt.daemons.masterapi
+import salt.utils.stringutils
+from salt.ext import six
 
 # Import 3rd-party libs
 import ioflo.app.run  # pylint: disable=3rd-party-module-not-gated
-from salt.ext import six
 
 
 def explode_opts(opts):
     '''
     Explode the opts into a preloads list
     '''
-    preloads = [('.salt.opts', dict(value=opts))]
+    preloads = [(salt.utils.stringutils.to_str('.salt.opts'), dict(value=opts))]
     for key, val in six.iteritems(opts):
         ukey = key.replace('.', '_')
-        preloads.append(('.salt.etc.{0}'.format(ukey), dict(value=val)))
-    preloads.append(('.salt.etc.id', dict(value=opts['id'])))
+        preloads.append((salt.utils.stringutils.to_str('.salt.etc.{0}'.format(ukey)), dict(value=val)))
+    preloads.append((salt.utils.stringutils.to_str('.salt.etc.id'), dict(value=opts['id'])))
     return preloads
 
 
@@ -74,7 +75,7 @@ class IofloMaster(object):
         self.preloads = explode_opts(self.opts)
         self.access_keys = salt.daemons.masterapi.access_keys(self.opts)
         self.preloads.append(
-                ('.salt.access_keys', dict(value=self.access_keys)))
+                (salt.utils.stringutils.to_str('.salt.access_keys'), dict(value=self.access_keys)))
 
     def start(self, behaviors=None):
         '''

--- a/salt/daemons/flo/__init__.py
+++ b/salt/daemons/flo/__init__.py
@@ -19,7 +19,7 @@ opts['caller_floscript']
 '''
 
 # Import Python libs
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import, print_function
 import os
 
 # Import modules

--- a/salt/daemons/flo/__init__.py
+++ b/salt/daemons/flo/__init__.py
@@ -53,6 +53,14 @@ def explode_opts(opts):
     return preloads
 
 
+def warn_deprecated():
+    salt.utils.versions.warn_until(
+        'Neon',
+        'The \'raet\' transport has been deprecated and will be removed in '
+        'Salt {version}. Please use \'zeromq\' or \'tcp\' transport instead.'
+    )
+
+
 class IofloMaster(object):
     '''
     IofloMaster Class
@@ -61,6 +69,7 @@ class IofloMaster(object):
         '''
         Assign self.opts
         '''
+        warn_deprecated()
         self.opts = opts
         self.preloads = explode_opts(self.opts)
         self.access_keys = salt.daemons.masterapi.access_keys(self.opts)
@@ -109,6 +118,7 @@ class IofloMinion(object):
         '''
         Assign self.opts
         '''
+        warn_deprecated()
         self.opts = opts
 
     def tune_in(self, behaviors=None):

--- a/salt/daemons/flo/core.py
+++ b/salt/daemons/flo/core.py
@@ -6,7 +6,7 @@ The core behaviors used by minion and master
 # pylint: disable=3rd-party-module-not-gated
 
 # Import python libs
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import, print_function
 import os
 import time
 import random

--- a/salt/daemons/flo/core.py
+++ b/salt/daemons/flo/core.py
@@ -6,7 +6,7 @@ The core behaviors used by minion and master
 # pylint: disable=3rd-party-module-not-gated
 
 # Import python libs
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, print_function, unicode_literals
 import os
 import time
 import random
@@ -78,7 +78,7 @@ class SaltRaetCleanup(ioflo.base.deeding.Deed):
 
     '''
     Ioinits = {
-                'opts': '.salt.opts',
+                'opts': salt.utils.stringutils.to_str('.salt.opts'),
             }
 
     def action(self):
@@ -119,9 +119,10 @@ class SaltRaetRoadClustered(ioflo.base.deeding.Deed):
     go next if .salt.road.manor.cluster.clustered
 
     '''
-    Ioinits = odict(inode=".salt.road.manor.",
-                    clustered=odict(ipath='cluster.clustered', ival=False),
-                    opts='.salt.opts',)
+    Ioinits = odict(inode=salt.utils.stringutils.to_str('.salt.road.manor.'),
+                    clustered=odict(ipath=salt.utils.stringutils.to_str('cluster.clustered'),
+                                    ival=False),
+                    opts=salt.utils.stringutils.to_str('.salt.opts'),)
 
     def action(self, **kwa):
         '''
@@ -134,7 +135,7 @@ class SaltRaetProcessManagerSetup(ioflo.base.deeding.Deed):
     '''
     Set up the process manager object
     '''
-    Ioinits = {'proc_mgr': '.salt.usr.proc_mgr'}
+    Ioinits = {'proc_mgr': salt.utils.stringutils.to_str('.salt.usr.proc_mgr')}
 
     def action(self):
         '''
@@ -154,9 +155,9 @@ class SaltRaetRoadUsherMinionSetup(ioflo.base.deeding.Deed):
 
     '''
     Ioinits = odict(
-        inode=".salt.road.manor.",
-        ushers='ushers',
-        opts='.salt.opts')
+        inode=salt.utils.stringutils.to_str('.salt.road.manor.'),
+        ushers=salt.utils.stringutils.to_str('ushers'),
+        opts=salt.utils.stringutils.to_str('.salt.opts'))
 
     def action(self):
         '''
@@ -183,9 +184,9 @@ class SaltRaetRoadUsherMasterSetup(ioflo.base.deeding.Deed):
 
     '''
     Ioinits = odict(
-        inode=".salt.road.manor.",
-        ushers='ushers',
-        opts='.salt.opts')
+        inode=salt.utils.stringutils.to_str('.salt.road.manor.'),
+        ushers=salt.utils.stringutils.to_str('ushers'),
+        opts=salt.utils.stringutils.to_str('.salt.opts'))
 
     def action(self):
         '''
@@ -210,10 +211,10 @@ class SaltRaetRoadClusterLoadSetup(ioflo.base.deeding.Deed):
 
     '''
     Ioinits = odict(
-        inode='.salt.road.manor.',
-        masters={'ipath': 'cluster.masters', 'ival': odict()},
-        stack='stack',
-        opts='.salt.opts',)
+        inode=salt.utils.stringutils.to_str('.salt.road.manor.'),
+        masters={'ipath': salt.utils.stringutils.to_str('cluster.masters'), 'ival': odict()},
+        stack=salt.utils.stringutils.to_str('stack'),
+        opts=salt.utils.stringutils.to_str('.salt.opts'),)
 
     def action(self, **kwa):
         '''
@@ -234,14 +235,14 @@ class SaltRaetRoadStackSetup(ioflo.base.deeding.Deed):
 
     '''
     Ioinits = {
-            'inode': 'salt.road.manor.',
-            'stack': 'stack',
-            'opts': '.salt.opts',
-            'txmsgs': {'ipath': 'txmsgs',
+            'inode': salt.utils.stringutils.to_str('salt.road.manor.'),
+            'stack': salt.utils.stringutils.to_str('stack'),
+            'opts': salt.utils.stringutils.to_str('.salt.opts'),
+            'txmsgs': {'ipath': salt.utils.stringutils.to_str('txmsgs'),
                        'ival': deque()},
-            'rxmsgs': {'ipath': 'rxmsgs',
+            'rxmsgs': {'ipath': salt.utils.stringutils.to_str('rxmsgs'),
                        'ival': deque()},
-            'local': {'ipath': 'local',
+            'local': {'ipath': salt.utils.stringutils.to_str('local'),
                       'ival': {'main': False,
                                'mutable': False,
                                'uid': None,
@@ -336,8 +337,8 @@ class SaltRaetRoadStackCloser(ioflo.base.deeding.Deed):
 
     '''
     Ioinits = odict(
-        inode=".salt.road.manor.",
-        stack='stack', )
+        inode=salt.utils.stringutils.to_str('.salt.road.manor.'),
+        stack=salt.utils.stringutils.to_str('stack'), )
 
     def action(self, **kwa):
         '''
@@ -360,10 +361,10 @@ class SaltRaetRoadStackJoiner(ioflo.base.deeding.Deed):
 
     '''
     Ioinits = odict(
-                    inode=".salt.road.manor.",
-                    stack='stack',
-                    ushers='ushers',
-                    opts='.salt.opts')
+                    inode=salt.utils.stringutils.to_str('.salt.road.manor.'),
+                    stack=salt.utils.stringutils.to_str('stack'),
+                    ushers=salt.utils.stringutils.to_str('ushers'),
+                    opts=salt.utils.stringutils.to_str('.salt.opts'))
 
     def action(self, **kwa):
         '''
@@ -420,13 +421,14 @@ class SaltRaetRoadStackJoined(ioflo.base.deeding.Deed):
 
     '''
     Ioinits = odict(
-        inode=".salt.road.manor.",
-        stack='stack',
-        status=odict(ipath='status', ival=odict(joined=False,
-                                                allowed=False,
-                                                alived=False,
-                                                rejected=False,
-                                                idle=False, )))
+        inode=salt.utils.stringutils.to_str('.salt.road.manor.'),
+        stack=salt.utils.stringutils.to_str('stack'),
+        status=odict(ipath=salt.utils.stringutils.to_str('status'),
+                     ival=odict(joined=False,
+                                allowed=False,
+                                alived=False,
+                                rejected=False,
+                                idle=False, )))
 
     def action(self, **kwa):
         '''
@@ -451,13 +453,14 @@ class SaltRaetRoadStackRejected(ioflo.base.deeding.Deed):
 
     '''
     Ioinits = odict(
-        inode=".salt.road.manor.",
-        stack='stack',
-        status=odict(ipath='status', ival=odict(joined=False,
-                                                allowed=False,
-                                                alived=False,
-                                                rejected=False,
-                                                idle=False, )))
+        inode=salt.utils.stringutils.to_str('.salt.road.manor.'),
+        stack=salt.utils.stringutils.to_str('stack'),
+        status=odict(ipath=salt.utils.stringutils.to_str('status'),
+                     ival=odict(joined=False,
+                                allowed=False,
+                                alived=False,
+                                rejected=False,
+                                idle=False, )))
 
     def action(self, **kwa):
         '''
@@ -484,8 +487,8 @@ class SaltRaetRoadStackAllower(ioflo.base.deeding.Deed):
 
     '''
     Ioinits = odict(
-        inode=".salt.road.manor.",
-        stack='stack', )
+        inode=salt.utils.stringutils.to_str('.salt.road.manor.'),
+        stack=salt.utils.stringutils.to_str('stack'), )
 
     def action(self, **kwa):
         '''
@@ -509,13 +512,14 @@ class SaltRaetRoadStackAllowed(ioflo.base.deeding.Deed):
 
     '''
     Ioinits = odict(
-        inode=".salt.road.manor.",
-        stack='stack',
-        status=odict(ipath='status', ival=odict(joined=False,
-                                                allowed=False,
-                                                alived=False,
-                                                rejected=False,
-                                                idle=False, )))
+        inode=salt.utils.stringutils.to_str('.salt.road.manor.'),
+        stack=salt.utils.stringutils.to_str('stack'),
+        status=odict(ipath=salt.utils.stringutils.to_str('status'),
+                     ival=odict(joined=False,
+                                allowed=False,
+                                alived=False,
+                                rejected=False,
+                                idle=False, )))
 
     def action(self, **kwa):
         '''
@@ -538,19 +542,19 @@ class SaltRaetRoadStackManager(ioflo.base.deeding.Deed):
 
     '''
     Ioinits = odict(
-        inode=".salt.road.manor.",
-        stack='stack',
-        alloweds={'ipath': '.salt.var.presence.alloweds',
+        inode=salt.utils.stringutils.to_str('.salt.road.manor.'),
+        stack=salt.utils.stringutils.to_str('stack'),
+        alloweds={'ipath': salt.utils.stringutils.to_str('.salt.var.presence.alloweds'),
                   'ival': odict()},
-        aliveds={'ipath': '.salt.var.presence.aliveds',
+        aliveds={'ipath': salt.utils.stringutils.to_str('.salt.var.presence.aliveds'),
                  'ival': odict()},
-        reapeds={'ipath': '.salt.var.presence.reapeds',
+        reapeds={'ipath': salt.utils.stringutils.to_str('.salt.var.presence.reapeds'),
                          'ival': odict()},
-        availables={'ipath': '.salt.var.presence.availables',
+        availables={'ipath': salt.utils.stringutils.to_str('.salt.var.presence.availables'),
                     'ival': set()},
-        changeds={'ipath': '.salt.var.presence.changeds',
+        changeds={'ipath': salt.utils.stringutils.to_str('.salt.var.presence.changeds'),
                   'ival': odict(plus=set(), minus=set())},
-        event='.salt.event.events',)
+        event=salt.utils.stringutils.to_str('.salt.event.events'),)
 
     def _fire_events(self):
         stack = self.stack.value
@@ -616,8 +620,8 @@ class SaltRaetRoadStackPrinter(ioflo.base.deeding.Deed):
 
     '''
     Ioinits = odict(
-        inode=".salt.road.manor.",
-        rxmsgs=odict(ipath='rxmsgs', ival=deque()),)
+        inode=salt.utils.stringutils.to_str('.salt.road.manor.'),
+        rxmsgs=odict(ipath=salt.utils.stringutils.to_str('rxmsgs'), ival=deque()),)
 
     def action(self, **kwa):
         '''
@@ -637,14 +641,14 @@ class SaltLoadModules(ioflo.base.deeding.Deed):
     do salt load modules at enter
 
     '''
-    Ioinits = {'opts': '.salt.opts',
-               'grains': '.salt.grains',
-               'utils': '.salt.loader.utils',
-               'modules': '.salt.loader.modules',
-               'grain_time': '.salt.var.grain_time',
-               'module_refresh': '.salt.var.module_refresh',
-               'returners': '.salt.loader.returners',
-               'module_executors': '.salt.loader.executors'}
+    Ioinits = {'opts': salt.utils.stringutils.to_str('.salt.opts'),
+               'grains': salt.utils.stringutils.to_str('.salt.grains'),
+               'utils': salt.utils.stringutils.to_str('.salt.loader.utils'),
+               'modules': salt.utils.stringutils.to_str('.salt.loader.modules'),
+               'grain_time': salt.utils.stringutils.to_str('.salt.var.grain_time'),
+               'module_refresh': salt.utils.stringutils.to_str('.salt.var.module_refresh'),
+               'returners': salt.utils.stringutils.to_str('.salt.loader.returners'),
+               'module_executors': salt.utils.stringutils.to_str('.salt.loader.executors')}
 
     def _prepare(self):
         self._load_modules()
@@ -703,13 +707,14 @@ class SaltLoadPillar(ioflo.base.deeding.Deed):
 
     do salt load pillar
     '''
-    Ioinits = {'opts': '.salt.opts',
-               'pillar': '.salt.pillar',
-               'grains': '.salt.grains',
-               'modules': '.salt.loader.modules',
-               'pillar_refresh': '.salt.var.pillar_refresh',
-               'road_stack': '.salt.road.manor.stack',
-               'master_estate_name': '.salt.track.master_estate_name', }
+    Ioinits = {'opts': salt.utils.stringutils.to_str('.salt.opts'),
+               'pillar': salt.utils.stringutils.to_str('.salt.pillar'),
+               'grains': salt.utils.stringutils.to_str('.salt.grains'),
+               'modules': salt.utils.stringutils.to_str('.salt.loader.modules'),
+               'pillar_refresh': salt.utils.stringutils.to_str('.salt.var.pillar_refresh'),
+               'road_stack': salt.utils.stringutils.to_str('.salt.road.manor.stack'),
+               'master_estate_name': salt.utils.stringutils.to_str('.salt.track.master_estate_name')
+               }
 
     def action(self):
         '''
@@ -762,11 +767,11 @@ class SaltSchedule(ioflo.base.deeding.Deed):
     do salt schedule
 
     '''
-    Ioinits = {'opts': '.salt.opts',
-               'grains': '.salt.grains',
-               'utils': '.salt.loader.utils',
-               'modules': '.salt.loader.modules',
-               'returners': '.salt.loader.returners'}
+    Ioinits = {'opts': salt.utils.stringutils.to_str('.salt.opts'),
+               'grains': salt.utils.stringutils.to_str('.salt.grains'),
+               'utils': salt.utils.stringutils.to_str('.salt.loader.utils'),
+               'modules': salt.utils.stringutils.to_str('.salt.loader.modules'),
+               'returners': salt.utils.stringutils.to_str('.salt.loader.returners')}
 
     def _prepare(self):
         '''
@@ -796,21 +801,21 @@ class SaltRaetManorLaneSetup(ioflo.base.deeding.Deed):
     do salt raet manor lane setup at enter
 
     '''
-    Ioinits = {'opts': '.salt.opts',
-               'event_yards': '.salt.event.yards',
-               'local_cmd': '.salt.var.local_cmd',
-               'remote_cmd': '.salt.var.remote_cmd',
-               'publish': '.salt.var.publish',
-               'fun': '.salt.var.fun',
-               'worker_verify': '.salt.var.worker_verify',
-               'event': '.salt.event.events',
-               'event_req': '.salt.event.event_req',
-               'presence_req': '.salt.presence.event_req',
-               'stats_req': '.salt.stats.event_req',
-               'workers': '.salt.track.workers',
-               'inode': '.salt.lane.manor.',
-               'stack': 'stack',
-               'local': {'ipath': 'local',
+    Ioinits = {'opts': salt.utils.stringutils.to_str('.salt.opts'),
+               'event_yards': salt.utils.stringutils.to_str('.salt.event.yards'),
+               'local_cmd': salt.utils.stringutils.to_str('.salt.var.local_cmd'),
+               'remote_cmd': salt.utils.stringutils.to_str('.salt.var.remote_cmd'),
+               'publish': salt.utils.stringutils.to_str('.salt.var.publish'),
+               'fun': salt.utils.stringutils.to_str('.salt.var.fun'),
+               'worker_verify': salt.utils.stringutils.to_str('.salt.var.worker_verify'),
+               'event': salt.utils.stringutils.to_str('.salt.event.events'),
+               'event_req': salt.utils.stringutils.to_str('.salt.event.event_req'),
+               'presence_req': salt.utils.stringutils.to_str('.salt.presence.event_req'),
+               'stats_req': salt.utils.stringutils.to_str('.salt.stats.event_req'),
+               'workers': salt.utils.stringutils.to_str('.salt.track.workers'),
+               'inode': salt.utils.stringutils.to_str('.salt.lane.manor.'),
+               'stack': salt.utils.stringutils.to_str('stack'),
+               'local': {'ipath': salt.utils.stringutils.to_str('local'),
                           'ival': {'lanename': 'master',
                                    'bufcnt': 100}},
             }
@@ -882,7 +887,7 @@ class SaltRaetLaneStackCloser(ioflo.base.deeding.Deed):  # pylint: disable=W0232
 
     '''
     Ioinits = odict(
-        inode=".salt.lane.manor",
+        inode='.salt.lane.manor',
         stack='stack',)
 
     def action(self, **kwa):
@@ -902,7 +907,7 @@ class SaltRaetRoadStackService(ioflo.base.deeding.Deed):
 
     '''
     Ioinits = {
-               'road_stack': '.salt.road.manor.stack',
+               'road_stack': salt.utils.stringutils.to_str('.salt.road.manor.stack'),
                }
 
     def action(self):
@@ -921,7 +926,7 @@ class SaltRaetRoadStackServiceRx(ioflo.base.deeding.Deed):
 
     '''
     Ioinits = {
-               'road_stack': '.salt.road.manor.stack',
+               'road_stack': salt.utils.stringutils.to_str('.salt.road.manor.stack'),
                }
 
     def action(self):
@@ -942,7 +947,7 @@ class SaltRaetRoadStackServiceTx(ioflo.base.deeding.Deed):
     # Yes, this class is identical to RX, this is because we still need to
     # separate out rx and tx in raet itself
     Ioinits = {
-               'road_stack': '.salt.road.manor.stack',
+               'road_stack': salt.utils.stringutils.to_str('.salt.road.manor.stack'),
                }
 
     def action(self):
@@ -961,7 +966,7 @@ class SaltRaetLaneStackServiceRx(ioflo.base.deeding.Deed):
 
     '''
     Ioinits = {
-               'lane_stack': '.salt.lane.manor.stack',
+               'lane_stack': salt.utils.stringutils.to_str('.salt.lane.manor.stack'),
                }
 
     def action(self):
@@ -982,7 +987,7 @@ class SaltRaetLaneStackServiceTx(ioflo.base.deeding.Deed):
     # Yes, this class is identical to RX, this is because we still need to
     # separate out rx and tx in raet itself
     Ioinits = {
-               'lane_stack': '.salt.lane.manor.stack',
+               'lane_stack': salt.utils.stringutils.to_str('.salt.lane.manor.stack'),
                }
 
     def action(self):
@@ -999,22 +1004,23 @@ class SaltRaetRouter(ioflo.base.deeding.Deed):
     This is a base class
 
     '''
-    Ioinits = {'opts': '.salt.opts',
-               'local_cmd': '.salt.var.local_cmd',
-               'remote_cmd': '.salt.var.remote_cmd',
-               'publish': '.salt.var.publish',
-               'fun': '.salt.var.fun',
-               'event': '.salt.event.events',
-               'event_req': '.salt.event.event_req',  # deque
-               'presence_req': '.salt.presence.event_req',  # deque
-               'stats_req': '.salt.stats.event_req',  # deque
-               'availables': '.salt.var.presence.availables',  # set()
-               'workers': '.salt.track.workers',
-               'worker_verify': '.salt.var.worker_verify',
-               'lane_stack': '.salt.lane.manor.stack',
-               'road_stack': '.salt.road.manor.stack',
-               'master_estate_name': '.salt.track.master_estate_name',
-               'laters': {'ipath': '.salt.lane.manor.laters',  # requeuing when not yet routable
+    Ioinits = {'opts': salt.utils.stringutils.to_str('.salt.opts'),
+               'local_cmd': salt.utils.stringutils.to_str('.salt.var.local_cmd'),
+               'remote_cmd': salt.utils.stringutils.to_str('.salt.var.remote_cmd'),
+               'publish': salt.utils.stringutils.to_str('.salt.var.publish'),
+               'fun': salt.utils.stringutils.to_str('.salt.var.fun'),
+               'event': salt.utils.stringutils.to_str('.salt.event.events'),
+               'event_req': salt.utils.stringutils.to_str('.salt.event.event_req'),  # deque
+               'presence_req': salt.utils.stringutils.to_str('.salt.presence.event_req'),  # deque
+               'stats_req': salt.utils.stringutils.to_str('.salt.stats.event_req'),  # deque
+               'availables': salt.utils.stringutils.to_str('.salt.var.presence.availables'),  # set()
+               'workers': salt.utils.stringutils.to_str('.salt.track.workers'),
+               'worker_verify': salt.utils.stringutils.to_str('.salt.var.worker_verify'),
+               'lane_stack': salt.utils.stringutils.to_str('.salt.lane.manor.stack'),
+               'road_stack': salt.utils.stringutils.to_str('.salt.road.manor.stack'),
+               'master_estate_name': salt.utils.stringutils.to_str('.salt.track.master_estate_name'),
+               # requeuing when not yet routable
+               'laters': {'ipath': salt.utils.stringutils.to_str('.salt.lane.manor.laters'),
                           'ival': deque()}}
 
     def _process_road_rxmsg(self, msg, sender):
@@ -1398,15 +1404,15 @@ class SaltRaetEventer(ioflo.base.deeding.Deed):
     do salt raet eventer
 
     '''
-    Ioinits = {'opts': '.salt.opts',
-               'event_yards': '.salt.event.yards',
-               'event': '.salt.event.events',
-               'event_req': '.salt.event.event_req',
-               'module_refresh': '.salt.var.module_refresh',
-               'pillar_refresh': '.salt.var.pillar_refresh',
-               'lane_stack': '.salt.lane.manor.stack',
-               'road_stack': '.salt.road.manor.stack',
-               'availables': '.salt.var.presence.availables', }
+    Ioinits = {'opts': salt.utils.stringutils.to_str('.salt.opts'),
+               'event_yards': salt.utils.stringutils.to_str('.salt.event.yards'),
+               'event': salt.utils.stringutils.to_str('.salt.event.events'),
+               'event_req': salt.utils.stringutils.to_str('.salt.event.event_req'),
+               'module_refresh': salt.utils.stringutils.to_str('.salt.var.module_refresh'),
+               'pillar_refresh': salt.utils.stringutils.to_str('.salt.var.pillar_refresh'),
+               'lane_stack': salt.utils.stringutils.to_str('.salt.lane.manor.stack'),
+               'road_stack': salt.utils.stringutils.to_str('.salt.road.manor.stack'),
+               'availables': salt.utils.stringutils.to_str('.salt.var.presence.availables'), }
 
     def _register_event_yard(self, msg):
         '''
@@ -1487,13 +1493,13 @@ class SaltRaetPresenter(ioflo.base.deeding.Deed):
     do salt raet presenter
 
     '''
-    Ioinits = {'opts': '.salt.opts',
-               'presence_req': '.salt.presence.event_req',
-               'lane_stack': '.salt.lane.manor.stack',
-               'alloweds': '.salt.var.presence.alloweds',  # odict
-               'aliveds': '.salt.var.presence.aliveds',  # odict
-               'reapeds': '.salt.var.presence.reapeds',  # odict
-               'availables': '.salt.var.presence.availables',  # set
+    Ioinits = {'opts': salt.utils.stringutils.to_str('.salt.opts'),
+               'presence_req': salt.utils.stringutils.to_str('.salt.presence.event_req'),
+               'lane_stack': salt.utils.stringutils.to_str('.salt.lane.manor.stack'),
+               'alloweds': salt.utils.stringutils.to_str('.salt.var.presence.alloweds'),  # odict
+               'aliveds': salt.utils.stringutils.to_str('.salt.var.presence.aliveds'),  # odict
+               'reapeds': salt.utils.stringutils.to_str('.salt.var.presence.reapeds'),  # odict
+               'availables': salt.utils.stringutils.to_str('.salt.var.presence.availables'),  # set
               }
 
     def _send_presence(self, msg):
@@ -1562,10 +1568,10 @@ class SaltRaetStatsEventer(ioflo.base.deeding.Deed):
     do salt raet state eventer
 
     '''
-    Ioinits = {'opts': '.salt.opts',
-               'stats_req': '.salt.stats.event_req',
-               'lane_stack': '.salt.lane.manor.stack',
-               'road_stack': '.salt.road.manor.stack',
+    Ioinits = {'opts': salt.utils.stringutils.to_str('.salt.opts'),
+               'stats_req': salt.utils.stringutils.to_str('.salt.stats.event_req'),
+               'lane_stack': salt.utils.stringutils.to_str('.salt.lane.manor.stack'),
+               'road_stack': salt.utils.stringutils.to_str('.salt.road.manor.stack'),
     }
 
     def _send_stats(self, msg):
@@ -1648,10 +1654,10 @@ class SaltRaetPublisher(ioflo.base.deeding.Deed):
     do salt raet publisher
 
     '''
-    Ioinits = {'opts': '.salt.opts',
-               'publish': '.salt.var.publish',
-               'stack': '.salt.road.manor.stack',
-               'availables': '.salt.var.presence.availables',
+    Ioinits = {'opts': salt.utils.stringutils.to_str('.salt.opts'),
+               'publish': salt.utils.stringutils.to_str('.salt.var.publish'),
+               'stack': salt.utils.stringutils.to_str('.salt.road.manor.stack'),
+               'availables': salt.utils.stringutils.to_str('.salt.var.presence.availables'),
             }
 
     def _publish(self, pub_msg):
@@ -1689,8 +1695,8 @@ class SaltRaetSetupEngines(ioflo.base.deeding.Deed):
     '''
     Start the engines!
     '''
-    Ioinits = {'opts': '.salt.opts',
-               'proc_mgr': '.salt.usr.proc_mgr'}
+    Ioinits = {'opts': salt.utils.stringutils.to_str('.salt.opts'),
+               'proc_mgr': salt.utils.stringutils.to_str('.salt.usr.proc_mgr')}
 
     def action(self):
         '''
@@ -1703,9 +1709,9 @@ class SaltRaetSetupBeacon(ioflo.base.deeding.Deed):
     '''
     Create the Beacon subsystem
     '''
-    Ioinits = {'opts': '.salt.opts',
-               'beacon': '.salt.beacon',
-               'modules': '.salt.loader.modules'}
+    Ioinits = {'opts': salt.utils.stringutils.to_str('.salt.opts'),
+               'beacon': salt.utils.stringutils.to_str('.salt.beacon'),
+               'modules': salt.utils.stringutils.to_str('.salt.loader.modules')}
 
     def action(self):
         '''
@@ -1720,11 +1726,11 @@ class SaltRaetBeacon(ioflo.base.deeding.Deed):
     '''
     Run the beacons
     '''
-    Ioinits = {'opts': '.salt.opts',
-               'modules': '.salt.loader.modules',
-               'master_events': '.salt.var.master_events',
-               'event': '.salt.event.events',
-               'beacon': '.salt.beacon'}
+    Ioinits = {'opts': salt.utils.stringutils.to_str('.salt.opts'),
+               'modules': salt.utils.stringutils.to_str('.salt.loader.modules'),
+               'master_events': salt.utils.stringutils.to_str('.salt.var.master_events'),
+               'event': salt.utils.stringutils.to_str('.salt.event.events'),
+               'beacon': salt.utils.stringutils.to_str('.salt.beacon')}
 
     def action(self):
         '''
@@ -1747,9 +1753,9 @@ class SaltRaetMasterEvents(ioflo.base.deeding.Deed):
     Take the events off the master event que and send them to the master to
     be fired
     '''
-    Ioinits = {'opts': '.salt.opts',
-               'road_stack': '.salt.road.manor.stack',
-               'master_events': '.salt.var.master_events'}
+    Ioinits = {'opts': salt.utils.stringutils.to_str('.salt.opts'),
+               'road_stack': salt.utils.stringutils.to_str('.salt.road.manor.stack'),
+               'master_events': salt.utils.stringutils.to_str('.salt.var.master_events')}
 
     def _prepare(self):
         self.master_events.value = deque()
@@ -1775,9 +1781,9 @@ class SaltRaetSetupMatcher(ioflo.base.deeding.Deed):
     '''
     Make the matcher object
     '''
-    Ioinits = {'opts': '.salt.opts',
-               'modules': '.salt.loader.modules',
-               'matcher': '.salt.matcher'}
+    Ioinits = {'opts': salt.utils.stringutils.to_str('.salt.opts'),
+               'modules': salt.utils.stringutils.to_str('.salt.loader.modules'),
+               'matcher': salt.utils.stringutils.to_str('.salt.matcher')}
 
     def action(self):
         self.matcher.value = salt.minion.Matcher(

--- a/salt/daemons/flo/dummy.py
+++ b/salt/daemons/flo/dummy.py
@@ -15,7 +15,7 @@ without the need for a swarm of real minions.
 # pylint: disable=3rd-party-module-not-gated
 
 # Import python libs
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import, print_function
 import logging
 
 # Import salt libs

--- a/salt/daemons/flo/dummy.py
+++ b/salt/daemons/flo/dummy.py
@@ -15,11 +15,12 @@ without the need for a swarm of real minions.
 # pylint: disable=3rd-party-module-not-gated
 
 # Import python libs
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, print_function, unicode_literals
 import logging
 
 # Import salt libs
 import ioflo.base.deeding
+import salt.utils.stringutils
 
 log = logging.getLogger(__name__)
 
@@ -30,10 +31,10 @@ class SaltDummyPublisher(ioflo.base.deeding.Deed):
     a translation system to have them mocked up and sent back into a router
     '''
     Ioinits = {
-            'opts': '.salt.opts',
-            'publish': '.salt.var.publish',
-            'lane_stack': '.salt.lane.manor.stack',
-            'workers': '.salt.track.workers',
+            'opts': salt.utils.stringutils.to_str('.salt.opts'),
+            'publish': salt.utils.stringutils.to_str('.salt.var.publish'),
+            'lane_stack': salt.utils.stringutils.to_str('.salt.lane.manor.stack'),
+            'workers': salt.utils.stringutils.to_str('.salt.track.workers'),
             }
 
     def action(self):

--- a/salt/daemons/flo/jobber.py
+++ b/salt/daemons/flo/jobber.py
@@ -6,7 +6,7 @@ Jobber Behaviors
 # pylint: disable=3rd-party-module-not-gated
 
 # Import python libs
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import, print_function
 import os
 import sys
 import types
@@ -307,13 +307,14 @@ class SaltRaetNixJobber(ioflo.base.deeding.Deed):
                         'non-empty list expected'.format(executors)
                     )
                 if self.opts.get('sudo_user', '') and executors[-1] != 'sudo':
-                    executors[-1] = 'sudo.get'  # replace
+                    executors[-1] = 'sudo'  # replace
                 log.trace("Executors list %s", executors)
 
                 for name in executors:
-                    if name not in self.module_executors.value:
+                    fname = '{0}.execute'.format(name)
+                    if fname not in self.module_executors.value:
                         raise SaltInvocationError("Executor '{0}' is not available".format(name))
-                    return_data = self.module_executors.value[name].execute(self.opts, data, func, args, kwargs)
+                    return_data = self.module_executors.value[fname](self.opts, data, func, args, kwargs)
                     if return_data is not None:
                         break
 

--- a/salt/daemons/flo/jobber.py
+++ b/salt/daemons/flo/jobber.py
@@ -6,7 +6,7 @@ Jobber Behaviors
 # pylint: disable=3rd-party-module-not-gated
 
 # Import python libs
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, print_function, unicode_literals
 import os
 import sys
 import types
@@ -45,13 +45,13 @@ log = logging.getLogger(__name__)
 
 
 @ioflo.base.deeding.deedify(
-        'SaltRaetShellJobberCheck',
-        ioinits={'opts': '.salt.opts',
-                 'grains': '.salt.grains',
-                 'fun': '.salt.var.fun',
-                 'matcher': '.salt.matcher',
-                 'shells': '.salt.var.shells',
-                 'stack': '.salt.road.manor.stack'})
+        salt.utils.stringutils.to_str('SaltRaetShellJobberCheck'),
+        ioinits={'opts': salt.utils.stringutils.to_str('.salt.opts'),
+                 'grains': salt.utils.stringutils.to_str('.salt.grains'),
+                 'fun': salt.utils.stringutils.to_str('.salt.var.fun'),
+                 'matcher': salt.utils.stringutils.to_str('.salt.matcher'),
+                 'shells': salt.utils.stringutils.to_str('.salt.var.shells'),
+                 'stack': salt.utils.stringutils.to_str('.salt.road.manor.stack')})
 def jobber_check(self):
     '''
     Iterate over the shell jobbers and return the ones that have finished
@@ -78,13 +78,14 @@ def jobber_check(self):
 
 
 @ioflo.base.deeding.deedify(
-        'SaltRaetShellJobber',
-        ioinits={'opts': '.salt.opts',
-                 'grains': '.salt.grains',
-                 'fun': '.salt.var.fun',
-                 'matcher': '.salt.matcher',
-                 'modules': '.salt.loader.modules',
-                 'shells': {'ipath': '.salt.var.shells', 'ival': {}}})
+        salt.utils.stringutils.to_str('SaltRaetShellJobber'),
+        ioinits={'opts': salt.utils.stringutils.to_str('.salt.opts'),
+                 'grains': salt.utils.stringutils.to_str('.salt.grains'),
+                 'fun': salt.utils.stringutils.to_str('.salt.var.fun'),
+                 'matcher': salt.utils.stringutils.to_str('.salt.matcher'),
+                 'modules': salt.utils.stringutils.to_str('.salt.loader.modules'),
+                 'shells': {'ipath': salt.utils.stringutils.to_str('.salt.var.shells'),
+                            'ival': {}}})
 def shell_jobber(self):
     '''
     Shell jobber start!
@@ -141,15 +142,15 @@ class SaltRaetNixJobber(ioflo.base.deeding.Deed):
     do salt raet nix jobber
 
     '''
-    Ioinits = {'opts_store': '.salt.opts',
-               'grains': '.salt.grains',
-               'modules': '.salt.loader.modules',
-               'returners': '.salt.loader.returners',
-               'module_executors': '.salt.loader.executors',
-               'fun': '.salt.var.fun',
-               'matcher': '.salt.matcher',
-               'executors': '.salt.track.executors',
-               'road_stack': '.salt.road.manor.stack', }
+    Ioinits = {'opts_store': salt.utils.stringutils.to_str('.salt.opts'),
+               'grains': salt.utils.stringutils.to_str('.salt.grains'),
+               'modules': salt.utils.stringutils.to_str('.salt.loader.modules'),
+               'returners': salt.utils.stringutils.to_str('.salt.loader.returners'),
+               'module_executors': salt.utils.stringutils.to_str('.salt.loader.executors'),
+               'fun': salt.utils.stringutils.to_str('.salt.var.fun'),
+               'matcher': salt.utils.stringutils.to_str('.salt.matcher'),
+               'executors': salt.utils.stringutils.to_str('.salt.track.executors'),
+               'road_stack': salt.utils.stringutils.to_str('.salt.road.manor.stack'), }
 
     def _prepare(self):
         '''

--- a/salt/daemons/flo/maint.py
+++ b/salt/daemons/flo/maint.py
@@ -3,7 +3,7 @@
 Define the behaviors used in the maintenance process
 '''
 # pylint: disable=3rd-party-module-not-gated
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import, print_function
 # Import python libs
 import multiprocessing
 import os

--- a/salt/daemons/flo/maint.py
+++ b/salt/daemons/flo/maint.py
@@ -3,7 +3,7 @@
 Define the behaviors used in the maintenance process
 '''
 # pylint: disable=3rd-party-module-not-gated
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, print_function, unicode_literals
 # Import python libs
 import multiprocessing
 import os
@@ -12,15 +12,17 @@ import os
 import ioflo.base.deeding
 
 # Import salt libs
+import salt.daemons.masterapi
 import salt.fileserver
 import salt.loader
 import salt.utils.minions
-import salt.daemons.masterapi
+import salt.utils.stringutils
 
 
 @ioflo.base.deeding.deedify(
-        'SaltRaetMaintFork',
-        ioinits={'opts': '.salt.opts', 'proc_mgr': '.salt.usr.proc_mgr'})
+        salt.utils.stringutils.to_str('SaltRaetMaintFork'),
+        ioinits={'opts': salt.utils.stringutils.to_str('.salt.opts'),
+                 'proc_mgr': salt.utils.stringutils.to_str('.salt.usr.proc_mgr')})
 def maint_fork(self):
     '''
     For off the maintinence process from the master router process
@@ -44,7 +46,7 @@ class Maintenance(multiprocessing.Process):
         Spin up a worker, do this in s multiprocess
         '''
         behaviors = ['salt.daemons.flo']
-        preloads = [('.salt.opts', dict(value=self.opts))]
+        preloads = [(salt.utils.stringutils.to_str('.salt.opts'), dict(value=self.opts))]
 
         console_logdir = self.opts.get('ioflo_console_logdir', '')
         if console_logdir:
@@ -78,11 +80,11 @@ class SaltRaetMaintSetup(ioflo.base.deeding.Deed):
     do salt raet maint setup at enter
 
     '''
-    Ioinits = {'opts': '.salt.opts',
-               'fileserver': '.salt.loader.fileserver',
-               'runners': '.salt.loader.runners',
-               'pillargitfs': '.salt.loader.pillargitfs',
-               'ckminions': '.salt.loader.ckminions'}
+    Ioinits = {'opts': salt.utils.stringutils.to_str('.salt.opts'),
+               'fileserver': salt.utils.stringutils.to_str('.salt.loader.fileserver'),
+               'runners': salt.utils.stringutils.to_str('.salt.loader.runners'),
+               'pillargitfs': salt.utils.stringutils.to_str('.salt.loader.pillargitfs'),
+               'ckminions': salt.utils.stringutils.to_str('.salt.loader.ckminions')}
 
     def action(self):
         '''
@@ -103,7 +105,7 @@ class SaltRaetMaintFileserverClean(ioflo.base.deeding.Deed):
     do salt raet maint fileserver clean at enter
 
     '''
-    Ioinits = {'opts': '.salt.opts'}
+    Ioinits = {'opts': salt.utils.stringutils.to_str('.salt.opts')}
 
     def action(self):
         '''
@@ -120,7 +122,7 @@ class SaltRaetMaintOldJobsClear(ioflo.base.deeding.Deed):
     do salt raet maint old jobs clear
 
     '''
-    Ioinits = {'opts': '.salt.opts'}
+    Ioinits = {'opts': salt.utils.stringutils.to_str('.salt.opts')}
 
     def action(self):
         '''
@@ -137,9 +139,9 @@ class SaltRaetMaintBackendsUpdate(ioflo.base.deeding.Deed):
     do salt raet maint backends update
 
     '''
-    Ioinits = {'opts': '.salt.opts',
-               'fileserver': '.salt.loader.fileserver',
-               'pillargitfs': '.salt.loader.pillargitfs'}
+    Ioinits = {'opts': salt.utils.stringutils.to_str('.salt.opts'),
+               'fileserver': salt.utils.stringutils.to_str('.salt.loader.fileserver'),
+               'pillargitfs': salt.utils.stringutils.to_str('.salt.loader.pillargitfs')}
 
     def action(self):
         '''

--- a/salt/daemons/flo/reactor.py
+++ b/salt/daemons/flo/reactor.py
@@ -3,19 +3,20 @@
 Start the reactor!
 '''
 # pylint: disable=3rd-party-module-not-gated
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, print_function, unicode_literals
 # Import salt libs
 import salt.utils.reactor
 import salt.utils.event
+import salt.utils.stringutils
 # Import ioflo libs
 import ioflo.base.deeding
 
 
 @ioflo.base.deeding.deedify(
-        'SaltRaetReactorFork',
+        salt.utils.stringutils.to_str('SaltRaetReactorFork'),
         ioinits={
-            'opts': '.salt.opts',
-            'proc_mgr': '.salt.usr.proc_mgr'})
+            'opts': salt.utils.stringutils.to_str('.salt.opts'),
+            'proc_mgr': salt.utils.stringutils.to_str('.salt.usr.proc_mgr')})
 def reactor_fork(self):
     '''
     Add a reactor object to the process manager
@@ -26,10 +27,10 @@ def reactor_fork(self):
 
 
 @ioflo.base.deeding.deedify(
-        'SaltRaetEventReturnFork',
+        salt.utils.stringutils.to_str('SaltRaetEventReturnFork'),
         ioinits={
-            'opts': '.salt.opts',
-            'proc_mgr': '.salt.usr.proc_mgr'})
+            'opts': salt.utils.stringutils.to_str('.salt.opts'),
+            'proc_mgr': salt.utils.stringutils.to_str('.salt.usr.proc_mgr')})
 def event_return_fork(self):
     '''
     Add a reactor object to the process manager

--- a/salt/daemons/flo/reactor.py
+++ b/salt/daemons/flo/reactor.py
@@ -3,7 +3,7 @@
 Start the reactor!
 '''
 # pylint: disable=3rd-party-module-not-gated
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import, print_function
 # Import salt libs
 import salt.utils.reactor
 import salt.utils.event

--- a/salt/daemons/flo/worker.py
+++ b/salt/daemons/flo/worker.py
@@ -5,7 +5,7 @@ The core behaviors used by minion and master
 # pylint: disable=W0232
 # pylint: disable=3rd-party-module-not-gated
 
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, print_function, unicode_literals
 
 # Import python libs
 import time
@@ -22,6 +22,7 @@ from raet.lane.stacking import LaneStack
 from raet.lane.yarding import RemoteYard
 
 import salt.utils.kinds as kinds
+import salt.utils.stringutils
 
 # Import ioflo libs
 import ioflo.base.deeding
@@ -33,14 +34,14 @@ INHIBIT_RETURN = []  # ['_return']  # cmd for which we should not send return
 
 
 @ioflo.base.deeding.deedify(
-    'SaltRaetWorkerFork',
+    salt.utils.stringutils.to_str('SaltRaetWorkerFork'),
     ioinits={
-        'opts': '.salt.opts',
-        'proc_mgr': '.salt.usr.proc_mgr',
-        'worker_verify': '.salt.var.worker_verify',
-        'access_keys': '.salt.access_keys',
-        'mkey': '.salt.var.zmq.master_key',
-        'aes': '.salt.var.zmq.aes'})
+        'opts': salt.utils.stringutils.to_str('.salt.opts'),
+        'proc_mgr': salt.utils.stringutils.to_str('.salt.usr.proc_mgr'),
+        'worker_verify': salt.utils.stringutils.to_str('.salt.var.worker_verify'),
+        'access_keys': salt.utils.stringutils.to_str('.salt.access_keys'),
+        'mkey': salt.utils.stringutils.to_str('.salt.var.zmq.master_key'),
+        'aes': salt.utils.stringutils.to_str('.salt.var.zmq.aes')})
 def worker_fork(self):
     '''
     Fork off the worker procs
@@ -83,13 +84,16 @@ class Worker(multiprocessing.Process):
         '''
         self.opts['__worker'] = True
         behaviors = ['salt.daemons.flo']
-        preloads = [('.salt.opts', dict(value=self.opts)),
-                    ('.salt.var.worker_verify', dict(value=self.worker_verify))]
-        preloads.append(('.salt.var.fork.worker.windex', dict(value=self.windex)))
-        preloads.append(('.salt.var.zmq.master_key', dict(value=self.mkey)))
-        preloads.append(('.salt.var.zmq.aes', dict(value=self.aes)))
-        preloads.append(
-                ('.salt.access_keys', dict(value=self.access_keys)))
+        preloads = [(salt.utils.stringutils.to_str('.salt.opts'), dict(value=self.opts)),
+                    (salt.utils.stringutils.to_str('.salt.var.worker_verify'),
+                     dict(value=self.worker_verify))]
+        preloads.append((salt.utils.stringutils.to_str('.salt.var.fork.worker.windex'),
+                         dict(value=self.windex)))
+        preloads.append((salt.utils.stringutils.to_str('.salt.var.zmq.master_key'),
+                         dict(value=self.mkey)))
+        preloads.append((salt.utils.stringutils.to_str('.salt.var.zmq.aes'), dict(value=self.aes)))
+        preloads.append((salt.utils.stringutils.to_str('.salt.access_keys'),
+                         dict(value=self.access_keys)))
         preloads.extend(salt.daemons.flo.explode_opts(self.opts))
 
         console_logdir = self.opts.get('ioflo_console_logdir', '')
@@ -124,14 +128,14 @@ class SaltRaetWorkerSetup(ioflo.base.deeding.Deed):
 
     '''
     Ioinits = {
-            'opts': '.salt.opts',
-            'windex': '.salt.var.fork.worker.windex',
-            'access_keys': '.salt.access_keys',
-            'remote_loader': '.salt.loader.remote',
-            'local_loader': '.salt.loader.local',
-            'inode': '.salt.lane.manor.',
-            'stack': 'stack',
-            'local': {'ipath': 'local',
+            'opts': salt.utils.stringutils.to_str('.salt.opts'),
+            'windex': salt.utils.stringutils.to_str('.salt.var.fork.worker.windex'),
+            'access_keys': salt.utils.stringutils.to_str('.salt.access_keys'),
+            'remote_loader': salt.utils.stringutils.to_str('.salt.loader.remote'),
+            'local_loader': salt.utils.stringutils.to_str('.salt.loader.local'),
+            'inode': salt.utils.stringutils.to_str('.salt.lane.manor.'),
+            'stack': salt.utils.stringutils.to_str('stack'),
+            'local': {'ipath': salt.utils.stringutils.to_str('local'),
                        'ival': {'lanename': 'master'}}
             }
 
@@ -190,12 +194,12 @@ class SaltRaetWorkerRouter(ioflo.base.deeding.Deed):
 
     '''
     Ioinits = {
-            'lane_stack': '.salt.lane.manor.stack',
-            'road_stack': '.salt.road.manor.stack',
-            'opts': '.salt.opts',
-            'worker_verify': '.salt.var.worker_verify',
-            'remote_loader': '.salt.loader.remote',
-            'local_loader': '.salt.loader.local',
+            'lane_stack': salt.utils.stringutils.to_str('.salt.lane.manor.stack'),
+            'road_stack': salt.utils.stringutils.to_str('.salt.road.manor.stack'),
+            'opts': salt.utils.stringutils.to_str('.salt.opts'),
+            'worker_verify': salt.utils.stringutils.to_str('.salt.var.worker_verify'),
+            'remote_loader': salt.utils.stringutils.to_str('.salt.loader.remote'),
+            'local_loader': salt.utils.stringutils.to_str('.salt.loader.local'),
             }
 
     def action(self):

--- a/salt/daemons/flo/worker.py
+++ b/salt/daemons/flo/worker.py
@@ -5,7 +5,7 @@ The core behaviors used by minion and master
 # pylint: disable=W0232
 # pylint: disable=3rd-party-module-not-gated
 
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import, print_function
 
 # Import python libs
 import time

--- a/salt/daemons/flo/zero.py
+++ b/salt/daemons/flo/zero.py
@@ -6,7 +6,7 @@ IoFlo behaviors for running a ZeroMQ based master
 # pylint: disable=3rd-party-module-not-gated
 
 # Import python libs
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import, print_function
 import os
 import logging
 import hashlib

--- a/salt/daemons/flo/zero.py
+++ b/salt/daemons/flo/zero.py
@@ -6,7 +6,7 @@ IoFlo behaviors for running a ZeroMQ based master
 # pylint: disable=3rd-party-module-not-gated
 
 # Import python libs
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, print_function, unicode_literals
 import os
 import logging
 import hashlib
@@ -21,6 +21,7 @@ try:
     import salt.crypt
     import salt.daemons.masterapi
     import salt.payload
+    import salt.utils.stringutils
     HAS_ZMQ = True
 except ImportError:
     HAS_ZMQ = False
@@ -38,9 +39,9 @@ class SaltZmqSetup(ioflo.base.deeding.Deed):
 
     This behavior must be run before any other zmq related
     '''
-    Ioinits = {'opts': '.salt.opts',
-           'mkey': '.salt.var.zmq.master_key',
-           'aes': '.salt.var.zmq.aes'}
+    Ioinits = {'opts': salt.utils.stringutils.to_str('.salt.opts'),
+               'mkey': salt.utils.stringutils.to_str('.salt.var.zmq.master_key'),
+               'aes': salt.utils.stringutils.to_str('.salt.var.zmq.aes')}
 
     def action(self):
         '''
@@ -52,12 +53,12 @@ class SaltZmqSetup(ioflo.base.deeding.Deed):
 
 
 @ioflo.base.deeding.deedify(
-        'SaltZmqRetFork',
+        salt.utils.stringutils.to_str('SaltZmqRetFork'),
         ioinits={
-            'opts': '.salt.opts',
-            'proc_mgr': '.salt.usr.proc_mgr',
-            'mkey': '.salt.var.zmq.master_key',
-            'aes': '.salt.var.zmq.aes'})
+            'opts': salt.utils.stringutils.to_str('.salt.opts'),
+            'proc_mgr': salt.utils.stringutils.to_str('.salt.usr.proc_mgr'),
+            'mkey': salt.utils.stringutils.to_str('.salt.var.zmq.master_key'),
+            'aes': salt.utils.stringutils.to_str('.salt.var.zmq.aes')})
 def zmq_ret_fork(self):
     '''
     Create the forked process for the ZeroMQ Ret Port
@@ -122,9 +123,9 @@ class SaltZmqCrypticleSetup(ioflo.base.deeding.Deed):
 
     do salt zmq crypticle setup at enter
     '''
-    Ioinits = {'opts': '.salt.opts',
-               'aes': '.salt.var.zmq.aes',
-               'crypticle': '.salt.var.zmq.crypticle'}
+    Ioinits = {'opts': salt.utils.stringutils.to_str('.salt.opts'),
+               'aes': salt.utils.stringutils.to_str('.salt.var.zmq.aes'),
+               'crypticle': salt.utils.stringutils.to_str('.salt.var.zmq.crypticle')}
 
     def action(self):
         '''
@@ -149,11 +150,11 @@ class SaltZmqPublisher(ioflo.base.deeding.Deed):
 
     before this deed
     '''
-    Ioinits = {'opts': '.salt.opts',
-               'publish': '.salt.var.publish',
-               'zmq_behavior': '.salt.etc.zmq_behavior',
-               'aes': '.salt.var.zmq.aes',
-               'crypticle': '.salt.var.zmq.crypticle'}
+    Ioinits = {'opts': salt.utils.stringutils.to_str('.salt.opts'),
+               'publish': salt.utils.stringutils.to_str('.salt.var.publish'),
+               'zmq_behavior': salt.utils.stringutils.to_str('.salt.etc.zmq_behavior'),
+               'aes': salt.utils.stringutils.to_str('.salt.var.zmq.aes'),
+               'crypticle': salt.utils.stringutils.to_str('.salt.var.zmq.crypticle')}
 
     def _prepare(self):
         '''
@@ -225,9 +226,9 @@ class SaltZmqWorker(ioflo.base.deeding.Deed):
     '''
     The zeromq behavior for the workers
     '''
-    Ioinits = {'opts': '.salt.opts',
-               'key': '.salt.access_keys',
-               'aes': '.salt.var.zmq.aes'}
+    Ioinits = {'opts': salt.utils.stringutils.to_str('.salt.opts'),
+               'key': salt.utils.stringutils.to_str('.salt.access_keys'),
+               'aes': salt.utils.stringutils.to_str('.salt.var.zmq.aes')}
 
     def _prepare(self):
         '''

--- a/salt/daemons/masterapi.py
+++ b/salt/daemons/masterapi.py
@@ -717,7 +717,7 @@ class RemoteFuncs(object):
                              'data',
                              {'grains': load['grains'], 'pillar': data})
             if self.opts.get('minion_data_cache_events') is True:
-                self.event.fire_event('Minion data cache refresh', salt.utils.event.tagify(load['id'], 'refresh', 'minion'))
+                self.event.fire_event({'comment': 'Minion data cache refresh'}, salt.utils.event.tagify(load['id'], 'refresh', 'minion'))
         return data
 
     def _minion_event(self, load):

--- a/salt/daemons/masterapi.py
+++ b/salt/daemons/masterapi.py
@@ -370,7 +370,7 @@ class AutoKey(object):
 
                     with salt.utils.files.fopen(grain_file, 'r') as f:
                         for line in f:
-                            line = line.strip()
+                            line = salt.utils.stringutils.to_unicode(line).strip()
                             if line.startswith('#'):
                                 continue
                             if autosign_grains[grain] == line:
@@ -692,7 +692,7 @@ class RemoteFuncs(object):
         with salt.utils.files.fopen(cpath, mode) as fp_:
             if load['loc']:
                 fp_.seek(load['loc'])
-            fp_.write(load['data'])
+            fp_.write(salt.utils.stringutils.to_str(load['data']))
         return True
 
     def _pillar(self, load):
@@ -851,7 +851,7 @@ class RemoteFuncs(object):
                 os.makedirs(auth_cache)
             jid_fn = os.path.join(auth_cache, load['jid'])
             with salt.utils.files.fopen(jid_fn, 'r') as fp_:
-                if not load['id'] == fp_.read():
+                if not load['id'] == salt.utils.stringutils.to_unicode(fp_.read()):
                     return {}
 
             return self.local.get_cache_returns(load['jid'])
@@ -909,7 +909,7 @@ class RemoteFuncs(object):
             os.makedirs(auth_cache)
         jid_fn = os.path.join(auth_cache, six.text_type(ret['jid']))
         with salt.utils.files.fopen(jid_fn, 'w+') as fp_:
-            fp_.write(load['id'])
+            fp_.write(salt.utils.stringutils.to_str(load['id']))
         return ret
 
     def minion_publish(self, load):

--- a/salt/daemons/salting.py
+++ b/salt/daemons/salting.py
@@ -3,7 +3,7 @@
 salting.py module of salt specific interfaces to raet
 
 '''
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, print_function, unicode_literals
 # pylint: skip-file
 # pylint: disable=W0611
 

--- a/salt/daemons/salting.py
+++ b/salt/daemons/salting.py
@@ -3,7 +3,7 @@
 salting.py module of salt specific interfaces to raet
 
 '''
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import, print_function
 # pylint: skip-file
 # pylint: disable=W0611
 

--- a/salt/daemons/test/plan/actors.py
+++ b/salt/daemons/test/plan/actors.py
@@ -22,6 +22,7 @@ from raet.road.estating import RemoteEstate
 from raet.road.stacking import RoadStack
 from raet.stacking import Stack
 
+import salt.utils.stringutils
 from salt.daemons import salting
 from salt.utils.event import tagify
 
@@ -43,7 +44,7 @@ class TestOptsSetup(ioflo.base.deeding.Deed):
     '''
     Setup opts share
     '''
-    Ioinits = {'opts': '.salt.opts'}
+    Ioinits = {'opts': salt.utils.stringutils.to_str('.salt.opts')}
 
     def action(self):
         '''
@@ -165,16 +166,17 @@ class PresenterTestSetup(ioflo.base.deeding.Deed):
     '''
     Setup shares for presence tests
     '''
-    Ioinits = {'presence_req': '.salt.presence.event_req',
-               'lane_stack': '.salt.lane.manor.stack',
-               'event_stack': '.salt.test.lane.stack',
-               'alloweds': {'ipath': '.salt.var.presence.alloweds',
+    Ioinits = {'presence_req': salt.utils.stringutils.to_str('.salt.presence.event_req'),
+               'lane_stack': salt.utils.stringutils.to_str('.salt.lane.manor.stack'),
+               'event_stack': salt.utils.stringutils.to_str('.salt.test.lane.stack'),
+               'alloweds': {'ipath': salt.utils.stringutils.to_str('.salt.var.presence.alloweds'),
                             'ival': odict()},
-               'aliveds': {'ipath': '.salt.var.presence.aliveds',
+               'aliveds': {'ipath': salt.utils.stringutils.to_str('.salt.var.presence.aliveds'),
                            'ival': odict()},
-               'reapeds': {'ipath': '.salt.var.presence.reapeds',
+               'reapeds': {'ipath': salt.utils.stringutils.to_str('.salt.var.presence.reapeds'),
                            'ival': odict()},
-               'availables': {'ipath': '.salt.var.presence.availables',
+               'availables': {'ipath': salt.utils.stringutils.to_str(
+                                            '.salt.var.presence.availables'),
                               'ival': set()}}
 
     def action(self):
@@ -213,14 +215,15 @@ class PresenterTestCleanup(ioflo.base.deeding.Deed):
     '''
     Clean up after a test
     '''
-    Ioinits = {'presence_req': '.salt.presence.event_req',
-               'alloweds': {'ipath': '.salt.var.presence.alloweds',
+    Ioinits = {'presence_req': salt.utils.stringutils.to_str('.salt.presence.event_req'),
+               'alloweds': {'ipath': salt.utils.stringutils.to_str('.salt.var.presence.alloweds'),
                             'ival': odict()},
-               'aliveds': {'ipath': '.salt.var.presence.aliveds',
+               'aliveds': {'ipath': salt.utils.stringutils.to_str('.salt.var.presence.aliveds'),
                            'ival': odict()},
-               'reapeds': {'ipath': '.salt.var.presence.reapeds',
+               'reapeds': {'ipath': salt.utils.stringutils.to_str('.salt.var.presence.reapeds'),
                            'ival': odict()},
-               'availables': {'ipath': '.salt.var.presence.availables',
+               'availables': {'ipath': salt.utils.stringutils.to_str(
+                                    '.salt.var.presence.availables'),
                               'ival': set()}}
 
     def action(self):
@@ -233,11 +236,12 @@ class PresenterTestCleanup(ioflo.base.deeding.Deed):
 
 
 class TestPresenceAvailable(ioflo.base.deeding.Deed):
-    Ioinits = {'presence_req': '.salt.presence.event_req',
-               'event_stack': '.salt.test.lane.stack',
-               'aliveds': {'ipath': '.salt.var.presence.aliveds',
+    Ioinits = {'presence_req': salt.utils.stringutils.to_str('.salt.presence.event_req'),
+               'event_stack': salt.utils.stringutils.to_str('.salt.test.lane.stack'),
+               'aliveds': {'ipath': salt.utils.stringutils.to_str('.salt.var.presence.aliveds'),
                            'ival': odict()},
-               'availables': {'ipath': '.salt.var.presence.availables',
+               'availables': {'ipath': salt.utils.stringutils.to_str(
+                                    '.salt.var.presence.availables'),
                               'ival': set()}}
 
     def action(self):
@@ -278,8 +282,8 @@ class TestPresenceAvailable(ioflo.base.deeding.Deed):
 
 
 class TestPresenceAvailableCheck(ioflo.base.deeding.Deed, DeedTestWrapper):
-    Ioinits = {'event_stack': '.salt.test.lane.stack',
-               'failure': '.meta.failure'}
+    Ioinits = {'event_stack': salt.utils.stringutils.to_str('.salt.test.lane.stack'),
+               'failure': salt.utils.stringutils.to_str('.meta.failure')}
 
     def action(self):
         testStack = self.event_stack.value
@@ -298,9 +302,9 @@ class TestPresenceAvailableCheck(ioflo.base.deeding.Deed, DeedTestWrapper):
 
 
 class TestPresenceJoined(ioflo.base.deeding.Deed):
-    Ioinits = {'presence_req': '.salt.presence.event_req',
-               'event_stack': '.salt.test.lane.stack',
-               'alloweds': {'ipath': '.salt.var.presence.alloweds',
+    Ioinits = {'presence_req': salt.utils.stringutils.to_str('.salt.presence.event_req'),
+               'event_stack': salt.utils.stringutils.to_str('.salt.test.lane.stack'),
+               'alloweds': {'ipath': salt.utils.stringutils.to_str('.salt.var.presence.alloweds'),
                             'ival': odict()}}
 
     def action(self):
@@ -323,8 +327,8 @@ class TestPresenceJoined(ioflo.base.deeding.Deed):
 
 
 class TestPresenceJoinedCheck(ioflo.base.deeding.Deed, DeedTestWrapper):
-    Ioinits = {'event_stack': '.salt.test.lane.stack',
-               'failure': '.meta.failure'}
+    Ioinits = {'event_stack': salt.utils.stringutils.to_str('.salt.test.lane.stack'),
+               'failure': salt.utils.stringutils.to_str('.meta.failure')}
 
     def action(self):
         testStack = self.event_stack.value
@@ -342,9 +346,9 @@ class TestPresenceJoinedCheck(ioflo.base.deeding.Deed, DeedTestWrapper):
 
 
 class TestPresenceAllowed(ioflo.base.deeding.Deed):
-    Ioinits = {'presence_req': '.salt.presence.event_req',
-               'event_stack': '.salt.test.lane.stack',
-               'alloweds': {'ipath': '.salt.var.presence.alloweds',
+    Ioinits = {'presence_req': salt.utils.stringutils.to_str('.salt.presence.event_req'),
+               'event_stack': salt.utils.stringutils.to_str('.salt.test.lane.stack'),
+               'alloweds': {'ipath': salt.utils.stringutils.to_str('.salt.var.presence.alloweds'),
                             'ival': odict()}}
 
     def action(self):
@@ -367,8 +371,8 @@ class TestPresenceAllowed(ioflo.base.deeding.Deed):
 
 
 class TestPresenceAllowedCheck(ioflo.base.deeding.Deed, DeedTestWrapper):
-    Ioinits = {'event_stack': '.salt.test.lane.stack',
-               'failure': '.meta.failure'}
+    Ioinits = {'event_stack': salt.utils.stringutils.to_str('.salt.test.lane.stack'),
+               'failure': salt.utils.stringutils.to_str('.meta.failure')}
 
     def action(self):
         testStack = self.event_stack.value
@@ -386,9 +390,9 @@ class TestPresenceAllowedCheck(ioflo.base.deeding.Deed, DeedTestWrapper):
 
 
 class TestPresenceAlived(ioflo.base.deeding.Deed):
-    Ioinits = {'presence_req': '.salt.presence.event_req',
-               'event_stack': '.salt.test.lane.stack',
-               'aliveds': {'ipath': '.salt.var.presence.aliveds',
+    Ioinits = {'presence_req': salt.utils.stringutils.to_str('.salt.presence.event_req'),
+               'event_stack': salt.utils.stringutils.to_str('.salt.test.lane.stack'),
+               'aliveds': {'ipath': salt.utils.stringutils.to_str('.salt.var.presence.aliveds'),
                             'ival': odict()}}
 
     def action(self):
@@ -411,8 +415,8 @@ class TestPresenceAlived(ioflo.base.deeding.Deed):
 
 
 class TestPresenceAlivedCheck(ioflo.base.deeding.Deed, DeedTestWrapper):
-    Ioinits = {'event_stack': '.salt.test.lane.stack',
-               'failure': '.meta.failure'}
+    Ioinits = {'event_stack': salt.utils.stringutils.to_str('.salt.test.lane.stack'),
+               'failure': salt.utils.stringutils.to_str('.meta.failure')}
 
     def action(self):
         testStack = self.event_stack.value
@@ -430,9 +434,9 @@ class TestPresenceAlivedCheck(ioflo.base.deeding.Deed, DeedTestWrapper):
 
 
 class TestPresenceReaped(ioflo.base.deeding.Deed):
-    Ioinits = {'presence_req': '.salt.presence.event_req',
-               'event_stack': '.salt.test.lane.stack',
-               'reapeds': {'ipath': '.salt.var.presence.reapeds',
+    Ioinits = {'presence_req': salt.utils.stringutils.to_str('.salt.presence.event_req'),
+               'event_stack': salt.utils.stringutils.to_str('.salt.test.lane.stack'),
+               'reapeds': {'ipath': salt.utils.stringutils.to_str('.salt.var.presence.reapeds'),
                            'ival': odict()}}
 
     def action(self):
@@ -455,8 +459,8 @@ class TestPresenceReaped(ioflo.base.deeding.Deed):
 
 
 class TestPresenceReapedCheck(ioflo.base.deeding.Deed, DeedTestWrapper):
-    Ioinits = {'event_stack': '.salt.test.lane.stack',
-               'failure': '.meta.failure'}
+    Ioinits = {'event_stack': salt.utils.stringutils.to_str('.salt.test.lane.stack'),
+               'failure': salt.utils.stringutils.to_str('.meta.failure')}
 
     def action(self):
         testStack = self.event_stack.value
@@ -484,8 +488,8 @@ class TestPresenceNoRequest(ioflo.base.deeding.Deed):
 
 
 class TestPresenceNoRequestCheck(ioflo.base.deeding.Deed, DeedTestWrapper):
-    Ioinits = {'event_stack': '.salt.test.lane.stack',
-               'failure': '.meta.failure'}
+    Ioinits = {'event_stack': salt.utils.stringutils.to_str('.salt.test.lane.stack'),
+               'failure': salt.utils.stringutils.to_str('.meta.failure')}
 
     def action(self):
         testStack = self.event_stack.value
@@ -495,9 +499,9 @@ class TestPresenceNoRequestCheck(ioflo.base.deeding.Deed, DeedTestWrapper):
 
 
 class TestPresenceUnknownSrc(ioflo.base.deeding.Deed, DeedTestWrapper):
-    Ioinits = {'presence_req': '.salt.presence.event_req',
-               'event_stack': '.salt.test.lane.stack',
-               'failure': '.meta.failure'}
+    Ioinits = {'presence_req': salt.utils.stringutils.to_str('.salt.presence.event_req'),
+               'event_stack': salt.utils.stringutils.to_str('.salt.test.lane.stack'),
+               'failure': salt.utils.stringutils.to_str('.meta.failure')}
 
     def action(self):
         '''
@@ -517,8 +521,8 @@ class TestPresenceUnknownSrc(ioflo.base.deeding.Deed, DeedTestWrapper):
 
 
 class TestPresenceUnknownSrcCheck(ioflo.base.deeding.Deed, DeedTestWrapper):
-    Ioinits = {'event_stack': '.salt.test.lane.stack',
-               'failure': '.meta.failure'}
+    Ioinits = {'event_stack': salt.utils.stringutils.to_str('.salt.test.lane.stack'),
+               'failure': salt.utils.stringutils.to_str('.meta.failure')}
 
     def action(self):
         testStack = self.event_stack.value
@@ -528,8 +532,8 @@ class TestPresenceUnknownSrcCheck(ioflo.base.deeding.Deed, DeedTestWrapper):
 
 
 class TestPresenceAvailableNoMinions(ioflo.base.deeding.Deed):
-    Ioinits = {'presence_req': '.salt.presence.event_req',
-               'event_stack': '.salt.test.lane.stack'}
+    Ioinits = {'presence_req': salt.utils.stringutils.to_str('.salt.presence.event_req'),
+               'event_stack': salt.utils.stringutils.to_str('.salt.test.lane.stack')}
 
     def action(self):
         '''
@@ -548,8 +552,8 @@ class TestPresenceAvailableNoMinions(ioflo.base.deeding.Deed):
 
 
 class TestPresenceAvailableNoMinionsCheck(ioflo.base.deeding.Deed, DeedTestWrapper):
-    Ioinits = {'event_stack': '.salt.test.lane.stack',
-               'failure': '.meta.failure'}
+    Ioinits = {'event_stack': salt.utils.stringutils.to_str('.salt.test.lane.stack'),
+               'failure': salt.utils.stringutils.to_str('.meta.failure')}
 
     def action(self):
         testStack = self.event_stack.value
@@ -567,11 +571,12 @@ class TestPresenceAvailableNoMinionsCheck(ioflo.base.deeding.Deed, DeedTestWrapp
 
 
 class TestPresenceAvailableOneMinion(ioflo.base.deeding.Deed):
-    Ioinits = {'presence_req': '.salt.presence.event_req',
-               'event_stack': '.salt.test.lane.stack',
-               'aliveds': {'ipath': '.salt.var.presence.aliveds',
+    Ioinits = {'presence_req': salt.utils.stringutils.to_str('.salt.presence.event_req'),
+               'event_stack': salt.utils.stringutils.to_str('.salt.test.lane.stack'),
+               'aliveds': {'ipath': salt.utils.stringutils.to_str('.salt.var.presence.aliveds'),
                            'ival': odict()},
-               'availables': {'ipath': '.salt.var.presence.availables',
+               'availables': {'ipath': salt.utils.stringutils.to_str(
+                                    '.salt.var.presence.availables'),
                               'ival': set()}}
 
     def action(self):
@@ -594,8 +599,8 @@ class TestPresenceAvailableOneMinion(ioflo.base.deeding.Deed):
 
 
 class TestPresenceAvailableOneMinionCheck(ioflo.base.deeding.Deed, DeedTestWrapper):
-    Ioinits = {'event_stack': '.salt.test.lane.stack',
-               'failure': '.meta.failure'}
+    Ioinits = {'event_stack': salt.utils.stringutils.to_str('.salt.test.lane.stack'),
+               'failure': salt.utils.stringutils.to_str('.meta.failure')}
 
     def action(self):
         testStack = self.event_stack.value
@@ -613,11 +618,12 @@ class TestPresenceAvailableOneMinionCheck(ioflo.base.deeding.Deed, DeedTestWrapp
 
 
 class TestPresenceAvailableUnknownIp(ioflo.base.deeding.Deed):
-    Ioinits = {'presence_req': '.salt.presence.event_req',
-               'event_stack': '.salt.test.lane.stack',
-               'aliveds': {'ipath': '.salt.var.presence.aliveds',
+    Ioinits = {'presence_req': salt.utils.stringutils.to_str('.salt.presence.event_req'),
+               'event_stack': salt.utils.stringutils.to_str('.salt.test.lane.stack'),
+               'aliveds': {'ipath': salt.utils.stringutils.to_str('.salt.var.presence.aliveds'),
                            'ival': odict()},
-               'availables': {'ipath': '.salt.var.presence.availables',
+               'availables': {'ipath': salt.utils.stringutils.to_str(
+                                    '.salt.var.presence.availables'),
                               'ival': set()}}
 
     def action(self):
@@ -643,8 +649,8 @@ class TestPresenceAvailableUnknownIp(ioflo.base.deeding.Deed):
 
 
 class TestPresenceAvailableUnknownIpCheck(ioflo.base.deeding.Deed, DeedTestWrapper):
-    Ioinits = {'event_stack': '.salt.test.lane.stack',
-               'failure': '.meta.failure'}
+    Ioinits = {'event_stack': salt.utils.stringutils.to_str('.salt.test.lane.stack'),
+               'failure': salt.utils.stringutils.to_str('.meta.failure')}
 
     def action(self):
         testStack = self.event_stack.value
@@ -664,8 +670,8 @@ class TestPresenceAvailableUnknownIpCheck(ioflo.base.deeding.Deed, DeedTestWrapp
 
 
 class TestPresenceAllowedNoMinions(ioflo.base.deeding.Deed):
-    Ioinits = {'presence_req': '.salt.presence.event_req',
-               'event_stack': '.salt.test.lane.stack'}
+    Ioinits = {'presence_req': salt.utils.stringutils.to_str('.salt.presence.event_req'),
+               'event_stack': salt.utils.stringutils.to_str('.salt.test.lane.stack')}
 
     def action(self):
         '''
@@ -684,8 +690,8 @@ class TestPresenceAllowedNoMinions(ioflo.base.deeding.Deed):
 
 
 class TestPresenceAllowedNoMinionsCheck(ioflo.base.deeding.Deed, DeedTestWrapper):
-    Ioinits = {'event_stack': '.salt.test.lane.stack',
-               'failure': '.meta.failure'}
+    Ioinits = {'event_stack': salt.utils.stringutils.to_str('.salt.test.lane.stack'),
+               'failure': salt.utils.stringutils.to_str('.meta.failure')}
 
     def action(self):
         testStack = self.event_stack.value
@@ -702,9 +708,9 @@ class TestPresenceAllowedNoMinionsCheck(ioflo.base.deeding.Deed, DeedTestWrapper
 
 
 class TestPresenceAllowedOneMinion(ioflo.base.deeding.Deed):
-    Ioinits = {'presence_req': '.salt.presence.event_req',
-               'event_stack': '.salt.test.lane.stack',
-               'alloweds': {'ipath': '.salt.var.presence.alloweds',
+    Ioinits = {'presence_req': salt.utils.stringutils.to_str('.salt.presence.event_req'),
+               'event_stack': salt.utils.stringutils.to_str('.salt.test.lane.stack'),
+               'alloweds': {'ipath': salt.utils.stringutils.to_str('.salt.var.presence.alloweds'),
                             'ival': odict()}}
 
     def action(self):
@@ -726,8 +732,8 @@ class TestPresenceAllowedOneMinion(ioflo.base.deeding.Deed):
 
 
 class TestPresenceAllowedOneMinionCheck(ioflo.base.deeding.Deed, DeedTestWrapper):
-    Ioinits = {'event_stack': '.salt.test.lane.stack',
-               'failure': '.meta.failure'}
+    Ioinits = {'event_stack': salt.utils.stringutils.to_str('.salt.test.lane.stack'),
+               'failure': salt.utils.stringutils.to_str('.meta.failure')}
 
     def action(self):
         testStack = self.event_stack.value
@@ -747,10 +753,10 @@ class StatsMasterTestSetup(ioflo.base.deeding.Deed):
     '''
     Setup shares for stats tests
     '''
-    Ioinits = {'stats_req': '.salt.stats.event_req',
-               'lane_stack': '.salt.lane.manor.stack',
-               'road_stack': '.salt.road.manor.stack',
-               'event_stack': '.salt.test.lane.stack'}
+    Ioinits = {'stats_req': salt.utils.stringutils.to_str('.salt.stats.event_req'),
+               'lane_stack': salt.utils.stringutils.to_str('.salt.lane.manor.stack'),
+               'road_stack': salt.utils.stringutils.to_str('.salt.road.manor.stack'),
+               'event_stack': salt.utils.stringutils.to_str('.salt.test.lane.stack')}
 
     def action(self):
 
@@ -784,10 +790,10 @@ class StatsMinionTestSetup(ioflo.base.deeding.Deed):
     '''
     Setup shares for stats tests
     '''
-    Ioinits = {'stats_req': '.salt.stats.event_req',
-               'lane_stack': '.salt.lane.manor.stack',
-               'road_stack': '.salt.road.manor.stack',
-               'event_stack': '.salt.test.road.stack'}
+    Ioinits = {'stats_req': salt.utils.stringutils.to_str('.salt.stats.event_req'),
+               'lane_stack': salt.utils.stringutils.to_str('.salt.lane.manor.stack'),
+               'road_stack': salt.utils.stringutils.to_str('.salt.road.manor.stack'),
+               'event_stack': salt.utils.stringutils.to_str('.salt.test.road.stack')}
 
     def action(self):
 

--- a/salt/daemons/test/test_presence.py
+++ b/salt/daemons/test/test_presence.py
@@ -20,6 +20,7 @@ from ioflo.test import testing
 from raet.lane.stacking import LaneStack
 from raet.stacking import Stack
 
+import salt.utils.stringutils
 from salt.utils.event import tagify
 
 
@@ -86,14 +87,15 @@ class PresenterTestCase(testing.FrameIofloTestCase):
         self.resolve()  # resolve House, Framer, Frame, Acts, Actors
 
         self.frame.enter()
-        self.assertDictEqual(act.actor.Ioinits,
-                             {'opts': '.salt.opts',
-                              'presence_req': '.salt.presence.event_req',
-                              'lane_stack': '.salt.lane.manor.stack',
-                              'alloweds': '.salt.var.presence.alloweds',
-                              'aliveds': '.salt.var.presence.aliveds',
-                              'reapeds': '.salt.var.presence.reapeds',
-                              'availables': '.salt.var.presence.availables'})
+        self.assertDictEqual(
+                act.actor.Ioinits,
+                {'opts': salt.utils.stringutils.to_str('.salt.opts'),
+                 'presence_req': salt.utils.stringutils.to_str('.salt.presence.event_req'),
+                 'lane_stack': salt.utils.stringutils.to_str('.salt.lane.manor.stack'),
+                 'alloweds': salt.utils.stringutils.to_str('.salt.var.presence.alloweds'),
+                 'aliveds': salt.utils.stringutils.to_str('.salt.var.presence.aliveds'),
+                 'reapeds': salt.utils.stringutils.to_str('.salt.var.presence.reapeds'),
+                 'availables': salt.utils.stringutils.to_str('.salt.var.presence.availables')})
 
         self.assertTrue(hasattr(act.actor, 'opts'))
         self.assertTrue(hasattr(act.actor, 'presence_req'))

--- a/salt/daemons/test/test_stats.py
+++ b/salt/daemons/test/test_stats.py
@@ -22,6 +22,7 @@ from raet.abiding import ns2u
 from raet.lane.stacking import LaneStack
 from raet.road.stacking import RoadStack
 
+import salt.utils.stringutils
 from salt.utils.event import tagify
 
 
@@ -77,11 +78,12 @@ class StatsEventerTestCase(testing.FrameIofloTestCase):
         self.resolve()  # resolve House, Framer, Frame, Acts, Actors
 
         self.frame.enter()
-        self.assertDictEqual(act.actor.Ioinits,
-                             {'opts': '.salt.opts',
-                              'stats_req': '.salt.stats.event_req',
-                              'lane_stack': '.salt.lane.manor.stack',
-                              'road_stack': '.salt.road.manor.stack'})
+        self.assertDictEqual(
+                act.actor.Ioinits,
+                {'opts': salt.utils.stringutils.to_str('.salt.opts'),
+                 'stats_req': salt.utils.stringutils.to_str('.salt.stats.event_req'),
+                 'lane_stack': salt.utils.stringutils.to_str('.salt.lane.manor.stack'),
+                 'road_stack': salt.utils.stringutils.to_str('.salt.road.manor.stack')})
 
         self.assertTrue(hasattr(act.actor, 'opts'))
         self.assertTrue(hasattr(act.actor, 'stats_req'))
@@ -384,11 +386,12 @@ class StatsEventerTestCase(testing.FrameIofloTestCase):
         self.resolve()  # resolve House, Framer, Frame, Acts, Actors
 
         self.frame.enter()
-        self.assertDictEqual(act.actor.Ioinits,
-                             {'opts': '.salt.opts',
-                              'stats_req': '.salt.stats.event_req',
-                              'lane_stack': '.salt.lane.manor.stack',
-                              'road_stack': '.salt.road.manor.stack'})
+        self.assertDictEqual(
+                act.actor.Ioinits,
+                {'opts': salt.utils.stringutils.to_str('.salt.opts'),
+                 'stats_req': salt.utils.stringutils.to_str('.salt.stats.event_req'),
+                 'lane_stack': salt.utils.stringutils.to_str('.salt.lane.manor.stack'),
+                 'road_stack': salt.utils.stringutils.to_str('.salt.road.manor.stack')})
 
         self.assertTrue(hasattr(act.actor, 'opts'))
         self.assertTrue(hasattr(act.actor, 'stats_req'))

--- a/salt/key.py
+++ b/salt/key.py
@@ -380,7 +380,7 @@ class Key(object):
                 io_loop=io_loop
                 )
 
-        self.passphrase = salt.utils.sdb.sdb_get(self.opts['signing_key_pass'], self.opts)
+        self.passphrase = salt.utils.sdb.sdb_get(self.opts.get('signing_key_pass'), self.opts)
 
     def _check_minions_directories(self):
         '''


### PR DESCRIPTION
### What does this PR do?
1. Basically fixes RAET transport support for Python2. At least I've tested master-minion connection with `test.ping`. Technically these fixes change nothing for zmq and tcp transports so it should be safe to merge this into oxygen.
2. Aded a deprecation warning and release note.

### What issues does this PR fix or reference?
No

### Tests written?
N/A

### Commits signed with GPG?
Yes