### PR TITLE
Add correct path to ssh.exe for Windows

### DIFF
--- a/pkg/windows/build_pkg.bat
+++ b/pkg/windows/build_pkg.bat
@@ -302,6 +302,8 @@ If Exist "%BinDir%\Lib\site-packages\salt\modules\solaris*"^
     del /Q "%BinDir%\Lib\site-packages\salt\modules\solaris*" 1>nul
 If Exist "%BinDir%\Lib\site-packages\salt\modules\solr.py"^
     del /Q "%BinDir%\Lib\site-packages\salt\modules\solr.*" 1>nul
+If Exist "%BinDir%\Lib\site-packages\salt\modules\ssh_*"^
+    del /Q "%BinDir%\Lib\site-packages\salt\modules\ssh_*" 1>nul
 If Exist "%BinDir%\Lib\site-packages\salt\modules\supervisord.py"^
     del /Q "%BinDir%\Lib\site-packages\salt\modules\supervisord.*" 1>nul
 If Exist "%BinDir%\Lib\site-packages\salt\modules\sysbench.py"^
@@ -436,6 +438,8 @@ If Exist "%BinDir%\Lib\site-packages\salt\states\smartos.py"^
     del /Q "%BinDir%\Lib\site-packages\salt\states\smartos.*" 1>nul
 If Exist "%BinDir%\Lib\site-packages\salt\states\snapper.py"^
     del /Q "%BinDir%\Lib\site-packages\salt\states\snapper.*" 1>nul
+If Exist "%BinDir%\Lib\site-packages\salt\states\ssh_*"^
+    del /Q "%BinDir%\Lib\site-packages\salt\states\ssh_*" 1>nul
 If Exist "%BinDir%\Lib\site-packages\salt\states\supervisord.py"^
     del /Q "%BinDir%\Lib\site-packages\salt\states\supervisord.*" 1>nul
 If Exist "%BinDir%\Lib\site-packages\salt\states\sysrc.py"^

--- a/pkg/windows/build_pkg.bat
+++ b/pkg/windows/build_pkg.bat
@@ -302,8 +302,6 @@ If Exist "%BinDir%\Lib\site-packages\salt\modules\solaris*"^
     del /Q "%BinDir%\Lib\site-packages\salt\modules\solaris*" 1>nul
 If Exist "%BinDir%\Lib\site-packages\salt\modules\solr.py"^
     del /Q "%BinDir%\Lib\site-packages\salt\modules\solr.*" 1>nul
-If Exist "%BinDir%\Lib\site-packages\salt\modules\ssh*"^
-    del /Q "%BinDir%\Lib\site-packages\salt\modules\ssh*" 1>nul
 If Exist "%BinDir%\Lib\site-packages\salt\modules\supervisord.py"^
     del /Q "%BinDir%\Lib\site-packages\salt\modules\supervisord.*" 1>nul
 If Exist "%BinDir%\Lib\site-packages\salt\modules\sysbench.py"^
@@ -438,8 +436,6 @@ If Exist "%BinDir%\Lib\site-packages\salt\states\smartos.py"^
     del /Q "%BinDir%\Lib\site-packages\salt\states\smartos.*" 1>nul
 If Exist "%BinDir%\Lib\site-packages\salt\states\snapper.py"^
     del /Q "%BinDir%\Lib\site-packages\salt\states\snapper.*" 1>nul
-If Exist "%BinDir%\Lib\site-packages\salt\states\ssh*"^
-    del /Q "%BinDir%\Lib\site-packages\salt\states\ssh*" 1>nul
 If Exist "%BinDir%\Lib\site-packages\salt\states\supervisord.py"^
     del /Q "%BinDir%\Lib\site-packages\salt\states\supervisord.*" 1>nul
 If Exist "%BinDir%\Lib\site-packages\salt\states\sysrc.py"^

--- a/salt/modules/git.py
+++ b/salt/modules/git.py
@@ -215,8 +215,8 @@ def _git_run(command, cwd=None, user=None, password=None, identity=None,
                                           'ssh.exe')]
                 for globmask in globmasks:
                     ssh_exe = glob.glob(globmask)
-                    if os.path.isfile(ssh_exe):
-                        env['GIT_SSH_EXE'] = ssh_exe
+                    if ssh_exe and os.path.isfile(ssh_exe[0]):
+                        env['GIT_SSH_EXE'] = ssh_exe[0]
                         break
                 else:
                     raise CommandExecutionError(

--- a/salt/modules/git.py
+++ b/salt/modules/git.py
@@ -9,6 +9,7 @@ import copy
 import logging
 import os
 import re
+import glob
 from distutils.version import LooseVersion as _LooseVersion
 
 # Import salt libs
@@ -205,11 +206,15 @@ def _git_run(command, cwd=None, user=None, password=None, identity=None,
                 'git/ssh-id-wrapper'
             )
             if salt.utils.is_windows():
-                for suffix in ('', ' (x86)'):
-                    ssh_exe = (
-                        'C:\\Program Files{0}\\Git\\bin\\ssh.exe'
-                        .format(suffix)
-                    )
+                # Known locations for Git's ssh.exe in Windows
+                globmasks = [os.path.join(os.getenv('SystemDrive'), os.sep,
+                                          'Program Files*', 'Git', 'usr', 'bin',
+                                          'ssh.exe'),
+                             os.path.join(os.getenv('SystemDrive'), os.sep,
+                                          'Program Files*', 'Git', 'bin',
+                                          'ssh.exe')]
+                for globmask in globmasks:
+                    ssh_exe = glob.glob(globmask)
                     if os.path.isfile(ssh_exe):
                         env['GIT_SSH_EXE'] = ssh_exe
                         break


### PR DESCRIPTION
### What does this PR do?
Adds the correct path to git's `ssh.exe` for Windows.
Includes the ssh state and execution modules in the Windows installer.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/34237

### Tests written?
No

### Commits signed with GPG?
Yes