### PR TITLE
Fixes base dir making logic to ensure not raising the exception when base directory already exists.

### DIFF
--- a/salt/cache/localfs.py
+++ b/salt/cache/localfs.py
@@ -14,6 +14,7 @@ from __future__ import absolute_import
 import logging
 import os
 import os.path
+import errno
 import shutil
 import tempfile
 
@@ -45,13 +46,14 @@ def store(bank, key, data, cachedir):
     Store information in a file.
     '''
     base = os.path.join(cachedir, os.path.normpath(bank))
-    if not os.path.isdir(base):
-        try:
-            os.makedirs(base)
-        except OSError as exc:
+    try:
+        os.makedirs(base)
+    except OSError as exc:
+        if exc.errno != errno.EEXIST:
             raise SaltCacheError(
-                'The cache directory, {0}, does not exist and could not be '
-                'created: {1}'.format(base, exc)
+                'The cache directory, {0}, could not be created: {1}'.format(
+                    base, exc
+                )
             )
 
     outfile = os.path.join(base, '{0}.p'.format(key))


### PR DESCRIPTION
### What does this PR do?
To avoid raising an exception even it doesn't have to, added a simple `if-else` branch.
If salt stack consists of multi-master with a physically shared cached directory (i.e. mounting NAS for cache directory), some kind of a race-condition could happen.

For example, 
Server 1 passes `if not os.path.isdir(base)`
Server 2 passes `if not os.path.isdir(base)`
Server 1 executes `os.makedirs(base)`
Server 2 executes `os.makedirs(base)` <- **raising Exception at this point even it shouldn't.**

(In the case of Python3, `os.makedirs(base, exist_ok=True)` will work exactly same with this code (`if-else` branch in `except` statement), but Python2 doesn't support the optional parameter `exist_ok`.)

### What issues does this PR fix or reference?
N/A

### Previous Behavior
Raised the exception SaltCacheError even base directory is available.

### New Behavior
Don't raise the exception SaltCacheError if a base directory already exists.

### Tests written?

Yes (partially)

### Commits signed with GPG?

Yes