### PR TITLE
fix last 2016.11.9 failing tests

### DIFF
--- a/tests/integration/modules/pip.py
+++ b/tests/integration/modules/pip.py
@@ -47,7 +47,7 @@ class PipModuleTest(integration.ModuleCase):
         '''
         return any(w in ret for w in ['URLError', 'Download error'])
 
-    def pip_successful_install(self, target, expect=('flake8', 'pep8',)):
+    def pip_successful_install(self, target, expect=('tox', 'pep8',)):
         '''
         isolate regex for extracting `successful install` message from pip
         '''
@@ -102,7 +102,7 @@ class PipModuleTest(integration.ModuleCase):
         with salt.utils.fopen(req1_filename, 'w') as f:
             f.write('-r requirements1b.txt\n')
         with salt.utils.fopen(req1b_filename, 'w') as f:
-            f.write('flake8\n')
+            f.write('tox\n')
         with salt.utils.fopen(req2_filename, 'w') as f:
             f.write('-r requirements2b.txt\n')
         with salt.utils.fopen(req2b_filename, 'w') as f:
@@ -140,7 +140,7 @@ class PipModuleTest(integration.ModuleCase):
         with salt.utils.fopen(req1_filename, 'w') as f:
             f.write('-r requirements1b.txt\n')
         with salt.utils.fopen(req1b_filename, 'w') as f:
-            f.write('flake8\n')
+            f.write('tox\n')
         with salt.utils.fopen(req2_filename, 'w') as f:
             f.write('-r requirements2b.txt\n')
         with salt.utils.fopen(req2b_filename, 'w') as f:
@@ -173,7 +173,7 @@ class PipModuleTest(integration.ModuleCase):
         req2_filename = os.path.join(self.venv_dir, 'requirements2.txt')
 
         with salt.utils.fopen(req1_filename, 'w') as f:
-            f.write('flake8\n')
+            f.write('tox\n')
         with salt.utils.fopen(req2_filename, 'w') as f:
             f.write('pep8\n')
 
@@ -210,7 +210,7 @@ class PipModuleTest(integration.ModuleCase):
         req2_filepath = os.path.join(req_cwd, req2_filename)
 
         with salt.utils.fopen(req1_filepath, 'w') as f:
-            f.write('flake8\n')
+            f.write('tox\n')
         with salt.utils.fopen(req2_filepath, 'w') as f:
             f.write('pep8\n')
 

--- a/tests/integration/modules/pkg.py
+++ b/tests/integration/modules/pkg.py
@@ -240,10 +240,10 @@ class PkgModuleTest(integration.ModuleCase,
             self.assertIn('bash-completion', keys)
             self.assertIn('dpkg', keys)
         elif os_family == 'RedHat':
-            ret = self.run_function(func, ['rpm', 'yum'])
+            ret = self.run_function(func, ['rpm', 'bash'])
             keys = ret.keys()
             self.assertIn('rpm', keys)
-            self.assertIn('yum', keys)
+            self.assertIn('bash', keys)
         elif os_family == 'SUSE':
             ret = self.run_function(func, ['less', 'zypper'])
             keys = ret.keys()


### PR DESCRIPTION
### What does this PR do?
yum is no longer installed by default on fedora.  apparently it has been
removed from the base installs, and only dnf is available.  Stop depending on
the pkg manager, and just use bash.

For the centos test, flake8 is having problems installing on centos6, so just
switching it to tox, which installs fine on all our supported versions still

### Tests written?

Yes

### Commits signed with GPG?

Yes