### PR TITLE
fix mock for opensuse

### DIFF
--- a/tests/unit/grains/core_test.py
+++ b/tests/unit/grains/core_test.py
@@ -485,10 +485,11 @@ PATCHLEVEL = 3
                     log.debug(
                         'Testing Docker cgroup substring \'%s\'', cgroup_substr)
                     with patch('salt.utils.fopen', mock_open(read_data=cgroup_data)):
-                        self.assertEqual(
-                            core._virtual({'kernel': 'Linux'}).get('virtual_subtype'),
-                            'Docker'
-                        )
+                        with patch.dict(core.__salt__, {'cmd.run_all': MagicMock()}):
+                            self.assertEqual(
+                                core._virtual({'kernel': 'Linux'}).get('virtual_subtype'),
+                                'Docker'
+                            )
 
     def _check_ipaddress(self, value, ip_v):
         '''


### PR DESCRIPTION
### What does this PR do?
Opensuse needs a run_all in here, mock it so we don't see an error, and still
test the docker stuff

### What issues does this PR fix or reference?
Last error for 2016.11.9

### Tests written?

Yes

### Commits signed with GPG?

Yes