### PR TITLE
Fix `unit.test_crypt` for Windows

### DIFF
--- a/tests/unit/test_crypt.py
+++ b/tests/unit/test_crypt.py
@@ -10,7 +10,6 @@ from tests.support.mock import patch, call, mock_open, NO_MOCK, NO_MOCK_REASON, 
 
 # salt libs
 import salt.utils.files
-import salt.utils.platform
 from salt import crypt
 
 # third-party libs


### PR DESCRIPTION
### What does this PR do?
Uses the `create=True` option in the patch for `os.chown` which does not exist in Windows. The `create` option will create the object if it doesn't exist. Documentation for patch states the following:

_By default patch will fail to replace attributes that don’t exist. If you pass in create=True, and the attribute doesn’t exist, patch will create the attribute for you when the patched function is called, and delete it again afterwards. This is useful for writing tests against attributes that your production code creates at runtime. It is off by by default because it can be dangerous. With it switched on you can write passing tests against APIs that don’t actually exist!_

Fixes linux-specific paths for the key file

### What issues does this PR fix or reference?
https://github.com/saltstack/salt-jenkins/issues/439

### Tests written?
Yes

### Commits signed with GPG?
Yes