### PR TITLE
Fix `unit.utils.test_configparser` for Windows

### DIFF
--- a/salt/utils/configparser.py
+++ b/salt/utils/configparser.py
@@ -74,7 +74,11 @@ class GitConfigParser(RawConfigParser, object):  # pylint: disable=undefined-var
         while True:
             line = fp.readline()
             if six.PY2:
-                line = line.decode(__salt_system_encoding__)
+                try:
+                    line = line.decode(__salt_system_encoding__)
+                except UnicodeDecodeError:
+                    # Fall back to UTF-8
+                    line = line.decode('utf-8')
             if not line:
                 break
             lineno = lineno + 1

--- a/tests/unit/utils/test_configparser.py
+++ b/tests/unit/utils/test_configparser.py
@@ -71,7 +71,7 @@ class TestGitConfigParser(TestCase):
             with salt.utils.files.fopen(self.orig_config, 'wb') as fp_:
                 fp_.write(
                     salt.utils.stringutils.to_bytes(
-                        '\n'.join(ORIG_CONFIG)
+                        os.linesep.join(ORIG_CONFIG)
                     )
                 )
         self.conf = salt.utils.configparser.GitConfigParser()


### PR DESCRIPTION
### What does this PR do?
Fixes a decode error in the config parser on Py2 in Windows. Similar to https://github.com/saltstack/salt/pull/45403

Uses os.linesep instead of hard-coded, Linux-specific line ending

### What issues does this PR fix or reference?
https://github.com/saltstack/salt-jenkins/issues/439

### Tests written?
Yes

### Commits signed with GPG?
Yes