### PR TITLE
Added the option to explicitly specify the user for django commands

### DIFF
--- a/salt/modules/djangomod.py
+++ b/salt/modules/djangomod.py
@@ -47,6 +47,7 @@ def command(settings_module,
             bin_env=None,
             pythonpath=None,
             env=None,
+            runas=None,
             *args, **kwargs):
     '''
     Run arbitrary django management command
@@ -69,7 +70,7 @@ def command(settings_module,
     for key, value in six.iteritems(kwargs):
         if not key.startswith('__'):
             cmd = '{0} --{1}={2}'.format(cmd, key, value)
-    return __salt__['cmd.run'](cmd, env=env, python_shell=False)
+    return __salt__['cmd.run'](cmd, env=env, runas=runas, python_shell=False)
 
 
 def syncdb(settings_module,
@@ -78,7 +79,8 @@ def syncdb(settings_module,
            database=None,
            pythonpath=None,
            env=None,
-           noinput=True):
+           noinput=True,
+           runas=None):
     '''
     Run syncdb
 
@@ -106,6 +108,7 @@ def syncdb(settings_module,
                    bin_env,
                    pythonpath,
                    env,
+                   runas,
                    *args, **kwargs)
 
 
@@ -115,7 +118,8 @@ def createsuperuser(settings_module,
                     bin_env=None,
                     database=None,
                     pythonpath=None,
-                    env=None):
+                    env=None,
+                    runas=None):
     '''
     Create a super user for the database.
     This function defaults to use the ``--noinput`` flag which prevents the
@@ -139,6 +143,7 @@ def createsuperuser(settings_module,
                    bin_env,
                    pythonpath,
                    env,
+                   runas,
                    *args, **kwargs)
 
 
@@ -185,7 +190,8 @@ def collectstatic(settings_module,
                   link=False,
                   no_default_ignore=False,
                   pythonpath=None,
-                  env=None):
+                  env=None,
+                  runas=None):
     '''
     Collect static files from each of your applications into a single location
     that can easily be served in production.
@@ -216,4 +222,5 @@ def collectstatic(settings_module,
                    bin_env,
                    pythonpath,
                    env,
+                   runas,
                    *args, **kwargs)

--- a/tests/unit/modules/test_djangomod.py
+++ b/tests/unit/modules/test_djangomod.py
@@ -105,7 +105,8 @@ class DjangomodCliCommandTestCase(TestCase, LoaderModuleMockMixin):
             mock.assert_called_once_with(
                 'django-admin.py runserver --settings=settings.py',
                 python_shell=False,
-                env=None
+                env=None,
+                runas=None
             )
 
     def test_django_admin_cli_command_with_args(self):
@@ -118,6 +119,7 @@ class DjangomodCliCommandTestCase(TestCase, LoaderModuleMockMixin):
                 None,
                 None,
                 None,
+                None,
                 'noinput',
                 'somethingelse'
             )
@@ -125,7 +127,8 @@ class DjangomodCliCommandTestCase(TestCase, LoaderModuleMockMixin):
                 'django-admin.py runserver --settings=settings.py '
                 '--noinput --somethingelse',
                 python_shell=False,
-                env=None
+                env=None,
+                runas=None
             )
 
     def test_django_admin_cli_command_with_kwargs(self):
@@ -137,13 +140,15 @@ class DjangomodCliCommandTestCase(TestCase, LoaderModuleMockMixin):
                 'runserver',
                 None,
                 None,
+                None,
                 database='something'
             )
             mock.assert_called_once_with(
                 'django-admin.py runserver --settings=settings.py '
                 '--database=something',
                 python_shell=False,
-                env=None
+                env=None,
+                runas=None
             )
 
     def test_django_admin_cli_command_with_kwargs_ignore_dunder(self):
@@ -151,12 +156,13 @@ class DjangomodCliCommandTestCase(TestCase, LoaderModuleMockMixin):
         with patch.dict(djangomod.__salt__,
                         {'cmd.run': mock}):
             djangomod.command(
-                'settings.py', 'runserver', None, None, __ignore='something'
+                'settings.py', 'runserver', None, None, None, __ignore='something'
             )
             mock.assert_called_once_with(
                 'django-admin.py runserver --settings=settings.py',
                 python_shell=False,
-                env=None
+                env=None,
+                runas=None
             )
 
     def test_django_admin_cli_syncdb(self):
@@ -167,7 +173,8 @@ class DjangomodCliCommandTestCase(TestCase, LoaderModuleMockMixin):
             mock.assert_called_once_with(
                 'django-admin.py syncdb --settings=settings.py --noinput',
                 python_shell=False,
-                env=None
+                env=None,
+                runas=None
             )
 
     def test_django_admin_cli_syncdb_migrate(self):
@@ -179,7 +186,8 @@ class DjangomodCliCommandTestCase(TestCase, LoaderModuleMockMixin):
                 'django-admin.py syncdb --settings=settings.py --migrate '
                 '--noinput',
                 python_shell=False,
-                env=None
+                env=None,
+                runas=None
             )
 
     def test_django_admin_cli_createsuperuser(self):
@@ -197,7 +205,7 @@ class DjangomodCliCommandTestCase(TestCase, LoaderModuleMockMixin):
             self.assertEqual(set(args[0].split()),
                              set('django-admin.py createsuperuser --settings=settings.py --noinput '
                                                    '--username=testuser --email=user@example.com'.split()))
-            self.assertDictEqual(kwargs, {'python_shell': False, 'env': None})
+            self.assertDictEqual(kwargs, {'python_shell': False, 'env': None, 'runas': None})
 
     def no_test_loaddata(self):
         mock = MagicMock()
@@ -220,5 +228,6 @@ class DjangomodCliCommandTestCase(TestCase, LoaderModuleMockMixin):
                 '--noinput --no-post-process --dry-run --clear --link '
                 '--no-default-ignore --ignore=something',
                 python_shell=False,
-                env=None
+                env=None,
+                runas=None
             )


### PR DESCRIPTION
Being able to specify the user to run django commands as can help to prevent permissions issues from cropping up, such as when compiling static assets or migrating a sqlite database which are then owned by root.

### What does this PR do?
Adds the `runas` parameter to the `django.command` and `django.collectstatic` functions for specifying the user to execute commands as.

### What issues does this PR fix or reference?
N/A

### Previous Behavior
All django commands would be executed by whichever user the salt daemon is being executed as.

### New Behavior
Django commands can be run as an arbitrary user to avoid permissions issues

### Tests written?

No

### Commits signed with GPG?

Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
