### PR TITLE
Dev/adelcast/opkg restartcheck support

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -997,6 +997,8 @@ def _ps(osdata):
         )
     elif osdata['os_family'] == 'AIX':
         grains['ps'] = '/usr/bin/ps auxww'
+    elif osdata['os_family'] == 'NILinuxRT':
+        grains['ps'] = 'ps -o user,pid,ppid,tty,time,comm'
     else:
         grains['ps'] = 'ps -efHww'
     return grains

--- a/salt/modules/debian_service.py
+++ b/salt/modules/debian_service.py
@@ -41,7 +41,7 @@ def __virtual__():
     '''
     Only work on Debian and when systemd isn't running
     '''
-    if __grains__['os'] in ('Debian', 'Raspbian', 'Devuan') and not salt.utils.systemd.booted(__context__):
+    if __grains__['os'] in ('Debian', 'Raspbian', 'Devuan', 'NILinuxRT') and not salt.utils.systemd.booted(__context__):
         return __virtualname__
     else:
         return (False, 'The debian_service module could not be loaded: '

--- a/salt/modules/restartcheck.py
+++ b/salt/modules/restartcheck.py
@@ -294,6 +294,23 @@ def _kernel_versions_redhat():
     return kernel_versions
 
 
+def _kernel_versions_nilrt():
+    '''
+    Last installed kernel name, for Debian based systems.
+
+    Returns:
+            List with possible names of last installed kernel
+            as they are probably interpreted in output of `uname -a` command.
+    '''
+    kernel_versions = []
+    kernel = os.readlink('/boot/bzImage')
+    kernel = os.path.basename(kernel)
+    kernel = kernel.strip('bzImage-')
+    kernel_versions.append(kernel)
+
+    return kernel_versions
+
+
 def restartcheck(ignorelist=None, blacklist=None, excludepid=None, verbose=True):
     '''
     Analyzes files openeded by running processes and seeks for packages which need to be restarted.
@@ -327,8 +344,12 @@ def restartcheck(ignorelist=None, blacklist=None, excludepid=None, verbose=True)
         systemd_folder = '/usr/lib/systemd/system/'
         systemd = '/usr/bin/systemctl'
         kernel_versions = _kernel_versions_redhat()
+    elif __grains__.get('os_family') == 'NILinuxRT':
+        cmd_pkg_query = 'opkg files '
+        systemd = ''
+        kernel_versions = _kernel_versions_nilrt()
     else:
-        return {'result': False, 'comment': 'Only available on Debian and Red Hat based systems.'}
+        return {'result': False, 'comment': 'Only available on Debian, Red Hat and NI Linux Real-Time based systems.'}
 
     # Check kernel versions
     kernel_current = __salt__['cmd.run']('uname -a')

--- a/tests/integration/modules/test_service.py
+++ b/tests/integration/modules/test_service.py
@@ -25,6 +25,9 @@ class ServiceModuleTest(ModuleCase):
         elif os_family == 'Arch':
             self.service_name = 'systemd-journald'
             cmd_name = 'systemctl'
+        elif os_family == 'NILinuxRT':
+            self.service_name = 'syslog'
+            cmd_name = 'syslog-ng'
         elif os_family == 'MacOS':
             self.service_name = 'org.ntp.ntpd'
 


### PR DESCRIPTION
### What does this PR do?

Add NILinuxRT support for the checkrestart module. As part of this PR, I added NILinuxRT support for the service module too, as it is used by the restart module. I also fixed the ps grain definition for NILinuxRT (used by status.pid, which is used in the service module).

### Tests written?

Yes. Enabled existing service module tests for NILinuxRT.

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
