### PR TITLE
update winrepo_source_dir document

### DIFF
--- a/doc/ref/configuration/minion.rst
+++ b/doc/ref/configuration/minion.rst
@@ -3044,6 +3044,27 @@ the metadata will be refreshed.
 
 .. _winrepo-minion-config-opts:
 
+Minion Windows Software Repo Settings
+=====================================
+
+.. important::
+    To use these config options, the minion can be running in master-minion or
+    masterless mode.
+
+
+.. conf_minion:: winrepo_source_dir
+
+``winrepo_source_dir``
+----------------------
+
+Default: ``salt://win/repo-ng/``
+
+The source location for the winrepo sls files.
+
+.. code-block:: yaml
+
+    winrepo_source_dir: salt://win/repo-ng/
+
 Standalone Minion Windows Software Repo Settings
 ================================================
 
@@ -3086,19 +3107,6 @@ out for 2015.8.0 and later minions.
 .. code-block:: yaml
 
     winrepo_dir_ng: /srv/salt/win/repo-ng
-
-.. conf_minion:: winrepo_source_dir
-
-``winrepo_source_dir``
-----------------------
-
-Default: ``salt://win/repo-ng/``
-
-The source location for the winrepo sls files.
-
-.. code-block:: yaml
-
-    winrepo_source_dir: salt://win/repo-ng/
 
 .. conf_minion:: winrepo_cachefile
 .. conf_minion:: win_repo_cachefile


### PR DESCRIPTION
The winrepo_source_dir minion config can be set with or without a master.  It is currently documented as only available if the minion is running in masterless mode.  I have updated the documentation to reflect that it will work in master or masterless mode.

### What does this PR do?
adds new section Minion Windows Software Repo Settings and moves winrepo_source_dir config option to this new section.
### What issues does this PR fix or reference?
fixes invalid documentation about the minion winrepo_source_dir config option
### Previous Behavior
Remove this section if not relevant
The winrepo_source_dir config option is available in both master-minion and masterless modes but it is documented that it will only work in masterless mode.

### Tests written?

No but it has been thoroughly manually tested. winrepo_source_dir definitely works in master-minion mode.  Tested with 2017.7.2 w/ ubuntu 16.04 master and Server 2016 minion.

### Commits signed with GPG?

No
Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
