### PR TITLE
Fix `unit.utils.test_schema` for Windows/Py2

### DIFF
--- a/tests/unit/utils/test_schema.py
+++ b/tests/unit/utils/test_schema.py
@@ -12,6 +12,7 @@ from tests.support.unit import TestCase, skipIf
 
 # Import Salt Libs
 import salt.utils.json
+import salt.utils.stringutils
 import salt.utils.yaml
 import salt.utils.schema as schema
 from salt.ext import six
@@ -777,8 +778,10 @@ class ConfigTestCase(TestCase):
             item = schema.IPv6Item(title='Item', description='Item description')
 
         try:
-            jsonschema.validate({'item': '::1'}, TestConf.serialize(),
-                                format_checker=jsonschema.FormatChecker())
+            jsonschema.validate(
+                {'item': salt.utils.stringutils.to_str('::1')},
+                TestConf.serialize(),
+                format_checker=jsonschema.FormatChecker())
         except jsonschema.exceptions.ValidationError as exc:
             self.fail('ValidationError raised: {0}'.format(exc))
 


### PR DESCRIPTION
### What does this PR do?
Fixes an issue with the test caused by the migration to `unicode_literals`

### What issues does this PR fix or reference?
https://github.com/saltstack/salt-jenkins/issues/439

### Previous Behavior
Remove this section if not relevant

### New Behavior
Remove this section if not relevant

### Tests written?

Yes/No

### Commits signed with GPG?

Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
