### PR TITLE
update 2017.7.3 tests

### DIFF
--- a/tests/unit/grains/test_core.py
+++ b/tests/unit/grains/test_core.py
@@ -493,10 +493,11 @@ PATCHLEVEL = 3
                     log.debug(
                         'Testing Docker cgroup substring \'%s\'', cgroup_substr)
                     with patch('salt.utils.fopen', mock_open(read_data=cgroup_data)):
-                        self.assertEqual(
-                            core._virtual({'kernel': 'Linux'}).get('virtual_subtype'),
-                            'Docker'
-                        )
+                        with patch.dict(core.__salt__, {'cmd.run_all': MagicMock()}):
+                            self.assertEqual(
+                                core._virtual({'kernel': 'Linux'}).get('virtual_subtype'),
+                                'Docker'
+                            )
 
     def _check_ipaddress(self, value, ip_v):
         '''

--- a/tests/unit/templates/test_jinja.py
+++ b/tests/unit/templates/test_jinja.py
@@ -892,7 +892,7 @@ class TestCustomExtensions(TestCase):
     def test_http_query(self):
         '''Test the `http_query` Jinja filter.'''
         for backend in ('requests', 'tornado', 'urllib2'):
-            rendered = render_jinja_tmpl("{{ 'http://www.google.com' | http_query(backend='" + backend + "') }}",
+            rendered = render_jinja_tmpl("{{ 'http://icanhazip.com' | http_query(backend='" + backend + "') }}",
                                          dict(opts=self.local_opts, saltenv='test', salt=self.local_salt))
             self.assertIsInstance(rendered, six.text_type, 'Failed with backend: {}'.format(backend))
             dict_reply = ast.literal_eval(rendered)


### PR DESCRIPTION
### What does this PR do?
backport one fix that was added in 2016.11.9

and fix the test query by using a simpler website that doesn't have redirects for ipv6.

### Tests written?

Yes

### Commits signed with GPG?

Yes