### PR TITLE
Fix arg order in log message

### DIFF
--- a/salt/cli/daemons.py
+++ b/salt/cli/daemons.py
@@ -82,7 +82,7 @@ class DaemonsMixin(object):  # pylint: disable=no-init
         :param action
         :return:
         '''
-        log.info('%s the Salt %s', self.__class__.__name__, action)
+        log.info('%s the Salt %s', action, self.__class__.__name__)
 
     def start_log_info(self):
         '''


### PR DESCRIPTION
When str.format() was removed from this log message in 685bfbb, the
order of arguments was not changed, which causes the info log to not
make sense. This corrects that oversight.