### PR TITLE
Test suite stability fixes

### DIFF
--- a/salt/engines/__init__.py
+++ b/salt/engines/__init__.py
@@ -127,4 +127,7 @@ class Engine(SignalHandlingMultiprocessingProcess):
         try:
             self.engine[self.fun](**kwargs)
         except Exception as exc:
-            log.critical('Engine %s could not be started! Error: %s', self.engine, exc)
+            log.critical(
+                'Engine \'%s\' could not be started!',
+                self.fun.split('.')[0], exc_info=True
+            )

--- a/salt/transport/zeromq.py
+++ b/salt/transport/zeromq.py
@@ -45,6 +45,9 @@ try:
 except ImportError:
     HAS_ZMQ_MONITOR = False
 
+LIBZMQ_VERSION = tuple(map(int, zmq.zmq_version().split('.')))
+PYZMQ_VERSION = tuple(map(int, zmq.pyzmq_version().split('.')))
+
 # Import Tornado Libs
 import tornado
 import tornado.gen
@@ -73,9 +76,7 @@ def _get_master_uri(master_ip,
 
     Source: http://api.zeromq.org/4-1:zmq-tcp
     '''
-    libzmq_version_tup = tuple(map(int, zmq.zmq_version().split('.')))
-    pyzmq_version_tup = tuple(map(int, zmq.pyzmq_version().split('.')))
-    if libzmq_version_tup >= (4, 1, 6) and pyzmq_version_tup >= (16, 0, 1):
+    if LIBZMQ_VERSION >= (4, 1, 6) and PYZMQ_VERSION >= (16, 0, 1):
         # The source:port syntax for ZeroMQ has been added in libzmq 4.1.6
         # which is included in the pyzmq wheels starting with 16.0.1.
         if source_ip or source_port:
@@ -410,7 +411,12 @@ class AsyncZeroMQPubChannel(salt.transport.mixins.auth.AESPubClientMixin, salt.t
             self._monitor.stop()
             self._monitor = None
         if hasattr(self, '_stream'):
-            self._stream.close(0)
+            if PYZMQ_VERSION < (14, 3, 0):
+                # stream.close() doesn't work properly on pyzmq < 14.3.0
+                self._stream.io_loop.remove_handler(self._stream.socket)
+                self._stream.socket.close(0)
+            else:
+                self._stream.close(0)
         elif hasattr(self, '_socket'):
             self._socket.close(0)
         if hasattr(self, 'context') and self.context.closed is False:
@@ -966,8 +972,17 @@ class AsyncReqMessageClient(object):
     # TODO: timeout all in-flight sessions, or error
     def destroy(self):
         if hasattr(self, 'stream') and self.stream is not None:
-            self.stream.close()
-            self.socket = None
+            if PYZMQ_VERSION < (14, 3, 0):
+                # stream.close() doesn't work properly on pyzmq < 14.3.0
+                if self.stream.socket:
+                    self.stream.socket.close()
+                self.stream.io_loop.remove_handler(self.stream.socket)
+                # set this to None, more hacks for messed up pyzmq
+                self.stream.socket = None
+                self.socket.close()
+            else:
+                self.stream.close()
+                self.socket = None
             self.stream = None
         if self.context.closed is False:
             self.context.term()

--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -92,8 +92,8 @@ SUB_EVENT = set([
     'state.sls',
 ])
 
-TAGEND = '\n\n'  # long tag delimiter
-TAGPARTER = '/'  # name spaced tag delimiter
+TAGEND = str('\n\n')  # long tag delimiter
+TAGPARTER = str('/')  # name spaced tag delimiter
 SALT = 'salt'  # base prefix for all salt/ events
 # dict map of namespaced base tag prefixes for salt events
 TAGS = {
@@ -730,13 +730,10 @@ class SaltEvent(object):
             use_bin_type=six.PY3
         )
         log.debug('Sending event: tag = %s; data = %s', tag, data)
-        if six.PY2:
-            event = '{0}{1}{2}'.format(tag, tagend, serialized_data)
-        else:
-            event = b''.join([
-                salt.utils.stringutils.to_bytes(tag),
-                salt.utils.stringutils.to_bytes(tagend),
-                serialized_data])
+        event = b''.join([
+            salt.utils.stringutils.to_bytes(tag),
+            salt.utils.stringutils.to_bytes(tagend),
+            serialized_data])
         msg = salt.utils.stringutils.to_bytes(event, 'utf-8')
         if self._run_io_loop_sync:
             with salt.utils.async.current_ioloop(self.io_loop):


### PR DESCRIPTION
This PR includes 2 fixes:

1. Fix error with event unpacking introduced in db41d9b
2. Fix breakage affecting pyzmq < 14.3.0 introduced in 00f31bf

It also makes a tweak to a log message which was not showing the correct information for the name of the engine that failed to initialize.