### PR TITLE
Improve robustness of daemons unit tests

### DIFF
--- a/tests/unit/test_daemons.py
+++ b/tests/unit/test_daemons.py
@@ -5,6 +5,7 @@
 
 # Import python libs
 from __future__ import absolute_import, print_function, unicode_literals
+import logging
 import multiprocessing
 
 # Import Salt Testing libs
@@ -14,6 +15,8 @@ from tests.support.mixins import SaltClientTestCaseMixin
 
 # Import Salt libs
 import salt.cli.daemons as daemons
+
+log = logging.getLogger(__name__)
 
 
 class LoggerMock(object):
@@ -34,7 +37,7 @@ class LoggerMock(object):
 
         :return:
         '''
-        self.messages = list()
+        self.messages = []
 
     def info(self, message, *args, **kwargs):
         '''
@@ -86,22 +89,26 @@ def _master_exec_test(child_pipe):
 
     _logger = LoggerMock()
     ret = True
-    with patch('salt.cli.daemons.check_user', MagicMock(return_value=True)):
-        with patch('salt.cli.daemons.log', _logger):
-            for alg in ['md5', 'sha1']:
-                _create_master().start()
-                ret = ret and _logger.messages \
-                      and _logger.has_message('Do not use {alg}'.format(alg=alg),
-                                              log_type='warning')
+    try:
+        with patch('salt.cli.daemons.check_user', MagicMock(return_value=True)):
+            with patch('salt.cli.daemons.log', _logger):
+                for alg in ['md5', 'sha1']:
+                    _create_master().start()
+                    ret = ret and _logger.has_message(
+                        'Do not use {alg}'.format(alg=alg),
+                        log_type='warning')
 
-            _logger.reset()
+                _logger.reset()
 
-            for alg in ['sha224', 'sha256', 'sha384', 'sha512']:
-                _create_master().start()
-                ret = ret and _logger.messages \
-                      and not _logger.has_message('Do not use ')
-            child_pipe.send(ret)
-            child_pipe.close()
+                for alg in ['sha224', 'sha256', 'sha384', 'sha512']:
+                    _create_master().start()
+                    ret = ret and _logger.messages \
+                          and not _logger.has_message('Do not use ')
+    except Exception:
+        log.exception('Exception raised in master daemon unit test')
+        ret = False
+    child_pipe.send(ret)
+    child_pipe.close()
 
 
 def _minion_exec_test(child_pipe):
@@ -119,23 +126,26 @@ def _minion_exec_test(child_pipe):
         return obj
 
     ret = True
-    _logger = LoggerMock()
-    with patch('salt.cli.daemons.check_user', MagicMock(return_value=True)):
-        with patch('salt.cli.daemons.log', _logger):
-            for alg in ['md5', 'sha1']:
-                _create_minion().start()
-                ret = ret and _logger.messages \
-                      and _logger.has_message('Do not use {alg}'.format(alg=alg),
-                                              log_type='warning')
-            _logger.reset()
+    try:
+        _logger = LoggerMock()
+        with patch('salt.cli.daemons.check_user', MagicMock(return_value=True)):
+            with patch('salt.cli.daemons.log', _logger):
+                for alg in ['md5', 'sha1']:
+                    _create_minion().start()
+                    ret = ret and _logger.has_message(
+                        'Do not use {alg}'.format(alg=alg),
+                        log_type='warning')
+                _logger.reset()
 
-            for alg in ['sha224', 'sha256', 'sha384', 'sha512']:
-                _create_minion().start()
-                ret = ret and _logger.messages \
-                      and not _logger.has_message('Do not use ')
-
-        child_pipe.send(ret)
-        child_pipe.close()
+                for alg in ['sha224', 'sha256', 'sha384', 'sha512']:
+                    _create_minion().start()
+                    ret = ret and _logger.messages \
+                          and not _logger.has_message('Do not use ')
+    except Exception:
+        log.exception('Exception raised in minion daemon unit test')
+        ret = False
+    child_pipe.send(ret)
+    child_pipe.close()
 
 
 def _proxy_exec_test(child_pipe):
@@ -153,21 +163,25 @@ def _proxy_exec_test(child_pipe):
         return obj
 
     ret = True
-    _logger = LoggerMock()
-    with patch('salt.cli.daemons.check_user', MagicMock(return_value=True)):
-        with patch('salt.cli.daemons.log', _logger):
-            for alg in ['md5', 'sha1']:
-                _create_proxy_minion().start()
-                ret = ret and _logger.messages \
-                      and _logger.has_message('Do not use {alg}'.format(alg=alg),
-                                              log_type='warning')
+    try:
+        _logger = LoggerMock()
+        with patch('salt.cli.daemons.check_user', MagicMock(return_value=True)):
+            with patch('salt.cli.daemons.log', _logger):
+                for alg in ['md5', 'sha1']:
+                    _create_proxy_minion().start()
+                    ret = ret and _logger.has_message(
+                        'Do not use {alg}'.format(alg=alg),
+                        log_type='warning')
 
-            _logger.reset()
+                _logger.reset()
 
-            for alg in ['sha224', 'sha256', 'sha384', 'sha512']:
-                _create_proxy_minion().start()
-                ret = ret and _logger.messages \
-                      and not _logger.has_message('Do not use ')
+                for alg in ['sha224', 'sha256', 'sha384', 'sha512']:
+                    _create_proxy_minion().start()
+                    ret = ret and _logger.messages \
+                          and not _logger.has_message('Do not use ')
+    except Exception:
+        log.exception('Exception raised in proxy daemon unit test')
+        ret = False
     child_pipe.send(ret)
     child_pipe.close()
 
@@ -186,22 +200,25 @@ def _syndic_exec_test(child_pipe):
         return obj
 
     ret = True
-    _logger = LoggerMock()
-    with patch('salt.cli.daemons.check_user', MagicMock(return_value=True)):
-        with patch('salt.cli.daemons.log', _logger):
-            for alg in ['md5', 'sha1']:
-                _create_syndic().start()
-                ret = ret and _logger.messages \
-                      and _logger.has_message('Do not use {alg}'.format(alg=alg),
-                                              log_type='warning')
+    try:
+        _logger = LoggerMock()
+        with patch('salt.cli.daemons.check_user', MagicMock(return_value=True)):
+            with patch('salt.cli.daemons.log', _logger):
+                for alg in ['md5', 'sha1']:
+                    _create_syndic().start()
+                    ret = ret and _logger.has_message(
+                        'Do not use {alg}'.format(alg=alg),
+                        log_type='warning')
 
-            _logger.reset()
+                _logger.reset()
 
-            for alg in ['sha224', 'sha256', 'sha384', 'sha512']:
-                _create_syndic().start()
-                ret = ret and _logger.messages \
-                      and not _logger.has_message('Do not use ')
-
+                for alg in ['sha224', 'sha256', 'sha384', 'sha512']:
+                    _create_syndic().start()
+                    ret = ret and _logger.messages \
+                          and not _logger.has_message('Do not use ')
+    except Exception:
+        log.exception('Exception raised in syndic daemon unit test')
+        ret = False
     child_pipe.send(ret)
     child_pipe.close()
 


### PR DESCRIPTION
https://github.com/saltstack/salt/pull/45583 was opened to fix some test failures in the daemons tests. However, with the way that the tests were written, `_multiproc_exec_test` was waiting for a response from the child function, which would never come due to the error raised during the test. This means that any exception raised during the test would stop the test suite dead in its tracks, causing it to eventually end in a timeout.

This commit addresses this design flaw by wrapping the test logic in a try/except, and ensuring that we always return a response from the child function. The tests will instead log the exception and gracefully fail the test, allowing whomever troubleshoots the failures to consult the salt-runtests.log to see the traceback.