### PR TITLE
update  MasterPillarUtil get_minion_grains method

### DIFF
--- a/salt/utils/master.py
+++ b/salt/utils/master.py
@@ -300,7 +300,7 @@ class MasterPillarUtil(object):
         cached minion data on the master, or by fetching the grains
         directly on the minion.
 
-        By default, this function tries hard to get the pillar data:
+        By default, this function tries hard to get the grains data:
             - Try to get the cached minion grains if the master
                 has minion_data_cache: True
             - If the grains data for the minion is cached, use it.

--- a/salt/utils/master.py
+++ b/salt/utils/master.py
@@ -309,7 +309,7 @@ class MasterPillarUtil(object):
         '''
         minion_grains = {}
         minion_ids = self._tgt_to_list()
-        if not minios_ids:
+        if not minion_ids:
             return {}
         if any(arg for arg in [self.use_cached_grains, self.grains_fallback]):
             log.debug('Getting cached minion data.')

--- a/salt/utils/master.py
+++ b/salt/utils/master.py
@@ -309,6 +309,8 @@ class MasterPillarUtil(object):
         '''
         minion_grains = {}
         minion_ids = self._tgt_to_list()
+        if not minios_ids:
+            return {}
         if any(arg for arg in [self.use_cached_grains, self.grains_fallback]):
             log.debug('Getting cached minion data.')
             cached_minion_grains, cached_minion_pillars = self._get_cached_minion_data(*minion_ids)


### PR DESCRIPTION
### What does this PR do?
update MasterPillarUtil get_minion_grains method behavior. If there target list is empty return empty dict

### What issues does this PR fix or reference?
 #45489
### Previous Behavior
```
# salt-run cache.grains --out=json tgt="issue" tgt_type="glob" | jq keys
[
  "lab-deb8-cloud03",
  "lab-deb9-cloud01",
  "lab-deb9-cloud02",
  "lab-smaster",
  "m-test03"
]
```

### New Behavior
```
# salt-run cache.grains --out=json tgt="issue" tgt_type="glob" | jq keys
[]
```
### Tests written?

No

### Commits signed with GPG?

Yes
