### PR TITLE
change webhook headers to dict

### DIFF
--- a/salt/engines/webhook.py
+++ b/salt/engines/webhook.py
@@ -70,7 +70,10 @@ def start(address=None, port=5000, ssl_crt=None, ssl_key=None):
         def post(self, tag):  # pylint: disable=arguments-differ
             body = self.request.body
             headers = self.request.headers
-            payload = {'headers': headers, 'body': body}
+            payload = {
+                'headers': headers if isinstance(headers, dict) else dict(headers),
+                'body': body,
+            }
             fire('salt/engines/hook/' + tag, payload)
 
     application = tornado.web.Application([(r"/(.*)", WebHook), ])


### PR DESCRIPTION
### What does this PR do?
Starting with Tornado 4.5.0, the headers are their own object, make sure this
is a dictionary.

### What issues does this PR fix or reference?
discovered in salt community slack
Fixes #45590

### Tests written?

No

### Commits signed with GPG?

Yes