### PR TITLE
Fix bug affecting salt-ssh when root_dir differs from the default

### DIFF
--- a/salt/client/ssh/state.py
+++ b/salt/client/ssh/state.py
@@ -205,7 +205,7 @@ def prep_trans_tar(opts, file_client, chunks, file_refs, pillar=None, id_=None):
             os.makedirs(env_root)
         for ref in file_refs[saltenv]:
             for name in ref:
-                short = salt.utils.url.parse(name)[0]
+                short = salt.utils.url.parse(name)[0].lstrip('/')
                 cache_dest = os.path.join(cache_dest_root, short)
                 try:
                     path = file_client.cache_file(name, saltenv, cachedir=cachedir)


### PR DESCRIPTION
H/T https://github.com/saltstack/salt/issues/44957#issuecomment-356122811

The join on the line below will cause the path to be incorrect due to leading slashes.