### PR TITLE
Replace all usage of six.b

### DIFF
--- a/salt/fileclient.py
+++ b/salt/fileclient.py
@@ -736,7 +736,7 @@ class Client(object):
             if no_cache:
                 if write_body[2]:
                     return ''.join(result)
-                return six.b('').join(result)
+                return b''.join(result)
             else:
                 destfp.close()
                 destfp = None

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1452,7 +1452,7 @@ def os_data():
                             "Unable to fetch data from /proc/1/cmdline"
                         )
                     if init_bin is not None and init_bin.endswith('bin/init'):
-                        supported_inits = (six.b(str('upstart')), six.b(str('sysvinit')), six.b(str('systemd')))  # future lint: disable=blacklisted-function
+                        supported_inits = (b'upstart', b'sysvinit', b'systemd')
                         edge_len = max(len(x) for x in supported_inits) - 1
                         try:
                             buf_size = __opts__['file_buffer_size']
@@ -1462,7 +1462,7 @@ def os_data():
                         try:
                             with salt.utils.files.fopen(init_bin, 'rb') as fp_:
                                 buf = True
-                                edge = six.b(str())  # future lint: disable=blacklisted-function
+                                edge = b''
                                 buf = fp_.read(buf_size).lower()
                                 while buf:
                                     buf = edge + buf
@@ -1471,7 +1471,7 @@ def os_data():
                                             if six.PY3:
                                                 item = item.decode('utf-8')
                                             grains['init'] = item
-                                            buf = six.b(str())  # future lint: disable=blacklisted-function
+                                            buf = b''
                                             break
                                     edge = buf[-edge_len:]
                                     buf = fp_.read(buf_size).lower()

--- a/salt/master.py
+++ b/salt/master.py
@@ -80,6 +80,7 @@ import salt.utils.platform
 import salt.utils.process
 import salt.utils.schedule
 import salt.utils.ssdp
+import salt.utils.stringutils
 import salt.utils.user
 import salt.utils.verify
 import salt.utils.zeromq
@@ -301,7 +302,7 @@ class Maintenance(salt.utils.process.SignalHandlingMultiprocessingProcess):
             for secret_key, secret_map in six.iteritems(SMaster.secrets):
                 # should be unnecessary-- since no one else should be modifying
                 with secret_map['secret'].get_lock():
-                    secret_map['secret'].value = six.b(secret_map['reload']())
+                    secret_map['secret'].value = salt.utils.stringutils.to_bytes(secret_map['reload']())
                 self.event.fire_event({'rotate_{0}_key'.format(secret_key): True}, tag='key')
             self.rotate = now
             if self.opts.get('ping_on_rotate'):
@@ -664,7 +665,9 @@ class Master(SMaster):
             SMaster.secrets['aes'] = {
                 'secret': multiprocessing.Array(
                     ctypes.c_char,
-                    six.b(salt.crypt.Crypticle.generate_key_string())
+                    salt.utils.stringutils.to_bytes(
+                        salt.crypt.Crypticle.generate_key_string()
+                    )
                 ),
                 'reload': salt.crypt.Crypticle.generate_key_string
             }

--- a/salt/modules/ssh.py
+++ b/salt/modules/ssh.py
@@ -774,8 +774,8 @@ def set_auth_key(
                         # File isn't empty, check if last byte is a newline
                         # If not, add one
                         _fh.seek(-1, 2)
-                        if _fh.read(1) != six.b('\n'):
-                            _fh.write(six.b('\n'))
+                        if _fh.read(1) != b'\n':
+                            _fh.write(b'\n')
                 if six.PY3:
                     auth_line = auth_line.encode(__salt_system_encoding__)
                 _fh.write(auth_line)

--- a/salt/modules/tls.py
+++ b/salt/modules/tls.py
@@ -227,7 +227,9 @@ def _new_serial(ca_name):
     '''
     hashnum = int(
         binascii.hexlify(
-            six.b('{0}_{1}'.format(_microtime(), os.urandom(5)))
+            salt.utils.stringutils.to_bytes(
+                '{0}_{1}'.format(_microtime(), os.urandom(5))
+            )
         ),
         16
     )
@@ -710,17 +712,17 @@ def create_ca(ca_name,
     if X509_EXT_ENABLED:
         ca.add_extensions([
             OpenSSL.crypto.X509Extension(
-                six.b('basicConstraints'), True, six.b('CA:TRUE, pathlen:0')),
+                b'basicConstraints', True, b'CA:TRUE, pathlen:0'),
             OpenSSL.crypto.X509Extension(
-                six.b('keyUsage'), True, six.b('keyCertSign, cRLSign')),
+                b'keyUsage', True, b'keyCertSign, cRLSign'),
             OpenSSL.crypto.X509Extension(
-                six.b('subjectKeyIdentifier'), False, six.b('hash'), subject=ca)])
+                b'subjectKeyIdentifier', False, b'hash', subject=ca)])
 
         ca.add_extensions([
             OpenSSL.crypto.X509Extension(
-                six.b('authorityKeyIdentifier'),
+                b'authorityKeyIdentifier',
                 False,
-                six.b('issuer:always,keyid:always'),
+                b'issuer:always,keyid:always',
                 issuer=ca)])
     ca.sign(key, digest)
 
@@ -1027,7 +1029,7 @@ def create_csr(ca_name,
 
             extension_adds.append(
                 OpenSSL.crypto.X509Extension(
-                    six.b('subjectAltName'), False, six.b(", ".join(subjectAltName))))
+                    b'subjectAltName', False, b', '.join(subjectAltName)))
         else:
             raise ValueError('subjectAltName cannot be set as X509 '
                              'extensions are not supported in pyOpenSSL '

--- a/salt/states/boto_apigateway.py
+++ b/salt/states/boto_apigateway.py
@@ -440,7 +440,10 @@ def _gen_md5_filehash(fname, *args):
             _hash.update(chunk)
 
     for extra_arg in args:
-        _hash.update(six.b(str(extra_arg)))  # future lint: disable=blacklisted-function
+        try:
+            _hash.update(salt.utils.stringutils.to_bytes(extra_arg))
+        except TypeError:
+            _hash.update(salt.utils.stringutils.to_bytes(six.text_type(extra_arg)))
     return _hash.hexdigest()
 
 

--- a/salt/transport/mixins/auth.py
+++ b/salt/transport/mixins/auth.py
@@ -78,8 +78,10 @@ class AESReqServerMixin(object):
             # 'tcp_test.py' and 'zeromq_test.py'. Fix that. In normal
             # cases, 'aes' is already set in the secrets.
             salt.master.SMaster.secrets['aes'] = {
-                'secret': multiprocessing.Array(ctypes.c_char,
-                              six.b(salt.crypt.Crypticle.generate_key_string())),
+                'secret': multiprocessing.Array(
+                    ctypes.c_char,
+                    salt.utils.stringutils.to_bytes(salt.crypt.Crypticle.generate_key_string())
+                ),
                 'reload': salt.crypt.Crypticle.generate_key_string
             }
 

--- a/salt/transport/zeromq.py
+++ b/salt/transport/zeromq.py
@@ -339,7 +339,7 @@ class AsyncZeroMQPubChannel(salt.transport.mixins.auth.AESPubClientMixin, salt.t
             zmq.eventloop.ioloop.install()
             self.io_loop = tornado.ioloop.IOLoop.current()
 
-        self.hexid = hashlib.sha1(six.b(self.opts['id'])).hexdigest()
+        self.hexid = hashlib.sha1(salt.utils.stringutils.to_bytes(self.opts['id'])).hexdigest()
 
         self.auth = salt.crypt.AsyncAuth(self.opts, io_loop=self.io_loop)
 

--- a/salt/utils/gitfs.py
+++ b/salt/utils/gitfs.py
@@ -746,7 +746,7 @@ class GitProvider(object):
                           os.O_CREAT | os.O_EXCL | os.O_WRONLY)
             with os.fdopen(fh_, 'wb'):
                 # Write the lock file and close the filehandle
-                os.write(fh_, six.b(six.text_type(os.getpid())))
+                os.write(fh_, salt.utils.stringutils.to_bytes(six.text_type(os.getpid())))
         except (OSError, IOError) as exc:
             if exc.errno == errno.EEXIST:
                 with salt.utils.files.fopen(self._get_lock_file(lock_type), 'r') as fd_:

--- a/salt/utils/minion.py
+++ b/salt/utils/minion.py
@@ -15,9 +15,6 @@ import salt.utils.files
 import salt.utils.platform
 import salt.utils.process
 
-# Import 3rd-party libs
-from salt.ext import six
-
 log = logging.getLogger(__name__)
 
 
@@ -143,7 +140,7 @@ def _check_cmdline(data):
         return False
     try:
         with salt.utils.files.fopen(path, 'rb') as fp_:
-            if six.b('salt') in fp_.read():
+            if b'salt' in fp_.read():
                 return True
     except (OSError, IOError):
         return False

--- a/salt/utils/rsax931.py
+++ b/salt/utils/rsax931.py
@@ -14,7 +14,6 @@ import salt.utils.platform
 import salt.utils.stringutils
 
 # Import 3rd-party libs
-from salt.ext import six
 from ctypes import cdll, c_char_p, c_int, c_void_p, pointer, create_string_buffer
 from ctypes.util import find_library
 
@@ -137,7 +136,7 @@ class RSAX931Verifier(object):
         :param str pubdata: The RSA public key in PEM format
         '''
         pubdata = salt.utils.stringutils.to_bytes(pubdata, 'ascii')
-        pubdata = pubdata.replace(six.b('RSA '), six.b(''))
+        pubdata = pubdata.replace(b'RSA ', b'')
         self._bio = libcrypto.BIO_new_mem_buf(pubdata, len(pubdata))
         self._rsa = c_void_p(libcrypto.RSA_new())
         if not libcrypto.PEM_read_bio_RSA_PUBKEY(self._bio, pointer(self._rsa), None, None):

--- a/tests/integration/minion/test_pillar.py
+++ b/tests/integration/minion/test_pillar.py
@@ -19,12 +19,10 @@ from tests.support.paths import TMP, TMP_CONF_DIR
 from tests.support.unit import skipIf
 from tests.support.helpers import requires_system_grains
 
-# Import 3rd-party libs
-from salt.ext import six
-
 # Import salt libs
 import salt.utils.files
 import salt.utils.path
+import salt.utils.stringutils
 import salt.utils.yaml
 import salt.pillar as pillar
 
@@ -223,7 +221,7 @@ class DecryptGPGPillarTest(ModuleCase):
                                       stdin=subprocess.PIPE,
                                       stdout=subprocess.PIPE,
                                       stderr=subprocess.STDOUT,
-                                      shell=False).communicate(input=six.b(TEST_KEY))[0]
+                                      shell=False).communicate(input=salt.utils.stringutils.to_bytes(TEST_KEY))[0]
             log.debug('Result:\n%s', output)
 
             os.makedirs(PILLAR_BASE)
@@ -245,7 +243,7 @@ class DecryptGPGPillarTest(ModuleCase):
                                       stdin=subprocess.PIPE,
                                       stdout=subprocess.PIPE,
                                       stderr=subprocess.STDOUT,
-                                      shell=False).communicate(input=six.b('KILLAGENT'))[0]
+                                      shell=False).communicate(input=b'KILLAGENT')[0]
             log.debug('Result:\n%s', output)
         except OSError:
             log.debug('No need to kill: old gnupg doesn\'t start the agent.')

--- a/tests/integration/states/test_file.py
+++ b/tests/integration/states/test_file.py
@@ -428,7 +428,7 @@ class FileTest(ModuleCase, SaltReturnAssertsMixin):
         '''
         name = os.path.join(TMP, 'grail_not_scene33')
         with salt.utils.files.fopen(name, 'wb') as fp_:
-            fp_.write(six.b('test_managed_show_changes_false\n'))
+            fp_.write(b'test_managed_show_changes_false\n')
 
         ret = self.run_state(
             'file.managed', name=name, source='salt://grail/scene33',

--- a/tests/integration/states/test_pip.py
+++ b/tests/integration/states/test_pip.py
@@ -296,7 +296,7 @@ class PipStateTest(ModuleCase, SaltReturnAssertsMixin):
             RUNTIME_VARS.TMP_STATE_TREE, 'issue-6912-requirements.txt'
         )
         with salt.utils.files.fopen(req_filename, 'wb') as reqf:
-            reqf.write(salt.utils.stringutils.to_bytes('pep8\n'))
+            reqf.write(b'pep8\n')
 
         try:
             ret = self.run_state(
@@ -363,7 +363,7 @@ class PipStateTest(ModuleCase, SaltReturnAssertsMixin):
             RUNTIME_VARS.TMP_STATE_TREE, 'issue-6912-requirements.txt'
         )
         with salt.utils.files.fopen(req_filename, 'wb') as reqf:
-            reqf.write(salt.utils.stringutils.to_bytes('pep8\n'))
+            reqf.write(b'pep8\n')
 
         try:
             ret = self.run_state(
@@ -458,7 +458,7 @@ class PipStateTest(ModuleCase, SaltReturnAssertsMixin):
             RUNTIME_VARS.TMP_PRODENV_STATE_TREE, 'prod-env-requirements.txt'
         )
         with salt.utils.files.fopen(requirements_file, 'wb') as reqf:
-            reqf.write(salt.utils.stringutils.to_bytes('pep8\n'))
+            reqf.write(b'pep8\n')
 
         try:
             self.run_function('virtualenv.create', [venv_dir])

--- a/tests/support/cptestcase.py
+++ b/tests/support/cptestcase.py
@@ -119,7 +119,7 @@ class BaseCherryPyTestCase(TestCase):
                 fd.close()
                 fd = None
 
-        if response.output_status.startswith(six.b('500')):
+        if response.output_status.startswith(b'500'):
             response_body = response.collapse_body()
             if six.PY3:
                 response_body = response_body.decode(__salt_system_encoding__)

--- a/tests/support/mock.py
+++ b/tests/support/mock.py
@@ -120,7 +120,7 @@ def _iterate_read_data(read_data):
     # Retrieve lines from read_data via a generator so that separate calls to
     # readline, read, and readlines are properly interleaved
     if six.PY3 and isinstance(read_data, six.binary_type):
-        data_as_list = ['{0}\n'.format(l.decode(__salt_system_encoding__)) for l in read_data.split(six.b('\n'))]
+        data_as_list = ['{0}\n'.format(l.decode(__salt_system_encoding__)) for l in read_data.split(b'\n')]
     else:
         data_as_list = ['{0}\n'.format(l) for l in read_data.split('\n')]
 

--- a/tests/unit/cache/test_localfs.py
+++ b/tests/unit/cache/test_localfs.py
@@ -25,9 +25,6 @@ import salt.utils.files
 import salt.cache.localfs as localfs
 from salt.exceptions import SaltCacheError
 
-# Import 3rd-party libs
-from salt.ext import six
-
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
 class LocalFSTest(TestCase, LoaderModuleMockMixin):
@@ -95,7 +92,7 @@ class LocalFSTest(TestCase, LoaderModuleMockMixin):
         # Read in the contents of the key.p file and assert "payload data" was written
         with salt.utils.files.fopen(tmp_dir + '/bank/key.p', 'rb') as fh_:
             for line in fh_:
-                self.assertIn(six.b(str('payload data')), line)  # future lint: disable=blacklisted-function
+                self.assertIn(b'payload data', line)
 
     # 'fetch' function tests: 3
 

--- a/tests/unit/utils/vmware/test_connection.py
+++ b/tests/unit/utils/vmware/test_connection.py
@@ -21,8 +21,6 @@ import salt.exceptions as excs
 
 # Import Salt libraries
 import salt.utils.vmware
-# Import Third Party Libs
-from salt.ext import six
 
 try:
     from pyVmomi import vim, vmodl
@@ -95,7 +93,7 @@ class GssapiTokenTest(TestCase):
             ret = salt.utils.vmware.get_gssapi_token('principal', 'host',
                                                      'domain')
             self.assertEqual(mock_context.return_value.step.called, 1)
-            self.assertEqual(ret, base64.b64encode(six.b('out_token')))
+            self.assertEqual(ret, base64.b64encode(b'out_token'))
 
     @skipIf(not HAS_GSSAPI, 'The \'gssapi\' library is missing')
     def test_out_token_undefined(self):


### PR DESCRIPTION
It can't be trusted to produce bytes, it returns unicode when a unicode string is passed, so unicode_literals breaks it.

```python
>>> from salt.ext import six
>>> six.b(u'I am six.b, and I am a damn dirty liar.')
u'I am six.b, and I am a damn dirty liar.'
```