### PR TITLE
Fix salt.utils.path.os_walk for certain Python 2 versions

### DIFF
--- a/salt/fileclient.py
+++ b/salt/fileclient.py
@@ -24,6 +24,7 @@ import salt.loader
 import salt.payload
 import salt.transport
 import salt.fileserver
+import salt.utils.data
 import salt.utils.files
 import salt.utils.gzip_util
 import salt.utils.hashutils
@@ -359,13 +360,16 @@ class Client(object):
                 )
                 return states
             for path in self.opts['file_roots'][saltenv]:
-                for root, dirs, files in salt.utils.path.os_walk(path, topdown=True):
+                for root, dirs, files in os.walk(path, topdown=True):  # future lint: disable=blacklisted-function
+                    root = salt.utils.data.decode(root)
+                    files = salt.utils.data.decode(files)
                     log.debug(
                         'Searching for states in dirs %s and files %s',
-                        dirs, files
+                        salt.utils.data.decode(dirs), files
                     )
                     if not [filename.endswith('.sls') for filename in files]:
-                        #  Use shallow copy so we don't disturb the memory used by os.walk. Otherwise this breaks!
+                        #  Use shallow copy so we don't disturb the memory used
+                        #  by os.walk. Otherwise this breaks!
                         del dirs[:]
                     else:
                         for found_file in files:

--- a/salt/utils/path.py
+++ b/salt/utils/path.py
@@ -408,11 +408,8 @@ def safe_path(path, allow_path=None):
 
 def os_walk(top, *args, **kwargs):
     '''
-    This is a helper to ensure that we get unicode paths when walking a
-    filesystem. The reason for this is that when using os.walk, the paths in
-    the generator which is returned are all the same type as the top directory
-    passed in. This can cause problems when a str path is passed and the
-    filesystem underneath that path contains files with unicode characters in
-    the filename.
+    This is a helper than ensures that all paths returned from os.walk are
+    unicode.
     '''
-    return os.walk(salt.utils.stringutils.to_unicode(top), *args, **kwargs)
+    for item in os.walk(top, *args, **kwargs):
+        yield salt.utils.data.decode(item, preserve_tuples=True)

--- a/tests/unit/fileserver/test_roots.py
+++ b/tests/unit/fileserver/test_roots.py
@@ -187,9 +187,12 @@ class RootsLimitTraversalTest(TestCase, AdaptedConfigurationTestCaseMixin):
     def test_limit_traversal(self):
         '''
         1) Set up a deep directory structure
-        2) Enable the configuration option for 'limit_directory_traversal'
-        3) Ensure that we can find SLS files in a directory so long as there is an SLS file in a directory above.
-        4) Ensure that we cannot find an SLS file in a directory that does not have an SLS file in a directory above.
+        2) Enable the configuration option 'fileserver_limit_traversal'
+        3) Ensure that we can find SLS files in a directory so long as there is
+           an SLS file in a directory above.
+        4) Ensure that we cannot find an SLS file in a directory that does not
+           have an SLS file in a directory above.
+
         '''
         file_client_opts = self.get_temp_config('master')
         file_client_opts['fileserver_limit_traversal'] = True


### PR DESCRIPTION
This helper was designed to ensure that the paths returned were all
unicode types, but on a couple platforms having the path be a unicode
type causes a traceback deep in the stdlib within posixpath.

To work around this, this commit makes the helper a generator that
simply decodes each tuple returned from os.walk as we iterate.