### PR TITLE
[2017.7] Fixing test_mac_user_enable_auto_login

### DIFF
--- a/tests/integration/modules/test_mac_user.py
+++ b/tests/integration/modules/test_mac_user.py
@@ -173,7 +173,7 @@ class MacUserModuleTest(ModuleCase):
             self.assertTrue(os.path.exists('/etc/kcpassword'))
 
             # Are the contents of the file correct
-            test_data = b'.\xf8\'B\xa0\xd9\xad\x8b\xcd\xcdl'
+            test_data = b".\xc3\xb8'B\xc2\xa0\xc3\x99\xc2\xad\xc2\x8b\xc3\x8d\xc3\x8dl"
             with salt.utils.fopen('/etc/kcpassword', 'rb') as f:
                 file_data = f.read()
             self.assertEqual(test_data, file_data)


### PR DESCRIPTION
### What does this PR do?
Fixing integration.modules.test_mac_user.MacUserModuleTest.test_mac_user_enable_auto_login

### What issues does this PR fix or reference?
N/A

### Previous Behavior
integration.modules.test_mac_user.MacUserModuleTest.test_mac_user_enable_auto_login was failing.

### New Behavior
integration.modules.test_mac_user.MacUserModuleTest.test_mac_user_enable_auto_login runs as expected.

### Tests written?
No.  But existing tests now run as expected.

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
