### PR TITLE
salt.utils.json: only encode data on PY2

### DIFF
--- a/salt/utils/json.py
+++ b/salt/utils/json.py
@@ -88,11 +88,13 @@ def dump(obj, fp, **kwargs):
     '''
     .. versionadded:: Oxygen
 
-    Wraps json.dump and encodes the result to the system encoding. Also assumes
-    that ensure_ascii is False (unless explicitly passed as True) for unicode
-    compatibility. Note that setting it to True will mess up any unicode
-    characters, as they will be dumped as the string literal version of the
-    unicode code point.
+    Wraps json.dump, and assumes that ensure_ascii is False (unless explicitly
+    passed as True) for unicode compatibility. Note that setting it to True
+    will mess up any unicode characters, as they will be dumped as the string
+    literal version of the unicode code point.
+
+    On Python 2, encodes the result to a str since json.dump does not want
+    unicode types.
 
     You can pass an alternate json module (loaded via import_json() above)
     using the _json_module argument)
@@ -100,7 +102,8 @@ def dump(obj, fp, **kwargs):
     json_module = kwargs.pop('_json_module', json)
     if 'ensure_ascii' not in kwargs:
         kwargs['ensure_ascii'] = False
-    obj = salt.utils.data.encode(obj)
+    if six.PY2:
+        obj = salt.utils.data.encode(obj)
     return json.dump(obj, fp, **kwargs)  # future lint: blacklisted-function
 
 
@@ -108,11 +111,13 @@ def dumps(obj, **kwargs):
     '''
     .. versionadded:: Oxygen
 
-    Wraps json.dumps and encodes the result to the system encoding. Also
-    assumes that ensure_ascii is False (unless explicitly passed as True) for
-    unicode compatibility. Note that setting it to True will mess up any
-    unicode characters, as they will be dumped as the string literal version of
-    the unicode code point.
+    Wraps json.dumps, and assumes that ensure_ascii is False (unless explicitly
+    passed as True) for unicode compatibility. Note that setting it to True
+    will mess up any unicode characters, as they will be dumped as the string
+    literal version of the unicode code point.
+
+    On Python 2, encodes the result to a str since json.dumps does not want
+    unicode types.
 
     You can pass an alternate json module (loaded via import_json() above)
     using the _json_module argument)
@@ -121,5 +126,6 @@ def dumps(obj, **kwargs):
     json_module = kwargs.pop('_json_module', json)
     if 'ensure_ascii' not in kwargs:
         kwargs['ensure_ascii'] = False
-    obj = salt.utils.data.encode(obj)
+    if six.PY2:
+        obj = salt.utils.data.encode(obj)
     return json_module.dumps(obj, **kwargs)  # future lint: blacklisted-function

--- a/tests/unit/utils/test_json.py
+++ b/tests/unit/utils/test_json.py
@@ -2,16 +2,72 @@
 '''
 Tests for salt.utils.json
 '''
-
 # Import Python libs
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
+import errno
+import functools
+import os
+import textwrap
 
-# Import Salt libs
-import salt.utils.json
+# Import Salt Testing libs
+from tests.support.paths import TMP
 from tests.support.unit import TestCase, LOREM_IPSUM
 
+# Import Salt libs
+import salt.utils.files
+import salt.utils.json
+import salt.utils.stringutils
 
-class JsonTestCase(TestCase):
+
+def with_tempfile(func):
+    '''
+    Generate a temp directory for a test
+    '''
+    @functools.wraps(func)
+    def wrapper(self, *args, **kwargs):
+        temp_file = salt.utils.files.mkstemp(dir=TMP)
+        try:
+            return func(self, temp_file, *args, **kwargs)
+        finally:
+            try:
+                os.remove(temp_file)
+            except OSError as exc:
+                if exc.errno != errno.ENOENT:
+                    raise
+    return wrapper
+
+
+class JSONTestCase(TestCase):
+    data = {
+        'спам': 'яйца',
+        'list': [1, 2, 'three'],
+        'dict': {'subdict': {'спам': 'яйца'}},
+        'True': False,
+        'float': 1.5,
+        'None': None,
+    }
+
+    serialized = salt.utils.stringutils.to_str(
+        '{"None": null, "True": false, "dict": {"subdict": {"спам": "яйца"}}, "float": 1.5, "list": [1, 2, "three"], "спам": "яйца"}'
+    )
+
+    serialized_indent4 = salt.utils.stringutils.to_str(textwrap.dedent('''\
+        {
+            "None": null,
+            "True": false,
+            "dict": {
+                "subdict": {
+                    "спам": "яйца"
+                }
+            },
+            "float": 1.5,
+            "list": [
+                1,
+                2,
+                "three"
+            ],
+            "спам": "яйца"
+        }'''))
 
     def test_find_json(self):
         test_sample_json = '''
@@ -56,3 +112,37 @@ class JsonTestCase(TestCase):
 
         # Test to see if a ValueError is raised if no JSON is passed in
         self.assertRaises(ValueError, salt.utils.json.find_json, LOREM_IPSUM)
+
+    def test_dumps_loads(self):
+        '''
+        Test dumping to and loading from a string
+        '''
+        # Dump with no indentation
+        ret = salt.utils.json.dumps(self.data, sort_keys=True)
+        # Make sure the result is as expected
+        self.assertEqual(ret, self.serialized)
+        # Loading it should be equal to the original data
+        self.assertEqual(salt.utils.json.loads(ret), self.data)
+
+        # Dump with 4 spaces of indentation
+        ret = salt.utils.json.dumps(self.data, sort_keys=True, indent=4)
+        # Make sure the result is as expected. Note that in Python 2, dumping
+        # results in trailing whitespace on lines ending in a comma. So, for a
+        # proper comparison, we will have to run rstrip on each line of the
+        # return and then stitch it back together.
+        ret = str('\n').join([x.rstrip() for x in ret.splitlines()])  # future lint: disable=blacklisted-function
+        self.assertEqual(ret, self.serialized_indent4)
+        # Loading it should be equal to the original data
+        self.assertEqual(salt.utils.json.loads(ret), self.data)
+
+    @with_tempfile
+    def test_dump_load(self, json_out):
+        '''
+        Test dumping to and loading from a file handle
+        '''
+        with salt.utils.files.fopen(json_out, 'w') as fp_:
+            salt.utils.json.dump(self.data, fp_)
+        with salt.utils.files.fopen(json_out, 'r') as fp_:
+            ret = salt.utils.json.load(fp_)
+            # Loading should be equal to the original data
+            self.assertEqual(ret, self.data)


### PR DESCRIPTION
We need a str type in both Python 2 and 3, and encoding produces a bytes type on Python 3. This makes the encoding conditional, only doing so in Python 2.

EDIT: for clarification, I mean that the strings in the data structure being dumped must be `str` in both Python 2 and 3. So this PR will make sure that unicode strings in the data structure being dumped are converted to `str` types.