### PR TITLE
modules.debian_ip: Fix resolv.conf handling

### DIFF
--- a/salt/modules/debian_ip.py
+++ b/salt/modules/debian_ip.py
@@ -2099,7 +2099,8 @@ def build_network_settings(**settings):
 
         # Write /etc/resolv.conf
         if not ('test' in settings and settings['test']):
-            _write_file_network(new_resolv, _DEB_RESOLV_FILE)
+            if not __salt__['file.is_link'](_DEB_RESOLV_FILE):
+                _write_file_network(new_resolv, _DEB_RESOLV_FILE)
 
     #  used for returning the results back
     try:

--- a/salt/modules/debian_ip.py
+++ b/salt/modules/debian_ip.py
@@ -2089,7 +2089,7 @@ def build_network_settings(**settings):
 
         # A search line didn't exist so we'll add one in
         # with the new search domain
-        if not found_search:
+        if not found_search and searchdomain:
             if new_contents[0].startswith('domain'):
                 new_contents.insert(1, 'search {0}\n' . format(searchdomain))
             else:


### PR DESCRIPTION
### What does this PR do?
Don't try to write `/etc/resolv.conf` if it's a symlink.

`resolv.conf` might be runtime-managed by `systemd-resolved`,
`resolvconf` or similar tools, which is indicated by `/etc/resolv.conf`
just being a symlink e.g. to `/run/systemd/resolve/stub-resolv.conf`

Just skip any kind of modifications of `resolv.conf` in those cases, as
this intrudes the domain of those tools and leads to broken resolvers
and causes flip-flopping of the corresponding state.

Furthermore, it ensures no empty `search` entries are written to `resolv.conf`.

### What issues does this PR fix or reference?
None

### Previous Behavior
Using `modules.debian_ip` (e.g. through a `network.hostname` state) caused corruption of DNS resolution through empty `search` entries and modifying `resolv.conf` which might be actually runtime-managed e.g. by `systemd-resolved`.

### New Behavior
- don't touch `/etc/resolv.conf` if it's a symlink
- don't write empty `search` entries to `resolv.conf`

### Tests written?

No

### Commits signed with GPG?

Yes