### PR TITLE
 Fix mac service and pkg tests for 10.13

### DIFF
--- a/tests/integration/modules/test_mac_pkgutil.py
+++ b/tests/integration/modules/test_mac_pkgutil.py
@@ -36,11 +36,16 @@ class MacPkgutilModuleTest(ModuleCase):
         if not salt.utils.which('pkgutil'):
             self.skipTest('Test requires pkgutil binary')
 
+        os_release = self.run_function('grains.get', ['osrelease'])
+        self.pkg_name = 'com.apple.pkg.BaseSystemResources'
+        if int(os_release.split('.')[1]) >= 13 and salt.utils.is_darwin():
+            self.pkg_name = 'com.apple.pkg.iTunesX'
+
     def tearDown(self):
         '''
         Reset to original settings
         '''
-        self.run_function('pkgutil.forget', ['org.macports.MacPorts'])
+        self.run_function('pkgutil.forget', [TEST_PKG_NAME])
         self.run_function('file.remove', ['/opt/local'])
 
     def test_list(self):
@@ -48,7 +53,7 @@ class MacPkgutilModuleTest(ModuleCase):
         Test pkgutil.list
         '''
         self.assertIsInstance(self.run_function('pkgutil.list'), list)
-        self.assertIn('com.apple.pkg.BaseSystemResources',
+        self.assertIn(self.pkg_name,
                       self.run_function('pkgutil.list'))
 
     def test_is_installed(self):
@@ -58,7 +63,7 @@ class MacPkgutilModuleTest(ModuleCase):
         # Test Package is installed
         self.assertTrue(
             self.run_function('pkgutil.is_installed',
-                              ['com.apple.pkg.BaseSystemResources']))
+                              [self.pkg_name]))
 
         # Test Package is not installed
         self.assertFalse(

--- a/tests/integration/modules/test_pkg.py
+++ b/tests/integration/modules/test_pkg.py
@@ -153,7 +153,7 @@ class PkgModuleTest(ModuleCase, SaltReturnAssertsMixin):
             self.assertIn(self.pkg, remove_ret)
 
         if version and isinstance(version, dict):
-            version = version[pkg]
+            version = version[self.pkg]
 
         if version:
             test_remove()

--- a/tests/integration/modules/test_pkg.py
+++ b/tests/integration/modules/test_pkg.py
@@ -28,7 +28,6 @@ class PkgModuleTest(ModuleCase, SaltReturnAssertsMixin):
             self.run_function('pkg.refresh_db')
 
         os_release = self.run_function('grains.get', ['osrelease'])
-        os_grain = self.run_function('grains.item', ['os'])['os']
         self.pkg = 'htop'
 
         if int(os_release.split('.')[1]) >= 13 and salt.utils.is_darwin():

--- a/tests/integration/modules/test_service.py
+++ b/tests/integration/modules/test_service.py
@@ -20,6 +20,7 @@ class ServiceModuleTest(ModuleCase):
         self.service_name = 'cron'
         cmd_name = 'crontab'
         os_family = self.run_function('grains.get', ['os_family'])
+        os_release = self.run_function('grains.get', ['osrelease'])
         if os_family == 'RedHat':
             self.service_name = 'crond'
         elif os_family == 'Arch':
@@ -27,6 +28,8 @@ class ServiceModuleTest(ModuleCase):
             cmd_name = 'systemctl'
         elif os_family == 'MacOS':
             self.service_name = 'org.ntp.ntpd'
+            if int(os_release.split('.')[1]) >= 13:
+                self.service_name = 'com.apple.AirPlayXPCHelper'
 
         if salt.utils.which(cmd_name) is None:
             self.skipTest('{0} is not installed'.format(cmd_name))


### PR DESCRIPTION
Fixes the tests:

integration.modules.test_mac_pkgutil.MacPkgutilModuleTest.test_is_installed
integration.modules.test_mac_pkgutil.MacPkgutilModuleTest.test_list
integration.modules.test_pkg.PkgModuleTest.test_install_remove
integration.modules.test_service.ServiceModuleTest.test_service_status_running

for MacOSX 10.13 