### PR TITLE
Win fix shell info

### DIFF
--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -2750,7 +2750,7 @@ def shell_info(shell, list_modules=False):
                 'Software\\Microsoft\\PowerShell\\{0}'.format(reg_ver),
                 'Install')
             if install_data.get('vtype') == 'REG_DWORD' and \
-                    install_data.get('vdata') == salt.utils.to_unicode(1, 'mbcs'):
+                    install_data.get('vdata') == 1:
                 details = __salt__['reg.list_values'](
                     'HKEY_LOCAL_MACHINE',
                     'Software\\Microsoft\\PowerShell\\{0}\\'

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -2749,9 +2749,8 @@ def shell_info(shell, list_modules=False):
                 'HKEY_LOCAL_MACHINE',
                 'Software\\Microsoft\\PowerShell\\{0}'.format(reg_ver),
                 'Install')
-            if 'vtype' in install_data and \
-                    install_data['vtype'] == 'REG_DWORD' and \
-                    install_data['vdata'] == 1:
+            if install_data.get('vtype') == 'REG_DWORD' and \
+                    install_data.get('vdata') == salt.utils.to_unicode(1, 'mbcs'):
                 details = __salt__['reg.list_values'](
                     'HKEY_LOCAL_MACHINE',
                     'Software\\Microsoft\\PowerShell\\{0}\\'

--- a/salt/modules/reg.py
+++ b/salt/modules/reg.py
@@ -296,9 +296,15 @@ def list_values(hive, key=None, use_32bit_registry=False, include_default=True):
             value = {'hive':   local_hive,
                      'key':    local_key,
                      'vname':  _to_mbcs(vname),
-                     'vdata':  _to_mbcs(vdata),
                      'vtype':  registry.vtype_reverse[vtype],
                      'success': True}
+            # Only convert text types to unicode
+            if vtype == win32con.REG_MULTI_SZ:
+                value['vdata'] = [_to_mbcs(i) for i in vdata]
+            elif vtype in [win32con.REG_SZ, win32con.REG_EXPAND_SZ]:
+                value['vdata'] = _to_mbcs(vdata)
+            else:
+                value['vdata'] = vdata
             values.append(value)
     except pywintypes.error as exc:  # pylint: disable=E0602
         log.debug(exc)

--- a/salt/modules/reg.py
+++ b/salt/modules/reg.py
@@ -372,11 +372,14 @@ def read_value(hive, key, vname=None, use_32bit_registry=False):
             # RegQueryValueEx returns and accepts unicode data
             vdata, vtype = win32api.RegQueryValueEx(handle, local_vname)
             if vdata or vdata in [0, '']:
+                # Only convert text types to unicode
                 ret['vtype'] = registry.vtype_reverse[vtype]
-                if vtype == 7:
+                if vtype == win32con.REG_MULTI_SZ:
                     ret['vdata'] = [_to_mbcs(i) for i in vdata]
-                else:
+                elif vtype in [win32con.REG_SZ, win32con.REG_EXPAND_SZ]:
                     ret['vdata'] = _to_mbcs(vdata)
+                else:
+                    ret['vdata'] = vdata
             else:
                 ret['comment'] = 'Empty Value'
         except WindowsError:  # pylint: disable=E0602


### PR DESCRIPTION
### What does this PR do?
Fixes an issue with `cmd.shell_info` where it wasn't detecting powershell on the system. Probably caused by changes made in https://github.com/saltstack/salt/pull/44193 as all values were being converted to unicode. This fix only converts string values to unicode (`REG_SZ, REG_EXPAND_SZ, REG_MULTI_SZ`)

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/45637

### Tests written?
No

### Commits signed with GPG?
Yes