### PR TITLE
Fix file.symlink backupname with basename path + file.move

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -1411,7 +1411,10 @@ def symlink(
                 __salt__['file.move'](name, backupname)
             except Exception as exc:
                 ret['changes'] = {}
-                log.debug(traceback.format_exc())
+                log.debug(
+                    'Encountered error renaming %s to %s',
+                    name, backupname, exc_info=True
+                )
                 return _error(ret, ('Unable to rename {0} to backup {1} -> '
                                     ': {2}'.format(name, backupname, exc)))
         elif force:

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -1257,6 +1257,9 @@ def symlink(
         renamed to the backupname. If the backupname already
         exists and force is False, the state will fail. Otherwise, the
         backupname will be removed first.
+        An absolute path OR a basename file/directory name must be provided.
+        The latter will be placed relative to the symlink destination's parent
+        directory.
 
     makedirs
         If the location of the symlink does not already have a parent directory
@@ -1388,15 +1391,29 @@ def symlink(
     elif os.path.isfile(name) or os.path.isdir(name):
         # It is not a link, but a file or dir
         if backupname is not None:
+            if not os.path.isabs(backupname):
+                if backupname == os.path.basename(backupname):
+                    backupname = os.path.join(
+                        os.path.dirname(os.path.normpath(name)),
+                        backupname)
+                else:
+                    return _error(ret, (('Backupname must be an absolute path '
+                                         'or a file name: {0}').format(backupname)))
             # Make a backup first
             if os.path.lexists(backupname):
                 if not force:
-                    return _error(ret, ((
-                                            'File exists where the backup target {0} should go'
-                                        ).format(backupname)))
+                    return _error(ret, (('Symlink & backup dest exists and Force not set.'
+                                         ' {0} -> {1} - backup: {2}').format(
+                                             name, target, backupname)))
                 else:
                     __salt__['file.remove'](backupname)
-            os.rename(name, backupname)
+            try:
+                __salt__['file.move'](name, backupname)
+            except Exception as exc:
+                ret['changes'] = {}
+                log.debug(traceback.format_exc())
+                return _error(ret, ('Unable to rename {0} to backup {1} -> '
+                                    ': {2}'.format(name, backupname, exc)))
         elif force:
             # Remove whatever is in the way
             if __salt__['file.is_link'](name):


### PR DESCRIPTION
### What does this PR do?
Updates the salt/states/file.py - file.symlink - function.

Tests if backupname is an absolute path or a single file/dir name.
If it's a single file/dir name it will be placed relative to the parent
directory of the named symlink.

Updated sys.doc to underline that an abspath or single file/dir must be used.

### What issues does this PR fix or reference?
Fixes #45631

### Previous Behavior
A non-absolute path for backupname would be relative to the HOME directory of the user running salt, which is counter-intuitive.

os.rename() in backupname would fail with an exception if the backup target was on another file system.

### New Behavior
backupname must be an absolute path or a single file/dir name. In the latter case the file/dir will be placed relative to the parent dir of the symlink.

Change from os.rename to "file.move" to prevent errors if the backupname
is on another filesystem (relevant to some flavours of *nix) to make for
more consistent behaviour.

### Tests written?

No

Tested locally:
- With backupname as an abspath, single file/dir, relative path (should fail), confirmed expected behaviour.
- With / without force option

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
