### PR TITLE
Add onlyifempty to group.absent

### DIFF
--- a/salt/states/group.py
+++ b/salt/states/group.py
@@ -275,7 +275,7 @@ def present(name,
     return ret
 
 
-def absent(name, onlyifempty=False):
+def absent(name, only_if_empty=False):
     '''
     Ensure that the named group is absent
 
@@ -283,8 +283,8 @@ def absent(name, onlyifempty=False):
         name (str):
             The name of the group to remove
 
-        onlyifempty (bool):
-            If True only delete if there are no members in the group
+        only_if_empty (bool):
+            Delete only if there are no members in the group
 
     Example:
 
@@ -298,8 +298,8 @@ def absent(name, onlyifempty=False):
 
         # Removes the local group `db_admin`, but only if there are no more members
         db_admin:
-          group.absent
-            - onlyifempty: True
+          group.absent:
+            - only_if_empty: True
     '''
     ret = {'name': name,
            'changes': {},
@@ -307,21 +307,21 @@ def absent(name, onlyifempty=False):
            'comment': ''}
     grp_info = __salt__['group.info'](name)
     if grp_info:
-        # Group already exists. Remove the group.
         if __opts__['test']:
-            if onlyifempty and grp_info['members']:
+            if only_if_empty and grp_info['members']:
                 ret['result'] = True
-                ret['comment'] = ('Group {0} will not be removed since members are '
-                                  'present and onlyifempty is set').format(name)
+                ret['comment'] = ('Group {0} would not be removed since members are '
+                                  'present and only_if_empty is set').format(name)
             else:
                 ret['result'] = None
                 ret['comment'] = 'Group {0} is set for removal'.format(name)
             return ret
-        if onlyifempty and grp_info['members']:
-            ret['comment'] = ('Group {0} will not be removed since members are '
-                              'present and onlyifempty is set').format(name)
+        if only_if_empty and grp_info['members']:
+            ret['comment'] = ('Group {0} was not removed since members are '
+                              'present and only_if_empty is set').format(name)
             return ret
         else:
+            # Group exists. Remove the group.
             ret['result'] = __salt__['group.delete'](name)
         if ret['result']:
             ret['changes'] = {name: ''}


### PR DESCRIPTION
### What does this PR do?
Adds the possibility to have a group.absent state conditionally remove a group
only if there are no members in the group.

### What issues does this PR fix or reference?
Fixes #45311

### Previous Behavior
A group would be removed regardless if it had any members.

### New Behavior
An _option_ to only remove the group if it has no members has been added.

The state will return a True result if this is the case.

### Tests written?

No

Tested locally

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.