### PR TITLE
Several oxygen test fixes

### DIFF
--- a/salt/modules/ini_manage.py
+++ b/salt/modules/ini_manage.py
@@ -399,7 +399,7 @@ class _Ini(_Section):
             with salt.utils.files.fopen(self.name, 'wb') as outfile:
                 ini_gen = self.gen_ini()
                 next(ini_gen)
-                outfile.writelines(salt.utils.data.encode(ini_gen))
+                outfile.writelines(salt.utils.data.encode(list(ini_gen)))
         except (OSError, IOError) as exc:
             raise CommandExecutionError(
                 "Unable to write file '{0}'. "

--- a/salt/utils/gitfs.py
+++ b/salt/utils/gitfs.py
@@ -446,7 +446,7 @@ class GitProvider(object):
         use_tags = 'tag' in self.ref_types
 
         ret = set()
-        for ref in refs:
+        for ref in salt.utils.data.decode(refs):
             if ref.startswith('refs/'):
                 ref = ref[5:]
             rtype, rname = ref.split('/', 1)

--- a/tests/integration/runners/test_state.py
+++ b/tests/integration/runners/test_state.py
@@ -169,7 +169,7 @@ class StateRunnerTest(ShellCase):
         '''
         self.run_run('saltutil.sync_runners')
         self.run_run('saltutil.sync_wheel')
-        ret = '\n'.join(self.run_run('state.orchestrate orch.retcode'))
+        ret = '\n'.join(self.run_run('state.orchestrate orch.retcode', timeout=120))
 
         for result in ('          ID: test_runner_success\n'
                        '    Function: salt.runner\n'

--- a/tests/unit/modules/test_inspect_fsdb.py
+++ b/tests/unit/modules/test_inspect_fsdb.py
@@ -136,16 +136,16 @@ class InspectorFSDBTestCase(TestCase):
                 csvdb.create_table_from_object(FoobarEntity())
 
             if six.PY2:
-                assert writable.data[0].strip() == "foo:int,bar:str,spam:float"
+                assert writable.data[0].strip() == "foo:int,bar:unicode,spam:float"
             else:
                 # Order in PY3 is not the same for every run
                 writable_data = writable.data[0].strip()
-                assert_order_options = ['bar:str,foo:int,spam:float',
-                                        'bar:str,spam:float,foo:int',
-                                        'foo:int,spam:float,bar:str',
-                                        'foo:int,bar:str,spam:float',
-                                        'spam:float,foo:int,bar:str',
-                                        'spam:float,bar:str,foo:int']
+                assert_order_options = ['bar:unicode,foo:int,spam:float',
+                                        'bar:unicode,spam:float,foo:int',
+                                        'foo:int,spam:float,bar:unicode',
+                                        'foo:int,bar:unicode,spam:float',
+                                        'spam:float,foo:int,bar:unicode',
+                                        'spam:float,bar:unicode,foo:int']
                 while assert_order_options:
                     assert_option = assert_order_options.pop()
                     try:


### PR DESCRIPTION
This fixes the following tests:

- unit.serializers.test_serializers.TestSerializers.test_serialize_yaml - This was caused by a difference in quoting between serializing using `yaml.CSafeDumper` and `yaml.SafeDumper` as a base class. (refs: https://github.com/saltstack/salt-jenkins/issues/784)
- unit.serializers.test_serializers.TestSerializers.test_serialize_yaml - This was caused by the cent6 ec2 image simply taking longer to run than other platforms. Increasing the timeout allows the orchestration to run to completion (refs: https://github.com/saltstack/salt-jenkins/issues/786)

Additionally, it fixes the following failures, which were all due to the fact that `salt.utils.data.encode()` does not work with generators: (refs: https://github.com/saltstack/salt-jenkins/issues/789)

- unit.modules.test_ini_manage.IniManageTestCase.test_empty_lines_preserved_after_edit
- unit.modules.test_ini_manage.IniManageTestCase.test_empty_lines_preserved_after_multiple_edits
- unit.modules.test_ini_manage.IniManageTestCase.test_empty_value_preserved_after_edit
- unit.modules.test_ini_manage.IniManageTestCase.test_set_option

These three failures I could not reproduce, but they all happened because of a str/unicode mismatch that is also fixed in this PR: (refs: https://github.com/saltstack/salt-jenkins/issues/790)

- unit.fileserver.test_gitfs.GitFSTest.test_dir_list
- unit.fileserver.test_gitfs.GitFSTest.test_envs
- unit.fileserver.test_gitfs.GitFSTest.test_file_list

Finally, the following test was updated to reflect a change in behavior when `unicode_literals` was added: (refs: https://github.com/saltstack/salt-jenkins/issues/791)

- unit.modules.test_inspect_fsdb.InspectorFSDBTestCase.test_create_table

I would specifically like to get input from @isbm on that last test, as I am not familiar with that code and how it works, and I want to be sure that the change in behavior introduced by `unicode_literals` is OK. Updating the test to make it pass is only good if we make sure we're confirming the correct behavior.