### PR TITLE
add salt.modules.vmctl to doc index

### DIFF
--- a/doc/ref/modules/all/index.rst
+++ b/doc/ref/modules/all/index.rst
@@ -446,6 +446,7 @@ execution modules
     victorops
     virt
     virtualenv_mod
+    vmctl
     vsphere
     win_autoruns
     win_certutil

--- a/doc/ref/modules/all/salt.modules.vmctl.rst
+++ b/doc/ref/modules/all/salt.modules.vmctl.rst
@@ -1,0 +1,6 @@
+==================
+salt.modules.vmctl
+==================
+
+.. automodule:: salt.modules.vmctl
+    :members:


### PR DESCRIPTION
### What does this PR do?

Adds the vmctl module from #45164 to the documentation.

### Tests written?

No

### Commits signed with GPG?

No