### PR TITLE
Fix failing pkg integration tests for releases with no '.'

### DIFF
--- a/tests/integration/modules/test_pkg.py
+++ b/tests/integration/modules/test_pkg.py
@@ -28,12 +28,13 @@ class PkgModuleTest(ModuleCase, SaltReturnAssertsMixin):
             self.run_function('pkg.refresh_db')
 
         os_release = self.run_function('grains.get', ['osrelease'])
-        self.pkg = 'htop'
 
-        if int(os_release.split('.')[1]) >= 13 and salt.utils.is_darwin():
+        if salt.utils.is_darwin() and int(os_release.split('.')[1]) >= 13:
             self.pkg = 'wget'
-        elif salt.utils.is_windows:
+        elif salt.utils.is_windows():
             self.pkg = 'putty'
+        else:
+            self.pkg = 'htop'
 
     def test_list(self):
         '''


### PR DESCRIPTION
Fedora releases are integers, and Arch's osrelease is simply `rolling`, so https://github.com/saltstack/salt/pull/45636 caused these tests to regress. This fixes them by moving the osrelease check until after the MacOS check.

It also fixes the windows check, which would _always_ evaluate to `True` since it was not calling the function. Therefore, the `if` would just be a simple boolean which would resolve to `True` since it was just checking a function reference.

Resolves https://github.com/saltstack/salt-jenkins/issues/793