### PR TITLE
default to upgrading when refreshing on archlinux

### DIFF
--- a/salt/modules/pacman.py
+++ b/salt/modules/pacman.py
@@ -438,7 +438,7 @@ def refresh_db(root=None):
 
 def install(name=None,
             refresh=False,
-            sysupgrade=False,
+            sysupgrade=None,
             pkgs=None,
             sources=None,
             **kwargs):
@@ -478,7 +478,8 @@ def install(name=None,
 
     sysupgrade
         Whether or not to upgrade the system packages before installing.
-
+        If refresh is set to ``True`` but sysupgrade is not specified, ``-u`` will be
+        applied
 
     Multiple Package Installation Options:
 
@@ -516,9 +517,6 @@ def install(name=None,
         {'<package>': {'old': '<old-version>',
                        'new': '<new-version>'}}
     '''
-    refresh = salt.utils.is_true(refresh)
-    sysupgrade = salt.utils.is_true(sysupgrade)
-
     try:
         pkg_params, pkg_type = __salt__['pkg_resource.parse_targets'](
             name, pkgs, sources, **kwargs
@@ -545,9 +543,9 @@ def install(name=None,
         cmd.extend(pkg_params)
     elif pkg_type == 'repository':
         cmd.append('-S')
-        if refresh:
+        if refresh is True:
             cmd.append('-y')
-        if sysupgrade:
+        if sysupgrade is True or (sysupgrade is None and refresh is True):
             cmd.append('-u')
         cmd.extend(['--noprogressbar', '--noconfirm', '--needed'])
         wildcards = []


### PR DESCRIPTION
### What does this PR do?
Archlinux does not do resolution for soname bumps, so if one set of packages is
updated, but something depended on a dependency package's soname, and it is
bumped, the other package will break.

When refreshing the package database, there should always be a -Su, run to
upgrade all other packages on the system.  But still allow sysupgrade to be set
to false to override this behavior.

http://gist.io/5660494


### Tests written?

No

### Commits signed with GPG?

Yes