### PR TITLE
make atime and mtime integers in file.touch()

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -3078,10 +3078,14 @@ def touch(name, atime=None, mtime=None):
     '''
     name = os.path.expanduser(name)
 
-    if atime and atime.isdigit():
+    try:
         atime = int(atime)
-    if mtime and mtime.isdigit():
+    except:
+        atime = None
+    try:
         mtime = int(mtime)
+    except:
+        mtime = None
     try:
         if not os.path.exists(name):
             with salt.utils.files.fopen(name, 'a'):


### PR DESCRIPTION

### What does this PR do?
More reliable conversion as atime and mtime could be passed as int to the method

### What issues does this PR fix or reference?
when calling file.touch from the command line like this:

salt '*' file.touch /tmp/test mtime=12345678

the mtime argument to file.touch() is already an integer.

### Previous Behavior
An exception AttributeError is thrown with the old code:

    The minion function caused an exception: Traceback (most recent call last):
      File "/usr/lib/python2.7/dist-packages/salt/minion.py", line 1470, in _thread_return
        return_data = executor.execute()
      File "/usr/lib/python2.7/dist-packages/salt/executors/direct_call.py", line 28, in execute
        return self.func(*self.args, **self.kwargs)
      File "/usr/lib/python2.7/dist-packages/salt/modules/file.py", line 2912, in touch
        if mtime and mtime.isdigit():
    AttributeError: 'int' object has no attribute 'isdigit'


### New Behavior

Exception is not thrown.

### Tests written?

No

### Commits signed with GPG?

Yes
