### PR TITLE
Ubuntu 14 test fixes

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -2427,27 +2427,29 @@ def default_gateway():
         ip_gw: True   # True if either of the above is True, False otherwise
     '''
     grains = {}
-    if not salt.utils.path.which('ip'):
+    ip_bin = salt.utils.path.which('ip')
+    if not ip_bin:
         return {}
     grains['ip_gw'] = False
     grains['ip4_gw'] = False
     grains['ip6_gw'] = False
-    if __salt__['cmd.run']('ip -4 route show | grep "^default"', python_shell=True):
-        grains['ip_gw'] = True
-        grains['ip4_gw'] = True
+    for ip_version in ('4', '6'):
         try:
-            gateway_ip = __salt__['cmd.run']('ip -4 route show | grep "^default via"', python_shell=True).split(' ')[2].strip()
-            grains['ip4_gw'] = gateway_ip if gateway_ip else True
-        except Exception as exc:
-            pass
-    if __salt__['cmd.run']('ip -6 route show | grep "^default"', python_shell=True):
-        grains['ip_gw'] = True
-        grains['ip6_gw'] = True
-        try:
-            gateway_ip = __salt__['cmd.run']('ip -6 route show | grep "^default via"', python_shell=True).split(' ')[2].strip()
-            grains['ip6_gw'] = gateway_ip if gateway_ip else True
-        except Exception as exc:
-            pass
+            out = __salt__['cmd.run']([ip_bin, '-' + ip_version, 'route', 'show'])
+            for line in out.splitlines():
+                if line.startswith('default'):
+                    grains['ip_gw'] = True
+                    grains['ip{0}_gw'.format(ip_version)] = True
+                    try:
+                        via, gw_ip = line.split()[1:3]
+                    except ValueError:
+                        pass
+                    else:
+                        if via == 'via':
+                            grains['ip{0}_gw'.format(ip_version)] = gw_ip
+                    break
+        except Exception:
+            continue
     return grains
 
 

--- a/tests/unit/test_minion.py
+++ b/tests/unit/test_minion.py
@@ -13,7 +13,7 @@ from tests.support.unit import TestCase, skipIf
 from tests.support.mock import NO_MOCK, NO_MOCK_REASON, patch, MagicMock
 from tests.support.helpers import skip_if_not_root
 # Import salt libs
-import salt.minion as minion
+import salt.minion
 import salt.utils.event as event
 from salt.exceptions import SaltSystemExit
 import salt.syspaths
@@ -27,7 +27,7 @@ __opts__ = {}
 class MinionTestCase(TestCase):
     def test_invalid_master_address(self):
         with patch.dict(__opts__, {'ipv6': False, 'master': float('127.0'), 'master_port': '4555', 'retry_dns': False}):
-            self.assertRaises(SaltSystemExit, minion.resolve_dns, __opts__)
+            self.assertRaises(SaltSystemExit, salt.minion.resolve_dns, __opts__)
 
     @skip_if_not_root
     def test_sock_path_len(self):
@@ -68,8 +68,8 @@ class MinionTestCase(TestCase):
         mock_data = {'fun': 'foo.bar',
                      'jid': 123}
         mock_jid_queue = [123]
+        minion = salt.minion.Minion(mock_opts, jid_queue=copy.copy(mock_jid_queue), io_loop=tornado.ioloop.IOLoop())
         try:
-            minion = salt.minion.Minion(mock_opts, jid_queue=copy.copy(mock_jid_queue), io_loop=tornado.ioloop.IOLoop())
             ret = minion._handle_decoded_payload(mock_data).result()
             self.assertEqual(minion.jid_queue, mock_jid_queue)
             self.assertIsNone(ret)
@@ -89,8 +89,8 @@ class MinionTestCase(TestCase):
             mock_data = {'fun': 'foo.bar',
                          'jid': mock_jid}
             mock_jid_queue = [123, 456]
+            minion = salt.minion.Minion(mock_opts, jid_queue=copy.copy(mock_jid_queue), io_loop=tornado.ioloop.IOLoop())
             try:
-                minion = salt.minion.Minion(mock_opts, jid_queue=copy.copy(mock_jid_queue), io_loop=tornado.ioloop.IOLoop())
 
                 # Assert that the minion's jid_queue attribute matches the mock_jid_queue as a baseline
                 # This can help debug any test failures if the _handle_decoded_payload call fails.
@@ -118,8 +118,8 @@ class MinionTestCase(TestCase):
             mock_data = {'fun': 'foo.bar',
                          'jid': 789}
             mock_jid_queue = [123, 456]
+            minion = salt.minion.Minion(mock_opts, jid_queue=copy.copy(mock_jid_queue), io_loop=tornado.ioloop.IOLoop())
             try:
-                minion = salt.minion.Minion(mock_opts, jid_queue=copy.copy(mock_jid_queue), io_loop=tornado.ioloop.IOLoop())
 
                 # Assert that the minion's jid_queue attribute matches the mock_jid_queue as a baseline
                 # This can help debug any test failures if the _handle_decoded_payload call fails.
@@ -148,9 +148,9 @@ class MinionTestCase(TestCase):
             mock_opts['minion_jid_queue_hwm'] = 100
             mock_opts["process_count_max"] = process_count_max
 
+            io_loop = tornado.ioloop.IOLoop()
+            minion = salt.minion.Minion(mock_opts, jid_queue=[], io_loop=io_loop)
             try:
-                io_loop = tornado.ioloop.IOLoop()
-                minion = salt.minion.Minion(mock_opts, jid_queue=[], io_loop=io_loop)
 
                 # mock gen.sleep to throw a special Exception when called, so that we detect it
                 class SleepCalledEception(Exception):
@@ -189,8 +189,8 @@ class MinionTestCase(TestCase):
                 patch('salt.utils.process.SignalHandlingMultiprocessingProcess.join', MagicMock(return_value=True)):
             mock_opts = copy.copy(salt.config.DEFAULT_MINION_OPTS)
             mock_opts['beacons_before_connect'] = True
+            minion = salt.minion.Minion(mock_opts, io_loop=tornado.ioloop.IOLoop())
             try:
-                minion = salt.minion.Minion(mock_opts, io_loop=tornado.ioloop.IOLoop())
 
                 try:
                     minion.tune_in(start=True)
@@ -213,9 +213,8 @@ class MinionTestCase(TestCase):
                 patch('salt.utils.process.SignalHandlingMultiprocessingProcess.join', MagicMock(return_value=True)):
             mock_opts = copy.copy(salt.config.DEFAULT_MINION_OPTS)
             mock_opts['scheduler_before_connect'] = True
+            minion = salt.minion.Minion(mock_opts, io_loop=tornado.ioloop.IOLoop())
             try:
-                minion = salt.minion.Minion(mock_opts, io_loop=tornado.ioloop.IOLoop())
-
                 try:
                     minion.tune_in(start=True)
                 except RuntimeError:


### PR DESCRIPTION
This fixes failures which were identified in Ubuntu 14 Jenkins PR builds

```
======================================================================
ERROR [0.000s]: setUpClass (unit.states.test_boto_vpc.BotoVpcTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/testing/tests/unit/states/test_boto_vpc.py", line 109, in setUpClass
    cls.opts['grains'] = salt.loader.grains(cls.opts)
  File "/testing/salt/loader.py", line 732, in grains
    ret = funcs[key]()
  File "/testing/salt/grains/core.py", line 2435, in default_gateway
    if __salt__['cmd.run']('ip -4 route show | grep "^default"', python_shell=True):
  File "/testing/salt/modules/cmdmod.py", line 716, in _run_quiet
    pillar_override=pillar_override)['stdout']
  File "/testing/salt/modules/cmdmod.py", line 564, in _run
    raise CommandExecutionError(msg)
CommandExecutionError: Unable to run command 'REDACTED' with the context '{u'shell': True, u'stderr': -2, u'stdout': -1, u'executable': '/bin/bash', u'bg': False, u'with_communicate': True, u'env': {'LC_NUMERIC': 'C', 'TESTS_XML_OUTPUT_DIR': '/tmp/xml-unittests-output', 'TESTS_LOG_LEVEL': '2', 'LC_CTYPE': 'C', 'PIP_BUILD_DIR': '', 'SSH_CLIENT': '23.253.68.71 46980 22', 'LOGNAME': 'root', 'USER': 'root', 'HOME': '/root', 'LC_PAPER': 'C', 'PATH': '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:c:\\salt:c:\\salt:Saltdude:/Saltdude', 'UCF_FORCE_CONFFOLD': '1', 'DESTRUCTIVE_TESTS': 'True', 'LANG': 'en_US.UTF-8', 'SHELL': '/bin/bash', 'LC_MEASUREMENT': 'C', '_': '/usr/bin/python', 'LC_MONETARY': 'C', 'USERNAME': 'root', 'XDG_RUNTIME_DIR': '/run/user/0', 'LC_ADDRESS': 'C', 'DEBIAN_FRONTEND': 'noninteractive', 'PIP_SOURCE_DIR': '', 'XDG_SESSION_ID': '21', 'APT_LISTCHANGES_FRONTEND': 'none', 'LC_IDENTIFICATION': 'C', 'LC_MESSAGES': 'C', 'SSH_TTY': '/dev/pts/0', 'LC_COLLATE': 'C', 'LC_TELEPHONE': 'C', 'SHLVL': '1', 'PWD': '/root', 'LC_NAME': 'C', 'MAIL': '/var/mail/root', 'LC_TIME': 'C', 'SSH_CONNECTION': '23.253.68.71 46980 10.0.0.181 22', 'APT_LISTBUGS_FRONTEND': 'none', 'SSH_DAEMON_RUNNING': 'True'}, u'close_fds': True, u'stdin': None, u'timeout': None, u'cwd': u'/root'}', reason: command not found

======================================================================
ERROR [0.045s]: test_beacons_before_connect (unit.test_minion.MinionTestCase)
[CPU:37.5%|MEM:97.6%]
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/testing/tests/unit/test_minion.py", line 204, in test_beacons_before_connect
    minion.destroy()
UnboundLocalError: local variable 'minion' referenced before assignment

======================================================================
ERROR [0.050s]: test_handle_decoded_payload_jid_match_in_jid_queue (unit.test_minion.MinionTestCase)
[CPU:36.4%|MEM:97.6%]
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/testing/tests/unit/test_minion.py", line 77, in test_handle_decoded_payload_jid_match_in_jid_queue
    minion.destroy()
UnboundLocalError: local variable 'minion' referenced before assignment

======================================================================
ERROR [0.035s]: test_handle_decoded_payload_jid_queue_addition (unit.test_minion.MinionTestCase)
[CPU:50.0%|MEM:97.6%]
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/testing/tests/unit/test_minion.py", line 106, in test_handle_decoded_payload_jid_queue_addition
    minion.destroy()
UnboundLocalError: local variable 'minion' referenced before assignment

======================================================================
ERROR [0.032s]: test_handle_decoded_payload_jid_queue_reduced_minion_jid_queue_hwm (unit.test_minion.MinionTestCase)
[CPU:42.9%|MEM:97.6%]
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/testing/tests/unit/test_minion.py", line 134, in test_handle_decoded_payload_jid_queue_reduced_minion_jid_queue_hwm
    minion.destroy()
UnboundLocalError: local variable 'minion' referenced before assignment

======================================================================
ERROR [0.032s]: test_process_count_max (unit.test_minion.MinionTestCase)
[CPU:57.1%|MEM:97.6%]
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/testing/tests/unit/test_minion.py", line 180, in test_process_count_max
    minion.destroy()
UnboundLocalError: local variable 'minion' referenced before assignment

======================================================================
ERROR [0.031s]: test_scheduler_before_connect (unit.test_minion.MinionTestCase)
[CPU:50.0%|MEM:97.6%]
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/testing/tests/unit/test_minion.py", line 228, in test_scheduler_before_connect
    minion.destroy()
UnboundLocalError: local variable 'minion' referenced before assignment
```