### PR TITLE
Fix `unit.pillar.test_saltclass` for Windows

### DIFF
--- a/salt/utils/saltclass.py
+++ b/salt/utils/saltclass.py
@@ -251,7 +251,6 @@ def expanded_dict_from_minion(minion_id, salt_data):
         if 'pillars' in exp_dict:
             dict_merge(pillars_dict, exp_dict)
 
-
     return expanded_classes, pillars_dict, classes_list, states_list
 
 

--- a/salt/utils/saltclass.py
+++ b/salt/utils/saltclass.py
@@ -159,7 +159,7 @@ def expand_classes_in_order(minion_dict,
                             seen_classes,
                             expanded_classes,
                             classes_to_expand):
-    # Get classes to expand from minion dictionnary
+    # Get classes to expand from minion dictionary
     if not classes_to_expand and 'classes' in minion_dict:
         classes_to_expand = minion_dict['classes']
 
@@ -230,7 +230,7 @@ def expanded_dict_from_minion(minion_id, salt_data):
             if minion_file == '{0}.yml'.format(minion_id):
                 _file = os.path.join(root, minion_file)
 
-    # Load the minion_id definition if existing, else an exmpty dict
+    # Load the minion_id definition if existing, else an empty dict
     node_dict = {}
     if _file:
         node_dict[minion_id] = render_yaml(_file, salt_data)

--- a/salt/utils/saltclass.py
+++ b/salt/utils/saltclass.py
@@ -40,15 +40,20 @@ def get_class(_class, salt_data):
     l_files = []
     saltclass_path = salt_data['path']
 
-    straight = '{0}/classes/{1}.yml'.format(saltclass_path, _class)
-    sub_straight = '{0}/classes/{1}.yml'.format(saltclass_path,
-                                                _class.replace('.', '/'))
-    sub_init = '{0}/classes/{1}/init.yml'.format(saltclass_path,
-                                                 _class.replace('.', '/'))
+    straight = os.path.join(saltclass_path,
+                            'classes',
+                            '{0}.yml'.format(_class))
+    sub_straight = os.path.join(saltclass_path,
+                                'classes',
+                                '{0}.yml'.format(_class.replace('.', os.sep)))
+    sub_init = os.path.join(saltclass_path,
+                            'classes',
+                            _class.replace('.', os.sep),
+                            'init.yml')
 
-    for root, dirs, files in salt.utils.path.os_walk('{0}/classes'.format(saltclass_path)):
+    for root, dirs, files in salt.utils.path.os_walk(os.path.join(saltclass_path, 'classes')):
         for l_file in files:
-            l_files.append('{0}/{1}'.format(root, l_file))
+            l_files.append(os.path.join(root, l_file))
 
     if straight in l_files:
         return render_yaml(straight, salt_data)
@@ -220,7 +225,7 @@ def expanded_dict_from_minion(minion_id, salt_data):
     _file = ''
     saltclass_path = salt_data['path']
     # Start
-    for root, dirs, files in salt.utils.path.os_walk('{0}/nodes'.format(saltclass_path)):
+    for root, dirs, files in salt.utils.path.os_walk(os.path.join(saltclass_path, 'nodes')):
         for minion_file in files:
             if minion_file == '{0}.yml'.format(minion_id):
                 _file = os.path.join(root, minion_file)
@@ -245,6 +250,7 @@ def expanded_dict_from_minion(minion_id, salt_data):
     for exp_dict in expanded_classes:
         if 'pillars' in exp_dict:
             dict_merge(pillars_dict, exp_dict)
+
 
     return expanded_classes, pillars_dict, classes_list, states_list
 

--- a/tests/unit/pillar/test_saltclass.py
+++ b/tests/unit/pillar/test_saltclass.py
@@ -16,7 +16,9 @@ import salt.pillar.saltclass as saltclass
 base_path = os.path.dirname(os.path.realpath(__file__))
 fake_minion_id = 'fake_id'
 fake_pillar = {}
-fake_args = ({'path': '{0}/../../integration/files/saltclass/examples'.format(base_path)})
+fake_args = ({'path': os.path.abspath(
+                        os.path.join(base_path, '..', '..', 'integration',
+                                     'files', 'saltclass', 'examples'))})
 fake_opts = {}
 fake_salt = {}
 fake_grains = {}


### PR DESCRIPTION
### What does this PR do?
This PR fixes some actual issues with `salt.utils.saltclass` where it was using Unix-style path separators.
Fixes an issue with the test that was using Unix-style path separators.
Fixes some typos in the comments in `saltclass.py`

### What issues does this PR fix or reference?
https://github.com/saltstack/salt-jenkins/issues/439

### Tests written?
Yes

### Commits signed with GPG?
Yes