### PR TITLE
Use dbus-run-session instead of dbus-launch

### DIFF
--- a/salt/modules/gnomedesktop.py
+++ b/salt/modules/gnomedesktop.py
@@ -20,6 +20,7 @@ try:
 except ImportError:
     HAS_GLIB = False
 
+import salt.utils
 
 log = logging.getLogger(__name__)
 
@@ -50,6 +51,17 @@ class _GSettings(object):
         self.UID = None
         self.HOME = None
 
+    @property
+    def gestting_command(self):
+        '''
+        return the command to run the gesttings binary
+        '''
+        if salt.utils.which_bin(['dbus-run-session']):
+            cmd = ['dbus-run-session', '--', 'gsettings']
+        else:
+            cmd = ['dbus-launch', '--exit-with-session', 'gsettings']
+        return cmd
+
     def _get(self):
         '''
         get the value for user in gsettings
@@ -62,7 +74,7 @@ class _GSettings(object):
             log.info('User does not exist')
             return False
 
-        cmd = 'dbus-launch --exit-with-session gsettings get {0} {1}'.format(self.SCHEMA, self.KEY)
+        cmd = self.gestting_command + ['get', str(self.SCHEMA), str(self.KEY)]
         environ = {}
         environ['XDG_RUNTIME_DIR'] = '/run/user/{0}'.format(uid)
         result = __salt__['cmd.run_all'](cmd, runas=user, env=environ, python_shell=False)
@@ -90,7 +102,7 @@ class _GSettings(object):
             result['stdout'] = 'User {0} does not exist'.format(user)
             return result
 
-        cmd = 'dbus-launch --exit-with-session gsettings set {0} {1} "{2}"'.format(self.SCHEMA, self.KEY, str(value))
+        cmd = self.gestting_command + ['set', str(self.SCHEMA), str(self.KEY), str(value)]
         environ = {}
         environ['XDG_RUNTIME_DIR'] = '/run/user/{0}'.format(uid)
         result = __salt__['cmd.run_all'](cmd, runas=user, env=environ, python_shell=False)


### PR DESCRIPTION
As described in https://lists.debian.org/debian-devel/2016/08/msg00554.html Simon McVittie tries to reduce how much dbus-launch is used in Debian.

This change requires dbus 1.8 or newer, but does not require dbus-launch (shipped by dbus-x11) or X11.

Closes: https://bugs.debian.org/836297