### PR TITLE
Fix traceback in btmp/wtmp beacons

### DIFF
--- a/salt/beacons/btmp.py
+++ b/salt/beacons/btmp.py
@@ -27,7 +27,7 @@ from salt.ext.six.moves import map
 
 __virtualname__ = 'btmp'
 BTMP = '/var/log/btmp'
-FMT = 'hi32s4s32s256shhiii4i20x'
+FMT = b'hi32s4s32s256shhiii4i20x'
 FIELDS = [
           'type',
           'PID',

--- a/salt/beacons/wtmp.py
+++ b/salt/beacons/wtmp.py
@@ -27,7 +27,7 @@ from salt.ext.six.moves import map
 
 __virtualname__ = 'wtmp'
 WTMP = '/var/log/wtmp'
-FMT = 'hi32s4s32s256shhiii4i20x'
+FMT = b'hi32s4s32s256shhiii4i20x'
 FIELDS = [
           'type',
           'PID',


### PR DESCRIPTION
struct.calcsize requires str or bytes