### PR TITLE
Raise LimitNOFILE to default max open files

### DIFF
--- a/pkg/salt-master.service
+++ b/pkg/salt-master.service
@@ -4,7 +4,7 @@ Documentation=man:salt-master(1) file:///usr/share/doc/salt/html/contents.html h
 After=network.target
 
 [Service]
-LimitNOFILE=16384
+LimitNOFILE=100000
 Type=notify
 NotifyAccess=all
 ExecStart=/usr/bin/salt-master


### PR DESCRIPTION
The configuration option max_open_files defaults to 100,000, but the salt-master service is only started with a limit of 16,384 open files. Therefore the higher limit cannot be applied and there will be a log
message:

```
Current values for max open files soft/hard setting: 16384/16384
The value for the 'max_open_files' setting, 100000, is higher than what the user running salt is allowed to raise to, 16384. Defaulting to 16384.
```

This is related to #40173.