### PR TITLE
[WIP] zfs/zpool refactor

### DIFF
--- a/salt/grains/zfs.py
+++ b/salt/grains/zfs.py
@@ -16,24 +16,24 @@ from __future__ import absolute_import, print_function, unicode_literals
 import logging
 
 # Import salt libs
-import salt.utils.dictupdate
+import salt.utils.dictupdate as dictupdate
 import salt.utils.path
 import salt.utils.platform
-try:
-    # The zfs_support grain will only be set to True if this module is supported
-    # This allows the grain to be set to False on systems that don't support zfs
-    # _conform_value is only called if zfs_support is set to True
-    from salt.modules.zfs import _conform_value
-except ImportError:
-    pass
 
 # Solve the Chicken and egg problem where grains need to run before any
 # of the modules are loaded and are generally available for any usage.
 import salt.modules.cmdmod
+import salt.utils.zfs
 
 __virtualname__ = 'zfs'
 __salt__ = {
     'cmd.run': salt.modules.cmdmod.run,
+}
+__utils__ = {
+    'zfs.is_supported': salt.utils.zfs.is_supported,
+    'zfs.has_feature_flags': salt.utils.zfs.has_feature_flags,
+    'zfs.zpool_command': salt.utils.zfs.zpool_command,
+    'zfs.to_auto': salt.utils.zfs.to_auto,
 }
 
 log = logging.getLogger(__name__)
@@ -48,45 +48,6 @@ def __virtual__():
     return __virtualname__
 
 
-def _check_retcode(cmd):
-    '''
-    Simple internal wrapper for cmdmod.retcode
-    '''
-    return salt.modules.cmdmod.retcode(cmd, output_loglevel='quiet', ignore_retcode=True) == 0
-
-
-def _zfs_support():
-    '''
-    Provide information about zfs kernel module
-    '''
-    grains = {'zfs_support': False}
-
-    # Check for zfs support
-    # NOTE: ZFS on Windows is in development
-    # NOTE: ZFS on NetBSD is in development
-    on_supported_platform = False
-    if salt.utils.platform.is_sunos() and salt.utils.path.which('zfs'):
-        on_supported_platform = True
-    elif salt.utils.platform.is_freebsd() and _check_retcode('kldstat -q -m zfs'):
-        on_supported_platform = True
-    elif salt.utils.platform.is_linux():
-        modinfo = salt.utils.path.which('modinfo')
-        if modinfo:
-            on_supported_platform = _check_retcode('{0} zfs'.format(modinfo))
-        else:
-            on_supported_platform = _check_retcode('ls /sys/module/zfs')
-
-        # NOTE: fallback to zfs-fuse if needed
-        if not on_supported_platform and salt.utils.path.which('zfs-fuse'):
-            on_supported_platform = True
-
-    # Additional check for the zpool command
-    if on_supported_platform and salt.utils.path.which('zpool'):
-        grains['zfs_support'] = True
-
-    return grains
-
-
 def _zfs_pool_data():
     '''
     Provide grains about zpools
@@ -94,12 +55,16 @@ def _zfs_pool_data():
     grains = {}
 
     # collect zpool data
-    zpool_cmd = salt.utils.path.which('zpool')
-    for zpool in __salt__['cmd.run']('{zpool} list -H -p -o name,size'.format(zpool=zpool_cmd)).splitlines():
+    zpool_list_cmd = __utils__['zfs.zpool_command'](
+        'list',
+        flags=['-H', '-p'],
+        opts={'-o': 'name,size'},
+    )
+    for zpool in __salt__['cmd.run'](zpool_list_cmd).splitlines():
         if 'zpool' not in grains:
             grains['zpool'] = {}
         zpool = zpool.split()
-        grains['zpool'][zpool[0]] = _conform_value(zpool[1], True)
+        grains['zpool'][zpool[0]] = __utils__['zfs.to_auto'](zpool[1], True)
 
     # return grain data
     return grains
@@ -110,10 +75,10 @@ def zfs():
     Provide grains for zfs/zpool
     '''
     grains = {}
-
-    grains = salt.utils.dictupdate.update(grains, _zfs_support(), merge_lists=True)
+    grains['zfs_support'] = __utils__['zfs.is_supported']()
+    grains['zfs_feature_flags'] = __utils__['zfs.has_feature_flags']()
     if grains['zfs_support']:
-        grains = salt.utils.dictupdate.update(grains, _zfs_pool_data(), merge_lists=True)
+        grains = dictupdate.update(grains, _zfs_pool_data(), merge_lists=True)
 
     return grains
 

--- a/salt/modules/zpool.py
+++ b/salt/modules/zpool.py
@@ -2,7 +2,7 @@
 '''
 Module for running ZFS zpool command
 
-:codeauthor:    Nitin Madhok <nmadhok@clemson.edu>
+:codeauthor:    Nitin Madhok <nmadhok@clemson.edu>, Jorge Schrauwen <sjorge@blackdot.be>
 :maintainer:    Jorge Schrauwen <sjorge@blackdot.be>
 :maturity:      new
 :depends:       salt.utils.zfs
@@ -12,15 +12,14 @@ from __future__ import absolute_import, print_function, unicode_literals
 
 # Import Python libs
 import os
-import stat
 import logging
 
 # Import Salt libs
 import salt.utils.decorators
 import salt.utils.decorators.path
 import salt.utils.path
+from salt.ext.six.moves import zip
 from salt.utils.odict import OrderedDict
-from salt.modules.zfs import _conform_value
 
 log = logging.getLogger(__name__)
 
@@ -41,23 +40,53 @@ def __virtual__():
         return (False, "The zpool module cannot be loaded: zfs not supported")
 
 
+def _clean_vdev_config(config):
+    '''
+    Return a simple vdev tree from zpool.status' config section
+    '''
+    cln_config = OrderedDict()
+    for label, sub_config in config.items():
+        if label not in ['state', 'read', 'write', 'cksum']:
+            sub_config = _clean_vdev_config(sub_config)
+
+            if sub_config and isinstance(cln_config, list):
+                cln_config.append(OrderedDict([(label, sub_config)]))
+            elif sub_config and isinstance(cln_config, OrderedDict):
+                cln_config[label] = sub_config
+            elif isinstance(cln_config, list):
+                cln_config.append(label)
+            elif isinstance(cln_config, OrderedDict):
+                new_config = []
+                for old_label, old_config in cln_config.items():
+                    new_config.append(OrderedDict([(old_label, old_config)]))
+                new_config.append(label)
+                cln_config = new_config
+            else:
+                cln_config = [label]
+
+    return cln_config
+
+
 def healthy():
     '''
-    .. versionadded:: 2016.3.0
-
     Check if all zpools are healthy
+
+    .. versionadded:: 2016.3.0
 
     CLI Example:
 
     .. code-block:: bash
 
         salt '*' zpool.healthy
+
     '''
+    ## collect status output
+    # NOTE: we pass the -x flag, by doing this
+    #       we will get 'all pools are healthy' on stdout
+    #       if all pools are healthy, otherwise we will get
+    #       the same output that we expect from zpool status
     res = __salt__['cmd.run_all'](
-        __utils__['zfs.zpool_command'](
-            command='status',
-            flags=['-x'],
-        ),
+        __utils__['zfs.zpool_command']('status', flags=['-x']),
         python_shell=False,
     )
     return res['stdout'] == 'all pools are healthy'
@@ -65,118 +94,143 @@ def healthy():
 
 def status(zpool=None):
     '''
-    .. versionchanged:: 2016.3.0
-
     Return the status of the named zpool
 
     zpool : string
         optional name of storage pool
+
+    .. versionadded:: 2016.3.0
+    .. versionchanged:: Fluorine
 
     CLI Example:
 
     .. code-block:: bash
 
         salt '*' zpool.status myzpool
+
     '''
     ret = OrderedDict()
 
-    # get zpool list data
+    ## collect status output
     res = __salt__['cmd.run_all'](
-        __utils__['zfs.zpool_command'](
-            command='status',
-            target=zpool,
-        ),
+        __utils__['zfs.zpool_command']('status', target=zpool),
         python_shell=False,
     )
-    if res['retcode'] != 0:
-        ret['error'] = res['stderr'] if 'stderr' in res else res['stdout']
-        return ret
 
-    # parse zpool status data
-    zp_data = {}
+    if res['retcode'] != 0:
+        return __utils__['zfs.parse_command_result'](res)
+
+    # NOTE: command output for reference
+    # =====================================================================
+    #   pool: data
+    #  state: ONLINE
+    #   scan: scrub repaired 0 in 2h27m with 0 errors on Mon Jan  8 03:27:25 2018
+    # config:
+    #
+    #     NAME                       STATE     READ WRITE CKSUM
+    #     data                       ONLINE       0     0     0
+    #       mirror-0                 ONLINE       0     0     0
+    #         c0tXXXXCXXXXXXXXXXXd0  ONLINE       0     0     0
+    #         c0tXXXXCXXXXXXXXXXXd0  ONLINE       0     0     0
+    #         c0tXXXXCXXXXXXXXXXXd0  ONLINE       0     0     0
+    #
+    # errors: No known data errors
+    # =====================================================================
+
+    ## parse status output
+    # NOTE: output is 'key: value' except for the 'config' key.
+    #       mulitple pools will repeat the output, so if switch pools if
+    #       we see 'pool:'
     current_pool = None
     current_prop = None
     for zpd in res['stdout'].splitlines():
         if zpd.strip() == '':
             continue
         if ':' in zpd:
+            # NOTE: line is 'key: value' format, we just update a dict
             prop = zpd.split(':')[0].strip()
             value = ":".join(zpd.split(':')[1:]).strip()
             if prop == 'pool' and current_pool != value:
                 current_pool = value
-                zp_data[current_pool] = {}
+                ret[current_pool] = OrderedDict()
             if prop != 'pool':
-                zp_data[current_pool][prop] = value
+                ret[current_pool][prop] = value
 
             current_prop = prop
         else:
-            zp_data[current_pool][current_prop] = "{0}\n{1}".format(
-                zp_data[current_pool][current_prop],
+            # NOTE: we append the line output to the last property
+            #       this should only happens once we hit the config
+            #       section
+            ret[current_pool][current_prop] = "{0}\n{1}".format(
+                ret[current_pool][current_prop],
                 zpd
             )
 
-    # parse zpool config data
-    for pool in zp_data:
-        if 'config' not in zp_data[pool]:
+    ## parse config property for each pool
+    # NOTE: the config property has some structured data
+    #       sadly this data is in a different format than
+    #       the rest and it needs further processing
+    for pool in ret:
+        if 'config' not in ret[pool]:
             continue
         header = None
         root_vdev = None
         vdev = None
         dev = None
-        config = zp_data[pool]['config']
+        rdev = None
+        config = ret[pool]['config']
         config_data = OrderedDict()
         for line in config.splitlines():
+            # NOTE: the first line is the header
+            #       we grab all the none whitespace values
             if not header:
                 header = line.strip().lower()
                 header = [x for x in header.split(' ') if x not in ['']]
                 continue
 
-            if line[0:1] == "\t":
+            # NOTE: data is indented by 1 tab, then multiples of 2 spaces
+            #       to differential root vdev, vdev, and dev
+            #
+            #       we just strip the intial tab (can't use .strip() here)
+            if line[0] == "\t":
                 line = line[1:]
 
-            stat_data = OrderedDict()
-            stats = [x for x in line.strip().split(' ') if x not in ['']]
-            for prop in header:
-                if prop == 'name':
-                    continue
-                if header.index(prop) < len(stats):
-                    stat_data[prop] = stats[header.index(prop)]
+            # NOTE: transform data into dict
+            stat_data = OrderedDict(list(zip(
+                header,
+                [x for x in line.strip().split(' ') if x not in ['']],
+            )))
 
-            dev = line.strip().split()[0]
+            # NOTE: decode the zfs values properly
+            stat_data = __utils__['zfs.from_auto_dict'](stat_data)
 
-            if line[0:4] != '    ':
-                if line[0:2] == '  ':
-                    vdev = line.strip().split()[0]
-                    dev = None
-                else:
-                    root_vdev = line.strip().split()[0]
-                    vdev = None
-                    dev = None
+            # NOTE: store stat_data in the proper location
+            if line.startswith(' ' * 6):
+                rdev = stat_data['name']
+                config_data[root_vdev][vdev][dev][rdev] = stat_data
+            elif line.startswith(' ' * 4):
+                rdev = None
+                dev = stat_data['name']
+                config_data[root_vdev][vdev][dev] = stat_data
+            elif line.startswith(' ' * 2):
+                rdev = dev = None
+                vdev = stat_data['name']
+                config_data[root_vdev][vdev] = stat_data
+            else:
+                rdev = dev = vdev = None
+                root_vdev = stat_data['name']
+                config_data[root_vdev] = stat_data
 
-            if root_vdev:
-                if root_vdev not in config_data:
-                    config_data[root_vdev] = {}
-                    if len(stat_data) > 0:
-                        config_data[root_vdev] = stat_data
-                if vdev:
-                    if vdev not in config_data[root_vdev]:
-                        config_data[root_vdev][vdev] = {}
-                        if len(stat_data) > 0:
-                            config_data[root_vdev][vdev] = stat_data
-                    if dev and dev not in config_data[root_vdev][vdev]:
-                        config_data[root_vdev][vdev][dev] = {}
-                        if len(stat_data) > 0:
-                            config_data[root_vdev][vdev][dev] = stat_data
+            # NOTE: name already used as identifier, drop duplicate data
+            del stat_data['name']
 
-        zp_data[pool]['config'] = config_data
+        ret[pool]['config'] = config_data
 
-    return zp_data
+    return ret
 
 
-def iostat(zpool=None, sample_time=5):
+def iostat(zpool=None, sample_time=5, parsable=True):
     '''
-    .. versionchanged:: 2016.3.0
-
     Display I/O statistics for the given pools
 
     zpool : string
@@ -184,8 +238,13 @@ def iostat(zpool=None, sample_time=5):
     sample_time : int
         seconds to capture data before output
         default a sample of 5 seconds is used
+    parsable : boolean
+        display data in pythonc values (True, False, Bytes,...)
 
-        .. versionchanged:: Fluorine
+    .. versionadded:: 2016.3.0
+    .. versionchanged:: Fluorine
+
+        Added ```parsable``` parameter that defaults to True
 
     CLI Example:
 
@@ -195,7 +254,7 @@ def iostat(zpool=None, sample_time=5):
     '''
     ret = OrderedDict()
 
-    # get zpool list data
+    ## get iostat output
     res = __salt__['cmd.run_all'](
         __utils__['zfs.zpool_command'](
             command='iostat',
@@ -206,91 +265,82 @@ def iostat(zpool=None, sample_time=5):
     )
 
     if res['retcode'] != 0:
-        ret['error'] = res['stderr'] if 'stderr' in res else res['stdout']
-        return ret
+        return __utils__['zfs.parse_command_result'](res)
 
-    # note: hardcoded header fields, the double header is hard to parse
-    #                                capacity     operations    bandwidth
-    #pool                         alloc   free   read  write   read  write
+    # NOTE: command output for reference
+    # =====================================================================
+    #                               capacity     operations    bandwidth
+    # pool                       alloc   free   read  write   read  write
+    # -------------------------  -----  -----  -----  -----  -----  -----
+    # mypool                      648G  1.18T     10      6  1.30M   817K
+    #   mirror                    648G  1.18T     10      6  1.30M   817K
+    #     c0tXXXXCXXXXXXXXXXXd0      -      -      9      5  1.29M   817K
+    #     c0tXXXXCXXXXXXXXXXXd0      -      -      9      5  1.29M   817K
+    #     c0tXXXXCXXXXXXXXXXXd0      -      -      9      5  1.29M   817K
+    # -------------------------  -----  -----  -----  -----  -----  -----
+    # =====================================================================
+
+    ## parse iostat output
+    # NOTE: hardcode the header
+    #       the double header line is hard to parse, we opt to
+    #       hardcode the header fields
     header = [
-        'pool',
-        'capacity-alloc',
-        'capacity-free',
-        'operations-read',
-        'operations-write',
-        'bandwith-read',
-        'bandwith-write'
+        'name',
+        'capacity-alloc', 'capacity-free',
+        'operations-read', 'operations-write',
+        'bandwith-read', 'bandwith-write',
     ]
     root_vdev = None
     vdev = None
     dev = None
-    config_data = None
-    current_pool = None
+    current_data = OrderedDict()
     for line in res['stdout'].splitlines():
-        if line.strip() == '':
+        # NOTE: skip header
+        if line.strip() == '' or \
+           line.strip().split()[-1] in ['write', 'bandwidth']:
             continue
 
-        # ignore header
-        if line.startswith('pool') and line.endswith('write'):
-            continue
-        if line.endswith('bandwidth'):
-            continue
-
+        # NOTE: reset pool on line separator
         if line.startswith('-') and line.endswith('-'):
-            if config_data:
-                ret[current_pool] = config_data
-            config_data = OrderedDict()
-            current_pool = None
+            ret.update(current_data)
+            current_data = OrderedDict()
+            continue
+
+        # NOTE: transform data into dict
+        io_data = OrderedDict(list(zip(
+            header,
+            [x for x in line.strip().split(' ') if x not in ['']],
+        )))
+
+        # NOTE: normalize values
+        if parsable:
+            # NOTE: raw numbers and pythonic types
+            io_data = __utils__['zfs.from_auto_dict'](io_data)
         else:
-            if not isinstance(config_data, salt.utils.odict.OrderedDict):
-                continue
+            # NOTE: human readable zfs types
+            io_data = __utils__['zfs.to_auto_dict'](io_data)
 
-            stat_data = OrderedDict()
-            stats = [x for x in line.strip().split(' ') if x not in ['']]
-            for prop in header:
-                if header.index(prop) < len(stats):
-                    if prop == 'pool':
-                        if not current_pool:
-                            current_pool = stats[header.index(prop)]
-                        continue
-                    if stats[header.index(prop)] == '-':
-                        continue
-                    stat_data[prop] = stats[header.index(prop)]
+        # NOTE: store io_data in the proper location
+        if line.startswith(' ' * 4):
+            dev = io_data['name']
+            current_data[root_vdev][vdev][dev] = io_data
+        elif line.startswith(' ' * 2):
+            dev = None
+            vdev = io_data['name']
+            current_data[root_vdev][vdev] = io_data
+        else:
+            dev = vdev = None
+            root_vdev = io_data['name']
+            current_data[root_vdev] = io_data
 
-            dev = line.strip().split()[0]
-
-            if line[0:4] != '    ':
-                if line[0:2] == '  ':
-                    vdev = line.strip().split()[0]
-                    dev = None
-                else:
-                    root_vdev = line.strip().split()[0]
-                    vdev = None
-                    dev = None
-
-            if root_vdev:
-                if not config_data.get(root_vdev):
-                    config_data[root_vdev] = {}
-                    if len(stat_data) > 0:
-                        config_data[root_vdev] = stat_data
-                if vdev:
-                    if vdev not in config_data[root_vdev]:
-                        config_data[root_vdev][vdev] = {}
-                        if len(stat_data) > 0:
-                            config_data[root_vdev][vdev] = stat_data
-                    if dev and dev not in config_data[root_vdev][vdev]:
-                        config_data[root_vdev][vdev][dev] = {}
-                        if len(stat_data) > 0:
-                            config_data[root_vdev][vdev][dev] = stat_data
+        # NOTE: name already used as identifier, drop duplicate data
+        del io_data['name']
 
     return ret
 
 
-def list_(properties='size,alloc,free,cap,frag,health', zpool=None, parsable=False):
+def list_(properties='size,alloc,free,cap,frag,health', zpool=None, parsable=True):
     '''
-    .. versionadded:: 2015.5.0
-    .. versionchanged:: Oxygen
-
     Return information about (all) storage pools
 
     zpool : string
@@ -298,8 +348,12 @@ def list_(properties='size,alloc,free,cap,frag,health', zpool=None, parsable=Fal
     properties : string
         comma-separated list of properties to display
     parsable : boolean
-        display numbers in parsable (exact) values
-        .. versionadded:: Oxygen
+        display data in pythonc values (True, False, Bytes,...)
+
+    .. versionadded:: 2015.5.0
+    .. versionchanged:: Fluorine
+
+        Added ```parsable``` parameter that defaults to True
 
     .. note::
         the 'name' property will always be included, the 'frag' property will get removed if not available
@@ -321,19 +375,22 @@ def list_(properties='size,alloc,free,cap,frag,health', zpool=None, parsable=Fal
     '''
     ret = OrderedDict()
 
-    # remove 'frag' property if not available
+    ## update properties
+    # NOTE: properties should be a list
     if not isinstance(properties, list):
         properties = properties.split(',')
+
+    # NOTE: name should be first property
     while 'name' in properties:
         properties.remove('name')
     properties.insert(0, 'name')
+
+    # NOTE: remove 'frags' if we don't have feature flags
     if not __utils__['zfs.has_feature_flags']():
         while 'frag' in properties:
             properties.remove('frag')
 
-    # get zpool list data
-    ## FIXME: we now always get parsable output... handle this during parsing instead
-    ##        !! fix test input also !!
+    ## collect list output
     res = __salt__['cmd.run_all'](
         __utils__['zfs.zpool_command'](
             command='list',
@@ -345,28 +402,37 @@ def list_(properties='size,alloc,free,cap,frag,health', zpool=None, parsable=Fal
     )
 
     if res['retcode'] != 0:
-        ret['error'] = res['stderr'] if 'stderr' in res else res['stdout']
-        return ret
+        return __utils__['zfs.parse_command_result'](res)
 
-    # parse zpool list data
-    for zp in res['stdout'].splitlines():
-        zp = zp.split("\t")
-        zp_data = {}
+    # NOTE: command output for reference
+    # ========================================================================
+    # data  1992864825344   695955501056    1296909324288   34  11%     ONLINE
+    # =========================================================================
 
-        for prop in properties:
-            zp_data[prop] = _conform_value(zp[properties.index(prop)])
+    ## parse list output
+    for line in res['stdout'].splitlines():
+        # NOTE: transform data into dict
+        zpool_data = OrderedDict(list(zip(
+            properties,
+            line.strip().split('\t'),
+        )))
 
-        ret[zp_data['name']] = zp_data
-        del ret[zp_data['name']]['name']
+        # NOTE: normalize values
+        if parsable:
+            # NOTE: raw numbers and pythonic types
+            zpool_data = __utils__['zfs.from_auto_dict'](zpool_data)
+        else:
+            # NOTE: human readable zfs types
+            zpool_data = __utils__['zfs.to_auto_dict'](zpool_data)
+
+        ret[zpool_data['name']] = zpool_data
+        del ret[zpool_data['name']]['name']
 
     return ret
 
 
-def get(zpool, prop=None, show_source=False, parsable=False):
+def get(zpool, prop=None, show_source=False, parsable=True):
     '''
-    .. versionadded:: 2016.3.0
-    .. versionchanged: Oxygen
-
     Retrieves the given list of properties
 
     zpool : string
@@ -376,8 +442,12 @@ def get(zpool, prop=None, show_source=False, parsable=False):
     show_source : boolean
         show source of property
     parsable : boolean
-        display numbers in parsable (exact) values
-        .. versionadded:: Oxygen
+        display data in pythonc values (True, False, Bytes,...)
+
+    .. versionadded:: 2016.3.0
+    .. versionchanged:: Fluorine
+
+        Added ```parsable``` parameter that defaults to True
 
     CLI Example:
 
@@ -386,11 +456,9 @@ def get(zpool, prop=None, show_source=False, parsable=False):
         salt '*' zpool.get myzpool
     '''
     ret = OrderedDict()
-    ret[zpool] = OrderedDict()
     value_properties = ['property', 'value', 'source']
 
-    # get zpool list data
-    ## FIXME: we now always get parsable output... handle this during parsing instead
+    ## collect get output
     res = __salt__['cmd.run_all'](
         __utils__['zfs.zpool_command'](
             command='get',
@@ -403,30 +471,44 @@ def get(zpool, prop=None, show_source=False, parsable=False):
     )
 
     if res['retcode'] != 0:
-        ret['error'] = res['stderr'] if 'stderr' in res else res['stdout']
-        return ret
+        return __utils__['zfs.parse_command_result'](res)
 
-    # parse zpool list data
-    for zp in res['stdout'].splitlines():
-        zp = zp.split("\t")
-        zp_data = {}
+    # NOTE: command output for reference
+    # ========================================================================
+    # ...
+    # data  mountpoint  /data   local
+    # data  compression off     default
+    # ...
+    # =========================================================================
 
-        for prop in value_properties:
-            zp_data[prop] = _conform_value(zp[value_properties.index(prop)])
+    # parse get output
+    for line in res['stdout'].splitlines():
+        # NOTE: transform data into dict
+        prop_data = OrderedDict(list(zip(
+            value_properties,
+            [x for x in line.strip().split('\t') if x not in ['']],
+        )))
 
-        if show_source:
-            ret[zpool][zp_data['property']] = zp_data
-            del ret[zpool][zp_data['property']]['property']
+        # NOTE: normalize values
+        if parsable:
+            # NOTE: raw numbers and pythonic types
+            prop_data['value'] = __utils__['zfs.from_auto'](prop_data['property'], prop_data['value'])
         else:
-            ret[zpool][zp_data['property']] = zp_data['value']
+            # NOTE: human readable zfs types
+            prop_data['value'] = __utils__['zfs.to_auto'](prop_data['property'], prop_data['value'])
+
+        # NOTE: show source if requested
+        if show_source:
+            ret[prop_data['property']] = prop_data
+            del ret[prop_data['property']]['property']
+        else:
+            ret[prop_data['property']] = prop_data['value']
 
     return ret
 
 
 def set(zpool, prop, value):
     '''
-    .. versionadded:: 2016.3.0
-
     Sets the given property on the specified pool
 
     zpool : string
@@ -436,19 +518,17 @@ def set(zpool, prop, value):
     value : string
         value to set property to
 
+    .. versionadded:: 2016.3.0
+
     CLI Example:
 
     .. code-block:: bash
 
         salt '*' zpool.set myzpool readonly yes
     '''
-    ret = {}
-    ret[zpool] = {}
+    ret = OrderedDict()
 
-    # make sure value is what zfs expects
-    value = _conform_value(value)
-
-    # get zpool list data
+    # set property
     res = __salt__['cmd.run_all'](
         __utils__['zfs.zpool_command'](
             command='set',
@@ -459,11 +539,7 @@ def set(zpool, prop, value):
         python_shell=False,
     )
 
-    if res['retcode'] != 0:
-        ret[zpool][prop] = res['stderr'] if 'stderr' in res else res['stdout']
-    else:
-        ret[zpool][prop] = value
-    return ret
+    return __utils__['zfs.parse_command_result'](res, 'set')
 
 
 def exists(zpool):
@@ -479,6 +555,8 @@ def exists(zpool):
 
         salt '*' zpool.exists myzpool
     '''
+    # list for zpool
+    # NOTE: retcode > 0 if zpool does not exists
     res = __salt__['cmd.run_all'](
         __utils__['zfs.zpool_command'](
             command='list',
@@ -487,15 +565,12 @@ def exists(zpool):
         python_shell=False,
         ignore_retcode=True,
     )
-    if res['retcode'] != 0:
-        return False
-    return True
+
+    return res['retcode'] == 0
 
 
 def destroy(zpool, force=False):
     '''
-    .. versionchanged:: 2016.3.0
-
     Destroys a storage pool
 
     zpool : string
@@ -503,40 +578,29 @@ def destroy(zpool, force=False):
     force : boolean
         force destroy of pool
 
+    .. versionchanged:: 2016.3.0
+
     CLI Example:
 
     .. code-block:: bash
 
         salt '*' zpool.destroy myzpool
     '''
-    ret = {}
-    ret[zpool] = {}
-    if not __salt__['zpool.exists'](zpool):
-        ret[zpool] = 'storage pool does not exist'
-    else:
-        res = __salt__['cmd.run_all'](
-            __utils__['zfs.zpool_command'](
-                command='destroy',
-                flags=['-f'] if force else None,
-                target=zpool,
-            ),
-            python_shell=False,
-        )
+    # destroy zpool
+    res = __salt__['cmd.run_all'](
+        __utils__['zfs.zpool_command'](
+            command='destroy',
+            flags=['-f'] if force else None,
+            target=zpool,
+        ),
+        python_shell=False,
+    )
 
-        if res['retcode'] != 0:
-            ret[zpool] = 'error destroying storage pool'
-            if 'stderr' in res and res['stderr'] != '':
-                ret[zpool] = res['stderr']
-        else:
-            ret[zpool] = 'destroyed'
-
-    return ret
+    return __utils__['zfs.parse_command_result'](res, 'destroyed')
 
 
 def scrub(zpool, stop=False, pause=False):
     '''
-    .. versionchanged:: 2016.3.0
-
     Scrub a storage pool
 
     zpool : string
@@ -550,6 +614,10 @@ def scrub(zpool, stop=False, pause=False):
         .. note::
 
             If both pause and stop are true, stop will win.
+            Pause support was added in this PR:
+            https://github.com/openzfs/openzfs/pull/407
+
+    .. versionchanged:: 2016.3.0
 
     CLI Example:
 
@@ -557,51 +625,37 @@ def scrub(zpool, stop=False, pause=False):
 
         salt '*' zpool.scrub myzpool
     '''
-    ret = {}
-    ret[zpool] = {}
-    if __salt__['zpool.exists'](zpool):
-        action = []
-        if stop:
-            action.append('-s')
-        elif pause:
-            # NOTE: https://github.com/openzfs/openzfs/pull/407
-            action.append('-p')
-        res = __salt__['cmd.run_all'](
-            __utils__['zfs.zpool_command'](
-                command='scrub',
-                flags=action,
-                target=zpool,
-            ),
-            python_shell=False,
-        )
-        ret[zpool] = {}
-        if res['retcode'] != 0:
-            ret[zpool]['scrubbing'] = False
-            if 'stderr' in res:
-                if 'currently scrubbing' in res['stderr']:
-                    ret[zpool]['scrubbing'] = True
-                elif 'no active scrub' not in res['stderr']:
-                    ret[zpool]['error'] = res['stderr']
-            else:
-                ret[zpool]['error'] = res['stdout']
-        else:
-            if stop:
-                ret[zpool]['scrubbing'] = False
-            elif pause:
-                ret[zpool]['scrubbing'] = False
-            else:
-                ret[zpool]['scrubbing'] = True
+    ## select correct action
+    if stop:
+        action = ['-s']
+    elif pause:
+        action = ['-p']
     else:
-        ret[zpool] = 'storage pool does not exist'
+        action = None
 
+    ## Scrub storage pool
+    res = __salt__['cmd.run_all'](
+        __utils__['zfs.zpool_command'](
+            command='scrub',
+            flags=action,
+            target=zpool,
+        ),
+        python_shell=False,
+    )
+
+    if res['retcode'] != 0:
+        return __utils__['zfs.parse_command_result'](res, 'scrubbing')
+
+    ret = OrderedDict()
+    if stop or pause:
+        ret['scrubbing'] = False
+    else:
+        ret['scrubbing'] = True
     return ret
 
 
 def create(zpool, *vdevs, **kwargs):
     '''
-    .. versionadded:: 2015.5.0
-    .. versionchanged:: 2016.3.0
-
     Create a simple zpool, a mirrored zpool, a zpool having nested VDEVs, a hybrid zpool with cache, spare and log drives or a zpool with RAIDZ-1, RAIDZ-2 or RAIDZ-3
 
     zpool : string
@@ -621,6 +675,9 @@ def create(zpool, *vdevs, **kwargs):
     createboot : boolean
         ..versionadded:: Oxygen
         create a boot partition
+
+    .. versionadded:: 2015.5.0
+    .. versionchanged:: Fluorine
 
     CLI Example:
 
@@ -652,26 +709,17 @@ def create(zpool, *vdevs, **kwargs):
 
             salt '*' zpool.create myzpool /path/to/vdev1 [...] properties="{'property1': 'value1', 'property2': 'value2'}"
     '''
-    ret = {}
-
-    # Check if the pool_name is already being used
-    if __salt__['zpool.exists'](zpool):
-        ret[zpool] = 'storage pool already exists'
-        return ret
-
-    if not vdevs:
-        ret[zpool] = 'no devices specified'
-        return ret
-
-    # Initialize defaults
+    ## Configure pool
+    # NOTE: initialize the defaults
     flags = []
     opts = {}
     target = []
 
-    # Set pool and fs properties
-    pool_properties = kwargs.get('properties', None)
-    filesystem_properties = kwargs.get('filesystem_properties', None)
+    # NOTE: push pool and filesystem properties
+    pool_properties = kwargs.get('properties', {})
+    filesystem_properties = kwargs.get('filesystem_properties', {})
 
+    # NOTE: set extra config based on kwargs
     if kwargs.get('force', False):
         flags.append('-f')
     if kwargs.get('createboot', False) or 'bootsize' in pool_properties:
@@ -680,10 +728,12 @@ def create(zpool, *vdevs, **kwargs):
         opts['-R'] = kwargs.get('altroot')
     if kwargs.get('mountpoint', False):
         opts['-m'] = kwargs.get('mountpoint')
+
+    # NOTE: append the pool name and specifications
     target.append(zpool)
     target.extend(vdevs)
 
-    # Create storage pool
+    ## Create storage pool
     res = __salt__['cmd.run_all'](
         __utils__['zfs.zpool_command'](
             command='create',
@@ -696,19 +746,18 @@ def create(zpool, *vdevs, **kwargs):
         python_shell=False,
     )
 
-    # Check and see if the pools is available
-    if res['retcode'] != 0:
-        ret[zpool] = res['stderr'] if 'stderr' in res else res['stdout']
-    else:
-        ret[zpool] = 'created with {0}'.format(' '.join(vdevs))
+    ret = __utils__['zfs.parse_command_result'](res, 'created')
+    if ret['created']:
+        ## NOTE: lookup zpool status for vdev config
+        ret['vdevs'] = _clean_vdev_config(
+            __salt__['zpool.status'](zpool=zpool)[zpool]['config'][zpool],
+        )
 
     return ret
 
 
 def add(zpool, *vdevs, **kwargs):
     '''
-    .. versionchanged:: 2016.3.0
-
     Add the specified vdev\'s to the given storage pool
 
     zpool : string
@@ -718,33 +767,28 @@ def add(zpool, *vdevs, **kwargs):
     force : boolean
         forces use of device
 
+    .. versionchanged:: Fluorine
+
     CLI Example:
 
     .. code-block:: bash
 
         salt '*' zpool.add myzpool /path/to/vdev1 /path/to/vdev2 [...]
     '''
-    ret = {}
-
-    # validate parameters
-    if not __salt__['zpool.exists'](zpool):
-        ret[zpool] = 'storage pool does not exist'
-        return ret
-
-    if not vdevs:
-        ret[zpool] = 'no devices specified'
-        return ret
-
-    # try and add vdev
-    # NOTE: watch out for mismatched replication levels
+    ## Configure pool
+    # NOTE: initialize the defaults
     flags = []
     target = []
 
+    # NOTE: set extra config based on kwargs
     if kwargs.get('force', False):
         flags.append('-f')
+
+    # NOTE: append the pool name and specifications
     target.append(zpool)
     target.extend(vdevs)
 
+    ## Update storage pool
     res = __salt__['cmd.run_all'](
         __utils__['zfs.zpool_command'](
             command='add',
@@ -754,18 +798,18 @@ def add(zpool, *vdevs, **kwargs):
         python_shell=False,
     )
 
-    if res['retcode'] != 0:
-        ret[zpool] = res['stderr'] if 'stderr' in res else res['stdout']
-    else:
-        ret[zpool] = 'added {0}'.format(' '.join(vdevs))
+    ret = __utils__['zfs.parse_command_result'](res, 'added')
+    if ret['added']:
+        ## NOTE: lookup zpool status for vdev config
+        ret['vdevs'] = _clean_vdev_config(
+            __salt__['zpool.status'](zpool=zpool)[zpool]['config'][zpool],
+        )
 
     return ret
 
 
 def attach(zpool, device, new_device, force=False):
     '''
-    .. versionchanged:: 2016.3.0
-
     Attach specified device to zpool
 
     zpool : string
@@ -777,49 +821,30 @@ def attach(zpool, device, new_device, force=False):
     force : boolean
         forces use of device
 
+    .. versionchanged:: 2016.3.0
+    .. versionchanged:: Fluorine
+
     CLI Example:
 
     .. code-block:: bash
 
         salt '*' zpool.attach myzpool /path/to/vdev1 /path/to/vdev2 [...]
     '''
-    ret = {}
-    dlist = []
-
-    # check for pool
-    if not __salt__['zpool.exists'](zpool):
-        ret[zpool] = 'storage pool does not exist'
-        return ret
-
-    # check devices
-    ret[zpool] = {}
-    if not os.path.exists(device):
-        ret[zpool][device] = 'not present on filesystem'
-    else:
-        mode = os.stat(device).st_mode
-        if not stat.S_ISBLK(mode) and not stat.S_ISREG(mode):
-            ret[zpool][device] = 'not a block device, a file vdev or character special device'
-    if not os.path.exists(new_device):
-        ret[zpool][new_device] = 'not present on filesystem'
-    else:
-        mode = os.stat(new_device).st_mode
-        if not stat.S_ISBLK(mode) and not stat.S_ISREG(mode):
-            ret[zpool][new_device] = 'not a block device, a file vdev or character special device'
-
-    if len(ret[zpool]) > 0:
-        return ret
-
-    # try and attach
-    # NOTE: watch out for mismatched replication levels
+    ## Configure pool
+    # NOTE: initialize the defaults
     flags = []
     target = []
 
+    # NOTE: set extra config
     if force:
         flags.append('-f')
+
+    # NOTE: append the pool name and specifications
     target.append(zpool)
     target.append(device)
     target.append(new_device)
 
+    ## Update storage pool
     res = __salt__['cmd.run_all'](
         __utils__['zfs.zpool_command'](
             command='attach',
@@ -829,19 +854,18 @@ def attach(zpool, device, new_device, force=False):
         python_shell=False,
     )
 
-    if res['retcode'] != 0:
-        ret[zpool] = res['stderr'] if 'stderr' in res else res['stdout']
-    else:
-        ret[zpool] = {}
-        ret[zpool][new_device] = 'attached'
+    ret = __utils__['zfs.parse_command_result'](res, 'attached')
+    if ret['attached']:
+        ## NOTE: lookup zpool status for vdev config
+        ret['vdevs'] = _clean_vdev_config(
+            __salt__['zpool.status'](zpool=zpool)[zpool]['config'][zpool],
+        )
 
     return ret
 
 
 def detach(zpool, device):
     '''
-    .. versionchanged:: 2016.3.0
-
     Detach specified device to zpool
 
     zpool : string
@@ -849,22 +873,15 @@ def detach(zpool, device):
     device : string
         device to detach
 
+    .. versionchanged:: Fluorine
+
     CLI Example:
 
     .. code-block:: bash
 
         salt '*' zpool.detach myzpool /path/to/vdev1
     '''
-    ret = {}
-    dlist = []
-
-    # check for pool
-    if not __salt__['zpool.exists'](zpool):
-        ret[zpool] = 'storage pool does not exist'
-        return ret
-
-    # try and detach
-    # NOTE: watch out for mismatched replication levels
+    ## Update storage pool
     res = __salt__['cmd.run_all'](
         __utils__['zfs.zpool_command'](
             command='detach',
@@ -873,25 +890,26 @@ def detach(zpool, device):
         python_shell=False,
     )
 
-    if res['retcode'] != 0:
-        ret[zpool] = res['stderr'] if 'stderr' in res else res['stdout']
-    else:
-        ret[zpool] = {}
-        ret[zpool][device] = 'detached'
+    ret = __utils__['zfs.parse_command_result'](res, 'detatched')
+    if ret['detatched']:
+        ## NOTE: lookup zpool status for vdev config
+        ret['vdevs'] = _clean_vdev_config(
+            __salt__['zpool.status'](zpool=zpool)[zpool]['config'][zpool],
+        )
 
     return ret
 
 
 def split(zpool, newzpool, **kwargs):
     '''
-    .. versionadded:: Oxygen
-
     Splits devices off pool creating newpool.
 
     .. note::
 
         All vdevs in pool must be mirrors.  At the time of the split,
         newpool will be a replica of pool.
+
+        After splitting, do not forget to import the new pool!
 
     zpool : string
         name of storage pool
@@ -903,6 +921,9 @@ def split(zpool, newzpool, **kwargs):
         sets altroot for newzpool
     properties : dict
         additional pool properties for newzpool
+
+    .. versionadded:: Oxygen
+    .. versionchanged:: Fluorine
 
     CLI Example:
 
@@ -925,23 +946,18 @@ def split(zpool, newzpool, **kwargs):
 
             salt '*' zpool.split datamirror databackup properties="{'readonly': 'on'}"
     '''
-    ret = {}
-
-    # Check if the pool_name is already being used
-    if __salt__['zpool.exists'](newzpool):
-        ret[newzpool] = 'storage pool already exists'
-        return ret
-
-    if not __salt__['zpool.exists'](zpool):
-        ret[zpool] = 'storage pool does not exists'
-        return ret
-
+    ## Configure pool
+    # NOTE: initialize the defaults
     opts = {}
-    pool_properties = kwargs.get('properties', None)
+
+    # NOTE: push pool and filesystem properties
+    pool_properties = kwargs.get('properties', {})
+
+    # NOTE: set extra config based on kwargs
     if kwargs.get('altroot', False):
         opts['-R'] = kwargs.get('altroot')
 
-    # Create storage pool
+    ## Split storage pool
     res = __salt__['cmd.run_all'](
         __utils__['zfs.zpool_command'](
             command='split',
@@ -952,19 +968,11 @@ def split(zpool, newzpool, **kwargs):
         python_shell=False,
     )
 
-    # Check and see if the pools is available
-    if res['retcode'] != 0:
-        ret[newzpool] = res['stderr'] if 'stderr' in res else res['stdout']
-    else:
-        ret[newzpool] = 'split off from {}'.format(zpool)
-
-    return ret
+    return __utils__['zfs.parse_command_result'](res, 'split')
 
 
 def replace(zpool, old_device, new_device=None, force=False):
     '''
-    .. versionchanged:: 2016.3.0
-
     Replaces old_device with new_device.
 
     .. note::
@@ -983,50 +991,30 @@ def replace(zpool, old_device, new_device=None, force=False):
     force : boolean
         Forces use of new_device, even if its appears to be in use.
 
+    .. versionchanged:: Fluorine
+
     CLI Example:
 
     .. code-block:: bash
 
         salt '*' zpool.replace myzpool /path/to/vdev1 /path/to/vdev2
     '''
-    ret = {}
-    # Make sure pool is there
-    if not __salt__['zpool.exists'](zpool):
-        ret[zpool] = 'storage pool does not exist'
-        return ret
-
-    # check devices
-    ret[zpool] = {}
-    if not new_device:  # if we have a new device, old_device is probably missing!
-        if not os.path.exists(old_device):
-            ret[zpool][old_device] = 'not present on filesystem'
-        else:
-            mode = os.stat(old_device).st_mode
-            if not stat.S_ISBLK(mode) and not stat.S_ISREG(mode):
-                ret[zpool][old_device] = 'not a block device, a file vdev or character special device'
-
-    if new_device:  # if we are replacing a device in the same slot, new device can be None
-        if not os.path.exists(new_device):
-            ret[zpool][new_device] = 'not present on filesystem'
-        else:
-            mode = os.stat(new_device).st_mode
-            if not stat.S_ISBLK(mode) and not stat.S_ISREG(mode):
-                ret[zpool][new_device] = 'not a block device, a file vdev or character special device'
-
-    if len(ret[zpool]) > 0:
-        return ret
-
-    # Replace vdevs
+    ## Configure pool
+    # NOTE: initialize the defaults
     flags = []
     target = []
 
+    # NOTE: set extra config
     if force:
         flags.append('-f')
+
+    # NOTE: append the pool name and specifications
     target.append(zpool)
     target.append(old_device)
     if new_device:
         target.append(new_device)
 
+    ## Replace device
     res = __salt__['cmd.run_all'](
         __utils__['zfs.zpool_command'](
             command='replace',
@@ -1036,12 +1024,12 @@ def replace(zpool, old_device, new_device=None, force=False):
         python_shell=False,
     )
 
-    if res['retcode'] != 0:
-        ret[zpool] = res['stderr'] if 'stderr' in res else res['stdout']
-    elif new_device:
-        ret[zpool] = 'replaced {0} with {1}'.format(old_device, new_device)
-    else:
-        ret[zpool] = 'replaced {0}'.format(old_device)
+    ret = __utils__['zfs.parse_command_result'](res, 'replaced')
+    if ret['replaced']:
+        ## NOTE: lookup zpool status for vdev config
+        ret['vdevs'] = _clean_vdev_config(
+            __salt__['zpool.status'](zpool=zpool)[zpool]['config'][zpool],
+        )
 
     return ret
 
@@ -1049,11 +1037,11 @@ def replace(zpool, old_device, new_device=None, force=False):
 @salt.utils.decorators.path.which('mkfile')
 def create_file_vdev(size, *vdevs):
     '''
-    .. versionchanged:: 2016.3.0
-
     Creates file based ``virtual devices`` for a zpool
 
     ``*vdevs`` is a list of full paths for mkfile to create
+
+    .. versionchanged:: Fluorine
 
     CLI Example:
 
@@ -1065,49 +1053,45 @@ def create_file_vdev(size, *vdevs):
 
         Depending on file size, the above command may take a while to return.
     '''
-    ret = {}
-    dlist = []
-    # Get file names to create
+    ret = OrderedDict()
+    err = OrderedDict()
+
+    _mkfile_cmd = salt.utils.path.which('mkfile')
     for vdev in vdevs:
-        # check if file is present if not add it
         if os.path.isfile(vdev):
             ret[vdev] = 'existed'
         else:
-            dlist.append(vdev)
-
-    _mkfile_cmd = salt.utils.path.which('mkfile')
-    for vdev in dlist:
-        res = __salt__['cmd.run_all'](
-            '{mkfile} {size} {vdev}'.format(
-                mkfile=_mkfile_cmd,
-                size=size,
-                vdev=vdev,
-            ),
-            python_shell=False,
-        )
-        ret[vdev] = 'failed'
-        if res['retcode'] != 0:
-            if 'stderr' in res and ':' in res['stderr']:
-                ret[vdev] = 'failed: {reason}'.format(
-                    reason=res['stderr'].split(': ')[-1],
-                )
-        elif os.path.isfile(vdev):
-            ret[vdev] = 'created'
+            res = __salt__['cmd.run_all'](
+                '{mkfile} {size} {vdev}'.format(
+                    mkfile=_mkfile_cmd,
+                    size=size,
+                    vdev=vdev,
+                ),
+                python_shell=False,
+            )
+            if res['retcode'] != 0:
+                if 'stderr' in res and ':' in res['stderr']:
+                    ret[vdev] = 'failed'
+                    err[vdev] = ":".join(res['stderr'].strip().split(':')[1:])
+            else:
+                ret[vdev] = 'created'
+    if err:
+        ret['error'] = err
 
     return ret
 
 
 def export(*pools, **kwargs):
     '''
-    .. versionadded:: 2015.5.0
-    .. versionchanged:: 2016.3.0
-
     Export storage pools
 
     *pools : string
         one or more storage pools to export
     force : boolean
         force export of storage pools
+
+    .. versionadded:: 2015.5.0
+    .. versionchanged:: Fluorine
 
     CLI Example:
 
@@ -1116,45 +1100,33 @@ def export(*pools, **kwargs):
         salt '*' zpool.export myzpool ... [force=True|False]
         salt '*' zpool.export myzpool2 myzpool2 ... [force=True|False]
     '''
-    ret = {}
-    pool_present = []
-    if not pools:
-        ret['error'] = 'atleast one storage pool must be specified'
-        return ret
-
-    for pool in pools:
-        if not __salt__['zpool.exists'](pool):
-            ret[pool] = 'storage pool does not exist'
-        else:
-            pool_present.append(pool)
-
+    ## Configure pool
+    # NOTE: initialize the defaults
     flags = []
+    targets = []
 
+    # NOTE: set extra config based on kwargs
     if kwargs.get('force', False):
         flags.append('-f')
 
-    for pool in pool_present:
-        res = __salt__['cmd.run_all'](
-            __utils__['zfs.zpool_command'](
-                command='export',
-                flags=flags,
-                target=pool,
-            ),
-            python_shell=False,
-        )
-        if res['retcode'] != 0:
-            ret[pool] = res['stderr'] if 'stderr' in res else res['stdout']
-        else:
-            ret[pool] = 'exported'
+    # NOTE: append the pool name and specifications
+    targets = list(pools)
 
-    return ret
+    ## Export pools
+    res = __salt__['cmd.run_all'](
+        __utils__['zfs.zpool_command'](
+            command='export',
+            flags=flags,
+            target=targets,
+        ),
+        python_shell=False,
+    )
+
+    return __utils__['zfs.parse_command_result'](res, 'exported')
 
 
 def import_(zpool=None, new_name=None, **kwargs):
     '''
-    .. versionadded:: 2015.5.0
-    .. versionchanged:: 2016.3.0
-
     Import storage pools or list pools available for import
 
     zpool : string
@@ -1173,6 +1145,19 @@ def import_(zpool=None, new_name=None, **kwargs):
         import the pool without mounting any file systems.
     only_destroyed : boolean
         imports destroyed pools only. this also sets force=True.
+    recovery : bool|str
+        false: do not try to recovery broken pools
+        true: try to recovery the pool by rolling back the latest transactions
+        test: check if a pool can be recovered, but don't import it
+        nolog: allow import without log device, recent transactions might be lost
+
+        .. note::
+            If feature flags are not support this forced to the default of 'false'
+
+        .. warning::
+            When recovery is set to 'test' the result will be have imported set to True if the pool
+            can be imported. The pool might also be imported if the pool was not broken to begin with.
+
     properties : dict
         additional pool properties
 
@@ -1184,6 +1169,9 @@ def import_(zpool=None, new_name=None, **kwargs):
 
             properties="{'property1': 'value1', 'property2': 'value2'}"
 
+    .. versionadded:: 2015.5.0
+    .. versionchanged:: Fluorine
+
     CLI Example:
 
     .. code-block:: bash
@@ -1192,41 +1180,47 @@ def import_(zpool=None, new_name=None, **kwargs):
         salt '*' zpool.import myzpool [mynewzpool] [force=True|False]
         salt '*' zpool.import myzpool dir='/tmp'
     '''
-    ret = {}
-
-    ## initialize defaults
+    ## Configure pool
+    # NOTE: initialize the defaults
     flags = []
     opts = {}
     target = []
 
-    ## build flags and options
-    if kwargs.get('force', False):
+    # NOTE: push pool and filesystem properties
+    pool_properties = kwargs.get('properties', {})
+
+    # NOTE: set extra config based on kwargs
+    if kwargs.get('force', False) or kwargs.get('only_destroyed', False):
         flags.append('-f')
+    if kwargs.get('only_destroyed', False):
+        flags.append('-D')
     if kwargs.get('no_mount', False):
         flags.append('-N')
-    if kwargs.get('only_destroyed', False):
-        if '-f' not in flags:
-            flags.append('-f')
-        flags.append('-D')
-    if not zpool:
-        flags.append('-a')
-    else:
-        target.append(zpool)
-    if zpool and new_name:
-        target.append(new_name)
     if kwargs.get('altroot', False):
         opts['-R'] = kwargs.get('altroot')
     if kwargs.get('mntopts', False):
+        # NOTE: -o is used for both mount options and pool properties!
+        #       ```-o nodevices,noexec,nosetuid,ro``` vs ```-o prop=val```
         opts['-o'] = kwargs.get('mntopts')
-    for d in kwargs.get('dir', '').split(','):
-        if '-d' not in opts:
-            opts['-d'] = []
-        opts['-d'].append(d)
+    if kwargs.get('dir', False):
+        opts['-d'] = kwargs.get('dir').split(',')
+    if kwargs.get('recovery', False) and __utils__['zfs.has_feature_flags']():
+        recovery = kwargs.get('recovery')
+        if recovery in [True, 'test']:
+            flags.append('-F')
+        if recovery == 'test':
+            flags.append('-n')
+        if recovery == 'nolog':
+            flags.append('-m')
 
-    ## pool properties
-    pool_properties = kwargs.get('properties', None)
+    # NOTE: append the pool name and specifications
+    if zpool:
+        target.append(zpool)
+        target.append(new_name)
+    else:
+        flags.append('-a')
 
-    ## execute import
+    ## Import storage pool
     res = __salt__['cmd.run_all'](
         __utils__['zfs.zpool_command'](
             command='import',
@@ -1238,25 +1232,11 @@ def import_(zpool=None, new_name=None, **kwargs):
         python_shell=False,
     )
 
-    if res['retcode'] != 0 and res['stderr'] != '':
-        if zpool:
-            ret[zpool] = res['stderr'] if 'stderr' in res else res['stdout']
-        else:
-            ret['error'] = res['stderr'] if 'stderr' in res else res['stdout']
-    else:
-        if zpool:
-            pool = new_name if zpool and new_name else zpool
-            ret[pool] = 'imported' if __salt__['zpool.exists'](pool) else 'not found'
-        else:
-            ret = True
-    return ret
+    return __utils__['zfs.parse_command_result'](res, 'imported')
 
 
 def online(zpool, *vdevs, **kwargs):
     '''
-    .. versionadded:: 2015.5.0
-    .. versionchanged:: 2016.3.0
-
     Ensure that the specified devices are online
 
     zpool : string
@@ -1270,6 +1250,9 @@ def online(zpool, *vdevs, **kwargs):
             If the device is part of a mirror or raidz then all devices must be
             expanded before the new space will become available to the pool.
 
+    .. versionadded:: 2015.5.0
+    .. versionchanged:: Fluorine
+
     CLI Example:
 
     .. code-block:: bash
@@ -1277,18 +1260,7 @@ def online(zpool, *vdevs, **kwargs):
         salt '*' zpool.online myzpool /path/to/vdev1 [...]
 
     '''
-    ret = {}
-    dlist = []
-
-    # Check if the pool_name exists
-    if not __salt__['zpool.exists'](zpool):
-        ret[zpool] = 'storage pool does not exist'
-        return ret
-
-    if not vdevs:
-        ret[zpool] = 'no devices specified'
-        return ret
-
+    ## Configure pool
     # default options
     flags = []
     target = []
@@ -1300,7 +1272,20 @@ def online(zpool, *vdevs, **kwargs):
     if vdevs:
         target.extend(vdevs)
 
-    # bring all specified devices online
+    ## Configure pool
+    # NOTE: initialize the defaults
+    flags = []
+    target = []
+
+    # NOTE: set extra config based on kwargs
+    if kwargs.get('expand', False):
+        flags.append('-e')
+
+    # NOTE: append the pool name and specifications
+    target.append(zpool)
+    target.extend(vdevs)
+
+    ## Bring online device
     res = __salt__['cmd.run_all'](
         __utils__['zfs.zpool_command'](
             command='online',
@@ -1310,18 +1295,11 @@ def online(zpool, *vdevs, **kwargs):
         python_shell=False,
     )
 
-    if res['retcode'] != 0:
-        ret[zpool] = res['stderr'] if 'stderr' in res else res['stdout']
-    else:
-        ret[zpool] = 'onlined {0}'.format(' '.join(vdevs))
-    return ret
+    return __utils__['zfs.parse_command_result'](res, 'onlined')
 
 
 def offline(zpool, *vdevs, **kwargs):
     '''
-    .. versionadded:: 2015.5.0
-    .. versionchanged:: 2016.3.0
-
     Ensure that the specified devices are offline
 
     .. warning::
@@ -1336,37 +1314,29 @@ def offline(zpool, *vdevs, **kwargs):
     temporary : boolean
         enable temporarily offline
 
+    .. versionadded:: 2015.5.0
+    .. versionchanged:: Fluorine
+
     CLI Example:
 
     .. code-block:: bash
 
         salt '*' zpool.offline myzpool /path/to/vdev1 [...] [temporary=True|False]
     '''
-    ret = {zpool: {}}
-
-    # Check if the pool_name exists
-    if not __salt__['zpool.exists'](zpool):
-        ret[zpool] = 'storage pool does not exist'
-        return ret
-
-    if not vdevs or len(vdevs) <= 0:
-        ret[zpool] = 'no devices specified'
-        return ret
-
-    # default options
+    ## Configure pool
+    # NOTE: initialize the defaults
     flags = []
     target = []
 
-    # set flags and options
+    # NOTE: set extra config based on kwargs
     if kwargs.get('temporary', False):
         flags.append('-t')
-    target.append(zpool)
-    if vdevs:
-        target.extend(vdevs)
 
-    # bring all specified devices offline
-    # NOTE: we don't check if the device exists
-    #       a device can be offlined until a replacement is available
+    # NOTE: append the pool name and specifications
+    target.append(zpool)
+    target.extend(vdevs)
+
+    ## Take a device offline
     res = __salt__['cmd.run_all'](
         __utils__['zfs.zpool_command'](
             command='offline',
@@ -1375,17 +1345,12 @@ def offline(zpool, *vdevs, **kwargs):
         ),
         python_shell=False,
     )
-    if res['retcode'] != 0:
-        ret[zpool] = res['stderr'] if 'stderr' in res else res['stdout']
-    else:
-        ret[zpool] = 'offlined {0}'.format(' '.join(vdevs))
-    return ret
+
+    return __utils__['zfs.parse_command_result'](res, 'offlined')
 
 
 def labelclear(device, force=False):
     '''
-    .. versionadded:: Oxygen
-
     Removes ZFS label information from the specified device
 
     .. warning::
@@ -1397,15 +1362,16 @@ def labelclear(device, force=False):
     force : boolean
         treat exported or foreign devices as inactive
 
+    .. versionadded:: Oxygen
+    .. versionchanged:: Fluorine
+
     CLI Example:
 
     .. code-block:: bash
 
         salt '*' zpool.labelclear /path/to/dev
     '''
-    ret = {}
-
-    # clear label for all specified devices
+    ## clear label for all specified device
     res = __salt__['cmd.run_all'](
         __utils__['zfs.zpool_command'](
             command='labelclear',
@@ -1414,23 +1380,54 @@ def labelclear(device, force=False):
         ),
         python_shell=False,
     )
-    if res['retcode'] != 0:
-        ## NOTE: skip the "use '-f' hint"
-        res['stderr'] = res['stderr'].split("\n")
-        if len(res['stderr']) >= 1:
-            if res['stderr'][0].startswith("use '-f'"):
-                del res['stderr'][0]
-        res['stderr'] = "\n".join(res['stderr'])
-        ret[device] = res['stderr'] if 'stderr' in res and res['stderr'] else res['stdout']
-    else:
-        ret[device] = 'cleared'
-    return ret
+
+    return __utils__['zfs.parse_command_result'](res, 'labelcleared')
+
+
+def clear(zpool, device=None):
+    '''
+    Clears device errors in a pool.
+
+    .. warning::
+
+        The device must not be part of an active pool configuration.
+
+    zpool : string
+        name of storage pool
+    device : string
+        (optional) specific device to clear
+
+    .. versionadded:: Fluorine
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' zpool.clear mypool
+        salt '*' zpool.clear mypool /path/to/dev
+    '''
+    ## Configure pool
+    # NOTE: initialize the defaults
+    target = []
+
+    # NOTE: append the pool name and specifications
+    target.append(zpool)
+    target.append(device)
+
+    ## clear storage pool errors
+    res = __salt__['cmd.run_all'](
+        __utils__['zfs.zpool_command'](
+            command='clear',
+            target=target,
+        ),
+        python_shell=False,
+    )
+
+    return __utils__['zfs.parse_command_result'](res, 'cleared')
 
 
 def reguid(zpool):
     '''
-    .. versionadded:: 2016.3.0
-
     Generates a new unique identifier for the pool
 
     .. warning::
@@ -1440,14 +1437,16 @@ def reguid(zpool):
     zpool : string
         name of storage pool
 
+    .. versionadded:: 2016.3.0
+    .. versionchanged:: Fluorine
+
     CLI Example:
 
     .. code-block:: bash
 
         salt '*' zpool.reguid myzpool
     '''
-    ret = {zpool: {}}
-
+    ## generate new GUID for pool
     res = __salt__['cmd.run_all'](
         __utils__['zfs.zpool_command'](
             command='reguid',
@@ -1455,21 +1454,19 @@ def reguid(zpool):
         ),
         python_shell=False,
     )
-    if res['retcode'] != 0:
-        ret[zpool] = res['stderr'] if 'stderr' in res and res['stderr'] != '' else res['stdout']
-    else:
-        ret[zpool] = 'reguided'
-    return ret
+
+    return __utils__['zfs.parse_command_result'](res, 'reguided')
 
 
 def reopen(zpool):
     '''
-    .. versionadded:: 2016.3.0
-
     Reopen all the vdevs associated with the pool
 
     zpool : string
         name of storage pool
+
+    .. versionadded:: 2016.3.0
+    .. versionchanged:: Fluorine
 
     CLI Example:
 
@@ -1477,8 +1474,7 @@ def reopen(zpool):
 
         salt '*' zpool.reopen myzpool
     '''
-    ret = {zpool: {}}
-
+    ## reopen all devices fro pool
     res = __salt__['cmd.run_all'](
         __utils__['zfs.zpool_command'](
             command='reopen',
@@ -1486,17 +1482,12 @@ def reopen(zpool):
         ),
         python_shell=False,
     )
-    if res['retcode'] != 0:
-        ret[zpool] = res['stderr'] if 'stderr' in res and res['stderr'] != '' else res['stdout']
-    else:
-        ret[zpool] = 'reopened'
-    return ret
+
+    return __utils__['zfs.parse_command_result'](res, 'reopened')
 
 
 def upgrade(zpool=None, version=None):
     '''
-    .. versionadded:: 2016.3.0
-
     Enables all supported features on the given pool
 
     .. warning::
@@ -1509,20 +1500,27 @@ def upgrade(zpool=None, version=None):
     version : int
         version to upgrade to, if unspecified upgrade to the highest possible
 
+    .. versionadded:: 2016.3.0
+    .. versionchanged:: Fluorine
+
     CLI Example:
 
     .. code-block:: bash
 
         salt '*' zpool.upgrade myzpool
     '''
-    ret = {}
-
+    ## Configure pool
+    # NOTE: initialize the defaults
     flags = []
     opts = {}
+
+    # NOTE: set extra config
     if version:
         opts['-V'] = version
     if not zpool:
         flags.append('-a')
+
+    ## Upgrade pool
     res = __salt__['cmd.run_all'](
         __utils__['zfs.zpool_command'](
             command='upgrade',
@@ -1532,23 +1530,12 @@ def upgrade(zpool=None, version=None):
         ),
         python_shell=False,
     )
-    if res['retcode'] != 0:
-        if zpool:
-            ret[zpool] = res['stderr'] if 'stderr' in res and res['stderr'] != '' else res['stdout']
-        else:
-            ret['error'] = res['stderr'] if 'stderr' in res and res['stderr'] != '' else res['stdout']
-    else:
-        if zpool:
-            ret[zpool] = 'upgraded to {0}'.format('version {0}'.format(version) if version else 'the highest supported version')
-        else:
-            ret = 'all pools upgraded to {0}'.format('version {0}'.format(version) if version else 'the highest supported version')
-    return ret
+
+    return __utils__['zfs.parse_command_result'](res, 'upgraded')
 
 
 def history(zpool=None, internal=False, verbose=False):
     '''
-    .. versionadded:: 2016.3.0
-
     Displays the command history of the specified pools or all pools if no pool is specified
 
     zpool : string
@@ -1558,19 +1545,28 @@ def history(zpool=None, internal=False, verbose=False):
     verbose : boolean
         toggle display of the user name, the hostname, and the zone in which the operation was performed
 
+    .. versionadded:: 2016.3.0
+    .. versionchanged:: Fluorine
+
     CLI Example:
 
     .. code-block:: bash
 
         salt '*' zpool.upgrade myzpool
     '''
-    ret = {}
+    ret = OrderedDict()
 
+    ## Configure pool
+    # NOTE: initialize the defaults
     flags = []
+
+    # NOTE: set extra config
     if verbose:
         flags.append('-l')
     if internal:
         flags.append('-i')
+
+    ## Lookup history
     res = __salt__['cmd.run_all'](
         __utils__['zfs.zpool_command'](
             command='history',
@@ -1579,21 +1575,21 @@ def history(zpool=None, internal=False, verbose=False):
         ),
         python_shell=False,
     )
+
     if res['retcode'] != 0:
-        if zpool:
-            ret[zpool] = res['stderr'] if 'stderr' in res and res['stderr'] != '' else res['stdout']
-        else:
-            ret['error'] = res['stderr'] if 'stderr' in res and res['stderr'] != '' else res['stdout']
+        return __utils__['zfs.parse_command_result'](res)
     else:
         pool = 'unknown'
         for line in res['stdout'].splitlines():
             if line.startswith('History for'):
                 pool = line[13:-2]
-                ret[pool] = []
+                ret[pool] = OrderedDict()
             else:
                 if line == '':
                     continue
-                ret[pool].append(line)
+                log_timestamp = line[0:19]
+                log_command = line[20:]
+                ret[pool][log_timestamp] = log_command
 
     return ret
 

--- a/salt/utils/zfs.py
+++ b/salt/utils/zfs.py
@@ -1,0 +1,713 @@
+# -*- coding: utf-8 -*-
+'''
+Utility functions for zfs
+
+These functions are for dealing with type conversion and basic execution
+
+:maintainer:    Jorge Schrauwen <sjorge@blackdot.be>
+:maturity:      new
+:depends:       salt.utils.stringutils, salt.ext, salt.module.cmdmod
+:platform:      illumos,freebsd,linux
+
+.. versionadded:: Fluorine
+'''
+
+# Import python libs
+from __future__ import absolute_import
+import os
+import re
+import math
+import logging
+from numbers import Number
+
+# Import salt libs
+from salt.utils.decorators import memoize as real_memoize
+from salt.utils.odict import OrderedDict
+import salt.utils.stringutils
+import salt.modules.cmdmod
+
+# Import 3rd-party libs
+from salt.ext.six.moves import zip
+
+# Size conversion data
+re_zfs_size = re.compile(r'^(\d+|\d+(?=\d*)\.\d+)([KkMmGgTtPpEe][Bb]?)$')
+zfs_size = ['K', 'M', 'G', 'T', 'P', 'E']
+
+log = logging.getLogger(__name__)
+
+
+def _check_retcode(cmd):
+    '''
+    Simple internal wrapper for cmdmod.retcode
+    '''
+    return salt.modules.cmdmod.retcode(cmd, output_loglevel='quiet', ignore_retcode=True) == 0
+
+
+def _exec(**kwargs):
+    '''
+    Simple internal wrapper for cmdmod.run
+    '''
+    if 'ignore_retcode' not in kwargs:
+        kwargs['ignore_retcode'] = True
+    if 'output_loglevel' not in kwargs:
+        kwargs['output_loglevel'] = 'quiet'
+    return salt.modules.cmdmod.run_all(**kwargs)
+
+
+def _merge_last(values, merge_after, merge_with=' '):
+    '''
+    Merge values all values after X into the last value
+    '''
+    if len(values) > merge_after:
+        values = values[0:(merge_after-1)] + [merge_with.join(values[(merge_after-1):])]
+
+    return values
+
+
+def _property_normalize_name(name):
+    '''
+    Normalizes property names
+    '''
+    if '@' in name:
+        name = name[:name.index('@')+1]
+    return name
+
+
+def _property_detect_type(name, values):
+    '''
+    Detect the datatype of a property
+    '''
+    value_type = 'str'
+    if values.startswith('on | off'):
+        value_type = 'bool'
+    elif values.startswith('yes | no'):
+        value_type = 'bool_alt'
+    elif values in ['<size>', '<size> | none']:
+        value_type = 'size'
+    elif values in ['<count>', '<count> | none']:
+        value_type = 'numeric'
+    elif name in ['sharenfs', 'sharesmb', 'canmount']:
+        value_type = 'bool'
+    elif name in ['version', 'copies']:
+        value_type = 'numeric'
+    return value_type
+
+
+def _property_create_dict(header, data):
+    '''
+    Create a property dict
+    '''
+    prop = dict(zip(header, _merge_last(data, len(header))))
+    prop['name'] = _property_normalize_name(prop['property'])
+    prop['type'] = _property_detect_type(prop['name'], prop['values'])
+    prop['edit'] = from_bool(prop['edit'])
+    if 'inherit' in prop:
+        prop['inherit'] = from_bool(prop['inherit'])
+    del prop['property']
+    return prop
+
+
+def _property_parse_cmd(cmd, alias=None):
+    '''
+    Parse output of zpool/zfs get command
+    '''
+    if not alias:
+        alias = {}
+    properties = {}
+
+    # NOTE: append get to command
+    if cmd[-3:] != 'get':
+        cmd += ' get'
+
+    # NOTE: parse output
+    prop_hdr = []
+    for prop_data in _exec(cmd=cmd)['stderr'].split('\n'):
+        # NOTE: make the line data more managable
+        prop_data = prop_data.lower().split()
+
+        # NOTE: skip empty lines
+        if len(prop_data) == 0:
+            continue
+        # NOTE: parse header
+        elif prop_data[0] == 'property':
+            prop_hdr = prop_data
+            continue
+        # NOTE: skip lines after data
+        elif len(prop_hdr) == 0 or prop_data[1] not in ['no', 'yes']:
+            continue
+
+        # NOTE: create property dict
+        prop = _property_create_dict(prop_hdr, prop_data)
+
+        # NOTE: add property to dict
+        properties[prop['name']] = prop
+        if prop['name'] in alias:
+            properties[alias[prop['name']]] = prop
+
+        # NOTE: cleanup some duplicate data
+        del prop['name']
+    return properties
+
+
+def _auto(direction, name, value, source='auto', convert_to_human=True):
+    '''
+    Internal magic for from_auto and to_auto
+    '''
+    # NOTE: check direction
+    if direction not in ['to', 'from']:
+        return value
+
+    # NOTE: collect property data
+    props = property_data_zpool()
+    if source == 'zfs':
+        props = property_data_zfs()
+    elif source == 'auto':
+        props.update(property_data_zfs())
+
+    # NOTE: figure out the conversion type
+    value_type = props[name]['type'] if name in props else 'str'
+
+    # NOTE: convert
+    if value_type == 'size' and direction == 'to':
+        return globals()['{}_{}'.format(direction, value_type)](value, convert_to_human)
+
+    return globals()['{}_{}'.format(direction, value_type)](value)
+
+
+@real_memoize
+def _zfs_cmd():
+    '''
+    Return the path of the zfs binary if present
+    '''
+    # Get the path to the zfs binary.
+    return salt.utils.path.which('zfs')
+
+
+@real_memoize
+def _zpool_cmd():
+    '''
+    Return the path of the zpool binary if present
+    '''
+    # Get the path to the zfs binary.
+    return salt.utils.path.which('zpool')
+
+
+def _command(source, command, flags=None, opts=None,
+             property_name=None, property_value=None,
+             filesystem_properties=None, pool_properties=None,
+             target=None):
+    '''
+    Build and properly escape a zfs command
+
+    .. note::
+
+        Input is not considered safe and will be passed through
+        to_auto(from_auto('input_here')), you do not need to do so
+        your self first.
+
+    '''
+    # NOTE: start with the zfs binary and command
+    cmd = []
+    cmd.append(_zpool_cmd() if source == 'zpool' else _zfs_cmd())
+    cmd.append(command)
+
+    # NOTE: append flags if we have any
+    if flags is None:
+        flags = []
+    for flag in flags:
+        cmd.append(flag)
+
+    # NOTE: append options
+    #       we pass through 'sorted' to garentee the same order
+    if opts is None:
+        opts = {}
+    for opt in sorted(opts):
+        if not isinstance(opts[opt], list):
+            opts[opt] = [opts[opt]]
+        for val in opts[opt]:
+            cmd.append(opt)
+            cmd.append(to_str(val))
+
+    # NOTE: append filesystem properties (really just options with a key/value)
+    #       we pass through 'sorted' to garentee the same order
+    if filesystem_properties is None:
+        filesystem_properties = {}
+    for fsopt in sorted(filesystem_properties):
+        cmd.append('-O' if source == 'zpool' else '-o')
+        cmd.append('{key}={val}'.format(
+            key=fsopt,
+            val=to_auto(fsopt, from_auto(fsopt, filesystem_properties[fsopt]), source='zfs', convert_to_human=False),
+        ))
+
+    # NOTE: append pool properties (really just options with a key/value)
+    #       we pass through 'sorted' to garentee the same order
+    if pool_properties is None:
+        pool_properties = {}
+    for fsopt in sorted(pool_properties):
+        cmd.append('-o')
+        cmd.append('{key}={val}'.format(
+            key=fsopt,
+            val=to_auto(fsopt, from_auto(fsopt, pool_properties[fsopt]), source='zpool', convert_to_human=False),
+        ))
+
+    # NOTE: append property and value
+    #       the set command takes a key=value pair, we need to support this
+    if property_name is not None:
+        if property_value is not None:
+            if not isinstance(property_name, list):
+                property_name = [property_name]
+            if not isinstance(property_value, list):
+                property_value = [property_value]
+            for key, val in zip(property_name, property_value):
+                cmd.append('{key}={val}'.format(
+                    key=key,
+                    val=to_auto(key, val, source=source, convert_to_human=False),
+                ))
+        else:
+            cmd.append(property_name)
+
+    # NOTE: append the target(s)
+    if target is not None:
+        if not isinstance(target, list):
+            target = [target]
+        for tgt in target:
+            # NOTE: skip None list items
+            #       we do not want to skip False and 0!
+            if tgt is None:
+                continue
+            cmd.append(to_str(from_str(tgt)))
+
+    return ' '.join(cmd)
+
+
+@real_memoize
+def is_supported():
+    '''
+    Check the system for ZFS support
+    '''
+    # Check for supported platforms
+    # NOTE: ZFS on Windows is in development
+    # NOTE: ZFS on NetBSD is in development
+    on_supported_platform = False
+    if salt.utils.platform.is_sunos():
+        on_supported_platform = True
+    elif salt.utils.platform.is_freebsd() and _check_retcode('kldstat -q -m zfs'):
+        on_supported_platform = True
+    elif salt.utils.platform.is_linux() and os.path.exists('/sys/module/zfs'):
+        on_supported_platform = True
+    elif salt.utils.platform.is_linux() and salt.utils.path.which('zfs-fuse'):
+        on_supported_platform = True
+    elif salt.utils.platform.is_darwin() and \
+         os.path.exists('/Library/Extensions/zfs.kext') and \
+         os.path.exists('/dev/zfs'):
+        on_supported_platform = True
+
+    # Additional check for the zpool command
+    return (_zpool_cmd() and on_supported_platform) is True
+
+
+@real_memoize
+def has_feature_flags():
+    '''
+    Check if zpool-features is available
+    '''
+    # get man location
+    man = salt.utils.path.which('man')
+    return _check_retcode('{man} zpool-features'.format(
+        man=man
+    )) if man else False
+
+
+@real_memoize
+def property_data_zpool():
+    '''
+    Return a dict of zpool properties
+
+    .. note::
+
+        Each property will have an entry with the following info:
+            - edit : boolean - is this property editable after pool creation
+            - type : str - either bool, bool_alt, size, numeric, or string
+            - values : str - list of possible values
+
+    .. warning::
+
+        This data is probed from the output of 'zpool get' with some suplimental
+        data that is hardcoded. There is no better way to get this informatio aside
+        from reading the code.
+
+    '''
+    property_data = _property_parse_cmd(_zpool_cmd(), {
+        'listsnapshots': 'listsnaps',
+        'autoexpand': 'expand',
+        'autoreplace': 'replace',
+    })
+
+    # NOTE: zpool status/iostat has a few extra fields
+    zpool_size_extra = [
+        'capacity-alloc', 'capacity-free',
+        'operations-read', 'operations-write',
+        'bandwith-read', 'bandwith-write',
+        'read', 'write',
+    ]
+
+    for prop in zpool_size_extra:
+        property_data[prop] = {
+            'edit': False,
+            'type': 'size',
+            'values': '<size>',
+        }
+
+    property_data['cksum'] = {
+        'edit': False,
+        'type': 'numeric',
+        'values': '<count>',
+    }
+
+    return property_data
+
+
+@real_memoize
+def property_data_zfs():
+    '''
+    Return a dict of zfs properties
+
+    .. note::
+
+        Each property will have an entry with the following info:
+            - edit : boolean - is this property editable after pool creation
+            - inherit : boolean - is this property inheritable
+            - type : str - either bool, bool_alt, size, numeric, or string
+            - values : str - list of possible values
+
+    .. warning::
+
+        This data is probed from the output of 'zfs get' with some suplimental
+        data that is hardcoded. There is no better way to get this informatio aside
+        from reading the code.
+
+    '''
+    return _property_parse_cmd(_zfs_cmd(), {
+        'available': 'avail',
+        'logicalreferenced': 'lrefer.',
+        'logicalused': 'lused.',
+        'referenced': 'refer',
+        'volblocksize': 'volblock',
+        'compression': 'compress',
+        'readonly': 'rdonly',
+        'recordsize': 'recsize',
+        'refreservation': 'refreserv',
+        'reservation': 'reserv',
+    })
+
+
+def from_numeric(value):
+    '''
+    Convert zfs numeric to python int
+    '''
+    if value == 'none':
+        value = None
+    elif value:
+        value = salt.utils.stringutils.to_num(value)
+    return value
+
+
+def to_numeric(value):
+    '''
+    Convert python int to zfs numeric
+    '''
+    value = from_numeric(value)
+    if value is None:
+        value = 'none'
+    return value
+
+
+def from_bool(value):
+    '''
+    Convert zfs bool to python bool
+    '''
+    if value in ['on', 'yes']:
+        value = True
+    elif value in ['off', 'no']:
+        value = False
+    elif value == 'none':
+        value = None
+
+    return value
+
+
+def from_bool_alt(value):
+    '''
+    Convert zfs bool_alt to python bool
+    '''
+    return from_bool(value)
+
+
+def to_bool(value):
+    '''
+    Convert python bool to zfs on/off bool
+    '''
+    value = from_bool(value)
+    if isinstance(value, bool):
+        value = 'on' if value else 'off'
+    elif value is None:
+        value = 'none'
+
+    return value
+
+
+def to_bool_alt(value):
+    '''
+    Convert python to zfs yes/no value
+    '''
+    value = from_bool_alt(value)
+    if isinstance(value, bool):
+        value = 'yes' if value else 'no'
+    elif value is None:
+        value = 'none'
+
+    return value
+
+
+def from_size(value):
+    '''
+    Convert zfs size (human readble) to python int (bytes)
+    '''
+    match_size = re_zfs_size.match(str(value))
+    if match_size:
+        v_unit = match_size.group(2).upper()[0]
+        v_size = float(match_size.group(1))
+        v_multiplier = math.pow(1024, zfs_size.index(v_unit) + 1)
+        value = v_size * v_multiplier
+        if int(value) == value:
+            value = int(value)
+    elif value is not None:
+        value = str(value)
+
+    return from_numeric(value)
+
+
+def to_size(value, convert_to_human=True):
+    '''
+    Convert python int (bytes) to zfs size
+
+    NOTE: http://src.illumos.org/source/xref/illumos-gate/usr/src/lib/pyzfs/common/util.py#114
+    '''
+    value = from_size(value)
+    if value is None:
+        value = 'none'
+
+    if isinstance(value, Number) and value > 1024 and convert_to_human:
+        v_power = int(math.floor(math.log(value, 1024)))
+        v_multiplier = math.pow(1024, v_power)
+
+        # NOTE: zfs is a bit odd on how it does the rounding,
+        #       see libzfs implementation linked above
+        v_size_float = float(value) / v_multiplier
+        if v_size_float == int(v_size_float):
+            value = "{:.0f}{}".format(
+                v_size_float,
+                zfs_size[v_power-1],
+            )
+        else:
+            for v_precision in ["{:.2f}{}", "{:.1f}{}", "{:.0f}{}"]:
+                v_size = v_precision.format(
+                    v_size_float,
+                    zfs_size[v_power-1],
+                )
+                if len(v_size) <= 5:
+                    value = v_size
+                    break
+
+    return value
+
+
+def from_str(value):
+    '''
+    Decode zfs safe string (used for name, path, ...)
+    '''
+    if value == 'none':
+        value = None
+    if value:
+        value = str(value)
+        if value.startswith('"') and value.endswith('"'):
+            value = value[1:-1]
+        value = value.replace('\\"', '"')
+
+    return value
+
+
+def to_str(value):
+    '''
+    Encode zfs safe string (used for name, path, ...)
+    '''
+    value = from_str(value)
+
+    if value:
+        value = value.replace('"', '\\"')
+        if ' ' in value:
+            value = '"' + value + '"'
+    elif value is None:
+        value = 'none'
+
+    return value
+
+
+def from_auto(name, value, source='auto'):
+    '''
+    Convert zfs value to python value
+    '''
+    return _auto('from', name, value, source)
+
+
+def to_auto(name, value, source='auto', convert_to_human=True):
+    '''
+    Convert python value to zfs value
+    '''
+    return _auto('to', name, value, source, convert_to_human)
+
+
+def from_auto_dict(values, source='auto'):
+    '''
+    Pass an entire dictionary to from_auto
+
+    .. note::
+        The key will be passed as the name
+    '''
+    for name, value in values.items():
+        values[name] = from_auto(name, value, source)
+
+    return values
+
+
+def to_auto_dict(values, source='auto', convert_to_human=True):
+    '''
+    Pass an entire dictionary to to_auto
+
+    .. note::
+        The key will be passed as the name
+    '''
+    for name, value in values.items():
+        values[name] = to_auto(name, value, source, convert_to_human)
+
+    return values
+
+
+def is_snapshot(name):
+    '''
+    Check if name is a valid snapshot name
+    '''
+    return from_str(name).count('@') == 1
+
+
+def is_bookmark(name):
+    '''
+    Check if name is a valid bookmark name
+    '''
+    return from_str(name).count('#') == 1
+
+
+def is_filesystem(name):
+    '''
+    Check if name is a valid filesystem name
+    '''
+    return not is_snapshot(name) and not is_bookmark(name)
+
+
+def is_volume(name):
+    '''
+    Check if name is a valid volume name
+    '''
+    # NOTE: filesystems and volumes have the same name format
+    return is_filesystem(name)
+
+
+def zfs_command(command, flags=None, opts=None, property_name=None, property_value=None,
+                filesystem_properties=None, target=None):
+    '''
+    Build and properly escape a zfs command
+
+    .. note::
+
+        Input is not considered safe and will be passed through
+        to_auto(from_auto('input_here')), you do not need to do so
+        your self first.
+
+    '''
+    return _command(
+        'zfs',
+        command=command,
+        flags=flags,
+        opts=opts,
+        property_name=property_name,
+        property_value=property_value,
+        filesystem_properties=filesystem_properties,
+        pool_properties=None,
+        target=target,
+    )
+
+
+def zpool_command(command, flags=None, opts=None, property_name=None, property_value=None,
+                  filesystem_properties=None, pool_properties=None, target=None):
+    '''
+    Build and properly escape a zpool command
+
+    .. note::
+
+        Input is not considered safe and will be passed through
+        to_auto(from_auto('input_here')), you do not need to do so
+        your self first.
+
+    '''
+    return _command(
+        'zpool',
+        command=command,
+        flags=flags,
+        opts=opts,
+        property_name=property_name,
+        property_value=property_value,
+        filesystem_properties=filesystem_properties,
+        pool_properties=pool_properties,
+        target=target,
+    )
+
+
+def parse_command_result(res, label=None):
+    '''
+    Parse the result of a zpool/zfs command
+
+    .. note::
+
+        Output on failure is rather predicatable.
+        - retcode > 0
+        - each 'error' is a line on stderr
+        - optional 'Usage:' block under those with hits
+
+        We simple check those and return a OrderedDict were
+        we set label = True|False and error = error_messages
+
+    '''
+    ret = OrderedDict()
+
+    if label:
+        ret[label] = res['retcode'] == 0
+
+    if res['retcode'] != 0:
+        ret['error'] = []
+        for error in res['stderr'].splitlines():
+            if error.lower().startswith('usage:'):
+                break
+            if error.lower().startswith("use '-f'"):
+                error = error.replace('-f', 'force=True')
+            if error.lower().startswith("use '-r'"):
+                error = error.replace('-r', 'recursive=True')
+            ret['error'].append(error)
+
+        if len(ret['error']):
+            ret['error'] = "\n".join(ret['error'])
+        else:
+            del ret['error']
+
+    return ret
+
+# vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4

--- a/tests/unit/modules/test_zfs.py
+++ b/tests/unit/modules/test_zfs.py
@@ -1,9 +1,12 @@
 # -*- coding: utf-8 -*-
 '''
-    :codeauthor: Nitin Madhok <nmadhok@clemson.edu>`
+Tests for salt.modules.zfs
 
-    tests.unit.modules.zfs_test
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+:codeauthor:    Nitin Madhok <nmadhok@clemson.edu>, Jorge Schrauwen <sjorge@blackdot.be>
+:maintainer:    Jorge Schrauwen <sjorge@blackdot.be>
+:maturity:      new
+:depends:       salt.utils.zfs
+:platform:      illumos,freebsd,linux
 '''
 
 # Import Python libs
@@ -19,8 +22,15 @@ from tests.support.mock import (
     NO_MOCK_REASON,
 )
 
+# Import test data from salt.utils.zfs test
+from tests.unit.utils.test_zfs import utils_patch
+
 # Import Salt Execution module to test
+import salt.utils.zfs
 import salt.modules.zfs as zfs
+
+# Import Salt Utils
+import salt.loader
 from salt.utils.odict import OrderedDict
 
 
@@ -31,10 +41,16 @@ class ZfsTestCase(TestCase, LoaderModuleMockMixin):
     This class contains a set of functions that test salt.modules.zfs module
     '''
     def setup_loader_modules(self):
-        patcher = patch('salt.modules.zfs._check_zfs', MagicMock(return_value='/sbin/zfs'))
-        patcher.start()
-        self.addCleanup(patcher.stop)
-        return {zfs: {}}
+        self.opts = opts = salt.config.DEFAULT_MINION_OPTS
+        utils = salt.loader.utils(opts, whitelist=['zfs'])
+        zfs_obj = {
+            zfs: {
+                '__opts__': opts,
+                '__utils__': utils,
+            }
+        }
+
+        return zfs_obj
 
     def test_exists_success(self):
         '''
@@ -45,7 +61,8 @@ class ZfsTestCase(TestCase, LoaderModuleMockMixin):
         ret['stderr'] = ''
         ret['retcode'] = 0
         mock_cmd = MagicMock(return_value=ret)
-        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zfs.__utils__, utils_patch):
             self.assertTrue(zfs.exists('myzpool/mydataset'))
 
     def test_exists_failure_not_exists(self):
@@ -57,7 +74,8 @@ class ZfsTestCase(TestCase, LoaderModuleMockMixin):
         ret['stderr'] = "cannot open 'myzpool/mydataset': dataset does not exist"
         ret['retcode'] = 1
         mock_cmd = MagicMock(return_value=ret)
-        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zfs.__utils__, utils_patch):
             self.assertFalse(zfs.exists('myzpool/mydataset'))
 
     def test_exists_failure_invalid_name(self):
@@ -69,46 +87,50 @@ class ZfsTestCase(TestCase, LoaderModuleMockMixin):
         ret['stderr'] = "cannot open 'myzpool/': invalid dataset name"
         ret['retcode'] = 1
         mock_cmd = MagicMock(return_value=ret)
-        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zfs.__utils__, utils_patch):
             self.assertFalse(zfs.exists('myzpool/'))
 
     def test_create_success(self):
         '''
         Tests successful return of create function on ZFS file system creation
         '''
-        res = {'myzpool/mydataset': 'created'}
+        res = OrderedDict([('created', True)])
         ret = {}
         ret['stdout'] = ""
         ret['stderr'] = ""
         ret['retcode'] = 0
         mock_cmd = MagicMock(return_value=ret)
-        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zfs.__utils__, utils_patch):
             self.assertEqual(zfs.create('myzpool/mydataset'), res)
 
     def test_create_success_with_create_parent(self):
         '''
         Tests successful return of create function when ``create_parent=True``
         '''
-        res = {'myzpool/mydataset/mysubdataset': 'created'}
+        res = OrderedDict([('created', True)])
         ret = {}
         ret['stdout'] = ""
         ret['stderr'] = ""
         ret['retcode'] = 0
         mock_cmd = MagicMock(return_value=ret)
-        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zfs.__utils__, utils_patch):
             self.assertEqual(zfs.create('myzpool/mydataset/mysubdataset', create_parent=True), res)
 
     def test_create_success_with_properties(self):
         '''
         Tests successful return of create function on ZFS file system creation (with properties)
         '''
-        res = {'myzpool/mydataset': 'created'}
+        res = OrderedDict([('created', True)])
         ret = {}
         ret['stdout'] = ""
         ret['stderr'] = ""
         ret['retcode'] = 0
         mock_cmd = MagicMock(return_value=ret)
-        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zfs.__utils__, utils_patch):
             self.assertEqual(
                 zfs.create(
                     'myzpool/mydataset',
@@ -123,46 +145,61 @@ class ZfsTestCase(TestCase, LoaderModuleMockMixin):
         '''
         Tests unsuccessful return of create function if dataset name is missing
         '''
-        res = {'myzpool': 'cannot create \'myzpool\': missing dataset name'}
+        res = OrderedDict([
+            ('created', False),
+            ('error', "cannot create 'myzpool': missing dataset name"),
+        ])
         ret = {}
         ret['stdout'] = ""
         ret['stderr'] = "cannot create 'myzpool': missing dataset name"
         ret['retcode'] = 1
         mock_cmd = MagicMock(return_value=ret)
-        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zfs.__utils__, utils_patch):
             self.assertEqual(zfs.create('myzpool'), res)
 
     def test_create_error_trailing_slash(self):
         '''
         Tests unsuccessful return of create function if trailing slash in name is present
         '''
-        res = {'myzpool/': 'cannot create \'myzpool/\': trailing slash in name'}
+        res = OrderedDict([
+            ('created', False),
+            ('error', "cannot create 'myzpool/': trailing slash in name"),
+        ])
         ret = {}
         ret['stdout'] = ""
         ret['stderr'] = "cannot create 'myzpool/': trailing slash in name"
         ret['retcode'] = 1
         mock_cmd = MagicMock(return_value=ret)
-        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zfs.__utils__, utils_patch):
             self.assertEqual(zfs.create('myzpool/'), res)
 
     def test_create_error_no_such_pool(self):
         '''
         Tests unsuccessful return of create function if the pool is not present
         '''
-        res = {'myzpool/mydataset': 'cannot create \'myzpool/mydataset\': no such pool \'myzpool\''}
+        res = OrderedDict([
+            ('created', False),
+            ('error', "cannot create 'myzpool/mydataset': no such pool 'myzpool'"),
+        ])
         ret = {}
         ret['stdout'] = ""
         ret['stderr'] = "cannot create 'myzpool/mydataset': no such pool 'myzpool'"
         ret['retcode'] = 1
         mock_cmd = MagicMock(return_value=ret)
-        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zfs.__utils__, utils_patch):
             self.assertEqual(zfs.create('myzpool/mydataset'), res)
 
     def test_create_error_missing_parent(self):
         '''
         Tests unsuccessful return of create function if the parent datasets do not exist
         '''
-        res = {'myzpool/mydataset/mysubdataset': 'cannot create \'myzpool/mydataset/mysubdataset\': parent does not exist'}
+        res = OrderedDict([
+            ('created', False),
+            ('error', "cannot create 'myzpool/mydataset/mysubdataset': parent does not exist"),
+        ])
         ret = {}
         ret['stdout'] = ""
         ret['stderr'] = "cannot create 'myzpool/mydataset/mysubdataset': parent does not exist"
@@ -171,129 +208,361 @@ class ZfsTestCase(TestCase, LoaderModuleMockMixin):
         with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
             self.assertEqual(zfs.create('myzpool/mydataset/mysubdataset'), res)
 
-    def test_list_success(self):
+    def test_destroy_success(self):
         '''
-        Tests zfs list
+        Tests successful return of destroy function on ZFS file system destruction
         '''
-        res = OrderedDict([('myzpool', {'avail': '954G', 'mountpoint': '/myzpool', 'used': '844G', 'refer': '96K'})])
-        ret = {'pid': 31817, 'retcode': 0, 'stderr': '', 'stdout': 'myzpool\t844G\t954G\t96K\t/myzpool'}
-        mock_cmd = MagicMock(return_value=ret)
-        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
-            self.assertEqual(zfs.list_('myzpool'), res)
-
-    def test_list_parsable_success(self):
-        '''
-        Tests zfs list with parsable output
-        '''
-        res = OrderedDict([('myzpool', {'avail': 1024795238400, 'mountpoint': '/myzpool', 'used': 905792561152, 'refer': 98304})])
-        ret = {'pid': 31817, 'retcode': 0, 'stderr': '', 'stdout': 'myzpool\t905792561152\t1024795238400\t98304\t/myzpool'}
-        mock_cmd = MagicMock(return_value=ret)
-        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
-            self.assertEqual(zfs.list_('myzpool', parsable=True), res)
-
-    def test_mount_success(self):
-        '''
-        Tests zfs mount of filesystem
-        '''
-        res = {'myzpool/mydataset': 'mounted'}
+        res = OrderedDict([('destroyed', True)])
         ret = {}
         ret['stdout'] = ""
         ret['stderr'] = ""
         ret['retcode'] = 0
         mock_cmd = MagicMock(return_value=ret)
-        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zfs.__utils__, utils_patch):
+            self.assertEqual(zfs.destroy('myzpool/mydataset'), res)
+
+    def test_destroy_error_not_exists(self):
+        '''
+        Tests failure return of destroy function on ZFS file system destruction
+        '''
+        res = OrderedDict([
+            ('destroyed', False),
+            ('error', "cannot open 'myzpool/mydataset': dataset does not exist"),
+        ])
+        ret = {}
+        ret['stdout'] = ""
+        ret['stderr'] = "cannot open 'myzpool/mydataset': dataset does not exist"
+        ret['retcode'] = 1
+        mock_cmd = MagicMock(return_value=ret)
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zfs.__utils__, utils_patch):
+            self.assertEqual(zfs.destroy('myzpool/mydataset'), res)
+
+    def test_destroy_error_has_children(self):
+        '''
+        Tests failure return of destroy function on ZFS file system destruction
+        '''
+        res = OrderedDict([
+            ('destroyed', False),
+            ('error', "\n".join([
+                "cannot destroy 'myzpool/mydataset': filesystem has children",
+                "use 'recursive=True' to destroy the following datasets:",
+                "myzpool/mydataset@snapshot",
+            ])),
+        ])
+        ret = {}
+        ret['stdout'] = ""
+        ret['stderr'] = "\n".join([
+            "cannot destroy 'myzpool/mydataset': filesystem has children",
+            "use '-r' to destroy the following datasets:",
+            "myzpool/mydataset@snapshot",
+        ])
+        ret['retcode'] = 1
+        mock_cmd = MagicMock(return_value=ret)
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zfs.__utils__, utils_patch):
+            self.assertEqual(zfs.destroy('myzpool/mydataset'), res)
+
+    def test_rename_success(self):
+        '''
+        Tests successful return of rename function
+        '''
+        res = OrderedDict([('renamed', True)])
+        ret = {}
+        ret['stdout'] = ""
+        ret['stderr'] = ""
+        ret['retcode'] = 0
+        mock_cmd = MagicMock(return_value=ret)
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zfs.__utils__, utils_patch):
+            self.assertEqual(zfs.rename('myzpool/mydataset', 'myzpool/newdataset'), res)
+
+    def test_rename_error_not_exists(self):
+        '''
+        Tests failure return of rename function
+        '''
+        res = OrderedDict([
+            ('renamed', False),
+            ('error', "cannot open 'myzpool/mydataset': dataset does not exist"),
+        ])
+        ret = {}
+        ret['stdout'] = ""
+        ret['stderr'] = "cannot open 'myzpool/mydataset': dataset does not exist"
+        ret['retcode'] = 1
+        mock_cmd = MagicMock(return_value=ret)
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zfs.__utils__, utils_patch):
+            self.assertEqual(zfs.rename('myzpool/mydataset', 'myzpool/newdataset'), res)
+
+    def test_list_success(self):
+        '''
+        Tests zfs list
+        '''
+        res = OrderedDict([
+            ('myzpool', OrderedDict([
+                ('used', 905792561152),
+                ('avail', 1024795238400),
+                ('refer', 98304),
+                ('mountpoint', '/myzpool'),
+            ])),
+        ])
+        ret = {}
+        ret['retcode'] = 0
+        ret['stdout'] = 'myzpool\t905792561152\t1024795238400\t98304\t/myzpool'
+        ret['stderr'] = ''
+        mock_cmd = MagicMock(return_value=ret)
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zfs.__utils__, utils_patch):
+            self.assertEqual(zfs.list_('myzpool'), res)
+
+    def test_list_parsable_success(self):
+        '''
+        Tests zfs list with parsable set to False
+        '''
+        res = OrderedDict([
+            ('myzpool', OrderedDict([
+                ('used', '844G'),
+                ('avail', '954G'),
+                ('refer', '96K'),
+                ('mountpoint', '/myzpool'),
+            ])),
+        ])
+        ret = {}
+        ret['retcode'] = 0
+        ret['stdout'] = 'myzpool\t905792561152\t1024795238400\t98304\t/myzpool'
+        ret['stderr'] = ''
+        mock_cmd = MagicMock(return_value=ret)
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zfs.__utils__, utils_patch):
+            self.assertEqual(zfs.list_('myzpool', parsable=False), res)
+
+    def test_list_custom_success(self):
+        '''
+        Tests zfs list
+        '''
+        res = OrderedDict([
+            ('myzpool', OrderedDict([
+                ('canmount', True),
+                ('used', 834786304),
+                ('avail', 87502848),
+                ('compression', False),
+            ])),
+        ])
+        ret = {}
+        ret['retcode'] = 0
+        ret['stdout'] = 'myzpool\ton\t834786304\t87502848\toff'
+        ret['stderr'] = ''
+        mock_cmd = MagicMock(return_value=ret)
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zfs.__utils__, utils_patch):
+            self.assertEqual(zfs.list_('myzpool', properties='canmount,used,avail,compression'), res)
+
+    def test_list_custom_parsable_success(self):
+        '''
+        Tests zfs list
+        '''
+        res = OrderedDict([
+            ('myzpool', OrderedDict([
+                ('canmount', 'on'),
+                ('used', '796M'),
+                ('avail', '83.4M'),
+                ('compression', 'off'),
+            ])),
+        ])
+        ret = {}
+        ret['retcode'] = 0
+        ret['stdout'] = 'myzpool\ton\t834786304\t87502848\toff'
+        ret['stderr'] = ''
+        mock_cmd = MagicMock(return_value=ret)
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zfs.__utils__, utils_patch):
+            self.assertEqual(zfs.list_('myzpool', properties='canmount,used,avail,compression', parsable=False), res)
+
+    def test_list_error_no_dataset(self):
+        '''
+        Tests zfs list
+        '''
+        res = OrderedDict()
+        ret = {}
+        ret['retcode'] = 1
+        ret['stdout'] = "cannot open 'myzpool': dataset does not exist"
+        ret['stderr'] = ''
+        mock_cmd = MagicMock(return_value=ret)
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zfs.__utils__, utils_patch):
+            self.assertEqual(zfs.list_('myzpool'), res)
+
+    def test_list_mount_success(self):
+        '''
+        Tests zfs list_mount
+        '''
+        res = OrderedDict([
+            ('myzpool/data', '/data'),
+            ('myzpool/data/ares', '/data/ares'),
+        ])
+        ret = {}
+        ret['retcode'] = 0
+        ret['stdout'] = "\n".join([
+            "myzpool/data\t\t\t\t/data",
+            "myzpool/data/ares\t\t\t/data/ares",
+        ])
+        ret['stderr'] = ''
+        mock_cmd = MagicMock(return_value=ret)
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zfs.__utils__, utils_patch):
+            self.assertEqual(zfs.list_mount(), res)
+
+    def test_mount_success(self):
+        '''
+        Tests zfs mount of filesystem
+        '''
+        res = OrderedDict([('mounted', True)])
+        ret = {}
+        ret['stdout'] = ""
+        ret['stderr'] = ""
+        ret['retcode'] = 0
+        mock_cmd = MagicMock(return_value=ret)
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zfs.__utils__, utils_patch):
             self.assertEqual(zfs.mount('myzpool/mydataset'), res)
 
     def test_mount_failure(self):
         '''
         Tests zfs mount of already mounted filesystem
         '''
-        res = {'myzpool/mydataset': "cannot mount 'myzpool/mydataset': filesystem already mounted"}
+        res = OrderedDict([('mounted', False), ('error', "cannot mount 'myzpool/mydataset': filesystem already mounted")])
         ret = {}
         ret['stdout'] = ""
         ret['stderr'] = "cannot mount 'myzpool/mydataset': filesystem already mounted"
         ret['retcode'] = 1
         mock_cmd = MagicMock(return_value=ret)
-        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zfs.__utils__, utils_patch):
             self.assertEqual(zfs.mount('myzpool/mydataset'), res)
 
     def test_unmount_success(self):
         '''
         Tests zfs unmount of filesystem
         '''
-        res = {'myzpool/mydataset': 'unmounted'}
+        res = OrderedDict([('unmounted', True)])
         ret = {}
         ret['stdout'] = ""
         ret['stderr'] = ""
         ret['retcode'] = 0
         mock_cmd = MagicMock(return_value=ret)
-        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zfs.__utils__, utils_patch):
             self.assertEqual(zfs.unmount('myzpool/mydataset'), res)
 
     def test_unmount_failure(self):
         '''
         Tests zfs unmount of already mounted filesystem
         '''
-        res = {'myzpool/mydataset': "cannot mount 'myzpool/mydataset': not currently mounted"}
+        res = OrderedDict([
+            ('unmounted', False),
+            ('error', "cannot mount 'myzpool/mydataset': not currently mounted"),
+        ])
         ret = {}
         ret['stdout'] = ""
         ret['stderr'] = "cannot mount 'myzpool/mydataset': not currently mounted"
         ret['retcode'] = 1
         mock_cmd = MagicMock(return_value=ret)
-        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zfs.__utils__, utils_patch):
             self.assertEqual(zfs.unmount('myzpool/mydataset'), res)
 
     def test_inherit_success(self):
         '''
         Tests zfs inherit of compression property
         '''
-        res = {'myzpool/mydataset': {'compression': 'cleared'}}
+        res = OrderedDict([('inherited', True)])
         ret = {'pid': 45193, 'retcode': 0, 'stderr': '', 'stdout': ''}
         mock_cmd = MagicMock(return_value=ret)
-        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zfs.__utils__, utils_patch):
             self.assertEqual(zfs.inherit('compression', 'myzpool/mydataset'), res)
 
     def test_inherit_failure(self):
         '''
         Tests zfs inherit of canmount
         '''
-        res = {
-            'myzpool/mydataset': {
-                'canmount': "'canmount' property cannot be inherited, use revert=True to try and reset it to it's default value."
-            }
-        }
+        res = OrderedDict([
+            ('inherited', False),
+            ('error', "'canmount' property cannot be inherited"),
+        ])
         ret = {'pid': 43898, 'retcode': 1, 'stderr': "'canmount' property cannot be inherited", 'stdout': ''}
         mock_cmd = MagicMock(return_value=ret)
-        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zfs.__utils__, utils_patch):
             self.assertEqual(zfs.inherit('canmount', 'myzpool/mydataset'), res)
 
     def test_diff(self):
         '''
         Tests zfs diff
         '''
-        res = ['M\t/\t/myzpool/mydataset/', '+\tF\t/myzpool/mydataset/hello']
-        ret = {'pid': 51495, 'retcode': 0, 'stderr': '', 'stdout': 'M\t/\t/myzpool/mydataset/\n+\tF\t/myzpool/mydataset/hello'}
+        res = [
+            'M\t/\t/myzpool/mydataset/',
+            '+\tF\t/myzpool/mydataset/hello',
+        ]
+        ret = {}
+        ret['retcode'] = 0
+        ret['stdout'] = "\n".join([
+            "M\t/\t/myzpool/mydataset/",
+            "+\tF\t/myzpool/mydataset/hello",
+        ])
+        ret['stderr'] = ''
         mock_cmd = MagicMock(return_value=ret)
-        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zfs.__utils__, utils_patch):
             self.assertEqual(zfs.diff('myzpool/mydataset@yesterday', 'myzpool/mydataset'), res)
+
+    def test_diff_parsed_time(self):
+        '''
+        Tests zfs diff
+        '''
+        res = OrderedDict([
+            ('2018-01-27.14:37:59.144517', 'M\t\t/data/test/'),
+            ('2018-01-27.14:37:55.296592', '+\t\t/data/test/world'),
+            ('2018-01-27.14:37:59.274438', '+\t\t/data/test/hello'),
+        ])
+        ret = {}
+        ret['retcode'] = 0
+        ret['stdout'] = "\n".join([
+            "1517063879.144517494\tM\t\t/data/test/",
+            "1517063875.296592355\t+\t\t/data/test/world",
+            "1517063879.274438467\t+\t\t/data/test/hello",
+        ])
+        ret['stderr'] = ''
+        mock_cmd = MagicMock(return_value=ret)
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zfs.__utils__, utils_patch):
+            self.assertEqual(zfs.diff('myzpool/data@yesterday', 'myzpool/data', show_changetime=True, parsable=False), res)
 
     def test_rollback_success(self):
         '''
         Tests zfs rollback success
         '''
-        res = {'myzpool/mydataset': 'rolledback to snapshot: yesterday'}
+        res = OrderedDict([('rolledback', True)])
         ret = {'pid': 56502, 'retcode': 0, 'stderr': '', 'stdout': ''}
         mock_cmd = MagicMock(return_value=ret)
-        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zfs.__utils__, utils_patch):
             self.assertEqual(zfs.rollback('myzpool/mydataset@yesterday'), res)
 
     def test_rollback_failure(self):
         '''
         Tests zfs rollback failure
         '''
-        res = {'myzpool/mydataset': "cannot rollback to 'myzpool/mydataset@yesterday': more recent snapshots "
-                                    "or bookmarks exist\nuse '-r' to force deletion of the following snapshots "
-                                    "and bookmarks:\nmyzpool/mydataset@today"}
+        res = OrderedDict([
+            ('rolledback', False),
+            ('error', "\n".join([
+                    "cannot rollback to 'myzpool/mydataset@yesterday': more recent snapshots or bookmarks exist",
+                    "use 'recursive=True' to force deletion of the following snapshots and bookmarks:",
+                    "myzpool/mydataset@today"
+                ]),
+            ),
+        ])
         ret = {
             'pid': 57471,
             'retcode': 1,
@@ -303,47 +572,58 @@ class ZfsTestCase(TestCase, LoaderModuleMockMixin):
             'stdout': ''
         }
         mock_cmd = MagicMock(return_value=ret)
-        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zfs.__utils__, utils_patch):
             self.assertEqual(zfs.rollback('myzpool/mydataset@yesterday'), res)
 
     def test_clone_success(self):
         '''
         Tests zfs clone success
         '''
-        res = {'myzpool/yesterday': 'cloned from myzpool/mydataset@yesterday'}
+        res = OrderedDict([('cloned', True)])
         ret = {'pid': 64532, 'retcode': 0, 'stderr': '', 'stdout': ''}
         mock_cmd = MagicMock(return_value=ret)
-        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zfs.__utils__, utils_patch):
             self.assertEqual(zfs.clone('myzpool/mydataset@yesterday', 'myzpool/yesterday'), res)
 
     def test_clone_failure(self):
         '''
         Tests zfs clone failure
         '''
-        res = {'myzpool/archive/yesterday': "cannot create 'myzpool/archive/yesterday': parent does not exist"}
+        res = OrderedDict([
+            ('cloned', False),
+            ('error', "cannot create 'myzpool/archive/yesterday': parent does not exist"),
+        ])
         ret = {'pid': 64864, 'retcode': 1, 'stderr': "cannot create 'myzpool/archive/yesterday': parent does not exist", 'stdout': ''}
         mock_cmd = MagicMock(return_value=ret)
-        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zfs.__utils__, utils_patch):
             self.assertEqual(zfs.clone('myzpool/mydataset@yesterday', 'myzpool/archive/yesterday'), res)
 
     def test_promote_success(self):
         '''
         Tests zfs promote success
         '''
-        res = {'myzpool/yesterday': 'promoted'}
+        res = OrderedDict([('promoted', True)])
         ret = {'pid': 69075, 'retcode': 0, 'stderr': '', 'stdout': ''}
         mock_cmd = MagicMock(return_value=ret)
-        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zfs.__utils__, utils_patch):
             self.assertEqual(zfs.promote('myzpool/yesterday'), res)
 
     def test_promote_failure(self):
         '''
         Tests zfs promote failure
         '''
-        res = {'myzpool/yesterday': "cannot promote 'myzpool/yesterday': not a cloned filesystem"}
+        res = OrderedDict([
+            ('promoted', False),
+            ('error', "cannot promote 'myzpool/yesterday': not a cloned filesystem"),
+        ])
         ret = {'pid': 69209, 'retcode': 1, 'stderr': "cannot promote 'myzpool/yesterday': not a cloned filesystem", 'stdout': ''}
         mock_cmd = MagicMock(return_value=ret)
-        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zfs.__utils__, utils_patch):
             self.assertEqual(zfs.promote('myzpool/yesterday'), res)
 
     def test_bookmark_success(self):
@@ -351,7 +631,7 @@ class ZfsTestCase(TestCase, LoaderModuleMockMixin):
         Tests zfs bookmark success
         '''
         with patch('salt.utils.path.which', MagicMock(return_value='/usr/bin/man')):
-            res = {'myzpool/mydataset@yesterday': 'bookmarked as myzpool/mydataset#important'}
+            res = OrderedDict([('bookmarked', True)])
             ret = {'pid': 20990, 'retcode': 0, 'stderr': '', 'stdout': ''}
             mock_cmd = MagicMock(return_value=ret)
             with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
@@ -361,128 +641,173 @@ class ZfsTestCase(TestCase, LoaderModuleMockMixin):
         '''
         Tests zfs holds success
         '''
-        res = {'myzpool/mydataset@baseline': {'important  ': 'Wed Dec 23 21:06 2015', 'release-1.0': 'Wed Dec 23 21:08 2015'}}
+        res = OrderedDict([
+            ('important  ', 'Wed Dec 23 21:06 2015'),
+            ('release-1.0', 'Wed Dec 23 21:08 2015'),
+        ])
         ret = {'pid': 40216, 'retcode': 0, 'stderr': '', 'stdout': 'myzpool/mydataset@baseline\timportant  \tWed Dec 23 21:06 2015\nmyzpool/mydataset@baseline\trelease-1.0\tWed Dec 23 21:08 2015'}
         mock_cmd = MagicMock(return_value=ret)
-        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zfs.__utils__, utils_patch):
             self.assertEqual(zfs.holds('myzpool/mydataset@baseline'), res)
 
     def test_holds_failure(self):
         '''
         Tests zfs holds failure
         '''
-        res = {'myzpool/mydataset@baseline': "cannot open 'myzpool/mydataset@baseline': dataset does not exist"}
+        res = OrderedDict([
+            ('error', "cannot open 'myzpool/mydataset@baseline': dataset does not exist"),
+        ])
         ret = {'pid': 40993, 'retcode': 1, 'stderr': "cannot open 'myzpool/mydataset@baseline': dataset does not exist", 'stdout': 'no datasets available'}
         mock_cmd = MagicMock(return_value=ret)
-        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zfs.__utils__, utils_patch):
             self.assertEqual(zfs.holds('myzpool/mydataset@baseline'), res)
 
     def test_hold_success(self):
         '''
         Tests zfs hold success
         '''
-        res = {'myzpool/mydataset@baseline': {'important': 'held'}, 'myzpool/mydataset@release-1.0': {'important': 'held'}}
+        res = OrderedDict([('held', True)])
         ret = {'pid': 50876, 'retcode': 0, 'stderr': '', 'stdout': ''}
         mock_cmd = MagicMock(return_value=ret)
-        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zfs.__utils__, utils_patch):
             self.assertEqual(zfs.hold('important', 'myzpool/mydataset@baseline', 'myzpool/mydataset@release-1.0'), res)
 
     def test_hold_failure(self):
         '''
         Tests zfs hold failure
         '''
-        res = {'myzpool/mydataset@baseline': {'important': 'tag already exists on this dataset'}}
+        res = OrderedDict([
+            ('held', False),
+            ('error', "cannot hold snapshot 'myzpool/mydataset@baseline': tag already exists on this dataset"),
+        ])
         ret = {'pid': 51006, 'retcode': 1, 'stderr': "cannot hold snapshot 'myzpool/mydataset@baseline': tag already exists on this dataset", 'stdout': ''}
         mock_cmd = MagicMock(return_value=ret)
-        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zfs.__utils__, utils_patch):
             self.assertEqual(zfs.hold('important', 'myzpool/mydataset@baseline'), res)
 
     def test_release_success(self):
         '''
         Tests zfs release success
         '''
-        res = {'myzpool/mydataset@baseline': {'important': 'released'}, 'myzpool/mydataset@release-1.0': {'important': 'released'}}
+        res = OrderedDict([('released', True)])
         ret = {'pid': 50876, 'retcode': 0, 'stderr': '', 'stdout': ''}
         mock_cmd = MagicMock(return_value=ret)
-        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zfs.__utils__, utils_patch):
             self.assertEqual(zfs.release('important', 'myzpool/mydataset@baseline', 'myzpool/mydataset@release-1.0'), res)
 
     def test_release_failure(self):
         '''
         Tests zfs release failure
         '''
-        res = {'myzpool/mydataset@baseline': {'important': 'no such tag on this dataset'}}
+        res = OrderedDict([
+            ('released', False),
+        ('error', "cannot release hold from snapshot 'myzpool/mydataset@baseline': no such tag on this dataset"),
+        ])
         ret = {'pid': 51006, 'retcode': 1, 'stderr': "cannot release hold from snapshot 'myzpool/mydataset@baseline': no such tag on this dataset", 'stdout': ''}
         mock_cmd = MagicMock(return_value=ret)
-        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zfs.__utils__, utils_patch):
             self.assertEqual(zfs.release('important', 'myzpool/mydataset@baseline'), res)
 
     def test_snapshot_success(self):
         '''
         Tests zfs snapshot success
         '''
-        res = {'myzpool/mydataset@baseline': 'snapshotted'}
+        res = OrderedDict([('snapshotted', True)])
         ret = {'pid': 69125, 'retcode': 0, 'stderr': '', 'stdout': ''}
         mock_cmd = MagicMock(return_value=ret)
-        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zfs.__utils__, utils_patch):
             self.assertEqual(zfs.snapshot('myzpool/mydataset@baseline'), res)
 
     def test_snapshot_failure(self):
         '''
         Tests zfs snapshot failure
         '''
-        res = {'myzpool/mydataset@baseline': 'dataset already exists'}
+        res = OrderedDict([
+            ('snapshotted', False),
+            ('error', "cannot create snapshot 'myzpool/mydataset@baseline': dataset already exists"),
+        ])
         ret = {'pid': 68526, 'retcode': 1, 'stderr': "cannot create snapshot 'myzpool/mydataset@baseline': dataset already exists", 'stdout': ''}
         mock_cmd = MagicMock(return_value=ret)
-        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zfs.__utils__, utils_patch):
             self.assertEqual(zfs.snapshot('myzpool/mydataset@baseline'), res)
 
     def test_snapshot_failure2(self):
         '''
         Tests zfs snapshot failure
         '''
-        res = {'myzpool/mydataset@baseline': 'dataset does not exist'}
+        res = OrderedDict([
+            ('snapshotted', False),
+            ('error', "cannot open 'myzpool/mydataset': dataset does not exist"),
+        ])
         ret = {'pid': 69256, 'retcode': 2, 'stderr': "cannot open 'myzpool/mydataset': dataset does not exist\nusage:\n\tsnapshot [-r] [-o property=value] ... <filesystem|volume>@<snap> ...\n\nFor the property list, run: zfs set|get\n\nFor the delegated permission list, run: zfs allow|unallow", 'stdout': ''}
         mock_cmd = MagicMock(return_value=ret)
-        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zfs.__utils__, utils_patch):
             self.assertEqual(zfs.snapshot('myzpool/mydataset@baseline'), res)
 
     def test_set_success(self):
         '''
         Tests zfs set success
         '''
-        res = {'myzpool/mydataset': {'compression': 'set'}}
+        res = OrderedDict([('set', True)])
         ret = {'pid': 79736, 'retcode': 0, 'stderr': '', 'stdout': ''}
         mock_cmd = MagicMock(return_value=ret)
-        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zfs.__utils__, utils_patch):
             self.assertEqual(zfs.set('myzpool/mydataset', compression='lz4'), res)
 
     def test_set_failure(self):
         '''
         Tests zfs set failure
         '''
-        res = {'myzpool/mydataset': {'canmount': "'canmount' must be one of 'on | off | noauto'"}}
+        res = OrderedDict([
+            ('set', False),
+    ('error', "cannot set property for 'myzpool/mydataset': 'canmount' must be one of 'on | off | noauto'"),
+        ])
         ret = {'pid': 79887, 'retcode': 1, 'stderr': "cannot set property for 'myzpool/mydataset': 'canmount' must be one of 'on | off | noauto'", 'stdout': ''}
         mock_cmd = MagicMock(return_value=ret)
-        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zfs.__utils__, utils_patch):
             self.assertEqual(zfs.set('myzpool/mydataset', canmount='lz4'), res)
 
     def test_get_success(self):
         '''
         Tests zfs get success
         '''
-        res = OrderedDict([('myzpool', {'used': {'value': '844G'}})])
-        ret = {'pid': 562, 'retcode': 0, 'stderr': '', 'stdout': 'myzpool\tused\t844G'}
+        res = OrderedDict([
+            ('myzpool', OrderedDict([
+                ('used', OrderedDict([
+                    ('value', 906238099456),
+                ])),
+            ])),
+        ])
+        ret = {'pid': 562, 'retcode': 0, 'stderr': '', 'stdout': 'myzpool\tused\t906238099456'}
         mock_cmd = MagicMock(return_value=ret)
-        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zfs.__utils__, utils_patch):
             self.assertEqual(zfs.get('myzpool', properties='used', fields='value'), res)
 
     def test_get_parsable_success(self):
         '''
         Tests zfs get with parsable output
         '''
-        res = OrderedDict([('myzpool', {'used': {'value': 905792561152}})])
-        ret = {'pid': 562, 'retcode': 0, 'stderr': '', 'stdout': 'myzpool\tused\t905792561152'}
+        res = OrderedDict([
+            ('myzpool', OrderedDict([
+                ('used', OrderedDict([
+                    ('value', '844G'),
+                ])),
+            ])),
+        ])
+        ret = {'pid': 562, 'retcode': 0, 'stderr': '', 'stdout': 'myzpool\tused\t906238099456'}
         mock_cmd = MagicMock(return_value=ret)
-        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
-            self.assertEqual(zfs.get('myzpool', properties='used', fields='value', parsable=True), res)
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zfs.__utils__, utils_patch):
+            self.assertEqual(zfs.get('myzpool', properties='used', fields='value', parsable=False), res)

--- a/tests/unit/modules/test_zpool.py
+++ b/tests/unit/modules/test_zpool.py
@@ -1,9 +1,12 @@
 # -*- coding: utf-8 -*-
 '''
-    :codeauthor: Nitin Madhok <nmadhok@clemson.edu>`
+Tests for salt.modules.zpool
 
-    tests.unit.modules.zpool_test
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+:codeauthor:    Nitin Madhok <nmadhok@clemson.edu>, Jorge Schrauwen <sjorge@blackdot.be>
+:maintainer:    Jorge Schrauwen <sjorge@blackdot.be>
+:maturity:      new
+:depends:       salt.utils.zfs
+:platform:      illumos,freebsd,linux
 '''
 
 # Import Python libs
@@ -13,17 +16,21 @@ from __future__ import absolute_import
 from tests.support.mixins import LoaderModuleMockMixin
 from tests.support.unit import skipIf, TestCase
 from tests.support.mock import (
-    Mock,
     MagicMock,
     patch,
     NO_MOCK,
     NO_MOCK_REASON,
 )
 
+# Import test data from salt.utils.zfs test
+from tests.unit.utils.test_zfs import utils_patch
+
 # Import Salt Execution module to test
+import salt.utils.zfs
 import salt.modules.zpool as zpool
 
 # Import Salt Utils
+import salt.loader
 from salt.utils.odict import OrderedDict
 
 
@@ -34,11 +41,16 @@ class ZpoolTestCase(TestCase, LoaderModuleMockMixin):
     This class contains a set of functions that test salt.modules.zpool module
     '''
     def setup_loader_modules(self):
-        patcher = patch('salt.modules.zpool._check_zpool',
-                        MagicMock(return_value='/sbin/zpool'))
-        patcher.start()
-        self.addCleanup(patcher.stop)
-        return {zpool: {}}
+        self.opts = opts = salt.config.DEFAULT_MINION_OPTS
+        utils = salt.loader.utils(opts, whitelist=['zfs'])
+        zpool_obj = {
+            zpool: {
+                '__opts__': opts,
+                '__utils__': utils,
+            }
+        }
+
+        return zpool_obj
 
     def test_exists_success(self):
         '''
@@ -49,7 +61,8 @@ class ZpoolTestCase(TestCase, LoaderModuleMockMixin):
         ret['stderr'] = ""
         ret['retcode'] = 0
         mock_cmd = MagicMock(return_value=ret)
-        with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}):
+        with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zpool.__utils__, utils_patch):
             self.assertTrue(zpool.exists('myzpool'))
 
     def test_exists_failure(self):
@@ -61,7 +74,9 @@ class ZpoolTestCase(TestCase, LoaderModuleMockMixin):
         ret['stderr'] = "cannot open 'myzpool': no such pool"
         ret['retcode'] = 1
         mock_cmd = MagicMock(return_value=ret)
-        with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}):
+
+        with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zpool.__utils__, utils_patch):
             self.assertFalse(zpool.exists('myzpool'))
 
     def test_healthy(self):
@@ -73,7 +88,9 @@ class ZpoolTestCase(TestCase, LoaderModuleMockMixin):
         ret['stderr'] = ""
         ret['retcode'] = 0
         mock_cmd = MagicMock(return_value=ret)
-        with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}):
+
+        with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zpool.__utils__, utils_patch):
             self.assertTrue(zpool.healthy())
 
     def test_status(self):
@@ -87,18 +104,19 @@ class ZpoolTestCase(TestCase, LoaderModuleMockMixin):
             "  scan: scrub repaired 0 in 0h6m with 0 errors on Mon Dec 21 02:06:17 2015",
             "config:",
             "",
-            "        NAME        STATE     READ WRITE CKSUM",
-            "        mypool      ONLINE       0     0     0",
-            "          mirror-0  ONLINE       0     0     0",
-            "            c2t0d0  ONLINE       0     0     0",
-            "            c2t1d0  ONLINE       0     0     0",
+            "\tNAME        STATE     READ WRITE CKSUM",
+            "\tmypool      ONLINE       0     0     0",
+            "\t  mirror-0  ONLINE       0     0     0",
+            "\t    c2t0d0  ONLINE       0     0     0",
+            "\t    c2t1d0  ONLINE       0     0     0",
             "",
             "errors: No known data errors",
         ])
         ret['stderr'] = ""
         ret['retcode'] = 0
         mock_cmd = MagicMock(return_value=ret)
-        with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}):
+        with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}), \
+                patch.dict(zpool.__utils__, utils_patch):
             ret = zpool.status()
             self.assertEqual('ONLINE', ret['mypool']['state'])
 
@@ -120,9 +138,38 @@ class ZpoolTestCase(TestCase, LoaderModuleMockMixin):
         ret['stderr'] = ""
         ret['retcode'] = 0
         mock_cmd = MagicMock(return_value=ret)
-        with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}):
-            ret = zpool.iostat('mypool')
-            self.assertEqual('46.7G', ret['mypool']['mypool']['capacity-alloc'])
+        with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zpool.__utils__, utils_patch):
+            ret = zpool.iostat('mypool', parsable=False)
+            self.assertEqual(ret['mypool']['capacity-alloc'], '46.7G')
+
+    def test_iostat_parsable(self):
+        '''
+        Tests successful return of iostat function
+
+        .. note:
+            The command output is the same as the non parsable!
+            There is no -p flag for zpool iostat, but our type
+            conversions can handle this!
+        '''
+        ret = {}
+        ret['stdout'] = "\n".join([
+            "               capacity     operations    bandwidth",
+            "pool        alloc   free   read  write   read  write",
+            "----------  -----  -----  -----  -----  -----  -----",
+            "mypool      46.7G  64.3G      4     19   113K   331K",
+            "  mirror    46.7G  64.3G      4     19   113K   331K",
+            "    c2t0d0      -      -      1     10   114K   334K",
+            "    c2t1d0      -      -      1     10   114K   334K",
+            "----------  -----  -----  -----  -----  -----  -----",
+        ])
+        ret['stderr'] = ""
+        ret['retcode'] = 0
+        mock_cmd = MagicMock(return_value=ret)
+        with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zpool.__utils__, utils_patch):
+            ret = zpool.iostat('mypool', parsable=True)
+            self.assertEqual(ret['mypool']['capacity-alloc'], 50143743180)
 
     def test_list(self):
         '''
@@ -134,10 +181,9 @@ class ZpoolTestCase(TestCase, LoaderModuleMockMixin):
         ret['retcode'] = 0
         mock_cmd = MagicMock(return_value=ret)
         with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}), \
-                patch('salt.modules.zpool._check_features',
-                      MagicMock(return_value=False)):
-            ret = zpool.list_()
-            res = OrderedDict([('mypool', {'alloc': '714G', 'cap': '38%', 'free': '1.11T', 'health': 'ONLINE', 'size': '1.81T'})])
+                patch.dict(zpool.__utils__, utils_patch):
+            ret = zpool.list_(parsable=False)
+            res = OrderedDict([('mypool', OrderedDict([('size', '1.81T'), ('alloc', '714G'), ('free', '1.11T'), ('cap', '38%'), ('health', 'ONLINE')]))])
             self.assertEqual(res, ret)
 
     def test_list_parsable(self):
@@ -150,10 +196,9 @@ class ZpoolTestCase(TestCase, LoaderModuleMockMixin):
         ret['retcode'] = 0
         mock_cmd = MagicMock(return_value=ret)
         with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}), \
-                patch('salt.modules.zpool._check_features',
-                      MagicMock(return_value=False)):
-            ret = zpool.list_()
-            res = OrderedDict([('mypool', {'alloc': 767076794368, 'cap': 38, 'free': 1225788030976, 'health': 'ONLINE', 'size': 1992864825344})])
+                patch.dict(zpool.__utils__, utils_patch):
+            ret = zpool.list_(parsable=True)
+            res = OrderedDict([('mypool', OrderedDict([('size', 1992864825344), ('alloc', 767076794368), ('free', 1225788030976), ('cap', 38), ('health', 'ONLINE')]))])
             self.assertEqual(res, ret)
 
     def test_get(self):
@@ -161,13 +206,14 @@ class ZpoolTestCase(TestCase, LoaderModuleMockMixin):
         Tests successful return of get function
         '''
         ret = {}
-        ret['stdout'] = "size\t1.81T\t-\n"
+        ret['stdout'] = "size\t1992864825344\t-\n"
         ret['stderr'] = ""
         ret['retcode'] = 0
         mock_cmd = MagicMock(return_value=ret)
-        with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}):
-            ret = zpool.get('mypool', 'size')
-            res = OrderedDict([('mypool', OrderedDict([('size', '1.81T')]))])
+        with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zpool.__utils__, utils_patch):
+            ret = zpool.get('mypool', 'size', parsable=False)
+            res = OrderedDict(OrderedDict([('size', '1.81T')]))
             self.assertEqual(res, ret)
 
     def test_get_parsable(self):
@@ -179,9 +225,10 @@ class ZpoolTestCase(TestCase, LoaderModuleMockMixin):
         ret['stderr'] = ""
         ret['retcode'] = 0
         mock_cmd = MagicMock(return_value=ret)
-        with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}):
-            ret = zpool.get('mypool', 'size')
-            res = OrderedDict([('mypool', OrderedDict([('size', 1992864825344)]))])
+        with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zpool.__utils__, utils_patch):
+            ret = zpool.get('mypool', 'size', parsable=True)
+            res = OrderedDict(OrderedDict([('size', 1992864825344)]))
             self.assertEqual(res, ret)
 
     def test_get_whitespace(self):
@@ -193,9 +240,10 @@ class ZpoolTestCase(TestCase, LoaderModuleMockMixin):
         ret['stderr'] = ""
         ret['retcode'] = 0
         mock_cmd = MagicMock(return_value=ret)
-        with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}):
+        with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zpool.__utils__, utils_patch):
             ret = zpool.get('mypool', 'comment')
-            res = OrderedDict([('mypool', OrderedDict([('comment', "'my testing pool'")]))])
+            res = OrderedDict(OrderedDict([('comment', "my testing pool")]))
             self.assertEqual(res, ret)
 
     def test_scrub_start(self):
@@ -209,11 +257,12 @@ class ZpoolTestCase(TestCase, LoaderModuleMockMixin):
         mock_cmd = MagicMock(return_value=ret)
         mock_exists = MagicMock(return_value=True)
 
-        with patch.dict(zpool.__salt__, {'zpool.exists': mock_exists}):
-            with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}):
-                ret = zpool.scrub('mypool')
-                res = OrderedDict([('mypool', OrderedDict([('scrubbing', True)]))])
-                self.assertEqual(res, ret)
+        with patch.dict(zpool.__salt__, {'zpool.exists': mock_exists}), \
+             patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zpool.__utils__, utils_patch):
+            ret = zpool.scrub('mypool')
+            res = OrderedDict(OrderedDict([('scrubbing', True)]))
+            self.assertEqual(res, ret)
 
     def test_scrub_pause(self):
         '''
@@ -226,11 +275,12 @@ class ZpoolTestCase(TestCase, LoaderModuleMockMixin):
         mock_cmd = MagicMock(return_value=ret)
         mock_exists = MagicMock(return_value=True)
 
-        with patch.dict(zpool.__salt__, {'zpool.exists': mock_exists}):
-            with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}):
-                ret = zpool.scrub('mypool', pause=True)
-                res = OrderedDict([('mypool', OrderedDict([('scrubbing', False)]))])
-                self.assertEqual(res, ret)
+        with patch.dict(zpool.__salt__, {'zpool.exists': mock_exists}), \
+             patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zpool.__utils__, utils_patch):
+            ret = zpool.scrub('mypool', pause=True)
+            res = OrderedDict(OrderedDict([('scrubbing', False)]))
+            self.assertEqual(res, ret)
 
     def test_scrub_stop(self):
         '''
@@ -243,11 +293,12 @@ class ZpoolTestCase(TestCase, LoaderModuleMockMixin):
         mock_cmd = MagicMock(return_value=ret)
         mock_exists = MagicMock(return_value=True)
 
-        with patch.dict(zpool.__salt__, {'zpool.exists': mock_exists}):
-            with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}):
-                ret = zpool.scrub('mypool', stop=True)
-                res = OrderedDict([('mypool', OrderedDict([('scrubbing', False)]))])
-                self.assertEqual(res, ret)
+        with patch.dict(zpool.__salt__, {'zpool.exists': mock_exists}), \
+             patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zpool.__utils__, utils_patch):
+            ret = zpool.scrub('mypool', stop=True)
+            res = OrderedDict(OrderedDict([('scrubbing', False)]))
+            self.assertEqual(res, ret)
 
     def test_split_success(self):
         '''
@@ -258,14 +309,12 @@ class ZpoolTestCase(TestCase, LoaderModuleMockMixin):
         ret['stderr'] = ""
         ret['retcode'] = 0
         mock_cmd = MagicMock(return_value=ret)
-        mock_exists = Mock()
-        mock_exists.side_effect = [False, True]
 
-        with patch.dict(zpool.__salt__, {'zpool.exists': mock_exists}):
-            with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}):
-                ret = zpool.split('datapool', 'backuppool')
-                res = OrderedDict([('backuppool', 'split off from datapool')])
-                self.assertEqual(res, ret)
+        with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zpool.__utils__, utils_patch):
+            ret = zpool.split('datapool', 'backuppool')
+            res = OrderedDict([('split', True)])
+            self.assertEqual(res, ret)
 
     def test_split_exist_new(self):
         '''
@@ -273,17 +322,15 @@ class ZpoolTestCase(TestCase, LoaderModuleMockMixin):
         '''
         ret = {}
         ret['stdout'] = ""
-        ret['stderr'] = ""
-        ret['retcode'] = 0
+        ret['stderr'] = "Unable to split datapool: pool already exists"
+        ret['retcode'] = 1
         mock_cmd = MagicMock(return_value=ret)
-        mock_exists = Mock()
-        mock_exists.side_effect = [True, True]
 
-        with patch.dict(zpool.__salt__, {'zpool.exists': mock_exists}):
-            with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}):
-                ret = zpool.split('datapool', 'backuppool')
-                res = OrderedDict([('backuppool', 'storage pool already exists')])
-                self.assertEqual(res, ret)
+        with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zpool.__utils__, utils_patch):
+            ret = zpool.split('datapool', 'backuppool')
+            res = OrderedDict([('split', False), ('error', 'Unable to split datapool: pool already exists')])
+            self.assertEqual(res, ret)
 
     def test_split_missing_pool(self):
         '''
@@ -291,17 +338,15 @@ class ZpoolTestCase(TestCase, LoaderModuleMockMixin):
         '''
         ret = {}
         ret['stdout'] = ""
-        ret['stderr'] = ""
-        ret['retcode'] = 0
+        ret['stderr'] = "cannot open 'datapool': no such pool"
+        ret['retcode'] = 1
         mock_cmd = MagicMock(return_value=ret)
-        mock_exists = Mock()
-        mock_exists.side_effect = [False, False]
 
-        with patch.dict(zpool.__salt__, {'zpool.exists': mock_exists}):
-            with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}):
-                ret = zpool.split('datapool', 'backuppool')
-                res = OrderedDict([('datapool', 'storage pool does not exists')])
-                self.assertEqual(res, ret)
+        with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zpool.__utils__, utils_patch):
+            ret = zpool.split('datapool', 'backuppool')
+            res = OrderedDict([('split', False), ('error', "cannot open 'datapool': no such pool")])
+            self.assertEqual(res, ret)
 
     def test_split_not_mirror(self):
         '''
@@ -312,14 +357,12 @@ class ZpoolTestCase(TestCase, LoaderModuleMockMixin):
         ret['stderr'] = "Unable to split datapool: Source pool must be composed only of mirrors"
         ret['retcode'] = 1
         mock_cmd = MagicMock(return_value=ret)
-        mock_exists = Mock()
-        mock_exists.side_effect = [False, True]
 
-        with patch.dict(zpool.__salt__, {'zpool.exists': mock_exists}):
-            with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}):
-                ret = zpool.split('datapool', 'backuppool')
-                res = OrderedDict([('backuppool', 'Unable to split datapool: Source pool must be composed only of mirrors')])
-                self.assertEqual(res, ret)
+        with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zpool.__utils__, utils_patch):
+            ret = zpool.split('datapool', 'backuppool')
+            res = OrderedDict([('split', False), ('error', 'Unable to split datapool: Source pool must be composed only of mirrors')])
+            self.assertEqual(res, ret)
 
     def test_labelclear_success(self):
         '''
@@ -330,9 +373,30 @@ class ZpoolTestCase(TestCase, LoaderModuleMockMixin):
         ret['stderr'] = ""
         ret['retcode'] = 0
         mock_cmd = MagicMock(return_value=ret)
-        with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}):
+
+        with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zpool.__utils__, utils_patch):
             ret = zpool.labelclear('/dev/rdsk/c0t0d0', force=False)
-            res = OrderedDict([('/dev/rdsk/c0t0d0', 'cleared')])
+            res = OrderedDict([('labelcleared', True)])
+            self.assertEqual(res, ret)
+
+    def test_labelclear_nodevice(self):
+        '''
+        Tests labelclear on non existing device
+        '''
+        ret = {}
+        ret['stdout'] = ""
+        ret['stderr'] = "failed to open /dev/rdsk/c0t0d0: No such file or directory"
+        ret['retcode'] = 1
+        mock_cmd = MagicMock(return_value=ret)
+
+        with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zpool.__utils__, utils_patch):
+            ret = zpool.labelclear('/dev/rdsk/c0t0d0', force=False)
+            res = OrderedDict([
+                ('labelcleared', False),
+                ('error', 'failed to open /dev/rdsk/c0t0d0: No such file or directory'),
+            ])
             self.assertEqual(res, ret)
 
     def test_labelclear_cleared(self):
@@ -344,9 +408,14 @@ class ZpoolTestCase(TestCase, LoaderModuleMockMixin):
         ret['stderr'] = "failed to read label from /dev/rdsk/c0t0d0"
         ret['retcode'] = 1
         mock_cmd = MagicMock(return_value=ret)
-        with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}):
+
+        with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zpool.__utils__, utils_patch):
             ret = zpool.labelclear('/dev/rdsk/c0t0d0', force=False)
-            res = OrderedDict([('/dev/rdsk/c0t0d0', 'failed to read label from /dev/rdsk/c0t0d0')])
+            res = OrderedDict([
+                ('labelcleared', False),
+                ('error', 'failed to read label from /dev/rdsk/c0t0d0'),
+            ])
             self.assertEqual(res, ret)
 
     def test_labelclear_exported(self):
@@ -361,7 +430,430 @@ class ZpoolTestCase(TestCase, LoaderModuleMockMixin):
         ])
         ret['retcode'] = 1
         mock_cmd = MagicMock(return_value=ret)
-        with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}):
+        with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zpool.__utils__, utils_patch):
             ret = zpool.labelclear('/dev/rdsk/c0t0d0', force=False)
-            res = OrderedDict([('/dev/rdsk/c0t0d0', '/dev/rdsk/c0t0d0 is a member of exported pool "mypool"')])
+            res = OrderedDict([
+                ('labelcleared', False),
+                ('error', 'use \'force=True\' to override the following error:\n/dev/rdsk/c0t0d0 is a member of exported pool "mypool"'),
+            ])
+            self.assertEqual(res, ret)
+
+    def test_create_file_vdev_success(self):
+        '''
+        Tests create_file_vdev when out of space
+        '''
+        ret = {}
+        ret['stdout'] = ""
+        ret['stderr'] = ""
+        ret['retcode'] = 0
+        mock_cmd = MagicMock(return_value=ret)
+
+        with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zpool.__utils__, utils_patch):
+            ret = zpool.create_file_vdev('64M', '/vdisks/disk0')
+            res = OrderedDict([
+                ('/vdisks/disk0', 'created'),
+            ])
+            self.assertEqual(res, ret)
+
+    def test_create_file_vdev_nospace(self):
+        '''
+        Tests create_file_vdev when out of space
+        '''
+        ret = {}
+        ret['stdout'] = ""
+        ret['stderr'] = "/vdisks/disk0: initialized 10424320 of 67108864 bytes: No space left on device"
+        ret['retcode'] = 1
+        mock_cmd = MagicMock(return_value=ret)
+
+        with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zpool.__utils__, utils_patch):
+            ret = zpool.create_file_vdev('64M', '/vdisks/disk0')
+            res = OrderedDict([
+                ('/vdisks/disk0', 'failed'),
+                ('error', OrderedDict([
+                    ('/vdisks/disk0', ' initialized 10424320 of 67108864 bytes: No space left on device'),
+                ])),
+            ])
+            self.assertEqual(res, ret)
+
+    def test_export_success(self):
+        '''
+        Tests export
+        '''
+        ret = {}
+        ret['stdout'] = ""
+        ret['stderr'] = ""
+        ret['retcode'] = 0
+        mock_cmd = MagicMock(return_value=ret)
+
+        with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zpool.__utils__, utils_patch):
+            ret = zpool.export('mypool')
+            res = OrderedDict([('exported', True)])
+            self.assertEqual(res, ret)
+
+    def test_export_nopool(self):
+        '''
+        Tests export when the pool does not exists
+        '''
+        ret = {}
+        ret['stdout'] = ""
+        ret['stderr'] = "cannot open 'mypool': no such pool"
+        ret['retcode'] = 1
+        mock_cmd = MagicMock(return_value=ret)
+
+        with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zpool.__utils__, utils_patch):
+            ret = zpool.export('mypool')
+            res = OrderedDict([('exported', False), ('error', "cannot open 'mypool': no such pool")])
+            self.assertEqual(res, ret)
+
+    def test_import_success(self):
+        '''
+        Tests import
+        '''
+        ret = {}
+        ret['stdout'] = ""
+        ret['stderr'] = ""
+        ret['retcode'] = 0
+        mock_cmd = MagicMock(return_value=ret)
+
+        with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zpool.__utils__, utils_patch):
+            ret = zpool.import_('mypool')
+            res = OrderedDict([('imported', True)])
+            self.assertEqual(res, ret)
+
+    def test_import_duplicate(self):
+        '''
+        Tests import with already imported pool
+        '''
+        ret = {}
+        ret['stdout'] = ""
+        ret['stderr'] = "\n".join([
+            "cannot import 'mypool': a pool with that name already exists",
+            "use the form 'zpool import <pool | id> <newpool>' to give it a new name",
+        ])
+        ret['retcode'] = 1
+        mock_cmd = MagicMock(return_value=ret)
+
+        with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zpool.__utils__, utils_patch):
+            ret = zpool.import_('mypool')
+            res = OrderedDict([
+                ('imported', False),
+                ('error', "cannot import 'mypool': a pool with that name already exists\nuse the form 'zpool import <pool | id> <newpool>' to give it a new name"),
+            ])
+            self.assertEqual(res, ret)
+
+    def test_import_nopool(self):
+        '''
+        Tests import
+        '''
+        ret = {}
+        ret['stdout'] = ""
+        ret['stderr'] = "cannot import 'mypool': no such pool available"
+        ret['retcode'] = 1
+        mock_cmd = MagicMock(return_value=ret)
+
+        with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zpool.__utils__, utils_patch):
+            ret = zpool.import_('mypool')
+            res = OrderedDict([
+                ('imported', False),
+                ('error', "cannot import 'mypool': no such pool available"),
+            ])
+            self.assertEqual(res, ret)
+
+    def test_online_success(self):
+        '''
+        Tests online
+        '''
+        ret = {}
+        ret['stdout'] = ""
+        ret['stderr'] = ""
+        ret['retcode'] = 0
+        mock_cmd = MagicMock(return_value=ret)
+
+        with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zpool.__utils__, utils_patch):
+            ret = zpool.online('mypool', '/dev/rdsk/c0t0d0')
+            res = OrderedDict([('onlined', True)])
+            self.assertEqual(res, ret)
+
+    def test_online_nodevice(self):
+        '''
+        Tests online
+        '''
+        ret = {}
+        ret['stdout'] = ""
+        ret['stderr'] = "cannot online /dev/rdsk/c0t0d1: no such device in pool"
+        ret['retcode'] = 1
+        mock_cmd = MagicMock(return_value=ret)
+
+        with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zpool.__utils__, utils_patch):
+            ret = zpool.online('mypool', '/dev/rdsk/c0t0d1')
+            res = OrderedDict([
+                ('onlined', False),
+                ('error', 'cannot online /dev/rdsk/c0t0d1: no such device in pool'),
+            ])
+            self.assertEqual(res, ret)
+
+    def test_offline_success(self):
+        '''
+        Tests offline
+        '''
+        ret = {}
+        ret['stdout'] = ""
+        ret['stderr'] = ""
+        ret['retcode'] = 0
+        mock_cmd = MagicMock(return_value=ret)
+
+        with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zpool.__utils__, utils_patch):
+            ret = zpool.offline('mypool', '/dev/rdsk/c0t0d0')
+            res = OrderedDict([('offlined', True)])
+            self.assertEqual(res, ret)
+
+    def test_offline_nodevice(self):
+        '''
+        Tests offline
+        '''
+        ret = {}
+        ret['stdout'] = ""
+        ret['stderr'] = "cannot offline /dev/rdsk/c0t0d1: no such device in pool"
+        ret['retcode'] = 1
+        mock_cmd = MagicMock(return_value=ret)
+
+        with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zpool.__utils__, utils_patch):
+            ret = zpool.offline('mypool', '/dev/rdsk/c0t0d1')
+            res = OrderedDict([
+                ('offlined', False),
+                ('error', 'cannot offline /dev/rdsk/c0t0d1: no such device in pool'),
+            ])
+            self.assertEqual(res, ret)
+
+    def test_offline_noreplica(self):
+        '''
+        Tests offline
+        '''
+        ret = {}
+        ret['stdout'] = ""
+        ret['stderr'] = "cannot offline /dev/rdsk/c0t0d1: no valid replicas"
+        ret['retcode'] = 1
+        mock_cmd = MagicMock(return_value=ret)
+
+        with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zpool.__utils__, utils_patch):
+            ret = zpool.offline('mypool', '/dev/rdsk/c0t0d1')
+            res = OrderedDict([
+                ('offlined', False),
+                ('error', 'cannot offline /dev/rdsk/c0t0d1: no valid replicas'),
+            ])
+            self.assertEqual(res, ret)
+
+    def test_reguid_success(self):
+        '''
+        Tests reguid
+        '''
+        ret = {}
+        ret['stdout'] = ""
+        ret['stderr'] = ""
+        ret['retcode'] = 0
+        mock_cmd = MagicMock(return_value=ret)
+
+        with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zpool.__utils__, utils_patch):
+            ret = zpool.reguid('mypool')
+            res = OrderedDict([('reguided', True)])
+            self.assertEqual(res, ret)
+
+    def test_reguid_nopool(self):
+        '''
+        Tests reguid with missing pool
+        '''
+        ret = {}
+        ret['stdout'] = ""
+        ret['stderr'] = "cannot open 'mypool': no such pool"
+        ret['retcode'] = 1
+        mock_cmd = MagicMock(return_value=ret)
+
+        with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zpool.__utils__, utils_patch):
+            ret = zpool.reguid('mypool')
+            res = OrderedDict([
+                ('reguided', False),
+                ('error', "cannot open 'mypool': no such pool"),
+            ])
+            self.assertEqual(res, ret)
+
+    def test_reopen_success(self):
+        '''
+        Tests reopen
+        '''
+        ret = {}
+        ret['stdout'] = ""
+        ret['stderr'] = ""
+        ret['retcode'] = 0
+        mock_cmd = MagicMock(return_value=ret)
+
+        with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zpool.__utils__, utils_patch):
+            ret = zpool.reopen('mypool')
+            res = OrderedDict([('reopened', True)])
+            self.assertEqual(res, ret)
+
+    def test_reopen_nopool(self):
+        '''
+        Tests reopen with missing pool
+        '''
+        ret = {}
+        ret['stdout'] = ""
+        ret['stderr'] = "cannot open 'mypool': no such pool"
+        ret['retcode'] = 1
+        mock_cmd = MagicMock(return_value=ret)
+
+        with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zpool.__utils__, utils_patch):
+            ret = zpool.reopen('mypool')
+            res = OrderedDict([
+                ('reopened', False),
+                ('error', "cannot open 'mypool': no such pool"),
+            ])
+            self.assertEqual(res, ret)
+
+    def test_upgrade_success(self):
+        '''
+        Tests upgrade
+        '''
+        ret = {}
+        ret['stdout'] = ""
+        ret['stderr'] = ""
+        ret['retcode'] = 0
+        mock_cmd = MagicMock(return_value=ret)
+
+        with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zpool.__utils__, utils_patch):
+            ret = zpool.upgrade('mypool')
+            res = OrderedDict([('upgraded', True)])
+            self.assertEqual(res, ret)
+
+    def test_upgrade_nopool(self):
+        '''
+        Tests upgrade with missing pool
+        '''
+        ret = {}
+        ret['stdout'] = ""
+        ret['stderr'] = "cannot open 'mypool': no such pool"
+        ret['retcode'] = 1
+        mock_cmd = MagicMock(return_value=ret)
+
+        with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zpool.__utils__, utils_patch):
+            ret = zpool.upgrade('mypool')
+            res = OrderedDict([
+                ('upgraded', False),
+                ('error', "cannot open 'mypool': no such pool"),
+            ])
+            self.assertEqual(res, ret)
+
+    def test_history_success(self):
+        '''
+        Tests history
+        '''
+        ret = {}
+        ret['stdout'] = "\n".join([
+            "History for 'mypool':",
+            "2018-01-18.16:56:12 zpool create -f mypool /dev/rdsk/c0t0d0",
+            "2018-01-19.16:01:55 zpool attach -f mypool /dev/rdsk/c0t0d0 /dev/rdsk/c0t0d1",
+        ])
+        ret['stderr'] = ""
+        ret['retcode'] = 0
+        mock_cmd = MagicMock(return_value=ret)
+
+        with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zpool.__utils__, utils_patch):
+            ret = zpool.history('mypool')
+            res = OrderedDict([
+                ('mypool', OrderedDict([
+                    ('2018-01-18.16:56:12', 'zpool create -f mypool /dev/rdsk/c0t0d0'),
+                    ('2018-01-19.16:01:55', 'zpool attach -f mypool /dev/rdsk/c0t0d0 /dev/rdsk/c0t0d1'),
+                ])),
+            ])
+            self.assertEqual(res, ret)
+
+    def test_history_nopool(self):
+        '''
+        Tests history with missing pool
+        '''
+        ret = {}
+        ret['stdout'] = ""
+        ret['stderr'] = "cannot open 'mypool': no such pool"
+        ret['retcode'] = 1
+        mock_cmd = MagicMock(return_value=ret)
+
+        with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zpool.__utils__, utils_patch):
+            ret = zpool.history('mypool')
+            res = OrderedDict([
+                ('error', "cannot open 'mypool': no such pool"),
+            ])
+            self.assertEqual(res, ret)
+
+    def test_clear_success(self):
+        '''
+        Tests clear
+        '''
+        ret = {}
+        ret['stdout'] = ""
+        ret['stderr'] = ""
+        ret['retcode'] = 0
+        mock_cmd = MagicMock(return_value=ret)
+
+        with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zpool.__utils__, utils_patch):
+            ret = zpool.clear('mypool')
+            res = OrderedDict([('cleared', True)])
+            self.assertEqual(res, ret)
+
+    def test_clear_nopool(self):
+        '''
+        Tests clear with missing pool
+        '''
+        ret = {}
+        ret['stdout'] = ""
+        ret['stderr'] = "cannot open 'mypool': no such pool"
+        ret['retcode'] = 1
+        mock_cmd = MagicMock(return_value=ret)
+
+        with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zpool.__utils__, utils_patch):
+            ret = zpool.clear('mypool')
+            res = OrderedDict([
+                ('cleared', False),
+                ('error', "cannot open 'mypool': no such pool"),
+            ])
+
+    def test_clear_nodevice(self):
+        '''
+        Tests clear with non existign device
+        '''
+        ret = {}
+        ret['stdout'] = ""
+        ret['stderr'] = "cannot clear errors for /dev/rdsk/c0t0d0: no such device in pool"
+        ret['retcode'] = 1
+        mock_cmd = MagicMock(return_value=ret)
+
+        with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zpool.__utils__, utils_patch):
+            ret = zpool.clear('mypool', '/dev/rdsk/c0t0d0')
+            res = OrderedDict([
+                ('cleared', False),
+                ('error', "cannot clear errors for /dev/rdsk/c0t0d0: no such device in pool"),
+            ])
+            self.assertEqual(res, ret)
             self.assertEqual(res, ret)

--- a/tests/unit/utils/test_zfs.py
+++ b/tests/unit/utils/test_zfs.py
@@ -1,0 +1,1721 @@
+# -*- coding: utf-8 -*-
+'''
+Tests for the zfs utils library
+
+:maintainer:    Jorge Schrauwen <sjorge@blackdot.be>
+:maturity:      new
+:platform:      illumos,freebsd,linux
+
+.. versionadded:: Fluorine
+'''
+
+# Import Python libs
+from __future__ import absolute_import
+
+# Import Salt Testing libs
+from tests.support.unit import skipIf, TestCase
+from tests.support.mock import (
+    MagicMock,
+    patch,
+    NO_MOCK,
+    NO_MOCK_REASON,
+)
+
+# Import Salt Execution module to test
+import salt.utils.zfs as zfs
+
+# Import Salt Utils
+import salt.loader
+from salt.utils.odict import OrderedDict
+
+# property_map mocks
+pmap_exec_zpool = {
+    'retcode': 2,
+    'stdout': '',
+    'stderr': "\n".join([
+        'missing property argument',
+        'usage:',
+        '        get [-Hp] [-o "all" | field[,...]] <"all" | property[,...]> <pool> ...',
+        '',
+        'the following properties are supported:',
+        '',
+        '        PROPERTY         EDIT   VALUES',
+        '',
+        '        allocated          NO   <size>',
+        '        capacity           NO   <size>',
+        '        dedupratio         NO   <1.00x or higher if deduped>',
+        '        expandsize         NO   <size>',
+        '        fragmentation      NO   <percent>',
+        '        free               NO   <size>',
+        '        freeing            NO   <size>',
+        '        guid               NO   <guid>',
+        '        health             NO   <state>',
+        '        leaked             NO   <size>',
+        '        size               NO   <size>',
+        '        altroot           YES   <path>',
+        '        autoexpand        YES   on | off',
+        '        autoreplace       YES   on | off',
+        '        bootfs            YES   <filesystem>',
+        '        bootsize          YES   <size>',
+        '        cachefile         YES   <file> | none',
+        '        comment           YES   <comment-string>',
+        '        dedupditto        YES   <threshold (min 100)>',
+        '        delegation        YES   on | off',
+        '        failmode          YES   wait | continue | panic',
+        '        listsnapshots     YES   on | off',
+        '        readonly          YES   on | off',
+        '        version           YES   <version>',
+        '        feature@...       YES   disabled | enabled | active',
+        '',
+        'The feature@ properties must be appended with a feature name.',
+        'See zpool-features(5). ',
+    ]),
+}
+pmap_zpool = {
+  'comment': {
+    'edit': True,
+    'type': 'str',
+    'values': '<comment-string>'
+  },
+  'freeing': {
+    'edit': False,
+    'type': 'size',
+    'values': '<size>'
+  },
+  'listsnapshots': {
+    'edit': True,
+    'type': 'bool',
+    'values': 'on | off'
+  },
+  'leaked': {
+    'edit': False,
+    'type': 'size',
+    'values': '<size>'
+  },
+  'version': {
+    'edit': True,
+    'type': 'numeric',
+    'values': '<version>'
+  },
+  'write': {
+    'edit': False,
+    'type': 'size',
+    'values': '<size>'
+  },
+  'replace': {
+    'edit': True,
+    'type': 'bool',
+    'values': 'on | off'
+  },
+  'delegation': {
+    'edit': True,
+    'type': 'bool',
+    'values': 'on | off'
+  },
+  'dedupditto': {
+    'edit': True,
+    'type': 'str',
+    'values': '<threshold (min 100)>'
+  },
+  'autoexpand': {
+    'edit': True,
+    'type': 'bool',
+    'values': 'on | off'
+  },
+  'alloc': {
+    'edit': False,
+    'type': 'size',
+    'values': '<size>'
+  },
+  'allocated': {
+    'edit': False,
+    'type': 'size',
+    'values': '<size>'
+  },
+  'guid': {
+    'edit': False,
+    'type': 'numeric',
+    'values': '<guid>'
+  },
+  'size': {
+    'edit': False,
+    'type': 'size',
+    'values': '<size>'
+  },
+  'cap': {
+    'edit': False,
+    'type': 'numeric',
+    'values': '<count>'
+  },
+  'capacity': {
+    'edit': False,
+    'type': 'size',
+    'values': '<size>'
+  },
+  "capacity-alloc": {
+    "edit": False,
+    "type": "size",
+    "values": "<size>"
+  },
+  "capacity-free": {
+    "edit": False,
+    "type": "size",
+    "values": "<size>"
+  },
+  'cachefile': {
+    'edit': True,
+    'type': 'str',
+    'values': '<file> | none'
+  },
+  "cksum": {
+    "edit": False,
+    "type": "numeric",
+    "values": "<count>"
+  },
+  'bootfs': {
+    'edit': True,
+    'type': 'str',
+    'values': '<filesystem>'
+  },
+  'autoreplace': {
+    'edit': True,
+    'type': 'bool',
+    'values': 'on | off'
+  },
+  "bandwith-read": {
+    "edit": False,
+    "type": "size",
+    "values": "<size>"
+  },
+  "bandwith-write": {
+    "edit": False,
+    "type": "size",
+    "values": "<size>"
+  },
+  "operations-read": {
+    "edit": False,
+    "type": "size",
+    "values": "<size>"
+  },
+  "operations-write": {
+    "edit": False,
+    "type": "size",
+    "values": "<size>"
+  },
+  "read": {
+    "edit": False,
+    "type": "size",
+    "values": "<size>"
+  },
+  'readonly': {
+    'edit': True,
+    'type': 'bool',
+    'values': 'on | off'
+  },
+  'dedupratio': {
+    'edit': False,
+    'type': 'str',
+    'values': '<1.00x or higher if deduped>'
+  },
+  'health': {
+    'edit': False,
+    'type': 'str',
+    'values': '<state>'
+  },
+  'feature@': {
+    'edit': True,
+    'type': 'str',
+    'values': 'disabled | enabled | active'
+  },
+  'expandsize': {
+    'edit': False,
+    'type': 'size',
+    'values': '<size>'
+  },
+  'listsnaps': {
+    'edit': True,
+    'type': 'bool',
+    'values': 'on | off'
+  },
+  'bootsize': {
+    'edit': True,
+    'type': 'size',
+    'values': '<size>'
+  },
+  'free': {
+    'edit': False,
+    'type': 'size',
+    'values': '<size>'
+  },
+  'failmode': {
+    'edit': True,
+    'type': 'str',
+    'values': 'wait | continue | panic'
+  },
+  'altroot': {
+    'edit': True,
+    'type': 'str',
+    'values': '<path>'
+  },
+  'expand': {
+    'edit': True,
+    'type': 'bool',
+    'values': 'on | off'
+  },
+  'frag': {
+    'edit': False,
+    'type': 'str',
+    'values': '<percent>'
+  },
+  'fragmentation': {
+    'edit': False,
+    'type': 'str',
+    'values': '<percent>'
+  }
+}
+pmap_exec_zfs = {
+    'retcode': 2,
+    'stdout': '',
+    'stderr': "\n".join([
+        'missing property argument',
+        'usage:',
+        '        get [-crHp] [-d max] [-o "all" | field[,...]]',
+        '            [-t type[,...]] [-s source[,...]]',
+        '            <"all" | property[,...]> [filesystem|volume|snapshot|bookmark] ...',
+        '',
+        'The following properties are supported:',
+        '',
+        '        PROPERTY       EDIT  INHERIT   VALUES',
+        '',
+        '        available        NO       NO   <size>',
+        '        clones           NO       NO   <dataset>[,...]',
+        '        compressratio    NO       NO   <1.00x or higher if compressed>',
+        '        creation         NO       NO   <date>',
+        '        defer_destroy    NO       NO   yes | no',
+        '        filesystem_count  NO       NO   <count>',
+        '        logicalreferenced  NO       NO   <size>',
+        '        logicalused      NO       NO   <size>',
+        '        mounted          NO       NO   yes | no',
+        '        origin           NO       NO   <snapshot>',
+        '        receive_resume_token  NO       NO   <string token>',
+        '        refcompressratio  NO       NO   <1.00x or higher if compressed>',
+        '        referenced       NO       NO   <size>',
+        '        snapshot_count   NO       NO   <count>',
+        '        type             NO       NO   filesystem | volume | snapshot | bookmark',
+        '        used             NO       NO   <size>',
+        '        usedbychildren   NO       NO   <size>',
+        '        usedbydataset    NO       NO   <size>',
+        '        usedbyrefreservation  NO       NO   <size>',
+        '        usedbysnapshots  NO       NO   <size>',
+        '        userrefs         NO       NO   <count>',
+        '        written          NO       NO   <size>',
+        '        aclinherit      YES      YES   discard | noallow | restricted | passthrough | passthrough-x',
+        '        aclmode         YES      YES   discard | groupmask | passthrough | restricted',
+        '        atime           YES      YES   on | off',
+        '        canmount        YES       NO   on | off | noauto',
+        '        casesensitivity  NO      YES   sensitive | insensitive | mixed',
+        '        checksum        YES      YES   on | off | fletcher2 | fletcher4 | sha256 | sha512 | skein | edonr',
+        '        compression     YES      YES   on | off | lzjb | gzip | gzip-[1-9] | zle | lz4',
+        '        copies          YES      YES   1 | 2 | 3',
+        '        dedup           YES      YES   on | off | verify | sha256[,verify], sha512[,verify], skein[,verify], edonr,verify',
+        '        devices         YES      YES   on | off',
+        '        exec            YES      YES   on | off',
+        '        filesystem_limit YES       NO   <count> | none',
+        '        logbias         YES      YES   latency | throughput',
+        '        mlslabel        YES      YES   <sensitivity label>',
+        '        mountpoint      YES      YES   <path> | legacy | none',
+        '        nbmand          YES      YES   on | off',
+        '        normalization    NO      YES   none | formC | formD | formKC | formKD',
+        '        primarycache    YES      YES   all | none | metadata',
+        '        quota           YES       NO   <size> | none',
+        '        readonly        YES      YES   on | off',
+        '        recordsize      YES      YES   512 to 1M, power of 2',
+        '        redundant_metadata YES      YES   all | most',
+        '        refquota        YES       NO   <size> | none',
+        '        refreservation  YES       NO   <size> | none',
+        '        reservation     YES       NO   <size> | none',
+        '        secondarycache  YES      YES   all | none | metadata',
+        '        setuid          YES      YES   on | off',
+        '        sharenfs        YES      YES   on | off | share(1M) options',
+        '        sharesmb        YES      YES   on | off | sharemgr(1M) options',
+        '        snapdir         YES      YES   hidden | visible',
+        '        snapshot_limit  YES       NO   <count> | none',
+        '        sync            YES      YES   standard | always | disabled',
+        '        utf8only         NO      YES   on | off',
+        '        version         YES       NO   1 | 2 | 3 | 4 | 5 | current',
+        '        volblocksize     NO      YES   512 to 128k, power of 2',
+        '        volsize         YES       NO   <size>',
+        '        vscan           YES      YES   on | off',
+        '        xattr           YES      YES   on | off',
+        '        zoned           YES      YES   on | off',
+        '        userused@...     NO       NO   <size>',
+        '        groupused@...    NO       NO   <size>',
+        '        userquota@...   YES       NO   <size> | none',
+        '        groupquota@...  YES       NO   <size> | none',
+        '        written@<snap>   NO       NO   <size>',
+        '',
+        'Sizes are specified in bytes with standard units such as K, M, G, etc.',
+        '',
+        'User-defined properties can be specified by using a name containing a colon (:).',
+        '',
+        'The {user|group}{used|quota}@ properties must be appended with',
+        'a user or group specifier of one of these forms:',
+        '    POSIX name      (eg: "matt")',
+        '    POSIX id        (eg: "126829")',
+        '    SMB name@domain (eg: "matt@sun")',
+        '    SMB SID         (eg: "S-1-234-567-89")',
+    ]),
+}
+pmap_zfs = {
+  "origin": {
+    "edit": False,
+    "inherit": False,
+    "values": "<snapshot>",
+    "type": "str"
+  },
+  "setuid": {
+    "edit": True,
+    "inherit": True,
+    "values": "on | off",
+    "type": "bool"
+  },
+  "referenced": {
+    "edit": False,
+    "inherit": False,
+    "values": "<size>",
+    "type": "size"
+  },
+  "vscan": {
+    "edit": True,
+    "inherit": True,
+    "values": "on | off",
+    "type": "bool"
+  },
+  "logicalused": {
+    "edit": False,
+    "inherit": False,
+    "values": "<size>",
+    "type": "size"
+  },
+  "userrefs": {
+    "edit": False,
+    "inherit": False,
+    "values": "<count>",
+    "type": "numeric"
+  },
+  "primarycache": {
+    "edit": True,
+    "inherit": True,
+    "values": "all | none | metadata",
+    "type": "str"
+  },
+  "logbias": {
+    "edit": True,
+    "inherit": True,
+    "values": "latency | throughput",
+    "type": "str"
+  },
+  "creation": {
+    "edit": False,
+    "inherit": False,
+    "values": "<date>",
+    "type": "str"
+  },
+  "sync": {
+    "edit": True,
+    "inherit": True,
+    "values": "standard | always | disabled",
+    "type": "str"
+  },
+  "dedup": {
+    "edit": True,
+    "inherit": True,
+    "values": "on | off | verify | sha256[,verify], sha512[,verify], skein[,verify], edonr,verify",
+    "type": "bool"
+  },
+  "sharenfs": {
+    "edit": True,
+    "inherit": True,
+    "values": "on | off | share(1m) options",
+    "type": "bool"
+  },
+  "receive_resume_token": {
+    "edit": False,
+    "inherit": False,
+    "values": "<string token>",
+    "type": "str"
+  },
+  "usedbyrefreservation": {
+    "edit": False,
+    "inherit": False,
+    "values": "<size>",
+    "type": "size"
+  },
+  "sharesmb": {
+    "edit": True,
+    "inherit": True,
+    "values": "on | off | sharemgr(1m) options",
+    "type": "bool"
+  },
+  "rdonly": {
+    "edit": True,
+    "inherit": True,
+    "values": "on | off",
+    "type": "bool"
+  },
+  "reservation": {
+    "edit": True,
+    "inherit": False,
+    "values": "<size> | none",
+    "type": "size"
+  },
+  "reserv": {
+    "edit": True,
+    "inherit": False,
+    "values": "<size> | none",
+    "type": "size"
+  },
+  "mountpoint": {
+    "edit": True,
+    "inherit": True,
+    "values": "<path> | legacy | none",
+    "type": "str"
+  },
+  "casesensitivity": {
+    "edit": False,
+    "inherit": True,
+    "values": "sensitive | insensitive | mixed",
+    "type": "str"
+  },
+  "utf8only": {
+    "edit": False,
+    "inherit": True,
+    "values": "on | off",
+    "type": "bool"
+  },
+  "usedbysnapshots": {
+    "edit": False,
+    "inherit": False,
+    "values": "<size>",
+    "type": "size"
+  },
+  "readonly": {
+    "edit": True,
+    "inherit": True,
+    "values": "on | off",
+    "type": "bool"
+  },
+  "written@": {
+    "edit": False,
+    "inherit": False,
+    "values": "<size>",
+    "type": "size"
+  },
+  "avail": {
+    "edit": False,
+    "inherit": False,
+    "values": "<size>",
+    "type": "size"
+  },
+  "recsize": {
+    "edit": True,
+    "inherit": True,
+    "values": "512 to 1m, power of 2",
+    "type": "str"
+  },
+  "atime": {
+    "edit": True,
+    "inherit": True,
+    "values": "on | off",
+    "type": "bool"
+  },
+  "compression": {
+    "edit": True,
+    "inherit": True,
+    "values": "on | off | lzjb | gzip | gzip-[1-9] | zle | lz4",
+    "type": "bool"
+  },
+  "snapdir": {
+    "edit": True,
+    "inherit": True,
+    "values": "hidden | visible",
+    "type": "str"
+  },
+  "aclmode": {
+    "edit": True,
+    "inherit": True,
+    "values": "discard | groupmask | passthrough | restricted",
+    "type": "str"
+  },
+  "zoned": {
+    "edit": True,
+    "inherit": True,
+    "values": "on | off",
+    "type": "bool"
+  },
+  "copies": {
+    "edit": True,
+    "inherit": True,
+    "values": "1 | 2 | 3",
+    "type": "numeric"
+  },
+  "snapshot_limit": {
+    "edit": True,
+    "inherit": False,
+    "values": "<count> | none",
+    "type": "numeric"
+  },
+  "aclinherit": {
+    "edit": True,
+    "inherit": True,
+    "values": "discard | noallow | restricted | passthrough | passthrough-x",
+    "type": "str"
+  },
+  "compressratio": {
+    "edit": False,
+    "inherit": False,
+    "values": "<1.00x or higher if compressed>",
+    "type": "str"
+  },
+  "xattr": {
+    "edit": True,
+    "inherit": True,
+    "values": "on | off",
+    "type": "bool"
+  },
+  "written": {
+    "edit": False,
+    "inherit": False,
+    "values": "<size>",
+    "type": "size"
+  },
+  "version": {
+    "edit": True,
+    "inherit": False,
+    "values": "1 | 2 | 3 | 4 | 5 | current",
+    "type": "numeric"
+  },
+  "recordsize": {
+    "edit": True,
+    "inherit": True,
+    "values": "512 to 1m, power of 2",
+    "type": "str"
+  },
+  "refquota": {
+    "edit": True,
+    "inherit": False,
+    "values": "<size> | none",
+    "type": "size"
+  },
+  "filesystem_limit": {
+    "edit": True,
+    "inherit": False,
+    "values": "<count> | none",
+    "type": "numeric"
+  },
+  "lrefer.": {
+    "edit": False,
+    "inherit": False,
+    "values": "<size>",
+    "type": "size"
+  },
+  "type": {
+    "edit": False,
+    "inherit": False,
+    "values": "filesystem | volume | snapshot | bookmark",
+    "type": "str"
+  },
+  "secondarycache": {
+    "edit": True,
+    "inherit": True,
+    "values": "all | none | metadata",
+    "type": "str"
+  },
+  "refer": {
+    "edit": False,
+    "inherit": False,
+    "values": "<size>",
+    "type": "size"
+  },
+  "available": {
+    "edit": False,
+    "inherit": False,
+    "values": "<size>",
+    "type": "size"
+  },
+  "used": {
+    "edit": False,
+    "inherit": False,
+    "values": "<size>",
+    "type": "size"
+  },
+  "exec": {
+    "edit": True,
+    "inherit": True,
+    "values": "on | off",
+    "type": "bool"
+  },
+  "compress": {
+    "edit": True,
+    "inherit": True,
+    "values": "on | off | lzjb | gzip | gzip-[1-9] | zle | lz4",
+    "type": "bool"
+  },
+  "volblock": {
+    "edit": False,
+    "inherit": True,
+    "values": "512 to 128k, power of 2",
+    "type": "str"
+  },
+  "refcompressratio": {
+    "edit": False,
+    "inherit": False,
+    "values": "<1.00x or higher if compressed>",
+    "type": "str"
+  },
+  "quota": {
+    "edit": True,
+    "inherit": False,
+    "values": "<size> | none",
+    "type": "size"
+  },
+  "groupquota@": {
+    "edit": True,
+    "inherit": False,
+    "values": "<size> | none",
+    "type": "size"
+  },
+  "userquota@": {
+    "edit": True,
+    "inherit": False,
+    "values": "<size> | none",
+    "type": "size"
+  },
+  "snapshot_count": {
+    "edit": False,
+    "inherit": False,
+    "values": "<count>",
+    "type": "numeric"
+  },
+  "volsize": {
+    "edit": True,
+    "inherit": False,
+    "values": "<size>",
+    "type": "size"
+  },
+  "clones": {
+    "edit": False,
+    "inherit": False,
+    "values": "<dataset>[,...]",
+    "type": "str"
+  },
+  "canmount": {
+    "edit": True,
+    "inherit": False,
+    "values": "on | off | noauto",
+    "type": "bool"
+  },
+  "mounted": {
+    "edit": False,
+    "inherit": False,
+    "values": "yes | no",
+    "type": "bool_alt"
+  },
+  "groupused@": {
+    "edit": False,
+    "inherit": False,
+    "values": "<size>",
+    "type": "size"
+  },
+  "normalization": {
+    "edit": False,
+    "inherit": True,
+    "values": "none | formc | formd | formkc | formkd",
+    "type": "str"
+  },
+  "usedbychildren": {
+    "edit": False,
+    "inherit": False,
+    "values": "<size>",
+    "type": "size"
+  },
+  "usedbydataset": {
+    "edit": False,
+    "inherit": False,
+    "values": "<size>",
+    "type": "size"
+  },
+  "mlslabel": {
+    "edit": True,
+    "inherit": True,
+    "values": "<sensitivity label>",
+    "type": "str"
+  },
+  "refreserv": {
+    "edit": True,
+    "inherit": False,
+    "values": "<size> | none",
+    "type": "size"
+  },
+  "defer_destroy": {
+    "edit": False,
+    "inherit": False,
+    "values": "yes | no",
+    "type": "bool_alt"
+  },
+  "volblocksize": {
+    "edit": False,
+    "inherit": True,
+    "values": "512 to 128k, power of 2",
+    "type": "str"
+  },
+  "lused.": {
+    "edit": False,
+    "inherit": False,
+    "values": "<size>",
+    "type": "size"
+  },
+  "redundant_metadata": {
+    "edit": True,
+    "inherit": True,
+    "values": "all | most",
+    "type": "str"
+  },
+  "filesystem_count": {
+    "edit": False,
+    "inherit": False,
+    "values": "<count>",
+    "type": "numeric"
+  },
+  "devices": {
+    "edit": True,
+    "inherit": True,
+    "values": "on | off",
+    "type": "bool"
+  },
+  "refreservation": {
+    "edit": True,
+    "inherit": False,
+    "values": "<size> | none",
+    "type": "size"
+  },
+  "userused@": {
+    "edit": False,
+    "inherit": False,
+    "values": "<size>",
+    "type": "size"
+  },
+  "logicalreferenced": {
+    "edit": False,
+    "inherit": False,
+    "values": "<size>",
+    "type": "size"
+  },
+  "checksum": {
+    "edit": True,
+    "inherit": True,
+    "values": "on | off | fletcher2 | fletcher4 | sha256 | sha512 | skein | edonr",
+    "type": "bool"
+  },
+  "nbmand": {
+    "edit": True,
+    "inherit": True,
+    "values": "on | off",
+    "type": "bool"
+  }
+}
+
+
+def _from_auto(name, value, source='auto'):
+    '''
+    some more complex patching for zfs.from_auto
+    '''
+    with patch.object(salt.utils.zfs, 'property_data_zpool', MagicMock(return_value=pmap_zpool)), \
+         patch.object(salt.utils.zfs, 'property_data_zfs', MagicMock(return_value=pmap_zfs)):
+        return salt.utils.zfs.from_auto(name, value, source)
+
+
+def _from_auto_dict(values, source='auto'):
+    '''
+    some more complex patching for zfs.from_auto
+    '''
+    with patch.object(salt.utils.zfs, 'property_data_zpool', MagicMock(return_value=pmap_zpool)), \
+         patch.object(salt.utils.zfs, 'property_data_zfs', MagicMock(return_value=pmap_zfs)):
+        return salt.utils.zfs.from_auto_dict(values, source)
+
+
+utils_patch = {
+    'zfs.is_supported': MagicMock(return_value=True),
+    'zfs.has_feature_flags': MagicMock(return_value=False),
+    'zfs.property_data_zpool': MagicMock(return_value=pmap_zpool),
+    'zfs.property_data_zfs': MagicMock(return_value=pmap_zfs),
+    # NOTE: we make zpool_command and zfs_command a NOOP
+    #       these are extensively tested in tests.unit.utils.test_zfs
+    'zfs.zpool_command': MagicMock(return_value='/bin/false'),
+    'zfs.zfs_command': MagicMock(return_value='/bin/false'),
+    # NOTE: from_auto_dict is a special snowflake
+    #       internally it calls multiple calls from
+    #       salt.utils.zfs but we cannot patch those using
+    #       the common methode, __utils__ is not available
+    #       so they are direct calls, we do some voodoo here.
+    'zfs.from_auto_dict': _from_auto_dict,
+    'zfs.from_auto': _from_auto,
+}
+
+
+# Skip this test case if we don't have access to mock!
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class ZfsUtilsTestCase(TestCase):
+    '''
+    This class contains a set of functions that test salt.utils.zfs utils
+    '''
+    ## NOTE: test parameter parsing
+    def test_property_data_zpool(self):
+        '''
+        Test parsing of zpool get output
+        '''
+        with patch.object(zfs, '_zfs_cmd', MagicMock(return_value='/sbin/zfs')):
+            with patch.object(zfs, '_zpool_cmd', MagicMock(return_value='/sbin/zpool')):
+                with patch.object(zfs, '_exec', MagicMock(return_value=pmap_exec_zpool)):
+                    self.assertEqual(zfs.property_data_zpool(), pmap_zpool)
+
+    def test_property_data_zfs(self):
+        '''
+        Test parsing of zfs get output
+        '''
+        with patch.object(zfs, '_zfs_cmd', MagicMock(return_value='/sbin/zfs')):
+            with patch.object(zfs, '_zpool_cmd', MagicMock(return_value='/sbin/zpool')):
+                with patch.object(zfs, '_exec', MagicMock(return_value=pmap_exec_zfs)):
+                    self.assertEqual(zfs.property_data_zfs(), pmap_zfs)
+
+    ## NOTE: testing from_bool results
+    def test_from_bool_on(self):
+        '''
+        Test from_bool with 'on'
+        '''
+        self.assertTrue(zfs.from_bool('on'))
+        self.assertTrue(zfs.from_bool(zfs.from_bool('on')))
+
+    def test_from_bool_off(self):
+        '''
+        Test from_bool with 'off'
+        '''
+        self.assertFalse(zfs.from_bool('off'))
+        self.assertFalse(zfs.from_bool(zfs.from_bool('off')))
+
+    def test_from_bool_none(self):
+        '''
+        Test from_bool with 'none'
+        '''
+        self.assertEqual(zfs.from_bool('none'), None)
+        self.assertEqual(zfs.from_bool(zfs.from_bool('none')), None)
+
+    def test_from_bool_passthrough(self):
+        '''
+        Test from_bool with 'passthrough'
+        '''
+        self.assertEqual(zfs.from_bool('passthrough'), 'passthrough')
+        self.assertEqual(zfs.from_bool(zfs.from_bool('passthrough')), 'passthrough')
+
+    def test_from_bool_alt_yes(self):
+        '''
+        Test from_bool_alt with 'yes'
+        '''
+        self.assertTrue(zfs.from_bool_alt('yes'))
+        self.assertTrue(zfs.from_bool_alt(zfs.from_bool_alt('yes')))
+
+    def test_from_bool_alt_no(self):
+        '''
+        Test from_bool_alt with 'no'
+        '''
+        self.assertFalse(zfs.from_bool_alt('no'))
+        self.assertFalse(zfs.from_bool_alt(zfs.from_bool_alt('no')))
+
+    def test_from_bool_alt_none(self):
+        '''
+        Test from_bool_alt with 'none'
+        '''
+        self.assertEqual(zfs.from_bool_alt('none'), None)
+        self.assertEqual(zfs.from_bool_alt(zfs.from_bool_alt('none')), None)
+
+    def test_from_bool_alt_passthrough(self):
+        '''
+        Test from_bool_alt with 'passthrough'
+        '''
+        self.assertEqual(zfs.from_bool_alt('passthrough'), 'passthrough')
+        self.assertEqual(zfs.from_bool_alt(zfs.from_bool_alt('passthrough')), 'passthrough')
+
+    ## NOTE: testing to_bool results
+    def test_to_bool_true(self):
+        '''
+        Test to_bool with True
+        '''
+        self.assertEqual(zfs.to_bool(True), 'on')
+        self.assertEqual(zfs.to_bool(zfs.to_bool(True)), 'on')
+
+    def test_to_bool_false(self):
+        '''
+        Test to_bool with False
+        '''
+        self.assertEqual(zfs.to_bool(False), 'off')
+        self.assertEqual(zfs.to_bool(zfs.to_bool(False)), 'off')
+
+    def test_to_bool_none(self):
+        '''
+        Test to_bool with None
+        '''
+        self.assertEqual(zfs.to_bool(None), 'none')
+        self.assertEqual(zfs.to_bool(zfs.to_bool(None)), 'none')
+
+    def test_to_bool_passthrough(self):
+        '''
+        Test to_bool with 'passthrough'
+        '''
+        self.assertEqual(zfs.to_bool('passthrough'), 'passthrough')
+        self.assertEqual(zfs.to_bool(zfs.to_bool('passthrough')), 'passthrough')
+
+    def test_to_bool_alt_true(self):
+        '''
+        Test to_bool_alt with True
+        '''
+        self.assertEqual(zfs.to_bool_alt(True), 'yes')
+        self.assertEqual(zfs.to_bool_alt(zfs.to_bool_alt(True)), 'yes')
+
+    def test_to_bool_alt_false(self):
+        '''
+        Test to_bool_alt with False
+        '''
+        self.assertEqual(zfs.to_bool_alt(False), 'no')
+        self.assertEqual(zfs.to_bool_alt(zfs.to_bool_alt(False)), 'no')
+
+    def test_to_bool_alt_none(self):
+        '''
+        Test to_bool_alt with None
+        '''
+        self.assertEqual(zfs.to_bool_alt(None), 'none')
+        self.assertEqual(zfs.to_bool_alt(zfs.to_bool_alt(None)), 'none')
+
+    def test_to_bool_alt_passthrough(self):
+        '''
+        Test to_bool_alt with 'passthrough'
+        '''
+        self.assertEqual(zfs.to_bool_alt('passthrough'), 'passthrough')
+        self.assertEqual(zfs.to_bool_alt(zfs.to_bool_alt('passthrough')), 'passthrough')
+
+    ## NOTE: testing from_numeric results
+    def test_from_numeric_str(self):
+        '''
+        Test from_numeric with '42'
+        '''
+        self.assertEqual(zfs.from_numeric('42'), 42)
+        self.assertEqual(zfs.from_numeric(zfs.from_numeric('42')), 42)
+
+    def test_from_numeric_int(self):
+        '''
+        Test from_numeric with 42
+        '''
+        self.assertEqual(zfs.from_numeric(42), 42)
+        self.assertEqual(zfs.from_numeric(zfs.from_numeric(42)), 42)
+
+    def test_from_numeric_none(self):
+        '''
+        Test from_numeric with 'none'
+        '''
+        self.assertEqual(zfs.from_numeric('none'), None)
+        self.assertEqual(zfs.from_numeric(zfs.from_numeric('none')), None)
+
+    def test_from_numeric_passthrough(self):
+        '''
+        Test from_numeric with 'passthrough'
+        '''
+        self.assertEqual(zfs.from_numeric('passthrough'), 'passthrough')
+        self.assertEqual(zfs.from_numeric(zfs.from_numeric('passthrough')), 'passthrough')
+
+    ## NOTE: testing to_numeric results
+    def test_to_numeric_str(self):
+        '''
+        Test to_numeric with '42'
+        '''
+        self.assertEqual(zfs.to_numeric('42'), 42)
+        self.assertEqual(zfs.to_numeric(zfs.to_numeric('42')), 42)
+
+    def test_to_numeric_int(self):
+        '''
+        Test to_numeric with 42
+        '''
+        self.assertEqual(zfs.to_numeric(42), 42)
+        self.assertEqual(zfs.to_numeric(zfs.to_numeric(42)), 42)
+
+    def test_to_numeric_none(self):
+        '''
+        Test to_numeric with 'none'
+        '''
+        self.assertEqual(zfs.to_numeric(None), 'none')
+        self.assertEqual(zfs.to_numeric(zfs.to_numeric(None)), 'none')
+
+    def test_to_numeric_passthrough(self):
+        '''
+        Test to_numeric with 'passthrough'
+        '''
+        self.assertEqual(zfs.to_numeric('passthrough'), 'passthrough')
+        self.assertEqual(zfs.to_numeric(zfs.to_numeric('passthrough')), 'passthrough')
+
+    ## NOTE: testing from_size results
+    def test_from_size_absolute(self):
+        '''
+        Test from_size with '5G'
+        '''
+        self.assertEqual(zfs.from_size('5G'), 5368709120)
+        self.assertEqual(zfs.from_size(zfs.from_size('5G')), 5368709120)
+
+    def test_from_size_decimal(self):
+        '''
+        Test from_size with '4.20M'
+        '''
+        self.assertEqual(zfs.from_size('4.20M'), 4404019)
+        self.assertEqual(zfs.from_size(zfs.from_size('4.20M')), 4404019)
+
+    def test_from_size_none(self):
+        '''
+        Test from_size with 'none'
+        '''
+        self.assertEqual(zfs.from_size('none'), None)
+        self.assertEqual(zfs.from_size(zfs.from_size('none')), None)
+
+    def test_from_size_passthrough(self):
+        '''
+        Test from_size with 'passthrough'
+        '''
+        self.assertEqual(zfs.from_size('passthrough'), 'passthrough')
+        self.assertEqual(zfs.from_size(zfs.from_size('passthrough')), 'passthrough')
+
+    ## NOTE: testing to_size results
+    def test_to_size_str_absolute(self):
+        '''
+        Test to_size with '5368709120'
+        '''
+        self.assertEqual(zfs.to_size('5368709120'), '5G')
+        self.assertEqual(zfs.to_size(zfs.to_size('5368709120')), '5G')
+
+    def test_to_size_str_decimal(self):
+        '''
+        Test to_size with '4404019'
+        '''
+        self.assertEqual(zfs.to_size('4404019'), '4.20M')
+        self.assertEqual(zfs.to_size(zfs.to_size('4404019')), '4.20M')
+
+    def test_to_size_int_absolute(self):
+        '''
+        Test to_size with 5368709120
+        '''
+        self.assertEqual(zfs.to_size(5368709120), '5G')
+        self.assertEqual(zfs.to_size(zfs.to_size(5368709120)), '5G')
+
+    def test_to_size_int_decimal(self):
+        '''
+        Test to_size with 4404019
+        '''
+        self.assertEqual(zfs.to_size(4404019), '4.20M')
+        self.assertEqual(zfs.to_size(zfs.to_size(4404019)), '4.20M')
+
+    def test_to_size_none(self):
+        '''
+        Test to_size with 'none'
+        '''
+        self.assertEqual(zfs.to_size(None), 'none')
+        self.assertEqual(zfs.to_size(zfs.to_size(None)), 'none')
+
+    def test_to_size_passthrough(self):
+        '''
+        Test to_size with 'passthrough'
+        '''
+        self.assertEqual(zfs.to_size('passthrough'), 'passthrough')
+        self.assertEqual(zfs.to_size(zfs.to_size('passthrough')), 'passthrough')
+
+    ## NOTE: testing from_str results
+    def test_from_str_space(self):
+        '''
+        Test from_str with "\"my pool/my dataset\"
+        '''
+        self.assertEqual(zfs.from_str('"my pool/my dataset"'), 'my pool/my dataset')
+        self.assertEqual(zfs.from_str(zfs.from_str('"my pool/my dataset"')), 'my pool/my dataset')
+
+    def test_from_str_squote_space(self):
+        '''
+        Test from_str with "my pool/jorge's dataset"
+        '''
+        self.assertEqual(zfs.from_str("my pool/jorge's dataset"), "my pool/jorge's dataset")
+        self.assertEqual(zfs.from_str(zfs.from_str("my pool/jorge's dataset")), "my pool/jorge's dataset")
+
+    def test_from_str_dquote_space(self):
+        '''
+        Test from_str with "my pool/the \"good\" stuff"
+        '''
+        self.assertEqual(zfs.from_str("my pool/the \"good\" stuff"), 'my pool/the "good" stuff')
+        self.assertEqual(zfs.from_str(zfs.from_str("my pool/the \"good\" stuff")), 'my pool/the "good" stuff')
+
+    def test_from_str_none(self):
+        '''
+        Test from_str with 'none'
+        '''
+        self.assertEqual(zfs.from_str('none'), None)
+        self.assertEqual(zfs.from_str(zfs.from_str('none')), None)
+
+    def test_from_str_passthrough(self):
+        '''
+        Test from_str with 'passthrough'
+        '''
+        self.assertEqual(zfs.from_str('passthrough'), 'passthrough')
+        self.assertEqual(zfs.from_str(zfs.from_str('passthrough')), 'passthrough')
+
+    ## NOTE: testing to_str results
+    def test_to_str_space(self):
+        '''
+        Test to_str with 'my pool/my dataset'
+        '''
+        ## NOTE: for fun we use both the '"str"' and "\"str\"" way of getting the literal string: "str"
+        self.assertEqual(zfs.to_str('my pool/my dataset'), '"my pool/my dataset"')
+        self.assertEqual(zfs.to_str(zfs.to_str('my pool/my dataset')), "\"my pool/my dataset\"")
+
+    def test_to_str_squote_space(self):
+        '''
+        Test to_str with "my pool/jorge's dataset"
+        '''
+        self.assertEqual(zfs.to_str("my pool/jorge's dataset"), "\"my pool/jorge's dataset\"")
+        self.assertEqual(zfs.to_str(zfs.to_str("my pool/jorge's dataset")), "\"my pool/jorge's dataset\"")
+
+    def test_to_str_none(self):
+        '''
+        Test to_str with 'none'
+        '''
+        self.assertEqual(zfs.to_str(None), 'none')
+        self.assertEqual(zfs.to_str(zfs.to_str(None)), 'none')
+
+    def test_to_str_passthrough(self):
+        '''
+        Test to_str with 'passthrough'
+        '''
+        self.assertEqual(zfs.to_str('passthrough'), 'passthrough')
+        self.assertEqual(zfs.to_str(zfs.to_str('passthrough')), 'passthrough')
+
+    ## NOTE: testing is_snapshot
+    def test_is_snapshot_snapshot(self):
+        '''
+        Test is_snapshot with a valid snapshot name
+        '''
+        self.assertTrue(zfs.is_snapshot('zpool_name/dataset@backup'))
+
+    def test_is_snapshot_bookmark(self):
+        '''
+        Test is_snapshot with a valid bookmark name
+        '''
+        self.assertFalse(zfs.is_snapshot('zpool_name/dataset#backup'))
+
+    def test_is_snapshot_filesystem(self):
+        '''
+        Test is_snapshot with a valid filesystem name
+        '''
+        self.assertFalse(zfs.is_snapshot('zpool_name/dataset'))
+
+    ## NOTE: testing is_bookmark
+    def test_is_bookmark_snapshot(self):
+        '''
+        Test is_bookmark with a valid snapshot name
+        '''
+        self.assertFalse(zfs.is_bookmark('zpool_name/dataset@backup'))
+
+    def test_is_bookmark_bookmark(self):
+        '''
+        Test is_bookmark with a valid bookmark name
+        '''
+        self.assertTrue(zfs.is_bookmark('zpool_name/dataset#backup'))
+
+    def test_is_bookmark_filesystem(self):
+        '''
+        Test is_bookmark with a valid filesystem name
+        '''
+        self.assertFalse(zfs.is_bookmark('zpool_name/dataset'))
+
+    ## NOTE: testing is_filesystem
+    def test_is_filesystem_snapshot(self):
+        '''
+        Test is_filesystem with a valid snapshot name
+        '''
+        self.assertFalse(zfs.is_filesystem('zpool_name/dataset@backup'))
+
+    def test_is_filesystem_bookmark(self):
+        '''
+        Test is_filesystem with a valid bookmark name
+        '''
+        self.assertFalse(zfs.is_filesystem('zpool_name/dataset#backup'))
+
+    def test_is_filesystem_filesystem(self):
+        '''
+        Test is_filesystem with a valid filesystem name
+        '''
+        self.assertTrue(zfs.is_filesystem('zpool_name/dataset'))
+
+    ## NOTE: testing is_volume
+    def test_is_volume_snapshot(self):
+        '''
+        Test is_volume with a valid snapshot name
+        '''
+        self.assertFalse(zfs.is_volume('zpool_name/dataset@backup'))
+
+    def test_is_volume_bookmark(self):
+        '''
+        Test is_volume with a valid bookmark name
+        '''
+        self.assertFalse(zfs.is_volume('zpool_name/dataset#backup'))
+
+    def test_is_volume_filesystem(self):
+        '''
+        Test is_volume with a valid filesystem name
+        '''
+        ## NOTE: volume and filesystem names are the same
+        self.assertTrue(zfs.is_volume('zpool_name/dataset'))
+
+    ## NOTE: testing zfs_command
+    def test_zfs_command_simple(self):
+        '''
+        Test if zfs_command builds the correct string
+        '''
+        with patch.object(zfs, '_zfs_cmd', MagicMock(return_value='/sbin/zfs')):
+            with patch.object(zfs, '_zpool_cmd', MagicMock(return_value='/sbin/zpool')):
+                with patch.object(zfs, 'property_data_zfs', MagicMock(return_value=pmap_zfs)):
+                    with patch.object(zfs, 'property_data_zpool', MagicMock(return_value=pmap_zpool)):
+                        self.assertEqual(
+                            zfs.zfs_command('list'),
+                            "/sbin/zfs list"
+                        )
+
+    def test_zfs_command_none_target(self):
+        '''
+        Test if zfs_command builds the correct string with a target of None
+        '''
+        with patch.object(zfs, '_zfs_cmd', MagicMock(return_value='/sbin/zfs')):
+            with patch.object(zfs, '_zpool_cmd', MagicMock(return_value='/sbin/zpool')):
+                with patch.object(zfs, 'property_data_zfs', MagicMock(return_value=pmap_zfs)):
+                    with patch.object(zfs, 'property_data_zpool', MagicMock(return_value=pmap_zpool)):
+                        self.assertEqual(
+                            zfs.zfs_command('list', target=[None, 'mypool', None]),
+                            "/sbin/zfs list mypool"
+                        )
+
+    def test_zfs_command_flag(self):
+        '''
+        Test if zfs_command builds the correct string
+        '''
+        with patch.object(zfs, '_zfs_cmd', MagicMock(return_value='/sbin/zfs')):
+            with patch.object(zfs, '_zpool_cmd', MagicMock(return_value='/sbin/zpool')):
+                with patch.object(zfs, 'property_data_zfs', MagicMock(return_value=pmap_zfs)):
+                    with patch.object(zfs, 'property_data_zpool', MagicMock(return_value=pmap_zpool)):
+                        my_flags = [
+                            '-r',  # recursive
+                            '-p',  # parsable
+                        ]
+                        self.assertEqual(
+                            zfs.zfs_command('list', flags=my_flags),
+                            "/sbin/zfs list -r -p"
+                        )
+
+    def test_zfs_command_opt(self):
+        '''
+        Test if zfs_command builds the correct string
+        '''
+        with patch.object(zfs, '_zfs_cmd', MagicMock(return_value='/sbin/zfs')):
+            with patch.object(zfs, '_zpool_cmd', MagicMock(return_value='/sbin/zpool')):
+                with patch.object(zfs, 'property_data_zfs', MagicMock(return_value=pmap_zfs)):
+                    with patch.object(zfs, 'property_data_zpool', MagicMock(return_value=pmap_zpool)):
+                        my_opts = {
+                            '-t': 'snap',  # only list snapshots
+                        }
+                        self.assertEqual(
+                            zfs.zfs_command('list', opts=my_opts),
+                            "/sbin/zfs list -t snap"
+                        )
+
+    def test_zfs_command_flag_opt(self):
+        '''
+        Test if zfs_command builds the correct string
+        '''
+        with patch.object(zfs, '_zfs_cmd', MagicMock(return_value='/sbin/zfs')):
+            with patch.object(zfs, '_zpool_cmd', MagicMock(return_value='/sbin/zpool')):
+                with patch.object(zfs, 'property_data_zfs', MagicMock(return_value=pmap_zfs)):
+                    with patch.object(zfs, 'property_data_zpool', MagicMock(return_value=pmap_zpool)):
+                        my_flags = [
+                            '-r',  # recursive
+                            '-p',  # parsable
+                        ]
+                        my_opts = {
+                            '-t': 'snap',  # only list snapshots
+                        }
+                        self.assertEqual(
+                            zfs.zfs_command('list', flags=my_flags, opts=my_opts),
+                            "/sbin/zfs list -r -p -t snap"
+                        )
+
+    def test_zfs_command_target(self):
+        '''
+        Test if zfs_command builds the correct string
+        '''
+        with patch.object(zfs, '_zfs_cmd', MagicMock(return_value='/sbin/zfs')):
+            with patch.object(zfs, '_zpool_cmd', MagicMock(return_value='/sbin/zpool')):
+                with patch.object(zfs, 'property_data_zfs', MagicMock(return_value=pmap_zfs)):
+                    with patch.object(zfs, 'property_data_zpool', MagicMock(return_value=pmap_zpool)):
+                        my_flags = [
+                            '-r',  # recursive
+                            '-p',  # parsable
+                        ]
+                        my_opts = {
+                            '-t': 'snap',  # only list snapshots
+                        }
+                        self.assertEqual(
+                            zfs.zfs_command('list', flags=my_flags, opts=my_opts, target='mypool'),
+                            "/sbin/zfs list -r -p -t snap mypool"
+                        )
+
+    def test_zfs_command_target_with_space(self):
+        '''
+        Test if zfs_command builds the correct string
+        '''
+        with patch.object(zfs, '_zfs_cmd', MagicMock(return_value='/sbin/zfs')):
+            with patch.object(zfs, '_zpool_cmd', MagicMock(return_value='/sbin/zpool')):
+                with patch.object(zfs, 'property_data_zfs', MagicMock(return_value=pmap_zfs)):
+                    with patch.object(zfs, 'property_data_zpool', MagicMock(return_value=pmap_zpool)):
+                        my_flags = [
+                            '-r',  # recursive
+                            '-p',  # parsable
+                        ]
+                        my_opts = {
+                            '-t': 'snap',  # only list snapshots
+                        }
+                        self.assertEqual(
+                            zfs.zfs_command('list', flags=my_flags, opts=my_opts, target='my pool'),
+                            '/sbin/zfs list -r -p -t snap "my pool"'
+                        )
+
+    def test_zfs_command_property(self):
+        '''
+        Test if zfs_command builds the correct string
+        '''
+        with patch.object(zfs, '_zfs_cmd', MagicMock(return_value='/sbin/zfs')):
+            with patch.object(zfs, '_zpool_cmd', MagicMock(return_value='/sbin/zpool')):
+                with patch.object(zfs, 'property_data_zfs', MagicMock(return_value=pmap_zfs)):
+                    with patch.object(zfs, 'property_data_zpool', MagicMock(return_value=pmap_zpool)):
+                        self.assertEqual(
+                            zfs.zfs_command('get', property_name='quota', target='mypool'),
+                            "/sbin/zfs get quota mypool"
+                        )
+
+    def test_zfs_command_property_value(self):
+        '''
+        Test if zfs_command builds the correct string
+        '''
+        with patch.object(zfs, '_zfs_cmd', MagicMock(return_value='/sbin/zfs')):
+            with patch.object(zfs, '_zpool_cmd', MagicMock(return_value='/sbin/zpool')):
+                with patch.object(zfs, 'property_data_zfs', MagicMock(return_value=pmap_zfs)):
+                    with patch.object(zfs, 'property_data_zpool', MagicMock(return_value=pmap_zpool)):
+                        my_flags = [
+                            '-r',  # recursive
+                        ]
+                        self.assertEqual(
+                            zfs.zfs_command('set', flags=my_flags, property_name='quota', property_value='5G', target='mypool'),
+                            "/sbin/zfs set -r quota=5368709120 mypool"
+                        )
+
+    def test_zfs_command_multi_property_value(self):
+        '''
+        Test if zfs_command builds the correct string
+        '''
+        with patch.object(zfs, '_zfs_cmd', MagicMock(return_value='/sbin/zfs')):
+            with patch.object(zfs, '_zpool_cmd', MagicMock(return_value='/sbin/zpool')):
+                with patch.object(zfs, 'property_data_zfs', MagicMock(return_value=pmap_zfs)):
+                    with patch.object(zfs, 'property_data_zpool', MagicMock(return_value=pmap_zpool)):
+                        property_name = ['quota', 'readonly']
+                        property_value = ['5G', 'no']
+                        self.assertEqual(
+                            zfs.zfs_command('set', property_name=property_name, property_value=property_value, target='mypool'),
+                            "/sbin/zfs set quota=5368709120 readonly=off mypool"
+                        )
+
+    def test_zfs_command_fs_props(self):
+        '''
+        Test if zfs_command builds the correct string
+        '''
+        with patch.object(zfs, '_zfs_cmd', MagicMock(return_value='/sbin/zfs')):
+            with patch.object(zfs, '_zpool_cmd', MagicMock(return_value='/sbin/zpool')):
+                with patch.object(zfs, 'property_data_zfs', MagicMock(return_value=pmap_zfs)):
+                    with patch.object(zfs, 'property_data_zpool', MagicMock(return_value=pmap_zpool)):
+                        my_flags = [
+                            '-p',  # create parent
+                        ]
+                        my_props = {
+                            'quota': '1G',
+                            'compression': 'lz4',
+                        }
+                        self.assertEqual(
+                            zfs.zfs_command('create', flags=my_flags, filesystem_properties=my_props, target='mypool/dataset'),
+                            "/sbin/zfs create -p -o compression=lz4 -o quota=1073741824 mypool/dataset"
+                        )
+
+    def test_zfs_command_fs_props_with_space(self):
+        '''
+        Test if zfs_command builds the correct string
+        '''
+        with patch.object(zfs, '_zfs_cmd', MagicMock(return_value='/sbin/zfs')):
+            with patch.object(zfs, '_zpool_cmd', MagicMock(return_value='/sbin/zpool')):
+                with patch.object(zfs, 'property_data_zfs', MagicMock(return_value=pmap_zfs)):
+                    with patch.object(zfs, 'property_data_zpool', MagicMock(return_value=pmap_zpool)):
+                        my_props = {
+                            'quota': '4.2M',
+                            'compression': 'lz4',
+                        }
+                        self.assertEqual(
+                            zfs.zfs_command('create', filesystem_properties=my_props, target="my pool/jorge's dataset"),
+                            '/sbin/zfs create -o compression=lz4 -o quota=4404019 "my pool/jorge\'s dataset"'
+                        )
+
+    ## NOTE: testing zpool_command
+    def test_zpool_command_simple(self):
+        '''
+        Test if zfs_command builds the correct string
+        '''
+        with patch.object(zfs, '_zfs_cmd', MagicMock(return_value='/sbin/zfs')):
+            with patch.object(zfs, '_zpool_cmd', MagicMock(return_value='/sbin/zpool')):
+                with patch.object(zfs, 'property_data_zfs', MagicMock(return_value=pmap_zfs)):
+                    with patch.object(zfs, 'property_data_zpool', MagicMock(return_value=pmap_zpool)):
+                        self.assertEqual(
+                            zfs.zpool_command('list'),
+                            "/sbin/zpool list"
+                        )
+
+    def test_zpool_command_opt(self):
+        '''
+        Test if zpool_command builds the correct string
+        '''
+        with patch.object(zfs, '_zfs_cmd', MagicMock(return_value='/sbin/zfs')):
+            with patch.object(zfs, '_zpool_cmd', MagicMock(return_value='/sbin/zpool')):
+                with patch.object(zfs, 'property_data_zfs', MagicMock(return_value=pmap_zfs)):
+                    with patch.object(zfs, 'property_data_zpool', MagicMock(return_value=pmap_zpool)):
+                        my_opts = {
+                            '-o': 'name,size',  # show only name and size
+                        }
+                        self.assertEqual(
+                            zfs.zpool_command('list', opts=my_opts),
+                            "/sbin/zpool list -o name,size"
+                        )
+
+    def test_zpool_command_opt_list(self):
+        '''
+        Test if zpool_command builds the correct string
+        '''
+        with patch.object(zfs, '_zfs_cmd', MagicMock(return_value='/sbin/zfs')):
+            with patch.object(zfs, '_zpool_cmd', MagicMock(return_value='/sbin/zpool')):
+                with patch.object(zfs, 'property_data_zfs', MagicMock(return_value=pmap_zfs)):
+                    with patch.object(zfs, 'property_data_zpool', MagicMock(return_value=pmap_zpool)):
+                        my_opts = {
+                            '-d': ['/tmp', '/zvol'],
+                        }
+                        self.assertEqual(
+                            zfs.zpool_command('import', opts=my_opts, target='mypool'),
+                            "/sbin/zpool import -d /tmp -d /zvol mypool"
+                        )
+
+    def test_zpool_command_flag_opt(self):
+        '''
+        Test if zpool_command builds the correct string
+        '''
+        with patch.object(zfs, '_zfs_cmd', MagicMock(return_value='/sbin/zfs')):
+            with patch.object(zfs, '_zpool_cmd', MagicMock(return_value='/sbin/zpool')):
+                with patch.object(zfs, 'property_data_zfs', MagicMock(return_value=pmap_zfs)):
+                    with patch.object(zfs, 'property_data_zpool', MagicMock(return_value=pmap_zpool)):
+                        my_flags = [
+                            '-p',  # parsable
+                        ]
+                        my_opts = {
+                            '-o': 'name,size',  # show only name and size
+                        }
+                        self.assertEqual(
+                            zfs.zpool_command('list', flags=my_flags, opts=my_opts),
+                            "/sbin/zpool list -p -o name,size"
+                        )
+
+    def test_zpool_command_target(self):
+        '''
+        Test if zpool_command builds the correct string
+        '''
+        with patch.object(zfs, '_zfs_cmd', MagicMock(return_value='/sbin/zfs')):
+            with patch.object(zfs, '_zpool_cmd', MagicMock(return_value='/sbin/zpool')):
+                with patch.object(zfs, 'property_data_zfs', MagicMock(return_value=pmap_zfs)):
+                    with patch.object(zfs, 'property_data_zpool', MagicMock(return_value=pmap_zpool)):
+                        my_flags = [
+                            '-p',  # parsable
+                        ]
+                        my_opts = {
+                            '-o': 'name,size',  # show only name and size
+                        }
+                        self.assertEqual(
+                            zfs.zpool_command('list', flags=my_flags, opts=my_opts, target='mypool'),
+                            "/sbin/zpool list -p -o name,size mypool"
+                        )
+
+    def test_zpool_command_target_with_space(self):
+        '''
+        Test if zpool_command builds the correct string
+        '''
+        with patch.object(zfs, '_zfs_cmd', MagicMock(return_value='/sbin/zfs')):
+            with patch.object(zfs, '_zpool_cmd', MagicMock(return_value='/sbin/zpool')):
+                with patch.object(zfs, 'property_data_zfs', MagicMock(return_value=pmap_zfs)):
+                    with patch.object(zfs, 'property_data_zpool', MagicMock(return_value=pmap_zpool)):
+                        fs_props = {
+                            'quota': '100G',
+                        }
+                        pool_props = {
+                            'comment': "jorge's comment has a space",
+                        }
+                        self.assertEqual(
+                            zfs.zpool_command('create', pool_properties=pool_props, filesystem_properties=fs_props, target='my pool'),
+                            "/sbin/zpool create -O quota=107374182400 -o comment=\"jorge's comment has a space\" \"my pool\""
+                        )
+
+    def test_zpool_command_property(self):
+        '''
+        Test if zpool_command builds the correct string
+        '''
+        with patch.object(zfs, '_zfs_cmd', MagicMock(return_value='/sbin/zfs')):
+            with patch.object(zfs, '_zpool_cmd', MagicMock(return_value='/sbin/zpool')):
+                with patch.object(zfs, 'property_data_zfs', MagicMock(return_value=pmap_zfs)):
+                    with patch.object(zfs, 'property_data_zpool', MagicMock(return_value=pmap_zpool)):
+                        self.assertEqual(
+                            zfs.zpool_command('get', property_name='comment', target='mypool'),
+                            "/sbin/zpool get comment mypool"
+                        )
+
+    def test_zpool_command_property_value(self):
+        '''
+        Test if zpool_command builds the correct string
+        '''
+        with patch.object(zfs, '_zfs_cmd', MagicMock(return_value='/sbin/zfs')):
+            with patch.object(zfs, '_zpool_cmd', MagicMock(return_value='/sbin/zpool')):
+                with patch.object(zfs, 'property_data_zfs', MagicMock(return_value=pmap_zfs)):
+                    with patch.object(zfs, 'property_data_zpool', MagicMock(return_value=pmap_zpool)):
+                        my_flags = [
+                            '-v',  # verbose
+                        ]
+                        self.assertEqual(
+                            zfs.zpool_command('iostat', flags=my_flags, target=['mypool', 60, 1]),
+                            "/sbin/zpool iostat -v mypool 60 1"
+                        )
+
+    def test_parse_command_result_success(self):
+        '''
+        Test if parse_command_result returns the expected result
+        '''
+        with patch.object(zfs, '_zfs_cmd', MagicMock(return_value='/sbin/zfs')):
+            with patch.object(zfs, '_zpool_cmd', MagicMock(return_value='/sbin/zpool')):
+                with patch.object(zfs, 'property_data_zfs', MagicMock(return_value=pmap_zfs)):
+                    with patch.object(zfs, 'property_data_zpool', MagicMock(return_value=pmap_zpool)):
+                        res = {}
+                        res['retcode'] = 0
+                        res['stderr'] = ''
+                        res['stdout'] = ''
+                        self.assertEqual(
+                            zfs.parse_command_result(res, 'tested'),
+                            OrderedDict([('tested', True)]),
+                        )
+
+    def test_parse_command_result_success_nolabel(self):
+        '''
+        Test if parse_command_result returns the expected result
+        '''
+        with patch.object(zfs, '_zfs_cmd', MagicMock(return_value='/sbin/zfs')):
+            with patch.object(zfs, '_zpool_cmd', MagicMock(return_value='/sbin/zpool')):
+                with patch.object(zfs, 'property_data_zfs', MagicMock(return_value=pmap_zfs)):
+                    with patch.object(zfs, 'property_data_zpool', MagicMock(return_value=pmap_zpool)):
+                        res = {}
+                        res['retcode'] = 0
+                        res['stderr'] = ''
+                        res['stdout'] = ''
+                        self.assertEqual(
+                            zfs.parse_command_result(res),
+                            OrderedDict(),
+                        )
+
+    def test_parse_command_result_fail(self):
+        '''
+        Test if parse_command_result returns the expected result on failure
+        '''
+        with patch.object(zfs, '_zfs_cmd', MagicMock(return_value='/sbin/zfs')):
+            with patch.object(zfs, '_zpool_cmd', MagicMock(return_value='/sbin/zpool')):
+                with patch.object(zfs, 'property_data_zfs', MagicMock(return_value=pmap_zfs)):
+                    with patch.object(zfs, 'property_data_zpool', MagicMock(return_value=pmap_zpool)):
+                        res = {}
+                        res['retcode'] = 1
+                        res['stderr'] = ''
+                        res['stdout'] = ''
+                        self.assertEqual(
+                            zfs.parse_command_result(res, 'tested'),
+                            OrderedDict([('tested', False)]),
+                        )
+
+    def test_parse_command_result_nolabel(self):
+        '''
+        Test if parse_command_result returns the expected result on failure
+        '''
+        with patch.object(zfs, '_zfs_cmd', MagicMock(return_value='/sbin/zfs')):
+            with patch.object(zfs, '_zpool_cmd', MagicMock(return_value='/sbin/zpool')):
+                with patch.object(zfs, 'property_data_zfs', MagicMock(return_value=pmap_zfs)):
+                    with patch.object(zfs, 'property_data_zpool', MagicMock(return_value=pmap_zpool)):
+                        res = {}
+                        res['retcode'] = 1
+                        res['stderr'] = ''
+                        res['stdout'] = ''
+                        self.assertEqual(
+                            zfs.parse_command_result(res),
+                            OrderedDict(),
+                        )
+
+    def test_parse_command_result_fail_message(self):
+        '''
+        Test if parse_command_result returns the expected result on failure with stderr
+        '''
+        with patch.object(zfs, '_zfs_cmd', MagicMock(return_value='/sbin/zfs')):
+            with patch.object(zfs, '_zpool_cmd', MagicMock(return_value='/sbin/zpool')):
+                with patch.object(zfs, 'property_data_zfs', MagicMock(return_value=pmap_zfs)):
+                    with patch.object(zfs, 'property_data_zpool', MagicMock(return_value=pmap_zpool)):
+                        res = {}
+                        res['retcode'] = 1
+                        res['stderr'] = "\n".join([
+                            'ice is not hot',
+                            'usage:',
+                            'this should not be printed',
+                        ])
+                        res['stdout'] = ''
+                        self.assertEqual(
+                            zfs.parse_command_result(res, 'tested'),
+                            OrderedDict([('tested', False), ('error', 'ice is not hot')]),
+                        )
+
+    def test_parse_command_result_fail_message_nolabel(self):
+        '''
+        Test if parse_command_result returns the expected result on failure with stderr
+        '''
+        with patch.object(zfs, '_zfs_cmd', MagicMock(return_value='/sbin/zfs')):
+            with patch.object(zfs, '_zpool_cmd', MagicMock(return_value='/sbin/zpool')):
+                with patch.object(zfs, 'property_data_zfs', MagicMock(return_value=pmap_zfs)):
+                    with patch.object(zfs, 'property_data_zpool', MagicMock(return_value=pmap_zpool)):
+                        res = {}
+                        res['retcode'] = 1
+                        res['stderr'] = "\n".join([
+                            'ice is not hot',
+                            'usage:',
+                            'this should not be printed',
+                        ])
+                        res['stdout'] = ''
+                        self.assertEqual(
+                            zfs.parse_command_result(res),
+                            OrderedDict([('error', 'ice is not hot')]),
+                        )
+
+# vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4

--- a/tests/unit/utils/test_zfs.py
+++ b/tests/unit/utils/test_zfs.py
@@ -2,6 +2,7 @@
 '''
 Tests for the zfs utils library
 
+:codeauthor:    Jorge Schrauwen <sjorge@blackdot.be>
 :maintainer:    Jorge Schrauwen <sjorge@blackdot.be>
 :maturity:      new
 :platform:      illumos,freebsd,linux


### PR DESCRIPTION
### What does this PR do?
This PR attempts to cleanup the code and reduce complexity for the zfs and zpool modules and states.

- [x] salt.utils.zfs
  - [x]  proper conversion from zfs 'values' to pythonic values
  - [x] command building with proper escaping and conversion for values
  - [x] common code like testing for feature flags, zfs support,...
- [x] salt.grains.zfs
  - [x] use __utils__['zfs.is_supported']
  - [x] use __utils__['zfs.has_feature_flags']
- [x] salt.modules.zpool
  - [x] switch to ```__utils__['zfs.zpool_command']```
  - [x] simply error handing (pass along what zpool complains about)
  - [x] refactor or clarify parsing code
  - [x] improve tests
- [x] salt.modules.zfs
  - [x] switch to ```__utils__['zfs.zfs_command']```
  - [x] simply error handing (pass along what zfs complains about)
  - [x] refactor or clarify parsing code
  - [x] improve tests
- [ ] salt.states.zpool
  - [ ] update to work with update salt.modules.zpool
- [ ] salt.states.zfs
  - [ ] update to work with update salt.modules.zfs

### What issues does this PR fix or reference?
#44801

### Previous Behavior
Lots of duplicate code

### New Behavior
Most duplicate code moved to a salt.utils.zfs, only do minimal error handling in modules (zfs/zpool command are pretty good at reporting what is wrong, so we just show that instead), more readable parsing code (hopefully).

### Tests written?
Yes

### Commits signed with GPG?
No
