### PR TITLE
Fix stacktrace at the end of a test

### DIFF
--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -1121,7 +1121,7 @@ class TestDaemon(object):
         for dirname in (TMP, RUNTIME_VARS.TMP_STATE_TREE,
                         RUNTIME_VARS.TMP_PILLAR_TREE, RUNTIME_VARS.TMP_PRODENV_STATE_TREE):
             if os.path.isdir(dirname):
-                shutil.rmtree(dirname, onerror=remove_readonly)
+                shutil.rmtree(six.text_type(dirname), onerror=remove_readonly)
 
     def wait_for_jid(self, targets, jid, timeout=120):
         time.sleep(1)  # Allow some time for minions to accept jobs


### PR DESCRIPTION
### What does this PR do?
Fixes an issue where there was a stacktrace at the end of a test run in Windows/Py2. It was failing when trying to remove a directory that had unicode characters. Using six.text_type on the path in the `shutil.rmtree` command seems to fix the problem.

The unicode character would be replaced with `?` which the `remove_readonly` function couldn't find. Here's the stack trace:
```
======================================================================
OK (total=1, skipped=0, passed=1, failures=0, errors=0)
=======================  Overall Tests Report  =======================
Traceback (most recent call last):
  File "runtests.py", line 846, in <module>
    main()
  File "runtests.py", line 839, in main
    parser.finalize(0)
  File "C:\\dev\\salt\tests\support\parser\cover.py", line 238, in finalize
    SaltTestingParser.finalize(self, exit_code)
  File "C:\\dev\\salt\tests\support\parser\__init__.py", line 655, in finalize
    self.post_execution_cleanup()
  File "runtests.py", line 546, in post_execution_cleanup
    TestDaemon.clean()
  File "C:\\dev\\salt\tests\integration\__init__.py", line 1124, in clean
    shutil.rmtree(dirname, onerror=remove_readonly)
  File "C:\Python27\lib\shutil.py", line 261, in rmtree
    rmtree(fullname, ignore_errors, onerror)
  File "C:\Python27\lib\shutil.py", line 261, in rmtree
    rmtree(fullname, ignore_errors, onerror)
  File "C:\Python27\lib\shutil.py", line 261, in rmtree
    rmtree(fullname, ignore_errors, onerror)
  File "C:\Python27\lib\shutil.py", line 261, in rmtree
    rmtree(fullname, ignore_errors, onerror)
  File "C:\Python27\lib\shutil.py", line 266, in rmtree
    onerror(os.remove, fullname, sys.exc_info())
  File "C:\\dev\\salt\tests\integration\__init__.py", line 1118, in remove_readonly
    os.chmod(path, stat.S_IRWXU)
WindowsError: [Error 123] The filename, directory name, or volume label syntax is incorrect: 'c:\\users\\admini~1\\appdata\\local\\temp\\2\\salt-tests-tmpdir\\gitfs_root\\.git\\refs\\heads\\test?'
```

### What issues does this PR fix or reference?
Found while fixing tests

### Tests written?
No

### Commits signed with GPG?
Yes