### PR TITLE
philips_hue: extend docs and fix status with id

### DIFF
--- a/salt/proxy/philips_hue.py
+++ b/salt/proxy/philips_hue.py
@@ -18,6 +18,19 @@
 Philips HUE lamps module for proxy.
 
 .. versionadded:: 2015.8.3
+
+First create a new user on the Hue bridge by following the
+`Meet hue <https://www.developers.meethue.com/documentation/getting-started>`_ instructions.
+
+To configure the proxy minion:
+
+.. code-block:: yaml
+
+    proxy:
+      proxytype: philips_hue
+      host: [hostname or ip]
+      user: [username]
+
 '''
 
 # pylint: disable=import-error,no-name-in-module,redefined-builtin
@@ -294,6 +307,7 @@ def call_status(*args, **kwargs):
     res = dict()
     devices = _get_lights()
     for dev_id in 'id' not in kwargs and sorted(devices.keys()) or _get_devices(kwargs):
+        dev_id = six.text_type(dev_id)
         res[dev_id] = {
             'on': devices[dev_id]['state']['on'],
             'reachable': devices[dev_id]['state']['reachable']


### PR DESCRIPTION
### What does this PR do?

Makes it a tad easier to get started with `philips_hue` by showing how to configure the proxy and how to obtain the `user` parameter.

While here, fix the `hue.status` function when providing an id to match the `id` kwarg with the fact the API returns a hash with device IDs as strings, not integers.

### Previous Behavior

```
[root@salt pillar]#  salt hue\* hue.status id=1
hueminion:
    The minion function caused an exception: Traceback (most recent call last):
      File "/usr/lib/python2.7/site-packages/salt/minion.py", line 1470, in _thread_return
        return_data = executor.execute()
      File "/usr/lib/python2.7/site-packages/salt/executors/direct_call.py", line 28, in execute
        return self.func(*self.args, **self.kwargs)
      File "/usr/lib/python2.7/site-packages/salt/modules/philips_hue.py", line 53, in _cmd
        return __proxy__[proxyfn](*args, **kw)
      File "/usr/lib/python2.7/site-packages/salt/proxy/philips_hue.py", line 299, in call_status
        'on': devices[dev_id]['state']['on'],
    KeyError: 1
```

### New Behavior

```
[root@salt pillar]#  salt hue\* hue.status id=1
hueminion:
    ----------
    1:
        ----------
        on:
            True
        reachable:
            False
```

### Tests written?

No

### Commits signed with GPG?

No