### PR TITLE
Fix traceback when exception instances are passed to our custom exceptions

### DIFF
--- a/salt/exceptions.py
+++ b/salt/exceptions.py
@@ -122,7 +122,19 @@ class CommandExecutionError(SaltException):
     def __init__(self, message='', info=None):
         # Avoid circular import
         import salt.utils.stringutils
-        self.error = exc_str_prefix = six.text_type(message)
+        try:
+            exc_str_prefix = salt.utils.stringutils.to_unicode(message)
+        except TypeError:
+            # Exception class instance passed. The SaltException __init__ will
+            # gracefully handle non-string types passed to it, but since this
+            # class needs to do some extra stuff with the exception "message"
+            # before handing it off to the parent class' __init__, we'll need
+            # to extract the message from the exception instance here
+            try:
+                exc_str_prefix = six.text_type(message)
+            except UnicodeDecodeError:
+                exc_str_prefix = salt.utils.stringutils.to_unicode(str(message))  # future lint: disable=blacklisted-function
+        self.error = exc_str_prefix
         self.info = info
         if self.info:
             if exc_str_prefix:
@@ -253,7 +265,18 @@ class SaltRenderError(SaltException):
         # Avoid circular import
         import salt.utils.stringutils
         self.error = message
-        exc_str = salt.utils.stringutils.to_unicode(message)
+        try:
+            exc_str = salt.utils.stringutils.to_unicode(message)
+        except TypeError:
+            # Exception class instance passed. The SaltException __init__ will
+            # gracefully handle non-string types passed to it, but since this
+            # class needs to do some extra stuff with the exception "message"
+            # before handing it off to the parent class' __init__, we'll need
+            # to extract the message from the exception instance here
+            try:
+                exc_str = six.text_type(message)
+            except UnicodeDecodeError:
+                exc_str = salt.utils.stringutils.to_unicode(str(message))  # future lint: disable=blacklisted-function
         self.line_num = line_num
         self.buffer = buf
         self.context = ''
@@ -373,7 +396,7 @@ class SaltCloudSystemExit(SaltCloudException):
     This exception is raised when the execution should be stopped.
     '''
     def __init__(self, message, exit_code=salt.defaults.exitcodes.EX_GENERIC):
-        SaltCloudException.__init__(self, message)
+        super(SaltCloudSystemExit, self).__init__(message)
         self.message = message
         self.exit_code = exit_code
 


### PR DESCRIPTION
This fixes a traceback in `unit.serializers.test_serializers.TestSerializers.test_serialize_yaml`:


```
Traceback (most recent call last):
  File "/testing/tests/unit/serializers/test_serializers.py", line 60, in test_serialize_yaml
    deserialized = yaml.deserialize(serialized)
  File "/testing/salt/serializers/yaml.py", line 57, in deserialize
    raise DeserializationError(error)
  File "/testing/salt/exceptions.py", line 256, in __init__
    exc_str = salt.utils.stringutils.to_unicode(message)
  File "/testing/salt/utils/stringutils.py", line 110, in to_unicode
    raise TypeError('expected str or bytearray')
TypeError: expected str or bytearray
```