### PR TITLE
Improve/remove PATH environment modifications

### DIFF
--- a/salt/modules/rbenv.py
+++ b/salt/modules/rbenv.py
@@ -19,6 +19,7 @@ import logging
 # Import Salt libs
 import salt.utils.args
 import salt.utils.data
+import salt.utils.path
 import salt.utils.platform
 from salt.exceptions import SaltInvocationError
 
@@ -380,11 +381,14 @@ def do(cmdline, runas=None, env=None):
     if not env:
         env = {}
 
+    # NOTE: Env vars (and their values) need to be str type on both Python 2
+    # and 3. The code below first normalizes all path components to unicode to
+    # stitch them together, and then converts the result back to a str type.
     env[str('PATH')] = salt.utils.stringutils.to_str(   # future lint: disable=blacklisted-function
-        '{0}/shims:{1}'.format(
-            path,
+        os.pathsep.join((
+            salt.utils.path.join(path, 'shims'),
             salt.utils.stringutils.to_unicode(os.environ['PATH'])
-        )
+        ))
     )
 
     try:

--- a/salt/modules/rbenv.py
+++ b/salt/modules/rbenv.py
@@ -380,7 +380,12 @@ def do(cmdline, runas=None, env=None):
     if not env:
         env = {}
 
-    env['PATH'] = '{0}/shims:{1}'.format(path, os.environ['PATH'])
+    env[str('PATH')] = salt.utils.stringutils.to_str(   # future lint: disable=blacklisted-function
+        '{0}/shims:{1}'.format(
+            path,
+            salt.utils.stringutils.to_unicode(os.environ['PATH'])
+        )
+    )
 
     try:
         cmdline = salt.utils.args.shlex_split(cmdline)

--- a/salt/modules/syslog_ng.py
+++ b/salt/modules/syslog_ng.py
@@ -796,6 +796,9 @@ def _run_command_in_extended_path(syslog_ng_sbin_dir, command, params):
             log.error('syslog_ng_sbin_dir path %s is not a directory',
                       syslog_ng_sbin_dir)
         else:
+            # Custom environment variables should be str types. This code
+            # normalizes the paths to unicode to join them together, and then
+            # converts back to a str type.
             env = {
                 str('PATH'): salt.utils.stringutils.to_str(  # future lint: disable=blacklisted-function
                     os.pathsep.join(

--- a/salt/modules/syslog_ng.py
+++ b/salt/modules/syslog_ng.py
@@ -735,14 +735,14 @@ def get_config_file():
     return __SYSLOG_NG_CONFIG_FILE
 
 
-def _run_command(cmd, options=()):
+def _run_command(cmd, options=(), env=None):
     '''
     Runs the command cmd with options as its CLI parameters and returns the
     result as a dictionary.
     '''
     params = [cmd]
     params.extend(options)
-    return __salt__['cmd.run_all'](params, python_shell=False)
+    return __salt__['cmd.run_all'](params, env=env, python_shell=False)
 
 
 def _determine_config_version(syslog_ng_sbin_dir):
@@ -785,49 +785,27 @@ def set_parameters(version=None,
     return _format_return_data(0)
 
 
-def _add_to_path_envvar(directory):
-    '''
-    Adds directory to the PATH environment variable and returns the original
-    one.
-    '''
-    orig_path = os.environ.get('PATH', '')
-    if directory:
-        if not os.path.isdir(directory):
-            log.error('The given parameter is not a directory')
-
-        os.environ['PATH'] = '{0}{1}{2}'.format(orig_path,
-                                                os.pathsep,
-                                                directory)
-    return orig_path
-
-
-def _restore_path_envvar(original):
-    '''
-    Sets the PATH environment variable to the parameter.
-    '''
-    if original:
-        os.environ['PATH'] = original
-
-
 def _run_command_in_extended_path(syslog_ng_sbin_dir, command, params):
     '''
-    Runs the given command in an environment, where the syslog_ng_sbin_dir is
-    added then removed from the PATH.
+    Runs the specified command with the syslog_ng_sbin_dir in the PATH
     '''
-    orig_path = _add_to_path_envvar(syslog_ng_sbin_dir)
-
-    if not salt.utils.path.which(command):
-        error_message = (
-            'Unable to execute the command \'{0}\'. It is not in the PATH.'
-            .format(command)
-        )
-        log.error(error_message)
-        _restore_path_envvar(orig_path)
-        raise CommandExecutionError(error_message)
-
-    ret = _run_command(command, options=params)
-    _restore_path_envvar(orig_path)
-    return ret
+    orig_path = os.environ.get('PATH', '')
+    env = None
+    if syslog_ng_sbin_dir:
+        if not os.path.isdir(syslog_ng_sbin_dir):
+            log.error('syslog_ng_sbin_dir path %s is not a directory',
+                      syslog_ng_sbin_dir)
+        else:
+            env = {
+                str('PATH'): salt.utils.stringutils.to_str(  # future lint: disable=blacklisted-function
+                    os.pathsep.join(
+                        salt.utils.data.decode(
+                            (orig_path, syslog_ng_sbin_dir)
+                        )
+                    )
+                )
+            }
+    return _run_command(command, options=params, env=env)
 
 
 def _format_return_data(retcode, stdout=None, stderr=None):

--- a/salt/modules/syslog_ng.py
+++ b/salt/modules/syslog_ng.py
@@ -792,22 +792,18 @@ def _run_command_in_extended_path(syslog_ng_sbin_dir, command, params):
     orig_path = os.environ.get('PATH', '')
     env = None
     if syslog_ng_sbin_dir:
-        if not os.path.isdir(syslog_ng_sbin_dir):
-            log.error('syslog_ng_sbin_dir path %s is not a directory',
-                      syslog_ng_sbin_dir)
-        else:
-            # Custom environment variables should be str types. This code
-            # normalizes the paths to unicode to join them together, and then
-            # converts back to a str type.
-            env = {
-                str('PATH'): salt.utils.stringutils.to_str(  # future lint: disable=blacklisted-function
-                    os.pathsep.join(
-                        salt.utils.data.decode(
-                            (orig_path, syslog_ng_sbin_dir)
-                        )
+        # Custom environment variables should be str types. This code
+        # normalizes the paths to unicode to join them together, and then
+        # converts back to a str type.
+        env = {
+            str('PATH'): salt.utils.stringutils.to_str(  # future lint: disable=blacklisted-function
+                os.pathsep.join(
+                    salt.utils.data.decode(
+                        (orig_path, syslog_ng_sbin_dir)
                     )
                 )
-            }
+            )
+        }
     return _run_command(command, options=params, env=env)
 
 

--- a/salt/modules/win_path.py
+++ b/salt/modules/win_path.py
@@ -14,6 +14,7 @@ import os
 import re
 
 # Import Salt libs
+import salt.utils.args
 import salt.utils.data
 import salt.utils.platform
 import salt.utils.stringutils
@@ -30,6 +31,12 @@ except ImportError:
 # Settings
 log = logging.getLogger(__name__)
 
+HIVE = 'HKEY_LOCAL_MACHINE'
+KEY = 'SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Environment'
+VNAME = 'PATH'
+VTYPE = 'REG_EXPAND_SZ'
+PATHSEP = str(os.pathsep)  # future lint: disable=blacklisted-function
+
 
 def __virtual__():
     '''
@@ -44,12 +51,13 @@ def _normalize_dir(string_):
     '''
     Normalize the directory to make comparison possible
     '''
-    return re.sub(r'\\$', '', string_.lower())
+    return re.sub(r'\\$', '', salt.utils.stringutils.to_unicode(string_))
 
 
 def rehash():
     '''
-    Send a WM_SETTINGCHANGE Broadcast to Windows to refresh the Environment variables
+    Send a WM_SETTINGCHANGE Broadcast to Windows to refresh the Environment
+    variables
 
     CLI Example:
 
@@ -100,17 +108,30 @@ def exists(path):
     path = _normalize_dir(path)
     sysPath = get_path()
 
-    return path in sysPath
+    return path.lower() in (x.lower() for x in sysPath)
 
 
-def add(path, index=0):
+def _update_local_path(local_path):
+    os.environ[str('PATH')] = PATHSEP.join(local_path)  # future lint: disable=blacklisted-function
+
+
+def add(path, index=None, **kwargs):
     '''
-    Add the directory to the SYSTEM path in the index location
+    Add the directory to the SYSTEM path in the index location. Returns
+    ``True`` if successful, otherwise ``False``.
 
-    Returns:
-        boolean True if successful, False if unsuccessful
+    path
+        Directory to add to path
 
-    CLI Example:
+    index
+        Optionally specify an index at which to insert the directory
+
+    rehash : True
+        If the registry was updated, and this value is set to ``True``, sends a
+        WM_SETTINGCHANGE broadcast to refresh the environment variables. Set
+        this to ``False`` to skip this broadcast.
+
+    CLI Examples:
 
     .. code-block:: bash
 
@@ -120,61 +141,156 @@ def add(path, index=0):
         # Will add to the end of the path
         salt '*' win_path.add 'c:\\python27' index='-1'
     '''
-    path = salt.utils.stringutils.to_str(_normalize_dir(path))
-    currIndex = -1
-    sysPath = get_path()
-    index = int(index)
+    kwargs = salt.utils.args.clean_kwargs(**kwargs)
+    rehash_ = kwargs.pop('rehash', True)
+    if kwargs:
+        salt.utils.args.invalid_kwargs(kwargs)
 
-    # validate index boundaries
-    if index < 0:
-        index = len(sysPath) + index + 1
-    if index > len(sysPath):
-        index = len(sysPath)
+    path = _normalize_dir(path)
+    path_str = salt.utils.stringutils.to_str(path)
+    system_path = get_path()
 
-    pathsep = str(os.pathsep)  # future lint: disable=blacklisted-function
     # The current path should not have any unicode in it, but don't take any
     # chances.
-    localPath = [
+    local_path = [
         salt.utils.stringutils.to_str(x)
-        for x in os.environ['PATH'].split(pathsep)
+        for x in os.environ['PATH'].split(PATHSEP)
     ]
-    if path not in localPath:
-        localPath.append(path)
-        os.environ[str('PATH')] = pathsep.join(localPath)  # future lint: disable=blacklisted-function
 
-    # Check if we are in the system path at the right location
-    try:
-        currIndex = sysPath.index(path)
-        if currIndex != index:
-            sysPath.pop(currIndex)
+    if index is not None:
+        try:
+            index = int(index)
+        except (TypeError, ValueError):
+            index = None
+
+    def _check_path(dirs, path, index):
+        '''
+        Check the dir list for the specified path, at the specified index, and
+        make changes to the list if needed. Return True if changes were made to
+        the list, otherwise return False.
+        '''
+        dirs_lc = [x.lower() for x in dirs]
+        try:
+            # Check index with case normalized
+            cur_index = dirs_lc.index(path.lower())
+        except ValueError:
+            cur_index = None
+
+        num_dirs = len(dirs)
+
+        # if pos is None, we don't care about where the directory is in the
+        # PATH. If it is a number, then that number is the index to be used for
+        # insertion (this number will be different from the index if the index
+        # is less than -1, for reasons explained in the comments below). If it
+        # is the string 'END', then the directory must be at the end of the
+        # PATH, so it should be removed before appending if it is anywhere but
+        # the end.
+        pos = index
+        if index is not None:
+            if index >= num_dirs or index == -1:
+                # Set pos to 'END' so we know that we're moving the directory
+                # if it exists and isn't already at the end.
+                pos = 'END'
+            elif index <= -num_dirs:
+                # Negative index is too large, shift index to beginning of list
+                index = pos = 0
+            elif index <= 0:
+                # Negative indexes (other than -1 which is handled above) must
+                # be inserted at index + 1 for the item  to end up in the
+                # position you want, since list.insert() inserts before the
+                # index passed to it. For example:
+                #
+                # >>> x = ['one', 'two', 'four', 'five']
+                # >>> x.insert(-3, 'three')
+                # >>> x
+                # ['one', 'three', 'two', 'four', 'five']
+                # >>> x = ['one', 'two', 'four', 'five']
+                # >>> x.insert(-2, 'three')
+                # >>> x
+                # ['one', 'two', 'three', 'four', 'five']
+                pos += 1
+
+        if pos == 'END':
+            if cur_index is not None:
+                if cur_index == num_dirs - 1:
+                    # Directory is already in the desired location, no changes
+                    # need to be made.
+                    return False
+                else:
+                    # Remove from current location and add it to the end
+                    dirs.pop(cur_index)
+                    dirs.append(path)
+                    return True
+            else:
+                # Doesn't exist in list, add it to the end
+                dirs.append(path)
+                return True
+        elif index is None:
+            # If index is None, that means that if the path is not already in
+            # list, we will be appending it to the end instead of inserting it
+            # somewhere in the middle.
+            if cur_index is not None:
+                # Directory is already in the PATH, no changes need to be made.
+                return False
+            else:
+                # Directory not in the PATH, and we're not enforcing the index.
+                # Append it to the list.
+                dirs.append(path)
+                return True
         else:
-            return True
-    except ValueError:
-        pass
-
-    # Add it to the Path
-    sysPath.insert(index, path)
-    regedit = __salt__['reg.set_value'](
-        'HKEY_LOCAL_MACHINE',
-        'SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Environment',
-        'PATH',
-        ';'.join(salt.utils.data.decode(sysPath)),
-        'REG_EXPAND_SZ'
-    )
-
-    # Broadcast WM_SETTINGCHANGE to Windows
-    if regedit:
-        return rehash()
-    else:
+            if cur_index is not None:
+                if (index < 0 and cur_index != (num_dirs + index)) \
+                        or (index >= 0 and cur_index != index):
+                    # Directory is present, but not at the desired index.
+                    # Remove it from the non-normalized path list and insert it
+                    # at the correct postition.
+                    dirs.pop(cur_index)
+                    dirs.insert(pos, path)
+                    return True
+                else:
+                    # Directory is present and its position matches the desired
+                    # index. No changes need to be made.
+                    return False
+            else:
+                # Insert the path at the desired index.
+                dirs.insert(pos, path)
+                return True
         return False
 
+    if _check_path(local_path, path_str, index):
+        _update_local_path(local_path)
 
-def remove(path):
+    if not _check_path(system_path, path, index):
+        # No changes necessary
+        return True
+
+    # Move forward with registry update
+    result = __salt__['reg.set_value'](
+        HIVE,
+        KEY,
+        VNAME,
+        ';'.join(salt.utils.data.decode(system_path)),
+        VTYPE
+    )
+
+    if result and rehash_:
+        # Broadcast WM_SETTINGCHANGE to Windows if registry was updated
+        return rehash()
+    else:
+        return result
+
+
+def remove(path, **kwargs):
     r'''
     Remove the directory from the SYSTEM path
 
     Returns:
         boolean True if successful, False if unsuccessful
+
+    rehash : True
+        If the registry was updated, and this value is set to ``True``, sends a
+        WM_SETTINGCHANGE broadcast to refresh the environment variables. Set
+        this to ``False`` to skip this broadcast.
 
     CLI Example:
 
@@ -183,33 +299,58 @@ def remove(path):
         # Will remove C:\Python27 from the path
         salt '*' win_path.remove 'c:\\python27'
     '''
-    path = salt.utils.stringutils.to_str(_normalize_dir(path))
-    sysPath = get_path()
+    kwargs = salt.utils.args.clean_kwargs(**kwargs)
+    rehash_ = kwargs.pop('rehash', True)
+    if kwargs:
+        salt.utils.args.invalid_kwargs(kwargs)
 
-    pathsep = str(os.pathsep)  # future lint: disable=blacklisted-function
+    path = _normalize_dir(path)
+    path_str = salt.utils.stringutils.to_str(path)
+    system_path = get_path()
+
     # The current path should not have any unicode in it, but don't take any
     # chances.
-    localPath = [
+    local_path = [
         salt.utils.stringutils.to_str(x)
-        for x in os.environ['PATH'].split(pathsep)
+        for x in os.environ['PATH'].split(PATHSEP)
     ]
-    if path in localPath:
-        localPath.remove(path)
-        os.environ[str('PATH')] = pathsep.join(localPath)  # future lint: disable=blacklisted-function
 
-    try:
-        sysPath.remove(path)
-    except ValueError:
+    def _check_path(dirs, path):
+        '''
+        Check the dir list for the specified path, and make changes to the list
+        if needed. Return True if changes were made to the list, otherwise
+        return False.
+        '''
+        dirs_lc = [x.lower() for x in dirs]
+        path_lc = path.lower()
+        new_dirs = []
+        for index, dirname in enumerate(dirs_lc):
+            if path_lc != dirname:
+                new_dirs.append(dirs[index])
+
+        if len(new_dirs) != len(dirs):
+            dirs[:] = new_dirs[:]
+            return True
+        else:
+            return False
+
+    if _check_path(local_path, path_str):
+        _update_local_path(local_path)
+
+    if not _check_path(system_path, path):
+        # No changes necessary
         return True
 
-    regedit = __salt__['reg.set_value'](
-        'HKEY_LOCAL_MACHINE',
-        'SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Environment',
-        'PATH',
-        ';'.join(salt.utils.data.decode(sysPath)),
-        'REG_EXPAND_SZ'
+    result = __salt__['reg.set_value'](
+        HIVE,
+        KEY,
+        VNAME,
+        ';'.join(salt.utils.data.decode(system_path)),
+        VTYPE
     )
-    if regedit:
+
+    if result and rehash_:
+        # Broadcast WM_SETTINGCHANGE to Windows if registry was updated
         return rehash()
     else:
-        return False
+        return result

--- a/salt/modules/win_path.py
+++ b/salt/modules/win_path.py
@@ -14,6 +14,7 @@ import os
 import re
 
 # Import Salt libs
+import salt.utils.data
 import salt.utils.platform
 import salt.utils.stringutils
 
@@ -157,7 +158,7 @@ def add(path, index=0):
         'HKEY_LOCAL_MACHINE',
         'SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Environment',
         'PATH',
-        str(';').join(sysPath),  # future lint: disable=blacklisted-function
+        ';'.join(salt.utils.data.decode(sysPath)),
         'REG_EXPAND_SZ'
     )
 
@@ -205,7 +206,7 @@ def remove(path):
         'HKEY_LOCAL_MACHINE',
         'SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Environment',
         'PATH',
-        str(';').join(sysPath),  # future lint: disable=blacklisted-function
+        ';'.join(salt.utils.data.decode(sysPath)),
         'REG_EXPAND_SZ'
     )
     if regedit:

--- a/salt/utils/path.py
+++ b/salt/utils/path.py
@@ -14,7 +14,6 @@ import posixpath
 import re
 import string
 import struct
-import sys
 
 # Import Salt libs
 import salt.utils.args
@@ -202,7 +201,9 @@ def which(exe=None):
             # executable in cwd or fullpath
             return exe
 
-        ext_list = os.environ.get('PATHEXT', '.EXE').split(';')
+        ext_list = salt.utils.stringutils.to_str(
+            os.environ.get('PATHEXT', str('.EXE'))
+        ).split(str(';'))
 
         @real_memoize
         def _exe_has_ext():
@@ -212,8 +213,13 @@ def which(exe=None):
             '''
             for ext in ext_list:
                 try:
-                    pattern = r'.*\.' + ext.lstrip('.') + r'$'
-                    re.match(pattern, exe, re.I).groups()
+                    pattern = r'.*\.{0}$'.format(
+                        salt.utils.stringutils.to_unicode(ext).lstrip('.')
+                    )
+                    re.match(
+                        pattern,
+                        salt.utils.stringutils.to_unicode(exe),
+                        re.I).groups()
                     return True
                 except AttributeError:
                     continue
@@ -221,13 +227,17 @@ def which(exe=None):
 
         # Enhance POSIX path for the reliability at some environments, when $PATH is changing
         # This also keeps order, where 'first came, first win' for cases to find optional alternatives
-        search_path = os.environ.get('PATH') and os.environ['PATH'].split(os.pathsep) or list()
-        for default_path in ['/bin', '/sbin', '/usr/bin', '/usr/sbin', '/usr/local/bin']:
-            if default_path not in search_path:
-                search_path.append(default_path)
-        os.environ['PATH'] = os.pathsep.join(search_path)
+        system_path = salt.utils.stringutils.to_unicode(os.environ.get('PATH', ''))
+        search_path = system_path.split(os.pathsep)
+        if not salt.utils.platform.is_windows():
+            search_path.extend([
+                x for x in ('/bin', '/sbin', '/usr/bin',
+                            '/usr/sbin', '/usr/local/bin')
+                if x not in search_path
+            ])
+
         for path in search_path:
-            full_path = os.path.join(path, exe)
+            full_path = join(path, exe)
             if _is_executable_file_or_link(full_path):
                 return full_path
             elif salt.utils.platform.is_windows() and not _exe_has_ext():
@@ -296,27 +306,12 @@ def join(*parts, **kwargs):
         # No args passed to func
         return ''
 
+    root = salt.utils.stringutils.to_unicode(root)
     if not parts:
         ret = root
     else:
         stripped = [p.lstrip(os.sep) for p in parts]
-        try:
-            ret = pathlib.join(root, *stripped)
-        except UnicodeDecodeError:
-            # This is probably Python 2 and one of the parts contains unicode
-            # characters in a bytestring. First try to decode to the system
-            # encoding.
-            try:
-                enc = __salt_system_encoding__
-            except NameError:
-                enc = sys.stdin.encoding or sys.getdefaultencoding()
-            try:
-                ret = pathlib.join(root.decode(enc),
-                                   *[x.decode(enc) for x in stripped])
-            except UnicodeDecodeError:
-                # Last resort, try UTF-8
-                ret = pathlib.join(root.decode('UTF-8'),
-                                   *[x.decode('UTF-8') for x in stripped])
+        ret = pathlib.join(root, *salt.utils.data.decode(stripped))
     return pathlib.normpath(ret)
 
 

--- a/tests/unit/modules/test_syslog_ng.py
+++ b/tests/unit/modules/test_syslog_ng.py
@@ -5,6 +5,7 @@ Test module for syslog_ng
 
 # Import Python modules
 from __future__ import absolute_import, unicode_literals, print_function
+import os
 from textwrap import dedent
 
 # Import Salt Testing libs
@@ -13,7 +14,6 @@ from tests.support.unit import skipIf, TestCase
 from tests.support.mock import NO_MOCK, NO_MOCK_REASON, MagicMock, patch
 
 # Import Salt libs
-import salt.utils.path
 import salt.modules.syslog_ng as syslog_ng
 
 _VERSION = "3.6.0alpha0"
@@ -57,6 +57,12 @@ _SYSLOG_NG_CTL_NOT_INSTALLED_RETURN_VALUE = {
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
 class SyslogNGTestCase(TestCase, LoaderModuleMockMixin):
+
+    # pylint: disable=blacklisted-function
+    orig_env = {str('PATH'): str('/foo:/bar')}
+    bin_dir = str('/baz')
+    mocked_env = {str('PATH'): str('/foo:/bar:/baz')}
+    # pylint: enable=blacklisted-function
 
     def setup_loader_modules(self):
         return {syslog_ng: {}}
@@ -199,83 +205,139 @@ class SyslogNGTestCase(TestCase, LoaderModuleMockMixin):
             '''), b)
 
     def test_version(self):
-        mock_return_value = {"retcode": 0, 'stdout': VERSION_OUTPUT}
-        expected_output = {"retcode": 0, "stdout": "3.6.0alpha0"}
-        mock_args = "syslog-ng -V"
-        self._assert_template(mock_args,
-                              mock_return_value,
-                              function_to_call=syslog_ng.version,
-                              expected_output=expected_output)
+        cmd_ret = {'retcode': 0, 'stdout': VERSION_OUTPUT}
+        expected_output = {'retcode': 0, 'stdout': _VERSION}
+        cmd_args = ['syslog-ng', '-V']
+
+        cmd_mock = MagicMock(return_value=cmd_ret)
+        with patch.dict(syslog_ng.__salt__, {'cmd.run_all': cmd_mock}), \
+                patch.dict(os.environ, self.orig_env):
+            result = syslog_ng.version()
+            self.assertEqual(result, expected_output)
+            cmd_mock.assert_called_once_with(
+                cmd_args,
+                env=None,
+                python_shell=False
+            )
+
+        cmd_mock = MagicMock(return_value=cmd_ret)
+        with patch.dict(syslog_ng.__salt__, {'cmd.run_all': cmd_mock}), \
+                patch.dict(os.environ, self.orig_env):
+            result = syslog_ng.version(syslog_ng_sbin_dir=self.bin_dir)
+            self.assertEqual(result, expected_output)
+            cmd_mock.assert_called_once_with(
+                cmd_args,
+                env=self.mocked_env,
+                python_shell=False
+            )
 
     def test_stats(self):
-        mock_return_value = {"retcode": 0, 'stdout': STATS_OUTPUT}
-        expected_output = {"retcode": 0, "stdout": STATS_OUTPUT}
-        mock_args = "syslog-ng-ctl stats"
-        self._assert_template(mock_args,
-                              mock_return_value,
-                              function_to_call=syslog_ng.stats,
-                              expected_output=expected_output)
+        cmd_ret = {'retcode': 0, 'stdout': STATS_OUTPUT}
+        cmd_args = ['syslog-ng-ctl', 'stats']
+
+        cmd_mock = MagicMock(return_value=cmd_ret)
+        with patch.dict(syslog_ng.__salt__, {'cmd.run_all': cmd_mock}), \
+                patch.dict(os.environ, self.orig_env):
+            result = syslog_ng.stats()
+            self.assertEqual(result, cmd_ret)
+            cmd_mock.assert_called_once_with(
+                cmd_args,
+                env=None,
+                python_shell=False
+            )
+
+        cmd_mock = MagicMock(return_value=cmd_ret)
+        with patch.dict(syslog_ng.__salt__, {'cmd.run_all': cmd_mock}), \
+                patch.dict(os.environ, self.orig_env):
+            result = syslog_ng.stats(syslog_ng_sbin_dir=self.bin_dir)
+            self.assertEqual(result, cmd_ret)
+            cmd_mock.assert_called_once_with(
+                cmd_args,
+                env=self.mocked_env,
+                python_shell=False
+            )
 
     def test_modules(self):
-        mock_return_value = {"retcode": 0, 'stdout': VERSION_OUTPUT}
-        expected_output = {"retcode": 0, "stdout": _MODULES}
-        mock_args = "syslog-ng -V"
-        self._assert_template(mock_args,
-                              mock_return_value,
-                              function_to_call=syslog_ng.modules,
-                              expected_output=expected_output)
+        cmd_ret = {'retcode': 0, 'stdout': VERSION_OUTPUT}
+        expected_output = {'retcode': 0, 'stdout': _MODULES}
+        cmd_args = ['syslog-ng', '-V']
 
-    def test_config_test_ok(self):
-        mock_return_value = {"retcode": 0, "stderr": "", "stdout": "Syslog-ng startup text..."}
-        mock_args = "syslog-ng --syntax-only"
-        self._assert_template(mock_args,
-                              mock_return_value,
-                              function_to_call=syslog_ng.config_test,
-                              expected_output=mock_return_value)
+        cmd_mock = MagicMock(return_value=cmd_ret)
+        with patch.dict(syslog_ng.__salt__, {'cmd.run_all': cmd_mock}), \
+                patch.dict(os.environ, self.orig_env):
+            result = syslog_ng.modules()
+            self.assertEqual(result, expected_output)
+            cmd_mock.assert_called_once_with(
+                cmd_args,
+                env=None,
+                python_shell=False
+            )
 
-    def test_config_test_fails(self):
-        mock_return_value = {"retcode": 1, 'stderr': "Syntax error...", "stdout": ""}
-        mock_args = "syslog-ng --syntax-only"
-        self._assert_template(mock_args,
-                              mock_return_value,
-                              function_to_call=syslog_ng.config_test,
-                              expected_output=mock_return_value)
+        cmd_mock = MagicMock(return_value=cmd_ret)
+        with patch.dict(syslog_ng.__salt__, {'cmd.run_all': cmd_mock}), \
+                patch.dict(os.environ, self.orig_env):
+            result = syslog_ng.modules(syslog_ng_sbin_dir=self.bin_dir)
+            self.assertEqual(result, expected_output)
+            cmd_mock.assert_called_once_with(
+                cmd_args,
+                env=self.mocked_env,
+                python_shell=False
+            )
+
+    def test_config_test(self):
+        cmd_ret = {'retcode': 0, 'stderr': '', 'stdout': 'Foo'}
+        cmd_args = ['syslog-ng', '--syntax-only']
+
+        cmd_mock = MagicMock(return_value=cmd_ret)
+        with patch.dict(syslog_ng.__salt__, {'cmd.run_all': cmd_mock}), \
+                patch.dict(os.environ, self.orig_env):
+            result = syslog_ng.config_test()
+            self.assertEqual(result, cmd_ret)
+            cmd_mock.assert_called_once_with(
+                cmd_args,
+                env=None,
+                python_shell=False
+            )
+
+        cmd_mock = MagicMock(return_value=cmd_ret)
+        with patch.dict(syslog_ng.__salt__, {'cmd.run_all': cmd_mock}), \
+                patch.dict(os.environ, self.orig_env):
+            result = syslog_ng.config_test(syslog_ng_sbin_dir=self.bin_dir)
+            self.assertEqual(result, cmd_ret)
+            cmd_mock.assert_called_once_with(
+                cmd_args,
+                env=self.mocked_env,
+                python_shell=False
+            )
 
     def test_config_test_cfgfile(self):
-        cfgfile = "/path/to/syslog-ng.conf"
-        mock_return_value = {"retcode": 1, 'stderr': "Syntax error...", "stdout": ""}
-        mock_args = "syslog-ng --syntax-only --cfgfile={0}".format(cfgfile)
-        self._assert_template(mock_args,
-                              mock_return_value,
-                              function_to_call=syslog_ng.config_test,
-                              function_args={"cfgfile": cfgfile},
-                              expected_output=mock_return_value)
+        cfgfile = '/path/to/syslog-ng.conf'
+        cmd_ret = {'retcode': 1, 'stderr': 'Syntax error...', 'stdout': ''}
+        cmd_args = ['syslog-ng', '--syntax-only',
+                    '--cfgfile={0}'.format(cfgfile)]
 
-    def _assert_template(self,
-                         mock_function_args,
-                         mock_return_value,
-                         function_to_call,
-                         expected_output,
-                         function_args=None):
-        if function_args is None:
-            function_args = {}
+        cmd_mock = MagicMock(return_value=cmd_ret)
+        with patch.dict(syslog_ng.__salt__, {'cmd.run_all': cmd_mock}), \
+                patch.dict(os.environ, self.orig_env):
+            self.assertEqual(syslog_ng.config_test(cfgfile=cfgfile), cmd_ret)
+            cmd_mock.assert_called_once_with(
+                cmd_args,
+                env=None,
+                python_shell=False
+            )
 
-        installed = True
-        if not salt.utils.path.which("syslog-ng"):
-            installed = False
-            if "syslog-ng-ctl" in mock_function_args:
-                expected_output = _SYSLOG_NG_CTL_NOT_INSTALLED_RETURN_VALUE
-            else:
-                expected_output = _SYSLOG_NG_NOT_INSTALLED_RETURN_VALUE
-
-        mock_function = MagicMock(return_value=mock_return_value)
-
-        with patch.dict(syslog_ng.__salt__, {'cmd.run_all': mock_function}):
-            got = function_to_call(**function_args)
-            self.assertEqual(expected_output, got)
-
-            if installed:
-                self.assertTrue(mock_function.called)
-                self.assertEqual(len(mock_function.call_args), 2)
-                mock_param = mock_function.call_args
-                self.assertEqual(mock_param[0][0], mock_function_args.split())
+        cmd_mock = MagicMock(return_value=cmd_ret)
+        with patch.dict(syslog_ng.__salt__, {'cmd.run_all': cmd_mock}), \
+                patch.dict(os.environ, self.orig_env):
+            self.assertEqual(
+                syslog_ng.config_test(
+                    syslog_ng_sbin_dir=self.bin_dir,
+                    cfgfile=cfgfile
+                ),
+                cmd_ret
+            )
+            cmd_mock.assert_called_once_with(
+                cmd_args,
+                env=self.mocked_env,
+                python_shell=False
+            )

--- a/tests/unit/modules/test_win_path.py
+++ b/tests/unit/modules/test_win_path.py
@@ -5,6 +5,7 @@
 
 # Import Python Libs
 from __future__ import absolute_import, unicode_literals, print_function
+import os
 
 # Import Salt Testing Libs
 from tests.support.mixins import LoaderModuleMockMixin
@@ -18,6 +19,7 @@ from tests.support.mock import (
 
 # Import Salt Libs
 import salt.modules.win_path as win_path
+import salt.utils.stringutils
 
 
 class MockWin32API(object):
@@ -58,54 +60,223 @@ class WinPathTestCase(TestCase, LoaderModuleMockMixin):
                            'HWND_BROADCAST': MagicMock,
                            'WM_SETTINGCHANGE': MagicMock}}
 
+    def __init__(self, *args, **kwargs):
+        super(WinPathTestCase, self).__init__(*args, **kwargs)
+        self.pathsep = str(';')  # future lint: disable=blacklisted-function
+
+    def assert_call_matches(self, mock_obj, new_path):
+        mock_obj.assert_called_once_with(
+            win_path.HIVE,
+            win_path.KEY,
+            win_path.VNAME,
+            self.pathsep.join(new_path),
+            win_path.VTYPE
+        )
+
+    def assert_path_matches(self, env, new_path):
+        self.assertEqual(
+            env['PATH'],
+            salt.utils.stringutils.to_str(self.pathsep.join(new_path))
+        )
+
     def test_rehash(self):
         '''
-            Test to rehash the Environment variables
+        Test to rehash the Environment variables
         '''
         self.assertTrue(win_path.rehash())
 
     def test_get_path(self):
         '''
-            Test to Returns the system path
+        Test to Returns the system path
         '''
-        mock = MagicMock(return_value={'vdata': 'c:\\salt'})
+        mock = MagicMock(return_value={'vdata': 'C:\\Salt'})
         with patch.dict(win_path.__salt__, {'reg.read_value': mock}):
-            self.assertListEqual(win_path.get_path(), ['c:\\salt'])
+            self.assertListEqual(win_path.get_path(), ['C:\\Salt'])
 
     def test_exists(self):
         '''
-            Test to check if the directory is configured
+        Test to check if the directory is configured
         '''
-        mock = MagicMock(return_value='c:\\salt')
-        with patch.object(win_path, 'get_path', mock):
-            self.assertTrue(win_path.exists("c:\\salt"))
+        get_mock = MagicMock(return_value=['C:\\Foo', 'C:\\Bar'])
+        with patch.object(win_path, 'get_path', get_mock):
+            # Ensure case insensitivity respected
+            self.assertTrue(win_path.exists('C:\\FOO'))
+            self.assertTrue(win_path.exists('c:\\foo'))
+            self.assertFalse(win_path.exists('c:\\mystuff'))
 
     def test_add(self):
         '''
-            Test to add the directory to the SYSTEM path
+        Test to add the directory to the SYSTEM path
         '''
-        mock_get = MagicMock(return_value=['c:\\salt'])
-        with patch.object(win_path, 'get_path', mock_get):
-            mock_set = MagicMock(return_value=True)
-            with patch.dict(win_path.__salt__, {'reg.set_value': mock_set}):
-                mock_rehash = MagicMock(side_effect=[True, False])
-                with patch.object(win_path, 'rehash', mock_rehash):
-                    self.assertTrue(win_path.add("c:\\salt", 1))
+        orig_path = ('C:\\Foo', 'C:\\Bar')
 
-                    self.assertFalse(win_path.add("c:\\salt", 1))
+        def _env(path):
+            return {
+                str('PATH'): salt.utils.stringutils.to_str(  # future lint: disable=blacklisted-function
+                    self.pathsep.join(path)
+                )
+            }
+
+        def _run(name, index=None, retval=True, path=None):
+            if path is None:
+                path = orig_path
+            env = _env(path)
+            mock_get = MagicMock(return_value=list(path))
+            mock_set = MagicMock(return_value=retval)
+            with patch.object(win_path, 'PATHSEP', self.pathsep), \
+                    patch.object(win_path, 'get_path', mock_get), \
+                    patch.object(os, 'environ', env), \
+                    patch.dict(win_path.__salt__, {'reg.set_value': mock_set}), \
+                    patch.object(win_path, 'rehash', MagicMock(return_value=True)):
+                return win_path.add(name, index), env, mock_set
+
+        # Test a successful reg update
+        ret, env, mock_set = _run('c:\\salt', retval=True)
+        new_path = ('C:\\Foo', 'C:\\Bar', 'c:\\salt')
+        self.assertTrue(ret)
+        self.assert_call_matches(mock_set, new_path)
+        self.assert_path_matches(env, new_path)
+
+        # Test an unsuccessful reg update
+        ret, env, mock_set = _run('c:\\salt', retval=False)
+        new_path = ('C:\\Foo', 'C:\\Bar', 'c:\\salt')
+        self.assertFalse(ret)
+        self.assert_call_matches(mock_set, new_path)
+        # The local path should still have been modified even
+        # though reg.set_value failed.
+        self.assert_path_matches(env, new_path)
+
+        # Test adding with a custom index
+        ret, env, mock_set = _run('c:\\salt', index=1, retval=True)
+        new_path = ('C:\\Foo', 'c:\\salt', 'C:\\Bar')
+        self.assertTrue(ret)
+        self.assert_call_matches(mock_set, new_path)
+        self.assert_path_matches(env, new_path)
+
+        # Test adding path with a case-insensitive match already present, and
+        # no index provided. The path should remain unchanged and we should not
+        # update the registry.
+        ret, env, mock_set = _run('c:\\foo', retval=True)
+        self.assertTrue(ret)
+        mock_set.assert_not_called()
+        self.assert_path_matches(env, orig_path)
+
+        # Test adding path with a case-insensitive match already present, and a
+        # negative index provided which does not match the current index. The
+        # match should be removed, and the path should be added to the end of
+        # the list.
+        ret, env, mock_set = _run('c:\\foo', index=-1, retval=True)
+        new_path = ('C:\\Bar', 'c:\\foo')
+        self.assertTrue(ret)
+        self.assert_call_matches(mock_set, new_path)
+        self.assert_path_matches(env, new_path)
+
+        # Test adding path with a case-insensitive match already present, and a
+        # negative index provided which matches the current index. No changes
+        # should be made.
+        ret, env, mock_set = _run('c:\\foo', index=-2, retval=True)
+        self.assertTrue(ret)
+        mock_set.assert_not_called()
+        self.assert_path_matches(env, orig_path)
+
+        # Test adding path with a case-insensitive match already present, and a
+        # negative index provided which is larger than the size of the list. No
+        # changes should be made, since in these cases we assume an index of 0,
+        # and the case-insensitive match is also at index 0.
+        ret, env, mock_set = _run('c:\\foo', index=-5, retval=True)
+        self.assertTrue(ret)
+        mock_set.assert_not_called()
+        self.assert_path_matches(env, orig_path)
+
+        # Test adding path with a case-insensitive match already present, and a
+        # negative index provided which is larger than the size of the list.
+        # The match should be removed from its current location and inserted at
+        # the beginning, since when a negative index is larger than the list,
+        # we put it at the beginning of the list.
+        ret, env, mock_set = _run('c:\\bar', index=-5, retval=True)
+        new_path = ('c:\\bar', 'C:\\Foo')
+        self.assertTrue(ret)
+        self.assert_call_matches(mock_set, new_path)
+        self.assert_path_matches(env, new_path)
+
+        # Test adding path with a case-insensitive match already present, and a
+        # negative index provided which matches the current index. The path
+        # should remain unchanged and we should not update the registry.
+        ret, env, mock_set = _run('c:\\bar', index=-1, retval=True)
+        self.assertTrue(ret)
+        mock_set.assert_not_called()
+        self.assert_path_matches(env, orig_path)
+
+        # Test adding path with a case-insensitive match already present, and
+        # an index provided which does not match the current index, and is also
+        # larger than the size of the PATH list. The match should be removed,
+        # and the path should be added to the end of the list.
+        ret, env, mock_set = _run('c:\\foo', index=5, retval=True)
+        new_path = ('C:\\Bar', 'c:\\foo')
+        self.assertTrue(ret)
+        self.assert_call_matches(mock_set, new_path)
+        self.assert_path_matches(env, new_path)
 
     def test_remove(self):
         '''
-            Test to remove the directory from the SYSTEM path
+        Test win_path.remove
         '''
-        mock_get = MagicMock(side_effect=[[1], ['c:\\salt'], ['c:\\salt']])
-        with patch.object(win_path, 'get_path', mock_get):
-            self.assertTrue(win_path.remove("c:\\salt"))
+        orig_path = ('C:\\Foo', 'C:\\Bar', 'C:\\Baz')
 
-            mock_set = MagicMock(side_effect=[True, False])
-            with patch.dict(win_path.__salt__, {'reg.set_value': mock_set}):
-                mock_rehash = MagicMock(return_value="Salt")
-                with patch.object(win_path, 'rehash', mock_rehash):
-                    self.assertEqual(win_path.remove("c:\\salt"), "Salt")
+        def _env(path):
+            return {
+                str('PATH'): salt.utils.stringutils.to_str(  # future lint: disable=blacklisted-function
+                    self.pathsep.join(path)
+                )
+            }
 
-                self.assertFalse(win_path.remove("c:\\salt"))
+        def _run(name='c:\\salt', index=None, retval=True, path=None):
+            if path is None:
+                path = orig_path
+            env = _env(path)
+            mock_get = MagicMock(return_value=list(path))
+            mock_set = MagicMock(return_value=retval)
+            with patch.object(win_path, 'PATHSEP', self.pathsep), \
+                    patch.object(win_path, 'get_path', mock_get), \
+                    patch.object(os, 'environ', env), \
+                    patch.dict(win_path.__salt__, {'reg.set_value': mock_set}), \
+                    patch.object(win_path, 'rehash', MagicMock(return_value=True)):
+                return win_path.remove(name), env, mock_set
+
+        # Test a successful reg update
+        ret, env, mock_set = _run('C:\\Bar', retval=True)
+        new_path = ('C:\\Foo', 'C:\\Baz')
+        self.assertTrue(ret)
+        self.assert_call_matches(mock_set, new_path)
+        self.assert_path_matches(env, new_path)
+
+        # Test a successful reg update with a case-insensitive match
+        ret, env, mock_set = _run('c:\\bar', retval=True)
+        new_path = ('C:\\Foo', 'C:\\Baz')
+        self.assertTrue(ret)
+        self.assert_call_matches(mock_set, new_path)
+        self.assert_path_matches(env, new_path)
+
+        # Test a successful reg update with multiple case-insensitive matches.
+        # All matches should be removed.
+        old_path = orig_path + ('C:\\BAR',)
+        ret, env, mock_set = _run('c:\\bar', retval=True)
+        new_path = ('C:\\Foo', 'C:\\Baz')
+        self.assertTrue(ret)
+        self.assert_call_matches(mock_set, new_path)
+        self.assert_path_matches(env, new_path)
+
+        # Test an unsuccessful reg update
+        ret, env, mock_set = _run('c:\\bar', retval=False)
+        new_path = ('C:\\Foo', 'C:\\Baz')
+        self.assertFalse(ret)
+        self.assert_call_matches(mock_set, new_path)
+        # The local path should still have been modified even
+        # though reg.set_value failed.
+        self.assert_path_matches(env, new_path)
+
+        # Test when no match found
+        ret, env, mock_set = _run('C:\\NotThere', retval=True)
+        self.assertTrue(ret)
+        mock_set.assert_not_called()
+        self.assert_path_matches(env, orig_path)

--- a/tests/unit/states/test_win_path.py
+++ b/tests/unit/states/test_win_path.py
@@ -4,12 +4,8 @@ Tests for win_path states
 '''
 
 # Import Python Libs
-<<<<<<< HEAD
-from __future__ import absolute_import, unicode_literals, print_function
-=======
 from __future__ import absolute_import, print_function, unicode_literals
 import copy
->>>>>>> Improve/remove PATH environment modifications
 
 # Import Salt Testing Libs
 from tests.support.mixins import LoaderModuleMockMixin

--- a/tests/unit/states/test_win_path.py
+++ b/tests/unit/states/test_win_path.py
@@ -218,6 +218,37 @@ class WinPathTestCase(TestCase, LoaderModuleMockMixin):
             }
         )
 
+    def test_exists_change_negative_index_success(self):
+        '''
+        Tests win_path.exists when the directory is already in the PATH and
+        needs to be moved to a different position (successful run).
+
+        This tests a negative index.
+        '''
+        dunder_salt = {
+            'win_path.get_path': MagicMock(side_effect=[
+                ['foo', 'bar', NAME, 'baz'],
+                ['foo', 'bar', 'baz', NAME]
+            ]),
+            'win_path.add': Mock(),
+            'win_path.remove': Mock(),
+        }
+        dunder_opts = {'test': False}
+
+        with patch.dict(win_path.__salt__, dunder_salt), \
+                patch.dict(win_path.__opts__, dunder_opts):
+            ret = win_path.exists(NAME, index=-1)
+
+        self.assertDictEqual(
+            ret,
+            {
+                'name': NAME,
+                'changes': {'index': {'old': -2, 'new': -1}},
+                'result': True,
+                'comment': 'Moved {0} from index -2 to -1.'.format(NAME)
+            }
+        )
+
     def test_exists_change_index_remove_exception(self):
         '''
         Tests win_path.exists when the directory is already in the PATH but an
@@ -227,7 +258,7 @@ class WinPathTestCase(TestCase, LoaderModuleMockMixin):
         dunder_salt = {
             'win_path.get_path': MagicMock(side_effect=[
                 ['foo', 'bar', 'baz', NAME],
-                ['foo', 'bar', 'baz', NAME],
+                ['foo', 'bar', 'baz', NAME]
             ]),
             'win_path.remove': MagicMock(
                 side_effect=Exception('Global Thermonuclear War')
@@ -247,6 +278,40 @@ class WinPathTestCase(TestCase, LoaderModuleMockMixin):
                 'result': False,
                 'comment': 'Encountered error: Global Thermonuclear War. '
                            'Failed to move {0} from index 3 to 0.'.format(NAME)
+            }
+        )
+
+    def test_exists_change_negative_index_remove_exception(self):
+        '''
+        Tests win_path.exists when the directory is already in the PATH but an
+        exception is raised when we attempt to remove the key from its
+        original location.
+
+        This tests a negative index.
+        '''
+        dunder_salt = {
+            'win_path.get_path': MagicMock(side_effect=[
+                ['foo', 'bar', NAME, 'baz'],
+                ['foo', 'bar', NAME, 'baz']
+            ]),
+            'win_path.remove': MagicMock(
+                side_effect=Exception('Global Thermonuclear War')
+            ),
+        }
+        dunder_opts = {'test': False}
+
+        with patch.dict(win_path.__salt__, dunder_salt), \
+                patch.dict(win_path.__opts__, dunder_opts):
+            ret = win_path.exists(NAME, index=-1)
+
+        self.assertDictEqual(
+            ret,
+            {
+                'name': NAME,
+                'changes': {},
+                'result': False,
+                'comment': 'Encountered error: Global Thermonuclear War. '
+                           'Failed to move {0} from index -2 to -1.'.format(NAME)
             }
         )
 
@@ -284,6 +349,42 @@ class WinPathTestCase(TestCase, LoaderModuleMockMixin):
             }
         )
 
+    def test_exists_change_negative_index_add_exception(self):
+        '''
+        Tests win_path.exists when the directory is already in the PATH but an
+        exception is raised when we attempt to add the key to its new location.
+
+        This tests a negative index.
+        '''
+        dunder_salt = {
+            'win_path.get_path': MagicMock(side_effect=[
+                ['foo', 'bar', NAME, 'baz'],
+                ['foo', 'bar', 'baz'],
+            ]),
+            'win_path.add': MagicMock(
+                side_effect=Exception('Global Thermonuclear War')
+            ),
+            'win_path.remove': Mock(),
+        }
+        dunder_opts = {'test': False}
+
+        with patch.dict(win_path.__salt__, dunder_salt), \
+                patch.dict(win_path.__opts__, dunder_opts):
+            ret = win_path.exists(NAME, index=-1)
+
+        self.assertDictEqual(
+            ret,
+            {
+                'name': NAME,
+                'changes': {'index': {'old': -2, 'new': None}},
+                'result': False,
+                'comment': 'Successfully removed {0} from the PATH '
+                           'at index -2, but failed to add it back at index -1. '
+                           'Encountered error: Global Thermonuclear War. '
+                           'Failed to move {0} from index -2 to -1.'.format(NAME)
+            }
+        )
+
     def test_exists_change_index_failure(self):
         '''
         Tests win_path.exists when the directory is already in the PATH and
@@ -310,6 +411,37 @@ class WinPathTestCase(TestCase, LoaderModuleMockMixin):
                 'changes': {},
                 'result': False,
                 'comment': 'Failed to move {0} from index 3 to 0.'.format(NAME)
+            }
+        )
+
+    def test_exists_change_negative_index_failure(self):
+        '''
+        Tests win_path.exists when the directory is already in the PATH and
+        needs to be moved to a different position (failed run).
+
+        This tests a negative index.
+        '''
+        dunder_salt = {
+            'win_path.get_path': MagicMock(side_effect=[
+                ['foo', 'bar', NAME, 'baz'],
+                ['foo', 'bar', NAME, 'baz']
+            ]),
+            'win_path.add': Mock(),
+            'win_path.remove': Mock(),
+        }
+        dunder_opts = {'test': False}
+
+        with patch.dict(win_path.__salt__, dunder_salt), \
+                patch.dict(win_path.__opts__, dunder_opts):
+            ret = win_path.exists(NAME, index=-1)
+
+        self.assertDictEqual(
+            ret,
+            {
+                'name': NAME,
+                'changes': {},
+                'result': False,
+                'comment': 'Failed to move {0} from index -2 to -1.'.format(NAME)
             }
         )
 
@@ -340,6 +472,33 @@ class WinPathTestCase(TestCase, LoaderModuleMockMixin):
             }
         )
 
+    def test_exists_change_negative_index_test_mode(self):
+        '''
+        Tests win_path.exists when the directory is already in the PATH and
+        needs to be moved to a different position (test mode enabled).
+        '''
+        dunder_salt = {
+            'win_path.get_path': MagicMock(side_effect=[
+                ['foo', 'bar', NAME, 'baz'],
+            ]),
+            'win_path.add': Mock(),
+        }
+        dunder_opts = {'test': True}
+
+        with patch.dict(win_path.__salt__, dunder_salt), \
+                patch.dict(win_path.__opts__, dunder_opts):
+            ret = win_path.exists(NAME, index=-1)
+
+        self.assertDictEqual(
+            ret,
+            {
+                'name': NAME,
+                'changes': {'index': {'old': -2, 'new': -1}},
+                'result': None,
+                'comment': '{0} would be moved from index -2 to -1.'.format(NAME)
+            }
+        )
+
     def _test_exists_add_already_present(self, index, test_mode):
         '''
         Tests win_path.exists when the directory already exists in the PATH.
@@ -350,7 +509,8 @@ class WinPathTestCase(TestCase, LoaderModuleMockMixin):
         if index is None:
             current_path.append(NAME)
         else:
-            current_path.insert(index, NAME)
+            pos = index if index >= 0 else len(current_path) + index + 1
+            current_path.insert(pos, NAME)
         dunder_salt = {
             'win_path.get_path': MagicMock(side_effect=[current_path]),
         }
@@ -382,7 +542,11 @@ class WinPathTestCase(TestCase, LoaderModuleMockMixin):
     def test_exists_add_index_already_present(self):
         self._test_exists_add_already_present(1, False)
         self._test_exists_add_already_present(2, False)
+        self._test_exists_add_already_present(-1, False)
+        self._test_exists_add_already_present(-2, False)
 
     def test_exists_add_index_already_present_test_mode(self):
         self._test_exists_add_already_present(1, True)
         self._test_exists_add_already_present(2, True)
+        self._test_exists_add_already_present(-1, True)
+        self._test_exists_add_already_present(-2, True)

--- a/tests/unit/states/test_win_path.py
+++ b/tests/unit/states/test_win_path.py
@@ -1,15 +1,21 @@
 # -*- coding: utf-8 -*-
 '''
-    :codeauthor: :email:`Rahul Handay <rahulha@saltstack.com>`
+Tests for win_path states
 '''
 
 # Import Python Libs
+<<<<<<< HEAD
 from __future__ import absolute_import, unicode_literals, print_function
+=======
+from __future__ import absolute_import, print_function, unicode_literals
+import copy
+>>>>>>> Improve/remove PATH environment modifications
 
 # Import Salt Testing Libs
 from tests.support.mixins import LoaderModuleMockMixin
 from tests.support.unit import TestCase, skipIf
 from tests.support.mock import (
+    Mock,
     MagicMock,
     patch,
     NO_MOCK,
@@ -19,64 +25,368 @@ from tests.support.mock import (
 # Import Salt Libs
 import salt.states.win_path as win_path
 
+NAME = 'salt'
+
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
 class WinPathTestCase(TestCase, LoaderModuleMockMixin):
     '''
-        Validate the win_path state
+    Validate the win_path state
     '''
     def setup_loader_modules(self):
         return {win_path: {}}
 
     def test_absent(self):
         '''
-            Test to remove the directory from the SYSTEM path
+        Test various cases for win_path.absent
         '''
-        ret = {'name': 'salt',
-               'changes': {},
-               'result': None,
-               'comment': ''}
-        mock = MagicMock(return_value=False)
-        with patch.dict(win_path.__salt__, {"win_path.exists": mock}):
-            with patch.dict(win_path.__opts__, {"test": True}):
-                ret.update({'comment': 'salt is not in the PATH'})
-                self.assertDictEqual(win_path.absent('salt'), ret)
+        ret_base = {'name': NAME, 'result': True, 'changes': {}}
 
-            with patch.dict(win_path.__opts__, {"test": False}):
-                mock = MagicMock(return_value=True)
-                with patch.dict(win_path.__salt__, {"win_path.remove": mock}):
-                    ret.update({'result': True})
-                    self.assertDictEqual(win_path.absent('salt'), ret)
+        def _mock(retval):
+            # Return a new MagicMock for each test case
+            return MagicMock(side_effect=retval)
 
-    def test_exists(self):
+        # We don't really want to run the remove func
+        with patch.dict(win_path.__salt__, {'win_path.remove': Mock()}):
+
+            # Test mode OFF
+            with patch.dict(win_path.__opts__, {'test': False}):
+
+                # Test already absent
+                with patch.dict(win_path.__salt__, {'win_path.exists': _mock([False])}):
+                    ret = copy.deepcopy(ret_base)
+                    ret['comment'] = '{0} is not in the PATH'.format(NAME)
+                    ret['result'] = True
+                    self.assertDictEqual(win_path.absent(NAME), ret)
+
+                # Test successful removal
+                with patch.dict(win_path.__salt__, {'win_path.exists': _mock([True, False])}):
+                    ret = copy.deepcopy(ret_base)
+                    ret['comment'] = 'Removed {0} from the PATH'.format(NAME)
+                    ret['changes']['removed'] = NAME
+                    ret['result'] = True
+                    self.assertDictEqual(win_path.absent(NAME), ret)
+
+                # Test unsucessful removal
+                with patch.dict(win_path.__salt__, {'win_path.exists': _mock([True, True])}):
+                    ret = copy.deepcopy(ret_base)
+                    ret['comment'] = 'Failed to remove {0} from the PATH'.format(NAME)
+                    ret['result'] = False
+                    self.assertDictEqual(win_path.absent(NAME), ret)
+
+            # Test mode ON
+            with patch.dict(win_path.__opts__, {'test': True}):
+
+                # Test already absent
+                with patch.dict(win_path.__salt__, {'win_path.exists': _mock([False])}):
+                    ret = copy.deepcopy(ret_base)
+                    ret['comment'] = '{0} is not in the PATH'.format(NAME)
+                    ret['result'] = True
+                    self.assertDictEqual(win_path.absent(NAME), ret)
+
+                # Test the test-mode return
+                with patch.dict(win_path.__salt__, {'win_path.exists': _mock([True])}):
+                    ret = copy.deepcopy(ret_base)
+                    ret['comment'] = '{0} would be removed from the PATH'.format(NAME)
+                    ret['result'] = None
+                    self.assertDictEqual(win_path.absent(NAME), ret)
+
+    def test_exists_invalid_index(self):
         '''
-            Test to add the directory to the system PATH at index location
+        Tests win_path.exists when a non-integer index is specified.
         '''
-        ret = {'name': 'salt',
-               'changes': {},
-               'result': True,
-               'comment': ''}
-        mock = MagicMock(return_value=['Salt', 'Saltdude'])
-        with patch.dict(win_path.__salt__, {"win_path.get_path": mock}):
-            mock = MagicMock(side_effect=['Saltdude', 'Saltdude', '/Saltdude',
-                                          'Saltdude'])
-            with patch.object(win_path, '_normalize_dir', mock):
-                ret.update({'comment': 'salt is already present in the'
-                            ' PATH at the right location'})
-                self.assertDictEqual(win_path.exists('salt', 1), ret)
+        ret = win_path.exists(NAME, index='foo')
+        self.assertDictEqual(
+            ret,
+            {
+                'name': NAME,
+                'changes': {},
+                'result': False,
+                'comment': 'Index must be an integer'
+            }
+        )
 
-                self.assertDictEqual(win_path.exists('salt'), ret)
+    def test_exists_add_no_index_success(self):
+        '''
+        Tests win_path.exists when the directory isn't already in the PATH and
+        no index is specified (successful run).
+        '''
+        dunder_salt = {
+            'win_path.get_path': MagicMock(side_effect=[
+                ['foo', 'bar', 'baz'],
+                ['foo', 'bar', 'baz', NAME]
+            ]),
+            'win_path.add': Mock(),
+        }
+        dunder_opts = {'test': False}
 
-                with patch.dict(win_path.__opts__, {"test": True}):
-                    ret.update({'comment': '', 'result': None,
-                                'changes': {'added': 'salt will be'
-                                            ' added at index 2'}})
-                    self.assertDictEqual(win_path.exists('salt'), ret)
+        with patch.dict(win_path.__salt__, dunder_salt), \
+                patch.dict(win_path.__opts__, dunder_opts):
+            ret = win_path.exists(NAME)
 
-                with patch.dict(win_path.__opts__, {"test": False}):
-                    mock = MagicMock(return_value=False)
-                    with patch.dict(win_path.__salt__, {"win_path.add": mock}):
-                        ret.update({'comment': 'salt is already present in the'
-                                    ' PATH at the right location',
-                                    'result': True, 'changes': {}})
-                        self.assertDictEqual(win_path.exists('salt'), ret)
+        self.assertDictEqual(
+            ret,
+            {
+                'name': NAME,
+                'changes': {'index': {'old': None, 'new': 3}},
+                'result': True,
+                'comment': 'Added {0} to the PATH.'.format(NAME)
+            }
+        )
+
+    def test_exists_add_no_index_failure(self):
+        '''
+        Tests win_path.exists when the directory isn't already in the PATH and
+        no index is specified (failed run).
+        '''
+        dunder_salt = {
+            'win_path.get_path': MagicMock(side_effect=[
+                ['foo', 'bar', 'baz'],
+                ['foo', 'bar', 'baz']
+            ]),
+            'win_path.add': Mock(),
+        }
+        dunder_opts = {'test': False}
+
+        with patch.dict(win_path.__salt__, dunder_salt), \
+                patch.dict(win_path.__opts__, dunder_opts):
+            ret = win_path.exists(NAME)
+
+        self.assertDictEqual(
+            ret,
+            {
+                'name': NAME,
+                'changes': {},
+                'result': False,
+                'comment': 'Failed to add {0} to the PATH.'.format(NAME)
+            }
+        )
+
+    def test_exists_add_no_index_failure_exception(self):
+        '''
+        Tests win_path.exists when the directory isn't already in the PATH and
+        no index is specified (failed run due to exception).
+        '''
+        dunder_salt = {
+            'win_path.get_path': MagicMock(side_effect=[
+                ['foo', 'bar', 'baz'],
+                ['foo', 'bar', 'baz']
+            ]),
+            'win_path.add': MagicMock(
+                side_effect=Exception('Global Thermonuclear War')
+            ),
+        }
+        dunder_opts = {'test': False}
+
+        with patch.dict(win_path.__salt__, dunder_salt), \
+                patch.dict(win_path.__opts__, dunder_opts):
+            ret = win_path.exists(NAME)
+
+        self.assertDictEqual(
+            ret,
+            {
+                'name': NAME,
+                'changes': {},
+                'result': False,
+                'comment': 'Encountered error: Global Thermonuclear War. '
+                           'Failed to add {0} to the PATH.'.format(NAME)
+            }
+        )
+
+    def test_exists_change_index_success(self):
+        '''
+        Tests win_path.exists when the directory is already in the PATH and
+        needs to be moved to a different position (successful run).
+        '''
+        dunder_salt = {
+            'win_path.get_path': MagicMock(side_effect=[
+                ['foo', 'bar', 'baz', NAME],
+                [NAME, 'foo', 'bar', 'baz']
+            ]),
+            'win_path.add': Mock(),
+            'win_path.remove': Mock(),
+        }
+        dunder_opts = {'test': False}
+
+        with patch.dict(win_path.__salt__, dunder_salt), \
+                patch.dict(win_path.__opts__, dunder_opts):
+            ret = win_path.exists(NAME, index=0)
+
+        self.assertDictEqual(
+            ret,
+            {
+                'name': NAME,
+                'changes': {'index': {'old': 3, 'new': 0}},
+                'result': True,
+                'comment': 'Moved {0} from index 3 to 0.'.format(NAME)
+            }
+        )
+
+    def test_exists_change_index_remove_exception(self):
+        '''
+        Tests win_path.exists when the directory is already in the PATH but an
+        exception is raised when we attempt to remove the key from its
+        original location.
+        '''
+        dunder_salt = {
+            'win_path.get_path': MagicMock(side_effect=[
+                ['foo', 'bar', 'baz', NAME],
+                ['foo', 'bar', 'baz', NAME],
+            ]),
+            'win_path.remove': MagicMock(
+                side_effect=Exception('Global Thermonuclear War')
+            ),
+        }
+        dunder_opts = {'test': False}
+
+        with patch.dict(win_path.__salt__, dunder_salt), \
+                patch.dict(win_path.__opts__, dunder_opts):
+            ret = win_path.exists(NAME, index=0)
+
+        self.assertDictEqual(
+            ret,
+            {
+                'name': NAME,
+                'changes': {},
+                'result': False,
+                'comment': 'Encountered error: Global Thermonuclear War. '
+                           'Failed to move {0} from index 3 to 0.'.format(NAME)
+            }
+        )
+
+    def test_exists_change_index_add_exception(self):
+        '''
+        Tests win_path.exists when the directory is already in the PATH but an
+        exception is raised when we attempt to add the key to its new location.
+        '''
+        dunder_salt = {
+            'win_path.get_path': MagicMock(side_effect=[
+                ['foo', 'bar', 'baz', NAME],
+                ['foo', 'bar', 'baz'],
+            ]),
+            'win_path.add': MagicMock(
+                side_effect=Exception('Global Thermonuclear War')
+            ),
+            'win_path.remove': Mock(),
+        }
+        dunder_opts = {'test': False}
+
+        with patch.dict(win_path.__salt__, dunder_salt), \
+                patch.dict(win_path.__opts__, dunder_opts):
+            ret = win_path.exists(NAME, index=0)
+
+        self.assertDictEqual(
+            ret,
+            {
+                'name': NAME,
+                'changes': {'index': {'old': 3, 'new': None}},
+                'result': False,
+                'comment': 'Successfully removed {0} from the PATH '
+                           'at index 3, but failed to add it back at index 0. '
+                           'Encountered error: Global Thermonuclear War. '
+                           'Failed to move {0} from index 3 to 0.'.format(NAME)
+            }
+        )
+
+    def test_exists_change_index_failure(self):
+        '''
+        Tests win_path.exists when the directory is already in the PATH and
+        needs to be moved to a different position (failed run).
+        '''
+        dunder_salt = {
+            'win_path.get_path': MagicMock(side_effect=[
+                ['foo', 'bar', 'baz', NAME],
+                ['foo', 'bar', 'baz', NAME]
+            ]),
+            'win_path.add': Mock(),
+            'win_path.remove': Mock(),
+        }
+        dunder_opts = {'test': False}
+
+        with patch.dict(win_path.__salt__, dunder_salt), \
+                patch.dict(win_path.__opts__, dunder_opts):
+            ret = win_path.exists(NAME, index=0)
+
+        self.assertDictEqual(
+            ret,
+            {
+                'name': NAME,
+                'changes': {},
+                'result': False,
+                'comment': 'Failed to move {0} from index 3 to 0.'.format(NAME)
+            }
+        )
+
+    def test_exists_change_index_test_mode(self):
+        '''
+        Tests win_path.exists when the directory is already in the PATH and
+        needs to be moved to a different position (test mode enabled).
+        '''
+        dunder_salt = {
+            'win_path.get_path': MagicMock(side_effect=[
+                ['foo', 'bar', 'baz', NAME],
+            ]),
+            'win_path.add': Mock(),
+        }
+        dunder_opts = {'test': True}
+
+        with patch.dict(win_path.__salt__, dunder_salt), \
+                patch.dict(win_path.__opts__, dunder_opts):
+            ret = win_path.exists(NAME, index=0)
+
+        self.assertDictEqual(
+            ret,
+            {
+                'name': NAME,
+                'changes': {'index': {'old': 3, 'new': 0}},
+                'result': None,
+                'comment': '{0} would be moved from index 3 to 0.'.format(NAME)
+            }
+        )
+
+    def _test_exists_add_already_present(self, index, test_mode):
+        '''
+        Tests win_path.exists when the directory already exists in the PATH.
+        Helper function to test both with and without and index, and with test
+        mode both disabled and enabled.
+        '''
+        current_path = ['foo', 'bar', 'baz']
+        if index is None:
+            current_path.append(NAME)
+        else:
+            current_path.insert(index, NAME)
+        dunder_salt = {
+            'win_path.get_path': MagicMock(side_effect=[current_path]),
+        }
+        dunder_opts = {'test': test_mode}
+
+        with patch.dict(win_path.__salt__, dunder_salt), \
+                patch.dict(win_path.__opts__, dunder_opts):
+            ret = win_path.exists(NAME, index=index)
+
+        self.assertDictEqual(
+            ret,
+            {
+                'name': NAME,
+                'changes': {},
+                'result': True,
+                'comment': '{0} already exists in the PATH{1}.'.format(
+                    NAME,
+                    ' at index {0}'.format(index) if index is not None else ''
+                )
+            }
+        )
+
+    def test_exists_add_no_index_already_present(self):
+        self._test_exists_add_already_present(None, False)
+
+    def test_exists_add_no_index_already_present_test_mode(self):
+        self._test_exists_add_already_present(None, True)
+
+    def test_exists_add_index_already_present(self):
+        self._test_exists_add_already_present(1, False)
+        self._test_exists_add_already_present(2, False)
+
+    def test_exists_add_index_already_present_test_mode(self):
+        self._test_exists_add_already_present(1, True)
+        self._test_exists_add_already_present(2, True)


### PR DESCRIPTION
- `salt/modules/rbenv.py`: Forces use of str types in the custom env dict passed to `cmd.run_all`.
- `salt/modules/syslog_ng.py`: Ditches janky PATH munging in favor of the stable and long-existing support built into cmdmod.py
- `salt/modules/win_path.py`: Forces use of str types in path modification functions.
- `salt/states/win_path.py`: Completely rewritten. Duplicated code from the execution module removed in favor of calls to the execution module. Tests junked and 14 new tests written.
- `salt/utils/path.py`: The `which()` function was mistakenly modified in 20033ee to inject the directories in the POSIX default path into the PATH environment variable (even for Windows!). We never used the PATH to find the executables, we simply cycled through the dirs one by one and looked for an executable file matching the named path. The code that modifies the path is now removed. In addition, `which()` now uses `salt.utils.path.join()`, which gracefully handles mismatched str and unicode directory components to prevent decode errors.  `join()` has also been simplified to use `salt.utils.data.decode()` to normalize directory components to unicode.