### PR TITLE
check the lowstate __id__ before using it

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -1980,7 +1980,8 @@ class State(object):
         # duration in milliseconds.microseconds
         duration = (delta.seconds * 1000000 + delta.microseconds)/1000.0
         ret['duration'] = duration
-        ret['__id__'] = low['__id__']
+        if '__id__' in low:
+            ret['__id__'] = low['__id__']
         log.info(
             'Completed state [%s] at time %s (duration_in_ms=%s)',
             low['name'].strip() if isinstance(low['name'], six.string_types)


### PR DESCRIPTION
it may not always be set, for example when coming in via state.low.

### What does this PR do?

Effectively unbreak `state.low` when `__id__` is not explicitly passed (as suggested by the documentation).

### What issues does this PR fix or reference?

#45682

### Previous Behavior

```
[root@salt salt]# salt salt\* state.low '{"state": "file", "fun": "exists", "name": "/etc/fstab"}'
salt.localdomain:
    The minion function caused an exception: Traceback (most recent call last):
      File "/usr/lib/python2.7/site-packages/salt/minion.py", line 1470, in _thread_return
        return_data = executor.execute()
      File "/usr/lib/python2.7/site-packages/salt/executors/direct_call.py", line 28, in execute
        return self.func(*self.args, **self.kwargs)
      File "/usr/lib/python2.7/site-packages/salt/modules/state.py", line 312, in low
        ret = st_.call(data)
      File "/usr/lib/python2.7/site-packages/salt/state.py", line 1901, in call
        ret['__id__'] = low['__id__']
    KeyError: '__id__'
[root@salt salt]#
```

### New Behavior

```
[root@salt salt]# salt salt\* state.low '{"state": "file", "fun": "exists", "name": "/etc/fstab"}'
salt.localdomain:
    ----------
    __run_num__:
        0
    __sls__:
        None
    changes:
        ----------
    comment:
        Path /etc/fstab exists
    duration:
        0.792
    name:
        /etc/fstab
    pchanges:
        ----------
    result:
        True
    start_time:
        07:48:24.983401
[root@salt salt]#
```

### Tests written?

No(t yet)

### Commits signed with GPG?

No