### PR TITLE
Fix exception when shutting down logging listener

### DIFF
--- a/salt/log/setup.py
+++ b/salt/log/setup.py
@@ -946,6 +946,12 @@ def shutdown_multiprocessing_logging_listener(daemonizing=False):
         # We're in the MainProcess and we're not daemonizing, return!
         # No multiprocessing logging listener shutdown shall happen
         return
+
+    if not daemonizing:
+        # Need to remove the queue handler so that it doesn't try to send
+        # data over a queue that was shut down on the listener end.
+        shutdown_multiprocessing_logging()
+
     if __MP_LOGGING_QUEUE_PROCESS is None:
         return
     if __MP_LOGGING_QUEUE_PROCESS.is_alive():

--- a/salt/log/setup.py
+++ b/salt/log/setup.py
@@ -933,6 +933,12 @@ def shutdown_multiprocessing_logging():
         logging.root.removeHandler(__MP_LOGGING_QUEUE_HANDLER)
         __MP_LOGGING_QUEUE_HANDLER = None
         __MP_LOGGING_CONFIGURED = False
+        if not logging.root.handlers:
+            # Ensure we have at least one logging root handler so
+            # something can handle logging messages. This case should
+            # only occur on Windows since on Windows we log to console
+            # and file through the Multiprocessing Logging Listener.
+            setup_console_logger()
     finally:
         logging._releaseLock()
 

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -261,6 +261,8 @@ class OptionParser(optparse.OptionParser, object):
                     )
                 )
         if self._setup_mp_logging_listener_ is True:
+            # Stop logging through the queue
+            log.shutdown_multiprocessing_logging()
             # Stop the logging queue listener process
             log.shutdown_multiprocessing_logging_listener(daemonizing=True)
         if isinstance(msg, six.string_types) and msg and msg[-1] != '\n':


### PR DESCRIPTION
### What does this PR do?

`shutdown_multiprocessing_logging_listener()` shuts down
the logging process which closes the multiprocessing queue
used to shuttle logging data. Before shutting down the
logging process, prevent this process from trying to write
to the logging queue to prevent an exception from occurring when
trying to write to a multiprocessing queue that has been closed
by the other side.

### What issues does this PR fix or reference?

#45301

### Tests written?

No

### Commits signed with GPG?

Yes