### PR TITLE
add seed option to rand_int

### DIFF
--- a/salt/modules/mod_random.py
+++ b/salt/modules/mod_random.py
@@ -164,7 +164,7 @@ def shadow_hash(crypt_salt=None, password=None, algorithm='sha512'):
     return salt.utils.pycrypto.gen_hash(crypt_salt, password, algorithm)
 
 
-def rand_int(start=1, end=10):
+def rand_int(start=1, end=10, seed=None):
     '''
     Returns a random integer number between the start and end number.
 
@@ -176,12 +176,21 @@ def rand_int(start=1, end=10):
     end : 10
         Any valid integer number
 
+    seed :
+        Optional hashable object
+
+    .. versionchanged:: Fluorine
+        Added seed argument. Will return the same result when run with the same seed.
+
+
     CLI Example:
 
     .. code-block:: bash
 
         salt '*' random.rand_int 1 10
     '''
+    if seed is not None:
+        random.seed(seed)
     return random.randint(start, end)
 
 


### PR DESCRIPTION
### What does this PR do?
Add seed option to rand_int function. 

Use case was wanting a cronjob to be scheduled 2 times an hour. Without the seed option, random numbers are generated on each state invocation, creating unnecessary changes. With the seed option, generated numbers can be hashed on a string, resulting in time consistency. 

### What issues does this PR fix or reference?

### Previous Behavior
```
salt-call random.rand_int 1 20
local:
    15
salt-call random.rand_int 1 20
local:
    17
```
### New Behavior
```
salt-call random.rand_int 1 20 seed=red
local:
    11
salt-call random.rand_int 1 20 seed=red
local:
    11
```
### Tests written?
No

### Commits signed with GPG?
No