### PR TITLE
Added source argument to function call

### DIFF
--- a/salt/states/chocolatey.py
+++ b/salt/states/chocolatey.py
@@ -101,7 +101,9 @@ def installed(name, version=None, source=None, force=False, pre_versions=False,
 
     # Package installed
     else:
-        version_info = __salt__['chocolatey.version'](name, check_remote=True)
+        version_info = __salt__['chocolatey.version'](name=name,
+                                                      check_remote=True,
+                                                      source=source)
 
         full_name = name
         for pkg in version_info:


### PR DESCRIPTION
### What does this PR do?
Fixes a KeyError exception when the chocolatey state calls the version function in the chocolatey module without passing along the source argument. This results in the module function comparing a list of installed packages to an empty list of available packages from our (by default) empty source argument. Line 889 in the chocolatey module throws the exception.

### Tests written?
No

### Commits signed with GPG?
Yes
