### PR TITLE
Decode git call output in Python 3

### DIFF
--- a/salt/version.py
+++ b/salt/version.py
@@ -512,6 +512,9 @@ def __discover_version(saltstack_version):
             process = subprocess.Popen(
                 ['git', 'describe', '--tags', '--match', 'v[0-9]*', '--always'], **kwargs)
             out, err = process.communicate()
+        if six.PY3:
+            out = out.decode()
+            err = err.decode()
         out = out.strip()
         err = err.strip()
 


### PR DESCRIPTION
The subprocess communicate() method returns byte streams for stdout and stderr in Python 3. They need to be decoded to str. Otherwise the version string parsing will fail:

```
Traceback (most recent call last):
  File "salt/version.py", line 522, in __discover_version
    return SaltStackVersion.parse(out)
  File "salt/version.py", line 267, in parse
    'Unable to parse version string: \'{0}\''.format(version_string)
ValueError: Unable to parse version string: 'b'c0e6782d''
```