### PR TITLE
fixed quoting of script path in cmd.script

### DIFF
--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -36,7 +36,6 @@ from salt.exceptions import CommandExecutionError, TimedProcTimeoutError, \
     SaltInvocationError
 from salt.log import LOG_LEVELS
 from salt.ext.six.moves import range, zip
-from salt.ext.six.moves import shlex_quote as _cmd_quote
 from salt.utils.locales import sdecode
 
 # Only available on POSIX systems, nonfatal on windows
@@ -47,9 +46,10 @@ except ImportError:
 
 if salt.utils.is_windows():
     from salt.utils.win_runas import runas as win_runas
-    from salt.utils.win_functions import escape_argument as win_cmd_quote
+    from salt.utils.win_functions import escape_argument as _cmd_quote
     HAS_WIN_RUNAS = True
 else:
+    from salt.ext.six.moves import shlex_quote as _cmd_quote
     HAS_WIN_RUNAS = False
 
 __proxyenabled__ = ['*']
@@ -2148,10 +2148,7 @@ def script(source,
         os.chmod(path, 320)
         os.chown(path, __salt__['file.user_to_uid'](runas), -1)
 
-    if salt.utils.is_windows():
-        path = win_cmd_quote(path)
-    else:
-        path = _cmd_quote(path)
+    path = _cmd_quote(path)
 
     ret = _run(path + ' ' + str(args) if args else path,
                cwd=cwd,

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -47,6 +47,7 @@ except ImportError:
 
 if salt.utils.is_windows():
     from salt.utils.win_runas import runas as win_runas
+    from salt.utils.win_functions import escape_argument as win_cmd_quote
     HAS_WIN_RUNAS = True
 else:
     HAS_WIN_RUNAS = False
@@ -2147,7 +2148,10 @@ def script(source,
         os.chmod(path, 320)
         os.chown(path, __salt__['file.user_to_uid'](runas), -1)
 
-    path = _cmd_quote(path)
+    if salt.utils.is_windows():
+        path = win_cmd_quote(path)
+    else:
+        path = _cmd_quote(path)
 
     ret = _run(path + ' ' + str(args) if args else path,
                cwd=cwd,

--- a/salt/utils/win_functions.py
+++ b/salt/utils/win_functions.py
@@ -5,6 +5,7 @@ missing functions in other modules
 '''
 from __future__ import absolute_import
 import platform
+import re
 
 # Import Salt Libs
 from salt.exceptions import CommandExecutionError
@@ -159,3 +160,51 @@ def get_sam_name(username):
         return '\\'.join([platform.node()[:15].upper(), username])
     username, domain, _ = win32security.LookupAccountSid(None, sid_obj)
     return '\\'.join([domain, username])
+
+def escape_argument(arg):
+    '''
+    Escape the argument for the cmd.exe shell.
+    See http://blogs.msdn.com/b/twistylittlepassagesallalike/archive/2011/04/23/everyone-quotes-arguments-the-wrong-way.aspx
+    
+    First we escape the quote chars to produce a argument suitable for
+    CommandLineToArgvW. We don't need to do this for simple arguments.
+
+    Args:
+        arg (str): a single command line argument to escape for the cmd.exe shell
+
+    Returns:
+        str: an escaped string suitable to be passed as a program argument to the cmd.exe shell
+    '''
+    if not arg or re.search(r'(["\s])', arg):
+        arg = '"' + arg.replace('"', r'\"') + '"'
+
+    return escape_for_cmd_exe(arg)
+
+def escape_for_cmd_exe(arg):
+    '''
+    Escape an argument string to be suitable to be passed to
+    cmd.exe on Windows
+    
+    This method takes an argument that is expected to already be properly
+    escaped for the receiving program to be properly parsed. This argument
+    will be further escaped to pass the interpolation performed by cmd.exe
+    unchanged.
+    
+    Any meta-characters will be escaped, removing the ability to e.g. use
+    redirects or variables.
+    
+    Args:
+        arg (str): a single command line argument to escape for cmd.exe
+
+    Returns:
+        str: an escaped string suitable to be passed as a program argument to cmd.exe
+    '''
+    meta_chars = '()%!^"<>&|'
+    meta_re = re.compile('(' + '|'.join(re.escape(char) for char in list(meta_chars)) + ')')
+    meta_map = { char: "^%s" % char for char in meta_chars }
+
+    def escape_meta_chars(m):
+        char = m.group(1)
+        return meta_map[char]
+
+    return meta_re.sub(escape_meta_chars, arg)

--- a/salt/utils/win_functions.py
+++ b/salt/utils/win_functions.py
@@ -161,11 +161,12 @@ def get_sam_name(username):
     username, domain, _ = win32security.LookupAccountSid(None, sid_obj)
     return '\\'.join([domain, username])
 
+
 def escape_argument(arg):
     '''
     Escape the argument for the cmd.exe shell.
     See http://blogs.msdn.com/b/twistylittlepassagesallalike/archive/2011/04/23/everyone-quotes-arguments-the-wrong-way.aspx
-    
+
     First we escape the quote chars to produce a argument suitable for
     CommandLineToArgvW. We don't need to do this for simple arguments.
 
@@ -180,19 +181,20 @@ def escape_argument(arg):
 
     return escape_for_cmd_exe(arg)
 
+
 def escape_for_cmd_exe(arg):
     '''
     Escape an argument string to be suitable to be passed to
     cmd.exe on Windows
-    
+
     This method takes an argument that is expected to already be properly
     escaped for the receiving program to be properly parsed. This argument
     will be further escaped to pass the interpolation performed by cmd.exe
     unchanged.
-    
+
     Any meta-characters will be escaped, removing the ability to e.g. use
     redirects or variables.
-    
+
     Args:
         arg (str): a single command line argument to escape for cmd.exe
 
@@ -201,7 +203,7 @@ def escape_for_cmd_exe(arg):
     '''
     meta_chars = '()%!^"<>&|'
     meta_re = re.compile('(' + '|'.join(re.escape(char) for char in list(meta_chars)) + ')')
-    meta_map = { char: "^%s" % char for char in meta_chars }
+    meta_map = {char: "^{0}".format(char) for char in meta_chars}
 
     def escape_meta_chars(m):
         char = m.group(1)

--- a/tests/unit/utils/test_win_functions.py
+++ b/tests/unit/utils/test_win_functions.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+
+# Import Python Libs
+from __future__ import absolute_import, unicode_literals, print_function
+
+# Import Salt Testing Libs
+from tests.support.unit import TestCase, skipIf
+from tests.support.mock import (
+    NO_MOCK,
+    NO_MOCK_REASON
+)
+
+# Import Salt Libs
+import salt.utils.win_functions as win_functions
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class WinFunctionsTestCase(TestCase):
+    '''
+    Test cases for salt.utils.win_functions
+    '''
+
+    def test_escape_argument_simple(self):
+        '''
+        Test to make sure we encode simple arguments correctly
+        '''
+        encoded = win_functions.escape_argument('simple')
+
+        self.assertEqual(encoded, 'simple')
+
+    def test_escape_argument_with_space(self):
+        '''
+        Test to make sure we encode arguments containing spaces correctly
+        '''
+        encoded = win_functions.escape_argument('with space')
+
+        self.assertEqual(encoded, '^"with space^"')
+
+    def test_escape_argument_simple_path(self):
+        '''
+        Test to make sure we encode simple path arguments correctly
+        '''
+        encoded = win_functions.escape_argument('C:\\some\\path')
+
+        self.assertEqual(encoded, 'C:\\some\\path')
+
+    def test_escape_argument_path_with_space(self):
+        '''
+        Test to make sure we encode path arguments containing spaces correctly
+        '''
+        encoded = win_functions.escape_argument('C:\\Some Path\\With Spaces')
+
+        self.assertEqual(encoded, '^"C:\\Some Path\\With Spaces^"')

--- a/tests/unit/utils/test_win_functions.py
+++ b/tests/unit/utils/test_win_functions.py
@@ -13,6 +13,7 @@ from tests.support.mock import (
 # Import Salt Libs
 import salt.utils.win_functions as win_functions
 
+
 @skipIf(NO_MOCK, NO_MOCK_REASON)
 class WinFunctionsTestCase(TestCase):
     '''


### PR DESCRIPTION
### What does this PR do?
This fixes the quoting of the script path in cmd.script on windows. Basically, shlex.quote doesn't quote arguments correctly for use in the cmd shell.

### What issues does this PR fix or reference?
Was introduced with #45134

### Example errors
```
PS C:\Users\william> salt-call cmd.script salt://any-powershell-script.ps1 shell=powershell
[ERROR   ] cmd.script: Unable to clean tempfile ''C:\Users\william\AppData\Local\Temp\__salt.tmp.o_a7jnl2.ps1'': Path not found: 'C:\Users\william\AppData\Local\Temp\__salt.tmp.o_a7jnl2.ps1'
local:
    ----------
    pid:
        6236
    retcode:
        4294770688
    stderr:
        Processing -File ''C:\Users\william\AppData\Local\Temp\__salt.tmp.o_a7jnl2.ps1'' failed: The given path's format is not supported. Specify a valid path for the -File parameter.
    stdout:
        Windows PowerShell
        Copyright (C) Microsoft Corporation. All rights reserved.

PS C:\Users\william> salt-call cmd.script salt://any-batch-script.bat
[ERROR   ] cmd.script: Unable to clean tempfile ''C:\Users\william\AppData\Local\Temp\__salt.tmp.73tymk82.bat'': Path not found: 'C:\Users\william\AppData\Local\Temp\__salt.tmp.73tymk82.bat'
local:
    ----------
    pid:
        6432
    retcode:
        1
    stderr:
        The filename, directory name, or volume label syntax is incorrect.
    stdout:
```

### Tests written?

Yes

### Commits signed with GPG?

No
