### PR TITLE
Salt cloud adds newly created insances to cache

### DIFF
--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -2802,6 +2802,7 @@ def create(vm_=None, call=None):
 
     # Ensure that the latest node data is returned
     node = _get_node(instance_id=vm_['instance_id'])
+    __utils__['cloud.cache_node'](node, __active_provider_name__, __opts__)
     ret.update(node)
 
     return ret

--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -2656,7 +2656,8 @@ def request_minion_cachedir(
 
     fname = '{0}.p'.format(minion_id)
     path = os.path.join(base, 'requested', fname)
-    with salt.utils.fopen(path, 'w') as fh_:
+    mode = 'wb' if six.PY3 else 'w'
+    with salt.utils.fopen(path, mode) as fh_:
         msgpack.dump(data, fh_)
 
 
@@ -2766,8 +2767,9 @@ def list_cache_nodes_full(opts=None, provider=None, base=None):
                 # Finally, get a list of full minion data
                 fpath = os.path.join(min_dir, fname)
                 minion_id = fname[:-2]  # strip '.p' from end of msgpack filename
-                with salt.utils.fopen(fpath, 'r') as fh_:
-                    minions[driver][prov][minion_id] = msgpack.load(fh_)
+                mode = 'rb' if six.PY3 else 'r'
+                with salt.utils.fopen(fpath, mode) as fh_:
+                    minions[driver][prov][minion_id] = msgpack.load(fh_, encoding='utf-8')
 
     return minions
 
@@ -2945,7 +2947,8 @@ def cache_node_list(nodes, provider, opts):
     for node in nodes:
         diff_node_cache(prov_dir, node, nodes[node], opts)
         path = os.path.join(prov_dir, '{0}.p'.format(node))
-        with salt.utils.fopen(path, 'w') as fh_:
+        mode = 'wb' if six.PY3 else 'w'
+        with salt.utils.fopen(path, mode) as fh_:
             msgpack.dump(nodes[node], fh_)
 
 
@@ -2970,7 +2973,8 @@ def cache_node(node, provider, opts):
     if not os.path.exists(prov_dir):
         os.makedirs(prov_dir)
     path = os.path.join(prov_dir, '{0}.p'.format(node['name']))
-    with salt.utils.fopen(path, 'w') as fh_:
+    mode = 'wb' if six.PY3 else 'w'
+    with salt.utils.fopen(path, mode) as fh_:
         msgpack.dump(node, fh_)
 
 


### PR DESCRIPTION
What does this PR do?
Fixes cloud roster so newly created could minions can be found by salt-ssh

What issues does this PR fix or reference?
#44449

Previous Behavior
Cache files failed to load because of encoding issues

New Behavior
Cache files load cleanly

Tests written?
No

Commits signed with GPG?
No