### PR TITLE
[oxygen] Argument to struct.pack must be a bytescode not unicode with Python 2.7.5

### DIFF
--- a/salt/utils/vt.py
+++ b/salt/utils/vt.py
@@ -708,7 +708,7 @@ class Terminal(object):
         def __detect_parent_terminal_size(self):
             try:
                 TIOCGWINSZ = getattr(termios, 'TIOCGWINSZ', 1074295912)
-                packed = struct.pack(str('HHHH'), 0, 0, 0, 0)  # future lint: blacklisted-function
+                packed = struct.pack(b'HHHH', 0, 0, 0, 0)
                 ioctl = fcntl.ioctl(sys.stdin.fileno(), TIOCGWINSZ, packed)
                 return struct.unpack('HHHH', ioctl)[0:2]
             except IOError:
@@ -731,7 +731,7 @@ class Terminal(object):
                 )
 
             TIOCGWINSZ = getattr(termios, 'TIOCGWINSZ', 1074295912)
-            packed = struct.pack('HHHH', 0, 0, 0, 0)
+            packed = struct.pack(b'HHHH', 0, 0, 0, 0)
             ioctl = fcntl.ioctl(self.child_fd, TIOCGWINSZ, packed)
             return struct.unpack('HHHH', ioctl)[0:2]
 
@@ -759,7 +759,7 @@ class Terminal(object):
                 # Same bits, but with sign.
                 TIOCSWINSZ = -2146929561
             # Note, assume ws_xpixel and ws_ypixel are zero.
-            packed = struct.pack('HHHH', rows, cols, 0, 0)
+            packed = struct.pack(b'HHHH', rows, cols, 0, 0)
             fcntl.ioctl(self.child_fd, TIOCSWINSZ, packed)
 
         def isalive(self,

--- a/salt/utils/vt.py
+++ b/salt/utils/vt.py
@@ -710,7 +710,7 @@ class Terminal(object):
                 TIOCGWINSZ = getattr(termios, 'TIOCGWINSZ', 1074295912)
                 packed = struct.pack(b'HHHH', 0, 0, 0, 0)
                 ioctl = fcntl.ioctl(sys.stdin.fileno(), TIOCGWINSZ, packed)
-                return struct.unpack('HHHH', ioctl)[0:2]
+                return struct.unpack(b'HHHH', ioctl)[0:2]
             except IOError:
                 # Return a default value of 24x80
                 return 24, 80
@@ -733,7 +733,7 @@ class Terminal(object):
             TIOCGWINSZ = getattr(termios, 'TIOCGWINSZ', 1074295912)
             packed = struct.pack(b'HHHH', 0, 0, 0, 0)
             ioctl = fcntl.ioctl(self.child_fd, TIOCGWINSZ, packed)
-            return struct.unpack('HHHH', ioctl)[0:2]
+            return struct.unpack(b'HHHH', ioctl)[0:2]
 
         def setwinsize(self, rows, cols):
             '''

--- a/salt/utils/vt.py
+++ b/salt/utils/vt.py
@@ -708,7 +708,7 @@ class Terminal(object):
         def __detect_parent_terminal_size(self):
             try:
                 TIOCGWINSZ = getattr(termios, 'TIOCGWINSZ', 1074295912)
-                packed = struct.pack('HHHH', 0, 0, 0, 0)
+                packed = struct.pack(str('HHHH'), 0, 0, 0, 0)  # future lint: blacklisted-function
                 ioctl = fcntl.ioctl(sys.stdin.fileno(), TIOCGWINSZ, packed)
                 return struct.unpack('HHHH', ioctl)[0:2]
             except IOError:


### PR DESCRIPTION
### What does this PR do?
Fixing code in salt/utils/vt.py

### What issues does this PR fix or reference?
https://github.com/saltstack/salt-jenkins/issues/806

### Previous Behavior
Test failed on CentOS 7

### New Behavior
Test passes.

### Tests written?
No, but existing tests pass as expected.

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
