### PR TITLE
Python 3 comptibility fixes

### DIFF
--- a/salt/modules/tls.py
+++ b/salt/modules/tls.py
@@ -228,11 +228,10 @@ def _new_serial(ca_name):
     '''
     hashnum = int(
         binascii.hexlify(
-            salt.utils.stringutils.to_bytes(
-                '{0}_{1}'.format(
-                    _microtime(),
-                    os.urandom(5).encode('hex'))
-            )
+            b'_'.join((
+                salt.utils.stringutils.to_bytes(_microtime()),
+                os.urandom(5) if six.PY3 else os.urandom(5).encode('hex')
+            ))
         ),
         16
     )
@@ -1020,15 +1019,15 @@ def create_csr(ca_name,
         extension_adds = []
 
         for ext, value in extensions.items():
-            if six.PY3:
-                ext = salt.utils.stringutils.to_bytes(ext)
-                if isinstance(value, six.string_types):
-                    value = salt.utils.stringutils.to_bytes(value)
+            if isinstance(value, six.string_types):
+                value = salt.utils.stringutils.to_bytes(value)
             extension_adds.append(
                 OpenSSL.crypto.X509Extension(
-                    salt.utils.stringutils.to_str(ext),
+                    salt.utils.stringutils.to_bytes(ext),
                     False,
-                    salt.utils.stringutils.to_str(value)))
+                    value
+                )
+            )
     except AssertionError as err:
         log.error(err)
         extensions = []

--- a/tests/unit/states/test_network.py
+++ b/tests/unit/states/test_network.py
@@ -118,13 +118,6 @@ class NetworkTestCase(TestCase, LoaderModuleMockMixin):
                                                                          False),
                                                          ret)
 
-                    ret.update({'changes': {'interface':
-                                            '--- \n+++ \n@@ -1 +1 @@\n-A\n+B'},
-                                'result': False,
-                                'comment': u"u'ip.down'"})
-                    log.debug('=== ret %s ===', ret)
-                    self.assertDictEqual(network.managed('salt', 'stack'), ret)
-
     def test_routes(self):
         '''
             Test to manage network interface static routes.

--- a/tests/unit/states/test_win_dns_client.py
+++ b/tests/unit/states/test_win_dns_client.py
@@ -46,7 +46,7 @@ class WinDnsClientTestCase(TestCase, LoaderModuleMockMixin):
             mock = MagicMock(return_value=[2, 'salt'])
             with patch.dict(win_dns_client.__salt__,
                             {'win_dns_client.get_dns_servers': mock}):
-                ret.update({'changes': {}, 'comment': "[2, u'salt'] are already"
+                ret.update({'changes': {}, 'comment': repr([2, 'salt']) + " are already"
                             " configured", 'result': True})
                 self.assertDictEqual(win_dns_client.dns_exists('salt',
                                                                [2, 'salt']),


### PR DESCRIPTION
This fixes the following failures:

- unit.modules.test_tls.TLSAddTestCase.test_create_ca
- unit.modules.test_tls.TLSAddTestCase.test_create_ca_signed_cert
- unit.modules.test_tls.TLSAddTestCase.test_create_csr
- unit.modules.test_tls.TLSAddTestCase.test_create_pkcs12
- unit.modules.test_tls.TLSAddTestCase.test_create_self_signed_cert
- unit.modules.test_tls.TLSAddTestCase.test_pyOpenSSL_version_destructive
- unit.modules.test_tls.TLSAddTestCase.test_recreate_ca
- unit.modules.test_tls.TLSAddTestCase.test_recreate_ca_signed_cert
- unit.modules.test_tls.TLSAddTestCase.test_recreate_csr
- unit.modules.test_tls.TLSAddTestCase.test_recreate_pkcs12
- unit.modules.test_tls.TLSAddTestCase.test_recreate_self_signed_cert
- unit.states.test_network.NetworkTestCase.test_managed
- unit.states.test_win_dns_client.WinDnsClientTestCase.test_dns_exists

Fixes https://github.com/saltstack/salt-jenkins/issues/809