### PR TITLE
Use bytestrings for struct.pack/unpack

### DIFF
--- a/salt/modules/omapi.py
+++ b/salt/modules/omapi.py
@@ -70,10 +70,10 @@ def add_host(mac, name=None, ip=None, ddns=False, group=None,
     statements = ''
     o = _conn()
     msg = omapi.OmapiMessage.open(b'host')
-    msg.message.append(('create', struct.pack('!I', 1)))
-    msg.message.append(('exclusive', struct.pack('!I', 1)))
+    msg.message.append(('create', struct.pack(b'!I', 1)))
+    msg.message.append(('exclusive', struct.pack(b'!I', 1)))
     msg.obj.append(('hardware-address', omapi.pack_mac(mac)))
-    msg.obj.append(('hardware-type', struct.pack('!I', 1)))
+    msg.obj.append(('hardware-type', struct.pack(b'!I', 1)))
     if ip:
         msg.obj.append(('ip-address', omapi.pack_ip(ip)))
     if name:
@@ -109,7 +109,7 @@ def delete_host(mac=None, name=None):
     msg = omapi.OmapiMessage.open(b'host')
     if mac:
         msg.obj.append(('hardware-address', omapi.pack_mac(mac)))
-        msg.obj.append(('hardware-type', struct.pack('!I', 1)))
+        msg.obj.append(('hardware-type', struct.pack(b'!I', 1)))
     if name:
         msg.obj.append(('name', name))
     response = o.query_server(msg)

--- a/salt/modules/win_lgpo.py
+++ b/salt/modules/win_lgpo.py
@@ -3158,10 +3158,10 @@ def _getDataFromRegPolData(search_string, policy_data, return_value_name=False):
                     if vtype == 'REG_DWORD' or vtype == 'REG_QWORD':
                         if value:
                             if vtype == 'REG_DWORD':
-                                for v in struct.unpack('I', value):
+                                for v in struct.unpack(b'I', value):
                                     value = v
                             elif vtype == 'REG_QWORD':
-                                for v in struct.unpack('Q', value):
+                                for v in struct.unpack(b'Q', value):
                                     value = v
                         else:
                             value = 0
@@ -3292,9 +3292,9 @@ def _buildKnownDataSearchString(reg_key, reg_valueName, reg_vtype, reg_data,
         reg_valueName = reg_valueName.encode('utf-16-le')
     if reg_data and not check_deleted:
         if reg_vtype == 'REG_DWORD':
-            this_element_value = struct.pack('I', int(reg_data))
+            this_element_value = struct.pack(b'I', int(reg_data))
         elif reg_vtype == "REG_QWORD":
-            this_element_value = struct.pack('Q', int(reg_data))
+            this_element_value = struct.pack(b'Q', int(reg_data))
         elif reg_vtype == 'REG_SZ':
             this_element_value = b''.join([reg_data.encode('utf-16-le'),
                                            encoded_null])
@@ -3365,7 +3365,7 @@ def _processValueItem(element, reg_key, reg_valuename, policy, parent_element,
     if etree.QName(element).localname == 'decimal' and etree.QName(parent_element).localname != 'elements':
         this_vtype = 'REG_DWORD'
         if 'value' in element.attrib:
-            this_element_value = struct.pack('I', int(element.attrib['value']))
+            this_element_value = struct.pack(b'I', int(element.attrib['value']))
         else:
             log.error('The %s child %s element for the policy with '
                       'attributes: %s does not have the required "value" '
@@ -3380,7 +3380,7 @@ def _processValueItem(element, reg_key, reg_valuename, policy, parent_element,
         # server, so untested/assumed
         this_vtype = 'REG_QWORD'
         if 'value' in element.attrib:
-            this_element_value = struct.pack('Q', int(element.attrib['value']))
+            this_element_value = struct.pack(b'Q', int(element.attrib['value']))
         else:
             log.error('The %s child %s element for the policy with '
                       'attributes: %s does not have the required "value" '
@@ -3411,7 +3411,7 @@ def _processValueItem(element, reg_key, reg_valuename, policy, parent_element,
             this_vtype = 'REG_DWORD'
             requested_val = this_element_value
             if this_element_value is not None:
-                this_element_value = struct.pack('I', int(this_element_value))
+                this_element_value = struct.pack(b'I', int(this_element_value))
             if 'storeAsText' in element.attrib:
                 if element.attrib['storeAsText'].lower() == 'true':
                     this_vtype = 'REG_SZ'
@@ -3424,7 +3424,7 @@ def _processValueItem(element, reg_key, reg_valuename, policy, parent_element,
             this_vtype = 'REG_QWORD'
             requested_val = this_element_value
             if this_element_value is not None:
-                this_element_value = struct.pack('Q', int(this_element_value))
+                this_element_value = struct.pack(b'Q', int(this_element_value))
             if 'storeAsText' in element.attrib:
                 if element.attrib['storeAsText'].lower() == 'true':
                     this_vtype = 'REG_SZ'
@@ -4207,12 +4207,12 @@ def _write_regpol_data(data_to_write,
                                         re.IGNORECASE | re.MULTILINE)
                 version_str = gpt_ini_data[version_loc.start():version_loc.end()]
                 version_str = version_str.split('=')
-                version_nums = struct.unpack('>2H', struct.pack('>I', int(version_str[1])))
+                version_nums = struct.unpack(b'>2H', struct.pack(b'>I', int(version_str[1])))
                 if gpt_extension.lower() == 'gPCMachineExtensionNames'.lower():
                     version_nums = (version_nums[0], version_nums[1] + 1)
                 elif gpt_extension.lower() == 'gPCUserExtensionNames'.lower():
                     version_nums = (version_nums[0] + 1, version_nums[1])
-                version_num = struct.unpack('>I', struct.pack('>2H', *version_nums))[0]
+                version_num = struct.unpack(b'>I', struct.pack(b'>2H', *version_nums))[0]
                 gpt_ini_data = "{0}{1}={2}\r\n{3}".format(
                         gpt_ini_data[0:version_loc.start()],
                         'Version', version_num,

--- a/salt/returners/carbon_return.py
+++ b/salt/returners/carbon_return.py
@@ -166,7 +166,7 @@ def _send_picklemetrics(metrics):
                for (metric_name, value, timestamp) in metrics]
 
     data = cPickle.dumps(metrics, -1)
-    payload = struct.pack('!L', len(data)) + data
+    payload = struct.pack(b'!L', len(data)) + data
 
     return payload
 

--- a/tests/support/ext/console.py
+++ b/tests/support/ext/console.py
@@ -51,7 +51,7 @@ def _getTerminalSize_windows():
     if res:
         (bufx, bufy, curx, cury, wattr,
          left, top, right, bottom, maxx, maxy) = struct.unpack(
-             'hhhhHhhhhhh', csbi.raw)
+             b'hhhhHhhhhhh', csbi.raw)
         sizex = right - left + 1
         sizey = bottom - top + 1
         return sizex, sizey
@@ -82,7 +82,7 @@ def _getTerminalSize_linux():
     def ioctl_GWINSZ(fd):
         try:
             cr = struct.unpack(
-                'hh', fcntl.ioctl(fd, termios.TIOCGWINSZ, '1234')
+                b'hh', fcntl.ioctl(fd, termios.TIOCGWINSZ, '1234')
             )
         except Exception:
             return None


### PR DESCRIPTION
https://github.com/saltstack/salt/pull/45687 and https://github.com/saltstack/salt/pull/45725 fixed problems with older Python 2 versions interacting with the struct module, since unicode_literals turned the format strings to unicode and older Python 2 releases can't accept a unicode format string. Since Python 2 and 3 both support using bytestrings for the format strings, this commit makes sure we are using bytestrings everywhere else we are using struct.pack/unpack.