### PR TITLE
Fix traceback in CLI output when value is trimmed

### DIFF
--- a/salt/cli/salt.py
+++ b/salt/cli/salt.py
@@ -406,7 +406,7 @@ class SaltCMD(parsers.SaltCMDOptionParser):
         for host in ret:
             if isinstance(ret[host], string_types) \
                     and (ret[host].startswith("Minion did not return")
-                         or ret[host] == 'VALUE TRIMMED'):
+                         or ret[host] == 'VALUE_TRIMMED'):
                 continue
             for fun in ret[host]:
                 if fun not in docs and ret[host][fun]:


### PR DESCRIPTION
The comparison here was looking for the wrong string, causing the
trimmed value not to be detected and leading to a traceback several
lines later.