### PR TITLE
Squelch pyVmomi error in __virtual__ functions

### DIFF
--- a/salt/modules/vsphere.py
+++ b/salt/modules/vsphere.py
@@ -211,7 +211,7 @@ try:
     if 'vim25/6.0' in VmomiSupport.versionMap and \
         sys.version_info > (2, 7) and sys.version_info < (2, 7, 9):
 
-        log.error('pyVmomi not loaded: Incompatible versions '
+        log.debug('pyVmomi not loaded: Incompatible versions '
                   'of Python. See Issue #29537.')
         raise ImportError()
     HAS_PYVMOMI = True

--- a/salt/states/esxi.py
+++ b/salt/states/esxi.py
@@ -124,7 +124,7 @@ try:
     if 'vim25/6.0' in VmomiSupport.versionMap and \
         sys.version_info > (2, 7) and sys.version_info < (2, 7, 9):
 
-        log.error('pyVmomi not loaded: Incompatible versions '
+        log.debug('pyVmomi not loaded: Incompatible versions '
                   'of Python. See Issue #29537.')
         raise ImportError()
     HAS_PYVMOMI = True


### PR DESCRIPTION
Logging an error in the `__virtual__` causes an error to be logged EVERY TIME it
is executed, which results in a lot of unnecessary logging.

This reduces the log level to debug for these messages.