### PR TITLE
list.copy() is not compatible with python 2.7

### DIFF
--- a/salt/cloud/__init__.py
+++ b/salt/cloud/__init__.py
@@ -240,7 +240,7 @@ class CloudClient(object):
                          if a.get('provider', '')]
             if providers:
                 _providers = opts.get('providers', {})
-                for provider in list(_providers).copy():
+                for provider in list(_providers)[:]:
                     if provider not in providers:
                         _providers.pop(provider)
         return opts

--- a/salt/cloud/__init__.py
+++ b/salt/cloud/__init__.py
@@ -240,7 +240,7 @@ class CloudClient(object):
                          if a.get('provider', '')]
             if providers:
                 _providers = opts.get('providers', {})
-                for provider in list(_providers)[:]:
+                for provider in _providers.copy():
                     if provider not in providers:
                         _providers.pop(provider)
         return opts


### PR DESCRIPTION
### What does this PR do?

I doubt that a .copy() is required there since list() would already create one but since the previous committer added it I am improving by replacing the .copy() with a [:] which makes a copy in python 2.7 and 3+

### What issues does this PR fix or reference?

```
An exception occurred in this state: Traceback (most recent call last):
                File "/usr/lib/python2.7/dist-packages/salt/state.py", line 1934, in call
                  **cdata['kwargs'])
                File "/usr/lib/python2.7/dist-packages/salt/loader.py", line 1799, in wrapper
                  return f(*args, **kwargs)
                File "/usr/lib/python2.7/dist-packages/salt/states/cloud.py", line 277, in profile
                  info = __salt__['cloud.profile'](profile, name, vm_overrides=kwargs, opts=opts)
                File "/usr/lib/python2.7/dist-packages/salt/modules/cloud.py", line 199, in profile_
                  info = client.profile(profile, names, vm_overrides=vm_overrides, **kwargs)
                File "/usr/lib/python2.7/dist-packages/salt/cloud/__init__.py", line 345, in profile
                  mapper = salt.cloud.Map(self._opts_defaults(**kwargs))
                File "/usr/lib/python2.7/dist-packages/salt/cloud/__init__.py", line 237, in _opts_defaults
                  for provider in list(_providers)[:]:
              AttributeError: 'list' object has no attribute 'copy'
```

### Tests written?

No

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
