### PR TITLE
fix for UnicodeEncodeError on debconf.get_selections

### DIFF
--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -609,7 +609,7 @@ def _run(cmd,
             out = ''
         except UnicodeDecodeError:
             log.error('UnicodeDecodeError while decoding output of cmd {0}'.format(cmd))
-            out = proc.stdout.decode(__salt_system_encoding__, 'replace')
+            out = proc.stdout.decode(__salt_system_encoding__, 'ignore')
 
         try:
             err = proc.stderr.decode(__salt_system_encoding__)
@@ -617,7 +617,7 @@ def _run(cmd,
             err = ''
         except UnicodeDecodeError:
             log.error('UnicodeDecodeError while decoding error of cmd {0}'.format(cmd))
-            err = proc.stderr.decode(__salt_system_encoding__, 'replace')
+            err = proc.stderr.decode(__salt_system_encoding__, 'ignore')
 
         if rstrip:
             if out is not None:


### PR DESCRIPTION
### What does this PR do?

Ignore non ascii characters in cmd output and error

### What issues does this PR fix or reference?

Fix for `UnicodeEncodeError: 'ascii' codec can't encode characters in position 12839-12840: ordinal not in range(128)` when calling the `debconf.get_selections` module

### Tests written?

No

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
