### PR TITLE
The `zypper.mod_repo`: fix typo in the docstring

### DIFF
--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -734,17 +734,17 @@ def mod_repo(repo, **kwargs):
         the URL for zypper to reference
 
     enabled
-        enable or disable (True or False) repository,
+        Enable or disable (True or False) repository,
         but do not remove if disabled.
 
     refresh
-        enable or disable (True or False) auto-refresh of the repository.
+        Enable or disable (True or False) auto-refresh of the repository.
 
     cache
         Enable or disable (True or False) RPM files caching.
 
     gpgcheck
-        Enable or disable (True or False) GOG check for this repository.
+        Enable or disable (True or False) GPG check for this repository.
 
     gpgautoimport
         Automatically trust and import new repository.


### PR DESCRIPTION
### What does this PR do?
Replaces `GOG` with `GPG`.

### Commits signed with GPG?
Yes
