### PR TITLE
runtests.py: allow user to set optparse options in REPL

### DIFF
--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -811,7 +811,7 @@ class SaltTestsuiteParser(SaltCoverageTestingParser):
         return status
 
 
-def main():
+def main(**kwargs):
     '''
     Parse command line options for running specific tests
     '''
@@ -822,6 +822,12 @@ def main():
             tests_logfile=os.path.join(SYS_TMP_DIR, 'salt-runtests.log')
         )
         parser.parse_args()
+
+        # Override parser options (helpful when importing runtests.py and
+        # running from within a REPL). Using kwargs.items() to avoid importing
+        # six, as this feature will rarely be used.
+        for key, val in kwargs.items():
+            setattr(parser.options, key, val)
 
         overall_status = []
         if parser.options.interactive:


### PR DESCRIPTION
This allows for the options set by optparse to be passed to main() as kwargs, so that the test suite can be run from within a REPL.

```python
>>> import runtests
>>> try:
...     runtests.main(ssh=True, verbosity=2, coverage_xml='/tmp/coverage.xml', xml='/tmp/xml-unittests-output', run_destructive=True, output_columns=80, sysinfo=True)
... except SystemExit:
...     pass
...
>>>
```