### PR TITLE
generate a jid for cache_jobs on the minion

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1761,7 +1761,9 @@ class Minion(MinionBase):
                     load['out'] = oput
         if self.opts['cache_jobs']:
             # Local job cache has been enabled
-            salt.utils.minion.cache_jobs(self.opts, load['jid'], ret)
+            if ret['jid'] == 'req':
+                ret['jid'] = salt.utils.jid.gen_jid()
+            salt.utils.minion.cache_jobs(self.opts, ret['jid'], ret)
 
         if not self.opts['pub_ret']:
             return ''


### PR DESCRIPTION
### What does this PR do?
If the load is passed back to the master with a jid of 'req', the master does a
'prep_jid' and uses that jid to store the data.  The minion would just save it
to the cache as 'req'.

This will at least generate the jid for the minions cache.

### What issues does this PR fix or reference?
Fixes #45738 

### Tests written?

No

### Commits signed with GPG?

Yes