### PR TITLE
Fix rehash function in win_path.py

### DIFF
--- a/salt/modules/reg.py
+++ b/salt/modules/reg.py
@@ -38,7 +38,6 @@ from salt.ext.six.moves import range  # pylint: disable=W0622,import-error
 
 # Import third party libs
 try:
-    import win32gui
     import win32api
     import win32con
     import pywintypes
@@ -48,6 +47,7 @@ except ImportError:
 
 # Import salt libs
 import salt.utils
+import salt.utils.win_functions
 from salt.exceptions import CommandExecutionError
 
 PY2 = sys.version_info[0] == 2
@@ -68,7 +68,7 @@ def __virtual__():
     if not HAS_WINDOWS_MODULES:
         return (False, 'reg execution module failed to load: '
                        'One of the following libraries did not load: '
-                       + 'win32gui, win32con, win32api')
+                       'win32con, win32api, pywintypes')
 
     return __virtualname__
 
@@ -193,11 +193,7 @@ def broadcast_change():
 
         salt '*' reg.broadcast_change
     '''
-    # https://msdn.microsoft.com/en-us/library/windows/desktop/ms644952(v=vs.85).aspx
-    _, res = win32gui.SendMessageTimeout(
-        win32con.HWND_BROADCAST, win32con.WM_SETTINGCHANGE, 0, 0,
-        win32con.SMTO_ABORTIFHUNG, 5000)
-    return not bool(res)
+    return salt.utils.win_functions.refresh_environment()
 
 
 def list_keys(hive, key=None, use_32bit_registry=False):

--- a/salt/modules/reg.py
+++ b/salt/modules/reg.py
@@ -29,8 +29,8 @@ Values/Entries are name/data pairs. There can be many values in a key. The
 # When production windows installer is using Python 3, Python 2 code can be removed
 
 # Import _future_ python libs first & before any other code
-from __future__ import absolute_import
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
+
 # Import python libs
 import sys
 import logging
@@ -193,7 +193,7 @@ def broadcast_change():
 
         salt '*' reg.broadcast_change
     '''
-    return salt.utils.win_functions.refresh_environment()
+    return salt.utils.win_functions.broadcast_setting_change('Environment')
 
 
 def list_keys(hive, key=None, use_32bit_registry=False):

--- a/salt/modules/win_path.py
+++ b/salt/modules/win_path.py
@@ -12,18 +12,17 @@ from __future__ import absolute_import
 import logging
 import re
 import os
-import ctypes
 from salt.ext.six.moves import map
 
 # Third party libs
 try:
-    from win32con import HWND_BROADCAST, WM_SETTINGCHANGE, SMTO_ABORTIFHUNG
     HAS_WIN32 = True
 except ImportError:
     HAS_WIN32 = False
 
 # Import salt libs
 import salt.utils
+import salt.utils.win_functions
 
 # Settings
 log = logging.getLogger(__name__)
@@ -63,12 +62,7 @@ def rehash():
 
         salt '*' win_path.rehash
     '''
-    broadcast_message = ctypes.create_unicode_buffer('Environment')
-    user32 = ctypes.windll('user32', use_last_error=True)
-    result = user32.SendMessageTimeoutW(HWND_BROADCAST, WM_SETTINGCHANGE, 0,
-                                        broadcast_message, SMTO_ABORTIFHUNG,
-                                        5000, 0)
-    return result == 1
+    return salt.utils.win_functions.refresh_environment()
 
 
 def get_path():

--- a/salt/modules/win_path.py
+++ b/salt/modules/win_path.py
@@ -54,7 +54,7 @@ def rehash():
         apply changes to the path to services, the host must be restarted. The
         ``salt-minion``, if running as a service, will not see changes to the
         environment until the system is restarted. See
-        `MSDN Documentation <https://support.microsoft.com/en-us/help/821761/changes-that-you-make-to-environment-variables-do-not-affect-services>`
+        `MSDN Documentation <https://support.microsoft.com/en-us/help/821761/changes-that-you-make-to-environment-variables-do-not-affect-services>`_
 
     CLI Example:
 

--- a/salt/modules/win_path.py
+++ b/salt/modules/win_path.py
@@ -62,7 +62,7 @@ def rehash():
 
         salt '*' win_path.rehash
     '''
-    return salt.utils.win_functions.refresh_environment()
+    return salt.utils.win_functions.broadcast_setting_change('Environment')
 
 
 def get_path():

--- a/salt/utils/win_functions.py
+++ b/salt/utils/win_functions.py
@@ -231,8 +231,6 @@ def broadcast_setting_change(message='Environment'):
             - a leaf node in the registry
             - the name of a section in the ``Win.ini`` file
 
-            `See here <https://msdn.microsoft.com/en-us/library/ms725497%28VS.85%29.aspx>`
-
             See lParam within msdn docs for
             `WM_SETTINGCHANGE <https://msdn.microsoft.com/en-us/library/ms725497%28VS.85%29.aspx>`
             for more information on Broadcasting Messages.

--- a/salt/utils/win_functions.py
+++ b/salt/utils/win_functions.py
@@ -233,12 +233,23 @@ def broadcast_setting_change(message='Environment'):
 
             `See here <https://msdn.microsoft.com/en-us/library/ms725497%28VS.85%29.aspx>`
 
+            See lParam within msdn docs for
+            `WM_SETTINGCHANGE <https://msdn.microsoft.com/en-us/library/ms725497%28VS.85%29.aspx>`
+            for more information on Broadcasting Messages.
+
+            See GWL_WNDPROC within msdn docs for
+            `SetWindowLong <https://msdn.microsoft.com/en-us/library/windows/desktop/ms633591(v=vs.85).aspx>`
+            for information on how to retrieve those messages.
+
     .. note::
         This will only affect new processes that aren't launched by services. To
         apply changes to the path or registry to services, the host must be
         restarted. The ``salt-minion``, if running as a service, will not see
-        changes to the environment until the system is restarted. See
+        changes to the environment until the system is restarted. Services
+        inherit their environment from ``services.exe`` which does not respond
+        to messaging events. See
         `MSDN Documentation <https://support.microsoft.com/en-us/help/821761/changes-that-you-make-to-environment-variables-do-not-affect-services>`
+        for more information.
 
     CLI Example:
 

--- a/salt/utils/win_functions.py
+++ b/salt/utils/win_functions.py
@@ -232,11 +232,11 @@ def broadcast_setting_change(message='Environment'):
             - the name of a section in the ``Win.ini`` file
 
             See lParam within msdn docs for
-            `WM_SETTINGCHANGE <https://msdn.microsoft.com/en-us/library/ms725497%28VS.85%29.aspx>`
+            `WM_SETTINGCHANGE <https://msdn.microsoft.com/en-us/library/ms725497%28VS.85%29.aspx>`_
             for more information on Broadcasting Messages.
 
             See GWL_WNDPROC within msdn docs for
-            `SetWindowLong <https://msdn.microsoft.com/en-us/library/windows/desktop/ms633591(v=vs.85).aspx>`
+            `SetWindowLong <https://msdn.microsoft.com/en-us/library/windows/desktop/ms633591(v=vs.85).aspx>`_
             for information on how to retrieve those messages.
 
     .. note::
@@ -246,7 +246,7 @@ def broadcast_setting_change(message='Environment'):
         changes to the environment until the system is restarted. Services
         inherit their environment from ``services.exe`` which does not respond
         to messaging events. See
-        `MSDN Documentation <https://support.microsoft.com/en-us/help/821761/changes-that-you-make-to-environment-variables-do-not-affect-services>`
+        `MSDN Documentation <https://support.microsoft.com/en-us/help/821761/changes-that-you-make-to-environment-variables-do-not-affect-services>`_
         for more information.
 
     CLI Example:
@@ -257,7 +257,7 @@ def broadcast_setting_change(message='Environment'):
         salt.utils.win_functions.broadcast_setting_change('Environment')
     '''
     # Listen for messages sent by this would involve working with the
-    # SetWindowLong function. This can be accessed via the win32gui or through
+    # SetWindowLong function. This can be accessed via win32gui or through
     # ctypes. You can find examples on how to do this by searching for
     # `Accessing WGL_WNDPROC` on the internet. Here are some examples of how
     # this might work:

--- a/salt/utils/win_functions.py
+++ b/salt/utils/win_functions.py
@@ -214,13 +214,13 @@ def escape_for_cmd_exe(arg):
     return meta_re.sub(escape_meta_chars, arg)
 
 
-def broadcast_setting_change(setting='Environment'):
+def broadcast_setting_change(message='Environment'):
     '''
     Send a WM_SETTINGCHANGE Broadcast to all Windows
 
     Args:
 
-        setting (str):
+        message (str):
             A string value representing the portion of the system that has been
             updated and needs to be refreshed. Default is ``Environment``. These
             are some common values:
@@ -247,7 +247,7 @@ def broadcast_setting_change(setting='Environment'):
         import salt.utils.win_functions
         salt.utils.win_functions.refresh_environment()
     '''
-    broadcast_message = ctypes.create_unicode_buffer(setting)
+    broadcast_message = ctypes.create_unicode_buffer(message)
     user32 = ctypes.WinDLL('user32', use_last_error=True)
     result = user32.SendMessageTimeoutW(HWND_BROADCAST, WM_SETTINGCHANGE, 0,
                                         broadcast_message, SMTO_ABORTIFHUNG,

--- a/salt/utils/win_functions.py
+++ b/salt/utils/win_functions.py
@@ -254,7 +254,7 @@ def broadcast_setting_change(message='Environment'):
     ... code-block:: python
 
         import salt.utils.win_functions
-        salt.utils.win_functions.refresh_environment()
+        salt.utils.win_functions.broadcast_setting_change('Environment')
     '''
     # Listen for messages sent by this would involve working with the
     # SetWindowLong function. This can be accessed via the win32gui or through

--- a/salt/utils/win_functions.py
+++ b/salt/utils/win_functions.py
@@ -258,6 +258,25 @@ def broadcast_setting_change(message='Environment'):
         import salt.utils.win_functions
         salt.utils.win_functions.refresh_environment()
     '''
+    # Listen for messages sent by this would involve working with the
+    # SetWindowLong function. This can be accessed via the win32gui or through
+    # ctypes. You can find examples on how to do this by searching for
+    # `Accessing WGL_WNDPROC` on the internet. Here are some examples of how
+    # this might work:
+    #
+    # # using win32gui
+    # import win32con
+    # import win32gui
+    # old_function = win32gui.SetWindowLong(window_handle, win32con.GWL_WNDPROC, new_function)
+    #
+    # # using ctypes
+    # import ctypes
+    # import win32con
+    # from ctypes import c_long, c_int
+    # user32 = ctypes.WinDLL('user32', use_last_error=True)
+    # WndProcType = ctypes.WINFUNCTYPE(c_int, c_long, c_int, c_int)
+    # new_function = WndProcType
+    # old_function = user32.SetWindowLongW(window_handle, win32con.GWL_WNDPROC, new_function)
     broadcast_message = ctypes.create_unicode_buffer(message)
     user32 = ctypes.WinDLL('user32', use_last_error=True)
     result = user32.SendMessageTimeoutW(HWND_BROADCAST, WM_SETTINGCHANGE, 0,

--- a/tests/unit/modules/test_win_path.py
+++ b/tests/unit/modules/test_win_path.py
@@ -20,49 +20,13 @@ from tests.support.mock import (
 import salt.modules.win_path as win_path
 
 
-class MockWin32API(object):
-    '''
-        Mock class for win32api
-    '''
-    def __init__(self):
-        pass
-
-    @staticmethod
-    def SendMessage(*args):
-        '''
-            Mock method for SendMessage
-        '''
-        return [args[0]]
-
-
-class MockWin32Con(object):
-    '''
-        Mock class for win32con
-    '''
-    HWND_BROADCAST = 1
-    WM_SETTINGCHANGE = 1
-
-    def __init__(self):
-        pass
-
-
 @skipIf(NO_MOCK, NO_MOCK_REASON)
 class WinPathTestCase(TestCase, LoaderModuleMockMixin):
     '''
         Test cases for salt.modules.win_path
     '''
     def setup_loader_modules(self):
-        return {win_path: {'win32api': MockWin32API,
-                           'win32con': MockWin32Con,
-                           'SendMessage': MagicMock,
-                           'HWND_BROADCAST': MagicMock,
-                           'WM_SETTINGCHANGE': MagicMock}}
-
-    def test_rehash(self):
-        '''
-            Test to rehash the Environment variables
-        '''
-        self.assertTrue(win_path.rehash())
+        return {win_path: {}}
 
     def test_get_path(self):
         '''

--- a/tests/unit/utils/test_win_functions.py
+++ b/tests/unit/utils/test_win_functions.py
@@ -12,6 +12,7 @@ from tests.support.mock import (
 
 # Import Salt Libs
 import salt.utils.win_functions as win_functions
+import salt.utils
 
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
@@ -51,3 +52,10 @@ class WinFunctionsTestCase(TestCase):
         encoded = win_functions.escape_argument('C:\\Some Path\\With Spaces')
 
         self.assertEqual(encoded, '^"C:\\Some Path\\With Spaces^"')
+
+    @skipIf(not salt.utils.is_windows(), 'WinDLL only available on Windows')
+    def test_broadcast_setting_change(self):
+        '''
+            Test to rehash the Environment variables
+        '''
+        self.assertTrue(win_functions.broadcast_setting_change())


### PR DESCRIPTION
### What does this PR do?
Uses `SendMessageTimeout` instead of `SendMessage` to broadcast an environment change. `SendMessage` was causing the system to hang in some scenarios where an open windows wasn't responding to the `SendMessage`.
Use `ctypes` to access the `user32.dll` directly instead of using pywin32 as this seems to actually work. `win32gui.SendMessageTimeout` would complete successfully but new windows would not reflect the path change.

### What issues does this PR fix or reference?
Found the hanging issue while testing: https://github.com/saltstack/salt/pull/45703#issuecomment-361013728

### Previous Behavior
Sometimes a `win_path.add` or `win_path.remove` would fail

### New Behavior
The refresh will time out after 5 seconds if windows aren't responding

### Tests written?
No

### Commits signed with GPG?
Yes