### PR TITLE
support amazon linux 2 for service module

### DIFF
--- a/salt/modules/rh_service.py
+++ b/salt/modules/rh_service.py
@@ -97,6 +97,15 @@ def __virtual__():
                     'RedHat-based distros >= version 7 use systemd, will not '
                     'load rh_service.py as virtual \'service\''
                 )
+        if __grains__['os'] == 'Amazon':
+            if int(osrelease_major) in (2016, 2017):
+                return __virtualname__
+            else:
+                return (
+                    False,
+                    'Amazon Linux >= version 2 use systemd, will not '
+                    'load rh_service.py as virtual \'service\''
+                )
         return __virtualname__
     return (False, 'Cannot load rh_service module: OS not in {0}'.format(enable))
 

--- a/salt/modules/rh_service.py
+++ b/salt/modules/rh_service.py
@@ -103,7 +103,7 @@ def __virtual__():
             else:
                 return (
                     False,
-                    'Amazon Linux >= version 2 use systemd, will not '
+                    'Amazon Linux >= version 2 uses systemd. Will not '
                     'load rh_service.py as virtual \'service\''
                 )
         return __virtualname__


### PR DESCRIPTION
### What does this PR do?
Same as #45758, but for the 2017.7 branch. Disables rh_service.py on Amazon Linux 2

### Previous Behavior
service.running states ran via rh_service.py rather than systemd and failed. 

### New Behavior
Systemd is used to manage service calls and runs properly.

### Tests written?
No

### Commits signed with GPG?
No