### PR TITLE
[oxygen] fixes to integration.modules.test_pkg.PkgModuleTest.test_pkg_upgrade_has_pending_upgrades

### DIFF
--- a/tests/integration/modules/test_pkg.py
+++ b/tests/integration/modules/test_pkg.py
@@ -308,16 +308,7 @@ class PkgModuleTest(ModuleCase, SaltReturnAssertsMixin):
                 self.skipTest('No updates available for this machine.  Skipping pkg.upgrade test.')
             else:
                 ret = self.run_function(func)
-
-                if 'Problem encountered' in ret:
-                    self.skipTest('A problem was encountered when running pkg.upgrade. This test is '
-                                  'meant to catch no-ops or problems with the salt function itself, '
-                                  'not problems with actual package installation. Skipping.')
-
-                # The changes dictionary should not be empty.
                 self.assertNotEqual(ret, {})
-                if 'changes' in ret:
-                    self.assertNotEqual(ret['changes'], {})
 
     @destructiveTest
     @skipIf(salt.utils.platform.is_windows(), 'minion is windows')


### PR DESCRIPTION
### What does this PR do?
pkg.upgrade does not return errors when something when wrong but raises an exception, so this code is no longer relevant.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt-jenkins/issues/724

### Previous Behavior
The `integration.modules.test_pkg.PkgModuleTest.test_pkg_upgrade_has_pending_upgrades` test is failing on Mac.

### New Behavior
The `integration.modules.test_pkg.PkgModuleTest.test_pkg_upgrade_has_pending_upgrades` will succeed on Mac.

### Tests written?
No.  Updates to existing tests.

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
