### PR TITLE
Add a central function to check for boto lib requirements

### DIFF
--- a/salt/modules/boto3_elasticache.py
+++ b/salt/modules/boto3_elasticache.py
@@ -52,9 +52,11 @@ import logging
 import time
 
 # Import Salt libs
+from salt.exceptions import SaltInvocationError, CommandExecutionError
 import salt.utils.boto3
 import salt.utils.compat
-from salt.exceptions import SaltInvocationError, CommandExecutionError
+import salt.utils.versions
+
 
 log = logging.getLogger(__name__)
 
@@ -75,9 +77,7 @@ def __virtual__():
     Only load if boto libraries exist and if boto libraries are greater than
     a given version.
     '''
-    if not HAS_BOTO3:
-        return (False, 'The boto3_elasticache module could not be loaded: boto3 libraries not found')
-    return True
+    return salt.utils.versions.check_boto_reqs()
 
 
 def __init__(opts):

--- a/salt/modules/boto3_route53.py
+++ b/salt/modules/boto3_route53.py
@@ -56,6 +56,7 @@ import time
 # Import Salt libs
 import salt.utils.boto3
 import salt.utils.compat
+import salt.utils.versions
 from salt.exceptions import SaltInvocationError
 log = logging.getLogger(__name__)  # pylint: disable=W1699
 
@@ -76,9 +77,7 @@ def __virtual__():
     Only load if boto libraries exist and if boto libraries are greater than
     a given version.
     '''
-    if not HAS_BOTO3:
-        return (False, 'The boto3_route53 module could not be loaded: boto3 libraries not found')
-    return True
+    return salt.utils.versions.check_boto_reqs()
 
 
 def __init__(opts):

--- a/salt/modules/boto3_sns.py
+++ b/salt/modules/boto3_sns.py
@@ -42,9 +42,12 @@ Connection module for Amazon SNS
 # keep lint from choking on _get_conn and _cache_id
 #pylint: disable=E0602
 
+# Import Python libs
 from __future__ import absolute_import, print_function, unicode_literals
-
 import logging
+
+# Import Salt libs
+import salt.utils.versions
 
 log = logging.getLogger(__name__)
 
@@ -65,10 +68,10 @@ def __virtual__():
     '''
     Only load if boto libraries exist.
     '''
-    if not HAS_BOTO:
-        return (False, 'The boto3_sns module could not be loaded: boto3 libraries not found')
-    __utils__['boto3.assign_funcs'](__name__, 'sns')
-    return True
+    has_boto_reqs = salt.utils.versions.check_boto_reqs()
+    if has_boto_reqs is True:
+        __utils__['boto3.assign_funcs'](__name__, 'sns')
+    return has_boto_reqs
 
 
 def list_topics(region=None, key=None, keyid=None, profile=None):

--- a/salt/modules/boto_apigateway.py
+++ b/salt/modules/boto_apigateway.py
@@ -85,7 +85,7 @@ from salt.ext import six
 import salt.utils.boto3
 import salt.utils.compat
 import salt.utils.json
-from salt.utils.versions import LooseVersion as _LooseVersion
+import salt.utils.versions
 
 log = logging.getLogger(__name__)
 
@@ -112,26 +112,14 @@ def __virtual__():
     Only load if boto libraries exist and if boto libraries are greater than
     a given version.
     '''
-    required_boto_version = '2.8.0'
-    required_boto3_version = '1.2.1'
-    required_botocore_version = '1.4.49'
     # the boto_apigateway execution module relies on the connect_to_region() method
     # which was added in boto 2.8.0
     # https://github.com/boto/boto/commit/33ac26b416fbb48a60602542b4ce15dcc7029f12
-    if not HAS_BOTO:
-        return (False, 'The boto_apigateway module could not be loaded: '
-                'boto libraries not found')
-    elif _LooseVersion(boto.__version__) < _LooseVersion(required_boto_version):
-        return (False, 'The boto_apigateway module could not be loaded: '
-                'boto version {0} or later must be installed.'.format(required_boto_version))
-    elif _LooseVersion(boto3.__version__) < _LooseVersion(required_boto3_version):
-        return (False, 'The boto_apigateway module could not be loaded: '
-                'boto3 version {0} or later must be installed.'.format(required_boto3_version))
-    elif _LooseVersion(found_botocore_version) < _LooseVersion(required_botocore_version):
-        return (False, 'The boto_apigateway module could not be loaded: '
-                'botocore version {0} or later must be installed.'.format(required_botocore_version))
-    else:
-        return True
+    return salt.utils.versions.check_boto_reqs(
+        boto_ver='2.8.0',
+        boto3_ver='1.2.1',
+        botocore_ver='1.4.49'
+    )
 
 
 def __init__(opts):

--- a/salt/modules/boto_asg.py
+++ b/salt/modules/boto_asg.py
@@ -48,7 +48,6 @@ Connection module for Amazon Autoscale Groups
 # Import Python libs
 from __future__ import absolute_import, print_function, unicode_literals
 import datetime
-import time
 import logging
 import sys
 import time
@@ -79,19 +78,19 @@ import salt.utils.boto3
 import salt.utils.compat
 import salt.utils.json
 import salt.utils.odict as odict
+import salt.utils.versions
 
 
 def __virtual__():
     '''
     Only load if boto libraries exist.
     '''
-    if not HAS_BOTO:
-        return (False, 'The boto_asg module could not be loaded: boto libraries not found')
-
-    __utils__['boto.assign_funcs'](__name__, 'asg', module='ec2.autoscale', pack=__salt__)
-    setattr(sys.modules[__name__], '_get_ec2_conn',
-            __utils__['boto.get_connection_func']('ec2'))
-    return True
+    has_boto_reqs = salt.utils.versions.check_boto_reqs()
+    if has_boto_reqs is True:
+        __utils__['boto.assign_funcs'](__name__, 'asg', module='ec2.autoscale', pack=__salt__)
+        setattr(sys.modules[__name__], '_get_ec2_conn',
+                __utils__['boto.get_connection_func']('ec2'))
+    return has_boto_reqs
 
 
 def __init__(opts):

--- a/salt/modules/boto_cfn.py
+++ b/salt/modules/boto_cfn.py
@@ -37,6 +37,9 @@ from __future__ import absolute_import, print_function, unicode_literals
 # Import Python libs
 import logging
 
+# Import Salt libs
+import salt.utils.versions
+
 log = logging.getLogger(__name__)
 
 # Import third party libs
@@ -57,9 +60,7 @@ def __virtual__():
     '''
     Only load if boto libraries exist.
     '''
-    if not HAS_BOTO:
-        return (False, 'The module boto_cfs could not be loaded: boto libraries not found')
-    return True
+    return salt.utils.versions.check_boto_reqs(check_boto3=False)
 
 
 def __init__(opts):

--- a/salt/modules/boto_cloudfront.py
+++ b/salt/modules/boto_cloudfront.py
@@ -57,6 +57,7 @@ import logging
 # Import Salt libs
 import salt.ext.six as six
 from salt.utils.odict import OrderedDict
+import salt.utils.versions
 
 # Import third party libs
 try:
@@ -76,11 +77,10 @@ def __virtual__():
     '''
     Only load if boto3 libraries exist.
     '''
-    if not HAS_BOTO:
-        msg = 'The boto_cloudfront module could not be loaded: {}.'
-        return (False, msg.format('boto3 libraries not found'))
-    __utils__['boto3.assign_funcs'](__name__, 'cloudfront')
-    return True
+    has_boto_reqs = salt.utils.versions.check_boto_reqs()
+    if has_boto_reqs is True:
+        __utils__['boto3.assign_funcs'](__name__, 'cloudfront')
+    return has_boto_reqs
 
 
 def _list_distributions(

--- a/salt/modules/boto_cloudtrail.py
+++ b/salt/modules/boto_cloudtrail.py
@@ -57,7 +57,7 @@ import logging
 from salt.ext import six
 import salt.utils.boto3
 import salt.utils.compat
-from salt.utils.versions import LooseVersion as _LooseVersion
+import salt.utils.versions
 
 log = logging.getLogger(__name__)
 
@@ -82,17 +82,12 @@ def __virtual__():
     Only load if boto libraries exist and if boto libraries are greater than
     a given version.
     '''
-    required_boto3_version = '1.2.5'
     # the boto_lambda execution module relies on the connect_to_region() method
     # which was added in boto 2.8.0
     # https://github.com/boto/boto/commit/33ac26b416fbb48a60602542b4ce15dcc7029f12
-    if not HAS_BOTO:
-        return (False, 'The boto_cloudtrial module could not be loaded: boto libraries not found')
-    elif _LooseVersion(boto3.__version__) < _LooseVersion(required_boto3_version):
-        return (False, 'The boto_cloudtrial module could not be loaded: '
-                'boto version {0} or later must be installed.'.format(required_boto3_version))
-    else:
-        return True
+    return salt.utils.versions.check_boto_reqs(
+        boto3_ver='1.2.5'
+    )
 
 
 def __init__(opts):

--- a/salt/modules/boto_cloudwatch.py
+++ b/salt/modules/boto_cloudwatch.py
@@ -50,8 +50,11 @@ from __future__ import absolute_import, print_function, unicode_literals
 import logging
 import yaml  # pylint: disable=blacklisted-import
 
+# Import Salt libs
+from salt.ext import six
 import salt.utils.json
 import salt.utils.odict as odict
+import salt.utils.versions
 
 log = logging.getLogger(__name__)
 
@@ -66,19 +69,17 @@ try:
 except ImportError:
     HAS_BOTO = False
 
-from salt.ext import six
-
 
 def __virtual__():
     '''
     Only load if boto libraries exist.
     '''
-    if not HAS_BOTO:
-        return (False, 'The boto_cloudwatch module cannot be loaded: boto libraries are unavailable.')
-    __utils__['boto.assign_funcs'](__name__, 'cloudwatch',
-                                   module='ec2.cloudwatch',
-                                   pack=__salt__)
-    return True
+    has_boto_reqs = salt.utils.versions.check_boto_reqs(check_boto3=False)
+    if has_boto_reqs is True:
+        __utils__['boto.assign_funcs'](__name__, 'cloudwatch',
+                                       module='ec2.cloudwatch',
+                                       pack=__salt__)
+    return has_boto_reqs
 
 
 def get_alarm(name, region=None, key=None, keyid=None, profile=None):

--- a/salt/modules/boto_cloudwatch_event.py
+++ b/salt/modules/boto_cloudwatch_event.py
@@ -48,8 +48,11 @@ from __future__ import absolute_import, print_function, unicode_literals
 
 # Import Python libs
 import logging
-import salt.utils.json
+
+# Import Salt libs
 import salt.utils.compat
+import salt.utils.json
+import salt.utils.versions
 
 log = logging.getLogger(__name__)
 
@@ -74,9 +77,7 @@ def __virtual__():
     '''
     Only load if boto libraries exist.
     '''
-    if not HAS_BOTO:
-        return (False, 'The boto_cloudwatch_event module cannot be loaded: boto libraries are unavailable.')
-    return True
+    return salt.utils.versions.check_boto_reqs()
 
 
 def __init__(opts):

--- a/salt/modules/boto_cognitoidentity.py
+++ b/salt/modules/boto_cognitoidentity.py
@@ -83,7 +83,7 @@ import logging
 # Import Salt libs
 import salt.utils.boto3
 import salt.utils.compat
-from salt.utils.versions import LooseVersion as _LooseVersion
+import salt.utils.versions
 
 log = logging.getLogger(__name__)
 
@@ -109,22 +109,13 @@ def __virtual__():
     Only load if boto libraries exist and if boto libraries are greater than
     a given version.
     '''
-    required_boto_version = '2.8.0'
-    required_boto3_version = '1.2.1'
     # the boto_cognitoidentity execution module relies on the connect_to_region() method
     # which was added in boto 2.8.0
     # https://github.com/boto/boto/commit/33ac26b416fbb48a60602542b4ce15dcc7029f12
-    if not HAS_BOTO:
-        return (False, 'The boto_cognitoidentity module could not be loaded: '
-                'boto libraries not found')
-    elif _LooseVersion(boto.__version__) < _LooseVersion(required_boto_version):
-        return (False, 'The boto_cognitoidentity module could not be loaded: '
-                'boto version {0} or later must be installed.'.format(required_boto_version))
-    elif _LooseVersion(boto3.__version__) < _LooseVersion(required_boto3_version):
-        return (False, 'The boto_cognitoidentity module could not be loaded: '
-                'boto version {0} or later must be installed.'.format(required_boto3_version))
-    else:
-        return True
+    return salt.utils.versions.check_boto_reqs(
+        boto_ver='2.8.0',
+        boto3_ver='1.2.1'
+    )
 
 
 def __init__(opts):

--- a/salt/modules/boto_datapipeline.py
+++ b/salt/modules/boto_datapipeline.py
@@ -6,11 +6,14 @@ Connection module for Amazon Data Pipeline
 
 :depends: boto3
 '''
-from __future__ import absolute_import, print_function, unicode_literals
 
+# Import Python libs
+from __future__ import absolute_import, print_function, unicode_literals
 import logging
 
+# Import Salt libs
 from salt.ext import six
+import salt.utils.versions
 
 log = logging.getLogger(__name__)
 
@@ -28,10 +31,7 @@ def __virtual__():
     '''
     Only load if boto3 libraries exists.
     '''
-    if not HAS_BOTO3:
-        return (False, 'The boto_datapipeline module could not be loaded: '
-                'boto libraries not found')
-    return True
+    return salt.utils.versions.check_boto_reqs(check_boto=False)
 
 
 def activate_pipeline(pipeline_id, region=None, key=None, keyid=None, profile=None):

--- a/salt/modules/boto_dynamodb.py
+++ b/salt/modules/boto_dynamodb.py
@@ -56,6 +56,8 @@ logging.getLogger('boto').setLevel(logging.INFO)
 from salt.ext import six
 from salt.ext.six.moves import range  # pylint: disable=import-error,redefined-builtin
 from salt.exceptions import SaltInvocationError
+import salt.utils.versions
+
 try:
     #pylint: disable=unused-import
     import boto
@@ -74,10 +76,10 @@ def __virtual__():
     '''
     Only load if boto libraries exist.
     '''
-    if not HAS_BOTO:
-        return (False, 'The module boto_dynamodb could not be loaded: boto libraries not found')
-    __utils__['boto.assign_funcs'](__name__, 'dynamodb2', pack=__salt__)
-    return True
+    has_boto_reqs = salt.utils.versions.check_boto_reqs(check_boto3=False)
+    if has_boto_reqs is True:
+        __utils__['boto.assign_funcs'](__name__, 'dynamodb2', pack=__salt__)
+    return has_boto_reqs
 
 
 def create_table(table_name, region=None, key=None, keyid=None, profile=None,

--- a/salt/modules/boto_ec2.py
+++ b/salt/modules/boto_ec2.py
@@ -54,9 +54,9 @@ import time
 import salt.utils.compat
 import salt.utils.data
 import salt.utils.json
+import salt.utils.versions
 from salt.ext import six
 from salt.exceptions import SaltInvocationError, CommandExecutionError
-from salt.utils.versions import LooseVersion as _LooseVersion
 
 # Import third party libs
 try:
@@ -78,17 +78,16 @@ def __virtual__():
     Only load if boto libraries exist and if boto libraries are greater than
     a given version.
     '''
-    required_boto_version = '2.8.0'
     # the boto_ec2 execution module relies on the connect_to_region() method
     # which was added in boto 2.8.0
     # https://github.com/boto/boto/commit/33ac26b416fbb48a60602542b4ce15dcc7029f12
-    if not HAS_BOTO:
-        return (False, "The boto_ec2 module cannot be loaded: boto library not found")
-    elif _LooseVersion(boto.__version__) < _LooseVersion(required_boto_version):
-        return (False, "The boto_ec2 module cannot be loaded: boto library version incorrect ")
-    else:
+    has_boto_reqs = salt.utils.versions.check_boto_reqs(
+        boto_ver='2.8.0',
+        check_boto3=False
+    )
+    if has_boto_reqs is True:
         __utils__['boto.assign_funcs'](__name__, 'ec2', pack=__salt__)
-        return True
+    return has_boto_reqs
 
 
 def __init__(opts):

--- a/salt/modules/boto_efs.py
+++ b/salt/modules/boto_efs.py
@@ -63,7 +63,7 @@ except ImportError:
     HAS_BOTO3 = False
 
 # Import salt libs
-from salt.utils.versions import LooseVersion as _LooseVersion
+import salt.utils.versions
 
 log = logging.getLogger(__name__)
 
@@ -73,18 +73,10 @@ def __virtual__():
     Only load if boto3 libraries exist and if boto3 libraries are greater than
     a given version.
     '''
-
-    required_boto_version = '1.0.0'
-
-    if not HAS_BOTO3:
-        return (False, "The boto3.efs module cannot be loaded: " +
-                "boto3 library not found")
-    elif _LooseVersion(boto3.__version__) < \
-         _LooseVersion(required_boto_version):
-        return (False, "The boto3.efs module cannot be loaded:" +
-                "boto3 library version incorrect")
-    else:
-        return True
+    return salt.utils.versions.check_boto_reqs(
+        boto3_ver='1.0.0',
+        check_boto=False
+    )
 
 
 def _get_conn(key=None,

--- a/salt/modules/boto_elasticache.py
+++ b/salt/modules/boto_elasticache.py
@@ -54,6 +54,7 @@ import time
 from salt.ext import six
 from salt.exceptions import SaltInvocationError
 import salt.utils.odict as odict
+import salt.utils.versions
 
 log = logging.getLogger(__name__)
 
@@ -74,10 +75,13 @@ def __virtual__():
     '''
     Only load if boto libraries exist.
     '''
-    if not HAS_BOTO:
-        return (False, 'The model boto_elasticache could not be loaded: boto libraries not found')
-    __utils__['boto.assign_funcs'](__name__, 'elasticache', pack=__salt__)
-    return True
+    has_boto_reqs = salt.utils.versions.check_boto_reqs(
+        check_boto3=False
+    )
+    if has_boto_reqs is True:
+        __utils__['boto.assign_funcs'](__name__, 'elasticache', pack=__salt__)
+
+    return has_boto_reqs
 
 
 def exists(name, region=None, key=None, keyid=None, profile=None):

--- a/salt/modules/boto_elasticsearch_domain.py
+++ b/salt/modules/boto_elasticsearch_domain.py
@@ -83,8 +83,8 @@ from salt.ext import six
 import salt.utils.boto3
 import salt.utils.compat
 import salt.utils.json
+import salt.utils.versions
 from salt.exceptions import SaltInvocationError
-from salt.utils.versions import LooseVersion as _LooseVersion
 
 log = logging.getLogger(__name__)
 
@@ -110,22 +110,13 @@ def __virtual__():
     Only load if boto libraries exist and if boto libraries are greater than
     a given version.
     '''
-    required_boto_version = '2.8.0'
-    required_boto3_version = '1.4.0'
     # the boto_lambda execution module relies on the connect_to_region() method
     # which was added in boto 2.8.0
     # https://github.com/boto/boto/commit/33ac26b416fbb48a60602542b4ce15dcc7029f12
-    if not HAS_BOTO:
-        return (False, 'The boto_lambda module could not be loaded: '
-                'boto libraries not found')
-    elif _LooseVersion(boto.__version__) < _LooseVersion(required_boto_version):
-        return (False, 'The boto_lambda module could not be loaded: '
-                'boto version {0} or later must be installed.'.format(required_boto_version))
-    elif _LooseVersion(boto3.__version__) < _LooseVersion(required_boto3_version):
-        return (False, 'The boto_lambda module could not be loaded: '
-                'boto version {0} or later must be installed.'.format(required_boto3_version))
-    else:
-        return True
+    return salt.utils.versions.check_boto_reqs(
+        boto_ver='2.8.0',
+        boto3_ver='1.4.0'
+    )
 
 
 def __init__(opts):

--- a/salt/modules/boto_elbv2.py
+++ b/salt/modules/boto_elbv2.py
@@ -48,10 +48,10 @@ import logging
 log = logging.getLogger(__name__)
 
 # Import Salt libs
-
-# Import third party libs
 from salt.ext import six
+import salt.utils.versions
 
+# Import third-party libs
 try:
     # pylint: disable=unused-import
     import salt.utils.boto3
@@ -71,10 +71,10 @@ def __virtual__():
     '''
     Only load if boto3 libraries exist.
     '''
-    if not HAS_BOTO:
-        return (False, "The boto_elbv2 module cannot be loaded: boto3 library not found")
-    __utils__['boto3.assign_funcs'](__name__, 'elbv2')
-    return True
+    has_boto_reqs = salt.utils.versions.check_boto_reqs()
+    if has_boto_reqs is True:
+        __utils__['boto3.assign_funcs'](__name__, 'elbv2')
+    return has_boto_reqs
 
 
 def create_target_group(name,

--- a/salt/modules/boto_iam.py
+++ b/salt/modules/boto_iam.py
@@ -47,6 +47,7 @@ from salt.ext import six
 import salt.utils.compat
 import salt.utils.json
 import salt.utils.odict as odict
+import salt.utils.versions
 
 # Import third party libs
 # pylint: disable=unused-import
@@ -70,9 +71,9 @@ def __virtual__():
     '''
     Only load if boto libraries exist.
     '''
-    if not HAS_BOTO:
-        return (False, 'The boto_iam module could not be loaded: boto libraries not found')
-    return True
+    return salt.utils.versions.check_boto_reqs(
+        check_boto3=False
+    )
 
 
 def __init__(opts):

--- a/salt/modules/boto_iot.py
+++ b/salt/modules/boto_iot.py
@@ -58,7 +58,7 @@ import datetime
 import salt.utils.boto3
 import salt.utils.compat
 import salt.utils.json
-from salt.utils.versions import LooseVersion as _LooseVersion
+import salt.utils.versions
 
 log = logging.getLogger(__name__)
 
@@ -84,22 +84,13 @@ def __virtual__():
     Only load if boto libraries exist and if boto libraries are greater than
     a given version.
     '''
-    required_boto3_version = '1.2.1'
-    required_botocore_version = '1.4.41'
     # the boto_lambda execution module relies on the connect_to_region() method
     # which was added in boto 2.8.0
     # https://github.com/boto/boto/commit/33ac26b416fbb48a60602542b4ce15dcc7029f12
-    if not HAS_BOTO:
-        return (False, 'The boto_iot module could not be loaded: '
-                'boto libraries not found')
-    elif _LooseVersion(boto3.__version__) < _LooseVersion(required_boto3_version):
-        return (False, 'The boto_iot module could not be loaded: '
-                'boto3 version {0} or later must be installed.'.format(required_boto3_version))
-    elif _LooseVersion(found_botocore_version) < _LooseVersion(required_botocore_version):
-        return (False, 'The boto_iot module could not be loaded: '
-                'botocore version {0} or later must be installed.'.format(required_botocore_version))
-    else:
-        return True
+    return salt.utils.versions.check_boto_reqs(
+        boto3_ver='1.2.1',
+        botocore_ver='1.4.41'
+    )
 
 
 def __init__(opts):

--- a/salt/modules/boto_kinesis.py
+++ b/salt/modules/boto_kinesis.py
@@ -51,7 +51,10 @@ import logging
 import time
 import random
 import sys
+
+# Import Salt libs
 from salt.ext.six.moves import range  # pylint: disable=import-error,redefined-builtin
+import salt.utils.versions
 
 # Import third party libs
 # pylint: disable=unused-import
@@ -73,10 +76,11 @@ def __virtual__():
     '''
     Only load if boto3 libraries exist.
     '''
-    if not HAS_BOTO:
-        return False, 'The boto_kinesis module could not be loaded: boto libraries not found.'
-    __utils__['boto3.assign_funcs'](__name__, 'kinesis')
-    return __virtualname__
+    has_boto_reqs = salt.utils.versions.check_boto_reqs()
+    if has_boto_reqs is True:
+        __utils__['boto3.assign_funcs'](__name__, 'kinesis')
+        return __virtualname__
+    return has_boto_reqs
 
 
 def _get_basic_stream(stream_name, conn):

--- a/salt/modules/boto_kms.py
+++ b/salt/modules/boto_kms.py
@@ -45,7 +45,7 @@ import logging
 import salt.utils.compat
 import salt.utils.odict as odict
 import salt.serializers.json
-from salt.utils.versions import LooseVersion as _LooseVersion
+import salt.utils.versions
 
 log = logging.getLogger(__name__)
 
@@ -53,13 +53,6 @@ log = logging.getLogger(__name__)
 try:
     # pylint: disable=unused-import
     import boto
-    # KMS added in version 2.38.0
-    required_boto_version = '2.38.0'
-    if (_LooseVersion(boto.__version__) <
-            _LooseVersion(required_boto_version)):
-        msg = 'boto_kms requires boto {0}.'.format(required_boto_version)
-        log.debug(msg)
-        raise ImportError()
     import boto.kms
     # pylint: enable=unused-import
     logging.getLogger('boto').setLevel(logging.CRITICAL)
@@ -72,9 +65,10 @@ def __virtual__():
     '''
     Only load if boto libraries exist.
     '''
-    if not HAS_BOTO:
-        return (False, 'The boto_kms module could not be loaded: boto libraries not found')
-    return True
+    return salt.utils.versions.check_boto_reqs(
+        boto_ver='2.38.0',
+        check_boto3=False
+    )
 
 
 def __init__(opts):

--- a/salt/modules/boto_lambda.py
+++ b/salt/modules/boto_lambda.py
@@ -90,7 +90,7 @@ from salt.ext import six
 import salt.utils.compat
 import salt.utils.files
 import salt.utils.json
-from salt.utils.versions import LooseVersion as _LooseVersion
+import salt.utils.versions
 from salt.exceptions import SaltInvocationError
 from salt.ext.six.moves import range  # pylint: disable=import-error
 
@@ -119,27 +119,15 @@ def __virtual__():
     Only load if boto libraries exist and if boto libraries are greater than
     a given version.
     '''
-    required_boto_version = '2.8.0'
-    required_boto3_version = '1.2.5'
-    required_botocore_version = '1.5.2'
     # the boto_lambda execution module relies on the connect_to_region() method
     # which was added in boto 2.8.0
     # https://github.com/boto/boto/commit/33ac26b416fbb48a60602542b4ce15dcc7029f12
     # botocore version >= 1.5.2 is required due to lambda environment variables
-    if not HAS_BOTO:
-        return (False, 'The boto_lambda module could not be loaded: '
-                'boto libraries not found')
-    elif _LooseVersion(boto.__version__) < _LooseVersion(required_boto_version):
-        return (False, 'The boto_lambda module could not be loaded: '
-                'boto version {0} or later must be installed.'.format(required_boto_version))
-    elif _LooseVersion(boto3.__version__) < _LooseVersion(required_boto3_version):
-        return (False, 'The boto_lambda module could not be loaded: '
-                'boto version {0} or later must be installed.'.format(required_boto3_version))
-    elif _LooseVersion(found_botocore_version) < _LooseVersion(required_botocore_version):
-        return (False, 'The boto_lambda module could not be loaded: '
-                'botocore version {0} or later must be installed.'.format(required_botocore_version))
-    else:
-        return True
+    return salt.utils.versions.check_boto_reqs(
+        boto_ver='2.8.0',
+        boto3_ver='1.2.5',
+        botocore_ver='1.5.2'
+    )
 
 
 def __init__(opts):

--- a/salt/modules/boto_rds.py
+++ b/salt/modules/boto_rds.py
@@ -56,8 +56,8 @@ import time
 import salt.utils.boto3
 import salt.utils.compat
 import salt.utils.odict as odict
+import salt.utils.versions
 from salt.exceptions import SaltInvocationError
-from salt.utils.versions import LooseVersion as _LooseVersion
 
 log = logging.getLogger(__name__)
 
@@ -128,15 +128,9 @@ def __virtual__():
     Only load if boto libraries exist and if boto libraries are greater than
     a given version.
     '''
-    required_boto3_version = '1.3.1'
-    if not HAS_BOTO:
-        return (False, 'The boto_rds module could not be loaded: '
-                'boto libraries not found')
-    elif _LooseVersion(boto3.__version__) < _LooseVersion(required_boto3_version):
-        return (False, 'The boto_rds module could not be loaded: '
-                'boto version {0} or later must be installed.'.format(required_boto3_version))
-    else:
-        return True
+    return salt.utils.versions.check_boto_reqs(
+        boto3_ver='1.3.1'
+    )
 
 
 def __init__(opts):

--- a/salt/modules/boto_route53.py
+++ b/salt/modules/boto_route53.py
@@ -55,13 +55,12 @@ import time
 import salt.utils.compat
 import salt.utils.versions
 import salt.utils.odict as odict
+import salt.utils.versions
 from salt.exceptions import SaltInvocationError
-from salt.utils.versions import LooseVersion as _LooseVersion
 
 log = logging.getLogger(__name__)
 
 # Import third party libs
-REQUIRED_BOTO_VERSION = '2.35.0'
 try:
     #pylint: disable=unused-import
     import boto
@@ -69,9 +68,6 @@ try:
     import boto.route53.healthcheck
     from boto.route53.exception import DNSServerError
     #pylint: enable=unused-import
-    # create_zone params were changed in boto 2.35+
-    if _LooseVersion(boto.__version__) < _LooseVersion(REQUIRED_BOTO_VERSION):
-        raise ImportError()
     logging.getLogger('boto').setLevel(logging.CRITICAL)
     HAS_BOTO = True
 except ImportError:
@@ -82,11 +78,11 @@ def __virtual__():
     '''
     Only load if boto libraries exist.
     '''
-    if not HAS_BOTO:
-        msg = ('A boto library with version at least {0} was not '
-               'found').format(REQUIRED_BOTO_VERSION)
-        return (False, msg)
-    return True
+    # create_zone params were changed in boto 2.35+
+    return salt.utils.versions.check_boto_reqs(
+        boto_ver='2.35.0',
+        check_boto3=False
+    )
 
 
 def __init__(opts):

--- a/salt/modules/boto_s3.py
+++ b/salt/modules/boto_s3.py
@@ -55,7 +55,7 @@ from __future__ import absolute_import, print_function, unicode_literals
 import logging
 
 # Import Salt libs
-from salt.utils.versions import LooseVersion as _LooseVersion
+import salt.utils.versions
 
 log = logging.getLogger(__name__)
 
@@ -77,16 +77,9 @@ def __virtual__():
     Only load if boto libraries exist and if boto libraries are greater than
     a given version.
     '''
-    needed_boto3_version = '1.2.1'
-    msg = 'The boto_s3 module cannot be loaded: {0}.'
-    if not HAS_BOTO:
-        return (False, msg.format('boto3 libraries not found'))
-    if _LooseVersion(boto3.__version__) < _LooseVersion(needed_boto3_version):
-        submsg = 'boto3 library version {0} is required'.format(
-            needed_boto3_version,
-        )
-        return (False, msg.format(submsg))
-    return True
+    return salt.utils.versions.check_boto_reqs(
+        boto3_ver='1.2.1'
+    )
 
 
 def __init__(opts):  # pylint: disable=unused-argument

--- a/salt/modules/boto_s3_bucket.py
+++ b/salt/modules/boto_s3_bucket.py
@@ -60,8 +60,8 @@ from salt.ext import six
 from salt.ext.six.moves import range  # pylint: disable=import-error
 import salt.utils.compat
 import salt.utils.json
+import salt.utils.versions
 from salt.exceptions import SaltInvocationError
-from salt.utils.versions import LooseVersion as _LooseVersion
 
 log = logging.getLogger(__name__)
 
@@ -86,18 +86,12 @@ def __virtual__():
     Only load if boto libraries exist and if boto libraries are greater than
     a given version.
     '''
-    required_boto3_version = '1.2.1'
     # the boto_lambda execution module relies on the connect_to_region() method
     # which was added in boto 2.8.0
     # https://github.com/boto/boto/commit/33ac26b416fbb48a60602542b4ce15dcc7029f12
-    if not HAS_BOTO:
-        return (False, 'The boto_s3_bucket module could not be loaded: '
-                'boto libraries not found')
-    elif _LooseVersion(boto3.__version__) < _LooseVersion(required_boto3_version):
-        return (False, 'The boto_cognitoidentity module could not be loaded: '
-                'boto version {0} or later must be installed.'.format(required_boto3_version))
-    else:
-        return True
+    return salt.utils.versions.check_boto_reqs(
+        boto3_ver='1.2.1'
+    )
 
 
 def __init__(opts):

--- a/salt/modules/boto_sns.py
+++ b/salt/modules/boto_sns.py
@@ -42,9 +42,12 @@ Connection module for Amazon SNS
 # keep lint from choking on _get_conn and _cache_id
 #pylint: disable=E0602
 
+# Import Python libs
 from __future__ import absolute_import, print_function, unicode_literals
-
 import logging
+
+# Import Salt libs
+import salt.utils.versions
 
 log = logging.getLogger(__name__)
 
@@ -64,10 +67,12 @@ def __virtual__():
     '''
     Only load if boto libraries exist.
     '''
-    if not HAS_BOTO:
-        return (False, 'The boto_sns module could not be loaded: boto libraries not found')
-    __utils__['boto.assign_funcs'](__name__, 'sns', pack=__salt__)
-    return True
+    has_boto_reqs = salt.utils.versions.check_boto_reqs(
+        check_boto3=False
+    )
+    if has_boto_reqs is True:
+        __utils__['boto.assign_funcs'](__name__, 'sns', pack=__salt__)
+    return has_boto_reqs
 
 
 def get_all_topics(region=None, key=None, keyid=None, profile=None):

--- a/salt/modules/boto_sqs.py
+++ b/salt/modules/boto_sqs.py
@@ -51,6 +51,7 @@ import logging
 
 # Import Salt libs
 import salt.utils.json
+import salt.utils.versions
 
 # Import 3rd-party libs
 from salt.ext import six
@@ -78,10 +79,10 @@ def __virtual__():
     '''
     Only load if boto3 libraries exist.
     '''
-    if not HAS_BOTO3:
-        return (False, 'The boto_sqs module could not be loaded: boto3 libraries not found')
-    __utils__['boto3.assign_funcs'](__name__, 'sqs')
-    return True
+    has_boto_reqs = salt.utils.versions.check_boto_reqs()
+    if has_boto_reqs is True:
+        __utils__['boto3.assign_funcs'](__name__, 'sqs')
+    return has_boto_reqs
 
 
 def _preprocess_attributes(attributes):

--- a/salt/modules/boto_vpc.py
+++ b/salt/modules/boto_vpc.py
@@ -139,7 +139,6 @@ import salt.utils.boto3
 import salt.utils.compat
 import salt.utils.versions
 from salt.exceptions import SaltInvocationError, CommandExecutionError
-from salt.utils.versions import LooseVersion as _LooseVersion
 
 # from salt.utils import exactly_one
 # TODO: Uncomment this and s/_exactly_one/exactly_one/
@@ -181,22 +180,15 @@ def __virtual__():
     Only load if boto libraries exist and if boto libraries are greater than
     a given version.
     '''
-    required_boto_version = '2.8.0'
     # the boto_vpc execution module relies on the connect_to_region() method
     # which was added in boto 2.8.0
     # https://github.com/boto/boto/commit/33ac26b416fbb48a60602542b4ce15dcc7029f12
-    if not HAS_BOTO:
-        return (False, 'The boto_vpc module could not be loaded: boto libraries not found')
-    elif _LooseVersion(boto.__version__) < _LooseVersion(required_boto_version):
-        return (False, 'The boto_vpc module could not be loaded: boto library version 2.8.0 is required')
-    required_boto3_version = '1.2.6'
     # the boto_vpc execution module relies on the create_nat_gateway() method
     # which was added in boto3 1.2.6
-    if not HAS_BOTO3:
-        return (False, 'The boto_vpc module could not be loaded: boto3 libraries not found')
-    elif _LooseVersion(boto3.__version__) < _LooseVersion(required_boto3_version):
-        return (False, 'The boto_vpc module could not be loaded: boto3 library version 1.2.6 is required')
-    return True
+    return salt.utils.versions.check_boto_reqs(
+        boto_ver='2.8.0',
+        boto3_ver='1.2.6'
+    )
 
 
 def __init__(opts):

--- a/salt/utils/boto.py
+++ b/salt/utils/boto.py
@@ -46,8 +46,8 @@ from salt.loader import minion_mods
 from salt.ext import six
 from salt.ext.six.moves import range  # pylint: disable=import-error,redefined-builtin
 from salt.exceptions import SaltInvocationError
-from salt.utils.versions import LooseVersion as _LooseVersion
 import salt.utils.stringutils
+import salt.utils.versions
 
 # Import third party libs
 # pylint: disable=import-error
@@ -73,17 +73,12 @@ def __virtual__():
     Only load if boto libraries exist and if boto libraries are greater than
     a given version.
     '''
-    # TODO: Determine minimal version we want to support. VPC requires > 2.8.0.
-    required_boto_version = '2.0.0'
-    if not HAS_BOTO:
-        return False
-    elif _LooseVersion(boto.__version__) < _LooseVersion(required_boto_version):
-        return False
-    else:
+    has_boto_requirements = salt.utils.versions.check_boto_reqs(check_boto3=False)
+    if has_boto_requirements is True:
         global __salt__
         if not __salt__:
             __salt__ = minion_mods(__opts__)
-        return True
+    return has_boto_requirements
 
 
 def _get_profile(service, region, key, keyid, profile):

--- a/salt/utils/boto3.py
+++ b/salt/utils/boto3.py
@@ -44,9 +44,9 @@ from functools import partial
 # Import salt libs
 from salt.ext.six.moves import range  # pylint: disable=import-error,redefined-builtin
 from salt.exceptions import SaltInvocationError
-from salt.utils.versions import LooseVersion as _LooseVersion
 from salt.ext import six
 import salt.utils.stringutils
+import salt.utils.versions
 
 # Import third party libs
 # pylint: disable=import-error
@@ -74,22 +74,7 @@ def __virtual__():
     Only load if boto libraries exist and if boto libraries are greater than
     a given version.
     '''
-    # TODO: Determine minimal version we want to support. VPC requires > 2.8.0.
-    required_boto_version = '2.0.0'
-    # boto_s3_bucket module requires boto3 1.2.6 and botocore 1.3.23 for
-    # idempotent ACL operations via the fix in  https://github.com/boto/boto3/issues/390
-    required_boto3_version = '1.2.6'
-    required_botocore_version = '1.3.23'
-    if not HAS_BOTO:
-        return False
-    elif _LooseVersion(boto.__version__) < _LooseVersion(required_boto_version):
-        return False
-    elif _LooseVersion(boto3.__version__) < _LooseVersion(required_boto3_version):
-        return False
-    elif _LooseVersion(botocore.__version__) < _LooseVersion(required_botocore_version):
-        return False
-    else:
-        return True
+    return salt.utils.versions.check_boto_reqs()
 
 
 def _option(value):

--- a/salt/utils/boto3.py
+++ b/salt/utils/boto3.py
@@ -56,7 +56,7 @@ try:
     import boto3
     import boto.exception
     import boto3.session
-    import botocore
+    import botocore  # pylint: disable=W0611
 
     # pylint: enable=import-error
     logging.getLogger('boto3').setLevel(logging.CRITICAL)

--- a/salt/utils/versions.py
+++ b/salt/utils/versions.py
@@ -292,3 +292,73 @@ def compare(ver1='', oper='==', ver2='', cmp_func=None, ignore_epoch=False):
             cmp_result = 1
 
         return cmp_result in cmp_map[oper]
+
+
+def check_boto_reqs(boto_ver=None,
+                    boto3_ver=None,
+                    botocore_ver=None,
+                    check_boto=True,
+                    check_boto3=True):
+    '''
+    Checks for the version of various required boto libs in one central location. Most
+    boto states and modules rely on a single version of the boto, boto3, or botocore libs.
+    However, some require newer versions of any of these dependencies. This function allows
+    the module to pass in a version to override the default minimum required version.
+
+    This function is useful in centralizing checks for ``__virtual__()`` functions in the
+    various, and many, boto modules and states.
+
+    boto_ver
+        The minimum required version of the boto library. Defaults to ``2.0.0``.
+
+    boto3_ver
+        The minimum required version of the boto3 library. Defaults to ``1.2.6``.
+
+    botocore_ver
+        The minimum required version of the botocore library. Defaults to ``1.3.23``.
+
+    check_boto
+        Boolean defining whether or not to check for boto deps. This defaults to ``True`` as
+        most boto modules/states rely on boto, but some do not.
+
+    check_boto3
+        Boolean defining whether or not to check for boto3 (and therefore botocore) deps.
+        This defaults to ``True`` as most boto modules/states rely on boto3/botocore, but
+        some do not.
+    '''
+    if check_boto is True:
+        try:
+            # Late import so we can only load these for this function
+            import boto
+            has_boto = True
+        except ImportError:
+            has_boto = False
+
+        if boto_ver is None:
+            boto_ver = '2.0.0'
+
+        if not has_boto or version_cmp(boto.__version__, boto_ver) == -1:
+            return False, 'A minimum version of boto {0} is required.'.format(boto_ver)
+
+    if check_boto3 is True:
+        try:
+            # Late import so we can only load these for this function
+            import boto3
+            import botocore
+            has_boto3 = True
+        except ImportError:
+            has_boto3 = False
+
+        # boto_s3_bucket module requires boto3 1.2.6 and botocore 1.3.23 for
+        # idempotent ACL operations via the fix in https://github.com/boto/boto3/issues/390
+        if boto3_ver is None:
+            boto3_ver = '1.2.6'
+        if botocore_ver is None:
+            botocore_ver = '1.3.23'
+
+        if not has_boto3 or version_cmp(boto3.__version__, boto3_ver) == -1:
+            return False, 'A minimum version of boto3 {0} is required.'.format(boto3_ver)
+        elif version_cmp(botocore.__version__, botocore_ver) == -1:
+            return False, 'A minimum version of botocore {0} is required'.format(botocore_ver)
+
+    return True


### PR DESCRIPTION
This was added to salt.utils.versions.py in order for the boto.py
and boto3.py utils files to use it and to avoid adding a kind of
circular check in various __utils__ files for the boto deps.

The arguments added to versions.check_boto_reqs() allow the individual
module to override the boto, boto3, and/or botocore minimum versions
where the default values are defined in versions.check_boto_reqs().

Replaces PR #42476
