### PR TITLE
Fix an inconsistency in the docs

### DIFF
--- a/doc/ref/configuration/master.rst
+++ b/doc/ref/configuration/master.rst
@@ -2470,8 +2470,9 @@ on a large number of minions.
 
 .. note::
     Rather than altering this configuration parameter, it may be advisable to
-    use the :mod:`fileserver.clear_list_cache
-    <salt.runners.fileserver.clear_list_cache>` runner to clear these caches.
+    use the :mod:`fileserver.clear_file_list_cache
+    <salt.runners.fileserver.clear_file_list_cache>` runner to clear these
+    caches.
 
 .. code-block:: yaml
 


### PR DESCRIPTION
### What does this PR do?
Fixes an inconsistency in the docs, where there are 2 occurencies of the function ``clear_list_cache``. According to the code of ``salt.runners.fileserver`` its name should be ``clear_file_list_cache`` instead.

### What issues does this PR fix or reference?
No issues.

### Tests written?
No

### Commits signed with GPG?
No
