### PR TITLE
Support comma separated minion list target in payload for TCP transport

### DIFF
--- a/salt/transport/tcp.py
+++ b/salt/transport/tcp.py
@@ -1336,6 +1336,7 @@ class TCPPubServerChannel(salt.transport.server.PubServerChannel):
     def __init__(self, opts):
         self.opts = opts
         self.serial = salt.payload.Serial(self.opts)  # TODO: in init?
+        self.ckminions = salt.utils.minions.CkMinions(opts)
         self.io_loop = None
 
     def __setstate__(self, state):
@@ -1440,6 +1441,16 @@ class TCPPubServerChannel(salt.transport.server.PubServerChannel):
 
         # add some targeting stuff for lists only (for now)
         if load['tgt_type'] == 'list':
-            int_payload['topic_lst'] = load['tgt']
+            if isinstance(load['tgt'], six.string_types):
+                # Fetch a list of minions that match
+                _res = self.ckminions.check_minions(load['tgt'],
+                                                    tgt_type=load['tgt_type'])
+                match_ids = _res['minions']
+
+                log.debug("Publish Side Match: %s", match_ids)
+                # Send list of miions thru so zmq can target them
+                int_payload['topic_lst'] = match_ids
+            else:
+                int_payload['topic_lst'] = load['tgt']
         # Send it over IPC!
         pub_sock.send(int_payload)


### PR DESCRIPTION
### What does this PR do?
Support comma separated minion list target in payload for TCP transport.

We have no problems with it because `salt` cmdline transforms comma-separated target list (when `-L` is set) to the python list object and sets `tgt` in payload to the list.
But the failing `integration.client.test_standard.StdTest.test_missing_minion_list` uses `client.cmd` function and passes comma-separated string to the client. ZeroMQ transport handles this correctly with `ckminions.check_minions` when TCP transport lacks this and tries to iterate though the string during publishing the job over minions.

### What issues does this PR fix or reference?
Fixes https://github.com/saltstack/salt-jenkins/issues/813

### Tests written?
Exists