### PR TITLE
SSH shell shim: Don't use $() for optimal support

### DIFF
--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -157,17 +157,17 @@ do
         py_cmd_path=`"$py_cmd" -c \
                    'from __future__ import print_function;
                    import sys; print(sys.executable);'`
-        cmdpath=$(command -v $py_cmd 2>/dev/null || which $py_cmd 2>/dev/null)
+        cmdpath=`command -v $py_cmd 2>/dev/null || which $py_cmd 2>/dev/null`
         if file $cmdpath | grep "shell script" > /dev/null
         then
             ex_vars="'PATH', 'LD_LIBRARY_PATH', 'MANPATH', \
                    'XDG_DATA_DIRS', 'PKG_CONFIG_PATH'"
-            export $($py_cmd -c \
+            export `$py_cmd -c \
                   "from __future__ import print_function;
                   import sys;
                   import os;
                   map(sys.stdout.write, ['{{{{0}}}}={{{{1}}}} ' \
-                  .format(x, os.environ[x]) for x in [$ex_vars]])")
+                  .format(x, os.environ[x]) for x in [$ex_vars]])"`
             exec $SUDO PATH=$PATH LD_LIBRARY_PATH=$LD_LIBRARY_PATH \
                      MANPATH=$MANPATH XDG_DATA_DIRS=$XDG_DATA_DIRS \
                      PKG_CONFIG_PATH=$PKG_CONFIG_PATH \


### PR DESCRIPTION
Some shells don't support the `$()` syntax, so use the backticks instead.
### Previous Behavior
```
this-posix-compliant-shell-oldskool.example.com:
    ----------
    retcode:
        2
    stderr:
        SUDO=
        + [ -n  ] 
        SUDO_USER=
        + [  ] 
        + [  ] 
        EX_PYTHON_INVALID=10
        PYTHON_CMDS=python3 python27 python2.7 python26 python2.6 python2 python
        /bin/sh: syntax error at line 28: `cmdpath=$' unexpected
    stdout:
```
