### PR TITLE
Allow gpg renderer to render multiple ciphertexts in a single string

### DIFF
--- a/tests/unit/renderers/test_gpg.py
+++ b/tests/unit/renderers/test_gpg.py
@@ -20,9 +20,11 @@ from salt.exceptions import SaltRenderError
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
 class GPGTestCase(TestCase, LoaderModuleMockMixin):
+
     '''
     unit test GPG renderer
     '''
+
     def setup_loader_modules(self):
         return {gpg: {}}
 
@@ -46,11 +48,16 @@ class GPGTestCase(TestCase, LoaderModuleMockMixin):
         secret = 'Use more salt.'
         crypted = '-----BEGIN PGP MESSAGE-----!@#$%^&*()_+-----END PGP MESSAGE-----'
 
+        multisecret = 'password is {0} and salt is {0}'.format(secret)
+        multicrypted = 'password is {0} and salt is {0}'.format(crypted)
+
         class GPGDecrypt(object):
+
             def communicate(self, *args, **kwargs):
                 return [secret, None]
 
         class GPGNotDecrypt(object):
+
             def communicate(self, *args, **kwargs):
                 return [None, 'decrypt error']
 
@@ -58,8 +65,12 @@ class GPGTestCase(TestCase, LoaderModuleMockMixin):
                 patch('salt.utils.path.which', MagicMock()):
             with patch('salt.renderers.gpg.Popen', MagicMock(return_value=GPGDecrypt())):
                 self.assertEqual(gpg._decrypt_ciphertexts(crypted), secret)
+                self.assertEqual(
+                    gpg._decrypt_ciphertexts(multicrypted), multisecret)
             with patch('salt.renderers.gpg.Popen', MagicMock(return_value=GPGNotDecrypt())):
                 self.assertEqual(gpg._decrypt_ciphertexts(crypted), crypted)
+                self.assertEqual(
+                    gpg._decrypt_ciphertexts(multicrypted), multicrypted)
 
     def test__decrypt_object(self):
         '''

--- a/tests/unit/renderers/test_gpg.py
+++ b/tests/unit/renderers/test_gpg.py
@@ -44,7 +44,7 @@ class GPGTestCase(TestCase, LoaderModuleMockMixin):
         '''
         key_dir = '/etc/salt/gpgkeys'
         secret = 'Use more salt.'
-        crypted = '!@#$%^&*()_+'
+        crypted = '-----BEGIN PGP MESSAGE-----!@#$%^&*()_+-----END PGP MESSAGE-----'
 
         class GPGDecrypt(object):
             def communicate(self, *args, **kwargs):
@@ -57,9 +57,9 @@ class GPGTestCase(TestCase, LoaderModuleMockMixin):
         with patch('salt.renderers.gpg._get_key_dir', MagicMock(return_value=key_dir)), \
                 patch('salt.utils.path.which', MagicMock()):
             with patch('salt.renderers.gpg.Popen', MagicMock(return_value=GPGDecrypt())):
-                self.assertEqual(gpg._decrypt_ciphertext(crypted), secret)
+                self.assertEqual(gpg._decrypt_ciphertexts(crypted), secret)
             with patch('salt.renderers.gpg.Popen', MagicMock(return_value=GPGNotDecrypt())):
-                self.assertEqual(gpg._decrypt_ciphertext(crypted), crypted)
+                self.assertEqual(gpg._decrypt_ciphertexts(crypted), crypted)
 
     def test__decrypt_object(self):
         '''
@@ -67,7 +67,7 @@ class GPGTestCase(TestCase, LoaderModuleMockMixin):
         '''
 
         secret = 'Use more salt.'
-        crypted = '-----BEGIN PGP MESSAGE-----!@#$%^&*()_+'
+        crypted = '-----BEGIN PGP MESSAGE-----!@#$%^&*()_+-----END PGP MESSAGE-----'
 
         secret_map = {'secret': secret}
         crypted_map = {'secret': crypted}


### PR DESCRIPTION
### What does this PR do?
This PR allows to encode more than one secret in a single pillar value. Moreover, it prevents `gpg` renderer stripping surrounding unencrypted text.

### What issues does this PR fix or reference?
With current behaviour it is not possible to use `gpg` renderer in the middle of a renderer pipe-chain:
* you either have to use it first (encrypting the whole file and chaining other renderers afterwards), but it is not very straightforward to modify the pillar structure as you have to decrypt the whole `sls`, do modifications and encrypt again
* or use it last in the chain, but then you cannot have pillar values, which contain multiple secrets in a single value. Also, you can't have secrets mixed with plaintext data, because all plaintext data is stripped upon decryption
* because of the above, you cannot have a renderer, which does additional processing of data chained after `gpg` renderer, for example:

```
#!pgp|xml

<foo>
  <bar>
    -----BEGIN PGP MESSAGE-----<super key here>-----END PGP MESSAGE-----
  </bar>
</foo>
```

### Previous Behavior
pillar:
```
#!yaml|gpg

foo:
  bar: |
    this is my complex pillar value
    it has a password:
    -----BEGIN PGP MESSAGE-----<encrypted password>-----END PGP MESSAGE-----
    and salt:
    -----BEGIN PGP MESSAGE-----<encrypted salt>-----END PGP MESSAGE-----
```
will be rendered as
```
foo:
  bar: |
    <decrypted password>
```
`gpg` will render only the first ciphertext and strip the rest of plaintext and the second ciphertext

### New Behavior
pillar:
```
#!yaml|gpg

foo:
  bar: |
    this is my complex pillar value
    it has a password:
    -----BEGIN PGP MESSAGE-----<encrypted password>-----END PGP MESSAGE-----
    and salt:
    -----BEGIN PGP MESSAGE-----<encrypted salt>-----END PGP MESSAGE-----
```
will be rendered as
```
  bar: |
    this is my complex pillar value
    it has a password:
    <decrypted password>
    and salt:
    <decrypted salt>
```

### Tests written?
Yes

### Commits signed with GPG?
No
