### PR TITLE
 Fix race condition in Salt loader.

### DIFF
--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -82,7 +82,6 @@ import hashlib
 import binascii
 import datetime
 import base64
-import msgpack
 import re
 import decimal
 
@@ -91,6 +90,7 @@ import salt.utils.cloud
 import salt.utils.files
 import salt.utils.hashutils
 import salt.utils.json
+import salt.utils.msgpack
 import salt.utils.stringutils
 import salt.utils.yaml
 from salt._compat import ElementTree as ET
@@ -4840,7 +4840,7 @@ def _parse_pricing(url, name):
         __opts__['cachedir'], 'ec2-pricing-{0}.p'.format(name)
     )
     with salt.utils.files.fopen(outfile, 'w') as fho:
-        msgpack.dump(regions, fho)
+        salt.utils.msgpack.dump(regions, fho)
 
     return True
 
@@ -4908,7 +4908,8 @@ def show_pricing(kwargs=None, call=None):
         update_pricing({'type': name}, 'function')
 
     with salt.utils.files.fopen(pricefile, 'r') as fhi:
-        ec2_price = salt.utils.stringutils.to_unicode(msgpack.load(fhi))
+        ec2_price = salt.utils.stringutils.to_unicode(
+            salt.utils.msgpack.load(fhi))
 
     region = get_location(profile)
     size = profile.get('size', None)

--- a/salt/cloud/clouds/gce.py
+++ b/salt/cloud/clouds/gce.py
@@ -53,7 +53,6 @@ import sys
 import re
 import pprint
 import logging
-import msgpack
 from ast import literal_eval
 from salt.utils.versions import LooseVersion as _LooseVersion
 
@@ -91,6 +90,7 @@ from salt.ext import six
 import salt.utils.cloud
 import salt.utils.files
 import salt.utils.http
+import salt.utils.msgpack
 import salt.config as config
 from salt.cloud.libcloudfuncs import *  # pylint: disable=redefined-builtin,wildcard-import,unused-wildcard-import
 from salt.exceptions import (
@@ -2619,7 +2619,7 @@ def update_pricing(kwargs=None, call=None):
         __opts__['cachedir'], 'gce-pricing.p'
     )
     with salt.utils.files.fopen(outfile, 'w') as fho:
-        msgpack.dump(price_json['dict'], fho)
+        salt.utils.msgpack.dump(price_json['dict'], fho)
 
     return True
 
@@ -2658,7 +2658,7 @@ def show_pricing(kwargs=None, call=None):
         update_pricing()
 
     with salt.utils.files.fopen(pricefile, 'r') as fho:
-        sizes = msgpack.load(fho)
+        sizes = salt.utils.msgpack.load(fho)
 
     per_hour = float(sizes['gcp_price_list'][size][region])
 

--- a/salt/engines/stalekey.py
+++ b/salt/engines/stalekey.py
@@ -28,11 +28,11 @@ import salt.config
 import salt.key
 import salt.utils.files
 import salt.utils.minions
+import salt.utils.msgpack
 import salt.wheel
 
 # Import 3rd-party libs
 from salt.ext import six
-import msgpack
 
 log = logging.getLogger(__name__)
 
@@ -60,7 +60,7 @@ def start(interval=3600, expire=604800):
         if os.path.exists(presence_file):
             try:
                 with salt.utils.files.fopen(presence_file, 'r') as f:
-                    minions = msgpack.load(f)
+                    minions = salt.utils.msgpack.load(f)
             except IOError as e:
                 log.error('Could not open presence file %s: %s', presence_file, e)
                 time.sleep(interval)
@@ -95,7 +95,7 @@ def start(interval=3600, expire=604800):
 
         try:
             with salt.utils.files.fopen(presence_file, 'w') as f:
-                msgpack.dump(minions, f)
+                salt.utils.msgpack.dump(minions, f)
         except IOError as e:
             log.error('Could not write to presence file %s: %s', presence_file, e)
         time.sleep(interval)

--- a/salt/key.py
+++ b/salt/key.py
@@ -38,9 +38,10 @@ from salt.ext import six
 from salt.ext.six.moves import input
 # pylint: enable=import-error,no-name-in-module,redefined-builtin
 
-# Import third party libs
+# We do not always need msgpack, so we do not want to fail here if msgpack is
+# not available.
 try:
-    import msgpack
+    import salt.utils.msgpack
 except ImportError:
     pass
 
@@ -1035,7 +1036,7 @@ class RaetKey(Key):
                     if ext == '.json':
                         data = salt.utils.json.load(fp_)
                     elif ext == '.msgpack':
-                        data = msgpack.load(fp_)
+                        data = salt.utils.msgpack.load(fp_)
                     role = salt.utils.stringutils.to_unicode(data['role'])
                     if role not in minions:
                         os.remove(path)

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -13,6 +13,7 @@ import time
 import logging
 import inspect
 import tempfile
+import threading
 import functools
 import types
 from collections import MutableMapping
@@ -28,6 +29,7 @@ import salt.utils.files
 import salt.utils.lazy
 import salt.utils.odict
 import salt.utils.platform
+import salt.utils.thread_local_proxy
 import salt.utils.versions
 from salt.exceptions import LoaderError
 from salt.template import check_render_pipe_str
@@ -1003,6 +1005,76 @@ def _mod_type(module_path):
     return 'ext'
 
 
+def _inject_into_mod(mod, name, value, force_lock=False):
+    '''
+    Inject a variable into a module. This is used to inject "globals" like
+    ``__salt__``, ``__pillar``, or ``grains``.
+
+    Instead of injecting the value directly, a ``ThreadLocalProxy`` is created.
+    If such a proxy is already present under the specified name, it is updated
+    with the new value. This update only affects the current thread, so that
+    the same name can refer to different values depending on the thread of
+    execution.
+
+    This is important for data that is not truly global. For example, pillar
+    data might be dynamically overriden through function parameters and thus
+    the actual values available in pillar might depend on the thread that is
+    calling a module.
+
+    mod:
+        module object into which the value is going to be injected.
+
+    name:
+        name of the variable that is injected into the module.
+
+    value:
+        value that is injected into the variable. The value is not injected
+        directly, but instead set as the new reference of the proxy that has
+        been created for the variable.
+
+    force_lock:
+        whether the lock should be acquired before checking whether a proxy
+        object for the specified name has already been injected into the
+        module. If ``False`` (the default), this function checks for the
+        module's variable without acquiring the lock and only acquires the lock
+        if a new proxy has to be created and injected.
+    '''
+    from salt.utils.thread_local_proxy import ThreadLocalProxy
+    old_value = getattr(mod, name, None)
+    # We use a double-checked locking scheme in order to avoid taking the lock
+    # when a proxy object has already been injected.
+    # In most programming languages, double-checked locking is considered
+    # unsafe when used without explicit memory barriers because one might read
+    # an uninitialized value. In CPython it is safe due to the global
+    # interpreter lock (GIL). In Python implementations that do not have the
+    # GIL, it could be unsafe, but at least Jython also guarantees that (for
+    # Python objects) memory is not corrupted when writing and reading without
+    # explicit synchronization
+    # (http://www.jython.org/jythonbook/en/1.0/Concurrency.html).
+    # Please note that in order to make this code safe in a runtime environment
+    # that does not make this guarantees, it is not sufficient. The
+    # ThreadLocalProxy must also be created with fallback_to_shared set to
+    # False or a lock must be added to the ThreadLocalProxy.
+    if force_lock:
+        with _inject_into_mod.lock:
+            if isinstance(old_value, ThreadLocalProxy):
+                ThreadLocalProxy.set_reference(old_value, value)
+            else:
+                setattr(mod, name, ThreadLocalProxy(value, True))
+    else:
+        if isinstance(old_value, ThreadLocalProxy):
+            ThreadLocalProxy.set_reference(old_value, value)
+        else:
+            _inject_into_mod(mod, name, value, True)
+
+
+# Lock used when injecting globals. This is needed to avoid a race condition
+# when two threads try to load the same module concurrently. This must be
+# outside the loader because there might be more than one loader for the same
+# namespace.
+_inject_into_mod.lock = threading.RLock()
+
+
 # TODO: move somewhere else?
 class FilterDictWrapper(MutableMapping):
     '''
@@ -1493,7 +1565,7 @@ class LazyLoader(salt.utils.lazy.LazyDict):
 
         # pack whatever other globals we were asked to
         for p_name, p_value in six.iteritems(self.pack):
-            setattr(mod, p_name, p_value)
+            _inject_into_mod(mod, p_name, p_value)
 
         module_name = mod.__name__.rsplit('.', 1)[-1]
 

--- a/salt/log/handlers/fluent_mod.py
+++ b/salt/log/handlers/fluent_mod.py
@@ -97,14 +97,17 @@ log = logging.getLogger(__name__)
 try:
     # Attempt to import msgpack
     import msgpack
+    import salt.utils.msgpack
     # There is a serialization issue on ARM and potentially other platforms
     # for some msgpack bindings, check for it
     if msgpack.loads(msgpack.dumps([1, 2, 3]), use_list=True) is None:
         raise ImportError
+    import salt.utils.msgpack
 except ImportError:
     # Fall back to msgpack_pure
     try:
         import msgpack_pure as msgpack
+        import salt.utils.msgpack
     except ImportError:
         # TODO: Come up with a sane way to get a configured logfile
         #       and write to the logfile when this error is hit also
@@ -456,7 +459,7 @@ class FluentSender(object):
         packet = (tag, timestamp, data)
         if self.verbose:
             print(packet)
-        return msgpack.packb(packet)
+        return salt.utils.msgpack.packb(packet, _msgpack_module=msgpack)
 
     def _send(self, bytes_):
         self.lock.acquire()

--- a/salt/modules/saltcheck.py
+++ b/salt/modules/saltcheck.py
@@ -51,7 +51,7 @@ from __future__ import absolute_import, unicode_literals, print_function
 import logging
 import os
 import time
-from json import loads, dumps
+from salt.utils.json import loads, dumps
 try:
     import salt.utils.files
     import salt.utils.path

--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -34,6 +34,7 @@ import salt.utils.functools
 import salt.utils.hashutils
 import salt.utils.jid
 import salt.utils.json
+import salt.utils.msgpack
 import salt.utils.platform
 import salt.utils.state
 import salt.utils.stringutils
@@ -44,7 +45,6 @@ from salt.runners.state import orchestrate as _orchestrate
 
 # Import 3rd-party libs
 from salt.ext import six
-import msgpack
 
 __proxyenabled__ = ['*']
 
@@ -184,7 +184,7 @@ def _get_pause(jid, state_id=None):
             data[state_id] = {}
     if os.path.exists(pause_path):
         with salt.utils.files.fopen(pause_path, 'rb') as fp_:
-            data = msgpack.loads(fp_.read())
+            data = salt.utils.msgpack.loads(fp_.read())
     return data, pause_path
 
 
@@ -255,7 +255,7 @@ def soft_kill(jid, state_id=None):
     data, pause_path = _get_pause(jid, state_id)
     data[state_id]['kill'] = True
     with salt.utils.files.fopen(pause_path, 'wb') as fp_:
-        fp_.write(msgpack.dumps(data))
+        fp_.write(salt.utils.msgpack.dumps(data))
 
 
 def pause(jid, state_id=None, duration=None):
@@ -290,7 +290,7 @@ def pause(jid, state_id=None, duration=None):
     if duration:
         data[state_id]['duration'] = int(duration)
     with salt.utils.files.fopen(pause_path, 'wb') as fp_:
-        fp_.write(msgpack.dumps(data))
+        fp_.write(salt.utils.msgpack.dumps(data))
 
 
 def resume(jid, state_id=None):
@@ -324,7 +324,7 @@ def resume(jid, state_id=None):
     if state_id == '__all__':
         data = {}
     with salt.utils.files.fopen(pause_path, 'wb') as fp_:
-        fp_.write(msgpack.dumps(data))
+        fp_.write(salt.utils.msgpack.dumps(data))
 
 
 def orchestrate(mods,

--- a/salt/modules/win_repo.py
+++ b/salt/modules/win_repo.py
@@ -31,11 +31,8 @@ from salt.runners.winrepo import (
     PER_REMOTE_ONLY
 )
 from salt.ext import six
-try:
-    import msgpack
-except ImportError:
-    import msgpack_pure as msgpack  # pylint: disable=import-error
 import salt.utils.gitfs
+import salt.utils.msgpack
 # pylint: enable=unused-import
 
 log = logging.getLogger(__name__)

--- a/salt/payload.py
+++ b/salt/payload.py
@@ -55,6 +55,10 @@ except ImportError:
         #sys.exit(salt.defaults.exitcodes.EX_GENERIC)
 
 
+if HAS_MSGPACK:
+    import salt.utils.msgpack
+
+
 if HAS_MSGPACK and not hasattr(msgpack, 'exceptions'):
     class PackValueError(Exception):
         '''
@@ -75,14 +79,15 @@ def package(payload):
     This method for now just wraps msgpack.dumps, but it is here so that
     we can make the serialization a custom option in the future with ease.
     '''
-    return msgpack.dumps(payload)
+    return salt.utils.msgpack.dumps(payload, _msgpack_module=msgpack)
 
 
 def unpackage(package_):
     '''
     Unpackages a payload
     '''
-    return msgpack.loads(package_, use_list=True)
+    return salt.utils.msgpack.loads(package_, use_list=True,
+                                    _msgpack_module=msgpack)
 
 
 def format_payload(enc, **kwargs):
@@ -141,9 +146,14 @@ class Serial(object):
                 # Due to this, if we don't need it, don't pass it at all so
                 # that under Python 2 we can still work with older versions
                 # of msgpack.
-                ret = msgpack.loads(msg, use_list=True, ext_hook=ext_type_decoder, encoding=encoding)
+                ret = salt.utils.msgpack.loads(msg, use_list=True,
+                                               ext_hook=ext_type_decoder,
+                                               encoding=encoding,
+                                               _msgpack_module=msgpack)
             else:
-                ret = msgpack.loads(msg, use_list=True, ext_hook=ext_type_decoder)
+                ret = salt.utils.msgpack.loads(msg, use_list=True,
+                                               ext_hook=ext_type_decoder,
+                                               _msgpack_module=msgpack)
             if six.PY3 and encoding is None and not raw:
                 ret = salt.transport.frame.decode_embedded_strs(ret)
         except Exception as exc:
@@ -210,9 +220,12 @@ class Serial(object):
                 # Due to this, if we don't need it, don't pass it at all so
                 # that under Python 2 we can still work with older versions
                 # of msgpack.
-                return msgpack.dumps(msg, default=ext_type_encoder, use_bin_type=use_bin_type)
+                return salt.utils.msgpack.dumps(msg, default=ext_type_encoder,
+                                                use_bin_type=use_bin_type,
+                                                _msgpack_module=msgpack)
             else:
-                return msgpack.dumps(msg, default=ext_type_encoder)
+                return salt.utils.msgpack.dumps(msg, default=ext_type_encoder,
+                                                _msgpack_module=msgpack)
         except (OverflowError, msgpack.exceptions.PackValueError):
             # msgpack<=0.4.6 don't call ext encoder on very long integers raising the error instead.
             # Convert any very long longs to strings and call dumps again.
@@ -235,9 +248,12 @@ class Serial(object):
 
             msg = verylong_encoder(msg)
             if msgpack.version >= (0, 4, 0):
-                return msgpack.dumps(msg, default=ext_type_encoder, use_bin_type=use_bin_type)
+                return salt.utils.msgpack.dumps(msg, default=ext_type_encoder,
+                                                use_bin_type=use_bin_type,
+                                                _msgpack_module=msgpack)
             else:
-                return msgpack.dumps(msg, default=ext_type_encoder)
+                return salt.utils.msgpack.dumps(msg, default=ext_type_encoder,
+                                                _msgpack_module=msgpack)
 
     def dump(self, msg, fn_):
         '''

--- a/salt/renderers/msgpack.py
+++ b/salt/renderers/msgpack.py
@@ -1,10 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, print_function, unicode_literals
 
-# Import third party libs
-import msgpack
-
 # Import salt libs
+import salt.utils.msgpack
 from salt.ext import six
 
 
@@ -28,4 +26,4 @@ def render(msgpack_data, saltenv='base', sls='', **kws):
         msgpack_data = msgpack_data[(msgpack_data.find('\n') + 1):]
     if not msgpack_data.strip():
         return {}
-    return msgpack.loads(msgpack_data)
+    return salt.utils.msgpack.loads(msgpack_data)

--- a/salt/returners/local_cache.py
+++ b/salt/returners/local_cache.py
@@ -20,11 +20,11 @@ import salt.utils.atomicfile
 import salt.utils.files
 import salt.utils.jid
 import salt.utils.minions
+import salt.utils.msgpack
 import salt.utils.stringutils
 import salt.exceptions
 
 # Import 3rd-party libs
-import msgpack
 from salt.ext import six
 from salt.ext.six.moves import range  # pylint: disable=import-error,redefined-builtin
 
@@ -514,7 +514,7 @@ def save_reg(data):
             raise
     try:
         with salt.utils.files.fopen(regfile, 'a') as fh_:
-            msgpack.dump(data, fh_)
+            salt.utils.msgpack.dump(data, fh_)
     except:
         log.error('Could not write to msgpack file %s', __opts__['outdir'])
         raise
@@ -528,7 +528,7 @@ def load_reg():
     regfile = os.path.join(reg_dir, 'register')
     try:
         with salt.utils.files.fopen(regfile, 'r') as fh_:
-            return msgpack.load(fh_)
+            return salt.utils.msgpack.load(fh_)
     except:
         log.error('Could not write to msgpack file %s', __opts__['outdir'])
         raise

--- a/salt/runners/winrepo.py
+++ b/salt/runners/winrepo.py
@@ -12,15 +12,12 @@ import os
 
 # Import third party libs
 from salt.ext import six
-try:
-    import msgpack
-except ImportError:
-    import msgpack_pure as msgpack  # pylint: disable=import-error
 
 # Import salt libs
 from salt.exceptions import CommandExecutionError, SaltRenderError
 import salt.utils.files
 import salt.utils.gitfs
+import salt.utils.msgpack
 import salt.utils.path
 import logging
 import salt.minion
@@ -124,7 +121,7 @@ def genrepo(opts=None, fire_event=True):
                     ret.setdefault('name_map', {}).update(revmap)
     with salt.utils.files.fopen(
             os.path.join(winrepo_dir, winrepo_cachefile), 'w+b') as repo:
-        repo.write(msgpack.dumps(ret))
+        repo.write(salt.utils.msgpack.dumps(ret))
     return ret
 
 

--- a/salt/sdb/sqlite3.py
+++ b/salt/sdb/sqlite3.py
@@ -54,10 +54,8 @@ except ImportError:
     HAS_SQLITE3 = False
 
 # Import salt libs
+import salt.utils.msgpack
 from salt.ext import six
-
-# Import third party libs
-import msgpack
 
 
 DEFAULT_TABLE = 'sdb'
@@ -126,9 +124,9 @@ def set_(key, value, profile=None):
         return False
     conn, cur, table = _connect(profile)
     if six.PY2:
-        value = buffer(msgpack.packb(value))
+        value = buffer(salt.utils.msgpack.packb(value))
     else:
-        value = memoryview(msgpack.packb(value))
+        value = memoryview(salt.utils.msgpack.packb(value))
     q = profile.get('set_query', ('INSERT OR REPLACE INTO {0} VALUES '
                                   '(:key, :value)').format(table))
     conn.execute(q, {'key': key, 'value': value})
@@ -149,4 +147,4 @@ def get(key, profile=None):
     res = res.fetchone()
     if not res:
         return None
-    return msgpack.unpackb(res[0])
+    return salt.utils.msgpack.unpackb(res[0])

--- a/salt/state.py
+++ b/salt/state.py
@@ -38,6 +38,7 @@ import salt.utils.dictupdate
 import salt.utils.event
 import salt.utils.files
 import salt.utils.immutabletypes as immutabletypes
+import salt.utils.msgpack
 import salt.utils.platform
 import salt.utils.process
 import salt.utils.url
@@ -1746,7 +1747,7 @@ class State(object):
                 # and the attempt, we are safe to pass
                 pass
         with salt.utils.files.fopen(tfile, 'wb+') as fp_:
-            fp_.write(msgpack.dumps(ret))
+            fp_.write(salt.utils.msgpack.dumps(ret, _msgpack_module=msgpack))
 
     def call_parallel(self, cdata, low):
         '''
@@ -2147,7 +2148,8 @@ class State(object):
                     tries = 0
                     with salt.utils.files.fopen(pause_path, 'rb') as fp_:
                         try:
-                            pdat = msgpack.loads(fp_.read())
+                            pdat = salt.utils.msgpack.loads(
+                                fp_.read(), _msgpack_module=msgpack)
                         except msgpack.UnpackValueError:
                             # Reading race condition
                             if tries > 10:
@@ -2194,7 +2196,8 @@ class State(object):
                                'changes': {}}
                     try:
                         with salt.utils.files.fopen(ret_cache, 'rb') as fp_:
-                            ret = msgpack.loads(fp_.read())
+                            ret = salt.utils.msgpack.loads(
+                                fp_.read(), _msgpack_module=msgpack)
                     except (OSError, IOError):
                         ret = {'result': False,
                                'comment': 'Parallel cache failure',

--- a/salt/states/netsnmp.py
+++ b/salt/states/netsnmp.py
@@ -23,9 +23,8 @@ from __future__ import absolute_import, print_function, unicode_literals
 import logging
 log = logging.getLogger(__name__)
 
-from json import loads, dumps
-
 # salt lib
+from salt.utils.json import loads, dumps
 from salt.ext import six
 # import NAPALM utils
 import salt.utils.napalm

--- a/salt/states/netusers.py
+++ b/salt/states/netusers.py
@@ -25,9 +25,9 @@ log = logging.getLogger(__name__)
 
 # Python std lib
 from copy import deepcopy
-from json import loads, dumps
 
 # salt lib
+from salt.utils.json import loads, dumps
 from salt.ext import six
 # import NAPALM utils
 import salt.utils.napalm

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -135,10 +135,6 @@ if salt.utils.platform.is_windows():
     # The following imports are used by the namespaced win_pkg funcs
     # and need to be included in their globals.
     # pylint: disable=import-error,unused-import
-    try:
-        import msgpack
-    except ImportError:
-        import msgpack_pure as msgpack
     from salt.utils.versions import LooseVersion
     # pylint: enable=import-error,unused-import
 # pylint: enable=invalid-name

--- a/salt/states/probes.py
+++ b/salt/states/probes.py
@@ -25,9 +25,9 @@ import logging
 log = logging.getLogger(__name__)
 
 from copy import deepcopy
-from json import loads, dumps
 
 # salt modules
+from salt.utils.json import loads, dumps
 from salt.ext import six
 # import NAPALM utils
 import salt.utils.napalm

--- a/salt/states/zabbix_host.py
+++ b/salt/states/zabbix_host.py
@@ -7,7 +7,7 @@ Management of Zabbix hosts.
 
 '''
 from __future__ import absolute_import, print_function, unicode_literals
-from json import loads, dumps
+from salt.utils.json import loads, dumps
 from copy import deepcopy
 from salt.ext import six
 

--- a/salt/states/zabbix_user.py
+++ b/salt/states/zabbix_user.py
@@ -9,7 +9,7 @@ Management of Zabbix users.
 
 # Import Python libs
 from __future__ import absolute_import, print_function, unicode_literals
-from json import loads, dumps
+from salt.utils.json import loads, dumps
 from copy import deepcopy
 
 # Import Salt libs

--- a/salt/transport/frame.py
+++ b/salt/transport/frame.py
@@ -4,7 +4,7 @@ Helper functions for transport components to handle message framing
 '''
 # Import python libs
 from __future__ import absolute_import, print_function, unicode_literals
-import msgpack
+import salt.utils.msgpack
 from salt.ext import six
 
 
@@ -18,7 +18,7 @@ def frame_msg(body, header=None, raw_body=False):  # pylint: disable=unused-argu
 
     framed_msg['head'] = header
     framed_msg['body'] = body
-    return msgpack.dumps(framed_msg)
+    return salt.utils.msgpack.dumps(framed_msg)
 
 
 def frame_msg_ipc(body, header=None, raw_body=False):  # pylint: disable=unused-argument
@@ -35,9 +35,9 @@ def frame_msg_ipc(body, header=None, raw_body=False):  # pylint: disable=unused-
     framed_msg['head'] = header
     framed_msg['body'] = body
     if six.PY2:
-        return msgpack.dumps(framed_msg)
+        return salt.utils.msgpack.dumps(framed_msg)
     else:
-        return msgpack.dumps(framed_msg, use_bin_type=True)
+        return salt.utils.msgpack.dumps(framed_msg, use_bin_type=True)
 
 
 def _decode_embedded_list(src):

--- a/salt/utils/cache.py
+++ b/salt/utils/cache.py
@@ -9,7 +9,7 @@ import re
 import time
 import logging
 try:
-    import msgpack
+    import salt.utils.msgpack
     HAS_MSGPACK = True
 except ImportError:
     HAS_MSGPACK = False
@@ -139,7 +139,9 @@ class CacheDisk(CacheDict):
         if not HAS_MSGPACK or not os.path.exists(self._path):
             return
         with salt.utils.files.fopen(self._path, 'rb') as fp_:
-            cache = salt.utils.data.decode(msgpack.load(fp_, encoding=__salt_system_encoding__))
+            cache = salt.utils.data.decode(
+                salt.utils.msgpack.load(
+                    fp_, encoding=__salt_system_encoding__))
         if "CacheDisk_cachetime" in cache:  # new format
             self._dict = cache["CacheDisk_data"]
             self._key_cache_time = cache["CacheDisk_cachetime"]
@@ -164,7 +166,7 @@ class CacheDisk(CacheDict):
                 "CacheDisk_data": self._dict,
                 "CacheDisk_cachetime": self._key_cache_time
             }
-            msgpack.dump(cache, fp_, use_bin_type=True)
+            salt.utils.msgpack.dump(cache, fp_, use_bin_type=True)
 
 
 class CacheCli(object):

--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -18,7 +18,6 @@ import subprocess
 import multiprocessing
 import logging
 import pipes
-import msgpack
 import traceback
 import copy
 import re
@@ -51,6 +50,7 @@ import salt.utils.crypt
 import salt.utils.data
 import salt.utils.event
 import salt.utils.files
+import salt.utils.msgpack
 import salt.utils.platform
 import salt.utils.stringutils
 import salt.utils.versions
@@ -2510,7 +2510,9 @@ def cachedir_index_add(minion_id, profile, driver, provider, base=None):
     if os.path.exists(index_file):
         mode = 'rb' if six.PY3 else 'r'
         with salt.utils.files.fopen(index_file, mode) as fh_:
-            index = salt.utils.data.decode(msgpack.load(fh_, encoding=MSGPACK_ENCODING))
+            index = salt.utils.data.decode(
+                salt.utils.msgpack.msgpack.load(
+                    fh_, encoding=MSGPACK_ENCODING))
     else:
         index = {}
 
@@ -2527,7 +2529,7 @@ def cachedir_index_add(minion_id, profile, driver, provider, base=None):
 
     mode = 'wb' if six.PY3 else 'w'
     with salt.utils.files.fopen(index_file, mode) as fh_:
-        msgpack.dump(index, fh_, encoding=MSGPACK_ENCODING)
+        salt.utils.msgpack.dump(index, fh_, encoding=MSGPACK_ENCODING)
 
     unlock_file(index_file)
 
@@ -2544,7 +2546,8 @@ def cachedir_index_del(minion_id, base=None):
     if os.path.exists(index_file):
         mode = 'rb' if six.PY3 else 'r'
         with salt.utils.files.fopen(index_file, mode) as fh_:
-            index = salt.utils.data.decode(msgpack.load(fh_, encoding=MSGPACK_ENCODING))
+            index = salt.utils.data.decode(
+                salt.utils.msgpack.load(fh_, encoding=MSGPACK_ENCODING))
     else:
         return
 
@@ -2553,7 +2556,7 @@ def cachedir_index_del(minion_id, base=None):
 
     mode = 'wb' if six.PY3 else 'w'
     with salt.utils.files.fopen(index_file, mode) as fh_:
-        msgpack.dump(index, fh_, encoding=MSGPACK_ENCODING)
+        salt.utils.msgpack.dump(index, fh_, encoding=MSGPACK_ENCODING)
 
     unlock_file(index_file)
 
@@ -2611,7 +2614,7 @@ def request_minion_cachedir(
     path = os.path.join(base, 'requested', fname)
     mode = 'wb' if six.PY3 else 'w'
     with salt.utils.files.fopen(path, mode) as fh_:
-        msgpack.dump(data, fh_, encoding=MSGPACK_ENCODING)
+        salt.utils.msgpack.dump(data, fh_, encoding=MSGPACK_ENCODING)
 
 
 def change_minion_cachedir(
@@ -2643,12 +2646,13 @@ def change_minion_cachedir(
     path = os.path.join(base, cachedir, fname)
 
     with salt.utils.files.fopen(path, 'r') as fh_:
-        cache_data = salt.utils.data.decode(msgpack.load(fh_, encoding=MSGPACK_ENCODING))
+        cache_data = salt.utils.data.decode(
+            salt.utils.msgpack.load(fh_, encoding=MSGPACK_ENCODING))
 
     cache_data.update(data)
 
     with salt.utils.files.fopen(path, 'w') as fh_:
-        msgpack.dump(cache_data, fh_, encoding=MSGPACK_ENCODING)
+        salt.utils.msgpack.dump(cache_data, fh_, encoding=MSGPACK_ENCODING)
 
 
 def activate_minion_cachedir(minion_id, base=None):
@@ -2722,7 +2726,8 @@ def list_cache_nodes_full(opts=None, provider=None, base=None):
                 minion_id = fname[:-2]  # strip '.p' from end of msgpack filename
                 mode = 'rb' if six.PY3 else 'r'
                 with salt.utils.files.fopen(fpath, mode) as fh_:
-                    minions[driver][prov][minion_id] = salt.utils.data.decode(msgpack.load(fh_, encoding=MSGPACK_ENCODING))
+                    minions[driver][prov][minion_id] = salt.utils.data.decode(
+                        salt.utils.msgpack.load(fh_, encoding=MSGPACK_ENCODING))
 
     return minions
 
@@ -2899,7 +2904,7 @@ def cache_node_list(nodes, provider, opts):
         path = os.path.join(prov_dir, '{0}.p'.format(node))
         mode = 'wb' if six.PY3 else 'w'
         with salt.utils.files.fopen(path, mode) as fh_:
-            msgpack.dump(nodes[node], fh_, encoding=MSGPACK_ENCODING)
+            salt.utils.msgpack.dump(nodes[node], fh_, encoding=MSGPACK_ENCODING)
 
 
 def cache_node(node, provider, opts):
@@ -2925,7 +2930,7 @@ def cache_node(node, provider, opts):
     path = os.path.join(prov_dir, '{0}.p'.format(node['name']))
     mode = 'wb' if six.PY3 else 'w'
     with salt.utils.files.fopen(path, mode) as fh_:
-        msgpack.dump(node, fh_, encoding=MSGPACK_ENCODING)
+        salt.utils.msgpack.dump(node, fh_, encoding=MSGPACK_ENCODING)
 
 
 def missing_node_cache(prov_dir, node_list, provider, opts):
@@ -3000,7 +3005,8 @@ def diff_node_cache(prov_dir, node, new_data, opts):
 
     with salt.utils.files.fopen(path, 'r') as fh_:
         try:
-            cache_data = salt.utils.data.decode(msgpack.load(fh_, encoding=MSGPACK_ENCODING))
+            cache_data = salt.utils.data.decode(
+                salt.utils.msgpack.load(fh_, encoding=MSGPACK_ENCODING))
         except ValueError:
             log.warning('Cache for %s was corrupt: Deleting', node)
             cache_data = {}

--- a/salt/utils/http.py
+++ b/salt/utils/http.py
@@ -83,7 +83,7 @@ except ImportError:
     HAS_REQUESTS = False
 
 try:
-    import msgpack
+    import salt.utils.msgpack
     HAS_MSGPACK = True
 except ImportError:
     HAS_MSGPACK = False
@@ -274,12 +274,12 @@ def query(url,
         # contain expirations, they can't be stored in a proper cookie jar.
         if os.path.isfile(session_cookie_jar):
             with salt.utils.files.fopen(session_cookie_jar, 'rb') as fh_:
-                session_cookies = msgpack.load(fh_)
+                session_cookies = salt.utils.msgpack.load(fh_)
             if isinstance(session_cookies, dict):
                 header_dict.update(session_cookies)
         else:
             with salt.utils.files.fopen(session_cookie_jar, 'wb') as fh_:
-                msgpack.dump('', fh_)
+                salt.utils.msgpack.dump('', fh_)
 
     for header in header_list:
         comps = header.split(':')
@@ -615,9 +615,9 @@ def query(url,
             with salt.utils.files.fopen(session_cookie_jar, 'wb') as fh_:
                 session_cookies = result_headers.get('set-cookie', None)
                 if session_cookies is not None:
-                    msgpack.dump({'Cookie': session_cookies}, fh_)
+                    salt.utils.msgpack.dump({'Cookie': session_cookies}, fh_)
                 else:
-                    msgpack.dump('', fh_)
+                    salt.utils.msgpack.dump('', fh_)
 
     if status is True:
         ret['status'] = result_status_code

--- a/salt/utils/json.py
+++ b/salt/utils/json.py
@@ -102,6 +102,7 @@ def dump(obj, fp, **kwargs):
     json_module = kwargs.pop('_json_module', json)
     if 'ensure_ascii' not in kwargs:
         kwargs['ensure_ascii'] = False
+    obj = salt.utils.thread_local_proxy.ThreadLocalProxy.unproxy_recursive(obj)
     if six.PY2:
         obj = salt.utils.data.encode(obj)
     return json_module.dump(obj, fp, **kwargs)  # future lint: blacklisted-function
@@ -126,6 +127,7 @@ def dumps(obj, **kwargs):
     json_module = kwargs.pop('_json_module', json)
     if 'ensure_ascii' not in kwargs:
         kwargs['ensure_ascii'] = False
+    obj = salt.utils.thread_local_proxy.ThreadLocalProxy.unproxy_recursive(obj)
     if six.PY2:
         obj = salt.utils.data.encode(obj)
     return json_module.dumps(obj, **kwargs)  # future lint: blacklisted-function

--- a/salt/utils/msgpack.py
+++ b/salt/utils/msgpack.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+'''
+Functions to work with MessagePack
+'''
+
+from __future__ import absolute_import
+
+# Import Python libs
+try:
+    # Attempt to import msgpack
+    import msgpack
+except ImportError:
+    # Fall back to msgpack_pure
+    import msgpack_pure as msgpack  # pylint: disable=import-error
+
+# Import Salt libs
+import salt.utils.thread_local_proxy
+
+
+def pack(o, stream, **kwargs):
+    '''
+    .. versionadded:: Oxygen
+
+    Wraps msgpack.pack and ensures that the passed object is unwrapped if it is
+    a proxy.
+
+    By default, this function uses the msgpack module and falls back to
+    msgpack_pure, if the msgpack is not available. You can pass an alternate
+    msgpack module using the _msgpack_module argument.
+    '''
+    msgpack_module = kwargs.pop('_msgpack_module', msgpack)
+    o = salt.utils.thread_local_proxy.ThreadLocalProxy.unproxy_recursive(o)
+    return msgpack_module.pack(o, stream, **kwargs)
+
+
+def packb(o, **kwargs):
+    '''
+    .. versionadded:: Oxygen
+
+    Wraps msgpack.packb and ensures that the passed object is unwrapped if it
+    is a proxy.
+
+    By default, this function uses the msgpack module and falls back to
+    msgpack_pure, if the msgpack is not available. You can pass an alternate
+    msgpack module using the _msgpack_module argument.
+    '''
+    msgpack_module = kwargs.pop('_msgpack_module', msgpack)
+    o = salt.utils.thread_local_proxy.ThreadLocalProxy.unproxy_recursive(o)
+    return msgpack_module.packb(o, **kwargs)
+
+
+def unpack(stream, **kwargs):
+    '''
+    .. versionadded:: Oxygen
+
+    Wraps msgpack.unpack.
+
+    By default, this function uses the msgpack module and falls back to
+    msgpack_pure, if the msgpack is not available. You can pass an alternate
+    msgpack module using the _msgpack_module argument.
+    '''
+    msgpack_module = kwargs.pop('_msgpack_module', msgpack)
+    return msgpack_module.unpack(stream, **kwargs)
+
+
+def unpackb(packed, **kwargs):
+    '''
+    .. versionadded:: Oxygen
+
+    Wraps msgpack.unpack.
+
+    By default, this function uses the msgpack module and falls back to
+    msgpack_pure, if the msgpack is not available. You can pass an alternate
+    msgpack module using the _msgpack_module argument.
+    '''
+    msgpack_module = kwargs.pop('_msgpack_module', msgpack)
+    return msgpack_module.unpackb(packed, **kwargs)
+
+
+# alias for compatibility to simplejson/marshal/pickle.
+load = unpack
+loads = unpackb
+
+dump = pack
+dumps = packb

--- a/salt/utils/thread_local_proxy.py
+++ b/salt/utils/thread_local_proxy.py
@@ -1,0 +1,738 @@
+# -*- coding: utf-8 -*-
+'''
+Proxy object that can reference different values depending on the current
+thread of execution.
+
+..versionadded:: Oxygen
+
+'''
+
+# Import python libs
+from __future__ import absolute_import
+import threading
+
+# Import 3rd-party libs
+from salt.ext import six
+
+
+# There are certain types which are sequences, but actually represent string
+# like objects. We need a list of these types for the recursive unproxy code.
+_STRING_LIKE_TYPES = (six.binary_type, six.string_types, six.text_type)
+
+
+class ThreadLocalProxy(object):
+    '''
+    Proxy that delegates all operations to its referenced object. The referenced
+    object is hold through a thread-local variable, so that this proxy may refer
+    to different objects in different threads of execution.
+
+    For all practical purposes (operators, attributes, `isinstance`), the proxy
+    acts like the referenced object. Thus, code receiving the proxy object
+    instead of the reference object typically does not have to be changed. The
+    only exception is code that explicitly uses the ``type()`` function for
+    checking the proxy's type. While `isinstance(proxy, ...)` will yield the
+    expected results (based on the actual type of the referenced object), using
+    something like ``issubclass(type(proxy), ...)`` will not work, because
+    these tests will be made on the type of the proxy object instead of the
+    type of the referenced object. In order to avoid this, such code must be
+    changed to use ``issubclass(type(ThreadLocalProxy.unproxy(proxy)), ...)``.
+
+    If an instance of this class is created with the ``fallback_to_shared`` flag
+    set and a thread uses the instance without setting the reference explicitly,
+    the reference for this thread is initialized with the latest reference set
+    by any thread.
+
+    This class has primarily been designed for use by the Salt loader, but it
+    might also be useful in other places.
+    '''
+
+    __slots__ = ['_thread_local', '_last_reference', '_fallback_to_shared']
+
+    @staticmethod
+    def get_reference(proxy):
+        '''
+        Return the object that is referenced by the specified proxy.
+
+        If the proxy has not been bound to a reference for the current thread,
+        the behavior depends on th the ``fallback_to_shared`` flag that has
+        been specified when creating the proxy. If the flag has been set, the
+        last reference that has been set by any thread is returned (and
+        silently set as the reference for the current thread). If the flag has
+        not been set, an ``AttributeError`` is raised.
+
+        If the object references by this proxy is itself a proxy, that proxy is
+        returned. Use ``unproxy`` for unwrapping the referenced object until it
+        is not a proxy.
+
+        proxy:
+            proxy object for which the reference shall be returned. If the
+            specified object is not an instance of `ThreadLocalProxy`, the
+            behavior is unspecified. Typically, an ``AttributeError`` is
+            going to be raised.
+        '''
+        thread_local = object.__getattribute__(proxy, '_thread_local')
+        try:
+            return thread_local.reference
+        except AttributeError:
+            fallback_to_shared = object.__getattribute__(
+                proxy, '_fallback_to_shared')
+            if fallback_to_shared:
+                # If the reference has never been set in the current thread of
+                # execution, we use the reference that has been last set by any
+                # thread.
+                reference = object.__getattribute__(proxy, '_last_reference')
+                # We save the reference in the thread local so that future
+                # calls to get_reference will have consistent results.
+                ThreadLocalProxy.set_reference(proxy, reference)
+                return reference
+            else:
+                # We could simply return None, but this would make it hard to
+                # debug situations where the reference has not been set (the
+                # problem might go unnoticed until some code tries to do
+                # something with the returned object and it might not be easy to
+                # find out from where the None value originates).
+                # For this reason, we raise an AttributeError with an error
+                # message explaining the problem.
+                raise AttributeError(
+                    'The proxy object has not been bound to a reference in this thread of execution.')
+
+    @staticmethod
+    def set_reference(proxy, new_reference):
+        '''
+        Set the reference to be used the current thread of execution.
+
+        After calling this function, the specified proxy will act like it was
+        the referenced object.
+
+        proxy:
+            proxy object for which the reference shall be set. If the specified
+            object is not an instance of `ThreadLocalProxy`, the behavior is
+            unspecified. Typically, an ``AttributeError`` is going to be
+            raised.
+
+        new_reference:
+            reference the proxy should point to for the current thread after
+            calling this function.
+        '''
+        # If the new reference is itself a proxy, we have to ensure that it does
+        # not refer to this proxy. If it does, we simply return because updating
+        # the reference would result in an inifite loop when trying to use the
+        # proxy.
+        possible_proxy = new_reference
+        while isinstance(possible_proxy, ThreadLocalProxy):
+            if possible_proxy is proxy:
+                return
+            possible_proxy = ThreadLocalProxy.get_reference(possible_proxy)
+        thread_local = object.__getattribute__(proxy, '_thread_local')
+        thread_local.reference = new_reference
+        object.__setattr__(proxy, '_last_reference', new_reference)
+
+    @staticmethod
+    def unset_reference(proxy):
+        '''
+        Unset the reference to be used by the current thread of execution.
+
+        After calling this function, the specified proxy will act like the
+        reference had never been set for the current thread.
+
+        proxy:
+            proxy object for which the reference shall be unset. If the
+            specified object is not an instance of `ThreadLocalProxy`, the
+            behavior is unspecified. Typically, an ``AttributeError`` is going
+            to be raised.
+        '''
+        thread_local = object.__getattribute__(proxy, '_thread_local')
+        del thread_local.reference
+
+    @staticmethod
+    def unproxy(possible_proxy):
+        '''
+        Unwrap and return the object referenced by a proxy.
+
+        This function is very similar to :func:`get_reference`, but works for
+        both proxies and regular objects. If the specified object is a proxy,
+        its reference is extracted with ``get_reference`` and returned. If it
+        is not a proxy, it is returned as is.
+
+        If the object references by the proxy is itself a proxy, the unwrapping
+        is repeated until a regular (non-proxy) object is found.
+
+        possible_proxy:
+            object that might or might not be a proxy.
+        '''
+        while isinstance(possible_proxy, ThreadLocalProxy):
+            possible_proxy = ThreadLocalProxy.get_reference(possible_proxy)
+        return possible_proxy
+
+    @staticmethod
+    def unproxy_recursive(obj):
+        '''
+        Recursively check an object for proxied members and convert it so that
+        it does not contain any proxies. This is mainly intended for code that
+        wants to serialize an object that might potentially be a proxy (or
+        contain proxies) using json or msgpack.
+
+        The passed object is not modified. Instead, a new object is created if
+        conversion is needed.
+
+        :param obj: object that shall be converted.
+        '''
+        return ThreadLocalProxy._unproxy_recursive(obj)
+
+    @staticmethod
+    def _unproxy_recursive(obj, seen_objects=()):
+        import collections
+        # If the object is a well-known proxy, we simply unwrap it. We still
+        # process the unwrapped object like a regular object because the wrapped
+        # object might actually be of a type that also requires conversion.
+        # Although unlikely, a proxy might actually wrap another proxy, so we
+        # unwrap until we find a non-proxy object.
+        unwrapped_obj = ThreadLocalProxy.unproxy(obj)
+        if obj is not unwrapped_obj:
+            return ThreadLocalProxy._unproxy_recursive(unwrapped_obj, seen_objects)
+        # If the object we are supposed to process is already being processed,
+        # we must not process it again, as this would result in an infinite
+        # loop. For example, if we are processing a dict, that contains a
+        # reference back to itself (even indirectly), we do not process the dict
+        # again and instead use the instance that is in progress of being
+        # processed.
+        for seen_obj in seen_objects:
+            if obj is seen_obj[0]:
+                return seen_obj[1]
+        # msgpack's C code does (some) checks on the class of the object instead of
+        # doing them on the object itself. In addition to that, it only supports
+        # the actual dict and list types (or sub-classes if not in strict mode).
+        # This means that we have to convert objects which are mappings but not
+        # dicts and objects that are sequences but not lists or tuples to a
+        # supported type.
+        obj_type = type(obj)
+        if issubclass(obj_type, memoryview):
+            # msgpack has special handling for memoryview objects, so we never
+            # convert such objects.
+            return obj
+        elif isinstance(obj, collections.Mapping):
+            if (not issubclass(obj_type, dict)
+                    or ThreadLocalProxy._needs_unproxy_recursive(obj)):
+                key_value_pairs = {}
+                seen_objects += ((obj, key_value_pairs),)
+                for key, value in six.iteritems(obj):
+                    converted_key = ThreadLocalProxy._unproxy_recursive(key,
+                        seen_objects)
+                    converted_value = ThreadLocalProxy._unproxy_recursive(value,
+                        seen_objects)
+                key_value_pairs[converted_key] = converted_value
+                return key_value_pairs
+            else:
+                return obj
+        elif isinstance(obj, _STRING_LIKE_TYPES):
+            # Strings (both unicode and raw) also are sequences, but we do not want
+            # to handle them as such. If the object is an instance of a string
+            # type, but its type is not a subclass, it might be a proxy.
+            if not issubclass(obj_type, _STRING_LIKE_TYPES):
+                if six.PY3:
+                    if isinstance(obj, bytes):
+                        return bytes(obj)
+                    else:
+                        return str(obj)
+                else:
+                    # pylint: disable=incompatible-py3-code
+                    if isinstance(obj, unicode):
+                        return unicode(obj)
+                    else:
+                        return str(obj)
+            else:
+                return obj
+        elif isinstance(obj, collections.Sequence):
+            # Both JSON and MessagePack treat tuples and lists in the same way,
+            # so we can convert tuples to lists without having any effect on the
+            # serialized data.
+            if (not (issubclass(obj_type, list) or issubclass(obj_type, tuple))
+                    or ThreadLocalProxy._needs_unproxy_recursive(obj)):
+                elems = []
+                seen_objects += ((obj, elems),)
+                for elem in obj:
+                    elems += [ThreadLocalProxy._unproxy_recursive(
+                        elem, seen_objects)]
+                return elems
+            else:
+                return obj
+        else:
+            return obj
+
+    @staticmethod
+    def _needs_unproxy_recursive(obj, seen_objects=()):
+        import collections
+        # If the object is a well-known proxy, unproxying is needed.
+        unwrapped_obj = ThreadLocalProxy.unproxy(obj)
+        if obj is not unwrapped_obj:
+            return True
+        # If the object we are supposed to process is already being processed,
+        # we must not process it again, as this would result in an infinite
+        # loop. For example, if we are processing a dict, that contains a
+        # reference back to itself (even indirectly), we do not process the dict
+        # again and instead return False. This is correct because the dict does
+        # not have to be unproxied unless it contains another object that needs
+        # to be unproxied and in that case this method will return True for that
+        # object.
+        if any(obj is x for x in seen_objects):
+            return False
+        # We basically make the same decisions here as in _unproxy_recursive, as
+        # we want to know whether _unproxy_recursive would return the same
+        # object or a new one.
+        obj_type = type(obj)
+        if issubclass(obj_type, memoryview):
+            return False
+        elif isinstance(obj, collections.Mapping):
+            seen_objects += (obj,)
+            return any(
+                ThreadLocalProxy._needs_unproxy_recursive(key, seen_objects)
+                    or ThreadLocalProxy._needs_unproxy_recursive(value,
+                                                                seen_objects)
+                for key, value in six.iteritems(obj))
+        elif isinstance(obj, _STRING_LIKE_TYPES):
+            return False
+        elif isinstance(obj, collections.Sequence):
+            seen_objects += (obj,)
+            return any(
+                ThreadLocalProxy._needs_unproxy_recursive(elem) for elem in obj)
+        else:
+            return False
+
+    def __init__(self, initial_reference, fallback_to_shared=False):
+        '''
+        Create a proxy object that references the specified object.
+
+        initial_reference:
+            object this proxy should initially reference (for the current
+            thread of execution). The :func:`set_reference` function is called
+            for the newly created proxy, passing this object.
+
+        fallback_to_shared:
+            flag indicating what should happen when the proxy is used in a
+            thread where the reference has not been set explicitly. If
+            ``True``, the thread's reference is silently initialized to use the
+            reference last set by any thread. If ``False`` (the default), an
+            exception is raised when the proxy is used in a thread without
+            first initializing the reference in this thread.
+        '''
+        object.__setattr__(self, '_thread_local', threading.local())
+        object.__setattr__(self, '_fallback_to_shared', fallback_to_shared)
+        ThreadLocalProxy.set_reference(self, initial_reference)
+
+    def __repr__(self):
+        reference = ThreadLocalProxy.get_reference(self)
+        return repr(reference)
+
+    def __str__(self):
+        reference = ThreadLocalProxy.get_reference(self)
+        return str(reference)
+
+    def __lt__(self, other):
+        reference = ThreadLocalProxy.get_reference(self)
+        other = ThreadLocalProxy.unproxy(other)
+        return reference < other
+
+    def __le__(self, other):
+        reference = ThreadLocalProxy.get_reference(self)
+        other = ThreadLocalProxy.unproxy(other)
+        return reference <= other
+
+    def __eq__(self, other):
+        reference = ThreadLocalProxy.get_reference(self)
+        other = ThreadLocalProxy.unproxy(other)
+        return reference == other
+
+    def __ne__(self, other):
+        reference = ThreadLocalProxy.get_reference(self)
+        other = ThreadLocalProxy.unproxy(other)
+        return reference != other
+
+    def __gt__(self, other):
+        reference = ThreadLocalProxy.get_reference(self)
+        other = ThreadLocalProxy.unproxy(other)
+        return reference > other
+
+    def __ge__(self, other):
+        reference = ThreadLocalProxy.get_reference(self)
+        other = ThreadLocalProxy.unproxy(other)
+        return reference >= other
+
+    def __hash__(self):
+        reference = ThreadLocalProxy.get_reference(self)
+        return hash(reference)
+
+    def __nonzero__(self):
+        reference = ThreadLocalProxy.get_reference(self)
+        return bool(reference)
+
+    def __getattr__(self, name):
+        reference = ThreadLocalProxy.get_reference(self)
+        # Old-style classes might not have a __getattr__ method, but using
+        # getattr(...) will still work.
+        try:
+            original_method = reference.__getattr__
+        except AttributeError:
+            return getattr(reference, name)
+        return reference.__getattr__(name)
+
+    def __setattr__(self, name, value):
+        reference = ThreadLocalProxy.get_reference(self)
+        reference.__setattr__(name, value)
+
+    def __delattr__(self, name):
+        reference = ThreadLocalProxy.get_reference(self)
+        reference.__delattr__(name)
+
+    def __getattribute__(self, name):
+        reference = ThreadLocalProxy.get_reference(self)
+        return reference.__getattribute__(name)
+
+    def __call__(self, *args, **kwargs):
+        reference = ThreadLocalProxy.get_reference(self)
+        return reference(*args, **kwargs)
+
+    def __len__(self):
+        reference = ThreadLocalProxy.get_reference(self)
+        return len(reference)
+
+    def __getitem__(self, key):
+        reference = ThreadLocalProxy.get_reference(self)
+        return reference[key]
+
+    def __setitem__(self, key, value):
+        reference = ThreadLocalProxy.get_reference(self)
+        reference[key] = value
+
+    def __delitem__(self, key):
+        reference = ThreadLocalProxy.get_reference(self)
+        del reference[key]
+
+    def __iter__(self):
+        reference = ThreadLocalProxy.get_reference(self)
+        return reference.__iter__()
+
+    def __reversed__(self):
+        reference = ThreadLocalProxy.get_reference(self)
+        return reversed(reference)
+
+    def __contains__(self, item):
+        reference = ThreadLocalProxy.get_reference(self)
+        return item in reference
+
+    def __add__(self, other):
+        reference = ThreadLocalProxy.get_reference(self)
+        other = ThreadLocalProxy.unproxy(other)
+        return reference + other
+
+    def __sub__(self, other):
+        reference = ThreadLocalProxy.get_reference(self)
+        other = ThreadLocalProxy.unproxy(other)
+        return reference - other
+
+    def __mul__(self, other):
+        reference = ThreadLocalProxy.get_reference(self)
+        other = ThreadLocalProxy.unproxy(other)
+        return reference * other
+
+    def __floordiv__(self, other):
+        reference = ThreadLocalProxy.get_reference(self)
+        other = ThreadLocalProxy.unproxy(other)
+        return reference // other
+
+    def __mod__(self, other):
+        reference = ThreadLocalProxy.get_reference(self)
+        other = ThreadLocalProxy.unproxy(other)
+        return reference % other
+
+    def __divmod__(self, other):
+        reference = ThreadLocalProxy.get_reference(self)
+        other = ThreadLocalProxy.unproxy(other)
+        return divmod(reference, other)
+
+    def __pow__(self, other, modulo=None):
+        reference = ThreadLocalProxy.get_reference(self)
+        other = ThreadLocalProxy.unproxy(other)
+        modulo = ThreadLocalProxy.unproxy(modulo)
+        if modulo is None:
+            return pow(reference, other)
+        else:
+            return pow(reference, other, modulo)
+
+    def __lshift__(self, other):
+        reference = ThreadLocalProxy.get_reference(self)
+        other = ThreadLocalProxy.unproxy(other)
+        return reference << other
+
+    def __rshift__(self, other):
+        reference = ThreadLocalProxy.get_reference(self)
+        other = ThreadLocalProxy.unproxy(other)
+        return reference >> other
+
+    def __and__(self, other):
+        reference = ThreadLocalProxy.get_reference(self)
+        other = ThreadLocalProxy.unproxy(other)
+        return reference & other
+
+    def __xor__(self, other):
+        reference = ThreadLocalProxy.get_reference(self)
+        other = ThreadLocalProxy.unproxy(other)
+        return reference ^ other
+
+    def __or__(self, other):
+        reference = ThreadLocalProxy.get_reference(self)
+        other = ThreadLocalProxy.unproxy(other)
+        return reference | other
+
+    def __div__(self, other):
+        reference = ThreadLocalProxy.get_reference(self)
+        other = ThreadLocalProxy.unproxy(other)
+        try:
+            func = reference.__div__
+        except AttributeError:
+            return NotImplemented
+        return func(other)
+
+    def __truediv__(self, other):
+        reference = ThreadLocalProxy.get_reference(self)
+        other = ThreadLocalProxy.unproxy(other)
+        try:
+            func = reference.__truediv__
+        except AttributeError:
+            return NotImplemented
+        return func(other)
+
+    def __radd__(self, other):
+        reference = ThreadLocalProxy.get_reference(self)
+        other = ThreadLocalProxy.unproxy(other)
+        return other + reference
+
+    def __rsub__(self, other):
+        reference = ThreadLocalProxy.get_reference(self)
+        other = ThreadLocalProxy.unproxy(other)
+        return other - reference
+
+    def __rmul__(self, other):
+        reference = ThreadLocalProxy.get_reference(self)
+        other = ThreadLocalProxy.unproxy(other)
+        return other * reference
+
+    def __rdiv__(self, other):
+        reference = ThreadLocalProxy.get_reference(self)
+        other = ThreadLocalProxy.unproxy(other)
+        try:
+            func = reference.__rdiv__
+        except AttributeError:
+            return NotImplemented
+        return func(other)
+
+    def __rtruediv__(self, other):
+        reference = ThreadLocalProxy.get_reference(self)
+        other = ThreadLocalProxy.unproxy(other)
+        try:
+            func = reference.__rtruediv__
+        except AttributeError:
+            return NotImplemented
+        return func(other)
+
+    def __rfloordiv__(self, other):
+        reference = ThreadLocalProxy.get_reference(self)
+        other = ThreadLocalProxy.unproxy(other)
+        return other // reference
+
+    def __rmod__(self, other):
+        reference = ThreadLocalProxy.get_reference(self)
+        other = ThreadLocalProxy.unproxy(other)
+        return other % reference
+
+    def __rdivmod__(self, other):
+        reference = ThreadLocalProxy.get_reference(self)
+        other = ThreadLocalProxy.unproxy(other)
+        return divmod(other, reference)
+
+    def __rpow__(self, other):
+        reference = ThreadLocalProxy.get_reference(self)
+        other = ThreadLocalProxy.unproxy(other)
+        return other ** reference
+
+    def __rlshift__(self, other):
+        reference = ThreadLocalProxy.get_reference(self)
+        other = ThreadLocalProxy.unproxy(other)
+        return other << reference
+
+    def __rrshift__(self, other):
+        reference = ThreadLocalProxy.get_reference(self)
+        other = ThreadLocalProxy.unproxy(other)
+        return other >> reference
+
+    def __rand__(self, other):
+        reference = ThreadLocalProxy.get_reference(self)
+        other = ThreadLocalProxy.unproxy(other)
+        return other & reference
+
+    def __rxor__(self, other):
+        reference = ThreadLocalProxy.get_reference(self)
+        other = ThreadLocalProxy.unproxy(other)
+        return other ^ reference
+
+    def __ror__(self, other):
+        reference = ThreadLocalProxy.get_reference(self)
+        other = ThreadLocalProxy.unproxy(other)
+        return other | reference
+
+    def __iadd__(self, other):
+        reference = ThreadLocalProxy.get_reference(self)
+        other = ThreadLocalProxy.unproxy(other)
+        reference += other
+        ThreadLocalProxy.set_reference(self, reference)
+        return reference
+
+    def __isub__(self, other):
+        reference = ThreadLocalProxy.get_reference(self)
+        other = ThreadLocalProxy.unproxy(other)
+        reference -= other
+        ThreadLocalProxy.set_reference(self, reference)
+        return reference
+
+    def __imul__(self, other):
+        reference = ThreadLocalProxy.get_reference(self)
+        other = ThreadLocalProxy.unproxy(other)
+        reference *= other
+        ThreadLocalProxy.set_reference(self, reference)
+        return reference
+
+    def __idiv__(self, other):
+        reference = ThreadLocalProxy.get_reference(self)
+        other = ThreadLocalProxy.unproxy(other)
+        try:
+            func = reference.__idiv__
+        except AttributeError:
+            return NotImplemented
+        reference = func(other)
+        ThreadLocalProxy.set_reference(self, reference)
+        return reference
+
+    def __itruediv__(self, other):
+        reference = ThreadLocalProxy.get_reference(self)
+        other = ThreadLocalProxy.unproxy(other)
+        try:
+            func = reference.__itruediv__
+        except AttributeError:
+            return NotImplemented
+        reference = func(other)
+        ThreadLocalProxy.set_reference(self, reference)
+        return reference
+
+    def __ifloordiv__(self, other):
+        reference = ThreadLocalProxy.get_reference(self)
+        other = ThreadLocalProxy.unproxy(other)
+        reference //= other
+        ThreadLocalProxy.set_reference(self, reference)
+        return reference
+
+    def __imod__(self, other):
+        reference = ThreadLocalProxy.get_reference(self)
+        other = ThreadLocalProxy.unproxy(other)
+        reference %= other
+        ThreadLocalProxy.set_reference(self, reference)
+        return reference
+
+    def __ipow__(self, other):
+        reference = ThreadLocalProxy.get_reference(self)
+        other = ThreadLocalProxy.unproxy(other)
+        reference **= other
+        ThreadLocalProxy.set_reference(self, reference)
+        return reference
+
+    def __ilshift__(self, other):
+        reference = ThreadLocalProxy.get_reference(self)
+        other = ThreadLocalProxy.unproxy(other)
+        reference <<= other
+        ThreadLocalProxy.set_reference(self, reference)
+        return reference
+
+    def __irshift__(self, other):
+        reference = ThreadLocalProxy.get_reference(self)
+        other = ThreadLocalProxy.unproxy(other)
+        reference >>= other
+        ThreadLocalProxy.set_reference(self, reference)
+        return reference
+
+    def __iand__(self, other):
+        reference = ThreadLocalProxy.get_reference(self)
+        other = ThreadLocalProxy.unproxy(other)
+        reference &= other
+        ThreadLocalProxy.set_reference(self, reference)
+        return reference
+
+    def __ixor__(self, other):
+        reference = ThreadLocalProxy.get_reference(self)
+        other = ThreadLocalProxy.unproxy(other)
+        reference ^= other
+        ThreadLocalProxy.set_reference(self, reference)
+        return reference
+
+    def __ior__(self, other):
+        reference = ThreadLocalProxy.get_reference(self)
+        other = ThreadLocalProxy.unproxy(other)
+        reference |= other
+        ThreadLocalProxy.set_reference(self, reference)
+        return reference
+
+    def __neg__(self):
+        reference = ThreadLocalProxy.get_reference(self)
+        return - reference
+
+    def __pos__(self):
+        reference = ThreadLocalProxy.get_reference(self)
+        return + reference
+
+    def __abs__(self):
+        reference = ThreadLocalProxy.get_reference(self)
+        return abs(reference)
+
+    def __invert__(self):
+        reference = ThreadLocalProxy.get_reference(self)
+        return ~ reference
+
+    def __complex__(self):
+        reference = ThreadLocalProxy.get_reference(self)
+        return complex(reference)
+
+    def __int__(self):
+        reference = ThreadLocalProxy.get_reference(self)
+        return int(reference)
+
+    def __float__(self):
+        reference = ThreadLocalProxy.get_reference(self)
+        return float(reference)
+
+    def __oct__(self):
+        reference = ThreadLocalProxy.get_reference(self)
+        return oct(reference)
+
+    def __hex__(self):
+        reference = ThreadLocalProxy.get_reference(self)
+        return hex(reference)
+
+    def __index__(self):
+        reference = ThreadLocalProxy.get_reference(self)
+        try:
+            func = reference.__index__
+        except AttributeError:
+            return NotImplemented
+        return func()
+
+    def __coerce__(self, other):
+        reference = ThreadLocalProxy.get_reference(self)
+        other = ThreadLocalProxy.unproxy(other)
+        return coerce(reference, other)
+
+    if six.PY2:
+        # pylint: disable=incompatible-py3-code
+        def __unicode__(self):
+            reference = ThreadLocalProxy.get_reference(self)
+            return unicode(reference)
+
+        def __long__(self):
+            reference = ThreadLocalProxy.get_reference(self)
+            return long(reference)

--- a/tests/integration/files/log_handlers/runtests_log_handler.py
+++ b/tests/integration/files/log_handlers/runtests_log_handler.py
@@ -19,10 +19,8 @@ import logging
 import threading
 from multiprocessing import Queue
 
-# Import 3rd-party libs
-import msgpack
-
 # Import Salt libs
+import salt.utils.msgpack
 from salt.ext import six
 import salt.log.setup
 
@@ -85,7 +83,8 @@ def process_queue(port, queue):
                 break
             # Just log everything, filtering will happen on the main process
             # logging handlers
-            sock.sendall(msgpack.dumps(record.__dict__, encoding='utf-8'))
+            sock.sendall(salt.utils.msgpack.dumps(record.__dict__,
+                                                  encoding='utf-8'))
         except (IOError, EOFError, KeyboardInterrupt, SystemExit):
             sock.shutdown(socket.SHUT_RDWR)
             sock.close()

--- a/tests/packdump.py
+++ b/tests/packdump.py
@@ -9,8 +9,8 @@ import os
 import sys
 import pprint
 
-# Import third party libs
-import msgpack
+# Import Salt libs
+import salt.utils.msgpack
 
 
 def dump(path):
@@ -21,7 +21,7 @@ def dump(path):
         print('Not a file')
         return
     with open(path, 'rb') as fp_:
-        data = msgpack.loads(fp_.read())
+        data = salt.utils.msgpack.loads(fp_.read())
         pprint.pprint(data)
 
 

--- a/tests/unit/utils/test_thread_local_proxy.py
+++ b/tests/unit/utils/test_thread_local_proxy.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+
+# Import python libs
+from __future__ import absolute_import
+
+# Import Salt Libs
+from salt.utils import thread_local_proxy
+
+# Import Salt Testing Libs
+from tests.support.unit import TestCase
+
+
+class ThreadLocalProxyTestCase(TestCase):
+    '''
+    Test case for salt.utils.thread_local_proxy module.
+    '''
+
+    def test_set_reference_avoid_loop(self):
+        '''
+        Test that passing another proxy (or the same proxy) to set_reference
+        does not results in a recursive proxy loop.
+        '''
+        test_obj1 = 1
+        test_obj2 = 2
+        proxy1 = thread_local_proxy.ThreadLocalProxy(test_obj1)
+        proxy2 = thread_local_proxy.ThreadLocalProxy(proxy1)
+        self.assertEqual(test_obj1, proxy1)
+        self.assertEqual(test_obj1, proxy2)
+        self.assertEqual(proxy1, proxy2)
+        thread_local_proxy.ThreadLocalProxy.set_reference(proxy1, test_obj2)
+        self.assertEqual(test_obj2, proxy1)
+        self.assertEqual(test_obj2, proxy2)
+        self.assertEqual(proxy1, proxy2)
+        thread_local_proxy.ThreadLocalProxy.set_reference(proxy1, proxy2)
+        self.assertEqual(test_obj2, proxy1)
+        self.assertEqual(test_obj2, proxy2)
+        self.assertEqual(proxy1, proxy2)
+
+    def test_unproxy_recursive_dict_with_proxy(self):
+        '''
+        Test that recursively unproxying a proxy that references a dict that
+        points back to that proxy results in a dict that points back to itself.
+        '''
+        test_obj = {}
+        proxy = thread_local_proxy.ThreadLocalProxy(test_obj)
+        test_obj['x'] = proxy
+        unproxied = thread_local_proxy.ThreadLocalProxy.unproxy_recursive(proxy)
+        self.assertIs(unproxied, unproxied['x'])
+
+    def test_unproxy_recursive_dict_without_proxy(self):
+        '''
+        Test that unproxying a dict that contains a reference to itself works
+        and results in the same object being returned.
+        '''
+        test_obj = {}
+        test_obj['x'] = test_obj
+        unproxied = thread_local_proxy.ThreadLocalProxy.unproxy_recursive(
+            test_obj)
+        self.assertIs(test_obj, unproxied)
+
+    def test_unproxy_recursive_list_with_proxy(self):
+        '''
+        Test that recursively unproxying a proxy that references a list that
+        points back to that proxy results in a list that points back to itself.
+        '''
+        test_obj = ['abc', 123]
+        proxy = thread_local_proxy.ThreadLocalProxy(test_obj)
+        # Append to the list (through the proxy).
+        proxy += [proxy]
+        unproxied = thread_local_proxy.ThreadLocalProxy.unproxy_recursive(proxy)
+        self.assertIs(unproxied, unproxied[2])


### PR DESCRIPTION
### What does this PR do?

This PR is a new version of #39948, so the description has been copied from there. The only difference to the original PR is that this PR is targeted at the `oxygen` branch instead of the `develop` branch.

There was a race condition in the salt loader when injecting global values (e.g. "__pillar__" or "__salt__") into modules. One effect of this race condition was that in a setup with multiple threads, some threads may see pillar data intended for other threads or the pillar data seen by a thread might even change spuriously.

There have been earlier attempts to fix this problem (#27937, #29397). These patches tried to fix the problem by storing the dictionary that keeps the relevant data in a thread-local variable and referencing this thread-local variable from the variables that are injected into the modules.

These patches did not fix the problem completely because they only work when a module is loaded through a single loader instance only. When there is more than one loader, there is more than one thread-local variable and the variable injected into a module is changed to point to another thread-local variable when the module is loaded again. Thus, the problem resurfaced while working on #39670.

This patch attempts to solve the problem from a slightly different angle, complementing the earlier patches: The value injected into the modules now is a proxy that internally uses a thread-local variable to decide to which object it points. This means that when loading a module
again through a different loader (possibly passing different pillar data), the data is actually only changed in the thread in which the loader is used. Other threads are not affected by such a change.

This means that it will work correctly in the current situation where loaders are possibly created by many different modules and these modules do not necessary know in which context they are executed. Thus it is much more flexible and reliable than the more explicit approach
used by the two earlier patches.

### What issues does this PR fix or reference?

This PR fixes problems that surfaced when developing the parallel runners feature (#39670), but is also related to problems reported earlier (#23373). The problems described in #29028 might also be related, though this needs further confirmation.

### Previous Behavior
Changes to pillar data in one thread might have influenced pillar data in a different thread. Whether or when this problem actually appeared was unpredictable (due to the nature of a race condition).

### New Behavior
Changes to pillar data in one thread will never affect the pillar data in a different thread.

### Tests written?

No

### Regression Potential

The change to the loader code itself is rather small, but it affects a central component. So if there is a problem, the impact might affect nearly all components.