### PR TITLE
m/selinux.fcontext_get_policy allow long filespecs

### DIFF
--- a/salt/modules/selinux.py
+++ b/salt/modules/selinux.py
@@ -472,10 +472,10 @@ def fcontext_get_policy(name, filetype=None, sel_type=None, sel_user=None, sel_l
 
     parts = re.match(r'^({filespec}) +([a-z ]+) (.*)$'.format(**{'filespec': re.escape(name)}), current_entry_text)
     ret = {
-        'filespec': parts.group(1),
-        'filetype': parts.group(2),
+        'filespec': parts.group(1).strip(),
+        'filetype': parts.group(2).strip(),
     }
-    ret.update(_context_string_to_dict(parts.group(3)))
+    ret.update(_context_string_to_dict(parts.group(3).strip()))
 
     return ret
 

--- a/salt/modules/selinux.py
+++ b/salt/modules/selinux.py
@@ -456,7 +456,7 @@ def fcontext_get_policy(name, filetype=None, sel_type=None, sel_user=None, sel_l
     '''
     if filetype:
         _validate_filetype(filetype)
-    re_spacer = '[ ]{2,}'
+    re_spacer = '[ ]+'
     cmd_kwargs = {'spacer': re_spacer,
                   'filespec': re.escape(name),
                   'sel_user': sel_user or '[^:]+',
@@ -469,11 +469,14 @@ def fcontext_get_policy(name, filetype=None, sel_type=None, sel_user=None, sel_l
     current_entry_text = __salt__['cmd.shell'](cmd, ignore_retcode=True)
     if current_entry_text == '':
         return None
-    ret = {}
-    current_entry_list = re.split(re_spacer, current_entry_text)
-    ret['filespec'] = current_entry_list[0]
-    ret['filetype'] = current_entry_list[1]
-    ret.update(_context_string_to_dict(current_entry_list[2]))
+
+    parts = re.match(r'^({filespec}) +([a-z ]+) (.*)$'.format(**{'filespec': re.escape(name)}), current_entry_text)
+    ret = {
+        'filespec': parts.group(1),
+        'filetype': parts.group(2),
+    }
+    ret.update(_context_string_to_dict(parts.group(3)))
+
     return ret
 
 

--- a/tests/unit/modules/test_selinux.py
+++ b/tests/unit/modules/test_selinux.py
@@ -1,0 +1,88 @@
+# -*- coding: utf-8 -*-
+
+# Import Python libs
+import os
+
+# Import Salt Testing Libs
+from tests.support.mixins import LoaderModuleMockMixin
+from tests.support.unit import TestCase, skipIf
+from tests.support.mock import (
+    MagicMock,
+    patch,
+    NO_MOCK,
+    NO_MOCK_REASON
+)
+
+# Import Salt libs
+import salt.modules.selinux as selinux
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class SelinuxModuleTestCase(TestCase, LoaderModuleMockMixin):
+    '''
+    Test cases for salt.modules.selinux
+    '''
+    def setup_loader_modules(self):
+        return {selinux: {}}
+
+    def test_fcontext_get_policy_parsing(self):
+        '''
+        Test to verify that the parsing of the semanage output into fields is
+        correct. Added with #45784.
+        '''
+        cases = [
+            {
+                'semanage_out': '/var/www(/.*)?     all files          system_u:object_r:httpd_sys_content_t:s0',
+                'name': '/var/www(/.*)?',
+                'filetype': 'all files',
+                'sel_user': 'system_u',
+                'sel_role': 'object_r',
+                'sel_type': 'httpd_sys_content_t',
+                'sel_level': 's0'
+            },
+            {
+                'semanage_out': '/var/www(/.*)? all files          system_u:object_r:httpd_sys_content_t:s0',
+                'name': '/var/www(/.*)?',
+                'filetype': 'all files',
+                'sel_user': 'system_u',
+                'sel_role': 'object_r',
+                'sel_type': 'httpd_sys_content_t',
+                'sel_level': 's0'
+            },
+            {
+                'semanage_out': '/var/lib/dhcp3?                                    directory          system_u:object_r:dhcp_state_t:s0',
+                'name': '/var/lib/dhcp3?',
+                'filetype': 'directory',
+                'sel_user': 'system_u',
+                'sel_role': 'object_r',
+                'sel_type': 'dhcp_state_t',
+                'sel_level': 's0'
+            },
+            {
+                'semanage_out': '/var/lib/dhcp3?  directory          system_u:object_r:dhcp_state_t:s0',
+                'name': '/var/lib/dhcp3?',
+                'filetype': 'directory',
+                'sel_user': 'system_u',
+                'sel_role': 'object_r',
+                'sel_type': 'dhcp_state_t',
+                'sel_level': 's0'
+            },
+            {
+                'semanage_out': '/var/lib/dhcp3? directory          system_u:object_r:dhcp_state_t:s0',
+                'name': '/var/lib/dhcp3?',
+                'filetype': 'directory',
+                'sel_user': 'system_u',
+                'sel_role': 'object_r',
+                'sel_type': 'dhcp_state_t',
+                'sel_level': 's0'
+            }
+        ]
+
+        for case in cases:
+            with patch.dict(selinux.__salt__, {'cmd.shell': MagicMock(return_value=case['semanage_out'])}):
+                ret = selinux.fcontext_get_policy(case['name'])
+                self.assertEqual(ret['filespec'], case['name'])
+                self.assertEqual(ret['filetype'], case['filetype'])
+                self.assertEqual(ret['sel_user'], case['sel_user'])
+                self.assertEqual(ret['sel_role'], case['sel_role'])
+                self.assertEqual(ret['sel_type'], case['sel_type'])
+                self.assertEqual(ret['sel_level'], case['sel_level'])

--- a/tests/unit/modules/test_selinux.py
+++ b/tests/unit/modules/test_selinux.py
@@ -1,8 +1,5 @@
 # -*- coding: utf-8 -*-
 
-# Import Python libs
-import os
-
 # Import Salt Testing Libs
 from tests.support.mixins import LoaderModuleMockMixin
 from tests.support.unit import TestCase, skipIf

--- a/tests/unit/modules/test_selinux.py
+++ b/tests/unit/modules/test_selinux.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 # Import Salt Testing Libs
+from __future__ import absolute_import
 from tests.support.mixins import LoaderModuleMockMixin
 from tests.support.unit import TestCase, skipIf
 from tests.support.mock import (
@@ -12,6 +13,7 @@ from tests.support.mock import (
 
 # Import Salt libs
 import salt.modules.selinux as selinux
+
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
 class SelinuxModuleTestCase(TestCase, LoaderModuleMockMixin):


### PR DESCRIPTION
### What does this PR do?
The previous logic of matching the output of `semanage fcontext --list` did not
allow for filespecs that were longer than 49 characters. This was due to the
output of the semanage tool not conforming to the expected output.

We used to expect that the after the filespec would be at least two spaces.
However, with long filespecs there is only a single space separating it and the
next field (the file type).

This modifies the regular expression that we use to match the line to accept one
or more spaces as field delimeters.

However, this causes problems when we attempt to split the three fields into a
python dictionary. We cannot use the same logic as previously of using the field
delimeter as the file type field itself can contain a space. Instead we rely on
the fact that the first and last fields cannot contain spaces and pull those out
and the remaining text is the second field.

### What issues does this PR fix or reference?
Fixes #45784.

### Previous Behavior
See #45784.

### New Behavior
See #45784.

### Tests written?
~~No.~~
Yes.

### Commits signed with GPG?
Yes.