### PR TITLE
[oxygen] Bumping up the timeout for integration.cloud.providers.test_ec2 tests

### DIFF
--- a/tests/integration/cloud/providers/test_ec2.py
+++ b/tests/integration/cloud/providers/test_ec2.py
@@ -21,6 +21,7 @@ PROVIDER_NAME = 'ec2'
 
 EC2_TIMEOUT = 1000
 
+
 class EC2Test(ShellCase):
     '''
     Integration tests for the EC2 cloud provider in Salt-Cloud

--- a/tests/integration/cloud/providers/test_ec2.py
+++ b/tests/integration/cloud/providers/test_ec2.py
@@ -19,6 +19,7 @@ from tests.support.helpers import expensiveTest, generate_random_name
 INSTANCE_NAME = generate_random_name('CLOUD-TEST-')
 PROVIDER_NAME = 'ec2'
 
+EC2_TIMEOUT = 1000
 
 class EC2Test(ShellCase):
     '''
@@ -81,18 +82,21 @@ class EC2Test(ShellCase):
         Tests creating and deleting an instance on EC2 (classic)
         '''
         # create the instance
-        instance = self.run_cloud('-p ec2-test {0}'.format(INSTANCE_NAME), timeout=500)
+        instance = self.run_cloud('-p ec2-test {0}'.format(INSTANCE_NAME),
+                                  timeout=EC2_TIMEOUT)
         ret_str = '{0}:'.format(INSTANCE_NAME)
 
         # check if instance returned with salt installed
         try:
             self.assertIn(ret_str, instance)
         except AssertionError:
-            self.run_cloud('-d {0} --assume-yes'.format(INSTANCE_NAME), timeout=500)
+            self.run_cloud('-d {0} --assume-yes'.format(INSTANCE_NAME),
+                           timeout=EC2_TIMEOUT)
             raise
 
         # delete the instance
-        delete = self.run_cloud('-d {0} --assume-yes'.format(INSTANCE_NAME), timeout=500)
+        delete = self.run_cloud('-d {0} --assume-yes'.format(INSTANCE_NAME),
+                                timeout=EC2_TIMEOUT)
         ret_str = '                    shutting-down'
 
         # check if deletion was performed appropriately
@@ -107,17 +111,19 @@ class EC2Test(ShellCase):
         '''
         # create the instance
         rename = INSTANCE_NAME + '-rename'
-        instance = self.run_cloud('-p ec2-test {0} --no-deploy'.format(INSTANCE_NAME), timeout=500)
+        instance = self.run_cloud('-p ec2-test {0} --no-deploy'.format(INSTANCE_NAME),
+                                  timeout=EC2_TIMEOUT)
         ret_str = '{0}:'.format(INSTANCE_NAME)
 
         # check if instance returned
         try:
             self.assertIn(ret_str, instance)
         except AssertionError:
-            self.run_cloud('-d {0} --assume-yes'.format(INSTANCE_NAME), timeout=500)
+            self.run_cloud('-d {0} --assume-yes'.format(INSTANCE_NAME),
+                           timeout=EC2_TIMEOUT)
             raise
 
-        change_name = self.run_cloud('-a rename {0} newname={1} --assume-yes'.format(INSTANCE_NAME, rename), timeout=500)
+        change_name = self.run_cloud('-a rename {0} newname={1} --assume-yes'.format(INSTANCE_NAME, rename), timeout=EC2_TIMEOUT)
 
         check_rename = self.run_cloud('-a show_instance {0} --assume-yes'.format(rename), [rename])
         exp_results = ['        {0}:'.format(rename), '            size:',
@@ -126,11 +132,13 @@ class EC2Test(ShellCase):
             for result in exp_results:
                 self.assertIn(result, check_rename[0])
         except AssertionError:
-            self.run_cloud('-d {0} --assume-yes'.format(INSTANCE_NAME), timeout=500)
+            self.run_cloud('-d {0} --assume-yes'.format(INSTANCE_NAME),
+                           timeout=EC2_TIMEOUT)
             raise
 
         # delete the instance
-        delete = self.run_cloud('-d {0} --assume-yes'.format(rename), timeout=500)
+        delete = self.run_cloud('-d {0} --assume-yes'.format(rename),
+                                timeout=EC2_TIMEOUT)
         ret_str = '                    shutting-down'
 
         # check if deletion was performed appropriately
@@ -145,4 +153,5 @@ class EC2Test(ShellCase):
 
         # if test instance is still present, delete it
         if ret_str in query:
-            self.run_cloud('-d {0} --assume-yes'.format(INSTANCE_NAME), timeout=500)
+            self.run_cloud('-d {0} --assume-yes'.format(INSTANCE_NAME),
+                           timeout=EC2_TIMEOUT)


### PR DESCRIPTION
### What does this PR do?
Bumping up the timeout for integration.cloud.providers.test_ec2 tests.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt-jenkins/issues/650

### Previous Behavior
Tests were failing previously because 1) the AWS credentials were inactive 2) the timeout specified in the salt runner was being reached.

### New Behavior
AWS credentials have been fixed and this PR increases the timeout.

### Tests written?
No, Fixes to existing tests.

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
