### PR TITLE
Restore colors to the changes for the highstate outputter

### DIFF
--- a/salt/output/nested.py
+++ b/salt/output/nested.py
@@ -30,8 +30,8 @@ from numbers import Number
 # Import salt libs
 import salt.output
 import salt.utils.color
-import salt.utils.locales
 import salt.utils.odict
+import salt.utils.stringutils
 from salt.ext import six
 
 
@@ -63,9 +63,21 @@ class NestDisplay(object):
         fmt = '{0}{1}{2}{3}{4}{5}'
 
         try:
-            return fmt.format(indent, color, prefix, msg, endc, suffix)
+            return fmt.format(
+                indent,
+                color,
+                prefix,
+                msg,
+                endc,
+                suffix)
         except UnicodeDecodeError:
-            return fmt.format(indent, color, prefix, salt.utils.locales.sdecode(msg), endc, suffix)
+            return fmt.format(
+                indent,
+                color,
+                prefix,
+                salt.utils.stringutils.to_unicode(msg),
+                endc,
+                suffix)
 
     def display(self, ret, indent, prefix, out):
         '''


### PR DESCRIPTION
Also, remove usage of salt.utils.locales.sdecode in favor of the functions we have in salt.utils.data/stringutils to handle decoding to unicode.

In October 2013, when the highstate outputter was changed to display the changes using the nested outputter, it was configured to force all output in the changes to be cyan. This was done by temporarily setting `__opts__['color']` to `'CYAN'`, so that when the nested outputter grabs the color theme, it forces all output in the nested outputter to be cyan. However, along the way, a couple unrelated changes caused this logic to break down, making the nested outputter use its default color theme (green for strings, yellow for integers/bools, etc.). Firstly, the code that retrieves the color theme (`salt.utils.color.get_color_theme()`) was doing a type check on the the `use` parameter, only forcing the use of the passed color when it was a `str` type, and secondly the value the nested outputter passed became a `unicode` type, causing it to fail the type check (and thus ignoring the passed value).

Through our efforts to improve unicode compatibility, the type check in `salt.utils.color.get_color_theme()` was fixed, and the colors for changes are now all cyan. However, the contrast of having the different colors is actually much more readable, so this commit has removed the `__opts__` monkeypatching, which lets the nested outputter use its default colors when displaying changes.

NOTE: the removed `__opts__` monkeypatching is [here](https://github.com/saltstack/salt/pull/45791/files#diff-6783986d5efc4c6d746f4591ae8c1aabL484).