### PR TITLE
correct encoding for subprocess environments

### DIFF
--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -447,9 +447,10 @@ def _run(cmd,
             # Encode unicode kwargs to filesystem encoding to avoid a
             # UnicodeEncodeError when the subprocess is invoked.
             fse = sys.getfilesystemencoding()
+            encoded_env = {}
             for key, val in six.iteritems(env):
-                if isinstance(val, six.text_type):
-                    env[key] = val.encode(fse)
+                encoded_env[key.encode(fse)] = val.encode(fse)
+            env = encoded_env
         except ValueError:
             raise CommandExecutionError(
                 'Environment could not be retrieved for User \'{0}\''.format(


### PR DESCRIPTION
### What does this PR do?
Salt states that start a subprocess fail on a UnicodeEncodeError. This affects many kinds of salt states. This PR fixes the environment provided to subprocesses. 

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/45783

### Previous Behavior

Unicode failures whilst starting subprocesses. This affects many states, one example is cron.present

      ID: clean_tmp
    Function: cron.present
        Name: find /tmp -name test.tmp -delete
      Result: False
     Comment: An exception occurred in this state: Traceback (most recent call last):
                File "/usr/lib/python2.7/dist-packages/salt/state.py", line 1843, in call
                  **cdata['kwargs'])
                File "/usr/lib/python2.7/dist-packages/salt/loader.py", line 1795, in wrapper
                  return f(*args, **kwargs)
                File "/usr/lib/python2.7/dist-packages/salt/states/cron.py", line 349, in present
                  identifier=identifier)
                File "/usr/lib/python2.7/dist-packages/salt/modules/cron.py", line 461, in set_job
                  lst = list_tab(user)
                File "/usr/lib/python2.7/dist-packages/salt/modules/cron.py", line 293, in list_tab
                  data = raw_cron(user)
                File "/usr/lib/python2.7/dist-packages/salt/modules/cron.py", line 270, in raw_cron
                  python_shell=False)).splitlines(True)
                File "/usr/lib/python2.7/dist-packages/salt/modules/cmdmod.py", line 1318, in run_stdout
                  **kwargs)
                File "/usr/lib/python2.7/dist-packages/salt/modules/cmdmod.py", line 547, in _run
                  proc = salt.utils.timed_subprocess.TimedProc(cmd, **kwargs)
                File "/usr/lib/python2.7/dist-packages/salt/utils/timed_subprocess.py", line 42, in __init__
                  self.process = subprocess.Popen(args, **kwargs)
                File "/usr/lib/python2.7/subprocess.py", line 711, in __init__
                  errread, errwrite)
                File "/usr/lib/python2.7/subprocess.py", line 1343, in _execute_child
                  raise child_exception
              UnicodeEncodeError: 'ascii' codec can't encode characters in position 0-32: ordinal not in     range(128)
     Started: 17:41:19.429815
    Duration: 106.483 ms

### New Behavior
States that depend on starting a subprocess work as expected.

### Tests written?

No

### Commits signed with GPG?

No
