### PR TITLE
RAET transport Py3 support and shutdown fixes

### DIFF
--- a/salt/daemons/flo/__init__.py
+++ b/salt/daemons/flo/__init__.py
@@ -121,6 +121,7 @@ class IofloMinion(object):
         '''
         warn_deprecated()
         self.opts = opts
+        self.restart = False
 
     def tune_in(self, behaviors=None):
         '''

--- a/salt/daemons/test/minion.flo
+++ b/salt/daemons/test/minion.flo
@@ -11,7 +11,12 @@ framer minionudpstack be active first start
       exit
          do salt raet road stack closer per inode ".salt.road.manor."
 
-framer bootstrap be active first join
+framer bootstrap be active first setup
+   frame setup
+      enter
+          do salt raet road usher minion setup per inode ".salt.road.manor."
+      go join
+
    frame join
       print Joining...
       enter
@@ -44,7 +49,7 @@ framer bootstrap be active first join
    frame message
       print Messaging...
       enter
-         do raet road stack messenger to contents "Minion 1 Hello" code 15 \
+         do raet road stack messenger with contents "Minion 1 Hello" code 15 \
             per inode ".salt.road.manor."
       go next
 

--- a/salt/daemons/test/test_master.py
+++ b/salt/daemons/test/test_master.py
@@ -22,6 +22,10 @@ def test():
     if not os.path.exists(pkiDirpath):
         os.makedirs(pkiDirpath)
 
+    keyDirpath = os.path.join('/tmp', 'raet', 'testo', 'key')
+    if not os.path.exists(keyDirpath):
+        os.makedirs(keyDirpath)
+
     acceptedDirpath = os.path.join(pkiDirpath, 'accepted')
     if not os.path.exists(acceptedDirpath):
         os.makedirs(acceptedDirpath)
@@ -64,10 +68,12 @@ def test():
             client_acl=dict(),
             publisher_acl=dict(),
             pki_dir=pkiDirpath,
+            key_dir=keyDirpath,
             sock_dir=sockDirpath,
             cachedir=cacheDirpath,
             open_mode=True,
             auto_accept=True,
+            client_acl_verify=True,
             )
 
     master = salt.daemons.flo.IofloMaster(opts=opts)

--- a/salt/daemons/test/test_multimaster.py
+++ b/salt/daemons/test/test_multimaster.py
@@ -348,7 +348,7 @@ if __name__ == '__main__' and __package__ is None:
 
     #console.reinit(verbosity=console.Wordage.concise)
 
-    runAll() # run all unittests
+    runAll()  # run all unittests
 
     #runSome()  # only run some
 

--- a/salt/daemons/test/test_multimaster.py
+++ b/salt/daemons/test/test_multimaster.py
@@ -348,8 +348,8 @@ if __name__ == '__main__' and __package__ is None:
 
     #console.reinit(verbosity=console.Wordage.concise)
 
-    #runAll() # run all unittests
+    runAll() # run all unittests
 
-    runSome()  # only run some
+    #runSome()  # only run some
 
     #runOne('testParseHostname')

--- a/salt/daemons/test/test_presence.py
+++ b/salt/daemons/test/test_presence.py
@@ -5,6 +5,7 @@ Raet Ioflo Behavior Unittests
 from __future__ import absolute_import, print_function, unicode_literals
 import sys
 from salt.ext.six.moves import map
+import importlib
 # pylint: disable=blacklisted-import
 if sys.version_info < (2, 7):
     import unittest2 as unittest
@@ -40,6 +41,9 @@ class PresenterTestCase(testing.FrameIofloTestCase):
         '''
         Call super if override so House Framer and Frame are setup correctly
         '''
+        behaviors = ['salt.daemons.flo', 'salt.daemons.test.plan']
+        for behavior in behaviors:
+            mod = importlib.import_module(behavior)
         super(PresenterTestCase, self).setUp()
 
     def tearDown(self):

--- a/salt/daemons/test/test_raetkey.py
+++ b/salt/daemons/test/test_raetkey.py
@@ -7,6 +7,7 @@ from __future__ import absolute_import, print_function, unicode_literals
 # pylint: skip-file
 # pylint: disable=C0103
 import sys
+import salt.utils.stringutils
 from salt.ext.six.moves import map
 if sys.version_info < (2, 7):
     import unittest2 as unittest
@@ -30,11 +31,14 @@ from raet.road import estating, keeping, stacking
 
 from salt.key import RaetKey
 
+
 def setUpModule():
     console.reinit(verbosity=console.Wordage.concise)
 
+
 def tearDownModule():
     pass
+
 
 class BasicTestCase(unittest.TestCase):
     """"""
@@ -47,7 +51,7 @@ class BasicTestCase(unittest.TestCase):
 
         pkiDirpath = os.path.join(self.saltDirpath, 'pki')
         if not os.path.exists(pkiDirpath):
-                os.makedirs(pkiDirpath)
+            os.makedirs(pkiDirpath)
 
         acceptedDirpath = os.path.join(pkiDirpath, 'accepted')
         if not os.path.exists(acceptedDirpath):
@@ -81,7 +85,7 @@ class BasicTestCase(unittest.TestCase):
                         )
 
         self.mainKeeper = RaetKey(opts=self.opts)
-        self.baseDirpath = tempfile.mkdtemp(prefix="salt",  suffix="base", dir='/tmp')
+        self.baseDirpath = tempfile.mkdtemp(prefix="salt", suffix="base", dir='/tmp')
 
     def tearDown(self):
         if os.path.exists(self.saltDirpath):
@@ -119,9 +123,9 @@ class BasicTestCase(unittest.TestCase):
         self.opts['auto_accept'] = True
         self.assertTrue(self.opts['auto_accept'])
         self.assertDictEqual(self.mainKeeper.all_keys(), {'accepted': [],
-                                                            'local': [],
-                                                            'rejected': [],
-                                                            'pending': []})
+                                                          'local': [],
+                                                          'rejected': [],
+                                                          'pending': []})
 
         localkeys = self.mainKeeper.read_local()
         self.assertDictEqual(localkeys, {})
@@ -129,8 +133,9 @@ class BasicTestCase(unittest.TestCase):
         main = self.createRoadData(name='main', base=self.baseDirpath)
         self.mainKeeper.write_local(main['prihex'], main['sighex'])
         localkeys = self.mainKeeper.read_local()
-        self.assertDictEqual(localkeys, {'priv': main['prihex'],
-                                     'sign': main['sighex']})
+        self.assertDictEqual(localkeys,
+                             {'priv': salt.utils.stringutils.to_str(main['prihex']),
+                              'sign': salt.utils.stringutils.to_str(main['sighex'])})
         allkeys = self.mainKeeper.all_keys()
         self.assertDictEqual(allkeys, {'accepted': [],
                                        'local': [self.localFilepath],
@@ -147,39 +152,38 @@ class BasicTestCase(unittest.TestCase):
 
         allkeys = self.mainKeeper.all_keys()
         self.assertDictEqual(allkeys, {'accepted': ['other1', 'other2'],
-                                'local': [self.localFilepath],
-                                'pending': [],
-                                'rejected': []} )
+                                       'local': [self.localFilepath],
+                                       'pending': [],
+                                       'rejected': []})
 
         remotekeys = self.mainKeeper.read_remote(other1['name'])
-        self.assertDictEqual(remotekeys, {   'minion_id': 'other1',
-                                             'pub': other1['pubhex'],
-                                             'verify': other1['verhex']} )
+        self.assertDictEqual(remotekeys, {'minion_id': 'other1',
+                                          'pub': salt.utils.stringutils.to_str(other1['pubhex']),
+                                          'verify': salt.utils.stringutils.to_str(other1['verhex'])})
 
         remotekeys = self.mainKeeper.read_remote(other2['name'])
-        self.assertDictEqual(remotekeys, {  'minion_id': 'other2',
-                                            'pub': other2['pubhex'],
-                                            'verify': other2['verhex']} )
+        self.assertDictEqual(remotekeys, {'minion_id': 'other2',
+                                          'pub': salt.utils.stringutils.to_str(other2['pubhex']),
+                                          'verify': salt.utils.stringutils.to_str(other2['verhex'])})
 
         listkeys = self.mainKeeper.list_keys()
         self.assertDictEqual(listkeys, {'accepted': ['other1', 'other2'],
                                         'rejected': [],
                                         'pending': []})
 
-
         allremotekeys = self.mainKeeper.read_all_remote()
-        self.assertDictEqual(allremotekeys, {'other1':
-                                                 {'verify': other1['verhex'],
-                                                  'minion_id': 'other1',
-                                                  'acceptance': 'accepted',
-                                                  'pub': other1['pubhex'],},
-                                             'other2':
-                                                 {'verify': other2['verhex'],
-                                                  'minion_id': 'other2',
-                                                  'acceptance': 'accepted',
-                                                  'pub': other2['pubhex'],}
-                                            })
-
+        self.assertDictEqual(allremotekeys,
+                             {'other1':
+                                  {'verify': salt.utils.stringutils.to_str(other1['verhex']),
+                                   'minion_id': 'other1',
+                                   'acceptance': 'accepted',
+                                   'pub': salt.utils.stringutils.to_str(other1['pubhex']), },
+                              'other2':
+                                  {'verify': salt.utils.stringutils.to_str(other2['verhex']),
+                                   'minion_id': 'other2',
+                                   'acceptance': 'accepted',
+                                   'pub': salt.utils.stringutils.to_str(other2['pubhex']), }
+                              })
 
     def testManualAccept(self):
         '''
@@ -189,9 +193,9 @@ class BasicTestCase(unittest.TestCase):
         self.opts['auto_accept'] = False
         self.assertFalse(self.opts['auto_accept'])
         self.assertDictEqual(self.mainKeeper.all_keys(), {'accepted': [],
-                                                            'local': [],
-                                                            'rejected': [],
-                                                            'pending': []})
+                                                          'local': [],
+                                                          'rejected': [],
+                                                          'pending': []})
 
         localkeys = self.mainKeeper.read_local()
         self.assertDictEqual(localkeys, {})
@@ -199,8 +203,9 @@ class BasicTestCase(unittest.TestCase):
         main = self.createRoadData(name='main', base=self.baseDirpath)
         self.mainKeeper.write_local(main['prihex'], main['sighex'])
         localkeys = self.mainKeeper.read_local()
-        self.assertDictEqual(localkeys, {'priv': main['prihex'],
-                                     'sign': main['sighex']})
+        self.assertDictEqual(localkeys,
+                             {'priv': salt.utils.stringutils.to_str(main['prihex']),
+                              'sign': salt.utils.stringutils.to_str(main['sighex'])})
         allkeys = self.mainKeeper.all_keys()
         self.assertDictEqual(allkeys, {'accepted': [],
                                        'local': [self.localFilepath],
@@ -217,9 +222,9 @@ class BasicTestCase(unittest.TestCase):
 
         allkeys = self.mainKeeper.all_keys()
         self.assertDictEqual(allkeys, {'accepted': [],
-                                'local': [self.localFilepath],
-                                'pending': ['other1', 'other2'],
-                                'rejected': []} )
+                                       'local': [self.localFilepath],
+                                       'pending': ['other1', 'other2'],
+                                       'rejected': []})
 
         remotekeys = self.mainKeeper.read_remote(other1['name'])
         self.assertDictEqual(remotekeys, {})
@@ -232,56 +237,60 @@ class BasicTestCase(unittest.TestCase):
                                         'rejected': [],
                                         'pending': ['other1', 'other2']})
 
-
         allremotekeys = self.mainKeeper.read_all_remote()
-        self.assertDictEqual(allremotekeys, {'other1':
-                                                 {'verify': other1['verhex'],
-                                                  'minion_id': 'other1',
-                                                  'acceptance': 'pending',
-                                                  'pub': other1['pubhex'],},
-                                             'other2':
-                                                 {'verify': other2['verhex'],
-                                                  'minion_id': 'other2',
-                                                  'acceptance': 'pending',
-                                                  'pub': other2['pubhex'],}
-                                            })
+        self.assertDictEqual(allremotekeys,
+                             {'other1':
+                                  {'verify': salt.utils.stringutils.to_str(other1['verhex']),
+                                   'minion_id': 'other1',
+                                   'acceptance': 'pending',
+                                   'pub': salt.utils.stringutils.to_str(other1['pubhex']),
+                                   },
+                              'other2':
+                                  {'verify': salt.utils.stringutils.to_str(other2['verhex']),
+                                   'minion_id': 'other2',
+                                   'acceptance': 'pending',
+                                   'pub': salt.utils.stringutils.to_str(other2['pubhex']),
+                                   }
+                              })
 
         self.mainKeeper.accept_all()
 
         allkeys = self.mainKeeper.all_keys()
         self.assertDictEqual(allkeys, {'accepted': ['other1', 'other2'],
-                                'local': [self.localFilepath],
-                                'pending': [],
-                                'rejected': []} )
+                                       'local': [self.localFilepath],
+                                       'pending': [],
+                                       'rejected': []})
 
         remotekeys = self.mainKeeper.read_remote(other1['name'])
-        self.assertDictEqual(remotekeys, {   'minion_id': 'other1',
-                                             'pub': other1['pubhex'],
-                                             'verify': other1['verhex']} )
+        self.assertDictEqual(remotekeys, {'minion_id': 'other1',
+                                          'pub': salt.utils.stringutils.to_str(other1['pubhex']),
+                                          'verify': salt.utils.stringutils.to_str(other1['verhex'])})
 
         remotekeys = self.mainKeeper.read_remote(other2['name'])
-        self.assertDictEqual(remotekeys, {  'minion_id': 'other2',
-                                            'pub': other2['pubhex'],
-                                            'verify': other2['verhex']} )
+        self.assertDictEqual(remotekeys, {'minion_id': 'other2',
+                                          'pub': salt.utils.stringutils.to_str(other2['pubhex']),
+                                          'verify': salt.utils.stringutils.to_str(other2['verhex'])})
 
         listkeys = self.mainKeeper.list_keys()
         self.assertDictEqual(listkeys, {'accepted': ['other1', 'other2'],
                                         'rejected': [],
                                         'pending': []})
 
-
         allremotekeys = self.mainKeeper.read_all_remote()
-        self.assertDictEqual(allremotekeys, {'other1':
-                                                 {'verify': other1['verhex'],
-                                                  'minion_id': 'other1',
-                                                  'acceptance': 'accepted',
-                                                  'pub': other1['pubhex'],},
-                                             'other2':
-                                                 {'verify': other2['verhex'],
-                                                  'minion_id': 'other2',
-                                                  'acceptance': 'accepted',
-                                                  'pub': other2['pubhex'],}
-                                            })
+        self.assertDictEqual(allremotekeys,
+                             {'other1':
+                                  {'verify': salt.utils.stringutils.to_str(other1['verhex']),
+                                   'minion_id': 'other1',
+                                   'acceptance': 'accepted',
+                                   'pub': salt.utils.stringutils.to_str(other1['pubhex']),
+                                   },
+                              'other2':
+                                  {'verify': salt.utils.stringutils.to_str(other2['verhex']),
+                                   'minion_id': 'other2',
+                                   'acceptance': 'accepted',
+                                   'pub': salt.utils.stringutils.to_str(other2['pubhex']),
+                                   }
+                              })
 
     def testDelete(self):
         '''
@@ -291,9 +300,9 @@ class BasicTestCase(unittest.TestCase):
         self.opts['auto_accept'] = True
         self.assertTrue(self.opts['auto_accept'])
         self.assertDictEqual(self.mainKeeper.all_keys(), {'accepted': [],
-                                                            'local': [],
-                                                            'rejected': [],
-                                                            'pending': []})
+                                                          'local': [],
+                                                          'rejected': [],
+                                                          'pending': []})
 
         localkeys = self.mainKeeper.read_local()
         self.assertDictEqual(localkeys, {})
@@ -301,8 +310,9 @@ class BasicTestCase(unittest.TestCase):
         main = self.createRoadData(name='main', base=self.baseDirpath)
         self.mainKeeper.write_local(main['prihex'], main['sighex'])
         localkeys = self.mainKeeper.read_local()
-        self.assertDictEqual(localkeys, {'priv': main['prihex'],
-                                     'sign': main['sighex']})
+        self.assertDictEqual(localkeys,
+                             {'priv': salt.utils.stringutils.to_str(main['prihex']),
+                              'sign': salt.utils.stringutils.to_str(main['sighex'])})
         allkeys = self.mainKeeper.all_keys()
         self.assertDictEqual(allkeys, {'accepted': [],
                                        'local': [self.localFilepath],
@@ -319,70 +329,73 @@ class BasicTestCase(unittest.TestCase):
 
         allkeys = self.mainKeeper.all_keys()
         self.assertDictEqual(allkeys, {'accepted': ['other1', 'other2'],
-                                'local': [self.localFilepath],
-                                'pending': [],
-                                'rejected': []} )
+                                       'local': [self.localFilepath],
+                                       'pending': [],
+                                       'rejected': []})
 
         remotekeys = self.mainKeeper.read_remote(other1['name'])
-        self.assertDictEqual(remotekeys, {   'minion_id': 'other1',
-                                             'pub': other1['pubhex'],
-                                             'verify': other1['verhex']} )
+        self.assertDictEqual(remotekeys, {'minion_id': 'other1',
+                                          'pub': salt.utils.stringutils.to_str(other1['pubhex']),
+                                          'verify': salt.utils.stringutils.to_str(other1['verhex']),
+                                          })
 
         remotekeys = self.mainKeeper.read_remote(other2['name'])
-        self.assertDictEqual(remotekeys, {  'minion_id': 'other2',
-                                            'pub': other2['pubhex'],
-                                            'verify': other2['verhex']} )
+        self.assertDictEqual(remotekeys, {'minion_id': 'other2',
+                                          'pub': salt.utils.stringutils.to_str(other2['pubhex']),
+                                          'verify': salt.utils.stringutils.to_str(other2['verhex']),
+                                          })
 
         listkeys = self.mainKeeper.list_keys()
         self.assertDictEqual(listkeys, {'accepted': ['other1', 'other2'],
                                         'rejected': [],
                                         'pending': []})
 
-
         allremotekeys = self.mainKeeper.read_all_remote()
-        self.assertDictEqual(allremotekeys, {'other1':
-                                                 {'verify': other1['verhex'],
-                                                  'minion_id': 'other1',
-                                                  'acceptance': 'accepted',
-                                                  'pub': other1['pubhex']},
-                                             'other2':
-                                                 {'verify': other2['verhex'],
-                                                  'minion_id': 'other2',
-                                                  'acceptance': 'accepted',
-                                                  'pub': other2['pubhex'],}
-                                            })
+        self.assertDictEqual(allremotekeys,
+                             {'other1':
+                                  {'verify': salt.utils.stringutils.to_str(other1['verhex']),
+                                   'minion_id': 'other1',
+                                   'acceptance': 'accepted',
+                                   'pub': salt.utils.stringutils.to_str(other1['pubhex'])
+                                   },
+                              'other2':
+                                  {'verify': salt.utils.stringutils.to_str(other2['verhex']),
+                                   'minion_id': 'other2',
+                                   'acceptance': 'accepted',
+                                   'pub': salt.utils.stringutils.to_str(other2['pubhex']),
+                                   }
+                              })
 
         self.mainKeeper.delete_key(match=other1['name'])
 
         allkeys = self.mainKeeper.all_keys()
         self.assertDictEqual(allkeys, {'accepted': ['other2'],
-                                'local': [self.localFilepath],
-                                'pending': [],
-                                'rejected': []} )
+                                       'local': [self.localFilepath],
+                                       'pending': [],
+                                       'rejected': []})
 
         remotekeys = self.mainKeeper.read_remote(other1['name'])
-        self.assertDictEqual(remotekeys, {} )
+        self.assertDictEqual(remotekeys, {})
 
         remotekeys = self.mainKeeper.read_remote(other2['name'])
-        self.assertDictEqual(remotekeys, {  'minion_id': 'other2',
-                                            'pub': other2['pubhex'],
-                                            'verify': other2['verhex']} )
+        self.assertDictEqual(remotekeys, {'minion_id': 'other2',
+                                          'pub': salt.utils.stringutils.to_str(other2['pubhex']),
+                                          'verify': salt.utils.stringutils.to_str(other2['verhex'])})
 
         listkeys = self.mainKeeper.list_keys()
-        self.assertDictEqual(listkeys, {'accepted': [ 'other2'],
+        self.assertDictEqual(listkeys, {'accepted': ['other2'],
                                         'rejected': [],
                                         'pending': []})
 
-
         allremotekeys = self.mainKeeper.read_all_remote()
-        self.assertDictEqual(allremotekeys, {
-                                             'other2':
-                                                 {'verify': other2['verhex'],
-                                                  'minion_id': 'other2',
-                                                  'acceptance': 'accepted',
-                                                  'pub': other2['pubhex'],}
-                                             })
-
+        self.assertDictEqual(allremotekeys,
+                             {'other2':
+                                  {'verify': salt.utils.stringutils.to_str(other2['verhex']),
+                                   'minion_id': 'other2',
+                                   'acceptance': 'accepted',
+                                   'pub': salt.utils.stringutils.to_str(other2['pubhex']),
+                                   }
+                              })
 
 
 def runOne(test):
@@ -393,11 +406,12 @@ def runOne(test):
     suite = unittest.TestSuite([test])
     unittest.TextTestRunner(verbosity=2).run(suite)
 
+
 def runSome():
     '''
     Unittest runner
     '''
-    tests =  []
+    tests = []
     names = ['testAutoAccept',
              'testManualAccept',
              'testDelete']
@@ -406,6 +420,7 @@ def runSome():
 
     suite = unittest.TestSuite(tests)
     unittest.TextTestRunner(verbosity=2).run(suite)
+
 
 def runAll():
     '''
@@ -416,12 +431,12 @@ def runAll():
 
     unittest.TextTestRunner(verbosity=2).run(suite)
 
+
 if __name__ == '__main__' and __package__ is None:
+    # console.reinit(verbosity=console.Wordage.concise)
 
-    #console.reinit(verbosity=console.Wordage.concise)
+    runAll()  # run all unittests
 
-    runAll() #run all unittests
+    # runSome()  #only run some
 
-    #runSome()#only run some
-
-    #runOne('testDelete')
+    # runOne('testDelete')

--- a/salt/daemons/test/test_saltkeep.py
+++ b/salt/daemons/test/test_saltkeep.py
@@ -13,10 +13,11 @@ else:
 # pylint: enable=blacklisted-import
 
 import os
-import stat
-import time
-import tempfile
 import shutil
+import socket
+import stat
+import tempfile
+import time
 
 from ioflo.aid.odicting import odict
 from ioflo.aid.timing import StoreTimer
@@ -29,6 +30,7 @@ from raet.road import estating, stacking
 
 from salt.daemons import salting
 import salt.utils.kinds as kinds
+import salt.utils.stringutils
 
 
 def setUpModule():
@@ -232,20 +234,21 @@ class BasicTestCase(unittest.TestCase):  # pylint: disable=moved-test-case-class
                 os.path.join('main', 'raet', 'main_master')))
         self.assertTrue(main.ha, ("0.0.0.0", raeting.RAET_PORT))
         self.assertIs(main.keep.auto, raeting.AutoMode.never.value)
-        self.assertDictEqual(main.keep.loadLocalData(), {'name': mainData['name'],
-                                                         'uid': 1,
-                                                         'ha': ['127.0.0.1', 7530],
-                                                         'iha': None,
-                                                         'natted': None,
-                                                         'fqdn': '1.0.0.127.in-addr.arpa',
-                                                         'dyned': None,
-                                                         'sid': 0,
-                                                         'puid': 1,
-                                                         'aha': ['0.0.0.0', 7530],
-                                                         'role': mainData['role'],
-                                                         'sighex': mainData['sighex'],
-                                                         'prihex': mainData['prihex'],
-                                                         })
+        self.assertDictEqual(main.keep.loadLocalData(),
+                             {'name': mainData['name'],
+                              'uid': 1,
+                              'ha': ['127.0.0.1', 7530],
+                              'iha': None,
+                              'natted': None,
+                              'fqdn': socket.getfqdn('127.0.0.1'),
+                              'dyned': None,
+                              'sid': 0,
+                              'puid': 1,
+                              'aha': ['0.0.0.0', 7530],
+                              'role': mainData['role'],
+                              'sighex': salt.utils.stringutils.to_str(mainData['sighex']),
+                              'prihex': salt.utils.stringutils.to_str(mainData['prihex']),
+                              })
 
         data1 = self.createRoadData(role='remote1',
                                     kind=kinds.APPL_KIND_NAMES[kinds.applKinds.minion],
@@ -282,7 +285,7 @@ class BasicTestCase(unittest.TestCase):  # pylint: disable=moved-test-case-class
                      'ha': ['127.0.0.1', 7532],
                      'iha': None,
                      'natted': None,
-                     'fqdn': '1.0.0.127.in-addr.arpa',
+                     'fqdn': socket.getfqdn('127.0.0.1'),
                      'dyned': None,
                      'main': False,
                      'kind': data1['kind'],
@@ -290,8 +293,8 @@ class BasicTestCase(unittest.TestCase):  # pylint: disable=moved-test-case-class
                      'joined': None,
                      'role': data1['role'],
                      'acceptance': 0,
-                     'verhex': data1['verhex'],
-                     'pubhex': data1['pubhex'],
+                     'verhex': salt.utils.stringutils.to_str(data1['verhex']),
+                     'pubhex': salt.utils.stringutils.to_str(data1['pubhex']),
                      },
                 'remote2_minion':
                     {'name': data2['name'],
@@ -300,7 +303,7 @@ class BasicTestCase(unittest.TestCase):  # pylint: disable=moved-test-case-class
                      'ha': ['127.0.0.1', 7533],
                      'iha': None,
                      'natted': None,
-                     'fqdn': '1.0.0.127.in-addr.arpa',
+                     'fqdn': socket.getfqdn('127.0.0.1'),
                      'dyned': None,
                      'main': False,
                      'kind': data2['kind'],
@@ -308,8 +311,8 @@ class BasicTestCase(unittest.TestCase):  # pylint: disable=moved-test-case-class
                      'joined': None,
                      'role': data2['role'],
                      'acceptance': 0,
-                     'verhex': data2['verhex'],
-                     'pubhex': data2['pubhex'],
+                     'verhex': salt.utils.stringutils.to_str(data2['verhex']),
+                     'pubhex': salt.utils.stringutils.to_str(data2['pubhex']),
                      }
             })
 
@@ -362,14 +365,14 @@ class BasicTestCase(unittest.TestCase):  # pylint: disable=moved-test-case-class
                                 'ha': ['127.0.0.1', 7531],
                                 'iha': None,
                                 'natted': None,
-                                'fqdn': '1.0.0.127.in-addr.arpa',
+                                'fqdn': socket.getfqdn('127.0.0.1'),
                                 'dyned': None,
                                 'sid': 0,
                                 'puid': 1,
                                 'aha': ['0.0.0.0', 7531],
                                 'role': otherData['role'],
-                                'sighex': otherData['sighex'],
-                                'prihex': otherData['prihex'],
+                                'sighex': salt.utils.stringutils.to_str(otherData['sighex']),
+                                'prihex': salt.utils.stringutils.to_str(otherData['prihex']),
                             })
 
         data3 = self.createRoadData(role='remote3',
@@ -405,7 +408,7 @@ class BasicTestCase(unittest.TestCase):  # pylint: disable=moved-test-case-class
                     'ha': ['127.0.0.1', 7534],
                     'iha': None,
                     'natted': None,
-                    'fqdn': '1.0.0.127.in-addr.arpa',
+                    'fqdn': socket.getfqdn('127.0.0.1'),
                     'dyned': None,
                     'main': False,
                     'kind': data3['kind'],
@@ -413,8 +416,8 @@ class BasicTestCase(unittest.TestCase):  # pylint: disable=moved-test-case-class
                     'joined': None,
                     'role': data3['role'],
                     'acceptance': 0,
-                    'verhex': data3['verhex'],
-                    'pubhex': data3['pubhex'],
+                    'verhex': salt.utils.stringutils.to_str(data3['verhex']),
+                    'pubhex': salt.utils.stringutils.to_str(data3['pubhex']),
                 },
                 'remote4_minion':
                 {
@@ -424,7 +427,7 @@ class BasicTestCase(unittest.TestCase):  # pylint: disable=moved-test-case-class
                     'ha': ['127.0.0.1', 7535],
                     'iha': None,
                     'natted': None,
-                    'fqdn': '1.0.0.127.in-addr.arpa',
+                    'fqdn': socket.getfqdn('127.0.0.1'),
                     'dyned': None,
                     'main': False,
                     'kind': data4['kind'],
@@ -432,8 +435,8 @@ class BasicTestCase(unittest.TestCase):  # pylint: disable=moved-test-case-class
                     'joined': None,
                     'role': data4['role'],
                     'acceptance': 0,
-                    'verhex': data4['verhex'],
-                    'pubhex': data4['pubhex'],
+                    'verhex': salt.utils.stringutils.to_str(data4['verhex']),
+                    'pubhex': salt.utils.stringutils.to_str(data4['pubhex']),
                 }
             })
 
@@ -477,14 +480,14 @@ class BasicTestCase(unittest.TestCase):  # pylint: disable=moved-test-case-class
                                                          'ha': ['127.0.0.1', 7530],
                                                          'iha': None,
                                                          'natted': None,
-                                                         'fqdn': '1.0.0.127.in-addr.arpa',
+                                                         'fqdn': socket.getfqdn('127.0.0.1'),
                                                          'dyned': None,
                                                          'sid': 0,
                                                          'puid': 1,
                                                          'aha': ['0.0.0.0', 7530],
                                                          'role': mainData['role'],
-                                                         'sighex': mainData['sighex'],
-                                                         'prihex': mainData['prihex'],
+                                                         'sighex': salt.utils.stringutils.to_str(mainData['sighex']),
+                                                         'prihex': salt.utils.stringutils.to_str(mainData['prihex']),
                                                          })
 
         data1 = self.createRoadData(role='remote1',
@@ -520,7 +523,7 @@ class BasicTestCase(unittest.TestCase):  # pylint: disable=moved-test-case-class
                      'ha': ['127.0.0.1', 7532],
                      'iha': None,
                      'natted': None,
-                     'fqdn': '1.0.0.127.in-addr.arpa',
+                     'fqdn': socket.getfqdn('127.0.0.1'),
                      'dyned': None,
                      'main': False,
                      'kind': data1['kind'],
@@ -528,8 +531,8 @@ class BasicTestCase(unittest.TestCase):  # pylint: disable=moved-test-case-class
                      'joined': None,
                      'role': data1['role'],
                      'acceptance': 1,
-                     'verhex': data1['verhex'],
-                     'pubhex': data1['pubhex'],
+                     'verhex': salt.utils.stringutils.to_str(data1['verhex']),
+                     'pubhex': salt.utils.stringutils.to_str(data1['pubhex']),
                      },
                 'remote2_minion':
                     {'name': data2['name'],
@@ -538,7 +541,7 @@ class BasicTestCase(unittest.TestCase):  # pylint: disable=moved-test-case-class
                      'ha': ['127.0.0.1', 7533],
                      'iha': None,
                      'natted': None,
-                     'fqdn': '1.0.0.127.in-addr.arpa',
+                     'fqdn': socket.getfqdn('127.0.0.1'),
                      'dyned': None,
                      'main': False,
                      'kind': data2['kind'],
@@ -546,8 +549,8 @@ class BasicTestCase(unittest.TestCase):  # pylint: disable=moved-test-case-class
                      'joined': None,
                      'role': data2['role'],
                      'acceptance': 1,
-                     'verhex': data2['verhex'],
-                     'pubhex': data2['pubhex'],
+                     'verhex': salt.utils.stringutils.to_str(data2['verhex']),
+                     'pubhex': salt.utils.stringutils.to_str(data2['pubhex']),
                      }
             })
 
@@ -600,14 +603,14 @@ class BasicTestCase(unittest.TestCase):  # pylint: disable=moved-test-case-class
                                 'ha': ['127.0.0.1', 7531],
                                 'iha': None,
                                 'natted': None,
-                                'fqdn': '1.0.0.127.in-addr.arpa',
+                                'fqdn': socket.getfqdn('127.0.0.1'),
                                 'dyned': None,
                                 'sid': 0,
                                 'puid': 1,
                                 'aha': ['0.0.0.0', 7531],
                                 'role': otherData['role'],
-                                'sighex': otherData['sighex'],
-                                'prihex': otherData['prihex'],
+                                'sighex': salt.utils.stringutils.to_str(otherData['sighex']),
+                                'prihex': salt.utils.stringutils.to_str(otherData['prihex']),
                             })
 
         data3 = self.createRoadData(role='remote3',
@@ -643,7 +646,7 @@ class BasicTestCase(unittest.TestCase):  # pylint: disable=moved-test-case-class
                     'ha': ['127.0.0.1', 7534],
                     'iha': None,
                     'natted': None,
-                    'fqdn': '1.0.0.127.in-addr.arpa',
+                    'fqdn': socket.getfqdn('127.0.0.1'),
                     'dyned': None,
                     'main': False,
                     'kind': data3['kind'],
@@ -651,8 +654,8 @@ class BasicTestCase(unittest.TestCase):  # pylint: disable=moved-test-case-class
                     'joined': None,
                     'role': data3['role'],
                     'acceptance': 1,
-                    'verhex': data3['verhex'],
-                    'pubhex': data3['pubhex'],
+                    'verhex': salt.utils.stringutils.to_str(data3['verhex']),
+                    'pubhex': salt.utils.stringutils.to_str(data3['pubhex']),
                 },
                 'remote4_minion':
                 {
@@ -662,7 +665,7 @@ class BasicTestCase(unittest.TestCase):  # pylint: disable=moved-test-case-class
                     'ha': ['127.0.0.1', 7535],
                     'iha': None,
                     'natted': None,
-                    'fqdn': '1.0.0.127.in-addr.arpa',
+                    'fqdn': socket.getfqdn('127.0.0.1'),
                     'dyned': None,
                     'main': False,
                     'kind': data4['kind'],
@@ -670,8 +673,8 @@ class BasicTestCase(unittest.TestCase):  # pylint: disable=moved-test-case-class
                     'joined': None,
                     'role': data4['role'],
                     'acceptance': 1,
-                    'verhex': data4['verhex'],
-                    'pubhex': data4['pubhex'],
+                    'verhex': salt.utils.stringutils.to_str(data4['verhex']),
+                    'pubhex': salt.utils.stringutils.to_str(data4['pubhex']),
                 }
             })
 
@@ -715,13 +718,13 @@ class BasicTestCase(unittest.TestCase):  # pylint: disable=moved-test-case-class
                                                          'ha': ['127.0.0.1', 7530],
                                                          'iha': None,
                                                          'natted': None,
-                                                         'fqdn': '1.0.0.127.in-addr.arpa',
+                                                         'fqdn': socket.getfqdn('127.0.0.1'),
                                                          'dyned': None,
                                                          'sid': 0,
                                                          'puid': 1,
                                                          'aha': ['0.0.0.0', 7530],
-                                                         'sighex': mainData['sighex'],
-                                                         'prihex': mainData['prihex'],
+                                                         'sighex': salt.utils.stringutils.to_str(mainData['sighex']),
+                                                         'prihex': salt.utils.stringutils.to_str(mainData['prihex']),
                                                          'role': mainData['role'],
                                                          })
 
@@ -759,7 +762,7 @@ class BasicTestCase(unittest.TestCase):  # pylint: disable=moved-test-case-class
                      'ha': ['127.0.0.1', 7532],
                      'iha': None,
                      'natted': None,
-                     'fqdn': '1.0.0.127.in-addr.arpa',
+                     'fqdn': socket.getfqdn('127.0.0.1'),
                      'dyned': None,
                      'main': False,
                      'kind': data1['kind'],
@@ -767,8 +770,8 @@ class BasicTestCase(unittest.TestCase):  # pylint: disable=moved-test-case-class
                      'joined': None,
                      'role': data1['role'],
                      'acceptance': 1,
-                     'verhex': data1['verhex'],
-                     'pubhex': data1['pubhex'],
+                     'verhex': salt.utils.stringutils.to_str(data1['verhex']),
+                     'pubhex': salt.utils.stringutils.to_str(data1['pubhex']),
                      },
                 'remote2_minion':
                     {
@@ -778,7 +781,7 @@ class BasicTestCase(unittest.TestCase):  # pylint: disable=moved-test-case-class
                      'ha': ['127.0.0.1', 7533],
                      'iha': None,
                      'natted': None,
-                     'fqdn': '1.0.0.127.in-addr.arpa',
+                     'fqdn': socket.getfqdn('127.0.0.1'),
                      'dyned': None,
                      'main': False,
                      'kind': data2['kind'],
@@ -786,8 +789,8 @@ class BasicTestCase(unittest.TestCase):  # pylint: disable=moved-test-case-class
                      'joined': None,
                      'role': data2['role'],
                      'acceptance': 1,
-                     'verhex': data2['verhex'],
-                     'pubhex': data2['pubhex'],
+                     'verhex': salt.utils.stringutils.to_str(data2['verhex']),
+                     'pubhex': salt.utils.stringutils.to_str(data2['pubhex']),
                      }
             })
 
@@ -840,14 +843,14 @@ class BasicTestCase(unittest.TestCase):  # pylint: disable=moved-test-case-class
                                 'ha': ['127.0.0.1', 7531],
                                 'iha': None,
                                 'natted': None,
-                                'fqdn': '1.0.0.127.in-addr.arpa',
+                                'fqdn': socket.getfqdn('127.0.0.1'),
                                 'dyned': None,
                                 'sid': 0,
                                 'puid': 1,
                                 'aha': ['0.0.0.0', 7531],
                                 'role': otherData['role'],
-                                'sighex': otherData['sighex'],
-                                'prihex': otherData['prihex'],
+                                'sighex': salt.utils.stringutils.to_str(otherData['sighex']),
+                                'prihex': salt.utils.stringutils.to_str(otherData['prihex']),
                             })
 
         data3 = self.createRoadData(role='remote3',
@@ -883,7 +886,7 @@ class BasicTestCase(unittest.TestCase):  # pylint: disable=moved-test-case-class
                     'ha': ['127.0.0.1', 7534],
                     'iha': None,
                     'natted': None,
-                    'fqdn': '1.0.0.127.in-addr.arpa',
+                    'fqdn': socket.getfqdn('127.0.0.1'),
                     'dyned': None,
                     'main': False,
                     'kind': data3['kind'],
@@ -891,8 +894,8 @@ class BasicTestCase(unittest.TestCase):  # pylint: disable=moved-test-case-class
                     'joined': None,
                     'role': data3['role'],
                     'acceptance': 1,
-                    'verhex': data3['verhex'],
-                    'pubhex': data3['pubhex'],
+                    'verhex': salt.utils.stringutils.to_str(data3['verhex']),
+                    'pubhex': salt.utils.stringutils.to_str(data3['pubhex']),
                 },
                 'remote4_minion':
                 {
@@ -902,7 +905,7 @@ class BasicTestCase(unittest.TestCase):  # pylint: disable=moved-test-case-class
                     'ha': ['127.0.0.1', 7535],
                     'iha': None,
                     'natted': None,
-                    'fqdn': '1.0.0.127.in-addr.arpa',
+                    'fqdn': socket.getfqdn('127.0.0.1'),
                     'dyned': None,
                     'main': False,
                     'kind': data4['kind'],
@@ -910,8 +913,8 @@ class BasicTestCase(unittest.TestCase):  # pylint: disable=moved-test-case-class
                     'joined': None,
                     'role': data4['role'],
                     'acceptance': 1,
-                    'verhex': data4['verhex'],
-                    'pubhex': data4['pubhex'],
+                    'verhex': salt.utils.stringutils.to_str(data4['verhex']),
+                    'pubhex': salt.utils.stringutils.to_str(data4['pubhex']),
                 }
             })
 
@@ -955,14 +958,14 @@ class BasicTestCase(unittest.TestCase):  # pylint: disable=moved-test-case-class
                                                          'ha': ['127.0.0.1', 7530],
                                                          'iha': None,
                                                          'natted': None,
-                                                         'fqdn': '1.0.0.127.in-addr.arpa',
+                                                         'fqdn': socket.getfqdn('127.0.0.1'),
                                                          'dyned': None,
                                                          'sid': 0,
                                                          'puid': 1,
                                                          'aha': ['0.0.0.0', 7530],
                                                          'role': mainData['role'],
-                                                         'sighex': mainData['sighex'],
-                                                         'prihex': mainData['prihex'],
+                                                         'sighex': salt.utils.stringutils.to_str(mainData['sighex']),
+                                                         'prihex': salt.utils.stringutils.to_str(mainData['prihex']),
                                                          })
 
         # add multiple remotes all with same role
@@ -1006,7 +1009,7 @@ class BasicTestCase(unittest.TestCase):  # pylint: disable=moved-test-case-class
                      'ha': ['127.0.0.1', 7532],
                      'iha': None,
                      'natted': None,
-                     'fqdn': '1.0.0.127.in-addr.arpa',
+                     'fqdn': socket.getfqdn('127.0.0.1'),
                      'dyned': None,
                      'main': False,
                      'kind': data1['kind'],
@@ -1014,8 +1017,8 @@ class BasicTestCase(unittest.TestCase):  # pylint: disable=moved-test-case-class
                      'joined': None,
                      'role': data1['role'],
                      'acceptance': 0,
-                     'verhex': data1['verhex'],
-                     'pubhex': data1['pubhex'],
+                     'verhex': salt.utils.stringutils.to_str(data1['verhex']),
+                     'pubhex': salt.utils.stringutils.to_str(data1['pubhex']),
                      },
                 'primary_caller':
                     {
@@ -1025,7 +1028,7 @@ class BasicTestCase(unittest.TestCase):  # pylint: disable=moved-test-case-class
                      'ha': ['127.0.0.1', 7533],
                      'iha': None,
                      'natted': None,
-                     'fqdn': '1.0.0.127.in-addr.arpa',
+                     'fqdn': socket.getfqdn('127.0.0.1'),
                      'dyned': None,
                      'main': False,
                      'kind': data2['kind'],
@@ -1033,8 +1036,8 @@ class BasicTestCase(unittest.TestCase):  # pylint: disable=moved-test-case-class
                      'joined': None,
                      'role': data1['role'],
                      'acceptance': 0,
-                     'verhex': data1['verhex'],
-                     'pubhex': data1['pubhex'],
+                     'verhex': salt.utils.stringutils.to_str(data1['verhex']),
+                     'pubhex': salt.utils.stringutils.to_str(data1['pubhex']),
                      }
             })
 
@@ -1104,14 +1107,14 @@ class BasicTestCase(unittest.TestCase):  # pylint: disable=moved-test-case-class
                                                          'ha': ['127.0.0.1', 7530],
                                                          'iha': None,
                                                          'natted': None,
-                                                         'fqdn': '1.0.0.127.in-addr.arpa',
+                                                         'fqdn': socket.getfqdn('127.0.0.1'),
                                                          'dyned': None,
                                                          'sid': 0,
                                                          'puid': 1,
                                                          'aha': ['0.0.0.0', 7530],
                                                          'role': mainData['role'],
-                                                         'sighex': mainData['sighex'],
-                                                         'prihex': mainData['prihex'],
+                                                         'sighex': salt.utils.stringutils.to_str(mainData['sighex']),
+                                                         'prihex': salt.utils.stringutils.to_str(mainData['prihex']),
                                                          })
 
         # add multiple remotes all with same role
@@ -1149,7 +1152,7 @@ class BasicTestCase(unittest.TestCase):  # pylint: disable=moved-test-case-class
                      'ha': ['127.0.0.1', 7532],
                      'iha': None,
                      'natted': None,
-                     'fqdn': '1.0.0.127.in-addr.arpa',
+                     'fqdn': socket.getfqdn('127.0.0.1'),
                      'dyned': None,
                      'main': False,
                      'kind': data1['kind'],
@@ -1157,8 +1160,8 @@ class BasicTestCase(unittest.TestCase):  # pylint: disable=moved-test-case-class
                      'joined': None,
                      'role': data1['role'],
                      'acceptance': 1,
-                     'verhex': data2['verhex'],
-                     'pubhex': data2['pubhex'],
+                     'verhex': salt.utils.stringutils.to_str(data2['verhex']),
+                     'pubhex': salt.utils.stringutils.to_str(data2['pubhex']),
                      },
                 'primary_syndic':
                     {
@@ -1168,7 +1171,7 @@ class BasicTestCase(unittest.TestCase):  # pylint: disable=moved-test-case-class
                      'ha': ['127.0.0.1', 7533],
                      'iha': None,
                      'natted': None,
-                     'fqdn': '1.0.0.127.in-addr.arpa',
+                     'fqdn': socket.getfqdn('127.0.0.1'),
                      'dyned': None,
                      'main': False,
                      'kind': data2['kind'],
@@ -1176,8 +1179,8 @@ class BasicTestCase(unittest.TestCase):  # pylint: disable=moved-test-case-class
                      'joined': None,
                      'role': data2['role'],
                      'acceptance': 1,
-                     'verhex': data2['verhex'],
-                     'pubhex': data2['pubhex'],
+                     'verhex': salt.utils.stringutils.to_str(data2['verhex']),
+                     'pubhex': salt.utils.stringutils.to_str(data2['pubhex']),
                      }
             })
 
@@ -1248,14 +1251,14 @@ class BasicTestCase(unittest.TestCase):  # pylint: disable=moved-test-case-class
                                                          'ha': ['127.0.0.1', 7530],
                                                          'iha': None,
                                                          'natted': None,
-                                                         'fqdn': '1.0.0.127.in-addr.arpa',
+                                                         'fqdn': socket.getfqdn('127.0.0.1'),
                                                          'dyned': None,
                                                          'sid': 0,
                                                          'puid': 1,
                                                          'aha': ['0.0.0.0', 7530],
                                                          'role': mainData['role'],
-                                                         'sighex': mainData['sighex'],
-                                                         'prihex': mainData['prihex'],
+                                                         'sighex': salt.utils.stringutils.to_str(mainData['sighex']),
+                                                         'prihex': salt.utils.stringutils.to_str(mainData['prihex']),
                                                          })
 
         # add multiple remotes all with same role but different keys
@@ -1300,7 +1303,7 @@ class BasicTestCase(unittest.TestCase):  # pylint: disable=moved-test-case-class
                      'ha': ['127.0.0.1', 7532],
                      'iha': None,
                      'natted': None,
-                     'fqdn': '1.0.0.127.in-addr.arpa',
+                     'fqdn': socket.getfqdn('127.0.0.1'),
                      'dyned': None,
                      'main': False,
                      'kind': data1['kind'],
@@ -1308,8 +1311,8 @@ class BasicTestCase(unittest.TestCase):  # pylint: disable=moved-test-case-class
                      'joined': None,
                      'role': data1['role'],
                      'acceptance': 1,
-                     'verhex': data1['verhex'],
-                     'pubhex': data1['pubhex'],
+                     'verhex': salt.utils.stringutils.to_str(data1['verhex']),
+                     'pubhex': salt.utils.stringutils.to_str(data1['pubhex']),
                      },
                 'primary_syndic':
                     {
@@ -1319,7 +1322,7 @@ class BasicTestCase(unittest.TestCase):  # pylint: disable=moved-test-case-class
                      'ha': ['127.0.0.1', 7533],
                      'iha': None,
                      'natted': None,
-                     'fqdn': '1.0.0.127.in-addr.arpa',
+                     'fqdn': socket.getfqdn('127.0.0.1'),
                      'dyned': None,
                      'main': False,
                      'kind': data2['kind'],
@@ -1327,8 +1330,8 @@ class BasicTestCase(unittest.TestCase):  # pylint: disable=moved-test-case-class
                      'joined': None,
                      'role': data2['role'],
                      'acceptance': 1,
-                     'verhex': data1['verhex'],
-                     'pubhex': data1['pubhex'],
+                     'verhex': salt.utils.stringutils.to_str(data1['verhex']),
+                     'pubhex': salt.utils.stringutils.to_str(data1['pubhex']),
                      }
             })
 
@@ -1399,14 +1402,14 @@ class BasicTestCase(unittest.TestCase):  # pylint: disable=moved-test-case-class
                                                          'ha': ['127.0.0.1', 7530],
                                                          'iha': None,
                                                          'natted': None,
-                                                         'fqdn': '1.0.0.127.in-addr.arpa',
+                                                         'fqdn': socket.getfqdn('127.0.0.1'),
                                                          'dyned': None,
                                                          'sid': 0,
                                                          'puid': 1,
                                                          'aha': ['0.0.0.0', 7530],
                                                          'role': mainData['role'],
-                                                         'sighex': mainData['sighex'],
-                                                         'prihex': mainData['prihex'],
+                                                         'sighex': salt.utils.stringutils.to_str(mainData['sighex']),
+                                                         'prihex': salt.utils.stringutils.to_str(mainData['prihex']),
                                                          })
 
         opts = self.createOpts(role='other',
@@ -1441,14 +1444,14 @@ class BasicTestCase(unittest.TestCase):  # pylint: disable=moved-test-case-class
                                 'ha': ['127.0.0.1', 7531],
                                 'iha': None,
                                 'natted': None,
-                                'fqdn': '1.0.0.127.in-addr.arpa',
+                                'fqdn': socket.getfqdn('127.0.0.1'),
                                 'dyned': None,
                                 'sid': 0,
                                 'puid': 1,
                                 'aha': ['0.0.0.0', 7531],
                                 'role': otherData['role'],
-                                'sighex': otherData['sighex'],
-                                'prihex': otherData['prihex'],
+                                'sighex': salt.utils.stringutils.to_str(otherData['sighex']),
+                                'prihex': salt.utils.stringutils.to_str(otherData['prihex']),
                             })
 
         self.join(other, main)
@@ -1524,14 +1527,14 @@ class BasicTestCase(unittest.TestCase):  # pylint: disable=moved-test-case-class
                                                          'ha': ['127.0.0.1', 7530],
                                                          'iha': None,
                                                          'natted': None,
-                                                         'fqdn': '1.0.0.127.in-addr.arpa',
+                                                         'fqdn': socket.getfqdn('127.0.0.1'),
                                                          'dyned': None,
                                                          'sid': 0,
                                                          'puid': 1,
                                                          'aha': ['0.0.0.0', 7530],
                                                          'role': mainData['role'],
-                                                         'sighex': mainData['sighex'],
-                                                         'prihex': mainData['prihex'],
+                                                         'sighex': salt.utils.stringutils.to_str(mainData['sighex']),
+                                                         'prihex': salt.utils.stringutils.to_str(mainData['prihex']),
                                                          })
 
         opts = self.createOpts(role='other',
@@ -1566,14 +1569,14 @@ class BasicTestCase(unittest.TestCase):  # pylint: disable=moved-test-case-class
                                 'ha': ['127.0.0.1', 7531],
                                 'iha': None,
                                 'natted': None,
-                                'fqdn': '1.0.0.127.in-addr.arpa',
+                                'fqdn': socket.getfqdn('127.0.0.1'),
                                 'dyned': None,
                                 'sid': 0,
                                 'puid': 1,
                                 'aha': ['0.0.0.0', 7531],
                                 'role': otherData['role'],
-                                'sighex': otherData['sighex'],
-                                'prihex': otherData['prihex'],
+                                'sighex': salt.utils.stringutils.to_str(otherData['sighex']),
+                                'prihex': salt.utils.stringutils.to_str(otherData['prihex']),
                             })
 
         self.join(other, main)
@@ -1645,14 +1648,14 @@ class BasicTestCase(unittest.TestCase):  # pylint: disable=moved-test-case-class
                                                          'ha': ['127.0.0.1', 7530],
                                                          'iha': None,
                                                          'natted': None,
-                                                         'fqdn': '1.0.0.127.in-addr.arpa',
+                                                         'fqdn': socket.getfqdn('127.0.0.1'),
                                                          'dyned': None,
                                                          'sid': 0,
                                                          'puid': 1,
                                                          'aha': ['0.0.0.0', 7530],
                                                          'role': mainData['role'],
-                                                         'sighex': mainData['sighex'],
-                                                         'prihex': mainData['prihex'],
+                                                         'sighex': salt.utils.stringutils.to_str(mainData['sighex']),
+                                                         'prihex': salt.utils.stringutils.to_str(mainData['prihex']),
                                                          })
 
         opts = self.createOpts(role='other',
@@ -1687,13 +1690,13 @@ class BasicTestCase(unittest.TestCase):  # pylint: disable=moved-test-case-class
                                 'ha': ['127.0.0.1', 7531],
                                 'iha': None,
                                 'natted': None,
-                                'fqdn': '1.0.0.127.in-addr.arpa',
+                                'fqdn': socket.getfqdn('127.0.0.1'),
                                 'dyned': None,
                                 'sid': 0,
                                 'puid': 1,
                                 'aha': ['0.0.0.0', 7531],
-                                'sighex': otherData['sighex'],
-                                'prihex': otherData['prihex'],
+                                'sighex': salt.utils.stringutils.to_str(otherData['sighex']),
+                                'prihex': salt.utils.stringutils.to_str(otherData['prihex']),
                                 'role': otherData['role'],
                             })
 
@@ -1766,14 +1769,14 @@ class BasicTestCase(unittest.TestCase):  # pylint: disable=moved-test-case-class
                                                          'ha': ['127.0.0.1', 7530],
                                                          'iha': None,
                                                          'natted': None,
-                                                         'fqdn': '1.0.0.127.in-addr.arpa',
+                                                         'fqdn': socket.getfqdn('127.0.0.1'),
                                                          'dyned': None,
                                                          'sid': 0,
                                                          'puid': 1,
                                                          'aha': ['0.0.0.0', 7530],
                                                          'role': mainData['role'],
-                                                         'sighex': mainData['sighex'],
-                                                         'prihex': mainData['prihex'],
+                                                         'sighex': salt.utils.stringutils.to_str(mainData['sighex']),
+                                                         'prihex': salt.utils.stringutils.to_str(mainData['prihex']),
                                                          })
 
         opts = self.createOpts(role='primary',
@@ -1808,14 +1811,14 @@ class BasicTestCase(unittest.TestCase):  # pylint: disable=moved-test-case-class
                                 'ha': ['127.0.0.1', 7531],
                                 'iha': None,
                                 'natted': None,
-                                'fqdn': '1.0.0.127.in-addr.arpa',
+                                'fqdn': socket.getfqdn('127.0.0.1'),
                                 'dyned': None,
                                 'sid': 0,
                                 'puid': 1,
                                 'aha': ['0.0.0.0', 7531],
                                 'role': other1Data['role'],
-                                'sighex': other1Data['sighex'],
-                                'prihex': other1Data['prihex'],
+                                'sighex': salt.utils.stringutils.to_str(other1Data['sighex']),
+                                'prihex': salt.utils.stringutils.to_str(other1Data['prihex']),
                             })
 
         self.join(other1, main)
@@ -1876,13 +1879,13 @@ class BasicTestCase(unittest.TestCase):  # pylint: disable=moved-test-case-class
                                 'ha': ['127.0.0.1', 7532],
                                 'iha': None,
                                 'natted': None,
-                                'fqdn': '1.0.0.127.in-addr.arpa',
+                                'fqdn': socket.getfqdn('127.0.0.1'),
                                 'dyned': None,
                                 'sid': 0,
                                 'puid': 1,
                                 'aha': ['0.0.0.0', 7532],
-                                'sighex': other2Data['sighex'],
-                                'prihex': other2Data['prihex'],
+                                'sighex': salt.utils.stringutils.to_str(other2Data['sighex']),
+                                'prihex': salt.utils.stringutils.to_str(other2Data['prihex']),
                                 'role': other2Data['role'],
                             })
 
@@ -1936,14 +1939,14 @@ class BasicTestCase(unittest.TestCase):  # pylint: disable=moved-test-case-class
                                 'ha': ['127.0.0.1', 7532],
                                 'iha': None,
                                 'natted': None,
-                                'fqdn': '1.0.0.127.in-addr.arpa',
+                                'fqdn': socket.getfqdn('127.0.0.1'),
                                 'dyned': None,
                                 'sid': 0,
                                 'puid': 1,
                                 'aha': ['0.0.0.0', 7532],
                                 'role': other2Data['role'],
-                                'sighex': other1Data['sighex'],
-                                'prihex': other1Data['prihex'],
+                                'sighex': salt.utils.stringutils.to_str(other1Data['sighex']),
+                                'prihex': salt.utils.stringutils.to_str(other1Data['prihex']),
                             })
 
         # should join since same role and keys
@@ -2021,14 +2024,14 @@ class BasicTestCase(unittest.TestCase):  # pylint: disable=moved-test-case-class
                                                          'ha': ['127.0.0.1', 7530],
                                                          'iha': None,
                                                          'natted': None,
-                                                         'fqdn': '1.0.0.127.in-addr.arpa',
+                                                         'fqdn': socket.getfqdn('127.0.0.1'),
                                                          'dyned': None,
                                                          'sid': 0,
                                                          'puid': 1,
                                                          'aha': ['0.0.0.0', 7530],
                                                           'role': mainData['role'],
-                                                         'sighex': mainData['sighex'],
-                                                         'prihex': mainData['prihex'],
+                                                         'sighex': salt.utils.stringutils.to_str(mainData['sighex']),
+                                                         'prihex': salt.utils.stringutils.to_str(mainData['prihex']),
                                                          })
 
         opts = self.createOpts(role='primary',
@@ -2063,14 +2066,14 @@ class BasicTestCase(unittest.TestCase):  # pylint: disable=moved-test-case-class
                                 'ha': ['127.0.0.1', 7531],
                                 'iha': None,
                                 'natted': None,
-                                'fqdn': '1.0.0.127.in-addr.arpa',
+                                'fqdn': socket.getfqdn('127.0.0.1'),
                                 'dyned': None,
                                 'sid': 0,
                                 'puid': 1,
                                 'aha': ['0.0.0.0', 7531],
                                 'role': other1Data['role'],
-                                'sighex': other1Data['sighex'],
-                                'prihex': other1Data['prihex'],
+                                'sighex': salt.utils.stringutils.to_str(other1Data['sighex']),
+                                'prihex': salt.utils.stringutils.to_str(other1Data['prihex']),
                             })
 
         self.join(other1, main)
@@ -2130,14 +2133,14 @@ class BasicTestCase(unittest.TestCase):  # pylint: disable=moved-test-case-class
                                 'ha': ['127.0.0.1', 7532],
                                 'iha': None,
                                 'natted': None,
-                                'fqdn': '1.0.0.127.in-addr.arpa',
+                                'fqdn': socket.getfqdn('127.0.0.1'),
                                 'dyned': None,
                                 'sid': 0,
                                 'puid': 1,
                                 'aha': ['0.0.0.0', 7532],
                                 'role': other2Data['role'],
-                                'sighex': other2Data['sighex'],
-                                'prihex': other2Data['prihex'],
+                                'sighex': salt.utils.stringutils.to_str(other2Data['sighex']),
+                                'prihex': salt.utils.stringutils.to_str(other2Data['prihex']),
                             })
 
         # should join since open mode
@@ -2225,8 +2228,8 @@ if __name__ == '__main__' and __package__ is None:
 
     #console.reinit(verbosity=console.Wordage.concise)
 
-    #runAll()  # run all unittests
+    runAll()  # run all unittests
 
-    runSome()  # only run some
+    #runSome()  # only run some
 
     #runOne('testBootstrapRoleAuto')

--- a/salt/daemons/test/test_stats.py
+++ b/salt/daemons/test/test_stats.py
@@ -5,6 +5,7 @@ Raet Ioflo Behavior Unittests
 from __future__ import absolute_import, print_function, unicode_literals
 import sys
 from salt.ext.six.moves import map
+import importlib
 # pylint: disable=blacklisted-import
 if sys.version_info < (2, 7):
     import unittest2 as unittest
@@ -43,6 +44,9 @@ class StatsEventerTestCase(testing.FrameIofloTestCase):
         '''
         Call super if override so House Framer and Frame are setup correctly
         '''
+        behaviors = ['salt.daemons.flo', 'salt.daemons.test.plan']
+        for behavior in behaviors:
+            mod = importlib.import_module(behavior)
         super(StatsEventerTestCase, self).setUp()
 
     def tearDown(self):

--- a/salt/daemons/test/test_stats.py
+++ b/salt/daemons/test/test_stats.py
@@ -727,8 +727,8 @@ if __name__ == '__main__' and __package__ is None:
 
     # console.reinit(verbosity=console.Wordage.concise)
 
-    #runAll()  # run all unittests
+    runAll()  # run all unittests
 
-    runSome()  # only run some
+    #runSome()  # only run some
 
     #runOne('testMasterLaneStats')

--- a/salt/key.py
+++ b/salt/key.py
@@ -1082,6 +1082,8 @@ class RaetKey(Key):
         pre_path = os.path.join(pre, minion_id)
         rej_path = os.path.join(rej, minion_id)
         # open mode is turned on, force accept the key
+        pub = salt.utils.stringutils.to_str(pub)
+        verify = salt.utils.stringutils.to_str(verify)
         keydata = {
                 'minion_id': minion_id,
                 'pub': pub,
@@ -1148,7 +1150,7 @@ class RaetKey(Key):
         verify: <verify>
         '''
         path = os.path.join(self.opts['pki_dir'], status, minion_id)
-        with salt.utils.files.fopen(path, 'r') as fp_:
+        with salt.utils.files.fopen(path, 'rb') as fp_:
             keydata = self.serial.loads(fp_.read())
             return 'pub: {0}\nverify: {1}'.format(
                     keydata['pub'],
@@ -1158,7 +1160,7 @@ class RaetKey(Key):
         '''
         Return a sha256 kingerprint for the key
         '''
-        with salt.utils.files.fopen(path, 'r') as fp_:
+        with salt.utils.files.fopen(path, 'rb') as fp_:
             keydata = self.serial.loads(fp_.read())
             key = 'pub: {0}\nverify: {1}'.format(
                     keydata['pub'],
@@ -1442,7 +1444,7 @@ class RaetKey(Key):
         if os.path.exists(path):
             #mode = os.stat(path).st_mode
             os.chmod(path, stat.S_IWUSR | stat.S_IRUSR)
-        with salt.utils.files.fopen(path, 'w+') as fp_:
+        with salt.utils.files.fopen(path, 'w+b') as fp_:
             fp_.write(self.serial.dumps(keydata))
             os.chmod(path, stat.S_IRUSR)
         os.umask(c_umask)

--- a/salt/log/setup.py
+++ b/salt/log/setup.py
@@ -120,6 +120,7 @@ __MP_LOGGING_QUEUE = None
 __MP_LOGGING_QUEUE_PROCESS = None
 __MP_LOGGING_QUEUE_HANDLER = None
 __MP_IN_MAINPROCESS = multiprocessing.current_process().name == 'MainProcess'
+__MP_MAINPROCESS_ID = None
 
 
 class __NullLoggingHandler(TemporaryLoggingHandler):
@@ -822,6 +823,7 @@ def set_multiprocessing_logging_queue(queue):
 def setup_multiprocessing_logging_listener(opts, queue=None):
     global __MP_LOGGING_QUEUE_PROCESS
     global __MP_LOGGING_LISTENER_CONFIGURED
+    global __MP_MAINPROCESS_ID
 
     if __MP_IN_MAINPROCESS is False:
         # We're not in the MainProcess, return! No logging listener setup shall happen
@@ -830,6 +832,11 @@ def setup_multiprocessing_logging_listener(opts, queue=None):
     if __MP_LOGGING_LISTENER_CONFIGURED is True:
         return
 
+    if __MP_MAINPROCESS_ID is not None and __MP_MAINPROCESS_ID != os.getpid():
+        # We're not in the MainProcess, return! No logging listener setup shall happen
+        return
+
+    __MP_MAINPROCESS_ID = os.getpid()
     __MP_LOGGING_QUEUE_PROCESS = multiprocessing.Process(
         target=__process_multiprocessing_logging_queue,
         args=(opts, queue or get_multiprocessing_logging_queue(),)
@@ -954,6 +961,7 @@ def shutdown_multiprocessing_logging_listener(daemonizing=False):
     global __MP_LOGGING_QUEUE
     global __MP_LOGGING_QUEUE_PROCESS
     global __MP_LOGGING_LISTENER_CONFIGURED
+    global __MP_MAINPROCESS_ID
 
     if daemonizing is False and __MP_IN_MAINPROCESS is True:
         # We're in the MainProcess and we're not daemonizing, return!
@@ -967,6 +975,11 @@ def shutdown_multiprocessing_logging_listener(daemonizing=False):
 
     if __MP_LOGGING_QUEUE_PROCESS is None:
         return
+
+    if __MP_MAINPROCESS_ID is not None and __MP_MAINPROCESS_ID != os.getpid():
+        # We're not in the MainProcess, return! No logging listener setup shall happen
+        return
+
     if __MP_LOGGING_QUEUE_PROCESS.is_alive():
         logging.getLogger(__name__).debug('Stopping the multiprocessing logging queue listener')
         try:

--- a/salt/log/setup.py
+++ b/salt/log/setup.py
@@ -961,7 +961,6 @@ def shutdown_multiprocessing_logging_listener(daemonizing=False):
     global __MP_LOGGING_QUEUE
     global __MP_LOGGING_QUEUE_PROCESS
     global __MP_LOGGING_LISTENER_CONFIGURED
-    global __MP_MAINPROCESS_ID
 
     if daemonizing is False and __MP_IN_MAINPROCESS is True:
         # We're in the MainProcess and we're not daemonizing, return!

--- a/salt/utils/stringutils.py
+++ b/salt/utils/stringutils.py
@@ -5,6 +5,7 @@ Functions for manipulating or otherwise processing strings
 
 # Import Python libs
 from __future__ import absolute_import, print_function, unicode_literals
+import base64
 import errno
 import fnmatch
 import logging
@@ -203,7 +204,7 @@ def is_binary(data):
 @jinja_filter('random_str')
 def random(size=32):
     key = os.urandom(size)
-    return key.encode('base64').replace('\n', '')[:size]
+    return to_unicode(base64.b64encode(key).replace(b'\n', b'')[:size])
 
 
 @jinja_filter('contains_whitespace')


### PR DESCRIPTION
### What does this PR do?
Fixes RAET transport:
* Fixed specific tests for raet
* Python 3 support
* No tracebacks on shutdown Py2/Py3
* Tested Py2-Py3 network level compatibility

### What issues does this PR fix or reference?
This is the final part of RAET deprecation work.

### Tests written?
No

### Commits signed with GPG?
Yes