### PR TITLE
[bugfix] Fix for oversized filenames in fileclient

### DIFF
--- a/salt/fileclient.py
+++ b/salt/fileclient.py
@@ -46,6 +46,7 @@ from salt.ext.six.moves.urllib.parse import urlparse, urlunparse
 # pylint: enable=no-name-in-module,import-error
 
 log = logging.getLogger(__name__)
+MAX_FILENAME_LENGTH = 255
 
 
 def get_file_client(opts, pillar=False):
@@ -830,6 +831,9 @@ class Client(object):
             file_name = '-'.join([url_data.path, url_data.query])
         else:
             file_name = url_data.path
+
+        if len(file_name) > MAX_FILENAME_LENGTH:
+            file_name = salt.utils.hashutils.sha256_digest(file_name)
 
         return salt.utils.path.join(
             cachedir,

--- a/tests/unit/test_fileclient.py
+++ b/tests/unit/test_fileclient.py
@@ -50,3 +50,14 @@ class FileclientTestCase(TestCase):
                 with self.assertRaises(OSError):
                     with Client(self.opts)._cache_loc('testfile') as c_ref_itr:
                         assert c_ref_itr == '/__test__/files/base/testfile'
+
+    def test_extrn_path_with_long_filename(self):
+        safe_file_name = os.path.split(Client(self.opts)._extrn_path('https://test.com/' + ('A' * 254), 'base'))[-1]
+        assert safe_file_name == 'A' * 254
+
+        oversized_file_name = os.path.split(Client(self.opts)._extrn_path('https://test.com/' + ('A' * 255), 'base'))[-1]
+        assert len(oversized_file_name) < 256
+        assert oversized_file_name != 'A' * 255
+
+        oversized_file_with_query_params = os.path.split(Client(self.opts)._extrn_path('https://test.com/file?' + ('A' * 255), 'base'))[-1]
+        assert len(oversized_file_with_query_params) < 256


### PR DESCRIPTION
### What does this PR do?

This PR fixes the bug reported in #40846, wherein salt will attempt (and fail) to write a file with a long filename (e.g. a URL we download that has long query params). This is caused by filesystem naming limitations, which are generally at or above 255 characters.

### What issues does this PR fix or reference?

#40846

### Previous Behavior

Salt would crash when attempting to download and cache a file with a large URL or large set of query paramaters.

### New Behavior

Salt will now use a SHA256 hash of the file name if the file name meets or exceeds 255 characters.

### Tests written?

Yes

### Commits signed with GPG?

Yes
