### PR TITLE
doc: dockermod: fix typo with ignore_already_stopped

### DIFF
--- a/salt/modules/dockermod.py
+++ b/salt/modules/dockermod.py
@@ -5805,7 +5805,7 @@ def wait(name, ignore_already_stopped=False, fail_on_exit_status=False):
         Container name or ID
 
     ignore_already_stopped
-        Boolean flag that prevent execution to fail, if a container
+        Boolean flag that prevents execution to fail, if a container
         is already stopped.
 
     fail_on_exit_status


### PR DESCRIPTION
[ci skip]