### PR TITLE
Route53 AliasTarget and Infinite loop fixes

### DIFF
--- a/salt/modules/boto3_route53.py
+++ b/salt/modules/boto3_route53.py
@@ -862,7 +862,7 @@ def change_resource_record_sets(HostedZoneId=None, Name=None,
         args.update({'PrivateZone': PrivateZone}) if PrivateZone is not None else None
         zone = find_hosted_zone(**args)
         if not zone:
-            log.error("Couldn't resolve domain name {0} to a hosted zone ID.".format(Name))
+            log.error("Couldn't resolve domain name %s to a hosted zone ID.", Name)
             return []
         HostedZoneId = zone[0]['HostedZone']['Id']
 
@@ -879,6 +879,7 @@ def change_resource_record_sets(HostedZoneId=None, Name=None,
                 time.sleep(3)
                 retries -= 1
                 continue
-            log.error('Failed to apply requested changes to the hosted zone {0}: {1}'.format(
-                    Name or HostedZoneId, str(e)))
+            log.error('Failed to apply requested changes to the hosted zone {%s}: {%s}',
+                    (Name or HostedZoneId), str(e)))
+            raise e
     return False

--- a/salt/modules/boto3_route53.py
+++ b/salt/modules/boto3_route53.py
@@ -880,6 +880,6 @@ def change_resource_record_sets(HostedZoneId=None, Name=None,
                 retries -= 1
                 continue
             log.error('Failed to apply requested changes to the hosted zone {%s}: {%s}',
-                    (Name or HostedZoneId), str(e)))
+                    (Name or HostedZoneId), str(e))
             raise e
     return False

--- a/salt/modules/boto3_route53.py
+++ b/salt/modules/boto3_route53.py
@@ -887,6 +887,6 @@ def change_resource_record_sets(HostedZoneId=None, Name=None,
                 tries -= 1
                 continue
             log.error('Failed to apply requested changes to the hosted zone %s: %s',
-                    (Name or HostedZoneId), str(e))
+                    (Name or HostedZoneId), six.text_type(e))
             raise e
     return False


### PR DESCRIPTION
### What does this PR do?

1. Ensures that we don't get stuck in an infinite loop when change_resource_record_sets results in an API error that isn't rate limiting (such as the API refusing to make a change)
2. Correctly checks to see if ResourceRecords coming back from API is None prior to attempting to iterate / sort over it

### What issues does this PR fix or reference?

https://github.com/saltstack/salt/issues/45816
https://github.com/saltstack/salt/issues/45817

### Previous Behavior

1. An infinite loop when you attempt to change a DNS entry from say a CNAME to an A without cleaning up first
2. TypeError: 'NoneType' object is not iterable if the DNS entry you are attempting to change doesn't have an upstream ResourceRecords entry (such as when it only has an AliasTarget)

### New Behavior

1. module correctly throws an exception when it encounters an API error which is not associated with rate limiting
2. Correctly allows for empty ResourceRecords coming back from the API when attempting to determine if an update needs to be made

### Tests written?

No

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
