### PR TITLE
oxygen-added-highstate-output-to-slack-engine

### DIFF
--- a/salt/engines/slack.py
+++ b/salt/engines/slack.py
@@ -563,20 +563,11 @@ class SlackClient(object):
         '''
         Print out YAML using the block mode
         '''
-        params = {}
-        if 'output_indent' not in __opts__:
-            # default indentation
-            params.update(default_flow_style=False)
-        elif __opts__['output_indent'] >= 0:
-            # custom indent
-            params.update(default_flow_style=False,
-                          indent=__opts__['output_indent'])
-        else:  # no indentation
-            params.update(default_flow_style=True,
-                          indent=0)
         try:
-            #return salt.utils.yaml.safe_dump(data, **params).replace("\n\n", "\n")
-            return salt.utils.json.dumps(data, sort_keys=True, indent=1)
+            salt.output.highstate.__opts__ = __opts__
+            if 'color' not in salt.output.highstate.__opts__:
+                salt.output.highstate.__opts__.update({"color": ""})
+            return salt.output.highstate.output(data)
         # pylint: disable=broad-except
         except Exception as exc:
             import pprint


### PR DESCRIPTION
### What does this PR do?

Return the command result for slack engine in Highstate format and ordered for operation number

### Previous Behavior

Output state returned in Slack was unordered and in json format (not readable)

### New Behavior

Output state returned in Slack is ordered by run_num value and Highstate format (more readable)

### Tests written?

No

### Commits signed with GPG?

No
