### PR TITLE
Make vault session token reusable

### DIFF
--- a/salt/utils/vault.py
+++ b/salt/utils/vault.py
@@ -24,6 +24,8 @@ logging.getLogger("requests").setLevel(logging.WARNING)
 
 # Load the __salt__ dunder if not already loaded (when called from utils-module)
 __salt__ = None
+
+
 def __virtual__():  # pylint: disable=expected-2-blank-lines-found-0
     try:
         global __salt__  # pylint: disable=global-statement
@@ -50,27 +52,27 @@ def _get_token_and_url_from_master():
         log.debug('Running on minion, signing token request with key %s',
                   private_key)
         signature = base64.b64encode(salt.crypt.sign_message(
-                                                             private_key,
-                                                             minion_id
-                                                            ))
+            private_key,
+            minion_id
+        ))
         result = __salt__['publish.runner'](
-                                            'vault.generate_token',
-                                            arg=[minion_id, signature]
-                                           )
+            'vault.generate_token',
+            arg=[minion_id, signature]
+        )
     else:
         private_key = '{0}/master.pem'.format(pki_dir)
         log.debug('Running on master, signing token request for %s with key %s',
                   minion_id, private_key)
         signature = base64.b64encode(salt.crypt.sign_message(
-                                                             private_key,
-                                                             minion_id
-                                                            ))
+            private_key,
+            minion_id
+        ))
         result = __salt__['saltutil.runner'](
-                                             'vault.generate_token',
-                                             minion_id=minion_id,
-                                             signature=signature,
-                                             impersonated_by_master=True
-                                            )
+            'vault.generate_token',
+            minion_id=minion_id,
+            signature=signature,
+            impersonated_by_master=True
+        )
 
     if not result:
         log.error('Failed to get token from master! No result returned - '
@@ -85,10 +87,10 @@ def _get_token_and_url_from_master():
                   'An error was returned: %s', result['error'])
         raise salt.exceptions.CommandExecutionError(result)
     return {
-            'url': result['url'],
-            'token': result['token'],
-            'verify': result['verify'],
-           }
+        'url': result['url'],
+        'token': result['token'],
+        'verify': result['verify'],
+    }
 
 
 def _get_vault_connection():
@@ -126,7 +128,7 @@ def _get_vault_connection():
         return _get_token_and_url_from_master()
 
 
-def make_request(method, resource, profile=None, **args):
+def make_request(method, resource, profile=None, token=None, vault_url=None, get_token_url=False, **args):
     '''
     Make a request to Vault
     '''
@@ -134,16 +136,20 @@ def make_request(method, resource, profile=None, **args):
         # Deprecated code path
         return make_request_with_profile(method, resource, profile, **args)
 
-    connection = _get_vault_connection()
-    token, vault_url = connection['token'], connection['url']
-    if 'verify' not in args:
-        args['verify'] = connection['verify']
+    if not token or not vault_url:
+        connection = _get_vault_connection()
+        token, vault_url = connection['token'], connection['url']
+        if 'verify' not in args:
+            args['verify'] = connection['verify']
 
     url = "{0}/{1}".format(vault_url, resource)
     headers = {'X-Vault-Token': token, 'Content-Type': 'application/json'}
     response = requests.request(method, url, headers=headers, **args)
 
-    return response
+    if get_token_url:
+        return response, token, vault_url
+    else:
+        return response
 
 
 def make_request_with_profile(method, resource, profile, **args):


### PR DESCRIPTION
### What does this PR do?
Allow session token reuse in vault requests

### What issues does this PR fix or reference?
n\a

### Previous Behavior
Any call to make_requests implies re-authentication. Session token is not being reused

### New Behavior
One can now reuse the session token by first getting the url+token returned by the runner and then calling make_request with token and url:
```
result, token, vault_url =__utils__['vault.make_request']('GET', url, get_token_url)
__utils__['vault.make_request']('GET', url, token, vault_url)
```
### Tests written?

No

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
