### PR TITLE
Fix traceback in disks grains when /sys/block not available

### DIFF
--- a/salt/grains/disks.py
+++ b/salt/grains/disks.py
@@ -132,20 +132,23 @@ def _linux_disks():
     ret = {'disks': [], 'SSDs': []}
 
     for entry in glob.glob('/sys/block/*/queue/rotational'):
-        with salt.utils.files.fopen(entry) as entry_fp:
-            device = entry.split('/')[3]
-            flag = entry_fp.read(1)
-            if flag == '0':
-                ret['SSDs'].append(device)
-                log.trace('Device %s reports itself as an SSD', device)
-            elif flag == '1':
-                ret['disks'].append(device)
-                log.trace('Device %s reports itself as an HDD', device)
-            else:
-                log.trace(
-                    'Unable to identify device %s as an SSD or HDD. It does '
-                    'not report 0 or 1', device
-                )
+        try:
+            with salt.utils.files.fopen(entry) as entry_fp:
+                device = entry.split('/')[3]
+                flag = entry_fp.read(1)
+                if flag == '0':
+                    ret['SSDs'].append(device)
+                    log.trace('Device %s reports itself as an SSD', device)
+                elif flag == '1':
+                    ret['disks'].append(device)
+                    log.trace('Device %s reports itself as an HDD', device)
+                else:
+                    log.trace(
+                        'Unable to identify device %s as an SSD or HDD. It does '
+                        'not report 0 or 1', device
+                    )
+        except IOError:
+            pass
     return ret
 
 


### PR DESCRIPTION
This prevents a traceback when salt is run in a container where
/sys/block is not present.