### PR TITLE
Change "locale" value in versions-report to use __salt_system_encoding__

### DIFF
--- a/salt/version.py
+++ b/salt/version.py
@@ -7,7 +7,6 @@ Set up the version of Salt
 from __future__ import absolute_import, print_function, unicode_literals
 import re
 import sys
-import locale
 import platform
 
 # linux_distribution depreacted in py3.7
@@ -674,7 +673,7 @@ def system_information():
         ('release', release),
         ('machine', platform.machine()),
         ('version', version),
-        ('locale', locale.getpreferredencoding()),
+        ('locale', __salt_system_encoding__),
     ]
 
     for name, attr in system:


### PR DESCRIPTION
locale.getpreferredencoding() may not be equal to it, and we don't use
locale.getpreferredencoding() anyway when we perform unicode conversions
in salt, we use `__salt_system_encoding__`.