### PR TITLE
Fix IndexError of drbd.py and support different drbd version

### DIFF
--- a/salt/modules/drbd.py
+++ b/salt/modules/drbd.py
@@ -8,6 +8,15 @@ import logging
 
 log = logging.getLogger(__name__)
 
+def _analyse_overview_field(content):
+    if "(" in content:
+        # Output like "Connected(2*)" or "UpToDate(2*)"
+        return content.split("(")[0], content.split("(")[0]
+    elif "/" in content:
+        # Output like "Primar/Second" or "UpToDa/UpToDa"
+        return content.split("/")[0], content.split("/")[1]
+
+    return content, ""
 
 def overview():
     '''
@@ -25,13 +34,9 @@ def overview():
         fields = line.strip().split()
         minnum = fields[0].split(':')[0]
         device = fields[0].split(':')[1]
-        connstate = fields[1]
-        role = fields[2].split('/')
-        localrole = role[0]
-        partnerrole = role[1]
-        diskstate = fields[3].split('/')
-        localdiskstate = diskstate[0]
-        partnerdiskstate = diskstate[1]
+        connstate, _ = _analyse_overview_field(fields[1])
+        localrole, partnerrole = _analyse_overview_field(fields[2])
+        localdiskstate, partnerdiskstate = _analyse_overview_field(fields[3])
         if localdiskstate.startswith("UpTo"):
             if partnerdiskstate.startswith("UpTo"):
                 if len(fields) >= 5:

--- a/salt/modules/drbd.py
+++ b/salt/modules/drbd.py
@@ -8,6 +8,7 @@ import logging
 
 log = logging.getLogger(__name__)
 
+
 def _analyse_overview_field(content):
     if "(" in content:
         # Output like "Connected(2*)" or "UpToDate(2*)"
@@ -17,6 +18,7 @@ def _analyse_overview_field(content):
         return content.split("/")[0], content.split("/")[1]
 
     return content, ""
+
 
 def overview():
     '''

--- a/salt/modules/drbd.py
+++ b/salt/modules/drbd.py
@@ -11,7 +11,7 @@ log = logging.getLogger(__name__)
 
 def overview():
     '''
-    Show status of the DRBD devices
+    Show status of the DRBD devices, support two nodes only.
 
     CLI Example:
 
@@ -32,9 +32,9 @@ def overview():
         diskstate = fields[3].split('/')
         localdiskstate = diskstate[0]
         partnerdiskstate = diskstate[1]
-        if localdiskstate == "UpToDate":
-            if partnerdiskstate == "UpToDate":
-                if fields[4]:
+        if localdiskstate.startswith("UpTo"):
+            if partnerdiskstate.startswith("UpTo"):
+                if len(fields) >= 5:
                     mountpoint = fields[4]
                     fs_mounted = fields[5]
                     totalsize = fields[6]


### PR DESCRIPTION
### What does this PR do?
drbd module is kind of out of date since drbd upstream continue to develop.
This PR mainly fix a possible IndexError and support different drbd version. But like the previous action, still limited to two nodes.

More functions and multiple nodes support will be implemented in future, since eventually drbd-overview will be deprecated by new functions (but not now), since it is no longer friendly to represent the status of multiple nodes.

### What issues does this PR fix or reference?
Fix a possible IndexError and support different(including latest) drbd version. But like the solution before, still limited to two nodes.

### Previous Behavior
Only support the ancient drbd-utils and may raise an IndexError.

### New Behavior
Behavior doesn't change, but support the latest drbd version.

### Tests written?
No. No new function involved.

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
