### PR TITLE
Fix invalid Sphinx lexers in docs

### DIFF
--- a/doc/topics/tutorials/cron.rst
+++ b/doc/topics/tutorials/cron.rst
@@ -33,7 +33,7 @@ at midnight.
     may not include the path for any scripts or commands used by Salt, and it
     may be necessary to set the PATH accordingly in the crontab:
 
-    .. code-block:: cron
+    .. code-block:: bash
 
         PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin:/opt/bin
 

--- a/doc/topics/tutorials/firewall.rst
+++ b/doc/topics/tutorials/firewall.rst
@@ -130,7 +130,7 @@ command line.
 The Windows Firewall rule can be created by issuing a single command. Run the
 following command from the command line or a run prompt:
 
-.. code-block:: cmd
+.. code-block:: bash
 
     netsh advfirewall firewall add rule name="Salt" dir=in action=allow protocol=TCP localport=4505-4506
 

--- a/salt/engines/ircbot.py
+++ b/salt/engines/ircbot.py
@@ -40,7 +40,7 @@ event <tag> [<extra>, <data>]
 
 Example of usage
 
-.. code-block:: txt
+.. code-block:: text
 
     08:33:57 @gtmanfred > !ping
     08:33:57   gtmanbot > gtmanfred: pong
@@ -49,7 +49,7 @@ Example of usage
     08:34:17 @gtmanfred > !event test/tag/ircbot irc is usefull
     08:34:17   gtmanbot > gtmanfred: TaDa!
 
-.. code-block:: txt
+.. code-block:: text
 
     [DEBUG   ] Sending event: tag = salt/engines/ircbot/test/tag/ircbot; data = {'_stamp': '2016-11-28T14:34:16.633623', 'data': ['irc', 'is', 'useful']}
 

--- a/salt/modules/match.py
+++ b/salt/modules/match.py
@@ -369,7 +369,7 @@ def search_by(lookup, tgt_type='compound', minion_id=None):
 
     CLI Example:
 
-    .. code-block:: base
+    .. code-block:: bash
 
         salt '*' match.search_by '{web: [node1, node2], db: [node2, node]}'
 

--- a/salt/modules/nacl.py
+++ b/salt/modules/nacl.py
@@ -84,7 +84,7 @@ without extra parameters:
     salt-run nacl.enc 'asecretpass'
     salt-run nacl.dec 'tqXzeIJnTAM9Xf0mdLcpEdklMbfBGPj2oTKmlgrm3S1DTVVHNnh9h8mU1GKllGq/+cYsk6m5WhGdk58='
 
-.. code-block:: yam
+.. code-block:: yaml
 
     # a salt developers minion could have pillar data that includes a nacl public key
     nacl.config:

--- a/salt/runners/nacl.py
+++ b/salt/runners/nacl.py
@@ -84,7 +84,7 @@ without extra parameters:
     salt-run nacl.enc 'asecretpass'
     salt-run nacl.dec 'tqXzeIJnTAM9Xf0mdLcpEdklMbfBGPj2oTKmlgrm3S1DTVVHNnh9h8mU1GKllGq/+cYsk6m5WhGdk58='
 
-.. code-block:: yam
+.. code-block:: yaml
 
     # a salt developers minion could have pillar data that includes a nacl public key
     nacl.config:


### PR DESCRIPTION
This clears up some warnings when we build the docs, and improves the
syntax highlighting in the docs.