### PR TITLE
Mention nodegroups in the list of compound matchers

### DIFF
--- a/doc/topics/targeting/compound.rst
+++ b/doc/topics/targeting/compound.rst
@@ -21,6 +21,7 @@ I      Pillar glob          ``I@pdata:foobar``                                  
 J      Pillar PCRE          ``J@pdata:^(foo|bar)$``                                        Yes
 S      Subnet/IP address    ``S@192.168.1.0/24`` or ``S@192.168.1.100``                    No
 R      Range cluster        ``R@%foo.bar``                                                 No
+N      Nodegroups           ``N@group1``                                                   No 
 ====== ==================== ============================================================== =============================================
 
 Matchers can be joined using boolean ``and``, ``or``, and ``not`` operators.


### PR DESCRIPTION
### What does this PR do?

Add node groups to the table of supported compound matchers whose omission I believe was oversight.

### Tests written?

No

### Commits signed with GPG?

Yes