### PR TITLE
zfs/zpool refactor

### DIFF
--- a/salt/grains/zfs.py
+++ b/salt/grains/zfs.py
@@ -16,24 +16,24 @@ from __future__ import absolute_import, print_function, unicode_literals
 import logging
 
 # Import salt libs
-import salt.utils.dictupdate
+import salt.utils.dictupdate as dictupdate
 import salt.utils.path
 import salt.utils.platform
-try:
-    # The zfs_support grain will only be set to True if this module is supported
-    # This allows the grain to be set to False on systems that don't support zfs
-    # _conform_value is only called if zfs_support is set to True
-    from salt.modules.zfs import _conform_value
-except ImportError:
-    pass
 
 # Solve the Chicken and egg problem where grains need to run before any
 # of the modules are loaded and are generally available for any usage.
 import salt.modules.cmdmod
+import salt.utils.zfs
 
 __virtualname__ = 'zfs'
 __salt__ = {
     'cmd.run': salt.modules.cmdmod.run,
+}
+__utils__ = {
+    'zfs.is_supported': salt.utils.zfs.is_supported,
+    'zfs.has_feature_flags': salt.utils.zfs.has_feature_flags,
+    'zfs.zpool_command': salt.utils.zfs.zpool_command,
+    'zfs.to_auto': salt.utils.zfs.to_auto,
 }
 
 log = logging.getLogger(__name__)
@@ -48,45 +48,6 @@ def __virtual__():
     return __virtualname__
 
 
-def _check_retcode(cmd):
-    '''
-    Simple internal wrapper for cmdmod.retcode
-    '''
-    return salt.modules.cmdmod.retcode(cmd, output_loglevel='quiet', ignore_retcode=True) == 0
-
-
-def _zfs_support():
-    '''
-    Provide information about zfs kernel module
-    '''
-    grains = {'zfs_support': False}
-
-    # Check for zfs support
-    # NOTE: ZFS on Windows is in development
-    # NOTE: ZFS on NetBSD is in development
-    on_supported_platform = False
-    if salt.utils.platform.is_sunos() and salt.utils.path.which('zfs'):
-        on_supported_platform = True
-    elif salt.utils.platform.is_freebsd() and _check_retcode('kldstat -q -m zfs'):
-        on_supported_platform = True
-    elif salt.utils.platform.is_linux():
-        modinfo = salt.utils.path.which('modinfo')
-        if modinfo:
-            on_supported_platform = _check_retcode('{0} zfs'.format(modinfo))
-        else:
-            on_supported_platform = _check_retcode('ls /sys/module/zfs')
-
-        # NOTE: fallback to zfs-fuse if needed
-        if not on_supported_platform and salt.utils.path.which('zfs-fuse'):
-            on_supported_platform = True
-
-    # Additional check for the zpool command
-    if on_supported_platform and salt.utils.path.which('zpool'):
-        grains['zfs_support'] = True
-
-    return grains
-
-
 def _zfs_pool_data():
     '''
     Provide grains about zpools
@@ -94,12 +55,16 @@ def _zfs_pool_data():
     grains = {}
 
     # collect zpool data
-    zpool_cmd = salt.utils.path.which('zpool')
-    for zpool in __salt__['cmd.run']('{zpool} list -H -p -o name,size'.format(zpool=zpool_cmd)).splitlines():
+    zpool_list_cmd = __utils__['zfs.zpool_command'](
+        'list',
+        flags=['-H', '-p'],
+        opts={'-o': 'name,size'},
+    )
+    for zpool in __salt__['cmd.run'](zpool_list_cmd).splitlines():
         if 'zpool' not in grains:
             grains['zpool'] = {}
         zpool = zpool.split()
-        grains['zpool'][zpool[0]] = _conform_value(zpool[1], True)
+        grains['zpool'][zpool[0]] = __utils__['zfs.to_auto'](zpool[1], True)
 
     # return grain data
     return grains
@@ -110,10 +75,10 @@ def zfs():
     Provide grains for zfs/zpool
     '''
     grains = {}
-
-    grains = salt.utils.dictupdate.update(grains, _zfs_support(), merge_lists=True)
+    grains['zfs_support'] = __utils__['zfs.is_supported']()
+    grains['zfs_feature_flags'] = __utils__['zfs.has_feature_flags']()
     if grains['zfs_support']:
-        grains = salt.utils.dictupdate.update(grains, _zfs_pool_data(), merge_lists=True)
+        grains = dictupdate.update(grains, _zfs_pool_data(), merge_lists=True)
 
     return grains
 

--- a/salt/grains/zfs.py
+++ b/salt/grains/zfs.py
@@ -16,7 +16,7 @@ from __future__ import absolute_import, print_function, unicode_literals
 import logging
 
 # Import salt libs
-import salt.utils.dictupdate as dictupdate
+import salt.utils.dictupdate
 import salt.utils.path
 import salt.utils.platform
 
@@ -33,7 +33,7 @@ __utils__ = {
     'zfs.is_supported': salt.utils.zfs.is_supported,
     'zfs.has_feature_flags': salt.utils.zfs.has_feature_flags,
     'zfs.zpool_command': salt.utils.zfs.zpool_command,
-    'zfs.to_auto': salt.utils.zfs.to_auto,
+    'zfs.to_size': salt.utils.zfs.to_size,
 }
 
 log = logging.getLogger(__name__)
@@ -64,7 +64,7 @@ def _zfs_pool_data():
         if 'zpool' not in grains:
             grains['zpool'] = {}
         zpool = zpool.split()
-        grains['zpool'][zpool[0]] = __utils__['zfs.to_auto'](zpool[1], True)
+        grains['zpool'][zpool[0]] = __utils__['zfs.to_size'](zpool[1], True)
 
     # return grain data
     return grains
@@ -78,7 +78,7 @@ def zfs():
     grains['zfs_support'] = __utils__['zfs.is_supported']()
     grains['zfs_feature_flags'] = __utils__['zfs.has_feature_flags']()
     if grains['zfs_support']:
-        grains = dictupdate.update(grains, _zfs_pool_data(), merge_lists=True)
+        grains = salt.utils.dictupdate.update(grains, _zfs_pool_data(), merge_lists=True)
 
     return grains
 

--- a/salt/modules/zfs.py
+++ b/salt/modules/zfs.py
@@ -1,31 +1,28 @@
 # -*- coding: utf-8 -*-
 '''
-Salt interface to ZFS commands
+Module for running ZFS command
 
-:codeauthor: Nitin Madhok <nmadhok@clemson.edu>
+:codeauthor:    Nitin Madhok <nmadhok@clemson.edu>, Jorge Schrauwen <sjorge@blackdot.be>
+:maintainer:    Jorge Schrauwen <sjorge@blackdot.be>
+:maturity:      new
+:depends:       salt.utils.zfs
+:platform:      illumos,freebsd,linux
 
 '''
 from __future__ import absolute_import, unicode_literals, print_function
 
 # Import Python libs
-import re
-import math
 import logging
 
 # Import Salt libs
 import salt.utils.args
 import salt.utils.path
 import salt.modules.cmdmod
-import salt.utils.decorators as decorators
 from salt.utils.odict import OrderedDict
-from salt.utils.stringutils import to_num as str_to_num
-from salt.ext import six
+from salt.ext.six.moves import zip
 
 __virtualname__ = 'zfs'
 log = logging.getLogger(__name__)
-
-# Precompiled regex
-re_zfs_size = re.compile(r'^(\d+|\d+(?=\d*)\.\d+)([KkMmGgTtPpEeZz][Bb]?)$')
 
 # Function alias to set mapping.
 __func_alias__ = {
@@ -43,77 +40,8 @@ def __virtual__():
         return (False, "The zfs module cannot be loaded: zfs not supported")
 
 
-@decorators.memoize
-def _check_zfs():
-    '''
-    Looks to see if zfs is present on the system.
-    '''
-    # Get the path to the zfs binary.
-    return salt.utils.path.which('zfs')
-
-
-@decorators.memoize
-def _check_features():
-    '''
-    Looks to see if zpool-features is available
-    '''
-    # get man location
-    man = salt.utils.path.which('man')
-    if not man:
-        return False
-
-    cmd = '{man} zpool-features'.format(
-        man=man
-    )
-    res = __salt__['cmd.run_all'](cmd, python_shell=False)
-    return res['retcode'] == 0
-
-
-def _conform_value(value, convert_size=False):
-    '''
-    Ensure value always conform to what zfs expects
-    '''
-    # NOTE: salt breaks the on/off/yes/no properties
-    if isinstance(value, bool):
-        return 'on' if value else 'off'
-
-    if isinstance(value, six.text_type) or isinstance(value, str):
-        # NOTE: handle whitespaces
-        if ' ' in value:
-            # NOTE: quoting the string may be better
-            #       but it is hard to know if we already quoted it before
-            #       this can be improved in the future
-            return "'{0}'".format(value.strip("'"))
-
-        # NOTE: handle ZFS size conversion
-        match_size = re_zfs_size.match(value)
-        if convert_size and match_size:
-            v_size = float(match_size.group(1))
-            v_unit = match_size.group(2).upper()[0]
-            v_power = math.pow(1024, ['K', 'M', 'G', 'T', 'P', 'E', 'Z'].index(v_unit) + 1)
-            value = v_size * v_power
-            return int(value) if int(value) == value else value
-
-        # NOTE: convert to numeric if needed
-        return str_to_num(value)
-
-    # NOTE: passthrough
-    return value
-
-
-def _zfs_quote_escape_path(name):
-    '''
-    Quotes zfs path with single quotes and escapes single quotes in path if present
-    '''
-    if name:
-        name = '\'' + name.replace('\'', '\\\'') + '\''
-    return name
-
-
 def exists(name, **kwargs):
     '''
-    .. versionadded:: 2015.5.0
-
     Check if a ZFS filesystem or volume or snapshot exists.
 
     name : string
@@ -122,6 +50,9 @@ def exists(name, **kwargs):
         also check if dataset is of a certain type, valid choices are:
         filesystem, snapshot, volume, bookmark, or all.
 
+    .. versionadded:: 2015.5.0
+    .. versionchanged:: Fluorine
+
     CLI Example:
 
     .. code-block:: bash
@@ -129,20 +60,30 @@ def exists(name, **kwargs):
         salt '*' zfs.exists myzpool/mydataset
         salt '*' zfs.exists myzpool/myvolume type=volume
     '''
-    zfs = _check_zfs()
-    ltype = kwargs.get('type', None)
+    ## Configure command
+    # NOTE: initialize the defaults
+    opts = {}
 
-    cmd = '{0} list {1}{2}'.format(zfs, '-t {0} '.format(ltype) if ltype else '', _zfs_quote_escape_path(name))
-    res = __salt__['cmd.run_all'](cmd, ignore_retcode=True)
+    # NOTE: set extra config from kwargs
+    if kwargs.get('type', False):
+        opts['-t'] = kwargs.get('type')
+
+    ## Check if 'name' of 'type' exists
+    res = __salt__['cmd.run_all'](
+        __utils__['zfs.zfs_command'](
+            command='list',
+            opts=opts,
+            target=name,
+        ),
+        python_shell=False,
+        ignore_retcode=True,
+    )
 
     return res['retcode'] == 0
 
 
 def create(name, **kwargs):
     '''
-    .. versionadded:: 2015.5.0
-    .. versionchanged:: 2016.3.0
-
     Create a ZFS File System.
 
     name : string
@@ -165,6 +106,9 @@ def create(name, **kwargs):
 
             properties="{'property1': 'value1', 'property2': 'value2'}"
 
+    .. versionadded:: 2015.5.0
+    .. versionchanged:: Fluorine
+
     CLI Example:
 
     .. code-block:: bash
@@ -175,53 +119,39 @@ def create(name, **kwargs):
         salt '*' zfs.create myzpool/volume volume_size=1G properties="{'volblocksize': '512'}" [sparse=True|False]
 
     '''
-    ret = {}
+    ## Configure command
+    # NOTE: initialize the defaults
+    flags = []
+    opts = {}
 
-    zfs = _check_zfs()
-    properties = kwargs.get('properties', None)
-    if properties and 'mountpoint' in properties:
-        properties['mountpoint'] = _zfs_quote_escape_path(properties['mountpoint'])
-    create_parent = kwargs.get('create_parent', False)
-    volume_size = kwargs.get('volume_size', None)
-    sparse = kwargs.get('sparse', False)
-    cmd = '{0} create'.format(zfs)
+    # NOTE: push filesystem properties
+    filesystem_properties = kwargs.get('properties', {})
 
-    if create_parent:
-        cmd = '{0} -p'.format(cmd)
+    # NOTE: set extra config from kwargs
+    if kwargs.get('create_parent', False):
+        flags.append('-p')
+    if kwargs.get('sparse', False) and kwargs.get('volume_size', None):
+        flags.append('-s')
+    if kwargs.get('volume_size', None):
+        opts['-V'] = __utils__['zfs.to_size'](kwargs.get('volume_size'), convert_to_human=False)
 
-    if volume_size and sparse:
-        cmd = '{0} -s'.format(cmd)
+    ## Create filesystem/volume
+    res = __salt__['cmd.run_all'](
+        __utils__['zfs.zfs_command'](
+            command='create',
+            flags=flags,
+            opts=opts,
+            filesystem_properties=filesystem_properties,
+            target=name,
+        ),
+        python_shell=False,
+    )
 
-    # if zpool properties specified, then
-    # create "-o property=value" pairs
-    if properties:
-        proplist = []
-        for prop in properties:
-            proplist.append('-o {0}={1}'.format(prop, _conform_value(properties[prop])))
-        cmd = '{0} {1}'.format(cmd, ' '.join(proplist))
-
-    if volume_size:
-        cmd = '{0} -V {1}'.format(cmd, volume_size)
-
-    # append name
-    cmd = '{0} {1}'.format(cmd, _zfs_quote_escape_path(name))
-
-    # Create filesystem
-    res = __salt__['cmd.run_all'](cmd)
-
-    # Check and see if the dataset is available
-    if res['retcode'] != 0:
-        ret[name] = res['stderr'] if 'stderr' in res else res['stdout']
-    else:
-        ret[name] = 'created'
-
-    return ret
+    return __utils__['zfs.parse_command_result'](res, 'created')
 
 
 def destroy(name, **kwargs):
     '''
-    .. versionadded:: 2015.5.0
-
     Destroy a ZFS File System.
 
     name : string
@@ -237,49 +167,42 @@ def destroy(name, **kwargs):
     .. warning::
         watch out when using recursive and recursive_all
 
+    .. versionadded:: 2015.5.0
+    .. versionchanged:: Fluorine
+
     CLI Example:
 
     .. code-block:: bash
 
         salt '*' zfs.destroy myzpool/mydataset [force=True|False]
     '''
-    ret = {}
-    zfs = _check_zfs()
-    force = kwargs.get('force', False)
-    recursive = kwargs.get('recursive', False)
-    recursive_all = kwargs.get('recursive_all', False)
-    cmd = '{0} destroy'.format(zfs)
+    ## Configure command
+    # NOTE: initialize the defaults
+    flags = []
 
-    if recursive_all:
-        cmd = '{0} -R'.format(cmd)
+    # NOTE: set extra config from kwargs
+    if kwargs.get('force', False):
+        flags.append('-f')
+    if kwargs.get('recursive_all', False):
+        flags.append('-R')
+    if kwargs.get('recursive', False):
+        flags.append('-r')
 
-    if force:
-        cmd = '{0} -f'.format(cmd)
+    ## Destroy filesystem/volume/snapshot/...
+    res = __salt__['cmd.run_all'](
+        __utils__['zfs.zfs_command'](
+            command='destroy',
+            flags=flags,
+            target=name,
+        ),
+        python_shell=False,
+    )
 
-    if recursive:
-        cmd = '{0} -r'.format(cmd)
-
-    cmd = '{0} {1}'.format(cmd, _zfs_quote_escape_path(name))
-    res = __salt__['cmd.run_all'](cmd)
-
-    if res['retcode'] != 0:
-        if "operation does not apply to pools" in res['stderr']:
-            ret[name] = '{0}, use zpool.destroy to destroy the pool'.format(res['stderr'].splitlines()[0])
-        if "has children" in res['stderr']:
-            ret[name] = '{0}, you can add the "recursive=True" parameter'.format(res['stderr'].splitlines()[0])
-        else:
-            ret[name] = res['stderr'] if 'stderr' in res else res['stdout']
-    else:
-        ret[name] = 'destroyed'
-
-    return ret
+    return __utils__['zfs.parse_command_result'](res, 'destroyed')
 
 
 def rename(name, new_name, **kwargs):
     '''
-    .. versionadded:: 2015.5.0
-    .. versionchanged:: 2016.3.0
-
     Rename or Relocate a ZFS File System.
 
     name : string
@@ -296,50 +219,55 @@ def rename(name, new_name, **kwargs):
         recursively rename the snapshots of all descendent datasets.
         snapshots are the only dataset that can be renamed recursively.
 
+    .. versionadded:: 2015.5.0
+    .. versionchanged:: Fluorine
+
     CLI Example:
 
     .. code-block:: bash
 
         salt '*' zfs.rename myzpool/mydataset myzpool/renameddataset
     '''
-    ret = {}
-    zfs = _check_zfs()
-    create_parent = kwargs.get('create_parent', False)
-    force = kwargs.get('force', False)
-    recursive = kwargs.get('recursive', False)
+    ## Configure command
+    # NOTE: initialize the defaults
+    flags = []
+    target = []
 
-    # fix up conflicting parameters
-    if recursive:
-        if '@' in name:  # -p and -f don't work with -r
-            create_parent = False
-            force = False
-        else:  # -r only works with snapshots
-            recursive = False
-    if create_parent and '@' in name:  # doesn't work with snapshots
-        create_parent = False
-
-    res = __salt__['cmd.run_all']('{zfs} rename {force}{create_parent}{recursive}{name} {new_name}'.format(
-        zfs=zfs,
-        force='-f ' if force else '',
-        create_parent='-p ' if create_parent else '',
-        recursive='-r ' if recursive else '',
-        name=_zfs_quote_escape_path(name),
-        new_name=_zfs_quote_escape_path(new_name)
-    ))
-
-    if res['retcode'] != 0:
-        ret[name] = res['stderr'] if 'stderr' in res else res['stdout']
+    # NOTE: set extra config from kwargs
+    if __utils__['zfs.is_snapshot'](name):
+        if kwargs.get('create_parent', False):
+            log.warning('zfs.rename - create_parent=True cannot be used with snapshots.')
+        if kwargs.get('force', False):
+            log.warning('zfs.rename - force=True cannot be used with snapshots.')
+        if kwargs.get('recursive', False):
+            flags.append('-r')
     else:
-        ret[name] = 'renamed to {0}'.format(new_name)
+        if kwargs.get('create_parent', False):
+            flags.append('-p')
+        if kwargs.get('force', False):
+            flags.append('-f')
+        if kwargs.get('recursive', False):
+            log.warning('zfs.rename - recursive=True can only be used with snapshots.')
 
-    return ret
+    # NOTE: update target
+    target.append(name)
+    target.append(new_name)
+
+    ## Rename filesystem/volume/snapshot/...
+    res = __salt__['cmd.run_all'](
+        __utils__['zfs.zfs_command'](
+            command='rename',
+            flags=flags,
+            target=target,
+        ),
+        python_shell=False,
+    )
+
+    return __utils__['zfs.parse_command_result'](res, 'renamed')
 
 
 def list_(name=None, **kwargs):
     '''
-    .. versionadded:: 2015.5.0
-    .. versionchanged:: Oxygen
-
     Return a list of all datasets or a specified dataset on the system and the
     values of their used, available, referenced, and mountpoint properties.
 
@@ -362,6 +290,9 @@ def list_(name=None, **kwargs):
         display numbers in parsable (exact) values
         .. versionadded:: Oxygen
 
+    .. versionadded:: 2015.5.0
+    .. versionchanged:: Fluorine
+
     CLI Example:
 
     .. code-block:: bash
@@ -371,79 +302,119 @@ def list_(name=None, **kwargs):
         salt '*' zfs.list myzpool/mydataset properties="sharenfs,mountpoint"
     '''
     ret = OrderedDict()
-    zfs = _check_zfs()
-    recursive = kwargs.get('recursive', False)
-    depth = kwargs.get('depth', 0)
+
+    ## update properties
+    # NOTE: properties should be a list
     properties = kwargs.get('properties', 'used,avail,refer,mountpoint')
-    sort = kwargs.get('sort', None)
-    ltype = kwargs.get('type', None)
-    order = kwargs.get('order', 'ascending')
-    parsable = kwargs.get('parsable', False)
-    cmd = '{0} list -H'.format(zfs)
+    if not isinstance(properties, list):
+        properties = properties.split(',')
 
-    # parsable output
-    if parsable:
-        cmd = '{0} -p'.format(cmd)
-
-    # filter on type
-    if ltype:
-        cmd = '{0} -t {1}'.format(cmd, ltype)
-
-    # recursively list
-    if recursive:
-        cmd = '{0} -r'.format(cmd)
-        if depth:
-            cmd = '{0} -d {1}'.format(cmd, depth)
-
-    # add properties
-    properties = properties.split(',')
-    if 'name' in properties:  # ensure name is first property
+    # NOTE: name should be first property
+    while 'name' in properties:
         properties.remove('name')
     properties.insert(0, 'name')
-    cmd = '{0} -o {1}'.format(cmd, ','.join(properties))
 
-    # sorting
-    if sort and sort in properties:
-        if order.startswith('a'):
-            cmd = '{0} -s {1}'.format(cmd, sort)
+    ## Configure command
+    # NOTE: initialize the defaults
+    flags = ['-H', '-p']
+    opts = {}
+
+    # NOTE: set extra config from kwargs
+    if kwargs.get('recursive', False):
+        flags.append('-r')
+    if kwargs.get('recursive', False) and kwargs.get('depth', False):
+        opts['-d'] = kwargs.get('depth')
+    if kwargs.get('type', False):
+        opts['-t'] = kwargs.get('type')
+    if kwargs.get('sort', False) and kwargs.get('sort') in properties:
+        if kwargs.get('order', 'ascending').startswith('a'):
+            opts['-s'] = kwargs.get('sort')
         else:
-            cmd = '{0} -S {1}'.format(cmd, sort)
+            opts['-S'] = kwargs.get('sort')
+    if isinstance(properties, list):
+        # NOTE: There can be only one -o and it takes a comma-seperated list
+        opts['-o'] = ','.join(properties)
+    else:
+        opts['-o'] = properties
 
-    # add name if set
-    if name:
-        cmd = '{0} {1}'.format(cmd, _zfs_quote_escape_path(name))
-
-    # parse output
-    res = __salt__['cmd.run_all'](cmd)
+    ## parse zfs list
+    res = __salt__['cmd.run_all'](
+        __utils__['zfs.zfs_command'](
+            command='list',
+            flags=flags,
+            opts=opts,
+            target=name,
+        ),
+        python_shell=False,
+    )
     if res['retcode'] == 0:
-        for ds in [l for l in res['stdout'].splitlines()]:
-            ds = ds.split("\t")
-            ds_data = {}
-
-            for prop in properties:
-                ds_data[prop] = _conform_value(ds[properties.index(prop)])
+        for ds in res['stdout'].splitlines():
+            if kwargs.get('parsable', True):
+                ds_data = __utils__['zfs.from_auto_dict'](
+                    OrderedDict(list(zip(properties, ds.split("\t")))),
+                )
+            else:
+                ds_data = __utils__['zfs.to_auto_dict'](
+                    OrderedDict(list(zip(properties, ds.split("\t")))),
+                    convert_to_human=True,
+                )
 
             ret[ds_data['name']] = ds_data
             del ret[ds_data['name']]['name']
     else:
-        ret['error'] = res['stderr'] if 'stderr' in res else res['stdout']
+        return __utils__['zfs.parse_command_result'](res)
 
     return ret
 
 
-def mount(name='-a', **kwargs):
+def list_mount():
     '''
-    .. versionadded:: 2016.3.0
+    List mounted zfs filesystems
 
+    .. versionadded:: Fluorine
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' zfs.list_mount
+    '''
+    ## List mounted filesystem
+    res = __salt__['cmd.run_all'](
+        __utils__['zfs.zfs_command'](
+            command='mount',
+        ),
+        python_shell=False,
+    )
+
+    if res['retcode'] == 0:
+        ret = OrderedDict()
+        for mount in res['stdout'].splitlines():
+            mount = mount.split()
+            ret[mount[0]] = mount[-1]
+        return ret
+    else:
+        return __utils__['zfs.parse_command_result'](res)
+
+
+def mount(name=None, **kwargs):
+    '''
     Mounts ZFS file systems
 
     name : string
-        name of the filesystem, you can use '-a' to mount all unmounted filesystems. (this is the default)
+        name of the filesystem, having this set to None will mount all filesystems. (this is the default)
     overlay : boolean
         perform an overlay mount.
     options : string
         optional comma-separated list of mount options to use temporarily for
         the duration of the mount.
+
+    .. versionadded:: 2016.3.0
+    .. versionchanged:: Fluorine
+
+    .. warning::
+
+            Passing '-a' as name is deprecated and will be removed 2 verions after Flourine.
 
     CLI Example:
 
@@ -453,36 +424,43 @@ def mount(name='-a', **kwargs):
         salt '*' zfs.mount myzpool/mydataset
         salt '*' zfs.mount myzpool/mydataset options=ro
     '''
-    zfs = _check_zfs()
-    overlay = kwargs.get('overlay', False)
-    options = kwargs.get('options', None)
+    ## Configure command
+    # NOTE: initialize the defaults
+    flags = []
+    opts = {}
 
-    res = __salt__['cmd.run_all']('{zfs} mount {overlay}{options}{filesystem}'.format(
-        zfs=zfs,
-        overlay='-O ' if overlay else '',
-        options='-o {0} '.format(options) if options else '',
-        filesystem=_zfs_quote_escape_path(name)
-    ))
+    # NOTE: set extra config from kwargs
+    if kwargs.get('overlay', False):
+        flags.append('-O')
+    if kwargs.get('options', False):
+        opts['-o'] = kwargs.get('options')
+    if name in [None, '-a']:
+        # NOTE: still accept '-a' as name for backwards compatibility
+        #       two versions after Flourine this should just simplify
+        #       this to just set '-a' if name is not set.
+        flags.append('-a')
+        name = None
 
-    ret = {}
-    if name == '-a':
-        ret = res['retcode'] == 0
-    else:
-        if res['retcode'] != 0:
-            ret[name] = res['stderr'] if 'stderr' in res else res['stdout']
-        else:
-            ret[name] = 'mounted'
-    return ret
+    ## Mount filesystem
+    res = __salt__['cmd.run_all'](
+        __utils__['zfs.zfs_command'](
+            command='mount',
+            flags=flags,
+            opts=opts,
+            target=name,
+        ),
+        python_shell=False,
+    )
+
+    return __utils__['zfs.parse_command_result'](res, 'mounted')
 
 
 def unmount(name, **kwargs):
     '''
-    .. versionadded:: 2016.3.0
-
     Unmounts ZFS file systems
 
     name : string
-        name of the filesystem, you can use '-a' to unmount all mounted filesystems.
+        name of the filesystem, you can use None to unmount all mounted filesystems.
     force : boolean
         forcefully unmount the file system, even if it is currently in use.
 
@@ -490,36 +468,48 @@ def unmount(name, **kwargs):
 
         Using ``-a`` for the name parameter will probably break your system, unless your rootfs is not on zfs.
 
+    .. versionadded:: 2016.3.0
+    .. versionchanged:: Fluorine
+
+    .. warning::
+
+            Passing '-a' as name is deprecated and will be removed 2 verions after Flourine.
+
     CLI Example:
 
     .. code-block:: bash
 
         salt '*' zfs.unmount myzpool/mydataset [force=True|False]
     '''
-    zfs = _check_zfs()
-    force = kwargs.get('force', False)
+    ## Configure command
+    # NOTE: initialize the defaults
+    flags = []
 
-    res = __salt__['cmd.run_all']('{zfs} unmount {force}{filesystem}'.format(
-        zfs=zfs,
-        force='-f ' if force else '',
-        filesystem=_zfs_quote_escape_path(name)
-    ))
+    # NOTE: set extra config from kwargs
+    if kwargs.get('force', False):
+        flags.append('-f')
+    if name in [None, '-a']:
+        # NOTE: still accept '-a' as name for backwards compatibility
+        #       two versions after Flourine this should just simplify
+        #       this to just set '-a' if name is not set.
+        flags.append('-a')
+        name = None
 
-    ret = {}
-    if name == '-a':
-        ret = res['retcode'] == 0
-    else:
-        if res['retcode'] != 0:
-            ret[name] = res['stderr'] if 'stderr' in res else res['stdout']
-        else:
-            ret[name] = 'unmounted'
-    return ret
+    ## Unmount filesystem
+    res = __salt__['cmd.run_all'](
+        __utils__['zfs.zfs_command'](
+            command='unmount',
+            flags=flags,
+            target=name,
+        ),
+        python_shell=False,
+    )
+
+    return __utils__['zfs.parse_command_result'](res, 'unmounted')
 
 
 def inherit(prop, name, **kwargs):
     '''
-    .. versionadded:: 2016.3.0
-
     Clears the specified property
 
     prop : string
@@ -532,42 +522,41 @@ def inherit(prop, name, **kwargs):
         revert the property to the received value if one exists; otherwise
         operate as if the -S option was not specified.
 
+    .. versionadded:: 2016.3.0
+    .. versionchanged:: Fluorine
+
     CLI Example:
 
     .. code-block:: bash
 
         salt '*' zfs.inherit canmount myzpool/mydataset [recursive=True|False]
     '''
-    zfs = _check_zfs()
-    recursive = kwargs.get('recursive', False)
-    revert = kwargs.get('revert', False)
+    ## Configure command
+    # NOTE: initialize the defaults
+    flags = []
 
-    res = __salt__['cmd.run_all']('{zfs} inherit {recursive}{revert}{prop} {name}'.format(
-        zfs=zfs,
-        recursive='-r ' if recursive else '',
-        revert='-S ' if revert else '',
-        prop=prop,
-        name=_zfs_quote_escape_path(name)
-    ))
+    # NOTE: set extra config from kwargs
+    if kwargs.get('recursive', False):
+        flags.append('-r')
+    if kwargs.get('revert', False):
+        flags.append('-S')
 
-    ret = {}
-    ret[name] = {}
-    if res['retcode'] != 0:
-        ret[name][prop] = res['stderr'] if 'stderr' in res else res['stdout']
-        if 'property cannot be inherited' in res['stderr']:
-            ret[name][prop] = '{0}, {1}'.format(
-                ret[name][prop],
-                'use revert=True to try and reset it to it\'s default value.'
-            )
-    else:
-        ret[name][prop] = 'cleared'
-    return ret
+    ## Inherit property
+    res = __salt__['cmd.run_all'](
+        __utils__['zfs.zfs_command'](
+            command='inherit',
+            flags=flags,
+            property_name=prop,
+            target=name,
+        ),
+        python_shell=False,
+    )
+
+    return __utils__['zfs.parse_command_result'](res, 'inherited')
 
 
-def diff(name_a, name_b, **kwargs):
+def diff(name_a, name_b=None, **kwargs):
     '''
-    .. versionadded:: 2016.3.0
-
     Display the difference between a snapshot of a given filesystem and
     another snapshot of that filesystem from a later time or the current
     contents of the filesystem.
@@ -575,11 +564,16 @@ def diff(name_a, name_b, **kwargs):
     name_a : string
         name of snapshot
     name_b : string
-        name of snapshot or filesystem
+        (optional) name of snapshot or filesystem
     show_changetime : boolean
-        display the path's inode change time as the first column of output. (default = False)
+        display the path's inode change time as the first column of output. (default = True)
     show_indication : boolean
         display an indication of the type of file. (default = True)
+    parsable : boolean
+        if true we don't parse the timestamp to a more readable date (default = True)
+
+    .. versionadded:: 2016.3.0
+    .. versionchanged:: Fluorine
 
     CLI Example:
 
@@ -587,48 +581,50 @@ def diff(name_a, name_b, **kwargs):
 
         salt '*' zfs.diff myzpool/mydataset@yesterday myzpool/mydataset
     '''
-    ret = {}
+    ## Configure command
+    # NOTE: initialize the defaults
+    flags = ['-H']
+    target = []
 
-    zfs = _check_zfs()
-    show_changetime = kwargs.get('show_changetime', False)
-    show_indication = kwargs.get('show_indication', True)
+    # NOTE: set extra config from kwargs
+    if kwargs.get('show_changetime', True):
+        flags.append('-t')
+    if kwargs.get('show_indication', True):
+        flags.append('-F')
 
-    if '@' not in name_a:
-        ret[name_a] = 'MUST be a snapshot'
-        return ret
+    # NOTE: update target
+    target.append(name_a)
+    if name_b:
+        target.append(name_b)
 
-    res = __salt__['cmd.run_all']('{zfs} diff -H {changetime}{indication}{name_a} {name_b}'.format(
-        zfs=zfs,
-        changetime='-t ' if show_changetime else '',
-        indication='-F ' if show_indication else '',
-        name_a=_zfs_quote_escape_path(name_a),
-        name_b=_zfs_quote_escape_path(name_b)
-    ))
+    ## Diff filesystem/snapshot
+    res = __salt__['cmd.run_all'](
+        __utils__['zfs.zfs_command'](
+            command='diff',
+            flags=flags,
+            target=target,
+        ),
+        python_shell=False,
+    )
 
     if res['retcode'] != 0:
-        ret['error'] = res['stderr'] if 'stderr' in res else res['stdout']
+        return __utils__['zfs.parse_command_result'](res)
     else:
-        ret = []
-        for line in res['stdout'].splitlines():
-            ret.append(line)
-    return ret
+        if not kwargs.get('parsable', True) and kwargs.get('show_changetime', True):
+            ret = OrderedDict()
+            for entry in res['stdout'].splitlines():
+                entry = entry.split()
+                entry_timestamp = __utils__['dateutils.strftime'](entry[0], '%Y-%m-%d.%H:%M:%S.%f')
+                entry_data = "\t\t".join(entry[1:])
+                ret[entry_timestamp] = entry_data
+        else:
+            ret = res['stdout'].splitlines()
+        return ret
 
 
 def rollback(name, **kwargs):
     '''
-    .. versionadded:: 2016.3.0
-
     Roll back the given dataset to a previous snapshot.
-
-    .. warning::
-
-        When a dataset is rolled back, all data that has changed since
-        the snapshot is discarded, and the dataset reverts to the state
-        at the time of the snapshot. By default, the command refuses to
-        roll back to a snapshot other than the most recent one.
-
-        In order to do so, all intermediate snapshots and bookmarks
-        must be destroyed by specifying the -r option.
 
     name : string
         name of snapshot
@@ -642,47 +638,55 @@ def rollback(name, **kwargs):
         used with the -R option to force an unmount of any clone file
         systems that are to be destroyed.
 
+    .. warning::
+
+        When a dataset is rolled back, all data that has changed since
+        the snapshot is discarded, and the dataset reverts to the state
+        at the time of the snapshot. By default, the command refuses to
+        roll back to a snapshot other than the most recent one.
+
+        In order to do so, all intermediate snapshots and bookmarks
+        must be destroyed by specifying the -r option.
+
+    .. versionadded:: 2016.3.0
+    .. versionchanged:: Fluorine
+
     CLI Example:
 
     .. code-block:: bash
 
         salt '*' zfs.rollback myzpool/mydataset@yesterday
     '''
-    ret = {}
+    ## Configure command
+    # NOTE: initialize the defaults
+    flags = []
 
-    zfs = _check_zfs()
-    force = kwargs.get('force', False)
-    recursive = kwargs.get('recursive', False)
-    recursive_all = kwargs.get('recursive_all', False)
+    # NOTE: set extra config from kwargs
+    if kwargs.get('recursive_all', False):
+        flags.append('-R')
+    if kwargs.get('recursive', False):
+        flags.append('-r')
+    if kwargs.get('force', False):
+        if kwargs.get('recursive_all', False) or kwargs.get('recursive', False):
+            flags.append('-f')
+        else:
+            log.warning('zfs.rollback - force=True can only be used with recursive_all=True or recursive=True')
 
-    if '@' not in name:
-        ret[name] = 'MUST be a snapshot'
-        return ret
+    ## Rollback to snapshot
+    res = __salt__['cmd.run_all'](
+        __utils__['zfs.zfs_command'](
+            command='rollback',
+            flags=flags,
+            target=name,
+        ),
+        python_shell=False,
+    )
 
-    if force:
-        if not recursive and not recursive_all:  # -f only works with -R
-            log.warning('zfs.rollback - force=True can only be used when recursive_all=True or recursive=True')
-            force = False
-
-    res = __salt__['cmd.run_all']('{zfs} rollback {force}{recursive}{recursive_all}{snapshot}'.format(
-        zfs=zfs,
-        force='-f ' if force else '',
-        recursive='-r ' if recursive else '',
-        recursive_all='-R ' if recursive_all else '',
-        snapshot=_zfs_quote_escape_path(name)
-    ))
-
-    if res['retcode'] != 0:
-        ret[name[:name.index('@')]] = res['stderr'] if 'stderr' in res else res['stdout']
-    else:
-        ret[name[:name.index('@')]] = 'rolledback to snapshot: {0}'.format(name[name.index('@')+1:])
-    return ret
+    return __utils__['zfs.parse_command_result'](res, 'rolledback')
 
 
 def clone(name_a, name_b, **kwargs):
     '''
-    .. versionadded:: 2016.3.0
-
     Creates a clone of the given snapshot.
 
     name_a : string
@@ -703,49 +707,47 @@ def clone(name_a, name_b, **kwargs):
 
             properties="{'property1': 'value1', 'property2': 'value2'}"
 
+    .. versionadded:: 2016.3.0
+    .. versionchanged:: Fluorine
+
     CLI Example:
 
     .. code-block:: bash
 
         salt '*' zfs.clone myzpool/mydataset@yesterday myzpool/mydataset_yesterday
     '''
-    ret = {}
+    ## Configure command
+    # NOTE: initialize the defaults
+    flags = []
+    target = []
 
-    zfs = _check_zfs()
-    create_parent = kwargs.get('create_parent', False)
-    properties = kwargs.get('properties', None)
+    # NOTE: push filesystem properties
+    filesystem_properties = kwargs.get('properties', {})
 
-    if '@' not in name_a:
-        ret[name_b] = 'failed to clone from {0} because it is not a snapshot'.format(name_a)
-        return ret
+    # NOTE: set extra config from kwargs
+    if kwargs.get('create_parent', False):
+        flags.append('-p')
 
-    # if zpool properties specified, then
-    # create "-o property=value" pairs
-    if properties:
-        proplist = []
-        for prop in properties:
-            proplist.append('-o {0}={1}'.format(prop, properties[prop]))
-        properties = ' '.join(proplist)
+    # NOTE: update target
+    target.append(name_a)
+    target.append(name_b)
 
-    res = __salt__['cmd.run_all']('{zfs} clone {create_parent}{properties}{name_a} {name_b}'.format(
-        zfs=zfs,
-        create_parent='-p ' if create_parent else '',
-        properties='{0} '.format(properties) if properties else '',
-        name_a=_zfs_quote_escape_path(name_a),
-        name_b=_zfs_quote_escape_path(name_b)
-    ))
+    ## Clone filesystem/volume
+    res = __salt__['cmd.run_all'](
+        __utils__['zfs.zfs_command'](
+            command='clone',
+            flags=flags,
+            filesystem_properties=filesystem_properties,
+            target=target,
+        ),
+        python_shell=False,
+    )
 
-    if res['retcode'] != 0:
-        ret[name_b] = res['stderr'] if 'stderr' in res else res['stdout']
-    else:
-        ret[name_b] = 'cloned from {0}'.format(name_a)
-    return ret
+    return __utils__['zfs.parse_command_result'](res, 'cloned')
 
 
 def promote(name):
     '''
-    .. versionadded:: 2016.3.0
-
     Promotes a clone file system to no longer be dependent on its "origin"
     snapshot.
 
@@ -767,32 +769,28 @@ def promote(name):
     name : string
         name of clone-filesystem
 
+    .. versionadded:: 2016.3.0
+
     CLI Example:
 
     .. code-block:: bash
 
         salt '*' zfs.promote myzpool/myclone
     '''
-    ret = {}
+    ## Promote clone
+    res = __salt__['cmd.run_all'](
+        __utils__['zfs.zfs_command'](
+            command='promote',
+            target=name,
+        ),
+        python_shell=False,
+    )
 
-    zfs = _check_zfs()
-
-    res = __salt__['cmd.run_all']('{zfs} promote {name}'.format(
-        zfs=zfs,
-        name=_zfs_quote_escape_path(name)
-    ))
-
-    if res['retcode'] != 0:
-        ret[name] = res['stderr'] if 'stderr' in res else res['stdout']
-    else:
-        ret[name] = 'promoted'
-    return ret
+    return __utils__['zfs.parse_command_result'](res, 'promoted')
 
 
 def bookmark(snapshot, bookmark):
     '''
-    .. versionadded:: 2016.3.0
-
     Creates a bookmark of the given snapshot
 
     .. note::
@@ -808,47 +806,40 @@ def bookmark(snapshot, bookmark):
     bookmark : string
         name of bookmark
 
+    .. versionadded:: 2016.3.0
+
     CLI Example:
 
     .. code-block:: bash
 
         salt '*' zfs.bookmark myzpool/mydataset@yesterday myzpool/mydataset#complete
     '''
-    ret = {}
-
     # abort if we do not have feature flags
-    if not _check_features():
-        ret['error'] = 'bookmarks are not supported'
-        return ret
+    if not __utils__['zfs.has_feature_flags']():
+        return OrderedDict([('error', 'bookmarks are not supported')])
 
-    zfs = _check_zfs()
+    ## Configure command
+    # NOTE: initialize the defaults
+    target = []
 
-    if '@' not in snapshot:
-        ret[snapshot] = 'MUST be a snapshot'
+    # NOTE: update target
+    target.append(snapshot)
+    target.append(bookmark)
 
-    if '#' not in bookmark:
-        ret[bookmark] = 'MUST be a bookmark'
+    ## Bookmark snapshot
+    res = __salt__['cmd.run_all'](
+        __utils__['zfs.zfs_command'](
+            command='bookmark',
+            target=target,
+        ),
+        python_shell=False,
+    )
 
-    if len(ret) > 0:
-        return ret
-
-    res = __salt__['cmd.run_all']('{zfs} bookmark {snapshot} {bookmark}'.format(
-        zfs=zfs,
-        snapshot=_zfs_quote_escape_path(snapshot),
-        bookmark=_zfs_quote_escape_path(bookmark)
-    ))
-
-    if res['retcode'] != 0:
-        ret[snapshot] = res['stderr'] if 'stderr' in res else res['stdout']
-    else:
-        ret[snapshot] = 'bookmarked as {0}'.format(bookmark)
-    return ret
+    return __utils__['zfs.parse_command_result'](res, 'bookmarked')
 
 
 def holds(snapshot, **kwargs):
     '''
-    .. versionadded:: 2016.3.0
-
     Lists all existing user references for the given snapshot or snapshots.
 
     snapshot : string
@@ -856,51 +847,50 @@ def holds(snapshot, **kwargs):
     recursive : boolean
         lists the holds that are set on the named descendent snapshots also.
 
+    .. versionadded:: 2016.3.0
+
     CLI Example:
 
     .. code-block:: bash
 
         salt '*' zfs.holds myzpool/mydataset@baseline
     '''
-    ret = {}
+    ## Configure command
+    # NOTE: initialize the defaults
+    flags = ['-H']
+    target = []
 
-    if '@' not in snapshot:
-        ret[snapshot] = 'MUST be a snapshot'
-        return ret
+    # NOTE: set extra config from kwargs
+    if kwargs.get('recursive', False):
+        flags.append('-r')
 
-    zfs = _check_zfs()
-    recursive = kwargs.get('recursive', False)
+    # NOTE: update target
+    target.append(snapshot)
 
-    res = __salt__['cmd.run_all']('{zfs} holds -H {recursive}{snapshot}'.format(
-        zfs=zfs,
-        recursive='-r ' if recursive else '',
-        snapshot=_zfs_quote_escape_path(snapshot)
-    ))
+    ## Lookup holds
+    res = __salt__['cmd.run_all'](
+        __utils__['zfs.zfs_command'](
+            command='holds',
+            flags=flags,
+            target=target,
+        ),
+        python_shell=False,
+    )
 
+    ret = __utils__['zfs.parse_command_result'](res)
     if res['retcode'] == 0:
-        if res['stdout'] != '':
-            properties = "name,tag,timestamp".split(",")
-            for hold in [l for l in res['stdout'].splitlines()]:
-                hold = hold.split("\t")
-                hold_data = {}
+        for hold in res['stdout'].splitlines():
+            hold_data = OrderedDict(list(zip(
+                ['name', 'tag', 'timestamp'],
+                hold.split("\t"),
+            )))
+            ret[hold_data['tag'].strip()] = hold_data['timestamp']
 
-                for prop in properties:
-                    hold_data[prop] = hold[properties.index(prop)]
-
-                if hold_data['name'] not in ret:
-                    ret[hold_data['name']] = {}
-                ret[hold_data['name']][hold_data['tag']] = hold_data['timestamp']
-        else:
-            ret[snapshot] = 'no holds'
-    else:
-        ret[snapshot] = res['stderr'] if 'stderr' in res else res['stdout']
     return ret
 
 
 def hold(tag, *snapshot, **kwargs):
     '''
-    .. versionadded:: 2016.3.0
-
     Adds a single reference, named with the tag argument, to the specified
     snapshot or snapshots.
 
@@ -919,67 +909,54 @@ def hold(tag, *snapshot, **kwargs):
         specifies that a hold with the given tag is applied recursively to
         the snapshots of all descendent file systems.
 
-    .. note::
+    .. versionadded:: 2016.3.0
+    .. versionchanged:: Flourine
 
-        A comma-separated list can be provided for the tag parameter to hold multiple tags.
+    .. warning::
+
+        As of Flourine the tag parameter no longer accepts a comma-seprated value.
+        It's is now possible to create a tag that contains a comma, this was impossible before.
 
     CLI Example:
 
     .. code-block:: bash
 
         salt '*' zfs.hold mytag myzpool/mydataset@mysnapshot [recursive=True]
-        salt '*' zfs.hold mytag,myothertag myzpool/mydataset@mysnapshot
         salt '*' zfs.hold mytag myzpool/mydataset@mysnapshot myzpool/mydataset@myothersnapshot
     '''
-    ret = {}
+    ## warn about tag change
+    # NOTE: remove me 2 versions after Flourine
+    if ',' in tag:
+        log.warning('zfs.hold - on Flourine and later a comma in a tag will no longer create multiple tags!')
 
-    zfs = _check_zfs()
-    recursive = kwargs.get('recursive', False)
+    ## Configure command
+    # NOTE: initialize the defaults
+    flags = []
+    target = []
 
-    # verify snapshots
-    if not snapshot:
-        ret['error'] = 'one or more snapshots must be specified'
+    # NOTE: set extra config from kwargs
+    if kwargs.get('recursive', False):
+        flags.append('-r')
 
-    for snap in snapshot:
-        if '@' not in snap:
-            ret[snap] = 'not a snapshot'
+    # NOTE: update target
+    target.append(tag)
+    target.extend(snapshot)
 
-    if len(ret) > 0:
-        return ret
+    ## hold snapshot
+    res = __salt__['cmd.run_all'](
+        __utils__['zfs.zfs_command'](
+            command='hold',
+            flags=flags,
+            target=target,
+        ),
+        python_shell=False,
+    )
 
-    for csnap in snapshot:
-        for ctag in tag.split(','):
-            res = __salt__['cmd.run_all']('{zfs} hold {recursive}{tag} {snapshot}'.format(
-                zfs=zfs,
-                recursive='-r ' if recursive else '',
-                tag=_zfs_quote_escape_path(ctag),
-                snapshot=_zfs_quote_escape_path(csnap)
-            ))
-
-            if csnap not in ret:
-                ret[csnap] = {}
-
-            if res['retcode'] != 0:
-                for err in res['stderr'].splitlines():
-                    if err.startswith('cannot hold snapshot'):
-                        ret[csnap][ctag] = err[err.index(':')+2:]
-                    elif err.startswith('cannot open'):
-                        ret[csnap][ctag] = err[err.index(':')+2:]
-                    else:
-                        # fallback in case we hit a weird error
-                        if err == 'usage:':
-                            break
-                        ret[csnap][ctag] = res['stderr']
-            else:
-                ret[csnap][ctag] = 'held'
-
-    return ret
+    return __utils__['zfs.parse_command_result'](res, 'held')
 
 
 def release(tag, *snapshot, **kwargs):
     '''
-    .. versionadded:: 2016.3.0
-
     Removes a single reference, named with the tag argument, from the
     specified snapshot or snapshots.
 
@@ -997,9 +974,13 @@ def release(tag, *snapshot, **kwargs):
         recursively releases a hold with the given tag on the snapshots of
         all descendent file systems.
 
-    .. note::
+    .. versionadded:: 2016.3.0
+    .. versionchanged:: Flourine
 
-        A comma-separated list can be provided for the tag parameter to release multiple tags.
+    .. warning::
+
+        As of Flourine the tag parameter no longer accepts a comma-seprated value.
+        It's is now possible to create a tag that contains a comma, this was impossible before.
 
     CLI Example:
 
@@ -1008,55 +989,39 @@ def release(tag, *snapshot, **kwargs):
         salt '*' zfs.release mytag myzpool/mydataset@mysnapshot [recursive=True]
         salt '*' zfs.release mytag myzpool/mydataset@mysnapshot myzpool/mydataset@myothersnapshot
     '''
-    ret = {}
+    ## warn about tag change
+    # NOTE: remove me 2 versions after Flourine
+    if ',' in tag:
+        log.warning('zfs.release - on Flourine and later a comma in a tag will no longer create multiple tags!')
 
-    zfs = _check_zfs()
-    recursive = kwargs.get('recursive', False)
+    ## Configure command
+    # NOTE: initialize the defaults
+    flags = []
+    target = []
 
-    # verify snapshots
-    if not snapshot:
-        ret['error'] = 'one or more snapshots must be specified'
+    # NOTE: set extra config from kwargs
+    if kwargs.get('recursive', False):
+        flags.append('-r')
 
-    for snap in snapshot:
-        if '@' not in snap:
-            ret[snap] = 'not a snapshot'
+    # NOTE: update target
+    target.append(tag)
+    target.extend(snapshot)
 
-    if len(ret) > 0:
-        return ret
+    ## release snapshot
+    res = __salt__['cmd.run_all'](
+        __utils__['zfs.zfs_command'](
+            command='release',
+            flags=flags,
+            target=target,
+        ),
+        python_shell=False,
+    )
 
-    for csnap in snapshot:
-        for ctag in tag.split(','):
-            res = __salt__['cmd.run_all']('{zfs} release {recursive}{tag} {snapshot}'.format(
-                zfs=zfs,
-                recursive='-r ' if recursive else '',
-                tag=_zfs_quote_escape_path(ctag),
-                snapshot=_zfs_quote_escape_path(csnap)
-            ))
-
-            if csnap not in ret:
-                ret[csnap] = {}
-
-            if res['retcode'] != 0:
-                for err in res['stderr'].splitlines():
-                    if err.startswith('cannot release hold from snapshot'):
-                        ret[csnap][ctag] = err[err.index(':')+2:]
-                    elif err.startswith('cannot open'):
-                        ret[csnap][ctag] = err[err.index(':')+2:]
-                    else:
-                        # fallback in case we hit a weird error
-                        if err == 'usage:':
-                            break
-                        ret[csnap][ctag] = res['stderr']
-            else:
-                ret[csnap][ctag] = 'released'
-
-    return ret
+    return __utils__['zfs.parse_command_result'](res, 'released')
 
 
 def snapshot(*snapshot, **kwargs):
     '''
-    .. versionadded:: 2016.3.0
-
     Creates snapshots with the given names.
 
     *snapshot : string
@@ -1074,6 +1039,9 @@ def snapshot(*snapshot, **kwargs):
 
             properties="{'property1': 'value1', 'property2': 'value2'}"
 
+    .. versionadded:: 2016.3.0
+    .. versionchanged:: Flourine
+
     CLI Example:
 
     .. code-block:: bash
@@ -1081,59 +1049,33 @@ def snapshot(*snapshot, **kwargs):
         salt '*' zfs.snapshot myzpool/mydataset@yesterday [recursive=True]
         salt '*' zfs.snapshot myzpool/mydataset@yesterday myzpool/myotherdataset@yesterday [recursive=True]
     '''
-    ret = {}
+    ## Configure command
+    # NOTE: initialize the defaults
+    flags = []
 
-    zfs = _check_zfs()
-    recursive = kwargs.get('recursive', False)
-    properties = kwargs.get('properties', None)
+    # NOTE: push filesystem properties
+    filesystem_properties = kwargs.get('properties', {})
 
-    # verify snapshots
-    if not snapshot:
-        ret['error'] = 'one or more snapshots must be specified'
+    # NOTE: set extra config from kwargs
+    if kwargs.get('recursive', False):
+        flags.append('-r')
 
-    for snap in snapshot:
-        if '@' not in snap:
-            ret[snap] = 'not a snapshot'
+    ## Create snapshot
+    res = __salt__['cmd.run_all'](
+        __utils__['zfs.zfs_command'](
+            command='snapshot',
+            flags=flags,
+            filesystem_properties=filesystem_properties,
+            target=list(snapshot),
+        ),
+        python_shell=False,
+    )
 
-    # if zpool properties specified, then
-    # create "-o property=value" pairs
-    if properties:
-        proplist = []
-        for prop in properties:
-            proplist.append('-o {0}={1}'.format(prop, _conform_value((properties[prop]))))
-        properties = ' '.join(proplist)
-
-    for csnap in snapshot:
-        if '@' not in csnap:
-            continue
-
-        res = __salt__['cmd.run_all']('{zfs} snapshot {recursive}{properties}{snapshot}'.format(
-            zfs=zfs,
-            recursive='-r ' if recursive else '',
-            properties='{0} '.format(properties) if properties else '',
-            snapshot=_zfs_quote_escape_path(csnap)
-        ))
-
-        if res['retcode'] != 0:
-            for err in res['stderr'].splitlines():
-                if err.startswith('cannot create snapshot'):
-                    ret[csnap] = err[err.index(':')+2:]
-                elif err.startswith('cannot open'):
-                    ret[csnap] = err[err.index(':')+2:]
-                else:
-                    # fallback in case we hit a weird error
-                    if err == 'usage:':
-                        break
-                    ret[csnap] = res['stderr']
-        else:
-            ret[csnap] = 'snapshotted'
-    return ret
+    return __utils__['zfs.parse_command_result'](res, 'snapshotted')
 
 
 def set(*dataset, **kwargs):
     '''
-    .. versionadded:: 2016.3.0
-
     Sets the property or list of properties to the given value(s) for each dataset.
 
     *dataset : string
@@ -1155,9 +1097,11 @@ def set(*dataset, **kwargs):
         can be set and acceptable values.
 
         Numeric values can be specified as exact values, or in a human-readable
-        form with a suffix of B, K, M, G, T, P, E, Z (for bytes, kilobytes,
-        megabytes, gigabytes, terabytes, petabytes, exabytes, or zettabytes,
-        respectively).
+        form with a suffix of B, K, M, G, T, P, E (for bytes, kilobytes,
+        megabytes, gigabytes, terabytes, petabytes, or exabytes respectively).
+
+    .. versionadded:: 2016.3.0
+    .. versionchanged:: Flourine
 
     CLI Example:
 
@@ -1167,51 +1111,26 @@ def set(*dataset, **kwargs):
         salt '*' zfs.set myzpool/mydataset myzpool/myotherdataset compression=off
         salt '*' zfs.set myzpool/mydataset myzpool/myotherdataset compression=lz4 canmount=off
     '''
-    ret = {}
+    ## Configure command
+    # NOTE: push filesystem properties
+    filesystem_properties = salt.utils.args.clean_kwargs(**kwargs)
 
-    zfs = _check_zfs()
+    ## Set property
+    res = __salt__['cmd.run_all'](
+        __utils__['zfs.zfs_command'](
+            command='set',
+            property_name=filesystem_properties.keys(),
+            property_value=filesystem_properties.values(),
+            target=list(dataset),
+        ),
+        python_shell=False,
+    )
 
-    # verify snapshots
-    if not dataset:
-        ret['error'] = 'one or more snapshots must be specified'
-
-    # clean kwargs
-    properties = salt.utils.args.clean_kwargs(**kwargs)
-    if len(properties) < 1:
-        ret['error'] = '{0}one or more properties must be specified'.format(
-            '{0},\n'.format(ret['error']) if 'error' in ret else ''
-        )
-
-    if len(ret) > 0:
-        return ret
-
-    # for better error handling we don't do one big set command
-    for ds in dataset:
-        for prop in properties:
-            res = __salt__['cmd.run_all']('{zfs} set {prop}={value} {dataset}'.format(
-                zfs=zfs,
-                prop=prop,
-                value=_conform_value(properties[prop]),
-                dataset=_zfs_quote_escape_path(ds)
-            ))
-            if ds not in ret:
-                ret[ds] = {}
-
-            if res['retcode'] != 0:
-                ret[ds][prop] = res['stderr'] if 'stderr' in res else res['stdout']
-                if ':' in ret[ds][prop]:
-                    ret[ds][prop] = ret[ds][prop][ret[ds][prop].index(':')+2:]
-            else:
-                ret[ds][prop] = 'set'
-
-    return ret
+    return __utils__['zfs.parse_command_result'](res, 'set')
 
 
 def get(*dataset, **kwargs):
     '''
-    .. versionadded:: 2016.3.0
-    .. versionchanged:: Oxygen
-
     Displays properties for the given datasets.
 
     *dataset : string
@@ -1231,13 +1150,16 @@ def get(*dataset, **kwargs):
         comma-separated list of sources to display. Must be one of the following:
         local, default, inherited, temporary, and none. The default value is all sources.
     parsable : boolean
-        display numbers in parsable (exact) values
+        display numbers in parsable (exact) values (default = True)
         .. versionadded:: Oxygen
 
     .. note::
 
         If no datasets are specified, then the command displays properties
         for all datasets on the system.
+
+    .. versionadded:: 2016.3.0
+    .. versionchanged:: Flourine
 
     CLI Example:
 
@@ -1248,74 +1170,71 @@ def get(*dataset, **kwargs):
         salt '*' zfs.get myzpool/mydataset properties="sharenfs,mountpoint" [recursive=True|False]
         salt '*' zfs.get myzpool/mydataset myzpool/myotherdataset properties=available fields=value depth=1
     '''
-    ret = OrderedDict()
-    zfs = _check_zfs()
-    properties = kwargs.get('properties', 'all')
-    recursive = kwargs.get('recursive', False)
-    depth = kwargs.get('depth', 0)
-    fields = kwargs.get('fields', 'value,source')
-    ltype = kwargs.get('type', None)
-    source = kwargs.get('source', None)
-    parsable = kwargs.get('parsable', False)
-    cmd = '{0} get -H'.format(zfs)
+    ## Configure command
+    # NOTE: initialize the defaults
+    flags = ['-H', '-p']
+    opts = {}
 
-    # parsable output
-    if parsable:
-        cmd = '{0} -p'.format(cmd)
-
-    # recursively get
-    if depth:
-        cmd = '{0} -d {1}'.format(cmd, depth)
-    elif recursive:
-        cmd = '{0} -r'.format(cmd)
-
-    # fields
-    fields = fields.split(',')
-    if 'name' in fields:  # ensure name is first
+    # NOTE: set extra config from kwargs
+    if kwargs.get('depth', False):
+        opts['-d'] = kwargs.get('depth')
+    elif kwargs.get('recursive', False):
+        flags.append('-r')
+    fields = kwargs.get('fields', 'value,source').split(',')
+    if 'name' in fields:      # ensure name is first
         fields.remove('name')
     if 'property' in fields:  # ensure property is second
         fields.remove('property')
     fields.insert(0, 'name')
     fields.insert(1, 'property')
-    cmd = '{0} -o {1}'.format(cmd, ','.join(fields))
+    opts['-o'] = ",".join(fields)
+    if kwargs.get('type', False):
+        opts['-t'] = kwargs.get('type')
+    if kwargs.get('source', False):
+        opts['-s'] = kwargs.get('source')
 
-    # filter on type
-    if source:
-        cmd = '{0} -s {1}'.format(cmd, source)
+    # NOTE: set property_name
+    property_name = kwargs.get('properties', 'all')
 
-    # filter on type
-    if ltype:
-        cmd = '{0} -t {1}'.format(cmd, ltype)
+    ## Get properties
+    res = __salt__['cmd.run_all'](
+        __utils__['zfs.zfs_command'](
+            command='get',
+            flags=flags,
+            opts=opts,
+            property_name=property_name,
+            target=list(dataset),
+        ),
+        python_shell=False,
+    )
 
-    # properties
-    cmd = '{0} {1}'.format(cmd, properties)
-
-    # datasets
-    if dataset:
-        dataset = [_zfs_quote_escape_path(x) for x in dataset]
-    cmd = '{0} {1}'.format(cmd, ' '.join(dataset))
-
-    # parse output
-    res = __salt__['cmd.run_all'](cmd)
+    ret = __utils__['zfs.parse_command_result'](res)
     if res['retcode'] == 0:
-        for ds in [l for l in res['stdout'].splitlines()]:
-            ds = ds.split("\t")
-            ds_data = {}
+        for ds in res['stdout'].splitlines():
+            ds_data = OrderedDict(list(zip(
+                fields,
+                ds.split("\t")
+            )))
 
-            for field in fields:
-                ds_data[field] = _conform_value(ds[fields.index(field)])
+            if 'value' in ds_data:
+                if kwargs.get('parsable', True):
+                    ds_data['value'] = __utils__['zfs.from_auto'](
+                        ds_data['property'],
+                        ds_data['value'],
+                    )
+                else:
+                    ds_data['value'] = __utils__['zfs.to_auto'](
+                        ds_data['property'],
+                        ds_data['value'],
+                        convert_to_human=True,
+                    )
 
-            ds_name = ds_data['name']
-            ds_prop = ds_data['property']
+            if ds_data['name'] not in ret:
+                ret[ds_data['name']] = OrderedDict()
+
+            ret[ds_data['name']][ds_data['property']] = ds_data
             del ds_data['name']
             del ds_data['property']
-
-            if ds_name not in ret:
-                ret[ds_name] = {}
-
-            ret[ds_name][ds_prop] = ds_data
-    else:
-        ret['error'] = res['stderr'] if 'stderr' in res else res['stdout']
 
     return ret
 

--- a/salt/modules/zfs.py
+++ b/salt/modules/zfs.py
@@ -8,6 +8,10 @@ Module for running ZFS command
 :depends:       salt.utils.zfs
 :platform:      illumos,freebsd,linux
 
+.. versionchanged:: Fluorine
+  Big refactor to remove duplicate code, better type converions and improved
+  consistancy in output.
+
 '''
 from __future__ import absolute_import, unicode_literals, print_function
 
@@ -51,7 +55,6 @@ def exists(name, **kwargs):
         filesystem, snapshot, volume, bookmark, or all.
 
     .. versionadded:: 2015.5.0
-    .. versionchanged:: Fluorine
 
     CLI Example:
 
@@ -59,6 +62,7 @@ def exists(name, **kwargs):
 
         salt '*' zfs.exists myzpool/mydataset
         salt '*' zfs.exists myzpool/myvolume type=volume
+
     '''
     ## Configure command
     # NOTE: initialize the defaults
@@ -107,7 +111,6 @@ def create(name, **kwargs):
             properties="{'property1': 'value1', 'property2': 'value2'}"
 
     .. versionadded:: 2015.5.0
-    .. versionchanged:: Fluorine
 
     CLI Example:
 
@@ -168,13 +171,13 @@ def destroy(name, **kwargs):
         watch out when using recursive and recursive_all
 
     .. versionadded:: 2015.5.0
-    .. versionchanged:: Fluorine
 
     CLI Example:
 
     .. code-block:: bash
 
         salt '*' zfs.destroy myzpool/mydataset [force=True|False]
+
     '''
     ## Configure command
     # NOTE: initialize the defaults
@@ -220,13 +223,13 @@ def rename(name, new_name, **kwargs):
         snapshots are the only dataset that can be renamed recursively.
 
     .. versionadded:: 2015.5.0
-    .. versionchanged:: Fluorine
 
     CLI Example:
 
     .. code-block:: bash
 
         salt '*' zfs.rename myzpool/mydataset myzpool/renameddataset
+
     '''
     ## Configure command
     # NOTE: initialize the defaults
@@ -291,7 +294,6 @@ def list_(name=None, **kwargs):
         .. versionadded:: Oxygen
 
     .. versionadded:: 2015.5.0
-    .. versionchanged:: Fluorine
 
     CLI Example:
 
@@ -300,6 +302,7 @@ def list_(name=None, **kwargs):
         salt '*' zfs.list
         salt '*' zfs.list myzpool/mydataset [recursive=True|False]
         salt '*' zfs.list myzpool/mydataset properties="sharenfs,mountpoint"
+
     '''
     ret = OrderedDict()
 
@@ -378,6 +381,7 @@ def list_mount():
     .. code-block:: bash
 
         salt '*' zfs.list_mount
+
     '''
     ## List mounted filesystem
     res = __salt__['cmd.run_all'](
@@ -423,6 +427,7 @@ def mount(name=None, **kwargs):
         salt '*' zfs.mount
         salt '*' zfs.mount myzpool/mydataset
         salt '*' zfs.mount myzpool/mydataset options=ro
+
     '''
     ## Configure command
     # NOTE: initialize the defaults
@@ -480,6 +485,7 @@ def unmount(name, **kwargs):
     .. code-block:: bash
 
         salt '*' zfs.unmount myzpool/mydataset [force=True|False]
+
     '''
     ## Configure command
     # NOTE: initialize the defaults
@@ -523,13 +529,13 @@ def inherit(prop, name, **kwargs):
         operate as if the -S option was not specified.
 
     .. versionadded:: 2016.3.0
-    .. versionchanged:: Fluorine
 
     CLI Example:
 
     .. code-block:: bash
 
         salt '*' zfs.inherit canmount myzpool/mydataset [recursive=True|False]
+
     '''
     ## Configure command
     # NOTE: initialize the defaults
@@ -573,13 +579,13 @@ def diff(name_a, name_b=None, **kwargs):
         if true we don't parse the timestamp to a more readable date (default = True)
 
     .. versionadded:: 2016.3.0
-    .. versionchanged:: Fluorine
 
     CLI Example:
 
     .. code-block:: bash
 
         salt '*' zfs.diff myzpool/mydataset@yesterday myzpool/mydataset
+
     '''
     ## Configure command
     # NOTE: initialize the defaults
@@ -649,13 +655,13 @@ def rollback(name, **kwargs):
         must be destroyed by specifying the -r option.
 
     .. versionadded:: 2016.3.0
-    .. versionchanged:: Fluorine
 
     CLI Example:
 
     .. code-block:: bash
 
         salt '*' zfs.rollback myzpool/mydataset@yesterday
+
     '''
     ## Configure command
     # NOTE: initialize the defaults
@@ -708,13 +714,13 @@ def clone(name_a, name_b, **kwargs):
             properties="{'property1': 'value1', 'property2': 'value2'}"
 
     .. versionadded:: 2016.3.0
-    .. versionchanged:: Fluorine
 
     CLI Example:
 
     .. code-block:: bash
 
         salt '*' zfs.clone myzpool/mydataset@yesterday myzpool/mydataset_yesterday
+
     '''
     ## Configure command
     # NOTE: initialize the defaults
@@ -776,6 +782,7 @@ def promote(name):
     .. code-block:: bash
 
         salt '*' zfs.promote myzpool/myclone
+
     '''
     ## Promote clone
     res = __salt__['cmd.run_all'](
@@ -813,6 +820,7 @@ def bookmark(snapshot, bookmark):
     .. code-block:: bash
 
         salt '*' zfs.bookmark myzpool/mydataset@yesterday myzpool/mydataset#complete
+
     '''
     # abort if we do not have feature flags
     if not __utils__['zfs.has_feature_flags']():
@@ -854,6 +862,7 @@ def holds(snapshot, **kwargs):
     .. code-block:: bash
 
         salt '*' zfs.holds myzpool/mydataset@baseline
+
     '''
     ## Configure command
     # NOTE: initialize the defaults
@@ -923,6 +932,7 @@ def hold(tag, *snapshot, **kwargs):
 
         salt '*' zfs.hold mytag myzpool/mydataset@mysnapshot [recursive=True]
         salt '*' zfs.hold mytag myzpool/mydataset@mysnapshot myzpool/mydataset@myothersnapshot
+
     '''
     ## warn about tag change
     # NOTE: remove me 2 versions after Flourine
@@ -988,6 +998,7 @@ def release(tag, *snapshot, **kwargs):
 
         salt '*' zfs.release mytag myzpool/mydataset@mysnapshot [recursive=True]
         salt '*' zfs.release mytag myzpool/mydataset@mysnapshot myzpool/mydataset@myothersnapshot
+
     '''
     ## warn about tag change
     # NOTE: remove me 2 versions after Flourine
@@ -1040,7 +1051,6 @@ def snapshot(*snapshot, **kwargs):
             properties="{'property1': 'value1', 'property2': 'value2'}"
 
     .. versionadded:: 2016.3.0
-    .. versionchanged:: Flourine
 
     CLI Example:
 
@@ -1048,6 +1058,7 @@ def snapshot(*snapshot, **kwargs):
 
         salt '*' zfs.snapshot myzpool/mydataset@yesterday [recursive=True]
         salt '*' zfs.snapshot myzpool/mydataset@yesterday myzpool/myotherdataset@yesterday [recursive=True]
+
     '''
     ## Configure command
     # NOTE: initialize the defaults
@@ -1101,7 +1112,6 @@ def set(*dataset, **kwargs):
         megabytes, gigabytes, terabytes, petabytes, or exabytes respectively).
 
     .. versionadded:: 2016.3.0
-    .. versionchanged:: Flourine
 
     CLI Example:
 
@@ -1110,6 +1120,7 @@ def set(*dataset, **kwargs):
         salt '*' zfs.set myzpool/mydataset compression=off
         salt '*' zfs.set myzpool/mydataset myzpool/myotherdataset compression=off
         salt '*' zfs.set myzpool/mydataset myzpool/myotherdataset compression=lz4 canmount=off
+
     '''
     ## Configure command
     # NOTE: push filesystem properties
@@ -1159,7 +1170,6 @@ def get(*dataset, **kwargs):
         for all datasets on the system.
 
     .. versionadded:: 2016.3.0
-    .. versionchanged:: Flourine
 
     CLI Example:
 
@@ -1169,6 +1179,7 @@ def get(*dataset, **kwargs):
         salt '*' zfs.get myzpool/mydataset [recursive=True|False]
         salt '*' zfs.get myzpool/mydataset properties="sharenfs,mountpoint" [recursive=True|False]
         salt '*' zfs.get myzpool/mydataset myzpool/myotherdataset properties=available fields=value depth=1
+
     '''
     ## Configure command
     # NOTE: initialize the defaults

--- a/salt/modules/zpool.py
+++ b/salt/modules/zpool.py
@@ -2,21 +2,24 @@
 '''
 Module for running ZFS zpool command
 
-:codeauthor: Nitin Madhok <nmadhok@clemson.edu>
+:codeauthor:    Nitin Madhok <nmadhok@clemson.edu>, Jorge Schrauwen <sjorge@blackdot.be>
+:maintainer:    Jorge Schrauwen <sjorge@blackdot.be>
+:maturity:      new
+:depends:       salt.utils.zfs
+:platform:      illumos,freebsd,linux
 '''
 from __future__ import absolute_import, print_function, unicode_literals
 
 # Import Python libs
 import os
-import stat
 import logging
 
 # Import Salt libs
 import salt.utils.decorators
 import salt.utils.decorators.path
 import salt.utils.path
+from salt.ext.six.moves import zip
 from salt.utils.odict import OrderedDict
-from salt.modules.zfs import _conform_value
 
 log = logging.getLogger(__name__)
 
@@ -37,179 +40,211 @@ def __virtual__():
         return (False, "The zpool module cannot be loaded: zfs not supported")
 
 
-@salt.utils.decorators.memoize
-def _check_zpool():
+def _clean_vdev_config(config):
     '''
-    Looks to see if zpool is present on the system
+    Return a simple vdev tree from zpool.status' config section
     '''
-    return salt.utils.path.which('zpool')
+    cln_config = OrderedDict()
+    for label, sub_config in config.items():
+        if label not in ['state', 'read', 'write', 'cksum']:
+            sub_config = _clean_vdev_config(sub_config)
 
+            if sub_config and isinstance(cln_config, list):
+                cln_config.append(OrderedDict([(label, sub_config)]))
+            elif sub_config and isinstance(cln_config, OrderedDict):
+                cln_config[label] = sub_config
+            elif isinstance(cln_config, list):
+                cln_config.append(label)
+            elif isinstance(cln_config, OrderedDict):
+                new_config = []
+                for old_label, old_config in cln_config.items():
+                    new_config.append(OrderedDict([(old_label, old_config)]))
+                new_config.append(label)
+                cln_config = new_config
+            else:
+                cln_config = [label]
 
-@salt.utils.decorators.memoize
-def _check_features():
-    '''
-    Looks to see if zpool-features is available
-    '''
-    # get man location
-    man = salt.utils.path.which('man')
-    if not man:
-        return False
-
-    cmd = '{man} zpool-features'.format(
-        man=man
-    )
-    res = __salt__['cmd.run_all'](cmd, python_shell=False)
-    return res['retcode'] == 0
-
-
-@salt.utils.decorators.memoize
-def _check_mkfile():
-    '''
-    Looks to see if mkfile is present on the system
-    '''
-    return salt.utils.path.which('mkfile')
+    return cln_config
 
 
 def healthy():
     '''
-    .. versionadded:: 2016.3.0
-
     Check if all zpools are healthy
+
+    .. versionadded:: 2016.3.0
 
     CLI Example:
 
     .. code-block:: bash
 
         salt '*' zpool.healthy
-    '''
-    zpool_cmd = _check_zpool()
 
-    cmd = '{zpool_cmd} status -x'.format(
-        zpool_cmd=zpool_cmd
+    '''
+    ## collect status output
+    # NOTE: we pass the -x flag, by doing this
+    #       we will get 'all pools are healthy' on stdout
+    #       if all pools are healthy, otherwise we will get
+    #       the same output that we expect from zpool status
+    res = __salt__['cmd.run_all'](
+        __utils__['zfs.zpool_command']('status', flags=['-x']),
+        python_shell=False,
     )
-    res = __salt__['cmd.run_all'](cmd, python_shell=False)
     return res['stdout'] == 'all pools are healthy'
 
 
 def status(zpool=None):
     '''
-    .. versionchanged:: 2016.3.0
-
     Return the status of the named zpool
 
     zpool : string
         optional name of storage pool
+
+    .. versionadded:: 2016.3.0
+    .. versionchanged:: Fluorine
 
     CLI Example:
 
     .. code-block:: bash
 
         salt '*' zpool.status myzpool
+
     '''
     ret = OrderedDict()
 
-    # get zpool list data
-    zpool_cmd = _check_zpool()
-    cmd = '{zpool_cmd} status{zpool}'.format(
-        zpool_cmd=zpool_cmd,
-        zpool=' {0}'.format(zpool) if zpool else ''
+    ## collect status output
+    res = __salt__['cmd.run_all'](
+        __utils__['zfs.zpool_command']('status', target=zpool),
+        python_shell=False,
     )
-    res = __salt__['cmd.run_all'](cmd, python_shell=False)
-    if res['retcode'] != 0:
-        ret['error'] = res['stderr'] if 'stderr' in res else res['stdout']
-        return ret
 
-    # parse zpool status data
-    zp_data = {}
+    if res['retcode'] != 0:
+        return __utils__['zfs.parse_command_result'](res)
+
+    # NOTE: command output for reference
+    # =====================================================================
+    #   pool: data
+    #  state: ONLINE
+    #   scan: scrub repaired 0 in 2h27m with 0 errors on Mon Jan  8 03:27:25 2018
+    # config:
+    #
+    #     NAME                       STATE     READ WRITE CKSUM
+    #     data                       ONLINE       0     0     0
+    #       mirror-0                 ONLINE       0     0     0
+    #         c0tXXXXCXXXXXXXXXXXd0  ONLINE       0     0     0
+    #         c0tXXXXCXXXXXXXXXXXd0  ONLINE       0     0     0
+    #         c0tXXXXCXXXXXXXXXXXd0  ONLINE       0     0     0
+    #
+    # errors: No known data errors
+    # =====================================================================
+
+    ## parse status output
+    # NOTE: output is 'key: value' except for the 'config' key.
+    #       mulitple pools will repeat the output, so if switch pools if
+    #       we see 'pool:'
     current_pool = None
     current_prop = None
     for zpd in res['stdout'].splitlines():
         if zpd.strip() == '':
             continue
         if ':' in zpd:
+            # NOTE: line is 'key: value' format, we just update a dict
             prop = zpd.split(':')[0].strip()
             value = ":".join(zpd.split(':')[1:]).strip()
             if prop == 'pool' and current_pool != value:
                 current_pool = value
-                zp_data[current_pool] = {}
+                ret[current_pool] = OrderedDict()
             if prop != 'pool':
-                zp_data[current_pool][prop] = value
+                ret[current_pool][prop] = value
 
             current_prop = prop
         else:
-            zp_data[current_pool][current_prop] = "{0}\n{1}".format(
-                zp_data[current_pool][current_prop],
+            # NOTE: we append the line output to the last property
+            #       this should only happens once we hit the config
+            #       section
+            ret[current_pool][current_prop] = "{0}\n{1}".format(
+                ret[current_pool][current_prop],
                 zpd
             )
 
-    # parse zpool config data
-    for pool in zp_data:
-        if 'config' not in zp_data[pool]:
+    ## parse config property for each pool
+    # NOTE: the config property has some structured data
+    #       sadly this data is in a different format than
+    #       the rest and it needs further processing
+    for pool in ret:
+        if 'config' not in ret[pool]:
             continue
         header = None
         root_vdev = None
         vdev = None
         dev = None
-        config = zp_data[pool]['config']
+        rdev = None
+        config = ret[pool]['config']
         config_data = OrderedDict()
         for line in config.splitlines():
+            # NOTE: the first line is the header
+            #       we grab all the none whitespace values
             if not header:
                 header = line.strip().lower()
                 header = [x for x in header.split(' ') if x not in ['']]
                 continue
 
-            if line[0:1] == "\t":
+            # NOTE: data is indented by 1 tab, then multiples of 2 spaces
+            #       to differential root vdev, vdev, and dev
+            #
+            #       we just strip the intial tab (can't use .strip() here)
+            if line[0] == "\t":
                 line = line[1:]
 
-            stat_data = OrderedDict()
-            stats = [x for x in line.strip().split(' ') if x not in ['']]
-            for prop in header:
-                if prop == 'name':
-                    continue
-                if header.index(prop) < len(stats):
-                    stat_data[prop] = stats[header.index(prop)]
+            # NOTE: transform data into dict
+            stat_data = OrderedDict(list(zip(
+                header,
+                [x for x in line.strip().split(' ') if x not in ['']],
+            )))
 
-            dev = line.strip().split()[0]
+            # NOTE: decode the zfs values properly
+            stat_data = __utils__['zfs.from_auto_dict'](stat_data)
 
-            if line[0:4] != '    ':
-                if line[0:2] == '  ':
-                    vdev = line.strip().split()[0]
-                    dev = None
-                else:
-                    root_vdev = line.strip().split()[0]
-                    vdev = None
-                    dev = None
+            # NOTE: store stat_data in the proper location
+            if line.startswith(' ' * 6):
+                rdev = stat_data['name']
+                config_data[root_vdev][vdev][dev][rdev] = stat_data
+            elif line.startswith(' ' * 4):
+                rdev = None
+                dev = stat_data['name']
+                config_data[root_vdev][vdev][dev] = stat_data
+            elif line.startswith(' ' * 2):
+                rdev = dev = None
+                vdev = stat_data['name']
+                config_data[root_vdev][vdev] = stat_data
+            else:
+                rdev = dev = vdev = None
+                root_vdev = stat_data['name']
+                config_data[root_vdev] = stat_data
 
-            if root_vdev:
-                if root_vdev not in config_data:
-                    config_data[root_vdev] = {}
-                    if len(stat_data) > 0:
-                        config_data[root_vdev] = stat_data
-                if vdev:
-                    if vdev not in config_data[root_vdev]:
-                        config_data[root_vdev][vdev] = {}
-                        if len(stat_data) > 0:
-                            config_data[root_vdev][vdev] = stat_data
-                    if dev and dev not in config_data[root_vdev][vdev]:
-                        config_data[root_vdev][vdev][dev] = {}
-                        if len(stat_data) > 0:
-                            config_data[root_vdev][vdev][dev] = stat_data
+            # NOTE: name already used as identifier, drop duplicate data
+            del stat_data['name']
 
-        zp_data[pool]['config'] = config_data
+        ret[pool]['config'] = config_data
 
-    return zp_data
+    return ret
 
 
-def iostat(zpool=None, sample_time=0):
+def iostat(zpool=None, sample_time=5, parsable=True):
     '''
-    .. versionchanged:: 2016.3.0
-
     Display I/O statistics for the given pools
 
     zpool : string
         optional name of storage pool
     sample_time : int
         seconds to capture data before output
+        default a sample of 5 seconds is used
+    parsable : boolean
+        display data in pythonc values (True, False, Bytes,...)
+
+    .. versionadded:: 2016.3.0
+    .. versionchanged:: Fluorine
+
+        Added ```parsable``` parameter that defaults to True
 
     CLI Example:
 
@@ -219,109 +254,106 @@ def iostat(zpool=None, sample_time=0):
     '''
     ret = OrderedDict()
 
-    # get zpool list data
-    zpool_cmd = _check_zpool()
-    cmd = '{zpool_cmd} iostat -v{zpool}{sample_time}'.format(
-        zpool_cmd=zpool_cmd,
-        zpool=' {0}'.format(zpool) if zpool else '',
-        sample_time=' {0} 2'.format(sample_time) if sample_time else ''
+    ## get iostat output
+    res = __salt__['cmd.run_all'](
+        __utils__['zfs.zpool_command'](
+            command='iostat',
+            flags=['-v'],
+            target=[zpool, sample_time, 2]
+        ),
+        python_shell=False,
     )
-    res = __salt__['cmd.run_all'](cmd, python_shell=False)
-    if res['retcode'] != 0:
-        ret['error'] = res['stderr'] if 'stderr' in res else res['stdout']
-        return ret
 
-    # note: hardcoded header fields, the double header is hard to parse
-    #                                capacity     operations    bandwidth
-    #pool                         alloc   free   read  write   read  write
+    if res['retcode'] != 0:
+        return __utils__['zfs.parse_command_result'](res)
+
+    # NOTE: command output for reference
+    # =====================================================================
+    #                               capacity     operations    bandwidth
+    # pool                       alloc   free   read  write   read  write
+    # -------------------------  -----  -----  -----  -----  -----  -----
+    # mypool                      648G  1.18T     10      6  1.30M   817K
+    #   mirror                    648G  1.18T     10      6  1.30M   817K
+    #     c0tXXXXCXXXXXXXXXXXd0      -      -      9      5  1.29M   817K
+    #     c0tXXXXCXXXXXXXXXXXd0      -      -      9      5  1.29M   817K
+    #     c0tXXXXCXXXXXXXXXXXd0      -      -      9      5  1.29M   817K
+    # -------------------------  -----  -----  -----  -----  -----  -----
+    # =====================================================================
+
+    ## parse iostat output
+    # NOTE: hardcode the header
+    #       the double header line is hard to parse, we opt to
+    #       hardcode the header fields
     header = [
-        'pool',
-        'capacity-alloc',
-        'capacity-free',
-        'operations-read',
-        'operations-write',
-        'bandwith-read',
-        'bandwith-write'
+        'name',
+        'capacity-alloc', 'capacity-free',
+        'operations-read', 'operations-write',
+        'bandwith-read', 'bandwith-write',
     ]
     root_vdev = None
     vdev = None
     dev = None
-    config_data = None
-    current_pool = None
+    current_data = OrderedDict()
     for line in res['stdout'].splitlines():
-        if line.strip() == '':
+        # NOTE: skip header
+        if line.strip() == '' or \
+           line.strip().split()[-1] in ['write', 'bandwidth']:
             continue
 
-        # ignore header
-        if line.startswith('pool') and line.endswith('write'):
-            continue
-        if line.endswith('bandwidth'):
-            continue
-
+        # NOTE: reset pool on line separator
         if line.startswith('-') and line.endswith('-'):
-            if config_data:
-                ret[current_pool] = config_data
-            config_data = OrderedDict()
-            current_pool = None
+            ret.update(current_data)
+            current_data = OrderedDict()
+            continue
+
+        # NOTE: transform data into dict
+        io_data = OrderedDict(list(zip(
+            header,
+            [x for x in line.strip().split(' ') if x not in ['']],
+        )))
+
+        # NOTE: normalize values
+        if parsable:
+            # NOTE: raw numbers and pythonic types
+            io_data = __utils__['zfs.from_auto_dict'](io_data)
         else:
-            if not isinstance(config_data, salt.utils.odict.OrderedDict):
-                continue
+            # NOTE: human readable zfs types
+            io_data = __utils__['zfs.to_auto_dict'](io_data)
 
-            stat_data = OrderedDict()
-            stats = [x for x in line.strip().split(' ') if x not in ['']]
-            for prop in header:
-                if header.index(prop) < len(stats):
-                    if prop == 'pool':
-                        if not current_pool:
-                            current_pool = stats[header.index(prop)]
-                        continue
-                    if stats[header.index(prop)] == '-':
-                        continue
-                    stat_data[prop] = stats[header.index(prop)]
+        # NOTE: store io_data in the proper location
+        if line.startswith(' ' * 4):
+            dev = io_data['name']
+            current_data[root_vdev][vdev][dev] = io_data
+        elif line.startswith(' ' * 2):
+            dev = None
+            vdev = io_data['name']
+            current_data[root_vdev][vdev] = io_data
+        else:
+            dev = vdev = None
+            root_vdev = io_data['name']
+            current_data[root_vdev] = io_data
 
-            dev = line.strip().split()[0]
-
-            if line[0:4] != '    ':
-                if line[0:2] == '  ':
-                    vdev = line.strip().split()[0]
-                    dev = None
-                else:
-                    root_vdev = line.strip().split()[0]
-                    vdev = None
-                    dev = None
-
-            if root_vdev:
-                if not config_data.get(root_vdev):
-                    config_data[root_vdev] = {}
-                    if len(stat_data) > 0:
-                        config_data[root_vdev] = stat_data
-                if vdev:
-                    if vdev not in config_data[root_vdev]:
-                        config_data[root_vdev][vdev] = {}
-                        if len(stat_data) > 0:
-                            config_data[root_vdev][vdev] = stat_data
-                    if dev and dev not in config_data[root_vdev][vdev]:
-                        config_data[root_vdev][vdev][dev] = {}
-                        if len(stat_data) > 0:
-                            config_data[root_vdev][vdev][dev] = stat_data
+        # NOTE: name already used as identifier, drop duplicate data
+        del io_data['name']
 
     return ret
 
 
-def list_(properties='size,alloc,free,cap,frag,health', zpool=None, parsable=False):
+def list_(properties='size,alloc,free,cap,frag,health', zpool=None, parsable=True):
     '''
-    .. versionadded:: 2015.5.0
-    .. versionchanged:: Oxygen
-
     Return information about (all) storage pools
 
     zpool : string
         optional name of storage pool
     properties : string
-        comma-separated list of properties to list
+        comma-separated list of properties to display
     parsable : boolean
-        display numbers in parsable (exact) values
-        .. versionadded:: Oxygen
+        display data in pythonc values (True, False, Bytes,...)
+
+    .. versionadded:: 2015.5.0
+    .. versionchanged:: Fluorine
+
+        Added ```parsable``` parameter that defaults to True
 
     .. note::
         the 'name' property will always be included, the 'frag' property will get removed if not available
@@ -343,46 +375,64 @@ def list_(properties='size,alloc,free,cap,frag,health', zpool=None, parsable=Fal
     '''
     ret = OrderedDict()
 
-    # remove 'frag' property if not available
-    properties = properties.split(',')
-    if 'name' in properties:
+    ## update properties
+    # NOTE: properties should be a list
+    if not isinstance(properties, list):
+        properties = properties.split(',')
+
+    # NOTE: name should be first property
+    while 'name' in properties:
         properties.remove('name')
     properties.insert(0, 'name')
-    if not _check_features() and 'frag' in properties:
-        properties.remove('frag')
 
-    # get zpool list data
-    zpool_cmd = _check_zpool()
-    cmd = '{zpool_cmd} list -H -o {properties}{parsable}{zpool}'.format(
-        zpool_cmd=zpool_cmd,
-        properties=','.join(properties),
-        parsable=' -p' if parsable else '',
-        zpool=' {0}'.format(zpool) if zpool else ''
+    # NOTE: remove 'frags' if we don't have feature flags
+    if not __utils__['zfs.has_feature_flags']():
+        while 'frag' in properties:
+            properties.remove('frag')
+
+    ## collect list output
+    res = __salt__['cmd.run_all'](
+        __utils__['zfs.zpool_command'](
+            command='list',
+            flags=['-H', '-p'],
+            opts={'-o': ','.join(properties)},
+            target=zpool
+        ),
+        python_shell=False,
     )
-    res = __salt__['cmd.run_all'](cmd, python_shell=False)
+
     if res['retcode'] != 0:
-        ret['error'] = res['stderr'] if 'stderr' in res else res['stdout']
-        return ret
+        return __utils__['zfs.parse_command_result'](res)
 
-    # parse zpool list data
-    for zp in res['stdout'].splitlines():
-        zp = zp.split("\t")
-        zp_data = {}
+    # NOTE: command output for reference
+    # ========================================================================
+    # data  1992864825344   695955501056    1296909324288   34  11%     ONLINE
+    # =========================================================================
 
-        for prop in properties:
-            zp_data[prop] = _conform_value(zp[properties.index(prop)])
+    ## parse list output
+    for line in res['stdout'].splitlines():
+        # NOTE: transform data into dict
+        zpool_data = OrderedDict(list(zip(
+            properties,
+            line.strip().split('\t'),
+        )))
 
-        ret[zp_data['name']] = zp_data
-        del ret[zp_data['name']]['name']
+        # NOTE: normalize values
+        if parsable:
+            # NOTE: raw numbers and pythonic types
+            zpool_data = __utils__['zfs.from_auto_dict'](zpool_data)
+        else:
+            # NOTE: human readable zfs types
+            zpool_data = __utils__['zfs.to_auto_dict'](zpool_data)
+
+        ret[zpool_data['name']] = zpool_data
+        del ret[zpool_data['name']]['name']
 
     return ret
 
 
-def get(zpool, prop=None, show_source=False, parsable=False):
+def get(zpool, prop=None, show_source=False, parsable=True):
     '''
-    .. versionadded:: 2016.3.0
-    .. versionchanged: Oxygen
-
     Retrieves the given list of properties
 
     zpool : string
@@ -392,8 +442,12 @@ def get(zpool, prop=None, show_source=False, parsable=False):
     show_source : boolean
         show source of property
     parsable : boolean
-        display numbers in parsable (exact) values
-        .. versionadded:: Oxygen
+        display data in pythonc values (True, False, Bytes,...)
+
+    .. versionadded:: 2016.3.0
+    .. versionchanged:: Fluorine
+
+        Added ```parsable``` parameter that defaults to True
 
     CLI Example:
 
@@ -402,45 +456,59 @@ def get(zpool, prop=None, show_source=False, parsable=False):
         salt '*' zpool.get myzpool
     '''
     ret = OrderedDict()
-    ret[zpool] = OrderedDict()
+    value_properties = ['property', 'value', 'source']
 
-    properties = 'property,value,source'.split(',')
-
-    # get zpool list data
-    zpool_cmd = _check_zpool()
-    cmd = '{zpool_cmd} get -H -o {properties}{parsable} {prop} {zpool}'.format(
-        zpool_cmd=zpool_cmd,
-        properties=','.join(properties),
-        parsable=' -p' if parsable else '',
-        prop=prop if prop else 'all',
-        zpool=zpool
+    ## collect get output
+    res = __salt__['cmd.run_all'](
+        __utils__['zfs.zpool_command'](
+            command='get',
+            flags=['-H', '-p'],
+            opts={'-o': ','.join(value_properties)},
+            property_name=prop if prop else 'all',
+            target=zpool,
+        ),
+        python_shell=False,
     )
-    res = __salt__['cmd.run_all'](cmd, python_shell=False)
+
     if res['retcode'] != 0:
-        ret['error'] = res['stderr'] if 'stderr' in res else res['stdout']
-        return ret
+        return __utils__['zfs.parse_command_result'](res)
 
-    # parse zpool list data
-    for zp in res['stdout'].splitlines():
-        zp = zp.split("\t")
-        zp_data = {}
+    # NOTE: command output for reference
+    # ========================================================================
+    # ...
+    # data  mountpoint  /data   local
+    # data  compression off     default
+    # ...
+    # =========================================================================
 
-        for prop in properties:
-            zp_data[prop] = _conform_value(zp[properties.index(prop)])
+    # parse get output
+    for line in res['stdout'].splitlines():
+        # NOTE: transform data into dict
+        prop_data = OrderedDict(list(zip(
+            value_properties,
+            [x for x in line.strip().split('\t') if x not in ['']],
+        )))
 
-        if show_source:
-            ret[zpool][zp_data['property']] = zp_data
-            del ret[zpool][zp_data['property']]['property']
+        # NOTE: normalize values
+        if parsable:
+            # NOTE: raw numbers and pythonic types
+            prop_data['value'] = __utils__['zfs.from_auto'](prop_data['property'], prop_data['value'])
         else:
-            ret[zpool][zp_data['property']] = zp_data['value']
+            # NOTE: human readable zfs types
+            prop_data['value'] = __utils__['zfs.to_auto'](prop_data['property'], prop_data['value'])
+
+        # NOTE: show source if requested
+        if show_source:
+            ret[prop_data['property']] = prop_data
+            del ret[prop_data['property']]['property']
+        else:
+            ret[prop_data['property']] = prop_data['value']
 
     return ret
 
 
 def set(zpool, prop, value):
     '''
-    .. versionadded:: 2016.3.0
-
     Sets the given property on the specified pool
 
     zpool : string
@@ -450,32 +518,28 @@ def set(zpool, prop, value):
     value : string
         value to set property to
 
+    .. versionadded:: 2016.3.0
+
     CLI Example:
 
     .. code-block:: bash
 
         salt '*' zpool.set myzpool readonly yes
     '''
-    ret = {}
-    ret[zpool] = {}
+    ret = OrderedDict()
 
-    # make sure value is what zfs expects
-    value = _conform_value(value)
-
-    # get zpool list data
-    zpool_cmd = _check_zpool()
-    cmd = '{zpool_cmd} set {prop}={value} {zpool}'.format(
-        zpool_cmd=zpool_cmd,
-        prop=prop,
-        value=value,
-        zpool=zpool
+    # set property
+    res = __salt__['cmd.run_all'](
+        __utils__['zfs.zpool_command'](
+            command='set',
+            property_name=prop,
+            property_value=value,
+            target=zpool,
+        ),
+        python_shell=False,
     )
-    res = __salt__['cmd.run_all'](cmd, python_shell=False)
-    if res['retcode'] != 0:
-        ret[zpool][prop] = res['stderr'] if 'stderr' in res else res['stdout']
-    else:
-        ret[zpool][prop] = value
-    return ret
+
+    return __utils__['zfs.parse_command_result'](res, 'set')
 
 
 def exists(zpool):
@@ -491,21 +555,22 @@ def exists(zpool):
 
         salt '*' zpool.exists myzpool
     '''
-    zpool_cmd = _check_zpool()
-    cmd = '{zpool_cmd} list {zpool}'.format(
-        zpool_cmd=zpool_cmd,
-        zpool=zpool
+    # list for zpool
+    # NOTE: retcode > 0 if zpool does not exists
+    res = __salt__['cmd.run_all'](
+        __utils__['zfs.zpool_command'](
+            command='list',
+            target=zpool,
+        ),
+        python_shell=False,
+        ignore_retcode=True,
     )
-    res = __salt__['cmd.run_all'](cmd, python_shell=False, ignore_retcode=True)
-    if res['retcode'] != 0:
-        return False
-    return True
+
+    return res['retcode'] == 0
 
 
 def destroy(zpool, force=False):
     '''
-    .. versionchanged:: 2016.3.0
-
     Destroys a storage pool
 
     zpool : string
@@ -513,38 +578,29 @@ def destroy(zpool, force=False):
     force : boolean
         force destroy of pool
 
+    .. versionchanged:: 2016.3.0
+
     CLI Example:
 
     .. code-block:: bash
 
         salt '*' zpool.destroy myzpool
     '''
-    ret = {}
-    ret[zpool] = {}
-    if not __salt__['zpool.exists'](zpool):
-        ret[zpool] = 'storage pool does not exist'
-    else:
-        zpool_cmd = _check_zpool()
-        cmd = '{zpool_cmd} destroy {force}{zpool}'.format(
-            zpool_cmd=zpool_cmd,
-            force='-f ' if force else '',
-            zpool=zpool
-        )
-        res = __salt__['cmd.run_all'](cmd, python_shell=False)
-        if res['retcode'] != 0:
-            ret[zpool] = 'error destroying storage pool'
-            if 'stderr' in res and res['stderr'] != '':
-                ret[zpool] = res['stderr']
-        else:
-            ret[zpool] = 'destroyed'
+    # destroy zpool
+    res = __salt__['cmd.run_all'](
+        __utils__['zfs.zpool_command'](
+            command='destroy',
+            flags=['-f'] if force else None,
+            target=zpool,
+        ),
+        python_shell=False,
+    )
 
-    return ret
+    return __utils__['zfs.parse_command_result'](res, 'destroyed')
 
 
 def scrub(zpool, stop=False, pause=False):
     '''
-    .. versionchanged:: 2016.3.0
-
     Scrub a storage pool
 
     zpool : string
@@ -558,6 +614,10 @@ def scrub(zpool, stop=False, pause=False):
         .. note::
 
             If both pause and stop are true, stop will win.
+            Pause support was added in this PR:
+            https://github.com/openzfs/openzfs/pull/407
+
+    .. versionchanged:: 2016.3.0
 
     CLI Example:
 
@@ -565,51 +625,37 @@ def scrub(zpool, stop=False, pause=False):
 
         salt '*' zpool.scrub myzpool
     '''
-    ret = {}
-    ret[zpool] = {}
-    if __salt__['zpool.exists'](zpool):
-        zpool_cmd = _check_zpool()
-        if stop:
-            action = '-s '
-        elif pause:
-            # NOTE: https://github.com/openzfs/openzfs/pull/407
-            action = '-p '
-        else:
-            action = ''
-        cmd = '{zpool_cmd} scrub {action}{zpool}'.format(
-            zpool_cmd=zpool_cmd,
-            action=action,
-            zpool=zpool
-        )
-        res = __salt__['cmd.run_all'](cmd, python_shell=False)
-        ret[zpool] = {}
-        if res['retcode'] != 0:
-            ret[zpool]['scrubbing'] = False
-            if 'stderr' in res:
-                if 'currently scrubbing' in res['stderr']:
-                    ret[zpool]['scrubbing'] = True
-                elif 'no active scrub' not in res['stderr']:
-                    ret[zpool]['error'] = res['stderr']
-            else:
-                ret[zpool]['error'] = res['stdout']
-        else:
-            if stop:
-                ret[zpool]['scrubbing'] = False
-            elif pause:
-                ret[zpool]['scrubbing'] = False
-            else:
-                ret[zpool]['scrubbing'] = True
+    ## select correct action
+    if stop:
+        action = ['-s']
+    elif pause:
+        action = ['-p']
     else:
-        ret[zpool] = 'storage pool does not exist'
+        action = None
 
+    ## Scrub storage pool
+    res = __salt__['cmd.run_all'](
+        __utils__['zfs.zpool_command'](
+            command='scrub',
+            flags=action,
+            target=zpool,
+        ),
+        python_shell=False,
+    )
+
+    if res['retcode'] != 0:
+        return __utils__['zfs.parse_command_result'](res, 'scrubbing')
+
+    ret = OrderedDict()
+    if stop or pause:
+        ret['scrubbing'] = False
+    else:
+        ret['scrubbing'] = True
     return ret
 
 
 def create(zpool, *vdevs, **kwargs):
     '''
-    .. versionadded:: 2015.5.0
-    .. versionchanged:: 2016.3.0
-
     Create a simple zpool, a mirrored zpool, a zpool having nested VDEVs, a hybrid zpool with cache, spare and log drives or a zpool with RAIDZ-1, RAIDZ-2 or RAIDZ-3
 
     zpool : string
@@ -629,6 +675,9 @@ def create(zpool, *vdevs, **kwargs):
     createboot : boolean
         ..versionadded:: Oxygen
         create a boot partition
+
+    .. versionadded:: 2015.5.0
+    .. versionchanged:: Fluorine
 
     CLI Example:
 
@@ -660,77 +709,55 @@ def create(zpool, *vdevs, **kwargs):
 
             salt '*' zpool.create myzpool /path/to/vdev1 [...] properties="{'property1': 'value1', 'property2': 'value2'}"
     '''
-    ret = {}
+    ## Configure pool
+    # NOTE: initialize the defaults
+    flags = []
+    opts = {}
+    target = []
 
-    # Check if the pool_name is already being used
-    if __salt__['zpool.exists'](zpool):
-        ret[zpool] = 'storage pool already exists'
-        return ret
+    # NOTE: push pool and filesystem properties
+    pool_properties = kwargs.get('properties', {})
+    filesystem_properties = kwargs.get('filesystem_properties', {})
 
-    if not vdevs:
-        ret[zpool] = 'no devices specified'
-        return ret
+    # NOTE: set extra config based on kwargs
+    if kwargs.get('force', False):
+        flags.append('-f')
+    if kwargs.get('createboot', False) or 'bootsize' in pool_properties:
+        flags.append('-B')
+    if kwargs.get('altroot', False):
+        opts['-R'] = kwargs.get('altroot')
+    if kwargs.get('mountpoint', False):
+        opts['-m'] = kwargs.get('mountpoint')
 
-    devs = ' '.join(vdevs)
-    zpool_cmd = _check_zpool()
-    force = kwargs.get('force', False)
-    altroot = kwargs.get('altroot', None)
-    createboot = kwargs.get('createboot', False)
-    mountpoint = kwargs.get('mountpoint', None)
-    properties = kwargs.get('properties', None)
-    filesystem_properties = kwargs.get('filesystem_properties', None)
-    cmd = '{0} create'.format(zpool_cmd)
+    # NOTE: append the pool name and specifications
+    target.append(zpool)
+    target.extend(vdevs)
 
-    # bootsize implies createboot
-    if properties and 'bootsize' in properties:
-        createboot = True
+    ## Create storage pool
+    res = __salt__['cmd.run_all'](
+        __utils__['zfs.zpool_command'](
+            command='create',
+            flags=flags,
+            opts=opts,
+            pool_properties=pool_properties,
+            filesystem_properties=filesystem_properties,
+            target=target,
+        ),
+        python_shell=False,
+    )
 
-    # make sure values are in the format zfs expects
-    if properties:
-        for prop in properties:
-            properties[prop] = _conform_value(properties[prop])
-
-    if filesystem_properties:
-        for prop in filesystem_properties:
-            filesystem_properties[prop] = _conform_value(filesystem_properties[prop])
-
-    # apply extra arguments from kwargs
-    if force:  # force creation
-        cmd = '{0} -f'.format(cmd)
-    if createboot:  # create boot paritition
-        cmd = '{0} -B'.format(cmd)
-    if properties:  # create "-o property=value" pairs
-        proplist = []
-        for prop in properties:
-            proplist.append('-o {0}={1}'.format(prop, properties[prop]))
-        cmd = '{0} {1}'.format(cmd, ' '.join(proplist))
-    if filesystem_properties:  # create "-O property=value" pairs
-        fsproplist = []
-        for prop in filesystem_properties:
-            fsproplist.append('-O {0}={1}'.format(prop, filesystem_properties[prop]))
-        cmd = '{0} {1}'.format(cmd, ' '.join(fsproplist))
-    if mountpoint:  # set mountpoint
-        cmd = '{0} -m {1}'.format(cmd, mountpoint)
-    if altroot:  # set altroot
-        cmd = '{0} -R {1}'.format(cmd, altroot)
-    cmd = '{0} {1} {2}'.format(cmd, zpool, devs)
-
-    # Create storage pool
-    res = __salt__['cmd.run_all'](cmd, python_shell=False)
-
-    # Check and see if the pools is available
-    if res['retcode'] != 0:
-        ret[zpool] = res['stderr'] if 'stderr' in res else res['stdout']
-    else:
-        ret[zpool] = 'created with {0}'.format(devs)
+    ret = __utils__['zfs.parse_command_result'](res, 'created')
+    if ret['created']:
+        ## NOTE: lookup zpool status for vdev config
+        ret['vdevs'] = _clean_vdev_config(
+            __salt__['zpool.status'](zpool=zpool)[zpool]['config'][zpool],
+        )
 
     return ret
 
 
 def add(zpool, *vdevs, **kwargs):
     '''
-    .. versionchanged:: 2016.3.0
-
     Add the specified vdev\'s to the given storage pool
 
     zpool : string
@@ -740,47 +767,49 @@ def add(zpool, *vdevs, **kwargs):
     force : boolean
         forces use of device
 
+    .. versionchanged:: Fluorine
+
     CLI Example:
 
     .. code-block:: bash
 
         salt '*' zpool.add myzpool /path/to/vdev1 /path/to/vdev2 [...]
     '''
-    ret = {}
+    ## Configure pool
+    # NOTE: initialize the defaults
+    flags = []
+    target = []
 
-    # check for pool
-    if not __salt__['zpool.exists'](zpool):
-        ret[zpool] = 'storage pool does not exist'
-        return ret
+    # NOTE: set extra config based on kwargs
+    if kwargs.get('force', False):
+        flags.append('-f')
 
-    if not vdevs:
-        ret[zpool] = 'no devices specified'
-        return ret
+    # NOTE: append the pool name and specifications
+    target.append(zpool)
+    target.extend(vdevs)
 
-    force = kwargs.get('force', False)
-    devs = ' '.join(vdevs)
-
-    # try and add watch out for mismatched replication levels
-    zpool_cmd = _check_zpool()
-    cmd = '{zpool_cmd} add {force}{zpool} {devs}'.format(
-        zpool_cmd=zpool_cmd,
-        force='-f ' if force else '',
-        zpool=zpool,
-        devs=devs
+    ## Update storage pool
+    res = __salt__['cmd.run_all'](
+        __utils__['zfs.zpool_command'](
+            command='add',
+            flags=flags,
+            target=target,
+        ),
+        python_shell=False,
     )
-    res = __salt__['cmd.run_all'](cmd, python_shell=False)
-    if res['retcode'] != 0:
-        ret[zpool] = res['stderr'] if 'stderr' in res else res['stdout']
-    else:
-        ret[zpool] = 'added {0}'.format(devs)
+
+    ret = __utils__['zfs.parse_command_result'](res, 'added')
+    if ret['added']:
+        ## NOTE: lookup zpool status for vdev config
+        ret['vdevs'] = _clean_vdev_config(
+            __salt__['zpool.status'](zpool=zpool)[zpool]['config'][zpool],
+        )
 
     return ret
 
 
 def attach(zpool, device, new_device, force=False):
     '''
-    .. versionchanged:: 2016.3.0
-
     Attach specified device to zpool
 
     zpool : string
@@ -792,61 +821,51 @@ def attach(zpool, device, new_device, force=False):
     force : boolean
         forces use of device
 
+    .. versionchanged:: 2016.3.0
+    .. versionchanged:: Fluorine
+
     CLI Example:
 
     .. code-block:: bash
 
         salt '*' zpool.attach myzpool /path/to/vdev1 /path/to/vdev2 [...]
     '''
-    ret = {}
-    dlist = []
+    ## Configure pool
+    # NOTE: initialize the defaults
+    flags = []
+    target = []
 
-    # check for pool
-    if not __salt__['zpool.exists'](zpool):
-        ret[zpool] = 'storage pool does not exist'
-        return ret
+    # NOTE: set extra config
+    if force:
+        flags.append('-f')
 
-    # check devices
-    ret[zpool] = {}
-    if not os.path.exists(device):
-        ret[zpool][device] = 'not present on filesystem'
-    else:
-        mode = os.stat(device).st_mode
-        if not stat.S_ISBLK(mode) and not stat.S_ISREG(mode):
-            ret[zpool][device] = 'not a block device, a file vdev or character special device'
-    if not os.path.exists(new_device):
-        ret[zpool][new_device] = 'not present on filesystem'
-    else:
-        mode = os.stat(new_device).st_mode
-        if not stat.S_ISBLK(mode) and not stat.S_ISREG(mode):
-            ret[zpool][new_device] = 'not a block device, a file vdev or character special device'
+    # NOTE: append the pool name and specifications
+    target.append(zpool)
+    target.append(device)
+    target.append(new_device)
 
-    if len(ret[zpool]) > 0:
-        return ret
-
-    # try and add watch out for mismatched replication levels
-    zpool_cmd = _check_zpool()
-    cmd = '{zpool_cmd} attach {force}{zpool} {device} {new_device}'.format(
-        zpool_cmd=zpool_cmd,
-        force='-f ' if force else '',
-        zpool=zpool,
-        device=device,
-        new_device=new_device
+    ## Update storage pool
+    res = __salt__['cmd.run_all'](
+        __utils__['zfs.zpool_command'](
+            command='attach',
+            flags=flags,
+            target=target,
+        ),
+        python_shell=False,
     )
-    res = __salt__['cmd.run_all'](cmd, python_shell=False)
-    if res['retcode'] != 0:
-        ret[zpool] = res['stderr'] if 'stderr' in res else res['stdout']
-    else:
-        ret[zpool] = {}
-        ret[zpool][new_device] = 'attached'
+
+    ret = __utils__['zfs.parse_command_result'](res, 'attached')
+    if ret['attached']:
+        ## NOTE: lookup zpool status for vdev config
+        ret['vdevs'] = _clean_vdev_config(
+            __salt__['zpool.status'](zpool=zpool)[zpool]['config'][zpool],
+        )
 
     return ret
 
 
 def detach(zpool, device):
     '''
-    .. versionchanged:: 2016.3.0
-
     Detach specified device to zpool
 
     zpool : string
@@ -854,47 +873,43 @@ def detach(zpool, device):
     device : string
         device to detach
 
+    .. versionchanged:: Fluorine
+
     CLI Example:
 
     .. code-block:: bash
 
         salt '*' zpool.detach myzpool /path/to/vdev1
     '''
-    ret = {}
-    dlist = []
-
-    # check for pool
-    if not __salt__['zpool.exists'](zpool):
-        ret[zpool] = 'storage pool does not exist'
-        return ret
-
-    # try and add watch out for mismatched replication levels
-    zpool_cmd = _check_zpool()
-    cmd = '{zpool_cmd} detach {zpool} {device}'.format(
-        zpool_cmd=zpool_cmd,
-        zpool=zpool,
-        device=device
+    ## Update storage pool
+    res = __salt__['cmd.run_all'](
+        __utils__['zfs.zpool_command'](
+            command='detach',
+            target=[zpool, device],
+        ),
+        python_shell=False,
     )
-    res = __salt__['cmd.run_all'](cmd, python_shell=False)
-    if res['retcode'] != 0:
-        ret[zpool] = res['stderr'] if 'stderr' in res else res['stdout']
-    else:
-        ret[zpool] = {}
-        ret[zpool][device] = 'detached'
+
+    ret = __utils__['zfs.parse_command_result'](res, 'detatched')
+    if ret['detatched']:
+        ## NOTE: lookup zpool status for vdev config
+        ret['vdevs'] = _clean_vdev_config(
+            __salt__['zpool.status'](zpool=zpool)[zpool]['config'][zpool],
+        )
 
     return ret
 
 
 def split(zpool, newzpool, **kwargs):
     '''
-    .. versionadded:: Oxygen
-
     Splits devices off pool creating newpool.
 
     .. note::
 
         All vdevs in pool must be mirrors.  At the time of the split,
         newpool will be a replica of pool.
+
+        After splitting, do not forget to import the new pool!
 
     zpool : string
         name of storage pool
@@ -906,6 +921,9 @@ def split(zpool, newzpool, **kwargs):
         sets altroot for newzpool
     properties : dict
         additional pool properties for newzpool
+
+    .. versionadded:: Oxygen
+    .. versionchanged:: Fluorine
 
     CLI Example:
 
@@ -928,48 +946,33 @@ def split(zpool, newzpool, **kwargs):
 
             salt '*' zpool.split datamirror databackup properties="{'readonly': 'on'}"
     '''
-    ret = {}
+    ## Configure pool
+    # NOTE: initialize the defaults
+    opts = {}
 
-    # Check if the pool_name is already being used
-    if __salt__['zpool.exists'](newzpool):
-        ret[newzpool] = 'storage pool already exists'
-        return ret
+    # NOTE: push pool and filesystem properties
+    pool_properties = kwargs.get('properties', {})
 
-    if not __salt__['zpool.exists'](zpool):
-        ret[zpool] = 'storage pool does not exists'
-        return ret
+    # NOTE: set extra config based on kwargs
+    if kwargs.get('altroot', False):
+        opts['-R'] = kwargs.get('altroot')
 
-    zpool_cmd = _check_zpool()
-    altroot = kwargs.get('altroot', None)
-    properties = kwargs.get('properties', None)
-    cmd = '{0} split'.format(zpool_cmd)
+    ## Split storage pool
+    res = __salt__['cmd.run_all'](
+        __utils__['zfs.zpool_command'](
+            command='split',
+            opts=opts,
+            pool_properties=pool_properties,
+            target=[zpool, newzpool],
+        ),
+        python_shell=False,
+    )
 
-    # apply extra arguments from kwargs
-    if properties:  # create "-o property=value" pairs
-        proplist = []
-        for prop in properties:
-            proplist.append('-o {0}={1}'.format(prop, _conform_value(properties[prop])))
-        cmd = '{0} {1}'.format(cmd, ' '.join(proplist))
-    if altroot:  # set altroot
-        cmd = '{0} -R {1}'.format(cmd, altroot)
-    cmd = '{0} {1} {2}'.format(cmd, zpool, newzpool)
-
-    # Create storage pool
-    res = __salt__['cmd.run_all'](cmd, python_shell=False)
-
-    # Check and see if the pools is available
-    if res['retcode'] != 0:
-        ret[newzpool] = res['stderr'] if 'stderr' in res else res['stdout']
-    else:
-        ret[newzpool] = 'split off from {}'.format(zpool)
-
-    return ret
+    return __utils__['zfs.parse_command_result'](res, 'split')
 
 
 def replace(zpool, old_device, new_device=None, force=False):
     '''
-    .. versionchanged:: 2016.3.0
-
     Replaces old_device with new_device.
 
     .. note::
@@ -988,53 +991,45 @@ def replace(zpool, old_device, new_device=None, force=False):
     force : boolean
         Forces use of new_device, even if its appears to be in use.
 
+    .. versionchanged:: Fluorine
+
     CLI Example:
 
     .. code-block:: bash
 
         salt '*' zpool.replace myzpool /path/to/vdev1 /path/to/vdev2
     '''
-    ret = {}
-    # Make sure pool is there
-    if not __salt__['zpool.exists'](zpool):
-        ret[zpool] = 'storage pool does not exist'
-        return ret
+    ## Configure pool
+    # NOTE: initialize the defaults
+    flags = []
+    target = []
 
-    # check devices
-    ret[zpool] = {}
-    if not new_device:  # if we have a new device, old_device is probably missing!
-        if not os.path.exists(old_device):
-            ret[zpool][old_device] = 'not present on filesystem'
-        else:
-            mode = os.stat(old_device).st_mode
-            if not stat.S_ISBLK(mode) and not stat.S_ISREG(mode):
-                ret[zpool][old_device] = 'not a block device, a file vdev or character special device'
+    # NOTE: set extra config
+    if force:
+        flags.append('-f')
 
-    if new_device:  # if we are replacing a device in the same slot, new device can be None
-        if not os.path.exists(new_device):
-            ret[zpool][new_device] = 'not present on filesystem'
-        else:
-            mode = os.stat(new_device).st_mode
-            if not stat.S_ISBLK(mode) and not stat.S_ISREG(mode):
-                ret[zpool][new_device] = 'not a block device, a file vdev or character special device'
+    # NOTE: append the pool name and specifications
+    target.append(zpool)
+    target.append(old_device)
+    if new_device:
+        target.append(new_device)
 
-    if len(ret[zpool]) > 0:
-        return ret
-
-    # Replace vdevs
-    zpool_cmd = _check_zpool()
-    cmd = '{zpool_cmd} replace {force}{zpool} {old_device}{new_device}'.format(
-        zpool_cmd=zpool_cmd,
-        zpool=zpool,
-        force='-f ' if force else '',
-        old_device=old_device,
-        new_device=' {0}'.format(new_device) if new_device else ''
+    ## Replace device
+    res = __salt__['cmd.run_all'](
+        __utils__['zfs.zpool_command'](
+            command='replace',
+            flags=flags,
+            target=target,
+        ),
+        python_shell=False,
     )
-    res = __salt__['cmd.run_all'](cmd, python_shell=False)
-    if res['retcode'] != 0:
-        ret[zpool] = res['stderr'] if 'stderr' in res else res['stdout']
-    else:
-        ret[zpool] = 'replaced {0} with {1}'.format(old_device, new_device)
+
+    ret = __utils__['zfs.parse_command_result'](res, 'replaced')
+    if ret['replaced']:
+        ## NOTE: lookup zpool status for vdev config
+        ret['vdevs'] = _clean_vdev_config(
+            __salt__['zpool.status'](zpool=zpool)[zpool]['config'][zpool],
+        )
 
     return ret
 
@@ -1042,58 +1037,61 @@ def replace(zpool, old_device, new_device=None, force=False):
 @salt.utils.decorators.path.which('mkfile')
 def create_file_vdev(size, *vdevs):
     '''
-    .. versionchanged:: 2016.3.0
-
     Creates file based ``virtual devices`` for a zpool
 
     ``*vdevs`` is a list of full paths for mkfile to create
+
+    .. versionchanged:: Fluorine
 
     CLI Example:
 
     .. code-block:: bash
 
-        salt '*' zpool.create_file_vdev 7g /path/to/vdev1 [/path/to/vdev2] [...]
+        salt '*' zpool.create_file_vdev 7G /path/to/vdev1 [/path/to/vdev2] [...]
 
     .. note::
 
         Depending on file size, the above command may take a while to return.
     '''
-    ret = {}
-    dlist = []
-    # Get file names to create
+    ret = OrderedDict()
+    err = OrderedDict()
+
+    _mkfile_cmd = salt.utils.path.which('mkfile')
     for vdev in vdevs:
-        # check if file is present if not add it
         if os.path.isfile(vdev):
             ret[vdev] = 'existed'
         else:
-            dlist.append(vdev)
-
-    mkfile = _check_mkfile()
-    cmd = [mkfile, '{0}'.format(size)]
-    cmd.extend(dlist)
-    __salt__['cmd.run_all'](cmd, python_shell=False)
-
-    # Makesure the files are there
-    for vdev in vdevs:
-        if not os.path.isfile(vdev):
-            ret[vdev] = 'failed'
-        else:
-            if vdev not in ret:
+            res = __salt__['cmd.run_all'](
+                '{mkfile} {size} {vdev}'.format(
+                    mkfile=_mkfile_cmd,
+                    size=size,
+                    vdev=vdev,
+                ),
+                python_shell=False,
+            )
+            if res['retcode'] != 0:
+                if 'stderr' in res and ':' in res['stderr']:
+                    ret[vdev] = 'failed'
+                    err[vdev] = ":".join(res['stderr'].strip().split(':')[1:])
+            else:
                 ret[vdev] = 'created'
+    if err:
+        ret['error'] = err
+
     return ret
 
 
 def export(*pools, **kwargs):
     '''
-    .. versionadded:: 2015.5.0
-    .. versionchanged:: 2016.3.0
-
     Export storage pools
 
     *pools : string
         one or more storage pools to export
     force : boolean
         force export of storage pools
+
+    .. versionadded:: 2015.5.0
+    .. versionchanged:: Fluorine
 
     CLI Example:
 
@@ -1102,39 +1100,33 @@ def export(*pools, **kwargs):
         salt '*' zpool.export myzpool ... [force=True|False]
         salt '*' zpool.export myzpool2 myzpool2 ... [force=True|False]
     '''
-    ret = {}
-    pool_present = []
-    if not pools:
-        ret['error'] = 'atleast one storage pool must be specified'
-        return ret
+    ## Configure pool
+    # NOTE: initialize the defaults
+    flags = []
+    targets = []
 
-    for pool in pools:
-        if not __salt__['zpool.exists'](pool):
-            ret[pool] = 'storage pool does not exist'
-        else:
-            pool_present.append(pool)
+    # NOTE: set extra config based on kwargs
+    if kwargs.get('force', False):
+        flags.append('-f')
 
-    zpool = _check_zpool()
-    force = kwargs.get('force', False)
-    for pool in pool_present:
-        if force is True:
-            cmd = '{0} export -f {1}'.format(zpool, pool)
-        else:
-            cmd = '{0} export {1}'.format(zpool, pool)
-        res = __salt__['cmd.run_all'](cmd, ignore_retcode=True)
-        if res['retcode'] != 0:
-            ret[pool] = res['stderr'] if 'stderr' in res else res['stdout']
-        else:
-            ret[pool] = 'exported'
+    # NOTE: append the pool name and specifications
+    targets = list(pools)
 
-    return ret
+    ## Export pools
+    res = __salt__['cmd.run_all'](
+        __utils__['zfs.zpool_command'](
+            command='export',
+            flags=flags,
+            target=targets,
+        ),
+        python_shell=False,
+    )
+
+    return __utils__['zfs.parse_command_result'](res, 'exported')
 
 
 def import_(zpool=None, new_name=None, **kwargs):
     '''
-    .. versionadded:: 2015.5.0
-    .. versionchanged:: 2016.3.0
-
     Import storage pools or list pools available for import
 
     zpool : string
@@ -1153,6 +1145,19 @@ def import_(zpool=None, new_name=None, **kwargs):
         import the pool without mounting any file systems.
     only_destroyed : boolean
         imports destroyed pools only. this also sets force=True.
+    recovery : bool|str
+        false: do not try to recovery broken pools
+        true: try to recovery the pool by rolling back the latest transactions
+        test: check if a pool can be recovered, but don't import it
+        nolog: allow import without log device, recent transactions might be lost
+
+        .. note::
+            If feature flags are not support this forced to the default of 'false'
+
+        .. warning::
+            When recovery is set to 'test' the result will be have imported set to True if the pool
+            can be imported. The pool might also be imported if the pool was not broken to begin with.
+
     properties : dict
         additional pool properties
 
@@ -1164,6 +1169,9 @@ def import_(zpool=None, new_name=None, **kwargs):
 
             properties="{'property1': 'value1', 'property2': 'value2'}"
 
+    .. versionadded:: 2015.5.0
+    .. versionchanged:: Fluorine
+
     CLI Example:
 
     .. code-block:: bash
@@ -1172,69 +1180,63 @@ def import_(zpool=None, new_name=None, **kwargs):
         salt '*' zpool.import myzpool [mynewzpool] [force=True|False]
         salt '*' zpool.import myzpool dir='/tmp'
     '''
-    ret = {}
+    ## Configure pool
+    # NOTE: initialize the defaults
+    flags = []
+    opts = {}
+    target = []
 
-    zpool_cmd = _check_zpool()
-    force = kwargs.get('force', False)
-    altroot = kwargs.get('altroot', None)
-    mntopts = kwargs.get('mntopts', None)
-    properties = kwargs.get('properties', None)
-    dirs = kwargs.get('dir', None)
-    no_mount = kwargs.get('no_mount', False)
-    only_destroyed = kwargs.get('only_destroyed', False)
-    cmd = '{0} import'.format(zpool_cmd)
+    # NOTE: push pool and filesystem properties
+    pool_properties = kwargs.get('properties', {})
 
-    # apply extra arguments from kwargs
-    if mntopts:  # set mountpoint
-        cmd = '{0} -o {1}'.format(cmd, mntopts)
-    if properties:  # create "-o property=value" pairs
-        optlist = []
-        for prop in properties:
-            if ' ' in properties[prop]:
-                value = "'{0}'".format(properties[prop])
-            else:
-                value = properties[prop]
-            optlist.append('-o {0}={1}'.format(prop, value))
-        opts = ' '.join(optlist)
-        cmd = '{0} {1}'.format(cmd, opts)
-    if dirs:  # append -d params
-        dirs = dirs.split(',')
-        for d in dirs:
-            cmd = '{0} -d {1}'.format(cmd, d)
-    if only_destroyed:  # only import destroyed pools (-D)
-        force = True
-        cmd = '{0} -D'.format(cmd)
-    if force:  # force import (-f)
-        cmd = '{0} -f'.format(cmd)
-    if no_mount:  # set no mount (-N)
-        cmd = '{0} -N'.format(cmd)
-    if altroot:  # set altroot
-        cmd = '{0} -R {1}'.format(cmd, altroot)
+    # NOTE: set extra config based on kwargs
+    if kwargs.get('force', False) or kwargs.get('only_destroyed', False):
+        flags.append('-f')
+    if kwargs.get('only_destroyed', False):
+        flags.append('-D')
+    if kwargs.get('no_mount', False):
+        flags.append('-N')
+    if kwargs.get('altroot', False):
+        opts['-R'] = kwargs.get('altroot')
+    if kwargs.get('mntopts', False):
+        # NOTE: -o is used for both mount options and pool properties!
+        #       ```-o nodevices,noexec,nosetuid,ro``` vs ```-o prop=val```
+        opts['-o'] = kwargs.get('mntopts')
+    if kwargs.get('dir', False):
+        opts['-d'] = kwargs.get('dir').split(',')
+    if kwargs.get('recovery', False) and __utils__['zfs.has_feature_flags']():
+        recovery = kwargs.get('recovery')
+        if recovery in [True, 'test']:
+            flags.append('-F')
+        if recovery == 'test':
+            flags.append('-n')
+        if recovery == 'nolog':
+            flags.append('-m')
 
-    cmd = '{cmd} {zpool}{new_name}'.format(
-        cmd=cmd,
-        zpool='{0}'.format(zpool) if zpool else '-a',
-        new_name=' {0}'.format(new_name) if zpool and new_name else ''
-    )
-    res = __salt__['cmd.run_all'](cmd, python_shell=False)
-    if res['retcode'] != 0 and res['stderr'] != '':
-        if zpool:
-            ret[zpool] = res['stderr'] if 'stderr' in res else res['stdout']
-        else:
-            ret['error'] = res['stderr'] if 'stderr' in res else res['stdout']
+    # NOTE: append the pool name and specifications
+    if zpool:
+        target.append(zpool)
+        target.append(new_name)
     else:
-        if zpool:
-            ret[zpool if not new_name else new_name] = 'imported' if __salt__['zpool.exists'](zpool if not new_name else new_name) else 'not found'
-        else:
-            ret = True
-    return ret
+        flags.append('-a')
+
+    ## Import storage pool
+    res = __salt__['cmd.run_all'](
+        __utils__['zfs.zpool_command'](
+            command='import',
+            flags=flags,
+            opts=opts,
+            pool_properties=pool_properties,
+            target=target,
+        ),
+        python_shell=False,
+    )
+
+    return __utils__['zfs.parse_command_result'](res, 'imported')
 
 
 def online(zpool, *vdevs, **kwargs):
     '''
-    .. versionadded:: 2015.5.0
-    .. versionchanged:: 2016.3.0
-
     Ensure that the specified devices are online
 
     zpool : string
@@ -1248,6 +1250,9 @@ def online(zpool, *vdevs, **kwargs):
             If the device is part of a mirror or raidz then all devices must be
             expanded before the new space will become available to the pool.
 
+    .. versionadded:: 2015.5.0
+    .. versionchanged:: Fluorine
+
     CLI Example:
 
     .. code-block:: bash
@@ -1255,43 +1260,46 @@ def online(zpool, *vdevs, **kwargs):
         salt '*' zpool.online myzpool /path/to/vdev1 [...]
 
     '''
-    ret = {}
-    dlist = []
+    ## Configure pool
+    # default options
+    flags = []
+    target = []
 
-    # Check if the pool_name exists
-    if not __salt__['zpool.exists'](zpool):
-        ret[zpool] = 'storage pool does not exist'
-        return ret
+    # set flags and options
+    if kwargs.get('expand', False):
+        flags.append('-e')
+    target.append(zpool)
+    if vdevs:
+        target.extend(vdevs)
 
-    if not vdevs:
-        ret[zpool] = 'no devices specified'
-        return ret
+    ## Configure pool
+    # NOTE: initialize the defaults
+    flags = []
+    target = []
 
-    # get expand option
-    expand = kwargs.get('expand', False)
+    # NOTE: set extra config based on kwargs
+    if kwargs.get('expand', False):
+        flags.append('-e')
 
-    devs = ' '.join(vdevs)
-    zpool_cmd = _check_zpool()
-    cmd = '{zpool_cmd} online {expand}{zpool} {devs}'.format(
-        zpool_cmd=zpool_cmd,
-        expand='-e ' if expand else '',
-        zpool=zpool,
-        devs=devs
+    # NOTE: append the pool name and specifications
+    target.append(zpool)
+    target.extend(vdevs)
+
+    ## Bring online device
+    res = __salt__['cmd.run_all'](
+        __utils__['zfs.zpool_command'](
+            command='online',
+            flags=flags,
+            target=target,
+        ),
+        python_shell=False,
     )
-    # Bring all specified devices online
-    res = __salt__['cmd.run_all'](cmd, python_shell=False)
-    if res['retcode'] != 0:
-        ret[zpool] = res['stderr'] if 'stderr' in res else res['stdout']
-    else:
-        ret[zpool] = 'onlined {0}'.format(devs)
-    return ret
+
+    return __utils__['zfs.parse_command_result'](res, 'onlined')
 
 
 def offline(zpool, *vdevs, **kwargs):
     '''
-    .. versionadded:: 2015.5.0
-    .. versionchanged:: 2016.3.0
-
     Ensure that the specified devices are offline
 
     .. warning::
@@ -1306,47 +1314,43 @@ def offline(zpool, *vdevs, **kwargs):
     temporary : boolean
         enable temporarily offline
 
+    .. versionadded:: 2015.5.0
+    .. versionchanged:: Fluorine
+
     CLI Example:
 
     .. code-block:: bash
 
         salt '*' zpool.offline myzpool /path/to/vdev1 [...] [temporary=True|False]
     '''
-    ret = {}
+    ## Configure pool
+    # NOTE: initialize the defaults
+    flags = []
+    target = []
 
-    # Check if the pool_name exists
-    if not __salt__['zpool.exists'](zpool):
-        ret[zpool] = 'storage pool does not exist'
-        return ret
+    # NOTE: set extra config based on kwargs
+    if kwargs.get('temporary', False):
+        flags.append('-t')
 
-    if not vdevs or len(vdevs) <= 0:
-        ret[zpool] = 'no devices specified'
-        return ret
+    # NOTE: append the pool name and specifications
+    target.append(zpool)
+    target.extend(vdevs)
 
-    # note: we don't check if the device exists
-    #   a device can be offlined until a replacement is available
-    ret[zpool] = {}
-    devs = ' '.join(vdevs)
-    zpool_cmd = _check_zpool()
-    cmd = '{zpool_cmd} offline {temp}{zpool} {devs}'.format(
-        zpool_cmd=zpool_cmd,
-        temp='-t ' if kwargs.get('temporary', False) else '',
-        zpool=zpool,
-        devs=devs
+    ## Take a device offline
+    res = __salt__['cmd.run_all'](
+        __utils__['zfs.zpool_command'](
+            command='offline',
+            flags=flags,
+            target=target,
+        ),
+        python_shell=False,
     )
-    # Bring all specified devices offline
-    res = __salt__['cmd.run_all'](cmd, python_shell=False)
-    if res['retcode'] != 0:
-        ret[zpool] = res['stderr'] if 'stderr' in res else res['stdout']
-    else:
-        ret[zpool] = 'offlined {0}'.format(devs)
-    return ret
+
+    return __utils__['zfs.parse_command_result'](res, 'offlined')
 
 
 def labelclear(device, force=False):
     '''
-    .. versionadded:: Oxygen
-
     Removes ZFS label information from the specified device
 
     .. warning::
@@ -1358,39 +1362,72 @@ def labelclear(device, force=False):
     force : boolean
         treat exported or foreign devices as inactive
 
+    .. versionadded:: Oxygen
+    .. versionchanged:: Fluorine
+
     CLI Example:
 
     .. code-block:: bash
 
         salt '*' zpool.labelclear /path/to/dev
     '''
-    ret = {}
-
-    zpool_cmd = _check_zpool()
-    cmd = '{zpool_cmd} labelclear {force}{device}'.format(
-        zpool_cmd=zpool_cmd,
-        force='-f ' if force else '',
-        device=device,
+    ## clear label for all specified device
+    res = __salt__['cmd.run_all'](
+        __utils__['zfs.zpool_command'](
+            command='labelclear',
+            flags=['-f'] if force else None,
+            target=device,
+        ),
+        python_shell=False,
     )
-    # Bring all specified devices offline
-    res = __salt__['cmd.run_all'](cmd, python_shell=False)
-    if res['retcode'] != 0:
-        ## NOTE: skip the "use '-f' hint"
-        res['stderr'] = res['stderr'].split("\n")
-        if len(res['stderr']) >= 1:
-            if res['stderr'][0].startswith("use '-f'"):
-                del res['stderr'][0]
-        res['stderr'] = "\n".join(res['stderr'])
-        ret[device] = res['stderr'] if 'stderr' in res and res['stderr'] else res['stdout']
-    else:
-        ret[device] = 'cleared'
-    return ret
+
+    return __utils__['zfs.parse_command_result'](res, 'labelcleared')
+
+
+def clear(zpool, device=None):
+    '''
+    Clears device errors in a pool.
+
+    .. warning::
+
+        The device must not be part of an active pool configuration.
+
+    zpool : string
+        name of storage pool
+    device : string
+        (optional) specific device to clear
+
+    .. versionadded:: Fluorine
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' zpool.clear mypool
+        salt '*' zpool.clear mypool /path/to/dev
+    '''
+    ## Configure pool
+    # NOTE: initialize the defaults
+    target = []
+
+    # NOTE: append the pool name and specifications
+    target.append(zpool)
+    target.append(device)
+
+    ## clear storage pool errors
+    res = __salt__['cmd.run_all'](
+        __utils__['zfs.zpool_command'](
+            command='clear',
+            target=target,
+        ),
+        python_shell=False,
+    )
+
+    return __utils__['zfs.parse_command_result'](res, 'cleared')
 
 
 def reguid(zpool):
     '''
-    .. versionadded:: 2016.3.0
-
     Generates a new unique identifier for the pool
 
     .. warning::
@@ -1400,36 +1437,36 @@ def reguid(zpool):
     zpool : string
         name of storage pool
 
+    .. versionadded:: 2016.3.0
+    .. versionchanged:: Fluorine
+
     CLI Example:
 
     .. code-block:: bash
 
         salt '*' zpool.reguid myzpool
     '''
-    ret = {}
-    ret[zpool] = {}
-
-    zpool_cmd = _check_zpool()
-    cmd = '{zpool_cmd} reguid {zpool}'.format(
-        zpool_cmd=zpool_cmd,
-        zpool=zpool
+    ## generate new GUID for pool
+    res = __salt__['cmd.run_all'](
+        __utils__['zfs.zpool_command'](
+            command='reguid',
+            target=zpool,
+        ),
+        python_shell=False,
     )
-    res = __salt__['cmd.run_all'](cmd, python_shell=False)
-    if res['retcode'] != 0:
-        ret[zpool] = res['stderr'] if 'stderr' in res and res['stderr'] != '' else res['stdout']
-    else:
-        ret[zpool] = 'reguided'
-    return ret
+
+    return __utils__['zfs.parse_command_result'](res, 'reguided')
 
 
 def reopen(zpool):
     '''
-    .. versionadded:: 2016.3.0
-
     Reopen all the vdevs associated with the pool
 
     zpool : string
         name of storage pool
+
+    .. versionadded:: 2016.3.0
+    .. versionchanged:: Fluorine
 
     CLI Example:
 
@@ -1437,26 +1474,20 @@ def reopen(zpool):
 
         salt '*' zpool.reopen myzpool
     '''
-    ret = {}
-    ret[zpool] = {}
-
-    zpool_cmd = _check_zpool()
-    cmd = '{zpool_cmd} reopen {zpool}'.format(
-        zpool_cmd=zpool_cmd,
-        zpool=zpool
+    ## reopen all devices fro pool
+    res = __salt__['cmd.run_all'](
+        __utils__['zfs.zpool_command'](
+            command='reopen',
+            target=zpool,
+        ),
+        python_shell=False,
     )
-    res = __salt__['cmd.run_all'](cmd, python_shell=False)
-    if res['retcode'] != 0:
-        ret[zpool] = res['stderr'] if 'stderr' in res and res['stderr'] != '' else res['stdout']
-    else:
-        ret[zpool] = 'reopened'
-    return ret
+
+    return __utils__['zfs.parse_command_result'](res, 'reopened')
 
 
 def upgrade(zpool=None, version=None):
     '''
-    .. versionadded:: 2016.3.0
-
     Enables all supported features on the given pool
 
     .. warning::
@@ -1469,38 +1500,42 @@ def upgrade(zpool=None, version=None):
     version : int
         version to upgrade to, if unspecified upgrade to the highest possible
 
+    .. versionadded:: 2016.3.0
+    .. versionchanged:: Fluorine
+
     CLI Example:
 
     .. code-block:: bash
 
         salt '*' zpool.upgrade myzpool
     '''
-    ret = {}
+    ## Configure pool
+    # NOTE: initialize the defaults
+    flags = []
+    opts = {}
 
-    zpool_cmd = _check_zpool()
-    cmd = '{zpool_cmd} upgrade {version}{zpool}'.format(
-        zpool_cmd=zpool_cmd,
-        version='-V {0} '.format(version) if version else '',
-        zpool=zpool if zpool else '-a'
+    # NOTE: set extra config
+    if version:
+        opts['-V'] = version
+    if not zpool:
+        flags.append('-a')
+
+    ## Upgrade pool
+    res = __salt__['cmd.run_all'](
+        __utils__['zfs.zpool_command'](
+            command='upgrade',
+            flags=flags,
+            opts=opts,
+            target=zpool,
+        ),
+        python_shell=False,
     )
-    res = __salt__['cmd.run_all'](cmd, python_shell=False)
-    if res['retcode'] != 0:
-        if zpool:
-            ret[zpool] = res['stderr'] if 'stderr' in res and res['stderr'] != '' else res['stdout']
-        else:
-            ret['error'] = res['stderr'] if 'stderr' in res and res['stderr'] != '' else res['stdout']
-    else:
-        if zpool:
-            ret[zpool] = 'upgraded to {0}'.format('version {0}'.format(version) if version else 'the highest supported version')
-        else:
-            ret = 'all pools upgraded to {0}'.format('version {0}'.format(version) if version else 'the highest supported version')
-    return ret
+
+    return __utils__['zfs.parse_command_result'](res, 'upgraded')
 
 
 def history(zpool=None, internal=False, verbose=False):
     '''
-    .. versionadded:: 2016.3.0
-
     Displays the command history of the specified pools or all pools if no pool is specified
 
     zpool : string
@@ -1510,37 +1545,51 @@ def history(zpool=None, internal=False, verbose=False):
     verbose : boolean
         toggle display of the user name, the hostname, and the zone in which the operation was performed
 
+    .. versionadded:: 2016.3.0
+    .. versionchanged:: Fluorine
+
     CLI Example:
 
     .. code-block:: bash
 
         salt '*' zpool.upgrade myzpool
     '''
-    ret = {}
+    ret = OrderedDict()
 
-    zpool_cmd = _check_zpool()
-    cmd = '{zpool_cmd} history {verbose}{internal}{zpool}'.format(
-        zpool_cmd=zpool_cmd,
-        verbose='-l ' if verbose else '',
-        internal='-i ' if internal else '',
-        zpool=zpool if zpool else ''
+    ## Configure pool
+    # NOTE: initialize the defaults
+    flags = []
+
+    # NOTE: set extra config
+    if verbose:
+        flags.append('-l')
+    if internal:
+        flags.append('-i')
+
+    ## Lookup history
+    res = __salt__['cmd.run_all'](
+        __utils__['zfs.zpool_command'](
+            command='history',
+            flags=flags,
+            target=zpool,
+        ),
+        python_shell=False,
     )
-    res = __salt__['cmd.run_all'](cmd, python_shell=False)
+
     if res['retcode'] != 0:
-        if zpool:
-            ret[zpool] = res['stderr'] if 'stderr' in res and res['stderr'] != '' else res['stdout']
-        else:
-            ret['error'] = res['stderr'] if 'stderr' in res and res['stderr'] != '' else res['stdout']
+        return __utils__['zfs.parse_command_result'](res)
     else:
         pool = 'unknown'
         for line in res['stdout'].splitlines():
             if line.startswith('History for'):
                 pool = line[13:-2]
-                ret[pool] = []
+                ret[pool] = OrderedDict()
             else:
                 if line == '':
                     continue
-                ret[pool].append(line)
+                log_timestamp = line[0:19]
+                log_command = line[20:]
+                ret[pool][log_timestamp] = log_command
 
     return ret
 

--- a/salt/modules/zpool.py
+++ b/salt/modules/zpool.py
@@ -617,7 +617,7 @@ def scrub(zpool, stop=False, pause=False):
         if true, cancel ongoing scrub
     pause : boolean
         if true, pause ongoing scrub
-        .. versionadded:: Oxygen
+        .. versionadded:: 2018.3.0
 
         .. note::
 
@@ -680,7 +680,7 @@ def create(zpool, *vdevs, **kwargs):
     filesystem_properties : dict
         additional filesystem properties
     createboot : boolean
-        ..versionadded:: Oxygen
+        ..versionadded:: 2018.3.0
         create a boot partition
 
     .. versionadded:: 2015.5.0
@@ -925,7 +925,7 @@ def split(zpool, newzpool, **kwargs):
     properties : dict
         additional pool properties for newzpool
 
-    .. versionadded:: Oxygen
+    .. versionadded:: 2018.3.0
 
     .. note::
 
@@ -1358,7 +1358,7 @@ def labelclear(device, force=False):
     force : boolean
         treat exported or foreign devices as inactive
 
-    .. versionadded:: Oxygen
+    .. versionadded:: 2018.3.0
 
     CLI Example:
 

--- a/salt/modules/zpool.py
+++ b/salt/modules/zpool.py
@@ -7,6 +7,11 @@ Module for running ZFS zpool command
 :maturity:      new
 :depends:       salt.utils.zfs
 :platform:      illumos,freebsd,linux
+
+.. versionchanged:: Fluorine
+  Big refactor to remove duplicate code, better type converions and improved
+  consistancy in output.
+
 '''
 from __future__ import absolute_import, print_function, unicode_literals
 
@@ -100,7 +105,6 @@ def status(zpool=None):
         optional name of storage pool
 
     .. versionadded:: 2016.3.0
-    .. versionchanged:: Fluorine
 
     CLI Example:
 
@@ -251,6 +255,7 @@ def iostat(zpool=None, sample_time=5, parsable=True):
     .. code-block:: bash
 
         salt '*' zpool.iostat myzpool
+
     '''
     ret = OrderedDict()
 
@@ -372,6 +377,7 @@ def list_(properties='size,alloc,free,cap,frag,health', zpool=None, parsable=Tru
         salt '*' zpool.list zpool=tank
         salt '*' zpool.list 'size,free'
         salt '*' zpool.list 'size,free' tank
+
     '''
     ret = OrderedDict()
 
@@ -454,6 +460,7 @@ def get(zpool, prop=None, show_source=False, parsable=True):
     .. code-block:: bash
 
         salt '*' zpool.get myzpool
+
     '''
     ret = OrderedDict()
     value_properties = ['property', 'value', 'source']
@@ -525,6 +532,7 @@ def set(zpool, prop, value):
     .. code-block:: bash
 
         salt '*' zpool.set myzpool readonly yes
+
     '''
     ret = OrderedDict()
 
@@ -554,6 +562,7 @@ def exists(zpool):
     .. code-block:: bash
 
         salt '*' zpool.exists myzpool
+
     '''
     # list for zpool
     # NOTE: retcode > 0 if zpool does not exists
@@ -578,13 +587,12 @@ def destroy(zpool, force=False):
     force : boolean
         force destroy of pool
 
-    .. versionchanged:: 2016.3.0
-
     CLI Example:
 
     .. code-block:: bash
 
         salt '*' zpool.destroy myzpool
+
     '''
     # destroy zpool
     res = __salt__['cmd.run_all'](
@@ -617,13 +625,12 @@ def scrub(zpool, stop=False, pause=False):
             Pause support was added in this PR:
             https://github.com/openzfs/openzfs/pull/407
 
-    .. versionchanged:: 2016.3.0
-
     CLI Example:
 
     .. code-block:: bash
 
         salt '*' zpool.scrub myzpool
+
     '''
     ## select correct action
     if stop:
@@ -677,17 +684,6 @@ def create(zpool, *vdevs, **kwargs):
         create a boot partition
 
     .. versionadded:: 2015.5.0
-    .. versionchanged:: Fluorine
-
-    CLI Example:
-
-    .. code-block:: bash
-
-        salt '*' zpool.create myzpool /path/to/vdev1 [...] [force=True|False]
-        salt '*' zpool.create myzpool mirror /path/to/vdev1 /path/to/vdev2 [...] [force=True|False]
-        salt '*' zpool.create myzpool raidz1 /path/to/vdev1 /path/to/vdev2 raidz2 /path/to/vdev3 /path/to/vdev4 /path/to/vdev5 [...] [force=True|False]
-        salt '*' zpool.create myzpool mirror /path/to/vdev1 [...] mirror /path/to/vdev2 /path/to/vdev3 [...] [force=True|False]
-        salt '*' zpool.create myhybridzpool mirror /tmp/file1 [...] log mirror /path/to/vdev1 [...] cache /path/to/vdev2 [...] spare /path/to/vdev3 [...] [force=True|False]
 
     .. note::
 
@@ -708,6 +704,17 @@ def create(zpool, *vdevs, **kwargs):
         .. code-block:: bash
 
             salt '*' zpool.create myzpool /path/to/vdev1 [...] properties="{'property1': 'value1', 'property2': 'value2'}"
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' zpool.create myzpool /path/to/vdev1 [...] [force=True|False]
+        salt '*' zpool.create myzpool mirror /path/to/vdev1 /path/to/vdev2 [...] [force=True|False]
+        salt '*' zpool.create myzpool raidz1 /path/to/vdev1 /path/to/vdev2 raidz2 /path/to/vdev3 /path/to/vdev4 /path/to/vdev5 [...] [force=True|False]
+        salt '*' zpool.create myzpool mirror /path/to/vdev1 [...] mirror /path/to/vdev2 /path/to/vdev3 [...] [force=True|False]
+        salt '*' zpool.create myhybridzpool mirror /tmp/file1 [...] log mirror /path/to/vdev1 [...] cache /path/to/vdev2 [...] spare /path/to/vdev3 [...] [force=True|False]
+
     '''
     ## Configure pool
     # NOTE: initialize the defaults
@@ -767,13 +774,12 @@ def add(zpool, *vdevs, **kwargs):
     force : boolean
         forces use of device
 
-    .. versionchanged:: Fluorine
-
     CLI Example:
 
     .. code-block:: bash
 
         salt '*' zpool.add myzpool /path/to/vdev1 /path/to/vdev2 [...]
+
     '''
     ## Configure pool
     # NOTE: initialize the defaults
@@ -821,14 +827,12 @@ def attach(zpool, device, new_device, force=False):
     force : boolean
         forces use of device
 
-    .. versionchanged:: 2016.3.0
-    .. versionchanged:: Fluorine
-
     CLI Example:
 
     .. code-block:: bash
 
         salt '*' zpool.attach myzpool /path/to/vdev1 /path/to/vdev2 [...]
+
     '''
     ## Configure pool
     # NOTE: initialize the defaults
@@ -873,13 +877,12 @@ def detach(zpool, device):
     device : string
         device to detach
 
-    .. versionchanged:: Fluorine
-
     CLI Example:
 
     .. code-block:: bash
 
         salt '*' zpool.detach myzpool /path/to/vdev1
+
     '''
     ## Update storage pool
     res = __salt__['cmd.run_all'](
@@ -923,14 +926,6 @@ def split(zpool, newzpool, **kwargs):
         additional pool properties for newzpool
 
     .. versionadded:: Oxygen
-    .. versionchanged:: Fluorine
-
-    CLI Example:
-
-    .. code-block:: bash
-
-        salt '*' zpool.split datamirror databackup
-        salt '*' zpool.split datamirror databackup altroot=/backup
 
     .. note::
 
@@ -945,6 +940,14 @@ def split(zpool, newzpool, **kwargs):
         .. code-block:: bash
 
             salt '*' zpool.split datamirror databackup properties="{'readonly': 'on'}"
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' zpool.split datamirror databackup
+        salt '*' zpool.split datamirror databackup altroot=/backup
+
     '''
     ## Configure pool
     # NOTE: initialize the defaults
@@ -991,13 +994,12 @@ def replace(zpool, old_device, new_device=None, force=False):
     force : boolean
         Forces use of new_device, even if its appears to be in use.
 
-    .. versionchanged:: Fluorine
-
     CLI Example:
 
     .. code-block:: bash
 
         salt '*' zpool.replace myzpool /path/to/vdev1 /path/to/vdev2
+
     '''
     ## Configure pool
     # NOTE: initialize the defaults
@@ -1041,8 +1043,6 @@ def create_file_vdev(size, *vdevs):
 
     ``*vdevs`` is a list of full paths for mkfile to create
 
-    .. versionchanged:: Fluorine
-
     CLI Example:
 
     .. code-block:: bash
@@ -1052,6 +1052,7 @@ def create_file_vdev(size, *vdevs):
     .. note::
 
         Depending on file size, the above command may take a while to return.
+
     '''
     ret = OrderedDict()
     err = OrderedDict()
@@ -1091,7 +1092,6 @@ def export(*pools, **kwargs):
         force export of storage pools
 
     .. versionadded:: 2015.5.0
-    .. versionchanged:: Fluorine
 
     CLI Example:
 
@@ -1099,6 +1099,7 @@ def export(*pools, **kwargs):
 
         salt '*' zpool.export myzpool ... [force=True|False]
         salt '*' zpool.export myzpool2 myzpool2 ... [force=True|False]
+
     '''
     ## Configure pool
     # NOTE: initialize the defaults
@@ -1170,7 +1171,6 @@ def import_(zpool=None, new_name=None, **kwargs):
             properties="{'property1': 'value1', 'property2': 'value2'}"
 
     .. versionadded:: 2015.5.0
-    .. versionchanged:: Fluorine
 
     CLI Example:
 
@@ -1179,6 +1179,7 @@ def import_(zpool=None, new_name=None, **kwargs):
         salt '*' zpool.import [force=True|False]
         salt '*' zpool.import myzpool [mynewzpool] [force=True|False]
         salt '*' zpool.import myzpool dir='/tmp'
+
     '''
     ## Configure pool
     # NOTE: initialize the defaults
@@ -1251,7 +1252,6 @@ def online(zpool, *vdevs, **kwargs):
             expanded before the new space will become available to the pool.
 
     .. versionadded:: 2015.5.0
-    .. versionchanged:: Fluorine
 
     CLI Example:
 
@@ -1315,13 +1315,13 @@ def offline(zpool, *vdevs, **kwargs):
         enable temporarily offline
 
     .. versionadded:: 2015.5.0
-    .. versionchanged:: Fluorine
 
     CLI Example:
 
     .. code-block:: bash
 
         salt '*' zpool.offline myzpool /path/to/vdev1 [...] [temporary=True|False]
+
     '''
     ## Configure pool
     # NOTE: initialize the defaults
@@ -1353,23 +1353,19 @@ def labelclear(device, force=False):
     '''
     Removes ZFS label information from the specified device
 
-    .. warning::
-
-        The device must not be part of an active pool configuration.
-
     device : string
-        device
+        device, must not be part of an active pool configuration.
     force : boolean
         treat exported or foreign devices as inactive
 
     .. versionadded:: Oxygen
-    .. versionchanged:: Fluorine
 
     CLI Example:
 
     .. code-block:: bash
 
         salt '*' zpool.labelclear /path/to/dev
+
     '''
     ## clear label for all specified device
     res = __salt__['cmd.run_all'](
@@ -1405,6 +1401,7 @@ def clear(zpool, device=None):
 
         salt '*' zpool.clear mypool
         salt '*' zpool.clear mypool /path/to/dev
+
     '''
     ## Configure pool
     # NOTE: initialize the defaults
@@ -1438,7 +1435,6 @@ def reguid(zpool):
         name of storage pool
 
     .. versionadded:: 2016.3.0
-    .. versionchanged:: Fluorine
 
     CLI Example:
 
@@ -1466,13 +1462,13 @@ def reopen(zpool):
         name of storage pool
 
     .. versionadded:: 2016.3.0
-    .. versionchanged:: Fluorine
 
     CLI Example:
 
     .. code-block:: bash
 
         salt '*' zpool.reopen myzpool
+
     '''
     ## reopen all devices fro pool
     res = __salt__['cmd.run_all'](
@@ -1490,24 +1486,24 @@ def upgrade(zpool=None, version=None):
     '''
     Enables all supported features on the given pool
 
-    .. warning::
-        Once this is done, the pool will no longer be accessible on systems that do not
-        support feature flags. See zpool-features(5) for details on compatibility with
-        systems that support feature flags, but do not support all features enabled on the pool.
-
     zpool : string
         optional storage pool, applies to all otherwize
     version : int
         version to upgrade to, if unspecified upgrade to the highest possible
 
     .. versionadded:: 2016.3.0
-    .. versionchanged:: Fluorine
+
+    .. warning::
+        Once this is done, the pool will no longer be accessible on systems that do not
+        support feature flags. See zpool-features(5) for details on compatibility with
+        systems that support feature flags, but do not support all features enabled on the pool.
 
     CLI Example:
 
     .. code-block:: bash
 
         salt '*' zpool.upgrade myzpool
+
     '''
     ## Configure pool
     # NOTE: initialize the defaults
@@ -1546,13 +1542,13 @@ def history(zpool=None, internal=False, verbose=False):
         toggle display of the user name, the hostname, and the zone in which the operation was performed
 
     .. versionadded:: 2016.3.0
-    .. versionchanged:: Fluorine
 
     CLI Example:
 
     .. code-block:: bash
 
         salt '*' zpool.upgrade myzpool
+
     '''
     ret = OrderedDict()
 

--- a/salt/states/zfs.py
+++ b/salt/states/zfs.py
@@ -921,7 +921,7 @@ def scheduled_snapshot(name, prefix, recursive=True, schedule=None):
         a schedule must be setup to automatically run the state. this means that if
         you run the state daily the hourly snapshot will only be made once per day!
 
-    .. versionchanged:: Oxygen
+    .. versionchanged:: 2018.3.0
 
         switched to localtime from gmtime so times now take into account timezones.
 

--- a/salt/states/zfs.py
+++ b/salt/states/zfs.py
@@ -9,6 +9,8 @@ States for managing zfs datasets
 
 .. versionadded:: 2016.3.0
 .. versionchanged:: Flourine
+  Big refactor to remove duplicate code, better type converions and improved
+  consistancy in output.
 
 .. code-block:: yaml
 
@@ -85,7 +87,6 @@ def _absent(name, dataset_type, force=False, recursive=False):
     recursive : boolean
         also destroy all the child datasets
 
-    .. versionchanged:: Flourine
     '''
     ret = {'name': name,
            'changes': {},
@@ -142,8 +143,6 @@ def filesystem_absent(name, force=False, recursive=False):
     recursive : boolean
         also destroy all the child datasets (zfs destroy -r)
 
-    .. versionchanged:: Flourine
-
     .. warning::
 
         If a volume with ``name`` exists, this state will succeed without
@@ -170,8 +169,6 @@ def volume_absent(name, force=False, recursive=False):
         try harder to destroy the dataset (zfs destroy -f)
     recursive : boolean
         also destroy all the child datasets (zfs destroy -r)
-
-    .. versionchanged:: Flourine
 
     .. warning::
 
@@ -200,7 +197,6 @@ def snapshot_absent(name, force=False, recursive=False):
     recursive : boolean
         also destroy all the child datasets (zfs destroy -r)
 
-    .. versionchanged:: Flourine
     '''
     if not __utils__['zfs.is_snapshot'](name):
         ret = {'name': name,
@@ -223,7 +219,6 @@ def bookmark_absent(name, force=False, recursive=False):
     recursive : boolean
         also destroy all the child datasets (zfs destroy -r)
 
-    .. versionchanged:: Flourine
     '''
     if not __utils__['zfs.is_bookmark'](name):
         ret = {'name': name,
@@ -246,7 +241,6 @@ def hold_absent(name, snapshot, recursive=False):
     recursive : boolean
         recursively releases a hold with the given tag on the snapshots of all descendent file systems.
 
-    .. versionchanged:: Flourine
     '''
     ret = {'name': name,
            'changes': {},
@@ -317,7 +311,6 @@ def hold_present(name, snapshot, recursive=False):
     recursive : boolean
         recursively add hold with the given tag on the snapshots of all descendent file systems.
 
-    .. versionchanged:: Flourine
     '''
     ret = {'name': name,
            'changes': {},
@@ -399,8 +392,6 @@ def _dataset_present(dataset_type, name, volume_size=None, sparse=False, create_
         name of snapshot to clone
     properties : dict
         additional zfs properties (-o)
-
-    .. versionchanged:: Flourine
 
     .. note::
         ``cloned_from`` is only use if the volume does not exist yet,
@@ -573,8 +564,6 @@ def filesystem_present(name, create_parent=False, properties=None, cloned_from=N
     properties : dict
         additional zfs properties (-o)
 
-    .. versionchanged:: Flourine
-
     .. note::
         ``cloned_from`` is only use if the filesystem does not exist yet,
         when ``cloned_from`` is set after the filesystem exists it will be ignored.
@@ -611,8 +600,6 @@ def volume_present(name, volume_size, sparse=False, create_parent=False, propert
     properties : dict
         additional zfs properties (-o)
 
-    .. versionchanged:: Flourine
-
     .. note::
         ``cloned_from`` is only use if the volume does not exist yet,
         when ``cloned_from`` is set after the volume exists it will be ignored.
@@ -648,7 +635,6 @@ def bookmark_present(name, snapshot):
     snapshot : string
         name of snapshot
 
-    .. versionchanged:: Flourine
     '''
     ret = {'name': name,
            'changes': {},
@@ -710,8 +696,6 @@ def snapshot_present(name, recursive=False, properties=None):
         recursively create snapshots of all descendent datasets
     properties : dict
         additional zfs properties (-o)
-
-    .. versionchanged:: Flourine
 
     .. note:
         Properties are only set at creation time
@@ -775,7 +759,6 @@ def promoted(name):
         only one dataset can be the origin,
         if you promote a clone the original will now point to the promoted dataset
 
-    .. versionchanged:: Flourine
     '''
     ret = {'name': name,
            'changes': {},
@@ -886,7 +869,7 @@ def _schedule_snapshot_prepare(dataset, prefix, snapshots):
             continue
 
         ## NOTE: figure out if we need the current hold on the new snapshot
-        if len(snapshots[hold]) > 0:
+        if snapshots[hold]:
             ## NOTE: extract datetime from snapshot name
             timestamp = datetime.strptime(
                 snapshots[hold][-1],
@@ -942,7 +925,6 @@ def scheduled_snapshot(name, prefix, recursive=True, schedule=None):
 
         switched to localtime from gmtime so times now take into account timezones.
 
-    .. versionchanged:: Flourine
     '''
     ret = {'name': name,
            'changes': {},

--- a/salt/states/zfs.py
+++ b/salt/states/zfs.py
@@ -1,13 +1,14 @@
 # -*- coding: utf-8 -*-
 '''
-Management zfs datasets
+States for managing zfs datasets
 
 :maintainer:    Jorge Schrauwen <sjorge@blackdot.be>
 :maturity:      new
-:depends:       zfs
+:depends:       salt.utils.zfs, salt.modules.zfs
 :platform:      smartos, illumos, solaris, freebsd, linux
 
 .. versionadded:: 2016.3.0
+.. versionchanged:: Flourine
 
 .. code-block:: yaml
 
@@ -44,30 +45,31 @@ from __future__ import absolute_import, unicode_literals, print_function
 
 # Import Python libs
 import logging
-from time import strftime, strptime, localtime
+from datetime import datetime
 
 # Import Salt libs
-from salt.modules.zfs import _conform_value
+from salt.utils.odict import OrderedDict
 
 log = logging.getLogger(__name__)
 
 # Define the state's virtual name
 __virtualname__ = 'zfs'
 
+# Compare modifiers for zfs.schedule_snapshot
+comp_hour = {'minute': 0}
+comp_day = {'minute': 0, 'hour': 0}
+comp_month = {'minute': 0, 'hour': 0, 'day': 1}
+comp_year = {'minute': 0, 'hour': 0, 'day': 1, 'month': 1}
+
 
 def __virtual__():
     '''
     Provides zfs state
     '''
-    if 'zfs.create' in __salt__:
-        return True
+    if __grains__['zfs_support']:
+        return __virtualname__
     else:
-        return (
-            False,
-            '{0} state module can only be loaded on illumos, Solaris, SmartOS, FreeBSD, Linux, ...'.format(
-                __virtualname__
-            )
-        )
+        return (False, "The zfs state cannot be loaded: zfs not supported")
 
 
 def _absent(name, dataset_type, force=False, recursive=False):
@@ -83,59 +85,48 @@ def _absent(name, dataset_type, force=False, recursive=False):
     recursive : boolean
         also destroy all the child datasets
 
+    .. versionchanged:: Flourine
     '''
-    dataset_type = dataset_type.lower()
     ret = {'name': name,
            'changes': {},
            'result': True,
            'comment': ''}
 
+    ## log configuration
+    dataset_type = dataset_type.lower()
     log.debug('zfs.%s_absent::%s::config::force = %s',
               dataset_type, name, force)
     log.debug('zfs.%s_absent::%s::config::recursive = %s',
               dataset_type, name, recursive)
 
-    # check name and type
-    if dataset_type not in ['filesystem', 'volume', 'snapshot', 'bookmark']:
-        ret['result'] = False
-        ret['comment'] = 'unknown dateset type: {0}'.format(dataset_type)
+    ## destroy dataset if needed
+    if __salt__['zfs.exists'](name, **{'type': dataset_type}):
+        ## NOTE: dataset found with the name and dataset_type
+        if not __opts__['test']:
+            mod_res = __salt__['zfs.destroy'](name, **{'force': force, 'recursive': recursive})
+        else:
+            mod_res = OrderedDict([('destroyed', True)])
 
-    if ret['result'] and dataset_type in ['snapshot'] and '@' not in name:
-        ret['result'] = False
-        ret['comment'] = 'invalid snapshot name: {0}'.format(name)
-
-    if ret['result'] and dataset_type in ['bookmark'] and '#' not in name:
-        ret['result'] = False
-        ret['comment'] = 'invalid bookmark name: {0}'.format(name)
-
-    if ret['result'] and dataset_type in ['filesystem', 'volume']:
-        if '@' in name or '#' in name:
-            ret['result'] = False
-            ret['comment'] = 'invalid filesystem or volume name: {0}'.format(name)
-
-    # check if dataset exists
-    if ret['result']:
-        if __salt__['zfs.exists'](name, **{'type': dataset_type}):  # we need to destroy it
-            result = {name: 'destroyed'}
-            if not __opts__['test']:
-                result = __salt__['zfs.destroy'](name, **{'force': force, 'recursive': recursive})
-
-            ret['result'] = name in result and result[name] == 'destroyed'
-            ret['changes'] = result if ret['result'] else {}
-            if ret['result']:
-                ret['comment'] = '{0} {1} was destroyed'.format(
-                    dataset_type,
-                    name
-                )
-            else:
-                ret['comment'] = 'failed to destroy {0}'.format(name)
-                if name in result:
-                    ret['comment'] = result[name]
-        else:  # dataset with type and name does not exist! (all good)
-            ret['comment'] = '{0} {1} is not present'.format(
+        ret['result'] = mod_res['destroyed']
+        if ret['result']:
+            ret['changes'][name] = 'destroyed'
+            ret['comment'] = '{0} {1} was destroyed'.format(
                 dataset_type,
-                name
+                name,
             )
+        else:
+            ret['comment'] = 'failed to destroy {0} {1}'.format(
+                dataset_type,
+                name,
+            )
+            if 'error' in mod_res:
+                ret['comment'] = mod_res['error']
+    else:
+        ## NOTE: no dataset found with name of the dataset_type
+        ret['comment'] = '{0} {1} is absent'.format(
+            dataset_type,
+            name
+        )
 
     return ret
 
@@ -151,13 +142,22 @@ def filesystem_absent(name, force=False, recursive=False):
     recursive : boolean
         also destroy all the child datasets (zfs destroy -r)
 
+    .. versionchanged:: Flourine
+
     .. warning::
 
         If a volume with ``name`` exists, this state will succeed without
         destroying the volume specified by ``name``. This module is dataset type sensitive.
 
     '''
-    return _absent(name, 'filesystem', force, recursive)
+    if not __utils__['zfs.is_dataset'](name):
+        ret = {'name': name,
+               'changes': {},
+               'result': False,
+               'comment': 'invalid dataset name: {0}'.format(name)}
+    else:
+        ret = _absent(name, 'filesystem', force, recursive)
+    return ret
 
 
 def volume_absent(name, force=False, recursive=False):
@@ -171,13 +171,22 @@ def volume_absent(name, force=False, recursive=False):
     recursive : boolean
         also destroy all the child datasets (zfs destroy -r)
 
+    .. versionchanged:: Flourine
+
     .. warning::
 
         If a filesystem with ``name`` exists, this state will succeed without
         destroying the filesystem specified by ``name``. This module is dataset type sensitive.
 
     '''
-    return _absent(name, 'volume', force, recursive)
+    if not __utils__['zfs.is_dataset'](name):
+        ret = {'name': name,
+               'changes': {},
+               'result': False,
+               'comment': 'invalid dataset name: {0}'.format(name)}
+    else:
+        ret = _absent(name, 'volume', force, recursive)
+    return ret
 
 
 def snapshot_absent(name, force=False, recursive=False):
@@ -190,8 +199,17 @@ def snapshot_absent(name, force=False, recursive=False):
         try harder to destroy the dataset (zfs destroy -f)
     recursive : boolean
         also destroy all the child datasets (zfs destroy -r)
+
+    .. versionchanged:: Flourine
     '''
-    return _absent(name, 'snapshot', force, recursive)
+    if not __utils__['zfs.is_snapshot'](name):
+        ret = {'name': name,
+               'changes': {},
+               'result': False,
+               'comment': 'invalid snapshot name: {0}'.format(name)}
+    else:
+        ret = _absent(name, 'snapshot', force, recursive)
+    return ret
 
 
 def bookmark_absent(name, force=False, recursive=False):
@@ -204,8 +222,17 @@ def bookmark_absent(name, force=False, recursive=False):
         try harder to destroy the dataset (zfs destroy -f)
     recursive : boolean
         also destroy all the child datasets (zfs destroy -r)
+
+    .. versionchanged:: Flourine
     '''
-    return _absent(name, 'bookmark', force, recursive)
+    if not __utils__['zfs.is_bookmark'](name):
+        ret = {'name': name,
+               'changes': {},
+               'result': False,
+               'comment': 'invalid bookmark name: {0}'.format(name)}
+    else:
+        ret = _absent(name, 'bookmark', force, recursive)
+    return ret
 
 
 def hold_absent(name, snapshot, recursive=False):
@@ -213,56 +240,68 @@ def hold_absent(name, snapshot, recursive=False):
     ensure hold is absent on the system
 
     name : string
-        name of holdt
+        name of hold
     snapshot : string
         name of snapshot
     recursive : boolean
         recursively releases a hold with the given tag on the snapshots of all descendent file systems.
+
+    .. versionchanged:: Flourine
     '''
     ret = {'name': name,
            'changes': {},
            'result': True,
            'comment': ''}
 
+    ## log configuration
     log.debug('zfs.hold_absent::%s::config::snapshot = %s',
               name, snapshot)
     log.debug('zfs.hold_absent::%s::config::recursive = %s',
               name, recursive)
 
-    # check name and type
-    if '@' not in snapshot:
+    ## check we have a snapshot/tag name
+    if not __utils__['zfs.is_snapshot'](snapshot):
         ret['result'] = False
         ret['comment'] = 'invalid snapshot name: {0}'.format(snapshot)
         return ret
 
-    if '@' in name or '#' in name:
+    if __utils__['zfs.is_snapshot'](name) or \
+       __utils__['zfs.is_bookmark'](name) or \
+       name == 'error':
         ret['result'] = False
         ret['comment'] = 'invalid tag name: {0}'.format(name)
         return ret
 
-    result = __salt__['zfs.holds'](snapshot)
-    if snapshot not in result:
-        ret['result'] = False
-        ret['comment'] = '{0} is probably not a snapshot'.format(snapshot)
-    else:
-        if snapshot in result[snapshot]:
-            ret['result'] = False
-            ret['comment'] = result[snapshot]
-        elif result[snapshot] == 'no holds' or name not in result[snapshot]:
-            ret['comment'] = 'hold {0} not present'.format(name)
+    ## release hold if required
+    holds = __salt__['zfs.holds'](snapshot)
+    if name in holds:
+        ## NOTE: hold found for snapshot, release it
+        if not __opts__['test']:
+            mod_res = __salt__['zfs.release'](name, snapshot, **{'recursive': recursive})
         else:
-            result = {snapshot: {name: 'released'}}
-            if not __opts__['test']:
-                result = __salt__['zfs.release'](name, snapshot, **{'recursive': recursive})
+            mod_res = OrderedDict([('released', True)])
 
-            ret['result'] = snapshot in result and name in result[snapshot]
-            if ret['result']:
-                ret['changes'] = result[snapshot]
-                ret['comment'] = 'hold {0} released'.format(name)
-            else:
-                ret['comment'] = 'failed to release {0}'.format(name)
-                if snapshot in result:
-                    ret['comment'] = result[snapshot]
+        ret['result'] = mod_res['released']
+        if ret['result']:
+            ret['changes'] = {snapshot: {name: 'released'}}
+            ret['comment'] = 'hold {0} released'.format(
+                name,
+            )
+        else:
+            ret['comment'] = 'failed to release hold {0}'.format(
+                name,
+            )
+            if 'error' in mod_res:
+                ret['comment'] = mod_res['error']
+    elif 'error' in holds:
+        ## NOTE: we have an error
+        ret['result'] = False
+        ret['comment'] = holds['error']
+    else:
+        ## NOTE: no hold found with name for snapshot
+        ret['comment'] = 'hold {0} is absent'.format(
+            name,
+        )
 
     return ret
 
@@ -277,172 +316,76 @@ def hold_present(name, snapshot, recursive=False):
         name of snapshot
     recursive : boolean
         recursively add hold with the given tag on the snapshots of all descendent file systems.
+
+    .. versionchanged:: Flourine
     '''
     ret = {'name': name,
            'changes': {},
            'result': True,
            'comment': ''}
 
+    ## log configuration
     log.debug('zfs.hold_present::%s::config::snapshot = %s',
               name, snapshot)
     log.debug('zfs.hold_present::%s::config::recursive = %s',
               name, recursive)
 
-    # check name and type
-    if '@' not in snapshot:
+    ## check we have a snapshot/tag name
+    if not __utils__['zfs.is_snapshot'](snapshot):
         ret['result'] = False
         ret['comment'] = 'invalid snapshot name: {0}'.format(snapshot)
         return ret
 
-    if '@' in name or '#' in name:
+    if __utils__['zfs.is_snapshot'](name) or \
+       __utils__['zfs.is_bookmark'](name) or \
+       name == 'error':
         ret['result'] = False
         ret['comment'] = 'invalid tag name: {0}'.format(name)
         return ret
 
-    result = __salt__['zfs.holds'](snapshot)
-    if snapshot not in result:
-        ret['result'] = False
-        ret['comment'] = '{0} is probably not a snapshot'.format(snapshot)
+    ## place hold if required
+    holds = __salt__['zfs.holds'](snapshot)
+    if name in holds:
+        ## NOTE: hold with name already exists for snapshot
+        ret['comment'] = 'hold {0} is present for {1}'.format(
+            name,
+            snapshot,
+        )
     else:
-        if snapshot in result[snapshot]:
-            ret['result'] = False
-            ret['comment'] = result[snapshot]
-        elif result[snapshot] == 'no holds' or name not in result[snapshot]:  # add hold
-            result = {snapshot: {name: 'held'}}
-            if not __opts__['test']:
-                result = __salt__['zfs.hold'](name, snapshot, **{'recursive': recursive})
-
-            ret['result'] = snapshot in result and name in result[snapshot]
-            if ret['result']:
-                ret['changes'] = result[snapshot]
-                ret['comment'] = 'hold {0} added to {1}'.format(name, snapshot)
-            else:
-                ret['comment'] = 'failed to add hold {0}'.format(name)
-                if snapshot in result:
-                    ret['comment'] = result[snapshot]
-        else:  # hold present
-            ret['comment'] = 'hold already exists'
-
-    return ret
-
-
-def filesystem_present(name, create_parent=False, properties=None, cloned_from=None):
-    '''
-    ensure filesystem exists and has properties set
-
-    name : string
-        name of filesystem
-    create_parent : boolean
-        creates all the non-existing parent datasets.
-        any property specified on the command line using the -o option is ignored.
-    cloned_from : string
-        name of snapshot to clone
-    properties : dict
-        additional zfs properties (-o)
-
-    .. note::
-        ``cloned_from`` is only use if the filesystem does not exist yet,
-        when ``cloned_from`` is set after the filesystem exists it will be ignored.
-
-    .. note::
-        Properties do not get cloned, if you specify the properties in the
-        state file they will be applied on a subsequent run.
-
-    '''
-    ret = {'name': name,
-           'changes': {},
-           'result': True,
-           'comment': ''}
-
-    # check params
-    if not properties:
-        properties = {}
-
-    log.debug('zfs.filesystem_present::%s::config::create_parent = %s',
-              name, create_parent)
-    log.debug('zfs.filesystem_present::%s::config::cloned_from = %s',
-              name, cloned_from)
-    log.debug('zfs.filesystem_present::%s::config::properties = %s',
-              name, properties)
-
-    for prop in properties:
-        properties[prop] = _conform_value(properties[prop], True)
-
-    if '@' in name or '#' in name:
-        ret['result'] = False
-        ret['comment'] = 'invalid filesystem or volume name: {0}'.format(name)
-        return ret
-
-    if cloned_from:
-        if '@' not in cloned_from:
-            ret['result'] = False
-            ret['comment'] = '{0} is not a snapshot'.format(cloned_from)
-            return ret
-
-        if not __salt__['zfs.exists'](cloned_from, **{'type': 'snapshot'}):
-            ret['result'] = False
-            ret['comment'] = 'snapshot {0} does not exist'.format(cloned_from)
-            return ret
-
-        cloned_parent = cloned_from[:cloned_from.index('@')]
-        if not __salt__['zfs.exists'](cloned_parent, **{'type': 'filesystem'}):
-            ret['result'] = False
-            ret['comment'] = 'snapshot {0} is not from a filesystem'.format(cloned_from)
-            return ret
-
-    if __salt__['zfs.exists'](name, **{'type': 'filesystem'}):  # update properties if needed
-        result = {}
-        if len(properties) > 0:
-            result = __salt__['zfs.get'](name, **{'properties': ','.join(properties.keys()), 'fields': 'value', 'depth': 1, 'parsable': True})
-
-        for prop in properties:
-            if properties[prop] != result[name][prop]['value']:
-                if name not in ret['changes']:
-                    ret['changes'][name] = {}
-                ret['changes'][name][prop] = properties[prop]
-
-        if len(ret['changes']) > 0:
-            if not __opts__['test']:
-                result = __salt__['zfs.set'](name, **ret['changes'][name])
-                if name not in result:
-                    ret['result'] = False
-                else:
-                    for prop in result[name]:
-                        if result[name][prop] != 'set':
-                            ret['result'] = False
-
-            if ret['result']:
-                ret['comment'] = 'filesystem {0} was updated'.format(name)
-            else:
-                ret['changes'] = {}
-                ret['comment'] = 'filesystem {0} failed to be updated'.format(name)
-        else:
-            ret['comment'] = 'filesystem {0} is up to date'.format(name)
-    else:  # create filesystem
-        result = {name: 'created'}
+        ## NOTE: no hold found with name for snapshot
         if not __opts__['test']:
-            if not cloned_from:
-                result = __salt__['zfs.create'](name, **{'create_parent': create_parent, 'properties': properties})
-            else:
-                result = __salt__['zfs.clone'](cloned_from, name, **{'create_parent': create_parent, 'properties': properties})
-
-        ret['result'] = name in result
-        if ret['result']:
-            ret['result'] = result[name] == 'created' or result[name].startswith('cloned')
-        if ret['result']:
-            ret['changes'][name] = properties if len(properties) > 0 else result[name]
-            ret['comment'] = 'filesystem {0} was created'.format(name)
+            mod_res = __salt__['zfs.hold'](name, snapshot, **{'recursive': recursive})
         else:
-            ret['comment'] = 'failed to create filesystem {0}'.format(name)
-            if name in result:
-                ret['comment'] = result[name]
+            mod_res = OrderedDict([('held', True)])
+
+        ret['result'] = mod_res['held']
+        if ret['result']:
+            ret['changes'] = OrderedDict([
+                (snapshot, OrderedDict([
+                    (name, 'held'),
+                ])),
+            ])
+            ret['comment'] = 'hold {0} added to {1}'.format(
+                name,
+                snapshot,
+            )
+        else:
+            ret['comment'] = 'failed to add hold {0} to {1}'.format(
+                name,
+                snapshot,
+            )
+            if 'error' in mod_res:
+                ret['comment'] = mod_res['error']
+
     return ret
 
 
-def volume_present(name, volume_size, sparse=False, create_parent=False, properties=None, cloned_from=None):
+def _dataset_present(dataset_type, name, volume_size=None, sparse=False, create_parent=False, properties=None, cloned_from=None):
     '''
-    ensure volume exists and has properties set
+    internal handler for filesystem_present/volume_present
 
+    dataset_type : string
+        volume or filesystem
     name : string
         name of volume
     volume_size : string
@@ -456,6 +399,8 @@ def volume_present(name, volume_size, sparse=False, create_parent=False, propert
         name of snapshot to clone
     properties : dict
         additional zfs properties (-o)
+
+    .. versionchanged:: Flourine
 
     .. note::
         ``cloned_from`` is only use if the volume does not exist yet,
@@ -477,98 +422,221 @@ def volume_present(name, volume_size, sparse=False, create_parent=False, propert
            'result': True,
            'comment': ''}
 
-    # check params
-    if not properties:
+    ## fallback dataset_type to filesystem if out of range
+    if dataset_type not in ['filesystem', 'volume']:
+        dataset_type = 'filesystem'
+
+    ## ensure properties are zfs values
+    if volume_size:
+        volume_size = __utils__['zfs.from_size'](volume_size)
+    if properties:
+        properties = __utils__['zfs.from_auto_dict'](properties)
+    elif properties is None:
         properties = {}
 
-    log.debug('zfs.volume_present::%s::config::volume_size = %s',
-              name, volume_size)
-    log.debug('zfs.volume_present::%s::config::sparse = %s',
-              name, sparse)
-    log.debug('zfs.volume_present::%s::config::create_parent = %s',
-              name, create_parent)
-    log.debug('zfs.volume_present::%s::config::cloned_from = %s',
-              name, cloned_from)
-    log.debug('zfs.volume_present::%s::config::properties = %s',
-              name, properties)
+    ## log configuration
+    log.debug('zfs.%s_present::%s::config::volume_size = %s',
+              dataset_type, name, volume_size)
+    log.debug('zfs.%s_present::%s::config::sparse = %s',
+              dataset_type, name, sparse)
+    log.debug('zfs.%s_present::%s::config::create_parent = %s',
+              dataset_type, name, create_parent)
+    log.debug('zfs.%s_present::%s::config::cloned_from = %s',
+              dataset_type, name, cloned_from)
+    log.debug('zfs.%s_present::%s::config::properties = %s',
+              dataset_type, name, properties)
 
-    volume_size = _conform_value(volume_size, True)
-    for prop in properties:
-        properties[prop] = _conform_value(properties[prop], True)
-
-    if '@' in name or '#' in name:
+    ## check we have valid filesystem name/volume name/clone snapshot
+    if not __utils__['zfs.is_dataset'](name):
         ret['result'] = False
-        ret['comment'] = 'invalid filesystem or volume name: {0}'.format(name)
+        ret['comment'] = 'invalid dataset name: {1}'.format(name)
         return ret
 
-    if cloned_from:
-        if '@' not in cloned_from:
-            ret['result'] = False
-            ret['comment'] = '{0} is not a snapshot'.format(cloned_from)
-            return ret
+    if cloned_from and not __utils__['zfs.is_snapshot'](cloned_from):
+        ret['result'] = False
+        ret['comment'] = '{0} is not a snapshot'.format(cloned_from)
+        return ret
 
-        if not __salt__['zfs.exists'](cloned_from, **{'type': 'snapshot'}):
-            ret['result'] = False
-            ret['comment'] = 'snapshot {0} does not exist'.format(cloned_from)
-            return ret
+    ## ensure dataset is in correct state
+    ## NOTE: update the dataset
+    if __salt__['zfs.exists'](name, **{'type': dataset_type}):
+        ## NOTE: fetch current volume properties
+        properties_current = __salt__['zfs.get'](
+            name,
+            fields='value',
+            depth=1,
+            parsable=True,
+        ).get(name, OrderedDict())
 
-        cloned_parent = cloned_from[:cloned_from.index('@')]
-        if not __salt__['zfs.exists'](cloned_parent, **{'type': 'volume'}):
-            ret['result'] = False
-            ret['comment'] = 'snapshot {0} is not from a volume'.format(cloned_from)
-            return ret
+        ## NOTE: add volsize to properties
+        if volume_size:
+            properties['volsize'] = volume_size
 
-    if __salt__['zfs.exists'](name, **{'type': 'volume'}):  # update properties if needed
-        properties['volsize'] = volume_size  # add volume_size to properties
-        result = __salt__['zfs.get'](name, **{'properties': ','.join(properties.keys()), 'fields': 'value', 'depth': 1, 'parsable': True})
-
+        ## NOTE: build list of properties to update
+        properties_update = []
         for prop in properties:
-            if properties[prop] != result[name][prop]['value']:
+            ## NOTE: skip unexisting properties
+            if prop not in properties_current:
+                log.warning('zfs.%s_present::%s::update - unknown property: %s',
+                    dataset_type, name, prop)
+                continue
+
+            ## NOTE: compare current and wanted value
+            if properties_current[prop]['value'] != properties[prop]:
+                properties_update.append(prop)
+
+        ## NOTE: update pool properties
+        for prop in properties_update:
+            if not __opts__['test']:
+                mod_res = __salt__['zfs.set'](name, **{prop: properties[prop]})
+            else:
+                mod_res = OrderedDict([('set', True)])
+
+            if mod_res['set']:
                 if name not in ret['changes']:
                     ret['changes'][name] = {}
                 ret['changes'][name][prop] = properties[prop]
-
-        if len(ret['changes']) > 0:
-            if not __opts__['test']:
-                result = __salt__['zfs.set'](name, **ret['changes'][name])
-                if name not in result:
-                    ret['result'] = False
-                else:
-                    for prop in result[name]:
-                        if result[name][prop] != 'set':
-                            ret['result'] = False
-
-            if ret['result']:
-                ret['comment'] = 'volume {0} was updated'.format(name)
             else:
-                ret['changes'] = {}
-                ret['comment'] = 'volume {0} failed to be updated'.format(name)
-        else:
-            ret['comment'] = 'volume {0} is up to date'.format(name)
-    else:  # create volume
-        result = {name: 'created'}
-        if not __opts__['test']:
-            if not cloned_from:
-                result = __salt__['zfs.create'](name, **{
-                    'volume_size': volume_size,
-                    'sparse': sparse,
-                    'create_parent': create_parent,
-                    'properties': properties
-                })
-            else:
-                result = __salt__['zfs.clone'](cloned_from, name, **{'create_parent': create_parent, 'properties': properties})
+                ret['result'] = False
+                if ret['comment'] == '':
+                    ret['comment'] = 'The following properties were not updated:'
+                ret['comment'] = '{0} {1}'.format(ret['comment'], prop)
 
-        ret['result'] = name in result
-        if ret['result']:
-            ret['result'] = result[name] == 'created' or result[name].startswith('cloned')
-        if ret['result']:
-            ret['changes'][name] = properties if len(properties) > 0 else result[name]
-            ret['comment'] = 'volume {0} was created'.format(name)
+        ## NOTE: update comment
+        if ret['result'] and name in ret['changes']:
+            ret['comment'] = '{0} {1} was updated'.format(dataset_type, name)
+        elif ret['result']:
+            ret['comment'] = '{0} {1} is uptodate'.format(dataset_type, name)
         else:
-            ret['comment'] = 'failed to create volume {0}'.format(name)
-            if name in result:
-                ret['comment'] = result[name]
+            ret['comment'] = '{0} {1} failed to be updated'.format(dataset_type, name)
+
+    ## NOTE: create or clone the dataset
+    else:
+        mod_res_action = 'cloned' if cloned_from else 'created'
+        if __opts__['test']:
+            ## NOTE: pretend to create/clone
+            mod_res = OrderedDict([
+                (mod_res_action, True),
+            ])
+        elif cloned_from:
+            ## NOTE: add volsize to properties
+            if volume_size:
+                properties['volsize'] = volume_size
+
+            ## NOTE: clone the dataset
+            mod_res = __salt__['zfs.clone'](cloned_from, name, **{
+                'create_parent': create_parent,
+                'properties': properties,
+            })
+        else:
+            ## NOTE: create the dataset
+            mod_res = __salt__['zfs.create'](name, **{
+                'create_parent': create_parent,
+                'properties': properties,
+                'volume_size': volume_size,
+                'sparse': sparse,
+            })
+
+        ret['result'] = mod_res[mod_res_action]
+        if ret['result']:
+            ret['changes'][name] = mod_res_action
+            if properties:
+                ret['changes'][name] = properties
+            ret['comment'] = '{0} {1} was {2}'.format(
+                dataset_type,
+                name,
+                mod_res_action,
+            )
+        else:
+            ret['comment'] = 'failed to {0} {1} {2}'.format(
+                mod_res_action[:-1],
+                dataset_type,
+                name,
+            )
+            if 'error' in mod_res:
+                ret['comment'] = mod_res['error']
+
     return ret
+
+
+def filesystem_present(name, create_parent=False, properties=None, cloned_from=None):
+    '''
+    ensure filesystem exists and has properties set
+
+    name : string
+        name of filesystem
+    create_parent : boolean
+        creates all the non-existing parent datasets.
+        any property specified on the command line using the -o option is ignored.
+    cloned_from : string
+        name of snapshot to clone
+    properties : dict
+        additional zfs properties (-o)
+
+    .. versionchanged:: Flourine
+
+    .. note::
+        ``cloned_from`` is only use if the filesystem does not exist yet,
+        when ``cloned_from`` is set after the filesystem exists it will be ignored.
+
+    .. note::
+        Properties do not get cloned, if you specify the properties in the
+        state file they will be applied on a subsequent run.
+
+    '''
+    return _dataset_present(
+        'filesystem',
+        name,
+        create_parent=create_parent,
+        properties=properties,
+        cloned_from=cloned_from,
+    )
+
+
+def volume_present(name, volume_size, sparse=False, create_parent=False, properties=None, cloned_from=None):
+    '''
+    ensure volume exists and has properties set
+
+    name : string
+        name of volume
+    volume_size : string
+        size of volume
+    sparse : boolean
+        create sparse volume
+    create_parent : boolean
+        creates all the non-existing parent datasets.
+        any property specified on the command line using the -o option is ignored.
+    cloned_from : string
+        name of snapshot to clone
+    properties : dict
+        additional zfs properties (-o)
+
+    .. versionchanged:: Flourine
+
+    .. note::
+        ``cloned_from`` is only use if the volume does not exist yet,
+        when ``cloned_from`` is set after the volume exists it will be ignored.
+
+    .. note::
+        Properties do not get cloned, if you specify the properties in the state file
+        they will be applied on a subsequent run.
+
+        ``volume_size`` is considered a property, so the volume's size will be
+        corrected when the properties get updated if it differs from the
+        original volume.
+
+        The sparse parameter is ignored when using ``cloned_from``.
+
+    '''
+    return _dataset_present(
+        'volume',
+        name,
+        volume_size,
+        sparse=sparse,
+        create_parent=create_parent,
+        properties=properties,
+        cloned_from=cloned_from,
+    )
 
 
 def bookmark_present(name, snapshot):
@@ -580,41 +648,55 @@ def bookmark_present(name, snapshot):
     snapshot : string
         name of snapshot
 
+    .. versionchanged:: Flourine
     '''
     ret = {'name': name,
            'changes': {},
            'result': True,
            'comment': ''}
 
+    ## log configuration
     log.debug('zfs.bookmark_present::%s::config::snapshot = %s',
               name, snapshot)
 
-    if '@' not in snapshot:
+    ## check we have valid snapshot/bookmark name
+    if not __utils__['zfs.is_snapshot'](snapshot):
         ret['result'] = False
-        ret['comment'] = '{0} is not a snapshot'.format(snapshot)
+        ret['comment'] = 'invalid snapshot name: {0}'.format(name)
         return ret
 
-    if '#' not in name:
-        if '/' not in name:
-            name = '{0}#{1}'.format(snapshot[:snapshot.index('@')], name)
-        else:
-            ret['result'] = False
-            ret['comment'] = '{0} is not a bookmark'.format(name)
-            return ret
+    if '#' not in name and '/' not in name:
+        ## NOTE: simple snapshot name
+        #        take the snapshot name and replace the snapshot but with the simple name
+        #        e.g. pool/fs@snap + bm --> pool/fs#bm
+        name = '{0}#{1}'.format(snapshot[:snapshot.index('@')], name)
+        ret['name'] = name
 
-    if __salt__['zfs.exists'](name, **{'type': 'bookmark'}):
-        ret['comment'] = 'bookmark already exists'
-    else:  # create bookmark
-        result = {snapshot: 'bookmarked'}
+    if not __utils__['zfs.is_bookmark'](name):
+        ret['result'] = False
+        ret['comment'] = 'invalid bookmark name: {0}'.format(name)
+        return ret
+
+    ## ensure bookmark exists
+    if not __salt__['zfs.exists'](name, **{'type': 'bookmark'}):
+        ## NOTE: bookmark the snapshot
         if not __opts__['test']:
-            result = __salt__['zfs.bookmark'](snapshot, name)
-
-        ret['result'] = snapshot in result and result[snapshot].startswith('bookmarked')
-        if ret['result']:
-            ret['changes'] = result
-            ret['comment'] = 'snapshot {0} was bookmarked as {1}'.format(snapshot, name)
+            mod_res = __salt__['zfs.bookmark'](snapshot, name)
         else:
-            ret['comment'] = 'failed to create bookmark {0}'.format(name)
+            mod_res = OrderedDict([('bookmarked', True)])
+
+        ret['result'] = mod_res['bookmarked']
+        if ret['result']:
+            ret['changes'][name] = snapshot
+            ret['comment'] = '{0} bookmarked as {1}'.format(snapshot, name)
+        else:
+            ret['comment'] = 'failed to bookmark {0}'.format(snapshot)
+            if 'error' in mod_res:
+                ret['comment'] = mod_res['error']
+    else:
+        ## NOTE: bookmark already exists
+        ret['comment'] = 'bookmark is present'
+
     return ret
 
 
@@ -629,6 +711,8 @@ def snapshot_present(name, recursive=False, properties=None):
     properties : dict
         additional zfs properties (-o)
 
+    .. versionchanged:: Flourine
+
     .. note:
         Properties are only set at creation time
 
@@ -638,38 +722,43 @@ def snapshot_present(name, recursive=False, properties=None):
            'result': True,
            'comment': ''}
 
-    # check params
-    if not properties:
-        properties = {}
-
+    ## log configuration
     log.debug('zfs.snapshot_present::%s::config::recursive = %s',
               name, recursive)
     log.debug('zfs.snapshot_present::%s::config::properties = %s',
               name, properties)
 
-    for prop in properties:
-        properties[prop] = _conform_value(properties[prop], True)
+    ## ensure properties are zfs values
+    if properties:
+        properties = __utils__['zfs.from_auto_dict'](properties)
 
-    if '@' not in name:
+    ## check we have valid snapshot name
+    if not __utils__['zfs.is_snapshot'](name):
         ret['result'] = False
         ret['comment'] = 'invalid snapshot name: {0}'.format(name)
         return ret
 
-    if __salt__['zfs.exists'](name, **{'type': 'snapshot'}):  # we are all good
-        ret['comment'] = 'snapshot already exists'
-    else:  # create snapshot
-        result = {name: 'snapshotted'}
+    ## ensure snapshot exits
+    if not __salt__['zfs.exists'](name, **{'type': 'snapshot'}):
+        ## NOTE: create the snapshot
         if not __opts__['test']:
-            result = __salt__['zfs.snapshot'](name, **{'recursive': recursive, 'properties': properties})
+            mod_res = __salt__['zfs.snapshot'](name, **{'recursive': recursive, 'properties': properties})
+        else:
+            mod_res = OrderedDict([('snapshotted', True)])
 
-        ret['result'] = name in result and result[name] == 'snapshotted'
+        ret['result'] = mod_res['snapshotted']
         if ret['result']:
-            ret['changes'][name] = properties if len(properties) > 0 else result[name]
+            ret['changes'][name] = 'snapshotted'
+            if properties:
+                ret['changes'][name] = properties
             ret['comment'] = 'snapshot {0} was created'.format(name)
         else:
             ret['comment'] = 'failed to create snapshot {0}'.format(name)
-            if name in result:
-                ret['comment'] = result[name]
+            if 'error' in mod_res:
+                ret['comment'] = mod_res['error']
+    else:
+        ## NOTE: snapshot already exists
+        ret['comment'] = 'snapshot is present'
 
     return ret
 
@@ -686,43 +775,145 @@ def promoted(name):
         only one dataset can be the origin,
         if you promote a clone the original will now point to the promoted dataset
 
+    .. versionchanged:: Flourine
     '''
     ret = {'name': name,
            'changes': {},
            'result': True,
            'comment': ''}
 
-    if '@' in name or '#' in name:
+    ## check we if we have a valid dataset name
+    if not __utils__['zfs.is_dataset'](name):
         ret['result'] = False
-        ret['comment'] = 'invalid filesystem or volume name: {0}'.format(name)
+        ret['comment'] = 'invalid dataset name: {0}'.format(name)
         return ret
 
-    if __salt__['zfs.exists'](name):
-        origin = '-'
-        if not __opts__['test']:
-            origin = __salt__['zfs.get'](name, **{'properties': 'origin', 'fields': 'value', 'parsable': True})[name]['origin']['value']
-
-        if origin == '-':
-            ret['comment'] = '{0} already promoted'.format(name)
-        else:
-            result = {name: 'promoted'}
-            if not __opts__['test']:
-                result = __salt__['zfs.promote'](name)
-
-            ret['result'] = name in result and result[name] == 'promoted'
-            ret['changes'] = result if ret['result'] else {}
-            if ret['result']:
-                ret['comment'] = '{0} was promoted'.format(name)
-            else:
-                ret['comment'] = 'failed to promote {0}'.format(name)
-                if name in result:
-                    ret['comment'] = result[name]
-
-    else:  # we don't have the dataset
+    ## ensure dataset is the primary instance
+    if not __salt__['zfs.exists'](name, **{'type': 'filesystem,volume'}):
+        ## NOTE: we don't have a dataset
         ret['result'] = False
         ret['comment'] = 'dataset {0} does not exist'.format(name)
+    else:
+        ## NOTE: check if we have a blank origin (-)
+        if __salt__['zfs.get'](name, **{'properties': 'origin', 'fields': 'value', 'parsable': True})[name]['origin']['value'] == '-':
+            ## NOTE: we're already promoted
+            ret['comment'] = '{0} already promoted'.format(name)
+        else:
+            ## NOTE: promote dataset
+            if not __opts__['test']:
+                mod_res = __salt__['zfs.promote'](name)
+            else:
+                mod_res = OrderedDict([('promoted', True)])
+
+            ret['result'] = mod_res['promoted']
+            if ret['result']:
+                ret['changes'][name] = 'promoted'
+                ret['comment'] = '{0} promoted'.format(name)
+            else:
+                ret['comment'] = 'failed to promote {0}'.format(name)
+                if 'error' in mod_res:
+                    ret['comment'] = mod_res['error']
 
     return ret
+
+
+def _schedule_snapshot_retrieve(dataset, prefix, snapshots):
+    '''
+    Update snapshots dict with current snapshots
+
+    dataset: string
+        name of filesystem or volume
+    prefix : string
+        prefix for the snapshots
+        e.g. 'test' will result in snapshots being named 'test-yyyymmdd_hhmm'
+    snapshots : OrderedDict
+        preseeded OrderedDict with configuration
+
+    '''
+    ## NOTE: retrieve all snapshots for the dataset
+    for snap in sorted(__salt__['zfs.list'](dataset, **{'recursive': True, 'depth': 1, 'type': 'snapshot'}).keys()):
+        ## NOTE: we only want the actualy name
+        ##       myzpool/data@zbck-20171201_000248 -> zbck-20171201_000248
+        snap_name = snap[snap.index('@')+1:]
+
+        ## NOTE: we only want snapshots matching our prefix
+        if not snap_name.startswith('{0}-'.format(prefix)):
+            continue
+
+        ## NOTE: retrieve the holds for this snapshot
+        snap_holds = __salt__['zfs.holds'](snap)
+
+        ## NOTE: this snapshot has no holds, eligable for pruning
+        if not snap_holds:
+            snapshots['_prunable'].append(snap)
+
+        ## NOTE: update snapshots based on holds (if any)
+        ##       we are only interested in the ones from our schedule
+        ##       if we find any others we skip them
+        for hold in snap_holds:
+            if hold in snapshots['_schedule'].keys():
+                snapshots[hold].append(snap)
+
+    return snapshots
+
+
+def _schedule_snapshot_prepare(dataset, prefix, snapshots):
+    '''
+    Update snapshots dict with info for a new snapshot
+
+    dataset: string
+        name of filesystem or volume
+    prefix : string
+        prefix for the snapshots
+        e.g. 'test' will result in snapshots being named 'test-yyyymmdd_hhmm'
+    snapshots : OrderedDict
+        preseeded OrderedDict with configuration
+
+    '''
+    ## NOTE: generate new snapshot name
+    snapshot_create_name = '{dataset}@{prefix}-{timestamp}'.format(
+        dataset=dataset,
+        prefix=prefix,
+        timestamp=datetime.now().strftime('%Y%m%d_%H%M%S')
+    )
+
+    ## NOTE: figure out if we need to create the snapshot
+    timestamp_now = datetime.now().replace(second=0, microsecond=0)
+    snapshots['_create'][snapshot_create_name] = []
+    for hold, hold_count in snapshots['_schedule'].items():
+        ## NOTE: skip hold if we don't keep snapshots for it
+        if hold_count == 0:
+            continue
+
+        ## NOTE: figure out if we need the current hold on the new snapshot
+        if len(snapshots[hold]) > 0:
+            ## NOTE: extract datetime from snapshot name
+            timestamp = datetime.strptime(
+                snapshots[hold][-1],
+                '{0}@{1}-%Y%m%d_%H%M%S'.format(dataset, prefix),
+            ).replace(second=0, microsecond=0)
+
+            ## NOTE: compare current timestamp to timestamp from snapshot
+            if hold == 'minute' and \
+                timestamp_now <= timestamp:
+                continue
+            elif hold == 'hour' and \
+                timestamp_now.replace(**comp_hour) <= timestamp.replace(**comp_hour):
+                continue
+            elif hold == 'day' and \
+                timestamp_now.replace(**comp_day) <= timestamp.replace(**comp_day):
+                continue
+            elif hold == 'month' and \
+                timestamp_now.replace(**comp_month) <= timestamp.replace(**comp_month):
+                continue
+            elif hold == 'year' and \
+                timestamp_now.replace(**comp_year) <= timestamp.replace(**comp_year):
+                continue
+
+        ## NOTE: add hold entry for snapshot
+        snapshots['_create'][snapshot_create_name].append(hold)
+
+    return snapshots
 
 
 def scheduled_snapshot(name, prefix, recursive=True, schedule=None):
@@ -733,7 +924,7 @@ def scheduled_snapshot(name, prefix, recursive=True, schedule=None):
         name of filesystem or volume
     prefix : string
         prefix for the snapshots
-        e.g. 'test' will result in snapshots being named 'test-YYYYMMDD_HHMM'
+        e.g. 'test' will result in snapshots being named 'test-yyyymmdd_hhmm'
     recursive : boolean
         create snapshots for all children also
     schedule : dict
@@ -751,187 +942,155 @@ def scheduled_snapshot(name, prefix, recursive=True, schedule=None):
 
         switched to localtime from gmtime so times now take into account timezones.
 
+    .. versionchanged:: Flourine
     '''
     ret = {'name': name,
            'changes': {},
            'result': True,
            'comment': ''}
 
-    ## parse parameters
-    # update default schedule
-    state_schedule = schedule if schedule else {}
-    schedule = {
-        'minute': 0,
-        'hour': 0,
-        'day': 0,
-        'month': 0,
-        'year': 0,
-    }
-    for hold in state_schedule:
-        if hold not in schedule:
-            del state_schedule[hold]
-    schedule.update(state_schedule)
-    # check name
-    if not __salt__['zfs.exists'](name, **{'type': 'filesystem'}) and not __salt__['zfs.exists'](name, **{'type': 'volume'}):
-        ret['comment'] = '{0} is not a filesystem or a volume or does not exist'.format(name)
+    ## initialize defaults
+    schedule_holds = ['minute', 'hour', 'day', 'month', 'year']
+    snapshots = OrderedDict([
+        ('_create', OrderedDict()),
+        ('_prunable', []),
+        ('_schedule', OrderedDict()),
+    ])
+
+    ## strict configuration validation
+    ## NOTE: we need a valid dataset
+    if not __utils__['zfs.is_dataset'](name):
         ret['result'] = False
-    # check prefix
+        ret['comment'] = 'invalid dataset name: {0}'.format(name)
+
+    if not __salt__['zfs.exists'](name, **{'type': 'filesystem,volume'}):
+        ret['comment'] = 'dataset {0} does not exist'.format(name)
+        ret['result'] = False
+
+    ## NOTE: prefix must be 4 or longer
     if not prefix or len(prefix) < 4:
         ret['comment'] = 'prefix ({0}) must be at least 4 long'.format(prefix)
         ret['result'] = False
-    # check schedule
-    snap_count = 0
-    for hold in schedule:
-        if not isinstance(schedule[hold], int):
-            ret['comment'] = 'schedule values must be integers'
-            ret['result'] = False
-            break
-        snap_count += schedule[hold]
-    if ret['result'] and snap_count == 0:
-        ret['comment'] = 'at least one snapshot must be schedule'
-        ret['result'] = False
 
-    # print debug info
+    ## NOTE: validate schedule
+    total_count = 0
+    for hold in schedule_holds:
+        snapshots[hold] = []
+        if hold not in schedule:
+            snapshots['_schedule'][hold] = 0
+        elif isinstance(schedule[hold], int):
+            snapshots['_schedule'][hold] = schedule[hold]
+        else:
+            ret['result'] = False
+            ret['comment'] = 'schedule value for {0} is not an integer'.format(
+                hold,
+            )
+            break
+        total_count += snapshots['_schedule'][hold]
+    if ret['result'] and total_count == 0:
+        ret['result'] = False
+        ret['comment'] = 'schedule is not valid, you need to keep atleast 1 snapshot'
+
+    ## NOTE: return if configuration is not valid
+    if not ret['result']:
+        return ret
+
+    ## retrieve existing snapshots
+    snapshots = _schedule_snapshot_retrieve(name, prefix, snapshots)
+
+    ## prepare snapshot
+    snapshots = _schedule_snapshot_prepare(name, prefix, snapshots)
+
+    ## log configuration
     log.debug('zfs.scheduled_snapshot::%s::config::recursive = %s',
               name, recursive)
     log.debug('zfs.scheduled_snapshot::%s::config::prefix = %s',
               name, prefix)
-    log.debug('zfs.scheduled_snapshot::%s::config::schedule = %s',
-              name, schedule)
+    log.debug('zfs.scheduled_snapshot::%s::snapshots = %s',
+              name, snapshots)
 
-    ## manage snapshots
-    if ret['result']:
-        # retreive snapshots
-        prunable = []
-        snapshots = {}
-        for key in schedule:
-            snapshots[key] = []
+    ## create snapshot(s)
+    for snapshot_name, snapshot_holds in snapshots['_create'].items():
+        ## NOTE: skip if new snapshot has no holds
+        if not snapshot_holds:
+            continue
 
-        for snap in sorted(__salt__['zfs.list'](name, **{'recursive': True, 'depth': 1, 'type': 'snapshot'}).keys()):
-            if '@' not in snap:
-                continue
+        ## NOTE: create snapshot
+        if not __opts__['test']:
+            mod_res = __salt__['zfs.snapshot'](snapshot_name, **{'recursive': recursive})
+        else:
+            mod_res = OrderedDict([('snapshotted', True)])
 
-            snap_name = snap[snap.index('@')+1:]
-            if snap_name.startswith('{0}-'.format(prefix)):
-                holds = __salt__['zfs.holds'](snap)
-                if snap not in holds or holds[snap] == 'no holds':
-                    prunable.append(snap)
-                    continue
-                for hold in holds[snap]:
-                    hold = hold.strip()
-                    if hold not in snapshots.keys():
-                        continue
-                    snapshots[hold].append(snap)
-        log.debug('zfs.scheduled_snapshot::%s::snapshots = %s',
-                  name, snapshots)
-
-        # create snapshot
-        needed_holds = []
-        current_timestamp = localtime()
-        for hold in snapshots:
-            # check if we need need to consider hold
-            if schedule[hold] == 0:
-                continue
-
-            # check we need a new snapshot for hold
-            if len(snapshots[hold]) > 0:
-                snapshots[hold].sort()
-                timestamp = strptime(snapshots[hold][-1], '{0}@{1}-%Y%m%d_%H%M%S'.format(name, prefix))
-                if hold == 'minute':
-                    if current_timestamp.tm_min <= timestamp.tm_min and \
-                       current_timestamp.tm_hour <= timestamp.tm_hour and \
-                       current_timestamp.tm_mday <= timestamp.tm_mday and \
-                       current_timestamp.tm_mon <= timestamp.tm_mon and \
-                       current_timestamp.tm_year <= timestamp.tm_year:
-                        continue
-                elif hold == 'hour':
-                    if current_timestamp.tm_hour <= timestamp.tm_hour and \
-                       current_timestamp.tm_mday <= timestamp.tm_mday and \
-                       current_timestamp.tm_mon <= timestamp.tm_mon and \
-                       current_timestamp.tm_year <= timestamp.tm_year:
-                        continue
-                elif hold == 'day':
-                    if current_timestamp.tm_mday <= timestamp.tm_mday and \
-                       current_timestamp.tm_mon <= timestamp.tm_mon and \
-                       current_timestamp.tm_year <= timestamp.tm_year:
-                        continue
-                elif hold == 'month':
-                    if current_timestamp.tm_mon <= timestamp.tm_mon and \
-                       current_timestamp.tm_year <= timestamp.tm_year:
-                        continue
-                elif hold == 'year':
-                    if current_timestamp.tm_year <= timestamp.tm_year:
-                        continue
+        if not mod_res['snapshotted']:
+            ret['result'] = False
+            ret['comment'] = 'error creating snapshot ({0})'.format(snapshot_name)
+        else:
+            ## NOTE: create holds (if we have a snapshot)
+            for hold in snapshot_holds:
+                if not __opts__['test']:
+                    mod_res = __salt__['zfs.hold'](hold, snapshot_name, **{'recursive': recursive})
                 else:
-                    log.debug('zfs.scheduled_snapshot::%s::hold_unknown = %s',
-                              name, hold)
+                    mod_res = OrderedDict([('held', True)])
 
-            # mark snapshot for hold as needed
-            needed_holds.append(hold)
-
-        snap_name = '{prefix}-{timestamp}'.format(
-            prefix=prefix,
-            timestamp=strftime('%Y%m%d_%H%M%S')
-        )
-        log.debug('zfs.scheduled_snapshot::%s::needed_holds = %s',
-                  name, needed_holds)
-        if len(needed_holds) > 0:
-            snap = '{dataset}@{snapshot}'.format(dataset=name, snapshot=snap_name)
-            res = __salt__['zfs.snapshot'](snap, **{'recursive': recursive})
-            if snap not in res or res[snap] != 'snapshotted':  # something went wrong!
-                ret['comment'] = 'error creating snapshot ({0})'.format(snap)
-                ret['result'] = False
-
-            for hold in needed_holds:
-                if not ret['result']:
-                    continue  # skip if snapshot failed
-                res = __salt__['zfs.hold'](hold, snap, **{'recursive': recursive})
-                if snap not in res or hold not in res[snap] or res[snap][hold] != 'held':
-                    ret['comment'] = "{0}error adding hold ({1}) to snapshot ({2})".format(
-                        "{0}\n".format(ret['comment']) if not ret['result'] else '',
+                if not mod_res['held']:
+                    ret['result'] = False
+                    ret['comment'] = "error adding hold ({0}) to snapshot ({1})".format(
                         hold,
-                        snap
+                        snapshot_name,
                     )
-                    ret['result'] = False
-                else:  # add new snapshot to lists (for pruning)
-                    snapshots[hold].append(snap)
+                    break
 
-            if ret['result']:
-                ret['comment'] = 'scheduled snapshots were updated'
-                ret['changes']['created'] = [snap]
-                ret['changes']['pruned'] = []
+                snapshots[hold].append(snapshot_name)
 
-        # prune snapshots
-        for hold in schedule:
-            if hold not in snapshots.keys():
-                continue
-            while len(snapshots[hold]) > schedule[hold]:
-                # pop oldest snapshot and release hold
-                snap = snapshots[hold].pop(0)
-                __salt__['zfs.release'](hold, snap, **{'recursive': recursive})
-                # check if snapshot is prunable
-                holds = __salt__['zfs.holds'](snap)
-                if snap not in holds or holds[snap] == 'no holds':
-                    prunable.append(snap)
+        if ret['result']:
+            ret['comment'] = 'scheduled snapshots updated'
+            if 'created' not in ret['changes']:
+                ret['changes']['created'] = []
+            ret['changes']['created'].append(snapshot_name)
 
-        if len(prunable) > 0:
-            for snap in prunable:  # destroy if hold free
-                res = __salt__['zfs.destroy'](snap, **{'recursive': recursive})
-                if snap not in res or res[snap] != 'destroyed':
-                    ret['comment'] = "{0}error prunding snapshot ({1})".format(
-                        "{0}\n".format(ret['comment']) if not ret['result'] else '',
-                        snap
-                    )
-                    ret['result'] = False
-                else:
-                    ret['comment'] = 'scheduled snapshots were updated'
-                    if 'created' not in ret['changes']:
-                        ret['changes']['created'] = []
-                    if 'pruned' not in ret['changes']:
-                        ret['changes']['pruned'] = []
-                    ret['changes']['pruned'].append(snap)
+    ## prune hold(s)
+    for hold, hold_count in snapshots['_schedule'].items():
+        while ret['result'] and len(snapshots[hold]) > hold_count:
+            ## NOTE: pop oldest snapshot
+            snapshot_name = snapshots[hold].pop(0)
 
-    if ret['result'] and ret['comment'] == '':
+            ## NOTE: release hold for snapshot
+            if not __opts__['test']:
+                mod_res = __salt__['zfs.release'](hold, snapshot_name, **{'recursive': recursive})
+            else:
+                mod_res = OrderedDict([('released', True)])
+
+            if not mod_res['released']:
+                ret['result'] = False
+                ret['comment'] = "error adding hold ({0}) to snapshot ({1})".format(
+                    hold,
+                    snapshot_name,
+                )
+
+            ## NOTE: mark as prunable
+            if not __salt__['zfs.holds'](snapshot_name):
+                snapshots['_prunable'].append(snapshot_name)
+
+    ## prune snapshot(s)
+    for snapshot_name in snapshots['_prunable']:
+        ## NOTE: destroy snapshot
+        if not __opts__['test']:
+            mod_res = __salt__['zfs.destroy'](snapshot_name, **{'recursive': recursive})
+        else:
+            mod_res = OrderedDict([('destroyed', True)])
+
+        if not mod_res['destroyed']:
+            ret['result'] = False
+            ret['comment'] = "error prunding snapshot ({1})".format(
+                snapshot_name,
+            )
+            break
+
+    if ret['result'] and snapshots['_prunable']:
+        ret['comment'] = 'scheduled snapshots updated'
+        ret['changes']['pruned'] = snapshots['_prunable']
+
+    if ret['result'] and not ret['changes']:
         ret['comment'] = 'scheduled snapshots are up to date'
 
     return ret

--- a/salt/states/zpool.py
+++ b/salt/states/zpool.py
@@ -1,13 +1,14 @@
 # -*- coding: utf-8 -*-
 '''
-Management zpool
+States for managing zpools
 
 :maintainer:    Jorge Schrauwen <sjorge@blackdot.be>
 :maturity:      new
-:depends:       zpool
+:depends:       salt.utils.zfs, salt.modules.zpool
 :platform:      smartos, illumos, solaris, freebsd, linux
 
 .. versionadded:: 2016.3.0
+.. versionchanged:: Flourine
 
 .. code-block:: yaml
 
@@ -23,12 +24,12 @@ Management zpool
         - properties:
             comment: salty storage pool
         - layout:
-            mirror-0:
-              /dev/disk0
-              /dev/disk1
-            mirror-1:
-              /dev/disk2
-              /dev/disk3
+            - mirror:
+              - /dev/disk0
+              - /dev/disk1
+            - mirror:
+              - /dev/disk2
+              - /dev/disk3
 
     partitionpool:
       zpool.present:
@@ -73,7 +74,6 @@ import logging
 
 # Import Salt libs
 from salt.utils.odict import OrderedDict
-from salt.modules.zpool import _conform_value
 
 log = logging.getLogger(__name__)
 
@@ -85,15 +85,83 @@ def __virtual__():
     '''
     Provides zpool state
     '''
-    if 'zpool.create' in __salt__:
-        return True
+    if __grains__['zfs_support']:
+        return __virtualname__
     else:
-        return (
-            False,
-            '{0} state module can only be loaded on illumos, Solaris, SmartOS, FreeBSD, Linux, ...'.format(
-                __virtualname__
-            )
-        )
+        return (False, "The zpool state cannot be loaded: zfs not supported")
+
+
+def _layout_to_vdev(layout, device_dir=None):
+    '''
+    Turn the layout data into usable vdevs spedcification
+
+    We need to support 2 ways of passing the layout:
+
+    .. code::
+        layout_new:
+          - mirror:
+            - disk0
+            - disk1
+          - mirror:
+            - disk2
+            - disk3
+
+    .. code:
+        layout_legacy:
+          mirror-0:
+            disk0
+            disk1
+          mirror-1:
+            disk2
+            disk3
+
+    '''
+    vdevs = []
+
+    # NOTE: check device_dir exists
+    if device_dir and not os.path.exists(device_dir):
+        device_dir = None
+
+    # NOTE: handle list of OrderedDicts (new layout)
+    if isinstance(layout, list):
+        # NOTE: parse each vdev as a tiny layout and just append
+        for vdev in layout:
+            if isinstance(vdev, OrderedDict):
+                vdevs.extend(_layout_to_vdev(vdev, device_dir))
+            else:
+                if device_dir and vdev[0] != '/':
+                    vdev = os.path.join(device_dir, vdev)
+                vdevs.append(vdev)
+
+    # NOTE: handle nested OrderedDict (legacy layout)
+    #       this is also used to parse the nested OrderedDicts
+    #       from the new layout
+    elif isinstance(layout, OrderedDict):
+        for vdev in layout:
+            # NOTE: extract the vdev type and disks in the vdev
+            vdev_type = vdev.split('-')[0]
+            vdev_disk = layout[vdev]
+
+            # NOTE: skip appending the dummy type 'disk'
+            if vdev_type != 'disk':
+                vdevs.append(vdev_type)
+
+            # NOTE: ensure the disks are a list (legacy layout are not)
+            if not isinstance(vdev_disk, list):
+                vdev_disk = vdev_disk.split(' ')
+
+            # NOTE: also append the actualy disks behind the type
+            #       also prepend device_dir to disks if required
+            for disk in vdev_disk:
+                if device_dir and disk[0] != '/':
+                    disk = os.path.join(device_dir, disk)
+                vdevs.append(disk)
+
+    # NOTE: we got invalid data for layout
+    else:
+        vdevs = None
+
+    return vdevs
 
 
 def present(name, properties=None, filesystem_properties=None, layout=None, config=None):
@@ -115,13 +183,34 @@ def present(name, properties=None, filesystem_properties=None, layout=None, conf
 
         The following configuration properties can be toggled in the config parameter.
           - import (true) - try to import the pool before creating it if absent
-          - import_dirs (None) - specify additional locations to scan for devices on import
-          - device_dir (None, SunOS=/dev/rdsk) - specify device directory to use if not absolute path
+          - import_dirs (None) - specify additional locations to scan for devices on import (comma-seperated)
+          - device_dir (None, SunOS=/dev/dsk, Linux=/dev) - specify device directory to prepend for none absolute device paths
           - force (false) - try to force the import or creation
 
     .. note::
 
-        Because ID's inside the layout dict must be unique they need to have a suffix.
+        It is no longer needed to give a unique name to each top-level vdev, the old
+        layout format is still supported but no longer recommended.
+
+        .. code-block:: yaml
+
+            - mirror:
+              - /tmp/vdisk3
+              - /tmp/vdisk2
+            - mirror:
+              - /tmp/vdisk0
+              - /tmp/vdisk1
+
+        The above yaml will always result in the following zpool create:
+
+        .. code-block:: bash
+
+            zpool create mypool mirror /tmp/vdisk3 /tmp/vdisk2 mirror /tmp/vdisk0 /tmp/vdisk1
+
+    .. warning::
+
+        The legacy format is also still supported but not recommended,
+        because ID's inside the layout dict must be unique they need to have a suffix.
 
         .. code-block:: yaml
 
@@ -132,22 +221,16 @@ def present(name, properties=None, filesystem_properties=None, layout=None, conf
               /tmp/vdisk0
               /tmp/vdisk1
 
-        The above yaml will always result in the following zpool create:
-
-        .. code-block:: bash
-
-            zpool create mypool mirror /tmp/vdisk3 /tmp/vdisk2 mirror /tmp/vdisk0 /tmp/vdisk1
-
     .. warning::
 
         Pay attention to the order of your dict!
 
         .. code-block:: yaml
 
-            mirror-0:
-              /tmp/vdisk0
-              /tmp/vdisk1
-            /tmp/vdisk2:
+            - mirror:
+              - /tmp/vdisk0
+              - /tmp/vdisk1
+            - /tmp/vdisk2
 
         The above will result in the following zpool create:
 
@@ -163,60 +246,123 @@ def present(name, properties=None, filesystem_properties=None, layout=None, conf
            'result': None,
            'comment': ''}
 
-    # config defaults
-    state_config = config if config else {}
-    config = {
+    ## config defaults
+    default_config = {
         'import': True,
         'import_dirs': None,
         'device_dir': None,
         'force': False
     }
     if __grains__['kernel'] == 'SunOS':
-        config['device_dir'] = '/dev/rdsk'
+        default_config['device_dir'] = '/dev/dsk'
     elif __grains__['kernel'] == 'Linux':
-        config['device_dir'] = '/dev'
-    config.update(state_config)
-    log.debug('zpool.present::%s::config - %s', name, config)
+        default_config['device_dir'] = '/dev'
 
-    # parse layout
-    if layout:
-        for root_dev in layout:
-            if root_dev.count('-') != 1:
-                continue
-            layout[root_dev] = layout[root_dev].keys() if isinstance(layout[root_dev], OrderedDict) else layout[root_dev].split(' ')
+    ## merge state config
+    if config:
+        default_config.update(config)
+    config = default_config
 
-        log.debug('zpool.present::%s::layout - %s', name, layout)
+    ## ensure properties are zfs values
+    if properties:
+        properties = __utils__['zfs.from_auto_dict'](properties)
+    if filesystem_properties:
+        filesystem_properties = __utils__['zfs.from_auto_dict'](filesystem_properties)
 
-    # ensure properties conform to the zfs parsable format
-    for prop in properties:
-        properties[prop] = _conform_value(properties[prop], True)
+    ## parse layout
+    vdevs = _layout_to_vdev(layout, config['device_dir'])
+    if vdevs:
+        vdevs.insert(0, name)
 
-    # ensure the pool is present
+    ## log configuration
+    log.debug('zpool.present::%s::config - %s',
+        name, config)
+    log.debug('zpool.present::%s::vdevs - %s',
+        name, vdevs)
+    log.debug('zpool.present::%s::properties -  %s',
+        name, properties)
+    log.debug('zpool.present::%s::filesystem_properties -  %s',
+        name, filesystem_properties)
+
+    ## ensure the pool is present
     ret['result'] = False
-    if __salt__['zpool.exists'](name):  # update
+
+    ## NOTE: don't do anything because this is a test
+    if __opts__['test']:
+        ret['result'] = True
+        if __salt__['zpool.exists'](name):
+            ret['changes'][name] = 'uptodate'
+        else:
+            ret['changes'][name] = 'imported' if config['import'] else 'created'
+        ret['comment'] = 'storage pool {0} was {1}'.format(name, ret['changes'][name])
+
+    ## NOTE: import or create the pool (at least try to anyway)
+    elif not __salt__['zpool.exists'](name):
+        ## NOTE: import pool
+        if config['import']:
+            mod_res = __salt__['zpool.import'](
+                name,
+                force=config['force'],
+                dir=config['import_dirs'],
+            )
+
+            ret['result'] = mod_res['imported']
+            if ret['result']:
+                ret['changes'][name] = 'imported'
+                ret['comment'] = 'storage pool {0} was imported'.format(name)
+
+        ## NOTE: create pool
+        if not ret['result'] and vdevs:
+            log.debug('zpool.present::%s::creating', name)
+
+            ## NOTE: execute zpool.create
+            mod_res = __salt__['zpool.create'](
+                *vdevs,
+                force=config['force'],
+                properties=properties,
+                filesystem_properties=filesystem_properties
+            )
+
+            ret['result'] = mod_res['created']
+            if ret['result']:
+                ret['changes'][name] = 'created'
+                ret['comment'] = 'storage pool {0} was created'.format(name)
+            elif 'error' in mod_res:
+                ret['comment'] = mod_res['error']
+            else:
+                ret['comment'] = 'could not create storage pool {0}'.format(name)
+
+        ## NOTE: give up, we cannot import the pool and we do not have a layout to create it
+        if not ret['result'] and not vdevs:
+            ret['comment'] = 'storage pool {0} was not imported, no (valid) layout specified for creation'.format(name)
+
+    ## NOTE: update pool
+    else:
         ret['result'] = True
 
-        # retrieve current properties
-        properties_current = __salt__['zpool.get'](name)[name]
+        ## NOTE: fetch current pool properties
+        properties_current = __salt__['zpool.get'](name, parsable=True)
 
-        # figure out if updates needed
+        ## NOTE: build list of properties to update
         properties_update = []
         for prop in properties:
+            ## NOTE: skip unexisting properties
             if prop not in properties_current:
+                log.warning('zpool.present::%s::update - unknown property: %s', name, prop)
                 continue
 
+            ## NOTE: compare current and wanted value
             if properties_current[prop] != properties[prop]:
                 properties_update.append(prop)
 
-        # update properties
+        ## NOTE: update pool properties
         for prop in properties_update:
             res = __salt__['zpool.set'](name, prop, properties[prop])
 
-            # check return
-            if name in res and prop in res[name] and res[name][prop] == properties[prop]:
+            if res['set']:
                 if name not in ret['changes']:
                     ret['changes'][name] = {}
-                ret['changes'][name].update(res[name])
+                ret['changes'][name][prop] = properties[prop]
             else:
                 ret['result'] = False
                 if ret['comment'] == '':
@@ -225,57 +371,6 @@ def present(name, properties=None, filesystem_properties=None, layout=None, conf
 
         if ret['result']:
             ret['comment'] = 'properties updated' if len(ret['changes']) > 0 else 'no update needed'
-
-    else:  # import or create
-        if config['import']:  # try import
-            log.debug('zpool.present::%s::importing', name)
-            ret['result'] = __salt__['zpool.import'](
-                name,
-                force=config['force'],
-                dir=config['import_dirs']
-            )
-            ret['result'] = ret['result'].get(name) == 'imported'
-            if ret['result']:
-                ret['changes'][name] = 'imported'
-                ret['comment'] = 'storage pool {0} was imported'.format(name)
-
-        if not ret['result']:  # create
-            if not layout:
-                ret['comment'] = 'storage pool {0} was not imported, no layout specified for creation'.format(name)
-            else:
-                log.debug('zpool.present::%s::creating', name)
-                if __opts__['test']:
-                    ret['result'] = True
-                else:
-                    # construct *vdev parameter for zpool.create
-                    params = []
-                    params.append(name)
-                    for root_dev in layout:
-                        if root_dev.count('-') == 1:  # special device
-                            # NOTE: accomidate non existing 'disk' vdev
-                            if root_dev.split('-')[0] != 'disk':
-                                params.append(root_dev.split('-')[0])  # add the type by stripping the ID
-                            for sub_dev in layout[root_dev]:  # add all sub devices
-                                if '/' not in sub_dev and config['device_dir'] and os.path.exists(config['device_dir']):
-                                    sub_dev = os.path.join(config['device_dir'], sub_dev)
-                                params.append(sub_dev)
-                        else:  # normal device
-                            if '/' not in root_dev and config['device_dir'] and os.path.exists(config['device_dir']):
-                                root_dev = os.path.join(config['device_dir'], root_dev)
-                            params.append(root_dev)
-
-                    # execute zpool.create
-                    ret['result'] = __salt__['zpool.create'](*params, force=config['force'], properties=properties, filesystem_properties=filesystem_properties)
-                    if ret['result'].get(name).startswith('created'):
-                        ret['result'] = True
-                    else:
-                        if ret['result'].get(name):
-                            ret['comment'] = ret['result'].get(name)
-                        ret['result'] = False
-
-                if ret['result']:
-                    ret['changes'][name] = 'created'
-                    ret['comment'] = 'storage pool {0} was created'.format(name)
 
     return ret
 
@@ -297,31 +392,36 @@ def absent(name, export=False, force=False):
            'result': None,
            'comment': ''}
 
-    # config defaults
-    log.debug('zpool.absent::%s::config::force = %s', name, force)
-    log.debug('zpool.absent::%s::config::export = %s', name, export)
+    ## log configuration
+    log.debug('zpool.absent::%s::config::force = %s',
+        name, force)
+    log.debug('zpool.absent::%s::config::export = %s',
+        name, export)
 
-    # ensure the pool is absent
+    ## ensure the pool is absent
     if __salt__['zpool.exists'](name):  # looks like we need to do some work
+        mod_res = {}
         ret['result'] = False
 
-        if export:  # try to export the zpool
-            if __opts__['test']:
-                ret['result'] = True
-            else:
-                ret['result'] = __salt__['zpool.export'](name, force=force)
-                ret['result'] = ret['result'].get(name) == 'exported'
+        # NOTE: handle test
+        if __opts__['test']:
+            ret['result'] = True
 
-        else:  # try to destroy the zpool
-            if __opts__['test']:
-                ret['result'] = True
-            else:
-                ret['result'] = __salt__['zpool.destroy'](name, force=force)
-                ret['result'] = ret['result'].get(name) == 'destroyed'
+        # NOTE: try to export the pool
+        elif export:
+            mod_res = __salt__['zpool.export'](name, force=force)
+            ret['result'] = mod_res['exported']
+
+        # NOTE: try to destroy the pool
+        else:
+            mod_res = __salt__['zpool.destroy'](name, force=force)
+            ret['result'] = mod_res['destroyed']
 
         if ret['result']:  # update the changes and comment
             ret['changes'][name] = 'exported' if export else 'destroyed'
             ret['comment'] = 'storage pool {0} was {1}'.format(name, ret['changes'][name])
+        elif 'error' in mod_res:
+            ret['comment'] = mod_res['error']
 
     else:  # we are looking good
         ret['result'] = True

--- a/salt/states/zpool.py
+++ b/salt/states/zpool.py
@@ -9,6 +9,8 @@ States for managing zpools
 
 .. versionadded:: 2016.3.0
 .. versionchanged:: Flourine
+  Big refactor to remove duplicate code, better type converions and improved
+  consistancy in output.
 
 .. code-block:: yaml
 
@@ -334,7 +336,7 @@ def present(name, properties=None, filesystem_properties=None, layout=None, conf
                 ret['comment'] = '{0} {1}'.format(ret['comment'], prop)
 
         if ret['result']:
-            ret['comment'] = 'properties updated' if len(ret['changes']) > 0 else 'no update needed'
+            ret['comment'] = 'properties updated' if ret['changes'] else 'no update needed'
 
     ## NOTE: import or create the pool (at least try to anyway)
     else:

--- a/salt/utils/zfs.py
+++ b/salt/utils/zfs.py
@@ -10,6 +10,7 @@ These functions are for dealing with type conversion and basic execution
 :platform:      illumos,freebsd,linux
 
 .. versionadded:: Fluorine
+
 '''
 
 # Import python libs
@@ -126,14 +127,14 @@ def _property_parse_cmd(cmd, alias=None):
         prop_data = prop_data.lower().split()
 
         # NOTE: skip empty lines
-        if len(prop_data) == 0:
+        if not prop_data:
             continue
         # NOTE: parse header
         elif prop_data[0] == 'property':
             prop_hdr = prop_data
             continue
         # NOTE: skip lines after data
-        elif len(prop_hdr) == 0 or prop_data[1] not in ['no', 'yes']:
+        elif not prop_hdr or prop_data[1] not in ['no', 'yes']:
             continue
 
         # NOTE: create property dict
@@ -580,6 +581,7 @@ def from_auto_dict(values, source='auto'):
 
     .. note::
         The key will be passed as the name
+
     '''
     for name, value in values.items():
         values[name] = from_auto(name, value, source)
@@ -702,7 +704,7 @@ def parse_command_result(res, label=None):
                 error = error.replace('-r', 'recursive=True')
             ret['error'].append(error)
 
-        if len(ret['error']):
+        if ret['error']:
             ret['error'] = "\n".join(ret['error'])
         else:
             del ret['error']

--- a/salt/utils/zfs.py
+++ b/salt/utils/zfs.py
@@ -23,7 +23,7 @@ from numbers import Number
 # Import salt libs
 from salt.utils.decorators import memoize as real_memoize
 from salt.utils.odict import OrderedDict
-import salt.utils.stringutils
+from salt.utils.stringutils import to_num as str_to_num
 import salt.modules.cmdmod
 
 # Import 3rd-party libs
@@ -415,7 +415,7 @@ def from_numeric(value):
     if value == 'none':
         value = None
     elif value:
-        value = salt.utils.stringutils.to_num(value)
+        value = str_to_num(value)
     return value
 
 

--- a/salt/utils/zfs.py
+++ b/salt/utils/zfs.py
@@ -1,0 +1,712 @@
+# -*- coding: utf-8 -*-
+'''
+Utility functions for zfs
+
+These functions are for dealing with type conversion and basic execution
+
+:maintainer:    Jorge Schrauwen <sjorge@blackdot.be>
+:maturity:      new
+:depends:       salt.utils.stringutils, salt.ext, salt.module.cmdmod
+:platform:      illumos,freebsd,linux
+
+.. versionadded:: Fluorine
+'''
+
+# Import python libs
+from __future__ import absolute_import, unicode_literals, print_function
+import os
+import re
+import math
+import logging
+from numbers import Number
+
+# Import salt libs
+from salt.utils.decorators import memoize as real_memoize
+from salt.utils.odict import OrderedDict
+import salt.utils.stringutils
+import salt.modules.cmdmod
+
+# Import 3rd-party libs
+from salt.ext.six.moves import zip
+
+# Size conversion data
+re_zfs_size = re.compile(r'^(\d+|\d+(?=\d*)\.\d+)([KkMmGgTtPpEe][Bb]?)$')
+zfs_size = ['K', 'M', 'G', 'T', 'P', 'E']
+
+log = logging.getLogger(__name__)
+
+
+def _check_retcode(cmd):
+    '''
+    Simple internal wrapper for cmdmod.retcode
+    '''
+    return salt.modules.cmdmod.retcode(cmd, output_loglevel='quiet', ignore_retcode=True) == 0
+
+
+def _exec(**kwargs):
+    '''
+    Simple internal wrapper for cmdmod.run
+    '''
+    if 'ignore_retcode' not in kwargs:
+        kwargs['ignore_retcode'] = True
+    if 'output_loglevel' not in kwargs:
+        kwargs['output_loglevel'] = 'quiet'
+    return salt.modules.cmdmod.run_all(**kwargs)
+
+
+def _merge_last(values, merge_after, merge_with=' '):
+    '''
+    Merge values all values after X into the last value
+    '''
+    if len(values) > merge_after:
+        values = values[0:(merge_after-1)] + [merge_with.join(values[(merge_after-1):])]
+
+    return values
+
+
+def _property_normalize_name(name):
+    '''
+    Normalizes property names
+    '''
+    if '@' in name:
+        name = name[:name.index('@')+1]
+    return name
+
+
+def _property_detect_type(name, values):
+    '''
+    Detect the datatype of a property
+    '''
+    value_type = 'str'
+    if values.startswith('on | off'):
+        value_type = 'bool'
+    elif values.startswith('yes | no'):
+        value_type = 'bool_alt'
+    elif values in ['<size>', '<size> | none']:
+        value_type = 'size'
+    elif values in ['<count>', '<count> | none', '<guid>']:
+        value_type = 'numeric'
+    elif name in ['sharenfs', 'sharesmb', 'canmount']:
+        value_type = 'bool'
+    elif name in ['version', 'copies']:
+        value_type = 'numeric'
+    return value_type
+
+
+def _property_create_dict(header, data):
+    '''
+    Create a property dict
+    '''
+    prop = dict(zip(header, _merge_last(data, len(header))))
+    prop['name'] = _property_normalize_name(prop['property'])
+    prop['type'] = _property_detect_type(prop['name'], prop['values'])
+    prop['edit'] = from_bool(prop['edit'])
+    if 'inherit' in prop:
+        prop['inherit'] = from_bool(prop['inherit'])
+    del prop['property']
+    return prop
+
+
+def _property_parse_cmd(cmd, alias=None):
+    '''
+    Parse output of zpool/zfs get command
+    '''
+    if not alias:
+        alias = {}
+    properties = {}
+
+    # NOTE: append get to command
+    if cmd[-3:] != 'get':
+        cmd += ' get'
+
+    # NOTE: parse output
+    prop_hdr = []
+    for prop_data in _exec(cmd=cmd)['stderr'].split('\n'):
+        # NOTE: make the line data more managable
+        prop_data = prop_data.lower().split()
+
+        # NOTE: skip empty lines
+        if len(prop_data) == 0:
+            continue
+        # NOTE: parse header
+        elif prop_data[0] == 'property':
+            prop_hdr = prop_data
+            continue
+        # NOTE: skip lines after data
+        elif len(prop_hdr) == 0 or prop_data[1] not in ['no', 'yes']:
+            continue
+
+        # NOTE: create property dict
+        prop = _property_create_dict(prop_hdr, prop_data)
+
+        # NOTE: add property to dict
+        properties[prop['name']] = prop
+        if prop['name'] in alias:
+            properties[alias[prop['name']]] = prop
+
+        # NOTE: cleanup some duplicate data
+        del prop['name']
+    return properties
+
+
+def _auto(direction, name, value, source='auto', convert_to_human=True):
+    '''
+    Internal magic for from_auto and to_auto
+    '''
+    # NOTE: check direction
+    if direction not in ['to', 'from']:
+        return value
+
+    # NOTE: collect property data
+    props = property_data_zpool()
+    if source == 'zfs':
+        props = property_data_zfs()
+    elif source == 'auto':
+        props.update(property_data_zfs())
+
+    # NOTE: figure out the conversion type
+    value_type = props[name]['type'] if name in props else 'str'
+
+    # NOTE: convert
+    if value_type == 'size' and direction == 'to':
+        return globals()['{}_{}'.format(direction, value_type)](value, convert_to_human)
+
+    return globals()['{}_{}'.format(direction, value_type)](value)
+
+
+@real_memoize
+def _zfs_cmd():
+    '''
+    Return the path of the zfs binary if present
+    '''
+    # Get the path to the zfs binary.
+    return salt.utils.path.which('zfs')
+
+
+@real_memoize
+def _zpool_cmd():
+    '''
+    Return the path of the zpool binary if present
+    '''
+    # Get the path to the zfs binary.
+    return salt.utils.path.which('zpool')
+
+
+def _command(source, command, flags=None, opts=None,
+             property_name=None, property_value=None,
+             filesystem_properties=None, pool_properties=None,
+             target=None):
+    '''
+    Build and properly escape a zfs command
+
+    .. note::
+
+        Input is not considered safe and will be passed through
+        to_auto(from_auto('input_here')), you do not need to do so
+        your self first.
+
+    '''
+    # NOTE: start with the zfs binary and command
+    cmd = []
+    cmd.append(_zpool_cmd() if source == 'zpool' else _zfs_cmd())
+    cmd.append(command)
+
+    # NOTE: append flags if we have any
+    if flags is None:
+        flags = []
+    for flag in flags:
+        cmd.append(flag)
+
+    # NOTE: append options
+    #       we pass through 'sorted' to garentee the same order
+    if opts is None:
+        opts = {}
+    for opt in sorted(opts):
+        if not isinstance(opts[opt], list):
+            opts[opt] = [opts[opt]]
+        for val in opts[opt]:
+            cmd.append(opt)
+            cmd.append(to_str(val))
+
+    # NOTE: append filesystem properties (really just options with a key/value)
+    #       we pass through 'sorted' to garentee the same order
+    if filesystem_properties is None:
+        filesystem_properties = {}
+    for fsopt in sorted(filesystem_properties):
+        cmd.append('-O' if source == 'zpool' else '-o')
+        cmd.append('{key}={val}'.format(
+            key=fsopt,
+            val=to_auto(fsopt, filesystem_properties[fsopt], source='zfs', convert_to_human=False),
+        ))
+
+    # NOTE: append pool properties (really just options with a key/value)
+    #       we pass through 'sorted' to garentee the same order
+    if pool_properties is None:
+        pool_properties = {}
+    for fsopt in sorted(pool_properties):
+        cmd.append('-o')
+        cmd.append('{key}={val}'.format(
+            key=fsopt,
+            val=to_auto(fsopt, pool_properties[fsopt], source='zpool', convert_to_human=False),
+        ))
+
+    # NOTE: append property and value
+    #       the set command takes a key=value pair, we need to support this
+    if property_name is not None:
+        if property_value is not None:
+            if not isinstance(property_name, list):
+                property_name = [property_name]
+            if not isinstance(property_value, list):
+                property_value = [property_value]
+            for key, val in zip(property_name, property_value):
+                cmd.append('{key}={val}'.format(
+                    key=key,
+                    val=to_auto(key, val, source=source, convert_to_human=False),
+                ))
+        else:
+            cmd.append(property_name)
+
+    # NOTE: append the target(s)
+    if target is not None:
+        if not isinstance(target, list):
+            target = [target]
+        for tgt in target:
+            # NOTE: skip None list items
+            #       we do not want to skip False and 0!
+            if tgt is None:
+                continue
+            cmd.append(to_str(tgt))
+
+    return ' '.join(cmd)
+
+
+@real_memoize
+def is_supported():
+    '''
+    Check the system for ZFS support
+    '''
+    # Check for supported platforms
+    # NOTE: ZFS on Windows is in development
+    # NOTE: ZFS on NetBSD is in development
+    on_supported_platform = False
+    if salt.utils.platform.is_sunos():
+        on_supported_platform = True
+    elif salt.utils.platform.is_freebsd() and _check_retcode('kldstat -q -m zfs'):
+        on_supported_platform = True
+    elif salt.utils.platform.is_linux() and os.path.exists('/sys/module/zfs'):
+        on_supported_platform = True
+    elif salt.utils.platform.is_linux() and salt.utils.path.which('zfs-fuse'):
+        on_supported_platform = True
+    elif salt.utils.platform.is_darwin() and \
+         os.path.exists('/Library/Extensions/zfs.kext') and \
+         os.path.exists('/dev/zfs'):
+        on_supported_platform = True
+
+    # Additional check for the zpool command
+    return (_zpool_cmd() and on_supported_platform) is True
+
+
+@real_memoize
+def has_feature_flags():
+    '''
+    Check if zpool-features is available
+    '''
+    # get man location
+    man = salt.utils.path.which('man')
+    return _check_retcode('{man} zpool-features'.format(
+        man=man
+    )) if man else False
+
+
+@real_memoize
+def property_data_zpool():
+    '''
+    Return a dict of zpool properties
+
+    .. note::
+
+        Each property will have an entry with the following info:
+            - edit : boolean - is this property editable after pool creation
+            - type : str - either bool, bool_alt, size, numeric, or string
+            - values : str - list of possible values
+
+    .. warning::
+
+        This data is probed from the output of 'zpool get' with some suplimental
+        data that is hardcoded. There is no better way to get this informatio aside
+        from reading the code.
+
+    '''
+    # NOTE: man page also mentions a few short forms
+    property_data = _property_parse_cmd(_zpool_cmd(), {
+        'allocated': 'alloc',
+        'autoexpand': 'expand',
+        'autoreplace': 'replace',
+        'listsnapshots': 'listsnaps',
+        'fragmentation': 'frag',
+    })
+
+    # NOTE: zpool status/iostat has a few extra fields
+    zpool_size_extra = [
+        'capacity-alloc', 'capacity-free',
+        'operations-read', 'operations-write',
+        'bandwith-read', 'bandwith-write',
+        'read', 'write',
+    ]
+    zpool_numeric_extra = [
+        'cksum', 'cap',
+    ]
+
+    for prop in zpool_size_extra:
+        property_data[prop] = {
+            'edit': False,
+            'type': 'size',
+            'values': '<size>',
+        }
+
+    for prop in zpool_numeric_extra:
+        property_data[prop] = {
+            'edit': False,
+            'type': 'numeric',
+            'values': '<count>',
+        }
+
+    return property_data
+
+
+@real_memoize
+def property_data_zfs():
+    '''
+    Return a dict of zfs properties
+
+    .. note::
+
+        Each property will have an entry with the following info:
+            - edit : boolean - is this property editable after pool creation
+            - inherit : boolean - is this property inheritable
+            - type : str - either bool, bool_alt, size, numeric, or string
+            - values : str - list of possible values
+
+    .. warning::
+
+        This data is probed from the output of 'zfs get' with some suplimental
+        data that is hardcoded. There is no better way to get this informatio aside
+        from reading the code.
+
+    '''
+    return _property_parse_cmd(_zfs_cmd(), {
+        'available': 'avail',
+        'logicalreferenced': 'lrefer.',
+        'logicalused': 'lused.',
+        'referenced': 'refer',
+        'volblocksize': 'volblock',
+        'compression': 'compress',
+        'readonly': 'rdonly',
+        'recordsize': 'recsize',
+        'refreservation': 'refreserv',
+        'reservation': 'reserv',
+    })
+
+
+def from_numeric(value):
+    '''
+    Convert zfs numeric to python int
+    '''
+    if value == 'none':
+        value = None
+    elif value:
+        value = salt.utils.stringutils.to_num(value)
+    return value
+
+
+def to_numeric(value):
+    '''
+    Convert python int to zfs numeric
+    '''
+    value = from_numeric(value)
+    if value is None:
+        value = 'none'
+    return value
+
+
+def from_bool(value):
+    '''
+    Convert zfs bool to python bool
+    '''
+    if value in ['on', 'yes']:
+        value = True
+    elif value in ['off', 'no']:
+        value = False
+    elif value == 'none':
+        value = None
+
+    return value
+
+
+def from_bool_alt(value):
+    '''
+    Convert zfs bool_alt to python bool
+    '''
+    return from_bool(value)
+
+
+def to_bool(value):
+    '''
+    Convert python bool to zfs on/off bool
+    '''
+    value = from_bool(value)
+    if isinstance(value, bool):
+        value = 'on' if value else 'off'
+    elif value is None:
+        value = 'none'
+
+    return value
+
+
+def to_bool_alt(value):
+    '''
+    Convert python to zfs yes/no value
+    '''
+    value = from_bool_alt(value)
+    if isinstance(value, bool):
+        value = 'yes' if value else 'no'
+    elif value is None:
+        value = 'none'
+
+    return value
+
+
+def from_size(value):
+    '''
+    Convert zfs size (human readble) to python int (bytes)
+    '''
+    match_size = re_zfs_size.match(str(value))
+    if match_size:
+        v_unit = match_size.group(2).upper()[0]
+        v_size = float(match_size.group(1))
+        v_multiplier = math.pow(1024, zfs_size.index(v_unit) + 1)
+        value = v_size * v_multiplier
+        if int(value) == value:
+            value = int(value)
+    elif value is not None:
+        value = str(value)
+
+    return from_numeric(value)
+
+
+def to_size(value, convert_to_human=True):
+    '''
+    Convert python int (bytes) to zfs size
+
+    NOTE: http://src.illumos.org/source/xref/illumos-gate/usr/src/lib/pyzfs/common/util.py#114
+    '''
+    value = from_size(value)
+    if value is None:
+        value = 'none'
+
+    if isinstance(value, Number) and value > 1024 and convert_to_human:
+        v_power = int(math.floor(math.log(value, 1024)))
+        v_multiplier = math.pow(1024, v_power)
+
+        # NOTE: zfs is a bit odd on how it does the rounding,
+        #       see libzfs implementation linked above
+        v_size_float = float(value) / v_multiplier
+        if v_size_float == int(v_size_float):
+            value = "{:.0f}{}".format(
+                v_size_float,
+                zfs_size[v_power-1],
+            )
+        else:
+            for v_precision in ["{:.2f}{}", "{:.1f}{}", "{:.0f}{}"]:
+                v_size = v_precision.format(
+                    v_size_float,
+                    zfs_size[v_power-1],
+                )
+                if len(v_size) <= 5:
+                    value = v_size
+                    break
+
+    return value
+
+
+def from_str(value):
+    '''
+    Decode zfs safe string (used for name, path, ...)
+    '''
+    if value == 'none':
+        value = None
+    if value:
+        value = str(value)
+        if value.startswith('"') and value.endswith('"'):
+            value = value[1:-1]
+        value = value.replace('\\"', '"')
+
+    return value
+
+
+def to_str(value):
+    '''
+    Encode zfs safe string (used for name, path, ...)
+    '''
+    value = from_str(value)
+
+    if value:
+        value = value.replace('"', '\\"')
+        if ' ' in value:
+            value = '"' + value + '"'
+    elif value is None:
+        value = 'none'
+
+    return value
+
+
+def from_auto(name, value, source='auto'):
+    '''
+    Convert zfs value to python value
+    '''
+    return _auto('from', name, value, source)
+
+
+def to_auto(name, value, source='auto', convert_to_human=True):
+    '''
+    Convert python value to zfs value
+    '''
+    return _auto('to', name, value, source, convert_to_human)
+
+
+def from_auto_dict(values, source='auto'):
+    '''
+    Pass an entire dictionary to from_auto
+
+    .. note::
+        The key will be passed as the name
+    '''
+    for name, value in values.items():
+        values[name] = from_auto(name, value, source)
+
+    return values
+
+
+def to_auto_dict(values, source='auto', convert_to_human=True):
+    '''
+    Pass an entire dictionary to to_auto
+
+    .. note::
+        The key will be passed as the name
+    '''
+    for name, value in values.items():
+        values[name] = to_auto(name, value, source, convert_to_human)
+
+    return values
+
+
+def is_snapshot(name):
+    '''
+    Check if name is a valid snapshot name
+    '''
+    return from_str(name).count('@') == 1
+
+
+def is_bookmark(name):
+    '''
+    Check if name is a valid bookmark name
+    '''
+    return from_str(name).count('#') == 1
+
+
+def is_dataset(name):
+    '''
+    Check if name is a valid filesystem or volume name
+    '''
+    return not is_snapshot(name) and not is_bookmark(name)
+
+
+def zfs_command(command, flags=None, opts=None, property_name=None, property_value=None,
+                filesystem_properties=None, target=None):
+    '''
+    Build and properly escape a zfs command
+
+    .. note::
+
+        Input is not considered safe and will be passed through
+        to_auto(from_auto('input_here')), you do not need to do so
+        your self first.
+
+    '''
+    return _command(
+        'zfs',
+        command=command,
+        flags=flags,
+        opts=opts,
+        property_name=property_name,
+        property_value=property_value,
+        filesystem_properties=filesystem_properties,
+        pool_properties=None,
+        target=target,
+    )
+
+
+def zpool_command(command, flags=None, opts=None, property_name=None, property_value=None,
+                  filesystem_properties=None, pool_properties=None, target=None):
+    '''
+    Build and properly escape a zpool command
+
+    .. note::
+
+        Input is not considered safe and will be passed through
+        to_auto(from_auto('input_here')), you do not need to do so
+        your self first.
+
+    '''
+    return _command(
+        'zpool',
+        command=command,
+        flags=flags,
+        opts=opts,
+        property_name=property_name,
+        property_value=property_value,
+        filesystem_properties=filesystem_properties,
+        pool_properties=pool_properties,
+        target=target,
+    )
+
+
+def parse_command_result(res, label=None):
+    '''
+    Parse the result of a zpool/zfs command
+
+    .. note::
+
+        Output on failure is rather predicatable.
+        - retcode > 0
+        - each 'error' is a line on stderr
+        - optional 'Usage:' block under those with hits
+
+        We simple check those and return a OrderedDict were
+        we set label = True|False and error = error_messages
+
+    '''
+    ret = OrderedDict()
+
+    if label:
+        ret[label] = res['retcode'] == 0
+
+    if res['retcode'] != 0:
+        ret['error'] = []
+        for error in res['stderr'].splitlines():
+            if error.lower().startswith('usage:'):
+                break
+            if error.lower().startswith("use '-f'"):
+                error = error.replace('-f', 'force=True')
+            if error.lower().startswith("use '-r'"):
+                error = error.replace('-r', 'recursive=True')
+            ret['error'].append(error)
+
+        if len(ret['error']):
+            ret['error'] = "\n".join(ret['error'])
+        else:
+            del ret['error']
+
+    return ret
+
+# vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4

--- a/tests/unit/modules/test_zfs.py
+++ b/tests/unit/modules/test_zfs.py
@@ -104,7 +104,7 @@ class ZfsTestCase(TestCase, LoaderModuleMockMixin):
         mock_cmd = MagicMock(return_value=ret)
         with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
              patch.dict(zfs.__utils__, utils_patch):
-            self.assertEqual(zfs.create('myzpool/mydataset'), res)
+            self.assertEqual(res, zfs.create('myzpool/mydataset'))
 
     def test_create_success_with_create_parent(self):
         '''
@@ -118,7 +118,7 @@ class ZfsTestCase(TestCase, LoaderModuleMockMixin):
         mock_cmd = MagicMock(return_value=ret)
         with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
              patch.dict(zfs.__utils__, utils_patch):
-            self.assertEqual(zfs.create('myzpool/mydataset/mysubdataset', create_parent=True), res)
+            self.assertEqual(res, zfs.create('myzpool/mydataset/mysubdataset', create_parent=True))
 
     def test_create_success_with_properties(self):
         '''
@@ -133,13 +133,14 @@ class ZfsTestCase(TestCase, LoaderModuleMockMixin):
         with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
              patch.dict(zfs.__utils__, utils_patch):
             self.assertEqual(
+                res,
                 zfs.create(
                     'myzpool/mydataset',
                     properties={
                         'mountpoint': '/export/zfs',
                         'sharenfs': 'on'
                     }
-                ), res
+                ),
             )
 
     def test_create_error_missing_dataset(self):
@@ -157,7 +158,7 @@ class ZfsTestCase(TestCase, LoaderModuleMockMixin):
         mock_cmd = MagicMock(return_value=ret)
         with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
              patch.dict(zfs.__utils__, utils_patch):
-            self.assertEqual(zfs.create('myzpool'), res)
+            self.assertEqual(res, zfs.create('myzpool'))
 
     def test_create_error_trailing_slash(self):
         '''
@@ -174,7 +175,7 @@ class ZfsTestCase(TestCase, LoaderModuleMockMixin):
         mock_cmd = MagicMock(return_value=ret)
         with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
              patch.dict(zfs.__utils__, utils_patch):
-            self.assertEqual(zfs.create('myzpool/'), res)
+            self.assertEqual(res, zfs.create('myzpool/'))
 
     def test_create_error_no_such_pool(self):
         '''
@@ -191,7 +192,7 @@ class ZfsTestCase(TestCase, LoaderModuleMockMixin):
         mock_cmd = MagicMock(return_value=ret)
         with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
              patch.dict(zfs.__utils__, utils_patch):
-            self.assertEqual(zfs.create('myzpool/mydataset'), res)
+            self.assertEqual(res, zfs.create('myzpool/mydataset'))
 
     def test_create_error_missing_parent(self):
         '''
@@ -208,7 +209,7 @@ class ZfsTestCase(TestCase, LoaderModuleMockMixin):
         mock_cmd = MagicMock(return_value=ret)
         with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
              patch.dict(zfs.__utils__, utils_patch):
-            self.assertEqual(zfs.create('myzpool/mydataset/mysubdataset'), res)
+            self.assertEqual(res, zfs.create('myzpool/mydataset/mysubdataset'))
 
     def test_destroy_success(self):
         '''
@@ -222,7 +223,7 @@ class ZfsTestCase(TestCase, LoaderModuleMockMixin):
         mock_cmd = MagicMock(return_value=ret)
         with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
              patch.dict(zfs.__utils__, utils_patch):
-            self.assertEqual(zfs.destroy('myzpool/mydataset'), res)
+            self.assertEqual(res, zfs.destroy('myzpool/mydataset'))
 
     def test_destroy_error_not_exists(self):
         '''
@@ -239,7 +240,7 @@ class ZfsTestCase(TestCase, LoaderModuleMockMixin):
         mock_cmd = MagicMock(return_value=ret)
         with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
              patch.dict(zfs.__utils__, utils_patch):
-            self.assertEqual(zfs.destroy('myzpool/mydataset'), res)
+            self.assertEqual(res, zfs.destroy('myzpool/mydataset'))
 
     def test_destroy_error_has_children(self):
         '''
@@ -264,7 +265,7 @@ class ZfsTestCase(TestCase, LoaderModuleMockMixin):
         mock_cmd = MagicMock(return_value=ret)
         with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
              patch.dict(zfs.__utils__, utils_patch):
-            self.assertEqual(zfs.destroy('myzpool/mydataset'), res)
+            self.assertEqual(res, zfs.destroy('myzpool/mydataset'))
 
     def test_rename_success(self):
         '''
@@ -278,7 +279,7 @@ class ZfsTestCase(TestCase, LoaderModuleMockMixin):
         mock_cmd = MagicMock(return_value=ret)
         with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
              patch.dict(zfs.__utils__, utils_patch):
-            self.assertEqual(zfs.rename('myzpool/mydataset', 'myzpool/newdataset'), res)
+            self.assertEqual(res, zfs.rename('myzpool/mydataset', 'myzpool/newdataset'))
 
     def test_rename_error_not_exists(self):
         '''
@@ -295,7 +296,7 @@ class ZfsTestCase(TestCase, LoaderModuleMockMixin):
         mock_cmd = MagicMock(return_value=ret)
         with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
              patch.dict(zfs.__utils__, utils_patch):
-            self.assertEqual(zfs.rename('myzpool/mydataset', 'myzpool/newdataset'), res)
+            self.assertEqual(res, zfs.rename('myzpool/mydataset', 'myzpool/newdataset'))
 
     def test_list_success(self):
         '''
@@ -316,7 +317,7 @@ class ZfsTestCase(TestCase, LoaderModuleMockMixin):
         mock_cmd = MagicMock(return_value=ret)
         with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
              patch.dict(zfs.__utils__, utils_patch):
-            self.assertEqual(zfs.list_('myzpool'), res)
+            self.assertEqual(res, zfs.list_('myzpool'))
 
     def test_list_parsable_success(self):
         '''
@@ -337,7 +338,7 @@ class ZfsTestCase(TestCase, LoaderModuleMockMixin):
         mock_cmd = MagicMock(return_value=ret)
         with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
              patch.dict(zfs.__utils__, utils_patch):
-            self.assertEqual(zfs.list_('myzpool', parsable=False), res)
+            self.assertEqual(res, zfs.list_('myzpool', parsable=False))
 
     def test_list_custom_success(self):
         '''
@@ -358,7 +359,7 @@ class ZfsTestCase(TestCase, LoaderModuleMockMixin):
         mock_cmd = MagicMock(return_value=ret)
         with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
              patch.dict(zfs.__utils__, utils_patch):
-            self.assertEqual(zfs.list_('myzpool', properties='canmount,used,avail,compression'), res)
+            self.assertEqual(res, zfs.list_('myzpool', properties='canmount,used,avail,compression'))
 
     def test_list_custom_parsable_success(self):
         '''
@@ -379,7 +380,7 @@ class ZfsTestCase(TestCase, LoaderModuleMockMixin):
         mock_cmd = MagicMock(return_value=ret)
         with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
              patch.dict(zfs.__utils__, utils_patch):
-            self.assertEqual(zfs.list_('myzpool', properties='canmount,used,avail,compression', parsable=False), res)
+            self.assertEqual(res, zfs.list_('myzpool', properties='canmount,used,avail,compression', parsable=False))
 
     def test_list_error_no_dataset(self):
         '''
@@ -393,7 +394,7 @@ class ZfsTestCase(TestCase, LoaderModuleMockMixin):
         mock_cmd = MagicMock(return_value=ret)
         with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
              patch.dict(zfs.__utils__, utils_patch):
-            self.assertEqual(zfs.list_('myzpool'), res)
+            self.assertEqual(res, zfs.list_('myzpool'))
 
     def test_list_mount_success(self):
         '''
@@ -413,7 +414,7 @@ class ZfsTestCase(TestCase, LoaderModuleMockMixin):
         mock_cmd = MagicMock(return_value=ret)
         with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
              patch.dict(zfs.__utils__, utils_patch):
-            self.assertEqual(zfs.list_mount(), res)
+            self.assertEqual(res, zfs.list_mount())
 
     def test_mount_success(self):
         '''
@@ -427,7 +428,7 @@ class ZfsTestCase(TestCase, LoaderModuleMockMixin):
         mock_cmd = MagicMock(return_value=ret)
         with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
              patch.dict(zfs.__utils__, utils_patch):
-            self.assertEqual(zfs.mount('myzpool/mydataset'), res)
+            self.assertEqual(res, zfs.mount('myzpool/mydataset'))
 
     def test_mount_failure(self):
         '''
@@ -441,7 +442,7 @@ class ZfsTestCase(TestCase, LoaderModuleMockMixin):
         mock_cmd = MagicMock(return_value=ret)
         with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
              patch.dict(zfs.__utils__, utils_patch):
-            self.assertEqual(zfs.mount('myzpool/mydataset'), res)
+            self.assertEqual(res, zfs.mount('myzpool/mydataset'))
 
     def test_unmount_success(self):
         '''
@@ -455,7 +456,7 @@ class ZfsTestCase(TestCase, LoaderModuleMockMixin):
         mock_cmd = MagicMock(return_value=ret)
         with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
              patch.dict(zfs.__utils__, utils_patch):
-            self.assertEqual(zfs.unmount('myzpool/mydataset'), res)
+            self.assertEqual(res, zfs.unmount('myzpool/mydataset'))
 
     def test_unmount_failure(self):
         '''
@@ -472,7 +473,7 @@ class ZfsTestCase(TestCase, LoaderModuleMockMixin):
         mock_cmd = MagicMock(return_value=ret)
         with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
              patch.dict(zfs.__utils__, utils_patch):
-            self.assertEqual(zfs.unmount('myzpool/mydataset'), res)
+            self.assertEqual(res, zfs.unmount('myzpool/mydataset'))
 
     def test_inherit_success(self):
         '''
@@ -483,7 +484,7 @@ class ZfsTestCase(TestCase, LoaderModuleMockMixin):
         mock_cmd = MagicMock(return_value=ret)
         with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
              patch.dict(zfs.__utils__, utils_patch):
-            self.assertEqual(zfs.inherit('compression', 'myzpool/mydataset'), res)
+            self.assertEqual(res, zfs.inherit('compression', 'myzpool/mydataset'))
 
     def test_inherit_failure(self):
         '''
@@ -497,7 +498,7 @@ class ZfsTestCase(TestCase, LoaderModuleMockMixin):
         mock_cmd = MagicMock(return_value=ret)
         with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
              patch.dict(zfs.__utils__, utils_patch):
-            self.assertEqual(zfs.inherit('canmount', 'myzpool/mydataset'), res)
+            self.assertEqual(res, zfs.inherit('canmount', 'myzpool/mydataset'))
 
     def test_diff(self):
         '''
@@ -519,7 +520,7 @@ class ZfsTestCase(TestCase, LoaderModuleMockMixin):
         mock_cmd = MagicMock(return_value=ret)
         with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
              patch.dict(zfs.__utils__, utils_patch):
-            self.assertEqual(zfs.diff('myzpool/mydataset@yesterday', 'myzpool/mydataset'), res)
+            self.assertEqual(res, zfs.diff('myzpool/mydataset@yesterday', 'myzpool/mydataset'))
 
     def test_diff_parsed_time(self):
         '''
@@ -543,7 +544,7 @@ class ZfsTestCase(TestCase, LoaderModuleMockMixin):
         mock_cmd = MagicMock(return_value=ret)
         with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
              patch.dict(zfs.__utils__, utils_patch):
-            self.assertEqual(zfs.diff('myzpool/data@yesterday', 'myzpool/data', parsable=False), res)
+            self.assertEqual(res, zfs.diff('myzpool/data@yesterday', 'myzpool/data', parsable=False))
 
     def test_rollback_success(self):
         '''
@@ -554,7 +555,7 @@ class ZfsTestCase(TestCase, LoaderModuleMockMixin):
         mock_cmd = MagicMock(return_value=ret)
         with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
              patch.dict(zfs.__utils__, utils_patch):
-            self.assertEqual(zfs.rollback('myzpool/mydataset@yesterday'), res)
+            self.assertEqual(res, zfs.rollback('myzpool/mydataset@yesterday'))
 
     def test_rollback_failure(self):
         '''
@@ -580,7 +581,7 @@ class ZfsTestCase(TestCase, LoaderModuleMockMixin):
         mock_cmd = MagicMock(return_value=ret)
         with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
              patch.dict(zfs.__utils__, utils_patch):
-            self.assertEqual(zfs.rollback('myzpool/mydataset@yesterday'), res)
+            self.assertEqual(res, zfs.rollback('myzpool/mydataset@yesterday'))
 
     def test_clone_success(self):
         '''
@@ -591,7 +592,7 @@ class ZfsTestCase(TestCase, LoaderModuleMockMixin):
         mock_cmd = MagicMock(return_value=ret)
         with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
              patch.dict(zfs.__utils__, utils_patch):
-            self.assertEqual(zfs.clone('myzpool/mydataset@yesterday', 'myzpool/yesterday'), res)
+            self.assertEqual(res, zfs.clone('myzpool/mydataset@yesterday', 'myzpool/yesterday'))
 
     def test_clone_failure(self):
         '''
@@ -605,7 +606,7 @@ class ZfsTestCase(TestCase, LoaderModuleMockMixin):
         mock_cmd = MagicMock(return_value=ret)
         with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
              patch.dict(zfs.__utils__, utils_patch):
-            self.assertEqual(zfs.clone('myzpool/mydataset@yesterday', 'myzpool/archive/yesterday'), res)
+            self.assertEqual(res, zfs.clone('myzpool/mydataset@yesterday', 'myzpool/archive/yesterday'))
 
     def test_promote_success(self):
         '''
@@ -616,7 +617,7 @@ class ZfsTestCase(TestCase, LoaderModuleMockMixin):
         mock_cmd = MagicMock(return_value=ret)
         with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
              patch.dict(zfs.__utils__, utils_patch):
-            self.assertEqual(zfs.promote('myzpool/yesterday'), res)
+            self.assertEqual(res, zfs.promote('myzpool/yesterday'))
 
     def test_promote_failure(self):
         '''
@@ -630,7 +631,7 @@ class ZfsTestCase(TestCase, LoaderModuleMockMixin):
         mock_cmd = MagicMock(return_value=ret)
         with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
              patch.dict(zfs.__utils__, utils_patch):
-            self.assertEqual(zfs.promote('myzpool/yesterday'), res)
+            self.assertEqual(res, zfs.promote('myzpool/yesterday'))
 
     def test_bookmark_success(self):
         '''
@@ -642,7 +643,7 @@ class ZfsTestCase(TestCase, LoaderModuleMockMixin):
             mock_cmd = MagicMock(return_value=ret)
             with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
                  patch.dict(zfs.__utils__, utils_patch):
-                self.assertEqual(zfs.bookmark('myzpool/mydataset@yesterday', 'myzpool/mydataset#important'), res)
+                self.assertEqual(res, zfs.bookmark('myzpool/mydataset@yesterday', 'myzpool/mydataset#important'))
 
     def test_holds_success(self):
         '''
@@ -656,7 +657,7 @@ class ZfsTestCase(TestCase, LoaderModuleMockMixin):
         mock_cmd = MagicMock(return_value=ret)
         with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
              patch.dict(zfs.__utils__, utils_patch):
-            self.assertEqual(zfs.holds('myzpool/mydataset@baseline'), res)
+            self.assertEqual(res, zfs.holds('myzpool/mydataset@baseline'))
 
     def test_holds_failure(self):
         '''
@@ -669,7 +670,7 @@ class ZfsTestCase(TestCase, LoaderModuleMockMixin):
         mock_cmd = MagicMock(return_value=ret)
         with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
              patch.dict(zfs.__utils__, utils_patch):
-            self.assertEqual(zfs.holds('myzpool/mydataset@baseline'), res)
+            self.assertEqual(res, zfs.holds('myzpool/mydataset@baseline'))
 
     def test_hold_success(self):
         '''
@@ -680,7 +681,7 @@ class ZfsTestCase(TestCase, LoaderModuleMockMixin):
         mock_cmd = MagicMock(return_value=ret)
         with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
              patch.dict(zfs.__utils__, utils_patch):
-            self.assertEqual(zfs.hold('important', 'myzpool/mydataset@baseline', 'myzpool/mydataset@release-1.0'), res)
+            self.assertEqual(res, zfs.hold('important', 'myzpool/mydataset@baseline', 'myzpool/mydataset@release-1.0'))
 
     def test_hold_failure(self):
         '''
@@ -694,7 +695,7 @@ class ZfsTestCase(TestCase, LoaderModuleMockMixin):
         mock_cmd = MagicMock(return_value=ret)
         with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
              patch.dict(zfs.__utils__, utils_patch):
-            self.assertEqual(zfs.hold('important', 'myzpool/mydataset@baseline'), res)
+            self.assertEqual(res, zfs.hold('important', 'myzpool/mydataset@baseline'))
 
     def test_release_success(self):
         '''
@@ -705,7 +706,7 @@ class ZfsTestCase(TestCase, LoaderModuleMockMixin):
         mock_cmd = MagicMock(return_value=ret)
         with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
              patch.dict(zfs.__utils__, utils_patch):
-            self.assertEqual(zfs.release('important', 'myzpool/mydataset@baseline', 'myzpool/mydataset@release-1.0'), res)
+            self.assertEqual(res, zfs.release('important', 'myzpool/mydataset@baseline', 'myzpool/mydataset@release-1.0'))
 
     def test_release_failure(self):
         '''
@@ -719,7 +720,7 @@ class ZfsTestCase(TestCase, LoaderModuleMockMixin):
         mock_cmd = MagicMock(return_value=ret)
         with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
              patch.dict(zfs.__utils__, utils_patch):
-            self.assertEqual(zfs.release('important', 'myzpool/mydataset@baseline'), res)
+            self.assertEqual(res, zfs.release('important', 'myzpool/mydataset@baseline'))
 
     def test_snapshot_success(self):
         '''
@@ -730,7 +731,7 @@ class ZfsTestCase(TestCase, LoaderModuleMockMixin):
         mock_cmd = MagicMock(return_value=ret)
         with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
              patch.dict(zfs.__utils__, utils_patch):
-            self.assertEqual(zfs.snapshot('myzpool/mydataset@baseline'), res)
+            self.assertEqual(res, zfs.snapshot('myzpool/mydataset@baseline'))
 
     def test_snapshot_failure(self):
         '''
@@ -744,7 +745,7 @@ class ZfsTestCase(TestCase, LoaderModuleMockMixin):
         mock_cmd = MagicMock(return_value=ret)
         with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
              patch.dict(zfs.__utils__, utils_patch):
-            self.assertEqual(zfs.snapshot('myzpool/mydataset@baseline'), res)
+            self.assertEqual(res, zfs.snapshot('myzpool/mydataset@baseline'))
 
     def test_snapshot_failure2(self):
         '''
@@ -758,7 +759,7 @@ class ZfsTestCase(TestCase, LoaderModuleMockMixin):
         mock_cmd = MagicMock(return_value=ret)
         with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
              patch.dict(zfs.__utils__, utils_patch):
-            self.assertEqual(zfs.snapshot('myzpool/mydataset@baseline'), res)
+            self.assertEqual(res, zfs.snapshot('myzpool/mydataset@baseline'))
 
     def test_set_success(self):
         '''
@@ -769,7 +770,7 @@ class ZfsTestCase(TestCase, LoaderModuleMockMixin):
         mock_cmd = MagicMock(return_value=ret)
         with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
              patch.dict(zfs.__utils__, utils_patch):
-            self.assertEqual(zfs.set('myzpool/mydataset', compression='lz4'), res)
+            self.assertEqual(res, zfs.set('myzpool/mydataset', compression='lz4'))
 
     def test_set_failure(self):
         '''
@@ -783,7 +784,7 @@ class ZfsTestCase(TestCase, LoaderModuleMockMixin):
         mock_cmd = MagicMock(return_value=ret)
         with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
              patch.dict(zfs.__utils__, utils_patch):
-            self.assertEqual(zfs.set('myzpool/mydataset', canmount='lz4'), res)
+            self.assertEqual(res, zfs.set('myzpool/mydataset', canmount='lz4'))
 
     def test_get_success(self):
         '''
@@ -800,7 +801,7 @@ class ZfsTestCase(TestCase, LoaderModuleMockMixin):
         mock_cmd = MagicMock(return_value=ret)
         with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
              patch.dict(zfs.__utils__, utils_patch):
-            self.assertEqual(zfs.get('myzpool', properties='used', fields='value'), res)
+            self.assertEqual(res, zfs.get('myzpool', properties='used', fields='value'))
 
     def test_get_parsable_success(self):
         '''
@@ -817,4 +818,4 @@ class ZfsTestCase(TestCase, LoaderModuleMockMixin):
         mock_cmd = MagicMock(return_value=ret)
         with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
              patch.dict(zfs.__utils__, utils_patch):
-            self.assertEqual(zfs.get('myzpool', properties='used', fields='value', parsable=False), res)
+            self.assertEqual(res, zfs.get('myzpool', properties='used', fields='value', parsable=False))

--- a/tests/unit/modules/test_zfs.py
+++ b/tests/unit/modules/test_zfs.py
@@ -1,9 +1,12 @@
 # -*- coding: utf-8 -*-
 '''
-    :codeauthor: Nitin Madhok <nmadhok@clemson.edu>`
+Tests for salt.modules.zfs
 
-    tests.unit.modules.zfs_test
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+:codeauthor:    Nitin Madhok <nmadhok@clemson.edu>, Jorge Schrauwen <sjorge@blackdot.be>
+:maintainer:    Jorge Schrauwen <sjorge@blackdot.be>
+:maturity:      new
+:depends:       salt.utils.zfs
+:platform:      illumos,freebsd,linux
 '''
 
 # Import Python libs
@@ -19,9 +22,17 @@ from tests.support.mock import (
     NO_MOCK_REASON,
 )
 
+# Import test data from salt.utils.zfs test
+from tests.unit.utils.test_zfs import utils_patch
+
 # Import Salt Execution module to test
+import salt.utils.zfs
 import salt.modules.zfs as zfs
+
+# Import Salt Utils
+import salt.loader
 from salt.utils.odict import OrderedDict
+from salt.utils.dateutils import strftime
 
 
 # Skip this test case if we don't have access to mock!
@@ -31,10 +42,16 @@ class ZfsTestCase(TestCase, LoaderModuleMockMixin):
     This class contains a set of functions that test salt.modules.zfs module
     '''
     def setup_loader_modules(self):
-        patcher = patch('salt.modules.zfs._check_zfs', MagicMock(return_value='/sbin/zfs'))
-        patcher.start()
-        self.addCleanup(patcher.stop)
-        return {zfs: {}}
+        self.opts = opts = salt.config.DEFAULT_MINION_OPTS
+        utils = salt.loader.utils(opts, whitelist=['zfs'])
+        zfs_obj = {
+            zfs: {
+                '__opts__': opts,
+                '__utils__': utils,
+            }
+        }
+
+        return zfs_obj
 
     def test_exists_success(self):
         '''
@@ -45,7 +62,8 @@ class ZfsTestCase(TestCase, LoaderModuleMockMixin):
         ret['stderr'] = ''
         ret['retcode'] = 0
         mock_cmd = MagicMock(return_value=ret)
-        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zfs.__utils__, utils_patch):
             self.assertTrue(zfs.exists('myzpool/mydataset'))
 
     def test_exists_failure_not_exists(self):
@@ -57,7 +75,8 @@ class ZfsTestCase(TestCase, LoaderModuleMockMixin):
         ret['stderr'] = "cannot open 'myzpool/mydataset': dataset does not exist"
         ret['retcode'] = 1
         mock_cmd = MagicMock(return_value=ret)
-        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zfs.__utils__, utils_patch):
             self.assertFalse(zfs.exists('myzpool/mydataset'))
 
     def test_exists_failure_invalid_name(self):
@@ -69,46 +88,50 @@ class ZfsTestCase(TestCase, LoaderModuleMockMixin):
         ret['stderr'] = "cannot open 'myzpool/': invalid dataset name"
         ret['retcode'] = 1
         mock_cmd = MagicMock(return_value=ret)
-        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zfs.__utils__, utils_patch):
             self.assertFalse(zfs.exists('myzpool/'))
 
     def test_create_success(self):
         '''
         Tests successful return of create function on ZFS file system creation
         '''
-        res = {'myzpool/mydataset': 'created'}
+        res = OrderedDict([('created', True)])
         ret = {}
         ret['stdout'] = ""
         ret['stderr'] = ""
         ret['retcode'] = 0
         mock_cmd = MagicMock(return_value=ret)
-        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zfs.__utils__, utils_patch):
             self.assertEqual(zfs.create('myzpool/mydataset'), res)
 
     def test_create_success_with_create_parent(self):
         '''
         Tests successful return of create function when ``create_parent=True``
         '''
-        res = {'myzpool/mydataset/mysubdataset': 'created'}
+        res = OrderedDict([('created', True)])
         ret = {}
         ret['stdout'] = ""
         ret['stderr'] = ""
         ret['retcode'] = 0
         mock_cmd = MagicMock(return_value=ret)
-        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zfs.__utils__, utils_patch):
             self.assertEqual(zfs.create('myzpool/mydataset/mysubdataset', create_parent=True), res)
 
     def test_create_success_with_properties(self):
         '''
         Tests successful return of create function on ZFS file system creation (with properties)
         '''
-        res = {'myzpool/mydataset': 'created'}
+        res = OrderedDict([('created', True)])
         ret = {}
         ret['stdout'] = ""
         ret['stderr'] = ""
         ret['retcode'] = 0
         mock_cmd = MagicMock(return_value=ret)
-        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zfs.__utils__, utils_patch):
             self.assertEqual(
                 zfs.create(
                     'myzpool/mydataset',
@@ -123,177 +146,429 @@ class ZfsTestCase(TestCase, LoaderModuleMockMixin):
         '''
         Tests unsuccessful return of create function if dataset name is missing
         '''
-        res = {'myzpool': 'cannot create \'myzpool\': missing dataset name'}
+        res = OrderedDict([
+            ('created', False),
+            ('error', "cannot create 'myzpool': missing dataset name"),
+        ])
         ret = {}
         ret['stdout'] = ""
         ret['stderr'] = "cannot create 'myzpool': missing dataset name"
         ret['retcode'] = 1
         mock_cmd = MagicMock(return_value=ret)
-        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zfs.__utils__, utils_patch):
             self.assertEqual(zfs.create('myzpool'), res)
 
     def test_create_error_trailing_slash(self):
         '''
         Tests unsuccessful return of create function if trailing slash in name is present
         '''
-        res = {'myzpool/': 'cannot create \'myzpool/\': trailing slash in name'}
+        res = OrderedDict([
+            ('created', False),
+            ('error', "cannot create 'myzpool/': trailing slash in name"),
+        ])
         ret = {}
         ret['stdout'] = ""
         ret['stderr'] = "cannot create 'myzpool/': trailing slash in name"
         ret['retcode'] = 1
         mock_cmd = MagicMock(return_value=ret)
-        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zfs.__utils__, utils_patch):
             self.assertEqual(zfs.create('myzpool/'), res)
 
     def test_create_error_no_such_pool(self):
         '''
         Tests unsuccessful return of create function if the pool is not present
         '''
-        res = {'myzpool/mydataset': 'cannot create \'myzpool/mydataset\': no such pool \'myzpool\''}
+        res = OrderedDict([
+            ('created', False),
+            ('error', "cannot create 'myzpool/mydataset': no such pool 'myzpool'"),
+        ])
         ret = {}
         ret['stdout'] = ""
         ret['stderr'] = "cannot create 'myzpool/mydataset': no such pool 'myzpool'"
         ret['retcode'] = 1
         mock_cmd = MagicMock(return_value=ret)
-        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zfs.__utils__, utils_patch):
             self.assertEqual(zfs.create('myzpool/mydataset'), res)
 
     def test_create_error_missing_parent(self):
         '''
         Tests unsuccessful return of create function if the parent datasets do not exist
         '''
-        res = {'myzpool/mydataset/mysubdataset': 'cannot create \'myzpool/mydataset/mysubdataset\': parent does not exist'}
+        res = OrderedDict([
+            ('created', False),
+            ('error', "cannot create 'myzpool/mydataset/mysubdataset': parent does not exist"),
+        ])
         ret = {}
         ret['stdout'] = ""
         ret['stderr'] = "cannot create 'myzpool/mydataset/mysubdataset': parent does not exist"
         ret['retcode'] = 1
         mock_cmd = MagicMock(return_value=ret)
-        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zfs.__utils__, utils_patch):
             self.assertEqual(zfs.create('myzpool/mydataset/mysubdataset'), res)
 
-    def test_list_success(self):
+    def test_destroy_success(self):
         '''
-        Tests zfs list
+        Tests successful return of destroy function on ZFS file system destruction
         '''
-        res = OrderedDict([('myzpool', {'avail': '954G', 'mountpoint': '/myzpool', 'used': '844G', 'refer': '96K'})])
-        ret = {'pid': 31817, 'retcode': 0, 'stderr': '', 'stdout': 'myzpool\t844G\t954G\t96K\t/myzpool'}
-        mock_cmd = MagicMock(return_value=ret)
-        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
-            self.assertEqual(zfs.list_('myzpool'), res)
-
-    def test_list_parsable_success(self):
-        '''
-        Tests zfs list with parsable output
-        '''
-        res = OrderedDict([('myzpool', {'avail': 1024795238400, 'mountpoint': '/myzpool', 'used': 905792561152, 'refer': 98304})])
-        ret = {'pid': 31817, 'retcode': 0, 'stderr': '', 'stdout': 'myzpool\t905792561152\t1024795238400\t98304\t/myzpool'}
-        mock_cmd = MagicMock(return_value=ret)
-        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
-            self.assertEqual(zfs.list_('myzpool', parsable=True), res)
-
-    def test_mount_success(self):
-        '''
-        Tests zfs mount of filesystem
-        '''
-        res = {'myzpool/mydataset': 'mounted'}
+        res = OrderedDict([('destroyed', True)])
         ret = {}
         ret['stdout'] = ""
         ret['stderr'] = ""
         ret['retcode'] = 0
         mock_cmd = MagicMock(return_value=ret)
-        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zfs.__utils__, utils_patch):
+            self.assertEqual(zfs.destroy('myzpool/mydataset'), res)
+
+    def test_destroy_error_not_exists(self):
+        '''
+        Tests failure return of destroy function on ZFS file system destruction
+        '''
+        res = OrderedDict([
+            ('destroyed', False),
+            ('error', "cannot open 'myzpool/mydataset': dataset does not exist"),
+        ])
+        ret = {}
+        ret['stdout'] = ""
+        ret['stderr'] = "cannot open 'myzpool/mydataset': dataset does not exist"
+        ret['retcode'] = 1
+        mock_cmd = MagicMock(return_value=ret)
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zfs.__utils__, utils_patch):
+            self.assertEqual(zfs.destroy('myzpool/mydataset'), res)
+
+    def test_destroy_error_has_children(self):
+        '''
+        Tests failure return of destroy function on ZFS file system destruction
+        '''
+        res = OrderedDict([
+            ('destroyed', False),
+            ('error', "\n".join([
+                "cannot destroy 'myzpool/mydataset': filesystem has children",
+                "use 'recursive=True' to destroy the following datasets:",
+                "myzpool/mydataset@snapshot",
+            ])),
+        ])
+        ret = {}
+        ret['stdout'] = ""
+        ret['stderr'] = "\n".join([
+            "cannot destroy 'myzpool/mydataset': filesystem has children",
+            "use '-r' to destroy the following datasets:",
+            "myzpool/mydataset@snapshot",
+        ])
+        ret['retcode'] = 1
+        mock_cmd = MagicMock(return_value=ret)
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zfs.__utils__, utils_patch):
+            self.assertEqual(zfs.destroy('myzpool/mydataset'), res)
+
+    def test_rename_success(self):
+        '''
+        Tests successful return of rename function
+        '''
+        res = OrderedDict([('renamed', True)])
+        ret = {}
+        ret['stdout'] = ""
+        ret['stderr'] = ""
+        ret['retcode'] = 0
+        mock_cmd = MagicMock(return_value=ret)
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zfs.__utils__, utils_patch):
+            self.assertEqual(zfs.rename('myzpool/mydataset', 'myzpool/newdataset'), res)
+
+    def test_rename_error_not_exists(self):
+        '''
+        Tests failure return of rename function
+        '''
+        res = OrderedDict([
+            ('renamed', False),
+            ('error', "cannot open 'myzpool/mydataset': dataset does not exist"),
+        ])
+        ret = {}
+        ret['stdout'] = ""
+        ret['stderr'] = "cannot open 'myzpool/mydataset': dataset does not exist"
+        ret['retcode'] = 1
+        mock_cmd = MagicMock(return_value=ret)
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zfs.__utils__, utils_patch):
+            self.assertEqual(zfs.rename('myzpool/mydataset', 'myzpool/newdataset'), res)
+
+    def test_list_success(self):
+        '''
+        Tests zfs list
+        '''
+        res = OrderedDict([
+            ('myzpool', OrderedDict([
+                ('used', 905792561152),
+                ('avail', 1024795238400),
+                ('refer', 98304),
+                ('mountpoint', '/myzpool'),
+            ])),
+        ])
+        ret = {}
+        ret['retcode'] = 0
+        ret['stdout'] = 'myzpool\t905792561152\t1024795238400\t98304\t/myzpool'
+        ret['stderr'] = ''
+        mock_cmd = MagicMock(return_value=ret)
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zfs.__utils__, utils_patch):
+            self.assertEqual(zfs.list_('myzpool'), res)
+
+    def test_list_parsable_success(self):
+        '''
+        Tests zfs list with parsable set to False
+        '''
+        res = OrderedDict([
+            ('myzpool', OrderedDict([
+                ('used', '844G'),
+                ('avail', '954G'),
+                ('refer', '96K'),
+                ('mountpoint', '/myzpool'),
+            ])),
+        ])
+        ret = {}
+        ret['retcode'] = 0
+        ret['stdout'] = 'myzpool\t905792561152\t1024795238400\t98304\t/myzpool'
+        ret['stderr'] = ''
+        mock_cmd = MagicMock(return_value=ret)
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zfs.__utils__, utils_patch):
+            self.assertEqual(zfs.list_('myzpool', parsable=False), res)
+
+    def test_list_custom_success(self):
+        '''
+        Tests zfs list
+        '''
+        res = OrderedDict([
+            ('myzpool', OrderedDict([
+                ('canmount', True),
+                ('used', 834786304),
+                ('avail', 87502848),
+                ('compression', False),
+            ])),
+        ])
+        ret = {}
+        ret['retcode'] = 0
+        ret['stdout'] = 'myzpool\ton\t834786304\t87502848\toff'
+        ret['stderr'] = ''
+        mock_cmd = MagicMock(return_value=ret)
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zfs.__utils__, utils_patch):
+            self.assertEqual(zfs.list_('myzpool', properties='canmount,used,avail,compression'), res)
+
+    def test_list_custom_parsable_success(self):
+        '''
+        Tests zfs list
+        '''
+        res = OrderedDict([
+            ('myzpool', OrderedDict([
+                ('canmount', 'on'),
+                ('used', '796M'),
+                ('avail', '83.4M'),
+                ('compression', 'off'),
+            ])),
+        ])
+        ret = {}
+        ret['retcode'] = 0
+        ret['stdout'] = 'myzpool\ton\t834786304\t87502848\toff'
+        ret['stderr'] = ''
+        mock_cmd = MagicMock(return_value=ret)
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zfs.__utils__, utils_patch):
+            self.assertEqual(zfs.list_('myzpool', properties='canmount,used,avail,compression', parsable=False), res)
+
+    def test_list_error_no_dataset(self):
+        '''
+        Tests zfs list
+        '''
+        res = OrderedDict()
+        ret = {}
+        ret['retcode'] = 1
+        ret['stdout'] = "cannot open 'myzpool': dataset does not exist"
+        ret['stderr'] = ''
+        mock_cmd = MagicMock(return_value=ret)
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zfs.__utils__, utils_patch):
+            self.assertEqual(zfs.list_('myzpool'), res)
+
+    def test_list_mount_success(self):
+        '''
+        Tests zfs list_mount
+        '''
+        res = OrderedDict([
+            ('myzpool/data', '/data'),
+            ('myzpool/data/ares', '/data/ares'),
+        ])
+        ret = {}
+        ret['retcode'] = 0
+        ret['stdout'] = "\n".join([
+            "myzpool/data\t\t\t\t/data",
+            "myzpool/data/ares\t\t\t/data/ares",
+        ])
+        ret['stderr'] = ''
+        mock_cmd = MagicMock(return_value=ret)
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zfs.__utils__, utils_patch):
+            self.assertEqual(zfs.list_mount(), res)
+
+    def test_mount_success(self):
+        '''
+        Tests zfs mount of filesystem
+        '''
+        res = OrderedDict([('mounted', True)])
+        ret = {}
+        ret['stdout'] = ""
+        ret['stderr'] = ""
+        ret['retcode'] = 0
+        mock_cmd = MagicMock(return_value=ret)
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zfs.__utils__, utils_patch):
             self.assertEqual(zfs.mount('myzpool/mydataset'), res)
 
     def test_mount_failure(self):
         '''
         Tests zfs mount of already mounted filesystem
         '''
-        res = {'myzpool/mydataset': "cannot mount 'myzpool/mydataset': filesystem already mounted"}
+        res = OrderedDict([('mounted', False), ('error', "cannot mount 'myzpool/mydataset': filesystem already mounted")])
         ret = {}
         ret['stdout'] = ""
         ret['stderr'] = "cannot mount 'myzpool/mydataset': filesystem already mounted"
         ret['retcode'] = 1
         mock_cmd = MagicMock(return_value=ret)
-        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zfs.__utils__, utils_patch):
             self.assertEqual(zfs.mount('myzpool/mydataset'), res)
 
     def test_unmount_success(self):
         '''
         Tests zfs unmount of filesystem
         '''
-        res = {'myzpool/mydataset': 'unmounted'}
+        res = OrderedDict([('unmounted', True)])
         ret = {}
         ret['stdout'] = ""
         ret['stderr'] = ""
         ret['retcode'] = 0
         mock_cmd = MagicMock(return_value=ret)
-        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zfs.__utils__, utils_patch):
             self.assertEqual(zfs.unmount('myzpool/mydataset'), res)
 
     def test_unmount_failure(self):
         '''
         Tests zfs unmount of already mounted filesystem
         '''
-        res = {'myzpool/mydataset': "cannot mount 'myzpool/mydataset': not currently mounted"}
+        res = OrderedDict([
+            ('unmounted', False),
+            ('error', "cannot mount 'myzpool/mydataset': not currently mounted"),
+        ])
         ret = {}
         ret['stdout'] = ""
         ret['stderr'] = "cannot mount 'myzpool/mydataset': not currently mounted"
         ret['retcode'] = 1
         mock_cmd = MagicMock(return_value=ret)
-        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zfs.__utils__, utils_patch):
             self.assertEqual(zfs.unmount('myzpool/mydataset'), res)
 
     def test_inherit_success(self):
         '''
         Tests zfs inherit of compression property
         '''
-        res = {'myzpool/mydataset': {'compression': 'cleared'}}
+        res = OrderedDict([('inherited', True)])
         ret = {'pid': 45193, 'retcode': 0, 'stderr': '', 'stdout': ''}
         mock_cmd = MagicMock(return_value=ret)
-        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zfs.__utils__, utils_patch):
             self.assertEqual(zfs.inherit('compression', 'myzpool/mydataset'), res)
 
     def test_inherit_failure(self):
         '''
         Tests zfs inherit of canmount
         '''
-        res = {
-            'myzpool/mydataset': {
-                'canmount': "'canmount' property cannot be inherited, use revert=True to try and reset it to it's default value."
-            }
-        }
+        res = OrderedDict([
+            ('inherited', False),
+            ('error', "'canmount' property cannot be inherited"),
+        ])
         ret = {'pid': 43898, 'retcode': 1, 'stderr': "'canmount' property cannot be inherited", 'stdout': ''}
         mock_cmd = MagicMock(return_value=ret)
-        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zfs.__utils__, utils_patch):
             self.assertEqual(zfs.inherit('canmount', 'myzpool/mydataset'), res)
 
     def test_diff(self):
         '''
         Tests zfs diff
         '''
-        res = ['M\t/\t/myzpool/mydataset/', '+\tF\t/myzpool/mydataset/hello']
-        ret = {'pid': 51495, 'retcode': 0, 'stderr': '', 'stdout': 'M\t/\t/myzpool/mydataset/\n+\tF\t/myzpool/mydataset/hello'}
+        res = [
+            "1517063879.144517494\tM\t\t/data/test/",
+            "1517063875.296592355\t+\t\t/data/test/world",
+            "1517063879.274438467\t+\t\t/data/test/hello",
+        ]
+        ret = {}
+        ret['retcode'] = 0
+        ret['stdout'] = "\n".join([
+            "1517063879.144517494\tM\t\t/data/test/",
+            "1517063875.296592355\t+\t\t/data/test/world",
+            "1517063879.274438467\t+\t\t/data/test/hello",
+        ])
+        ret['stderr'] = ''
         mock_cmd = MagicMock(return_value=ret)
-        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zfs.__utils__, utils_patch):
             self.assertEqual(zfs.diff('myzpool/mydataset@yesterday', 'myzpool/mydataset'), res)
+
+    def test_diff_parsed_time(self):
+        '''
+        Tests zfs diff
+        '''
+        ## NOTE: do not hardcode parsed timestamps, timezone play a role here.
+        ##       zfs diff output seems to be timezone aware
+        res = OrderedDict([
+            (strftime(1517063879.144517494, '%Y-%m-%d.%H:%M:%S.%f'), 'M\t\t/data/test/'),
+            (strftime(1517063875.296592355, '%Y-%m-%d.%H:%M:%S.%f'), '+\t\t/data/test/world'),
+            (strftime(1517063879.274438467, '%Y-%m-%d.%H:%M:%S.%f'), '+\t\t/data/test/hello'),
+        ])
+        ret = {}
+        ret['retcode'] = 0
+        ret['stdout'] = "\n".join([
+            "1517063879.144517494\tM\t\t/data/test/",
+            "1517063875.296592355\t+\t\t/data/test/world",
+            "1517063879.274438467\t+\t\t/data/test/hello",
+        ])
+        ret['stderr'] = ''
+        mock_cmd = MagicMock(return_value=ret)
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zfs.__utils__, utils_patch):
+            self.assertEqual(zfs.diff('myzpool/data@yesterday', 'myzpool/data', parsable=False), res)
 
     def test_rollback_success(self):
         '''
         Tests zfs rollback success
         '''
-        res = {'myzpool/mydataset': 'rolledback to snapshot: yesterday'}
+        res = OrderedDict([('rolledback', True)])
         ret = {'pid': 56502, 'retcode': 0, 'stderr': '', 'stdout': ''}
         mock_cmd = MagicMock(return_value=ret)
-        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zfs.__utils__, utils_patch):
             self.assertEqual(zfs.rollback('myzpool/mydataset@yesterday'), res)
 
     def test_rollback_failure(self):
         '''
         Tests zfs rollback failure
         '''
-        res = {'myzpool/mydataset': "cannot rollback to 'myzpool/mydataset@yesterday': more recent snapshots "
-                                    "or bookmarks exist\nuse '-r' to force deletion of the following snapshots "
-                                    "and bookmarks:\nmyzpool/mydataset@today"}
+        res = OrderedDict([
+            ('rolledback', False),
+            ('error', "\n".join([
+                    "cannot rollback to 'myzpool/mydataset@yesterday': more recent snapshots or bookmarks exist",
+                    "use 'recursive=True' to force deletion of the following snapshots and bookmarks:",
+                    "myzpool/mydataset@today"
+                ]),
+            ),
+        ])
         ret = {
             'pid': 57471,
             'retcode': 1,
@@ -303,47 +578,58 @@ class ZfsTestCase(TestCase, LoaderModuleMockMixin):
             'stdout': ''
         }
         mock_cmd = MagicMock(return_value=ret)
-        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zfs.__utils__, utils_patch):
             self.assertEqual(zfs.rollback('myzpool/mydataset@yesterday'), res)
 
     def test_clone_success(self):
         '''
         Tests zfs clone success
         '''
-        res = {'myzpool/yesterday': 'cloned from myzpool/mydataset@yesterday'}
+        res = OrderedDict([('cloned', True)])
         ret = {'pid': 64532, 'retcode': 0, 'stderr': '', 'stdout': ''}
         mock_cmd = MagicMock(return_value=ret)
-        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zfs.__utils__, utils_patch):
             self.assertEqual(zfs.clone('myzpool/mydataset@yesterday', 'myzpool/yesterday'), res)
 
     def test_clone_failure(self):
         '''
         Tests zfs clone failure
         '''
-        res = {'myzpool/archive/yesterday': "cannot create 'myzpool/archive/yesterday': parent does not exist"}
+        res = OrderedDict([
+            ('cloned', False),
+            ('error', "cannot create 'myzpool/archive/yesterday': parent does not exist"),
+        ])
         ret = {'pid': 64864, 'retcode': 1, 'stderr': "cannot create 'myzpool/archive/yesterday': parent does not exist", 'stdout': ''}
         mock_cmd = MagicMock(return_value=ret)
-        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zfs.__utils__, utils_patch):
             self.assertEqual(zfs.clone('myzpool/mydataset@yesterday', 'myzpool/archive/yesterday'), res)
 
     def test_promote_success(self):
         '''
         Tests zfs promote success
         '''
-        res = {'myzpool/yesterday': 'promoted'}
+        res = OrderedDict([('promoted', True)])
         ret = {'pid': 69075, 'retcode': 0, 'stderr': '', 'stdout': ''}
         mock_cmd = MagicMock(return_value=ret)
-        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zfs.__utils__, utils_patch):
             self.assertEqual(zfs.promote('myzpool/yesterday'), res)
 
     def test_promote_failure(self):
         '''
         Tests zfs promote failure
         '''
-        res = {'myzpool/yesterday': "cannot promote 'myzpool/yesterday': not a cloned filesystem"}
+        res = OrderedDict([
+            ('promoted', False),
+            ('error', "cannot promote 'myzpool/yesterday': not a cloned filesystem"),
+        ])
         ret = {'pid': 69209, 'retcode': 1, 'stderr': "cannot promote 'myzpool/yesterday': not a cloned filesystem", 'stdout': ''}
         mock_cmd = MagicMock(return_value=ret)
-        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zfs.__utils__, utils_patch):
             self.assertEqual(zfs.promote('myzpool/yesterday'), res)
 
     def test_bookmark_success(self):
@@ -351,138 +637,184 @@ class ZfsTestCase(TestCase, LoaderModuleMockMixin):
         Tests zfs bookmark success
         '''
         with patch('salt.utils.path.which', MagicMock(return_value='/usr/bin/man')):
-            res = {'myzpool/mydataset@yesterday': 'bookmarked as myzpool/mydataset#important'}
+            res = OrderedDict([('bookmarked', True)])
             ret = {'pid': 20990, 'retcode': 0, 'stderr': '', 'stdout': ''}
             mock_cmd = MagicMock(return_value=ret)
-            with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
+            with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
+                 patch.dict(zfs.__utils__, utils_patch):
                 self.assertEqual(zfs.bookmark('myzpool/mydataset@yesterday', 'myzpool/mydataset#important'), res)
 
     def test_holds_success(self):
         '''
         Tests zfs holds success
         '''
-        res = {'myzpool/mydataset@baseline': {'important  ': 'Wed Dec 23 21:06 2015', 'release-1.0': 'Wed Dec 23 21:08 2015'}}
+        res = OrderedDict([
+            ('important', 'Wed Dec 23 21:06 2015'),
+            ('release-1.0', 'Wed Dec 23 21:08 2015'),
+        ])
         ret = {'pid': 40216, 'retcode': 0, 'stderr': '', 'stdout': 'myzpool/mydataset@baseline\timportant  \tWed Dec 23 21:06 2015\nmyzpool/mydataset@baseline\trelease-1.0\tWed Dec 23 21:08 2015'}
         mock_cmd = MagicMock(return_value=ret)
-        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zfs.__utils__, utils_patch):
             self.assertEqual(zfs.holds('myzpool/mydataset@baseline'), res)
 
     def test_holds_failure(self):
         '''
         Tests zfs holds failure
         '''
-        res = {'myzpool/mydataset@baseline': "cannot open 'myzpool/mydataset@baseline': dataset does not exist"}
+        res = OrderedDict([
+            ('error', "cannot open 'myzpool/mydataset@baseline': dataset does not exist"),
+        ])
         ret = {'pid': 40993, 'retcode': 1, 'stderr': "cannot open 'myzpool/mydataset@baseline': dataset does not exist", 'stdout': 'no datasets available'}
         mock_cmd = MagicMock(return_value=ret)
-        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zfs.__utils__, utils_patch):
             self.assertEqual(zfs.holds('myzpool/mydataset@baseline'), res)
 
     def test_hold_success(self):
         '''
         Tests zfs hold success
         '''
-        res = {'myzpool/mydataset@baseline': {'important': 'held'}, 'myzpool/mydataset@release-1.0': {'important': 'held'}}
+        res = OrderedDict([('held', True)])
         ret = {'pid': 50876, 'retcode': 0, 'stderr': '', 'stdout': ''}
         mock_cmd = MagicMock(return_value=ret)
-        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zfs.__utils__, utils_patch):
             self.assertEqual(zfs.hold('important', 'myzpool/mydataset@baseline', 'myzpool/mydataset@release-1.0'), res)
 
     def test_hold_failure(self):
         '''
         Tests zfs hold failure
         '''
-        res = {'myzpool/mydataset@baseline': {'important': 'tag already exists on this dataset'}}
+        res = OrderedDict([
+            ('held', False),
+            ('error', "cannot hold snapshot 'myzpool/mydataset@baseline': tag already exists on this dataset"),
+        ])
         ret = {'pid': 51006, 'retcode': 1, 'stderr': "cannot hold snapshot 'myzpool/mydataset@baseline': tag already exists on this dataset", 'stdout': ''}
         mock_cmd = MagicMock(return_value=ret)
-        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zfs.__utils__, utils_patch):
             self.assertEqual(zfs.hold('important', 'myzpool/mydataset@baseline'), res)
 
     def test_release_success(self):
         '''
         Tests zfs release success
         '''
-        res = {'myzpool/mydataset@baseline': {'important': 'released'}, 'myzpool/mydataset@release-1.0': {'important': 'released'}}
+        res = OrderedDict([('released', True)])
         ret = {'pid': 50876, 'retcode': 0, 'stderr': '', 'stdout': ''}
         mock_cmd = MagicMock(return_value=ret)
-        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zfs.__utils__, utils_patch):
             self.assertEqual(zfs.release('important', 'myzpool/mydataset@baseline', 'myzpool/mydataset@release-1.0'), res)
 
     def test_release_failure(self):
         '''
         Tests zfs release failure
         '''
-        res = {'myzpool/mydataset@baseline': {'important': 'no such tag on this dataset'}}
+        res = OrderedDict([
+            ('released', False),
+        ('error', "cannot release hold from snapshot 'myzpool/mydataset@baseline': no such tag on this dataset"),
+        ])
         ret = {'pid': 51006, 'retcode': 1, 'stderr': "cannot release hold from snapshot 'myzpool/mydataset@baseline': no such tag on this dataset", 'stdout': ''}
         mock_cmd = MagicMock(return_value=ret)
-        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zfs.__utils__, utils_patch):
             self.assertEqual(zfs.release('important', 'myzpool/mydataset@baseline'), res)
 
     def test_snapshot_success(self):
         '''
         Tests zfs snapshot success
         '''
-        res = {'myzpool/mydataset@baseline': 'snapshotted'}
+        res = OrderedDict([('snapshotted', True)])
         ret = {'pid': 69125, 'retcode': 0, 'stderr': '', 'stdout': ''}
         mock_cmd = MagicMock(return_value=ret)
-        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zfs.__utils__, utils_patch):
             self.assertEqual(zfs.snapshot('myzpool/mydataset@baseline'), res)
 
     def test_snapshot_failure(self):
         '''
         Tests zfs snapshot failure
         '''
-        res = {'myzpool/mydataset@baseline': 'dataset already exists'}
+        res = OrderedDict([
+            ('snapshotted', False),
+            ('error', "cannot create snapshot 'myzpool/mydataset@baseline': dataset already exists"),
+        ])
         ret = {'pid': 68526, 'retcode': 1, 'stderr': "cannot create snapshot 'myzpool/mydataset@baseline': dataset already exists", 'stdout': ''}
         mock_cmd = MagicMock(return_value=ret)
-        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zfs.__utils__, utils_patch):
             self.assertEqual(zfs.snapshot('myzpool/mydataset@baseline'), res)
 
     def test_snapshot_failure2(self):
         '''
         Tests zfs snapshot failure
         '''
-        res = {'myzpool/mydataset@baseline': 'dataset does not exist'}
+        res = OrderedDict([
+            ('snapshotted', False),
+            ('error', "cannot open 'myzpool/mydataset': dataset does not exist"),
+        ])
         ret = {'pid': 69256, 'retcode': 2, 'stderr': "cannot open 'myzpool/mydataset': dataset does not exist\nusage:\n\tsnapshot [-r] [-o property=value] ... <filesystem|volume>@<snap> ...\n\nFor the property list, run: zfs set|get\n\nFor the delegated permission list, run: zfs allow|unallow", 'stdout': ''}
         mock_cmd = MagicMock(return_value=ret)
-        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zfs.__utils__, utils_patch):
             self.assertEqual(zfs.snapshot('myzpool/mydataset@baseline'), res)
 
     def test_set_success(self):
         '''
         Tests zfs set success
         '''
-        res = {'myzpool/mydataset': {'compression': 'set'}}
+        res = OrderedDict([('set', True)])
         ret = {'pid': 79736, 'retcode': 0, 'stderr': '', 'stdout': ''}
         mock_cmd = MagicMock(return_value=ret)
-        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zfs.__utils__, utils_patch):
             self.assertEqual(zfs.set('myzpool/mydataset', compression='lz4'), res)
 
     def test_set_failure(self):
         '''
         Tests zfs set failure
         '''
-        res = {'myzpool/mydataset': {'canmount': "'canmount' must be one of 'on | off | noauto'"}}
+        res = OrderedDict([
+            ('set', False),
+    ('error', "cannot set property for 'myzpool/mydataset': 'canmount' must be one of 'on | off | noauto'"),
+        ])
         ret = {'pid': 79887, 'retcode': 1, 'stderr': "cannot set property for 'myzpool/mydataset': 'canmount' must be one of 'on | off | noauto'", 'stdout': ''}
         mock_cmd = MagicMock(return_value=ret)
-        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zfs.__utils__, utils_patch):
             self.assertEqual(zfs.set('myzpool/mydataset', canmount='lz4'), res)
 
     def test_get_success(self):
         '''
         Tests zfs get success
         '''
-        res = OrderedDict([('myzpool', {'used': {'value': '844G'}})])
-        ret = {'pid': 562, 'retcode': 0, 'stderr': '', 'stdout': 'myzpool\tused\t844G'}
+        res = OrderedDict([
+            ('myzpool', OrderedDict([
+                ('used', OrderedDict([
+                    ('value', 906238099456),
+                ])),
+            ])),
+        ])
+        ret = {'pid': 562, 'retcode': 0, 'stderr': '', 'stdout': 'myzpool\tused\t906238099456'}
         mock_cmd = MagicMock(return_value=ret)
-        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zfs.__utils__, utils_patch):
             self.assertEqual(zfs.get('myzpool', properties='used', fields='value'), res)
 
     def test_get_parsable_success(self):
         '''
         Tests zfs get with parsable output
         '''
-        res = OrderedDict([('myzpool', {'used': {'value': 905792561152}})])
-        ret = {'pid': 562, 'retcode': 0, 'stderr': '', 'stdout': 'myzpool\tused\t905792561152'}
+        res = OrderedDict([
+            ('myzpool', OrderedDict([
+                ('used', OrderedDict([
+                    ('value', '844G'),
+                ])),
+            ])),
+        ])
+        ret = {'pid': 562, 'retcode': 0, 'stderr': '', 'stdout': 'myzpool\tused\t906238099456'}
         mock_cmd = MagicMock(return_value=ret)
-        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}):
-            self.assertEqual(zfs.get('myzpool', properties='used', fields='value', parsable=True), res)
+        with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zfs.__utils__, utils_patch):
+            self.assertEqual(zfs.get('myzpool', properties='used', fields='value', parsable=False), res)

--- a/tests/unit/modules/test_zpool.py
+++ b/tests/unit/modules/test_zpool.py
@@ -144,7 +144,7 @@ class ZpoolTestCase(TestCase, LoaderModuleMockMixin):
         with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}), \
              patch.dict(zpool.__utils__, utils_patch):
             ret = zpool.iostat('mypool', parsable=False)
-            self.assertEqual(ret['mypool']['capacity-alloc'], '46.7G')
+            self.assertEqual('46.7G', ret['mypool']['capacity-alloc'])
 
     def test_iostat_parsable(self):
         '''
@@ -172,7 +172,7 @@ class ZpoolTestCase(TestCase, LoaderModuleMockMixin):
         with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}), \
              patch.dict(zpool.__utils__, utils_patch):
             ret = zpool.iostat('mypool', parsable=True)
-            self.assertEqual(ret['mypool']['capacity-alloc'], 50143743180)
+            self.assertEqual(50143743180, ret['mypool']['capacity-alloc'])
 
     def test_list(self):
         '''
@@ -194,7 +194,7 @@ class ZpoolTestCase(TestCase, LoaderModuleMockMixin):
                 ('frag', '0%'),
                 ('health', 'ONLINE'),
             ]))])
-            self.assertEqual(res, ret)
+            self.assertEqual(ret, res)
 
     def test_list_parsable(self):
         '''
@@ -216,7 +216,7 @@ class ZpoolTestCase(TestCase, LoaderModuleMockMixin):
                 ('frag', '0%'),
                 ('health', 'ONLINE'),
             ]))])
-            self.assertEqual(res, ret)
+            self.assertEqual(ret, res)
 
     def test_get(self):
         '''
@@ -231,7 +231,7 @@ class ZpoolTestCase(TestCase, LoaderModuleMockMixin):
              patch.dict(zpool.__utils__, utils_patch):
             ret = zpool.get('mypool', 'size', parsable=False)
             res = OrderedDict(OrderedDict([('size', '1.81T')]))
-            self.assertEqual(res, ret)
+            self.assertEqual(ret, res)
 
     def test_get_parsable(self):
         '''
@@ -246,7 +246,7 @@ class ZpoolTestCase(TestCase, LoaderModuleMockMixin):
              patch.dict(zpool.__utils__, utils_patch):
             ret = zpool.get('mypool', 'size', parsable=True)
             res = OrderedDict(OrderedDict([('size', 1992864825344)]))
-            self.assertEqual(res, ret)
+            self.assertEqual(ret, res)
 
     def test_get_whitespace(self):
         '''
@@ -261,7 +261,7 @@ class ZpoolTestCase(TestCase, LoaderModuleMockMixin):
              patch.dict(zpool.__utils__, utils_patch):
             ret = zpool.get('mypool', 'comment')
             res = OrderedDict(OrderedDict([('comment', "my testing pool")]))
-            self.assertEqual(res, ret)
+            self.assertEqual(ret, res)
 
     def test_scrub_start(self):
         '''
@@ -279,7 +279,7 @@ class ZpoolTestCase(TestCase, LoaderModuleMockMixin):
              patch.dict(zpool.__utils__, utils_patch):
             ret = zpool.scrub('mypool')
             res = OrderedDict(OrderedDict([('scrubbing', True)]))
-            self.assertEqual(res, ret)
+            self.assertEqual(ret, res)
 
     def test_scrub_pause(self):
         '''
@@ -297,7 +297,7 @@ class ZpoolTestCase(TestCase, LoaderModuleMockMixin):
              patch.dict(zpool.__utils__, utils_patch):
             ret = zpool.scrub('mypool', pause=True)
             res = OrderedDict(OrderedDict([('scrubbing', False)]))
-            self.assertEqual(res, ret)
+            self.assertEqual(ret, res)
 
     def test_scrub_stop(self):
         '''
@@ -315,7 +315,7 @@ class ZpoolTestCase(TestCase, LoaderModuleMockMixin):
              patch.dict(zpool.__utils__, utils_patch):
             ret = zpool.scrub('mypool', stop=True)
             res = OrderedDict(OrderedDict([('scrubbing', False)]))
-            self.assertEqual(res, ret)
+            self.assertEqual(ret, res)
 
     def test_split_success(self):
         '''
@@ -331,7 +331,7 @@ class ZpoolTestCase(TestCase, LoaderModuleMockMixin):
              patch.dict(zpool.__utils__, utils_patch):
             ret = zpool.split('datapool', 'backuppool')
             res = OrderedDict([('split', True)])
-            self.assertEqual(res, ret)
+            self.assertEqual(ret, res)
 
     def test_split_exist_new(self):
         '''
@@ -347,7 +347,7 @@ class ZpoolTestCase(TestCase, LoaderModuleMockMixin):
              patch.dict(zpool.__utils__, utils_patch):
             ret = zpool.split('datapool', 'backuppool')
             res = OrderedDict([('split', False), ('error', 'Unable to split datapool: pool already exists')])
-            self.assertEqual(res, ret)
+            self.assertEqual(ret, res)
 
     def test_split_missing_pool(self):
         '''
@@ -363,7 +363,7 @@ class ZpoolTestCase(TestCase, LoaderModuleMockMixin):
              patch.dict(zpool.__utils__, utils_patch):
             ret = zpool.split('datapool', 'backuppool')
             res = OrderedDict([('split', False), ('error', "cannot open 'datapool': no such pool")])
-            self.assertEqual(res, ret)
+            self.assertEqual(ret, res)
 
     def test_split_not_mirror(self):
         '''
@@ -379,7 +379,7 @@ class ZpoolTestCase(TestCase, LoaderModuleMockMixin):
              patch.dict(zpool.__utils__, utils_patch):
             ret = zpool.split('datapool', 'backuppool')
             res = OrderedDict([('split', False), ('error', 'Unable to split datapool: Source pool must be composed only of mirrors')])
-            self.assertEqual(res, ret)
+            self.assertEqual(ret, res)
 
     def test_labelclear_success(self):
         '''
@@ -395,7 +395,7 @@ class ZpoolTestCase(TestCase, LoaderModuleMockMixin):
              patch.dict(zpool.__utils__, utils_patch):
             ret = zpool.labelclear('/dev/rdsk/c0t0d0', force=False)
             res = OrderedDict([('labelcleared', True)])
-            self.assertEqual(res, ret)
+            self.assertEqual(ret, res)
 
     def test_labelclear_nodevice(self):
         '''
@@ -414,7 +414,7 @@ class ZpoolTestCase(TestCase, LoaderModuleMockMixin):
                 ('labelcleared', False),
                 ('error', 'failed to open /dev/rdsk/c0t0d0: No such file or directory'),
             ])
-            self.assertEqual(res, ret)
+            self.assertEqual(ret, res)
 
     def test_labelclear_cleared(self):
         '''
@@ -433,7 +433,7 @@ class ZpoolTestCase(TestCase, LoaderModuleMockMixin):
                 ('labelcleared', False),
                 ('error', 'failed to read label from /dev/rdsk/c0t0d0'),
             ])
-            self.assertEqual(res, ret)
+            self.assertEqual(ret, res)
 
     def test_labelclear_exported(self):
         '''
@@ -454,7 +454,7 @@ class ZpoolTestCase(TestCase, LoaderModuleMockMixin):
                 ('labelcleared', False),
                 ('error', 'use \'force=True\' to override the following error:\n/dev/rdsk/c0t0d0 is a member of exported pool "mypool"'),
             ])
-            self.assertEqual(res, ret)
+            self.assertEqual(ret, res)
 
     @skipIf(not salt.utils.path.which('mkfile'), 'Cannot find mkfile executable')
     def test_create_file_vdev_success(self):
@@ -473,7 +473,7 @@ class ZpoolTestCase(TestCase, LoaderModuleMockMixin):
             res = OrderedDict([
                 ('/vdisks/disk0', 'created'),
             ])
-            self.assertEqual(res, ret)
+            self.assertEqual(ret, res)
 
     @skipIf(not salt.utils.path.which('mkfile'), 'Cannot find mkfile executable')
     def test_create_file_vdev_nospace(self):
@@ -495,7 +495,7 @@ class ZpoolTestCase(TestCase, LoaderModuleMockMixin):
                     ('/vdisks/disk0', ' initialized 10424320 of 67108864 bytes: No space left on device'),
                 ])),
             ])
-            self.assertEqual(res, ret)
+            self.assertEqual(ret, res)
 
     def test_export_success(self):
         '''
@@ -511,7 +511,7 @@ class ZpoolTestCase(TestCase, LoaderModuleMockMixin):
              patch.dict(zpool.__utils__, utils_patch):
             ret = zpool.export('mypool')
             res = OrderedDict([('exported', True)])
-            self.assertEqual(res, ret)
+            self.assertEqual(ret, res)
 
     def test_export_nopool(self):
         '''
@@ -527,7 +527,7 @@ class ZpoolTestCase(TestCase, LoaderModuleMockMixin):
              patch.dict(zpool.__utils__, utils_patch):
             ret = zpool.export('mypool')
             res = OrderedDict([('exported', False), ('error', "cannot open 'mypool': no such pool")])
-            self.assertEqual(res, ret)
+            self.assertEqual(ret, res)
 
     def test_import_success(self):
         '''
@@ -543,7 +543,7 @@ class ZpoolTestCase(TestCase, LoaderModuleMockMixin):
              patch.dict(zpool.__utils__, utils_patch):
             ret = zpool.import_('mypool')
             res = OrderedDict([('imported', True)])
-            self.assertEqual(res, ret)
+            self.assertEqual(ret, res)
 
     def test_import_duplicate(self):
         '''
@@ -565,7 +565,7 @@ class ZpoolTestCase(TestCase, LoaderModuleMockMixin):
                 ('imported', False),
                 ('error', "cannot import 'mypool': a pool with that name already exists\nuse the form 'zpool import <pool | id> <newpool>' to give it a new name"),
             ])
-            self.assertEqual(res, ret)
+            self.assertEqual(ret, res)
 
     def test_import_nopool(self):
         '''
@@ -584,7 +584,7 @@ class ZpoolTestCase(TestCase, LoaderModuleMockMixin):
                 ('imported', False),
                 ('error', "cannot import 'mypool': no such pool available"),
             ])
-            self.assertEqual(res, ret)
+            self.assertEqual(ret, res)
 
     def test_online_success(self):
         '''
@@ -600,7 +600,7 @@ class ZpoolTestCase(TestCase, LoaderModuleMockMixin):
              patch.dict(zpool.__utils__, utils_patch):
             ret = zpool.online('mypool', '/dev/rdsk/c0t0d0')
             res = OrderedDict([('onlined', True)])
-            self.assertEqual(res, ret)
+            self.assertEqual(ret, res)
 
     def test_online_nodevice(self):
         '''
@@ -619,7 +619,7 @@ class ZpoolTestCase(TestCase, LoaderModuleMockMixin):
                 ('onlined', False),
                 ('error', 'cannot online /dev/rdsk/c0t0d1: no such device in pool'),
             ])
-            self.assertEqual(res, ret)
+            self.assertEqual(ret, res)
 
     def test_offline_success(self):
         '''
@@ -635,7 +635,7 @@ class ZpoolTestCase(TestCase, LoaderModuleMockMixin):
              patch.dict(zpool.__utils__, utils_patch):
             ret = zpool.offline('mypool', '/dev/rdsk/c0t0d0')
             res = OrderedDict([('offlined', True)])
-            self.assertEqual(res, ret)
+            self.assertEqual(ret, res)
 
     def test_offline_nodevice(self):
         '''
@@ -654,7 +654,7 @@ class ZpoolTestCase(TestCase, LoaderModuleMockMixin):
                 ('offlined', False),
                 ('error', 'cannot offline /dev/rdsk/c0t0d1: no such device in pool'),
             ])
-            self.assertEqual(res, ret)
+            self.assertEqual(ret, res)
 
     def test_offline_noreplica(self):
         '''
@@ -673,7 +673,7 @@ class ZpoolTestCase(TestCase, LoaderModuleMockMixin):
                 ('offlined', False),
                 ('error', 'cannot offline /dev/rdsk/c0t0d1: no valid replicas'),
             ])
-            self.assertEqual(res, ret)
+            self.assertEqual(ret, res)
 
     def test_reguid_success(self):
         '''
@@ -689,7 +689,7 @@ class ZpoolTestCase(TestCase, LoaderModuleMockMixin):
              patch.dict(zpool.__utils__, utils_patch):
             ret = zpool.reguid('mypool')
             res = OrderedDict([('reguided', True)])
-            self.assertEqual(res, ret)
+            self.assertEqual(ret, res)
 
     def test_reguid_nopool(self):
         '''
@@ -708,7 +708,7 @@ class ZpoolTestCase(TestCase, LoaderModuleMockMixin):
                 ('reguided', False),
                 ('error', "cannot open 'mypool': no such pool"),
             ])
-            self.assertEqual(res, ret)
+            self.assertEqual(ret, res)
 
     def test_reopen_success(self):
         '''
@@ -724,7 +724,7 @@ class ZpoolTestCase(TestCase, LoaderModuleMockMixin):
              patch.dict(zpool.__utils__, utils_patch):
             ret = zpool.reopen('mypool')
             res = OrderedDict([('reopened', True)])
-            self.assertEqual(res, ret)
+            self.assertEqual(ret, res)
 
     def test_reopen_nopool(self):
         '''
@@ -743,7 +743,7 @@ class ZpoolTestCase(TestCase, LoaderModuleMockMixin):
                 ('reopened', False),
                 ('error', "cannot open 'mypool': no such pool"),
             ])
-            self.assertEqual(res, ret)
+            self.assertEqual(ret, res)
 
     def test_upgrade_success(self):
         '''
@@ -759,7 +759,7 @@ class ZpoolTestCase(TestCase, LoaderModuleMockMixin):
              patch.dict(zpool.__utils__, utils_patch):
             ret = zpool.upgrade('mypool')
             res = OrderedDict([('upgraded', True)])
-            self.assertEqual(res, ret)
+            self.assertEqual(ret, res)
 
     def test_upgrade_nopool(self):
         '''
@@ -778,7 +778,7 @@ class ZpoolTestCase(TestCase, LoaderModuleMockMixin):
                 ('upgraded', False),
                 ('error', "cannot open 'mypool': no such pool"),
             ])
-            self.assertEqual(res, ret)
+            self.assertEqual(ret, res)
 
     def test_history_success(self):
         '''
@@ -803,7 +803,7 @@ class ZpoolTestCase(TestCase, LoaderModuleMockMixin):
                     ('2018-01-19.16:01:55', 'zpool attach -f mypool /dev/rdsk/c0t0d0 /dev/rdsk/c0t0d1'),
                 ])),
             ])
-            self.assertEqual(res, ret)
+            self.assertEqual(ret, res)
 
     def test_history_nopool(self):
         '''
@@ -821,7 +821,7 @@ class ZpoolTestCase(TestCase, LoaderModuleMockMixin):
             res = OrderedDict([
                 ('error', "cannot open 'mypool': no such pool"),
             ])
-            self.assertEqual(res, ret)
+            self.assertEqual(ret, res)
 
     def test_clear_success(self):
         '''
@@ -837,7 +837,7 @@ class ZpoolTestCase(TestCase, LoaderModuleMockMixin):
              patch.dict(zpool.__utils__, utils_patch):
             ret = zpool.clear('mypool')
             res = OrderedDict([('cleared', True)])
-            self.assertEqual(res, ret)
+            self.assertEqual(ret, res)
 
     def test_clear_nopool(self):
         '''
@@ -874,5 +874,4 @@ class ZpoolTestCase(TestCase, LoaderModuleMockMixin):
                 ('cleared', False),
                 ('error', "cannot clear errors for /dev/rdsk/c0t0d0: no such device in pool"),
             ])
-            self.assertEqual(res, ret)
-            self.assertEqual(res, ret)
+            self.assertEqual(ret, res)

--- a/tests/unit/modules/test_zpool.py
+++ b/tests/unit/modules/test_zpool.py
@@ -1,9 +1,12 @@
 # -*- coding: utf-8 -*-
 '''
-    :codeauthor: Nitin Madhok <nmadhok@clemson.edu>`
+Tests for salt.modules.zpool
 
-    tests.unit.modules.zpool_test
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+:codeauthor:    Nitin Madhok <nmadhok@clemson.edu>, Jorge Schrauwen <sjorge@blackdot.be>
+:maintainer:    Jorge Schrauwen <sjorge@blackdot.be>
+:maturity:      new
+:depends:       salt.utils.zfs
+:platform:      illumos,freebsd,linux
 '''
 
 # Import Python libs
@@ -13,18 +16,24 @@ from __future__ import absolute_import, print_function, unicode_literals
 from tests.support.mixins import LoaderModuleMockMixin
 from tests.support.unit import skipIf, TestCase
 from tests.support.mock import (
-    Mock,
     MagicMock,
     patch,
     NO_MOCK,
     NO_MOCK_REASON,
 )
 
+# Import test data from salt.utils.zfs test
+from tests.unit.utils.test_zfs import utils_patch
+
 # Import Salt Execution module to test
+import salt.utils.zfs
 import salt.modules.zpool as zpool
 
 # Import Salt Utils
+import salt.loader
 from salt.utils.odict import OrderedDict
+import salt.utils.decorators
+import salt.utils.decorators.path
 
 
 # Skip this test case if we don't have access to mock!
@@ -34,11 +43,16 @@ class ZpoolTestCase(TestCase, LoaderModuleMockMixin):
     This class contains a set of functions that test salt.modules.zpool module
     '''
     def setup_loader_modules(self):
-        patcher = patch('salt.modules.zpool._check_zpool',
-                        MagicMock(return_value='/sbin/zpool'))
-        patcher.start()
-        self.addCleanup(patcher.stop)
-        return {zpool: {}}
+        self.opts = opts = salt.config.DEFAULT_MINION_OPTS
+        utils = salt.loader.utils(opts, whitelist=['zfs'])
+        zpool_obj = {
+            zpool: {
+                '__opts__': opts,
+                '__utils__': utils,
+            }
+        }
+
+        return zpool_obj
 
     def test_exists_success(self):
         '''
@@ -50,7 +64,8 @@ class ZpoolTestCase(TestCase, LoaderModuleMockMixin):
         ret['stderr'] = ""
         ret['retcode'] = 0
         mock_cmd = MagicMock(return_value=ret)
-        with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}):
+        with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zpool.__utils__, utils_patch):
             self.assertTrue(zpool.exists('myzpool'))
 
     def test_exists_failure(self):
@@ -62,7 +77,9 @@ class ZpoolTestCase(TestCase, LoaderModuleMockMixin):
         ret['stderr'] = "cannot open 'myzpool': no such pool"
         ret['retcode'] = 1
         mock_cmd = MagicMock(return_value=ret)
-        with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}):
+
+        with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zpool.__utils__, utils_patch):
             self.assertFalse(zpool.exists('myzpool'))
 
     def test_healthy(self):
@@ -74,7 +91,9 @@ class ZpoolTestCase(TestCase, LoaderModuleMockMixin):
         ret['stderr'] = ""
         ret['retcode'] = 0
         mock_cmd = MagicMock(return_value=ret)
-        with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}):
+
+        with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zpool.__utils__, utils_patch):
             self.assertTrue(zpool.healthy())
 
     def test_status(self):
@@ -88,18 +107,19 @@ class ZpoolTestCase(TestCase, LoaderModuleMockMixin):
             "  scan: scrub repaired 0 in 0h6m with 0 errors on Mon Dec 21 02:06:17 2015",
             "config:",
             "",
-            "        NAME        STATE     READ WRITE CKSUM",
-            "        mypool      ONLINE       0     0     0",
-            "          mirror-0  ONLINE       0     0     0",
-            "            c2t0d0  ONLINE       0     0     0",
-            "            c2t1d0  ONLINE       0     0     0",
+            "\tNAME        STATE     READ WRITE CKSUM",
+            "\tmypool      ONLINE       0     0     0",
+            "\t  mirror-0  ONLINE       0     0     0",
+            "\t    c2t0d0  ONLINE       0     0     0",
+            "\t    c2t1d0  ONLINE       0     0     0",
             "",
             "errors: No known data errors",
         ])
         ret['stderr'] = ""
         ret['retcode'] = 0
         mock_cmd = MagicMock(return_value=ret)
-        with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}):
+        with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}), \
+                patch.dict(zpool.__utils__, utils_patch):
             ret = zpool.status()
             self.assertEqual('ONLINE', ret['mypool']['state'])
 
@@ -121,25 +141,59 @@ class ZpoolTestCase(TestCase, LoaderModuleMockMixin):
         ret['stderr'] = ""
         ret['retcode'] = 0
         mock_cmd = MagicMock(return_value=ret)
-        with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}):
-            ret = zpool.iostat('mypool')
-            self.assertEqual('46.7G', ret['mypool']['mypool']['capacity-alloc'])
+        with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zpool.__utils__, utils_patch):
+            ret = zpool.iostat('mypool', parsable=False)
+            self.assertEqual(ret['mypool']['capacity-alloc'], '46.7G')
+
+    def test_iostat_parsable(self):
+        '''
+        Tests successful return of iostat function
+
+        .. note:
+            The command output is the same as the non parsable!
+            There is no -p flag for zpool iostat, but our type
+            conversions can handle this!
+        '''
+        ret = {}
+        ret['stdout'] = "\n".join([
+            "               capacity     operations    bandwidth",
+            "pool        alloc   free   read  write   read  write",
+            "----------  -----  -----  -----  -----  -----  -----",
+            "mypool      46.7G  64.3G      4     19   113K   331K",
+            "  mirror    46.7G  64.3G      4     19   113K   331K",
+            "    c2t0d0      -      -      1     10   114K   334K",
+            "    c2t1d0      -      -      1     10   114K   334K",
+            "----------  -----  -----  -----  -----  -----  -----",
+        ])
+        ret['stderr'] = ""
+        ret['retcode'] = 0
+        mock_cmd = MagicMock(return_value=ret)
+        with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zpool.__utils__, utils_patch):
+            ret = zpool.iostat('mypool', parsable=True)
+            self.assertEqual(ret['mypool']['capacity-alloc'], 50143743180)
 
     def test_list(self):
         '''
         Tests successful return of list function
         '''
         ret = {}
-        ret['stdout'] = "mypool\t1.81T\t714G\t1.11T\t38%\tONLINE"
+        ret['stdout'] = "mypool\t1992864825344\t767076794368\t1225788030976\t38\t0%\tONLINE"
         ret['stderr'] = ""
         ret['retcode'] = 0
         mock_cmd = MagicMock(return_value=ret)
         with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}), \
-                patch('salt.modules.zpool._check_features',
-                      MagicMock(return_value=False)):
-            ret = zpool.list_()
-            res = OrderedDict([('mypool', {'alloc': '714G', 'cap': '38%', 'free': '1.11T',
-                                           'health': 'ONLINE', 'size': '1.81T'})])
+                patch.dict(zpool.__utils__, utils_patch):
+            ret = zpool.list_(parsable=False)
+            res = OrderedDict([('mypool', OrderedDict([
+                ('size', '1.81T'),
+                ('alloc', '714G'),
+                ('free', '1.11T'),
+                ('cap', 38),
+                ('frag', '0%'),
+                ('health', 'ONLINE'),
+            ]))])
             self.assertEqual(res, ret)
 
     def test_list_parsable(self):
@@ -147,17 +201,21 @@ class ZpoolTestCase(TestCase, LoaderModuleMockMixin):
         Tests successful return of list function with parsable output
         '''
         ret = {}
-        ret['stdout'] = "mypool\t1992864825344\t767076794368\t1225788030976\t38\tONLINE"
+        ret['stdout'] = "mypool\t1992864825344\t767076794368\t1225788030976\t38\t0%\tONLINE"
         ret['stderr'] = ""
         ret['retcode'] = 0
         mock_cmd = MagicMock(return_value=ret)
         with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}), \
-                patch('salt.modules.zpool._check_features',
-                      MagicMock(return_value=False)):
-            ret = zpool.list_()
-            res = OrderedDict([('mypool', {'alloc': 767076794368, 'cap': 38,
-                                           'free': 1225788030976, 'health': 'ONLINE',
-                                           'size': 1992864825344})])
+                patch.dict(zpool.__utils__, utils_patch):
+            ret = zpool.list_(parsable=True)
+            res = OrderedDict([('mypool', OrderedDict([
+                ('size', 1992864825344),
+                ('alloc', 767076794368),
+                ('free', 1225788030976),
+                ('cap', 38),
+                ('frag', '0%'),
+                ('health', 'ONLINE'),
+            ]))])
             self.assertEqual(res, ret)
 
     def test_get(self):
@@ -165,13 +223,14 @@ class ZpoolTestCase(TestCase, LoaderModuleMockMixin):
         Tests successful return of get function
         '''
         ret = {}
-        ret['stdout'] = "size\t1.81T\t-\n"
+        ret['stdout'] = "size\t1992864825344\t-\n"
         ret['stderr'] = ""
         ret['retcode'] = 0
         mock_cmd = MagicMock(return_value=ret)
-        with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}):
-            ret = zpool.get('mypool', 'size')
-            res = OrderedDict([('mypool', OrderedDict([('size', '1.81T')]))])
+        with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zpool.__utils__, utils_patch):
+            ret = zpool.get('mypool', 'size', parsable=False)
+            res = OrderedDict(OrderedDict([('size', '1.81T')]))
             self.assertEqual(res, ret)
 
     def test_get_parsable(self):
@@ -183,9 +242,10 @@ class ZpoolTestCase(TestCase, LoaderModuleMockMixin):
         ret['stderr'] = ""
         ret['retcode'] = 0
         mock_cmd = MagicMock(return_value=ret)
-        with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}):
-            ret = zpool.get('mypool', 'size')
-            res = OrderedDict([('mypool', OrderedDict([('size', 1992864825344)]))])
+        with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zpool.__utils__, utils_patch):
+            ret = zpool.get('mypool', 'size', parsable=True)
+            res = OrderedDict(OrderedDict([('size', 1992864825344)]))
             self.assertEqual(res, ret)
 
     def test_get_whitespace(self):
@@ -197,9 +257,10 @@ class ZpoolTestCase(TestCase, LoaderModuleMockMixin):
         ret['stderr'] = ""
         ret['retcode'] = 0
         mock_cmd = MagicMock(return_value=ret)
-        with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}):
+        with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zpool.__utils__, utils_patch):
             ret = zpool.get('mypool', 'comment')
-            res = OrderedDict([('mypool', OrderedDict([('comment', "'my testing pool'")]))])
+            res = OrderedDict(OrderedDict([('comment', "my testing pool")]))
             self.assertEqual(res, ret)
 
     def test_scrub_start(self):
@@ -213,11 +274,12 @@ class ZpoolTestCase(TestCase, LoaderModuleMockMixin):
         mock_cmd = MagicMock(return_value=ret)
         mock_exists = MagicMock(return_value=True)
 
-        with patch.dict(zpool.__salt__, {'zpool.exists': mock_exists}):
-            with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}):
-                ret = zpool.scrub('mypool')
-                res = OrderedDict([('mypool', OrderedDict([('scrubbing', True)]))])
-                self.assertEqual(res, ret)
+        with patch.dict(zpool.__salt__, {'zpool.exists': mock_exists}), \
+             patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zpool.__utils__, utils_patch):
+            ret = zpool.scrub('mypool')
+            res = OrderedDict(OrderedDict([('scrubbing', True)]))
+            self.assertEqual(res, ret)
 
     def test_scrub_pause(self):
         '''
@@ -230,11 +292,12 @@ class ZpoolTestCase(TestCase, LoaderModuleMockMixin):
         mock_cmd = MagicMock(return_value=ret)
         mock_exists = MagicMock(return_value=True)
 
-        with patch.dict(zpool.__salt__, {'zpool.exists': mock_exists}):
-            with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}):
-                ret = zpool.scrub('mypool', pause=True)
-                res = OrderedDict([('mypool', OrderedDict([('scrubbing', False)]))])
-                self.assertEqual(res, ret)
+        with patch.dict(zpool.__salt__, {'zpool.exists': mock_exists}), \
+             patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zpool.__utils__, utils_patch):
+            ret = zpool.scrub('mypool', pause=True)
+            res = OrderedDict(OrderedDict([('scrubbing', False)]))
+            self.assertEqual(res, ret)
 
     def test_scrub_stop(self):
         '''
@@ -247,11 +310,12 @@ class ZpoolTestCase(TestCase, LoaderModuleMockMixin):
         mock_cmd = MagicMock(return_value=ret)
         mock_exists = MagicMock(return_value=True)
 
-        with patch.dict(zpool.__salt__, {'zpool.exists': mock_exists}):
-            with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}):
-                ret = zpool.scrub('mypool', stop=True)
-                res = OrderedDict([('mypool', OrderedDict([('scrubbing', False)]))])
-                self.assertEqual(res, ret)
+        with patch.dict(zpool.__salt__, {'zpool.exists': mock_exists}), \
+             patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zpool.__utils__, utils_patch):
+            ret = zpool.scrub('mypool', stop=True)
+            res = OrderedDict(OrderedDict([('scrubbing', False)]))
+            self.assertEqual(res, ret)
 
     def test_split_success(self):
         '''
@@ -262,14 +326,12 @@ class ZpoolTestCase(TestCase, LoaderModuleMockMixin):
         ret['stderr'] = ""
         ret['retcode'] = 0
         mock_cmd = MagicMock(return_value=ret)
-        mock_exists = Mock()
-        mock_exists.side_effect = [False, True]
 
-        with patch.dict(zpool.__salt__, {'zpool.exists': mock_exists}):
-            with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}):
-                ret = zpool.split('datapool', 'backuppool')
-                res = OrderedDict([('backuppool', 'split off from datapool')])
-                self.assertEqual(res, ret)
+        with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zpool.__utils__, utils_patch):
+            ret = zpool.split('datapool', 'backuppool')
+            res = OrderedDict([('split', True)])
+            self.assertEqual(res, ret)
 
     def test_split_exist_new(self):
         '''
@@ -277,17 +339,15 @@ class ZpoolTestCase(TestCase, LoaderModuleMockMixin):
         '''
         ret = {}
         ret['stdout'] = ""
-        ret['stderr'] = ""
-        ret['retcode'] = 0
+        ret['stderr'] = "Unable to split datapool: pool already exists"
+        ret['retcode'] = 1
         mock_cmd = MagicMock(return_value=ret)
-        mock_exists = Mock()
-        mock_exists.side_effect = [True, True]
 
-        with patch.dict(zpool.__salt__, {'zpool.exists': mock_exists}):
-            with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}):
-                ret = zpool.split('datapool', 'backuppool')
-                res = OrderedDict([('backuppool', 'storage pool already exists')])
-                self.assertEqual(res, ret)
+        with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zpool.__utils__, utils_patch):
+            ret = zpool.split('datapool', 'backuppool')
+            res = OrderedDict([('split', False), ('error', 'Unable to split datapool: pool already exists')])
+            self.assertEqual(res, ret)
 
     def test_split_missing_pool(self):
         '''
@@ -295,17 +355,15 @@ class ZpoolTestCase(TestCase, LoaderModuleMockMixin):
         '''
         ret = {}
         ret['stdout'] = ""
-        ret['stderr'] = ""
-        ret['retcode'] = 0
+        ret['stderr'] = "cannot open 'datapool': no such pool"
+        ret['retcode'] = 1
         mock_cmd = MagicMock(return_value=ret)
-        mock_exists = Mock()
-        mock_exists.side_effect = [False, False]
 
-        with patch.dict(zpool.__salt__, {'zpool.exists': mock_exists}):
-            with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}):
-                ret = zpool.split('datapool', 'backuppool')
-                res = OrderedDict([('datapool', 'storage pool does not exists')])
-                self.assertEqual(res, ret)
+        with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zpool.__utils__, utils_patch):
+            ret = zpool.split('datapool', 'backuppool')
+            res = OrderedDict([('split', False), ('error', "cannot open 'datapool': no such pool")])
+            self.assertEqual(res, ret)
 
     def test_split_not_mirror(self):
         '''
@@ -316,15 +374,12 @@ class ZpoolTestCase(TestCase, LoaderModuleMockMixin):
         ret['stderr'] = "Unable to split datapool: Source pool must be composed only of mirrors"
         ret['retcode'] = 1
         mock_cmd = MagicMock(return_value=ret)
-        mock_exists = Mock()
-        mock_exists.side_effect = [False, True]
 
-        with patch.dict(zpool.__salt__, {'zpool.exists': mock_exists}):
-            with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}):
-                ret = zpool.split('datapool', 'backuppool')
-                res = OrderedDict([('backuppool', 'Unable to split datapool: '
-                                                  'Source pool must be composed only of mirrors')])
-                self.assertEqual(res, ret)
+        with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zpool.__utils__, utils_patch):
+            ret = zpool.split('datapool', 'backuppool')
+            res = OrderedDict([('split', False), ('error', 'Unable to split datapool: Source pool must be composed only of mirrors')])
+            self.assertEqual(res, ret)
 
     def test_labelclear_success(self):
         '''
@@ -335,9 +390,30 @@ class ZpoolTestCase(TestCase, LoaderModuleMockMixin):
         ret['stderr'] = ""
         ret['retcode'] = 0
         mock_cmd = MagicMock(return_value=ret)
-        with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}):
+
+        with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zpool.__utils__, utils_patch):
             ret = zpool.labelclear('/dev/rdsk/c0t0d0', force=False)
-            res = OrderedDict([('/dev/rdsk/c0t0d0', 'cleared')])
+            res = OrderedDict([('labelcleared', True)])
+            self.assertEqual(res, ret)
+
+    def test_labelclear_nodevice(self):
+        '''
+        Tests labelclear on non existing device
+        '''
+        ret = {}
+        ret['stdout'] = ""
+        ret['stderr'] = "failed to open /dev/rdsk/c0t0d0: No such file or directory"
+        ret['retcode'] = 1
+        mock_cmd = MagicMock(return_value=ret)
+
+        with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zpool.__utils__, utils_patch):
+            ret = zpool.labelclear('/dev/rdsk/c0t0d0', force=False)
+            res = OrderedDict([
+                ('labelcleared', False),
+                ('error', 'failed to open /dev/rdsk/c0t0d0: No such file or directory'),
+            ])
             self.assertEqual(res, ret)
 
     def test_labelclear_cleared(self):
@@ -349,9 +425,14 @@ class ZpoolTestCase(TestCase, LoaderModuleMockMixin):
         ret['stderr'] = "failed to read label from /dev/rdsk/c0t0d0"
         ret['retcode'] = 1
         mock_cmd = MagicMock(return_value=ret)
-        with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}):
+
+        with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zpool.__utils__, utils_patch):
             ret = zpool.labelclear('/dev/rdsk/c0t0d0', force=False)
-            res = OrderedDict([('/dev/rdsk/c0t0d0', 'failed to read label from /dev/rdsk/c0t0d0')])
+            res = OrderedDict([
+                ('labelcleared', False),
+                ('error', 'failed to read label from /dev/rdsk/c0t0d0'),
+            ])
             self.assertEqual(res, ret)
 
     def test_labelclear_exported(self):
@@ -366,7 +447,432 @@ class ZpoolTestCase(TestCase, LoaderModuleMockMixin):
         ])
         ret['retcode'] = 1
         mock_cmd = MagicMock(return_value=ret)
-        with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}):
+        with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zpool.__utils__, utils_patch):
             ret = zpool.labelclear('/dev/rdsk/c0t0d0', force=False)
-            res = OrderedDict([('/dev/rdsk/c0t0d0', '/dev/rdsk/c0t0d0 is a member of exported pool "mypool"')])
+            res = OrderedDict([
+                ('labelcleared', False),
+                ('error', 'use \'force=True\' to override the following error:\n/dev/rdsk/c0t0d0 is a member of exported pool "mypool"'),
+            ])
+            self.assertEqual(res, ret)
+
+    @skipIf(not salt.utils.path.which('mkfile'), 'Cannot find mkfile executable')
+    def test_create_file_vdev_success(self):
+        '''
+        Tests create_file_vdev when out of space
+        '''
+        ret = {}
+        ret['stdout'] = ""
+        ret['stderr'] = ""
+        ret['retcode'] = 0
+        mock_cmd = MagicMock(return_value=ret)
+
+        with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zpool.__utils__, utils_patch):
+            ret = zpool.create_file_vdev('64M', '/vdisks/disk0')
+            res = OrderedDict([
+                ('/vdisks/disk0', 'created'),
+            ])
+            self.assertEqual(res, ret)
+
+    @skipIf(not salt.utils.path.which('mkfile'), 'Cannot find mkfile executable')
+    def test_create_file_vdev_nospace(self):
+        '''
+        Tests create_file_vdev when out of space
+        '''
+        ret = {}
+        ret['stdout'] = ""
+        ret['stderr'] = "/vdisks/disk0: initialized 10424320 of 67108864 bytes: No space left on device"
+        ret['retcode'] = 1
+        mock_cmd = MagicMock(return_value=ret)
+
+        with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zpool.__utils__, utils_patch):
+            ret = zpool.create_file_vdev('64M', '/vdisks/disk0')
+            res = OrderedDict([
+                ('/vdisks/disk0', 'failed'),
+                ('error', OrderedDict([
+                    ('/vdisks/disk0', ' initialized 10424320 of 67108864 bytes: No space left on device'),
+                ])),
+            ])
+            self.assertEqual(res, ret)
+
+    def test_export_success(self):
+        '''
+        Tests export
+        '''
+        ret = {}
+        ret['stdout'] = ""
+        ret['stderr'] = ""
+        ret['retcode'] = 0
+        mock_cmd = MagicMock(return_value=ret)
+
+        with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zpool.__utils__, utils_patch):
+            ret = zpool.export('mypool')
+            res = OrderedDict([('exported', True)])
+            self.assertEqual(res, ret)
+
+    def test_export_nopool(self):
+        '''
+        Tests export when the pool does not exists
+        '''
+        ret = {}
+        ret['stdout'] = ""
+        ret['stderr'] = "cannot open 'mypool': no such pool"
+        ret['retcode'] = 1
+        mock_cmd = MagicMock(return_value=ret)
+
+        with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zpool.__utils__, utils_patch):
+            ret = zpool.export('mypool')
+            res = OrderedDict([('exported', False), ('error', "cannot open 'mypool': no such pool")])
+            self.assertEqual(res, ret)
+
+    def test_import_success(self):
+        '''
+        Tests import
+        '''
+        ret = {}
+        ret['stdout'] = ""
+        ret['stderr'] = ""
+        ret['retcode'] = 0
+        mock_cmd = MagicMock(return_value=ret)
+
+        with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zpool.__utils__, utils_patch):
+            ret = zpool.import_('mypool')
+            res = OrderedDict([('imported', True)])
+            self.assertEqual(res, ret)
+
+    def test_import_duplicate(self):
+        '''
+        Tests import with already imported pool
+        '''
+        ret = {}
+        ret['stdout'] = ""
+        ret['stderr'] = "\n".join([
+            "cannot import 'mypool': a pool with that name already exists",
+            "use the form 'zpool import <pool | id> <newpool>' to give it a new name",
+        ])
+        ret['retcode'] = 1
+        mock_cmd = MagicMock(return_value=ret)
+
+        with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zpool.__utils__, utils_patch):
+            ret = zpool.import_('mypool')
+            res = OrderedDict([
+                ('imported', False),
+                ('error', "cannot import 'mypool': a pool with that name already exists\nuse the form 'zpool import <pool | id> <newpool>' to give it a new name"),
+            ])
+            self.assertEqual(res, ret)
+
+    def test_import_nopool(self):
+        '''
+        Tests import
+        '''
+        ret = {}
+        ret['stdout'] = ""
+        ret['stderr'] = "cannot import 'mypool': no such pool available"
+        ret['retcode'] = 1
+        mock_cmd = MagicMock(return_value=ret)
+
+        with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zpool.__utils__, utils_patch):
+            ret = zpool.import_('mypool')
+            res = OrderedDict([
+                ('imported', False),
+                ('error', "cannot import 'mypool': no such pool available"),
+            ])
+            self.assertEqual(res, ret)
+
+    def test_online_success(self):
+        '''
+        Tests online
+        '''
+        ret = {}
+        ret['stdout'] = ""
+        ret['stderr'] = ""
+        ret['retcode'] = 0
+        mock_cmd = MagicMock(return_value=ret)
+
+        with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zpool.__utils__, utils_patch):
+            ret = zpool.online('mypool', '/dev/rdsk/c0t0d0')
+            res = OrderedDict([('onlined', True)])
+            self.assertEqual(res, ret)
+
+    def test_online_nodevice(self):
+        '''
+        Tests online
+        '''
+        ret = {}
+        ret['stdout'] = ""
+        ret['stderr'] = "cannot online /dev/rdsk/c0t0d1: no such device in pool"
+        ret['retcode'] = 1
+        mock_cmd = MagicMock(return_value=ret)
+
+        with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zpool.__utils__, utils_patch):
+            ret = zpool.online('mypool', '/dev/rdsk/c0t0d1')
+            res = OrderedDict([
+                ('onlined', False),
+                ('error', 'cannot online /dev/rdsk/c0t0d1: no such device in pool'),
+            ])
+            self.assertEqual(res, ret)
+
+    def test_offline_success(self):
+        '''
+        Tests offline
+        '''
+        ret = {}
+        ret['stdout'] = ""
+        ret['stderr'] = ""
+        ret['retcode'] = 0
+        mock_cmd = MagicMock(return_value=ret)
+
+        with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zpool.__utils__, utils_patch):
+            ret = zpool.offline('mypool', '/dev/rdsk/c0t0d0')
+            res = OrderedDict([('offlined', True)])
+            self.assertEqual(res, ret)
+
+    def test_offline_nodevice(self):
+        '''
+        Tests offline
+        '''
+        ret = {}
+        ret['stdout'] = ""
+        ret['stderr'] = "cannot offline /dev/rdsk/c0t0d1: no such device in pool"
+        ret['retcode'] = 1
+        mock_cmd = MagicMock(return_value=ret)
+
+        with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zpool.__utils__, utils_patch):
+            ret = zpool.offline('mypool', '/dev/rdsk/c0t0d1')
+            res = OrderedDict([
+                ('offlined', False),
+                ('error', 'cannot offline /dev/rdsk/c0t0d1: no such device in pool'),
+            ])
+            self.assertEqual(res, ret)
+
+    def test_offline_noreplica(self):
+        '''
+        Tests offline
+        '''
+        ret = {}
+        ret['stdout'] = ""
+        ret['stderr'] = "cannot offline /dev/rdsk/c0t0d1: no valid replicas"
+        ret['retcode'] = 1
+        mock_cmd = MagicMock(return_value=ret)
+
+        with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zpool.__utils__, utils_patch):
+            ret = zpool.offline('mypool', '/dev/rdsk/c0t0d1')
+            res = OrderedDict([
+                ('offlined', False),
+                ('error', 'cannot offline /dev/rdsk/c0t0d1: no valid replicas'),
+            ])
+            self.assertEqual(res, ret)
+
+    def test_reguid_success(self):
+        '''
+        Tests reguid
+        '''
+        ret = {}
+        ret['stdout'] = ""
+        ret['stderr'] = ""
+        ret['retcode'] = 0
+        mock_cmd = MagicMock(return_value=ret)
+
+        with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zpool.__utils__, utils_patch):
+            ret = zpool.reguid('mypool')
+            res = OrderedDict([('reguided', True)])
+            self.assertEqual(res, ret)
+
+    def test_reguid_nopool(self):
+        '''
+        Tests reguid with missing pool
+        '''
+        ret = {}
+        ret['stdout'] = ""
+        ret['stderr'] = "cannot open 'mypool': no such pool"
+        ret['retcode'] = 1
+        mock_cmd = MagicMock(return_value=ret)
+
+        with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zpool.__utils__, utils_patch):
+            ret = zpool.reguid('mypool')
+            res = OrderedDict([
+                ('reguided', False),
+                ('error', "cannot open 'mypool': no such pool"),
+            ])
+            self.assertEqual(res, ret)
+
+    def test_reopen_success(self):
+        '''
+        Tests reopen
+        '''
+        ret = {}
+        ret['stdout'] = ""
+        ret['stderr'] = ""
+        ret['retcode'] = 0
+        mock_cmd = MagicMock(return_value=ret)
+
+        with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zpool.__utils__, utils_patch):
+            ret = zpool.reopen('mypool')
+            res = OrderedDict([('reopened', True)])
+            self.assertEqual(res, ret)
+
+    def test_reopen_nopool(self):
+        '''
+        Tests reopen with missing pool
+        '''
+        ret = {}
+        ret['stdout'] = ""
+        ret['stderr'] = "cannot open 'mypool': no such pool"
+        ret['retcode'] = 1
+        mock_cmd = MagicMock(return_value=ret)
+
+        with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zpool.__utils__, utils_patch):
+            ret = zpool.reopen('mypool')
+            res = OrderedDict([
+                ('reopened', False),
+                ('error', "cannot open 'mypool': no such pool"),
+            ])
+            self.assertEqual(res, ret)
+
+    def test_upgrade_success(self):
+        '''
+        Tests upgrade
+        '''
+        ret = {}
+        ret['stdout'] = ""
+        ret['stderr'] = ""
+        ret['retcode'] = 0
+        mock_cmd = MagicMock(return_value=ret)
+
+        with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zpool.__utils__, utils_patch):
+            ret = zpool.upgrade('mypool')
+            res = OrderedDict([('upgraded', True)])
+            self.assertEqual(res, ret)
+
+    def test_upgrade_nopool(self):
+        '''
+        Tests upgrade with missing pool
+        '''
+        ret = {}
+        ret['stdout'] = ""
+        ret['stderr'] = "cannot open 'mypool': no such pool"
+        ret['retcode'] = 1
+        mock_cmd = MagicMock(return_value=ret)
+
+        with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zpool.__utils__, utils_patch):
+            ret = zpool.upgrade('mypool')
+            res = OrderedDict([
+                ('upgraded', False),
+                ('error', "cannot open 'mypool': no such pool"),
+            ])
+            self.assertEqual(res, ret)
+
+    def test_history_success(self):
+        '''
+        Tests history
+        '''
+        ret = {}
+        ret['stdout'] = "\n".join([
+            "History for 'mypool':",
+            "2018-01-18.16:56:12 zpool create -f mypool /dev/rdsk/c0t0d0",
+            "2018-01-19.16:01:55 zpool attach -f mypool /dev/rdsk/c0t0d0 /dev/rdsk/c0t0d1",
+        ])
+        ret['stderr'] = ""
+        ret['retcode'] = 0
+        mock_cmd = MagicMock(return_value=ret)
+
+        with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zpool.__utils__, utils_patch):
+            ret = zpool.history('mypool')
+            res = OrderedDict([
+                ('mypool', OrderedDict([
+                    ('2018-01-18.16:56:12', 'zpool create -f mypool /dev/rdsk/c0t0d0'),
+                    ('2018-01-19.16:01:55', 'zpool attach -f mypool /dev/rdsk/c0t0d0 /dev/rdsk/c0t0d1'),
+                ])),
+            ])
+            self.assertEqual(res, ret)
+
+    def test_history_nopool(self):
+        '''
+        Tests history with missing pool
+        '''
+        ret = {}
+        ret['stdout'] = ""
+        ret['stderr'] = "cannot open 'mypool': no such pool"
+        ret['retcode'] = 1
+        mock_cmd = MagicMock(return_value=ret)
+
+        with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zpool.__utils__, utils_patch):
+            ret = zpool.history('mypool')
+            res = OrderedDict([
+                ('error', "cannot open 'mypool': no such pool"),
+            ])
+            self.assertEqual(res, ret)
+
+    def test_clear_success(self):
+        '''
+        Tests clear
+        '''
+        ret = {}
+        ret['stdout'] = ""
+        ret['stderr'] = ""
+        ret['retcode'] = 0
+        mock_cmd = MagicMock(return_value=ret)
+
+        with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zpool.__utils__, utils_patch):
+            ret = zpool.clear('mypool')
+            res = OrderedDict([('cleared', True)])
+            self.assertEqual(res, ret)
+
+    def test_clear_nopool(self):
+        '''
+        Tests clear with missing pool
+        '''
+        ret = {}
+        ret['stdout'] = ""
+        ret['stderr'] = "cannot open 'mypool': no such pool"
+        ret['retcode'] = 1
+        mock_cmd = MagicMock(return_value=ret)
+
+        with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zpool.__utils__, utils_patch):
+            ret = zpool.clear('mypool')
+            res = OrderedDict([
+                ('cleared', False),
+                ('error', "cannot open 'mypool': no such pool"),
+            ])
+
+    def test_clear_nodevice(self):
+        '''
+        Tests clear with non existign device
+        '''
+        ret = {}
+        ret['stdout'] = ""
+        ret['stderr'] = "cannot clear errors for /dev/rdsk/c0t0d0: no such device in pool"
+        ret['retcode'] = 1
+        mock_cmd = MagicMock(return_value=ret)
+
+        with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}), \
+             patch.dict(zpool.__utils__, utils_patch):
+            ret = zpool.clear('mypool', '/dev/rdsk/c0t0d0')
+            res = OrderedDict([
+                ('cleared', False),
+                ('error', "cannot clear errors for /dev/rdsk/c0t0d0: no such device in pool"),
+            ])
+            self.assertEqual(res, ret)
             self.assertEqual(res, ret)

--- a/tests/unit/states/test_zfs.py
+++ b/tests/unit/states/test_zfs.py
@@ -1,0 +1,696 @@
+# -*- coding: utf-8 -*-
+'''
+Tests for salt.states.zfs
+
+:codeauthor:    Jorge Schrauwen <sjorge@blackdot.be>
+:maintainer:    Jorge Schrauwen <sjorge@blackdot.be>
+:maturity:      new
+:depends:       salt.utils.zfs, salt.modules.zfs
+:platform:      illumos,freebsd,linux
+'''
+# Import Python libs
+from __future__ import absolute_import, unicode_literals, print_function
+
+# Import Salt Testing Libs
+from tests.support.mixins import LoaderModuleMockMixin
+from tests.support.unit import skipIf, TestCase
+from tests.support.mock import (
+    NO_MOCK,
+    NO_MOCK_REASON,
+    MagicMock,
+    patch)
+
+# Import test data from salt.utils.zfs test
+from tests.unit.utils.test_zfs import utils_patch
+
+# Import Salt Execution module to test
+import salt.utils.zfs
+import salt.states.zfs as zfs
+
+# Import Salt Utils
+import salt.loader
+from salt.utils.odict import OrderedDict
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class ZfsTestCase(TestCase, LoaderModuleMockMixin):
+    '''
+    Test cases for salt.states.zfs
+    '''
+    def setup_loader_modules(self):
+        self.opts = opts = salt.config.DEFAULT_MINION_OPTS
+        utils = salt.loader.utils(opts, whitelist=['zfs'])
+        zfs_obj = {
+            zfs: {
+                '__opts__': opts,
+                '__grains__': {'kernel': 'SunOS'},
+                '__utils__': utils,
+            }
+        }
+
+        return zfs_obj
+
+    def test_filesystem_absent_nofs(self):
+        '''
+        Test if filesystem is absent (non existing filesystem)
+        '''
+        ret = {'name': 'myzpool/filesystem',
+               'result': True,
+               'comment': 'filesystem myzpool/filesystem is absent',
+               'changes': {}}
+
+        mock_exists = MagicMock(return_value=False)
+        with patch.dict(zfs.__salt__, {'zfs.exists': mock_exists}), \
+             patch.dict(zfs.__utils__, utils_patch):
+            self.assertEqual(ret, zfs.filesystem_absent('myzpool/filesystem'))
+
+    def test_filesystem_absent_removed(self):
+        '''
+        Test if filesystem is absent
+        '''
+        ret = {'name': 'myzpool/filesystem',
+               'result': True,
+               'comment': 'filesystem myzpool/filesystem was destroyed',
+               'changes': {'myzpool/filesystem': 'destroyed'}}
+
+        mock_exists = MagicMock(return_value=True)
+        mock_destroy = MagicMock(return_value=OrderedDict([('destroyed', True)]))
+        with patch.dict(zfs.__salt__, {'zfs.exists': mock_exists}), \
+             patch.dict(zfs.__salt__, {'zfs.destroy': mock_destroy}), \
+             patch.dict(zfs.__utils__, utils_patch):
+            self.assertEqual(ret, zfs.filesystem_absent('myzpool/filesystem'))
+
+    def test_filesystem_absent_fail(self):
+        '''
+        Test if filesystem is absent (with snapshots)
+        '''
+        ret = {'name': 'myzpool/filesystem',
+               'result': False,
+               'comment': "\n".join([
+                    "cannot destroy 'myzpool/filesystem': filesystem has children",
+                    "use 'recursive=True' to destroy the following datasets:",
+                    "myzpool/filesystem@snap",
+                ]),
+               'changes': {}}
+
+        mock_exists = MagicMock(return_value=True)
+        mock_destroy = MagicMock(return_value=OrderedDict([
+            ('destroyed', False),
+            ('error', "\n".join([
+                "cannot destroy 'myzpool/filesystem': filesystem has children",
+                "use 'recursive=True' to destroy the following datasets:",
+                "myzpool/filesystem@snap",
+            ])),
+        ]))
+        with patch.dict(zfs.__salt__, {'zfs.exists': mock_exists}), \
+             patch.dict(zfs.__salt__, {'zfs.destroy': mock_destroy}), \
+             patch.dict(zfs.__utils__, utils_patch):
+            self.assertEqual(ret, zfs.filesystem_absent('myzpool/filesystem'))
+
+    def test_volume_absent_novol(self):
+        '''
+        Test if volume is absent (non existing volume)
+        '''
+        ret = {'name': 'myzpool/volume',
+               'result': True,
+               'comment': 'volume myzpool/volume is absent',
+               'changes': {}}
+
+        mock_exists = MagicMock(return_value=False)
+        with patch.dict(zfs.__salt__, {'zfs.exists': mock_exists}), \
+             patch.dict(zfs.__utils__, utils_patch):
+            self.assertEqual(ret, zfs.volume_absent('myzpool/volume'))
+
+    def test_volume_absent_removed(self):
+        '''
+        Test if volume is absent
+        '''
+        ret = {'name': 'myzpool/volume',
+               'result': True,
+               'comment': 'volume myzpool/volume was destroyed',
+               'changes': {'myzpool/volume': 'destroyed'}}
+
+        mock_exists = MagicMock(return_value=True)
+        mock_destroy = MagicMock(return_value=OrderedDict([('destroyed', True)]))
+        with patch.dict(zfs.__salt__, {'zfs.exists': mock_exists}), \
+             patch.dict(zfs.__salt__, {'zfs.destroy': mock_destroy}), \
+             patch.dict(zfs.__utils__, utils_patch):
+            self.assertEqual(ret, zfs.volume_absent('myzpool/volume'))
+
+    def test_volume_absent_fail(self):
+        '''
+        Test if volume is absent (with snapshots)
+        '''
+        ret = {'name': 'myzpool/volume',
+               'result': False,
+               'comment': "\n".join([
+                    "cannot destroy 'myzpool/volume': volume has children",
+                    "use 'recursive=True' to destroy the following datasets:",
+                    "myzpool/volume@snap",
+                ]),
+               'changes': {}}
+
+        mock_exists = MagicMock(return_value=True)
+        mock_destroy = MagicMock(return_value=OrderedDict([
+            ('destroyed', False),
+            ('error', "\n".join([
+                "cannot destroy 'myzpool/volume': volume has children",
+                "use 'recursive=True' to destroy the following datasets:",
+                "myzpool/volume@snap",
+            ])),
+        ]))
+        with patch.dict(zfs.__salt__, {'zfs.exists': mock_exists}), \
+             patch.dict(zfs.__salt__, {'zfs.destroy': mock_destroy}), \
+             patch.dict(zfs.__utils__, utils_patch):
+            self.assertEqual(ret, zfs.volume_absent('myzpool/volume'))
+
+    def test_snapshot_absent_nosnap(self):
+        '''
+        Test if snapshot is absent (non existing snapshot)
+        '''
+        ret = {'name': 'myzpool/filesystem@snap',
+               'result': True,
+               'comment': 'snapshot myzpool/filesystem@snap is absent',
+               'changes': {}}
+
+        mock_exists = MagicMock(return_value=False)
+        with patch.dict(zfs.__salt__, {'zfs.exists': mock_exists}), \
+             patch.dict(zfs.__utils__, utils_patch):
+            self.assertEqual(ret, zfs.snapshot_absent('myzpool/filesystem@snap'))
+
+    def test_snapshot_absent_removed(self):
+        '''
+        Test if snapshot is absent
+        '''
+        ret = {'name': 'myzpool/filesystem@snap',
+               'result': True,
+               'comment': 'snapshot myzpool/filesystem@snap was destroyed',
+               'changes': {'myzpool/filesystem@snap': 'destroyed'}}
+
+        mock_exists = MagicMock(return_value=True)
+        mock_destroy = MagicMock(return_value=OrderedDict([('destroyed', True)]))
+        with patch.dict(zfs.__salt__, {'zfs.exists': mock_exists}), \
+             patch.dict(zfs.__salt__, {'zfs.destroy': mock_destroy}), \
+             patch.dict(zfs.__utils__, utils_patch):
+            self.assertEqual(ret, zfs.snapshot_absent('myzpool/filesystem@snap'))
+
+    def test_snapshot_absent_fail(self):
+        '''
+        Test if snapshot is absent (with snapshots)
+        '''
+        ret = {'name': 'myzpool/filesystem@snap',
+               'result': False,
+               'comment': 'cannot destroy snapshot myzpool/filesystem@snap: dataset is busy',
+               'changes': {}}
+
+        mock_exists = MagicMock(return_value=True)
+        mock_destroy = MagicMock(return_value=OrderedDict([
+            ('destroyed', False),
+            ('error', 'cannot destroy snapshot myzpool/filesystem@snap: dataset is busy'),
+        ]))
+        with patch.dict(zfs.__salt__, {'zfs.exists': mock_exists}), \
+             patch.dict(zfs.__salt__, {'zfs.destroy': mock_destroy}), \
+             patch.dict(zfs.__utils__, utils_patch):
+            self.assertEqual(ret, zfs.snapshot_absent('myzpool/filesystem@snap'))
+
+    def test_bookmark_absent_nobook(self):
+        '''
+        Test if bookmark is absent (non existing bookmark)
+        '''
+        ret = {'name': 'myzpool/filesystem#book',
+               'result': True,
+               'comment': 'bookmark myzpool/filesystem#book is absent',
+               'changes': {}}
+
+        mock_exists = MagicMock(return_value=False)
+        with patch.dict(zfs.__salt__, {'zfs.exists': mock_exists}), \
+             patch.dict(zfs.__utils__, utils_patch):
+            self.assertEqual(ret, zfs.bookmark_absent('myzpool/filesystem#book'))
+
+    def test_bookmark_absent_removed(self):
+        '''
+        Test if bookmark is absent
+        '''
+        ret = {'name': 'myzpool/filesystem#book',
+               'result': True,
+               'comment': 'bookmark myzpool/filesystem#book was destroyed',
+               'changes': {'myzpool/filesystem#book': 'destroyed'}}
+
+        mock_exists = MagicMock(return_value=True)
+        mock_destroy = MagicMock(return_value=OrderedDict([('destroyed', True)]))
+        with patch.dict(zfs.__salt__, {'zfs.exists': mock_exists}), \
+             patch.dict(zfs.__salt__, {'zfs.destroy': mock_destroy}), \
+             patch.dict(zfs.__utils__, utils_patch):
+            self.assertEqual(ret, zfs.bookmark_absent('myzpool/filesystem#book'))
+
+    def test_hold_absent_nohold(self):
+        '''
+        Test if hold is absent (non existing hold)
+        '''
+        ret = {'name': 'myhold',
+               'result': True,
+               'comment': 'hold myhold is absent',
+               'changes': {}}
+
+        mock_holds = MagicMock(return_value=OrderedDict([]))
+        with patch.dict(zfs.__salt__, {'zfs.holds': mock_holds}), \
+             patch.dict(zfs.__utils__, utils_patch):
+            self.assertEqual(ret, zfs.hold_absent('myhold', 'myzpool/filesystem@snap'))
+
+    def test_hold_absent_removed(self):
+        '''
+        Test if hold is absent
+        '''
+        ret = {'name': 'myhold',
+               'result': True,
+               'comment': 'hold myhold released',
+               'changes': OrderedDict([
+                    ('myzpool/filesystem@snap', OrderedDict([
+                        ('myhold', 'released'),
+                    ])),
+                ])}
+
+        mock_holds = MagicMock(return_value=OrderedDict([('myhold', 'Thu Feb 15 16:24 2018')]))
+        mock_release = MagicMock(return_value=OrderedDict([('released', True)]))
+        with patch.dict(zfs.__salt__, {'zfs.holds': mock_holds}), \
+             patch.dict(zfs.__salt__, {'zfs.release': mock_release}), \
+             patch.dict(zfs.__utils__, utils_patch):
+            self.assertEqual(ret, zfs.hold_absent('myhold', 'myzpool/filesystem@snap'))
+
+    def test_hold_absent_fail(self):
+        '''
+        Test if hold is absent (non existing snapshot)
+        '''
+        ret = {'name': 'myhold',
+               'result': False,
+               'comment': "cannot open 'myzpool/filesystem@snap': dataset does not exist",
+               'changes': {}}
+
+        mock_holds = MagicMock(return_value=OrderedDict([
+            ('error', "cannot open 'myzpool/filesystem@snap': dataset does not exist"),
+        ]))
+        with patch.dict(zfs.__salt__, {'zfs.holds': mock_holds}), \
+             patch.dict(zfs.__utils__, utils_patch):
+            self.assertEqual(ret, zfs.hold_absent('myhold', 'myzpool/filesystem@snap'))
+
+    def test_hold_present(self):
+        '''
+        Test if hold is present (hold already present)
+        '''
+        ret = {'name': 'myhold',
+               'result': True,
+               'comment': 'hold myhold is present for myzpool/filesystem@snap',
+               'changes': {}}
+
+        mock_holds = MagicMock(return_value=OrderedDict([('myhold', 'Thu Feb 15 16:24 2018')]))
+        with patch.dict(zfs.__salt__, {'zfs.holds': mock_holds}), \
+             patch.dict(zfs.__utils__, utils_patch):
+            self.assertEqual(ret, zfs.hold_present('myhold', 'myzpool/filesystem@snap'))
+
+    def test_hold_present_new(self):
+        '''
+        Test if hold is present (new)
+        '''
+        ret = {'name': 'myhold',
+               'result': True,
+               'comment': 'hold myhold added to myzpool/filesystem@snap',
+               'changes': {'myzpool/filesystem@snap': {'myhold': 'held'}}}
+
+        mock_holds = MagicMock(return_value=OrderedDict([]))
+        mock_hold = MagicMock(return_value=OrderedDict([('held', True)]))
+        with patch.dict(zfs.__salt__, {'zfs.holds': mock_holds}), \
+             patch.dict(zfs.__salt__, {'zfs.hold': mock_hold}), \
+             patch.dict(zfs.__utils__, utils_patch):
+            self.assertEqual(ret, zfs.hold_present('myhold', 'myzpool/filesystem@snap'))
+
+    def test_hold_present_fail(self):
+        '''
+        Test if hold is present (using non existing snapshot)
+        '''
+        ret = {'name': 'myhold',
+               'result': False,
+               'comment': "cannot hold snapshot 'zsalt/filesystem@snap': dataset does not exist",
+               'changes': {}}
+
+        mock_holds = MagicMock(return_value=OrderedDict([]))
+        mock_hold = MagicMock(return_value=OrderedDict([
+            ('held', False),
+            ('error', "cannot hold snapshot 'zsalt/filesystem@snap': dataset does not exist"),
+        ]))
+        with patch.dict(zfs.__salt__, {'zfs.holds': mock_holds}), \
+             patch.dict(zfs.__salt__, {'zfs.hold': mock_hold}), \
+             patch.dict(zfs.__utils__, utils_patch):
+            self.assertEqual(ret, zfs.hold_present('myhold', 'myzpool/filesystem@snap'))
+
+    def test_filesystem_present(self):
+        '''
+        Test if filesystem is present (existing filesystem)
+        '''
+        ret = {'name': 'myzpool/filesystem',
+               'result': True,
+               'comment': 'filesystem myzpool/filesystem is uptodate',
+               'changes': {}}
+
+        mock_exists = MagicMock(return_value=True)
+        mock_get = MagicMock(return_value=OrderedDict([
+            ('myzpool/filesystem', OrderedDict([
+                ('type', OrderedDict([
+                    ('value', 'filesystem'),
+                ])),
+                ('compression', OrderedDict([
+                    ('value', False),
+                ])),
+            ])),
+        ]))
+        with patch.dict(zfs.__salt__, {'zfs.exists': mock_exists}), \
+             patch.dict(zfs.__salt__, {'zfs.get': mock_get}), \
+             patch.dict(zfs.__utils__, utils_patch):
+            self.assertEqual(ret, zfs.filesystem_present('myzpool/filesystem'))
+
+    def test_filesystem_present_new(self):
+        '''
+        Test if filesystem is present (non existing filesystem)
+        '''
+        ret = {'name': 'myzpool/filesystem',
+               'result': True,
+               'comment': 'filesystem myzpool/filesystem was created',
+               'changes': {'myzpool/filesystem': u'created'}}
+
+        mock_exists = MagicMock(return_value=False)
+        mock_create = MagicMock(return_value=OrderedDict([('created', True)]))
+        with patch.dict(zfs.__salt__, {'zfs.exists': mock_exists}), \
+             patch.dict(zfs.__salt__, {'zfs.create': mock_create}), \
+             patch.dict(zfs.__utils__, utils_patch):
+            self.assertEqual(ret, zfs.filesystem_present('myzpool/filesystem'))
+
+    def test_filesystem_present_update(self):
+        '''
+        Test if filesystem is present (non existing filesystem)
+        '''
+        ret = {'name': 'myzpool/filesystem',
+               'result': True,
+               'comment': 'filesystem myzpool/filesystem was updated',
+               'changes': {'myzpool/filesystem': {'compression': 'lz4'}}}
+
+        mock_exists = MagicMock(return_value=True)
+        mock_set = MagicMock(return_value=OrderedDict([('set', True)]))
+        mock_get = MagicMock(return_value=OrderedDict([
+            ('myzpool/filesystem', OrderedDict([
+                ('type', OrderedDict([
+                    ('value', 'filesystem'),
+                ])),
+                ('compression', OrderedDict([
+                    ('value', False),
+                ])),
+            ])),
+        ]))
+        with patch.dict(zfs.__salt__, {'zfs.exists': mock_exists}), \
+             patch.dict(zfs.__salt__, {'zfs.get': mock_get}), \
+             patch.dict(zfs.__salt__, {'zfs.set': mock_set}), \
+             patch.dict(zfs.__utils__, utils_patch):
+            self.assertEqual(ret, zfs.filesystem_present(
+                name='myzpool/filesystem',
+                properties={'compression': 'lz4'},
+            ))
+
+    def test_filesystem_present_fail(self):
+        '''
+        Test if filesystem is present (non existing pool)
+        '''
+        ret = {'name': 'myzpool/filesystem',
+               'result': False,
+               'comment': "cannot create 'myzpool/filesystem': no such pool 'myzpool'",
+               'changes': {}}
+
+        mock_exists = MagicMock(return_value=False)
+        mock_create = MagicMock(return_value=OrderedDict([
+            ('created', False),
+            ('error', "cannot create 'myzpool/filesystem': no such pool 'myzpool'"),
+        ]))
+        with patch.dict(zfs.__salt__, {'zfs.exists': mock_exists}), \
+             patch.dict(zfs.__salt__, {'zfs.create': mock_create}), \
+             patch.dict(zfs.__utils__, utils_patch):
+            self.assertEqual(ret, zfs.filesystem_present('myzpool/filesystem'))
+
+    def test_volume_present(self):
+        '''
+        Test if volume is present (existing volume)
+        '''
+        ret = {'name': 'myzpool/volume',
+               'result': True,
+               'comment': 'volume myzpool/volume is uptodate',
+               'changes': {}}
+
+        mock_exists = MagicMock(return_value=True)
+        mock_get = MagicMock(return_value=OrderedDict([
+            ('myzpool/volume', OrderedDict([
+                ('type', OrderedDict([
+                    ('value', 'volume'),
+                ])),
+                ('compression', OrderedDict([
+                    ('value', False),
+                ])),
+            ])),
+        ]))
+        with patch.dict(zfs.__salt__, {'zfs.exists': mock_exists}), \
+             patch.dict(zfs.__salt__, {'zfs.get': mock_get}), \
+             patch.dict(zfs.__utils__, utils_patch):
+            self.assertEqual(ret, zfs.volume_present('myzpool/volume', volume_size='1G'))
+
+    def test_volume_present_new(self):
+        '''
+        Test if volume is present (non existing volume)
+        '''
+        ret = {'name': 'myzpool/volume',
+               'result': True,
+               'comment': 'volume myzpool/volume was created',
+               'changes': {'myzpool/volume': u'created'}}
+
+        mock_exists = MagicMock(return_value=False)
+        mock_create = MagicMock(return_value=OrderedDict([('created', True)]))
+        with patch.dict(zfs.__salt__, {'zfs.exists': mock_exists}), \
+             patch.dict(zfs.__salt__, {'zfs.create': mock_create}), \
+             patch.dict(zfs.__utils__, utils_patch):
+            self.assertEqual(ret, zfs.volume_present('myzpool/volume', volume_size='1G'))
+
+    def test_volume_present_update(self):
+        '''
+        Test if volume is present (non existing volume)
+        '''
+        ret = {'name': 'myzpool/volume',
+               'result': True,
+               'comment': 'volume myzpool/volume was updated',
+               'changes': {'myzpool/volume': {'compression': 'lz4'}}}
+
+        mock_exists = MagicMock(return_value=True)
+        mock_set = MagicMock(return_value=OrderedDict([('set', True)]))
+        mock_get = MagicMock(return_value=OrderedDict([
+            ('myzpool/volume', OrderedDict([
+                ('type', OrderedDict([
+                    ('value', 'volume'),
+                ])),
+                ('compression', OrderedDict([
+                    ('value', False),
+                ])),
+            ])),
+        ]))
+        with patch.dict(zfs.__salt__, {'zfs.exists': mock_exists}), \
+             patch.dict(zfs.__salt__, {'zfs.get': mock_get}), \
+             patch.dict(zfs.__salt__, {'zfs.set': mock_set}), \
+             patch.dict(zfs.__utils__, utils_patch):
+            self.assertEqual(ret, zfs.volume_present(
+                name='myzpool/volume',
+                volume_size='1G',
+                properties={'compression': 'lz4'},
+            ))
+
+    def test_volume_present_fail(self):
+        '''
+        Test if volume is present (non existing pool)
+        '''
+        ret = {'name': 'myzpool/volume',
+               'result': False,
+               'comment': "cannot create 'myzpool/volume': no such pool 'myzpool'",
+               'changes': {}}
+
+        mock_exists = MagicMock(return_value=False)
+        mock_create = MagicMock(return_value=OrderedDict([
+            ('created', False),
+            ('error', "cannot create 'myzpool/volume': no such pool 'myzpool'"),
+        ]))
+        with patch.dict(zfs.__salt__, {'zfs.exists': mock_exists}), \
+             patch.dict(zfs.__salt__, {'zfs.create': mock_create}), \
+             patch.dict(zfs.__utils__, utils_patch):
+            self.assertEqual(ret, zfs.volume_present('myzpool/volume', volume_size='1G'))
+
+    def test_bookmark_present(self):
+        '''
+        Test if bookmark is present (bookmark already present)
+        '''
+        ret = {'name': 'myzpool/filesystem#mybookmark',
+               'result': True,
+               'comment': 'bookmark is present',
+               'changes': {}}
+
+        mock_exists = MagicMock(return_value=True)
+        with patch.dict(zfs.__salt__, {'zfs.exists': mock_exists}), \
+             patch.dict(zfs.__utils__, utils_patch):
+            self.assertEqual(ret, zfs.bookmark_present('mybookmark', 'myzpool/filesystem@snap'))
+
+    def test_bookmark_present_new(self):
+        '''
+        Test if bookmark is present (new)
+        '''
+        ret = {'name': 'myzpool/filesystem#mybookmark',
+               'result': True,
+               'comment': 'myzpool/filesystem@snap bookmarked as myzpool/filesystem#mybookmark',
+               'changes': {'myzpool/filesystem#mybookmark': 'myzpool/filesystem@snap'}}
+
+        mock_exists = MagicMock(return_value=False)
+        mock_bookmark = MagicMock(return_value=OrderedDict([('bookmarked', True)]))
+        with patch.dict(zfs.__salt__, {'zfs.exists': mock_exists}), \
+             patch.dict(zfs.__salt__, {'zfs.bookmark': mock_bookmark}), \
+             patch.dict(zfs.__utils__, utils_patch):
+            self.assertEqual(ret, zfs.bookmark_present('mybookmark', 'myzpool/filesystem@snap'))
+
+    def test_bookmark_present_fail(self):
+        '''
+        Test if bookmark is present (using non existing snapshot)
+        '''
+        ret = {'name': 'myzpool/filesystem#mybookmark',
+               'result': False,
+               'comment': "cannot bookmark snapshot 'zsalt/filesystem@snap': dataset does not exist",
+               'changes': {}}
+
+        mock_exists = MagicMock(return_value=False)
+        mock_bookmark = MagicMock(return_value=OrderedDict([
+            ('bookmarked', False),
+            ('error', "cannot bookmark snapshot 'zsalt/filesystem@snap': dataset does not exist"),
+        ]))
+        with patch.dict(zfs.__salt__, {'zfs.exists': mock_exists}), \
+             patch.dict(zfs.__salt__, {'zfs.bookmark': mock_bookmark}), \
+             patch.dict(zfs.__utils__, utils_patch):
+            self.assertEqual(ret, zfs.bookmark_present('mybookmark', 'myzpool/filesystem@snap'))
+
+    def test_snapshot_present(self):
+        '''
+        Test if snapshot is present (snapshot already present)
+        '''
+        ret = {'name': 'myzpool/filesystem@snap',
+               'result': True,
+               'comment': 'snapshot is present',
+               'changes': {}}
+
+        mock_exists = MagicMock(return_value=True)
+        with patch.dict(zfs.__salt__, {'zfs.exists': mock_exists}), \
+             patch.dict(zfs.__utils__, utils_patch):
+            self.assertEqual(ret, zfs.snapshot_present('myzpool/filesystem@snap'))
+
+    def test_snapshot_present_new(self):
+        '''
+        Test if snapshot is present (new)
+        '''
+        ret = {'name': 'myzpool/filesystem@snap',
+               'result': True,
+               'comment': 'snapshot myzpool/filesystem@snap was created',
+               'changes': {u'myzpool/filesystem@snap': u'snapshotted'}}
+
+        mock_exists = MagicMock(return_value=False)
+        mock_snapshot = MagicMock(return_value=OrderedDict([('snapshotted', True)]))
+        with patch.dict(zfs.__salt__, {'zfs.exists': mock_exists}), \
+             patch.dict(zfs.__salt__, {'zfs.snapshot': mock_snapshot}), \
+             patch.dict(zfs.__utils__, utils_patch):
+            self.assertEqual(ret, zfs.snapshot_present('myzpool/filesystem@snap'))
+
+    def test_snapshot_present_fail(self):
+        '''
+        Test if snapshot is present (using non existing snapshot)
+        '''
+        ret = {'name': 'myzpool/filesystem@snap',
+               'result': False,
+               'comment': "cannot open 'myzpool/filesystem': dataset does not exist",
+               'changes': {}}
+
+        mock_exists = MagicMock(return_value=False)
+        mock_snapshot = MagicMock(return_value=OrderedDict([
+            ('snapshotted', False),
+            ('error', "cannot open 'myzpool/filesystem': dataset does not exist"),
+        ]))
+        with patch.dict(zfs.__salt__, {'zfs.exists': mock_exists}), \
+             patch.dict(zfs.__salt__, {'zfs.snapshot': mock_snapshot}), \
+             patch.dict(zfs.__utils__, utils_patch):
+            self.assertEqual(ret, zfs.snapshot_present('myzpool/filesystem@snap'))
+
+    def test_propmoted(self):
+        '''
+        Test promotion of clone (already promoted)
+        '''
+        ret = {'name': 'myzpool/filesystem',
+               'result': True,
+               'comment': 'myzpool/filesystem already promoted',
+               'changes': {}}
+
+        mock_exists = MagicMock(return_value=True)
+        mock_get = MagicMock(return_value=OrderedDict([
+            ('myzpool/filesystem', OrderedDict([
+                ('origin', OrderedDict([
+                    ('value', '-'),
+                ])),
+            ])),
+        ]))
+        with patch.dict(zfs.__salt__, {'zfs.exists': mock_exists}), \
+             patch.dict(zfs.__salt__, {'zfs.get': mock_get}), \
+             patch.dict(zfs.__utils__, utils_patch):
+            self.assertEqual(ret, zfs.promoted('myzpool/filesystem'))
+
+    def test_propmoted_clone(self):
+        '''
+        Test promotion of clone
+        '''
+        ret = {'name': 'myzpool/filesystem',
+               'result': True,
+               'comment': 'myzpool/filesystem promoted',
+               'changes': {'myzpool/filesystem': 'promoted'}}
+
+        mock_exists = MagicMock(return_value=True)
+        mock_get = MagicMock(return_value=OrderedDict([
+            ('myzpool/filesystem', OrderedDict([
+                ('origin', OrderedDict([
+                    ('value', 'myzool/filesystem_source@clean'),
+                ])),
+            ])),
+        ]))
+        mock_promote = MagicMock(return_value=OrderedDict([('promoted', True)]))
+        with patch.dict(zfs.__salt__, {'zfs.exists': mock_exists}), \
+             patch.dict(zfs.__salt__, {'zfs.get': mock_get}), \
+             patch.dict(zfs.__salt__, {'zfs.promote': mock_promote}), \
+             patch.dict(zfs.__utils__, utils_patch):
+            self.assertEqual(ret, zfs.promoted('myzpool/filesystem'))
+
+    def test_propmoted_fail(self):
+        '''
+        Test promotion of clone (unknown dataset)
+        '''
+        ret = {'name': 'myzpool/filesystem',
+               'result': False,
+               'comment': 'dataset myzpool/filesystem does not exist',
+               'changes': {}}
+
+        mock_exists = MagicMock(return_value=False)
+        with patch.dict(zfs.__salt__, {'zfs.exists': mock_exists}), \
+             patch.dict(zfs.__utils__, utils_patch):
+            self.assertEqual(ret, zfs.promoted('myzpool/filesystem'))
+
+    def test_scheduled_snapshot_fail(self):
+        '''
+        Test scheduled_snapshot of unknown dataset
+        '''
+        ret = {'name': 'myzpool/filesystem',
+               'result': False,
+               'comment': 'dataset myzpool/filesystem does not exist',
+               'changes': {}}
+
+        mock_exists = MagicMock(return_value=False)
+        with patch.dict(zfs.__salt__, {'zfs.exists': mock_exists}), \
+             patch.dict(zfs.__utils__, utils_patch):
+            self.assertEqual(ret, zfs.scheduled_snapshot('myzpool/filesystem', 'shadow', schedule={'hour': 6}))

--- a/tests/unit/states/test_zpool.py
+++ b/tests/unit/states/test_zpool.py
@@ -1,0 +1,450 @@
+# -*- coding: utf-8 -*-
+'''
+Tests for salt.states.zpool
+
+:codeauthor:    Jorge Schrauwen <sjorge@blackdot.be>
+:maintainer:    Jorge Schrauwen <sjorge@blackdot.be>
+:maturity:      new
+:depends:       salt.utils.zfs, salt.modules.zpool
+:platform:      illumos,freebsd,linux
+'''
+# Import Python libs
+from __future__ import absolute_import, unicode_literals, print_function
+
+# Import Salt Testing Libs
+from tests.support.mixins import LoaderModuleMockMixin
+from tests.support.unit import skipIf, TestCase
+from tests.support.mock import (
+    NO_MOCK,
+    NO_MOCK_REASON,
+    MagicMock,
+    patch)
+
+# Import test data from salt.utils.zfs test
+from tests.unit.utils.test_zfs import utils_patch
+
+# Import Salt Execution module to test
+import salt.utils.zfs
+import salt.states.zpool as zpool
+
+# Import Salt Utils
+import salt.loader
+from salt.utils.odict import OrderedDict
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class ZpoolTestCase(TestCase, LoaderModuleMockMixin):
+    '''
+    Test cases for salt.states.zpool
+    '''
+    def setup_loader_modules(self):
+        self.opts = opts = salt.config.DEFAULT_MINION_OPTS
+        utils = salt.loader.utils(opts, whitelist=['zfs'])
+        zpool_obj = {
+            zpool: {
+                '__opts__': opts,
+                '__grains__': {'kernel': 'SunOS'},
+                '__utils__': utils,
+            }
+        }
+
+        return zpool_obj
+
+    def test_absent_without_pool(self):
+        '''
+        Test zpool absent without a pool
+        '''
+        ret = {'name': 'myzpool',
+               'result': True,
+               'comment': 'storage pool myzpool is absent',
+               'changes': {}}
+
+        mock_exists = MagicMock(return_value=False)
+        with patch.dict(zpool.__salt__, {'zpool.exists': mock_exists}), \
+             patch.dict(zpool.__utils__, utils_patch):
+            self.assertEqual(zpool.absent('myzpool'), ret)
+
+    def test_absent_destroy_pool(self):
+        '''
+        Test zpool absent destroying pool
+        '''
+        ret = {
+            'name': 'myzpool',
+            'result': True,
+            'comment': 'storage pool myzpool was destroyed',
+            'changes': {'myzpool': 'destroyed'},
+        }
+
+        mock_exists = MagicMock(return_value=True)
+        mock_destroy = MagicMock(return_value=OrderedDict([
+            ('destroyed', True),
+        ]))
+        with patch.dict(zpool.__salt__, {'zpool.exists': mock_exists}), \
+             patch.dict(zpool.__salt__, {'zpool.destroy': mock_destroy}), \
+             patch.dict(zpool.__utils__, utils_patch):
+            self.assertEqual(zpool.absent('myzpool'), ret)
+
+    def test_absent_exporty_pool(self):
+        '''
+        Test zpool absent exporting pool
+        '''
+        ret = {
+            'name': 'myzpool',
+            'result': True,
+            'comment': 'storage pool myzpool was exported',
+            'changes': {'myzpool': 'exported'},
+        }
+
+        mock_exists = MagicMock(return_value=True)
+        mock_destroy = MagicMock(return_value=OrderedDict([
+            ('exported', True),
+        ]))
+        with patch.dict(zpool.__salt__, {'zpool.exists': mock_exists}), \
+             patch.dict(zpool.__salt__, {'zpool.export': mock_destroy}), \
+             patch.dict(zpool.__utils__, utils_patch):
+            self.assertEqual(zpool.absent('myzpool', export=True), ret)
+
+    def test_absent_busy(self):
+        '''
+        Test zpool absent on a busy pool
+        '''
+        ret = {
+            'name': 'myzpool',
+            'result': False,
+            'comment': "\n".join([
+                "cannot unmount '/myzpool': Device busy",
+                "cannot export 'myzpool': pool is busy",
+            ]),
+            'changes': {},
+        }
+
+        mock_exists = MagicMock(return_value=True)
+        mock_destroy = MagicMock(return_value=OrderedDict([
+            ('exported', False),
+            ('error', "\n".join([
+                "cannot unmount '/myzpool': Device busy",
+                "cannot export 'myzpool': pool is busy",
+            ])),
+        ]))
+        with patch.dict(zpool.__salt__, {'zpool.exists': mock_exists}), \
+             patch.dict(zpool.__salt__, {'zpool.export': mock_destroy}), \
+             patch.dict(zpool.__utils__, utils_patch):
+            self.assertEqual(zpool.absent('myzpool', export=True), ret)
+
+    def test_present_import_success(self):
+        '''
+        Test zpool present with import allowed and unimported pool
+        '''
+        ret = {'name': 'myzpool',
+               'result': True,
+               'comment': 'storage pool myzpool was imported',
+               'changes': {'myzpool': 'imported'}}
+
+        config = {
+            'import': True,
+        }
+
+        mock_exists = MagicMock(return_value=False)
+        mock_import = MagicMock(return_value=OrderedDict([
+            ('imported', True),
+        ]))
+        with patch.dict(zpool.__salt__, {'zpool.exists': mock_exists}), \
+             patch.dict(zpool.__salt__, {'zpool.import': mock_import}), \
+             patch.dict(zpool.__utils__, utils_patch):
+            self.assertEqual(zpool.present('myzpool', config=config), ret)
+
+    def test_present_import_fail(self):
+        '''
+        Test zpool present with import allowed and no unimported pool or layout
+        '''
+        ret = {'name': 'myzpool',
+               'result': False,
+               'comment': 'storage pool myzpool was not imported, no (valid) layout specified for creation',
+               'changes': {}}
+
+        config = {
+            'import': True,
+        }
+
+        mock_exists = MagicMock(return_value=False)
+        mock_import = MagicMock(return_value=OrderedDict([
+            ('imported', False),
+        ]))
+        with patch.dict(zpool.__salt__, {'zpool.exists': mock_exists}), \
+             patch.dict(zpool.__salt__, {'zpool.import': mock_import}), \
+             patch.dict(zpool.__utils__, utils_patch):
+            self.assertEqual(zpool.present('myzpool', config=config), ret)
+
+    def test_present_create_success(self):
+        '''
+        Test zpool present with non existing pool
+        '''
+        ret = {'name': 'myzpool',
+               'result': True,
+               'comment': 'storage pool myzpool was created',
+               'changes': {'myzpool': 'created'}}
+
+        config = {
+            'import': False,
+        }
+        layout = [
+            OrderedDict([('mirror', ['disk0', 'disk1'])]),
+            OrderedDict([('mirror', ['disk2', 'disk3'])]),
+        ]
+        properties = {
+            'autoexpand': True,
+        }
+        filesystem_properties = {
+            'quota': '5G',
+        }
+
+        mock_exists = MagicMock(return_value=False)
+        mock_create = MagicMock(return_value=OrderedDict([
+            ('created', True),
+            ('vdevs', OrderedDict([
+                ('mirror-0', ['/dev/dsk/disk0', '/dev/dsk/disk1']),
+                ('mirror-1', ['/dev/dsk/disk2', '/dev/dsk/disk3']),
+            ])),
+        ]))
+        with patch.dict(zpool.__salt__, {'zpool.exists': mock_exists}), \
+             patch.dict(zpool.__salt__, {'zpool.create': mock_create}), \
+             patch.dict(zpool.__utils__, utils_patch):
+            self.assertEqual(
+                zpool.present(
+                    'myzpool',
+                    config=config,
+                    layout=layout,
+                    properties=properties,
+                    filesystem_properties=filesystem_properties,
+                ),
+                ret,
+            )
+
+    def test_present_create_fail(self):
+        '''
+        Test zpool present with non existing pool (without a layout)
+        '''
+        ret = {'name': 'myzpool',
+               'result': False,
+               'comment': 'storage pool myzpool was not imported, no (valid) layout specified for creation',
+               'changes': {}}
+
+        config = {
+            'import': False,
+        }
+
+        mock_exists = MagicMock(return_value=False)
+        with patch.dict(zpool.__salt__, {'zpool.exists': mock_exists}), \
+             patch.dict(zpool.__utils__, utils_patch):
+            self.assertEqual(zpool.present('myzpool', config=config), ret)
+
+    def test_present_create_passthrough_fail(self):
+        '''
+        Test zpool present with non existing pool (without a layout)
+        '''
+        ret = {'name': 'myzpool',
+               'result': False,
+               'comment': "\n".join([
+                    "invalid vdev specification",
+                    "use 'force=True' to override the following errors:",
+                    "/data/salt/vdisk0 is part of exported pool 'zsalt'",
+                    "/data/salt/vdisk1 is part of exported pool 'zsalt'",
+                ]),
+               'changes': {}}
+
+        config = {
+            'force': False,
+            'import': False,
+        }
+        layout = [
+            OrderedDict([('mirror', ['disk0', 'disk1'])]),
+            OrderedDict([('mirror', ['disk2', 'disk3'])]),
+        ]
+        properties = {
+            'autoexpand': True,
+        }
+        filesystem_properties = {
+            'quota': '5G',
+        }
+
+        mock_exists = MagicMock(return_value=False)
+        mock_create = MagicMock(return_value=OrderedDict([
+            ('created', False),
+            ('error', "\n".join([
+                "invalid vdev specification",
+                "use 'force=True' to override the following errors:",
+                "/data/salt/vdisk0 is part of exported pool 'zsalt'",
+                "/data/salt/vdisk1 is part of exported pool 'zsalt'",
+            ])),
+        ]))
+        with patch.dict(zpool.__salt__, {'zpool.exists': mock_exists}), \
+             patch.dict(zpool.__salt__, {'zpool.create': mock_create}), \
+             patch.dict(zpool.__utils__, utils_patch):
+            self.assertEqual(
+                zpool.present(
+                    'myzpool',
+                    config=config,
+                    layout=layout,
+                    properties=properties,
+                    filesystem_properties=filesystem_properties,
+                ),
+                ret,
+            )
+
+    def test_present_update_success(self):
+        '''
+        Test zpool present with an existing pool that needs an update
+        '''
+        ret = {'name': 'myzpool',
+               'result': True,
+               'comment': 'properties updated',
+               'changes': {'myzpool': {'autoexpand': False}}}
+
+        config = {
+            'import': False,
+        }
+        layout = [
+            OrderedDict([('mirror', ['disk0', 'disk1'])]),
+            OrderedDict([('mirror', ['disk2', 'disk3'])]),
+        ]
+        properties = {
+            'autoexpand': False,
+        }
+
+        mock_exists = MagicMock(return_value=True)
+        mock_get = MagicMock(return_value=OrderedDict([
+            ('comment', 'salt managed pool'),
+            ('freeing', 0),
+            ('listsnapshots', False),
+            ('leaked', 0),
+            ('feature@obsolete_counts', 'enabled'),
+            ('feature@sha512', 'enabled'),
+            ('delegation', True),
+            ('dedupditto', '0'),
+            ('dedupratio', '1.00x'),
+            ('autoexpand', True),
+            ('feature@bookmarks', 'enabled'),
+            ('allocated', 115712),
+            ('guid', 1591906802560842214),
+            ('feature@large_blocks', 'enabled'),
+            ('size', 2113929216),
+            ('feature@enabled_txg', 'active'),
+            ('feature@hole_birth', 'active'),
+            ('capacity', 0),
+            ('feature@multi_vdev_crash_dump', 'enabled'),
+            ('feature@extensible_dataset', 'enabled'),
+            ('cachefile', '-'),
+            ('bootfs', '-'),
+            ('autoreplace', True),
+            ('readonly', False),
+            ('version', '-'),
+            ('health', 'ONLINE'),
+            ('expandsize', '-'),
+            ('feature@embedded_data', 'active'),
+            ('feature@lz4_compress', 'active'),
+            ('feature@async_destroy', 'enabled'),
+            ('feature@skein', 'enabled'),
+            ('feature@empty_bpobj', 'enabled'),
+            ('feature@spacemap_histogram', 'active'),
+            ('bootsize', '-'),
+            ('free', 2113813504),
+            ('feature@device_removal', 'enabled'),
+            ('failmode', 'wait'),
+            ('feature@filesystem_limits', 'enabled'),
+            ('feature@edonr', 'enabled'),
+            ('altroot', '-'),
+            ('fragmentation', '0%'),
+        ]))
+        mock_set = MagicMock(return_value=OrderedDict([
+            ('set', True),
+        ]))
+        with patch.dict(zpool.__salt__, {'zpool.exists': mock_exists}), \
+             patch.dict(zpool.__salt__, {'zpool.get': mock_get}), \
+             patch.dict(zpool.__salt__, {'zpool.set': mock_set}), \
+             patch.dict(zpool.__utils__, utils_patch):
+            self.assertEqual(
+                zpool.present(
+                    'myzpool',
+                    config=config,
+                    layout=layout,
+                    properties=properties,
+                ),
+                ret,
+            )
+
+    def test_present_update_nochange_success(self):
+        '''
+        Test zpool present with non existing pool
+        '''
+        ret = {'name': 'myzpool',
+               'result': True,
+               'comment': 'no update needed',
+               'changes': {}}
+
+        config = {
+            'import': False,
+        }
+        layout = [
+            OrderedDict([('mirror', ['disk0', 'disk1'])]),
+            OrderedDict([('mirror', ['disk2', 'disk3'])]),
+        ]
+        properties = {
+            'autoexpand': True,
+        }
+
+        mock_exists = MagicMock(return_value=True)
+        mock_get = MagicMock(return_value=OrderedDict([
+            ('comment', 'salt managed pool'),
+            ('freeing', 0),
+            ('listsnapshots', False),
+            ('leaked', 0),
+            ('feature@obsolete_counts', 'enabled'),
+            ('feature@sha512', 'enabled'),
+            ('delegation', True),
+            ('dedupditto', '0'),
+            ('dedupratio', '1.00x'),
+            ('autoexpand', True),
+            ('feature@bookmarks', 'enabled'),
+            ('allocated', 115712),
+            ('guid', 1591906802560842214),
+            ('feature@large_blocks', 'enabled'),
+            ('size', 2113929216),
+            ('feature@enabled_txg', 'active'),
+            ('feature@hole_birth', 'active'),
+            ('capacity', 0),
+            ('feature@multi_vdev_crash_dump', 'enabled'),
+            ('feature@extensible_dataset', 'enabled'),
+            ('cachefile', '-'),
+            ('bootfs', '-'),
+            ('autoreplace', True),
+            ('readonly', False),
+            ('version', '-'),
+            ('health', 'ONLINE'),
+            ('expandsize', '-'),
+            ('feature@embedded_data', 'active'),
+            ('feature@lz4_compress', 'active'),
+            ('feature@async_destroy', 'enabled'),
+            ('feature@skein', 'enabled'),
+            ('feature@empty_bpobj', 'enabled'),
+            ('feature@spacemap_histogram', 'active'),
+            ('bootsize', '-'),
+            ('free', 2113813504),
+            ('feature@device_removal', 'enabled'),
+            ('failmode', 'wait'),
+            ('feature@filesystem_limits', 'enabled'),
+            ('feature@edonr', 'enabled'),
+            ('altroot', '-'),
+            ('fragmentation', '0%'),
+        ]))
+        with patch.dict(zpool.__salt__, {'zpool.exists': mock_exists}), \
+             patch.dict(zpool.__salt__, {'zpool.get': mock_get}), \
+             patch.dict(zpool.__utils__, utils_patch):
+            self.assertEqual(
+                zpool.present(
+                    'myzpool',
+                    config=config,
+                    layout=layout,
+                    properties=properties,
+                ),
+                ret,
+            )

--- a/tests/unit/utils/test_zfs.py
+++ b/tests/unit/utils/test_zfs.py
@@ -1,0 +1,1722 @@
+# -*- coding: utf-8 -*-
+'''
+Tests for the zfs utils library
+
+:codeauthor:    Jorge Schrauwen <sjorge@blackdot.be>
+:maintainer:    Jorge Schrauwen <sjorge@blackdot.be>
+:maturity:      new
+:platform:      illumos,freebsd,linux
+
+.. versionadded:: Fluorine
+'''
+
+# Import Python libs
+from __future__ import absolute_import, unicode_literals, print_function
+
+# Import Salt Testing libs
+from tests.support.unit import skipIf, TestCase
+from tests.support.mock import (
+    MagicMock,
+    patch,
+    NO_MOCK,
+    NO_MOCK_REASON,
+)
+
+# Import Salt Execution module to test
+import salt.utils.zfs as zfs
+
+# Import Salt Utils
+import salt.loader
+from salt.utils.odict import OrderedDict
+
+# property_map mocks
+pmap_exec_zpool = {
+    'retcode': 2,
+    'stdout': '',
+    'stderr': "\n".join([
+        'missing property argument',
+        'usage:',
+        '        get [-Hp] [-o "all" | field[,...]] <"all" | property[,...]> <pool> ...',
+        '',
+        'the following properties are supported:',
+        '',
+        '        PROPERTY         EDIT   VALUES',
+        '',
+        '        allocated          NO   <size>',
+        '        capacity           NO   <size>',
+        '        dedupratio         NO   <1.00x or higher if deduped>',
+        '        expandsize         NO   <size>',
+        '        fragmentation      NO   <percent>',
+        '        free               NO   <size>',
+        '        freeing            NO   <size>',
+        '        guid               NO   <guid>',
+        '        health             NO   <state>',
+        '        leaked             NO   <size>',
+        '        size               NO   <size>',
+        '        altroot           YES   <path>',
+        '        autoexpand        YES   on | off',
+        '        autoreplace       YES   on | off',
+        '        bootfs            YES   <filesystem>',
+        '        bootsize          YES   <size>',
+        '        cachefile         YES   <file> | none',
+        '        comment           YES   <comment-string>',
+        '        dedupditto        YES   <threshold (min 100)>',
+        '        delegation        YES   on | off',
+        '        failmode          YES   wait | continue | panic',
+        '        listsnapshots     YES   on | off',
+        '        readonly          YES   on | off',
+        '        version           YES   <version>',
+        '        feature@...       YES   disabled | enabled | active',
+        '',
+        'The feature@ properties must be appended with a feature name.',
+        'See zpool-features(5). ',
+    ]),
+}
+pmap_zpool = {
+  'comment': {
+    'edit': True,
+    'type': 'str',
+    'values': '<comment-string>'
+  },
+  'freeing': {
+    'edit': False,
+    'type': 'size',
+    'values': '<size>'
+  },
+  'listsnapshots': {
+    'edit': True,
+    'type': 'bool',
+    'values': 'on | off'
+  },
+  'leaked': {
+    'edit': False,
+    'type': 'size',
+    'values': '<size>'
+  },
+  'version': {
+    'edit': True,
+    'type': 'numeric',
+    'values': '<version>'
+  },
+  'write': {
+    'edit': False,
+    'type': 'size',
+    'values': '<size>'
+  },
+  'replace': {
+    'edit': True,
+    'type': 'bool',
+    'values': 'on | off'
+  },
+  'delegation': {
+    'edit': True,
+    'type': 'bool',
+    'values': 'on | off'
+  },
+  'dedupditto': {
+    'edit': True,
+    'type': 'str',
+    'values': '<threshold (min 100)>'
+  },
+  'autoexpand': {
+    'edit': True,
+    'type': 'bool',
+    'values': 'on | off'
+  },
+  'alloc': {
+    'edit': False,
+    'type': 'size',
+    'values': '<size>'
+  },
+  'allocated': {
+    'edit': False,
+    'type': 'size',
+    'values': '<size>'
+  },
+  'guid': {
+    'edit': False,
+    'type': 'numeric',
+    'values': '<guid>'
+  },
+  'size': {
+    'edit': False,
+    'type': 'size',
+    'values': '<size>'
+  },
+  'cap': {
+    'edit': False,
+    'type': 'numeric',
+    'values': '<count>'
+  },
+  'capacity': {
+    'edit': False,
+    'type': 'size',
+    'values': '<size>'
+  },
+  "capacity-alloc": {
+    "edit": False,
+    "type": "size",
+    "values": "<size>"
+  },
+  "capacity-free": {
+    "edit": False,
+    "type": "size",
+    "values": "<size>"
+  },
+  'cachefile': {
+    'edit': True,
+    'type': 'str',
+    'values': '<file> | none'
+  },
+  "cksum": {
+    "edit": False,
+    "type": "numeric",
+    "values": "<count>"
+  },
+  'bootfs': {
+    'edit': True,
+    'type': 'str',
+    'values': '<filesystem>'
+  },
+  'autoreplace': {
+    'edit': True,
+    'type': 'bool',
+    'values': 'on | off'
+  },
+  "bandwith-read": {
+    "edit": False,
+    "type": "size",
+    "values": "<size>"
+  },
+  "bandwith-write": {
+    "edit": False,
+    "type": "size",
+    "values": "<size>"
+  },
+  "operations-read": {
+    "edit": False,
+    "type": "size",
+    "values": "<size>"
+  },
+  "operations-write": {
+    "edit": False,
+    "type": "size",
+    "values": "<size>"
+  },
+  "read": {
+    "edit": False,
+    "type": "size",
+    "values": "<size>"
+  },
+  'readonly': {
+    'edit': True,
+    'type': 'bool',
+    'values': 'on | off'
+  },
+  'dedupratio': {
+    'edit': False,
+    'type': 'str',
+    'values': '<1.00x or higher if deduped>'
+  },
+  'health': {
+    'edit': False,
+    'type': 'str',
+    'values': '<state>'
+  },
+  'feature@': {
+    'edit': True,
+    'type': 'str',
+    'values': 'disabled | enabled | active'
+  },
+  'expandsize': {
+    'edit': False,
+    'type': 'size',
+    'values': '<size>'
+  },
+  'listsnaps': {
+    'edit': True,
+    'type': 'bool',
+    'values': 'on | off'
+  },
+  'bootsize': {
+    'edit': True,
+    'type': 'size',
+    'values': '<size>'
+  },
+  'free': {
+    'edit': False,
+    'type': 'size',
+    'values': '<size>'
+  },
+  'failmode': {
+    'edit': True,
+    'type': 'str',
+    'values': 'wait | continue | panic'
+  },
+  'altroot': {
+    'edit': True,
+    'type': 'str',
+    'values': '<path>'
+  },
+  'expand': {
+    'edit': True,
+    'type': 'bool',
+    'values': 'on | off'
+  },
+  'frag': {
+    'edit': False,
+    'type': 'str',
+    'values': '<percent>'
+  },
+  'fragmentation': {
+    'edit': False,
+    'type': 'str',
+    'values': '<percent>'
+  }
+}
+pmap_exec_zfs = {
+    'retcode': 2,
+    'stdout': '',
+    'stderr': "\n".join([
+        'missing property argument',
+        'usage:',
+        '        get [-crHp] [-d max] [-o "all" | field[,...]]',
+        '            [-t type[,...]] [-s source[,...]]',
+        '            <"all" | property[,...]> [filesystem|volume|snapshot|bookmark] ...',
+        '',
+        'The following properties are supported:',
+        '',
+        '        PROPERTY       EDIT  INHERIT   VALUES',
+        '',
+        '        available        NO       NO   <size>',
+        '        clones           NO       NO   <dataset>[,...]',
+        '        compressratio    NO       NO   <1.00x or higher if compressed>',
+        '        creation         NO       NO   <date>',
+        '        defer_destroy    NO       NO   yes | no',
+        '        filesystem_count  NO       NO   <count>',
+        '        logicalreferenced  NO       NO   <size>',
+        '        logicalused      NO       NO   <size>',
+        '        mounted          NO       NO   yes | no',
+        '        origin           NO       NO   <snapshot>',
+        '        receive_resume_token  NO       NO   <string token>',
+        '        refcompressratio  NO       NO   <1.00x or higher if compressed>',
+        '        referenced       NO       NO   <size>',
+        '        snapshot_count   NO       NO   <count>',
+        '        type             NO       NO   filesystem | volume | snapshot | bookmark',
+        '        used             NO       NO   <size>',
+        '        usedbychildren   NO       NO   <size>',
+        '        usedbydataset    NO       NO   <size>',
+        '        usedbyrefreservation  NO       NO   <size>',
+        '        usedbysnapshots  NO       NO   <size>',
+        '        userrefs         NO       NO   <count>',
+        '        written          NO       NO   <size>',
+        '        aclinherit      YES      YES   discard | noallow | restricted | passthrough | passthrough-x',
+        '        aclmode         YES      YES   discard | groupmask | passthrough | restricted',
+        '        atime           YES      YES   on | off',
+        '        canmount        YES       NO   on | off | noauto',
+        '        casesensitivity  NO      YES   sensitive | insensitive | mixed',
+        '        checksum        YES      YES   on | off | fletcher2 | fletcher4 | sha256 | sha512 | skein | edonr',
+        '        compression     YES      YES   on | off | lzjb | gzip | gzip-[1-9] | zle | lz4',
+        '        copies          YES      YES   1 | 2 | 3',
+        '        dedup           YES      YES   on | off | verify | sha256[,verify], sha512[,verify], skein[,verify], edonr,verify',
+        '        devices         YES      YES   on | off',
+        '        exec            YES      YES   on | off',
+        '        filesystem_limit YES       NO   <count> | none',
+        '        logbias         YES      YES   latency | throughput',
+        '        mlslabel        YES      YES   <sensitivity label>',
+        '        mountpoint      YES      YES   <path> | legacy | none',
+        '        nbmand          YES      YES   on | off',
+        '        normalization    NO      YES   none | formC | formD | formKC | formKD',
+        '        primarycache    YES      YES   all | none | metadata',
+        '        quota           YES       NO   <size> | none',
+        '        readonly        YES      YES   on | off',
+        '        recordsize      YES      YES   512 to 1M, power of 2',
+        '        redundant_metadata YES      YES   all | most',
+        '        refquota        YES       NO   <size> | none',
+        '        refreservation  YES       NO   <size> | none',
+        '        reservation     YES       NO   <size> | none',
+        '        secondarycache  YES      YES   all | none | metadata',
+        '        setuid          YES      YES   on | off',
+        '        sharenfs        YES      YES   on | off | share(1M) options',
+        '        sharesmb        YES      YES   on | off | sharemgr(1M) options',
+        '        snapdir         YES      YES   hidden | visible',
+        '        snapshot_limit  YES       NO   <count> | none',
+        '        sync            YES      YES   standard | always | disabled',
+        '        utf8only         NO      YES   on | off',
+        '        version         YES       NO   1 | 2 | 3 | 4 | 5 | current',
+        '        volblocksize     NO      YES   512 to 128k, power of 2',
+        '        volsize         YES       NO   <size>',
+        '        vscan           YES      YES   on | off',
+        '        xattr           YES      YES   on | off',
+        '        zoned           YES      YES   on | off',
+        '        userused@...     NO       NO   <size>',
+        '        groupused@...    NO       NO   <size>',
+        '        userquota@...   YES       NO   <size> | none',
+        '        groupquota@...  YES       NO   <size> | none',
+        '        written@<snap>   NO       NO   <size>',
+        '',
+        'Sizes are specified in bytes with standard units such as K, M, G, etc.',
+        '',
+        'User-defined properties can be specified by using a name containing a colon (:).',
+        '',
+        'The {user|group}{used|quota}@ properties must be appended with',
+        'a user or group specifier of one of these forms:',
+        '    POSIX name      (eg: "matt")',
+        '    POSIX id        (eg: "126829")',
+        '    SMB name@domain (eg: "matt@sun")',
+        '    SMB SID         (eg: "S-1-234-567-89")',
+    ]),
+}
+pmap_zfs = {
+  "origin": {
+    "edit": False,
+    "inherit": False,
+    "values": "<snapshot>",
+    "type": "str"
+  },
+  "setuid": {
+    "edit": True,
+    "inherit": True,
+    "values": "on | off",
+    "type": "bool"
+  },
+  "referenced": {
+    "edit": False,
+    "inherit": False,
+    "values": "<size>",
+    "type": "size"
+  },
+  "vscan": {
+    "edit": True,
+    "inherit": True,
+    "values": "on | off",
+    "type": "bool"
+  },
+  "logicalused": {
+    "edit": False,
+    "inherit": False,
+    "values": "<size>",
+    "type": "size"
+  },
+  "userrefs": {
+    "edit": False,
+    "inherit": False,
+    "values": "<count>",
+    "type": "numeric"
+  },
+  "primarycache": {
+    "edit": True,
+    "inherit": True,
+    "values": "all | none | metadata",
+    "type": "str"
+  },
+  "logbias": {
+    "edit": True,
+    "inherit": True,
+    "values": "latency | throughput",
+    "type": "str"
+  },
+  "creation": {
+    "edit": False,
+    "inherit": False,
+    "values": "<date>",
+    "type": "str"
+  },
+  "sync": {
+    "edit": True,
+    "inherit": True,
+    "values": "standard | always | disabled",
+    "type": "str"
+  },
+  "dedup": {
+    "edit": True,
+    "inherit": True,
+    "values": "on | off | verify | sha256[,verify], sha512[,verify], skein[,verify], edonr,verify",
+    "type": "bool"
+  },
+  "sharenfs": {
+    "edit": True,
+    "inherit": True,
+    "values": "on | off | share(1m) options",
+    "type": "bool"
+  },
+  "receive_resume_token": {
+    "edit": False,
+    "inherit": False,
+    "values": "<string token>",
+    "type": "str"
+  },
+  "usedbyrefreservation": {
+    "edit": False,
+    "inherit": False,
+    "values": "<size>",
+    "type": "size"
+  },
+  "sharesmb": {
+    "edit": True,
+    "inherit": True,
+    "values": "on | off | sharemgr(1m) options",
+    "type": "bool"
+  },
+  "rdonly": {
+    "edit": True,
+    "inherit": True,
+    "values": "on | off",
+    "type": "bool"
+  },
+  "reservation": {
+    "edit": True,
+    "inherit": False,
+    "values": "<size> | none",
+    "type": "size"
+  },
+  "reserv": {
+    "edit": True,
+    "inherit": False,
+    "values": "<size> | none",
+    "type": "size"
+  },
+  "mountpoint": {
+    "edit": True,
+    "inherit": True,
+    "values": "<path> | legacy | none",
+    "type": "str"
+  },
+  "casesensitivity": {
+    "edit": False,
+    "inherit": True,
+    "values": "sensitive | insensitive | mixed",
+    "type": "str"
+  },
+  "utf8only": {
+    "edit": False,
+    "inherit": True,
+    "values": "on | off",
+    "type": "bool"
+  },
+  "usedbysnapshots": {
+    "edit": False,
+    "inherit": False,
+    "values": "<size>",
+    "type": "size"
+  },
+  "readonly": {
+    "edit": True,
+    "inherit": True,
+    "values": "on | off",
+    "type": "bool"
+  },
+  "written@": {
+    "edit": False,
+    "inherit": False,
+    "values": "<size>",
+    "type": "size"
+  },
+  "avail": {
+    "edit": False,
+    "inherit": False,
+    "values": "<size>",
+    "type": "size"
+  },
+  "recsize": {
+    "edit": True,
+    "inherit": True,
+    "values": "512 to 1m, power of 2",
+    "type": "str"
+  },
+  "atime": {
+    "edit": True,
+    "inherit": True,
+    "values": "on | off",
+    "type": "bool"
+  },
+  "compression": {
+    "edit": True,
+    "inherit": True,
+    "values": "on | off | lzjb | gzip | gzip-[1-9] | zle | lz4",
+    "type": "bool"
+  },
+  "snapdir": {
+    "edit": True,
+    "inherit": True,
+    "values": "hidden | visible",
+    "type": "str"
+  },
+  "aclmode": {
+    "edit": True,
+    "inherit": True,
+    "values": "discard | groupmask | passthrough | restricted",
+    "type": "str"
+  },
+  "zoned": {
+    "edit": True,
+    "inherit": True,
+    "values": "on | off",
+    "type": "bool"
+  },
+  "copies": {
+    "edit": True,
+    "inherit": True,
+    "values": "1 | 2 | 3",
+    "type": "numeric"
+  },
+  "snapshot_limit": {
+    "edit": True,
+    "inherit": False,
+    "values": "<count> | none",
+    "type": "numeric"
+  },
+  "aclinherit": {
+    "edit": True,
+    "inherit": True,
+    "values": "discard | noallow | restricted | passthrough | passthrough-x",
+    "type": "str"
+  },
+  "compressratio": {
+    "edit": False,
+    "inherit": False,
+    "values": "<1.00x or higher if compressed>",
+    "type": "str"
+  },
+  "xattr": {
+    "edit": True,
+    "inherit": True,
+    "values": "on | off",
+    "type": "bool"
+  },
+  "written": {
+    "edit": False,
+    "inherit": False,
+    "values": "<size>",
+    "type": "size"
+  },
+  "version": {
+    "edit": True,
+    "inherit": False,
+    "values": "1 | 2 | 3 | 4 | 5 | current",
+    "type": "numeric"
+  },
+  "recordsize": {
+    "edit": True,
+    "inherit": True,
+    "values": "512 to 1m, power of 2",
+    "type": "str"
+  },
+  "refquota": {
+    "edit": True,
+    "inherit": False,
+    "values": "<size> | none",
+    "type": "size"
+  },
+  "filesystem_limit": {
+    "edit": True,
+    "inherit": False,
+    "values": "<count> | none",
+    "type": "numeric"
+  },
+  "lrefer.": {
+    "edit": False,
+    "inherit": False,
+    "values": "<size>",
+    "type": "size"
+  },
+  "type": {
+    "edit": False,
+    "inherit": False,
+    "values": "filesystem | volume | snapshot | bookmark",
+    "type": "str"
+  },
+  "secondarycache": {
+    "edit": True,
+    "inherit": True,
+    "values": "all | none | metadata",
+    "type": "str"
+  },
+  "refer": {
+    "edit": False,
+    "inherit": False,
+    "values": "<size>",
+    "type": "size"
+  },
+  "available": {
+    "edit": False,
+    "inherit": False,
+    "values": "<size>",
+    "type": "size"
+  },
+  "used": {
+    "edit": False,
+    "inherit": False,
+    "values": "<size>",
+    "type": "size"
+  },
+  "exec": {
+    "edit": True,
+    "inherit": True,
+    "values": "on | off",
+    "type": "bool"
+  },
+  "compress": {
+    "edit": True,
+    "inherit": True,
+    "values": "on | off | lzjb | gzip | gzip-[1-9] | zle | lz4",
+    "type": "bool"
+  },
+  "volblock": {
+    "edit": False,
+    "inherit": True,
+    "values": "512 to 128k, power of 2",
+    "type": "str"
+  },
+  "refcompressratio": {
+    "edit": False,
+    "inherit": False,
+    "values": "<1.00x or higher if compressed>",
+    "type": "str"
+  },
+  "quota": {
+    "edit": True,
+    "inherit": False,
+    "values": "<size> | none",
+    "type": "size"
+  },
+  "groupquota@": {
+    "edit": True,
+    "inherit": False,
+    "values": "<size> | none",
+    "type": "size"
+  },
+  "userquota@": {
+    "edit": True,
+    "inherit": False,
+    "values": "<size> | none",
+    "type": "size"
+  },
+  "snapshot_count": {
+    "edit": False,
+    "inherit": False,
+    "values": "<count>",
+    "type": "numeric"
+  },
+  "volsize": {
+    "edit": True,
+    "inherit": False,
+    "values": "<size>",
+    "type": "size"
+  },
+  "clones": {
+    "edit": False,
+    "inherit": False,
+    "values": "<dataset>[,...]",
+    "type": "str"
+  },
+  "canmount": {
+    "edit": True,
+    "inherit": False,
+    "values": "on | off | noauto",
+    "type": "bool"
+  },
+  "mounted": {
+    "edit": False,
+    "inherit": False,
+    "values": "yes | no",
+    "type": "bool_alt"
+  },
+  "groupused@": {
+    "edit": False,
+    "inherit": False,
+    "values": "<size>",
+    "type": "size"
+  },
+  "normalization": {
+    "edit": False,
+    "inherit": True,
+    "values": "none | formc | formd | formkc | formkd",
+    "type": "str"
+  },
+  "usedbychildren": {
+    "edit": False,
+    "inherit": False,
+    "values": "<size>",
+    "type": "size"
+  },
+  "usedbydataset": {
+    "edit": False,
+    "inherit": False,
+    "values": "<size>",
+    "type": "size"
+  },
+  "mlslabel": {
+    "edit": True,
+    "inherit": True,
+    "values": "<sensitivity label>",
+    "type": "str"
+  },
+  "refreserv": {
+    "edit": True,
+    "inherit": False,
+    "values": "<size> | none",
+    "type": "size"
+  },
+  "defer_destroy": {
+    "edit": False,
+    "inherit": False,
+    "values": "yes | no",
+    "type": "bool_alt"
+  },
+  "volblocksize": {
+    "edit": False,
+    "inherit": True,
+    "values": "512 to 128k, power of 2",
+    "type": "str"
+  },
+  "lused.": {
+    "edit": False,
+    "inherit": False,
+    "values": "<size>",
+    "type": "size"
+  },
+  "redundant_metadata": {
+    "edit": True,
+    "inherit": True,
+    "values": "all | most",
+    "type": "str"
+  },
+  "filesystem_count": {
+    "edit": False,
+    "inherit": False,
+    "values": "<count>",
+    "type": "numeric"
+  },
+  "devices": {
+    "edit": True,
+    "inherit": True,
+    "values": "on | off",
+    "type": "bool"
+  },
+  "refreservation": {
+    "edit": True,
+    "inherit": False,
+    "values": "<size> | none",
+    "type": "size"
+  },
+  "userused@": {
+    "edit": False,
+    "inherit": False,
+    "values": "<size>",
+    "type": "size"
+  },
+  "logicalreferenced": {
+    "edit": False,
+    "inherit": False,
+    "values": "<size>",
+    "type": "size"
+  },
+  "checksum": {
+    "edit": True,
+    "inherit": True,
+    "values": "on | off | fletcher2 | fletcher4 | sha256 | sha512 | skein | edonr",
+    "type": "bool"
+  },
+  "nbmand": {
+    "edit": True,
+    "inherit": True,
+    "values": "on | off",
+    "type": "bool"
+  }
+}
+
+
+def _from_auto(name, value, source='auto'):
+    '''
+    some more complex patching for zfs.from_auto
+    '''
+    with patch.object(salt.utils.zfs, 'property_data_zpool', MagicMock(return_value=pmap_zpool)), \
+         patch.object(salt.utils.zfs, 'property_data_zfs', MagicMock(return_value=pmap_zfs)):
+        return salt.utils.zfs.from_auto(name, value, source)
+
+
+def _from_auto_dict(values, source='auto'):
+    '''
+    some more complex patching for zfs.from_auto_dict
+    '''
+    with patch.object(salt.utils.zfs, 'property_data_zpool', MagicMock(return_value=pmap_zpool)), \
+         patch.object(salt.utils.zfs, 'property_data_zfs', MagicMock(return_value=pmap_zfs)):
+        return salt.utils.zfs.from_auto_dict(values, source)
+
+
+def _to_auto(name, value, source='auto', convert_to_human=True):
+    '''
+    some more complex patching for zfs.to_auto
+    '''
+    with patch.object(salt.utils.zfs, 'property_data_zpool', MagicMock(return_value=pmap_zpool)), \
+         patch.object(salt.utils.zfs, 'property_data_zfs', MagicMock(return_value=pmap_zfs)):
+        return salt.utils.zfs.to_auto(name, value, source, convert_to_human)
+
+
+def _to_auto_dict(values, source='auto', convert_to_human=True):
+    '''
+    some more complex patching for zfs.to_auto_dict
+    '''
+    with patch.object(salt.utils.zfs, 'property_data_zpool', MagicMock(return_value=pmap_zpool)), \
+         patch.object(salt.utils.zfs, 'property_data_zfs', MagicMock(return_value=pmap_zfs)):
+        return salt.utils.zfs.to_auto_dict(values, source, convert_to_human)
+
+
+utils_patch = {
+    'zfs.is_supported': MagicMock(return_value=True),
+    'zfs.has_feature_flags': MagicMock(return_value=True),
+    'zfs.property_data_zpool': MagicMock(return_value=pmap_zpool),
+    'zfs.property_data_zfs': MagicMock(return_value=pmap_zfs),
+    # NOTE: we make zpool_command and zfs_command a NOOP
+    #       these are extensively tested in tests.unit.utils.test_zfs
+    'zfs.zpool_command': MagicMock(return_value='/bin/false'),
+    'zfs.zfs_command': MagicMock(return_value='/bin/false'),
+    # NOTE: from_auto_dict is a special snowflake
+    #       internally it calls multiple calls from
+    #       salt.utils.zfs but we cannot patch those using
+    #       the common methode, __utils__ is not available
+    #       so they are direct calls, we do some voodoo here.
+    'zfs.from_auto_dict': _from_auto_dict,
+    'zfs.from_auto': _from_auto,
+    'zfs.to_auto_dict': _to_auto_dict,
+    'zfs.to_auto': _to_auto,
+}
+
+
+# Skip this test case if we don't have access to mock!
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class ZfsUtilsTestCase(TestCase):
+    '''
+    This class contains a set of functions that test salt.utils.zfs utils
+    '''
+    ## NOTE: test parameter parsing
+    def test_property_data_zpool(self):
+        '''
+        Test parsing of zpool get output
+        '''
+        with patch.object(zfs, '_zfs_cmd', MagicMock(return_value='/sbin/zfs')):
+            with patch.object(zfs, '_zpool_cmd', MagicMock(return_value='/sbin/zpool')):
+                with patch.object(zfs, '_exec', MagicMock(return_value=pmap_exec_zpool)):
+                    self.assertEqual(zfs.property_data_zpool(), pmap_zpool)
+
+    def test_property_data_zfs(self):
+        '''
+        Test parsing of zfs get output
+        '''
+        with patch.object(zfs, '_zfs_cmd', MagicMock(return_value='/sbin/zfs')):
+            with patch.object(zfs, '_zpool_cmd', MagicMock(return_value='/sbin/zpool')):
+                with patch.object(zfs, '_exec', MagicMock(return_value=pmap_exec_zfs)):
+                    self.assertEqual(zfs.property_data_zfs(), pmap_zfs)
+
+    ## NOTE: testing from_bool results
+    def test_from_bool_on(self):
+        '''
+        Test from_bool with 'on'
+        '''
+        self.assertTrue(zfs.from_bool('on'))
+        self.assertTrue(zfs.from_bool(zfs.from_bool('on')))
+
+    def test_from_bool_off(self):
+        '''
+        Test from_bool with 'off'
+        '''
+        self.assertFalse(zfs.from_bool('off'))
+        self.assertFalse(zfs.from_bool(zfs.from_bool('off')))
+
+    def test_from_bool_none(self):
+        '''
+        Test from_bool with 'none'
+        '''
+        self.assertEqual(zfs.from_bool('none'), None)
+        self.assertEqual(zfs.from_bool(zfs.from_bool('none')), None)
+
+    def test_from_bool_passthrough(self):
+        '''
+        Test from_bool with 'passthrough'
+        '''
+        self.assertEqual(zfs.from_bool('passthrough'), 'passthrough')
+        self.assertEqual(zfs.from_bool(zfs.from_bool('passthrough')), 'passthrough')
+
+    def test_from_bool_alt_yes(self):
+        '''
+        Test from_bool_alt with 'yes'
+        '''
+        self.assertTrue(zfs.from_bool_alt('yes'))
+        self.assertTrue(zfs.from_bool_alt(zfs.from_bool_alt('yes')))
+
+    def test_from_bool_alt_no(self):
+        '''
+        Test from_bool_alt with 'no'
+        '''
+        self.assertFalse(zfs.from_bool_alt('no'))
+        self.assertFalse(zfs.from_bool_alt(zfs.from_bool_alt('no')))
+
+    def test_from_bool_alt_none(self):
+        '''
+        Test from_bool_alt with 'none'
+        '''
+        self.assertEqual(zfs.from_bool_alt('none'), None)
+        self.assertEqual(zfs.from_bool_alt(zfs.from_bool_alt('none')), None)
+
+    def test_from_bool_alt_passthrough(self):
+        '''
+        Test from_bool_alt with 'passthrough'
+        '''
+        self.assertEqual(zfs.from_bool_alt('passthrough'), 'passthrough')
+        self.assertEqual(zfs.from_bool_alt(zfs.from_bool_alt('passthrough')), 'passthrough')
+
+    ## NOTE: testing to_bool results
+    def test_to_bool_true(self):
+        '''
+        Test to_bool with True
+        '''
+        self.assertEqual(zfs.to_bool(True), 'on')
+        self.assertEqual(zfs.to_bool(zfs.to_bool(True)), 'on')
+
+    def test_to_bool_false(self):
+        '''
+        Test to_bool with False
+        '''
+        self.assertEqual(zfs.to_bool(False), 'off')
+        self.assertEqual(zfs.to_bool(zfs.to_bool(False)), 'off')
+
+    def test_to_bool_none(self):
+        '''
+        Test to_bool with None
+        '''
+        self.assertEqual(zfs.to_bool(None), 'none')
+        self.assertEqual(zfs.to_bool(zfs.to_bool(None)), 'none')
+
+    def test_to_bool_passthrough(self):
+        '''
+        Test to_bool with 'passthrough'
+        '''
+        self.assertEqual(zfs.to_bool('passthrough'), 'passthrough')
+        self.assertEqual(zfs.to_bool(zfs.to_bool('passthrough')), 'passthrough')
+
+    def test_to_bool_alt_true(self):
+        '''
+        Test to_bool_alt with True
+        '''
+        self.assertEqual(zfs.to_bool_alt(True), 'yes')
+        self.assertEqual(zfs.to_bool_alt(zfs.to_bool_alt(True)), 'yes')
+
+    def test_to_bool_alt_false(self):
+        '''
+        Test to_bool_alt with False
+        '''
+        self.assertEqual(zfs.to_bool_alt(False), 'no')
+        self.assertEqual(zfs.to_bool_alt(zfs.to_bool_alt(False)), 'no')
+
+    def test_to_bool_alt_none(self):
+        '''
+        Test to_bool_alt with None
+        '''
+        self.assertEqual(zfs.to_bool_alt(None), 'none')
+        self.assertEqual(zfs.to_bool_alt(zfs.to_bool_alt(None)), 'none')
+
+    def test_to_bool_alt_passthrough(self):
+        '''
+        Test to_bool_alt with 'passthrough'
+        '''
+        self.assertEqual(zfs.to_bool_alt('passthrough'), 'passthrough')
+        self.assertEqual(zfs.to_bool_alt(zfs.to_bool_alt('passthrough')), 'passthrough')
+
+    ## NOTE: testing from_numeric results
+    def test_from_numeric_str(self):
+        '''
+        Test from_numeric with '42'
+        '''
+        self.assertEqual(zfs.from_numeric('42'), 42)
+        self.assertEqual(zfs.from_numeric(zfs.from_numeric('42')), 42)
+
+    def test_from_numeric_int(self):
+        '''
+        Test from_numeric with 42
+        '''
+        self.assertEqual(zfs.from_numeric(42), 42)
+        self.assertEqual(zfs.from_numeric(zfs.from_numeric(42)), 42)
+
+    def test_from_numeric_none(self):
+        '''
+        Test from_numeric with 'none'
+        '''
+        self.assertEqual(zfs.from_numeric('none'), None)
+        self.assertEqual(zfs.from_numeric(zfs.from_numeric('none')), None)
+
+    def test_from_numeric_passthrough(self):
+        '''
+        Test from_numeric with 'passthrough'
+        '''
+        self.assertEqual(zfs.from_numeric('passthrough'), 'passthrough')
+        self.assertEqual(zfs.from_numeric(zfs.from_numeric('passthrough')), 'passthrough')
+
+    ## NOTE: testing to_numeric results
+    def test_to_numeric_str(self):
+        '''
+        Test to_numeric with '42'
+        '''
+        self.assertEqual(zfs.to_numeric('42'), 42)
+        self.assertEqual(zfs.to_numeric(zfs.to_numeric('42')), 42)
+
+    def test_to_numeric_int(self):
+        '''
+        Test to_numeric with 42
+        '''
+        self.assertEqual(zfs.to_numeric(42), 42)
+        self.assertEqual(zfs.to_numeric(zfs.to_numeric(42)), 42)
+
+    def test_to_numeric_none(self):
+        '''
+        Test to_numeric with 'none'
+        '''
+        self.assertEqual(zfs.to_numeric(None), 'none')
+        self.assertEqual(zfs.to_numeric(zfs.to_numeric(None)), 'none')
+
+    def test_to_numeric_passthrough(self):
+        '''
+        Test to_numeric with 'passthrough'
+        '''
+        self.assertEqual(zfs.to_numeric('passthrough'), 'passthrough')
+        self.assertEqual(zfs.to_numeric(zfs.to_numeric('passthrough')), 'passthrough')
+
+    ## NOTE: testing from_size results
+    def test_from_size_absolute(self):
+        '''
+        Test from_size with '5G'
+        '''
+        self.assertEqual(zfs.from_size('5G'), 5368709120)
+        self.assertEqual(zfs.from_size(zfs.from_size('5G')), 5368709120)
+
+    def test_from_size_decimal(self):
+        '''
+        Test from_size with '4.20M'
+        '''
+        self.assertEqual(zfs.from_size('4.20M'), 4404019)
+        self.assertEqual(zfs.from_size(zfs.from_size('4.20M')), 4404019)
+
+    def test_from_size_none(self):
+        '''
+        Test from_size with 'none'
+        '''
+        self.assertEqual(zfs.from_size('none'), None)
+        self.assertEqual(zfs.from_size(zfs.from_size('none')), None)
+
+    def test_from_size_passthrough(self):
+        '''
+        Test from_size with 'passthrough'
+        '''
+        self.assertEqual(zfs.from_size('passthrough'), 'passthrough')
+        self.assertEqual(zfs.from_size(zfs.from_size('passthrough')), 'passthrough')
+
+    ## NOTE: testing to_size results
+    def test_to_size_str_absolute(self):
+        '''
+        Test to_size with '5368709120'
+        '''
+        self.assertEqual(zfs.to_size('5368709120'), '5G')
+        self.assertEqual(zfs.to_size(zfs.to_size('5368709120')), '5G')
+
+    def test_to_size_str_decimal(self):
+        '''
+        Test to_size with '4404019'
+        '''
+        self.assertEqual(zfs.to_size('4404019'), '4.20M')
+        self.assertEqual(zfs.to_size(zfs.to_size('4404019')), '4.20M')
+
+    def test_to_size_int_absolute(self):
+        '''
+        Test to_size with 5368709120
+        '''
+        self.assertEqual(zfs.to_size(5368709120), '5G')
+        self.assertEqual(zfs.to_size(zfs.to_size(5368709120)), '5G')
+
+    def test_to_size_int_decimal(self):
+        '''
+        Test to_size with 4404019
+        '''
+        self.assertEqual(zfs.to_size(4404019), '4.20M')
+        self.assertEqual(zfs.to_size(zfs.to_size(4404019)), '4.20M')
+
+    def test_to_size_none(self):
+        '''
+        Test to_size with 'none'
+        '''
+        self.assertEqual(zfs.to_size(None), 'none')
+        self.assertEqual(zfs.to_size(zfs.to_size(None)), 'none')
+
+    def test_to_size_passthrough(self):
+        '''
+        Test to_size with 'passthrough'
+        '''
+        self.assertEqual(zfs.to_size('passthrough'), 'passthrough')
+        self.assertEqual(zfs.to_size(zfs.to_size('passthrough')), 'passthrough')
+
+    ## NOTE: testing from_str results
+    def test_from_str_space(self):
+        '''
+        Test from_str with "\"my pool/my dataset\"
+        '''
+        self.assertEqual(zfs.from_str('"my pool/my dataset"'), 'my pool/my dataset')
+        self.assertEqual(zfs.from_str(zfs.from_str('"my pool/my dataset"')), 'my pool/my dataset')
+
+    def test_from_str_squote_space(self):
+        '''
+        Test from_str with "my pool/jorge's dataset"
+        '''
+        self.assertEqual(zfs.from_str("my pool/jorge's dataset"), "my pool/jorge's dataset")
+        self.assertEqual(zfs.from_str(zfs.from_str("my pool/jorge's dataset")), "my pool/jorge's dataset")
+
+    def test_from_str_dquote_space(self):
+        '''
+        Test from_str with "my pool/the \"good\" stuff"
+        '''
+        self.assertEqual(zfs.from_str("my pool/the \"good\" stuff"), 'my pool/the "good" stuff')
+        self.assertEqual(zfs.from_str(zfs.from_str("my pool/the \"good\" stuff")), 'my pool/the "good" stuff')
+
+    def test_from_str_none(self):
+        '''
+        Test from_str with 'none'
+        '''
+        self.assertEqual(zfs.from_str('none'), None)
+        self.assertEqual(zfs.from_str(zfs.from_str('none')), None)
+
+    def test_from_str_passthrough(self):
+        '''
+        Test from_str with 'passthrough'
+        '''
+        self.assertEqual(zfs.from_str('passthrough'), 'passthrough')
+        self.assertEqual(zfs.from_str(zfs.from_str('passthrough')), 'passthrough')
+
+    ## NOTE: testing to_str results
+    def test_to_str_space(self):
+        '''
+        Test to_str with 'my pool/my dataset'
+        '''
+        ## NOTE: for fun we use both the '"str"' and "\"str\"" way of getting the literal string: "str"
+        self.assertEqual(zfs.to_str('my pool/my dataset'), '"my pool/my dataset"')
+        self.assertEqual(zfs.to_str(zfs.to_str('my pool/my dataset')), "\"my pool/my dataset\"")
+
+    def test_to_str_squote_space(self):
+        '''
+        Test to_str with "my pool/jorge's dataset"
+        '''
+        self.assertEqual(zfs.to_str("my pool/jorge's dataset"), "\"my pool/jorge's dataset\"")
+        self.assertEqual(zfs.to_str(zfs.to_str("my pool/jorge's dataset")), "\"my pool/jorge's dataset\"")
+
+    def test_to_str_none(self):
+        '''
+        Test to_str with 'none'
+        '''
+        self.assertEqual(zfs.to_str(None), 'none')
+        self.assertEqual(zfs.to_str(zfs.to_str(None)), 'none')
+
+    def test_to_str_passthrough(self):
+        '''
+        Test to_str with 'passthrough'
+        '''
+        self.assertEqual(zfs.to_str('passthrough'), 'passthrough')
+        self.assertEqual(zfs.to_str(zfs.to_str('passthrough')), 'passthrough')
+
+    ## NOTE: testing is_snapshot
+    def test_is_snapshot_snapshot(self):
+        '''
+        Test is_snapshot with a valid snapshot name
+        '''
+        self.assertTrue(zfs.is_snapshot('zpool_name/dataset@backup'))
+
+    def test_is_snapshot_bookmark(self):
+        '''
+        Test is_snapshot with a valid bookmark name
+        '''
+        self.assertFalse(zfs.is_snapshot('zpool_name/dataset#backup'))
+
+    def test_is_snapshot_filesystem(self):
+        '''
+        Test is_snapshot with a valid filesystem name
+        '''
+        self.assertFalse(zfs.is_snapshot('zpool_name/dataset'))
+
+    ## NOTE: testing is_bookmark
+    def test_is_bookmark_snapshot(self):
+        '''
+        Test is_bookmark with a valid snapshot name
+        '''
+        self.assertFalse(zfs.is_bookmark('zpool_name/dataset@backup'))
+
+    def test_is_bookmark_bookmark(self):
+        '''
+        Test is_bookmark with a valid bookmark name
+        '''
+        self.assertTrue(zfs.is_bookmark('zpool_name/dataset#backup'))
+
+    def test_is_bookmark_filesystem(self):
+        '''
+        Test is_bookmark with a valid filesystem name
+        '''
+        self.assertFalse(zfs.is_bookmark('zpool_name/dataset'))
+
+    ## NOTE: testing is_dataset
+    def test_is_dataset_snapshot(self):
+        '''
+        Test is_dataset with a valid snapshot name
+        '''
+        self.assertFalse(zfs.is_dataset('zpool_name/dataset@backup'))
+
+    def test_is_dataset_bookmark(self):
+        '''
+        Test is_dataset with a valid bookmark name
+        '''
+        self.assertFalse(zfs.is_dataset('zpool_name/dataset#backup'))
+
+    def test_is_dataset_filesystem(self):
+        '''
+        Test is_dataset with a valid filesystem/volume name
+        '''
+        self.assertTrue(zfs.is_dataset('zpool_name/dataset'))
+
+    ## NOTE: testing zfs_command
+    def test_zfs_command_simple(self):
+        '''
+        Test if zfs_command builds the correct string
+        '''
+        with patch.object(zfs, '_zfs_cmd', MagicMock(return_value='/sbin/zfs')):
+            with patch.object(zfs, '_zpool_cmd', MagicMock(return_value='/sbin/zpool')):
+                with patch.object(zfs, 'property_data_zfs', MagicMock(return_value=pmap_zfs)):
+                    with patch.object(zfs, 'property_data_zpool', MagicMock(return_value=pmap_zpool)):
+                        self.assertEqual(
+                            zfs.zfs_command('list'),
+                            "/sbin/zfs list"
+                        )
+
+    def test_zfs_command_none_target(self):
+        '''
+        Test if zfs_command builds the correct string with a target of None
+        '''
+        with patch.object(zfs, '_zfs_cmd', MagicMock(return_value='/sbin/zfs')):
+            with patch.object(zfs, '_zpool_cmd', MagicMock(return_value='/sbin/zpool')):
+                with patch.object(zfs, 'property_data_zfs', MagicMock(return_value=pmap_zfs)):
+                    with patch.object(zfs, 'property_data_zpool', MagicMock(return_value=pmap_zpool)):
+                        self.assertEqual(
+                            zfs.zfs_command('list', target=[None, 'mypool', None]),
+                            "/sbin/zfs list mypool"
+                        )
+
+    def test_zfs_command_flag(self):
+        '''
+        Test if zfs_command builds the correct string
+        '''
+        with patch.object(zfs, '_zfs_cmd', MagicMock(return_value='/sbin/zfs')):
+            with patch.object(zfs, '_zpool_cmd', MagicMock(return_value='/sbin/zpool')):
+                with patch.object(zfs, 'property_data_zfs', MagicMock(return_value=pmap_zfs)):
+                    with patch.object(zfs, 'property_data_zpool', MagicMock(return_value=pmap_zpool)):
+                        my_flags = [
+                            '-r',  # recursive
+                            '-p',  # parsable
+                        ]
+                        self.assertEqual(
+                            zfs.zfs_command('list', flags=my_flags),
+                            "/sbin/zfs list -r -p"
+                        )
+
+    def test_zfs_command_opt(self):
+        '''
+        Test if zfs_command builds the correct string
+        '''
+        with patch.object(zfs, '_zfs_cmd', MagicMock(return_value='/sbin/zfs')):
+            with patch.object(zfs, '_zpool_cmd', MagicMock(return_value='/sbin/zpool')):
+                with patch.object(zfs, 'property_data_zfs', MagicMock(return_value=pmap_zfs)):
+                    with patch.object(zfs, 'property_data_zpool', MagicMock(return_value=pmap_zpool)):
+                        my_opts = {
+                            '-t': 'snap',  # only list snapshots
+                        }
+                        self.assertEqual(
+                            zfs.zfs_command('list', opts=my_opts),
+                            "/sbin/zfs list -t snap"
+                        )
+
+    def test_zfs_command_flag_opt(self):
+        '''
+        Test if zfs_command builds the correct string
+        '''
+        with patch.object(zfs, '_zfs_cmd', MagicMock(return_value='/sbin/zfs')):
+            with patch.object(zfs, '_zpool_cmd', MagicMock(return_value='/sbin/zpool')):
+                with patch.object(zfs, 'property_data_zfs', MagicMock(return_value=pmap_zfs)):
+                    with patch.object(zfs, 'property_data_zpool', MagicMock(return_value=pmap_zpool)):
+                        my_flags = [
+                            '-r',  # recursive
+                            '-p',  # parsable
+                        ]
+                        my_opts = {
+                            '-t': 'snap',  # only list snapshots
+                        }
+                        self.assertEqual(
+                            zfs.zfs_command('list', flags=my_flags, opts=my_opts),
+                            "/sbin/zfs list -r -p -t snap"
+                        )
+
+    def test_zfs_command_target(self):
+        '''
+        Test if zfs_command builds the correct string
+        '''
+        with patch.object(zfs, '_zfs_cmd', MagicMock(return_value='/sbin/zfs')):
+            with patch.object(zfs, '_zpool_cmd', MagicMock(return_value='/sbin/zpool')):
+                with patch.object(zfs, 'property_data_zfs', MagicMock(return_value=pmap_zfs)):
+                    with patch.object(zfs, 'property_data_zpool', MagicMock(return_value=pmap_zpool)):
+                        my_flags = [
+                            '-r',  # recursive
+                            '-p',  # parsable
+                        ]
+                        my_opts = {
+                            '-t': 'snap',  # only list snapshots
+                        }
+                        self.assertEqual(
+                            zfs.zfs_command('list', flags=my_flags, opts=my_opts, target='mypool'),
+                            "/sbin/zfs list -r -p -t snap mypool"
+                        )
+
+    def test_zfs_command_target_with_space(self):
+        '''
+        Test if zfs_command builds the correct string
+        '''
+        with patch.object(zfs, '_zfs_cmd', MagicMock(return_value='/sbin/zfs')):
+            with patch.object(zfs, '_zpool_cmd', MagicMock(return_value='/sbin/zpool')):
+                with patch.object(zfs, 'property_data_zfs', MagicMock(return_value=pmap_zfs)):
+                    with patch.object(zfs, 'property_data_zpool', MagicMock(return_value=pmap_zpool)):
+                        my_flags = [
+                            '-r',  # recursive
+                            '-p',  # parsable
+                        ]
+                        my_opts = {
+                            '-t': 'snap',  # only list snapshots
+                        }
+                        self.assertEqual(
+                            zfs.zfs_command('list', flags=my_flags, opts=my_opts, target='my pool'),
+                            '/sbin/zfs list -r -p -t snap "my pool"'
+                        )
+
+    def test_zfs_command_property(self):
+        '''
+        Test if zfs_command builds the correct string
+        '''
+        with patch.object(zfs, '_zfs_cmd', MagicMock(return_value='/sbin/zfs')):
+            with patch.object(zfs, '_zpool_cmd', MagicMock(return_value='/sbin/zpool')):
+                with patch.object(zfs, 'property_data_zfs', MagicMock(return_value=pmap_zfs)):
+                    with patch.object(zfs, 'property_data_zpool', MagicMock(return_value=pmap_zpool)):
+                        self.assertEqual(
+                            zfs.zfs_command('get', property_name='quota', target='mypool'),
+                            "/sbin/zfs get quota mypool"
+                        )
+
+    def test_zfs_command_property_value(self):
+        '''
+        Test if zfs_command builds the correct string
+        '''
+        with patch.object(zfs, '_zfs_cmd', MagicMock(return_value='/sbin/zfs')):
+            with patch.object(zfs, '_zpool_cmd', MagicMock(return_value='/sbin/zpool')):
+                with patch.object(zfs, 'property_data_zfs', MagicMock(return_value=pmap_zfs)):
+                    with patch.object(zfs, 'property_data_zpool', MagicMock(return_value=pmap_zpool)):
+                        my_flags = [
+                            '-r',  # recursive
+                        ]
+                        self.assertEqual(
+                            zfs.zfs_command('set', flags=my_flags, property_name='quota', property_value='5G', target='mypool'),
+                            "/sbin/zfs set -r quota=5368709120 mypool"
+                        )
+
+    def test_zfs_command_multi_property_value(self):
+        '''
+        Test if zfs_command builds the correct string
+        '''
+        with patch.object(zfs, '_zfs_cmd', MagicMock(return_value='/sbin/zfs')):
+            with patch.object(zfs, '_zpool_cmd', MagicMock(return_value='/sbin/zpool')):
+                with patch.object(zfs, 'property_data_zfs', MagicMock(return_value=pmap_zfs)):
+                    with patch.object(zfs, 'property_data_zpool', MagicMock(return_value=pmap_zpool)):
+                        property_name = ['quota', 'readonly']
+                        property_value = ['5G', 'no']
+                        self.assertEqual(
+                            zfs.zfs_command('set', property_name=property_name, property_value=property_value, target='mypool'),
+                            "/sbin/zfs set quota=5368709120 readonly=off mypool"
+                        )
+
+    def test_zfs_command_fs_props(self):
+        '''
+        Test if zfs_command builds the correct string
+        '''
+        with patch.object(zfs, '_zfs_cmd', MagicMock(return_value='/sbin/zfs')):
+            with patch.object(zfs, '_zpool_cmd', MagicMock(return_value='/sbin/zpool')):
+                with patch.object(zfs, 'property_data_zfs', MagicMock(return_value=pmap_zfs)):
+                    with patch.object(zfs, 'property_data_zpool', MagicMock(return_value=pmap_zpool)):
+                        my_flags = [
+                            '-p',  # create parent
+                        ]
+                        my_props = {
+                            'quota': '1G',
+                            'compression': 'lz4',
+                        }
+                        self.assertEqual(
+                            zfs.zfs_command('create', flags=my_flags, filesystem_properties=my_props, target='mypool/dataset'),
+                            "/sbin/zfs create -p -o compression=lz4 -o quota=1073741824 mypool/dataset"
+                        )
+
+    def test_zfs_command_fs_props_with_space(self):
+        '''
+        Test if zfs_command builds the correct string
+        '''
+        with patch.object(zfs, '_zfs_cmd', MagicMock(return_value='/sbin/zfs')):
+            with patch.object(zfs, '_zpool_cmd', MagicMock(return_value='/sbin/zpool')):
+                with patch.object(zfs, 'property_data_zfs', MagicMock(return_value=pmap_zfs)):
+                    with patch.object(zfs, 'property_data_zpool', MagicMock(return_value=pmap_zpool)):
+                        my_props = {
+                            'quota': '4.2M',
+                            'compression': 'lz4',
+                        }
+                        self.assertEqual(
+                            zfs.zfs_command('create', filesystem_properties=my_props, target="my pool/jorge's dataset"),
+                            '/sbin/zfs create -o compression=lz4 -o quota=4404019 "my pool/jorge\'s dataset"'
+                        )
+
+    ## NOTE: testing zpool_command
+    def test_zpool_command_simple(self):
+        '''
+        Test if zfs_command builds the correct string
+        '''
+        with patch.object(zfs, '_zfs_cmd', MagicMock(return_value='/sbin/zfs')):
+            with patch.object(zfs, '_zpool_cmd', MagicMock(return_value='/sbin/zpool')):
+                with patch.object(zfs, 'property_data_zfs', MagicMock(return_value=pmap_zfs)):
+                    with patch.object(zfs, 'property_data_zpool', MagicMock(return_value=pmap_zpool)):
+                        self.assertEqual(
+                            zfs.zpool_command('list'),
+                            "/sbin/zpool list"
+                        )
+
+    def test_zpool_command_opt(self):
+        '''
+        Test if zpool_command builds the correct string
+        '''
+        with patch.object(zfs, '_zfs_cmd', MagicMock(return_value='/sbin/zfs')):
+            with patch.object(zfs, '_zpool_cmd', MagicMock(return_value='/sbin/zpool')):
+                with patch.object(zfs, 'property_data_zfs', MagicMock(return_value=pmap_zfs)):
+                    with patch.object(zfs, 'property_data_zpool', MagicMock(return_value=pmap_zpool)):
+                        my_opts = {
+                            '-o': 'name,size',  # show only name and size
+                        }
+                        self.assertEqual(
+                            zfs.zpool_command('list', opts=my_opts),
+                            "/sbin/zpool list -o name,size"
+                        )
+
+    def test_zpool_command_opt_list(self):
+        '''
+        Test if zpool_command builds the correct string
+        '''
+        with patch.object(zfs, '_zfs_cmd', MagicMock(return_value='/sbin/zfs')):
+            with patch.object(zfs, '_zpool_cmd', MagicMock(return_value='/sbin/zpool')):
+                with patch.object(zfs, 'property_data_zfs', MagicMock(return_value=pmap_zfs)):
+                    with patch.object(zfs, 'property_data_zpool', MagicMock(return_value=pmap_zpool)):
+                        my_opts = {
+                            '-d': ['/tmp', '/zvol'],
+                        }
+                        self.assertEqual(
+                            zfs.zpool_command('import', opts=my_opts, target='mypool'),
+                            "/sbin/zpool import -d /tmp -d /zvol mypool"
+                        )
+
+    def test_zpool_command_flag_opt(self):
+        '''
+        Test if zpool_command builds the correct string
+        '''
+        with patch.object(zfs, '_zfs_cmd', MagicMock(return_value='/sbin/zfs')):
+            with patch.object(zfs, '_zpool_cmd', MagicMock(return_value='/sbin/zpool')):
+                with patch.object(zfs, 'property_data_zfs', MagicMock(return_value=pmap_zfs)):
+                    with patch.object(zfs, 'property_data_zpool', MagicMock(return_value=pmap_zpool)):
+                        my_flags = [
+                            '-p',  # parsable
+                        ]
+                        my_opts = {
+                            '-o': 'name,size',  # show only name and size
+                        }
+                        self.assertEqual(
+                            zfs.zpool_command('list', flags=my_flags, opts=my_opts),
+                            "/sbin/zpool list -p -o name,size"
+                        )
+
+    def test_zpool_command_target(self):
+        '''
+        Test if zpool_command builds the correct string
+        '''
+        with patch.object(zfs, '_zfs_cmd', MagicMock(return_value='/sbin/zfs')):
+            with patch.object(zfs, '_zpool_cmd', MagicMock(return_value='/sbin/zpool')):
+                with patch.object(zfs, 'property_data_zfs', MagicMock(return_value=pmap_zfs)):
+                    with patch.object(zfs, 'property_data_zpool', MagicMock(return_value=pmap_zpool)):
+                        my_flags = [
+                            '-p',  # parsable
+                        ]
+                        my_opts = {
+                            '-o': 'name,size',  # show only name and size
+                        }
+                        self.assertEqual(
+                            zfs.zpool_command('list', flags=my_flags, opts=my_opts, target='mypool'),
+                            "/sbin/zpool list -p -o name,size mypool"
+                        )
+
+    def test_zpool_command_target_with_space(self):
+        '''
+        Test if zpool_command builds the correct string
+        '''
+        with patch.object(zfs, '_zfs_cmd', MagicMock(return_value='/sbin/zfs')):
+            with patch.object(zfs, '_zpool_cmd', MagicMock(return_value='/sbin/zpool')):
+                with patch.object(zfs, 'property_data_zfs', MagicMock(return_value=pmap_zfs)):
+                    with patch.object(zfs, 'property_data_zpool', MagicMock(return_value=pmap_zpool)):
+                        fs_props = {
+                            'quota': '100G',
+                        }
+                        pool_props = {
+                            'comment': "jorge's comment has a space",
+                        }
+                        self.assertEqual(
+                            zfs.zpool_command('create', pool_properties=pool_props, filesystem_properties=fs_props, target='my pool'),
+                            "/sbin/zpool create -O quota=107374182400 -o comment=\"jorge's comment has a space\" \"my pool\""
+                        )
+
+    def test_zpool_command_property(self):
+        '''
+        Test if zpool_command builds the correct string
+        '''
+        with patch.object(zfs, '_zfs_cmd', MagicMock(return_value='/sbin/zfs')):
+            with patch.object(zfs, '_zpool_cmd', MagicMock(return_value='/sbin/zpool')):
+                with patch.object(zfs, 'property_data_zfs', MagicMock(return_value=pmap_zfs)):
+                    with patch.object(zfs, 'property_data_zpool', MagicMock(return_value=pmap_zpool)):
+                        self.assertEqual(
+                            zfs.zpool_command('get', property_name='comment', target='mypool'),
+                            "/sbin/zpool get comment mypool"
+                        )
+
+    def test_zpool_command_property_value(self):
+        '''
+        Test if zpool_command builds the correct string
+        '''
+        with patch.object(zfs, '_zfs_cmd', MagicMock(return_value='/sbin/zfs')):
+            with patch.object(zfs, '_zpool_cmd', MagicMock(return_value='/sbin/zpool')):
+                with patch.object(zfs, 'property_data_zfs', MagicMock(return_value=pmap_zfs)):
+                    with patch.object(zfs, 'property_data_zpool', MagicMock(return_value=pmap_zpool)):
+                        my_flags = [
+                            '-v',  # verbose
+                        ]
+                        self.assertEqual(
+                            zfs.zpool_command('iostat', flags=my_flags, target=['mypool', 60, 1]),
+                            "/sbin/zpool iostat -v mypool 60 1"
+                        )
+
+    def test_parse_command_result_success(self):
+        '''
+        Test if parse_command_result returns the expected result
+        '''
+        with patch.object(zfs, '_zfs_cmd', MagicMock(return_value='/sbin/zfs')):
+            with patch.object(zfs, '_zpool_cmd', MagicMock(return_value='/sbin/zpool')):
+                with patch.object(zfs, 'property_data_zfs', MagicMock(return_value=pmap_zfs)):
+                    with patch.object(zfs, 'property_data_zpool', MagicMock(return_value=pmap_zpool)):
+                        res = {}
+                        res['retcode'] = 0
+                        res['stderr'] = ''
+                        res['stdout'] = ''
+                        self.assertEqual(
+                            zfs.parse_command_result(res, 'tested'),
+                            OrderedDict([('tested', True)]),
+                        )
+
+    def test_parse_command_result_success_nolabel(self):
+        '''
+        Test if parse_command_result returns the expected result
+        '''
+        with patch.object(zfs, '_zfs_cmd', MagicMock(return_value='/sbin/zfs')):
+            with patch.object(zfs, '_zpool_cmd', MagicMock(return_value='/sbin/zpool')):
+                with patch.object(zfs, 'property_data_zfs', MagicMock(return_value=pmap_zfs)):
+                    with patch.object(zfs, 'property_data_zpool', MagicMock(return_value=pmap_zpool)):
+                        res = {}
+                        res['retcode'] = 0
+                        res['stderr'] = ''
+                        res['stdout'] = ''
+                        self.assertEqual(
+                            zfs.parse_command_result(res),
+                            OrderedDict(),
+                        )
+
+    def test_parse_command_result_fail(self):
+        '''
+        Test if parse_command_result returns the expected result on failure
+        '''
+        with patch.object(zfs, '_zfs_cmd', MagicMock(return_value='/sbin/zfs')):
+            with patch.object(zfs, '_zpool_cmd', MagicMock(return_value='/sbin/zpool')):
+                with patch.object(zfs, 'property_data_zfs', MagicMock(return_value=pmap_zfs)):
+                    with patch.object(zfs, 'property_data_zpool', MagicMock(return_value=pmap_zpool)):
+                        res = {}
+                        res['retcode'] = 1
+                        res['stderr'] = ''
+                        res['stdout'] = ''
+                        self.assertEqual(
+                            zfs.parse_command_result(res, 'tested'),
+                            OrderedDict([('tested', False)]),
+                        )
+
+    def test_parse_command_result_nolabel(self):
+        '''
+        Test if parse_command_result returns the expected result on failure
+        '''
+        with patch.object(zfs, '_zfs_cmd', MagicMock(return_value='/sbin/zfs')):
+            with patch.object(zfs, '_zpool_cmd', MagicMock(return_value='/sbin/zpool')):
+                with patch.object(zfs, 'property_data_zfs', MagicMock(return_value=pmap_zfs)):
+                    with patch.object(zfs, 'property_data_zpool', MagicMock(return_value=pmap_zpool)):
+                        res = {}
+                        res['retcode'] = 1
+                        res['stderr'] = ''
+                        res['stdout'] = ''
+                        self.assertEqual(
+                            zfs.parse_command_result(res),
+                            OrderedDict(),
+                        )
+
+    def test_parse_command_result_fail_message(self):
+        '''
+        Test if parse_command_result returns the expected result on failure with stderr
+        '''
+        with patch.object(zfs, '_zfs_cmd', MagicMock(return_value='/sbin/zfs')):
+            with patch.object(zfs, '_zpool_cmd', MagicMock(return_value='/sbin/zpool')):
+                with patch.object(zfs, 'property_data_zfs', MagicMock(return_value=pmap_zfs)):
+                    with patch.object(zfs, 'property_data_zpool', MagicMock(return_value=pmap_zpool)):
+                        res = {}
+                        res['retcode'] = 1
+                        res['stderr'] = "\n".join([
+                            'ice is not hot',
+                            'usage:',
+                            'this should not be printed',
+                        ])
+                        res['stdout'] = ''
+                        self.assertEqual(
+                            zfs.parse_command_result(res, 'tested'),
+                            OrderedDict([('tested', False), ('error', 'ice is not hot')]),
+                        )
+
+    def test_parse_command_result_fail_message_nolabel(self):
+        '''
+        Test if parse_command_result returns the expected result on failure with stderr
+        '''
+        with patch.object(zfs, '_zfs_cmd', MagicMock(return_value='/sbin/zfs')):
+            with patch.object(zfs, '_zpool_cmd', MagicMock(return_value='/sbin/zpool')):
+                with patch.object(zfs, 'property_data_zfs', MagicMock(return_value=pmap_zfs)):
+                    with patch.object(zfs, 'property_data_zpool', MagicMock(return_value=pmap_zpool)):
+                        res = {}
+                        res['retcode'] = 1
+                        res['stderr'] = "\n".join([
+                            'ice is not hot',
+                            'usage:',
+                            'this should not be printed',
+                        ])
+                        res['stdout'] = ''
+                        self.assertEqual(
+                            zfs.parse_command_result(res),
+                            OrderedDict([('error', 'ice is not hot')]),
+                        )
+
+# vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4


### PR DESCRIPTION
### What does this PR do?
This PR attempts to cleanup the code and reduce complexity for the zfs and zpool modules and states.

- [x] salt.utils.zfs
  - [x]  proper conversion from zfs 'values' to pythonic values
  - [x] command building with proper escaping and conversion for values
  - [x] common code like testing for feature flags, zfs support,...
- [x] salt.grains.zfs
  - [x] use __utils__['zfs.is_supported']
  - [x] use __utils__['zfs.has_feature_flags']
- [x] salt.modules.zpool
  - [x] switch to ```__utils__['zfs.zpool_command']```
  - [x] simply error handing (pass along what zpool complains about)
  - [x] refactor or clarify parsing code
  - [x] improve tests
- [x] salt.modules.zfs
  - [x] switch to ```__utils__['zfs.zfs_command']```
  - [x] simply error handing (pass along what zfs complains about)
  - [x] refactor or clarify parsing code
  - [x] improve tests
- [x] salt.states.zpool
  - [x] update to work with update salt.modules.zpool
  - [x] add tests for salt.states.zpool
- [x] salt.states.zfs
  - [x] update to work with update salt.modules.zfs
  - [x] add tests for salt.states.zfs
- [x] final pass of minor cleanup

### What issues does this PR fix or reference?
#44801

### Previous Behavior
Lots of duplicate code, inconsistencies in output, ...

### New Behavior
Most duplicate code moved to a salt.utils.zfs, only do minimal error handling in modules (zfs/zpool command are pretty good at reporting what is wrong, so we just show that instead), more readable parsing code (hopefully).

Support for ZFS on OSX also added.

### Tests written?
Yes

### Commits signed with GPG?
No