### PR TITLE
Support searching by 'groupattribute' when using freeipa client

### DIFF
--- a/salt/auth/ldap.py
+++ b/salt/auth/ldap.py
@@ -362,10 +362,10 @@ def groups(username, **kwargs):
             search_results = bind.search_s(search_base,
                                            ldap.SCOPE_SUBTREE,
                                            search_string,
-                                           [_config('accountattributename'), 'cn'])
+                                           [_config('accountattributename'), 'cn', _config('groupattribute'), 'cn'])
 
             for entry, result in search_results:
-                for user in result[_config('accountattributename')]:
+                for user in result[_config('accountattributename'), _config('groupattribute')]:
                     if username == user.split(',')[0].split('=')[-1]:
                         group_list.append(entry.split(',')[0].split('=')[-1])
 


### PR DESCRIPTION
### What does this PR do?
Adds the attribute 'groupattribute' to the search path when using freeipa client to support configurations where authentication is by group.

### What issues does this PR fix or reference?
N/A

### Previous Behavior
Only the 'accountattributename' attribute was searched.

### New Behavior
First 'accountattributename' is searched then 'groupattribute' to provide extended search functionality similar to that in the "else" section of the code block

### Tests written?
No

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
