### PR TITLE
pillar_ldap: Include distinguished names in results

### DIFF
--- a/salt/pillar/pillar_ldap.py
+++ b/salt/pillar/pillar_ldap.py
@@ -201,6 +201,9 @@ def _result_to_dict(data, result, conf, source):
         data[source] = []
         for record in result:
             ret = {}
+            if 'dn' in attrs or 'distinguishedName' in attrs:
+                log.debug('dn: %s', record[0])
+                ret['dn'] = record[0]
             record = record[1]
             log.debug('record: %s', record)
             for key in record:


### PR DESCRIPTION
### What does this PR do?
Makes it possible to include distinguished names (DNs) of LDAP entries in the results provided by the pillar_ldap module in map mode

### What issues does this PR fix or reference?
None

### Previous Behavior
DNs cannot be included in pillars

### New Behavior
DNs of LDAP entries are included in the results provided by the pillar_ldap module in map mode if 'dn' or 'distinguishedName' is included in the 'attrs' configuration option.

### Tests written?
No

### Commits signed with GPG?
Yes