### PR TITLE
Remove special handling for PY2 escape function in zfs module

### DIFF
--- a/salt/modules/zfs.py
+++ b/salt/modules/zfs.py
@@ -106,10 +106,7 @@ def _zfs_quote_escape_path(name):
     Quotes zfs path with single quotes and escapes single quotes in path if present
     '''
     if name:
-        if six.PY3:
-            name = '\'' + name.replace('\'', '\\\'') + '\''
-        else:
-            name = '\'' + name.encode('string_escape').replace('\'', '\\\'') + '\''
+        name = '\'' + name.replace('\'', '\\\'') + '\''
     return name
 
 


### PR DESCRIPTION
With the changes in oxygen to use `unicode_literals`, we shouldn't need
to encode these lines anymore specifically for PY2 in this way.

Fixes the zfs unit module test failures on develop:

https://github.com/saltstack/salt-jenkins/issues/824