### PR TITLE
Add unit tests for gitfs features new to Oxygen

### DIFF
--- a/salt/utils/gitfs.py
+++ b/salt/utils/gitfs.py
@@ -7,7 +7,6 @@ Classes which provide the shared base for GitFS, git_pillar, and winrepo
 from __future__ import absolute_import, print_function, unicode_literals
 import copy
 import contextlib
-import distutils
 import errno
 import fnmatch
 import glob
@@ -90,9 +89,9 @@ log = logging.getLogger(__name__)
 try:
     import git
     import gitdb
-    HAS_GITPYTHON = True
+    GITPYTHON_VERSION = _LooseVersion(git.__version__)
 except ImportError:
-    HAS_GITPYTHON = False
+    GITPYTHON_VERSION = None
 
 try:
     # Squelch warning on cent7 due to them upgrading cffi
@@ -100,7 +99,31 @@ try:
     with warnings.catch_warnings():
         warnings.simplefilter('ignore')
         import pygit2
-    HAS_PYGIT2 = True
+    PYGIT2_VERSION = _LooseVersion(pygit2.__version__)
+    LIBGIT2_VERSION = _LooseVersion(pygit2.LIBGIT2_VERSION)
+
+    # Work around upstream bug where bytestrings were being decoded using the
+    # default encoding (which is usually ascii on Python 2). This was fixed
+    # on 2 Feb 2018, so releases prior to 0.26.2 will need a workaround.
+    if PYGIT2_VERSION <= _LooseVersion('0.26.2'):
+        try:
+            import pygit2.ffi
+            import pygit2.remote
+        except ImportError:
+            # If we couldn't import these, then we're using an old enough
+            # version where ffi isn't in use and this workaround would be
+            # useless.
+            pass
+        else:
+            def __maybe_string(ptr):
+                if not ptr:
+                    return None
+                return pygit2.ffi.string(ptr).decode('utf-8')
+
+            pygit2.remote.maybe_string = __maybe_string
+
+    # Older pygit2 releases did not raise a specific exception class, this
+    # try/except makes Salt's exception catching work on any supported release.
     try:
         GitError = pygit2.errors.GitError
     except AttributeError:
@@ -111,16 +134,17 @@ except Exception as exc:
     # to rebuild itself against the newer cffi). Therefore, we simply will
     # catch a generic exception, and log the exception if it is anything other
     # than an ImportError.
-    HAS_PYGIT2 = False
+    PYGIT2_VERSION = None
+    LIBGIT2_VERSION = None
     if not isinstance(exc, ImportError):
         log.exception('Failed to import pygit2')
 
 # pylint: enable=import-error
 
 # Minimum versions for backend providers
-GITPYTHON_MINVER = '0.3'
-PYGIT2_MINVER = '0.20.3'
-LIBGIT2_MINVER = '0.20.0'
+GITPYTHON_MINVER = _LooseVersion('0.3')
+PYGIT2_MINVER = _LooseVersion('0.20.3')
+LIBGIT2_MINVER = _LooseVersion('0.20.0')
 
 
 def enforce_types(key, val):
@@ -1841,10 +1865,7 @@ class Pygit2(GitProvider):
         '''
         Assign attributes for pygit2 callbacks
         '''
-        # pygit2 radically changed fetching in 0.23.2
-        pygit2_version = pygit2.__version__
-        if distutils.version.LooseVersion(pygit2_version) >= \
-                distutils.version.LooseVersion('0.23.2'):
+        if PYGIT2_VERSION >= _LooseVersion('0.23.2'):
             self.remotecallbacks = pygit2.RemoteCallbacks(
                 credentials=self.credentials)
             if not self.ssl_verify:
@@ -1859,7 +1880,7 @@ class Pygit2(GitProvider):
                     'pygit2 does not support disabling the SSL certificate '
                     'check in versions prior to 0.23.2 (installed: {0}). '
                     'Fetches for self-signed certificates will fail.'.format(
-                        pygit2_version
+                        PYGIT2_VERSION
                     )
                 )
 
@@ -2435,10 +2456,10 @@ class GitBase(object):
         Check if GitPython is available and at a compatible version (>= 0.3.0)
         '''
         def _recommend():
-            if HAS_PYGIT2 and 'pygit2' in self.git_providers:
+            if PYGIT2_VERSION and 'pygit2' in self.git_providers:
                 log.error(_RECOMMEND_PYGIT2, self.role, self.role)
 
-        if not HAS_GITPYTHON:
+        if not GITPYTHON_VERSION:
             if not quiet:
                 log.error(
                     '%s is configured but could not be loaded, is GitPython '
@@ -2449,18 +2470,14 @@ class GitBase(object):
         elif 'gitpython' not in self.git_providers:
             return False
 
-        # pylint: disable=no-member
-        gitver = _LooseVersion(git.__version__)
-        minver = _LooseVersion(GITPYTHON_MINVER)
-        # pylint: enable=no-member
         errors = []
-        if gitver < minver:
+        if GITPYTHON_VERSION < GITPYTHON_MINVER:
             errors.append(
                 '{0} is configured, but the GitPython version is earlier than '
                 '{1}. Version {2} detected.'.format(
                     self.role,
                     GITPYTHON_MINVER,
-                    git.__version__
+                    GITPYTHON_VERSION
                 )
             )
         if not salt.utils.path.which('git'):
@@ -2486,10 +2503,10 @@ class GitBase(object):
         Pygit2 must be at least 0.20.3 and libgit2 must be at least 0.20.0.
         '''
         def _recommend():
-            if HAS_GITPYTHON and 'gitpython' in self.git_providers:
+            if GITPYTHON_VERSION and 'gitpython' in self.git_providers:
                 log.error(_RECOMMEND_GITPYTHON, self.role, self.role)
 
-        if not HAS_PYGIT2:
+        if not PYGIT2_VERSION:
             if not quiet:
                 log.error(
                     '%s is configured but could not be loaded, are pygit2 '
@@ -2500,31 +2517,23 @@ class GitBase(object):
         elif 'pygit2' not in self.git_providers:
             return False
 
-        # pylint: disable=no-member
-        pygit2ver = _LooseVersion(pygit2.__version__)
-        pygit2_minver = _LooseVersion(PYGIT2_MINVER)
-
-        libgit2ver = _LooseVersion(pygit2.LIBGIT2_VERSION)
-        libgit2_minver = _LooseVersion(LIBGIT2_MINVER)
-        # pylint: enable=no-member
-
         errors = []
-        if pygit2ver < pygit2_minver:
+        if PYGIT2_VERSION < PYGIT2_MINVER:
             errors.append(
                 '{0} is configured, but the pygit2 version is earlier than '
                 '{1}. Version {2} detected.'.format(
                     self.role,
                     PYGIT2_MINVER,
-                    pygit2.__version__
+                    PYGIT2_VERSION
                 )
             )
-        if libgit2ver < libgit2_minver:
+        if LIBGIT2_VERSION < LIBGIT2_MINVER:
             errors.append(
                 '{0} is configured, but the libgit2 version is earlier than '
                 '{1}. Version {2} detected.'.format(
                     self.role,
                     LIBGIT2_MINVER,
-                    pygit2.LIBGIT2_VERSION
+                    LIBGIT2_VERSION
                 )
             )
         if not salt.utils.path.which('git'):

--- a/tests/integration/pillar/test_git_pillar.py
+++ b/tests/integration/pillar/test_git_pillar.py
@@ -87,24 +87,28 @@ from tests.support.unit import skipIf
 # Import Salt libs
 import salt.utils.path
 import salt.utils.platform
-from salt.utils.gitfs import GITPYTHON_MINVER, PYGIT2_MINVER
 from salt.utils.versions import LooseVersion
 from salt.modules.virtualenv_mod import KNOWN_BINARY_NAMES as VIRTUALENV_NAMES
 from salt.ext.six.moves import range  # pylint: disable=redefined-builtin
+from salt.utils.gitfs import (
+    GITPYTHON_VERSION,
+    GITPYTHON_MINVER,
+    PYGIT2_VERSION,
+    PYGIT2_MINVER,
+    LIBGIT2_VERSION,
+    LIBGIT2_MINVER
+)
 
 # Check for requisite components
 try:
-    import git
-    HAS_GITPYTHON = \
-        LooseVersion(git.__version__) >= LooseVersion(GITPYTHON_MINVER)
+    HAS_GITPYTHON = GITPYTHON_VERSION >= GITPYTHON_MINVER
 except ImportError:
     HAS_GITPYTHON = False
 
 try:
-    import pygit2
-    HAS_PYGIT2 = \
-        LooseVersion(pygit2.__version__) >= LooseVersion(PYGIT2_MINVER)
-except ImportError:
+    HAS_PYGIT2 = PYGIT2_VERSION >= PYGIT2_MINVER \
+        and LIBGIT2_VERSION >= LIBGIT2_MINVER
+except AttributeError:
     HAS_PYGIT2 = False
 
 HAS_SSHD = bool(salt.utils.path.which('sshd'))
@@ -419,7 +423,7 @@ class TestGitPythonAuthenticatedHTTP(TestGitPythonHTTP, GitPythonMixin):
 @skipIf(NO_MOCK, NO_MOCK_REASON)
 @skipIf(_windows_or_mac(), 'minion is windows or mac')
 @skip_if_not_root
-@skipIf(not HAS_PYGIT2, 'pygit2 >= {0} required'.format(PYGIT2_MINVER))
+@skipIf(not HAS_PYGIT2, 'pygit2 >= {0} and libgit2 >= {1} required'.format(PYGIT2_MINVER, LIBGIT2_MINVER))
 @skipIf(not HAS_SSHD, 'sshd not present')
 class TestPygit2SSH(GitPillarSSHTestBase):
     '''
@@ -432,12 +436,6 @@ class TestPygit2SSH(GitPillarSSHTestBase):
     id_rsa_withpass = _rand_key_name(8)
     username = USERNAME
     passphrase = PASSWORD
-
-    def setUp(self):
-        super(TestPygit2SSH, self).setUp()
-        if self.is_el7():  # pylint: disable=E1120
-            self.skipTest(
-                'skipped until EPEL7 fixes pygit2/libgit2 version mismatch')
 
     @requires_system_grains
     def test_single_source(self, grains):
@@ -1199,19 +1197,13 @@ class TestPygit2SSH(GitPillarSSHTestBase):
 @skipIf(NO_MOCK, NO_MOCK_REASON)
 @skipIf(_windows_or_mac(), 'minion is windows or mac')
 @skip_if_not_root
-@skipIf(not HAS_PYGIT2, 'pygit2 >= {0} required'.format(PYGIT2_MINVER))
+@skipIf(not HAS_PYGIT2, 'pygit2 >= {0} and libgit2 >= {1} required'.format(PYGIT2_MINVER, LIBGIT2_MINVER))
 @skipIf(not HAS_NGINX, 'nginx not present')
 @skipIf(not HAS_VIRTUALENV, 'virtualenv not present')
 class TestPygit2HTTP(GitPillarHTTPTestBase):
     '''
     Test git_pillar with pygit2 using SSH authentication
     '''
-    def setUp(self):
-        super(TestPygit2HTTP, self).setUp()
-        if self.is_el7():  # pylint: disable=E1120
-            self.skipTest(
-                'skipped until EPEL7 fixes pygit2/libgit2 version mismatch')
-
     def test_single_source(self):
         '''
         Test using a single ext_pillar repo
@@ -1452,7 +1444,7 @@ class TestPygit2HTTP(GitPillarHTTPTestBase):
 @skipIf(NO_MOCK, NO_MOCK_REASON)
 @skipIf(_windows_or_mac(), 'minion is windows or mac')
 @skip_if_not_root
-@skipIf(not HAS_PYGIT2, 'pygit2 >= {0} required'.format(PYGIT2_MINVER))
+@skipIf(not HAS_PYGIT2, 'pygit2 >= {0} and libgit2 >= {1} required'.format(PYGIT2_MINVER, LIBGIT2_MINVER))
 @skipIf(not HAS_NGINX, 'nginx not present')
 @skipIf(not HAS_VIRTUALENV, 'virtualenv not present')
 class TestPygit2AuthenticatedHTTP(GitPillarHTTPTestBase):
@@ -1464,12 +1456,6 @@ class TestPygit2AuthenticatedHTTP(GitPillarHTTPTestBase):
     '''
     user = USERNAME
     password = PASSWORD
-
-    def setUp(self):
-        super(TestPygit2AuthenticatedHTTP, self).setUp()
-        if self.is_el7():  # pylint: disable=E1120
-            self.skipTest(
-                'skipped until EPEL7 fixes pygit2/libgit2 version mismatch')
 
     def test_single_source(self):
         '''

--- a/tests/integration/pillar/test_git_pillar.py
+++ b/tests/integration/pillar/test_git_pillar.py
@@ -87,7 +87,6 @@ from tests.support.unit import skipIf
 # Import Salt libs
 import salt.utils.path
 import salt.utils.platform
-from salt.utils.versions import LooseVersion
 from salt.modules.virtualenv_mod import KNOWN_BINARY_NAMES as VIRTUALENV_NAMES
 from salt.ext.six.moves import range  # pylint: disable=redefined-builtin
 from salt.utils.gitfs import (

--- a/tests/unit/fileserver/test_gitfs.py
+++ b/tests/unit/fileserver/test_gitfs.py
@@ -31,7 +31,6 @@ import salt.utils.files
 import salt.utils.platform
 import salt.utils.win_functions
 import salt.utils.yaml
-from salt.utils.versions import LooseVersion as _LooseVersion
 
 import salt.utils.gitfs
 from salt.utils.gitfs import (

--- a/tests/unit/fileserver/test_gitfs.py
+++ b/tests/unit/fileserver/test_gitfs.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
 '''
-    :codeauthor: :email:`Erik Johnson <erik@saltstack.com>`
+:codeauthor: :email:`Erik Johnson <erik@saltstack.com>`
 '''
 
 # Import Python libs
 from __future__ import absolute_import, print_function, unicode_literals
+import copy
 import errno
 import os
 import shutil
@@ -18,15 +19,6 @@ try:
 except ImportError:
     pass
 
-# Import 3rd-party libs
-try:
-    import git  # pylint: disable=unused-import
-    HAS_GITPYTHON = True
-    GITFS_AVAILABLE = True
-except ImportError:
-    HAS_GITPYTHON = False
-    GITFS_AVAILABLE = False
-
 # Import Salt Testing Libs
 from tests.support.mixins import LoaderModuleMockMixin
 from tests.support.unit import TestCase, skipIf
@@ -36,10 +28,36 @@ from tests.support.paths import TMP, FILES
 # Import salt libs
 import salt.fileserver.gitfs as gitfs
 import salt.utils.files
-import salt.utils.gitfs
 import salt.utils.platform
 import salt.utils.win_functions
 import salt.utils.yaml
+from salt.utils.versions import LooseVersion as _LooseVersion
+
+import salt.utils.gitfs
+from salt.utils.gitfs import (
+    GITPYTHON_VERSION,
+    GITPYTHON_MINVER,
+    PYGIT2_VERSION,
+    PYGIT2_MINVER,
+    LIBGIT2_VERSION,
+    LIBGIT2_MINVER
+)
+
+try:
+    import git
+    # We still need to use GitPython here for temp repo setup, so we do need to
+    # actually import it. But we don't need import pygit2 in this module, we
+    # can just use the LooseVersion instances imported along with
+    # salt.utils.gitfs to check if we have a compatible version.
+    HAS_GITPYTHON = GITPYTHON_VERSION >= GITPYTHON_MINVER
+except (ImportError, AttributeError):
+    HAS_GITPYTHON = False
+
+try:
+    HAS_PYGIT2 = PYGIT2_VERSION >= PYGIT2_MINVER \
+        and LIBGIT2_VERSION >= LIBGIT2_MINVER
+except AttributeError:
+    HAS_PYGIT2 = False
 
 log = logging.getLogger(__name__)
 
@@ -48,6 +66,38 @@ TMP_REPO_DIR = os.path.join(TMP, 'gitfs_root')
 INTEGRATION_BASE_FILES = os.path.join(FILES, 'file', 'base')
 UNICODE_FILENAME = 'питон.txt'
 UNICODE_DIRNAME = UNICODE_ENVNAME = 'соль'
+TAG_NAME = 'mytag'
+
+OPTS = {
+    'sock_dir': TMP_SOCK_DIR,
+    'gitfs_remotes': ['file://' + TMP_REPO_DIR],
+    'gitfs_root': '',
+    'fileserver_backend': ['gitfs'],
+    'gitfs_base': 'master',
+    'fileserver_events': True,
+    'transport': 'zeromq',
+    'gitfs_mountpoint': '',
+    'gitfs_saltenv': [],
+    'gitfs_env_whitelist': [],
+    'gitfs_env_blacklist': [],
+    'gitfs_saltenv_whitelist': [],
+    'gitfs_saltenv_blacklist': [],
+    'gitfs_user': '',
+    'gitfs_password': '',
+    'gitfs_insecure_auth': False,
+    'gitfs_privkey': '',
+    'gitfs_pubkey': '',
+    'gitfs_passphrase': '',
+    'gitfs_refspecs': [
+        '+refs/heads/*:refs/remotes/origin/*',
+        '+refs/tags/*:refs/tags/*'
+    ],
+    'gitfs_ssl_verify': True,
+    'gitfs_disable_saltenv_mapping': False,
+    'gitfs_ref_types': ['branch', 'tag', 'sha'],
+    'gitfs_update_interval': 60,
+    '__role': 'master',
+}
 
 
 def _rmtree_error(func, path, excinfo):
@@ -55,43 +105,23 @@ def _rmtree_error(func, path, excinfo):
     func(path)
 
 
-@skipIf(not HAS_GITPYTHON, 'GitPython is not installed')
+def _clear_instance_map():
+    try:
+        del salt.utils.gitfs.GitFS.instance_map[tornado.ioloop.IOLoop.current()]
+    except KeyError:
+        pass
+
+
+@skipIf(not HAS_GITPYTHON, 'GitPython >= {0} required'.format(GITPYTHON_MINVER))
 class GitfsConfigTestCase(TestCase, LoaderModuleMockMixin):
 
     def setup_loader_modules(self):
-        self.tmp_cachedir = tempfile.mkdtemp(dir=TMP)
+        opts = copy.deepcopy(OPTS)
+        opts['cachedir'] = self.tmp_cachedir
+        opts['sock_dir'] = self.tmp_sock_dir
         return {
             gitfs: {
-                '__opts__': {
-                    'cachedir': self.tmp_cachedir,
-                    'sock_dir': TMP_SOCK_DIR,
-                    'gitfs_root': 'salt',
-                    'fileserver_backend': ['gitfs'],
-                    'gitfs_base': 'master',
-                    'fileserver_events': True,
-                    'transport': 'zeromq',
-                    'gitfs_mountpoint': '',
-                    'gitfs_saltenv': [],
-                    'gitfs_env_whitelist': [],
-                    'gitfs_env_blacklist': [],
-                    'gitfs_saltenv_whitelist': [],
-                    'gitfs_saltenv_blacklist': [],
-                    'gitfs_user': '',
-                    'gitfs_password': '',
-                    'gitfs_insecure_auth': False,
-                    'gitfs_privkey': '',
-                    'gitfs_pubkey': '',
-                    'gitfs_passphrase': '',
-                    'gitfs_refspecs': [
-                        '+refs/heads/*:refs/remotes/origin/*',
-                        '+refs/tags/*:refs/tags/*'
-                    ],
-                    'gitfs_ssl_verify': True,
-                    'gitfs_disable_saltenv_mapping': False,
-                    'gitfs_ref_types': ['branch', 'tag', 'sha'],
-                    'gitfs_update_interval': 60,
-                    '__role': 'master',
-                }
+                '__opts__': opts,
             }
         }
 
@@ -99,16 +129,27 @@ class GitfsConfigTestCase(TestCase, LoaderModuleMockMixin):
     def setUpClass(cls):
         # Clear the instance map so that we make sure to create a new instance
         # for this test class.
-        try:
-            del salt.utils.gitfs.GitFS.instance_map[tornado.ioloop.IOLoop.current()]
-        except KeyError:
-            pass
+        _clear_instance_map()
+        cls.tmp_cachedir = tempfile.mkdtemp(dir=TMP)
+        cls.tmp_sock_dir = tempfile.mkdtemp(dir=TMP)
 
-    def tearDown(self):
-        shutil.rmtree(self.tmp_cachedir)
+    @classmethod
+    def tearDownClass(cls):
+        '''
+        Remove the temporary git repository and gitfs cache directory to ensure
+        a clean environment for the other test class(es).
+        '''
+        for path in (cls.tmp_cachedir, cls.tmp_sock_dir):
+            try:
+                shutil.rmtree(path, onerror=_rmtree_error)
+            except OSError as exc:
+                if exc.errno != errno.EEXIST:
+                    raise
 
     def test_per_saltenv_config(self):
         opts_override = textwrap.dedent('''
+            gitfs_root: salt
+
             gitfs_saltenv:
               - baz:
                 # when loaded, the "salt://" prefix will be removed
@@ -186,110 +227,27 @@ class GitfsConfigTestCase(TestCase, LoaderModuleMockMixin):
 LOAD = {'saltenv': 'base'}
 
 
-@skipIf(not GITFS_AVAILABLE, "GitFS could not be loaded. Skipping GitFS tests!")
-@skipIf(NO_MOCK, NO_MOCK_REASON)
-class GitFSTest(TestCase, LoaderModuleMockMixin):
+class GitFSTestFuncs(object):
+    '''
+    These are where the tests go, so that they can be run using both GitPython
+    and pygit2.
 
-    def setup_loader_modules(self):
-        self.tmp_cachedir = tempfile.mkdtemp(dir=TMP)
-        return {
-            gitfs: {
-                '__opts__': {
-                    'cachedir': self.tmp_cachedir,
-                    'sock_dir': TMP_SOCK_DIR,
-                    'gitfs_remotes': ['file://' + TMP_REPO_DIR],
-                    'gitfs_root': '',
-                    'fileserver_backend': ['gitfs'],
-                    'gitfs_base': 'master',
-                    'fileserver_events': True,
-                    'transport': 'zeromq',
-                    'gitfs_mountpoint': '',
-                    'gitfs_saltenv': [],
-                    'gitfs_env_whitelist': [],
-                    'gitfs_env_blacklist': [],
-                    'gitfs_saltenv_whitelist': [],
-                    'gitfs_saltenv_blacklist': [],
-                    'gitfs_user': '',
-                    'gitfs_password': '',
-                    'gitfs_insecure_auth': False,
-                    'gitfs_privkey': '',
-                    'gitfs_pubkey': '',
-                    'gitfs_passphrase': '',
-                    'gitfs_refspecs': [
-                        '+refs/heads/*:refs/remotes/origin/*',
-                        '+refs/tags/*:refs/tags/*'
-                    ],
-                    'gitfs_ssl_verify': True,
-                    'gitfs_disable_saltenv_mapping': False,
-                    'gitfs_ref_types': ['branch', 'tag', 'sha'],
-                    'gitfs_update_interval': 60,
-                    '__role': 'master',
-                }
-            }
-        }
+    NOTE: The gitfs.update() has to happen AFTER the setUp is called. This is
+    because running it inside the setUp will spawn a new singleton, which means
+    that tests which need to mock the __opts__ will be too late; the setUp will
+    have created a new singleton that will bypass our mocking. To ensure that
+    our tests are reliable and correct, we want to make sure that each test
+    uses a new gitfs object, allowing different manipulations of the opts to be
+    tested.
 
-    @classmethod
-    def setUpClass(cls):
-        # Clear the instance map so that we make sure to create a new instance
-        # for this test class.
-        try:
-            del salt.utils.gitfs.GitFS.instance_map[tornado.ioloop.IOLoop.current()]
-        except KeyError:
-            pass
+    Therefore, keep the following in mind:
 
-        # Create the dir if it doesn't already exist
-        try:
-            shutil.copytree(INTEGRATION_BASE_FILES, TMP_REPO_DIR + '/')
-        except OSError:
-            # We probably caught an error because files already exist. Ignore
-            pass
-
-        try:
-            repo = git.Repo(TMP_REPO_DIR)
-        except git.exc.InvalidGitRepositoryError:
-            repo = git.Repo.init(TMP_REPO_DIR)
-
-        if 'USERNAME' not in os.environ:
-            try:
-                if salt.utils.platform.is_windows():
-                    os.environ['USERNAME'] = salt.utils.win_functions.get_current_user()
-                else:
-                    os.environ['USERNAME'] = pwd.getpwuid(os.geteuid()).pw_name
-            except AttributeError:
-                log.error('Unable to get effective username, falling back to '
-                          '\'root\'.')
-                os.environ['USERNAME'] = 'root'
-
-        repo.index.add([x for x in os.listdir(TMP_REPO_DIR)
-                        if x != '.git'])
-        repo.index.commit('Test')
-
-        # Add another branch with unicode characters in the name
-        repo.create_head(UNICODE_ENVNAME, 'HEAD')
-
-    def setUp(self):
-        '''
-        We don't want to check in another .git dir into GH because that just
-        gets messy. Instead, we'll create a temporary repo on the fly for the
-        tests to examine.
-        '''
-        if not gitfs.__virtual__():
-            self.skipTest("GitFS could not be loaded. Skipping GitFS tests!")
-        self.tmp_cachedir = tempfile.mkdtemp(dir=TMP)
-        gitfs.update()
-
-    def tearDown(self):
-        '''
-        Remove the temporary git repository and gitfs cache directory to ensure
-        a clean environment for each test.
-        '''
-        try:
-            shutil.rmtree(self.tmp_cachedir, onerror=_rmtree_error)
-        except OSError as exc:
-            if exc.errno != errno.EEXIST:
-                raise
-
+    1. Each test needs to call gitfs.update() *after* any patching, and
+       *before* calling the function being tested.
+    2. Do *NOT* move the gitfs.update() into the setUp.
+    '''
     def test_file_list(self):
+        gitfs.update()
         ret = gitfs.file_list(LOAD)
         self.assertIn('testfile', ret)
         self.assertIn(UNICODE_FILENAME, ret)
@@ -298,11 +256,242 @@ class GitFSTest(TestCase, LoaderModuleMockMixin):
         self.assertIn('/'.join((UNICODE_DIRNAME, 'foo.txt')), ret)
 
     def test_dir_list(self):
+        gitfs.update()
         ret = gitfs.dir_list(LOAD)
         self.assertIn('grail', ret)
         self.assertIn(UNICODE_DIRNAME, ret)
 
     def test_envs(self):
+        gitfs.update()
         ret = gitfs.envs(ignore_cache=True)
         self.assertIn('base', ret)
         self.assertIn(UNICODE_ENVNAME, ret)
+        self.assertIn(TAG_NAME, ret)
+
+    def test_ref_types_global(self):
+        '''
+        Test the global gitfs_ref_types config option
+        '''
+        with patch.dict(gitfs.__opts__, {'gitfs_ref_types': ['branch']}):
+            gitfs.update()
+            ret = gitfs.envs(ignore_cache=True)
+            # Since we are restricting to branches only, the tag should not
+            # appear in the envs list.
+            self.assertIn('base', ret)
+            self.assertIn(UNICODE_ENVNAME, ret)
+            self.assertNotIn(TAG_NAME, ret)
+
+    def test_ref_types_per_remote(self):
+        '''
+        Test the per_remote ref_types config option, using a different
+        ref_types setting than the global test.
+        '''
+        remotes = [{'file://' + TMP_REPO_DIR: [{'ref_types': ['tag']}]}]
+        with patch.dict(gitfs.__opts__, {'gitfs_remotes': remotes}):
+            gitfs.update()
+            ret = gitfs.envs(ignore_cache=True)
+            # Since we are restricting to tags only, the tag should appear in
+            # the envs list, but the branches should not.
+            self.assertNotIn('base', ret)
+            self.assertNotIn(UNICODE_ENVNAME, ret)
+            self.assertIn(TAG_NAME, ret)
+
+    def test_disable_saltenv_mapping_global_with_mapping_defined_globally(self):
+        '''
+        Test the global gitfs_disable_saltenv_mapping config option, combined
+        with the per-saltenv mapping being defined in the global gitfs_saltenv
+        option.
+        '''
+        opts = salt.utils.yaml.safe_load(textwrap.dedent('''\
+            gitfs_disable_saltenv_mapping: True
+            gitfs_saltenv:
+              - foo:
+                - ref: base
+            '''))
+        with patch.dict(gitfs.__opts__, opts):
+            gitfs.update()
+            ret = gitfs.envs(ignore_cache=True)
+            # Since we are restricting to tags only, the tag should appear in
+            # the envs list, but the branches should not.
+            self.assertEqual(ret, ['foo'])
+
+    def test_disable_saltenv_mapping_global_with_mapping_defined_per_remote(self):
+        '''
+        Test the global gitfs_disable_saltenv_mapping config option, combined
+        with the per-saltenv mapping being defined in the remote itself via the
+        "saltenv" per-remote option.
+        '''
+        opts = salt.utils.yaml.safe_load(textwrap.dedent('''\
+            gitfs_disable_saltenv_mapping: True
+            gitfs_remotes:
+              - file://{0}:
+                - saltenv:
+                  - bar:
+                    - ref: base
+            '''.format(TMP_REPO_DIR)))
+        with patch.dict(gitfs.__opts__, opts):
+            gitfs.update()
+            ret = gitfs.envs(ignore_cache=True)
+            # Since we are restricting to tags only, the tag should appear in
+            # the envs list, but the branches should not.
+            self.assertEqual(ret, ['bar'])
+
+    def test_disable_saltenv_mapping_per_remote_with_mapping_defined_globally(self):
+        '''
+        Test the per-remote disable_saltenv_mapping config option, combined
+        with the per-saltenv mapping being defined in the global gitfs_saltenv
+        option.
+        '''
+        opts = salt.utils.yaml.safe_load(textwrap.dedent('''\
+            gitfs_remotes:
+              - file://{0}:
+                - disable_saltenv_mapping: True
+
+            gitfs_saltenv:
+              - hello:
+                - ref: base
+            '''))
+        with patch.dict(gitfs.__opts__, opts):
+            gitfs.update()
+            ret = gitfs.envs(ignore_cache=True)
+            # Since we are restricting to tags only, the tag should appear in
+            # the envs list, but the branches should not.
+            self.assertEqual(ret, ['hello'])
+
+    def test_disable_saltenv_mapping_per_remote_with_mapping_defined_per_remote(self):
+        '''
+        Test the per-remote disable_saltenv_mapping config option, combined
+        with the per-saltenv mapping being defined in the remote itself via the
+        "saltenv" per-remote option.
+        '''
+        opts = salt.utils.yaml.safe_load(textwrap.dedent('''\
+            gitfs_remotes:
+              - file://{0}:
+                - disable_saltenv_mapping: True
+                - saltenv:
+                  - world:
+                    - ref: base
+            '''.format(TMP_REPO_DIR)))
+        with patch.dict(gitfs.__opts__, opts):
+            gitfs.update()
+            ret = gitfs.envs(ignore_cache=True)
+            # Since we are restricting to tags only, the tag should appear in
+            # the envs list, but the branches should not.
+            self.assertEqual(ret, ['world'])
+
+
+class GitFSTestBase(object):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.tmp_cachedir = tempfile.mkdtemp(dir=TMP)
+        cls.tmp_sock_dir = tempfile.mkdtemp(dir=TMP)
+
+        try:
+            shutil.rmtree(TMP_REPO_DIR)
+        except OSError as exc:
+            if exc.errno != errno.ENOENT:
+                raise
+        shutil.copytree(INTEGRATION_BASE_FILES, TMP_REPO_DIR + '/')
+
+        repo = git.Repo.init(TMP_REPO_DIR)
+
+        username_key = str('USERNAME')
+        orig_username = os.environ.get(username_key)
+        try:
+            if username_key not in os.environ:
+                try:
+                    if salt.utils.platform.is_windows():
+                        os.environ[username_key] = \
+                            salt.utils.win_functions.get_current_user()
+                    else:
+                        os.environ[username_key] = \
+                            pwd.getpwuid(os.geteuid()).pw_name
+                except AttributeError:
+                    log.error(
+                        'Unable to get effective username, falling back to '
+                        '\'root\'.'
+                    )
+                    os.environ[username_key] = str('root')
+
+            repo.index.add([x for x in os.listdir(TMP_REPO_DIR)
+                            if x != '.git'])
+            repo.index.commit('Test')
+
+            # Add another branch with unicode characters in the name
+            repo.create_head(UNICODE_ENVNAME, 'HEAD')
+
+            # Add a tag
+            repo.create_tag(TAG_NAME, 'HEAD')
+        finally:
+            if orig_username is not None:
+                os.environ[username_key] = orig_username
+            else:
+                os.environ.pop(username_key, None)
+
+    @classmethod
+    def tearDownClass(cls):
+        '''
+        Remove the temporary git repository and gitfs cache directory to ensure
+        a clean environment for the other test class(es).
+        '''
+        for path in (cls.tmp_cachedir, cls.tmp_sock_dir, TMP_REPO_DIR):
+            try:
+                shutil.rmtree(path, onerror=_rmtree_error)
+            except OSError as exc:
+                if exc.errno != errno.EEXIST:
+                    raise
+
+    def setUp(self):
+        '''
+        We don't want to check in another .git dir into GH because that just
+        gets messy. Instead, we'll create a temporary repo on the fly for the
+        tests to examine.
+
+        Also ensure we A) don't re-use the singleton, and B) that the cachedirs
+        are cleared. This keeps these performance enhancements from affecting
+        the results of subsequent tests.
+        '''
+        if not gitfs.__virtual__():
+            self.skipTest("GitFS could not be loaded. Skipping GitFS tests!")
+
+        _clear_instance_map()
+        for subdir in ('gitfs', 'file_lists'):
+            try:
+                shutil.rmtree(os.path.join(self.tmp_cachedir, subdir))
+            except OSError as exc:
+                if exc.errno != errno.ENOENT:
+                    raise
+
+
+@skipIf(not HAS_GITPYTHON, 'GitPython >= {0} required'.format(GITPYTHON_MINVER))
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class GitPythonTest(GitFSTestBase, GitFSTestFuncs, TestCase, LoaderModuleMockMixin):
+
+    def setup_loader_modules(self):
+        opts = copy.deepcopy(OPTS)
+        opts['cachedir'] = self.tmp_cachedir
+        opts['sock_dir'] = self.tmp_sock_dir
+        opts['gitfs_provider'] = 'gitpython'
+        return {
+            gitfs: {
+                '__opts__': opts,
+            }
+        }
+
+
+@skipIf(not HAS_GITPYTHON, 'GitPython >= {0} required for temp repo setup'.format(GITPYTHON_MINVER))
+@skipIf(not HAS_PYGIT2, 'pygit2 >= {0} and libgit2 >= {1} required'.format(PYGIT2_MINVER, LIBGIT2_MINVER))
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class Pygit2Test(GitFSTestBase, GitFSTestFuncs, TestCase, LoaderModuleMockMixin):
+
+    def setup_loader_modules(self):
+        opts = copy.deepcopy(OPTS)
+        opts['cachedir'] = self.tmp_cachedir
+        opts['sock_dir'] = self.tmp_sock_dir
+        opts['gitfs_provider'] = 'pygit2'
+        return {
+            gitfs: {
+                '__opts__': opts,
+            }
+        }


### PR DESCRIPTION
This adds unit tests for two new features. It also expands the unit testing to include pygit2 as well as GitPython.

In the process of getting the unit tests running for pygit2, I discovered an upstream bug with handling unicode refs. This bug was coincidentally fixed in pygit2 just 5 days ago, so this PR also includes a workaround for pygit2 releases prior to 0.26.2 which monkeypatches the broken function with a fixed version.

Resolves #45473.