### PR TITLE
Update cisconso.py docstring

### DIFF
--- a/salt/modules/cisconso.py
+++ b/salt/modules/cisconso.py
@@ -60,7 +60,7 @@ def get_data(datastore, path):
 
 def set_data_value(datastore, path, data):
     '''
-    Get a data entry in a datastore
+    Set a data entry in a datastore
 
     :param datastore: The datastore, e.g. running, operational.
         One of the NETCONF store IETF types


### PR DESCRIPTION
set_data_value() sets a value in the datastore, not gets.

### What does this PR do?
Updates docstring to reflect its actual function.