### PR TITLE
add execution module for OpenBSD Packet Filter

### DIFF
--- a/doc/ref/modules/all/index.rst
+++ b/doc/ref/modules/all/index.rst
@@ -315,6 +315,7 @@ execution modules
     pcs
     pdbedit
     pecl
+    pf
     philips_hue
     pillar
     pip

--- a/doc/ref/modules/all/salt.modules.pf.rst
+++ b/doc/ref/modules/all/salt.modules.pf.rst
@@ -1,0 +1,6 @@
+===============
+salt.modules.pf
+===============
+
+.. automodule:: salt.modules.pf
+    :members:

--- a/salt/modules/pf.py
+++ b/salt/modules/pf.py
@@ -1,0 +1,349 @@
+# -*- coding: utf-8 -*-
+'''
+Control the OpenBSD packet filter (PF).
+
+:codeauthor: Jasper Lievisse Adriaanse <j@jasper.la>
+
+.. versionadded:: Fluorine
+'''
+
+from __future__ import absolute_import, print_function, unicode_literals
+
+# Import python libs
+import logging
+import re
+
+# Import salt libs
+import salt.utils.path
+from salt.exceptions import (CommandExecutionError, SaltInvocationError)
+
+log = logging.getLogger(__name__)
+
+
+def __virtual__():
+    '''
+    Only works on OpenBSD for now; other systems with pf (macOS, FreeBSD, etc)
+    need to be tested before enabling them.
+    '''
+    if __grains__['os'] == 'OpenBSD' and salt.utils.path.which('pfctl'):
+        return True
+
+    return (False, 'The pf execution module cannot be loaded: either the system is not OpenBSD or the pfctl binary was not found')
+
+
+def enable():
+    '''
+    Enable the Packet Filter.
+
+    CLI example:
+
+    .. code-block:: bash
+
+        salt '*' pf.enable
+    '''
+    ret = {}
+    result = __salt__['cmd.run_all']('pfctl -e',
+                                     output_loglevel='trace',
+                                     python_shell=False)
+
+    if result['retcode'] == 0:
+        ret = {'comment': 'pf enabled', 'changes': True}
+    else:
+        # If pf was already enabled the return code is also non-zero.
+        # Don't raise an exception in that case.
+        if result['stderr'] == 'pfctl: pf already enabled':
+            ret = {'comment': 'pf already enabled', 'changes': False}
+        else:
+            raise CommandExecutionError(
+                'Could not enable pf',
+                info={'errors': [result['stderr']], 'changes': False}
+            )
+
+    return ret
+
+
+def disable():
+    '''
+    Disable the Packet Filter.
+
+    CLI example:
+
+    .. code-block:: bash
+
+        salt '*' pf.disable
+    '''
+    ret = {}
+    result = __salt__['cmd.run_all']('pfctl -d',
+                                     output_loglevel='trace',
+                                     python_shell=False)
+
+    if result['retcode'] == 0:
+        ret = {'comment': 'pf disabled', 'changes': True}
+    else:
+        # If pf was already disabled the return code is also non-zero.
+        # Don't raise an exception in that case.
+        if result['stderr'] == 'pfctl: pf not enabled':
+            ret = {'comment': 'pf already disabled', 'changes': False}
+        else:
+            raise CommandExecutionError(
+                'Could not disable pf',
+                info={'errors': [result['stderr']], 'changes': False}
+            )
+
+    return ret
+
+
+def loglevel(level):
+    '''
+    Set the debug level which limits the severity of log messages printed by ``pf(4)``.
+
+    level:
+        Log level. Should be one of the following: emerg, alert, crit, err, warning, notice,
+        info or debug.
+
+    CLI example:
+
+    .. code-block:: bash
+
+        salt '*' pf.loglevel emerg
+    '''
+    # There's no way to getting the previous loglevel so imply we've
+    # always made a change.
+    ret = {'changes': True}
+
+    all_levels = ['emerg', 'alert', 'crit', 'err', 'warning', 'notice', 'info', 'debug']
+    if level not in all_levels:
+        raise SaltInvocationError('Unknown loglevel: {0}'.format(level))
+
+    result = __salt__['cmd.run_all']('pfctl -x {0}'.format(level),
+                                     output_loglevel='trace',
+                                     python_shell=False)
+
+    if result['retcode'] != 0:
+        raise CommandExecutionError(
+            'Problem encountered setting loglevel',
+            info={'errors': [result['stderr']], 'changes': False}
+        )
+
+    return ret
+
+
+def load(file='/etc/pf.conf', noop=False):
+    '''
+    Load a ruleset from the specific file, overwriting the currently loaded ruleset.
+
+    file:
+        Full path to the file containing the ruleset.
+
+    noop:
+        Don't actually load the rules, just parse them.
+
+    CLI example:
+
+    .. code-block:: bash
+
+        salt '*' pf.load /etc/pf.conf.d/lockdown.conf
+    '''
+    # We cannot precisely determine if loading the ruleset implied
+    # any changes so assume it always does.
+    ret = {'changes': True}
+    cmd = ['pfctl', '-f', file]
+
+    if noop:
+        ret['changes'] = False
+        cmd.append('-n')
+
+    result = __salt__['cmd.run_all'](cmd,
+                                     output_loglevel='trace',
+                                     python_shell=False)
+
+    if result['retcode'] != 0:
+        raise CommandExecutionError(
+            'Problem loading the ruleset from {0}'.format(file),
+            info={'errors': [result['stderr']], 'changes': False}
+        )
+
+    return ret
+
+
+def flush(modifier):
+    '''
+    Flush the specified packet filter parameters.
+
+    modifier:
+        Should be one of the following:
+
+        - all
+        - info
+        - osfp
+        - rules
+        - sources
+        - states
+        - tables
+
+        Please refer to the OpenBSD `pfctl(8) <https://man.openbsd.org/pfctl#T>`_
+        documentation for a detailed explanation of each command.
+
+    CLI example:
+
+    .. code-block:: bash
+
+        salt '*' pf.flush states
+    '''
+    ret = {}
+
+    all_modifiers = ['rules', 'states', 'info', 'osfp', 'all', 'sources', 'tables']
+
+    # Accept the following two modifiers to allow for a consistent interface between
+    # pfctl(8) and Salt.
+    capital_modifiers = ['Sources', 'Tables']
+    all_modifiers += capital_modifiers
+    if modifier.title() in capital_modifiers:
+        modifier = modifier.title()
+
+    if modifier not in all_modifiers:
+        raise SaltInvocationError('Unknown modifier: {0}'.format(modifier))
+
+    cmd = 'pfctl -v -F {0}'.format(modifier)
+    result = __salt__['cmd.run_all'](cmd,
+                                     output_loglevel='trace',
+                                     python_shell=False)
+
+    if result['retcode'] == 0:
+        if re.match(r'^0.*', result['stderr']):
+            ret['changes'] = False
+        else:
+            ret['changes'] = True
+
+        ret['comment'] = result['stderr']
+    else:
+        raise CommandExecutionError(
+            'Could not flush {0}'.format(modifier),
+            info={'errors': [result['stderr']], 'changes': False}
+        )
+
+    return ret
+
+
+def table(command, table, **kwargs):
+    '''
+    Apply a command on the specified table.
+
+    table:
+        Name of the table.
+
+    command:
+        Command to apply to the table. Supported commands are:
+
+        - add
+        - delete
+        - expire
+        - flush
+        - kill
+        - replace
+        - show
+        - test
+        - zero
+
+        Please refer to the OpenBSD `pfctl(8) <https://man.openbsd.org/pfctl#T>`_
+        documentation for a detailed explanation of each command.
+
+    CLI example:
+
+    .. code-block:: bash
+
+        salt '*' pf.table expire table=spam_hosts number=300
+        salt '*' pf.table add table=local_hosts addresses='["127.0.0.1", "::1"]'
+    '''
+    ret = {}
+
+    all_commands = ['kill', 'flush', 'add', 'delete', 'expire', 'replace', 'show', 'test', 'zero']
+    if command not in all_commands:
+        raise SaltInvocationError('Unknown table command: {0}'.format(command))
+
+    cmd = ['pfctl', '-t', table, '-T', command]
+
+    if command in ['add', 'delete', 'replace', 'test']:
+        cmd += kwargs.get('addresses', [])
+    elif command == 'expire':
+        number = kwargs.get('number', None)
+        if not number:
+            raise SaltInvocationError('need expire_number argument for expire command')
+        else:
+            cmd.append(number)
+
+    result = __salt__['cmd.run_all'](cmd,
+                                     output_level='trace',
+                                     python_shell=False)
+
+    if result['retcode'] == 0:
+        if command == 'show':
+            ret = {'comment': result['stdout'].split()}
+        elif command == 'test':
+            ret = {'comment': result['stderr'], 'matches': True}
+        else:
+            if re.match(r'^(0.*|no changes)', result['stderr']):
+                ret['changes'] = False
+            else:
+                ret['changes'] = True
+
+            ret['comment'] = result['stderr']
+    else:
+        # 'test' returns a non-zero code if the address didn't match, even if
+        # the command itself ran fine; also set 'matches' to False since not
+        # everything matched.
+        if command == 'test' and re.match(r'^\d+/\d+ addresses match.$', result['stderr']):
+            ret = {'comment': result['stderr'], 'matches': False}
+        else:
+            raise CommandExecutionError(
+                'Could not apply {0} on table {1}'.format(command, table),
+                info={'errors': [result['stderr']], 'changes': False}
+            )
+
+    return ret
+
+
+def show(modifier):
+    '''
+    Show filter parameters.
+
+    modifier:
+        Modifier to apply for filtering. Only a useful subset of what pfctl supports
+        can be used with Salt.
+
+        - rules
+        - states
+        - tables
+
+    CLI example:
+
+    .. code-block:: bash
+
+        salt '*' pf.show rules
+    '''
+    # By definition showing the parameters makes no changes.
+    ret = {'changes': False}
+
+    capital_modifiers = ['Tables']
+    all_modifiers = ['rules', 'states', 'tables']
+    all_modifiers += capital_modifiers
+    if modifier.title() in capital_modifiers:
+        modifier = modifier.title()
+
+    if modifier not in all_modifiers:
+        raise SaltInvocationError('Unknown modifier: {0}'.format(modifier))
+
+    cmd = 'pfctl -s {0}'.format(modifier)
+    result = __salt__['cmd.run_all'](cmd,
+                                     output_loglevel='trace',
+                                     python_shell=False)
+
+    if result['retcode'] == 0:
+        ret['comment'] = result['stdout'].split('\n')
+    else:
+        raise CommandExecutionError(
+            'Could not show {0}'.format(modifier),
+            info={'errors': [result['stderr']], 'changes': False}
+        )
+
+    return ret

--- a/tests/unit/modules/test_pf.py
+++ b/tests/unit/modules/test_pf.py
@@ -1,0 +1,238 @@
+# -*- coding: utf-8 -*-
+
+# Import Python libs
+from __future__ import absolute_import, print_function, unicode_literals
+
+# Import Salt Libs
+import salt.modules.pf as pf
+
+# Import Salt Testing Libs
+from tests.support.mixins import LoaderModuleMockMixin
+from tests.support.unit import TestCase
+from tests.support.mock import (
+    MagicMock,
+    patch,
+)
+
+
+class PfTestCase(TestCase, LoaderModuleMockMixin):
+    '''
+    test modules.pf functions
+    '''
+    def setup_loader_modules(self):
+        return {pf: {}}
+
+    def test_enable_when_disabled(self):
+        '''
+        Tests enabling pf when it's not enabled yet.
+        '''
+        ret = {}
+        ret['stderr'] = 'pf enabled'
+        ret['retcode'] = 0
+        mock_cmd = MagicMock(return_value=ret)
+        with patch.dict(pf.__salt__, {'cmd.run_all': mock_cmd}):
+            self.assertTrue(pf.enable()['changes'])
+
+    def test_enable_when_enabled(self):
+        '''
+        Tests enabling pf when it already enabled.
+        '''
+        ret = {}
+        ret['stderr'] = 'pfctl: pf already enabled'
+        ret['retcode'] = 1
+        mock_cmd = MagicMock(return_value=ret)
+        with patch.dict(pf.__salt__, {'cmd.run_all': mock_cmd}):
+            self.assertFalse(pf.enable()['changes'])
+
+    def test_disable_when_enabled(self):
+        '''
+        Tests disabling pf when it's enabled.
+        '''
+        ret = {}
+        ret['stderr'] = 'pf disabled'
+        ret['retcode'] = 0
+        mock_cmd = MagicMock(return_value=ret)
+        with patch.dict(pf.__salt__, {'cmd.run_all': mock_cmd}):
+            self.assertTrue(pf.disable()['changes'])
+
+    def test_disable_when_disabled(self):
+        '''
+        Tests disabling pf when it already disabled.
+        '''
+        ret = {}
+        ret['stderr'] = 'pfctl: pf not enabled'
+        ret['retcode'] = 1
+        mock_cmd = MagicMock(return_value=ret)
+        with patch.dict(pf.__salt__, {'cmd.run_all': mock_cmd}):
+            self.assertFalse(pf.disable()['changes'])
+
+    def test_loglevel(self):
+        '''
+        Tests setting a loglevel.
+        '''
+        ret = {}
+        ret['retcode'] = 0
+        mock_cmd = MagicMock(return_value=ret)
+        with patch.dict(pf.__salt__, {'cmd.run_all': mock_cmd}):
+            res = pf.loglevel('crit')
+            mock_cmd.assert_called_once_with('pfctl -x crit',
+                    output_loglevel='trace', python_shell=False)
+            self.assertTrue(res['changes'])
+
+    def test_load(self):
+        '''
+        Tests loading ruleset.
+        '''
+        ret = {}
+        ret['retcode'] = 0
+        mock_cmd = MagicMock(return_value=ret)
+        with patch.dict(pf.__salt__, {'cmd.run_all': mock_cmd}):
+            res = pf.load()
+            mock_cmd.assert_called_once_with(['pfctl', '-f', '/etc/pf.conf'],
+                    output_loglevel='trace', python_shell=False)
+            self.assertTrue(res['changes'])
+
+    def test_load_noop(self):
+        '''
+        Tests evaluating but not actually loading ruleset.
+        '''
+        ret = {}
+        ret['retcode'] = 0
+        mock_cmd = MagicMock(return_value=ret)
+        with patch.dict(pf.__salt__, {'cmd.run_all': mock_cmd}):
+            res = pf.load(noop=True)
+            mock_cmd.assert_called_once_with(['pfctl', '-f', '/etc/pf.conf', '-n'],
+                    output_loglevel='trace', python_shell=False)
+            self.assertFalse(res['changes'])
+
+    def test_flush(self):
+        '''
+        Tests a regular flush command.
+        '''
+        ret = {}
+        ret['stderr'] = 'pf: statistics cleared'
+        ret['retcode'] = 0
+        mock_cmd = MagicMock(return_value=ret)
+        with patch.dict(pf.__salt__, {'cmd.run_all': mock_cmd}):
+            res = pf.flush('info')
+            mock_cmd.assert_called_once_with('pfctl -v -F info',
+                    output_loglevel='trace', python_shell=False)
+            self.assertTrue(res['changes'])
+
+    def test_flush_capital(self):
+        '''
+        Tests a flush command starting with a capital letter.
+        '''
+        ret = {}
+        ret['stderr'] = '2 tables cleared'
+        ret['retcode'] = 0
+        mock_cmd = MagicMock(return_value=ret)
+        with patch.dict(pf.__salt__, {'cmd.run_all': mock_cmd}):
+            res = pf.flush('tables')
+            mock_cmd.assert_called_once_with('pfctl -v -F Tables',
+                    output_loglevel='trace', python_shell=False)
+            self.assertTrue(res['changes'])
+
+    def test_flush_without_changes(self):
+        '''
+        Tests a flush command that has no changes.
+        '''
+        ret = {}
+        ret['stderr'] = '0 tables cleared'
+        ret['retcode'] = 0
+        mock_cmd = MagicMock(return_value=ret)
+        with patch.dict(pf.__salt__, {'cmd.run_all': mock_cmd}):
+            self.assertFalse(pf.flush('tables')['changes'])
+
+    def test_table(self):
+        '''
+        Tests a regular table command.
+        '''
+        ret = {}
+        ret['stderr'] = '42 addresses deleted'
+        ret['retcode'] = 0
+        mock_cmd = MagicMock(return_value=ret)
+        with patch.dict(pf.__salt__, {'cmd.run_all': mock_cmd}):
+            self.assertTrue(pf.table('flush', table='bad_hosts')['changes'])
+
+    def test_table_expire(self):
+        '''
+        Tests the table expire command.
+        '''
+        ret = {}
+        ret['stderr'] = '1/1 addresses expired.'
+        ret['retcode'] = 0
+        mock_cmd = MagicMock(return_value=ret)
+        with patch.dict(pf.__salt__, {'cmd.run_all': mock_cmd}):
+            self.assertTrue(pf.table('expire', table='bad_hosts', number=300)['changes'])
+
+    def test_table_add_addresses(self):
+        '''
+        Tests adding addresses to a table.
+        '''
+        ret = {}
+        ret['stderr'] = '2/2 addressess added.'
+        ret['retcode'] = 0
+        mock_cmd = MagicMock(return_value=ret)
+        with patch.dict(pf.__salt__, {'cmd.run_all': mock_cmd}):
+            self.assertTrue(pf.table('add', table='bad_hosts', addresses=['1.2.3.4', '5.6.7.8'])['changes'])
+
+    def test_table_test_address(self):
+        '''
+        Tests testing addresses in a table.
+        '''
+        ret = {}
+        ret['stderr'] = '1/2 addressess match.'
+        ret['retcode'] = 0
+        mock_cmd = MagicMock(return_value=ret)
+        with patch.dict(pf.__salt__, {'cmd.run_all': mock_cmd}):
+            self.assertTrue(pf.table('test', table='bad_hosts', addresses=['1.2.3.4'])['matches'])
+
+    def test_table_no_changes(self):
+        '''
+        Tests a table command that has no changes.
+        '''
+        ret = {}
+        ret['stderr'] = '0/1 addresses expired.'
+        ret['retcode'] = 0
+        mock_cmd = MagicMock(return_value=ret)
+        with patch.dict(pf.__salt__, {'cmd.run_all': mock_cmd}):
+            self.assertFalse(pf.table('expire', table='bad_hosts', number=300)['changes'])
+
+    def test_table_show(self):
+        '''
+        Tests showing table contents.
+        '''
+        ret = {}
+        ret['stdout'] = '1.2.3.4\n5.6.7.8'
+        ret['retcode'] = 0
+        expected = ['1.2.3.4', '5.6.7.8']
+        mock_cmd = MagicMock(return_value=ret)
+        with patch.dict(pf.__salt__, {'cmd.run_all': mock_cmd}):
+            self.assertListEqual(pf.table('show', table='bad_hosts')['comment'], expected)
+
+    def test_show(self):
+        '''
+        Tests a regular show command.
+        '''
+        ret = {}
+        ret['stdout'] = 'block return\npass'
+        ret['retcode'] = 0
+        expected = ['block return', 'pass']
+        mock_cmd = MagicMock(return_value=ret)
+        with patch.dict(pf.__salt__, {'cmd.run_all': mock_cmd}):
+            self.assertListEqual(pf.show('rules')['comment'], expected)
+
+    def test_show_capital(self):
+        '''
+        Tests a show command starting with a capital letter.
+        '''
+        ret = {}
+        ret['stdout'] = 'bad_hosts'
+        ret['retcode'] = 0
+        mock_cmd = MagicMock(return_value=ret)
+        with patch.dict(pf.__salt__, {'cmd.run_all': mock_cmd}):
+            res = pf.show('tables')
+            mock_cmd.assert_called_once_with('pfctl -s Tables',
+                    output_loglevel='trace', python_shell=False)
+            self.assertFalse(res['changes'])


### PR DESCRIPTION
### What does this PR do?

Add a new module used to interact with the OpenBSD Packet Filter (pf). While it's possible to use pfctl on other platforms (e.g. FreeBSD or macOS) I have not yet verified it's working there.

### What issues does this PR fix or reference?

#33248

### Tests written?

Yes

### Commits signed with GPG?

Yes