### PR TITLE
Fix backport of grains fix

### DIFF
--- a/salt/grains/disks.py
+++ b/salt/grains/disks.py
@@ -128,7 +128,7 @@ def _linux_disks():
 
     for entry in glob.glob('/sys/block/*/queue/rotational'):
         try:
-            with salt.utils.files.fopen(entry) as entry_fp:
+            with salt.utils.fopen(entry) as entry_fp:
                 device = entry.split('/')[3]
                 flag = entry_fp.read(1)
                 if flag == '0':


### PR DESCRIPTION
A fix recently made to the salt/grains/disks.py was backported to
2017.7, but the fopen function was moved in oxygen and so the function
does not exist in 2017.7.

This did not make it into 2017.7.3 so there is no need to add this fix
to any hotfixes.

@rallytime we need to make sure that when merged forward, we use the new
salt.utils.files.fopen here.