### PR TITLE
Fix for #45884 ("TypeError: can't serialize <NodeImage" when calling salt-cloud with the dimensiondata driver)

### DIFF
--- a/salt/cloud/clouds/dimensiondata.py
+++ b/salt/cloud/clouds/dimensiondata.py
@@ -220,7 +220,6 @@ def create(vm_):
 
     log.info('Creating Cloud VM %s', vm_['name'])
     conn = get_conn()
-    rootPw = NodeAuthPassword(vm_['auth'])
 
     location = conn.ex_get_location_by_id(vm_['location'])
     images = conn.list_images(location=location)
@@ -251,7 +250,6 @@ def create(vm_):
     kwargs = {
         'name': vm_['name'],
         'image': image,
-        'auth': rootPw,
         'ex_description': vm_['description'],
         'ex_network_domain': network_domain,
         'ex_vlan': vlan,
@@ -259,7 +257,6 @@ def create(vm_):
     }
 
     event_data = _to_event_data(kwargs)
-    del event_data['auth']
 
     __utils__['cloud.fire_event'](
         'event',
@@ -269,6 +266,10 @@ def create(vm_):
         sock_dir=__opts__['sock_dir'],
         transport=__opts__['transport']
     )
+
+    # Initial password (excluded from event payload)
+    rootPw = NodeAuthPassword(vm_['auth'])
+    kwargs['auth'] = rootPw
 
     try:
         data = conn.create_node(**kwargs)

--- a/salt/cloud/clouds/dimensiondata.py
+++ b/salt/cloud/clouds/dimensiondata.py
@@ -262,8 +262,8 @@ def create(vm_):
     )
 
     # Initial password (excluded from event payload)
-    rootPw = NodeAuthPassword(vm_['auth'])
-    kwargs['auth'] = rootPw
+    initial_password = NodeAuthPassword(vm_['auth'])
+    kwargs['auth'] = initial_password
 
     try:
         data = conn.create_node(**kwargs)
@@ -577,6 +577,7 @@ def get_lb_conn(dd_driver=None):
         )
     return get_driver_lb(Provider_lb.DIMENSIONDATA)(user_id, key, region=region)
 
+
 def _to_event_data(obj):
     '''
     Convert the specified object into a form that can be serialised by msgpack as event data.
@@ -599,7 +600,7 @@ def _to_event_data(obj):
     if isinstance(obj, dict):
         return obj
 
-    if isinstance(obj, NodeDriver): # Special case for NodeDriver (cyclic references)
+    if isinstance(obj, NodeDriver):  # Special case for NodeDriver (cyclic references)
         return obj.name
 
     if isinstance(obj, list):
@@ -612,7 +613,7 @@ def _to_event_data(obj):
 
         attribute_value = getattr(obj, attribute_name)
 
-        if callable(attribute_value): # Strip out methods
+        if callable(attribute_value):  # Strip out methods
             continue
 
         event_data[attribute_name] = _to_event_data(attribute_value)

--- a/salt/cloud/clouds/dimensiondata.py
+++ b/salt/cloud/clouds/dimensiondata.py
@@ -52,12 +52,6 @@ try:
 except ImportError:
     HAS_LIBCLOUD = False
 
-# Import generic libcloud functions
-# from salt.cloud.libcloudfuncs import *
-
-# Import salt libs
-import salt.utils
-
 # Import salt.cloud libs
 from salt.cloud.libcloudfuncs import *  # pylint: disable=redefined-builtin,wildcard-import,unused-wildcard-import
 from salt.utils import namespaced_function
@@ -170,7 +164,7 @@ def _query_node_data(vm_, data):
             private_ip = preferred_ip(vm_, [private_ip])
             if private_ip is False:
                 continue
-            if salt.utils.cloud.is_public_ip(private_ip):
+            if __utils__['cloud.is_public_ip'](private_ip):
                 log.warning('%s is a public IP', private_ip)
                 data.public_ips.append(private_ip)
             else:
@@ -284,7 +278,7 @@ def create(vm_):
         return False
 
     try:
-        data = salt.utils.cloud.wait_for_ip(
+        data = __utils__['cloud.wait_for_ip'](
             _query_node_data,
             update_args=(vm_, data),
             timeout=config.get_cloud_config_value(
@@ -310,7 +304,7 @@ def create(vm_):
         ip_address = preferred_ip(vm_, data.public_ips)
     log.debug('Using IP address %s', ip_address)
 
-    if salt.utils.cloud.get_salt_interface(vm_, __opts__) == 'private_ips':
+    if __utils__['cloud.get_salt_interface'](vm_, __opts__) == 'private_ips':
         salt_ip_address = preferred_ip(vm_, data.private_ips)
         log.info('Salt interface set to: %s', salt_ip_address)
     else:
@@ -326,7 +320,7 @@ def create(vm_):
     vm_['ssh_host'] = ip_address
     vm_['password'] = vm_['auth']
 
-    ret = salt.utils.cloud.bootstrap(vm_, __opts__)
+    ret = __utils__['cloud.bootstrap'](vm_, __opts__)
 
     ret.update(data.__dict__)
 

--- a/salt/cloud/clouds/dimensiondata.py
+++ b/salt/cloud/clouds/dimensiondata.py
@@ -164,7 +164,7 @@ def _query_node_data(vm_, data):
             private_ip = preferred_ip(vm_, [private_ip])
             if private_ip is False:
                 continue
-            if __utils__['cloud.is_public_ip'](private_ip):
+            if salt.utils.cloud.is_public_ip(private_ip):
                 log.warning('%s is a public IP', private_ip)
                 data.public_ips.append(private_ip)
             else:

--- a/tests/integration/cloud/providers/test_dimensiondata.py
+++ b/tests/integration/cloud/providers/test_dimensiondata.py
@@ -56,7 +56,7 @@ class DimensionDataTest(ShellCase):
         key = config[profile_str][PROVIDER_NAME]['key']
         region = config[profile_str][PROVIDER_NAME]['region']
 
-        if personal_token == '' or ssh_file == '' or ssh_name == '':
+        if user_id == '' or key == '' or region == '':
             self.skipTest(
                 'A user Id, password, and a region '
                 'must be provided to run these tests. Check '

--- a/tests/integration/cloud/providers/test_dimensiondata.py
+++ b/tests/integration/cloud/providers/test_dimensiondata.py
@@ -1,0 +1,124 @@
+# -*- coding: utf-8 -*-
+'''
+Integration tests for the Dimension Data cloud provider
+'''
+
+# Import Python Libs
+from __future__ import absolute_import, print_function, unicode_literals
+import os
+
+# Import Salt Testing Libs
+from tests.support.case import ShellCase
+from tests.support.paths import FILES
+from tests.support.helpers import expensiveTest, generate_random_name
+
+# Import Salt Libs
+from salt.config import cloud_providers_config
+
+# Create the cloud instance name to be used throughout the tests
+INSTANCE_NAME = generate_random_name('CLOUD-TEST-')
+PROVIDER_NAME = 'dimensiondata'
+
+
+class DimensionDataTest(ShellCase):
+    '''
+    Integration tests for the Dimension Data cloud provider in Salt-Cloud
+    '''
+
+    @expensiveTest
+    def setUp(self):
+        '''
+        Sets up the test requirements
+        '''
+        super(DimensionDataTest, self).setUp()
+
+        # check if appropriate cloud provider and profile files are present
+        profile_str = 'dimensiondata-config'
+        providers = self.run_cloud('--list-providers')
+        if profile_str + ':' not in providers:
+            self.skipTest(
+                'Configuration file for {0} was not found. Check {0}.conf files '
+                'in tests/integration/files/conf/cloud.*.d/ to run these tests.'
+                .format(PROVIDER_NAME)
+            )
+
+        # check if user_id, key, and region are present
+        config = cloud_providers_config(
+            os.path.join(
+                FILES,
+                'conf',
+                'cloud.providers.d',
+                PROVIDER_NAME + '.conf'
+            )
+        )
+
+        user_id = config[profile_str][PROVIDER_NAME]['user_id']
+        key = config[profile_str][PROVIDER_NAME]['key']
+        region = config[profile_str][PROVIDER_NAME]['region']
+
+        if personal_token == '' or ssh_file == '' or ssh_name == '':
+            self.skipTest(
+                'A user Id, password, and a region '
+                'must be provided to run these tests. Check '
+                'tests/integration/files/conf/cloud.providers.d/{0}.conf'
+                .format(PROVIDER_NAME)
+            )
+
+    def test_list_images(self):
+        '''
+        Tests the return of running the --list-images command for the dimensiondata cloud provider
+        '''
+        image_list = self.run_cloud('--list-images {0}'.format(PROVIDER_NAME))
+        self.assertIn(
+            'Ubuntu 14.04 2 CPU',
+            [i.strip() for i in image_list]
+        )
+
+    def test_list_locations(self):
+        '''
+        Tests the return of running the --list-locations command for the dimensiondata cloud provider
+        '''
+        _list_locations = self.run_cloud('--list-locations {0}'.format(PROVIDER_NAME))
+        self.assertIn(
+            'Australia - Melbourne MCP2',
+            [i.strip() for i in _list_locations]
+        )
+
+    def test_list_sizes(self):
+        '''
+        Tests the return of running the --list-sizes command for the dimensiondata cloud provider
+        '''
+        _list_sizes = self.run_cloud('--list-sizes {0}'.format(PROVIDER_NAME))
+        self.assertIn(
+            'default',
+            [i.strip() for i in _list_sizes]
+        )
+
+    def test_instance(self):
+        '''
+        Test creating an instance on Dimension Data's cloud
+        '''
+        # check if instance with salt installed returned
+        try:
+            self.assertIn(
+                INSTANCE_NAME,
+                [i.strip() for i in self.run_cloud('-p dimensiondata-test {0}'.format(INSTANCE_NAME), timeout=500)]
+            )
+        except AssertionError:
+            self.run_cloud('-d {0} --assume-yes'.format(INSTANCE_NAME), timeout=500)
+            raise
+
+        # delete the instance
+        try:
+            self.assertIn(
+                'True',
+                [i.strip() for i in self.run_cloud('-d {0} --assume-yes'.format(INSTANCE_NAME), timeout=500)]
+            )
+        except AssertionError:
+            raise
+
+        # Final clean-up of created instance, in case something went wrong.
+        # This was originally in a tearDown function, but that didn't make sense
+        # To run this for each test when not all tests create instances.
+        if INSTANCE_NAME in [i.strip() for i in self.run_cloud('--query')]:
+            self.run_cloud('-d {0} --assume-yes'.format(INSTANCE_NAME), timeout=500)

--- a/tests/integration/cloud/providers/test_dimensiondata.py
+++ b/tests/integration/cloud/providers/test_dimensiondata.py
@@ -6,18 +6,31 @@ Integration tests for the Dimension Data cloud provider
 # Import Python Libs
 from __future__ import absolute_import, print_function, unicode_literals
 import os
+import random
+import string
 
 # Import Salt Testing Libs
 from tests.support.case import ShellCase
 from tests.support.paths import FILES
-from tests.support.helpers import expensiveTest, generate_random_name
+from tests.support.helpers import expensiveTest
 
 # Import Salt Libs
 from salt.config import cloud_providers_config
+from salt.ext.six.moves import range  # pylint: disable=import-error,redefined-builtin
 
 # Create the cloud instance name to be used throughout the tests
-INSTANCE_NAME = generate_random_name('CLOUD-TEST-')
+INSTANCE_NAME = _random_name('CLOUD-TEST-')
 PROVIDER_NAME = 'dimensiondata'
+
+
+def _random_name(size=6):
+    '''
+    Generates a random cloud instance name
+    '''
+    return 'cloud-test-' + ''.join(
+        random.choice(string.ascii_lowercase + string.digits)
+        for x in range(size)
+    )
 
 
 class DimensionDataTest(ShellCase):

--- a/tests/integration/files/conf/cloud.profiles.d/dimensiondata.conf
+++ b/tests/integration/files/conf/cloud.profiles.d/dimensiondata.conf
@@ -1,0 +1,10 @@
+dimensiondata-test:
+  provider: dimensiondata-config
+  image: 42816eb2-9846-4483-95c3-7d7fbddebf2c
+  size: default
+  location: AU10
+  is_started: yes
+  description: 'Salt Ubuntu test'
+  network_domain: ''
+  vlan:  ''
+  auth: ''

--- a/tests/integration/files/conf/cloud.profiles.d/dimensiondata.conf
+++ b/tests/integration/files/conf/cloud.profiles.d/dimensiondata.conf
@@ -7,4 +7,5 @@ dimensiondata-test:
   description: 'Salt Ubuntu test'
   network_domain: ''
   vlan:  ''
+  ssh_interface: private_ips
   auth: ''

--- a/tests/integration/files/conf/cloud.providers.d/dimensiondata.conf
+++ b/tests/integration/files/conf/cloud.providers.d/dimensiondata.conf
@@ -1,0 +1,5 @@
+dimensiondata-config:
+  driver: dimensiondata
+  user_id: ''
+  key: ''
+  region: 'dd-au'


### PR DESCRIPTION
### What does this PR do?

* Fixes the behaviour of the `dimensiondata` cloud driver when deploying a new server by ensuring that event payloads are in a format that can be serialised by msgpack (i.e. only dicts, lists, and intrinsic data types; no raw Libcloud objects).
* Adds a couple of integration tests for the `dimensiondata` driver (there were none before) including one to deploy a server.

### What issues does this PR fix or reference?

* "TypeError: can't serialize <NodeImage" error when calling salt-cloud to create a new server with the dimensiondata driver (saltstack/salt#45884)

### Tests written?

Yes (integration).

### Commits signed with GPG?

Yes. Using my key (C6AFE8C008E7F2B3).