### PR TITLE
LGPO Module: Convert reg values to unicode for debug

### DIFF
--- a/salt/modules/win_lgpo.py
+++ b/salt/modules/win_lgpo.py
@@ -2442,7 +2442,7 @@ class _policy_info(object):
                 elif ord(val) == 1:
                     return 'Enabled'
                 else:
-                    return 'Invalid Value'
+                    return 'Invalid Value: %s' % repr(val)
             else:
                 return 'Not Defined'
         except TypeError:
@@ -5047,7 +5047,10 @@ def get(policy_class=None, return_full_policy_names=True,
                     class_vals[policy_name] = __salt__['reg.read_value'](_pol['Registry']['Hive'],
                                                                          _pol['Registry']['Path'],
                                                                          _pol['Registry']['Value'])['vdata']
-                    log.debug('Value {0} found for reg policy {1}'.format(class_vals[policy_name], policy_name))
+                    log.debug(
+                        'Value {0} found for reg policy {1}'.format(
+                            salt.utils.to_unicode(class_vals[policy_name]),
+                            policy_name))
                 elif 'Secedit' in _pol:
                     # get value from secedit
                     _ret, _val = _findOptionValueInSeceditFile(_pol['Secedit']['Option'])

--- a/salt/modules/win_lgpo.py
+++ b/salt/modules/win_lgpo.py
@@ -2442,7 +2442,7 @@ class _policy_info(object):
                 elif ord(val) == 1:
                     return 'Enabled'
                 else:
-                    return 'Invalid Value: %s' % repr(val)
+                    return 'Invalid Value: {0!r}'.format(val)  # pylint: disable=repr-flag-used-in-string
             else:
                 return 'Not Defined'
         except TypeError:

--- a/salt/modules/win_lgpo.py
+++ b/salt/modules/win_lgpo.py
@@ -5048,9 +5048,9 @@ def get(policy_class=None, return_full_policy_names=True,
                                                                          _pol['Registry']['Path'],
                                                                          _pol['Registry']['Value'])['vdata']
                     log.debug(
-                        'Value {0} found for reg policy {1}'.format(
-                            salt.utils.to_unicode(class_vals[policy_name]),
-                            policy_name))
+                        'Value %r found for reg policy %s',
+                        class_vals[policy_name], policy_name
+                    )
                 elif 'Secedit' in _pol:
                     # get value from secedit
                     _ret, _val = _findOptionValueInSeceditFile(_pol['Secedit']['Option'])


### PR DESCRIPTION
### What does this PR do?
When the get function reads values from the registry it has the ability to return a `REG_BINARY` value. These values often cause the `log.debug` function to fail. This function converts the value to Unicode for the debug message. It also returns the actual value in the return when the data is invalid.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/45868

### Tests written?
No

### Commits signed with GPG?
Yes