### PR TITLE
Windows unicode related bugfix

### DIFF
--- a/salt/utils/rsax931.py
+++ b/salt/utils/rsax931.py
@@ -28,7 +28,8 @@ def _load_libcrypto():
     Load OpenSSL libcrypto
     '''
     if sys.platform.startswith('win'):
-        return cdll.LoadLibrary('libeay32')
+        # cdll.LoadLibrary on windows requires an 'str' argument
+        return cdll.LoadLibrary(str('libeay32'))  # future lint: disable=blacklisted-function
     elif getattr(sys, 'frozen', False) and salt.utils.platform.is_smartos():
         return cdll.LoadLibrary(glob.glob(os.path.join(
             os.path.dirname(sys.executable),

--- a/salt/utils/win_osinfo.py
+++ b/salt/utils/win_osinfo.py
@@ -14,7 +14,8 @@ except (ImportError, ValueError):
     HAS_WIN32 = False
 
 if HAS_WIN32:
-    kernel32 = ctypes.WinDLL('kernel32', use_last_error=True)
+    kernel32 = ctypes.WinDLL(str('kernel32'),  # future lint: disable=blacklisted-function
+                             use_last_error=True)
 
 
 # Although utils are often directly imported, it is also possible to use the

--- a/salt/utils/win_runas.py
+++ b/salt/utils/win_runas.py
@@ -46,8 +46,8 @@ def __virtual__():
 
 if HAS_WIN32:
     # ctypes definitions
-    kernel32 = ctypes.WinDLL('kernel32')
-    advapi32 = ctypes.WinDLL('advapi32')
+    kernel32 = ctypes.WinDLL(str('kernel32'))  # future lint: disable=blacklisted-function
+    advapi32 = ctypes.WinDLL(str('advapi32'))  # future lint: disable=blacklisted-function
 
     INVALID_HANDLE_VALUE = wintypes.HANDLE(-1).value
     INVALID_DWORD_VALUE = wintypes.DWORD(-1).value  # ~WinAPI


### PR DESCRIPTION
### What does this PR do?
Use `str()` conversion for `WindDLL` and `ctypes.LoadLibrary` function arguments that require `str` on windows.

### What issues does this PR fix or reference?
Related to #45833

### Tests written?
No

### Commits signed with GPG?
Yes
