### PR TITLE
yumpkg: Pass through kwargs from upgrade_available to latest_version

### DIFF
--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -560,7 +560,7 @@ def latest_version(*names, **kwargs):
 available_version = salt.utils.functools.alias_function(latest_version, 'available_version')
 
 
-def upgrade_available(name):
+def upgrade_available(name, **kwargs):
     '''
     Check whether or not an upgrade is available for a given package
 
@@ -570,7 +570,7 @@ def upgrade_available(name):
 
         salt '*' pkg.upgrade_available <package name>
     '''
-    return latest_version(name) != ''
+    return latest_version(name, **kwargs) != ''
 
 
 def version(*names, **kwargs):


### PR DESCRIPTION
The `upgrade_available` func is there as a convenience for people who are used to the yum/dnf syntax. However, it doesn't pass through kwargs and thus does not support the repo options that `latest_version` does. This commit makes the simple tweak of passing through the kwargs, allowing this convenience func to support all the extended options that `latest_version` does.

@rallytime up to you whether or not you think this merits a backport. It seems low-priority to me since one can just use `latest_version`.