### PR TITLE
Fix publisher_acl for oxygen

### DIFF
--- a/salt/cli/daemons.py
+++ b/salt/cli/daemons.py
@@ -152,7 +152,6 @@ class Master(salt.utils.parsers.MasterOptionParser, DaemonsMixin):  # pylint: di
                         os.path.join(self.config['cachedir'], 'jobs'),
                         os.path.join(self.config['cachedir'], 'proc'),
                         self.config['sock_dir'],
-                        self.config['key_dir'],
                         self.config['token_dir'],
                         self.config['syndic_dir'],
                         self.config['sqlite_queue_dir'],
@@ -167,7 +166,7 @@ class Master(salt.utils.parsers.MasterOptionParser, DaemonsMixin):  # pylint: di
                     self.config['user'],
                     permissive=self.config['permissive_pki_access'],
                     root_dir=self.config['root_dir'],
-                    sensitive_dirs=[self.config['pki_dir'], self.config['key_dir']],
+                    pki_dir=self.config['pki_dir'],
                 )
                 # Clear out syndics from cachedir
                 for syndic_file in os.listdir(self.config['syndic_dir']):
@@ -289,7 +288,7 @@ class Minion(salt.utils.parsers.MinionOptionParser, DaemonsMixin):  # pylint: di
                     self.config['user'],
                     permissive=self.config['permissive_pki_access'],
                     root_dir=self.config['root_dir'],
-                    sensitive_dirs=[self.config['pki_dir']],
+                    pki_dir=self.config['pki_dir'],
                 )
         except OSError as error:
             self.environment_failure(error)
@@ -471,7 +470,7 @@ class ProxyMinion(salt.utils.parsers.ProxyMinionOptionParser, DaemonsMixin):  # 
                     self.config['user'],
                     permissive=self.config['permissive_pki_access'],
                     root_dir=self.config['root_dir'],
-                    sensitive_dirs=[self.config['pki_dir']],
+                    pki_dir=self.config['pki_dir'],
                 )
         except OSError as error:
             self.environment_failure(error)
@@ -580,7 +579,7 @@ class Syndic(salt.utils.parsers.SyndicOptionParser, DaemonsMixin):  # pylint: di
                     self.config['user'],
                     permissive=self.config['permissive_pki_access'],
                     root_dir=self.config['root_dir'],
-                    sensitive_dirs=[self.config['pki_dir']],
+                    pki_dir=self.config['pki_dir'],
                 )
         except OSError as error:
             self.environment_failure(error)

--- a/salt/cli/salt.py
+++ b/salt/cli/salt.py
@@ -10,6 +10,7 @@ import os
 import salt.utils.job
 import salt.utils.parsers
 import salt.utils.stringutils
+import salt.log
 from salt.utils.args import yamlify_arg
 from salt.utils.verify import verify_log
 from salt.exceptions import (
@@ -38,9 +39,10 @@ class SaltCMD(salt.utils.parsers.SaltCMDOptionParser):
         import salt.client
         self.parse_args()
 
-        # Setup file logging!
-        self.setup_logfile_logger()
-        verify_log(self.config)
+        if self.config['log_level'] not in ('quiet', ):
+            # Setup file logging!
+            self.setup_logfile_logger()
+            verify_log(self.config)
 
         try:
             # We don't need to bail on config file permission errors

--- a/salt/cli/salt.py
+++ b/salt/cli/salt.py
@@ -84,7 +84,7 @@ class SaltCMD(salt.utils.parsers.SaltCMDOptionParser):
         if 'token' in self.config:
             import salt.utils.files
             try:
-                with salt.utils.files.fopen(os.path.join(self.config['key_dir'], '.root_key'), 'r') as fp_:
+                with salt.utils.files.fopen(os.path.join(self.config['cachedir'], '.root_key'), 'r') as fp_:
                     kwargs['key'] = fp_.readline()
             except IOError:
                 kwargs['token'] = self.config['token']

--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -194,11 +194,11 @@ class LocalClient(object):
             # The username may contain '\' if it is in Windows
             # 'DOMAIN\username' format. Fix this for the keyfile path.
             key_user = key_user.replace('\\', '_')
-        keyfile = os.path.join(self.opts['key_dir'],
+        keyfile = os.path.join(self.opts['cachedir'],
                                '.{0}_key'.format(key_user))
         try:
             # Make sure all key parent directories are accessible
-            salt.utils.verify.check_path_traversal(self.opts['key_dir'],
+            salt.utils.verify.check_path_traversal(self.opts['cachedir'],
                                                    key_user,
                                                    self.skip_perm_errors)
             with salt.utils.files.fopen(keyfile, 'r') as key:

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -197,9 +197,6 @@ VALID_OPTS = {
     # The directory used to store public key data
     'pki_dir': six.string_types,
 
-    # The directory to store authentication keys of a master's local environment.
-    'key_dir': six.string_types,
-
     # A unique identifier for this daemon
     'id': six.string_types,
 
@@ -1495,7 +1492,6 @@ DEFAULT_MASTER_OPTS = {
     'archive_jobs': False,
     'root_dir': salt.syspaths.ROOT_DIR,
     'pki_dir': os.path.join(salt.syspaths.CONFIG_DIR, 'pki', 'master'),
-    'key_dir': os.path.join(salt.syspaths.CONFIG_DIR, 'key'),
     'key_cache': '',
     'cachedir': os.path.join(salt.syspaths.CACHE_DIR, 'master'),
     'file_roots': {
@@ -2497,7 +2493,7 @@ def syndic_config(master_config_path,
     opts.update(syndic_opts)
     # Prepend root_dir to other paths
     prepend_root_dirs = [
-        'pki_dir', 'key_dir', 'cachedir', 'pidfile', 'sock_dir', 'extension_modules',
+        'pki_dir', 'cachedir', 'pidfile', 'sock_dir', 'extension_modules',
         'autosign_file', 'autoreject_file', 'token_dir', 'autosign_grains_dir'
     ]
     for config_key in ('log_file', 'key_logfile', 'syndic_log_file'):
@@ -3934,7 +3930,7 @@ def apply_master_config(overrides=None, defaults=None):
 
     # Prepend root_dir to other paths
     prepend_root_dirs = [
-        'pki_dir', 'key_dir', 'cachedir', 'pidfile', 'sock_dir', 'extension_modules',
+        'pki_dir', 'cachedir', 'pidfile', 'sock_dir', 'extension_modules',
         'autosign_file', 'autoreject_file', 'token_dir', 'syndic_dir',
         'sqlite_queue_dir', 'autosign_grains_dir'
     ]

--- a/salt/daemons/masterapi.py
+++ b/salt/daemons/masterapi.py
@@ -186,11 +186,11 @@ def mk_key(opts, user):
         # The username may contain '\' if it is in Windows
         # 'DOMAIN\username' format. Fix this for the keyfile path.
         keyfile = os.path.join(
-            opts['key_dir'], '.{0}_key'.format(user.replace('\\', '_'))
+            opts['cachedir'], '.{0}_key'.format(user.replace('\\', '_'))
         )
     else:
         keyfile = os.path.join(
-            opts['key_dir'], '.{0}_key'.format(user)
+            opts['cachedir'], '.{0}_key'.format(user)
         )
 
     if os.path.exists(keyfile):

--- a/salt/key.py
+++ b/salt/key.py
@@ -125,7 +125,7 @@ class KeyCLI(object):
         if self.opts['eauth']:
             if 'token' in self.opts:
                 try:
-                    with salt.utils.files.fopen(os.path.join(self.opts['key_dir'], '.root_key'), 'r') as fp_:
+                    with salt.utils.files.fopen(os.path.join(self.opts['cachedir'], '.root_key'), 'r') as fp_:
                         low['key'] = \
                             salt.utils.stringutils.to_unicode(fp_.readline())
                 except IOError:

--- a/salt/runner.py
+++ b/salt/runner.py
@@ -205,7 +205,7 @@ class Runner(RunnerClient):
                 if self.opts.get('eauth'):
                     if 'token' in self.opts:
                         try:
-                            with salt.utils.files.fopen(os.path.join(self.opts['key_dir'], '.root_key'), 'r') as fp_:
+                            with salt.utils.files.fopen(os.path.join(self.opts['cachedir'], '.root_key'), 'r') as fp_:
                                 low['key'] = salt.utils.stringutils.to_unicode(fp_.readline())
                         except IOError:
                             low['token'] = self.opts['token']

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -717,7 +717,7 @@ class LogLevelMixIn(six.with_metaclass(MixInMeta, object)):
             # Remove it from config so it inherits from log_file
             self.config.pop(self._logfile_config_setting_name_)
 
-        if self.config['verify_env']:
+        if self.config['verify_env'] and self.config['log_level'] not in ('quiet', ):
             # Verify the logfile if it was explicitly set but do not try to
             # verify the default
             if logfile is not None and not logfile.startswith(('tcp://', 'udp://', 'file://')):

--- a/salt/utils/verify.py
+++ b/salt/utils/verify.py
@@ -204,8 +204,7 @@ def verify_env(
         permissive=False,
         pki_dir='',
         skip_extra=False,
-        root_dir=ROOT_DIR,
-        sensitive_dirs=None):
+        root_dir=ROOT_DIR):
     '''
     Verify that the named directories are in place and that the environment
     can shake the salt
@@ -224,8 +223,7 @@ def verify_env(
         return win_verify_env(root_dir,
                               dirs,
                               permissive=permissive,
-                              skip_extra=skip_extra,
-                              sensitive_dirs=sensitive_dirs)
+                              skip_extra=skip_extra)
     import pwd  # after confirming not running Windows
     try:
         pwnam = pwd.getpwnam(user)
@@ -300,11 +298,10 @@ def verify_env(
         # to read in what it needs to integrate.
         #
         # If the permissions aren't correct, default to the more secure 700.
-        # If acls are enabled, the sensitive_dirs (i.e. pki_dir, key_dir) needs to
-        # remain readable, this is still secure because the private keys are still
-        # only readable by the user running the master
-        sensitive_dirs = sensitive_dirs or []
-        if dir_ in sensitive_dirs:
+        # If acls are enabled, the pki_dir needs to remain readable, this
+        # is still secure because the private keys are still only readable
+        # by the user running the master
+        if dir_ == pki_dir:
             smode = stat.S_IMODE(mode.st_mode)
             if smode != 448 and smode != 488:
                 if os.access(dir_, os.W_OK):
@@ -555,8 +552,7 @@ def win_verify_env(
         dirs,
         permissive=False,
         pki_dir='',
-        skip_extra=False,
-        sensitive_dirs=None):
+        skip_extra=False):
     '''
     Verify that the named directories are in place and that the environment
     can shake the salt
@@ -647,9 +643,8 @@ def win_verify_env(
                 sys.stderr.write(msg.format(dir_, err))
                 sys.exit(err.errno)
 
-        # The senitive_dirs (i.e. pki_dir, key_dir) gets its own permissions
-        sensitive_dirs = sensitive_dirs or []
-        if dir_ in sensitive_dirs:
+        # The PKI dir gets its own permissions
+        if dir_ == pki_dir:
             try:
                 # Make Administrators group the owner
                 salt.utils.win_dacl.set_owner(path, 'S-1-5-32-544')

--- a/salt/utils/verify.py
+++ b/salt/utils/verify.py
@@ -31,7 +31,6 @@ import salt.utils.files
 import salt.utils.path
 import salt.utils.platform
 import salt.utils.user
-import salt.utils.versions
 
 log = logging.getLogger(__name__)
 
@@ -209,16 +208,6 @@ def verify_env(
     Verify that the named directories are in place and that the environment
     can shake the salt
     '''
-    if pki_dir:
-        salt.utils.versions.warn_until(
-            'Neon',
-            'Use of \'pki_dir\' was detected: \'pki_dir\' has been deprecated '
-            'in favor of \'sensitive_dirs\'. Support for \'pki_dir\' will be '
-            'removed in Salt Neon.'
-        )
-        sensitive_dirs = sensitive_dirs or []
-        sensitive_dirs.append(list(pki_dir))
-
     if salt.utils.platform.is_windows():
         return win_verify_env(root_dir,
                               dirs,
@@ -557,16 +546,6 @@ def win_verify_env(
     Verify that the named directories are in place and that the environment
     can shake the salt
     '''
-    if pki_dir:
-        salt.utils.versions.warn_until(
-            'Neon',
-            'Use of \'pki_dir\' was detected: \'pki_dir\' has been deprecated '
-            'in favor of \'sensitive_dirs\'. Support for \'pki_dir\' will be '
-            'removed in Salt Neon.'
-        )
-        sensitive_dirs = sensitive_dirs or []
-        sensitive_dirs.append(list(pki_dir))
-
     import salt.utils.win_functions
     import salt.utils.win_dacl
     import salt.utils.path

--- a/tests/unit/utils/test_verify.py
+++ b/tests/unit/utils/test_verify.py
@@ -113,20 +113,13 @@ class TestVerify(TestCase):
         root_dir = tempfile.mkdtemp(dir=TMP)
         var_dir = os.path.join(root_dir, 'var', 'log', 'salt')
         key_dir = os.path.join(root_dir, 'key_dir')
-        verify_env([var_dir, key_dir], getpass.getuser(), root_dir=root_dir, sensitive_dirs=[key_dir])
+        verify_env([var_dir], getpass.getuser(), root_dir=root_dir)
         self.assertTrue(os.path.exists(var_dir))
-        self.assertTrue(os.path.exists(key_dir))
-
-        var_dir_stat = os.stat(var_dir)
-        self.assertEqual(var_dir_stat.st_uid, os.getuid())
-        self.assertEqual(var_dir_stat.st_mode & stat.S_IRWXU, stat.S_IRWXU)
-        self.assertEqual(var_dir_stat.st_mode & stat.S_IRWXG, 40)
-        self.assertEqual(var_dir_stat.st_mode & stat.S_IRWXO, 5)
-
-        key_dir_stat = os.stat(key_dir)
-        self.assertEqual(key_dir_stat.st_mode & stat.S_IRWXU, stat.S_IRWXU)
-        self.assertEqual(key_dir_stat.st_mode & stat.S_IRWXG, 0)
-        self.assertEqual(key_dir_stat.st_mode & stat.S_IRWXO, 0)
+        dir_stat = os.stat(var_dir)
+        self.assertEqual(dir_stat.st_uid, os.getuid())
+        self.assertEqual(dir_stat.st_mode & stat.S_IRWXU, stat.S_IRWXU)
+        self.assertEqual(dir_stat.st_mode & stat.S_IRWXG, 40)
+        self.assertEqual(dir_stat.st_mode & stat.S_IRWXO, 5)
 
     @requires_network(only_local_network=True)
     def test_verify_socket(self):


### PR DESCRIPTION
### What does this PR do?
1) This fixes handling of the master log when quiet is passed.  Before it would exit because the salt commandline could not write to /var/log/salt/master, even when logging was disabled with `-l quiet`

2) Separating out the [key_dir](https://github.com/saltstack/salt/pull/43474) was reverted.
Here is the description from the revert commit
```
This change breaks publisher_acls.

1) The key_dir's permissions are controlled by `permissive_pki_access` which is
   not required by publisher_acls.  By default, it is also changed back to 700
   each time that the salt-master restarts, so it will have to be chmodded each
   time.
2) The default directory for these keys is changed, which will break a lot of
   users publisher_acls setups on an upgrade to Oxygen, and require them to go
   back in to chmod new directories.

I was going through and switching out the key dir to default back to
/var/cache/salt/master, and allow it to be changed, and also be able to specify
that it is a sensitive dir, but once I ran across the `permissive_pki_access`
stuff, I thought it was better to just revert this change and try again against
Fluorine, since we do not have a lot of tests in this area around publisher_acl.
```

### What issues does this PR fix or reference?
Fixes #45023 

### Tests written?

No

### Commits signed with GPG?

Yes