### PR TITLE
Fix cmd run_all bg error

### DIFF
--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -317,6 +317,9 @@ def _run(cmd,
         # yaml-ified into non-string types
         cwd = str(cwd)
 
+    if bg:
+        ignore_retcode = True
+
     if not salt.utils.is_windows():
         if not os.path.isfile(shell) or not os.access(shell, os.X_OK):
             msg = 'The shell {0} is not available'.format(shell)
@@ -3118,7 +3121,6 @@ def run_bg(cmd,
         output_loglevel='debug',
         log_callback=None,
         reset_system_locale=True,
-        ignore_retcode=False,
         saltenv='base',
         password=None,
         **kwargs):
@@ -3278,7 +3280,6 @@ def run_bg(cmd,
                log_callback=log_callback,
                timeout=timeout,
                reset_system_locale=reset_system_locale,
-               ignore_retcode=ignore_retcode,
                saltenv=saltenv,
                password=password,
                **kwargs


### PR DESCRIPTION
### What does this PR do?
Fix erroneous logging/retcode errors when `bg=True` in `cmd.run(_all)`

### What issues does this PR fix or reference?
relates to #39980
fixes #42932

### Previous Behavior
```
root@w1:~# salt-call -l debug --out=raw cmd.run_all bg=True 'sleep 5' 
[DEBUG   ] LazyLoaded cmd.run_all
[DEBUG   ] LazyLoaded config.get
[INFO    ] Executing command 'sleep 5' in directory '/root'. Executing command in the background, no output will be logged.
[ERROR   ] Command 'sleep 5' failed with return code: None
[DEBUG   ] LazyLoaded raw.output
{'local': {'pid': 18860, 'retcode': None, 'stderr': '', 'stdout': None}}
```

### New Behavior
```
root@w1:~# salt-call -l debug --out=raw cmd.run_all bg=True 'sleep 5' 
[DEBUG   ] LazyLoaded config.get
[INFO    ] Executing command 'sleep 5' in directory '/root'. Executing command in the background, no output will be logged.
[DEBUG   ] LazyLoaded raw.output
{'local': {'pid': 17579, 'retcode': None, 'stderr': '', 'stdout': None}}
```
