### PR TITLE
Fix Py2 unicode issue in win_pkg.py

### DIFF
--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -1820,7 +1820,7 @@ def get_repo_data(saltenv='base'):
         serial = salt.payload.Serial(__opts__)
         with salt.utils.files.fopen(repo_details.winrepo_file, 'rb') as repofile:
             try:
-                repodata = salt.utils.data.decode(serial.loads(repofile.read()) or {})
+                repodata = salt.utils.data.decode(serial.loads(repofile.read(), encoding='utf-8') or {})
                 __context__['winrepo.data'] = repodata
                 return repodata
             except Exception as exc:
@@ -1843,7 +1843,7 @@ def _get_name_map(saltenv='base'):
         return name_map
 
     for k in name_map:
-        u_name_map[k.decode('utf-8')] = name_map[k]
+        u_name_map[k] = name_map[k]
     return u_name_map
 
 

--- a/salt/utils/templates.py
+++ b/salt/utils/templates.py
@@ -167,11 +167,9 @@ def wrap_tmpl_func(render_str):
             tmplsrc.close()
         try:
             output = render_str(tmplstr, context, tmplpath)
-            if six.PY2:
-                output = output.encode(SLS_ENCODING)
             if salt.utils.platform.is_windows():
                 newline = False
-                if salt.utils.stringutils.to_unicode(output).endswith(('\n', os.linesep)):
+                if salt.utils.stringutils.to_unicode(output, encoding=SLS_ENCODING).endswith(('\n', os.linesep)):
                     newline = True
                 # Write out with Windows newlines
                 output = os.linesep.join(output.splitlines())
@@ -188,9 +186,7 @@ def wrap_tmpl_func(render_str):
             if to_str:  # then render as string
                 return dict(result=True, data=output)
             with tempfile.NamedTemporaryFile('wb', delete=False, prefix=salt.utils.files.TEMPFILE_PREFIX) as outf:
-                if six.PY3:
-                    output = output.encode(SLS_ENCODING)
-                outf.write(output)
+                outf.write(salt.utils.stringutils.to_bytes(output, encoding=SLS_ENCODING))
                 # Note: If nothing is replaced or added by the rendering
                 #       function, then the contents of the output file will
                 #       be exactly the same as the input.


### PR DESCRIPTION
### What does this PR do?
`salt.utils.templates`
Fixes an issue where the template renderer was doing some unnecessary encoding
Also ensures `utf-8` encoding when writing the file

`salt.modules.win_pkg`
Fixes an issue where the `winrepo.p` file was being decoded with the system decoding. This makes sure it's using `utf-8`
Removes the need to decode the names since they're already in `utf-8` format

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/45886

### Tests written?
No

### Commits signed with GPG?
Yes