### PR TITLE
Fix use of su  to use '-'  on AIX 

### DIFF
--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -407,7 +407,7 @@ def _run(cmd,
             elif __grains__['os_family'] in ['Solaris']:
                 env_cmd = ('su', '-', runas, '-c', sys.executable)
             elif __grains__['os_family'] in ['AIX']:
-                env_cmd = ('su', runas, '-c', sys.executable)
+                env_cmd = ('su', '-', runas, '-c', sys.executable)
             else:
                 env_cmd = ('su', '-s', shell, '-', runas, '-c', sys.executable)
             env_encoded = subprocess.Popen(


### PR DESCRIPTION
### What does this PR do?
Adds additional '-' when using su command  on AIX, similar to other platforms

### What issues does this PR fix or reference?
https://github.com/saltstack/zh/issues/1381

### Tests written?
No - change hand tested on AIX

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
