### PR TITLE
Fix incorrect translation of docker port_bindings -> ports (2017.7 branch)

### DIFF
--- a/salt/utils/docker/__init__.py
+++ b/salt/utils/docker/__init__.py
@@ -300,7 +300,7 @@ def translate_input(**kwargs):
                 else:
                     port_num, proto = port_def.split('/')
                     ports_to_open.add((int(port_num), proto))
-            kwargs['ports'] = sorted(ports_to_open)
+            kwargs['ports'] = list(ports_to_open)
 
     if 'ports' in kwargs \
             and all(x not in skip_translate for x in ('expose', 'ports')):

--- a/salt/utils/docker/__init__.py
+++ b/salt/utils/docker/__init__.py
@@ -287,27 +287,31 @@ def translate_input(**kwargs):
             actual_volumes.sort()
 
     if kwargs.get('port_bindings') is not None \
-            and (skip_translate is True or
-                 all(x not in skip_translate
-                     for x in ('port_bindings', 'expose', 'ports'))):
+            and all(x not in skip_translate
+                    for x in ('port_bindings', 'expose', 'ports')):
         # Make sure that all ports defined in "port_bindings" are included in
         # the "ports" param.
-        auto_ports = list(kwargs['port_bindings'])
-        if auto_ports:
-            actual_ports = []
-            # Sort list to make unit tests more reliable
-            for port in auto_ports:
-                if port in actual_ports:
-                    continue
-                if isinstance(port, six.integer_types):
-                    actual_ports.append((port, 'tcp'))
+        ports_to_bind = list(kwargs['port_bindings'])
+        if ports_to_bind:
+            ports_to_open = set(kwargs.get('ports', []))
+            for port_def in ports_to_bind:
+                if isinstance(port_def, six.integer_types):
+                    ports_to_open.add(port_def)
                 else:
-                    port, proto = port.split('/')
-                    actual_ports.append((int(port), proto))
-            actual_ports.sort()
-            actual_ports = [
-                port if proto == 'tcp' else '{}/{}'.format(port, proto) for (port, proto) in actual_ports
-            ]
-            kwargs.setdefault('ports', actual_ports)
+                    port_num, proto = port_def.split('/')
+                    ports_to_open.add((int(port_num), proto))
+            kwargs['ports'] = sorted(ports_to_open)
+
+    if 'ports' in kwargs \
+            and all(x not in skip_translate for x in ('expose', 'ports')):
+        # TCP ports should only be passed as the port number. Normalize the
+        # input so a port definition of 80/tcp becomes just 80 instead of
+        # (80, 'tcp').
+        for index, _ in enumerate(kwargs['ports']):
+            try:
+                if kwargs['ports'][index][1] == 'tcp':
+                    kwargs['ports'][index] = ports_to_open[index][0]
+            except TypeError:
+                continue
 
     return kwargs, invalid, sorted(collisions)

--- a/salt/utils/docker/translate.py
+++ b/salt/utils/docker/translate.py
@@ -705,7 +705,7 @@ def ports(val, **kwargs):  # pylint: disable=unused-argument
             raise SaltInvocationError(exc.__str__())
         new_ports.update([_get_port_def(x, proto)
                           for x in range(range_start, range_end + 1)])
-    return sorted(new_ports)
+    return list(new_ports)
 
 
 def privileged(val, **kwargs):  # pylint: disable=unused-argument

--- a/salt/utils/docker/translate.py
+++ b/salt/utils/docker/translate.py
@@ -705,13 +705,7 @@ def ports(val, **kwargs):  # pylint: disable=unused-argument
             raise SaltInvocationError(exc.__str__())
         new_ports.update([_get_port_def(x, proto)
                           for x in range(range_start, range_end + 1)])
-    ordered_new_ports = [
-        port if proto == 'tcp' else (port, proto) for (port, proto) in sorted(
-            [(new_port, 'tcp') if isinstance(new_port, six.integer_types) else new_port
-             for new_port in new_ports]
-        )
-    ]
-    return ordered_new_ports
+    return sorted(new_ports)
 
 
 def privileged(val, **kwargs):  # pylint: disable=unused-argument

--- a/tests/unit/utils/test_docker.py
+++ b/tests/unit/utils/test_docker.py
@@ -1108,7 +1108,9 @@ class TranslateInputTestCase(TestCase):
                 '3334/udp': ('10.4.5.6', 3334),
                 '5505/udp': ('10.7.8.9', 15505),
                 '5506/udp': ('10.7.8.9', 15506)},
-             'ports': [80, '81/udp', 3333, '3334/udp', 4505, 4506, '5505/udp', '5506/udp'],
+             'ports': [80, 3333, 4505, 4506,
+                       (81, 'udp'), (3334, 'udp'),
+                       (5505, 'udp'), (5506, 'udp')]
             },
             {}, []
         )
@@ -1146,7 +1148,9 @@ class TranslateInputTestCase(TestCase):
                 '3334/udp': ('10.4.5.6',),
                 '5505/udp': ('10.7.8.9',),
                 '5506/udp': ('10.7.8.9',)},
-             'ports': [80, '81/udp', 3333, '3334/udp', 4505, 4506, '5505/udp', '5506/udp'],
+             'ports': [80, 3333, 4505, 4506,
+                       (81, 'udp'), (3334, 'udp'),
+                       (5505, 'udp'), (5506, 'udp')]
             },
             {}, []
         )
@@ -1182,7 +1186,9 @@ class TranslateInputTestCase(TestCase):
                                '3334/udp': 3334,
                                '5505/udp': 15505,
                                '5506/udp': 15506},
-             'ports': [80, '81/udp', 3333, '3334/udp', 4505, 4506, '5505/udp', '5506/udp'],
+             'ports': [80, 3333, 4505, 4506,
+                       (81, 'udp'), (3334, 'udp'),
+                       (5505, 'udp'), (5506, 'udp')]
             },
             {}, []
         )
@@ -1217,7 +1223,9 @@ class TranslateInputTestCase(TestCase):
                                '3334/udp': None,
                                '5505/udp': None,
                                '5506/udp': None},
-             'ports': [80, '81/udp', 3333, '3334/udp', 4505, 4506, '5505/udp', '5506/udp'],
+             'ports': [80, 3333, 4505, 4506,
+                       (81, 'udp'), (3334, 'udp'),
+                       (5505, 'udp'), (5506, 'udp')]
             },
             {}, []
         )
@@ -1251,8 +1259,11 @@ class TranslateInputTestCase(TestCase):
                                '19999/udp': None,
                                '20000/udp': None,
                                '20001/udp': None},
-             'ports': [80, '81/udp', 3333, '3334/udp', 4505, 4506, '5505/udp', '5506/udp',
-                       9999, 10000, 10001, '19999/udp', '20000/udp', '20001/udp']
+             'ports': [80, 3333, 4505, 4506, 9999, 10000, 10001,
+                       (81, 'udp'), (3334, 'udp'), (5505, 'udp'),
+                       (5506, 'udp'), (19999, 'udp'),
+                       (20000, 'udp'), (20001, 'udp')]
+
             },
             {}, []
         )
@@ -1439,7 +1450,7 @@ class TranslateInputTestCase(TestCase):
         the port numbers must end up as integers. None of the decorators will
         suffice so this one must be tested specially.
         '''
-        expected = ({'ports': [1111, 2222, (3333, 'udp'), 4505, 4506]}, {}, [])
+        expected = ({'ports': [1111, 2222, 4505, 4506, (3333, 'udp')]}, {}, [])
         # Comma-separated list
         self.assertEqual(
             docker_utils.translate_input(ports='1111,2222/tcp,3333/udp,4505-4506'),


### PR DESCRIPTION
This is a backport of https://github.com/saltstack/salt/pull/45941 for the 2017.7 branch. Any changes that need to be made to that PR before merging need to be duplicated here before this PR is merged. Therefore, this PR should not be merged until https://github.com/saltstack/salt/pull/45941 is.