### PR TITLE
Add NetBox module autodoc

### DIFF
--- a/doc/ref/modules/all/index.rst
+++ b/doc/ref/modules/all/index.rst
@@ -276,6 +276,7 @@ execution modules
     napalm_users
     napalm_yang_mod
     netaddress
+    netbox
     netbsd_sysctl
     netbsdservice
     netscaler

--- a/doc/ref/modules/all/salt.modules.netbox.rst
+++ b/doc/ref/modules/all/salt.modules.netbox.rst
@@ -1,0 +1,7 @@
+==========================
+salt.modules.netbox module
+==========================
+
+.. automodule:: salt.modules.netbox
+    :members:
+


### PR DESCRIPTION
### What does this PR do?

Adding autodoc for the netbox execution module submitted via https://github.com/saltstack/salt/pull/44612.