### PR TITLE
Fix issue with reg.present

### DIFF
--- a/salt/states/reg.py
+++ b/salt/states/reg.py
@@ -194,7 +194,7 @@ def present(name,
 
     add_change = {'Key': r'{0}\{1}'.format(hive, key),
                   'Entry': u'{0}'.format(salt.utils.to_unicode(vname, 'utf-8') if vname else u'(Default)'),
-                  'Value': salt.utils.to_unicode(vdata, 'utf-8')}
+                  'Value': salt.utils.to_str(vdata, 'utf-8')}
 
     # Check for test option
     if __opts__['test']:


### PR DESCRIPTION
### What does this PR do?
When generating the changed item, it would crash when it encountered binary data because it was trying to convert to unicode (`salt.utils.to_unicode`).

This will use `salt.utils.to_str` instead.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/45910

### Tests written?
No

### Commits signed with GPG?
Yes