### PR TITLE
stop 'data' being assigned with serialised empty dict for GET requests

### DIFF
--- a/salt/modules/consul.py
+++ b/salt/modules/consul.py
@@ -61,7 +61,7 @@ def _query(function,
     :param api_version  The Consul api version
     :param function:    The Consul api function to perform.
     :param method:      The HTTP method, e.g. GET or POST.
-    :param data:        The data to be sent for POST method.
+    :param data:        The data to be sent for POST method. This param is ignored for GET requests.
     :return:            The json response from the API call or False.
     '''
 

--- a/salt/modules/consul.py
+++ b/salt/modules/consul.py
@@ -78,9 +78,12 @@ def _query(function,
     base_url = urllib.parse.urljoin(consul_url, '{0}/'.format(api_version))
     url = urllib.parse.urljoin(base_url, function, False)
 
-    if data is None:
-        data = {}
-    data = salt.utils.json.dumps(data)
+    if method == 'GET':
+        data = None
+    else:
+        if data is None:
+            data = {}
+        data = salt.utils.json.dumps(data)
 
     result = salt.utils.http.query(
         url,


### PR DESCRIPTION
### What does this PR do?
stops 'data' param being set for GET requests in module consul.py

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/43798

### Previous Behavior
if 'data' was None, it would be set to json serialised empty dict which causes exception in http modules.

### New Behavior
For GET requests, force data = None.

### Tests written?
No

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
