### PR TITLE
zeromq dependency: pycrypto --> cryptodome

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -10,7 +10,7 @@ PyYAML = "*"
 MarkupSafe = "*"
 requests = ">=1.0.0"
 tornado = ">=4.2.1,<5.0"
-pycrypto = ">=2.6.1"
+pycryptodomex = ">=3.4.7"
 pyzmq = ">=2.2.0"
 
 [dev-packages]

--- a/doc/spelling_wordlist.txt
+++ b/doc/spelling_wordlist.txt
@@ -622,6 +622,7 @@ py
 pybluez
 pycassa
 pycrypto
+pycryptodomex
 pydsl
 pygerduty
 pygit

--- a/doc/topics/development/conventions/packaging.rst
+++ b/doc/topics/development/conventions/packaging.rst
@@ -106,7 +106,7 @@ Depends
 - `Salt Common`
 - `ZeroMQ` >= 3.2
 - `PyZMQ` >= 2.10
-- `PyCrypto`
+- `PyCryptodome`
 - `M2Crypto`
 - `Python MessagePack` (Messagepack C lib, or msgpack-pure)
 
@@ -140,7 +140,7 @@ Depends
 - `Salt Master`
 - `ZeroMQ` >= 3.2
 - `PyZMQ` >= 2.10
-- `PyCrypto`
+- `PyCryptodome`
 - `M2Crypto`
 - `Python MessagePack` (Messagepack C lib, or msgpack-pure)
 
@@ -169,7 +169,7 @@ Depends
 - `Salt Common`
 - `ZeroMQ` >= 3.2
 - `PyZMQ` >= 2.10
-- `PyCrypto`
+- `PyCryptodome`
 - `M2Crypto`
 - `Python MessagePack` (Messagepack C lib, or msgpack-pure)
 

--- a/doc/topics/development/hacking.rst
+++ b/doc/topics/development/hacking.rst
@@ -66,7 +66,7 @@ Install Salt (and dependencies) into the virtualenv:
 
 .. code-block:: bash
 
-    pip install pyzmq PyYAML pycrypto msgpack-python jinja2 psutil futures tornado
+    pip install pyzmq PyYAML pycryptodomex msgpack-python jinja2 psutil futures tornado
     pip install -e ./salt   # the path to the salt git clone from above
 
 .. note:: Installing psutil

--- a/doc/topics/development/tests/index.rst
+++ b/doc/topics/development/tests/index.rst
@@ -107,7 +107,7 @@ On Debian, Ubuntu or their derivatives run the following commands:
     apt-get install build-essential python-dev
     pip install -r requirements/zeromq.txt
 
-This will install the latest ``pycrypto`` and ``pyzmq`` (with bundled
+This will install the latest ``pycryptodomex`` and ``pyzmq`` (with bundled
 ``libzmq``) Python modules required for running integration tests suite.
 
 Once all requirements are installed, use ``runtests.py`` script to run all of
@@ -445,8 +445,8 @@ successfully. If a network connection is not detected, the test will not run.
 order for the test to be executed. Otherwise, the test is skipped.
 
 `@requires_system_grains` -- Loads and passes the grains on the system as an
-keyword argument to the test function with the name `grains`. 
-    
+keyword argument to the test function with the name `grains`.
+
 `@skip_if_binaries_missing(['list', 'of', 'binaries'])` -- If called from inside a test,
 the test will be skipped if the binaries are not all present on the system.
 

--- a/doc/topics/installation/index.rst
+++ b/doc/topics/installation/index.rst
@@ -104,7 +104,7 @@ vary:
 
   * `ZeroMQ`_ >= 3.2.0
   * `pyzmq`_ >= 2.2.0 - ZeroMQ Python bindings
-  * `PyCrypto`_ - The Python cryptography toolkit
+  * `PyCryptodome`_ - low-level cryptographic primitives
 
 * RAET:
 
@@ -147,7 +147,7 @@ Optional Dependencies
 .. _`pyzmq`: https://github.com/zeromq/pyzmq
 .. _`msgpack-python`:  https://pypi.python.org/pypi/msgpack-python/
 .. _`M2Crypto`: https://gitlab.com/m2crypto/m2crypto
-.. _`PyCrypto`: https://www.dlitz.net/software/pycrypto/
+.. _`PyCryptodome`: http://www.pycryptodome.org/
 .. _`YAML`: http://pyyaml.org/
 .. _`Jinja2`: http://jinja.pocoo.org/
 .. _`MarkupSafe`: https://pypi.python.org/pypi/MarkupSafe
@@ -188,4 +188,3 @@ SaltStack states and execution modules to build Salt and a specified set of
 dependencies, from which a platform specific repository can be built.
 
 https://github.com/saltstack/salt-pack
-

--- a/doc/topics/transports/raet/index.rst
+++ b/doc/topics/transports/raet/index.rst
@@ -31,7 +31,7 @@ Using RAET in Salt
 ==================
 
 Using RAET in Salt is easy, the main difference is that the core dependencies
-change, instead of needing pycrypto, M2Crypto, ZeroMQ, and PYZMQ, the packages
+change, instead of needing pycryptodomex, M2Crypto, ZeroMQ, and PYZMQ, the packages
 `libsodium`_, libnacl, ioflo, and raet are required. Encryption is handled very cleanly
 by libnacl, while the queueing and flow control is handled by
 ioflo. Distribution packages are forthcoming, but `libsodium`_ can be easily

--- a/doc/topics/tutorials/writing_tests.rst
+++ b/doc/topics/tutorials/writing_tests.rst
@@ -61,7 +61,7 @@ On Debian, Ubuntu or their derivatives run the following commands:
     apt-get install build-essential python-dev
     pip install -r requirements/zeromq.txt
 
-This will install the latest ``pycrypto`` and ``pyzmq`` (with bundled
+This will install the latest ``pycryptodomex`` and ``pyzmq`` (with bundled
 ``libzmq``) Python modules required for running integration tests suite.
 
 
@@ -164,7 +164,7 @@ the test suite, allowing you to write tests to assert against expected or
 unexpected behaviors.
 
 A simple example of a test utilizing a typical master/minion execution module command
-is the test for the ``test_ping`` function in the 
+is the test for the ``test_ping`` function in the
 ``tests/integration/modules/test_test.py``
 file:
 
@@ -320,7 +320,7 @@ Args can be passed in to the ``run_function`` method as well:
         '''
         self.assertEqual(self.run_function('test.echo', ['text']), 'text')
 
-The next example is taken from the 
+The next example is taken from the
 ``tests/integration/modules/test_aliases.py`` file and
 demonstrates how to pass kwargs to the ``run_function`` call. Also note that this
 test uses another salt function to ensure the correct data is present (via the

--- a/pkg/arch/PKGBUILD-local
+++ b/pkg/arch/PKGBUILD-local
@@ -13,7 +13,7 @@ depends=('python2'
          'python2-pyzmq'
          'python-m2crypto'
          'python2-yaml'
-         'pycrypto'
+         'pycryptodomex'
          'python2-psutil')
 makedepends=('git')
 provides=()

--- a/pkg/osx/req.txt
+++ b/pkg/osx/req.txt
@@ -17,7 +17,7 @@ MarkupSafe==1.0
 msgpack-python==0.4.8
 pyasn1==0.4.2
 pycparser==2.18
-pycrypto==2.6.1
+pycryptodomex>=3.4.7
 python-dateutil==2.6.1
 python-gnupg==0.4.1
 PyYAML==3.12

--- a/pkg/smartos/esky/zeromq_requirements.txt
+++ b/pkg/smartos/esky/zeromq_requirements.txt
@@ -1,6 +1,6 @@
 # Need to set a specific version of pyzmq, so can't use the main project's requirements file... have to copy it in and modify...
 #-r ../../../requirements/zeromq.txt
 -r ../../../requirements/base.txt
-pycrypto>=2.6.1
+pycryptodomex>=3.4.7
 pyzmq
 -r requirements.txt

--- a/pkg/suse/salt.spec
+++ b/pkg/suse/salt.spec
@@ -74,7 +74,7 @@ BuildRequires:  python-ioflo >= 1.1.7
 BuildRequires:  python-raet >= 0.6.0
 %endif
 # requirements/zeromq.txt
-BuildRequires:  python-pycrypto >= 2.6.1
+BuildRequires:  python-pycryptodomex >= 3.4.7
 BuildRequires:  python-pyzmq >= 2.2.0
 %if %{with test}
 # requirements/dev_python27.txt
@@ -121,7 +121,7 @@ Recommends:     python-gnupg
 # Recommends:     salt-raet
 # requirements/zeromq.txt
 %endif
-Requires:       python-pycrypto >= 2.6.1
+Requires:       python-pycryptodomex >= 3.4.7
 Requires:       python-pyzmq >= 2.2.0
 #
 %if 0%{?suse_version}

--- a/pkg/windows/req.txt
+++ b/pkg/windows/req.txt
@@ -19,7 +19,7 @@ msgpack-python==0.4.8
 psutil==5.2.2
 pyasn1==0.2.3
 pycparser==2.17
-pycrypto==2.6.1
+pycryptodomex>=3.4.7
 pycurl==7.43.0
 PyMySQL==0.7.11
 pyOpenSSL==17.5.0

--- a/requirements/zeromq.txt
+++ b/requirements/zeromq.txt
@@ -1,4 +1,4 @@
 -r base.txt
 
-pycrypto>=2.6.1
+pycryptodomex>=3.4.7
 pyzmq>=2.2.0

--- a/salt/cloud/clouds/joyent.py
+++ b/salt/cloud/clouds/joyent.py
@@ -46,7 +46,7 @@ included:
 
       api_host_suffix: .api.myhostname.com
 
-:depends: PyCrypto
+:depends: PyCryptodomex
 '''
 # pylint: disable=invalid-name,function-redefined
 

--- a/salt/cloud/deploy/bootstrap-salt.sh
+++ b/salt/cloud/deploy/bootstrap-salt.sh
@@ -3702,7 +3702,7 @@ install_centos_git_deps() {
 
     if [ "${_PY_EXE}" != "" ]; then
         # If "-x" is defined, install dependencies with pip based on the Python version given.
-        _PIP_PACKAGES="m2crypto jinja2 msgpack-python pycrypto PyYAML tornado<5.0 zmq"
+        _PIP_PACKAGES="m2crypto jinja2 msgpack-python pycryptodomex PyYAML tornado<5.0 zmq"
 
         # install swig and openssl on cent6
         if [ "$DISTRO_MAJOR_VERSION" -eq 6 ]; then
@@ -5528,7 +5528,7 @@ install_opensuse_git_deps() {
 
     __git_clone_and_checkout || return 1
 
-    __PACKAGES="libzmq5 python-Jinja2 python-m2crypto python-msgpack-python python-pycrypto python-pyzmq python-xml"
+    __PACKAGES="libzmq5 python-Jinja2 python-m2crypto python-msgpack-python python-pycryptodomex python-pyzmq python-xml"
 
     if [ -f "${_SALT_GIT_CHECKOUT_DIR}/requirements/base.txt" ]; then
         # We're on the develop branch, install whichever tornado is on the requirements file
@@ -5748,7 +5748,7 @@ install_suse_12_git_deps() {
 
     __PACKAGES=""
     # shellcheck disable=SC2089
-    __PACKAGES="${__PACKAGES} libzmq3 python-Jinja2 python-msgpack-python python-pycrypto"
+    __PACKAGES="${__PACKAGES} libzmq3 python-Jinja2 python-msgpack-python python-pycryptodomex"
     __PACKAGES="${__PACKAGES} python-pyzmq python-xml"
 
     if [ -f "${_SALT_GIT_CHECKOUT_DIR}/requirements/base.txt" ]; then
@@ -5855,7 +5855,7 @@ install_suse_11_git_deps() {
 
     __PACKAGES=""
     # shellcheck disable=SC2089
-    __PACKAGES="${__PACKAGES} libzmq4 python-Jinja2 python-msgpack-python python-pycrypto"
+    __PACKAGES="${__PACKAGES} libzmq4 python-Jinja2 python-msgpack-python python-pycryptodomex"
     __PACKAGES="${__PACKAGES} python-pyzmq python-xml python-zypp"
 
     if [ -f "${_SALT_GIT_CHECKOUT_DIR}/requirements/base.txt" ]; then

--- a/tests/unit/modules/test_pip.py
+++ b/tests/unit/modules/test_pip.py
@@ -950,7 +950,7 @@ class PipTestCase(TestCase, LoaderModuleMockMixin):
             '-e git+git@github.com:s0undt3ch/salt-testing.git@9ed81aa2f918d59d3706e56b18f0782d1ea43bf8#egg=SaltTesting-dev',
             'bbfreeze==1.1.0',
             'bbfreeze-loader==1.1.0',
-            'pycrypto==2.6'
+            'pycryptodomex==3.4.7'
         ]
         mock = MagicMock(
             return_value={
@@ -1009,7 +1009,7 @@ class PipTestCase(TestCase, LoaderModuleMockMixin):
             'bbfreeze==1.1.0',
             'bbfreeze-loader==1.1.0',
             'pip==0.9.1',
-            'pycrypto==2.6',
+            'pycryptodomex==3.4.7',
             'setuptools==20.10.1'
         ]
         mock = MagicMock(
@@ -1048,7 +1048,7 @@ class PipTestCase(TestCase, LoaderModuleMockMixin):
             '-e git+git@github.com:s0undt3ch/salt-testing.git@9ed81aa2f918d59d3706e56b18f0782d1ea43bf8#egg=SaltTesting-dev',
             'bbfreeze==1.1.0',
             'bbfreeze-loader==1.1.0',
-            'pycrypto==2.6'
+            'pycryptodomex==3.4.7'
         ]
         mock_version = '6.1.1'
         mock = MagicMock(return_value={'retcode': 0, 'stdout': '\n'.join(eggs)})
@@ -1092,7 +1092,7 @@ class PipTestCase(TestCase, LoaderModuleMockMixin):
             'bbfreeze==1.1.0',
             'bbfreeze-loader==1.1.0',
             'pip==9.0.1',
-            'pycrypto==2.6',
+            'pycryptodomex==3.4.7',
             'setuptools==20.10.1'
         ]
         # N.B.: this is deliberately different from the "output" of pip freeze.
@@ -1140,7 +1140,7 @@ class PipTestCase(TestCase, LoaderModuleMockMixin):
             '-e git+git@github.com:s0undt3ch/salt-testing.git@9ed81aa2f918d59d3706e56b18f0782d1ea43bf8#egg=SaltTesting-dev',
             'bbfreeze==1.1.0',
             'bbfreeze-loader==1.1.0',
-            'pycrypto==2.6'
+            'pycryptodomex==3.4.7'
         ]
         mock = MagicMock(
             return_value={
@@ -1230,7 +1230,7 @@ class PipTestCase(TestCase, LoaderModuleMockMixin):
             '-e git+git@github.com:s0undt3ch/salt-testing.git@9ed81aa2f918d59d3706e56b18f0782d1ea43bf8#egg=SaltTesting-dev',
             'bbfreeze==1.1.0',
             'bbfreeze-loader==1.1.0',
-            'pycrypto==2.6'
+            'pycryptodomex==3.4.7'
         ]
         mock = MagicMock(
             return_value={
@@ -1257,7 +1257,7 @@ class PipTestCase(TestCase, LoaderModuleMockMixin):
             '-e git+git@github.com:s0undt3ch/salt-testing.git@9ed81aa2f918d59d3706e56b18f0782d1ea43bf8#egg=SaltTesting-dev',
             'bbfreeze==1.1.0',
             'bbfreeze-loader==1.1.0',
-            'pycrypto==2.6'
+            'pycryptodomex==3.4.7'
         ]
         mock = MagicMock(
             return_value={


### PR DESCRIPTION
I was unable to pip install pycrypto because of an autoconf error, and found 

This
https://github.com/dlitz/pycrypto/issues/168

which led me to  this
`tl;dr: PyCrypto is dead. Switch to PyCryptodome (GitHub: https://github.com/Legrandin/pycryptodome PyPi: https://pypi.python.org/pypi/pycryptodome). Do not report any new bugs here!`
https://github.com/dlitz/pycrypto/issues/238

Support for salt with pycryptodome in some form has been around since 31c6a10d1b9ce854bb857ca6b0287650093d2f8b

### What does this PR do?

Switches pip dependency from pycrypto (unmaintained) to cryptodome

### What issues does this PR fix or reference?
No known issues yet, maybe this will create some? :)
It's probably worth it.

### Previous Behavior
pip installation of salt would attempt to install pycrypto, which has become orphaned, and subsumed by the drop-in replacement pycryptodome

### New Behavior
pip installation of salt would attempt to install pycryptodome to provide functionality previously provided by pycrypto, as a drop-in replacement.

### Tests written?

No

There is already much code in salt to accommodate pycryptodome.
eg. #41882 #40503

### Commits signed with GPG?

Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
