### PR TITLE
move log_file option to changeable defaults

### DIFF
--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -880,6 +880,7 @@ class Single(object):
         # Pre apply changeable defaults
         self.minion_opts = {
                     'grains_cache': True,
+                    'log_file': 'salt-call.log',
                 }
         self.minion_opts.update(opts.get('ssh_minion_opts', {}))
         if minion_opts is not None:
@@ -889,7 +890,6 @@ class Single(object):
                     'root_dir': os.path.join(self.thin_dir, 'running_data'),
                     'id': self.id,
                     'sock_dir': '/',
-                    'log_file': 'salt-call.log',
                     'fileserver_list_cache_time': 3,
                 })
         self.minion_config = salt.serializers.yaml.serialize(self.minion_opts)


### PR DESCRIPTION
### What does this PR do?

Using salt-ssh with --wipe always remove the logfile. This patch makes it possible to overwrite
the log_file option and redirect it out of the thin dir which gets removed.

### What issues does this PR fix or reference?

https://github.com/saltstack/salt/issues/43385

### Tests written?

No

### Commits signed with GPG?

No