### PR TITLE
[2017.7] Backport #45894 - Missing `format` in the call to write.

### DIFF
--- a/salt/log/handlers/__init__.py
+++ b/salt/log/handlers/__init__.py
@@ -179,7 +179,7 @@ if sys.version_info < (3, 2):
                 self.queue.put_nowait(record)
             except queue.Full:
                 sys.stderr.write('[WARNING ] Message queue is full, '
-                                 'unable to write "{0}" to log', record
+                                 'unable to write "{0}" to log'.format(record)
                                  )
 
         def prepare(self, record):


### PR DESCRIPTION
### What does this PR do?
Missing `format` in the call to write.

### What issues does this PR fix or reference?
N/A

### Previous Behavior
Throwing an exception because `format` was left out of the call to `sys.stderr.write`

### New Behavior
Included `format`.

### Tests written?
Yes

### Commits signed with GPG?

Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
