### PR TITLE
Add vpc_peering_connection_id to describe_route_tables route_keys

### DIFF
--- a/salt/modules/boto_vpc.py
+++ b/salt/modules/boto_vpc.py
@@ -2576,6 +2576,7 @@ def describe_route_tables(route_table_id=None, route_table_name=None,
                       'instance_id': 'Instance',
                       'interface_id': 'NetworkInterfaceId',
                       'nat_gateway_id': 'NatGatewayId',
+                      'vpc_peering_connection_id': 'VpcPeeringConnectionId',
                       }
         assoc_keys = {'id': 'RouteTableAssociationId',
                       'main': 'Main',


### PR DESCRIPTION
This is required to fix state module function _routes_present when using a vpc_peering_connection.

### What does this PR do?

Adds the vpc_peering_connection_id to describe_route_tables route_keys.

### What issues does this PR fix or reference?
Unknown

### Previous Behavior
VPC Peering connections did not get returned therefore causing the state module boto_vpc.route_table_present to apply changes even when no changes existed.

### New Behavior
When using boto_vpc.route_table_present with vpc_peering_connection_id or name the state does not delete and reapply all routes associated with peering connections.

### Tests written?
No

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
Done

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.

