### PR TITLE
Fix hosted zone Comment updates & quote TXT entries correctly

### DIFF
--- a/salt/states/boto3_route53.py
+++ b/salt/states/boto3_route53.py
@@ -138,7 +138,7 @@ def _from_aws_encoding(string):  # XXX TODO
 
 
 def hosted_zone_present(name, Name=None, PrivateZone=False,
-                        CallerReference=None, Comment='', VPCs=None,
+                        CallerReference=None, Comment=None, VPCs=None,
                         region=None, key=None, keyid=None, profile=None):
     '''
     Ensure a hosted zone exists with the given attributes.
@@ -642,6 +642,11 @@ def rr_present(name, HostedZoneId=None, DomainName=None, PrivateZone=False, Name
                     ret['result'] = False
                     return ret
             else:
+                # for TXT records the entry must be encapsulated in quotes as required by the API
+                # this appears to be incredibly difficult with the jinja templating engine
+                # so inject the quotations here to make a viable ChangeBatch
+                if Type == 'TXT':
+                    rr = '"%s"' % (rr)
                 fixed_rrs += [rr]
         ResourceRecords = [{'Value': rr} for rr in sorted(fixed_rrs)]
 

--- a/salt/states/boto3_route53.py
+++ b/salt/states/boto3_route53.py
@@ -646,7 +646,7 @@ def rr_present(name, HostedZoneId=None, DomainName=None, PrivateZone=False, Name
                 # this appears to be incredibly difficult with the jinja templating engine
                 # so inject the quotations here to make a viable ChangeBatch
                 if Type == 'TXT':
-                    rr = '"%s"' % (rr)
+                    rr = '"{}"'.format(rr)
                 fixed_rrs += [rr]
         ResourceRecords = [{'Value': rr} for rr in sorted(fixed_rrs)]
 


### PR DESCRIPTION
### What does this PR do?

1. Protects continual updates to the Comment field which isn't '' but rather is None when attempting to compare the local changes against it
2. Encapsulates ResourceRecords in quotes if they happen to be part of a TXT Type. The API requires that the entries are surrounded by quotes when being submitted in a ChangeBatch.

A wiser person might be able to figure out how to get the jinja templating engine to pass through the quotes are they are written in the state file, but I just couldn't figure it out.

Taking a clue from Ansible I'm just quoting ResourceRecord entries if the Type happens to be a TXT, when this happens everything is magical

### What issues does this PR fix or reference?

* https://github.com/saltstack/salt/issues/45995
* https://github.com/saltstack/salt/issues/45996

### Previous Behavior

1. The Comment field in the Zone is updated even though you are leaving it blank
2. TXT records cannot be created at all

### New Behavior

1. Since the upstream value for Comment is actually None not '' when empty, we initialise the local variable with a None if you leave it out so that the comparison works correctly and the field isn't updated.
2. TXT records can be created, yay!

### Tests written?

No

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
