### PR TITLE
Retry loading serialized job details

### DIFF
--- a/salt/returners/local_cache.py
+++ b/salt/returners/local_cache.py
@@ -26,7 +26,7 @@ import salt.exceptions
 # Import 3rd-party libs
 import msgpack
 from salt.ext import six
-
+from salt.ext.six.moves import range  # pylint: disable=import-error,redefined-builtin
 
 log = logging.getLogger(__name__)
 
@@ -296,8 +296,19 @@ def get_load(jid):
         return {}
     serial = salt.payload.Serial(__opts__)
     ret = {}
-    with salt.utils.files.fopen(os.path.join(jid_dir, LOAD_P), 'rb') as rfh:
-        ret = serial.load(rfh)
+    load_p = os.path.join(jid_dir, LOAD_P)
+    num_tries = 5
+    for index in range(1, num_tries + 1):
+        with salt.utils.files.fopen(load_p, 'rb') as rfh:
+            try:
+                ret = serial.load(rfh)
+                break
+            except Exception as exc:
+                if index == num_tries:
+                    time.sleep(0.25)
+    else:
+        log.critical('Failed to unpack %s', load_p)
+        raise exc
     if ret is None:
         ret = {}
     minions_cache = [os.path.join(jid_dir, MINIONS_P)]


### PR DESCRIPTION
This works around a race condition that can occur in the test suite when the event handler tries to process an event before the job's serialized details have finished being written to disk.

@cachedout I tried to err on the side of caution here, by trying 5 times and waiting a quarter-second between each try. In my testing, just a single retry (i.e. 2 tries total) got rid of all instances of this traceback, but I figured there wasn't any harm in trying to account for longer delays. I'm open to tweaking this if you think it's worth doing.

Resolves #45954.

**NOTE: This traceback does not affect test results, it's in the event handler. To confirm whether or not this fixed the traceback, you will need to check the full console output for the job in Jenkins and look for the string `UnpackValueError`.**