### PR TITLE
Pyzmq 17.0.0 proper handling

### DIFF
--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -57,11 +57,6 @@ from salt.exceptions import (
 # Import third party libs
 from salt.ext import six
 # pylint: disable=import-error
-try:
-    import zmq
-    HAS_ZMQ = True
-except ImportError:
-    HAS_ZMQ = False
 
 # Try to import range from https://github.com/ytoolshed/range
 HAS_RANGE = False

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -60,11 +60,7 @@ try:
     HAS_WINSHELL = False
 except ImportError:
     HAS_WINSHELL = False
-try:
-    import zmq
-    HAS_ZMQ = True
-except ImportError:
-    HAS_ZMQ = False
+from salt.utils.zeromq import zmq
 
 # The directory where salt thin is deployed
 DEFAULT_THIN_DIR = '/var/tmp/.%%USER%%_%%FQDNUUID%%_salt'
@@ -214,7 +210,7 @@ class SSH(object):
     def __init__(self, opts):
         self.__parsed_rosters = {SSH.ROSTER_UPDATE_FLAG: True}
         pull_sock = os.path.join(opts['sock_dir'], 'master_event_pull.ipc')
-        if os.path.exists(pull_sock) and HAS_ZMQ:
+        if os.path.exists(pull_sock) and zmq:
             self.event = salt.utils.event.get_event(
                     'master',
                     opts['sock_dir'],

--- a/salt/daemons/flo/zero.py
+++ b/salt/daemons/flo/zero.py
@@ -15,16 +15,12 @@ import errno
 # Import ioflo libs
 import ioflo.base.deeding
 # Import third party libs
-try:
-    import zmq
-    import salt.master
-    import salt.crypt
-    import salt.daemons.masterapi
-    import salt.payload
-    import salt.utils.stringutils
-    HAS_ZMQ = True
-except ImportError:
-    HAS_ZMQ = False
+from salt.utils.zeromq import zmq
+import salt.master
+import salt.crypt
+import salt.daemons.masterapi
+import salt.payload
+import salt.utils.stringutils
 
 log = logging.getLogger(__name__)
 
@@ -160,7 +156,7 @@ class SaltZmqPublisher(ioflo.base.deeding.Deed):
         '''
         Set up tracking value(s)
         '''
-        if not HAS_ZMQ:
+        if not zmq:
             return
         self.created = False
         self.serial = salt.payload.Serial(self.opts.value)

--- a/salt/engines/napalm_syslog.py
+++ b/salt/engines/napalm_syslog.py
@@ -173,11 +173,7 @@ from __future__ import absolute_import, print_function, unicode_literals
 import logging
 
 # Import third party libraries
-try:
-    import zmq
-    HAS_ZMQ = True
-except ImportError:
-    HAS_ZMQ = False
+from salt.utils.zeromq import zmq
 
 try:
     # pylint: disable=W0611
@@ -209,7 +205,7 @@ def __virtual__():
     '''
     Load only if napalm-logs is installed.
     '''
-    if not HAS_NAPALM_LOGS or not HAS_ZMQ:
+    if not HAS_NAPALM_LOGS or not zmq:
         return (False, 'napalm_syslog could not be loaded. \
             Please install napalm-logs library amd ZeroMQ.')
     return True

--- a/salt/master.py
+++ b/salt/master.py
@@ -24,7 +24,7 @@ import salt.serializers.msgpack
 # pylint: disable=import-error,no-name-in-module,redefined-builtin
 from salt.ext import six
 from salt.ext.six.moves import range
-from salt.utils.zeromq import zmq, ZMQDefaultLoop, install_zmq, zmq_version_info
+from salt.utils.zeromq import zmq, ZMQDefaultLoop, install_zmq, ZMQ_VERSION_INFO
 # pylint: enable=import-error,no-name-in-module,redefined-builtin
 
 import tornado.gen  # pylint: disable=F0401
@@ -486,7 +486,7 @@ class Master(SMaster):
 
         :param dict: The salt options
         '''
-        if zmq and zmq_version_info < (3, 2):
+        if zmq and ZMQ_VERSION_INFO < (3, 2):
             log.warning(
                 'You have a version of ZMQ less than ZMQ 3.2! There are '
                 'known connection keep-alive issues with ZMQ < 3.2 which '

--- a/salt/master.py
+++ b/salt/master.py
@@ -27,19 +27,6 @@ from salt.ext.six.moves import range
 from salt.utils.zeromq import zmq, ZMQDefaultLoop, install_zmq, zmq_version_info
 # pylint: enable=import-error,no-name-in-module,redefined-builtin
 
-try:
-    import zmq
-    import zmq.eventloop.ioloop
-    # support pyzmq 13.0.x, TODO: remove once we force people to 14.0.x
-    if not hasattr(zmq.eventloop.ioloop, 'ZMQIOLoop'):
-        zmq.eventloop.ioloop.ZMQIOLoop = zmq.eventloop.ioloop.IOLoop
-    LOOP_CLASS = zmq.eventloop.ioloop.ZMQIOLoop
-    HAS_ZMQ = True
-except ImportError:
-    import tornado.ioloop
-    LOOP_CLASS = tornado.ioloop.IOLoop
-    HAS_ZMQ = False
-
 import tornado.gen  # pylint: disable=F0401
 
 # Import salt libs

--- a/salt/master.py
+++ b/salt/master.py
@@ -24,6 +24,7 @@ import salt.serializers.msgpack
 # pylint: disable=import-error,no-name-in-module,redefined-builtin
 from salt.ext import six
 from salt.ext.six.moves import range
+from salt.utils.zeromq import zmq, ZMQDefaultLoop, install_zmq, zmq_version_info
 # pylint: enable=import-error,no-name-in-module,redefined-builtin
 
 try:
@@ -993,9 +994,8 @@ class MWorker(salt.utils.process.SignalHandlingMultiprocessingProcess):
         Bind to the local port
         '''
         # using ZMQIOLoop since we *might* need zmq in there
-        if HAS_ZMQ:
-            zmq.eventloop.ioloop.install()
-        self.io_loop = LOOP_CLASS()
+        install_zmq()
+        self.io_loop = ZMQDefaultLoop()
         self.io_loop.make_current()
         for req_channel in self.req_channels:
             req_channel.post_fork(self._handle_payload, io_loop=self.io_loop)  # TODO: cleaner? Maybe lazily?

--- a/salt/master.py
+++ b/salt/master.py
@@ -499,23 +499,13 @@ class Master(SMaster):
 
         :param dict: The salt options
         '''
-        if HAS_ZMQ:
-            # Warn if ZMQ < 3.2
-            try:
-                zmq_version_info = zmq.zmq_version_info()
-            except AttributeError:
-                # PyZMQ <= 2.1.9 does not have zmq_version_info, fall back to
-                # using zmq.zmq_version() and build a version info tuple.
-                zmq_version_info = tuple(
-                    [int(x) for x in zmq.zmq_version().split('.')]
-                )
-            if zmq_version_info < (3, 2):
-                log.warning(
-                    'You have a version of ZMQ less than ZMQ 3.2! There are '
-                    'known connection keep-alive issues with ZMQ < 3.2 which '
-                    'may result in loss of contact with minions. Please '
-                    'upgrade your ZMQ!'
-                )
+        if zmq and zmq_version_info < (3, 2):
+            log.warning(
+                'You have a version of ZMQ less than ZMQ 3.2! There are '
+                'known connection keep-alive issues with ZMQ < 3.2 which '
+                'may result in loss of contact with minions. Please '
+                'upgrade your ZMQ!'
+            )
         SMaster.__init__(self, opts)
 
     def __set_max_open_files(self):

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -31,7 +31,7 @@ if six.PY3:
 else:
     import salt.ext.ipaddress as ipaddress
 from salt.ext.six.moves import range
-from salt.utils.zeromq import zmq, ZMQDefaultLoop, install_zmq
+from salt.utils.zeromq import zmq, ZMQDefaultLoop, install_zmq, ZMQ_VERSION_INFO
 
 # pylint: enable=no-name-in-module,redefined-builtin
 
@@ -1077,15 +1077,7 @@ class Minion(MinionBase):
 
         # Warn if ZMQ < 3.2
         if zmq:
-            try:
-                zmq_version_info = zmq.zmq_version_info()
-            except AttributeError:
-                # PyZMQ <= 2.1.9 does not have zmq_version_info, fall back to
-                # using zmq.zmq_version() and build a version info tuple.
-                zmq_version_info = tuple(
-                    [int(x) for x in zmq.zmq_version().split('.')]  # pylint: disable=no-member
-                )
-            if zmq_version_info < (3, 2):
+            if ZMQ_VERSION_INFO < (3, 2):
                 log.warning(
                     'You have a version of ZMQ less than ZMQ 3.2! There are '
                     'known connection keep-alive issues with ZMQ < 3.2 which '

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -781,10 +781,7 @@ class SMinion(MinionBase):
         # Clean out the proc directory (default /var/cache/salt/minion/proc)
         if (self.opts.get('file_client', 'remote') == 'remote'
                 or self.opts.get('use_master_when_local', False)):
-            if self.opts['transport'] == 'zeromq' and zmq:
-                io_loop = zmq.eventloop.ioloop.ZMQIOLoop()
-            else:
-                io_loop = ZMQDefaultLoop.current()
+            io_loop = ZMQDefaultLoop.current()
             io_loop.run_sync(
                 lambda: self.eval_master(self.opts, failed=True)
             )

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -781,6 +781,7 @@ class SMinion(MinionBase):
         # Clean out the proc directory (default /var/cache/salt/minion/proc)
         if (self.opts.get('file_client', 'remote') == 'remote'
                 or self.opts.get('use_master_when_local', False)):
+            install_zmq()
             io_loop = ZMQDefaultLoop.current()
             io_loop.run_sync(
                 lambda: self.eval_master(self.opts, failed=True)

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -31,23 +31,11 @@ if six.PY3:
 else:
     import salt.ext.ipaddress as ipaddress
 from salt.ext.six.moves import range
+from salt.utils.zeromq import zmq, ZMQDefaultLoop, install_zmq
+
 # pylint: enable=no-name-in-module,redefined-builtin
 
 # Import third party libs
-try:
-    import zmq
-    # TODO: cleanup
-    import zmq.eventloop.ioloop
-    # support pyzmq 13.0.x, TODO: remove once we force people to 14.0.x
-    if not hasattr(zmq.eventloop.ioloop, 'ZMQIOLoop'):
-        zmq.eventloop.ioloop.ZMQIOLoop = zmq.eventloop.ioloop.IOLoop
-    LOOP_CLASS = zmq.eventloop.ioloop.ZMQIOLoop
-    HAS_ZMQ = True
-except ImportError:
-    import tornado.ioloop
-    LOOP_CLASS = tornado.ioloop.IOLoop
-    HAS_ZMQ = False
-
 HAS_RANGE = False
 try:
     import seco.range
@@ -690,7 +678,7 @@ class MinionBase(object):
                     if self.opts['transport'] == 'detect':
                         self.opts['detect_mode'] = True
                         for trans in ('zeromq', 'tcp'):
-                            if trans == 'zeromq' and not HAS_ZMQ:
+                            if trans == 'zeromq' and not zmq:
                                 continue
                             self.opts['transport'] = trans
                             pub_channel = salt.transport.client.AsyncPubChannel.factory(self.opts, **factory_kwargs)
@@ -793,10 +781,10 @@ class SMinion(MinionBase):
         # Clean out the proc directory (default /var/cache/salt/minion/proc)
         if (self.opts.get('file_client', 'remote') == 'remote'
                 or self.opts.get('use_master_when_local', False)):
-            if self.opts['transport'] == 'zeromq' and HAS_ZMQ:
+            if self.opts['transport'] == 'zeromq' and zmq:
                 io_loop = zmq.eventloop.ioloop.ZMQIOLoop()
             else:
-                io_loop = LOOP_CLASS.current()
+                io_loop = ZMQDefaultLoop.current()
             io_loop.run_sync(
                 lambda: self.eval_master(self.opts, failed=True)
             )
@@ -931,9 +919,8 @@ class MinionManager(MinionBase):
         self.minions = []
         self.jid_queue = []
 
-        if HAS_ZMQ:
-            zmq.eventloop.ioloop.install()
-        self.io_loop = LOOP_CLASS.current()
+        install_zmq()
+        self.io_loop = ZMQDefaultLoop.current()
         self.process_manager = ProcessManager(name='MultiMinionProcessManager')
         self.io_loop.spawn_callback(self.process_manager.run, async=True)
 
@@ -1086,14 +1073,13 @@ class Minion(MinionBase):
         self.periodic_callbacks = {}
 
         if io_loop is None:
-            if HAS_ZMQ:
-                zmq.eventloop.ioloop.install()
-            self.io_loop = LOOP_CLASS.current()
+            install_zmq()
+            self.io_loop = ZMQDefaultLoop.current()
         else:
             self.io_loop = io_loop
 
         # Warn if ZMQ < 3.2
-        if HAS_ZMQ:
+        if zmq:
             try:
                 zmq_version_info = zmq.zmq_version_info()
             except AttributeError:
@@ -2886,9 +2872,8 @@ class SyndicManager(MinionBase):
         self.jid_forward_cache = set()
 
         if io_loop is None:
-            if HAS_ZMQ:
-                zmq.eventloop.ioloop.install()
-            self.io_loop = LOOP_CLASS.current()
+            install_zmq()
+            self.io_loop = ZMQDefaultLoop.current()
         else:
             self.io_loop = io_loop
 

--- a/salt/transport/zeromq.py
+++ b/salt/transport/zeromq.py
@@ -514,14 +514,7 @@ class ZeroMQReqServerChannel(salt.transport.mixins.auth.AESReqServerMixin,
             # IPv6 sockets work for both IPv6 and IPv4 addresses
             self.clients.setsockopt(zmq.IPV4ONLY, 0)
         self.clients.setsockopt(zmq.BACKLOG, self.opts.get('zmq_backlog', 1000))
-        if HAS_ZMQ_MONITOR and self.opts['zmq_monitor']:
-            # Socket monitor shall be used the only for debug
-            # purposes so using threading doesn't look too bad here
-            import threading
-            self._monitor = ZeroMQSocketMonitor(self.clients)
-            t = threading.Thread(target=self._monitor.start_poll)
-            t.start()
-
+        self._start_zmq_monitor()
         self.workers = self.context.socket(zmq.DEALER)
 
         if self.opts.get('ipc_mode', '') == 'tcp':
@@ -583,6 +576,21 @@ class ZeroMQReqServerChannel(salt.transport.mixins.auth.AESReqServerMixin,
         salt.transport.mixins.auth.AESReqServerMixin.pre_fork(self, process_manager)
         process_manager.add_process(self.zmq_device)
 
+    def _start_zmq_monitor(self):
+        '''
+        Starts ZMQ monitor for debugging purposes.
+        :return:
+        '''
+        # Socket monitor shall be used the only for debug
+        # purposes so using threading doesn't look too bad here
+
+        if HAS_ZMQ_MONITOR and self.opts['zmq_monitor']:
+            log.debug('Starting ZMQ monitor')
+            import threading
+            self._w_monitor = ZeroMQSocketMonitor(self._socket)
+            threading.Thread(target=self._w_monitor.start_poll).start()
+            log.debug('ZMQ monitor has been started started')
+
     def post_fork(self, payload_handler, io_loop):
         '''
         After forking we need to create all of the local sockets to listen to the
@@ -597,13 +605,7 @@ class ZeroMQReqServerChannel(salt.transport.mixins.auth.AESReqServerMixin,
 
         self.context = zmq.Context(1)
         self._socket = self.context.socket(zmq.REP)
-        if HAS_ZMQ_MONITOR and self.opts['zmq_monitor']:
-            # Socket monitor shall be used the only for debug
-            # purposes so using threading doesn't look too bad here
-            import threading
-            self._w_monitor = ZeroMQSocketMonitor(self._socket)
-            t = threading.Thread(target=self._w_monitor.start_poll)
-            t.start()
+        self._start_zmq_monitor()
 
         if self.opts.get('ipc_mode', '') == 'tcp':
             self.w_uri = 'tcp://127.0.0.1:{0}'.format(

--- a/salt/transport/zeromq.py
+++ b/salt/transport/zeromq.py
@@ -131,7 +131,8 @@ class AsyncZeroMQReqChannel(salt.transport.client.ReqChannel):
             obj = object.__new__(cls)
             obj.__singleton_init__(opts, **kwargs)
             loop_instance_map[key] = obj
-            log.trace('Inserted key into loop_instance_map id %s for key %s and process %s', id(loop_instance_map), key, os.getpid())
+            log.trace('Inserted key into loop_instance_map id %s for key %s and process %s',
+                      id(loop_instance_map), key, os.getpid())
         else:
             log.debug('Re-using AsyncZeroMQReqChannel for %s', key)
         return obj
@@ -493,7 +494,8 @@ class AsyncZeroMQPubChannel(salt.transport.mixins.auth.AESPubClientMixin, salt.t
         return self.stream.on_recv(wrap_callback)
 
 
-class ZeroMQReqServerChannel(salt.transport.mixins.auth.AESReqServerMixin, salt.transport.server.ReqServerChannel):
+class ZeroMQReqServerChannel(salt.transport.mixins.auth.AESReqServerMixin,
+                             salt.transport.server.ReqServerChannel):
 
     def __init__(self, opts):
         salt.transport.server.ReqServerChannel.__init__(self, opts)
@@ -514,7 +516,8 @@ class ZeroMQReqServerChannel(salt.transport.mixins.auth.AESReqServerMixin, salt.
             self.clients.setsockopt(zmq.IPV4ONLY, 0)
         self.clients.setsockopt(zmq.BACKLOG, self.opts.get('zmq_backlog', 1000))
         if HAS_ZMQ_MONITOR and self.opts['zmq_monitor']:
-            # Socket monitor shall be used the only for debug  purposes so using threading doesn't look too bad here
+            # Socket monitor shall be used the only for debug
+            # purposes so using threading doesn't look too bad here
             import threading
             self._monitor = ZeroMQSocketMonitor(self.clients)
             t = threading.Thread(target=self._monitor.start_poll)
@@ -597,7 +600,8 @@ class ZeroMQReqServerChannel(salt.transport.mixins.auth.AESReqServerMixin, salt.
         self.context = zmq.Context(1)
         self._socket = self.context.socket(zmq.REP)
         if HAS_ZMQ_MONITOR and self.opts['zmq_monitor']:
-            # Socket monitor shall be used the only for debug  purposes so using threading doesn't look too bad here
+            # Socket monitor shall be used the only for debug
+            # purposes so using threading doesn't look too bad here
             import threading
             self._w_monitor = ZeroMQSocketMonitor(self._socket)
             t = threading.Thread(target=self._w_monitor.start_poll)

--- a/salt/transport/zeromq.py
+++ b/salt/transport/zeromq.py
@@ -1037,7 +1037,8 @@ class AsyncReqMessageClient(object):
 
             try:
                 ret = yield future
-            except:  # pylint: disable=W0702
+            except Exception as err:  # pylint: disable=W0702
+                log.debug('Re-init ZMQ socket: %s', err)
                 self._init_socket()  # re-init the zmq socket (no other way in zmq)
                 del self.send_queue[0]
                 continue

--- a/salt/transport/zeromq.py
+++ b/salt/transport/zeromq.py
@@ -374,8 +374,7 @@ class AsyncZeroMQPubChannel(salt.transport.mixins.auth.AESPubClientMixin, salt.t
 
         if self.opts['recon_randomize']:
             recon_delay = randint(self.opts['recon_default'],
-                                  self.opts['recon_default'] + self.opts['recon_max']
-                          )
+                                  self.opts['recon_default'] + self.opts['recon_max'])
 
             log.debug(
                 "Generated random reconnect delay between '%sms' and '%sms' (%s)",

--- a/salt/transport/zeromq.py
+++ b/salt/transport/zeromq.py
@@ -814,27 +814,35 @@ class ZeroMQPubServerChannel(salt.transport.server.PubServerChannel):
                 # Catch and handle EINTR from when this process is sent
                 # SIGUSR1 gracefully so we don't choke and die horribly
                 try:
+                    log.trace('Getting data from puller %s', pull_uri)
                     package = pull_sock.recv()
                     unpacked_package = salt.payload.unpackage(package)
                     if six.PY3:
                         unpacked_package = salt.transport.frame.decode_embedded_strs(unpacked_package)
                     payload = unpacked_package['payload']
+                    log.trace('Accepted unpacked package from puller')
                     if self.opts['zmq_filtering']:
                         # if you have a specific topic list, use that
                         if 'topic_lst' in unpacked_package:
                             for topic in unpacked_package['topic_lst']:
+                                log.trace('Sending filtered data over publisher %s', pub_uri)
                                 # zmq filters are substring match, hash the topic
                                 # to avoid collisions
                                 htopic = hashlib.sha1(topic).hexdigest()
                                 pub_sock.send(htopic, flags=zmq.SNDMORE)
                                 pub_sock.send(payload)
+                                log.trace('Filtered data has been sent')
                                 # otherwise its a broadcast
                         else:
                             # TODO: constants file for "broadcast"
+                            log.trace('Sending broadcasted data over publisher %s', pub_uri)
                             pub_sock.send('broadcast', flags=zmq.SNDMORE)
                             pub_sock.send(payload)
+                            log.trace('Broadcasted data has been sent')
                     else:
+                        log.trace('Sending ZMQ-unfiltered data over publisher %s', pub_uri)
                         pub_sock.send(payload)
+                        log.trace('Unfiltered data has been sent')
                 except zmq.ZMQError as exc:
                     if exc.errno == errno.EINTR:
                         continue

--- a/salt/transport/zeromq.py
+++ b/salt/transport/zeromq.py
@@ -535,7 +535,6 @@ class ZeroMQReqServerChannel(salt.transport.mixins.auth.AESReqServerMixin,
 
         log.info('Setting up the master communication server')
         self.clients.bind(self.uri)
-
         self.workers.bind(self.w_uri)
 
         while True:

--- a/salt/transport/zeromq.py
+++ b/salt/transport/zeromq.py
@@ -29,16 +29,13 @@ import salt.transport.client
 import salt.transport.server
 import salt.transport.mixins.auth
 from salt.ext import six
-from salt.ext.six.moves import map
 from salt.exceptions import SaltReqTimeoutError
 
-import zmq
+from salt.utils.zeromq import zmq, ZMQDefaultLoop, install_zmq, ZMQ_VERSION_INFO, LIBZMQ_VERSION_INFO
 import zmq.error
 import zmq.eventloop.ioloop
-# support pyzmq 13.0.x, TODO: remove once we force people to 14.0.x
-if not hasattr(zmq.eventloop.ioloop, 'ZMQIOLoop'):
-    zmq.eventloop.ioloop.ZMQIOLoop = zmq.eventloop.ioloop.IOLoop
 import zmq.eventloop.zmqstream
+
 try:
     import zmq.utils.monitor
     HAS_ZMQ_MONITOR = True

--- a/salt/transport/zeromq.py
+++ b/salt/transport/zeromq.py
@@ -550,10 +550,11 @@ class ZeroMQReqServerChannel(salt.transport.mixins.auth.AESReqServerMixin,
             return
         log.info('MWorkerQueue under PID %s is closing', os.getpid())
         self._closing = True
-        if hasattr(self, '_monitor') and self._monitor is not None:
+        # pylint: disable=E0203
+        if getattr(self, '_monitor', None) is not None:
             self._monitor.stop()
             self._monitor = None
-        if hasattr(self, '_w_monitor') and self._w_monitor is not None:
+        if getattr(self, '_w_monitor', None) is not None:
             self._w_monitor.stop()
             self._w_monitor = None
         if hasattr(self, 'clients') and self.clients.closed is False:
@@ -566,6 +567,7 @@ class ZeroMQReqServerChannel(salt.transport.mixins.auth.AESReqServerMixin,
             self._socket.close()
         if hasattr(self, 'context') and self.context.closed is False:
             self.context.term()
+        # pylint: enable=E0203
 
     def pre_fork(self, process_manager):
         '''

--- a/salt/transport/zeromq.py
+++ b/salt/transport/zeromq.py
@@ -16,8 +16,6 @@ import weakref
 from random import randint
 
 # Import Salt Libs
-from salt.ext import six
-from salt.ext.six.moves import map
 import salt.auth
 import salt.crypt
 import salt.utils.event

--- a/salt/utils/async.py
+++ b/salt/utils/async.py
@@ -7,19 +7,8 @@ from __future__ import absolute_import, print_function, unicode_literals
 
 import tornado.ioloop
 import tornado.concurrent
-# attempt to use zmq-- if we have it otherwise fallback to tornado loop
-try:
-    import zmq.eventloop.ioloop
-    # support pyzmq 13.0.x, TODO: remove once we force people to 14.0.x
-    if not hasattr(zmq.eventloop.ioloop, 'ZMQIOLoop'):
-        zmq.eventloop.ioloop.ZMQIOLoop = zmq.eventloop.ioloop.IOLoop
-    LOOP_CLASS = zmq.eventloop.ioloop.ZMQIOLoop
-    HAS_ZMQ = True
-except ImportError:
-    LOOP_CLASS = tornado.ioloop.IOLoop
-    HAS_ZMQ = False
-
 import contextlib
+from salt.utils import zeromq
 
 
 @contextlib.contextmanager
@@ -53,7 +42,7 @@ class SyncWrapper(object):
         if kwargs is None:
             kwargs = {}
 
-        self.io_loop = LOOP_CLASS()
+        self.io_loop = zeromq.ZMQDefaultLoop()
         kwargs['io_loop'] = self.io_loop
 
         with current_ioloop(self.io_loop):

--- a/salt/utils/cache.py
+++ b/salt/utils/cache.py
@@ -23,11 +23,7 @@ import salt.utils.files
 
 # Import third party libs
 from salt.ext.six.moves import range  # pylint: disable=import-error,redefined-builtin
-try:
-    import zmq
-    HAS_ZMQ = True
-except ImportError:
-    HAS_ZMQ = False
+from salt.utils.zeromq import zmq
 
 log = logging.getLogger(__name__)
 

--- a/salt/utils/master.py
+++ b/salt/utils/master.py
@@ -34,11 +34,7 @@ from salt.utils.process import MultiprocessingProcess
 
 # Import third party libs
 from salt.ext import six
-try:
-    import zmq
-    HAS_ZMQ = True
-except ImportError:
-    HAS_ZMQ = False
+from salt.utils.zeromq import zmq
 
 log = logging.getLogger(__name__)
 

--- a/salt/utils/zeromq.py
+++ b/salt/utils/zeromq.py
@@ -26,7 +26,7 @@ try:
         if ZMQ_VERSION_INFO[0] > 16:  # 17.0.x+ deprecates zmq's ioloops
             ZMQDefaultLoop = tornado.ioloop.IOLoop
 except Exception as ex:
-    log.exception(ex)
+    log.exception('Error while getting PyZMQ library version')
 
 if ZMQDefaultLoop is None:
     try:

--- a/salt/utils/zeromq.py
+++ b/salt/utils/zeromq.py
@@ -38,6 +38,17 @@ if ZMQDefaultLoop is None:
     except ImportError:
         ZMQDefaultLoop = tornado.ioloop.IOLoop
 
+# Build version info
+if zmq:
+    if hasattr(zmq, 'zmq_version_info'):
+        zmq_version_info = zmq.zmq_version_info()
+    else:
+        # PyZMQ <= 2.1.9 does not have zmq_version_info, fall back to
+        # using zmq.zmq_version() and build a version info tuple.
+        zmq_version_info = tuple([int(v_el) for v_el in zmq.zmq_version().split('.')])
+else:
+    zmq_version_info = (-1, -1, -1)
+
 
 def install_zmq():
     '''

--- a/salt/utils/zeromq.py
+++ b/salt/utils/zeromq.py
@@ -27,7 +27,7 @@ try:
         LIBZMQ_VERSION_INFO = tuple([int(v_el) for v_el in zmq.zmq_version().split('.')])
         if ZMQ_VERSION_INFO[0] > 16:  # 17.0.x+ deprecates zmq's ioloops
             ZMQDefaultLoop = tornado.ioloop.IOLoop
-except Exception as ex:
+except Exception:
     log.exception('Error while getting LibZMQ/PyZMQ library version')
 
 if ZMQDefaultLoop is None:

--- a/salt/utils/zeromq.py
+++ b/salt/utils/zeromq.py
@@ -19,10 +19,12 @@ except ImportError:
 
 ZMQDefaultLoop = None
 ZMQ_VERSION_INFO = (-1, -1, -1)
+LIBZMQ_VERSION_INFO = (-1, -1, -1)
 
 try:
     if zmq:
-        ZMQ_VERSION_INFO = [int(v_el) for v_el in zmq.__version__.split('.')]
+        ZMQ_VERSION_INFO = tuple([int(v_el) for v_el in zmq.__version__.split('.')])
+        LIBZMQ_VERSION_INFO = tuple([int(v_el) for v_el in zmq.zmq_version().split('.')])
         if ZMQ_VERSION_INFO[0] > 16:  # 17.0.x+ deprecates zmq's ioloops
             ZMQDefaultLoop = tornado.ioloop.IOLoop
 except Exception as ex:

--- a/salt/utils/zeromq.py
+++ b/salt/utils/zeromq.py
@@ -5,15 +5,40 @@ ZMQ-specific functions
 # Import Python libs
 from __future__ import absolute_import, print_function, unicode_literals
 
-# Import Salt libs
+import logging
+import tornado.ioloop
 from salt.exceptions import SaltSystemExit
 
-# Import 3rd-party libs
+log = logging.getLogger(__name__)
+
 try:
     import zmq
-    HAS_ZMQ = True
 except ImportError:
-    HAS_ZMQ = False
+    zmq = None
+    log.debug('ZMQ module is not found')
+
+ZMQDefaultLoop = None
+ZMQ_VERSION_INFO = (-1, -1, -1)
+
+try:
+    if zmq:
+        ZMQ_VERSION_INFO = [int(v_el) for v_el in zmq.__version__.split('.')]
+        if ZMQ_VERSION_INFO[0] > 16:  # 17.0.x+ deprecates zmq's ioloops
+            ZMQDefaultLoop = tornado.ioloop.IOLoop
+except Exception as ex:
+    log.exception(ex)
+
+if ZMQDefaultLoop is None:
+    try:
+        import zmq.eventloop.ioloop
+        # Support for ZeroMQ 13.x
+        if not hasattr(zmq.eventloop.ioloop, 'ZMQIOLoop'):
+            zmq.eventloop.ioloop.ZMQIOLoop = zmq.eventloop.ioloop.IOLoop
+        ZMQDefaultLoop = zmq.eventloop.ioloop.ZMQIOLoop
+    except ImportError:
+        ZMQDefaultLoop = tornado.ioloop.IOLoop
+
+
 
 
 def check_ipc_path_max_len(uri):

--- a/salt/utils/zeromq.py
+++ b/salt/utils/zeromq.py
@@ -40,17 +40,6 @@ if ZMQDefaultLoop is None:
     except ImportError:
         ZMQDefaultLoop = tornado.ioloop.IOLoop
 
-# Build version info
-if zmq:
-    if hasattr(zmq, 'zmq_version_info'):
-        zmq_version_info = zmq.zmq_version_info()
-    else:
-        # PyZMQ <= 2.1.9 does not have zmq_version_info, fall back to
-        # using zmq.zmq_version() and build a version info tuple.
-        zmq_version_info = tuple([int(v_el) for v_el in zmq.zmq_version().split('.')])
-else:
-    zmq_version_info = (-1, -1, -1)
-
 
 def install_zmq():
     '''

--- a/salt/utils/zeromq.py
+++ b/salt/utils/zeromq.py
@@ -39,12 +39,20 @@ if ZMQDefaultLoop is None:
         ZMQDefaultLoop = tornado.ioloop.IOLoop
 
 
+def install_zmq():
+    '''
+    While pyzmq 17 no longer needs any special integration for tornado,
+    older version still need one.
+    :return:
+    '''
+    if zmq and ZMQ_VERSION_INFO[0] < 17:
+        zmq.eventloop.ioloop.install()
 
 
 def check_ipc_path_max_len(uri):
     # The socket path is limited to 107 characters on Solaris and
     # Linux, and 103 characters on BSD-based systems.
-    if not HAS_ZMQ:
+    if zmq is None:
         return
     ipc_path_max_len = getattr(zmq, 'IPC_PATH_MAX_LEN', 103)
     if ipc_path_max_len and len(uri) > ipc_path_max_len:

--- a/salt/utils/zeromq.py
+++ b/salt/utils/zeromq.py
@@ -26,7 +26,7 @@ try:
         if ZMQ_VERSION_INFO[0] > 16:  # 17.0.x+ deprecates zmq's ioloops
             ZMQDefaultLoop = tornado.ioloop.IOLoop
 except Exception as ex:
-    log.exception('Error while getting PyZMQ library version')
+    log.exception('Error while getting LibZMQ/PyZMQ library version')
 
 if ZMQDefaultLoop is None:
     try:

--- a/tests/integration/netapi/rest_tornado/test_app.py
+++ b/tests/integration/netapi/rest_tornado/test_app.py
@@ -18,12 +18,8 @@ from tests.support.unit import skipIf
 
 # Import 3rd-party libs
 from salt.ext import six
-try:
-    import zmq
-    from zmq.eventloop.ioloop import ZMQIOLoop
-    HAS_ZMQ_IOLOOP = True
-except ImportError:
-    HAS_ZMQ_IOLOOP = False
+from salt.utils.zeromq import zmq, ZMQDefaultLoop as ZMQIOLoop
+HAS_ZMQ_IOLOOP = bool(zmq)
 
 
 class _SaltnadoIntegrationTestCase(SaltnadoTestCase):  # pylint: disable=abstract-method


### PR DESCRIPTION
### What does this PR do?

ZeroMQ 4.1.6 and PyZMQ 17.0.0 no longer need extra-integration with Tornado. If used, deprecation warning appears all around the place.

### What issues does this PR fix or reference?

- Removes code duplication for `zmq` import handling around Master/Minion and other places.
- Adds utility that handles all the discrepancies at one place. Other modules should just reuse it.
- Cleans up unnecessary checks and forgotten unused imports

### Tests written?

No
