### PR TITLE
Add extra_args to list_upgrades in yumpkg.

### DIFF
--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -972,13 +972,15 @@ def list_upgrades(refresh=True, **kwargs):
     '''
     repo_arg = _get_repo_options(**kwargs)
     exclude_arg = _get_excludes_option(**kwargs)
+    extra_args = _get_extra_options(**kwargs)
 
     if salt.utils.data.is_true(refresh):
         refresh_db(check_update=False, **kwargs)
 
     cmd = [_yum(), '--quiet']
-    cmd.extend(repo_arg)
-    cmd.extend(exclude_arg)
+    for args in (repo_arg, exclude_arg, extra_args):
+        if args:
+            cmd.extend(args)
     cmd.extend(['list', 'upgrades' if _yum() == 'dnf' else 'updates'])
     out = __salt__['cmd.run_all'](cmd,
                                   output_loglevel='trace',


### PR DESCRIPTION
Fixes #46025

### What does this PR do?
Adds support for extra_args to list_upgrades in the same way as upgrade.

### What issues does this PR fix or reference?
#46025 

### Previous Behavior
```
(salt-venv)[vagrant@localhost salt-venv]$ salt -c ./etc/salt '*' pkg.list_updates security=True
10.0.2.15:
----------
bind-libs-lite:
32:9.9.4-51.el7_4.2
bind-license:
32:9.9.4-51.el7_4.2
binutils:
2.25.1-32.base.el7_4.2

(salt-venv)[vagrant@localhost salt-venv]$ yum list updates --security | grep available
No packages needed for security; 29 packages available
```
### New Behavior
(salt-venv)[vagrant@localhost salt-venv]$ salt -c ./etc/salt '*' pkg.list_updates security=True
10.0.2.15:
    ----------

### Tests written?
No

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
