### PR TITLE
Workaroung python bug in traceback.format_exc()

### DIFF
--- a/salt/scripts.py
+++ b/salt/scripts.py
@@ -43,7 +43,12 @@ def _handle_interrupt(exc, original_exc, hardfail=False, trace=''):
 
 
 def _handle_signals(client, signum, sigframe):
-    trace = traceback.format_exc()
+    try:
+        # This raises AttributeError on Python 3.4 and 3.5 if there is no current exception.
+        # Ref: https://bugs.python.org/issue23003
+        trace = traceback.format_exc()
+    except AttributeError:
+        trace = ''
     try:
         hardcrash = client.options.hard_crash
     except (AttributeError, KeyError):


### PR DESCRIPTION
### What does this PR do?
Workaroung python bug in traceback.format_exc()
The function raises an AttributeError if there is no current exception.
https://bugs.python.org/issue23003
In this PR I catch the exception and set the result to an empty string.

### What issues does this PR fix or reference?
Fix #45956

### Previous Behavior
`salt '*' test.sleep 30` prints a traceback produced by `traceback.format_exc()` if press Ctrl-C in the middle of execution on Python 3.4 and theoretically on Python3.5.

### New Behavior
`salt '*' test.sleep 30` if press Ctrl-C in the middle of execution prints an info about how to get the job information. I.e. works as expected.

### Tests written?
No

### Commits signed with GPG?
Yes