### PR TITLE
setup.py: Work around bad code in distutils

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -522,7 +522,7 @@ class Sdist(sdist):
             self.run_command('write_salt_ssh_packaging_file')
             self.filelist.files.append(os.path.basename(PACKAGED_FOR_SALT_SSH_FILE))
 
-        if not IS_PY3 and isinstance(base_dir, unicode):  # pylint: disable=incompatible-py3-code
+        if not IS_PY3 and not isinstance(base_dir, str):
             # Work around some bad code in distutils which logs unicode paths
             # against a str format string.
             base_dir = base_dir.encode('utf-8')

--- a/setup.py
+++ b/setup.py
@@ -522,8 +522,11 @@ class Sdist(sdist):
             self.run_command('write_salt_ssh_packaging_file')
             self.filelist.files.append(os.path.basename(PACKAGED_FOR_SALT_SSH_FILE))
 
-        pkgfiles = [pkgfile if IS_PY3 else pkgfile.decode(__salt_system_encoding__) for pkgfile in files]
-        sdist.make_release_tree(self, base_dir, pkgfiles)
+        if not IS_PY3 and isinstance(base_dir, unicode):  # pylint: disable=incompatible-py3-code
+            # Work around some bad code in distutils which logs unicode paths
+            # against a str format string.
+            base_dir = base_dir.encode('utf-8')
+        sdist.make_release_tree(self, base_dir, files)
 
         # Let's generate salt/_version.py to include in the sdist tarball
         self.distribution.running_salt_sdist = True


### PR DESCRIPTION
While running an sdist, distutils logs when it creates paths. However, if the paths are unicode _and_ contain unicode code points, the log message results in a `UnicodeEncodeError` as distutils attempts to perform string replacement using a str format string and a unicode path.

Paths recently added in the test suite's files to test unicode compatibility have caused this issue to surface.

This fixes the resulting traceback by ensuring that Python 2 only passes utf-8 encoded bytestrings when making the release tree.