### PR TITLE
Allow zookeeper znode creation to not require an ACL

### DIFF
--- a/salt/states/zookeeper.py
+++ b/salt/states/zookeeper.py
@@ -158,7 +158,7 @@ def present(name, value, acls=None, ephemeral=False, sequence=False, makepath=Fa
                 value_result = new_value == value
                 changes.setdefault('new', {}).setdefault('value', new_value)
                 changes.setdefault('old', {}).setdefault('value', cur_value)
-            if not _check_acls(chk_acls, cur_acls):
+            if chk_acls and not _check_acls(chk_acls, cur_acls):
                 __salt__['zookeeper.set_acls'](name, acls, version, **connkwargs)
                 new_acls = __salt__['zookeeper.get_acls'](name, **connkwargs)
                 acl_result = _check_acls(new_acls, chk_acls)


### PR DESCRIPTION
### What does this PR do?
It allows the zookeeper znode creation state to not require an ACL.

### What issues does this PR fix or reference?
#45938

### Previous Behavior
Error on no ACL

### New Behavior
No error on no ACL