### PR TITLE
implement minimal fix for #45798

### DIFF
--- a/salt/cloud/libcloudfuncs.py
+++ b/salt/cloud/libcloudfuncs.py
@@ -25,7 +25,7 @@ try:
     )
     HAS_LIBCLOUD = True
     LIBCLOUD_VERSION_INFO = tuple([
-        int(part) for part in libcloud.__version__.replace('-', '.').replace('rc', '.').split('.')[:3]
+        int(part) for part in re.split(r'[^\d]+', libcloud.__version__)[:3]
     ])
 
 except ImportError:


### PR DESCRIPTION
### What does this PR do?
Changes the libcloud version checker to not choke on -rc release versions.

### What issues does this PR fix or reference?
This should fix #45798

### Previous Behavior
```
$ salt-cloud -V                                                         
Traceback (most recent call last):
[..]
  File "/usr/lib/python2.7/site-packages/salt/cloud/libcloudfuncs.py", line 28, in <module>
    int(part) for part in libcloud.__version__.replace('-', '.').split('.')[:3]
ValueError: invalid literal for int() with base 10: '0rc2'
```

### New Behavior
```
$ salt-cloud -V
Salt Version:
            Salt: 2018.2.0-2306-g2972204
 
Dependency Versions:
 Apache Libcloud: 2.0.0rc2
[..]
```

### Tests written?
No

### Commits signed with GPG?
No
