### PR TITLE
Fix mac_assistive module not loading

### DIFF
--- a/salt/modules/mac_assistive.py
+++ b/salt/modules/mac_assistive.py
@@ -30,7 +30,7 @@ def __virtual__():
     Only work on Mac OS
     '''
     if salt.utils.platform.is_darwin() \
-            and _LooseVersion(__grains__['osrelease']) >= '10.9':
+            and _LooseVersion(__grains__['osrelease']) >= _LooseVersion('10.9'):
         return True
     return (
         False,


### PR DESCRIPTION
### What issues does this PR fix or reference?
Fixes https://github.com/saltstack/salt/issues/46055

### Previous Behavior
module would not load and spits out error in issue report

### New Behavior
module loads

tests: current mac assistive tests are failing.