### PR TITLE
Add unicode normalization support to data/stringutils helpers

### DIFF
--- a/salt/utils/data.py
+++ b/salt/utils/data.py
@@ -111,6 +111,9 @@ def decode(data, encoding=None, errors='strict', keep=False,
             data = salt.utils.stringutils.to_unicode(
                 data, encoding, errors, normalize)
         except TypeError:
+            # to_unicode raises a TypeError when input is not a
+            # string/bytestring/bytearray. This is expected and simply means we
+            # are going to leave the value as-is.
             pass
         except UnicodeDecodeError:
             if not keep:
@@ -138,6 +141,9 @@ def decode_dict(data, encoding=None, errors='strict', keep=False,
                 key = salt.utils.stringutils.to_unicode(
                     key, encoding, errors, normalize)
             except TypeError:
+                # to_unicode raises a TypeError when input is not a
+                # string/bytestring/bytearray. This is expected and simply
+                # means we are going to leave the value as-is.
                 pass
             except UnicodeDecodeError:
                 if not keep:
@@ -160,6 +166,9 @@ def decode_dict(data, encoding=None, errors='strict', keep=False,
                 value = salt.utils.stringutils.to_unicode(
                     value, encoding, errors, normalize)
             except TypeError:
+                # to_unicode raises a TypeError when input is not a
+                # string/bytestring/bytearray. This is expected and simply
+                # means we are going to leave the value as-is.
                 pass
             except UnicodeDecodeError:
                 if not keep:
@@ -194,6 +203,9 @@ def decode_list(data, encoding=None, errors='strict', keep=False,
                 item = salt.utils.stringutils.to_unicode(
                     item, encoding, errors, normalize)
             except TypeError:
+                # to_unicode raises a TypeError when input is not a
+                # string/bytestring/bytearray. This is expected and simply
+                # means we are going to leave the value as-is.
                 pass
             except UnicodeDecodeError:
                 if not keep:
@@ -240,6 +252,9 @@ def encode(data, encoding=None, errors='strict', keep=False,
         try:
             return salt.utils.stringutils.to_bytes(data, encoding, errors)
         except TypeError:
+            # to_bytes raises a TypeError when input is not a
+            # string/bytestring/bytearray. This is expected and simply
+            # means we are going to leave the value as-is.
             pass
         except UnicodeEncodeError:
             if not keep:
@@ -265,6 +280,9 @@ def encode_dict(data, encoding=None, errors='strict', keep=False,
             try:
                 key = salt.utils.stringutils.to_bytes(key, encoding, errors)
             except TypeError:
+                # to_bytes raises a TypeError when input is not a
+                # string/bytestring/bytearray. This is expected and simply
+                # means we are going to leave the value as-is.
                 pass
             except UnicodeEncodeError:
                 if not keep:
@@ -285,6 +303,9 @@ def encode_dict(data, encoding=None, errors='strict', keep=False,
             try:
                 value = salt.utils.stringutils.to_bytes(value, encoding, errors)
             except TypeError:
+                # to_bytes raises a TypeError when input is not a
+                # string/bytestring/bytearray. This is expected and simply
+                # means we are going to leave the value as-is.
                 pass
             except UnicodeEncodeError:
                 if not keep:
@@ -318,6 +339,9 @@ def encode_list(data, encoding=None, errors='strict', keep=False,
             try:
                 item = salt.utils.stringutils.to_bytes(item, encoding, errors)
             except TypeError:
+                # to_bytes raises a TypeError when input is not a
+                # string/bytestring/bytearray. This is expected and simply
+                # means we are going to leave the value as-is.
                 pass
             except UnicodeEncodeError:
                 if not keep:

--- a/salt/utils/data.py
+++ b/salt/utils/data.py
@@ -68,7 +68,7 @@ def compare_lists(old=None, new=None):
 
 
 def decode(data, encoding=None, errors='strict', keep=False,
-           preserve_dict_class=False, preserve_tuples=False):
+           normalize=False, preserve_dict_class=False, preserve_tuples=False):
     '''
     Generic function which will decode whichever type is passed, if necessary
 
@@ -77,21 +77,39 @@ def decode(data, encoding=None, errors='strict', keep=False,
     original value to silently be returned in cases where decoding fails. This
     can be useful for cases where the data passed to this function is likely to
     contain binary blobs, such as in the case of cp.recv.
+
+    If `normalize` is True, then unicodedata.normalize() will be used to
+    normalize unicode strings down to a single code point per glyph. It is
+    recommended not to normalize unless you know what you're doing. For
+    instance, if `data` contains a dictionary, it is possible that normalizing
+    will lead to data loss because the following two strings will normalize to
+    the same value:
+
+    - u'\\u044f\\u0438\\u0306\\u0446\\u0430.txt'
+    - u'\\u044f\\u0439\\u0446\\u0430.txt'
+
+    One good use case for normalization is in the test suite. For example, on
+    some platforms such as Mac OS, os.listdir() will produce the first of the
+    two strings above, in which "й" is represented as two code points (i.e. one
+    for the base character, and one for the breve mark). Normalizing allows for
+    a more reliable test case.
     '''
     if isinstance(data, collections.Mapping):
-        return decode_dict(data, encoding, errors, keep,
+        return decode_dict(data, encoding, errors, keep, normalize,
                            preserve_dict_class, preserve_tuples)
     elif isinstance(data, list):
-        return decode_list(data, encoding, errors, keep,
+        return decode_list(data, encoding, errors, keep, normalize,
                            preserve_dict_class, preserve_tuples)
     elif isinstance(data, tuple):
-        return decode_tuple(data, encoding, errors, keep, preserve_dict_class) \
+        return decode_tuple(data, encoding, errors, keep, normalize,
+                            preserve_dict_class) \
             if preserve_tuples \
-            else decode_list(data, encoding, errors, keep,
+            else decode_list(data, encoding, errors, keep, normalize,
                              preserve_dict_class, preserve_tuples)
     else:
         try:
-            return salt.utils.stringutils.to_unicode(data, encoding, errors)
+            data = salt.utils.stringutils.to_unicode(
+                data, encoding, errors, normalize)
         except TypeError:
             pass
         except UnicodeDecodeError:
@@ -101,7 +119,8 @@ def decode(data, encoding=None, errors='strict', keep=False,
 
 
 def decode_dict(data, encoding=None, errors='strict', keep=False,
-                preserve_dict_class=False, preserve_tuples=False):
+                normalize=False, preserve_dict_class=False,
+                preserve_tuples=False):
     '''
     Decode all string values to Unicode
     '''
@@ -109,13 +128,15 @@ def decode_dict(data, encoding=None, errors='strict', keep=False,
     rv = data.__class__() if preserve_dict_class else {}
     for key, value in six.iteritems(data):
         if isinstance(key, tuple):
-            key = decode_tuple(key, encoding, errors, keep, preserve_dict_class) \
+            key = decode_tuple(key, encoding, errors, keep, normalize,
+                               preserve_dict_class) \
                 if preserve_tuples \
-                else decode_list(key, encoding, errors, keep,
+                else decode_list(key, encoding, errors, keep, normalize,
                                  preserve_dict_class, preserve_tuples)
         else:
             try:
-                key = salt.utils.stringutils.to_unicode(key, encoding, errors)
+                key = salt.utils.stringutils.to_unicode(
+                    key, encoding, errors, normalize)
             except TypeError:
                 pass
             except UnicodeDecodeError:
@@ -123,19 +144,21 @@ def decode_dict(data, encoding=None, errors='strict', keep=False,
                     raise
 
         if isinstance(value, list):
-            value = decode_list(value, encoding, errors, keep,
+            value = decode_list(value, encoding, errors, keep, normalize,
                                 preserve_dict_class, preserve_tuples)
         elif isinstance(value, tuple):
-            value = decode_tuple(value, encoding, errors, keep, preserve_dict_class) \
+            value = decode_tuple(value, encoding, errors, keep, normalize,
+                                 preserve_dict_class) \
                 if preserve_tuples \
-                else decode_list(value, encoding, errors, keep,
+                else decode_list(value, encoding, errors, keep, normalize,
                                  preserve_dict_class, preserve_tuples)
         elif isinstance(value, collections.Mapping):
-            value = decode_dict(value, encoding, errors, keep,
+            value = decode_dict(value, encoding, errors, keep, normalize,
                                 preserve_dict_class, preserve_tuples)
         else:
             try:
-                value = salt.utils.stringutils.to_unicode(value, encoding, errors)
+                value = salt.utils.stringutils.to_unicode(
+                    value, encoding, errors, normalize)
             except TypeError:
                 pass
             except UnicodeDecodeError:
@@ -147,26 +170,29 @@ def decode_dict(data, encoding=None, errors='strict', keep=False,
 
 
 def decode_list(data, encoding=None, errors='strict', keep=False,
-                preserve_dict_class=False, preserve_tuples=False):
+                normalize=False, preserve_dict_class=False,
+                preserve_tuples=False):
     '''
     Decode all string values to Unicode
     '''
     rv = []
     for item in data:
         if isinstance(item, list):
-            item = decode_list(item, encoding, errors, keep,
+            item = decode_list(item, encoding, errors, keep, normalize,
                                preserve_dict_class, preserve_tuples)
         elif isinstance(item, tuple):
-            item = decode_tuple(item, encoding, errors, keep, preserve_dict_class) \
+            item = decode_tuple(item, encoding, errors, keep, normalize,
+                                preserve_dict_class) \
                 if preserve_tuples \
-                else decode_list(item, encoding, errors, keep,
+                else decode_list(item, encoding, errors, keep, normalize,
                                  preserve_dict_class, preserve_tuples)
         elif isinstance(item, collections.Mapping):
-            item = decode_dict(item, encoding, errors, keep,
+            item = decode_dict(item, encoding, errors, keep, normalize,
                                preserve_dict_class, preserve_tuples)
         else:
             try:
-                item = salt.utils.stringutils.to_unicode(item, encoding, errors)
+                item = salt.utils.stringutils.to_unicode(
+                    item, encoding, errors, normalize)
             except TypeError:
                 pass
             except UnicodeDecodeError:
@@ -178,12 +204,14 @@ def decode_list(data, encoding=None, errors='strict', keep=False,
 
 
 def decode_tuple(data, encoding=None, errors='strict', keep=False,
-                 preserve_dict_class=False):
+                 normalize=False, preserve_dict_class=False):
     '''
     Decode all string values to Unicode
     '''
     return tuple(
-        decode_list(data, encoding, errors, keep, preserve_dict_class, True))
+        decode_list(data, encoding, errors, keep, normalize,
+                    preserve_dict_class, True)
+    )
 
 
 def encode(data, encoding=None, errors='strict', keep=False,

--- a/salt/utils/stringutils.py
+++ b/salt/utils/stringutils.py
@@ -13,6 +13,7 @@ import os
 import shlex
 import re
 import time
+import unicodedata
 
 # Import Salt libs
 from salt.utils.decorators.jinja import jinja_filter
@@ -83,31 +84,34 @@ def to_str(s, encoding=None, errors='strict'):
         raise TypeError('expected str, bytearray, or unicode')
 
 
-def to_unicode(s, encoding=None, errors='strict'):
+def to_unicode(s, encoding=None, errors='strict', normalize=False):
     '''
     Given str or unicode, return unicode (str for python 3)
     '''
+    def _normalize(s):
+        return unicodedata.normalize('NFC', s) if normalize else s
+
     if six.PY3:
         if isinstance(s, str):
-            return s
+            return _normalize(s)
         elif isinstance(s, (bytes, bytearray)):
-            return to_str(s, encoding, errors)
+            return _normalize(to_str(s, encoding, errors))
         raise TypeError('expected str, bytes, or bytearray')
     else:
         # This needs to be str and not six.string_types, since if the string is
         # already a unicode type, it does not need to be decoded (and doing so
         # will raise an exception).
         if isinstance(s, unicode):  # pylint: disable=incompatible-py3-code
-            return s
+            return _normalize(s)
         elif isinstance(s, (str, bytearray)):
             if encoding:
-                return s.decode(encoding, errors)
+                return _normalize(s.decode(encoding, errors))
             else:
                 try:
-                    return s.decode(__salt_system_encoding__, errors)
+                    return _normalize(s.decode(__salt_system_encoding__, errors))
                 except UnicodeDecodeError:
                     # Fall back to UTF-8
-                    return s.decode('utf-8', errors)
+                    return _normalize(s.decode('utf-8', errors))
         raise TypeError('expected str or bytearray')
 
 

--- a/tests/integration/states/test_file.py
+++ b/tests/integration/states/test_file.py
@@ -1185,8 +1185,8 @@ class FileTest(ModuleCase, SaltReturnAssertsMixin):
                                  source='salt://соль')
             self.assertSaltTrueReturn(ret)
             self.assertEqual(
-                sorted(salt.utils.data.decode(os.listdir(name))),
-                sorted(['foo.txt', 'спам.txt', 'яйца.txt'])
+                sorted(salt.utils.data.decode(os.listdir(name), normalize=True)),
+                sorted(['foo.txt', 'спам.txt', 'яйца.txt']),
             )
         finally:
             shutil.rmtree(name, ignore_errors=True)

--- a/tests/unit/utils/test_data.py
+++ b/tests/unit/utils/test_data.py
@@ -19,6 +19,9 @@ log = logging.getLogger(__name__)
 _b = lambda x: x.encode('utf-8')
 # Some randomized data that will not decode
 BYTES = b'\x9c\xb1\xf7\xa3'
+# This is an example of a unicode string with й constructed using two separate
+# code points. Do not modify it.
+EGGS = '\u044f\u0438\u0306\u0446\u0430'
 
 
 class DataTestCase(TestCase):
@@ -30,17 +33,18 @@ class DataTestCase(TestCase):
         True,
         False,
         None,
+        EGGS,
         BYTES,
-        [123, 456.789, _b('спам'), True, False, None, BYTES],
-        (987, 654.321, _b('яйца'), None, (True, False, BYTES)),
+        [123, 456.789, _b('спам'), True, False, None, EGGS, BYTES],
+        (987, 654.321, _b('яйца'), EGGS, None, (True, EGGS, BYTES)),
         {_b('str_key'): _b('str_val'),
          None: True,
          123: 456.789,
-         'blob': BYTES,
-         _b('subdict'): {'unicode_key': 'unicode_val',
-                         _b('tuple'): (123, 'hello', _b('world'), True, BYTES),
-                         _b('list'): [456, _b('спам'), False, BYTES]}},
-        OrderedDict([(_b('foo'), 'bar'), (123, 456), ('blob', BYTES)])
+         EGGS: BYTES,
+         _b('subdict'): {'unicode_key': EGGS,
+                         _b('tuple'): (123, 'hello', _b('world'), True, EGGS, BYTES),
+                         _b('list'): [456, _b('спам'), False, EGGS, BYTES]}},
+        OrderedDict([(_b('foo'), 'bar'), (123, 456), (EGGS, BYTES)])
     ]
 
     def test_sorted_ignorecase(self):
@@ -220,23 +224,25 @@ class DataTestCase(TestCase):
             True,
             False,
             None,
+            'яйца',
             BYTES,
-            [123, 456.789, 'спам', True, False, None, BYTES],
-            (987, 654.321, 'яйца', None, (True, False, BYTES)),
+            [123, 456.789, 'спам', True, False, None, 'яйца', BYTES],
+            (987, 654.321, 'яйца', 'яйца', None, (True, 'яйца', BYTES)),
             {'str_key': 'str_val',
              None: True,
              123: 456.789,
-             'blob': BYTES,
-             'subdict': {'unicode_key': 'unicode_val',
-                         'tuple': (123, 'hello', 'world', True, BYTES),
-                         'list': [456, 'спам', False, BYTES]}},
-            OrderedDict([('foo', 'bar'), (123, 456), ('blob', BYTES)])
+             'яйца': BYTES,
+             'subdict': {'unicode_key': 'яйца',
+                         'tuple': (123, 'hello', 'world', True, 'яйца', BYTES),
+                         'list': [456, 'спам', False, 'яйца', BYTES]}},
+            OrderedDict([('foo', 'bar'), (123, 456), ('яйца', BYTES)])
         ]
 
         ret = salt.utils.data.decode(
             self.test_data,
             encoding='utf-8',
             keep=True,
+            normalize=True,
             preserve_dict_class=True,
             preserve_tuples=True)
         self.assertEqual(ret, expected)
@@ -249,19 +255,21 @@ class DataTestCase(TestCase):
             self.test_data,
             encoding='utf-8',
             keep=False,
+            normalize=True,
             preserve_dict_class=True,
             preserve_tuples=True)
 
         # Now munge the expected data so that we get what we would expect if we
         # disable preservation of dict class and tuples
-        expected[9] = [987, 654.321, 'яйца', None, [True, False, BYTES]]
-        expected[10]['subdict']['tuple'] = [123, 'hello', 'world', True, BYTES]
-        expected[11] = {'foo': 'bar', 123: 456, 'blob': BYTES}
+        expected[10] = [987, 654.321, 'яйца', 'яйца', None, [True, 'яйца', BYTES]]
+        expected[11]['subdict']['tuple'] = [123, 'hello', 'world', True, 'яйца', BYTES]
+        expected[12] = {'foo': 'bar', 123: 456, 'яйца': BYTES}
 
         ret = salt.utils.data.decode(
             self.test_data,
             encoding='utf-8',
             keep=True,
+            normalize=True,
             preserve_dict_class=False,
             preserve_tuples=False)
         self.assertEqual(ret, expected)
@@ -275,6 +283,8 @@ class DataTestCase(TestCase):
         # Test single strings (not in a data structure)
         self.assertEqual(salt.utils.data.decode('foo'), 'foo')
         self.assertEqual(salt.utils.data.decode(_b('bar')), 'bar')
+        self.assertEqual(salt.utils.data.decode(EGGS, normalize=True), 'яйца')
+        self.assertEqual(salt.utils.data.decode(EGGS, normalize=False), EGGS)
 
         # Test binary blob
         self.assertEqual(salt.utils.data.decode(BYTES, keep=True), BYTES)
@@ -305,17 +315,18 @@ class DataTestCase(TestCase):
             True,
             False,
             None,
+            _b(EGGS),
             BYTES,
-            [123, 456.789, _b('спам'), True, False, None, BYTES],
-            (987, 654.321, _b('яйца'), None, (True, False, BYTES)),
+            [123, 456.789, _b('спам'), True, False, None, _b(EGGS), BYTES],
+            (987, 654.321, _b('яйца'), _b(EGGS), None, (True, _b(EGGS), BYTES)),
             {_b('str_key'): _b('str_val'),
              None: True,
              123: 456.789,
-             _b('blob'): BYTES,
-             _b('subdict'): {_b('unicode_key'): _b('unicode_val'),
-                             _b('tuple'): (123, _b('hello'), _b('world'), True, BYTES),
-                             _b('list'): [456, _b('спам'), False, BYTES]}},
-             OrderedDict([(_b('foo'), _b('bar')), (123, 456), (_b('blob'), BYTES)])
+             _b(EGGS): BYTES,
+             _b('subdict'): {_b('unicode_key'): _b(EGGS),
+                             _b('tuple'): (123, _b('hello'), _b('world'), True, _b(EGGS), BYTES),
+                             _b('list'): [456, _b('спам'), False, _b(EGGS), BYTES]}},
+             OrderedDict([(_b('foo'), _b('bar')), (123, 456), (_b(EGGS), BYTES)])
         ]
 
         # Both keep=True and keep=False should work because the BYTES data is
@@ -335,11 +346,12 @@ class DataTestCase(TestCase):
 
         # Now munge the expected data so that we get what we would expect if we
         # disable preservation of dict class and tuples
-        expected[9] = [987, 654.321, _b('яйца'), None, [True, False, BYTES]]
-        expected[10][_b('subdict')][_b('tuple')] = [
-            123, _b('hello'), _b('world'), True, BYTES
+        expected[10] = [987, 654.321, _b('яйца'), _b(EGGS), None, [True, _b(EGGS), BYTES]]
+        expected[11][_b('subdict')][_b('tuple')] = [
+            123, _b('hello'), _b('world'), True, _b(EGGS), BYTES
         ]
-        expected[11] = {_b('foo'): _b('bar'), 123: 456, _b('blob'): BYTES}
+        expected[12] = {_b('foo'): _b('bar'), 123: 456, _b(EGGS): BYTES}
+
         ret = salt.utils.data.encode(
             self.test_data,
             keep=True,

--- a/tests/unit/utils/test_stringutils.py
+++ b/tests/unit/utils/test_stringutils.py
@@ -14,6 +14,9 @@ from salt.ext.six.moves import builtins, range  # pylint: disable=redefined-buil
 
 UNICODE = '中国語 (繁体)'
 STR = BYTES = UNICODE.encode('utf-8')
+# This is an example of a unicode string with й constructed using two separate
+# code points. Do not modify it.
+EGGS = '\u044f\u0438\u0306\u0446\u0430'
 
 
 class StringutilsTestCase(TestCase):
@@ -91,6 +94,23 @@ class StringutilsTestCase(TestCase):
             self.assertEqual(salt.utils.stringutils.to_bytes(UNICODE, 'utf-8'), BYTES)
 
     def test_to_unicode(self):
+        self.assertEqual(
+            salt.utils.stringutils.to_unicode(
+                EGGS,
+                encoding='utf=8',
+                normalize=True
+            ),
+            'яйца'
+        )
+        self.assertNotEqual(
+            salt.utils.stringutils.to_unicode(
+                EGGS,
+                encoding='utf=8',
+                normalize=False
+            ),
+            'яйца'
+        )
+
         if six.PY3:
             self.assertEqual(salt.utils.stringutils.to_unicode('plugh'), 'plugh')
             self.assertEqual(salt.utils.stringutils.to_unicode('áéíóúý'), 'áéíóúý')


### PR DESCRIPTION
This allows for optional normalization of unicode strings, which will make testing more reliable. In Mac OS, os.listdir() will produce certain unicode glyphs using separate code points for the base character and diacritic mark, while others will use a single code point to represent the same unicode glyph. Adding this optional normalization will make our integration tests more reliable across different platforms.

```python
>>> a = u'\u0065\u0301'
>>> b = u'\u00e9'
>>> print(a)
é
>>> print(b)
é
>>> a == b
False
>>> import salt.utils.stringutils
>>> salt.utils.stringutils.to_unicode(a, normalize=True) == b
True
>>>
```