### PR TITLE
Broken Fedora cloud image link fixed

### DIFF
--- a/doc/topics/tutorials/cloud_controller.rst
+++ b/doc/topics/tutorials/cloud_controller.rst
@@ -192,7 +192,7 @@ Fedora Linux
 ~~~~~~~~~~~~
 
 Images for Fedora Linux can be found here:
-http://fedoraproject.org/en/get-fedora#clouds
+https://alt.fedoraproject.org/cloud
 
 openSUSE
 ~~~~~~~~


### PR DESCRIPTION
http://fedoraproject.org/en/get-fedora#clouds
is broken. 
New url is: https://alt.fedoraproject.org/cloud/

### What does this PR do?

- Fixes a web link.

### What issues does this PR fix or reference?

http://fedoraproject.org/en/get-fedora#clouds
is broken. 
New url is: https://alt.fedoraproject.org/cloud/

### Tests written?

Yes

### Commits signed with GPG?

Yes