### PR TITLE
Pin tornado version in requirements file

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -3,6 +3,6 @@ msgpack-python>0.3
 PyYAML
 MarkupSafe
 requests>=1.0.0
-tornado>=4.2.1
+tornado>=4.2.1,<5.0
 # Required by Tornado to handle threads stuff.
 futures>=2.0


### PR DESCRIPTION
tornado needs to be >= 4.2.1, but less that 5.0.

Tornado 5.0 is introducing backwards-incompatible changes. Therefore, we need to pin the version of tornado in base.txt until we can fix supporting Tornado 5.0 in Salt.

Refs #45790
