### PR TITLE
Patch salt.utils call for test_parse_localectl test

### DIFF
--- a/tests/unit/modules/test_localemod.py
+++ b/tests/unit/modules/test_localemod.py
@@ -609,6 +609,7 @@ class LocalemodTestCase(TestCase, LoaderModuleMockMixin):
                 patch('os.listdir', MagicMock(return_value=['en_US'])):
             assert localemod.gen_locale('en_US.UTF-8', verbose=True) == ret
 
+    @patch('salt.utils.path.which', MagicMock(return_value="/usr/bin/localctl"))
     def test_parse_localectl(self):
         localectl_out = ('   System Locale: LANG=en_US.UTF-8\n'
                          '                  LANGUAGE=en_US:en\n'


### PR DESCRIPTION
### What does this PR do?
Fixes test `unit.modules.test_localemod.LocalemodTestCase.test_parse_localectl` on macosx

### Previous Behavior
Test failing on MacOSX:

```
=====================================================  Overall Tests Report  ======================================================
*** unit.modules.test_localemod.LocalemodTestCase.test_parse_localectl Tests  *****************************************************
 --------  Tests with Errors  -----------------------------------------------------------------------------------------------------
   -> unit.modules.test_localemod.LocalemodTestCase.test_parse_localectl  .........................................................
       Traceback (most recent call last):
         File "/testing/tests/unit/modules/test_localemod.py", line 618, in test_parse_localectl
           ret = localemod._localectl_status()['system_locale']
         File "/testing/salt/modules/localemod.py", line 71, in _localectl_status
           raise CommandExecutionError('Unable to find "localectl"')
       salt.exceptions.CommandExecutionError: Unable to find "localectl"
   ................................................................................................................................
 ----------------------------------------------------------------------------------------------------------------------------------
```

### New Behavior
tests pass

