### PR TITLE
[oxygen] swap scheduler to use datetime objects

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -2158,6 +2158,8 @@ class Minion(MinionBase):
             self.schedule.disable_job(name, persist)
         elif func == 'postpone_job':
             self.schedule.postpone_job(name, data)
+        elif func == 'skip_job':
+            self.schedule.skip_job(name, data)
         elif func == 'reload':
             self.schedule.reload(schedule)
         elif func == 'list':

--- a/salt/modules/schedule.py
+++ b/salt/modules/schedule.py
@@ -983,6 +983,8 @@ def postpone_job(name,
     ret = {'comment': [],
            'result': True}
 
+    time_fmt = kwargs.get('time_fmt', '%Y-%m-%dT%H:%M:%S')
+
     if not name:
         ret['comment'] = 'Job name is required.'
         ret['result'] = False
@@ -1082,6 +1084,8 @@ def skip_job(name, current_time, **kwargs):
 
     ret = {'comment': [],
            'result': True}
+
+    time_fmt = kwargs.get('time_fmt', '%Y-%m-%dT%H:%M:%S')
 
     if not name:
         ret['comment'] = 'Job name is required.'

--- a/salt/modules/schedule.py
+++ b/salt/modules/schedule.py
@@ -983,8 +983,6 @@ def postpone_job(name,
     ret = {'comment': [],
            'result': True}
 
-    time_fmt = kwargs.get('time_fmt', '%Y-%m-%dT%H:%M:%S')
-
     if not name:
         ret['comment'] = 'Job name is required.'
         ret['result'] = False
@@ -1084,8 +1082,6 @@ def skip_job(name, current_time, **kwargs):
 
     ret = {'comment': [],
            'result': True}
-
-    time_fmt = kwargs.get('time_fmt', '%Y-%m-%dT%H:%M:%S')
 
     if not name:
         ret['comment'] = 'Job name is required.'

--- a/salt/modules/schedule.py
+++ b/salt/modules/schedule.py
@@ -966,7 +966,7 @@ def postpone_job(name,
     Postpone a job in the minion's schedule
 
     Current time and new time should be in date string format,
-    %Y-%m-%dT%H:%M:%S.
+    default value is %Y-%m-%dT%H:%M:%S.
 
     .. versionadded:: Oxygen
 
@@ -1028,11 +1028,13 @@ def postpone_job(name,
             event_data = {'name': name,
                           'time': current_time,
                           'new_time': new_time,
+                          'time_fmt': time_fmt,
                           'func': 'postpone_job'}
         elif name in list_(show_all=True, where='pillar', return_yaml=False):
             event_data = {'name': name,
                           'time': current_time,
                           'new_time': new_time,
+                          'time_fmt': time_fmt,
                           'where': 'pillar',
                           'func': 'postpone_job'}
         else:
@@ -1066,7 +1068,7 @@ def skip_job(name, current_time, **kwargs):
     Skip a job in the minion's schedule at specified time.
 
     Time to skip should be specified as date string format,
-    %Y-%m-%dT%H:%M:%S.
+    default value is %Y-%m-%dT%H:%M:%S.
 
     .. versionadded:: Oxygen
 
@@ -1107,10 +1109,12 @@ def skip_job(name, current_time, **kwargs):
         if name in list_(show_all=True, where='opts', return_yaml=False):
             event_data = {'name': name,
                           'time': current_time,
+                          'time_fmt': time_fmt,
                           'func': 'skip_job'}
         elif name in list_(show_all=True, where='pillar', return_yaml=False):
             event_data = {'name': name,
                           'time': current_time,
+                          'time_fmt': time_fmt,
                           'where': 'pillar',
                           'func': 'skip_job'}
         else:

--- a/salt/modules/schedule.py
+++ b/salt/modules/schedule.py
@@ -979,6 +979,7 @@ def postpone_job(name,
         salt '*' schedule.postpone_job job current_time new_time time_fmt='%Y-%m-%dT%H:%M:%S'
     '''
 
+    time_fmt = kwargs.get('time_fmt') or '%Y-%m-%dT%H:%M:%S'
     ret = {'comment': [],
            'result': True}
 
@@ -994,8 +995,7 @@ def postpone_job(name,
     else:
         try:
             # Validate date string
-            datetime.datetime.strptime(current_time,
-                                       '%Y-%m-%dT%H:%M:%S')
+            datetime.datetime.strptime(current_time, time_fmt)
         except (TypeError, ValueError):
             log.error('Date string could not be parsed: %s, %s',
                       new_time, time_fmt)
@@ -1011,8 +1011,7 @@ def postpone_job(name,
     else:
         try:
             # Validate date string
-            datetime.datetime.strptime(new_time,
-                                       '%Y-%m-%dT%H:%M:%S')
+            datetime.datetime.strptime(new_time, time_fmt)
         except (TypeError, ValueError):
             log.error('Date string could not be parsed: %s, %s',
                       new_time, time_fmt)
@@ -1077,6 +1076,7 @@ def skip_job(name, current_time, **kwargs):
 
         salt '*' schedule.skip_job job time
     '''
+    time_fmt = kwargs.get('time_fmt') or '%Y-%m-%dT%H:%M:%S'
 
     ret = {'comment': [],
            'result': True}
@@ -1091,8 +1091,7 @@ def skip_job(name, current_time, **kwargs):
     else:
         # Validate date string
         try:
-            datetime.datetime.strptime(current_time,
-                                       '%Y-%m-%dT%H:%M:%S')
+            datetime.datetime.strptime(current_time, time_fmt)
         except (TypeError, ValueError):
             log.error('Date string could not be parsed: %s, %s',
                       current_time, time_fmt)

--- a/salt/modules/schedule.py
+++ b/salt/modules/schedule.py
@@ -965,8 +965,8 @@ def postpone_job(name,
     '''
     Postpone a job in the minion's schedule
 
-    Current time and new time should be specified specified date string format,
-    default format is %Y-%m-%dT%H:%M:%S.
+    Current time and new time should be in date string format,
+    %Y-%m-%dT%H:%M:%S.
 
     .. versionadded:: Oxygen
 
@@ -982,8 +982,6 @@ def postpone_job(name,
     ret = {'comment': [],
            'result': True}
 
-    time_fmt = kwargs.get('time_fmt', '%Y-%m-%dT%H:%M:%S')
-
     if not name:
         ret['comment'] = 'Job name is required.'
         ret['result'] = False
@@ -995,8 +993,9 @@ def postpone_job(name,
         return ret
     else:
         try:
-            current_time = datetime.datetime.strptime(current_time,
-                                                      time_fmt)
+            # Validate date string
+            datetime.datetime.strptime(current_time,
+                                       '%Y-%m-%dT%H:%M:%S')
         except (TypeError, ValueError):
             log.error('Date string could not be parsed: %s, %s',
                       new_time, time_fmt)
@@ -1011,8 +1010,9 @@ def postpone_job(name,
         return ret
     else:
         try:
-            new_time = datetime.datetime.strptime(new_time,
-                                                  time_fmt)
+            # Validate date string
+            datetime.datetime.strptime(new_time,
+                                       '%Y-%m-%dT%H:%M:%S')
         except (TypeError, ValueError):
             log.error('Date string could not be parsed: %s, %s',
                       new_time, time_fmt)
@@ -1066,8 +1066,8 @@ def skip_job(name, current_time, **kwargs):
     '''
     Skip a job in the minion's schedule at specified time.
 
-    Time to skip should be specified as specified date string format,
-    default format is %Y-%m-%dT%H:%M:%S.
+    Time to skip should be specified as date string format,
+    %Y-%m-%dT%H:%M:%S.
 
     .. versionadded:: Oxygen
 
@@ -1081,8 +1081,6 @@ def skip_job(name, current_time, **kwargs):
     ret = {'comment': [],
            'result': True}
 
-    time_fmt = kwargs.get('time_fmt', '%Y-%m-%dT%H:%M:%S')
-
     if not name:
         ret['comment'] = 'Job name is required.'
         ret['result'] = False
@@ -1091,9 +1089,10 @@ def skip_job(name, current_time, **kwargs):
         ret['comment'] = 'Job time is required.'
         ret['result'] = False
     else:
+        # Validate date string
         try:
-            current_time = datetime.datetime.strptime(current_time,
-                                                      time_fmt)
+            datetime.datetime.strptime(current_time,
+                                       '%Y-%m-%dT%H:%M:%S'))
         except (TypeError, ValueError):
             log.error('Date string could not be parsed: %s, %s',
                       current_time, time_fmt)

--- a/salt/modules/schedule.py
+++ b/salt/modules/schedule.py
@@ -1092,7 +1092,7 @@ def skip_job(name, current_time, **kwargs):
         # Validate date string
         try:
             datetime.datetime.strptime(current_time,
-                                       '%Y-%m-%dT%H:%M:%S'))
+                                       '%Y-%m-%dT%H:%M:%S')
         except (TypeError, ValueError):
             log.error('Date string could not be parsed: %s, %s',
                       current_time, time_fmt)

--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -134,8 +134,7 @@ class Schedule(object):
 
     def _get_schedule(self,
                       include_opts=True,
-                      include_pillar=True,
-                      include_hidden=True):
+                      include_pillar=True):
         '''
         Return the schedule data structure
         '''
@@ -458,13 +457,11 @@ class Schedule(object):
         List the current schedule items
         '''
         if where == 'pillar':
-            schedule = self._get_schedule(include_opts=False,
-                                          include_hidden=False)
+            schedule = self._get_schedule(include_opts=False)
         elif where == 'opts':
-            schedule = self._get_schedule(include_pillar=False,
-                                          include_hidden=False)
+            schedule = self._get_schedule(include_pillar=False)
         else:
-            schedule = self._get_schedule(include_hidden=False)
+            schedule = self._get_schedule()
 
         # Fire the complete event back along with the list of schedule
         evt = salt.utils.event.get_event('minion', opts=self.opts, listen=False)
@@ -821,6 +818,7 @@ class Schedule(object):
                    'skip_during_range']
         for job, data in six.iteritems(schedule):
 
+            log.debug('=== job %s data %s ===', job, data)
             # Clear out _skip_reason from previous runs
             if '_skip_reason' in data:
                 del data['_skip_reason']

--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -1266,6 +1266,7 @@ class Schedule(object):
                                     data['_skipped'] = True
                                 else:
                                     run = True
+                                log.debug('=== run %s ===', run)
                             else:
                                 log.error(
                                     'schedule.handle_func: Invalid range, end '
@@ -1342,6 +1343,7 @@ class Schedule(object):
                             run = False
 
             if not run:
+                log.debug('=== run is false, continue now %s ===', now)
                 continue
 
             miss_msg = ''

--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -134,7 +134,8 @@ class Schedule(object):
 
     def _get_schedule(self,
                       include_opts=True,
-                      include_pillar=True):
+                      include_pillar=True,
+                      include_hidden=True):
         '''
         Return the schedule data structure
         '''
@@ -457,11 +458,13 @@ class Schedule(object):
         List the current schedule items
         '''
         if where == 'pillar':
-            schedule = self._get_schedule(include_opts=False)
+            schedule = self._get_schedule(include_opts=False,
+                                          include_hidden=False)
         elif where == 'opts':
-            schedule = self._get_schedule(include_pillar=False)
+            schedule = self._get_schedule(include_pillar=False,
+                                          include_hidden=False)
         else:
-            schedule = self._get_schedule()
+            schedule = self._get_schedule(include_hidden=False)
 
         # Fire the complete event back along with the list of schedule
         evt = salt.utils.event.get_event('minion', opts=self.opts, listen=False)
@@ -1140,7 +1143,6 @@ class Schedule(object):
                     seconds = (data['_splay'] - now).total_seconds()
 
             if '_seconds' in data:
-                log.debug('==== seconds %s ====', seconds)
                 if seconds <= 0:
                     run = True
             elif 'when' in data and data['_run']:
@@ -1246,8 +1248,8 @@ class Schedule(object):
                             # after the skip_during_range is over
                             if 'run_after_skip_range' in data and \
                                data['run_after_skip_range']:
-                                if 'run_explicit' not in data:
-                                    data['run_explicit'] = []
+                                if '_run_explicit' not in data:
+                                    data['_run_explicit'] = []
                                 # Add a run_explicit for immediately after the
                                 # skip_during_range ends
                                 _run_immediate = (end + datetime.timedelta(seconds=self.opts['loop_interval'])).strftime('%Y-%m-%dT%H:%M:%S')

--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -1245,8 +1245,8 @@ class Schedule(object):
                             # after the skip_during_range is over
                             if 'run_after_skip_range' in data and \
                                data['run_after_skip_range']:
-                                if '_run_explicit' not in data:
-                                    data['_run_explicit'] = []
+                                if 'run_explicit' not in data:
+                                    data['run_explicit'] = []
                                 # Add a run_explicit for immediately after the
                                 # skip_during_range ends
                                 _run_immediate = (end + datetime.timedelta(seconds=self.opts['loop_interval'])).strftime('%Y-%m-%dT%H:%M:%S')

--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -1106,10 +1106,8 @@ class Schedule(object):
                     # Get next time frame for a "cron" job if it has been never
                     # executed before or already executed in the past.
                     try:
-                        data['_next_fire_time'] = int(
-                            croniter.croniter(data['cron'], now).get_next())
-                        data['_next_scheduled_fire_time'] = int(
-                            croniter.croniter(data['cron'], now).get_next())
+                        data['_next_fire_time'] = croniter.croniter(data['cron'], now).get_next(datetime.datetime)
+                        data['_next_scheduled_fire_time'] = croniter.croniter(data['cron'], now).get_next(datetime.datetime)
                     except (ValueError, KeyError):
                         log.error('Invalid cron string. Ignoring')
                         continue
@@ -1118,16 +1116,14 @@ class Schedule(object):
                     # configured loop interval is longer than that, we should
                     # shorten it to get our job executed closer to the beginning
                     # of desired time.
-                    interval = now - data['_next_fire_time']
+                    interval = (now - data['_next_fire_time']).total_seconds()
                     if interval >= 60 and interval < self.loop_interval:
                         self.loop_interval = interval
 
             else:
                 continue
 
-            log.debug('=== _next_fire_time %s now %s ===', data['_next_fire_time'], now)
-            seconds = (data['_next_fire_time'] - now).seconds
-            log.debug('=== seconds %s ===', seconds)
+            seconds = (data['_next_fire_time'] - now).total_seconds()
 
             if 'splay' in data:
                 # Got "splay" configured, make decision to run a job based on that
@@ -1277,7 +1273,6 @@ class Schedule(object):
                                     data['_skipped'] = True
                                 else:
                                     run = True
-                                log.debug('=== run %s ===', run)
                             else:
                                 log.error(
                                     'schedule.handle_func: Invalid range, end '
@@ -1318,7 +1313,6 @@ class Schedule(object):
                             run = True
 
             if not run:
-                log.debug('=== run is false, continue now %s ===', now)
                 continue
 
             miss_msg = ''

--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -1266,7 +1266,6 @@ class Schedule(object):
                                     data['_skipped'] = True
                                 else:
                                     run = True
-                                log.debug('=== run %s ===', run)
                             else:
                                 log.error(
                                     'schedule.handle_func: Invalid range, end '
@@ -1343,7 +1342,6 @@ class Schedule(object):
                             run = False
 
             if not run:
-                log.debug('=== run is false, continue now %s ===', now)
                 continue
 
             miss_msg = ''

--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -850,7 +850,7 @@ class Schedule(object):
                     log.error('Missing python-dateutil. '
                               'Ignoring until.')
                 else:
-                    until__ = dateutil_parser.parse(data['until'])
+                    until = dateutil_parser.parse(data['until'])
 
                     if until <= now:
                         log.debug(
@@ -864,7 +864,7 @@ class Schedule(object):
                     log.error('Missing python-dateutil. '
                               'Ignoring after.')
                 else:
-                    after__ = dateutil_parser.parse(data['after'])
+                    after = dateutil_parser.parse(data['after'])
 
                     if after >= now:
                         log.debug(

--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -1140,6 +1140,7 @@ class Schedule(object):
                     seconds = (data['_splay'] - now).total_seconds()
 
             if '_seconds' in data:
+                log.debug('==== seconds %s ====', seconds)
                 if seconds <= 0:
                     run = True
             elif 'when' in data and data['_run']:

--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -818,7 +818,6 @@ class Schedule(object):
                    'skip_during_range']
         for job, data in six.iteritems(schedule):
 
-            log.debug('=== job %s data %s ===', job, data)
             # Clear out _skip_reason from previous runs
             if '_skip_reason' in data:
                 del data['_skip_reason']

--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -1054,7 +1054,7 @@ class Schedule(object):
                             continue
                         _when = self.opts['pillar']['whens'][data['when']]
                         try:
-                            when__ = dateutil_parser.parse(_when)
+                            when = dateutil_parser.parse(_when)
                         except ValueError:
                             log.error('Invalid date string. Ignoring')
                             continue
@@ -1065,18 +1065,17 @@ class Schedule(object):
                             continue
                         _when = self.opts['grains']['whens'][data['when']]
                         try:
-                            when__ = dateutil_parser.parse(_when)
+                            when = dateutil_parser.parse(_when)
                         except ValueError:
                             log.error('Invalid date string. Ignoring')
                             continue
                     else:
                         try:
-                            when__ = dateutil_parser.parse(data['when'])
+                            when = dateutil_parser.parse(data['when'])
                         except ValueError:
                             log.error('Invalid date string. Ignoring')
                             continue
 
-                    when = when__
                     if when < now - datetime.timedelta(seconds=self.opts['loop_interval']) and \
                             not data.get('_run', False) and \
                             not run and \

--- a/tests/integration/scheduler/test_eval.py
+++ b/tests/integration/scheduler/test_eval.py
@@ -24,11 +24,11 @@ import salt.utils.schedule
 
 from salt.modules.test import ping as ping
 
-try:
-    import croniter  # pylint: disable=W0611
-    HAS_CRONITER = True
-except ImportError:
-    HAS_CRONITER = False
+#try:
+#    import croniter  # pylint: disable=W0611
+#    HAS_CRONITER = True
+#except ImportError:
+HAS_CRONITER = False
 
 log = logging.getLogger(__name__)
 ROOT_DIR = os.path.join(integration.TMP, 'schedule-unit-tests')
@@ -201,6 +201,7 @@ class SchedulerEvalTest(ModuleCase, SaltReturnAssertsMixin):
         # Evaluate 1 second at the run time
         self.schedule.eval(now=run_time)
         ret = self.schedule.job_status('job1')
+        log.debug('=== ret %s ===', ret)
         self.assertEqual(ret['_last_run'], run_time)
 
     def test_eval_once_loop_interval(self):

--- a/tests/integration/scheduler/test_eval.py
+++ b/tests/integration/scheduler/test_eval.py
@@ -24,11 +24,11 @@ import salt.utils.schedule
 
 from salt.modules.test import ping as ping
 
-#try:
-#    import croniter  # pylint: disable=W0611
-#    HAS_CRONITER = True
-#except ImportError:
-HAS_CRONITER = False
+try:
+    import croniter  # pylint: disable=W0611
+    HAS_CRONITER = True
+except ImportError:
+    AS_CRONITER = False
 
 log = logging.getLogger(__name__)
 ROOT_DIR = os.path.join(integration.TMP, 'schedule-unit-tests')

--- a/tests/integration/scheduler/test_eval.py
+++ b/tests/integration/scheduler/test_eval.py
@@ -307,13 +307,11 @@ class SchedulerEvalTest(ModuleCase, SaltReturnAssertsMixin):
         run_time = dateutil_parser.parse('11/29/2017 2:00pm')
         self.schedule.eval(now=run_time)
         ret = self.schedule.job_status('job_eval_after')
-        log.debug('=== ret %s ===', ret)
 
         # eval at 3:00pm, will run.
         run_time = dateutil_parser.parse('11/29/2017 3:00pm')
         self.schedule.eval(now=run_time)
         ret = self.schedule.job_status('job_eval_after')
-        log.debug('=== ret %s ===', ret)
         self.assertEqual(ret['_last_run'], run_time)
 
         # eval at 4:00pm, will run.

--- a/tests/integration/scheduler/test_eval.py
+++ b/tests/integration/scheduler/test_eval.py
@@ -201,7 +201,6 @@ class SchedulerEvalTest(ModuleCase, SaltReturnAssertsMixin):
         # Evaluate 1 second at the run time
         self.schedule.eval(now=run_time)
         ret = self.schedule.job_status('job1')
-        log.debug('=== ret %s ===', ret)
         self.assertEqual(ret['_last_run'], run_time)
 
     def test_eval_once_loop_interval(self):

--- a/tests/integration/scheduler/test_eval.py
+++ b/tests/integration/scheduler/test_eval.py
@@ -25,11 +25,11 @@ import salt.utils.schedule
 
 from salt.modules.test import ping as ping
 
-#try:
-#    import croniter  # pylint: disable=W0611
-#    HAS_CRONITER = True
-#except ImportError:
-HAS_CRONITER = False
+try:
+    import croniter  # pylint: disable=W0611
+    HAS_CRONITER = True
+except ImportError:
+    AS_CRONITER = False
 
 log = logging.getLogger(__name__)
 ROOT_DIR = os.path.join(integration.TMP, 'schedule-unit-tests')

--- a/tests/integration/scheduler/test_eval.py
+++ b/tests/integration/scheduler/test_eval.py
@@ -3,6 +3,7 @@
 # Import Python libs
 from __future__ import absolute_import
 import copy
+import datetime
 import logging
 import os
 import random
@@ -24,11 +25,11 @@ import salt.utils.schedule
 
 from salt.modules.test import ping as ping
 
-try:
-    import croniter  # pylint: disable=W0611
-    HAS_CRONITER = True
-except ImportError:
-    HAS_CRONITER = False
+#try:
+#    import croniter  # pylint: disable=W0611
+#    HAS_CRONITER = True
+#except ImportError:
+HAS_CRONITER = False
 
 log = logging.getLogger(__name__)
 ROOT_DIR = os.path.join(integration.TMP, 'schedule-unit-tests')
@@ -67,8 +68,8 @@ class SchedulerEvalTest(ModuleCase, SaltReturnAssertsMixin):
             }
           }
         }
-        run_time2 = int(time.mktime(dateutil_parser.parse('11/29/2017 4:00pm').timetuple()))
-        run_time1 = run_time2 - 1
+        run_time2 = dateutil_parser.parse('11/29/2017 4:00pm')
+        run_time1 = run_time2 - datetime.timedelta(seconds=1)
 
         # Add the job to the scheduler
         self.schedule.opts.update(job)
@@ -98,8 +99,8 @@ class SchedulerEvalTest(ModuleCase, SaltReturnAssertsMixin):
             }
           }
         }
-        run_time1 = int(time.mktime(dateutil_parser.parse('11/29/2017 4:00pm').timetuple()))
-        run_time2 = int(time.mktime(dateutil_parser.parse('11/29/2017 5:00pm').timetuple()))
+        run_time1 = dateutil_parser.parse('11/29/2017 4:00pm')
+        run_time2 = dateutil_parser.parse('11/29/2017 5:00pm')
 
         # Add the job to the scheduler
         self.schedule.opts.update(job)
@@ -130,16 +131,16 @@ class SchedulerEvalTest(ModuleCase, SaltReturnAssertsMixin):
         LOOP_INTERVAL = random.randint(30, 59)
         self.schedule.opts['loop_interval'] = LOOP_INTERVAL
 
-        run_time2 = int(time.mktime(dateutil_parser.parse('11/29/2017 4:00pm').timetuple()))
+        run_time2 = dateutil_parser.parse('11/29/2017 4:00pm')
 
         # Add the job to the scheduler
         self.schedule.opts.update(job)
 
         # Evaluate 1 second at the run time
-        self.schedule.eval(now=run_time2 + LOOP_INTERVAL)
+        self.schedule.eval(now=run_time2 + datetime.timedelta(seconds=LOOP_INTERVAL))
 
         ret = self.schedule.job_status('job1')
-        self.assertEqual(ret['_last_run'], run_time2 + LOOP_INTERVAL)
+        self.assertEqual(ret['_last_run'], run_time2 + datetime.timedelta(seconds=LOOP_INTERVAL))
 
     def test_eval_multiple_whens_loop_interval(self):
         '''
@@ -160,21 +161,21 @@ class SchedulerEvalTest(ModuleCase, SaltReturnAssertsMixin):
         LOOP_INTERVAL = random.randint(30, 59)
         self.schedule.opts['loop_interval'] = LOOP_INTERVAL
 
-        run_time1 = int(time.mktime(dateutil_parser.parse('11/29/2017 4:00pm').timetuple()))
-        run_time2 = int(time.mktime(dateutil_parser.parse('11/29/2017 5:00pm').timetuple()))
+        run_time1 = dateutil_parser.parse('11/29/2017 4:00pm') + datetime.timedelta(seconds=LOOP_INTERVAL)
+        run_time2 = dateutil_parser.parse('11/29/2017 5:00pm') + datetime.timedelta(seconds=LOOP_INTERVAL)
 
         # Add the job to the scheduler
         self.schedule.opts.update(job)
 
         # Evaluate 1 second at the run time
-        self.schedule.eval(now=run_time1 + LOOP_INTERVAL)
+        self.schedule.eval(now=run_time1)
         ret = self.schedule.job_status('job1')
-        self.assertEqual(ret['_last_run'], run_time1 + LOOP_INTERVAL)
+        self.assertEqual(ret['_last_run'], run_time1)
 
         # Evaluate 1 second at the run time
-        self.schedule.eval(now=run_time2 + LOOP_INTERVAL)
+        self.schedule.eval(now=run_time2)
         ret = self.schedule.job_status('job1')
-        self.assertEqual(ret['_last_run'], run_time2 + LOOP_INTERVAL)
+        self.assertEqual(ret['_last_run'], run_time2)
 
     def test_eval_once(self):
         '''
@@ -188,7 +189,7 @@ class SchedulerEvalTest(ModuleCase, SaltReturnAssertsMixin):
             }
           }
         }
-        run_time = int(time.mktime(dateutil_parser.parse('12/13/2017 1:00pm').timetuple()))
+        run_time = dateutil_parser.parse('12/13/2017 1:00pm')
 
         # Add the job to the scheduler
         self.schedule.opts.update(job)
@@ -196,6 +197,7 @@ class SchedulerEvalTest(ModuleCase, SaltReturnAssertsMixin):
         # Evaluate 1 second at the run time
         self.schedule.eval(now=run_time)
         ret = self.schedule.job_status('job1')
+        log.debug('=== ret %s ===', ret)
         self.assertEqual(ret['_last_run'], run_time)
 
     def test_eval_once_loop_interval(self):
@@ -215,7 +217,7 @@ class SchedulerEvalTest(ModuleCase, SaltReturnAssertsMixin):
         self.schedule.opts['loop_interval'] = LOOP_INTERVAL
 
         # Run the job at the right plus LOOP_INTERVAL
-        run_time = int(time.mktime(dateutil_parser.parse('12/13/2017 1:00:{0}pm'.format(LOOP_INTERVAL)).timetuple()))
+        run_time = dateutil_parser.parse('12/13/2017 1:00:{0}pm'.format(LOOP_INTERVAL))
 
         # Add the job to the scheduler
         self.schedule.opts.update(job)
@@ -242,7 +244,7 @@ class SchedulerEvalTest(ModuleCase, SaltReturnAssertsMixin):
         # Add the job to the scheduler
         self.schedule.opts.update(job)
 
-        run_time = int(time.mktime(dateutil_parser.parse('11/29/2017 4:00pm').timetuple()))
+        run_time = dateutil_parser.parse('11/29/2017 4:00pm')
         with patch('croniter.croniter.get_next', MagicMock(return_value=run_time)):
             self.schedule.eval(now=run_time)
 
@@ -269,7 +271,7 @@ class SchedulerEvalTest(ModuleCase, SaltReturnAssertsMixin):
         # Add the job to the scheduler
         self.schedule.opts.update(job)
 
-        run_time = int(time.mktime(dateutil_parser.parse('11/29/2017 4:00pm').timetuple()))
+        run_time = dateutil_parser.parse('11/29/2017 4:00pm')
         with patch('croniter.croniter.get_next', MagicMock(return_value=run_time)):
             self.schedule.eval(now=run_time)
 

--- a/tests/integration/scheduler/test_eval.py
+++ b/tests/integration/scheduler/test_eval.py
@@ -29,7 +29,7 @@ try:
     import croniter  # pylint: disable=W0611
     HAS_CRONITER = True
 except ImportError:
-    AS_CRONITER = False
+    HAS_CRONITER = False
 
 log = logging.getLogger(__name__)
 ROOT_DIR = os.path.join(integration.TMP, 'schedule-unit-tests')
@@ -217,7 +217,7 @@ class SchedulerEvalTest(ModuleCase, SaltReturnAssertsMixin):
         self.schedule.opts['loop_interval'] = LOOP_INTERVAL
 
         # Run the job at the right plus LOOP_INTERVAL
-        run_time = dateutil_parser.parse('12/13/2017 1:00:{0}pm'.format(LOOP_INTERVAL))
+        run_time = dateutil_parser.parse('12/13/2017 1:00pm') + datetime.timedelta(seconds=LOOP_INTERVAL)
 
         # Add the job to the scheduler
         self.schedule.opts.update(job)

--- a/tests/integration/scheduler/test_eval.py
+++ b/tests/integration/scheduler/test_eval.py
@@ -71,6 +71,7 @@ class SchedulerEvalTest(ModuleCase, SaltReturnAssertsMixin):
         run_time1 = run_time2 - datetime.timedelta(seconds=1)
 
         # Add the job to the scheduler
+        self.schedule.opts['schedule'] = {}
         self.schedule.opts.update(job)
 
         # Evaluate 1 second before the run time
@@ -102,6 +103,7 @@ class SchedulerEvalTest(ModuleCase, SaltReturnAssertsMixin):
         run_time2 = dateutil_parser.parse('11/29/2017 5:00pm')
 
         # Add the job to the scheduler
+        self.schedule.opts['schedule'] = {}
         self.schedule.opts.update(job)
 
         # Evaluate run time1
@@ -133,6 +135,7 @@ class SchedulerEvalTest(ModuleCase, SaltReturnAssertsMixin):
         run_time2 = dateutil_parser.parse('11/29/2017 4:00pm')
 
         # Add the job to the scheduler
+        self.schedule.opts['schedule'] = {}
         self.schedule.opts.update(job)
 
         # Evaluate 1 second at the run time
@@ -164,6 +167,7 @@ class SchedulerEvalTest(ModuleCase, SaltReturnAssertsMixin):
         run_time2 = dateutil_parser.parse('11/29/2017 5:00pm') + datetime.timedelta(seconds=LOOP_INTERVAL)
 
         # Add the job to the scheduler
+        self.schedule.opts['schedule'] = {}
         self.schedule.opts.update(job)
 
         # Evaluate 1 second at the run time
@@ -191,6 +195,7 @@ class SchedulerEvalTest(ModuleCase, SaltReturnAssertsMixin):
         run_time = dateutil_parser.parse('12/13/2017 1:00pm')
 
         # Add the job to the scheduler
+        self.schedule.opts['schedule'] = {}
         self.schedule.opts.update(job)
 
         # Evaluate 1 second at the run time
@@ -218,6 +223,7 @@ class SchedulerEvalTest(ModuleCase, SaltReturnAssertsMixin):
         run_time = dateutil_parser.parse('12/13/2017 1:00pm') + datetime.timedelta(seconds=LOOP_INTERVAL)
 
         # Add the job to the scheduler
+        self.schedule.opts['schedule'] = {}
         self.schedule.opts.update(job)
 
         # Evaluate at the run time
@@ -240,6 +246,7 @@ class SchedulerEvalTest(ModuleCase, SaltReturnAssertsMixin):
         }
 
         # Add the job to the scheduler
+        self.schedule.opts['schedule'] = {}
         self.schedule.opts.update(job)
 
         run_time = dateutil_parser.parse('11/29/2017 4:00pm')
@@ -267,6 +274,7 @@ class SchedulerEvalTest(ModuleCase, SaltReturnAssertsMixin):
         self.schedule.opts['loop_interval'] = LOOP_INTERVAL
 
         # Add the job to the scheduler
+        self.schedule.opts['schedule'] = {}
         self.schedule.opts.update(job)
 
         run_time = dateutil_parser.parse('11/29/2017 4:00pm')
@@ -283,7 +291,7 @@ class SchedulerEvalTest(ModuleCase, SaltReturnAssertsMixin):
         '''
         job = {
           'schedule': {
-            'job1': {
+            'job_eval_after': {
               'function': 'test.ping',
               'hours': '1',
               'until': '11/29/2017 5:00pm'
@@ -292,29 +300,32 @@ class SchedulerEvalTest(ModuleCase, SaltReturnAssertsMixin):
         }
 
         # Add job to schedule
+        self.schedule.delete_job('job_eval_after')
         self.schedule.opts.update(job)
 
         # eval at 2:00pm to prime, simulate minion start up.
         run_time = dateutil_parser.parse('11/29/2017 2:00pm')
         self.schedule.eval(now=run_time)
-        ret = self.schedule.job_status('job1')
+        ret = self.schedule.job_status('job_eval_after')
+        log.debug('=== ret %s ===', ret)
 
         # eval at 3:00pm, will run.
         run_time = dateutil_parser.parse('11/29/2017 3:00pm')
         self.schedule.eval(now=run_time)
-        ret = self.schedule.job_status('job1')
+        ret = self.schedule.job_status('job_eval_after')
+        log.debug('=== ret %s ===', ret)
         self.assertEqual(ret['_last_run'], run_time)
 
         # eval at 4:00pm, will run.
         run_time = dateutil_parser.parse('11/29/2017 4:00pm')
         self.schedule.eval(now=run_time)
-        ret = self.schedule.job_status('job1')
+        ret = self.schedule.job_status('job_eval_after')
         self.assertEqual(ret['_last_run'], run_time)
 
         # eval at 5:00pm, will not run
         run_time = dateutil_parser.parse('11/29/2017 5:00pm')
         self.schedule.eval(now=run_time)
-        ret = self.schedule.job_status('job1')
+        ret = self.schedule.job_status('job_eval_after')
         self.assertEqual(ret['_skip_reason'], 'until_passed')
         self.assertEqual(ret['_skipped_time'], run_time)
 
@@ -334,6 +345,7 @@ class SchedulerEvalTest(ModuleCase, SaltReturnAssertsMixin):
         }
 
         # Add job to schedule
+        self.schedule.delete_job('job1')
         self.schedule.opts.update(job)
 
         # eval at 2:00pm to prime, simulate minion start up.

--- a/tests/integration/scheduler/test_eval.py
+++ b/tests/integration/scheduler/test_eval.py
@@ -7,7 +7,6 @@ import datetime
 import logging
 import os
 import random
-import time
 
 import dateutil.parser as dateutil_parser
 

--- a/tests/integration/scheduler/test_eval.py
+++ b/tests/integration/scheduler/test_eval.py
@@ -28,7 +28,7 @@ try:
     import croniter  # pylint: disable=W0611
     HAS_CRONITER = True
 except ImportError:
-    AS_CRONITER = False
+    HAS_CRONITER = False
 
 log = logging.getLogger(__name__)
 ROOT_DIR = os.path.join(integration.TMP, 'schedule-unit-tests')

--- a/tests/integration/scheduler/test_postpone.py
+++ b/tests/integration/scheduler/test_postpone.py
@@ -3,6 +3,7 @@
 # Import Python libs
 from __future__ import absolute_import
 import copy
+import datetime
 import logging
 import os
 import time
@@ -61,7 +62,7 @@ class SchedulerPostponeTest(ModuleCase, SaltReturnAssertsMixin):
         }
 
         # 11/29/2017 4pm
-        run_time = int(time.mktime(dateutil_parser.parse('11/29/2017 4:00pm').timetuple()))
+        run_time = dateutil_parser.parse('11/29/2017 4:00pm')
 
         # 5 minute delay
         delay = 300
@@ -71,7 +72,7 @@ class SchedulerPostponeTest(ModuleCase, SaltReturnAssertsMixin):
 
         # Postpone the job by 5 minutes
         self.schedule.postpone_job('job1', {'time': run_time,
-                                            'new_time': run_time + delay})
+                                            'new_time': run_time + datetime.timedelta(seconds=delay)})
 
         # Run at the original time
         self.schedule.eval(now=run_time)
@@ -79,11 +80,11 @@ class SchedulerPostponeTest(ModuleCase, SaltReturnAssertsMixin):
         self.assertNotIn('_last_run', ret)
 
         # Run 5 minutes later
-        self.schedule.eval(now=run_time + delay)
+        self.schedule.eval(now=run_time + datetime.timedelta(seconds=delay))
         ret = self.schedule.job_status('job1')
-        self.assertEqual(ret['_last_run'], run_time + delay)
+        self.assertEqual(ret['_last_run'], run_time + datetime.timedelta(seconds=delay))
 
         # Run 6 minutes later
-        self.schedule.eval(now=run_time + delay + 1)
+        self.schedule.eval(now=run_time + datetime.timedelta(seconds=delay + 1))
         ret = self.schedule.job_status('job1')
-        self.assertEqual(ret['_last_run'], run_time + delay)
+        self.assertEqual(ret['_last_run'], run_time + datetime.timedelta(seconds=delay))

--- a/tests/integration/scheduler/test_postpone.py
+++ b/tests/integration/scheduler/test_postpone.py
@@ -70,8 +70,8 @@ class SchedulerPostponeTest(ModuleCase, SaltReturnAssertsMixin):
         self.schedule.opts.update(job)
 
         # Postpone the job by 5 minutes
-        self.schedule.postpone_job('job1', {'time': run_time,
-                                            'new_time': run_time + datetime.timedelta(seconds=delay)})
+        self.schedule.postpone_job('job1', {'time': run_time.strftime('%Y-%m-%dT%H:%M:%S'),
+                                            'new_time': (run_time + datetime.timedelta(seconds=delay)).strftime('%Y-%m-%dT%H:%M:%S')})
 
         # Run at the original time
         self.schedule.eval(now=run_time)

--- a/tests/integration/scheduler/test_postpone.py
+++ b/tests/integration/scheduler/test_postpone.py
@@ -6,7 +6,6 @@ import copy
 import datetime
 import logging
 import os
-import time
 
 import dateutil.parser as dateutil_parser
 

--- a/tests/integration/scheduler/test_skip.py
+++ b/tests/integration/scheduler/test_skip.py
@@ -64,7 +64,8 @@ class SchedulerSkipTest(ModuleCase, SaltReturnAssertsMixin):
         self.schedule.opts.update(job)
 
         run_time = dateutil_parser.parse('11/29/2017 4:00pm')
-        self.schedule.skip_job('job1', {'time': run_time.strftime('%Y-%m-%dT%H:%M:%S')})
+        self.schedule.skip_job('job1', {'time': run_time.strftime('%Y-%m-%dT%H:%M:%S'),
+                                        'time_fmt': '%Y-%m-%dT%H:%M:%S'})
 
         # Run 11/29/2017 at 4pm
         self.schedule.eval(now=run_time)

--- a/tests/integration/scheduler/test_skip.py
+++ b/tests/integration/scheduler/test_skip.py
@@ -5,7 +5,6 @@ from __future__ import absolute_import
 import copy
 import logging
 import os
-import time
 
 import dateutil.parser as dateutil_parser
 

--- a/tests/integration/scheduler/test_skip.py
+++ b/tests/integration/scheduler/test_skip.py
@@ -105,13 +105,11 @@ class SchedulerSkipTest(ModuleCase, SaltReturnAssertsMixin):
         run_time = dateutil_parser.parse('11/29/2017 1:30pm')
         self.schedule.eval(now=run_time)
         ret = self.schedule.job_status('job1')
-        log.debug('=== ret %s ===', ret)
 
         # eval at 2:30pm, will not run during range.
         run_time = dateutil_parser.parse('11/29/2017 2:30pm')
         self.schedule.eval(now=run_time)
         ret = self.schedule.job_status('job1')
-        log.debug('=== ret %s ===', ret)
         self.assertNotIn('_last_run', ret)
         self.assertEqual(ret['_skip_reason'], 'in_skip_range')
         self.assertEqual(ret['_skipped_time'], run_time)
@@ -120,7 +118,6 @@ class SchedulerSkipTest(ModuleCase, SaltReturnAssertsMixin):
         run_time = dateutil_parser.parse('11/29/2017 3:30pm')
         self.schedule.eval(now=run_time)
         ret = self.schedule.job_status('job1')
-        log.debug('=== ret %s ===', ret)
         self.assertEqual(ret['_last_run'], run_time)
 
     def test_skip_during_range_global(self):

--- a/tests/integration/scheduler/test_skip.py
+++ b/tests/integration/scheduler/test_skip.py
@@ -105,11 +105,13 @@ class SchedulerSkipTest(ModuleCase, SaltReturnAssertsMixin):
         run_time = dateutil_parser.parse('11/29/2017 1:30pm')
         self.schedule.eval(now=run_time)
         ret = self.schedule.job_status('job1')
+        log.debug('=== ret %s ===', ret)
 
         # eval at 2:30pm, will not run during range.
         run_time = dateutil_parser.parse('11/29/2017 2:30pm')
         self.schedule.eval(now=run_time)
         ret = self.schedule.job_status('job1')
+        log.debug('=== ret %s ===', ret)
         self.assertNotIn('_last_run', ret)
         self.assertEqual(ret['_skip_reason'], 'in_skip_range')
         self.assertEqual(ret['_skipped_time'], run_time)
@@ -118,6 +120,7 @@ class SchedulerSkipTest(ModuleCase, SaltReturnAssertsMixin):
         run_time = dateutil_parser.parse('11/29/2017 3:30pm')
         self.schedule.eval(now=run_time)
         ret = self.schedule.job_status('job1')
+        log.debug('=== ret %s ===', ret)
         self.assertEqual(ret['_last_run'], run_time)
 
     def test_skip_during_range_global(self):

--- a/tests/integration/scheduler/test_skip.py
+++ b/tests/integration/scheduler/test_skip.py
@@ -63,7 +63,7 @@ class SchedulerSkipTest(ModuleCase, SaltReturnAssertsMixin):
         # Add job to schedule
         self.schedule.opts.update(job)
 
-        run_time = int(time.mktime(dateutil_parser.parse('11/29/2017 4:00pm').timetuple()))
+        run_time = dateutil_parser.parse('11/29/2017 4:00pm')
         self.schedule.skip_job('job1', {'time': run_time})
 
         # Run 11/29/2017 at 4pm
@@ -74,7 +74,7 @@ class SchedulerSkipTest(ModuleCase, SaltReturnAssertsMixin):
         self.assertEqual(ret['_skipped_time'], run_time)
 
         # Run 11/29/2017 at 5pm
-        run_time = int(time.mktime(dateutil_parser.parse('11/29/2017 5:00pm').timetuple()))
+        run_time = dateutil_parser.parse('11/29/2017 5:00pm')
         self.schedule.eval(now=run_time)
         ret = self.schedule.job_status('job1')
         self.assertEqual(ret['_last_run'], run_time)
@@ -100,22 +100,25 @@ class SchedulerSkipTest(ModuleCase, SaltReturnAssertsMixin):
         self.schedule.opts.update(job)
 
         # eval at 1:30pm to prime.
-        run_time = int(time.mktime(dateutil_parser.parse('11/29/2017 1:30pm').timetuple()))
+        run_time = dateutil_parser.parse('11/29/2017 1:30pm')
         self.schedule.eval(now=run_time)
         ret = self.schedule.job_status('job1')
+        log.debug('=== ret %s ===', ret)
 
         # eval at 2:30pm, will not run during range.
-        run_time = int(time.mktime(dateutil_parser.parse('11/29/2017 2:30pm').timetuple()))
+        run_time = dateutil_parser.parse('11/29/2017 2:30pm')
         self.schedule.eval(now=run_time)
         ret = self.schedule.job_status('job1')
+        log.debug('=== ret %s ===', ret)
         self.assertNotIn('_last_run', ret)
         self.assertEqual(ret['_skip_reason'], 'in_skip_range')
         self.assertEqual(ret['_skipped_time'], run_time)
 
         # eval at 3:30pm, will run.
-        run_time = int(time.mktime(dateutil_parser.parse('11/29/2017 3:30pm').timetuple()))
+        run_time = dateutil_parser.parse('11/29/2017 3:30pm')
         self.schedule.eval(now=run_time)
         ret = self.schedule.job_status('job1')
+        log.debug('=== ret %s ===', ret)
         self.assertEqual(ret['_last_run'], run_time)
 
     def test_skip_during_range_global(self):
@@ -139,12 +142,12 @@ class SchedulerSkipTest(ModuleCase, SaltReturnAssertsMixin):
         self.schedule.opts.update(job)
 
         # eval at 1:30pm to prime.
-        run_time = int(time.mktime(dateutil_parser.parse('11/29/2017 1:30pm').timetuple()))
+        run_time = dateutil_parser.parse('11/29/2017 1:30pm')
         self.schedule.eval(now=run_time)
         ret = self.schedule.job_status('job1')
 
         # eval at 2:30pm, will not run during range.
-        run_time = int(time.mktime(dateutil_parser.parse('11/29/2017 2:30pm').timetuple()))
+        run_time = dateutil_parser.parse('11/29/2017 2:30pm')
         self.schedule.eval(now=run_time)
         ret = self.schedule.job_status('job1')
         self.assertNotIn('_last_run', ret)
@@ -152,7 +155,7 @@ class SchedulerSkipTest(ModuleCase, SaltReturnAssertsMixin):
         self.assertEqual(ret['_skipped_time'], run_time)
 
         # eval at 3:30pm, will run.
-        run_time = int(time.mktime(dateutil_parser.parse('11/29/2017 3:30pm').timetuple()))
+        run_time = dateutil_parser.parse('11/29/2017 3:30pm')
         self.schedule.eval(now=run_time)
         ret = self.schedule.job_status('job1')
         self.assertEqual(ret['_last_run'], run_time)
@@ -179,7 +182,7 @@ class SchedulerSkipTest(ModuleCase, SaltReturnAssertsMixin):
         self.schedule.opts.update(job)
 
         # eval at 2:30pm, will not run during range.
-        run_time = int(time.mktime(dateutil_parser.parse('11/29/2017 2:30pm').timetuple()))
+        run_time = dateutil_parser.parse('11/29/2017 2:30pm')
         self.schedule.eval(now=run_time)
         ret = self.schedule.job_status('job1')
         self.assertNotIn('_last_run', ret)
@@ -187,7 +190,7 @@ class SchedulerSkipTest(ModuleCase, SaltReturnAssertsMixin):
         self.assertEqual(ret['_skipped_time'], run_time)
 
         # eval at 3:00:01pm, will run.
-        run_time = int(time.mktime(dateutil_parser.parse('11/29/2017 3:00:01pm').timetuple()))
+        run_time = dateutil_parser.parse('11/29/2017 3:00:01pm')
         self.schedule.eval(now=run_time)
         ret = self.schedule.job_status('job1')
         self.assertEqual(ret['_last_run'], run_time)

--- a/tests/integration/scheduler/test_skip.py
+++ b/tests/integration/scheduler/test_skip.py
@@ -60,10 +60,11 @@ class SchedulerSkipTest(ModuleCase, SaltReturnAssertsMixin):
         }
 
         # Add job to schedule
+        self.schedule.opts['schedule'] = {}
         self.schedule.opts.update(job)
 
         run_time = dateutil_parser.parse('11/29/2017 4:00pm')
-        self.schedule.skip_job('job1', {'time': run_time})
+        self.schedule.skip_job('job1', {'time': run_time.strftime('%Y-%m-%dT%H:%M:%S')})
 
         # Run 11/29/2017 at 4pm
         self.schedule.eval(now=run_time)
@@ -96,6 +97,7 @@ class SchedulerSkipTest(ModuleCase, SaltReturnAssertsMixin):
         }
 
         # Add job to schedule
+        self.schedule.opts['schedule'] = {}
         self.schedule.opts.update(job)
 
         # eval at 1:30pm to prime.
@@ -135,6 +137,7 @@ class SchedulerSkipTest(ModuleCase, SaltReturnAssertsMixin):
         }
 
         # Add job to schedule
+        self.schedule.opts['schedule'] = {}
         self.schedule.opts.update(job)
 
         # eval at 1:30pm to prime.
@@ -175,6 +178,7 @@ class SchedulerSkipTest(ModuleCase, SaltReturnAssertsMixin):
         }
 
         # Add job to schedule
+        self.schedule.opts['schedule'] = {}
         self.schedule.opts.update(job)
 
         # eval at 2:30pm, will not run during range.

--- a/tests/integration/scheduler/test_skip.py
+++ b/tests/integration/scheduler/test_skip.py
@@ -103,13 +103,11 @@ class SchedulerSkipTest(ModuleCase, SaltReturnAssertsMixin):
         run_time = dateutil_parser.parse('11/29/2017 1:30pm')
         self.schedule.eval(now=run_time)
         ret = self.schedule.job_status('job1')
-        log.debug('=== ret %s ===', ret)
 
         # eval at 2:30pm, will not run during range.
         run_time = dateutil_parser.parse('11/29/2017 2:30pm')
         self.schedule.eval(now=run_time)
         ret = self.schedule.job_status('job1')
-        log.debug('=== ret %s ===', ret)
         self.assertNotIn('_last_run', ret)
         self.assertEqual(ret['_skip_reason'], 'in_skip_range')
         self.assertEqual(ret['_skipped_time'], run_time)
@@ -118,7 +116,6 @@ class SchedulerSkipTest(ModuleCase, SaltReturnAssertsMixin):
         run_time = dateutil_parser.parse('11/29/2017 3:30pm')
         self.schedule.eval(now=run_time)
         ret = self.schedule.job_status('job1')
-        log.debug('=== ret %s ===', ret)
         self.assertEqual(ret['_last_run'], run_time)
 
     def test_skip_during_range_global(self):

--- a/tests/unit/utils/test_schedule.py
+++ b/tests/unit/utils/test_schedule.py
@@ -6,6 +6,7 @@
 # Import python libs
 from __future__ import absolute_import, print_function, unicode_literals
 import copy
+import datetime
 import os
 import time
 
@@ -294,7 +295,7 @@ class ScheduleTestCase(TestCase):
         '''
         self.schedule.opts.update({'pillar': {'schedule': {}}})
         self.schedule.opts.update({'schedule': {'testjob': {'function': 'test.true', 'seconds': 60}}})
-        now = int(time.time())
+        now = datetime.datetime.now()
         self.schedule.eval()
         self.assertTrue(self.schedule.opts['schedule']['testjob']['_next_fire_time'] > now)
 
@@ -305,9 +306,9 @@ class ScheduleTestCase(TestCase):
         self.schedule.opts.update({'pillar': {'schedule': {}}})
         self.schedule.opts.update(
             {'schedule': {'testjob': {'function': 'test.true', 'seconds': 60, 'splay': 5}}})
-        now = int(time.time())
+        now = datetime.datetime.now()
         self.schedule.eval()
-        self.assertTrue(self.schedule.opts['schedule']['testjob']['_splay'] - now > 60)
+        self.assertTrue((self.schedule.opts['schedule']['testjob']['_splay'] - now).total_seconds() > 60)
 
     @skipIf(not _CRON_SUPPORTED, 'croniter module not installed')
     def test_eval_schedule_cron(self):
@@ -316,7 +317,7 @@ class ScheduleTestCase(TestCase):
         '''
         self.schedule.opts.update({'pillar': {'schedule': {}}})
         self.schedule.opts.update({'schedule': {'testjob': {'function': 'test.true', 'cron': '* * * * *'}}})
-        now = int(time.time())
+        now = datetime.datetime.now()
         self.schedule.eval()
         self.assertTrue(self.schedule.opts['schedule']['testjob']['_next_fire_time'] > now)
 

--- a/tests/unit/utils/test_schedule.py
+++ b/tests/unit/utils/test_schedule.py
@@ -8,7 +8,6 @@ from __future__ import absolute_import, print_function, unicode_literals
 import copy
 import datetime
 import os
-import time
 
 # Import Salt Testing Libs
 from tests.support.unit import skipIf, TestCase


### PR DESCRIPTION
### What does this PR do?
Swap scheduler to use `datetime` objects

### What issues does this PR fix or reference?
N/A

### Previous Behavior
Internally the scheduler was using `int` values based on the seconds.

### New Behavior
This change switched everything over to using `datetime` objects internally. This change will make some future planned enhancements a lot easier.
 
### Tests written?
Yes.  Existing tests run as expected.

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
