### PR TITLE
fix kernel subpackages install bug

### DIFF
--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -1556,8 +1556,8 @@ def install(name=None,
                             break
                     else:
                         if pkgname is not None:
-                            if re.match('kernel(-.+)?', pkgname):
-                                # kernel and its subpackages support multiple
+                            if re.match('^kernel(|-devel)$', pkgname):
+                                # kernel and kernel-devel support multiple
                                 # installs as their paths do not conflict.
                                 # Performing a yum/dnf downgrade will be a
                                 # no-op so just do an install instead. It will


### PR DESCRIPTION
### What does this PR do?
ONLY kernel and kernel-devel support multiple installs as their paths do not conflict.
NOT kernel and its subpackages

### What issues does this PR fix or reference?
No

### Tests written?
No

### Commits signed with GPG?
No

### EXAMPLE
`[root@x ~]# yum downgrade kernel kernel-devel kernel-headers kernel-firmware
Loaded plugins: fastestmirror
Setting up Downgrade Process
Loading mirror speeds from cached hostfile
Package kernel-2.6.32-431.29.2.x86_64 is allowed multiple installs, skipping
Package kernel-devel-2.6.32-431.29.2.x86_64 is allowed multiple installs, skipping
Resolving Dependencies
--> Running transaction check
---> Package kernel-firmware.noarch 0:2.6.32-696.16.1.el6 will be a downgrade
---> Package kernel-firmware.noarch 0:2.6.32-696.18.7.el6 will be erased
---> Package kernel-headers.x86_64 0:2.6.32-696.16.1.el6 will be a downgrade
---> Package kernel-headers.x86_64 0:2.6.32-696.18.7.el6 will be erased
--> Finished Dependency Resolution

Dependencies Resolved

==================================================================================================================================================================================
Package Arch Version Repository Size
Downgrading:
kernel-firmware noarch 2.6.32-696.16.1.el6 centos-updates 29 M
kernel-headers x86_64 2.6.32-696.16.1.el6 centos-updates 4.5 M

Transaction Summary
Downgrade 2 Package(s)

Total download size: 33 M
Is this ok [y/N]:`
