### PR TITLE
Add ability to specify a startup script id in a profile.

### DIFF
--- a/salt/cloud/clouds/vultrpy.py
+++ b/salt/cloud/clouds/vultrpy.py
@@ -109,6 +109,20 @@ def avail_locations(conn=None):
     return _query('regions/list')
 
 
+def avail_scripts(conn=None):
+    '''
+    return available startup scripts
+    '''
+    return _query('startupscript/list')
+
+
+def list_scripts(conn=None, call=None):
+    '''
+    return list of Startup Scripts
+    '''
+    return avail_scripts()
+
+
 def avail_sizes(conn=None):
     '''
     Return available sizes ("plans" in VultrSpeak)
@@ -236,6 +250,15 @@ def create(vm_):
         'enable_private_network', vm_, __opts__, search_global=False, default=False,
     )
 
+    startup_script = config.get_cloud_config_value(
+        'startup_script_id', vm_, __opts__, search_global=False, default=None,
+    )
+
+    if startup_script and str(startup_script) not in avail_scripts():
+        log.error('Your Vultr account does not have a startup script with ID {0}'.format(startup_script))
+        return False
+
+
     if private_networking is not None:
         if not isinstance(private_networking, bool):
             raise SaltCloudConfigError("'private_networking' should be a boolean value.")
@@ -276,6 +299,8 @@ def create(vm_):
         'hostname': vm_['name'],
         'enable_private_network': enable_private_network,
     }
+    if startup_script:
+        kwargs['SCRIPTID'] = startup_script
 
     log.info('Creating Cloud VM %s', vm_['name'])
 

--- a/salt/cloud/clouds/vultrpy.py
+++ b/salt/cloud/clouds/vultrpy.py
@@ -31,6 +31,26 @@ Set up the cloud profile at ``/etc/salt/cloud.profiles`` or
       size: 95
       enable_private_network: True
 
+This driver also supports Vultr's `startup script` feature.  You can list startup
+scripts in your account with
+
+.. code-block:: bash
+
+    salt-cloud -f list_scripts <name of vultr provider>
+
+That list will include the IDs of the scripts in your account.  Thus, if you
+have a script called 'setup-networking' with an ID of 493234 you can specify
+that startup script in a profile like so:
+
+.. code-block:: yaml
+
+    nyc-2gb-1cpu-ubuntu-17-04:
+      location: 1
+      provider: my-vultr-config
+      image: 223
+      size: 13
+      startup_script_id: 493234
+
 '''
 
 # Import python libs

--- a/salt/cloud/clouds/vultrpy.py
+++ b/salt/cloud/clouds/vultrpy.py
@@ -249,6 +249,9 @@ def show_instance(name, call=None):
 
 
 def _lookup_vultrid(which_key, availkey, keyname):
+    '''
+    Helper function to retrieve a Vultr ID
+    '''
     if DETAILS == {}:
         _cache_provider_details()
 
@@ -275,9 +278,8 @@ def create(vm_):
     )
 
     if startup_script and str(startup_script) not in avail_scripts():
-        log.error('Your Vultr account does not have a startup script with ID {0}'.format(startup_script))
+        log.error('Your Vultr account does not have a startup script with ID %s', str(startup_script))
         return False
-
 
     if private_networking is not None:
         if not isinstance(private_networking, bool):


### PR DESCRIPTION
### What does this PR do?

Vultr, the cloud provider, has a feature called `startup scripts`.  These are scripts that you create inside the Vultr control panel (or via the API) to be run when a new VM instance is launched.

The Vultr salt-cloud driver did not support specifying a startup script to run.  This PR adds this feature as well as the ability to list scripts in your account so you can find out what ID to use in your cloud profile.

### Tests written?

No

### Commits signed with GPG?

Yes
