### PR TITLE
Fix memory leak

### DIFF
--- a/salt/transport/ipc.py
+++ b/salt/transport/ipc.py
@@ -559,6 +559,11 @@ class IPCMessagePublisher(object):
                     io_loop=self.io_loop
                 )
             self.streams.add(stream)
+
+            def discard_after_closed():
+                self.streams.discard(stream)
+
+            stream.set_close_callback(discard_after_closed)
         except Exception as exc:
             log.error('IPC streaming error: {0}'.format(exc))
 


### PR DESCRIPTION
### What does this PR do?

Fixes memory leak which is caused by a combination of several following reasons.
1. There is a possibility of not discarding `stream` object in `streams` set. Previous code only discards `stream` when [this code](https://github.com/kstreee/salt/blob/6dd2044dbd000586fbedd86471b1b60945ae2194/salt/transport/ipc.py#L523-L532) raises exception.
2. `LocalClient` (especially, subscribing patterns of `event` object in the method `run_job`, and it's internal methods) doesn't consume data of the master's publish channel.
3. Cause of 2, when a master has a client of a tornado version of salt api, master's `IPCMessagePublisher` streams' sending data queue keep having data to send to the client even the client never read data from a master.

We checked every use points of `LocalClient`, but the salt api case is the only problematic point. (Personally, I think the `LocalClient` should be fixed to use the publish channel appropriately, but it is a quite huge and risky work to be done..)


### What issues does this PR fix or reference?

N/A

### Previous Behavior

Leaks memory.

### New Behavior

1. Discards `stream` object in a set `streams` proactively to prevent a possibility of not calling the method `discard`.
2. Generates and deletes the dictionary `saltclients` based on tornado web object lifecycle to prevent the memory leak.

### Tests written?

No, but following is a memory usage graph for a month. After applied this pr to our salt master, mem uses are stabilized. Before it, we restarted regularly to prevent a failure by the memory leak.

![screen shot 2018-02-19 at 1 46 39 pm](https://user-images.githubusercontent.com/374702/36362841-6943c78e-157b-11e8-9f64-b02f9c18a1ee.png)



### Commits signed with GPG?

Yes