### PR TITLE
[DOC] Put https link to the formulas doc page

### DIFF
--- a/doc/topics/development/conventions/formulas.rst
+++ b/doc/topics/development/conventions/formulas.rst
@@ -1245,7 +1245,7 @@ A sample skeleton for the ``README.rst`` file:
     .. note::
 
         See the full `Salt Formulas installation and usage instructions
-        <http://docs.saltstack.com/en/latest/topics/development/conventions/formulas.html>`_.
+        <https://docs.saltstack.com/en/latest/topics/development/conventions/formulas.html>`_.
 
     Available states
     ================


### PR DESCRIPTION
### What issues does this PR fix or reference?
It is always better to have `https` links instead of `http` if available for generic security reasons.
Corresponding PR has been submitted to saltstack-formulas/template-formula#13.

FYI @aboe76 

### Commits signed with GPG?
Yes
