### PR TITLE
Handle IPv6 scope parameter in resolv.conf

### DIFF
--- a/salt/utils/dns.py
+++ b/salt/utils/dns.py
@@ -797,6 +797,8 @@ def parse_resolv(src='/etc/resolv.conf'):
     '''
 
     nameservers = []
+    ip4_nameservers = []
+    ip6_nameservers = []
     search = []
     sortlist = []
     domain = ''
@@ -815,10 +817,20 @@ def parse_resolv(src='/etc/resolv.conf'):
                         lambda x: x[0] not in ('#', ';'), arg))
 
                     if directive == 'nameserver':
+                        # Split the scope (interface) if it is present
+                        addr, scope = arg[0].split('%', 1) if '%' in arg[0] else (arg[0], '')
                         try:
-                            ip_addr = ipaddress.ip_address(arg[0])
+                            ip_addr = ipaddress.ip_address(addr)
+                            version = ip_addr.version
+                            # Rejoin scope after address validation
+                            if scope:
+                                ip_addr = '%'.join((str(ip_addr), scope))
                             if ip_addr not in nameservers:
                                 nameservers.append(ip_addr)
+                            if version == 4 and ip_addr not in ip4_nameservers:
+                                ip4_nameservers.append(ip_addr)
+                            elif version == 6 and ip_addr not in ip6_nameservers:
+                                ip6_nameservers.append(ip_addr)
                         except ValueError as exc:
                             log.error('{0}: {1}'.format(src, exc))
                     elif directive == 'domain':
@@ -870,8 +882,8 @@ def parse_resolv(src='/etc/resolv.conf'):
 
         return {
             'nameservers':     nameservers,
-            'ip4_nameservers': [ip for ip in nameservers if ip.version == 4],
-            'ip6_nameservers': [ip for ip in nameservers if ip.version == 6],
+            'ip4_nameservers': ip4_nameservers,
+            'ip6_nameservers': ip6_nameservers,
             'sortlist':        [ip.with_netmask for ip in sortlist],
             'domain':          domain,
             'search':          search,

--- a/tests/unit/grains/test_core.py
+++ b/tests/unit/grains/test_core.py
@@ -39,6 +39,7 @@ IP4_ADD2 = '10.0.0.2'
 IP6_LOCAL = '::1'
 IP6_ADD1 = '2001:4860:4860::8844'
 IP6_ADD2 = '2001:4860:4860::8888'
+IP6_ADD_SCOPE = 'fe80::6238:e0ff:fe06:3f6b%enp2s0'
 OS_RELEASE_DIR = os.path.join(os.path.dirname(__file__), "os-releases")
 
 
@@ -673,15 +674,18 @@ PATCHLEVEL = 3
         '''
         resolv_mock = {'domain': '', 'sortlist': [], 'nameservers':
                    [ipaddress.IPv4Address(IP4_ADD1),
-                    ipaddress.IPv6Address(IP6_ADD1)], 'ip4_nameservers':
+                    ipaddress.IPv6Address(IP6_ADD1),
+                    IP6_ADD_SCOPE], 'ip4_nameservers':
                    [ipaddress.IPv4Address(IP4_ADD1)],
                    'search': ['test.saltstack.com'], 'ip6_nameservers':
-                   [ipaddress.IPv6Address(IP6_ADD1)], 'options': []}
+                   [ipaddress.IPv6Address(IP6_ADD1),
+                    IP6_ADD_SCOPE], 'options': []}
         ret = {'dns': {'domain': '', 'sortlist': [], 'nameservers':
-                       [IP4_ADD1, IP6_ADD1], 'ip4_nameservers':
+                       [IP4_ADD1, IP6_ADD1,
+                        IP6_ADD_SCOPE], 'ip4_nameservers':
                        [IP4_ADD1], 'search': ['test.saltstack.com'],
-                       'ip6_nameservers': [IP6_ADD1], 'options':
-                       []}}
+                       'ip6_nameservers': [IP6_ADD1, IP6_ADD_SCOPE],
+                       'options': []}}
         self._run_dns_test(resolv_mock, ret)
 
     def _run_dns_test(self, resolv_mock, ret):


### PR DESCRIPTION
### What does this PR do?

Handle IPv6 scope parameter in `resolv.conf`.

### What issues does this PR fix or reference?

Recent versions of resolv.conf append the device name to IPv6 nameserver
IP address entries as a scoping parameter for that nameserver.  See for
example, https://bugzilla.redhat.com/show_bug.cgi?id=1093294#c4.

### Previous Behavior

```bash
# cat /etc/resolv.conf
domain saltdomain
nameserver 192.168.1.1
nameserver fe80::6238:e0ff:fe06:3f6b%enp2s0
```
```yaml
# salt-call --local grains.item dns
[ERROR   ] /etc/resolv.conf: 'fe80::6238:e0ff:fe06:3f6b%enp2s0' does not appear to be an IPv4 or IPv6 address
local:
    ----------
    dns:
        ----------
        domain:
            saltdomain
        ip4_nameservers:
            - 192.168.1.1
        ip6_nameservers:
        nameservers:
            - 192.168.1.1
        options:
        search:
        sortlist:
```

### New Behavior

```yaml
# salt-call --local grains.item dns
local:
    ----------
    dns:
        ----------
        domain:
            saltdomain
        ip4_nameservers:
            - 192.168.1.1
        ip6_nameservers:
            - fe80::6238:e0ff:fe06:3f6b%enp2s0
        nameservers:
            - 192.168.1.1
            - fe80::6238:e0ff:fe06:3f6b%enp2s0
        options:
        search:
        sortlist:
```

### Tests written?

Yes

### Commits signed with GPG?

Yes