### PR TITLE
In OpenRC exec module, make sure to ignore retcode on status

### DIFF
--- a/salt/modules/gentoo_service.py
+++ b/salt/modules/gentoo_service.py
@@ -37,9 +37,9 @@ def __virtual__():
             'only available on Gentoo/Open-RC systems.')
 
 
-def _ret_code(cmd):
+def _ret_code(cmd, ignore_retcode=False):
     log.debug('executing [{0}]'.format(cmd))
-    sts = __salt__['cmd.retcode'](cmd, python_shell=False)
+    sts = __salt__['cmd.retcode'](cmd, python_shell=False, ignore_retcode=ignore_retcode)
     return sts
 
 
@@ -248,8 +248,9 @@ def status(name, sig=None):
     '''
     if sig:
         return bool(__salt__['status.pid'](sig))
+
     cmd = _service_cmd(name, 'status')
-    return not _ret_code(cmd)
+    return not _ret_code(cmd, ignore_retcode=True)
 
 
 def enable(name, **kwargs):

--- a/tests/unit/modules/test_gentoo_service.py
+++ b/tests/unit/modules/test_gentoo_service.py
@@ -151,7 +151,9 @@ class GentooServicesTestCase(TestCase, LoaderModuleMockMixin):
         mock = MagicMock(return_value=True)
         with patch.dict(gentoo_service.__salt__, {'cmd.retcode': mock}):
             self.assertFalse(gentoo_service.start('name'))
-        mock.assert_called_once_with('/etc/init.d/name start', python_shell=False)
+        mock.assert_called_once_with('/etc/init.d/name start',
+                                     ignore_retcode=False,
+                                     python_shell=False)
 
     def test_stop(self):
         '''
@@ -160,7 +162,9 @@ class GentooServicesTestCase(TestCase, LoaderModuleMockMixin):
         mock = MagicMock(return_value=True)
         with patch.dict(gentoo_service.__salt__, {'cmd.retcode': mock}):
             self.assertFalse(gentoo_service.stop('name'))
-        mock.assert_called_once_with('/etc/init.d/name stop', python_shell=False)
+        mock.assert_called_once_with('/etc/init.d/name stop',
+                                     ignore_retcode=False,
+                                     python_shell=False)
 
     def test_restart(self):
         '''
@@ -169,7 +173,9 @@ class GentooServicesTestCase(TestCase, LoaderModuleMockMixin):
         mock = MagicMock(return_value=True)
         with patch.dict(gentoo_service.__salt__, {'cmd.retcode': mock}):
             self.assertFalse(gentoo_service.restart('name'))
-        mock.assert_called_once_with('/etc/init.d/name restart', python_shell=False)
+        mock.assert_called_once_with('/etc/init.d/name restart',
+                                     ignore_retcode=False,
+                                     python_shell=False)
 
     def test_reload_(self):
         '''
@@ -178,7 +184,9 @@ class GentooServicesTestCase(TestCase, LoaderModuleMockMixin):
         mock = MagicMock(return_value=True)
         with patch.dict(gentoo_service.__salt__, {'cmd.retcode': mock}):
             self.assertFalse(gentoo_service.reload_('name'))
-        mock.assert_called_once_with('/etc/init.d/name reload', python_shell=False)
+        mock.assert_called_once_with('/etc/init.d/name reload',
+                                     ignore_retcode=False,
+                                     python_shell=False)
 
     def test_zap(self):
         '''
@@ -187,7 +195,9 @@ class GentooServicesTestCase(TestCase, LoaderModuleMockMixin):
         mock = MagicMock(return_value=True)
         with patch.dict(gentoo_service.__salt__, {'cmd.retcode': mock}):
             self.assertFalse(gentoo_service.zap('name'))
-        mock.assert_called_once_with('/etc/init.d/name zap', python_shell=False)
+        mock.assert_called_once_with('/etc/init.d/name zap',
+                                     ignore_retcode=False,
+                                     python_shell=False)
 
     def test_status(self):
         '''
@@ -201,25 +211,33 @@ class GentooServicesTestCase(TestCase, LoaderModuleMockMixin):
         mock = MagicMock(return_value=0)
         with patch.dict(gentoo_service.__salt__, {'cmd.retcode': mock}):
             self.assertTrue(gentoo_service.status('name'))
-        mock.assert_called_once_with('/etc/init.d/name status', python_shell=False)
+        mock.assert_called_once_with('/etc/init.d/name status',
+                                     ignore_retcode=True,
+                                     python_shell=False)
 
         # service is not running
         mock = MagicMock(return_value=1)
         with patch.dict(gentoo_service.__salt__, {'cmd.retcode': mock}):
             self.assertFalse(gentoo_service.status('name'))
-        mock.assert_called_once_with('/etc/init.d/name status', python_shell=False)
+        mock.assert_called_once_with('/etc/init.d/name status',
+                                     ignore_retcode=True,
+                                     python_shell=False)
 
         # service is stopped
         mock = MagicMock(return_value=3)
         with patch.dict(gentoo_service.__salt__, {'cmd.retcode': mock}):
             self.assertFalse(gentoo_service.status('name'))
-        mock.assert_called_once_with('/etc/init.d/name status', python_shell=False)
+        mock.assert_called_once_with('/etc/init.d/name status',
+                                     ignore_retcode=True,
+                                     python_shell=False)
 
         # service has crashed
         mock = MagicMock(return_value=32)
         with patch.dict(gentoo_service.__salt__, {'cmd.retcode': mock}):
             self.assertFalse(gentoo_service.status('name'))
-        mock.assert_called_once_with('/etc/init.d/name status', python_shell=False)
+        mock.assert_called_once_with('/etc/init.d/name status',
+                                     ignore_retcode=True,
+                                     python_shell=False)
 
     def test_enable(self):
         '''
@@ -228,7 +246,9 @@ class GentooServicesTestCase(TestCase, LoaderModuleMockMixin):
         rc_update_mock = MagicMock(return_value=0)
         with patch.dict(gentoo_service.__salt__, {'cmd.retcode': rc_update_mock}):
             self.assertTrue(gentoo_service.enable('name'))
-        rc_update_mock.assert_called_once_with('rc-update add name', python_shell=False)
+        rc_update_mock.assert_called_once_with('rc-update add name',
+                                               ignore_retcode=False,
+                                               python_shell=False)
         rc_update_mock.reset_mock()
 
         # move service from 'l1' to 'l2' runlevel
@@ -238,8 +258,12 @@ class GentooServicesTestCase(TestCase, LoaderModuleMockMixin):
         with patch.dict(gentoo_service.__salt__, {'cmd.run': level_list_mock}):
             with patch.dict(gentoo_service.__salt__, {'cmd.retcode': rc_update_mock}):
                 self.assertTrue(gentoo_service.enable('name', runlevels='l2'))
-        rc_update_mock.assert_has_calls([call('rc-update delete name l1', python_shell=False),
-                                         call('rc-update add name l2', python_shell=False)])
+        rc_update_mock.assert_has_calls([call('rc-update delete name l1',
+                                              ignore_retcode=False,
+                                              python_shell=False),
+                                         call('rc-update add name l2',
+                                              ignore_retcode=False,
+                                              python_shell=False)])
         rc_update_mock.reset_mock()
 
         # requested levels are the same as the current ones
@@ -260,7 +284,9 @@ class GentooServicesTestCase(TestCase, LoaderModuleMockMixin):
         with patch.dict(gentoo_service.__salt__, {'cmd.run': level_list_mock}):
             with patch.dict(gentoo_service.__salt__, {'cmd.retcode': rc_update_mock}):
                 self.assertTrue(gentoo_service.enable('name', runlevels=['l2', 'l1']))
-        rc_update_mock.assert_called_once_with('rc-update add name l2', python_shell=False)
+        rc_update_mock.assert_called_once_with('rc-update add name l2',
+                                               ignore_retcode=False,
+                                               python_shell=False)
         rc_update_mock.reset_mock()
 
         # remove service from 'l1' runlevel
@@ -269,15 +295,21 @@ class GentooServicesTestCase(TestCase, LoaderModuleMockMixin):
         with patch.dict(gentoo_service.__salt__, {'cmd.run': level_list_mock}):
             with patch.dict(gentoo_service.__salt__, {'cmd.retcode': rc_update_mock}):
                 self.assertTrue(gentoo_service.enable('name', runlevels=['l2']))
-        rc_update_mock.assert_called_once_with('rc-update delete name l1', python_shell=False)
+        rc_update_mock.assert_called_once_with('rc-update delete name l1',
+                                               ignore_retcode=False,
+                                               python_shell=False)
         rc_update_mock.reset_mock()
 
         # move service from 'l2' add to 'l3', leaving at l1
         with patch.dict(gentoo_service.__salt__, {'cmd.run': level_list_mock}):
             with patch.dict(gentoo_service.__salt__, {'cmd.retcode': rc_update_mock}):
                 self.assertTrue(gentoo_service.enable('name', runlevels=['l1', 'l3']))
-        rc_update_mock.assert_has_calls([call('rc-update delete name l2', python_shell=False),
-                                         call('rc-update add name l3', python_shell=False)])
+        rc_update_mock.assert_has_calls([call('rc-update delete name l2',
+                                              ignore_retcode=False,
+                                              python_shell=False),
+                                         call('rc-update add name l3',
+                                              ignore_retcode=False,
+                                              python_shell=False)])
         rc_update_mock.reset_mock()
 
         # remove from l1, l3, and add to l2, l4, and leave at l5
@@ -286,15 +318,21 @@ class GentooServicesTestCase(TestCase, LoaderModuleMockMixin):
         with patch.dict(gentoo_service.__salt__, {'cmd.run': level_list_mock}):
             with patch.dict(gentoo_service.__salt__, {'cmd.retcode': rc_update_mock}):
                 self.assertTrue(gentoo_service.enable('name', runlevels=['l2', 'l4', 'l5']))
-        rc_update_mock.assert_has_calls([call('rc-update delete name l1 l3', python_shell=False),
-                                         call('rc-update add name l2 l4', python_shell=False)])
+        rc_update_mock.assert_has_calls([call('rc-update delete name l1 l3',
+                                              ignore_retcode=False,
+                                              python_shell=False),
+                                         call('rc-update add name l2 l4',
+                                              ignore_retcode=False,
+                                              python_shell=False)])
         rc_update_mock.reset_mock()
 
         # rc-update failed
         rc_update_mock = MagicMock(return_value=1)
         with patch.dict(gentoo_service.__salt__, {'cmd.retcode': rc_update_mock}):
             self.assertFalse(gentoo_service.enable('name'))
-        rc_update_mock.assert_called_once_with('rc-update add name', python_shell=False)
+        rc_update_mock.assert_called_once_with('rc-update add name',
+                                               ignore_retcode=False,
+                                               python_shell=False)
         rc_update_mock.reset_mock()
 
         # move service delete failed
@@ -303,7 +341,9 @@ class GentooServicesTestCase(TestCase, LoaderModuleMockMixin):
         with patch.dict(gentoo_service.__salt__, {'cmd.run': level_list_mock}):
             with patch.dict(gentoo_service.__salt__, {'cmd.retcode': rc_update_mock}):
                 self.assertFalse(gentoo_service.enable('name', runlevels='l2'))
-        rc_update_mock.assert_called_once_with('rc-update delete name l1', python_shell=False)
+        rc_update_mock.assert_called_once_with('rc-update delete name l1',
+                                               ignore_retcode=False,
+                                               python_shell=False)
         rc_update_mock.reset_mock()
 
         # move service delete succeeds. add fails
@@ -312,8 +352,12 @@ class GentooServicesTestCase(TestCase, LoaderModuleMockMixin):
         with patch.dict(gentoo_service.__salt__, {'cmd.run': level_list_mock}):
             with patch.dict(gentoo_service.__salt__, {'cmd.retcode': rc_update_mock}):
                 self.assertFalse(gentoo_service.enable('name', runlevels='l2'))
-        rc_update_mock.assert_has_calls([call('rc-update delete name l1', python_shell=False),
-                                         call('rc-update add name l2', python_shell=False)])
+        rc_update_mock.assert_has_calls([call('rc-update delete name l1',
+                                              ignore_retcode=False,
+                                              python_shell=False),
+                                         call('rc-update add name l2',
+                                              ignore_retcode=False,
+                                              python_shell=False)])
         rc_update_mock.reset_mock()
 
     def test_disable(self):
@@ -323,7 +367,9 @@ class GentooServicesTestCase(TestCase, LoaderModuleMockMixin):
         rc_update_mock = MagicMock(return_value=0)
         with patch.dict(gentoo_service.__salt__, {'cmd.retcode': rc_update_mock}):
             self.assertTrue(gentoo_service.disable('name'))
-        rc_update_mock.assert_called_once_with('rc-update delete name', python_shell=False)
+        rc_update_mock.assert_called_once_with('rc-update delete name',
+                                               ignore_retcode=False,
+                                               python_shell=False)
         rc_update_mock.reset_mock()
 
         # disable service
@@ -334,6 +380,7 @@ class GentooServicesTestCase(TestCase, LoaderModuleMockMixin):
             with patch.dict(gentoo_service.__salt__, {'cmd.retcode': rc_update_mock}):
                 self.assertTrue(gentoo_service.disable('name', runlevels='l1'))
         rc_update_mock.assert_called_once_with('rc-update delete name l1',
+                                               ignore_retcode=False,
                                                python_shell=False)
         rc_update_mock.reset_mock()
 
@@ -344,6 +391,7 @@ class GentooServicesTestCase(TestCase, LoaderModuleMockMixin):
             with patch.dict(gentoo_service.__salt__, {'cmd.retcode': rc_update_mock}):
                 self.assertTrue(gentoo_service.disable('name', runlevels=['l1']))
         rc_update_mock.assert_called_once_with('rc-update delete name l1',
+                                               ignore_retcode=False,
                                                python_shell=False)
         rc_update_mock.reset_mock()
 
@@ -354,6 +402,7 @@ class GentooServicesTestCase(TestCase, LoaderModuleMockMixin):
             with patch.dict(gentoo_service.__salt__, {'cmd.retcode': rc_update_mock}):
                 self.assertTrue(gentoo_service.disable('name', runlevels=['l1']))
         rc_update_mock.assert_called_once_with('rc-update delete name l1',
+                                               ignore_retcode=False,
                                                python_shell=False)
         rc_update_mock.reset_mock()
 
@@ -373,6 +422,7 @@ class GentooServicesTestCase(TestCase, LoaderModuleMockMixin):
             with patch.dict(gentoo_service.__salt__, {'cmd.retcode': rc_update_mock}):
                 self.assertTrue(gentoo_service.disable('name', runlevels=['l1', 'l3']))
         rc_update_mock.assert_called_once_with('rc-update delete name l1 l3',
+                                               ignore_retcode=False,
                                                python_shell=False)
         rc_update_mock.reset_mock()
 
@@ -380,7 +430,9 @@ class GentooServicesTestCase(TestCase, LoaderModuleMockMixin):
         rc_update_mock = MagicMock(return_value=1)
         with patch.dict(gentoo_service.__salt__, {'cmd.retcode': rc_update_mock}):
             self.assertFalse(gentoo_service.disable('name'))
-        rc_update_mock.assert_called_once_with('rc-update delete name', python_shell=False)
+        rc_update_mock.assert_called_once_with('rc-update delete name',
+                                               ignore_retcode=False,
+                                               python_shell=False)
         rc_update_mock.reset_mock()
 
         # move service delete failed
@@ -389,7 +441,9 @@ class GentooServicesTestCase(TestCase, LoaderModuleMockMixin):
         with patch.dict(gentoo_service.__salt__, {'cmd.run': level_list_mock}):
             with patch.dict(gentoo_service.__salt__, {'cmd.retcode': rc_update_mock}):
                 self.assertFalse(gentoo_service.disable('name', runlevels='l1'))
-        rc_update_mock.assert_called_once_with('rc-update delete name l1', python_shell=False)
+        rc_update_mock.assert_called_once_with('rc-update delete name l1',
+                                               ignore_retcode=False,
+                                               python_shell=False)
         rc_update_mock.reset_mock()
 
         # move service delete succeeds. add fails
@@ -399,6 +453,7 @@ class GentooServicesTestCase(TestCase, LoaderModuleMockMixin):
             with patch.dict(gentoo_service.__salt__, {'cmd.retcode': rc_update_mock}):
                 self.assertFalse(gentoo_service.disable('name', runlevels=['l1', 'l3']))
         rc_update_mock.assert_called_once_with('rc-update delete name l1 l3',
+                                               ignore_retcode=False,
                                                python_shell=False)
         rc_update_mock.reset_mock()
 


### PR DESCRIPTION
### What does this PR do?

In the OpenRC exec module, make sure to ignore retcode on status.

### What issues does this PR fix or reference?

For example, when a service is stopped, the retcode of `/sbin/openrc-run status` is
`3`, not `0`.

### Previous Behavior

```yaml
# salt-call --local state.single service.dead my-service
[ERROR   ] Command '/etc/init.d/my-service status' failed with return code: 3
[ERROR   ] output:  * status: stopped
local:
----------
          ID: my-service
    Function: service.dead
      Result: True
     Comment: The service my-service is already dead
     Started: 05:46:06.918276
    Duration: 235.749 ms
     Changes:

Summary for local
------------
Succeeded: 1
Failed:    0
------------
Total states run:     1
Total run time: 235.749 ms
```

### New Behavior

```yaml
# salt-call --local state.single service.dead my-service
local:
----------
          ID: my-service
    Function: service.dead
      Result: True
     Comment: The service my-service is already dead
     Started: 05:46:31.445100
    Duration: 233.924 ms
     Changes:

Summary for local
------------
Succeeded: 1
Failed:    0
------------
Total states run:     1
Total run time: 233.924 ms
```

### Tests written?

Yes

### Commits signed with GPG?

Yes