### PR TITLE
Fix skipping Kubernetes tests if client is not installed

### DIFF
--- a/tests/unit/modules/test_kubernetes.py
+++ b/tests/unit/modules/test_kubernetes.py
@@ -16,15 +16,12 @@ from tests.support.mock import (
     NO_MOCK_REASON
 )
 
-try:
-    from salt.modules import kubernetes
-except ImportError:
-    kubernetes = False
+from salt.modules import kubernetes
 
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
-@skipIf(kubernetes is False, "Probably Kubernetes client lib is not installed. \
-                              Skipping test_kubernetes.py")
+@skipIf(not kubernetes.HAS_LIBS, "Kubernetes client lib is not installed. "
+                                 "Skipping test_kubernetes.py")
 class KubernetesTestCase(TestCase, LoaderModuleMockMixin):
     '''
     Test cases for salt.modules.kubernetes


### PR DESCRIPTION
When the Kubernetes client is not installed, the import of `salt.modules.kubernetes` will still succeed, but `HAS_LIBS` will be set to `False` (since the library import will be covered by a try-except clause).

Therefore expect the salt.modules.kubernetes to always succeed and check `kubernetes.HAS_LIBS` instead for the presence of the kubernetes library.

I stumbled over the failing test when working on the Debian package for the 2017.7.3 release.