### PR TITLE
M2Crypto Py3 unicode fix

### DIFF
--- a/salt/crypt.py
+++ b/salt/crypt.py
@@ -806,7 +806,7 @@ class AsyncAuth(object):
             pubkey_path = os.path.join(self.opts['pki_dir'], self.mpub)
             pub = get_rsa_pub_key(pubkey_path)
             if HAS_M2:
-                payload['token'] = pub.public_encrypt(six.b(self.token), RSA.pkcs1_oaep_padding)
+                payload['token'] = pub.public_encrypt(self.token, RSA.pkcs1_oaep_padding)
             else:
                 cipher = PKCS1_OAEP.new(pub)
                 payload['token'] = cipher.encrypt(self.token)
@@ -845,7 +845,8 @@ class AsyncAuth(object):
             log.debug('Decrypting the current master AES key')
         key = self.get_keys()
         if HAS_M2:
-            key_str = key.private_decrypt(six.b(payload['aes']), RSA.pkcs1_oaep_padding)
+            key_str = key.private_decrypt(payload['aes'],
+                                          RSA.pkcs1_oaep_padding)
         else:
             cipher = PKCS1_OAEP.new(key)
             key_str = cipher.decrypt(payload['aes'])
@@ -876,7 +877,8 @@ class AsyncAuth(object):
         else:
             if 'token' in payload:
                 if HAS_M2:
-                    token = key.private_decrypt(six.b(payload['token']), RSA.pkcs1_oaep_padding)
+                    token = key.private_decrypt(payload['token'],
+                                                RSA.pkcs1_oaep_padding)
                 else:
                     token = cipher.decrypt(payload['token'])
                 return key_str, token

--- a/salt/transport/mixins/auth.py
+++ b/salt/transport/mixins/auth.py
@@ -128,14 +128,13 @@ class AESReqServerMixin(object):
             return {'error': 'AES key not found'}
 
         pret = {}
+        if not six.PY2:
+            key = salt.utils.stringutils.to_bytes(key)
         if HAS_M2:
-            pret['key'] = pub.public_encrypt(six.b(key), RSA.pkcs1_oaep_padding)
+            pret['key'] = pub.public_encrypt(key, RSA.pkcs1_oaep_padding)
         else:
             cipher = PKCS1_OAEP.new(pub)
-            if six.PY2:
-                pret['key'] = cipher.encrypt(key)
-            else:
-                pret['key'] = cipher.encrypt(salt.utils.stringutils.to_bytes(key))
+            pret['key'] = cipher.encrypt(key)
         pret[dictkey] = pcrypt.dumps(
             ret if ret is not False else {}
         )
@@ -468,7 +467,7 @@ class AESReqServerMixin(object):
             if 'token' in load:
                 try:
                     if HAS_M2:
-                        mtoken = self.master_key.key.private_decrypt(six.b(load['token']),
+                        mtoken = self.master_key.key.private_decrypt(load['token'],
                                                                      RSA.pkcs1_oaep_padding)
                     else:
                         mtoken = mcipher.decrypt(load['token'])
@@ -481,16 +480,16 @@ class AESReqServerMixin(object):
                 aes = salt.master.SMaster.secrets['aes']['secret'].value
 
             if HAS_M2:
-                ret['aes'] = pub.public_encrypt(six.b(aes), RSA.pkcs1_oaep_padding)
+                ret['aes'] = pub.public_encrypt(aes, RSA.pkcs1_oaep_padding)
             else:
                 ret['aes'] = cipher.encrypt(aes)
         else:
             if 'token' in load:
                 try:
                     if HAS_M2:
-                        mtoken = self.master_key.key.private_decrypt(six.b(load['token']),
+                        mtoken = self.master_key.key.private_decrypt(load['token'],
                                                                      RSA.pkcs1_oaep_padding)
-                        ret['token'] = pub.public_encrypt(six.b(mtoken), RSA.pkcs1_oaep_padding)
+                        ret['token'] = pub.public_encrypt(mtoken, RSA.pkcs1_oaep_padding)
                     else:
                         mtoken = mcipher.decrypt(load['token'])
                         ret['token'] = cipher.encrypt(mtoken)
@@ -501,11 +500,12 @@ class AESReqServerMixin(object):
 
             aes = salt.master.SMaster.secrets['aes']['secret'].value
             if HAS_M2:
-                ret['aes'] = pub.public_encrypt(six.b(aes), RSA.pkcs1_oaep_padding)
+                ret['aes'] = pub.public_encrypt(aes,
+                                                RSA.pkcs1_oaep_padding)
             else:
                 ret['aes'] = cipher.encrypt(aes)
         # Be aggressive about the signature
-        digest = hashlib.sha256(aes).hexdigest()
+        digest = salt.utils.stringutils.to_bytes(hashlib.sha256(aes).hexdigest())
         ret['sig'] = salt.crypt.private_encrypt(self.master_key.key, digest)
         eload = {'result': True,
                  'act': 'accept',

--- a/salt/transport/tcp.py
+++ b/salt/transport/tcp.py
@@ -302,7 +302,7 @@ class AsyncTCPReqChannel(salt.transport.client.ReqChannel):
         ret = yield self.message_client.send(self._package_load(self.auth.crypticle.dumps(load)), timeout=timeout)
         key = self.auth.get_keys()
         if HAS_M2:
-            aes = key.private_decrypt(six.b(ret['key']), RSA.pkcs1_oaep_padding)
+            aes = key.private_decrypt(ret['key'], RSA.pkcs1_oaep_padding)
         else:
             cipher = PKCS1_OAEP.new(key)
             aes = cipher.decrypt(ret['key'])

--- a/salt/transport/zeromq.py
+++ b/salt/transport/zeromq.py
@@ -248,7 +248,8 @@ class AsyncZeroMQReqChannel(salt.transport.client.ReqChannel):
                 tries=tries,
             )
         if HAS_M2:
-            aes = key.private_decrypt(six.b(ret['key']), RSA.pkcs1_oaep_padding)
+            aes = key.private_decrypt(ret['key'],
+                                      RSA.pkcs1_oaep_padding)
         else:
             cipher = PKCS1_OAEP.new(key)
             aes = cipher.decrypt(ret['key'])


### PR DESCRIPTION
### What does this PR do?
During checking some issues I've found that Py2 minion can't connect to Py3 master. It was surprise for me because I've checked this behavior on the moment I've done work on M2Crypto.
I've found that the issue is in Unicode handling so I've removed the unneeded tries to convert binary to binary in Py3 from M2Crypto related code.

### What issues does this PR fix or reference?
Related to #44923

### Tests written?
No

### Commits signed with GPG?
Yes