### PR TITLE
Add --assumeyes on YUM/DNF commands

### DIFF
--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -1025,8 +1025,8 @@ def refresh_db(**kwargs):
 
     options = _get_options(**kwargs)
 
-    clean_cmd = [_yum(), '--quiet', 'clean', 'expire-cache']
-    update_cmd = [_yum(), '--quiet', 'check-update']
+    clean_cmd = [_yum(), '--quiet', '--assumeyes', 'clean', 'expire-cache']
+    update_cmd = [_yum(), '--quiet', '--assumeyes', 'check-update']
 
     if __grains__.get('os_family') == 'RedHat' \
             and __grains__.get('osmajorrelease') == 7:

--- a/tests/unit/modules/test_yumpkg.py
+++ b/tests/unit/modules/test_yumpkg.py
@@ -311,11 +311,11 @@ class YumTestCase(TestCase, LoaderModuleMockMixin):
                     fromrepo='good',
                     branch='foo')
                 clean_cmd.assert_called_once_with(
-                    ['yum', '--quiet', 'clean', 'expire-cache', '--disablerepo=*',
+                    ['yum', '--quiet', '--assumeyes', 'clean', 'expire-cache', '--disablerepo=*',
                      '--enablerepo=good', '--branch=foo'],
                     python_shell=False)
                 update_cmd.assert_called_once_with(
-                    ['yum', '--quiet', 'check-update',
+                    ['yum', '--quiet', '--assumeyes', 'check-update',
                      '--setopt=autocheck_running_kernel=false', '--disablerepo=*',
                      '--enablerepo=good', '--branch=foo'],
                     output_loglevel='trace',
@@ -333,11 +333,11 @@ class YumTestCase(TestCase, LoaderModuleMockMixin):
                     disablerepo='bad',
                     branch='foo')
                 clean_cmd.assert_called_once_with(
-                    ['yum', '--quiet', 'clean', 'expire-cache', '--disablerepo=bad',
+                    ['yum', '--quiet', '--assumeyes', 'clean', 'expire-cache', '--disablerepo=bad',
                      '--enablerepo=good', '--branch=foo'],
                     python_shell=False)
                 update_cmd.assert_called_once_with(
-                    ['yum', '--quiet', 'check-update',
+                    ['yum', '--quiet', '--assumeyes', 'check-update',
                      '--setopt=autocheck_running_kernel=false', '--disablerepo=bad',
                      '--enablerepo=good', '--branch=foo'],
                     output_loglevel='trace',
@@ -354,7 +354,7 @@ class YumTestCase(TestCase, LoaderModuleMockMixin):
                     fromrepo='good',
                     branch='foo')
                 clean_cmd.assert_called_once_with(
-                    ['yum', '--quiet', 'clean', 'expire-cache', '--disablerepo=*',
+                    ['yum', '--quiet', '--assumeyes', 'clean', 'expire-cache', '--disablerepo=*',
                      '--enablerepo=good', '--branch=foo'],
                     python_shell=False)
 
@@ -367,7 +367,7 @@ class YumTestCase(TestCase, LoaderModuleMockMixin):
                     disablerepo='bad',
                     branch='foo')
                 clean_cmd.assert_called_once_with(
-                    ['yum', '--quiet', 'clean', 'expire-cache', '--disablerepo=bad',
+                    ['yum', '--quiet', '--assumeyes', 'clean', 'expire-cache', '--disablerepo=bad',
                      '--enablerepo=good', '--branch=foo'],
                     python_shell=False)
 


### PR DESCRIPTION
### What does this PR do?
Add `--assumeyes` on some YUM/DNF commands to bypass a prompt for user confirmation.

### What issues does this PR fix or reference?
#46106

### Previous Behavior
`salt.modules.yumpkg.refresh_db` could hang indefinitely if there is an repository signing key that has not yet been accepted on the system.

### New Behavior
YUM/DNF command bypass user confirmation and "assume yes".

### Tests written?
Yes

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
