### PR TITLE
Fix failure to build docs in develop branch

### DIFF
--- a/doc/ref/modules/all/salt.modules.telegram.rst
+++ b/doc/ref/modules/all/salt.modules.telegram.rst
@@ -1,0 +1,6 @@
+=====================
+salt.modules.telegram
+=====================
+
+.. automodule:: salt.modules.telegram
+    :members:


### PR DESCRIPTION
The docs are failing to build with the following error:

```
Failed to import 'salt.cloud.clouds.azurearm'; the module executes module
level statement and it might call sys.exit().
```

The "cleanup" done in 982c55cf broke docs builds on develop. It made a number of unnecessary changes, for puzzling reasons. The `__opts__` and `__utils__` dunders do not need to be manually created, they're present automagically courtesy of the loader.

This removes all of the module level calls and replaces the helpers with calls to the corresponding functions from the `__utils__` dunder.