### PR TITLE
Ensure new line is added to file in mac sysctl.present

### DIFF
--- a/salt/modules/mac_sysctl.py
+++ b/salt/modules/mac_sysctl.py
@@ -164,7 +164,7 @@ def persist(name, value, config='/etc/sysctl.conf', apply_change=False):
 
     with salt.utils.files.fopen(config, 'r') as ifile:
         for line in ifile:
-            line = salt.utils.stringutils.to_unicode(line).rstrip('\n')
+            line = salt.utils.stringutils.to_unicode(line)
             if not line.startswith('{0}='.format(name)):
                 nlines.append(line)
                 continue


### PR DESCRIPTION
### What does this PR do?
Fixes failing test on mac: `integration.modules.test_darwin_sysctl.DarwinSysctlModuleTest.test_persist_already_set`
### Previous Behavior
Test failing:

```
*** integration.modules.test_darwin_sysctl.DarwinSysctlModuleTest.test_persist_already_set Tests  *******************************************
***************************************************************                                                                              
 --------  Failed Tests  --------------------------------------------------------------------------------------------------------------------
---------------------------------------------------------------                                                                              
   -> integration.modules.test_darwin_sysctl.DarwinSysctlModuleTest.test_persist_already_set  ...............................................
...............................................................                                                                              
       Traceback (most recent call last):                                                                                                    
         File "/testing/tests/integration/modules/test_darwin_sysctl.py", line 108, in test_persist_already_set                              
           self.assertEqual(ret, 'Already set')                                                                                              
       AssertionError: 'Updated' != 'Already set'                                                                                            
       - Updated                                                                                                                             
       + Already set                                                                                                                         
   ..........................................................................................................................................
...............................................................                                                                              
 --------------------------------------------------------------------------------------------------------------------------------------------
---------------------------------------------------------------                                                                              
=========================================================================================================================================
```

And this is what the sysctl file looks like:

```
## Kernel sysctl configuration#net.inet.icmp.icmplim=50net.inet.icmp.icmplim=50
```

### New Behavior
test passes
and file looks like this now:

```
#
# Kernel sysctl configuration
#
net.inet.icmp.icmplim=50
```
