### PR TITLE
Add stringutils.to_str in test_roster_config_validate test

### DIFF
--- a/tests/unit/config/schemas/test_ssh.py
+++ b/tests/unit/config/schemas/test_ssh.py
@@ -14,6 +14,7 @@ from tests.support.unit import TestCase, skipIf
 # Import Salt Libs
 from salt.config.schemas import ssh as ssh_schemas
 from salt.config.schemas.minion import MinionConfiguration
+import salt.utils.stringutils
 from salt.utils.versions import LooseVersion as _LooseVersion
 
 # Import 3rd-party libs
@@ -286,7 +287,7 @@ class RosterItemTest(TestCase):
 
         with self.assertRaises(jsonschema.exceptions.ValidationError) as excinfo:
             jsonschema.validate(
-                {'target-1:1':
+                {salt.utils.stringutils.to_str('target-1:1'):
                     {
                         'host': 'localhost',
                         'user': 'root',


### PR DESCRIPTION
### What does this PR do?
Fixes test: `unit.config.schemas.test_ssh.RosterItemTest.test_roster_config_validate` on macosx

Because mac has jsonschema version 2.5.1 installed it is attempting to check that `"Additional properties are not allowed (\'target-1:1\' was unexpected)'"` is in the exception returned. But this is returning:

`"Additional properties are not allowed (u'target-1:1' was unexpected)"`  (note: `u'target-1:1'`)

### Previous Behavior

```
FAILED (failures=1)

================================================================  Overall Tests Report  =================================================================
*** unit.config.schemas.test_ssh Tests  *****************************************************************************************************************
 --------  Failed Tests  --------------------------------------------------------------------------------------------------------------------------------
   -> unit.config.schemas.test_ssh.RosterItemTest.test_roster_config_validate  ..........................................................................
       Traceback (most recent call last):
         File "/testing/tests/unit/config/schemas/test_ssh.py", line 303, in test_roster_config_validate
           excinfo.exception.message
       AssertionError: u"Additional properties are not allowed ('target-1:1' was unexpected)" not found in "Additional properties are not allowed (u'target-1:1' was unexpected)"
   ......................................................................................................................................................
 --------------------------------------------------------------------------------------------------------------------------------------------------------
=========================================================================================================================================================
FAILED (total=4, skipped=0, passed=3, failures=1, errors=0)
================================================================  Overall Tests Report  =================================================================
```

### New Behavior
tests pass

ping @terminalmage if i could get your review here as this is my first use of `salt.utils.stringutils.to_str`. i want to ensure i'm using it in the right place. thanks :)