### PR TITLE
If no pubkey is passed in openmode fail

### DIFF
--- a/salt/transport/mixins/auth.py
+++ b/salt/transport/mixins/auth.py
@@ -417,6 +417,10 @@ class AESReqServerMixin(object):
                 log.debug('Host key change detected in open mode.')
                 with salt.utils.fopen(pubfn, 'w+') as fp_:
                     fp_.write(load['pub'])
+            elif not load['pub']:
+                log.error('Public key is empty: {0}'.format(load['id']))
+                return {'enc': 'clear',
+                        'load': {'ret': False}}
 
         pub = None
 


### PR DESCRIPTION
### What does this PR do?
If the pub entry in the load is empty, we should fail authentication in open
mode.  This is usually caught elsewhere for the other modes, because we would
just write it to a file, but in this case, we only write it to a file if it
actually exists, and if it is different from disk_key, so we would catch all
other options when trying to load the public key.

### What issues does this PR fix or reference?
Fixes #46085

### Tests written?

No

### Commits signed with GPG?

Yes