### PR TITLE
Add os grains test cases for Debian/Ubuntu and fix oscodename on Ubuntu

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1694,7 +1694,7 @@ def os_data():
                 grains['osrelease_info']
             )
         os_name = grains['os' if grains.get('os') in (
-            'FreeBSD', 'OpenBSD', 'NetBSD', 'Mac', 'Raspbian') else 'osfullname']
+            'Debian', 'FreeBSD', 'OpenBSD', 'NetBSD', 'Mac', 'Raspbian') else 'osfullname']
         grains['osfinger'] = '{0}-{1}'.format(
             os_name, grains['osrelease'] if os_name in ('Ubuntu',) else grains['osrelease_info'][0])
 

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1423,7 +1423,9 @@ def os_data():
                         grains['lsb_distrib_id'] = os_release['NAME'].strip()
                     if 'VERSION_ID' in os_release:
                         grains['lsb_distrib_release'] = os_release['VERSION_ID']
-                    if 'PRETTY_NAME' in os_release:
+                    if 'VERSION_CODENAME' in os_release:
+                        grains['lsb_distrib_codename'] = os_release['VERSION_CODENAME']
+                    elif 'PRETTY_NAME' in os_release:
                         codename = os_release['PRETTY_NAME']
                         # https://github.com/saltstack/salt/issues/44108
                         if os_release['ID'] == 'debian':

--- a/tests/unit/grains/os-releases/debian-7
+++ b/tests/unit/grains/os-releases/debian-7
@@ -1,0 +1,10 @@
+# Taken from base-files 7.1wheezy11
+PRETTY_NAME="Debian GNU/Linux 7 (wheezy)"
+NAME="Debian GNU/Linux"
+VERSION_ID="7"
+VERSION="7 (wheezy)"
+ID=debian
+ANSI_COLOR="1;31"
+HOME_URL="http://www.debian.org/"
+SUPPORT_URL="http://www.debian.org/support/"
+BUG_REPORT_URL="http://bugs.debian.org/"

--- a/tests/unit/grains/os-releases/debian-8
+++ b/tests/unit/grains/os-releases/debian-8
@@ -1,0 +1,9 @@
+# Taken from base-files 8+deb8u10
+PRETTY_NAME="Debian GNU/Linux 8 (jessie)"
+NAME="Debian GNU/Linux"
+VERSION_ID="8"
+VERSION="8 (jessie)"
+ID=debian
+HOME_URL="http://www.debian.org/"
+SUPPORT_URL="http://www.debian.org/support"
+BUG_REPORT_URL="https://bugs.debian.org/"

--- a/tests/unit/grains/os-releases/debian-9
+++ b/tests/unit/grains/os-releases/debian-9
@@ -1,0 +1,9 @@
+# Taken from base-files 9.9+deb9u3
+PRETTY_NAME="Debian GNU/Linux 9 (stretch)"
+NAME="Debian GNU/Linux"
+VERSION_ID="9"
+VERSION="9 (stretch)"
+ID=debian
+HOME_URL="https://www.debian.org/"
+SUPPORT_URL="https://www.debian.org/support"
+BUG_REPORT_URL="https://bugs.debian.org/"

--- a/tests/unit/grains/os-releases/ubuntu-16.04
+++ b/tests/unit/grains/os-releases/ubuntu-16.04
@@ -1,0 +1,12 @@
+# Taken from base-files 9.4ubuntu4.5
+NAME="Ubuntu"
+VERSION="16.04.3 LTS (Xenial Xerus)"
+ID=ubuntu
+ID_LIKE=debian
+PRETTY_NAME="Ubuntu 16.04.3 LTS"
+VERSION_ID="16.04"
+HOME_URL="http://www.ubuntu.com/"
+SUPPORT_URL="http://help.ubuntu.com/"
+BUG_REPORT_URL="http://bugs.launchpad.net/ubuntu/"
+VERSION_CODENAME=xenial
+UBUNTU_CODENAME=xenial

--- a/tests/unit/grains/os-releases/ubuntu-17.10
+++ b/tests/unit/grains/os-releases/ubuntu-17.10
@@ -1,0 +1,13 @@
+# Taken from base-files 9.6ubuntu102
+NAME="Ubuntu"
+VERSION="17.10 (Artful Aardvark)"
+ID=ubuntu
+ID_LIKE=debian
+PRETTY_NAME="Ubuntu 17.10"
+VERSION_ID="17.10"
+HOME_URL="https://www.ubuntu.com/"
+SUPPORT_URL="https://help.ubuntu.com/"
+BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
+PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
+VERSION_CODENAME=artful
+UBUNTU_CODENAME=artful

--- a/tests/unit/grains/test_core.py
+++ b/tests/unit/grains/test_core.py
@@ -204,7 +204,7 @@ class CoreGrainsTestCase(TestCase, LoaderModuleMockMixin):
         self.assertEqual(os_grains.get('os_family'), 'Suse')
         self.assertEqual(os_grains.get('os'), 'SUSE')
 
-    def _run_os_grains_tests(self, os_release_filename, os_release_map):
+    def _run_os_grains_tests(self, os_release_filename, os_release_map, expectation):
         path_isfile_mock = MagicMock(side_effect=lambda x: x in os_release_map.get('files', []))
         empty_mock = MagicMock(return_value={})
         osarch_mock = MagicMock(return_value="amd64")
@@ -256,19 +256,16 @@ class CoreGrainsTestCase(TestCase, LoaderModuleMockMixin):
                                                     with patch.dict(core.__salt__, {'cmd.run': osarch_mock}):
                                                         os_grains = core.os_data()
 
-        self.assertEqual(os_grains.get('os'), os_release_map['os'])
-        self.assertEqual(os_grains.get('os_family'), os_release_map['os_family'])
-        self.assertEqual(os_grains.get('osfullname'), os_release_map['osfullname'])
-        self.assertEqual(os_grains.get('oscodename'), os_release_map['oscodename'])
-        self.assertEqual(os_grains.get('osrelease'), os_release_map['osrelease'])
-        self.assertListEqual(list(os_grains.get('osrelease_info')), os_release_map['osrelease_info'])
-        self.assertEqual(os_grains.get('osmajorrelease'), os_release_map['osmajorrelease'])
+        grains = {k: v for k, v in os_grains.items()
+                  if k in set(["os", "os_family", "osfullname", "oscodename", "osfinger",
+                               "osrelease", "osrelease_info", "osmajorrelease"])}
+        self.assertEqual(grains, expectation)
 
-    def _run_suse_os_grains_tests(self, os_release_map):
+    def _run_suse_os_grains_tests(self, os_release_map, expectation):
         os_release_map['linux_distribution'] = ('SUSE test', 'version', 'arch')
-        os_release_map['os'] = 'SUSE'
-        os_release_map['os_family'] = 'Suse'
-        self._run_os_grains_tests(None, os_release_map)
+        expectation['os'] = 'SUSE'
+        expectation['os_family'] = 'Suse'
+        self._run_os_grains_tests(None, os_release_map, expectation)
 
     @skipIf(not salt.utils.is_linux(), 'System is not Linux')
     def test_suse_os_grains_sles11sp3(self):
@@ -280,14 +277,17 @@ class CoreGrainsTestCase(TestCase, LoaderModuleMockMixin):
 VERSION = 11
 PATCHLEVEL = 3
 ''',
+            'files': ["/etc/SuSE-release"],
+        }
+        expectation = {
             'oscodename': 'SUSE Linux Enterprise Server 11 SP3',
             'osfullname': "SLES",
             'osrelease': '11.3',
-            'osrelease_info': [11, 3],
+            'osrelease_info': (11, 3),
             'osmajorrelease': 11,
-            'files': ["/etc/SuSE-release"],
+            'osfinger': 'SLES-11',
         }
-        self._run_suse_os_grains_tests(_os_release_map)
+        self._run_suse_os_grains_tests(_os_release_map, expectation)
 
     @skipIf(not salt.utils.is_linux(), 'System is not Linux')
     def test_suse_os_grains_sles11sp4(self):
@@ -304,13 +304,16 @@ PATCHLEVEL = 3
                 'ANSI_COLOR': '0;32',
                 'CPE_NAME': 'cpe:/o:suse:sles:11:4'
             },
+        }
+        expectation = {
             'oscodename': 'SUSE Linux Enterprise Server 11 SP4',
             'osfullname': "SLES",
             'osrelease': '11.4',
-            'osrelease_info': [11, 4],
+            'osrelease_info': (11, 4),
             'osmajorrelease': 11,
+            'osfinger': 'SLES-11',
         }
-        self._run_suse_os_grains_tests(_os_release_map)
+        self._run_suse_os_grains_tests(_os_release_map, expectation)
 
     @skipIf(not salt.utils.is_linux(), 'System is not Linux')
     def test_suse_os_grains_sles12(self):
@@ -327,13 +330,16 @@ PATCHLEVEL = 3
                 'ANSI_COLOR': '0;32',
                 'CPE_NAME': 'cpe:/o:suse:sles:12'
             },
+        }
+        expectation = {
             'oscodename': 'SUSE Linux Enterprise Server 12',
             'osfullname': "SLES",
             'osrelease': '12',
-            'osrelease_info': [12],
+            'osrelease_info': (12,),
             'osmajorrelease': 12,
+            'osfinger': 'SLES-12',
         }
-        self._run_suse_os_grains_tests(_os_release_map)
+        self._run_suse_os_grains_tests(_os_release_map, expectation)
 
     @skipIf(not salt.utils.is_linux(), 'System is not Linux')
     def test_suse_os_grains_sles12sp1(self):
@@ -350,13 +356,16 @@ PATCHLEVEL = 3
                 'ANSI_COLOR': '0;32',
                 'CPE_NAME': 'cpe:/o:suse:sles:12:sp1'
             },
+        }
+        expectation = {
             'oscodename': 'SUSE Linux Enterprise Server 12 SP1',
             'osfullname': "SLES",
             'osrelease': '12.1',
-            'osrelease_info': [12, 1],
+            'osrelease_info': (12, 1),
             'osmajorrelease': 12,
+            'osfinger': 'SLES-12',
         }
-        self._run_suse_os_grains_tests(_os_release_map)
+        self._run_suse_os_grains_tests(_os_release_map, expectation)
 
     @skipIf(not salt.utils.is_linux(), 'System is not Linux')
     def test_suse_os_grains_opensuse_leap_42_1(self):
@@ -373,13 +382,16 @@ PATCHLEVEL = 3
                 'ANSI_COLOR': '0;32',
                 'CPE_NAME': 'cpe:/o:opensuse:opensuse:42.1'
             },
+        }
+        expectation = {
             'oscodename': 'openSUSE Leap 42.1 (x86_64)',
             'osfullname': "Leap",
             'osrelease': '42.1',
-            'osrelease_info': [42, 1],
+            'osrelease_info': (42, 1),
             'osmajorrelease': 42,
+            'osfinger': 'Leap-42',
         }
-        self._run_suse_os_grains_tests(_os_release_map)
+        self._run_suse_os_grains_tests(_os_release_map, expectation)
 
     @skipIf(not salt.utils.is_linux(), 'System is not Linux')
     def test_suse_os_grains_tumbleweed(self):
@@ -396,13 +408,16 @@ PATCHLEVEL = 3
                 'ANSI_COLOR': '0;32',
                 'CPE_NAME': 'cpe:/o:opensuse:opensuse:20160504'
             },
+        }
+        expectation = {
             'oscodename': 'openSUSE Tumbleweed (20160504) (x86_64)',
             'osfullname': "Tumbleweed",
             'osrelease': '20160504',
-            'osrelease_info': [20160504],
+            'osrelease_info': (20160504,),
             'osmajorrelease': 20160504,
+            'osfinger': 'Tumbleweed-20160504',
         }
-        self._run_suse_os_grains_tests(_os_release_map)
+        self._run_suse_os_grains_tests(_os_release_map, expectation)
 
     @skipIf(not salt.utils.is_linux(), 'System is not Linux')
     def test_debian_7_os_grains(self):
@@ -411,16 +426,18 @@ PATCHLEVEL = 3
         '''
         _os_release_map = {
             'linux_distribution': ('debian', '7.11', ''),
+        }
+        expectation = {
             'os': 'Debian',
             'os_family': 'Debian',
             'oscodename': 'wheezy',
             'osfullname': 'Debian GNU/Linux',
             'osrelease': '7',
-            'osrelease_info': [7],
+            'osrelease_info': (7,),
             'osmajorrelease': 7,
             'osfinger': 'Debian-7',
         }
-        self._run_os_grains_tests("debian-7", _os_release_map)
+        self._run_os_grains_tests("debian-7", _os_release_map, expectation)
 
     @skipIf(not salt.utils.is_linux(), 'System is not Linux')
     def test_debian_8_os_grains(self):
@@ -429,16 +446,18 @@ PATCHLEVEL = 3
         '''
         _os_release_map = {
             'linux_distribution': ('debian', '8.10', ''),
+        }
+        expectation = {
             'os': 'Debian',
             'os_family': 'Debian',
             'oscodename': 'jessie',
             'osfullname': 'Debian GNU/Linux',
             'osrelease': '8',
-            'osrelease_info': [8],
+            'osrelease_info': (8,),
             'osmajorrelease': 8,
             'osfinger': 'Debian-8',
         }
-        self._run_os_grains_tests("debian-8", _os_release_map)
+        self._run_os_grains_tests("debian-8", _os_release_map, expectation)
 
     @skipIf(not salt.utils.is_linux(), 'System is not Linux')
     def test_debian_9_os_grains(self):
@@ -447,16 +466,18 @@ PATCHLEVEL = 3
         '''
         _os_release_map = {
             'linux_distribution': ('debian', '9.3', ''),
+        }
+        expectation = {
             'os': 'Debian',
             'os_family': 'Debian',
             'oscodename': 'stretch',
             'osfullname': 'Debian GNU/Linux',
             'osrelease': '9',
-            'osrelease_info': [9],
+            'osrelease_info': (9,),
             'osmajorrelease': 9,
             'osfinger': 'Debian-9',
         }
-        self._run_os_grains_tests("debian-9", _os_release_map)
+        self._run_os_grains_tests("debian-9", _os_release_map, expectation)
 
     @skipIf(not salt.utils.is_linux(), 'System is not Linux')
     def test_ubuntu_xenial_os_grains(self):
@@ -465,16 +486,18 @@ PATCHLEVEL = 3
         '''
         _os_release_map = {
             'linux_distribution': ('Ubuntu', '16.04', 'xenial'),
+        }
+        expectation = {
             'os': 'Ubuntu',
             'os_family': 'Debian',
             'oscodename': 'xenial',
             'osfullname': 'Ubuntu',
             'osrelease': '16.04',
-            'osrelease_info': [16, 4],
+            'osrelease_info': (16, 4),
             'osmajorrelease': 16,
             'osfinger': 'Ubuntu-16.04',
         }
-        self._run_os_grains_tests("ubuntu-16.04", _os_release_map)
+        self._run_os_grains_tests("ubuntu-16.04", _os_release_map, expectation)
 
     @skipIf(not salt.utils.is_linux(), 'System is not Linux')
     def test_ubuntu_artful_os_grains(self):
@@ -483,16 +506,18 @@ PATCHLEVEL = 3
         '''
         _os_release_map = {
             'linux_distribution': ('Ubuntu', '17.10', 'artful'),
+        }
+        expectation = {
             'os': 'Ubuntu',
             'os_family': 'Debian',
             'oscodename': 'artful',
             'osfullname': 'Ubuntu',
             'osrelease': '17.10',
-            'osrelease_info': [17, 10],
+            'osrelease_info': (17, 10),
             'osmajorrelease': 17,
             'osfinger': 'Ubuntu-17.10',
         }
-        self._run_os_grains_tests("ubuntu-17.10", _os_release_map)
+        self._run_os_grains_tests("ubuntu-17.10", _os_release_map, expectation)
 
     def test_docker_virtual(self):
         '''

--- a/tests/unit/grains/test_core.py
+++ b/tests/unit/grains/test_core.py
@@ -405,6 +405,60 @@ PATCHLEVEL = 3
         self._run_suse_os_grains_tests(_os_release_map)
 
     @skipIf(not salt.utils.is_linux(), 'System is not Linux')
+    def test_debian_7_os_grains(self):
+        '''
+        Test if OS grains are parsed correctly in Debian 7 "wheezy"
+        '''
+        _os_release_map = {
+            'linux_distribution': ('debian', '7.11', ''),
+            'os': 'Debian',
+            'os_family': 'Debian',
+            'oscodename': 'wheezy',
+            'osfullname': 'Debian GNU/Linux',
+            'osrelease': '7',
+            'osrelease_info': [7],
+            'osmajorrelease': 7,
+            'osfinger': 'Debian-7',
+        }
+        self._run_os_grains_tests("debian-7", _os_release_map)
+
+    @skipIf(not salt.utils.is_linux(), 'System is not Linux')
+    def test_debian_8_os_grains(self):
+        '''
+        Test if OS grains are parsed correctly in Debian 8 "jessie"
+        '''
+        _os_release_map = {
+            'linux_distribution': ('debian', '8.10', ''),
+            'os': 'Debian',
+            'os_family': 'Debian',
+            'oscodename': 'jessie',
+            'osfullname': 'Debian GNU/Linux',
+            'osrelease': '8',
+            'osrelease_info': [8],
+            'osmajorrelease': 8,
+            'osfinger': 'Debian-8',
+        }
+        self._run_os_grains_tests("debian-8", _os_release_map)
+
+    @skipIf(not salt.utils.is_linux(), 'System is not Linux')
+    def test_debian_9_os_grains(self):
+        '''
+        Test if OS grains are parsed correctly in Debian 9 "stretch"
+        '''
+        _os_release_map = {
+            'linux_distribution': ('debian', '9.3', ''),
+            'os': 'Debian',
+            'os_family': 'Debian',
+            'oscodename': 'stretch',
+            'osfullname': 'Debian GNU/Linux',
+            'osrelease': '9',
+            'osrelease_info': [9],
+            'osmajorrelease': 9,
+            'osfinger': 'Debian-9',
+        }
+        self._run_os_grains_tests("debian-9", _os_release_map)
+
+    @skipIf(not salt.utils.is_linux(), 'System is not Linux')
     def test_ubuntu_xenial_os_grains(self):
         '''
         Test if OS grains are parsed correctly in Ubuntu 16.04 "Xenial Xerus"

--- a/tests/unit/grains/test_core.py
+++ b/tests/unit/grains/test_core.py
@@ -415,6 +415,7 @@ PATCHLEVEL = 3
         Test if OS grains are parsed correctly in Ubuntu Xenial Xerus
         '''
         _os_release_map = {
+            'linux_distribution': ('Ubuntu', '16.04', 'xenial'),
             'os_release_file': {
                 'NAME': 'Ubuntu',
                 'VERSION': '16.04.1 LTS (Xenial Xerus)',
@@ -422,21 +423,17 @@ PATCHLEVEL = 3
                 'PRETTY_NAME': '',
                 'ID': 'ubuntu',
             },
+            'os': 'Ubuntu',
+            'os_family': 'Debian',
             'oscodename': 'xenial',
             'osfullname': 'Ubuntu',
             'osrelease': '16.04',
             'osrelease_info': [16, 4],
             'osmajorrelease': 16,
             'osfinger': 'Ubuntu-16.04',
+            'files': '/etc/os-release',
         }
-        self._run_ubuntu_os_grains_tests(_os_release_map)
-
-    def _run_ubuntu_os_grains_tests(self, os_release_map):
-        os_release_map['linux_distribution'] = ('Ubuntu', '16.04', 'xenial')
-        os_release_map['os'] = 'Ubuntu'
-        os_release_map['os_family'] = 'Debian'
-        os_release_map['files'] = '/etc/os-release'
-        self._run_os_grains_tests(os_release_map)
+        self._run_os_grains_tests(_os_release_map)
 
     def test_docker_virtual(self):
         '''

--- a/tests/unit/grains/test_core.py
+++ b/tests/unit/grains/test_core.py
@@ -147,9 +147,6 @@ class CoreGrainsTestCase(TestCase, LoaderModuleMockMixin):
         _path_exists_map = {
             '/proc/1/cmdline': False
         }
-        _path_isfile_map = {
-            '/etc/os-release': True,
-        }
         _os_release_map = {
             'NAME': 'SLES',
             'VERSION': '12-SP1',
@@ -161,9 +158,6 @@ class CoreGrainsTestCase(TestCase, LoaderModuleMockMixin):
         }
 
         path_exists_mock = MagicMock(side_effect=lambda x: _path_exists_map[x])
-        path_isfile_mock = MagicMock(
-            side_effect=lambda x: _path_isfile_map.get(x, False)
-        )
         empty_mock = MagicMock(return_value={})
         osarch_mock = MagicMock(return_value="amd64")
         os_release_mock = MagicMock(return_value=_os_release_map)
@@ -191,7 +185,7 @@ class CoreGrainsTestCase(TestCase, LoaderModuleMockMixin):
                     with patch('{0}.__import__'.format(built_in),
                                side_effect=_import_mock):
                         # Skip all the /etc/*-release stuff (not pertinent)
-                        with patch.object(os.path, 'isfile', path_isfile_mock):
+                        with patch.object(os.path, 'isfile', MagicMock(return_value=False)):
                             with patch.object(core, '_parse_os_release', os_release_mock):
                                 # Mock linux_distribution to give us the OS
                                 # name that we want.
@@ -210,10 +204,10 @@ class CoreGrainsTestCase(TestCase, LoaderModuleMockMixin):
         self.assertEqual(os_grains.get('os'), 'SUSE')
 
     def _run_os_grains_tests(self, os_release_map):
-        path_isfile_mock = MagicMock(side_effect=lambda x: x in os_release_map['files'])
+        path_isfile_mock = MagicMock(side_effect=lambda x: x in os_release_map.get('files', []))
         empty_mock = MagicMock(return_value={})
         osarch_mock = MagicMock(return_value="amd64")
-        os_release_mock = MagicMock(return_value=os_release_map.get('os_release_file'))
+        os_release_mock = MagicMock(return_value=os_release_map.get('os_release_file', {}))
 
         orig_import = __import__
         if six.PY2:
@@ -309,7 +303,6 @@ PATCHLEVEL = 3
             'osrelease': '11.4',
             'osrelease_info': [11, 4],
             'osmajorrelease': 11,
-            'files': ["/etc/os-release"],
         }
         self._run_suse_os_grains_tests(_os_release_map)
 
@@ -333,7 +326,6 @@ PATCHLEVEL = 3
             'osrelease': '12',
             'osrelease_info': [12],
             'osmajorrelease': 12,
-            'files': ["/etc/os-release"],
         }
         self._run_suse_os_grains_tests(_os_release_map)
 
@@ -357,7 +349,6 @@ PATCHLEVEL = 3
             'osrelease': '12.1',
             'osrelease_info': [12, 1],
             'osmajorrelease': 12,
-            'files': ["/etc/os-release"],
         }
         self._run_suse_os_grains_tests(_os_release_map)
 
@@ -381,7 +372,6 @@ PATCHLEVEL = 3
             'osrelease': '42.1',
             'osrelease_info': [42, 1],
             'osmajorrelease': 42,
-            'files': ["/etc/os-release"],
         }
         self._run_suse_os_grains_tests(_os_release_map)
 
@@ -405,7 +395,6 @@ PATCHLEVEL = 3
             'osrelease': '20160504',
             'osrelease_info': [20160504],
             'osmajorrelease': 20160504,
-            'files': ["/etc/os-release"],
         }
         self._run_suse_os_grains_tests(_os_release_map)
 
@@ -431,7 +420,6 @@ PATCHLEVEL = 3
             'osrelease_info': [16, 4],
             'osmajorrelease': 16,
             'osfinger': 'Ubuntu-16.04',
-            'files': '/etc/os-release',
         }
         self._run_os_grains_tests(_os_release_map)
 

--- a/tests/unit/grains/test_core.py
+++ b/tests/unit/grains/test_core.py
@@ -405,7 +405,7 @@ PATCHLEVEL = 3
         self._run_suse_os_grains_tests(_os_release_map)
 
     @skipIf(not salt.utils.is_linux(), 'System is not Linux')
-    def test_ubuntu_os_grains(self):
+    def test_ubuntu_xenial_os_grains(self):
         '''
         Test if OS grains are parsed correctly in Ubuntu 16.04 "Xenial Xerus"
         '''
@@ -421,6 +421,24 @@ PATCHLEVEL = 3
             'osfinger': 'Ubuntu-16.04',
         }
         self._run_os_grains_tests("ubuntu-16.04", _os_release_map)
+
+    @skipIf(not salt.utils.is_linux(), 'System is not Linux')
+    def test_ubuntu_artful_os_grains(self):
+        '''
+        Test if OS grains are parsed correctly in Ubuntu 17.10 "Artful Aardvark"
+        '''
+        _os_release_map = {
+            'linux_distribution': ('Ubuntu', '17.10', 'artful'),
+            'os': 'Ubuntu',
+            'os_family': 'Debian',
+            'oscodename': 'artful',
+            'osfullname': 'Ubuntu',
+            'osrelease': '17.10',
+            'osrelease_info': [17, 10],
+            'osmajorrelease': 17,
+            'osfinger': 'Ubuntu-17.10',
+        }
+        self._run_os_grains_tests("ubuntu-17.10", _os_release_map)
 
     def test_docker_virtual(self):
         '''

--- a/tests/unit/grains/test_core.py
+++ b/tests/unit/grains/test_core.py
@@ -407,17 +407,10 @@ PATCHLEVEL = 3
     @skipIf(not salt.utils.is_linux(), 'System is not Linux')
     def test_ubuntu_os_grains(self):
         '''
-        Test if OS grains are parsed correctly in Ubuntu Xenial Xerus
+        Test if OS grains are parsed correctly in Ubuntu 16.04 "Xenial Xerus"
         '''
         _os_release_map = {
             'linux_distribution': ('Ubuntu', '16.04', 'xenial'),
-            'os_release_file': {
-                'NAME': 'Ubuntu',
-                'VERSION': '16.04.1 LTS (Xenial Xerus)',
-                'VERSION_ID': '16.04',
-                'PRETTY_NAME': '',
-                'ID': 'ubuntu',
-            },
             'os': 'Ubuntu',
             'os_family': 'Debian',
             'oscodename': 'xenial',
@@ -427,7 +420,7 @@ PATCHLEVEL = 3
             'osmajorrelease': 16,
             'osfinger': 'Ubuntu-16.04',
         }
-        self._run_os_grains_tests(None, _os_release_map)
+        self._run_os_grains_tests("ubuntu-16.04", _os_release_map)
 
     def test_docker_virtual(self):
         '''


### PR DESCRIPTION
This pull requests adds os grains test cases for Debian and Ubuntu (to address comments in #34423) and fixes an incorrect oscodename grain on Ubuntu (found the test case).