### PR TITLE
[oxygen.rc1] fix failing schedule tests

### DIFF
--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -247,6 +247,14 @@ class Schedule(object):
         if persist:
             self.persist()
 
+    def reset(self):
+        '''
+        Reset the scheduler to defaults
+        '''
+        self.skip_function = None
+        self.skip_during_range = None
+        self.opts['schedule'] = {}
+
     def delete_job_prefix(self, name, persist=True):
         '''
         Deletes a job from the scheduler. Ignores jobs from pillar

--- a/tests/integration/scheduler/test_eval.py
+++ b/tests/integration/scheduler/test_eval.py
@@ -53,7 +53,7 @@ class SchedulerEvalTest(ModuleCase, SaltReturnAssertsMixin):
         self.schedule.opts['loop_interval'] = 1
 
     def tearDown(self):
-        del self.schedule
+        self.schedule.reset()
 
     def test_eval(self):
         '''
@@ -71,7 +71,6 @@ class SchedulerEvalTest(ModuleCase, SaltReturnAssertsMixin):
         run_time1 = run_time2 - datetime.timedelta(seconds=1)
 
         # Add the job to the scheduler
-        self.schedule.opts['schedule'] = {}
         self.schedule.opts.update(job)
 
         # Evaluate 1 second before the run time
@@ -103,7 +102,6 @@ class SchedulerEvalTest(ModuleCase, SaltReturnAssertsMixin):
         run_time2 = dateutil_parser.parse('11/29/2017 5:00pm')
 
         # Add the job to the scheduler
-        self.schedule.opts['schedule'] = {}
         self.schedule.opts.update(job)
 
         # Evaluate run time1
@@ -135,7 +133,6 @@ class SchedulerEvalTest(ModuleCase, SaltReturnAssertsMixin):
         run_time2 = dateutil_parser.parse('11/29/2017 4:00pm')
 
         # Add the job to the scheduler
-        self.schedule.opts['schedule'] = {}
         self.schedule.opts.update(job)
 
         # Evaluate 1 second at the run time
@@ -167,7 +164,6 @@ class SchedulerEvalTest(ModuleCase, SaltReturnAssertsMixin):
         run_time2 = dateutil_parser.parse('11/29/2017 5:00pm') + datetime.timedelta(seconds=LOOP_INTERVAL)
 
         # Add the job to the scheduler
-        self.schedule.opts['schedule'] = {}
         self.schedule.opts.update(job)
 
         # Evaluate 1 second at the run time
@@ -195,7 +191,6 @@ class SchedulerEvalTest(ModuleCase, SaltReturnAssertsMixin):
         run_time = dateutil_parser.parse('12/13/2017 1:00pm')
 
         # Add the job to the scheduler
-        self.schedule.opts['schedule'] = {}
         self.schedule.opts.update(job)
 
         # Evaluate 1 second at the run time
@@ -223,7 +218,6 @@ class SchedulerEvalTest(ModuleCase, SaltReturnAssertsMixin):
         run_time = dateutil_parser.parse('12/13/2017 1:00pm') + datetime.timedelta(seconds=LOOP_INTERVAL)
 
         # Add the job to the scheduler
-        self.schedule.opts['schedule'] = {}
         self.schedule.opts.update(job)
 
         # Evaluate at the run time
@@ -274,7 +268,6 @@ class SchedulerEvalTest(ModuleCase, SaltReturnAssertsMixin):
         self.schedule.opts['loop_interval'] = LOOP_INTERVAL
 
         # Add the job to the scheduler
-        self.schedule.opts['schedule'] = {}
         self.schedule.opts.update(job)
 
         run_time = dateutil_parser.parse('11/29/2017 4:00pm')
@@ -300,7 +293,6 @@ class SchedulerEvalTest(ModuleCase, SaltReturnAssertsMixin):
         }
 
         # Add job to schedule
-        self.schedule.delete_job('job_eval_after')
         self.schedule.opts.update(job)
 
         # eval at 2:00pm to prime, simulate minion start up.
@@ -312,6 +304,7 @@ class SchedulerEvalTest(ModuleCase, SaltReturnAssertsMixin):
         run_time = dateutil_parser.parse('11/29/2017 3:00pm')
         self.schedule.eval(now=run_time)
         ret = self.schedule.job_status('job_eval_after')
+        log.debug('=== ret %s ===', ret)
         self.assertEqual(ret['_last_run'], run_time)
 
         # eval at 4:00pm, will run.
@@ -343,7 +336,6 @@ class SchedulerEvalTest(ModuleCase, SaltReturnAssertsMixin):
         }
 
         # Add job to schedule
-        self.schedule.delete_job('job1')
         self.schedule.opts.update(job)
 
         # eval at 2:00pm to prime, simulate minion start up.

--- a/tests/integration/scheduler/test_eval.py
+++ b/tests/integration/scheduler/test_eval.py
@@ -304,7 +304,6 @@ class SchedulerEvalTest(ModuleCase, SaltReturnAssertsMixin):
         run_time = dateutil_parser.parse('11/29/2017 3:00pm')
         self.schedule.eval(now=run_time)
         ret = self.schedule.job_status('job_eval_after')
-        log.debug('=== ret %s ===', ret)
         self.assertEqual(ret['_last_run'], run_time)
 
         # eval at 4:00pm, will run.

--- a/tests/integration/scheduler/test_postpone.py
+++ b/tests/integration/scheduler/test_postpone.py
@@ -45,7 +45,7 @@ class SchedulerPostponeTest(ModuleCase, SaltReturnAssertsMixin):
         self.schedule.opts['loop_interval'] = 1
 
     def tearDown(self):
-        del self.schedule
+        self.schedule.reset()
 
     def test_postpone(self):
         '''

--- a/tests/integration/scheduler/test_skip.py
+++ b/tests/integration/scheduler/test_skip.py
@@ -44,7 +44,7 @@ class SchedulerSkipTest(ModuleCase, SaltReturnAssertsMixin):
         self.schedule.opts['loop_interval'] = 1
 
     def tearDown(self):
-        del self.schedule
+        self.schedule.reset()
 
     def test_skip(self):
         '''
@@ -60,7 +60,6 @@ class SchedulerSkipTest(ModuleCase, SaltReturnAssertsMixin):
         }
 
         # Add job to schedule
-        self.schedule.opts['schedule'] = {}
         self.schedule.opts.update(job)
 
         run_time = dateutil_parser.parse('11/29/2017 4:00pm')
@@ -98,7 +97,6 @@ class SchedulerSkipTest(ModuleCase, SaltReturnAssertsMixin):
         }
 
         # Add job to schedule
-        self.schedule.opts['schedule'] = {}
         self.schedule.opts.update(job)
 
         # eval at 1:30pm to prime.
@@ -138,7 +136,6 @@ class SchedulerSkipTest(ModuleCase, SaltReturnAssertsMixin):
         }
 
         # Add job to schedule
-        self.schedule.opts['schedule'] = {}
         self.schedule.opts.update(job)
 
         # eval at 1:30pm to prime.
@@ -179,7 +176,6 @@ class SchedulerSkipTest(ModuleCase, SaltReturnAssertsMixin):
         }
 
         # Add job to schedule
-        self.schedule.opts['schedule'] = {}
         self.schedule.opts.update(job)
 
         # eval at 2:30pm, will not run during range.


### PR DESCRIPTION
### What does this PR do?
Adding a internal reset function to scheduler.  Calling reset between schedule tests to ensure schedule is empty and it is using defaults.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt-jenkins/issues/847

### Previous Behavior
When the scheduler integration tests run the scheduler object is reused between jobs, certain options were being left behind during test run which was causing problems.

### New Behavior
Reset function is now called after each job to ensure everything is set back to defaults.

### Tests written?
Yes.  Existing tests.

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
