### PR TITLE
Fix salt-ssh state.apply "'NoneType' object has no attribute 'count'" and unicode issue

### DIFF
--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -440,7 +440,7 @@ class SSH(object):
             if target.get('passwd', False) or self.opts['ssh_passwd']:
                 self._key_deploy_run(host, target, False)
             return ret
-        if ret[host].get('stderr', '').count('Permission denied'):
+        if (ret[host].get('stderr') or '').count('Permission denied'):
             target = self.targets[host]
             # permission denied, attempt to auto deploy ssh key
             print(('Permission denied for host {0}, do you want to deploy '
@@ -753,7 +753,7 @@ class SSH(object):
             self.cache_job(jid, host, ret[host], fun)
             ret = self.key_deploy(host, ret)
 
-            if isinstance(ret[host], dict) and ret[host].get('stderr', '').startswith('ssh:'):
+            if isinstance(ret[host], dict) and (ret[host].get('stderr') or '').startswith('ssh:'):
                 ret[host] = ret[host]['stderr']
 
             if not isinstance(ret[host], dict):

--- a/salt/utils/vt.py
+++ b/salt/utils/vt.py
@@ -642,7 +642,7 @@ class Terminal(object):
             if self.child_fde in rlist:
                 try:
                     stderr = self._translate_newlines(
-                        salt.utils.stringutils.to_str(
+                        salt.utils.stringutils.to_unicode(
                             os.read(self.child_fde, maxsize)
                         )
                     )
@@ -675,7 +675,7 @@ class Terminal(object):
             if self.child_fd in rlist:
                 try:
                     stdout = self._translate_newlines(
-                        salt.utils.stringutils.to_str(
+                        salt.utils.stringutils.to_unicode(
                             os.read(self.child_fd, maxsize)
                         )
                     )


### PR DESCRIPTION
### What does this PR do?

Fixes "'NoneType' object has no attribute 'count'" and 

```
[ERROR   ] An Exception occurred while executing state.apply: 'ascii' codec can't decode byte 0xc2 in position 10: ordinal not in range(128) 
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/salt/client/ssh/__init__.py", line 1133, in run_wfunc
    result = self.wfuncs[self.fun](*self.args, **self.kwargs)
  File "/usr/lib/python2.7/site-packages/salt/client/ssh/wrapper/state.py", line 462, in apply_
    return sls(mods, **kwargs)
  File "/usr/lib/python2.7/site-packages/salt/client/ssh/wrapper/state.py", line 190, in sls
    stdout, stderr, _ = single.cmd_block()
  File "/usr/lib/python2.7/site-packages/salt/client/ssh/__init__.py", line 1272, in cmd_block
    stdout, stderr, retcode = self.shim_cmd(cmd_str)
  File "/usr/lib/python2.7/site-packages/salt/client/ssh/__init__.py", line 1218, in shim_cmd
    return self.shell.exec_cmd(cmd_str)
  File "/usr/lib/python2.7/site-packages/salt/client/ssh/shell.py", line 344, in exec_cmd
    ret = self._run_cmd(cmd)
  File "/usr/lib/python2.7/site-packages/salt/client/ssh/shell.py", line 391, in _run_cmd
    stdout, stderr = term.recv()
  File "/usr/lib/python2.7/site-packages/salt/utils/vt.py", line 310, in recv
    return self._recv(maxsize)
  File "/usr/lib/python2.7/site-packages/salt/utils/vt.py", line 679, in _recv
    os.read(self.child_fd, maxsize)
  File "/usr/lib/python2.7/site-packages/salt/utils/vt.py", line 343, in _translate_newlines
    return data.replace('\r\n', os.linesep)
```

### What issues does this PR fix or reference?

### Tests written?

No

### Commits signed with GPG?

No