### PR TITLE
Add a KMS Envelope-Encryption Renderer

### DIFF
--- a/salt/renderers/aws_kms.py
+++ b/salt/renderers/aws_kms.py
@@ -188,6 +188,8 @@ def _plaintext_data_key():
         setattr(_plaintext_data_key, 'response', response)
     key_id = response['KeyId']
     plaintext = response['Plaintext']
+    if hasattr(plaintext, 'encode'):
+        plaintext = plaintext.encode(__salt_system_encoding__)
     log.debug('Using key %s from %s', key_id, 'cache' if cache_hit else 'api call')
     return plaintext
 
@@ -208,13 +210,13 @@ def _decrypt_ciphertext(cipher, translate_newlines=False):
     '''
     if translate_newlines:
         cipher = cipher.replace(r'\n', '\n')
-    if six.PY3:
+    if hasattr(cipher, 'encode'):
         cipher = cipher.encode(__salt_system_encoding__)
 
     # Decryption
     data_key = _base64_plaintext_data_key()
     plain_text = fernet.Fernet(data_key).decrypt(cipher)
-    if six.PY3 and isinstance(plain_text, bytes):
+    if hasattr(plain_text, 'decode'):
         plain_text = plain_text.decode(__salt_system_encoding__)
     return six.text_type(plain_text)
 

--- a/salt/renderers/aws_kms.py
+++ b/salt/renderers/aws_kms.py
@@ -70,7 +70,6 @@ import base64
 
 # Import salt libs
 import salt.utils.stringio
-import salt.utils.decorators as decorators
 
 # Import 3rd-party libs
 from salt.ext import six

--- a/salt/renderers/aws_kms.py
+++ b/salt/renderers/aws_kms.py
@@ -1,0 +1,169 @@
+# -*- coding: utf-8 -*-
+r'''
+Renderer that will decrypt ciphers encrypted using `AWS KMS Envelope Encryption`_.
+
+.. _`AWS KMS Envelope Encryption`: https://docs.aws.amazon.com/kms/latest/developerguide/workflow.html
+
+Any key in the data to be rendered can be a urlsafe_b64encoded string, and this renderer will attempt
+to decrypt it before passing it off to Salt. This allows you to safely store secrets in
+source control, in such a way that only your Salt master can decrypt them and
+distribute them only to the minions that need them.
+
+The typical use-case would be to use ciphers in your pillar data, and keep the encrypted
+data key on your master. This way developers with appropriate AWS IAM privileges can add new secrets
+quickly and easily.
+
+This renderer requires the boto3_ Python library.
+
+.. _boto3: https://boto3.readthedocs.io/
+
+Setup
+-----
+
+To set things up, first generate a KMS key.
+https://docs.aws.amazon.com/kms/latest/developerguide/create-keys.html
+
+Then generate a local data key from that KMS key and store it in your master config:
+
+.. code-block:: bash
+
+    # data_key=$(aws kms generate-data-key --key-id your-key-id --key-spec AES_256 --query 'CiphertextBlob' --output text)
+    # printf 'aws_kms_data_key: !!binary "%s"\n' "$data_key" >> config/master
+
+To apply the renderer on a file-by-file basis add the following line to the
+top of any pillar with gpg data in it:
+
+.. code-block:: yaml
+
+    #!yaml|aws_kms
+
+Now with your renderer configured, you can include your ciphers in your pillar
+data like so:
+
+.. code-block:: yaml
+
+    #!yaml|aws_kms
+
+    a-secret: gAAAAABaj5uzShPI3PEz6nL5Vhk2eEHxGXSZj8g71B84CZsVjAAtDFY1mfjNRl-1Su9YVvkUzNjI4lHCJJfXqdcTvwczBYtKy0Pa7Ri02s10Wn1tF0tbRwk=
+
+'''
+
+# Import python libs
+from __future__ import absolute_import, print_function, unicode_literals
+import logging
+import base64
+
+# Import salt libs
+import salt.utils.stringio
+import salt.utils.decorators as decorators
+
+# Import 3rd-party libs
+from salt.ext import six
+
+try:
+    import botocore.exceptions
+    import boto3
+    logging.getLogger('boto3').setLevel(logging.CRITICAL)
+except ImportError:
+    pass
+
+try:
+    import cryptography.fernet as fernet
+    HAS_FERNET = True
+except ImportError:
+    HAS_FERNET = False
+
+
+def __virtual__():
+    '''
+    Only load if boto libraries exist and if boto libraries are greater than
+    a given version.
+    '''
+    return HAS_FERNET and salt.utils.versions.check_boto_reqs()
+
+log = logging.getLogger(__name__)
+
+
+@decorators.memoize
+def _get_data_key():
+    '''
+    Return the configured KMS data key decrypted and encoded in urlsafe base64.
+
+    Memoize the result to minimize API calls to AWS.
+    '''
+    get_config = __salt__['config.get'] if 'config.get' in __salt__ else __opts__.get
+    data_key = get_config('aws_kms_data_key', '')
+    if not data_key:
+        raise salt.exceptions.SaltConfigurationError('aws_kms_data_key is not set')
+    client = boto3.client('kms')
+    try:
+        response = client.decrypt(CiphertextBlob=data_key)
+    except botocore.exceptions.ClientError as orig_exc:
+        error_code = orig_exc.response.get("Error", {}).get("Code", "")
+        if error_code == 'InvalidCiphertextException':
+            err_msg = 'aws_kms_data_key is not a valid KMS data key'
+            config_error = salt.exceptions.SaltConfigurationError(err_msg)
+            six.raise_from(config_error, orig_exc)
+        raise
+
+    log.debug('Using key %s', response['KeyId'])
+    clear_data_key = response['Plaintext']
+    return base64.urlsafe_b64encode(clear_data_key)
+
+
+def _decrypt_ciphertext(cipher, translate_newlines=False):
+    '''
+    Given a blob of ciphertext as a bytestring, try to decrypt
+    the cipher and return the decrypted string. If the cipher cannot be
+    decrypted, log the error, and return the ciphertext back out.
+    '''
+    if translate_newlines:
+        cipher = cipher.replace(r'\n', '\n')
+    if six.PY3:
+        cipher = cipher.encode(__salt_system_encoding__)
+
+    # Decryption
+    data_key = _get_data_key()
+    plain_text = fernet.Fernet(data_key).decrypt(cipher)
+    if six.PY3 and isinstance(plain_text, bytes):
+        plain_text = plain_text.decode(__salt_system_encoding__)
+    return six.text_type(plain_text)
+
+
+def _decrypt_object(obj, translate_newlines=False):
+    '''
+    Recursively try to decrypt any object.
+    Recur on objects that are not strings.
+    Decrypt strings that are valid Fernet tokens.
+    Return the rest unchanged.
+    '''
+    if salt.utils.stringio.is_readable(obj):
+        return _decrypt_object(obj.getvalue(), translate_newlines)
+    if isinstance(obj, six.string_types):
+        try:
+            return _decrypt_ciphertext(obj,
+                                       translate_newlines=translate_newlines)
+        except (fernet.InvalidToken, TypeError):
+            return obj
+
+    elif isinstance(obj, dict):
+        for key, value in six.iteritems(obj):
+            obj[key] = _decrypt_object(value,
+                                       translate_newlines=translate_newlines)
+        return obj
+    elif isinstance(obj, list):
+        for key, value in enumerate(obj):
+            obj[key] = _decrypt_object(value,
+                                       translate_newlines=translate_newlines)
+        return obj
+    else:
+        return obj
+
+
+def render(gpg_data, saltenv='base', sls='', argline='', **kwargs):  # pylint: disable=unused-argument
+    '''
+    Create a gpg object given a gpg_keydir, and then use it to try to decrypt
+    the data to be rendered.
+    '''
+    translate_newlines = kwargs.get('translate_newlines', False)
+    return _decrypt_object(gpg_data, translate_newlines=translate_newlines)

--- a/tests/unit/renderers/test_aws_kms.py
+++ b/tests/unit/renderers/test_aws_kms.py
@@ -1,0 +1,110 @@
+# -*- coding: utf-8 -*-
+
+'''
+Unit tests for AWS KMS Decryption Renderer.
+'''
+# pylint: disable=protected-access
+
+# Import Python Libs
+from __future__ import absolute_import, print_function, unicode_literals
+
+import base64
+
+# Import Salt Testing libs
+from tests.support.mixins import LoaderModuleMockMixin
+from tests.support.unit import skipIf, TestCase
+from tests.support.mock import (
+    NO_MOCK,
+    NO_MOCK_REASON,
+    MagicMock,
+    patch
+)
+
+# Import Salt libs
+import salt.exceptions
+import salt.renderers.aws_kms as aws_kms
+
+try:
+    import cryptography.fernet as fernet
+    HAS_FERNET = True
+except ImportError:
+    HAS_FERNET = False
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class AWSKMSTestCase(TestCase, LoaderModuleMockMixin):
+
+    '''
+    unit test AWS KMS renderer
+    '''
+
+    def setup_loader_modules(self):
+        return {aws_kms: {}}
+
+    def test__get_data_key(self):
+        '''
+        test _get_data_key
+        '''
+        mocked_data_key = 'MockedKeyPlaintext'
+        self.assertRaises(salt.exceptions.SaltConfigurationError, aws_kms._get_data_key)
+
+        with patch.dict(aws_kms.__salt__, {'config.get': MagicMock(return_value='abc123')}):  # pylint: disable=no-member
+            self.assertRaises(salt.exceptions.SaltConfigurationError, aws_kms._get_data_key)
+
+            def mock_make_api_call(self, operation_name, kwarg):   # pylint: disable=unused-argument
+                '''
+                Generically mock a boto3 API call
+                '''
+                if operation_name == 'Decrypt':
+                    return {'KeyId': 'MockedKeyId', 'Plaintext': mocked_data_key}
+                return {}
+
+            with patch('botocore.client.BaseClient._make_api_call', new=mock_make_api_call):
+                data_key = aws_kms._get_data_key()
+                self.assertEqual(base64.urlsafe_b64decode(data_key), mocked_data_key)
+
+    @skipIf(not HAS_FERNET, 'Failed to import cryptography.fernet')
+    def test__decrypt_ciphertext(self):
+        '''
+        test _decrypt_ciphertext
+        '''
+        test_key = fernet.Fernet.generate_key()
+        secret = 'Use more salt.'
+        crypted = fernet.Fernet(test_key).encrypt(bytes(secret))
+        with patch('salt.renderers.aws_kms._get_data_key', MagicMock(return_value=test_key)):
+            self.assertEqual(aws_kms._decrypt_ciphertext(crypted), secret)
+
+    @skipIf(not HAS_FERNET, 'Failed to import cryptography.fernet')
+    def test__decrypt_object(self):
+        '''
+        test _decrypt_object
+        '''
+
+        test_key = fernet.Fernet.generate_key()
+        secret = 'Use more salt.'
+        crypted = fernet.Fernet(test_key).encrypt(bytes(secret))
+        secret_map = {'secret': secret}
+        crypted_map = {'secret': crypted}
+
+        secret_list = [secret]
+        crypted_list = [crypted]
+
+        with patch('salt.renderers.aws_kms._get_data_key', MagicMock(return_value=test_key)):
+            self.assertEqual(aws_kms._decrypt_object(secret), secret)
+            self.assertEqual(aws_kms._decrypt_object(crypted), secret)
+            self.assertEqual(aws_kms._decrypt_object(crypted_map), secret_map)
+            self.assertEqual(aws_kms._decrypt_object(crypted_list), secret_list)
+            self.assertEqual(aws_kms._decrypt_object(None), None)
+
+    @skipIf(not HAS_FERNET, 'Failed to import cryptography.fernet')
+    def test_render(self):
+        '''
+        test render
+        '''
+
+        test_key = fernet.Fernet.generate_key()
+        secret = 'Use more salt.'
+        crypted = fernet.Fernet(test_key).encrypt(bytes(secret))
+
+        with patch('salt.renderers.aws_kms._get_data_key', MagicMock(return_value=test_key)):
+            self.assertEqual(aws_kms.render(crypted), secret)

--- a/tests/unit/renderers/test_aws_kms.py
+++ b/tests/unit/renderers/test_aws_kms.py
@@ -37,9 +37,10 @@ except ImportError:
     NO_FERNET = True
 
 
+PLAINTEXT_SECRET = 'Use more salt.'
 ENCRYPTED_DATA_KEY = 'encrypted-data-key'
-PLAINTEXT_DATA_KEY = 'plaintext-data-key'
-BASE64_DATA_KEY = 'cGxhaW50ZXh0LWRhdGEta2V5'
+PLAINTEXT_DATA_KEY = b'plaintext-data-key'
+BASE64_DATA_KEY = b'cGxhaW50ZXh0LWRhdGEta2V5'
 AWS_PROFILE = 'test-profile'
 REGION_NAME = 'us-test-1'
 
@@ -169,10 +170,9 @@ class AWSKMSTestCase(TestCase, LoaderModuleMockMixin):
         test _decrypt_ciphertext
         '''
         test_key = fernet.Fernet.generate_key()
-        secret = 'Use more salt.'
-        crypted = fernet.Fernet(test_key).encrypt(bytes(secret))
+        crypted = fernet.Fernet(test_key).encrypt(PLAINTEXT_SECRET.encode())
         with patch.object(aws_kms, '_base64_plaintext_data_key', return_value=test_key):
-            self.assertEqual(aws_kms._decrypt_ciphertext(crypted), secret)
+            self.assertEqual(aws_kms._decrypt_ciphertext(crypted), PLAINTEXT_SECRET)
 
     @skipIf(NO_FERNET, 'Failed to import cryptography.fernet')
     def test__decrypt_object(self):
@@ -180,17 +180,16 @@ class AWSKMSTestCase(TestCase, LoaderModuleMockMixin):
         Test _decrypt_object
         '''
         test_key = fernet.Fernet.generate_key()
-        secret = 'Use more salt.'
-        crypted = fernet.Fernet(test_key).encrypt(bytes(secret))
-        secret_map = {'secret': secret}
+        crypted = fernet.Fernet(test_key).encrypt(PLAINTEXT_SECRET.encode())
+        secret_map = {'secret': PLAINTEXT_SECRET}
         crypted_map = {'secret': crypted}
 
-        secret_list = [secret]
+        secret_list = [PLAINTEXT_SECRET]
         crypted_list = [crypted]
 
         with patch.object(aws_kms, '_base64_plaintext_data_key', return_value=test_key):
-            self.assertEqual(aws_kms._decrypt_object(secret), secret)
-            self.assertEqual(aws_kms._decrypt_object(crypted), secret)
+            self.assertEqual(aws_kms._decrypt_object(PLAINTEXT_SECRET), PLAINTEXT_SECRET)
+            self.assertEqual(aws_kms._decrypt_object(crypted), PLAINTEXT_SECRET)
             self.assertEqual(aws_kms._decrypt_object(crypted_map), secret_map)
             self.assertEqual(aws_kms._decrypt_object(crypted_list), secret_list)
             self.assertEqual(aws_kms._decrypt_object(None), None)
@@ -201,8 +200,6 @@ class AWSKMSTestCase(TestCase, LoaderModuleMockMixin):
         Test that we can decrypt some data.
         '''
         test_key = fernet.Fernet.generate_key()
-        secret = 'Use more salt.'
-        crypted = fernet.Fernet(test_key).encrypt(bytes(secret))
-
+        crypted = fernet.Fernet(test_key).encrypt(PLAINTEXT_SECRET.encode())
         with patch.object(aws_kms, '_base64_plaintext_data_key', return_value=test_key):
-            self.assertEqual(aws_kms.render(crypted), secret)
+            self.assertEqual(aws_kms.render(crypted), PLAINTEXT_SECRET)

--- a/tests/unit/renderers/test_aws_kms.py
+++ b/tests/unit/renderers/test_aws_kms.py
@@ -8,8 +8,6 @@ Unit tests for AWS KMS Decryption Renderer.
 # Import Python Libs
 from __future__ import absolute_import, print_function, unicode_literals
 
-import base64
-
 # Import Salt Testing libs
 from tests.support.mixins import LoaderModuleMockMixin
 from tests.support.unit import skipIf, TestCase
@@ -25,13 +23,29 @@ import salt.exceptions
 import salt.renderers.aws_kms as aws_kms
 
 try:
-    import cryptography.fernet as fernet
-    HAS_FERNET = True
+    import botocore.exceptions
+    import botocore.session
+    import botocore.stub
+    NO_BOTOCORE = False
 except ImportError:
-    HAS_FERNET = False
+    NO_BOTOCORE = True
+
+try:
+    import cryptography.fernet as fernet
+    NO_FERNET = False
+except ImportError:
+    NO_FERNET = True
+
+
+ENCRYPTED_DATA_KEY = 'encrypted-data-key'
+PLAINTEXT_DATA_KEY = 'plaintext-data-key'
+BASE64_DATA_KEY = 'cGxhaW50ZXh0LWRhdGEta2V5'
+AWS_PROFILE = 'test-profile'
+REGION_NAME = 'us-test-1'
 
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
+@skipIf(NO_BOTOCORE, 'Unable to import botocore libraries')
 class AWSKMSTestCase(TestCase, LoaderModuleMockMixin):
 
     '''
@@ -41,29 +55,115 @@ class AWSKMSTestCase(TestCase, LoaderModuleMockMixin):
     def setup_loader_modules(self):
         return {aws_kms: {}}
 
-    def test__get_data_key(self):
+    def test__cfg_data_key(self):
         '''
-        test _get_data_key
+        _cfg_data_key returns the aws_kms:data_key from configuration.
         '''
-        mocked_data_key = 'MockedKeyPlaintext'
-        self.assertRaises(salt.exceptions.SaltConfigurationError, aws_kms._get_data_key)
+        config = {'aws_kms': {'data_key': ENCRYPTED_DATA_KEY}}
+        with patch.dict(aws_kms.__salt__, {'config.get': config.get}):  # pylint: disable=no-member
+            self.assertEqual(aws_kms._cfg_data_key(), ENCRYPTED_DATA_KEY,
+                             '_cfg_data_key did not return the data key configured in __salt__.')
+        with patch.dict(aws_kms.__opts__, config):  # pylint: disable=no-member
+            self.assertEqual(aws_kms._cfg_data_key(), ENCRYPTED_DATA_KEY,
+                             '_cfg_data_key did not return the data key configured in __opts__.')
 
-        with patch.dict(aws_kms.__salt__, {'config.get': MagicMock(return_value='abc123')}):  # pylint: disable=no-member
-            self.assertRaises(salt.exceptions.SaltConfigurationError, aws_kms._get_data_key)
+    def test__cfg_data_key_no_key(self):
+        '''
+        When no aws_kms:data_key is configured,
+        calling _cfg_data_key should raise a SaltConfigurationError
+        '''
+        self.assertRaises(salt.exceptions.SaltConfigurationError, aws_kms._cfg_data_key)
 
-            def mock_make_api_call(self, operation_name, kwarg):   # pylint: disable=unused-argument
-                '''
-                Generically mock a boto3 API call
-                '''
-                if operation_name == 'Decrypt':
-                    return {'KeyId': 'MockedKeyId', 'Plaintext': mocked_data_key}
-                return {}
+    def test__session_profile(self):  # pylint: disable=no-self-use
+        '''
+        _session instantiates boto3.Session with the configured profile_name
+        '''
+        with patch.object(aws_kms, '_cfg', lambda k: AWS_PROFILE):
+            with patch('boto3.Session') as session:
+                aws_kms._session()
+                session.assert_called_with(profile_name=AWS_PROFILE)
 
-            with patch('botocore.client.BaseClient._make_api_call', new=mock_make_api_call):
-                data_key = aws_kms._get_data_key()
-                self.assertEqual(base64.urlsafe_b64decode(data_key), mocked_data_key)
+    def test__session_noprofile(self):
+        '''
+        _session raises a SaltConfigurationError
+        when boto3 raises botocore.exceptions.ProfileNotFound.
+        '''
+        with patch('boto3.Session') as session:
+            session.side_effect = botocore.exceptions.ProfileNotFound(profile=AWS_PROFILE)
+            self.assertRaises(salt.exceptions.SaltConfigurationError, aws_kms._session)
 
-    @skipIf(not HAS_FERNET, 'Failed to import cryptography.fernet')
+    def test__session_noregion(self):
+        '''
+        _session raises a SaltConfigurationError
+        when boto3 raises botocore.exceptions.NoRegionError
+        '''
+        with patch('boto3.Session') as session:
+            session.side_effect = botocore.exceptions.NoRegionError
+            self.assertRaises(salt.exceptions.SaltConfigurationError, aws_kms._session)
+
+    def test__kms(self):  # pylint: disable=no-self-use
+        '''
+        _kms calls boto3.Session.client with 'kms' as its only argument.
+        '''
+        with patch('boto3.Session.client') as client:
+            aws_kms._kms()
+            client.assert_called_with('kms')
+
+    def test__kms_noregion(self):
+        '''
+        _kms raises a SaltConfigurationError
+        when boto3 raises a NoRegionError.
+        '''
+        with patch('boto3.Session') as session:
+            session.side_effect = botocore.exceptions.NoRegionError
+            self.assertRaises(salt.exceptions.SaltConfigurationError, aws_kms._kms)
+
+    def test__api_decrypt(self):  # pylint: disable=no-self-use
+        '''
+        _api_decrypt_response calls kms.decrypt with the
+        configured data key as the CiphertextBlob kwarg.
+        '''
+        kms_client = MagicMock()
+        with patch.object(aws_kms, '_kms') as kms_getter:
+            kms_getter.return_value = kms_client
+            with patch.object(aws_kms, '_cfg_data_key', lambda: ENCRYPTED_DATA_KEY):
+                aws_kms._api_decrypt()
+                kms_client.decrypt.assert_called_with(CiphertextBlob=ENCRYPTED_DATA_KEY)  # pylint: disable=no-member
+
+    def test__api_decrypt_badkey(self):
+        '''
+        _api_decrypt_response raises SaltConfigurationError
+        when kms.decrypt raises a botocore.exceptions.ClientError
+        with an error_code of 'InvalidCiphertextException'.
+        '''
+        kms_client = MagicMock()
+        kms_client.decrypt.side_effect = botocore.exceptions.ClientError(  # pylint: disable=no-member
+            error_response={'Error': {'Code': 'InvalidCiphertextException'}},
+            operation_name='Decrypt',
+        )
+        with patch.object(aws_kms, '_kms') as kms_getter:
+            kms_getter.return_value = kms_client
+            with patch.object(aws_kms, '_cfg_data_key', lambda: ENCRYPTED_DATA_KEY):
+                self.assertRaises(salt.exceptions.SaltConfigurationError, aws_kms._api_decrypt)
+
+    def test__plaintext_data_key(self):
+        '''
+        _plaintext_data_key returns the 'Plaintext' value from the response.
+        It caches the response and only calls _api_decrypt exactly once.
+        '''
+        with patch.object(aws_kms, '_api_decrypt', return_value={'KeyId': 'key-id', 'Plaintext': PLAINTEXT_DATA_KEY}) as api_decrypt:
+            self.assertEqual(aws_kms._plaintext_data_key(), PLAINTEXT_DATA_KEY)
+            aws_kms._plaintext_data_key()
+            api_decrypt.assert_called_once()
+
+    def test__base64_plaintext_data_key(self):
+        '''
+        _base64_plaintext_data_key returns the urlsafe base64 encoded plain text data key.
+        '''
+        with patch.object(aws_kms, '_plaintext_data_key', return_value=PLAINTEXT_DATA_KEY):
+            self.assertEqual(aws_kms._base64_plaintext_data_key(), BASE64_DATA_KEY)
+
+    @skipIf(NO_FERNET, 'Failed to import cryptography.fernet')
     def test__decrypt_ciphertext(self):
         '''
         test _decrypt_ciphertext
@@ -71,15 +171,14 @@ class AWSKMSTestCase(TestCase, LoaderModuleMockMixin):
         test_key = fernet.Fernet.generate_key()
         secret = 'Use more salt.'
         crypted = fernet.Fernet(test_key).encrypt(bytes(secret))
-        with patch('salt.renderers.aws_kms._get_data_key', MagicMock(return_value=test_key)):
+        with patch.object(aws_kms, '_base64_plaintext_data_key', return_value=test_key):
             self.assertEqual(aws_kms._decrypt_ciphertext(crypted), secret)
 
-    @skipIf(not HAS_FERNET, 'Failed to import cryptography.fernet')
+    @skipIf(NO_FERNET, 'Failed to import cryptography.fernet')
     def test__decrypt_object(self):
         '''
-        test _decrypt_object
+        Test _decrypt_object
         '''
-
         test_key = fernet.Fernet.generate_key()
         secret = 'Use more salt.'
         crypted = fernet.Fernet(test_key).encrypt(bytes(secret))
@@ -89,22 +188,21 @@ class AWSKMSTestCase(TestCase, LoaderModuleMockMixin):
         secret_list = [secret]
         crypted_list = [crypted]
 
-        with patch('salt.renderers.aws_kms._get_data_key', MagicMock(return_value=test_key)):
+        with patch.object(aws_kms, '_base64_plaintext_data_key', return_value=test_key):
             self.assertEqual(aws_kms._decrypt_object(secret), secret)
             self.assertEqual(aws_kms._decrypt_object(crypted), secret)
             self.assertEqual(aws_kms._decrypt_object(crypted_map), secret_map)
             self.assertEqual(aws_kms._decrypt_object(crypted_list), secret_list)
             self.assertEqual(aws_kms._decrypt_object(None), None)
 
-    @skipIf(not HAS_FERNET, 'Failed to import cryptography.fernet')
+    @skipIf(NO_FERNET, 'Failed to import cryptography.fernet')
     def test_render(self):
         '''
-        test render
+        Test that we can decrypt some data.
         '''
-
         test_key = fernet.Fernet.generate_key()
         secret = 'Use more salt.'
         crypted = fernet.Fernet(test_key).encrypt(bytes(secret))
 
-        with patch('salt.renderers.aws_kms._get_data_key', MagicMock(return_value=test_key)):
+        with patch.object(aws_kms, '_base64_plaintext_data_key', return_value=test_key):
             self.assertEqual(aws_kms.render(crypted), secret)


### PR DESCRIPTION
### What does this PR do?

This provides a renderer to decrypt values stored using a KMS data key as per [KMS envelope encryption](https://docs.aws.amazon.com/kms/latest/developerguide/workflow.html). It is pretty similar to the gpg renderer -- it just uses a different approach to do the actual decryption. This is something that is useful to me. I hope it's useful to others, too.

### New Behavior

1. Provide a encrypted KMS data key in your master config under the name `aws_kms_data_key`.
2. Ensure that the salt master has appropriate iam permissions and configuration to access the KMS key needed to decrypt the data key.
3. Encrypt some values using the plaintext value of the data key with [`cryptography.fernet`](https://cryptography.io/en/latest/fernet/) and put them in a sls file to be rendered via the kms renderer provided in this PR.

### Notes and sales pitch

This is most useful for salt users already in an AWS environment who need shared secrets stored in pillars and prefer to put them e.g. in Git rather than in S3. With GPG you would need each salt user to have their own key, but encrypted PGP messages get linearly larger with each recipient key. Of course, you could use a single shared GPG key, but then you'd have to figure out how to securely share that key. KMS just handles the securely-sharing keys bit for us.

### Tests written?

Yes

### Commits signed with GPG?

Yes