### PR TITLE
Add team-suse to CODEOWNERS file for zypper files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -52,6 +52,9 @@ salt/**/thin.py                     @saltstack/team-ssh
 # Team State
 salt/state.py                       @saltstack/team-state
 
+# Team SUSE
+salt/**/*zypper*                      @saltstack/team-suse
+
 # Team Transport
 salt/transport/                     @saltstack/team-transport
 salt/utils/zeromq.py                @saltstack/team-transport

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -53,7 +53,11 @@ salt/**/thin.py                     @saltstack/team-ssh
 salt/state.py                       @saltstack/team-state
 
 # Team SUSE
-salt/**/*zypper*                      @saltstack/team-suse
+salt/**/*btrfs*                     @saltstack/team-suse
+salt/**/*kubernetes*                @saltstack/team-suse
+salt/**/*xfs*                       @saltstack/team-suse
+salt/**/*yumpkg*                    @saltstack/team-suse
+salt/**/*zypper*                    @saltstack/team-suse
 
 # Team Transport
 salt/transport/                     @saltstack/team-transport

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -55,8 +55,9 @@ salt/state.py                       @saltstack/team-state
 # Team SUSE
 salt/**/*btrfs*                     @saltstack/team-suse
 salt/**/*kubernetes*                @saltstack/team-suse
+salt/**/*pkg*                       @saltstack/team-suse
+salt/**/*snapper*                   @saltstack/team-suse
 salt/**/*xfs*                       @saltstack/team-suse
-salt/**/*yumpkg*                    @saltstack/team-suse
 salt/**/*zypper*                    @saltstack/team-suse
 
 # Team Transport


### PR DESCRIPTION
This addition will enable automatic reviews from team-suse for PRs that touch the zypper files.

