### PR TITLE
Add credentials and secretfile to mount.mounted mount_invisible_keys

### DIFF
--- a/salt/states/mount.py
+++ b/salt/states/mount.py
@@ -319,10 +319,12 @@ def mounted(name,
                 mount_invisible_keys = [
                     'actimeo',
                     'comment',
+                    'credentials',
                     'direct-io-mode',
                     'password',
-                    'retry',
                     'port',
+                    'retry',
+                    'secretfile',
                 ]
 
                 if extra_mount_invisible_keys:


### PR DESCRIPTION
### What does this PR do?

Adds 'credentails' and 'secretfile' to mount_invisible_keys because these keys don't appear in /proc/self/mountinfo and therefore trigger a forced remount of the share every time the state is run.

### What issues does this PR fix or reference?

Fixes #45136 and #46178

### Previous Behavior

Share will be force remounted every time the state is run when 'credentails=' or 'secretfile=' are used as an option.

### New Behavior

Share is no longer force-remounted under these conditions.

### Tests written?

No

### Commits signed with GPG?

No