### PR TITLE
Fix docker_container.running HostConfig Ulimits comparison

### DIFF
--- a/salt/modules/dockermod.py
+++ b/salt/modules/dockermod.py
@@ -575,6 +575,15 @@ def _scrub_links(links, name):
     return ret
 
 
+def _ulimit_sort(ulimit_val):
+    if isinstance(ulimit_val, list):
+        return sorted(ulimit_val,
+                      key=lambda x: (x.get('Name'),
+                                     x.get('Hard', 0),
+                                     x.get('Soft', 0)))
+    return ulimit_val
+
+
 def _size_fmt(num):
     '''
     Format bytes as human-readable file sizes
@@ -912,6 +921,9 @@ def compare_container(first, second, ignore=None):
                 if item == 'Links':
                     val1 = sorted(_scrub_links(val1, first))
                     val2 = sorted(_scrub_links(val2, second))
+                if item == 'Ulimits':
+                    val1 = _ulimit_sort(val1)
+                    val2 = _ulimit_sort(val2)
                 if val1 != val2:
                     ret.setdefault(conf_dict, {})[item] = {'old': val1, 'new': val2}
         # Check for optionally-present items that were in the second container
@@ -935,6 +947,9 @@ def compare_container(first, second, ignore=None):
                 if item == 'Links':
                     val1 = sorted(_scrub_links(val1, first))
                     val2 = sorted(_scrub_links(val2, second))
+                if item == 'Ulimits':
+                    val1 = _ulimit_sort(val1)
+                    val2 = _ulimit_sort(val2)
                 if val1 != val2:
                     ret.setdefault(conf_dict, {})[item] = {'old': val1, 'new': val2}
     return ret

--- a/salt/states/docker_container.py
+++ b/salt/states/docker_container.py
@@ -1445,14 +1445,14 @@ def running(name,
         .. code-block:: yaml
 
             foo:
-              dockerng.running:
+              docker_container.running:
                 - image: bar/baz:latest
                 - ulimits: nofile=1024:1024,nproc=60
 
         .. code-block:: yaml
 
             foo:
-              dockerng.running:
+              docker_container.running:
                 - image: bar/baz:latest
                 - ulimits:
                   - nofile=1024:1024

--- a/tests/unit/modules/test_dockermod.py
+++ b/tests/unit/modules/test_dockermod.py
@@ -725,6 +725,35 @@ class DockerTestCase(TestCase, LoaderModuleMockMixin):
                 ret = docker_mod.compare_container('container1', 'container2')
                 self.assertEqual(ret, {})
 
+    def test_compare_container_ulimits_order(self):
+        '''
+        Test comparing two containers when the order of the Ulimits HostConfig
+        values are different, but the values are the same.
+        '''
+        def _inspect_container_effect(id_):
+            return {
+                'container1': {'Config': {},
+                               'HostConfig': {
+                                   'Ulimits': [
+                                       {u'Hard': -1, u'Soft': -1, u'Name': u'core'},
+                                       {u'Hard': 65536, u'Soft': 65536, u'Name': u'nofile'}
+                                   ]
+                               }},
+                'container2': {'Config': {},
+                               'HostConfig': {
+                                   'Ulimits': [
+                                       {u'Hard': 65536, u'Soft': 65536, u'Name': u'nofile'},
+                                       {u'Hard': -1, u'Soft': -1, u'Name': u'core'}
+                                   ]
+                               }},
+            }[id_]
+
+        inspect_container_mock = MagicMock(side_effect=_inspect_container_effect)
+
+        with patch.object(docker_mod, 'inspect_container', inspect_container_mock):
+            ret = docker_mod.compare_container('container1', 'container2')
+            self.assertEqual(ret, {})
+
     def test_resolve_tag(self):
         '''
         Test the resolve_tag function


### PR DESCRIPTION
### What does this PR do?

Ensures any list coming back from `HostConfig`'s  `Ulimits` is sorted before comparison with `docker.compare_container`.  Also fixes an old `dockerng` state reference in the docs.

### What issues does this PR fix or reference?

Fixes #46182.

### Tests written?

Yes

### Commits signed with GPG?

Yes
