### PR TITLE
Format string before passing to log_callback.

### DIFF
--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -456,7 +456,8 @@ def _run(cmd,
                 env_cmd = ('su', runas, '-c', sys.executable)
             else:
                 env_cmd = ('su', '-s', shell, '-', runas, '-c', sys.executable)
-            log.debug(log_callback('env command: %s', env_cmd))
+            msg = 'env command: {0}'.format(env_cmd)
+            log.debug(log_callback(msg))
             env_bytes = salt.utils.stringutils.to_bytes(subprocess.Popen(
                 env_cmd,
                 stdin=subprocess.PIPE,


### PR DESCRIPTION
### What does this PR do?
Fixes wrong usage of `log_callback` function in cmdmod. The `log_callback` function accepts the only one argument so the string have to be formatted first.
This fixes `integration.states.test_virtualenv.VirtualenvTest.test_issue_1959_virtualenv_runas` integration test.

### What issues does this PR fix or reference?
Fix https://github.com/saltstack/salt-jenkins/issues/831
Fix https://github.com/saltstack/salt-jenkins/issues/827

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
