### PR TITLE
Bugfix: SSDP crash on Python3  environment (bytes vs unicode)

### DIFF
--- a/salt/utils/ssdp.py
+++ b/salt/utils/ssdp.py
@@ -193,10 +193,10 @@ class SSDPFactory(SSDPBase):
 
             self.log.debug('Received "%s" from %s:%s', message, *addr)
             self._sendto(
-                str('{0}:@:{1}').format(  # future lint: disable=blacklisted-function
+                salt.utils.stringutils.to_bytes(str('{0}:@:{1}').format(  # future lint: disable=blacklisted-function
                     self.signature,
                     salt.utils.json.dumps(self.answer, _json_module=_json)
-                ),
+                )),
                 addr
             )
         else:

--- a/tests/unit/utils/test_ssdp.py
+++ b/tests/unit/utils/test_ssdp.py
@@ -305,7 +305,7 @@ class SSDPFactoryTestCase(TestCase):
             assert factory.log.debug.called
             assert factory.disable_hidden
             assert factory._sendto.called
-            assert factory._sendto.call_args[0][0] == "{}:@:{{}}".format(signature)
+            assert factory._sendto.call_args[0][0] == salt.utils.stringutils.to_bytes("{}:@:{{}}".format(signature))
             assert 'Received "%s" from %s:%s' in factory.log.debug.call_args[0][0]
 
 


### PR DESCRIPTION
### What does this PR do?

Bugfix

### What issues does this PR fix or reference?

Unicode won't be sent over socket, but bytes. This was overlooked.

### Tests written?

Yes
