### PR TITLE
Fixed bad clustershell merge.

### DIFF
--- a/salt/roster/clustershell.py
+++ b/salt/roster/clustershell.py
@@ -45,7 +45,7 @@ def targets(tgt, tgt_type='glob', **kwargs):
 
     for host, addr in host_addrs.items():
         addr = six.text_type(addr)
-        ret[addr] = copy.deepcopy(__opts__.get('roster_defaults', {}))
+        ret[host] = copy.deepcopy(__opts__.get('roster_defaults', {}))
         for port in ports:
             try:
                 sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)


### PR DESCRIPTION
### What does this PR do?
There are 2 commits fefd28d8964 and 4ab5d5d390e touching line 48 in `roster/clustershell.py`.
It looks like fefd28d8964 was put above the 4ab5d5d390e and discarded that line changes. I've returned them back.

### What issues does this PR fix or reference?
Fix https://github.com/saltstack/salt-jenkins/issues/829

### Previous Behavior
Clustershell sets `ret[addr]` and then tries to update `ret[host]` getting a `KeyError`.

### New Behavior
Set `ret[host]` and then update it by that key `ret[host]`.

### Tests written?
Fixes the already written test.

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
