### PR TITLE
Add mapper to salt.utils.args.split_input()

### DIFF
--- a/salt/utils/args.py
+++ b/salt/utils/args.py
@@ -14,7 +14,7 @@ import shlex
 # Import salt libs
 from salt.exceptions import SaltInvocationError
 from salt.ext import six
-from salt.ext.six.moves import zip  # pylint: disable=import-error,redefined-builtin
+from salt.ext.six.moves import map, zip  # pylint: disable=import-error,redefined-builtin
 import salt.utils.data
 import salt.utils.jid
 import salt.utils.versions
@@ -339,16 +339,18 @@ def argspec_report(functions, module=''):
     return ret
 
 
-def split_input(val):
+def split_input(val, mapper=None):
     '''
     Take an input value and split it into a list, returning the resulting list
     '''
+    if mapper is None:
+        mapper = lambda x: x
     if isinstance(val, list):
-        return val
+        return map(mapper, val)
     try:
-        return [x.strip() for x in val.split(',')]
+        return map(mapper, [x.strip() for x in val.split(',')])
     except AttributeError:
-        return [x.strip() for x in six.text_type(val).split(',')]
+        return map(mapper, [x.strip() for x in six.text_type(val).split(',')])
 
 
 def test_mode(**kwargs):

--- a/salt/utils/args.py
+++ b/salt/utils/args.py
@@ -346,11 +346,11 @@ def split_input(val, mapper=None):
     if mapper is None:
         mapper = lambda x: x
     if isinstance(val, list):
-        return map(mapper, val)
+        return list(map(mapper, val))
     try:
-        return map(mapper, [x.strip() for x in val.split(',')])
+        return list(map(mapper, [x.strip() for x in val.split(',')]))
     except AttributeError:
-        return map(mapper, [x.strip() for x in six.text_type(val).split(',')])
+        return list(map(mapper, [x.strip() for x in six.text_type(val).split(',')]))
 
 
 def test_mode(**kwargs):


### PR DESCRIPTION
This allows for one to pass a function reference as a second argumment
to split_input, which will be used to perform conversion on the split
input. This is useful for instances where we want to get a list of ints
out of a Salt CLI arg like foo=1,2,3. With the pre-existing code, this
would force you to either manually run something like:

```python
map(int, salt.utils.args.split_input(val))
```

With this PR, you can now run:

```python
salt.utils.args.split_input(val, int)
```