### PR TITLE
adding loaded feature to mac_service

### DIFF
--- a/salt/modules/mac_service.py
+++ b/salt/modules/mac_service.py
@@ -162,7 +162,7 @@ def _always_running_service(name):
 
     :rtype: bool
 
-    .. versionadded::
+    .. versionadded:: Fluorine
     '''
 
     # get all the info from the launchctl service

--- a/salt/modules/mac_service.py
+++ b/salt/modules/mac_service.py
@@ -150,6 +150,37 @@ def _get_service(name):
     raise CommandExecutionError('Service not found: {0}'.format(name))
 
 
+def _always_running_service(name):
+    '''
+    Check if the service should always be running based on the KeepAlive Key
+    in the service plist.
+
+    :param str name: Service label, file name, or full path
+
+    :return: True if the KeepAlive key is set to True, False if set to False or
+        not set in the plist at all.
+
+    :rtype: bool
+
+    .. versionadded::
+    '''
+
+    # get all the info from the launchctl service
+    service_info = show(name)
+
+    # get the value for the KeepAlive key in service plist
+    try:
+        keep_alive = service_info['plist']['KeepAlive']
+    except KeyError:
+        return False
+
+    # check if KeepAlive is True and not just set.
+    if keep_alive == True:
+        return True
+
+    return False
+
+
 def show(name):
     '''
     Show properties of a launchctl service
@@ -403,7 +434,9 @@ def status(name, sig=None, runas=None):
 
     :param str runas: User to run launchctl commands
 
-    :return: The PID for the service if it is running, otherwise an empty string
+    :return: The PID for the service if it is running, or 'loaded' if the
+        service should not always have a PID, or otherwise an empty string
+
     :rtype: str
 
     CLI Example:
@@ -415,6 +448,12 @@ def status(name, sig=None, runas=None):
     # Find service with ps
     if sig:
         return __salt__['status.pid'](sig)
+
+    # mac services are a little different than other platforms as they may be
+    # set to run on intervals and may not always active with a PID. This will
+    # return a string 'loaded' if it shouldn't always be running and is enabled.
+    if not _always_running_service(name) and enabled(name):
+        return 'loaded'
 
     output = list_(runas=runas)
 

--- a/salt/modules/mac_service.py
+++ b/salt/modules/mac_service.py
@@ -175,7 +175,7 @@ def _always_running_service(name):
         return False
 
     # check if KeepAlive is True and not just set.
-    if keep_alive == True:
+    if keep_alive is True:
         return True
 
     return False


### PR DESCRIPTION
### What does this PR do?
Adds the ability for the mac_service module to recognize whether or not a mac service should have an active PID when checking the status, as some macOS services run on intervals or are initiated by other manners. This improves the support for the service state which previously would only work properly for services that are set be always running with an active PID.

### What issues does this PR fix or reference?
None

### Previous Behavior
service.status on macOS would return an empty string for any service that did not have an active PID. Which would send a false positive of sorts to the service state module.

### New Behavior
Salt will now check the macOS service to see whether or not the service should actively be running by checking the `KeepAlive` key in service plist. If the service is not meant to be always running but the service is properly loaded in launchd service.status will now return a string 'loaded'.

CC @gtmanfred as we briefly talked about this addition. 

### Tests written?

No

### Commits signed with GPG?

Yes