### PR TITLE
Fix references to renamed attributes from salt.utils.gitfs

### DIFF
--- a/salt/runners/winrepo.py
+++ b/salt/runners/winrepo.py
@@ -164,7 +164,8 @@ def update_git_repos(opts=None, clean=False, masterless=False):
 
     ret = {}
     for remotes, base_dir in winrepo_cfg:
-        if not any((salt.utils.gitfs.HAS_GITPYTHON, salt.utils.gitfs.HAS_PYGIT2)):
+        if not any((salt.utils.gitfs.GITPYTHON_VERSION,
+                    salt.utils.gitfs.PYGIT2_VERSION)):
             # Use legacy code
             winrepo_result = {}
             for remote_info in remotes:


### PR DESCRIPTION
This change should have been part of a0f7eec7, but these refs were overlooked.

Fixes #46205.