### PR TITLE
PY2: Remove conversion of values from config file to str types

### DIFF
--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -2126,10 +2126,6 @@ def _read_conf_file(path):
                 conf_opts['id'] = six.text_type(conf_opts['id'])
             else:
                 conf_opts['id'] = sdecode(conf_opts['id'])
-        for key, value in six.iteritems(conf_opts.copy()):
-            if isinstance(value, six.text_type) and six.PY2:
-                # We do not want unicode settings
-                conf_opts[key] = value.encode('utf-8')
         return conf_opts
 
 

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -3699,7 +3699,9 @@ def apply_minion_config(overrides=None,
             )
             opts['fileserver_backend'][idx] = new_val
 
-    opts['__cli'] = os.path.basename(sys.argv[0])
+    opts['__cli'] = salt.utils.stringutils.to_unicode(
+        os.path.basename(sys.argv[0])
+    )
 
     # No ID provided. Will getfqdn save us?
     using_ip_for_id = False

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -168,7 +168,11 @@ def generate_minion_id():
 
     :return:
     '''
-    return _generate_minion_id().first() or 'localhost'
+    try:
+        ret = salt.utils.stringutils.to_unicode(_generate_minion_id().first())
+    except TypeError:
+        ret = None
+    return ret or 'localhost'
 
 
 def get_socket(addr, type=socket.SOCK_STREAM, proto=0):

--- a/salt/utils/user.py
+++ b/salt/utils/user.py
@@ -16,6 +16,7 @@ import sys
 # Import Salt libs
 import salt.utils.path
 import salt.utils.platform
+import salt.utils.stringutils
 from salt.exceptions import CommandExecutionError
 from salt.utils.decorators.jinja import jinja_filter
 
@@ -55,12 +56,13 @@ def get_user():
     Get the current user
     '''
     if HAS_PWD:
-        return pwd.getpwuid(os.geteuid()).pw_name
+        ret = pwd.getpwuid(os.geteuid()).pw_name
     elif HAS_WIN_FUNCTIONS and salt.utils.win_functions.HAS_WIN32:
-        return salt.utils.win_functions.get_current_user()
+        ret = salt.utils.win_functions.get_current_user()
     else:
         raise CommandExecutionError(
             'Required external library (pwd or win32api) not installed')
+    return salt.utils.stringutils.to_unicode(ret)
 
 
 @jinja_filter('get_uid')


### PR DESCRIPTION
This removes a weird block that only affected string types loaded from a config file. We absolutely *do* want unicode types here, so we shouldn't be encoding them to str types. Also, this misguided code ignored strings in nested data structures, so it didn't even properly do what it was *trying* to do.