### PR TITLE
[DOC] Replace `note` rST block for GitHub

### DIFF
--- a/doc/topics/development/conventions/formulas.rst
+++ b/doc/topics/development/conventions/formulas.rst
@@ -1242,10 +1242,10 @@ A sample skeleton for the ``README.rst`` file:
 
     Install and configure the FOO service.
 
-    .. note::
+    **NOTE**
 
-        See the full `Salt Formulas installation and usage instructions
-        <https://docs.saltstack.com/en/latest/topics/development/conventions/formulas.html>`_.
+    See the full `Salt Formulas installation and usage instructions
+    <https://docs.saltstack.com/en/latest/topics/development/conventions/formulas.html>`_.
 
     Available states
     ================


### PR DESCRIPTION
### What does this PR do?
This PR removes `note` rST block in favor of just bold heading text in example of README file at formulas doc page.
It seems neither GitHub, nor Bitbucket does not properly support it and the rendered text does not look expressive. Same thing was done previously in saltstack/salt-bootstrap repository.

### Commits signed with GPG?
Yes
