### PR TITLE
Document out-of-date or wrong

### DIFF
--- a/doc/topics/cloud/azurearm.rst
+++ b/doc/topics/cloud/azurearm.rst
@@ -316,6 +316,7 @@ How this is used depends on the operating system that is being deployed. If
 used, any ``userdata`` setting will be ignored.
 
 wait_for_ip_timeout
+
 -------------------
 Optional. Default is ``600``. When waiting for a VM to be created, Salt Cloud
 will attempt to connect to the VM's IP address until it starts responding. This


### PR DESCRIPTION
The URL of this document is the first result for Google search "salt-cloud azurearm" but it appears to be out of date or just plain wrong leading to dispair and suffering :-)
In particular, most of the named config parameters in this document are invalid.

**HOWEVER:** Another saltstack document appears to be correct and up-to-date: https://docs.saltstack.com/en/latest/ref/clouds/all/salt.cloud.clouds.azurearm.html

I suggest eliminating the incorrect doc alltogether or to fix it by incorporating the information from the "working" version.

