### PR TITLE
engine.docker_events: Add filter

### DIFF
--- a/salt/engines/docker_events.py
+++ b/salt/engines/docker_events.py
@@ -41,7 +41,8 @@ def __virtual__():
 
 def start(docker_url='unix://var/run/docker.sock',
           timeout=CLIENT_TIMEOUT,
-          tag='salt/engines/docker_events'):
+          tag='salt/engines/docker_events',
+          filters=None):
     '''
     Scan for Docker events and fire events
 
@@ -52,10 +53,18 @@ def start(docker_url='unix://var/run/docker.sock',
         engines:
           - docker_events:
               docker_url: unix://var/run/docker.sock
+              filters:
+                containers:
+                - start
+                - stop
+                - die
+                - oom
 
     The config above sets up engines to listen
     for events from the Docker daemon and publish
     them to the Salt event bus.
+
+    For filter reference, see https://docs.docker.com/engine/reference/commandline/events/
     '''
 
     if __opts__.get('__role') == 'master':
@@ -81,7 +90,7 @@ def start(docker_url='unix://var/run/docker.sock',
         client = docker.Client(base_url=docker_url, timeout=timeout)
 
     try:
-        events = client.events()
+        events = client.events(filters=filters)
         for event in events:
             data = salt.utils.json.loads(event.decode(__salt_system_encoding__, errors='replace'))
             # https://github.com/docker/cli/blob/master/cli/command/system/events.go#L109

--- a/salt/engines/docker_events.py
+++ b/salt/engines/docker_events.py
@@ -54,7 +54,7 @@ def start(docker_url='unix://var/run/docker.sock',
           - docker_events:
               docker_url: unix://var/run/docker.sock
               filters:
-                containers:
+                event:
                 - start
                 - stop
                 - die


### PR DESCRIPTION
### What does this PR do?
Add filters to the `docker_events` engine

### What reference?
https://docs.docker.com/engine/reference/commandline/events/
https://docs.docker.com/engine/api/v1.36/#operation/SystemEvents

### New Behavior
Add the API's native `filters` parameter 
