### PR TITLE
Fix `unit.modules.test_network` for Windows

### DIFF
--- a/salt/ext/win_inet_pton.py
+++ b/salt/ext/win_inet_pton.py
@@ -37,7 +37,7 @@ def inet_pton(address_family, ip_string):
     # This will catch IP Addresses such as 10.1.2
     if address_family == socket.AF_INET:
         try:
-            ipaddress.ip_address(six.u(ip_string))
+            ipaddress.ip_address(six.text_type(ip_string))
         except ValueError:
             raise socket.error('illegal IP address string passed to inet_pton')
         return socket.inet_aton(ip_string)


### PR DESCRIPTION
### What does this PR do?
Fixes a Unicode issue in win_inet_pton. Use `six.test_type` instead of `six.u` for converting to unicode. Probably exposed by conversion to `unicode_literals` throughout salt code. Found in by failing test.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt-jenkins/issues/439

### Tests written?
No

### Commits signed with GPG?
Yes