### PR TITLE
Fix hanging tests in integration suite

### DIFF
--- a/tests/integration/modules/test_cp.py
+++ b/tests/integration/modules/test_cp.py
@@ -498,6 +498,7 @@ class CPModuleTest(ModuleCase):
             url = url_prefix + (code or 'actual_file')
             log.debug('attempting to cache %s', url)
             ret = self.run_function('cp.cache_file', [url])
+            self.assertTrue(ret)
             with salt.utils.fopen(ret) as fp_:
                 cached_contents = fp_.read()
                 self.assertEqual(cached_contents, file_contents)


### PR DESCRIPTION
A recent change to nginx appears to be causing this test to fail to cache the test file in the temp nginx instance we've spun up. This causes the return of cp.cache_file to be False, which in and of itself should be enough to fail the test. But since we're not asserting on the cp.cache_file results, flow proceeds to the next block of code, in which we open the "file" that we cached. Some genius thought it would be a swell idea to make io.open() successfully open a filehandle when the path passed to it is a boolean False. When you try to read from this filehandle, an AMAZING thing happens... It just blocks. Forever. I know, right? Pure genius.

This commit adds an assert so that the test fails gracefully and doesn't try to read from a bogus filehandle that SHOULDN'T EVEN EXIST.