### PR TITLE
Added new functions to CIMC modules

### DIFF
--- a/salt/modules/cimc.py
+++ b/salt/modules/cimc.py
@@ -663,7 +663,7 @@ def set_hostname(hostname=None):
 
 def set_logging_levels(remote=None, local=None):
     '''
-    Sets the logging levels of the CIMC devices. The logging levels must match 
+    Sets the logging levels of the CIMC devices. The logging levels must match
     the following options: emergency, alert, critical, error, warning, notice,
     informational, debug.
 

--- a/salt/modules/cimc.py
+++ b/salt/modules/cimc.py
@@ -268,7 +268,7 @@ def get_hostname():
 
     '''
     ret = __proxy__['cimc.get_config_resolver_class']('mgmtIf', True)
-    
+
     try:
         return ret['outConfigs']['mgmtIf'][0]['hostname']
     except Exception as err:
@@ -466,8 +466,8 @@ def get_syslog_settings():
     ret = __proxy__['cimc.get_config_resolver_class']('commSyslog', False)
 
     return ret
-    
-    
+
+
 def get_system_info():
     '''
     Get the system information.
@@ -637,8 +637,8 @@ def set_hostname(hostname=None):
 
     '''
     if not hostname:
-        raise salt.exceptions.CommandExecutionError("Hostname option must be provided.") 
-    
+        raise salt.exceptions.CommandExecutionError("Hostname option must be provided.")
+
     dn = "sys/rack-unit-1/mgmt/if-1"
     inconfig = """<mgmtIf dn="sys/rack-unit-1/mgmt/if-1" hostname="{0}" ></mgmtIf>""".format(hostname)
 
@@ -671,24 +671,24 @@ def set_logging_levels(remote=None, local=None):
         salt '*' cimc.set_logging_levels remote=error local=notice
 
     '''
-    
-    logging_options = ['emergency', 
-                       'alert', 
-                       'critical', 
+
+    logging_options = ['emergency',
+                       'alert',
+                       'critical',
                        'error',
                        'warning',
                        'notice',
                        'informational',
                        'debug']
-    
+
     query = ""
-    
+
     if remote:
         if remote in logging_options:
             query += ' remoteSeverity="{0}"'.format(remote)
         else:
             raise salt.exceptions.CommandExecutionError("Remote Severity option is not valid.")
-            
+
     if local:
         if local in logging_options:
             query += ' localSeverity="{0}"'.format(local)
@@ -701,7 +701,7 @@ def set_logging_levels(remote=None, local=None):
     ret = __proxy__['cimc.set_config_modify'](dn, inconfig, False)
 
     return ret
-    
+
 
 def set_ntp_server(server1='', server2='', server3='', server4=''):
     '''
@@ -741,28 +741,28 @@ def set_power_configuration(policy=None, delayType=None, delayValue=None):
     C-Series servers.
 
     Args:
-        policy(str): The action to be taken when chassis power is restored after 
+        policy(str): The action to be taken when chassis power is restored after
         an unexpected power loss. This can be one of the following:
-        
-            reset: The server is allowed to boot up normally when power is 
-            restored. The server can restart immediately or, optionally, after a
-            fixed or random delay. 
-            
-            stay-off: The server remains off until it is manually restarted.
-            
-            last-state: The server restarts and the system attempts to restore 
-            any processes that were running before power was lost. 
 
-        delayType(str): If the selected policy is reset, the restart can be 
+            reset: The server is allowed to boot up normally when power is
+            restored. The server can restart immediately or, optionally, after a
+            fixed or random delay.
+
+            stay-off: The server remains off until it is manually restarted.
+
+            last-state: The server restarts and the system attempts to restore
+            any processes that were running before power was lost.
+
+        delayType(str): If the selected policy is reset, the restart can be
         delayed with this option. This can be one of the following:
-        
-            fixed: The server restarts after a fixed delay. 
-            
+
+            fixed: The server restarts after a fixed delay.
+
             random: The server restarts after a random delay.
-            
-        delayValue(int): If a fixed delay is selected, once chassis power is 
-        restored and the Cisco IMC has finished rebooting, the system waits for 
-        the specified number of seconds before restarting the server. Enter an 
+
+        delayValue(int): If a fixed delay is selected, once chassis power is
+        restored and the Cisco IMC has finished rebooting, the system waits for
+        the specified number of seconds before restarting the server. Enter an
         integer between 0 and 240.
 
     CLI Example:
@@ -774,7 +774,7 @@ def set_power_configuration(policy=None, delayType=None, delayValue=None):
         salt '*' cimc.set_power_configuration reset fixed 0
 
     '''
-    
+
     query = ""
     if policy == "reset":
         query = ' vpResumeOnACPowerLoss="reset"'
@@ -795,15 +795,15 @@ def set_power_configuration(policy=None, delayType=None, delayValue=None):
         raise salt.exceptions.CommandExecutionError("The power state must be specified.")
 
     dn = "sys/rack-unit-1/board/Resume-on-AC-power-loss"
-    inconfig = """<biosVfResumeOnACPowerLoss 
+    inconfig = """<biosVfResumeOnACPowerLoss
     dn="sys/rack-unit-1/board/Resume-on-AC-power-loss"{0}>
     </biosVfResumeOnACPowerLoss>""".format(query)
 
     ret = __proxy__['cimc.set_config_modify'](dn, inconfig, False)
 
     return ret
-    
-    
+
+
 def set_syslog_server(server=None, type="primary"):
     '''
     Set the SYSLOG server on the host.
@@ -842,8 +842,8 @@ def set_syslog_server(server=None, type="primary"):
     ret = __proxy__['cimc.set_config_modify'](dn, inconfig, False)
 
     return ret
-    
-    
+
+
 def set_user(uid=None, username=None, password=None, priv=None, status=None):
     '''
     Sets a CIMC user with specified configurations.
@@ -856,7 +856,7 @@ def set_user(uid=None, username=None, password=None, priv=None, status=None):
         password(str): The clear text password of the user.
 
         priv(str): The privilege level of the user.
-        
+
         status(str): The account status of the user.
 
     CLI Example:
@@ -873,13 +873,13 @@ def set_user(uid=None, username=None, password=None, priv=None, status=None):
 
     if status:
         conf += ' accountStatus="{0}"'.format(status)
-        
+
     if username:
         conf += ' name="{0}"'.format(username)
 
     if priv:
         conf += ' priv="{0}"'.format(priv)
-        
+
     if password:
         conf += ' pwd="{0}"'.format(password)
 

--- a/salt/modules/cimc.py
+++ b/salt/modules/cimc.py
@@ -256,6 +256,25 @@ def get_firmware():
     return ret
 
 
+def get_hostname():
+    '''
+    Retrieves the hostname from the device.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' cimc.get_hostname
+
+    '''
+    ret = __proxy__['cimc.get_config_resolver_class']('mgmtIf', True)
+    
+    try:
+        return ret['outConfigs']['mgmtIf'][0]['hostname']
+    except Exception as err:
+        return "Unable to retrieve hostname"
+
+
 def get_ldap():
     '''
     Retrieves LDAP server details.
@@ -368,6 +387,23 @@ def get_pci_adapters():
     return ret
 
 
+def get_power_configuration():
+    '''
+    Get the configuration of the power settings from the device. This is only available
+    on some C-Series servers.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' cimc.get_power_configuration
+
+    '''
+    ret = __proxy__['cimc.get_config_resolver_class']('biosVfResumeOnACPowerLoss', True)
+
+    return ret
+
+
 def get_power_supplies():
     '''
     Retrieves the power supply unit details.
@@ -416,6 +452,22 @@ def get_syslog():
     return ret
 
 
+def get_syslog_settings():
+    '''
+    Get the Syslog configuration settings from the system.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' cimc.get_syslog_settings
+
+    '''
+    ret = __proxy__['cimc.get_config_resolver_class']('commSyslog', False)
+
+    return ret
+    
+    
 def get_system_info():
     '''
     Get the system information.
@@ -570,6 +622,87 @@ def reboot():
     return ret
 
 
+def set_hostname(hostname=None):
+    '''
+    Sets the hostname on the server.
+
+    Args:
+        hostname(str): The new hostname to set.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' cimc.set_hostname foobar
+
+    '''
+    if not hostname:
+        raise salt.exceptions.CommandExecutionError("Hostname option must be provided.") 
+    
+    dn = "sys/rack-unit-1/mgmt/if-1"
+    inconfig = """<mgmtIf dn="sys/rack-unit-1/mgmt/if-1" hostname="{0}" ></mgmtIf>""".format(hostname)
+
+    ret = __proxy__['cimc.set_config_modify'](dn, inconfig, False)
+
+    try:
+        if ret['outConfig']['mgmtIf'][0]['status'] == 'modified':
+            return True
+        else:
+            return False
+    except Exception as err:
+        return False
+
+
+def set_logging_levels(remote=None, local=None):
+    '''
+    Sets the logging levels of the CIMC devices. The logging levels must match 
+    the following options: emergency, alert, critical, error, warning, notice,
+    informational, debug.
+
+    Args:
+        remote(str): The logging level for SYSLOG logs.
+
+        local(str): The logging level for the local device.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' cimc.set_logging_levels remote=error local=notice
+
+    '''
+    
+    logging_options = ['emergency', 
+                       'alert', 
+                       'critical', 
+                       'error',
+                       'warning',
+                       'notice',
+                       'informational',
+                       'debug']
+    
+    query = ""
+    
+    if remote:
+        if remote in logging_options:
+            query += ' remoteSeverity="{0}"'.format(remote)
+        else:
+            raise salt.exceptions.CommandExecutionError("Remote Severity option is not valid.")
+            
+    if local:
+        if local in logging_options:
+            query += ' localSeverity="{0}"'.format(local)
+        else:
+            raise salt.exceptions.CommandExecutionError("Local Severity option is not valid.")
+
+    dn = "sys/svc-ext/syslog"
+    inconfig = """<commSyslog dn="sys/svc-ext/syslog"{0} ></commSyslog>""".format(query)
+
+    ret = __proxy__['cimc.set_config_modify'](dn, inconfig, False)
+
+    return ret
+    
+
 def set_ntp_server(server1='', server2='', server3='', server4=''):
     '''
     Sets the NTP servers configuration. This will also enable the client NTP service.
@@ -602,6 +735,75 @@ def set_ntp_server(server1='', server2='', server3='', server4=''):
     return ret
 
 
+def set_power_configuration(policy=None, delayType=None, delayValue=None):
+    '''
+    Sets the power configuration on the device. This is only available for some
+    C-Series servers.
+
+    Args:
+        policy(str): The action to be taken when chassis power is restored after 
+        an unexpected power loss. This can be one of the following:
+        
+            reset: The server is allowed to boot up normally when power is 
+            restored. The server can restart immediately or, optionally, after a
+            fixed or random delay. 
+            
+            stay-off: The server remains off until it is manually restarted.
+            
+            last-state: The server restarts and the system attempts to restore 
+            any processes that were running before power was lost. 
+
+        delayType(str): If the selected policy is reset, the restart can be 
+        delayed with this option. This can be one of the following:
+        
+            fixed: The server restarts after a fixed delay. 
+            
+            random: The server restarts after a random delay.
+            
+        delayValue(int): If a fixed delay is selected, once chassis power is 
+        restored and the Cisco IMC has finished rebooting, the system waits for 
+        the specified number of seconds before restarting the server. Enter an 
+        integer between 0 and 240.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' cimc.set_power_configuration stay-off
+
+        salt '*' cimc.set_power_configuration reset fixed 0
+
+    '''
+    
+    query = ""
+    if policy == "reset":
+        query = ' vpResumeOnACPowerLoss="reset"'
+        if delayType:
+            if delayType == "fixed":
+                query += ' delayType="fixed"'
+                if delayValue:
+                    query += ' delay="{0}"'.format(delayValue)
+            elif delayType == "random":
+                query += ' delayType="random"'
+            else:
+                raise salt.exceptions.CommandExecutionError("Invalid delay type entered.")
+    elif policy == "stay-off":
+        query = ' vpResumeOnACPowerLoss="reset"'
+    elif policy == "last-state":
+        query = ' vpResumeOnACPowerLoss="last-state"'
+    else:
+        raise salt.exceptions.CommandExecutionError("The power state must be specified.")
+
+    dn = "sys/rack-unit-1/board/Resume-on-AC-power-loss"
+    inconfig = """<biosVfResumeOnACPowerLoss 
+    dn="sys/rack-unit-1/board/Resume-on-AC-power-loss"{0}>
+    </biosVfResumeOnACPowerLoss>""".format(query)
+
+    ret = __proxy__['cimc.set_config_modify'](dn, inconfig, False)
+
+    return ret
+    
+    
 def set_syslog_server(server=None, type="primary"):
     '''
     Set the SYSLOG server on the host.
@@ -636,6 +838,55 @@ def set_syslog_server(server=None, type="primary"):
         dn='sys/svc-ext/syslog/client-secondary'> </commSyslogClient>""".format(server)
     else:
         raise salt.exceptions.CommandExecutionError("The SYSLOG type must be either primary or secondary.")
+
+    ret = __proxy__['cimc.set_config_modify'](dn, inconfig, False)
+
+    return ret
+    
+    
+def set_user(uid=None, username=None, password=None, priv=None, status=None):
+    '''
+    Sets a CIMC user with specified configurations.
+
+    Args:
+        uid(int): The user ID slot to create the user account in.
+
+        username(str): The name of the user.
+
+        password(str): The clear text password of the user.
+
+        priv(str): The privilege level of the user.
+        
+        status(str): The account status of the user.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' cimc.set_user 11 username=admin password=foobar priv=admin active
+
+    '''
+
+    conf = ""
+    if not uid:
+        raise salt.exceptions.CommandExecutionError("The user ID must be specified.")
+
+    if status:
+        conf += ' accountStatus="{0}"'.format(status)
+        
+    if username:
+        conf += ' name="{0}"'.format(username)
+
+    if priv:
+        conf += ' priv="{0}"'.format(priv)
+        
+    if password:
+        conf += ' pwd="{0}"'.format(password)
+
+    dn = "sys/user-ext/user-{0}".format(uid)
+
+    inconfig = """<aaaUser id="{0}"{1} dn="sys/user-ext/user-{0}"/>""".format(uid,
+                                                                               conf)
 
     ret = __proxy__['cimc.set_config_modify'](dn, inconfig, False)
 

--- a/salt/modules/cimc.py
+++ b/salt/modules/cimc.py
@@ -260,6 +260,8 @@ def get_hostname():
     '''
     Retrieves the hostname from the device.
 
+    .. versionadded:: Fluorine
+
     CLI Example:
 
     .. code-block:: bash
@@ -392,6 +394,8 @@ def get_power_configuration():
     Get the configuration of the power settings from the device. This is only available
     on some C-Series servers.
 
+    .. versionadded:: Fluorine
+
     CLI Example:
 
     .. code-block:: bash
@@ -455,6 +459,8 @@ def get_syslog():
 def get_syslog_settings():
     '''
     Get the Syslog configuration settings from the system.
+
+    .. versionadded:: Fluorine
 
     CLI Example:
 
@@ -626,6 +632,8 @@ def set_hostname(hostname=None):
     '''
     Sets the hostname on the server.
 
+    .. versionadded:: Fluorine
+
     Args:
         hostname(str): The new hostname to set.
 
@@ -658,6 +666,8 @@ def set_logging_levels(remote=None, local=None):
     Sets the logging levels of the CIMC devices. The logging levels must match 
     the following options: emergency, alert, critical, error, warning, notice,
     informational, debug.
+
+    .. versionadded:: Fluorine
 
     Args:
         remote(str): The logging level for SYSLOG logs.
@@ -739,6 +749,8 @@ def set_power_configuration(policy=None, delayType=None, delayValue=None):
     '''
     Sets the power configuration on the device. This is only available for some
     C-Series servers.
+
+    .. versionadded:: Fluorine
 
     Args:
         policy(str): The action to be taken when chassis power is restored after
@@ -847,6 +859,8 @@ def set_syslog_server(server=None, type="primary"):
 def set_user(uid=None, username=None, password=None, priv=None, status=None):
     '''
     Sets a CIMC user with specified configurations.
+
+    .. versionadded:: Fluorine
 
     Args:
         uid(int): The user ID slot to create the user account in.

--- a/salt/states/cimc.py
+++ b/salt/states/cimc.py
@@ -47,6 +47,8 @@ def hostname(name, hostname=None):
     '''
     Ensures that the hostname is set to the specified value.
 
+    .. versionadded:: Fluorine
+
     name: The name of the module function to execute.
 
     hostname(str): The hostname of the server.
@@ -103,6 +105,8 @@ def logging_levels(name, remote=None, local=None):
     Ensures that the logging levels are set on the device. The logging levels
     must match the following options: emergency, alert, critical, error, warning,
     notice, informational, debug.
+
+    .. versionadded:: Fluorine
 
     name: The name of the module function to execute.
 
@@ -247,6 +251,8 @@ def power_configuration(name, policy=None, delayType=None, delayValue=None):
     '''
     Ensures that the power configuration is configured on the system. This is
     only available on some C-Series servers.
+
+    .. versionadded:: Fluorine
 
     name: The name of the module function to execute.
 
@@ -432,6 +438,8 @@ def user(name, id='', user='', priv='', password='', status='active'):
     '''
     Ensures that a user is configured on the device. Due to being unable to
     verify the user password. This is a forced operation.
+
+    .. versionadded:: Fluorine
 
     name: The name of the module function to execute.
 

--- a/salt/states/cimc.py
+++ b/salt/states/cimc.py
@@ -19,7 +19,7 @@ relies on the CIMC proxy module to interface with the device.
 '''
 
 # Import Python Libs
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function, unicode_literals
 import logging
 
 log = logging.getLogger(__name__)
@@ -58,24 +58,24 @@ def hostname(name, hostname=None):
         set_name:
           cimc.hostname:
             - hostname: foobar
-            
+
     '''
-    
+
     ret = _default_ret(name)
 
     current_name = __salt__['cimc.get_hostname']()
-    
+
     req_change = False
-    
+
     try:
-        
+
         if current_name != hostname:
             req_change = True
-        
+
         if req_change:
 
             update = __salt__['cimc.set_hostname'](hostname)
-                                                              
+
             if not update:
                 ret['result'] = False
                 ret['comment'] = "Error setting hostname."
@@ -86,7 +86,7 @@ def hostname(name, hostname=None):
             ret['comment'] = "Hostname modified."
         else:
             ret['comment'] = "Hostname already configured. No changes required."
-                
+
     except Exception as err:
         ret['result'] = False
         ret['comment'] = "Error occurred setting hostname."
@@ -96,12 +96,12 @@ def hostname(name, hostname=None):
     ret['result'] = True
 
     return ret
-    
-    
+
+
 def logging_levels(name, remote=None, local=None):
     '''
-    Ensures that the logging levels are set on the device. The logging levels 
-    must match the following options: emergency, alert, critical, error, warning, 
+    Ensures that the logging levels are set on the device. The logging levels
+    must match the following options: emergency, alert, critical, error, warning,
     notice, informational, debug.
 
     name: The name of the module function to execute.
@@ -118,27 +118,27 @@ def logging_levels(name, remote=None, local=None):
           cimc.logging_levels:
             - remote: informational
             - local: notice
-            
+
     '''
 
     ret = _default_ret(name)
 
     syslog_conf = __salt__['cimc.get_syslog_settings']()
-    
+
     req_change = False
-    
+
     try:
         syslog_dict = syslog_conf['outConfigs']['commSyslog'][0]
-        
+
         if remote and syslog_dict['remoteSeverity'] != remote:
             req_change = True
         elif local and syslog_dict['localSeverity'] != local:
             req_change = True
-                    
+
         if req_change:
 
             update = __salt__['cimc.set_logging_levels'](remote, local)
-                                                              
+
             if update['outConfig']['commSyslog'][0]['status'] != 'modified':
                 ret['result'] = False
                 ret['comment'] = "Error setting logging levels."
@@ -149,7 +149,7 @@ def logging_levels(name, remote=None, local=None):
             ret['comment'] = "Logging level settings modified."
         else:
             ret['comment'] = "Logging level already configured. No changes required."
-                
+
     except Exception as err:
         ret['result'] = False
         ret['comment'] = "Error occurred setting logging level settings."
@@ -159,8 +159,8 @@ def logging_levels(name, remote=None, local=None):
     ret['result'] = True
 
     return ret
-    
-    
+
+
 def ntp(name, servers):
     '''
     Ensures that the NTP servers are configured. Servers are provided as an individual string or list format. Only four
@@ -250,28 +250,28 @@ def power_configuration(name, policy=None, delayType=None, delayValue=None):
 
     name: The name of the module function to execute.
 
-    policy(str): The action to be taken when chassis power is restored after 
+    policy(str): The action to be taken when chassis power is restored after
     an unexpected power loss. This can be one of the following:
-        
-        reset: The server is allowed to boot up normally when power is 
-        restored. The server can restart immediately or, optionally, after a
-        fixed or random delay. 
-            
-        stay-off: The server remains off until it is manually restarted.
-            
-        last-state: The server restarts and the system attempts to restore 
-        any processes that were running before power was lost. 
 
-    delayType(str): If the selected policy is reset, the restart can be 
+        reset: The server is allowed to boot up normally when power is
+        restored. The server can restart immediately or, optionally, after a
+        fixed or random delay.
+
+        stay-off: The server remains off until it is manually restarted.
+
+        last-state: The server restarts and the system attempts to restore
+        any processes that were running before power was lost.
+
+    delayType(str): If the selected policy is reset, the restart can be
     delayed with this option. This can be one of the following:
-        
-        fixed: The server restarts after a fixed delay. 
-            
+
+        fixed: The server restarts after a fixed delay.
+
         random: The server restarts after a random delay.
-            
-    delayValue(int): If a fixed delay is selected, once chassis power is 
-    restored and the Cisco IMC has finished rebooting, the system waits for 
-    the specified number of seconds before restarting the server. Enter an 
+
+    delayValue(int): If a fixed delay is selected, once chassis power is
+    restored and the Cisco IMC has finished rebooting, the system waits for
+    the specified number of seconds before restarting the server. Enter an
     integer between 0 and 240.
 
 
@@ -284,7 +284,7 @@ def power_configuration(name, policy=None, delayType=None, delayValue=None):
             - policy: reset
             - delayType: fixed
             - delayValue: 0
-            
+
         power_off:
           cimc.power_configuration:
             - policy: stay-off
@@ -295,12 +295,12 @@ def power_configuration(name, policy=None, delayType=None, delayValue=None):
     ret = _default_ret(name)
 
     power_conf = __salt__['cimc.get_power_configuration']()
-    
+
     req_change = False
-    
+
     try:
         power_dict = power_conf['outConfigs']['biosVfResumeOnACPowerLoss'][0]
-        
+
         if policy and power_dict['vpResumeOnACPowerLoss'] != policy:
             req_change = True
         elif policy == "reset":
@@ -314,13 +314,12 @@ def power_configuration(name, policy=None, delayType=None, delayValue=None):
             ret['comment'] = "The power policy must be specified."
             return ret
 
-                    
         if req_change:
 
             update = __salt__['cimc.set_power_configuration'](policy,
                                                               delayType,
                                                               delayValue)
-                                                              
+
             if update['outConfig']['biosVfResumeOnACPowerLoss'][0]['status'] != 'modified':
                 ret['result'] = False
                 ret['comment'] = "Error setting power configuration."
@@ -331,7 +330,7 @@ def power_configuration(name, policy=None, delayType=None, delayValue=None):
             ret['comment'] = "Power settings modified."
         else:
             ret['comment'] = "Power settings already configured. No changes required."
-                
+
     except Exception as err:
         ret['result'] = False
         ret['comment'] = "Error occurred setting power settings."
@@ -463,7 +462,7 @@ def user(name, id='', user='', priv='', password='', status='active'):
     ret = _default_ret(name)
 
     user_conf = __salt__['cimc.get_users']()
-    
+
     try:
         for entry in user_conf['outConfigs']['aaaUser']:
             if entry['id'] == str(id):

--- a/salt/states/cimc.py
+++ b/salt/states/cimc.py
@@ -19,7 +19,7 @@ relies on the CIMC proxy module to interface with the device.
 '''
 
 # Import Python Libs
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import
 import logging
 
 log = logging.getLogger(__name__)
@@ -43,6 +43,124 @@ def _default_ret(name):
     return ret
 
 
+def hostname(name, hostname=None):
+    '''
+    Ensures that the hostname is set to the specified value.
+
+    name: The name of the module function to execute.
+
+    hostname(str): The hostname of the server.
+
+    SLS Example:
+
+    .. code-block:: yaml
+
+        set_name:
+          cimc.hostname:
+            - hostname: foobar
+            
+    '''
+    
+    ret = _default_ret(name)
+
+    current_name = __salt__['cimc.get_hostname']()
+    
+    req_change = False
+    
+    try:
+        
+        if current_name != hostname:
+            req_change = True
+        
+        if req_change:
+
+            update = __salt__['cimc.set_hostname'](hostname)
+                                                              
+            if not update:
+                ret['result'] = False
+                ret['comment'] = "Error setting hostname."
+                return ret
+
+            ret['changes']['before'] = current_name
+            ret['changes']['after'] = hostname
+            ret['comment'] = "Hostname modified."
+        else:
+            ret['comment'] = "Hostname already configured. No changes required."
+                
+    except Exception as err:
+        ret['result'] = False
+        ret['comment'] = "Error occurred setting hostname."
+        log.error(err)
+        return ret
+
+    ret['result'] = True
+
+    return ret
+    
+    
+def logging_levels(name, remote=None, local=None):
+    '''
+    Ensures that the logging levels are set on the device. The logging levels 
+    must match the following options: emergency, alert, critical, error, warning, 
+    notice, informational, debug.
+
+    name: The name of the module function to execute.
+
+    remote(str): The logging level for SYSLOG logs.
+
+    local(str): The logging level for the local device.
+
+    SLS Example:
+
+    .. code-block:: yaml
+
+        logging_levels:
+          cimc.logging_levels:
+            - remote: informational
+            - local: notice
+            
+    '''
+
+    ret = _default_ret(name)
+
+    syslog_conf = __salt__['cimc.get_syslog_settings']()
+    
+    req_change = False
+    
+    try:
+        syslog_dict = syslog_conf['outConfigs']['commSyslog'][0]
+        
+        if remote and syslog_dict['remoteSeverity'] != remote:
+            req_change = True
+        elif local and syslog_dict['localSeverity'] != local:
+            req_change = True
+                    
+        if req_change:
+
+            update = __salt__['cimc.set_logging_levels'](remote, local)
+                                                              
+            if update['outConfig']['commSyslog'][0]['status'] != 'modified':
+                ret['result'] = False
+                ret['comment'] = "Error setting logging levels."
+                return ret
+
+            ret['changes']['before'] = syslog_conf
+            ret['changes']['after'] = __salt__['cimc.get_syslog_settings']()
+            ret['comment'] = "Logging level settings modified."
+        else:
+            ret['comment'] = "Logging level already configured. No changes required."
+                
+    except Exception as err:
+        ret['result'] = False
+        ret['comment'] = "Error occurred setting logging level settings."
+        log.error(err)
+        return ret
+
+    ret['result'] = True
+
+    return ret
+    
+    
 def ntp(name, servers):
     '''
     Ensures that the NTP servers are configured. Servers are provided as an individual string or list format. Only four
@@ -119,6 +237,106 @@ def ntp(name, servers):
         ret['comment'] = "NTP settings modified."
     else:
         ret['comment'] = "NTP already configured. No changes required."
+
+    ret['result'] = True
+
+    return ret
+
+
+def power_configuration(name, policy=None, delayType=None, delayValue=None):
+    '''
+    Ensures that the power configuration is configured on the system. This is
+    only available on some C-Series servers.
+
+    name: The name of the module function to execute.
+
+    policy(str): The action to be taken when chassis power is restored after 
+    an unexpected power loss. This can be one of the following:
+        
+        reset: The server is allowed to boot up normally when power is 
+        restored. The server can restart immediately or, optionally, after a
+        fixed or random delay. 
+            
+        stay-off: The server remains off until it is manually restarted.
+            
+        last-state: The server restarts and the system attempts to restore 
+        any processes that were running before power was lost. 
+
+    delayType(str): If the selected policy is reset, the restart can be 
+    delayed with this option. This can be one of the following:
+        
+        fixed: The server restarts after a fixed delay. 
+            
+        random: The server restarts after a random delay.
+            
+    delayValue(int): If a fixed delay is selected, once chassis power is 
+    restored and the Cisco IMC has finished rebooting, the system waits for 
+    the specified number of seconds before restarting the server. Enter an 
+    integer between 0 and 240.
+
+
+    SLS Example:
+
+    .. code-block:: yaml
+
+        reset_power:
+          cimc.power_configuration:
+            - policy: reset
+            - delayType: fixed
+            - delayValue: 0
+            
+        power_off:
+          cimc.power_configuration:
+            - policy: stay-off
+
+
+    '''
+
+    ret = _default_ret(name)
+
+    power_conf = __salt__['cimc.get_power_configuration']()
+    
+    req_change = False
+    
+    try:
+        power_dict = power_conf['outConfigs']['biosVfResumeOnACPowerLoss'][0]
+        
+        if policy and power_dict['vpResumeOnACPowerLoss'] != policy:
+            req_change = True
+        elif policy == "reset":
+            if power_dict['delayType'] != delayType:
+                req_change = True
+            elif power_dict['delayType'] == "fixed":
+                if str(power_dict['delay']) != str(delayValue):
+                    req_change = True
+        else:
+            ret['result'] = False
+            ret['comment'] = "The power policy must be specified."
+            return ret
+
+                    
+        if req_change:
+
+            update = __salt__['cimc.set_power_configuration'](policy,
+                                                              delayType,
+                                                              delayValue)
+                                                              
+            if update['outConfig']['biosVfResumeOnACPowerLoss'][0]['status'] != 'modified':
+                ret['result'] = False
+                ret['comment'] = "Error setting power configuration."
+                return ret
+
+            ret['changes']['before'] = power_conf
+            ret['changes']['after'] = __salt__['cimc.get_power_configuration']()
+            ret['comment'] = "Power settings modified."
+        else:
+            ret['comment'] = "Power settings already configured. No changes required."
+                
+    except Exception as err:
+        ret['result'] = False
+        ret['comment'] = "Error occurred setting power settings."
+        log.error(err)
+        return ret
 
     ret['result'] = True
 
@@ -205,6 +423,73 @@ def syslog(name, primary=None, secondary=None):
         ret['comment'] = "SYSLOG settings modified."
     else:
         ret['comment'] = "SYSLOG already configured. No changes required."
+
+    ret['result'] = True
+
+    return ret
+
+
+def user(name, id='', user='', priv='', password='', status='active'):
+    '''
+    Ensures that a user is configured on the device. Due to being unable to
+    verify the user password. This is a forced operation.
+
+    name: The name of the module function to execute.
+
+    id(int): The user ID slot on the device.
+
+    user(str): The username of the user.
+
+    priv(str): The privilege level of the user.
+
+    password(str): The password of the user.
+
+    status(str): The status of the user. Can be either active or inactive.
+
+    SLS Example:
+
+    .. code-block:: yaml
+
+        user_configuration:
+          cimc.user:
+            - id: 11
+            - user: foo
+            - priv: admin
+            - password: mypassword
+            - status: active
+
+    '''
+
+    ret = _default_ret(name)
+
+    user_conf = __salt__['cimc.get_users']()
+    
+    try:
+        for entry in user_conf['outConfigs']['aaaUser']:
+            if entry['id'] == str(id):
+                conf = entry
+
+        if not conf:
+            ret['result'] = False
+            ret['comment'] = "Unable to find requested user id on device. Please verify id is valid."
+            return ret
+
+        updates = __salt__['cimc.set_user'](str(id), user, password, priv, status)
+
+        if 'outConfig' in updates:
+            ret['changes']['before'] = conf
+            ret['changes']['after'] = updates['outConfig']['aaaUser']
+            ret['comment'] = "User settings modified."
+        else:
+            ret['result'] = False
+            ret['comment'] = "Error setting user configuration."
+            return ret
+
+    except Exception as err:
+        ret['result'] = False
+        ret['comment'] = "Error setting user configuration."
+        log.error(err)
+        return ret
 
     ret['result'] = True
 


### PR DESCRIPTION
### What does this PR do?
Add new CIMC Execution modules:
  - get_hostname
  - get_power_configuration
  - get_syslog_settings
  - set_hostname
  - set_logging_levels
  - set_power_configuration
  - set_user

Add new CIMC State Modules:
  - hostname
  - logging_levels
  - power_configuration
  - user

### Tests written?

No

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
