### PR TITLE
Git Pillars: Fix floaty branch names stacktraces

### DIFF
--- a/salt/utils/gitfs.py
+++ b/salt/utils/gitfs.py
@@ -1224,9 +1224,9 @@ class Pygit2(GitProvider):
         Checkout the configured branch/tag
         '''
         tgt_ref = self.get_checkout_target()
-        local_ref = 'refs/heads/' + tgt_ref
-        remote_ref = 'refs/remotes/origin/' + tgt_ref
-        tag_ref = 'refs/tags/' + tgt_ref
+        local_ref = 'refs/heads/{0}'.format(tgt_ref)
+        remote_ref = 'refs/remotes/origin/{0}'.format(tgt_ref)
+        tag_ref = 'refs/tags/{0}'.format(tgt_ref)
 
         try:
             local_head = self.repo.lookup_reference('HEAD')


### PR DESCRIPTION
### What does this PR do?
Set `git_pillar_base` to a floaty value, e.g.

```yaml
git_pillar_base: 2017.7
```
or even
```yaml
git_pillar_base: '2017.7'
```

will make the value be loaded as a `float`. GitFS then proceeds to stacktrace on it:

```sh
2018-02-27 22:00:56,296 [salt.pillar      :843 ][ERROR   ][7497] Execption caught loading ext_pillar 'git':
  File "/usr/lib/python2.7/dist-packages/salt/pillar/__init__.py", line 833, in ext_pillar
    key)
  File "/usr/lib/python2.7/dist-packages/salt/pillar/__init__.py", line 760, in _external_pillar_data
    pillar_dirs)
  File "/usr/lib/python2.7/dist-packages/salt/pillar/git_pillar.py", line 558, in ext_pillar
    pillar.checkout()
  File "/usr/lib/python2.7/dist-packages/salt/utils/gitfs.py", line 2753, in checkout
    cachedir = self.do_checkout(repo)
  File "/usr/lib/python2.7/dist-packages/salt/utils/gitfs.py", line 2409, in do_checkout
    return repo.checkout()
  File "/usr/lib/python2.7/dist-packages/salt/utils/gitfs.py", line 1227, in checkout
    local_ref = 'refs/heads/' + tgt_ref
```
### Previous Behavior
Stacktrace, don't checkout repo

### New Behavior
Don't stacktrace, checkout repo

