### PR TITLE
Mock file_client call in smtp return test

### DIFF
--- a/tests/unit/returners/test_smtp_return.py
+++ b/tests/unit/returners/test_smtp_return.py
@@ -17,6 +17,7 @@ from tests.support.mock import NO_MOCK, NO_MOCK_REASON, MagicMock, patch
 
 # Import salt libs
 import salt.returners.smtp_return as smtp
+from salt.utils.jinja import SaltCacheLoader
 
 try:
     import gnupg  # pylint: disable=unused-import
@@ -54,7 +55,8 @@ class SMTPReturnerTestCase(TestCase, LoaderModuleMockMixin):
                    'gpgowner': '',
                    'subject': ''}
 
-        with patch('salt.returners.smtp_return._get_options', MagicMock(return_value=options)):
+        with patch('salt.returners.smtp_return._get_options', MagicMock(return_value=options)), \
+             patch.object(SaltCacheLoader, 'file_client', MagicMock()):
             smtp.returner(ret)
             self.assertTrue(mocked_smtplib.return_value.sendmail.called)
 


### PR DESCRIPTION
### What does this PR do?
Fixes test: unit.returners.test_smtp_return

### Previous Behavior
Test was failing with:

```
===================================================  Overall Tests Report  ====================================================
*** unit.returners.test_smtp_return Tests  ************************************************************************************
 --------  Tests with Errors  -------------------------------------------------------------------------------------------------
   -> unit.returners.test_smtp_return.SMTPReturnerTestCase.test_returner  .....................................................
       Traceback (most recent call last):
         File "/testing/tests/unit/returners/test_smtp_return.py", line 86, in test_returner
           self._test_returner(mocked_smtplib)
         File "/testing/tests/unit/returners/test_smtp_return.py", line 60, in _test_returner
           smtp.returner(ret)
         File "/testing/salt/returners/smtp_return.py", line 198, in returner
           **ret)
         File "/testing/salt/template.py", line 93, in compile_template
           ret = render(input_data, saltenv, sls, **render_kwargs)
         File "/testing/salt/renderers/jinja.py", line 73, in render
           tmp_data.get('data', 'Unknown render error in jinja renderer')
       SaltRenderError: Traceback (most recent call last):
         File "/testing/salt/utils/templates.py", line 169, in render_tmpl
           output = render_str(tmplstr, context, tmplpath)
         File "/testing/salt/utils/templates.py", line 306, in render_jinja_tmpl
           loader = salt.utils.jinja.SaltCacheLoader(opts, saltenv, pillar_rend=context.get('_pillar_rend', False))
         File "/testing/salt/utils/jinja.py", line 74, in __init__
           self.file_client()
         File "/testing/salt/utils/jinja.py", line 82, in file_client
           self.opts, self.pillar_rend)
         File "/testing/salt/fileclient.py", line 63, in get_file_client
           }.get(client, RemoteClient)(opts)
         File "/testing/salt/fileclient.py", line 1060, in __init__
           self.channel = salt.transport.Channel.factory(self.opts)
         File "/testing/salt/transport/__init__.py", line 53, in factory
           return ReqChannel.factory(opts, **kwargs)
         File "/testing/salt/transport/client.py", line 25, in factory
           sync = SyncWrapper(AsyncReqChannel.factory, (opts,), kwargs)
         File "/testing/salt/utils/async.py", line 49, in __init__
           self.async = method(*args, **kwargs)
         File "/testing/salt/transport/client.py", line 108, in factory
           return salt.transport.zeromq.AsyncZeroMQReqChannel(opts, **kwargs)
         File "/testing/salt/transport/zeromq.py", line 124, in __new__
           key = cls.__key(opts, **kwargs)
         File "/testing/salt/transport/zeromq.py", line 164, in __key
           return (opts['pki_dir'],     # where the keys are stored
       KeyError: u'pki_dir'
   ............................................................................................................................
 ------------------------------------------------------------------------------------------------------------------------------
===============================================================================================================================
```

This is due to this change https://github.com/saltstack/salt/pull/46149/commits/a8cded1c836198c1ad7a6f521419b9ef10ae06d7 here adding the new `self.file_client()` call requires us to mock the `file_client` call for this test. 
Would like review from @terminalmage to ensure this is only a test fix and not code as this is a new change. 

### New Behavior
tests pass
