### PR TITLE
Fix `unit.modules.test_pip` for Windows

### DIFF
--- a/salt/modules/pip.py
+++ b/salt/modules/pip.py
@@ -139,11 +139,7 @@ def _get_pip_bin(bin_env):
     # try to get pip bin from virtualenv, bin_env
     if os.path.isdir(bin_env):
         if salt.utils.platform.is_windows():
-            if six.PY2:
-                pip_bin = os.path.join(
-                    bin_env, 'Scripts', 'pip.exe').encode('string-escape')
-            else:
-                pip_bin = os.path.join(bin_env, 'Scripts', 'pip.exe')
+            pip_bin = os.path.join(bin_env, 'Scripts', 'pip.exe')
         else:
             pip_bin = os.path.join(bin_env, 'bin', 'pip')
         if os.path.isfile(pip_bin):

--- a/tests/unit/modules/test_pip.py
+++ b/tests/unit/modules/test_pip.py
@@ -298,7 +298,7 @@ class PipTestCase(TestCase, LoaderModuleMockMixin):
             with patch.dict(pip.__salt__, {'cmd.run_all': mock}):
                 if salt.utils.platform.is_windows():
                     venv_path = 'c:\\test_env'
-                    bin_path = os.path.join(venv_path, 'Scripts', 'pip.exe').encode('string-escape')
+                    bin_path = os.path.join(venv_path, 'Scripts', 'pip.exe')
                 else:
                     venv_path = '/test_env'
                     bin_path = os.path.join(venv_path, 'bin', 'pip')


### PR DESCRIPTION
### What does this PR do?
Fix an encoding issue caused by `unicode_literals`. Since moving to `unicode_literals`, we no longer need to use `.encoding('string-escape')`. Found by the test suite.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt-jenkins/issues/439

### Tests written?
Yes

### Commits signed with GPG?
Yes