### PR TITLE
Add trust_failures option to svn.export and svn.latest.

### DIFF
--- a/salt/states/svn.py
+++ b/salt/states/svn.py
@@ -48,7 +48,8 @@ def latest(name,
            password=None,
            force=False,
            externals=True,
-           trust=False):
+           trust=False,
+           trust_failures=None):
     '''
     Checkout or update the working directory to the latest revision from the
     remote repository.
@@ -84,6 +85,14 @@ def latest(name,
 
     trust : False
         Automatically trust the remote server. SVN's --trust-server-cert
+
+    trust_failures : None
+        Comma-separated list of certificate trust failures, that shall be
+        ignored. This can be used if trust=True is not sufficient. The
+        specified string is passed to SVN's --trust-server-cert-failures
+        option as-is.
+
+        .. versionadded:: Fluorine
     '''
     ret = {'name': name, 'result': True, 'comment': '', 'changes': {}}
     if not target:
@@ -147,6 +156,9 @@ def latest(name,
     if trust:
         opts += ('--trust-server-cert',)
 
+    if trust_failures:
+        opts += ('--trust-server-cert-failures', trust_failures)
+
     if svn_cmd == 'svn.update':
         out = __salt__[svn_cmd](cwd, basename, user, username, password, *opts)
 
@@ -184,7 +196,8 @@ def export(name,
            force=False,
            overwrite=False,
            externals=True,
-           trust=False):
+           trust=False,
+           trust_failures=None):
     '''
     Export a file or directory from an SVN repository
 
@@ -222,6 +235,14 @@ def export(name,
 
     trust : False
         Automatically trust the remote server. SVN's --trust-server-cert
+
+    trust_failures : None
+        Comma-separated list of certificate trust failures, that shall be
+        ignored. This can be used if trust=True is not sufficient. The
+        specified string is passed to SVN's --trust-server-cert-failures
+        option as-is.
+
+        .. versionadded:: Fluorine
     '''
     ret = {'name': name, 'result': True, 'comment': '', 'changes': {}}
     if not target:
@@ -259,6 +280,9 @@ def export(name,
 
     if trust:
         opts += ('--trust-server-cert',)
+
+    if trust_failures:
+        opts += ('--trust-server-cert-failures', trust_failures)
 
     out = __salt__[svn_cmd](cwd, name, basename, user, username, password, rev, *opts)
     ret['changes'] = name + ' was Exported to ' + target


### PR DESCRIPTION
### What does this PR do?

This PR adds the new `trust_failures` option to the `svn.export` and `svn.latest` states.

If set, the value of this option is passed to `svn` using the `--trust-server-cert-failures` option. This is useful in cases where using the `--trust-server-cert` option (as enabled by the `trust` option of the states) is not sufficient. One example of such a case is when the host name of the SVN server does not match the name in the certificate. In this case, specifying `trust: cn-mismatch` will make `svn` still accept the certificate.

### What issues does this PR fix or reference?

None, it is a new feature.

### Tests written?

No

### Commits signed with GPG?

No
