### PR TITLE
archive.extracted: don't check source file when if_missing path exists

### DIFF
--- a/salt/states/archive.py
+++ b/salt/states/archive.py
@@ -690,7 +690,7 @@ def extracted(name,
         # True
         # >>> os.path.isfile('/tmp/foo.txt/')
         # False
-        name = name.rstrip('/')
+        name = name.rstrip(os.sep)
         if os.path.isfile(name):
             ret['comment'] = '{0} exists and is not a directory'.format(name)
             return ret
@@ -722,6 +722,11 @@ def extracted(name,
                     .format(name)
                 )
                 return ret
+
+    if if_missing is not None and os.path.exists(if_missing):
+        ret['result'] = True
+        ret['comment'] = 'Path {0} exists'.format(if_missing)
+        return ret
 
     if user or group:
         if salt.utils.is_windows():
@@ -1519,7 +1524,7 @@ def extracted(name,
         if not if_missing:
             # If is_missing was used, and both a) the archive had never been
             # extracted, and b) the path referred to by if_missing exists, then
-            # enforce_missing would contain paths of top_levle dirs/files that
+            # enforce_missing would contain paths of top_level dirs/files that
             # _would_ have been extracted. Since if_missing can be used as a
             # semaphore to conditionally extract, we don't want to make this a
             # case where the state fails, so we only fail the state if

--- a/tests/unit/states/test_archive.py
+++ b/tests/unit/states/test_archive.py
@@ -203,3 +203,25 @@ class ArchiveTestCase(TestCase, LoaderModuleMockMixin):
                                     enforce_toplevel=False,
                                     keep=True)
             self.assertEqual(ret['changes']['extracted_files'], 'stderr')
+
+    def test_extracted_when_if_missing_path_exists(self):
+        '''
+        When if_missing exists, we should exit without making any changes.
+
+        NOTE: We're not mocking the __salt__ dunder because if we actually run
+        any functions from that dunder, we're doing something wrong. So, in
+        those cases we'll just let it raise a KeyError and cause the test to
+        fail.
+        '''
+        name = if_missing = '/tmp/foo'
+        source = 'salt://foo.bar.tar'
+        with patch.object(os.path, 'exists', MagicMock(return_value=True)):
+            ret = archive.extracted(
+                name,
+                source=source,
+                if_missing=if_missing)
+            self.assertTrue(ret['result'], ret)
+            self.assertEqual(
+                ret['comment'],
+                'Path {0} exists'.format(if_missing)
+            )


### PR DESCRIPTION
This exits the state early with a True result when the if_missing path
exists.

Fixes #46109.