### PR TITLE
Don't ignore 'private_ips' unnecessarily

### DIFF
--- a/salt/cloud/clouds/openstack.py
+++ b/salt/cloud/clouds/openstack.py
@@ -700,7 +700,7 @@ def _query_node_data(vm_, data, floating, conn):
     if not result and ssh_interface(vm_) == 'private_ips':
         for private_ip in private:
             ignore_ip = ignore_cidr(vm_, private_ip)
-            if private_ip not in data.private_ips and not ignore_ip:
+            if not ignore_ip:
                 result.append(private_ip)
 
     if result:


### PR DESCRIPTION
### What does this PR do?
Removes a test for the existence of a private_ip in an earlier list of private_ips where salt-cloud has been told to use private_ips for ssh access.
### What issues does this PR fix or reference?
#46215 salt-cloud will only intermittently build rackspace cloud instances with purely private networks

### Previous Behavior
salt-cloud ignores valid private_ip addresses assigned by the API

### New Behavior
If ssh_interface is 'private_ips' then check whether IP is in ignore_cidr range, but don't ignore the IP if it was found in the original list of private_ips which was gathered when the new instance was created. 

### Tests written?

No

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
