### PR TITLE
Kubernetes configured via kubeconfig

### DIFF
--- a/salt/modules/kubernetes.py
+++ b/salt/modules/kubernetes.py
@@ -8,7 +8,7 @@ Module for handling kubernetes calls.
 
         kubernetes.kubeconfig: '/path/to/kubeconfig'
         kubernetes.kubeconfig-data: '<base64 encoded kubeconfig content'
-        kubernetes.contect: 'context'
+        kubernetes.context: 'context'
 
 These settings can be also overrided by adding `context and `kubeconfig` or
 `kubeconfig_data` parameters when calling a function.

--- a/salt/modules/kubernetes.py
+++ b/salt/modules/kubernetes.py
@@ -10,14 +10,14 @@ Module for handling kubernetes calls.
         kubernetes.kubeconfig-data: '<base64 encoded kubeconfig content'
         kubernetes.context: 'context'
 
-These settings can be also overrided by adding `context and `kubeconfig` or
+These settings can be overridden by adding `context and `kubeconfig` or
 `kubeconfig_data` parameters when calling a function.
 
 The data format for `kubernetes.kubeconfig-data` value is the content of
 `kubeconfig` base64 encoded in one line.
 
 Only `kubeconfig` or `kubeconfig-data` should be provided. In case both are
-provided `kubeconfig` entry is prefered.
+provided `kubeconfig` entry is preferred.
 
 .. code-block:: bash
 
@@ -126,7 +126,7 @@ def _cleanup(**kwargs):
                 os.unlink(kubeconfig)
             except (IOError, OSError) as err:
                 if err.errno != errno.ENOENT:
-                    log.exception('Removing kubeconfig failed: {0}'.format(err))
+                    log.exception(err)
 
 
 def ping(**kwargs):

--- a/salt/modules/kubernetes.py
+++ b/salt/modules/kubernetes.py
@@ -112,6 +112,80 @@ if not salt.utils.platform.is_windows():
     POLLING_TIME_LIMIT = 30
 
 
+def _setup_conn_old(**kwargs):
+    '''
+    Setup kubernetes API connection singleton the old way
+    '''
+    host = __salt__['config.option']('kubernetes.api_url',
+                                     'http://localhost:8080')
+    username = __salt__['config.option']('kubernetes.user')
+    password = __salt__['config.option']('kubernetes.password')
+    ca_cert = __salt__['config.option']('kubernetes.certificate-authority-data')
+    client_cert = __salt__['config.option']('kubernetes.client-certificate-data')
+    client_key = __salt__['config.option']('kubernetes.client-key-data')
+    ca_cert_file = __salt__['config.option']('kubernetes.certificate-authority-file')
+    client_cert_file = __salt__['config.option']('kubernetes.client-certificate-file')
+    client_key_file = __salt__['config.option']('kubernetes.client-key-file')
+
+    # Override default API settings when settings are provided
+    if 'api_url' in kwargs:
+        host = kwargs.get('api_url')
+
+    if 'api_user' in kwargs:
+        username = kwargs.get('api_user')
+
+    if 'api_password' in kwargs:
+        password = kwargs.get('api_password')
+
+    if 'api_certificate_authority_file' in kwargs:
+        ca_cert_file = kwargs.get('api_certificate_authority_file')
+
+    if 'api_client_certificate_file' in kwargs:
+        client_cert_file = kwargs.get('api_client_certificate_file')
+
+    if 'api_client_key_file' in kwargs:
+        client_key_file = kwargs.get('api_client_key_file')
+
+    if (
+            kubernetes.client.configuration.host != host or
+            kubernetes.client.configuration.user != username or
+            kubernetes.client.configuration.password != password):
+        # Recreates API connection if settings are changed
+        kubernetes.client.configuration.__init__()
+
+    kubernetes.client.configuration.host = host
+    kubernetes.client.configuration.user = username
+    kubernetes.client.configuration.passwd = password
+
+    if ca_cert_file:
+        kubernetes.client.configuration.ssl_ca_cert = ca_cert_file
+    elif ca_cert:
+        with tempfile.NamedTemporaryFile(prefix='salt-kube-', delete=False) as ca:
+            ca.write(base64.b64decode(ca_cert))
+            kubernetes.client.configuration.ssl_ca_cert = ca.name
+    else:
+        kubernetes.client.configuration.ssl_ca_cert = None
+
+    if client_cert_file:
+        kubernetes.client.configuration.cert_file = client_cert_file
+    elif client_cert:
+        with tempfile.NamedTemporaryFile(prefix='salt-kube-', delete=False) as c:
+            c.write(base64.b64decode(client_cert))
+            kubernetes.client.configuration.cert_file = c.name
+    else:
+        kubernetes.client.configuration.cert_file = None
+
+    if client_key_file:
+        kubernetes.client.configuration.key_file = client_key_file
+    elif client_key:
+        with tempfile.NamedTemporaryFile(prefix='salt-kube-', delete=False) as k:
+            k.write(base64.b64decode(client_key))
+            kubernetes.client.configuration.key_file = k.name
+    else:
+        kubernetes.client.configuration.key_file = None
+    return {}
+
+
 # pylint: disable=no-member
 def _setup_conn(**kwargs):
     '''
@@ -125,13 +199,43 @@ def _setup_conn(**kwargs):
         with tempfile.NamedTemporaryFile(prefix='salt-kubeconfig-', delete=False) as kcfg:
             kcfg.write(base64.b64decode(kubeconfig_data))
             kubeconfig = kcfg.name
+
+    if not (kubeconfig and context):
+        if kwargs.get('api_url') or __salt__['config.option']('kubernetes.api_url'):
+            salt.utils.versions.warn_until('Sodium',
+                    'Kubernetes configuration via url, certificate, username and password will be removed in Sodiom. '
+                    'Use \'kubeconfig\' and \'context\' instead.')
+            try:
+                return _setup_conn_old(**kwargs)
+            except Exception:
+                raise CommandExecutionError('Old style kubernetes configuration is only supported up to python-kubernetes 2.0.0')
+        else:
+            raise CommandExecutionError('Invalid kubernetes configuration. Parameter \'kubeconfig\' and \'context\' are required.')
     kubernetes.config.load_kube_config(config_file=kubeconfig, context=context)
 
     # The return makes unit testing easier
     return {'kubeconfig': kubeconfig, 'context': context}
 
 
+def _cleanup_old(**kwargs):
+    try:
+        ca = kubernetes.client.configuration.ssl_ca_cert
+        cert = kubernetes.client.configuration.cert_file
+        key = kubernetes.client.configuration.key_file
+        if cert and os.path.exists(cert) and os.path.basename(cert).startswith('salt-kube-'):
+            salt.utils.safe_rm(cert)
+        if key and os.path.exists(key) and os.path.basename(key).startswith('salt-kube-'):
+            salt.utils.safe_rm(key)
+        if ca and os.path.exists(ca) and os.path.basename(ca).startswith('salt-kube-'):
+            salt.utils.safe_rm(ca)
+    except Exception:
+        pass
+
+
 def _cleanup(**kwargs):
+    if not kwargs:
+        return _cleanup_old(**kwargs)
+
     if 'kubeconfig' in kwargs:
         kubeconfig = kwargs.get('kubeconfig')
         if kubeconfig and os.path.basename(kubeconfig).startswith('salt-kubeconfig-'):

--- a/salt/modules/kubernetes.py
+++ b/salt/modules/kubernetes.py
@@ -104,22 +104,11 @@ def _setup_conn(**kwargs):
     '''
     Setup kubernetes API connection singleton
     '''
-    kubeconfig = __salt__['config.option']('kubernetes.kubeconfig')
-    kubeconfig_data = __salt__['config.option']('kubernetes.kubeconfig-data')
-    context = __salt__['config.option']('kubernetes.context')
+    kubeconfig = kwargs.get('kubeconfig') or __salt__['config.option']('kubernetes.kubeconfig')
+    kubeconfig_data = kwargs.get('kubeconfig_data') or __salt__['config.option']('kubernetes.kubeconfig-data')
+    context = kwargs.get('context') or __salt__['config.option']('kubernetes.context')
 
-    kubeconfig_data_overwrite = False
-    # Override default API settings when settings are provided
-    if 'kubeconfig' in kwargs:
-        kubeconfig = kwargs.get('kubeconfig')
-    elif 'kubeconfig_data' in kwargs:
-        kubeconfig_data = kwargs.get('kubeconfig_data')
-        kubeconfig_data_overwrite = True
-
-    if 'context' in kwargs:
-        context = kwargs.get('context')
-
-    if (kubeconfig_data and not kubeconfig) or (kubeconfig_data and kubeconfig_data_overwrite):
+    if (kubeconfig_data and not kubeconfig) or (kubeconfig_data and kwargs.get('kubeconfig_data')):
         with tempfile.NamedTemporaryFile(prefix='salt-kubeconfig-', delete=False) as kcfg:
             kcfg.write(base64.b64decode(kubeconfig_data))
             kubeconfig = kcfg.name

--- a/salt/modules/kubernetes.py
+++ b/salt/modules/kubernetes.py
@@ -1538,7 +1538,7 @@ def __dict_to_deployment_spec(spec):
     '''
     Converts a dictionary into kubernetes AppsV1beta1DeploymentSpec instance.
     '''
-    spec_obj = AppsV1beta1DeploymentSpec()
+    spec_obj = AppsV1beta1DeploymentSpec(template="")
     for key, value in iteritems(spec):
         if hasattr(spec_obj, key):
             setattr(spec_obj, key, value)

--- a/salt/modules/kubernetes.py
+++ b/salt/modules/kubernetes.py
@@ -37,6 +37,7 @@ from __future__ import absolute_import, unicode_literals, print_function
 import sys
 import os.path
 import base64
+import errno
 import logging
 import tempfile
 import signal

--- a/salt/modules/kubernetes.py
+++ b/salt/modules/kubernetes.py
@@ -6,30 +6,22 @@ Module for handling kubernetes calls.
 :configuration: The k8s API settings are provided either in a pillar, in
     the minion's config file, or in master's config file::
 
-        kubernetes.user: admin
-        kubernetes.password: verybadpass
-        kubernetes.api_url: 'http://127.0.0.1:8080'
-        kubernetes.certificate-authority-data: '...'
-        kubernetes.client-certificate-data: '....n
-        kubernetes.client-key-data: '...'
-        kubernetes.certificate-authority-file: '/path/to/ca.crt'
-        kubernetes.client-certificate-file: '/path/to/client.crt'
-        kubernetes.client-key-file: '/path/to/client.key'
+        kubernetes.kubeconfig: '/path/to/kubeconfig'
+        kubernetes.kubeconfig-data: '<base64 encoded kubeconfig content'
+        kubernetes.contect: 'context'
 
+These settings can be also overrided by adding `context and `kubeconfig` or
+`kubeconfig_data` parameters when calling a function.
 
-These settings can be also overrided by adding `api_url`, `api_user`,
-`api_password`, `api_certificate_authority_file`, `api_client_certificate_file`
-or `api_client_key_file` parameters when calling a function:
+The data format for `kubernetes.kubeconfig-data` value is the content of
+`kubeconfig` base64 encoded in one line.
 
-The data format for `kubernetes.*-data` values is the same as provided in `kubeconfig`.
-It's base64 encoded certificates/keys in one line.
-
-For an item only one field should be provided. Either a `data` or a `file` entry.
-In case both are provided the `file` entry is prefered.
+Only `kubeconfig` or `kubeconfig-data` should be provided. In case both are
+provided `kubeconfig` entry is prefered.
 
 .. code-block:: bash
 
-    salt '*' kubernetes.nodes api_url=http://k8s-api-server:port api_user=myuser api_password=pass
+    salt '*' kubernetes.nodes kubeconfig=/etc/salt/k8s/kubeconfig context=minikube
 
 .. versionadded: 2017.7.0
 '''
@@ -106,91 +98,36 @@ def _setup_conn(**kwargs):
     '''
     Setup kubernetes API connection singleton
     '''
-    host = __salt__['config.option']('kubernetes.api_url',
-                                     'http://localhost:8080')
-    username = __salt__['config.option']('kubernetes.user')
-    password = __salt__['config.option']('kubernetes.password')
-    ca_cert = __salt__['config.option']('kubernetes.certificate-authority-data')
-    client_cert = __salt__['config.option']('kubernetes.client-certificate-data')
-    client_key = __salt__['config.option']('kubernetes.client-key-data')
-    ca_cert_file = __salt__['config.option']('kubernetes.certificate-authority-file')
-    client_cert_file = __salt__['config.option']('kubernetes.client-certificate-file')
-    client_key_file = __salt__['config.option']('kubernetes.client-key-file')
+    kubeconfig = __salt__['config.option']('kubernetes.kubeconfig')
+    kubeconfig_data = __salt__['config.option']('kubernetes.kubeconfig-data')
+    context = __salt__['config.option']('kubernetes.context')
 
+    kubeconfig_data_overwrite = False
     # Override default API settings when settings are provided
-    if 'api_url' in kwargs:
-        host = kwargs.get('api_url')
+    if 'kubeconfig' in kwargs:
+        kubeconfig = kwargs.get('kubeconfig')
+    elif 'kubeconfig_data' in kwargs:
+        kubeconfig_data = kwargs.get('kubeconfig_data')
+        kubeconfig_data_overwrite = True
 
-    if 'api_user' in kwargs:
-        username = kwargs.get('api_user')
+    if 'context' in kwargs:
+        context = kwargs.get('context')
 
-    if 'api_password' in kwargs:
-        password = kwargs.get('api_password')
-
-    if 'api_certificate_authority_file' in kwargs:
-        ca_cert_file = kwargs.get('api_certificate_authority_file')
-
-    if 'api_client_certificate_file' in kwargs:
-        client_cert_file = kwargs.get('api_client_certificate_file')
-
-    if 'api_client_key_file' in kwargs:
-        client_key_file = kwargs.get('api_client_key_file')
-
-    if (
-            kubernetes.client.configuration.host != host or
-            kubernetes.client.configuration.user != username or
-            kubernetes.client.configuration.password != password):
-        # Recreates API connection if settings are changed
-        kubernetes.client.configuration.__init__()
-
-    kubernetes.client.configuration.host = host
-    kubernetes.client.configuration.user = username
-    kubernetes.client.configuration.passwd = password
-    if __salt__['config.option']('kubernetes.api_key'):
-        kubernetes.client.configuration.api_key = {'authorization': __salt__['config.option']('kubernetes.api_key')}
-        kubernetes.client.configuration.api_key_prefix = {'authorization': __salt__['config.option']('kubernetes.api_key_prefix')}
-
-    if ca_cert_file:
-        kubernetes.client.configuration.ssl_ca_cert = ca_cert_file
-    elif ca_cert:
-        with tempfile.NamedTemporaryFile(prefix='salt-kube-', delete=False) as ca:
-            ca.write(base64.b64decode(ca_cert))
-            kubernetes.client.configuration.ssl_ca_cert = ca.name
-    else:
-        kubernetes.client.configuration.ssl_ca_cert = None
-
-    if client_cert_file:
-        kubernetes.client.configuration.cert_file = client_cert_file
-    elif client_cert:
-        with tempfile.NamedTemporaryFile(prefix='salt-kube-', delete=False) as c:
-            c.write(base64.b64decode(client_cert))
-            kubernetes.client.configuration.cert_file = c.name
-    else:
-        kubernetes.client.configuration.cert_file = None
-
-    if client_key_file:
-        kubernetes.client.configuration.key_file = client_key_file
-    elif client_key:
-        with tempfile.NamedTemporaryFile(prefix='salt-kube-', delete=False) as k:
-            k.write(base64.b64decode(client_key))
-            kubernetes.client.configuration.key_file = k.name
-    else:
-        kubernetes.client.configuration.key_file = None
+    if (kubeconfig_data and not kubeconfig) or (kubeconfig_data and kubeconfig_data_overwrite):
+        with tempfile.NamedTemporaryFile(prefix='salt-kubeconfig-', delete=False) as kcfg:
+            kcfg.write(base64.b64decode(kubeconfig_data))
+            kubeconfig = kcfg.name
+    kubernetes.config.load_kube_config(config_file=kubeconfig, context=context)
 
     # The return makes unit testing easier
-    return vars(kubernetes.client.configuration)
+    return {'kubeconfig': kubeconfig, 'context': context}
 
 
 def _cleanup(**kwargs):
-    ca = kubernetes.client.configuration.ssl_ca_cert
-    cert = kubernetes.client.configuration.cert_file
-    key = kubernetes.client.configuration.key_file
-    if cert and os.path.exists(cert) and os.path.basename(cert).startswith('salt-kube-'):
-        salt.utils.files.safe_rm(cert)
-    if key and os.path.exists(key) and os.path.basename(key).startswith('salt-kube-'):
-        salt.utils.files.safe_rm(key)
-    if ca and os.path.exists(ca) and os.path.basename(ca).startswith('salt-kube-'):
-        salt.utils.files.safe_rm(ca)
+    if 'kubeconfig' in kwargs:
+        kubeconfig = kwargs.get('kubeconfig')
+        if os.path.exists(kubeconfig) and os.path.basename(kubeconfig).startswith('salt-kubeconfig-'):
+            salt.utils.files.safe_rm(kubeconfig)
 
 
 def ping(**kwargs):
@@ -217,9 +154,9 @@ def nodes(**kwargs):
     CLI Examples::
 
         salt '*' kubernetes.nodes
-        salt '*' kubernetes.nodes api_url=http://myhost:port api_user=my-user
+        salt '*' kubernetes.nodes kubeconfig=/etc/salt/k8s/kubeconfig context=minikube
     '''
-    _setup_conn(**kwargs)
+    cfg = _setup_conn(**kwargs)
     try:
         api_instance = kubernetes.client.CoreV1Api()
         api_response = api_instance.list_node()
@@ -232,7 +169,7 @@ def nodes(**kwargs):
             log.exception('Exception when calling CoreV1Api->list_node')
             raise CommandExecutionError(exc)
     finally:
-        _cleanup()
+        _cleanup(**cfg)
 
 
 def node(name, **kwargs):
@@ -243,7 +180,7 @@ def node(name, **kwargs):
 
         salt '*' kubernetes.node name='minikube'
     '''
-    _setup_conn(**kwargs)
+    cfg = _setup_conn(**kwargs)
     try:
         api_instance = kubernetes.client.CoreV1Api()
         api_response = api_instance.list_node()
@@ -254,7 +191,7 @@ def node(name, **kwargs):
             log.exception('Exception when calling CoreV1Api->list_node')
             raise CommandExecutionError(exc)
     finally:
-        _cleanup()
+        _cleanup(**cfg)
 
     for k8s_node in api_response.items:
         if k8s_node.metadata.name == name:
@@ -290,7 +227,7 @@ def node_add_label(node_name, label_name, label_value, **kwargs):
         salt '*' kubernetes.node_add_label node_name="minikube" \
             label_name="foo" label_value="bar"
     '''
-    _setup_conn(**kwargs)
+    cfg = _setup_conn(**kwargs)
     try:
         api_instance = kubernetes.client.CoreV1Api()
         body = {
@@ -308,7 +245,7 @@ def node_add_label(node_name, label_name, label_value, **kwargs):
             log.exception('Exception when calling CoreV1Api->patch_node')
             raise CommandExecutionError(exc)
     finally:
-        _cleanup()
+        _cleanup(**cfg)
 
     return None
 
@@ -323,7 +260,7 @@ def node_remove_label(node_name, label_name, **kwargs):
         salt '*' kubernetes.node_remove_label node_name="minikube" \
             label_name="foo"
     '''
-    _setup_conn(**kwargs)
+    cfg = _setup_conn(**kwargs)
     try:
         api_instance = kubernetes.client.CoreV1Api()
         body = {
@@ -341,7 +278,7 @@ def node_remove_label(node_name, label_name, **kwargs):
             log.exception('Exception when calling CoreV1Api->patch_node')
             raise CommandExecutionError(exc)
     finally:
-        _cleanup()
+        _cleanup(**cfg)
 
     return None
 
@@ -353,9 +290,9 @@ def namespaces(**kwargs):
     CLI Examples::
 
         salt '*' kubernetes.namespaces
-        salt '*' kubernetes.namespaces api_url=http://myhost:port api_user=my-user
+        salt '*' kubernetes.namespaces kubeconfig=/etc/salt/k8s/kubeconfig context=minikube
     '''
-    _setup_conn(**kwargs)
+    cfg = _setup_conn(**kwargs)
     try:
         api_instance = kubernetes.client.CoreV1Api()
         api_response = api_instance.list_namespace()
@@ -368,7 +305,7 @@ def namespaces(**kwargs):
             log.exception('Exception when calling CoreV1Api->list_namespace')
             raise CommandExecutionError(exc)
     finally:
-        _cleanup()
+        _cleanup(**cfg)
 
 
 def deployments(namespace='default', **kwargs):
@@ -380,7 +317,7 @@ def deployments(namespace='default', **kwargs):
         salt '*' kubernetes.deployments
         salt '*' kubernetes.deployments namespace=default
     '''
-    _setup_conn(**kwargs)
+    cfg = _setup_conn(**kwargs)
     try:
         api_instance = kubernetes.client.ExtensionsV1beta1Api()
         api_response = api_instance.list_namespaced_deployment(namespace)
@@ -396,7 +333,7 @@ def deployments(namespace='default', **kwargs):
             )
             raise CommandExecutionError(exc)
     finally:
-        _cleanup()
+        _cleanup(**cfg)
 
 
 def services(namespace='default', **kwargs):
@@ -408,7 +345,7 @@ def services(namespace='default', **kwargs):
         salt '*' kubernetes.services
         salt '*' kubernetes.services namespace=default
     '''
-    _setup_conn(**kwargs)
+    cfg = _setup_conn(**kwargs)
     try:
         api_instance = kubernetes.client.CoreV1Api()
         api_response = api_instance.list_namespaced_service(namespace)
@@ -424,7 +361,7 @@ def services(namespace='default', **kwargs):
             )
             raise CommandExecutionError(exc)
     finally:
-        _cleanup()
+        _cleanup(**cfg)
 
 
 def pods(namespace='default', **kwargs):
@@ -436,7 +373,7 @@ def pods(namespace='default', **kwargs):
         salt '*' kubernetes.pods
         salt '*' kubernetes.pods namespace=default
     '''
-    _setup_conn(**kwargs)
+    cfg = _setup_conn(**kwargs)
     try:
         api_instance = kubernetes.client.CoreV1Api()
         api_response = api_instance.list_namespaced_pod(namespace)
@@ -452,7 +389,7 @@ def pods(namespace='default', **kwargs):
             )
             raise CommandExecutionError(exc)
     finally:
-        _cleanup()
+        _cleanup(**cfg)
 
 
 def secrets(namespace='default', **kwargs):
@@ -464,7 +401,7 @@ def secrets(namespace='default', **kwargs):
         salt '*' kubernetes.secrets
         salt '*' kubernetes.secrets namespace=default
     '''
-    _setup_conn(**kwargs)
+    cfg = _setup_conn(**kwargs)
     try:
         api_instance = kubernetes.client.CoreV1Api()
         api_response = api_instance.list_namespaced_secret(namespace)
@@ -480,7 +417,7 @@ def secrets(namespace='default', **kwargs):
             )
             raise CommandExecutionError(exc)
     finally:
-        _cleanup()
+        _cleanup(**cfg)
 
 
 def configmaps(namespace='default', **kwargs):
@@ -492,7 +429,7 @@ def configmaps(namespace='default', **kwargs):
         salt '*' kubernetes.configmaps
         salt '*' kubernetes.configmaps namespace=default
     '''
-    _setup_conn(**kwargs)
+    cfg = _setup_conn(**kwargs)
     try:
         api_instance = kubernetes.client.CoreV1Api()
         api_response = api_instance.list_namespaced_config_map(namespace)
@@ -508,7 +445,7 @@ def configmaps(namespace='default', **kwargs):
             )
             raise CommandExecutionError(exc)
     finally:
-        _cleanup()
+        _cleanup(**cfg)
 
 
 def show_deployment(name, namespace='default', **kwargs):
@@ -520,7 +457,7 @@ def show_deployment(name, namespace='default', **kwargs):
         salt '*' kubernetes.show_deployment my-nginx default
         salt '*' kubernetes.show_deployment name=my-nginx namespace=default
     '''
-    _setup_conn(**kwargs)
+    cfg = _setup_conn(**kwargs)
     try:
         api_instance = kubernetes.client.ExtensionsV1beta1Api()
         api_response = api_instance.read_namespaced_deployment(name, namespace)
@@ -536,7 +473,7 @@ def show_deployment(name, namespace='default', **kwargs):
             )
             raise CommandExecutionError(exc)
     finally:
-        _cleanup()
+        _cleanup(**cfg)
 
 
 def show_service(name, namespace='default', **kwargs):
@@ -548,7 +485,7 @@ def show_service(name, namespace='default', **kwargs):
         salt '*' kubernetes.show_service my-nginx default
         salt '*' kubernetes.show_service name=my-nginx namespace=default
     '''
-    _setup_conn(**kwargs)
+    cfg = _setup_conn(**kwargs)
     try:
         api_instance = kubernetes.client.CoreV1Api()
         api_response = api_instance.read_namespaced_service(name, namespace)
@@ -564,7 +501,7 @@ def show_service(name, namespace='default', **kwargs):
             )
             raise CommandExecutionError(exc)
     finally:
-        _cleanup()
+        _cleanup(**cfg)
 
 
 def show_pod(name, namespace='default', **kwargs):
@@ -576,7 +513,7 @@ def show_pod(name, namespace='default', **kwargs):
         salt '*' kubernetes.show_pod guestbook-708336848-fqr2x
         salt '*' kubernetes.show_pod guestbook-708336848-fqr2x namespace=default
     '''
-    _setup_conn(**kwargs)
+    cfg = _setup_conn(**kwargs)
     try:
         api_instance = kubernetes.client.CoreV1Api()
         api_response = api_instance.read_namespaced_pod(name, namespace)
@@ -592,7 +529,7 @@ def show_pod(name, namespace='default', **kwargs):
             )
             raise CommandExecutionError(exc)
     finally:
-        _cleanup()
+        _cleanup(**cfg)
 
 
 def show_namespace(name, **kwargs):
@@ -603,7 +540,7 @@ def show_namespace(name, **kwargs):
 
         salt '*' kubernetes.show_namespace kube-system
     '''
-    _setup_conn(**kwargs)
+    cfg = _setup_conn(**kwargs)
     try:
         api_instance = kubernetes.client.CoreV1Api()
         api_response = api_instance.read_namespace(name)
@@ -619,7 +556,7 @@ def show_namespace(name, **kwargs):
             )
             raise CommandExecutionError(exc)
     finally:
-        _cleanup()
+        _cleanup(**cfg)
 
 
 def show_secret(name, namespace='default', decode=False, **kwargs):
@@ -634,7 +571,7 @@ def show_secret(name, namespace='default', decode=False, **kwargs):
         salt '*' kubernetes.show_secret name=confidential namespace=default
         salt '*' kubernetes.show_secret name=confidential decode=True
     '''
-    _setup_conn(**kwargs)
+    cfg = _setup_conn(**kwargs)
     try:
         api_instance = kubernetes.client.CoreV1Api()
         api_response = api_instance.read_namespaced_secret(name, namespace)
@@ -655,7 +592,7 @@ def show_secret(name, namespace='default', decode=False, **kwargs):
             )
             raise CommandExecutionError(exc)
     finally:
-        _cleanup()
+        _cleanup(**cfg)
 
 
 def show_configmap(name, namespace='default', **kwargs):
@@ -667,7 +604,7 @@ def show_configmap(name, namespace='default', **kwargs):
         salt '*' kubernetes.show_configmap game-config default
         salt '*' kubernetes.show_configmap name=game-config namespace=default
     '''
-    _setup_conn(**kwargs)
+    cfg = _setup_conn(**kwargs)
     try:
         api_instance = kubernetes.client.CoreV1Api()
         api_response = api_instance.read_namespaced_config_map(
@@ -685,7 +622,7 @@ def show_configmap(name, namespace='default', **kwargs):
             )
             raise CommandExecutionError(exc)
     finally:
-        _cleanup()
+        _cleanup(**cfg)
 
 
 def delete_deployment(name, namespace='default', **kwargs):
@@ -697,7 +634,7 @@ def delete_deployment(name, namespace='default', **kwargs):
         salt '*' kubernetes.delete_deployment my-nginx
         salt '*' kubernetes.delete_deployment name=my-nginx namespace=default
     '''
-    _setup_conn(**kwargs)
+    cfg = _setup_conn(**kwargs)
     body = kubernetes.client.V1DeleteOptions(orphan_dependents=True)
 
     try:
@@ -740,7 +677,7 @@ def delete_deployment(name, namespace='default', **kwargs):
             )
             raise CommandExecutionError(exc)
     finally:
-        _cleanup()
+        _cleanup(**cfg)
 
 
 def delete_service(name, namespace='default', **kwargs):
@@ -752,7 +689,7 @@ def delete_service(name, namespace='default', **kwargs):
         salt '*' kubernetes.delete_service my-nginx default
         salt '*' kubernetes.delete_service name=my-nginx namespace=default
     '''
-    _setup_conn(**kwargs)
+    cfg = _setup_conn(**kwargs)
 
     try:
         api_instance = kubernetes.client.CoreV1Api()
@@ -770,7 +707,7 @@ def delete_service(name, namespace='default', **kwargs):
             )
             raise CommandExecutionError(exc)
     finally:
-        _cleanup()
+        _cleanup(**cfg)
 
 
 def delete_pod(name, namespace='default', **kwargs):
@@ -782,7 +719,7 @@ def delete_pod(name, namespace='default', **kwargs):
         salt '*' kubernetes.delete_pod guestbook-708336848-5nl8c default
         salt '*' kubernetes.delete_pod name=guestbook-708336848-5nl8c namespace=default
     '''
-    _setup_conn(**kwargs)
+    cfg = _setup_conn(**kwargs)
     body = kubernetes.client.V1DeleteOptions(orphan_dependents=True)
 
     try:
@@ -803,7 +740,7 @@ def delete_pod(name, namespace='default', **kwargs):
             )
             raise CommandExecutionError(exc)
     finally:
-        _cleanup()
+        _cleanup(**cfg)
 
 
 def delete_namespace(name, **kwargs):
@@ -815,7 +752,7 @@ def delete_namespace(name, **kwargs):
         salt '*' kubernetes.delete_namespace salt
         salt '*' kubernetes.delete_namespace name=salt
     '''
-    _setup_conn(**kwargs)
+    cfg = _setup_conn(**kwargs)
     body = kubernetes.client.V1DeleteOptions(orphan_dependents=True)
 
     try:
@@ -832,7 +769,7 @@ def delete_namespace(name, **kwargs):
             )
             raise CommandExecutionError(exc)
     finally:
-        _cleanup()
+        _cleanup(**cfg)
 
 
 def delete_secret(name, namespace='default', **kwargs):
@@ -844,7 +781,7 @@ def delete_secret(name, namespace='default', **kwargs):
         salt '*' kubernetes.delete_secret confidential default
         salt '*' kubernetes.delete_secret name=confidential namespace=default
     '''
-    _setup_conn(**kwargs)
+    cfg = _setup_conn(**kwargs)
     body = kubernetes.client.V1DeleteOptions(orphan_dependents=True)
 
     try:
@@ -864,7 +801,7 @@ def delete_secret(name, namespace='default', **kwargs):
             )
             raise CommandExecutionError(exc)
     finally:
-        _cleanup()
+        _cleanup(**cfg)
 
 
 def delete_configmap(name, namespace='default', **kwargs):
@@ -876,7 +813,7 @@ def delete_configmap(name, namespace='default', **kwargs):
         salt '*' kubernetes.delete_configmap settings default
         salt '*' kubernetes.delete_configmap name=settings namespace=default
     '''
-    _setup_conn(**kwargs)
+    cfg = _setup_conn(**kwargs)
     body = kubernetes.client.V1DeleteOptions(orphan_dependents=True)
 
     try:
@@ -897,7 +834,7 @@ def delete_configmap(name, namespace='default', **kwargs):
             )
             raise CommandExecutionError(exc)
     finally:
-        _cleanup()
+        _cleanup(**cfg)
 
 
 def create_deployment(
@@ -924,7 +861,7 @@ def create_deployment(
         template=template,
         saltenv=saltenv)
 
-    _setup_conn(**kwargs)
+    cfg = _setup_conn(**kwargs)
 
     try:
         api_instance = kubernetes.client.ExtensionsV1beta1Api()
@@ -942,7 +879,7 @@ def create_deployment(
             )
             raise CommandExecutionError(exc)
     finally:
-        _cleanup()
+        _cleanup(**cfg)
 
 
 def create_pod(
@@ -969,7 +906,7 @@ def create_pod(
         template=template,
         saltenv=saltenv)
 
-    _setup_conn(**kwargs)
+    cfg = _setup_conn(**kwargs)
 
     try:
         api_instance = kubernetes.client.CoreV1Api()
@@ -987,7 +924,7 @@ def create_pod(
             )
             raise CommandExecutionError(exc)
     finally:
-        _cleanup()
+        _cleanup(**cfg)
 
 
 def create_service(
@@ -1014,7 +951,7 @@ def create_service(
         template=template,
         saltenv=saltenv)
 
-    _setup_conn(**kwargs)
+    cfg = _setup_conn(**kwargs)
 
     try:
         api_instance = kubernetes.client.CoreV1Api()
@@ -1032,7 +969,7 @@ def create_service(
             )
             raise CommandExecutionError(exc)
     finally:
-        _cleanup()
+        _cleanup(**cfg)
 
 
 def create_secret(
@@ -1069,7 +1006,7 @@ def create_secret(
         metadata=__dict_to_object_meta(name, namespace, {}),
         data=data)
 
-    _setup_conn(**kwargs)
+    cfg = _setup_conn(**kwargs)
 
     try:
         api_instance = kubernetes.client.CoreV1Api()
@@ -1087,7 +1024,7 @@ def create_secret(
             )
             raise CommandExecutionError(exc)
     finally:
-        _cleanup()
+        _cleanup(**cfg)
 
 
 def create_configmap(
@@ -1120,7 +1057,7 @@ def create_configmap(
         metadata=__dict_to_object_meta(name, namespace, {}),
         data=data)
 
-    _setup_conn(**kwargs)
+    cfg = _setup_conn(**kwargs)
 
     try:
         api_instance = kubernetes.client.CoreV1Api()
@@ -1138,7 +1075,7 @@ def create_configmap(
             )
             raise CommandExecutionError(exc)
     finally:
-        _cleanup()
+        _cleanup(**cfg)
 
 
 def create_namespace(
@@ -1156,7 +1093,7 @@ def create_namespace(
     body = kubernetes.client.V1Namespace(metadata=meta_obj)
     body.metadata.name = name
 
-    _setup_conn(**kwargs)
+    cfg = _setup_conn(**kwargs)
 
     try:
         api_instance = kubernetes.client.CoreV1Api()
@@ -1173,7 +1110,7 @@ def create_namespace(
             )
             raise CommandExecutionError(exc)
     finally:
-        _cleanup()
+        _cleanup(**cfg)
 
 
 def replace_deployment(name,
@@ -1200,7 +1137,7 @@ def replace_deployment(name,
         template=template,
         saltenv=saltenv)
 
-    _setup_conn(**kwargs)
+    cfg = _setup_conn(**kwargs)
 
     try:
         api_instance = kubernetes.client.ExtensionsV1beta1Api()
@@ -1218,7 +1155,7 @@ def replace_deployment(name,
             )
             raise CommandExecutionError(exc)
     finally:
-        _cleanup()
+        _cleanup(**cfg)
 
 
 def replace_service(name,
@@ -1251,7 +1188,7 @@ def replace_service(name,
     body.spec.cluster_ip = old_service['spec']['cluster_ip']
     body.metadata.resource_version = old_service['metadata']['resource_version']
 
-    _setup_conn(**kwargs)
+    cfg = _setup_conn(**kwargs)
 
     try:
         api_instance = kubernetes.client.CoreV1Api()
@@ -1269,7 +1206,7 @@ def replace_service(name,
             )
             raise CommandExecutionError(exc)
     finally:
-        _cleanup()
+        _cleanup(**cfg)
 
 
 def replace_secret(name,
@@ -1306,7 +1243,7 @@ def replace_secret(name,
         metadata=__dict_to_object_meta(name, namespace, {}),
         data=data)
 
-    _setup_conn(**kwargs)
+    cfg = _setup_conn(**kwargs)
 
     try:
         api_instance = kubernetes.client.CoreV1Api()
@@ -1324,7 +1261,7 @@ def replace_secret(name,
             )
             raise CommandExecutionError(exc)
     finally:
-        _cleanup()
+        _cleanup(**cfg)
 
 
 def replace_configmap(name,
@@ -1355,7 +1292,7 @@ def replace_configmap(name,
         metadata=__dict_to_object_meta(name, namespace, {}),
         data=data)
 
-    _setup_conn(**kwargs)
+    cfg = _setup_conn(**kwargs)
 
     try:
         api_instance = kubernetes.client.CoreV1Api()
@@ -1373,7 +1310,7 @@ def replace_configmap(name,
             )
             raise CommandExecutionError(exc)
     finally:
-        _cleanup()
+        _cleanup(**cfg)
 
 
 def __create_object_body(kind,

--- a/salt/modules/kubernetes.py
+++ b/salt/modules/kubernetes.py
@@ -28,7 +28,19 @@ provided `kubeconfig` entry is preferred.
 
 .. warning::
 
-    Configuration options changed in Flourine.
+    Configuration options changed in Flourine. The following configuration options have been removed:
+
+    - kubernetes.user
+    - kubernetes.password
+    - kubernetes.api_url
+    - kubernetes.certificate-authority-data/file
+    - kubernetes.client-certificate-data/file
+    - kubernetes.client-key-data/file
+
+    Please use now:
+
+    - kubernetes.kubeconfig or kubernetes.kubeconfig-data
+    - kubernetes.context
 
 '''
 

--- a/salt/modules/kubernetes.py
+++ b/salt/modules/kubernetes.py
@@ -121,8 +121,12 @@ def _setup_conn(**kwargs):
 def _cleanup(**kwargs):
     if 'kubeconfig' in kwargs:
         kubeconfig = kwargs.get('kubeconfig')
-        if os.path.exists(kubeconfig) and os.path.basename(kubeconfig).startswith('salt-kubeconfig-'):
-            salt.utils.files.safe_rm(kubeconfig)
+        if kubeconfig and os.path.basename(kubeconfig).startswith('salt-kubeconfig-'):
+            try:
+                os.unlink(kubeconfig)
+            except (IOError, OSError) as err:
+                if err.errno != errno.ENOENT:
+                    log.exception('Removing kubeconfig failed: {0}'.format(err))
 
 
 def ping(**kwargs):

--- a/salt/modules/kubernetes.py
+++ b/salt/modules/kubernetes.py
@@ -24,6 +24,12 @@ provided `kubeconfig` entry is prefered.
     salt '*' kubernetes.nodes kubeconfig=/etc/salt/k8s/kubeconfig context=minikube
 
 .. versionadded: 2017.7.0
+.. versionchanged:: Fluorine
+
+.. warning::
+
+    Configuration options changed in Flourine.
+
 '''
 
 # Import Python Futures

--- a/tests/unit/modules/test_kubernetes.py
+++ b/tests/unit/modules/test_kubernetes.py
@@ -55,7 +55,7 @@ class KubernetesTestCase(TestCase, LoaderModuleMockMixin):
         :return:
         '''
         with mock_kubernetes_library() as mock_kubernetes_lib:
-            with patch.dict(kubernetes.__salt__, {'config.option': Mock(return_value="")}):
+            with patch.dict(kubernetes.__salt__, {'config.option': Mock(side_effect=self.settings)}):
                 mock_kubernetes_lib.client.CoreV1Api.return_value = Mock(
                     **{"list_node.return_value.to_dict.return_value":
                         {'items': [{'metadata': {'name': 'mock_node_name'}}]}}
@@ -69,7 +69,7 @@ class KubernetesTestCase(TestCase, LoaderModuleMockMixin):
         :return:
         '''
         with mock_kubernetes_library() as mock_kubernetes_lib:
-            with patch.dict(kubernetes.__salt__, {'config.option': Mock(return_value="")}):
+            with patch.dict(kubernetes.__salt__, {'config.option': Mock(side_effect=self.settings)}):
                 mock_kubernetes_lib.client.ExtensionsV1beta1Api.return_value = Mock(
                     **{"list_namespaced_deployment.return_value.to_dict.return_value":
                         {'items': [{'metadata': {'name': 'mock_deployment_name'}}]}}
@@ -84,7 +84,7 @@ class KubernetesTestCase(TestCase, LoaderModuleMockMixin):
         :return:
         '''
         with mock_kubernetes_library() as mock_kubernetes_lib:
-            with patch.dict(kubernetes.__salt__, {'config.option': Mock(return_value="")}):
+            with patch.dict(kubernetes.__salt__, {'config.option': Mock(side_effect=self.settings)}):
                 mock_kubernetes_lib.client.CoreV1Api.return_value = Mock(
                     **{"list_namespaced_service.return_value.to_dict.return_value":
                         {'items': [{'metadata': {'name': 'mock_service_name'}}]}}
@@ -98,7 +98,7 @@ class KubernetesTestCase(TestCase, LoaderModuleMockMixin):
         :return:
         '''
         with mock_kubernetes_library() as mock_kubernetes_lib:
-            with patch.dict(kubernetes.__salt__, {'config.option': Mock(return_value="")}):
+            with patch.dict(kubernetes.__salt__, {'config.option': Mock(side_effect=self.settings)}):
                 mock_kubernetes_lib.client.CoreV1Api.return_value = Mock(
                     **{"list_namespaced_pod.return_value.to_dict.return_value":
                         {'items': [{'metadata': {'name': 'mock_pod_name'}}]}}
@@ -114,7 +114,7 @@ class KubernetesTestCase(TestCase, LoaderModuleMockMixin):
         '''
         with mock_kubernetes_library() as mock_kubernetes_lib:
             with patch('salt.modules.kubernetes.show_deployment', Mock(return_value=None)):
-                with patch.dict(kubernetes.__salt__, {'config.option': Mock(return_value="")}):
+                with patch.dict(kubernetes.__salt__, {'config.option': Mock(side_effect=self.settings)}):
                     mock_kubernetes_lib.client.V1DeleteOptions = Mock(return_value="")
                     mock_kubernetes_lib.client.ExtensionsV1beta1Api.return_value = Mock(
                         **{"delete_namespaced_deployment.return_value.to_dict.return_value": {'code': ''}}
@@ -130,7 +130,7 @@ class KubernetesTestCase(TestCase, LoaderModuleMockMixin):
         :return:
         '''
         with mock_kubernetes_library() as mock_kubernetes_lib:
-            with patch.dict(kubernetes.__salt__, {'config.option': Mock(return_value="")}):
+            with patch.dict(kubernetes.__salt__, {'config.option': Mock(side_effect=self.settings)}):
                 mock_kubernetes_lib.client.ExtensionsV1beta1Api.return_value = Mock(
                     **{"create_namespaced_deployment.return_value.to_dict.return_value": {}}
                 )

--- a/tests/unit/modules/test_kubernetes.py
+++ b/tests/unit/modules/test_kubernetes.py
@@ -140,18 +140,24 @@ class KubernetesTestCase(TestCase, LoaderModuleMockMixin):
                     kubernetes.kubernetes.client.ExtensionsV1beta1Api().
                     create_namespaced_deployment().to_dict.called)
 
+    @staticmethod
+    def settings(name, value=None):
+        '''
+        Test helper
+        :return: settings or default
+        '''
+        data = {
+            'kubernetes.kubeconfig': '/home/testuser/.minikube/kubeconfig.cfg',
+            'kubernetes.context': 'minikube'
+        }
+        return data.get(name, value)
+
+
     def test_setup_kubeconfig_file(self):
         '''
         Test that the `kubernetes.kubeconfig` configuration isn't overwritten
         :return:
         '''
-        def settings(name, value=None):
-            data = {
-                'kubernetes.kubeconfig': '/home/testuser/.minikube/kubeconfig.cfg',
-                'kubernetes.context': 'minikube'
-            }
-            return data.get(name, value)
-
         with mock_kubernetes_library() as mock_kubernetes_lib:
             with patch.dict(kubernetes.__salt__, {'config.option': Mock(side_effect=settings)}):
                 mock_kubernetes_lib.config.load_kube_config = Mock()
@@ -167,13 +173,6 @@ class KubernetesTestCase(TestCase, LoaderModuleMockMixin):
         by provided kubeconfig_data in the command
         :return:
         '''
-        def settings(name, value=None):
-            data = {
-                'kubernetes.kubeconfig': '/home/testuser/.minikube/kubeconfig.cfg',
-                'kubernetes.context': 'minikube'
-            }
-            return data.get(name, value)
-
         with mock_kubernetes_library() as mock_kubernetes_lib:
             with patch.dict(kubernetes.__salt__, {'config.option': Mock(side_effect=settings)}):
                 mock_kubernetes_lib.config.load_kube_config = Mock()

--- a/tests/unit/modules/test_kubernetes.py
+++ b/tests/unit/modules/test_kubernetes.py
@@ -152,18 +152,17 @@ class KubernetesTestCase(TestCase, LoaderModuleMockMixin):
         }
         return data.get(name, value)
 
-
     def test_setup_kubeconfig_file(self):
         '''
         Test that the `kubernetes.kubeconfig` configuration isn't overwritten
         :return:
         '''
         with mock_kubernetes_library() as mock_kubernetes_lib:
-            with patch.dict(kubernetes.__salt__, {'config.option': Mock(side_effect=settings)}):
+            with patch.dict(kubernetes.__salt__, {'config.option': Mock(side_effect=self.settings)}):
                 mock_kubernetes_lib.config.load_kube_config = Mock()
                 config = kubernetes._setup_conn()
                 self.assertEqual(
-                    settings('kubernetes.kubeconfig'),
+                    self.settings('kubernetes.kubeconfig'),
                     config['kubeconfig'],
                 )
 
@@ -174,7 +173,7 @@ class KubernetesTestCase(TestCase, LoaderModuleMockMixin):
         :return:
         '''
         with mock_kubernetes_library() as mock_kubernetes_lib:
-            with patch.dict(kubernetes.__salt__, {'config.option': Mock(side_effect=settings)}):
+            with patch.dict(kubernetes.__salt__, {'config.option': Mock(side_effect=self.settings)}):
                 mock_kubernetes_lib.config.load_kube_config = Mock()
                 config = kubernetes._setup_conn(kubeconfig_data='MTIzNDU2Nzg5MAo=', context='newcontext')
                 self.assertTrue(config['kubeconfig'].startswith('/tmp/salt-kubeconfig-'))


### PR DESCRIPTION
### What does this PR do?

Newer versions of python-kubernetes (>2.0) has changed a lot in the way they want to have the configuration parameters. Also new types of authentication were added and more will come in near future.
All this make the current way to provide authentication data a bit useless.

The only future-proof way seems to be to provide the full `kubeconfig` file and let the python library
do the rest.

### What issues does this PR fix or reference?
Mainly it support new python-kubernetes library as requested in https://github.com/saltstack/salt/issues/44701 .

Configuring via kubeconfig was requested in https://github.com/saltstack/salt/issues/43514 .

Last but not least this PR make it also possible to provide the full kubeconfig as data to overwrite configured kubeconfig like requested in https://github.com/saltstack/salt/issues/46086 .

### Previous Behavior

Configuring the cluster access and authentication was possible via single values:

- kubernetes.user
- kubernetes.password
- kubernetes.api_url
- kubernetes.certificate-authority-data/file
- kubernetes.client-certificate-data/file
- kubernetes.client-key-data/file

### New Behavior

This will be replaced by just configure via `kubeconfig` and `context`

- kubernetes.kubeconfig
- kubernetes.context

### Tests written?

Yes (adapted the existing)

### Commits signed with GPG?

No

### Related PR

2017.7 - add warning about config option change : https://github.com/saltstack/salt/pull/46320
