### PR TITLE
[develop] display usage for runners when missing arguments

### DIFF
--- a/salt/client/mixins.py
+++ b/salt/client/mixins.py
@@ -384,7 +384,11 @@ class SyncClientMixin(object):
 
             # Initialize a context for executing the method.
             with tornado.stack_context.StackContext(self.functions.context_dict.clone):
-                data['return'] = self.functions[fun](*args, **kwargs)
+                func = self.functions[fun]
+                try:
+                    data['return'] = func(*args, **kwargs)
+                except TypeError as exc:
+                    data['return'] = '\nPassed invalid arguments: {0}\n\nUsage:\n{1}'.format(exc, func.__doc__)
                 try:
                     data['success'] = self.context.get('retcode', 0) == 0
                 except AttributeError:

--- a/tests/integration/runners/test_cache.py
+++ b/tests/integration/runners/test_cache.py
@@ -34,3 +34,15 @@ class ManageTest(ShellCase):
         ret = self.run_run_plus('cache.flush', bank='cachetest/runner', key='test_cache')
         ret = self.run_run_plus('cache.list', bank='cachetest/runner')
         self.assertNotIn('test_cache', ret['return'])
+
+    def test_cache_invalid(self):
+        '''
+        Store, list, fetch, then flush data
+        '''
+        # Store the data
+        ret = self.run_run_plus(
+            'cache.store',
+        )
+        # Make sure we can see the new key
+        expected = 'Passed invalid arguments:'
+        self.assertIn(expected, ret['return'])

--- a/tests/integration/runners/test_jobs.py
+++ b/tests/integration/runners/test_jobs.py
@@ -9,6 +9,7 @@ from __future__ import absolute_import, print_function, unicode_literals
 from tests.support.case import ShellCase
 from tests.support.unit import skipIf
 
+
 class ManageTest(ShellCase):
     '''
     Test the manage runner
@@ -35,7 +36,7 @@ class ManageTest(ShellCase):
         '''
         ret = self.run_run_plus('jobs.lookup_jid')
         expected = 'Passed invalid arguments:'
-        self.self.assertIn(expected, ret['return'])
+        self.assertIn(expected, ret['return'])
 
     @skipIf(True, 'to be re-enabled when #23623 is merged')
     def test_list_jobs(self):

--- a/tests/integration/runners/test_jobs.py
+++ b/tests/integration/runners/test_jobs.py
@@ -9,7 +9,6 @@ from __future__ import absolute_import, print_function, unicode_literals
 from tests.support.case import ShellCase
 from tests.support.unit import skipIf
 
-
 class ManageTest(ShellCase):
     '''
     Test the manage runner
@@ -29,6 +28,14 @@ class ManageTest(ShellCase):
         ret = self.run_run_plus('jobs.lookup_jid', '23974239742394')
         self.assertEqual(ret['return'], {})
         self.assertEqual(ret['out'], [])
+
+    def test_lookup_jid_invalid(self):
+        '''
+        jobs.lookup_jid
+        '''
+        ret = self.run_run_plus('jobs.lookup_jid')
+        expected = 'Passed invalid arguments:'
+        self.self.assertIn(expected, ret['return'])
 
     @skipIf(True, 'to be re-enabled when #23623 is merged')
     def test_list_jobs(self):

--- a/tests/integration/runners/test_salt.py
+++ b/tests/integration/runners/test_salt.py
@@ -25,3 +25,11 @@ class SaltRunnerTest(ShellCase):
 
         self.assertEqual(out_ret, 'True')
         self.assertTrue(return_ret)
+
+    def test_salt_cmd_invalid(self):
+        '''
+        test return values of salt.cmd invalid parameters
+        '''
+        ret = self.run_run_plus('salt.cmd')
+        expected = 'Passed invalid arguments:'
+        self.assertIn(expected, ret['return'])


### PR DESCRIPTION
### What does this PR do?
Catch TypeError when not all required arguments are passed to a runner.  Display error and usage.

### What issues does this PR fix or reference?
#45325

### Previous Behavior
An traceback would occur if the wrong number of required arguments was passed to a Salt runner.

### New Behavior
This change catches the exception, displays the error then includes the usage documentation for the Salt runner.

### Tests written?
Yes

### Commits signed with GPG?

Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
