### PR TITLE
2018.3.0rc1 Properly dump and load datetime objects with msgpack

### DIFF
--- a/tests/unit/test_payload.py
+++ b/tests/unit/test_payload.py
@@ -7,18 +7,19 @@
     ~~~~~~~~~~~~~~~~~~~~~~~
 '''
 
-# Import Salt libs
+# Import python libs
 from __future__ import absolute_import, print_function, unicode_literals
 import time
 import errno
 import threading
+import datetime
 
 # Import Salt Testing libs
 from tests.support.unit import skipIf, TestCase
 from tests.support.helpers import MockWraps
 from tests.support.mock import NO_MOCK, NO_MOCK_REASON, patch
 
-# Import salt libs
+# Import Salt libs
 import salt.payload
 from salt.utils.odict import OrderedDict
 import salt.exceptions
@@ -58,6 +59,20 @@ class PayloadTestCase(TestCase):
             odata = payload.loads(payload.dumps(idata.copy()))
             self.assertNoOrderedDict(odata)
             self.assertEqual(idata, odata)
+
+    def test_datetime_dump_load(self):
+        '''
+        Check the custom datetime handler can understand itself
+        '''
+        payload = salt.payload.Serial('msgpack')
+        idata = {datetime.datetime.now(): datetime.datetime.now(),
+                 'int': 1,
+                 'str': 'abc',
+                 'list': [1, 2, 3],
+                 'dict': {'key': 'value'}}
+        sdata = payload.dumps(idata.copy())
+        odata = payload.loads(sdata)
+        self.assertEqual(idata, odata)
 
 
 class SREQTestCase(TestCase):


### PR DESCRIPTION
### What does this PR do?
Properly dump and load datetime objects with msgpack.

There are two problems with `payload.Serial` and `datetime`:
1. datetime object is serialized twice: as a custom object to bytestring and then as a bytestring. This is fixed in `dumps` part.
2. no custom hooks used in `loads` at all. This is fixed in `loads` part.

There still a problem with other custom hooks that are workarounds for different types not supported by msgpack by default but all that workarounds work alone so current code can't serialize a dict containing two different exceptions.
I plan to rework it in the next PR.

### What issues does this PR fix or reference?
Fix #46202

### Previous Behavior
After `schedule` is evaluated and persisted once the datetime objects go to `minion.d/_schedule.conf` and breaks master and minion because both can't compile their configuration after it.

### Tests written?
Yes

### Commits signed with GPG?
Yes