### PR TITLE
Don't install msgpack 0.5.5

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 Jinja2
-msgpack-python>0.3
+msgpack-python>0.3,!=0.5.5
 PyYAML
 MarkupSafe
 requests>=1.0.0


### PR DESCRIPTION
This version has known critical issues.

See https://github.com/msgpack/msgpack-python/commit/da902f9c1d996fb461f1efef6487ef40d32d365a#r27725642 for more information.
