### PR TITLE
Normalize global git_pillar/winrepo config items

### DIFF
--- a/doc/ref/configuration/master.rst
+++ b/doc/ref/configuration/master.rst
@@ -4852,11 +4852,10 @@ branch/tag.
 
     winrepo_branch: winrepo
 
-    ext_pillar:
-      - git:
-        - https://mygitserver/winrepo1.git
-        - https://mygitserver/winrepo2.git:
-        - foo https://mygitserver/winrepo3.git
+    winrepo_remotes:
+      - https://mygitserver/winrepo1.git
+      - https://mygitserver/winrepo2.git:
+      - foo https://mygitserver/winrepo3.git
 
 .. conf_master:: winrepo_ssl_verify
 

--- a/salt/daemons/masterapi.py
+++ b/salt/daemons/masterapi.py
@@ -94,8 +94,8 @@ def init_git_pillar(opts):
                     pillar.init_remotes(
                         opts_dict['git'],
                         git_pillar.PER_REMOTE_OVERRIDES,
-                        git_pillar.PER_REMOTE_ONLY
-                    )
+                        git_pillar.PER_REMOTE_ONLY,
+                        git_pillar.GLOBAL_ONLY)
                     ret.append(pillar)
                 except FileserverConfigError:
                     if opts.get('git_pillar_verify_config', True):

--- a/salt/master.py
+++ b/salt/master.py
@@ -504,7 +504,8 @@ class Master(SMaster):
                             git_pillar.init_remotes(
                                 repo['git'],
                                 salt.pillar.git_pillar.PER_REMOTE_OVERRIDES,
-                                salt.pillar.git_pillar.PER_REMOTE_ONLY)
+                                salt.pillar.git_pillar.PER_REMOTE_ONLY,
+                                salt.pillar.git_pillar.GLOBAL_ONLY)
                         except FileserverConfigError as exc:
                             critical_errors.append(exc.strerror)
                 finally:

--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -792,7 +792,8 @@ class Pillar(object):
                 git_pillar.init_remotes(
                     self.ext['git'],
                     salt.pillar.git_pillar.PER_REMOTE_OVERRIDES,
-                    salt.pillar.git_pillar.PER_REMOTE_ONLY)
+                    salt.pillar.git_pillar.PER_REMOTE_ONLY,
+                    salt.pillar.git_pillar.GLOBAL_ONLY)
                 git_pillar.fetch_remotes()
         except TypeError:
             # Handle malformed ext_pillar

--- a/salt/pillar/git_pillar.py
+++ b/salt/pillar/git_pillar.py
@@ -491,6 +491,7 @@ except ImportError:
 
 PER_REMOTE_OVERRIDES = ('env', 'root', 'ssl_verify', 'refspecs')
 PER_REMOTE_ONLY = ('name', 'mountpoint')
+GLOBAL_ONLY = ('base', 'branch')
 
 # Fall back to default per-remote-only. This isn't technically needed since
 # salt.utils.gitfs.GitBase.init_remotes() will default to
@@ -550,7 +551,11 @@ def ext_pillar(minion_id, repo, pillar_dirs):
         opts['pillar_roots'] = {}
         opts['__git_pillar'] = True
         pillar = salt.utils.gitfs.GitPillar(opts)
-        pillar.init_remotes(repo, PER_REMOTE_OVERRIDES, PER_REMOTE_ONLY)
+        pillar.init_remotes(
+            repo,
+            PER_REMOTE_OVERRIDES,
+            PER_REMOTE_ONLY,
+            GLOBAL_ONLY)
         if __opts__.get('__role') == 'minion':
             # If masterless, fetch the remotes. We'll need to remove this once
             # we make the minion daemon able to run standalone.

--- a/salt/runners/cache.py
+++ b/salt/runners/cache.py
@@ -342,7 +342,8 @@ def clear_git_lock(role, remote=None, **kwargs):
                 obj.init_remotes(
                     ext_pillar['git'],
                     salt.pillar.git_pillar.PER_REMOTE_OVERRIDES,
-                    salt.pillar.git_pillar.PER_REMOTE_ONLY)
+                    salt.pillar.git_pillar.PER_REMOTE_ONLY,
+                    salt.pillar.git_pillar.GLOBAL_ONLY)
                 git_objects.append(obj)
     elif role == 'winrepo':
         winrepo_dir = __opts__['winrepo_dir']
@@ -357,7 +358,8 @@ def clear_git_lock(role, remote=None, **kwargs):
             obj.init_remotes(
                 remotes,
                 salt.runners.winrepo.PER_REMOTE_OVERRIDES,
-                salt.runners.winrepo.PER_REMOTE_ONLY)
+                salt.runners.winrepo.PER_REMOTE_ONLY,
+                salt.runners.winrepo.GLOBAL_ONLY)
             git_objects.append(obj)
     else:
         raise SaltInvocationError('Invalid role \'{0}\''.format(role))

--- a/salt/runners/git_pillar.py
+++ b/salt/runners/git_pillar.py
@@ -87,7 +87,8 @@ def update(branch=None, repo=None):
             pillar = salt.utils.gitfs.GitPillar(__opts__)
             pillar.init_remotes(pillar_conf,
                                 salt.pillar.git_pillar.PER_REMOTE_OVERRIDES,
-                                salt.pillar.git_pillar.PER_REMOTE_ONLY)
+                                salt.pillar.git_pillar.PER_REMOTE_ONLY,
+                                salt.pillar.git_pillar.GLOBAL_ONLY)
             for remote in pillar.remotes:
                 # Skip this remote if it doesn't match the search criteria
                 if branch is not None:

--- a/salt/runners/winrepo.py
+++ b/salt/runners/winrepo.py
@@ -36,6 +36,7 @@ PER_REMOTE_OVERRIDES = ('ssl_verify', 'refspecs')
 # salt.utils.gitfs.PER_REMOTE_ONLY for this value, so this is mainly for
 # runners and other modules that import salt.runners.winrepo.
 PER_REMOTE_ONLY = salt.utils.gitfs.PER_REMOTE_ONLY
+GLOBAL_ONLY = ('branch',)
 
 
 def genrepo(opts=None, fire_event=True):
@@ -218,7 +219,10 @@ def update_git_repos(opts=None, clean=False, masterless=False):
             try:
                 winrepo = salt.utils.gitfs.WinRepo(opts, base_dir)
                 winrepo.init_remotes(
-                    remotes, PER_REMOTE_OVERRIDES, PER_REMOTE_ONLY)
+                    remotes,
+                    PER_REMOTE_OVERRIDES,
+                    PER_REMOTE_ONLY,
+                    GLOBAL_ONLY)
                 winrepo.fetch_remotes()
                 # Since we're not running update(), we need to manually call
                 # clear_old_remotes() to remove directories from remotes that


### PR DESCRIPTION
We were only normalizing the global version of a config parameter if it had a per-remote counterpart. This was all well and good for gitfs, which doesn't have any config values that are global-only, but git_pillar and winrepo have config params which are global-only, and they were therefore not being normalized.

This fixes that oversight, and also makes a few other changes in salt.utils.gitfs to ensure that we're not pulling from the un-normalized values from the opts dict, when we need to fall back to global defaults.

Additionally, it fixes an issue in which the `git_pillar_branch` config item was overriding the branch set in a git_pillar remote.

Fixes #46258.
Fixes #46259.

Verification of the fixes below (all Docker commands run from root of git checkout, see [here](https://help.github.com/articles/checking-out-pull-requests-locally/) for info on checking out this PR locally to confirm the fix).

```
% docker run --rm -it -v $PWD:/testing terminalmage/issues:46258 salt-call pillar.get foo
local:
    2017.7
% docker run --rm -it -v $PWD:/testing terminalmage/issues:46259 salt-call pillar.get foo
local:
    2017.7
```

Repo can be found here: https://github.com/terminalmage/git_pillar/tree/2017.7