### PR TITLE
sysctl.set can still not set unicode sysctl keys

### DIFF
--- a/salt/modules/linux_sysctl.py
+++ b/salt/modules/linux_sysctl.py
@@ -132,7 +132,7 @@ def assign(name, value):
             trans_args = ({
                 ord('/'): '.',
                 ord('.'): '/'
-            })
+            },)
         else:
             trans_args = string.maketrans('./', '/.')
         tran_tab = name.translate(*trans_args)

--- a/salt/modules/linux_sysctl.py
+++ b/salt/modules/linux_sysctl.py
@@ -129,7 +129,10 @@ def assign(name, value):
         tran_tab = name.translate(''.maketrans('./', '/.'))
     else:
         if isinstance(name, unicode):  # pylint: disable=incompatible-py3-code
-            trans_args = ({ord(x): None for x in ''.join(['./', '/.'])},)
+            trans_args = ({
+                ord('/'): '.',
+                ord('.'): '/'
+            })
         else:
             trans_args = string.maketrans('./', '/.')
         tran_tab = name.translate(*trans_args)


### PR DESCRIPTION
### What does this PR do?
```
[WARNING ] LOOKING FOR vmswappiness
[ERROR   ] Failed to set vm.swappiness to 5: sysctl vm.swappiness does not exist
[INFO    ] Completed state [vm.swappiness] at time 20:32:37.719748 (duration_in_ms=18.762)
```

The function sysctl.set does: 
```py
trans_args = ({ord(x): None for x in ''.join(['./', '/.'])},)
# as opposed to
trans_args = string.maketrans('./', '/.')
```

for e.g. `vm.swappiness`, one delivers `vmswappiness` and the other `vm/swappiness`.

### What issues does this PR fix or reference?
* #19838 (the maketrans is necessary to replace the sysctl *value* `net.ipv6.conf.enp1s0/20.mtu` to the *path* `/proc/sys/net/ipv6/conf/enp1s0.20/mtu`)
* #45574

### Version
```
Salt Version:                                       
           Salt: 2018.3.0-296-g1d2dc49              
                                                    
Dependency Versions:                                
           cffi: 1.10.0                             
       cherrypy: Not Installed                      
       dateutil: 2.6.0                              
      docker-py: 3.0.1                              
          gitdb: Not Installed                      
      gitpython: Not Installed                      
          ioflo: Not Installed                      
         Jinja2: 2.9.6                              
        libgit2: 0.26.0                             
        libnacl: Not Installed                      
       M2Crypto: 0.25.1                             
           Mako: Not Installed                      
   msgpack-pure: Not Installed                      
 msgpack-python: 0.5.1                              
   mysql-python: Not Installed                      
      pycparser: 2.14                               
       pycrypto: 2.6.1                              
   pycryptodome: Not Installed                      
         pygit2: 0.26.3                             
         Python: 2.7.14 (default, Feb 17 2018, 10:42:17)                                                 
   python-gnupg: Not Installed                      
         PyYAML: 3.12                               
          PyZMQ: 16.0.2                             
           RAET: Not Installed                      
          smmap: Not Installed                      
        timelib: Not Installed                      
        Tornado: 4.5.2                              
            ZMQ: 4.1.6                              
                                                    
System Versions:                                    
           dist: fedora 27 Twenty Seven             
         locale: UTF-8                              
        machine: x86_64                             
        release: 4.15.4-300.fc27.x86_64             
         system: Linux                              
        version: Fedora 27 Twenty Seven             
```