### PR TITLE
Fix incorrect merge conflict resolution

### DIFF
--- a/salt/pillar/git_pillar.py
+++ b/salt/pillar/git_pillar.py
@@ -492,12 +492,6 @@ except ImportError:
 PER_REMOTE_OVERRIDES = ('env', 'root', 'ssl_verify', 'refspecs')
 PER_REMOTE_ONLY = ('name', 'mountpoint')
 
-# Fall back to default per-remote-only. This isn't technically needed since
-# salt.utils.gitfs.GitBase.init_remotes() will default to
-# salt.utils.gitfs.PER_REMOTE_ONLY for this value, so this is mainly for
-# runners and other modules that import salt.pillar.git_pillar.
-PER_REMOTE_ONLY = salt.utils.gitfs.PER_REMOTE_ONLY
-
 # Set up logging
 log = logging.getLogger(__name__)
 


### PR DESCRIPTION
This was fixed in develop (at the time, now 2018.3), but it doesn't look
like this was fixed in 2017.7.

Fixes #46128.