### PR TITLE
Add username/password to profitbricks conf for cloud tests

### DIFF
--- a/tests/integration/files/conf/cloud.providers.d/profitbricks.conf
+++ b/tests/integration/files/conf/cloud.providers.d/profitbricks.conf
@@ -1,6 +1,6 @@
 profitbricks-config:
-  username: ''
-  password: ''
+  username: 'foo'
+  password: 'bar'
   datacenter_id: 74d65326-d9b7-41c3-9f51-73ffe0fcd16d
   driver: profitbricks
   ssh_public_key: ~/.ssh/id_rsa.pub


### PR DESCRIPTION
### What does this PR do?
Adds username/password to profitbricks file. Since these are empty when a `profitbricks.list_nodes()` is called on creationg or deletion of a VM, we are seeing this in our cluod tests:

```
AssertionError: 'CLOUD-TEST-IBQL4P:' not found in ['Please enter your username: CLOUD-TEST-IBQL4P:'
```

The reason for this is shown here: https://github.com/profitbricks/profitbricks-sdk-python/blob/master/profitbricks/client.py#L133

As we are not supplying a username it query's for the username in the profitbricks python module.