### PR TITLE
Remove dup start events

### DIFF
--- a/conf/minion
+++ b/conf/minion
@@ -389,6 +389,16 @@
 # minion event bus. The value is expressed in bytes.
 #max_event_size: 1048576
 
+# When a minion starts up it sends a notification on the event bus with a tag
+# that looks like this: `salt/minion/<minion_id>/start`. For historical reasons
+# the minion also sends a similar event with an event tag like this:
+# `minion_start`. This duplication can cause a lot of clutter on the event bus
+# when there are many minions. Set `enable_legacy_startup_events: False` in the
+# minion config to ensure only the `salt/minion/<minion_id>/start` events are
+# sent. Beginning with the `Neon` Salt release this option will default to
+# `False`
+#enable_legacy_startup_events: True
+
 # To detect failed master(s) and fire events on connect/disconnect, set
 # master_alive_interval to the number of seconds to poll the masters for
 # connection events.

--- a/doc/ref/configuration/minion.rst
+++ b/doc/ref/configuration/minion.rst
@@ -208,6 +208,28 @@ minion event bus. The value is expressed in bytes.
 
     max_event_size: 1048576
 
+.. conf_minion:: enable_legacy_startup_events
+
+``enable_legacy_startup_events``
+--------------------------------
+
+.. versionadded:: Fluorine
+
+Default: ``True``
+
+When a minion starts up it sends a notification on the event bus with a tag
+that looks like this: `salt/minion/<minion_id>/start`. For historical reasons
+the minion also sends a similar event with an event tag like this:
+`minion_start`. This duplication can cause a lot of clutter on the event bus
+when there are many minions. Set `enable_legacy_startup_events: False` in the
+minion config to ensure only the `salt/minion/<minion_id>/start` events are
+sent. Beginning with the `Neon` Salt release this option will default to
+`False`
+
+.. code-block:: yaml
+
+    enable_legacy_startup_events: True
+
 .. conf_minion:: master_failback
 
 ``master_failback``

--- a/doc/topics/reactor/index.rst
+++ b/doc/topics/reactor/index.rst
@@ -706,8 +706,8 @@ Salt will sync all custom types (by running a :mod:`saltutil.sync_all
 <running-highstate>`. However, there is a chicken-and-egg issue where, on the
 initial :ref:`highstate <running-highstate>`, a minion will not yet have these
 custom types synced when the top file is first compiled. This can be worked
-around with a simple reactor which watches for ``minion_start`` events, which
-each minion fires when it first starts up and connects to the master.
+around with a simple reactor which watches for ``salt/minion/*/start`` events,
+which each minion fires when it first starts up and connects to the master.
 
 On the master, create **/srv/reactor/sync_grains.sls** with the following
 contents:

--- a/doc/topics/releases/fluorine.rst
+++ b/doc/topics/releases/fluorine.rst
@@ -3,3 +3,22 @@
 ======================================
 Salt Release Notes - Codename Fluorine
 ======================================
+
+
+Minion Startup Events
+---------------------
+
+When a minion starts up it sends a notification on the event bus with a tag
+that looks like this: `salt/minion/<minion_id>/start`. For historical reasons
+the minion also sends a similar event with an event tag like this:
+`minion_start`. This duplication can cause a lot of clutter on the event bus
+when there are many minions. Set `enable_legacy_startup_events: False` in the
+minion config to ensure only the `salt/minion/<minion_id>/start` events are
+sent.
+
+The new :conf_minion:`enable_legacy_startup_events` minion config option
+defaults to ``True``, but will be set to default to ``False`` beginning with
+the Neon release of Salt.
+
+The Salt Syndic currently sends an old style  `sydic_start` event as well. The
+syndic respects :conf_minion:`enable_legacy_startup_events` as well.

--- a/doc/topics/releases/fluorine.rst
+++ b/doc/topics/releases/fluorine.rst
@@ -20,5 +20,5 @@ The new :conf_minion:`enable_legacy_startup_events` minion config option
 defaults to ``True``, but will be set to default to ``False`` beginning with
 the Neon release of Salt.
 
-The Salt Syndic currently sends an old style  `sydic_start` event as well. The
+The Salt Syndic currently sends an old style  `syndic_start` event as well. The
 syndic respects :conf_minion:`enable_legacy_startup_events` as well.

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -433,6 +433,9 @@ VALID_OPTS = {
     # If an event is above this size, it will be trimmed before putting it on the event bus
     'max_event_size': int,
 
+    # Enable old style events to be sent on minion_startup. Change default to False in Neon release
+    'enable_legacy_startup_events': bool,
+
     # Always execute states with test=True if this flag is set
     'test': bool,
 
@@ -1360,6 +1363,7 @@ DEFAULT_MINION_OPTS = {
     'log_rotate_max_bytes': 0,
     'log_rotate_backup_count': 0,
     'max_event_size': 1048576,
+    'enable_legacy_startup_events': True,
     'test': False,
     'ext_job_cache': '',
     'cython_enable': False,

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -2054,14 +2054,16 @@ class Minion(MinionBase):
 
     def _fire_master_minion_start(self):
         # Send an event to the master that the minion is live
-        self._fire_master(
-            'Minion {0} started at {1}'.format(
-            self.opts['id'],
-            time.asctime()
-            ),
-            'minion_start'
-        )
-        # dup name spaced event
+        if self.opts['enable_legacy_startup_events']:
+            # old style event. Defaults to False in Neon Salt release
+            self._fire_master(
+                'Minion {0} started at {1}'.format(
+                self.opts['id'],
+                time.asctime()
+                ),
+                'minion_start'
+            )
+        # send name spaced event
         self._fire_master(
             'Minion {0} started at {1}'.format(
             self.opts['id'],
@@ -2756,14 +2758,16 @@ class Syndic(Minion):
 
     def fire_master_syndic_start(self):
         # Send an event to the master that the minion is live
-        self._fire_master(
-            'Syndic {0} started at {1}'.format(
-                self.opts['id'],
-                time.asctime()
-            ),
-            'syndic_start',
-            sync=False,
-        )
+        if self.opts['enable_legacy_startup_events']:
+            # old style event. Defaults to false in Neon Salt release.
+            self._fire_master(
+                'Syndic {0} started at {1}'.format(
+                    self.opts['id'],
+                    time.asctime()
+                ),
+                'syndic_start',
+                sync=False,
+            )
         self._fire_master(
             'Syndic {0} started at {1}'.format(
                 self.opts['id'],

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -2059,6 +2059,14 @@ class Minion(MinionBase):
             self.opts['id'],
             time.asctime()
             ),
+            'minion_start'
+        )
+        # dup name spaced event
+        self._fire_master(
+            'Minion {0} started at {1}'.format(
+            self.opts['id'],
+            time.asctime()
+            ),
             tagify([self.opts['id'], 'start'], 'minion'),
         )
 
@@ -2748,6 +2756,14 @@ class Syndic(Minion):
 
     def fire_master_syndic_start(self):
         # Send an event to the master that the minion is live
+        self._fire_master(
+            'Syndic {0} started at {1}'.format(
+                self.opts['id'],
+                time.asctime()
+            ),
+            'syndic_start',
+            sync=False,
+        )
         self._fire_master(
             'Syndic {0} started at {1}'.format(
                 self.opts['id'],

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -2059,14 +2059,6 @@ class Minion(MinionBase):
             self.opts['id'],
             time.asctime()
             ),
-            'minion_start'
-        )
-        # dup name spaced event
-        self._fire_master(
-            'Minion {0} started at {1}'.format(
-            self.opts['id'],
-            time.asctime()
-            ),
             tagify([self.opts['id'], 'start'], 'minion'),
         )
 
@@ -2756,14 +2748,6 @@ class Syndic(Minion):
 
     def fire_master_syndic_start(self):
         # Send an event to the master that the minion is live
-        self._fire_master(
-            'Syndic {0} started at {1}'.format(
-                self.opts['id'],
-                time.asctime()
-            ),
-            'syndic_start',
-            sync=False,
-        )
         self._fire_master(
             'Syndic {0} started at {1}'.format(
                 self.opts['id'],

--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -2263,7 +2263,7 @@ def check_auth(name, sock_dir=None, queue=None, timeout=300):
         ret = event.get_event(full=True)
         if ret is None:
             continue
-        if ret['tag'] == 'minion_start' and ret['data']['id'] == name:
+        if ret['tag'] == 'salt/minion/{0}/start'.format(name):
             queue.put(name)
             newtimeout = 0
             log.debug('Minion %s is ready to receive commands', name)


### PR DESCRIPTION
### What does this PR do?
Remove duplicate `minion_start` and `syndic_start` events.

### What issues does this PR fix or reference?
None

### Previous Behavior
When the minion started 2 events with the following event tags were sent up the event bus:

`minion_start`
`salt/minion/<minion id>/start`

The same behavior happened for the salt syndic daemon.

### New Behavior
Only `salt/minion/<minion id>/start` event is sent on minion startup.

The same behavior now happens for the salt syndic daemon.

### Tests written?

No, but I verified that current tests were only testing the new style event tags.
The old style event tags were untested. This PR removes a bit of untested code.

### Commits signed with GPG?

Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
