### PR TITLE
Make sure rest_cherrypy's config is all str types on PY2

### DIFF
--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -3577,7 +3577,7 @@ def get_id(opts, cache_minion_id=False):
     if opts.get('minion_id_caching', True):
         try:
             with salt.utils.files.fopen(id_cache) as idf:
-                name = idf.readline().strip()
+                name = salt.utils.stringutils.to_unicode(idf.readline().strip())
                 bname = salt.utils.stringutils.to_bytes(name)
                 if bname.startswith(codecs.BOM):  # Remove BOM if exists
                     name = salt.utils.stringutils.to_str(bname.replace(codecs.BOM, '', 1))

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -2218,7 +2218,6 @@ def include_config(include, orig_path, verbose, exit_on_config_errors=False):
     main config file.
     '''
     # Protect against empty option
-
     if not include:
         return {}
 
@@ -3835,10 +3834,10 @@ def master_config(path, env_var='SALT_MASTER_CONFIG', defaults=None, exit_on_con
                                     defaults['default_include'])
     include = overrides.get('include', [])
 
-    overrides.update(include_config(default_include, path, verbose=False),
-                     exit_on_config_errors=exit_on_config_errors)
-    overrides.update(include_config(include, path, verbose=True),
-                     exit_on_config_errors=exit_on_config_errors)
+    overrides.update(include_config(default_include, path, verbose=False,
+                     exit_on_config_errors=exit_on_config_errors))
+    overrides.update(include_config(include, path, verbose=True,
+                     exit_on_config_errors=exit_on_config_errors))
     opts = apply_master_config(overrides, defaults)
     _validate_ssh_minion_opts(opts)
     _validate_opts(opts)

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -3887,6 +3887,10 @@ def apply_master_config(overrides=None, defaults=None):
             )
             opts['saltenv'] = opts['environment']
 
+    if six.PY2 and 'rest_cherrypy' in opts:
+        # CherryPy is not unicode-compatible
+        opts['rest_cherrypy'] = salt.utils.data.encode(opts['rest_cherrypy'])
+
     for idx, val in enumerate(opts['fileserver_backend']):
         if val in ('git', 'hg', 'svn', 'minion'):
             new_val = val + 'fs'

--- a/tests/unit/config/test_config.py
+++ b/tests/unit/config/test_config.py
@@ -678,7 +678,7 @@ class ConfigTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
         '''
         tally = self._get_tally(sconfig.master_config)
         non_unicode = tally.get('non_unicode', [])
-        self.assertEqual(len(non_unicode), 8, non_unicode)
+        self.assertEqual(len(non_unicode), 8 if six.PY2 else 0, non_unicode)
         self.assertTrue(tally['unicode'] > 0)
 
     def test_conf_file_strings_are_unicode_for_minion(self):


### PR DESCRIPTION
CherryPy is not unicode-compatible.

Fixes #46274.