### PR TITLE
salt.utils.docker.translate_input: operate on deepcopy of kwargs

### DIFF
--- a/salt/utils/docker/__init__.py
+++ b/salt/utils/docker/__init__.py
@@ -8,6 +8,7 @@ input as formatted by states.
 
 # Import Python libs
 from __future__ import absolute_import
+import copy
 import logging
 import os
 
@@ -174,7 +175,7 @@ def translate_input(**kwargs):
     have their translation skipped. Optionally, skip_translate can be set to
     True to skip *all* translation.
     '''
-    kwargs = salt.utils.clean_kwargs(**kwargs)
+    kwargs = copy.deepcopy(salt.utils.clean_kwargs(**kwargs))
     invalid = {}
     collisions = []
 


### PR DESCRIPTION
This keeps the translation from rewriting the low chunks and breaking
the watch requisite.

Fixes #44046.