### PR TITLE
Fix grains with '\n'

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -2169,7 +2169,7 @@ def _hw_data(osdata):
             if os.path.exists(contents_file):
                 try:
                     with salt.utils.files.fopen(contents_file, 'r') as ifile:
-                        grains[key] = ifile.read()
+                        grains[key] = ifile.read().strip()
                         if key == 'uuid':
                             grains['uuid'] = grains['uuid'].lower()
                 except (IOError, OSError) as err:


### PR DESCRIPTION
### What does this PR do?

Fixes the grains that contain a trailing new line char.

```bash
bash-4.3# salt-call --local grains.items --out=json > /tmp/before.json
# apply fix here
bash-4.3# salt-call --local grains.items --out=json > /tmp/after.json
bash-4.3# diff /tmp/before.json /tmp/after.json
3c3
<         "biosversion": "A14\n",
---
>         "biosversion": "A14",
27,28c27,28
<         "serialnumber": "GLK3A32\n",
<         "pid": 536,
---
>         "serialnumber": "GLK3A32",
>         "pid": 553,
57c57
<         "uuid": "2c3c1621-011x-5910-2163-b5a03f3c3834\n",
---
>         "uuid": "2c3c1621-011x-5910-2163-b5a03f3c3834",
227,228c227,228
<         "biosreleasedate": "09/14/2015\n",
<         "manufacturer": "Dell Inc.\n",
---
>         "biosreleasedate": "09/14/2015",
>         "manufacturer": "Dell Inc.",
249c249
<         "productname": "OptiPlex 9020\n",
---
>         "productname": "OptiPlex 9020",
```

### Tests written?

No

### Commits signed with GPG?

No