### PR TITLE
fix return dict for salt-ssh if something goes wrong

### DIFF
--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -659,6 +659,8 @@ class SSH(object):
             self.cache_job(jid, host, ret[host], fun)
             if self.event:
                 id_, data = next(six.iteritems(ret))
+                if isinstance(data, six.text_type):
+                    data = {'return': data}
                 if 'id' not in data:
                     data['id'] = id_
                 data['jid'] = jid  # make the jid in the payload the same as the jid in the tag
@@ -772,6 +774,8 @@ class SSH(object):
                         self.opts)
             if self.event:
                 id_, data = next(six.iteritems(ret))
+                if isinstance(data, six.text_type):
+                    data = {'return': data}
                 if 'id' not in data:
                     data['id'] = id_
                 data['jid'] = jid  # make the jid in the payload the same as the jid in the tag

--- a/tests/unit/ssh/test_ssh.py
+++ b/tests/unit/ssh/test_ssh.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+'''
+    :codeauthor: :email:`Daniel Wallace <dwallace@saltstack.com`
+'''
+
+# Import python libs
+from __future__ import absolute_import, unicode_literals
+import os
+
+# Import Salt Testing libs
+from tests.support.unit import skipIf
+from tests.support.case import ShellCase
+from tests.support.mock import NO_MOCK, NO_MOCK_REASON, patch, MagicMock
+
+# Import Salt libs
+import salt.config
+from salt.client import ssh
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class SSHPasswordTests(ShellCase):
+    def test_password_failure(self):
+        '''
+        Check password failures when trying to deploy keys
+        '''
+        opts = salt.config.client_config(self.get_config_file_path('master'))
+        opts['list_hosts'] = False
+        opts['argv'] = ['test.ping']
+        opts['selected_target_option'] = 'glob'
+        opts['tgt'] = 'localhost'
+        opts['arg'] = []
+        roster = os.path.join(self.get_config_dir(), 'roster')
+        handle_ssh_ret = [
+            {'localhost': {'retcode': 255, 'stderr': u'Permission denied (publickey).\r\n', 'stdout': ''}},
+        ]
+        expected = {'localhost': 'Permission denied (publickey)'}
+        display_output = MagicMock()
+        with patch('salt.roster.get_roster_file', MagicMock(return_value=roster)), \
+                patch('salt.client.ssh.SSH.handle_ssh', MagicMock(return_value=handle_ssh_ret)), \
+                patch('salt.client.ssh.SSH.key_deploy', MagicMock(return_value=expected)), \
+                patch('salt.output.display_output', display_output):
+            client = ssh.SSH(opts)
+            ret = next(client.run_iter())
+            with self.assertRaises(SystemExit):
+                client.run()
+        display_output.assert_called_once_with(expected, 'nested', opts)
+        self.assertIs(ret, handle_ssh_ret[0])


### PR DESCRIPTION
### What does this PR do?
If we are unable to login go the minion, the return will not be a dictionary,
it will be a string.  We should still return this, but it needs to be in the
correct format.


### What issues does this PR fix or reference?
Fixes #46283

### Tests written?

No

### Commits signed with GPG?

Yes