### PR TITLE
Ensure minion id is unicode when minion_id_caching is set

### DIFF
--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -3577,7 +3577,7 @@ def get_id(opts, cache_minion_id=False):
     if opts.get('minion_id_caching', True):
         try:
             with salt.utils.files.fopen(id_cache) as idf:
-                name = idf.readline().strip()
+                name = salt.utils.stringutils.to_unicode(idf.readline().strip())
                 bname = salt.utils.stringutils.to_bytes(name)
                 if bname.startswith(codecs.BOM):  # Remove BOM if exists
                     name = salt.utils.stringutils.to_str(bname.replace(codecs.BOM, '', 1))


### PR DESCRIPTION
### What issues does this PR fix or reference?
https://github.com/saltstack/salt-jenkins/issues/861

### Previous Behavior
test failing:

```
=====================================================  Overall Tests Report  ======================================================
*** unit.config.test_config.ConfigTestCase.test_conf_file_strings_are_unicode Tests  **********************************************
 --------  Failed Tests  ----------------------------------------------------------------------------------------------------------
   -> unit.config.test_config.ConfigTestCase.test_conf_file_strings_are_unicode  ..................................................
       Traceback (most recent call last):
         File "/testing/tests/unit/config/test_config.py", line 660, in test_conf_file_strings_are_unicode
           self.assertEqual(tally['non-unicode'], 0)
       AssertionError: 1 != 0
   ................................................................................................................................
 ----------------------------------------------------------------------------------------------------------------------------------
===================================================================================================================================
```

### New Behavior
test passes :)