### PR TITLE
Fix Python3 comparison `TypeError` in `salt.modules.upstart`

### DIFF
--- a/salt/modules/upstart.py
+++ b/salt/modules/upstart.py
@@ -97,7 +97,7 @@ def _find_utmp():
             result[os.stat(utmp).st_mtime] = utmp
         except Exception:
             pass
-    if result > 0:
+    if len(result):
         return result[sorted(result).pop()]
     else:
         return False


### PR DESCRIPTION
Use `len()` to determine the number of keys in a dictionary.

#44624 introduced a Python3 incompatible comparison where a dict is
compared against an integer, causing breakage on Ubuntu 18.04/bionic
which uses Python3 by default for SaltStack:

```
File "/usr/lib/python3/dist-packages/salt/modules/upstart.py", line 100, in _find_utmp
  if result > 0:
TypeError: '>' not supported between instances of 'dict' and 'int'
```

### What does this PR do?
See commit msg

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/pull/44624#discussion_r156496576

### Previous Behavior
```
File "/usr/lib/python3/dist-packages/salt/modules/upstart.py", line 100, in _find_utmp
  if result > 0:
TypeError: '>' not supported between instances of 'dict' and 'int'
```

### New Behavior
`salt.modules.upstart` doesn't cause a backtrace anymore

### Tests written?

No

### Commits signed with GPG?

Yes