### PR TITLE
[develop] quick fix to unit.utils.test_schedule.ScheduleTestCase.test_eval_schedule_time_eval

### DIFF
--- a/tests/unit/utils/test_schedule.py
+++ b/tests/unit/utils/test_schedule.py
@@ -307,7 +307,7 @@ class ScheduleTestCase(TestCase):
             {'schedule': {'testjob': {'function': 'test.true', 'seconds': 60, 'splay': 5}}})
         now = datetime.datetime.now()
         self.schedule.eval()
-        self.assertTrue((self.schedule.opts['schedule']['testjob']['_splay'] - now).total_seconds() > 60)
+        self.assertTrue(self.schedule.opts['schedule']['testjob']['_splay'] - now > datetime.timedelta(seconds=60))
 
     @skipIf(not _CRON_SUPPORTED, 'croniter module not installed')
     def test_eval_schedule_cron(self):


### PR DESCRIPTION
### What does this PR do?
Quick fix to the scheduler unit tests to ensure time.deltatime objects are used.

### What issues does this PR fix or reference?
N/A

### Previous Behavior
Broken test unit.utils.test_schedule.ScheduleTestCase.test_eval_schedule_time_eval

### New Behavior
Fixed test unit.utils.test_schedule.ScheduleTestCase.test_eval_schedule_time_eval

### Tests written?
Yes.  Existing tests.

### Commits signed with GPG?

Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
