### PR TITLE
Account for output variations in pkgng._parse_upgrade

### DIFF
--- a/salt/modules/pkgng.py
+++ b/salt/modules/pkgng.py
@@ -2316,84 +2316,110 @@ def _parse_upgrade(stdout):
         'upgrade':
           pkgname:
             'repo': repository
+            'reason': reason
             'version':
               'current': n.n.n
               'new': n.n.n
         'install':
           pkgname:
             'repo': repository
+            'reason': reason
             'version':
               'current': n.n.n
         'reinstall':
           pkgname:
             'repo': repository
+            'reason': reason
             'version':
               'current': n.n.n
-
+        'downgrade':
+          pkgname:
+            'repo': repository
+            'reason': reason
+            'version':
+              'current': n.n.n
+              'new': n.n.n
+        'remove':
+          pkgname:
+            'repo': repository
+            'reason': reason
+            'version':
+              'current': n.n.n
     '''
     # Match strings like 'python36: 3.6.3 -> 3.6.4 [FreeBSD]'
-    upgrade_regex = re.compile(r'^\s+([^:]+):\s([0-9p_,.]+)\s+->\s+([0-9p_,.]+)\s+\[([^]]+)\]')
+    upgrade_regex = re.compile(r'^\s+([^:]+):\s([0-9a-z_,.]+)\s+->\s+([0-9a-z_,.]+)\s*(\[([^]]+)\])?\s*(\(([^)]+)\))?')
     # Match strings like 'rubygem-bcrypt_pbkdf: 1.0.0 [FreeBSD]'
-    install_regex = re.compile(r'^\s+([^:]+):\s+([0-9p_,.]+)\s+\[([^]]+)\]')
+    install_regex = re.compile(r'^\s+([^:]+):\s+([0-9a-z_,.]+)\s*(\[([^]]+)\])?\s*(\(([^)]+)\))?')
     # Match strings like 'py27-yaml-3.11_2 [FreeBSD] (direct dependency changed: py27-setuptools)'
-    reinstall_regex = re.compile(r'^\s+(\S+)-(?<=-)([0-9p_,.]+)\s+\[([^]]+)\]')
+    reinstall_regex = re.compile(r'^\s+(\S+)-(?<=-)([0-9a-z_,.]+)\s*(\[([^]]+)\])?\s*(\(([^)]+)\))?')
 
-    result = {'upgrade': {}, 'install': {}, 'reinstall': {}}
-    section = None
+    result = {'upgrade': {}, 'install': {}, 'reinstall': {}, 'remove': {}, 'downgrade': {}}
+    action = None
     for line in salt.utils.itertools.split(stdout, '\n'):
 
         if not line:
-            section = None
+            action = None
             continue
 
         if line == 'Installed packages to be UPGRADED:':
-            section = 'upgrade'
+            action = 'upgrade'
             continue
 
         if line == 'New packages to be INSTALLED:':
-            section = 'install'
+            action = 'install'
             continue
 
         if line == 'Installed packages to be REINSTALLED:':
-            section = 'reinstall'
+            action = 'reinstall'
             continue
 
-        if section == 'upgrade':
+        if line == 'Installed packages to be REMOVED:':
+            action = 'remove'
+            continue
+
+        if line == 'Installed packages to be DOWNGRADED:':
+            action = 'downgrade'
+            continue
+
+        if action == 'upgrade' or action == 'downgrade':
             match = upgrade_regex.match(line)
             if match:
-                result[section][match.group(1)] = {
+                result[action][match.group(1)] = {
                     'version': {
                         'current': match.group(2),
                         'new': match.group(3)
                     },
-                    'repo': match.group(4)
+                    'repo': match.group(5),
+                    'reason': match.group(7)
                 }
             else:
-                log.error('Unable to parse upgrade: \'%s\'', line)
+                log.error('Unable to parse %s: \'%s\'', action, line)
 
-        if section == 'install':
+        if action == 'install':
             match = install_regex.match(line)
             if match:
-                result[section][match.group(1)] = {
+                result[action][match.group(1)] = {
                     'version': {
                         'current': match.group(2)
                     },
-                    'repo': match.group(3)
+                    'repo': match.group(4),
+                    'reason': match.group(6)
                 }
             else:
-                log.error('Unable to parse install: \'%s\'', line)
+                log.error('Unable to parse %s: \'%s\'', action, line)
 
-        if section == 'reinstall':
+        if (action == 'reinstall') or (action == 'remove'):
             match = reinstall_regex.match(line)
             if match:
-                result[section][match.group(1)] = {
+                result[action][match.group(1)] = {
                     'version': {
                         'current': match.group(2)
                     },
-                    'repo': match.group(3)
+                    'repo': match.group(4),
+                    'reason': match.group(6)
                 }
             else:
-                log.error('Unable to parse reinstall: \'%s\'', line)
+                log.error('Unable to parse %s: \'%s\'', action, line)
 
     return result
 

--- a/tests/unit/modules/test_pkgng.py
+++ b/tests/unit/modules/test_pkgng.py
@@ -114,17 +114,35 @@ class PkgNgTestCase(TestCase, LoaderModuleMockMixin):
             """
             The following 6 package(s) will be affected (of 0 checked):
 
-            New packages to be INSTALLED:
-                    pkge: 5.0 [FreeBSD]
-                    pkgf: 6.0 [FreeBSD]
-
             Installed packages to be UPGRADED:
-                    pkga: 1.0 -> 1.1 [FreeBSD]
+                    pkga: 1.0 -> 1.1
                     pkgb: 2.0 -> 2.1 [FreeBSD]
+                    pkgc: 3.0 -> 3.1 [FreeBSD] (dependency changed)
+                    pkgd: 4.0 -> 4.1 (dependency changed)
+
+            New packages to be INSTALLED:
+                    pkge: 1.0
+                    pkgf: 2.0 [FreeBSD]
+                    pkgg: 3.0 [FreeBSD] (dependency changed)
+                    pkgh: 4.0 (dependency changed)
 
             Installed packages to be REINSTALLED:
-                    pkgc-3.0 [FreeBSD] (direct dependency changed: pkga)
-                    pkgd-4.0 [FreeBSD] (direct dependency changed: pkgb)
+                    pkgi-1.0
+                    pkgj-2.0 [FreeBSD]
+                    pkgk-3.0 [FreeBSD] (direct dependency changed: pkga)
+                    pkgl-4.0 (direct dependency changed: pkgb)
+
+            Installed packages to be DOWNGRADED:
+                    pkgm: 1.1 -> 1.0
+                    pkgn: 2.1 -> 2.0 [FreeBSD]
+                    pkgo: 3.1 -> 3.0 [FreeBSD] (dependency changed)
+                    pkgp: 4.1 -> 4.0 (dependency changed)
+
+            Installed packages to be REMOVED:
+                    pkgq-1.0
+                    pkgr-2.0 [FreeBSD]
+                    pkgs-3.0 [FreeBSD] (direct dependency changed: pkga)
+                    pkgt-4.0 (direct dependency changed: pkgb)
 
             Number of packages to be upgraded: 2
             Number of packages to be reinstalled: 2
@@ -137,7 +155,7 @@ class PkgNgTestCase(TestCase, LoaderModuleMockMixin):
         with patch.dict(pkgng.__salt__, {'cmd.run_stdout': pkg_cmd}):
 
             result = pkgng.list_upgrades(refresh=False)
-            self.assertDictEqual(result, {'pkga': '1.1', 'pkgb': '2.1'})
+            self.assertDictEqual(result, {'pkga': '1.1', 'pkgb': '2.1', 'pkgc': '3.1', 'pkgd': '4.1'})
             pkg_cmd.assert_called_with(
                 ['pkg', 'upgrade', '--dry-run', '--quiet', '--no-repo-update'],
                 output_loglevel='trace', python_shell=False, ignore_retcode=True


### PR DESCRIPTION
### What does this PR do?
Provide more robust parsing for `pkg upgrade` output on FreeBSD

### What issues does this PR fix or reference?
None

### Previous Behavior
Some variants of output could not be parsed

### New Behavior
Variants now supported:
1. Source repository missing - this happens when only one repository is configured
2. Reason for action missing
3. Alphabetic characters in the version string (e.g. `r1`, `p1`)

### Tests written?
Yes

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
