### PR TITLE
Fix encryption algorithm hash id in comment

### DIFF
--- a/salt/modules/shadow.py
+++ b/salt/modules/shadow.py
@@ -270,7 +270,7 @@ def set_password(name, password, use_usermod=False):
     ``SALTsalt`` is the 8-character crpytographic salt. Valid characters in the
     salt are ``.``, ``/``, and any alphanumeric character.
 
-    Keep in mind that the $7 represents a sha512 hash, if your OS is using a
+    Keep in mind that the $6 represents a sha512 hash, if your OS is using a
     different hashing algorithm this needs to be changed accordingly
 
     CLI Example:


### PR DESCRIPTION
### What does this PR do?

Trivial fix to a comment around shadow password hashing. `$7` is a non-existent encryption algorithm id - `$6` is the correct id for `sha-512` - see [crypt(3)](http://man7.org/linux/man-pages/man3/crypt.3.html)

### What issues does this PR fix or reference?

None

### Tests written?

N/A

### Commits signed with GPG?

Yes