### PR TITLE
Fix ValueError for template in AppsV1beta1DeploymentSpec

### DIFF
--- a/salt/modules/kubernetes.py
+++ b/salt/modules/kubernetes.py
@@ -1461,7 +1461,7 @@ def __dict_to_deployment_spec(spec):
     '''
     Converts a dictionary into kubernetes AppsV1beta1DeploymentSpec instance.
     '''
-    spec_obj = AppsV1beta1DeploymentSpec()
+    spec_obj = AppsV1beta1DeploymentSpec(template=spec.get('template', ''))
     for key, value in iteritems(spec):
         if hasattr(spec_obj, key):
             setattr(spec_obj, key, value)


### PR DESCRIPTION
Instantiating AppsV1beta1DeploymentSpec without specifying a template will raise:
```
ValueError: Invalid value for `template`, must not be `None`
```

Therefore directly specifying the template when instantiating AppsV1beta1DeploymentSpec and use '' as default template. This fixes the test_create_deployments test case (fixes #46329).

Since I do not use Kubernetes, I am not sure if specifying an empty string as template is acceptable or if this should be prevented by salt.