### PR TITLE
Update the merge-forward docs to reference the 2018.3 branch

### DIFF
--- a/doc/topics/development/contributing.rst
+++ b/doc/topics/development/contributing.rst
@@ -282,9 +282,9 @@ The Salt repository follows a "Merge Forward" policy. The merge-forward
 behavior means that changes submitted to older main release branches will
 automatically be "merged-forward" into the newer branches.
 
-For example, a pull request is merged into ``2016.11``. Then, the entire
-``2016.11`` branch is merged-forward into the ``2017.7`` branch, and the
-``2017.7`` branch is merged-forward into the ``develop`` branch.
+For example, a pull request is merged into ``2017.7``. Then, the entire
+``2017.7`` branch is merged-forward into the ``2018.3`` branch, and the
+``2018.3`` branch is merged-forward into the ``develop`` branch.
 
 This process makes is easy for contributors to make only one pull-request
 against an older branch, but allows the change to propagate to all **main**


### PR DESCRIPTION
This will make the docs for 2018.3.x more coherent once the docs for
2018.3 are pushed live.