### PR TITLE
Fixes color parameter mismatch and handles 204 responses correctly

### DIFF
--- a/salt/modules/hipchat.py
+++ b/salt/modules/hipchat.py
@@ -176,8 +176,8 @@ def _query(function,
     if result.get('status', None) == salt.ext.six.moves.http_client.OK:
         response = hipchat_functions.get(api_version).get(function).get('response')
         return result.get('dict', {}).get(response, None)
-    elif result.get('status', None) == salt.ext.six.moves.http_client.NO_CONTENT:
-        return False
+    elif result.get('status', None) == salt.ext.six.moves.http_client.NO_CONTENT and api_version == 'v2':
+        return True
     else:
         log.debug(url)
         log.debug(query_params)

--- a/salt/states/hipchat.py
+++ b/salt/states/hipchat.py
@@ -45,7 +45,7 @@ def send_message(name,
                  api_url=None,
                  api_key=None,
                  api_version=None,
-                 color='yellow',
+                 message_color='yellow',
                  notify=False):
     '''
     Send a message to a Hipchat room.
@@ -60,7 +60,7 @@ def send_message(name,
             - api_url: https://hipchat.myteam.com
             - api_key: peWcBiMOS9HrZG15peWcBiMOS9HrZG15
             - api_version: v1
-            - color: green
+            - message_color: green
             - notify: True
 
     The following parameters are required:
@@ -93,7 +93,7 @@ def send_message(name,
         The api version for Hipchat to use,
         if not specified in the configuration options of master or minion.
 
-    color
+    message_color
         The color the Hipchat message should be displayed in. One of the following, default: yellow
         "yellow", "red", "green", "purple", "gray", or "random".
 
@@ -129,7 +129,7 @@ def send_message(name,
         api_url=api_url,
         api_key=api_key,
         api_version=api_version,
-        color=color,
+        color=message_color,
         notify=notify,
     )
 

--- a/salt/states/hipchat.py
+++ b/salt/states/hipchat.py
@@ -45,7 +45,7 @@ def send_message(name,
                  api_url=None,
                  api_key=None,
                  api_version=None,
-                 message_color='yellow',
+                 color='yellow',
                  notify=False):
     '''
     Send a message to a Hipchat room.
@@ -129,7 +129,7 @@ def send_message(name,
         api_url=api_url,
         api_key=api_key,
         api_version=api_version,
-        color=message_color,
+        color=color,
         notify=notify,
     )
 


### PR DESCRIPTION
### What does this PR do?
Fixes the hipchat module and state to handle API v2 204 (NO_CONTENT) responses correctly. Also fixes the `message_color` and `color` parameters mismatch between the docs and the code.

### What issues does this PR fix or reference?
#42438

### Previous Behavior
When trying to send a message to hipchat using the state, the message is delivered sucessfully but the state returns as failed since it is considering a 204 HTTP response as invalid when it is actually the desired behaviour for the [Hipchat v2 API](https://www.hipchat.com/docs/apiv2/method/send_room_notification)

### New Behavior
The state returns True for such scenarios

### Tests written?

No

### Commits signed with GPG?

No

### Notes
The `develop` branch has this already fixed but it uses a code leveraged for the upcoming 2018 release  that contains components not present on 2017 like `salt.utils.json`. Pushing this PR in the hopes it can make to the next point release 2017.7.5