### PR TITLE
Don't encode response string from role API

### DIFF
--- a/salt/utils/aws.py
+++ b/salt/utils/aws.py
@@ -89,9 +89,7 @@ def creds(provider):
                 proxies={'http': ''}, timeout=AWS_METADATA_TIMEOUT,
             )
             result.raise_for_status()
-            role = result.text.encode(
-                result.encoding if result.encoding else 'utf-8'
-            )
+            role = result.text
         except (requests.exceptions.HTTPError, requests.exceptions.ConnectionError):
             return provider['id'], provider['key'], ''
 


### PR DESCRIPTION
Substituting a bytestring in the URL of the subsequent request leads to a malformed URL and thus 404.

Solves #46237. This may also be an issue elsewhere in here where Python 3 string semantics differ from Python 2. I haven't checked all the other uses of `encode` in this file, but this was enough to get me going.