### PR TITLE
Change 'del_all_vol_on_destroy' to 'del_all_vols_on_destroy' as per code

### DIFF
--- a/doc/topics/cloud/aws.rst
+++ b/doc/topics/cloud/aws.rst
@@ -296,7 +296,7 @@ Set up an initial profile at ``/etc/salt/cloud.profiles``:
           SecurityGroupId:
             - sg-750af413
       del_root_vol_on_destroy: True
-      del_all_vol_on_destroy: True
+      del_all_vols_on_destroy: True
       volumes:
         - { size: 10, device: /dev/sdf }
         - { size: 10, device: /dev/sdg, type: io1, iops: 1000 }


### PR DESCRIPTION
In the code, del_all_vols_on_destroy is used and in documentation del_all_vol_on_destroy has been mentioned. Hence there is a mismatch.

### What does this PR do?

### What issues does this PR fix or reference?

### Previous Behavior
Remove this section if not relevant

### New Behavior
Remove this section if not relevant

### Tests written?

Yes/No

### Commits signed with GPG?

Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
