### PR TITLE
make vault like all other sdb backends

### DIFF
--- a/doc/topics/sdb/index.rst
+++ b/doc/topics/sdb/index.rst
@@ -79,22 +79,12 @@ from the ``kevinopenstack`` profile above, you would use:
 
     salt-call sdb.get sdb://kevinopenstack/password
 
-Some drivers use slightly more complex URIs. For instance, the ``vault`` driver
-requires the full path to where the key is stored, followed by a question mark,
-followed by the key to be retrieved.  If you were using a profile called
-``myvault``, you would use a URI that looks like:
-
-.. code-block:: bash
-
-    salt-call sdb.get 'sdb://myvault/secret/salt?saltstack'
-
 Setting a value uses the same URI as would be used to retrieve it, followed
-by the value as another argument. For the above ``myvault`` URI, you would set
-a new value using a command like:
+by the value as another argument.
 
 .. code-block:: bash
 
-    salt-call sdb.set 'sdb://myvault/secret/salt?saltstack' 'super awesome'
+    salt-call sdb.set 'sdb://myvault/secret/salt/saltstack' 'super awesome'
 
 Deleting values (if supported by the driver) is done pretty much the same way as
 getting them. Provided that you have a profile called ``mykvstore`` that uses
@@ -109,8 +99,8 @@ the runner system:
 
 .. code-block:: bash
 
-    salt-run sdb.get 'sdb://myvault/secret/salt?saltstack'
-    salt-run sdb.set 'sdb://myvault/secret/salt?saltstack' 'super awesome'
+    salt-run sdb.get 'sdb://myvault/secret/salt/saltstack'
+    salt-run sdb.set 'sdb://myvault/secret/salt/saltstack' 'super awesome'
     salt-run sdb.delete 'sdb://mykvstore/foobar'
 
 

--- a/salt/sdb/vault.py
+++ b/salt/sdb/vault.py
@@ -27,7 +27,7 @@ Once configured you can access data using a URL such as:
 
 .. code-block:: yaml
 
-    password: sdb://myvault/secret/passwords?mypassword
+    password: sdb://myvault/secret/passwords/mypassword
 
 In this URL, ``myvault`` refers to the configuration profile,
 ``secret/passwords`` is the path where the data resides, and ``mypassword`` is
@@ -56,9 +56,17 @@ def set_(key, value, profile=None):
     '''
     Set a key/value pair in the vault service
     '''
-    comps = key.split('?')
-    path = comps[0]
-    key = comps[1]
+    if '?' in key:
+        __utils__['versions.warn_until'](
+            'Neon',
+            (
+                'Using ? to seperate between the path and key for vault has been deprecated '
+                'and will be removed in {version}.  Please just use a /.'
+            ),
+        )
+        path, key = key.split('?')
+    else:
+        path, key = key.rsplit('/', 1)
 
     try:
         url = 'v1/{0}'.format(path)
@@ -81,9 +89,17 @@ def get(key, profile=None):
     '''
     Get a value from the vault service
     '''
-    comps = key.split('?')
-    path = comps[0]
-    key = comps[1]
+    if '?' in key:
+        __utils__['versions.warn_until'](
+            'Neon',
+            (
+                'Using ? to seperate between the path and key for vault has been deprecated '
+                'and will be removed in {version}.  Please just use a /.'
+            ),
+        )
+        path, key = key.split('?')
+    else:
+        path, key = key.rsplit('/', 1)
 
     try:
         url = 'v1/{0}'.format(path)


### PR DESCRIPTION
### What does this PR do?
This is a dumb.  There is no reason we shouldn't just split the last value off and use it for the key name in the vault path.

### Previous Behavior
reference sdb

```
salt-call sdb.get sdb://myvault/path/to/value?key
```

### New Behavior
New format

```
salt-call sdb.get sdb://myvault/path/to/value/key
```

So that it looks like all other sdb backends

### Tests written?

https://github.com/saltstack/salt/issues/46052

### Commits signed with GPG?

Yes