### PR TITLE
Add the salt.utils.http.query function to the docs and the module index

### DIFF
--- a/salt/modules/http.py
+++ b/salt/modules/http.py
@@ -18,7 +18,10 @@ def query(url, **kwargs):
     '''
     Query a resource, and decode the return data
 
-    .. versionadded:: 2015.5.0
+    Passes through all the parameters described in the
+    :py:func:`utils.http.query function <salt.utils.http.query>`:
+
+    .. autofunction:: salt.utils.http.query
 
     CLI Example:
 

--- a/salt/runners/http.py
+++ b/salt/runners/http.py
@@ -19,7 +19,8 @@ def query(url, output=True, **kwargs):
     '''
     Query a resource, and decode the return data
 
-    .. versionadded:: 2015.5.0
+    Passes through all the parameters described in the
+    :py:func:`utils.http.query function <salt.utils.http.query>`:
 
     CLI Example:
 

--- a/salt/states/http.py
+++ b/salt/states/http.py
@@ -24,7 +24,8 @@ def query(name, match=None, match_type='string', status=None, wait_for=None, **k
     '''
     Perform an HTTP query and statefully return the result
 
-    .. versionadded:: 2015.5.0
+    Passes through all the parameters described in the
+    :py:func:`utils.http.query function <salt.utils.http.query>`:
 
     name
         The name of the query.


### PR DESCRIPTION
### What does this PR do?

Pull the `salt.utils.http.query` function signature (in all its terrible glory) into the docs.