### PR TITLE
Fix reg module when vname=None

### DIFF
--- a/salt/modules/reg.py
+++ b/salt/modules/reg.py
@@ -83,6 +83,8 @@ def _to_unicode(vdata):
     Converts from current users character encoding to unicode. Use this for
     parameters being pass to reg functions
     '''
+    if vdata is None:
+        return None
     return salt.utils.stringutils.to_unicode(vdata, 'utf-8')
 
 
@@ -364,7 +366,7 @@ def read_value(hive, key, vname=None, use_32bit_registry=False):
     # Setup the return array
     local_hive = _to_unicode(hive)
     local_key = _to_unicode(key)
-    local_vname = _to_unicode(vname) if vname is not None else None
+    local_vname = _to_unicode(vname)
 
     ret = {'hive':  local_hive,
            'key':   local_key,
@@ -517,7 +519,7 @@ def set_value(hive,
     '''
     local_hive = _to_unicode(hive)
     local_key = _to_unicode(key)
-    local_vname = _to_unicode(vname) if vname is not None else None
+    local_vname = _to_unicode(vname)
     local_vtype = _to_unicode(vtype)
 
     registry = Registry()
@@ -694,7 +696,7 @@ def delete_value(hive, key, vname=None, use_32bit_registry=False):
     '''
     local_hive = _to_unicode(hive)
     local_key = _to_unicode(key)
-    local_vname = _to_unicode(vname) if vname is not None else None
+    local_vname = _to_unicode(vname)
 
     registry = Registry()
     hkey = registry.hkeys[local_hive]

--- a/salt/modules/reg.py
+++ b/salt/modules/reg.py
@@ -532,20 +532,18 @@ def set_value(hive,
     # int will automatically become long on 64bit numbers
     # https://www.python.org/dev/peps/pep-0237/
 
-    local_vdata = None
-    if vdata is not None:
-        # String Types to Unicode
-        if vtype_value in [win32con.REG_SZ, win32con.REG_EXPAND_SZ]:
-            local_vdata = _to_unicode(vdata)
-        # Don't touch binary...
-        elif vtype_value == win32con.REG_BINARY:
-            local_vdata = vdata
-        # Make sure REG_MULTI_SZ is a list of strings
-        elif vtype_value == win32con.REG_MULTI_SZ:
-            local_vdata = [_to_unicode(i) for i in vdata]
-        # Everything else is int
-        else:
-            local_vdata = int(vdata)
+    # String Types to Unicode
+    if vtype_value in [win32con.REG_SZ, win32con.REG_EXPAND_SZ]:
+        local_vdata = _to_unicode(vdata)
+    # Don't touch binary...
+    elif vtype_value == win32con.REG_BINARY:
+        local_vdata = vdata
+    # Make sure REG_MULTI_SZ is a list of strings
+    elif vtype_value == win32con.REG_MULTI_SZ:
+        local_vdata = [_to_unicode(i) for i in vdata]
+    # Everything else is int
+    else:
+        local_vdata = int(vdata)
 
     if volatile:
         create_options = registry.opttype['REG_OPTION_VOLATILE']

--- a/salt/modules/reg.py
+++ b/salt/modules/reg.py
@@ -83,6 +83,7 @@ def _to_unicode(vdata):
     Converts from current users character encoding to unicode. Use this for
     parameters being pass to reg functions
     '''
+    # None does not convert to Unicode
     if vdata is None:
         return None
     return salt.utils.stringutils.to_unicode(vdata, 'utf-8')

--- a/salt/modules/reg.py
+++ b/salt/modules/reg.py
@@ -364,7 +364,7 @@ def read_value(hive, key, vname=None, use_32bit_registry=False):
     # Setup the return array
     local_hive = _to_unicode(hive)
     local_key = _to_unicode(key)
-    local_vname = _to_unicode(vname)
+    local_vname = _to_unicode(vname) if vname is not None else None
 
     ret = {'hive':  local_hive,
            'key':   local_key,
@@ -517,7 +517,7 @@ def set_value(hive,
     '''
     local_hive = _to_unicode(hive)
     local_key = _to_unicode(key)
-    local_vname = _to_unicode(vname)
+    local_vname = _to_unicode(vname) if vname is not None else None
     local_vtype = _to_unicode(vtype)
 
     registry = Registry()
@@ -529,18 +529,20 @@ def set_value(hive,
     # int will automatically become long on 64bit numbers
     # https://www.python.org/dev/peps/pep-0237/
 
-    # String Types to Unicode
-    if vtype_value in [1, 2]:
-        local_vdata = _to_unicode(vdata)
-    # Don't touch binary...
-    elif vtype_value == 3:
-        local_vdata = vdata
-    # Make sure REG_MULTI_SZ is a list of strings
-    elif vtype_value == 7:
-        local_vdata = [_to_unicode(i) for i in vdata]
-    # Everything else is int
-    else:
-        local_vdata = int(vdata)
+    local_vdata = None
+    if vdata is not None:
+        # String Types to Unicode
+        if vtype_value in [win32con.REG_SZ, win32con.REG_EXPAND_SZ]:
+            local_vdata = _to_unicode(vdata)
+        # Don't touch binary...
+        elif vtype_value == win32con.REG_BINARY:
+            local_vdata = vdata
+        # Make sure REG_MULTI_SZ is a list of strings
+        elif vtype_value == win32con.REG_MULTI_SZ:
+            local_vdata = [_to_unicode(i) for i in vdata]
+        # Everything else is int
+        else:
+            local_vdata = int(vdata)
 
     if volatile:
         create_options = registry.opttype['REG_OPTION_VOLATILE']
@@ -690,10 +692,9 @@ def delete_value(hive, key, vname=None, use_32bit_registry=False):
 
         salt '*' reg.delete_value HKEY_CURRENT_USER 'SOFTWARE\\Salt' 'version'
     '''
-
     local_hive = _to_unicode(hive)
     local_key = _to_unicode(key)
-    local_vname = _to_unicode(vname)
+    local_vname = _to_unicode(vname) if vname is not None else None
 
     registry = Registry()
     hkey = registry.hkeys[local_hive]


### PR DESCRIPTION
### What does this PR do?
Fixes an issue with None values being converted to unicode (or attempted).

To set the default value of a key in the registry, you set the `vname` parameter to `None`. This was causing a stacktrace when the module was attempting to convert `vname` to unicode. This PR adds an if statement to the `_to_unicode` function to just return `None` if the passed value is `None`.

Add `win32con.REG_TYPE` names to if statements to make it clearer what is being checked.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/46341

### Tests written?
No

### Commits signed with GPG?
Yes