### PR TITLE
Explore 'module.run' state module output in depth to catch "result" properly

### DIFF
--- a/salt/states/module.py
+++ b/salt/states/module.py
@@ -530,7 +530,20 @@ def _get_result(func_ret, changes):
                 res = changes_ret.get('result', {})
             elif changes_ret.get('retcode', 0) != 0:
                 res = False
+            # Explore dict in depth to determine if there is a
+            # 'result' key set to False which sets the global
+            # state result.
+            else:
+                res = _get_result_in_depth(changes_ret)
 
     return res
+
+def _get_result_in_depth(node):
+    for key, val in node.iteritems():
+        if key == 'result' and val is False:
+            return False
+        elif isinstance(val, dict):
+            return _get_result_in_depth(val)
+    return True
 
 mod_watch = salt.utils.alias_function(run, 'mod_watch')

--- a/salt/states/module.py
+++ b/salt/states/module.py
@@ -538,8 +538,9 @@ def _get_result(func_ret, changes):
 
     return res
 
+
 def _get_result_in_depth(node):
-    for key, val in node.iteritems():
+    for key, val in six.iteritems(node):
         if key == 'result' and val is False:
             return False
         elif isinstance(val, dict):

--- a/salt/states/module.py
+++ b/salt/states/module.py
@@ -534,17 +534,21 @@ def _get_result(func_ret, changes):
             # 'result' key set to False which sets the global
             # state result.
             else:
-                res = _get_result_in_depth(changes_ret)
+                res = _get_dict_result(changes_ret)
 
     return res
 
 
-def _get_result_in_depth(node):
+def _get_dict_result(node):
+    ret = True
     for key, val in six.iteritems(node):
         if key == 'result' and val is False:
-            return False
+            ret = False
+            break
         elif isinstance(val, dict):
-            return _get_result_in_depth(val)
-    return True
+            ret = _get_dict_result(val)
+            if ret is False:
+                break
+    return ret
 
 mod_watch = salt.utils.alias_function(run, 'mod_watch')

--- a/tests/unit/states/test_module.py
+++ b/tests/unit/states/test_module.py
@@ -25,6 +25,57 @@ log = logging.getLogger(__name__)
 
 CMD = 'foo.bar'
 
+STATE_APPLY_RET = {
+    'module_|-test2_|-state.apply_|-run': {
+        'comment': 'Module function state.apply executed',
+        'name': 'state.apply',
+        'start_time': '16:11:48.818932',
+        'result': False,
+        'duration': 179.439,
+        '__run_num__': 0,
+        'changes': {
+            'ret': {
+                'module_|-test3_|-state.apply_|-run': {
+                    'comment': 'Module function state.apply executed',
+                    'name': 'state.apply',
+                    'start_time': '16:11:48.904796',
+                    'result': True,
+                    'duration': 89.522,
+                    '__run_num__': 0,
+                    'changes': {
+                        'ret': {
+                            'module_|-test4_|-cmd.run_|-run': {
+                                'comment': 'Module function cmd.run executed',
+                                'name': 'cmd.run',
+                                'start_time': '16:11:48.988574',
+                                'result': True,
+                                'duration': 4.543,
+                                '__run_num__': 0,
+                                'changes': {
+                                    'ret': 'Wed Mar  7 16:11:48 CET 2018'
+                                },
+                                '__id__': 'test4'
+                            }
+                        }
+                    },
+                    '__id__': 'test3'
+                },
+                'module_|-test3_fail_|-test3_fail_|-run': {
+                    'comment': 'Module function test3_fail is not available',
+                    'name': 'test3_fail',
+                    'start_time': '16:11:48.994607',
+                    'result': False,
+                    'duration': 0.466,
+                    '__run_num__': 1,
+                    'changes': {},
+                    '__id__': 'test3_fail'
+                }
+            }
+        },
+        '__id__': 'test2'
+    }
+}
+
 
 def _mocked_func_named(name, names=('Fred', 'Swen',)):
     '''
@@ -142,6 +193,17 @@ class ModuleStateTest(TestCase, LoaderModuleMockMixin):
                 ret = module.run(**{CMD: ['Fred']})
                 if ret['comment'] != '{0}: Success'.format(CMD) or not ret['result']:
                     self.fail('module.run failed: {0}'.format(ret))
+
+    def test_run_state_apply_result_false(self):
+        '''
+        Tests the 'result' of module.run that calls state.apply execution module
+        :return:
+        '''
+        with patch.dict(module.__salt__, {"state.apply": MagicMock(return_value=STATE_APPLY_RET)}):
+            with patch.dict(module.__opts__, {'use_deprecated': ['module.run']}):
+                ret = module.run(**{"name": "state.apply", 'mods': 'test2'})
+                if ret['result']:
+                    self.fail('module.run did not report false result: {0}'.format(ret))
 
     def test_run_unexpected_keywords(self):
         with patch.dict(module.__salt__, {CMD: _mocked_func_args}):


### PR DESCRIPTION
### What does this PR do?
This PR adds a mechanism into the `module.run` state module to explore in depth the output dictionary returned by the called module in order to find out the `result` attribute (which in some cases can be wrapped by the output of the module called).

Currently, when the `state.apply` module is called within a `module.run` state, the response produced by the `module.run` does not properly set the `result` attribute. Therefore the `require` statements are not working on these cases.

Given the following SLS file:
```yaml
my_test_state_1:
  module.run:
    - name: state.apply
    - mods: my_other_state

my_test_state_2:
  module.run:
    - name: state.apply
    - mods: my_other_state_2
    - require:
      - module: my_test_state_1
```

### Previous Behavior
```
minsles12sp3-demo-1.tf.local:                                                                                                                                               
----------                                                                                                                                                                  
          ID: my_test_state_1
    Function: module.run
        Name: state.apply
      Result: True
     Comment: Module function state.apply executed
     Started: 11:12:01.866882
    Duration: 130.021 ms
     Changes:   
              ----------
              ret:
                  ----------
                  test_|-execute_command_|-test_|-fail_with_changes:
                      ----------
                      __id__:
                          execute_command
                      __run_num__:
                          0
                      changes:
                          ----------
                          testing:
                              ----------
                              new:
                                  Something pretended to change
                              old:
                                  Unchanged
                      comment:
                          Failure!
                      duration:
                          1.832
                      name:
                          test
                      result:
                          False
                      start_time:
                          11:12:01.992528
----------
          ID: my_test_state_2
    Function: module.run
        Name: state.apply
      Result: True
     Comment: Module function state.apply executed
     Started: 11:12:01.997184
    Duration: 101.492 ms
     Changes:   
              ----------
              ret:
                  ----------
                  test_|-execute_command_|-test_|-nop:
                      ----------
                      __id__:
                          execute_command
                      __run_num__:
                          0
                      changes:
                          ----------
                      comment:
                          Success!
                      duration:
                          0.238
                      name:
                          test
                      result:
                          True
                      start_time:
                          11:12:02.097643

Summary for minsles12sp3-demo-1.tf.local
------------
Succeeded: 2 (changed=2)
Failed:    0
------------
Total states run:     2
Total run time: 231.513 ms
```

As you can see, the result for `my_test_state_1` is set to `True` while the `ret` output returned by the `state.apply` module called contains `result = False`. Therefore the two states are actually executed while the expected behavior would be that the second state won't be executed due the `require` statement.

### New Behavior
```
minsles12sp3-demo-1.tf.local:
----------         
          ID: my_test_state_1                                     
    Function: module.run
        Name: state.apply
      Result: False                     
     Comment: Module function state.apply executed
     Started: 11:15:55.548039
    Duration: 86.597 ms
     Changes:   
              ----------
              ret:        
                  ----------
                  test_|-execute_command_|-test_|-fail_with_changes:
                      ----------
                      __id__:
                          execute_command
                      __run_num__:
                          0
                      changes:
                          ----------
                          testing:
                              ----------
                              new:
                                  Something pretended to change
                              old:
                                  Unchanged
                      comment:
                          Failure!
                      duration:
                          1.865
                      name:
                          test
                      result:
                          False
                      start_time:
                          11:15:55.629306
----------
          ID: my_test_state_2
    Function: module.run
        Name: state.apply
      Result: False
     Comment: One or more requisite failed: testpr.my_test_state_1
     Changes:   

Summary for minsles12sp3-demo-1.tf.local
------------
Succeeded: 0 (changed=1)
Failed:    2
------------
Total states run:     2
Total run time:  86.597 ms
ERROR: Minions returned with non-zero exit code

```

### Tests written?

Yes

### Commits signed with GPG?

Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
