### PR TITLE
Fix cp.push empty file

### DIFF
--- a/salt/master.py
+++ b/salt/master.py
@@ -1451,7 +1451,7 @@ class AESFuncs(object):
             if load['loc']:
                 fp_.seek(load['loc'])
 
-            fp_.write(load['data'])
+            fp_.write(salt.utils.stringutils.to_bytes(load['data']))
         return True
 
     def _pillar(self, load):


### PR DESCRIPTION
Co-authored-by: Jochen Breuer <jbreuer@suse.de>

### What does this PR do?

When running `cp.push` I get this in salt-master log:

```
[ERROR   ] Error in function _file_recv:
Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/salt/master.py", line 1776, in run_func
    ret = getattr(self, func)(load)
  File "/usr/lib/python3.6/site-packages/salt/master.py", line 1454, in _file_recv
    fp_.write(load['data'])
TypeError: a bytes-like object is required, not 'str'
```

Using `salt.utils.stringutils.to_str` didn't help so I am using plain `encode('utf8')`.

### Tests written?

No

### Commits signed with GPG?

No