### PR TITLE
Fix SSH client exception if SSH is not found

### DIFF
--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -220,7 +220,8 @@ class SSH(object):
         if self.opts['regen_thin']:
             self.opts['ssh_wipe'] = True
         if not salt.utils.which('ssh'):
-            raise salt.exceptions.SaltSystemExit('No ssh binary found in path -- ssh must be installed for salt-ssh to run. Exiting.')
+            raise salt.exceptions.SaltSystemExit(code=-1,
+                msg='No ssh binary found in path -- ssh must be installed for salt-ssh to run. Exiting.')
         self.opts['_ssh_version'] = ssh_version()
         self.tgt_type = self.opts['selected_target_option'] \
             if self.opts['selected_target_option'] else 'glob'


### PR DESCRIPTION
When no SSH client is installed, salt will create an empty SaltSystemExit exception:

```
Traceback (most recent call last):
  File "tests/unit/ssh/test_ssh.py", line 42, in test_password_failure
    client = ssh.SSH(opts)
  File "salt/client/ssh/__init__.py", line 226, in __init__
    raise salt.exceptions.SaltSystemExit('No ssh binary found in path -- ssh must be '
salt.exceptions.SaltSystemExit: None
```

The SaltSystemExit exception takes two parameters: code and msg.