### PR TITLE
Skip SSHPasswordTests if ssh binary is not found

### DIFF
--- a/tests/unit/ssh/test_ssh.py
+++ b/tests/unit/ssh/test_ssh.py
@@ -14,10 +14,12 @@ from tests.support.mock import NO_MOCK, NO_MOCK_REASON, patch, MagicMock
 
 # Import Salt libs
 import salt.config
+import salt.utils.path
 from salt.client import ssh
 
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
+@skipIf(not salt.utils.path.which('ssh'), "No ssh binary found in path")
 class SSHPasswordTests(ShellCase):
     def test_password_failure(self):
         '''


### PR DESCRIPTION
If the ssh binary is not found in path, SSHPasswordTests will fail:

```
ERROR: test_password_failure (unit.ssh.test_ssh.SSHPasswordTests)
[CPU:0.0%|MEM:54.9%]
----------------------------------------------------------------------
Traceback (most recent call last):
  File "tests/unit/ssh/test_ssh.py", line 42, in test_password_failure
    client = ssh.SSH(opts)
  File "salt/client/ssh/__init__.py", line 226, in __init__
    raise salt.exceptions.SaltSystemExit('No ssh binary found in path -- ssh must be '
salt.exceptions.SaltSystemExit: None
```

Either SSHPasswordTests needs to be converted into a real unit test (i.e. mocking the salt call) or this tests needs to be skipped if ssh is not available.