### PR TITLE
better reporting/handling of Linode API errors

### DIFF
--- a/salt/cloud/clouds/linode.py
+++ b/salt/cloud/clouds/linode.py
@@ -1500,6 +1500,24 @@ def _query(action=None,
         hide_fields=['api_key', 'rootPass'],
         opts=__opts__,
     )
+
+    if 'ERRORARRAY' in result['dict']:
+        if len(result['dict']['ERRORARRAY']):
+            error_list = []
+
+            for error in result['dict']['ERRORARRAY']:
+                msg = error['ERRORMESSAGE']
+ 
+                if msg == "Authentication failed":
+                    raise SaltCloudSystemExit(
+                        'Linode API Key is expired or invalid'
+                    )
+                else:
+                    error_list.append(msg)
+            raise SaltCloudException(
+                'Linode API reported error(s): {}'.format(", ".join(error_list))
+            )
+
     LASTCALL = int(time.mktime(datetime.datetime.now().timetuple()))
     log.debug('Linode Response Status Code: %s', result['status'])
 

--- a/salt/cloud/clouds/linode.py
+++ b/salt/cloud/clouds/linode.py
@@ -1507,7 +1507,7 @@ def _query(action=None,
 
             for error in result['dict']['ERRORARRAY']:
                 msg = error['ERRORMESSAGE']
- 
+
                 if msg == "Authentication failed":
                     raise SaltCloudSystemExit(
                         'Linode API Key is expired or invalid'


### PR DESCRIPTION
### What does this PR do?
Raises an exception in the _query function of the Linode salt-cloud module when the Linode API reports back an error (or errors)

This isn't a massive improvement but an easy win, mostly just aiming to stop the silent failing/bizarre error messages.

### Previous Behavior
For example, in the case of an API authentication failure:
- certain calls like avail.locations would silent fail
- other things, like attempting to create a Linode would fail with confusing errors related to functions like avail_sizes() barfing on the lack of expected data

### New Behavior
Now, we'll raise a SaltCloudSystemExit exception if an API authentication failure occurs (a fatal error). Otherwise, we raise a plain SaltCloudException noting the error messages from the API.

I'm not certain, in context, that we actually again anything by raising SaltCloudSystemExit instead of a generic SaltCloudException - but it seems more right?

### Tests written?

No

### Commits signed with GPG?

Yes