### PR TITLE
Fix issue with dev env install on Windows

### DIFF
--- a/pkg/windows/req.txt
+++ b/pkg/windows/req.txt
@@ -31,7 +31,7 @@ PyYAML==3.12
 pyzmq==16.0.2
 requests==2.13.0
 singledispatch==3.4.0.3
-six==1.10.0
+six==1.11.0
 smmap==0.9.0
 timelib==0.2.4
 tornado==4.5.1

--- a/pkg/windows/req.txt
+++ b/pkg/windows/req.txt
@@ -31,7 +31,6 @@ PyYAML==3.12
 pyzmq==16.0.2
 requests==2.13.0
 singledispatch==3.4.0.3
-six==1.11.0
 smmap==0.9.0
 timelib==0.2.4
 tornado==4.5.1


### PR DESCRIPTION
### What does this PR do?
Set six version for salt to match the six version required for CherryPy. CherryPy has a requisite of six>=1.11.0 and salt had a requisite of six==1.10.0 which was causing a problem in the dev environment installation (`pip install -e .`)

Salt commands failed to start with the following stack trace:
```
C:\WINDOWS\system32>salt-minion -l debug
Traceback (most recent call last):
  File "C:\Python27\Scripts\salt-minion-script.py", line 6, in <module>
    from pkg_resources import load_entry_point
  File "c:\python27\lib\site-packages\pkg_resources\__init__.py", line 3036, in <module>
    @_call_aside
  File "c:\python27\lib\site-packages\pkg_resources\__init__.py", line 3020, in _call_aside
    f(*args, **kwargs)
  File "c:\python27\lib\site-packages\pkg_resources\__init__.py", line 3049, in _initialize_master_working_set
    working_set = WorkingSet._build_master()
  File "c:\python27\lib\site-packages\pkg_resources\__init__.py", line 656, in _build_master
    return cls._build_from_requirements(__requires__)
  File "c:\python27\lib\site-packages\pkg_resources\__init__.py", line 669, in _build_from_requirements
    dists = ws.resolve(reqs, Environment())
  File "c:\python27\lib\site-packages\pkg_resources\__init__.py", line 859, in resolve
    raise VersionConflict(dist, req).with_context(dependent_req)
pkg_resources.ContextualVersionConflict: (six 1.10.0 (c:\python27\lib\site-packages), Requirement.parse('six>=1.11.0')
, set(['cheroot']))
```

This didn't seem to affect normal salt installation for some reason. Meaning, the packages don't seem to throw this stack trace.

### Tests written?
NA

### Commits signed with GPG?
Yes