### PR TITLE
Fix problem with __virtual__ in win_snmp

### DIFF
--- a/salt/modules/reg.py
+++ b/salt/modules/reg.py
@@ -155,9 +155,10 @@ class Registry(object):  # pylint: disable=R0903
             raise CommandExecutionError(msg.format(k, hkeys))
 
 
-def _key_exists(hive, key, use_32bit_registry=False):
+def key_exists(hive, key, use_32bit_registry=False):
     '''
-    Check that the key is found in the registry
+    Check that the key is found in the registry. This refers to keys and not
+    value/data pairs.
 
     :param str hive: The hive to connect to.
     :param str key: The key to check
@@ -179,6 +180,10 @@ def _key_exists(hive, key, use_32bit_registry=False):
         return True
     except WindowsError:  # pylint: disable=E0602
         return False
+    except pywintypes.error as exc:
+        if exc.winerror == 2:
+            return False
+        raise
 
 
 def broadcast_change():
@@ -603,7 +608,7 @@ def delete_key_recursive(hive, key, use_32bit_registry=False):
     key_path = local_key
     access_mask = registry.registry_32[use_32bit_registry] | win32con.KEY_ALL_ACCESS
 
-    if not _key_exists(local_hive, local_key, use_32bit_registry):
+    if not key_exists(local_hive, local_key, use_32bit_registry):
         return False
 
     if (len(key) > 1) and (key.count('\\', 1) < registry.subkey_slash_check[hkey]):

--- a/salt/modules/win_snmp.py
+++ b/salt/modules/win_snmp.py
@@ -45,7 +45,7 @@ def __virtual__():
     if not salt.utils.is_windows():
         return False, 'Module win_snmp: Requires Windows'
 
-    if not __salt__['reg.read_value'](_HKEY, _SNMP_KEY)['success']:
+    if not __salt__['reg.key_exists'](_HKEY, _SNMP_KEY):
         return False, 'Module win_snmp: SNMP not installed'
 
     return __virtualname__

--- a/salt/utils/win_functions.py
+++ b/salt/utils/win_functions.py
@@ -3,7 +3,7 @@
 Various functions to be used by windows during start up and to monkey patch
 missing functions in other modules
 '''
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import
 import platform
 import re
 import ctypes


### PR DESCRIPTION
### What does this PR do?
Exposes the `_key_exists` function in the `reg.py` module as `key_exists`
Fixes an issue where `key_exists` was throwing an error when the key didn't exist
Fixes a problem with the `broadcast_change` function in the `win_functions.py` salt util. It was using `unicode_literals` and those aren't implemented until 2018.3. The `ctypes.WinDLL` function is expecting
a string value, not Unicode
Have the `__virtual__` function for `win_snmp.py` use the `key_exists` function to detect the presence of the SNMP key in the registry. This will fail gracefully if it doesn't exist

### What issues does this PR fix or reference?
https://groups.google.com/forum/#!topic/salt-users/N_ZbLYDlSmA

### Tests written?
No

### Commits signed with GPG?
Yes