### PR TITLE
Fix suse_apache os_family

### DIFF
--- a/salt/modules/suse_apache.py
+++ b/salt/modules/suse_apache.py
@@ -23,7 +23,7 @@ def __virtual__():
     '''
     Only load the module if apache is installed.
     '''
-    if salt.utils.path.which('apache2ctl') and __grains__['os_family'] == 'SUSE':
+    if salt.utils.path.which('apache2ctl') and __grains__['os_family'].upper() == 'SUSE':
         return __virtualname__
     return (False, 'apache execution module not loaded: apache not installed.')
 

--- a/salt/modules/suse_apache.py
+++ b/salt/modules/suse_apache.py
@@ -23,7 +23,7 @@ def __virtual__():
     '''
     Only load the module if apache is installed.
     '''
-    if salt.utils.path.which('apache2ctl') and __grains__['os_family'].upper() == 'SUSE':
+    if salt.utils.path.which('apache2ctl') and __grains__['os_family'] == 'Suse':
         return __virtualname__
     return (False, 'apache execution module not loaded: apache not installed.')
 

--- a/salt/modules/suse_apache.py
+++ b/salt/modules/suse_apache.py
@@ -23,7 +23,7 @@ def __virtual__():
     '''
     Only load the module if apache is installed.
     '''
-    if salt.utils.path.which('apache2ctl') and __grains__['os_family'].upper() == 'SUSE':
+    if salt.utils.path.which('apache2ctl') and __grains__['os_family'] == 'SUSE':
         return __virtualname__
     return (False, 'apache execution module not loaded: apache not installed.')
 


### PR DESCRIPTION
### What does this PR do?
Fixing os_family for SUSE Systems. This was changed from "Suse" to "SUSE" with commit c9d0cdb All systems I was able to check (SLES11SP4, SLES12SP2+3, openSUSE) have "Suse" as os_family, though I went for the ".upper()" way since they may be cases on SUSE systems that I was not able to check and this will work for both cases.
### What issues does this PR fix or reference?

### Previous Behavior
Remove this section if not relevant

### New Behavior
Remove this section if not relevant

### Tests written?

Yes/No

### Commits signed with GPG?

Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
