### PR TITLE
Fix unicode decode error with salt-ssh

### DIFF
--- a/salt/utils/json.py
+++ b/salt/utils/json.py
@@ -128,4 +128,7 @@ def dumps(obj, **kwargs):
         kwargs['ensure_ascii'] = False
     if six.PY2:
         obj = salt.utils.data.encode(obj)
-    return json_module.dumps(obj, **kwargs)  # future lint: blacklisted-function
+    ret = json_module.dumps(obj, **kwargs)  # future lint: blacklisted-function
+    if six.PY2:
+        return ret.decode(__salt_system_encoding__)
+    return ret


### PR DESCRIPTION
### What does this PR do?

with salt-ssh, dumps() is called and the output went in find_json() where
it can produce a decode error. As we encode first to str() we should decode
the output back when we run with python2.

### Tests written?

No

### Commits signed with GPG?

No
