### PR TITLE
Fix various typos

### DIFF
--- a/doc/ref/configuration/master.rst
+++ b/doc/ref/configuration/master.rst
@@ -519,7 +519,7 @@ Default: ``0``
 
 Memcache is an additional cache layer that keeps a limited amount of data
 fetched from the minion data cache for a limited period of time in memory that
-makes cache operations faster. It doesn't make much sence for the ``localfs``
+makes cache operations faster. It doesn't make much sense for the ``localfs``
 cache driver but helps for more complex drivers like ``consul``.
 
 This option sets the memcache items expiration time. By default is set to ``0``

--- a/doc/ref/configuration/proxy.rst
+++ b/doc/ref/configuration/proxy.rst
@@ -108,7 +108,7 @@ The frequency of keepalive checks, in minutes. It requires the
 
 Default: ``True``
 
-Wheter the proxy should maintain the connection with the remote
+Whether the proxy should maintain the connection with the remote
 device. Similarly to :conf_proxy:`proxy_keep_alive`, this option
 is very specific to the design of the proxy module.
 When :conf_proxy:`proxy_always_alive` is set to ``False``,
@@ -126,7 +126,7 @@ has to be closed after every command.
 
 Default: ``False``.
 
-Wheter the pillar data to be merged into the proxy configuration options.
+Whether the pillar data to be merged into the proxy configuration options.
 As multiple proxies can run on the same server, we may need different
 configuration options for each, while there's one single configuration file.
 The solution is merging the pillar data of each proxy minion into the opts.

--- a/doc/ref/internals/fileserver-and-client.rst
+++ b/doc/ref/internals/fileserver-and-client.rst
@@ -6,7 +6,7 @@ The Salt Fileserver and Client
 Introduction
 ------------
 
-Salt has a modular fileserver, and mulitple client classes which are used to
+Salt has a modular fileserver, and multiple client classes which are used to
 interact with it. This page serves as a developer's reference, to help explain
 how the fileserver and clients both work.
 

--- a/doc/ref/states/parallel.rst
+++ b/doc/ref/states/parallel.rst
@@ -12,7 +12,7 @@ option to your state declaration:
       service.running:
         - parallel: True
 
-Now ``nginx`` will be started in a seperate process from the normal state run
+Now ``nginx`` will be started in a separate process from the normal state run
 and will therefore not block additional states.
 
 Parallel States and Requisites

--- a/doc/topics/cloud/aws.rst
+++ b/doc/topics/cloud/aws.rst
@@ -1019,7 +1019,7 @@ so:-
         - AndThirdSecurityGroup
 
 Note that 'subnetid' takes precedence over 'subnetname', but 'securitygroupid'
-and 'securitygroupname' are merged toghether to generate a single list for
+and 'securitygroupname' are merged together to generate a single list for
 SecurityGroups of instances.
 
 Specifying interface properties

--- a/doc/topics/cloud/cloudstack.rst
+++ b/doc/topics/cloud/cloudstack.rst
@@ -156,7 +156,7 @@ security_group
 ~~~~~~~~~~~~~~
 .. versionadded:: next-release
 
-You can specifiy a list of security groups (by name or id) that should be
+You can specify a list of security groups (by name or id) that should be
 assigned to the VM.
 
 .. code-block:: yaml

--- a/doc/topics/development/tests/index.rst
+++ b/doc/topics/development/tests/index.rst
@@ -436,7 +436,7 @@ external resource, like a cloud virtual machine. This decorator is not normally
 used by developers outside of the Salt core team.
 
 `@destructiveTest` -- Marks a test as potentially destructive. It will not be run
-by the test runner unles the ``-run-destructive`` test is expressly passed.
+by the test runner unless the ``-run-destructive`` test is expressly passed.
 
 `@requires_network` -- Requires a network connection for the test to operate
 successfully. If a network connection is not detected, the test will not run.

--- a/doc/topics/development/tests/unit.rst
+++ b/doc/topics/development/tests/unit.rst
@@ -98,7 +98,7 @@ Mocking Loader Modules
 Salt loader modules use a series of globally available dunder variables,
 ``__salt__``, ``__opts__``, ``__pillar__``, etc. To facilitate testing these
 modules a mixin class was created, ``LoaderModuleMockMixin`` which can be found
-in ``tests/support/mixins.py``. The reason for the existance of this class is
+in ``tests/support/mixins.py``. The reason for the existence of this class is
 because historiclly and because it was easier, one would add these dunder
 variables directly on the imported module. This however, introduces unexpected
 behavior when running the full test suite since those attributes would not be

--- a/doc/topics/installation/solaris.rst
+++ b/doc/topics/installation/solaris.rst
@@ -17,4 +17,4 @@ For example, to install the develop version of salt:
 
 .. note::
 
-    SaltStack does offer commerical support for Solaris which includes packages.
+    SaltStack does offer commercial support for Solaris which includes packages.

--- a/doc/topics/jobs/external_cache.rst
+++ b/doc/topics/jobs/external_cache.rst
@@ -18,7 +18,7 @@ and others):
 The major difference between these two mechanism is from where results are
 returned (from the Salt Master or Salt Minion). Configuring either of these
 options will also make the :py:mod:`Jobs Runner functions <salt.runners.jobs>`
-to automatically query the remote stores for infomation.
+to automatically query the remote stores for information.
 
 External Job Cache - Minion-Side Returner
 -----------------------------------------

--- a/doc/topics/reactor/index.rst
+++ b/doc/topics/reactor/index.rst
@@ -68,7 +68,7 @@ and each event tag has a list of reactor SLS files to be run.
 Reactor SLS files are similar to State and Pillar SLS files. They are by
 default YAML + Jinja templates and are passed familiar context variables.
 Click :ref:`here <reactor-jinja-context>` for more detailed information on the
-variables availble in Jinja templating.
+variables available in Jinja templating.
 
 Here is the SLS for a simple reaction:
 
@@ -179,7 +179,7 @@ The below two examples are equivalent:
 |                                 |           fromrepo: updates |
 +---------------------------------+-----------------------------+
 
-This reaction would be equvalent to running the following Salt command:
+This reaction would be equivalent to running the following Salt command:
 
 .. code-block:: bash
 
@@ -230,7 +230,7 @@ The below two examples are equivalent:
 +-------------------------------------------------+-------------------------------------------------+
 
 Assuming that the event tag is ``foo``, and the data passed to the event is
-``{'bar': 'baz'}``, then this reaction is equvalent to running the following
+``{'bar': 'baz'}``, then this reaction is equivalent to running the following
 Salt command:
 
 .. code-block:: bash
@@ -295,7 +295,7 @@ The below two examples are equivalent:
 |         - name: /tmp/foo        |         - /tmp/foo        |
 +---------------------------------+---------------------------+
 
-This reaction is equvalent to running the following Salt command:
+This reaction is equivalent to running the following Salt command:
 
 .. code-block:: bash
 

--- a/doc/topics/releases/2015.5.3.rst
+++ b/doc/topics/releases/2015.5.3.rst
@@ -1251,12 +1251,12 @@ Changes:
 - **PR** `#24456`_: (*rallytime*) Back-port `#24441`_ to 2015.5
   @ *2015-06-05T22:32:25Z*
 
-  - **PR** `#24441`_: (*arthurlogilab*) [doc] Alignement fix on external_auth documentation
+  - **PR** `#24441`_: (*arthurlogilab*) [doc] Alignment fix on external_auth documentation
     | refs: `#24456`_
   * ced558a Merge pull request `#24456`_ from rallytime/`bp-24441`_
   * 7002855 yaml indentations should be 2 spaces
 
-  * 21b51ab [doc] Alignement fix on external_auth documentation
+  * 21b51ab [doc] Alignment fix on external_auth documentation
 
 - **PR** `#24398`_: (*kiorky*) VirtualName for states.apt
   | refs: `#24399`_

--- a/doc/topics/releases/2016.11.4.rst
+++ b/doc/topics/releases/2016.11.4.rst
@@ -21,7 +21,7 @@ Minion Data Cache Fixes
 Added Memcache booster for the minion data cache.
 Memcache is an additional cache layer that keeps a limited amount of data
 fetched from the minion data cache for a limited period of time in memory that
-makes cache operations faster. It doesn't make much sence for the ``localfs``
+makes cache operations faster. It doesn't make much sense for the ``localfs``
 cache driver but helps for more complex drivers like ``consul``.
 For more details see ``memcache_expire_seconds`` and other ``memcache_*``
 options in the master config reverence.

--- a/doc/topics/releases/2016.11.6.rst
+++ b/doc/topics/releases/2016.11.6.rst
@@ -518,7 +518,7 @@ Changes:
 
   * ef8e3ef569 Update win_pki.py
 
-- **PR** `#41557`_: (*dmurphy18*) Add symbolic link for salt-proxy service similar to other serivce files
+- **PR** `#41557`_: (*dmurphy18*) Add symbolic link for salt-proxy service similar to other service files
   @ *2017-06-06T17:13:52Z*
 
   * 3335fcbc7d Merge pull request `#41557`_ from dmurphy18/fix-proxy-service
@@ -753,7 +753,7 @@ Changes:
 
   * 66ab1e5184 Re-adding neutron dependency check
 
-  * cce07eefc2 Updating Neutron module to suport KeystoneAuth
+  * cce07eefc2 Updating Neutron module to support KeystoneAuth
 
 - **PR** `#41409`_: (*garethgreenaway*) Fixes to ipc transport
   @ *2017-05-25T21:06:27Z*
@@ -926,7 +926,7 @@ Changes:
 
   - **ISSUE** `#41306`_: (*lomeroe*) win_lgpo does not properly pack group policy version number in gpt.ini
     | refs: `#41319`_ `#41307`_
-  - **PR** `#41307`_: (*lomeroe*) properly pack/unpack the verison numbers into a number
+  - **PR** `#41307`_: (*lomeroe*) properly pack/unpack the version numbers into a number
     | refs: `#41319`_
   * 140b0427e1 Merge pull request `#41319`_ from lomeroe/bp_41307
   * 4f0aa577a5 backport 41307 to 2016.11, properly pack version numbers into single number

--- a/doc/topics/releases/2016.11.8.rst
+++ b/doc/topics/releases/2016.11.8.rst
@@ -632,7 +632,7 @@ Changes:
   * 3072576 Merge pull request `#42629`_ from xiaoanyunfei/tornadoapi
   * 1e13383 tornado api
 
-- **PR** `#42655`_: (*whiteinge*) Reenable cpstats for rest_cherrypy
+- **PR** `#42655`_: (*whiteinge*) Re-enable cpstats for rest_cherrypy
   @ *2017-08-03T20:44:10Z*
 
   - **PR** `#33806`_: (*cachedout*) Work around upstream cherrypy bug
@@ -640,7 +640,7 @@ Changes:
   * f0f00fc Merge pull request `#42655`_ from whiteinge/rest_cherrypy-reenable-stats
   * deb6316 Fix lint errors
 
-  * 6bd91c8 Reenable cpstats for rest_cherrypy
+  * 6bd91c8 Re-enable cpstats for rest_cherrypy
 
 - **PR** `#42693`_: (*gilbsgilbs*) Fix RabbitMQ tags not properly set.
   @ *2017-08-03T20:23:08Z*
@@ -847,11 +847,11 @@ Changes:
   * 42bb1a6 Merge pull request `#42350`_ from twangboy/win_fix_ver_grains_2016.11
   * 8c04840 Detect Server OS with a desktop release name
 
-- **PR** `#42356`_: (*meaksh*) Allow to check whether a function is available on the AliasesLoader wrapper
+- **PR** `#42356`_: (*meaksh*) Allow checking whether a function is available on the AliasesLoader wrapper
   @ *2017-07-19T16:56:41Z*
 
   * 0a72e56 Merge pull request `#42356`_ from meaksh/2016.11-AliasesLoader-wrapper-fix
-  * 915d942 Allow to check whether a function is available on the AliasesLoader wrapper
+  * 915d942 Allow checking whether a function is available on the AliasesLoader wrapper
 
 - **PR** `#42368`_: (*twangboy*) Remove build and dist directories before install (2016.11)
   @ *2017-07-19T16:47:28Z*
@@ -1392,7 +1392,7 @@ Changes:
 
   * 7f69613 test and lint fixes
 
-  * 8ee4843 Suppress output of crypt context and be more specifc with whitespace vs. serial
+  * 8ee4843 Suppress output of crypt context and be more specific with whitespace vs. serial
 
   * 61f817d Match serials based on output position (fix for non-English languages)
 

--- a/doc/topics/releases/2016.11.9.rst
+++ b/doc/topics/releases/2016.11.9.rst
@@ -29,7 +29,7 @@ Significate changes (PR #43708 & #45390, damon-atkins) have been made to the pkg
 - ``pkg.install`` without a ``version`` parameter no longer upgrades software if the software is already installed. Use ``pkg.install version=latest`` or in a state use ``pkg.latest`` to get the old behavior. 
 - ``pkg.list_pkgs`` now returns multiple versions if software installed more than once.
 - ``pkg.list_pkgs`` now returns 'Not Found' when the version is not found instead of '(value not set)' which matches the contents of the sls definitions.
-- ``pkg.remove()`` will wait upto 3 seconds (normally about a second) to detect changes in the registry after removing software, improving reporting of version changes.
+- ``pkg.remove()`` will wait up to 3 seconds (normally about a second) to detect changes in the registry after removing software, improving reporting of version changes.
 - ``pkg.remove()`` can remove ``latest`` software, if ``latest`` is defined in sls definition.
 - Documentation was update for the execution module to match the style in new versions, some corrections as well.
 - All install/remove commands are prefix with cmd.exe shell and cmdmod is called with a command line string instead of a list. Some sls files in saltstack/salt-winrepo-ng expected the commands to be prefixed with cmd.exe (i.e. the use of ``&``).
@@ -407,7 +407,7 @@ Windows cmdmod forcing cmd to be a list (issue #43522) resolved by "cmdmod: Don'
   @ *2017-11-28T21:50:19Z*
 
   * 998d714ee7 Merge pull request `#44517`_ from whytewolf/publish_port_doc_missing
-  * 4b5855283a missed one place where i didnt chanbge master_port from my copy to publish_port
+  * 4b5855283a missed one place where i didn't change master_port from my copy to publish_port
 
   * e4610baea5 update doc to have publish port
 
@@ -598,7 +598,7 @@ Windows cmdmod forcing cmd to be a list (issue #43522) resolved by "cmdmod: Don'
   @ *2017-10-31T17:56:34Z*
 
   * cab54e34b5 Merge pull request `#44173`_ from twangboy/win_system_docs
-  * 8e111b413d Fix some of the wording and grammer errors
+  * 8e111b413d Fix some of the wording and grammar errors
 
   * a12bc5ae41 Use google style docstrings
 
@@ -831,7 +831,7 @@ Windows cmdmod forcing cmd to be a list (issue #43522) resolved by "cmdmod: Don'
 
   - **ISSUE** `#43581`_: (*jcourington*) cherrypy stats issue
     | refs: `#44021`_
-  - **PR** `#42655`_: (*whiteinge*) Reenable cpstats for rest_cherrypy
+  - **PR** `#42655`_: (*whiteinge*) Re-enable cpstats for rest_cherrypy
     | refs: `#44021`_
   - **PR** `#33806`_: (*cachedout*) Work around upstream cherrypy bug
     | refs: `#42655`_
@@ -1001,13 +1001,13 @@ Windows cmdmod forcing cmd to be a list (issue #43522) resolved by "cmdmod: Don'
   * ea8d273c2b Merge pull request `#43768`_ from vutny/fix-pylint-deprecation-warnings
   * f8b3fa9da1 Merge branch '2016.11' into fix-pylint-deprecation-warnings
 
-- **PR** `#43772`_: (*gtmanfred*) dont print Minion not responding with quiet
+- **PR** `#43772`_: (*gtmanfred*) don't print Minion not responding with quiet
   @ *2017-09-27T15:39:18Z*
 
   - **ISSUE** `#40311`_: (*cralston0*) --hide-timeout used with --output json --static produces unparseable JSON
     | refs: `#43772`_
   * 1a8cc60bb4 Merge pull request `#43772`_ from gtmanfred/2016.11
-  * 0194c60960 dont print Minion not responding with quiet
+  * 0194c60960 don't print Minion not responding with quiet
 
 - **PR** `#43747`_: (*rallytime*) Add GPG Verification section to Contributing Docs
   @ *2017-09-26T21:25:37Z*

--- a/doc/topics/releases/2017.7.0.rst
+++ b/doc/topics/releases/2017.7.0.rst
@@ -41,7 +41,7 @@ Salt's policy has always been that when upgrading, the minion should never be
 on a newer version than the master.  Specifically with this update, because of
 changes in the fileclient, the 2017.7 minion requires a 2017.7 master.
 
-Backwards compatiblity is still maintained, so older minions can still be used.
+Backwards compatibility is still maintained, so older minions can still be used.
 
 More information can be found in the :ref:`Salt FAQ<which-version>`
 
@@ -54,7 +54,7 @@ The :py:func:`service.masked <salt.states.service.masked>` and
 added to allow Salt to manage masking of systemd units.
 
 Additionally, the following functions in the :mod:`systemd
-<salt.modules.systemd>` execution module have changed to accomodate the fact
+<salt.modules.systemd>` execution module have changed to accommodate the fact
 that indefinite and runtime masks can co-exist for the same unit:
 
 - :py:func:`service.masked <salt.modules.systemd.masked>` - The return from
@@ -152,7 +152,7 @@ State Module Changes
 
   In a rare case that you have a function that needs to be called several times but
   with the different parameters, an additional feature of "tagging" is to the
-  rescue. In order to tag a function, use a colon delimeter. For example:
+  rescue. In order to tag a function, use a colon delimiter. For example:
 
   .. code-block:: yaml
 
@@ -281,7 +281,7 @@ Minion Configuration Additions
 salt-api Changes
 ================
 
-The ``rest_cherrypy`` netapi module has recieved a few minor improvements:
+The ``rest_cherrypy`` netapi module has received a few minor improvements:
 
 * A CORS bugfix.
 * A new ``/token`` convenience endpoint to generate Salt eauth tokens.
@@ -557,7 +557,7 @@ of objects (users, databases, roles, etc.).
 .. note::
     With the `Moby announcement`_ coming at this year's DockerCon_, Salt's
     :mod:`docker <salt.modules.dockermod>` execution module (as well as the
-    state modules) work interchangably when **docker** is replaced with
+    state modules) work interchangeably when **docker** is replaced with
     **moby** (e.g.  :py:func:`moby_container.running
     <salt.states.docker_container.running>`, :py:func:`moby_image.present
     <salt.states.docker_image.present>`, :py:func:`moby.inspect_container

--- a/doc/topics/releases/2017.7.2.rst
+++ b/doc/topics/releases/2017.7.2.rst
@@ -962,7 +962,7 @@ Changes
 - **PR** `#42884`_: (*Giandom*) Convert to dict type the pillar string value passed from slack
   @ *2017-08-16T22:30:43Z*
 
-  - **ISSUE** `#42842`_: (*Giandom*) retreive kwargs passed with slack engine
+  - **ISSUE** `#42842`_: (*Giandom*) retrieve kwargs passed with slack engine
     | refs: `#42884`_
   * 82be9dceb6 Merge pull request `#42884`_ from Giandom/2017.7.1-fix-slack-engine-pillar-args
   * 80fd733c99 Update slack.py
@@ -1235,13 +1235,13 @@ Changes
   * 4ce96eb1a1 Merge pull request `#42778`_ from gtmanfred/spm
   * 7ef691e8da make sure to use the correct out_file
 
-- **PR** `#42857`_: (*gtmanfred*) use older name if _create_unverified_context is unvailable
+- **PR** `#42857`_: (*gtmanfred*) use older name if _create_unverified_context is unavailable
   @ *2017-08-11T13:37:59Z*
 
   - **ISSUE** `#480`_: (*zyluo*) PEP8 types clean-up
     | refs: `#42857`_
   * 3d05d89e09 Merge pull request `#42857`_ from gtmanfred/vmware
-  * c1f673eca4 use older name if _create_unverified_context is unvailable
+  * c1f673eca4 use older name if _create_unverified_context is unavailable
 
 - **PR** `#42866`_: (*twangboy*) Change to GitPython version 2.1.1
   @ *2017-08-11T13:23:52Z*
@@ -1448,7 +1448,7 @@ Changes
     | refs: `#42574`_
   - **PR** `#42693`_: (*gilbsgilbs*) Fix RabbitMQ tags not properly set.
   - **PR** `#42669`_: (*garethgreenaway*)  [2016.11] Fixes to augeas module
-  - **PR** `#42655`_: (*whiteinge*) Reenable cpstats for rest_cherrypy
+  - **PR** `#42655`_: (*whiteinge*) Re-enable cpstats for rest_cherrypy
   - **PR** `#42629`_: (*xiaoanyunfei*) tornado api
   - **PR** `#42623`_: (*terminalmage*) Fix unicode constructor in custom YAML loader
   - **PR** `#42574`_: (*sbojarski*) Fixed error reporting in "boto_cfn.present" function.
@@ -1469,7 +1469,7 @@ Changes
 
       * deb6316d67 Fix lint errors
 
-      * 6bd91c8b03 Reenable cpstats for rest_cherrypy
+      * 6bd91c8b03 Re-enable cpstats for rest_cherrypy
 
     * 21cf15f9c3 Merge pull request `#42693`_ from gilbsgilbs/fix-rabbitmq-tags
 
@@ -2031,7 +2031,7 @@ Changes
   - **PR** `#42368`_: (*twangboy*) Remove build and dist directories before install (2016.11)
   - **PR** `#42360`_: (*Ch3LL*) [2016.11] Update version numbers in doc config for 2017.7.0 release
   - **PR** `#42359`_: (*Ch3LL*) [2016.3] Update version numbers in doc config for 2017.7.0 release
-  - **PR** `#42356`_: (*meaksh*) Allow to check whether a function is available on the AliasesLoader wrapper
+  - **PR** `#42356`_: (*meaksh*) Allow checking whether a function is available on the AliasesLoader wrapper
   - **PR** `#42352`_: (*CorvinM*) Multiple documentation fixes
   - **PR** `#42350`_: (*twangboy*) Fixes problem with Version and OS Release related grains on certain versions of Python (2016.11)
   - **PR** `#42319`_: (*rallytime*) Add more documentation for config options that are missing from master/minion docs
@@ -2046,7 +2046,7 @@ Changes
 
     * 0a72e56f6b Merge pull request `#42356`_ from meaksh/2016.11-AliasesLoader-wrapper-fix
 
-      * 915d94219e Allow to check whether a function is available on the AliasesLoader wrapper
+      * 915d94219e Allow checking whether a function is available on the AliasesLoader wrapper
 
     * 10eb7b7a79 Merge pull request `#42368`_ from twangboy/win_fix_build_2016.11
 

--- a/doc/topics/releases/2017.7.3.rst
+++ b/doc/topics/releases/2017.7.3.rst
@@ -30,7 +30,7 @@ Significate changes (PR #43708 & #45390, damon-atkins) have been made to the pkg
 - ``pkg.install`` without a ``version`` parameter no longer upgrades software if the software is already installed. Use ``pkg.install version=latest`` or in a state use ``pkg.latest`` to get the old behavior. 
 - ``pkg.list_pkgs`` now returns multiple versions if software installed more than once.
 - ``pkg.list_pkgs`` now returns 'Not Found' when the version is not found instead of '(value not set)' which matches the contents of the sls definitions.
-- ``pkg.remove()`` will wait upto 3 seconds (normally about a second) to detect changes in the registry after removing software, improving reporting of version changes.
+- ``pkg.remove()`` will wait up to 3 seconds (normally about a second) to detect changes in the registry after removing software, improving reporting of version changes.
 - ``pkg.remove()`` can remove ``latest`` software, if ``latest`` is defined in sls definition.
 - Documentation was update for the execution module to match the style in new versions, some corrections as well.
 - All install/remove commands are prefix with cmd.exe shell and cmdmod is called with a command line string instead of a list. Some sls files in saltstack/salt-winrepo-ng expected the commands to be prefixed with cmd.exe (i.e. the use of ``&``).
@@ -69,7 +69,7 @@ Windows cmdmod forcing cmd to be a list (issue #43522) resolved by "cmdmod: Don'
 - **PR** `#45664`_: (*rallytime*) Back-port `#45452`_ to 2017.7.3
   @ *2018-01-24T15:33:13Z*
 
-  - **PR** `#45452`_: (*adelcast*) opkg.py: make owner fuction return value, instead of iterator
+  - **PR** `#45452`_: (*adelcast*) opkg.py: make owner function return value, instead of iterator
     | refs: `#45664`_
   * 0717f7a578 Merge pull request `#45664`_ from rallytime/`bp-45452`_
   * 369720677b opkg.py: make owner function return value, instead of iterator
@@ -359,7 +359,7 @@ Windows cmdmod forcing cmd to be a list (issue #43522) resolved by "cmdmod: Don'
   * 66da9b47bc Merge pull request `#45299`_ from garethgreenaway/config_gate_auth_events
   * 9a15ec3430 Updating versionadded string.  Fixing typo.
 
-  * edfc3dc078 Adding in documention for `auth_events` configuration option
+  * edfc3dc078 Adding in documentation for `auth_events` configuration option
 
   * 3ee4eabffd Fixing small typo
 
@@ -1007,7 +1007,7 @@ Windows cmdmod forcing cmd to be a list (issue #43522) resolved by "cmdmod: Don'
 
   * 4b60b1ec84 Merge remote branch 'refs/remotes/upstream/2017.7' into 2017.7_replace_with_newer_2016.11_win_pkg
 
-  * b46f818a57 Raise a PR to fix 2016 issues commited here, fixed issues with merge.
+  * b46f818a57 Raise a PR to fix 2016 issues committed here, fixed issues with merge.
 
   * 32ef1e12ae Merge branch '2017.7' into 2017.7_replace_with_newer_2016.11_win_pkg
 
@@ -1362,7 +1362,7 @@ Windows cmdmod forcing cmd to be a list (issue #43522) resolved by "cmdmod: Don'
 
     * 998d714ee7 Merge pull request `#44517`_ from whytewolf/publish_port_doc_missing
 
-      * 4b5855283a missed one place where i didnt chanbge master_port from my copy to publish_port
+      * 4b5855283a missed one place where i didn't change master_port from my copy to publish_port
 
       * e4610baea5 update doc to have publish port
 
@@ -1569,9 +1569,9 @@ Windows cmdmod forcing cmd to be a list (issue #43522) resolved by "cmdmod: Don'
 
   * 3bb385b44e removing debugging logging
 
-  * 7f0ff5a8b0 When passing IDs on the command line convert them all the strings for later comparision.
+  * 7f0ff5a8b0 When passing IDs on the command line convert them all the strings for later comparison.
 
-  * 99e436add4 When looking for job ids to remove based on the tag_name the comparision was comparing an INT to a STR, so the correct job id was not being returned.
+  * 99e436add4 When looking for job ids to remove based on the tag_name the comparison was comparing an INT to a STR, so the correct job id was not being returned.
 
 - **PR** `#44695`_: (*gtmanfred*) pop None for runas and runas_password
   @ *2017-12-01T14:35:01Z*
@@ -1714,7 +1714,7 @@ Windows cmdmod forcing cmd to be a list (issue #43522) resolved by "cmdmod: Don'
 
     * 88ef9f18fc ignore lint error on import
 
-    * 25427d845e convert key iterator to list as python 3 wont index an iterator
+    * 25427d845e convert key iterator to list as python 3 won't index an iterator
 
   * bce50154e5 Merge branch '2017.7' into improve-net-load
 
@@ -1773,13 +1773,13 @@ Windows cmdmod forcing cmd to be a list (issue #43522) resolved by "cmdmod: Don'
 
                   * c6733ac1ee pop None
 
-- **PR** `#44616`_: (*Ch3LL*) Add Non Base Environement salt:// source integration test
+- **PR** `#44616`_: (*Ch3LL*) Add Non Base Environment salt:// source integration test
   @ *2017-11-22T16:13:54Z*
 
   * d6ccf4bb30 Merge pull request `#44616`_ from Ch3LL/nonbase_test
   * 80b71652e3 Merge branch '2017.7' into nonbase_test
 
-  * c9ba33432e Add Non Base Environement salt:// source integration test
+  * c9ba33432e Add Non Base Environment salt:// source integration test
 
 - **PR** `#44617`_: (*Ch3LL*) Add ssh thin_dir integration test
   @ *2017-11-22T16:12:51Z*
@@ -1896,7 +1896,7 @@ Windows cmdmod forcing cmd to be a list (issue #43522) resolved by "cmdmod: Don'
   * 1643bb7fd4 Merge pull request `#44551`_ from cloudflare/annoying-tmpnam
   * ce1882943d Use salt.utils.files.mkstemp() instead
 
-  * 6689bd3b2d Dont use dangerous os.tmpnam
+  * 6689bd3b2d Don't use dangerous os.tmpnam
 
   * 2d6176b0bc Fx2 proxy minion: clean return, like all the other modules
 
@@ -2151,7 +2151,7 @@ Windows cmdmod forcing cmd to be a list (issue #43522) resolved by "cmdmod: Don'
 
   * cab54e34b5 Merge pull request `#44173`_ from twangboy/win_system_docs
 
-    * 8e111b413d Fix some of the wording and grammer errors
+    * 8e111b413d Fix some of the wording and grammar errors
 
     * a12bc5ae41 Use google style docstrings
 
@@ -2728,7 +2728,7 @@ Windows cmdmod forcing cmd to be a list (issue #43522) resolved by "cmdmod: Don'
   @ *2017-10-17T15:24:19Z*
 
   * 6252f82f58 Merge pull request `#44133`_ from cachedout/fix_paralell_docs
-  * 8d1c1e21f0 Fix typos in paralell states docs
+  * 8d1c1e21f0 Fix typos in parallel states docs
 
 - **PR** `#44135`_: (*timfreund*) Insert missing verb in gitfs walkthrough
   @ *2017-10-17T14:32:13Z*
@@ -2814,7 +2814,7 @@ Windows cmdmod forcing cmd to be a list (issue #43522) resolved by "cmdmod: Don'
   - **PR** `#44021`_: (*whiteinge*) Also catch cpstats AttributeError for bad CherryPy release ~5.6.0
   - **PR** `#44010`_: (*Ch3LL*) Security Fixes for 2016.3.8
   - **PR** `#43977`_: (*Ch3LL*) Add Security Notes to 2016.3.8 Release Notes
-  - **PR** `#42655`_: (*whiteinge*) Reenable cpstats for rest_cherrypy
+  - **PR** `#42655`_: (*whiteinge*) Re-enable cpstats for rest_cherrypy
     | refs: `#44021`_
   - **PR** `#33806`_: (*cachedout*) Work around upstream cherrypy bug
     | refs: `#42655`_
@@ -3286,7 +3286,7 @@ Windows cmdmod forcing cmd to be a list (issue #43522) resolved by "cmdmod: Don'
 
   - **ISSUE** `#40311`_: (*cralston0*) --hide-timeout used with --output json --static produces unparseable JSON
     | refs: `#43772`_
-  - **PR** `#43772`_: (*gtmanfred*) dont print Minion not responding with quiet
+  - **PR** `#43772`_: (*gtmanfred*) don't print Minion not responding with quiet
   - **PR** `#43747`_: (*rallytime*) Add GPG Verification section to Contributing Docs
   * 9615ca32d5 Merge pull request `#43773`_ from rallytime/merge-2017.7
   * f7035ed7da Merge branch '2017.7' into merge-2017.7
@@ -3295,7 +3295,7 @@ Windows cmdmod forcing cmd to be a list (issue #43522) resolved by "cmdmod: Don'
 
     * 1a8cc60bb4 Merge pull request `#43772`_ from gtmanfred/2016.11
 
-      * 0194c60960 dont print Minion not responding with quiet
+      * 0194c60960 don't print Minion not responding with quiet
 
     * 9dee896fb9 Merge pull request `#43747`_ from rallytime/gpg-verification
 

--- a/doc/topics/spm/spm_formula.rst
+++ b/doc/topics/spm/spm_formula.rst
@@ -178,7 +178,7 @@ that the text following it can be evaluated properly.
 
 local States
 ~~~~~~~~~~~~
-``local`` states are evaluated locally; this is analagous to issuing a state
+``local`` states are evaluated locally; this is analogous to issuing a state
 run using a ``salt-call --local`` command. These commands will be issued on the
 local machine running the ``spm`` command, whether that machine is a master or
 a minion.

--- a/pkg/suse/salt.changes
+++ b/pkg/suse/salt.changes
@@ -1042,7 +1042,7 @@ Thu Sep 19 17:18:06 UTC 2013 - aboe76@gmail.com
      * salt-ssh requires sshpass
      * salt-syndic requires salt-master
   Minor features:
-  - 0.17.0 release wil be last release for 0.XX.X numbering system
+  - 0.17.0 release will be last release for 0.XX.X numbering system
     Next release will be <Year>.<Month>.<Minor>
 
 -------------------------------------------------------------------

--- a/salt/beacons/diskusage.py
+++ b/salt/beacons/diskusage.py
@@ -79,7 +79,7 @@ def beacon(config):
     The second one will match disks from A:\ to Z:\ on a Windows system
 
     Note that if a regular expression are evaluated after static mount points,
-    which means that if a regular expression matches an other defined mount point,
+    which means that if a regular expression matches another defined mount point,
     it will override the previously defined threshold.
 
     '''

--- a/salt/beacons/load.py
+++ b/salt/beacons/load.py
@@ -113,7 +113,7 @@ def beacon(config):
             for k in ['1m', '5m', '15m']:
                 LAST_STATUS[k] = avg_dict[k]
             if not config['emitatstartup']:
-                log.debug('Dont emit because emitatstartup is False')
+                log.debug("Don't emit because emitatstartup is False")
                 return ret
 
     send_beacon = False

--- a/salt/cache/redis_cache.py
+++ b/salt/cache/redis_cache.py
@@ -333,7 +333,7 @@ def flush(bank, key=None):
     An improvement for this would be loading a custom Lua script in the Redis instance of the user
     (using the ``register_script`` feature) and call it whenever we flush.
     This script would only need to build this sub-tree causing problems. It can be added later and the behaviour
-    should not change as the user needs to explicitely allow Salt inject scripts in their Redis instance.
+    should not change as the user needs to explicitly allow Salt inject scripts in their Redis instance.
     '''
     redis_server = _get_redis_server()
     redis_pipe = redis_server.pipeline()

--- a/salt/client/ssh/ssh_py_shim.py
+++ b/salt/client/ssh/ssh_py_shim.py
@@ -101,7 +101,7 @@ def is_windows():
 def need_deployment():
     """
     Salt thin needs to be deployed - prep the target directory and emit the
-    delimeter and exit code that signals a required deployment.
+    delimiter and exit code that signals a required deployment.
     """
     if os.path.exists(OPTIONS.saltdir):
         shutil.rmtree(OPTIONS.saltdir)

--- a/salt/engines/hipchat.py
+++ b/salt/engines/hipchat.py
@@ -235,13 +235,13 @@ def start(token,
             - ``html``: send the output as HTML
             - ``code``: send the output as code
 
-        This can be overriden when executing a command, using the ``--out-type`` argument.
+        This can be overridden when executing a command, using the ``--out-type`` argument.
 
         .. versionadded:: 2017.7.0
 
     outputter: ``nested``
         The format to display the data, using the outputters available on the CLI.
-        This argument can also be overriden when executing a command, using the ``--out`` option.
+        This argument can also be overridden when executing a command, using the ``--out`` option.
 
         .. versionadded:: 2017.7.0
 

--- a/salt/fileserver/__init__.py
+++ b/salt/fileserver/__init__.py
@@ -536,7 +536,7 @@ class Fileserver(object):
         if '../' in path:
             return fnd
         if salt.utils.url.is_escaped(path):
-            # don't attempt to find URL query arguements in the path
+            # don't attempt to find URL query arguments in the path
             path = salt.utils.url.unescape(path)
         else:
             if '?' in path:

--- a/salt/grains/napalm.py
+++ b/salt/grains/napalm.py
@@ -326,7 +326,7 @@ def host(proxy=None):
 
     .. note::
 
-        The diference betwen ``host`` and ``hostname`` is that
+        The diference between ``host`` and ``hostname`` is that
         ``host`` provides the physical location - either domain name or IP address,
         while ``hostname`` provides the hostname as configured on the device.
         They are not necessarily the same.

--- a/salt/modules/bcache.py
+++ b/salt/modules/bcache.py
@@ -927,7 +927,7 @@ def _wipe(dev):
 def _wait(lfunc, log_lvl=None, log_msg=None, tries=10):
     '''
     Wait for lfunc to be True
-    :return: True if lfunc succeeded within tries, False if it didnt
+    :return: True if lfunc succeeded within tries, False if it didn't
     '''
     i = 0
     while i < tries:

--- a/salt/modules/boto_vpc.py
+++ b/salt/modules/boto_vpc.py
@@ -2634,7 +2634,7 @@ def _maybe_set_tags(tags, obj):
 def _maybe_set_dns(conn, vpcid, dns_support, dns_hostnames):
     if dns_support:
         conn.modify_vpc_attribute(vpc_id=vpcid, enable_dns_support=dns_support)
-        log.debug('DNS spport was set to: {0} on vpc {1}'.format(dns_support, vpcid))
+        log.debug('DNS support was set to: {0} on vpc {1}'.format(dns_support, vpcid))
     if dns_hostnames:
         conn.modify_vpc_attribute(vpc_id=vpcid, enable_dns_hostnames=dns_hostnames)
         log.debug('DNS hostnames was set to: {0} on vpc {1}'.format(dns_hostnames, vpcid))

--- a/salt/modules/capirca_acl.py
+++ b/salt/modules/capirca_acl.py
@@ -424,7 +424,7 @@ def _merge_list_of_dict(first, second, prepend=True):
     if first and not second:
         return first
     # Determine overlaps
-    # So we dont change the position of the existing terms/filters
+    # So we don't change the position of the existing terms/filters
     overlaps = []
     merged = []
     appended = []

--- a/salt/modules/dockermod.py
+++ b/salt/modules/dockermod.py
@@ -5454,7 +5454,7 @@ def sls_build(name, base='opensuse/python', mods=None, saltenv='base',
         the salt environment to use
 
     dryrun: False
-        when set to True the container will not be commited at the end of
+        when set to True the container will not be committed at the end of
         the build. The dryrun succeed also when the state contains errors.
 
     **RETURN DATA**

--- a/salt/modules/etcd_mod.py
+++ b/salt/modules/etcd_mod.py
@@ -215,7 +215,7 @@ def rm_(key, recurse=False, profile=None):
     '''
     .. versionadded:: 2014.7.0
 
-    Delete a key from etcd.  Returns True if the key was deleted, False if it wasn
+    Delete a key from etcd.  Returns True if the key was deleted, False if it was
     not and None if there was a failure.
 
     CLI Example:

--- a/salt/modules/glusterfs.py
+++ b/salt/modules/glusterfs.py
@@ -124,7 +124,7 @@ def peer_status():
     The return value is a dictionary with peer UUIDs as keys and dicts of peer
     information as values. Hostnames are listed in one list. GlusterFS separates
     one of the hostnames but the only reason for this seems to be which hostname
-    happens to be used firts in peering.
+    happens to be used first in peering.
 
     CLI Example:
 

--- a/salt/modules/heat.py
+++ b/salt/modules/heat.py
@@ -223,7 +223,7 @@ def _parse_template(tmpl_str):
     return tpl
 
 
-def _parse_enviroment(env_str):
+def _parse_environment(env_str):
     '''
     Parsing template
     '''
@@ -460,9 +460,9 @@ def delete_stack(name=None, poll=0, timeout=60, profile=None):
     return ret
 
 
-def create_stack(name=None, template_file=None, enviroment=None,
+def create_stack(name=None, template_file=None, environment=None,
                  parameters=None, poll=0, rollback=False, timeout=60,
-                 profile=None):
+                 profile=None, enviroment=None):
     '''
     Create a stack (heat stack-create)
 
@@ -472,8 +472,8 @@ def create_stack(name=None, template_file=None, enviroment=None,
     template_file
         File of template
 
-    enviroment
-        File of enviroment
+    environment
+        File of environment
 
     parameters
         Parameter dict used to create the stack
@@ -496,11 +496,23 @@ def create_stack(name=None, template_file=None, enviroment=None,
 
         salt '*' heat.create_stack name=mystack \\
                  template_file=salt://template.yaml \\
-                 enviroment=salt://enviroment.yaml \\
+                 environment=salt://environment.yaml \\
                  parameters="{"image": "Debian 8", "flavor": "m1.small"}" \\
                  poll=5 rollback=False timeout=60 profile=openstack1
 
+    .. versionadded:: 2017.7.5,2018.3.1
+
+        The spelling mistake in parameter `enviroment` was corrected to `environment`.
+        The misspelled version is still supported for backward compatibility, but will
+        be removed in Salt Neon.
+
     '''
+    if environment is None and enviroment is not None:
+        salt.utils.warn_until('Neon', (
+            "Please use the 'environment' parameter instead of the misspelled 'enviroment' "
+            "parameter which will be removed in Salt Neon."
+        ))
+        environment = enviroment
     h_client = _auth(profile)
     ret = {
         'result': True,
@@ -570,12 +582,12 @@ def create_stack(name=None, template_file=None, enviroment=None,
         ret['comment'] = 'Template not valid {0}'.format(ex)
         return ret
     env = {}
-    if enviroment:
-        enviroment_tmp_file = salt.utils.files.mkstemp()
+    if environment:
+        environment_tmp_file = salt.utils.files.mkstemp()
         esfn, source_sum, comment_ = __salt__['file.get_managed'](
-            name=enviroment_tmp_file,
+            name=environment_tmp_file,
             template=None,
-            source=enviroment,
+            source=environment,
             source_hash=None,
             user=None,
             group=None,
@@ -586,11 +598,11 @@ def create_stack(name=None, template_file=None, enviroment=None,
             skip_verify=False,
             kwargs=None)
 
-        enviroment_manage_result = __salt__['file.manage_file'](
-            name=enviroment_tmp_file,
+        environment_manage_result = __salt__['file.manage_file'](
+            name=environment_tmp_file,
             sfn=esfn,
             ret=None,
-            source=enviroment,
+            source=environment,
             source_sum=source_sum,
             user=None,
             group=None,
@@ -602,18 +614,18 @@ def create_stack(name=None, template_file=None, enviroment=None,
             show_changes=False,
             contents=None,
             dir_mode=None)
-        if enviroment_manage_result['result']:
-            with salt.utils.fopen(enviroment_tmp_file, 'r') as efp_:
+        if environment_manage_result['result']:
+            with salt.utils.fopen(environment_tmp_file, 'r') as efp_:
                 env_str = efp_.read()
-                salt.utils.safe_rm(enviroment_tmp_file)
+                salt.utils.safe_rm(environment_tmp_file)
                 try:
-                    env = _parse_enviroment(env_str)
+                    env = _parse_environment(env_str)
                 except ValueError as ex:
                     ret['result'] = False
                     ret['comment'] = 'Error parsing template {0}'.format(ex)
         else:
             ret['result'] = False
-            ret['comment'] = 'Can not open enviroment: {0}, {1}'.format(enviroment, comment_)
+            ret['comment'] = 'Can not open environment: {0}, {1}'.format(environment, comment_)
     if ret['result'] is False:
         return ret
 
@@ -645,9 +657,9 @@ def create_stack(name=None, template_file=None, enviroment=None,
     return ret
 
 
-def update_stack(name=None, template_file=None, enviroment=None,
+def update_stack(name=None, template_file=None, environment=None,
                  parameters=None, poll=0, rollback=False, timeout=60,
-                 profile=None):
+                 profile=None, enviroment=None):
     '''
     Update a stack (heat stack-template)
 
@@ -657,8 +669,8 @@ def update_stack(name=None, template_file=None, enviroment=None,
     template_file
         File of template
 
-    enviroment
-        File of enviroment
+    environment
+        File of environment
 
     parameters
         Parameter dict used to update the stack
@@ -681,11 +693,23 @@ def update_stack(name=None, template_file=None, enviroment=None,
 
         salt '*' heat.update_stack name=mystack \\
                  template_file=salt://template.yaml \\
-                 enviroment=salt://enviroment.yaml \\
+                 environment=salt://environment.yaml \\
                  parameters="{"image": "Debian 8", "flavor": "m1.small"}" \\
                  poll=5 rollback=False timeout=60 profile=openstack1
 
+    .. versionadded:: 2017.7.5,2018.3.1
+
+        The spelling mistake in parameter `enviroment` was corrected to `environment`.
+        The misspelled version is still supported for backward compatibility, but will
+        be removed in Salt Neon.
+
     '''
+    if environment is None and enviroment is not None:
+        salt.utils.warn_until('Neon', (
+            "Please use the 'environment' parameter instead of the misspelled 'enviroment' "
+            "parameter which will be removed in Salt Neon."
+        ))
+        environment = enviroment
     h_client = _auth(profile)
     ret = {
         'result': True,
@@ -759,12 +783,12 @@ def update_stack(name=None, template_file=None, enviroment=None,
         ret['comment'] = 'Template not valid {0}'.format(ex)
         return ret
     env = {}
-    if enviroment:
-        enviroment_tmp_file = salt.utils.files.mkstemp()
+    if environment:
+        environment_tmp_file = salt.utils.files.mkstemp()
         esfn, source_sum, comment_ = __salt__['file.get_managed'](
-            name=enviroment_tmp_file,
+            name=environment_tmp_file,
             template=None,
-            source=enviroment,
+            source=environment,
             source_hash=None,
             user=None,
             group=None,
@@ -775,11 +799,11 @@ def update_stack(name=None, template_file=None, enviroment=None,
             skip_verify=False,
             kwargs=None)
 
-        enviroment_manage_result = __salt__['file.manage_file'](
-            name=enviroment_tmp_file,
+        environment_manage_result = __salt__['file.manage_file'](
+            name=environment_tmp_file,
             sfn=esfn,
             ret=None,
-            source=enviroment,
+            source=environment,
             source_sum=source_sum,
             user=None,
             group=None,
@@ -791,18 +815,18 @@ def update_stack(name=None, template_file=None, enviroment=None,
             show_changes=False,
             contents=None,
             dir_mode=None)
-        if enviroment_manage_result['result']:
-            with salt.utils.fopen(enviroment_tmp_file, 'r') as efp_:
+        if environment_manage_result['result']:
+            with salt.utils.fopen(environment_tmp_file, 'r') as efp_:
                 env_str = efp_.read()
-                salt.utils.safe_rm(enviroment_tmp_file)
+                salt.utils.safe_rm(environment_tmp_file)
                 try:
-                    env = _parse_enviroment(env_str)
+                    env = _parse_environment(env_str)
                 except ValueError as ex:
                     ret['result'] = False
                     ret['comment'] = 'Error parsing template {0}'.format(ex)
         else:
             ret['result'] = False
-            ret['comment'] = 'Can not open enviroment: {0}, {1}'.format(enviroment, comment_)
+            ret['comment'] = 'Can not open environment: {0}, {1}'.format(environment, comment_)
     if ret['result'] is False:
         return ret
 

--- a/salt/modules/junos.py
+++ b/salt/modules/junos.py
@@ -589,7 +589,7 @@ def ping(dest_ip=None, **kwargs):
 def cli(command=None, format='text', **kwargs):
     '''
     Executes the CLI commands and returns the output in specified format. \
-    (default is text) The ouput can also be stored in a file.
+    (default is text) The output can also be stored in a file.
 
     Usage:
 

--- a/salt/modules/kubernetes.py
+++ b/salt/modules/kubernetes.py
@@ -17,7 +17,7 @@ Module for handling kubernetes calls.
         kubernetes.client-key-file: '/path/to/client.key'
 
 
-These settings can be also overrided by adding `api_url`, `api_user`,
+These settings can be also overridden by adding `api_url`, `api_user`,
 `api_password`, `api_certificate_authority_file`, `api_client_certificate_file`
 or `api_client_key_file` parameters when calling a function:
 
@@ -25,7 +25,7 @@ The data format for `kubernetes.*-data` values is the same as provided in `kubec
 It's base64 encoded certificates/keys in one line.
 
 For an item only one field should be provided. Either a `data` or a `file` entry.
-In case both are provided the `file` entry is prefered.
+In case both are provided the `file` entry is preferred.
 
 .. code-block:: bash
     salt '*' kubernetes.nodes api_url=http://k8s-api-server:port api_user=myuser api_password=pass

--- a/salt/modules/logmod.py
+++ b/salt/modules/logmod.py
@@ -18,7 +18,7 @@ CLI Example:
 
 .. code-block:: bash
 
-    salt '*' log.error 'Please dont do that, this module is not for CLI use!'
+    salt '*' log.error "Please don't do that, this module is not for CLI use!"
 '''
 from __future__ import absolute_import
 

--- a/salt/modules/lxc.py
+++ b/salt/modules/lxc.py
@@ -868,7 +868,7 @@ def _network_conf(conf_tuples=None, **kwargs):
         for row in val:
             ret.append(salt.utils.odict.OrderedDict([(row, val[row])]))
     # on old versions of lxc, still support the gateway auto mode
-    # if we didnt explicitly say no to
+    # if we didn't explicitly say no to
     # (lxc.network.ipv4.gateway: auto)
     if _LooseVersion(version()) <= '1.0.7' and \
             True not in ['lxc.network.ipv4.gateway' in a for a in ret] and \

--- a/salt/modules/mssql.py
+++ b/salt/modules/mssql.py
@@ -102,7 +102,7 @@ def version(**kwargs):
 
 def db_list(**kwargs):
     '''
-    Return the databse list created on a MS SQL server.
+    Return the database list created on a MS SQL server.
 
     CLI Example:
 

--- a/salt/modules/napalm_acl.py
+++ b/salt/modules/napalm_acl.py
@@ -198,7 +198,7 @@ def load_term_config(filter_name,
 
     debug: ``False``
         Debug mode. Will insert a new key under the output dictionary,
-        as ``loaded_config`` contaning the raw configuration loaded on the device.
+        as ``loaded_config`` containing the raw configuration loaded on the device.
 
     source_service
         A special service to choose from. This is a helper so the user is able to
@@ -543,7 +543,7 @@ def load_filter_config(filter_name,
 
     debug: ``False``
         Debug mode. Will insert a new key under the output dictionary,
-        as ``loaded_config`` contaning the raw configuration loaded on the device.
+        as ``loaded_config`` containing the raw configuration loaded on the device.
 
     The output is a dictionary having the same form as :mod:`net.load_config <salt.modules.napalm_network.load_config>`.
 
@@ -743,7 +743,7 @@ def load_policy_config(filters=None,
 
     debug: ``False``
         Debug mode. Will insert a new key under the output dictionary,
-        as ``loaded_config`` contaning the raw configuration loaded on the device.
+        as ``loaded_config`` containing the raw configuration loaded on the device.
 
     The output is a dictionary having the same form as :mod:`net.load_config <salt.modules.napalm_network.load_config>`.
 

--- a/salt/modules/napalm_network.py
+++ b/salt/modules/napalm_network.py
@@ -853,10 +853,10 @@ def config(source=None, **kwargs):  # pylint: disable=unused-argument
 
         - running (string): Representation of the native running configuration.
         - candidate (string): Representation of the native candidate configuration.
-            If the device doesnt differentiate between running and startup
+            If the device doesn't differentiate between running and startup
             configuration this will an empty string.
         - startup (string): Representation of the native startup configuration.
-            If the device doesnt differentiate between running and startup
+            If the device doesn't differentiate between running and startup
             configuration this will an empty string.
 
     CLI Example:
@@ -1366,7 +1366,7 @@ def load_template(template_name,
                     # use the custom template path
                     saltenv = template_path if not salt_render else 'base'
             elif salt_render and not saltenv:
-                # if saltenv not overrided and path specified as salt:// or http:// etc.
+                # if saltenv not overridden and path specified as salt:// or http:// etc.
                 # will use the default environment, from the base
                 saltenv = template_path if template_path else 'base'
             if not saltenv:
@@ -1454,7 +1454,7 @@ def load_template(template_name,
             # after running the other features:
             # compare_config, discard / commit
             # which have to be over the same session
-            # so we'll set the CLOSE global explicitely as False
+            # so we'll set the CLOSE global explicitly as False
             napalm_device['CLOSE'] = False  # pylint: disable=undefined-variable
         _loaded = salt.utils.napalm.call(
             napalm_device,  # pylint: disable=undefined-variable

--- a/salt/modules/napalm_route.py
+++ b/salt/modules/napalm_route.py
@@ -67,7 +67,7 @@ def show(destination, protocol=None, **kwargs):  # pylint: disable=unused-argume
         In case the destination prefix is too short,
         there may be too many routes matched.
         Therefore in cases of devices having a very high number of routes
-        it may be necessary to adjust the prefix lenght and request
+        it may be necessary to adjust the prefix length and request
         using a longer prefix.
 
     destination

--- a/salt/modules/napalm_yang_mod.py
+++ b/salt/modules/napalm_yang_mod.py
@@ -435,7 +435,7 @@ def load_config(data, models, **kwargs):
 
     debug: ``False``
         Debug mode. Will insert a new key under the output dictionary,
-        as ``loaded_config`` contaning the raw configuration loaded on the device.
+        as ``loaded_config`` containing the raw configuration loaded on the device.
 
     replace: ``False``
         Should replace the config with the new generate one?

--- a/salt/modules/pdbedit.py
+++ b/salt/modules/pdbedit.py
@@ -266,7 +266,7 @@ def modify(
         specify user account control properties
 
         .. note::
-            Only the follwing can be set:
+            Only the following can be set:
             - N: No password required
             - D: Account disabled
             - H: Home directory required

--- a/salt/modules/selinux.py
+++ b/salt/modules/selinux.py
@@ -561,7 +561,7 @@ def fcontext_apply_policy(name, recursive=False):
     .. versionadded:: 2017.7.0
 
     Applies SElinux policies to filespec using `restorecon [-R]
-    filespec`. Returns dict with changes if succesful, the output of
+    filespec`. Returns dict with changes if successful, the output of
     the restorecon command otherwise.
 
     name

--- a/salt/modules/sensehat.py
+++ b/salt/modules/sensehat.py
@@ -140,7 +140,7 @@ def show_message(message, msg_type=None,
     message
         The message to display
     msg_type
-        The type of the message. Changes the appearence of the message.
+        The type of the message. Changes the appearance of the message.
 
         Available types are::
 

--- a/salt/modules/smartos_vmadm.py
+++ b/salt/modules/smartos_vmadm.py
@@ -165,7 +165,7 @@ def _create_update_from_cfg(mode='create', uuid=None, vmcfg=None):
                 ret['Error'] = res['stderr']
         return ret
     else:
-        # cleanup json file (only when succesful to help troubleshooting)
+        # cleanup json file (only when successful to help troubleshooting)
         salt.utils.safe_rm(vmadm_json_file)
 
         # return uuid

--- a/salt/modules/solrcloud.py
+++ b/salt/modules/solrcloud.py
@@ -195,7 +195,7 @@ def cluster_status(**kwargs):
 def alias_exists(alias_name, **kwargs):
     '''
 
-    Check alias existance
+    Check alias existence
 
     Additional parameters (kwargs) may be passed, they will be proxied to http.query
 

--- a/salt/modules/win_groupadd.py
+++ b/salt/modules/win_groupadd.py
@@ -218,7 +218,7 @@ def getent(refresh=False):
 
         refresh (bool):
             Refresh the info for all groups in ``__context__``. If False only
-            the groups in ``__context__`` wil be returned. If True the
+            the groups in ``__context__`` will be returned. If True the
             ``__context__`` will be refreshed with current data and returned.
             Default is False
 
@@ -469,7 +469,7 @@ def list_groups(refresh=False):
 
         refresh (bool):
             Refresh the info for all groups in ``__context__``. If False only
-            the groups in ``__context__`` wil be returned. If True, the
+            the groups in ``__context__`` will be returned. If True, the
             ``__context__`` will be refreshed with current data and returned.
             Default is False
 

--- a/salt/modules/win_system.py
+++ b/salt/modules/win_system.py
@@ -1285,7 +1285,7 @@ def get_pending_servermanager():
     key = r'SOFTWARE\Microsoft\ServerManager'
 
     # There are situations where it's possible to have '(value not set)' as
-    # the value data, and since an actual reboot wont be pending in that
+    # the value data, and since an actual reboot won't be pending in that
     # instance, just catch instances where we try unsuccessfully to cast as int.
 
     reg_ret = __salt__['reg.read_value']('HKLM', key, vname)

--- a/salt/netapi/rest_cherrypy/app.py
+++ b/salt/netapi/rest_cherrypy/app.py
@@ -1993,7 +1993,7 @@ class Run(LowDataAdapter):
         The /run enpoint can also be used to issue commands using the salt-ssh
         subsystem.
 
-        When using salt-ssh, eauth credentials should not be supplied. Instad,
+        When using salt-ssh, eauth credentials should not be supplied. Instead,
         authentication should be handled by the SSH layer itself. The use of
         the salt-ssh client does not require a salt master to be running.
         Instead, only a roster file must be present in the salt configuration
@@ -2178,7 +2178,7 @@ class Events(object):
           very busy and can quickly overwhelm the memory allocated to a
           browser tab.
 
-        A full, working proof-of-concept JavaScript appliction is available
+        A full, working proof-of-concept JavaScript application is available
         :blob:`adjacent to this file <salt/netapi/rest_cherrypy/index.html>`.
         It can be viewed by pointing a browser at the ``/app`` endpoint in a
         running ``rest_cherrypy`` instance.

--- a/salt/renderers/pyobjects.py
+++ b/salt/renderers/pyobjects.py
@@ -263,7 +263,7 @@ different grain matches.
     **Ubuntu** classes, since Ubuntu has an ``os_family`` grain of **Debian**
     an an ``os`` grain of **Ubuntu**. As of the 2017.7.0 release, the order is
     dictated by the order of declaration, with classes defined later overriding
-    earlier ones. Addtionally, 2017.7.0 adds support for explicitly defining
+    earlier ones. Additionally, 2017.7.0 adds support for explicitly defining
     the ordering using an optional attribute called ``priority``.
 
     Given the above example, ``os_family`` matches will be processed first,

--- a/salt/returners/elasticsearch_return.py
+++ b/salt/returners/elasticsearch_return.py
@@ -227,7 +227,7 @@ def returner(ret):
 
     if ret.get('return', None) is None:
         log.info('Won\'t push new data to Elasticsearch, job with jid={0} was '
-                 'not succesful'.format(job_id))
+                 'not successful'.format(job_id))
         return
 
     # Build the index name

--- a/salt/runners/bgp.py
+++ b/salt/runners/bgp.py
@@ -53,7 +53,7 @@ Configuration
 
         By default, the following extra fields are returned (displayed):
 
-        - ``connection_stats``: connection stats, as descibed below
+        - ``connection_stats``: connection stats, as described below
         - ``import_policy``: the name of the import policy
         - ``export_policy``: the name of the export policy
 

--- a/salt/runners/manage.py
+++ b/salt/runners/manage.py
@@ -262,7 +262,7 @@ def list_state(subset=None, show_ipv4=False, state=None):
                 minions = [m for m in minions if m in subset]
     else:
         # Always return 'present' for 0MQ for now
-        # TODO: implement other states spport for 0MQ
+        # TODO: implement other states support for 0MQ
         ckminions = salt.utils.minions.CkMinions(__opts__)
         minions = ckminions.connected_ids(show_ipv4=show_ipv4, subset=subset, include_localhost=True)
 

--- a/salt/state.py
+++ b/salt/state.py
@@ -1742,7 +1742,7 @@ class State(object):
         ret = {'name': cdata['args'][0],
                 'result': None,
                 'changes': {},
-                'comment': 'Started in a seperate process',
+                'comment': 'Started in a separate process',
                 'proc': proc}
         return ret
 

--- a/salt/states/docker_container.py
+++ b/salt/states/docker_container.py
@@ -256,7 +256,7 @@ def running(name,
 
         .. versionchanged:: 2017.7.0
             This option was renamed from ``stop_timeout`` to
-            ``shutdown_timeout`` to acommodate the ``stop_timeout`` container
+            ``shutdown_timeout`` to accommodate the ``stop_timeout`` container
             configuration setting.
 
     client_timeout : 60

--- a/salt/states/elasticsearch.py
+++ b/salt/states/elasticsearch.py
@@ -175,7 +175,7 @@ def alias_present(name, index, definition=None):
                 if not old:
                     ret['comment'] = 'Alias {0} for index {1} does not exist and will be created'.format(name, index)
                 else:
-                    ret['comment'] = 'Alias {0} for index {1} exists with wrong configuration and will be overriden'.format(name, index)
+                    ret['comment'] = 'Alias {0} for index {1} exists with wrong configuration and will be overridden'.format(name, index)
 
                 ret['result'] = None
             else:
@@ -348,7 +348,7 @@ def pipeline_present(name, definition):
                 if not pipeline:
                     ret['comment'] = 'Pipeline {0} does not exist and will be created'.format(name)
                 else:
-                    ret['comment'] = 'Pipeline {0} exists with wrong configuration and will be overriden'.format(name)
+                    ret['comment'] = 'Pipeline {0} exists with wrong configuration and will be overridden'.format(name)
 
                 ret['result'] = None
             else:
@@ -439,7 +439,7 @@ def search_template_present(name, definition):
                 if not template:
                     ret['comment'] = 'Search template {0} does not exist and will be created'.format(name)
                 else:
-                    ret['comment'] = 'Search template {0} exists with wrong configuration and will be overriden'.format(name)
+                    ret['comment'] = 'Search template {0} exists with wrong configuration and will be overridden'.format(name)
 
                 ret['result'] = None
             else:

--- a/salt/states/grafana4_datasource.py
+++ b/salt/states/grafana4_datasource.py
@@ -27,7 +27,7 @@ Manage Grafana v4.0 data sources
           grafana_token: token
           grafana_timeout: 3
 
-The bahavior of this module is to create data sources if the do not exists, and
+The behavior of this module is to create data sources if the do not exists, and
 to update data sources if the already exists.
 
 .. code-block:: yaml

--- a/salt/states/heat.py
+++ b/salt/states/heat.py
@@ -141,7 +141,7 @@ def deployed(name, template=None, enviroment=None, params=None, poll=5,
         Parameter dict used to create the stack
 
     poll
-        Poll(in sec.) and report events until stack complete
+        Poll (in sec.) and report events until stack complete
 
     rollback
         Enable rollback on create failure

--- a/salt/states/heat.py
+++ b/salt/states/heat.py
@@ -16,7 +16,7 @@ Stack can be set as either absent or deploy.
   heat.deployed:
     - name:
     - template: #Required
-    - enviroment:
+    - environment:
     - params: {}
     - poll: 5
     - rollback: False
@@ -32,6 +32,12 @@ mysql:
     - params:
       image: Debian 7
     - rollback: True
+
+.. versionadded:: 2017.7.5,2018.3.1
+
+    The spelling mistake in parameter `enviroment` was corrected to `environment`.
+    The misspelled version is still supported for backward compatibility, but will
+    be removed in Salt Neon.
 
 '''
 from __future__ import absolute_import
@@ -122,7 +128,7 @@ def _parse_template(tmpl_str):
     return tpl
 
 
-def deployed(name, template=None, enviroment=None, params=None, poll=5,
+def deployed(name, template=None, environment=None, params=None, poll=5,
              rollback=False, timeout=60, update=False, profile=None,
              **connection_args):
     '''
@@ -134,8 +140,8 @@ def deployed(name, template=None, enviroment=None, params=None, poll=5,
     template
         File of template
 
-    enviroment
-        File of enviroment
+    environment
+        File of environment
 
     params
         Parameter dict used to create the stack
@@ -152,10 +158,22 @@ def deployed(name, template=None, enviroment=None, params=None, poll=5,
     profile
         Profile to use
 
+    .. versionadded:: 2017.7.5,2018.3.1
+
+        The spelling mistake in parameter `enviroment` was corrected to `environment`.
+        The misspelled version is still supported for backward compatibility, but will
+        be removed in Salt Neon.
+
     '''
+    if environment is None and 'enviroment' in connection_args:
+        salt.utils.warn_until('Neon', (
+            "Please use the 'environment' parameter instead of the misspelled 'enviroment' "
+            "parameter which will be removed in Salt Neon."
+        ))
+        environment = connection_args.pop('enviroment')
     log.debug('Deployed with(' +
               '{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}, {9})'
-              .format(name, template, enviroment, params, poll, rollback,
+              .format(name, template, environment, params, poll, rollback,
                       timeout, update, profile, connection_args))
     ret = {'name': None,
            'comment': '',
@@ -266,7 +284,7 @@ def deployed(name, template=None, enviroment=None, params=None, poll=5,
         else:
             stack = __salt__['heat.update_stack'](name=name,
                                                   template_file=template,
-                                                  enviroment=enviroment,
+                                                  environment=environment,
                                                   parameters=params, poll=poll,
                                                   rollback=rollback,
                                                   timeout=timeout,
@@ -282,7 +300,7 @@ def deployed(name, template=None, enviroment=None, params=None, poll=5,
         else:
             stack = __salt__['heat.create_stack'](name=name,
                                                   template_file=template,
-                                                  enviroment=enviroment,
+                                                  environment=environment,
                                                   parameters=params, poll=poll,
                                                   rollback=rollback,
                                                   timeout=timeout,

--- a/salt/states/http.py
+++ b/salt/states/http.py
@@ -143,7 +143,7 @@ def wait_for_successful_query(name, wait_for=300, **kwargs):
 
     .. note::
 
-        All other arguements are passed to the http.query state.
+        All other arguments are passed to the http.query state.
     '''
     starttime = time.time()
 

--- a/salt/states/junos.py
+++ b/salt/states/junos.py
@@ -40,7 +40,7 @@ def rpc(name, dest=None, format='xml', args=None, **kwargs):
           The rpc to be executed. (default = None)
       Optional
         * dest:
-          Destination file where the rpc ouput is stored. (default = None)
+          Destination file where the rpc output is stored. (default = None)
           Note that the file will be stored on the proxy minion. To push the
           files to the master use the salt's following execution module: \
             :py:func:`cp.push <salt.modules.cp.push>`
@@ -319,7 +319,7 @@ def install_config(name, **kwargs):
               the given time unless the commit is confirmed.
             * diffs_file:
               Path to the file where the diff (difference in old configuration
-              and the commited configuration) will be stored.(default = None)
+              and the committed configuration) will be stored.(default = None)
               Note that the file will be stored on the proxy minion. To push the
               files to the master use the salt's following execution module: \
               :py:func:`cp.push <salt.modules.cp.push>`

--- a/salt/states/netacl.py
+++ b/salt/states/netacl.py
@@ -155,7 +155,7 @@ def term(name,
 
     debug: ``False``
         Debug mode. Will insert a new key under the output dictionary,
-        as ``loaded_config`` contaning the raw configuration loaded on the device.
+        as ``loaded_config`` containing the raw configuration loaded on the device.
 
     source_service
         A special service to choose from. This is a helper so the user is able to
@@ -406,7 +406,7 @@ def term(name,
     .. note::
         The first method allows the user to eventually apply complex manipulation
         and / or retrieve the data from external services before passing the
-        data to the state. The second one is more straighforward, for less
+        data to the state. The second one is more straightforward, for less
         complex cases when loading the data directly from the pillar is sufficient.
 
     .. note::
@@ -526,7 +526,7 @@ def filter(name,  # pylint: disable=redefined-builtin
 
     debug: ``False``
         Debug mode. Will insert a new key under the output dictionary,
-        as ``loaded_config`` contaning the raw configuration loaded on the device.
+        as ``loaded_config`` containing the raw configuration loaded on the device.
 
     CLI Example:
 
@@ -636,7 +636,7 @@ def filter(name,  # pylint: disable=redefined-builtin
     .. note::
         The first method allows the user to eventually apply complex manipulation
         and / or retrieve the data from external services before passing the
-        data to the state. The second one is more straighforward, for less
+        data to the state. The second one is more straightforward, for less
         complex cases when loading the data directly from the pillar is sufficient.
 
     .. note::
@@ -710,7 +710,7 @@ def managed(name,
         :conf_minion:`pillarenv_from_saltenv`, and is otherwise ignored.
 
     merge_pillar: ``False``
-        Merge the ``filters`` wil the corresponding values from the pillar. Default: ``False``.
+        Merge the ``filters`` will the corresponding values from the pillar. Default: ``False``.
 
         .. note::
             By default this state does not merge, to avoid any unexpected behaviours.
@@ -746,7 +746,7 @@ def managed(name,
 
     debug: ``False``
         Debug mode. Will insert a new key under the output dictionary,
-        as ``loaded_config`` contaning the raw configuration loaded on the device.
+        as ``loaded_config`` containing the raw configuration loaded on the device.
 
     CLI Example:
 
@@ -933,7 +933,7 @@ def managed(name,
     .. note::
         The first method allows the user to eventually apply complex manipulation
         and / or retrieve the data from external services before passing the
-        data to the state. The second one is more straighforward, for less
+        data to the state. The second one is more straightforward, for less
         complex cases when loading the data directly from the pillar is sufficient.
 
     .. note::

--- a/salt/states/netconfig.py
+++ b/salt/states/netconfig.py
@@ -135,8 +135,8 @@ def managed(name,
     To replace the config, set ``replace`` to ``True``. This option is recommended to be used with caution!
 
     .. warning::
-        The spport for NAPALM native templates will be dropped beginning with Salt Fluorine.
-        Implicitly, the ``template_path`` argument will be depreacted and removed.
+        The support for NAPALM native templates will be dropped beginning with Salt Fluorine.
+        Implicitly, the ``template_path`` argument will be deprecated and removed.
 
     template_name
         Identifies path to the template source. The template can be either stored on the local machine,
@@ -152,7 +152,7 @@ def managed(name,
 
         Placing the template under ``/etc/salt/states/templates/example.jinja``, it can be used as
         ``salt://templates/example.jinja``.
-        Alternatively, for local files, the user can specify the abolute path.
+        Alternatively, for local files, the user can specify the absolute path.
         If remotely, the source can be retrieved via ``http``, ``https`` or ``ftp``.
 
         Examples:
@@ -213,7 +213,7 @@ def managed(name,
         Commit? Default: ``True``.
 
     debug: False
-        Debug mode. Will insert a new key under the output dictionary, as ``loaded_config`` contaning the raw
+        Debug mode. Will insert a new key under the output dictionary, as ``loaded_config`` containing the raw
         result after the template was rendered.
 
     replace: False
@@ -223,7 +223,7 @@ def managed(name,
         Default variables/context passed to the template.
 
     **template_vars
-        Dictionary with the arguments/context to be used when the template is rendered. Do not explicitely specify this
+        Dictionary with the arguments/context to be used when the template is rendered. Do not explicitly specify this
         argument. This represents any other variable that will be sent to the template rendering system. Please
         see an example below! In both ``ntp_peers_example_using_pillar`` and ``ntp_peers_example``, ``peers`` is sent as
         template variable.

--- a/salt/states/netyang.py
+++ b/salt/states/netyang.py
@@ -109,7 +109,7 @@ def managed(name,
 
     debug: ``False``
         Debug mode. Will insert a new key under the output dictionary,
-        as ``loaded_config`` contaning the raw configuration loaded on the device.
+        as ``loaded_config`` containing the raw configuration loaded on the device.
 
     replace: ``False``
         Should replace the config with the new generate one?
@@ -212,7 +212,7 @@ def configured(name,
         configuration on the device and the expected
         configuration. Depending on the platform and hardware
         capabilities, one could be more optimal than the other.
-        Additionally, the output of the ``managed`` is diferent,
+        Additionally, the output of the ``managed`` is different,
         in such a way that the ``pchange`` field in the output
         contains structured data, rather than text.
 
@@ -236,7 +236,7 @@ def configured(name,
 
     debug: ``False``
         Debug mode. Will insert a new key under the output dictionary,
-        as ``loaded_config`` contaning the raw configuration loaded on the device.
+        as ``loaded_config`` containing the raw configuration loaded on the device.
 
     replace: ``False``
         Should replace the config with the new generate one?

--- a/salt/states/pdbedit.py
+++ b/salt/states/pdbedit.py
@@ -107,7 +107,7 @@ def managed(name, **kwargs):
         specify user account control properties
 
         .. note::
-            Only the follwing can be set:
+            Only the following can be set:
             - N: No password required
             - D: Account disabled
             - H: Home directory required

--- a/salt/states/pip_state.py
+++ b/salt/states/pip_state.py
@@ -827,7 +827,7 @@ def installed(name,
                                                      user=user, cwd=cwd,
                                                      env_vars=env_vars)
 
-                    # If we didnt find the package in the system after
+                    # If we didn't find the package in the system after
                     # installing it report it
                     if not pipsearch:
                         pkg_404_comms.append(

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -1953,7 +1953,7 @@ def downloaded(name,
         return ret
 
     # It doesn't make sense here to received 'downloadonly' as kwargs
-    # as we're explicitely passing 'downloadonly=True' to execution module.
+    # as we're explicitly passing 'downloadonly=True' to execution module.
     if 'downloadonly' in kwargs:
         del kwargs['downloadonly']
 
@@ -2126,7 +2126,7 @@ def patch_downloaded(name, advisory_ids=None, **kwargs):
                            'this platform'}
 
     # It doesn't make sense here to received 'downloadonly' as kwargs
-    # as we're explicitely passing 'downloadonly=True' to execution module.
+    # as we're explicitly passing 'downloadonly=True' to execution module.
     if 'downloadonly' in kwargs:
         del kwargs['downloadonly']
     return patch_installed(name=name, advisory_ids=advisory_ids, downloadonly=True, **kwargs)

--- a/salt/states/rabbitmq_user.py
+++ b/salt/states/rabbitmq_user.py
@@ -126,7 +126,7 @@ def present(name,
             return ret
 
     if user and not any((force, perms, tags, passwd_reqs_update)):
-        log.debug(('RabbitMQ user \'%s\' exists, password is upto'
+        log.debug(('RabbitMQ user \'%s\' exists, password is up to'
                    ' date and force is not set.'), name)
         ret['comment'] = 'User \'{0}\' is already present.'.format(name)
         ret['result'] = True

--- a/salt/states/smartos.py
+++ b/salt/states/smartos.py
@@ -368,7 +368,7 @@ def image_vacuum(name):
     # list of images to keep
     images = []
 
-    # retreive image_present state data for host
+    # retrieve image_present state data for host
     for state in __salt__['state.show_lowstate']():
         # don't throw exceptions when not highstate run
         if 'state' not in state:

--- a/salt/states/win_lgpo.py
+++ b/salt/states/win_lgpo.py
@@ -23,7 +23,7 @@ Example single policy configuration
 
 .. code-block:: yaml
 
-    Acount lockout duration:
+    Account lockout duration:
       gpo.set:
         - setting: 120
         - policy_class: Machine

--- a/salt/states/zfs.py
+++ b/salt/states/zfs.py
@@ -764,7 +764,7 @@ def scheduled_snapshot(name, prefix, recursive=True, schedule=None):
 
     ## manage snapshots
     if ret['result']:
-        # retreive snapshots
+        # retrieve snapshots
         prunable = []
         snapshots = {}
         for key in schedule:

--- a/salt/states/zone.py
+++ b/salt/states/zone.py
@@ -9,7 +9,7 @@ Management of Solaris Zones
 
 .. versionadded:: 2017.7.0
 
-Bellow are some examples of how to use this state.
+Below are some examples of how to use this state.
 Lets start with creating a zone and installing it.
 
 .. code-block:: yaml
@@ -47,7 +47,7 @@ Lets start with creating a zone and installing it.
 
 A zone without network access is not very useful. We could update
 the zone.present state in the example above to add a network interface
-or we could use a seperate state for this.
+or we could use a separate state for this.
 
 .. code-block:: yaml
 
@@ -836,7 +836,7 @@ def import_(name, path, mode='import', nodataset=False, brand_opts=None):
 
 def present(name, brand, zonepath, properties=None, resources=None):
     '''
-    Ensure a zone with certain properties and resouces
+    Ensure a zone with certain properties and resources
 
     name : string
         name of the zone

--- a/salt/utils/docker/__init__.py
+++ b/salt/utils/docker/__init__.py
@@ -2,7 +2,7 @@
 '''
 Common logic used by the docker state and execution module
 
-This module contains logic to accomodate docker/salt CLI usage, as well as
+This module contains logic to accommodate docker/salt CLI usage, as well as
 input as formatted by states.
 '''
 

--- a/salt/utils/napalm.py
+++ b/salt/utils/napalm.py
@@ -238,7 +238,7 @@ def call(napalm_device, method, *args, **kwargs):
             # either running in a not-always-alive proxy
             # either running in a regular minion
             # close the connection when the call is over
-            # unless the CLOSE is explicitely set as False
+            # unless the CLOSE is explicitly set as False
             napalm_device['DRIVER'].close()
     return {
         'out': out,
@@ -392,7 +392,7 @@ def proxy_napalm_wrap(func):
             else:
                 # in case the `inherit_napalm_device` is set
                 # and it also has a non-empty value,
-                # the global var `napalm_device` will be overriden.
+                # the global var `napalm_device` will be overridden.
                 # this is extremely important for configuration-related features
                 # as all actions must be issued within the same configuration session
                 # otherwise we risk to open multiple sessions
@@ -418,7 +418,7 @@ def proxy_napalm_wrap(func):
             else:
                 # in case the `inherit_napalm_device` is set
                 # and it also has a non-empty value,
-                # the global var `napalm_device` will be overriden.
+                # the global var `napalm_device` will be overridden.
                 # this is extremely important for configuration-related features
                 # as all actions must be issued within the same configuration session
                 # otherwise we risk to open multiple sessions

--- a/salt/utils/schema.py
+++ b/salt/utils/schema.py
@@ -731,7 +731,7 @@ class SchemaItem(six.with_metaclass(BaseSchemaItemMeta, object)):
         '''
         Return the argname value looking up on all possible attributes
         '''
-        # Let's see if there's a private fuction to get the value
+        # Let's see if there's a private function to get the value
         argvalue = getattr(self, '__get_{0}__'.format(argname), None)
         if argvalue is not None and callable(argvalue):
             argvalue = argvalue()

--- a/salt/version.py
+++ b/salt/version.py
@@ -10,7 +10,7 @@ import sys
 import locale
 import platform
 
-# linux_distribution depreacted in py3.7
+# linux_distribution deprecated in py3.7
 try:
     from platform import linux_distribution
 except ImportError:

--- a/tests/integration/runners/test_state.py
+++ b/tests/integration/runners/test_state.py
@@ -107,7 +107,7 @@ class StateRunnerTest(ShellCase):
 
     def test_orchestrate_target_doesnt_exists(self):
         '''
-        test orchestration when target doesnt exist
+        test orchestration when target doesn't exist
         while using multiple states
         '''
         ret = self.run_run('state.orchestrate orch.target-doesnt-exists')

--- a/tests/unit/cloud/clouds/__init__.py
+++ b/tests/unit/cloud/clouds/__init__.py
@@ -3,7 +3,7 @@
 
 def _preferred_ip(ip_set, preferred=None):
     '''
-    Returns a function that reacts which ip is prefered
+    Returns a function that reacts which ip is preferred
     :param ip_set:
     :param private:
     :return:

--- a/tests/unit/states/test_boto_apigateway.py
+++ b/tests/unit/states/test_boto_apigateway.py
@@ -383,7 +383,7 @@ class TempSwaggerFile(object):
             self.swaggerdict['invalid_key'] = 'invalid'
             # remove one of the required keys 'schemes'
             self.swaggerdict.pop('schemes', None)
-            # set swagger version to an unsupported verison 3.0
+            # set swagger version to an unsupported version 3.0
             self.swaggerdict['swagger'] = '3.0'
             # missing info object
             self.swaggerdict.pop('info', None)

--- a/tests/unit/states/test_elasticsearch.py
+++ b/tests/unit/states/test_elasticsearch.py
@@ -187,7 +187,7 @@ class ElasticsearchTestCase(TestCase, LoaderModuleMockMixin):
                 ret.update({'comment': "Alias foo for index bar does not exist and will be created", 'result': None, 'changes': {'new': {"test2": "key"}}})
                 self.assertDictEqual(elasticsearch.alias_present(name, index, {"test2": "key"}), ret)
 
-                ret.update({'comment': "Alias foo for index bar exists with wrong configuration and will be overriden", 'result': None, 'changes': {'old': {"test": "key"}, 'new': {"test2": "key"}}})
+                ret.update({'comment': "Alias foo for index bar exists with wrong configuration and will be overridden", 'result': None, 'changes': {'old': {"test": "key"}, 'new': {"test2": "key"}}})
                 self.assertDictEqual(elasticsearch.alias_present(name, index, {"test2": "key"}), ret)
 
             ret.update({'comment': '', 'result': False, 'changes': {}})
@@ -352,7 +352,7 @@ class ElasticsearchTestCase(TestCase, LoaderModuleMockMixin):
                 ret.update({'comment': "Pipeline foo does not exist and will be created", 'result': None, 'changes': {'new': {"test2": "key"}}})
                 self.assertDictEqual(elasticsearch.pipeline_present(name, {"test2": "key"}), ret)
 
-                ret.update({'comment': "Pipeline foo exists with wrong configuration and will be overriden", 'result': None, 'changes': {'old': {"test": "key"}, 'new': {"test2": "key"}}})
+                ret.update({'comment': "Pipeline foo exists with wrong configuration and will be overridden", 'result': None, 'changes': {'old': {"test": "key"}, 'new': {"test2": "key"}}})
                 self.assertDictEqual(elasticsearch.pipeline_present(name, {"test2": "key"}), ret)
 
             ret.update({'comment': '', 'result': False, 'changes': {}})
@@ -434,7 +434,7 @@ class ElasticsearchTestCase(TestCase, LoaderModuleMockMixin):
                 ret.update({'comment': "Search template foo does not exist and will be created", 'result': None, 'changes': {'new': {"test2": "key"}}})
                 self.assertDictEqual(elasticsearch.search_template_present(name, {"test2": "key"}), ret)
 
-                ret.update({'comment': "Search template foo exists with wrong configuration and will be overriden", 'result': None, 'changes': {'old': {"test": "key"}, 'new': {"test2": "key"}}})
+                ret.update({'comment': "Search template foo exists with wrong configuration and will be overridden", 'result': None, 'changes': {'old': {"test": "key"}, 'new': {"test2": "key"}}})
                 self.assertDictEqual(elasticsearch.search_template_present(name, {"test2": "key"}), ret)
 
             ret.update({'comment': '', 'result': False, 'changes': {}})

--- a/tests/unit/utils/test_cache.py
+++ b/tests/unit/utils/test_cache.py
@@ -77,7 +77,7 @@ class CacheContextTestCase(TestCase):
     def test_context_wrapper(self):
         '''
         Test to ensure that a module which decorates itself
-        with a context cache can store and retreive its contextual
+        with a context cache can store and retrieve its contextual
         data
         '''
         opts = salt.config.DEFAULT_MINION_OPTS


### PR DESCRIPTION
Lintian found various typos. The first commit fixes the trivial typos. The second commit fixes the typo in the heat module/state parameter. The rename is documented and support for the misspelled version for backward compatibility is added.

