### PR TITLE
Use integer parameter for sleep command

### DIFF
--- a/salt/cloud/deploy/bootstrap-salt.sh
+++ b/salt/cloud/deploy/bootstrap-salt.sh
@@ -2791,7 +2791,7 @@ install_ubuntu_stable_post() {
                 /bin/systemctl preset salt-$fname.service > /dev/null 2>&1 &&
                 /bin/systemctl enable salt-$fname.service > /dev/null 2>&1
             )
-            sleep 0.1
+            sleep 1
             /bin/systemctl daemon-reload
         elif [ -f /etc/init.d/salt-$fname ]; then
             update-rc.d salt-$fname defaults
@@ -2817,7 +2817,7 @@ install_ubuntu_git_post() {
             [ $fname = "api" ] && continue
 
             systemctl is-enabled salt-$fname.service || (systemctl preset salt-$fname.service && systemctl enable salt-$fname.service)
-            sleep 0.1
+            sleep 1
             systemctl daemon-reload
         elif [ -f /sbin/initctl ]; then
             _upstart_conf="/etc/init/salt-$fname.conf"
@@ -3395,7 +3395,7 @@ install_fedora_stable_post() {
         [ $fname = "syndic" ] && [ "$_INSTALL_SYNDIC" -eq $BS_FALSE ] && continue
 
         systemctl is-enabled salt-$fname.service || (systemctl preset salt-$fname.service && systemctl enable salt-$fname.service)
-        sleep 0.1
+        sleep 1
         systemctl daemon-reload
     done
 }
@@ -3456,7 +3456,7 @@ install_fedora_git_post() {
         [ $fname = "api" ] && continue
 
         systemctl is-enabled salt-$fname.service || (systemctl preset salt-$fname.service && systemctl enable salt-$fname.service)
-        sleep 0.1
+        sleep 1
         systemctl daemon-reload
     done
 }
@@ -4704,7 +4704,7 @@ install_arch_linux_post() {
                 /usr/bin/systemctl preset salt-$fname.service > /dev/null 2>&1 &&
                 /usr/bin/systemctl enable salt-$fname.service > /dev/null 2>&1
             )
-            sleep 0.1
+            sleep 1
             /usr/bin/systemctl daemon-reload
             continue
         fi
@@ -4732,7 +4732,7 @@ install_arch_linux_git_post() {
                 /usr/bin/systemctl preset salt-${fname}.service > /dev/null 2>&1 &&
                 /usr/bin/systemctl enable salt-${fname}.service > /dev/null 2>&1
             )
-            sleep 0.1
+            sleep 1
             /usr/bin/systemctl daemon-reload
             continue
         fi
@@ -5594,7 +5594,7 @@ install_opensuse_stable_post() {
 
         if [ -f /bin/systemctl ]; then
             systemctl is-enabled salt-$fname.service || (systemctl preset salt-$fname.service && systemctl enable salt-$fname.service)
-            sleep 0.1
+            sleep 1
             systemctl daemon-reload
             continue
         fi


### PR DESCRIPTION
The bootstrap-salt.sh script uses a "bashism" for the sleep command. Bash allows real numbers as sleep time, but other POSIX shell interpreters only support an integer as parameter. Thus raise the sleep timeout from 0.1 to 1 second.

The git history does not explain why a sleep command is used in the code. You might be able to remove the sleep command completely.

Bug-Debian: https://bugs.debian.org/772406