### PR TITLE
make spm cache_dir instead of all cachedirs

### DIFF
--- a/salt/cli/spm.py
+++ b/salt/cli/spm.py
@@ -30,7 +30,7 @@ class SPM(parsers.SPMParser):
         self.parse_args()
         self.setup_logfile_logger()
         v_dirs = [
-            self.config['cachedir'],
+            self.config['spm_cache_dir'],
         ]
         verify_env(v_dirs,
                    self.config['user'],


### PR DESCRIPTION
### What does this PR do?
This will allow spm to be run as a non root user, with a cache dir set to
somewhere other than /var/cache/salt.

### What issues does this PR fix or reference?
Fixes #46451

### Tests written?

Yes

### Commits signed with GPG?

Yes