### PR TITLE
.format remove fix for #44452

### DIFF
--- a/salt/cloud/__init__.py
+++ b/salt/cloud/__init__.py
@@ -1493,8 +1493,8 @@ class Cloud(object):
                             vm_name = vm_details['id']
                         else:
                             log.debug(
-                                'vm:{0} in provider:{1} is not in name '
-                                'list:\'{2}\''.format(vm_name, driver, names)
+                                'vm:%s in provider:%s is not in name '
+                                'list:\'%s\'', vm_name, driver, names
                             )
                             continue
 


### PR DESCRIPTION
### What does this PR do?

fixes #44452 With the least intensive fix.

### What issues does this PR fix or reference?

fixes #44452 With the least intensive fix. As format does not look to handle the Unicode while the built-in log formatting does. 

### Previous Behavior

get an error like the following

```
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/salt/cloud/cli.py", line 253, in run
    ret = mapper.do_action(names, kwargs)
  File "/usr/lib/python2.7/site-packages/salt/cloud/__init__.py", line 1497, in do_action
    'list:\'{2}\''.format(vm_name, driver, names)
UnicodeEncodeError: 'ascii' codec can't encode character u'\u2013' in position 4: ordinal not in range(128)
```

### New Behavior

create snapshot even when the environment has instances with Unicode in the name. 

### Tests written?

No 

### Commits signed with GPG?

Yes