### PR TITLE
[Docs] Clarify `mine_interval` setting location in mine docs

### DIFF
--- a/doc/topics/mine/index.rst
+++ b/doc/topics/mine/index.rst
@@ -79,7 +79,8 @@ Mine Interval
 
 The Salt Mine functions are executed when the Minion starts and at a given
 interval by the scheduler. The default interval is every 60 minutes and can
-be adjusted for the Minion via the ``mine_interval`` option:
+be adjusted for the Minion via the ``mine_interval`` option in the minion
+config:
 
 .. code-block:: yaml
 


### PR DESCRIPTION
### What does this PR do?

Clarify mine docs pointing direct to the minion config explicitly as it follows config that can be in either pillar or config which can be confusing. Especially to me :D

### What issues does this PR fix or reference?

None

### Tests written?

No

### Commits signed with GPG?

No