### PR TITLE
Update requirements files to depend on mock>=2.0.0

### DIFF
--- a/requirements/dev_python27.txt
+++ b/requirements/dev_python27.txt
@@ -1,6 +1,6 @@
 -r base.txt
 
-mock
+mock>=2.0.0
 apache-libcloud>=0.14.0
 boto>=2.32.1
 boto3>=1.2.1

--- a/requirements/dev_python34.txt
+++ b/requirements/dev_python34.txt
@@ -1,6 +1,6 @@
 -r base.txt
 
-mock
+mock>=2.0.0
 apache-libcloud>=0.14.0
 boto>=2.32.1
 boto3>=1.2.1


### PR DESCRIPTION
This requirement was changed in salt-jenkins but never done here.