### PR TITLE
fix salt subset in orchestrator

### DIFF
--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -481,6 +481,8 @@ class LocalClient(object):
         following exceptions.
 
         :param sub: The number of systems to execute on
+        :param cli: When this is set to True, a generator is returned,
+                    otherwise a dictionary of the minion returns is returned
 
         .. code-block:: python
 

--- a/salt/modules/saltutil.py
+++ b/salt/modules/saltutil.py
@@ -1273,7 +1273,7 @@ def _exec(client, tgt, fun, arg, timeout, tgt_type, ret, kwarg, **kwargs):
         _cmd = client.cmd_subset
         cmd_kwargs = {
             'tgt': tgt, 'fun': fun, 'arg': arg, 'tgt_type': tgt_type,
-            'ret': ret, 'kwarg': kwarg, 'sub': kwargs['subset'],
+            'ret': ret, 'cli': True, 'kwarg': kwarg, 'sub': kwargs['subset'],
         }
         del kwargs['subset']
     else:

--- a/tests/integration/files/file/base/orch/subset.sls
+++ b/tests/integration/files/file/base/orch/subset.sls
@@ -1,0 +1,5 @@
+test subset:
+  salt.state:
+    - tgt: '*'
+    - subset: 1
+    - sls: test

--- a/tests/integration/files/file/base/test.sls
+++ b/tests/integration/files/file/base/test.sls
@@ -1,0 +1,3 @@
+test state:
+  test.succeed_without_changes:
+    - name: test

--- a/tests/integration/runners/test_state.py
+++ b/tests/integration/runners/test_state.py
@@ -151,6 +151,17 @@ class StateRunnerTest(ShellCase):
 
         server_thread.join()
 
+    def test_orchestrate_subset(self):
+        '''
+        test orchestration state using subset
+        '''
+        ret = self.run_run('state.orchestrate orch.subset')
+        def count(thing, listobj):
+            return sum([obj.strip() == thing for obj in listobj])
+        self.assertEqual(count('ID: test subset', ret), 1)
+        self.assertEqual(count('Succeeded: 1', ret), 1)
+        self.assertEqual(count('Failed:    0', ret), 1)
+
 
 @skipIf(salt.utils.is_windows(), '*NIX-only test')
 class OrchEventTest(ShellCase):

--- a/tests/integration/runners/test_state.py
+++ b/tests/integration/runners/test_state.py
@@ -156,8 +156,10 @@ class StateRunnerTest(ShellCase):
         test orchestration state using subset
         '''
         ret = self.run_run('state.orchestrate orch.subset')
+
         def count(thing, listobj):
             return sum([obj.strip() == thing for obj in listobj])
+
         self.assertEqual(count('ID: test subset', ret), 1)
         self.assertEqual(count('Succeeded: 1', ret), 1)
         self.assertEqual(count('Failed:    0', ret), 1)


### PR DESCRIPTION
### What does this PR do?
This was originally supposed to be part of https://github.com/saltstack/salt/pull/43933

But went missing for some reason, possibly in my rebase to add the comment about popping expect_minions

### What issues does this PR fix or reference?
Fixes #46456

### Tests?

Yes

### Commits signed with GPG?

Yes