### PR TITLE
salt-ssh: fix JSON load of return data when it contains non-ascii

### DIFF
--- a/salt/utils/json.py
+++ b/salt/utils/json.py
@@ -25,8 +25,13 @@ def find_json(raw):
     string to start with garbage and end with json but be cleanly loaded
     '''
     ret = {}
-    for ind, _ in enumerate(raw):
-        working = '\n'.join(raw.splitlines()[ind:])
+    lines = raw.splitlines()
+    for ind, _ in enumerate(lines):
+        try:
+            working = '\n'.join(lines[ind:])
+        except UnicodeDecodeError:
+            working = '\n'.join(salt.utils.data.decode(lines[ind:]))
+
         try:
             ret = json.loads(working)  # future lint: blacklisted-function
         except ValueError:

--- a/salt/utils/json.py
+++ b/salt/utils/json.py
@@ -19,13 +19,22 @@ from salt.ext import six
 log = logging.getLogger(__name__)
 
 
+def __split(raw):
+    '''
+    Performs a splitlines on the string. This function exists to make mocking
+    possible in unit tests, since the member functions of the str/unicode
+    builtins cannot be mocked.
+    '''
+    return raw.splitlines()
+
+
 def find_json(raw):
     '''
     Pass in a raw string and load the json when it starts. This allows for a
     string to start with garbage and end with json but be cleanly loaded
     '''
     ret = {}
-    lines = raw.splitlines()
+    lines = __split(raw)
     for ind, _ in enumerate(lines):
         try:
             working = '\n'.join(lines[ind:])

--- a/tests/unit/utils/test_json.py
+++ b/tests/unit/utils/test_json.py
@@ -4,37 +4,19 @@ Tests for salt.utils.json
 '''
 # Import Python libs
 from __future__ import absolute_import, print_function, unicode_literals
-import errno
-import functools
-import os
 import textwrap
 
 # Import Salt Testing libs
-from tests.support.paths import TMP
-from tests.support.unit import TestCase, LOREM_IPSUM
+from tests.support.helpers import with_tempfile
+from tests.support.mock import patch, MagicMock, NO_MOCK, NO_MOCK_REASON
+from tests.support.unit import TestCase, LOREM_IPSUM, skipIf
 
 # Import Salt libs
 import salt.utils.files
 import salt.utils.json
+import salt.utils.platform
 import salt.utils.stringutils
-
-
-def with_tempfile(func):
-    '''
-    Generate a temp directory for a test
-    '''
-    @functools.wraps(func)
-    def wrapper(self, *args, **kwargs):
-        temp_file = salt.utils.files.mkstemp(dir=TMP)
-        try:
-            return func(self, temp_file, *args, **kwargs)
-        finally:
-            try:
-                os.remove(temp_file)
-            except OSError as exc:
-                if exc.errno != errno.ENOENT:
-                    raise
-    return wrapper
+from salt.ext import six
 
 
 class JSONTestCase(TestCase):
@@ -112,6 +94,21 @@ class JSONTestCase(TestCase):
 
         # Test to see if a ValueError is raised if no JSON is passed in
         self.assertRaises(ValueError, salt.utils.json.find_json, LOREM_IPSUM)
+
+    @skipIf(salt.utils.platform.is_windows(), 'skip until we figure out what to do about decoding unicode on windows')
+    @skipIf(not six.PY2, 'Test only needed on Python 2')
+    @skipIf(NO_MOCK, NO_MOCK_REASON)
+    def test_find_json_unicode_splitlines(self):
+        '''
+        Tests a case in salt-ssh where a unicode string is split into a list of
+        str types by .splitlines().
+        '''
+        raw = '{"foo": "öäü"}'
+        mock_split = MagicMock(return_value=[raw.encode('utf8')])
+
+        with patch.object(salt.utils.json, '__split', mock_split):
+            ret = salt.utils.json.find_json(raw)
+            self.assertEqual(ret, {'foo': 'öäü'})
 
     def test_dumps_loads(self):
         '''


### PR DESCRIPTION
For reasons I can't explain, in `salt.utils.json.find_json()` using `.splitlines()` will sometimes convert a unicode string into a list of str types on Python 2. So, that's weird. This can be triggered in salt-ssh whenever there are non-ascii chars in the return data.

```
[DEBUG] raw = u'{"local": {"return": {"foo": "\xf6\xe4\xfc"}}}'
[DEBUG] raw.splitlines() = ['{"local": {"return": {"foo": "\xc3\xb6\xc3\xa4\xc3\xbc"}}}']
```

To resolve this, the UnicodeDecodeError is caught and reattempted with a decoded list.

This fix can be confirmed using a Docker container I have provided:

```
% docker run --rm -it -v $PWD:/testing terminalmage/issues:46477 sh -c '/usr/sbin/sshd -D & salt-ssh foobar grains.item foo'
foobar:
    ----------
    foo:
        öäü
```

This command should be run from the root of a git clone of Salt, as it will mount the git repo into that container and run salt-ssh from the mounted repo. [This walkthrough](https://help.github.com/articles/checking-out-pull-requests-locally/) can be used to check out this PR into your clone.