### PR TITLE
Fix KeyError in salt/states/boto_ec2.py

### DIFF
--- a/salt/states/boto_ec2.py
+++ b/salt/states/boto_ec2.py
@@ -886,6 +886,8 @@ def instance_present(name, instance_name=None, instance_id=None, image_id=None,
                     allocation_id=allocation_id, region=region, key=key,
                     keyid=keyid, profile=profile)
             if r:
+                if 'new' not in ret['changes']:
+                    ret['changes']['new'] = {}
                 ret['changes']['new']['public_ip'] = ip
             else:
                 ret['result'] = False


### PR DESCRIPTION
### What does this PR do?

Fix KeyError in salt/states/boto_ec2.py when an EIP is being associated to an existing instance where the state is being executed.

### What issues does this PR fix or reference?

Fixes #46479 

### Previous Behavior
Remove this section if not relevant

```
[DEBUG   ] LazyLoaded boto_ec2.instance_present
[INFO    ] Running state [associate_eip] at time 00:59:55.594009
[INFO    ] Executing state boto_ec2.instance_present for [associate_eip]
[DEBUG   ] The filters criteria {'instance_ids': ['i-02f8ae3a412912345'], 'filters': {}} matched the following instances:[Instance:i-02f8ae3a412912345]
[DEBUG   ] Limiting instance matches to those in the requested states: [Instance:i-02f8ae3a412912345]
[INFO    ] Instance exists.
[ERROR   ] An exception occurred in this state: Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/salt/state.py", line 1851, in call
    **cdata['kwargs'])
  File "/usr/lib/python2.7/site-packages/salt/loader.py", line 1795, in wrapper
    return f(*args, **kwargs)
  File "/usr/lib/python2.7/site-packages/salt/states/boto_ec2.py", line 889, in instance_present
    ret['changes']['new']['public_ip'] = ip
KeyError: 'new'

[INFO    ] Completed state [associate_eip] at time 00:59:56.136205 duration_in_ms=542.195
```

### New Behavior
Remove this section if not relevant

```
[INFO    ] Executing state boto_ec2.instance_present for [associate_eip]
[DEBUG   ] The filters criteria {'instance_ids': ['i-02f8ae3a412912345'], 'filters': {}} matched the following instances:[Instance:i-02f8ae3a412912345]
[DEBUG   ] Limiting instance matches to those in the requested states: [Instance:i-02f8ae3a412912345]
[INFO    ] Instance exists.
[INFO    ] {'new': {'public_ip': u'1.2.3.4'}}
[INFO    ] Completed state [associate_eip] at time 14:28:14.016232 duration_in_ms=881.598
```

### Tests written?

No

### Commits signed with GPG?

No
