### PR TITLE
Fixes stdout user environment corruption

### DIFF
--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -420,7 +420,7 @@ def _run(cmd,
                 stdout=subprocess.PIPE
             ).communicate(py_code.encode(__salt_system_encoding__))[0]
             env_mark = env_encoded.find(marker + '\n')
-            if (env_mark < 0):
+            if env_mark < 0:
                 raise CommandExecutionError(
                     'Environment could not be retrieved for User \'{0}\': missing first marker'.format(
                         runas
@@ -429,7 +429,7 @@ def _run(cmd,
             # strip first marker line plus newline
             env_encoded = env_encoded[env_mark + len(marker) + 1:]
             env_mark = env_encoded.find('\n' + marker + '\n')
-            if (env_mark < 0):
+            if env_mark < 0:
                 raise CommandExecutionError(
                     'Environment could not be retrieved for User \'{0}\': missing second marker'.format(
                         runas


### PR DESCRIPTION
### What does this PR do?
This fix will set a marker before the users env is created. Make the env var.
Then set a marker after it is done. Then will grab the real env info between
the markers, and throw away the markers. Any stdout noise is then mitigated.

### What issues does this PR fix or reference?
When using PAM module pam_lastlog.so with config option "showfailed", it
outputs a "Last login ..." line to stdout everytime a shell is spawned.
This corrupts a random env var and causes havoc in paths and the like.

To reproduce: PAM option was put in /etc/pam.d/su file with line:
session required pam_lastlog.so showfailed

then: salt minionid cmd.run runas=username env

Which will show "Last login ..." in one of the env vars.

### Previous Behavior
    LOGNAME=username
    XDG_SESSION_ID=c4Last login: Sat Mar 10 23:49:26 EST 2018 from 192.168.0.55 on pts/3
    LC_COLLATE=C

### New Behavior
    LOGNAME=username
    XDG_SESSION_ID=c9
    LC_COLLATE=C

### Tests written?
No

### Commits signed with GPG?
No