### PR TITLE
Update azurearm.py

### DIFF
--- a/salt/cloud/clouds/azurearm.py
+++ b/salt/cloud/clouds/azurearm.py
@@ -1080,10 +1080,9 @@ def request_instance(call=None, kwargs=None):  # pylint: disable=unused-argument
         # https://{storage_account}.blob.core.windows.net/{path}/{vhd}
         source_image = VirtualHardDisk(vm_['image'])
         img_ref = None
-        if win_installer:
-            os_type = 'Windows'
-        else:
-            os_type = 'Linux'
+        os_type = config.get_cloud_config_value(
+        'os_type', vm_, __opts__, search_global=True
+        )
     else:
         img_pub, img_off, img_sku, img_ver = vm_['image'].split('|')
         source_image = None


### PR DESCRIPTION
Added parameter os_type to decide which os the custom vhd will provision.

### What does this PR do?

This PR will choose os_type for custom vhd correctly.

### What issues does this PR fix or reference?
The os_type was selected as linux for windows also.
### Previous Behavior
Earlier the decision of os_type was dependent on win_installer parameter.But if deploy is false, we will not give win_installer and in that case always the os_type was selected as linux. 

### New Behavior
Now os_type is directly set in profile


