### PR TITLE
Update azurearm.py

### DIFF
--- a/salt/cloud/clouds/azurearm.py
+++ b/salt/cloud/clouds/azurearm.py
@@ -1076,14 +1076,20 @@ def request_instance(call=None, kwargs=None):  # pylint: disable=unused-argument
     win_installer = config.get_cloud_config_value(
         'win_installer', vm_, __opts__, search_global=True
     )
+    os_type = config.get_cloud_config_value(
+        'os_type', vm_, __opts__, search_global=True
+    )
+    
     if vm_['image'].startswith('http'):
         # https://{storage_account}.blob.core.windows.net/{path}/{vhd}
         source_image = VirtualHardDisk(vm_['image'])
         img_ref = None
-        if win_installer:
-            os_type = 'Windows'
-        else:
-            os_type = 'Linux'
+        if not os_type:
+            raise SaltCloudSystemExit(
+            'os_type must be specified in case of custom vhd'
+        )
+        
+        
     else:
         img_pub, img_off, img_sku, img_ver = vm_['image'].split('|')
         source_image = None


### PR DESCRIPTION
 os_type decision making in case of custom vhd

### Purpose 
select os_type correctly for custom vhd

### Issue
 wrong os_type for custom vhd

### Previous Behavior
Earlier for custom vhd os_type was selected on whether win_installer is specified or not  but in case when deploy is false we will not provide win_installer and os_type was set to linux for windows custom vhds also.
```
if win_installer:
            os_type = 'Windows'
        else:
            os_type = 'Linux'
```
### New Behavior
Now os_type will be needed in profile in case of custom vhds,else error will occur.
 ```
 os_type = config.get_cloud_config_value(
      'os_type', vm_, __opts__, search_global=True    )

```