### PR TITLE
iptables cgroup support

### DIFF
--- a/salt/modules/iptables.py
+++ b/salt/modules/iptables.py
@@ -1093,6 +1093,8 @@ def _parser():
     add_arg('--ahres', dest='ahres', action='append')
     ## bpf
     add_arg('--bytecode', dest='bytecode', action='append')
+    ## cgroup
+    add_arg('--cgroup', dest='cgroup', action='append')
     ## cluster
     add_arg('--cluster-total-nodes',
             dest='cluster-total-nodes',


### PR DESCRIPTION
### What does this PR do?

It allows the iptables module to manage cgroup-based rules. According to its documentation:
```
$ iptables -m cgroup --help
[...]
cgroup match options:
[!] --cgroup fwid  Match cgroup fwid
```

### What issues does this PR fix or reference?
No issue created for this.

### Previous Behavior
The salt master would report
```
Minion did not return. [No response]
```
and the salt minion would log
```
[INFO    ] Executing state iptables.insert for iptables-log-docker
usage: salt-minion [-h] [-A APPEND] [-D DELETE] [-I INSERT] [-R REPLACE]
                   [-L LIST] [-F FLUSH] [-Z ZERO] [-N NEW-CHAIN]
[...]
salt-minion: error: unrecognized arguments: --cgroup 86
```
if a state like
```
iptables-output-cg86:
  iptables.append:
    - chain: OUTPUT
    - match: cgroup
    - cgroup: 86
    - jump: CG86
    - save: True
```
had previously been applied. To make Salt work again, one had to manually flush the rules (`iptables --flush`).

### New Behavior
Correctly parse the current iptables ruleset if it contains `--cgroup`.

### Tests written?

No

### Commits signed with GPG?

Yes
