### PR TITLE
Add the ability to send Salt minion keys to the userdata script

### DIFF
--- a/doc/topics/cloud/azurearm.rst
+++ b/doc/topics/cloud/azurearm.rst
@@ -322,6 +322,18 @@ Optional. The path to a file to be read and submitted to Azure as user data.
 How this is used depends on the operating system that is being deployed. If
 used, any ``userdata`` setting will be ignored.
 
+userdata_sendkeys
+-------------
+Optional. Set to ``True`` in order to generate salt minion keys and provide
+them as variables to the userdata script when running it through the template
+renderer. The keys can be referenced as ``{{opts['priv_key']}}`` and
+``{{opts['pub_key']}}``.
+
+userdata_template
+-------------
+Optional. Enter the renderer, such as ``jinja``, to be used for the userdata
+script template.
+
 wait_for_ip_timeout
 -------------------
 Optional. Default is ``600``. When waiting for a VM to be created, Salt Cloud

--- a/salt/cloud/clouds/azurearm.py
+++ b/salt/cloud/clouds/azurearm.py
@@ -1223,6 +1223,26 @@ def request_instance(vm_):
                 userdata = fh_.read()
 
     if userdata and userdata_template:
+        userdata_sendkeys = config.get_cloud_config_value(
+            'userdata_sendkeys', vm_, __opts__, search_global=False, default=None
+        )
+        if userdata_sendkeys:
+            vm_['priv_key'], vm_['pub_key'] = salt.utils.cloud.gen_keys(
+                config.get_cloud_config_value(
+                    'keysize',
+                    vm_,
+                    __opts__
+                )
+            )
+
+            key_id = vm_.get('name')
+            if 'append_domain' in vm_:
+                key_id = '.'.join([key_id, vm_['append_domain']])
+
+            salt.utils.cloud.accept_key(
+                __opts__['pki_dir'], vm_['pub_key'], key_id
+            )
+
         userdata = salt.utils.cloud.userdata_template(__opts__, vm_, userdata)
 
     custom_extension = None


### PR DESCRIPTION
### What does this PR do?
This PR adds the ability to send Salt minion keys to the userdata script when using a template renderer. The use case for this behavior is when you cannot use the built-in salt-cloud deploy scripts due to inability to SSH directly to the instance. If you are deploying instances to a secluded virtual network with outbound-only access, you can utilize a userdata script with `userdata_sendkeys` enabled to install the salt-minion software and deploy a pre-accepted key.

### What issues does this PR fix or reference?
N/A

### Tests written?
No

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
