### PR TITLE
salt-call: don't re-use initial pillar if CLI overrides passed

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -703,8 +703,12 @@ class State(object):
             except AttributeError:
                 pillar_enc = str(pillar_enc).lower()
         self._pillar_enc = pillar_enc
-        if initial_pillar:
+        if initial_pillar and not self._pillar_override:
             self.opts['pillar'] = initial_pillar
+        else:
+            # Compile pillar data
+            self.opts['pillar'] = self._gather_pillar()
+            # Reapply overrides on top of compiled pillar
             if self._pillar_override:
                 self.opts['pillar'] = salt.utils.dictupdate.merge(
                     self.opts['pillar'],
@@ -712,8 +716,6 @@ class State(object):
                     self.opts.get('pillar_source_merging_strategy', 'smart'),
                     self.opts.get('renderer', 'yaml'),
                     self.opts.get('pillar_merge_lists', False))
-        else:
-            self.opts['pillar'] = self._gather_pillar()
         self.state_con = context or {}
         self.load_modules()
         self.active = set()


### PR DESCRIPTION
A salt-call run already compiles pillar before executing the specified function. Therefore, a performance improvement was made to re-use that initial pillar data when running states. However, when we just re-use that pillar data, we lose the ability to have custom external pillar modules gain access to CLI pillar overrides. Therefore, this commit changes the code in the state compiler which gathers/re-uses the pillar data so that it only re-uses the existing in-memory pillar data when no CLI pillar overrides were passed.

Refs: 8d6fdb7, #44483

Fixes #46207

Use [this walkthrough](https://help.github.com/articles/checking-out-pull-requests-locally/) to check out the PR locally, and then the docker container below can be used to confirm the fix. All docker commands should be run from the root of the git clone of Salt.

Note that what the override doesn't make it into the initial calls to evaluate the ext_pillar, this is because these are run as salt-call is starting up. The final call comes as we're running the highstate though, and does indeed contain the CLI overrides.

```
% docker run --rm -it -v $PWD:/testing terminalmage/issues:46207
[root@512d8dd78ec8 /]# salt-master -d; salt-minion -d; sleep 10; salt-call state.highstate pillar='{"foo": "bar"}'; grep PILLAR /var/log/salt/master
local:
----------
          ID: echo bar
    Function: cmd.run
      Result: True
     Comment: Command "echo bar" run
     Started: 16:48:51.669426
    Duration: 376.983 ms
     Changes:
              ----------
              pid:
                  553
              retcode:
                  0
              stderr:
              stdout:
                  bar

Summary for local
------------
Succeeded: 1 (changed=1)
Failed:    0
------------
Total states run:     1
Total run time: 376.983 ms
2018-03-12 16:48:51,119 [salt.loaded.ext.pillar.my_ext_pillar           :6   ][CRITICAL][55] PILLAR: {}
2018-03-12 16:48:51,171 [salt.loaded.ext.pillar.my_ext_pillar           :6   ][CRITICAL][55] PILLAR: {}
2018-03-12 16:48:51,349 [salt.loaded.ext.pillar.my_ext_pillar           :6   ][CRITICAL][47] PILLAR: {'foo': 'bar'}
[root@512d8dd78ec8 /]#
```