### PR TITLE
Remove deprecated syntax for roster_order in roster/cache.py

### DIFF
--- a/doc/topics/releases/fluorine.rst
+++ b/doc/topics/releases/fluorine.rst
@@ -22,3 +22,18 @@ the Neon release of Salt.
 
 The Salt Syndic currently sends an old style  `syndic_start` event as well. The
 syndic respects :conf_minion:`enable_legacy_startup_events` as well.
+
+
+Deprecations
+------------
+
+Roster Deprecations
+===================
+
+The ``cache`` roster had the following changes:
+
+- Support for ``roster_order`` as a list or tuple has been removed. As of the
+  ``Fluorine`` release, ``roster_order`` must be a dictionary.
+- The ``roster_order`` option now includes IPv6 in addition to IPv4 for the
+  ``private``, ``public``, ``global`` or ``local`` settings. The syntax for these
+  settings has changed to ``ipv4-*`` or ``ipv6-*``, respectively.

--- a/salt/roster/cache.py
+++ b/salt/roster/cache.py
@@ -93,17 +93,16 @@ This should be especially useful for the other roster keys:
             - ssh:auth:private_key
 
 '''
-from __future__ import absolute_import, print_function, unicode_literals
 
-# Python
+# Import Python libs
+from __future__ import absolute_import, print_function, unicode_literals
 import logging
 import re
 import copy
 
-# Salt libs
+# Import Salt libs
 import salt.utils.data
 import salt.utils.minions
-import salt.utils.versions
 import salt.cache
 from salt._compat import ipaddress
 from salt.ext import six
@@ -132,25 +131,6 @@ def targets(tgt, tgt_type='glob', **kwargs):  # pylint: disable=W0613
     roster_order = __opts__.get('roster_order', {
         'host': ('ipv6-private', 'ipv6-global', 'ipv4-private', 'ipv4-public')
     })
-    if isinstance(roster_order, (tuple, list)):
-        salt.utils.versions.warn_until(
-            'Fluorine',
-            'Using legacy syntax for roster_order'
-        )
-        roster_order = {
-            'host': roster_order
-        }
-    for config_key, order in roster_order.items():
-        for idx, key in enumerate(order):
-            if key in ('public', 'private', 'local'):
-                salt.utils.versions.warn_until(
-                    'Fluorine',
-                    'roster_order {0} will include IPv6 soon. '
-                    'Set order to ipv4-{0} if needed.'.format(key)
-                )
-                order[idx] = 'ipv4-' + key
-
-    # log.debug(roster_order)
 
     ret = {}
     for minion_id in minions:


### PR DESCRIPTION
Fixes #46474

This code was marked for removal in the Fluorine release.