### PR TITLE
Remove deprecated syntax for "profile" in vault pillar

### DIFF
--- a/doc/topics/releases/fluorine.rst
+++ b/doc/topics/releases/fluorine.rst
@@ -27,6 +27,14 @@ syndic respects :conf_minion:`enable_legacy_startup_events` as well.
 Deprecations
 ------------
 
+Pillar Deprecations
+===================
+
+The ``vault`` pillar had the following changes:
+
+- Support for the ``profile`` argument was removed. Any options passed up until
+  and following the first ``path=`` are discarded.
+
 Roster Deprecations
 ===================
 

--- a/salt/pillar/vault.py
+++ b/salt/pillar/vault.py
@@ -52,9 +52,6 @@ Multiple Vault sources may also be used:
 from __future__ import absolute_import, print_function, unicode_literals
 import logging
 
-# Import Salt libs
-import salt.utils.versions
-
 log = logging.getLogger(__name__)
 
 __func_alias__ = {
@@ -77,12 +74,6 @@ def ext_pillar(minion_id,  # pylint: disable=W0613
     '''
     comps = conf.split()
 
-    if not comps[0].startswith('path='):
-        salt.utils.versions.warn_until(
-            'Fluorine',
-            'The \'profile\' argument has been deprecated. Any parts up until '
-            'and following the first "path=" are discarded'
-        )
     paths = [comp for comp in comps if comp.startswith('path=')]
     if not paths:
         log.error('"%s" is not a valid Vault ext_pillar config', conf)


### PR DESCRIPTION
Fixes #46475