### PR TITLE
Fixes stdout user environment corruption

### DIFF
--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -462,12 +462,14 @@ def _run(cmd,
             env_encoded = env_encoded[env_mark + len(marker) + 1:]
             env_mark = env_encoded.find('\n' + marker + '\n')
             if env_mark < 0:
+                raise CommandExecutionError(
                     'Environment could not be retrieved for User \'{0}\':'
                     ' second marker, got err={1} out={2}'.format(
                         runas,
                         repr(env_encoded_err),
                         repr(env_encoded_org)
                     )
+                )
             # strip second marker line plus leading newline
             env_encoded = env_encoded[0:env_mark]
 

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -475,7 +475,7 @@ def _run(cmd,
             else:
                 raise CommandExecutionError(
                     'Environment could not be retrieved for User \'{0}\':'
-                    ' missing a marker, got err={1!r} out={2!r}'.format(
+                    ' missing a marker, got err={1} out={2}'.format(
                         runas,
                         repr(env_encoded_err),
                         repr(env_encoded_org)

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -445,9 +445,9 @@ def _run(cmd,
                 stdout=subprocess.PIPE,
                 stdin=subprocess.PIPE
             ).communicate(py_code.encode(__salt_system_encoding__))
+            env_encoded_err = env_encoded[1]
+            env_encoded = env_encoded[0]
             env_encoded_org = env_encoded
-            env_encoded = env_encoded_org[0]
-            env_encoded_err = env_encoded_org[1]
             env_mark = env_encoded.find(marker + '\n')
             if env_mark < 0:
                 raise CommandExecutionError(

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -448,10 +448,10 @@ def _run(cmd,
             ).communicate(py_code.encode(__salt_system_encoding__))
             env_encoded_err = env_encoded[1]
             env_encoded = env_encoded[0]
-            if isinstance(env_encoded_err,str):
-              env_encoded_err = env_encoded_err.encode(__salt_system_encoding__)
-            if isinstance(env_encoded,str):
-              env_encoded = env_encoded.encode(__salt_system_encoding__)
+            if isinstance(env_encoded_err, str):
+                env_encoded_err = env_encoded_err.encode(__salt_system_encoding__)
+            if isinstance(env_encoded, str):
+                env_encoded = env_encoded.encode(__salt_system_encoding__)
             env_encoded_org = env_encoded
             env_mark = env_encoded.find(marker_b + b'\n')
             if env_mark < 0:

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -421,6 +421,7 @@ def _run(cmd,
             # There must be a better way to do this.
             import uuid
             marker = '<<<' + str(uuid.uuid4()) + '>>>'
+            marker_b = marker.encode(__salt_system_encoding__)
             py_code = (
                 'import sys, os, itertools; '
                 'sys.stdout.write(\"' + marker + '\\n\"); '
@@ -448,7 +449,7 @@ def _run(cmd,
             env_encoded_err = env_encoded[1]
             env_encoded = env_encoded[0]
             env_encoded_org = env_encoded
-            env_mark = env_encoded.find(marker + '\n')
+            env_mark = env_encoded.find(marker_b + b'\n')
             if env_mark < 0:
                 raise CommandExecutionError(
                     'Environment could not be retrieved for User \'{0}\':'
@@ -460,7 +461,7 @@ def _run(cmd,
                 )
             # strip first marker line plus newline
             env_encoded = env_encoded[env_mark + len(marker) + 1:]
-            env_mark = env_encoded.find('\n' + marker + '\n')
+            env_mark = env_encoded.find(b'\n' + marker_b + b'\n')
             if env_mark < 0:
                 raise CommandExecutionError(
                     'Environment could not be retrieved for User \'{0}\':'

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -448,6 +448,10 @@ def _run(cmd,
             ).communicate(py_code.encode(__salt_system_encoding__))
             env_encoded_err = env_encoded[1]
             env_encoded = env_encoded[0]
+            if isinstance(env_encoded_err,str):
+              env_encoded_err = env_encoded_err.encode(__salt_system_encoding__)
+            if isinstance(env_encoded,str):
+              env_encoded = env_encoded.encode(__salt_system_encoding__)
             env_encoded_org = env_encoded
             env_mark = env_encoded.find(marker_b + b'\n')
             if env_mark < 0:

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -446,7 +446,18 @@ def _run(cmd,
                 stdout=subprocess.PIPE,
                 stdin=subprocess.PIPE
             ).communicate(py_code.encode(__salt_system_encoding__))
-            if env_encoded.count(marker_b) != 2:
+            marker_count = env_encoded.count(marker_b)
+            if marker_count == 0:
+                # Possibly PAM prevented the login
+                log.error(
+                    'Environment could not be retrieved for user \'%s\': '
+                    'stderr=%r stdout=%r',
+                    runas, env_encoded_err, env_encoded
+                )
+                # Ensure that we get an empty env_runas dict below since we
+                # were not able to get the environment.
+                env_encoded = b''
+            elif marker_count != 2:
                 raise CommandExecutionError(
                     'Environment could not be retrieved for user \'{0}\'',
                     info={'stderr': repr(env_encoded_err),

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -424,9 +424,9 @@ def _run(cmd,
             marker_b = marker.encode(__salt_system_encoding__)
             py_code = (
                 'import sys, os, itertools; '
-                'sys.stdout.write(\"' + marker + '\\n\"); '
+                'sys.stdout.write(\"' + marker + '\"); '
                 'sys.stdout.write(\"\\0\".join(itertools.chain(*os.environ.items()))); '
-                'sys.stdout.write(\"\\n' + marker + '\\n\");'
+                'sys.stdout.write(\"' + marker + '\");'
             )
             if __grains__['os'] in ['MacOS', 'Darwin']:
                 env_cmd = ('sudo', '-i', '-u', runas, '--',
@@ -440,47 +440,21 @@ def _run(cmd,
                 env_cmd = ('su', '-', runas, '-c', sys.executable)
             else:
                 env_cmd = ('su', '-s', shell, '-', runas, '-c', sys.executable)
-            env_encoded = subprocess.Popen(
+            env_encoded, env_encoded_err = subprocess.Popen(
                 env_cmd,
                 stderr=subprocess.PIPE,
                 stdout=subprocess.PIPE,
                 stdin=subprocess.PIPE
             ).communicate(py_code.encode(__salt_system_encoding__))
-            env_encoded_err = env_encoded[1]
-            env_encoded = env_encoded[0]
-            if isinstance(env_encoded_err, str):
-                env_encoded_err = env_encoded_err.encode(__salt_system_encoding__)
-            if isinstance(env_encoded, str):
-                env_encoded = env_encoded.encode(__salt_system_encoding__)
-            env_encoded_org = env_encoded
-            env_mark = env_encoded.find(marker_b + b'\n')
-            first_marker_found = False
-            if env_mark >= 0:
-                # strip first marker line plus newline
-                env_encoded = env_encoded[env_mark + len(marker) + 1:]
-                first_marker_found = True
-            env_mark = env_encoded.find(b'\n' + marker_b + b'\n')
-            second_marker_found = False
-            if env_mark >= 0:
-                # strip second marker line plus leading newline
-                env_encoded = env_encoded[0:env_mark]
-                second_marker_found = True
-            if first_marker_found == second_marker_found:
-                if not first_marker_found:
-                    log.error('Unable to retrieve environment for \'%s\': err=%s out=%s',
-                              runas,
-                              repr(env_encoded_err),
-                              repr(env_encoded_org)
-                    )
-            else:
+            if env_encoded.count(marker_b) != 2:
                 raise CommandExecutionError(
-                    'Environment could not be retrieved for User \'{0}\':'
-                    ' missing a marker, got err={1} out={2}'.format(
-                        runas,
-                        repr(env_encoded_err),
-                        repr(env_encoded_org)
-                    )
+                    'Environment could not be retrieved for user \'{0}\'',
+                    info={'stderr': repr(env_encoded_err),
+                          'stdout': repr(env_encoded)}
                 )
+            else:
+                # Strip the marker
+                env_encoded = env_encoded.split(marker_b)[1]
 
             if six.PY2:
                 import itertools

--- a/tests/unit/modules/test_cmdmod.py
+++ b/tests/unit/modules/test_cmdmod.py
@@ -274,7 +274,7 @@ class CMDMODTestCase(TestCase, LoaderModuleMockMixin):
                 environment = os.environ.copy()
 
                 popen_mock.return_value = Mock(
-                    communicate=lambda *args, **kwags: ['{}', None],
+                    communicate=lambda *args, **kwags: [b'', None],
                     pid=lambda: 1,
                     retcode=0
                 )


### PR DESCRIPTION
### What does this PR do?
This fix will set a marker before the users env is created. Make the env var.
Then set a marker after it is done. Then will grab the real env info between
the markers, and throw away the markers. Any stdout noise is then mitigated.

### What issues does this PR fix or reference?
When using PAM module pam_lastlog.so with config option "showfailed", it
outputs a "Last login ..." line to stdout everytime a shell is spawned.
This corrupts a random env var and causes havoc in paths and the like.

To reproduce: PAM option was put in /etc/pam.d/su file with line:
session required pam_lastlog.so showfailed

then: salt <minion> cmd.run runas=<user> env

Which will show "Last login ..." in one of the env vars.

This fix will set a marker before the users env is created. Make the env var.
Then set a marker after it is done. Then will grab the real env info between
the markers, and throw away the markers. Any stdout noise is then mitigated.

### Previous Behavior
...
LOGNAME=username
XDG_SESSION_ID=c4Last login: Sat Mar 10 23:49:26 EST 2018 from 192.168.0.55 on pts/3
LC_COLLATE=C
...

### New Behavior
...
LOGNAME=username
XDG_SESSION_ID=c9
LC_COLLATE=C
...

### Tests written?
No

### Commits signed with GPG?
No