### PR TITLE
Touch up glossary references

### DIFF
--- a/doc/glossary.rst
+++ b/doc/glossary.rst
@@ -83,8 +83,8 @@ Glossary
         to the system.  State module functions should be idempotent.  Some
         state module functions, such as :mod:`cmd.run <salt.states.cmd.run>`
         are not idempotent by default but can be made idempotent with the
-        proper use of requisites such as :ref:```unless`` <unless-requisite>`
-        and :ref:```onlyif`` <onlyif-requisite>`.  For more information, *see*
+        proper use of requisites such as :ref:`unless <unless-requisite>`
+        and :ref:`onlyif <onlyif-requisite>`. For more information, *see*
         `wikipedia <https://en.wikipedia.org/wiki/Idempotent>`_.
 
     Jinja


### PR DESCRIPTION
### What does this PR do?

(Hopefully) fixes the glossary documentation links

### What issues does this PR fix or reference?

Issue can be seen at https://docs.saltstack.com/en/latest/glossary.html#term-idempotent

![current salt glossary page](https://user-images.githubusercontent.com/1447148/37170920-da8c7018-22d1-11e8-86cd-13c343e6726c.png)

### Tests written?

No

### Commits signed with GPG?

Yes