### PR TITLE
Make iSCSI and Fibre Channel grains optional

### DIFF
--- a/doc/ref/configuration/minion.rst
+++ b/doc/ref/configuration/minion.rst
@@ -786,6 +786,35 @@ A value of 10 minutes is a reasonable default.
 
     grains_refresh_every: 0
 
+.. conf_minion:: fibre_channel_grains
+
+``fibre_channel_grains``
+------------------------
+
+Default: ``False``
+
+The ``fibre_channel_grains`` setting will enable the ``fc_wwn`` grain for
+Fibre Channel WWN's on the minion. Since this grain is expensive is
+disabled by default.
+
+.. code-block:: yaml
+
+    fibre_channel_grains: True
+
+.. conf_minion:: iscsi_grains
+
+``iscsi_grains``
+------------------------
+
+Default: ``False``
+
+The ``iscsi_grains`` setting will enable the ``iscsi_iqn`` grain on the
+minion. Since this grain is expensive is disabled by default.
+
+.. code-block:: yaml
+
+    iscsi_grains: True
+
 .. conf_minion:: mine_enabled
 
 ``mine_enabled``

--- a/doc/ref/configuration/minion.rst
+++ b/doc/ref/configuration/minion.rst
@@ -794,7 +794,7 @@ A value of 10 minutes is a reasonable default.
 Default: ``False``
 
 The ``fibre_channel_grains`` setting will enable the ``fc_wwn`` grain for
-Fibre Channel WWN's on the minion. Since this grain is expensive is
+Fibre Channel WWN's on the minion. Since this grain is expensive, it is
 disabled by default.
 
 .. code-block:: yaml
@@ -809,7 +809,7 @@ disabled by default.
 Default: ``False``
 
 The ``iscsi_grains`` setting will enable the ``iscsi_iqn`` grain on the
-minion. Since this grain is expensive is disabled by default.
+minion. Since this grain is expensivem it is disabled by default.
 
 .. code-block:: yaml
 

--- a/doc/ref/configuration/minion.rst
+++ b/doc/ref/configuration/minion.rst
@@ -809,7 +809,7 @@ disabled by default.
 Default: ``False``
 
 The ``iscsi_grains`` setting will enable the ``iscsi_iqn`` grain on the
-minion. Since this grain is expensivem it is disabled by default.
+minion. Since this grain is expensive, it is disabled by default.
 
 .. code-block:: yaml
 

--- a/doc/topics/releases/2018.3.0.rst
+++ b/doc/topics/releases/2018.3.0.rst
@@ -521,6 +521,8 @@ In addition to the ``mapping`` and ``port`` options, the following additional op
   match a given Master. If set to ``any`` (the default), then any match to a
   key/value mapping will constitute a match.
 - ``pause`` - The interval in seconds between attempts (default: 5).
+- ``fibre_channel_grains`` - Enables the ``fc_wwn`` grain. (Default: False)
+- ``iscsi_grains`` - Enables the ``iscsi_iqn`` grain. (Default: False)
 
 Connection to a type instead of DNS
 ===================================

--- a/salt/grains/fibre_channel.py
+++ b/salt/grains/fibre_channel.py
@@ -22,7 +22,6 @@ import salt.modules.cmdmod
 import salt.utils.platform
 import salt.utils.files
 
-__proxyenabled__ = ['fibre_channel']
 __virtualname__ = 'fibre_channel'
 
 # Get logging started

--- a/salt/grains/fibre_channel.py
+++ b/salt/grains/fibre_channel.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+'''
+Grains for Fibre Channel WWN's. On Windows this runs a PowerShell command that
+queries WMI to get the Fibre Channel WWN's available.
+
+.. versionadded:: 2018.3.0
+
+To enable these grains set ``fibre_channel_grains: True``.
+
+.. code-block:: yaml
+
+    fibre_channel_grains: True
+'''
+# Import Python libs
+from __future__ import absolute_import, print_function, unicode_literals
+
+import glob
+import logging
+
+# Import Salt libs
+import salt.modules.cmdmod
+import salt.utils.platform
+import salt.utils.files
+
+__proxyenabled__ = ['fibre_channel']
+__virtualname__ = 'fibre_channel'
+
+# Get logging started
+log = logging.getLogger(__name__)
+
+
+def __virtual__():
+    if __opts__.get('fibre_channel_grains', False) is False:
+        return False
+    else:
+        return __virtualname__
+
+
+def _linux_wwns():
+    '''
+    Return Fibre Channel port WWNs from a Linux host.
+    '''
+    ret = []
+    for fc_file in glob.glob('/sys/class/fc_host/*/port_name'):
+        with salt.utils.files.fopen(fc_file, 'r') as _wwn:
+            for line in _wwn:
+                ret.append(line.rstrip()[2:])
+    return ret
+
+
+def _windows_wwns():
+    '''
+    Return Fibre Channel port WWNs from a Windows host.
+    '''
+    ps_cmd = r'Get-WmiObject -ErrorAction Stop ' \
+             r'-class MSFC_FibrePortHBAAttributes ' \
+             r'-namespace "root\WMI" | ' \
+             r'Select -Expandproperty Attributes | ' \
+             r'%{($_.PortWWN | % {"{0:x2}" -f $_}) -join ""}'
+    ret = []
+    cmd_ret = salt.modules.cmdmod.powershell(ps_cmd)
+    for line in cmd_ret:
+        ret.append(line.rstrip())
+    return ret
+
+
+def fibre_channel_wwns():
+    '''
+    Return list of fiber channel HBA WWNs
+    '''
+    grains = {'fc_wwn': False}
+    if salt.utils.platform.is_linux():
+        grains['fc_wwn'] = _linux_wwns()
+    elif salt.utils.platform.is_windows():
+        grains['fc_wwn'] = _windows_wwns()
+    return grains

--- a/salt/grains/fibre_channel.py
+++ b/salt/grains/fibre_channel.py
@@ -43,7 +43,8 @@ def _linux_wwns():
     ret = []
     for fc_file in glob.glob('/sys/class/fc_host/*/port_name'):
         with salt.utils.files.fopen(fc_file, 'r') as _wwn:
-            for line in _wwn:
+            content = _wwn.read()
+            for line in content.splitlines():
                 ret.append(line.rstrip()[2:])
     return ret
 

--- a/salt/grains/iscsi.py
+++ b/salt/grains/iscsi.py
@@ -22,7 +22,6 @@ import salt.utils.files
 import salt.utils.path
 import salt.utils.platform
 
-__proxyenabled__ = ['iscsi']
 __virtualname__ = 'iscsi'
 
 # Get logging started

--- a/salt/grains/iscsi.py
+++ b/salt/grains/iscsi.py
@@ -1,0 +1,115 @@
+# -*- coding: utf-8 -*-
+'''
+Grains for iSCSI Qualified Names (IQN).
+
+.. versionadded:: 2018.3.0
+
+To enable these grains set `iscsi_grains: True`.
+
+.. code-block:: yaml
+
+    iscsi_grains: True
+'''
+# Import Python libs
+from __future__ import absolute_import, print_function, unicode_literals
+
+import logging
+import os
+
+# Import Salt libs
+import salt.modules.cmdmod
+import salt.utils.files
+import salt.utils.path
+import salt.utils.platform
+
+__proxyenabled__ = ['iscsi']
+__virtualname__ = 'iscsi'
+
+# Get logging started
+log = logging.getLogger(__name__)
+
+
+def __virtual__():
+    if __opts__.get('iscsi_grains', False) is False:
+        return False
+    else:
+        return __virtualname__
+
+
+def iscsi_iqn():
+    '''
+    Return iSCSI IQN
+    '''
+    grains = {}
+    grains['iscsi_iqn'] = False
+    if salt.utils.platform.is_linux():
+        grains['iscsi_iqn'] = _linux_iqn()
+    elif salt.utils.platform.is_windows():
+        grains['iscsi_iqn'] = _windows_iqn()
+    elif salt.utils.platform.is_aix():
+        grains['iscsi_iqn'] = _aix_iqn()
+    return grains
+
+
+def _linux_iqn():
+    '''
+    Return iSCSI IQN from a Linux host.
+    '''
+    ret = []
+
+    initiator = '/etc/iscsi/initiatorname.iscsi'
+    try:
+        with salt.utils.files.fopen(initiator, 'r') as _iscsi:
+            for line in _iscsi:
+                line = line.strip()
+                if line.startswith('InitiatorName='):
+                    ret.append(line.split('=', 1)[1])
+    except IOError as ex:
+        if ex.errno != os.errno.ENOENT:
+            log.debug("Error while accessing '%s': %s", initiator, ex)
+
+    return ret
+
+
+def _aix_iqn():
+    '''
+    Return iSCSI IQN from an AIX host.
+    '''
+    ret = []
+
+    aix_cmd = 'lsattr -E -l iscsi0 | grep initiator_name'
+
+    aix_ret = salt.modules.cmdmod.run(aix_cmd)
+    if aix_ret[0].isalpha():
+        try:
+            ret.append(aix_ret.split()[1].rstrip())
+        except IndexError:
+            pass
+    return ret
+
+
+def _windows_iqn():
+    '''
+    Return iSCSI IQN from a Windows host.
+    '''
+    ret = []
+
+    wmic = salt.utils.path.which('wmic')
+
+    if not wmic:
+        return ret
+
+    namespace = r'\\root\WMI'
+    path = 'MSiSCSIInitiator_MethodClass'
+    get = 'iSCSINodeName'
+
+    cmd_ret = salt.modules.cmdmod.run_all(
+        '{0} /namespace:{1} path {2} get {3} /format:table'
+        ''.format(wmic, namespace, path, get))
+
+    for line in cmd_ret['stdout'].splitlines():
+        if line.startswith('iqn.'):
+            line = line.rstrip()
+            ret.append(line.rstrip())
+
+    return ret

--- a/tests/unit/grains/test_core.py
+++ b/tests/unit/grains/test_core.py
@@ -487,58 +487,6 @@ PATCHLEVEL = 3
         self.assertListEqual(list(os_grains.get('osrelease_info')), os_release_map['osrelease_info'])
         self.assertEqual(os_grains.get('osmajorrelease'), os_release_map['osmajorrelease'])
 
-    def test_windows_iscsi_iqn_grains(self):
-        cmd_run_mock = MagicMock(
-            return_value={'stdout': 'iSCSINodeName\niqn.1991-05.com.microsoft:simon-x1\n'}
-        )
-
-        with patch.object(salt.utils.platform, 'is_linux',
-                          MagicMock(return_value=False)):
-            with patch.object(salt.utils.platform, 'is_windows',
-                              MagicMock(return_value=True)):
-                with patch.dict(core.__salt__, {'run_all': cmd_run_mock}):
-                    with patch.object(salt.utils.path, 'which',
-                                      MagicMock(return_value=True)):
-                        with patch.dict(core.__salt__, {'cmd.run_all': cmd_run_mock}):
-                            _grains = core.iscsi_iqn()
-
-        self.assertEqual(_grains.get('iscsi_iqn'),
-                         ['iqn.1991-05.com.microsoft:simon-x1'])
-
-    @skipIf(salt.utils.platform.is_windows(), 'System is Windows')
-    def test_aix_iscsi_iqn_grains(self):
-        cmd_run_mock = MagicMock(
-            return_value='initiator_name iqn.localhost.hostid.7f000001'
-        )
-
-        with patch.object(salt.utils.platform, 'is_linux',
-                          MagicMock(return_value=False)):
-            with patch.object(salt.utils.platform, 'is_aix',
-                              MagicMock(return_value=True)):
-                with patch.dict(core.__salt__, {'cmd.run': cmd_run_mock}):
-                    _grains = core.iscsi_iqn()
-
-        self.assertEqual(_grains.get('iscsi_iqn'),
-                         ['iqn.localhost.hostid.7f000001'])
-
-    @patch('salt.grains.core.os.path.isfile', MagicMock(return_value=True))
-    @patch('salt.grains.core.os.access', MagicMock(return_value=True))
-    def test_linux_iscsi_iqn_grains(self):
-        _iscsi_file = '## DO NOT EDIT OR REMOVE THIS FILE!\n' \
-                      '## If you remove this file, the iSCSI daemon will not start.\n' \
-                      '## If you change the InitiatorName, existing access control lists\n' \
-                      '## may reject this initiator.  The InitiatorName must be unique\n' \
-                      '## for each iSCSI initiator.  Do NOT duplicate iSCSI InitiatorNames.\n' \
-                      'InitiatorName=iqn.1993-08.org.debian:01:d12f7aba36\n'
-
-        with patch('salt.utils.files.fopen', mock_open()) as iscsi_initiator_file:
-            iscsi_initiator_file.return_value.__iter__.return_value = _iscsi_file.splitlines()
-            iqn = core._linux_iqn()
-
-        assert isinstance(iqn, list)
-        assert len(iqn) == 1
-        assert iqn == ['iqn.1993-08.org.debian:01:d12f7aba36']
-
     @skipIf(not salt.utils.platform.is_linux(), 'System is not Linux')
     def test_linux_memdata(self):
         '''
@@ -835,30 +783,3 @@ SwapTotal:       4789244 kB'''
                        []}}
         with patch.object(salt.utils.dns, 'parse_resolv', MagicMock(return_value=resolv_mock)):
             assert core.dns() == ret
-
-    @patch('salt.utils.files.fopen', MagicMock(side_effect=IOError(os.errno.EPERM,
-                                                                   'The cables are not the same length.')))
-    @patch('salt.grains.core.log', MagicMock())
-    def test_linux_iqn_non_root(self):
-        '''
-        Test if linux_iqn is running on salt-master as non-root
-        and handling access denial properly.
-        :return:
-        '''
-        assert core._linux_iqn() == []
-        core.log.debug.assert_called()
-        assert 'Error while accessing' in core.log.debug.call_args[0][0]
-        assert 'cables are not the same' in core.log.debug.call_args[0][2].strerror
-        assert core.log.debug.call_args[0][2].errno == os.errno.EPERM
-        assert core.log.debug.call_args[0][1] == '/etc/iscsi/initiatorname.iscsi'
-
-    @patch('salt.utils.files.fopen', MagicMock(side_effect=IOError(os.errno.ENOENT, '')))
-    @patch('salt.grains.core.log', MagicMock())
-    def test_linux_iqn_no_iscsii_initiator(self):
-        '''
-        Test if linux_iqn is running on salt-master as root.
-        iscsii initiator is not there accessible or is not supported.
-        :return:
-        '''
-        assert core._linux_iqn() == []
-        core.log.debug.assert_not_called()

--- a/tests/unit/grains/test_fibre_channel.py
+++ b/tests/unit/grains/test_fibre_channel.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+'''
+    :codeauthor: :email:`Shane Lee <slee@saltstack.com>`
+'''
+# Import Python libs
+from __future__ import absolute_import, print_function, unicode_literals
+
+# Import Salt Testing Libs
+from tests.support.unit import TestCase, skipIf
+from tests.support.mock import (
+    patch,
+    mock_open,
+    MagicMock,
+    NO_MOCK,
+    NO_MOCK_REASON
+)
+
+# Import Salt Libs
+import salt.grains.fibre_channel as fibre_channel
+
+
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class FibreChannelGrainsTestCase(TestCase):
+    '''
+    Test cases for iscsi grains
+    '''
+    def test_windows_fibre_channel_wwns_grains(self):
+        wwns = ['20:00:00:25:b5:11:11:4c',
+                '20:00:00:25:b5:11:11:5c',
+                '20:00:00:25:b5:44:44:4c',
+                '20:00:00:25:b5:44:44:5c']
+        cmd_run_mock = MagicMock(return_value=wwns)
+        with patch('salt.modules.cmdmod.powershell', cmd_run_mock):
+            ret = fibre_channel._windows_wwns()
+        self.assertEqual(ret, wwns)
+
+    @skipIf(True, "I can't get this to work")
+    def test_linux_fibre_channel_wwns_grains(self):
+
+        def multi_mock_open(*file_contents):
+            mock_files = [mock_open(read_data=content).return_value for content in file_contents]
+            mock_opener = mock_open()
+            mock_opener.side_effect = mock_files
+
+            return mock_opener
+
+        files = ['file1', 'file2']
+        with patch('glob.glob', MagicMock(return_value=files)):
+            with patch('salt.utils.files.fopen', multi_mock_open('0x500143802426baf4', '0x500143802426baf5')):
+                ret = fibre_channel._linux_wwns()
+
+        self.assertEqual(ret, ['0x500143802426baf4', '0x500143802426baf5'])

--- a/tests/unit/grains/test_fibre_channel.py
+++ b/tests/unit/grains/test_fibre_channel.py
@@ -34,7 +34,6 @@ class FibreChannelGrainsTestCase(TestCase):
             ret = fibre_channel._windows_wwns()
         self.assertEqual(ret, wwns)
 
-    @skipIf(True, "I can't get this to work")
     def test_linux_fibre_channel_wwns_grains(self):
 
         def multi_mock_open(*file_contents):
@@ -46,7 +45,7 @@ class FibreChannelGrainsTestCase(TestCase):
 
         files = ['file1', 'file2']
         with patch('glob.glob', MagicMock(return_value=files)):
-            with patch('salt.utils.files.fopen', multi_mock_open('0x500143802426baf4', '0x500143802426baf5')):
+            with patch('salt.utils.files.fopen', multi_mock_open(u'0x500143802426baf4', u'0x500143802426baf5')):
                 ret = fibre_channel._linux_wwns()
 
-        self.assertEqual(ret, ['0x500143802426baf4', '0x500143802426baf5'])
+        self.assertEqual(ret, ['500143802426baf4', '500143802426baf5'])

--- a/tests/unit/grains/test_fibre_channel.py
+++ b/tests/unit/grains/test_fibre_channel.py
@@ -45,7 +45,7 @@ class FibreChannelGrainsTestCase(TestCase):
 
         files = ['file1', 'file2']
         with patch('glob.glob', MagicMock(return_value=files)):
-            with patch('salt.utils.files.fopen', multi_mock_open(u'0x500143802426baf4', u'0x500143802426baf5')):
+            with patch('salt.utils.files.fopen', multi_mock_open('0x500143802426baf4', '0x500143802426baf5')):
                 ret = fibre_channel._linux_wwns()
 
         self.assertEqual(ret, ['500143802426baf4', '500143802426baf5'])

--- a/tests/unit/grains/test_fibre_channel.py
+++ b/tests/unit/grains/test_fibre_channel.py
@@ -19,8 +19,6 @@ from tests.support.mock import (
 import salt.grains.fibre_channel as fibre_channel
 
 
-
-
 @skipIf(NO_MOCK, NO_MOCK_REASON)
 class FibreChannelGrainsTestCase(TestCase):
     '''

--- a/tests/unit/grains/test_iscsi.py
+++ b/tests/unit/grains/test_iscsi.py
@@ -31,9 +31,9 @@ class IscsiGrainsTestCase(TestCase):
                                     'iqn.1991-05.com.microsoft:simon-x1\n'}
         )
         _grains = {}
-        with patch('salt.utils.path.which', MagicMock(return_value=True)) and \
-                patch('salt.modules.cmdmod.run_all', cmd_run_mock):
-            _grains['iscsi_iqn'] = iscsi._windows_iqn()
+        with patch('salt.utils.path.which', MagicMock(return_value=True)):
+            with patch('salt.modules.cmdmod.run_all', cmd_run_mock):
+                _grains['iscsi_iqn'] = iscsi._windows_iqn()
 
         self.assertEqual(_grains.get('iscsi_iqn'),
                          ['iqn.1991-05.com.microsoft:simon-x1'])

--- a/tests/unit/grains/test_iscsi.py
+++ b/tests/unit/grains/test_iscsi.py
@@ -1,0 +1,94 @@
+# -*- coding: utf-8 -*-
+'''
+    :codeauthor: :email:`Shane Lee <slee@saltstack.com>`
+'''
+# Import Python libs
+from __future__ import absolute_import, print_function, unicode_literals
+import os
+
+# Import Salt Testing Libs
+from tests.support.unit import TestCase, skipIf
+from tests.support.mock import (
+    patch,
+    mock_open,
+    MagicMock,
+    NO_MOCK,
+    NO_MOCK_REASON
+)
+
+# Import Salt Libs
+import salt.grains.iscsi as iscsi
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class IscsiGrainsTestCase(TestCase):
+    '''
+    Test cases for iscsi grains
+    '''
+    def test_windows_iscsi_iqn_grains(self):
+        cmd_run_mock = MagicMock(
+            return_value={'stdout': 'iSCSINodeName\n'
+                                    'iqn.1991-05.com.microsoft:simon-x1\n'}
+        )
+        _grains = {}
+        with patch('salt.utils.path.which', MagicMock(return_value=True)) and \
+                patch('salt.modules.cmdmod.run_all', cmd_run_mock):
+            _grains['iscsi_iqn'] = iscsi._windows_iqn()
+
+        self.assertEqual(_grains.get('iscsi_iqn'),
+                         ['iqn.1991-05.com.microsoft:simon-x1'])
+
+    def test_aix_iscsi_iqn_grains(self):
+        cmd_run_mock = MagicMock(
+            return_value='initiator_name iqn.localhost.hostid.7f000001'
+        )
+
+        _grains = {}
+        with patch('salt.modules.cmdmod.run', cmd_run_mock):
+            _grains['iscsi_iqn'] = iscsi._aix_iqn()
+
+        self.assertEqual(_grains.get('iscsi_iqn'),
+                         ['iqn.localhost.hostid.7f000001'])
+
+    def test_linux_iscsi_iqn_grains(self):
+        _iscsi_file = '## DO NOT EDIT OR REMOVE THIS FILE!\n' \
+                      '## If you remove this file, the iSCSI daemon will not start.\n' \
+                      '## If you change the InitiatorName, existing access control lists\n' \
+                      '## may reject this initiator.  The InitiatorName must be unique\n' \
+                      '## for each iSCSI initiator.  Do NOT duplicate iSCSI InitiatorNames.\n' \
+                      'InitiatorName=iqn.1993-08.org.debian:01:d12f7aba36\n'
+
+        with patch('salt.utils.files.fopen', mock_open()) as iscsi_initiator_file:
+            iscsi_initiator_file.return_value.__iter__.return_value = _iscsi_file.splitlines()
+            iqn = iscsi._linux_iqn()
+
+        assert isinstance(iqn, list)
+        assert len(iqn) == 1
+        assert iqn == ['iqn.1993-08.org.debian:01:d12f7aba36']
+
+    @patch('salt.utils.files.fopen', MagicMock(side_effect=IOError(os.errno.EPERM,
+                                                                   'The cables are not the same length.')))
+    @patch('salt.grains.iscsi.log', MagicMock())
+    def test_linux_iqn_non_root(self):
+        '''
+        Test if linux_iqn is running on salt-master as non-root
+        and handling access denial properly.
+        :return:
+        '''
+        assert iscsi._linux_iqn() == []
+        iscsi.log.debug.assert_called()
+        assert 'Error while accessing' in iscsi.log.debug.call_args[0][0]
+        assert 'cables are not the same' in iscsi.log.debug.call_args[0][2].strerror
+        assert iscsi.log.debug.call_args[0][2].errno == os.errno.EPERM
+        assert iscsi.log.debug.call_args[0][1] == '/etc/iscsi/initiatorname.iscsi'
+
+    @patch('salt.utils.files.fopen', MagicMock(side_effect=IOError(os.errno.ENOENT, '')))
+    @patch('salt.grains.iscsi.log', MagicMock())
+    def test_linux_iqn_no_iscsii_initiator(self):
+        '''
+        Test if linux_iqn is running on salt-master as root.
+        iscsii initiator is not there accessible or is not supported.
+        :return:
+        '''
+        assert iscsi._linux_iqn() == []
+        iscsi.log.debug.assert_not_called()


### PR DESCRIPTION
### What does this PR do?
Creates `iscsi.py` and `fibre_channel.py`
Removes those grains from `core.py`
Gates the grains with options from the config file:
- `fibre_channel_grains`
- `iscsi_grains`

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/46425
https://github.com/saltstack/salt/pull/43647

### Previous Behavior
Grains would (attempt) to be populated every time. It is especially slow on Windows because it uses PowerShell and WMIC.

### New Behavior
These grains are now optional via config

### Tests written?
No

### Commits signed with GPG?
Yes