### PR TITLE
Fixed GPG pillar decryption.

### DIFF
--- a/tests/unit/renderers/test_gpg.py
+++ b/tests/unit/renderers/test_gpg.py
@@ -20,11 +20,9 @@ from salt.exceptions import SaltRenderError
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
 class GPGTestCase(TestCase, LoaderModuleMockMixin):
-
     '''
     unit test GPG renderer
     '''
-
     def setup_loader_modules(self):
         return {gpg: {}}
 
@@ -46,29 +44,30 @@ class GPGTestCase(TestCase, LoaderModuleMockMixin):
         '''
         key_dir = '/etc/salt/gpgkeys'
         secret = 'Use more salt.'
-        crypted = '-----BEGIN PGP MESSAGE-----!@#$%^&*()_+-----END PGP MESSAGE-----'
+        crypted_long = '-----BEGIN PGP MESSAGE-----!@#$%^&*()_+-----END PGP MESSAGE-----'
+        crypted_short = '!@#$%^&*()_+'
 
         multisecret = 'password is {0} and salt is {0}'.format(secret)
-        multicrypted = 'password is {0} and salt is {0}'.format(crypted)
+        multicrypted = 'password is {0} and salt is {0}'.format(crypted_long)
 
         class GPGDecrypt(object):
-
             def communicate(self, *args, **kwargs):
                 return [secret, None]
 
         class GPGNotDecrypt(object):
-
             def communicate(self, *args, **kwargs):
                 return [None, 'decrypt error']
 
         with patch('salt.renderers.gpg._get_key_dir', MagicMock(return_value=key_dir)), \
                 patch('salt.utils.path.which', MagicMock()):
             with patch('salt.renderers.gpg.Popen', MagicMock(return_value=GPGDecrypt())):
-                self.assertEqual(gpg._decrypt_ciphertexts(crypted), secret)
+                self.assertEqual(gpg._decrypt_ciphertexts(crypted_short), secret)
+                self.assertEqual(gpg._decrypt_ciphertexts(crypted_long), secret)
                 self.assertEqual(
                     gpg._decrypt_ciphertexts(multicrypted), multisecret)
             with patch('salt.renderers.gpg.Popen', MagicMock(return_value=GPGNotDecrypt())):
-                self.assertEqual(gpg._decrypt_ciphertexts(crypted), crypted)
+                self.assertEqual(gpg._decrypt_ciphertexts(crypted_short), crypted_short)
+                self.assertEqual(gpg._decrypt_ciphertexts(crypted_long), crypted_long)
                 self.assertEqual(
                     gpg._decrypt_ciphertexts(multicrypted), multicrypted)
 
@@ -76,7 +75,6 @@ class GPGTestCase(TestCase, LoaderModuleMockMixin):
         '''
         test _decrypt_object
         '''
-
         secret = 'Use more salt.'
         crypted = '-----BEGIN PGP MESSAGE-----!@#$%^&*()_+-----END PGP MESSAGE-----'
 
@@ -97,7 +95,6 @@ class GPGTestCase(TestCase, LoaderModuleMockMixin):
         '''
         test render
         '''
-
         key_dir = '/etc/salt/gpgkeys'
         secret = 'Use more salt.'
         crypted = '-----BEGIN PGP MESSAGE-----!@#$%^&*()_+'


### PR DESCRIPTION
### What does this PR do?
1. Returned back the ability to decrypt raw encrypted data containing no
begin/end marks.
2. Remove trailing newlines if decrypted in a new 'multi' way
implemented in #45781

### What issues does this PR fix or reference?
Fix https://github.com/saltstack/salt-jenkins/issues/828
Update #45781

### Previous Behavior (before #45781)
pillar:
```
#!yaml|gpg
foo:
  bar: <encrypted data>
  baz: |
    -----BEGIN PGP MESSAGE-----
    <encrypted data>
    -----END PGP MESSAGE-----
  quux: |
    this is my complex pillar value
    it has a password:
    -----BEGIN PGP MESSAGE-----<encrypted password>-----END PGP MESSAGE-----
    and salt:
    -----BEGIN PGP MESSAGE-----<encrypted salt>-----END PGP MESSAGE-----
```
will be rendered as
```
foo:
  bar: <decrypted data>
  baz: <decrypted data>
  quux: <decrypted password>
```
`gpg` will render only the first ciphertext and strip the rest of plaintext and the second ciphertext

### Old Behavior (after #45781)
The same pillar:
```
#!yaml|gpg
foo:
  bar: <encrypted data>
  baz: |
    -----BEGIN PGP MESSAGE-----
    <encrypted data>
    -----END PGP MESSAGE-----
  quux: |
    this is my complex pillar value
    it has a password:
    -----BEGIN PGP MESSAGE-----<encrypted password>-----END PGP MESSAGE-----
    and salt:
    -----BEGIN PGP MESSAGE-----<encrypted salt>-----END PGP MESSAGE-----
```
will be rendered as
```
foo:
  bar: <encrypted data>
  baz: <decrypted data>\n
  quux: |
    this is my complex pillar value
    it has a password:
    <decrypted password>
    and salt:
    <decrypted salt>
```
Raw value for `bar` is not decrypted. Decrypted value for `baz` has unwanted newline symbol at the end.

### New Behavior
pillar:
```
#!yaml|gpg
foo:
  bar: <encrypted data>
  baz: |
    -----BEGIN PGP MESSAGE-----
    <encrypted data>
    -----END PGP MESSAGE-----
  quux: |
    this is my complex pillar value
    it has a password:
    -----BEGIN PGP MESSAGE-----<encrypted password>-----END PGP MESSAGE-----
    and salt:
    -----BEGIN PGP MESSAGE-----<encrypted salt>-----END PGP MESSAGE-----
```
will be rendered as
```
foo:
  bar: <decrypted data>
  baz: <decrypted data>
  quux: |
    this is my complex pillar value
    it has a password:
    <decrypted password>
    and salt:
    <decrypted salt>
```
`bar` and `baz` works as before. New _multi_ functionality works as designed by the author.

### Tests written?
Updated existing

### Commits signed with GPG?
Yes