### PR TITLE
Allow running the schedule jobs to run in the foreground.

### DIFF
--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -426,23 +426,27 @@ class Schedule(object):
 
         # Grab run, assume True
         run = data.get('run', True)
+        run_schedule_jobs_in_background = self.opts.get('run_schedule_jobs_in_background', True)
         if run:
-            multiprocessing_enabled = self.opts.get('multiprocessing', True)
-            if multiprocessing_enabled:
-                thread_cls = salt.utils.process.SignalHandlingMultiprocessingProcess
-            else:
-                thread_cls = threading.Thread
+            if run_schedule_jobs_in_background:
+                multiprocessing_enabled = self.opts.get('multiprocessing', True)
+                if multiprocessing_enabled:
+                    thread_cls = salt.utils.process.SignalHandlingMultiprocessingProcess
+                else:
+                    thread_cls = threading.Thread
 
-            if multiprocessing_enabled:
-                with salt.utils.process.default_signals(signal.SIGINT, signal.SIGTERM):
+                if multiprocessing_enabled:
+                    with salt.utils.process.default_signals(signal.SIGINT, signal.SIGTERM):
+                        proc = thread_cls(target=self.handle_func, args=(multiprocessing_enabled, func, data))
+                        # Reset current signals before starting the process in
+                        # order not to inherit the current signal handlers
+                        proc.start()
+                    proc.join()
+                else:
                     proc = thread_cls(target=self.handle_func, args=(multiprocessing_enabled, func, data))
-                    # Reset current signals before starting the process in
-                    # order not to inherit the current signal handlers
                     proc.start()
-                proc.join()
             else:
-                proc = thread_cls(target=self.handle_func, args=(multiprocessing_enabled, func, data))
-                proc.start()
+                func(data)
 
     def enable_schedule(self):
         '''


### PR DESCRIPTION
### What does this PR do?
Allows the scheduler to run jobs in the foreground.

### Previous Behavior
Schedule jobs always ran in the background either on a new process or a thread.

### Tests written?

No

### Commits signed with GPG?

Yes