### PR TITLE
[2017.7] Disable service module for Cumulus

### DIFF
--- a/salt/modules/service.py
+++ b/salt/modules/service.py
@@ -45,7 +45,8 @@ def __virtual__():
         'Void',
         'Mint',
         'Raspbian',
-        'XenServer'
+        'XenServer',
+        'Cumulus'
     ))
     if __grains__.get('os', '') in disable:
         return (False, 'Your OS is on the disabled list')


### PR DESCRIPTION
### What does this PR do?
Disable the `service` module on Cumulus since it is using systemd.

### What issues does this PR fix or reference?
#46427 

### Previous Behavior
Cumulus, based on Debian, was attempting to use the service module and failing since it is using systemd.

### New Behavior
Disable service module for Cumulus so systemd is activated.

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
