### PR TITLE
profitbrick test: check for foo,bar username,password set in profitbrick config

### DIFF
--- a/tests/integration/cloud/providers/test_profitbricks.py
+++ b/tests/integration/cloud/providers/test_profitbricks.py
@@ -78,7 +78,7 @@ class ProfitBricksTest(ShellCase):
         username = config[profile_str][DRIVER_NAME]['username']
         password = config[profile_str][DRIVER_NAME]['password']
         datacenter_id = config[profile_str][DRIVER_NAME]['datacenter_id']
-        if username == '' or password == '' or datacenter_id == '':
+        if username in ('' or 'foo') or password in ('' or 'bar') or datacenter_id == '':
             self.skipTest(
                 'A username, password, and an datacenter must be provided to '
                 'run these tests. Check '


### PR DESCRIPTION
### What does this PR do?
need to check for foo and bar due to this PR: https://github.com/saltstack/salt/pull/46265

### What issues does this PR fix or reference?
https://github.com/saltstack/salt-jenkins/issues/887