### PR TITLE
INFRA-6667 - avoid stack-trace in boto_asg module

### DIFF
--- a/salt/states/boto_asg.py
+++ b/salt/states/boto_asg.py
@@ -487,9 +487,10 @@ def present(
                 iargs = {'ami_name': image_name, 'region': region, 'key': key,
                          'keyid': keyid, 'profile': profile}
                 image_ids = __salt__['boto_ec2.find_images'](**iargs)
-                if len(image_ids):
+                if image_ids:  # find_images() returns False on failure
                     launch_config[index]['image_id'] = image_ids[0]
                 else:
+                    log.warning("Couldn't find AMI named `%s`, passing literally.", image_name)
                     launch_config[index]['image_id'] = image_name
                 del launch_config[index]['image_name']
                 break


### PR DESCRIPTION
- boto_ec2.find_images() returns False on failure (or error) but boto_asg.present() unconditionally assumes it received back a list, causing stack-traces when the AMI name fails to be resolved to an ID.
- boto_ec2.find_images() was not coping with AWS API Throttling so it fails to retry on this transient error.
- ever-so-slight improvements in logging when these things are encountered.