### PR TITLE
virtualenv version too old for python3.6

### DIFF
--- a/tests/integration/states/test_pip.py
+++ b/tests/integration/states/test_pip.py
@@ -14,6 +14,7 @@ import os
 import pwd
 import glob
 import shutil
+import sys
 
 # Import Salt Testing libs
 from tests.support.mixins import SaltReturnAssertsMixin
@@ -523,6 +524,7 @@ class PipStateTest(ModuleCase, SaltReturnAssertsMixin):
             if os.path.isdir(venv_dir):
                 shutil.rmtree(venv_dir)
 
+    @skipIf(sys.version_info[:2] >= (3, 6), 'Old version of virtualenv too old for python3.6')
     def test_46127_pip_env_vars(self):
         '''
         Test that checks if env_vars passed to pip.installed are also passed


### PR DESCRIPTION
### What does this PR do?
This test is testing an old version of virtualenv with pip_env, and the version
of pip is 6.x.x, which is too old and doesn't work with the importlib in python
3.6. Skipping this test if python is newer then 3.5.

### What issues does this PR fix or reference?
Fixes saltstack/salt-jenkins#886

### Tests written?

Yes

### Commits signed with GPG?

Yes