### PR TITLE
Break out of ~infinite loop in boto_asg.get_instances

### DIFF
--- a/salt/modules/boto_asg.py
+++ b/salt/modules/boto_asg.py
@@ -829,6 +829,7 @@ def get_instances(name, lifecycle_state="InService", health_status="Healthy",
     while True:
         try:
             asgs = conn.get_all_groups(names=[name])
+            break
         except boto.exception.BotoServerError as e:
             if retries and e.code == 'Throttling':
                 log.debug('Throttled by AWS API, retrying in 5 seconds...')


### PR DESCRIPTION
### What does this PR do?

Fix a minor ~infinite loop bug in `boto_asg.get_instances`.

### What issues does this PR fix or reference?

Described above.

### Previous Behavior

`boto_asg.get_instances` could loop ~infinitely. In practice, it will be throttled by AWS, and will switch back and forth between both states until it fails.
 
### New Behavior

Break out of the retry loop as soon as AWS returns a successful response.

### Tests written?

No.

### Commits signed with GPG?

No.
