### PR TITLE
Honor named tests when running integration suites

### DIFF
--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -694,6 +694,7 @@ class SaltTestsuiteParser(SaltCoverageTestingParser):
                         continue
                     results = self.run_suite('', name, suffix='test_*.py', load_from_name=True)
                     status.append(results)
+                return status
             for suite in TEST_SUITES:
                 if suite != 'unit' and getattr(self.options, suite):
                     status.append(self.run_integration_suite(**TEST_SUITES[suite]))


### PR DESCRIPTION
### What does this PR do?

Modifies runtests.py to honor -n parameter for extra integration test suites (cloud, runners, renderers, ect).

### What issues does this PR fix or reference?

#46521

### Previous Behavior

Prior to this change. Running the following command would run the single test, then proceed to run then entire cloud suite (including the named test).

```
python tests/runtests.py --cloud-provider-tests --name integration.cloud.providers.test_ec2.EC2Test.test_instance
```


### New Behavior

The following command runs only the test specified by the `--name` parameter
```
python tests/runtests.py --cloud-provider-tests --name integration.cloud.providers.test_ec2.EC2Test.test_instance
```

### Tests written?

No

### Commits signed with GPG?

Yes

