### PR TITLE
Addition of -sa flag to allow for revision numbers other than -0 or -1

### DIFF
--- a/salt/modules/debbuild.py
+++ b/salt/modules/debbuild.py
@@ -420,6 +420,9 @@ def build(runas,
     # use default /var/cache/pbuilder/result
     results_dir = '/var/cache/pbuilder/result'
 
+    ## ensure clean
+    __salt__['cmd.run']('rm -fR {0}'.format(results_dir))
+
     # dscs should only contain salt orig and debian tarballs and dsc file
     for dsc in dscs:
         afile = os.path.basename(dsc)
@@ -430,10 +433,10 @@ def build(runas,
             try:
                 __salt__['cmd.run']('chown {0} -R {1}'.format(runas, dbase))
 
-                cmd = 'pbuilder --update --override-config'
+                cmd = 'pbuilder update --override-config'
                 __salt__['cmd.run'](cmd, runas=runas, python_shell=True)
 
-                cmd = 'pbuilder --build {0}'.format(dsc)
+                cmd = 'pbuilder build --debbuildopts "-sa" {0}'.format(dsc)
                 __salt__['cmd.run'](cmd, runas=runas, python_shell=True)
 
                 # ignore local deps generated package file


### PR DESCRIPTION
### What does this PR do?
Allows for building Debian and Ubuntu packages with revision numbers great than -0 or -1

### What issues does this PR fix or reference?
Allows for building Python 3 packages for Debian and Ubuntu for Oxygen

### Previous Behavior
original tarball would not be included in source for package, for example:
The following packages were not built: timelib_0.2.4.orig.tar.gz where the revision is '-2'

### New Behavior
Original tarball is now included in source packages for Debian and Ubuntu

### Tests written?
No, used to build successfully


### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
