### PR TITLE
Fix: decrease loglevel when unable to resolve addr

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1927,7 +1927,7 @@ def fqdns():
             fqdns.add(socket.gethostbyaddr(ip)[0])
         except (socket.error, socket.herror,
             socket.gaierror, socket.timeout) as e:
-            log.error("Exception during resolving address: " + str(e))
+            log.info("Exception during resolving address: " + str(e))
 
     grains['fqdns'] = sorted(list(fqdns))
     return grains


### PR DESCRIPTION
### What does this PR do?

It occurs that when the machine has multiple interfaces without an associated FQDN, Salt logs are polluted by this error.
Some examples:

```
caasp-admin:~ # uptime
 09:08am  up   0:13,  2 users,  load average: 1.30, 1.37, 0.98
caasp-admin:~ # docker logs $(docker ps | grep salt-master | awk '{print $1}') 2>&1 | grep "Exception during resolving address" | wc -l
528
```

```
caasp-admin:~ # docker exec -it $(docker ps | grep salt-master | awk '{print $1}') salt '*' cmd.run uptime
b24f41eb4cc94624862ca0c9e8afcd15:
     09:08am  up   0:11,  0 users,  load average: 1.26, 0.83, 0.40
admin:
     09:08am  up   0:13,  2 users,  load average: 1.33, 1.37, 0.99
ba8c76af029043a39ba917f7ab2af796:
     09:08am  up   0:12,  0 users,  load average: 0.84, 0.63, 0.32
7b7aa52158524556a0c46ae57569ce93:
     09:08am  up   0:11,  1 user,  load average: 1.05, 0.77, 0.38
5ab0e18cbd084e9088a928a17edb86cb:
     09:08am  up   0:10,  0 users,  load average: 0.12, 0.25, 0.20
1756c9cd9a9a402b91d8636400d1e512:
     09:08am  up   0:09,  0 users,  load average: 0.12, 0.23, 0.14
ca:
     09:08am  up   0:13,  0 users,  load average: 1.33, 1.37, 0.99
caasp-admin:~ # docker exec -it $(docker ps | grep salt-master | awk '{print $1}') salt '*' cmd.run "bash -c 'cat /var/log/salt/minion | grep \"Exception during resolving address\" | wc -l'"
admin:
    63
ba8c76af029043a39ba917f7ab2af796:
    47
5ab0e18cbd084e9088a928a17edb86cb:
    55
7b7aa52158524556a0c46ae57569ce93:
    59
b24f41eb4cc94624862ca0c9e8afcd15:
    47
1756c9cd9a9a402b91d8636400d1e512:
    59
ca:
    25
```

This patch changes the log level of the exception to INFO, since the resolve-unable problem is not blocking.

### What issues does this PR fix or reference?

Logs "spamming"

### Previous Behavior

Logging with log level = ERROR

### New Behavior

Logging with log level = INFO

### Tests written?

No, just a change of log level

### Commits signed with GPG?

No
