### PR TITLE
Clarify some issues with msu files in win_dism.py

### DIFF
--- a/salt/modules/win_dism.py
+++ b/salt/modules/win_dism.py
@@ -426,16 +426,27 @@ def add_package(package,
     Install a package using DISM
 
     Args:
-        package (str): The package to install. Can be a .cab file, a .msu file,
-            or a folder
-        ignore_check (Optional[bool]): Skip installation of the package if the
-            applicability checks fail
-        prevent_pending (Optional[bool]): Skip the installation of the package
-            if there are pending online actions
-        image (Optional[str]): The path to the root directory of an offline
-            Windows image. If `None` is passed, the running operating system is
-            targeted. Default is None.
-        restart (Optional[bool]): Reboot the machine if required by the install
+        package (str):
+            The package to install. Can be a .cab file, a .msu file, or a folder
+
+            .. note::
+                An `.msu` package is supported only when the target image is
+                offline, either mounted or applied.
+
+        ignore_check (Optional[bool]):
+            Skip installation of the package if the applicability checks fail
+
+        prevent_pending (Optional[bool]):
+            Skip the installation of the package if there are pending online
+            actions
+
+        image (Optional[str]):
+            The path to the root directory of an offline Windows image. If
+            ``None`` is passed, the running operating system is targeted.
+            Default is None.
+
+        restart (Optional[bool]):
+            Reboot the machine if required by the install
 
     Returns:
         dict: A dictionary containing the results of the command


### PR DESCRIPTION
### What does this PR do?
Clarifies some issues with `.msu` files in the `add_package` function of `win_dism.py`. You can only apply `.msu` files to offline images. Meaning this won't work to apply an `.msu` file to the running operating system.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/46292

### Tests written?
NA

### Commits signed with GPG?
Yes