### PR TITLE
Preserve tuples when decoding grain data in loader

### DIFF
--- a/salt/loader.py
+++ b/salt/loader.py
@@ -652,7 +652,7 @@ def _load_cached_grains(opts, cfn):
     try:
         serial = salt.payload.Serial(opts)
         with salt.utils.files.fopen(cfn, 'rb') as fp_:
-            cached_grains = salt.utils.data.decode(serial.load(fp_))
+            cached_grains = salt.utils.data.decode(serial.load(fp_), preserve_tuples=True)
         if not cached_grains:
             log.debug('Cached grains are empty, cache might be corrupted. Refreshing.')
             return None
@@ -820,7 +820,7 @@ def grains(opts, force_refresh=False, proxy=None):
         salt.utils.dictupdate.update(grains_data, opts['grains'])
     else:
         grains_data.update(opts['grains'])
-    return salt.utils.data.decode(grains_data)
+    return salt.utils.data.decode(grains_data, preserve_tuples=True)
 
 
 # TODO: get rid of? Does anyone use this? You should use raw() instead


### PR DESCRIPTION
### What does this PR do?
Ensures we are preserving the tuples when decoding grain data. Previously the `__grains__['osrelease_info']` grain returned a tuple now its returning a list as shown in issue: https://github.com/saltstack/salt-jenkins/issues/895#issuecomment-373867084

I believe this is the right approach instead of changing the check in the mac user file to check for a list, because we don't want to change the data type that osrelease_info is returning in a release without deprecation or notice. I noticed that mac_group.py also is doing a similar check so that should resolve the mac_group tests that are failing as well on mac.

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt-jenkins/issues/895
