### PR TITLE
Send only used log records to MP Logging Listener

### DIFF
--- a/salt/engines/__init__.py
+++ b/salt/engines/__init__.py
@@ -69,11 +69,11 @@ class Engine(SignalHandlingMultiprocessingProcess):
     '''
     Execute the given engine in a new process
     '''
-    def __init__(self, opts, fun, config, funcs, runners, proxy, log_queue=None):
+    def __init__(self, opts, fun, config, funcs, runners, proxy, **kwargs):
         '''
         Set up the process executor
         '''
-        super(Engine, self).__init__(log_queue=log_queue)
+        super(Engine, self).__init__(**kwargs)
         self.opts = opts
         self.config = config
         self.fun = fun
@@ -93,17 +93,21 @@ class Engine(SignalHandlingMultiprocessingProcess):
             state['funcs'],
             state['runners'],
             state['proxy'],
-            log_queue=state['log_queue']
+            log_queue=state['log_queue'],
+            log_queue_level=state['log_queue_level']
         )
 
     def __getstate__(self):
-        return {'opts': self.opts,
-                'fun': self.fun,
-                'config': self.config,
-                'funcs': self.funcs,
-                'runners': self.runners,
-                'proxy': self.proxy,
-                'log_queue': self.log_queue}
+        return {
+            'opts': self.opts,
+            'fun': self.fun,
+            'config': self.config,
+            'funcs': self.funcs,
+            'runners': self.runners,
+            'proxy': self.proxy,
+            'log_queue': self.log_queue,
+            'log_queue_level': self.log_queue_level
+        }
 
     def run(self):
         '''

--- a/salt/master.py
+++ b/salt/master.py
@@ -139,13 +139,13 @@ class Maintenance(salt.utils.process.SignalHandlingMultiprocessingProcess):
     '''
     A generalized maintenance process which performs maintenance routines.
     '''
-    def __init__(self, opts, log_queue=None):
+    def __init__(self, opts, **kwargs):
         '''
         Create a maintenance instance
 
         :param dict opts: The salt options
         '''
-        super(Maintenance, self).__init__(log_queue=log_queue)
+        super(Maintenance, self).__init__(**kwargs)
         self.opts = opts
         # How often do we perform the maintenance tasks
         self.loop_interval = int(self.opts['loop_interval'])
@@ -159,11 +159,18 @@ class Maintenance(salt.utils.process.SignalHandlingMultiprocessingProcess):
     # process so that a register_after_fork() equivalent will work on Windows.
     def __setstate__(self, state):
         self._is_child = True
-        self.__init__(state['opts'], log_queue=state['log_queue'])
+        self.__init__(
+            state['opts'],
+            log_queue=state['log_queue'],
+            log_queue_level=state['log_queue_level']
+        )
 
     def __getstate__(self):
-        return {'opts': self.opts,
-                'log_queue': self.log_queue}
+        return {
+            'opts': self.opts,
+            'log_queue': self.log_queue,
+            'log_queue_level': self.log_queue_level
+        }
 
     def _post_fork_init(self):
         '''
@@ -709,6 +716,7 @@ class Master(SMaster):
             kwargs = {}
             if salt.utils.platform.is_windows():
                 kwargs['log_queue'] = salt.log.setup.get_multiprocessing_logging_queue()
+                kwargs['log_queue_level'] = salt.log.setup.get_multiprocessing_logging_level()
                 kwargs['secrets'] = SMaster.secrets
 
             self.process_manager.add_process(
@@ -758,13 +766,13 @@ class Halite(salt.utils.process.SignalHandlingMultiprocessingProcess):
     '''
     Manage the Halite server
     '''
-    def __init__(self, hopts, log_queue=None):
+    def __init__(self, hopts, **kwargs):
         '''
         Create a halite instance
 
         :param dict hopts: The halite options
         '''
-        super(Halite, self).__init__(log_queue=log_queue)
+        super(Halite, self).__init__(**kwargs)
         self.hopts = hopts
 
     # __setstate__ and __getstate__ are only used on Windows.
@@ -772,11 +780,18 @@ class Halite(salt.utils.process.SignalHandlingMultiprocessingProcess):
     # process so that a register_after_fork() equivalent will work on Windows.
     def __setstate__(self, state):
         self._is_child = True
-        self.__init__(state['hopts'], log_queue=state['log_queue'])
+        self.__init__(
+            state['hopts'],
+            log_queue=state['log_queue'],
+            log_queue_level=state['log_queue_level']
+        )
 
     def __getstate__(self):
-        return {'hopts': self.hopts,
-                'log_queue': self.log_queue}
+        return {
+            'hopts': self.hopts,
+            'log_queue': self.log_queue,
+            'log_queue_level': self.log_queue_level
+        }
 
     def run(self):
         '''
@@ -791,7 +806,7 @@ class ReqServer(salt.utils.process.SignalHandlingMultiprocessingProcess):
     Starts up the master request server, minions send results to this
     interface.
     '''
-    def __init__(self, opts, key, mkey, log_queue=None, secrets=None):
+    def __init__(self, opts, key, mkey, secrets=None, **kwargs):
         '''
         Create a request server
 
@@ -802,7 +817,7 @@ class ReqServer(salt.utils.process.SignalHandlingMultiprocessingProcess):
         :rtype: ReqServer
         :returns: Request server
         '''
-        super(ReqServer, self).__init__(log_queue=log_queue)
+        super(ReqServer, self).__init__(**kwargs)
         self.opts = opts
         self.master_key = mkey
         # Prepare the AES key
@@ -814,15 +829,24 @@ class ReqServer(salt.utils.process.SignalHandlingMultiprocessingProcess):
     # process so that a register_after_fork() equivalent will work on Windows.
     def __setstate__(self, state):
         self._is_child = True
-        self.__init__(state['opts'], state['key'], state['mkey'],
-                      log_queue=state['log_queue'], secrets=state['secrets'])
+        self.__init__(
+            state['opts'],
+            state['key'],
+            state['mkey'],
+            secrets=state['secrets'],
+            log_queue=state['log_queue'],
+            log_queue_level=state['log_queue_level']
+        )
 
     def __getstate__(self):
-        return {'opts': self.opts,
-                'key': self.key,
-                'mkey': self.master_key,
-                'log_queue': self.log_queue,
-                'secrets': self.secrets}
+        return {
+            'opts': self.opts,
+            'key': self.key,
+            'mkey': self.master_key,
+            'secrets': self.secrets,
+            'log_queue': self.log_queue,
+            'log_queue_level': self.log_queue_level
+        }
 
     def _handle_signals(self, signum, sigframe):  # pylint: disable=unused-argument
         self.destroy(signum)
@@ -834,6 +858,8 @@ class ReqServer(salt.utils.process.SignalHandlingMultiprocessingProcess):
         '''
         if self.log_queue is not None:
             salt.log.setup.set_multiprocessing_logging_queue(self.log_queue)
+        if self.log_queue_level is not None:
+            salt.log.setup.set_multiprocessing_logging_level(self.log_queue_level)
         salt.log.setup.setup_multiprocessing_logging(self.log_queue)
         if self.secrets is not None:
             SMaster.secrets = self.secrets
@@ -864,6 +890,7 @@ class ReqServer(salt.utils.process.SignalHandlingMultiprocessingProcess):
         kwargs = {}
         if salt.utils.platform.is_windows():
             kwargs['log_queue'] = self.log_queue
+            kwargs['log_queue_level'] = self.log_queue_level
             # Use one worker thread if only the TCP transport is set up on
             # Windows and we are using Python 2. There is load balancer
             # support on Windows for the TCP transport when using Python 3.
@@ -945,7 +972,10 @@ class MWorker(salt.utils.process.SignalHandlingMultiprocessingProcess):
     # non-Windows platforms.
     def __setstate__(self, state):
         self._is_child = True
-        super(MWorker, self).__init__(log_queue=state['log_queue'])
+        super(MWorker, self).__init__(
+            log_queue=state['log_queue'],
+            log_queue_level=state['log_queue_level']
+        )
         self.opts = state['opts']
         self.req_channels = state['req_channels']
         self.mkey = state['mkey']
@@ -954,13 +984,16 @@ class MWorker(salt.utils.process.SignalHandlingMultiprocessingProcess):
         SMaster.secrets = state['secrets']
 
     def __getstate__(self):
-        return {'opts': self.opts,
-                'req_channels': self.req_channels,
-                'mkey': self.mkey,
-                'key': self.key,
-                'k_mtime': self.k_mtime,
-                'log_queue': self.log_queue,
-                'secrets': SMaster.secrets}
+        return {
+            'opts': self.opts,
+            'req_channels': self.req_channels,
+            'mkey': self.mkey,
+            'key': self.key,
+            'k_mtime': self.k_mtime,
+            'secrets': SMaster.secrets,
+            'log_queue': self.log_queue,
+            'log_queue_level': self.log_queue_level
+        }
 
     def _handle_signals(self, signum, sigframe):
         for channel in getattr(self, 'req_channels', ()):

--- a/salt/transport/tcp.py
+++ b/salt/transport/tcp.py
@@ -144,8 +144,8 @@ if USE_LOAD_BALANCER:
         # Based on default used in tornado.netutil.bind_sockets()
         backlog = 128
 
-        def __init__(self, opts, socket_queue, log_queue=None):
-            super(LoadBalancerServer, self).__init__(log_queue=log_queue)
+        def __init__(self, opts, socket_queue, **kwargs):
+            super(LoadBalancerServer, self).__init__(**kwargs)
             self.opts = opts
             self.socket_queue = socket_queue
             self._socket = None
@@ -159,13 +159,17 @@ if USE_LOAD_BALANCER:
             self.__init__(
                 state['opts'],
                 state['socket_queue'],
-                log_queue=state['log_queue']
+                log_queue=state['log_queue'],
+                log_queue_level=state['log_queue_level']
             )
 
         def __getstate__(self):
-            return {'opts': self.opts,
-                    'socket_queue': self.socket_queue,
-                    'log_queue': self.log_queue}
+            return {
+                'opts': self.opts,
+                'socket_queue': self.socket_queue,
+                'log_queue': self.log_queue,
+                'log_queue_level': self.log_queue_level
+            }
 
         def close(self):
             if self._socket is not None:
@@ -1347,14 +1351,18 @@ class TCPPubServerChannel(salt.transport.server.PubServerChannel):
         return {'opts': self.opts,
                 'secrets': salt.master.SMaster.secrets}
 
-    def _publish_daemon(self, log_queue=None):
+    def _publish_daemon(self, **kwargs):
         '''
         Bind to the interface specified in the configuration file
         '''
         salt.utils.process.appendproctitle(self.__class__.__name__)
 
+        log_queue = kwargs.get('log_queue')
         if log_queue is not None:
             salt.log.setup.set_multiprocessing_logging_queue(log_queue)
+        log_queue_level = kwargs.get('log_queue_level')
+        if log_queue_level is not None:
+            salt.log.setup.set_multiprocessing_logging_level(log_queue_level)
         salt.log.setup.setup_multiprocessing_logging(log_queue)
 
         # Check if io_loop was set outside
@@ -1408,6 +1416,9 @@ class TCPPubServerChannel(salt.transport.server.PubServerChannel):
         if salt.utils.platform.is_windows():
             kwargs['log_queue'] = (
                 salt.log.setup.get_multiprocessing_logging_queue()
+            )
+            kwargs['log_queue_level'] = (
+                salt.log.setup.get_multiprocessing_logging_level()
             )
 
         process_manager.add_process(self._publish_daemon, kwargs=kwargs)

--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -1056,8 +1056,8 @@ class EventPublisher(salt.utils.process.SignalHandlingMultiprocessingProcess):
     The interface that takes master events and republishes them out to anyone
     who wants to listen
     '''
-    def __init__(self, opts, log_queue=None):
-        super(EventPublisher, self).__init__(log_queue=log_queue)
+    def __init__(self, opts, **kwargs):
+        super(EventPublisher, self).__init__(**kwargs)
         self.opts = salt.config.DEFAULT_MASTER_OPTS.copy()
         self.opts.update(opts)
         self._closing = False
@@ -1067,11 +1067,18 @@ class EventPublisher(salt.utils.process.SignalHandlingMultiprocessingProcess):
     # process so that a register_after_fork() equivalent will work on Windows.
     def __setstate__(self, state):
         self._is_child = True
-        self.__init__(state['opts'], log_queue=state['log_queue'])
+        self.__init__(
+            state['opts'],
+            log_queue=state['log_queue'],
+            log_queue_level=state['log_queue_level']
+        )
 
     def __getstate__(self):
-        return {'opts': self.opts,
-                'log_queue': self.log_queue}
+        return {
+            'opts': self.opts,
+            'log_queue': self.log_queue,
+            'log_queue_level': self.log_queue_level
+        }
 
     def run(self):
         '''
@@ -1171,13 +1178,13 @@ class EventReturn(salt.utils.process.SignalHandlingMultiprocessingProcess):
         instance = super(EventReturn, cls).__new__(cls, *args, **kwargs)
         return instance
 
-    def __init__(self, opts, log_queue=None):
+    def __init__(self, opts, **kwargs):
         '''
         Initialize the EventReturn system
 
         Return an EventReturn instance
         '''
-        super(EventReturn, self).__init__(log_queue=log_queue)
+        super(EventReturn, self).__init__(**kwargs)
 
         self.opts = opts
         self.event_return_queue = self.opts['event_return_queue']
@@ -1192,11 +1199,18 @@ class EventReturn(salt.utils.process.SignalHandlingMultiprocessingProcess):
     # process so that a register_after_fork() equivalent will work on Windows.
     def __setstate__(self, state):
         self._is_child = True
-        self.__init__(state['opts'], log_queue=state['log_queue'])
+        self.__init__(
+            state['opts'],
+            log_queue=state['log_queue'],
+            log_queue_level=state['log_queue_level']
+        )
 
     def __getstate__(self):
-        return {'opts': self.opts,
-                'log_queue': self.log_queue}
+        return {
+            'opts': self.opts,
+            'log_queue': self.log_queue,
+            'log_queue_level': self.log_queue_level
+        }
 
     def _handle_signals(self, signum, sigframe):
         # Flush and terminate

--- a/salt/utils/master.py
+++ b/salt/utils/master.py
@@ -438,11 +438,11 @@ class CacheWorker(MultiprocessingProcess):
     main-loop when refreshing minion-list
     '''
 
-    def __init__(self, opts, log_queue=None):
+    def __init__(self, opts, **kwargs):
         '''
         Sets up the zmq-connection to the ConCache
         '''
-        super(CacheWorker, self).__init__(log_queue=log_queue)
+        super(CacheWorker, self).__init__(**kwargs)
         self.opts = opts
 
     # __setstate__ and __getstate__ are only used on Windows.
@@ -450,11 +450,18 @@ class CacheWorker(MultiprocessingProcess):
     # process so that a register_after_fork() equivalent will work on Windows.
     def __setstate__(self, state):
         self._is_child = True
-        self.__init__(state['opts'], log_queue=state['log_queue'])
+        self.__init__(
+            state['opts'],
+            log_queue=state['log_queue'],
+            log_queue_level=state['log_queue_level']
+        )
 
     def __getstate__(self):
-        return {'opts': self.opts,
-                'log_queue': self.log_queue}
+        return {
+            'opts': self.opts,
+            'log_queue': self.log_queue,
+            'log_queue_level': self.log_queue_level
+        }
 
     def run(self):
         '''
@@ -475,11 +482,11 @@ class ConnectedCache(MultiprocessingProcess):
     the master publisher port.
     '''
 
-    def __init__(self, opts, log_queue=None):
+    def __init__(self, opts, **kwargs):
         '''
         starts the timer and inits the cache itself
         '''
-        super(ConnectedCache, self).__init__(log_queue=log_queue)
+        super(ConnectedCache, self).__init__(**kwargs)
         log.debug('ConCache initializing...')
 
         # the possible settings for the cache
@@ -506,11 +513,18 @@ class ConnectedCache(MultiprocessingProcess):
     # process so that a register_after_fork() equivalent will work on Windows.
     def __setstate__(self, state):
         self._is_child = True
-        self.__init__(state['opts'], log_queue=state['log_queue'])
+        self.__init__(
+            state['opts'],
+            log_queue=state['log_queue'],
+            log_queue_level=state['log_queue_level']
+        )
 
     def __getstate__(self):
-        return {'opts': self.opts,
-                'log_queue': self.log_queue}
+        return {
+            'opts': self.opts,
+            'log_queue': self.log_queue,
+            'log_queue_level': self.log_queue_level
+        }
 
     def signal_handler(self, sig, frame):
         '''

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -862,21 +862,30 @@ class LogLevelMixIn(six.with_metaclass(MixInMeta, object)):
             )
 
     def _setup_mp_logging_client(self, *args):  # pylint: disable=unused-argument
-        if salt.utils.platform.is_windows() and self._setup_mp_logging_listener_:
-            # On Windows, all logging including console and
-            # log file logging will go through the multiprocessing
-            # logging listener if it exists.
-            # This will allow log file rotation on Windows
-            # since only one process can own the log file
-            # for log file rotation to work.
-            log.setup_multiprocessing_logging(
-                self._get_mp_logging_listener_queue()
-            )
-            # Remove the temp logger and any other configured loggers since all of
-            # our logging is going through the multiprocessing logging listener.
-            log.shutdown_temp_logging()
-            log.shutdown_console_logging()
-            log.shutdown_logfile_logging()
+        if self._setup_mp_logging_listener_:
+            # Set multiprocessing logging level even in non-Windows
+            # environments. In non-Windows environments, this setting will
+            # propogate from process to process via fork behavior and will be
+            # used by child processes if they invoke the multiprocessing
+            # logging client.
+            log.set_multiprocessing_logging_level_by_opts(self.config)
+
+            if salt.utils.platform.is_windows():
+                # On Windows, all logging including console and
+                # log file logging will go through the multiprocessing
+                # logging listener if it exists.
+                # This will allow log file rotation on Windows
+                # since only one process can own the log file
+                # for log file rotation to work.
+                log.setup_multiprocessing_logging(
+                    self._get_mp_logging_listener_queue()
+                )
+                # Remove the temp logger and any other configured loggers since
+                # all of our logging is going through the multiprocessing
+                # logging listener.
+                log.shutdown_temp_logging()
+                log.shutdown_console_logging()
+                log.shutdown_logfile_logging()
 
     def __setup_console_logger_config(self, *args):  # pylint: disable=unused-argument
         # Since we're not going to be a daemon, setup the console logger

--- a/salt/utils/process.py
+++ b/salt/utils/process.py
@@ -376,20 +376,30 @@ class ProcessManager(object):
             kwargs = {}
 
         if salt.utils.platform.is_windows():
-            # Need to ensure that 'log_queue' is correctly transferred to
-            # processes that inherit from 'MultiprocessingProcess'.
+            # Need to ensure that 'log_queue' and 'log_queue_level' is
+            # correctly transferred to processes that inherit from
+            # 'MultiprocessingProcess'.
             if type(MultiprocessingProcess) is type(tgt) and (
                     issubclass(tgt, MultiprocessingProcess)):
                 need_log_queue = True
             else:
                 need_log_queue = False
 
-            if need_log_queue and 'log_queue' not in kwargs:
-                if hasattr(self, 'log_queue'):
-                    kwargs['log_queue'] = self.log_queue
-                else:
-                    kwargs['log_queue'] = (
-                            salt.log.setup.get_multiprocessing_logging_queue())
+            if need_log_queue:
+                if 'log_queue' not in kwargs:
+                    if hasattr(self, 'log_queue'):
+                        kwargs['log_queue'] = self.log_queue
+                    else:
+                        kwargs['log_queue'] = (
+                            salt.log.setup.get_multiprocessing_logging_queue()
+                        )
+                if 'log_queue_level' not in kwargs:
+                    if hasattr(self, 'log_queue_level'):
+                        kwargs['log_queue_level'] = self.log_queue_level
+                    else:
+                        kwargs['log_queue_level'] = (
+                            salt.log.setup.get_multiprocessing_logging_level()
+                        )
 
         # create a nicer name for the debug log
         if name is None:
@@ -686,8 +696,14 @@ class MultiprocessingProcess(multiprocessing.Process, NewStyleClassMixIn):
             # salt.log.setup.get_multiprocessing_logging_queue().
             salt.log.setup.set_multiprocessing_logging_queue(self.log_queue)
 
+        self.log_queue_level = kwargs.pop('log_queue_level', None)
+        if self.log_queue_level is None:
+            self.log_queue_level = salt.log.setup.get_multiprocessing_logging_level()
+        else:
+            salt.log.setup.set_multiprocessing_logging_level(self.log_queue_level)
+
         # Call __init__ from 'multiprocessing.Process' only after removing
-        # 'log_queue' from kwargs.
+        # 'log_queue' and 'log_queue_level' from kwargs.
         super(MultiprocessingProcess, self).__init__(*args, **kwargs)
 
         if salt.utils.platform.is_windows():
@@ -732,6 +748,8 @@ class MultiprocessingProcess(multiprocessing.Process, NewStyleClassMixIn):
         kwargs = self._kwargs_for_getstate
         if 'log_queue' not in kwargs:
             kwargs['log_queue'] = self.log_queue
+        if 'log_queue_level' not in kwargs:
+            kwargs['log_queue_level'] = self.log_queue_level
         # Remove the version of these in the parent process since
         # they are no longer needed.
         del self._args_for_getstate

--- a/salt/utils/reactor.py
+++ b/salt/utils/reactor.py
@@ -50,8 +50,8 @@ class Reactor(salt.utils.process.SignalHandlingMultiprocessingProcess, salt.stat
         'cmd': 'local',
     }
 
-    def __init__(self, opts, log_queue=None):
-        super(Reactor, self).__init__(log_queue=log_queue)
+    def __init__(self, opts, **kwargs):
+        super(Reactor, self).__init__(**kwargs)
         local_minion_opts = opts.copy()
         local_minion_opts['file_client'] = 'local'
         self.minion = salt.minion.MasterMinion(local_minion_opts)
@@ -66,11 +66,16 @@ class Reactor(salt.utils.process.SignalHandlingMultiprocessingProcess, salt.stat
         self._is_child = True
         Reactor.__init__(
             self, state['opts'],
-            log_queue=state['log_queue'])
+            log_queue=state['log_queue'],
+            log_queue_level=state['log_queue_level']
+        )
 
     def __getstate__(self):
-        return {'opts': self.opts,
-                'log_queue': self.log_queue}
+        return {
+            'opts': self.opts,
+            'log_queue': self.log_queue,
+            'log_queue_level': self.log_queue_level
+        }
 
     def render_reaction(self, glob_ref, tag, data):
         '''


### PR DESCRIPTION
### What does this PR do?

Currently, the architecture sends all log records to the Multiprocessing
Logging Listener through a multiprocessing queue. On production systems,
this will send many records that ultimately will not be used, including
debug and trace level log records from Salt and any dependencies of Salt
and its plugins. Such log records are numerous and some may be very large
due to containing packet information. This creates an unneeded burden on a
production system.

This change will determine the minimum needed logging level based on
the configuration and use that for the Multiprocessing Logging clients.

### What issues does this PR fix or reference?

### Tests written?

No

### Commits signed with GPG?

Yes