### PR TITLE
Remove deprecated functions in trafficserver module and state

### DIFF
--- a/doc/topics/releases/fluorine.rst
+++ b/doc/topics/releases/fluorine.rst
@@ -30,6 +30,15 @@ Deprecations
 Module Deprecations
 ===================
 
+The ``trafficserver`` module had the following changes:
+
+- Support for the ``match_var`` function was removed. Please use the
+  ``match_metric`` function instead.
+- Support for the ``read_var`` function was removed. Please use the
+  ``read_config`` function instead.
+- Support for the ``set_var`` function was removed. Please use the
+  ``set_config`` function instead.
+
 The ``win_update`` module has been removed. It has been replaced by ``win_wua``
 module.
 
@@ -79,5 +88,10 @@ instead:
   files to use the ``kubernetes.node_label_present`` function instead.
 - The ``k8s.label_folder_absent`` function was removed. Please update applicable
   SLS files to use the ``kubernetes.node_label_folder_absent`` function instead.
+
+The ``trafficserver`` state had the following changes:
+
+- Support for the ``set_var`` function was removed. Please use the ``config``
+  function instead.
 
 The ``win_update`` state has been removed. Please use the ``win_wua`` state instead.

--- a/salt/modules/trafficserver.py
+++ b/salt/modules/trafficserver.py
@@ -16,7 +16,6 @@ import subprocess
 # Import salt libs
 import salt.utils.path
 import salt.utils.stringutils
-import salt.utils.versions
 
 __virtualname__ = 'trafficserver'
 
@@ -203,28 +202,6 @@ def restart_local(drain=False):
     return _subprocess(cmd)
 
 
-def match_var(regex):
-    '''
-    Display the current values of all performance statistics or configuration
-    variables whose names match the given regular expression.
-
-    .. deprecated:: Fluorine
-        Use ``match_metric`` or ``match_config`` instead.
-
-    .. code-block:: bash
-
-        salt '*' trafficserver.match_var regex
-    '''
-    salt.utils.versions.warn_until(
-        'Fluorine',
-        'The \'match_var\' function has been deprecated and will be removed in Salt '
-        '{version}. Please use \'match_metric\' or \'match_config\' instead.'
-    )
-    cmd = _traffic_line('-m', regex)
-    log.debug('Running: %s', cmd)
-    return _subprocess(cmd)
-
-
 def match_metric(regex):
     '''
     Display the current values of all metrics whose names match the
@@ -343,55 +320,6 @@ def set_config(variable, value):
 
     log.debug('Setting %s to %s', variable, value)
     return _subprocess(cmd)
-
-
-def read_var(*args):
-    '''
-    Read variable definitions from the traffic_line command.
-
-    .. deprecated:: Fluorine
-        Use ``read_metric`` or ``read_config`` instead. Note that this
-        function does not work for Traffic Server versions >= 7.0.
-
-    .. code-block:: bash
-
-        salt '*' trafficserver.read_var proxy.process.http.tcp_hit_count_stat
-    '''
-    salt.utils.versions.warn_until(
-        'Fluorine',
-        'The \'read_var\' function has been deprecated and will be removed in Salt '
-        '{version}. Please use \'read_metric\' or \'read_config\' instead.'
-    )
-
-    ret = {}
-
-    try:
-        for arg in args:
-            log.debug('Querying: %s', arg)
-            cmd = '{0} {1} {2}'.format(_TRAFFICLINE, '-r', arg)
-            ret[arg] = _subprocess(cmd)
-    except KeyError:
-        pass
-
-    return ret
-
-
-def set_var(variable, value):
-    '''
-    .. code-block:: bash
-
-    .. deprecated:: Fluorine
-        Use ``set_config`` instead. Note that this function does
-        not work for Traffic Server versions >= 7.0.
-
-        salt '*' trafficserver.set_var proxy.config.http.server_ports
-    '''
-    salt.utils.versions.warn_until(
-        'Fluorine',
-        'The \'set_var\' function has been deprecated and will be removed in Salt '
-        '{version}. Please use \'set_config\' instead.'
-    )
-    return set_config(variable, value)
 
 
 def shutdown():

--- a/salt/states/trafficserver.py
+++ b/salt/states/trafficserver.py
@@ -9,9 +9,6 @@ Control Apache Traffic Server
 # Import Python libs
 from __future__ import absolute_import, unicode_literals, print_function
 
-# Import Salt libs
-import salt.utils.versions
-
 
 def __virtual__():
     '''
@@ -237,35 +234,6 @@ def config(name, value):
     ret['result'] = True
     ret['comment'] = 'Configured {0} to {1}'.format(name, value)
     return ret
-
-
-def set_var(name, value):
-    '''
-    Set Traffic Server configuration variable values.
-
-    .. deprecated:: Fluorine
-        Use ``trafficserver.config`` instead.
-
-    .. code-block:: yaml
-
-        proxy.config.proxy_name:
-          trafficserver.set_var:
-            - value: cdn.site.domain.tld
-
-        OR
-
-        traffic_server_setting:
-          trafficserver.set_var:
-            - name: proxy.config.proxy_name
-            - value: cdn.site.domain.tld
-
-    '''
-    salt.utils.versions.warn_until(
-        'Fluorine',
-        'The \'set_var\' function has been deprecated and will be removed in Salt '
-        '{version}. Please use \'trafficserver.config\' instead.'
-    )
-    return config(name, value)
 
 
 def shutdown(name):


### PR DESCRIPTION
There are several functions that are deprecated and marked for removal in the Fluorine release in the trafficserver state and execution module. This PR handles them. All changes have been documented in the Fluorine release notes.

Fixes #46469 