### PR TITLE
[develop] fixes to scheduler 

### DIFF
--- a/salt/modules/schedule.py
+++ b/salt/modules/schedule.py
@@ -58,7 +58,7 @@ SCHEDULE_CONF = [
         'after',
         'return_config',
         'return_kwargs',
-        'run_on_start'
+        'run_on_start',
         'skip_during_range',
         'run_after_skip_range',
 ]

--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -1474,7 +1474,7 @@ class Schedule(object):
 
                 # If there is no job specific skip_during_range available,
                 # grab the global which defaults to None.
-                if 'skip_during_range' not in data:
+                if 'skip_during_range' not in data and self.skip_during_range:
                     data['skip_during_range'] = self.skip_during_range
 
                 if 'skip_during_range' in data and data['skip_during_range']:

--- a/tests/integration/scheduler/test_eval.py
+++ b/tests/integration/scheduler/test_eval.py
@@ -515,3 +515,32 @@ class SchedulerEvalTest(ModuleCase, SaltReturnAssertsMixin):
         ret = self.schedule.job_status('job1')
         self.assertNotIn('_last_run', ret)
         self.assertEqual(ret['_skip_reason'], 'disabled')
+
+    def test_eval_run_on_start(self):
+        '''
+        verify that scheduled job is run when minion starts
+        '''
+        job = {
+          'schedule': {
+            'job1': {
+              'function': 'test.ping',
+              'hours': '1',
+              'run_on_start': True
+            }
+          }
+        }
+
+        # Add job to schedule
+        self.schedule.opts.update(job)
+
+        # eval at 2:00pm, will run.
+        run_time = dateutil_parser.parse('11/29/2017 2:00pm')
+        self.schedule.eval(now=run_time)
+        ret = self.schedule.job_status('job1')
+        self.assertEqual(ret['_last_run'], run_time)
+
+        # eval at 3:00pm, will run.
+        run_time = dateutil_parser.parse('11/29/2017 3:00pm')
+        self.schedule.eval(now=run_time)
+        ret = self.schedule.job_status('job1')
+        self.assertEqual(ret['_last_run'], run_time)


### PR DESCRIPTION
### What does this PR do?
Fixing a bug that would result in constant changes using the schedule state module when a job was added with run_on_start.  Adding an eval test to test run_on_start functionality.

### What issues does this PR fix or reference?
#46593 

### Tests written?
Yes

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
