### PR TITLE
Fix symlink loop when file_roots/pillar_roots is a string instead of a list

### DIFF
--- a/salt/fileclient.py
+++ b/salt/fileclient.py
@@ -863,7 +863,10 @@ class LocalClient(Client):
         if saltenv not in self.opts['file_roots']:
             return ret
         prefix = prefix.strip('/')
-        for path in self.opts['file_roots'][saltenv]:
+        paths = self.opts['file_roots'][saltenv]
+        if not isinstance(paths, list):
+            paths = [paths]
+        for path in paths:
             for root, dirs, files in os.walk(
                 os.path.join(path, prefix), followlinks=True
             ):

--- a/salt/fileserver/roots.py
+++ b/salt/fileserver/roots.py
@@ -399,7 +399,10 @@ def _file_lists(load, form):
                         # (i.e. the "path" variable)
                         ret['links'][rel_path] = link_dest
 
-        for path in __opts__['file_roots'][load['saltenv']]:
+        paths = __opts__['file_roots'][load['saltenv']]
+        if not isinstance(paths, list):
+            paths = [paths]
+        for path in paths:
             for root, dirs, files in os.walk(
                     path,
                     followlinks=__opts__['fileserver_followsymlinks']):


### PR DESCRIPTION
While strings are not the correct data type for these values, using a string instead of a list will cause file_list to try to iterate over each element in the _string_. This will cause it to try to walk the entire filesystem starting at `/`, which will end up causing a symlink loop when walking through `/proc/<PID>`.

This catches instances where a string was passed and ensures we are iterating over a list instead of a string.