### PR TITLE
Fix pillar unit test failures: file_roots and pillar_roots environments should be lists

### DIFF
--- a/tests/unit/test_pillar.py
+++ b/tests/unit/test_pillar.py
@@ -55,13 +55,13 @@ class PillarTestCase(TestCase):
             'renderer_blacklist': [],
             'renderer_whitelist': [],
             'state_top': '',
-            'pillar_roots': {'__env__': '/srv/pillar/__env__', 'base': '/srv/pillar/base'},
-            'file_roots': {'base': '/srv/salt/base', 'dev': '/svr/salt/dev'},
+            'pillar_roots': {'__env__': ['/srv/pillar/__env__'], 'base': ['/srv/pillar/base']},
+            'file_roots': {'base': ['/srv/salt/base'], 'dev': ['/svr/salt/dev']},
             'extension_modules': '',
         }
         pillar = salt.pillar.Pillar(opts, {}, 'mocked-minion', 'base', pillarenv='dev')
         self.assertEqual(pillar.opts['file_roots'],
-                         {'base': '/srv/pillar/base', 'dev': '/srv/pillar/__env__'})
+                         {'base': ['/srv/pillar/base'], 'dev': ['/srv/pillar/__env__']})
 
     def test_ignored_dynamic_pillarenv(self):
         opts = {
@@ -69,12 +69,12 @@ class PillarTestCase(TestCase):
             'renderer_blacklist': [],
             'renderer_whitelist': [],
             'state_top': '',
-            'pillar_roots': {'__env__': '/srv/pillar/__env__', 'base': '/srv/pillar/base'},
-            'file_roots': {'base': '/srv/salt/base', 'dev': '/svr/salt/dev'},
+            'pillar_roots': {'__env__': ['/srv/pillar/__env__'], 'base': ['/srv/pillar/base']},
+            'file_roots': {'base': ['/srv/salt/base'], 'dev': ['/svr/salt/dev']},
             'extension_modules': '',
         }
         pillar = salt.pillar.Pillar(opts, {}, 'mocked-minion', 'base', pillarenv='base')
-        self.assertEqual(pillar.opts['file_roots'], {'base': '/srv/pillar/base'})
+        self.assertEqual(pillar.opts['file_roots'], {'base': ['/srv/pillar/base']})
 
     def test_malformed_pillar_sls(self):
         with patch('salt.pillar.compile_template') as compile_template:


### PR DESCRIPTION
These tests were written in #46309, and passed just fine on the 2017.7 branch. However, during the merge forward in #46569, it exposed a flaw in the tests, and a small bug in the code which is addressed in #46629.

The environments in `file_roots` and `pillar_roots` need to be lists. Otherwise, the tests will spin because the addition in #41423 calls out to `list_states` in the 2018.3 branch, which requires the envs to be lists. :)

This PR just back-ports the fix in the merge-forward PR for good measure to make sure the tests are correct everywhere.

Thanks to @terminalmage for helping track this one down.