### PR TITLE
Fix file.recurse w/ clean=True #36802

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -635,6 +635,7 @@ def _clean_dir(root, keep, exclude_pat):
     '''
     real_keep = _find_keep_files(root, keep)
     removed = set()
+
     def _delete_not_kept(nfn):
         if nfn not in real_keep:
             # -- check if this is a part of exclude_pat(only). No need to

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -263,7 +263,6 @@ For example:
 
 # Import python libs
 from __future__ import absolute_import
-import collections
 import difflib
 import itertools
 import logging
@@ -614,7 +613,7 @@ def _find_keep_files(root, keep):
     '''
     real_keep = set()
     real_keep.add(root)
-    if isinstance(keep, collections.Iterable):
+    if isinstance(keep, list):
         for fn_ in keep:
             if not os.path.isabs(fn_):
                 continue
@@ -634,7 +633,7 @@ def _clean_dir(root, keep, exclude_pat):
     Clean out all of the files and directories in a directory (root) while
     preserving the files in a list (keep) and part of exclude_pat
     '''
-    real_keep = _find_keep_files_old(root, keep)
+    real_keep = _find_keep_files(root, keep)
     removed = set()
     def _delete_not_kept(nfn):
         if nfn not in real_keep:

--- a/tests/unit/states/test_file.py
+++ b/tests/unit/states/test_file.py
@@ -1849,7 +1849,7 @@ class TestFindKeepFiles(TestCase):
 
     @skipIf(salt.utils.is_windows(), 'Do not run on Windows')
     def test__find_keep_files_unix(self):
-        keep = filestate._find_keep_files_old(
+        keep = filestate._find_keep_files(
             '/test/parent_folder',
             ['/test/parent_folder/meh.txt']
         )

--- a/tests/unit/states/test_file.py
+++ b/tests/unit/states/test_file.py
@@ -1843,3 +1843,36 @@ class TestFileState(TestCase, LoaderModuleMockMixin):
         run_checks(test=True)
         run_checks(strptime_format=fake_strptime_format)
         run_checks(strptime_format=fake_strptime_format, test=True)
+
+
+class TestFindKeepFiles(TestCase):
+
+    @skipIf(salt.utils.is_windows(), 'Do not run on Windows')
+    def test__find_keep_files_unix(self):
+        keep = filestate._find_keep_files_old(
+            '/test/parent_folder',
+            ['/test/parent_folder/meh.txt']
+        )
+        expected = [
+            '/',
+            '/test',
+            '/test/parent_folder',
+            '/test/parent_folder/meh.txt',
+        ]
+        actual = sorted(list(keep))
+        assert actual == expected, actual
+
+    @skipIf(not salt.utils.is_windows(), 'Only run on Windows')
+    def test__find_keep_files_win32(self):
+        keep = filestate._find_keep_files(
+            'c:\\test\\parent_folder',
+            ['C:\\test\\parent_folder\\meh-2.txt']
+        )
+        expected = [
+            'c:\\',
+            'c:\\test',
+            'c:\\test\\parent_folder',
+            'c:\\test\\parent_folder\\meh-2.txt'
+        ]
+        actual = sorted(list(keep))
+        assert actual == expected, actual


### PR DESCRIPTION
### What does this PR do?

Fix an endless looping but in file.recurse when clean is set to true.
This patch normalizes paths and handles the root correctly.

### What issues does this PR fix or reference?

#36802 

### Previous Behavior

Using file.recurse with clean = True on windows could result in an endless loop iteration.

### New Behavior

Keep files processed correctly with a loop that always terminates.


### Tests written?

Yes

### Commits signed with GPG?

Yes

