### PR TITLE
Add `fail-fast` option to test runner

### DIFF
--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -550,7 +550,10 @@ class SaltTestsuiteParser(SaltCoverageTestingParser):
         Run an integration test suite
         '''
         full_path = os.path.join(TEST_DIR, path)
-        return self.run_suite(full_path, display_name, suffix='test_*.py')
+        return self.run_suite(
+            full_path, display_name, suffix='test_*.py',
+            failfast=self.options.failfast,
+        )
 
     def start_daemons_only(self):
         if not salt.utils.platform.is_windows():
@@ -729,12 +732,16 @@ class SaltTestsuiteParser(SaltCoverageTestingParser):
                         results = self.run_suite(os.path.dirname(name),
                                                  name,
                                                  suffix=os.path.basename(name),
+                                                 failfast=self.options.failfast,
                                                  load_from_name=False)
                         status.append(results)
                         continue
                     if name.startswith(('tests.unit.', 'unit.')):
                         continue
-                    results = self.run_suite('', name, suffix='test_*.py', load_from_name=True)
+                    results = self.run_suite(
+                        '', name, suffix='test_*.py', load_from_name=True,
+                        failfast=self.options.failfast,
+                    )
                     status.append(results)
             for suite in TEST_SUITES:
                 if suite != 'unit' and getattr(self.options, suite):
@@ -763,7 +770,8 @@ class SaltTestsuiteParser(SaltCoverageTestingParser):
             self.set_filehandle_limits('unit')
 
             results = self.run_suite(
-                os.path.join(TEST_DIR, 'unit'), 'Unit', suffix='test_*.py'
+                os.path.join(TEST_DIR, 'unit'), 'Unit', suffix='test_*.py',
+                failfast=self.options.failfast,
             )
             status.append(results)
             # We executed ALL unittests, we can skip running unittests by name
@@ -772,7 +780,8 @@ class SaltTestsuiteParser(SaltCoverageTestingParser):
 
         for name in named_unit_test:
             results = self.run_suite(
-                os.path.join(TEST_DIR, 'unit'), name, suffix='test_*.py', load_from_name=True
+                os.path.join(TEST_DIR, 'unit'), name, suffix='test_*.py',
+                load_from_name=True, failfast=self.options.failfast,
             )
             status.append(results)
         return status

--- a/tests/support/parser/__init__.py
+++ b/tests/support/parser/__init__.py
@@ -242,6 +242,14 @@ class SaltTestingParser(optparse.OptionParser):
             self, 'Output Options'
         )
         self.output_options_group.add_option(
+            '-f',
+            '--fail-fast',
+            dest='failfast',
+            default=False,
+            action='store_true',
+            help='Stop on first failure'
+        )
+        self.output_options_group.add_option(
             '-v',
             '--verbose',
             dest='verbosity',
@@ -476,7 +484,7 @@ class SaltTestingParser(optparse.OptionParser):
                     shutil.rmtree(path)
 
     def run_suite(self, path, display_name, suffix='test_*.py',
-                  load_from_name=False, additional_test_dirs=None):
+                  load_from_name=False, additional_test_dirs=None, failfast=False):
         '''
         Execute a unit test suite
         '''
@@ -508,22 +516,25 @@ class SaltTestingParser(optparse.OptionParser):
             runner = XMLTestRunner(
                 stream=sys.stdout,
                 output=self.xml_output_dir,
-                verbosity=self.options.verbosity
+                verbosity=self.options.verbosity,
+                failfast=failfast,
             ).run(tests)
         else:
             runner = TextTestRunner(
                 stream=sys.stdout,
-                verbosity=self.options.verbosity).run(tests)
+                verbosity=self.options.verbosity,
+                failfast=failfast
+            ).run(tests)
 
         errors = []
         skipped = []
         failures = []
         for testcase, reason in runner.errors:
-            errors.append(TestResult(testcase.id(), reason))
+            errors.append(TestResult(testcase.id(), reason, failfast=failfast))
         for testcase, reason in runner.skipped:
-            skipped.append(TestResult(testcase.id(), reason))
+            skipped.append(TestResult(testcase.id(), reason, failfast=failfast))
         for testcase, reason in runner.failures:
-            failures.append(TestResult(testcase.id(), reason))
+            failures.append(TestResult(testcase.id(), reason, failfast=failfast))
         self.testsuite_results.append(
             TestsuiteResult(header,
                             errors,
@@ -930,6 +941,6 @@ class SaltTestcaseParser(SaltTestingParser):
                          width=self.options.output_columns)
 
         runner = TextTestRunner(
-            verbosity=self.options.verbosity).run(tests)
+            verbosity=self.options.verbosity, failfast=True).run(tests)
         self.testsuite_results.append((header, runner))
         return runner.wasSuccessful()

--- a/tests/support/parser/__init__.py
+++ b/tests/support/parser/__init__.py
@@ -530,11 +530,11 @@ class SaltTestingParser(optparse.OptionParser):
         skipped = []
         failures = []
         for testcase, reason in runner.errors:
-            errors.append(TestResult(testcase.id(), reason, failfast=failfast))
+            errors.append(TestResult(testcase.id(), reason))
         for testcase, reason in runner.skipped:
-            skipped.append(TestResult(testcase.id(), reason, failfast=failfast))
+            skipped.append(TestResult(testcase.id(), reason))
         for testcase, reason in runner.failures:
-            failures.append(TestResult(testcase.id(), reason, failfast=failfast))
+            failures.append(TestResult(testcase.id(), reason))
         self.testsuite_results.append(
             TestsuiteResult(header,
                             errors,

--- a/tests/support/parser/__init__.py
+++ b/tests/support/parser/__init__.py
@@ -242,7 +242,7 @@ class SaltTestingParser(optparse.OptionParser):
             self, 'Output Options'
         )
         self.output_options_group.add_option(
-            '-f',
+            '-F',
             '--fail-fast',
             dest='failfast',
             default=False,
@@ -941,6 +941,8 @@ class SaltTestcaseParser(SaltTestingParser):
                          width=self.options.output_columns)
 
         runner = TextTestRunner(
-            verbosity=self.options.verbosity, failfast=True).run(tests)
+            verbosity=self.options.verbosity,
+            failfast=self.options.failfast,
+        ).run(tests)
         self.testsuite_results.append((header, runner))
         return runner.wasSuccessful()


### PR DESCRIPTION
### What does this PR do?

Adds `--fail-fast (-f)` option to test suite. This will cause the test runner to exit on the first failure. 

### Commits signed with GPG?

Yes
