### PR TITLE
Use the correct path for nacl certificates in Windows

### DIFF
--- a/salt/modules/nacl.py
+++ b/salt/modules/nacl.py
@@ -185,9 +185,9 @@ def _get_config(**kwargs):
     config = {
         'box_type': 'sealedbox',
         'sk': None,
-        'sk_file': os.path.join(__opts__['pki_dir'], 'master/nacl'),
+        'sk_file': os.path.join(__opts__['pki_dir'], 'master', 'nacl'),
         'pk': None,
-        'pk_file': os.path.join(__opts__['pki_dir'], 'master/nacl.pub'),
+        'pk_file': os.path.join(__opts__['pki_dir'], 'master', 'nacl.pub'),
     }
     config_key = '{0}.config'.format(__virtualname__)
     try:


### PR DESCRIPTION
This prevents the path from being `C:\path\to\pki\master/nacl` on
Windows.

This is a follow-up to #46426.