### PR TITLE
[DOC] Unify cloud modules index header

### DIFF
--- a/doc/ref/clouds/all/index.rst
+++ b/doc/ref/clouds/all/index.rst
@@ -1,8 +1,8 @@
 .. _all-salt.clouds:
 
-===============================
-Full list of Salt Cloud modules
-===============================
+=============
+cloud modules
+=============
 
 .. currentmodule:: salt.cloud.clouds
 


### PR DESCRIPTION
### What does this PR do?
It updates Salt Module Reference doc page to unify Salt Cloud modules entry with all other entries.

### Was
```rst
* auth modules
* beacon modules
* cache modules
* Full list of Salt Cloud modules
* ...
```

### Now
```rst
* auth modules
* beacon modules
* cache modules
* cloud modules
* ...
```

### Commits signed with GPG?
Yes
