### PR TITLE
fix docker return

### DIFF
--- a/salt/modules/dockermod.py
+++ b/salt/modules/dockermod.py
@@ -1369,7 +1369,7 @@ def login(*registries):
     # information is added to the config.json, since docker-py isn't designed
     # to do so.
     registry_auth = __pillar__.get('docker-registries', {})
-    ret = {}
+    ret = {'retcode': 0}
     errors = ret.setdefault('Errors', [])
     if not isinstance(registry_auth, dict):
         errors.append('\'docker-registries\' Pillar value must be a dictionary')
@@ -1427,6 +1427,8 @@ def login(*registries):
                     errors.append(login_cmd['stderr'])
                 elif login_cmd['stdout']:
                     errors.append(login_cmd['stdout'])
+    if errors:
+        ret['retcode'] = 1
     return ret
 
 
@@ -4505,7 +4507,7 @@ def pull(image,
 
     time_started = time.time()
     response = _client_wrapper('pull', image, **kwargs)
-    ret = {'Time_Elapsed': time.time() - time_started}
+    ret = {'Time_Elapsed': time.time() - time_started, 'retcode': 0}
     _clear_context()
 
     if not response:
@@ -4538,6 +4540,7 @@ def pull(image,
 
     if errors:
         ret['Errors'] = errors
+        ret['retcode'] = 1
     return ret
 
 
@@ -4600,7 +4603,7 @@ def push(image,
 
     time_started = time.time()
     response = _client_wrapper('push', image, **kwargs)
-    ret = {'Time_Elapsed': time.time() - time_started}
+    ret = {'Time_Elapsed': time.time() - time_started, 'retcode': 0}
     _clear_context()
 
     if not response:
@@ -4632,6 +4635,7 @@ def push(image,
 
     if errors:
         ret['Errors'] = errors
+        ret['retcode'] = 1
     return ret
 
 
@@ -4703,9 +4707,11 @@ def rmi(*names, **kwargs):
 
     _clear_context()
     ret = {'Layers': [x for x in pre_images if x not in images(all=True)],
-           'Tags': [x for x in pre_tags if x not in list_tags()]}
+           'Tags': [x for x in pre_tags if x not in list_tags()],
+           'retcode': 0}
     if errors:
         ret['Errors'] = errors
+        ret['retcode'] = 1
     return ret
 
 

--- a/tests/unit/modules/test_dockermod.py
+++ b/tests/unit/modules/test_dockermod.py
@@ -81,8 +81,8 @@ class DockerTestCase(TestCase, LoaderModuleMockMixin):
             with patch.object(docker_mod, '_get_client', get_client_mock):
                 with patch.dict(docker_mod.__salt__, {'cmd.run_all': MagicMock(return_value=ref_out)}):
                     ret = docker_mod.login('portus.example.com:5000')
-                    self.assertTrue('retcode' in ret)
-                    self.assertTrue(ret['retcode'] > 0)
+                    self.assertIn('retcode', ret)
+                    self.assertNotEqual(ret['retcode'], 0)
 
     def test_ps_with_host_true(self):
         '''

--- a/tests/unit/modules/test_dockermod.py
+++ b/tests/unit/modules/test_dockermod.py
@@ -64,6 +64,26 @@ class DockerTestCase(TestCase, LoaderModuleMockMixin):
         '''
         docker_mod.__context__.pop('docker.client', None)
 
+    def test_failed_login(self):
+        '''
+        Check that when docker.login failed a retcode other then 0
+        is part of the return.
+        '''
+        client = Mock()
+        get_client_mock = MagicMock(return_value=client)
+        ref_out = {
+            'stdout': '',
+            'stderr': 'login failed',
+            'retcode': 1
+        }
+        with patch.dict(docker_mod.__pillar__, {'docker-registries': {'portus.example.com:5000':
+                {'username': 'admin', 'password': 'linux12345', 'email': 'tux@example.com'}}}):
+            with patch.object(docker_mod, '_get_client', get_client_mock):
+                with patch.dict(docker_mod.__salt__, {'cmd.run_all': MagicMock(return_value=ref_out)}):
+                    ret = docker_mod.login('portus.example.com:5000')
+                    self.assertTrue('retcode' in ret)
+                    self.assertTrue(ret['retcode'] > 0)
+
     def test_ps_with_host_true(self):
         '''
         Check that docker.ps called with host is ``True``,


### PR DESCRIPTION
### What does this PR do?

Make it possible to use login, pull and push from module.run and get result correct

when using state.apply module.run doing docker operations retcode
is tracked to find out if the call was successful or not.

Example:
```
mgr_registries_login:
  module.run:
    - name: dockerng.login
    - registries: {{ pillar.get('docker-registries', {}).keys() }}

mgr_image_profileupdate:
  module.run:
    - name: dockerng.sls_build
    - m_name: "{{ container_name }}"
    - base: "{{ pillar.get('imagename') }}"
    - mods: packages.profileupdate
    - dryrun: True
    - kwargs:
        entrypoint: ""
    - require:
      - module: mgr_registries_login
```

The require can only work if a failed login is seen as failed (result: false).
This is the case when setting `retcode` correctly when a dictionary is returned.

### Tests written?

No

### Commits signed with GPG?

No
