### PR TITLE
Fix `unit.returners.test_local_cache` for Windows

### DIFF
--- a/salt/returners/local_cache.py
+++ b/salt/returners/local_cache.py
@@ -420,7 +420,7 @@ def clean_old_jobs():
                     shutil.rmtree(t_path)
                 elif os.path.isfile(jid_file):
                     jid_ctime = os.stat(jid_file).st_ctime
-                    hours_difference = (time.time()- jid_ctime) / 3600.0
+                    hours_difference = (time.time() - jid_ctime) / 3600.0
                     if hours_difference > __opts__['keep_jobs'] and os.path.exists(t_path):
                         # Remove the entire t_path from the original JID dir
                         shutil.rmtree(t_path)

--- a/tests/unit/returners/test_local_cache.py
+++ b/tests/unit/returners/test_local_cache.py
@@ -10,6 +10,7 @@ Unit tests for the Default Job Cache (local_cache).
 from __future__ import absolute_import
 import os
 import shutil
+import time
 import logging
 import tempfile
 
@@ -75,6 +76,11 @@ class LocalCacheCleanOldJobsTestCase(TestCase, LoaderModuleMockMixin):
         # Call clean_old_jobs function, patching the keep_jobs value with a
         # very small value to force the call to clean the job.
         with patch.dict(local_cache.__opts__, {'keep_jobs': 0.00000001}):
+            # Sleep on Windows because time.time is only precise to 3 decimal
+            # points, and therefore subtracting the jid_ctime from time.time
+            # will result in a negative number
+            if salt.utils.is_windows():
+                time.sleep(0.25)
             local_cache.clean_old_jobs()
 
         # Assert that the JID dir was removed
@@ -138,6 +144,11 @@ class LocalCacheCleanOldJobsTestCase(TestCase, LoaderModuleMockMixin):
         # Call clean_old_jobs function, patching the keep_jobs value with a
         # very small value to force the call to clean the job.
         with patch.dict(local_cache.__opts__, {'keep_jobs': 0.00000001}):
+            # Sleep on Windows because time.time is only precise to 3 decimal
+            # points, and therefore subtracting the jid_ctime from time.time
+            # will result in a negative number
+            if salt.utils.is_windows():
+                time.sleep(0.25)
             local_cache.clean_old_jobs()
 
         # Assert that the JID dir was removed


### PR DESCRIPTION
### What does this PR do?
Fixes an issue with the `unit.returners.test_local_cache` test on Windows. `time.time()` is only precise to 3 decimal places in Windows. The test passes a `keep_jobs` time of `.0000000001` seconds. The module compares the date/time stamp on the file to the current time from `time.time()`. When the file time stampe is subtracted from `time.time()` it produces a negative number due to the in-precision of the `time.time()` function on Windows. This PR adds a sleep for .25 seconds on Windows to allow the test to pass.
Additionally, this PR fixes a lint error.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/46348

### Tests written?
Yes

### Commits signed with GPG?
Yes