### PR TITLE
Fix the tear down function in integration.modules.test_grains

### DIFF
--- a/tests/integration/modules/test_grains.py
+++ b/tests/integration/modules/test_grains.py
@@ -152,8 +152,7 @@ class GrainsAppendTestCase(ModuleCase):
     GRAIN_VAL = 'my-grain-val'
 
     def tearDown(self):
-        for item in self.run_function('grains.get', [self.GRAIN_KEY]):
-            self.run_function('grains.remove', [self.GRAIN_KEY, item])
+        self.run_function('grains.setval', [self.GRAIN_KEY, []])
 
     def test_grains_append(self):
         '''


### PR DESCRIPTION
### What does this PR do?
`integration.modules.test_grains.GrainsAppendTestCase`
Fix the `tearDown` function to just set the grain to an empty list instead of removing each individual item.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/46351

### Tests written?
Yes

### Commits signed with GPG?
Yes