### PR TITLE
Make server_id consistent on Python 3

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -2404,7 +2404,30 @@ def get_server_id():
 
     if salt.utils.is_proxy():
         return {}
-    return {'server_id': abs(hash(__opts__.get('id', '')) % (2 ** 31))}
+    id_ = __opts__.get('id', '')
+    id_hash = None
+    py_ver = sys.version_info[:2]
+    if py_ver >= (3, 3):
+        # Python 3.3 enabled hash randomization, so we need to shell out to get
+        # a reliable hash.
+        py_bin = 'python{0}.{1}'.format(*py_ver)
+        id_hash = __salt__['cmd.run'](
+            [py_bin, '-c', 'print(hash("{0}"))'.format(id_)],
+            env={'PYTHONHASHSEED': '0'}
+        )
+        try:
+            id_hash = int(id_hash)
+        except (TypeError, ValueError):
+            log.debug(
+                'Failed to hash the ID to get the server_id grain. Result of '
+                'hash command: %s', id_hash
+            )
+            id_hash = None
+    if id_hash is None:
+        # Python < 3.3 or error encountered above
+        id_hash = hash(id_)
+
+    return {'server_id': abs(id_hash % (2 ** 31))}
 
 
 def get_master():


### PR DESCRIPTION
Hashing is randomized using a random seed on Python >= 3.3. This causes the server_id grain (which uses hash), to be inconsistent. To solve this, on Python >= 3.3 we now must shell out to Python with the PYTHONHASHSEED variable set to 0 to get a consistent hash for this grain.

Fixes #46595

```
% docker run --rm -it -v $PWD:/testing terminalmage/issues:46595 salt-call grains.item server_id
local:
    ----------
    server_id:
        1308370872
% docker run --rm -it -v $PWD:/testing terminalmage/issues:46595 salt-call grains.item server_id
local:
    ----------
    server_id:
        1308370872
```