### PR TITLE
Mirror libnacl imports in test from the nacl module

### DIFF
--- a/tests/integration/modules/test_nacl.py
+++ b/tests/integration/modules/test_nacl.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 '''
-Tests for the salt-run command
+Tests for the nacl execution module
 '''
 # Import Python libs
 from __future__ import absolute_import, print_function, unicode_literals
@@ -12,7 +12,8 @@ from tests.support.case import ModuleCase
 from tests.support.unit import skipIf
 
 try:
-    import libnacl  # pylint: disable=unused-import
+    import libnacl.secret  # pylint: disable=unused-import
+    import libnacl.sealed  # pylint: disable=unused-import
     HAS_LIBNACL = True
 except ImportError:
     HAS_LIBNACL = False

--- a/tests/integration/runners/test_nacl.py
+++ b/tests/integration/runners/test_nacl.py
@@ -10,7 +10,8 @@ from tests.support.case import ShellCase
 from tests.support.unit import skipIf
 
 try:
-    import libnacl  # pylint: disable=unused-import
+    import libnacl.secret  # pylint: disable=unused-import
+    import libnacl.sealed  # pylint: disable=unused-import
     HAS_LIBNACL = True
 except ImportError:
     HAS_LIBNACL = False


### PR DESCRIPTION
### What does this PR do?
on mac 10.13 the `libnacl.sealed` import does not work:

```
Mac-2:testing root# python -c "import libnacl.secret; import libnacl.sealed"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
ImportError: No module named sealed
```

The tests are failing because it cannot import the nacl module. This will ensure the tests have the correct libnacl imports.

