### PR TITLE
openstack: fix keyword arg for __query_node()

### DIFF
--- a/salt/cloud/clouds/openstack.py
+++ b/salt/cloud/clouds/openstack.py
@@ -708,7 +708,7 @@ def create(vm_):
     try:
         ip_address = __utils__['cloud.wait_for_fun'](
             __query_node,
-            update_args=(vm_,)
+            vm_=vm_
         )
     except (SaltCloudExecutionTimeout, SaltCloudExecutionFailure) as exc:
         try:


### PR DESCRIPTION
### What does this PR do?
Currently the rackspace cloud tests are failing with this failure: `Caught exception in wait_for_fun: __query_node() got an unexpected keyword argument 'update_args'`

This is due to the change in this PR: https://github.com/saltstack/salt/pull/46400
