### PR TITLE
Fixing cleanUp method to restore environment

### DIFF
--- a/salt/states/environ.py
+++ b/salt/states/environ.py
@@ -28,6 +28,7 @@ def _norm_key(key):
         return key.upper()
     return key
 
+
 def setenv(name,
            value,
            false_unsets=False,

--- a/salt/states/environ.py
+++ b/salt/states/environ.py
@@ -20,6 +20,14 @@ def __virtual__():
     return True
 
 
+def _norm_key(key):
+    '''
+    Normalize windows environment keys
+    '''
+    if utils.is_windows():
+        return key.upper()
+    return key
+
 def setenv(name,
            value,
            false_unsets=False,
@@ -124,12 +132,11 @@ def setenv(name,
                         permanent_hive = 'HKLM'
                         permanent_key = r'SYSTEM\CurrentControlSet\Control\Session Manager\Environment'
 
-                    out = __salt__['reg.read_value'](permanent_hive, permanent_key, key)
+                    out = __salt__['reg.read_value'](permanent_hive, permanent_key, _norm_key(key))
                     return out['success'] is True
                 else:
                     return False
-
-            if current_environ.get(key, None) is None and not key_exists():
+            if current_environ.get(_norm_key(key), None) is None and not key_exists():
                 # The key does not exist in environment
                 if false_unsets is not True:
                     # This key will be added with value ''
@@ -138,13 +145,13 @@ def setenv(name,
                 # The key exists.
                 if false_unsets is not True:
                     # Check to see if the value will change
-                    if current_environ.get(key, None) != '':
+                    if current_environ.get(_norm_key(key), None) != '':
                         # This key value will change to ''
                         ret['changes'].update({key: ''})
                 else:
                     # We're going to delete the key
                     ret['changes'].update({key: None})
-        elif current_environ.get(key, '') == val:
+        elif current_environ.get(_norm_key(key), '') == val:
             already_set.append(key)
         else:
             ret['changes'].update({key: val})

--- a/tests/unit/states/test_environ.py
+++ b/tests/unit/states/test_environ.py
@@ -27,12 +27,11 @@ class TestEnvironState(TestCase, LoaderModuleMockMixin):
         return {envstate: loader_globals, envmodule: loader_globals}
 
     def setUp(self):
-        original_environ = os.environ.copy()
-        os.environ = {'INITIAL': 'initial'}
-
-        def reset_environ(original_environ):
-            os.environ = original_environ
-        self.addCleanup(reset_environ, original_environ)
+        patcher = patch.dict(os.environ, {'INITIAL': 'initial'})
+        patcher.start()
+        def reset_environ(patcher):
+            patcher.stop()
+        self.addCleanup(reset_environ, patcher)
 
     def test_setenv(self):
         '''test that a subsequent calls of setenv changes nothing'''

--- a/tests/unit/states/test_environ.py
+++ b/tests/unit/states/test_environ.py
@@ -6,7 +6,7 @@ import os
 
 # Import Salt Testing libs
 from tests.support.mixins import LoaderModuleMockMixin
-from tests.support.unit import TestCase
+from tests.support.unit import TestCase, skipIf
 from tests.support.mock import (
     MagicMock,
     patch

--- a/tests/unit/states/test_environ.py
+++ b/tests/unit/states/test_environ.py
@@ -14,8 +14,8 @@ from tests.support.mock import (
 # Import salt libs
 import salt.states.environ as envstate
 import salt.modules.environ as envmodule
-import salt.modules.reg as regmodule
-import salt.utils as utils
+import salt.modules.reg
+import salt.utils
 
 
 class TestEnvironState(TestCase, LoaderModuleMockMixin):
@@ -26,7 +26,7 @@ class TestEnvironState(TestCase, LoaderModuleMockMixin):
             '__opts__': {'test': False},
             '__salt__': {
                 'environ.setenv': envmodule.setenv,
-                'reg.read_value': regmodule.read_value,
+                'reg.read_value': salt.modules.reg.read_value,
             }
         }
         return {envstate: loader_globals, envmodule: loader_globals}
@@ -53,7 +53,7 @@ class TestEnvironState(TestCase, LoaderModuleMockMixin):
         ret = envstate.setenv('test', 'other')
         self.assertEqual(ret['changes'], {})
 
-    @skipIf(not utils.is_windows(), 'Windows only')
+    @skipIf(not salt.utils.is_windows(), 'Windows only')
     def test_setenv_permanent(self):
         '''test that we can set perminent environment variables (requires pywin32)'''
         with patch.dict(envmodule.__salt__, {'reg.set_value': MagicMock(), 'reg.delete_value': MagicMock()}):
@@ -89,7 +89,7 @@ class TestEnvironState(TestCase, LoaderModuleMockMixin):
         '''test that ``clear_all`` option sets other values to '' '''
         ret = envstate.setenv('test', 'value', clear_all=True)
         self.assertEqual(ret['changes'], {'test': 'value', 'INITIAL': ''})
-        if utils.is_windows():
+        if salt.utils.is_windows():
             self.assertEqual(envstate.os.environ, {'TEST': 'value', 'INITIAL': ''})
         else:
             self.assertEqual(envstate.os.environ, {'test': 'value', 'INITIAL': ''})
@@ -99,7 +99,7 @@ class TestEnvironState(TestCase, LoaderModuleMockMixin):
         unsets other values from environment'''
         ret = envstate.setenv('test', 'value', false_unsets=True, clear_all=True)
         self.assertEqual(ret['changes'], {'test': 'value', 'INITIAL': None})
-        if utils.is_windows():
+        if salt.utils.is_windows():
             self.assertEqual(envstate.os.environ, {'TEST': 'value'})
         else:
             self.assertEqual(envstate.os.environ, {'test': 'value'})
@@ -113,7 +113,7 @@ class TestEnvironState(TestCase, LoaderModuleMockMixin):
             ret = envstate.setenv(
                 'notimportant', {'test': False, 'foo': 'baz'}, false_unsets=True)
         self.assertEqual(ret['changes'], {'test': None, 'foo': 'baz'})
-        if utils.is_windows():
+        if salt.utils.is_windows():
             self.assertEqual(envstate.os.environ, {'INITIAL': 'initial', 'FOO': 'baz'})
         else:
             self.assertEqual(envstate.os.environ, {'INITIAL': 'initial', 'foo': 'baz'})
@@ -121,7 +121,7 @@ class TestEnvironState(TestCase, LoaderModuleMockMixin):
         with patch.dict(envstate.__salt__, {'reg.read_value': MagicMock()}):
             ret = envstate.setenv('notimportant', {'test': False, 'foo': 'bax'})
         self.assertEqual(ret['changes'], {'test': '', 'foo': 'bax'})
-        if utils.is_windows():
+        if salt.utils.is_windows():
             self.assertEqual(envstate.os.environ, {'INITIAL': 'initial', 'FOO': 'bax', 'TEST': ''})
         else:
             self.assertEqual(envstate.os.environ, {'INITIAL': 'initial', 'foo': 'bax', 'test': ''})

--- a/tests/unit/states/test_environ.py
+++ b/tests/unit/states/test_environ.py
@@ -14,6 +14,7 @@ from tests.support.mock import (
 # Import salt libs
 import salt.states.environ as envstate
 import salt.modules.environ as envmodule
+import salt.modules.reg as regmodule
 import salt.utils as utils
 
 
@@ -23,7 +24,10 @@ class TestEnvironState(TestCase, LoaderModuleMockMixin):
         loader_globals = {
             '__env__': 'base',
             '__opts__': {'test': False},
-            '__salt__': {'environ.setenv': envmodule.setenv}
+            '__salt__': {
+                'environ.setenv': envmodule.setenv,
+                'reg.read_value': regmodule.read_value,
+            }
         }
         return {envstate: loader_globals, envmodule: loader_globals}
 

--- a/tests/unit/states/test_environ.py
+++ b/tests/unit/states/test_environ.py
@@ -30,8 +30,10 @@ class TestEnvironState(TestCase, LoaderModuleMockMixin):
     def setUp(self):
         patcher = patch.dict(os.environ, {'INITIAL': 'initial'}, clear=True)
         patcher.start()
+
         def reset_environ(patcher):
             patcher.stop()
+
         self.addCleanup(reset_environ, patcher)
 
     def test_setenv(self):

--- a/tests/unit/states/test_environ.py
+++ b/tests/unit/states/test_environ.py
@@ -53,9 +53,10 @@ class TestEnvironState(TestCase, LoaderModuleMockMixin):
         ret = envstate.setenv('test', 'other')
         self.assertEqual(ret['changes'], {})
 
+    @skipIf(not utils.is_windows(), 'Windows only')
     def test_setenv_permanent(self):
-        with patch.dict(envmodule.__salt__, {'reg.set_value': MagicMock(), 'reg.delete_value': MagicMock()}), \
-                patch('salt.utils.is_windows', MagicMock(return_value=True)):
+        '''test that we can set perminent environment variables (requires pywin32)'''
+        with patch.dict(envmodule.__salt__, {'reg.set_value': MagicMock(), 'reg.delete_value': MagicMock()}):
             ret = envstate.setenv('test', 'value', permanent=True)
             self.assertEqual(ret['changes'], {'test': 'value'})
             envmodule.__salt__['reg.set_value'].assert_called_with("HKCU", "Environment", 'test', 'value')


### PR DESCRIPTION
### What does this PR do?

The clean-up method was not reliabliy restoring sys.environment on
windows. Using Mock's patch to cleanup more reliably.

### What issues does this PR fix or reference?

#46350, #46345, #46349, #46354

### Previous Behavior

cleanUp method was not restoring sys.environ properly (at least on windows)

### New Behavior

Mock's patch method restores environ properly

### Tests written?

No - This fixes a hand full of existing tests.

### Commits signed with GPG?

Yes
