### PR TITLE
Changed destination for ipv6 in _ip_route_linux()

### DIFF
--- a/salt/modules/network.py
+++ b/salt/modules/network.py
@@ -542,7 +542,7 @@ def _ip_route_linux():
 
             ret.append({
                 'addr_family': 'inet6',
-                'destination': '::',
+                'destination': '::/0',
                 'gateway': comps[2],
                 'netmask': '',
                 'flags': 'UG',


### PR DESCRIPTION
Changed destination for ipv6 in _ip_route_linux() to known default route destination of default_route() function

### What does this PR do?

Returns destination '::/0' instead of '::' for default ipv6 routes. '::/0' is known to be a default route destination in the default_route() function.

### What issues does this PR fix or reference?

Fixes bug #46555

### Tests written?

No

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
