### PR TITLE
Add option to return to pre-2017.7.3 pillar include merge order

### DIFF
--- a/doc/ref/configuration/master.rst
+++ b/doc/ref/configuration/master.rst
@@ -4029,6 +4029,25 @@ Recursively merge lists by aggregating them instead of replacing them.
 
     pillar_merge_lists: False
 
+.. conf_master:: pillar_includes_override_sls
+
+``pillar_includes_override_sls``
+********************************
+
+.. versionadded:: 2017.7.6,2018.3.1
+
+Default: ``False``
+
+Prior to version 2017.7.3, keys from :ref:`pillar includes <pillar-include>`
+would be merged on top of the pillar SLS. Since 2017.7.3, the includes are
+merged together and then the pillar SLS is merged on top of that.
+
+Set this option to ``True`` to return to the old behavior.
+
+.. code-block:: yaml
+
+    pillar_includes_override_sls: True
+
 .. _pillar-cache-opts:
 
 Pillar Cache Options

--- a/doc/topics/pillar/index.rst
+++ b/doc/topics/pillar/index.rst
@@ -285,6 +285,8 @@ Since both pillar SLS files contained a ``bind`` key which contained a nested
 dictionary, the pillar dictionary's ``bind`` key contains the combined contents
 of both SLS files' ``bind`` keys.
 
+.. _pillar-include:
+
 Including Other Pillars
 =======================
 

--- a/doc/topics/releases/2017.7.6.rst
+++ b/doc/topics/releases/2017.7.6.rst
@@ -1,0 +1,15 @@
+===========================
+Salt 2017.7.6 Release Notes
+===========================
+
+Version 2017.7.6 is a bugfix release for :ref:`2017.7.0 <release-2017-7-0>`.
+
+Option to Return to Previous Pillar Include Behavior
+----------------------------------------------------
+
+Prior to version 2017.7.3, keys from :ref:`pillar includes <pillar-include>`
+would be merged on top of the pillar SLS. Since 2017.7.3, the includes are
+merged together and then the pillar SLS is merged on top of that.
+
+The :conf_master:`pillar_includes_override_sls` option has been added allow
+users to switch back to the pre-2017.7.3 behavior.

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -680,6 +680,9 @@ VALID_OPTS = {
     # Recursively merge lists by aggregating them instead of replacing them.
     'pillar_merge_lists': bool,
 
+    # If True, values from included pillar SLS targets will override
+    'pillar_includes_override_sls': bool,
+
     # How to merge multiple top files from multiple salt environments
     # (saltenvs); can be 'merge' or 'same'
     'top_file_merging_strategy': str,
@@ -1139,6 +1142,9 @@ DEFAULT_MINION_OPTS = {
     'pillarenv': None,
     'pillarenv_from_saltenv': False,
     'pillar_opts': False,
+    'pillar_source_merging_strategy': 'smart',
+    'pillar_merge_lists': False,
+    'pillar_includes_override_sls': False,
     # ``pillar_cache``, ``pillar_cache_ttl`` and ``pillar_cache_backend``
     # are not used on the minion but are unavoidably in the code path
     'pillar_cache': False,
@@ -1467,6 +1473,7 @@ DEFAULT_MASTER_OPTS = {
     'pillar_safe_render_error': True,
     'pillar_source_merging_strategy': 'smart',
     'pillar_merge_lists': False,
+    'pillar_includes_override_sls': False,
     'pillar_cache': False,
     'pillar_cache_ttl': 3600,
     'pillar_cache_backend': 'disk',

--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -696,11 +696,22 @@ class Pillar(object):
                                             nstate = {
                                                 key_fragment: nstate
                                             }
-                                    include_states.append(nstate)
+                                    if not self.opts.get('pillar_includes_override_sls', False):
+                                        include_states.append(nstate)
+                                    else:
+                                        state = merge(
+                                            state,
+                                            nstate,
+                                            self.merge_strategy,
+                                            self.opts.get('renderer', 'yaml'),
+                                            self.opts.get('pillar_merge_lists', False))
                                 if err:
                                     errors += err
-                        if include_states:
-                            # merge included state(s) with the current state merged last
+
+                        if not self.opts.get('pillar_includes_override_sls', False):
+                            # merge included state(s) with the current state
+                            # merged last to ensure that its values are
+                            # authoritative.
                             include_states.append(state)
                             state = None
                             for s in include_states:


### PR DESCRIPTION
https://github.com/saltstack/salt/pull/45025 changed the pillar include merge order. This adds a new config option which allows a user to revert to the pre-2017.7.3 behavior.