### PR TITLE
Skip test when git symlinks are not configured

### DIFF
--- a/tests/unit/modules/test_inspect_collector.py
+++ b/tests/unit/modules/test_inspect_collector.py
@@ -48,9 +48,12 @@ def no_symlinks():
     output = ''
     try:
         output = subprocess.check_output('git config --get core.symlinks', shell=True)
-    except OSError as ex:
-        if es.errno != errno.ENOENT:
+    except OSError as exc:
+        if exc.errno != errno.ENOENT:
             raise
+    except subprocess.CalledProcessError:
+        # git returned non-zero status
+        pass
     HAS_SYMLINKS = False
     if output.strip() == 'true':
         HAS_SYMLINKS = True

--- a/tests/unit/modules/test_inspect_collector.py
+++ b/tests/unit/modules/test_inspect_collector.py
@@ -19,6 +19,7 @@
 # Import Python Libs
 from __future__ import absolute_import
 import os
+import subprocess
 
 # Import Salt Testing Libs
 from tests.support.unit import TestCase, skipIf
@@ -33,7 +34,22 @@ from tests.support.mock import (
 from salt.modules.inspectlib.collector import Inspector
 
 
+HAS_SYMLINKS = None
+
+
+def no_symlinks():
+    global HAS_SYMLINKS
+    if HAS_SYMLINKS is not None:
+        return not HAS_SYMLINKS
+    output = subprocess.check_output('git config --get core.symlinks', shell=True)
+    HAS_SYMLINKS = False
+    if output.strip() == 'true':
+        HAS_SYMLINKS = True
+    return not HAS_SYMLINKS
+
+
 @skipIf(NO_MOCK, NO_MOCK_REASON)
+@skipIf(no_symlinks(), "Git missing 'core.symlinks=true' config")
 class InspectorCollectorTestCase(TestCase):
     '''
     Test inspectlib:collector:Inspector

--- a/tests/unit/modules/test_inspect_collector.py
+++ b/tests/unit/modules/test_inspect_collector.py
@@ -19,6 +19,7 @@
 # Import Python Libs
 from __future__ import absolute_import
 import os
+import errno
 import subprocess
 
 # Import Salt Testing Libs
@@ -38,10 +39,18 @@ HAS_SYMLINKS = None
 
 
 def no_symlinks():
+    '''
+    Check if git is installed and has symlinks enabled in the configuration.
+    '''
     global HAS_SYMLINKS
     if HAS_SYMLINKS is not None:
         return not HAS_SYMLINKS
-    output = subprocess.check_output('git config --get core.symlinks', shell=True)
+    output = ''
+    try:
+        output = subprocess.check_output('git config --get core.symlinks', shell=True)
+    except OSError as ex:
+        if es.errno != errno.ENOENT:
+            raise
     HAS_SYMLINKS = False
     if output.strip() == 'true':
         HAS_SYMLINKS = True


### PR DESCRIPTION
### What does this PR do?

Skips symlink tests when git configuration does not support symlinks.

### What issues does this PR fix or reference?

#46347

### Previous Behavior

Tests would fail if git was cloned without 'core.symlinks=true'

### New Behavior

Tests pass when the config supports them and are skipped with a nice message otherwise.

### Tests written?

No - Fixes existing tests

### Commits signed with GPG?

Yes
