### PR TITLE
Add save_load in zabbix returner

### DIFF
--- a/salt/returners/zabbix_return.py
+++ b/salt/returners/zabbix_return.py
@@ -71,8 +71,10 @@ def zabbix_send(key, host, output):
         if flag == 'false':
             cmd = zbx()['sender'] + " -c " + zbx()['config'] + " -s " + host + " -k " + key + " -o \"" + output +"\""
 
+
 def save_load(jid, load, minions=None):
     pass
+
 
 def returner(ret):
     changes = False

--- a/salt/returners/zabbix_return.py
+++ b/salt/returners/zabbix_return.py
@@ -71,6 +71,8 @@ def zabbix_send(key, host, output):
         if flag == 'false':
             cmd = zbx()['sender'] + " -c " + zbx()['config'] + " -s " + host + " -k " + key + " -o \"" + output +"\""
 
+def save_load(jid, load, minions=None):
+    pass
 
 def returner(ret):
     changes = False


### PR DESCRIPTION
### What does this PR do?
Add save_load function with pass in zabbix returners in order to use this returner in ext_job_cache without logging critical errors.
### What issues does this PR fix or reference?

### Previous Behavior
[salt.master      :2085][CRITICAL][12594] The specified returner used for the external job cache "zabbix" does not have a save_load function!

### New Behavior
No critical error. Same behaviour as using --return on command line.

### Tests written?

No

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.