### PR TITLE
saltnado bugfixes for ldap & syndics

### DIFF
--- a/salt/netapi/rest_tornado/saltnado.py
+++ b/salt/netapi/rest_tornado/saltnado.py
@@ -752,6 +752,7 @@ class SaltAuthHandler(BaseSaltAPIHandler):  # pylint: disable=W0223
                 for group in user_groups & eauth_groups:
                     perms.extend(eauth['{0}%'.format(group)])
 
+            perms = sorted(list(set(perms)))
         # If we can't find the creds, then they aren't authorized
         except KeyError:
             self.send_error(401)
@@ -952,10 +953,6 @@ class SaltAPIHandler(BaseSaltAPIHandler):  # pylint: disable=W0223
         # seed minions_remaining with the pub_data
         minions_remaining = pub_data['minions']
 
-        syndic_min_wait = None
-        if self.application.opts['order_masters']:
-            syndic_min_wait = tornado.gen.sleep(self.application.opts['syndic_wait'])
-
         # To ensure job_not_running and all_return are terminated by each other, communicate using a future
         is_finished = Future()
         job_not_running_future = self.job_not_running(pub_data['jid'],
@@ -964,10 +961,6 @@ class SaltAPIHandler(BaseSaltAPIHandler):  # pylint: disable=W0223
                                                       is_finished,
                                                       minions_remaining=list(minions_remaining),
                                                       )
-
-        # if we have a min_wait, do that
-        if syndic_min_wait is not None:
-            yield syndic_min_wait
 
         all_return_future = self.all_returns(pub_data['jid'],
                                              is_finished,
@@ -992,16 +985,21 @@ class SaltAPIHandler(BaseSaltAPIHandler):  # pylint: disable=W0223
         chunk_ret = {}
 
         minion_events = {}
+
+        syndic_min_wait = 0
+        if self.application.opts['order_masters']:
+            syndic_min_wait = self.application.opts['syndic_wait']
+
         for minion in minions_remaining:
             tag = tagify([jid, 'ret', minion], 'job')
             minion_event = self.application.event_listener.get_event(self,
                                                                      tag=tag,
                                                                      matcher=EventListener.exact_matcher,
-                                                                     timeout=self.application.opts['timeout'])
+                                                                     timeout=self.application.opts['timeout'] + syndic_min_wait)
             minion_events[minion_event] = minion
 
         while True:
-            f = yield Any(minion_events.keys() + [is_finished])
+            f = yield Any(list(minion_events.keys()) + [is_finished])
             try:
                 if f is is_finished:
                     for event in minion_events:

--- a/tests/unit/netapi/rest_tornado/test_handlers.py
+++ b/tests/unit/netapi/rest_tornado/test_handlers.py
@@ -531,7 +531,7 @@ class TestSaltAuthHandler(SaltnadoTestCase):
 
         self.assertEqual(response.code, 200)
         response_obj = salt.utils.json.loads(response.body)['return'][0]
-        self.assertEqual(response_obj['perms'], self.opts['external_auth']['auto'][self.auth_creds_dict['username']])
+        self.assertEqual(sorted(response_obj['perms']), sorted(self.opts['external_auth']['auto'][self.auth_creds_dict['username']]))
         self.assertIn('token', response_obj)  # TODO: verify that its valid?
         self.assertEqual(response_obj['user'], self.auth_creds_dict['username'])
         self.assertEqual(response_obj['eauth'], self.auth_creds_dict['eauth'])
@@ -544,7 +544,7 @@ class TestSaltAuthHandler(SaltnadoTestCase):
 
         self.assertEqual(response.code, 200)
         response_obj = salt.utils.json.loads(response.body)['return'][0]
-        self.assertEqual(response_obj['perms'], self.opts['external_auth']['auto'][self.auth_creds_dict['username']])
+        self.assertEqual(sorted(response_obj['perms']), sorted(self.opts['external_auth']['auto'][self.auth_creds_dict['username']]))
         self.assertIn('token', response_obj)  # TODO: verify that its valid?
         self.assertEqual(response_obj['user'], self.auth_creds_dict['username'])
         self.assertEqual(response_obj['eauth'], self.auth_creds_dict['eauth'])
@@ -557,7 +557,7 @@ class TestSaltAuthHandler(SaltnadoTestCase):
 
         self.assertEqual(response.code, 200)
         response_obj = salt.utils.json.loads(response.body)['return'][0]
-        self.assertEqual(response_obj['perms'], self.opts['external_auth']['auto'][self.auth_creds_dict['username']])
+        self.assertEqual(sorted(response_obj['perms']), sorted(self.opts['external_auth']['auto'][self.auth_creds_dict['username']]))
         self.assertIn('token', response_obj)  # TODO: verify that its valid?
         self.assertEqual(response_obj['user'], self.auth_creds_dict['username'])
         self.assertEqual(response_obj['eauth'], self.auth_creds_dict['eauth'])
@@ -586,7 +586,10 @@ class TestSaltAuthHandler(SaltnadoTestCase):
         for key, val in six.iteritems(self.auth_creds_dict):
             if key == 'username':
                 val = val + 'foo'
+            if key == 'eauth':
+                val = 'sharedsecret'
             bad_creds.append((key, val))
+
         response = self.fetch('/login',
                                method='POST',
                                body=urlencode(bad_creds),


### PR DESCRIPTION
### What does this PR do?
fix syndic_wait handling in saltnado in syndic topologies:

 as is, yielding sleep before registering the event listener as actually causing saltnado to _miss_ the event entirely. instead of waiting before registering  instead we just add the syndic_wait to the futures base timeout. This issue only affected synchronous localclient calls

also included, a fix for ldap group based perms that mimics cherrypy compatibility.

### New Behavior
- saltnado now works with syndic topologies
- saltnado now works with group perms with ldap

### Tests written?
Yes

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
