### PR TITLE
Windows `unit.test_client` fixes

### DIFF
--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -96,7 +96,7 @@ class LocalClientTestCase(TestCase,
     @skipIf(not salt.utils.is_windows(), 'Windows only test')
     def test_pub_win32(self):
         '''
-        Tests that the cleint raises a timeout error when using TCP transport
+        Tests that the client raises a timeout error when using TCP transport
         and publisher is not running.
 
         Note: Requires TCP transport, this is only the default on Windows.

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -13,7 +13,10 @@ from tests.support.mock import patch, NO_MOCK, NO_MOCK_REASON
 
 # Import Salt libs
 from salt import client
-from salt.exceptions import EauthAuthenticationError, SaltInvocationError, SaltClientError
+import salt.utils
+from salt.exceptions import (
+    EauthAuthenticationError, SaltInvocationError, SaltClientError, SaltReqTimeoutError
+)
 
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
@@ -67,12 +70,42 @@ class LocalClientTestCase(TestCase,
                                                     kwarg=None, tgt_type='list',
                                                     ret='')
 
+    @skipIf(salt.utils.is_windows(), 'Not supported on Windows')
     def test_pub(self):
+        '''
+        Tests that the client cleanly returns when the publisher is not running
+
+        Note: Requires IPC transport which is not supported on windows.
+        '''
         if self.get_config('minion')['transport'] != 'zeromq':
             self.skipTest('This test only works with ZeroMQ')
         # Make sure we cleanly return if the publisher isn't running
         with patch('os.path.exists', return_value=False):
             self.assertRaises(SaltClientError, lambda: self.client.pub('*', 'test.ping'))
+
+        # Check nodegroups behavior
+        with patch('os.path.exists', return_value=True):
+            with patch.dict(self.client.opts,
+                            {'nodegroups':
+                                 {'group1': 'L@foo.domain.com,bar.domain.com,baz.domain.com or bl*.domain.com'}}):
+                # Do we raise an exception if the nodegroup can't be matched?
+                self.assertRaises(SaltInvocationError,
+                                  self.client.pub,
+                                  'non_existent_group', 'test.ping', tgt_type='nodegroup')
+
+    @skipIf(not salt.utils.is_windows(), 'Windows only test')
+    def test_pub_win32(self):
+        '''
+        Tests that the cleint raises a timeout error when using TCP transport
+        and publisher is not running.
+
+        Note: Requires TCP transport, this is only the default on Windows.
+        '''
+        if self.get_config('minion')['transport'] != 'zeromq':
+            self.skipTest('This test only works with ZeroMQ')
+        # Make sure we cleanly return if the publisher isn't running
+        with patch('os.path.exists', return_value=False):
+            self.assertRaises(SaltReqTimeoutError, lambda: self.client.pub('*', 'test.ping'))
 
         # Check nodegroups behavior
         with patch('os.path.exists', return_value=True):

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -75,7 +75,7 @@ class LocalClientTestCase(TestCase,
         '''
         Tests that the client cleanly returns when the publisher is not running
 
-        Note: Requires IPC transport which is not supported on windows.
+        Note: Requires ZeroMQ's IPC transport which is not supported on windows.
         '''
         if self.get_config('minion')['transport'] != 'zeromq':
             self.skipTest('This test only works with ZeroMQ')
@@ -96,10 +96,10 @@ class LocalClientTestCase(TestCase,
     @skipIf(not salt.utils.is_windows(), 'Windows only test')
     def test_pub_win32(self):
         '''
-        Tests that the client raises a timeout error when using TCP transport
-        and publisher is not running.
+        Tests that the client raises a timeout error when using ZeroMQ's TCP
+        transport and publisher is not running.
 
-        Note: Requires TCP transport, this is only the default on Windows.
+        Note: Requires ZeroMQ's TCP transport, this is only the default on Windows.
         '''
         if self.get_config('minion')['transport'] != 'zeromq':
             self.skipTest('This test only works with ZeroMQ')


### PR DESCRIPTION


### What does this PR do?

- Skip IPC transport test on windows
- Add TCP transport test for windows

### What issues does this PR fix or reference

#46352

### Previous Behavior

IPC test failed with exception

### New Behavior

Skip IPC test and instead test TCP transport which is the default on windows.

### Tests written?

Yes - New test for windows behavior.

### Commits signed with GPG?

Yes