### PR TITLE
[2018.3.0rc1] Ensure event payloads are sent as Unicode

### DIFF
--- a/salt/output/highstate.py
+++ b/salt/output/highstate.py
@@ -248,6 +248,7 @@ def _format_host(host, data):
                 tcolor = colors['LIGHT_YELLOW']
 
             state_output = __opts__.get('state_output', 'full').lower()
+            tname = salt.utils.stringutils.to_unicode(tname)
             comps = tname.split('_|-')
 
             if state_output.endswith('_id'):

--- a/salt/output/highstate.py
+++ b/salt/output/highstate.py
@@ -248,7 +248,6 @@ def _format_host(host, data):
                 tcolor = colors['LIGHT_YELLOW']
 
             state_output = __opts__.get('state_output', 'full').lower()
-            tname = salt.utils.stringutils.to_unicode(tname)
             comps = tname.split('_|-')
 
             if state_output.endswith('_id'):

--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -432,7 +432,7 @@ class SaltEvent(object):
 
         if six.PY2:
             mtag, sep, mdata = raw.partition(TAGEND)  # split tag from data
-            data = serial.loads(mdata)
+            data = serial.loads(mdata, encoding='utf-8')
         else:
             mtag, sep, mdata = raw.partition(salt.utils.stringutils.to_bytes(TAGEND))  # split tag from data
             mtag = salt.utils.stringutils.to_str(mtag)

--- a/tests/integration/cli/test_batch.py
+++ b/tests/integration/cli/test_batch.py
@@ -18,7 +18,7 @@ class BatchTest(ShellCase):
         '''
         Tests executing a simple batch command to help catch regressions
         '''
-        ret = 'Executing run on [\'sub_minion\']'
+        ret = 'Executing run on [u\'sub_minion\']'
 
         cmd = self.run_salt('\'*minion\' test.echo \'batch testing\' -b 50%')
         self.assertIn(ret, cmd)
@@ -28,7 +28,7 @@ class BatchTest(ShellCase):
         Tests executing a simple batch command using a number division instead of
         a percentage with full batch CLI call.
         '''
-        ret = "Executing run on ['minion', 'sub_minion']"
+        ret = "Executing run on [u'minion', u'sub_minion']"
         cmd = self.run_salt('\'*minion\' test.ping --batch-size 2')
         self.assertIn(ret, cmd)
 
@@ -38,8 +38,8 @@ class BatchTest(ShellCase):
         targeting.
         '''
         os_grain = ''
-        sub_min_ret = "Executing run on ['sub_minion']"
-        min_ret = "Executing run on ['minion']"
+        sub_min_ret = "Executing run on [u'sub_minion']"
+        min_ret = "Executing run on [u'minion']"
 
         for item in self.run_salt('minion grains.get os'):
             if item != 'minion':

--- a/tests/integration/cli/test_batch.py
+++ b/tests/integration/cli/test_batch.py
@@ -18,7 +18,7 @@ class BatchTest(ShellCase):
         '''
         Tests executing a simple batch command to help catch regressions
         '''
-        ret = 'Executing run on [u\'sub_minion\']'
+        ret = 'Executing run on [{0}]'.format(repr('sub_minion'))
 
         cmd = self.run_salt('\'*minion\' test.echo \'batch testing\' -b 50%')
         self.assertIn(ret, cmd)
@@ -28,7 +28,7 @@ class BatchTest(ShellCase):
         Tests executing a simple batch command using a number division instead of
         a percentage with full batch CLI call.
         '''
-        ret = "Executing run on [u'minion', u'sub_minion']"
+        ret = "Executing run on [{0}, {1}]".format(repr('minion'), repr('sub_minion'))
         cmd = self.run_salt('\'*minion\' test.ping --batch-size 2')
         self.assertIn(ret, cmd)
 
@@ -38,8 +38,8 @@ class BatchTest(ShellCase):
         targeting.
         '''
         os_grain = ''
-        sub_min_ret = "Executing run on [u'sub_minion']"
-        min_ret = "Executing run on [u'minion']"
+        sub_min_ret = "Executing run on [{0}]".format(repr('sub_minion'))
+        min_ret = "Executing run on [{0}]".format(repr('minion'))
 
         for item in self.run_salt('minion grains.get os'):
             if item != 'minion':

--- a/tests/integration/files/file/base/issue-46672.sls
+++ b/tests/integration/files/file/base/issue-46672.sls
@@ -1,0 +1,3 @@
+echo1:
+  cmd.run:
+    - name: "echo 'This is Æ test!'"

--- a/tests/integration/modules/test_state.py
+++ b/tests/integration/modules/test_state.py
@@ -1753,6 +1753,16 @@ class StateModuleTest(ModuleCase, SaltReturnAssertsMixin):
                              'File {0} updated'.format(file_name))
             self.assertEqual(val['changes']['diff'], 'New file')
 
+    def test_state_sls_unicode_characters(self):
+        '''
+        test state.sls when state file contains non-ascii characters
+        '''
+        ret = self.run_function('state.sls', ['issue-46672'])
+        log.debug('== ret %s ==', type(ret))
+
+        _expected = "cmd_|-echo1_|-echo 'This is Æ test!'_|-run"
+        self.assertIn(_expected, ret)
+
     def tearDown(self):
         nonbase_file = os.path.join(TMP, 'nonbase_env')
         if os.path.isfile(nonbase_file):

--- a/tests/integration/states/test_file.py
+++ b/tests/integration/states/test_file.py
@@ -2169,7 +2169,7 @@ class FileTest(ModuleCase, SaltReturnAssertsMixin):
             'salt_utf8_tests',
             '{0}.txt'.format(korean_1)
         )
-        test_file_encoded = salt.utils.stringutils.to_str(test_file)
+        test_file_encoded = test_file
         template_path = os.path.join(TMP_STATE_TREE, 'issue-8947.sls')
         # create the sls template
         template_lines = [
@@ -2234,46 +2234,45 @@ class FileTest(ModuleCase, SaltReturnAssertsMixin):
                 ' 한국어 시험\n'
                 '+마지막 행\n'
             )
-            diff = salt.utils.stringutils.to_str(diff)
             # future_lint: disable=blacklisted-function
             expected = {
-                str('file_|-some-utf8-file-create_|-{0}_|-managed').format(test_file_encoded): {
+                'file_|-some-utf8-file-create_|-{0}_|-managed'.format(test_file_encoded): {
                     'name': test_file_encoded,
                     '__run_num__': 0,
-                    'comment': str('File {0} updated').format(test_file_encoded),
+                    'comment': 'File {0} updated'.format(test_file_encoded),
                     'diff': 'New file'
                 },
-                str('file_|-some-utf8-file-create2_|-{0}_|-managed').format(test_file_encoded): {
+                'file_|-some-utf8-file-create2_|-{0}_|-managed'.format(test_file_encoded): {
                     'name': test_file_encoded,
                     '__run_num__': 1,
-                    'comment': str('File {0} updated').format(test_file_encoded),
+                    'comment': 'File {0} updated'.format(test_file_encoded),
                     'diff': diff
                 },
-                str('file_|-some-utf8-file-exists_|-{0}_|-exists').format(test_file_encoded): {
+                'file_|-some-utf8-file-exists_|-{0}_|-exists'.format(test_file_encoded): {
                     'name': test_file_encoded,
                     '__run_num__': 2,
-                    'comment': str('Path {0} exists').format(test_file_encoded)
+                    'comment': 'Path {0} exists'.format(test_file_encoded)
                 },
-                str('cmd_|-some-utf8-file-content-test_|-cat "{0}"_|-run').format(test_file_encoded): {
-                    'name': str('cat "{0}"').format(test_file_encoded),
+                'cmd_|-some-utf8-file-content-test_|-cat "{0}"_|-run'.format(test_file_encoded): {
+                    'name': 'cat "{0}"'.format(test_file_encoded),
                     '__run_num__': 3,
-                    'comment': str('Command "cat "{0}"" run').format(test_file_encoded),
-                    'stdout': str('{0}\n{1}\n{2}').format(
-                        salt.utils.stringutils.to_str(korean_2),
-                        salt.utils.stringutils.to_str(korean_1),
-                        salt.utils.stringutils.to_str(korean_3),
+                    'comment': 'Command "cat "{0}"" run'.format(test_file_encoded),
+                    'stdout': '{0}\n{1}\n{2}'.format(
+                        korean_2,
+                        korean_1,
+                        korean_3,
                     )
                 },
-                str('cmd_|-some-utf8-file-content-remove_|-rm -f "{0}"_|-run').format(test_file_encoded): {
-                    'name': str('rm -f "{0}"').format(test_file_encoded),
+                'cmd_|-some-utf8-file-content-remove_|-rm -f "{0}"_|-run'.format(test_file_encoded): {
+                    'name': 'rm -f "{0}"'.format(test_file_encoded),
                     '__run_num__': 4,
-                    'comment': str('Command "rm -f "{0}"" run').format(test_file_encoded),
+                    'comment': 'Command "rm -f "{0}"" run'.format(test_file_encoded),
                     'stdout': ''
                 },
-                str('file_|-some-utf8-file-removed_|-{0}_|-missing').format(test_file_encoded): {
+                'file_|-some-utf8-file-removed_|-{0}_|-missing'.format(test_file_encoded): {
                     'name': test_file_encoded,
                     '__run_num__': 5,
-                    'comment': str('Path {0} is missing').format(test_file_encoded),
+                    'comment': 'Path {0} is missing'.format(test_file_encoded),
                 }
             }
             # future_lint: enable=blacklisted-function
@@ -2295,7 +2294,7 @@ class FileTest(ModuleCase, SaltReturnAssertsMixin):
 
             self.assertEqual(expected, result)
             # future_lint: disable=blacklisted-function
-            cat_id = str('cmd_|-some-utf8-file-content-test_|-cat "{0}"_|-run').format(test_file_encoded)
+            cat_id = 'cmd_|-some-utf8-file-content-test_|-cat "{0}"_|-run'.format(test_file_encoded)
             # future_lint: enable=blacklisted-function
             self.assertEqual(
                 salt.utils.stringutils.to_unicode(result[cat_id]['stdout']),


### PR DESCRIPTION
### What does this PR do?
Ensure payloads for events are using Unicode.  Prior to this change, states that included Unicode characters would error out.

### What issues does this PR fix or reference?
#46672 

### Previous Behavior
See issue #46672 for details

### New Behavior
Allow unicode/non-ascii characters in state file.

### Tests written?
Yes

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
