### PR TITLE
Update service.py

### DIFF
--- a/salt/modules/service.py
+++ b/salt/modules/service.py
@@ -32,6 +32,7 @@ def __virtual__():
         'Gentoo',
         'Ubuntu',
         'Debian',
+        'Cumulus',
         'Devuan',
         'Arch',
         'Arch ARM',


### PR DESCRIPTION
add Cumulus to the disable list in def virtual()

### What does this PR do?
This adds Cumulus Linux into the to the disable list in def virtual() to allow it access to systemd.py

### What issues does this PR fix or reference?
Salt forces Cumulus linux to init.d scripts and not systemd #46673 

### Previous Behavior
running service.* on Cumulus minion would force it to look up services in the init.d scripts

### New Behavior
running service.* on Cumulus minion will correctly use systemd to find services

### Tests written?

No

### Commits signed with GPG?

Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
