### PR TITLE
Specify .conf in profile file names on Linode API page

### DIFF
--- a/doc/topics/cloud/linode.rst
+++ b/doc/topics/cloud/linode.rst
@@ -38,7 +38,7 @@ Set up the provider cloud configuration file at ``/etc/salt/cloud.providers`` or
 Profile Configuration
 =====================
 Linode profiles require a ``provider``, ``size``, ``image``, and ``location``. Set up an initial profile
-at ``/etc/salt/cloud.profiles`` or in the ``/etc/salt/cloud.profiles.d/`` directory:
+at ``/etc/salt/cloud.profiles`` or ``/etc/salt/cloud.profiles.d/*.conf``:
 
 .. code-block:: yaml
 


### PR DESCRIPTION
Following this page to store profiles in `cloud.profiles.d/`, `salt-cloud -p linode_1024 linode-instance` returns the error below unless the profile is named with a `.conf` file extension.

```
[ERROR   ] Profile linode_1024 is not defined
Error:
    Profile linode_1024 is not defined
```

### What does this PR do?

### What issues does this PR fix or reference?

### Previous Behavior
Remove this section if not relevant

### New Behavior
Remove this section if not relevant

### Tests written?

Yes/No

### Commits signed with GPG?

Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
