### PR TITLE
docker_container.running: disconnect unspecified networks

### DIFF
--- a/salt/states/docker_container.py
+++ b/salt/states/docker_container.py
@@ -423,6 +423,17 @@ def running(name,
 
     .. _`connect_container_to_network`: https://docker-py.readthedocs.io/en/stable/api.html#docker.api.network.NetworkApiMixin.connect_container_to_network
 
+    To start a container with no network connectivity (only possible in
+    Fluorine and later) pass this option as an empty list. For example:
+
+    .. code-block:: yaml
+
+        foo:
+          docker_container.running:
+            - image: myuser/myimage:foo
+            - networks: []
+
+
     **CONTAINER CONFIGURATION PARAMETERS**
 
     auto_remove (or *rm*) : False

--- a/tests/integration/files/file/base/mkimage-busybox-static
+++ b/tests/integration/files/file/base/mkimage-busybox-static
@@ -82,16 +82,19 @@ cp "$busybox" "$rootfsDir/bin/busybox"
 	unset IFS
 
 	for module in "${modules[@]}"; do
+		# Don't stomp on the busybox binary (newer busybox releases
+		# include busybox in the --list-modules output)
+		test "$module" == "bin/busybox" && continue
 		mkdir -p "$(dirname "$module")"
 		ln -sf /bin/busybox "$module"
 	done
-        # Make sure the image has the needed files to make users work
-        mkdir etc
-        echo "$etc_passwd" >etc/passwd
-        echo "$etc_group" >etc/group
-        echo "$etc_shadow" >etc/shadow
-        # Import the image
-        tar --numeric-owner -cf- . | docker import --change "CMD sleep 300" - "$imageName"
-        docker run --rm -i "$imageName" /bin/true
-        exit $?
+	# Make sure the image has the needed files to make users work
+	mkdir etc
+	echo "$etc_passwd" >etc/passwd
+	echo "$etc_group" >etc/group
+	echo "$etc_shadow" >etc/shadow
+	# Import the image
+	tar --numeric-owner -cf- . | docker import --change "CMD sleep 300" - "$imageName"
+	docker run --rm -i "$imageName" /bin/true
+	exit $?
 )

--- a/tests/integration/states/test_docker_container.py
+++ b/tests/integration/states/test_docker_container.py
@@ -791,6 +791,65 @@ class DockerContainerTestCase(ModuleCase, SaltReturnAssertsMixin):
     def test_running_mixed_ipv4_and_ipv6(self, container_name, *nets):
         self._test_running(container_name, *nets)
 
+    @with_network(subnet='10.247.197.96/27', create=True)
+    @container_name
+    def test_running_explicit_networks(self, container_name, net):
+        '''
+        Ensure that if we use an explicit network configuration, we remove any
+        default networks not specified (e.g. the default "bridge" network).
+        '''
+        # Create a container with no specific network configuration. The only
+        # networks connected will be the default ones.
+        ret = self.run_state(
+            'docker_container.running',
+            name=container_name,
+            image=self.image,
+            shutdown_timeout=1)
+        self.assertSaltTrueReturn(ret)
+
+        inspect_result = self.run_function('docker.inspect_container',
+                                           [container_name])
+        # Get the default network names
+        default_networks = list(inspect_result['NetworkSettings']['Networks'])
+
+        # Re-run the state with an explicit network configuration. All of the
+        # default networks should be disconnected.
+        ret = self.run_state(
+            'docker_container.running',
+            name=container_name,
+            image=self.image,
+            networks=[net.name],
+            shutdown_timeout=1)
+        self.assertSaltTrueReturn(ret)
+        ret = ret[next(iter(ret))]
+        net_changes = ret['changes']['container']['Networks']
+
+        self.assertIn(
+            "Container '{0}' is already configured as specified.".format(
+                container_name
+            ),
+            ret['comment']
+        )
+
+        updated_networks = self.run_function(
+            'docker.inspect_container',
+            [container_name])['NetworkSettings']['Networks']
+
+        for default_network in default_networks:
+            self.assertIn(
+                "Disconnected from network '{0}'.".format(default_network),
+                ret['comment']
+            )
+            self.assertIn(default_network, net_changes)
+            # We've tested that the state return is correct, but let's be extra
+            # paranoid and check the actual connected networks.
+            self.assertNotIn(default_network, updated_networks)
+
+        self.assertIn(
+            "Connected to network '{0}'.".format(net.name),
+            ret['comment']
+        )
+
     @container_name
     def test_run_with_onlyif(self, name):
         '''

--- a/tests/integration/states/test_docker_container.py
+++ b/tests/integration/states/test_docker_container.py
@@ -683,7 +683,6 @@ class DockerContainerTestCase(ModuleCase, SaltReturnAssertsMixin):
         self.assertEqual(ret['comment'], expected)
 
         # Update the SLS configuration to remove the last network
-        log.critical('networks = %s', kwargs['networks'])
         kwargs['networks'].pop(-1)
         ret = self.run_state('docker_container.running', **kwargs)
         self.assertSaltTrueReturn(ret)


### PR DESCRIPTION
When an explicit network configuration is specified, any connected networks not specified in the SLS will now be disconnected.

Resolves #46708.