### PR TITLE
Remove support for expr_form

### DIFF
--- a/doc/topics/releases/fluorine.rst
+++ b/doc/topics/releases/fluorine.rst
@@ -27,6 +27,19 @@ syndic respects :conf_minion:`enable_legacy_startup_events` as well.
 Deprecations
 ------------
 
+API Deprecations
+================
+
+Support for :ref:`LocalClient <local-client>`'s ``expr_form`` argument has
+been removed. Please use ``tgt_type`` instead. This change was made due to
+numerous reports of confusion among community members, since the targeting
+method is published to minions as ``tgt_type``, and appears as ``tgt_type``
+in the job cache as well.
+
+Those who are using the :ref:`LocalClient <local-client>` (either directly,
+or implicitly via a :ref:`netapi module <all-netapi-modules>`) need to update
+their code to use ``tgt_type``.
+
 Module Deprecations
 ===================
 

--- a/doc/topics/releases/fluorine.rst
+++ b/doc/topics/releases/fluorine.rst
@@ -40,6 +40,13 @@ Those who are using the :ref:`LocalClient <local-client>` (either directly,
 or implicitly via a :ref:`netapi module <all-netapi-modules>`) need to update
 their code to use ``tgt_type``.
 
+.. code-block:: python
+
+    >>> import salt.client
+    >>> local = salt.client.LocalClient()
+    >>> local.cmd('*', 'cmd.run', ['whoami'], tgt_type='glob')
+    {'jerry': 'root'}
+
 Module Deprecations
 ===================
 

--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -41,7 +41,6 @@ import salt.utils.platform
 import salt.utils.stringutils
 import salt.utils.user
 import salt.utils.verify
-import salt.utils.versions
 import salt.utils.zeromq
 import salt.syspaths as syspaths
 from salt.exceptions import (
@@ -315,15 +314,6 @@ class LocalClient(object):
             >>> local.run_job('*', 'test.sleep', [300])
             {'jid': '20131219215650131543', 'minions': ['jerry']}
         '''
-        if 'expr_form' in kwargs:
-            salt.utils.versions.warn_until(
-                'Fluorine',
-                'The target type should be passed using the \'tgt_type\' '
-                'argument instead of \'expr_form\'. Support for using '
-                '\'expr_form\' will be removed in Salt Fluorine.'
-            )
-            tgt_type = kwargs.pop('expr_form')
-
         arg = salt.utils.args.condition_input(arg, kwarg)
 
         try:
@@ -380,15 +370,6 @@ class LocalClient(object):
             >>> local.run_job_async('*', 'test.sleep', [300])
             {'jid': '20131219215650131543', 'minions': ['jerry']}
         '''
-        if 'expr_form' in kwargs:
-            salt.utils.versions.warn_until(
-                'Fluorine',
-                'The target type should be passed using the \'tgt_type\' '
-                'argument instead of \'expr_form\'. Support for using '
-                '\'expr_form\' will be removed in Salt Fluorine.'
-            )
-            tgt_type = kwargs.pop('expr_form')
-
         arg = salt.utils.args.condition_input(arg, kwarg)
 
         try:
@@ -437,15 +418,6 @@ class LocalClient(object):
             >>> local.cmd_async('*', 'test.sleep', [300])
             '20131219215921857715'
         '''
-        if 'expr_form' in kwargs:
-            salt.utils.versions.warn_until(
-                'Fluorine',
-                'The target type should be passed using the \'tgt_type\' '
-                'argument instead of \'expr_form\'. Support for using '
-                '\'expr_form\' will be removed in Salt Fluorine.'
-            )
-            tgt_type = kwargs.pop('expr_form')
-
         arg = salt.utils.args.condition_input(arg, kwarg)
         pub_data = self.run_job(tgt,
                                 fun,
@@ -484,15 +456,6 @@ class LocalClient(object):
             >>> SLC.cmd_subset('*', 'test.ping', sub=1)
             {'jerry': True}
         '''
-        if 'expr_form' in kwargs:
-            salt.utils.versions.warn_until(
-                'Fluorine',
-                'The target type should be passed using the \'tgt_type\' '
-                'argument instead of \'expr_form\'. Support for using '
-                '\'expr_form\' will be removed in Salt Fluorine.'
-            )
-            tgt_type = kwargs.pop('expr_form')
-
         minion_ret = self.cmd(tgt,
                               'sys.list_functions',
                               tgt_type=tgt_type,
@@ -547,15 +510,6 @@ class LocalClient(object):
             {'dave': {...}}
             {'stewart': {...}}
         '''
-        if 'expr_form' in kwargs:
-            salt.utils.versions.warn_until(
-                'Fluorine',
-                'The target type should be passed using the \'tgt_type\' '
-                'argument instead of \'expr_form\'. Support for using '
-                '\'expr_form\' will be removed in Salt Fluorine.'
-            )
-            tgt_type = kwargs.pop('expr_form')
-
         import salt.cli.batch
         arg = salt.utils.args.condition_input(arg, kwarg)
         opts = {'tgt': tgt,
@@ -705,15 +659,6 @@ class LocalClient(object):
             minion ID. A compound command will return a sub-dictionary keyed by
             function name.
         '''
-        if 'expr_form' in kwargs:
-            salt.utils.versions.warn_until(
-                'Fluorine',
-                'The target type should be passed using the \'tgt_type\' '
-                'argument instead of \'expr_form\'. Support for using '
-                '\'expr_form\' will be removed in Salt Fluorine.'
-            )
-            tgt_type = kwargs.pop('expr_form')
-
         arg = salt.utils.args.condition_input(arg, kwarg)
         was_listening = self.event.cpub
 
@@ -774,15 +719,6 @@ class LocalClient(object):
         :param verbose: Print extra information about the running command
         :returns: A generator
         '''
-        if 'expr_form' in kwargs:
-            salt.utils.versions.warn_until(
-                'Fluorine',
-                'The target type should be passed using the \'tgt_type\' '
-                'argument instead of \'expr_form\'. Support for using '
-                '\'expr_form\' will be removed in Salt Fluorine.'
-            )
-            tgt_type = kwargs.pop('expr_form')
-
         arg = salt.utils.args.condition_input(arg, kwarg)
         was_listening = self.event.cpub
 
@@ -861,15 +797,6 @@ class LocalClient(object):
             {'dave': {'ret': True}}
             {'stewart': {'ret': True}}
         '''
-        if 'expr_form' in kwargs:
-            salt.utils.versions.warn_until(
-                'Fluorine',
-                'The target type should be passed using the \'tgt_type\' '
-                'argument instead of \'expr_form\'. Support for using '
-                '\'expr_form\' will be removed in Salt Fluorine.'
-            )
-            tgt_type = kwargs.pop('expr_form')
-
         arg = salt.utils.args.condition_input(arg, kwarg)
         was_listening = self.event.cpub
 
@@ -937,15 +864,6 @@ class LocalClient(object):
             None
             {'stewart': {'ret': True}}
         '''
-        if 'expr_form' in kwargs:
-            salt.utils.versions.warn_until(
-                'Fluorine',
-                'The target type should be passed using the \'tgt_type\' '
-                'argument instead of \'expr_form\'. Support for using '
-                '\'expr_form\' will be removed in Salt Fluorine.'
-            )
-            tgt_type = kwargs.pop('expr_form')
-
         arg = salt.utils.args.condition_input(arg, kwarg)
         was_listening = self.event.cpub
 
@@ -994,15 +912,6 @@ class LocalClient(object):
         '''
         Execute a salt command and return
         '''
-        if 'expr_form' in kwargs:
-            salt.utils.versions.warn_until(
-                'Fluorine',
-                'The target type should be passed using the \'tgt_type\' '
-                'argument instead of \'expr_form\'. Support for using '
-                '\'expr_form\' will be removed in Salt Fluorine.'
-            )
-            tgt_type = kwargs.pop('expr_form')
-
         arg = salt.utils.args.condition_input(arg, kwarg)
         was_listening = self.event.cpub
 
@@ -1045,15 +954,6 @@ class LocalClient(object):
 
         :returns: all of the information for the JID
         '''
-        if 'expr_form' in kwargs:
-            salt.utils.versions.warn_until(
-                'Fluorine',
-                'The target type should be passed using the \'tgt_type\' '
-                'argument instead of \'expr_form\'. Support for using '
-                '\'expr_form\' will be removed in Salt Fluorine.'
-            )
-            tgt_type = kwargs.pop('expr_form')
-
         if verbose:
             msg = 'Executing job with jid {0}'.format(jid)
             print(msg)
@@ -1124,15 +1024,6 @@ class LocalClient(object):
 
         :returns: all of the information for the JID
         '''
-        if 'expr_form' in kwargs:
-            salt.utils.versions.warn_until(
-                'Fluorine',
-                'The target type should be passed using the \'tgt_type\' '
-                'argument instead of \'expr_form\'. Support for using '
-                '\'expr_form\' will be removed in Salt Fluorine.'
-            )
-            tgt_type = kwargs.pop('expr_form')
-
         if not isinstance(minions, set):
             if isinstance(minions, six.string_types):
                 minions = set([minions])
@@ -1571,15 +1462,6 @@ class LocalClient(object):
         '''
         log.trace('func get_cli_event_returns()')
 
-        if 'expr_form' in kwargs:
-            salt.utils.versions.warn_until(
-                'Fluorine',
-                'The target type should be passed using the \'tgt_type\' '
-                'argument instead of \'expr_form\'. Support for using '
-                '\'expr_form\' will be removed in Salt Fluorine.'
-            )
-            tgt_type = kwargs.pop('expr_form')
-
         if verbose:
             msg = 'Executing job with jid {0}'.format(jid)
             print(msg)
@@ -1766,15 +1648,6 @@ class LocalClient(object):
             minions:
                 A set, the targets that the tgt passed should match.
         '''
-        if 'expr_form' in kwargs:
-            salt.utils.versions.warn_until(
-                'Fluorine',
-                'The target type should be passed using the \'tgt_type\' '
-                'argument instead of \'expr_form\'. Support for using '
-                '\'expr_form\' will be removed in Salt Fluorine.'
-            )
-            tgt_type = kwargs.pop('expr_form')
-
         # Make sure the publisher is running by checking the unix socket
         if (self.opts.get('ipc_mode', '') != 'tcp' and
                 not os.path.exists(os.path.join(self.opts['sock_dir'],
@@ -1882,15 +1755,6 @@ class LocalClient(object):
             minions:
                 A set, the targets that the tgt passed should match.
         '''
-        if 'expr_form' in kwargs:
-            salt.utils.versions.warn_until(
-                'Fluorine',
-                'The target type should be passed using the \'tgt_type\' '
-                'argument instead of \'expr_form\'. Support for using '
-                '\'expr_form\' will be removed in Salt Fluorine.'
-            )
-            tgt_type = kwargs.pop('expr_form')
-
         # Make sure the publisher is running by checking the unix socket
         if (self.opts.get('ipc_mode', '') != 'tcp' and
                 not os.path.exists(os.path.join(self.opts['sock_dir'],

--- a/salt/client/raet/__init__.py
+++ b/salt/client/raet/__init__.py
@@ -13,7 +13,6 @@ import logging
 import salt.config
 import salt.client
 import salt.utils.kinds as kinds
-import salt.utils.versions
 import salt.syspaths as syspaths
 
 try:
@@ -49,15 +48,6 @@ class LocalClient(salt.client.LocalClient):
         '''
         Publish the command!
         '''
-        if 'expr_form' in kwargs:
-            salt.utils.versions.warn_until(
-                'Fluorine',
-                'The target type should be passed using the \'tgt_type\' '
-                'argument instead of \'expr_form\'. Support for using '
-                '\'expr_form\' will be removed in Salt Fluorine.'
-            )
-            tgt_type = kwargs.pop('expr_form')
-
         payload_kwargs = self._prep_pub(
                 tgt,
                 fun,

--- a/salt/client/ssh/client.py
+++ b/salt/client/ssh/client.py
@@ -9,7 +9,7 @@ import random
 
 # Import Salt libs
 import salt.config
-import salt.utils.versions
+import salt.utils.args
 import salt.syspaths as syspaths
 from salt.exceptions import SaltClientError  # Temporary
 
@@ -52,15 +52,6 @@ class SSHClient(object):
         '''
         Prepare the arguments
         '''
-        if 'expr_form' in kwargs:
-            salt.utils.versions.warn_until(
-                'Fluorine',
-                'The target type should be passed using the \'tgt_type\' '
-                'argument instead of \'expr_form\'. Support for using '
-                '\'expr_form\' will be removed in Salt Fluorine.'
-            )
-            tgt_type = kwargs.pop('expr_form')
-
         opts = copy.deepcopy(self.opts)
         opts.update(kwargs)
         if timeout:
@@ -88,15 +79,6 @@ class SSHClient(object):
 
         .. versionadded:: 2015.5.0
         '''
-        if 'expr_form' in kwargs:
-            salt.utils.versions.warn_until(
-                'Fluorine',
-                'The target type should be passed using the \'tgt_type\' '
-                'argument instead of \'expr_form\'. Support for using '
-                '\'expr_form\' will be removed in Salt Fluorine.'
-            )
-            tgt_type = kwargs.pop('expr_form')
-
         ssh = self._prep_ssh(
                 tgt,
                 fun,
@@ -122,15 +104,6 @@ class SSHClient(object):
 
         .. versionadded:: 2015.5.0
         '''
-        if 'expr_form' in kwargs:
-            salt.utils.versions.warn_until(
-                'Fluorine',
-                'The target type should be passed using the \'tgt_type\' '
-                'argument instead of \'expr_form\'. Support for using '
-                '\'expr_form\' will be removed in Salt Fluorine.'
-            )
-            tgt_type = kwargs.pop('expr_form')
-
         ssh = self._prep_ssh(
                 tgt,
                 fun,
@@ -226,14 +199,6 @@ class SSHClient(object):
 
         .. versionadded:: 2017.7.0
         '''
-        if 'expr_form' in kwargs:
-            salt.utils.versions.warn_until(
-                'Fluorine',
-                'The target type should be passed using the \'tgt_type\' '
-                'argument instead of \'expr_form\'. Support for using '
-                '\'expr_form\' will be removed in Salt Fluorine.'
-            )
-            tgt_type = kwargs.pop('expr_form')
         minion_ret = self.cmd(tgt,
                               'sys.list_functions',
                               tgt_type=tgt_type,

--- a/salt/client/ssh/wrapper/publish.py
+++ b/salt/client/ssh/wrapper/publish.py
@@ -18,7 +18,6 @@ import logging
 import salt.client.ssh
 import salt.runner
 import salt.utils.args
-import salt.utils.versions
 
 log = logging.getLogger(__name__)
 
@@ -112,8 +111,7 @@ def publish(tgt,
             tgt_type='glob',
             returner='',
             timeout=5,
-            roster=None,
-            expr_form=None):
+            roster=None):
     '''
     Publish a command "from the minion out to other minions". In reality, the
     minion does not execute this function, it is executed by the master. Thus,
@@ -172,17 +170,6 @@ def publish(tgt,
 
 
     '''
-    # remember to remove the expr_form argument from this function when
-    # performing the cleanup on this deprecation.
-    if expr_form is not None:
-        salt.utils.versions.warn_until(
-            'Fluorine',
-            'the target type should be passed using the \'tgt_type\' '
-            'argument instead of \'expr_form\'. Support for using '
-            '\'expr_form\' will be removed in Salt Fluorine.'
-        )
-        tgt_type = expr_form
-
     return _publish(tgt,
                     fun,
                     arg=arg,
@@ -199,8 +186,7 @@ def full_data(tgt,
               tgt_type='glob',
               returner='',
               timeout=5,
-              roster=None,
-              expr_form=None):
+              roster=None):
     '''
     Return the full data about the publication, this is invoked in the same
     way as the publish function
@@ -222,17 +208,6 @@ def full_data(tgt,
             salt-ssh '*' publish.full_data test.kwarg arg='cheese=spam'
 
     '''
-    # remember to remove the expr_form argument from this function when
-    # performing the cleanup on this deprecation.
-    if expr_form is not None:
-        salt.utils.versions.warn_until(
-            'Fluorine',
-            'the target type should be passed using the \'tgt_type\' '
-            'argument instead of \'expr_form\'. Support for using '
-            '\'expr_form\' will be removed in Salt Fluorine.'
-        )
-        tgt_type = expr_form
-
     return _publish(tgt,
                     fun,
                     arg=arg,

--- a/salt/modules/match.py
+++ b/salt/modules/match.py
@@ -11,7 +11,6 @@ import sys
 
 # Import salt libs
 import salt.minion
-import salt.utils.versions
 from salt.defaults import DEFAULT_TARGET_DELIM
 from salt.ext import six
 
@@ -309,7 +308,6 @@ def glob(tgt, minion_id=None):
 def filter_by(lookup,
               tgt_type='compound',
               minion_id=None,
-              expr_form=None,
               default='default'):
     '''
     Return the first match in a dictionary of target patterns
@@ -335,17 +333,6 @@ def filter_by(lookup,
         # Make the filtered data available to Pillar:
         roles: {{ roles | yaml() }}
     '''
-    # remember to remove the expr_form argument from this function when
-    # performing the cleanup on this deprecation.
-    if expr_form is not None:
-        salt.utils.versions.warn_until(
-            'Fluorine',
-            'the target type should be passed using the \'tgt_type\' '
-            'argument instead of \'expr_form\'. Support for using '
-            '\'expr_form\' will be removed in Salt Fluorine.'
-        )
-        tgt_type = expr_form
-
     expr_funcs = dict(inspect.getmembers(sys.modules[__name__],
         predicate=inspect.isfunction))
 

--- a/salt/modules/mine.py
+++ b/salt/modules/mine.py
@@ -16,7 +16,6 @@ import salt.payload
 import salt.utils.args
 import salt.utils.event
 import salt.utils.network
-import salt.utils.versions
 from salt.exceptions import SaltClientError
 
 # Import 3rd-party libs
@@ -242,8 +241,7 @@ def send(func, *args, **kwargs):
 def get(tgt,
         fun,
         tgt_type='glob',
-        exclude_minion=False,
-        expr_form=None):
+        exclude_minion=False):
     '''
     Get data from the mine based on the target, function and tgt_type
 
@@ -288,17 +286,6 @@ def get(tgt,
                 fun='network.ip_addrs',
                 tgt_type='glob') %}
     '''
-    # remember to remove the expr_form argument from this function when
-    # performing the cleanup on this deprecation.
-    if expr_form is not None:
-        salt.utils.versions.warn_until(
-            'Fluorine',
-            'the target type should be passed using the \'tgt_type\' '
-            'argument instead of \'expr_form\'. Support for using '
-            '\'expr_form\' will be removed in Salt Fluorine.'
-        )
-        tgt_type = expr_form
-
     if __opts__['file_client'] == 'local':
         ret = {}
         is_target = {'glob': __salt__['match.glob'],

--- a/salt/modules/publish.py
+++ b/salt/modules/publish.py
@@ -13,7 +13,6 @@ import salt.crypt
 import salt.payload
 import salt.transport
 import salt.utils.args
-import salt.utils.versions
 from salt.exceptions import SaltReqTimeoutError, SaltInvocationError
 
 log = logging.getLogger(__name__)
@@ -183,8 +182,7 @@ def publish(tgt,
             tgt_type='glob',
             returner='',
             timeout=5,
-            via_master=None,
-            expr_form=None):
+            via_master=None):
     '''
     Publish a command from the minion out to other minions.
 
@@ -251,17 +249,6 @@ def publish(tgt,
     master the publication should be sent to. Only one master may be specified. If
     unset, the publication will be sent only to the first master in minion configuration.
     '''
-    # remember to remove the expr_form argument from this function when
-    # performing the cleanup on this deprecation.
-    if expr_form is not None:
-        salt.utils.versions.warn_until(
-            'Fluorine',
-            'the target type should be passed using the \'tgt_type\' '
-            'argument instead of \'expr_form\'. Support for using '
-            '\'expr_form\' will be removed in Salt Fluorine.'
-        )
-        tgt_type = expr_form
-
     return _publish(tgt,
                     fun,
                     arg=arg,
@@ -278,8 +265,7 @@ def full_data(tgt,
               arg=None,
               tgt_type='glob',
               returner='',
-              timeout=5,
-              expr_form=None):
+              timeout=5):
     '''
     Return the full data about the publication, this is invoked in the same
     way as the publish function
@@ -301,17 +287,6 @@ def full_data(tgt,
             salt '*' publish.full_data test.kwarg arg='cheese=spam'
 
     '''
-    # remember to remove the expr_form argument from this function when
-    # performing the cleanup on this deprecation.
-    if expr_form is not None:
-        salt.utils.versions.warn_until(
-            'Fluorine',
-            'the target type should be passed using the \'tgt_type\' '
-            'argument instead of \'expr_form\'. Support for using '
-            '\'expr_form\' will be removed in Salt Fluorine.'
-        )
-        tgt_type = expr_form
-
     return _publish(tgt,
                     fun,
                     arg=arg,

--- a/salt/modules/raet_publish.py
+++ b/salt/modules/raet_publish.py
@@ -12,7 +12,6 @@ import logging
 import salt.payload
 import salt.transport
 import salt.utils.args
-import salt.utils.versions
 from salt.exceptions import SaltReqTimeoutError
 
 # Import 3rd party libs
@@ -111,8 +110,7 @@ def publish(tgt,
             arg=None,
             tgt_type='glob',
             returner='',
-            timeout=5,
-            expr_form=None):
+            timeout=5):
     '''
     Publish a command from the minion out to other minions.
 
@@ -167,17 +165,6 @@ def publish(tgt,
 
 
     '''
-    # remember to remove the expr_form argument from this function when
-    # performing the cleanup on this deprecation.
-    if expr_form is not None:
-        salt.utils.versions.warn_until(
-            'Fluorine',
-            'the target type should be passed using the \'tgt_type\' '
-            'argument instead of \'expr_form\'. Support for using '
-            '\'expr_form\' will be removed in Salt Fluorine.'
-        )
-        tgt_type = expr_form
-
     return _publish(tgt,
                     fun,
                     arg=arg,
@@ -192,8 +179,7 @@ def full_data(tgt,
               arg=None,
               tgt_type='glob',
               returner='',
-              timeout=5,
-              expr_form=None):
+              timeout=5):
     '''
     Return the full data about the publication, this is invoked in the same
     way as the publish function
@@ -215,17 +201,6 @@ def full_data(tgt,
             salt '*' publish.full_data test.kwarg arg='cheese=spam'
 
     '''
-    # remember to remove the expr_form argument from this function when
-    # performing the cleanup on this deprecation.
-    if expr_form is not None:
-        salt.utils.versions.warn_until(
-            'Fluorine',
-            'the target type should be passed using the \'tgt_type\' '
-            'argument instead of \'expr_form\'. Support for using '
-            '\'expr_form\' will be removed in Salt Fluorine.'
-        )
-        tgt_type = expr_form
-
     return _publish(tgt,
                     fun,
                     arg=arg,

--- a/salt/modules/saltutil.py
+++ b/salt/modules/saltutil.py
@@ -55,7 +55,6 @@ import salt.utils.minion
 import salt.utils.path
 import salt.utils.process
 import salt.utils.url
-import salt.utils.versions
 import salt.wheel
 
 HAS_PSUTIL = True
@@ -1366,15 +1365,6 @@ def _get_ssh_or_api_client(cfgfile, ssh=False):
 
 
 def _exec(client, tgt, fun, arg, timeout, tgt_type, ret, kwarg, **kwargs):
-    if 'expr_form' in kwargs:
-        salt.utils.versions.warn_until(
-            'Fluorine',
-            'The target type should be passed using the \'tgt_type\' '
-            'argument instead of \'expr_form\'. Support for using '
-            '\'expr_form\' will be removed in Salt Fluorine.'
-        )
-        tgt_type = kwargs.pop('expr_form')
-
     fcn_ret = {}
     seen = 0
     if 'batch' in kwargs:

--- a/salt/runners/cache.py
+++ b/salt/runners/cache.py
@@ -30,7 +30,7 @@ __func_alias__ = {
 }
 
 
-def grains(tgt=None, tgt_type='glob'):
+def grains(tgt=None, tgt_type='glob', **kwargs):
     '''
     .. versionchanged:: 2017.7.0
         The ``expr_form`` argument has been renamed to ``tgt_type``, earlier
@@ -52,7 +52,7 @@ def grains(tgt=None, tgt_type='glob'):
     return cached_grains
 
 
-def pillar(tgt=None, tgt_type='glob'):
+def pillar(tgt=None, tgt_type='glob', **kwargs):
     '''
     .. versionchanged:: 2017.7.0
         The ``expr_form`` argument has been renamed to ``tgt_type``, earlier

--- a/salt/runners/cache.py
+++ b/salt/runners/cache.py
@@ -15,7 +15,6 @@ import salt.log
 import salt.utils.args
 import salt.utils.gitfs
 import salt.utils.master
-import salt.utils.versions
 import salt.payload
 import salt.cache
 import salt.fileserver.gitfs
@@ -31,7 +30,7 @@ __func_alias__ = {
 }
 
 
-def grains(tgt=None, tgt_type='glob', **kwargs):
+def grains(tgt=None, tgt_type='glob'):
     '''
     .. versionchanged:: 2017.7.0
         The ``expr_form`` argument has been renamed to ``tgt_type``, earlier
@@ -45,15 +44,6 @@ def grains(tgt=None, tgt_type='glob', **kwargs):
 
         salt-run cache.grains
     '''
-    if 'expr_form' in kwargs:
-        salt.utils.versions.warn_until(
-            'Fluorine',
-            'The target type should be passed using the \'tgt_type\' '
-            'argument instead of \'expr_form\'. Support for using '
-            '\'expr_form\' will be removed in Salt Fluorine.'
-        )
-        tgt_type = kwargs.pop('expr_form')
-
     pillar_util = salt.utils.master.MasterPillarUtil(tgt, tgt_type,
                                                      use_cached_grains=True,
                                                      grains_fallback=False,
@@ -62,7 +52,7 @@ def grains(tgt=None, tgt_type='glob', **kwargs):
     return cached_grains
 
 
-def pillar(tgt=None, tgt_type='glob', **kwargs):
+def pillar(tgt=None, tgt_type='glob'):
     '''
     .. versionchanged:: 2017.7.0
         The ``expr_form`` argument has been renamed to ``tgt_type``, earlier
@@ -76,15 +66,6 @@ def pillar(tgt=None, tgt_type='glob', **kwargs):
 
         salt-run cache.pillar
     '''
-    if 'expr_form' in kwargs:
-        salt.utils.versions.warn_until(
-            'Fluorine',
-            'The target type should be passed using the \'tgt_type\' '
-            'argument instead of \'expr_form\'. Support for using '
-            '\'expr_form\' will be removed in Salt Fluorine.'
-        )
-        tgt_type = kwargs.pop('expr_form')
-
     pillar_util = salt.utils.master.MasterPillarUtil(tgt, tgt_type,
                                                      use_cached_grains=True,
                                                      grains_fallback=False,
@@ -95,7 +76,7 @@ def pillar(tgt=None, tgt_type='glob', **kwargs):
     return cached_pillar
 
 
-def mine(tgt=None, tgt_type='glob', **kwargs):
+def mine(tgt=None, tgt_type='glob'):
     '''
     .. versionchanged:: 2017.7.0
         The ``expr_form`` argument has been renamed to ``tgt_type``, earlier
@@ -109,15 +90,6 @@ def mine(tgt=None, tgt_type='glob', **kwargs):
 
         salt-run cache.mine
     '''
-    if 'expr_form' in kwargs:
-        salt.utils.versions.warn_until(
-            'Fluorine',
-            'The target type should be passed using the \'tgt_type\' '
-            'argument instead of \'expr_form\'. Support for using '
-            '\'expr_form\' will be removed in Salt Fluorine.'
-        )
-        tgt_type = kwargs.pop('expr_form')
-
     pillar_util = salt.utils.master.MasterPillarUtil(tgt, tgt_type,
                                                      use_cached_grains=False,
                                                      grains_fallback=False,
@@ -151,7 +123,7 @@ def _clear_cache(tgt=None,
                                                 clear_mine_func=clear_mine_func_flag)
 
 
-def clear_pillar(tgt=None, tgt_type='glob', expr_form=None):
+def clear_pillar(tgt=None, tgt_type='glob'):
     '''
     .. versionchanged:: 2017.7.0
         The ``expr_form`` argument has been renamed to ``tgt_type``, earlier
@@ -165,21 +137,10 @@ def clear_pillar(tgt=None, tgt_type='glob', expr_form=None):
 
         salt-run cache.clear_pillar
     '''
-    # remember to remove the expr_form argument from this function when
-    # performing the cleanup on this deprecation.
-    if expr_form is not None:
-        salt.utils.versions.warn_until(
-            'Fluorine',
-            'the target type should be passed using the \'tgt_type\' '
-            'argument instead of \'expr_form\'. Support for using '
-            '\'expr_form\' will be removed in Salt Fluorine.'
-        )
-        tgt_type = expr_form
-
     return _clear_cache(tgt, tgt_type, clear_pillar_flag=True)
 
 
-def clear_grains(tgt=None, tgt_type='glob', expr_form=None):
+def clear_grains(tgt=None, tgt_type='glob'):
     '''
     .. versionchanged:: 2017.7.0
         The ``expr_form`` argument has been renamed to ``tgt_type``, earlier
@@ -193,21 +154,10 @@ def clear_grains(tgt=None, tgt_type='glob', expr_form=None):
 
         salt-run cache.clear_grains
     '''
-    # remember to remove the expr_form argument from this function when
-    # performing the cleanup on this deprecation.
-    if expr_form is not None:
-        salt.utils.versions.warn_until(
-            'Fluorine',
-            'the target type should be passed using the \'tgt_type\' '
-            'argument instead of \'expr_form\'. Support for using '
-            '\'expr_form\' will be removed in Salt Fluorine.'
-        )
-        tgt_type = expr_form
-
     return _clear_cache(tgt, tgt_type, clear_grains_flag=True)
 
 
-def clear_mine(tgt=None, tgt_type='glob', expr_form=None):
+def clear_mine(tgt=None, tgt_type='glob'):
     '''
     .. versionchanged:: 2017.7.0
         The ``expr_form`` argument has been renamed to ``tgt_type``, earlier
@@ -221,24 +171,12 @@ def clear_mine(tgt=None, tgt_type='glob', expr_form=None):
 
         salt-run cache.clear_mine
     '''
-    # remember to remove the expr_form argument from this function when
-    # performing the cleanup on this deprecation.
-    if expr_form is not None:
-        salt.utils.versions.warn_until(
-            'Fluorine',
-            'the target type should be passed using the \'tgt_type\' '
-            'argument instead of \'expr_form\'. Support for using '
-            '\'expr_form\' will be removed in Salt Fluorine.'
-        )
-        tgt_type = expr_form
-
     return _clear_cache(tgt, tgt_type, clear_mine_flag=True)
 
 
 def clear_mine_func(tgt=None,
                     tgt_type='glob',
-                    clear_mine_func_flag=None,
-                    expr_form=None):
+                    clear_mine_func_flag=None):
     '''
     .. versionchanged:: 2017.7.0
         The ``expr_form`` argument has been renamed to ``tgt_type``, earlier
@@ -255,7 +193,7 @@ def clear_mine_func(tgt=None,
     return _clear_cache(tgt, tgt_type, clear_mine_func_flag=clear_mine_func_flag)
 
 
-def clear_all(tgt=None, tgt_type='glob', expr_form=None):
+def clear_all(tgt=None, tgt_type='glob'):
     '''
     .. versionchanged:: 2017.7.0
         The ``expr_form`` argument has been renamed to ``tgt_type``, earlier
@@ -269,17 +207,6 @@ def clear_all(tgt=None, tgt_type='glob', expr_form=None):
 
         salt-run cache.clear_all
     '''
-    # remember to remove the expr_form argument from this function when
-    # performing the cleanup on this deprecation.
-    if expr_form is not None:
-        salt.utils.versions.warn_until(
-            'Fluorine',
-            'the target type should be passed using the \'tgt_type\' '
-            'argument instead of \'expr_form\'. Support for using '
-            '\'expr_form\' will be removed in Salt Fluorine.'
-        )
-        tgt_type = expr_form
-
     return _clear_cache(tgt,
                         tgt_type,
                         clear_pillar_flag=True,

--- a/salt/runners/cache.py
+++ b/salt/runners/cache.py
@@ -76,7 +76,7 @@ def pillar(tgt=None, tgt_type='glob'):
     return cached_pillar
 
 
-def mine(tgt=None, tgt_type='glob'):
+def mine(tgt=None, tgt_type='glob', **kwargs):
     '''
     .. versionchanged:: 2017.7.0
         The ``expr_form`` argument has been renamed to ``tgt_type``, earlier

--- a/salt/runners/manage.py
+++ b/salt/runners/manage.py
@@ -26,7 +26,6 @@ import salt.utils.files
 import salt.utils.minions
 import salt.utils.path
 import salt.utils.raetevent
-import salt.utils.versions
 import salt.client
 import salt.client.ssh
 import salt.wheel
@@ -70,16 +69,7 @@ def _ping(tgt, tgt_type, timeout, gather_job_timeout):
     return returned, not_returned
 
 
-def _warn_expr_form():
-    salt.utils.versions.warn_until(
-        'Fluorine',
-        'the target type should be passed using the \'tgt_type\' '
-        'argument instead of \'expr_form\'. Support for using '
-        '\'expr_form\' will be removed in Salt Fluorine.'
-    )
-
-
-def status(output=True, tgt='*', tgt_type='glob', expr_form=None, timeout=None, gather_job_timeout=None):
+def status(output=True, tgt='*', tgt_type='glob', timeout=None, gather_job_timeout=None):
     '''
     .. versionchanged:: 2017.7.0
         The ``expr_form`` argument has been renamed to ``tgt_type``, earlier
@@ -95,12 +85,6 @@ def status(output=True, tgt='*', tgt_type='glob', expr_form=None, timeout=None, 
         salt-run manage.status tgt="webservers" tgt_type="nodegroup"
         salt-run manage.status timeout=5 gather_job_timeout=10
     '''
-    # remember to remove the expr_form argument from this function when
-    # performing the cleanup on this deprecation.
-    if expr_form is not None:
-        _warn_expr_form()
-        tgt_type = expr_form
-
     ret = {}
 
     if not timeout:
@@ -165,7 +149,7 @@ def key_regen():
     return msg
 
 
-def down(removekeys=False, tgt='*', tgt_type='glob', expr_form=None):
+def down(removekeys=False, tgt='*', tgt_type='glob'):
     '''
     .. versionchanged:: 2017.7.0
         The ``expr_form`` argument has been renamed to ``tgt_type``, earlier
@@ -183,12 +167,6 @@ def down(removekeys=False, tgt='*', tgt_type='glob', expr_form=None):
         salt-run manage.down tgt="webservers" tgt_type="nodegroup"
 
     '''
-    # remember to remove the expr_form argument from this function when
-    # performing the cleanup on this deprecation.
-    if expr_form is not None:
-        _warn_expr_form()
-        tgt_type = expr_form
-
     ret = status(output=False, tgt=tgt, tgt_type=tgt_type).get('down', [])
     for minion in ret:
         if removekeys:
@@ -197,7 +175,7 @@ def down(removekeys=False, tgt='*', tgt_type='glob', expr_form=None):
     return ret
 
 
-def up(tgt='*', tgt_type='glob', expr_form=None, timeout=None, gather_job_timeout=None):  # pylint: disable=C0103
+def up(tgt='*', tgt_type='glob', timeout=None, gather_job_timeout=None):  # pylint: disable=C0103
     '''
     .. versionchanged:: 2017.7.0
         The ``expr_form`` argument has been renamed to ``tgt_type``, earlier
@@ -213,12 +191,6 @@ def up(tgt='*', tgt_type='glob', expr_form=None, timeout=None, gather_job_timeou
         salt-run manage.up tgt="webservers" tgt_type="nodegroup"
         salt-run manage.up timeout=5 gather_job_timeout=10
     '''
-    # remember to remove the expr_form argument from this function when
-    # performing the cleanup on this deprecation.
-    if expr_form is not None:
-        _warn_expr_form()
-        tgt_type = expr_form
-
     ret = status(
         output=False,
         tgt=tgt,
@@ -598,7 +570,7 @@ def lane_stats(estate=None):
     return get_stats(estate=estate, stack='lane')
 
 
-def safe_accept(target, tgt_type='glob', expr_form=None):
+def safe_accept(target, tgt_type='glob'):
     '''
     .. versionchanged:: 2017.7.0
         The ``expr_form`` argument has been renamed to ``tgt_type``, earlier
@@ -613,12 +585,6 @@ def safe_accept(target, tgt_type='glob', expr_form=None):
         salt-run manage.safe_accept my_minion
         salt-run manage.safe_accept minion1,minion2 tgt_type=list
     '''
-    # remember to remove the expr_form argument from this function when
-    # performing the cleanup on this deprecation.
-    if expr_form is not None:
-        _warn_expr_form()
-        tgt_type = expr_form
-
     salt_key = salt.key.Key(__opts__)
     ssh_client = salt.client.ssh.client.SSHClient()
 

--- a/salt/runners/ssh.py
+++ b/salt/runners/ssh.py
@@ -10,7 +10,6 @@ from __future__ import absolute_import, print_function, unicode_literals
 
 # Import Salt Libs
 import salt.client.ssh.client
-import salt.utils.versions
 
 
 def cmd(tgt,
@@ -18,8 +17,7 @@ def cmd(tgt,
         arg=(),
         timeout=None,
         tgt_type='glob',
-        kwarg=None,
-        expr_form=None):
+        kwarg=None):
     '''
     .. versionadded:: 2015.5.0
     .. versionchanged:: 2017.7.0
@@ -32,17 +30,6 @@ def cmd(tgt,
     A wrapper around the :py:meth:`SSHClient.cmd
     <salt.client.ssh.client.SSHClient.cmd>` method.
     '''
-    # remember to remove the expr_form argument from this function when
-    # performing the cleanup on this deprecation.
-    if expr_form is not None:
-        salt.utils.versions.warn_until(
-            'Fluorine',
-            'the target type should be passed using the \'tgt_type\' '
-            'argument instead of \'expr_form\'. Support for using '
-            '\'expr_form\' will be removed in Salt Fluorine.'
-        )
-        tgt_type = expr_form
-
     client = salt.client.ssh.client.SSHClient(mopts=__opts__)
     return client.cmd(
             tgt,

--- a/salt/states/modjk_worker.py
+++ b/salt/states/modjk_worker.py
@@ -19,7 +19,6 @@ Mandatory Settings:
   execution module :mod:`documentation <salt.modules.modjk>`
 '''
 from __future__ import absolute_import, print_function, unicode_literals
-import salt.utils.versions
 
 
 def __virtual__():
@@ -172,7 +171,7 @@ def _talk2modjk(name, lbn, target, action, profile='default', tgt_type='glob'):
     return ret
 
 
-def stop(name, lbn, target, profile='default', tgt_type='glob', expr_form=None):
+def stop(name, lbn, target, profile='default', tgt_type='glob'):
     '''
     .. versionchanged:: 2017.7.0
         The ``expr_form`` argument has been renamed to ``tgt_type``, earlier
@@ -192,21 +191,10 @@ def stop(name, lbn, target, profile='default', tgt_type='glob', expr_form=None):
             - target: 'roles:balancer'
             - tgt_type: grain
     '''
-    # remember to remove the expr_form argument from this function when
-    # performing the cleanup on this deprecation.
-    if expr_form is not None:
-        salt.utils.versions.warn_until(
-            'Fluorine',
-            'the target type should be passed using the \'tgt_type\' '
-            'argument instead of \'expr_form\'. Support for using '
-            '\'expr_form\' will be removed in Salt Fluorine.'
-        )
-        tgt_type = expr_form
-
     return _talk2modjk(name, lbn, target, 'worker_stop', profile, tgt_type)
 
 
-def activate(name, lbn, target, profile='default', tgt_type='glob', expr_form=None):
+def activate(name, lbn, target, profile='default', tgt_type='glob'):
     '''
     .. versionchanged:: 2017.7.0
         The ``expr_form`` argument has been renamed to ``tgt_type``, earlier
@@ -226,21 +214,10 @@ def activate(name, lbn, target, profile='default', tgt_type='glob', expr_form=No
             - target: 'roles:balancer'
             - tgt_type: grain
     '''
-    # remember to remove the expr_form argument from this function when
-    # performing the cleanup on this deprecation.
-    if expr_form is not None:
-        salt.utils.versions.warn_until(
-            'Fluorine',
-            'the target type should be passed using the \'tgt_type\' '
-            'argument instead of \'expr_form\'. Support for using '
-            '\'expr_form\' will be removed in Salt Fluorine.'
-        )
-        tgt_type = expr_form
-
     return _talk2modjk(name, lbn, target, 'worker_activate', profile, tgt_type)
 
 
-def disable(name, lbn, target, profile='default', tgt_type='glob', expr_form=None):
+def disable(name, lbn, target, profile='default', tgt_type='glob'):
     '''
     .. versionchanged:: 2017.7.0
         The ``expr_form`` argument has been renamed to ``tgt_type``, earlier
@@ -261,15 +238,4 @@ def disable(name, lbn, target, profile='default', tgt_type='glob', expr_form=Non
             - target: 'roles:balancer'
             - tgt_type: grain
     '''
-    # remember to remove the expr_form argument from this function when
-    # performing the cleanup on this deprecation.
-    if expr_form is not None:
-        salt.utils.versions.warn_until(
-            'Fluorine',
-            'the target type should be passed using the \'tgt_type\' '
-            'argument instead of \'expr_form\'. Support for using '
-            '\'expr_form\' will be removed in Salt Fluorine.'
-        )
-        tgt_type = expr_form
-
     return _talk2modjk(name, lbn, target, 'worker_disable', profile, tgt_type)

--- a/salt/states/saltmod.py
+++ b/salt/states/saltmod.py
@@ -36,7 +36,6 @@ import salt.exceptions
 import salt.output
 import salt.utils.data
 import salt.utils.event
-import salt.utils.versions
 from salt.ext import six
 
 log = logging.getLogger(__name__)
@@ -110,7 +109,6 @@ def state(name,
         tgt,
         ssh=False,
         tgt_type='glob',
-        expr_form=None,
         ret='',
         ret_config=None,
         ret_kwargs=None,
@@ -147,10 +145,6 @@ def state(name,
 
     tgt_type
         The target type to resolve, defaults to ``glob``
-
-    expr_form
-        .. deprecated:: 2017.7.0
-            Use tgt_type instead
 
     ret
         Optionally set a single or a list of returners to use
@@ -270,17 +264,6 @@ def state(name,
         state_ret['result'] = False
         state_ret['comment'] = 'Passed invalid value for \'allow_fail\', must be an int'
         return state_ret
-
-    # remember to remove the expr_form argument from this function when
-    # performing the cleanup on this deprecation.
-    if expr_form is not None:
-        salt.utils.versions.warn_until(
-            'Fluorine',
-            'the target type should be passed using the \'tgt_type\' '
-            'argument instead of \'expr_form\'. Support for using '
-            '\'expr_form\' will be removed in Salt Fluorine.'
-        )
-        tgt_type = expr_form
 
     cmd_kw['tgt_type'] = tgt_type
     cmd_kw['ssh'] = ssh
@@ -429,7 +412,6 @@ def function(
         tgt,
         ssh=False,
         tgt_type='glob',
-        expr_form=None,
         ret='',
         ret_config=None,
         ret_kwargs=None,
@@ -452,10 +434,6 @@ def function(
 
     tgt_type
         The target type, defaults to ``glob``
-
-    expr_form
-        .. deprecated:: 2017.7.0
-            Use tgt_type instead
 
     arg
         The list of arguments to pass into the function
@@ -507,17 +485,6 @@ def function(
         arg = arg.split()
 
     cmd_kw = {'arg': arg or [], 'kwarg': kwarg, 'ret': ret, 'timeout': timeout}
-
-    # remember to remove the expr_form argument from this function when
-    # performing the cleanup on this deprecation.
-    if expr_form is not None:
-        salt.utils.versions.warn_until(
-            'Fluorine',
-            'the target type should be passed using the \'tgt_type\' '
-            'argument instead of \'expr_form\'. Support for using '
-            '\'expr_form\' will be removed in Salt Fluorine.'
-        )
-        tgt_type = expr_form
 
     if batch is not None:
         cmd_kw['batch'] = six.text_type(batch)

--- a/salt/utils/master.py
+++ b/salt/utils/master.py
@@ -25,7 +25,6 @@ import salt.utils.minions
 import salt.utils.platform
 import salt.utils.stringutils
 import salt.utils.verify
-import salt.utils.versions
 import salt.payload
 from salt.exceptions import SaltException
 import salt.config
@@ -72,19 +71,7 @@ class MasterPillarUtil(object):
                  use_cached_pillar=True,
                  grains_fallback=True,
                  pillar_fallback=True,
-                 opts=None,
-                 expr_form=None):
-
-        # remember to remove the expr_form argument from this function when
-        # performing the cleanup on this deprecation.
-        if expr_form is not None:
-            salt.utils.versions.warn_until(
-                'Fluorine',
-                'the target type should be passed using the \'tgt_type\' '
-                'argument instead of \'expr_form\'. Support for using '
-                '\'expr_form\' will be removed in Salt Fluorine.'
-            )
-            tgt_type = expr_form
+                 opts=None):
 
         log.debug('New instance of %s created.',
                   self.__class__.__name__)

--- a/salt/utils/minions.py
+++ b/salt/utils/minions.py
@@ -718,21 +718,11 @@ class CkMinions(object):
         _res = self.check_minions(v_expr, v_matcher)
         return set(_res['minions'])
 
-    def validate_tgt(self, valid, expr, tgt_type, minions=None, expr_form=None):
+    def validate_tgt(self, valid, expr, tgt_type, minions=None):
         '''
         Return a Bool. This function returns if the expression sent in is
         within the scope of the valid expression
         '''
-        # remember to remove the expr_form argument from this function when
-        # performing the cleanup on this deprecation.
-        if expr_form is not None:
-            salt.utils.versions.warn_until(
-                'Fluorine',
-                'the target type should be passed using the \'tgt_type\' '
-                'argument instead of \'expr_form\'. Support for using '
-                '\'expr_form\' will be removed in Salt Fluorine.'
-            )
-            tgt_type = expr_form
 
         v_minions = self._expand_matching(valid)
         if minions is None:


### PR DESCRIPTION
This option has been deprecated and marked for removal in Fluorine.

``tgt_type`` should be used instead.

Fixes #46467 
