### PR TITLE
Bump deprecation notices in nacl module & runner to Neon

### DIFF
--- a/doc/topics/releases/2018.3.0.rst
+++ b/doc/topics/releases/2018.3.0.rst
@@ -1610,9 +1610,9 @@ NaCL Module and Runner changes
 ------------------------------
 
 In addition to argument changes in both the NaCL module and runner for future
-deprecation in the Fluorine release, the default box_type has changed from
-`secretbox` to `sealedbox`.  SecretBox is data encrypted using private key
-`sk` and Sealedbox is encrypted using public key `pk`
+removal in the Neon release, the default "box_type" has changed from
+``secretbox`` to ``sealedbox``.  SecretBox is data encrypted using private key
+``sk`` and Sealedbox is encrypted using public key ``pk``.
 
 Deprecations
 ------------

--- a/salt/modules/nacl.py
+++ b/salt/modules/nacl.py
@@ -161,6 +161,7 @@ import salt.syspaths
 import salt.utils.files
 import salt.utils.platform
 import salt.utils.stringutils
+import salt.utils.versions
 import salt.utils.win_functions
 import salt.utils.win_dacl
 
@@ -254,7 +255,7 @@ def keygen(sk_file=None, pk_file=None, **kwargs):
     '''
     if 'keyfile' in kwargs:
         salt.utils.versions.warn_until(
-            'Fluorine',
+            'Neon',
             'The \'keyfile\' argument has been deprecated and will be removed in Salt '
             '{version}. Please use \'sk_file\' argument instead.'
         )
@@ -322,7 +323,7 @@ def enc(data, **kwargs):
     '''
     if 'keyfile' in kwargs:
         salt.utils.versions.warn_until(
-            'Fluorine',
+            'Neon',
             'The \'keyfile\' argument has been deprecated and will be removed in Salt '
             '{version}. Please use \'sk_file\' argument instead.'
         )
@@ -330,7 +331,7 @@ def enc(data, **kwargs):
 
     if 'key' in kwargs:
         salt.utils.versions.warn_until(
-            'Fluorine',
+            'Neon',
             'The \'key\' argument has been deprecated and will be removed in Salt '
             '{version}. Please use \'sk\' argument instead.'
         )
@@ -388,7 +389,7 @@ def dec(data, **kwargs):
     '''
     if 'keyfile' in kwargs:
         salt.utils.versions.warn_until(
-            'Fluorine',
+            'Neon',
             'The \'keyfile\' argument has been deprecated and will be removed in Salt '
             '{version}. Please use \'sk_file\' argument instead.'
         )
@@ -399,7 +400,7 @@ def dec(data, **kwargs):
 
     if 'key' in kwargs:
         salt.utils.versions.warn_until(
-            'Fluorine',
+            'Neon',
             'The \'key\' argument has been deprecated and will be removed in Salt '
             '{version}. Please use \'sk\' argument instead.'
         )

--- a/salt/runners/nacl.py
+++ b/salt/runners/nacl.py
@@ -121,6 +121,7 @@ import os
 import salt.utils.files
 import salt.utils.platform
 import salt.utils.stringutils
+import salt.utils.versions
 import salt.utils.win_functions
 import salt.utils.win_dacl
 import salt.syspaths
@@ -219,7 +220,7 @@ def keygen(sk_file=None, pk_file=None, **kwargs):
 
     if 'keyfile' in kwargs:
         salt.utils.versions.warn_until(
-            'Fluorine',
+            'Neon',
             'The \'keyfile\' argument has been deprecated and will be removed in Salt '
             '{version}. Please use \'sk_file\' argument instead.'
         )
@@ -288,7 +289,7 @@ def enc(data, **kwargs):
 
     if 'keyfile' in kwargs:
         salt.utils.versions.warn_until(
-            'Fluorine',
+            'Neon',
             'The \'keyfile\' argument has been deprecated and will be removed in Salt '
             '{version}. Please use \'sk_file\' argument instead.'
         )
@@ -296,7 +297,7 @@ def enc(data, **kwargs):
 
     if 'key' in kwargs:
         salt.utils.versions.warn_until(
-            'Fluorine',
+            'Neon',
             'The \'key\' argument has been deprecated and will be removed in Salt '
             '{version}. Please use \'sk\' argument instead.'
         )
@@ -353,7 +354,7 @@ def dec(data, **kwargs):
     '''
     if 'keyfile' in kwargs:
         salt.utils.versions.warn_until(
-            'Fluorine',
+            'Neon',
             'The \'keyfile\' argument has been deprecated and will be removed in Salt '
             '{version}. Please use \'sk_file\' argument instead.'
         )
@@ -364,7 +365,7 @@ def dec(data, **kwargs):
 
     if 'key' in kwargs:
         salt.utils.versions.warn_until(
-            'Fluorine',
+            'Neon',
             'The \'key\' argument has been deprecated and will be removed in Salt '
             '{version}. Please use \'sk\' argument instead.'
         )


### PR DESCRIPTION
These were initially marked for removal in "Fluorine", but we need to give users 2 feature releases to update. The version that the options will be removed in is "Neon". The related references have been updated, as well as the relevant documentation.

Refs #46426
