### PR TITLE
Performance improvement/error catching in expr_match

### DIFF
--- a/salt/utils/stringutils.py
+++ b/salt/utils/stringutils.py
@@ -294,15 +294,24 @@ def build_whitespace_split_regex(text):
 
 def expr_match(line, expr):
     '''
-    Evaluate a line of text against an expression. First try a full-string
-    match, next try globbing, and then try to match assuming expr is a regular
+    Evaluate a line of text against an expression. Tries to match expr first as
+    a glob using fnmatch.fnmatch(), and then tries to match expr as a regular
     expression. Originally designed to match minion IDs for
     whitelists/blacklists.
+
+    Note that this also does exact matches, as fnmatch.fnmatch() will return
+    ``True`` when no glob characters are used and the string is an exact match:
+
+    .. code-block:: python
+
+        >>> fnmatch.fnmatch('foo', 'foo')
+        True
     '''
-    if line == expr:
-        return True
-    if fnmatch.fnmatch(line, expr):
-        return True
+    try:
+        if fnmatch.fnmatch(line, expr):
+            return True
+    except TypeError:
+        pass
     try:
         if re.match(r'\A{0}\Z'.format(expr), line):
             return True

--- a/salt/utils/stringutils.py
+++ b/salt/utils/stringutils.py
@@ -292,11 +292,11 @@ def build_whitespace_split_regex(text):
     return r'(?m)^{0}$'.format(regex)
 
 
-def expr_match(line, expr):
+def expr_match(val, expr):
     '''
-    Evaluate a line of text against an expression. Tries to match expr first as
-    a glob using fnmatch.fnmatch(), and then tries to match expr as a regular
-    expression. Originally designed to match minion IDs for
+    Checks whether or not val matches the specified expression. Tries to match
+    expr first as a glob using fnmatch.fnmatch(), and then tries to match expr
+    as a regular expression. Originally designed to match minion IDs for
     whitelists/blacklists.
 
     Note that this also does exact matches, as fnmatch.fnmatch() will return
@@ -308,15 +308,15 @@ def expr_match(line, expr):
         True
     '''
     try:
-        if fnmatch.fnmatch(line, expr):
+        if fnmatch.fnmatch(val, expr):
             return True
+        try:
+            if re.match(r'\A{0}\Z'.format(expr), val):
+                return True
+        except re.error:
+            pass
     except TypeError:
-        pass
-    try:
-        if re.match(r'\A{0}\Z'.format(expr), line):
-            return True
-    except re.error:
-        pass
+        log.exception('Value %r or expression %r is not a string', val, expr)
     return False
 
 
@@ -346,22 +346,16 @@ def check_whitelist_blacklist(value, whitelist=None, blacklist=None):
     if blacklist is not None:
         if not hasattr(blacklist, '__iter__'):
             blacklist = [blacklist]
-        try:
-            for expr in blacklist:
-                if expr_match(value, expr):
-                    return False
-        except TypeError:
-            log.error('Non-iterable blacklist %s', blacklist)
+        for expr in blacklist:
+            if expr_match(value, expr):
+                return False
 
     if whitelist:
         if not hasattr(whitelist, '__iter__'):
             whitelist = [whitelist]
-        try:
-            for expr in whitelist:
-                if expr_match(value, expr):
-                    return True
-        except TypeError:
-            log.error('Non-iterable whitelist %s', whitelist)
+        for expr in whitelist:
+            if expr_match(value, expr):
+                return True
     else:
         return True
 

--- a/salt/utils/stringutils.py
+++ b/salt/utils/stringutils.py
@@ -292,12 +292,12 @@ def build_whitespace_split_regex(text):
     return r'(?m)^{0}$'.format(regex)
 
 
-def expr_match(val, expr):
+def expr_match(line, expr):
     '''
-    Checks whether or not val matches the specified expression. Tries to match
-    expr first as a glob using fnmatch.fnmatch(), and then tries to match expr
-    as a regular expression. Originally designed to match minion IDs for
-    whitelists/blacklists.
+    Checks whether or not the passed value matches the specified expression.
+    Tries to match expr first as a glob using fnmatch.fnmatch(), and then tries
+    to match expr as a regular expression. Originally designed to match minion
+    IDs for whitelists/blacklists.
 
     Note that this also does exact matches, as fnmatch.fnmatch() will return
     ``True`` when no glob characters are used and the string is an exact match:
@@ -308,15 +308,15 @@ def expr_match(val, expr):
         True
     '''
     try:
-        if fnmatch.fnmatch(val, expr):
+        if fnmatch.fnmatch(line, expr):
             return True
         try:
-            if re.match(r'\A{0}\Z'.format(expr), val):
+            if re.match(r'\A{0}\Z'.format(expr), line):
                 return True
         except re.error:
             pass
     except TypeError:
-        log.exception('Value %r or expression %r is not a string', val, expr)
+        log.exception('Value %r or expression %r is not a string', line, expr)
     return False
 
 

--- a/tests/unit/utils/test_stringutils.py
+++ b/tests/unit/utils/test_stringutils.py
@@ -169,3 +169,12 @@ class StringutilsTestCase(TestCase):
         context = salt.utils.stringutils.get_context(template, 8, num_lines=2, marker=' <---')
         expected = '---\n[...]\n6\n7\n8 <---\n9\na\n[...]\n---'
         self.assertEqual(expected, context)
+
+    def test_expr_match(self):
+        val = 'foo/bar/baz'
+        # Exact match
+        self.assertTrue(salt.utils.stringutils.expr_match(val, val))
+        # Glob match
+        self.assertTrue(salt.utils.stringutils.expr_match(val, 'foo/*/baz'))
+        # Glob non-match
+        self.assertFalse(salt.utils.stringutils.expr_match(val, 'foo/*/bar'))


### PR DESCRIPTION
`fnmatch.fnmatch()` does exact matches, so checking for an exact match is an unnecessary extra step.

Additionally, while regex errors are caught, TypeErrors are not, so the use of non-string expressions/values will result in a traceback. This prevents those tracebacks.