### PR TITLE
Make busybox image builder work with newer busybox releases

### DIFF
--- a/tests/integration/files/file/base/mkimage-busybox-static
+++ b/tests/integration/files/file/base/mkimage-busybox-static
@@ -32,6 +32,9 @@ cp "$busybox" "$rootfsDir/bin/busybox"
 	unset IFS
 
 	for module in "${modules[@]}"; do
+		# Don't stomp on the busybox binary (newer busybox releases
+		# include busybox in the --list-modules output)
+		test "$module" == "bin/busybox" && continue
 		mkdir -p "$(dirname "$module")"
 		ln -sf /bin/busybox "$module"
 	done


### PR DESCRIPTION
This doesn't yet affect the versions of busybox Jenkins uses, but it will eventually.