### PR TITLE
Workaround getpwnam in auth test for MacOSX

### DIFF
--- a/tests/integration/shell/test_auth.py
+++ b/tests/integration/shell/test_auth.py
@@ -59,12 +59,18 @@ class AuthTest(ShellCase):
     def setUp(self):
         for user in (self.userA, self.userB):
             try:
+                if salt.utils.is_darwin() and user not in str(self.run_call('user.list_users')):
+                    # workaround for https://github.com/saltstack/salt-jenkins/issues/504
+                    raise KeyError
                 pwd.getpwnam(user)
             except KeyError:
                 self.run_call('user.add {0} createhome=False'.format(user))
 
         # only put userB into the group for the group auth test
         try:
+            if salt.utils.is_darwin() and self.group not in str(self.run_call('group.info {0}'.format(self.group))):
+                # workaround for https://github.com/saltstack/salt-jenkins/issues/504
+                raise KeyError
             grp.getgrnam(self.group)
         except KeyError:
             self.run_call('group.add {0}'.format(self.group))


### PR DESCRIPTION
### What does this PR do?
As explained in comment https://github.com/saltstack/salt-jenkins/issues/504#issuecomment-328961942 there is an issue on macosx when running `pwd.getpwnam` in the same python instance if the user is deleted it still detects the user. 
### What issues does this PR fix or reference?
Fixes https://github.com/saltstack/salt-jenkins/issues/504