### PR TITLE
[DOC] Remove mentions of COPR repo from RHEL installation page

### DIFF
--- a/doc/topics/installation/rhel.rst
+++ b/doc/topics/installation/rhel.rst
@@ -49,17 +49,13 @@ the SaltStack Repository.
 Installation from the Community-Maintained Repository
 =====================================================
 
-Beginning with version 0.9.4, Salt has been available in `EPEL`_. For
-RHEL/CentOS 5, `Fedora COPR`_ is a single community repository that provides
-Salt packages due to the removal from EPEL5.
+Beginning with version 0.9.4, Salt has been available in `EPEL`_.
 
 .. note::
-   Packages in these repositories are built by community, and it can
-   take a little while until the latest stable SaltStack release become
-   available.
+   Packages in this repository are built by community, and it can take a little
+   while until the latest stable SaltStack release become available.
 
 .. _`EPEL`: http://fedoraproject.org/wiki/EPEL
-.. _`Fedora COPR`: https://copr.fedorainfracloud.org/coprs/saltstack/salt-el5/
 
 RHEL/CentOS 6 and 7, Scientific Linux, etc.
 -------------------------------------------
@@ -146,25 +142,12 @@ ZeroMQ 4
 ========
 
 We recommend using ZeroMQ 4 where available. SaltStack provides ZeroMQ 4.0.5
-and pyzmq 14.5.0 in the :ref:`SaltStack Repository <installation-rhel-repo>`
-as well as a separate `zeromq4 COPR`_ repository.
-
-.. _`zeromq4 COPR`: http://copr.fedorainfracloud.org/coprs/saltstack/zeromq4/
+and ``pyzmq`` 14.5.0 in the :ref:`SaltStack Repository
+<installation-rhel-repo>`.
 
 If this repository is added *before* Salt is installed, then installing either
 ``salt-master`` or ``salt-minion`` will automatically pull in ZeroMQ 4.0.5, and
 additional steps to upgrade ZeroMQ and pyzmq are unnecessary.
-
-.. warning:: RHEL/CentOS 5 Users
-    Using COPR repos on RHEL/CentOS 5 requires that the ``python-hashlib``
-    package be installed. Not having it present will result in checksum errors
-    because YUM will not be able to process the SHA256 checksums used by COPR.
-
-.. note::
-    For RHEL/CentOS 5 installations, if using the SaltStack repo or Fedora COPR
-    to install Salt (as described :ref:`above <installation-rhel-repo>`),
-    then it is not necessary to enable the `zeromq4 COPR`_, because those
-    repositories already include ZeroMQ 4.
 
 Package Management
 ==================


### PR DESCRIPTION
### What does this PR do?
It drops abandoned, no-longer maintained Fedora COPR repo for ZeroMQ and Salt rpms from the installation documentation of modern Salt releases.

### What issues does this PR fix or reference?
Fixes #28142.

### Commits signed with GPG?
Yes
