### PR TITLE
top file merging strategy 'same' works again

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -2817,6 +2817,7 @@ class BaseHighState(object):
                     'top_file_merging_strategy set to \'same\', but no '
                     'default_top configuration option was set'
                 )
+            self.opts['environment'] = self.opts['default_top']
 
         if self.opts['environment']:
             contents = self.client.cache_file(


### PR DESCRIPTION
### What does this PR do?
Fix the 'top_file_merging_strategy: same' behavior, broken since 82bf7fe5e

See Previous Behavior

### What issues does this PR fix or reference?
#46660 

### Previous Behavior
In case there are multiple environments with same or very similar file hierarchy, and merging
strategy set to 'same', running highstate without adding the saltenv=base (or whatever set as
default_top) argument caused merge conflicts, as get_tops() actually worked in merge mode, 
when collecting the environments, and thus highstate runs have been failed.

### New Behavior
Same as with 2016.3, the previous major version.

Running highstate without a saltenv=&lt;env> argument, would result in using the environment set in the 'default_top' config option.

### Tests written?
No

### Commits signed with GPG?
No