### PR TITLE
Update vault.py

### DIFF
--- a/salt/pillar/vault.py
+++ b/salt/pillar/vault.py
@@ -80,7 +80,7 @@ def ext_pillar(minion_id,  # pylint: disable=W0613
         return {}
 
     vault_pillar = {}
-    
+
     try:
         path = paths[0].replace('path=', '')
         path = path.format(**{'minion': minion_id})

--- a/salt/pillar/vault.py
+++ b/salt/pillar/vault.py
@@ -87,7 +87,9 @@ def ext_pillar(minion_id,  # pylint: disable=W0613
         url = 'v1/{0}'.format(path)
         response = __utils__['vault.make_request']('GET', url)
         if response.status_code == 200:
-            vault_pillar = response.json()['data']
+            vault_pillar = response.json().get('data', {})
+        else:
+            log.info('Vault secret not found for: %s', path)
     except KeyError:
         log.error('No such path in Vault: %s', path)
 

--- a/salt/pillar/vault.py
+++ b/salt/pillar/vault.py
@@ -79,16 +79,16 @@ def ext_pillar(minion_id,  # pylint: disable=W0613
         log.error('"%s" is not a valid Vault ext_pillar config', conf)
         return {}
 
+    vault_pillar = {}
+    
     try:
         path = paths[0].replace('path=', '')
         path = path.format(**{'minion': minion_id})
         url = 'v1/{0}'.format(path)
         response = __utils__['vault.make_request']('GET', url)
-        if response.status_code != 200:
-            response.raise_for_status()
-        vault_pillar = response.json()['data']
+        if response.status_code == 200:
+            vault_pillar = response.json()['data']
     except KeyError:
         log.error('No such path in Vault: %s', path)
-        vault_pillar = {}
 
     return vault_pillar


### PR DESCRIPTION
### What does this PR do?

A small fix to prevent a critical log message when vault returns a 404 (missing object)

### What issues does this PR fix or reference?

Fixes critical log messages created by Response.raise_for_status() on anything other than a status 200 from Vault

### Previous Behavior

```
[CRITICAL] Pillar render error: Failed to load ext_pillar vault: 404 Client Error: Not Found for url: https://vault:8200/v1/secret/saltstack/minion/nn/pillar
```

### New Behavior
 return empty vault_pillar for unavailable objects

### Tests written?

No

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
