### PR TITLE
Fix 'virtual_subtype' grain detection for kubernetes and libpod containers

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -821,6 +821,10 @@ def _virtual(osdata):
                     fhr_contents = fhr.read()
                 if ':/lxc/' in fhr_contents:
                     grains['virtual_subtype'] = 'LXC'
+                elif ':/kubepods/' in fhr_contents:
+                    grains['virtual_subtype'] = 'kubernetes'
+                elif ':/libpod_parent/' in fhr_contents:
+                    grains['virtual_subtype'] = 'libpod'
                 else:
                     if any(x in fhr_contents
                            for x in (':/system.slice/docker', ':/docker/',


### PR DESCRIPTION
### What does this PR do?

Fix `virtual_subtype` grain detection for containers managed by kubernetes and by tools using libpod.

### What issues does this PR fix or reference?

I didn't file an issue, should I? hashtag#newbie

### Previous Behavior

All the containers started by kubelet (hence kubernetes) are assigned to the `kubepods` cgroup slice (see these [guidelines](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/node/node-allocatable.md#recommended-cgroups-setup)). That happens despite of the Container Runtime Interface being used.

Containers started via tools using [libpod](https://github.com/projectatomic/libpod) (eg: [podman](https://medium.com/cri-o/introducing-kpod-f06109b96374)) are assigned to the `libpod_parent` cgroup slice.

Previous to this PR salt didn't set the `virtual_subtype` grain for all these containers.

### New Behavior

The `virtual_subtype` grain is set to `kubernetes` for the containers managed by kubernetes, while it's set to `libpod` for the ones managed by a tool using libpod.

### Tests written?

No, there was no test covering this area of the codebase.

### Commits signed with GPG?

Yes