### PR TITLE
Change the way we're cleaning up after some tests

### DIFF
--- a/tests/integration/modules/test_cp.py
+++ b/tests/integration/modules/test_cp.py
@@ -4,7 +4,6 @@
 from __future__ import absolute_import
 import os
 import uuid
-import shutil
 import hashlib
 import logging
 import psutil
@@ -25,7 +24,6 @@ import tests.support.paths as paths
 # Import salt libs
 import salt.ext.six as six
 import salt.utils
-import salt.utils.files
 
 log = logging.getLogger(__name__)
 

--- a/tests/integration/modules/test_cp.py
+++ b/tests/integration/modules/test_cp.py
@@ -15,13 +15,17 @@ import textwrap
 
 # Import Salt Testing libs
 from tests.support.case import ModuleCase
-from tests.support.helpers import get_unused_localhost_port, skip_if_not_root
+from tests.support.helpers import (
+    get_unused_localhost_port,
+    skip_if_not_root,
+    with_tempfile)
 from tests.support.unit import skipIf
 import tests.support.paths as paths
 
 # Import salt libs
 import salt.ext.six as six
 import salt.utils
+import salt.utils.files
 
 log = logging.getLogger(__name__)
 
@@ -30,11 +34,11 @@ class CPModuleTest(ModuleCase):
     '''
     Validate the cp module
     '''
-    def test_get_file(self):
+    @with_tempfile
+    def test_get_file(self, tgt):
         '''
         cp.get_file
         '''
-        tgt = os.path.join(paths.TMP, 'scene33')
         self.run_function(
                 'cp.get_file',
                 [
@@ -46,11 +50,11 @@ class CPModuleTest(ModuleCase):
             self.assertIn('KNIGHT:  They\'re nervous, sire.', data)
             self.assertNotIn('bacon', data)
 
-    def test_get_file_templated_paths(self):
+    @with_tempfile
+    def test_get_file_templated_paths(self, tgt):
         '''
         cp.get_file
         '''
-        tgt = os.path.join(paths.TMP, 'cheese')
         self.run_function(
             'cp.get_file',
             [
@@ -64,11 +68,11 @@ class CPModuleTest(ModuleCase):
             self.assertIn('Gromit', data)
             self.assertNotIn('bacon', data)
 
-    def test_get_file_gzipped(self):
+    @with_tempfile
+    def test_get_file_gzipped(self, tgt):
         '''
         cp.get_file
         '''
-        tgt = os.path.join(paths.TMP, 'file.big')
         src = os.path.join(paths.FILES, 'file', 'base', 'file.big')
         with salt.utils.fopen(src, 'r') as fp_:
             data = fp_.read()
@@ -111,11 +115,11 @@ class CPModuleTest(ModuleCase):
             self.assertIn('KNIGHT:  They\'re nervous, sire.', data)
             self.assertNotIn('bacon', data)
 
-    def test_get_template(self):
+    @with_tempfile
+    def test_get_template(self, tgt):
         '''
         cp.get_template
         '''
-        tgt = os.path.join(paths.TMP, 'scene33')
         self.run_function(
                 'cp.get_template',
                 ['salt://grail/scene33', tgt],
@@ -160,11 +164,11 @@ class CPModuleTest(ModuleCase):
 
     # cp.get_url tests
 
-    def test_get_url(self):
+    @with_tempfile
+    def test_get_url(self, tgt):
         '''
         cp.get_url with salt:// source given
         '''
-        tgt = os.path.join(paths.TMP, 'scene33')
         self.run_function(
             'cp.get_url',
             [
@@ -235,11 +239,11 @@ class CPModuleTest(ModuleCase):
             ])
         self.assertEqual(ret, False)
 
-    def test_get_url_https(self):
+    @with_tempfile
+    def test_get_url_https(self, tgt):
         '''
         cp.get_url with https:// source given
         '''
-        tgt = os.path.join(paths.TMP, 'test_get_url_https')
         self.run_function(
             'cp.get_url',
             [
@@ -576,30 +580,24 @@ class CPModuleTest(ModuleCase):
             self.assertEqual(
                 sha256_hash['hsum'], hashlib.sha256(data).hexdigest())
 
-    def test_get_file_from_env_predefined(self):
+    @with_tempfile
+    def test_get_file_from_env_predefined(self, tgt):
         '''
         cp.get_file
         '''
-        tgt = os.path.join(paths.TMP, 'cheese')
-        try:
-            self.run_function('cp.get_file', ['salt://cheese', tgt])
-            with salt.utils.fopen(tgt, 'r') as cheese:
-                data = cheese.read()
-                self.assertIn('Gromit', data)
-                self.assertNotIn('Comte', data)
-        finally:
-            os.unlink(tgt)
+        self.run_function('cp.get_file', ['salt://cheese', tgt])
+        with salt.utils.fopen(tgt, 'r') as cheese:
+            data = cheese.read()
+            self.assertIn('Gromit', data)
+            self.assertNotIn('Comte', data)
 
-    def test_get_file_from_env_in_url(self):
-        tgt = os.path.join(paths.TMP, 'cheese')
-        try:
-            self.run_function('cp.get_file', ['salt://cheese?saltenv=prod', tgt])
-            with salt.utils.fopen(tgt, 'r') as cheese:
-                data = cheese.read()
-                self.assertIn('Gromit', data)
-                self.assertIn('Comte', data)
-        finally:
-            os.unlink(tgt)
+    @with_tempfile
+    def test_get_file_from_env_in_url(self, tgt):
+        self.run_function('cp.get_file', ['salt://cheese?saltenv=prod', tgt])
+        with salt.utils.fopen(tgt, 'r') as cheese:
+            data = cheese.read()
+            self.assertIn('Gromit', data)
+            self.assertIn('Comte', data)
 
     def test_push(self):
         log_to_xfer = os.path.join(paths.TMP, uuid.uuid4().hex)


### PR DESCRIPTION
### What does this PR do?
Uses the `@with_tempfile` decorator instead of `try/finally` blocks to clean up temp files.

### What issues does this PR fix or reference?
Sometimes the `os.unlink` function was failing to clean up, causing the test to fail. The decorator cleans up and fails gracefully, without nullifying the results of the test.

### Tests written?
Yes

### Commits signed with GPG?
Yes