### PR TITLE
Change pyzmq dep the the non-beta version

### DIFF
--- a/pkg/osx/req.txt
+++ b/pkg/osx/req.txt
@@ -21,7 +21,7 @@ pycrypto==2.6.1
 python-dateutil==2.6.1
 python-gnupg==0.4.1
 PyYAML==3.12
-pyzmq==17.0.0b3
+pyzmq==16.0.3
 requests==2.18.4
 singledispatch==3.4.0.3
 six==1.11.0

--- a/pkg/osx/req.txt
+++ b/pkg/osx/req.txt
@@ -21,7 +21,7 @@ pycrypto==2.6.1
 python-dateutil==2.6.1
 python-gnupg==0.4.1
 PyYAML==3.12
-pyzmq==16.0.3
+pyzmq==17.0.0
 requests==2.18.4
 singledispatch==3.4.0.3
 six==1.11.0


### PR DESCRIPTION
### What does this PR do?
Fixes a stacktrace we're seeing in mac caused by the version of Tornado installed. The version in the req.txt file was `17.0.0b3` for the beta version. Apparently the `b` causes problems when comparing versions.

### What issues does this PR fix or reference?
Found in testing

### Previous Behavior
`salt-call` was throwing the following stacktrace
```
[ERROR   ] Error while getting LibZMQ/PyZMQ library version
Traceback (most recent call last):
  File "/opt/salt/lib/python2.7/site-packages/salt/utils/zeromq.py", line 26, in <module>
    ZMQ_VERSION_INFO = tuple([int(v_el) for v_el in zmq.__version__.split('.')])
ValueError: invalid literal for int() with base 10: 'b3'
```

### Tests written?
NA

### Commits signed with GPG?
Yes