### PR TITLE
fix container removal if auto_remove was enabled

### DIFF
--- a/salt/modules/dockermod.py
+++ b/salt/modules/dockermod.py
@@ -3798,6 +3798,7 @@ def rm_(name, force=False, volumes=False, **kwargs):
     kwargs = __utils__['args.clean_kwargs'](**kwargs)
     stop_ = kwargs.pop('stop', False)
     timeout = kwargs.pop('timeout', None)
+    auto_remove = False
     if kwargs:
         __utils__['args.invalid_kwargs'](kwargs)
 
@@ -3807,9 +3808,12 @@ def rm_(name, force=False, volumes=False, **kwargs):
             'remove this container'.format(name)
         )
     if stop_ and not force:
+        auto_remove = inspect_container(name)['HostConfig']['AutoRemove']
         stop(name, timeout=timeout)
     pre = ps_(all=True)
-    _client_wrapper('remove_container', name, v=volumes, force=force)
+
+    if not auto_remove:
+        _client_wrapper('remove_container', name, v=volumes, force=force)
     _clear_context()
     return [x for x in pre if x not in ps_(all=True)]
 

--- a/salt/modules/dockermod.py
+++ b/salt/modules/dockermod.py
@@ -3808,7 +3808,14 @@ def rm_(name, force=False, volumes=False, **kwargs):
             'remove this container'.format(name)
         )
     if stop_ and not force:
-        auto_remove = inspect_container(name)['HostConfig']['AutoRemove']
+        inspect_results = inspect_container(name)
+        try:
+            auto_remove = inspect_results['HostConfig']['AutoRemove']
+        except KeyError:
+            log.error(
+                'Failed to find AutoRemove in inspect results, Docker API may '
+                'have changed. Full results: %s', inspect_results
+            )
         stop(name, timeout=timeout)
     pre = ps_(all=True)
 


### PR DESCRIPTION
### What does this PR do?
Corrects a bug in the container stop & removal flow. It the container was started with the AutoRemove flag  (--rm), when stopped, the docker engine will automatically remove it, and salt's rm function will throw a 404 when removing.

### What issues does this PR fix or reference?
Did not open an issue.

### Previous Behavior
`salt myminion docker.rm mycontainer stop=True`
This would throw 404 if `mycontainer` had the AutoRemove flag enabled as stopping the container would imply auto removal.

### New Behavior
`salt myminion docker.rm mycontainer stop=True`
If `stop=True`, we check the container's AutoRemove flag and do not remove the container if the flag is set to True. The docker engine will take care of that.

No longer throws 404 if `mycontainer` had the AutoRemove flag enabled.

### Tests written?

No

### Commits signed with GPG?

No
