### PR TITLE
Add opkg/NILinuxRT 'reboot required' witnessing feature

### DIFF
--- a/salt/modules/opkg.py
+++ b/salt/modules/opkg.py
@@ -22,6 +22,7 @@ import copy
 import os
 import re
 import logging
+import errno
 
 # Import salt libs
 import salt.utils.args
@@ -55,12 +56,68 @@ log = logging.getLogger(__name__)
 # Define the module's virtual name
 __virtualname__ = 'pkg'
 
+NILRT_MODULE_STATE_PATH = '/var/lib/salt/kernel_module_state'
+
+
+def _update_nilrt_module_dep_info():
+    '''
+    Update modules.dep timestamp & checksum.
+
+    NILRT systems determine whether to reboot after kernel module install/
+    removals/etc by checking modules.dep which gets modified/touched by
+    each kernel module on-target dkms-like compilation. This function
+    updates the module.dep data after each opkg kernel module operation
+    which needs a reboot as detected by the salt checkrestart module.
+    '''
+    __salt__['cmd.shell']('stat -c %Y /lib/modules/$(uname -r)/modules.dep >{0}/modules.dep.timestamp'
+                          .format(NILRT_MODULE_STATE_PATH))
+    __salt__['cmd.shell']('md5sum /lib/modules/$(uname -r)/modules.dep >{0}/modules.dep.md5sum'
+                          .format(NILRT_MODULE_STATE_PATH))
+
+
+def _get_restartcheck_result(errors):
+    '''
+    Return restartcheck result and append errors (if any) to ``errors``
+    '''
+    rs_result = __salt__['restartcheck.restartcheck'](verbose=False)
+    if isinstance(rs_result, dict) and 'comment' in rs_result:
+        errors.append(rs_result['comment'])
+    return rs_result
+
+
+def _process_restartcheck_result(rs_result):
+    '''
+    Check restartcheck output to see if system/service restarts were requested
+    and take appropriate action.
+    '''
+    if 'No packages seem to need to be restarted' in rs_result:
+        return
+    for rstr in rs_result:
+        if 'System restart required' in rstr:
+            _update_nilrt_module_dep_info()
+            __salt__['system.set_reboot_required_witnessed']()
+        else:
+            service = os.path.join('/etc/init.d', rstr)
+            if os.path.exists(service):
+                __salt__['cmd.run']([service, 'restart'])
+
 
 def __virtual__():
     '''
     Confirm this module is on a nilrt based system
     '''
-    if __grains__.get('os_family', False) == 'NILinuxRT':
+    if __grains__.get('os_family') == 'NILinuxRT':
+        try:
+            os.makedirs(NILRT_MODULE_STATE_PATH)
+        except OSError as exc:
+            if exc.errno != errno.EEXIST:
+                return False, 'Error creating {0} (-{1}): {2}'.format(
+                    NILRT_MODULE_STATE_PATH,
+                    exc.errno,
+                    exc.strerror)
+        if not (os.path.exists(os.path.join(NILRT_MODULE_STATE_PATH, 'modules.dep.timestamp')) and
+                os.path.exists(os.path.join(NILRT_MODULE_STATE_PATH, 'modules.dep.md5sum'))):
+            _update_nilrt_module_dep_info()
         return __virtualname__
     return (False, "Module opkg only works on nilrt based systems")
 
@@ -412,11 +469,15 @@ def install(name=None,
             ret.update({pkgname: {'old': old.get(pkgname, ''),
                                   'new': new.get(pkgname, '')}})
 
+    rs_result = _get_restartcheck_result(errors)
+
     if errors:
         raise CommandExecutionError(
             'Problem encountered installing package(s)',
             info={'errors': errors, 'changes': ret}
         )
+
+    _process_restartcheck_result(rs_result)
 
     return ret
 
@@ -475,11 +536,15 @@ def remove(name=None, pkgs=None, **kwargs):  # pylint: disable=unused-argument
     new = list_pkgs()
     ret = salt.utils.data.compare_dicts(old, new)
 
+    rs_result = _get_restartcheck_result(errors)
+
     if errors:
         raise CommandExecutionError(
             'Problem encountered removing package(s)',
             info={'errors': errors, 'changes': ret}
         )
+
+    _process_restartcheck_result(rs_result)
 
     return ret
 
@@ -536,6 +601,8 @@ def upgrade(refresh=True, **kwargs):  # pylint: disable=unused-argument
            'comment': '',
            }
 
+    errors = []
+
     if salt.utils.data.is_true(refresh):
         refresh_db()
 
@@ -550,10 +617,17 @@ def upgrade(refresh=True, **kwargs):  # pylint: disable=unused-argument
     ret = salt.utils.data.compare_dicts(old, new)
 
     if result['retcode'] != 0:
+        errors.append(result)
+
+    rs_result = _get_restartcheck_result(errors)
+
+    if errors:
         raise CommandExecutionError(
             'Problem encountered upgrading packages',
-            info={'changes': ret, 'result': result}
+            info={'errors': errors, 'changes': ret}
         )
+
+    _process_restartcheck_result(rs_result)
 
     return ret
 

--- a/salt/modules/restartcheck.py
+++ b/salt/modules/restartcheck.py
@@ -547,10 +547,10 @@ def restartcheck(ignorelist=None, blacklist=None, excludepid=None, **kwargs):
             service = __salt__['service.available'](packages[package]['process_name'])
 
             if service:
-                packages[package]['systemdservice'].append(packages[package]['process_name'])
-            else:
                 if os.path.exists('/etc/init.d/' + packages[package]['process_name']):
                     packages[package]['initscripts'].append(packages[package]['process_name'])
+                else:
+                    packages[package]['systemdservice'].append(packages[package]['process_name'])
 
     restartable = []
     nonrestartable = []

--- a/salt/modules/restartcheck.py
+++ b/salt/modules/restartcheck.py
@@ -358,9 +358,9 @@ def restartcheck(ignorelist=None, blacklist=None, excludepid=None, **kwargs):
         timeout: int, timeout in minute
 
     Returns:
-        True if no packages for restart found.
-        False on failure.
-        String with checkrestart output if some package seems to need to be restarted.
+        Dict on error: { 'result': False, 'comment': '<reason>' }
+        String with checkrestart output if some package seems to need to be restarted or
+        if no packages need restarting.
 
     .. versionadded:: 2015.8.3
 

--- a/salt/modules/restartcheck.py
+++ b/salt/modules/restartcheck.py
@@ -345,6 +345,36 @@ def _check_timeout(start_time, timeout):
         raise salt.exceptions.TimeoutError('Timeout expired.')
 
 
+def _kernel_modules_changed_nilrt(kernelversion):
+    '''
+    Once a NILRT kernel module is inserted, it can't be rmmod so systems need
+    rebooting (some modules explicitely ask for reboots even on first install),
+    hence this functionality of determining if the module state got modified by
+    testing if depmod was run.
+
+    Returns:
+             - True/False depending if modules.dep got modified/touched
+    '''
+    depmodpath_base = '/lib/modules/{0}/modules.dep'.format(kernelversion)
+    depmodpath_timestamp = "/var/lib/salt/kernel_module_state/modules.dep.timestamp"
+    depmodpath_md5sum = "/var/lib/salt/kernel_module_state/modules.dep.md5sum"
+
+    # nothing can be detected without these dependencies
+    if (kernelversion is None or
+            not os.path.exists(depmodpath_timestamp) or
+            not os.path.exists(depmodpath_md5sum)):
+        return False
+
+    prev_timestamp = __salt__['file.read'](depmodpath_timestamp).rstrip()
+    # need timestamp in seconds so floor it using int()
+    cur_timestamp = str(int(os.path.getmtime(depmodpath_base)))
+
+    if prev_timestamp != cur_timestamp:
+        return True
+
+    return bool(__salt__['cmd.retcode']('md5sum -cs {0}'.format(depmodpath_md5sum), output_loglevel="quiet"))
+
+
 # pylint: disable=too-many-locals,too-many-branches,too-many-statements
 def restartcheck(ignorelist=None, blacklist=None, excludepid=None, **kwargs):
     '''
@@ -396,8 +426,14 @@ def restartcheck(ignorelist=None, blacklist=None, excludepid=None, **kwargs):
     for kernel in kernel_versions:
         _check_timeout(start_time, timeout)
         if kernel in kernel_current:
-            kernel_restart = False
-            break
+            if __grains__.get('os_family') == 'NILinuxRT':
+                # Check kernel modules for version changes
+                if not _kernel_modules_changed_nilrt(kernel):
+                    kernel_restart = False
+                    break
+            else:
+                kernel_restart = False
+                break
 
     packages = {}
     running_services = {}


### PR DESCRIPTION
### What does this PR do?

Add  new reboot required witnessed logic to opkg operations on NILRT systems similar to how win_system.py does it, using the same system API as on windows.

### What issues does this PR fix or reference?

Doesn't have an issue assigned.

### New Behavior

A new Linux system API is added for getting/setting reboot witness events which is called by the opkg module. The witness events are stored in volatile memory such that they're cleared upon reboot.

### Tests written?

No

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
