### PR TITLE
Return int(-1) when pidfile contains invalid data

### DIFF
--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -35,6 +35,7 @@ import salt.utils.args
 import salt.utils.xdg
 import salt.utils.jid
 import salt.utils.files
+import salt.utils.win_functions
 from salt.utils import kinds
 from salt.defaults import DEFAULT_TARGET_DELIM
 from salt.utils.validate.path import is_writeable
@@ -1020,8 +1021,8 @@ class DaemonMixIn(six.with_metaclass(MixInMeta, object)):
                 if self.check_pidfile() and self.is_daemonized(pid) and not os.getppid() == pid:
                     return True
             else:
-                # We have no os.getppid() on Windows. Best effort.
-                if self.check_pidfile() and self.is_daemonized(pid):
+                # We have no os.getppid() on Windows. Use salt.utils.win_functions.get_parent_pid
+                if self.check_pidfile() and self.is_daemonized(pid) and not salt.utils.win_functions.get_parent_pid() == pid:
                     return True
         return False
 

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -1018,11 +1018,11 @@ class DaemonMixIn(six.with_metaclass(MixInMeta, object)):
         if self.check_pidfile():
             pid = self.get_pidfile()
             if not salt.utils.is_windows():
-                if self.check_pidfile() and self.is_daemonized(pid) and not os.getppid() == pid:
+                if self.check_pidfile() and self.is_daemonized(pid) and os.getppid() != pid:
                     return True
             else:
                 # We have no os.getppid() on Windows. Use salt.utils.win_functions.get_parent_pid
-                if self.check_pidfile() and self.is_daemonized(pid) and not salt.utils.win_functions.get_parent_pid() == pid:
+                if self.check_pidfile() and self.is_daemonized(pid) and salt.utils.win_functions.get_parent_pid() != pid:
                     return True
         return False
 

--- a/salt/utils/process.py
+++ b/salt/utils/process.py
@@ -147,7 +147,7 @@ def get_pidfile(pidfile):
             pid = pdf.read().strip()
         return int(pid)
     except (OSError, IOError, TypeError, ValueError):
-        return int(-1)
+        return -1
 
 
 def clean_proc(proc, wait_for_kill=10):

--- a/salt/utils/process.py
+++ b/salt/utils/process.py
@@ -147,7 +147,7 @@ def get_pidfile(pidfile):
             pid = pdf.read().strip()
         return int(pid)
     except (OSError, IOError, TypeError, ValueError):
-        return None
+        return int(-1)
 
 
 def clean_proc(proc, wait_for_kill=10):


### PR DESCRIPTION
### What does this PR do?
DISCLAIMER: I know this may not be the right fix. Please recommend the appropriate solution. Perhaps the bug is upstream in `psutil`.

Returns `int(-1)` instead of `None` when the `pidfile` contains invalid data such as null bytes. This was an issue on Windows when salt-minion is running as a service. The issue doesn't occur with salt-minion running in debug mode.

Here's a pidfile with null bytes. Save the file as `salt-minion.pid` and place it in the pidfile location. (`C:\salt\var\run\salt-minion.pid`):
![salt-minion.pid](https://user-images.githubusercontent.com/9383935/38117581-0edc1bc8-3373-11e8-9029-9e8b683c1bf3.jpg)

Also uses salt.utils.win_functions.get_parent_pid function to maintain sync with Linux.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/46757

### Previous Behavior
The salt minion service would fail to start. The NSSM would continue attempting to start the service causing it to burn a lot of CPU cycles.

The minion log showed repeated instances of this stacktrace:
```
2018-03-28 13:17:15,009 [salt.log.setup   :1133][ERROR   ][20736] An un-handled exception was caught by salt's global exception handler:
TypeError: unorderable types: NoneType() < int()
Traceback (most recent call last):
  File "c:\salt\bin\Scripts\salt-minion", line 26, in <module>
    salt_minion()
  File "c:\salt\bin\lib\site-packages\salt\scripts.py", line 168, in salt_minion
    minion.start()
  File "c:\salt\bin\lib\site-packages\salt\cli\daemons.py", line 342, in start
    super(Minion, self).start()
  File "c:\salt\bin\lib\site-packages\salt\utils\parsers.py", line 1039, in start
    self.prepare()
  File "c:\salt\bin\lib\site-packages\salt\cli\daemons.py", line 299, in prepare
    if self.check_running():
  File "c:\salt\bin\lib\site-packages\salt\utils\parsers.py", line 1022, in check_running
    if self.check_pidfile() and self.is_daemonized(pid):
  File "c:\salt\bin\lib\site-packages\salt\utils\parsers.py", line 1028, in is_daemonized
    return os_is_running(pid)
  File "c:\salt\bin\lib\site-packages\salt\utils\process.py", line 187, in os_is_running
    return psutil.pid_exists(pid)
  File "c:\salt\bin\lib\site-packages\psutil\__init__.py", line 1438, in pid_exists
    if pid < 0:
TypeError: unorderable types: NoneType() < int()
```

### New Behavior
The salt-minion starts successfully.

### Tests written?
No

### Commits signed with GPG?
Yes