### PR TITLE
WIP: Adding pysmb support to salt.utils.smb

### DIFF
--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -1133,8 +1133,8 @@ def deploy_windows(host,
             if use_winrm:
                 winrm_cmd(winrm_session, 'rmdir', ['/Q', '/S', 'C:\\salttemp\\'])
             else:
-                smb_conn.deleteFile('C$', 'salttemp/{0}'.format(installer))
-                smb_conn.deleteDirectory('C$', 'salttemp')
+                salt.utils.delete_file('C$', 'salttemp/{0}'.format(installer), smb_conn)
+                salt.utils.delete_directory('C$', 'salttemp', smb_conn)
         # Shell out to winexe to ensure salt-minion service started
         if use_winrm:
             winrm_cmd(winrm_session, 'sc', ['stop', 'salt-minion'])

--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -1027,10 +1027,9 @@ def deploy_windows(host,
         log.debug('SMB port %s on %s is available', port, host)
         log.debug('Logging into %s:%s as %s', host, port, username)
         newtimeout = timeout - (time.mktime(time.localtime()) - starttime)
-
         smb_conn = salt.utils.smb.get_conn(host, username, password)
         if smb_conn is False:
-            log.error('Please install impacket to enable SMB functionality')
+            log.error('Please install pysmb or impacket to enable SMB functionality')
             return False
 
         creds = "-U '{0}%{1}' //{2}".format(
@@ -1059,8 +1058,12 @@ def deploy_windows(host,
             # Read master-sign.pub file
             log.debug("Copying master_sign.pub file from %s to minion", master_sign_pub_file)
             try:
-                with salt.utils.files.fopen(master_sign_pub_file, 'rb') as master_sign_fh:
-                    smb_conn.putFile('C$', 'salt\\conf\\pki\\minion\\master_sign.pub', master_sign_fh.read)
+                salt.utils.smb.put_file(
+                    master_sign_pub_file,
+                    'salt\\conf\\pki\\minion\\master_sign.pub',
+                    'C$',
+                    conn=smb_conn,
+                )
             except Exception as e:
                 log.debug("Exception copying master_sign.pub file %s to minion", master_sign_pub_file)
 
@@ -1071,8 +1074,12 @@ def deploy_windows(host,
         comps = win_installer.split('/')
         local_path = '/'.join(comps[:-1])
         installer = comps[-1]
-        with salt.utils.files.fopen(win_installer, 'rb') as inst_fh:
-            smb_conn.putFile('C$', 'salttemp/{0}'.format(installer), inst_fh.read)
+        salt.utils.smb.put_file(
+            win_installer,
+            'salttemp\\{0}'.format(installer),
+            'C$',
+            conn=smb_conn,
+        )
 
         if use_winrm:
             winrm_cmd(winrm_session, 'c:\\salttemp\\{0}'.format(installer), ['/S', '/master={0}'.format(master),

--- a/salt/utils/smb.py
+++ b/salt/utils/smb.py
@@ -128,7 +128,7 @@ def mkdirs(path, share='C$', conn=None, host=None, username=None, password=None)
     raise Exception("Need smb lib")
 
 
-def _put_str_impocket(content, path, share='C$', conn=None, host=None, username=None, password=None):
+def _put_str_impacket(content, path, share='C$', conn=None, host=None, username=None, password=None):
     if conn is None:
         conn = get_conn(host, username, password)
 
@@ -205,4 +205,52 @@ def put_file(local_path, path, share='C$', conn=None, host=None, username=None, 
         return _put_file_pysmb(host, username, password)
     elif HAS_IMPACKET:
         return _put_file_impacket(host, username, password)
+    raise Exception("Need smb lib")
+
+
+def _delete_file_impacket(path, share='C$', conn=None, host=None, username=None, password=None):
+    if conn is None:
+        conn = get_conn(host, username, password)
+    if conn is False:
+        return False
+    conn.deleteFile(share, path)
+
+
+def _delete_file_pysmb(path, share='C$', conn=None, host=None, username=None, password=None):
+    if conn is None:
+        conn = get_conn(host, username, password)
+    if conn is False:
+        return False
+    # deleteFiles accepts a glob, we are passing the full file path
+    conn.deleteFiles(share, path)
+
+
+def delete_file(path, share='C$', conn=None, host=None, username=None, password=None):
+    if HAS_PYSMB:
+        return _put_file_pysmb(host, username, password)
+    elif HAS_IMPACKET:
+        return _put_file_impacket(host, username, password)
+    raise Exception("Need smb lib")
+
+
+def _delete_directory_impacket(path, share='C$', conn=None, host=None, username=None, password=None):
+    if conn is None:
+        conn = get_conn(host, username, password)
+    if conn is False:
+        return False
+    conn.deleteDirectory(share, path)
+
+
+def _delete_directory_pysmb(path, share='C$', conn=None, host=None, username=None, password=None):
+    if conn is None:
+        conn = get_conn(host, username, password)
+    if conn is False:
+        return False
+    conn.deleteDirectory(share, path)
+
+def delete_directory(path, share='C$', conn=None, host=None, username=None, password=None):
+    if HAS_PYSMB:
+        return delete_directoy_pysmb(host, username, password)
+    elif HAS_IMPACKET:
+        return _delete_directoy_impacket(host, username, password)
     raise Exception("Need smb lib")

--- a/tests/integration/utils/test_smb.py
+++ b/tests/integration/utils/test_smb.py
@@ -1,0 +1,128 @@
+import getpass
+import logging
+import os
+import signal
+import subprocess
+import tempfile
+import time
+
+import salt.utils.smb
+
+from tests.support.case import TestCase
+
+log = logging.getLogger(__name__)
+CONFIG = (
+    '[global]\n'
+    'workgroup = WORKGROUP\n'
+    'interfaces = lo 127.0.0.0/8\n'
+    'smb ports = 1445\n'
+    'log level = 2\n'
+    'map to guest = Bad User\n'
+    'enable core files = no\n'
+    'passdb backend = smbpasswd\n'
+    'smb passwd file = {passwdb}\n'
+    'lock directory = {samba_dir}\n'
+    'state directory = {samba_dir}\n'
+    'cache directory = {samba_dir}\n'
+    'pid directory = {samba_dir}\n'
+    'private dir = {samba_dir}\n'
+    'ncalrpc dir = {samba_dir}\n'
+    '\n'
+    '[public]\n'
+    'path = {public_dir}\n'
+    'read only = no\n'
+    'guest ok = no\n'
+)
+TBE = (
+    '{}:0:XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX:AC8E657F8'
+    '3DF82BEEA5D43BDAF7800CC:[U          ]:LCT-507C14C7:'
+)
+
+
+class SmbTestCase(TestCase):
+    _smbd = None
+
+
+    @staticmethod
+    def check_pid(pid):
+        try:
+            os.kill(pid, 0)
+        except OSError:
+            return False
+        else:
+            return True
+
+    @classmethod
+    def setUpClass(cls):
+        tmpdir = tempfile.mkdtemp()
+        cls.samba_dir = os.path.join(tmpdir, 'samba')
+        cls.public_dir = os.path.join(tmpdir, 'public')
+        os.makedirs(cls.samba_dir)
+        os.makedirs(cls.public_dir)
+        passwdb = os.path.join(tmpdir, 'passwdb')
+        cls.username = getpass.getuser()
+        with open(passwdb, 'w') as fp:
+            fp.write(TBE.format(cls.username))
+        samba_conf = os.path.join(tmpdir, 'smb.conf')
+        with open(samba_conf, 'w') as fp:
+            fp.write(
+                CONFIG.format(
+                    samba_dir=cls.samba_dir,
+                    public_dir=cls.public_dir,
+                    passwdb=passwdb,
+                )
+            )
+        cls._smbd = subprocess.Popen(
+            '/usr/sbin/smbd -FS -s {}'.format(samba_conf),
+            shell=True
+        )
+        time.sleep(.1)
+        pidfile = os.path.join(cls.samba_dir, 'smbd.pid')
+        with open(pidfile, 'r') as fp:
+            cls._pid = int(fp.read().strip())
+        if not cls.check_pid(cls._pid):
+            raise Exception()
+
+    @classmethod
+    def tearDownClass(cls):
+        log.warn('teardown')
+        try:
+            os.kill(cls._pid, signal.SIGTERM)
+        except:
+            log.exception("Ignoring stuff")
+
+    def test_write_file(self):
+        name = 'test_write_file.txt'
+        content = 'write test file content'
+        share_path = os.path.join(self.public_dir, name)
+        assert not os.path.exists(share_path)
+
+        local_path = tempfile.mktemp()
+        with open(local_path, 'w') as fp:
+            fp.write(content)
+        conn = salt.utils.smb.get_conn('127.0.0.1', self.username, 'foo', port=1445)
+        salt.utils.smb.put_file(local_path, name, 'public', conn=conn)
+        conn.close()
+
+        with open(share_path, 'r') as fp:
+            result = fp.read()
+        assert result == content
+
+    def test_delete_file(self):
+        name = 'test_delete_file.txt'
+        content = 'read test file content'
+        share_path = os.path.join(self.public_dir, name)
+        with open(share_path, 'w') as fp:
+            fp.write(content)
+        assert os.path.exists(share_path)
+
+        conn = salt.utils.smb.get_conn('127.0.0.1', self.username, 'foo', port=1445)
+        salt.utils.smb.delete_file(name, 'public', conn=conn)
+        conn.close()
+
+        assert not os.path.exists(share_path)
+
+    def test_connection(self):
+        conn = salt.utils.smb.get_conn('127.0.0.1', self.username, 'foo', port=1445)
+        conn.close()
+        time.sleep(.1)


### PR DESCRIPTION
### What does this PR do?

Adds support for pysmb to the `salt.utils.smb`. This uses pysmb in place of impacket for samba share interactions. The pysmb library has been ported to python 3 but that work is still in-progress for impacket.

### What issues does this PR fix or reference?

Missing smb support in python 3

### Previous Behavior

Impacket won't work on python 3

### New Behavior

Python 3 can use pysmb instead of impacket

### Tests written?

Yes

### Commits signed with GPG?

Yes
