### PR TITLE
Fix regression introduced in merge-forward

### DIFF
--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -482,10 +482,11 @@ def _run(cmd,
             if env_runas.get('USER') != runas:
                 env_runas['USER'] = runas
             env = env_runas
-        except ValueError:
+        except ValueError as exc:
+            log.exception('Error raised retrieving environment for user %s', runas)
             raise CommandExecutionError(
-                'Environment could not be retrieved for User \'{0}\''.format(
-                    runas
+                'Environment could not be retrieved for user \'{0}\': {1}'.format(
+                    runas, exc
                 )
             )
 

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -443,7 +443,7 @@ def _run(cmd,
                 stderr=subprocess.PIPE,
                 stdout=subprocess.PIPE,
                 stdin=subprocess.PIPE
-            ).communicate(salt.utils.stringutils.to_bytes(py_code))[0]
+            ).communicate(salt.utils.stringutils.to_bytes(py_code))
             marker_count = env_bytes.count(marker_b)
             if marker_count == 0:
                 # Possibly PAM prevented the login

--- a/tests/integration/modules/test_cmdmod.py
+++ b/tests/integration/modules/test_cmdmod.py
@@ -15,9 +15,11 @@ from tests.support.helpers import (
     skip_if_not_root
 )
 from tests.support.paths import TMP
+from tests.support.unit import skipIf
 
 # Import salt libs
 import salt.utils.path
+import salt.utils.platform
 
 # Import 3rd-party libs
 from salt.ext import six
@@ -265,6 +267,15 @@ class CMDModuleTest(ModuleCase):
         result = self.run_function('cmd.run_stdout', [cmd],
                                    runas=runas).strip()
         self.assertEqual(result, expected_result)
+
+    @skipIf(salt.utils.platform.is_windows(), 'minion is windows')
+    @skip_if_not_root
+    def test_runas(self):
+        '''
+        Ensure that the env is the runas user's
+        '''
+        out = self.run_function('cmd.run', ['env'], runas='nobody').splitlines()
+        self.assertIn('USER=nobody', out)
 
     def test_timeout(self):
         '''


### PR DESCRIPTION
When #46503 was merged forward, there was a problem in the merge conflict.  The tuple indexing was kept, and we are now grabbing both stdout and stderr from the `subprocess.Popen.communicate()`. Therefore a ValueError is raised when we try to unpack a single element of a tuple into two separate variables.

Fixes #46779