### PR TITLE
Adds zip64 switch to archive.zip.

### DIFF
--- a/salt/modules/archive.py
+++ b/salt/modules/archive.py
@@ -699,7 +699,7 @@ def cmd_zip(zip_file, sources, template=None, cwd=None, runas=None):
 
 
 @salt.utils.decorators.depends('zipfile', fallback_function=cmd_zip)
-def zip_(zip_file, sources, template=None, cwd=None, runas=None):
+def zip_(zip_file, sources, template=None, cwd=None, runas=None, zip64=False):
     '''
     Uses the ``zipfile`` Python module to create zip files
 
@@ -744,6 +744,14 @@ def zip_(zip_file, sources, template=None, cwd=None, runas=None):
         Create the zip file as the specified user. Defaults to the user under
         which the minion is running.
 
+    zip64 : False
+        Used to enable ZIP64 support, necessary to create archives larger than
+        4 GByte in size.
+        If true, will create ZIP file with the ZIPp64 extension when the zipfile
+        is larger than 2 GB.
+        ZIP64 extension is disabled by default in the Python native zip support
+        because the default zip and unzip commands on Unix (the InfoZIP utilities)
+        don't support these extensions.
 
     CLI Example:
 
@@ -788,7 +796,7 @@ def zip_(zip_file, sources, template=None, cwd=None, runas=None):
     try:
         exc = None
         archived_files = []
-        with contextlib.closing(zipfile.ZipFile(zip_file, 'w', zipfile.ZIP_DEFLATED)) as zfile:
+        with contextlib.closing(zipfile.ZipFile(zip_file, 'w', zipfile.ZIP_DEFLATED, zip64)) as zfile:
             for src in sources:
                 if cwd:
                     src = os.path.join(cwd, src)
@@ -828,9 +836,15 @@ def zip_(zip_file, sources, template=None, cwd=None, runas=None):
         if exc is not None:
             # Wait to raise the exception until euid/egid are restored to avoid
             # permission errors in writing to minion log.
-            raise CommandExecutionError(
-                'Exception encountered creating zipfile: {0}'.format(exc)
-            )
+            if exc == zipfile.LargeZipFile:
+                raise CommandExecutionError(
+                    'Resulting zip file too large, would require ZIP64 support'
+                    'which has not been enabled. Rerun command with zip64=True'
+                )
+            else:
+                raise CommandExecutionError(
+                    'Exception encountered creating zipfile: {0}'.format(exc)
+                )
 
     return archived_files
 


### PR DESCRIPTION
### What does this PR do?
Adds a switch to enable ZIP64 support to archive.zip. ZIP64 extension is required to create zip files larger than 4 GBytes.

Zip-files larger than 4GB created by Pythons zipfile with the ZIP64 extension seem to work fine together with archive.is_encrypted and archive.unzip, so no changes in these functions seems necessary (which I initially thought). For the same reason the archive state is left unchanged.

### What issues does this PR fix or reference?
No reported issue that I have found.

### Previous Behavior
Not being able to create zip files larger than 2.1GB with archive.zip (when the archive grows larger than this an error is thrown).

### New Behavior
Possible to create zip files larger than 2.1GB if used with zip64=True.
Gives nicer error if zip64=False (the default) and zip file grows beyond 2.1GB.

### Tests written?
No

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
