### PR TITLE
fix win_lgpo to correctly create valuenames of list item types

### DIFF
--- a/salt/modules/win_lgpo.py
+++ b/salt/modules/win_lgpo.py
@@ -3439,7 +3439,7 @@ def _processValueItem(element, reg_key, reg_valuename, policy, parent_element,
             element_valuenames = []
             element_values = this_element_value
             if this_element_value is not None:
-                element_valuenames = list(range(1, len(this_element_value) + 1))
+                element_valuenames = list([str(z) for z in range(1, len(this_element_value) + 1)])
             if 'additive' in element.attrib:
                 if element.attrib['additive'].lower() == 'false':
                     # a delete values will be added before all the other
@@ -3464,11 +3464,18 @@ def _processValueItem(element, reg_key, reg_valuename, policy, parent_element,
                 if this_element_value is not None:
                     element_valuenames = this_element_value.keys()
                     element_values = this_element_value.values()
-
-            if 'valuePrefix' in element.attrib and element.attrib['valuePrefix'] != '':
-                if this_element_value is not None:
-                    element_valuenames = ['{0}{1}'.format(element.attrib['valuePrefix'],
-                                                          k) for k in element_valuenames]
+            if 'valuePrefix' in element.attrib:
+                # if the valuePrefix attribute exists, the valuenames are <prefix><number>
+                # most prefixes attributes are empty in the admx files, so the valuenames
+                # end up being just numbers
+                if element.attrib['valuePrefix'] != '':
+                    if this_element_value is not None:
+                        element_valuenames = ['{0}{1}'.format(element.attrib['valuePrefix'],
+                                                              k) for k in element_valuenames]
+            else:
+                # if there is no valuePrefix attribute, the valuename is the value
+                if element_values is not None:
+                    element_valuenames = [str(z) for z in element_values]
             if not check_deleted:
                 if this_element_value is not None:
                     log.debug('_processValueItem has an explicit element_value of {0}'.format(this_element_value))


### PR DESCRIPTION
### What does this PR do?
corrects the creation of valuenames for ADMX "list" types

if the valuePrefix attribute does not exist on the list item, the value
is the value name, other wise, the valuename a number with the
valuePrefix prepended to it

needs to be backported to 2016.11 as well

### What issues does this PR fix or reference?
fixes #46627

### Previous Behavior
if the valuePrefix attribute didn't exist or was empty, numbers were used as the valuename, however if the valuePrefix attirbute does not exist at all on the list item, the values are used as the valuenames

### New Behavior
if the valuePrefix attribute does not exist, the values are used as valuenames
if the valuePrefix attribute exists, numbers are used with the valuePrefix attribute value prepended to the number

### Tests written?
No

edited to add: 
Validated with this state:
```
test_list_policies:
  lgpo.set:
    - computer_policy:
        # a policy with no valuePrefix attribute
        'RA_Unsolicit':
            'Configure Offer Remote Access': Enabled
            'Permit remote control of this computer': 'Allow helpers to remotely control the computer'
            'Helpers':
               - 'administrators'
               - 'other_user'
        # a policy with valuePrefix=""
        'Specify communities':
            'Communities':
              - community_new1
              - community_new2
```

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
