### PR TITLE
Add support for more init systems

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1495,6 +1495,12 @@ def os_data():
                             )
                     elif salt.utils.path.which('supervisord') in init_cmdline:
                         grains['init'] = 'supervisord'
+                    elif salt.utils.path.which('dumb-init') in init_cmdline:
+                        # https://github.com/Yelp/dumb-init
+                        grains['init'] = 'dumb-init'
+                    elif salt.utils.path.which('tini') in init_cmdline:
+                        # https://github.com/krallin/tini
+                        grains['init'] = 'tini'
                     elif init_cmdline == ['runit']:
                         grains['init'] = 'runit'
                     elif '/sbin/my_init' in init_cmdline:


### PR DESCRIPTION
https://github.com/Yelp/dumb-init
https://github.com/krallin/tini

### What does this PR do?

Add tini and dumb-init support for grains['init']. It is useful for containerized environments like docker. 

### What issues does this PR fix or reference?
#46805

### Previous Behavior
A lot of log records with message "Could not determine init system from command line ..."

### New Behavior
grains['init'] = 'dumb-init'
or
grains['init'] = 'tini'

### Tests written?

No

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
