### PR TITLE
Fix sharedsecret authentication

### DIFF
--- a/salt/auth/sharedsecret.py
+++ b/salt/auth/sharedsecret.py
@@ -37,8 +37,8 @@ import logging
 log = logging.getLogger(__name__)
 
 
-def auth(username, sharedsecret, **kwargs):
+def auth(username, password):
     '''
     Shared secret authentication
     '''
-    return sharedsecret == __opts__.get('sharedsecret')
+    return password == __opts__.get('sharedsecret')


### PR DESCRIPTION
### What does this PR do?

Fix sharedsecret authentication

### What issues does this PR fix or reference?

#46808

### Previous Behavior
for `salt -a sharedsecret test.ping` for example
1. cli ask username
2. cli skip password because of this https://github.com/saltstack/salt/blob/develop/salt/auth/__init__.py#L699
3. minion send request to master with username only
4. master compare sharedsecret with sharedsecret which is always true
Authentication could fail only if there was no such user. 

### New Behavior
1. cli ask username
2. cli ask password
3. minion send request to master with username and password
4. master compare password with sharedsecret which is always true

### Tests written?

No

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
