### PR TITLE
Get rid of confusing debug logging

### DIFF
--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -2030,8 +2030,9 @@ def event(tagmatch='*',
                         indent=None if not pretty else 4)))
                 sys.stdout.flush()
 
-            count -= 1
-            log.debug('Remaining event matches: %s', count)
+            if count > 0:
+                count -= 1
+                log.debug('Remaining event matches: %s', count)
 
             if count == 0:
                 break


### PR DESCRIPTION
When count is its default of -1, we get confusing debug logging counting down negative numbers as the function listens for a matching event. This gets rid of that by only logging when the count is positive.

Inspired by d74c155.