### PR TITLE
Improve __virtual__ checks in sensehat module

### DIFF
--- a/salt/modules/sensehat.py
+++ b/salt/modules/sensehat.py
@@ -25,7 +25,6 @@ import logging
 
 try:
     from sense_hat import SenseHat
-    _sensehat = SenseHat()
     has_sense_hat = True
 except (ImportError, NameError):
     _sensehat = None
@@ -39,14 +38,19 @@ def __virtual__():
     Only load the module if SenseHat is available
     '''
     if has_sense_hat:
+        try:
+            _sensehat = SenseHat()
+        except OSError:
+            return False, 'This module can only be used on a Raspberry Pi with a SenseHat.'
+
         rotation = __salt__['pillar.get']('sensehat:rotation', 0)
         if rotation in [0, 90, 180, 270]:
             _sensehat.set_rotation(rotation, False)
         else:
-            log.error("{0} is not a valid rotation. Using default rotation.".format(rotation))
+            log.error('{0} is not a valid rotation. Using default rotation.'.format(rotation))
         return True
-    else:
-        return False, "The SenseHat excecution module can not be loaded: SenseHat unavailable.\nThis module can only be used on a Raspberry Pi with a SenseHat. Also make sure that the sense_hat python library is installed!"
+
+    return False, 'The SenseHat execution module cannot be loaded: \'sense_hat\' python library unavailable.'
 
 
 def set_pixels(pixels):


### PR DESCRIPTION
If the `sense_hat` python library is installed on the Raspberry Pi, but the Pi doesn't actually have a SenseHat available, the execution module will stacktrace when it's loaded:

```
root@raspberrypi:/home/pi# salt-call --local sys.doc none
[ERROR   ] Failed to import module sensehat, this is due most likely to a syntax error:
Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/salt/loader.py", line 1411, in _load_module
    mod = imp.load_module(mod_namespace, fn_, fpath, desc)
  File "/usr/lib/python2.7/dist-packages/salt/modules/sensehat.py", line 26, in <module>
    _sensehat = SenseHat()
  File "/usr/lib/python2.7/dist-packages/sense_hat/sense_hat.py", line 36, in __init__
    raise OSError('Cannot detect %s device' % self.SENSE_HAT_FB_NAME)
OSError: Cannot detect RPi-Sense FB device
local:
    ----------
```

We need to catch the OSError and warn people that this module needs a SenseHat available to the Pi to work.

This PR catches that OSError in the `__virtual__()` and displays a helpful message to the user.

This change also helps distinguish the errors of when the `sense_hat` python lib is missing vs the actual SenseHat missing.

Fixes #42312
