### PR TITLE
Regression to ignore retcodes on crontab calls

### DIFF
--- a/salt/modules/cron.py
+++ b/salt/modules/cron.py
@@ -289,12 +289,14 @@ def raw_cron(user):
         # Preserve line endings
         lines = sdecode(__salt__['cmd.run_stdout'](cmd,
                                            runas=user,
+                                           ignore_retcode=True,
                                            rstrip=False,
                                            python_shell=False)).splitlines(True)
     else:
         cmd = 'crontab -u {0} -l'.format(user)
         # Preserve line endings
         lines = sdecode(__salt__['cmd.run_stdout'](cmd,
+                                           ignore_retcode=True,
                                            rstrip=False,
                                            python_shell=False)).splitlines(True)
 

--- a/tests/unit/modules/test_cron.py
+++ b/tests/unit/modules/test_cron.py
@@ -789,6 +789,7 @@ class CronTestCase(TestCase, LoaderModuleMockMixin):
             cron.raw_cron(STUB_USER)
             cron.__salt__['cmd.run_stdout'].assert_called_with("crontab -l",
                                                                runas=STUB_USER,
+                                                               ignore_retcode=True,
                                                                rstrip=False,
                                                                python_shell=False)
 
@@ -803,6 +804,7 @@ class CronTestCase(TestCase, LoaderModuleMockMixin):
                           MagicMock(return_value=False)):
             cron.raw_cron(STUB_USER)
             cron.__salt__['cmd.run_stdout'].assert_called_with("crontab -u root -l",
+                                                               ignore_retcode=True,
                                                                rstrip=False,
                                                                python_shell=False)
 
@@ -818,6 +820,7 @@ class CronTestCase(TestCase, LoaderModuleMockMixin):
             cron.raw_cron(STUB_USER)
             cron.__salt__['cmd.run_stdout'].assert_called_with("crontab -l",
                                                                runas=STUB_USER,
+                                                               ignore_retcode=True,
                                                                rstrip=False,
                                                                python_shell=False)
 
@@ -833,6 +836,7 @@ class CronTestCase(TestCase, LoaderModuleMockMixin):
             cron.raw_cron(STUB_USER)
             cron.__salt__['cmd.run_stdout'].assert_called_with("crontab -l",
                                                                runas=STUB_USER,
+                                                               ignore_retcode=True,
                                                                rstrip=False,
                                                                python_shell=False)
 
@@ -848,6 +852,7 @@ class CronTestCase(TestCase, LoaderModuleMockMixin):
             cron.raw_cron(STUB_USER)
             cron.__salt__['cmd.run_stdout'].assert_called_with("crontab -l",
                                                                runas=STUB_USER,
+                                                               ignore_retcode=True,
                                                                rstrip=False,
                                                                python_shell=False)
 
@@ -863,6 +868,7 @@ class CronTestCase(TestCase, LoaderModuleMockMixin):
             cron.raw_cron(STUB_USER)
             cron.__salt__['cmd.run_stdout'].assert_called_with("crontab -l",
                                                                runas=STUB_USER,
+                                                               ignore_retcode=True,
                                                                rstrip=False,
                                                                python_shell=False)
 


### PR DESCRIPTION
### What does this PR do?
Ensures there is no error logging if the crontab doesn't exist.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/46439

### Previous Behavior
Salt errors while checking for user crontab, then the state advises it ran successfully without installing a crontab.

### New Behavior
Salt checks for user crontab, if present, done, if not present, install the users crontab.

### Tests written?

No

### Commits signed with GPG?

Yes
