### PR TITLE
match tuple for targets as well

### DIFF
--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -1586,7 +1586,7 @@ def subdict_match(data,
                            exact_match=exact_match):
                 return True
             continue
-        if isinstance(match, list):
+        if isinstance(match, (list, tuple)):
             # We are matching a single component to a single list member
             for member in match:
                 if isinstance(member, dict):


### PR DESCRIPTION
### What does this PR do?
We should be matching tuples in the same way as lists in the targeting (especially since some grains are now tuples)

### What issues does this PR fix or reference?
Fixes #46826

### Tests written?

No

### Commits signed with GPG?

Yes