### PR TITLE
Add support to only return failed states to slack.

### DIFF
--- a/salt/returners/slack_returner.py
+++ b/salt/returners/slack_returner.py
@@ -215,10 +215,10 @@ def returner(ret):
 
     returns = ret.get('return')
     if changes is True:
-        returns = {key, value for key, value in returns.items() if value['result'] is not True or value['changes']}
+        returns = {(key, value) for key, value in returns.items() if value['result'] is not True or value['changes']}
 
     if only_show_failed is True:
-        returns = {key, value for key, value in returns.items() if value['result'] is not True}
+        returns = {(key, value) for key, value in returns.items() if value['result'] is not True}
 
     if yaml_format is True:
         returns = salt.utils.yaml.safe_dump(returns)

--- a/salt/returners/slack_returner.py
+++ b/salt/returners/slack_returner.py
@@ -215,10 +215,10 @@ def returner(ret):
 
     returns = ret.get('return')
     if changes is True:
-        returns = dict((key, value) for key, value in returns.items() if value['result'] is not True or value['changes'])
+        returns = {key, value for key, value in returns.items() if value['result'] is not True or value['changes']}
 
     if only_show_failed is True:
-        returns = dict((key, value) for key, value in returns.items() if value['result'] is not True)
+        returns = {key, value for key, value in returns.items() if value['result'] is not True}
 
     if yaml_format is True:
         returns = salt.utils.yaml.safe_dump(returns)

--- a/salt/returners/slack_returner.py
+++ b/salt/returners/slack_returner.py
@@ -14,6 +14,7 @@ The following fields can be set in the minion conf file:
     slack.as_user (required to see the profile picture of your bot)
     slack.profile (optional)
     slack.changes(optional, only show changes and failed states)
+    slack.only_show_failed(optional, only show failed states)
     slack.yaml_format(optional, format the json in yaml format)
 
 
@@ -110,6 +111,7 @@ def _get_options(ret=None):
              'as_user': 'as_user',
              'api_key': 'api_key',
              'changes': 'changes',
+             'only_show_failed': 'only_show_failed',
              'yaml_format': 'yaml_format',
              }
 
@@ -188,6 +190,7 @@ def returner(ret):
     as_user = _options.get('as_user')
     api_key = _options.get('api_key')
     changes = _options.get('changes')
+    only_show_failed = _options.get('only_show_failed')
     yaml_format = _options.get('yaml_format')
 
     if not channel:
@@ -206,9 +209,16 @@ def returner(ret):
         log.error('slack.api_key not defined in salt config')
         return
 
+    if only_show_failed and changes:
+        log.error('cannot define both slack.changes and slack.only_show_failed in salt config')
+        return
+
     returns = ret.get('return')
     if changes is True:
         returns = dict((key, value) for key, value in returns.items() if value['result'] is not True or value['changes'])
+
+    if only_show_failed is True:
+        returns = dict((key, value) for key, value in returns.items() if value['result'] is not True)
 
     if yaml_format is True:
         returns = salt.utils.yaml.safe_dump(returns)


### PR DESCRIPTION
### What does this PR do?
Add support to only return failed states to slack via slack_retuner.

### What issues does this PR fix or reference?
N/A

### Previous Behavior
Previously, using `changes: true` returned both states that had changes and states that failed.

### New Behavior
Now, you can still use `changes: true` to return changed and failed states, or you can use `only_show_failed: true` to only return failed states.

### Tests written?
No

### Commits signed with GPG?
Yes