### PR TITLE
Make raw imports from _utils work

### DIFF
--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -1503,6 +1503,7 @@ def mod_data(fsclient):
             'grains',
             'renderers',
             'returners',
+            'utils',
             ]
     ret = {}
     envs = fsclient.envs()

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -221,7 +221,7 @@ def minion_mods(
     if not whitelist:
         whitelist = opts.get('whitelist_modules', None)
     ret = LazyLoader(
-        _module_dirs(opts, 'modules', 'module'),
+        _module_dirs(opts, 'modules', 'module') + _module_dirs(opts, 'utils'),
         opts,
         tag='module',
         pack={'__context__': context, '__utils__': utils, '__proxy__': proxy},
@@ -502,7 +502,7 @@ def states(opts, functions, utils, serializers, whitelist=None, proxy=None):
         statemods = salt.loader.states(__opts__, None, None)
     '''
     ret = LazyLoader(
-        _module_dirs(opts, 'states'),
+        _module_dirs(opts, 'states') + _module_dirs(opts, 'utils'),
         opts,
         tag='states',
         pack={'__salt__': functions, '__proxy__': proxy or {}},


### PR DESCRIPTION
This is a quick hack to make it work with salt-ssh.
It would be great if anyone could outline the proper solution, since I got lost in module loading logic.

### What issues does this PR fix or reference?
#32500

### Previous Behavior
Importing `_utils` module resulted in `ImportError`.

### New Behavior
Importing `_utils` module works as described in https://docs.saltstack.com/en/latest/topics/utils/index.html

### Tests written?

No

### Commits signed with GPG?

Yes