### PR TITLE
Use new formatting for string substitution in fileserver/roots.py

### DIFF
--- a/salt/fileserver/roots.py
+++ b/salt/fileserver/roots.py
@@ -174,8 +174,8 @@ def update():
                 except ValueError:
                     # Document the invalid entry in the log
                     log.warning(
-                        'Skipped invalid cache mtime entry in %s: %s',
-                        mtime_map_path, line
+                        'Skipped invalid cache mtime entry in {0}: {1}'.format(
+                        mtime_map_path, line)
                     )
 
     # compare the maps, set changed to the return value
@@ -303,7 +303,7 @@ def _file_lists(load, form):
         try:
             os.makedirs(list_cachedir)
         except os.error:
-            log.critical('Unable to make cachedir %s', list_cachedir)
+            log.critical('Unable to make cachedir {0}'.format(list_cachedir))
             return []
     list_cache = os.path.join(list_cachedir, '{0}.p'.format(load['saltenv']))
     w_lock = os.path.join(list_cachedir, '.{0}.w'.format(load['saltenv']))
@@ -333,16 +333,16 @@ def _file_lists(load, form):
 
             for item in items:
                 abs_path = os.path.join(parent_dir, item)
-                log.trace('roots: Processing %s', abs_path)
+                log.trace('roots: Processing {0}'.format(abs_path))
                 is_link = salt.utils.path.islink(abs_path)
                 log.trace(
-                    'roots: %s is %sa link',
-                    abs_path, 'not ' if not is_link else ''
+                    'roots: {0} is {1}a link'.format(
+                    abs_path, 'not ' if not is_link else '')
                 )
                 if is_link and __opts__['fileserver_ignoresymlinks']:
                     continue
                 rel_path = _translate_sep(os.path.relpath(abs_path, fs_root))
-                log.trace('roots: %s relative path is %s', abs_path, rel_path)
+                log.trace('roots: {0} relative path is {1}'.format(abs_path, rel_path))
                 if salt.fileserver.is_file_ignored(__opts__, rel_path):
                     continue
                 tgt.add(rel_path)
@@ -357,8 +357,8 @@ def _file_lists(load, form):
                 if is_link:
                     link_dest = salt.utils.path.readlink(abs_path)
                     log.trace(
-                        'roots: %s symlink destination is %s',
-                        abs_path, link_dest
+                        'roots: {0} symlink destination is {1}'.format(
+                        abs_path, link_dest)
                     )
                     if salt.utils.platform.is_windows() \
                             and link_dest.startswith('\\\\'):
@@ -366,8 +366,8 @@ def _file_lists(load, form):
                         # join UNC and non-UNC paths, just assume the original
                         # path.
                         log.trace(
-                            'roots: %s is a UNC path, using %s instead',
-                            link_dest, abs_path
+                            'roots: {0} is a UNC path, using {1} instead'.format(
+                            link_dest, abs_path)
                         )
                         link_dest = abs_path
                     if link_dest.startswith('..'):
@@ -383,8 +383,8 @@ def _file_lists(load, form):
                         )
                     )
                     log.trace(
-                        'roots: %s relative path is %s',
-                        abs_path, rel_dest
+                        'roots: {0} relative path is {1}'.format(
+                        abs_path, rel_dest)
                     )
                     if not rel_dest.startswith('..'):
                         # Only count the link if it does not point


### PR DESCRIPTION
### What does this PR do?

Changes the string substitution to use `.format()`, which fixes handling of non-ascii characters

### What issues does this PR fix or reference?
Fixes #46737

### Previous Behavior
When using non-ascii characters in directory names, `cp.list_master_dirs` would be empty and the following error would appear in the master log:

```[salt.master      :1643][ERROR   ][4123] Error in function _dir_list:
Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/salt/master.py", line 1633, in run_func
    ret = getattr(self, func)(load)
  File "/usr/lib/python2.7/dist-packages/salt/fileserver/__init__.py", line 818, in dir_list
    ret.update(self.servers[fstr](load))
  File "/usr/lib/python2.7/dist-packages/salt/fileserver/roots.py", line 445, in dir_list
    return _file_lists(load, 'dirs')
  File "/usr/lib/python2.7/dist-packages/salt/fileserver/roots.py", line 406, in _file_lists
    _add_to(ret['dirs'], path, root, dirs)
  File "/usr/lib/python2.7/dist-packages/salt/fileserver/roots.py", line 343, in _add_to
    log.trace('roots: Processing %s', abs_path)
  File "/usr/lib/python2.7/dist-packages/salt/log/mixins.py", line 35, in trace
    self.log(getattr(logging, 'TRACE', 5), msg, *args, **kwargs)
  File "/usr/lib/python2.7/logging/__init__.py", line 1224, in log
    self._log(level, msg, args, **kwargs)
  File "/usr/lib/python2.7/dist-packages/salt/log/setup.py", line 327, in _log
    self, level, msg, args, exc_info=exc_info, extra=extra
  File "/usr/lib/python2.7/logging/__init__.py", line 1278, in _log
    record = self.makeRecord(self.name, level, fn, lno, msg, args, exc_info, func, extra)
  File "/usr/lib/python2.7/dist-packages/salt/log/setup.py", line 361, in makeRecord
    exc_info, func)
  File "/usr/lib/python2.7/dist-packages/salt/log/setup.py", line 208, in __init__
    self.colormsg = '%s%s%s' % (cmsg, self.getMessage(), reset)
  File "/usr/lib/python2.7/logging/__init__.py", line 335, in getMessage
    msg = msg % self.args
```

### New Behavior

`cp.list_master_dirs` now returns correctly and no error is thrown.

### Tests written?

No

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
