### PR TITLE
strdup from libc is not available on windows

### DIFF
--- a/salt/auth/pam.py
+++ b/salt/auth/pam.py
@@ -48,15 +48,20 @@ from salt.ext.six.moves import range  # pylint: disable=import-error,redefined-b
 # Import 3rd-party libs
 import salt.ext.six as six
 
-LIBC = CDLL(find_library('c'))
+try:
+    LIBC = CDLL(find_library('c'))
 
-CALLOC = LIBC.calloc
-CALLOC.restype = c_void_p
-CALLOC.argtypes = [c_uint, c_uint]
+    CALLOC = LIBC.calloc
+    CALLOC.restype = c_void_p
+    CALLOC.argtypes = [c_uint, c_uint]
 
-STRDUP = LIBC.strdup
-STRDUP.argstypes = [c_char_p]
-STRDUP.restype = POINTER(c_char)  # NOT c_char_p !!!!
+    STRDUP = LIBC.strdup
+    STRDUP.argstypes = [c_char_p]
+    STRDUP.restype = POINTER(c_char)  # NOT c_char_p !!!!
+except AttributeError:
+    HAS_LIBC = False
+else:
+    HAS_LIBC = True
 
 # Various constants
 PAM_PROMPT_ECHO_OFF = 1
@@ -147,7 +152,7 @@ def __virtual__():
     '''
     Only load on Linux systems
     '''
-    return HAS_PAM
+    return HAS_LIBC and HAS_PAM
 
 
 def authenticate(username, password):


### PR DESCRIPTION
### What does this PR do?

Fixes exceptions seen in test suite on windows builds

### What issues does this PR fix or reference?

N/A

### Previous Behavior
We are errors in the builds like this:
```
17:34:07         Zjk-2017_7-dev-c7-11:34:07,542 [salt.loader                                :1460][ERROR   ] Failed to import auth pam, this is due most likely to a syntax error:
17:34:07 Traceback (most recent call last):
17:34:07   File "C:\testing\salt\loader.py", line 1438, in _load_module
17:34:07     mod = imp.load_module(mod_namespace, fn_, fpath, desc)
17:34:07   File "C:\testing\salt\auth\pam.py", line 57, in <module>
17:34:07     STRDUP = LIBC.strdup
17:34:07   File "C:\Python27\lib\ctypes\__init__.py", line 375, in __getattr__
17:34:07     func = self.__getitem__(name)
17:34:07   File "C:\Python27\lib\ctypes\__init__.py", line 380, in __getitem__
17:34:07     func = self._FuncPtr((name_or_ordinal, self))
17:34:07 AttributeError: function 'strdup' not found
```

### New Behavior

The loader can try to load salt.auth.pam on Windows without an exception.

### Tests written?

No

### Commits signed with GPG?

Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
