### PR TITLE
Unbreak creating etherstubs on SmartOS

### DIFF
--- a/salt/modules/smartos_nictagadm.py
+++ b/salt/modules/smartos_nictagadm.py
@@ -143,14 +143,14 @@ def add(name, mac, mtu=1500):
     mac : string
         mac of parent interface or 'etherstub' to create a ether stub
     mtu : int
-        MTU
+        MTU (ignored for etherstubs)
 
     CLI Example:
 
     .. code-block:: bash
 
-        salt '*' nictagadm.add storage etherstub
-        salt '*' nictagadm.add trunk 'DE:AD:OO:OO:BE:EF' 9000
+        salt '*' nictagadm.add storage0 etherstub
+        salt '*' nictagadm.add trunk0 'DE:AD:OO:OO:BE:EF' 9000
     '''
     ret = {}
 
@@ -163,17 +163,10 @@ def add(name, mac, mtu=1500):
             return {'Error': '{0} is not present on this system.'.format(mac)}
 
     if mac == 'etherstub':
-        cmd = 'nictagadm add -l -p mtu={mtu} {name}'.format(
-            mtu=mtu,
-            name=name
-        )
+        cmd = 'nictagadm add -l {0}'.format(name)
         res = __salt__['cmd.run_all'](cmd)
     else:
-        cmd = 'nictagadm add -p mtu={mtu},mac={mac} {name}'.format(
-            mtu=mtu,
-            mac=mac,
-            name=name
-        )
+        cmd = 'nictagadm add -p mtu={0},mac={1} {2}'.format(mtu, mac, name)
         res = __salt__['cmd.run_all'](cmd)
 
     if res['retcode'] == 0:
@@ -224,10 +217,7 @@ def update(name, mac=None, mtu=None):
     elif mtu:
         properties = "mtu={0}".format(mtu) if mtu else ""
 
-    cmd = 'nictagadm update -p {properties} {name}'.format(
-        properties=properties,
-        name=name
-    )
+    cmd = 'nictagadm update -p {0} {1}'.format(properties, name)
     res = __salt__['cmd.run_all'](cmd)
 
     if res['retcode'] == 0:
@@ -256,10 +246,7 @@ def delete(name, force=False):
     if name not in list_nictags():
         return True
 
-    cmd = 'nictagadm delete {force}{name}'.format(
-        force="-f " if force else "",
-        name=name
-    )
+    cmd = 'nictagadm delete {0}{1}'.format("-f " if force else "", name)
     res = __salt__['cmd.run_all'](cmd)
 
     if res['retcode'] == 0:


### PR DESCRIPTION
### What does this PR do?

SmartOS (no longer?) handles setting an MTU for etherstub devices, so silently drop it in order to maintain the current API.

Also fixup two examples while here which failed to run.

### Previous Behavior

```
salt:2066 salt % doas salt-ssh smartos-gz nictagadm.add storage0 etherstub
smartos-gz:
    ----------
    Error:
        Error: Cannot specify MTU for local nic tag
```

### Tests written?

No (Tested on SmartOS 20160204T080230Z and 20180203T031130Z though)

### Commits signed with GPG?

Yes

@sjorge could you review this too please?