### PR TITLE
fix creating a nic tag on a link with double 0 in the MAC

### DIFF
--- a/salt/modules/smartos_nictagadm.py
+++ b/salt/modules/smartos_nictagadm.py
@@ -118,7 +118,7 @@ def exists(*nictag, **kwargs):
         salt '*' nictagadm.exists admin
     '''
     ret = {}
-    if len(nictag) == 0:
+    if not nictag:
         return {'Error': 'Please provide at least one nictag to check.'}
 
     cmd = 'nictagadm exists -l {0}'.format(' '.join(nictag))
@@ -159,7 +159,8 @@ def add(name, mac, mtu=1500):
     if mac != 'etherstub':
         cmd = 'dladm show-phys -m -p -o address'
         res = __salt__['cmd.run_all'](cmd)
-        if mac not in res['stdout'].splitlines():
+        # dladm prints '00' as '0', so account for that.
+        if mac.replace('00', '0') not in res['stdout'].splitlines():
             return {'Error': '{0} is not present on this system.'.format(mac)}
 
     if mac == 'etherstub':
@@ -207,7 +208,8 @@ def update(name, mac=None, mtu=None):
         else:
             cmd = 'dladm show-phys -m -p -o address'
             res = __salt__['cmd.run_all'](cmd)
-            if mac not in res['stdout'].splitlines():
+            # dladm prints '00' as '0', so account for that.
+            if mac.replace('00', '0') not in res['stdout'].splitlines():
                 return {'Error': '{0} is not present on this system.'.format(mac)}
 
     if mac and mtu:


### PR DESCRIPTION
### What does this PR do?

Otherwise we get a message like '12:34:00:56:78:90 is not present on this system.' as dladm prints the '00' as '0' and we fail to correctly identify the existing interface.

### Tests written?

No

### Commits signed with GPG?

Yes

@sjorge could you please review this too?