### PR TITLE
git.latest: add option to hard-reset only when there are remote changes

### DIFF
--- a/salt/modules/git.py
+++ b/salt/modules/git.py
@@ -2140,13 +2140,9 @@ def discard_local_changes(cwd,
         Windows only. Required when specifying ``user``. This parameter will be
         ignored on non-Windows platforms.
 
-      .. versionadded:: 2016.3.4
-
     ignore_retcode : False
         If ``True``, do not log an error to the minion log if the git command
         returns a nonzero exit status.
-
-        .. versionadded:: 2015.8.0
 
     output_encoding
         Use this option to specify which encoding to use to decode the output
@@ -2154,23 +2150,9 @@ def discard_local_changes(cwd,
         cases.
 
         .. note::
-
-            On Windows, this option works slightly differently in the git state
-            and execution module than it does in the :mod:`"cmd" execution
-            module <salt.modules.cmdmod>`. The filenames in most git
-            repositories are created using a UTF-8 locale, and the system
-            encoding on Windows (CP1252) will successfully (but incorrectly)
-            decode many UTF-8 characters. This makes interacting with
-            repositories containing UTF-8 filenames on Windows unreliable.
-            Therefore, Windows will default to decoding the output from git
-            commands using UTF-8 unless this option is explicitly used to
-            specify the encoding.
-
-            On non-Windows platforms, the default output decoding behavior will
-            be observed (i.e. the encoding specified by the locale will be
-            tried first, and if that fails, UTF-8 will be used as a fallback).
-
-        .. versionadded:: 2018.3.1
+            This should only be needed if the files in the repository were
+            created with filenames using an encoding other than UTF-8 to handle
+            Unicode characters.
 
     CLI Example:
 

--- a/salt/modules/git.py
+++ b/salt/modules/git.py
@@ -2115,6 +2115,82 @@ def diff(cwd,
                     output_encoding=output_encoding)['stdout']
 
 
+def discard_local_changes(cwd,
+                          path='.',
+                          user=None,
+                          password=None,
+                          ignore_retcode=False,
+                          output_encoding=None):
+    '''
+    .. versionadded:: Fluorine
+
+    Runs a ``git checkout -- <path>`` from the directory specified by ``cwd``.
+
+    cwd
+        The path to the git checkout
+
+    path
+        path relative to cwd (defaults to ``.``)
+
+    user
+        User under which to run the git command. By default, the command is run
+        by the user under which the minion is running.
+
+    password
+        Windows only. Required when specifying ``user``. This parameter will be
+        ignored on non-Windows platforms.
+
+      .. versionadded:: 2016.3.4
+
+    ignore_retcode : False
+        If ``True``, do not log an error to the minion log if the git command
+        returns a nonzero exit status.
+
+        .. versionadded:: 2015.8.0
+
+    output_encoding
+        Use this option to specify which encoding to use to decode the output
+        from any git commands which are run. This should not be needed in most
+        cases.
+
+        .. note::
+
+            On Windows, this option works slightly differently in the git state
+            and execution module than it does in the :mod:`"cmd" execution
+            module <salt.modules.cmdmod>`. The filenames in most git
+            repositories are created using a UTF-8 locale, and the system
+            encoding on Windows (CP1252) will successfully (but incorrectly)
+            decode many UTF-8 characters. This makes interacting with
+            repositories containing UTF-8 filenames on Windows unreliable.
+            Therefore, Windows will default to decoding the output from git
+            commands using UTF-8 unless this option is explicitly used to
+            specify the encoding.
+
+            On non-Windows platforms, the default output decoding behavior will
+            be observed (i.e. the encoding specified by the locale will be
+            tried first, and if that fails, UTF-8 will be used as a fallback).
+
+        .. versionadded:: 2018.3.1
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion git.discard_local_changes /path/to/repo
+        salt myminion git.discard_local_changes /path/to/repo path=foo
+    '''
+    cwd = _expand_path(cwd, user)
+    command = ['git', 'checkout', '--', path]
+    # Checkout message goes to stderr
+    return _git_run(command,
+                    cwd=cwd,
+                    user=user,
+                    password=password,
+                    ignore_retcode=ignore_retcode,
+                    redirect_stderr=True,
+                    output_encoding=output_encoding)['stdout']
+
+
 def fetch(cwd,
           remote=None,
           force=False,

--- a/salt/states/git.py
+++ b/salt/states/git.py
@@ -152,8 +152,10 @@ def _strip_exc(exc):
 def _uptodate(ret, target, comments=None, local_changes=False):
     ret['comment'] = 'Repository {0} is up-to-date'.format(target)
     if local_changes:
-        ret['comment'] += ', but with local changes. Set \'force_reset\' to ' \
-                          'True to purge local changes.'
+        ret['comment'] += (
+            ', but with uncommitted changes. Set \'force_reset\' to True to '
+            'purge uncommitted changes.'
+        )
     if comments:
         # Shouldn't be making any changes if the repo was up to date, but
         # report on them so we are alerted to potential problems with our
@@ -223,7 +225,7 @@ def _not_fast_forward(ret, rev, pre, post, branch, local_branch,
     return _fail(
         ret,
         'Repository would be updated {0}{1}, but {2}. Set \'force_reset\' to '
-        'True to force this update{3}.{4}'.format(
+        'True{3} to force this update{4}.{5}'.format(
             'from {0} to {1}'.format(pre, post)
                 if local_changes and pre != post
                 else 'to {0}'.format(post),
@@ -233,6 +235,7 @@ def _not_fast_forward(ret, rev, pre, post, branch, local_branch,
             'this is not a fast-forward merge'
                 if not local_changes
                 else 'there are uncommitted changes',
+            ' (or \'remote-changes\')' if local_changes else '',
             ' and discard these changes' if local_changes else '',
             branch_msg,
         ),
@@ -420,6 +423,11 @@ def latest(name,
         If the update is not a fast-forward, this state will fail. Set this
         argument to ``True`` to force a hard-reset to the remote revision in
         these cases.
+
+        .. versionchanged:: Fluorine
+            This option can now be set to ``remote-changes``, which will
+            instruct Salt not to discard local changes if the repo is
+            up-to-date with the remote repository.
 
     submodules : False
         Update submodules on clone or branch change
@@ -620,6 +628,12 @@ def latest(name,
         return _fail(
             ret,
             '\'{0}\' is not a valid value for the \'rev\' argument'.format(rev)
+        )
+
+    if force_reset not in (True, False, 'remote-changes'):
+        return _fail(
+            ret,
+            '\'force_reset\' must be one of True, False, or \'remote-changes\''
         )
 
     # Ensure that certain arguments are strings to ensure that comparisons work
@@ -936,11 +950,13 @@ def latest(name,
                 local_changes = False
 
             if local_changes and revs_match:
-                if force_reset:
+                if force_reset is True:
                     msg = (
-                        '{0} is up-to-date, but with local changes. Since '
-                        '\'force_reset\' is enabled, these local changes '
-                        'would be reset.'.format(target)
+                        '{0} is up-to-date, but with uncommitted changes. '
+                        'Since \'force_reset\' is set to True, these local '
+                        'changes would be reset. To only reset when there are '
+                        'changes in the remote repository, set '
+                        '\'force_reset\' to \'remote-changes\'.'.format(target)
                     )
                     if __opts__['test']:
                         ret['changes']['forced update'] = True
@@ -950,9 +966,9 @@ def latest(name,
                     log.debug(msg.replace('would', 'will'))
                 else:
                     log.debug(
-                        '%s up-to-date, but with local changes. Since '
-                        '\'force_reset\' is disabled, no changes will be '
-                        'made.', target
+                        '%s up-to-date, but with uncommitted changes. Since '
+                        '\'force_reset\' is set to %s, no changes will be '
+                        'made.', target, force_reset
                     )
                     return _uptodate(ret,
                                      target,
@@ -1054,20 +1070,23 @@ def latest(name,
                         elif remote_rev_type == 'sha1':
                             has_remote_rev = True
 
-            # If fast_forward is not boolean, then we don't know if this will
-            # be a fast forward or not, because a fetch is required.
-            fast_forward = None if not local_changes else False
+            # If fast_forward is not boolean, then we don't yet know if this
+            # will be a fast forward or not, because a fetch is required.
+            fast_forward = False \
+                if (local_changes and force_reset != 'remote-changes') \
+                else None
 
             if has_remote_rev:
                 if (not revs_match and not update_head) \
                         and (branch is None or branch == local_branch):
-                    ret['comment'] = remote_loc.capitalize() \
-                        if rev == 'HEAD' \
-                        else remote_loc
-                    ret['comment'] += (
-                        ' is already present and local HEAD ({0}) does not '
+                    ret['comment'] = (
+                        '{0} is already present and local HEAD ({1}) does not '
                         'match, but update_head=False. HEAD has not been '
-                        'updated locally.'.format(local_rev[:7])
+                        'updated locally.'.format(
+                            remote_loc.capitalize() if rev == 'HEAD'
+                                else remote_loc,
+                            local_rev[:7]
+                        )
                     )
                     return ret
 
@@ -1081,9 +1100,8 @@ def latest(name,
                         # existed there and a remote was added and fetched, but
                         # the repository was not fast-forwarded. Regardless,
                         # going from no HEAD to a locally-present rev is
-                        # considered a fast-forward update, unless there are
-                        # local changes.
-                        fast_forward = not bool(local_changes)
+                        # considered a fast-forward update.
+                        fast_forward = True
                     else:
                         fast_forward = __salt__['git.merge_base'](
                             target,
@@ -1095,7 +1113,7 @@ def latest(name,
                             output_encoding=output_encoding)
 
             if fast_forward is False:
-                if not force_reset:
+                if force_reset is False:
                     return _not_fast_forward(
                         ret,
                         rev,
@@ -1439,7 +1457,10 @@ def latest(name,
                             password=password,
                             output_encoding=output_encoding)
 
-                    if fast_forward is False and not force_reset:
+                    if fast_forward is force_reset is False \
+                            or (fast_forward is True
+                                and local_changes
+                                and force_reset is False):
                         return _not_fast_forward(
                             ret,
                             rev,
@@ -1495,9 +1516,6 @@ def latest(name,
                             '\'{0}\' was checked out'.format(checkout_rev)
                         )
 
-                if local_changes:
-                    comments.append('Local changes were discarded')
-
                 if fast_forward is False:
                     __salt__['git.reset'](
                         target,
@@ -1506,9 +1524,20 @@ def latest(name,
                         password=password,
                         output_encoding=output_encoding)
                     ret['changes']['forced update'] = True
+                    if local_changes:
+                        comments.append('Uncommitted changes were discarded')
                     comments.append(
                         'Repository was hard-reset to {0}'.format(remote_loc)
                     )
+                elif fast_forward is True \
+                        and local_changes \
+                        and force_reset is not False:
+                    __salt__['git.discard_local_changes'](
+                        target,
+                        user=user,
+                        password=password,
+                        output_encoding=output_encoding)
+                    comments.append('Uncommitted changes were discarded')
 
                 if branch_opts is not None:
                     __salt__['git.branch'](

--- a/tests/integration/states/test_git.py
+++ b/tests/integration/states/test_git.py
@@ -244,8 +244,9 @@ class GitTest(ModuleCase, SaltReturnAssertsMixin):
             self.assertSaltTrueReturn(ret)
             self.assertEqual(
                 ret[next(iter(ret))]['comment'],
-                ('Repository {0} is up-to-date, but with local changes. Set '
-                 '\'force_reset\' to True to purge local changes.'.format(name))
+                ('Repository {0} is up-to-date, but with uncommitted changes. '
+                 'Set \'force_reset\' to True to purge uncommitted changes.'
+                 .format(name))
             )
 
             # Now run the state with force_reset=True
@@ -560,43 +561,228 @@ class LocalRepoGitTest(ModuleCase, SaltReturnAssertsMixin):
     '''
     Tests which do no require connectivity to github.com
     '''
+    def setUp(self):
+        self.repo = tempfile.mkdtemp(dir=TMP)
+        self.admin = tempfile.mkdtemp(dir=TMP)
+        self.target = tempfile.mkdtemp(dir=TMP)
+        for dirname in (self.repo, self.admin, self.target):
+            self.addCleanup(shutil.rmtree, dirname, ignore_errors=True)
+
+        # Create bare repo
+        self.run_function('git.init', [self.repo], bare=True)
+        # Clone bare repo
+        self.run_function('git.clone', [self.admin], url=self.repo)
+        self._commit(self.admin, '', message='initial commit')
+        self._push(self.admin)
+
+    def _commit(self, repo_path, content, message):
+        with salt.utils.files.fopen(os.path.join(repo_path, 'foo'), 'a') as fp_:
+            fp_.write(content)
+        self.run_function('git.add', [repo_path, '.'])
+        self.run_function(
+            'git.commit', [repo_path, message],
+            git_opts='-c user.name="Foo Bar" -c user.email=foo@bar.com',
+        )
+
+    def _push(self, repo_path, remote='origin', ref='master'):
+        self.run_function('git.push', [repo_path], remote=remote, ref=ref)
+
+    def _test_latest_force_reset_setup(self):
+        # Perform the initial clone
+        ret = self.run_state(
+            'git.latest',
+            name=self.repo,
+            target=self.target)
+        self.assertSaltTrueReturn(ret)
+
+        # Make and push changes to remote repo
+        self._commit(self.admin,
+                     content='Hello world!\n',
+                     message='added a line')
+        self._push(self.admin)
+
+        # Make local changes to clone, but don't commit them
+        with salt.utils.files.fopen(os.path.join(self.target, 'foo'), 'a') as fp_:
+            fp_.write('Local changes!\n')
+
+    def test_latest_force_reset_remote_changes(self):
+        '''
+        This tests that an otherwise fast-forward change with local chanegs
+        will not reset local changes when force_reset='remote_changes'
+        '''
+        self._test_latest_force_reset_setup()
+
+        # This should fail because of the local changes
+        ret = self.run_state(
+            'git.latest',
+            name=self.repo,
+            target=self.target)
+        self.assertSaltFalseReturn(ret)
+        ret = ret[next(iter(ret))]
+        self.assertIn('there are uncommitted changes', ret['comment'])
+        self.assertIn(
+            'Set \'force_reset\' to True (or \'remote-changes\')',
+            ret['comment']
+        )
+        self.assertEqual(ret['changes'], {})
+
+        # Now run again with force_reset='remote_changes', the state should
+        # succeed and discard the local changes
+        ret = self.run_state(
+            'git.latest',
+            name=self.repo,
+            target=self.target,
+            force_reset='remote-changes')
+        self.assertSaltTrueReturn(ret)
+        ret = ret[next(iter(ret))]
+        self.assertIn('Uncommitted changes were discarded', ret['comment'])
+        self.assertIn('Repository was fast-forwarded', ret['comment'])
+        self.assertNotIn('forced update', ret['changes'])
+        self.assertIn('revision', ret['changes'])
+
+        # Add new local changes, but don't commit them
+        with salt.utils.files.fopen(os.path.join(self.target, 'foo'), 'a') as fp_:
+            fp_.write('More local changes!\n')
+
+        # Now run again with force_reset='remote_changes', the state should
+        # succeed with an up-to-date message and mention that there are local
+        # changes, telling the user how to discard them.
+        ret = self.run_state(
+            'git.latest',
+            name=self.repo,
+            target=self.target,
+            force_reset='remote-changes')
+        self.assertSaltTrueReturn(ret)
+        ret = ret[next(iter(ret))]
+        self.assertIn('up-to-date, but with uncommitted changes', ret['comment'])
+        self.assertIn(
+            'Set \'force_reset\' to True to purge uncommitted changes',
+            ret['comment']
+        )
+        self.assertEqual(ret['changes'], {})
+
+    def test_latest_force_reset_true_fast_forward(self):
+        '''
+        This tests that an otherwise fast-forward change with local chanegs
+        does reset local changes when force_reset=True
+        '''
+        self._test_latest_force_reset_setup()
+
+        # Test that local changes are discarded and that we fast-forward
+        ret = self.run_state(
+            'git.latest',
+            name=self.repo,
+            target=self.target,
+            force_reset=True)
+        self.assertSaltTrueReturn(ret)
+        ret = ret[next(iter(ret))]
+        self.assertIn('Uncommitted changes were discarded', ret['comment'])
+        self.assertIn('Repository was fast-forwarded', ret['comment'])
+
+        # Add new local changes
+        with salt.utils.files.fopen(os.path.join(self.target, 'foo'), 'a') as fp_:
+            fp_.write('More local changes!\n')
+
+        # Running without setting force_reset should mention uncommitted changes
+        ret = self.run_state(
+            'git.latest',
+            name=self.repo,
+            target=self.target)
+        self.assertSaltTrueReturn(ret)
+        ret = ret[next(iter(ret))]
+        self.assertIn('up-to-date, but with uncommitted changes', ret['comment'])
+        self.assertIn(
+            'Set \'force_reset\' to True to purge uncommitted changes',
+            ret['comment']
+        )
+        self.assertEqual(ret['changes'], {})
+
+        # Test that local changes are discarded
+        ret = self.run_state(
+            'git.latest',
+            name=self.repo,
+            target=self.target,
+            force_reset=True)
+        self.assertSaltTrueReturn(ret)
+        ret = ret[next(iter(ret))]
+        self.assertIn('Uncommitted changes were discarded', ret['comment'])
+        self.assertIn('Repository was hard-reset', ret['comment'])
+        self.assertIn('forced update', ret['changes'])
+
+    def test_latest_force_reset_true_non_fast_forward(self):
+        '''
+        This tests that a non fast-forward change with divergent commits fails
+        unless force_reset=True.
+        '''
+        self._test_latest_force_reset_setup()
+
+        # Reset to remote HEAD
+        ret = self.run_state(
+            'git.latest',
+            name=self.repo,
+            target=self.target,
+            force_reset=True)
+        self.assertSaltTrueReturn(ret)
+        ret = ret[next(iter(ret))]
+        self.assertIn('Uncommitted changes were discarded', ret['comment'])
+        self.assertIn('Repository was fast-forwarded', ret['comment'])
+
+        # Make and push changes to remote repo
+        self._commit(self.admin,
+                     content='New line\n',
+                     message='added another line')
+        self._push(self.admin)
+
+        # Make different changes to local file and commit locally
+        self._commit(self.target,
+                     content='Different new line\n',
+                     message='added a different line')
+
+        # This should fail since the local clone has diverged and cannot
+        # fast-forward to the remote rev
+        ret = self.run_state(
+            'git.latest',
+            name=self.repo,
+            target=self.target)
+        self.assertSaltFalseReturn(ret)
+        ret = ret[next(iter(ret))]
+        self.assertIn('this is not a fast-forward merge', ret['comment'])
+        self.assertIn(
+            'Set \'force_reset\' to True to force this update',
+            ret['comment']
+        )
+        self.assertEqual(ret['changes'], {})
+
+        # Repeat the state with force_reset=True and confirm that the hard
+        # reset was performed
+        ret = self.run_state(
+            'git.latest',
+            name=self.repo,
+            target=self.target,
+            force_reset=True)
+        self.assertSaltTrueReturn(ret)
+        ret = ret[next(iter(ret))]
+        self.assertIn('Repository was hard-reset', ret['comment'])
+        self.assertIn('forced update', ret['changes'])
+        self.assertIn('revision', ret['changes'])
+
     def test_renamed_default_branch(self):
         '''
         Test the case where the remote branch has been removed
         https://github.com/saltstack/salt/issues/36242
         '''
-        repo = tempfile.mkdtemp(dir=TMP)
-        admin = tempfile.mkdtemp(dir=TMP)
-        name = tempfile.mkdtemp(dir=TMP)
-        for dirname in (repo, admin, name):
-            self.addCleanup(shutil.rmtree, dirname, ignore_errors=True)
-
-        # Create bare repo
-        self.run_function('git.init', [repo], bare=True)
-        # Clone bare repo
-        self.run_function('git.clone', [admin], url=repo)
-        # Create, add, commit, and push file
-        with salt.utils.files.fopen(os.path.join(admin, 'foo'), 'w'):
-            pass
-        self.run_function('git.add', [admin, '.'])
-        self.run_function(
-            'git.commit', [admin, 'initial commit'],
-            git_opts='-c user.name="Foo Bar" -c user.email=foo@bar.com',
-        )
-        self.run_function('git.push', [admin], remote='origin', ref='master')
-
         # Rename remote 'master' branch to 'develop'
         os.rename(
-            os.path.join(repo, 'refs', 'heads', 'master'),
-            os.path.join(repo, 'refs', 'heads', 'develop')
+            os.path.join(self.repo, 'refs', 'heads', 'master'),
+            os.path.join(self.repo, 'refs', 'heads', 'develop')
         )
 
         # Run git.latest state. This should successfully clone and fail with a
         # specific error in the comment field.
         ret = self.run_state(
             'git.latest',
-            name=repo,
-            target=name,
+            name=self.repo,
+            target=self.target,
             rev='develop',
         )
         self.assertSaltFalseReturn(ret)
@@ -610,19 +796,19 @@ class LocalRepoGitTest(ModuleCase, SaltReturnAssertsMixin):
             '(which will ensure that the named branch is created '
             'if it does not already exist).\n\n'
             'Changes already made: {0} cloned to {1}'
-            .format(repo, name)
+            .format(self.repo, self.target)
         )
         self.assertEqual(
             ret[next(iter(ret))]['changes'],
-            {'new': '{0} => {1}'.format(repo, name)}
+            {'new': '{0} => {1}'.format(self.repo, self.target)}
         )
 
         # Run git.latest state again. This should fail again, with a different
         # error in the comment field, and should not change anything.
         ret = self.run_state(
             'git.latest',
-            name=repo,
-            target=name,
+            name=self.repo,
+            target=self.target,
             rev='develop',
         )
         self.assertSaltFalseReturn(ret)
@@ -643,8 +829,8 @@ class LocalRepoGitTest(ModuleCase, SaltReturnAssertsMixin):
         # checkout a new branch and the state should pass.
         ret = self.run_state(
             'git.latest',
-            name=repo,
-            target=name,
+            name=self.repo,
+            target=self.target,
             rev='develop',
             branch='develop',
         )


### PR DESCRIPTION
This adds a third potential value for the `force_reset` argument, `'remote-changes'` which if used will not discard uncommitted changes unless the local clone is not up-to-date with the remote repository.

Resolves #35888.