### PR TITLE
Backport string arg normalization to 2017.7 branch

### DIFF
--- a/salt/log/setup.py
+++ b/salt/log/setup.py
@@ -337,15 +337,16 @@ class SaltLoggingClass(six.with_metaclass(LoggingMixInMeta, LOGGING_LOGGER_CLASS
             # If nothing else is in extra, make it None
             extra = None
 
+        salt_system_encoding = __salt_system_encoding__
+        if salt_system_encoding == 'ascii':
+            # Encoding detection most likely failed, let's use the utf-8
+            # value which we defaulted before __salt_system_encoding__ was
+            # implemented
+            salt_system_encoding = 'utf-8'
+
         # Let's try to make every logging message unicode
         if isinstance(msg, six.string_types) \
                 and not isinstance(msg, six.text_type):
-            salt_system_encoding = __salt_system_encoding__
-            if salt_system_encoding == 'ascii':
-                # Encoding detection most likely failed, let's use the utf-8
-                # value which we defaulted before __salt_system_encoding__ was
-                # implemented
-                salt_system_encoding = 'utf-8'
             try:
                 _msg = msg.decode(salt_system_encoding, 'replace')
             except UnicodeDecodeError:
@@ -353,11 +354,23 @@ class SaltLoggingClass(six.with_metaclass(LoggingMixInMeta, LOGGING_LOGGER_CLASS
         else:
             _msg = msg
 
+        _args = []
+        for item in args:
+            if isinstance(item, six.string_types) \
+                    and not isinstance(item, six.text_type):
+                try:
+                    _args.append(item.decode(salt_system_encoding, 'replace'))
+                except UnicodeDecodeError:
+                    _args.append(item.decode(salt_system_encoding, 'ignore'))
+            else:
+                _args.append(item)
+        _args = tuple(_args)
+
         if six.PY3:
-            logrecord = _LOG_RECORD_FACTORY(name, level, fn, lno, _msg, args,
+            logrecord = _LOG_RECORD_FACTORY(name, level, fn, lno, _msg, _args,
                                             exc_info, func, sinfo)
         else:
-            logrecord = _LOG_RECORD_FACTORY(name, level, fn, lno, _msg, args,
+            logrecord = _LOG_RECORD_FACTORY(name, level, fn, lno, _msg, _args,
                                             exc_info, func)
 
         if extra is not None:


### PR DESCRIPTION
Prior to 2018.3 we were normalizing the format string to unicode but not the args. This means that even when a non-unicode format string was used, a str argument containing utf8-encoded non-ascii chars would result in a traceback.

This backports the arg normalization from 2018.3 to to 2017.7 to ensure that these sort of cases do not cause errors in logging.