### PR TITLE
Add support to skip checking if DB exists in mysql_query

### DIFF
--- a/salt/states/mysql_query.py
+++ b/salt/states/mysql_query.py
@@ -57,6 +57,7 @@ def run_file(name,
         grain=None,
         key=None,
         overwrite=True,
+        check_db_exists=True,
         **connection_args):
     '''
     Execute an arbitrary query on the specified database
@@ -85,6 +86,10 @@ def run_file(name,
     overwrite:
         The file or grain will be overwritten if it already exists (default)
 
+    check_db_exists:
+        The state run will check that the specified database exists (default=True)
+        before running any queries
+
     .. versionadded:: 2017.7.0
     '''
     ret = {'name': name,
@@ -98,7 +103,7 @@ def run_file(name,
         return ret
 
     # check if database exists
-    if not __salt__['mysql.db_exists'](database, **connection_args):
+    if check_db_exists and not __salt__['mysql.db_exists'](database, **connection_args):
         err = _get_mysql_error()
         if err is not None:
             ret['comment'] = err
@@ -216,6 +221,7 @@ def run(name,
         grain=None,
         key=None,
         overwrite=True,
+        check_db_exists=False,
         **connection_args):
     '''
     Execute an arbitrary query on the specified database
@@ -243,13 +249,17 @@ def run(name,
 
     overwrite:
         The file or grain will be overwritten if it already exists (default)
+
+    check_db_exists:
+        The state run will check that the specified database exists (default=True)
+        before running any queries
     '''
     ret = {'name': name,
            'changes': {},
            'result': True,
            'comment': 'Database {0} is already present'.format(database)}
     # check if database exists
-    if not __salt__['mysql.db_exists'](database, **connection_args):
+    if check_db_exists and not __salt__['mysql.db_exists'](database, **connection_args):
         err = _get_mysql_error()
         if err is not None:
             ret['comment'] = err


### PR DESCRIPTION
### What does this PR do?
- Some database servers do not support the command used, and instead
  of changing the command we can just skip that check altogether.
- For example, ProxySQL's admin interface has a SHOW DATABASES command
  but not SHOW DATABASES LIKE x.

### What issues does this PR fix or reference?

### Previous Behavior
`mysql_query.run` and `mysql_query.run_file` checked that the database selected for the query exists

### New Behavior
`mysql_query.run` and `mysql_query.run_file` can take a boolean flag `check_db_exists`, which defaults to `True`, to disable the `db_exists` check for each state

### Tests written?

No

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
