### PR TITLE
Fixes sdb etcd get

### DIFF
--- a/salt/sdb/etcd_db.py
+++ b/salt/sdb/etcd_db.py
@@ -74,7 +74,7 @@ def get(key, service=None, profile=None):  # pylint: disable=W0613
     '''
     client = _get_conn(profile)
     result = client.get(key)
-    return result.value
+    return result
 
 
 def _get_conn(profile):


### PR DESCRIPTION
Fixes #40851

### What does this PR do?
Fixes sdb etcd get error

### What issues does this PR fix or reference?
 #40851

### Previous Behavior
```
# salt-run sdb.get 'sdb://etcd/mtest'
...
  File "/usr/lib/python2.7/dist-packages/salt/sdb/etcd_db.py", line 78, in get
    return result.value
AttributeError: 'NoneType' object has no attribute 'value'
```

### New Behavior
```
# salt-run sdb.get 'sdb://etcd/mtest'
test
```

### Tests written?

No

### Commits signed with GPG?

No


Not sure if this breakes something else but it is a very small change and easy to test by others. Please see linked issue for more info.
