### PR TITLE
pull latest vm data after building for openstack shade driver

### DIFF
--- a/salt/cloud/clouds/openstack.py
+++ b/salt/cloud/clouds/openstack.py
@@ -689,11 +689,11 @@ def create(vm_):
                     __opts__
                 )
             )
-        data = show_instance(vm_['instance_id'], conn=conn, call='action')
     else:
         # Put together all of the information required to request the instance,
         # and then fire off the request for it
-        data = request_instance(conn=conn, call='action', vm_=vm_)
+        request_instance(conn=conn, call='action', vm_=vm_)
+    data = show_instance(vm_.get('instance_id', vm_['name']), conn=conn, call='action')
     log.debug('VM is now running')
 
     def __query_node(vm_):


### PR DESCRIPTION
### What issues does this PR fix or reference?
Fixes #46659

### Previous Behavior
Shade returns the initial query of the instance before attaching the ip addresses.

### New Behavior
We request the newest information about the instance, once all of the attaching jobs have finished

### Tests written?

No

### Commits signed with GPG?

Yes