### PR TITLE
Fix libvirt_events engine running on master

### DIFF
--- a/salt/engines/libvirt_events.py
+++ b/salt/engines/libvirt_events.py
@@ -32,7 +32,7 @@ network events have been added in libvirt 1.2.1.
 Running the engine on non-root
 ------------------------------
 
-Running this engine as non root requires a special attention, which is surely
+Running this engine as non-root requires a special attention, which is surely
 the case for the master running as user `salt`. The engine is likely to fail
 to connect to libvirt with an error like this one:
 


### PR DESCRIPTION
### What does this PR do?

Parameters order is different when firing events on master or minion.
The order for master was wrong. Also added documentation on how to setup
polkit to run the engine on a master node.

### What issues does this PR fix or reference?

None reported

### Previous Behavior

Error when firing libvirt events when running on master node

### New Behavior

Libvirt events sent on master node as well

### Tests written?

No - trivial fix

### Commits signed with GPG?

Yes