### PR TITLE
Only very recent zfs support parsable output

### DIFF
--- a/salt/grains/zfs.py
+++ b/salt/grains/zfs.py
@@ -57,14 +57,14 @@ def _zfs_pool_data():
     # collect zpool data
     zpool_list_cmd = __utils__['zfs.zpool_command'](
         'list',
-        flags=['-H', '-p'],
+        flags=['-H'],
         opts={'-o': 'name,size'},
     )
     for zpool in __salt__['cmd.run'](zpool_list_cmd).splitlines():
         if 'zpool' not in grains:
             grains['zpool'] = {}
         zpool = zpool.split()
-        grains['zpool'][zpool[0]] = __utils__['zfs.to_size'](zpool[1], True)
+        grains['zpool'][zpool[0]] = __utils__['zfs.to_size'](zpool[1], False)
 
     # return grain data
     return grains

--- a/salt/modules/zfs.py
+++ b/salt/modules/zfs.py
@@ -322,7 +322,7 @@ def list_(name=None, **kwargs):
 
     ## Configure command
     # NOTE: initialize the defaults
-    flags = ['-H', '-p']
+    flags = ['-H']
     opts = {}
 
     # NOTE: set extra config from kwargs
@@ -1198,7 +1198,7 @@ def get(*dataset, **kwargs):
     '''
     ## Configure command
     # NOTE: initialize the defaults
-    flags = ['-H', '-p']
+    flags = ['-H']
     opts = {}
 
     # NOTE: set extra config from kwargs

--- a/salt/modules/zpool.py
+++ b/salt/modules/zpool.py
@@ -405,7 +405,7 @@ def list_(properties='size,alloc,free,cap,frag,health', zpool=None, parsable=Tru
     res = __salt__['cmd.run_all'](
         __utils__['zfs.zpool_command'](
             command='list',
-            flags=['-H', '-p'],
+            flags=['-H'],
             opts={'-o': ','.join(properties)},
             target=zpool
         ),
@@ -476,7 +476,7 @@ def get(zpool, prop=None, show_source=False, parsable=True):
     res = __salt__['cmd.run_all'](
         __utils__['zfs.zpool_command'](
             command='get',
-            flags=['-H', '-p'],
+            flags=['-H'],
             opts={'-o': ','.join(value_properties)},
             property_name=prop if prop else 'all',
             target=zpool,

--- a/tests/unit/modules/test_zfs.py
+++ b/tests/unit/modules/test_zfs.py
@@ -304,15 +304,15 @@ class ZfsTestCase(TestCase, LoaderModuleMockMixin):
         '''
         res = OrderedDict([
             ('myzpool', OrderedDict([
-                ('used', 905792561152),
-                ('avail', 1024795238400),
+                ('used', 849329782784),
+                ('avail', 1081258016768),
                 ('refer', 98304),
                 ('mountpoint', '/myzpool'),
             ])),
         ])
         ret = {}
         ret['retcode'] = 0
-        ret['stdout'] = 'myzpool\t905792561152\t1024795238400\t98304\t/myzpool'
+        ret['stdout'] = 'myzpool\t791G\t1007G\t96K\t/myzpool'
         ret['stderr'] = ''
         mock_cmd = MagicMock(return_value=ret)
         with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
@@ -325,15 +325,15 @@ class ZfsTestCase(TestCase, LoaderModuleMockMixin):
         '''
         res = OrderedDict([
             ('myzpool', OrderedDict([
-                ('used', '844G'),
-                ('avail', '954G'),
+                ('used', '791G'),
+                ('avail', '1007G'),
                 ('refer', '96K'),
                 ('mountpoint', '/myzpool'),
             ])),
         ])
         ret = {}
         ret['retcode'] = 0
-        ret['stdout'] = 'myzpool\t905792561152\t1024795238400\t98304\t/myzpool'
+        ret['stdout'] = 'myzpool\t791G\t1007G\t96K\t/myzpool'
         ret['stderr'] = ''
         mock_cmd = MagicMock(return_value=ret)
         with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
@@ -347,14 +347,14 @@ class ZfsTestCase(TestCase, LoaderModuleMockMixin):
         res = OrderedDict([
             ('myzpool', OrderedDict([
                 ('canmount', True),
-                ('used', 834786304),
-                ('avail', 87502848),
+                ('used', 849329782784),
+                ('avail', 1081258016768),
                 ('compression', False),
             ])),
         ])
         ret = {}
         ret['retcode'] = 0
-        ret['stdout'] = 'myzpool\ton\t834786304\t87502848\toff'
+        ret['stdout'] = 'myzpool\ton\t791G\t1007G\toff'
         ret['stderr'] = ''
         mock_cmd = MagicMock(return_value=ret)
         with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \
@@ -368,14 +368,14 @@ class ZfsTestCase(TestCase, LoaderModuleMockMixin):
         res = OrderedDict([
             ('myzpool', OrderedDict([
                 ('canmount', 'on'),
-                ('used', '796M'),
-                ('avail', '83.4M'),
+                ('used', '791G'),
+                ('avail', '1007G'),
                 ('compression', 'off'),
             ])),
         ])
         ret = {}
         ret['retcode'] = 0
-        ret['stdout'] = 'myzpool\ton\t834786304\t87502848\toff'
+        ret['stdout'] = 'myzpool\ton\t791G\t1007G\toff'
         ret['stderr'] = ''
         mock_cmd = MagicMock(return_value=ret)
         with patch.dict(zfs.__salt__, {'cmd.run_all': mock_cmd}), \

--- a/tests/unit/modules/test_zpool.py
+++ b/tests/unit/modules/test_zpool.py
@@ -179,7 +179,7 @@ class ZpoolTestCase(TestCase, LoaderModuleMockMixin):
         Tests successful return of list function
         '''
         ret = {}
-        ret['stdout'] = "mypool\t1992864825344\t767076794368\t1225788030976\t38\t0%\tONLINE"
+        ret['stdout'] = "mypool\t1.81T\t661G\t1.17T\t35%\t11%\tONLINE"
         ret['stderr'] = ""
         ret['retcode'] = 0
         mock_cmd = MagicMock(return_value=ret)
@@ -188,10 +188,10 @@ class ZpoolTestCase(TestCase, LoaderModuleMockMixin):
             ret = zpool.list_(parsable=False)
             res = OrderedDict([('mypool', OrderedDict([
                 ('size', '1.81T'),
-                ('alloc', '714G'),
-                ('free', '1.11T'),
-                ('cap', 38),
-                ('frag', '0%'),
+                ('alloc', '661G'),
+                ('free', '1.17T'),
+                ('cap', '35%'),
+                ('frag', '11%'),
                 ('health', 'ONLINE'),
             ]))])
             self.assertEqual(ret, res)
@@ -201,7 +201,7 @@ class ZpoolTestCase(TestCase, LoaderModuleMockMixin):
         Tests successful return of list function with parsable output
         '''
         ret = {}
-        ret['stdout'] = "mypool\t1992864825344\t767076794368\t1225788030976\t38\t0%\tONLINE"
+        ret['stdout'] = "mypool\t1.81T\t661G\t1.17T\t35%\t11%\tONLINE"
         ret['stderr'] = ""
         ret['retcode'] = 0
         mock_cmd = MagicMock(return_value=ret)
@@ -209,11 +209,11 @@ class ZpoolTestCase(TestCase, LoaderModuleMockMixin):
                 patch.dict(zpool.__utils__, utils_patch):
             ret = zpool.list_(parsable=True)
             res = OrderedDict([('mypool', OrderedDict([
-                ('size', 1992864825344),
-                ('alloc', 767076794368),
-                ('free', 1225788030976),
-                ('cap', 38),
-                ('frag', '0%'),
+                ('size', 1990116046274),
+                ('alloc', 709743345664),
+                ('free', 1286428604497),
+                ('cap', '35%'),
+                ('frag', '11%'),
                 ('health', 'ONLINE'),
             ]))])
             self.assertEqual(ret, res)
@@ -223,7 +223,7 @@ class ZpoolTestCase(TestCase, LoaderModuleMockMixin):
         Tests successful return of get function
         '''
         ret = {}
-        ret['stdout'] = "size\t1992864825344\t-\n"
+        ret['stdout'] = "size\t1.81T\t-\n"
         ret['stderr'] = ""
         ret['retcode'] = 0
         mock_cmd = MagicMock(return_value=ret)
@@ -238,14 +238,14 @@ class ZpoolTestCase(TestCase, LoaderModuleMockMixin):
         Tests successful return of get function with parsable output
         '''
         ret = {}
-        ret['stdout'] = "size\t1992864825344\t-\n"
+        ret['stdout'] = "size\t1.81T\t-\n"
         ret['stderr'] = ""
         ret['retcode'] = 0
         mock_cmd = MagicMock(return_value=ret)
         with patch.dict(zpool.__salt__, {'cmd.run_all': mock_cmd}), \
              patch.dict(zpool.__utils__, utils_patch):
             ret = zpool.get('mypool', 'size', parsable=True)
-            res = OrderedDict(OrderedDict([('size', 1992864825344)]))
+            res = OrderedDict(OrderedDict([('size', 1990116046274)]))
             self.assertEqual(ret, res)
 
     def test_get_whitespace(self):

--- a/tests/unit/utils/test_zfs.py
+++ b/tests/unit/utils/test_zfs.py
@@ -1313,11 +1313,10 @@ class ZfsUtilsTestCase(TestCase):
                     with patch.object(zfs, 'property_data_zpool', MagicMock(return_value=pmap_zpool)):
                         my_flags = [
                             '-r',  # recursive
-                            '-p',  # parsable
                         ]
                         self.assertEqual(
                             zfs.zfs_command('list', flags=my_flags),
-                            "/sbin/zfs list -r -p"
+                            "/sbin/zfs list -r"
                         )
 
     def test_zfs_command_opt(self):
@@ -1346,14 +1345,13 @@ class ZfsUtilsTestCase(TestCase):
                     with patch.object(zfs, 'property_data_zpool', MagicMock(return_value=pmap_zpool)):
                         my_flags = [
                             '-r',  # recursive
-                            '-p',  # parsable
                         ]
                         my_opts = {
                             '-t': 'snap',  # only list snapshots
                         }
                         self.assertEqual(
                             zfs.zfs_command('list', flags=my_flags, opts=my_opts),
-                            "/sbin/zfs list -r -p -t snap"
+                            "/sbin/zfs list -r -t snap"
                         )
 
     def test_zfs_command_target(self):
@@ -1366,14 +1364,13 @@ class ZfsUtilsTestCase(TestCase):
                     with patch.object(zfs, 'property_data_zpool', MagicMock(return_value=pmap_zpool)):
                         my_flags = [
                             '-r',  # recursive
-                            '-p',  # parsable
                         ]
                         my_opts = {
                             '-t': 'snap',  # only list snapshots
                         }
                         self.assertEqual(
                             zfs.zfs_command('list', flags=my_flags, opts=my_opts, target='mypool'),
-                            "/sbin/zfs list -r -p -t snap mypool"
+                            "/sbin/zfs list -r -t snap mypool"
                         )
 
     def test_zfs_command_target_with_space(self):
@@ -1386,14 +1383,13 @@ class ZfsUtilsTestCase(TestCase):
                     with patch.object(zfs, 'property_data_zpool', MagicMock(return_value=pmap_zpool)):
                         my_flags = [
                             '-r',  # recursive
-                            '-p',  # parsable
                         ]
                         my_opts = {
                             '-t': 'snap',  # only list snapshots
                         }
                         self.assertEqual(
                             zfs.zfs_command('list', flags=my_flags, opts=my_opts, target='my pool'),
-                            '/sbin/zfs list -r -p -t snap "my pool"'
+                            '/sbin/zfs list -r -t snap "my pool"'
                         )
 
     def test_zfs_command_property(self):
@@ -1531,15 +1527,12 @@ class ZfsUtilsTestCase(TestCase):
             with patch.object(zfs, '_zpool_cmd', MagicMock(return_value='/sbin/zpool')):
                 with patch.object(zfs, 'property_data_zfs', MagicMock(return_value=pmap_zfs)):
                     with patch.object(zfs, 'property_data_zpool', MagicMock(return_value=pmap_zpool)):
-                        my_flags = [
-                            '-p',  # parsable
-                        ]
                         my_opts = {
                             '-o': 'name,size',  # show only name and size
                         }
                         self.assertEqual(
-                            zfs.zpool_command('list', flags=my_flags, opts=my_opts),
-                            "/sbin/zpool list -p -o name,size"
+                            zfs.zpool_command('list', opts=my_opts),
+                            "/sbin/zpool list -o name,size"
                         )
 
     def test_zpool_command_target(self):
@@ -1550,15 +1543,12 @@ class ZfsUtilsTestCase(TestCase):
             with patch.object(zfs, '_zpool_cmd', MagicMock(return_value='/sbin/zpool')):
                 with patch.object(zfs, 'property_data_zfs', MagicMock(return_value=pmap_zfs)):
                     with patch.object(zfs, 'property_data_zpool', MagicMock(return_value=pmap_zpool)):
-                        my_flags = [
-                            '-p',  # parsable
-                        ]
                         my_opts = {
                             '-o': 'name,size',  # show only name and size
                         }
                         self.assertEqual(
-                            zfs.zpool_command('list', flags=my_flags, opts=my_opts, target='mypool'),
-                            "/sbin/zpool list -p -o name,size mypool"
+                            zfs.zpool_command('list', opts=my_opts, target='mypool'),
+                            "/sbin/zpool list -o name,size mypool"
                         )
 
     def test_zpool_command_target_with_space(self):


### PR DESCRIPTION
### What does this PR do?
~~On the latest LTS version of ubuntu there is not support for the parsable output in zfs/zpool.~~
Only recent zfs on linux supports parsable output.
We can simply strip the -p flag if we are running on this version.

It also looks like Oracle ZFS does not have the ```-p``` flag at all.

Since we now do value normalization, we can deal with not having parsable output.
However we still request parsable output when we can, as this is faster.

### What issues does this PR fix or reference?
#46903

### Previous Behavior
On older zfs on linux, zpool/zfs commands do not yet support parsable output (-p), it would fail.
Likewise for Oracle ZFS

### New behavior
We drop the ```-p``` flag.

### Tests written?
No

### Commits signed with GPG?
No