### PR TITLE
Fix at.atq support on FreeBSD. This also unbreaks at job creation with at.at.

### DIFF
--- a/salt/modules/at.py
+++ b/salt/modules/at.py
@@ -104,7 +104,7 @@ def atq(tag=None):
         if __grains__['os_family'] == 'RedHat':
             job, spec = line.split('\t')
             specs = spec.split()
-        elif __grains__['os'] in BSD:
+        elif __grains__['os'] == 'OpenBSD':
             if line.startswith(' Rank'):
                 continue
             else:
@@ -115,6 +115,17 @@ def atq(tag=None):
                     '%H:%M')[0:5])).isoformat().split('T')
                 specs.append(tmp[7])
                 specs.append(tmp[5])
+        elif __grains__['os'] == 'FreeBSD':
+            if line.startswith('Date'):
+                continue
+            else:
+                tmp = line.split()
+                timestr = ' '.join(tmp[1:6])
+                job = tmp[8]
+                specs = datetime.datetime(*(time.strptime(timestr,
+                    '%b %d %H:%M:%S %Z %Y')[0:5])).isoformat().split('T')
+                specs.append(tmp[7])
+                specs.append(tmp[6])
 
         else:
             job, spec = line.split('\t')


### PR DESCRIPTION
Fix at.atq support on FreeBSD. This also unbreaks at job creation with at.at.

Given:
```
root@minion2:~ # atq
Date                            Owner           Queue   Job#
Fri Apr  6 23:18:00 UTC 2018    root            c       4
root@minion2:~ #
```

Running at.atq on this minion will fail:
```
root@master:~ # salt 'minion2' at.atq

minion2:
    The minion function caused an exception: Traceback (most recent call last):
      File "/usr/local/lib/python3.6/site-packages/salt/minion.py", line 1493, in _thread_return
        return_data = executor.execute()
      File "/usr/local/lib/python3.6/site-packages/salt/executors/direct_call.py", line 28, in execute
        return self.func(*self.args, **self.kwargs)
      File "/usr/local/lib/python3.6/site-packages/salt/modules/at.py", line 110, in atq
        job = tmp[6]
    IndexError: list index out of range
root@master:~ #
```

This patch seems to make it work:
```
root@master:~ # salt 'minion1' at.atq

minion1:
    ----------
    jobs:
        |_
          ----------
          date:
              2018-04-06
          job:
              7
          queue:
              c
          tag:
          time:
              23:42:00
          user:
              root
root@master:~ #
```

Tested against:
```
root@minion1:~ # uname -r
11.1-RELEASE-p9
root@minion1:~ # pkg info | grep salt
py36-salt-2017.7.4_1           Distributed remote execution and configuration management system
root@minion1:~ #
```

### What does this PR do?
Fixes atq output parsing on FreeBSD.

### What issues does this PR fix or reference?
Cannot create jobs on FreeBSD via at.at
Cannot view existing jobs on FreeBSD via at.atq

### Tests written?

No

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
