### PR TITLE
[2018.3] cron.file with salt source URL

### DIFF
--- a/salt/states/cron.py
+++ b/salt/states/cron.py
@@ -606,6 +606,7 @@ def file(name,
             user,
             group,
             mode,
+            [],
             __env__,
             context,
             defaults,
@@ -634,6 +635,7 @@ def file(name,
             user,
             group,
             mode,
+            [],
             __env__,
             backup
         )
@@ -650,7 +652,7 @@ def file(name,
         if cron_ret['retcode'] == 0:
             ret['comment'] = 'Crontab for user {0} was updated'.format(user)
             ret['result'] = True
-            ret['changes'] = ret['changes']['diff']
+            ret['changes'] = ret['changes']
         else:
             ret['comment'] = 'Unable to update user {0} crontab {1}.' \
                              ' Error: {2}'.format(user, cron_path, cron_ret['stderr'])

--- a/salt/states/cron.py
+++ b/salt/states/cron.py
@@ -572,18 +572,18 @@ def file(name,
         return ret
 
     if __opts__['test']:
-        fcm = __salt__['file.check_managed'](cron_path,
-                                             source,
-                                             source_hash,
-                                             source_hash_name,
-                                             user,
-                                             group,
-                                             mode,
-                                             [],  # no special attrs for cron
-                                             template,
-                                             context,
-                                             defaults,
-                                             __env__,
+        fcm = __salt__['file.check_managed'](name=cron_path,
+                                             source=source,
+                                             source_hash=source_hash,
+                                             source_hash_name=source_hash_name,
+                                             user=user,
+                                             group=group,
+                                             mode=mode,
+                                             attrs=[],  # no special attrs for cron
+                                             template=template,
+                                             context=context,
+                                             defaults=defaults,
+                                             saltenv=__env__,
                                              **kwargs
                                              )
         ret['result'], ret['comment'] = fcm
@@ -598,19 +598,19 @@ def file(name,
     # Gather the source file from the server
     try:
         sfn, source_sum, comment = __salt__['file.get_managed'](
-            cron_path,
-            template,
-            source,
-            source_hash,
-            source_hash_name,
-            user,
-            group,
-            mode,
-            [],
-            __env__,
-            context,
-            defaults,
-            False,        # skip_verify
+            name=cron_path,
+            template=template,
+            source=source,
+            source_hash=source_hash,
+            source_hash_name=source_hash_name,
+            user=user,
+            group=group,
+            mode=mode,
+            attrs=[],
+            saltenv=__env__,
+            context=context,
+            defaults=defaults,
+            skip_verify=False,        # skip_verify
             **kwargs
         )
     except Exception as exc:
@@ -627,17 +627,17 @@ def file(name,
 
     try:
         ret = __salt__['file.manage_file'](
-            cron_path,
-            sfn,
-            ret,
-            source,
-            source_sum,
-            user,
-            group,
-            mode,
-            [],
-            __env__,
-            backup
+            name=cron_path,
+            sfn=sfn,
+            ret=ret,
+            source=source,
+            source_sum=source_sum,
+            user=user,
+            group=group,
+            mode=mode,
+            attrs=[],
+            saltenv=__env__,
+            backup=backup
         )
     except Exception as exc:
         ret['result'] = False

--- a/tests/integration/files/file/base/issue-46881/cron
+++ b/tests/integration/files/file/base/issue-46881/cron
@@ -1,0 +1,2 @@
+# Lines below here are managed by Salt, do not edit
+@hourly touch /tmp/test-file

--- a/tests/integration/states/test_cron.py
+++ b/tests/integration/states/test_cron.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+
+'''
+Tests for the cron state
+'''
+
+# Import Python libs
+from __future__ import absolute_import, print_function, unicode_literals
+import logging
+
+log = logging.getLogger(__name__)
+
+# Import Salt Testing libs
+from tests.support.case import ModuleCase
+from tests.support.unit import skipIf
+from tests.support.paths import FILES, TMP, TMP_STATE_TREE
+from tests.support.helpers import (
+    skip_if_not_root,
+    with_system_user_and_group,
+    with_tempfile,
+    Webserver,
+)
+
+
+class CronTest(ModuleCase):
+    '''
+    Validate the file state
+    '''
+    def setUp(self):
+        '''
+        Setup
+        '''
+        self.run_state('user.present', name='test_cron_user')
+
+    def tearDown(self):
+        '''
+        Teardown
+        '''
+        # Remove cron file
+        self.run_function('cmd.run',
+                          cmd='crontab -u test_cron_user -r')
+
+        # Delete user
+        self.run_state('user.absent', name='test_cron_user')
+
+    def test_managed(self):
+        '''
+        file.managed
+        '''
+        ret = self.run_state(
+            'cron.file',
+            name='salt://issue-46881/cron',
+            user='test_cron_user'
+        )
+        _expected = '--- \n+++ \n@@ -1 +1,2 @@\n-\n+# Lines below here are managed by Salt, do not edit\n+@hourly touch /tmp/test-file\n'
+        self.assertIn('changes', ret['cron_|-salt://issue-46881/cron_|-salt://issue-46881/cron_|-file'])
+        self.assertIn('diff', ret['cron_|-salt://issue-46881/cron_|-salt://issue-46881/cron_|-file']['changes'])
+        self.assertEqual(_expected, ret['cron_|-salt://issue-46881/cron_|-salt://issue-46881/cron_|-file']['changes']['diff'])

--- a/tests/integration/states/test_cron.py
+++ b/tests/integration/states/test_cron.py
@@ -13,15 +13,12 @@ log = logging.getLogger(__name__)
 # Import Salt Testing libs
 from tests.support.case import ModuleCase
 from tests.support.unit import skipIf
-from tests.support.paths import FILES, TMP, TMP_STATE_TREE
-from tests.support.helpers import (
-    skip_if_not_root,
-    with_system_user_and_group,
-    with_tempfile,
-    Webserver,
-)
+
+# Import Salt libs
+import salt.utils.platform
 
 
+@skipIf(salt.utils.platform.is_windows(), 'minion is windows')
 class CronTest(ModuleCase):
     '''
     Validate the file state


### PR DESCRIPTION
### What does this PR do?
Fixing bug that made cron.file unable to use a file via a Salt URL.

### What issues does this PR fix or reference?
#46881 

### Tests written?
Yes

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
