### PR TITLE
libvirt_events, harmonize object descriptions

### DIFF
--- a/salt/engines/libvirt_events.py
+++ b/salt/engines/libvirt_events.py
@@ -229,7 +229,8 @@ def _domain_event_lifecycle_cb(conn, domain, event, detail, opaque):
     '''
     event_str, detail_str = _get_domain_event_detail(event, detail)
 
-    _salt_send_domain_event(opaque, conn, domain, event_str, {
+    _salt_send_domain_event(opaque, conn, domain, opaque['event'], {
+        'event':  event_str,
         'detail': detail_str
     })
 

--- a/salt/engines/libvirt_events.py
+++ b/salt/engines/libvirt_events.py
@@ -214,7 +214,8 @@ def _salt_send_domain_event(opaque, conn, domain, event, event_data):
     data = {
         'domain': {
             'name': domain.name(),
-            'id': domain.ID()
+            'id': domain.ID(),
+            'uuid': domain.UUIDString()
         },
         'event': event
     }
@@ -468,7 +469,10 @@ def _network_event_lifecycle_cb(conn, net, event, detail, opaque):
     '''
 
     _salt_send_event(opaque, conn, {
-        'network': net.name(),
+        'network': {
+            'name': net.name(),
+            'uuid': net.UUIDString()
+        },
         'event': _get_libvirt_enum_string('VIR_NETWORK_EVENT_', event),
         'detail': 'unknown'  # currently unused
     })
@@ -479,7 +483,10 @@ def _pool_event_lifecycle_cb(conn, pool, event, detail, opaque):
     Storage pool lifecycle events handler
     '''
     _salt_send_event(opaque, conn, {
-        'pool': pool.name(),
+        'pool': {
+            'name': pool.name(),
+            'uuid': pool.UUIDString()
+        },
         'event': _get_libvirt_enum_string('VIR_STORAGE_POOL_EVENT_', event),
         'detail': 'unknown'  # currently unused
     })
@@ -490,7 +497,10 @@ def _pool_event_refresh_cb(conn, pool, opaque):
     Storage pool refresh events handler
     '''
     _salt_send_event(opaque, conn, {
-        'pool': pool.name(),
+        'pool': {
+            'name': pool.name(),
+            'uuid': pool.UUIDString()
+        },
         'event': opaque['event']
     })
 
@@ -500,7 +510,9 @@ def _nodedev_event_lifecycle_cb(conn, dev, event, detail, opaque):
     Node device lifecycle events handler
     '''
     _salt_send_event(opaque, conn, {
-        'nodedev': dev.name(),
+        'nodedev': {
+            'name': dev.name()
+        },
         'event': _get_libvirt_enum_string('VIR_NODE_DEVICE_EVENT_', event),
         'detail': 'unknown'  # currently unused
     })
@@ -511,7 +523,9 @@ def _nodedev_event_update_cb(conn, dev, opaque):
     Node device update events handler
     '''
     _salt_send_event(opaque, conn, {
-        'nodedev': dev.name(),
+        'nodedev': {
+            'name': dev.name()
+        },
         'event': opaque['event']
     })
 
@@ -521,7 +535,9 @@ def _secret_event_lifecycle_cb(conn, secret, event, detail, opaque):
     Secret lifecycle events handler
     '''
     _salt_send_event(opaque, conn, {
-        'secret': secret.UUIDString(),
+        'secret': {
+            'uuid': secret.UUIDString()
+        },
         'event': _get_libvirt_enum_string('VIR_SECRET_EVENT_', event),
         'detail': 'unknown'  # currently unused
     })
@@ -532,7 +548,9 @@ def _secret_event_value_changed_cb(conn, secret, opaque):
     Secret value change events handler
     '''
     _salt_send_event(opaque, conn, {
-        'secret': secret.UUIDString(),
+        'secret': {
+            'uuid': secret.UUIDString()
+        },
         'event': opaque['event']
     })
 


### PR DESCRIPTION
### What does this PR do?

Use a dictionary to describe all events objects (domain, network, pool,
nodedev and secret). This allows future extensions of the data
describing these objects.

Also make sure to provide the object UUID where one exists since some
client applications use them to identify objects.

### What issues does this PR fix or reference?

No issue referenced. While writing client code listening for the events, I realized that some infos may be missing in the events, like UUIDs (and may be nodedev parent)

### Previous Behavior

Events for domain, network and pool objects didn't include the object UUID

### New Behavior

These events data now include UUIDs and are using JSON objects to allow more extensibility

### Tests written?

No, just minor data changes

### Commits signed with GPG?

Yes