### PR TITLE
Switch to assertCountEqual since order can change

### DIFF
--- a/tests/unit/grains/test_core.py
+++ b/tests/unit/grains/test_core.py
@@ -889,4 +889,5 @@ SwapTotal:       4789244 kB'''
         ret = {'fqdns': ['bluesniff.foo.bar', 'foo.bar.baz', 'rinzler.evil-corp.com']}
         with patch.object(socket, 'gethostbyaddr', side_effect=reverse_resolv_mock):
             fqdns = core.fqdns()
-            self.assertEqual(fqdns, ret)
+            self.assertCountEqual(fqdns['fqdns'], ret['fqdns'])
+

--- a/tests/unit/grains/test_core.py
+++ b/tests/unit/grains/test_core.py
@@ -890,4 +890,3 @@ SwapTotal:       4789244 kB'''
         with patch.object(socket, 'gethostbyaddr', side_effect=reverse_resolv_mock):
             fqdns = core.fqdns()
             self.assertCountEqual(fqdns['fqdns'], ret['fqdns'])
-


### PR DESCRIPTION
### What does this PR do?
Since the order of the list in the dict can change, the assertEqual might fail. assertCountEqual not only checks the count, it also checks for matching elements regardless of the order. [assertCountEqual is
Python=>3.2](https://docs.python.org/3.2/library/unittest.html#unittest.TestCase.assertCountEqual).

### What issues does this PR fix or reference?

None

### Previous Behavior
Test might fail although all the elements are in the list, just because of the order.

### New Behavior
Test passes regardless of the order.

### Commits signed with GPG?

Yes
