### PR TITLE
Added clone_images to OpenNebula template_clone kwargs

### DIFF
--- a/salt/cloud/clouds/opennebula.py
+++ b/salt/cloud/clouds/opennebula.py
@@ -2387,6 +2387,7 @@ def template_clone(call=None, kwargs=None):
     name = kwargs.get('name', None)
     template_id = kwargs.get('template_id', None)
     template_name = kwargs.get('template_name', None)
+    clone_images = kwargs.get('clone_images', False)
 
     if name is None:
         raise SaltCloudSystemExit(
@@ -2410,7 +2411,7 @@ def template_clone(call=None, kwargs=None):
     server, user, password = _get_xml_rpc()
     auth = ':'.join([user, password])
 
-    response = server.one.template.clone(auth, int(template_id), name)
+    response = server.one.template.clone(auth, int(template_id), name, clone_images)
 
     data = {
         'action': 'template.clone',

--- a/salt/cloud/clouds/opennebula.py
+++ b/salt/cloud/clouds/opennebula.py
@@ -2369,6 +2369,9 @@ def template_clone(call=None, kwargs=None):
     template_name
         The name of the template to be cloned. Can be used instead of ``template_id``.
 
+    clone_images
+        Optional, defaults to False. Indicates if the images attached to the template should be cloned as well.
+
     CLI Example:
 
     .. code-block:: bash


### PR DESCRIPTION
### What does this PR do?
Added clone_images to OpenNebula template_clone kwargs. If set to True the images attached to the template will be cloned as well.

Link to the OpenNebula docs: https://docs.opennebula.org/5.4/integration/system_interfaces/api.html#one-template-clone
It's the 4th param in the one.template.clone call which reads as follows: "true to clone the template plus any image defined in DISK. The new IMAGE_ID is set into each DISK."

### What issues does this PR fix or reference?
Unknown

### Previous Behavior
Previously only the template would be cloned and the cloned template would be linked to the original image.

### New Behavior
With this code the option to clone the images along with the template in one RPC call has been added.

### Tests written?

No

### Commits signed with GPG?

No
