### PR TITLE
convert azure sub id to byte string vs UTF

### DIFF
--- a/salt/utils/azurearm.py
+++ b/salt/utils/azurearm.py
@@ -125,7 +125,7 @@ def _determine_auth(**kwargs):
 
     subscription_id = salt.utils.stringutils.to_str(kwargs['subscription_id'])
 
-    return credentials, subscription_id.encode(), cloud_env
+    return credentials, subscription_id, cloud_env
 
 
 def get_client(client_type, **kwargs):

--- a/salt/utils/azurearm.py
+++ b/salt/utils/azurearm.py
@@ -124,7 +124,7 @@ def _determine_auth(**kwargs):
 
     subscription_id = kwargs['subscription_id']
 
-    return credentials, subscription_id, cloud_env
+    return credentials, subscription_id.encode(), cloud_env
 
 
 def get_client(client_type, **kwargs):
@@ -163,7 +163,6 @@ def get_client(client_type, **kwargs):
         )
 
     credentials, subscription_id, cloud_env = _determine_auth(**kwargs)
-
     if client_type == 'subscription':
         client = Client(
             credentials=credentials,

--- a/salt/utils/azurearm.py
+++ b/salt/utils/azurearm.py
@@ -31,6 +31,7 @@ import sys
 import salt.config
 import salt.ext.six as six
 import salt.loader
+import salt.utils.stringutils
 import salt.version
 from salt.exceptions import (
     SaltInvocationError, SaltSystemExit
@@ -122,7 +123,7 @@ def _determine_auth(**kwargs):
             'A subscription_id must be specified'
         )
 
-    subscription_id = kwargs['subscription_id']
+    subscription_id = salt.utils.stringutils.to_str(kwargs['subscription_id'])
 
     return credentials, subscription_id.encode(), cloud_env
 


### PR DESCRIPTION
### What does this PR do?
convert azure subscription_id to byte string vs UTF

### What issues does this PR fix or reference?
[46935](https://github.com/saltstack/salt/issues/46935)

### Previous Behavior
Using the azurearm driver would throw a "subscription_id must be a str" error

### New Behavior
Error no longer is thrown

### Tests written?

No

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
