### PR TITLE
Add new utils arg to schedule init

### DIFF
--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -105,6 +105,7 @@ class Schedule(object):
                  intervals=None,
                  cleanup=None,
                  proxy=None,
+                 utils=None,
                  standalone=False,
                  new_instance=False):
         pass


### PR DESCRIPTION
This was missed in the last merge-forward and causes lint to fail.

Refs #46907