### PR TITLE
Fix traceback when attempting to decode binary data to unicode

### DIFF
--- a/salt/payload.py
+++ b/salt/payload.py
@@ -141,7 +141,11 @@ class Serial(object):
                 # Due to this, if we don't need it, don't pass it at all so
                 # that under Python 2 we can still work with older versions
                 # of msgpack.
-                ret = msgpack.loads(msg, use_list=True, ext_hook=ext_type_decoder, encoding=encoding)
+                try:
+                    ret = msgpack.loads(msg, use_list=True, ext_hook=ext_type_decoder, encoding=encoding)
+                except UnicodeDecodeError:
+                    # msg contains binary data
+                    ret = msgpack.loads(msg, use_list=True, ext_hook=ext_type_decoder)
             else:
                 ret = msgpack.loads(msg, use_list=True, ext_hook=ext_type_decoder)
             if six.PY3 and encoding is None and not raw:

--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -738,7 +738,7 @@ class Pillar(object):
             msg = 'Rendering SLS \'{0}\' failed, render error:\n{1}'.format(
                 sls, exc
             )
-            log.critical(msg)
+            log.critical(msg, exc_info=True)
             if self.opts.get('pillar_safe_render_error', True):
                 errors.append(
                     'Rendering SLS \'{0}\' failed. Please see master log for '


### PR DESCRIPTION
When using the gpg renderer to render encrypted binary data, or attempting to unpack serialized binary blobs, a UnicodeDecodeError is raised. This suppresses those errors and leaves the binary data as-is.

Resolves #46934.