### PR TITLE
Revert changes from #46520 that were not merged-forward correctly

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -2524,7 +2524,6 @@ class Minion(MinionBase):
                     self.opts,
                     self.functions,
                     self.returners,
-                    utils=self.utils,
                     cleanup=[master_event(type='alive')])
 
             try:

--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -110,11 +110,10 @@ class Schedule(object):
         pass
 
     # an init for the singleton instance to call
-    def __singleton_init__(self, opts, functions, returners=None, intervals=None, cleanup=None, proxy=None, utils=None, standalone=False):
+    def __singleton_init__(self, opts, functions, returners=None, intervals=None, cleanup=None, proxy=None, standalone=False):
         self.opts = opts
         self.proxy = proxy
         self.functions = functions
-        self.utils = utils
         self.standalone = standalone
         self.skip_function = None
         self.skip_during_range = None
@@ -598,11 +597,10 @@ class Schedule(object):
             # This also needed for ZeroMQ transport to reset all functions
             # context data that could keep paretns connections. ZeroMQ will
             # hang on polling parents connections from the child process.
-            utils = self.utils or salt.loader.utils(self.opts)
             if self.opts['__role'] == 'master':
-                self.functions = salt.loader.runner(self.opts, utils=utils)
+                self.functions = salt.loader.runner(self.opts)
             else:
-                self.functions = salt.loader.minion_mods(self.opts, proxy=self.proxy, utils=utils)
+                self.functions = salt.loader.minion_mods(self.opts, proxy=self.proxy)
             self.returners = salt.loader.returners(self.opts, self.functions, proxy=self.proxy)
         ret = {'id': self.opts.get('id', 'master'),
                'fun': func,
@@ -1625,7 +1623,6 @@ class Schedule(object):
                 # Restore our function references.
                 self.functions = functions
                 self.returners = returners
-                self.utils = utils
 
 
 def clean_proc_dir(opts):


### PR DESCRIPTION
This removes the changes from #46520 that were merged-forward and not handled correctly in #46907.

Changes to `salt/utils/schedule.py` cannot be merged forward to develop as the code there has be significantly refactored. The change in #46520 will need to be applied directly to `develop` instead.

This fixes the lint errors on the `develop` branch and the related test failures. These were caused by the merge forward in #46907.