### PR TITLE
 [2017.7] fix to pkgrepo comments test

### DIFF
--- a/tests/integration/states/test_pkgrepo.py
+++ b/tests/integration/states/test_pkgrepo.py
@@ -98,17 +98,13 @@ class PkgrepoTest(ModuleCase, SaltReturnAssertsMixin):
         try:
             # Run the state to add the repo
             ret = self.run_state('pkgrepo.managed', **kwargs)
-            import logging
-            log = logging.getLogger(__name__)
             self.assertSaltTrueReturn(ret)
 
             # Run again with modified comments
             kwargs['comments'].append('This is another comment')
             ret = self.run_state('pkgrepo.managed', **kwargs)
-            log.debug('=== ret %s ===', ret)
             self.assertSaltTrueReturn(ret)
             ret = ret[next(iter(ret))]
-            log.debug('=== ret %s ===', ret)
             self.assertEqual(
                 ret['changes'],
                 {

--- a/tests/integration/states/test_pkgrepo.py
+++ b/tests/integration/states/test_pkgrepo.py
@@ -83,7 +83,7 @@ class PkgrepoTest(ModuleCase, SaltReturnAssertsMixin):
         '''
         os_family = grains['os_family'].lower()
 
-        if os_family in ('redhat'):
+        if os_family in ('redhat',):
             kwargs = {
                 'name': 'examplerepo',
                 'baseurl': 'http://example.com/repo',

--- a/tests/integration/states/test_pkgrepo.py
+++ b/tests/integration/states/test_pkgrepo.py
@@ -83,7 +83,7 @@ class PkgrepoTest(ModuleCase, SaltReturnAssertsMixin):
         '''
         os_family = grains['os_family'].lower()
 
-        if os_family in ('redhat', 'suse'):
+        if os_family in ('redhat'):
             kwargs = {
                 'name': 'examplerepo',
                 'baseurl': 'http://example.com/repo',
@@ -98,13 +98,17 @@ class PkgrepoTest(ModuleCase, SaltReturnAssertsMixin):
         try:
             # Run the state to add the repo
             ret = self.run_state('pkgrepo.managed', **kwargs)
+            import logging
+            log = logging.getLogger(__name__)
             self.assertSaltTrueReturn(ret)
 
             # Run again with modified comments
             kwargs['comments'].append('This is another comment')
             ret = self.run_state('pkgrepo.managed', **kwargs)
+            log.debug('=== ret %s ===', ret)
             self.assertSaltTrueReturn(ret)
             ret = ret[next(iter(ret))]
+            log.debug('=== ret %s ===', ret)
             self.assertEqual(
                 ret['changes'],
                 {


### PR DESCRIPTION
### What does this PR do?
Removing suse from pkgrepo comments tests.  the pkgrepo functions in SUSE pkg module do not support comments.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt-jenkins/issues/917

### Tests written?
Yes.  Test updated.

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
