### PR TITLE
New "apply_to" kwarg in rabbitmq module should be added at the end

### DIFF
--- a/salt/modules/rabbitmq.py
+++ b/salt/modules/rabbitmq.py
@@ -850,7 +850,13 @@ def list_policies(vhost="/", runas=None):
     return ret
 
 
-def set_policy(vhost, name, pattern, definition, priority=None, apply_to=None, runas=None):
+def set_policy(vhost,
+               name,
+               pattern,
+               definition,
+               priority=None,
+               runas=None,
+               apply_to=None):
     '''
     Set a policy based on rabbitmqctl set_policy.
 

--- a/salt/states/rabbitmq_policy.py
+++ b/salt/states/rabbitmq_policy.py
@@ -36,10 +36,10 @@ def __virtual__():
 def present(name,
             pattern,
             definition,
-            apply_to=None,
             priority=0,
             vhost='/',
-            runas=None):
+            runas=None,
+            apply_to=None):
     '''
     Ensure the RabbitMQ policy exists.
 
@@ -53,12 +53,12 @@ def present(name,
         A json dict describing the policy
     priority
         Priority (defaults to 0)
-    apply_to
-        Apply policy to 'queues', 'exchanges' or 'all' (default to 'all')
     vhost
         Virtual host to apply to (defaults to '/')
     runas
         Name of the user to run the command as
+    apply_to
+        Apply policy to 'queues', 'exchanges' or 'all' (default to 'all')
     '''
     ret = {'name': name, 'result': True, 'comment': '', 'changes': {}}
     result = {}
@@ -90,9 +90,9 @@ def present(name,
                                                      name,
                                                      pattern,
                                                      definition,
-                                                     apply_to,
                                                      priority=priority,
-                                                     runas=runas)
+                                                     runas=runas,
+                                                     apply_to=apply_to)
     elif updates:
         ret['changes'].update({'old': policy, 'new': updates})
         if __opts__['test']:
@@ -103,9 +103,9 @@ def present(name,
                                                      name,
                                                      pattern,
                                                      definition,
-                                                     apply_to,
                                                      priority=priority,
-                                                     runas=runas)
+                                                     runas=runas,
+                                                     apply_to=apply_to)
 
     if 'Error' in result:
         ret['result'] = False


### PR DESCRIPTION
The change in #41233 added the "apply_to" kwarg to rabbitmq.set_policy. Since
the arg was not added at the end of the kwarg list, there was an API change.

In addition, when the order of "apply_to" and "priority" was swapped, the
corresponding kwargs were not changed, which causes a stack trace and the
rabbitmq_policy state to fail.

This change fixes #46880 so that the policy option will work correctly and we
can avoid this API change for the module. In 2017.7.x versions of Salt, the
order of args/kwargs is `vhost`, `name`, `pattern`, `definition`, `priority`,
and then `runas`. Therefore, `apply_to` must be last.

Fixes #46880
