### PR TITLE
Restrict permission on accumulator files.

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -336,7 +336,11 @@ def _persist_accummulators(accumulators, accumulators_deps):
 
     serial = salt.payload.Serial(__opts__)
     try:
-        with salt.utils.fopen(_get_accumulator_filepath(), 'w+b') as f:
+        # This creates the file with a restricted permission set so that only
+        # the salt user can access it
+        with salt.utils.fopen(
+                os.open(_get_accumulator_filepath(), os.O_CREAT | os.O_RDWR, 0o600),
+                'w+b') as f:
             serial.dump(accumm_data, f)
     except NameError:
         # msgpack error from salt-ssh


### PR DESCRIPTION
### What does this PR do?

This commit alters the _persist_accumulators function to explicitly set
the mode of the created file so that only the user that salt is running
as (or root) can access it.



### What issues does this PR fix or reference?
Currently when accumulators are being persisted the files are written
out using the default permission as specified by the umask. This
ususally means they are world-readable. This is a potential security
hole as the file that is being managed and accumulates said accumulators
may not be world readable.

### Previous Behavior
Accumulator files would be world readable.

### New Behavior
Accumulator files are only readable by the user salt is running as.

### Tests written?

No

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
