### PR TITLE
Fix: tuple instead of string

### DIFF
--- a/salt/modules/keystone.py
+++ b/salt/modules/keystone.py
@@ -167,7 +167,7 @@ def auth(profile=None, **connection_args):
         'Neon',
         (
             'The keystone module has been deprecated and will be removed in {version}.  '
-            'Please update to using the keystoneng module',
+            'Please update to using the keystoneng module'
         ),
     )
     kwargs = _get_kwargs(profile=profile, **connection_args)


### PR DESCRIPTION
### What does this PR do?
Fixes wrong variable type.

### Previous Behavior
Running the following command threw an error:

`salt 'mynode.*' keystone.project_list`
```
    The minion function caused an exception: Traceback (most recent call last):
      File "/usr/lib/python2.7/dist-packages/salt/minion.py", line 1600, in _thread_return
        return_data = minion_instance.executors[fname](opts, data, func, args, kwargs)
      File "/usr/lib/python2.7/dist-packages/salt/executors/direct_call.py", line 12, in execute
        return func(*args, **kwargs)
      File "/usr/lib/python2.7/dist-packages/salt/modules/keystone.py", line 820, in project_list
        auth(profile, **connection_args)
      File "/usr/lib/python2.7/dist-packages/salt/modules/keystone.py", line 169, in auth
        'The keystone module has been deprecated and will be removed in {version}.  '
      File "/usr/lib/python2.7/dist-packages/salt/utils/versions.py", line 159, in warn_until
        message.format(version=version.formatted_version),
    AttributeError: 'tuple' object has no attribute 'format'
```

### New Behavior
Projects will be returned.

### Tests written?
No