### PR TITLE
Fix respository (=> repository) typo in sls_build

### DIFF
--- a/salt/modules/dockermod.py
+++ b/salt/modules/dockermod.py
@@ -6887,7 +6887,7 @@ def sls_build(repository,
             'The \'name\' argument to docker.sls_build has been deprecated, '
             'please use \'repository\' instead.'
         )
-        respository = name
+        repository = name
 
     create_kwargs = __utils__['args.clean_kwargs'](**copy.deepcopy(kwargs))
     for key in ('image', 'name', 'cmd', 'interactive', 'tty'):


### PR DESCRIPTION
### What does this PR do?

This typo looks to have been introduced with 64aa4fb and would affect anyone relying on the deprecated "name" attribute.

### What issues does this PR fix or reference?

* #44638

### Previous Behavior

The `name` attribute would not have been treated as the `repository` value.

### New Behavior

The `name` attribute now provides the value of the `repository` value, if present.

### Tests written?

Yes/No

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
