### PR TITLE
Remove salt FreeBSD repo which is now 2 years out of date

### DIFF
--- a/doc/topics/installation/freebsd.rst
+++ b/doc/topics/installation/freebsd.rst
@@ -5,49 +5,31 @@ FreeBSD
 Installation
 ============
 
-Salt is available in binary package form from both the FreeBSD pkgng repository
-or directly from SaltStack. The instructions below outline installation via
-both methods:
+Salt is available in the FreeBSD ports at `sysutils/py-salt. <https://www.freshports.org/sysutils/py-salt/>`__
 
-FreeBSD repo
-============
 
-The FreeBSD pkgng repository is preconfigured on systems 10.x and above. No
-configuration is needed to pull from these repositories.
+FreeBSD binary repo
+===================
 
 .. code-block:: shell
 
     pkg install py27-salt
 
-These packages are usually available within a few days of upstream release.
+FreeBSD ports
+=============
 
-.. _freebsd-upstream:
-
-SaltStack repo
-==============
-
-SaltStack also hosts internal binary builds of the Salt package, available from
-https://repo.saltstack.com/freebsd/. To make use of this repository, add the
-following file to your system:
-
-**/usr/local/etc/pkg/repos/saltstack.conf:**
-
-.. code-block:: json
-
-    saltstack: {
-      url: "https://repo.saltstack.com/freebsd/${ABI}/",
-      enabled: yes
-    }
-
-You should now be able to install Salt from this new repository:
+By default salt is packaged using python 2.7, but if you build your own packages from FreeBSD ports either by hand or with poudriere you can instead package it with your choice of python. Add a line to /etc/make.conf to choose your python flavour:
 
 .. code-block:: shell
 
-    pkg install py27-salt
+    echo "DEFAULT_VERSIONS+= python=3.6" >> /etc/make.conf
 
-These packages are usually available earlier than upstream FreeBSD. Also
-available are release candidates and development releases. Use these pre-release
-packages with caution.
+Then build the port and install:
+
+.. code-block:: shell
+
+    cd /usr/ports/sysutils/py-salt
+    make install
 
 Post-installation tasks
 =======================


### PR DESCRIPTION
The saltstack repository has the 2016 version is current. Its not being updated, but there is a perfectly good port in the FreeBSD tree to use instead. Enhance the documentation on how to install that from binary or source.

### What does this PR do?

Fix FreeBSD install instructions and remove wrong bits.

### What issues does this PR fix or reference?
None