### PR TITLE
Fix some issues with the win_servermanager module

### DIFF
--- a/salt/modules/win_servermanager.py
+++ b/salt/modules/win_servermanager.py
@@ -60,6 +60,7 @@ def _pshell_json(cmd, cwd=None):
     log.debug('PowerShell: %s', cmd)
     ret = __salt__['cmd.run_all'](cmd, shell='powershell', cwd=cwd)
 
+    ret.pop()
     if 'pid' in ret:
         del ret['pid']
 
@@ -123,10 +124,7 @@ def list_installed():
           '-ErrorAction SilentlyContinue ' \
           '-WarningAction SilentlyContinue ' \
           '| Select DisplayName,Name,Installed'
-    try:
-        features = _pshell_json(cmd)
-    except CommandExecutionError:
-        raise
+    features = _pshell_json(cmd)
 
     ret = {}
     for entry in features:
@@ -225,10 +223,7 @@ def install(feature, recurse=False, restart=False, source=None, exclude=None):
           .format(command, _cmd_quote(feature), management_tools,
                   '-IncludeAllSubFeature' if recurse else '',
                   '' if source is None else '-Source {0}'.format(source))
-    try:
-        out = _pshell_json(cmd)
-    except CommandExecutionError:
-        raise
+    out = _pshell_json(cmd)
 
     # Uninstall items in the exclude list
     # The Install-WindowsFeature command doesn't have the concept of an exclude

--- a/salt/modules/win_servermanager.py
+++ b/salt/modules/win_servermanager.py
@@ -60,7 +60,6 @@ def _pshell_json(cmd, cwd=None):
     log.debug('PowerShell: %s', cmd)
     ret = __salt__['cmd.run_all'](cmd, shell='powershell', cwd=cwd)
 
-    ret.pop()
     if 'pid' in ret:
         del ret['pid']
 

--- a/salt/states/win_servermanager.py
+++ b/salt/states/win_servermanager.py
@@ -13,7 +13,6 @@ from __future__ import absolute_import, unicode_literals, print_function
 # Import salt modules
 import salt.utils.data
 import salt.utils.versions
-from salt.exceptions import CommandExecutionError
 
 
 def __virtual__():

--- a/salt/states/win_servermanager.py
+++ b/salt/states/win_servermanager.py
@@ -299,11 +299,8 @@ def removed(name, features=None, remove_payload=False, restart=False):
         return ret
 
     # Remove the features
-    try:
-        status = __salt__['win_servermanager.remove'](
-            features, remove_payload=remove_payload, restart=restart)
-    except CommandExecutionError:
-        raise
+    status = __salt__['win_servermanager.remove'](
+        features, remove_payload=remove_payload, restart=restart)
 
     ret['result'] = status['Success']
 

--- a/salt/states/win_servermanager.py
+++ b/salt/states/win_servermanager.py
@@ -13,6 +13,7 @@ from __future__ import absolute_import, unicode_literals, print_function
 # Import salt modules
 import salt.utils.data
 import salt.utils.versions
+from salt.exceptions import CommandExecutionError
 
 
 def __virtual__():
@@ -111,7 +112,7 @@ def installed(name,
               - XPS-Viewer
               - SNMP-Service
             - exclude:
-              - Web-Service
+              - Web-Server
     '''
     if 'force' in kwargs:
         salt.utils.versions.warn_until(
@@ -298,8 +299,11 @@ def removed(name, features=None, remove_payload=False, restart=False):
         return ret
 
     # Remove the features
-    status = __salt__['win_servermanager.remove'](
-        features, remove_payload=remove_payload, restart=restart)
+    try:
+        status = __salt__['win_servermanager.remove'](
+            features, remove_payload=remove_payload, restart=restart)
+    except CommandExecutionError:
+        raise
 
     ret['result'] = status['Success']
 


### PR DESCRIPTION
### What does this PR do?
Puts some error checking in the `_pshell_json`  helper function
Use `cmd.run_all` instead of `cmd.shell`
Raise `CommandExecutionError`s when it finds a problem
Account for instances where there's an empty string returned that will cause the JSON load to fail
Add `try/except` blocks to handle the `CommandExecutionError`s

Fix the example in the docs for the state
Add `try/except` blocks to the state

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/46968

### Tests written?
No

### Commits signed with GPG?
Yes