### PR TITLE
Test is now also working with Python2

### DIFF
--- a/tests/unit/grains/test_core.py
+++ b/tests/unit/grains/test_core.py
@@ -889,4 +889,6 @@ SwapTotal:       4789244 kB'''
         ret = {'fqdns': ['bluesniff.foo.bar', 'foo.bar.baz', 'rinzler.evil-corp.com']}
         with patch.object(socket, 'gethostbyaddr', side_effect=reverse_resolv_mock):
             fqdns = core.fqdns()
-            self.assertCountEqual(fqdns['fqdns'], ret['fqdns'])
+            self.assertIn('fqdns', fqdns)
+            self.assertEqual(len(fqdns['fqdns']), len(ret['fqdns']))
+            self.assertEqual(set(fqdns['fqdns']), set(ret['fqdns']))


### PR DESCRIPTION
### What does this PR do?

Since assertCountEqual was Python>=3.2 only, we backported this
to Python2.

### Previous Behavior

Testing with Python3 would work and Python2 would fail.

### New Behavior

Testing with Python2 and Python3 would work.

### Commits signed with GPG?

Yes