### PR TITLE
Don’t encode a unicode string

### DIFF
--- a/salt/modules/pip.py
+++ b/salt/modules/pip.py
@@ -130,7 +130,8 @@ def _get_pip_bin(bin_env):
              'pip{0}'.format(sys.version_info[0]),
              'pip', 'pip-python']
         )
-        if salt.utils.platform.is_windows() and six.PY2:
+        if salt.utils.platform.is_windows() and six.PY2 \
+           and isinstance(which_result, str):
             which_result.encode('string-escape')
         if which_result is None:
             raise CommandNotFoundError('Could not find a `pip` binary')


### PR DESCRIPTION
### What does this PR do?

Fixes pip installations on windows, by not encoding a unicode string.

### What issues does this PR fix or reference?

### Previous Behavior
```
$$$$$$ [ERROR   ] An exception occurred in this state: Traceback (most recent call last):
$$$$$$   File "C:\salt\bin\lib\site-packages\salt\state.py", line 1878, in call
$$$$$$     **cdata['kwargs'])
$$$$$$   File "C:\salt\bin\lib\site-packages\salt\loader.py", line 1823, in wrapper
$$$$$$     return f(*args, **kwargs)
$$$$$$   File "C:\salt\bin\lib\site-packages\salt\states\pip_state.py", line 685, in installed
$$$$$$     upgrade, user, cwd, bin_env)
$$$$$$   File "C:\salt\bin\lib\site-packages\salt\states\pip_state.py", line 193, in _check_if_installed
$$$$$$     user=user, cwd=cwd)
$$$$$$   File "C:\Users\BUILDU~1\AppData\Local\Temp\kitchen\var\cache\salt\minion\extmods\modules\pip.py", line 1082, in list_
$$$$$$     for line in freeze(bin_env=bin_env, user=user, cwd=cwd, env_vars=env_vars):
$$$$$$   File "C:\Users\BUILDU~1\AppData\Local\Temp\kitchen\var\cache\salt\minion\extmods\modules\pip.py", line 1019, in freeze
$$$$$$     pip_bin = _get_pip_bin(bin_env)
$$$$$$   File "C:\Users\BUILDU~1\AppData\Local\Temp\kitchen\var\cache\salt\minion\extmods\modules\pip.py", line 135, in _get_pip_bin
$$$$$$     which_result.encode('string-escape', errors='ignore')
$$$$$$ TypeError: escape_encode() argument 1 must be string, not unicode
```


### Tests written?

No

### Commits signed with GPG?

No
