### PR TITLE
[2018.3] Fixing integration.modules.test_state_jinja_filters.StateModuleJinjaFiltersTest.test_path_which

### DIFF
--- a/tests/support/jinja_filters.py
+++ b/tests/support/jinja_filters.py
@@ -602,12 +602,10 @@ class JinjaFiltersTest(object):
         '''
         test jinja filter path.which
         '''
-        _expected = {'ret': '/usr/bin/which'}
         ret = self.run_function('state.sls',
                                 ['jinja_filters.path_which'])
         self.assertIn('module_|-test_|-test.echo_|-run', ret)
-        self.assertEqual(ret['module_|-test_|-test.echo_|-run']['changes'],
-                         _expected)
+        self.assertIn('ret', ret['module_|-test_|-test.echo_|-run']['changes'])
 
     def test_stringutils_contains_whitespace(self):
         '''


### PR DESCRIPTION
### What does this PR do?
Fixing test_path_which to check that the filter is available rather than results.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt-jenkins/issues/920

### Tests written?
Yes.  Updated existing test.

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
