### PR TITLE
Add auth.file module to auth documentation page

### DIFF
--- a/doc/ref/auth/all/index.rst
+++ b/doc/ref/auth/all/index.rst
@@ -12,6 +12,7 @@ auth modules
 
     auto
     django
+    file
     keystone
     ldap
     mysql


### PR DESCRIPTION
### What does this PR do?

The 2018.3 Oxygen release included a new `file` auth module, but the documentation page that lists available auth modules was not updated to include it. This PR adds the `file` auth module to the documentation index.

### Tests written?

No

### Commits signed with GPG?

Yes
