### PR TITLE
Fix server_id grain in PY3 on Windows

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -2411,9 +2411,8 @@ def get_server_id():
     if py_ver >= (3, 3):
         # Python 3.3 enabled hash randomization, so we need to shell out to get
         # a reliable hash.
-        py_bin = 'python{0}.{1}'.format(*py_ver)
         id_hash = __salt__['cmd.run'](
-            [py_bin, '-c', 'print(hash("{0}"))'.format(id_)],
+            [sys.executable, '-c', 'print(hash("{0}"))'.format(id_)],
             env={'PYTHONHASHSEED': '0'}
         )
         try:


### PR DESCRIPTION
https://github.com/saltstack/salt/pull/46649 caused a regression on Windows since the executable path does not exist. This fixes that grain on Windows by using `sys.executable`.