### PR TITLE
Fix winrm powershell script

### DIFF
--- a/doc/topics/cloud/windows.rst
+++ b/doc/topics/cloud/windows.rst
@@ -127,24 +127,24 @@ the following userdata example:
     $SourceStoreScope = 'LocalMachine'
     $SourceStorename = 'Remote Desktop'
 
-    $SourceStore = New-Object  -TypeName System.Security.Cryptography.X509Certificates.X509Store  -ArgumentList $SourceStorename, $SourceStoreScope
+    $SourceStore = New-Object -TypeName System.Security.Cryptography.X509Certificates.X509Store -ArgumentList $SourceStorename, $SourceStoreScope
     $SourceStore.Open([System.Security.Cryptography.X509Certificates.OpenFlags]::ReadOnly)
 
-    $cert = $SourceStore.Certificates | Where-Object  -FilterScript {
+    $cert = $SourceStore.Certificates | Where-Object -FilterScript {
         $_.subject -like '*'
     }
 
     $DestStoreScope = 'LocalMachine'
     $DestStoreName = 'My'
 
-    $DestStore = New-Object  -TypeName System.Security.Cryptography.X509Certificates.X509Store  -ArgumentList $DestStoreName, $DestStoreScope
+    $DestStore = New-Object -TypeName System.Security.Cryptography.X509Certificates.X509Store -ArgumentList $DestStoreName, $DestStoreScope
     $DestStore.Open([System.Security.Cryptography.X509Certificates.OpenFlags]::ReadWrite)
     $DestStore.Add($cert)
 
     $SourceStore.Close()
     $DestStore.Close()
 
-    winrm create winrm/config/listener?Address=*+Transport=HTTPS  `@`{Hostname=`"($certId)`"`;CertificateThumbprint=`"($cert.Thumbprint)`"`}
+    winrm create winrm/config/listener?Address=*+Transport=HTTPS `@`{CertificateThumbprint=`"($cert.Thumbprint)`"`}
 
     Restart-Service winrm
     </powershell>

--- a/tests/integration/files/windows-firewall.ps1
+++ b/tests/integration/files/windows-firewall.ps1
@@ -10,24 +10,24 @@ winrm set winrm/config/service/auth '@{Basic="true"}'
 $SourceStoreScope = 'LocalMachine'
 $SourceStorename = 'Remote Desktop'
 
-$SourceStore = New-Object  -TypeName System.Security.Cryptography.X509Certificates.X509Store  -ArgumentList $SourceStorename, $SourceStoreScope
+$SourceStore = New-Object -TypeName System.Security.Cryptography.X509Certificates.X509Store -ArgumentList $SourceStorename, $SourceStoreScope
 $SourceStore.Open([System.Security.Cryptography.X509Certificates.OpenFlags]::ReadOnly)
 
-$cert = $SourceStore.Certificates | Where-Object  -FilterScript {
+$cert = $SourceStore.Certificates | Where-Object -FilterScript {
     $_.subject -like '*'
 }
 
 $DestStoreScope = 'LocalMachine'
 $DestStoreName = 'My'
 
-$DestStore = New-Object  -TypeName System.Security.Cryptography.X509Certificates.X509Store  -ArgumentList $DestStoreName, $DestStoreScope
+$DestStore = New-Object -TypeName System.Security.Cryptography.X509Certificates.X509Store -ArgumentList $DestStoreName, $DestStoreScope
 $DestStore.Open([System.Security.Cryptography.X509Certificates.OpenFlags]::ReadWrite)
 $DestStore.Add($cert)
 
 $SourceStore.Close()
 $DestStore.Close()
 
-winrm create winrm/config/listener?Address=*+Transport=HTTPS  `@`{Hostname=`"($certId)`"`;CertificateThumbprint=`"($cert.Thumbprint)`"`}
+winrm create winrm/config/listener?Address=*+Transport=HTTPS `@`{CertificateThumbprint=`"($cert.Thumbprint)`"`}
 
 Restart-Service winrm
 </powershell>


### PR DESCRIPTION
### What does this PR do?
Removes the `Hostname` parameter in the `winrm create` command. It is not needed. It must match the hostname on the certificate, which is not defined in the case of the Remote Desktop certificate
Removes extra spaces
Updates the sample script in the docs as well as the script that is used in the integration tests.

### Tests written?
No

### Commits signed with GPG?
Yes