### PR TITLE
Fix ba7d00f5 for gentoo pkg.installed method

### DIFF
--- a/salt/modules/ebuild.py
+++ b/salt/modules/ebuild.py
@@ -90,6 +90,13 @@ def _p_to_cp(p):
     except portage.exception.InvalidAtom:
         pass
 
+    try:
+        ret = _porttree().dbapi.xmatch("match-all", p)
+        if ret:
+            return portage.cpv_getkey(ret[0])
+    except portage.exception.InvalidAtom:
+        pass
+
     return None
 
 
@@ -105,6 +112,13 @@ def _allnodes():
 def _cpv_to_cp(cpv):
     try:
         ret = portage.dep_getkey(cpv)
+        if ret:
+            return ret
+    except portage.exception.InvalidAtom:
+        pass
+
+    try:
+        ret = portage.cpv_getkey(cpv)
         if ret:
             return ret
     except portage.exception.InvalidAtom:

--- a/salt/modules/portage_config.py
+++ b/salt/modules/portage_config.py
@@ -111,6 +111,13 @@ def _p_to_cp(p):
     except portage.exception.InvalidAtom:
         pass
 
+    try:
+        ret = _porttree().dbapi.xmatch("match-all", p)
+        if ret:
+            return portage.cpv_getkey(ret[0])
+    except portage.exception.InvalidAtom:
+        pass
+
     return None
 
 


### PR DESCRIPTION

### What does this PR do?

The commit ba7d00f5 change _cpv_to_cp inner implementation, but the
original parameter cpv is not changed, its format is `<p>-<v>`, and
`dep_getkey` need format for `=<p>-<v>` if `cpv` with version, so it cause
`InvalidAtom` exception and actually return cpv itself. So I add the
original implementation back to fix this problem and still keep
`dep_getkey` if the cpv format will be fixed in the future


### What issues does this PR fix or reference?

https://github.com/saltstack/salt/commit/ba7d00f58ef10dd441dbc90ea1d92f28eb92d7d1

### Previous Behavior

In past version, the `pkg.installed` works fine

### New Behavior

In this version, as description mentioned, the `_cpv_to_cp()` return cpv with format `<p>-<v>`, so it can't do match with only `<p>`, and such cause it think the pkg is not installed.


