### PR TITLE
switch order of file to be diffed

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -4812,7 +4812,7 @@ def check_file_meta(
             if sfn:
                 try:
                     changes['diff'] = get_diff(
-                        sfn, name, template=True, show_filenames=False)
+                        name, sfn, template=True, show_filenames=False)
                 except CommandExecutionError as exc:
                     changes['diff'] = exc.strerror
             else:


### PR DESCRIPTION
as described by title, otherwise, the diff show in test mode are reversed when apply.

Fixes #46931