### PR TITLE
handle jinja error in <module> level

### DIFF
--- a/salt/utils/templates.py
+++ b/salt/utils/templates.py
@@ -205,7 +205,8 @@ def _get_jinja_error_slug(tb_data):
         return [
             x
             for x in tb_data if x[2] in ('top-level template code',
-                                         'template')
+                                         'template',
+                                         '<module>')
         ][-1]
     except IndexError:
         pass


### PR DESCRIPTION
prepare test case:
 # echo '{% import_yaml "a.yaml" as a with context %}' > a.sls
 # echo 'a: {{ "now"|strftime }}' > a.yaml

remove 'import salt.utils.daeutils' from salt/utils/templates.py, then run

 # salt-call state.sls a
[CRITICAL] Rendering SLS 'base:a' failed: Traceback (most recent call last):
  File "/usr/lib64/python2.7/site-packages/salt/utils/templates.py", line 169, in render_tmpl
    output = render_str(tmplstr, context, tmplpath)
  File "/usr/lib64/python2.7/site-packages/salt/utils/templates.py", line 395, in render_jinja_tmpl
    line, out = _get_jinja_error(trace, context=decoded_context)
  File "/usr/lib64/python2.7/site-packages/salt/utils/templates.py", line 248, in _get_jinja_error
    line = _get_jinja_error_line(trace)
  File "/usr/lib64/python2.7/site-packages/salt/utils/templates.py", line 231, in _get_jinja_error_line
    return _get_jinja_error_slug(tb_data)[1]
TypeError: 'NoneType' object has no attribute '__getitem__'

after apply the patch:

 # salt-call state.sls a
Traceback (most recent call last):
  File "/usr/lib64/python2.7/site-packages/salt/utils/templates.py", line 169, in render_tmpl
    output = render_str(tmplstr, context, tmplpath)
  File "/usr/lib64/python2.7/site-packages/salt/utils/templates.py", line 402, in render_jinja_tmpl
    tmplstr)
SaltRenderError: Jinja syntax error: no filter named 'strftime'
/var/cache/salt/minion/files/base/a.yaml(1):
---
a: {{ "now"|strftime }}    <======================
---
[CRITICAL] Rendering SLS 'base:a' failed: Jinja syntax error: no filter named 'strftime'
/var/cache/salt/minion/files/base/a.yaml(1):
---
a: {{ "now"|strftime }}    <======================
---

which shows accurate information for debug.
