### PR TITLE
#47000 - add proper handling of full_return in cmd_subset

### DIFF
--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -473,6 +473,7 @@ class LocalClient(object):
             sub=3,
             cli=False,
             progress=False,
+            full_return=False,
             **kwargs):
         '''
         Execute a command on a random subset of the targeted systems
@@ -521,6 +522,7 @@ class LocalClient(object):
                 ret=ret,
                 kwarg=kwarg,
                 progress=progress,
+                full_return=full_return,
                 **kwargs)
 
     def cmd_batch(

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -54,20 +54,30 @@ class LocalClientTestCase(TestCase,
                 self.client.cmd_subset('*', 'first.func', sub=1, cli=True)
                 try:
                     cmd_cli_mock.assert_called_with(['minion2'], 'first.func', (), progress=False,
-                                                    kwarg=None, tgt_type='list',
+                                                    kwarg=None, tgt_type='list', full_return=False,
                                                     ret='')
                 except AssertionError:
                     cmd_cli_mock.assert_called_with(['minion1'], 'first.func', (), progress=False,
-                                                    kwarg=None, tgt_type='list',
+                                                    kwarg=None, tgt_type='list', full_return=False,
                                                     ret='')
                 self.client.cmd_subset('*', 'first.func', sub=10, cli=True)
                 try:
                     cmd_cli_mock.assert_called_with(['minion2', 'minion1'], 'first.func', (), progress=False,
-                                                    kwarg=None, tgt_type='list',
+                                                    kwarg=None, tgt_type='list', full_return=False,
                                                     ret='')
                 except AssertionError:
                     cmd_cli_mock.assert_called_with(['minion1', 'minion2'], 'first.func', (), progress=False,
-                                                    kwarg=None, tgt_type='list',
+                                                    kwarg=None, tgt_type='list', full_return=False,
+                                                    ret='')
+
+                ret = self.client.cmd_subset('*', 'first.func', sub=1, cli=True, full_return=True)
+                try:
+                    cmd_cli_mock.assert_called_with(['minion2'], 'first.func', (), progress=False,
+                                                    kwarg=None, tgt_type='list', full_return=True,
+                                                    ret='')
+                except AssertionError:
+                    cmd_cli_mock.assert_called_with(['minion1'], 'first.func', (), progress=False,
+                                                    kwarg=None, tgt_type='list', full_return=True,
                                                     ret='')
 
     @skipIf(salt.utils.is_windows(), 'Not supported on Windows')


### PR DESCRIPTION
### What does this PR do?
add proper handling of full_return in cmd_subset

 as noted in the original issue, full_return wasnt being handled properly. This rectifies that.
### What issues does this PR fix or reference?
#47000 

### Tests written?
Yes

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
