### PR TITLE
WIP: Fix repobuild

### DIFF
--- a/salt/modules/rpmbuild.py
+++ b/salt/modules/rpmbuild.py
@@ -29,11 +29,12 @@ import salt.utils.path
 import salt.utils.user
 import salt.utils.vt
 
-# Import 3rd-party libs
+# Import third party libs
 from salt.ext import six
 from salt.ext.six.moves.urllib.parse import urlparse as _urlparse  # pylint: disable=no-name-in-module,import-error
 
 HAS_LIBS = False
+SIGN_PROMPT_RE = re.compile(r'Enter pass phrase: ', re.M)
 
 try:
     import gnupg    # pylint: disable=unused-import
@@ -61,11 +62,12 @@ def __virtual__():
     if HAS_LIBS and not missing_util:
         if __grains__.get('os_family', False) in ('RedHat', 'Suse'):
             return __virtualname__
-        else:
-            # The module will be exposed as `rpmbuild` on non-RPM based systems
-            return 'rpmbuild'
+        # The module will be exposed as `rpmbuild` on non-RPM based systems
+        return 'rpmbuild'
     else:
-        return False, 'The rpmbuild module could not be loaded: requires python-gnupg, gpg, rpm, rpmbuild, mock and createrepo utilities to be installed'
+        return False, ('The rpmbuild module could not be loaded: requires '
+                       'python-gnupg, gpg, rpm, rpmbuild, mock and createrepo '
+                       'utilities to be installed')
 
 
 def _create_rpmmacros():
@@ -104,7 +106,7 @@ def _mk_tree():
     return basedir
 
 
-def _get_spec(tree_base, spec, template, saltenv='base'):
+def _get_spec(tree_base, spec, saltenv='base'):
     '''
     Get the spec file and place it in the SPECS dir
     '''
@@ -124,7 +126,7 @@ def _get_src(tree_base, source, saltenv='base'):
     sbase = os.path.basename(source)
     dest = os.path.join(tree_base, 'SOURCES', sbase)
     if parsed.scheme:
-        lsrc = __salt__['cp.get_url'](source, dest, saltenv=saltenv)
+        __salt__['cp.get_url'](source, dest, saltenv=saltenv)
     else:
         shutil.copy(source, dest)
 
@@ -171,7 +173,7 @@ def _get_deps(deps, tree_base, saltenv='base'):
     return deps_list
 
 
-def make_src_pkg(dest_dir, spec, sources, env=None, template=None, saltenv='base'):
+def make_src_pkg(dest_dir, spec, sources, env=None, saltenv='base'):
     '''
     Create a source rpm from the given spec file and sources
 
@@ -193,7 +195,7 @@ def make_src_pkg(dest_dir, spec, sources, env=None, template=None, saltenv='base
     '''
     _create_rpmmacros()
     tree_base = _mk_tree()
-    spec_path = _get_spec(tree_base, spec, template, saltenv)
+    spec_path = _get_spec(tree_base, spec, saltenv)
     if isinstance(sources, six.string_types):
         sources = sources.split(',')
     for src in sources:
@@ -201,7 +203,7 @@ def make_src_pkg(dest_dir, spec, sources, env=None, template=None, saltenv='base
 
     # make source rpms for dist el6 with SHA256, usable with mock on other dists
     cmd = 'rpmbuild --verbose --define "_topdir {0}" -bs --define "dist .el6" {1}'.format(tree_base, spec_path)
-    __salt__['cmd.run'](cmd)
+    __salt__['cmd.run'](cmd, env=env)
     srpms = os.path.join(tree_base, 'SRPMS')
     ret = []
     if not os.path.isdir(dest_dir):
@@ -246,8 +248,7 @@ def build(runas,
     srpm_dir = os.path.join(dest_dir, 'SRPMS')
     srpm_build_dir = tempfile.mkdtemp()
     try:
-        srpms = make_src_pkg(srpm_build_dir, spec, sources,
-                             env, template, saltenv)
+        srpms = make_src_pkg(srpm_build_dir, spec, sources, env, template, saltenv)
     except Exception as exc:
         shutil.rmtree(srpm_build_dir)
         log.error('Failed to make src package')
@@ -401,15 +402,17 @@ def make_repo(repodir,
         salt '*' pkgbuild.make_repo /var/www/html/
 
     '''
-    SIGN_PROMPT_RE = re.compile(r'Enter pass phrase: ', re.M)
-
     define_gpg_name = ''
     local_keyid = None
     local_uids = None
     phrase = ''
+    if gnupghome:
+        if env is None:
+            env = {}
+        env['GNUPGHOME'] = gnupghome
 
     if keyid is not None:
-        ## import_keys
+        # import_keys
         pkg_pub_key_file = '{0}/{1}'.format(gnupghome, __salt__['pillar.get']('gpg_pkg_pub_keyname', None))
         pkg_priv_key_file = '{0}/{1}'.format(gnupghome, __salt__['pillar.get']('gpg_pkg_priv_keyname', None))
 
@@ -453,33 +456,32 @@ def make_repo(repodir,
 
         # need to update rpm with public key
         cmd = 'rpm --import {0}'.format(pkg_pub_key_file)
-        __salt__['cmd.run'](cmd, runas=runas, use_vt=True)
+        __salt__['cmd.run'](cmd, runas=runas, use_vt=True, env=env)
 
-        ## sign_it_here
+        # sign_it_here
         # interval of 0.125 is really too fast on some systems
         interval = 0.5
-        for (dirpath, dirnames, filenames) in os.walk(repodir):
+        for (dirpath, _, filenames) in os.walk(repodir):
             for filename in filenames:
-                file = os.path.join(dirpath, name)
-                if file.endswith('.rpm'):
-                    abs_file = os.path.join(repodir, file)
+                if filename.endswith('.rpm'):
+                    abs_file = os.path.join(dirpath, filename)
                     number_retries = timeout / interval
                     times_looped = 0
                     error_msg = 'Failed to sign file {0}'.format(abs_file)
                     cmd = 'rpm {0} --addsign {1}'.format(define_gpg_name, abs_file)
                     preexec_fn = functools.partial(salt.utils.user.chugid_and_umask, runas, None)
                     try:
-                        stdout, stderr = None, None
+                        stdout = None
                         proc = salt.utils.vt.Terminal(
                             cmd,
-                            env={'GNUPGHOME': gnupghome},
+                            env=env,
                             shell=True,
                             preexec_fn=preexec_fn,
                             stream_stdout=True,
                             stream_stderr=True
                         )
                         while proc.has_unread_data:
-                            stdout, stderr = proc.recv()
+                            stdout, _ = proc.recv()
                             if stdout and SIGN_PROMPT_RE.search(stdout):
                                 # have the prompt for inputting the passphrase
                                 proc.sendline(phrase)
@@ -506,4 +508,4 @@ def make_repo(repodir,
                         proc.close(terminate=True, kill=True)
 
     cmd = 'createrepo --update {0}'.format(repodir)
-    return __salt__['cmd.run_all'](cmd, runas=runas)
+    return __salt__['cmd.run_all'](cmd, runas=runas, env=env)

--- a/salt/modules/rpmbuild.py
+++ b/salt/modules/rpmbuild.py
@@ -248,7 +248,7 @@ def build(runas,
     srpm_dir = os.path.join(dest_dir, 'SRPMS')
     srpm_build_dir = tempfile.mkdtemp()
     try:
-        srpms = make_src_pkg(srpm_build_dir, spec, sources, env, template, saltenv)
+        srpms = make_src_pkg(srpm_build_dir, spec, sources, env, saltenv)
     except Exception as exc:
         shutil.rmtree(srpm_build_dir)
         log.error('Failed to make src package')


### PR DESCRIPTION
### What does this PR do?
It fixes several problems with the `rpmbuild.py`-module:
- make_repo can be used to sign packages, but it only signed packages in the root of `repodir`. This has been changed to recursively walk the filesystem (without following symlinks).
- make_repo: Documentation of the keyid-parameter included information about storing private keys in the pillar, however this specific pillar-data is never used. Removed this documentation and added a bit to explain how the pillar variables *are* used.
- make_repo: Documentation of the keyid-parameter did not mention that only the last 8 hex-digits of the GPG-keyid should be supplied. This has been added.
- make_repo: The command used to sign packages is executed via salt.utils.vt.Terminal, however the `gnupghome`-parameter was not used here, causing package signing to fail. It has been added to the `env`-paramater passed to the proc.

This commit also includes some small pylint-inspired changes.

### What issues does this PR fix or reference?
None that I'm aware of.

### Previous Behavior
- make_repo does not sign packages if GNUPGHOME environment variable is not set correctly on the minion it is executed on, even though a `gnupghome`-parameter is available.
- make_repo only signs packages in the root of the supplied `repodir`.

### New Behavior
- make_repo signs packages in all subdirs of the supplied `repodir`.
- make_repo signs packages even if the GNUPGHOME environment variable is not present on the minion it is executed on.

### Tests written?
No

### Commits signed with GPG?
Yes