### PR TITLE
Fix calls to file.lsattr when lsattr is not installed

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -511,6 +511,9 @@ def _cmp_attrs(path, attrs):
     Returns a pair (list) where first item are attributes to
     add and second item are to be removed.
 
+    Please take into account when using this function that some minions will
+    not have lsattr installed.
+
     path
         path to file to compare attributes with.
 
@@ -519,7 +522,11 @@ def _cmp_attrs(path, attrs):
     '''
     diff = [None, None]
 
-    lattrs = lsattr(path).get(path, '')
+    try:
+        lattrs = lsattr(path).get(path, '')
+    except AttributeError:
+        # lsattr not installed
+        return None
 
     old = [chr for chr in lattrs if chr not in attrs]
     if len(old) > 0:
@@ -535,6 +542,8 @@ def _cmp_attrs(path, attrs):
 def lsattr(path):
     '''
     .. versionadded:: 2018.3.0
+    .. versionchanged:: 2018.3.1
+        If ``lsattr`` is not installed on the system, ``None`` is returned.
 
     Obtain the modifiable attributes of the given file. If path
     is to a directory, an empty list is returned.
@@ -548,6 +557,9 @@ def lsattr(path):
 
         salt '*' file.lsattr foo1.txt
     '''
+    if not salt.utils.path.which('lsattr'):
+        return None
+
     if not os.path.exists(path):
         raise SaltInvocationError("File or directory does not exist.")
 
@@ -4425,7 +4437,6 @@ def check_perms(name, ret, user, group, mode, attrs=None, follow_symlinks=False)
         ``follow_symlinks`` option added
     '''
     name = os.path.expanduser(name)
-    lsattr_cmd = salt.utils.path.which('lsattr')
 
     if not ret:
         ret = {'name': name,
@@ -4445,12 +4456,14 @@ def check_perms(name, ret, user, group, mode, attrs=None, follow_symlinks=False)
     perms['lmode'] = salt.utils.files.normalize_mode(cur['mode'])
 
     is_dir = os.path.isdir(name)
-    if not salt.utils.platform.is_windows() and not is_dir and lsattr_cmd:
-        # List attributes on file
-        perms['lattrs'] = ''.join(lsattr(name).get('name', ''))
-        # Remove attributes on file so changes can be enforced.
-        if perms['lattrs']:
-            chattr(name, operator='remove', attributes=perms['lattrs'])
+    if not salt.utils.platform.is_windows() and not is_dir:
+        lattrs = lsattr(name)
+        if lattrs is not None:
+            # List attributes on file
+            perms['lattrs'] = ''.join(lattrs.get('name', ''))
+            # Remove attributes on file so changes can be enforced.
+            if perms['lattrs']:
+                chattr(name, operator='remove', attributes=perms['lattrs'])
 
     # Mode changes if needed
     if mode is not None:
@@ -4556,9 +4569,9 @@ def check_perms(name, ret, user, group, mode, attrs=None, follow_symlinks=False)
     if __opts__['test'] is True and ret['changes']:
         ret['result'] = None
 
-    if not salt.utils.platform.is_windows() and not is_dir and lsattr_cmd:
+    if not salt.utils.platform.is_windows() and not is_dir:
         # Replace attributes on file if it had been removed
-        if perms['lattrs']:
+        if perms.get('lattrs', ''):
             chattr(name, operator='add', attributes=perms['lattrs'])
 
     # Modify attributes of file if needed
@@ -4569,22 +4582,23 @@ def check_perms(name, ret, user, group, mode, attrs=None, follow_symlinks=False)
             pass
         else:
             diff_attrs = _cmp_attrs(name, attrs)
-            if diff_attrs[0] is not None or diff_attrs[1] is not None:
-                if __opts__['test'] is True:
-                    ret['changes']['attrs'] = attrs
-                else:
-                    if diff_attrs[0] is not None:
-                        chattr(name, operator="add", attributes=diff_attrs[0])
-                    if diff_attrs[1] is not None:
-                        chattr(name, operator="remove", attributes=diff_attrs[1])
-                    cmp_attrs = _cmp_attrs(name, attrs)
-                    if cmp_attrs[0] is not None or cmp_attrs[1] is not None:
-                        ret['result'] = False
-                        ret['comment'].append(
-                            'Failed to change attributes to {0}'.format(attrs)
-                        )
-                    else:
+            if diff_attrs is not None:
+                if diff_attrs[0] is not None or diff_attrs[1] is not None:
+                    if __opts__['test'] is True:
                         ret['changes']['attrs'] = attrs
+                    else:
+                        if diff_attrs[0] is not None:
+                            chattr(name, operator="add", attributes=diff_attrs[0])
+                        if diff_attrs[1] is not None:
+                            chattr(name, operator="remove", attributes=diff_attrs[1])
+                        cmp_attrs = _cmp_attrs(name, attrs)
+                        if cmp_attrs[0] is not None or cmp_attrs[1] is not None:
+                            ret['result'] = False
+                            ret['comment'].append(
+                                'Failed to change attributes to {0}'.format(attrs)
+                            )
+                        else:
+                            ret['changes']['attrs'] = attrs
 
     return ret, perms
 
@@ -4787,7 +4801,6 @@ def check_file_meta(
     contents
         File contents
     '''
-    lsattr_cmd = salt.utils.path.which('lsattr')
     changes = {}
     if not source_sum:
         source_sum = dict()
@@ -4859,14 +4872,13 @@ def check_file_meta(
         if mode is not None and mode != smode:
             changes['mode'] = mode
 
-        if lsattr_cmd and attrs:
+        if attrs:
             diff_attrs = _cmp_attrs(name, attrs)
-            if (
-                attrs is not None and
-                diff_attrs[0] is not None or
-                diff_attrs[1] is not None
-            ):
-                changes['attrs'] = attrs
+            if diff_attrs is not None:
+                if attrs is not None \
+                        and (diff_attrs[0] is not None
+                             or diff_attrs[1] is not None):
+                    changes['attrs'] = attrs
 
     return changes
 


### PR DESCRIPTION
This was partially fixed before 2018.3.0, but some careless programming since then has caused problems to return. This fixes those by making `file.lsattr` return `None` when lsattr is not installed, and then fixes all references to take this into account.