### PR TITLE
Return an empty dict for 'changes' instead of 'None'

### DIFF
--- a/salt/states/boto_cfn.py
+++ b/salt/states/boto_cfn.py
@@ -186,7 +186,7 @@ def present(name, template_body=None, template_url=None, parameters=None, notifi
             ret['changes']['new'] = updated
             return ret
         ret['comment'] = 'Stack {0} exists.'.format(name)
-        ret['changes'] = None
+        ret['changes'] = {}
         return ret
     if __opts__['test']:
         ret['comment'] = 'Stack {0} is set to be created.'.format(name)
@@ -221,7 +221,7 @@ def absent(name, region=None, key=None, keyid=None, profile=None):
     ret = {'name': name, 'result': True, 'comment': '', 'changes': {}}
     if not __salt__['boto_cfn.exists'](name, region, key, keyid, profile):
         ret['comment'] = 'Stack {0} does not exist.'.format(name)
-        ret['changes'] = None
+        ret['changes'] = {}
         return ret
     if __opts__['test']:
         ret['comment'] = 'Stack {0} is set to be deleted.'.format(name)
@@ -232,7 +232,7 @@ def absent(name, region=None, key=None, keyid=None, profile=None):
         code, message = _get_error(deleted)
         ret['comment'] = 'Stack {0} could not be deleted.\n{1}\n{2}'.format(name, code, message)
         ret['result'] = False
-        ret['changes'] = None
+        ret['changes'] = {}
         return ret
     if deleted:
         ret['comment'] = 'Stack {0} was deleted.'.format(name)

--- a/salt/states/boto_iam.py
+++ b/salt/states/boto_iam.py
@@ -1324,7 +1324,7 @@ def account_policy(name=None, allow_users_to_change_password=None,
                                                            region, key, keyid, profile):
         return ret
     ret['comment'] = 'Account policy is not changed.'
-    ret['changes'] = None
+    ret['changes'] = {}
     ret['result'] = False
     return ret
 

--- a/salt/states/boto_iot.py
+++ b/salt/states/boto_iot.py
@@ -727,7 +727,7 @@ def topic_rule_present(name, ruleName, sql, actions, description='',
     if need_update:
         if __opts__['test']:
             msg = 'Rule {0} set to be modified.'.format(ruleName)
-            ret['changes'] = None
+            ret['changes'] = {}
             ret['comment'] = msg
             ret['result'] = None
             return ret

--- a/salt/states/glassfish.py
+++ b/salt/states/glassfish.py
@@ -250,7 +250,7 @@ def connection_factory_present(name,
                 ret['comment'] = 'Connection factory updated'
         else:
             ret['result'] = True
-            ret['changes'] = None
+            ret['changes'] = {}
             ret['comment'] = 'Connection factory is already up-to-date'
     else:
         ret['result'] = False
@@ -528,7 +528,7 @@ def jdbc_datasource_present(name,
                 ret['comment'] = 'JDBC Datasource updated'
         else:
             ret['result'] = True
-            ret['changes'] = None
+            ret['changes'] = {}
             ret['comment'] = 'JDBC Datasource is already up-to-date'
     else:
         ret['result'] = False
@@ -602,7 +602,7 @@ def system_properties_present(server=None, **kwargs):
             ret['changes'] = kwargs
             ret['coment'] = 'System properties would have been updated'
     else:
-        ret['changes'] = None
+        ret['changes'] = {}
         ret['result'] = True
         ret['comment'] = 'System properties are already up-to-date'
     return ret

--- a/salt/states/grafana_datasource.py
+++ b/salt/states/grafana_datasource.py
@@ -100,7 +100,7 @@ def present(name,
         if ret['changes']['new'] or ret['changes']['old']:
             ret['comment'] = 'Data source {0} updated'.format(name)
         else:
-            ret['changes'] = None
+            ret['changes'] = {}
             ret['comment'] = 'Data source {0} already up-to-date'.format(name)
     else:
         requests.post(

--- a/salt/states/influxdb_user.py
+++ b/salt/states/influxdb_user.py
@@ -122,7 +122,7 @@ def present(name,
                         'following changes:'.format(name)
                 for k, v in ret['changes']:
                     ret['comment'] += '\n{0} => {1}'.format(k, v)
-                ret['changes'] = None
+                ret['changes'] = {}
             else:
                 ret['comment'] = 'Updated user {0}'.format(name)
 

--- a/tests/unit/states/test_grafana_datasource.py
+++ b/tests/unit/states/test_grafana_datasource.py
@@ -59,7 +59,7 @@ class GrafanaDatasourceTestCase(TestCase, LoaderModuleMockMixin):
                 )
                 self.assertTrue(ret['result'])
                 self.assertEqual(ret['comment'], 'Data source test already up-to-date')
-                self.assertEqual(ret['changes'], None)
+                self.assertEqual(ret['changes'], {})
 
             with patch('requests.put') as rput:
                 ret = grafana_datasource.present('test', 'type', 'newurl', profile=profile)


### PR DESCRIPTION

### What does this PR do?

Replaces any cases where a state would return `None` with an empty dict (`{}`).

### What issues does this PR fix or reference?

Fixes #47059

Ref #47048

### Previous Behavior
States would return `None` in some circumstances.

### New Behavior
States now return `{}` instead of `None`


### Tests written?

No

Note that this fix has not been tested for any knock-on negative effects, it's purely a speculative change against a code structure anomaly.


### Commits signed with GPG?

No

