### PR TITLE
Kitchn should ignore artifacts directory

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -46,6 +46,7 @@ provisioner:
     - .bundle
     - .kitchen
     - .kitchen.yml
+    - artifacts
     - Gemfile
     - Gemfile.lock
     - README.rst


### PR DESCRIPTION
### What does this PR do?

Configure kitchen to ignore `artifacts` directory

### Previous Behavior

Kitchen transfers artifacts directory which might cause some tests to fail

### New Behavior

Kitchen ignores artifacts dir

### Tests written?

No - Fixes existing tests

### Commits signed with GPG?

Yes