### PR TITLE
Correct examples in smartos state docs to be valid yaml

### DIFF
--- a/salt/states/smartos.py
+++ b/salt/states/smartos.py
@@ -25,14 +25,14 @@ Management of SmartOS Standalone Compute Nodes
               label: 'test vm'
               owner: 'sjorge'
             nics:
-              "82:1b:8e:49:e9:12"
+              "82:1b:8e:49:e9:12":
                 nic_tag: trunk
                 mtu: 1500
                 ips:
                   - 172.16.1.123/16
                   - 192.168.2.123/24
                 vlan_id: 10
-              "82:1b:8e:49:e9:13"
+              "82:1b:8e:49:e9:13":
                 nic_tag: trunk
                 mtu: 1500
                 ips:
@@ -64,7 +64,7 @@ Management of SmartOS Standalone Compute Nodes
                 compression: lz4
                 boot: true
             nics:
-              "82:1b:8e:49:e9:15"
+              "82:1b:8e:49:e9:15":
                 nic_tag: trunk
                 mtu: 1500
                 ips:


### PR DESCRIPTION
### What does this PR do?
There were missing ```:``` at the end of the MAC addresses in the examples.

### What issues does this PR fix or reference?
N/a

### Previous Behavior
Docs for smartos state had invalid yaml.

### New Behavior
Docs now have valid yaml

### Tests written?
No

### Commits signed with GPG?
No

### Backports needed?
- 2018.3
- 2017.7