### PR TITLE
pillar_ldap: Load config options as str types

### DIFF
--- a/salt/modules/ldapmod.py
+++ b/salt/modules/ldapmod.py
@@ -86,7 +86,7 @@ def _config(name, key=None, **kwargs):
         value = kwargs[name]
     else:
         value = __salt__['config.option']('ldap.{0}'.format(key))
-    return value
+    return salt.utils.data.decode(value, to_str=True)
 
 
 def _connect(**kwargs):
@@ -141,7 +141,7 @@ def search(filter,      # pylint: disable=C0103
     if attrs == '':  # Allow command line 'return all' attr override
         attrs = None
     elif attrs is None:
-        attrs = salt.utils.data.decode(_config('attrs'), to_str=True)
+        attrs = _config('attrs')
     _ldap = _connect(**kwargs)
     start = time.time()
     log.debug(

--- a/salt/pillar/pillar_ldap.py
+++ b/salt/pillar/pillar_ldap.py
@@ -118,6 +118,7 @@ import os
 import logging
 
 # Import salt libs
+import salt.utils.data
 from salt.exceptions import SaltInvocationError
 
 # Import third party libs
@@ -158,7 +159,7 @@ def _config(name, conf):
     Return a value for 'name' from  the config file options.
     '''
     try:
-        value = conf[name]
+        value = salt.utils.data.decode(conf[name], to_str=True)
     except KeyError:
         value = None
     return value


### PR DESCRIPTION
Also make the same str type enforcement apply to all calls to _config() in ldapmod.py.

This is a follow-up to #47029.