### PR TITLE
Fix failing state test by normalizing line endings

### DIFF
--- a/tests/integration/modules/test_state.py
+++ b/tests/integration/modules/test_state.py
@@ -32,7 +32,7 @@ def trim_line_end(line):
     '''
     if line[-2:] == salt.utils.to_bytes('\r\n'):
         return line[:-2]
-    elif line[-1] == salt.utils.to_bytes('\n'):
+    elif line[-1:] == salt.utils.to_bytes('\n'):
         return line[:-1]
     raise Exception("Invalid line ending")
 


### PR DESCRIPTION
### What does this PR do?

Fixes:

integration.modules.test_state.StateModuleTest.test_issue_1896_file_append_source

### What issues does this PR fix or reference?

### Previous Behavior

If git is mis-configured or the test is run through kitchen the file won't have the required line endings for the test.

### New Behavior

The line endings are normalized and the test passes

### Tests written?

No - Fixes test

### Commits signed with GPG?

Yes