### PR TITLE
saltclass: added pillars to __pillar__ when encountered

### DIFF
--- a/salt/utils/saltclass.py
+++ b/salt/utils/saltclass.py
@@ -171,6 +171,10 @@ def expand_classes_in_order(minion_dict,
             # Fix corner case where class is loaded but doesn't contain anything
             if expanded_classes[klass] is None:
                 expanded_classes[klass] = {}
+
+            # Merge newly found pillars into existing ones
+            dict_merge(salt_data['__pillar__'], expanded_classes[klass].get('pillars', {}))
+
             # Now replace class element in classes_to_expand by expansion
             if 'classes' in expanded_classes[klass]:
                 l_id = classes_to_expand.index(klass)
@@ -237,6 +241,9 @@ def expanded_dict_from_minion(minion_id, salt_data):
     else:
         log.warning('%s: Node definition not found', minion_id)
         node_dict[minion_id] = {}
+
+    # Merge newly found pillars into existing ones
+    dict_merge(salt_data['__pillar__'], node_dict[minion_id].get('pillars', {}))
 
     # Get 2 ordered lists:
     # expanded_classes: A list of all the dicts


### PR DESCRIPTION
### What does this PR do?

Add found pillars to the `__pillar__` variable when encountered.
This allows referencing other `__pillar__` dynamically and also more
complex jinja operations referencing in saltclass defined pillars.

#### Example

`nodes/node1.yml`:

```yaml
classes:
  - some_server

pillars:
  some_server_instances:
    instance1:
      port: 80
    instance1:
      port: 8080
```

`classes/some_server.yml`:

```yaml
pillars:
  all_server_ports:
  {% for val in __pillar__.get('some_server_instances', []).values() %}
    - {{val.port}}
  {% endfor %}
```


### What issues does this PR fix or reference?

N/A

### Previous Behavior

Referencing other pillars  that are defined (earlier or later) in saltclass is possible with variable expansion.

### New Behavior

Referencing all (already) defined pillars in saltclass from within saltclass, leveraging full jinja support.

### Tests written?

No

### Commits signed with GPG?

No