### PR TITLE
dont allow using no_use_wheel for pip 10.0.0 or newer

### DIFF
--- a/salt/modules/pip.py
+++ b/salt/modules/pip.py
@@ -798,6 +798,11 @@ def install(pkgs=None,  # pylint: disable=R0912,R0913,R0914
         # Put the commas back in while making sure the names are contained in
         # quotes, this allows for proper version spec passing salt>=0.17.0
         cmd.extend(['{0}'.format(p.replace(';', ',')) for p in pkgs])
+    else:
+        # Starting with pip 10.0.0, if no packages are specified in the
+        # command, it returns a retcode 1.  So instead of running the command,
+        # just return the output without running pip.
+        return {'retcode': 0, 'stdout': 'No packages to install.'}
 
     if editable:
         egg_match = re.compile(r'(?:#|#.*?&)egg=([^&]*)')

--- a/salt/modules/pip.py
+++ b/salt/modules/pip.py
@@ -798,7 +798,7 @@ def install(pkgs=None,  # pylint: disable=R0912,R0913,R0914
         # Put the commas back in while making sure the names are contained in
         # quotes, this allows for proper version spec passing salt>=0.17.0
         cmd.extend(['{0}'.format(p.replace(';', ',')) for p in pkgs])
-    else:
+    elif not any([requirements, editable]):
         # Starting with pip 10.0.0, if no packages are specified in the
         # command, it returns a retcode 1.  So instead of running the command,
         # just return the output without running pip.

--- a/salt/states/pip_state.py
+++ b/salt/states/pip_state.py
@@ -321,7 +321,8 @@ def installed(name,
               use_vt=False,
               trusted_host=None,
               no_cache_dir=False,
-              cache_dir=None):
+              cache_dir=None,
+              no_binary=None):
     '''
     Make sure the package is installed
 
@@ -355,6 +356,25 @@ def installed(name,
 
     no_use_wheel : False
         Force to not use wheel archives (requires pip>=1.4)
+
+    no_binary
+        Force to not use binary packages (requires pip >= 7.0.0)
+        Accepts either :all: to disable all binary packages, :none: to empty the set,
+        or a list of one or more packages
+
+    Example:
+
+    .. code-block:: yaml
+
+        django:
+          pip.installed:
+            - no_binary: ':all:'
+
+        flask:
+          pip.installed:
+            - no_binary:
+              - itsdangerous
+              - click
 
     log
         Log file where a complete (maximum verbosity) record will be kept
@@ -598,23 +618,39 @@ def installed(name,
     # Check that the pip binary supports the 'use_wheel' option
     if use_wheel:
         min_version = '1.4'
+        max_version = '9.0.3'
         cur_version = __salt__['pip.version'](bin_env)
-        if not salt.utils.compare_versions(ver1=cur_version, oper='>=',
-                                           ver2=min_version):
+        too_low = salt.utils.compare_versions(ver1=cur_version, oper='<', ver2=min_version)
+        too_high = salt.utils.compare_versions(ver1=cur_version, oper='>', ver2=max_version)
+        if too_low or too_high:
             ret['result'] = False
             ret['comment'] = ('The \'use_wheel\' option is only supported in '
-                              'pip {0} and newer. The version of pip detected '
-                              'was {1}.').format(min_version, cur_version)
+                              'pip between {0} and {1}. The version of pip detected '
+                              'was {2}.').format(min_version, max_version, cur_version)
             return ret
 
     # Check that the pip binary supports the 'no_use_wheel' option
     if no_use_wheel:
         min_version = '1.4'
+        max_version = '9.0.3'
         cur_version = __salt__['pip.version'](bin_env)
-        if not salt.utils.compare_versions(ver1=cur_version, oper='>=',
-                                           ver2=min_version):
+        too_low = salt.utils.compare_versions(ver1=cur_version, oper='<', ver2=min_version)
+        too_high = salt.utils.compare_versions(ver1=cur_version, oper='>', ver2=max_version)
+        if too_low or too_high:
             ret['result'] = False
             ret['comment'] = ('The \'no_use_wheel\' option is only supported in '
+                              'pip between {0} and {1}. The version of pip detected '
+                              'was {2}.').format(min_version, max_version, cur_version)
+            return ret
+
+    # Check that the pip binary supports the 'no_binary' option
+    if no_binary:
+        min_version = '7.0.0'
+        cur_version = __salt__['pip.version'](bin_env)
+        too_low = salt.utils.compare_versions(ver1=cur_version, oper='<', ver2=min_version)
+        if too_low:
+            ret['result'] = False
+            ret['comment'] = ('The \'no_binary\' option is only supported in '
                               'pip {0} and newer. The version of pip detected '
                               'was {1}.').format(min_version, cur_version)
             return ret
@@ -730,6 +766,7 @@ def installed(name,
         bin_env=bin_env,
         use_wheel=use_wheel,
         no_use_wheel=no_use_wheel,
+        no_binary=no_binary,
         log=log,
         proxy=proxy,
         timeout=timeout,

--- a/salt/states/virtualenv_mod.py
+++ b/salt/states/virtualenv_mod.py
@@ -57,7 +57,8 @@ def managed(name,
             pip_pkgs=None,
             pip_no_cache_dir=False,
             pip_cache_dir=None,
-            process_dependency_links=False):
+            process_dependency_links=False,
+            no_binary=None):
     '''
     Create a virtualenv and optionally manage it with pip
 
@@ -102,6 +103,11 @@ def managed(name,
 
     no_use_wheel: False
         Force to not use wheel archives (requires pip>=1.4)
+
+    no_binary
+        Force to not use binary packages (requires pip >= 7.0.0)
+        Accepts either :all: to disable all binary packages, :none: to empty the set,
+        or a list of one or more packages
 
     pip_upgrade: False
         Pass `--upgrade` to `pip install`.
@@ -222,27 +228,44 @@ def managed(name,
     elif venv_exists:
         ret['comment'] = 'virtualenv exists'
 
+    # Check that the pip binary supports the 'use_wheel' option
     if use_wheel:
         min_version = '1.4'
+        max_version = '9.0.3'
         cur_version = __salt__['pip.version'](bin_env=name)
-        if not salt.utils.compare_versions(ver1=cur_version, oper='>=',
-                                           ver2=min_version):
+        too_low = salt.utils.compare_versions(ver1=cur_version, oper='<', ver2=min_version)
+        too_high = salt.utils.compare_versions(ver1=cur_version, oper='>', ver2=max_version)
+        if too_low or too_high:
             ret['result'] = False
             ret['comment'] = ('The \'use_wheel\' option is only supported in '
-                              'pip {0} and newer. The version of pip detected '
-                              'was {1}.').format(min_version, cur_version)
+                              'pip between {0} and {1}. The version of pip detected '
+                              'was {2}.').format(min_version, max_version, cur_version)
             return ret
 
+    # Check that the pip binary supports the 'no_use_wheel' option
     if no_use_wheel:
         min_version = '1.4'
+        max_version = '9.0.3'
         cur_version = __salt__['pip.version'](bin_env=name)
-        if not salt.utils.compare_versions(ver1=cur_version, oper='>=',
-                                           ver2=min_version):
+        too_low = salt.utils.compare_versions(ver1=cur_version, oper='<', ver2=min_version)
+        too_high = salt.utils.compare_versions(ver1=cur_version, oper='>', ver2=max_version)
+        if too_low or too_high:
             ret['result'] = False
-            ret['comment'] = ('The \'no_use_wheel\' option is only supported '
-                              'in pip {0} and newer. The version of pip '
-                              'detected was {1}.').format(min_version,
-                                                          cur_version)
+            ret['comment'] = ('The \'no_use_wheel\' option is only supported in '
+                              'pip between {0} and {1}. The version of pip detected '
+                              'was {2}.').format(min_version, max_version, cur_version)
+            return ret
+
+    # Check that the pip binary supports the 'no_binary' option
+    if no_binary:
+        min_version = '7.0.0'
+        cur_version = __salt__['pip.version'](bin_env=name)
+        too_low = salt.utils.compare_versions(ver1=cur_version, oper='<', ver2=min_version)
+        if too_low:
+            ret['result'] = False
+            ret['comment'] = ('The \'no_binary\' option is only supported in '
+                              'pip {0} and newer. The version of pip detected '
+                              'was {1}.').format(min_version, cur_version)
             return ret
 
     # Populate the venv via a requirements file
@@ -275,6 +298,7 @@ def managed(name,
             bin_env=name,
             use_wheel=use_wheel,
             no_use_wheel=no_use_wheel,
+            no_binary=no_binary,
             user=user,
             cwd=cwd,
             index_url=index_url,

--- a/tests/integration/files/file/base/issue-1959-virtualenv-runas/init.sls
+++ b/tests/integration/files/file/base/issue-1959-virtualenv-runas/init.sls
@@ -4,6 +4,5 @@
     - user: issue-1959
     {%- if grains.get('pythonversion')[0] != 2 %}
     {#- wheels are disabled because the pip cache dir will not be owned by the above issue-1959 user. Need to check this ASAP #}
-    - use_wheel: False
-    - no_use_wheel: True
+    - no_binary: ':all:'
     {%- endif %}

--- a/tests/unit/modules/test_pip.py
+++ b/tests/unit/modules/test_pip.py
@@ -139,11 +139,12 @@ class PipTestCase(TestCase, LoaderModuleMockMixin):
             expected = ['pip', 'install', '--use-mirrors']
             for item in mirrors:
                 expected.extend(['--mirrors', item])
+            expected.append('pep8')
 
             # Passing mirrors as a list
             mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
             with patch.dict(pip.__salt__, {'cmd.run_all': mock}):
-                pip.install(mirrors=mirrors)
+                pip.install(pkgs=['pep8'], mirrors=mirrors)
                 mock.assert_called_once_with(
                     expected,
                     saltenv='base',
@@ -155,7 +156,7 @@ class PipTestCase(TestCase, LoaderModuleMockMixin):
             # Passing mirrors as a comma separated list
             mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
             with patch.dict(pip.__salt__, {'cmd.run_all': mock}):
-                pip.install(mirrors=','.join(mirrors))
+                pip.install(pkgs=['pep8'], mirrors=','.join(mirrors))
                 mock.assert_called_once_with(
                     expected,
                     saltenv='base',
@@ -167,9 +168,9 @@ class PipTestCase(TestCase, LoaderModuleMockMixin):
             # As single string (just use the first element from mirrors)
             mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
             with patch.dict(pip.__salt__, {'cmd.run_all': mock}):
-                pip.install(mirrors=mirrors[0])
+                pip.install(pkgs=['pep8'], mirrors=mirrors[0])
                 mock.assert_called_once_with(
-                    ['pip', 'install', '--use-mirrors', '--mirrors', mirrors[0]],
+                    ['pip', 'install', '--use-mirrors', '--mirrors', mirrors[0], 'pep8'],
                     saltenv='base',
                     runas=None,
                     use_vt=False,

--- a/tests/unit/states/test_virtualenv_mod.py
+++ b/tests/unit/states/test_virtualenv_mod.py
@@ -75,7 +75,7 @@ class VirtualenvModTestCase(TestCase, LoaderModuleMockMixin):
 
                 with patch.dict(virtualenv_mod.__opts__, {"test": False}):
                     ret.update({'comment': "The 'use_wheel' option is"
-                                " only supported in pip 1.4 and newer."
+                                " only supported in pip between 1.4 and 9.0.3."
                                 " The version of pip detected was 1.1.",
                                 'result': False})
                     self.assertDictEqual(virtualenv_mod.managed('salt',


### PR DESCRIPTION
### What does this PR do?
The --no-use-wheel flag has been deprecated in pip 10.0.0

### Tests written?

Yes, there is a test that uses this right now, which is failing, and will stop failing once this has been merged.

### Commits signed with GPG?

Yes