### PR TITLE
Fix unit.utils.test_event.TestAsyncEventPublisher.test_event_subscription

### DIFF
--- a/tests/unit/test_minion.py
+++ b/tests/unit/test_minion.py
@@ -18,12 +18,13 @@ from salt.utils import event
 from salt.exceptions import SaltSystemExit
 import salt.syspaths
 import tornado
+import tornado.testing
 
 __opts__ = {}
 
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
-class MinionTestCase(TestCase):
+class MinionTestCase(TestCase, tornado.testing.AsyncTestCase):
     def test_invalid_master_address(self):
         with patch.dict(__opts__, {'ipv6': False, 'master': float('127.0'), 'master_port': '4555', 'retry_dns': False}):
             self.assertRaises(SaltSystemExit, minion.resolve_dns, __opts__)


### PR DESCRIPTION
### What does this PR do?

Fix unit.utils.test_event.TestAsyncEventPublisher.test_event_subscription

### Previous Behavior

Test failed when run with other unit tests but passed when run by itself.

### New Behavior

unit.utils.test_event.TestAsyncEventPublisher.test_event_subscription will pass when run with full unit-test and integration test suite.

### Tests written?

No - Fixes tests

### Commits signed with GPG?

Yes