### PR TITLE
Fixes misusing of the timeout option.

### DIFF
--- a/salt/netapi/rest_tornado/saltnado.py
+++ b/salt/netapi/rest_tornado/saltnado.py
@@ -289,7 +289,7 @@ class EventListener(object):
 
         self.event.set_event_handler(self._handle_event_socket_recv)
 
-    def clean_timeout_futures(self, request):
+    def clean_by_request(self, request):
         '''
         Remove all futures that were waiting for request `request` since it is done waiting
         '''
@@ -481,7 +481,7 @@ class BaseSaltAPIHandler(tornado.web.RequestHandler):  # pylint: disable=W0223
         timeout a session
         '''
         # TODO: set a header or something??? so we know it was a timeout
-        self.application.event_listener.clean_timeout_futures(self)
+        self.application.event_listener.clean_by_request(self)
 
     def on_finish(self):
         '''
@@ -965,8 +965,7 @@ class SaltAPIHandler(BaseSaltAPIHandler):  # pylint: disable=W0223
             tag = tagify([jid, 'ret', minion], 'job')
             minion_future = self.application.event_listener.get_event(self,
                                                                       tag=tag,
-                                                                      matcher=EventListener.exact_matcher,
-                                                                      timeout=self.application.opts['timeout'])
+                                                                      matcher=EventListener.exact_matcher)
             future_minion_map[minion_future] = minion
         return future_minion_map
 
@@ -1032,8 +1031,7 @@ class SaltAPIHandler(BaseSaltAPIHandler):  # pylint: disable=W0223
             try:
                 event = self.application.event_listener.get_event(self,
                                                                   tag=ping_tag,
-                                                                  timeout=self.application.opts['gather_job_timeout'],
-                                                                  )
+                                                                  timeout=self.application.opts['gather_job_timeout'])
                 f = yield Any([event, is_finished])
                 # When finished entire routine, cleanup other futures and return result
                 if f is is_finished:

--- a/tests/unit/netapi/rest_tornado/test_utils.py
+++ b/tests/unit/netapi/rest_tornado/test_utils.py
@@ -139,3 +139,84 @@ class TestEventListener(AsyncTestCase):
             self.assertTrue(event_future.done())
             with self.assertRaises(saltnado.TimeoutException):
                 event_future.result()
+
+    def test_clean_by_request(self):
+        '''
+        Make sure the method clean_by_request clean up every related data in EventListener
+        request_future_1 : will be timeout-ed by clean_by_request(self)
+        request_future_2 : will be finished by me.fire_event ...
+        dummy_request_future_1 : will be finished by me.fire_event ...
+        dummy_request_future_2 : will be timeout-ed by clean-by_request(dummy_request)
+        '''
+        class DummyRequest(object):
+            '''
+            Dummy request object to simulate the request object
+            '''
+            @property
+            def _finished(self):
+                '''
+                Simulate _finished of the request object
+                '''
+                return False
+
+        # Inner functions never permit modifying primitive values directly
+        cnt = [0]
+
+        def stop():
+            '''
+            To realize the scenario of this test, define a custom stop method to call
+            self.stop after finished two events.
+            '''
+            cnt[0] += 1
+            if cnt[0] == 2:
+                self.stop()
+
+        with eventpublisher_process():
+            me = event.MasterEvent(SOCK_DIR)
+            event_listener = saltnado.EventListener({},  # we don't use mod_opts, don't save?
+                                                    {'sock_dir': SOCK_DIR,
+                                                     'transport': 'zeromq'})
+
+            self.assertEqual(0, len(event_listener.tag_map))
+            self.assertEqual(0, len(event_listener.request_map))
+
+            self._finished = False  # fit to event_listener's behavior
+            dummy_request = DummyRequest()
+            request_future_1 = event_listener.get_event(self, tag='evt1')
+            request_future_2 = event_listener.get_event(self, tag='evt2', callback=lambda f: stop())
+            dummy_request_future_1 = event_listener.get_event(dummy_request, tag='evt3', callback=lambda f: stop())
+            dummy_request_future_2 = event_listener.get_event(dummy_request, timeout=10, tag='evt4')
+
+            self.assertEqual(4, len(event_listener.tag_map))
+            self.assertEqual(2, len(event_listener.request_map))
+
+            me.fire_event({'data': 'foo2'}, 'evt2')
+            me.fire_event({'data': 'foo3'}, 'evt3')
+            self.wait()
+            event_listener.clean_by_request(self)
+            me.fire_event({'data': 'foo1'}, 'evt1')
+
+            self.assertTrue(request_future_1.done())
+            with self.assertRaises(saltnado.TimeoutException):
+                request_future_1.result()
+
+            self.assertTrue(request_future_2.done())
+            self.assertEqual(request_future_2.result()['tag'], 'evt2')
+            self.assertEqual(request_future_2.result()['data']['data'], 'foo2')
+
+            self.assertTrue(dummy_request_future_1.done())
+            self.assertEqual(dummy_request_future_1.result()['tag'], 'evt3')
+            self.assertEqual(dummy_request_future_1.result()['data']['data'], 'foo3')
+
+            self.assertFalse(dummy_request_future_2.done())
+
+            self.assertEqual(2, len(event_listener.tag_map))
+            self.assertEqual(1, len(event_listener.request_map))
+
+            event_listener.clean_by_request(dummy_request)
+
+            with self.assertRaises(saltnado.TimeoutException):
+                dummy_request_future_2.result()
+
+            self.assertEqual(0, len(event_listener.tag_map))
+            self.assertEqual(0, len(event_listener.request_map))


### PR DESCRIPTION
### What does this PR do?

Fixes misusing of the timeout option. Detailed descriptions of this pr are in #46326.

### What issues does this PR fix or reference?

#46326

### Previous Behavior

Timeout after waiting 'timeout' seconds for minions' job.

### New Behavior

Waiting forever until the request has been finished.

### Tests written?

Yes

### Commits signed with GPG?

Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.