### PR TITLE
Support proto for IPSec policy extension in iptables state

### DIFF
--- a/salt/modules/iptables.py
+++ b/salt/modules/iptables.py
@@ -205,6 +205,14 @@ def build_rule(table='filter', chain=None, command=None, position='', full=None,
     To pass in jump options that doesn't take arguments, pass in an empty
     string.
 
+    .. note::
+
+        Whereas iptables will accept ``-p``, ``--proto[c[o[l]]]`` as synonyms
+        of ``--protocol``, if ``--proto`` appears in an iptables command after
+        the appearance of ``-m policy``, it is interpreted as the ``--proto``
+        option of the policy extension (see the iptables-extensions(8) man
+        page).
+
     CLI Examples:
 
     .. code-block:: bash
@@ -235,7 +243,6 @@ def build_rule(table='filter', chain=None, command=None, position='', full=None,
         salt '*' iptables.build_rule filter INPUT command=I position=3 \\
             full=True match=state state=RELATED,ESTABLISHED jump=ACCEPT \\
             family=ipv6
-
     '''
     if 'target' in kwargs:
         kwargs['jump'] = kwargs.pop('target')
@@ -249,7 +256,7 @@ def build_rule(table='filter', chain=None, command=None, position='', full=None,
             del kwargs[ignore]
 
     rule = []
-    proto = False
+    protocol = False
     bang_not_pat = re.compile(r'(!|not)\s?')
 
     def maybe_add_negation(arg):
@@ -273,12 +280,15 @@ def build_rule(table='filter', chain=None, command=None, position='', full=None,
         rule.append('{0}-o {1}'.format(maybe_add_negation('of'), kwargs['of']))
         del kwargs['of']
 
-    for proto_arg in ('protocol', 'proto'):
-        if proto_arg in kwargs:
-            if not proto:
-                rule.append('{0}-p {1}'.format(maybe_add_negation(proto_arg), kwargs[proto_arg]))
-                proto = True
-            del kwargs[proto_arg]
+    if 'proto' in kwargs and kwargs.get('match') != 'policy':
+        kwargs['protocol'] = kwargs['proto']
+        del kwargs['proto']
+        # Handle the case 'proto' in kwargs and kwargs.get('match') == 'policy' below
+    if 'protocol' in kwargs:
+        if not protocol:
+            rule.append('{0}-p {1}'.format(maybe_add_negation('protocol'), kwargs['protocol']))
+            protocol = True
+        del kwargs['protocol']
 
     if 'match' in kwargs:
         match_value = kwargs['match']
@@ -289,6 +299,9 @@ def build_rule(table='filter', chain=None, command=None, position='', full=None,
             if 'name_' in kwargs and match.strip() in ('pknock', 'quota2', 'recent'):
                 rule.append('--name {0}'.format(kwargs['name_']))
                 del kwargs['name_']
+        if 'proto' in kwargs and kwargs.get('match') == 'policy':
+            rule.append('{0}--proto {1}'.format(maybe_add_negation('proto'), kwargs['proto']))
+            del kwargs['proto']
         del kwargs['match']
 
     if 'match-set' in kwargs:
@@ -322,8 +335,8 @@ def build_rule(table='filter', chain=None, command=None, position='', full=None,
         if multiport_arg in kwargs:
             if '-m multiport' not in rule:
                 rule.append('-m multiport')
-                if not proto:
-                    return 'Error: proto must be specified'
+                if not protocol:
+                    return 'Error: protocol must be specified'
 
             mp_value = kwargs[multiport_arg]
             if isinstance(mp_value, list):
@@ -1033,9 +1046,9 @@ def _parse_conf(conf_file=None, in_mem=False, family='ipv4'):
 
 def _parser():
     '''
-    This function contains _all_ the options I could find in man 8 iptables,
-    listed in the first section that I found them in. They will not all be used
-    by all parts of the module; use them intelligently and appropriately.
+    This function attempts to list all the options documented in the
+    iptables(8) and iptables-extensions(8) man pages.  They will not all be
+    used by all parts of the module; use them intelligently and appropriately.
     '''
     add_arg = None
     if sys.version.startswith('2.6'):

--- a/salt/states/iptables.py
+++ b/salt/states/iptables.py
@@ -17,7 +17,7 @@ at some point be deprecated in favor of a more generic ``firewall`` state.
         - match: state
         - connstate: NEW
         - dport: 80
-        - proto: tcp
+        - protocol: tcp
         - sport: 1025:65535
         - save: True
 
@@ -32,7 +32,7 @@ at some point be deprecated in favor of a more generic ``firewall`` state.
         - comment: "Allow HTTP"
         - connstate: NEW
         - dport: 80
-        - proto: tcp
+        - protocol: tcp
         - sport: 1025:65535
         - save: True
 
@@ -48,7 +48,7 @@ at some point be deprecated in favor of a more generic ``firewall`` state.
         - connstate: NEW
         - source: '127.0.0.1'
         - dport: 80
-        - proto: tcp
+        - protocol: tcp
         - sport: 1025:65535
         - save: True
 
@@ -65,7 +65,7 @@ at some point be deprecated in favor of a more generic ``firewall`` state.
         - connstate: NEW
         - source: '! 127.0.0.1'
         - dport: 80
-        - proto: tcp
+        - protocol: tcp
         - sport: 1025:65535
         - save: True
 
@@ -81,7 +81,7 @@ at some point be deprecated in favor of a more generic ``firewall`` state.
         - connstate: NEW
         - source: 'not 127.0.0.1'
         - dport: 80
-        - proto: tcp
+        - protocol: tcp
         - sport: 1025:65535
         - save: True
 
@@ -94,7 +94,7 @@ at some point be deprecated in favor of a more generic ``firewall`` state.
         - match: state
         - connstate: NEW
         - dport: 80
-        - proto: tcp
+        - protocol: tcp
         - sport: 1025:65535
         - save: True
 
@@ -109,7 +109,7 @@ at some point be deprecated in favor of a more generic ``firewall`` state.
         - dports:
             - 80
             - 443
-        - proto: tcp
+        - protocol: tcp
         - sport: 1025:65535
         - save: True
 
@@ -122,7 +122,7 @@ at some point be deprecated in favor of a more generic ``firewall`` state.
         - match: state
         - connstate: NEW
         - dport: 80
-        - proto: tcp
+        - protocol: tcp
         - sport: 1025:65535
         - save: True
 
@@ -136,7 +136,7 @@ at some point be deprecated in favor of a more generic ``firewall`` state.
         - match: state
         - connstate: NEW
         - dport: 80
-        - proto: tcp
+        - protocol: tcp
         - sport: 1025:65535
         - save: True
 
@@ -148,7 +148,7 @@ at some point be deprecated in favor of a more generic ``firewall`` state.
         - match: state
         - connstate: NEW
         - dport: 80
-        - proto: tcp
+        - protocol: tcp
         - sport: 1025:65535
         - save: True
 
@@ -161,7 +161,7 @@ at some point be deprecated in favor of a more generic ``firewall`` state.
         - match: state
         - connstate: NEW
         - dport: 80
-        - proto: tcp
+        - protocol: tcp
         - sport: 1025:65535
         - save: True
 
@@ -174,7 +174,7 @@ at some point be deprecated in favor of a more generic ``firewall`` state.
         - match: state
         - connstate: NEW
         - dport: 80
-        - proto: tcp
+        - protocol: tcp
         - sport: 1025:65535
         - save: True
 
@@ -182,6 +182,55 @@ at some point be deprecated in favor of a more generic ``firewall`` state.
       iptables.set_policy:
         - chain: INPUT
         - policy: ACCEPT
+
+.. note::
+
+    Whereas iptables will accept ``-p``, ``--proto[c[o[l]]]`` as synonyms of
+    ``--protocol``, if ``--proto`` appears in an iptables command after the
+    appearance of ``-m policy``, it is interpreted as the ``--proto`` option of
+    the policy extension (see the iptables-extensions(8) man page).
+
+Example rules for IPSec policy:
+
+.. code-block:: yaml
+
+    accept_esp_in:
+      iptables.append:
+        - table: filter
+        - chain: INPUT
+        - jump: ACCEPT
+        - source: 10.20.0.0/24
+        - destination: 10.10.0.0/24
+        - in-interface: eth0
+        - match: policy
+        - dir: in
+        - pol: ipsec
+        - reqid: 1
+        - proto: esp
+    accept_esp_forward_in:
+      iptables.append:
+        - use:
+          - iptables: accept_esp_in
+        - chain: FORWARD
+
+    accept_esp_out:
+      iptables.append:
+        - table: filter
+        - chain: OUTPUT
+        - jump: ACCEPT
+        - source: 10.10.0.0/24
+        - destination: 10.20.0.0/24
+        - out-interface: eth0
+        - match: policy
+        - dir: out
+        - pol: ipsec
+        - reqid: 1
+        - proto: esp
+    accept_esp_forward_out:
+      iptables.append:
+        - use:
+          - iptables: accept_esp_out
+        - chain: FORWARD
 
 .. note::
 

--- a/tests/unit/modules/test_iptables.py
+++ b/tests/unit/modules/test_iptables.py
@@ -60,38 +60,38 @@ class IptablesTestCase(TestCase, LoaderModuleMockMixin):
             self.assertEqual(iptables.build_rule(**{'if': 'not eth0'}),
                              '! -i eth0')
 
-            self.assertEqual(iptables.build_rule(**{'proto': 'tcp', 'syn': '!'}),
+            self.assertEqual(iptables.build_rule(**{'protocol': 'tcp', 'syn': '!'}),
                             '-p tcp ! --syn')
 
-            self.assertEqual(iptables.build_rule(dports=[80, 443], proto='tcp'),
+            self.assertEqual(iptables.build_rule(dports=[80, 443], protocol='tcp'),
                              '-p tcp -m multiport --dports 80,443')
 
-            self.assertEqual(iptables.build_rule(dports='80,443', proto='tcp'),
+            self.assertEqual(iptables.build_rule(dports='80,443', protocol='tcp'),
                              '-p tcp -m multiport --dports 80,443')
 
             # Should it really behave this way?
             self.assertEqual(iptables.build_rule(dports=['!80', 443],
-                                                 proto='tcp'),
+                                                 protocol='tcp'),
                              '-p tcp -m multiport ! --dports 80,443')
 
-            self.assertEqual(iptables.build_rule(dports='!80,443', proto='tcp'),
+            self.assertEqual(iptables.build_rule(dports='!80,443', protocol='tcp'),
                              '-p tcp -m multiport ! --dports 80,443')
 
-            self.assertEqual(iptables.build_rule(sports=[80, 443], proto='tcp'),
+            self.assertEqual(iptables.build_rule(sports=[80, 443], protocol='tcp'),
                              '-p tcp -m multiport --sports 80,443')
 
-            self.assertEqual(iptables.build_rule(sports='80,443', proto='tcp'),
+            self.assertEqual(iptables.build_rule(sports='80,443', protocol='tcp'),
                              '-p tcp -m multiport --sports 80,443')
 
             self.assertEqual(iptables.build_rule('filter', 'INPUT', command='I',
                                                  position='3', full=True,
-                                                 dports='proto', jump='ACCEPT'),
-                             'Error: proto must be specified')
+                                                 dports='protocol', jump='ACCEPT'),
+                             'Error: protocol must be specified')
 
             self.assertEqual(iptables.build_rule('filter', 'INPUT', command='I',
                                                  position='3', full=True,
-                                                 sports='proto', jump='ACCEPT'),
-                             'Error: proto must be specified')
+                                                 sports='protocol', jump='ACCEPT'),
+                             'Error: protocol must be specified')
 
             self.assertEqual(iptables.build_rule('', 'INPUT', command='I',
                                                  position='3', full='True',


### PR DESCRIPTION
### What does this PR do?
Support `--proto` for iptables IPSec policy extension in iptables state.

### What issues does this PR fix or reference?
I found no issues (open or closed) referencing this problem.

### Previous Behavior
Consider the following state:
```sls
ipt-test:
  iptables.append:
    - name: ipt-test
    - table: filter
    - chain: INPUT
    - source: 10.20.0.0/24
    - destination: 10.10.0.0/24
    - in-interface: eth0
    - match: policy
    - proto: esp
    - dir: in
    - pol: ipsec
    - reqid: 1
    - jump: ACCEPT
```
Prior to this fix, applying `ipt-test` would produce this *incorrect* iptables rule:
```sh
# iptables -vL
...
 pkts bytes target     prot opt in     out     source               destination
...
    0     0 ACCEPT     esp  --  eth0   any     10.20.0.0/24         10.10.0.0/24         policy match dir in pol ipsec reqid 1
...
# iptables-save
...
-A INPUT -s 10.20.0.0/24 -d 10.10.0.0/24 -i eth0 -p esp -m policy --dir in --pol ipsec --reqid 1 -j ACCEPT
...
```
### New Behavior
The state `ipt-test` now produces the correct iptables rule:
```sh
# iptables -vL
...
 pkts bytes target     prot opt in     out     source               destination
...
    0     0 ACCEPT     all  --  eth0   any     10.20.0.0/24         10.10.0.0/24         policy match dir in pol ipsec reqid 1 proto esp
...
# iptables-save
...
-A INPUT -s 10.20.0.0/24 -d 10.10.0.0/24 -i eth0 -m policy --dir in --pol ipsec --reqid 1 --proto esp -j ACCEPT
...
```
Notice how the `proto` is now interpreted as a parameter of the IPSec policy extension of iptables.

### Tests written?

Automating tests for this would require iptables to be installed and working on the test system.  If requested, I will attempt to make the necessary changes to SaltTesting.  The full test case I used is copied below.  The details of the state failure are shown in the `Previous Behavior` section.  I compared the rules generated by the execution and state modules before and after the change against the rules generated with the raw iptables commands.

#### Raw commands
```
iptables -A INPUT -s 10.20.0.0/24 -d 10.10.0.0/24 -i eth0 -m policy --protocol esp --dir in --pol ipsec --reqid 1 -j ACCEPT
iptables -A INPUT --proto esp -s 10.20.0.0/24 -d 10.10.0.0/24 -i eth0 -m policy --proto esp --dir in --pol ipsec --reqid 1 -j ACCEPT
iptables -A INPUT -s 10.20.0.0/24 -d 10.10.0.0/24 -i eth0 -m policy --proto esp --dir in --pol ipsec --reqid 1 -j ACCEPT
```

#### `salt iptables.append` command line
```
salt-call --local iptables.append filter INPUT rule='-s 10.20.0.0/24 -d 10.10.0.0/24 -i eth0 -m policy --protocol esp --dir in --pol ipsec --reqid 1 -j ACCEPT'
salt-call --local iptables.append filter INPUT rule='--proto esp -s 10.20.0.0/24 -d 10.10.0.0/24 -i eth0 -m policy --proto esp --dir in --pol ipsec --reqid 1 -j ACCEPT'
salt-call --local iptables.append filter INPUT rule='-s 10.20.0.0/24 -d 10.10.0.0/24 -i eth0 -m policy --proto esp --dir in --pol ipsec --reqid 1 -j ACCEPT'
```

#### `salt state.single iptables.append` command line
```
salt-call --local state.single iptables.append name=ipt-test table=filter chain=INPUT source=10.20.0.0/24 destination=10.10.0.0/24 in-interface=eth0 match=policy protocol=esp dir=in pol=ipsec reqid=1 jump=ACCEPT
salt-call --local state.single iptables.append name=ipt-test table=filter chain=INPUT protocol=esp source=10.20.0.0/24 destination=10.10.0.0/24 in-interface=eth0 match=policy proto=esp dir=in pol=ipsec reqid=1 jump=ACCEPT
salt-call --local state.single iptables.append name=ipt-test table=filter chain=INPUT source=10.20.0.0/24 destination=10.10.0.0/24 in-interface=eth0 match=policy proto=esp dir=in pol=ipsec reqid=1 jump=ACCEPT
```

#### `iptables-save` output
```
-A INPUT -s 10.20.0.0/24 -d 10.10.0.0/24 -i eth0 -p esp -m policy --dir in --pol ipsec --reqid 1 -j ACCEPT
-A INPUT -s 10.20.0.0/24 -d 10.10.0.0/24 -i eth0 -p esp -m policy --dir in --pol ipsec --reqid 1 --proto esp -j ACCEPT
-A INPUT -s 10.20.0.0/24 -d 10.10.0.0/24 -i eth0 -m policy --dir in --pol ipsec --reqid 1 --proto esp -j ACCEPT
```

#### `iptables -vL` output
```
    0     0 ACCEPT     esp  --  eth0   any     10.20.0.0/24         10.10.0.0/24         policy match dir in pol ipsec reqid 1
    0     0 ACCEPT     esp  --  eth0   any     10.20.0.0/24         10.10.0.0/24         policy match dir in pol ipsec reqid 1 proto esp
    0     0 ACCEPT     all  --  eth0   any     10.20.0.0/24         10.10.0.0/24         policy match dir in pol ipsec reqid 1 proto esp
```
#### Results
Mode | Before | After
--- | --- | ---
exec module | pass | pass
state module | fail | pass

### Commits signed with GPG?
Yes