### PR TITLE
salt-cloud/vmware if specified use ssh_host to deploy

### DIFF
--- a/salt/cloud/clouds/vmware.py
+++ b/salt/cloud/clouds/vmware.py
@@ -2804,7 +2804,8 @@ def create(vm_):
             if deploy:
                 vm_['key_filename'] = key_filename
                 # if specified, prefer ssh_host to the discovered ip address
-                vm_['ssh_host'] = vm_.get('ssh_host', ip)
+                if 'ssh_host' not in vm_:
+                    vm_['ssh_host'] = ip
                 log.info("[ {0} ] Deploying to {1}".format(vm_name, vm_['ssh_host']))
 
                 out = __utils__['cloud.bootstrap'](vm_, __opts__)

--- a/salt/cloud/clouds/vmware.py
+++ b/salt/cloud/clouds/vmware.py
@@ -2803,7 +2803,9 @@ def create(vm_):
             # ssh or smb using ip and install salt only if deploy is True
             if deploy:
                 vm_['key_filename'] = key_filename
-                vm_['ssh_host'] = ip
+                # if specified, prefer ssh_host to the discovered ip address
+                vm_['ssh_host'] = vm_.get('ssh_host', ip)
+                log.info("[ {0} ] Deploying to {1}".format(vm_name, vm_['ssh_host']))
 
                 out = __utils__['cloud.bootstrap'](vm_, __opts__)
 


### PR DESCRIPTION
Fixes #36543

### What does this PR do?
In the salt-cloud vmware provider, use ssh_host when specified to deploy salt.

### What issues does this PR fix or reference?
#36543

### Previous Behavior
Deploy salt through the first discovered IP address.

### New Behavior
If ssh_host is defined in the profile, prefer it to the discovered IP address.

### Tests written?

No

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
