### PR TITLE
Use correct path to ipaddress

### DIFF
--- a/salt/modules/network.py
+++ b/salt/modules/network.py
@@ -1140,7 +1140,7 @@ def convert_cidr(cidr):
     ret = {'network': None,
            'netmask': None}
     cidr = calc_net(cidr)
-    network_info = salt.ext.ipaddress.ip_network(cidr)
+    network_info = ipaddress.ip_network(cidr)
     ret['network'] = six.text_type(network_info.network_address)
     ret['netmask'] = six.text_type(network_info.netmask)
     return ret


### PR DESCRIPTION
### What does this PR do?
Fix call of ipaddress.ip_network, so that network.default_route does not throw an exception.

### What issues does this PR fix or reference?
https://bugzilla.suse.com/show_bug.cgi?id=1089501

### Previous Behavior
network.default_route throws exception

### Tests written?

No

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
