### PR TITLE
fix pip import error in pip 10.0.0

### DIFF
--- a/salt/states/pip_state.py
+++ b/salt/states/pip_state.py
@@ -46,7 +46,7 @@ if HAS_PIP is True:
         # pip 10.0.0 move req module under pip._internal
         try:
             from pip._internal.req import InstallRequirement
-        except:
+        except ImportError:
             HAS_PIP = False
             # Remove references to the loaded pip module above so reloading works
             import sys

--- a/salt/states/pip_state.py
+++ b/salt/states/pip_state.py
@@ -41,14 +41,18 @@ except ImportError:
 
 if HAS_PIP is True:
     try:
-        import pip.req
+        from pip.req import InstallRequirement
     except ImportError:
-        HAS_PIP = False
-        # Remove references to the loaded pip module above so reloading works
-        import sys
-        del pip
-        if 'pip' in sys.modules:
-            del sys.modules['pip']
+        # pip 10.0.0 move req module under pip._internal
+        try:
+            from pip._internal.req import InstallRequirement
+        except:
+            HAS_PIP = False
+            # Remove references to the loaded pip module above so reloading works
+            import sys
+            del pip
+            if 'pip' in sys.modules:
+                del sys.modules['pip']
 
     try:
         from pip.exceptions import InstallationError
@@ -127,7 +131,7 @@ def _check_pkg_version_format(pkg):
             # The next line is meant to trigger an AttributeError and
             # handle lower pip versions
             log.debug('Installed pip version: %s', pip.__version__)
-            install_req = pip.req.InstallRequirement.from_line(pkg)
+            install_req = InstallRequirement.from_line(pkg)
         except AttributeError:
             log.debug('Installed pip version is lower than 1.2')
             supported_vcs = ('git', 'svn', 'hg', 'bzr')
@@ -135,12 +139,12 @@ def _check_pkg_version_format(pkg):
                 for vcs in supported_vcs:
                     if pkg.startswith(vcs):
                         from_vcs = True
-                        install_req = pip.req.InstallRequirement.from_line(
+                        install_req = InstallRequirement.from_line(
                             pkg.split('{0}+'.format(vcs))[-1]
                         )
                         break
             else:
-                install_req = pip.req.InstallRequirement.from_line(pkg)
+                install_req = InstallRequirement.from_line(pkg)
     except (ValueError, InstallationError) as exc:
         ret['result'] = False
         if not from_vcs and '=' in pkg and '==' not in pkg:


### PR DESCRIPTION
### What does this PR do?
This PR tries to fix the import error caused by the latest pip (10.0.0)

### What issues does this PR fix or reference?
#47116
### Previous Behavior
Remove this section if not relevant
pip_state.py raised ImportError since there there is no pip.req module in pip 10.0.0.

### New Behavior
Remove this section if not relevant
If there is no pip.req, pip_state.py also checks pip._internal.req where pip 10.0.0 places the req module.

### Tests written?
No

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
