### PR TITLE
add __cli opts variable for master processes

### DIFF
--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -3571,6 +3571,8 @@ def apply_master_config(overrides=None, defaults=None):
     if overrides:
         opts.update(overrides)
 
+    opts['__cli'] = os.path.basename(sys.argv[0])
+
     if len(opts['sock_dir']) > len(opts['cachedir']) + 10:
         opts['sock_dir'] = os.path.join(opts['cachedir'], '.salt-unix')
 

--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -280,7 +280,7 @@ def _get_opts(**kwargs):
 
 
 def _get_initial_pillar(opts):
-    return __pillar__ if __opts__['__cli'] == 'salt-call' \
+    return __pillar__ if __opts__.get('__cli', None) == 'salt-call' \
         and opts['pillarenv'] == __opts__['pillarenv'] \
         else None
 


### PR DESCRIPTION
### What does this PR do?

Add the `__cli` opt like apply_minion_config does.

https://github.com/saltstack/salt/blob/2017.7/salt/config/__init__.py#L3427

### What issues does this PR fix or reference?
Discovered in salt community slack

### Tests written?

No

### Commits signed with GPG?

Yes