### PR TITLE
Support glob pattern in file.absent state

### DIFF
--- a/tests/integration/states/test_file.py
+++ b/tests/integration/states/test_file.py
@@ -186,6 +186,20 @@ class FileTest(ModuleCase, SaltReturnAssertsMixin):
         self.assertSaltTrueReturn(ret)
         self.assertFalse(os.path.isfile(name))
 
+    def test_absent_file_glob(self):
+        '''
+        file.absent
+        '''
+        name = os.path.join(TMP, 'file_to_kill_*')
+        fnames = ['file_to_kill_1', 'file_to_kill_2']
+        for fname in fnames:
+            with salt.utils.files.fopen(os.path.join(TMP, fname), 'w+') as fp_:
+                fp_.write('killme')
+        ret = self.run_state('file.absent', name=name, resolve_glob=True)
+        self.assertSaltTrueReturn(ret)
+        for fname in fnames:
+            self.assertFalse(os.path.isfile(os.path.join(TMP, fname)))
+
     def test_absent_dir(self):
         '''
         file.absent


### PR DESCRIPTION
This is a rework of the older PR #44723. The original author never
finished the PR and the feature is actually worthwhile.

Changed glob import
Added simple test-case.

### What does this PR do?
Add globbing support to the file.absent state.

### What issues does this PR fix or reference?
#9183