### PR TITLE
Pass custom serializer options to merge_if_exists

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -6287,7 +6287,7 @@ def serialize(name,
                         'result': False}
 
             with salt.utils.files.fopen(name, 'r') as fhr:
-                existing_data = __serializers__[deserializer_name](fhr)
+                existing_data = __serializers__[deserializer_name](fhr, **options.get(serializer_name, {}))
 
             if existing_data is not None:
                 merged_data = salt.utils.dictupdate.merge_recurse(existing_data, dataset)


### PR DESCRIPTION
### What does this PR do?
Fixes an issue encountered with configparser serializer as parsing invalid entries like in my.cnf:
```
!include /etc/my.super.cnf
```

```
salt.serializers.DeserializationError: Source contains parsing errors: '/etc/my.cnf'
              	[line  5]: '!include /etc/my-super.cnf\n'
```

with the following sate:
```
/etc/my.cnf:
  file.serialize:
    - formatter: configparser
    - dataset_pillar: mysql:my.cnf
    - merge_if_exists: True
    - serializer_opts:
      - comment_prefixes: '!'
```

### What issues does this PR fix or reference?
Passes options to first read before merge happens.

### Previous Behavior
serializer_opts not being honored during merge_if_exists

### New Behavior
serializer_opts honored during merge_if_exists

### Tests written?

No

### Commits signed with GPG?

Yes