### PR TITLE
plaintext not supported in Windows Server 2016.

### DIFF
--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -835,7 +835,7 @@ def wait_for_winrm(host, port, username, password, timeout=900, use_ssl=True, ve
     )
     transport = 'ssl'
     if not use_ssl:
-        transport = 'plaintext'
+        transport = 'ntlm'
     trycount = 0
     while True:
         trycount += 1


### PR DESCRIPTION
ntlm authentication is backwards compatible to Windows Server 2008 at least, but plaintext is not supported in Server 2016.

### What does this PR do?
Changes default winrm behaviour on 'Deploy' for windows machines created via salt-cloud.

### What issues does this PR fix or reference?
My issue of not being able to install windows with a minion on google/aws with Server 2016.

### Tests written?

no

### Commits signed with GPG?

Yes
