### PR TITLE
[Bugfix] Add proper (and explicit) ordering to s3fs

### DIFF
--- a/salt/fileserver/s3fs.py
+++ b/salt/fileserver/s3fs.py
@@ -57,6 +57,25 @@ structure::
 
 .. note:: This fileserver back-end requires the use of the MD5 hashing algorithm.
     MD5 may not be compliant with all security policies.
+
+.. note:: This fileserver back-end is only compatible with MD5 ETag hashes in
+    the S3 metadata. This means that you must use SSE-S3 or plaintext for
+    bucket encryption, and that you must not use multipart upload when
+    uploading to your bucket. More information here:
+    https://docs.aws.amazon.com/AmazonS3/latest/API/RESTCommonResponseHeaders.html
+
+    Objects without an MD5 ETag will be fetched on every fileserver update.
+
+    If you deal with objects greater than 8MB, then you should use the
+    following AWS CLI config to avoid mutipart upload:
+
+    .. code-block::
+
+        s3 =
+          multipart_threshold = 1024MB
+
+    More info here:
+    https://docs.aws.amazon.com/AmazonS3/latest/API/RESTCommonResponseHeaders.html
 '''
 
 # Import python libs

--- a/salt/fileserver/s3fs.py
+++ b/salt/fileserver/s3fs.py
@@ -152,7 +152,7 @@ def find_file(path, saltenv='base', **kwargs):
                 fnd['path'] = path
                 break
         else:
-            continue # only executes if we didn't break
+            continue  # only executes if we didn't break
         break
 
     if not fnd['path'] or not fnd['bucket']:

--- a/salt/fileserver/s3fs.py
+++ b/salt/fileserver/s3fs.py
@@ -75,7 +75,7 @@ structure::
           multipart_threshold = 1024MB
 
     More info here:
-    https://docs.aws.amazon.com/AmazonS3/latest/API/RESTCommonResponseHeaders.html
+    https://docs.aws.amazon.com/cli/latest/topic/s3-config.html
 '''
 
 # Import python libs


### PR DESCRIPTION
### What does this PR do?

Adds proper ordering to s3fs so that salt will always use the version of a file from the first listed bucket with that file (as in gitfs and other fileservers).

### Previous Behavior

Previously, while processing the buckets, s3fs would use dictionaries, which are unordered in python 2. This could result in buckets being searched in unexpected order.

### New Behavior

The internal data structure now uses lists of dictionaries to make sure order is maintained, and buckets will properly be searched in their defined order.

### Tests written?

No

### Commits signed with GPG?

Yes

----------

I consider this a serious bug in s3fs and think this should be backported to all supported versions. However, it's not critical for me as we have already included this updated version [in hubble](https://github.com/hubblestack/hubble/pull/355).