### PR TITLE
states.user.present: Make usage of `hash_password` idempotent

### DIFF
--- a/salt/states/user.py
+++ b/salt/states/user.py
@@ -438,7 +438,24 @@ def present(name,
     # hash_password is True, then hash it.
     if password and hash_password:
         log.debug('Hashing a clear text password')
-        password = __salt__['shadow.gen_password'](password)
+        # in case a password is already set, it will contain a Salt
+        # which should be re-used to generate the new hash, other-
+        # wise the Salt will be generated randomly, causing the
+        # hash to change each time and thereby making the
+        # user.present state non-idempotent.
+        algorithms = {
+            '1':  'md5',
+            '2a': 'blowfish',
+            '5':  'sha256',
+            '6':  'sha512',
+        }
+        try:
+            _, algo, shadow_salt, shadow_hash = __salt__['shadow.info'](name)['passwd'].split('$', 4)
+            log.debug('Re-using existing shadow salt for hashing password using {}'.format(algorithms.get(algo)))
+            password = __salt__['shadow.gen_password'](password, crypt_salt=shadow_salt, algorithm=algorithms.get(algo))
+        except ValueError:
+            log.info('No existing shadow salt found, defaulting to a randomly generated new one')
+            password = __salt__['shadow.gen_password'](password)
 
     if fullname is not None:
         fullname = sdecode(fullname)

--- a/salt/states/user.py
+++ b/salt/states/user.py
@@ -451,6 +451,8 @@ def present(name,
         }
         try:
             _, algo, shadow_salt, shadow_hash = __salt__['shadow.info'](name)['passwd'].split('$', 4)
+            if algo == '1':
+                log.warning('Using MD5 for hashing passwords is considered insecure!')
             log.debug('Re-using existing shadow salt for hashing password using {}'.format(algorithms.get(algo)))
             password = __salt__['shadow.gen_password'](password, crypt_salt=shadow_salt, algorithm=algorithms.get(algo))
         except ValueError:


### PR DESCRIPTION
### What does this PR do?

It fixes the non-idempotent behavior of `states.user.present` when `hash_password: True` described in #45939 
It targets `2018.3`, but due to it's trivial nature, it should be easily cherry-picked for backports to older releases.

### What issues does this PR fix or reference?
#45939

### Previous Behavior
Every time `states.user.present` with `hash_password: True` was used, a new shadow hash was generated based on a new randomly generated salt value for hashing which made this state's behavior idempotent.

### New Behavior
Before hashing a password, it checks now whether an existing salt can be retrieved.
If yes, it will be re-used for generating the hash.
If not, it defaults to using a new randomly generated salt.

### Tests written?

No

### Commits signed with GPG?

Yes