### PR TITLE
Add extra_filerefs to sls_build

### DIFF
--- a/salt/modules/dockermod.py
+++ b/salt/modules/dockermod.py
@@ -6558,7 +6558,7 @@ def _generate_tmp_path():
         'salt.docker.{0}'.format(uuid.uuid4().hex[:6]))
 
 
-def _prepare_trans_tar(name, sls_opts, mods=None, pillar=None):
+def _prepare_trans_tar(name, sls_opts, mods=None, pillar=None, extra_filerefs=''):
     '''
     Prepares a self contained tarball that has the state
     to be applied in the container
@@ -6566,7 +6566,7 @@ def _prepare_trans_tar(name, sls_opts, mods=None, pillar=None):
     chunks = _compile_state(sls_opts, mods)
     # reuse it from salt.ssh, however this function should
     # be somewhere else
-    refs = salt.client.ssh.state.lowstate_file_refs(chunks)
+    refs = salt.client.ssh.state.lowstate_file_refs(chunks, extra_filerefs)
     _mk_fileclient()
     trans_tar = salt.client.ssh.state.prep_trans_tar(
         sls_opts,
@@ -6757,7 +6757,8 @@ def sls(name, mods=None, **kwargs):
         name,
         sls_opts,
         mods=mods,
-        pillar=pillar)
+        pillar=pillar,
+        extra_filerefs=kwargs.get('extra_filerefs', ''))
 
     # where to put the salt trans tar
     trans_dest_path = _generate_tmp_path()
@@ -6890,7 +6891,7 @@ def sls_build(repository,
         repository = name
 
     create_kwargs = __utils__['args.clean_kwargs'](**copy.deepcopy(kwargs))
-    for key in ('image', 'name', 'cmd', 'interactive', 'tty'):
+    for key in ('image', 'name', 'cmd', 'interactive', 'tty', 'extra_filerefs'):
         try:
             del create_kwargs[key]
         except KeyError:


### PR DESCRIPTION
### What does this PR do?

Adds an `extra_filerefs` option to `docker.sls_build`, consistent with the `salt-ssh` `--extra-filerefs` option. This enables developers to include requirements of templates (e.g. a `macros.sls` file) in the thin bundle sent to the container.

### What issues does this PR fix or reference?

* #9878 -- original issue against `salt-ssh`
    * #13794 -- add CLI argument
    *  #16733 -- add `extra_filerefs` option to `salt.client.ssh.state.lowstate_file_refs`

### Previous Behavior

Any missing template dependencies would fail with a `TemplateNotFound` error like the following:

```
Traceback (most recent call last):
  File "/tmp/salt.docker.[snip]/pyall/salt/utils/templates.py", line 388, in render_jinja_tmpl
    output = template.render(**decoded_context)
  File "/tmp/salt.docker.[snip]/pyall/jinja2/environment.py", line 1008, in render
    return self.environment.handle_exception(exc_info, True)
  File "/tmp/salt.docker.[snip]/pyall/jinja2/environment.py", line 780, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "<template>", line 1, in top-level template code
  File "/tmp/salt.docker.[snip]/pyall/salt/utils/jinja.py", line 140, in get_source
    raise TemplateNotFound(template)
TemplateNotFound: web-base/macros.sls
```

### New Behavior

Including `extra_filerefs`, e.g. as follows, allows the states to complete as the necessary dependencies are included in the thin archive transferred to the container:

```
$ salt-call \
        --local --file-root ~/salt --pillar-root ~/pillar \
        docker.sls_build container base=base mods=some-state,some-other-state \
        extra_filerefs=salt://some-state/some-dep.jinja
```

### Tests written?

No -- I'm not sure how best to test this. I'm happy to try if I can get an idea of where to start?

### Commits signed with GPG?

No