### PR TITLE
Fix patchinstall for yumpkg

### DIFF
--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -1322,7 +1322,7 @@ def install(name=None,
 
     try:
         pkg_params, pkg_type = __salt__['pkg_resource.parse_targets'](
-            name, pkgs, sources, saltenv=saltenv, normalize=normalize
+            name, pkgs, sources, saltenv=saltenv, normalize=normalize, **kwargs
         )
     except MinionError as exc:
         raise CommandExecutionError(exc)

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -1620,7 +1620,7 @@ def install(name=None,
             if _yum() == 'dnf':
                 cmd.extend(['--best', '--allowerasing'])
             _add_common_args(cmd)
-            cmd.append('install' if pkg_type is not 'advisory' else 'update')
+            cmd.append('install' if pkg_type != 'advisory' else 'update')
             cmd.extend(targets)
             out = __salt__['cmd.run_all'](
                 cmd,


### PR DESCRIPTION
### What does this PR do?

Installing advisories is not working with yum because of two issues:

1. pkg_resource.parse_targets search for advisory_ids in kwargs to detect pkg_type `advisory`. Adding kwargs to the call is required.
2. comparing "pkg_type is not 'advisory'" is not working, must be "pkg_type != 'advisory'

### Tests written?

No

