### PR TITLE
Change check_db_exists default to True

### DIFF
--- a/salt/states/mysql_query.py
+++ b/salt/states/mysql_query.py
@@ -221,7 +221,7 @@ def run(name,
         grain=None,
         key=None,
         overwrite=True,
-        check_db_exists=False,
+        check_db_exists=True,
         **connection_args):
     '''
     Execute an arbitrary query on the specified database


### PR DESCRIPTION
This option was added in PR #46895 where the default in the `run_file` function was set to `True`, but in the `run` function it was set to `False`. This is an error and the default should be `True`.

With the default set to False, it causes a test failure and would also be a change in behavior from previous releases. In addition, the docs also say that default is True. Therefore, this looks to be a typo. This PR sets the default to `True`.

Fixes the following test failure:

- unit.states.test_mysql_query.MysqlQueryTestCase.test_run
