### PR TITLE
Fix for whitelist/blacklist checking for non-list iterables

### DIFF
--- a/salt/utils/stringutils.py
+++ b/salt/utils/stringutils.py
@@ -364,6 +364,12 @@ def check_whitelist_blacklist(value, whitelist=None, blacklist=None):
     if blacklist is not None:
         if isinstance(blacklist, six.string_types):
             blacklist = [blacklist]
+        if not hasattr(blacklist, '__iter__'):
+            raise TypeError(
+                'Expecting iterable blacklist, but got {0} ({1})'.format(
+                    type(blacklist).__name__, blacklist
+                )
+            )
         for expr in blacklist:
             if expr_match(value, expr):
                 return False
@@ -371,6 +377,12 @@ def check_whitelist_blacklist(value, whitelist=None, blacklist=None):
     if whitelist is not None:
         if isinstance(whitelist, six.string_types):
             whitelist = [whitelist]
+        if not hasattr(whitelist, '__iter__'):
+            raise TypeError(
+                'Expecting iterable whitelist, but got {0} ({1})'.format(
+                    type(whitelist).__name__, whitelist
+                )
+            )
         for expr in whitelist:
             if expr_match(value, expr):
                 return True

--- a/salt/utils/stringutils.py
+++ b/salt/utils/stringutils.py
@@ -362,14 +362,14 @@ def check_whitelist_blacklist(value, whitelist=None, blacklist=None):
     found in the whitelist, the function returns ``False``.
     '''
     if blacklist is not None:
-        if not isinstance(blacklist, list):
+        if isinstance(blacklist, six.string_types):
             blacklist = [blacklist]
         for expr in blacklist:
             if expr_match(value, expr):
                 return False
 
-    if whitelist:
-        if not isinstance(whitelist, list):
+    if whitelist is not None:
+        if isinstance(whitelist, six.string_types):
             whitelist = [whitelist]
         for expr in whitelist:
             if expr_match(value, expr):

--- a/tests/unit/utils/test_stringutils.py
+++ b/tests/unit/utils/test_stringutils.py
@@ -331,3 +331,15 @@ class StringutilsTestCase(TestCase):
                 blacklist=set(blacklist),
             )
         )
+
+        # Test with invalid type for whitelist/blacklist
+        self.assertRaises(
+            TypeError,
+            salt.utils.stringutils.check_whitelist_blacklist,
+            'foo', whitelist=123
+        )
+        self.assertRaises(
+            TypeError,
+            salt.utils.stringutils.check_whitelist_blacklist,
+            'foo', blacklist=123
+        )

--- a/tests/unit/utils/test_stringutils.py
+++ b/tests/unit/utils/test_stringutils.py
@@ -292,7 +292,7 @@ class StringutilsTestCase(TestCase):
             )
         )
 
-        # Tests with list whitelist/blacklist
+        # Tests with set whitelist/blacklist
         self.assertFalse(
             salt.utils.stringutils.check_whitelist_blacklist(
                 'web_one',

--- a/tests/unit/utils/test_stringutils.py
+++ b/tests/unit/utils/test_stringutils.py
@@ -217,23 +217,55 @@ class StringutilsTestCase(TestCase):
             salt.utils.stringutils.check_whitelist_blacklist(
                 'web_one',
                 whitelist=whitelist[1],
+                blacklist=None,
+            )
+        )
+        self.assertFalse(
+            salt.utils.stringutils.check_whitelist_blacklist(
+                'web_one',
+                whitelist=whitelist[1],
+                blacklist=[],
             )
         )
         self.assertTrue(
             salt.utils.stringutils.check_whitelist_blacklist(
                 'web1',
                 whitelist=whitelist[1],
+                blacklist=None,
+            )
+        )
+        self.assertTrue(
+            salt.utils.stringutils.check_whitelist_blacklist(
+                'web1',
+                whitelist=whitelist[1],
+                blacklist=[],
             )
         )
         self.assertFalse(
             salt.utils.stringutils.check_whitelist_blacklist(
                 'web5',
+                whitelist=None,
+                blacklist=blacklist[1],
+            )
+        )
+        self.assertFalse(
+            salt.utils.stringutils.check_whitelist_blacklist(
+                'web5',
+                whitelist=[],
                 blacklist=blacklist[1],
             )
         )
         self.assertTrue(
             salt.utils.stringutils.check_whitelist_blacklist(
                 'web_five',
+                whitelist=None,
+                blacklist=blacklist[1],
+            )
+        )
+        self.assertTrue(
+            salt.utils.stringutils.check_whitelist_blacklist(
+                'web_five',
+                whitelist=[],
                 blacklist=blacklist[1],
             )
         )
@@ -257,23 +289,55 @@ class StringutilsTestCase(TestCase):
             salt.utils.stringutils.check_whitelist_blacklist(
                 'web_one',
                 whitelist=whitelist,
+                blacklist=None,
+            )
+        )
+        self.assertFalse(
+            salt.utils.stringutils.check_whitelist_blacklist(
+                'web_one',
+                whitelist=whitelist,
+                blacklist=[],
             )
         )
         self.assertTrue(
             salt.utils.stringutils.check_whitelist_blacklist(
                 'web1',
                 whitelist=whitelist,
+                blacklist=None,
+            )
+        )
+        self.assertTrue(
+            salt.utils.stringutils.check_whitelist_blacklist(
+                'web1',
+                whitelist=whitelist,
+                blacklist=[],
             )
         )
         self.assertFalse(
             salt.utils.stringutils.check_whitelist_blacklist(
                 'web5',
+                whitelist=None,
+                blacklist=blacklist,
+            )
+        )
+        self.assertFalse(
+            salt.utils.stringutils.check_whitelist_blacklist(
+                'web5',
+                whitelist=[],
                 blacklist=blacklist,
             )
         )
         self.assertTrue(
             salt.utils.stringutils.check_whitelist_blacklist(
                 'web_five',
+                whitelist=None,
+                blacklist=blacklist,
+            )
+        )
+        self.assertTrue(
+            salt.utils.stringutils.check_whitelist_blacklist(
+                'web_five',
+                whitelist=[],
                 blacklist=blacklist,
             )
         )
@@ -297,23 +361,55 @@ class StringutilsTestCase(TestCase):
             salt.utils.stringutils.check_whitelist_blacklist(
                 'web_one',
                 whitelist=set(whitelist),
+                blacklist=None,
+            )
+        )
+        self.assertFalse(
+            salt.utils.stringutils.check_whitelist_blacklist(
+                'web_one',
+                whitelist=set(whitelist),
+                blacklist=set(),
             )
         )
         self.assertTrue(
             salt.utils.stringutils.check_whitelist_blacklist(
                 'web1',
                 whitelist=set(whitelist),
+                blacklist=None,
+            )
+        )
+        self.assertTrue(
+            salt.utils.stringutils.check_whitelist_blacklist(
+                'web1',
+                whitelist=set(whitelist),
+                blacklist=set(),
             )
         )
         self.assertFalse(
             salt.utils.stringutils.check_whitelist_blacklist(
                 'web5',
+                whitelist=None,
+                blacklist=set(blacklist),
+            )
+        )
+        self.assertFalse(
+            salt.utils.stringutils.check_whitelist_blacklist(
+                'web5',
+                whitelist=set(),
                 blacklist=set(blacklist),
             )
         )
         self.assertTrue(
             salt.utils.stringutils.check_whitelist_blacklist(
                 'web_five',
+                whitelist=None,
+                blacklist=set(blacklist),
+            )
+        )
+        self.assertTrue(
+            salt.utils.stringutils.check_whitelist_blacklist(
+                'web_five',
+                whitelist=set(),
                 blacklist=set(blacklist),
             )
         )

--- a/tests/unit/utils/test_stringutils.py
+++ b/tests/unit/utils/test_stringutils.py
@@ -204,3 +204,130 @@ class StringutilsTestCase(TestCase):
         self.assertTrue(salt.utils.stringutils.expr_match(val, 'foo/*/baz'))
         # Glob non-match
         self.assertFalse(salt.utils.stringutils.expr_match(val, 'foo/*/bar'))
+
+    def test_check_whitelist_blacklist(self):
+        '''
+        Ensure that whitelist matching works on both PY2 and PY3
+        '''
+        whitelist = ['one/two/three', r'web[0-9]']
+        blacklist = ['four/five/six', r'web[5-9]']
+
+        # Tests with string whitelist/blacklist
+        self.assertFalse(
+            salt.utils.stringutils.check_whitelist_blacklist(
+                'web_one',
+                whitelist=whitelist[1],
+            )
+        )
+        self.assertTrue(
+            salt.utils.stringutils.check_whitelist_blacklist(
+                'web1',
+                whitelist=whitelist[1],
+            )
+        )
+        self.assertFalse(
+            salt.utils.stringutils.check_whitelist_blacklist(
+                'web5',
+                blacklist=blacklist[1],
+            )
+        )
+        self.assertTrue(
+            salt.utils.stringutils.check_whitelist_blacklist(
+                'web_five',
+                blacklist=blacklist[1],
+            )
+        )
+        self.assertFalse(
+            salt.utils.stringutils.check_whitelist_blacklist(
+                'web5',
+                whitelist=whitelist[1],
+                blacklist=blacklist[1],
+            )
+        )
+        self.assertTrue(
+            salt.utils.stringutils.check_whitelist_blacklist(
+                'web4',
+                whitelist=whitelist[1],
+                blacklist=blacklist[1],
+            )
+        )
+
+        # Tests with list whitelist/blacklist
+        self.assertFalse(
+            salt.utils.stringutils.check_whitelist_blacklist(
+                'web_one',
+                whitelist=whitelist,
+            )
+        )
+        self.assertTrue(
+            salt.utils.stringutils.check_whitelist_blacklist(
+                'web1',
+                whitelist=whitelist,
+            )
+        )
+        self.assertFalse(
+            salt.utils.stringutils.check_whitelist_blacklist(
+                'web5',
+                blacklist=blacklist,
+            )
+        )
+        self.assertTrue(
+            salt.utils.stringutils.check_whitelist_blacklist(
+                'web_five',
+                blacklist=blacklist,
+            )
+        )
+        self.assertFalse(
+            salt.utils.stringutils.check_whitelist_blacklist(
+                'web5',
+                whitelist=whitelist,
+                blacklist=blacklist,
+            )
+        )
+        self.assertTrue(
+            salt.utils.stringutils.check_whitelist_blacklist(
+                'web4',
+                whitelist=whitelist,
+                blacklist=blacklist,
+            )
+        )
+
+        # Tests with list whitelist/blacklist
+        self.assertFalse(
+            salt.utils.stringutils.check_whitelist_blacklist(
+                'web_one',
+                whitelist=set(whitelist),
+            )
+        )
+        self.assertTrue(
+            salt.utils.stringutils.check_whitelist_blacklist(
+                'web1',
+                whitelist=set(whitelist),
+            )
+        )
+        self.assertFalse(
+            salt.utils.stringutils.check_whitelist_blacklist(
+                'web5',
+                blacklist=set(blacklist),
+            )
+        )
+        self.assertTrue(
+            salt.utils.stringutils.check_whitelist_blacklist(
+                'web_five',
+                blacklist=set(blacklist),
+            )
+        )
+        self.assertFalse(
+            salt.utils.stringutils.check_whitelist_blacklist(
+                'web5',
+                whitelist=set(whitelist),
+                blacklist=set(blacklist),
+            )
+        )
+        self.assertTrue(
+            salt.utils.stringutils.check_whitelist_blacklist(
+                'web4',
+                whitelist=set(whitelist),
+                blacklist=set(blacklist),
+            )
+        )


### PR DESCRIPTION
A recent PY3-compatibility fix was made to `check_whitelist_blacklist`.  The function was previously checking for the `__iter__` attribute to check if the blacklist and/or whitelist was a sequence of expressions or a single expression. However, the `str` type has the `__iter__` attribute in PY3 while it does not in PY2. To fix this, the check was changed to see if the blacklist and/or whitelist were `list` types. This however causes problems in `salt.daemons.masterapi` when we pass `set` types.

To fix this, we just check if the whitelist and/or blacklist are string types, rather than that they are _not_ some sort of sequence type.