### PR TITLE
Partial backport of #47161 to 2018.3 branch

### DIFF
--- a/tests/unit/test_pillar.py
+++ b/tests/unit/test_pillar.py
@@ -439,8 +439,8 @@ class PillarTestCase(TestCase):
             'renderer_blacklist': [],
             'renderer_whitelist': [],
             'state_top': '',
-            'pillar_roots': [],
-            'file_roots': [],
+            'pillar_roots': {},
+            'file_roots': {},
             'extension_modules': ''
         }
         grains = {


### PR DESCRIPTION
One of the commits from #47161 also applies to the 2018.3 branch. The mocked file_roots and pillar_roots should be dicts, not lists. This didn't happen to cause any problems with the test in 2018.3, but it would if the 2018.3 branch changed such that the code being tested here ended up referencing either file_roots or pillar_roots like it does now in develop.