### PR TITLE
Updage jenkins module autodocs to use jenkinsmod name instead

### DIFF
--- a/doc/ref/modules/all/index.rst
+++ b/doc/ref/modules/all/index.rst
@@ -186,7 +186,7 @@ execution modules
     iwtools
     jboss7
     jboss7_cli
-    jenkins
+    jenkinsmod
     junos
     k8s
     kapacitor

--- a/doc/ref/modules/all/salt.modules.jenkins.rst
+++ b/doc/ref/modules/all/salt.modules.jenkins.rst
@@ -1,5 +1,0 @@
-salt.modules.jenkins module
-===========================
-
-.. automodule:: salt.modules.jenkins
-    :members:

--- a/doc/ref/modules/all/salt.modules.jenkinsmod.rst
+++ b/doc/ref/modules/all/salt.modules.jenkinsmod.rst
@@ -1,0 +1,5 @@
+salt.modules.jenkinsmod module
+==============================
+
+.. automodule:: salt.modules.jenkinsmod
+    :members:


### PR DESCRIPTION
Refs #46801

The jenkins module was renamed to jenkinsmod recently, but the autodoc files were never updated.

We need to remove the jenkins.py docs from the docbuild server, but we can't do that if the new docs for jenkinsmod.py aren't building yet.

This PR updates the autodoc files to point to the new file.
