### PR TITLE
Make sure a str type is passed to os.walk

### DIFF
--- a/salt/utils/path.py
+++ b/salt/utils/path.py
@@ -406,5 +406,5 @@ def os_walk(top, *args, **kwargs):
     This is a helper than ensures that all paths returned from os.walk are
     unicode.
     '''
-    for item in os.walk(top, *args, **kwargs):
+    for item in os.walk(salt.utils.stringutils.to_str(top), *args, **kwargs):
         yield salt.utils.data.decode(item, preserve_tuples=True)


### PR DESCRIPTION
With strings internally being unicode types in 2018.3.0, we end up passing a unicode path to os.walk. Python 2 appears to have a bug in the stdlib in some versions, in which posixpath can't handle unicode types.  This commit ensures that we pass a str type to os.walk in our os.walk helper.

Fixes #47081.