### PR TITLE
catch invalid data in hw_data

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -53,6 +53,7 @@ import salt.utils.files
 import salt.utils.network
 import salt.utils.path
 import salt.utils.platform
+import salt.utils.stringutils
 from salt.ext import six
 from salt.ext.six.moves import range
 
@@ -2225,10 +2226,7 @@ def _hw_data(osdata):
             if os.path.exists(contents_file):
                 try:
                     with salt.utils.files.fopen(contents_file, 'r') as ifile:
-                        try:
-                            grains[key] = ifile.read().strip().decode('utf-8')
-                        except UnicodeDecodeError:
-                            grains[key] = ''
+                        grains[key] = salt.utils.stringutils.to_unicode(ifile.read().strip())
                         if key == 'uuid':
                             grains['uuid'] = grains['uuid'].lower()
                 except (IOError, OSError) as err:

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -2225,7 +2225,10 @@ def _hw_data(osdata):
             if os.path.exists(contents_file):
                 try:
                     with salt.utils.files.fopen(contents_file, 'r') as ifile:
-                        grains[key] = ifile.read().strip()
+                        try:
+                            grains[key] = ifile.read().strip().decode('utf-8')
+                        except UnicodeDecodeError:
+                            grains[key] = ''
                         if key == 'uuid':
                             grains['uuid'] = grains['uuid'].lower()
                 except (IOError, OSError) as err:


### PR DESCRIPTION
Invalid data in `/sys/class/dmi/id/product_serial` was causing salt to crash with

```
UnicodeDecodeError: 'utf8' codec can't decode byte 0xff in position 0: invalid start byte
Traceback (most recent call last):
  File "salt-call", line 15, in <module>
    salt_call()
  File "py2/salt/scripts.py", line 400, in salt_call
    client.run()
  File "py2/salt/cli/call.py", line 47, in run
    caller = salt.cli.caller.Caller.factory(self.config)
  File "py2/salt/cli/caller.py", line 79, in factory
    return ZeroMQCaller(opts, **kwargs)
  File "py2/salt/cli/caller.py", line 291, in __init__
    super(ZeroMQCaller, self).__init__(opts)
  File "py2/salt/cli/caller.py", line 102, in __init__
    self.minion = salt.minion.SMinion(opts)
  File "py2/salt/minion.py", line 778, in __init__
    opts['grains'] = salt.loader.grains(opts)
  File "py2/salt/loader.py", line 823, in grains
    return salt.utils.data.decode(grains_data, preserve_tuples=True)
  File "py2/salt/utils/data.py", line 99, in decode
    preserve_dict_class, preserve_tuples)
  File "py2/salt/utils/data.py", line 167, in decode_dict
    value, encoding, errors, normalize)
  File "py2/salt/utils/stringutils.py", line 114, in to_unicode
    return _normalize(s.decode('utf-8', errors))
  File "/usr/lib/python2.7/encodings/utf_8.py", line 16, in decode
    return codecs.utf_8_decode(input, errors, True)
UnicodeDecodeError: 'utf8' codec can't decode byte 0xff in position 0: invalid start byte
```

This change makes sure that these grains are valid utf8 before setting them.