### PR TITLE
Create new Softlayer VMs with security_groups attached if configured.

### DIFF
--- a/salt/cloud/clouds/softlayer.py
+++ b/salt/cloud/clouds/softlayer.py
@@ -357,6 +357,27 @@ def create(vm_):
             }
         }
 
+    public_security_groups = config.get_cloud_config_value(
+        'public_security_groups', vm_, __opts__, default=False
+    )
+    if public_security_groups:
+        secgroups = [{'securityGroup': {'id': int(sg)}}
+                     for sg in public_security_groups]
+        pnc = kwargs.get('primaryNetworkComponent', {})
+        pnc['securityGroupBindings'] = secgroups
+        kwargs.update({'primaryNetworkComponent': pnc})
+
+    private_security_groups = config.get_cloud_config_value(
+        'private_security_groups', vm_, __opts__, default=False
+    )
+
+    if private_security_groups:
+        secgroups = [{'securityGroup': {'id': int(sg)}}
+                     for sg in private_security_groups]
+        pbnc = kwargs.get('primaryBackendNetworkComponent', {})
+        pbnc['securityGroupBindings'] = secgroups
+        kwargs.update({'primaryBackendNetworkComponent': pbnc})
+
     max_net_speed = config.get_cloud_config_value(
         'max_net_speed', vm_, __opts__, default=10
     )


### PR DESCRIPTION
### What does this PR do?
If you add config values to your cloud profile for the Softlayer security groups (id's) you want on your VM public and private interfaces it adds them to the creation request.

https://www.ibm.com/blogs/bluemix/2017/09/network-security-groups/

/etc/salt/cloud.profiles.d/xxx.conf
`  public_security_groups: [ 536467, 133621 ]  
  private_security_groups: [ 133627,133629]   
`
### What issues does this PR fix or reference?

### Previous Behavior
These settings would be ignored, the VM created, after creation the Softlayer portal would allow you to add the Security groups to the Public and Private interface, but require another reboot to activate.

### New Behavior
The lists get picked up from the config and added to the vm creation request if it is configured.

### Tests written?
No

### Commits signed with GPG?

Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
