### PR TITLE
salt-ssh: Do not attempt to match host/ip to minion ID if reverse lookup fails

### DIFF
--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -353,6 +353,9 @@ class SSH(object):
         needs_expansion = '*' not in hostname and salt.utils.network.is_reachable_host(hostname)
         if needs_expansion:
             hostname = salt.utils.network.ip_to_host(hostname)
+            if hostname is None:
+                # Reverse lookup failed
+                return
             self._get_roster()
             for roster_filename in self.__parsed_rosters:
                 roster_data = self.__parsed_rosters[roster_filename]

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -218,7 +218,8 @@ def ip_to_host(ip):
     '''
     try:
         hostname, aliaslist, ipaddrlist = socket.gethostbyaddr(ip)
-    except Exception:
+    except Exception as exc:
+        log.debug('salt.utils.network.ip_to_host(%r) failed: %s', ip, exc)
         hostname = None
     return hostname
 


### PR DESCRIPTION
When the reverse lookup fails, `salt.utils.network.ip_to_host()` returns `None`. Later, when we attempt to look through the roster(s) for a minion ID matching the target's host, a roster entry without a `host` key will mean that `roster_data.get('host')` evaluates as None. This causes the target expression to be expanded as `None`, when what we should do is simply carry on without attempting to find a match in the roster(s). This commit does just that.

Fixes #47150.