### PR TITLE
Fix issues with pip

### DIFF
--- a/salt/modules/pip.py
+++ b/salt/modules/pip.py
@@ -715,7 +715,7 @@ def install(pkgs=None,  # pylint: disable=R0912,R0913,R0914
 
     if mirrors:
         # https://github.com/pypa/pip/pull/2641/files#diff-3ef137fb9ffdd400f117a565cd94c188L216
-        pip_version = version(pip_bin)
+        pip_version = version(bin_env)
         if salt.utils.compare_versions(ver1=pip_version, oper='>=', ver2='7.0.0'):
             raise CommandExecutionError(
                     'pip >= 7.0.0 does not support mirror argument:'
@@ -781,7 +781,7 @@ def install(pkgs=None,  # pylint: disable=R0912,R0913,R0914
 
     if pre_releases:
         # Check the locally installed pip version
-        pip_version = version(pip_bin)
+        pip_version = version(bin_env)
 
         # From pip v1.4 the --pre flag is available
         if salt.utils.compare_versions(ver1=pip_version, oper='>=', ver2='1.4'):

--- a/salt/modules/pip.py
+++ b/salt/modules/pip.py
@@ -417,7 +417,6 @@ def install(pkgs=None,  # pylint: disable=R0912,R0913,R0914
             global_options=None,
             install_options=None,
             user=None,
-            no_chown=False,
             cwd=None,
             pre_releases=False,
             cert=None,
@@ -431,7 +430,8 @@ def install(pkgs=None,  # pylint: disable=R0912,R0913,R0914
             trusted_host=None,
             no_cache_dir=False,
             cache_dir=None,
-            no_binary=None):
+            no_binary=None,
+            **kwargs):
     '''
     Install packages with pip
 
@@ -553,10 +553,6 @@ def install(pkgs=None,  # pylint: disable=R0912,R0913,R0914
     user
         The user under which to run pip
 
-    no_chown
-        When user is given, do not attempt to copy and chown a requirements
-        file
-
     cwd
         Current working directory to run pip from
 
@@ -617,6 +613,12 @@ def install(pkgs=None,  # pylint: disable=R0912,R0913,R0914
                 editable=git+https://github.com/worldcompany/djangoembed.git#egg=djangoembed upgrade=True no_deps=True
 
     '''
+    if 'no_chown' in kwargs:
+        salt.utils.warn_until(
+            'Flourine',
+            'The no_chown argument has been deprecated and is no longer used. '
+            'Its functionality was removed in Boron.')
+        kwargs.pop('no_chown')
     cmd = _get_pip_bin(bin_env)
     cmd.append('install')
 
@@ -915,7 +917,6 @@ def uninstall(pkgs=None,
               proxy=None,
               timeout=None,
               user=None,
-              no_chown=False,
               cwd=None,
               saltenv='base',
               use_vt=False):
@@ -948,11 +949,6 @@ def uninstall(pkgs=None,
         Set the socket timeout (default 15 seconds)
     user
         The user under which to run pip
-    no_chown
-        When user is given, do not attempt to copy and chown
-        a requirements file (needed if the requirements file refers to other
-        files via relative paths, as the copy-and-chown procedure does not
-        account for such files)
     cwd
         Current working directory to run pip from
     use_vt

--- a/salt/modules/virtualenv_mod.py
+++ b/salt/modules/virtualenv_mod.py
@@ -56,7 +56,8 @@ def create(path,
            upgrade=None,
            user=None,
            use_vt=False,
-           saltenv='base'):
+           saltenv='base',
+           **kwargs):
     '''
     Create a virtualenv
 
@@ -251,7 +252,7 @@ def create(path,
     cmd.append(path)
 
     # Let's create the virtualenv
-    ret = __salt__['cmd.run_all'](cmd, runas=user, python_shell=False)
+    ret = __salt__['cmd.run_all'](cmd, runas=user, python_shell=False, **kwargs)
     if ret['retcode'] != 0:
         # Something went wrong. Let's bail out now!
         return ret

--- a/salt/modules/virtualenv_mod.py
+++ b/salt/modules/virtualenv_mod.py
@@ -103,6 +103,11 @@ def create(path,
     user : None
         Set ownership for the virtualenv
 
+        .. note::
+            On Windows you must also pass a ``password`` parameter. Additionally,
+            the user must have permissions to the location where the virtual
+            environment is being created
+
     runas : None
         Set ownership for the virtualenv
 
@@ -162,7 +167,7 @@ def create(path,
             # Unable to import?? Let's parse the version from the console
             version_cmd = [venv_bin, '--version']
             ret = __salt__['cmd.run_all'](
-                    version_cmd, runas=user, python_shell=False
+                    version_cmd, runas=user, python_shell=False, **kwargs
                 )
             if ret['retcode'] > 0 or not ret['stdout'].strip():
                 raise CommandExecutionError(

--- a/salt/states/pip_state.py
+++ b/salt/states/pip_state.py
@@ -184,9 +184,9 @@ def _check_pkg_version_format(pkg):
     return ret
 
 
-def _check_if_installed(prefix, state_pkg_name, version_spec,
-                        ignore_installed, force_reinstall,
-                        upgrade, user, cwd, bin_env, env_vars):
+def _check_if_installed(prefix, state_pkg_name, version_spec, ignore_installed,
+                        force_reinstall, upgrade, user, cwd, bin_env, env_vars,
+                        **kwargs):
     # result: None means the command failed to run
     # result: True means the package is installed
     # result: False means the package is not installed
@@ -195,7 +195,7 @@ def _check_if_installed(prefix, state_pkg_name, version_spec,
     # Check if the requested package is already installed.
     pip_list = __salt__['pip.list'](prefix, bin_env=bin_env,
                                     user=user, cwd=cwd,
-                                    env_vars=env_vars)
+                                    env_vars=env_vars, **kwargs)
     prefix_realname = _find_key(prefix, pip_list)
 
     # If the package was already installed, check
@@ -723,7 +723,8 @@ def installed(name,
                 version_spec = version_spec
                 out = _check_if_installed(prefix, state_pkg_name, version_spec,
                                           ignore_installed, force_reinstall,
-                                          upgrade, user, cwd, bin_env, env_vars)
+                                          upgrade, user, cwd, bin_env, env_vars,
+                                          **kwargs)
                 # If _check_if_installed result is None, something went wrong with
                 # the command running. This way we keep stateful output.
                 if out['result'] is None:
@@ -814,7 +815,8 @@ def installed(name,
         env_vars=env_vars,
         use_vt=use_vt,
         trusted_host=trusted_host,
-        no_cache_dir=no_cache_dir
+        no_cache_dir=no_cache_dir,
+        **kwargs
     )
 
     if pip_install_call and pip_install_call.get('retcode', 1) == 0:
@@ -870,7 +872,8 @@ def installed(name,
                 if prefix:
                     pipsearch = __salt__['pip.list'](prefix, bin_env,
                                                      user=user, cwd=cwd,
-                                                     env_vars=env_vars)
+                                                     env_vars=env_vars,
+                                                     **kwargs)
 
                     # If we didn't find the package in the system after
                     # installing it report it

--- a/salt/states/pip_state.py
+++ b/salt/states/pip_state.py
@@ -308,7 +308,6 @@ def installed(name,
               install_options=None,
               global_options=None,
               user=None,
-              no_chown=False,
               cwd=None,
               pre_releases=False,
               cert=None,
@@ -321,7 +320,8 @@ def installed(name,
               trusted_host=None,
               no_cache_dir=False,
               cache_dir=None,
-              no_binary=None):
+              no_binary=None,
+              **kwargs):
     '''
     Make sure the package is installed
 
@@ -442,10 +442,6 @@ def installed(name,
 
     no_install
         Download and unpack all packages, but don't actually install them
-
-    no_chown
-        When user is given, do not attempt to copy and chown
-        a requirements file
 
     no_cache_dir:
         Disable the cache.
@@ -589,6 +585,12 @@ def installed(name,
 
     .. _`virtualenv`: http://www.virtualenv.org/en/latest/
     '''
+    if 'no_chown' in kwargs:
+        salt.utils.warn_until(
+            'Flourine',
+            'The no_chown argument has been deprecated and is no longer used. '
+            'Its functionality was removed in Boron.')
+        kwargs.pop('no_chown')
 
     if pip_bin and not bin_env:
         bin_env = pip_bin
@@ -801,7 +803,6 @@ def installed(name,
         install_options=install_options,
         global_options=global_options,
         user=user,
-        no_chown=no_chown,
         cwd=cwd,
         pre_releases=pre_releases,
         cert=cert,

--- a/salt/states/virtualenv_mod.py
+++ b/salt/states/virtualenv_mod.py
@@ -39,7 +39,6 @@ def managed(name,
             never_download=None,
             prompt=None,
             user=None,
-            no_chown=False,
             cwd=None,
             index_url=None,
             extra_index_url=None,
@@ -58,7 +57,8 @@ def managed(name,
             pip_no_cache_dir=False,
             pip_cache_dir=None,
             process_dependency_links=False,
-            no_binary=None):
+            no_binary=None,
+            **kwargs):
     '''
     Create a virtualenv and optionally manage it with pip
 
@@ -77,11 +77,6 @@ def managed(name,
 
     user: None
         The user under which to run virtualenv and pip.
-
-    no_chown: False
-        When user is given, do not attempt to copy and chown a requirements file
-        (needed if the requirements file refers to other files via relative
-        paths, as the copy-and-chown procedure does not account for such files)
 
     cwd: None
         Path to the working directory where `pip install` is executed.
@@ -133,6 +128,13 @@ def managed(name,
             - env_vars:
                 PATH_VAR: '/usr/local/bin/'
     '''
+    if 'no_chown' in kwargs:
+        salt.utils.warn_until(
+            'Flourine',
+            'The no_chown argument has been deprecated and is no longer used. '
+            'Its functionality was removed in Boron.')
+        kwargs.pop('no_chown')
+
     ret = {'name': name, 'result': True, 'comment': '', 'changes': {}}
 
     if 'virtualenv.create' not in __salt__:
@@ -305,7 +307,6 @@ def managed(name,
             extra_index_url=extra_index_url,
             download=pip_download,
             download_cache=pip_download_cache,
-            no_chown=no_chown,
             pre_releases=pre_releases,
             exists_action=pip_exists_action,
             ignore_installed=pip_ignore_installed,

--- a/salt/states/virtualenv_mod.py
+++ b/salt/states/virtualenv_mod.py
@@ -207,6 +207,7 @@ def managed(name,
                 prompt=prompt,
                 user=user,
                 use_vt=use_vt,
+                **kwargs
             )
         except CommandNotFoundError as err:
             ret['result'] = False
@@ -316,7 +317,8 @@ def managed(name,
             use_vt=use_vt,
             env_vars=env_vars,
             no_cache_dir=pip_no_cache_dir,
-            cache_dir=pip_cache_dir
+            cache_dir=pip_cache_dir,
+            **kwargs
         )
         ret['result'] &= pip_ret['retcode'] == 0
         if pip_ret['retcode'] > 0:

--- a/tests/integration/states/test_pip.py
+++ b/tests/integration/states/test_pip.py
@@ -333,7 +333,7 @@ class PipStateTest(ModuleCase, SaltReturnAssertsMixin):
             'virtualenv.create', [venv_dir], user=username,
             password='PassWord1!')
         if venv_create['retcode'] > 0:
-            self.skiptest('failed to create testcase virtual environment: {0}'
+            self.skipTest('failed to create testcase virtual environment: {0}'
                           ''.format(venv_create))
 
         # pip install using a requirements file

--- a/tests/unit/modules/test_pip.py
+++ b/tests/unit/modules/test_pip.py
@@ -50,7 +50,7 @@ class PipTestCase(TestCase, LoaderModuleMockMixin):
             'git+https://github.com/saltstack/salt-testing.git#egg=SaltTesting'
         ]
 
-        expected = [sys.executable, '-m','pip', 'install']
+        expected = [sys.executable, '-m', 'pip', 'install']
         for item in editables:
             expected.extend(['--editable', item])
 

--- a/tests/unit/modules/test_pip.py
+++ b/tests/unit/modules/test_pip.py
@@ -3,6 +3,7 @@
 # Import python libs
 from __future__ import absolute_import
 import os
+import sys
 
 # Import Salt Testing libs
 from tests.support.mixins import LoaderModuleMockMixin
@@ -25,9 +26,8 @@ class PipTestCase(TestCase, LoaderModuleMockMixin):
         mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
         with patch.dict(pip.__salt__, {'cmd.run_all': mock}):
             pip.install(requirements='requirements.txt')
-            expected_cmd = ['pip', 'install', '--requirement',
-                            'requirements.txt']
-            mock.assert_called_once_with(
+            expected_cmd = [sys.executable, '-m', 'pip', 'install', '--requirement', 'requirements.txt']
+            mock.assert_called_with(
                 expected_cmd,
                 saltenv='base',
                 runas=None,
@@ -50,7 +50,7 @@ class PipTestCase(TestCase, LoaderModuleMockMixin):
             'git+https://github.com/saltstack/salt-testing.git#egg=SaltTesting'
         ]
 
-        expected = ['pip', 'install']
+        expected = [sys.executable, '-m','pip', 'install']
         for item in editables:
             expected.extend(['--editable', item])
 
@@ -58,7 +58,7 @@ class PipTestCase(TestCase, LoaderModuleMockMixin):
         mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
         with patch.dict(pip.__salt__, {'cmd.run_all': mock}):
             pip.install(editable=editables)
-            mock.assert_called_once_with(
+            mock.assert_called_with(
                 expected,
                 saltenv='base',
                 runas=None,
@@ -70,7 +70,7 @@ class PipTestCase(TestCase, LoaderModuleMockMixin):
         mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
         with patch.dict(pip.__salt__, {'cmd.run_all': mock}):
             pip.install(editable=','.join(editables))
-            mock.assert_called_once_with(
+            mock.assert_called_with(
                 expected,
                 saltenv='base',
                 runas=None,
@@ -85,7 +85,8 @@ class PipTestCase(TestCase, LoaderModuleMockMixin):
             'git+https://github.com/saltstack/salt-testing.git#egg=SaltTesting'
         ]
 
-        expected = ['pip', 'install'] + pkgs
+        expected = [sys.executable, '-m', 'pip', 'install']
+        expected.extend(pkgs)
         for item in editables:
             expected.extend(['--editable', item])
 
@@ -93,7 +94,7 @@ class PipTestCase(TestCase, LoaderModuleMockMixin):
         mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
         with patch.dict(pip.__salt__, {'cmd.run_all': mock}):
             pip.install(pkgs=pkgs, editable=editables)
-            mock.assert_called_once_with(
+            mock.assert_called_with(
                 expected,
                 saltenv='base',
                 runas=None,
@@ -105,7 +106,7 @@ class PipTestCase(TestCase, LoaderModuleMockMixin):
         mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
         with patch.dict(pip.__salt__, {'cmd.run_all': mock}):
             pip.install(pkgs=','.join(pkgs), editable=','.join(editables))
-            mock.assert_called_once_with(
+            mock.assert_called_with(
                 expected,
                 saltenv='base',
                 runas=None,
@@ -117,8 +118,9 @@ class PipTestCase(TestCase, LoaderModuleMockMixin):
         mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
         with patch.dict(pip.__salt__, {'cmd.run_all': mock}):
             pip.install(pkgs=pkgs[0], editable=editables[0])
-            mock.assert_called_once_with(
-                ['pip', 'install', pkgs[0], '--editable', editables[0]],
+            expected = [sys.executable, '-m', 'pip', 'install', pkgs[0], '--editable', editables[0]]
+            mock.assert_called_with(
+                expected,
                 saltenv='base',
                 runas=None,
                 use_vt=False,
@@ -136,7 +138,7 @@ class PipTestCase(TestCase, LoaderModuleMockMixin):
                 'http://pypi.crate.io'
             ]
 
-            expected = ['pip', 'install', '--use-mirrors']
+            expected = [sys.executable, '-m', 'pip', 'install', '--use-mirrors']
             for item in mirrors:
                 expected.extend(['--mirrors', item])
             expected.append('pep8')
@@ -145,7 +147,7 @@ class PipTestCase(TestCase, LoaderModuleMockMixin):
             mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
             with patch.dict(pip.__salt__, {'cmd.run_all': mock}):
                 pip.install(pkgs=['pep8'], mirrors=mirrors)
-                mock.assert_called_once_with(
+                mock.assert_called_with(
                     expected,
                     saltenv='base',
                     runas=None,
@@ -157,7 +159,7 @@ class PipTestCase(TestCase, LoaderModuleMockMixin):
             mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
             with patch.dict(pip.__salt__, {'cmd.run_all': mock}):
                 pip.install(pkgs=['pep8'], mirrors=','.join(mirrors))
-                mock.assert_called_once_with(
+                mock.assert_called_with(
                     expected,
                     saltenv='base',
                     runas=None,
@@ -165,12 +167,14 @@ class PipTestCase(TestCase, LoaderModuleMockMixin):
                     python_shell=False,
                 )
 
+            expected = [sys.executable, '-m', 'pip', 'install', '--use-mirrors', '--mirrors', mirrors[0], 'pep8']
+
             # As single string (just use the first element from mirrors)
             mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
             with patch.dict(pip.__salt__, {'cmd.run_all': mock}):
                 pip.install(pkgs=['pep8'], mirrors=mirrors[0])
-                mock.assert_called_once_with(
-                    ['pip', 'install', '--use-mirrors', '--mirrors', mirrors[0], 'pep8'],
+                mock.assert_called_with(
+                    expected,
                     saltenv='base',
                     runas=None,
                     use_vt=False,
@@ -185,7 +189,7 @@ class PipTestCase(TestCase, LoaderModuleMockMixin):
         ]
         pkg = 'pep8'
 
-        expected = ['pip', 'install']
+        expected = [sys.executable, '-m', 'pip', 'install']
         for item in find_links:
             expected.extend(['--find-links', item])
         expected.append(pkg)
@@ -194,7 +198,7 @@ class PipTestCase(TestCase, LoaderModuleMockMixin):
         mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
         with patch.dict(pip.__salt__, {'cmd.run_all': mock}):
             pip.install(pkg, find_links=find_links)
-            mock.assert_called_once_with(
+            mock.assert_called_with(
                 expected,
                 saltenv='base',
                 runas=None,
@@ -206,7 +210,7 @@ class PipTestCase(TestCase, LoaderModuleMockMixin):
         mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
         with patch.dict(pip.__salt__, {'cmd.run_all': mock}):
             pip.install(pkg, find_links=','.join(find_links))
-            mock.assert_called_once_with(
+            mock.assert_called_with(
                 expected,
                 saltenv='base',
                 runas=None,
@@ -214,12 +218,26 @@ class PipTestCase(TestCase, LoaderModuleMockMixin):
                 python_shell=False,
             )
 
+        # Valid protos work?
+        mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
+        with patch.dict(pip.__salt__, {'cmd.run_all': mock}):
+            pip.install(pkg, find_links=find_links)
+            mock.assert_called_with(
+                expected,
+                saltenv='base',
+                runas=None,
+                use_vt=False,
+                python_shell=False,
+            )
+
+        expected = [sys.executable, '-m', 'pip', 'install', '--find-links', find_links[0], pkg]
+
         # As single string (just use the first element from find_links)
         mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
         with patch.dict(pip.__salt__, {'cmd.run_all': mock}):
             pip.install(pkg, find_links=find_links[0])
-            mock.assert_called_once_with(
-                ['pip', 'install', '--find-links', find_links[0], pkg],
+            mock.assert_called_with(
+                expected,
                 saltenv='base',
                 runas=None,
                 use_vt=False,
@@ -234,18 +252,6 @@ class PipTestCase(TestCase, LoaderModuleMockMixin):
                 pip.install,
                 '\'' + pkg + '\'',
                 find_links='sftp://pypi.crate.io'
-            )
-
-        # Valid protos work?
-        mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
-        with patch.dict(pip.__salt__, {'cmd.run_all': mock}):
-            pip.install(pkg, find_links=find_links)
-            mock.assert_called_once_with(
-                expected,
-                saltenv='base',
-                runas=None,
-                use_vt=False,
-                python_shell=False,
             )
 
     def test_install_no_index_with_index_url_or_extra_index_url_raises(self):
@@ -276,8 +282,8 @@ class PipTestCase(TestCase, LoaderModuleMockMixin):
             mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
             with patch.dict(pip.__salt__, {'cmd.run_all': mock}):
                 pip.install(requirements='salt://requirements.txt')
-                expected = ['pip', 'install', '--requirement', 'my_cached_reqs']
-                mock.assert_called_once_with(
+                expected = [sys.executable, '-m', 'pip', 'install', '--requirement', 'my_cached_reqs']
+                mock.assert_called_with(
                     expected,
                     saltenv='base',
                     runas=None,
@@ -287,26 +293,25 @@ class PipTestCase(TestCase, LoaderModuleMockMixin):
 
     def test_install_venv(self):
         with patch('os.path') as mock_path:
-            mock_path.is_file.return_value = True
-            mock_path.isdir.return_value = True
-
-            pkg = 'mock'
 
             def join(*args):
-                return os.sep.join(args)
+                return os.path.normpath(os.sep.join(args))
 
+            mock_path.is_file.return_value = True
+            mock_path.isdir.return_value = True
             mock_path.join = join
+
             mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
             with patch.dict(pip.__salt__, {'cmd.run_all': mock}):
                 if salt.utils.is_windows():
-                    venv_path = 'c:\\test_env'
-                    bin_path = os.path.join(venv_path, 'Scripts', 'pip.exe')
+                    venv_path = 'C:\\test_env'
+                    bin_path = os.path.join(venv_path, 'python.exe')
                 else:
                     venv_path = '/test_env'
-                    bin_path = os.path.join(venv_path, 'bin', 'pip')
-                pip.install(pkg, bin_env=venv_path)
-                mock.assert_called_once_with(
-                    [bin_path, 'install', pkg],
+                    bin_path = os.path.join(venv_path, 'python')
+                pip.install('mock', bin_env=venv_path)
+                mock.assert_called_with(
+                    [bin_path, '-m', 'pip', 'install', 'mock'],
                     env={'VIRTUAL_ENV': venv_path},
                     saltenv='base',
                     runas=None,
@@ -321,8 +326,9 @@ class PipTestCase(TestCase, LoaderModuleMockMixin):
             mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
             with patch.dict(pip.__salt__, {'cmd.run_all': mock}):
                 pip.install(pkg, log=log_path)
-                mock.assert_called_once_with(
-                    ['pip', 'install', '--log', log_path, pkg],
+                expected = [sys.executable, '-m', 'pip', 'install', '--log', log_path, pkg]
+                mock.assert_called_with(
+                    expected,
                     saltenv='base',
                     runas=None,
                     use_vt=False,
@@ -347,12 +353,12 @@ class PipTestCase(TestCase, LoaderModuleMockMixin):
     def test_install_timeout_argument_in_resulting_command(self):
         # Passing an int
         pkg = 'pep8'
-        expected_prefix = ['pip', 'install', '--timeout']
+        expected = [sys.executable, '-m', 'pip', 'install', '--timeout']
         mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
         with patch.dict(pip.__salt__, {'cmd.run_all': mock}):
             pip.install(pkg, timeout=10)
-            mock.assert_called_once_with(
-                expected_prefix + [10, pkg],
+            mock.assert_called_with(
+                expected + [10, pkg],
                 saltenv='base',
                 runas=None,
                 use_vt=False,
@@ -363,8 +369,8 @@ class PipTestCase(TestCase, LoaderModuleMockMixin):
         mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
         with patch.dict(pip.__salt__, {'cmd.run_all': mock}):
             pip.install(pkg, timeout='10')
-            mock.assert_called_once_with(
-                expected_prefix + ['10', pkg],
+            mock.assert_called_with(
+                expected + ['10', pkg],
                 saltenv='base',
                 runas=None,
                 use_vt=False,
@@ -387,8 +393,9 @@ class PipTestCase(TestCase, LoaderModuleMockMixin):
         mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
         with patch.dict(pip.__salt__, {'cmd.run_all': mock}):
             pip.install(pkg, index_url=index_url)
-            mock.assert_called_once_with(
-                ['pip', 'install', '--index-url', index_url, pkg],
+            expected = [sys.executable, '-m', 'pip', 'install', '--index-url', index_url, pkg]
+            mock.assert_called_with(
+                expected,
                 saltenv='base',
                 runas=None,
                 use_vt=False,
@@ -401,8 +408,9 @@ class PipTestCase(TestCase, LoaderModuleMockMixin):
         mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
         with patch.dict(pip.__salt__, {'cmd.run_all': mock}):
             pip.install(pkg, extra_index_url=extra_index_url)
-            mock.assert_called_once_with(
-                ['pip', 'install', '--extra-index-url', extra_index_url, pkg],
+            expected = [sys.executable, '-m', 'pip', 'install', '--extra-index-url', extra_index_url, pkg]
+            mock.assert_called_with(
+                expected,
                 saltenv='base',
                 runas=None,
                 use_vt=False,
@@ -414,8 +422,9 @@ class PipTestCase(TestCase, LoaderModuleMockMixin):
         mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
         with patch.dict(pip.__salt__, {'cmd.run_all': mock}):
             pip.install(pkg, no_index=True)
-            mock.assert_called_once_with(
-                ['pip', 'install', '--no-index', pkg],
+            expected = [sys.executable, '-m', 'pip', 'install', '--no-index', pkg]
+            mock.assert_called_with(
+                expected,
                 saltenv='base',
                 runas=None,
                 use_vt=False,
@@ -428,8 +437,9 @@ class PipTestCase(TestCase, LoaderModuleMockMixin):
         mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
         with patch.dict(pip.__salt__, {'cmd.run_all': mock}):
             pip.install(pkg, build=build)
-            mock.assert_called_once_with(
-                ['pip', 'install', '--build', build, pkg],
+            expected = [sys.executable, '-m', 'pip', 'install', '--build', build, pkg]
+            mock.assert_called_with(
+                expected,
                 saltenv='base',
                 runas=None,
                 use_vt=False,
@@ -442,8 +452,9 @@ class PipTestCase(TestCase, LoaderModuleMockMixin):
         mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
         with patch.dict(pip.__salt__, {'cmd.run_all': mock}):
             pip.install(pkg, target=target)
-            mock.assert_called_once_with(
-                ['pip', 'install', '--target', target, pkg],
+            expected = [sys.executable, '-m', 'pip', 'install', '--target', target, pkg]
+            mock.assert_called_with(
+                expected,
                 saltenv='base',
                 runas=None,
                 use_vt=False,
@@ -456,8 +467,9 @@ class PipTestCase(TestCase, LoaderModuleMockMixin):
         mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
         with patch.dict(pip.__salt__, {'cmd.run_all': mock}):
             pip.install(pkg, download=download)
-            mock.assert_called_once_with(
-                ['pip', 'install', '--download', download, pkg],
+            expected = [sys.executable, '-m', 'pip', 'install', '--download', download, pkg]
+            mock.assert_called_with(
+                expected,
                 saltenv='base',
                 runas=None,
                 use_vt=False,
@@ -469,8 +481,9 @@ class PipTestCase(TestCase, LoaderModuleMockMixin):
         mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
         with patch.dict(pip.__salt__, {'cmd.run_all': mock}):
             pip.install(pkg, no_download=True)
-            mock.assert_called_once_with(
-                ['pip', 'install', '--no-download', pkg],
+            expected = [sys.executable, '-m', 'pip', 'install', '--no-download', pkg]
+            mock.assert_called_with(
+                expected,
                 saltenv='base',
                 runas=None,
                 use_vt=False,
@@ -492,8 +505,9 @@ class PipTestCase(TestCase, LoaderModuleMockMixin):
                            MagicMock(return_value=pip_version)):
                     # test `download_cache` kwarg
                     pip.install(pkg, download_cache='/tmp/foo')
+                    expected = [sys.executable, '-m', 'pip', 'install', cmd_arg, download_cache, pkg]
                     mock.assert_called_with(
-                        ['pip', 'install', cmd_arg, download_cache, pkg],
+                        expected,
                         saltenv='base',
                         runas=None,
                         use_vt=False,
@@ -503,7 +517,7 @@ class PipTestCase(TestCase, LoaderModuleMockMixin):
                     # test `cache_dir` kwarg
                     pip.install(pkg, cache_dir='/tmp/foo')
                     mock.assert_called_with(
-                        ['pip', 'install', cmd_arg, download_cache, pkg],
+                        expected,
                         saltenv='base',
                         runas=None,
                         use_vt=False,
@@ -516,8 +530,9 @@ class PipTestCase(TestCase, LoaderModuleMockMixin):
         mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
         with patch.dict(pip.__salt__, {'cmd.run_all': mock}):
             pip.install(pkg, source=source)
-            mock.assert_called_once_with(
-                ['pip', 'install', '--source', source, pkg],
+            expected = [sys.executable, '-m', 'pip', 'install', '--source', source, pkg]
+            mock.assert_called_with(
+                expected,
                 saltenv='base',
                 runas=None,
                 use_vt=False,
@@ -529,9 +544,10 @@ class PipTestCase(TestCase, LoaderModuleMockMixin):
         for action in ('s', 'i', 'w', 'b'):
             mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
             with patch.dict(pip.__salt__, {'cmd.run_all': mock}):
-                pip.install('pep8', exists_action=action)
-                mock.assert_called_once_with(
-                    ['pip', 'install', '--exists-action', action, pkg],
+                pip.install(pkg, exists_action=action)
+                expected = [sys.executable, '-m', 'pip', 'install', '--exists-action', action, pkg]
+                mock.assert_called_with(
+                    expected,
                     saltenv='base',
                     runas=None,
                     use_vt=False,
@@ -555,7 +571,7 @@ class PipTestCase(TestCase, LoaderModuleMockMixin):
         ]
         pkg = 'pep8'
 
-        expected = ['pip', 'install']
+        expected = [sys.executable, '-m', 'pip', 'install']
         for item in install_options:
             expected.extend(['--install-option', item])
         expected.append(pkg)
@@ -564,7 +580,7 @@ class PipTestCase(TestCase, LoaderModuleMockMixin):
         mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
         with patch.dict(pip.__salt__, {'cmd.run_all': mock}):
             pip.install(pkg, install_options=install_options)
-            mock.assert_called_once_with(
+            mock.assert_called_with(
                 expected,
                 saltenv='base',
                 runas=None,
@@ -576,7 +592,7 @@ class PipTestCase(TestCase, LoaderModuleMockMixin):
         mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
         with patch.dict(pip.__salt__, {'cmd.run_all': mock}):
             pip.install(pkg, install_options=','.join(install_options))
-            mock.assert_called_once_with(
+            mock.assert_called_with(
                 expected,
                 saltenv='base',
                 runas=None,
@@ -588,9 +604,9 @@ class PipTestCase(TestCase, LoaderModuleMockMixin):
         mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
         with patch.dict(pip.__salt__, {'cmd.run_all': mock}):
             pip.install(pkg, install_options=install_options[0])
-            mock.assert_called_once_with(
-                ['pip', 'install', '--install-option',
-                 install_options[0], pkg],
+            expected = [sys.executable, '-m', 'pip', 'install', '--install-option', install_options[0], pkg]
+            mock.assert_called_with(
+                expected,
                 saltenv='base',
                 runas=None,
                 use_vt=False,
@@ -604,7 +620,7 @@ class PipTestCase(TestCase, LoaderModuleMockMixin):
         ]
         pkg = 'pep8'
 
-        expected = ['pip', 'install']
+        expected = [sys.executable, '-m', 'pip', 'install']
         for item in global_options:
             expected.extend(['--global-option', item])
         expected.append(pkg)
@@ -613,7 +629,7 @@ class PipTestCase(TestCase, LoaderModuleMockMixin):
         mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
         with patch.dict(pip.__salt__, {'cmd.run_all': mock}):
             pip.install(pkg, global_options=global_options)
-            mock.assert_called_once_with(
+            mock.assert_called_with(
                 expected,
                 saltenv='base',
                 runas=None,
@@ -625,7 +641,7 @@ class PipTestCase(TestCase, LoaderModuleMockMixin):
         mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
         with patch.dict(pip.__salt__, {'cmd.run_all': mock}):
             pip.install(pkg, global_options=','.join(global_options))
-            mock.assert_called_once_with(
+            mock.assert_called_with(
                 expected,
                 saltenv='base',
                 runas=None,
@@ -637,8 +653,9 @@ class PipTestCase(TestCase, LoaderModuleMockMixin):
         mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
         with patch.dict(pip.__salt__, {'cmd.run_all': mock}):
             pip.install(pkg, global_options=global_options[0])
-            mock.assert_called_once_with(
-                ['pip', 'install', '--global-option', global_options[0], pkg],
+            expected = [sys.executable, '-m', 'pip', 'install', '--global-option', global_options[0], pkg]
+            mock.assert_called_with(
+                expected,
                 saltenv='base',
                 runas=None,
                 use_vt=False,
@@ -650,8 +667,9 @@ class PipTestCase(TestCase, LoaderModuleMockMixin):
         mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
         with patch.dict(pip.__salt__, {'cmd.run_all': mock}):
             pip.install(pkg, upgrade=True)
-            mock.assert_called_once_with(
-                ['pip', 'install', '--upgrade', pkg],
+            expected = [sys.executable, '-m', 'pip', 'install', '--upgrade', pkg]
+            mock.assert_called_with(
+                expected,
                 saltenv='base',
                 runas=None,
                 use_vt=False,
@@ -663,8 +681,9 @@ class PipTestCase(TestCase, LoaderModuleMockMixin):
         mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
         with patch.dict(pip.__salt__, {'cmd.run_all': mock}):
             pip.install(pkg, force_reinstall=True)
-            mock.assert_called_once_with(
-                ['pip', 'install', '--force-reinstall', pkg],
+            expected = [sys.executable, '-m', 'pip', 'install', '--force-reinstall', pkg]
+            mock.assert_called_with(
+                expected,
                 saltenv='base',
                 runas=None,
                 use_vt=False,
@@ -676,8 +695,9 @@ class PipTestCase(TestCase, LoaderModuleMockMixin):
         mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
         with patch.dict(pip.__salt__, {'cmd.run_all': mock}):
             pip.install(pkg, ignore_installed=True)
-            mock.assert_called_once_with(
-                ['pip', 'install', '--ignore-installed', pkg],
+            expected = [sys.executable, '-m', 'pip', 'install', '--ignore-installed', pkg]
+            mock.assert_called_with(
+                expected,
                 saltenv='base',
                 runas=None,
                 use_vt=False,
@@ -689,8 +709,9 @@ class PipTestCase(TestCase, LoaderModuleMockMixin):
         mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
         with patch.dict(pip.__salt__, {'cmd.run_all': mock}):
             pip.install(pkg, no_deps=True)
-            mock.assert_called_once_with(
-                ['pip', 'install', '--no-deps', pkg],
+            expected = [sys.executable, '-m', 'pip', 'install', '--no-deps', pkg]
+            mock.assert_called_with(
+                expected,
                 saltenv='base',
                 runas=None,
                 use_vt=False,
@@ -702,8 +723,9 @@ class PipTestCase(TestCase, LoaderModuleMockMixin):
         mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
         with patch.dict(pip.__salt__, {'cmd.run_all': mock}):
             pip.install(pkg, no_install=True)
-            mock.assert_called_once_with(
-                ['pip', 'install', '--no-install', pkg],
+            expected = [sys.executable, '-m', 'pip', 'install', '--no-install', pkg]
+            mock.assert_called_with(
+                expected,
                 saltenv='base',
                 runas=None,
                 use_vt=False,
@@ -716,8 +738,9 @@ class PipTestCase(TestCase, LoaderModuleMockMixin):
         mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
         with patch.dict(pip.__salt__, {'cmd.run_all': mock}):
             pip.install(pkg, proxy=proxy)
-            mock.assert_called_once_with(
-                ['pip', 'install', '--proxy', proxy, pkg],
+            expected = [sys.executable, '-m', 'pip', 'install', '--proxy', proxy, pkg]
+            mock.assert_called_with(
+                expected,
                 saltenv='base',
                 runas=None,
                 use_vt=False,
@@ -734,7 +757,7 @@ class PipTestCase(TestCase, LoaderModuleMockMixin):
                 'salt://requirements-1.txt', 'salt://requirements-2.txt'
             ]
 
-            expected = ['pip', 'install']
+            expected = [sys.executable, '-m', 'pip', 'install']
             for item in cached_reqs:
                 expected.extend(['--requirement', item])
 
@@ -742,7 +765,7 @@ class PipTestCase(TestCase, LoaderModuleMockMixin):
             mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
             with patch.dict(pip.__salt__, {'cmd.run_all': mock}):
                 pip.install(requirements=requirements)
-                mock.assert_called_once_with(
+                mock.assert_called_with(
                     expected,
                     saltenv='base',
                     runas=None,
@@ -755,7 +778,7 @@ class PipTestCase(TestCase, LoaderModuleMockMixin):
             mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
             with patch.dict(pip.__salt__, {'cmd.run_all': mock}):
                 pip.install(requirements=','.join(requirements))
-                mock.assert_called_once_with(
+                mock.assert_called_with(
                     expected,
                     saltenv='base',
                     runas=None,
@@ -768,8 +791,9 @@ class PipTestCase(TestCase, LoaderModuleMockMixin):
             mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
             with patch.dict(pip.__salt__, {'cmd.run_all': mock}):
                 pip.install(requirements=requirements[0])
-                mock.assert_called_once_with(
-                    ['pip', 'install', '--requirement', cached_reqs[0]],
+                expected = [sys.executable, '-m', 'pip', 'install', '--requirement', cached_reqs[0]]
+                mock.assert_called_with(
+                    expected,
                     saltenv='base',
                     runas=None,
                     use_vt=False,
@@ -786,7 +810,7 @@ class PipTestCase(TestCase, LoaderModuleMockMixin):
                 'salt://requirements-1.txt', 'salt://requirements-2.txt'
             ]
 
-            expected = ['pip', 'uninstall', '-y']
+            expected = [sys.executable, '-m', 'pip', 'uninstall', '-y']
             for item in cached_reqs:
                 expected.extend(['--requirement', item])
 
@@ -794,7 +818,7 @@ class PipTestCase(TestCase, LoaderModuleMockMixin):
             mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
             with patch.dict(pip.__salt__, {'cmd.run_all': mock}):
                 pip.uninstall(requirements=requirements)
-                mock.assert_called_once_with(
+                mock.assert_called_with(
                     expected,
                     cwd=None,
                     saltenv='base',
@@ -808,7 +832,7 @@ class PipTestCase(TestCase, LoaderModuleMockMixin):
             mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
             with patch.dict(pip.__salt__, {'cmd.run_all': mock}):
                 pip.uninstall(requirements=','.join(requirements))
-                mock.assert_called_once_with(
+                mock.assert_called_with(
                     expected,
                     cwd=None,
                     saltenv='base',
@@ -822,8 +846,9 @@ class PipTestCase(TestCase, LoaderModuleMockMixin):
             mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
             with patch.dict(pip.__salt__, {'cmd.run_all': mock}):
                 pip.uninstall(requirements=requirements[0])
-                mock.assert_called_once_with(
-                    ['pip', 'uninstall', '-y', '--requirement', cached_reqs[0]],
+                expected = [sys.executable, '-m', 'pip', 'uninstall', '-y', '--requirement', cached_reqs[0]]
+                mock.assert_called_with(
+                    expected,
                     cwd=None,
                     saltenv='base',
                     runas=None,
@@ -837,8 +862,9 @@ class PipTestCase(TestCase, LoaderModuleMockMixin):
         mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
         with patch.dict(pip.__salt__, {'cmd.run_all': mock}):
             pip.uninstall(pkg, proxy=proxy)
-            mock.assert_called_once_with(
-                ['pip', 'uninstall', '-y', '--proxy', proxy, pkg],
+            expected = [sys.executable, '-m', 'pip', 'uninstall', '-y', '--proxy', proxy, pkg]
+            mock.assert_called_with(
+                expected,
                 saltenv='base',
                 cwd=None,
                 runas=None,
@@ -847,22 +873,24 @@ class PipTestCase(TestCase, LoaderModuleMockMixin):
             )
 
     def test_uninstall_log_argument_in_resulting_command(self):
-        with patch('os.path') as mock_path:
-            pkg = 'pep8'
-            log_path = '/tmp/pip-install.log'
-            mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
-            with patch.dict(pip.__salt__, {'cmd.run_all': mock}):
-                pip.uninstall(pkg, log=log_path)
-                mock.assert_called_once_with(
-                    ['pip', 'uninstall', '-y', '--log', log_path, pkg],
-                    saltenv='base',
-                    cwd=None,
-                    runas=None,
-                    use_vt=False,
-                    python_shell=False,
-                )
+        pkg = 'pep8'
+        log_path = '/tmp/pip-install.log'
 
-            # Let's fake a non-writable log file
+        mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
+        with patch.dict(pip.__salt__, {'cmd.run_all': mock}):
+            pip.uninstall(pkg, log=log_path)
+            expected = [sys.executable, '-m', 'pip', 'uninstall', '-y', '--log', log_path, pkg]
+            mock.assert_called_with(
+                expected,
+                saltenv='base',
+                cwd=None,
+                runas=None,
+                use_vt=False,
+                python_shell=False,
+            )
+
+        # Let's fake a non-writable log file
+        with patch('os.path') as mock_path:
             mock_path.exists.side_effect = IOError('Fooo!')
             mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
             with patch.dict(pip.__salt__, {'cmd.run_all': mock}):
@@ -875,13 +903,13 @@ class PipTestCase(TestCase, LoaderModuleMockMixin):
 
     def test_uninstall_timeout_argument_in_resulting_command(self):
         pkg = 'pep8'
-        expected_prefix = ['pip', 'uninstall', '-y', '--timeout']
+        expected = [sys.executable, '-m', 'pip', 'uninstall', '-y', '--timeout']
         # Passing an int
         mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
         with patch.dict(pip.__salt__, {'cmd.run_all': mock}):
             pip.uninstall(pkg, timeout=10)
-            mock.assert_called_once_with(
-                expected_prefix + [10, pkg],
+            mock.assert_called_with(
+                expected + [10, pkg],
                 cwd=None,
                 saltenv='base',
                 runas=None,
@@ -893,8 +921,8 @@ class PipTestCase(TestCase, LoaderModuleMockMixin):
         mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
         with patch.dict(pip.__salt__, {'cmd.run_all': mock}):
             pip.uninstall(pkg, timeout='10')
-            mock.assert_called_once_with(
-                expected_prefix + ['10', pkg],
+            mock.assert_called_with(
+                expected + ['10', pkg],
                 cwd=None,
                 saltenv='base',
                 runas=None,
@@ -913,6 +941,7 @@ class PipTestCase(TestCase, LoaderModuleMockMixin):
             )
 
     def test_freeze_command(self):
+        expected = [sys.executable, '-m', 'pip', 'freeze']
         eggs = [
             'M2Crypto==0.21.1',
             '-e git+git@github.com:s0undt3ch/salt-testing.git@9ed81aa2f918d59d3706e56b18f0782d1ea43bf8#egg=SaltTesting-dev',
@@ -930,8 +959,8 @@ class PipTestCase(TestCase, LoaderModuleMockMixin):
             with patch('salt.modules.pip.version',
                        MagicMock(return_value='6.1.1')):
                 ret = pip.freeze()
-                mock.assert_called_once_with(
-                    ['pip', 'freeze'],
+                mock.assert_called_with(
+                    expected,
                     cwd=None,
                     runas=None,
                     use_vt=False,
@@ -950,8 +979,8 @@ class PipTestCase(TestCase, LoaderModuleMockMixin):
             with patch('salt.modules.pip.version',
                        MagicMock(return_value='6.1.1')):
                 ret = pip.freeze(env_vars={"foo": "bar"})
-                mock.assert_called_once_with(
-                    ['pip', 'freeze'],
+                mock.assert_called_with(
+                    expected,
                     cwd=None,
                     runas=None,
                     use_vt=False,
@@ -990,8 +1019,9 @@ class PipTestCase(TestCase, LoaderModuleMockMixin):
             with patch('salt.modules.pip.version',
                        MagicMock(return_value='9.0.1')):
                 ret = pip.freeze()
-                mock.assert_called_once_with(
-                    ['pip', 'freeze', '--all'],
+                expected = [sys.executable, '-m', 'pip', 'freeze', '--all']
+                mock.assert_called_with(
+                    expected,
                     cwd=None,
                     runas=None,
                     use_vt=False,
@@ -1023,8 +1053,9 @@ class PipTestCase(TestCase, LoaderModuleMockMixin):
             with patch('salt.modules.pip.version',
                        MagicMock(return_value=mock_version)):
                 ret = pip.list_()
+                expected = [sys.executable, '-m', 'pip', 'freeze']
                 mock.assert_called_with(
-                    ['pip', 'freeze'],
+                    expected,
                     cwd=None,
                     runas=None,
                     python_shell=False,
@@ -1070,8 +1101,9 @@ class PipTestCase(TestCase, LoaderModuleMockMixin):
             with patch('salt.modules.pip.version',
                        MagicMock(return_value=mock_version)):
                 ret = pip.list_()
+                expected = [sys.executable, '-m', 'pip', 'freeze', '--all']
                 mock.assert_called_with(
-                    ['pip', 'freeze', '--all'],
+                    expected,
                     cwd=None,
                     runas=None,
                     python_shell=False,
@@ -1117,8 +1149,9 @@ class PipTestCase(TestCase, LoaderModuleMockMixin):
             with patch('salt.modules.pip.version',
                        MagicMock(return_value='6.1.1')):
                 ret = pip.list_(prefix='bb')
+                expected = [sys.executable, '-m', 'pip', 'freeze']
                 mock.assert_called_with(
-                    ['pip', 'freeze'],
+                    expected,
                     cwd=None,
                     runas=None,
                     python_shell=False,
@@ -1143,8 +1176,9 @@ class PipTestCase(TestCase, LoaderModuleMockMixin):
             with patch('salt.modules.pip.version',
                        MagicMock(return_value='1.3')):
                 pip.install(pkg, pre_releases=True)
+                expected = [sys.executable, '-m', 'pip', 'install', pkg]
                 mock.assert_called_with(
-                    ['pip', 'install', pkg],
+                    expected,
                     saltenv='base',
                     runas=None,
                     use_vt=False,
@@ -1156,10 +1190,11 @@ class PipTestCase(TestCase, LoaderModuleMockMixin):
         with patch.dict(pip.__salt__, {'cmd.run': mock_run,
                                        'cmd.run_all': mock_run_all}):
             with patch('salt.modules.pip._get_pip_bin',
-                       MagicMock(return_value='pip')):
+                       MagicMock(return_value=['pip'])):
                 pip.install(pkg, pre_releases=True)
+                expected = ['pip', 'install', '--pre', pkg]
                 mock_run_all.assert_called_with(
-                    ['pip', 'install', '--pre', pkg],
+                    expected,
                     saltenv='base',
                     runas=None,
                     use_vt=False,

--- a/tests/unit/states/test_pip.py
+++ b/tests/unit/states/test_pip.py
@@ -43,211 +43,156 @@ class PipStateTest(TestCase, SaltReturnAssertsMixin, LoaderModuleMockMixin):
     def test_install_requirements_parsing(self):
         mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
         pip_list = MagicMock(return_value={'pep8': '1.3.3'})
-        with patch.dict(pip_state.__salt__, {'cmd.run_all': mock,
-                                             'pip.list': pip_list}):
-            with patch.dict(pip_state.__opts__, {'test': True}):
-                ret = pip_state.installed('pep8=1.3.2')
-                self.assertSaltFalseReturn({'test': ret})
-                self.assertInSaltComment(
-                    'Invalid version specification in package pep8=1.3.2. '
-                    '\'=\' is not supported, use \'==\' instead.',
-                    {'test': ret}
-                )
+        pip_version = MagicMock(return_value='10.0.1')
+        with patch.dict(pip_state.__salt__, {'pip.version': pip_version}):
+            with patch.dict(pip_state.__salt__, {'cmd.run_all': mock,
+                                                 'pip.list': pip_list}):
+                with patch.dict(pip_state.__opts__, {'test': True}):
+                    ret = pip_state.installed('pep8=1.3.2')
+                    self.assertSaltFalseReturn({'test': ret})
+                    self.assertInSaltComment(
+                        'Invalid version specification in package pep8=1.3.2. '
+                        '\'=\' is not supported, use \'==\' instead.',
+                        {'test': ret}
+                    )
 
-        mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
-        pip_list = MagicMock(return_value={'pep8': '1.3.3'})
-        pip_install = MagicMock(return_value={'retcode': 0})
-        with patch.dict(pip_state.__salt__, {'cmd.run_all': mock,
-                                             'pip.list': pip_list,
-                                             'pip.install': pip_install}):
-            with patch.dict(pip_state.__opts__, {'test': True}):
-                ret = pip_state.installed('pep8>=1.3.2')
-                self.assertSaltTrueReturn({'test': ret})
-                self.assertInSaltComment(
-                    'Python package pep8>=1.3.2 was already installed',
-                    {'test': ret}
-                )
+            mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
+            pip_list = MagicMock(return_value={'pep8': '1.3.3'})
+            pip_install = MagicMock(return_value={'retcode': 0})
+            with patch.dict(pip_state.__salt__, {'cmd.run_all': mock,
+                                                 'pip.list': pip_list,
+                                                 'pip.install': pip_install}):
+                with patch.dict(pip_state.__opts__, {'test': True}):
+                    ret = pip_state.installed('pep8>=1.3.2')
+                    self.assertSaltTrueReturn({'test': ret})
+                    self.assertInSaltComment(
+                        'Python package pep8>=1.3.2 was already installed',
+                        {'test': ret}
+                    )
 
-        mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
-        pip_list = MagicMock(return_value={'pep8': '1.3.3'})
-        with patch.dict(pip_state.__salt__, {'cmd.run_all': mock,
-                                             'pip.list': pip_list}):
-            with patch.dict(pip_state.__opts__, {'test': True}):
-                ret = pip_state.installed('pep8<1.3.2')
-                self.assertSaltNoneReturn({'test': ret})
-                self.assertInSaltComment(
-                    'Python package pep8<1.3.2 is set to be installed',
-                    {'test': ret}
-                )
+            mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
+            pip_list = MagicMock(return_value={'pep8': '1.3.3'})
+            with patch.dict(pip_state.__salt__, {'cmd.run_all': mock,
+                                                 'pip.list': pip_list}):
+                with patch.dict(pip_state.__opts__, {'test': True}):
+                    ret = pip_state.installed('pep8<1.3.2')
+                    self.assertSaltNoneReturn({'test': ret})
+                    self.assertInSaltComment(
+                        'Python package pep8<1.3.2 is set to be installed',
+                        {'test': ret}
+                    )
 
-        mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
-        pip_list = MagicMock(return_value={'pep8': '1.3.2'})
-        pip_install = MagicMock(return_value={'retcode': 0})
-        with patch.dict(pip_state.__salt__, {'cmd.run_all': mock,
-                                             'pip.list': pip_list,
-                                             'pip.install': pip_install}):
-            with patch.dict(pip_state.__opts__, {'test': True}):
-                ret = pip_state.installed('pep8>1.3.1,<1.3.3')
-                self.assertSaltTrueReturn({'test': ret})
-                self.assertInSaltComment(
-                    'Python package pep8>1.3.1,<1.3.3 was already installed',
-                    {'test': ret}
-                )
+            mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
+            pip_list = MagicMock(return_value={'pep8': '1.3.2'})
+            pip_install = MagicMock(return_value={'retcode': 0})
+            with patch.dict(pip_state.__salt__, {'cmd.run_all': mock,
+                                                 'pip.list': pip_list,
+                                                 'pip.install': pip_install}):
+                with patch.dict(pip_state.__opts__, {'test': True}):
+                    ret = pip_state.installed('pep8>1.3.1,<1.3.3')
+                    self.assertSaltTrueReturn({'test': ret})
+                    self.assertInSaltComment(
+                        'Python package pep8>1.3.1,<1.3.3 was already installed',
+                        {'test': ret}
+                    )
 
-        mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
-        pip_list = MagicMock(return_value={'pep8': '1.3.1'})
-        pip_install = MagicMock(return_value={'retcode': 0})
-        with patch.dict(pip_state.__salt__, {'cmd.run_all': mock,
-                                             'pip.list': pip_list,
-                                             'pip.install': pip_install}):
-            with patch.dict(pip_state.__opts__, {'test': True}):
-                ret = pip_state.installed('pep8>1.3.1,<1.3.3')
-                self.assertSaltNoneReturn({'test': ret})
-                self.assertInSaltComment(
-                    'Python package pep8>1.3.1,<1.3.3 is set to be installed',
-                    {'test': ret}
-                )
+            mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
+            pip_list = MagicMock(return_value={'pep8': '1.3.1'})
+            pip_install = MagicMock(return_value={'retcode': 0})
+            with patch.dict(pip_state.__salt__, {'cmd.run_all': mock,
+                                                 'pip.list': pip_list,
+                                                 'pip.install': pip_install}):
+                with patch.dict(pip_state.__opts__, {'test': True}):
+                    ret = pip_state.installed('pep8>1.3.1,<1.3.3')
+                    self.assertSaltNoneReturn({'test': ret})
+                    self.assertInSaltComment(
+                        'Python package pep8>1.3.1,<1.3.3 is set to be installed',
+                        {'test': ret}
+                    )
 
-        mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
-        pip_list = MagicMock(return_value={'pep8': '1.3.1'})
-        with patch.dict(pip_state.__salt__, {'cmd.run_all': mock,
-                                             'pip.list': pip_list}):
-            with patch.dict(pip_state.__opts__, {'test': True}):
-                ret = pip_state.installed(
-                    'git+https://github.com/saltstack/salt-testing.git#egg=SaltTesting>=0.5.1'
-                )
-                self.assertSaltNoneReturn({'test': ret})
-                self.assertInSaltComment(
-                    'Python package git+https://github.com/saltstack/'
-                    'salt-testing.git#egg=SaltTesting>=0.5.1 is set to be '
-                    'installed',
-                    {'test': ret}
-                )
+            mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
+            pip_list = MagicMock(return_value={'pep8': '1.3.1'})
+            with patch.dict(pip_state.__salt__, {'cmd.run_all': mock,
+                                                 'pip.list': pip_list}):
+                with patch.dict(pip_state.__opts__, {'test': True}):
+                    ret = pip_state.installed(
+                        'git+https://github.com/saltstack/salt-testing.git#egg=SaltTesting>=0.5.1'
+                    )
+                    self.assertSaltNoneReturn({'test': ret})
+                    self.assertInSaltComment(
+                        'Python package git+https://github.com/saltstack/'
+                        'salt-testing.git#egg=SaltTesting>=0.5.1 is set to be '
+                        'installed',
+                        {'test': ret}
+                    )
 
-        mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
-        pip_list = MagicMock(return_value={'pep8': '1.3.1'})
-        with patch.dict(pip_state.__salt__, {'cmd.run_all': mock,
-                                             'pip.list': pip_list}):
-            with patch.dict(pip_state.__opts__, {'test': True}):
-                ret = pip_state.installed(
-                    'git+https://github.com/saltstack/salt-testing.git#egg=SaltTesting'
-                )
-                self.assertSaltNoneReturn({'test': ret})
-                self.assertInSaltComment(
-                    'Python package git+https://github.com/saltstack/'
-                    'salt-testing.git#egg=SaltTesting is set to be '
-                    'installed',
-                    {'test': ret}
-                )
+            mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
+            pip_list = MagicMock(return_value={'pep8': '1.3.1'})
+            with patch.dict(pip_state.__salt__, {'cmd.run_all': mock,
+                                                 'pip.list': pip_list}):
+                with patch.dict(pip_state.__opts__, {'test': True}):
+                    ret = pip_state.installed(
+                        'git+https://github.com/saltstack/salt-testing.git#egg=SaltTesting'
+                    )
+                    self.assertSaltNoneReturn({'test': ret})
+                    self.assertInSaltComment(
+                        'Python package git+https://github.com/saltstack/'
+                        'salt-testing.git#egg=SaltTesting is set to be '
+                        'installed',
+                        {'test': ret}
+                    )
 
-        mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
-        pip_list = MagicMock(return_value={'pep8': '1.3.1'})
-        with patch.dict(pip_state.__salt__, {'cmd.run_all': mock,
-                                             'pip.list': pip_list}):
-            with patch.dict(pip_state.__opts__, {'test': True}):
+            mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
+            pip_list = MagicMock(return_value={'pep8': '1.3.1'})
+            with patch.dict(pip_state.__salt__, {'cmd.run_all': mock,
+                                                 'pip.list': pip_list}):
+                with patch.dict(pip_state.__opts__, {'test': True}):
+                    ret = pip_state.installed(
+                        'https://pypi.python.org/packages/source/S/SaltTesting/'
+                        'SaltTesting-0.5.0.tar.gz'
+                        '#md5=e6760af92b7165f8be53b5763e40bc24'
+                    )
+                    self.assertSaltNoneReturn({'test': ret})
+                    self.assertInSaltComment(
+                        'Python package https://pypi.python.org/packages/source/'
+                        'S/SaltTesting/SaltTesting-0.5.0.tar.gz'
+                        '#md5=e6760af92b7165f8be53b5763e40bc24 is set to be '
+                        'installed',
+                        {'test': ret}
+                    )
+
+            mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
+            pip_list = MagicMock(return_value={'SaltTesting': '0.5.0'})
+            pip_install = MagicMock(return_value={
+                'retcode': 0,
+                'stderr': '',
+                'stdout': 'Downloading/unpacking https://pypi.python.org/packages'
+                          '/source/S/SaltTesting/SaltTesting-0.5.0.tar.gz\n  '
+                          'Downloading SaltTesting-0.5.0.tar.gz\n  Running '
+                          'setup.py egg_info for package from '
+                          'https://pypi.python.org/packages/source/S/SaltTesting/'
+                          'SaltTesting-0.5.0.tar.gz\n    \nCleaning up...'
+            })
+            with patch.dict(pip_state.__salt__, {'cmd.run_all': mock,
+                                                 'pip.list': pip_list,
+                                                 'pip.install': pip_install}):
                 ret = pip_state.installed(
                     'https://pypi.python.org/packages/source/S/SaltTesting/'
                     'SaltTesting-0.5.0.tar.gz'
                     '#md5=e6760af92b7165f8be53b5763e40bc24'
                 )
-                self.assertSaltNoneReturn({'test': ret})
-                self.assertInSaltComment(
-                    'Python package https://pypi.python.org/packages/source/'
-                    'S/SaltTesting/SaltTesting-0.5.0.tar.gz'
-                    '#md5=e6760af92b7165f8be53b5763e40bc24 is set to be '
-                    'installed',
+                self.assertSaltTrueReturn({'test': ret})
+                self.assertInSaltComment('All packages were successfully installed',
                     {'test': ret}
                 )
-
-        mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
-        pip_list = MagicMock(return_value={'SaltTesting': '0.5.0'})
-        pip_install = MagicMock(return_value={
-            'retcode': 0,
-            'stderr': '',
-            'stdout': 'Downloading/unpacking https://pypi.python.org/packages'
-                      '/source/S/SaltTesting/SaltTesting-0.5.0.tar.gz\n  '
-                      'Downloading SaltTesting-0.5.0.tar.gz\n  Running '
-                      'setup.py egg_info for package from '
-                      'https://pypi.python.org/packages/source/S/SaltTesting/'
-                      'SaltTesting-0.5.0.tar.gz\n    \nCleaning up...'
-        })
-        with patch.dict(pip_state.__salt__, {'cmd.run_all': mock,
-                                             'pip.list': pip_list,
-                                             'pip.install': pip_install}):
-            ret = pip_state.installed(
-                'https://pypi.python.org/packages/source/S/SaltTesting/'
-                'SaltTesting-0.5.0.tar.gz'
-                '#md5=e6760af92b7165f8be53b5763e40bc24'
-            )
-            self.assertSaltTrueReturn({'test': ret})
-            self.assertInSaltComment('All packages were successfully installed',
-                {'test': ret}
-            )
-            self.assertInSaltReturn(
-                'Installed',
-                {'test': ret},
-                ('changes', 'https://pypi.python.org/packages/source/S/'
-                            'SaltTesting/SaltTesting-0.5.0.tar.gz'
-                            '#md5=e6760af92b7165f8be53b5763e40bc24==???')
-            )
-
-        mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
-        pip_list = MagicMock(return_value={'SaltTesting': '0.5.0'})
-        pip_install = MagicMock(return_value={
-            'retcode': 0,
-            'stderr': '',
-            'stdout': 'Cloned!'
-        })
-        with patch.dict(pip_state.__salt__, {'cmd.run_all': mock,
-                                             'pip.list': pip_list,
-                                             'pip.install': pip_install}):
-            with patch.dict(pip_state.__opts__, {'test': False}):
-                ret = pip_state.installed(
-                    'git+https://github.com/saltstack/salt-testing.git#egg=SaltTesting'
-                )
-                self.assertSaltTrueReturn({'test': ret})
-                self.assertInSaltComment(
-                    'packages are already installed',
-                    {'test': ret}
+                self.assertInSaltReturn(
+                    'Installed',
+                    {'test': ret},
+                    ('changes', 'https://pypi.python.org/packages/source/S/'
+                                'SaltTesting/SaltTesting-0.5.0.tar.gz'
+                                '#md5=e6760af92b7165f8be53b5763e40bc24==???')
                 )
 
-        mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
-        pip_list = MagicMock(return_value={'pep8': '1.3.1'})
-        pip_install = MagicMock(return_value={'retcode': 0})
-        with patch.dict(pip_state.__salt__, {'cmd.run_all': mock,
-                                             'pip.list': pip_list,
-                                             'pip.install': pip_install}):
-            with patch.dict(pip_state.__opts__, {'test': False}):
-                ret = pip_state.installed(
-                    'arbitrary ID that should be ignored due to requirements specified',
-                    requirements='/tmp/non-existing-requirements.txt'
-                )
-                self.assertSaltTrueReturn({'test': ret})
-
-        # Test VCS installations using git+git://
-        mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
-        pip_list = MagicMock(return_value={'SaltTesting': '0.5.0'})
-        pip_install = MagicMock(return_value={
-            'retcode': 0,
-            'stderr': '',
-            'stdout': 'Cloned!'
-        })
-        with patch.dict(pip_state.__salt__, {'cmd.run_all': mock,
-                                             'pip.list': pip_list,
-                                             'pip.install': pip_install}):
-            with patch.dict(pip_state.__opts__, {'test': False}):
-                ret = pip_state.installed(
-                    'git+git://github.com/saltstack/salt-testing.git#egg=SaltTesting'
-                )
-                self.assertSaltTrueReturn({'test': ret})
-                self.assertInSaltComment(
-                    'packages are already installed',
-                    {'test': ret}
-                )
-
-        # Test VCS installations with version info like >= 0.1
-        with patch.object(pip, '__version__', MagicMock(side_effect=AttributeError(
-                                                    'Faked missing __version__ attribute'))):
             mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
             pip_list = MagicMock(return_value={'SaltTesting': '0.5.0'})
             pip_install = MagicMock(return_value={
@@ -260,13 +205,70 @@ class PipStateTest(TestCase, SaltReturnAssertsMixin, LoaderModuleMockMixin):
                                                  'pip.install': pip_install}):
                 with patch.dict(pip_state.__opts__, {'test': False}):
                     ret = pip_state.installed(
-                        'git+https://github.com/saltstack/salt-testing.git#egg=SaltTesting>=0.5.0'
+                        'git+https://github.com/saltstack/salt-testing.git#egg=SaltTesting'
                     )
                     self.assertSaltTrueReturn({'test': ret})
                     self.assertInSaltComment(
                         'packages are already installed',
                         {'test': ret}
                     )
+
+            mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
+            pip_list = MagicMock(return_value={'pep8': '1.3.1'})
+            pip_install = MagicMock(return_value={'retcode': 0})
+            with patch.dict(pip_state.__salt__, {'cmd.run_all': mock,
+                                                 'pip.list': pip_list,
+                                                 'pip.install': pip_install}):
+                with patch.dict(pip_state.__opts__, {'test': False}):
+                    ret = pip_state.installed(
+                        'arbitrary ID that should be ignored due to requirements specified',
+                        requirements='/tmp/non-existing-requirements.txt'
+                    )
+                    self.assertSaltTrueReturn({'test': ret})
+
+            # Test VCS installations using git+git://
+            mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
+            pip_list = MagicMock(return_value={'SaltTesting': '0.5.0'})
+            pip_install = MagicMock(return_value={
+                'retcode': 0,
+                'stderr': '',
+                'stdout': 'Cloned!'
+            })
+            with patch.dict(pip_state.__salt__, {'cmd.run_all': mock,
+                                                 'pip.list': pip_list,
+                                                 'pip.install': pip_install}):
+                with patch.dict(pip_state.__opts__, {'test': False}):
+                    ret = pip_state.installed(
+                        'git+git://github.com/saltstack/salt-testing.git#egg=SaltTesting'
+                    )
+                    self.assertSaltTrueReturn({'test': ret})
+                    self.assertInSaltComment(
+                        'packages are already installed',
+                        {'test': ret}
+                    )
+
+            # Test VCS installations with version info like >= 0.1
+            with patch.object(pip, '__version__', MagicMock(side_effect=AttributeError(
+                                                        'Faked missing __version__ attribute'))):
+                mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
+                pip_list = MagicMock(return_value={'SaltTesting': '0.5.0'})
+                pip_install = MagicMock(return_value={
+                    'retcode': 0,
+                    'stderr': '',
+                    'stdout': 'Cloned!'
+                })
+                with patch.dict(pip_state.__salt__, {'cmd.run_all': mock,
+                                                     'pip.list': pip_list,
+                                                     'pip.install': pip_install}):
+                    with patch.dict(pip_state.__opts__, {'test': False}):
+                        ret = pip_state.installed(
+                            'git+https://github.com/saltstack/salt-testing.git#egg=SaltTesting>=0.5.0'
+                        )
+                        self.assertSaltTrueReturn({'test': ret})
+                        self.assertInSaltComment(
+                            'packages are already installed',
+                            {'test': ret}
+                        )
 
     def test_install_in_editable_mode(self):
         '''
@@ -281,9 +283,11 @@ class PipStateTest(TestCase, SaltReturnAssertsMixin, LoaderModuleMockMixin):
             'stderr': '',
             'stdout': 'Cloned!'
         })
+        pip_version = MagicMock(return_value='10.0.1')
         with patch.dict(pip_state.__salt__, {'cmd.run_all': mock,
                                              'pip.list': pip_list,
-                                             'pip.install': pip_install}):
+                                             'pip.install': pip_install,
+                                             'pip.version': pip_version}):
             ret = pip_state.installed('state@name',
                                       cwd='/path/to/project',
                                       editable=['.'])

--- a/tests/unit/states/test_pip.py
+++ b/tests/unit/states/test_pip.py
@@ -17,6 +17,7 @@ from tests.support.mock import NO_MOCK, NO_MOCK_REASON, MagicMock, patch
 
 # Import salt libs
 import salt.states.pip_state as pip_state
+import salt.utils
 
 # Import 3rd-party libs
 try:
@@ -43,18 +44,25 @@ class PipStateTest(TestCase, SaltReturnAssertsMixin, LoaderModuleMockMixin):
     def test_install_requirements_parsing(self):
         mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
         pip_list = MagicMock(return_value={'pep8': '1.3.3'})
-        pip_version = MagicMock(return_value='10.0.1')
-        with patch.dict(pip_state.__salt__, {'pip.version': pip_version}):
+        pip_version = pip.__version__
+        mock_pip_version = MagicMock(return_value=pip_version)
+        with patch.dict(pip_state.__salt__, {'pip.version': mock_pip_version}):
             with patch.dict(pip_state.__salt__, {'cmd.run_all': mock,
                                                  'pip.list': pip_list}):
                 with patch.dict(pip_state.__opts__, {'test': True}):
-                    ret = pip_state.installed('pep8=1.3.2')
-                    self.assertSaltFalseReturn({'test': ret})
-                    self.assertInSaltComment(
-                        'Invalid version specification in package pep8=1.3.2. '
-                        '\'=\' is not supported, use \'==\' instead.',
-                        {'test': ret}
-                    )
+                    if salt.utils.compare_versions(ver1=pip_version,
+                                                   oper='<',
+                                                   ver2='10.0'):
+                        ret = pip_state.installed('pep8=1.3.2')
+                        self.assertSaltFalseReturn({'test': ret})
+                        self.assertInSaltComment(
+                            'Invalid version specification in package pep8=1.3.2. '
+                            '\'=\' is not supported, use \'==\' instead.',
+                            {'test': ret})
+                    else:
+                        self.assertRaises(
+                            pip._internal.exceptions.InstallationError,
+                            pip_state.installed, 'pep=1.3.2')
 
             mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
             pip_list = MagicMock(return_value={'pep8': '1.3.3'})

--- a/tests/whitelist.txt
+++ b/tests/whitelist.txt
@@ -18,6 +18,7 @@ integration.modules.test_mine
 integration.modules.test_network
 integration.modules.test_ntp
 integration.modules.test_pillar
+integration.modules.test_pip
 integration.modules.test_pkg
 integration.modules.test_publish
 integration.modules.test_state
@@ -34,6 +35,7 @@ integration.runners.test_jobs
 integration.runners.test_salt
 integration.sdb.test_env
 integration.states.test_host
+integration.states.test_pip
 integration.states.test_renderers
 integration.utils.testprogram
 integration.wheel.test_client


### PR DESCRIPTION
### What does this PR do?
The pip module has been basically broken since pip 8.1.2 due to how pip has changed the output of some functions. It has also been problematic in Windows since `c:\salt\bin` and `c:\salt\bin\Scripts` are not a part of the search path. Therefore you always had to pass the full path to the pip binary.

This PR does many things:
1. Defaults to the pip for the running python if `bin_env` is not passed. Uses `python -m pip`
2. Defaults to the cwd for the running python if `cwd` is not passed on Windows
3. Uses a list to build commands throughout
4. Fixes a problem with parsing lines that have `#egg=` in them in the `pip.list` function
5. Fixes issues where `pip --version` was being called many times
6. Fixes an issue in `pip.list_upgrades` where the output format has changed since version pip 8.0.0.
7. Also adds support for the `--format json` option available in pip 9.0.0 so we don't have to parse stdout
8. Skips `salt` in `pip.upgrade` function on Windows as it will fail to update itself

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/47024
https://github.com/saltstack/salt/issues/47146

### Tests written?
No

### Commits signed with GPG?
Yes