### PR TITLE
Fix #46918: add the TTL field

### DIFF
--- a/salt/modules/capirca_acl.py
+++ b/salt/modules/capirca_acl.py
@@ -132,7 +132,8 @@ _TERM_FIELDS = {
     'flattened_addr': None,
     'flattened_saddr': None,
     'flattened_daddr': None,
-    'priority': None
+    'priority': None,
+    'ttl': None
 }
 
 # IP-type fields


### PR DESCRIPTION
### What does this PR do?

Fix #46918: add the TTL field (introduced in a newer version of Capirca)