### PR TITLE
Fix pip_state with pip3 if no changes occourred

### DIFF
--- a/salt/states/pip_state.py
+++ b/salt/states/pip_state.py
@@ -725,6 +725,13 @@ def installed(name,
                 ret['comment'] = out['comment']
                 return ret
 
+        if not target_pkgs:
+            ret['result'] = True
+            aicomms = '\n'.join(already_installed_comments)
+            last_line = 'All specified packages are already installed' + (' and up-to-date' if upgrade else '')
+            ret['comment'] = aicomms + ('\n' if aicomms else '') + last_line
+            return ret
+
     # Construct the string that will get passed to the install call
     pkgs_str = ','.join([state_name for _, state_name in target_pkgs])
 
@@ -777,9 +784,7 @@ def installed(name,
     # Check the retcode for success, but don't fail if using pip1 and the package is
     # already present. Pip1 returns a retcode of 1 (instead of 0 for pip2) if you run
     # "pip install" without any arguments. See issue #21845.
-    if pip_install_call and \
-            (pip_install_call.get('retcode', 1) == 0 or pip_install_call.get('stdout', '').startswith(
-                'You must give at least one requirement to install')):
+    if pip_install_call and pip_install_call.get('retcode', 1) == 0:
         ret['result'] = True
 
         if requirements or editable:
@@ -787,6 +792,8 @@ def installed(name,
             if requirements:
                 PIP_REQUIREMENTS_NOCHANGE = [
                     'Requirement already satisfied',
+                    'Requirement already up-to-date',
+                    'Requirement not upgraded',
                     'Collecting',
                     'Cloning',
                     'Cleaning up...',

--- a/tests/integration/modules/test_state.py
+++ b/tests/integration/modules/test_state.py
@@ -884,13 +884,13 @@ class StateModuleTest(ModuleCase, SaltReturnAssertsMixin):
             'pip_|-another_non_changing_state_|-mock_|-installed': {
                 '__run_num__': 3,
                 'changes': False,
-                'comment': 'Python package mock was already installed\nAll packages were successfully installed',
+                'comment': 'Python package mock was already installed\nAll specified packages are already installed',
                 'result': True
             },
             'pip_|-non_changing_state_|-mock_|-installed': {
                 '__run_num__': 2,
                 'changes': False,
-                'comment': 'Python package mock was already installed\nAll packages were successfully installed',
+                'comment': 'Python package mock was already installed\nAll specified packages are already installed',
                 'result': True
             }
         }

--- a/tests/integration/states/test_pip.py
+++ b/tests/integration/states/test_pip.py
@@ -592,7 +592,7 @@ class PipStateTest(ModuleCase, SaltReturnAssertsMixin):
                 self.assertEqual(
                     ret[key]['comment'],
                     ('Python package carbon < 1.3 was already installed\n'
-                     'All packages were successfully installed'))
+                     'All specified packages are already installed'))
                 break
             else:
                 raise Exception('Expected state did not run')

--- a/tests/unit/states/test_pip.py
+++ b/tests/unit/states/test_pip.py
@@ -207,7 +207,7 @@ class PipStateTest(TestCase, SaltReturnAssertsMixin, LoaderModuleMockMixin):
                 )
                 self.assertSaltTrueReturn({'test': ret})
                 self.assertInSaltComment(
-                    'successfully installed',
+                    'packages are already installed',
                     {'test': ret}
                 )
 
@@ -241,7 +241,7 @@ class PipStateTest(TestCase, SaltReturnAssertsMixin, LoaderModuleMockMixin):
                 )
                 self.assertSaltTrueReturn({'test': ret})
                 self.assertInSaltComment(
-                    'were successfully installed',
+                    'packages are already installed',
                     {'test': ret}
                 )
 
@@ -264,7 +264,7 @@ class PipStateTest(TestCase, SaltReturnAssertsMixin, LoaderModuleMockMixin):
                     )
                     self.assertSaltTrueReturn({'test': ret})
                     self.assertInSaltComment(
-                        'were successfully installed',
+                        'packages are already installed',
                         {'test': ret}
                     )
 
@@ -289,6 +289,6 @@ class PipStateTest(TestCase, SaltReturnAssertsMixin, LoaderModuleMockMixin):
                                       editable=['.'])
             self.assertSaltTrueReturn({'test': ret})
             self.assertInSaltComment(
-                'successfully installed',
+                'packages are already installed',
                 {'test': ret}
             )


### PR DESCRIPTION
### What does this PR do?
This fixes the behavior of `states.pip.installed` when used with `pip3` (via `bin_env`) in the case that no changes occurred (all packages are already installed and up-to-date).

### Previous Behavior
If packages specified via the `name` parameter were already installed the function returned with an error because in this case `salt` tells `pip` to install no packages which produces an error. For older versions of `pip` that error was caught via a `startswith()`-call on `stdout`. This fails when using `pip3` because it now outputs the error on `stderr` and adds an additional `ERROR`-prefix.

If packages were instead specified via a `requirements`-file salt always reported that something changed because `pip3` uses a slightly different wording to indicate that a package wasn't changed.

### New Behavior
If no package needs to be installed the function returns without calling `pip install` and reports that all packages are installed (and up-to-date, if `upgrade` was specified).

### Commits signed with GPG?

Yes

Also does this count as a bugfix and needs to go into a different branch? If so just tell me into which branch I should merge.