### PR TITLE
Fix for AWS EC2 Rate Limit Failures in salt-cloud

### DIFF
--- a/salt/utils/aws.py
+++ b/salt/utils/aws.py
@@ -20,6 +20,7 @@ import hmac
 import logging
 import salt.config
 import re
+import random
 from salt.ext import six
 
 # Import Salt libs
@@ -442,8 +443,9 @@ def query(params=None, setname=None, requesturl=None, location=None,
         )
         headers = {}
 
-    attempts = 5
-    while attempts > 0:
+    MAX_RETRIES = 6
+    attempts = 0
+    while attempts < MAX_RETRIES:
         log.debug('AWS Request: %s', requesturl)
         log.trace('AWS Request Parameters: %s', params_with_headers)
         try:
@@ -461,15 +463,23 @@ def query(params=None, setname=None, requesturl=None, location=None,
 
             # check to see if we should retry the query
             err_code = data.get('Errors', {}).get('Error', {}).get('Code', '')
-            if attempts > 0 and err_code and err_code in AWS_RETRY_CODES:
-                attempts -= 1
+            if attempts < MAX_RETRIES and err_code and err_code in AWS_RETRY_CODES:
+                attempts += 1
                 log.error(
                     'AWS Response Status Code and Error: [%s %s] %s; '
                     'Attempts remaining: %s',
                     exc.response.status_code, exc, data, attempts
                 )
-                # Wait a bit before continuing to prevent throttling
-                time.sleep(2)
+                # backoff an exponential amount of time to throttle requests
+                # during "API Rate Exceeded" failures as suggested by the AWS documentation here:
+                # https://docs.aws.amazon.com/AWSEC2/latest/APIReference/query-api-troubleshooting.html
+                # and also here:
+                # https://docs.aws.amazon.com/general/latest/gr/api-retries.html
+                # Failure to implement this approach results in a failure rate of >30% when using salt-cloud with
+                # "--parallel" when creating 50 or more instances with a fixed delay of 2 seconds.
+                # A failure rate of >10% is observed when using the salt-api with an asyncronous client
+                # specified (runner_async).
+                time.sleep(random.uniform(1, 2**attempts))
                 continue
 
             log.error(


### PR DESCRIPTION
### What does this PR do?
Implements these fixes to "rate limit failures" suggested by AWS referenced **here:**

https://docs.aws.amazon.com/AWSEC2/latest/APIReference/query-api-troubleshooting.html (scan down to "Calculating the sleep interval")

**also:**
https://docs.aws.amazon.com/general/latest/gr/api-retries.html

**and also for the really nerdy:**
https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter

### What issues does this PR fix or reference?
Experiencing sporadic failures while deploying large (~50 node clusters) in Amazon EC2 when using
salt-cloud libraries in parallel (asynchronously).
This behavior has been demonstrated to occur to a greater or lesser degree with these salt-cloud APIs:
- salt-api,
- salt-runner,
- salt-cloud (using map files and "--parallel" option)


### Previous Behavior
Starting a cluster of 50 VMs in rapid succession using salt-cloud or salt-api
will experience sporadic failures with the following EC2 error:

```
[ERROR   ] AWS Response Status Code and Error: [503 503 Server Error: Service Unavailable for url: https://ec2.us-west-1.amazonaws.com/?Action=RunInstances&ImageId=ami-02d0d962&InstanceType=t2.micro&KeyName=edlane&MaxCount=1&MinCount=1&NetworkInterface.0.AssociatePublicIpAddress=true&NetworkInterface.0.DeleteOnTermination=true&NetworkInterface.0.DeviceIndex=0&NetworkInterface.0.SubnetId=subnet-36e8e570&Version=2014-10-01] {'Errors': {'Error': {'Message': 'Request limit exceeded.', 'Code': 'RequestLimitExceeded'}}, 'RequestID': 'e70bd27a-f596-464e-ac42-321a810aa4fb'}; Attempts remaining: 0
```

Of 50 instances  started by:

- salt-cloud "--parallel" only 36/50 were successful
- salt-api-client "async" 47/50 were successful
- salt-runner-client "async" 40/50 were successful


Code snippet to create 50 VMs using the salt-api with this python code snippet:

```
for i in xrange(50):
    utime = str(int(time.time()*100000))
    instance_name = "ed-deletemenow-{}-{}".format(i, utime)
    resp = session.post('http://localhost:8000',
                        json=[{
                            'client': 'runner_async',
                            'fun': 'cloud.profile',
                            'kwarg': {'prof': 'ec2-suse',
                                      'instances': [instance_name]},
                            'timeout': 60,
                        }])
```

These instances in EC2 were successfully started:
```
> Instances:
> i-00050429381246a66 (ed-deletemenow-49-152305508833218)
> i-0ed479f7b2bb6a930 (ed-deletemenow-48-152305508789902)
> i-0786d7a383f738dfd (ed-deletemenow-47-152305508762035)
> i-0e66618666b6d9b52 (ed-deletemenow-46-152305508719381)
> i-077c26e7d8641d6f2 (ed-deletemenow-45-152305508690150)
> i-03e6af6fc11605776 (ed-deletemenow-44-152305508668648)
> i-0ed92206f0cc040e7 (ed-deletemenow-43-152305508640317)
> i-0c296873bccc8d776 (ed-deletemenow-42-152305508612510)
> i-03e91e795deb71404 (ed-deletemenow-41-152305508579093)
> i-07e727cf677382022 (ed-deletemenow-40-152305508555978)
> i-05807192be7fe25af (ed-deletemenow-39-152305508530497)
> i-010ca9a0e7be12320 (ed-deletemenow-38-152305508507573)
> i-02a14682e0ffdeceb (ed-deletemenow-37-152305508485284)
> i-08f37c064b96000f0 (ed-deletemenow-36-152305508462995)
> i-0ea724b7f1a5ada47 (ed-deletemenow-35-152305508440455)
> i-058a80cd4745508b5 (ed-deletemenow-34-152305508387215)
> i-04b8e9def937804c9 (ed-deletemenow-33-152305508358606)
> i-048ac5ecd1cfc982e (ed-deletemenow-32-152305508337390)
> i-084635764db12182b (ed-deletemenow-31-152305508317540)
> 
> i-03109ca145e0ff5af (ed-deletemenow-29-152305508277783)
> i-09e6181bb8c767fa1 (ed-deletemenow-28-152305508259215)
> i-01d066da36edd3c0b (ed-deletemenow-27-152305508238342)
> i-09d89ed7d42062f35 (ed-deletemenow-26-152305508221588)
> i-0aca852b527e27bb0 (ed-deletemenow-25-152305508204830)
> 
> i-06daf815108b4acbd (ed-deletemenow-23-152305508170091)
> i-0cd2afad71acdcf98 (ed-deletemenow-22-152305508152775)
> i-089017ef47f0bc996 (ed-deletemenow-21-152305508134055)
> i-0f6cc49b096a44d31 (ed-deletemenow-20-152305508117903)
> i-0b18823ea90539e3c (ed-deletemenow-19-152305508103250)
> i-09b5285ee0620830a (ed-deletemenow-18-152305508086661)
> i-0d90fc0c759ebf2b1 (ed-deletemenow-17-152305508073287)
> i-0a04cfc379461d271 (ed-deletemenow-16-152305508064550)
> i-02e18fe316df8c870 (ed-deletemenow-15-152305508054187)
> 
> i-0b682e0fe3963fbe9 (ed-deletemenow-13-152305508031121)
> i-0cb53485132e2a113 (ed-deletemenow-12-152305508024421)
> i-0624086b52e60d17e (ed-deletemenow-11-152305508015505)
> i-0e1d439d6a0da21fb (ed-deletemenow-10-152305508009005)
> i-0372f9b0116f8a125 (ed-deletemenow-9-152305508002291)
> i-072bfa87e927e9313 (ed-deletemenow-8-152305507996648)
> i-08faa9e88cf439c1c (ed-deletemenow-7-152305507989781)
> i-0cd1b8f46a0ba696d (ed-deletemenow-6-152305507983082)
> i-0f5ea0ad4edbc11ac (ed-deletemenow-5-152305507975926)
> i-0086a911a3e6d0e18 (ed-deletemenow-4-152305507968669)
> i-0309c2b5ab9d6f2eb (ed-deletemenow-3-152305507601968)
> i-0ecf8db9658730390 (ed-deletemenow-2-152305507522503)
> i-0daa92a1d34f32f5c (ed-deletemenow-1-152305507427559)
> i-0bc163e976f58903d (ed-deletemenow-0-152305506711397)
```

missing from this list are these 3 instances:
```
> ed-deletemenow-14-xxxxxxxxxxxxxxx
> ed-deletemenow-24-xxxxxxxxxxxxxxx
> ed-deletemenow-30-xxxxxxxxxxxxxxx
```

Essentially you get back a job id that can be queried from salt like this:
```
{u'return': [{u'jid': u'20180406165113116898', u'tag': u'salt/run/20180406165113116898'}]} 
```
A query of this example shows this result:
```
> Arguments:
> Function:
>     runner.cloud.profile
> Result:
>     ----------
>     suse-ed_master:
>         ----------
>         return:
>             ----------
>             _stamp:
>                 2018-04-06T22:51:22.010763
>             fun:
>                 runner.cloud.profile
>             fun_args:
>                 |_
>                 |
>                   ---------
>                   instances:
>                       - ed-deletemenow-14-152305508043994
>                   prof:
>                       ec2-suse
>                   timeout:
>                       60
>             jid:
>                 20180406165120517710
>             return:
>                 Exception occurred in runner cloud.profile: Traceback (most recent call last):
>                   File
>                   "/usr/lib/python2.7/site-packages/salt/client/mixins.py",
>                   line 387, in _low>                   
>                     data['return'] = self.functions[fun](*args, **kwargs)
>                   File
>                   "/usr/lib/python2.7/site-packages/salt/runners/cloud.py",
>                   line 114, in profile>                   
>                     info = client.profile(prof, instances,
>                     **salt.utils.args.clean_kwargs(**kwargs))>                   
>                   File
>                   "/usr/lib/python2.7/site-packages/salt/cloud/__init__.py"
>                   , line 354, in profile>                   
>                     mapper.run_profile(profile, names,
>                     vm_overrides=vm_overrides)
>                   File
>                   "/usr/lib/python2.7/site-packages/salt/cloud/__init__.py"
>                   , line 1458, in run_profile>                   
>                     raise SaltCloudSystemExit('Failed to deploy VM')
>                 SaltCloudSystemExit: Failed to deploy VM
>             success:
>                 False
>             user:
>                 salt-test-user
> StartTime:
>     2018, Apr 06 16:51:20.517710
> Target:
>     suse-ed_maste
> Target-type:
>     list
> User:
>     salt-test-user
> jid:
>     20180406165120517710
```

### New Behavior

No observed failures 

### Tests written?

Yes (see attached code)


[salt-cloud-runner-rate-limit-test.py.txt](https://github.com/saltstack/salt/files/1932998/salt-cloud-runner-rate-limit-test.py.txt)

### Salt Versions:
```
suse-ed:/home/lane/develop/salt # salt --versions
Salt Version:
           Salt: 2018.3.0
 
Dependency Versions:
           cffi: 1.11.5
       cherrypy: 3.2.2
       dateutil: 2.6.1
      docker-py: 3.1.4
          gitdb: Not Installed
      gitpython: Not Installed
          ioflo: Not Installed
         Jinja2: 2.10
        libgit2: Not Installed
        libnacl: 1.6.1
       M2Crypto: 0.29.0
           Mako: Not Installed
   msgpack-pure: Not Installed
 msgpack-python: 0.5.6
   mysql-python: Not Installed
      pycparser: 2.17
       pycrypto: 2.6.1
   pycryptodome: Not Installed
         pygit2: Not Installed
         Python: 2.7.14 (default, Oct 12 2017, 15:50:02) [GCC]
   python-gnupg: Not Installed
         PyYAML: 3.12
          PyZMQ: 14.7.0
           RAET: Not Installed
          smmap: Not Installed
        timelib: Not Installed
        Tornado: 4.2.1
            ZMQ: 4.2.5
 
System Versions:
           dist:   
         locale: UTF-8
        machine: x86_64
        release: 4.16.1-1-default
         system: Linux
        version: Not Installed
```
