### PR TITLE
Fix coverage on py3 windows builds

### DIFF
--- a/tests/support/parser/cover.py
+++ b/tests/support/parser/cover.py
@@ -175,7 +175,7 @@ class SaltCoverageTestingParser(SaltTestingParser):
             # Update environ so that any subprocess started on tests are also
             # included in the report
             coverage_options['data_suffix'] = True
-            os.environ['COVERAGE_PROCESS_START'] = '1'
+            os.environ['COVERAGE_PROCESS_START'] = ''
             os.environ['COVERAGE_OPTIONS'] = json.dumps(coverage_options)
 
         # Setup coverage


### PR DESCRIPTION
Setting a value for will cause coverage to look for a config file
named '1' and in-turn raises an Exception. Based on the docs, if the
environment variable exists coverage is enabled. Just defined the
environment variable instead of giving it a value.

### What does this PR do?

Fixes windows py3 builds with coverage enabled

### Previous Behavior

Test runner stops with unhandled Exception due to missing config file.

### New Behavior

Test run with coverage and multiprocessing support as expected.

### Tests written?

No - Fixes existing tests.

### Commits signed with GPG?

Yes