### PR TITLE
Remove installation of pywin32 from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -149,12 +149,6 @@ def _parse_requirements_file(requirements_file):
                     # In Windows, we're installing M2CryptoWin{32,64} which comes
                     # compiled
                     continue
-                if 'pywin32' in line.lower():
-                    # In Windows, we're installing PyWin32 from a whl file
-                    continue
-                if 'pypiwin32' in line.lower():
-                    # In Windows, we're installing PyWin32 from a whl file
-                    continue
             if IS_PY3 and 'futures' in line.lower():
                 # Python 3 already has futures, installing it will only break
                 # the current python installation whenever futures is imported
@@ -324,11 +318,6 @@ if WITH_SETUPTOOLS:
                     self.run_command('install-m2crypto-windows')
                     self.distribution.salt_installing_m2crypto_windows = None
 
-                # Install PyWin32
-                self.distribution.salt_installing_pywin32_windows = True
-                self.run_command('install-pywin32-windows')
-                self.distribution.salt_installing_pywin32_windows = None
-
                 # Download the required DLLs
                 self.distribution.salt_download_windows_dlls = True
                 self.run_command('download-windows-dlls')
@@ -345,56 +334,6 @@ if WITH_SETUPTOOLS:
 
             # Resume normal execution
             develop.run(self)
-
-
-class InstallPyWin32Wheel(Command):
-
-    description = 'Install PyWin32 on Windows'
-
-    def initialize_options(self):
-        pass
-
-    def finalize_options(self):
-        pass
-
-    def run(self):
-        if getattr(self.distribution, 'salt_installing_pywin32_windows', None) is None:
-            print('This command is not meant to be called on it\'s own')
-            exit(1)
-        import platform
-        # Detect if already installed, any version will work
-        from pip.utils import get_installed_version
-        if get_installed_version('pywin32') is not None:
-            print('PyWin32 already installed')
-            return
-        if get_installed_version('pypiwin32') is not None:
-            print('PyWin32 already installed')
-            return
-        # Install PyWin32 from Salt repo
-        from pip.utils import call_subprocess
-        from pip.utils.logging import indent_log
-        platform_bits, _ = platform.architecture()
-        call_arguments = ['pip', 'install', 'wheel']
-        if platform_bits == '64bit':
-            if IS_PY3:
-                call_arguments.append(
-                    'https://repo.saltstack.com/windows/dependencies/64/pywin32-221-cp35-cp35m-win_amd64.whl'
-                )
-            else:
-                call_arguments.append(
-                    'https://repo.saltstack.com/windows/dependencies/64/pywin32-221-cp27-cp27m-win_amd64.whl'
-                )
-        else:
-            if IS_PY3:
-                call_arguments.append(
-                    'https://repo.saltstack.com/windows/dependencies/32/pywin32-221-cp35-cp35m-win32.whl'
-                )
-            else:
-                call_arguments.append(
-                    'https://repo.saltstack.com/windows/dependencies/32/pywin32-221-cp27-cp27m-win32.whl'
-                )
-        with indent_log():
-            call_subprocess(call_arguments)
 
 
 class InstallM2CryptoWindows(Command):


### PR DESCRIPTION
### What does this PR do?
Remove the installation of PyWin32 from `setup.py`. It's a part of the `req.txt` file and needs no additionaly handling in `setup.py`.

This keeps regressing for some reason. This is the 3rd time I've had to fix this... I believe

### Tests written?
No

### Commits signed with GPG?
Yes