### PR TITLE
[2018.3] Fixing a backward compatibility issue with vault module & runner

### DIFF
--- a/salt/utils/vault.py
+++ b/salt/utils/vault.py
@@ -87,7 +87,7 @@ def _get_token_and_url_from_master():
     return {
             'url': result['url'],
             'token': result['token'],
-            'verify': result['verify'],
+            'verify': result.get('verify', None),
            }
 
 


### PR DESCRIPTION
### What does this PR do?
When using the vault module on a 2018.3 minion against a 2017.7 maste, the 2018.3 minion is expecting a verify element in the results from the Salt runner on the master.  The runner in 2017.7 did not include a verify element, which results in an error.  This change accounts for this by using the default in 2018.3 which is not to verify if not configured.

### What issues does this PR fix or reference?
N/A

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
