### PR TITLE
Fix pip.installed when no changes occurred with pip >= 1.0.0

### DIFF
--- a/tests/integration/states/test_pip.py
+++ b/tests/integration/states/test_pip.py
@@ -590,7 +590,7 @@ class PipStateTest(ModuleCase, SaltReturnAssertsMixin):
                 self.assertEqual(
                     ret[key]['comment'],
                     ('Python package carbon < 1.3 was already installed\n'
-                     'All packages were successfully installed'))
+                     'All specified packages are already installed'))
                 break
             else:
                 raise Exception('Expected state did not run')

--- a/tests/unit/states/test_pip.py
+++ b/tests/unit/states/test_pip.py
@@ -289,6 +289,6 @@ class PipStateTest(TestCase, SaltReturnAssertsMixin, LoaderModuleMockMixin):
                                       editable=['.'])
             self.assertSaltTrueReturn({'test': ret})
             self.assertInSaltComment(
-                'packages are already installed',
+                'successfully installed',
                 {'test': ret}
             )

--- a/tests/unit/states/test_pip.py
+++ b/tests/unit/states/test_pip.py
@@ -207,7 +207,7 @@ class PipStateTest(TestCase, SaltReturnAssertsMixin, LoaderModuleMockMixin):
                 )
                 self.assertSaltTrueReturn({'test': ret})
                 self.assertInSaltComment(
-                    'successfully installed',
+                    'packages are already installed',
                     {'test': ret}
                 )
 
@@ -241,7 +241,7 @@ class PipStateTest(TestCase, SaltReturnAssertsMixin, LoaderModuleMockMixin):
                 )
                 self.assertSaltTrueReturn({'test': ret})
                 self.assertInSaltComment(
-                    'were successfully installed',
+                    'packages are already installed',
                     {'test': ret}
                 )
 
@@ -264,7 +264,7 @@ class PipStateTest(TestCase, SaltReturnAssertsMixin, LoaderModuleMockMixin):
                     )
                     self.assertSaltTrueReturn({'test': ret})
                     self.assertInSaltComment(
-                        'were successfully installed',
+                        'packages are already installed',
                         {'test': ret}
                     )
 
@@ -289,6 +289,6 @@ class PipStateTest(TestCase, SaltReturnAssertsMixin, LoaderModuleMockMixin):
                                       editable=['.'])
             self.assertSaltTrueReturn({'test': ret})
             self.assertInSaltComment(
-                'successfully installed',
+                'packages are already installed',
                 {'test': ret}
             )


### PR DESCRIPTION
### What does this PR do?
#47102 recently fixed the error that occurred with pip >= 1.0.0 when `modules.pip.install` was called only with packages that were already installed, but this fix didn't remove the code that already existed in `states.pip.installed` to prevent the same issue on previous versions of pip.

This PR removes that now unnecessary code. Additionally, the state module now doesn't call `modules.pip.install` anymore, when it is already clear that no new packages need to be installed and also reports that all packages are already installed (instead of saying that everything was installed, even though no changes occurred).

Additionally, this also fixes the state from reporting changes when a requirements file is used and the upgrade option is true.

When merging forward this will most likely fail a test that isn't present in 2017.7, because of the changed wording. If you think that it's better to leave the message the same (Always say everything was installed, even when nothing was changed), I can also revert that change which should leave all tests working. Otherwise, the necessary fixes are already present in my previous PR for `develop`: https://github.com/saltstack/salt/pull/47207/files#diff-0dcf0b17cb06297607ef8b154aa674ebL884
You can either change it yourself or tell me and I will create a new PR after this was merged forward.

### Related
My previous PR before I realized that this was already fixed in 2017.7 and only not merged forward yet: #47207

### Commits signed with GPG?
Yes