### PR TITLE
Fix issue #47225: avoid zfs.filesystem_present slowdown when dataset has lots of snapshots

### DIFF
--- a/salt/states/zfs.py
+++ b/salt/states/zfs.py
@@ -454,8 +454,9 @@ def _dataset_present(dataset_type, name, volume_size=None, sparse=False, create_
         ## NOTE: fetch current volume properties
         properties_current = __salt__['zfs.get'](
             name,
+            type=dataset_type,
             fields='value',
-            depth=1,
+            depth=0,
             parsable=True,
         ).get(name, OrderedDict())
 


### PR DESCRIPTION
### What does this PR do?

Changes zfs.dataset_present so it 1) takes into consideration the intended type of dataset while filtering for properties. 2) limits the properties query depth to 0 (ie. just the referenced dataset)

### What issues does this PR fix or reference?

Fixes #47225 (against develop)

### Previous Behavior

Existing dataset's properties query did not filter by dataset type, and (incorrectly) included fetching of sub-dataset properties.

### New Behavior

Now only really needed information is requested to zfs, thus speeding up the query (a lot) on affected scenarios.

### Tests written?

No

### Commits signed with GPG?

No

