### PR TITLE
Fix issue #47225: avoid zfs.filesystem_present slowdown when dataset has lots of snapshots (2017.7 branch)

### DIFF
--- a/salt/states/zfs.py
+++ b/salt/states/zfs.py
@@ -376,7 +376,7 @@ def filesystem_present(name, create_parent=False, properties=None, cloned_from=N
         if name in __salt__['zfs.list'](name, **{'type': 'filesystem'}):  # update properties if needed
             result = {}
             if len(properties) > 0:
-                result = __salt__['zfs.get'](name, **{'properties': ','.join(properties.keys()), 'fields': 'value', 'depth': 1})
+                result = __salt__['zfs.get'](name, **{'properties': ','.join(properties.keys()), 'type': 'filesystem', 'fields': 'value', 'depth': 0})
 
             for prop in properties:
                 if properties[prop] != result[name][prop]['value']:


### PR DESCRIPTION
### Description of Issue/Question

This is the same pull-request as #47226, but against branch 2017.7.

zfs.filesystem_present (when specifying properties) takes forever on a dataset with lots (10k+) of snapshots, this is due to underlying zfs.dataset_present function not limiting properties query to only the filesystem actually being tested for presence, 
but instead allowing query to ask for snapshots and other sub-datasets too.

### Setup

Given a zfs dataset with lots of snapshots, a state like the follwing will take minutes to complete:

```yaml
zfs::dataset::data:
  zfs.filesystem_present:
    - name: TANK/data
    - properties:
        mountpount: /data
```

### Versions Report

```
Salt Version:
           Salt: 2017.7.1

Dependency Versions:
           cffi: Not Installed
       cherrypy: Not Installed
       dateutil: Not Installed
      docker-py: Not Installed
          gitdb: Not Installed
      gitpython: Not Installed
          ioflo: Not Installed
         Jinja2: 2.7.2
        libgit2: Not Installed
        libnacl: Not Installed
       M2Crypto: Not Installed
           Mako: Not Installed
   msgpack-pure: Not Installed
 msgpack-python: 0.5.1
   mysql-python: Not Installed
      pycparser: Not Installed
       pycrypto: 2.6.1
   pycryptodome: Not Installed
         pygit2: Not Installed
         Python: 2.7.5 (default, Aug  4 2017, 00:39:18)
   python-gnupg: 0.3.8
         PyYAML: 3.11
          PyZMQ: 15.3.0
           RAET: Not Installed
          smmap: Not Installed
        timelib: Not Installed
        Tornado: 4.2.1
            ZMQ: 4.1.4

System Versions:
           dist: centos 7.4.1708 Core
         locale: UTF-8
        machine: x86_64
        release: 4.4.128-1.el7.elrepo.x86_64
         system: Linux
        version: CentOS Linux 7.4.1708 Core
```
