### PR TITLE
Fix issue #47225: avoid zfs.filesystem_present slowdown when dataset has lots of snapshots (2018.3 branch)

### DIFF
--- a/salt/states/zfs.py
+++ b/salt/states/zfs.py
@@ -454,8 +454,9 @@ def _dataset_present(dataset_type, name, volume_size=None, sparse=False, create_
         ## NOTE: fetch current volume properties
         properties_current = __salt__['zfs.get'](
             name,
+            type=dataset_type,
             fields='value',
-            depth=1,
+            depth=0,
             parsable=True,
         ).get(name, OrderedDict())
 


### PR DESCRIPTION
### Description of Issue/Question

This is the same pull-request as #47226, but against branch 2018.3.

zfs.filesystem_present (when specifying properties) takes forever on a dataset with lots (10k+) of snapshots, this is due to underlying zfs.dataset_present function not limiting properties query to only the filesystem actually being tested for presence, 
but instead allowing query to ask for snapshots and other sub-datasets too.

### Setup

Given a zfs dataset with lots of snapshots, a state like the follwing will take minutes to complete:

```yaml
zfs::dataset::data:
  zfs.filesystem_present:
    - name: TANK/data
    - properties:
        mountpount: /data
```

