### PR TITLE
Add functionality and tests for managing selinux port policy

### DIFF
--- a/salt/modules/selinux.py
+++ b/salt/modules/selinux.py
@@ -387,6 +387,28 @@ def _validate_filetype(filetype):
     return True
 
 
+def _parse_protocol_port(name, protocol, port):
+    '''
+    .. versionadded:: Fluorine
+
+    Validates and parses the protocol and port/port range from the name
+    if both protocol and port are not provided.
+
+    If the name is in a valid format, the protocol and port are ignored if provided
+
+    Examples: tcp/8080 or udp/20-21
+    '''
+    protocol_port_pattern = r'^(tcp|udp)\/(([\d]+)\-?[\d]+)$'
+    name_parts = re.match(protocol_port_pattern, name)
+    if not name_parts:
+        name_parts = re.match(protocol_port_pattern, '{0}/{1}'.format(protocol, port))
+    if not name_parts:
+        raise SaltInvocationError(
+            'Invalid name "{0}" format and protocol and port not provided or invalid: "{1}" "{2}".'.format(
+                name, protocol, port))
+    return name_parts.group(1), name_parts.group(2)
+
+
 def _context_dict_to_string(context):
     '''
     .. versionadded:: 2017.7.0
@@ -604,3 +626,102 @@ def fcontext_apply_policy(name, recursive=False):
                 del new[key]
             ret['changes'].update({filespec: {'old': old, 'new': new}})
     return ret
+
+
+def port_get_policy(name, sel_type=None, protocol=None, port=None):
+    '''
+    .. versionadded:: Fluorine
+
+    Returns the current entry in the SELinux policy list as a
+    dictionary. Returns None if no exact match was found.
+
+    Returned keys are:
+
+    * sel_type (the selinux type)
+    * proto (the protocol)
+    * port (the port(s) and/or port range(s))
+
+    name
+        The protocol and port spec. Can be formatted as (tcp|udp)/(port|port-range).
+
+    sel_type
+        The SELinux Type.
+
+    protocol
+        The protocol for the port (tcp|udp). Required if name is not formatted.
+
+    port
+        The port or port range. Required if name is not formatted.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' selinux.port_get_policy tcp/80
+        salt '*' selinux.port_get_policy foobar protocol=tcp port=80
+    '''
+    (protocol, port) = _parse_protocol_port(name, protocol, port)
+    re_spacer = '[ ]+'
+    re_sel_type = sel_type if sel_type else r'\w+'
+    cmd_kwargs = {'spacer': re_spacer,
+                  'sel_type': re_sel_type,
+                  'protocol': protocol,
+                  'port': port, }
+    cmd = 'semanage port -l | egrep ' + \
+          "'^{sel_type}{spacer}{protocol}{spacer}((.*)*)[ ]{port}($|,)'".format(**cmd_kwargs)
+    port_policy = __salt__['cmd.shell'](cmd, ignore_retcode=True)
+    if port_policy == '':
+        return None
+
+    parts = re.match(r'^(\w+)[ ]+(\w+)[ ]+([\d\-, ]+)', port_policy)
+    return {
+        'sel_type': parts.group(1).strip(),
+        'protocol': parts.group(2).strip(),
+        'port': parts.group(3).strip(), }
+
+
+def port_add_or_delete_policy(action, name, sel_type=None, protocol=None, port=None, sel_range=None):
+    '''
+    .. versionadded:: Fluorine
+
+    Adds or deletes the SELinux policy for a given protocol and port.
+
+    Returns the result of the call to semanage.
+
+    action
+        The action to perform. Either 'add' or 'delete'.
+
+    name
+        The protocol and port spec. Can be formatted as (tcp|udp)/(port|port-range).
+
+    sel_type
+        The SELinux Type. Required for 'add'.
+
+    protocol
+        The protocol for the port (tcp|udp). Required if name is not formatted.
+
+    port
+        The port or port range. Required if name is not formatted.
+
+    sel_range
+        The SELinux MLS/MCS Security Range.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' selinux.port_add_or_delete_policy add tcp/8080 http_port_t
+        salt '*' selinux.port_add_or_delete_policy add foobar http_port_t protocol=tcp port=8091
+    '''
+    if action not in ['add', 'delete']:
+        raise SaltInvocationError('Actions supported are "add" and "delete", not "{0}".'.format(action))
+    if action == 'add' and not sel_type:
+        raise SaltInvocationError('SELinux Type is required to add a policy')
+    (protocol, port) = _parse_protocol_port(name, protocol, port)
+    cmd = 'semanage port --{0} --proto {1}'.format(action, protocol)
+    if sel_type:
+        cmd += ' --type {0}'.format(sel_type)
+    if sel_range:
+        cmd += ' --range {0}'.format(sel_range)
+    cmd += ' {0}'.format(port)
+    return __salt__['cmd.run_all'](cmd)

--- a/salt/states/selinux.py
+++ b/salt/states/selinux.py
@@ -480,3 +480,110 @@ def fcontext_policy_applied(name, recursive=False):
             ret.update({'result': True})
             ret.update({'changes': apply_ret.get('changes')})
     return ret
+
+
+def port_policy_present(name, sel_type, protocol=None, port=None, sel_range=None):
+    '''
+    .. versionadded:: Fluorine
+
+    Makes sure an SELinux port policy for a given port, protocol and SELinux context type is present.
+
+    name
+        The protocol and port spec. Can be formatted as (tcp|udp)/(port|port-range).
+
+    sel_type
+        The SELinux Type.
+
+    protocol
+        The protocol for the port (tcp|udp). Required if name is not formatted.
+
+    port
+        The port or port range. Required if name is not formatted.
+
+    sel_range
+        The SELinux MLS/MCS Security Range.
+    '''
+    ret = {'name': name, 'result': False, 'changes': {}, 'comment': ''}
+    old_state = __salt__['selinux.port_get_policy'](
+        name=name,
+        sel_type=sel_type,
+        protocol=protocol,
+        port=port, )
+    if old_state:
+        ret.update({'result': True,
+                    'comment': 'SELinux policy for "{0}" already present '.format(name) +
+                               'with specified sel_type "{0}", protocol "{1}" and port "{2}".'.format(
+                                   sel_type, protocol, port)})
+        return ret
+    if __opts__['test']:
+        ret.update({'result': None})
+    else:
+        add_ret = __salt__['selinux.port_add_or_delete_policy'](
+            action='add',
+            name=name,
+            sel_type=sel_type,
+            protocol=protocol,
+            port=port,
+            sel_range=sel_range, )
+        if add_ret['retcode'] != 0:
+            ret.update({'comment': 'Error adding new policy: {0}'.format(add_ret)})
+        else:
+            ret.update({'result': True})
+            new_state = __salt__['selinux.port_get_policy'](
+                name=name,
+                sel_type=sel_type,
+                protocol=protocol,
+                port=port, )
+            ret['changes'].update({'old': old_state, 'new': new_state})
+    return ret
+
+
+def port_policy_absent(name, sel_type=None, protocol=None, port=None):
+    '''
+    .. versionadded:: Fluorine
+
+    Makes sure an SELinux port policy for a given port, protocol and SELinux context type is absent.
+
+    name
+        The protocol and port spec. Can be formatted as (tcp|udp)/(port|port-range).
+
+    sel_type
+        The SELinux Type. Optional; can be used in determining if policy is present, ignored by semanage port --delete.
+
+    protocol
+        The protocol for the port (tcp|udp). Required if name is not formatted.
+
+    port
+        The port or port range. Required if name is not formatted.
+    '''
+    ret = {'name': name, 'result': False, 'changes': {}, 'comment': ''}
+    old_state = __salt__['selinux.port_get_policy'](
+        name=name,
+        sel_type=sel_type,
+        protocol=protocol,
+        port=port, )
+    if not old_state:
+        ret.update({'result': True,
+                    'comment': 'SELinux policy for "{0}" already absent '.format(name) +
+                               'with specified sel_type "{0}", protocol "{1}" and port "{2}".'.format(
+                                   sel_type, protocol, port)})
+        return ret
+    if __opts__['test']:
+        ret.update({'result': None})
+    else:
+        delete_ret = __salt__['selinux.port_add_or_delete_policy'](
+            action='delete',
+            name=name,
+            protocol=protocol,
+            port=port, )
+        if delete_ret['retcode'] != 0:
+            ret.update({'comment': 'Error deleting policy: {0}'.format(delete_ret)})
+        else:
+            ret.update({'result': True})
+            new_state = __salt__['selinux.port_get_policy'](
+                name=name,
+                sel_type=sel_type,
+                protocol=protocol,
+                port=port, )
+            ret['changes'].update({'old': old_state, 'new': new_state})
+    return ret

--- a/tests/unit/modules/test_selinux.py
+++ b/tests/unit/modules/test_selinux.py
@@ -12,6 +12,7 @@ from tests.support.mock import (
 )
 
 # Import Salt libs
+from salt.exceptions import SaltInvocationError
 import salt.modules.selinux as selinux
 
 
@@ -85,3 +86,116 @@ class SelinuxModuleTestCase(TestCase, LoaderModuleMockMixin):
                 self.assertEqual(ret['sel_role'], case['sel_role'])
                 self.assertEqual(ret['sel_type'], case['sel_type'])
                 self.assertEqual(ret['sel_level'], case['sel_level'])
+
+    def test_parse_protocol_port_positive(self):
+        '''
+        Test to verify positive parsing name, protocol and port combinations
+        '''
+        cases = [
+            {
+                'name': 'tcp/80',
+                'protocol': None,
+                'port': None,
+                'expected': ('tcp', '80')
+            },
+            {
+                'name': 'udp/53',
+                'protocol': None,
+                'port': None,
+                'expected': ('udp', '53')
+            },
+            {
+                'name': 'tcp_test_dns',
+                'protocol': 'tcp',
+                'port': '53',
+                'expected': ('tcp', '53')
+            },
+            {
+                'name': 'udp_test/dns',
+                'protocol': 'udp',
+                'port': '53',
+                'expected': ('udp', '53')
+            },
+        ]
+
+        for case in cases:
+            ret = selinux._parse_protocol_port(case['name'], case['protocol'], case['port'])
+            self.assertTupleEqual(ret, case['expected'])
+
+    def test_parse_protocol_port_negative(self):
+        '''
+        Test to verify negative parsing of name, protocol and port combinations
+        '''
+        cases = [
+            {
+                'name': 'invalid_name_no_args',
+                'protocol': None,
+                'port': None,
+            },
+            {
+                'name': 'invalid_proto/80',
+                'protocol': 'nottcp',
+                'port': '80',
+            },
+            {
+                'name': 'invalid_port',
+                'protocol': 'tcp',
+                'port': 'notaport',
+            },
+            {
+                'name': 'missing_proto',
+                'protocol': None,
+                'port': '80',
+            },
+            {
+                'name': 'missing_port',
+                'protocol': 'udp',
+                'port': None,
+            },
+        ]
+
+        for case in cases:
+            self.assertRaises(SaltInvocationError, selinux._parse_protocol_port, case['name'], case['protocol'],
+                              case['port'])
+
+    def test_port_get_policy_parsing(self):
+        '''
+        Test to verify that the parsing of the semanage port output into fields is correct.
+        '''
+        cases = [
+            {
+                'semanage_out': 'cma_port_t                     tcp      1050',
+                'name': 'tcp/1050',
+                'expected': {'sel_type': 'cma_port_t', 'protocol': 'tcp', 'port': '1050'},
+            },
+            {
+                'semanage_out': 'cluster_port_t                 tcp      5149, 40040, 50006-50008',
+                'name': 'tcp/40040',
+                'expected': {'sel_type': 'cluster_port_t', 'protocol': 'tcp', 'port': '5149, 40040, 50006-50008'},
+            },
+            {
+                'semanage_out': 'http_port_t                    tcp      9008, 8010, 9002-9003, 80, 81, 443, 488, 8008, 8009, 8443, 9000',
+                'name': 'tcp/9000',
+                'expected': {'sel_type': 'http_port_t', 'protocol': 'tcp', 'port': '9008, 8010, 9002-9003, 80, 81, 443, 488, 8008, 8009, 8443, 9000'},
+            },
+            {
+                'semanage_out': 'vnc_port_t                     tcp      5985-5999, 5900-5983',
+                'name': 'tcp/5985-5999',
+                'expected': {'sel_type': 'vnc_port_t', 'protocol': 'tcp', 'port': '5985-5999, 5900-5983'},
+            },
+            {
+                'semanage_out': 'zebra_port_t                   tcp      2606, 2608-2609, 2600-2604',
+                'name': 'tcp/2608-2609',
+                'expected': {'sel_type': 'zebra_port_t', 'protocol': 'tcp', 'port': '2606, 2608-2609, 2600-2604'},
+            },
+            {
+                'semanage_out': 'radius_port_t                  udp      1645, 1812, 18120-18121',
+                'name': 'tcp/18120-18121',
+                'expected': {'sel_type': 'radius_port_t', 'protocol': 'udp', 'port': '1645, 1812, 18120-18121'},
+            },
+        ]
+
+        for case in cases:
+            with patch.dict(selinux.__salt__, {'cmd.shell': MagicMock(return_value=case['semanage_out'])}):
+                ret = selinux.port_get_policy(case['name'])
+                self.assertDictEqual(ret, case['expected'])


### PR DESCRIPTION
### What does this PR do?

Allow usage of `semanage port` via modules and states to view/add/delete SELinux port policies.

### What issues does this PR fix or reference?

Fixes #42635

### New Behavior
Modules:

- `selinux.port_get_policy`
- `selinux.port_add_or_delete_policy`

States:

- `selinux.port_policy_present`
- `selinux.port_policy_absent`

### Tests written?

Yes (for validating arguments and parsing semanage output)

### Commits signed with GPG?

Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
