### PR TITLE
Fixed usage of ipaddress

### DIFF
--- a/salt/modules/network.py
+++ b/salt/modules/network.py
@@ -1140,7 +1140,7 @@ def convert_cidr(cidr):
     ret = {'network': None,
            'netmask': None}
     cidr = calc_net(cidr)
-    network_info = salt.ext.ipaddress.ip_network(cidr)
+    network_info = ipaddress.ip_network(cidr)
     ret['network'] = six.text_type(network_info.network_address)
     ret['netmask'] = six.text_type(network_info.netmask)
     return ret


### PR DESCRIPTION
### What does this PR do?

ipaddress is imported either directly or from salt.ext. If we use it, we shouldn't address it with salt.ext.ipaddress.

### What issues does this PR fix or reference?

### Previous Behavior

AttributeError: module 'salt.ext' has no attribute 'ipaddress'

### New Behavior

No more AttributeError.

### Tests written?

No

### Commits signed with GPG?

Yes