### PR TITLE
Handle yum.Errors.YumBaseError

### DIFF
--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -314,6 +314,10 @@ def _get_yum_config():
             raise CommandExecutionError(
                 'Could not query yum config: {0}'.format(exc)
             )
+        except yum.Errors.YumBaseError as yum_base_error:
+            raise CommandExecutionError(
+                'Error accessing yum or rpmdb: {0}'.format(yum_base_error)
+            )
     else:
         # fall back to parsing the config ourselves
         # Look for the config the same order yum does

--- a/tests/unit/modules/test_yumpkg.py
+++ b/tests/unit/modules/test_yumpkg.py
@@ -3,6 +3,7 @@
 # Import Python Libs
 from __future__ import absolute_import
 import os
+import sys
 
 # Import Salt Testing Libs
 from tests.support.mixins import LoaderModuleMockMixin
@@ -664,6 +665,8 @@ class YumTestCase(TestCase, LoaderModuleMockMixin):
                     self.assertTrue(info['arch'] in ('x86_64', 'i686'))
 
     def test_yum_base_error(self):
+        if not yumpkg.HAS_YUM:
+            sys.modules['yum'] = Mock()
         with patch('yum.YumBase') as mock_yum_yumbase:
             mock_yum_yumbase.side_effect = CommandExecutionError
             self.assertRaises(CommandExecutionError, yumpkg._get_yum_config)

--- a/tests/unit/modules/test_yumpkg.py
+++ b/tests/unit/modules/test_yumpkg.py
@@ -16,6 +16,7 @@ from tests.support.mock import (
 )
 
 # Import Salt libs
+from salt.exceptions import CommandExecutionError
 import salt.modules.yumpkg as yumpkg
 import salt.modules.pkg_resource as pkg_resource
 
@@ -661,3 +662,8 @@ class YumTestCase(TestCase, LoaderModuleMockMixin):
                 self.assertEqual(len(pkg_info_list), 2 if pkg_name == "virgo-dummy" else 1)
                 for info in pkg_info_list:
                     self.assertTrue(info['arch'] in ('x86_64', 'i686'))
+
+    def test_yum_base_error(self):
+        with patch('yum.YumBase') as mock_yum_yumbase:
+            mock_yum_yumbase.side_effect = CommandExecutionError
+            self.assertRaises(CommandExecutionError, yumpkg._get_yum_config)


### PR DESCRIPTION
Happens at least in event rpmdb is corrupt/cannot be opened

### What does this PR do?

Excepts `yum.Errors.YumBaseError` and raises `CommandExecutionError` for consistency and simplified display

### What issues does this PR fix or reference?

Fixes #44331

### Previous Behavior

Full Traceback was printed in Comment

### New Behavior

`CommandExecutionError` is raised with simplified message from the original `yum.Errors.YumBaseError`

### Tests written?

No

### Commits signed with GPG?

Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
