### PR TITLE
Add autoremove, force-removal-of-dependent-packages for opkg.remove

### DIFF
--- a/salt/modules/opkg.py
+++ b/salt/modules/opkg.py
@@ -435,6 +435,15 @@ def remove(name=None, pkgs=None, **kwargs):  # pylint: disable=unused-argument
         A list of packages to delete. Must be passed as a python list. The
         ``name`` parameter will be ignored if this option is passed.
 
+    remove_dependent_packages
+        Remove package and all dependencies
+
+        .. versionadded:: Fluorine
+
+    auto_remove
+        Remove packages that were installed automatically to satisfy dependencies
+
+        .. versionadded:: Fluorine
 
     Returns a dict containing the changes.
 
@@ -445,6 +454,7 @@ def remove(name=None, pkgs=None, **kwargs):  # pylint: disable=unused-argument
         salt '*' pkg.remove <package name>
         salt '*' pkg.remove <package1>,<package2>,<package3>
         salt '*' pkg.remove pkgs='["foo", "bar"]'
+        salt '*' pkg.remove pkgs='["foo", "bar"]' remove_dependent_packages=True auto_remove=True
     '''
     try:
         pkg_params = __salt__['pkg_resource.parse_targets'](name, pkgs)[0]
@@ -456,6 +466,10 @@ def remove(name=None, pkgs=None, **kwargs):  # pylint: disable=unused-argument
     if not targets:
         return {}
     cmd = ['opkg', 'remove']
+    if kwargs.get('remove_dependent_packages', False):
+        cmd.append('--force-removal-of-dependent-packages')
+    if kwargs.get('auto_remove', False):
+        cmd.append('--autoremove')
     cmd.extend(targets)
 
     out = __salt__['cmd.run_all'](


### PR DESCRIPTION
### What does this PR do?
This PR adds support for opkg remove in terms of giving the possibility of specifying two extra parameters: force-removal-of-dependent-packages, autoremove 

### Previous Behavior
The implementation was always calling opkg remove without any extra parameters.

### New Behavior
Now we check these 2 force-options in kwargs and append them to the command if necessary:
- --force-removal-of-dependent-packages - Remove package and all dependencies
- --autoremove - Remove packages that were installed automatically to
satisfy dependencies

### Tests written?
No

### Commits signed with GPG?
No
