### PR TITLE
PY3 fix for zeromq setsockopt

### DIFF
--- a/salt/engines/napalm_syslog.py
+++ b/salt/engines/napalm_syslog.py
@@ -220,7 +220,7 @@ def _zmq(address, port, **kwargs):
         addr=address,
         port=port)
     )
-    socket.setsockopt(zmq.SUBSCRIBE, '')
+    socket.setsockopt(zmq.SUBSCRIBE, b'')
     return socket.recv
 
 


### PR DESCRIPTION
What does this PR do?

Resolves the following traceback, appears related to zmq changes -

[CRITICAL] Engine 'napalm_syslog' could not be started!
Traceback (most recent call last):
File "/usr/lib/python2.7/dist-packages/salt/engines/init.py", line 128, in run
self.engineself.fun
File "/usr/lib/python2.7/dist-packages/salt/engines/napalm_syslog.py", line 317, in start
port=port)
File "/usr/lib/python2.7/dist-packages/salt/engines/napalm_syslog.py", line 234, in _get_transport_recv
return TRANSPORT_FUN_MAP[name](address, port, **kwargs)
File "/usr/lib/python2.7/dist-packages/salt/engines/napalm_syslog.py", line 223, in _zmq
socket.setsockopt(zmq.SUBSCRIBE, '')
File "zmq/backend/cython/socket.pyx", line 426, in zmq.backend.cython.socket.Socket.set
TypeError: unicode not allowed, use setsockopt_string
Tests written?

No.
Commits signed with GPG?

No.

Please review Salt's Contributing Guide for best practices.

See GitHub's page on GPG signing for more information about signing commits with GPG.