### PR TITLE
virt connection improvements

### DIFF
--- a/doc/topics/tutorials/cloud_controller.rst
+++ b/doc/topics/tutorials/cloud_controller.rst
@@ -245,7 +245,7 @@ The Salt Virt runner will now automatically select a hypervisor to deploy
 the new virtual machine on. Using ``salt://`` assumes that the CentOS virtual
 machine image is located in the root of the :ref:`file-server` on the master.
 When images are cloned (i.e. copied locatlly after retrieval from the file server)
-the destination directory on the hypervisor minion is determined by the ``virt.images``
+the destination directory on the hypervisor minion is determined by the ``virt:images``
 config option; by default this is ``/srv/salt/salt-images/``.
 
 When a VM is initialized using ``virt.init`` the image is copied to the hypervisor

--- a/doc/topics/tutorials/cloud_controller.rst
+++ b/doc/topics/tutorials/cloud_controller.rst
@@ -322,16 +322,17 @@ opened on hypervisors:
 
     :ref:`Opening the Firewall up for Salt <firewall>`
 
-Salt also needs the ``virt.tunnel`` option to be turned on.
+Salt also needs the ``virt:tunnel`` option to be turned on.
 This flag tells Salt to run migrations securely via the libvirt TLS tunnel and to
-use port 16514. Without ``virt.tunnel`` libvirt tries to bind to random ports when
+use port 16514. Without ``virt:tunnel`` libvirt tries to bind to random ports when
 running migrations.
 
-To turn on ``virt.tunnel`` simple apply it to the master config file:
+To turn on ``virt:tunnel`` simply apply it to the master config file:
 
 .. code-block:: yaml
 
-    virt.tunnel: True
+    virt:
+        tunnel: True
 
 Once the master config has been updated, restart the master and send out a call
 to the minions to refresh the pillar to pick up on the change:

--- a/doc/topics/virt/nic.rst
+++ b/doc/topics/virt/nic.rst
@@ -10,16 +10,17 @@ read from the ``config.option`` function, meaning that the configuration can be
 stored in the minion config file, the master config file, or the minion's
 pillar.
 
-This configuration option is called ``virt.nic``. By default the ``virt.nic``
+This configuration option is called ``virt:nic``. By default the ``virt:nic``
 option is empty but defaults to a data structure which looks like this:
 
 .. code-block:: yaml
 
-    virt.nic:
-      default:
-        eth0:
-          bridge: br0
-          model: virtio
+    virt:
+      nic:
+        default:
+          eth0:
+            bridge: br0
+            model: virtio
 
 .. note::
 
@@ -30,7 +31,7 @@ option is empty but defaults to a data structure which looks like this:
 This configuration sets up a network profile called default. The default
 profile creates a single Ethernet device on the virtual machine that is bridged
 to the hypervisor's :strong:`br0` interface. This default setup does not
-require setting up the ``virt.nic`` configuration, and is the reason why a
+require setting up the ``virt:nic`` configuration, and is the reason why a
 default install only requires setting up the :strong:`br0` bridge device on the
 hypervisor.
 
@@ -42,41 +43,42 @@ more than one profile, this can be easily accomplished:
 
 .. code-block:: yaml
 
-    virt.nic:
-      dual:
-        eth0:
-          bridge: service_br
-        eth1:
-          bridge: storage_br
-      single:
-        eth0:
-          bridge: service_br
-      triple:
-        eth0:
-          bridge: service_br
-        eth1:
-          bridge: storage_br
-        eth2:
-          bridge: dmz_br
-      all:
-        eth0:
-          bridge: service_br
-        eth1:
-          bridge: storage_br
-        eth2:
-          bridge: dmz_br
-        eth3:
-          bridge: database_br
-      dmz:
-        eth0:
-          bridge: service_br
-        eth1:
-          bridge: dmz_br
-      database:
-        eth0:
-          bridge: service_br
-        eth1:
-          bridge: database_br
+    virt:
+      nic:
+        dual:
+          eth0:
+            bridge: service_br
+          eth1:
+            bridge: storage_br
+        single:
+          eth0:
+            bridge: service_br
+        triple:
+          eth0:
+            bridge: service_br
+          eth1:
+            bridge: storage_br
+          eth2:
+            bridge: dmz_br
+        all:
+          eth0:
+            bridge: service_br
+          eth1:
+            bridge: storage_br
+          eth2:
+            bridge: dmz_br
+          eth3:
+            bridge: database_br
+        dmz:
+          eth0:
+            bridge: service_br
+          eth1:
+            bridge: dmz_br
+        database:
+          eth0:
+            bridge: service_br
+          eth1:
+            bridge: database_br
 
 This configuration allows for one of six profiles to be selected, allowing
 virtual machines to be created which attach to different network depending

--- a/salt/client/ssh/wrapper/config.py
+++ b/salt/client/ssh/wrapper/config.py
@@ -49,8 +49,8 @@ DEFAULTS = {'mongo.db': 'salt',
             'ldap.bindpw': '',
             'hosts.file': '/etc/hosts',
             'aliases.file': '/etc/aliases',
-            'virt.images': os.path.join(syspaths.SRV_ROOT_DIR, 'salt-images'),
-            'virt': {'tunnel': False},
+            'virt': {'tunnel': False,
+                     'images': os.path.join(syspaths.SRV_ROOT_DIR, 'salt-images')},
             }
 
 

--- a/salt/client/ssh/wrapper/config.py
+++ b/salt/client/ssh/wrapper/config.py
@@ -50,7 +50,7 @@ DEFAULTS = {'mongo.db': 'salt',
             'hosts.file': '/etc/hosts',
             'aliases.file': '/etc/aliases',
             'virt.images': os.path.join(syspaths.SRV_ROOT_DIR, 'salt-images'),
-            'virt.tunnel': False,
+            'virt': {'tunnel': False},
             }
 
 

--- a/salt/modules/config.py
+++ b/salt/modules/config.py
@@ -77,7 +77,7 @@ DEFAULTS = {'mongo.db': 'salt',
             'hosts.file': _HOSTS_FILE,
             'aliases.file': '/etc/aliases',
             'virt.images': os.path.join(syspaths.SRV_ROOT_DIR, 'salt-images'),
-            'virt.tunnel': False,
+            'virt': {'tunnel': False},
             }
 
 

--- a/salt/modules/config.py
+++ b/salt/modules/config.py
@@ -76,8 +76,8 @@ DEFAULTS = {'mongo.db': 'salt',
             'ldap.bindpw': '',
             'hosts.file': _HOSTS_FILE,
             'aliases.file': '/etc/aliases',
-            'virt.images': os.path.join(syspaths.SRV_ROOT_DIR, 'salt-images'),
-            'virt': {'tunnel': False},
+            'virt': {'tunnel': False,
+                     'images': os.path.join(syspaths.SRV_ROOT_DIR, 'salt-images')},
             }
 
 

--- a/salt/modules/config.py
+++ b/salt/modules/config.py
@@ -390,6 +390,15 @@ def get(key, default='', delimiter=':', merge=None, omit_opts=False,
                 delimiter=delimiter)
             if ret != '_|-':
                 return sdb.sdb_get(ret, __opts__)
+
+        ret = salt.utils.data.traverse_dict_and_list(
+            DEFAULTS,
+            key,
+            '_|-',
+            delimiter=delimiter)
+        log.debug("key: %s, ret: %s", key, ret)
+        if ret != '_|-':
+            return sdb.sdb_get(ret, __opts__)
     else:
         if merge not in ('recurse', 'overwrite'):
             log.warning('Unsupported merge strategy \'{0}\'. Falling back '
@@ -398,7 +407,8 @@ def get(key, default='', delimiter=':', merge=None, omit_opts=False,
 
         merge_lists = salt.config.master_config('/etc/salt/master').get('pillar_merge_lists')
 
-        data = copy.copy(__pillar__.get('master', {}))
+        data = copy.copy(DEFAULTS)
+        data = salt.utils.dictupdate.merge(data, __pillar__.get('master', {}), strategy=merge, merge_lists=merge_lists)
         data = salt.utils.dictupdate.merge(data, __pillar__, strategy=merge, merge_lists=merge_lists)
         data = salt.utils.dictupdate.merge(data, __grains__, strategy=merge, merge_lists=merge_lists)
         data = salt.utils.dictupdate.merge(data, __opts__, strategy=merge, merge_lists=merge_lists)

--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -710,18 +710,6 @@ def _qemu_image_create(vm_name,
     return img_dest
 
 
-# TODO: this function is deprecated, should be replaced with
-# _qemu_image_info()
-def _image_type(vda):
-    '''
-    Detect what driver needs to be used for the given image
-    '''
-    out = __salt__['cmd.run']('qemu-img info {0}'.format(vda))
-    if 'file format: qcow2' in out:
-        return 'qcow2'
-    return 'raw'
-
-
 # TODO: this function is deprecated, should be merged and replaced
 # with _disk_profile()
 def _get_image_info(hypervisor, name, **kwargs):

--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -135,10 +135,7 @@ def __get_conn():
         '''
         return [[libvirt.VIR_CRED_EXTERNAL], lambda: 0, None]
 
-    if 'virt.connect' in __opts__:
-        conn_str = __opts__['virt.connect']
-    else:
-        conn_str = 'qemu:///system'
+    conn_str = __salt__['config.get']('virt.connect', None)
 
     conn_func = {
         'esxi': [libvirt.openAuth, [__esxi_uri(),

--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -839,7 +839,13 @@ def _nic_profile(profile_name, hypervisor, **kwargs):
         profile_name, None
     )
 
-    if config_data is None:
+    if config_data is not None:
+        salt.utils.warn_until(
+            'Sodium',
+            '\'virt.nic\' has been deprecated in favor of \'virt:nic\'. '
+            '\'virt.nic\' will stop being used in {version}.'
+        )
+    else:
         config_data = __salt__['config.get']('virt:nic', {}).get(
             profile_name, default
         )

--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -420,7 +420,16 @@ def _get_migrate_command():
     '''
     Returns the command shared by the different migration types
     '''
-    if __salt__['config.option']('virt.tunnel'):
+    tunnel = __salt__['config.option']('virt.tunnel')
+    if tunnel:
+        salt.utils.warn_until(
+            'Sodium',
+            '\'virt.tunnel\' has been deprecated in favor of '
+            '\'virt:tunnel\'. \'virt.tunnel\' will stop '
+            'being used in {version}.')
+    else:
+        tunnel = __salt__['config.get']('virt:tunnel')
+    if tunnel:
         return ('virsh migrate --p2p --tunnelled --live --persistent '
                 '--undefinesource ')
     return 'virsh migrate --live --persistent --undefinesource '
@@ -1754,6 +1763,17 @@ def migrate_non_shared(vm_, target, ssh=False):
     .. code-block:: bash
 
         salt '*' virt.migrate_non_shared <vm name> <target hypervisor>
+
+    A tunnel data migration can be performed by setting this in the
+    configuration:
+
+    .. code-block:: yaml
+
+        virt:
+            tunnel: True
+
+    For more details on tunnelled data migrations, report to
+    https://libvirt.org/migration.html#transporttunnel
     '''
     cmd = _get_migrate_command() + ' --copy-storage-all ' + vm_\
         + _get_target(target, ssh)
@@ -1773,6 +1793,17 @@ def migrate_non_shared_inc(vm_, target, ssh=False):
     .. code-block:: bash
 
         salt '*' virt.migrate_non_shared_inc <vm name> <target hypervisor>
+
+    A tunnel data migration can be performed by setting this in the
+    configuration:
+
+    .. code-block:: yaml
+
+        virt:
+            tunnel: True
+
+    For more details on tunnelled data migrations, report to
+    https://libvirt.org/migration.html#transporttunnel
     '''
     cmd = _get_migrate_command() + ' --copy-storage-inc ' + vm_\
         + _get_target(target, ssh)
@@ -1792,6 +1823,17 @@ def migrate(vm_, target, ssh=False):
     .. code-block:: bash
 
         salt '*' virt.migrate <domain> <target hypervisor>
+
+    A tunnel data migration can be performed by setting this in the
+    configuration:
+
+    .. code-block:: yaml
+
+        virt:
+            tunnel: True
+
+    For more details on tunnelled data migrations, report to
+    https://libvirt.org/migration.html#transporttunnel
     '''
     cmd = _get_migrate_command() + ' ' + vm_\
         + _get_target(target, ssh)

--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -1698,8 +1698,26 @@ def define_vol_xml_str(xml):
     .. code-block:: bash
 
         salt '*' virt.define_vol_xml_str <XML in string format>
+
+    The storage pool where the disk image will be defined is ``default``
+    unless changed with a configuration like this:
+
+    .. code-block:: yaml
+
+        virt:
+            storagepool: mine
     '''
-    poolname = __salt__['config.get']('libvirt:storagepool', 'default')
+    poolname = __salt__['config.get']('libvirt:storagepool', None)
+    if poolname is not None:
+        salt.utils.warn_until(
+            'Sodium',
+            '\'libvirt:storagepool\' has been deprecated in favor of '
+            '\'virt:storagepool\'. \'libvirt:storagepool\' will stop '
+            'being used in {version}.'
+        )
+    else:
+        poolname = __salt__['config.get']('virt:storagepool', 'default')
+
     conn = __get_conn()
     pool = conn.storagePoolLookupByName(six.text_type(poolname))
     ret = pool.createXML(xml, 0) is not None

--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -2663,7 +2663,7 @@ def pool_define_build(name, **kwargs):
 
     .. code-block:: bash
 
-        salt '*' virt.pool_defin base logical base
+        salt '*' virt.pool_define base logical base
     '''
     exist = False
     update = False

--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -108,6 +108,15 @@ def __get_conn():
          - http://libvirt.org/uri.html#URI_config
         '''
         connection = __salt__['config.get']('libvirt:connection', 'esx')
+        if connection is not None:
+            salt.utils.warn_until(
+                'Sodium',
+                '\'libvirt.connection\' configuration property has been deprecated in favor '
+                'of \'virt:connection:uri\'. \'libvirt.connection\' will stop being used in '
+                '{version}.'
+            )
+
+        connection = __salt__['config.get']('virt:connection:uri', connection)
         return connection
 
     def __esxi_auth():
@@ -136,6 +145,24 @@ def __get_conn():
         return [[libvirt.VIR_CRED_EXTERNAL], lambda: 0, None]
 
     conn_str = __salt__['config.get']('virt.connect', None)
+    if conn_str is not None:
+        salt.utils.warn_until(
+            'Sodium',
+            '\'virt.connect\' configuration property has been deprecated in favor '
+            'of \'virt:connection:uri\'. \'virt.connect\' will stop being used in '
+            '{version}.'
+        )
+    else:
+        conn_str = __salt__['config.get']('libvirt:connection', None)
+        if conn_str is not None:
+            salt.utils.warn_until(
+                'Sodium',
+                '\'libvirt.connection\' configuration property has been deprecated in favor '
+                'of \'virt:connection:uri\'. \'libvirt.connection\' will stop being used in '
+                '{version}.'
+            )
+
+    conn_str = __salt__['config.get']('virt:connection:uri', conn_str)
 
     conn_func = {
         'esxi': [libvirt.openAuth, [__esxi_uri(),

--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -213,7 +213,15 @@ def _get_domain(*vms, **kwargs):
     lookup_vms = list()
     conn = __get_conn()
 
-    all_vms = list_domains()
+    all_vms = []
+    if kwargs.get('active', True):
+        for id_ in conn.listDomainsID():
+            all_vms.append(conn.lookupByID(id_).name())
+
+    if kwargs.get('inactive', True):
+        for id_ in conn.listDefinedDomains():
+            all_vms.append(id_)
+
     if not all_vms:
         raise CommandExecutionError('No virtual machines found.')
 
@@ -1061,8 +1069,8 @@ def list_domains():
         salt '*' virt.list_domains
     '''
     vms = []
-    vms.extend(list_active_vms())
-    vms.extend(list_inactive_vms())
+    for dom in _get_domain():
+        vms.append(dom.name())
     return vms
 
 
@@ -1076,10 +1084,9 @@ def list_active_vms():
 
         salt '*' virt.list_active_vms
     '''
-    conn = __get_conn()
     vms = []
-    for id_ in conn.listDomainsID():
-        vms.append(conn.lookupByID(id_).name())
+    for dom in _get_domain(inactive=False):
+        vms.append(dom.name())
     return vms
 
 
@@ -1093,10 +1100,9 @@ def list_inactive_vms():
 
         salt '*' virt.list_inactive_vms
     '''
-    conn = __get_conn()
     vms = []
-    for id_ in conn.listDefinedDomains():
-        vms.append(id_)
+    for dom in _get_domain(active=False):
+        vms.append(dom.name())
     return vms
 
 

--- a/tests/unit/modules/test_virt.py
+++ b/tests/unit/modules/test_virt.py
@@ -51,6 +51,9 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         self.mock_conn.lookupByName.return_value = mock_domain
         mock_domain.getXMLDesc.return_value = xml
 
+        # Return state as shutdown
+        mock_domain.info.return_value = [4, 0, 0, 0]
+
     def test_boot_default_dev(self):
         diskp = virt._disk_profile('default', 'kvm')
         nicp = virt._nic_profile('default', 'kvm')

--- a/tests/unit/modules/test_virt.py
+++ b/tests/unit/modules/test_virt.py
@@ -455,31 +455,32 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
     def test_mixed_dict_and_list_as_profile_objects(self):
 
         yaml_config = '''
-          virt.nic:
-             new-listonly-profile:
-                - bridge: br0
-                  name: eth0
-                - model: virtio
-                  name: eth1
-                  source: test_network
-                  type: network
-             new-list-with-legacy-names:
-                - eth0:
-                     bridge: br0
-                - eth1:
-                     bridge: br1
-                     model: virtio
-             non-default-legacy-profile:
-                eth0:
-                   bridge: br0
-                eth1:
-                   bridge: br1
-                   model: virtio
+          virt:
+             nic:
+                new-listonly-profile:
+                   - bridge: br0
+                     name: eth0
+                   - model: virtio
+                     name: eth1
+                     source: test_network
+                     type: network
+                new-list-with-legacy-names:
+                   - eth0:
+                        bridge: br0
+                   - eth1:
+                        bridge: br1
+                        model: virtio
+                non-default-legacy-profile:
+                   eth0:
+                      bridge: br0
+                   eth1:
+                      bridge: br1
+                      model: virtio
         '''
         mock_config = salt.utils.yaml.safe_load(yaml_config)
         with patch.dict(salt.modules.config.__opts__, mock_config):
 
-            for name in six.iterkeys(mock_config['virt.nic']):
+            for name in six.iterkeys(mock_config['virt']['nic']):
                 profile = salt.modules.virt._nic_profile(name, 'kvm')
                 self.assertEqual(len(profile), 2)
 


### PR DESCRIPTION
### What does this PR do?

The main goal of this PR is to improve the way the `libvirt_events` engine and the `virt` module are handling libvirt connections. The big changes are:

* Let libvirt guess the connection to open by default on both the engine and the module
* Refactor the module to rationalize its configuration options: they are now all gathered in a `virt` tree and the `config` module is used to access them
* Refactor the module to avoid opening too many connections and close them properly
* Add per-function optional connection parameters.

On the road towards this goal, I fixed a lot of the pylints in the virt module, just leave the `fixme` ones.

### What issues does this PR fix or reference?

It fixes issue 47156

### Previous Behavior

- Default connection improvements: on a Xen machine, the default connection was not `xen:///`, the user had to manually change it in the configuration.
- Per-function connection configuration: the user couldn't handle lxc domains with the virt module on a Xen or KVM enabled minion: the configuration was the only way to switch.

### New Behavior

- Default connection improvements: on a Xen machine, the default connection is automatically `xen:///`
- Per function connection configuration: the user can now configure an hypervisor as the default (say KVM or Xen) and still manage domains of another hypervisor like a remote one, or local LXC containers.

### Tests written?

No test added, but tests improved to fit the changes

### Docs written?

Changed where needed

### Commits signed with GPG?

Yes