### PR TITLE
Ensure we pass hexid as bytes when zmq_filtering enabled

### DIFF
--- a/salt/transport/zeromq.py
+++ b/salt/transport/zeromq.py
@@ -351,7 +351,10 @@ class AsyncZeroMQPubChannel(salt.transport.mixins.auth.AESPubClientMixin, salt.t
         if self.opts['zmq_filtering']:
             # TODO: constants file for "broadcast"
             self._socket.setsockopt(zmq.SUBSCRIBE, b'broadcast')
-            self._socket.setsockopt(zmq.SUBSCRIBE, self.hexid)
+            self._socket.setsockopt(
+                zmq.SUBSCRIBE,
+                salt.utils.stringutils.to_bytes(self.hexid)
+            )
         else:
             self._socket.setsockopt(zmq.SUBSCRIBE, b'')
 


### PR DESCRIPTION
When using hashlib and running `.hexdigest()`, a `str` type is returned.  It needs to be converted to a bytes type for the setsockopt a few lines below, if zmq_filtering is enabled and the master is running Python 3.

Inspired by https://github.com/saltstack/salt/pull/47242.