### PR TITLE
Fix the matching patterns in the CODEOWNERS file to use fnmatch patterns

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,43 +9,45 @@
 # See https://help.github.com/articles/about-codeowners/
 # for more info about the CODEOWNERS file
 
+# This file uses an fnmatch-style matching pattern.
+
 # Team Boto
 salt/**/*boto*                      @saltstack/team-boto
 
 # Team Core
-salt/auth/                          @saltstack/team-core
-salt/cache/                         @saltstack/team-core
-salt/cli/                           @saltstack/team-core
+salt/auth/*                         @saltstack/team-core
+salt/cache/*                        @saltstack/team-core
+salt/cli/*                          @saltstack/team-core
 salt/client/*                       @saltstack/team-core
 salt/config/*                       @saltstack/team-core
-salt/daemons/                       @saltstack/team-core
-salt/pillar/                        @saltstack/team-core
+salt/daemons/*                      @saltstack/team-core
+salt/pillar/*                       @saltstack/team-core
 salt/loader.py                      @saltstack/team-core
 salt/payload.py                     @saltstack/team-core
 salt/**/master*                     @saltstack/team-core
 salt/**/minion*                     @saltstack/team-core
 
 # Team Cloud
-salt/cloud/                         @saltstack/team-cloud
-salt/utils/openstack/               @saltstack/team-cloud
+salt/cloud/*                        @saltstack/team-cloud
+salt/utils/openstack/*              @saltstack/team-cloud
 salt/utils/aws.py                   @saltstack/team-cloud
 salt/**/*cloud*                     @saltstack/team-cloud
 
 # Team NetAPI
 salt/cli/api.py                     @saltstack/team-netapi
 salt/client/netapi.py               @saltstack/team-netapi
-salt/netapi/                        @saltstack/team-netapi
+salt/netapi/*                       @saltstack/team-netapi
 
 # Team Network
-salt/proxy/                         @saltstack/team-proxy
+salt/proxy/*                        @saltstack/team-proxy
 
 # Team SPM
 salt/cli/spm.py                     @saltstack/team-spm
-salt/spm/                           @saltstack/team-spm
+salt/spm/*                          @saltstack/team-spm
 
 # Team SSH
 salt/cli/ssh.py                     @saltstack/team-ssh
-salt/client/ssh/                    @saltstack/team-ssh
+salt/client/ssh/*                   @saltstack/team-ssh
 salt/runners/ssh.py                 @saltstack/team-ssh
 salt/**/thin.py                     @saltstack/team-ssh
 
@@ -61,7 +63,7 @@ salt/**/*xfs*                       @saltstack/team-suse
 salt/**/*zypper*                    @saltstack/team-suse
 
 # Team Transport
-salt/transport/                     @saltstack/team-transport
+salt/transport/*                    @saltstack/team-transport
 salt/utils/zeromq.py                @saltstack/team-transport
 
 # Team Windows


### PR DESCRIPTION
The CODEOWNERS file documentation for GitHub says they use a .gitignore-style file matching pattern. That's the style that was followed when this file was originally created. However, since [tamarack](https://github.com/rallytime/tamarack) is doing the actual team review requesting work, the file matching patterns need to be switched to using `fnmatch` instead. This is what [tamarack uses](https://github.com/rallytime/tamarack/blob/194eaa4d21d3594463c459e2908339e8a15e6ce7/tamarack/utils/prs.py#L133).

This PR updates some of the file matching patterns to use `fnmatch` more specifically and will improve the review requests to be more accurate and increase the number of automatic team review requests.

Fixes https://github.com/rallytime/tamarack/issues/17
