### PR TITLE
[salt.cloud.clouds.oneandone] Added block storage and ssh key support

### DIFF
--- a/doc/topics/cloud/oneandone.rst
+++ b/doc/topics/cloud/oneandone.rst
@@ -142,5 +142,23 @@ wait_for_timeout
     The timeout to wait in seconds for provisioning resources such as servers.
     The default wait_for_timeout is 15 minutes.
 
+public_key_ids
+    List of public key IDs (ssh key).
+
+Functions
+=========
+
+* Create an SSH key
+
+.. code-block:: bash
+
+    sudo salt-cloud -f create_ssh_key my-oneandone-config name='SaltTest' description='SaltTestDescription'
+
+* Create a block storage
+
+.. code-block:: bash
+
+    sudo salt-cloud -f create_block_storage my-oneandone-config name='SaltTest2' description='SaltTestDescription' size=50 datacenter_id='5091F6D8CBFEF9C26ACE957C652D5D49'
+
 For more information concerning cloud profiles, see :ref:`here
 <salt-cloud-profiles>`.


### PR DESCRIPTION
### What does this PR do?
This PR adds support for SSH key and block storage resources to 1and1 salt cloud module.

### Tests written?
No (Tested the behavior manually)

### Commits signed with GPG?
No