### PR TITLE
add macOS mac_service update.

### DIFF
--- a/salt/modules/mac_service.py
+++ b/salt/modules/mac_service.py
@@ -2,6 +2,24 @@
 '''
 The service module for macOS
 .. versionadded:: 2016.3.0
+
+This module has support for services in the following locations.
+
+.. code-block:: bash
+    /System/Library/LaunchDaemons/
+    /System/Library/LaunchAgents/
+    /Library/LaunchDaemons/
+    /Library/LaunchAgents/
+
+    # As of version "Fluorine" support for user-specific services were added.
+    /Users/foo/Library/LaunchAgents/
+
+.. note::
+
+    As of version "Fluorine", if a service is located in a ``LaunchAgent`` path
+    and a ``runas`` user is NOT specified the current console user will be used
+    to properly interact with the service.
+
 '''
 from __future__ import absolute_import, unicode_literals, print_function
 
@@ -128,6 +146,8 @@ def _get_domain_target(name, service_target=False):
     :return: Tuple of the domain/service target and the path to the service.
 
     :rtype: tuple
+
+    .. versionadded:: Fluorine
     '''
 
     # Get service information
@@ -158,15 +178,17 @@ def _launch_agent(name):
 
     :param str name: Service label, file name, or full path
 
-    :return: True if a LaunchAgent, False is not.
+    :return: True if a LaunchAgent, False if not.
 
     :rtype: bool
+
+    .. versionadded:: Fluorine
     '''
 
     # Get the path to the service.
     path = _get_service(name)['file_path']
 
-    if not 'LaunchAgents' in path:
+    if 'LaunchAgents' not in path:
         return False
     return True
 

--- a/salt/modules/mac_service.py
+++ b/salt/modules/mac_service.py
@@ -80,7 +80,7 @@ def _get_service(name):
     :return: The service information for the service, otherwise an Error
     :rtype: dict
     '''
-    services = salt.utils.mac_utils.available_services()
+    services = __utils__['mac_utils.available_services']()
     name = name.lower()
 
     if name in services:
@@ -162,7 +162,7 @@ def _get_domain_target(name, service_target=False):
     # check if a LaunchAgent as we should treat these differently.
     if 'LaunchAgents' in path:
         # Get the console user so we can service in the correct session
-        uid = salt.utils.mac_utils.console_user()
+        uid = __utils__['mac_utils.console_user']()
         domain_target = 'gui/{}'.format(uid)
 
     # check to see if we need to make it a full service target.
@@ -238,7 +238,7 @@ def launchctl(sub_cmd, *args, **kwargs):
 
         salt '*' service.launchctl debug org.cups.cupsd
     '''
-    return salt.utils.mac_utils.launchctl(sub_cmd, *args, **kwargs)
+    return __utils__['mac_utils.launchctl'](sub_cmd, *args, **kwargs)
 
 
 def list_(name=None, runas=None):
@@ -577,7 +577,7 @@ def get_all(runas=None):
     enabled = get_enabled(runas=runas)
 
     # Get list of all services
-    available = list(salt.utils.mac_utils.available_services().keys())
+    available = list(__utils__['mac_utils.available_services']().keys())
 
     # Return composite list
     return sorted(set(enabled + available))

--- a/salt/utils/mac_utils.py
+++ b/salt/utils/mac_utils.py
@@ -296,10 +296,13 @@ def _available_services():
         '/System/Library/LaunchDaemons',
     ]
 
-    for user in os.listdir('/Users/'):
-        agent_path = '/Users/{}/Library/LaunchAgents/'.format(user)
-        if os.path.isdir(agent_path):
-            launchd_paths.append(agent_path)
+    try:
+        for user in os.listdir('/Users/'):
+            agent_path = '/Users/{}/Library/LaunchAgents/'.format(user)
+            if os.path.isdir(agent_path):
+                launchd_paths.append(agent_path)
+    except OSError:
+        pass
 
     _available_services = dict()
     for launch_dir in launchd_paths:


### PR DESCRIPTION
### What does this PR do?
This PR adds support for using the latest macOS `launchctl` subcommands as well as the ability to manage user specific services. 

### Previous Behavior
Previously salt would use the legacy subcommands like `/bin/launchctl load/unload` to start and stop services. It was also not capable of modifying any user specific services located in `/Users/foo/Library/LaunchAgents/`

### New Behavior
Salt now leverages the latest subcommands `/bin/launchctl bootstrap/bootout` to start and stop services. Using these subcommands allows us to properly load and unload LauchAgents from root without having to run commands as the user as this is handled properly by `launchctl` when specifying to appropriate domain/system targets like `gui/501/` or `gui/501/com.apple.example.`

Salt also now looks for user specific services located in `/Users/foo/Library/LaunchAgents/` and is now capable of modifying them.

### Tests written?

No

### Commits signed with GPG?

Yes
