### PR TITLE
Role is not a list but a dictionary

### DIFF
--- a/salt/cloud/clouds/msazure.py
+++ b/salt/cloud/clouds/msazure.py
@@ -2043,9 +2043,10 @@ def list_input_endpoints(kwargs=None, conn=None, call=None):
 
     ret = {}
     for item in data:
-        if 'Role' not in item:
-            continue
-        for role in item['Role']:
+        if 'Role' in item:
+            role = item['Role']
+            if not isinstance(role, dict):
+                return ret
             input_endpoint = role['ConfigurationSets']['ConfigurationSet'].get('InputEndpoints', {}).get('InputEndpoint')
             if not input_endpoint:
                 continue
@@ -2053,6 +2054,7 @@ def list_input_endpoints(kwargs=None, conn=None, call=None):
                 input_endpoint = [input_endpoint]
             for endpoint in input_endpoint:
                 ret[endpoint['Name']] = endpoint
+            return ret
     return ret
 
 


### PR DESCRIPTION
### What does this PR do?
Checks if there is a Role key and make sure it's a dictionary so it could be parsed.

### What issues does this PR fix or reference?
Fixes a bug in salt cloud msazure:
```
input_endpoint = role['ConfigurationSets']['ConfigurationSet'].get('InputEndpoints', {}).get('InputEndpoint')
TypeError: string indices must be integers
``` 

### Previous Behavior
Not able to list or add input endpoints for azure classic

### New Behavior
Able to list and add input endpoints for azure classic

### Tests written?

No

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
