### PR TITLE
Updated confusing docstring for tcp_pub/pull_port in conf examples

### DIFF
--- a/conf/master
+++ b/conf/master
@@ -176,6 +176,14 @@
 # master event bus. The value is expressed in bytes.
 #max_event_size: 1048576
 
+# Windows platforms lack posix IPC and must rely on slower TCP based inter-
+# process communications. Set ipc_mode to 'tcp' on such systems
+#ipc_mode: ipc
+
+# Overwrite the default tcp ports used by the minion when ipc_mode is set to 'tcp'
+#tcp_master_pub_port: 4510
+#tcp_master_pull_port: 4511
+
 # By default, the master AES key rotates every 24 hours. The next command
 # following a key rotation will trigger a key refresh from the minion which may
 # result in minions which do not respond to the first command after a key refresh.

--- a/conf/minion
+++ b/conf/minion
@@ -380,7 +380,7 @@
 # process communications. Set ipc_mode to 'tcp' on such systems
 #ipc_mode: ipc
 
-# Overwrite the default tcp ports used by the minion when in tcp mode
+# Overwrite the default tcp ports used by the minion when ipc_mode is set to 'tcp'
 #tcp_pub_port: 4510
 #tcp_pull_port: 4511
 


### PR DESCRIPTION
### What does this PR do?
I've updated the confusing comment in the minion config example describing `tcp_pub_port` and `tcp_pull_port` config options that are only related to the previous one `ipc_mode` when it's set to `tcp`.
Also added description of the similar options for master config example.

### What issues does this PR fix or reference?
Related to #45185

### Tests written?
N/A

### Commits signed with GPG?
Yes