### PR TITLE
load rh_service for amazon linux not booted with systemd

### DIFF
--- a/salt/modules/rh_service.py
+++ b/salt/modules/rh_service.py
@@ -97,15 +97,6 @@ def __virtual__():
                     'RedHat-based distros >= version 7 use systemd, will not '
                     'load rh_service.py as virtual \'service\''
                 )
-        if __grains__['os'] == 'Amazon':
-            if int(osrelease_major) in (2016, 2017):
-                return __virtualname__
-            else:
-                return (
-                    False,
-                    'Amazon Linux >= version 2 uses systemd. Will not '
-                    'load rh_service.py as virtual \'service\''
-                )
         return __virtualname__
     return (False, 'Cannot load rh_service module: OS not in {0}'.format(enable))
 

--- a/salt/modules/rh_service.py
+++ b/salt/modules/rh_service.py
@@ -48,6 +48,10 @@ def __virtual__():
     Only work on select distros which still use Red Hat's /usr/bin/service for
     management of either sysvinit or a hybrid sysvinit/upstart init system.
     '''
+    # Disable when booted with systemd
+    if __utils__['systemd.booted'](__context__):
+        return (False, 'The rh_service execution module failed to load: this system was booted with systemd.')
+
     # Enable on these platforms only.
     enable = set((
         'XenServer',


### PR DESCRIPTION
### What does this PR do?
Amazon continues to release versions of Amazon Linux 1, which boots with
rh_service, but also Amazon linux 2, and both with the same versioning scheme,
so we cannot depend on the date for making decisions here.

### What issues does this PR fix or reference?
Fixes #47258

### Commits signed with GPG?

Yes