### PR TITLE
Add windows tests and reg module/state to CODEOWNERS file for team-windows

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -67,4 +67,8 @@ salt/transport/*                    @saltstack/team-transport
 salt/utils/zeromq.py                @saltstack/team-transport
 
 # Team Windows
-salt/**/*win*                       @saltstack/team-windows
+salt/*/*win*                        @saltstack/team-windows
+salt/modules/reg.py                 @saltstack/team-windows
+salt/states/reg.py                  @saltstack/team-windows
+tests/*/*win*                       @saltstack/team-windows
+tests/*/test_reg.py                 @saltstack/team-windows


### PR DESCRIPTION
`team-windows` should be requested for reviews whenever a windows test file or the reg.py execution module and accompanying reg.py state file are edited.