### PR TITLE
fix vpc_peering_connection_name option for create_route in boto_vpc module

### DIFF
--- a/salt/modules/boto_vpc.py
+++ b/salt/modules/boto_vpc.py
@@ -2302,10 +2302,10 @@ def create_route(route_table_id=None, destination_cidr_block=None,
                                   'must be provided.')
 
     if not _exactly_one((gateway_id, internet_gateway_name, instance_id, interface_id, vpc_peering_connection_id,
-                         nat_gateway_id, nat_gateway_subnet_id, nat_gateway_subnet_name)):
+                         nat_gateway_id, nat_gateway_subnet_id, nat_gateway_subnet_name, vpc_peering_connection_name)):
         raise SaltInvocationError('Only one of gateway_id, internet_gateway_name, instance_id, '
                                   'interface_id, vpc_peering_connection_id, nat_gateway_id, '
-                                  'nat_gateway_subnet_id or nat_gateway_subnet_name may be provided.')
+                                  'nat_gateway_subnet_id, nat_gateway_subnet_name or vpc_peering_connection_name may be provided.')
 
     if destination_cidr_block is None:
         raise SaltInvocationError('destination_cidr_block is required.')


### PR DESCRIPTION
All logic was there for use of vpc_peering_connection_name but it was missing from the _exactly_one conditional statement and the exception message

### What does this PR do?
Makes it possible to use vpc_peering_connection_name in the create_route function of the module boto_vpc

### What issues does this PR fix or reference?
Makes it possible to use vpc_peering_connection_name in the create_route function of the module boto_vpc

### Previous Behavior
If you tried to use vpc_peering_connection_name you would get the _exactly_one error

### New Behavior
Looks up the vpc based on name

### Tests written?

No

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
