### PR TITLE
Fix minion crash on NetBSD

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -449,7 +449,7 @@ def _bsd_memdata(osdata):
             mem = __salt__['cmd.run']('{0} -n hw.physmem64'.format(sysctl))
         grains['mem_total'] = int(mem) // 1024 // 1024
 
-        if osdata['kernel'] == 'OpenBSD':
+        if osdata['kernel'] in ['OpenBSD', 'NetBSD']:
             swapctl = salt.utils.path.which('swapctl')
             swap_total = __salt__['cmd.run']('{0} -sk'.format(swapctl)).split(' ')[1]
         else:


### PR DESCRIPTION
### What does this PR do?
Use swapctl instead of sysctl, in the core grain, to get the swap size, on NetBSD.

### Previous Behavior
Minion crashes when processing core grains.
<pre>Traceback (most recent call last):
  File "/usr/pkg/lib/python2.7/multiprocessing/process.py", line 258, in _bootstrap
    self.run()
  File "/usr/pkg/lib/python2.7/multiprocessing/process.py", line 114, in run
    self._target(*self._args, **self._kwargs)
  File "/usr/pkg/lib/python2.7/site-packages/salt/scripts.py", line 144, in minion_process
    minion.start()
  File "/usr/pkg/lib/python2.7/site-packages/salt/cli/daemons.py", line 348, in start
    self.minion.tune_in()
  File "/usr/pkg/lib/python2.7/site-packages/salt/minion.py", line 1023, in tune_in
    self._spawn_minions()
  File "/usr/pkg/lib/python2.7/site-packages/salt/minion.py", line 972, in _spawn_minions
    jid_queue=self.jid_queue,
  File "/usr/pkg/lib/python2.7/site-packages/salt/minion.py", line 953, in _create_minion_object
    jid_queue=jid_queue)
  File "/usr/pkg/lib/python2.7/site-packages/salt/minion.py", line 1093, in __init__
    self.opts['grains'] = salt.loader.grains(opts)
  File "/usr/pkg/lib/python2.7/site-packages/salt/loader.py", line 733, in grains
    ret = funcs[key]()
  File "/usr/pkg/lib/python2.7/site-packages/salt/grains/core.py", line 1784, in os_data
    grains.update(_memdata(grains))
  File "/usr/pkg/lib/python2.7/site-packages/salt/grains/core.py", line 509, in _memdata
    grains.update(_bsd_memdata(osdata))
  File "/usr/pkg/lib/python2.7/site-packages/salt/grains/core.py", line 458, in _bsd_memdata
    grains['swap_total'] = int(swap_total) // 1024 // 1024
ValueError: invalid literal for int() with base 10: "sysctl: second level name 'swap_total' in 'vm.swap_total' is invalid"</pre>

### New Behavior
Minion stays running

### Tests written?
No

### Commits signed with GPG?
No