### PR TITLE
Gracefully shutdown worker threads

### DIFF
--- a/salt/transport/tcp.py
+++ b/salt/transport/tcp.py
@@ -32,7 +32,7 @@ import salt.transport.client
 import salt.transport.server
 import salt.transport.mixins.auth
 import salt.ext.six as six
-from salt.ext.six.moves import queue
+from salt.ext.six.moves import queue  # pylint: disable=import-error
 from salt.exceptions import SaltReqTimeoutError, SaltClientError
 from salt.transport import iter_transport_opts
 

--- a/salt/transport/tcp.py
+++ b/salt/transport/tcp.py
@@ -563,7 +563,6 @@ class TCPReqServerChannel(salt.transport.mixins.auth.AESReqServerMixin, salt.tra
             except Exception as exc:
                 log.debug("TCPReqServerChannel close generated an exception: %s", str(exc))
 
-
     def __del__(self):
         self.close()
 

--- a/salt/transport/tcp.py
+++ b/salt/transport/tcp.py
@@ -545,8 +545,6 @@ class TCPReqServerChannel(salt.transport.mixins.auth.AESReqServerMixin, salt.tra
         return self._socket
 
     def close(self):
-        if hasattr(self.req_server, 'stop'):
-            self.req_server.stop()
         if self._socket is not None:
             try:
                 self._socket.shutdown(socket.SHUT_RDWR)
@@ -559,6 +557,8 @@ class TCPReqServerChannel(salt.transport.mixins.auth.AESReqServerMixin, salt.tra
                     raise exc
             self._socket.close()
             self._socket = None
+        if hasattr(self.req_server, 'stop'):
+            self.req_server.stop()
 
     def __del__(self):
         self.close()

--- a/salt/transport/tcp.py
+++ b/salt/transport/tcp.py
@@ -12,7 +12,6 @@ import logging
 import msgpack
 import socket
 import os
-import queue
 import weakref
 import time
 import traceback
@@ -33,6 +32,7 @@ import salt.transport.client
 import salt.transport.server
 import salt.transport.mixins.auth
 import salt.ext.six as six
+import salt.ext.six.moves import queue
 from salt.exceptions import SaltReqTimeoutError, SaltClientError
 from salt.transport import iter_transport_opts
 

--- a/salt/transport/tcp.py
+++ b/salt/transport/tcp.py
@@ -561,7 +561,7 @@ class TCPReqServerChannel(salt.transport.mixins.auth.AESReqServerMixin, salt.tra
             try:
                 self.req_server.stop()
             except Exception as exc:
-                log.debug("TCPReqServerChannel close generated an exception: %s" str(exc))
+                log.debug("TCPReqServerChannel close generated an exception: %s", str(exc))
 
 
     def __del__(self):

--- a/salt/transport/tcp.py
+++ b/salt/transport/tcp.py
@@ -32,7 +32,7 @@ import salt.transport.client
 import salt.transport.server
 import salt.transport.mixins.auth
 import salt.ext.six as six
-import salt.ext.six.moves import queue
+from salt.ext.six.moves import queue
 from salt.exceptions import SaltReqTimeoutError, SaltClientError
 from salt.transport import iter_transport_opts
 

--- a/salt/transport/tcp.py
+++ b/salt/transport/tcp.py
@@ -558,7 +558,11 @@ class TCPReqServerChannel(salt.transport.mixins.auth.AESReqServerMixin, salt.tra
             self._socket.close()
             self._socket = None
         if hasattr(self.req_server, 'stop'):
-            self.req_server.stop()
+            try:
+                self.req_server.stop()
+            except Exception as exc:
+                log.debug("TCPReqServerChannel close generated an exception: %s" str(exc))
+
 
     def __del__(self):
         self.close()


### PR DESCRIPTION
### What does this PR do?

Gracefully shutdown worker threads when TCPReqServerChannel is closed or destroyed.

### Previous Behavior

Running thread causes processes not to terminate.

### New Behavior

Threads will stop gracefully and processes will terminate as they should. This fixes the windows python 3 Jenkins build.

### Tests written?

No - Fixes test suite

### Commits signed with GPG?

No