### PR TITLE
make sure not to send invalid information

### DIFF
--- a/salt/modules/localemod.py
+++ b/salt/modules/localemod.py
@@ -87,7 +87,7 @@ def _localectl_status():
                         ret[ctl_key] = {}
                     ret[ctl_key][loc_set[0]] = loc_set[1]
             else:
-                ret[ctl_key] = {'data': ctl_data}
+                ret[ctl_key] = {'data': None if ctl_data == 'n/a' else ctl_data}
     if not ret:
         log.debug("Unable to find any locale information inside the following data:\n%s", locale_ctl_out)
         raise CommandExecutionError('Unable to parse result of "localectl"')
@@ -102,7 +102,7 @@ def _localectl_set(locale=''):
     '''
     locale_params = _parse_dbus_locale() if dbus is not None else _localectl_status().get('system_locale', {})
     locale_params['LANG'] = six.text_type(locale)
-    args = ' '.join(['{0}="{1}"'.format(k, v) for k, v in six.iteritems(locale_params)])
+    args = ' '.join(['{0}="{1}"'.format(k, v) for k, v in six.iteritems(locale_params) if v is not None])
     return not __salt__['cmd.retcode']('localectl set-locale {0}'.format(args), python_shell=False)
 
 

--- a/tests/unit/modules/test_localemod.py
+++ b/tests/unit/modules/test_localemod.py
@@ -86,7 +86,7 @@ class LocalemodTestCase(TestCase, LoaderModuleMockMixin):
         assert out['system_locale']['LANG'] == out['system_locale']['LANGUAGE'] == 'de_DE.utf8'
         assert isinstance(out['vc_keymap'], dict)
         assert 'data' in out['vc_keymap']
-        assert out['vc_keymap']['data'] == 'n/a'
+        assert out['vc_keymap']['data'] == None
         assert isinstance(out['x11_layout'], dict)
         assert 'data' in out['x11_layout']
         assert out['x11_layout']['data'] == 'us'
@@ -107,13 +107,13 @@ class LocalemodTestCase(TestCase, LoaderModuleMockMixin):
             assert key in out
         assert isinstance(out['system_locale'], dict)
         assert 'data' in out['system_locale']
-        assert out['system_locale']['data'] == 'n/a'
+        assert out['system_locale']['data'] == None
         assert isinstance(out['vc_keymap'], dict)
         assert 'data' in out['vc_keymap']
-        assert out['vc_keymap']['data'] == 'n/a'
+        assert out['vc_keymap']['data'] == None
         assert isinstance(out['x11_layout'], dict)
         assert 'data' in out['x11_layout']
-        assert out['x11_layout']['data'] == 'n/a'
+        assert out['x11_layout']['data'] == None
 
     @patch('salt.modules.localemod.dbus', MagicMock())
     def test_dbus_locale_parser_matches(self):

--- a/tests/unit/modules/test_localemod.py
+++ b/tests/unit/modules/test_localemod.py
@@ -86,7 +86,7 @@ class LocalemodTestCase(TestCase, LoaderModuleMockMixin):
         assert out['system_locale']['LANG'] == out['system_locale']['LANGUAGE'] == 'de_DE.utf8'
         assert isinstance(out['vc_keymap'], dict)
         assert 'data' in out['vc_keymap']
-        assert out['vc_keymap']['data'] == None
+        assert out['vc_keymap']['data'] is None
         assert isinstance(out['x11_layout'], dict)
         assert 'data' in out['x11_layout']
         assert out['x11_layout']['data'] == 'us'
@@ -107,13 +107,13 @@ class LocalemodTestCase(TestCase, LoaderModuleMockMixin):
             assert key in out
         assert isinstance(out['system_locale'], dict)
         assert 'data' in out['system_locale']
-        assert out['system_locale']['data'] == None
+        assert out['system_locale']['data'] is None
         assert isinstance(out['vc_keymap'], dict)
         assert 'data' in out['vc_keymap']
-        assert out['vc_keymap']['data'] == None
+        assert out['vc_keymap']['data'] is None
         assert isinstance(out['x11_layout'], dict)
         assert 'data' in out['x11_layout']
-        assert out['x11_layout']['data'] == None
+        assert out['x11_layout']['data'] is None
 
     @patch('salt.modules.localemod.dbus', MagicMock())
     def test_dbus_locale_parser_matches(self):


### PR DESCRIPTION
### What does this PR do?
Localectl outputs n/a sometimes when stuff is not set, instead of just not
outputting anything.  Actually put None in the variable when parsing it, and do
not add it to the localectl set command.

### What issues does this PR fix or reference?

Fixes #46862

### Tests written?

Yes

### Commits signed with GPG?

Yes