### PR TITLE
convert unicode ssh pass to str for azure

### DIFF
--- a/salt/cloud/clouds/azurearm.py
+++ b/salt/cloud/clouds/azurearm.py
@@ -1023,10 +1023,12 @@ def request_instance(vm_):
         default=False
     )
 
-    vm_password = config.get_cloud_config_value(
-        'ssh_password', vm_, __opts__, search_global=True,
-        default=config.get_cloud_config_value(
-            'win_password', vm_, __opts__, search_global=True
+    vm_password = salt.utils.stringutils.to_str(
+        config.get_cloud_config_value(
+            'ssh_password', vm_, __opts__, search_global=True,
+            default=config.get_cloud_config_value(
+                'win_password', vm_, __opts__, search_global=True
+            )
         )
     )
 


### PR DESCRIPTION
### What does this PR do?

Convert unicode text into a str so that the `vm_password` check doesn't fail. This is based on version `salt-cloud 2018.3.0-371-g71cf458 (Oxygen)`

### What issues does this PR fix or reference?

none

### Previous Behavior

Previously the error `Error: There was a profile error: The admin password must be a string.` would be displayed and VM creation would fail

### New Behavior

VM creation is successful

### Tests written?

No

### Commits signed with GPG?

Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
