### PR TITLE
Fix proxy minion beacon doc

### DIFF
--- a/doc/topics/proxyminion/beacon.rst
+++ b/doc/topics/proxyminion/beacon.rst
@@ -46,7 +46,9 @@ This should complete the proxy setup for ``p8000``
 
     beacons:
       salt_proxy:
-        - p8000: {}
+        - proxies:
+            p8000: {}
+            p8001: {}
 
 
 Once this beacon is configured it will automatically start the ``salt-proxy``

--- a/doc/topics/releases/2018.3.0.rst
+++ b/doc/topics/releases/2018.3.0.rst
@@ -495,7 +495,7 @@ pkg
 Significate changes have been made to the :mod:`win_pkg <salt.modules.win_pkg>` execution module. Users should test this release against their existing package sls definition files. These changes are also in 2016.11.9 & 2017.7.3.
 
 - ``pkg.list_available`` no longer defaults to refreshing the winrepo meta database.
-- ``pkg.install`` without a ``version`` parameter no longer upgrades software if the software is already installed. Use ``pkg.install version=latest`` or in a state use ``pkg.latest`` to get the old behavior. 
+- ``pkg.install`` without a ``version`` parameter no longer upgrades software if the software is already installed. Use ``pkg.install version=latest`` or in a state use ``pkg.latest`` to get the old behavior.
 - ``pkg.list_pkgs`` now returns multiple versions if software installed more than once.
 - ``pkg.list_pkgs`` now returns 'Not Found' when the version is not found instead of '(value not set)' which matches the contents of the sls definitions.
 - ``pkg.remove()`` will wait upto 3 seconds (normally about a second) to detect changes in the registry after removing software, improving reporting of version changes.
@@ -1220,10 +1220,11 @@ check the configuration for the correct format and only load if the validation p
         beacons:
           proxy_example:
             endpoint: beacon
-        ```
 
     New behavior:
-        ```
+
+    .. code-block:: yaml
+
         beacons:
           proxy_example:
             - endpoint: beacon


### PR DESCRIPTION
### What does this PR do?
* Fixes salt-proxy beacon yaml example in https://docs.saltstack.com/en/latest/topics/proxyminion/beacon.html
* Fixes proxy_example beacon yaml example for 2018.3 release notes in:
https://docs.saltstack.com/en/latest/topics/releases/2018.3.0.html#beacon-configuration-changes

### What issues does this PR fix or reference?
Related documentation to https://github.com/saltstack/salt/issues/47239

### Tests written?
No

### Commits signed with GPG?
Yes