### PR TITLE
Fix error logging during network interface querying (fqdn)

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1934,7 +1934,7 @@ def fqdns():
         try:
             fqdns.add(socket.getfqdn(socket.gethostbyaddr(ip)[0]))
         except socket.herror as err:
-            if err.errno == 1:
+            if err.errno == 0:
                 # No FQDN for this IP address, so we don't need to know this all the time.
                 log.debug("Unable to resolve address %s: %s", ip, err)
             else:


### PR DESCRIPTION
### What does this PR do?
This PR fixes a wrong "errno" value used to avoid executing `log.error` when FQDN cannot be resolved for the system IP. 

The `socket.herror` exception has `errno = 0` (not 1) when resolution fails.

### Previous Behavior

```
2018-04-25 09:27:56,726 [salt.core.grains:1937][ERROR   ][685] Unable to resolve address 123.123.123.123: [Errno 0] Resolver Error 0 (no error)
```

### New Behavior

This particular exception message is not longer logged as ERROR but as a DEBUG message.

### Tests written?

No

### Commits signed with GPG?

Yes

/cc @brejoc 