### PR TITLE
Added clarity on oldest supported main release branch

### DIFF
--- a/doc/topics/development/contributing.rst
+++ b/doc/topics/development/contributing.rst
@@ -60,7 +60,7 @@ Fork a Repo Guide_>`_ and is well worth reading.
         isolated into separate branches.
 
     If you're working on a bug or documentation fix, create your branch from
-    the oldest release branch that contains the bug or requires the documentation
+    the oldest **supported** main release branch that contains the bug or requires the documentation
     update. See :ref:`Which Salt Branch? <which-salt-branch>`.
 
     .. code-block:: bash
@@ -212,8 +212,11 @@ There are three different kinds of branches in use: develop, main release
 branches, and dot release branches.
 
 - All feature work should go into the ``develop`` branch.
-- Bug fixes and documentation changes should go into the oldest supported
-  **main** release branch affected by the the bug or documentation change.
+- Bug fixes and documentation changes should go into the oldest **supported
+  main** release branch affected by the the bug or documentation change (you
+  can use the blame button in github to figure out when the bug was introduced).
+  Supported releases are the last 2 releases. For example, if the latest release
+  is 2018.3, the last two release are 2018.3 and 2017.7.
   Main release branches are named after a year and month, such as
   ``2016.11`` and ``2017.7``.
 - Hot fixes, as determined by SaltStack's release team, should be submitted
@@ -247,7 +250,7 @@ Main Release Branches
 =====================
 
 The current release branch is the most recent stable release. Pull requests
-containing bug fixes or documentation changes should be made against the main
+containing bug fixes or documentation changes should be made against the oldest supported main
 release branch that is affected.
 
 The branch name will be a date-based name such as ``2016.11``.


### PR DESCRIPTION
added clarity on how to figure out what is the oldest supported main release branch

### What does this PR do?
added clarity on how to figure out what is the oldest supported main release branch
### What issues does this PR fix or reference?
added clarity on how to figure out what is the oldest supported main release branch
### Previous Behavior
No way to know what the oldest supported main release branch is 

### Tests written?

No

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
