### PR TITLE
Pass timeout to salt CLI for tests

### DIFF
--- a/tests/support/case.py
+++ b/tests/support/case.py
@@ -121,7 +121,7 @@ class ShellTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
                     data = '\n'.join(data)
                     self.assertIn('minion', data)
         '''
-        arg_str = '-c {0} {1}'.format(self.get_config_dir(), arg_str)
+        arg_str = '-c {0} -t {1} {2}'.format(self.get_config_dir(), timeout, arg_str)
         return self.run_script('salt', arg_str, with_retcode=with_retcode, catch_stderr=catch_stderr, timeout=timeout)
 
     def run_ssh(self, arg_str, with_retcode=False, timeout=25,


### PR DESCRIPTION
This should hopefully fix up the race condition in the long-running
jobs test.

