### PR TITLE
[develop] Fixing unit.engines.test_libvirt_events.test_create_register

### DIFF
--- a/tests/unit/engines/test_libvirt_events.py
+++ b/tests/unit/engines/test_libvirt_events.py
@@ -87,6 +87,9 @@ class EngineLibvirtEventTestCase(TestCase, LoaderModuleMockMixin):
         mock_cnx = MagicMock()
         mock_libvirt.openReadOnly.return_value = mock_cnx
 
+        # Don't loop for ever
+        mock_libvirt.virEventRunDefaultImpl.return_value = -1
+
         mock_cnx.networkEventRegisterAny.return_value = 10000
 
         libvirt_events.start('test:///', 'test/prefix')


### PR DESCRIPTION
### What does this PR do?
Fixing unit.engines.test_libvirt_events.test_event_register to ensure the return value is correct and the engine does not loop forever.

### What issues does this PR fix or reference?
N/A

### Tests written?
Yes.  Existing tests updated.

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
