### PR TITLE
Do not join a thread that is stopped

### DIFF
--- a/salt/transport/tcp.py
+++ b/salt/transport/tcp.py
@@ -558,7 +558,10 @@ class TCPReqServerChannel(salt.transport.mixins.auth.AESReqServerMixin, salt.tra
             self._socket.close()
             self._socket = None
         if hasattr(self.req_server, 'stop'):
-            self.req_server.stop()
+            try:
+                self.req_server.stop()
+            except Exception as exc:
+                log.exception('TCPReqServerChannel close generated an exception: %s', str(exc))
 
     def __del__(self):
         self.close()
@@ -750,9 +753,8 @@ if USE_LOAD_BALANCER:
             self.thread.start()
 
         def stop(self):
-            if self.thread.is_alive():
-                self._stop.set()
-                self.thread.join()
+            self._stop.set()
+            self.thread.join()
 
         def socket_queue_thread(self):
             try:

--- a/salt/transport/tcp.py
+++ b/salt/transport/tcp.py
@@ -558,10 +558,7 @@ class TCPReqServerChannel(salt.transport.mixins.auth.AESReqServerMixin, salt.tra
             self._socket.close()
             self._socket = None
         if hasattr(self.req_server, 'stop'):
-            try:
-                self.req_server.stop()
-            except Exception as exc:
-                log.debug("TCPReqServerChannel close generated an exception: %s", str(exc))
+            self.req_server.stop()
 
     def __del__(self):
         self.close()
@@ -753,8 +750,9 @@ if USE_LOAD_BALANCER:
             self.thread.start()
 
         def stop(self):
-            self._stop.set()
-            self.thread.join()
+            if self.thread.is_alive():
+                self._stop.set()
+                self.thread.join()
 
         def socket_queue_thread(self):
             try:


### PR DESCRIPTION

### What does this PR do?

Remove the need for exception handling by not raising exceptions in the
first place.

### What issues does this PR fix or reference?

Follow up PR to #47279

### Previous Behavior

Multiple calls to `LoadBalancedWorker.stop` would raise exceptions

### New Behavior

The stop method can be called multiple times without raising exceptions. This remove the need for special exception handling elsewhere.

### Tests written?

No - Covered by multiple existing tests

### Commits signed with GPG?

Yes