### PR TITLE
Skip unix group tests on windows.

### DIFF
--- a/tests/integration/modules/test_groupadd.py
+++ b/tests/integration/modules/test_groupadd.py
@@ -128,6 +128,7 @@ class GroupModuleTest(ModuleCase):
             self.assertFalse(self.run_function('group.add', [self._group], gid=self._gid))
 
     @destructiveTest
+    @skipIf(salt.utils.platform.is_windows(), 'Skip on Windows')
     def test_add_system_group(self):
         '''
         Test the add group function with system=True
@@ -146,6 +147,7 @@ class GroupModuleTest(ModuleCase):
                                            [self._group]))
 
     @destructiveTest
+    @skipIf(salt.utils.platform.is_windows(), 'Skip on Windows')
     def test_add_system_group_gid(self):
         '''
         Test the add group function with system=True and a specific gid


### PR DESCRIPTION
### What does this PR do?

Skip tests that read from `/etc/login.defs` when running on Windows

https://jenkinsci.saltstack.com/job/2018.3/job/salt-windows-2016-py2/33/testReport/

### What issues does this PR fix or reference?

Fixes 2018.3 failing builds

### Commits signed with GPG?

Yes