### PR TITLE
Some Redis fixes

### DIFF
--- a/salt/cache/redis_cache.py
+++ b/salt/cache/redis_cache.py
@@ -205,6 +205,7 @@ def _get_redis_cache_opts():
     return {
         'host': __opts__.get('cache.redis.host', 'localhost'),
         'port': __opts__.get('cache.redis.port', 6379),
+        'unix_socket_path': __opts__.get('cache.redis.unix_socket_path', None),
         'db': __opts__.get('cache.redis.db', '0'),
         'password': __opts__.get('cache.redis.password', ''),
         'cluster_mode': __opts__.get('cache.redis.cluster_mode', False),
@@ -231,6 +232,7 @@ def _get_redis_server(opts=None):
     else:
         REDIS_SERVER = redis.StrictRedis(opts['host'],
                                    opts['port'],
+                                   unix_socket_path=opts['unix_socket_path'],
                                    db=opts['db'],
                                    password=opts['password'])
     return REDIS_SERVER

--- a/salt/cache/redis_cache.py
+++ b/salt/cache/redis_cache.py
@@ -74,7 +74,7 @@ cluster.startup_nodes:
     A list of host, port dictionaries pointing to cluster members. At least one is required
     but multiple nodes are better
 
-    .. code-block::yaml
+    .. code-block:: yaml
 
         cache.redis.cluster.startup_nodes
           - host: redis-member-1
@@ -102,7 +102,7 @@ password:
 
 Configuration Example:
 
-.. code-block::yaml
+.. code-block:: yaml
 
     cache.redis.host: localhost
     cache.redis.port: 6379
@@ -115,7 +115,7 @@ Configuration Example:
 
 Cluster Configuration Example:
 
-.. code-block::yaml
+.. code-block:: yaml
 
     cache.redis.cluster_mode: true
     cache.redis.cluster.skip_full_coverage_check: true

--- a/salt/cache/redis_cache.py
+++ b/salt/cache/redis_cache.py
@@ -100,6 +100,12 @@ db: ``'0'``
 password:
     Redis connection password.
 
+unix_socket_path:
+
+    .. versionadded:: 2018.3.1
+
+    Path to a UNIX socket for access. Overrides `host` / `port`.
+
 Configuration Example:
 
 .. code-block:: yaml

--- a/salt/returners/redis_return.py
+++ b/salt/returners/redis_return.py
@@ -14,7 +14,7 @@ config, these are the defaults:
 
 Cluster Mode Example:
 
-.. code-block::yaml
+.. code-block:: yaml
 
     redis.db: '0'
     redis.cluster_mode: true
@@ -66,7 +66,7 @@ cluster.startup_nodes:
     A list of host, port dictionaries pointing to cluster members. At least one is required
     but multiple nodes are better
 
-    .. code-block::yaml
+    .. code-block:: yaml
 
         cache.redis.cluster.startup_nodes
           - host: redis-member-1
@@ -139,7 +139,7 @@ def _get_options(ret=None):
              'cluster_mode': 'cluster_mode',
              'startup_nodes': 'cluster.startup_nodes',
              'skip_full_coverage_check': 'cluster.skip_full_coverage_check',
-        }
+             }
 
     if salt.utils.platform.is_proxy():
         return {

--- a/salt/returners/redis_return.py
+++ b/salt/returners/redis_return.py
@@ -124,7 +124,7 @@ def __virtual__():
     if not HAS_REDIS:
         return False, 'Could not import redis returner; ' \
                       'redis python client is not installed.'
-    if not HAS_REDIS_CLUSTER and _get_options()['cluster_mode']:
+    if not HAS_REDIS_CLUSTER and _get_options().get('cluster_mode', False):
         return (False, "Please install the redis-py-cluster package.")
     return __virtualname__
 

--- a/salt/returners/redis_return.py
+++ b/salt/returners/redis_return.py
@@ -12,6 +12,15 @@ config, these are the defaults:
     redis.host: 'salt'
     redis.port: 6379
 
+.. versionadded:: 2018.3.1
+
+    Alternatively a UNIX socket can be specified by `unix_socket_path`:
+
+.. code-block:: yaml
+
+    redis.db: '0'
+    redis.unix_socket_path: /var/run/redis/redis.sock
+
 Cluster Mode Example:
 
 .. code-block:: yaml


### PR DESCRIPTION
### What does this PR do?
Assortment of small fixes to the Redis cache & returner

### Previous Behavior
* `KeyError` stacktrace during module loading if `cluster_mode` not in conf
* doc generation skips certain codeblocks
* can't use UNIX sockets

### New Behavior
* `cluster_mode` defaults to False for `__virtual__`
* all doc blocks render correctly
* can use `unix_socket_path` to access Redis through socket 

For `redis_return` I had to refactor the pool code a bit, it now looks *amazingly* similar to the one in `redis_cache`. Fancy that ;) maybe it should be in `utils` so all Redis share the same codebase?  
