### PR TITLE
salt.returners.pgjsonb: update jids row on conflict

### DIFF
--- a/salt/returners/pgjsonb.py
+++ b/salt/returners/pgjsonb.py
@@ -191,6 +191,7 @@ __virtualname__ = 'pgjsonb'
 
 PG_SAVE_LOAD_SQL = '''INSERT INTO jids (jid, load) VALUES (%(jid)s, %(load)s)'''
 
+
 def __virtual__():
     if not HAS_PG:
         return False, 'Could not import pgjsonb returner; python-psycopg2 is not installed.'

--- a/salt/returners/pgjsonb.py
+++ b/salt/returners/pgjsonb.py
@@ -189,6 +189,7 @@ log = logging.getLogger(__name__)
 # Define the module's virtual name
 __virtualname__ = 'pgjsonb'
 
+PG_SAVE_LOAD_SQL = '''INSERT INTO jids (jid, load) VALUES (%(jid)s, %(load)s)'''
 
 def __virtual__():
     if not HAS_PG:
@@ -257,6 +258,14 @@ def _get_serv(ret=None, commit=False):
     except psycopg2.OperationalError as exc:
         raise salt.exceptions.SaltMasterError('pgjsonb returner could not connect to database: {exc}'.format(exc=exc))
 
+    if conn.server_version is not None or conn.server_version >= 90500:
+        global PG_SAVE_LOAD_SQL
+        PG_SAVE_LOAD_SQL = '''INSERT INTO jids
+                              (jid, load)
+                              VALUES (%(jid)s, %(load)s)
+                              ON CONFLICT (jid) DO UPDATE
+                              SET load=%(load)s'''
+
     cursor = conn.cursor()
 
     try:
@@ -317,13 +326,9 @@ def save_load(jid, load, minions=None):
     Save the load to the specified jid id
     '''
     with _get_serv(commit=True) as cur:
-
-        sql = '''INSERT INTO jids
-               (jid, load)
-                VALUES (%s, %s)'''
-
         try:
-            cur.execute(sql, (jid, psycopg2.extras.Json(load)))
+            cur.execute(PG_SAVE_LOAD_SQL,
+                        {'jid': jid, 'load': psycopg2.extras.Json(load)})
         except psycopg2.IntegrityError:
             # https://github.com/saltstack/salt/issues/22171
             # Without this try:except: we get tons of duplicate entry errors

--- a/salt/returners/pgjsonb.py
+++ b/salt/returners/pgjsonb.py
@@ -258,7 +258,7 @@ def _get_serv(ret=None, commit=False):
     except psycopg2.OperationalError as exc:
         raise salt.exceptions.SaltMasterError('pgjsonb returner could not connect to database: {exc}'.format(exc=exc))
 
-    if conn.server_version is not None or conn.server_version >= 90500:
+    if conn.server_version is not None and conn.server_version >= 90500:
         global PG_SAVE_LOAD_SQL
         PG_SAVE_LOAD_SQL = '''INSERT INTO jids
                               (jid, load)


### PR DESCRIPTION
### What does this PR do?

* salt/returners/pgjsonb.py: add “ON CONFLICT” clause to the “INSERT”
  to update the “load” column when the jid is already registered.
  Use named placeholders in SQL statement.

### What issues does this PR fix or reference?

This commit fix #47327.

### Previous Behavior
I had errors in PostgreSQL logs

```
ERROR:  duplicate key value violates unique constraint "jids_pkey"
DETAIL:  Key (jid)=(20180426141333546550) already exists.
STATEMENT:  INSERT INTO jids (jid, load) VALUES ('20180426141333546550', '{"fun_args": [], "jid": "20180426141333546550", "return": true, "retcode": 0, "success": true, "cmd": "_return", "_stamp": "2018-04-26T14:13:33.758033", "fun": "test.ping", "id": "5"}')
```

### New Behavior
I have no errors in PostgreSQL logs.

### Tests written?

No, I don't know how to test this.

### Commits signed with GPG?

Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
