### PR TITLE
Remove un-needed string-escape

### DIFF
--- a/tests/unit/modules/test_pip.py
+++ b/tests/unit/modules/test_pip.py
@@ -300,7 +300,7 @@ class PipTestCase(TestCase, LoaderModuleMockMixin):
             with patch.dict(pip.__salt__, {'cmd.run_all': mock}):
                 if salt.utils.is_windows():
                     venv_path = 'c:\\test_env'
-                    bin_path = os.path.join(venv_path, 'Scripts', 'pip.exe').encode('string-escape')
+                    bin_path = os.path.join(venv_path, 'Scripts', 'pip.exe')
                 else:
                     venv_path = '/test_env'
                     bin_path = os.path.join(venv_path, 'bin', 'pip')


### PR DESCRIPTION
### What does this PR do?

Removes un-needed string-escape call. Fixing:

https://jenkinsci.saltstack.com/job/2017.7/view/Python3/job/salt-windows-2016-py3/4/testReport/junit/unit.modules.test_pip/PipTestCase/test_install_venv/

### Tests written?

No - Fixes existing test

### Commits signed with GPG?

Yes