### PR TITLE
Use salt.utils.fopen for line ending consistancy

### DIFF
--- a/tests/unit/modules/test_ssh.py
+++ b/tests/unit/modules/test_ssh.py
@@ -93,10 +93,8 @@ class SSHAuthKeyTestCase(TestCase, LoaderModuleMockMixin):
         comment_line = '# this is a comment \n'
 
         # Write out the authorized key to a temporary file
-        if salt.utils.is_windows():
-            temp_file = tempfile.NamedTemporaryFile(delete=False)
-        else:
-            temp_file = tempfile.NamedTemporaryFile(delete=False, mode='w+')
+        temp_file = tempfile.NamedTemporaryFile(delete=False, mode='w+')
+        temp_file.close()
 
         with salt.utils.fopen(temp_file.name, 'w') as _fh:
             # Add comment

--- a/tests/unit/modules/test_ssh.py
+++ b/tests/unit/modules/test_ssh.py
@@ -102,7 +102,6 @@ class SSHAuthKeyTestCase(TestCase, LoaderModuleMockMixin):
             # Add empty line for #41335
             _fh.write(empty_line)
             _fh.write('{0} {1} {2} {3}'.format(options, enc, key, email))
-            _fh.close()
 
         with patch.dict(ssh.__salt__, {'user.info': MagicMock(return_value={})}):
             with patch('salt.modules.ssh._get_config_file', MagicMock(return_value=temp_file.name)):

--- a/tests/unit/modules/test_ssh.py
+++ b/tests/unit/modules/test_ssh.py
@@ -98,12 +98,13 @@ class SSHAuthKeyTestCase(TestCase, LoaderModuleMockMixin):
         else:
             temp_file = tempfile.NamedTemporaryFile(delete=False, mode='w+')
 
-        # Add comment
-        temp_file.write(comment_line)
-        # Add empty line for #41335
-        temp_file.write(empty_line)
-        temp_file.write('{0} {1} {2} {3}'.format(options, enc, key, email))
-        temp_file.close()
+        with salt.utils.fopen(temp_file.name, 'w') as _fh:
+            # Add comment
+            _fh.write(comment_line)
+            # Add empty line for #41335
+            _fh.write(empty_line)
+            _fh.write('{0} {1} {2} {3}'.format(options, enc, key, email))
+            _fh.close()
 
         with patch.dict(ssh.__salt__, {'user.info': MagicMock(return_value={})}):
             with patch('salt.modules.ssh._get_config_file', MagicMock(return_value=temp_file.name)):


### PR DESCRIPTION
### What does this PR do?

Fixes failing python 3 test case on windows.

https://jenkinsci.saltstack.com/job/2017.7/view/Python3/job/salt-windows-2016-py3/4/testReport/junit/unit.modules.test_ssh/SSHAuthKeyTestCase/test_replace_auth_key/


### Tests written?

No - Fix existing test

### Commits signed with GPG?

Yes