### PR TITLE
Added masterless support to utils/minions.py:_pki_minions function

### DIFF
--- a/salt/utils/minions.py
+++ b/salt/utils/minions.py
@@ -243,6 +243,8 @@ class CkMinions(object):
             # Compiling pillar directly on the master, just return the master's
             # ID as that is the only one that is available.
             return [self.opts['id']]
+        if self.opts.get('__role') == 'minion': # Return self if running masterless
+            return [self.opts['id']]
         minions = []
         pki_cache_fn = os.path.join(self.opts['pki_dir'], self.acc, '.key_cache')
         try:


### PR DESCRIPTION
### What does this PR do?
Adds support to utils/minions.py's _pki_minions function for masterless calls

### What issues does this PR fix or reference?
No known issues/pr open related to this but I ran into this being an issue when using ext_pillar & file_tree on a masterless dev. environment. The file_tree module would use the minions utility library to get all minions / nodegroups from PKI files which don't exist on the masterless minion.

### Previous Behavior
```
$ salt-call --local pillar.get nodegroups 
[ERROR   ] Failed matching available minions with compound pattern: *
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/salt/utils/minions.py", line 684, in check_minions
    _res = check_func(expr, delimiter, greedy)
  File "/usr/lib/python2.7/site-packages/salt/utils/minions.py", line 476, in _check_compound_minions
    minions = set(self._pki_minions())
  File "/usr/lib/python2.7/site-packages/salt/utils/minions.py", line 250, in _pki_minions
    if self.opts['key_cache'] and os.path.exists(pki_cache_fn):
KeyError: u'key_cache'
```

### Tests written?
No

### Commits signed with GPG?
Yes
