### PR TITLE
Fix python 3 support for inet_pton function

### DIFF
--- a/salt/ext/win_inet_pton.py
+++ b/salt/ext/win_inet_pton.py
@@ -56,7 +56,7 @@ def inet_pton(address_family, ip_string):
     addr_size = ctypes.c_int(ctypes.sizeof(addr))
 
     if WSAStringToAddressA(
-            ip_string,
+            ip_string.encode('ascii'),
             address_family,
             None,
             ctypes.byref(addr),


### PR DESCRIPTION
### What does this PR do?

Encode addresses before passing them to `WSAStringToAddress`.
Fixes: https://jenkinsci.saltstack.com/job/2017.7/view/Python3/job/salt-windows-2016-py3/4/testReport/junit/unit.utils.test_validate_net/ValidateNetTestCase/test_ipv6_addr/


### Tests written?

No - Fixing existing test

### Commits signed with GPG?

Yes