### PR TITLE
Fix mysql test cases

### DIFF
--- a/tests/unit/pillar/test_mysql.py
+++ b/tests/unit/pillar/test_mysql.py
@@ -11,6 +11,16 @@ from tests.support.mock import NO_MOCK, NO_MOCK_REASON
 import salt.pillar.mysql as mysql
 
 
+def sorted_result(result):
+    sorted_result = {}
+    for x in result:
+        sorted_result[x] = sorted(result[x])
+        for y in sorted_result[x]:
+            for z in y:
+                y[z] = sorted(y[z])
+    return sorted_result
+
+
 @skipIf(NO_MOCK, NO_MOCK_REASON)
 @skipIf(not mysql.HAS_MYSQL, 'Install MySQL bindings before running MySQL unit tests.')
 class MysqlPillarTestCase(TestCase):
@@ -541,7 +551,7 @@ class MysqlPillarTestCase(TestCase):
                       ]
                   }
             ]},
-             return_data.result
+             sorted_result(return_data.result)
         )
 
     def test_302_process_results_with_lists_consecutive(self):
@@ -566,5 +576,5 @@ class MysqlPillarTestCase(TestCase):
                       ]
                   ]
             ]},
-             return_data.result
+             sorted_result(return_data.result)
         )


### PR DESCRIPTION
### What does this PR do?

Sort mysql results so tests pass consistently.
Fixes:
https://jenkinsci.saltstack.com/job/2017.7/view/Python3/job/salt-windows-2016-py3/4/testReport/junit/unit.pillar.test_mysql/MysqlPillarTestCase/test_301_process_results_with_lists/ 

### Tests written?

No - Fixing existing tests

### Commits signed with GPG?

Yes