### PR TITLE
Proper fix for mysql tests

### DIFF
--- a/tests/unit/pillar/test_mysql.py
+++ b/tests/unit/pillar/test_mysql.py
@@ -614,10 +614,10 @@ class MysqlPillarTestCase(TestCase):
                 for y in x[0]:
                     if 'j' in y:
                         assert len(y.keys()) == 2
-                        y['j'] == 3
+                        assert y['j'] == 3
                     elif 'k' in y:
                         assert len(y.keys()) == 2
-                        y['k'] == 4
+                        assert y['k'] == 4
                     else:
                         raise ValueError(
                             "Unexpected value {0}".format(len(x[0][0]))

--- a/tests/unit/pillar/test_mysql.py
+++ b/tests/unit/pillar/test_mysql.py
@@ -556,7 +556,7 @@ class MysqlPillarTestCase(TestCase):
                         assert list(y.keys()) == ['g']
                         assert y['g'] == 2
                     else:
-                        raise ValueError("Unexpected value %s" % y)
+                        raise ValueError("Unexpected value {0}".format(y))
             elif 'h' in x:
                 assert len(x['h']) == 1
                 for y in x['h']:
@@ -567,9 +567,9 @@ class MysqlPillarTestCase(TestCase):
                         assert len(y.keys()) == 2
                         assert y['k'] == 4
                     else:
-                        raise ValueError("Unexpected value %s" % y)
+                        raise ValueError("Unexpected value {0}".format(y))
             else:
-                raise ValueError("Unexpected value %s" % x)
+                raise ValueError("Unexpected value {0}".format(x))
 
     def test_302_process_results_with_lists_consecutive(self):
         '''
@@ -609,7 +609,7 @@ class MysqlPillarTestCase(TestCase):
                         assert list(y.keys()) == ['g']
                         assert y['g'] == 2
                     else:
-                        raise ValueError("Unexpected value %s" % y)
+                        raise ValueError("Unexpected value {0}".format(y))
             elif len(x[0][0]) == 2:
                 for y in x[0]:
                     if 'j' in y:
@@ -619,6 +619,8 @@ class MysqlPillarTestCase(TestCase):
                         assert len(y.keys()) == 2
                         y['k'] == 4
                     else:
-                        raise ValueError("Unexpected value %s" % len(x[0][0]))
+                        raise ValueError(
+                            "Unexpected value {0}".format(len(x[0][0]))
+                        )
             else:
-                raise ValueError("Unexpected value %s" % x)
+                raise ValueError("Unexpected value {0}".format(x))

--- a/tests/unit/pillar/test_mysql.py
+++ b/tests/unit/pillar/test_mysql.py
@@ -11,16 +11,6 @@ from tests.support.mock import NO_MOCK, NO_MOCK_REASON
 import salt.pillar.mysql as mysql
 
 
-def sorted_result(result):
-    sorted_result = {}
-    for x in result:
-        sorted_result[x] = sorted(result[x])
-        for y in sorted_result[x]:
-            for z in y:
-                y[z] = sorted(y[z])
-    return sorted_result
-
-
 @skipIf(NO_MOCK, NO_MOCK_REASON)
 @skipIf(not mysql.HAS_MYSQL, 'Install MySQL bindings before running MySQL unit tests.')
 class MysqlPillarTestCase(TestCase):
@@ -530,6 +520,21 @@ class MysqlPillarTestCase(TestCase):
         )
 
     def test_301_process_results_with_lists(self):
+        '''
+        Validates the following results:
+
+          {'a': [
+                {'c': [
+                    {'e': 1},
+                    {'g': 2}
+                    ]
+                },
+                {'h': [
+                    {'j': 3, 'k': 4}
+                    ]
+                }
+          ]}
+        '''
         return_data = mysql.MySQLExtPillar()
         return_data.as_list = False
         return_data.with_lists = [1, 3]
@@ -539,22 +544,49 @@ class MysqlPillarTestCase(TestCase):
                                      ['a', 'b', 'c', 'f', 'g', 2],
                                      ['a', 'z', 'h', 'y', 'j', 3],
                                      ['a', 'z', 'h', 'y', 'k', 4]])
-        self.assertEqual(
-            {'a': [
-                  {'c': [
-                      {'e': 1},
-                      {'g': 2}
-                      ]
-                  },
-                  {'h': [
-                      {'j': 3, 'k': 4}
-                      ]
-                  }
-            ]},
-             sorted_result(return_data.result)
-        )
+        assert 'a' in return_data.result
+        for x in return_data.result['a']:
+            if 'c' in x:
+                assert list(x.keys()) == ['c'], x.keys()
+                for y in x['c']:
+                    if 'e' in y:
+                        assert list(y.keys()) == ['e']
+                        assert y['e'] == 1
+                    elif 'g' in y:
+                        assert list(y.keys()) == ['g']
+                        assert y['g'] == 2
+                    else:
+                        raise ValueError("Unexpected value %s" % y)
+            elif 'h' in x:
+                assert len(x['h']) == 1
+                for y in x['h']:
+                    if 'j' in y:
+                        assert len(y.keys()) == 2
+                        assert y['j'] == 3
+                    elif 'h' in y:
+                        assert len(y.keys()) == 2
+                        assert y['k'] == 4
+                    else:
+                        raise ValueError("Unexpected value %s" % y)
+            else:
+                raise ValueError("Unexpected value %s" % x)
 
     def test_302_process_results_with_lists_consecutive(self):
+        '''
+        Validates the following results:
+
+          {'a': [
+                [[
+                    {'e': 1},
+                    {'g': 2}
+                    ]
+                ],
+                [[
+                    {'j': 3, 'k': 4}
+                    ]
+                ]
+          ]}
+        '''
         return_data = mysql.MySQLExtPillar()
         return_data.as_list = False
         return_data.with_lists = [1, 2, 3]
@@ -564,17 +596,29 @@ class MysqlPillarTestCase(TestCase):
                                      ['a', 'b', 'c', 'f', 'g', 2],
                                      ['a', 'z', 'h', 'y', 'j', 3],
                                      ['a', 'z', 'h', 'y', 'k', 4]])
-        self.assertEqual(
-            {'a': [
-                  [[
-                      {'e': 1},
-                      {'g': 2}
-                      ]
-                  ],
-                  [[
-                      {'j': 3, 'k': 4}
-                      ]
-                  ]
-            ]},
-             sorted_result(return_data.result)
-        )
+
+        assert 'a' in return_data.result
+        for x in return_data.result['a']:
+            assert len(x) == 1
+            if len(x[0][0]) == 1:
+                for y in x[0]:
+                    if 'e' in y:
+                        assert list(y.keys()) == ['e']
+                        assert y['e'] == 1
+                    elif 'g' in y:
+                        assert list(y.keys()) == ['g']
+                        assert y['g'] == 2
+                    else:
+                        raise ValueError("Unexpected value %s" % y)
+            elif len(x[0][0]) == 2:
+                for y in x[0]:
+                    if 'j' in y:
+                        assert len(y.keys()) == 2
+                        y['j'] == 3
+                    elif 'k' in y:
+                        assert len(y.keys()) == 2
+                        y['k'] == 4
+                    else:
+                        raise ValueError("Unexpected value %s" % len(x[0][0]))
+            else:
+                raise ValueError("Unexpected value %s" % x)


### PR DESCRIPTION
### What does this PR do?

Fixes tests that fail due to depending on dictionary sorting. Just walk the results and validate them.


### Tests written?

No - Fixes tests

```
unit.pillar.test_mysql.MysqlPillarTestCase.test_301_process_results_with_lists
unit.pillar.test_mysql.MysqlPillarTestCase.test_302_process_results_with_lists_consecutive
```

### Commits signed with GPG?

Yes