### PR TITLE
libvirt_events engine: fix graphics callback

### DIFF
--- a/salt/engines/libvirt_events.py
+++ b/salt/engines/libvirt_events.py
@@ -313,10 +313,9 @@ def _domain_event_graphics_cb(conn, domain, phase, local, remote, auth, subject,
         '''
         transform address structure into event data piece
         '''
-        data = {'family': _get_libvirt_enum_string('{0}_ADDRESS_'.format(prefix), addr.family),
-                'node': addr.node}
-        if addr.service is not None:
-            data['service'] = addr.service
+        data = {'family': _get_libvirt_enum_string('{0}_ADDRESS_'.format(prefix), addr['family']),
+                'node': addr['node'],
+                'service': addr['service']}
         return addr
 
     _salt_send_domain_event(opaque, conn, domain, opaque['event'], {
@@ -324,10 +323,7 @@ def _domain_event_graphics_cb(conn, domain, phase, local, remote, auth, subject,
         'local': get_address(local),
         'remote': get_address(remote),
         'authScheme': auth,
-        'subject': {
-            'type': subject.type,
-            'name': subject.name
-        }
+        'subject': [{'type': item[0], 'name': item[1]} for item in subject]
     })
 
 


### PR DESCRIPTION
### What does this PR do?

The addresses parameter is dictionary but its members weren't
properly accessed.

The subject parameter is actually a list of tuples containing two items:
one for the subject type and one for its name.

### What issues does this PR fix or reference?

None

### Previous Behavior

The libvirt_events engine was raising an exception for each graphics event. To trigger these, just open a Spice or VNC connection to one of the running VMs.

### New Behavior

No exception any more

### Tests written?

No

### Commits signed with GPG?

Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
