### PR TITLE
fix forward port of #46751

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -3012,7 +3012,7 @@ class BaseHighState(object):
                     'top_file_merging_strategy set to \'same\', but no '
                     'default_top configuration option was set'
                 )
-            self.opts['environment'] = self.opts['default_top']
+            self.opts['saltenv'] = self.opts['default_top']
 
         if self.opts['saltenv']:
             contents = self.client.cache_file(


### PR DESCRIPTION
### What does this PR do?

self.opts key 'environment' have been renamed to 'saltenv' after 2017.7,
thus the forward port broke the 'same' merging strategy

### What issues does this PR fix or reference?

#46660

### Previous Behavior

https://github.com/saltstack/salt/pull/46751

### New Behavior

https://github.com/saltstack/salt/pull/46751

### Tests written?

No

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
