### PR TITLE
Fix sysctl translate

### DIFF
--- a/salt/modules/linux_sysctl.py
+++ b/salt/modules/linux_sysctl.py
@@ -129,13 +129,10 @@ def assign(name, value):
         tran_tab = name.translate(''.maketrans('./', '/.'))
     else:
         if isinstance(name, unicode):  # pylint: disable=incompatible-py3-code
-            trans_args = ({
-                ord('/'): '.',
-                ord('.'): '/'
-            },)
+            trans_args = {ord('/'): u'.', ord('.'): u'/'}
         else:
             trans_args = string.maketrans('./', '/.')
-        tran_tab = name.translate(*trans_args)
+        tran_tab = name.translate(trans_args)
 
     sysctl_file = '/proc/sys/{0}'.format(tran_tab)
     if not os.path.exists(sysctl_file):


### PR DESCRIPTION
### What does this PR do?
Fix sysctl state failing on either unicode or non-unicode names.

### What issues does this PR fix or reference?
This is a follow-up to 72e6b31314a3439a00f435081cd92dab70d9af45 and 61c5397805a26f2b3ec59bd9bb4eadfe68a3f7ad

Essentially both 2017.7 and 2018.3 don't work, since in one case unicode names are broken, in the other the non-unicode names. This PR should ensure all if-else branches work.

### Previous Behavior
sysctl.present broken

### New Behavior
sysctl.present works

### Tests written?
No

### Commits signed with GPG?
No