### PR TITLE
fix stacktraces during access_keys

### DIFF
--- a/salt/utils/stringutils.py
+++ b/salt/utils/stringutils.py
@@ -362,14 +362,14 @@ def check_whitelist_blacklist(value, whitelist=None, blacklist=None):
     found in the whitelist, the function returns ``False``.
     '''
     if blacklist is not None:
-        if not isinstance(blacklist, list):
+        if not isinstance(blacklist, (list, tuple, set)):
             blacklist = [blacklist]
         for expr in blacklist:
             if expr_match(value, expr):
                 return False
 
     if whitelist:
-        if not isinstance(whitelist, list):
+        if not isinstance(whitelist, (list, tuple, set)):
             whitelist = [whitelist]
         for expr in whitelist:
             if expr_match(value, expr):


### PR DESCRIPTION
### What does this PR do?
the `stringutils.check_whitelist_blacklist` incorrectly assumes a set to be  a single item to be put in a list and iterated over.
This causes stacktraces during `access_keys` in Salt Master boot.

### Versions
```
[root@pampus salt]# salt --versions
Salt Version:
           Salt: 2018.3.0-368-g117b64d
 
Dependency Versions:
           cffi: 1.11.5
       cherrypy: Not Installed
       dateutil: 2.7.2
      docker-py: 3.2.1
          gitdb: Not Installed
      gitpython: Not Installed
          ioflo: Not Installed
         Jinja2: 2.10
        libgit2: 0.25.1
        libnacl: 1.6.1
       M2Crypto: 0.29.0
           Mako: Not Installed
   msgpack-pure: Not Installed
 msgpack-python: 0.5.6
   mysql-python: Not Installed
      pycparser: 2.18
       pycrypto: 2.6.1
   pycryptodome: Not Installed
         pygit2: 0.25.1
         Python: 2.7.5 (default, Aug  4 2017, 00:39:18)
   python-gnupg: Not Installed
         PyYAML: 3.12
          PyZMQ: 15.3.0
           RAET: Not Installed
          smmap: Not Installed
        timelib: 0.2.4
        Tornado: 4.2.1
            ZMQ: 4.1.4
 
System Versions:
           dist: centos 7.4.1708 Core
         locale: UTF-8
        machine: x86_64
        release: 4.14.11-300.profects1234.fc27.x86_64
         system: Linux
        version: CentOS Linux 7.4.1708 Core
```

### Previous Behavior
`daemons.masterapi.access_keys()` calls `salt.utils.stringutils.check_whitelist_blacklist(user, whitelist=acl_users)`, resulting in:
```
2018-04-27 14:11:33,791 [salt.daemons.masterapi:236 ][INFO    ][7823] Preparing the root key for local communication
2018-04-27 14:11:33,792 [salt.daemons.masterapi:198 ][DEBUG   ][7823] Removing stale keyfile: /var/cache/salt/master/.root_key
2018-04-27 14:11:33,794 [salt.daemons.masterapi:26  ][PROFILE ][7823] Beginning pwd.getpwall() call in masterapi access_keys function
2018-04-27 14:11:33,797 [salt.utils.stringutils:337 ][ERROR   ][7823] Value 'bin' or expression set([u'root']) is not a string
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/salt/utils/stringutils.py", line 329, in expr_match
    if fnmatch.fnmatch(line, expr):
  File "/usr/lib64/python2.7/fnmatch.py", line 43, in fnmatch
    return fnmatchcase(name, pat)
  File "/usr/lib64/python2.7/fnmatch.py", line 74, in fnmatchcase
    if not pat in _cache:
TypeError: unhashable type: 'set'
2018-04-27 14:11:33,817 [salt.utils.stringutils:337 ][ERROR   ][7823] Value 'nobody' or expression set([u'root']) is not a string
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/salt/utils/stringutils.py", line 329, in expr_match
    if fnmatch.fnmatch(line, expr):
  File "/usr/lib64/python2.7/fnmatch.py", line 43, in fnmatch
    return fnmatchcase(name, pat)
  File "/usr/lib64/python2.7/fnmatch.py", line 74, in fnmatchcase
    if not pat in _cache:
TypeError: unhashable type: 'set'
2018-04-27 14:11:33,819 [salt.utils.stringutils:337 ][ERROR   ][7823] Value 'avahi-autoipd' or expression set([u'root']) is not a string
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/salt/utils/stringutils.py", line 329, in expr_match
    if fnmatch.fnmatch(line, expr):
  File "/usr/lib64/python2.7/fnmatch.py", line 43, in fnmatch
    return fnmatchcase(name, pat)
  File "/usr/lib64/python2.7/fnmatch.py", line 74, in fnmatchcase
    if not pat in _cache:
TypeError: unhashable type: 'set'
2018-04-27 14:11:33,821 [salt.utils.stringutils:337 ][ERROR   ][7823] Value 'systemd-bus-proxy' or expression set([u'root']) is not a string
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/salt/utils/stringutils.py", line 329, in expr_match
    if fnmatch.fnmatch(line, expr):
  File "/usr/lib64/python2.7/fnmatch.py", line 43, in fnmatch
    return fnmatchcase(name, pat)
  File "/usr/lib64/python2.7/fnmatch.py", line 74, in fnmatchcase
    if not pat in _cache:
TypeError: unhashable type: 'set'
2018-04-27 14:11:33,822 [salt.utils.stringutils:337 ][ERROR   ][7823] Value 'systemd-network' or expression set([u'root']) is not a string
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/salt/utils/stringutils.py", line 329, in expr_match
    if fnmatch.fnmatch(line, expr):
  File "/usr/lib64/python2.7/fnmatch.py", line 43, in fnmatch
    return fnmatchcase(name, pat)
  File "/usr/lib64/python2.7/fnmatch.py", line 74, in fnmatchcase
    if not pat in _cache:
TypeError: unhashable type: 'set'
(etc)
```

### New Behavior
`stringutils.check_whitelist_blacklist`  will only put items in a wrapper-list if they're not lists/sets/tuples.

