### PR TITLE
Tornado5.0: Future.exc_info is dropped

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1057,7 +1057,7 @@ class Minion(MinionBase):
         # I made the following 3 line oddity to preserve traceback.
         # Please read PR #23978 before changing, hopefully avoiding regressions.
         # Good luck, we're all counting on you.  Thanks.
-        future_exception = self._connect_master_future.exc_info()
+        future_exception = self._connect_master_future.exception()
         if future_exception:
             # This needs to be re-raised to preserve restart_on_error behavior.
             raise six.reraise(*future_exception)

--- a/salt/transport/ipc.py
+++ b/salt/transport/ipc.py
@@ -296,7 +296,7 @@ class IPCClient(object):
         else:
             if hasattr(self, '_connecting_future'):
                 # read previous future result to prevent the "unhandled future exception" error
-                self._connecting_future.exc_info()  # pylint: disable=E0203
+                self._connecting_future.exception()  # pylint: disable=E0203
             future = tornado.concurrent.Future()
             self._connecting_future = future
             self._connect(timeout=timeout)
@@ -753,9 +753,9 @@ class IPCMessageSubscriber(IPCClient):
             # '[ERROR   ] Future exception was never retrieved:
             # StreamClosedError'
             if self._read_sync_future is not None:
-                self._read_sync_future.exc_info()
+                self._read_sync_future.exception()
             if self._read_stream_future is not None:
-                self._read_stream_future.exc_info()
+                self._read_stream_future.exception()
 
     def __del__(self):
         if IPCMessageSubscriber in globals():

--- a/salt/transport/tcp.py
+++ b/salt/transport/tcp.py
@@ -886,7 +886,7 @@ class SaltMessageClient(object):
                 # This happens because the logic is always waiting to read
                 # the next message and the associated read future is marked
                 # 'StreamClosedError' when the stream is closed.
-                self._read_until_future.exc_info()
+                self._read_until_future.exception()
                 if (not self._stream_return_future.done() and
                         self.io_loop != tornado.ioloop.IOLoop.current(
                             instance=False)):
@@ -1139,7 +1139,7 @@ class Subscriber(object):
                 # This happens because the logic is always waiting to read
                 # the next message and the associated read future is marked
                 # 'StreamClosedError' when the stream is closed.
-                self._read_until_future.exc_info()
+                self._read_until_future.exception()
 
     def __del__(self):
         self.close()


### PR DESCRIPTION
### What does this PR do?
Tornado 5.0 on Py3 has moved to the builtin asyncio that's `Future` class has no `exc_info` method.
This PR replaces all `Future.exc_info` calls with `Future.exception` that is just another name of the method that presents in all currently supported versions.

### What issues does this PR fix or reference?
@gtmanfred is there one?

### Previous Behavior
```
20:17:46        Traceback (most recent call last):
20:17:46          File "/tmp/kitchen/testing/tests/runtests.py", line 789, in <module>
20:17:46            main()
20:17:46          File "/tmp/kitchen/testing/tests/runtests.py", line 774, in main
20:17:46            status = parser.run_integration_tests()
20:17:46          File "/tmp/kitchen/testing/tests/runtests.py", line 698, in run_integration_tests
20:17:46            with TestDaemon(self):
20:17:46          File "/tmp/kitchen/testing/tests/integration/__init__.py", line 239, in __enter__
20:17:46            grains = self.client.cmd('minion', 'grains.items')
20:17:46          File "/tmp/kitchen/testing/salt/client/__init__.py", line 758, in cmd
20:17:46            self.event.close_pub()
20:17:46          File "/tmp/kitchen/testing/salt/utils/event.py", line 391, in close_pub
20:17:46            self.subscriber.close()
20:17:46          File "/tmp/kitchen/testing/salt/transport/ipc.py", line 758, in close
20:17:46            self._read_stream_future.exc_info()
20:17:46        AttributeError: 'Future' object has no attribute 'exc_info'
```

### New Behavior
Works.

### Tests written?
No

### Commits signed with GPG?
Yes