### PR TITLE
[develop] Adding clean_old_jobs to pgjsonb returner for Fluorine

### DIFF
--- a/salt/returners/pgjsonb.py
+++ b/salt/returners/pgjsonb.py
@@ -59,6 +59,22 @@ optional. The following ssl options are simply for illustration purposes:
     alternative.pgjsonb.ssl_cert: '/etc/pki/mysql/certs/localhost.crt'
     alternative.pgjsonb.ssl_key: '/etc/pki/mysql/certs/localhost.key'
 
+Should you wish the returner data to be cleaned out every so often, set
+`keep_jobs` to the number of hours for the jobs to live in the tables.
+Setting it to `0` or leaving it unset will cause the data to stay in the tables.
+
+Should you wish to archive jobs in a different table for later processing,
+set `archive_jobs` to True.  Salt will create 3 archive tables
+
+- `jids_archive`
+- `salt_returns_archive`
+- `salt_events_archive`
+
+and move the contents of `jids`, `salt_returns`, and `salt_events` that are
+more than `keep_jobs` hours old to these tables.
+
+.. versionadded:: 2015.5.0
+
 Use the following Pg database schema:
 
 .. code-block:: sql
@@ -417,3 +433,126 @@ def prep_jid(nocache=False, passed_jid=None):  # pylint: disable=unused-argument
     Do any work necessary to prepare a JID, including sending a custom id
     '''
     return passed_jid if passed_jid is not None else salt.utils.jid.gen_jid(__opts__)
+
+
+def _purge_jobs(timestamp):
+    '''
+    Purge records from the returner tables.
+    :param job_age_in_seconds:  Purge jobs older than this
+    :return:
+    '''
+    with _get_serv() as cursor:
+        try:
+            sql = 'delete from jids where jid in (select distinct jid from salt_returns where alter_time < %s)'
+            cursor.execute(sql, (timestamp,))
+            cursor.execute('COMMIT')
+        except psycopg2.DatabaseError as err:
+            error = err.args
+            sys.stderr.write(six.text_type(error))
+            cursor.execute("ROLLBACK")
+            raise err
+
+        try:
+            sql = 'delete from salt_returns where alter_time < %s'
+            cursor.execute(sql, (timestamp,))
+            cursor.execute('COMMIT')
+        except psycopg2.DatabaseError as err:
+            error = err.args
+            sys.stderr.write(six.text_type(error))
+            cursor.execute("ROLLBACK")
+            raise err
+
+        try:
+            sql = 'delete from salt_events where alter_time < %s'
+            cursor.execute(sql, (timestamp,))
+            cursor.execute('COMMIT')
+        except psycopg2.DatabaseError as err:
+            error = err.args
+            sys.stderr.write(six.text_type(error))
+            cursor.execute("ROLLBACK")
+            raise err
+
+    return True
+
+
+def _archive_jobs(timestamp):
+    '''
+    Copy rows to a set of backup tables, then purge rows.
+    :param timestamp: Archive rows older than this timestamp
+    :return:
+    '''
+    source_tables = ['jids',
+                     'salt_returns',
+                     'salt_events']
+
+    with _get_serv() as cursor:
+        target_tables = {}
+        for table_name in source_tables:
+            try:
+                tmp_table_name = table_name + '_archive'
+                sql = 'create table IF NOT exists {0} (LIKE {1})'.format(tmp_table_name, table_name)
+                cursor.execute(sql)
+                cursor.execute('COMMIT')
+                target_tables[table_name] = tmp_table_name
+            except psycopg2.DatabaseError as err:
+                error = err.args
+                sys.stderr.write(six.text_type(error))
+                cursor.execute("ROLLBACK")
+                raise err
+
+        try:
+            sql = 'insert into {0} select * from {1} where jid in (select distinct jid from salt_returns where alter_time < %s)'.format(target_tables['jids'], 'jids')
+            cursor.execute(sql, (timestamp,))
+            cursor.execute('COMMIT')
+        except psycopg2.DatabaseError as err:
+            error = err.args
+            sys.stderr.write(six.text_type(error))
+            cursor.execute("ROLLBACK")
+            raise err
+        except Exception as e:
+            log.error(e)
+            raise
+
+        try:
+            sql = 'insert into {0} select * from {1} where alter_time < %s'.format(target_tables['salt_returns'], 'salt_returns')
+            cursor.execute(sql, (timestamp,))
+            cursor.execute('COMMIT')
+        except psycopg2.DatabaseError as err:
+            error = err.args
+            sys.stderr.write(six.text_type(error))
+            cursor.execute("ROLLBACK")
+            raise err
+
+        try:
+            sql = 'insert into {0} select * from {1} where alter_time < %s'.format(target_tables['salt_events'], 'salt_events')
+            cursor.execute(sql, (timestamp,))
+            cursor.execute('COMMIT')
+        except psycopg2.DatabaseError as err:
+            error = err.args
+            sys.stderr.write(six.text_type(error))
+            cursor.execute("ROLLBACK")
+            raise err
+
+    return _purge_jobs(timestamp)
+
+
+def clean_old_jobs():
+    '''
+    Called in the master's event loop every loop_interval.  Archives and/or
+    deletes the events and job details from the database.
+    :return:
+    '''
+    if __opts__.get('keep_jobs', False) and int(__opts__.get('keep_jobs', 0)) > 0:
+        try:
+            with _get_serv() as cur:
+                sql = "select (NOW() -  interval '{0}' hour) as stamp;".format(__opts__['keep_jobs'])
+                cur.execute(sql)
+                rows = cur.fetchall()
+                stamp = rows[0][0]
+
+            if __opts__.get('archive_jobs', False):
+                _archive_jobs(stamp)
+            else:
+                _purge_jobs(stamp)
+        except Exception as e:
+            log.error(e)

--- a/salt/returners/pgjsonb.py
+++ b/salt/returners/pgjsonb.py
@@ -60,20 +60,20 @@ optional. The following ssl options are simply for illustration purposes:
     alternative.pgjsonb.ssl_key: '/etc/pki/mysql/certs/localhost.key'
 
 Should you wish the returner data to be cleaned out every so often, set
-`keep_jobs` to the number of hours for the jobs to live in the tables.
-Setting it to `0` or leaving it unset will cause the data to stay in the tables.
+``keep_jobs`` to the number of hours for the jobs to live in the tables.
+Setting it to ``0`` or leaving it unset will cause the data to stay in the tables.
 
 Should you wish to archive jobs in a different table for later processing,
-set `archive_jobs` to True.  Salt will create 3 archive tables
+set ``archive_jobs`` to True.  Salt will create 3 archive tables
 
-- `jids_archive`
-- `salt_returns_archive`
-- `salt_events_archive`
+- ``jids_archive``
+- ``salt_returns_archive`
+- ``salt_events_archive`
 
-and move the contents of `jids`, `salt_returns`, and `salt_events` that are
-more than `keep_jobs` hours old to these tables.
+and move the contents of ``jids``, ``salt_returns``, and ``salt_events`` that are
+more than ``keep_jobs`` hours old to these tables.
 
-.. versionadded:: 2015.5.0
+.. versionadded:: Fluorine
 
 Use the following Pg database schema:
 

--- a/tests/unit/returners/test_pgjsonb_return.py
+++ b/tests/unit/returners/test_pgjsonb_return.py
@@ -8,17 +8,10 @@ Unit tests for the PGJsonb returner (pgjsonb).
 
 # Import Python libs
 from __future__ import absolute_import, print_function, unicode_literals
-import os
-import shutil
-import time
 import logging
-import tempfile
-import time
 
 # Import Salt Testing libs
-from tests.integration import AdaptedConfigurationTestCaseMixin
 from tests.support.mixins import LoaderModuleMockMixin
-from tests.support.paths import TMP
 from tests.support.unit import TestCase, skipIf
 from tests.support.mock import (
     MagicMock,
@@ -28,12 +21,7 @@ from tests.support.mock import (
 )
 
 # Import Salt libs
-import salt.utils.files
-import salt.utils.jid
-import salt.utils.job
-import salt.utils.platform
 import salt.returners.pgjsonb as pgjsonb
-from salt.ext import six
 
 log = logging.getLogger(__name__)
 
@@ -53,8 +41,7 @@ class PGJsonbCleanOldJobsTestCase(TestCase, LoaderModuleMockMixin):
         connect_mock = MagicMock()
         with patch.object(pgjsonb, '_get_serv', connect_mock):
             with patch.dict(pgjsonb.__salt__, {'config.option': MagicMock()}):
-                ret = pgjsonb.clean_old_jobs()
-                self.assertEqual(ret, None)
+                self.assertEqual(pgjsonb.clean_old_jobs(), None)
 
     def test_clean_old_jobs_archive(self):
         '''
@@ -64,5 +51,4 @@ class PGJsonbCleanOldJobsTestCase(TestCase, LoaderModuleMockMixin):
         with patch.object(pgjsonb, '_get_serv', connect_mock):
             with patch.dict(pgjsonb.__salt__, {'config.option': MagicMock()}):
                 with patch.dict(pgjsonb.__opts__, {'archive_jobs': 1}):
-                    ret = pgjsonb.clean_old_jobs()
-                    self.assertEqual(ret, None)
+                    self.assertEqual(pgjsonb.clean_old_jobs(), None)

--- a/tests/unit/returners/test_pgjsonb_return.py
+++ b/tests/unit/returners/test_pgjsonb_return.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+'''
+tests.unit.returners.pgjsonb_test
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Unit tests for the PGJsonb returner (pgjsonb).
+'''
+
+# Import Python libs
+from __future__ import absolute_import, print_function, unicode_literals
+import os
+import shutil
+import time
+import logging
+import tempfile
+import time
+
+# Import Salt Testing libs
+from tests.integration import AdaptedConfigurationTestCaseMixin
+from tests.support.mixins import LoaderModuleMockMixin
+from tests.support.paths import TMP
+from tests.support.unit import TestCase, skipIf
+from tests.support.mock import (
+    MagicMock,
+    NO_MOCK,
+    NO_MOCK_REASON,
+    patch
+)
+
+# Import Salt libs
+import salt.utils.files
+import salt.utils.jid
+import salt.utils.job
+import salt.utils.platform
+import salt.returners.pgjsonb as pgjsonb
+from salt.ext import six
+
+log = logging.getLogger(__name__)
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class PGJsonbCleanOldJobsTestCase(TestCase, LoaderModuleMockMixin):
+    '''
+    Tests for the local_cache.clean_old_jobs function.
+    '''
+    def setup_loader_modules(self):
+        return {pgjsonb: {'__opts__': {'keep_jobs': 1, 'archive_jobs': 0}}}
+
+    def test_clean_old_jobs_purge(self):
+        '''
+        Tests that the function returns None when no jid_root is found.
+        '''
+        connect_mock = MagicMock()
+        with patch.object(pgjsonb, '_get_serv', connect_mock):
+            with patch.dict(pgjsonb.__salt__, {'config.option': MagicMock()}):
+                ret = pgjsonb.clean_old_jobs()
+                self.assertEqual(ret, None)
+
+    def test_clean_old_jobs_archive(self):
+        '''
+        Tests that the function returns None when no jid_root is found.
+        '''
+        connect_mock = MagicMock()
+        with patch.object(pgjsonb, '_get_serv', connect_mock):
+            with patch.dict(pgjsonb.__salt__, {'config.option': MagicMock()}):
+                with patch.dict(pgjsonb.__opts__, {'archive_jobs': 1}):
+                    ret = pgjsonb.clean_old_jobs()
+                    self.assertEqual(ret, None)


### PR DESCRIPTION
### What does this PR do?
Adding the clean_old_jobs function the pgjsonb returner for Fluorine

### What issues does this PR fix or reference?
#47316 

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
