### PR TITLE
Return an empty dict if no search_order in ldap ext_pillar config file

### DIFF
--- a/salt/pillar/pillar_ldap.py
+++ b/salt/pillar/pillar_ldap.py
@@ -324,6 +324,7 @@ def ext_pillar(minion_id,  # pylint: disable=W0613
             'pillar_ldap: search_order missing from configuration. See the '
             'documentation for more information.'
         )
+        return {}
 
     data = {}
     for source in opts['search_order']:


### PR DESCRIPTION
I forgot to do this in https://github.com/saltstack/salt/pull/47334, it is needed to prevent a `KeyError` in these cases.