### PR TITLE
Fix "of pass" typo in grains.delval docs: change to "or pass"

### DIFF
--- a/salt/modules/grains.py
+++ b/salt/modules/grains.py
@@ -453,8 +453,8 @@ def delval(key, destructive=False):
     .. versionadded:: 0.17.0
 
     Delete a grain value from the grains config file. This will just set the
-    grain value to `None`. To completely remove the grain run `grains.delkey`
-    of pass `destructive=True` to `grains.delval`.
+    grain value to ``None``. To completely remove the grain, run ``grains.delkey``
+    or pass ``destructive=True`` to ``grains.delval``.
 
     key
         The grain key from which to delete the value.


### PR DESCRIPTION
Fixes #47264

This also fixes the syntax highlighting since rst needs double backticks rather than single backticks.
