### PR TITLE
Allow for passing in previously compiled grains to custom grain modules

### DIFF
--- a/doc/topics/grains/index.rst
+++ b/doc/topics/grains/index.rst
@@ -269,6 +269,11 @@ grain will override that core grain. Similarly, grains from
 ``/etc/salt/minion`` override both core grains and custom grain modules, and
 grains in ``_grains`` will override *any* grains of the same name.
 
+For custom grains, if the function takes an argument ``grains``, then the
+previously rendered grains will be passed in.  Because the rest of the grains
+could be rendered in any order, the only grains that can be relied upon to be
+passed in are ``core`` grains. This was added in the Fluorine Release.
+
 
 Examples of Grains
 ==================

--- a/doc/topics/grains/index.rst
+++ b/doc/topics/grains/index.rst
@@ -272,7 +272,7 @@ grains in ``_grains`` will override *any* grains of the same name.
 For custom grains, if the function takes an argument ``grains``, then the
 previously rendered grains will be passed in.  Because the rest of the grains
 could be rendered in any order, the only grains that can be relied upon to be
-passed in are ``core`` grains. This was added in the Fluorine Release.
+passed in are ``core`` grains. This was added in the Fluorine release.
 
 
 Examples of Grains

--- a/doc/topics/releases/fluorine.rst
+++ b/doc/topics/releases/fluorine.rst
@@ -10,7 +10,7 @@ Grains Dictionary Passed into Custom Grains
 
 Starting in this release, if a custom grains function accepts a variable named
 ``grains``, the Grains dictionary of the already compiled grains will be passed
-in.  Because of the non deterministic order that grains are rendered in, the
+in.  Because of the non-deterministic order that grains are rendered in, the
 only grains that can be relied upon to be passed in are ``core.py`` grains,
 since those are compiled first.
 

--- a/doc/topics/releases/fluorine.rst
+++ b/doc/topics/releases/fluorine.rst
@@ -5,6 +5,16 @@ Salt Release Notes - Codename Fluorine
 ======================================
 
 
+Grains Dictionary Passed into Custom Grains
+-------------------------------------------
+
+Starting in this release, if a custom grains function accepts a variable named
+``grains``, the Grains dictionary of the already compiled grains will be passed
+in.  Because of the non deterministic order that grains are rendered in, the
+only grains that can be relied upon to be passed in are ``core.py`` grains,
+since those are compiled first.
+
+
 "Virtual Package" Support Dropped for APT
 -----------------------------------------
 

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -752,15 +752,12 @@ def grains(opts, force_refresh=False, proxy=None):
             # device.
             log.trace('Loading %s grain', key)
             parameters = list(funcs[key].__code__.co_varnames)
-            if funcs[key].__code__.co_argcount > 0:
-                kwargs = {}
-                if 'proxy' in parameters:
-                    kwargs['proxy'] = proxy
-                if 'grains' in parameters:
-                    kwargs['grains'] = grains_data
-                ret = funcs[key](**kwargs)
-            else:
-                ret = funcs[key]()
+            kwargs = {}
+            if 'proxy' in parameters:
+                kwargs['proxy'] = proxy
+            if 'grains' in parameters:
+                kwargs['grains'] = grains_data
+            ret = funcs[key](**kwargs)
         except Exception:
             if salt.utils.platform.is_proxy():
                 log.info('The following CRITICAL message may not be an error; the proxy may not be completely established yet.')

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -751,8 +751,14 @@ def grains(opts, force_refresh=False, proxy=None):
             # proxymodule for retrieving information from the connected
             # device.
             log.trace('Loading %s grain', key)
-            if funcs[key].__code__.co_argcount == 1:
-                ret = funcs[key](proxy)
+            parameters = list(funcs[key].__code__.co_varnames)
+            if funcs[key].__code__.co_argcount > 0:
+                kwargs = {}
+                if 'proxy' in parameters:
+                    kwargs['proxy'] = proxy
+                if 'grains' in parameters:
+                    kwargs['grains'] = grains_data
+                ret = funcs[key](**kwargs)
             else:
                 ret = funcs[key]()
         except Exception:

--- a/tests/integration/files/file/base/_grains/test_custom_grains.py
+++ b/tests/integration/files/file/base/_grains/test_custom_grains.py
@@ -1,0 +1,4 @@
+def test(grains):
+    if 'os' in grains:
+        return {'custom_grain_test': 'itworked'}
+    return {'custom_grain_test': 'itdidntwork'}

--- a/tests/integration/grains/test_custom.py
+++ b/tests/integration/grains/test_custom.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+'''
+Test the core grains
+'''
+
+# Import python libs
+from __future__ import absolute_import, unicode_literals
+
+# Import Salt Testing libs
+from tests.support.case import ModuleCase
+
+
+class TestGrainsCore(ModuleCase):
+    '''
+    Test the core grains grains
+    '''
+
+    def test_grains_passed_to_custom_grain(self):
+        '''
+        test if current grains are passed to grains module functions that have a grains argument
+        '''
+        self.assertEqual(self.run_function('grains.get', ['custom_grain_test']), 'itworked')


### PR DESCRIPTION
### What does this PR do?
If a grains module function accepts a variable named `grains` then the grains dict will be passed in.

### What issues does this PR fix or reference?
Closes #47338

### Previous Behavior
No grains are passed to custom grains modules

### New Behavior
Previously compiled grains are passed into grains functions if the function accepts a variable called `grains`

### Tests written?

Yes

### Commits signed with GPG?

Yes