### PR TITLE
Fix py2 version of pip test

### DIFF
--- a/tests/unit/modules/test_pip.py
+++ b/tests/unit/modules/test_pip.py
@@ -301,6 +301,8 @@ class PipTestCase(TestCase, LoaderModuleMockMixin):
                 if salt.utils.is_windows():
                     venv_path = 'c:\\test_env'
                     bin_path = os.path.join(venv_path, 'Scripts', 'pip.exe')
+                    if six.PY2:
+                        bin_path = bin_path.encode('string-escape')
                 else:
                     venv_path = '/test_env'
                     bin_path = os.path.join(venv_path, 'bin', 'pip')


### PR DESCRIPTION
### What does this PR do?

Fixes broken pip test on py2 windows build.

This special case is a bit odd but it matches the logic found in the install method it is testing.

https://github.com/saltstack/salt/blob/2017.7/salt/modules/pip.py#L137

### Tests written?

No - Fixing existing tests

### Commits signed with GPG?

Yes