### PR TITLE
Older GitPython versions will not have close

### DIFF
--- a/tests/unit/fileserver/test_gitfs.py
+++ b/tests/unit/fileserver/test_gitfs.py
@@ -220,7 +220,8 @@ class GitFSTest(TestCase, LoaderModuleMockMixin):
         repo.index.add([x for x in os.listdir(self.tmp_repo_dir)
                         if x != '.git'])
         repo.index.commit('Test')
-        repo.close()
+        if hasattr(repo, 'close'):
+            repo.close()
         gitfs.update()
 
     def tearDown(self):


### PR DESCRIPTION
### What does this PR do?

Only call close on repo object when the method exists

Fixes:
https://jenkinsci.saltstack.com/job/2017.7/job/salt-centos-6-py2/117/testReport/junit/unit.fileserver.test_gitfs/GitFSTest/test_dir_list/

### Tests written?

No - Fixing tests

### Commits signed with GPG?

Yes