### PR TITLE
zeromq 17 deprecation warning backport from 2018.3 + tornado 5 fixes

### DIFF
--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -47,11 +47,6 @@ from salt.exceptions import (
 # Import third party libs
 import salt.ext.six as six
 # pylint: disable=import-error
-try:
-    import zmq
-    HAS_ZMQ = True
-except ImportError:
-    HAS_ZMQ = False
 
 # Try to import range from https://github.com/ytoolshed/range
 HAS_RANGE = False

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -56,11 +56,7 @@ try:
     HAS_WINSHELL = True
 except ImportError:
     HAS_WINSHELL = False
-try:
-    import zmq
-    HAS_ZMQ = True
-except ImportError:
-    HAS_ZMQ = False
+from salt.utils.zeromq import zmq
 
 # The directory where salt thin is deployed
 DEFAULT_THIN_DIR = '/var/tmp/.%%USER%%_%%FQDNUUID%%_salt'
@@ -207,7 +203,7 @@ class SSH(object):
     '''
     def __init__(self, opts):
         pull_sock = os.path.join(opts['sock_dir'], 'master_event_pull.ipc')
-        if os.path.isfile(pull_sock) and HAS_ZMQ:
+        if os.path.exists(pull_sock) and zmq:
             self.event = salt.utils.event.get_event(
                     'master',
                     opts['sock_dir'],

--- a/salt/daemons/flo/zero.py
+++ b/salt/daemons/flo/zero.py
@@ -15,15 +15,13 @@ import errno
 # Import ioflo libs
 import ioflo.base.deeding
 # Import third party libs
-try:
-    import zmq
-    import salt.master
-    import salt.crypt
-    import salt.daemons.masterapi
-    import salt.payload
-    HAS_ZMQ = True
-except ImportError:
-    HAS_ZMQ = False
+from salt.utils.zeromq import zmq
+import salt.master
+import salt.crypt
+import salt.daemons.masterapi
+import salt.payload
+import salt.utils.stringutils
+
 
 log = logging.getLogger(__name__)
 
@@ -159,7 +157,7 @@ class SaltZmqPublisher(ioflo.base.deeding.Deed):
         '''
         Set up tracking value(s)
         '''
-        if not HAS_ZMQ:
+        if not zmq:
             return
         self.created = False
         self.serial = salt.payload.Serial(self.opts.value)

--- a/salt/daemons/flo/zero.py
+++ b/salt/daemons/flo/zero.py
@@ -20,7 +20,6 @@ import salt.master
 import salt.crypt
 import salt.daemons.masterapi
 import salt.payload
-import salt.utils.stringutils
 
 
 log = logging.getLogger(__name__)

--- a/salt/engines/napalm_syslog.py
+++ b/salt/engines/napalm_syslog.py
@@ -173,11 +173,7 @@ from __future__ import absolute_import
 import logging
 
 # Import third party libraries
-try:
-    import zmq
-    HAS_ZMQ = True
-except ImportError:
-    HAS_ZMQ = False
+from salt.utils.zeromq import zmq
 
 try:
     # pylint: disable=W0611
@@ -209,7 +205,7 @@ def __virtual__():
     '''
     Load only if napalm-logs is installed.
     '''
-    if not HAS_NAPALM_LOGS or not HAS_ZMQ:
+    if not HAS_NAPALM_LOGS or not zmq:
         return (False, 'napalm_syslog could not be loaded. \
             Please install napalm-logs library amd ZeroMQ.')
     return True

--- a/salt/master.py
+++ b/salt/master.py
@@ -28,6 +28,7 @@ except ImportError:
 # pylint: disable=import-error,no-name-in-module,redefined-builtin
 import salt.ext.six as six
 from salt.ext.six.moves import range
+from salt.utils.zeromq import zmq, ZMQDefaultLoop, install_zmq, zmq_version_info
 # pylint: enable=import-error,no-name-in-module,redefined-builtin
 
 try:
@@ -858,9 +859,8 @@ class MWorker(SignalHandlingMultiprocessingProcess):
         Bind to the local port
         '''
         # using ZMQIOLoop since we *might* need zmq in there
-        if HAS_ZMQ and not TORNADO_50:
-            zmq.eventloop.ioloop.install()
-        self.io_loop = LOOP_CLASS()
+        install_zmq()
+        self.io_loop = ZMQDefaultLoop()
         self.io_loop.make_current()
         for req_channel in self.req_channels:
             req_channel.post_fork(self._handle_payload, io_loop=self.io_loop)  # TODO: cleaner? Maybe lazily?

--- a/salt/master.py
+++ b/salt/master.py
@@ -379,23 +379,13 @@ class Master(SMaster):
 
         :param dict: The salt options
         '''
-        if HAS_ZMQ:
-            # Warn if ZMQ < 3.2
-            try:
-                zmq_version_info = zmq.zmq_version_info()
-            except AttributeError:
-                # PyZMQ <= 2.1.9 does not have zmq_version_info, fall back to
-                # using zmq.zmq_version() and build a version info tuple.
-                zmq_version_info = tuple(
-                    [int(x) for x in zmq.zmq_version().split('.')]
-                )
-            if zmq_version_info < (3, 2):
-                log.warning(
-                    'You have a version of ZMQ less than ZMQ 3.2! There are '
-                    'known connection keep-alive issues with ZMQ < 3.2 which '
-                    'may result in loss of contact with minions. Please '
-                    'upgrade your ZMQ!'
-                )
+        if zmq and zmq_version_info < (3, 2):
+            log.warning(
+                'You have a version of ZMQ less than ZMQ 3.2! There are '
+                'known connection keep-alive issues with ZMQ < 3.2 which '
+                'may result in loss of contact with minions. Please '
+                'upgrade your ZMQ!'
+            )
         SMaster.__init__(self, opts)
 
     def __set_max_open_files(self):

--- a/salt/master.py
+++ b/salt/master.py
@@ -31,21 +31,6 @@ from salt.ext.six.moves import range
 from salt.utils.zeromq import zmq, ZMQDefaultLoop, install_zmq, zmq_version_info
 # pylint: enable=import-error,no-name-in-module,redefined-builtin
 
-try:
-    import zmq
-    import zmq.eventloop.ioloop
-    # support pyzmq 13.0.x, TODO: remove once we force people to 14.0.x
-    if not hasattr(zmq.eventloop.ioloop, 'ZMQIOLoop'):
-        zmq.eventloop.ioloop.ZMQIOLoop = zmq.eventloop.ioloop.IOLoop
-    HAS_ZMQ = True
-except ImportError:
-    HAS_ZMQ = False
-
-import tornado
-TORNADO_50 = tornado.version_info >= (5,)
-
-from salt.utils.async import LOOP_CLASS
-
 import tornado.gen  # pylint: disable=F0401
 
 # Import salt libs

--- a/salt/master.py
+++ b/salt/master.py
@@ -28,7 +28,7 @@ except ImportError:
 # pylint: disable=import-error,no-name-in-module,redefined-builtin
 import salt.ext.six as six
 from salt.ext.six.moves import range
-from salt.utils.zeromq import zmq, ZMQDefaultLoop, install_zmq, zmq_version_info
+from salt.utils.zeromq import zmq, ZMQDefaultLoop, install_zmq, ZMQ_VERSION_INFO
 # pylint: enable=import-error,no-name-in-module,redefined-builtin
 
 import tornado.gen  # pylint: disable=F0401
@@ -364,7 +364,7 @@ class Master(SMaster):
 
         :param dict: The salt options
         '''
-        if zmq and zmq_version_info < (3, 2):
+        if zmq and ZMQ_VERSION_INFO < (3, 2):
             log.warning(
                 'You have a version of ZMQ less than ZMQ 3.2! There are '
                 'known connection keep-alive issues with ZMQ < 3.2 which '

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -33,7 +33,6 @@ from salt.ext.six.moves import range
 from salt.utils.zeromq import zmq, ZMQDefaultLoop, install_zmq, ZMQ_VERSION_INFO
 
 # pylint: enable=no-name-in-module,redefined-builtin
-from salt.utils.async import LOOP_CLASS
 import tornado
 
 HAS_RANGE = False

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -30,7 +30,7 @@ if six.PY3:
 else:
     import salt.ext.ipaddress as ipaddress
 from salt.ext.six.moves import range
-from salt.utils.zeromq import zmq, ZMQDefaultLoop, install_zmq
+from salt.utils.zeromq import zmq, ZMQDefaultLoop, install_zmq, ZMQ_VERSION_INFO
 
 # pylint: enable=no-name-in-module,redefined-builtin
 from salt.utils.async import LOOP_CLASS
@@ -946,15 +946,7 @@ class Minion(MinionBase):
 
         # Warn if ZMQ < 3.2
         if zmq:
-            try:
-                zmq_version_info = zmq.zmq_version_info()
-            except AttributeError:
-                # PyZMQ <= 2.1.9 does not have zmq_version_info, fall back to
-                # using zmq.zmq_version() and build a version info tuple.
-                zmq_version_info = tuple(
-                    [int(x) for x in zmq.zmq_version().split('.')]  # pylint: disable=no-member
-                )
-            if zmq_version_info < (3, 2):
+            if ZMQ_VERSION_INFO < (3, 2):
                 log.warning(
                     'You have a version of ZMQ less than ZMQ 3.2! There are '
                     'known connection keep-alive issues with ZMQ < 3.2 which '

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -645,10 +645,7 @@ class SMinion(MinionBase):
         # Clean out the proc directory (default /var/cache/salt/minion/proc)
         if (self.opts.get('file_client', 'remote') == 'remote'
                 or self.opts.get('use_master_when_local', False)):
-            if self.opts['transport'] == 'zeromq' and zmq and not tornado.version_info >= (5,):
-                io_loop = zmq.eventloop.ioloop.ZMQIOLoop()
-            else:
-                io_loop = ZMQDefaultLoop.current()
+            io_loop = ZMQDefaultLoop.current()
             io_loop.run_sync(
                 lambda: self.eval_master(self.opts, failed=True)
             )

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -645,6 +645,7 @@ class SMinion(MinionBase):
         # Clean out the proc directory (default /var/cache/salt/minion/proc)
         if (self.opts.get('file_client', 'remote') == 'remote'
                 or self.opts.get('use_master_when_local', False)):
+            install_zmq()
             io_loop = ZMQDefaultLoop.current()
             io_loop.run_sync(
                 lambda: self.eval_master(self.opts, failed=True)

--- a/salt/transport/zeromq.py
+++ b/salt/transport/zeromq.py
@@ -129,7 +129,8 @@ class AsyncZeroMQReqChannel(salt.transport.client.ReqChannel):
             obj = object.__new__(cls)
             obj.__singleton_init__(opts, **kwargs)
             loop_instance_map[key] = obj
-            log.trace('Inserted key into loop_instance_map id {0} for key {1} and process {2}'.format(id(loop_instance_map), key, os.getpid()))
+            log.trace('Inserted key into loop_instance_map id %s for key %s and process %s',
+                      id(loop_instance_map), key, os.getpid())
         else:
             log.debug('Re-using AsyncZeroMQReqChannel for {0}'.format(key))
         return obj
@@ -476,7 +477,8 @@ class AsyncZeroMQPubChannel(salt.transport.mixins.auth.AESPubClientMixin, salt.t
         return self.stream.on_recv(wrap_callback)
 
 
-class ZeroMQReqServerChannel(salt.transport.mixins.auth.AESReqServerMixin, salt.transport.server.ReqServerChannel):
+class ZeroMQReqServerChannel(salt.transport.mixins.auth.AESReqServerMixin,
+                             salt.transport.server.ReqServerChannel):
 
     def __init__(self, opts):
         salt.transport.server.ReqServerChannel.__init__(self, opts)
@@ -497,7 +499,8 @@ class ZeroMQReqServerChannel(salt.transport.mixins.auth.AESReqServerMixin, salt.
             self.clients.setsockopt(zmq.IPV4ONLY, 0)
         self.clients.setsockopt(zmq.BACKLOG, self.opts.get('zmq_backlog', 1000))
         if HAS_ZMQ_MONITOR and self.opts['zmq_monitor']:
-            # Socket monitor shall be used the only for debug  purposes so using threading doesn't look too bad here
+            # Socket monitor shall be used the only for debug
+            # purposes so using threading doesn't look too bad here
             import threading
             self._monitor = ZeroMQSocketMonitor(self.clients)
             t = threading.Thread(target=self._monitor.start_poll)
@@ -580,7 +583,8 @@ class ZeroMQReqServerChannel(salt.transport.mixins.auth.AESReqServerMixin, salt.
         self.context = zmq.Context(1)
         self._socket = self.context.socket(zmq.REP)
         if HAS_ZMQ_MONITOR and self.opts['zmq_monitor']:
-            # Socket monitor shall be used the only for debug  purposes so using threading doesn't look too bad here
+            # Socket monitor shall be used the only for debug
+            # purposes so using threading doesn't look too bad here
             import threading
             self._w_monitor = ZeroMQSocketMonitor(self._socket)
             t = threading.Thread(target=self._w_monitor.start_poll)

--- a/salt/transport/zeromq.py
+++ b/salt/transport/zeromq.py
@@ -518,7 +518,6 @@ class ZeroMQReqServerChannel(salt.transport.mixins.auth.AESReqServerMixin,
 
         log.info('Setting up the master communication server')
         self.clients.bind(self.uri)
-
         self.workers.bind(self.w_uri)
 
         while True:

--- a/salt/transport/zeromq.py
+++ b/salt/transport/zeromq.py
@@ -362,8 +362,7 @@ class AsyncZeroMQPubChannel(salt.transport.mixins.auth.AESPubClientMixin, salt.t
 
         if self.opts['recon_randomize']:
             recon_delay = randint(self.opts['recon_default'],
-                                  self.opts['recon_default'] + self.opts['recon_max']
-                          )
+                                  self.opts['recon_default'] + self.opts['recon_max'])
 
             log.debug("Generated random reconnect delay between '{0}ms' and '{1}ms' ({2})".format(
                 self.opts['recon_default'],

--- a/salt/transport/zeromq.py
+++ b/salt/transport/zeromq.py
@@ -30,13 +30,11 @@ import salt.transport.server
 import salt.transport.mixins.auth
 from salt.exceptions import SaltReqTimeoutError
 
-import zmq
+from salt.utils.zeromq import zmq, ZMQDefaultLoop, install_zmq, ZMQ_VERSION_INFO, LIBZMQ_VERSION_INFO
 import zmq.error
 import zmq.eventloop.ioloop
-# support pyzmq 13.0.x, TODO: remove once we force people to 14.0.x
-if not hasattr(zmq.eventloop.ioloop, 'ZMQIOLoop'):
-    zmq.eventloop.ioloop.ZMQIOLoop = zmq.eventloop.ioloop.IOLoop
 import zmq.eventloop.zmqstream
+
 try:
     import zmq.utils.monitor
     HAS_ZMQ_MONITOR = True

--- a/salt/transport/zeromq.py
+++ b/salt/transport/zeromq.py
@@ -1015,7 +1015,8 @@ class AsyncReqMessageClient(object):
 
             try:
                 ret = yield future
-            except:  # pylint: disable=W0702
+            except Exception as err:  # pylint: disable=W0702
+                log.debug('Re-init ZMQ socket: %s', err)
                 self._init_socket()  # re-init the zmq socket (no other way in zmq)
                 del self.send_queue[0]
                 continue

--- a/salt/transport/zeromq.py
+++ b/salt/transport/zeromq.py
@@ -533,10 +533,11 @@ class ZeroMQReqServerChannel(salt.transport.mixins.auth.AESReqServerMixin,
             return
         log.info('MWorkerQueue under PID %s is closing', os.getpid())
         self._closing = True
-        if hasattr(self, '_monitor') and self._monitor is not None:
+        # pylint: disable=E0203
+        if getattr(self, '_monitor', None) is not None:
             self._monitor.stop()
             self._monitor = None
-        if hasattr(self, '_w_monitor') and self._w_monitor is not None:
+        if getattr(self, '_w_monitor', None) is not None:
             self._w_monitor.stop()
             self._w_monitor = None
         if hasattr(self, 'clients') and self.clients.closed is False:
@@ -549,6 +550,7 @@ class ZeroMQReqServerChannel(salt.transport.mixins.auth.AESReqServerMixin,
             self._socket.close()
         if hasattr(self, 'context') and self.context.closed is False:
             self.context.term()
+        # pylint: enable=E0203
 
     def pre_fork(self, process_manager):
         '''

--- a/salt/transport/zeromq.py
+++ b/salt/transport/zeromq.py
@@ -328,7 +328,7 @@ class AsyncZeroMQPubChannel(salt.transport.mixins.auth.AESPubClientMixin, salt.t
             install_zmq()
             self.io_loop = ZMQDefaultLoop.current()
 
-        self.hexid = hashlib.sha1(salt.utils.stringutils.to_bytes(self.opts['id'])).hexdigest()
+        self.hexid = hashlib.sha1(salt.utils.to_bytes(self.opts['id'])).hexdigest()
         self.auth = salt.crypt.AsyncAuth(self.opts, io_loop=self.io_loop)
         self.serial = salt.payload.Serial(self.opts)
         self.context = zmq.Context()

--- a/salt/utils/async.py
+++ b/salt/utils/async.py
@@ -7,26 +7,9 @@ from __future__ import absolute_import
 
 import tornado.ioloop
 import tornado.concurrent
-# attempt to use zmq-- if we have it otherwise fallback to tornado loop
-try:
-    import zmq.eventloop.ioloop
-    # support pyzmq 13.0.x, TODO: remove once we force people to 14.0.x
-    if not hasattr(zmq.eventloop.ioloop, 'ZMQIOLoop'):
-        zmq.eventloop.ioloop.ZMQIOLoop = zmq.eventloop.ioloop.IOLoop
-    HAS_ZMQ = True
-except ImportError:
-    HAS_ZMQ = False
-
-import tornado
-TORNADO_50 = tornado.version_info >= (5,)
-
-if HAS_ZMQ and not TORNADO_50:
-    LOOP_CLASS = zmq.eventloop.ioloop.ZMQIOLoop
-else:
-    import tornado.ioloop
-    LOOP_CLASS = tornado.ioloop.IOLoop
 
 import contextlib
+from salt.utils import zeromq
 
 
 @contextlib.contextmanager
@@ -60,7 +43,7 @@ class SyncWrapper(object):
         if kwargs is None:
             kwargs = {}
 
-        self.io_loop = LOOP_CLASS()
+        self.io_loop = zeromq.ZMQDefaultLoop()
         kwargs['io_loop'] = self.io_loop
 
         with current_ioloop(self.io_loop):

--- a/salt/utils/cache.py
+++ b/salt/utils/cache.py
@@ -18,11 +18,7 @@ import salt.utils.dictupdate
 
 # Import third party libs
 from salt.ext.six.moves import range  # pylint: disable=import-error,redefined-builtin
-try:
-    import zmq
-    HAS_ZMQ = True
-except ImportError:
-    HAS_ZMQ = False
+from salt.utils.zeromq import zmq
 
 log = logging.getLogger(__name__)
 

--- a/salt/utils/master.py
+++ b/salt/utils/master.py
@@ -29,12 +29,8 @@ from salt.utils.cache import CacheCli as cache_cli
 from salt.utils.process import MultiprocessingProcess
 
 # Import third party libs
-import salt.ext.six as six
-try:
-    import zmq
-    HAS_ZMQ = True
-except ImportError:
-    HAS_ZMQ = False
+from salt.ext import six
+from salt.utils.zeromq import zmq
 
 log = logging.getLogger(__name__)
 

--- a/salt/utils/zeromq.py
+++ b/salt/utils/zeromq.py
@@ -44,7 +44,8 @@ def install_zmq():
     :return:
     '''
     if zmq and ZMQ_VERSION_INFO[0] < 17:
-        zmq.eventloop.ioloop.install()
+        if not tornado.version_info >= (5,):
+            zmq.eventloop.ioloop.install()
 
 
 def check_ipc_path_max_len(uri):

--- a/salt/utils/zeromq.py
+++ b/salt/utils/zeromq.py
@@ -24,7 +24,7 @@ try:
         if ZMQ_VERSION_INFO[0] > 16:  # 17.0.x+ deprecates zmq's ioloops
             ZMQDefaultLoop = tornado.ioloop.IOLoop
 except Exception as ex:
-    log.exception(ex)
+    log.exception('Error while getting PyZMQ library version')
 
 if ZMQDefaultLoop is None:
     try:

--- a/salt/utils/zeromq.py
+++ b/salt/utils/zeromq.py
@@ -32,8 +32,11 @@ if ZMQDefaultLoop is None:
         # Support for ZeroMQ 13.x
         if not hasattr(zmq.eventloop.ioloop, 'ZMQIOLoop'):
             zmq.eventloop.ioloop.ZMQIOLoop = zmq.eventloop.ioloop.IOLoop
-        ZMQDefaultLoop = zmq.eventloop.ioloop.ZMQIOLoop
+        if not tornado.version_info >= (5,):
+            ZMQDefaultLoop = zmq.eventloop.ioloop.ZMQIOLoop
     except ImportError:
+        ZMQDefaultLoop = None
+    if ZMQDefaultLoop is None:
         ZMQDefaultLoop = tornado.ioloop.IOLoop
 
 

--- a/salt/utils/zeromq.py
+++ b/salt/utils/zeromq.py
@@ -41,17 +41,6 @@ if ZMQDefaultLoop is None:
     if ZMQDefaultLoop is None:
         ZMQDefaultLoop = tornado.ioloop.IOLoop
 
-# Build version info
-if zmq:
-    if hasattr(zmq, 'zmq_version_info'):
-        zmq_version_info = zmq.zmq_version_info()
-    else:
-        # PyZMQ <= 2.1.9 does not have zmq_version_info, fall back to
-        # using zmq.zmq_version() and build a version info tuple.
-        zmq_version_info = tuple([int(v_el) for v_el in zmq.zmq_version().split('.')])
-else:
-    zmq_version_info = (-1, -1, -1)
-
 
 def install_zmq():
     '''

--- a/salt/utils/zeromq.py
+++ b/salt/utils/zeromq.py
@@ -34,7 +34,7 @@ if ZMQDefaultLoop is None:
         # Support for ZeroMQ 13.x
         if not hasattr(zmq.eventloop.ioloop, 'ZMQIOLoop'):
             zmq.eventloop.ioloop.ZMQIOLoop = zmq.eventloop.ioloop.IOLoop
-        if not tornado.version_info >= (5,):
+        if tornado.version_info < (5,):
             ZMQDefaultLoop = zmq.eventloop.ioloop.ZMQIOLoop
     except ImportError:
         ZMQDefaultLoop = None
@@ -49,7 +49,7 @@ def install_zmq():
     :return:
     '''
     if zmq and ZMQ_VERSION_INFO[0] < 17:
-        if not tornado.version_info >= (5,):
+        if tornado.version_info < (5,):
             zmq.eventloop.ioloop.install()
 
 

--- a/salt/utils/zeromq.py
+++ b/salt/utils/zeromq.py
@@ -39,6 +39,17 @@ if ZMQDefaultLoop is None:
     if ZMQDefaultLoop is None:
         ZMQDefaultLoop = tornado.ioloop.IOLoop
 
+# Build version info
+if zmq:
+    if hasattr(zmq, 'zmq_version_info'):
+        zmq_version_info = zmq.zmq_version_info()
+    else:
+        # PyZMQ <= 2.1.9 does not have zmq_version_info, fall back to
+        # using zmq.zmq_version() and build a version info tuple.
+        zmq_version_info = tuple([int(v_el) for v_el in zmq.zmq_version().split('.')])
+else:
+    zmq_version_info = (-1, -1, -1)
+
 
 def install_zmq():
     '''

--- a/salt/utils/zeromq.py
+++ b/salt/utils/zeromq.py
@@ -17,10 +17,12 @@ except ImportError:
 
 ZMQDefaultLoop = None
 ZMQ_VERSION_INFO = (-1, -1, -1)
+LIBZMQ_VERSION_INFO = (-1, -1, -1)
 
 try:
     if zmq:
-        ZMQ_VERSION_INFO = [int(v_el) for v_el in zmq.__version__.split('.')]
+        ZMQ_VERSION_INFO = tuple([int(v_el) for v_el in zmq.__version__.split('.')])
+        LIBZMQ_VERSION_INFO = tuple([int(v_el) for v_el in zmq.zmq_version().split('.')])
         if ZMQ_VERSION_INFO[0] > 16:  # 17.0.x+ deprecates zmq's ioloops
             ZMQDefaultLoop = tornado.ioloop.IOLoop
 except Exception as ex:

--- a/salt/utils/zeromq.py
+++ b/salt/utils/zeromq.py
@@ -37,12 +37,20 @@ if ZMQDefaultLoop is None:
         ZMQDefaultLoop = tornado.ioloop.IOLoop
 
 
+def install_zmq():
+    '''
+    While pyzmq 17 no longer needs any special integration for tornado,
+    older version still need one.
+    :return:
+    '''
+    if zmq and ZMQ_VERSION_INFO[0] < 17:
+        zmq.eventloop.ioloop.install()
 
 
 def check_ipc_path_max_len(uri):
     # The socket path is limited to 107 characters on Solaris and
     # Linux, and 103 characters on BSD-based systems.
-    if not HAS_ZMQ:
+    if zmq is None:
         return
     ipc_path_max_len = getattr(zmq, 'IPC_PATH_MAX_LEN', 103)
     if ipc_path_max_len and len(uri) > ipc_path_max_len:

--- a/salt/utils/zeromq.py
+++ b/salt/utils/zeromq.py
@@ -24,7 +24,7 @@ try:
         if ZMQ_VERSION_INFO[0] > 16:  # 17.0.x+ deprecates zmq's ioloops
             ZMQDefaultLoop = tornado.ioloop.IOLoop
 except Exception as ex:
-    log.exception('Error while getting PyZMQ library version')
+    log.exception('Error while getting LibZMQ/PyZMQ library version')
 
 if ZMQDefaultLoop is None:
     try:

--- a/salt/utils/zeromq.py
+++ b/salt/utils/zeromq.py
@@ -25,7 +25,7 @@ try:
         LIBZMQ_VERSION_INFO = tuple([int(v_el) for v_el in zmq.zmq_version().split('.')])
         if ZMQ_VERSION_INFO[0] > 16:  # 17.0.x+ deprecates zmq's ioloops
             ZMQDefaultLoop = tornado.ioloop.IOLoop
-except Exception as ex:
+except Exception:
     log.exception('Error while getting LibZMQ/PyZMQ library version')
 
 if ZMQDefaultLoop is None:

--- a/tests/integration/netapi/rest_tornado/test_app.py
+++ b/tests/integration/netapi/rest_tornado/test_app.py
@@ -18,13 +18,9 @@ from tests.support.helpers import flaky
 from tests.support.unit import skipIf
 
 # Import 3rd-party libs
-import salt.ext.six as six
-try:
-    import zmq
-    from zmq.eventloop.ioloop import ZMQIOLoop
-    HAS_ZMQ_IOLOOP = True
-except ImportError:
-    HAS_ZMQ_IOLOOP = False
+from salt.ext import six
+from salt.utils.zeromq import zmq, ZMQDefaultLoop as ZMQIOLoop
+HAS_ZMQ_IOLOOP = bool(zmq)
 
 
 def json_loads(data):


### PR DESCRIPTION
### What does this PR do?

- Backports https://github.com/saltstack/salt/pull/46002
- Adds Tornado 5 fixes
- Breaks something, maybe... :wink: 

### Tests written?

No, this is import-based changes

### Commits signed with GPG?

No

@gtmanfred @rallytime Here, you have it!