### PR TITLE
gitfs: Fix identification of base env when saltenv mapping is disabled

### DIFF
--- a/salt/utils/gitfs.py
+++ b/salt/utils/gitfs.py
@@ -467,7 +467,10 @@ class GitProvider(object):
             if rname in self.saltenv_revmap:
                 env_set.update(self.saltenv_revmap[rname])
             else:
-                env_set.add('base' if rname == self.base else rname)
+                if rname == self.base:
+                    env_set.add('base')
+                elif not self.disable_saltenv_mapping:
+                    env_set.add(rname)
 
         use_branches = 'branch' in self.ref_types
         use_tags = 'tag' in self.ref_types
@@ -2692,9 +2695,7 @@ class GitFS(GitBase):
                 return cache_match
         ret = set()
         for repo in self.remotes:
-            repo_envs = set()
-            if not repo.disable_saltenv_mapping:
-                repo_envs.update(repo.envs())
+            repo_envs = repo.envs()
             for env_list in six.itervalues(repo.saltenv_revmap):
                 repo_envs.update(env_list)
             ret.update([x for x in repo_envs if repo.env_is_exposed(x)])

--- a/tests/unit/fileserver/test_gitfs.py
+++ b/tests/unit/fileserver/test_gitfs.py
@@ -305,14 +305,14 @@ class GitFSTestFuncs(object):
             gitfs_disable_saltenv_mapping: True
             gitfs_saltenv:
               - foo:
-                - ref: base
+                - ref: somebranch
             '''))
         with patch.dict(gitfs.__opts__, opts):
             gitfs.update()
             ret = gitfs.envs(ignore_cache=True)
             # Since we are restricting to tags only, the tag should appear in
             # the envs list, but the branches should not.
-            self.assertEqual(ret, ['foo'])
+            self.assertEqual(ret, ['base', 'foo'])
 
     def test_disable_saltenv_mapping_global_with_mapping_defined_per_remote(self):
         '''
@@ -326,14 +326,14 @@ class GitFSTestFuncs(object):
               - file://{0}:
                 - saltenv:
                   - bar:
-                    - ref: base
+                    - ref: somebranch
             '''.format(TMP_REPO_DIR)))
         with patch.dict(gitfs.__opts__, opts):
             gitfs.update()
             ret = gitfs.envs(ignore_cache=True)
             # Since we are restricting to tags only, the tag should appear in
             # the envs list, but the branches should not.
-            self.assertEqual(ret, ['bar'])
+            self.assertEqual(ret, ['bar', 'base'])
 
     def test_disable_saltenv_mapping_per_remote_with_mapping_defined_globally(self):
         '''
@@ -348,14 +348,14 @@ class GitFSTestFuncs(object):
 
             gitfs_saltenv:
               - hello:
-                - ref: base
-            '''))
+                - ref: somebranch
+            '''.format(TMP_REPO_DIR)))
         with patch.dict(gitfs.__opts__, opts):
             gitfs.update()
             ret = gitfs.envs(ignore_cache=True)
             # Since we are restricting to tags only, the tag should appear in
             # the envs list, but the branches should not.
-            self.assertEqual(ret, ['hello'])
+            self.assertEqual(ret, ['base', 'hello'])
 
     def test_disable_saltenv_mapping_per_remote_with_mapping_defined_per_remote(self):
         '''
@@ -369,14 +369,14 @@ class GitFSTestFuncs(object):
                 - disable_saltenv_mapping: True
                 - saltenv:
                   - world:
-                    - ref: base
+                    - ref: somebranch
             '''.format(TMP_REPO_DIR)))
         with patch.dict(gitfs.__opts__, opts):
             gitfs.update()
             ret = gitfs.envs(ignore_cache=True)
             # Since we are restricting to tags only, the tag should appear in
             # the envs list, but the branches should not.
-            self.assertEqual(ret, ['world'])
+            self.assertEqual(ret, ['base', 'world'])
 
 
 class GitFSTestBase(object):


### PR DESCRIPTION
Resolves #47260.