### PR TITLE
Fix issue where the cwd was being removed

### DIFF
--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -2077,7 +2077,9 @@ def script(source,
         # Create a temp working directory
         cwd = tempfile.mkdtemp(dir=__opts__['cachedir'])
         win_cwd = True
-        salt.utils.win_dacl.set_permissions(obj_name=cwd, principal=runas, permissions='full_control')
+        salt.utils.win_dacl.set_permissions(obj_name=cwd,
+                                            principal=runas,
+                                            permissions='full_control')
 
     path = salt.utils.files.mkstemp(dir=cwd, suffix=os.path.splitext(source)[1])
 


### PR DESCRIPTION
### What does this PR do?
Fixes an issue where the passed `cwd` was being deleted by cmd.script. The only `cwd` we want to delete is the temporary one created by salt if `cwd` is not passed on Windows. The runas functionality requires a `cwd` on Windows.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/47125

### Previous Behavior
Any directory passed in cwd was being deleted on Windows

### New Behavior
Only deletes the temp cwd created by salt

### Tests written?
No

### Commits signed with GPG?
Yes