### PR TITLE
Fixes a bug of rest_tornado's 'local' client, complement fix of #46326

### DIFF
--- a/tests/integration/netapi/rest_tornado/test_app.py
+++ b/tests/integration/netapi/rest_tornado/test_app.py
@@ -89,8 +89,6 @@ class TestSaltAPIHandler(_SaltnadoIntegrationTestCase):
         self.assertEqual(response.code, 302)
         self.assertEqual(response.headers['Location'], '/login')
 
-    # Local client tests
-    @skipIf(True, 'to be re-enabled when #23623 is merged')
     def test_simple_local_post(self):
         '''
         Test a basic API of /
@@ -108,7 +106,8 @@ class TestSaltAPIHandler(_SaltnadoIntegrationTestCase):
                               request_timeout=30,
                               )
         response_obj = json_loads(response.body)
-        self.assertEqual(response_obj['return'], [{'minion': True, 'sub_minion': True}])
+        self.assertEqual(len(response_obj['return']), 1)
+        self.assertEqual(response_obj['return'][0], {'minion': True, 'sub_minion': True})
 
     def test_simple_local_post_no_tgt(self):
         '''
@@ -129,8 +128,6 @@ class TestSaltAPIHandler(_SaltnadoIntegrationTestCase):
         response_obj = json_loads(response.body)
         self.assertEqual(response_obj['return'], ["No minions matched the target. No command was sent, no jid was assigned."])
 
-    # local client request body test
-    @skipIf(True, 'Undetermined race condition in test. Temporarily disabled.')
     def test_simple_local_post_only_dictionary_request(self):
         '''
         Test a basic API of /
@@ -148,7 +145,8 @@ class TestSaltAPIHandler(_SaltnadoIntegrationTestCase):
                               request_timeout=30,
                               )
         response_obj = json_loads(response.body)
-        self.assertEqual(response_obj['return'], [{'minion': True, 'sub_minion': True}])
+        self.assertEqual(len(response_obj['return']), 1)
+        self.assertEqual(response_obj['return'][0], {'minion': True, 'sub_minion': True})
 
     def test_simple_local_post_invalid_request(self):
         '''

--- a/tests/integration/netapi/rest_tornado/test_app.py
+++ b/tests/integration/netapi/rest_tornado/test_app.py
@@ -53,6 +53,7 @@ class TestSaltAPIHandler(_SaltnadoIntegrationTestCase):
         application = self.build_tornado_app(urls)
 
         application.event_listener = saltnado.EventListener({}, self.opts)
+        self.application = application
         return application
 
     def test_root(self):
@@ -260,6 +261,28 @@ class TestSaltAPIHandler(_SaltnadoIntegrationTestCase):
                               )
         response_obj = json_loads(response.body)
         self.assertEqual(response_obj['return'], [{}])
+
+    def test_simple_local_post_only_dictionary_request_with_order_masters(self):
+        '''
+        Test a basic API of /
+        '''
+        low = {'client': 'local',
+                'tgt': '*',
+                'fun': 'test.ping',
+              }
+        response = self.fetch('/',
+                              method='POST',
+                              body=salt.utils.json.dumps(low),
+                              headers={'Content-Type': self.content_type_map['json'],
+                                       saltnado.AUTH_TOKEN_HEADER: self.token['token']},
+                              connect_timeout=30,
+                              request_timeout=30,
+                              )
+        response_obj = salt.utils.json.loads(response.body)
+
+        self.application.opts['order_masters'] = []
+        self.application.opts['syndic_wait'] = 5
+        self.assertEqual(response_obj['return'], [{'minion': True, 'sub_minion': True}])
 
     # runner tests
     def test_simple_local_runner_post(self):


### PR DESCRIPTION
### What does this PR do?

Targeting minions to subscribe before publishing  a requested job. The exact targeted minions can get after publishing a job, but this newer version of 'local' client subscribes minion's return before publishing the job, to not miss the results. Thus, to get what minions will be targeted, this fix changes the logic to use the `ckminions`' `check_minions` method.

### What issues does this PR fix or reference?

This fix is a complement fix of #46326, and a relevant discussion is in #47200 too.

 ### Tests written?

No, but re-enabled the two tests will cover the cases what I missed.

### Commits signed with GPG?

Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.