### PR TITLE
revert instantiating a Caller Client in the engine

### DIFF
--- a/doc/topics/releases/2018.3.1.rst
+++ b/doc/topics/releases/2018.3.1.rst
@@ -3,3 +3,12 @@ Salt 2018.3.1 Release Notes
 ===========================
 
 Version 2018.3.1 is a bugfix release for :ref:`2018.3.0 <release-2018-3-0>`.
+
+Changes to Slack Engine pillars
+-------------------------------
+
+When using ``groups_pillar_name`` for the slack engine, the engine should be
+used as part of a salt-minion process running on the master.  This will allow
+the minion to have pillars assigned to it, and will still allow the engine to
+create a LocalClient connection to the master ipc sockets to control
+environments.

--- a/salt/engines/slack.py
+++ b/salt/engines/slack.py
@@ -88,6 +88,13 @@ In addition, other groups are being loaded from pillars.
 
 :depends: slackclient
 
+
+.. note:: groups_pillar_name
+
+    In order to use this, the engine must be running as of a minion running on
+    the master, so that the ``Caller`` client can be used to retrieve that
+    minions pillar data, because the master process does not have pillars.
+
 '''
 
 # Import python libraries
@@ -237,10 +244,8 @@ class SlackClient(object):
         XXX: instead of using Caller, make the minion to use configurable so there could be some
              restrictions placed on what pillars can be used.
         '''
-        if pillar_name:
-            caller = salt.client.Caller()
-            pillar_groups = caller.cmd('pillar.get', pillar_name)
-            # pillar_groups = __salt__['pillar.get'](pillar_name, {})
+        if pillar_name and __opts__['__role'] == 'minion':
+            pillar_groups = __salt__['pillar.get'](pillar_name, {})
             log.debug('Got pillar groups %s from pillar %s', pillar_groups, pillar_name)
             log.debug('pillar groups is %s', pillar_groups)
             log.debug('pillar groups type is %s', type(pillar_groups))

--- a/salt/engines/slack.py
+++ b/salt/engines/slack.py
@@ -91,7 +91,7 @@ In addition, other groups are being loaded from pillars.
 
 .. note:: groups_pillar_name
 
-    In order to use this, the engine must be running as of a minion running on
+    In order to use this, the engine must be running as a minion running on
     the master, so that the ``Caller`` client can be used to retrieve that
     minions pillar data, because the master process does not have pillars.
 


### PR DESCRIPTION
### What does this PR do?
This Caller client prevents running the salt master as a non root user.  Also,
master processes are not assigned pillars so it is using whatever minion get
instantiated on the master from a caller client.

Instead, to use pillars, the engine should be started on in a minion process.

### What issues does this PR fix or reference?
Fixes https://github.com/saltstack/salt/issues/47416

### Tests written?

No

### Commits signed with GPG?

Yes