### PR TITLE
added auto_assign_public_ipv4 option to state subnet_present and modu…

### DIFF
--- a/salt/modules/boto_vpc.py
+++ b/salt/modules/boto_vpc.py
@@ -844,7 +844,7 @@ def _find_subnets(subnet_name=None, vpc_id=None, cidr=None, tags=None, conn=None
 
 
 def create_subnet(vpc_id=None, cidr_block=None, vpc_name=None,
-                  availability_zone=None, subnet_name=None, tags=None,
+                  availability_zone=None, subnet_name=None, auto_assign_public_ipv4=False, tags=None,
                   region=None, key=None, keyid=None, profile=None):
     '''
     Given a valid VPC ID or Name and a CIDR block, create a subnet for the VPC.
@@ -873,10 +873,15 @@ def create_subnet(vpc_id=None, cidr_block=None, vpc_name=None,
     except BotoServerError as e:
         return {'created': False, 'error': salt.utils.boto.get_error(e)}
 
-    return _create_resource('subnet', name=subnet_name, tags=tags, vpc_id=vpc_id,
+    subnet_object = _create_resource('subnet', name=subnet_name, tags=tags, vpc_id=vpc_id,
                             availability_zone=availability_zone,
                             cidr_block=cidr_block, region=region, key=key,
                             keyid=keyid, profile=profile)
+    # if auto_assign_public_ipv4 is requested set that to true using boto3
+    if auto_assign_public_ipv4:
+        conn3 = _get_conn3(region=region, key=key, keyid=keyid, profile=profile)
+        conn3.modify_subnet_attribute(MapPublicIpOnLaunch={'Value': True}, SubnetId=subnet_object['id'])
+    return subnet_object
 
 
 def delete_subnet(subnet_id=None, subnet_name=None, region=None, key=None,

--- a/salt/states/boto_vpc.py
+++ b/salt/states/boto_vpc.py
@@ -498,7 +498,7 @@ def dhcp_options_absent(name=None, dhcp_options_id=None, region=None, key=None, 
 
 
 def subnet_present(name, cidr_block, vpc_name=None, vpc_id=None,
-                   availability_zone=None, tags=None,
+                   availability_zone=None, auto_assign_public_ipv4=False, tags=None,
                    region=None, key=None,
                    keyid=None, profile=None,
                    route_table_id=None, route_table_name=None):
@@ -610,6 +610,7 @@ def subnet_present(name, cidr_block, vpc_name=None, vpc_id=None,
         r = __salt__['boto_vpc.create_subnet'](subnet_name=name,
                                                cidr_block=cidr_block,
                                                availability_zone=availability_zone,
+                                               auto_assign_public_ipv4=auto_assign_public_ipv4,
                                                vpc_name=vpc_name, vpc_id=vpc_id,
                                                tags=tags, region=region,
                                                key=key, keyid=keyid,


### PR DESCRIPTION
added auto_assign_public_ipv4 option to state subnet_present and module create_subnet

### What does this PR do?
added auto_assign_public_ipv4 option to state subnet_present and module create_subnet
### What issues does this PR fix or reference?
added auto_assign_public_ipv4 option to state subnet_present and module create_subnet
### Previous Behavior
No way to set the auto assign public ipv4 to true in the subnet_present module

### New Behavior
You can now create a subnet with auto assign public ipv4 set to true

### Tests written?

No

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
