### PR TITLE
make pillar top_matches work with node groups

### DIFF
--- a/doc/topics/targeting/nodegroups.rst
+++ b/doc/topics/targeting/nodegroups.rst
@@ -59,11 +59,13 @@ To match a nodegroup on the CLI, use the ``-N`` command-line option:
 
     salt -N group1 test.ping
 
+.. versionadded:: Fluorine
 .. note::
 
-    The ``N@`` classifier cannot be used in compound matches within the CLI or
-    :term:`top file`, it is only recognized in the :conf_master:`nodegroups`
-    master config file parameter.
+    The ``N@`` classifier historically could not be used in compound matches
+    within the CLI or :term:`top file`, it was only recognized in the
+    :conf_master:`nodegroups` master config file parameter. As of Fluorine
+    release, this limitation no longer exists.
 
 To match a nodegroup in your :term:`top file`, make sure to put ``- match:
 nodegroup`` on the line directly following the nodegroup name.

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -3421,7 +3421,8 @@ class Matcher(object):
                 if 'N' == target_info['engine']:
                     # if we encounter a node group, just evaluate it in-place
                     decomposed = salt.utils.minions.nodegroup_comp(target_info['pattern'], nodegroups)
-                    words = decomposed + words
+                    if decomposed:
+                        words = decomposed + words
                     continue
 
                 engine = ref.get(target_info['engine'])

--- a/salt/utils/minions.py
+++ b/salt/utils/minions.py
@@ -475,6 +475,8 @@ class CkMinions(object):
         minions = set(self._pki_minions())
         log.debug('minions: %s', minions)
 
+        nodegroups = self.opts.get('nodegroups', {})
+
         if self.opts.get('minion_data_cache', False):
             ref = {'G': self._check_grain_minions,
                    'P': self._check_grain_pcre_minions,
@@ -497,9 +499,11 @@ class CkMinions(object):
             if isinstance(expr, six.string_types):
                 words = expr.split()
             else:
-                words = expr
+                # we make a shallow copy in order to not affect the passed in arg
+                words = expr[:]
 
-            for word in words:
+            while words:
+                word = words.pop(0)
                 target_info = parse_target(word)
 
                 # Easy check first
@@ -556,9 +560,11 @@ class CkMinions(object):
 
                 elif target_info and target_info['engine']:
                     if 'N' == target_info['engine']:
-                        # Nodegroups should already be expanded/resolved to other engines
-                        log.error('Detected nodegroup expansion failure of "%s"', word)
-                        return {'minions': [], 'missing': []}
+                        # if we encounter a node group, just evaluate it in-place
+                        decomposed = nodegroup_comp(target_info['pattern'], nodegroups)
+                        words = decomposed + words
+                        continue
+
                     engine = ref.get(target_info['engine'])
                     if not engine:
                         # If an unknown engine is called at any time, fail out

--- a/salt/utils/minions.py
+++ b/salt/utils/minions.py
@@ -562,7 +562,8 @@ class CkMinions(object):
                     if 'N' == target_info['engine']:
                         # if we encounter a node group, just evaluate it in-place
                         decomposed = nodegroup_comp(target_info['pattern'], nodegroups)
-                        words = decomposed + words
+                        if decomposed:
+                            words = decomposed + words
                         continue
 
                     engine = ref.get(target_info['engine'])

--- a/tests/integration/files/pillar/base/ng1.sls
+++ b/tests/integration/files/pillar/base/ng1.sls
@@ -1,0 +1,1 @@
+pillar_from_nodegroup: True

--- a/tests/integration/files/pillar/base/ng2.sls
+++ b/tests/integration/files/pillar/base/ng2.sls
@@ -1,0 +1,1 @@
+pillar_from_nodegroup_with_ghost: True

--- a/tests/integration/files/pillar/base/top.sls
+++ b/tests/integration/files/pillar/base/top.sls
@@ -9,3 +9,7 @@ base:
   'localhost':
     - generic
     - blackout
+  'N@mins not L@minion':
+    - ng1
+  'N@missing_minion':
+    - ng2

--- a/tests/integration/minion/test_pillar.py
+++ b/tests/integration/minion/test_pillar.py
@@ -188,6 +188,28 @@ GPG_PILLAR_DECRYPTED = {
     },
 }
 
+class BasePillarTest(ModuleCase):
+    '''
+    Tests for pillar decryption
+    '''
+    def test_pillar_top_compound_match(self, grains=None):
+        '''
+        Test that a compound match topfile that refers to a nodegroup via N@ works
+        as expected.
+        '''
+        if not grains:
+            grains = {}
+        grains['os'] = 'Fedora'
+        pillar_obj = pillar.Pillar(self.get_config('master', from_scratch=True), grains, 'minion', 'base')
+        ret = pillar_obj.compile_pillar()
+        self.assertEqual(ret.get('pillar_from_nodegroup_with_ghost'), True)
+        self.assertEqual(ret.get('pillar_from_nodegroup'), None)
+
+        sub_pillar_obj = pillar.Pillar(self.get_config('master', from_scratch=True), grains, 'sub_minion', 'base')
+        sub_ret = sub_pillar_obj.compile_pillar()
+        self.assertEqual(sub_ret.get('pillar_from_nodegroup_with_ghost'), None)
+        self.assertEqual(sub_ret.get('pillar_from_nodegroup'), True)
+
 
 @skipIf(not salt.utils.path.which('gpg'), 'GPG is not installed')
 class DecryptGPGPillarTest(ModuleCase):
@@ -380,3 +402,4 @@ class DecryptGPGPillarTest(ModuleCase):
             'not a valid decryption renderer. Valid choices are: foo, bar'
         ]
         self.assertEqual(ret, expected)
+

--- a/tests/integration/minion/test_pillar.py
+++ b/tests/integration/minion/test_pillar.py
@@ -188,6 +188,7 @@ GPG_PILLAR_DECRYPTED = {
     },
 }
 
+
 class BasePillarTest(ModuleCase):
     '''
     Tests for pillar decryption
@@ -402,4 +403,3 @@ class DecryptGPGPillarTest(ModuleCase):
             'not a valid decryption renderer. Valid choices are: foo, bar'
         ]
         self.assertEqual(ret, expected)
-

--- a/tests/integration/shell/test_matcher.py
+++ b/tests/integration/shell/test_matcher.py
@@ -101,7 +101,6 @@ class MatchTest(ShellCase, ShellCaseCommonTestsMixin):
         self.assertFalse(minion_in_returns('sub_minion', data))
 
 
-
     def test_nodegroup(self):
         '''
         test salt nodegroup matcher

--- a/tests/integration/shell/test_matcher.py
+++ b/tests/integration/shell/test_matcher.py
@@ -100,7 +100,6 @@ class MatchTest(ShellCase, ShellCaseCommonTestsMixin):
         self.assertTrue(minion_in_returns('minion', data))
         self.assertFalse(minion_in_returns('sub_minion', data))
 
-
     def test_nodegroup(self):
         '''
         test salt nodegroup matcher

--- a/tests/integration/shell/test_matcher.py
+++ b/tests/integration/shell/test_matcher.py
@@ -88,6 +88,19 @@ class MatchTest(ShellCase, ShellCaseCommonTestsMixin):
         data = self.run_salt("-C 'J%@knights%^(Lancelot|Galahad)$' test.ping")
         self.assertTrue(minion_in_returns('minion', data))
         self.assertTrue(minion_in_returns('sub_minion', data))
+        time.sleep(2)
+        data = self.run_salt("-C 'N@multiline_nodegroup' test.ping")
+        self.assertTrue(minion_in_returns('minion', data))
+        self.assertTrue(minion_in_returns('sub_minion', data))
+        time.sleep(2)
+        data = self.run_salt("-C 'N@multiline_nodegroup not sub_minion' test.ping")
+        self.assertTrue(minion_in_returns('minion', data))
+        self.assertFalse(minion_in_returns('sub_minion', data))
+        data = self.run_salt("-C 'N@multiline_nodegroup not @fakenodegroup not sub_minion' test.ping")
+        self.assertTrue(minion_in_returns('minion', data))
+        self.assertFalse(minion_in_returns('sub_minion', data))
+
+
 
     def test_nodegroup(self):
         '''


### PR DESCRIPTION
### What does this PR do?
the compound match evaluator to date relied callers to pre-evaluate nodegroups
into their decomposed state. in some places this wasn't happening. Rather than
fix every call site, teach compound_match to evaluate nodegroups in place.

It seems matchers were refactored to salt.utils.minions at some point but the
original minion.py matcher was not ported to use it. Given the hugeness of that
change, i've left as is and ported my fix to salt.utils.minions as well
instead.

### What issues does this PR fix or reference?
this should fix #6602

### Previous Behavior
nodegroup in compound didn't work.

### New Behavior
it works.

### Tests written?
Yes

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
