### PR TITLE
Enable passing test=False as kwarg from orchestration file to minion in permanent test mode

### DIFF
--- a/doc/topics/releases/fluorine.rst
+++ b/doc/topics/releases/fluorine.rst
@@ -470,3 +470,22 @@ It is also possible to use several alternative versions of Salt. You can for ins
 a minimal tarball using runners and include that. But this is only possible, when such specific
 Salt version is also available on the Master machine, although does not need to be directly
 installed together with the older Python interpreter.
+
+=======
+State Module Changes
+====================
+
+states.saltmod
+--------------
+The 'test' option now defaults to None. A value of True or False set here is
+passed to the state being run and can be used to override a ``test:True`` option
+set in the minion's config file. In previous releases the minion's config option
+would take precedence and it would be impossible to run an orchestration on a
+minion with test mode set to True in the config file.
+
+If a minion is not in permanent test mode due to the config file and the 'test'
+argument here is left as None then a value of ``test=True`` on the command-line is
+passed correctly to the minion to run an orchestration in test mode. At present
+it is not possible to pass ``test=False`` on the command-line to override a
+minion in permanent test mode and so the ``test:False`` option must still be set
+in the orchestration file.

--- a/salt/states/saltmod.py
+++ b/salt/states/saltmod.py
@@ -170,7 +170,7 @@ def state(name,
 
     test
         Pass ``test=true`` or ``test=false`` through to the state function. This
-        can be used to overide a test mode set in the minion's config file. If 
+        can be used to overide a test mode set in the minion's config file. If
         left as the default of None and the 'test' mode is supplied on the
         command line, that value is passed instead.
 

--- a/salt/states/saltmod.py
+++ b/salt/states/saltmod.py
@@ -116,7 +116,7 @@ def state(name,
         sls=None,
         top=None,
         saltenv=None,
-        test=False,
+        test=None,
         pillar=None,
         pillarenv=None,
         expect_minions=True,
@@ -169,7 +169,10 @@ def state(name,
         containing a single sls file, or a list of sls files
 
     test
-        Pass ``test=true`` through to the state function
+        Pass ``test=true`` or ``test=false`` through to the state function. This
+        can be used to overide a test mode set in the minion's config file. If 
+        left as the default of None and the 'test' mode is supplied on the
+        command line, that value is passed instead.
 
     pillar
         Pass the ``pillar`` kwarg through to the state function
@@ -283,8 +286,8 @@ def state(name,
         state_ret['result'] = False
         return state_ret
 
-    if test or __opts__.get('test'):
-        cmd_kw['kwarg']['test'] = True
+    if test is not None or __opts__.get('test'):
+        cmd_kw['kwarg']['test'] = test if test is not None else __opts__.get('test')
 
     if pillar:
         cmd_kw['kwarg']['pillar'] = pillar


### PR DESCRIPTION
### What does this PR do?
Enables passing test mode=False as kwarg from orchestration file down to minion so as to override a minion with test:True enabled in the config file.

NOTE: This is a re-implementation of #45253 as that one got horribly messed up after a rebase.

### What issues does this PR fix or reference?

#24209

### Previous Behavior

Minion would ignore the test mode override and execute states in test mode regardless.

### New Behavior

Minion now receives and uses the test=False override from the orchestration file.

### Tests written?

No

### Commits signed with GPG?

No