### PR TITLE
Add catch for VPCAssociationNotFound

### DIFF
--- a/salt/modules/boto3_route53.py
+++ b/salt/modules/boto3_route53.py
@@ -636,6 +636,10 @@ def disassociate_vpc_from_hosted_zone(HostedZoneId=None, Name=None, VPCId=None,
             r = conn.disassociate_vpc_from_hosted_zone(**args)
             return _wait_for_sync(r['ChangeInfo']['Id'], conn)
         except ClientError as e:
+            if e.response.get('Error', {}).get('Code') == 'VPCAssociationNotFound':
+                log.debug('No VPC Association exists.')
+                # return True since the current state is the desired one
+                return True
             if tries and e.response.get('Error', {}).get('Code') == 'Throttling':
                 log.debug('Throttled by AWS API.')
                 time.sleep(3)


### PR DESCRIPTION
### What does this PR do?
Add a catch for when no apv association exists
### What issues does this PR fix or reference?
Add a catch for when no apv association exists
### Previous Behavior
If no vpc associated existed it would just continuously error out

### New Behavior
Returns true because the current state is the desired one

### Tests written?

No

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
