### PR TITLE
lgpo fix for issue #47436

### DIFF
--- a/salt/modules/win_lgpo.py
+++ b/salt/modules/win_lgpo.py
@@ -3679,7 +3679,7 @@ def _checkAllAdmxPolicies(policy_class,
             if ENABLED_VALUE_XPATH(admx_policy) and this_policy_setting == 'Not Configured':
                 # some policies have a disabled list but not an enabled list
                 # added this to address those issues
-                if DISABLED_LIST_XPATH(admx_policy):
+                if DISABLED_LIST_XPATH(admx_policy) or DISABLED_VALUE_XPATH(admx_policy):
                     element_only_enabled_disabled = False
                     explicit_enable_disable_value_setting = True
                 if _checkValueItemParent(admx_policy,
@@ -3689,14 +3689,14 @@ def _checkAllAdmxPolicies(policy_class,
                                          ENABLED_VALUE_XPATH,
                                          policy_filedata):
                     this_policy_setting = 'Enabled'
-                    log.debug('{0} is enabled'.format(this_policyname))
+                    log.debug('{0} is enabled by detected ENABLED_VALUE_XPATH'.format(this_policyname))
                     if this_policynamespace not in policy_vals:
                         policy_vals[this_policynamespace] = {}
                     policy_vals[this_policynamespace][this_policyname] = this_policy_setting
             if DISABLED_VALUE_XPATH(admx_policy) and this_policy_setting == 'Not Configured':
                 # some policies have a disabled list but not an enabled list
                 # added this to address those issues
-                if ENABLED_LIST_XPATH(admx_policy):
+                if ENABLED_LIST_XPATH(admx_policy) or ENABLED_VALUE_XPATH(admx_policy):
                     element_only_enabled_disabled = False
                     explicit_enable_disable_value_setting = True
                 if _checkValueItemParent(admx_policy,
@@ -3706,25 +3706,27 @@ def _checkAllAdmxPolicies(policy_class,
                                          DISABLED_VALUE_XPATH,
                                          policy_filedata):
                     this_policy_setting = 'Disabled'
-                    log.debug('{0} is disabled'.format(this_policyname))
+                    log.debug('{0} is disabled by detected DISABLED_VALUE_XPATH'.format(this_policyname))
                     if this_policynamespace not in policy_vals:
                         policy_vals[this_policynamespace] = {}
                     policy_vals[this_policynamespace][this_policyname] = this_policy_setting
             if ENABLED_LIST_XPATH(admx_policy) and this_policy_setting == 'Not Configured':
-                element_only_enabled_disabled = False
-                explicit_enable_disable_value_setting = True
+                if DISABLED_LIST_XPATH(admx_policy) or DISABLED_VALUE_XPATH(admx_policy):
+                    element_only_enabled_disabled = False
+                    explicit_enable_disable_value_setting = True
                 if _checkListItem(admx_policy, this_policyname, this_key, ENABLED_LIST_XPATH, policy_filedata):
                     this_policy_setting = 'Enabled'
-                    log.debug('{0} is enabled'.format(this_policyname))
+                    log.debug('{0} is enabled by detected ENABLED_LIST_XPATH'.format(this_policyname))
                     if this_policynamespace not in policy_vals:
                         policy_vals[this_policynamespace] = {}
                     policy_vals[this_policynamespace][this_policyname] = this_policy_setting
             if DISABLED_LIST_XPATH(admx_policy) and this_policy_setting == 'Not Configured':
-                element_only_enabled_disabled = False
-                explicit_enable_disable_value_setting = True
+                if ENABLED_LIST_XPATH(admx_policy) or ENABLED_VALUE_XPATH(admx_policy):
+                    element_only_enabled_disabled = False
+                    explicit_enable_disable_value_setting = True
                 if _checkListItem(admx_policy, this_policyname, this_key, DISABLED_LIST_XPATH, policy_filedata):
                     this_policy_setting = 'Disabled'
-                    log.debug('{0} is disabled'.format(this_policyname))
+                    log.debug('{0} is disabled by detected DISABLED_LIST_XPATH'.format(this_policyname))
                     if this_policynamespace not in policy_vals:
                         policy_vals[this_policynamespace] = {}
                     policy_vals[this_policynamespace][this_policyname] = this_policy_setting
@@ -3739,7 +3741,7 @@ def _checkAllAdmxPolicies(policy_class,
                                                                                 '1')),
                                           policy_filedata):
                     this_policy_setting = 'Enabled'
-                    log.debug('{0} is enabled'.format(this_policyname))
+                    log.debug('{0} is enabled by no explicit enable/disable list or value'.format(this_policyname))
                     if this_policynamespace not in policy_vals:
                         policy_vals[this_policynamespace] = {}
                     policy_vals[this_policynamespace][this_policyname] = this_policy_setting
@@ -3750,7 +3752,7 @@ def _checkAllAdmxPolicies(policy_class,
                                                                                   check_deleted=True)),
                                             policy_filedata):
                     this_policy_setting = 'Disabled'
-                    log.debug('{0} is disabled'.format(this_policyname))
+                    log.debug('{0} is disabled by no explicit enable/disable list or value'.format(this_policyname))
                     if this_policynamespace not in policy_vals:
                         policy_vals[this_policynamespace] = {}
                     policy_vals[this_policynamespace][this_policyname] = this_policy_setting


### PR DESCRIPTION
Check if a policy has either an enabled value or enabled list entry or a disabled value or disabled list entry when determining the state of the policy

Some policies have one but not the other (in which case different
entries in the registry.pol file are added for 'Enabled' or 'Disabled').  All experimentation has shown in these instances Enabled is a REG_DWORD of 1 and Disabled is a **del. for the registry value.

A partial fix for this was
added in PR #44944, but did not check for all possibilities when trying
to determine if the policy is enabled/disabled and also did not perform
the same check in all applicable scenarios.

This would result in some policies being reported by the module as
Enabled even though they were disabled (for example "Windows
Components\Internet Explorer\Make proxy settings per-machine (rather
than per-user)" if set to 'Disabled' would report 'Enabled' by the module)

### What does this PR do?
Ensures that the disabledValue/disabledList/enabledValue/enabledList values are properly utilized

### What issues does this PR fix or reference?
#47436 

### Previous Behavior
Policies may report as "Enabled" when they are "Disabled" or vice-versa.  Depending on the settings of the policy, the actual setting in the registry.pol file (and registry) may or may not be correct.

In the state listed in #47436, the registry and registry.pol file ends up being correct, b/c "Disabled" for the policy is a DWORD of 1 for the registry value, which the module uses (although improperly in this case).

### New Behavior
Policies are properly displayed and configured

### Tests written?
No

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
