### PR TITLE
[WIP] enable passing a unix_socket for mysql returners

### DIFF
--- a/salt/returners/mysql.py
+++ b/salt/returners/mysql.py
@@ -18,6 +18,7 @@ config. These are the defaults:
     mysql.pass: 'salt'
     mysql.db: 'salt'
     mysql.port: 3306
+    mysql.unix_socket: '/tmp/mysql.sock'
 
 SSL is optional. The defaults are set to None. If you do not want to use SSL,
 either exclude these options or set them to None.
@@ -43,6 +44,7 @@ optional. The following ssl options are simply for illustration purposes:
     alternative.mysql.ssl_ca: '/etc/pki/mysql/certs/localhost.pem'
     alternative.mysql.ssl_cert: '/etc/pki/mysql/certs/localhost.crt'
     alternative.mysql.ssl_key: '/etc/pki/mysql/certs/localhost.key'
+    alternative.mysql.unix_socket: '/tmp/mysql.sock'
 
 Should you wish the returner data to be cleaned out every so often, set
 `keep_jobs` to the number of hours for the jobs to live in the tables.
@@ -198,7 +200,8 @@ def _get_options(ret=None):
                 'port': 3306,
                 'ssl_ca': None,
                 'ssl_cert': None,
-                'ssl_key': None}
+                'ssl_key': None,
+                'unix_socket': '/tmp/mysql.sock'}
 
     attrs = {'host': 'host',
              'user': 'user',
@@ -207,7 +210,8 @@ def _get_options(ret=None):
              'port': 'port',
              'ssl_ca': 'ssl_ca',
              'ssl_cert': 'ssl_cert',
-             'ssl_key': 'ssl_key'}
+             'ssl_key': 'ssl_key',
+             'unix_socket': 'unix_socket'}
 
     _options = salt.returners.get_returner_options(__virtualname__,
                                                    ret,
@@ -261,7 +265,8 @@ def _get_serv(ret=None, commit=False):
                                    passwd=_options.get('pass'),
                                    db=_options.get('db'),
                                    port=_options.get('port'),
-                                   ssl=ssl_options)
+                                   ssl=ssl_options,
+                                   unix_socket=_options.get('unix_socket'))
 
             try:
                 __context__['mysql_returner_conn'] = conn


### PR DESCRIPTION
### What does this PR do?
enable the `unix_socket` config option for returners