### PR TITLE
Add In Progress Warning for 2017.7.6 Release Notes

### DIFF
--- a/doc/topics/releases/2017.7.6.rst
+++ b/doc/topics/releases/2017.7.6.rst
@@ -1,8 +1,9 @@
 ===========================
-Salt 2017.7.6 Release Notes
+In Progress: Salt 2017.7.6 Release Notes
 ===========================
 
-Version 2017.7.6 is a bugfix release for :ref:`2017.7.0 <release-2017-7-0>`.
+Version 2017.7.6 is an **unreleased** bugfix release for :ref:`2017.7.0 <release-2017-7-0>`.
+This release is still in progress and has not been released yet.
 
 Option to Return to Previous Pillar Include Behavior
 ----------------------------------------------------


### PR DESCRIPTION
### What does this PR do?
In the docs if 'In Progress' is in the title it will not include the warning about it being an old release as detailed in the issue. This will now not show the warning and include more details in the release notes that this is unreleased. Once this approach has been approved and merged I will also add the same details for 2018.3.1 release notes.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/47431