### PR TITLE
Sysname returns text type

### DIFF
--- a/tests/integration/modules/test_system.py
+++ b/tests/integration/modules/test_system.py
@@ -372,7 +372,7 @@ class WinSystemModuleTest(ModuleCase):
         '''
         ret = self.run_function('system.get_computer_name')
 
-        self.assertTrue(isinstance(ret, str))
+        self.assertTrue(isinstance(ret, six.text_type))
         import socket
         name = socket.gethostname()
         self.assertEqual(name, ret)


### PR DESCRIPTION
### What does this PR do?

Fixes failing test case in 2018.3 suite:

https://jenkinsci.saltstack.com/job/2018.3/job/salt-windows-2016-py2/41/testReport/junit/integration.modules.test_system/WinSystemModuleTest/test_get_computer_name/

### Tests written?

No - Fixing existing test

### Commits signed with GPG?

Yes