### PR TITLE
Fix docs build on Sphinx 1.7+

### DIFF
--- a/doc/_ext/youtube.py
+++ b/doc/_ext/youtube.py
@@ -38,7 +38,10 @@ from __future__ import division
 import re
 from docutils import nodes
 from docutils.parsers.rst import directives
-from sphinx.util.compat import Directive
+try:
+    from sphinx.util.compat import Directive
+except ImportError:
+    from docutils.parsers.rst import Directive
 
 CONTROL_HEIGHT = 30
 


### PR DESCRIPTION
Sphinx 1.7 got rid of sphinx.utils.compat. This commit allows the builds to work both on both older and newer Sphinx.