### PR TITLE
Fix inconsistency with "jid" on minion scheduled jobs and the returners output

### DIFF
--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -941,11 +941,13 @@ class Schedule(object):
                 else:
                     # Send back to master so the job is included in the job list
                     mret = ret.copy()
-                    mret['jid'] = 'req'
-                    if data.get('return_job') == 'nocache':
-                        # overwrite 'req' to signal to master that
-                        # this job shouldn't be stored
-                        mret['jid'] = 'nocache'
+                    # No returners defined, so we're only sending back to the master
+                    if not data_returner and not self.schedule_returner:
+                        mret['jid'] = 'req'
+                        if data.get('return_job') == 'nocache':
+                            # overwrite 'req' to signal to master that
+                            # this job shouldn't be stored
+                            mret['jid'] = 'nocache'
                     load = {'cmd': '_return', 'id': self.opts['id']}
                     for key, value in six.iteritems(mret):
                         load[key] = value


### PR DESCRIPTION
### What does this PR do?
This PR proposes a fix to an inconsistent behavior happening at the moment with scheduled jobs and the returners output for these jobs.

Currently the "jid" which is included in the returner output is generated by the standalone job created on the minion, but it's not generated and stored on the Salt master. Salt does the following for scheduled jobs on minions:

1- A `jid` is generated by the standalone schedule job on the minion.
2- Once the job is completed, the output is provided to the returner.
3- Now the output is passed back to the Salt master but the `jid` is internally set to 'req' to indicate the "jid" needs to be created at master side. I guess the reason for this is to avoid jids collisions because those were generated on the minion instead on the master.

This behavior produces inconsistent references to "jid" between the Salt event bus (which includes the "jid" generated on the master) and the returner output (with a different one generated by the minion) for the same Salt job.

### Previous Behavior
Given this scheduled job:
```
$ salt-call schedule.list
local:
    schedule:
      job1:
        enabled: true
        function: test.ping
        jid_include: true
        maxrunning: 1
        name: job1
        returner: rawfile_json
        seconds: 30
```

I got this returner output:
```
{"fun_args": [], "jid": "20180504111741349996", "return": true, "retcode": 0, "success": true, "schedule": "job1", "pid": 16959, "fun": "test.ping", "id": "min-sles12sp3.tf.local"}
```
While I get this on the Salt event bus:
```
salt/job/20180504111741855597/ret/min-sles12sp3.tf.local	{
    "_stamp": "2018-05-04T09:17:41.857059", 
    "arg": [], 
    "cmd": "_return", 
    "fun": "test.ping", 
    "fun_args": [], 
    "id": "min-sles12sp3.tf.local", 
    "jid": "20180504111741855597", 
    "pid": 16959, 
    "retcode": 0, 
    "return": true, 
    "schedule": "job1", 
    "success": true, 
    "tgt": "min-sles12sp3.tf.local", 
    "tgt_type": "glob"
}
```

Notice that the two `jid` are different for the same Salt job.

### New Behavior
The proposed behavior is to included a new `schedule_jid` attribute on the scheduled job return which references the `jid` that was used on the minion while executing the job (which would be the one referenced on the returner output):

```
salt/job/20180504111939850120/ret/min-sles12sp3.tf.local	{
...
    "fun": "test.ping",
    "jid": "20180504112008951172", 
    "pid": 17938,
    "schedule": "job1", 
    "schedule_jid": "20180504111939347461", 
...
}
```
and this returner output:
```
{"fun_args": [], "jid": "20180504111939347461", "return": true, "retcode": 0, "success": true, "schedule": "job1", "pid": 17938, "fun": "test.ping", "id": "min-sles12sp3.tf.local"}
```

I'm targeting this PR to 2017.7 branch since this could be considered as a bug. Downside is that this would produce a change on the output schema of the job return event. Let me know if I should point this directly to `develop`.

Once this PR is merged, a change on https://github.com/SUSE/salt-netapi-client/blob/master/src/main/java/com/suse/salt/netapi/event/JobReturnEvent.java to reflect the new attribute there.

What do you think about this proposal? Is this feasible or do you think we should use another approach?

### Tests written?
No

### Commits signed with GPG?

Yes