### PR TITLE
fix virtualenv test where HOME is set

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,5 +1,5 @@
 ---
-<% vagrant = system('which vagrant 2>/dev/null >/dev/null') %>
+<% vagrant = system('gem list -i kitchen-vagrant 2>/dev/null >/dev/null') %>
 <% version = '2017.7.4' %>
 <% platformsfile = ENV['SALT_KITCHEN_PLATFORMS'] || '.kitchen/platforms.yml' %>
 <% driverfile = ENV['SALT_KITCHEN_DRIVER'] || '.kitchen/driver.yml' %>

--- a/tests/integration/states/test_virtualenv.py
+++ b/tests/integration/states/test_virtualenv.py
@@ -26,6 +26,15 @@ from salt.modules.virtualenv_mod import KNOWN_BINARY_NAMES
 
 @skipIf(salt.utils.which_bin(KNOWN_BINARY_NAMES) is None, 'virtualenv not installed')
 class VirtualenvTest(ModuleCase, SaltReturnAssertsMixin):
+
+    def setUp(self):
+        self.oldhome = os.environ.pop('HOME', None)
+
+    def tearDown(self):
+        if self.oldhome:
+            os.environ['HOME'] = self.oldhome
+        delattr(self, 'oldhome')
+
     @destructiveTest
     @skip_if_not_root
     def test_issue_1959_virtualenv_runas(self):


### PR DESCRIPTION
### What does this PR do?

Because of the way we run our tests in kitchen, HOME could get set, we do not want it set for the virtualenv creation when running in our test.

### Tests written?

Yes

### Commits signed with GPG?

Yes