### PR TITLE
Specify the cache directory for newer virtualenv modules

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,5 +1,5 @@
 ---
-<% vagrant = system('which vagrant 2>/dev/null >/dev/null') %>
+<% vagrant = system('gem list -i kitchen-vagrant 2>/dev/null >/dev/null') %>
 <% version = '2017.7.4' %>
 <% platformsfile = ENV['SALT_KITCHEN_PLATFORMS'] || '.kitchen/platforms.yml' %>
 <% driverfile = ENV['SALT_KITCHEN_DRIVER'] || '.kitchen/driver.yml' %>

--- a/tests/integration/files/file/base/issue-1959-virtualenv-runas/init.sls
+++ b/tests/integration/files/file/base/issue-1959-virtualenv-runas/init.sls
@@ -6,3 +6,5 @@
     {#- wheels are disabled because the pip cache dir will not be owned by the above issue-1959 user. Need to check this ASAP #}
     - no_binary: ':all:'
     {%- endif %}
+    - env:
+        XDG_CACHE_HOME: /tmp


### PR DESCRIPTION
### What does this PR do?

Without this env variable being set, pip tries to use HOME, and because we HOME still set from the sudo user, this is causing an error.  Even if we move over to `sudo -HE` we will run into the problem that the git tests need HOME set for testing `git config`.

### Tests written?

Yes

### Commits signed with GPG?

Yes