### PR TITLE
added handling for the aws error ConflictingDomainExists

### DIFF
--- a/salt/modules/boto3_route53.py
+++ b/salt/modules/boto3_route53.py
@@ -544,6 +544,10 @@ def associate_vpc_with_hosted_zone(HostedZoneId=None, Name=None, VPCId=None,
             r = conn.associate_vpc_with_hosted_zone(**args)
             return _wait_for_sync(r['ChangeInfo']['Id'], conn)
         except ClientError as e:
+            if e.response.get('Error', {}).get('Code') == 'ConflictingDomainExists':
+                log.debug('VPC Association already exists.')
+                # return True since the current state is the desired one
+                return True
             if tries and e.response.get('Error', {}).get('Code') == 'Throttling':
                 log.debug('Throttled by AWS API.')
                 time.sleep(3)


### PR DESCRIPTION
### What does this PR do?
if your vpc is already associated with the private hosted zone you are trying to associate return true

### What issues does this PR fix or reference?
if your vpc is already associated with the private hosted zone you are trying to associate return true

### Previous Behavior
if your vpc is already associated with the private hosted zone you are trying to associate it would error out

### New Behavior
if your vpc is already associated with the private hosted zone you are trying to associate return true

### Tests written?

No

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
