### PR TITLE
Fix salt-ssh --extra-filerefs to include files even if no refs in states to apply

### DIFF
--- a/salt/client/ssh/state.py
+++ b/salt/client/ssh/state.py
@@ -135,9 +135,9 @@ def lowstate_file_refs(chunks, extras=''):
             elif state.startswith('__'):
                 continue
             crefs.extend(salt_refs(chunk[state]))
+        if saltenv not in refs:
+            refs[saltenv] = []
         if crefs:
-            if saltenv not in refs:
-                refs[saltenv] = []
             refs[saltenv].append(crefs)
     if extras:
         extra_refs = extras.split(',')


### PR DESCRIPTION
### What does this PR do?
Fix salt-ssh `--extra-filerefs` to include the given files files in the stat tarball even if no `salt://` references are found in the state files to be applied.

### What issues does this PR fix or reference?
#47496 

### Previous Behavior
Files were not included if not `salt://` refs were found in the state files.

### New Behavior
Includes the given files in the state tarball.

### Tests written?

No

### Commits signed with GPG?

No

