### PR TITLE
Fix #47502: Remove an extraneous (accidentally introduced?) call to rstrip()

### DIFF
--- a/salt/modules/freebsdservice.py
+++ b/salt/modules/freebsdservice.py
@@ -225,7 +225,7 @@ def _switch(name,                   # pylint: disable=C0103
     if os.path.exists(config):
         with salt.utils.files.fopen(config, 'r') as ifile:
             for line in ifile:
-                line = salt.utils.stringutils.to_unicode(line).rstrip('\n')
+                line = salt.utils.stringutils.to_unicode(line)
                 if not line.startswith('{0}='.format(rcvar)):
                     nlines.append(line)
                     continue


### PR DESCRIPTION
### What does this PR do?
Fix freebsdservice.enable/.disable so that they don't destroy /etc/rc.conf.

### What issues does this PR fix or reference?\
#47502 

### Previous Behavior
Using service.enable or service.disable on FreeBSD would destroy /etc/rc.conf by removing all newlines.

### New Behavior
Revert to prior behavior, in which /etc/rc.conf was updated correctly.

### Tests written?

No

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
