### PR TITLE
fix win_task for py3

### DIFF
--- a/salt/modules/win_task.py
+++ b/salt/modules/win_task.py
@@ -240,7 +240,7 @@ def _reverse_lookup(dictionary, value):
             value_index = idx
             break
 
-    return dictionary.keys()[value_index]
+    return list(dictionary)[value_index]
 
 
 def _lookup_first(dictionary, key):


### PR DESCRIPTION
### What does this PR do?
.keys() on python3 creates a dict_keys object which cannot be indexed like a
list, if we just call list() on the dictionary we get a list of keys.

### What issues does this PR fix or reference?
Fixes #47479

### Tests written?

No

### Commits signed with GPG?

Yes