### PR TITLE
Fix svn export invalid changes data

### DIFF
--- a/salt/states/svn.py
+++ b/salt/states/svn.py
@@ -285,7 +285,7 @@ def export(name,
         opts += ('--trust-server-cert-failures', trust_failures)
 
     out = __salt__[svn_cmd](cwd, name, basename, user, username, password, rev, *opts)
-    ret['changes']['new'] = target
+    ret['changes']['new'] = name
     ret['changes']['comment'] = name + ' was Exported to ' + target
 
     return ret

--- a/salt/states/svn.py
+++ b/salt/states/svn.py
@@ -285,7 +285,8 @@ def export(name,
         opts += ('--trust-server-cert-failures', trust_failures)
 
     out = __salt__[svn_cmd](cwd, name, basename, user, username, password, rev, *opts)
-    ret['changes'] = name + ' was Exported to ' + target
+    ret['changes']['new'] = target
+    ret['changes']['comment'] = name + ' was Exported to ' + target
 
     return ret
 

--- a/tests/unit/states/test_svn.py
+++ b/tests/unit/states/test_svn.py
@@ -104,13 +104,18 @@ class SvnTestCase(TestCase, LoaderModuleMockMixin):
             with patch.dict(svn.__opts__, {'test': False}):
                 mock = MagicMock(return_value=True)
                 with patch.dict(svn.__salt__, {'svn.export': mock}):
-                    self.assertDictEqual(svn.export("salt",
-                                                    "c://salt"),
-                                         {'changes': 'salt was Exported'
-                                          ' to c://salt', 'comment': '',
-                                          'name': 'salt', 'result': True
-                                          }
-                                         )
+                    self.assertDictEqual(
+                        svn.export("salt", "c://salt"),
+                        {
+                            'changes': {
+                                'new': 'salt',
+                                'comment': 'salt was Exported to c://salt',
+                            },
+                            'comment': '',
+                            'name': 'salt',
+                            'result': True,
+                        }
+                    )
 
     def test_dirty(self):
         '''


### PR DESCRIPTION
### What does this PR do?
This pull request fixes invalid "changes" data reported by ``svn.export`` state - currently it is string but must be dictionary.

### What issues does this PR fix or reference?
#21025, #40004

### Previous Behavior
``svn.export`` changes data is string which is invalid and results in failing state.

### New Behavior
Now data under "changes" key is dictionary.

### Tests written?

Yes

### Commits signed with GPG?

No
