### PR TITLE
Fix #46546 eos napalm's grains issue 

### DIFF
--- a/salt/grains/napalm.py
+++ b/salt/grains/napalm.py
@@ -91,7 +91,7 @@ def _retrieve_device_cache(proxy=None):
                 DEVICE_CACHE = proxy['napalm.get_device']()
         elif not proxy and salt.utils.napalm.is_minion(__opts__):
             # if proxy var not passed and is running in a straight minion
-            DEVICE_CACHE = salt.utils.napalm.get_device_opts(__opts__)
+            DEVICE_CACHE = salt.utils.napalm.get_device(__opts__)
     return DEVICE_CACHE
 
 


### PR DESCRIPTION
### What does this PR do?
For eos minion (not proxy minon), grains are not able to retrieve due to connection is not opened.
By changing the device cache update to function get_device, it will setup a connection first.
### What issues does this PR fix or reference?
#46546
#47203
### Previous Behavior
➜   docker exec -t d03bd4c21b37 salt '*' grains.get vendor
supervisor1:
    None
### New Behavior
➜  docker exec -t d03bd4c21b37 salt '*' grains.get hostname
test:
    test
➜   docker exec -t d03bd4c21b37 salt '*' grains.get vendor
test:
    Arista
After change hostname to test2
➜  frankie docker exec -t d03bd4c21b37 salt '*' saltutil.refresh_grains                                                                                                       
test:
    True
➜   docker exec -t d03bd4c21b37 salt '*' grains.get hostname
test:
    test2


### Tests written?

No

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
