### PR TITLE
Fix 47364: ensure we are not caching zfs.is_supported

### DIFF
--- a/salt/utils/zfs.py
+++ b/salt/utils/zfs.py
@@ -279,7 +279,6 @@ def _command(source, command, flags=None, opts=None,
     return ' '.join(cmd)
 
 
-@real_memoize
 def is_supported():
     '''
     Check the system for ZFS support
@@ -302,7 +301,7 @@ def is_supported():
         on_supported_platform = True
 
     # Additional check for the zpool command
-    return (_zpool_cmd() and on_supported_platform) is True
+    return (salt.utils.path.which('zpool') and on_supported_platform) is True
 
 
 @real_memoize

--- a/tests/unit/utils/test_zfs.py
+++ b/tests/unit/utils/test_zfs.py
@@ -891,6 +891,18 @@ class ZfsUtilsTestCase(TestCase):
     This class contains a set of functions that test salt.utils.zfs utils
     '''
     ## NOTE: test parameter parsing
+    def test_is_supported(self):
+        '''
+        Test zfs.is_supported method
+        '''
+        for value in [False, True]:
+            with patch.object(zfs, '_zpool_cmd', MagicMock(return_value=value)):
+                with patch('salt.utils.path.which',
+                           MagicMock(return_value=value)):
+                    with patch('salt.utils.platform.is_linux',
+                                      MagicMock(return_value=value)):
+                        self.assertEqual(value, zfs.is_supported())
+
     def test_property_data_zpool(self):
         '''
         Test parsing of zpool get output

--- a/tests/unit/utils/test_zfs.py
+++ b/tests/unit/utils/test_zfs.py
@@ -896,12 +896,11 @@ class ZfsUtilsTestCase(TestCase):
         Test zfs.is_supported method
         '''
         for value in [False, True]:
-            with patch.object(zfs, '_zpool_cmd', MagicMock(return_value=value)):
-                with patch('salt.utils.path.which',
-                           MagicMock(return_value=value)):
-                    with patch('salt.utils.platform.is_linux',
-                                      MagicMock(return_value=value)):
-                        self.assertEqual(value, zfs.is_supported())
+            with patch('salt.utils.path.which',
+                       MagicMock(return_value=value)):
+                with patch('salt.utils.platform.is_linux',
+                                  MagicMock(return_value=value)):
+                    self.assertEqual(value, zfs.is_supported())
 
     def test_property_data_zpool(self):
         '''


### PR DESCRIPTION
### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/47364

### Previous Behavior
When attempting to reload the grains after installing the zfs package during a state run it would not work properly because the decorator `@real_memoize` was caching the previous query. 

### New Behavior
refreshing grains during a state run works now for zfs_supported grain.

### Tests written?

Yes

### Commits signed with GPG?

Yes