### PR TITLE
Cleanup weird spaces

### DIFF
--- a/tests/integration/netapi/rest_tornado/test_app.py
+++ b/tests/integration/netapi/rest_tornado/test_app.py
@@ -80,7 +80,7 @@ class TestSaltAPIHandler(_SaltnadoIntegrationTestCase):
         self.assertEqual(response.headers['Location'], '/login')
 
     # Local client tests
-    @ skipIf(True, 'to be re-enabled when #23623 is merged')
+    @skipIf(True, 'to be re-enabled when #23623 is merged')
     def test_simple_local_post(self):
         '''
         Test a basic API of /
@@ -121,7 +121,7 @@ class TestSaltAPIHandler(_SaltnadoIntegrationTestCase):
         self.assertEqual(response_obj['return'], ["No minions matched the target. No command was sent, no jid was assigned."])
 
     # local client request body test
-    @ skipIf(True, 'Undetermined race condition in test. Temporarily disabled.')
+    @skipIf(True, 'Undetermined race condition in test. Temporarily disabled.')
     def test_simple_local_post_only_dictionary_request(self):
         '''
         Test a basic API of /


### PR DESCRIPTION
Some spaces between the `@` and the `skipIf` snuck into the branch and the linter, nor the tests, caught this for some reason.
