### PR TITLE
Trying to add a duplicate sec group rule true

### DIFF
--- a/salt/modules/boto_secgroup.py
+++ b/salt/modules/boto_secgroup.py
@@ -476,6 +476,9 @@ def authorize(name=None, source_group_name=None,
                 log.error(msg)
                 return False
         except boto.exception.EC2ResponseError as e:
+            # if we are trying to add the same rule then we are already in the desired state, return true
+            if e.error_code == 'InvalidPermission.Duplicate':
+                return True
             msg = ('Failed to add rule to security group {0} with id {1}.'
                    .format(group.name, group.id))
             log.error(msg)


### PR DESCRIPTION

### What does this PR do?
If we are trying to a duplicate security group rule, then we are already in the desired state, return true

### What issues does this PR fix or reference?
If we are trying to a duplicate security group rule, then we are already in the desired state, return true

### Previous Behavior
Error with:
[ERROR   ] Failed to add rule to security group default with id sg-xxxxxxxxxx.
[ERROR   ] EC2ResponseError: 400 Bad Request
<?xml version="1.0" encoding="UTF-8"?>
<Response><Errors><Error><Code>InvalidPermission.Duplicate</Code><Message>the specified rule "peer: 10.x.x.x/xx, TCP, from port: xxx, to port: xxx, ALLOW" already exists</Message></Error></Errors><RequestID>xxxxxxxx</RequestID></Response>
[ERROR   ] {u'ret': False}

### New Behavior
If we are trying to a duplicate security group rule, then we are already in the desired state, return true

### Tests written?

No

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
