### PR TITLE
Fix corner case where runas user's HOME env value is incorrect

### DIFF
--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -478,10 +478,18 @@ def _run(cmd,
 
             env_runas = dict((sdecode(k), sdecode(v)) for k, v in six.iteritems(env_runas))
             env_runas.update(env)
+
             # Fix platforms like Solaris that don't set a USER env var in the
             # user's default environment as obtained above.
             if env_runas.get('USER') != runas:
                 env_runas['USER'] = runas
+
+            # Fix some corner cases where shelling out to get the user's
+            # environment returns the wrong home directory.
+            runas_home = os.path.expanduser('~{0}'.format(runas))
+            if env_runas.get('HOME') != runas_home:
+                env_runas['HOME'] = runas_home
+
             env = env_runas
             # Encode unicode kwargs to filesystem encoding to avoid a
             # UnicodeEncodeError when the subprocess is invoked.

--- a/tests/integration/states/test_pip_state.py
+++ b/tests/integration/states/test_pip_state.py
@@ -296,7 +296,7 @@ class PipStateTest(ModuleCase, SaltReturnAssertsMixin):
         # pip install passing the package name in `name`
         ret = self.run_state(
             'pip.installed', name='pep8', user=username, bin_env=venv_dir,
-            no_cache_dir=True, password='PassWord1!')
+            password='PassWord1!')
         self.assertSaltTrueReturn(ret)
 
         if HAS_PWD:
@@ -340,12 +340,12 @@ class PipStateTest(ModuleCase, SaltReturnAssertsMixin):
         req_filename = os.path.join(
             RUNTIME_VARS.TMP_STATE_TREE, 'issue-6912-requirements.txt')
         with salt.utils.fopen(req_filename, 'wb') as reqf:
-            reqf.write(six.b('pep8'))
+            reqf.write(b'pep8')
 
         ret = self.run_state(
             'pip.installed', name='', user=username, bin_env=venv_dir,
             requirements='salt://issue-6912-requirements.txt',
-            no_cache_dir=True, password='PassWord1!')
+            password='PassWord1!')
         self.assertSaltTrueReturn(ret)
 
         if HAS_PWD:
@@ -430,7 +430,7 @@ class PipStateTest(ModuleCase, SaltReturnAssertsMixin):
             RUNTIME_VARS.TMP_PRODENV_STATE_TREE, 'prod-env-requirements.txt'
         )
         with salt.utils.fopen(requirements_file, 'wb') as reqf:
-            reqf.write(six.b('pep8\n'))
+            reqf.write(b'pep8\n')
 
         try:
             self.run_function('virtualenv.create', [venv_dir])


### PR DESCRIPTION
In the test suite, two of the failing `pip.installed` tests were failing because when we shelled out to get the user's environment, the `HOME` environment variable's value was incorrectly showing the root user's home dir.

This change ensures that we use the correct value for the `HOME` environment variable when running a command as another user.