### PR TITLE
switch skip-roster to update-roster

### DIFF
--- a/conf/master
+++ b/conf/master
@@ -538,6 +538,10 @@
 # targeted with the normal -N argument to salt-ssh.
 #ssh_list_nodegroups: {}
 
+# salt-ssh has the ability to update the flat roster file if a minion is not
+# found in the roster.  Set this to True to enable it.
+#ssh_update_roster: False
+
 #####    Master Module Management    #####
 ##########################################
 # Manage how master side modules are loaded.

--- a/doc/topics/releases/2018.3.1.rst
+++ b/doc/topics/releases/2018.3.1.rst
@@ -13,3 +13,13 @@ used as part of a salt-minion process running on the master.  This will allow
 the minion to have pillars assigned to it, and will still allow the engine to
 create a LocalClient connection to the master ipc sockets to control
 environments.
+
+Changes to Automatically Updating the Roster File
+-------------------------------------------------
+
+In ``2018.3.0`` salt-ssh was configured to automatically update the flat roster
+file if a minion was not found for salt-ssh. This was decided to be
+undesireable as a default.  The ``--skip-roster`` flag has been removed and
+replaced  with ``--update-roster``, which will enable salt-ssh to add minions
+to the flat roster file.  This behavior can also be enabled by setting
+``ssh_update_roster: True`` in the master config file.

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -410,7 +410,7 @@ class SSH(object):
                 'host': hostname,
                 'user': user,
             }
-            if not self.opts.get('ssh_skip_roster'):
+            if self.opts.get('ssh_update_roster'):
                 self._update_roster()
 
     def get_pubkey(self):

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -3078,11 +3078,11 @@ class SaltSSHOptionParser(six.with_metaclass(OptionParserMeta,
             help='Run command via sudo.'
         )
         auth_group.add_option(
-            '--skip-roster',
-            dest='ssh_skip_roster',
+            '--update-roster',
+            dest='ssh_update_roster',
             default=False,
             action='store_true',
-            help='If hostname is not found in the roster, do not store the information'
+            help='If hostname is not found in the roster, store the information'
                  'into the default roster file (flat).'
         )
         self.add_option_group(auth_group)


### PR DESCRIPTION
### What does this PR do?
Writing to the /etc/salt/roster file by default was agreed by the SaltStack core engineers to be an undesirable action.  So I have switched the flag to be `--update-roster` and it defaults to False.

### What issues does this PR fix or reference?
Fixes #47532

### Tests written?

No

### Commits signed with GPG?

Yes