### PR TITLE
Fix non-root build and signing for rpm packages

### DIFF
--- a/salt/modules/rpmbuild.py
+++ b/salt/modules/rpmbuild.py
@@ -248,7 +248,7 @@ def make_src_pkg(dest_dir, spec, sources, env=None, template=None, saltenv='base
     srpms = os.path.join(tree_base, 'SRPMS')
     ret = []
     if not os.path.isdir(dest_dir):
-        __salt__['file.chown'](path=dest_dir, user=runas, group='mock')
+        __salt__['file.makedirs_perms'](name=dest_dir, user=runas, group='mock')
     for fn_ in os.listdir(srpms):
         full = os.path.join(srpms, fn_)
         tgt = os.path.join(dest_dir, fn_)

--- a/salt/modules/rpmbuild.py
+++ b/salt/modules/rpmbuild.py
@@ -213,7 +213,7 @@ def make_src_pkg(dest_dir, spec, sources, env=None, template=None, saltenv='base
     runas
         The user to run the build process as
 
-        .. versionadded:: 2018.3.1
+        .. versionadded:: 2018.3.2
 
 
     .. note::


### PR DESCRIPTION
### What does this PR do?
Restores the ability to build and sign packages for rpm builds as a non-root user
This ability was changed in the Nitrogen release.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt-pack/issues/545

### Previous Behavior
Could only perform builds and signing for rpm packages as root since 2017.7.0

### New Behavior
Restores ability to perform builds and signing for rpm packages as non-root user, for example: builder, with Salt minions as prior to the 2017.7.0 release.

### Tests written?
No, built and signed Centos 7 packages.

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
