### PR TITLE
Catch Sysloghandler errors when log file does not exist

### DIFF
--- a/salt/log/handlers/__init__.py
+++ b/salt/log/handlers/__init__.py
@@ -17,7 +17,6 @@ import logging.handlers
 
 # Import salt libs
 from salt.log.mixins import NewStyleClassMixIn, ExcInfoOnLogLevelFormatMixIn
-from salt.ext import six
 from salt.ext.six.moves import queue
 
 log = logging.getLogger(__name__)
@@ -110,7 +109,7 @@ class SysLogHandler(ExcInfoOnLogLevelFormatMixIn, logging.handlers.SysLogHandler
         Deal with syslog os errors when the log file does not exist
         '''
         handled = False
-        if sys.stderr and six.PY3:
+        if sys.stderr and sys.version_info >= (3, 5, 4):
             t, v, tb = sys.exc_info()
             if t.__name__ in 'FileNotFoundError':
                 sys.stderr.write('[WARNING ] The log_file does not exist. Logging not setup correctly or syslog service not started.\n')

--- a/salt/log/handlers/__init__.py
+++ b/salt/log/handlers/__init__.py
@@ -17,6 +17,7 @@ import logging.handlers
 
 # Import salt libs
 from salt.log.mixins import NewStyleClassMixIn, ExcInfoOnLogLevelFormatMixIn
+from salt.ext import six
 from salt.ext.six.moves import queue
 
 log = logging.getLogger(__name__)
@@ -103,6 +104,20 @@ class SysLogHandler(ExcInfoOnLogLevelFormatMixIn, logging.handlers.SysLogHandler
     '''
     Syslog handler which properly handles exc_info on a per handler basis
     '''
+    def handleError(self, record):
+        '''
+        Override the default error handling mechanism for py3
+        Deal with syslog os errors when the log file does not exist
+        '''
+        handled = False
+        if sys.stderr and six.PY3:
+            t, v, tb = sys.exc_info()
+            if t.__name__ in 'FileNotFoundError':
+                sys.stderr.write('[WARNING ] The log_file does not exist. Logging not setup correctly or syslog service not started.\n')
+                handled = True
+
+        if not handled:
+            super(SysLogHandler, self).handleError(record)
 
 
 class RotatingFileHandler(ExcInfoOnLogLevelFormatMixIn, logging.handlers.RotatingFileHandler, NewStyleClassMixIn):

--- a/tests/integration/shell/test_call.py
+++ b/tests/integration/shell/test_call.py
@@ -368,7 +368,7 @@ class CallTest(ShellCase, testprogram.TestProgramCase, ShellCaseCommonTestsMixin
             with_retcode=True
         )
         try:
-            if six.PY3:
+            if sys.version_info >= (3, 5, 4):
                 self.assertIn('local:', ret[0])
                 self.assertIn('[WARNING ] The log_file does not exist. Logging not setup correctly or syslog service not started.', ret[1])
                 self.assertEqual(ret[2], 0)

--- a/tests/integration/shell/test_call.py
+++ b/tests/integration/shell/test_call.py
@@ -340,6 +340,48 @@ class CallTest(ShellCase, testprogram.TestProgramCase, ShellCaseCommonTestsMixin
             if os.path.isdir(config_dir):
                 shutil.rmtree(config_dir)
 
+    def test_syslog_file_not_found(self):
+        '''
+        test when log_file is set to a syslog file that does not exist
+        '''
+        old_cwd = os.getcwd()
+        config_dir = os.path.join(TMP, 'log_file_incorrect')
+        if not os.path.isdir(config_dir):
+            os.makedirs(config_dir)
+
+        os.chdir(config_dir)
+
+        with salt.utils.fopen(self.get_config_file_path('minion'), 'r') as fh_:
+            minion_config = yaml.load(fh_.read())
+            minion_config['log_file'] = 'file:///dev/doesnotexist'
+            with salt.utils.fopen(os.path.join(config_dir, 'minion'), 'w') as fh_:
+                fh_.write(
+                    yaml.dump(minion_config, default_flow_style=False)
+                )
+        ret = self.run_script(
+            'salt-call',
+            '--config-dir {0} cmd.run "echo foo"'.format(
+                config_dir
+            ),
+            timeout=60,
+            catch_stderr=True,
+            with_retcode=True
+        )
+        try:
+            if six.PY3:
+                self.assertIn('local:', ret[0])
+                self.assertIn('[WARNING ] The log_file does not exist. Logging not setup correctly or syslog service not started.', ret[1])
+                self.assertEqual(ret[2], 0)
+            else:
+                self.assertIn(
+                    'Failed to setup the Syslog logging handler', '\n'.join(ret[1])
+                )
+                self.assertEqual(ret[2], 2)
+        finally:
+            self.chdir(old_cwd)
+            if os.path.isdir(config_dir):
+                shutil.rmtree(config_dir)
+
     def test_issue_15074_output_file_append(self):
         output_file_append = os.path.join(TMP, 'issue-15074')
         try:


### PR DESCRIPTION
### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/47432
https://github.com/saltstack/salt-jenkins/issues/936

### Previous Behavior
In python3 this PR was added https://github.com/python/cpython/pull/663  which makes sure it just passes when there is an OSERROR. The problem is when running salt with a `log_file` set to `file://doesnotexist` or syslog service hasn't started yet it prints the entire traceback and is hard to digest.

### New Behavior
Prints out a new warning: `[WARNING ] The log_file does not exist. Logging not setup correctly or syslog service not started.`

### Tests written?

Yes

### Commits signed with GPG?

Yes