### PR TITLE
I deleted this in an earlier commit, I'm restoring the function

### DIFF
--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -3660,6 +3660,44 @@ def show_detailed_monitoring(name=None, instance_id=None, call=None, quiet=False
     return matched['monitoring']
 
 
+def enable_term_protect(name, call=None):
+    '''
+    Enable termination protection on a node
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt-cloud -a enable_term_protect mymachine
+    '''
+    if call != 'action':
+        raise SaltCloudSystemExit(
+            'The enable_term_protect action must be called with '
+            '-a or --action.'
+        )
+
+    return _toggle_term_protect(name, 'true')
+
+
+def disable_term_protect(name, call=None):
+    '''
+    Disable termination protection on a node
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt-cloud -a disable_term_protect mymachine
+    '''
+    if call != 'action':
+        raise SaltCloudSystemExit(
+            'The disable_term_protect action must be called with '
+            '-a or --action.'
+        )
+
+    return _toggle_term_protect(name, 'false')
+
+
 def _toggle_term_protect(name, value):
     '''
     Enable or Disable termination protection on a node
@@ -3678,25 +3716,6 @@ def _toggle_term_protect(name, value):
                        sigver='4')
 
     return show_term_protect(name=name, instance_id=instance_id, call='action')
-
-
-def enable_term_protect(name, call=None):
-    '''
-    Enable termination protection on a node
-
-    CLI Example:
-
-    .. code-block:: bash
-
-        salt-cloud -a enable_term_protect mymachine
-    '''
-    if call != 'action':
-        raise SaltCloudSystemExit(
-            'The enable_term_protect action must be called with '
-            '-a or --action.'
-        )
-
-    return _toggle_term_protect(name, 'true')
 
 
 def disable_detailed_monitoring(name, call=None):


### PR DESCRIPTION
We need enable/disable term protection

### What does this PR do?

Restores the ability to disable termination protection on a minion/ec2 instance

### What issues does this PR fix or reference?

N/A

### Previous Behavior
The function was missing.

### New Behavior
This restores the pre-2018.3.0 behavior

### Tests written?

No

### Commits signed with GPG?

Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
