### PR TITLE
Fixes a bad deletion I did that only surfaced in 2018.3

### DIFF
--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -3675,6 +3675,25 @@ def enable_term_protect(name, call=None):
     return _toggle_term_protect(name, 'true')
 
 
+def disable_term_protect(name, call=None):
+    '''
+    Disable termination protection on a node
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt-cloud -a disable_term_protect mymachine
+    '''
+    if call != 'action':
+        raise SaltCloudSystemExit(
+            'The enable_term_protect action must be called with '
+            '-a or --action.'
+        )
+
+    return _toggle_term_protect(name, 'false')
+
+
 def disable_detailed_monitoring(name, call=None):
     '''
     Enable/disable detailed monitoring on a node


### PR DESCRIPTION
We need enable/disable term protection. This restores the functionality to 2018.3

### What does this PR do?

Restores the ability to disable termination protection on a minion/ec2 instance

### What issues does this PR fix or reference?

N/A

### Previous Behavior
The function was missing, so invoking `salt-cloud -a disable_term_protect <minion name>` was breaking.

### New Behavior
This restores the pre-2018.3.0 behaviour.  

### Tests written?

No

### Commits signed with GPG?

Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
