### PR TITLE
Converted unicode str version to a LooseVersion; matching line 2080.

### DIFF
--- a/salt/modules/lxc.py
+++ b/salt/modules/lxc.py
@@ -867,7 +867,7 @@ def _network_conf(conf_tuples=None, **kwargs):
     # on old versions of lxc, still support the gateway auto mode
     # if we didn't explicitly say no to
     # (lxc.network.ipv4.gateway: auto)
-    if _LooseVersion(version()) <= '1.0.7' and \
+    if _LooseVersion(version()) <= _LooseVersion('1.0.7') and \
             True not in ['lxc.network.ipv4.gateway' in a for a in ret] and \
             True in ['lxc.network.ipv4' in a for a in ret]:
         ret.append({'lxc.network.ipv4.gateway': 'auto'})


### PR DESCRIPTION
### What does this PR do?

This corrects an LooseVersion compare that occurs when a lxc.present state is ran to provision an lxc container.  The provision completes, but the state is flagged as fail

### What issues does this PR fix or reference?

#47553 

### Previous Behavior
if statement compares a LooseVersion to a unicode string version

### New Behavior
if statement compares a LooseVersion to the version converted to a LooseVersion

### Tests written?

No

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
