### PR TITLE
YAML: Use C bindings if available

### DIFF
--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -46,6 +46,7 @@ try:
 except ImportError:
     HAS_PSUTIL = False
 
+_SafeDumper = yaml.CSafeDumper if yaml.__with_libyaml__ else yaml.SafeDumper
 log = logging.getLogger(__name__)
 
 _DFLT_LOG_DATEFMT = '%H:%M:%S'
@@ -2138,7 +2139,7 @@ def _read_conf_file(path):
     log.debug('Reading configuration from %s', path)
     with salt.utils.files.fopen(path, 'r') as conf_file:
         try:
-            conf_opts = salt.utils.yaml.safe_load(conf_file) or {}
+            conf_opts = salt.utils.yaml.load(conf_file, Loader=_SafeLoader) or {}
         except salt.utils.yaml.YAMLError as err:
             message = 'Error parsing configuration file: {0} - {1}'.format(path, err)
             log.error(message)


### PR DESCRIPTION
C bindings offer a considerable speed increase, so use them when
available (i.e. if libyaml is installed).

While at it, explicitly use safe dump for reference-enabled YAML.

Is a partial fix for https://jira.opnfv.org/browse/ARMBAND-347

Signed-off-by: Cristina Pauna <cristina.pauna@enea.com>

### What does this PR do?

### What issues does this PR fix or reference?

### Previous Behavior
Remove this section if not relevant

### New Behavior
Remove this section if not relevant

### Tests written?

Yes/No

### Commits signed with GPG?

Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
