### PR TITLE
salt.serializers.yaml/yamlex: remove invalid multi_constructor

### DIFF
--- a/salt/serializers/yaml.py
+++ b/salt/serializers/yaml.py
@@ -11,6 +11,7 @@
 
 from __future__ import absolute_import, print_function, unicode_literals
 import datetime
+import logging
 
 import yaml
 from yaml.constructor import ConstructorError
@@ -21,6 +22,8 @@ from salt.ext import six
 from salt.utils.odict import OrderedDict
 
 __all__ = ['deserialize', 'serialize', 'available']
+
+log = logging.getLogger(__name__)
 
 available = True
 
@@ -46,14 +49,17 @@ def deserialize(stream_or_string, **options):
     try:
         return yaml.load(stream_or_string, **options)
     except ScannerError as error:
+        log.exception('Error encountered while deserializing')
         err_type = ERROR_MAP.get(error.problem, 'Unknown yaml render error')
         line_num = error.problem_mark.line + 1
         raise DeserializationError(err_type,
                                    line_num,
                                    error.problem_mark.buffer)
     except ConstructorError as error:
+        log.exception('Error encountered while deserializing')
         raise DeserializationError(error)
     except Exception as error:
+        log.exception('Error encountered while deserializing')
         raise DeserializationError(error)
 
 
@@ -74,6 +80,7 @@ def serialize(obj, **options):
             return response[:-1]
         return response
     except Exception as error:
+        log.exception('Error encountered while serializing')
         raise SerializationError(error)
 
 

--- a/salt/serializers/yaml.py
+++ b/salt/serializers/yaml.py
@@ -108,7 +108,6 @@ Loader.add_multi_constructor('tag:yaml.org,2002:set', Loader.construct_yaml_set)
 Loader.add_multi_constructor('tag:yaml.org,2002:str', Loader.construct_yaml_str)
 Loader.add_multi_constructor('tag:yaml.org,2002:seq', Loader.construct_yaml_seq)
 Loader.add_multi_constructor('tag:yaml.org,2002:map', Loader.construct_yaml_map)
-Loader.add_multi_constructor(None, Loader.construct_undefined)
 
 
 class Dumper(BaseDumper):  # pylint: disable=W0232

--- a/salt/serializers/yamlex.py
+++ b/salt/serializers/yamlex.py
@@ -150,14 +150,17 @@ def deserialize(stream_or_string, **options):
     try:
         return yaml.load(stream_or_string, **options)
     except ScannerError as error:
+        log.exception('Error encountered while deserializing')
         err_type = ERROR_MAP.get(error.problem, 'Unknown yaml render error')
         line_num = error.problem_mark.line + 1
         raise DeserializationError(err_type,
                                    line_num,
                                    error.problem_mark.buffer)
     except ConstructorError as error:
+        log.exception('Error encountered while deserializing')
         raise DeserializationError(error)
     except Exception as error:
+        log.exception('Error encountered while deserializing')
         raise DeserializationError(error)
 
 
@@ -178,6 +181,7 @@ def serialize(obj, **options):
             return response[:-1]
         return response
     except Exception as error:
+        log.exception('Error encountered while serializing')
         raise SerializationError(error)
 
 

--- a/salt/serializers/yamlex.py
+++ b/salt/serializers/yamlex.py
@@ -322,7 +322,6 @@ Loader.add_multi_constructor('tag:yaml.org,2002:pairs', Loader.construct_yaml_pa
 Loader.add_multi_constructor('tag:yaml.org,2002:set', Loader.construct_yaml_set)
 Loader.add_multi_constructor('tag:yaml.org,2002:seq', Loader.construct_yaml_seq)
 Loader.add_multi_constructor('tag:yaml.org,2002:map', Loader.construct_yaml_map)
-Loader.add_multi_constructor(None, Loader.construct_undefined)
 
 
 class SLSMap(OrderedDict):


### PR DESCRIPTION
The first argument to add_multi_constructor must be a YAML tag. This is because when PyYAML looks for a constructor to match the tag (in order to get the function to use for deserialization) it matches the tag using `.startswith()`. Thus, when this is attempted using a constructor with a tag value of `None`, an error is raised.

The ordering of the list of multi_constructors in the Loader object appears to differ from platform to platform, which explains why this only caused the unit tests to fail on one or two platforms. If a tag match is found, then PyYAML stops iterating through the list of multi_constructors, so this invalid one has been able to stay in Salt without causing any noticeable trouble until now.

Additionally, this PR adds some exception logging to aid in troubleshooting, since we re-raise our own exception classes using the caught exception message, which means we lose the context of what actually raised the original exception.

Refs: https://github.com/saltstack/salt-jenkins/issues/971