### PR TITLE
Update salt.utils.path mock in virtual core test

### DIFF
--- a/tests/unit/grains/test_core.py
+++ b/tests/unit/grains/test_core.py
@@ -866,7 +866,7 @@ SwapTotal:       4789244 kB'''
         virt = 'kvm'
         with patch.object(salt.utils, 'is_windows',
                           MagicMock(return_value=False)):
-            with patch.object(salt.utils, 'which',
+            with patch.object(salt.utils.path, 'which',
                               MagicMock(return_value=True)):
                 with patch.dict(core.__salt__, {'cmd.run_all':
                                                 MagicMock(return_value={'pid': 78,

--- a/tests/unit/grains/test_core.py
+++ b/tests/unit/grains/test_core.py
@@ -864,7 +864,7 @@ SwapTotal:       4789244 kB'''
         test virtual grain with cmd virt-what
         '''
         virt = 'kvm'
-        with patch.object(salt.utils, 'is_windows',
+        with patch.object(salt.utils.platform, 'is_windows',
                           MagicMock(return_value=False)):
             with patch.object(salt.utils.path, 'which',
                               MagicMock(return_value=True)):


### PR DESCRIPTION
### What does this PR do?
change mock in `test_core_virtual` from `salt.utils.which` to `salt.utils.path.which` as this was updated in 2018.3.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt-jenkins/issues/969
