### PR TITLE
Update dependency to msgpack

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,7 @@
 Jinja2
-msgpack-python>0.3,!=0.5.5
+# This should be changed to msgpack-python for Packages
+# msgpack-python>0.3,!=0.5.5
+msgpack>=0.5,!=0.5.5
 PyYAML
 MarkupSafe
 requests>=1.0.0


### PR DESCRIPTION
### What does this PR do?
`msgpack-python` has been renamed to `msgpack`.

We have decided to update our requirements.txt, but still use msgpack-python for distributions that still have that older name in their repositories.

### Tests written?

Yes

### Commits signed with GPG?

Yes