### PR TITLE
[2018.3] Small Documentation Fixes

### DIFF
--- a/doc/ref/states/all/index.rst
+++ b/doc/ref/states/all/index.rst
@@ -124,7 +124,6 @@ state modules
     influxdb_database
     influxdb_retention_policy
     influxdb_user
-    infoblox
     infoblox_a
     infoblox_cname
     infoblox_host_record

--- a/doc/ref/states/all/salt.states.infoblox.rst
+++ b/doc/ref/states/all/salt.states.infoblox.rst
@@ -1,5 +1,0 @@
-salt.states.infoblox module
-===========================
-
-.. automodule:: salt.states.infoblox
-    :members:

--- a/doc/topics/cloud/config.rst
+++ b/doc/topics/cloud/config.rst
@@ -351,6 +351,7 @@ This driver can be configured using the ``/etc/openstack/clouds.yml`` file with
 `os-client-config <https://docs.openstack.org/os-client-config/latest/>`
 
 .. code-block:: yaml
+
     myopenstack:
       driver: openstack
       region_name: RegionOne
@@ -359,6 +360,7 @@ This driver can be configured using the ``/etc/openstack/clouds.yml`` file with
 Or by just configuring the same auth block directly in the cloud provider config.
 
 .. code-block:: yaml
+
     myopenstack:
       driver: openstack
       region_name: RegionOne

--- a/salt/modules/dockermod.py
+++ b/salt/modules/dockermod.py
@@ -3210,6 +3210,7 @@ def run_container(image,
     CLI Examples:
 
     .. code-block:: bash
+
         salt myminion docker.run_container myuser/myimage command=/usr/local/bin/myscript.sh
         # Run container in the background
         salt myminion docker.run_container myuser/myimage command=/usr/local/bin/myscript.sh bg=True

--- a/salt/modules/glanceng.py
+++ b/salt/modules/glanceng.py
@@ -9,10 +9,12 @@ Glance module for interacting with OpenStack Glance
 Example configuration
 
 .. code-block:: yaml
+
     glance:
       cloud: default
 
 .. code-block:: yaml
+
     glance:
       auth:
         username: admin

--- a/salt/modules/keystoneng.py
+++ b/salt/modules/keystoneng.py
@@ -9,10 +9,12 @@ Keystone module for interacting with OpenStack Keystone
 Example configuration
 
 .. code-block:: yaml
+
     keystone:
       cloud: default
 
 .. code-block:: yaml
+
     keystone:
       auth:
         username: admin

--- a/salt/modules/neutronng.py
+++ b/salt/modules/neutronng.py
@@ -9,10 +9,12 @@ Neutron module for interacting with OpenStack Neutron
 Example configuration
 
 .. code-block:: yaml
+
     neutron:
       cloud: default
 
 .. code-block:: yaml
+
     neutron:
       auth:
         username: admin

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -331,6 +331,7 @@ def version(*names, **kwargs):
         dict: The package name(s) with the installed versions.
 
     .. code-block:: cfg
+
         {['<version>', '<version>', ]} OR
         {'<package name>': ['<version>', '<version>', ]}
 

--- a/salt/states/influxdb_user.py
+++ b/salt/states/influxdb_user.py
@@ -48,6 +48,7 @@ def present(name,
     **Example:**
 
     .. code-block:: yaml
+
         example user present in influxdb:
           influxdb_user.present:
             - name: example


### PR DESCRIPTION
I fixed a couple of doc build errors that I saw today when building the docs. 

- Remove infoblox state autodoc file - This state does not exist. There is an execution module named infoblox, and several other infoblox_x state fails, but not a pure infoblox.py state module.
- Add extra lines that are needed for proper code-block formatting