### PR TITLE
Remove duplicate file id in watch_any doc example

### DIFF
--- a/doc/ref/states/requisites.rst
+++ b/doc/ref/states/requisites.rst
@@ -410,16 +410,12 @@ exactly like the ``require`` requisite (the watching state will execute if
       service.running:
         - watch_any:
           - file: /etc/apache2/sites-available/site1.conf
-          - file: /etc/apache2/sites-available/site2.conf
       file.managed:
         - name: /etc/apache2/sites-available/site1.conf
         - source: salt://apache2/files/site1.conf
-      file.managed:
-        - name: /etc/apache2/sites-available/site2.conf
-        - source: salt://apache2/files/site2.conf
 
-In this example, the service will be reloaded/restarted if either of the
-file.managed states has a result of True and has changes.
+In this example, the service will be reloaded/restarted if the
+file.managed state has a result of True and has changes.
 
 .. _requisites-prereq:
 

--- a/doc/ref/states/requisites.rst
+++ b/doc/ref/states/requisites.rst
@@ -410,12 +410,17 @@ exactly like the ``require`` requisite (the watching state will execute if
       service.running:
         - watch_any:
           - file: /etc/apache2/sites-available/site1.conf
+          - file: apache2-site2
       file.managed:
         - name: /etc/apache2/sites-available/site1.conf
         - source: salt://apache2/files/site1.conf
+    apache2-site2:
+      file.managed:
+        - name: /etc/apache2/sites-available/site2.conf
+        - source: salt://apache2/files/site2.conf
 
-In this example, the service will be reloaded/restarted if the
-file.managed state has a result of True and has changes.
+In this example, the service will be reloaded/restarted if either of the
+file.managed states has a result of True and has changes.
 
 .. _requisites-prereq:
 


### PR DESCRIPTION
### What does this PR do?
Update docs to remove duplicate ID. As far as I know this is still not possible within salts rendering to allow multiple calls of the same state module under one ID. 

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/47574

