### PR TITLE
Fix firewalld prune_services deprecation warning

### DIFF
--- a/salt/states/firewalld.py
+++ b/salt/states/firewalld.py
@@ -235,7 +235,7 @@ def present(name,
         salt.utils.versions.warn_until(
             'Neon',
             'The \'prune_services\' argument default is currently True, '
-            'but will be changed to True in future releases.')
+            'but will be changed to False in the Neon release.')
 
     ret = _present(name, block_icmp, prune_block_icmp, default, masquerade, ports, prune_ports,
             port_fwd, prune_port_fwd, services, prune_services, interfaces, prune_interfaces,


### PR DESCRIPTION
### What does this PR do?
Fixes the deprecation warning for the `prune_services` argument in the firewalld state.

You can see from the PR here: https://github.com/saltstack/salt/pull/43780 that the intention was to change this to False in the Neon Release.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/47579
