### PR TITLE
Back-port #47569 to 2018.3.1

### DIFF
--- a/tests/unit/grains/test_core.py
+++ b/tests/unit/grains/test_core.py
@@ -866,7 +866,7 @@ SwapTotal:       4789244 kB'''
         virt = 'kvm'
         with patch.object(salt.utils, 'is_windows',
                           MagicMock(return_value=False)):
-            with patch.object(salt.utils, 'which',
+            with patch.object(salt.utils.path, 'which',
                               MagicMock(return_value=True)):
                 with patch.dict(core.__salt__, {'cmd.run_all':
                                                 MagicMock(return_value={'pid': 78,

--- a/tests/unit/grains/test_core.py
+++ b/tests/unit/grains/test_core.py
@@ -864,7 +864,7 @@ SwapTotal:       4789244 kB'''
         test virtual grain with cmd virt-what
         '''
         virt = 'kvm'
-        with patch.object(salt.utils, 'is_windows',
+        with patch.object(salt.utils.platform, 'is_windows',
                           MagicMock(return_value=False)):
             with patch.object(salt.utils.path, 'which',
                               MagicMock(return_value=True)):


### PR DESCRIPTION
Back-port #47569 to 2018.3.1

This fixes a test failure on the 2018.3.1 branch.