### PR TITLE
Prevent crash on NetBSD and OpenBSD when no swap is configured.

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -459,7 +459,11 @@ def _bsd_memdata(osdata):
 
         if osdata['kernel'] in ['OpenBSD', 'NetBSD']:
             swapctl = salt.utils.path.which('swapctl')
-            swap_total = __salt__['cmd.run']('{0} -sk'.format(swapctl)).split(' ')[1]
+            swap_data = __salt__['cmd.run']('{0} -sk'.format(swapctl))
+            if swap_data == 'no swap devices configured':
+                swap_total = 0
+            else:
+                swap_total = swap_data.split(' ')[1]
         else:
             swap_total = __salt__['cmd.run']('{0} -n vm.swap_total'.format(sysctl))
         grains['swap_total'] = int(swap_total) // 1024 // 1024


### PR DESCRIPTION
### What does this PR do?

Prevents the ``salt`` and ``salt-master`` commands from crashing on NetBSD and OpenBSD when no swap space is configured.

### What issues does this PR fix or reference?
I am not aware of an existing open issue.

### Previous Behavior
On a NetBSD 7.1.2 system with no swap configured:

```
salt# swapctl -sk
no swap devices configured

salt# salt-master --help
Traceback (most recent call last):
  File "/opt/pkg/bin/salt-master", line 22, in <module>
    salt_master()
  File "/opt/pkg/lib/python2.7/site-packages/salt/scripts.py", line 95, in salt_master
    import salt.cli.daemons
  File "/opt/pkg/lib/python2.7/site-packages/salt/cli/daemons.py", line 48, in <module>
    import salt.utils.parsers
  File "/opt/pkg/lib/python2.7/site-packages/salt/utils/parsers.py", line 27, in <module>
    import salt.config as config
  File "/opt/pkg/lib/python2.7/site-packages/salt/config/__init__.py", line 98, in <module>
    _DFLT_IPC_WBUFFER = _gather_buffer_space() * .5
  File "/opt/pkg/lib/python2.7/site-packages/salt/config/__init__.py", line 91, in _gather_buffer_space
    grains = salt.grains.core._memdata(os_data)
  File "/opt/pkg/lib/python2.7/site-packages/salt/grains/core.py", line 509, in _memdata
    grains.update(_bsd_memdata(osdata))
  File "/opt/pkg/lib/python2.7/site-packages/salt/grains/core.py", line 458, in _bsd_memdata
    grains['swap_total'] = int(swap_total) // 1024 // 1024
ValueError: invalid literal for int() with base 10: 'swap'
```

### New Behavior

Salt commands work without crashing.

### Tests written?

No

### Commits signed with GPG?

Yes
