### PR TITLE
Update napalm.py

### DIFF
--- a/salt/proxy/napalm.py
+++ b/salt/proxy/napalm.py
@@ -236,16 +236,7 @@ def get_grains():
     '''
     Retrieve facts from the network device.
     '''
-    refresh_needed = False
-    refresh_needed = refresh_needed or (not DETAILS.get('grains_cache', {}))
-    refresh_needed = refresh_needed or (not DETAILS.get('grains_cache', {}).get('result', False))
-    refresh_needed = refresh_needed or (not DETAILS.get('grains_cache', {}).get('out', {}))
-
-    if refresh_needed:
-        facts = call('get_facts', **{})
-        DETAILS['grains_cache'] = facts
-
-    return DETAILS.get('grains_cache', {})
+    return call('get_facts', **{})
 
 
 def grains_refresh():


### PR DESCRIPTION
### What does this PR do?
Address issue - https://github.com/saltstack/salt/issues/47203

This will allow napalm proxy grains to update with a saltutil.refresh_grains

### What issues does this PR fix or reference?
This will allow napalm proxy grains to update with a saltutil.refresh_grains

### Previous Behavior
Grains would not update.

### New Behavior
Grains will update.

### Tests written?

No

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
