### PR TITLE
Add bhyve support to virt

### DIFF
--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -3292,7 +3292,10 @@ def purge(vm_, dirs=False, removables=None, **kwargs):
             shutil.rmtree(dir_)
     if getattr(libvirt, 'VIR_DOMAIN_UNDEFINE_NVRAM', False):
         # This one is only in 1.2.8+
-        dom.undefineFlags(libvirt.VIR_DOMAIN_UNDEFINE_NVRAM)
+        try:
+            dom.undefineFlags(libvirt.VIR_DOMAIN_UNDEFINE_NVRAM)
+        except Exception:
+            dom.undefine()
     else:
         dom.undefine()
     conn.close()

--- a/salt/states/virt.py
+++ b/salt/states/virt.py
@@ -246,6 +246,7 @@ def running(name,
             nic_profile=None,
             interfaces=None,
             graphics=None,
+            loader=None,
             seed=True,
             install=True,
             pub_key=None,
@@ -291,6 +292,11 @@ def running(name,
     :param graphics:
         Graphics device to create for the new virtual machine.
         See :ref:`init-graphics-def` for more details on this dictionary
+
+        .. versionadded:: Fluorine
+    :param loader:
+        Firmware loader for the new virtual machine.
+        See :ref:`init-loader-def` for more details on this dictionary
 
         .. versionadded:: Fluorine
     :param saltenv:
@@ -436,6 +442,7 @@ def running(name,
                                   nic=nic_profile,
                                   interfaces=interfaces,
                                   graphics=graphics,
+                                  loader=loader,
                                   seed=seed,
                                   install=install,
                                   pub_key=pub_key,

--- a/salt/templates/virt/libvirt_domain.jinja
+++ b/salt/templates/virt/libvirt_domain.jinja
@@ -7,6 +7,9 @@
                 {% for dev in boot_dev %}
                 <boot dev='{{ dev }}' />
                 {% endfor %}
+		{% if loader %}
+		<loader {{ loader.get('_attributes') }}>{{ loader.get('path') }}</loader>
+		{% endif %}
         </os>
         <devices>
                 {% for diskname, disk in disks.items() %}

--- a/tests/unit/modules/test_virt.py
+++ b/tests/unit/modules/test_virt.py
@@ -278,6 +278,23 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         root = ET.fromstring(xml_data)
         self.assertIsNone(root.find('devices/graphics'))
 
+    def test_gen_xml_noloader_default(self):
+        '''
+        Test virt._gen_xml() with default no loader
+        '''
+        diskp = virt._disk_profile('default', 'kvm', [], 'hello')
+        nicp = virt._nic_profile('default', 'kvm')
+        xml_data = virt._gen_xml(
+            'hello',
+            1,
+            512,
+            diskp,
+            nicp,
+            'kvm'
+            )
+        root = ET.fromstring(xml_data)
+        self.assertIsNone(root.find('os/loader'))
+
     def test_gen_xml_vnc_default(self):
         '''
         Test virt._gen_xml() with default vnc graphics device
@@ -324,6 +341,45 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         self.assertEqual(root.find('devices/graphics').attrib['listen'], '0.0.0.0')
         self.assertEqual(root.find('devices/graphics/listen').attrib['type'], 'address')
         self.assertEqual(root.find('devices/graphics/listen').attrib['address'], '0.0.0.0')
+
+    def test_gen_xml_loader_default(self):
+        '''
+        Test virt._gen_xml() with a loder specified
+        '''
+        diskp = virt._disk_profile('default', 'kvm', [], 'hello')
+        nicp = virt._nic_profile('default', 'kvm')
+        xml_data = virt._gen_xml(
+            'hello',
+            1,
+            512,
+            diskp,
+            nicp,
+            'kvm',
+            loader={'path': '/foo/bar', 'readonly': 'yes', 'type': 'pflash', 'secure': 'yes'}
+            )
+        root = ET.fromstring(xml_data)
+        self.assertEqual(root.find('os/loader').text, '/foo/bar')
+        self.assertEqual(root.find('os/loader').attrib['type'], 'pflash')
+        self.assertEqual(root.find('os/loader').attrib['readonly'], 'yes')
+        self.assertEqual(root.find('os/loader').attrib['secure'], 'yes')
+
+    def test_gen_xml_loader_invalid(self):
+        '''
+        Test virt._gen_xml() with an invalid loader (missing path) specified
+        '''
+        diskp = virt._disk_profile('default', 'kvm', [], 'hello')
+        nicp = virt._nic_profile('default', 'kvm')
+        xml_data = virt._gen_xml(
+            'hello',
+            1,
+            512,
+            diskp,
+            nicp,
+            'kvm',
+            loader={'readonly': 'yes', 'type': 'pflash', 'secure': 'yes'}
+            )
+        root = ET.fromstring(xml_data)
+        self.assertFalse('loader' in root.find('os'))
 
     def test_gen_xml_spice(self):
         '''
@@ -979,6 +1035,23 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         self.assertEqual('vnc', graphics['type'])
         self.assertEqual('5900', graphics['port'])
         self.assertEqual('0.0.0.0', graphics['listen'])
+
+    def test_get_loader(self):
+        '''
+        Test virt.get_loader()
+        '''
+        xml = '''<domain type='kvm' id='7'>
+              <name>test-vm</name>
+              <os>
+                <loader readonly='yes' type='pflash'>/foo/bar</loader>
+              </os>
+            </domain>
+        '''
+        self.set_mock_vm("test-vm", xml)
+
+        loader = virt.get_loader('test-vm')
+        self.assertEqual('/foo/bar', loader['path'])
+        self.assertEqual('yes', loader['readonly'])
 
     def test_get_nics(self):
         '''

--- a/tests/unit/states/test_virt.py
+++ b/tests/unit/states/test_virt.py
@@ -254,7 +254,7 @@ class LibvirtTestCase(TestCase, LoaderModuleMockMixin):
                                               image='/path/to/img.qcow2'), ret)
             init_mock.assert_called_with('myvm', cpu=2, mem=2048, image='/path/to/img.qcow2',
                                          disk=None, disks=None, nic=None, interfaces=None,
-                                         graphics=None, hypervisor=None,
+                                         graphics=None, loader=None, hypervisor=None,
                                          seed=True, install=True, pub_key=None, priv_key=None,
                                          connection=None, username=None, password=None)
 
@@ -286,6 +286,7 @@ class LibvirtTestCase(TestCase, LoaderModuleMockMixin):
                          'source': 'admin'
                       }]
             graphics = {'type': 'spice', 'listen': {'type': 'address', 'address': '192.168.0.1'}}
+            loader = {'path': '/path/to/loader', 'readonly': 'yes'}
             self.assertDictEqual(virt.running('myvm',
                                               cpu=2,
                                               mem=2048,
@@ -295,6 +296,7 @@ class LibvirtTestCase(TestCase, LoaderModuleMockMixin):
                                               nic_profile='prod',
                                               interfaces=ifaces,
                                               graphics=graphics,
+                                              loader=loader,
                                               seed=False,
                                               install=False,
                                               pub_key='/path/to/key.pub',
@@ -311,6 +313,7 @@ class LibvirtTestCase(TestCase, LoaderModuleMockMixin):
                                          nic='prod',
                                          interfaces=ifaces,
                                          graphics=graphics,
+                                         loader=loader,
                                          hypervisor='qemu',
                                          seed=False,
                                          install=False,


### PR DESCRIPTION
### What does this PR do?
Add bhyve support to the virt module, and add ZFS compatibility for cloning/creating zvols when using bhyve as a hypervisor.

### What issues does this PR fix or reference?
#47619

### Previous Behavior
Not implemented. Crashes when performing virt.init for a bhyve hypervisor.

### New Behavior
Using virt.init for a bhyve hypervisor will create a VM with (multiple) ZFS provisioned disks. Using virt.purge will destroy the VM and the corresponding ZFS datasets.

### Tests written?
No

### Commits signed with GPG?
No
