### PR TITLE
handle new _create_stream in tornado 5.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -5,6 +5,6 @@ msgpack>=0.5,!=0.5.5
 PyYAML
 MarkupSafe
 requests>=1.0.0
-tornado>=4.2.1,<5.0
+tornado>=4.2.1,<6.0
 # Required by Tornado to handle threads stuff.
 futures>=2.0

--- a/salt/transport/tcp.py
+++ b/salt/transport/tcp.py
@@ -880,33 +880,33 @@ class SaltMessageClient(object):
             return
         self._closing = True
         if hasattr(self, '_stream') and not self._stream.closed():
-            self._stream.close()
-            if self._read_until_future is not None:
-                # This will prevent this message from showing up:
-                # '[ERROR   ] Future exception was never retrieved:
-                # StreamClosedError'
-                # This happens because the logic is always waiting to read
-                # the next message and the associated read future is marked
-                # 'StreamClosedError' when the stream is closed.
-                self._read_until_future.exception()
-                if (not self._stream_return_future.done() and
-                        self.io_loop != tornado.ioloop.IOLoop.current(
-                            instance=False)):
-                    # If _stream_return() hasn't completed, it means the IO
-                    # Loop is stopped (such as when using
-                    # 'salt.utils.async.SyncWrapper'). Ensure that
-                    # _stream_return() completes by restarting the IO Loop.
-                    # This will prevent potential errors on shutdown.
-                    orig_loop = tornado.ioloop.IOLoop.current()
-                    self.io_loop.make_current()
-                    try:
-                        self.io_loop.add_future(
-                            self._stream_return_future,
-                            lambda future: self.io_loop.stop()
-                        )
-                        self.io_loop.start()
-                    finally:
-                        orig_loop.make_current()
+            # If _stream_return() hasn't completed, it means the IO
+            # Loop is stopped (such as when using
+            # 'salt.utils.async.SyncWrapper'). Ensure that
+            # _stream_return() completes by restarting the IO Loop.
+            # This will prevent potential errors on shutdown.
+            try:
+                orig_loop = tornado.ioloop.IOLoop.current()
+                self.io_loop.make_current()
+                self._stream.close()
+                if self._read_until_future is not None:
+                    # This will prevent this message from showing up:
+                    # '[ERROR   ] Future exception was never retrieved:
+                    # StreamClosedError'
+                    # This happens because the logic is always waiting to read
+                    # the next message and the associated read future is marked
+                    # 'StreamClosedError' when the stream is closed.
+                    self._read_until_future.exception()
+                    if (not self._stream_return_future.done() and
+                            self.io_loop != tornado.ioloop.IOLoop.current(
+                                instance=False)):
+                            self.io_loop.add_future(
+                                self._stream_return_future,
+                                lambda future: self.io_loop.stop()
+                            )
+                            self.io_loop.start()
+            finally:
+                orig_loop.make_current()
         self._tcp_client.close()
         # Clear callback references to allow the object that they belong to
         # to be deleted.

--- a/salt/transport/tcp.py
+++ b/salt/transport/tcp.py
@@ -900,11 +900,11 @@ class SaltMessageClient(object):
                     if (not self._stream_return_future.done() and
                             self.io_loop != tornado.ioloop.IOLoop.current(
                                 instance=False)):
-                            self.io_loop.add_future(
-                                self._stream_return_future,
-                                lambda future: self.io_loop.stop()
-                            )
-                            self.io_loop.start()
+                        self.io_loop.add_future(
+                            self._stream_return_future,
+                            lambda future: self.io_loop.stop()
+                        )
+                        self.io_loop.start()
             finally:
                 orig_loop.make_current()
         self._tcp_client.close()


### PR DESCRIPTION
### What does this PR do?
In tornado 5.0, this _create_stream function now returns a tuple instead of
just the stream.connect() object.  So since we are overriding it, we need to
update.

Also initialize the SaltMessageServer with the current io_loop set.

### What issues does this PR fix or reference?
This fixes the the last tests that are failing with tornado 5.0.

### Tests written?

Yes

### Commits signed with GPG?

Yes