### PR TITLE
query the pip path for test test_issue_2087_missing_pip

### DIFF
--- a/tests/integration/modules/test_pip.py
+++ b/tests/integration/modules/test_pip.py
@@ -11,7 +11,6 @@ from __future__ import absolute_import
 import os
 import re
 import shutil
-import sys
 import tempfile
 
 # Import Salt Testing libs
@@ -73,8 +72,7 @@ class PipModuleTest(ModuleCase):
 
         # Let's remove the pip binary
         pip_bin = os.path.join(self.venv_dir, 'bin', 'pip')
-        py_dir = 'python{0}.{1}'.format(*sys.version_info[:2])
-        site_dir = os.path.join(self.venv_dir, 'lib', py_dir, 'site-packages')
+        site_dir = self.run_function('virtualenv.get_distribution_path', [self.venv_dir, 'pip'])
         if salt.utils.is_windows():
             pip_bin = os.path.join(self.venv_dir, 'Scripts', 'pip.exe')
             site_dir = os.path.join(self.venv_dir, 'lib', 'site-packages')

--- a/tests/integration/states/test_pip.py
+++ b/tests/integration/states/test_pip.py
@@ -215,8 +215,7 @@ class PipStateTest(ModuleCase, SaltReturnAssertsMixin):
 
             # Let's remove the pip binary
             pip_bin = os.path.join(venv_dir, 'bin', 'pip')
-            py_dir = 'python{0}.{1}'.format(*sys.version_info[:2])
-            site_dir = os.path.join(venv_dir, 'lib', py_dir, 'site-packages')
+            site_dir = self.run_function('virtualenv.get_distribution_path', [venv_dir, 'pip'])
             if salt.utils.is_windows():
                 pip_bin = os.path.join(venv_dir, 'Scripts', 'pip.exe')
                 site_dir = os.path.join(venv_dir, 'lib', 'site-packages')


### PR DESCRIPTION
### What does this PR do?
The following tests are failing on macosx python3:

```
integration.modules.test_pip.PipModuleTest.test_issue_2087_missing_pip                                                                                                              
integration.states.test_pip.PipStateTest.test_issue_2087_missing_pip
```

This is because when the virtualenv is created its created with python2 because the default `python` is 2 on the macosx hosts. My understanding of the virtualenv.create module is that it will use the default python version installed unless `python=python3` is passed to the command. I could be wrong about this code analysis as I am not certain if its suppose to grab the version of python that salt is running.

This PR changes the test to query what the site-packages path is for the pip package before we try to remove it, instead of assuming the path is the same version of python as the test runner. 