### PR TITLE
Add reference to the logs when state cannot be rendered.

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -3902,7 +3902,8 @@ class BaseHighState(object):
         err += self.verify_tops(top)
         matches = self.top_matches(top)
         if not matches:
-            msg = 'No Top file or master_tops data matches found.'
+            msg = ('No Top file or master_tops data matches found. Please see '
+                   'master log for details.')
             ret[tag_name]['comment'] = msg
             return ret
         matches = self.matches_whitelist(matches, whitelist)


### PR DESCRIPTION
As discussed in issue #47612 on github; the addition is the same of the one in the pillar when there's an error rendering it.

### What does this PR do?
It points out to have a look in the logs for more information.

### What issues does this PR fix or reference?
#47612

### Previous Behavior
The error returned doesn't point the user to the issue in rendering the state.

### Tests written?
Not needed (?), since it's just an improvement in an error message.

### Commits signed with GPG?
No