### PR TITLE
Update test_mac_user_enable_auto_login to test both py2 and py3

### DIFF
--- a/tests/integration/modules/test_mac_user.py
+++ b/tests/integration/modules/test_mac_user.py
@@ -16,6 +16,7 @@ from tests.support.helpers import destructiveTest, skip_if_not_root
 # Import Salt Libs
 import salt.utils
 from salt.exceptions import CommandExecutionError
+import salt.ext.six as six
 
 # Import 3rd-party libs
 from salt.ext.six.moves import range  # pylint: disable=import-error,redefined-builtin
@@ -173,8 +174,11 @@ class MacUserModuleTest(ModuleCase):
             self.assertTrue(os.path.exists('/etc/kcpassword'))
 
             # Are the contents of the file correct
-            test_data = b".\xc3\xb8'B\xc2\xa0\xc3\x99\xc2\xad\xc2\x8b\xc3\x8d\xc3\x8dl"
-            with salt.utils.fopen('/etc/kcpassword', 'rb') as f:
+            if six.PY2:
+                test_data = b'.\xf8\'B\xa0\xd9\xad\x8b\xcd\xcdl'
+            else:
+                test_data = b".\xc3\xb8'B\xc2\xa0\xc3\x99\xc2\xad\xc2\x8b\xc3\x8d\xc3\x8dl"
+            with salt.utils.fopen('/etc/kcpassword', 'r' if six.PY2 else 'rb') as f:
                 file_data = f.read()
             self.assertEqual(test_data, file_data)
 


### PR DESCRIPTION
### What does this PR do?
semi-backport of https://github.com/saltstack/salt/pull/46173. Need to account for both py2 adn py3 in 2017.7 branch as well. 

### Previous Behavior

```
*** integration.modules.test_mac_user.MacUserModuleTest.test_mac_user_enable_auto_login Tests  ******************************************************************************************************************************************
 --------  Failed Tests  ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
   -> integration.modules.test_mac_user.MacUserModuleTest.test_mac_user_enable_auto_login  ..............................................................................................................................................
       Traceback (most recent call last):
         File "/testing/tests/integration/modules/test_mac_user.py", line 179, in test_mac_user_enable_auto_login
           self.assertEqual(test_data, file_data)
       AssertionError: ".\xc3\xb8'B\xc2\xa0\xc3\x99\xc2\xad\xc2\x8b\xc3\x8d\xc3\x8dl" != ".\xf8'B\xa0\xd9\xad\x8b\xcd\xcdl"
   ......................................................................................................................................................................................................................................
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
=========================================================================================================================================================================================================================================
FAILED (total=1, skipped=0, passed=0, failures=1, errors=0) 
========================================================================================================  Overall Tests Report  =========================================================================================================
```

### New Behavior

```
========================================================================================================  Overall Tests Report  =========================================================================================================
***  No Problems Found While Running Tests  *********************************************************************************************************************************************************************************************
=========================================================================================================================================================================================================================================
OK (total=1, skipped=0, passed=1, failures=0, errors=0) 
========================================================================================================  Overall Tests Report  =========================================================================================================
```
