### PR TITLE
Backport #45808 to 2017.7

### DIFF
--- a/salt/fileclient.py
+++ b/salt/fileclient.py
@@ -41,6 +41,7 @@ from salt.ext.six.moves.urllib.parse import urlparse, urlunparse
 # pylint: enable=no-name-in-module,import-error
 
 log = logging.getLogger(__name__)
+MAX_FILENAME_LENGTH = 255
 
 
 def get_file_client(opts, pillar=False):
@@ -798,6 +799,9 @@ class Client(object):
             file_name = '-'.join([url_data.path, url_data.query])
         else:
             file_name = url_data.path
+
+        if len(file_name) > MAX_FILENAME_LENGTH:
+            file_name = salt.utils.hashutils.sha256_digest(file_name)
 
         return salt.utils.path_join(
             cachedir,

--- a/tests/unit/test_fileclient.py
+++ b/tests/unit/test_fileclient.py
@@ -50,3 +50,14 @@ class FileclientTestCase(TestCase):
                 with self.assertRaises(OSError):
                     with Client(self.opts)._cache_loc('testfile') as c_ref_itr:
                         assert c_ref_itr == '/__test__/files/base/testfile'
+
+    def test_extrn_path_with_long_filename(self):
+        safe_file_name = os.path.split(Client(self.opts)._extrn_path('https://test.com/' + ('A' * 254), 'base'))[-1]
+        assert safe_file_name == 'A' * 254
+
+        oversized_file_name = os.path.split(Client(self.opts)._extrn_path('https://test.com/' + ('A' * 255), 'base'))[-1]
+        assert len(oversized_file_name) < 256
+        assert oversized_file_name != 'A' * 255
+
+        oversized_file_with_query_params = os.path.split(Client(self.opts)._extrn_path('https://test.com/file?' + ('A' * 255), 'base'))[-1]
+        assert len(oversized_file_with_query_params) < 256


### PR DESCRIPTION
See #45808.