### PR TITLE
Fix regression in table outputter due to unicode types

### DIFF
--- a/salt/output/table_out.py
+++ b/salt/output/table_out.py
@@ -148,7 +148,7 @@ class TableDisplay(object):
                 for item in row
             ]
             rows = []
-            for item in map(None, *new_rows):
+            for item in map(lambda *args: args, *new_rows):
                 if isinstance(item, (tuple, list)):
                     rows.append([substr or '' for substr in item])
                 else:
@@ -160,7 +160,7 @@ class TableDisplay(object):
             for row in rows
         ]
 
-        columns = map(None, *reduce(operator.add, logical_rows))
+        columns = map(lambda *args: args, *reduce(operator.add, logical_rows))
 
         max_widths = [
             max([len(six.text_type(item)) for item in column])

--- a/salt/output/table_out.py
+++ b/salt/output/table_out.py
@@ -43,6 +43,7 @@ from functools import reduce  # pylint: disable=redefined-builtin
 # Import Salt libs
 import salt.output
 import salt.utils.color
+import salt.utils.data
 import salt.utils.locales
 
 # Import 3rd-party libs
@@ -62,9 +63,9 @@ class TableDisplay(object):
     '''
 
     _JUSTIFY_MAP = {
-        'center': str.center,
-        'right': str.rjust,
-        'left': str.ljust
+        'center': six.text_type.center,
+        'right': six.text_type.rjust,
+        'left': six.text_type.ljust
     }
 
     def __init__(self,
@@ -363,7 +364,7 @@ def output(ret, **kwargs):
             )
         )
 
-    return '\n'.join(table.display(ret,
+    return '\n'.join(table.display(salt.utils.data.decode(ret),
                                    base_indent,
                                    out,
                                    rows_key=rows_key,

--- a/tests/unit/output/test_table_out.py
+++ b/tests/unit/output/test_table_out.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+'''
+unittests for table outputter
+'''
+
+# Import Python Libs
+from __future__ import absolute_import, print_function, unicode_literals
+
+# Import Salt Testing Libs
+from tests.support.mixins import LoaderModuleMockMixin
+from tests.support.unit import TestCase
+
+# Import Salt Libs
+import salt.output.table_out as table_out
+import salt.utils.stringutils
+
+
+class TableTestCase(TestCase, LoaderModuleMockMixin):
+    '''
+    Test cases for salt.output.table_out
+    '''
+    def setup_loader_modules(self):
+        return {table_out: {}}
+
+    # The test data should include unicode chars, and in Python 2 there should
+    # be an example both of an encoded str type and an actual unicode type.
+    # Since unicode_literals is imported, we will achieve the former using
+    # salt.utils.stringutils.to_str and the latter by simply using a string
+    # literal.
+    data = [
+        {'Food': salt.utils.stringutils.to_str('яйца, бекон, колбаса и спам'),
+         'Price': 5.99},
+        {'Food': 'спам, спам, спам, яйца и спам',
+         'Price': 3.99},
+    ]
+
+    def test_output(self):
+        ret = table_out.output(self.data)
+        self.assertEqual(
+            ret,
+            ('    -----------------------------------------\n'
+             '    |              Food             | Price |\n'
+             '    -----------------------------------------\n'
+             '    |  яйца, бекон, колбаса и спам  |  5.99 |\n'
+             '    -----------------------------------------\n'
+             '    | спам, спам, спам, яйца и спам |  3.99 |\n'
+             '    -----------------------------------------')
+        )


### PR DESCRIPTION
This ensures that we use the proper justification functions from the unicode type on Python 2, and that we also normalize the input so that we are guaranteed that all strings are unicode types.

It also adds a unit test module, as this outputter did not have test coverage.

BONUS: In the course of writing this test, I found a Python 3 incompatibility (`map(None, some_iterable)` is not valid usage in Python 3). This PR also fixes that incompatiblity in a way that works in both Python 2 and 3.

Resolves #47587.