### PR TITLE
[develop] Collect all versions of installed packages on SUSE and RHEL systems

### DIFF
--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -1040,11 +1040,8 @@ def info_installed(*names, **kwargs):
                     t_nfo[key] = value
             if not all_versions:
                 ret[pkg_name] = t_nfo
-            elif not pkg_name in ret:
-                ret[pkg_name] = [t_nfo]
             else:
-                ret[pkg_name].append(t_nfo)
-
+                ret.setdefault(pkg_name, []).append(t_nfo)
     return ret
 
 

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -1015,12 +1015,16 @@ def info_installed(*names, **kwargs):
 
     Return the information of the named package(s), installed on the system.
 
+    :param all_versions:
+        Include information for all versions of the packages installed on the minion.
+
     CLI example:
 
     .. code-block:: bash
 
         salt '*' pkg.info_installed <package1>
         salt '*' pkg.info_installed <package1> <package2> <package3> ...
+        salt '*' pkg.info_installed <package1> <package2> <package3> all_versions=True
     '''
     all_versions = kwargs.get('all_versions', False)
     ret = dict()

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -1965,7 +1965,24 @@ def remove(name=None, pkgs=None, **kwargs):  # pylint: disable=W0613
         raise CommandExecutionError(exc)
 
     old = list_pkgs()
-    targets = [x for x in pkg_params if x in old]
+    targets = []
+    for target in pkg_params:
+        # Check if package version set to be removed is actually installed:
+        # old[target] contains a comma-separated list of installed versions
+        if target in old and not pkg_params[target]:
+            targets.append(target)
+        elif target in old and pkg_params[target] in old[target].split(','):
+            arch = ''
+            pkgname = target
+            try:
+                namepart, archpart = target.rsplit('.', 1)
+            except ValueError:
+                pass
+            else:
+                if archpart in salt.utils.pkg.rpm.ARCHES:
+                    arch = '.' + archpart
+                    pkgname = namepart
+            targets.append('{0}-{1}{2}'.format(pkgname, pkg_params[target], arch))
     if not targets:
         return {}
 

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -481,17 +481,24 @@ def info_installed(*names, **kwargs):
         salt '*' pkg.info_installed <package1> <package2> <package3> ... attr=version,vendor errors=ignore
         salt '*' pkg.info_installed <package1> <package2> <package3> ... attr=version,vendor errors=report
     '''
+    all_versions = kwargs.get('all_versions', False)
     ret = dict()
-    for pkg_name, pkg_nfo in __salt__['lowpkg.info'](*names, **kwargs).items():
-        t_nfo = dict()
-        # Translate dpkg-specific keys to a common structure
-        for key, value in six.iteritems(pkg_nfo):
-            if key == 'source_rpm':
-                t_nfo['source'] = value
+    for pkg_name, pkgs_nfo in __salt__['lowpkg.info'](*names, **kwargs).items():
+        pkg_nfo = pkgs_nfo if all_versions else [pkgs_nfo]
+        for _nfo in pkg_nfo:
+            t_nfo = dict()
+            # Translate dpkg-specific keys to a common structure
+            for key, value in six.iteritems(_nfo):
+                if key == 'source_rpm':
+                    t_nfo['source'] = value
+                else:
+                    t_nfo[key] = value
+            if not all_versions:
+                ret[pkg_name] = t_nfo
+            elif not pkg_name in ret:
+                ret[pkg_name] = [t_nfo]
             else:
-                t_nfo[key] = value
-        ret[pkg_name] = t_nfo
-
+                ret[pkg_name].append(t_nfo)
     return ret
 
 

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -499,10 +499,8 @@ def info_installed(*names, **kwargs):
                     t_nfo[key] = value
             if not all_versions:
                 ret[pkg_name] = t_nfo
-            elif not pkg_name in ret:
-                ret[pkg_name] = [t_nfo]
             else:
-                ret[pkg_name].append(t_nfo)
+                ret.setdefault(pkg_name, []).append(t_nfo)
     return ret
 
 

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -470,13 +470,17 @@ def info_installed(*names, **kwargs):
         Valid attributes are:
             ignore, report
 
+    :param all_versions:
+        Include information for all versions of the packages installed on the minion.
+
     CLI example:
 
     .. code-block:: bash
 
         salt '*' pkg.info_installed <package1>
         salt '*' pkg.info_installed <package1> <package2> <package3> ...
-        salt '*' pkg.info_installed <package1> attr=version,vendor
+        salt '*' pkg.info_installed <package1> <package2> <package3> all_versions=True
+        salt '*' pkg.info_installed <package1> attr=version,vendor all_versions=True
         salt '*' pkg.info_installed <package1> <package2> <package3> ... attr=version,vendor
         salt '*' pkg.info_installed <package1> <package2> <package3> ... attr=version,vendor errors=ignore
         salt '*' pkg.info_installed <package1> <package2> <package3> ... attr=version,vendor errors=report

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -844,6 +844,17 @@ def _verify_install(desired, new_pkgs, ignore_epoch=False, new_caps=None):
             cver = new_pkgs.get(pkgname.split('%')[0])
         elif __grains__['os_family'] == 'Debian':
             cver = new_pkgs.get(pkgname.split('=')[0])
+        elif __grains__['os_family'] == 'Suse':
+            # On SUSE systems. Zypper returns packages without "arch" in name
+            try:
+                namepart, archpart = pkgname.rsplit('.', 1)
+            except ValueError:
+                cver = new_pkgs.get(pkgname)
+            else:
+                if archpart in salt.utils.pkg.rpm.ARCHES + ("noarch",):
+                    cver = new_pkgs.get(namepart)
+                else:
+                    cver = new_pkgs.get(pkgname)
         else:
             cver = new_pkgs.get(pkgname)
             if not cver and pkgname in new_caps:

--- a/tests/unit/modules/test_yumpkg.py
+++ b/tests/unit/modules/test_yumpkg.py
@@ -611,3 +611,53 @@ class YumTestCase(TestCase, LoaderModuleMockMixin):
                      '--exclude=kernel*', 'upgrade'],
                     output_loglevel='trace',
                     python_shell=False)
+
+    def test_info_installed_with_all_versions(self):
+        '''
+        Test the return information of all versions for the named package(s), installed on the system.
+
+        :return:
+        '''
+        run_out = {
+            'virgo-dummy': [
+                {'build_date': '2015-07-09T10:55:19Z',
+                 'vendor': 'openSUSE Build Service',
+                 'description': 'This is the Virgo dummy package used for testing SUSE Manager',
+                 'license': 'GPL-2.0', 'build_host': 'sheep05', 'url': 'http://www.suse.com',
+                 'build_date_time_t': 1436432119, 'relocations': '(not relocatable)',
+                 'source_rpm': 'virgo-dummy-1.0-1.1.src.rpm', 'install_date': '2016-02-23T16:31:57Z',
+                 'install_date_time_t': 1456241517, 'summary': 'Virgo dummy package', 'version': '1.0',
+                 'signature': 'DSA/SHA1, Thu Jul  9 08:55:33 2015, Key ID 27fa41bd8a7c64f9',
+                 'release': '1.1', 'group': 'Applications/System', 'arch': 'i686', 'size': '17992'},
+                {'build_date': '2015-07-09T10:15:19Z',
+                 'vendor': 'openSUSE Build Service',
+                 'description': 'This is the Virgo dummy package used for testing SUSE Manager',
+                 'license': 'GPL-2.0', 'build_host': 'sheep05', 'url': 'http://www.suse.com',
+                 'build_date_time_t': 1436432119, 'relocations': '(not relocatable)',
+                 'source_rpm': 'virgo-dummy-1.0-1.1.src.rpm', 'install_date': '2016-02-23T16:31:57Z',
+                 'install_date_time_t': 14562415127, 'summary': 'Virgo dummy package', 'version': '1.0',
+                 'signature': 'DSA/SHA1, Thu Jul  9 08:55:33 2015, Key ID 27fa41bd8a7c64f9',
+                 'release': '1.1', 'group': 'Applications/System', 'arch': 'x86_64', 'size': '13124'}
+            ],
+            'libopenssl1_0_0': [
+                {'build_date': '2015-11-04T23:20:34Z', 'vendor': 'SUSE LLC <https://www.suse.com/>',
+                 'description': 'The OpenSSL Project is a collaborative effort.',
+                 'license': 'OpenSSL', 'build_host': 'sheep11', 'url': 'https://www.openssl.org/',
+                 'build_date_time_t': 1446675634, 'relocations': '(not relocatable)',
+                 'source_rpm': 'openssl-1.0.1i-34.1.src.rpm', 'install_date': '2016-02-23T16:31:35Z',
+                 'install_date_time_t': 1456241495, 'summary': 'Secure Sockets and Transport Layer Security',
+                 'version': '1.0.1i', 'signature': 'RSA/SHA256, Wed Nov  4 22:21:34 2015, Key ID 70af9e8139db7c82',
+                 'release': '34.1', 'group': 'Productivity/Networking/Security', 'packager': 'https://www.suse.com/',
+                 'arch': 'x86_64', 'size': '2576912'}
+            ]
+        }
+        with patch.dict(yumpkg.__salt__, {'lowpkg.info': MagicMock(return_value=run_out)}):
+            installed = yumpkg.info_installed(all_versions=True)
+            # Test overall products length
+            self.assertEqual(len(installed), 2)
+
+            # Test multiple versions for the same package
+            for pkg_name, pkg_info_list in installed.items():
+                self.assertEqual(len(pkg_info_list), 2 if pkg_name == "virgo-dummy" else 1)
+                for info in pkg_info_list:
+                    self.assertTrue(info['arch'] in ('x86_64', 'i686'))

--- a/tests/unit/modules/test_zypper.py
+++ b/tests/unit/modules/test_zypper.py
@@ -327,6 +327,56 @@ class ZypperTestCase(TestCase, LoaderModuleMockMixin):
             installed = zypper.info_installed()
             self.assertEqual(installed['vīrgô']['description'], 'vīrgô d€šçripţiǫñ')
 
+    def test_info_installed_with_all_versions(self):
+        '''
+        Test the return information of all versions for the named package(s), installed on the system.
+
+        :return:
+        '''
+        run_out = {
+            'virgo-dummy': [
+                {'build_date': '2015-07-09T10:55:19Z',
+                 'vendor': 'openSUSE Build Service',
+                 'description': 'This is the Virgo dummy package used for testing SUSE Manager',
+                 'license': 'GPL-2.0', 'build_host': 'sheep05', 'url': 'http://www.suse.com',
+                 'build_date_time_t': 1436432119, 'relocations': '(not relocatable)',
+                 'source_rpm': 'virgo-dummy-1.0-1.1.src.rpm', 'install_date': '2016-02-23T16:31:57Z',
+                 'install_date_time_t': 1456241517, 'summary': 'Virgo dummy package', 'version': '1.0',
+                 'signature': 'DSA/SHA1, Thu Jul  9 08:55:33 2015, Key ID 27fa41bd8a7c64f9',
+                 'release': '1.1', 'group': 'Applications/System', 'arch': 'i686', 'size': '17992'},
+                {'build_date': '2015-07-09T10:15:19Z',
+                 'vendor': 'openSUSE Build Service',
+                 'description': 'This is the Virgo dummy package used for testing SUSE Manager',
+                 'license': 'GPL-2.0', 'build_host': 'sheep05', 'url': 'http://www.suse.com',
+                 'build_date_time_t': 1436432119, 'relocations': '(not relocatable)',
+                 'source_rpm': 'virgo-dummy-1.0-1.1.src.rpm', 'install_date': '2016-02-23T16:31:57Z',
+                 'install_date_time_t': 14562415127, 'summary': 'Virgo dummy package', 'version': '1.0',
+                 'signature': 'DSA/SHA1, Thu Jul  9 08:55:33 2015, Key ID 27fa41bd8a7c64f9',
+                 'release': '1.1', 'group': 'Applications/System', 'arch': 'x86_64', 'size': '13124'}
+            ],
+            'libopenssl1_0_0': [
+                {'build_date': '2015-11-04T23:20:34Z', 'vendor': 'SUSE LLC <https://www.suse.com/>',
+                 'description': 'The OpenSSL Project is a collaborative effort.',
+                 'license': 'OpenSSL', 'build_host': 'sheep11', 'url': 'https://www.openssl.org/',
+                 'build_date_time_t': 1446675634, 'relocations': '(not relocatable)',
+                 'source_rpm': 'openssl-1.0.1i-34.1.src.rpm', 'install_date': '2016-02-23T16:31:35Z',
+                 'install_date_time_t': 1456241495, 'summary': 'Secure Sockets and Transport Layer Security',
+                 'version': '1.0.1i', 'signature': 'RSA/SHA256, Wed Nov  4 22:21:34 2015, Key ID 70af9e8139db7c82',
+                 'release': '34.1', 'group': 'Productivity/Networking/Security', 'packager': 'https://www.suse.com/',
+                 'arch': 'x86_64', 'size': '2576912'}
+            ]
+        }
+        with patch.dict(zypper.__salt__, {'lowpkg.info': MagicMock(return_value=run_out)}):
+            installed = zypper.info_installed(all_versions=True)
+            # Test overall products length
+            self.assertEqual(len(installed), 2)
+
+            # Test multiple versions for the same package
+            for pkg_name, pkg_info_list in installed.items():
+                self.assertEqual(len(pkg_info_list), 2 if pkg_name == "virgo-dummy" else 1)
+                for info in pkg_info_list:
+                    self.assertTrue(info['arch'] in ('x86_64', 'i686'))
+
     def test_info_available(self):
         '''
         Test return the information of the named package available for the system.


### PR DESCRIPTION
### What does this PR do?
This PR targets `develop` branch as discussed on https://github.com/saltstack/salt/pull/47638 

@terminalmage - I've also addressed your comment about using `ret.setdefault()` instead `if-else` statement. Thanks

<hr>

At the moment, Salt `pkg.info_installed` method (for zypper & yum modules) only returns one version information per installed package name:

```
$ rpm -qa libgcc
libgcc-4.4.7-18.el6_9.2.i686
libgcc-4.4.7-18.el6_9.2.x86_64
```

Now we ask Salt for information of the installed `libgcc` package:

```
$ salt-call pkg.info_installed libgcc attr=version,arch
local:
    ----------
    libgcc:
        ----------
        arch:
            i686
        version:
            4.4.7
```

In case of multiple installed versions of the same package name, Salt is currently returning the latest installed package.

This PR also fixes an issue with the `pkg` state on SUSE systems when targeting packages like `glibc.x86_64`. Zypper actually install/remove the packages but the comparison made by `pkg` state is setting the packages as `failed` because zypper response does not include the "arch" as part of the package name.

### Previous Behavior
No way to get information for all package versions installed on the minion.

### New Behavior
This PR introduces the `all_versions` parameter into `zypper.info_installed`, `yum.info_installed` and also to `rpm.info` methods which is set to `False` by default. No changes on the returned structure.

Only when using `all_versions=True` it would change the output structure to produce a list of package information which actually reflects all installed versions for `libgcc`:

```
$ salt-call pkg.info_installed libgcc attr=version,arch all_versions=True
local:
    ----------
    libgcc:
        |_
          ----------
          arch:
              i686
          edition:
              4.4.7-18.el6_9.2
          version:
              4.4.7
        |_
          ----------
          arch:
              x86_64
          edition:
              4.4.7-18.el6_9.2
          version:
              4.4.7
```


### Tests written?

Yes

### Commits signed with GPG?

Yes