### PR TITLE
Adding a merge_all function to slsutil

### DIFF
--- a/salt/modules/slsutil.py
+++ b/salt/modules/slsutil.py
@@ -56,13 +56,28 @@ def merge(obj_a, obj_b, strategy='smart', renderer='yaml', merge_lists=False):
 
 def merge_all(lst, strategy='smart', renderer='yaml', merge_lists=False):
     '''
+    .. versionadded:: Fluorine
+
     Merge a list of objects into each other in order
+
+    :type lst: Iterable
+    :param lst: List of objects to be merged.
+
+    :type strategy: String
+    :param strategy: Merge strategy. See utils.dictupdate.
+
+    :type renderer: String
+    :param renderer:
+        Renderer type. Used to determine strategy when strategy is 'smart'.
+
+    :type merge_lists: Bool
+    :param merge_lists: Defines whether to merge embedded object lists.
 
     CLI Example:
 
     .. code-block:: shell
 
-        > salt-call --output=txt slsutil.merge_all '[{foo: Foo}, {foo: Bar}]'
+        $ salt-call --output=txt slsutil.merge_all '[{foo: Foo}, {foo: Bar}]'
         local: {u'foo': u'Bar'}
     '''
 

--- a/salt/modules/slsutil.py
+++ b/salt/modules/slsutil.py
@@ -53,6 +53,7 @@ def merge(obj_a, obj_b, strategy='smart', renderer='yaml', merge_lists=False):
     return salt.utils.dictupdate.merge(obj_a, obj_b, strategy, renderer,
             merge_lists)
 
+
 def merge_all(lst, strategy='smart', renderer='yaml', merge_lists=False):
     '''
     Merge a list of objects into each other in order
@@ -61,7 +62,7 @@ def merge_all(lst, strategy='smart', renderer='yaml', merge_lists=False):
 
     .. code-block:: shell
 
-        > salt '*' slsutil.merge_all '[{foo: Foo}, {foo: Bar}]'
+        > salt-call --output=txt slsutil.merge_all '[{foo: Foo}, {foo: Bar}]'
         local: {u'foo': u'Bar'}
     '''
 

--- a/salt/modules/slsutil.py
+++ b/salt/modules/slsutil.py
@@ -53,6 +53,26 @@ def merge(obj_a, obj_b, strategy='smart', renderer='yaml', merge_lists=False):
     return salt.utils.dictupdate.merge(obj_a, obj_b, strategy, renderer,
             merge_lists)
 
+def merge_all(lst, strategy='smart', renderer='yaml', merge_lists=False):
+    '''
+    Merge a list of objects into each other in order
+
+    CLI Example:
+
+    .. code-block:: shell
+
+        > salt '*' slsutil.merge_all '[{foo: Foo}, {foo: Bar}]'
+        local: {u'foo': u'Bar'}
+    '''
+
+    ret = {}
+    for obj in lst:
+        ret = salt.utils.dictupdate.merge(
+            ret, obj, strategy, renderer, merge_lists
+        )
+
+    return ret
+
 
 def renderer(path=None, string=None, default_renderer='jinja|yaml', **kwargs):
     '''


### PR DESCRIPTION
The merge_all function merges a list of objects in order. This will make merging multiple objects more readable. Consider the difference between merging three objects with `slsutil.merge` versus merging with `slsutil.merge_all`

With `slsutil.merge`:
```
{{ hadoop.hdfs.data_node.service.name }}_environment_file_installed:
  file.managed:
    - name: /etc/sysconfig/{{ hadoop.hdfs.data_node.service.name }}
    - source: salt://hadoop/files/environment
    - template: jinja
    - context:
        environment: {{
          salt.slsutil.merge(
            hadoop.environment, salt.slsutil.merge(
              hadoop.hdfs.environment,
              hadoop.hdfs.data_node.environment
            )
          )
        }}
```

With `slsutil.merge_all`:
```
{{ hadoop.hdfs.data_node.service.name }}_environment_file_installed:
  file.managed:
    - name: /etc/sysconfig/{{ hadoop.hdfs.data_node.service.name }}
    - source: salt://hadoop/files/environment
    - template: jinja
    - context:
        environment: {{
          salt.slsutil.merge_all([
            hadoop.environment,
            hadoop.hdfs.environment,
            hadoop.hdfs.data_node.environment
          ])
        }}
```

I'm interested to know if you all think it would be better to add this function or to overload the merge function. 

### What does this PR do?

This PR adds a merge_all function to the slsutil module

### What issues does this PR fix or reference?

None

### Tests written?

No

### Commits signed with GPG?

Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
