### PR TITLE
Fix traceback when excludes are present in an included SLS file

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -243,11 +243,21 @@ def find_sls_ids(sls, high):
     '''
     ret = []
     for nid, item in six.iteritems(high):
-        if item['__sls__'] == sls:
-            for st_ in item:
-                if st_.startswith('__'):
-                    continue
-                ret.append((nid, st_))
+        try:
+            sls_tgt = item['__sls__']
+        except TypeError:
+            if nid != '__exclude__':
+                log.error(
+                    'Invalid non-dict item \'%s\' in high data. Value: %r',
+                    nid, item
+                )
+            continue
+        else:
+            if sls_tgt == sls:
+                for st_ in item:
+                    if st_.startswith('__'):
+                        continue
+                    ret.append((nid, st_))
     return ret
 
 

--- a/tests/integration/files/file/base/issue-47182/slsfile1.sls
+++ b/tests/integration/files/file/base/issue-47182/slsfile1.sls
@@ -1,0 +1,2 @@
+slsfile1-nop:
+  test.nop

--- a/tests/integration/files/file/base/issue-47182/slsfile2.sls
+++ b/tests/integration/files/file/base/issue-47182/slsfile2.sls
@@ -1,0 +1,2 @@
+slsfile2-nop:
+  test.nop

--- a/tests/integration/files/file/base/issue-47182/stateA/init.sls
+++ b/tests/integration/files/file/base/issue-47182/stateA/init.sls
@@ -1,0 +1,2 @@
+include:
+  - issue-47182.stateA.newer

--- a/tests/integration/files/file/base/issue-47182/stateA/newer.sls
+++ b/tests/integration/files/file/base/issue-47182/stateA/newer.sls
@@ -1,0 +1,6 @@
+exclude:
+  - sls: issue-47182.stateA
+
+somestuff:
+  cmd.run:
+    - name: echo This supersedes the stuff previously done in issue-47182.stateA

--- a/tests/integration/files/file/base/issue-47182/stateB.sls
+++ b/tests/integration/files/file/base/issue-47182/stateB.sls
@@ -1,0 +1,10 @@
+include:
+  - issue-47182.slsfile1
+  - issue-47182.slsfile2
+
+some-state:
+  test.nop:
+    - require:
+      - sls: issue-47182.slsfile1
+    - require_in:
+      - sls: issue-47182.slsfile2

--- a/tests/integration/files/file/base/issue-47182/top.sls
+++ b/tests/integration/files/file/base/issue-47182/top.sls
@@ -1,0 +1,4 @@
+base:
+  '*':
+    - issue-47182.stateA
+    - issue-47182.stateB

--- a/tests/support/paths.py
+++ b/tests/support/paths.py
@@ -48,6 +48,8 @@ SYS_TMP_DIR = os.path.abspath(os.path.realpath(
 ))
 TMP = os.path.join(SYS_TMP_DIR, 'salt-tests-tmpdir')
 FILES = os.path.join(INTEGRATION_TEST_DIR, 'files')
+BASE_FILES = os.path.join(FILES, 'file', 'base')
+PROD_FILES = os.path.join(FILES, 'file', 'prod')
 PYEXEC = 'python{0}.{1}'.format(*sys.version_info)
 MOCKBIN = os.path.join(INTEGRATION_TEST_DIR, 'mockbin')
 SCRIPT_DIR = os.path.join(CODE_DIR, 'scripts')

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -156,7 +156,7 @@ class HighStateTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
         # Manually compile the high data. We don't have to worry about all of
         # the normal error checking we do here since we know that all the SLS
         # files exist and there is no whitelist/blacklist being used.
-        top = self.highstate.get_top()
+        top = self.highstate.get_top()  # pylint: disable=assignment-from-none
         matches = self.highstate.top_matches(top)
         high, _ = self.highstate.render_highstate(matches)
         ret = salt.state.find_sls_ids('issue-47182.stateA.newer', high)

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -7,6 +7,7 @@
 from __future__ import absolute_import
 import copy
 import os
+import shutil
 import tempfile
 
 # Import Salt Testing libs
@@ -14,6 +15,7 @@ import tests.integration as integration
 from tests.support.unit import TestCase, skipIf
 from tests.support.mock import NO_MOCK, NO_MOCK_REASON, patch
 from tests.support.mixins import AdaptedConfigurationTestCaseMixin
+from tests.support.paths import BASE_FILES
 
 # Import Salt libs
 import salt.state
@@ -66,9 +68,9 @@ class StateCompilerTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
 class HighStateTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
     def setUp(self):
         root_dir = tempfile.mkdtemp(dir=integration.TMP)
-        state_tree_dir = os.path.join(root_dir, 'state_tree')
+        self.state_tree_dir = os.path.join(root_dir, 'state_tree')
         cache_dir = os.path.join(root_dir, 'cachedir')
-        for dpath in (root_dir, state_tree_dir, cache_dir):
+        for dpath in (root_dir, self.state_tree_dir, cache_dir):
             if not os.path.isdir(dpath):
                 os.makedirs(dpath)
 
@@ -77,7 +79,7 @@ class HighStateTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
         overrides['state_events'] = False
         overrides['id'] = 'match'
         overrides['file_client'] = 'local'
-        overrides['file_roots'] = dict(base=[state_tree_dir])
+        overrides['file_roots'] = dict(base=[self.state_tree_dir])
         overrides['cachedir'] = cache_dir
         overrides['test'] = False
         self.config = self.get_temp_config('minion', **overrides)
@@ -137,6 +139,28 @@ class HighStateTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
         self.assertEqual(state_usage_dict['base']['count_all'], 3)
         self.assertEqual(state_usage_dict['base']['used'], ['state.a', 'state.b'])
         self.assertEqual(state_usage_dict['base']['unused'], ['state.c'])
+
+    def test_find_sls_ids_with_exclude(self):
+        '''
+        See https://github.com/saltstack/salt/issues/47182
+        '''
+        sls_dir = 'issue-47182'
+        shutil.copytree(
+            os.path.join(BASE_FILES, sls_dir),
+            os.path.join(self.state_tree_dir, sls_dir)
+        )
+        shutil.move(
+            os.path.join(self.state_tree_dir, sls_dir, 'top.sls'),
+            self.state_tree_dir
+        )
+        # Manually compile the high data. We don't have to worry about all of
+        # the normal error checking we do here since we know that all the SLS
+        # files exist and there is no whitelist/blacklist being used.
+        top = self.highstate.get_top()
+        matches = self.highstate.top_matches(top)
+        high, _ = self.highstate.render_highstate(matches)
+        ret = salt.state.find_sls_ids('issue-47182.stateA.newer', high)
+        self.assertEqual(ret, [('somestuff', 'cmd')])
 
 
 class TopFileMergeTestCase(TestCase, AdaptedConfigurationTestCaseMixin):


### PR DESCRIPTION
This causes a traceback in `salt.state.find_sls_ids()` as it expects the high chunks to all be dicts, but the excludes are a list of excluded SLS targets.

Resolves #47182.