### PR TITLE
Remove unnecessary setUp in states.test_user test for mac

### DIFF
--- a/tests/integration/states/test_user.py
+++ b/tests/integration/states/test_user.py
@@ -44,12 +44,6 @@ class UserTest(ModuleCase, SaltReturnAssertsMixin):
     user_name = 'salt_test'
     user_home = '/var/lib/salt_test'
 
-    def setUp(self):
-        if salt.utils.is_darwin():
-            #on mac we need to add user, because there is
-            #no creationtime for nobody user.
-            add_user = self.run_function('user.add', [USER], gid=GID)
-
     def test_user_absent(self):
         ret = self.run_state('user.absent', name='unpossible')
         self.assertSaltTrueReturn(ret)


### PR DESCRIPTION
### What does this PR do?
Fixes test_user state integration tests for macosx. This setUp is unnecessary because the user is added where needed in the user.present tests. I also  believe it might be the cause for some flakiness with the test_user  states on macosx. In particular it was causing this test to fail regularly: `integration.states.test_user.UserTest.test_user_if_present_with_gid`  as the user was being created twice and then trying to change the gid caused an expected warning on 2018.3