### PR TITLE
Update regexes for Solaris 'product' grain and copy to 'productname' grain

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -2160,9 +2160,9 @@ def _hw_data(osdata):
 
         product_regexes = [
             re.compile(r) for r in [
-                r'(?im)^\s*System\s+Configuration:\s*.*?sun\d\S+\s(.*)',  # prtdiag
-                r'(?im)^\s*banner-name:\s*(.*)',  # prtconf
-                r'(?im)^\s*product-name:\s*(.*)',  # prtconf
+                r'(?im)^\s*System\s+Configuration:\s*.*?sun\d\S+[^\S\r\n]*(.*)',  # prtdiag
+                r'(?im)^[^\S\r\n]*banner-name:[^\S\r\n]*(.*)',  # prtconf
+                r'(?im)^[^\S\r\n]*product-name:[^\S\r\n]*(.*)',  # prtconf
             ]
         ]
 
@@ -2229,8 +2229,11 @@ def _hw_data(osdata):
         for regex in product_regexes:
             res = regex.search(data)
             if res and len(res.groups()) >= 1:
-                grains['product'] = res.group(1).strip().replace("'", "")
-                break
+                t_productname = res.group(1).strip().replace("'", "")
+                if t_productname:
+                    grains['product'] = t_productname
+                    grains['productname'] = t_productname
+                    break
 
     return grains
 

--- a/tests/unit/grains/os-releases/solaris-11.3
+++ b/tests/unit/grains/os-releases/solaris-11.3
@@ -1,0 +1,3 @@
+                            Oracle Solaris 11.3 SPARC
+  Copyright (c) 1983, 2017, Oracle and/or its affiliates.  All rights reserved.
+                            Assembled 05 October 2017

--- a/tests/unit/grains/solaris/prtconf.s7-zone
+++ b/tests/unit/grains/solaris/prtconf.s7-zone
@@ -1,0 +1,24 @@
+System Configuration:  Oracle Corporation  sun4v
+Memory size: 16384 Megabytes
+System Peripherals (PROM Nodes):
+
+Node 0xfffffffff
+    scsi-initiator-id:  00000007
+    idprom:  00000000.00000000.00000000.00000000.00000000.00000000.00000000.00000000
+    pcie-ari-supported:
+    #priqs-per-pcibus:  00000010
+    #priqs-per-cpu:  00000010
+    priq-eq-sizes:  00000003
+    non-ios-perf-counters:  'ORCL,sn-non-ios-pr'
+    ios-perf-counters:  'ORCL,sn-ios-pr'
+    storage-variant:  '8dbp'
+    product-name:  'SPARC S7-2'
+    banner-name:  'SPARC S7-2'
+    name:  'ORCL,SPARC-S7-2'
+    stick-frequency:  3b9aca00
+    hv-api-groups:  00000000.00000000.00000000.00000000.00000000.00000000.00000000.00000000.000000060.00000000.00000000
+    breakpoint-trap:  0000007f
+    device_type:  'sun4v'
+    compatible: 'sun4v'
+    #address-cells:  00000002
+    #size-cells:  00000002

--- a/tests/unit/grains/solaris/prtconf.t5220-zone
+++ b/tests/unit/grains/solaris/prtconf.t5220-zone
@@ -1,0 +1,16 @@
+System Configuration:  Oracle Corporation  sun4v
+Memory size: 8192 Megabytes
+System Peripherals (PROM Nodes):
+
+Node 0xffffffff
+    idprom:  11111111.11111111.00000000.11111111.00000000.00000000.00000000.00000000
+    scsi-initiator-id:  00000007
+    banner-name:  'SPARC Enterprise T5220'
+    name:  'SUNW,SPARC-Enterprise-T5220'
+    stick-frequency:  5458c3a0
+    hv-api-groups:  00000000.00000000.00000000.00000000.00000000.00000000.00000000.00000000
+    breakpoint-trap:  0000007f
+    device_type:  'sun4v'
+    compatible: 'sun4v'
+    #address-cells:  00000002
+    #size-cells:  00000002

--- a/tests/unit/grains/solaris/prtdiag.s7
+++ b/tests/unit/grains/solaris/prtdiag.s7
@@ -1,0 +1,24 @@
+System Configuration:  Oracle Corporation  sun4v SPARC S7-2
+Memory size: 16384 Megabytes
+
+================================ Virtual CPUs ================================
+
+
+CPU ID Frequency Implementation         Status
+------ --------- ---------------------- -------
+0      4267 MHz  SPARC-S7               on-line
+1      4267 MHz  SPARC-S7               on-line
+2      4267 MHz  SPARC-S7               on-line
+3      4267 MHz  SPARC-S7               on-line
+4      4267 MHz  SPARC-S7               on-line
+5      4267 MHz  SPARC-S7               on-line
+6      4267 MHz  SPARC-S7               on-line
+7      4267 MHz  SPARC-S7               on-line
+8      4267 MHz  SPARC-S7               on-line
+9      4267 MHz  SPARC-S7               on-line
+10     4267 MHz  SPARC-S7               on-line
+11     4267 MHz  SPARC-S7               on-line
+12     4267 MHz  SPARC-S7               on-line
+13     4267 MHz  SPARC-S7               on-line
+14     4267 MHz  SPARC-S7               on-line
+15     4267 MHz  SPARC-S7               on-line

--- a/tests/unit/grains/solaris/prtdiag.t5220
+++ b/tests/unit/grains/solaris/prtdiag.t5220
@@ -1,0 +1,16 @@
+System Configuration:  Oracle Corporation  sun4v SPARC Enterprise T5220
+Memory size: 8192 Megabytes
+
+================================ Virtual CPUs ================================
+
+
+CPU ID Frequency Implementation         Status
+------ --------- ---------------------- -------
+0      1415 MHz  SUNW,UltraSPARC-T2     on-line
+1      1415 MHz  SUNW,UltraSPARC-T2     on-line
+2      1415 MHz  SUNW,UltraSPARC-T2     on-line
+3      1415 MHz  SUNW,UltraSPARC-T2     on-line
+4      1415 MHz  SUNW,UltraSPARC-T2     on-line
+5      1415 MHz  SUNW,UltraSPARC-T2     on-line
+6      1415 MHz  SUNW,UltraSPARC-T2     on-line
+7      1415 MHz  SUNW,UltraSPARC-T2     on-line

--- a/tests/unit/grains/test_core.py
+++ b/tests/unit/grains/test_core.py
@@ -43,6 +43,7 @@ IP6_ADD_SCOPE = 'fe80::6238:e0ff:fe06:3f6b%enp2s0'
 OS_RELEASE_DIR = os.path.join(os.path.dirname(__file__), "os-releases")
 SOLARIS_DIR = os.path.join(os.path.dirname(__file__), 'solaris')
 
+
 @skipIf(NO_MOCK, NO_MOCK_REASON)
 class CoreGrainsTestCase(TestCase, LoaderModuleMockMixin):
     '''

--- a/tests/unit/grains/test_core.py
+++ b/tests/unit/grains/test_core.py
@@ -41,7 +41,7 @@ IP6_ADD1 = '2001:4860:4860::8844'
 IP6_ADD2 = '2001:4860:4860::8888'
 IP6_ADD_SCOPE = 'fe80::6238:e0ff:fe06:3f6b%enp2s0'
 OS_RELEASE_DIR = os.path.join(os.path.dirname(__file__), "os-releases")
-
+SOLARIS_DIR = os.path.join(os.path.dirname(__file__), 'solaris')
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
 class CoreGrainsTestCase(TestCase, LoaderModuleMockMixin):
@@ -714,3 +714,91 @@ PATCHLEVEL = 3
                     osdata = {'kernel': 'test', }
                     ret = core._virtual(osdata)
                     self.assertEqual(ret['virtual'], virt)
+
+    def test_solaris_sparc_s7zone(self):
+        '''
+        verify productname grain for s7 zone
+        '''
+        expectation = {
+                'productname': 'SPARC S7-2',
+                'prodct': 'SPARC S7-2',
+        }
+        with salt.utils.fopen(os.path.join(SOLARIS_DIR, 'prtconf.s7-zone')) as sparc_return_data:
+            this_sparc_return_data = sparc_return_data.readlines()
+            this_sparc_return_data += '\n'
+        _check_solaris_sparc_productname_grains(this_sparc_return_data, expectation)
+
+    def test_solaris_sparc_s7(self):
+        '''
+        verify productname grain for s7
+        '''
+        expectation = {
+                'productname': 'SPARC S7-2',
+                'prodct': 'SPARC S7-2',
+        }
+        with salt.utils.fopen(os.path.join(SOLARIS_DIR, 'prtdiag.s7')) as sparc_return_data:
+            this_sparc_return_data = sparc_return_data.readlines()
+            this_sparc_return_data += '\n'
+        _check_solaris_sparc_productname_grains(this_sparc_return_data, expectation)
+
+    def test_solaris_sparc_t5220(self):
+        '''
+        verify productname grain for t5220
+        '''
+        expectation = {
+                'productname': 'SPARC Enterprise T5220',
+                'prodct': 'SPARC Enterprise T5220',
+        }
+        with salt.utils.fopen(os.path.join(SOLARIS_DIR, 'prtdiag.t5220')) as sparc_return_data:
+            this_sparc_return_data = sparc_return_data.readlines()
+            this_sparc_return_data += '\n'
+        _check_solaris_sparc_productname_grains(this_sparc_return_data, expectation)
+
+    def test_solaris_sparc_t5220zone(self):
+        '''
+        verify productname grain for t5220 zone
+        '''
+        expectation = {
+                'productname': 'SPARC Enterprise T5220',
+                'prodct': 'SPARC Enterprise T5220',
+        }
+        with salt.utils.fopen(os.path.join(SOLARIS_DIR, 'prtdiag.t5220-zone')) as sparc_return_data:
+            this_sparc_return_data = sparc_return_data.readlines()
+            this_sparc_return_data += '\n'
+        _check_solaris_sparc_productname_grains(this_sparc_return_data, expectation)
+
+    def _check_solaris_sparc_productname_grains(self, prtdata, expectation):
+        '''
+        verify product grains on solaris sparc
+        '''
+        path_isfile_mock = MagicMock(side_effect=lambda x: x in ['/etc/release'])
+        with patch.object(platform, 'uname',
+                  MagicMock(return_value=('SunOS', 'testsystem', '5.11', '11.3', 'sunv4', 'sparc'))
+            with patch.object(salt.utils, 'is_proxy',
+                      MagicMock(return_value=False)):
+                with patch.object(salt.utils, 'is_linux',
+                          MagicMock(return_value=False)):
+                    with patch.object(salt.utils, 'is_windows',
+                              MagicMock(return_value=False)):
+                        with patch.object(salt.utils, 'is_smartos',
+                                  MagicMock(return_value=False)):
+                            with patch.object(os.path, 'isfile', path_isfile_mock):
+                                with salt.utils.fopen(os.path.join(OS_RELEASE_DIR, "solaris-11.3")) as os_release_file:
+                                    os_release_content = os_release_file.readlines()
+                                    with patch("salt.utils.fopen", mock_open()) as os_release_file:
+                                        os_release_file.return_value.__iter__.return_value = os_release_content
+                                        with patch.object(core, '_sunos_cpudata',
+                                                  MagicMock(return_value={'cpuarch':'sparcv9',
+                                                                          'num_cpus': '1',
+                                                                          'cpu_model': 'MOCK_CPU_MODEL',
+                                                                          'cpu_flags': []})
+                                            with patch.object(core, '_memdata',
+                                                      MagicMock(return_value={'mem_total': 16384})
+                                                with patch.object(salt.utils, 'which',
+                                                          MagicMock(return_value=True)):
+                                                    sparc_return_mock = MagicMock(return_value=prtdata)
+                                                    with patch.dict(core.__salt__, {'cmd.run': sparc_return_mock})
+                                                        os_grains = core.os_data()
+        grains = {k: v for k, v in os_grains.items()
+                  if k in set(['product', 'productname'])}
+        self.assertEqual(grains, expectation)

--- a/tests/unit/grains/test_core.py
+++ b/tests/unit/grains/test_core.py
@@ -721,12 +721,12 @@ PATCHLEVEL = 3
         '''
         expectation = {
                 'productname': 'SPARC S7-2',
-                'prodct': 'SPARC S7-2',
+                'product': 'SPARC S7-2',
         }
         with salt.utils.fopen(os.path.join(SOLARIS_DIR, 'prtconf.s7-zone')) as sparc_return_data:
-            this_sparc_return_data = sparc_return_data.readlines()
+            this_sparc_return_data = '\n'.join(sparc_return_data.readlines())
             this_sparc_return_data += '\n'
-        _check_solaris_sparc_productname_grains(this_sparc_return_data, expectation)
+        self._check_solaris_sparc_productname_grains(this_sparc_return_data, expectation)
 
     def test_solaris_sparc_s7(self):
         '''
@@ -734,12 +734,12 @@ PATCHLEVEL = 3
         '''
         expectation = {
                 'productname': 'SPARC S7-2',
-                'prodct': 'SPARC S7-2',
+                'product': 'SPARC S7-2',
         }
         with salt.utils.fopen(os.path.join(SOLARIS_DIR, 'prtdiag.s7')) as sparc_return_data:
-            this_sparc_return_data = sparc_return_data.readlines()
+            this_sparc_return_data = '\n'.join(sparc_return_data.readlines())
             this_sparc_return_data += '\n'
-        _check_solaris_sparc_productname_grains(this_sparc_return_data, expectation)
+        self._check_solaris_sparc_productname_grains(this_sparc_return_data, expectation)
 
     def test_solaris_sparc_t5220(self):
         '''
@@ -747,12 +747,12 @@ PATCHLEVEL = 3
         '''
         expectation = {
                 'productname': 'SPARC Enterprise T5220',
-                'prodct': 'SPARC Enterprise T5220',
+                'product': 'SPARC Enterprise T5220',
         }
         with salt.utils.fopen(os.path.join(SOLARIS_DIR, 'prtdiag.t5220')) as sparc_return_data:
-            this_sparc_return_data = sparc_return_data.readlines()
+            this_sparc_return_data = '\n'.join(sparc_return_data.readlines())
             this_sparc_return_data += '\n'
-        _check_solaris_sparc_productname_grains(this_sparc_return_data, expectation)
+        self._check_solaris_sparc_productname_grains(this_sparc_return_data, expectation)
 
     def test_solaris_sparc_t5220zone(self):
         '''
@@ -760,20 +760,21 @@ PATCHLEVEL = 3
         '''
         expectation = {
                 'productname': 'SPARC Enterprise T5220',
-                'prodct': 'SPARC Enterprise T5220',
+                'product': 'SPARC Enterprise T5220',
         }
-        with salt.utils.fopen(os.path.join(SOLARIS_DIR, 'prtdiag.t5220-zone')) as sparc_return_data:
-            this_sparc_return_data = sparc_return_data.readlines()
+        with salt.utils.fopen(os.path.join(SOLARIS_DIR, 'prtconf.t5220-zone')) as sparc_return_data:
+            this_sparc_return_data = '\n'.join(sparc_return_data.readlines())
             this_sparc_return_data += '\n'
-        _check_solaris_sparc_productname_grains(this_sparc_return_data, expectation)
+        self._check_solaris_sparc_productname_grains(this_sparc_return_data, expectation)
 
     def _check_solaris_sparc_productname_grains(self, prtdata, expectation):
         '''
         verify product grains on solaris sparc
         '''
+        import platform
         path_isfile_mock = MagicMock(side_effect=lambda x: x in ['/etc/release'])
         with patch.object(platform, 'uname',
-                  MagicMock(return_value=('SunOS', 'testsystem', '5.11', '11.3', 'sunv4', 'sparc')))
+                  MagicMock(return_value=('SunOS', 'testsystem', '5.11', '11.3', 'sunv4', 'sparc'))):
             with patch.object(salt.utils, 'is_proxy',
                       MagicMock(return_value=False)):
                 with patch.object(salt.utils, 'is_linux',
@@ -782,23 +783,31 @@ PATCHLEVEL = 3
                               MagicMock(return_value=False)):
                         with patch.object(salt.utils, 'is_smartos',
                                   MagicMock(return_value=False)):
-                            with patch.object(os.path, 'isfile', path_isfile_mock):
-                                with salt.utils.fopen(os.path.join(OS_RELEASE_DIR, "solaris-11.3")) as os_release_file:
-                                    os_release_content = os_release_file.readlines()
-                                    with patch("salt.utils.fopen", mock_open()) as os_release_file:
-                                        os_release_file.return_value.__iter__.return_value = os_release_content
-                                        with patch.object(core, '_sunos_cpudata',
-                                                  MagicMock(return_value={'cpuarch':'sparcv9',
-                                                                          'num_cpus': '1',
-                                                                          'cpu_model': 'MOCK_CPU_MODEL',
-                                                                          'cpu_flags': []})
-                                            with patch.object(core, '_memdata',
-                                                      MagicMock(return_value={'mem_total': 16384})
-                                                with patch.object(salt.utils, 'which',
-                                                          MagicMock(return_value=True)):
-                                                    sparc_return_mock = MagicMock(return_value=prtdata)
-                                                    with patch.dict(core.__salt__, {'cmd.run': sparc_return_mock})
-                                                        os_grains = core.os_data()
+                            with patch.object(salt.utils, 'which_bin',
+                                      MagicMock(return_value=None)):
+                                with patch.object(os.path, 'isfile', path_isfile_mock):
+                                    with salt.utils.fopen(os.path.join(OS_RELEASE_DIR, "solaris-11.3")) as os_release_file:
+                                        os_release_content = os_release_file.readlines()
+                                        with patch("salt.utils.fopen", mock_open()) as os_release_file:
+                                            os_release_file.return_value.__iter__.return_value = os_release_content
+                                            with patch.object(core, '_sunos_cpudata',
+                                                      MagicMock(return_value={'cpuarch':'sparcv9',
+                                                                              'num_cpus': '1',
+                                                                              'cpu_model': 'MOCK_CPU_MODEL',
+                                                                              'cpu_flags': []})):
+                                                with patch.object(core, '_memdata',
+                                                          MagicMock(return_value={'mem_total': 16384})):
+                                                    with patch.object(core, '_zpool_data',
+                                                              MagicMock(return_value={})):
+                                                        with patch.object(core, '_virtual',
+                                                                  MagicMock(return_value={})):
+                                                            with patch.object(core, '_ps',
+                                                                      MagicMock(return_value={})):
+                                                                with patch.object(salt.utils, 'which',
+                                                                          MagicMock(return_value=True)):
+                                                                    sparc_return_mock = MagicMock(return_value=prtdata)
+                                                                    with patch.dict(core.__salt__, {'cmd.run': sparc_return_mock}):
+                                                                        os_grains = core.os_data()
         grains = {k: v for k, v in os_grains.items()
                   if k in set(['product', 'productname'])}
         self.assertEqual(grains, expectation)

--- a/tests/unit/grains/test_core.py
+++ b/tests/unit/grains/test_core.py
@@ -792,7 +792,7 @@ PATCHLEVEL = 3
                                         with patch("salt.utils.fopen", mock_open()) as os_release_file:
                                             os_release_file.return_value.__iter__.return_value = os_release_content
                                             with patch.object(core, '_sunos_cpudata',
-                                                      MagicMock(return_value={'cpuarch':'sparcv9',
+                                                      MagicMock(return_value={'cpuarch': 'sparcv9',
                                                                               'num_cpus': '1',
                                                                               'cpu_model': 'MOCK_CPU_MODEL',
                                                                               'cpu_flags': []})):

--- a/tests/unit/grains/test_core.py
+++ b/tests/unit/grains/test_core.py
@@ -773,7 +773,7 @@ PATCHLEVEL = 3
         '''
         path_isfile_mock = MagicMock(side_effect=lambda x: x in ['/etc/release'])
         with patch.object(platform, 'uname',
-                  MagicMock(return_value=('SunOS', 'testsystem', '5.11', '11.3', 'sunv4', 'sparc'))
+                  MagicMock(return_value=('SunOS', 'testsystem', '5.11', '11.3', 'sunv4', 'sparc')))
             with patch.object(salt.utils, 'is_proxy',
                       MagicMock(return_value=False)):
                 with patch.object(salt.utils, 'is_linux',


### PR DESCRIPTION
### What does this PR do?
Updates the regexes for detecting the 'product' grain, additionally copies the data to 'productname' to be more consistent with other OSes.

### What issues does this PR fix or reference?
#47690 

### Previous Behavior
Only the 'product' grain is set and in certain circumstances has incorrect data.

### New Behavior
Both 'product' and 'productname' grians have data and accurate data should be displayed.

### Tests written?
Yes

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
