### PR TITLE
Default windows to m1.small for ec2-classic

### DIFF
--- a/tests/integration/files/conf/cloud.profiles.d/ec2.conf
+++ b/tests/integration/files/conf/cloud.profiles.d/ec2.conf
@@ -6,7 +6,7 @@ ec2-test:
   script_args: '-P -Z'
 ec2-win2012r2-test:
   provider: ec2-config
-  size: t2.micro
+  size: m1.small
   image: ami-eb1ecd96
   smb_port: 445
   win_installer: ''
@@ -20,7 +20,7 @@ ec2-win2012r2-test:
   deploy: True
 ec2-win2016-test:
   provider: ec2-config
-  size: t2.micro
+  size: m1.small
   image: ami-ed14c790
   smb_port: 445
   win_installer: ''


### PR DESCRIPTION
### What does this PR do?

Configure ec2 profile default instance type to `m1.small`, this is needed to launch the instance into ec2-classic.

### What issues does this PR fix or reference?

https://github.com/saltstack/salt-jenkins/issues/980

### Commits signed with GPG?

Yes