### PR TITLE
Bugfix: crash when master runs as non-root 

### DIFF
--- a/salt/returners/local_cache.py
+++ b/salt/returners/local_cache.py
@@ -444,7 +444,10 @@ def clean_old_jobs():
                     hours_difference = (time.time() - jid_ctime) / 3600.0
                     if hours_difference > __opts__['keep_jobs'] and os.path.exists(t_path):
                         # Remove the entire f_path from the original JID dir
-                        shutil.rmtree(f_path)
+                        try:
+                            shutil.rmtree(f_path)
+                        except OSError as err:
+                            log.error('Unable to remove %s: %s', t_path, err)
 
         # Remove empty JID dirs from job cache, if they're old enough.
         # JID dirs may be empty either from a previous cache-clean with the bug


### PR DESCRIPTION
### What does this PR do?

Bugfix.

### What issues does this PR fix or reference?

When master previously runs as root and then not as such, there are still some jobs in the cache that has `root/root` permissions. While this needs to be fixed on its own by `chown`, yet when this happens, non-root master crashes the returner process with `OSError`.

### Previous Behavior
Crash and traceback in the logs.

### New Behavior
Log message that permission denied to a particular path.

### Tests written?

No
