### PR TITLE
fix roots modification time check

### DIFF
--- a/salt/fileserver/roots.py
+++ b/salt/fileserver/roots.py
@@ -255,7 +255,7 @@ def file_hash(load, fnd):
                     except OSError:
                         pass
                     return file_hash(load, fnd)
-                if os.path.getmtime(path) == mtime:
+                if "{}".format(os.path.getmtime(path)) == mtime:
                     # check if mtime changed
                     ret['hsum'] = hsum
                     return ret

--- a/salt/fileserver/roots.py
+++ b/salt/fileserver/roots.py
@@ -255,7 +255,7 @@ def file_hash(load, fnd):
                     except OSError:
                         pass
                     return file_hash(load, fnd)
-                if os.path.getmtime(path) == mtime:
+                if str(os.path.getmtime(path)) == mtime:
                     # check if mtime changed
                     ret['hsum'] = hsum
                     return ret


### PR DESCRIPTION
### What does this PR do?
Fix cache modification time comparison. When converting the modification from os.path.getmtime to string, the number is stripped and the comparison is always false. the hash is recomputed everytime
### What issues does this PR fix or reference?

### Previous Behavior
hash was compute everytime like if the cache was not present
### New Behavior
cache is used

### Tests written?

No

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
