### PR TITLE
State pkg.latest called win pkg.install with list of pkgs and the required versions

### DIFF
--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -2449,15 +2449,14 @@ def latest(
                     'result': None,
                     'comment': '\n'.join(comments)}
 
-
         # No need to refresh, if a refresh was necessary it would have been
         # performed above when pkg.latest_version was run.
         try:
             if salt.utils.is_windows():
                 # pkg.install execution module on windows ensures the
                 # software package is installed when no version is
-                # specified, it does not upgrade the software to the 
-                # latest. This is per the design. 
+                # specified, it does not upgrade the software to the
+                # latest. This is per the design.
                 # Build updated list of pkgs *with verion number*, exclude
                 # non-targeted ones
                 targeted_pkgs = [{x: targets[x]} for x in targets.keys()]

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -2449,32 +2449,26 @@ def latest(
                     'result': None,
                     'comment': '\n'.join(comments)}
 
+        if salt.utils.is_windows():
+            # pkg.install execution module on windows ensures the software
+            # package is installed when no version is specified, it does not
+            # upgrade the software to the latest. This is per the design.
+            # Build updated list of pkgs *with verion number*, exclude
+            # non-targeted ones
+            targeted_pkgs = [{x: targets[x]} for x in targets.keys()]
+        else:
+            # Build updated list of pkgs to exclude non-targeted ones
+            targeted_pkgs = list(targets.keys()) if pkgs else None
+
         # No need to refresh, if a refresh was necessary it would have been
         # performed above when pkg.latest_version was run.
         try:
-            if salt.utils.is_windows():
-                # pkg.install execution module on windows ensures the
-                # software package is installed when no version is
-                # specified, it does not upgrade the software to the
-                # latest. This is per the design.
-                # Build updated list of pkgs *with verion number*, exclude
-                # non-targeted ones
-                targeted_pkgs = [{x: targets[x]} for x in targets.keys()]
-                changes = __salt__['pkg.install'](name=None,
-                                                  refresh=False,
-                                                  fromrepo=fromrepo,
-                                                  skip_verify=skip_verify,
-                                                  pkgs=targeted_pkgs,
-                                                  **kwargs)
-            else:
-                # Build updated list of pkgs to exclude non-targeted ones
-                targeted_pkgs = list(targets.keys()) if pkgs else None
-                changes = __salt__['pkg.install'](name,
-                                                  refresh=False,
-                                                  fromrepo=fromrepo,
-                                                  skip_verify=skip_verify,
-                                                  pkgs=targeted_pkgs,
-                                                  **kwargs)
+            changes = __salt__['pkg.install'](name=None,
+                                              refresh=False,
+                                              fromrepo=fromrepo,
+                                              skip_verify=skip_verify,
+                                              pkgs=targeted_pkgs,
+                                              **kwargs)
         except CommandExecutionError as exc:
             return {'name': name,
                     'changes': {},

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -2455,10 +2455,10 @@ def latest(
             # upgrade the software to the latest. This is per the design.
             # Build updated list of pkgs *with verion number*, exclude
             # non-targeted ones
-            targeted_pkgs = [{x: targets[x]} for x in targets.keys()]
+            targeted_pkgs = [{x: targets[x]} for x in targets]
         else:
             # Build updated list of pkgs to exclude non-targeted ones
-            targeted_pkgs = list(targets.keys()) if pkgs else None
+            targeted_pkgs = list(targets)
 
         # No need to refresh, if a refresh was necessary it would have been
         # performed above when pkg.latest_version was run.


### PR DESCRIPTION
### What does this PR do?
If the software is already installed windows pkg.install does not upgrade the software, as design.
However the state pkg.latest expected this behaviour.

The state pkg.latest determines already the software which needs to be updated and the version required. However does not use the version information.

This fix applied only to windows passes on this information (pkg + version) to pkg.installed.

### What issues does this PR fix or reference?
Windows: pkg.latest state not updating packages. (#47484)

### Previous Behavior
The state pkg.latest did not work unless the "Package Definition" used latest as the version number.

### New Behavior
Works with normal version number and "latest"

Given the way Windows pkg system works.  If pkg.latest is called and the current version of the software is not "Package Definition" the software may be downgraded to the latest version defined in the "Package Definition" 

### Tests written?
No New Tests

### Commits signed with GPG?
Yes
