### PR TITLE
Add cmd._run_all_quiet to mac_utils and __utils__ in mac_service

### DIFF
--- a/salt/modules/mac_service.py
+++ b/salt/modules/mac_service.py
@@ -157,13 +157,11 @@ def list_(name=None, runas=None):
         return launchctl('list',
                          label,
                          return_stdout=True,
-                         output_loglevel='trace',
                          runas=runas)
 
     # Collect information on all services: will raise an error if it fails
     return launchctl('list',
                      return_stdout=True,
-                     output_loglevel='trace',
                      runas=runas)
 
 

--- a/salt/modules/mac_service.py
+++ b/salt/modules/mac_service.py
@@ -14,7 +14,6 @@ import salt.utils.files
 import salt.utils.path
 import salt.utils.platform
 import salt.utils.stringutils
-import salt.utils.mac_utils
 from salt.exceptions import CommandExecutionError
 from salt.utils.versions import LooseVersion as _LooseVersion
 
@@ -62,7 +61,7 @@ def _get_service(name):
     :return: The service information for the service, otherwise an Error
     :rtype: dict
     '''
-    services = salt.utils.mac_utils.available_services()
+    services = __utils__['mac_utils.available_services']()
     name = name.lower()
 
     if name in services:
@@ -127,7 +126,7 @@ def launchctl(sub_cmd, *args, **kwargs):
 
         salt '*' service.launchctl debug org.cups.cupsd
     '''
-    return salt.utils.mac_utils.launchctl(sub_cmd, *args, **kwargs)
+    return __utils__['mac_utils.launchctl'](sub_cmd, *args, **kwargs)
 
 
 def list_(name=None, runas=None):
@@ -454,7 +453,7 @@ def get_all(runas=None):
     enabled = get_enabled(runas=runas)
 
     # Get list of all services
-    available = list(salt.utils.mac_utils.available_services().keys())
+    available = list(__utils__['mac_utils.available_services']().keys())
 
     # Return composite list
     return sorted(set(enabled + available))

--- a/salt/utils/mac_utils.py
+++ b/salt/utils/mac_utils.py
@@ -327,7 +327,6 @@ def _available_services():
                     # the system provided plutil program to do the conversion
                     cmd = '/usr/bin/plutil -convert xml1 -o - -- "{0}"'.format(
                         true_path)
-
                     plist_xml = __salt__['cmd.run'](cmd)
                     if six.PY2:
                         plist = plistlib.readPlistFromString(plist_xml)

--- a/salt/utils/mac_utils.py
+++ b/salt/utils/mac_utils.py
@@ -42,7 +42,6 @@ __salt__ = {
 }
 
 
-
 def __virtual__():
     '''
     Load only on Mac OS


### PR DESCRIPTION
### What does this PR do?
ensures `__salt__` is in the mac_utils `__utils__`.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/47705

### Previous Behavior

```
salt-call --local service.launchctl error bootstrap 64

Traceback (most recent call last):
  File "/testing/scripts/salt-call", line 11, in <module>
    salt_call()
  File "/testing/salt/scripts.py", line 400, in salt_call
    client.run()
  File "/testing/salt/cli/call.py", line 57, in run
    caller.run()
  File "/testing/salt/cli/caller.py", line 134, in run
    ret = self.call()
  File "/testing/salt/cli/caller.py", line 212, in call
    ret['return'] = func(*args, **kwargs)
  File "/testing/salt/modules/mac_service.py", line 130, in launchctl
    return salt.utils.mac_utils.launchctl(sub_cmd, *args, **kwargs)
  File "/testing/salt/utils/mac_utils.py", line 270, in launchctl
    ret = salt.modules.cmdmod.run_all(cmd, **kwargs)
  File "/testing/salt/modules/cmdmod.py", line 1834, in run_all
    **kwargs)
  File "/testing/salt/modules/cmdmod.py", line 357, in _run
    if not _check_avail(cmd):
  File "/testing/salt/modules/cmdmod.py", line 230, in _check_avail
    if __salt__['config.get']('cmd_blacklist_glob'):
NameError: global name '__salt__' is not defined
```

### New Behavior

```
Mac-66:testing root# salt-call --local service.launchctl error bootstrap 64
local:
    True
Mac-66:testing root# 
```

### Tests written?

Yes - this was found because the launchctl test `integration.modules.test_mac_service.MacServiceModuleTest.test_launchctl` was failing.