### PR TITLE
salt.loader: add error logging when whitelist lookup fails

### DIFF
--- a/salt/loader.py
+++ b/salt/loader.py
@@ -1629,7 +1629,11 @@ class LazyLoader(salt.utils.lazy.LazyDict):
                 return True
             # if the modulename isn't in the whitelist, don't bother
             if self.whitelist and mod_name not in self.whitelist:
-                raise KeyError
+                log.error(
+                    'Failed to load key %s because its module (%s) is not in '
+                    'the whitelist: %s', key, mod_name, self.whitelist
+                )
+                raise KeyError(key)
 
             def _inner_load(mod_name):
                 for name in self._iter_files(mod_name):

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -1630,8 +1630,8 @@ class LazyLoader(salt.utils.lazy.LazyDict):
             # if the modulename isn't in the whitelist, don't bother
             if self.whitelist and mod_name not in self.whitelist:
                 log.error(
-                    'Failed to load key %s because its module (%s) is not in '
-                    'the whitelist: %s', key, mod_name, self.whitelist
+                    'Failed to load function %s because its module (%s) is '
+                    'not in the whitelist: %s', key, mod_name, self.whitelist
                 )
                 raise KeyError(key)
 

--- a/tests/unit/modules/test_dockermod.py
+++ b/tests/unit/modules/test_dockermod.py
@@ -45,7 +45,7 @@ class DockerTestCase(TestCase, LoaderModuleMockMixin):
     def setup_loader_modules(self):
         utils = salt.loader.utils(
             salt.config.DEFAULT_MINION_OPTS,
-            whitelist=['args']
+            whitelist=['args', 'docker', 'json', 'state', 'thin']
         )
         return {docker_mod: {'__context__': {'docker.docker_version': ''},
                              '__utils__': utils}}

--- a/tests/unit/modules/test_dockermod.py
+++ b/tests/unit/modules/test_dockermod.py
@@ -45,11 +45,8 @@ class DockerTestCase(TestCase, LoaderModuleMockMixin):
     def setup_loader_modules(self):
         utils = salt.loader.utils(
             salt.config.DEFAULT_MINION_OPTS,
-            whitelist=['state']
+            whitelist=['args']
         )
-        # Force the LazyDict to populate its references. Otherwise the lookup
-        # will fail inside the unit tests.
-        list(utils)
         return {docker_mod: {'__context__': {'docker.docker_version': ''},
                              '__utils__': utils}}
 

--- a/tests/unit/states/test_boto_cloudfront.py
+++ b/tests/unit/states/test_boto_cloudfront.py
@@ -26,12 +26,9 @@ class BotoCloudfrontTestCase(TestCase, LoaderModuleMockMixin):
     def setup_loader_modules(self):
         utils = salt.loader.utils(
             self.opts,
-            whitelist=['boto3', 'dictdiffer', 'yamldumper'],
+            whitelist=['boto3', 'dictdiffer', 'yaml'],
             context={},
         )
-        # Force the LazyDict to populate its references. Otherwise the lookup
-        # will fail inside the unit tests.
-        list(utils)
         return {
             boto_cloudfront: {
                 '__utils__': utils,

--- a/tests/unit/states/test_boto_sqs.py
+++ b/tests/unit/states/test_boto_sqs.py
@@ -25,12 +25,9 @@ class BotoSqsTestCase(TestCase, LoaderModuleMockMixin):
     def setup_loader_modules(self):
         utils = salt.loader.utils(
             self.opts,
-            whitelist=['boto3', 'yamldumper'],
+            whitelist=['boto3', 'yaml'],
             context={}
         )
-        # Force the LazyDict to populate its references. Otherwise the lookup
-        # will fail inside the unit tests.
-        list(utils)
         return {
             boto_sqs: {
                 '__utils__': utils,


### PR DESCRIPTION
Rather than just raising a bare KeyError with no additional information, this raises a proper KeyError with the key that failed to be looked up. It also logs the key that failed to load, as well as the whitelist, to aid in troubleshooting.

Additionally, this resolves failed lazydict lookups in the tests due to improperly-set whitelists.