### PR TITLE
add docker proxy minion

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -170,6 +170,7 @@ additional-builtins=__opts__,
   __proxy__,
   __serializers__,
   __reg__,
+  __executors__,
   __events__
 
 # List of strings which can identify a callback function by name. A callback

--- a/.testing.pylintrc
+++ b/.testing.pylintrc
@@ -267,6 +267,7 @@ additional-builtins=__opts__,
   __proxy__,
   __serializers__,
   __reg__,
+  __executors__,
   __events__
 
 

--- a/doc/ref/executors/all/index.rst
+++ b/doc/ref/executors/all/index.rst
@@ -11,5 +11,6 @@ executors modules
     :template: autosummary.rst.tmpl
 
     direct_call
+    docker
     splay
     sudo

--- a/doc/ref/executors/all/salt.executors.docker.rst
+++ b/doc/ref/executors/all/salt.executors.docker.rst
@@ -1,0 +1,6 @@
+salt.executors.docker module
+============================
+
+.. automodule:: salt.executors.docker
+    :members:
+

--- a/doc/ref/executors/index.rst
+++ b/doc/ref/executors/index.rst
@@ -83,3 +83,7 @@ option set by commandline or API ``data.get('executor_opts',
 {}).get('splaytime')`` should be used. So if an option is safe and must be
 accessible by user executor should check it in both places, but if an option is
 unsafe it should be read from the only config ignoring the passed request data.
+
+There is also a function named ``all_missing_func`` which the name of the
+``func`` is passed, which can be used to verify if the command should still be
+run, even if it is not loaded in minion_mods.

--- a/doc/topics/releases/fluorine.rst
+++ b/doc/topics/releases/fluorine.rst
@@ -4,6 +4,24 @@
 Salt Release Notes - Codename Fluorine
 ======================================
 
+New Docker Proxy Minion
+-----------------------
+
+Docker containers can now be treated as actual minions without installing salt
+in the container, using the new :py:mod:`docker proxy minion <salt.proxy.docker>`.
+
+This proxy minion uses the :py:mod:`docker executor <salt.executors.docker>` to
+pass commands to the docker container using :py:func:`docker.call
+<salt.modules.dockermod.call>`.  Any state module calls are passed through the
+corresponding function from the :py:mod:`docker <salt.modules.dockermod>`
+module.
+
+.. code-block:: yaml
+
+    proxy:
+      proxytype: docker
+      name: keen_proskuriakova
+
 
 Grains Dictionary Passed into Custom Grains
 -------------------------------------------

--- a/salt/executors/docker.py
+++ b/salt/executors/docker.py
@@ -9,6 +9,7 @@ Used with the docker proxy minion.
 from __future__ import absolute_import, unicode_literals
 
 
+__virtualname__ = 'docker'
 DOCKER_MOD_MAP = {
     'state.sls': 'docker.sls',
     'state.apply': 'docker.apply',
@@ -33,3 +34,7 @@ def execute(opts, data, func, args, kwargs):
     if data['fun'] in DOCKER_MOD_MAP:
         return __executors__['direct_call.execute'](opts, data, __salt__[DOCKER_MOD_MAP[data['fun']]], [opts['proxy']['name']] + args, kwargs)
     return __salt__['docker.call'](opts['proxy']['name'], data['fun'], *args, **kwargs)
+
+
+def allow_missing_funcs():
+    return True

--- a/salt/executors/docker.py
+++ b/salt/executors/docker.py
@@ -16,6 +16,14 @@ DOCKER_MOD_MAP = {
 }
 
 
+def __virtual__():
+    if 'proxy' not in __opts__:
+        return False, 'Docker executor is only meant to be used with Docker Proxy Minions'
+    if __opts__.get('proxy', {}).get('proxytype') != __virtualname__:
+        return False, 'Proxytype does not match: {0}'.format(__virtualname__)
+    return True
+
+
 def execute(opts, data, func, args, kwargs):
     '''
     Directly calls the given function with arguments
@@ -25,7 +33,3 @@ def execute(opts, data, func, args, kwargs):
     if data['fun'] in DOCKER_MOD_MAP:
         return __executors__['direct_call.execute'](opts, data, __salt__[DOCKER_MOD_MAP[data['fun']]], [opts['proxy']['name']] + args, kwargs)
     return __salt__['docker.call'](opts['proxy']['name'], data['fun'], *args, **kwargs)
-
-
-def allow_missing_funcs():
-    return True

--- a/salt/executors/docker.py
+++ b/salt/executors/docker.py
@@ -36,5 +36,11 @@ def execute(opts, data, func, args, kwargs):
     return __salt__['docker.call'](opts['proxy']['name'], data['fun'], *args, **kwargs)
 
 
-def allow_missing_funcs():
+def allow_missing_func(function):  # pylint: disable=unused-argument
+    '''
+    Allow all calls to be passed through to docker container.
+
+    The docker call will use direct_call, which will return back if the module
+    was unable to be run.
+    '''
     return True

--- a/salt/executors/docker.py
+++ b/salt/executors/docker.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+'''
+Docker executor module
+
+.. versionadded: Fluorine
+
+Used with the docker proxy minion.
+'''
+from __future__ import absolute_import, unicode_literals
+
+
+DOCKER_MOD_MAP = {
+    'state.sls': 'docker.sls',
+    'state.apply': 'docker.apply',
+    'state.highstate': 'docker.highstate',
+}
+
+
+def execute(opts, data, func, args, kwargs):
+    '''
+    Directly calls the given function with arguments
+    '''
+    if data['fun'] == 'saltutil.find_job':
+        return __executors__['direct_call.execute'](opts, data, func, args, kwargs)
+    if data['fun'] in DOCKER_MOD_MAP:
+        return __executors__['direct_call.execute'](opts, data, __salt__[DOCKER_MOD_MAP[data['fun']]], [opts['proxy']['name']] + args, kwargs)
+    return __salt__['docker.call'](opts['proxy']['name'], data['fun'], *args, **kwargs)
+
+
+def allow_missing_funcs():
+    return True

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -971,12 +971,14 @@ def executors(opts, functions=None, context=None, proxy=None):
     '''
     Returns the executor modules
     '''
-    return LazyLoader(
+    executors = LazyLoader(
         _module_dirs(opts, 'executors', 'executor'),
         opts,
         tag='executor',
         pack={'__salt__': functions, '__context__': context or {}, '__proxy__': proxy or {}},
     )
+    executors.pack['__executors__'] = executors
+    return executors
 
 
 def cache(opts, serial):

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1569,9 +1569,9 @@ class Minion(MinionBase):
                     getattr(minion_instance, 'module_executors', []) or \
                     opts.get('module_executors', ['direct_call'])
         allow_missing_funcs = any([
-            minion_instance.executors['{0}.allow_missing_funcs'.format(executor)]()
+            minion_instance.executors['{0}.allow_missing_func'.format(executor)](function_name)
             for executor in executors
-            if '{0}.allow_missing_funcs' in minion_instance.executors
+            if '{0}.allow_missing_func' in minion_instance.executors
         ])
         if function_name in minion_instance.functions or allow_missing_funcs is True:
             try:

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1565,7 +1565,15 @@ class Minion(MinionBase):
             fp_.write(minion_instance.serial.dumps(sdata))
         ret = {'success': False}
         function_name = data['fun']
-        if function_name in minion_instance.functions:
+        executors = data.get('module_executors') or \
+                    getattr(minion_instance, 'module_executors', []) or \
+                    opts.get('module_executors', ['direct_call'])
+        allow_missing_funcs = any([
+            minion_instance.executors['{0}.allow_missing_funcs'.format(executor)]()
+            for executor in executors
+            if '{0}.allow_missing_funcs' in minion_instance.executors
+        ])
+        if function_name in minion_instance.functions or allow_missing_funcs is True:
             try:
                 minion_blackout_violation = False
                 if minion_instance.connected and minion_instance.opts['pillar'].get('minion_blackout', False):
@@ -1583,15 +1591,17 @@ class Minion(MinionBase):
                                              'to False in pillar or grains to resume operations. Only '
                                              'saltutil.refresh_pillar allowed in blackout mode.')
 
-                func = minion_instance.functions[function_name]
-                args, kwargs = load_args_and_kwargs(
-                    func,
-                    data['arg'],
-                    data)
+                if function_name in minion_instance.functions:
+                    func = minion_instance.functions[function_name]
+                    args, kwargs = load_args_and_kwargs(
+                        func,
+                        data['arg'],
+                        data)
+                else:
+                    # only run if function_name is not in minion_instance.functions and allow_missing_funcs is True
+                    func = function_name
+                    args, kwargs = data['arg'], data
                 minion_instance.functions.pack['__context__']['retcode'] = 0
-                executors = data.get('module_executors') or \
-                            getattr(minion_instance, 'module_executors', []) or \
-                            opts.get('module_executors', ['direct_call'])
                 if isinstance(executors, six.string_types):
                     executors = [executors]
                 elif not isinstance(executors, list) or not executors:

--- a/salt/modules/dockermod.py
+++ b/salt/modules/dockermod.py
@@ -275,7 +275,7 @@ __virtual_aliases__ = ('dockerng', 'moby')
 __proxyenabled__ = ['docker']
 __outputter__ = {
     'sls': 'highstate',
-    'apply': 'highstate',
+    'apply_': 'highstate',
     'highstate': 'highstate',
 }
 

--- a/salt/modules/dockermod.py
+++ b/salt/modules/dockermod.py
@@ -201,6 +201,7 @@ import pipes
 import re
 import shutil
 import string
+import sys
 import time
 import uuid
 import subprocess
@@ -6669,7 +6670,7 @@ def call(name, function, *args, **kwargs):
 
     try:
         salt_argv = [
-            'python',
+            'python{0}'.format(sys.version_info[0]),
             os.path.join(thin_dest_path, 'salt-call'),
             '--metadata',
             '--local',

--- a/salt/proxy/docker.py
+++ b/salt/proxy/docker.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+'''
+Docker Proxy Minion
+
+.. versionadded: Fluorine
+
+:depends: docker
+
+This proxy minion is just a shim to the docker executor, which will use the
+:py:func:`docker.call <salt.modules.dockermod.call>` for everything except
+state runs.
+
+
+To configure the proxy minion:
+
+.. code-block:: yaml
+
+    proxy:
+      proxytype: docker
+      name: festive_leakey
+
+It is also possible to just name the proxy minion the same name as the
+container, and use grains to configure the proxy minion:
+
+.. code-block:: yaml
+
+    proxy:
+        proxytype: docker
+        name: {{grains['id']}}
+
+name
+
+    Name of the docker container
+'''
+from __future__ import absolute_import, unicode_literals
+
+__proxyenabled__ = ['docker']
+__virtualname__ = 'docker'
+
+
+def __virtual__():
+    if __opts__.get('proxy', {}).get('proxytype') != __virtualname__:
+        return False, 'Proxytype does not match: {0}'.format(__virtualname__)
+    return True
+
+
+def module_executors():
+    '''
+    List of module executors to use for this Proxy Minion
+    '''
+    return ['docker', ]
+
+
+def init(opts):
+    '''
+    Always initialize
+    '''
+    __context__['initialized'] = True
+
+
+def initialized():
+    '''
+    This should always be initialized
+    '''
+    return __context__.get('initialized', False)
+
+
+def shutdown(opts):
+    '''
+    Nothing needs to be done to shutdown
+    '''
+    __context__['initialized'] = False

--- a/tests/integration/files/file/base/core.sls
+++ b/tests/integration/files/file/base/core.sls
@@ -2,3 +2,4 @@
   file:
     - managed
     - source: salt://testfile
+    - makedirs: true

--- a/tests/integration/files/file/base/docker_non_root/Dockerfile
+++ b/tests/integration/files/file/base/docker_non_root/Dockerfile
@@ -1,4 +1,4 @@
-FROM opensuse/python:latest
+FROM centos:latest
 
 RUN useradd -m daniel
 USER daniel

--- a/tests/integration/files/file/prod/docker_test.sls
+++ b/tests/integration/files/file/prod/docker_test.sls
@@ -1,0 +1,2 @@
+/tmp/test.txt:
+  file.touch

--- a/tests/integration/files/file/prod/docker_test.sls
+++ b/tests/integration/files/file/prod/docker_test.sls
@@ -1,2 +1,0 @@
-/tmp/test.txt:
-  file.touch

--- a/tests/integration/modules/test_dockermod.py
+++ b/tests/integration/modules/test_dockermod.py
@@ -43,7 +43,7 @@ def with_random_name(func):
 
 
 @destructiveTest
-@skipIf(not salt.utils.path.which('dockerd'), 'Docker not installed')
+@skipIf(not salt.utils.path.which('docker'), 'Docker not installed')
 class DockerCallTestCase(ModuleCase, SaltReturnAssertsMixin):
     '''
     Test docker_container states
@@ -86,3 +86,10 @@ class DockerCallTestCase(ModuleCase, SaltReturnAssertsMixin):
         '''
         ret = self.run_function('docker.call', [self.random_name, 'test.ping'])
         self.assertTrue(ret)
+
+    def test_docker_highstate(self):
+        '''
+        check that docker.highstate works, and works with a container not running as root
+        '''
+        ret = self.run_function('docker.call', [self.random_name, 'state.apply', 'prod'])
+        self.assertSaltTrueReturn({'test': ret})

--- a/tests/integration/modules/test_dockermod.py
+++ b/tests/integration/modules/test_dockermod.py
@@ -43,7 +43,7 @@ def with_random_name(func):
 
 
 @destructiveTest
-@skipIf(not salt.utils.path.which('docker'), 'Docker not installed')
+@skipIf(not salt.utils.path.which('dockerd'), 'Docker not installed')
 class DockerCallTestCase(ModuleCase, SaltReturnAssertsMixin):
     '''
     Test docker_container states
@@ -62,6 +62,7 @@ class DockerCallTestCase(ModuleCase, SaltReturnAssertsMixin):
                        name='{0}/Dockerfile'.format(self.tmp_build_dir))
         self.run_state('docker_image.present',
                        build=self.tmp_build_dir,
+                       tag='latest',
                        name=self.random_name)
         self.run_state('docker_container.running',
                        name=self.random_name,
@@ -85,11 +86,18 @@ class DockerCallTestCase(ModuleCase, SaltReturnAssertsMixin):
         check that docker.call works, and works with a container not running as root
         '''
         ret = self.run_function('docker.call', [self.random_name, 'test.ping'])
-        self.assertTrue(ret)
+        assert ret is True
+
+    def test_docker_sls(self):
+        '''
+        check that docker.sls works, and works with a container not running as root
+        '''
+        ret = self.run_function('docker.apply', [self.random_name, 'core'])
+        self.assertSaltTrueReturn(ret)
 
     def test_docker_highstate(self):
         '''
         check that docker.highstate works, and works with a container not running as root
         '''
-        ret = self.run_function('docker.call', [self.random_name, 'state.apply', 'prod'])
-        self.assertSaltTrueReturn({'test': ret})
+        ret = self.run_function('docker.apply', [self.random_name])
+        self.assertSaltTrueReturn(ret)

--- a/tests/integration/modules/test_dockermod.py
+++ b/tests/integration/modules/test_dockermod.py
@@ -8,12 +8,11 @@ from __future__ import absolute_import, print_function, unicode_literals
 import functools
 import random
 import string
-import tempfile
+import sys
 
 # Import Salt Testing Libs
 from tests.support.unit import skipIf
 from tests.support.case import ModuleCase
-from tests.support.paths import TMP
 from tests.support.helpers import destructiveTest
 from tests.support.mixins import SaltReturnAssertsMixin
 
@@ -55,31 +54,28 @@ class DockerCallTestCase(ModuleCase, SaltReturnAssertsMixin):
         '''
         # Create temp dir
         self.random_name = name
-        self.tmp_build_dir = tempfile.mkdtemp(dir=TMP)
+        self.image_tag = sys.version_info[0]
 
-        self.run_state('file.managed',
-                       source='salt://docker_non_root/Dockerfile',
-                       name='{0}/Dockerfile'.format(self.tmp_build_dir))
         self.run_state('docker_image.present',
-                       build=self.tmp_build_dir,
-                       tag='latest',
-                       name=self.random_name)
+                       tag=self.image_tag,
+                       name='python')
         self.run_state('docker_container.running',
                        name=self.random_name,
-                       image=self.random_name)
+                       image='python:{0}'.format(self.image_tag),
+                       entrypoint='tail -f /dev/null')
 
     def tearDown(self):
         '''
         teardown docker.call tests
         '''
-        self.run_state('file.absent',
-                       name=self.tmp_build_dir)
         self.run_state('docker_container.absent',
                        name=self.random_name,
                        force=True)
         self.run_state('docker_image.absent',
-                       images=[self.random_name, 'docker.io/opensuse/python:latest'],
+                       images=['python:{0}'.format(self.image_tag)],
                        force=True)
+        delattr(self, 'random_name')
+        delattr(self, 'image_tag')
 
     def test_docker_call(self):
         '''


### PR DESCRIPTION
### What does this PR do?
This proxy minion + executor combo allows for using the docker.call module to run salt modules inside of docker containers.

This also adds the ability to run a highstate on the docker container.

### Tests written?

Yes

### Commits signed with GPG?

Yes