### PR TITLE
2 master_tops/ext_nodes fixes

### DIFF
--- a/salt/fileclient.py
+++ b/salt/fileclient.py
@@ -1391,14 +1391,12 @@ class RemoteClient(Client):
         '''
         Return the metadata derived from the master_tops system
         '''
-        salt.utils.versions.warn_until(
-            'Magnesium',
-            'The _ext_nodes master function has '
-            'been renamed to _master_tops. To ensure '
-            'compatibility when using older Salt masters '
-            'we continue to pass the function as _ext_nodes.'
+        log.debug(
+            'The _ext_nodes master function has been renamed to _master_tops. '
+            'To ensure compatibility when using older Salt masters we will '
+            'continue to invoke the function as _ext_nodes until the '
+            'Magnesium release.'
         )
-
         # TODO: Change back to _master_tops
         # for Magnesium release
         load = {'cmd': '_ext_nodes',

--- a/salt/fileserver/__init__.py
+++ b/salt/fileserver/__init__.py
@@ -850,7 +850,8 @@ class FSChan(object):
                 self.opts['__fs_update'] = True
         else:
             self.fs.update()
-        self.cmd_stub = {'master_tops': {}}
+        self.cmd_stub = {'master_tops': {},
+                         'ext_nodes': {}}
 
     def send(self, load, tries=None, timeout=None, raw=False):  # pylint: disable=unused-argument
         '''


### PR DESCRIPTION
1. Fix spurious "Malformed request" error in masterless salt-call

   Since we are invoking `_ext_nodes` now for backward compatibility, an entry for it needed to be added to the cmd_stub.

2. Change deprecation warning to debug logging

   This prevents a confusing warning from being logged to the console for salt-call (and to the log file upon each salt-minion daemon restart).

    It seems that the intent of the deprecation warning was to use the logic in `warn_until` to force us to make the final deprecation when the Magnesium release cycle arrives, but when we do these sort of deprecations we are typically pro-active and do a grep on the release codename. So, keeping "Magnesium" in the log message should be sufficient to remind us of this.

CC: @garethgreenaway