### PR TITLE
Fix salt.utils.versions.warn_until spelling

### DIFF
--- a/salt/modules/kubernetes.py
+++ b/salt/modules/kubernetes.py
@@ -35,7 +35,7 @@ In case both are provided the `file` entry is preferred.
 
 .. warning::
 
-    Configuration options will change in Flourine. All options above will be replaced by:
+    Configuration options will change in Fluorine. All options above will be replaced by:
 
     - kubernetes.kubeconfig or kubernetes.kubeconfig-data
     - kubernetes.context

--- a/salt/modules/pip.py
+++ b/salt/modules/pip.py
@@ -630,7 +630,7 @@ def install(pkgs=None,  # pylint: disable=R0912,R0913,R0914
     '''
     if 'no_chown' in kwargs:
         salt.utils.versions.warn_until(
-            'Flourine',
+            'Fluorine',
             'The no_chown argument has been deprecated and is no longer used. '
             'Its functionality was removed in Boron.')
         kwargs.pop('no_chown')

--- a/salt/states/kubernetes.py
+++ b/salt/states/kubernetes.py
@@ -8,7 +8,7 @@ salt.modules.kubernetes for more information.
 
 .. warning::
 
-    Configuration options will change in Flourine.
+    Configuration options will change in Fluorine.
 
 The kubernetes module is used to manage different kubernetes resources.
 

--- a/salt/states/pip_state.py
+++ b/salt/states/pip_state.py
@@ -586,7 +586,7 @@ def installed(name,
     '''
     if 'no_chown' in kwargs:
         salt.utils.versions.warn_until(
-            'Flourine',
+            'Fluorine',
             'The no_chown argument has been deprecated and is no longer used. '
             'Its functionality was removed in Boron.')
         kwargs.pop('no_chown')

--- a/salt/states/virtualenv_mod.py
+++ b/salt/states/virtualenv_mod.py
@@ -137,7 +137,7 @@ def managed(name,
     '''
     if 'no_chown' in kwargs:
         salt.utils.versions.warn_until(
-            'Flourine',
+            'Fluorine',
             'The no_chown argument has been deprecated and is no longer used. '
             'Its functionality was removed in Boron.')
         kwargs.pop('no_chown')

--- a/salt/states/win_servermanager.py
+++ b/salt/states/win_servermanager.py
@@ -115,10 +115,10 @@ def installed(name,
     '''
     if 'force' in kwargs:
         salt.utils.versions.warn_until(
-            'Flourine',
+            'Fluorine',
             'Parameter \'force\' has been detected in the argument list. This'
             'parameter is no longer used and has been replaced by \'recurse\''
-            'as of Salt 2018.3.0. This warning will be removed in Salt Flourine.'
+            'as of Salt 2018.3.0. This warning will be removed in Salt Fluorine.'
         )
         kwargs.pop('force')
 

--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -2733,9 +2733,9 @@ def cache_nodes_ip(opts, base=None):
     addresses. Returns a dict.
     '''
     salt.utils.versions.warn_until(
-        'Flourine',
+        'Fluorine',
         'This function is incomplete and non-functional '
-        'and will be removed in Salt Flourine.'
+        'and will be removed in Salt Fluorine.'
     )
     if base is None:
         base = opts['cachedir']


### PR DESCRIPTION
### What does this PR do?
Fixes salt.utils.versions.warn_util spellings and adds a test that checks to make sure the spellings are correct for these calls going forward. 

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/47715

