### PR TITLE
fix cli example to match function name

### DIFF
--- a/salt/modules/win_system.py
+++ b/salt/modules/win_system.py
@@ -510,7 +510,7 @@ def get_system_info():
 
     .. code-block:: bash
 
-        salt 'minion-id' system.get_info
+        salt 'minion-id' system.get_system_info
     '''
     os_type = {1: 'Work Station',
                2: 'Domain Controller',


### PR DESCRIPTION
### What does this PR do?
Fixes cli example to use the actual function name.
