### PR TITLE
feat: read Salt-Cloud Maps from the Pillar

### DIFF
--- a/doc/topics/cloud/config.rst
+++ b/doc/topics/cloud/config.rst
@@ -173,8 +173,8 @@ Pillar Configuration
 ====================
 
 It is possible to configure cloud providers using pillars. This is only used when inside the cloud
-module. You can setup a variable called ``cloud`` that contains your profile and provider to pass
-that information to the cloud servers instead of having to copy the full configuration to every
+module. You can setup a variable called ``cloud`` that contains your profile, provider, and map to
+pass that information to the cloud servers instead of having to copy the full configuration to every
 minion. In your pillar file, you would use something like this:
 
 .. code-block:: yaml
@@ -197,6 +197,26 @@ minion. In your pillar file, you would use something like this:
           size: ds512M
           image: CentOS 7
           script_args: git develop
+
+      maps:
+        my-dev-map:
+          ubuntu-openstack:
+            - dev-test01
+            - dev-test02
+            - dev-test03
+            - dev-test04
+        my-prd-map:
+          ubuntu-openstack:
+            - prd-web01
+            - prd-web02
+                minion:
+                  id: custom-minion-id-app1-stack1-frontend
+                grains:
+                  roles:
+                    - webserver
+                  deployment: datacenter4-openstack
+            - prod-db01
+            - prod-db02
 
 
 Cloud Configurations
@@ -345,7 +365,7 @@ OpenStack
 ---------
 
 Using Salt for OpenStack uses the `shade <https://docs.openstack.org/shade/latest/>` driver managed by the
-openstack-infra team.  
+openstack-infra team.
 
 This driver can be configured using the ``/etc/openstack/clouds.yml`` file with
 `os-client-config <https://docs.openstack.org/os-client-config/latest/>`

--- a/doc/topics/cloud/map.rst
+++ b/doc/topics/cloud/map.rst
@@ -88,9 +88,9 @@ Any top level data element from your profile may be overridden in the map file:
 
     fedora_small:
       - web1:
-        size: t2.micro
+          size: t2.micro
       - web2:
-        size: t2.nano
+          size: t2.nano
 
 As of Salt 2017.7.0, nested elements are merged, and can can be specified
 individually without having to repeat the complete definition for each top

--- a/salt/modules/cloud.py
+++ b/salt/modules/cloud.py
@@ -204,11 +204,21 @@ def map_run(path=None, **kwargs):
     '''
     Execute a salt cloud map file
 
+    Cloud Map data can be retrieved from several sources:
+      - a local file (provide the path to the file to the 'path' argument)
+      - a JSON-formatted map directly (provide the appropriately formatted to using the 'map_data' argument)
+      - the Salt Pillar (provide the map name of under 'pillar:cloud:maps' to the 'map_pillar' argument)
+      Note: Only one of these sources can be read at a time. The options are listed in their order of precedence.
+
+
     CLI Examples:
 
     .. code-block:: bash
 
         salt minionname cloud.map_run /path/to/cloud.map
+        salt minionname cloud.map_run path=/path/to/cloud.map
+        salt minionname cloud.map_run map_pillar='<map_pillar>'
+          .. versionchanged:: 2018.3.1
         salt minionname cloud.map_run map_data='<actual map data>'
     '''
     client = _get_client()


### PR DESCRIPTION
### What does this PR do?
Enable use of cloud map data sourced from the Pillar.
Uses the map data found in the pillar at `cloud:maps:` + the key-name provided with `map_pillar` argument.

Example
```bash
salt-call cloud.map_run map_pillar=my-prd-map
```

Where
```yaml
cloud:
  maps:
    my-prd-map:
      named-profile-01:
        - named-instance-01
        - named-instance-02
```

To preserve backwards compatibility the `map_pillar` option is ignored in the presence of either `map_data` or `path` arguments.

The implementation is in two parts: (1) add maps data from the pillar at `CloudClient.__init__()`  (alongside the existing similarly loaded `profiles` and `providers` info), and (2) allow for selecting and reading from this data in `Map.read()`, which is the function that map data is sourced from.

### What issues does this PR fix or reference?
#40975 

### Previous Behavior
Allow loading map data from a file or from a JSON data structure via CLI.

### New Behavior
Add a pillar-based option to the existing map data.
 
### Tests written?
No so far, but what sort of tests should this have?

### Commits signed with GPG?
No
