### PR TITLE
Fix "dnf list upgrades" parsing

### DIFF
--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -85,6 +85,7 @@ def _strip_headers(output, *args):
     if not args:
         args_lc = ('installed packages',
                    'available packages',
+                   'available upgrades',
                    'updated packages',
                    'upgraded packages')
     else:


### PR DESCRIPTION
The header for the output of this command appears to have changed at some point, which breaks our output parsing. This adds the new header to the `_strip_headers()` helper so that we ignore it while parsing.

Fixes #47717.