### PR TITLE
Allow value 0(zero) for updatables in ResourceRecordSet.

### DIFF
--- a/salt/states/boto3_route53.py
+++ b/salt/states/boto3_route53.py
@@ -702,7 +702,10 @@ def rr_present(name, HostedZoneId=None, DomainName=None, PrivateZone=False, Name
         if ResourceRecords:
             ResourceRecordSet['ResourceRecords'] = ResourceRecords
         for u in updatable:
-            ResourceRecordSet.update({u: locals().get(u)}) if locals().get(u) else None
+            if locals().get(u) or (locals().get(u) == 0):
+                ResourceRecordSet.update({u: locals().get(u)})
+            else:
+                log.debug('Not updating ResourceRecordSet with local value: %s', locals().get(u))
 
         ChangeBatch = {
             'Changes': [


### PR DESCRIPTION
### What does this PR do?
Allow value 0(zero) for updatables in ResourceRecordSet.

### What issues does this PR fix or reference?
Fixes #47693 

### Previous Behavior
Python treats zero as false:
  https://docs.python.org/2/library/stdtypes.html#truth-value-testing

False causes the updatable to be omitted from the API request, which causes AWS API
errors in some cases (e.g. defining Weight: 0).

### New Behavior
Successfully updates with values of zero in the ResourceRecordSet.

### Tests written?
No

### Commits signed with GPG?
Yes