### PR TITLE
Add stderr launchctl helper class and fix service mac tests

### DIFF
--- a/salt/utils/mac_utils.py
+++ b/salt/utils/mac_utils.py
@@ -119,6 +119,18 @@ def _run_all(cmd):
     return ret
 
 
+def _check_launchctl_stderr(ret):
+    '''
+    helper class to check the launchctl stderr.
+    launchctl does not always return bad exit code
+    if there is a failure
+    '''
+    err = ret['stderr'].lower()
+    if 'service is disabled' in err:
+        return True
+    return False
+
+
 def execute_return_success(cmd):
     '''
     Executes the passed command. Returns True if successful
@@ -274,9 +286,10 @@ def launchctl(sub_cmd, *args, **kwargs):
     kwargs['python_shell'] = False
     kwargs = salt.utils.args.clean_kwargs(**kwargs)
     ret = __salt__['cmd.run_all'](cmd, **kwargs)
+    error = _check_launchctl_stderr(ret)
 
     # Raise an error or return successful result
-    if ret['retcode']:
+    if ret['retcode'] or error:
         out = 'Failed to {0} service:\n'.format(sub_cmd)
         out += 'stdout: {0}\n'.format(ret['stdout'])
         out += 'stderr: {0}\n'.format(ret['stderr'])

--- a/tests/integration/modules/test_mac_service.py
+++ b/tests/integration/modules/test_mac_service.py
@@ -40,8 +40,10 @@ class MacServiceModuleTest(ModuleCase):
         '''
         if self.SERVICE_ENABLED:
             self.run_function('service.start', [self.SERVICE_NAME])
+            self.run_function('service.enable', [self.SERVICE_NAME])
         else:
             self.run_function('service.stop', [self.SERVICE_NAME])
+            self.run_function('service.disable', [self.SERVICE_NAME])
 
     def test_show(self):
         '''

--- a/tests/integration/states/test_service.py
+++ b/tests/integration/states/test_service.py
@@ -63,8 +63,9 @@ class ServiceTest(ModuleCase, SaltReturnAssertsMixin):
         '''
         test service.running state module
         '''
-        stop_service = self.run_function('service.stop', name=self.service_name)
-        self.assertTrue(stop_service)
+        if self.run_function('service.status', name=self.service_name):
+            stop_service = self.run_function('service.stop', name=self.service_name)
+            self.assertTrue(stop_service)
         self.check_service_status(self.stopped)
 
         if salt.utils.platform.is_darwin():

--- a/tests/integration/states/test_service.py
+++ b/tests/integration/states/test_service.py
@@ -13,6 +13,7 @@ from tests.support.mixins import SaltReturnAssertsMixin
 
 # Import salt libs
 import salt.utils.path
+import salt.utils.platform
 
 INIT_DELAY = 5
 
@@ -62,9 +63,13 @@ class ServiceTest(ModuleCase, SaltReturnAssertsMixin):
         '''
         test service.running state module
         '''
-        stop_service = self.run_function('service.stop', self.service_name)
+        stop_service = self.run_function('service.stop', name=self.service_name)
         self.assertTrue(stop_service)
         self.check_service_status(self.stopped)
+
+        if salt.utils.platform.is_darwin():
+            # make sure the service is enabled on macosx
+            enable = self.run_function('service.enable', name=self.service_name)
 
         start_service = self.run_state('service.running',
                                        name=self.service_name)


### PR DESCRIPTION
### What does this PR do?
Improve the error reporting for when the `service is disabled` message shows up in the launchctl stderr. Currently launchctl does not return a bad exit code so catching this error to report to the user they cannot start a service since its disabled. Also fixing the mac service tests. Currently this test is failing: `integration.states.test_service.ServiceTest.test_service_running` because i believe a test in modules.test_mac_service is  disabling the service, so I improved the tearDown there as well to ensure we are setting the disable/enabled status back to what it was initially.

