### PR TITLE
correctly handle AWS provider setting config vm_[name] to None

### DIFF
--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -3335,7 +3335,7 @@ def get_cloud_config_value(name, vm_, opts, default=None, search_global=True):
         if isinstance(vm_[name], types.GeneratorType):
             value = next(vm_[name], '')
         else:
-            if isinstance(value, dict):
+            if isinstance(value, dict) and isinstance(vm_[name], dict):
                 value.update(vm_[name].copy())
             else:
                 value = deepcopy(vm_[name])


### PR DESCRIPTION
### What does this PR do?
Causes salt.config.get_cloud_config_value() to ignore `None` config values at the highest level of precedence: vm_

Setting a vm_[name] config to None or anything else that evaluates to False will still be returned as `value = deepcopy(vm_[name])` 

### What issues does this PR fix or reference?
At some point in the salt-cloud mapfile deployment of AWS EC2 VMs, the aws provider sometimes sets the config value of `vm_[name]` to `None`. Using `None` doesn't seem to make any sense. The documented behavior of `salt.config.get_cloud_config_value()` tries to prefer this over the map, profile, and provider defaults, but fails to `vm_[name].copy()` the value to return the name because it is `None`, which is `NoneType`, and does not implement `.copy()`, and generates an exception to this effect.

    [ERROR   ] There was a profile error: 'NoneType' object has no attribute 'copy' Traceback (most recent call last):
    File "/usr/lib/python2.7/dist-packages/salt/cloud/cli.py", line 281, in run self.config.get('names')
    File "/usr/lib/python2.7/dist-packages/salt/cloud/__init__.py", line 1454, in run_profile ret[name] = self.create(vm_)
    File "/usr/lib/python2.7/dist-packages/salt/cloud/__init__.py", line 1284, in create output = self.clouds[func](vm_)
    File "/usr/lib/python2.7/dist-packages/salt/cloud/clouds/ec2.py", line 2760, in create for key, value in six.iteritems(__utils__['cloud.bootstrap'](vm_, __opts__)):
    File "/usr/lib/python2.7/dist-packages/salt/utils/cloud.py", line 362, in bootstrap minion_conf = minion_config(opts, vm_)
    File "/usr/lib/python2.7/dist-packages/salt/utils/cloud.py", line 260, in minion_config 'grains', vm_, opts, default={}, search_global=True
    File "/usr/lib/python2.7/dist-packages/salt/config/__init__.py", line 3309, in get_cloud_config_value value.update(vm_[name].copy())

Add CommentCollapse 

### Tests written?

No

### Commits signed with GPG?

Yes
