### PR TITLE
Prevent zypper from parsing repo configuration from not .repo files

### DIFF
--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -829,7 +829,7 @@ def _get_configured_repos():
     '''
 
     repos_cfg = configparser.ConfigParser()
-    repos_cfg.read([REPOS + '/' + fname for fname in os.listdir(REPOS)])
+    repos_cfg.read([REPOS + '/' + fname for fname in os.listdir(REPOS) if fname.endswith(".repo")])
 
     return repos_cfg
 


### PR DESCRIPTION
### What does this PR do?
This PR fixes a crash of the zypper module when the minion contains files which are not ".repo" files on `/etc/zypp/repos.d/`.

Currently, the zypper module tries to parse repositories configuration from all files listed on `/etc/zypp/repos.d/` and this is wrong, it should only read ".repo" like zypper does.

When those non-repo files are placed on `/etc/zypp/repos.d/`, i.a. a repo key file, we get the following python trace:
```
[ERROR   ] An un-handled exception was caught by salt's global exception handler:
MissingSectionHeaderError: File contains no section headers.
file: /etc/zypp/repos.d/my-custom-repo.key, line: 1
'-----BEGIN PGP PUBLIC KEY BLOCK-----\n'
Traceback (most recent call last):
  File "/usr/bin/salt-call", line 11, in <module>
    salt_call()
  File "/usr/lib/python2.7/site-packages/salt/scripts.py", line 379, in salt_call
    client.run()
  File "/usr/lib/python2.7/site-packages/salt/cli/call.py", line 58, in run
    caller.run()
  File "/usr/lib/python2.7/site-packages/salt/cli/caller.py", line 134, in run
    ret = self.call()
  File "/usr/lib/python2.7/site-packages/salt/cli/caller.py", line 197, in call
    ret['return'] = func(*args, **kwargs)
  File "/usr/lib/python2.7/site-packages/salt/modules/zypper.py", line 726, in list_repos
    repos_cfg = _get_configured_repos()
  File "/usr/lib/python2.7/site-packages/salt/modules/zypper.py", line 680, in _get_configured_repos
    repos_cfg.read([REPOS + '/' + fname for fname in os.listdir(REPOS)])
  File "/usr/lib64/python2.7/ConfigParser.py", line 305, in read
    self._read(fp, filename)
  File "/usr/lib64/python2.7/ConfigParser.py", line 512, in _read
    raise MissingSectionHeaderError(fpname, lineno, line)
```

### Tests written?

No

### Commits signed with GPG?

Yes