### PR TITLE
Back-port #47769 to 2018.3.1

### DIFF
--- a/tests/unit/modules/test_cmdmod.py
+++ b/tests/unit/modules/test_cmdmod.py
@@ -249,6 +249,7 @@ class CMDMODTestCase(TestCase, LoaderModuleMockMixin):
                             self.assertRaises(CommandExecutionError, cmdmod._run, 'foo')
 
     @skipIf(salt.utils.platform.is_windows(), 'Do not run on Windows')
+    @skipIf(True, 'Test breaks unittests runs')
     def test_run(self):
         '''
         Tests end result when a command is not found


### PR DESCRIPTION
Back-port #47769 to 2018.3.1