### PR TITLE
[2018.3] Fixes to failing _before_connect tests

### DIFF
--- a/tests/unit/test_minion.py
+++ b/tests/unit/test_minion.py
@@ -266,7 +266,9 @@ class MinionTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
                 patch('salt.utils.process.SignalHandlingMultiprocessingProcess.join', MagicMock(return_value=True)):
             mock_opts = self.get_config('minion', from_scratch=True)
             mock_opts['beacons_before_connect'] = True
-            minion = salt.minion.Minion(mock_opts, io_loop=tornado.ioloop.IOLoop())
+            io_loop = tornado.ioloop.IOLoop()
+            io_loop.make_current()
+            minion = salt.minion.Minion(mock_opts, io_loop=io_loop)
             try:
 
                 try:
@@ -290,7 +292,9 @@ class MinionTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
                 patch('salt.utils.process.SignalHandlingMultiprocessingProcess.join', MagicMock(return_value=True)):
             mock_opts = self.get_config('minion', from_scratch=True)
             mock_opts['scheduler_before_connect'] = True
-            minion = salt.minion.Minion(mock_opts, io_loop=tornado.ioloop.IOLoop())
+            io_loop = tornado.ioloop.IOLoop()
+            io_loop.make_current()
+            minion = salt.minion.Minion(mock_opts, io_loop=io_loop)
             try:
                 try:
                     minion.tune_in(start=True)


### PR DESCRIPTION
### What does this PR do?
Fixing unit.test_minion.MinionTestCase.test_beacons_before_connect and unit.test_minion.MinionTestCase.test_scheduler_before_connect.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt-jenkins/issues/970

### Tests written?
Yes.  Updated tests.

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
