### PR TITLE
Add test_pkg integration state tests to windows

### DIFF
--- a/tests/integration/files/file/base/win/repo-ng/7zip.sls
+++ b/tests/integration/files/file/base/win/repo-ng/7zip.sls
@@ -1,0 +1,24 @@
+{% set versions = {'18':['05', '03', '01'], '16':['04', '03', '02', '00'], '9':['20']} %}
+
+7zip:
+{% for major, subversions in versions.items() %}
+{% for minor in subversions %}
+  '{{major}}.{{minor}}.00.0':
+    {% if grains['cpuarch'] == 'AMD64' %}
+    full_name: '7-Zip {{major}}.{{minor}} (x64 edition)'
+    installer: 'http://d.7-zip.org/a/7z{{major}}{{minor}}-x64.msi'
+    uninstaller: 'http://d.7-zip.org/a/7z{{major}}{{minor}}-x64.msi'
+    arch: x64
+    {% else %}
+    full_name: '7-Zip {{major}}.{{minor}}'
+    installer: 'http://d.7-zip.org/a/7z{{major}}{{minor}}.msi'
+    uninstaller: 'http://d.7-zip.org/a/7z{{major}}{{minor}}.msi'
+    arch: x86
+    {% endif %}
+    install_flags: '/qn /norestart'
+    uninstall_flags: '/qn /norestart'
+    msiexec: True
+    locale: en_US
+    reboot: False
+{% endfor %}
+{% endfor %}

--- a/tests/integration/files/file/base/win/repo-ng/7zip.sls
+++ b/tests/integration/files/file/base/win/repo-ng/7zip.sls
@@ -1,6 +1,6 @@
 {% set versions = {'18':['05', '03', '01'], '16':['04', '03', '02', '00'], '9':['20']} %}
 
-7zip:
+Zzip:
 {% for major, subversions in versions.items() %}
 {% for minor in subversions %}
   '{{major}}.{{minor}}.00.0':

--- a/tests/integration/states/test_pkg.py
+++ b/tests/integration/states/test_pkg.py
@@ -36,7 +36,7 @@ _PKG_TARGETS = {
     'FreeBSD': ['aalib', 'pth'],
     'Suse': ['aalib', 'python-pssh'],
     'MacOS': ['libpng', 'jpeg'],
-    'Windows': ['firefox', '7zip'],
+    'Windows': ['putty', '7zip'],
 }
 
 _PKG_TARGETS_32 = {
@@ -158,7 +158,6 @@ class PkgTest(ModuleCase, SaltReturnAssertsMixin):
             self.run_function('pkg.refresh_db')
             __testcontext__['refresh'] = True
 
-    @skipIf(salt.utils.is_windows(), 'minion is windows')
     @requires_system_grains
     def test_pkg_001_installed(self, grains=None):
         '''
@@ -189,7 +188,6 @@ class PkgTest(ModuleCase, SaltReturnAssertsMixin):
         ret = self.run_state('pkg.removed', name=target)
         self.assertSaltTrueReturn(ret)
 
-    @skipIf(salt.utils.is_windows(), 'minion is windows')
     @requires_system_grains
     def test_pkg_002_installed_with_version(self, grains=None):
         '''
@@ -237,7 +235,6 @@ class PkgTest(ModuleCase, SaltReturnAssertsMixin):
         ret = self.run_state('pkg.removed', name=target)
         self.assertSaltTrueReturn(ret)
 
-    @skipIf(salt.utils.is_windows(), 'minion is windows')
     @requires_system_grains
     def test_pkg_003_installed_multipkg(self, grains=None):
         '''
@@ -259,7 +256,10 @@ class PkgTest(ModuleCase, SaltReturnAssertsMixin):
         # If this assert fails, we need to find new targets, this test needs to
         # be able to test successful installation of packages, so these
         # packages need to not be installed before we run the states below
-        self.assertFalse(any(version.values()))
+        try:
+            self.assertFalse(any(version.values()))
+        except AssertionError:
+            self.assertSaltTrueReturn(self.run_state('pkg.removed', name=None, pkgs=pkg_targets))
 
         ret = self.run_state('pkg.installed',
                              name=None,
@@ -269,7 +269,6 @@ class PkgTest(ModuleCase, SaltReturnAssertsMixin):
         ret = self.run_state('pkg.removed', name=None, pkgs=pkg_targets)
         self.assertSaltTrueReturn(ret)
 
-    @skipIf(salt.utils.is_windows(), 'minion is windows')
     @requires_system_grains
     def test_pkg_004_installed_multipkg_with_version(self, grains=None):
         '''
@@ -318,7 +317,6 @@ class PkgTest(ModuleCase, SaltReturnAssertsMixin):
         ret = self.run_state('pkg.removed', name=None, pkgs=pkg_targets)
         self.assertSaltTrueReturn(ret)
 
-    @skipIf(salt.utils.is_windows(), 'minion is windows')
     @requires_system_grains
     def test_pkg_005_installed_32bit(self, grains=None):
         '''
@@ -355,7 +353,6 @@ class PkgTest(ModuleCase, SaltReturnAssertsMixin):
             ret = self.run_state('pkg.removed', name=target)
             self.assertSaltTrueReturn(ret)
 
-    @skipIf(salt.utils.is_windows(), 'minion is windows')
     @requires_system_grains
     def test_pkg_006_installed_32bit_with_version(self, grains=None):
         '''
@@ -403,7 +400,6 @@ class PkgTest(ModuleCase, SaltReturnAssertsMixin):
         ret = self.run_state('pkg.removed', name=target)
         self.assertSaltTrueReturn(ret)
 
-    @skipIf(salt.utils.is_windows(), 'minion is windows')
     @requires_system_grains
     def test_pkg_007_with_dot_in_pkgname(self, grains=None):
         '''
@@ -434,7 +430,6 @@ class PkgTest(ModuleCase, SaltReturnAssertsMixin):
         ret = self.run_state('pkg.removed', name=target)
         self.assertSaltTrueReturn(ret)
 
-    @skipIf(salt.utils.is_windows(), 'minion is windows')
     @requires_system_grains
     def test_pkg_008_epoch_in_version(self, grains=None):
         '''
@@ -485,7 +480,6 @@ class PkgTest(ModuleCase, SaltReturnAssertsMixin):
                              refresh=False)
         self.assertSaltTrueReturn(ret)
 
-    @skipIf(salt.utils.is_windows(), 'minion is windows')
     @requires_salt_modules('pkg.info_installed')
     def test_pkg_010_latest_with_epoch_and_info_installed(self):
         '''
@@ -505,7 +499,6 @@ class PkgTest(ModuleCase, SaltReturnAssertsMixin):
         ret = self.run_function('pkg.info_installed', [package])
         self.assertTrue(pkgquery in str(ret))
 
-    @skipIf(salt.utils.is_windows(), 'minion is windows')
     @requires_system_grains
     def test_pkg_011_latest(self, grains=None):
         '''
@@ -537,7 +530,6 @@ class PkgTest(ModuleCase, SaltReturnAssertsMixin):
         ret = self.run_state('pkg.removed', name=target)
         self.assertSaltTrueReturn(ret)
 
-    @skipIf(salt.utils.is_windows(), 'minion is windows')
     @requires_system_grains
     def test_pkg_012_latest_only_upgrade(self, grains=None):
         '''

--- a/tests/whitelist.txt
+++ b/tests/whitelist.txt
@@ -38,6 +38,7 @@ integration.runners.test_salt
 integration.sdb.test_env
 integration.states.test_host
 integration.states.test_pip_state
+integration.states.test_pkg
 integration.states.test_renderers
 integration.utils.testprogram
 integration.wheel.test_client


### PR DESCRIPTION
### What does this PR do?
Allow the state test_pkg integration tests to run on windows.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/45016

