### PR TITLE
Update cloud test profile and docs to use new Linode size lables

### DIFF
--- a/doc/topics/cloud/linode.rst
+++ b/doc/topics/cloud/linode.rst
@@ -44,7 +44,7 @@ at ``/etc/salt/cloud.profiles`` or in the ``/etc/salt/cloud.profiles.d/`` direct
 
     linode_1024:
       provider: my-linode-config
-      size: Linode 2048
+      size: Linode 2GB
       image: CentOS 7
       location: London, England, UK
 
@@ -77,11 +77,13 @@ command:
         ----------
         linode:
             ----------
-            Linode 1024:
+            Linode 2GB:
                 ----------
                 AVAIL:
                     ----------
                     10:
+                        500
+                    11:
                         500
                     2:
                         500
@@ -100,11 +102,19 @@ command:
                 CORES:
                     1
                 DISK:
-                    24
+                    50
                 HOURLY:
                     0.015
                 LABEL:
-                    Linode 1024
+                    Linode 2GB
+                PLANID:
+                    2
+                PRICE:
+                    10.0
+                RAM:
+                    2048
+                XFER:
+                    2000
     ...SNIP...
 
 

--- a/tests/integration/files/conf/cloud.profiles.d/linode.conf
+++ b/tests/integration/files/conf/cloud.profiles.d/linode.conf
@@ -1,5 +1,5 @@
 linode-test:
   provider: linode-config
-  size: Linode 2048
+  size: Linode 2GB
   image: Ubuntu 14.04 LTS
   script_args: '-P -Z'


### PR DESCRIPTION
### What does this PR do?
Linode changed their size labels recently, so the cloud test profile and the docs need to be updated accordingly.

The new sizes can be found by running `salt-cloud --list-sizes <my-linode-config>`.

For example, the `Linode 2048` size is now `Linode 2GB`.

### What issues does this PR fix or reference?

N/A - found by cloud tests

### Previous Behavior
Spinning up a new VM would stacktrace because the old cloud size no longer exists on Linode.

### New Behavior
Using the correct size allows salt-cloud to work properly on Linode again.

### Tests written?

Yes

### Commits signed with GPG?

Yes