### PR TITLE
Back-port #47776 to 2018.3.1

### DIFF
--- a/tests/unit/test_minion.py
+++ b/tests/unit/test_minion.py
@@ -266,7 +266,9 @@ class MinionTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
                 patch('salt.utils.process.SignalHandlingMultiprocessingProcess.join', MagicMock(return_value=True)):
             mock_opts = self.get_config('minion', from_scratch=True)
             mock_opts['beacons_before_connect'] = True
-            minion = salt.minion.Minion(mock_opts, io_loop=tornado.ioloop.IOLoop())
+            io_loop = tornado.ioloop.IOLoop()
+            io_loop.make_current()
+            minion = salt.minion.Minion(mock_opts, io_loop=io_loop)
             try:
 
                 try:
@@ -290,7 +292,9 @@ class MinionTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
                 patch('salt.utils.process.SignalHandlingMultiprocessingProcess.join', MagicMock(return_value=True)):
             mock_opts = self.get_config('minion', from_scratch=True)
             mock_opts['scheduler_before_connect'] = True
-            minion = salt.minion.Minion(mock_opts, io_loop=tornado.ioloop.IOLoop())
+            io_loop = tornado.ioloop.IOLoop()
+            io_loop.make_current()
+            minion = salt.minion.Minion(mock_opts, io_loop=io_loop)
             try:
                 try:
                     minion.tune_in(start=True)


### PR DESCRIPTION
Back-port #47776 to 2018.3.1