### PR TITLE
Fix Linode plan selection

### DIFF
--- a/salt/cloud/clouds/linode.py
+++ b/salt/cloud/clouds/linode.py
@@ -1006,36 +1006,41 @@ def decode_linode_plan_label(label):
     """
     sizes = avail_sizes()
 
-    if label not in sizes and "GB" not in label:
-        plan = label.split()
-
-        if len(plan) != 2:
+    if label not in sizes:
+        if "GB" in label:
             raise SaltCloudException(
                 'Invalid Linode plan ({}) specified - call avail_sizes() for all available options'.format(label)
             )
+        else:
+            plan = label.split()
 
-        plan_type = plan[0]
-        try:
-            plan_size = int(plan[1])
-        except Exception as e:
-            plan_size = 0
+            if len(plan) != 2:
+                raise SaltCloudException(
+                    'Invalid Linode plan ({}) specified - call avail_sizes() for all available options'.format(label)
+                )
 
-        if plan_type == "Linode" and plan_size == 1024:
-            plan_type = "Nanode"
+            plan_type = plan[0]
+            try:
+                plan_size = int(plan[1])
+            except Exception as e:
+                plan_size = 0
 
-        plan_size = plan_size/1024
-        new_label = "{} {}GB".format(plan_type, plan_size)
+            if plan_type == "Linode" and plan_size == 1024:
+                plan_type = "Nanode"
 
-        if new_label not in sizes:
-            raise SaltCloudException(
-                'Invalid Linode plan ({}) specified - call avail_sizes() for all available options'.format(new_label)
-            )
+            plan_size = plan_size/1024
+            new_label = "{} {}GB".format(plan_type, plan_size)
 
-        log.warning("An outdated Linode plan label was detected in your Cloud profile ({})."
-                    " Please update the profile to use"
-                    " the new label format ({}) for the requested Linode plan size.".format(label, new_label))
+            if new_label not in sizes:
+                raise SaltCloudException(
+                    'Invalid Linode plan ({}) specified - call avail_sizes() for all available options'.format(new_label)
+                )
 
-        label = new_label
+            log.warning("An outdated Linode plan label was detected in your Cloud profile ({})."
+                        " Please update the profile to use"
+                        " the new label format ({}) for the requested Linode plan size.".format(label, new_label))
+
+            label = new_label
 
     return sizes[label]['PLANID']
 

--- a/salt/cloud/clouds/linode.py
+++ b/salt/cloud/clouds/linode.py
@@ -1035,6 +1035,10 @@ def decode_linode_plan_label(label):
                     'Invalid Linode plan ({}) specified - call avail_sizes() for all available options'.format(new_label)
                 )
 
+            log.warning("An outdated Linode plan label was detected in your Cloud profile ({})."
+                        " Please update the profile to use"
+                        " the new label format {} for the requested Linode plan size.'.format(label, new_label))
+
             label = new_label
 
     return sizes[label]['PLANID']

--- a/salt/cloud/clouds/linode.py
+++ b/salt/cloud/clouds/linode.py
@@ -1037,7 +1037,7 @@ def decode_linode_plan_label(label):
 
             log.warning("An outdated Linode plan label was detected in your Cloud profile ({})."
                         " Please update the profile to use"
-                        " the new label format ({}) for the requested Linode plan size.'.format(label, new_label))
+                        " the new label format ({}) for the requested Linode plan size.".format(label, new_label))
 
             label = new_label
 

--- a/salt/cloud/clouds/linode.py
+++ b/salt/cloud/clouds/linode.py
@@ -993,33 +993,17 @@ def get_password(vm_):
     )
 
 
-def get_plan_id(kwargs=None, call=None):
-    '''
-    Returns the Linode Plan ID.
+def decode_linode_plan_label(label):
+    """
+    Attempts to decode a user-supplied Linode plan label
+    into the format in Linode API output
 
     label
-        The label, or name, of the plan to get the ID from.
+        The label, or name, of the plan to decode.
 
-    CLI Example:
-
-    .. code-block:: bash
-
-        salt-cloud -f get_plan_id linode label="Linode 1024"
-    '''
-    if call == 'action':
-        raise SaltCloudException(
-            'The show_instance action must be called with -f or --function.'
-        )
-
-    if kwargs is None:
-        kwargs = {}
-
-    label = kwargs.get('label', None)
-    if label is None:
-        raise SaltCloudException(
-            'The get_plan_id function requires a \'label\'.'
-        )
-
+    Example:
+        `Linode 2048` will decode to `Linode 2GB`
+    """
     sizes = avail_sizes()
 
     if label not in sizes:
@@ -1054,6 +1038,38 @@ def get_plan_id(kwargs=None, call=None):
             label = new_label
 
     return sizes[label]['PLANID']
+
+
+def get_plan_id(kwargs=None, call=None):
+    '''
+    Returns the Linode Plan ID.
+
+    label
+        The label, or name, of the plan to get the ID from.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt-cloud -f get_plan_id linode label="Linode 1024"
+    '''
+    if call == 'action':
+        raise SaltCloudException(
+            'The show_instance action must be called with -f or --function.'
+        )
+
+    if kwargs is None:
+        kwargs = {}
+
+    label = kwargs.get('label', None)
+    if label is None:
+        raise SaltCloudException(
+            'The get_plan_id function requires a \'label\'.'
+        )
+
+    label = decode_linode_plan_label(label)
+
+    return label
 
 
 def get_private_ip(vm_):

--- a/salt/cloud/clouds/linode.py
+++ b/salt/cloud/clouds/linode.py
@@ -1007,7 +1007,7 @@ def _decode_linode_plan_label(label):
     sizes = avail_sizes()
 
     if label not in sizes:
-        if "GB" in label:
+        if 'GB' in label:
             raise SaltCloudException(
                 'Invalid Linode plan ({}) specified - call avail_sizes() for all available options'.format(label)
             )
@@ -1024,10 +1024,10 @@ def _decode_linode_plan_label(label):
                 plan_size = int(plan[1])
             except TypeError:
                 plan_size = 0
-                log.debug('Failed to decode user-supplied Linode plan label: %s', label)
+                log.debug('Failed to decode Linode plan label in Cloud Profile: %s', label)
 
-            if plan_type == "Linode" and plan_size == 1024:
-                plan_type = "Nanode"
+            if plan_type == 'Linode' and plan_size == 1024:
+                plan_type = 'Nanode'
 
             plan_size = plan_size/1024
             new_label = "{} {}GB".format(plan_type, plan_size)
@@ -1037,9 +1037,9 @@ def _decode_linode_plan_label(label):
                     'Invalid Linode plan ({}) specified - call avail_sizes() for all available options'.format(new_label)
                 )
 
-            log.warning("An outdated Linode plan label was detected in your Cloud profile ({})."
-                        " Please update the profile to use"
-                        " the new label format ({}) for the requested Linode plan size.".format(label, new_label))
+            log.warning('An outdated Linode plan label was detected in your Cloud Profile ({}).'
+                        ' Please update the profile to use'
+                        ' the new label format ({}) for the requested Linode plan size.'.format(label, new_label))
 
             label = new_label
 

--- a/salt/cloud/clouds/linode.py
+++ b/salt/cloud/clouds/linode.py
@@ -994,7 +994,7 @@ def get_password(vm_):
 
 
 def _decode_linode_plan_label(label):
-    """
+    '''
     Attempts to decode a user-supplied Linode plan label
     into the format in Linode API output
 
@@ -1003,7 +1003,7 @@ def _decode_linode_plan_label(label):
 
     Example:
         `Linode 2048` will decode to `Linode 2GB`
-    """
+    '''
     sizes = avail_sizes()
 
     if label not in sizes:
@@ -1022,8 +1022,9 @@ def _decode_linode_plan_label(label):
             plan_type = plan[0]
             try:
                 plan_size = int(plan[1])
-            except Exception as e:
+            except TypeError:
                 plan_size = 0
+                log.debug('Failed to decode user-supplied Linode plan label: %s', label)
 
             if plan_type == "Linode" and plan_size == 1024:
                 plan_type = "Nanode"
@@ -1072,7 +1073,7 @@ def get_plan_id(kwargs=None, call=None):
             'The get_plan_id function requires a \'label\'.'
         )
 
-    label = decode_linode_plan_label(label)
+    label = _decode_linode_plan_label(label)
 
     return label
 

--- a/salt/cloud/clouds/linode.py
+++ b/salt/cloud/clouds/linode.py
@@ -993,7 +993,7 @@ def get_password(vm_):
     )
 
 
-def decode_linode_plan_label(label):
+def _decode_linode_plan_label(label):
     """
     Attempts to decode a user-supplied Linode plan label
     into the format in Linode API output

--- a/salt/cloud/clouds/linode.py
+++ b/salt/cloud/clouds/linode.py
@@ -1006,40 +1006,36 @@ def decode_linode_plan_label(label):
     """
     sizes = avail_sizes()
 
-    if label not in sizes:
-        # Linode plan labels have changed from e.g. Linode 1024 to Linode 1GB
-        if "GB" not in label:
-            plan = label.split()
+    if label not in sizes and "GB" not in label:
+        plan = label.split()
 
-            # label is invalid if it isn't a space-separated string
-            if len(plan) != 2:
-                raise SaltCloudException(
-                    'Invalid Linode plan ({}) specified - call avail_sizes() for all available options'.format(label)
-                )
+        if len(plan) != 2:
+            raise SaltCloudException(
+                'Invalid Linode plan ({}) specified - call avail_sizes() for all available options'.format(label)
+            )
 
-            plan_type = plan[0]
-            try:
-                plan_size = int(plan[1])
-            except:
-                plan_size = 0
+        plan_type = plan[0]
+        try:
+            plan_size = int(plan[1])
+        except Exception as e:
+            plan_size = 0
 
-            if plan_type == "Linode" and plan_size == 1024:
-                plan_type = "Nanode"
+        if plan_type == "Linode" and plan_size == 1024:
+            plan_type = "Nanode"
 
-            # translate from MB to GB
-            plan_size = plan_size/1024
-            new_label = "{} {}GB".format(plan_type, plan_size)
+        plan_size = plan_size/1024
+        new_label = "{} {}GB".format(plan_type, plan_size)
 
-            if new_label not in sizes:
-                raise SaltCloudException(
-                    'Invalid Linode plan ({}) specified - call avail_sizes() for all available options'.format(new_label)
-                )
+        if new_label not in sizes:
+            raise SaltCloudException(
+                'Invalid Linode plan ({}) specified - call avail_sizes() for all available options'.format(new_label)
+            )
 
-            log.warning("An outdated Linode plan label was detected in your Cloud profile ({})."
-                        " Please update the profile to use"
-                        " the new label format ({}) for the requested Linode plan size.".format(label, new_label))
+        log.warning("An outdated Linode plan label was detected in your Cloud profile ({})."
+                    " Please update the profile to use"
+                    " the new label format ({}) for the requested Linode plan size.".format(label, new_label))
 
-            label = new_label
+        label = new_label
 
     return sizes[label]['PLANID']
 

--- a/salt/cloud/clouds/linode.py
+++ b/salt/cloud/clouds/linode.py
@@ -1037,7 +1037,7 @@ def decode_linode_plan_label(label):
 
             log.warning("An outdated Linode plan label was detected in your Cloud profile ({})."
                         " Please update the profile to use"
-                        " the new label format {} for the requested Linode plan size.'.format(label, new_label))
+                        " the new label format ({}) for the requested Linode plan size.'.format(label, new_label))
 
             label = new_label
 


### PR DESCRIPTION
### What does this PR do?

Fixes Linode plan selection in the Linode Salt Cloud module.

### What issues does this PR fix or reference?

Linode plan labels used to look like this: `Linode 2048`
Now, they look like this: `Linode 2GB`

Additionally, 1GB Linodes are labeled `Nanode 1GB`.

This has broken, presumably, all existing Linode cloud profiles.

### Previous Behavior

Only accepting plan labels in the form of `Linode 2048`.

### New Behavior

Accepting labels in either form (`Linode 2048` vs. `Linode 2GB`). Also, a 1GB Linode can be deployed via the "Linode" or "Nanode" label, for backwards compatibility.

### Tests written?

No

### Commits signed with GPG?

Yes