### PR TITLE
Add windows to service disable ERROR check in tests

### DIFF
--- a/tests/integration/modules/test_service.py
+++ b/tests/integration/modules/test_service.py
@@ -118,7 +118,7 @@ class ServiceModuleTest(ModuleCase):
         systemd = salt.utils.systemd.booted()
 
         # check service was not enabled
-        if systemd:
+        if systemd or salt.utils.is_windows():
             self.assertIn('ERROR', enable)
         else:
             self.assertFalse(enable)


### PR DESCRIPTION
### What does this PR do?
Currently this test `integration.modules.test_service.ServiceModuleTest.test_service_disable_doesnot_exist ` is failing on windows with the error:

```
Traceback (most recent call last):
  File "c:\users\admini~1\appdata\local\temp\kitchen\testing\tests\integration\modules\test_service.py", line 124, in test_service_disable_doesnot_exist
    self.assertFalse(enable)
AssertionError: 'ERROR: Failed To Open doesnotexist: The specified service does not exist as an installed service.' is not false
```

This is because the test was expecting False but sometimes the service disable check returns ERROR if the service does not exist, so updating the test to ensure windows changes the check for ERROR.