### PR TITLE
Remove output_loglevel in mac_system module

### DIFF
--- a/salt/modules/mac_system.py
+++ b/salt/modules/mac_system.py
@@ -74,8 +74,7 @@ def _atrun_enabled():
         # Collect information on service: will raise an error if it fails
         salt.utils.mac_utils.launchctl('list',
                                        label,
-                                       return_stdout=True,
-                                       output_loglevel='quiet')
+                                       return_stdout=True)
         return True
     except CommandExecutionError:
         return False
@@ -111,9 +110,8 @@ def _enable_atrun():
         return False
 
     salt.utils.mac_utils.launchctl('enable',
-                                   'system/{0}'.format(label),
-                                   output_loglevel='quiet')
-    salt.utils.mac_utils.launchctl('load', path, output_loglevel='quiet')
+                                   'system/{0}'.format(label))
+    salt.utils.mac_utils.launchctl('load', path)
     return _atrun_enabled()
 
 


### PR DESCRIPTION
### What does this PR do?
These tests are failing on mac:
integration.modules.test_mac_system.MacSystemModuleTest.test_get_list_startup_disk
integration.modules.test_mac_system.MacSystemModuleTest.test_get_set_computer_name
integration.modules.test_mac_system.MacSystemModuleTest.test_get_set_disable_keyboard_on_lock
integration.modules.test_mac_system.MacSystemModuleTest.test_get_set_remote_events
integration.modules.test_mac_system.MacSystemModuleTest.test_get_set_remote_login
integration.modules.test_mac_system.MacSystemModuleTest.test_get_set_subnet_name

This is because we no longer need output_loglevel as we have transfered to using  _run_all_quiet and _run_quiet instead