### PR TITLE
Specify the correct port in socket.connect

### DIFF
--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -1783,7 +1783,7 @@ def dns_check(addr, port, safe=False, ipv6=None):
 
                 try:
                     s = socket.socket(h[0], socket.SOCK_STREAM)
-                    s.connect((candidate_addr.strip('[]'), h[1]))
+                    s.connect((candidate_addr.strip('[]'), h[4][1]))
                     s.close()
 
                     resolved = candidate_addr


### PR DESCRIPTION
### What does this PR do?

Pass the correct port to `socket.connect` in `dns_check` in `utils/network.py`

### Previous Behavior

It takes a long time until minions connect to the master.

Since commit c7cb2c591216 the port passed to `socket.connect` is no longer the value of the `port` argument passed to `dns_check`, but `h[1]`, where `h` is the result of a previous `getaddrinfo` call. However, `h[1]` doesn't describe the port but the socket type, so `dns_check` waits for `socket.connect` to timeout (as it's connecting to the wrong port) until resorting to its fallback mechanism of returning `candidates[0]`.

### Fix

Pass `h[4][1]` instead of `h[1]` as the port argument to `socket.connect`