### PR TITLE
Fix issue when archive is on mapped drive

### DIFF
--- a/salt/states/archive.py
+++ b/salt/states/archive.py
@@ -73,7 +73,7 @@ def _checksum_file_path(path):
             )
     except ValueError as exc:
         # The path is on a different drive (Windows)
-        if 'path is on drive' in exc.message:
+        if str(exc).startswith('path is on'):
             drive, path = os.path.splitdrive(path)
             relpath = salt.utils.path_join(
                 'local',

--- a/salt/states/archive.py
+++ b/salt/states/archive.py
@@ -72,14 +72,17 @@ def _checksum_file_path(path):
                 os.path.splitdrive(path)[-1].lstrip('/\\'),
             )
     except ValueError as exc:
-        # The path is on a network drive (Windows)
+        # The path is on a different drive (Windows)
         if 'path is on drive' in exc.message:
+            drive, path = os.path.splitdrive(path)
             relpath = salt.utils.path_join(
-                'network',
-                os.path.splitdrive(path)[-1].lstrip('/\\'),
+                'local',
+                drive.rstrip(':'),
+                path.lstrip('/\\'),
             )
         else:
             raise
+    log.debug('Found path: %s', relpath)
     return salt.utils.path_join(__opts__['cachedir'], 'archive_hash', relpath)
 
 

--- a/salt/states/archive.py
+++ b/salt/states/archive.py
@@ -63,13 +63,23 @@ def _gen_checksum(path):
 
 
 def _checksum_file_path(path):
-    relpath = '.'.join((os.path.relpath(path, __opts__['cachedir']), 'hash'))
-    if re.match(r'..[/\\]', relpath):
-        # path is a local file
-        relpath = salt.utils.path_join(
-            'local',
-            os.path.splitdrive(path)[-1].lstrip('/\\'),
-        )
+    try:
+        relpath = '.'.join((os.path.relpath(path, __opts__['cachedir']), 'hash'))
+        if re.match(r'..[/\\]', relpath):
+            # path is a local file
+            relpath = salt.utils.path_join(
+                'local',
+                os.path.splitdrive(path)[-1].lstrip('/\\'),
+            )
+    except ValueError as exc:
+        # The path is on a network drive (Windows)
+        if 'path is on drive' in exc.message:
+            relpath = salt.utils.path_join(
+                'network',
+                os.path.splitdrive(path)[-1].lstrip('/\\'),
+            )
+        else:
+            raise
     return salt.utils.path_join(__opts__['cachedir'], 'archive_hash', relpath)
 
 

--- a/salt/states/archive.py
+++ b/salt/states/archive.py
@@ -82,8 +82,9 @@ def _checksum_file_path(path):
             )
         else:
             raise
-    log.debug('Found path: %s', relpath)
-    return salt.utils.path_join(__opts__['cachedir'], 'archive_hash', relpath)
+    ret = salt.utils.path_join(__opts__['cachedir'], 'archive_hash', relpath)
+    log.debug('Using checksum file %s for cached archive file %s', ret, path)
+    return ret
 
 
 def _update_checksum(path):


### PR DESCRIPTION
### What does this PR do?
Fixes an issue when the archive is on a drive letter that is not the same working directory as python. `os.path.relpath` throws the following error:
```
[ERROR   ] An exception occurred in this state: Traceback (most recent call last):
  File "c:\dev\salt\salt\state.py", line 1889, in call
    **cdata['kwargs'])
  File "c:\dev\salt\salt\loader.py", line 1826, in wrapper
    return f(*args, **kwargs)
  File "c:\dev\salt\salt\states\archive.py", line 1006, in extracted
    existing_cached_source_sum = _read_cached_checksum(cached)
  File "c:\dev\salt\salt\states\archive.py", line 130, in _read_cached_checksum
    checksum_file = _checksum_file_path(path)
  File "c:\dev\salt\salt\states\archive.py", line 69, in _checksum_file_path
    log.debug('.'.join((os.path.relpath(path, __opts__['cachedir']), 'hash')))
  File "c:\python27\lib\ntpath.py", line 529, in relpath
    % (path_prefix, start_prefix))
ValueError: path is on drive z:, start on drive c:
```

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/47791

### Previous Behavior
If the archive was on any other drive it would throw the above error.

### New Behavior
Now it doesn't. 
For the file `C:\temp\test.zip` on the same drive as the cwd, it creates the hash dir in the following location, dropping the drive letter (normal, previous behavior):
` c:\salt\var\cache\salt\minion\archive_hash\local\Temp\test.zip`
If the file was on a different drive (`Z:\temp\test.zip`) it will create the hash dir like this, instead of throwing an error (adding the drive letter):
`c:\salt\var\cache\salt\minion\archive_hash\local\z\temp\test.zip`

### Tests written?
No

### Commits signed with GPG?
Yes