### PR TITLE
Add allowing for wheel publish jobs

### DIFF
--- a/doc/ref/peer.rst
+++ b/doc/ref/peer.rst
@@ -108,6 +108,12 @@ Peer Wheel Communication
 
 .. versionadded: Fluorine
 
+.. warning::
+
+    Any of the below configurations allow the minion to be able to control the
+    master.  Any minion that has the ability to use these functions will be
+    **fully trusted** by the master.
+
 Configuration to allow minions to execute wheel functions from the master is
 done via the ``peer_wheel`` option on the master. The ``peer_wheel``
 configuration follows the same logic as the ``peer`` option. The only
@@ -120,11 +126,6 @@ To open up access to all minions to all wheel:
     peer_wheel:
       .*:
         - .*
-
-.. warning::
-
-    The above configuration allows all the minions to control the master,
-    including changing master configuration files.
 
 This configuration will allow minions with IDs ending in example.com access
 to the key wheel functions.

--- a/doc/ref/peer.rst
+++ b/doc/ref/peer.rst
@@ -99,6 +99,36 @@ to the manage and jobs runner functions.
 .. note::
     Functions are matched using regular expressions.
 
+.. _peer-wheel:
+
+Peer Wheel Communication
+=========================
+
+Configuration to allow minions to execute wheel from the master is done via
+the ``peer_wheel`` option on the master. The ``peer_wheel`` configuration follows
+the same logic as the ``peer`` option. The only difference is that access is
+granted to wheel modules.
+
+To open up access to all minions to all wheel:
+
+.. code-block:: yaml
+
+    peer_wheel:
+      .*:
+        - .*
+
+This configuration will allow minions with IDs ending in example.com access
+to the key wheel functions.
+
+.. code-block:: yaml
+
+    peer_wheel:
+      .*example.com:
+        - key.*
+
+.. note::
+    Functions are matched using regular expressions.
+
 Using Peer Communication
 ========================
 
@@ -113,12 +143,6 @@ To execute test.ping on all minions:
 
     # salt-call publish.publish \* test.ping
 
-To execute the manage.up runner:
-
-.. code-block:: bash
-
-    # salt-call publish.runner manage.up
-
 To match minions using other matchers, use ``tgt_type``:
 
 .. code-block:: bash
@@ -127,3 +151,15 @@ To match minions using other matchers, use ``tgt_type``:
 
 .. note::
     In pre-2017.7.0 releases, use ``expr_form`` instead of ``tgt_type``.
+
+To execute the manage.up runner:
+
+.. code-block:: bash
+
+    # salt-call publish.runner manage.up
+
+To execute the key.accept wheel module:
+
+.. code-block:: bash
+
+    # salt-call publish.wheel key.accept arg='match=<minionid>'

--- a/doc/ref/peer.rst
+++ b/doc/ref/peer.rst
@@ -68,6 +68,7 @@ allow minions ending with foo.org access to the publisher.
         - pkg.*
 
 .. note::
+
     Functions are matched using regular expressions.
 
 Peer Runner Communication
@@ -97,6 +98,7 @@ to the manage and jobs runner functions.
         - jobs.*
 
 .. note::
+
     Functions are matched using regular expressions.
 
 .. _peer-wheel:
@@ -104,10 +106,12 @@ to the manage and jobs runner functions.
 Peer Wheel Communication
 =========================
 
-Configuration to allow minions to execute wheel from the master is done via
-the ``peer_wheel`` option on the master. The ``peer_wheel`` configuration follows
-the same logic as the ``peer`` option. The only difference is that access is
-granted to wheel modules.
+.. versionadded: Fluorine
+
+Configuration to allow minions to execute wheel functions from the master is
+done via the ``peer_wheel`` option on the master. The ``peer_wheel``
+configuration follows the same logic as the ``peer`` option. The only
+difference is that access is granted to wheel modules.
 
 To open up access to all minions to all wheel:
 
@@ -127,6 +131,7 @@ to the key wheel functions.
         - key.*
 
 .. note::
+
     Functions are matched using regular expressions.
 
 Using Peer Communication
@@ -150,6 +155,7 @@ To match minions using other matchers, use ``tgt_type``:
     # salt-call publish.publish 'webserv* and not G@os:Ubuntu' test.ping tgt_type='compound'
 
 .. note::
+
     In pre-2017.7.0 releases, use ``expr_form`` instead of ``tgt_type``.
 
 To execute the manage.up runner:

--- a/doc/ref/peer.rst
+++ b/doc/ref/peer.rst
@@ -121,6 +121,11 @@ To open up access to all minions to all wheel:
       .*:
         - .*
 
+.. warning::
+
+    The above configuration allows all the minions to control the master,
+    including changing master configuration files.
+
 This configuration will allow minions with IDs ending in example.com access
 to the key wheel functions.
 

--- a/doc/topics/releases/fluorine.rst
+++ b/doc/topics/releases/fluorine.rst
@@ -180,6 +180,16 @@ The syntax is as follows:
     - :py:mod:`yumpkg <salt.modules.yumpkg>`
     - :py:mod:`zypper <salt.modules.zypper>`
 
+Wheel Peering Options
+=====================
+
+A ``publish.wheel`` module has been added, allowing access to the wheel
+functions on the master.
+
+The peer configuration can be found :ref:`here <peer-wheel>`.
+>>>>>>> add docs
+
+
 "Virtual Package" Support Dropped for APT
 =========================================
 

--- a/doc/topics/releases/fluorine.rst
+++ b/doc/topics/releases/fluorine.rst
@@ -187,7 +187,6 @@ A ``publish.wheel`` module has been added, allowing access to the wheel
 functions on the master.
 
 The peer configuration can be found :ref:`here <peer-wheel>`.
->>>>>>> add docs
 
 
 "Virtual Package" Support Dropped for APT

--- a/doc/topics/releases/fluorine.rst
+++ b/doc/topics/releases/fluorine.rst
@@ -186,6 +186,11 @@ Wheel Peering Options
 A ``publish.wheel`` module has been added, allowing access to the wheel
 functions on the master.
 
+.. warning:
+
+    This can be used to gain full access of the master.  This should be used
+    sparingly and only when it cannot be avoided.
+
 The peer configuration can be found :ref:`here <peer-wheel>`.
 
 

--- a/salt/daemons/masterapi.py
+++ b/salt/daemons/masterapi.py
@@ -865,7 +865,6 @@ class RemoteFuncs(object):
         opts = {}
         opts.update(self.opts)
         client = salt.wheel.WheelClient(opts)
-        arg, kwarg = salt.utils.args.parse_input(load['arg'], no_parse=load.get('no_parse', []))
         arg = kwarg = None
         if load['arg']:
             args = salt.utils.args.parse_input(load['arg'], no_parse=load.get('no_parse', []))

--- a/salt/daemons/masterapi.py
+++ b/salt/daemons/masterapi.py
@@ -859,7 +859,7 @@ class RemoteFuncs(object):
         if not good:
             # The minion is not who it says it is!
             # We don't want to listen to it!
-            log.warning('Minion id %s is not who it says it is!', load['id'])
+            log.warning('Minion id %s does not have permission to run wheel module: %s', load['id'], load['fun'])
             return {}
         # Prepare the runner object
         opts = {}

--- a/salt/daemons/masterapi.py
+++ b/salt/daemons/masterapi.py
@@ -836,6 +836,47 @@ class RemoteFuncs(object):
         runner = salt.runner.Runner(opts)
         return runner.run()
 
+    def minion_wheel(self, load):
+        '''
+        Execute a wheel from a minion, return the wheel's function data
+        '''
+        if 'peer_wheel' not in self.opts:
+            return {}
+        if not isinstance(self.opts['peer_wheel'], dict):
+            return {}
+        if any(key not in load for key in ('fun', 'arg', 'id')):
+            return {}
+        perms = set()
+        for match in self.opts['peer_wheel']:
+            if re.match(match, load['id']):
+                # This is the list of funcs/modules!
+                if isinstance(self.opts['peer_wheel'][match], list):
+                    perms.update(self.opts['peer_wheel'][match])
+        good = False
+        for perm in perms:
+            if re.match(perm, load['fun']):
+                good = True
+        if not good:
+            # The minion is not who it says it is!
+            # We don't want to listen to it!
+            log.warning('Minion id %s is not who it says it is!', load['id'])
+            return {}
+        # Prepare the runner object
+        opts = {}
+        opts.update(self.opts)
+        client = salt.wheel.WheelClient(opts)
+        arg, kwarg = salt.utils.args.parse_input(load['arg'], no_parse=load.get('no_parse', []))
+        arg = kwarg = None
+        if load['arg']:
+            args = salt.utils.args.parse_input(load['arg'], no_parse=load.get('no_parse', []))
+            if isinstance(args, tuple):
+                arg, kwarg = args
+            elif isinstance(args, dict):
+                kwarg = args
+            else:
+                arg = args
+        return client.cmd(load['fun'], arg=arg, kwarg=kwarg)
+
     def pub_ret(self, load, skip_verify=False):
         '''
         Request the return data from a specific jid, only allowed

--- a/salt/master.py
+++ b/salt/master.py
@@ -1681,6 +1681,21 @@ class AESFuncs(object):
         else:
             return self.masterapi.minion_runner(clear_load)
 
+    def minion_wheel(self, clear_load):
+        '''
+        Execute a wheel from a minion, return the wheel's function data
+
+        :param dict clear_load: The minion payload
+
+        :rtype: dict
+        :return: The wheel function data
+        '''
+        load = self.__verify_load(clear_load, ('fun', 'arg', 'id', 'tok'))
+        if load is False:
+            return {}
+        else:
+            return self.masterapi.minion_wheel(clear_load)
+
     def pub_ret(self, load):
         '''
         Request the return data from a specific jid, only allowed

--- a/salt/modules/publish.py
+++ b/salt/modules/publish.py
@@ -328,3 +328,36 @@ def runner(fun, arg=None, timeout=5):
         return channel.send(load)
     except SaltReqTimeoutError:
         return '\'{0}\' runner publish timed out'.format(fun)
+
+
+def wheel(fun, arg=None, timeout=5):
+    '''
+    Execute a runner on the master and return the data from the runner
+    function
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt publish.runner manage.down
+    '''
+    arg = _parse_args(arg)
+
+    if 'master_uri' not in __opts__:
+        return 'No access to master. If using salt-call with --local, please remove.'
+    log.info('Publishing wheel \'{0}\' to {master_uri}'.format(fun, **__opts__))
+    auth = salt.crypt.SAuth(__opts__)
+    tok = auth.gen_token('salt')
+    load = {'cmd': 'minion_wheel',
+            'fun': fun,
+            'arg': arg,
+            'tok': tok,
+            'tmo': timeout,
+            'id': __opts__['id'],
+            'no_parse': __opts__.get('no_parse', [])}
+
+    channel = salt.transport.Channel.factory(__opts__)
+    try:
+        return channel.send(load)
+    except SaltReqTimeoutError:
+        return '\'{0}\' wheel publish timed out'.format(fun)

--- a/tests/integration/files/conf/master
+++ b/tests/integration/files/conf/master
@@ -30,6 +30,10 @@ peer:
   '.*':
     - 'test.*'
 
+peer_wheel:
+  'minion':
+    - 'key.accept'
+
 ext_pillar:
   - test_ext_pillar_opts:
     - test_issue_5951_actual_file_roots_in_opts

--- a/tests/integration/modules/test_publish.py
+++ b/tests/integration/modules/test_publish.py
@@ -153,3 +153,40 @@ class PublishModuleTest(ModuleCase, SaltReturnAssertsMixin):
             f_timeout=50
         )
         self.assertEqual(ret, {})
+
+
+class PublishWheelModuleTest(ModuleCase, SaltReturnAssertsMixin):
+    '''
+    Validate the publish.wheel module
+    '''
+
+    def test_publish_wheel(self):
+        '''
+        test accepting key
+        '''
+        ret = self.run_function(
+            'publish.wheel',
+            ['key.accept', 'arg=minion'],
+        )
+        self.assertEqual(ret, {'minions': ['minion']})
+
+    def test_publish_wheel_not_allowed(self):
+        '''
+        test accepting key
+        '''
+        ret = self.run_function(
+            'publish.wheel',
+            ['key.list_all'],
+        )
+        self.assertEqual(ret, {'minions': ['minion']})
+
+    def test_publish_wheel_rejected(self):
+        '''
+        test accepting key
+        '''
+        ret = self.run_function(
+            'publish.wheel',
+            ['key.accept', 'arg=minion'],
+            minion_tgt='subminion',
+        )
+        self.assertEqual(ret, {'minions': ['minion']})

--- a/tests/integration/modules/test_publish.py
+++ b/tests/integration/modules/test_publish.py
@@ -5,6 +5,7 @@ from __future__ import absolute_import, print_function, unicode_literals
 
 # Import Salt Testing libs
 from tests.support.case import ModuleCase
+from tests.support.helpers import flaky
 from tests.support.mixins import SaltReturnAssertsMixin
 
 
@@ -155,6 +156,7 @@ class PublishModuleTest(ModuleCase, SaltReturnAssertsMixin):
         self.assertEqual(ret, {})
 
 
+@flaky
 class PublishWheelModuleTest(ModuleCase, SaltReturnAssertsMixin):
     '''
     Validate the publish.wheel module

--- a/tests/integration/modules/test_publish.py
+++ b/tests/integration/modules/test_publish.py
@@ -172,21 +172,21 @@ class PublishWheelModuleTest(ModuleCase, SaltReturnAssertsMixin):
 
     def test_publish_wheel_not_allowed(self):
         '''
-        test accepting key
+        test running a wheel function that is not allowed
         '''
         ret = self.run_function(
             'publish.wheel',
             ['key.list_all'],
         )
-        self.assertEqual(ret, {'minions': ['minion']})
+        self.assertEqual(ret, {})
 
     def test_publish_wheel_rejected(self):
         '''
-        test accepting key
+        test accepting key from a minion that isn't approved
         '''
         ret = self.run_function(
             'publish.wheel',
             ['key.accept', 'arg=minion'],
             minion_tgt='subminion',
         )
-        self.assertEqual(ret, {'minions': ['minion']})
+        self.assertEqual(ret, {})


### PR DESCRIPTION
### What does this PR do?
This is required to allow minions to use the wheel clients on the master.

Specifically this will be useful with the direction of allowing minions to bootstrap other minions and then tell the master to accept the new minions key.

### Tests written?

Yes

### Commits signed with GPG?

Yes