### PR TITLE
Virt fixes

### DIFF
--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -324,7 +324,7 @@ def _get_nics(dom):
     Get domain network interfaces from a libvirt domain object.
     '''
     nics = {}
-    doc = minidom.parse(_StringIO(dom.getXMLDesc(0)))
+    doc = minidom.parse(_StringIO(dom.XMLDesc(0)))
     for node in doc.getElementsByTagName('devices'):
         i_nodes = node.getElementsByTagName('interface')
         for i_node in i_nodes:
@@ -366,7 +366,7 @@ def _get_graphics(dom):
            'listen': 'None',
            'port': 'None',
            'type': 'None'}
-    xml = dom.getXMLDesc(0)
+    xml = dom.XMLDesc(0)
     ssock = _StringIO(xml)
     doc = minidom.parse(ssock)
     for node in doc.getElementsByTagName('domain'):
@@ -382,7 +382,7 @@ def _get_disks(dom):
     Get domain disks from a libvirt domain object.
     '''
     disks = {}
-    doc = minidom.parse(_StringIO(dom.getXMLDesc(0)))
+    doc = minidom.parse(_StringIO(dom.XMLDesc(0)))
     for elem in doc.getElementsByTagName('disk'):
         sources = elem.getElementsByTagName('source')
         targets = elem.getElementsByTagName('target')
@@ -2266,7 +2266,7 @@ def vm_diskstats(vm_=None, **kwargs):
         '''
         Extract the disk devices names from the domain XML definition
         '''
-        doc = minidom.parse(_StringIO(dom.getXMLDesc(0)))
+        doc = minidom.parse(_StringIO(dom.XMLDesc(0)))
         disks = []
         for elem in doc.getElementsByTagName('disk'):
             targets = elem.getElementsByTagName('target')

--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -1620,7 +1620,7 @@ def start(name, **kwargs):
         salt '*' virt.start <domain>
     '''
     conn = __get_conn(**kwargs)
-    ret = _get_domain(conn, name).create == 0
+    ret = _get_domain(conn, name).create() == 0
     conn.close()
     return ret
 

--- a/tests/unit/modules/test_virt.py
+++ b/tests/unit/modules/test_virt.py
@@ -49,7 +49,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         self.mock_conn.listDefinedDomains.return_value = [name]
         mock_domain = MagicMock()
         self.mock_conn.lookupByName.return_value = mock_domain
-        mock_domain.getXMLDesc.return_value = xml
+        mock_domain.XMLDesc.return_value = xml
 
         # Return state as shutdown
         mock_domain.info.return_value = [4, 0, 0, 0]


### PR DESCRIPTION
### What does this PR do?

This PR fixes bugs introduced during the last big virt module refactoring.

* `virt.start` doesn't do anything anymore
* `getXMLDesc` doesn't exist on virDomain objects

### What issues does this PR fix or reference?

None

### Tests written?

No: updated tests where possible

### Commits signed with GPG?

Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
