### PR TITLE
Fixes zabbix template components creation order

### DIFF
--- a/salt/states/zabbix_template.py
+++ b/salt/states/zabbix_template.py
@@ -24,11 +24,11 @@ log = logging.getLogger(__name__)
 TEMPLATE_RELATIONS = ['groups', 'hosts', 'macros']
 TEMPLATE_COMPONENT_ORDER = ('applications',
                             'items',
-                            'triggers',
                             'gitems',
                             'graphs',
                             'screens',
                             'httpTests',
+                            'triggers',
                             'discoveries')
 DISCOVERYRULE_COMPONENT_ORDER = ('itemprototypes', 'triggerprototypes', 'graphprototypes', 'hostprototypes')
 TEMPLATE_COMPONENT_DEF = {


### PR DESCRIPTION
### What does this PR do?
Fixes Zabbix Template components handling order.

### What issues does this PR fix or reference?
Previous pull request [#47398](https://github.com/saltstack/salt/pull/47398)

### Previous Behavior
If Zabbix Template have webchecks defined and then triggers on these webchecks should be created, it fails due to wrong order of Template component handling (i.e. triggers are processed before a webcheck item is created).

### New Behavior
Zabbix Template with webcheck triggers is created sucessfully.

### Tests written?

Yes.

### Commits signed with GPG?

Yes
