### PR TITLE
Populate productname grain on ARM Linux

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -2262,6 +2262,7 @@ def _hw_data(osdata):
         hwdata = {
             'manufacturer': 'manufacturer',
             'serialnumber': 'serial#',
+            'productname': 'DeviceDesc',
         }
         for grain_name, cmd_key in six.iteritems(hwdata):
             result = __salt__['cmd.run_all']('fw_printenv {0}'.format(cmd_key))


### PR DESCRIPTION
Populate the productname grain on ARM Linux from the
DeviceDesc UBOOT variable

Signed-off-by: Molly Kreis <molly.kreis@ni.com>
Reviewed-by: Rares POP <rares.pop@ni.com>

### What does this PR do?

Populate productname grain on ARM Linux

### Tests written?

No

### Commits signed with GPG?

No