### PR TITLE
Fix Azure RM cloud module network_resource_group handling

### DIFF
--- a/doc/topics/cloud/azurearm.rst
+++ b/doc/topics/cloud/azurearm.rst
@@ -235,9 +235,10 @@ etc) will be created in.
 
 network_resource_group
 ----------------------
-Optional. If specified, then the VM will be connected to the network resources
-in this group, rather than the group that it was created in. The VM interfaces
-and IPs will remain in the configured ``resource_group`` with the VM.
+Optional. If specified, then the VM will be connected to the virtual network
+in this resource group, rather than the parent resource group of the instance.
+The VM interfaces and IPs will remain in the configured ``resource_group`` with
+the VM.
 
 network
 -------

--- a/salt/cloud/clouds/azurearm.py
+++ b/salt/cloud/clouds/azurearm.py
@@ -329,13 +329,17 @@ def get_conn(client_type):
     return client
 
 
-def get_location(call=None):  # pylint: disable=unused-argument
+def get_location(call=None, kwargs=None):  # pylint: disable=unused-argument
     '''
     Return the location that is configured for this provider
     '''
+    if not kwargs:
+        kwargs = {}
+    vm_dict = get_configured_provider()
+    vm_dict.update(kwargs)
     return config.get_cloud_config_value(
         'location',
-        get_configured_provider(), __opts__, search_global=False
+        vm_dict, __opts__, search_global=False
     )
 
 
@@ -766,20 +770,28 @@ def create_network_interface(call=None, kwargs=None):
         )
 
     if kwargs.get('network_resource_group') is None:
-        kwargs['resource_group'] = config.get_cloud_config_value(
+        kwargs['network_resource_group'] = config.get_cloud_config_value(
             'resource_group', vm_, __opts__, search_global=False
         )
-    else:
-        kwargs['resource_group'] = kwargs['network_resource_group']
 
     if kwargs.get('iface_name') is None:
         kwargs['iface_name'] = '{0}-iface0'.format(vm_['name'])
 
-    subnet_obj = netconn.subnets.get(
-        resource_group_name=kwargs['resource_group'],
-        virtual_network_name=kwargs['network'],
-        subnet_name=kwargs['subnet'],
-    )
+    try:
+        subnet_obj = netconn.subnets.get(
+            resource_group_name=kwargs['network_resource_group'],
+            virtual_network_name=kwargs['network'],
+            subnet_name=kwargs['subnet'],
+        )
+    except CloudError as exc:
+        raise SaltCloudSystemExit(
+            '{0} (Resource Group: "{1}", VNET: "{2}", Subnet: "{3}")'.format(
+                exc.message,
+                kwargs['network_resource_group'],
+                kwargs['network'],
+                kwargs['subnet']
+            )
+        )
 
     ip_kwargs = {}
     ip_configurations = None
@@ -1377,10 +1389,10 @@ def create(vm_):
     __utils__['cloud.cachedir_index_add'](
         vm_['name'], vm_['profile'], 'azurearm', vm_['driver']
     )
-    location = get_location(vm_)
-    vm_['location'] = location
+    if not vm_.get('location'):
+        vm_['location'] = get_location(kwargs=vm_)
 
-    log.info('Creating Cloud VM %s in %s', vm_['name'], location)
+    log.info('Creating Cloud VM %s in %s', vm_['name'], vm_['location'])
 
     vm_request = request_instance(vm_=vm_)
 


### PR DESCRIPTION
### What does this PR do?
Fixes the behavior of `network_resource_group` to ensure that the virtual network is expected to be in that resource group while the instance and all associated objects created by the cloud module end up in `resource_group`.

### What issues does this PR fix or reference?
 #47794 

### Previous Behavior
Details in the issue.

### New Behavior
The virtual network is expected to be in `network_resource_group` while the instance and all associated objects created by the cloud module end up in `resource_group`.

### Tests written?
No

### Commits signed with GPG?
Yes