### PR TITLE
[2018.3] orchestration results False when function is False

### DIFF
--- a/salt/states/saltmod.py
+++ b/salt/states/saltmod.py
@@ -581,6 +581,9 @@ def function(
             m_ret = mdata['ret']
             m_func = (not fail_function and True) or __salt__[fail_function](m_ret)
 
+            if m_ret is False:
+                m_func = False
+
         if not m_func:
             if minion not in fail_minions:
                 fail.add(minion)

--- a/tests/integration/files/file/base/orch/issue30367/init.sls
+++ b/tests/integration/files/file/base/orch/issue30367/init.sls
@@ -1,0 +1,4 @@
+deploy_check:
+  salt.function:
+    - name: test.false
+    - tgt: minion

--- a/tests/integration/runners/test_state.py
+++ b/tests/integration/runners/test_state.py
@@ -257,6 +257,32 @@ class StateRunnerTest(ShellCase):
         self.assertEqual(count('Succeeded: 1', ret), 1)
         self.assertEqual(count('Failed:    0', ret), 1)
 
+    def test_orchestrate_salt_function_return_false_failure(self):
+        '''
+        Ensure that functions that only return False in the return
+        are flagged as failed when run as orchestrations.
+
+        See https://github.com/saltstack/salt/issues/30367
+        '''
+        self.run_run('saltutil.sync_modules')
+        ret = salt.utils.json.loads(
+            '\n'.join(
+                self.run_run('state.orchestrate orch.issue30367 --out=json')
+            )
+        )
+        # Drill down to the changes dict
+        state_result = ret['data']['master']['salt_|-deploy_check_|-test.false_|-function']['result']
+        func_ret = ret['data']['master']['salt_|-deploy_check_|-test.false_|-function']['changes']
+
+        self.assertEqual(
+            state_result,
+            False,
+        )
+
+        self.assertEqual(
+            func_ret,
+            {'out': 'highstate', 'ret': {'minion': False}}
+        )
 
 @skipIf(salt.utils.platform.is_windows(), '*NIX-only test')
 class OrchEventTest(ShellCase):

--- a/tests/integration/runners/test_state.py
+++ b/tests/integration/runners/test_state.py
@@ -284,6 +284,7 @@ class StateRunnerTest(ShellCase):
             {'out': 'highstate', 'ret': {'minion': False}}
         )
 
+
 @skipIf(salt.utils.platform.is_windows(), '*NIX-only test')
 class OrchEventTest(ShellCase):
     '''


### PR DESCRIPTION
### What does this PR do?
Updating function in saltmod to ensure that the result is a failure if the function being run returns as False.

### What issues does this PR fix or reference?
#30367 

### Previous Behavior
Previously functions that returned False would still return in a True result in the orchestration results.

### New Behavior
If the function being run in orchestration returns as False then the orchestration result is False.

### Tests written?
Yes

### Commits signed with GPG?

Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
