### PR TITLE
Don't issue warning if virt-what is not installed

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -605,11 +605,7 @@ def _virtual(osdata):
     if not salt.utils.platform.is_windows() and osdata['kernel'] not in skip_cmds:
         if salt.utils.path.which('virt-what'):
             _cmds = ['virt-what']
-        else:
-            log.debug(
-                'Please install \'virt-what\' to improve results of the '
-                '\'virtual\' grain.'
-            )
+
     # Check if enable_lspci is True or False
     if __opts__.get('enable_lspci', True) is True:
         # /proc/bus/pci does not exists, lspci will fail
@@ -789,14 +785,6 @@ def _virtual(osdata):
         elif command == 'virtinfo':
             grains['virtual'] = 'LDOM'
             break
-    else:
-        if osdata['kernel'] not in skip_cmds:
-            log.debug(
-                'All tools for virtual hardware identification failed to '
-                'execute because they do not exist on the system running this '
-                'instance or the user does not have the necessary permissions '
-                'to execute them. Grains output might not be accurate.'
-            )
 
     choices = ('Linux', 'HP-UX')
     isdir = os.path.isdir


### PR DESCRIPTION
### What does this PR do?

Remove misleading warning the `virt-what` is not installed. Salt is often run without this utility, and improvements since 2015.8.0 the make the virtual grain accurate on most platforms.

If the virtual grain is not filled in correctly, and we don't usually consider the installation of `virt-what` to be a substitute for improving other logic in `grains/core.py`.

### What issues does this PR fix or reference?

#47296

### Tests written?

No

### Commits signed with GPG?

Yes