### PR TITLE
Fix some major issues with the LGPO module

### DIFF
--- a/salt/modules/win_lgpo.py
+++ b/salt/modules/win_lgpo.py
@@ -35,7 +35,7 @@ Current known limitations
   - lxml
   - uuid
   - struct
-  - salt.modules.reg
+  - salt.utils.win_reg
 '''
 # Import Python libs
 from __future__ import absolute_import, unicode_literals, print_function
@@ -98,7 +98,7 @@ try:
     import lxml
     import struct
     from lxml import etree
-    from salt.modules.reg import Registry as Registry
+    from salt.utils.win_reg import Registry
     HAS_WINDOWS_MODULES = True
     TRUE_VALUE_XPATH = etree.XPath('.//*[local-name() = "trueValue"]')
     FALSE_VALUE_XPATH = etree.XPath('.//*[local-name() = "falseValue"]')
@@ -2672,9 +2672,12 @@ def __virtual__():
     '''
     Only works on Windows systems
     '''
-    if salt.utils.platform.is_windows() and HAS_WINDOWS_MODULES:
-        return __virtualname__
-    return False
+    if not salt.utils.platform.is_windows():
+        return False, 'win_lgpo: Not a Windows System'
+    if not HAS_WINDOWS_MODULES:
+        return False, 'win_lgpo: Required modules failed to load'
+    log.debug('win_lgpo: LGPO module loaded successfully')
+    return __virtualname__
 
 
 def _updateNamespace(item, new_namespace):
@@ -5372,7 +5375,7 @@ def set_(computer_policy=None, user_policy=None,
                         else:
                             raise SaltInvocationError(msg)
                         if policy_namespace and policy_name in _admTemplateData[policy_namespace] and the_policy is not None:
-                            log.debug('setting == %s', _admTemplateData[policy_namespace][policy_name].lower())
+                            log.debug('setting == %s', six.text_type(_admTemplateData[policy_namespace][policy_name]).lower())
                             log.debug(six.text_type(_admTemplateData[policy_namespace][policy_name]).lower())
                             if six.text_type(_admTemplateData[policy_namespace][policy_name]).lower() != 'disabled' \
                                     and six.text_type(_admTemplateData[policy_namespace][policy_name]).lower() != 'not configured':

--- a/salt/modules/win_lgpo.py
+++ b/salt/modules/win_lgpo.py
@@ -2676,7 +2676,6 @@ def __virtual__():
         return False, 'win_lgpo: Not a Windows System'
     if not HAS_WINDOWS_MODULES:
         return False, 'win_lgpo: Required modules failed to load'
-    log.debug('win_lgpo: LGPO module loaded successfully')
     return __virtualname__
 
 


### PR DESCRIPTION
### What does this PR do?
Fixes an issue where a `dict` was causing a stacktrace when creating the `log.debug` message.
Fixes a critical bug caused by the creation of the `salt.utils.win_reg` file which now contains the Registry object. (https://github.com/saltstack/salt/pull/47216)

### What issues does this PR fix or reference?
#47784 

### Previous Behavior
The LGPO module would fail to load

### New Behavior
Now it loads and handles dict values

### Tests written?
No

### Commits signed with GPG?
Yes