### PR TITLE
Fixup! add master.py:FileserverUpdate **kwargs

### DIFF
--- a/salt/master.py
+++ b/salt/master.py
@@ -349,8 +349,8 @@ class FileserverUpdate(salt.utils.process.SignalHandlingMultiprocessingProcess):
     '''
     A process from which to update any dynamic fileserver backends
     '''
-    def __init__(self, opts, log_queue=None):
-        super(FileserverUpdate, self).__init__(log_queue=log_queue)
+    def __init__(self, opts, **kwargs):
+        super(FileserverUpdate, self).__init__(**kwargs)
         self.opts = opts
         self.update_threads = {}
         # Avoid circular import
@@ -363,11 +363,17 @@ class FileserverUpdate(salt.utils.process.SignalHandlingMultiprocessingProcess):
     # process so that a register_after_fork() equivalent will work on Windows.
     def __setstate__(self, state):
         self._is_child = True
-        self.__init__(state['opts'], log_queue=state['log_queue'])
+        self.__init__(
+            state['opts'],
+            log_queue=state['log_queue'],
+            log_queue_level=state['log_queue_level']
+        )
 
     def __getstate__(self):
         return {'opts': self.opts,
-                'log_queue': self.log_queue}
+                'log_queue': self.log_queue,
+                'log_queue_level': self.log_queue_level
+        }
 
     def fill_buckets(self):
         '''


### PR DESCRIPTION
Fixup! add master.py:FileserverUpdate **kwargs

All classes inherited from salt/utils/process.py:MultiprocessingProcess 
must use **kwargs after commit 90edc69

Signed-off-by: Rares POP <rares.pop@ni.com>

### What does this PR do?
It fixes the master on Windows platform.

### What issues does this PR fix or reference?

### Previous Behavior
salt-master was broken

### Tests written?

No

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
