### PR TITLE
Fixing "installed:" in pkg.info

### DIFF
--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -555,7 +555,7 @@ def info_available(*names, **kwargs):
         if nfo.get('status'):
             nfo['status'] = nfo.get('status')
         if nfo.get('installed'):
-            nfo['installed'] = nfo.get('installed').lower() == 'yes' and True or False
+            nfo['installed'] = nfo.get('installed').lower().startswith( 'yes' ) and True or False
 
     return ret
 

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -555,7 +555,7 @@ def info_available(*names, **kwargs):
         if nfo.get('status'):
             nfo['status'] = nfo.get('status')
         if nfo.get('installed'):
-            nfo['installed'] = nfo.get('installed').lower().startswith( 'yes' ) and True or False
+            nfo['installed'] = nfo.get('installed').lower().startswith('yes')
 
     return ret
 


### PR DESCRIPTION
In some cases, ie. for packages that have been installed as dependency, zypper info's output will be "Installed      : Yes (automatically)" which will result in "Installed: False" when using pkg.info

Random example:

sles12sp3-7:~ # zypper info xev
Loading repository data...
Reading installed packages...

Information for package xev:
----------------------------
Repository     : @System
Name           : xev
Version        : 1.2.1-2.15
Arch           : x86_64
Vendor         : SUSE LLC <https://www.suse.com/>
Support Level  : unknown
Installed Size : 49.9 KiB
Installed      : Yes (automatically)

suma31:~ # salt sles12sp3-7 pkg.info xev
sles12sp3-7:
    ----------
    xev:
        ----------
        arch:
            x86_64
        installed:
            False

### Previous Behavior
pkg.info shows wrong information for some packages

### New Behavior
pkg.info shows correct information for these packages ;)

### Tests written?

No

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
