### PR TITLE
Tornado 5.0 is only supported on python 2 for now

### DIFF
--- a/doc/topics/releases/2017.7.6.rst
+++ b/doc/topics/releases/2017.7.6.rst
@@ -5,6 +5,16 @@ In Progress: Salt 2017.7.6 Release Notes
 Version 2017.7.6 is an **unreleased** bugfix release for :ref:`2017.7.0 <release-2017-7-0>`.
 This release is still in progress and has not been released yet.
 
+Tornado 5.0 Support for Python 2 Only
+-------------------------------------
+
+Tornado 5.0 moves to using asyncio for all python3 versions.  Because of this
+and changes in asyncio between python 3.4 and 3.5 to only be able to use one
+ioloop, which requires some rearchitecting, support for tornado 5.0 and python3
+versions of salt has been delayed to a later release.
+
+For now, to use tornado 5.0, the python 2 version of salt must be used.
+
 Option to Return to Previous Pillar Include Behavior
 ----------------------------------------------------
 

--- a/doc/topics/releases/2018.3.1.rst
+++ b/doc/topics/releases/2018.3.1.rst
@@ -5,6 +5,16 @@ In Progress: Salt 2018.3.1 Release Notes
 Version 2018.3.1 is an **unreleased** bugfix release for :ref:`2018.3.0 <release-2018-3-0>`.
 This release is still in progress and has not been released yet.
 
+Tornado 5.0 Support for Python 2 Only
+-------------------------------------
+
+Tornado 5.0 moves to using asyncio for all python3 versions.  Because of this
+and changes in asyncio between python 3.4 and 3.5 to only be able to use one
+ioloop, which requires some rearchitecting, support for tornado 5.0 and python3
+versions of salt has been delayed to a later release.
+
+For now, to use tornado 5.0, the python 2 version of salt must be used.
+
 Changes to Slack Engine pillars
 -------------------------------
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -5,6 +5,8 @@ msgpack>=0.5,!=0.5.5
 PyYAML
 MarkupSafe
 requests>=1.0.0
-tornado>=4.2.1,<6.0
+tornado>=4.2.1,<6.0; python_version < 3
+tornado>=4.2.1,<5.0; python_version >= 3.4
+
 # Required by Tornado to handle threads stuff.
 futures>=2.0


### PR DESCRIPTION
### What does this PR do?

Add release note documentation to only support tornado 5.0 on python2

### Commits signed with GPG?

Yes