### PR TITLE
Update 2017.7.6 release notes: remove "unreleased" text

### DIFF
--- a/doc/topics/releases/2017.7.6.rst
+++ b/doc/topics/releases/2017.7.6.rst
@@ -1,5 +1,5 @@
 ===========================
-In Progress: Salt 2017.7.6 Release Notes
+Salt 2017.7.6 Release Notes
 ===========================
 
 Version 2017.7.6 is a bugfix release for :ref:`2017.7.0 <release-2017-7-0>`.

--- a/doc/topics/releases/2017.7.6.rst
+++ b/doc/topics/releases/2017.7.6.rst
@@ -2,7 +2,7 @@
 In Progress: Salt 2017.7.6 Release Notes
 ===========================
 
-Version 2017.7.6 is an **unreleased** bugfix release for :ref:`2017.7.0 <release-2017-7-0>`.
+Version 2017.7.6 is a bugfix release for :ref:`2017.7.0 <release-2017-7-0>`.
 This release is still in progress and has not been released yet.
 
 Tornado 5.0 Support for Python 2 Only

--- a/doc/topics/releases/2017.7.6.rst
+++ b/doc/topics/releases/2017.7.6.rst
@@ -3,7 +3,6 @@ Salt 2017.7.6 Release Notes
 ===========================
 
 Version 2017.7.6 is a bugfix release for :ref:`2017.7.0 <release-2017-7-0>`.
-This release is still in progress and has not been released yet.
 
 Tornado 5.0 Support for Python 2 Only
 -------------------------------------


### PR DESCRIPTION
In preparation for the 2017.7.6 release, remove the "unreleased" text from the release notes.
