### PR TITLE
Add file read windows

### DIFF
--- a/salt/modules/win_file.py
+++ b/salt/modules/win_file.py
@@ -44,6 +44,7 @@ from salt.exceptions import CommandExecutionError, SaltInvocationError
 # Import salt libs
 import salt.utils
 import salt.utils.path
+import salt.utils.files
 from salt.modules.file import (check_hash,  # pylint: disable=W0611
         directory_exists, get_managed,
         check_managed, check_managed_changes, source_list,
@@ -52,7 +53,7 @@ from salt.modules.file import (check_hash,  # pylint: disable=W0611
         get_hash, manage_file, file_exists, get_diff, line, list_backups,
         __clean_tmp, check_file_meta, _binary_replace,
         _splitlines_preserving_trailing_newline, restore_backup,
-        access, copy, readdir, rmdir, truncate, replace, delete_backup,
+        access, copy, readdir, read, rmdir, truncate, replace, delete_backup,
         search, _get_flags, extract_hash, _error, _sed_esc, _psed,
         RE_FLAG_TABLE, blockreplace, prepend, seek_read, seek_write, rename,
         lstat, path_exists_glob, write, pardir, join, HASHES, HASHES_REVMAP,
@@ -109,7 +110,7 @@ def __virtual__():
             global contains_regex, contains_glob, get_source_sum
             global find, psed, get_sum, check_hash, get_hash, delete_backup
             global get_diff, line, _get_flags, extract_hash, comment_line
-            global access, copy, readdir, rmdir, truncate, replace, search
+            global access, copy, readdir, read, rmdir, truncate, replace, search
             global _binary_replace, _get_bkroot, list_backups, restore_backup
             global _splitlines_preserving_trailing_newline
             global blockreplace, prepend, seek_read, seek_write, rename, lstat
@@ -155,6 +156,7 @@ def __virtual__():
             access = _namespaced_function(access, globals())
             copy = _namespaced_function(copy, globals())
             readdir = _namespaced_function(readdir, globals())
+            read = _namespaced_function(read, globals())
             rmdir = _namespaced_function(rmdir, globals())
             truncate = _namespaced_function(truncate, globals())
             blockreplace = _namespaced_function(blockreplace, globals())


### PR DESCRIPTION
### What does this PR do?
Adds the `file.read` function to the `win_file.py` module

### Related Issue
https://github.com/saltstack/salt/issues/45520

### Previous Behavior
```
[root@localhost]# salt '*' file.read "C:\\salt\\conf\\minion"
win2016-2:
    ----------
    file.read:
        'file.read' is not available.
```
### New Behavior
```
[root@localhost _modules]# salt '*' myfile.read "C:\\salt\\conf\\minion"
win2016-2:
    master: 192.168.60.10
    log_level_logfile: debug
    startup_states: highstate
```

### Tests written?

No

### Commits signed with GPG?

No
