### PR TITLE
Revert job chunk wait time change

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -2065,7 +2065,7 @@ class State(object):
         while True:
             if self.reconcile_procs(running):
                 break
-            time.sleep(0.0001)
+            time.sleep(0.01)
         ret = dict(list(disabled.items()) + list(running.items()))
         return ret
 
@@ -2197,7 +2197,7 @@ class State(object):
             while True:
                 if self.reconcile_procs(run_dict):
                     break
-                time.sleep(0.0001)
+                time.sleep(0.01)
 
             for chunk in chunks:
                 tag = _gen_tag(chunk)


### PR DESCRIPTION
### What does this PR do?

Reverting the sleep time from 0.0001 back to 0.01, sleeping such a short
amount of time eats up CPU resources needlessly.

### What issues does this PR fix or reference?

### Previous Behavior

Sleeping 0.0001 seconds eats about 25% of a 2Ghz core. 

### New Behavior

Sleeping less allows things to run smoothly and preserves resources for things needing them.

### Tests written?

No

### Commits signed with GPG?

Yes