### PR TITLE
Fix ami role usage warts #47269

### DIFF
--- a/salt/utils/aws.py
+++ b/salt/utils/aws.py
@@ -89,9 +89,7 @@ def creds(provider):
                 proxies={'http': ''}, timeout=AWS_METADATA_TIMEOUT,
             )
             result.raise_for_status()
-            role = result.text.encode(
-                result.encoding if result.encoding else 'utf-8'
-            )
+            role = result.text
         except (requests.exceptions.HTTPError, requests.exceptions.ConnectionError):
             return provider['id'], provider['key'], ''
 
@@ -451,7 +449,7 @@ def query(params=None, setname=None, requesturl=None, location=None,
             log.debug('AWS Response Status Code: %s', result.status_code)
             log.trace(
                 'AWS Response Text: %s',
-                result.text.encode(result.encoding if result.encoding else 'utf-8')
+                result.text
             )
             result.raise_for_status()
             break
@@ -488,11 +486,7 @@ def query(params=None, setname=None, requesturl=None, location=None,
             return {'error': data}, requesturl
         return {'error': data}
 
-    response = result.text.encode(
-        result.encoding if result.encoding else 'utf-8'
-    )
-
-    root = ET.fromstring(response)
+    root = ET.fromstring(result.text)
     items = root[1]
     if return_root is True:
         items = root


### PR DESCRIPTION
### What does this PR do?

Fixes #47269 by removing 3 un-needed encode calls. Requests Response.text is unicode,
now that this file uses unicode_literals Response.text can by used
without having to encode it.

### What issues does this PR fix or reference?

#47269

### Previous Behavior

Calls using the AMI role fail.

### New Behavior

AMI credentials can be used succesfully

### Tests written?

No

### Commits signed with GPG?

Yes