### PR TITLE
Updating minion configuration doc

### DIFF
--- a/doc/ref/configuration/minion.rst
+++ b/doc/ref/configuration/minion.rst
@@ -2795,7 +2795,7 @@ The level of messages to send to the console. See also :conf_log:`log_level`.
 ``log_level_logfile``
 ---------------------
 
-Default: ``info``
+Default: ``warning``
 
 The level of messages to send to the log file. See also
 :conf_log:`log_level_logfile`. When it is not set explicitly


### PR DESCRIPTION
Correcting default value for log_level_logfile like written in default /etc/salt/minion. See #47893

### What does this PR do?

Correct documentation for log_level_logfile minion configuration

### What issues does this PR fix or reference?

Issue #47893 

### Tests written?

Not relevant

### Commits signed with GPG?

No
