### PR TITLE
salt-jenkins issue 1000

### DIFF
--- a/tests/integration/shell/test_call.py
+++ b/tests/integration/shell/test_call.py
@@ -408,7 +408,7 @@ class CallTest(ShellCase, testprogram.TestProgramCase, ShellCaseCommonTestsMixin
         with salt.utils.files.set_umask(0o077):
             try:
                 # Let's create an initial output file with some data
-                self.run_script(
+                stdout, stderr, retcode = self.run_script(
                     'salt-call',
                     '-c {0} --output-file={1} -g'.format(
                         self.get_config_dir(),
@@ -417,7 +417,20 @@ class CallTest(ShellCase, testprogram.TestProgramCase, ShellCaseCommonTestsMixin
                     catch_stderr=True,
                     with_retcode=True
                 )
-                stat1 = os.stat(output_file)
+                try:
+                    stat1 = os.stat(output_file)
+                except OSError:
+                    log.error(
+                        'run_script failed to generate output file:\n'
+                        'return code %d\n'
+                        'stdout:\n'
+                        '%s\n\n'
+                        'stderr\n'
+                        '%s',
+                        retcode, stdout, stderr
+                    )
+                    self.fail(
+                        'Failed to generate output file, see log for details')
 
                 # Let's change umask
                 os.umask(0o777)  # pylint: disable=blacklisted-function

--- a/tests/support/case.py
+++ b/tests/support/case.py
@@ -98,9 +98,14 @@ class ShellTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
                             script_name
                         )
                     )
-                sfh.write(
+                contents = (
                     '#!{0}\n'.format(sys.executable) +
                     '\n'.join(script_template).format(script_name.replace('salt-', ''))
+                )
+                sfh.write(contents)
+                log.debug(
+                    'Wrote the following contents to temp script %s:\n%s',
+                    script_path, contents
                 )
             st = os.stat(script_path)
             os.chmod(script_path, st.st_mode | stat.S_IEXEC)


### PR DESCRIPTION
This adds logging of the output and retcode when the output file fails to be created. As I have thus far been unable to reproduce this locally, this is the best shot at seeing what is causing the issue, since ShellCase's run_script is rather opaque about what happens in the script itself. We do know from the salt-runtests.log that the `salt-call -g` is successfully returning, what we don't know is what happened after that data was returned, and this should provide that insight.