### PR TITLE
Virt nets pools

### DIFF
--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -2895,3 +2895,26 @@ def pool_define_build(name, **kwargs):
         return (True, 'Pool exist')
 
     return True
+
+
+def list_pools(**kwargs):
+    '''
+    List all storage pools.
+
+    :param connection: libvirt connection URI, overriding defaults
+    :param username: username to connect with, overriding defaults
+    :param password: password to connect with, overriding defaults
+
+    ..versionadded:: Fluorine
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' virt.list_pools
+    '''
+    conn = __get_conn(**kwargs)
+    try:
+        return [pool.name() for pool in conn.listAllStoragePools()]
+    finally:
+        conn.close()

--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -3033,3 +3033,28 @@ def pool_stop(name, **kwargs):
         return not bool(pool.destroy())
     finally:
         conn.close()
+
+
+def pool_undefine(name, **kwargs):
+    '''
+    Remove a defined libvirt storage pool. The pool needs to be stopped before calling.
+
+    :param name: libvirt storage pool name
+    :param connection: libvirt connection URI, overriding defaults
+    :param username: username to connect with, overriding defaults
+    :param password: password to connect with, overriding defaults
+
+    ..versionadded:: Fluorine
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' virt.pool_undefine default
+    '''
+    conn = __get_conn(**kwargs)
+    try:
+        pool = conn.storagePoolLookupByName(name)
+        return not bool(pool.undefine())
+    finally:
+        conn.close()

--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -3141,3 +3141,28 @@ def pool_set_autostart(name, state='on', **kwargs):
         return not bool(pool.setAutostart(1 if state == 'on' else 0))
     finally:
         conn.close()
+
+
+def pool_list_volumes(name, **kwargs):
+    '''
+    List the volumes contained in a defined libvirt storage pool.
+
+    :param name: libvirt storage pool name
+    :param connection: libvirt connection URI, overriding defaults
+    :param username: username to connect with, overriding defaults
+    :param password: password to connect with, overriding defaults
+
+    ..versionadded:: Fluorine
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt "*" virt.pool_list_volumes <pool>
+    '''
+    conn = __get_conn(**kwargs)
+    try:
+        pool = conn.storagePoolLookupByName(name)
+        return pool.listVolumes()
+    finally:
+        conn.close()

--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -3113,3 +3113,31 @@ def pool_refresh(name, **kwargs):
         return not bool(pool.refresh())
     finally:
         conn.close()
+
+
+def pool_set_autostart(name, state='on', **kwargs):
+    '''
+    Set the autostart flag on a libvirt storage pool so that the storage pool
+    will start with the host system on reboot.
+
+    :param name: libvirt storage pool name
+    :param state: 'on' to auto start the pool, anything else to mark the
+                  pool not to be started when the host boots
+    :param connection: libvirt connection URI, overriding defaults
+    :param username: username to connect with, overriding defaults
+    :param password: password to connect with, overriding defaults
+
+    ..versionadded:: Fluorine
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt "*" virt.pool_set_autostart <pool> <on | off>
+    '''
+    conn = __get_conn(**kwargs)
+    try:
+        pool = conn.storagePoolLookupByName(name)
+        return not bool(pool.setAutostart(1 if state == 'on' else 0))
+    finally:
+        conn.close()

--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -2649,6 +2649,29 @@ def net_define(name, bridge, forward, **kwargs):
     return True
 
 
+def list_networks(**kwargs):
+    '''
+    List all virtual networks.
+
+    :param connection: libvirt connection URI, overriding defaults
+    :param username: username to connect with, overriding defaults
+    :param password: password to connect with, overriding defaults
+
+    ..versionadded:: Fluorine
+
+    CLI Example:
+
+    .. code-block:: bash
+
+       salt '*' virt.list_networks
+    '''
+    conn = __get_conn(**kwargs)
+    try:
+        return [net.name() for net in conn.listAllNetworks()]
+    finally:
+        conn.close()
+
+
 def pool_define_build(name, **kwargs):
     '''
     Create libvirt pool.

--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -2792,6 +2792,34 @@ def network_undefine(name, **kwargs):
         conn.close()
 
 
+def network_set_autostart(name, state='on', **kwargs):
+    '''
+    Set the autostart flag on a virtual network so that the network
+    will start with the host system on reboot.
+
+    :param name: virtual network name
+    :param state: 'on' to auto start the network, anything else to mark the
+                  virtual network not to be started when the host boots
+    :param connection: libvirt connection URI, overriding defaults
+    :param username: username to connect with, overriding defaults
+    :param password: password to connect with, overriding defaults
+
+    ..versionadded:: Fluorine
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt "*" virt.network_set_autostart <pool> <on | off>
+    '''
+    conn = __get_conn(**kwargs)
+    try:
+        net = conn.networkLookupByName(name)
+        return not bool(net.setAutostart(1 if state == 'on' else 0))
+    finally:
+        conn.close()
+
+
 def pool_define_build(name, **kwargs):
     '''
     Create libvirt pool.

--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -2717,6 +2717,56 @@ def network_info(name, **kwargs):
     return result
 
 
+def network_start(name, **kwargs):
+    '''
+    Start a defined virtual network.
+
+    :param name: virtual network name
+    :param connection: libvirt connection URI, overriding defaults
+    :param username: username to connect with, overriding defaults
+    :param password: password to connect with, overriding defaults
+
+    ..versionadded:: Fluorine
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' virt.network_start default
+    '''
+    conn = __get_conn(**kwargs)
+    try:
+        net = conn.networkLookupByName(name)
+        return not bool(net.create())
+    finally:
+        conn.close()
+
+
+def network_stop(name, **kwargs):
+    '''
+    Stop a defined virtual network.
+
+    :param name: virtual network name
+    :param connection: libvirt connection URI, overriding defaults
+    :param username: username to connect with, overriding defaults
+    :param password: password to connect with, overriding defaults
+
+    ..versionadded:: Fluorine
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' virt.network_stop default
+    '''
+    conn = __get_conn(**kwargs)
+    try:
+        net = conn.networkLookupByName(name)
+        return not bool(net.destroy())
+    finally:
+        conn.close()
+
+
 def pool_define_build(name, **kwargs):
     '''
     Create libvirt pool.

--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -2767,6 +2767,31 @@ def network_stop(name, **kwargs):
         conn.close()
 
 
+def network_undefine(name, **kwargs):
+    '''
+    Remove a defined virtual network. This does not stop the virtual network.
+
+    :param name: virtual network name
+    :param connection: libvirt connection URI, overriding defaults
+    :param username: username to connect with, overriding defaults
+    :param password: password to connect with, overriding defaults
+
+    ..versionadded:: Fluorine
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' virt.network_undefine default
+    '''
+    conn = __get_conn(**kwargs)
+    try:
+        net = conn.networkLookupByName(name)
+        return not bool(net.undefine())
+    finally:
+        conn.close()
+
+
 def pool_define_build(name, **kwargs):
     '''
     Create libvirt pool.

--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -2958,3 +2958,78 @@ def pool_info(name, **kwargs):
     finally:
         conn.close()
     return result
+
+
+def pool_start(name, **kwargs):
+    '''
+    Start a defined libvirt storage pool.
+
+    :param name: libvirt storage pool name
+    :param connection: libvirt connection URI, overriding defaults
+    :param username: username to connect with, overriding defaults
+    :param password: password to connect with, overriding defaults
+
+    ..versionadded:: Fluorine
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' virt.pool_start default
+    '''
+    conn = __get_conn(**kwargs)
+    try:
+        pool = conn.storagePoolLookupByName(name)
+        ret = not bool(pool.create())
+    finally:
+        conn.close()
+
+
+def pool_build(name, **kwargs):
+    '''
+    Build a defined libvirt storage pool.
+
+    :param name: libvirt storage pool name
+    :param connection: libvirt connection URI, overriding defaults
+    :param username: username to connect with, overriding defaults
+    :param password: password to connect with, overriding defaults
+
+    ..versionadded:: Fluorine
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' virt.pool_build default
+    '''
+    conn = __get_conn(**kwargs)
+    try:
+        pool = conn.storagePoolLookupByName(name)
+        return not bool(pool.build())
+    finally:
+        conn.close()
+
+
+def pool_stop(name, **kwargs):
+    '''
+    Stop a defined libvirt storage pool.
+
+    :param name: libvirt storage pool name
+    :param connection: libvirt connection URI, overriding defaults
+    :param username: username to connect with, overriding defaults
+    :param password: password to connect with, overriding defaults
+
+    ..versionadded:: Fluorine
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' virt.pool_stop default
+    '''
+    conn = __get_conn(**kwargs)
+    try:
+        pool = conn.storagePoolLookupByName(name)
+        return not bool(pool.destroy())
+    finally:
+        conn.close()

--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -3088,3 +3088,28 @@ def pool_delete(name, fast=True, **kwargs):
         return not bool(pool.delete(flags))
     finally:
         conn.close()
+
+
+def pool_refresh(name, **kwargs):
+    '''
+    Refresh a defined libvirt storage pool.
+
+    :param name: libvirt storage pool name
+    :param connection: libvirt connection URI, overriding defaults
+    :param username: username to connect with, overriding defaults
+    :param password: password to connect with, overriding defaults
+
+    ..versionadded:: Fluorine
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' virt.pool_refresh default
+    '''
+    conn = __get_conn(**kwargs)
+    try:
+        pool = conn.storagePoolLookupByName(name)
+        return not bool(pool.refresh())
+    finally:
+        conn.close()

--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -3058,3 +3058,33 @@ def pool_undefine(name, **kwargs):
         return not bool(pool.undefine())
     finally:
         conn.close()
+
+
+def pool_delete(name, fast=True, **kwargs):
+    '''
+    Delete the resources of a defined libvirt storage pool.
+
+    :param name: libvirt storage pool name
+    :param fast: if set to False, zeroes out all the data.
+                 Default value is True.
+    :param connection: libvirt connection URI, overriding defaults
+    :param username: username to connect with, overriding defaults
+    :param password: password to connect with, overriding defaults
+
+    ..versionadded:: Fluorine
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' virt.pool_delete default
+    '''
+    conn = __get_conn(**kwargs)
+    try:
+        pool = conn.storagePoolLookupByName(name)
+        flags = libvirt.VIR_STORAGE_POOL_DELETE_NORMAL
+        if fast:
+            flags = libvirt.VIR_STORAGE_POOL_DELETE_ZEROED
+        return not bool(pool.delete(flags))
+    finally:
+        conn.close()

--- a/tests/unit/modules/test_virt.py
+++ b/tests/unit/modules/test_virt.py
@@ -884,3 +884,15 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
             self.mock_libvirt.libvirtError("Pool not found")  # pylint: disable=no-member
         pool = virt.pool_info('foo')
         self.assertEqual({}, pool)
+
+    def test_pool_list_volumes(self):
+        '''
+        Test virt.pool_list_volumes
+        '''
+        names = ['volume1', 'volume2']
+        mock_pool = MagicMock()
+        # pylint: disable=no-member
+        mock_pool.listVolumes.return_value = names
+        self.mock_conn.storagePoolLookupByName.return_value = mock_pool
+        # pylint: enable=no-member
+        self.assertEqual(names, virt.pool_list_volumes('default'))

--- a/tests/unit/modules/test_virt.py
+++ b/tests/unit/modules/test_virt.py
@@ -745,6 +745,19 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         self.assertEqual(root.find('virtualport').attrib['type'], 'openvswitch')
         self.assertEqual(root.find('vlan/tag').attrib['id'], '1001')
 
+    def test_list_networks(self):
+        '''
+        Test virt.list_networks()
+        '''
+        names = ['net1', 'default', 'net2']
+        net_mocks = [MagicMock(), MagicMock(), MagicMock()]
+        for i, value in enumerate(names):
+            net_mocks[i].name.return_value = value
+
+        self.mock_conn.listAllNetworks.return_value = net_mocks  # pylint: disable=no-member
+        actual = virt.list_networks()
+        self.assertEqual(names, actual)
+
     def test_pool(self):
         '''
         Test virt._gen_pool_xml()

--- a/tests/unit/modules/test_virt.py
+++ b/tests/unit/modules/test_virt.py
@@ -839,3 +839,16 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         self.assertEqual(root.attrib['type'], 'logical')
         self.assertEqual(root.find('target/path').text, '/dev/base')
         self.assertEqual(root.find('source/device').attrib['path'], '/dev/sda')
+
+    def test_list_pools(self):
+        '''
+        Test virt.list_pools()
+        '''
+        names = ['pool1', 'default', 'pool2']
+        pool_mocks = [MagicMock(), MagicMock(), MagicMock()]
+        for i, value in enumerate(names):
+            pool_mocks[i].name.return_value = value
+
+        self.mock_conn.listAllStoragePools.return_value = pool_mocks  # pylint: disable=no-member
+        actual = virt.list_pools()
+        self.assertEqual(names, actual)

--- a/tests/unit/modules/test_virt.py
+++ b/tests/unit/modules/test_virt.py
@@ -1,4 +1,7 @@
 # -*- coding: utf-8 -*-
+'''
+virt execution module unit tests
+'''
 
 # Import python libs
 from __future__ import absolute_import, print_function, unicode_literals
@@ -21,14 +24,25 @@ import salt.config
 from salt.ext import six
 
 
-class LibvirtMock(MagicMock):
+# pylint: disable=invalid-name,protected-access,attribute-defined-outside-init,too-many-public-methods,unused-argument
+
+
+class LibvirtMock(MagicMock):  # pylint: disable=too-many-ancestors
+    '''
+    Libvirt library mock
+    '''
 
     class libvirtError(Exception):
-        pass
+        '''
+        libvirtError mock
+        '''
 
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
 class VirtTestCase(TestCase, LoaderModuleMockMixin):
+    '''
+    Test cases for salt.module.virt
+    '''
 
     def setup_loader_modules(self):
         self.mock_libvirt = LibvirtMock()
@@ -46,15 +60,21 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         return {virt: loader_globals, config: loader_globals}
 
     def set_mock_vm(self, name, xml):
-        self.mock_conn.listDefinedDomains.return_value = [name]
+        '''
+        Define VM to use in tests
+        '''
+        self.mock_conn.listDefinedDomains.return_value = [name]  # pylint: disable=no-member
         mock_domain = MagicMock()
-        self.mock_conn.lookupByName.return_value = mock_domain
-        mock_domain.XMLDesc.return_value = xml
+        self.mock_conn.lookupByName.return_value = mock_domain  # pylint: disable=no-member
+        mock_domain.XMLDesc.return_value = xml  # pylint: disable=no-member
 
         # Return state as shutdown
-        mock_domain.info.return_value = [4, 0, 0, 0]
+        mock_domain.info.return_value = [4, 0, 0, 0]  # pylint: disable=no-member
 
     def test_boot_default_dev(self):
+        '''
+        Test virt_gen_xml() default boot device
+        '''
         diskp = virt._disk_profile('default', 'kvm')
         nicp = virt._nic_profile('default', 'kvm')
         xml_data = virt._gen_xml(
@@ -69,6 +89,9 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         self.assertEqual(root.find('os/boot').attrib['dev'], 'hd')
 
     def test_boot_custom_dev(self):
+        '''
+        Test virt_gen_xml() custom boot device
+        '''
         diskp = virt._disk_profile('default', 'kvm')
         nicp = virt._nic_profile('default', 'kvm')
         xml_data = virt._gen_xml(
@@ -84,6 +107,9 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         self.assertEqual(root.find('os/boot').attrib['dev'], 'cdrom')
 
     def test_boot_multiple_devs(self):
+        '''
+        Test virt_gen_xml() multiple boot devices
+        '''
         diskp = virt._disk_profile('default', 'kvm')
         nicp = virt._nic_profile('default', 'kvm')
         xml_data = virt._gen_xml(
@@ -100,6 +126,9 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         self.assertTrue(len(devs) == 2)
 
     def test_gen_xml_for_serial_console(self):
+        '''
+        Test virt_gen_xml() serial console
+        '''
         diskp = virt._disk_profile('default', 'kvm')
         nicp = virt._nic_profile('default', 'kvm')
         xml_data = virt._gen_xml(
@@ -117,6 +146,9 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         self.assertEqual(root.find('devices/console').attrib['type'], 'pty')
 
     def test_gen_xml_for_telnet_console(self):
+        '''
+        Test virt_gen_xml() telnet console
+        '''
         diskp = virt._disk_profile('default', 'kvm')
         nicp = virt._nic_profile('default', 'kvm')
         xml_data = virt._gen_xml(
@@ -136,6 +168,9 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         self.assertEqual(root.find('devices/console/source').attrib['service'], '22223')
 
     def test_gen_xml_for_telnet_console_unspecified_port(self):
+        '''
+        Test virt_gen_xml() telnet console without any specified port
+        '''
         diskp = virt._disk_profile('default', 'kvm')
         nicp = virt._nic_profile('default', 'kvm')
         xml_data = virt._gen_xml(
@@ -154,6 +189,9 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         self.assertIsInstance(int(root.find('devices/console/source').attrib['service']), int)
 
     def test_gen_xml_for_serial_no_console(self):
+        '''
+        Test virt_gen_xml() with no serial console
+        '''
         diskp = virt._disk_profile('default', 'kvm')
         nicp = virt._nic_profile('default', 'kvm')
         xml_data = virt._gen_xml(
@@ -171,6 +209,9 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         self.assertEqual(root.find('devices/console'), None)
 
     def test_gen_xml_for_telnet_no_console(self):
+        '''
+        Test virt_gen_xml() with no telnet console
+        '''
         diskp = virt._disk_profile('default', 'kvm')
         nicp = virt._nic_profile('default', 'kvm')
         xml_data = virt._gen_xml(
@@ -188,8 +229,11 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         self.assertEqual(root.find('devices/console'), None)
 
     def test_default_disk_profile_hypervisor_esxi(self):
+        '''
+        Test virt._disk_profile() default ESXi profile
+        '''
         mock = MagicMock(return_value={})
-        with patch.dict(virt.__salt__, {'config.get': mock}):
+        with patch.dict(virt.__salt__, {'config.get': mock}):  # pylint: disable=no-member
             ret = virt._disk_profile('nonexistent', 'esxi')
             self.assertTrue(len(ret) == 1)
             self.assertIn('system', ret[0])
@@ -199,8 +243,11 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
             self.assertTrue(int(system['size']) >= 1)
 
     def test_default_disk_profile_hypervisor_kvm(self):
+        '''
+        Test virt._disk_profile() default KVM profile
+        '''
         mock = MagicMock(return_value={})
-        with patch.dict(virt.__salt__, {'config.get': mock}):
+        with patch.dict(virt.__salt__, {'config.get': mock}):  # pylint: disable=no-member
             ret = virt._disk_profile('nonexistent', 'kvm')
             self.assertTrue(len(ret) == 1)
             self.assertIn('system', ret[0])
@@ -210,8 +257,11 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
             self.assertTrue(int(system['size']) >= 1)
 
     def test_default_nic_profile_hypervisor_esxi(self):
+        '''
+        Test virt._nic_profile() default ESXi profile
+        '''
         mock = MagicMock(return_value={})
-        with patch.dict(virt.__salt__, {'config.get': mock}):
+        with patch.dict(virt.__salt__, {'config.get': mock}):  # pylint: disable=no-member
             ret = virt._nic_profile('nonexistent', 'esxi')
             self.assertTrue(len(ret) == 1)
             eth0 = ret[0]
@@ -221,8 +271,11 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
             self.assertEqual(eth0['model'], 'e1000')
 
     def test_default_nic_profile_hypervisor_kvm(self):
+        '''
+        Test virt._nic_profile() default KVM profile
+        '''
         mock = MagicMock(return_value={})
-        with patch.dict(virt.__salt__, {'config.get': mock}):
+        with patch.dict(virt.__salt__, {'config.get': mock}):  # pylint: disable=no-member
             ret = virt._nic_profile('nonexistent', 'kvm')
             self.assertTrue(len(ret) == 1)
             eth0 = ret[0]
@@ -232,6 +285,9 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
             self.assertEqual(eth0['model'], 'virtio')
 
     def test_gen_vol_xml_for_kvm(self):
+        '''
+        Test virt._get_vol_xml(), KVM case
+        '''
         xml_data = virt._gen_vol_xml('vmname', 'system', 8192, 'kvm')
         root = ET.fromstring(xml_data)
         self.assertEqual(root.find('name').text, 'vmname/system.qcow2')
@@ -240,6 +296,9 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         self.assertEqual(root.find('capacity').text, six.text_type(8192 * 1024))
 
     def test_gen_vol_xml_for_esxi(self):
+        '''
+        Test virt._get_vol_xml(), ESXi case
+        '''
         xml_data = virt._gen_vol_xml('vmname', 'system', 8192, 'esxi')
         root = ET.fromstring(xml_data)
         self.assertEqual(root.find('name').text, 'vmname/system.vmdk')
@@ -248,6 +307,9 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         self.assertEqual(root.find('capacity').text, six.text_type(8192 * 1024))
 
     def test_gen_xml_for_kvm_default_profile(self):
+        '''
+        Test virt._gen_xml(), KVM default profile case
+        '''
         diskp = virt._disk_profile('default', 'kvm')
         nicp = virt._nic_profile('default', 'kvm')
         xml_data = virt._gen_xml(
@@ -287,6 +349,9 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
               re.match('^([0-9A-F]{2}[:-]){5}([0-9A-F]{2})$', mac, re.I))
 
     def test_gen_xml_for_esxi_default_profile(self):
+        '''
+        Test virt._gen_xml(), ESXi default profile case
+        '''
         diskp = virt._disk_profile('default', 'esxi')
         nicp = virt._nic_profile('default', 'esxi')
         xml_data = virt._gen_xml(
@@ -324,6 +389,9 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
               re.match('^([0-9A-F]{2}[:-]){5}([0-9A-F]{2})$', mac, re.I))
 
     def test_gen_xml_for_esxi_custom_profile(self):
+        '''
+        Test virt._gen_xml(), ESXi custom profile case
+        '''
         diskp_yaml = '''
 - first:
     size: 8192
@@ -332,8 +400,8 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
     pool: datastore1
 - second:
     size: 4096
-    format: vmdk  # FIX remove line, currently test fails
-    model: scsi   # FIX remove line, currently test fails
+    format: vmdk
+    model: scsi
     pool: datastore2
 '''
         nicp_yaml = '''
@@ -371,6 +439,9 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
             self.assertTrue(len(root.findall('.//interface')) == 2)
 
     def test_gen_xml_for_kvm_custom_profile(self):
+        '''
+        Test virt._gen_xml(), KVM custom profile case
+        '''
         diskp_yaml = '''
 - first:
     size: 8192
@@ -379,8 +450,8 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
     pool: /var/lib/images
 - second:
     size: 4096
-    format: qcow2   # FIX remove line, currently test fails
-    model: virtio   # FIX remove line, currently test fails
+    format: qcow2
+    model: virtio
     pool: /var/lib/images
 '''
         nicp_yaml = '''
@@ -418,6 +489,9 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
             self.assertTrue(len(root.findall('.//interface')) == 2)
 
     def test_controller_for_esxi(self):
+        '''
+        Test virt._gen_xml() generated device controller for ESXi
+        '''
         diskp = virt._disk_profile('default', 'esxi')
         nicp = virt._nic_profile('default', 'esxi')
         xml_data = virt._gen_xml(
@@ -435,6 +509,9 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         self.assertEqual(controller.attrib['model'], 'lsilogic')
 
     def test_controller_for_kvm(self):
+        '''
+        Test virt._gen_xml() generated device controller for KVM
+        '''
         diskp = virt._disk_profile('default', 'kvm')
         nicp = virt._nic_profile('default', 'kvm')
         xml_data = virt._gen_xml(
@@ -453,7 +530,9 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         self.assertTrue("mac address='52:54:00" in xml_data)
 
     def test_mixed_dict_and_list_as_profile_objects(self):
-
+        '''
+        Test virt._nic_profile with mixed dictionaries and lists as input.
+        '''
         yaml_config = '''
           virt:
              nic:
@@ -478,7 +557,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
                       model: virtio
         '''
         mock_config = salt.utils.yaml.safe_load(yaml_config)
-        with patch.dict(salt.modules.config.__opts__, mock_config):
+        with patch.dict(salt.modules.config.__opts__, mock_config):  # pylint: disable=no-member
 
             for name in six.iterkeys(mock_config['virt']['nic']):
                 profile = salt.modules.virt._nic_profile(name, 'kvm')
@@ -493,9 +572,12 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
                 self.assertIn('mac', interface_attrs)
                 self.assertTrue(
                     re.match('^([0-9A-F]{2}[:-]){5}([0-9A-F]{2})$',
-                    interface_attrs['mac'], re.I))
+                             interface_attrs['mac'], re.I))
 
     def test_get_graphics(self):
+        '''
+        Test virt.get_graphics()
+        '''
         xml = '''<domain type='kvm' id='7'>
               <name>test-vm</name>
               <devices>
@@ -513,6 +595,9 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         self.assertEqual('0.0.0.0', graphics['listen'])
 
     def test_get_nics(self):
+        '''
+        Test virt.get_nics()
+        '''
         xml = '''<domain type='kvm' id='7'>
               <name>test-vm</name>
               <devices>
@@ -535,6 +620,9 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
     @patch('subprocess.Popen')
     @patch('subprocess.Popen.communicate', return_value="")
     def test_get_disks(self, mock_communicate, mock_popen):
+        '''
+        Test virt.get_discs()
+        '''
         xml = '''<domain type='kvm' id='7'>
               <name>test-vm</name>
               <devices>
@@ -568,6 +656,9 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
     @patch('salt.modules.virt.undefine')
     @patch('os.remove')
     def test_purge_default(self, mock_remove, mock_undefine, mock_stop, mock_communicate, mock_popen):
+        '''
+        Test virt.purge() with default parameters
+        '''
         xml = '''<domain type='kvm' id='7'>
               <name>test-vm</name>
               <devices>
@@ -598,7 +689,9 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
     @patch('salt.modules.virt.undefine')
     @patch('os.remove')
     def test_purge_noremovable(self, mock_remove, mock_undefine, mock_stop, mock_communicate, mock_popen):
-
+        '''
+        Test virt.purge(removables=False)
+        '''
         xml = '''<domain type='kvm' id='7'>
               <name>test-vm</name>
               <devices>
@@ -630,6 +723,9 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         mock_remove.assert_any_call('/disks/test.qcow2')
 
     def test_network(self):
+        '''
+        Test virt._get_net_xml()
+        '''
         xml_data = virt._gen_net_xml('network', 'main', 'bridge', 'openvswitch')
         root = ET.fromstring(xml_data)
         self.assertEqual(root.find('name').text, 'network')
@@ -638,6 +734,9 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         self.assertEqual(root.find('virtualport').attrib['type'], 'openvswitch')
 
     def test_network_tag(self):
+        '''
+        Test virt._get_net_xml() with VLAN tag
+        '''
         xml_data = virt._gen_net_xml('network', 'main', 'bridge', 'openvswitch', 1001)
         root = ET.fromstring(xml_data)
         self.assertEqual(root.find('name').text, 'network')
@@ -647,6 +746,9 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         self.assertEqual(root.find('vlan/tag').attrib['id'], '1001')
 
     def test_pool(self):
+        '''
+        Test virt._gen_pool_xml()
+        '''
         xml_data = virt._gen_pool_xml('pool', 'logical', 'base')
         root = ET.fromstring(xml_data)
         self.assertEqual(root.find('name').text, 'pool')
@@ -654,6 +756,9 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         self.assertEqual(root.find('target/path').text, '/dev/base')
 
     def test_pool_with_source(self):
+        '''
+        Test virt._gen_pool_xml() with a source device
+        '''
         xml_data = virt._gen_pool_xml('pool', 'logical', 'base', 'sda')
         root = ET.fromstring(xml_data)
         self.assertEqual(root.find('name').text, 'pool')


### PR DESCRIPTION
### What does this PR do?

Add functions to the virt execution module to manage libvirt networks and storage pools.
As a follow up, a future PR will add functions to manage storage volumes.

### What issues does this PR fix or reference?

None

### Tests written?

Yes, but no unit tests were written for the state changing functions since these wouldn't be super useful.

Note: the virt module unit tests are no pylint-clean!

### Commits signed with GPG?

Yes