### PR TITLE
Align SUSE salt-master.service 'LimitNOFILES' limit with upstream Salt

### DIFF
--- a/pkg/suse/salt-master.service
+++ b/pkg/suse/salt-master.service
@@ -4,7 +4,7 @@ Documentation=man:salt-master(1) file:///usr/share/doc/salt/html/contents.html h
 After=network.target
 
 [Service]
-LimitNOFILE=16384
+LimitNOFILE=100000
 Type=simple
 ExecStart=/usr/bin/salt-master
 TasksMax=infinity


### PR DESCRIPTION
### What does this PR do?
This PR aligns the `pkg/suse/salt-master.service` file (used for SUSE packaging) with this changes introduced on https://github.com/saltstack/salt/pull/45688 to the main `salt-master.service` file.

### Tests written?

No

### Commits signed with GPG?

Yes