### PR TITLE
Fix salt.states.pkg.latest for IPS packages on Solaris

### DIFF
--- a/salt/modules/solarisips.py
+++ b/salt/modules/solarisips.py
@@ -466,7 +466,7 @@ def install(name=None, refresh=False, pkgs=None, version=None, test=False, **kwa
     '''
     if not pkgs:
         if is_installed(name):
-            return 'Package already installed.'
+            return {}
 
     if refresh:
         refresh_db(full=True)

--- a/salt/modules/solarisips.py
+++ b/salt/modules/solarisips.py
@@ -355,6 +355,10 @@ def latest_version(*names, **kwargs):
 
     installed = version(*names)
 
+    if len(names) == 1:
+        # Convert back our result in a dict if only one name is passed
+        installed = { list(ret.keys())[0] if len(ret) > 0 else names[0]: installed }
+
     for name in ret:
         if not name in installed:
             continue

--- a/salt/modules/solarisips.py
+++ b/salt/modules/solarisips.py
@@ -310,7 +310,7 @@ def version(*names, **kwargs):
         ret[_ips_get_pkgname(line)] = _ips_get_pkgversion(line)
 
     # Append package names which are not installed/found
-    unmatched = list(filter(lambda name: not reduce(lambda x, y : x or name in y, ret.keys(), False), names))
+    unmatched = list(filter(lambda name: not reduce(lambda x, y : x or name in y, ret), False), names))
     ret.update(zip(unmatched, [ '' ] * len(unmatched)))
 
     # Return a string if only one package name passed
@@ -357,7 +357,7 @@ def latest_version(*names, **kwargs):
 
     if len(names) == 1:
         # Convert back our result in a dict if only one name is passed
-        installed = { list(ret.keys())[0] if len(ret) > 0 else names[0]: installed }
+        installed = { list(ret)[0] if len(ret) > 0 else names[0]: installed }
 
     for name in ret:
         if not name in installed:
@@ -366,7 +366,7 @@ def latest_version(*names, **kwargs):
             ret[name] = ''
 
     # Append package names which are not found
-    unmatched = list(filter(lambda name: not reduce(lambda x, y : x or name in y, ret.keys(), False), names))
+    unmatched = list(filter(lambda name: not reduce(lambda x, y : x or name in y, ret, False), names))
     ret.update(zip(unmatched, [ '' ] * len(unmatched)))
 
     # Return a string if only one package name passed

--- a/salt/modules/solarisips.py
+++ b/salt/modules/solarisips.py
@@ -332,7 +332,7 @@ def latest_version(*names, **kwargs):
     Please use pkg.latest_version as pkg.available_version is being deprecated.
 
     .. versionchanged:: Fluorine
-        Argument changed from 'name' to '*names' tu support multiple packages.
+        Support for multiple package names added.
 
     CLI Example:
 

--- a/salt/modules/solarisips.py
+++ b/salt/modules/solarisips.py
@@ -314,7 +314,7 @@ def version(*names, **kwargs):
     ret.update(zip(unmatched, [ '' ] * len(unmatched)))
 
     # Return a string if only one package name passed
-    if len(ret) == 1:
+    if len(names) == 1:
         return list(ret.values())[0]
 
     return ret
@@ -366,7 +366,7 @@ def latest_version(*names, **kwargs):
     ret.update(zip(unmatched, [ '' ] * len(unmatched)))
 
     # Return a string if only one package name passed
-    if len(ret) == 1:
+    if len(names) == 1:
         return list(ret.values())[0]
 
     return ret

--- a/salt/modules/solarisips.py
+++ b/salt/modules/solarisips.py
@@ -314,7 +314,7 @@ def version(*names, **kwargs):
         ret[_ips_get_pkgname(line)] = _ips_get_pkgversion(line)
 
     # Append package names which are not installed/found
-    unmatched = list(filter(lambda name: not reduce(lambda x, y : x or name in y, ret), False), names))
+    unmatched = list(filter(lambda name: not reduce(lambda x, y : x or name in y, ret, False), names))
     ret.update(zip(unmatched, itertools.cycle(('',))))
 
     # Return a string if only one package name passed

--- a/salt/modules/solarisips.py
+++ b/salt/modules/solarisips.py
@@ -314,8 +314,8 @@ def version(*names, **kwargs):
     ret.update(zip(unmatched, [ '' ] * len(unmatched)))
 
     # Return a string if only one package name passed
-    if len(names) == 1:
-        return ret[names[0]]
+    if len(ret) == 1:
+        return list(ret.values())[0]
 
     return ret
 
@@ -366,8 +366,8 @@ def latest_version(*names, **kwargs):
     ret.update(zip(unmatched, [ '' ] * len(unmatched)))
 
     # Return a string if only one package name passed
-    if len(names) == 1:
-        return ret[names[0]]
+    if len(ret) == 1:
+        return list(ret.values())[0]
 
     return ret
 

--- a/salt/modules/solarisips.py
+++ b/salt/modules/solarisips.py
@@ -342,9 +342,11 @@ def latest_version(*names, **kwargs):
         if ret[name] == installed[name]:
             ret[name] = ''
 
-    if ret:
-        return ret
-    return ''
+    # Return a string if only one package name passed
+    if len(names) == 1:
+        return ret[names[0]]
+
+    return ret
 
 # available_version is being deprecated
 available_version = salt.utils.functools.alias_function(latest_version, 'available_version')

--- a/salt/modules/solarisips.py
+++ b/salt/modules/solarisips.py
@@ -47,6 +47,7 @@ import salt.utils.functools
 import salt.utils.path
 import salt.utils.pkg
 from salt.exceptions import CommandExecutionError
+from salt.ext import six
 
 # Define the module's virtual name
 __virtualname__ = 'pkg'
@@ -315,7 +316,10 @@ def version(*names, **kwargs):
 
     # Return a string if only one package name passed
     if len(names) == 1:
-        return list(ret.values())[0]
+        try:
+            return next(six.itervalues(ret))
+        except StopIteration:
+            return ''
 
     return ret
 
@@ -371,7 +375,10 @@ def latest_version(*names, **kwargs):
 
     # Return a string if only one package name passed
     if len(names) == 1:
-        return list(ret.values())[0]
+        try:
+            return next(six.itervalues(ret))
+        except StopIteration:
+            return ''
 
     return ret
 

--- a/salt/modules/solarisips.py
+++ b/salt/modules/solarisips.py
@@ -315,13 +315,22 @@ def latest_version(*names, **kwargs):
     The available version of packages in the repository.
     In case of multiple matches, it returns list of all matched packages.
     Accepts full or partial FMRI.
+
+    If the latest version of a given package is already installed, an empty
+    string will be returned for that package.
+
     Please use pkg.latest_version as pkg.available_version is being deprecated.
+
+    .. versionchanged:: Fluorine
+        Argument changed from 'name' to '*names' tu support multiple packages.
 
     CLI Example:
 
     .. code-block:: bash
 
+        salt '*' pkg.latest_version bash
         salt '*' pkg.latest_version pkg://solaris/entire
+        salt '*' pkg.latest_version postfix sendmail
     '''
 
     if len(names) == 0:

--- a/salt/modules/solarisips.py
+++ b/salt/modules/solarisips.py
@@ -348,7 +348,7 @@ def latest_version(*names, **kwargs):
 
     cmd = ['/bin/pkg', 'list', '-Hnv']
     cmd.extend(names)
-    lines = __salt__['cmd.run_stdout'](cmd).splitlines()
+    lines = __salt__['cmd.run_stdout'](cmd, ignore_retcode=True).splitlines()
     ret = {}
     for line in lines:
         ret[_ips_get_pkgname(line)] = _ips_get_pkgversion(line)

--- a/salt/modules/solarisips.py
+++ b/salt/modules/solarisips.py
@@ -39,6 +39,7 @@ Or you can override it globally by setting the :conf_minion:`providers` paramete
 from __future__ import absolute_import, print_function, unicode_literals
 import copy
 import logging
+import itertools
 
 
 # Import salt libs
@@ -48,6 +49,8 @@ import salt.utils.path
 import salt.utils.pkg
 from salt.exceptions import CommandExecutionError
 from salt.ext import six
+from salt.ext.six.moves import zip  # pylint: disable=redefined-builtin
+
 
 # Define the module's virtual name
 __virtualname__ = 'pkg'
@@ -312,7 +315,7 @@ def version(*names, **kwargs):
 
     # Append package names which are not installed/found
     unmatched = list(filter(lambda name: not reduce(lambda x, y : x or name in y, ret), False), names))
-    ret.update(zip(unmatched, [ '' ] * len(unmatched)))
+    ret.update(zip(unmatched, itertools.cycle(('',))))
 
     # Return a string if only one package name passed
     if len(names) == 1:
@@ -371,7 +374,7 @@ def latest_version(*names, **kwargs):
 
     # Append package names which are not found
     unmatched = list(filter(lambda name: not reduce(lambda x, y : x or name in y, ret, False), names))
-    ret.update(zip(unmatched, [ '' ] * len(unmatched)))
+    ret.update(zip(unmatched, itertools.cycle(('',))))
 
     # Return a string if only one package name passed
     if len(names) == 1:

--- a/salt/modules/solarisips.py
+++ b/salt/modules/solarisips.py
@@ -51,7 +51,6 @@ from salt.exceptions import CommandExecutionError
 from salt.ext import six
 from salt.ext.six.moves import zip  # pylint: disable=redefined-builtin
 
-
 # Define the module's virtual name
 __virtualname__ = 'pkg'
 log = logging.getLogger(__name__)

--- a/salt/modules/solarisips.py
+++ b/salt/modules/solarisips.py
@@ -314,7 +314,7 @@ def version(*names, **kwargs):
         ret[_ips_get_pkgname(line)] = _ips_get_pkgversion(line)
 
     # Append package names which are not installed/found
-    unmatched = list(filter(lambda name: not reduce(lambda x, y : x or name in y, ret, False), names))
+    unmatched = list(filter(lambda name: not reduce(lambda x, y: x or name in y, ret, False), names))
     ret.update(zip(unmatched, itertools.cycle(('',))))
 
     # Return a string if only one package name passed
@@ -364,16 +364,16 @@ def latest_version(*names, **kwargs):
 
     if len(names) == 1:
         # Convert back our result in a dict if only one name is passed
-        installed = { list(ret)[0] if len(ret) > 0 else names[0]: installed }
+        installed = {list(ret)[0] if len(ret) > 0 else names[0]: installed}
 
     for name in ret:
-        if not name in installed:
+        if name not in installed:
             continue
         if ret[name] == installed[name]:
             ret[name] = ''
 
     # Append package names which are not found
-    unmatched = list(filter(lambda name: not reduce(lambda x, y : x or name in y, ret, False), names))
+    unmatched = list(filter(lambda name: not reduce(lambda x, y: x or name in y, ret, False), names))
     ret.update(zip(unmatched, itertools.cycle(('',))))
 
     # Return a string if only one package name passed

--- a/salt/modules/solarisips.py
+++ b/salt/modules/solarisips.py
@@ -50,6 +50,7 @@ import salt.utils.pkg
 from salt.exceptions import CommandExecutionError
 from salt.ext import six
 from salt.ext.six.moves import zip  # pylint: disable=redefined-builtin
+from functools import reduce
 
 # Define the module's virtual name
 __virtualname__ = 'pkg'
@@ -313,7 +314,7 @@ def version(*names, **kwargs):
         ret[_ips_get_pkgname(line)] = _ips_get_pkgversion(line)
 
     # Append package names which are not installed/found
-    unmatched = list(filter(lambda name: not reduce(lambda x, y: x or name in y, ret, False), names))
+    unmatched = list([name for name in names if not reduce(lambda x, y: x or name in y, ret, False)])
     ret.update(zip(unmatched, itertools.cycle(('',))))
 
     # Return a string if only one package name passed
@@ -372,7 +373,7 @@ def latest_version(*names, **kwargs):
             ret[name] = ''
 
     # Append package names which are not found
-    unmatched = list(filter(lambda name: not reduce(lambda x, y: x or name in y, ret, False), names))
+    unmatched = list([name for name in names if not reduce(lambda x, y: x or name in y, ret, False)])
     ret.update(zip(unmatched, itertools.cycle(('',))))
 
     # Return a string if only one package name passed


### PR DESCRIPTION
### What does this PR do?
Fix salt.states.pkg.latest for IPS packages on Solaris.

### What issues does this PR fix or reference?

None.

### Previous Behavior
Currently the state function pkg.latest is broken with the solarisips provider because the modules functions solarisips.install() and solarisips.latest_version() don't return the expected value in some cases.

### New Behavior
The module install() now returns an empty dict if the package is already installed.
The latest_version() now returns an empty string for packages already at the latest version.
The version() function ignores the return code of pkg list to avoid errors when checking the version of non installed packages.

### Tests written?

No

### Commits signed with GPG?

No

