### PR TITLE
Fixup! beacons/avahi_announce.py finding grains

### DIFF
--- a/salt/beacons/avahi_announce.py
+++ b/salt/beacons/avahi_announce.py
@@ -182,7 +182,7 @@ def beacon(config):
     for item in _config['txt']:
         changes_key = 'txt.' + salt.utils.stringutils.to_unicode(item)
         if _config['txt'][item].startswith('grains.'):
-            grain = _config['txt'][item][6:]
+            grain = _config['txt'][item][7:]
             grain_index = None
             square_bracket = grain.find('[')
             if square_bracket != -1 and grain[-1] == ']':


### PR DESCRIPTION
This pull resquest broke the avahi_announce
https://github.com/saltstack/salt/pull/45657
because len('grains.') is 7 and not 6 as this
change say.
What happens now is that is looking in
__grains__ for '.{grain_name}' instead of {grain_name}.

Signed-off-by: Rares POP <rares.pop@ni.com>

### What does this PR do?
Is fixing the avahi_announce beacon after a python3 unicode refactoring done here:
https://github.com/saltstack/salt/pull/45657

### What issues does this PR fix or reference?

### Previous Behavior
avahi_announce beacon is broken now, it doesn't find the grains from the configuration

### Tests written?

No
