### PR TITLE
Fix windows tests suite breakage

### DIFF
--- a/salt/utils/win_functions.py
+++ b/salt/utils/win_functions.py
@@ -119,7 +119,7 @@ def get_sid_from_name(name):
     return win32security.ConvertSidToStringSid(sid)
 
 
-def get_current_user():
+def get_current_user(with_domain=True):
     '''
     Gets the user executing the process
 
@@ -136,6 +136,8 @@ def get_current_user():
                 user_name = 'SYSTEM'
             elif get_sid_from_name(test_user) == 'S-1-5-18':
                 user_name = 'SYSTEM'
+        elif not with_domain:
+            user_name = win32api.GetUserName()
     except pywintypes.error as exc:
         raise CommandExecutionError(
             'Failed to get current user: {0}'.format(exc.strerror))

--- a/tests/support/helpers.py
+++ b/tests/support/helpers.py
@@ -1563,5 +1563,5 @@ def this_user():
     Get the user associated with the current process.
     '''
     if salt.utils.is_windows():
-        return salt.utils.win_functions.get_current_user()
+        return salt.utils.win_functions.get_current_user(with_domain=False)
     return pwd.getpwuid(os.getuid())[0]


### PR DESCRIPTION
### What does this PR do?

Fix runtests.py for windows builds. This broke in PR #47500

### Previous Behavior

#47500 started including the domain with the username which broke the test suite.

### New Behavior

Still use centralized current username lookup but do not include the domain by default in the `tests.support.helpers.this_user` function. This gets the windows test suite running and reporting results.

### Tests written?

No - Fixes existing tests

### Commits signed with GPG?

Yes