### PR TITLE
Prevent crash if files in file.recurse

### DIFF
--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -41,7 +41,6 @@ import salt.utils.versions
 from salt.exceptions import CommandExecutionError, SaltInvocationError
 from salt.runners.state import orchestrate as _orchestrate
 from salt.utils.odict import OrderedDict
-from salt.utils import to_unicode
 
 # Import 3rd-party libs
 from salt.ext import six
@@ -2085,9 +2084,9 @@ def pkg(pkg_path,
     # Verify that the tarball does not extract outside of the intended root
     members = s_pkg.getmembers()
     for member in members:
-        if to_unicode(member.path).startswith((os.sep, '..{0}'.format(os.sep))):
+        if salt.utils.stringutils.to_unicode(member.path).startswith((os.sep, '..{0}'.format(os.sep))):
             return {}
-        elif '..{0}'.format(os.sep) in to_unicode(member.path):
+        elif '..{0}'.format(os.sep) in salt.utils.stringutils.to_unicode(member.path):
             return {}
     s_pkg.extractall(root)
     s_pkg.close()

--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -41,6 +41,7 @@ import salt.utils.versions
 from salt.exceptions import CommandExecutionError, SaltInvocationError
 from salt.runners.state import orchestrate as _orchestrate
 from salt.utils.odict import OrderedDict
+from salt.utils import to_unicode
 
 # Import 3rd-party libs
 from salt.ext import six
@@ -2084,9 +2085,9 @@ def pkg(pkg_path,
     # Verify that the tarball does not extract outside of the intended root
     members = s_pkg.getmembers()
     for member in members:
-        if member.path.startswith((os.sep, '..{0}'.format(os.sep))):
+        if to_unicode(member.path).startswith((os.sep, '..{0}'.format(os.sep))):
             return {}
-        elif '..{0}'.format(os.sep) in member.path:
+        elif '..{0}'.format(os.sep) in to_unicode(member.path):
             return {}
     s_pkg.extractall(root)
     s_pkg.close()


### PR DESCRIPTION
### What does this PR do?

Bugfix.

### What issues does this PR fix or reference?

```yaml
foo:
  file.recurse:
    - name: /tmp/blah
    - source: salt://foo
```

If we have `$SALT/foo/здоров-був.txt` file, crash happens. This PR fixes it.