### PR TITLE
Catch all exceptions in git import for salt.utils.gitfs

### DIFF
--- a/salt/utils/gitfs.py
+++ b/salt/utils/gitfs.py
@@ -93,7 +93,7 @@ try:
     import git
     import gitdb
     GITPYTHON_VERSION = _LooseVersion(git.__version__)
-except ImportError:
+except Exception:
     GITPYTHON_VERSION = None
 
 try:


### PR DESCRIPTION
### What does this PR do?
Makes sure we catch all exceptions when attempting to import salt due to an upstream bug here: https://github.com/gitpython-developers/GitPython/issues/762  This will workaround the upstream issue to ensure we aren't stack tracing when attempting to import git.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/47905#issuecomment-393912172

