### PR TITLE
Replace co_varnames check with argspec

### DIFF
--- a/salt/loader.py
+++ b/salt/loader.py
@@ -22,6 +22,7 @@ from zipimport import zipimporter
 # Import salt libs
 import salt.config
 import salt.syspaths
+import salt.utils.args
 import salt.utils.context
 import salt.utils.data
 import salt.utils.dictupdate
@@ -751,7 +752,7 @@ def grains(opts, force_refresh=False, proxy=None):
             # proxymodule for retrieving information from the connected
             # device.
             log.trace('Loading %s grain', key)
-            parameters = list(funcs[key].__code__.co_varnames)
+            parameters = salt.utils.args.get_function_argspec(funcs[key]).args
             kwargs = {}
             if 'proxy' in parameters:
                 kwargs['proxy'] = proxy


### PR DESCRIPTION
co_varnames, according to the Python docs, includes a function's local variables. So any public function which uses a local variable named "grains" will have the grains data passed to them, resulting in a traceback if that function doesn't accept a "grains" argument.

Refs: 05ab624fcd8106c69785248822c2f731cefa4720

CC: @gtmanfred