### PR TITLE
Use six.itervalues() instead of dict.values()

### DIFF
--- a/salt/cli/salt.py
+++ b/salt/cli/salt.py
@@ -402,7 +402,7 @@ class SaltCMD(salt.utils.parsers.SaltCMDOptionParser):
         # if there is a dict with retcode, use that
         if isinstance(ret, dict) and ret.get('retcode', 0) != 0:
             if isinstance(ret.get('retcode', 0), dict):
-                return max(ret.get('retcode', {0: 0}).values())
+                return max(six.itervalues(ret.get('retcode', {0: 0})))
             return ret['retcode']
         # if its a boolean, False means 1
         elif isinstance(ret, bool) and not ret:


### PR DESCRIPTION
This will give a modest mem usage improvement on Python 2 since we won't be allocating a new list.