### PR TITLE
Fix parsing fstab when dump and pass aren't present

### DIFF
--- a/salt/modules/mount.py
+++ b/salt/modules/mount.py
@@ -276,7 +276,7 @@ class _fstab_entry(object):
             raise cls.ParseError("Comment!")
 
         comps = line.split()
-        if len(comps)  < 4 or len(comps) > 6:
+        if len(comps) < 4 or len(comps) > 6:
             raise cls.ParseError("Invalid Entry!")
 
         comps.extend(['0'] * (len(keys) - len(comps)))

--- a/salt/modules/mount.py
+++ b/salt/modules/mount.py
@@ -276,8 +276,10 @@ class _fstab_entry(object):
             raise cls.ParseError("Comment!")
 
         comps = line.split()
-        if len(comps) != 6:
+        if len(comps)  < 4 or len(comps) > 6:
             raise cls.ParseError("Invalid Entry!")
+
+        comps.extend(['0'] * (len(keys) - len(comps)))
 
         return dict(zip(keys, comps))
 


### PR DESCRIPTION
### What does this PR do?

Currently the mount module will not parse any fstab line if the optional mount and pass arguments aren't there. This PR fixes this and fill the missing arguments with their default values.

### What issues does this PR fix or reference?

None

### Previous Behavior
Lines in fstab are ignored.

### New Behavior
The lines are now parsed correctly.

### Tests written?

No

### Commits signed with GPG?

No
