### PR TITLE
Fix NI Linux RT distribution core grains

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1350,7 +1350,6 @@ _OS_NAME_MAP = {
     'scientific': 'ScientificLinux',
     'synology': 'Synology',
     'nilrt': 'NILinuxRT',
-    'nilrt-xfce': 'NILinuxRT-XFCE',
     'poky': 'Poky',
     'manjaro': 'Manjaro',
     'manjarolin': 'Manjaro',
@@ -1423,7 +1422,6 @@ _OS_FAMILY_MAP = {
     'Cumulus': 'Debian',
     'Deepin': 'Debian',
     'NILinuxRT': 'NILinuxRT',
-    'NILinuxRT-XFCE': 'NILinuxRT',
     'KDE neon': 'Debian',
     'Void': 'Void',
     'IDMS': 'Debian',
@@ -1788,8 +1786,11 @@ def os_data():
         # so that linux_distribution() does the /etc/lsb-release parsing, but
         # we do it anyway here for the sake for full portability.
         if 'osfullname' not in grains:
-            grains['osfullname'] = \
-                grains.get('lsb_distrib_id', osname).strip()
+            # If NI Linux RT distribution, set the grains['osfullname'] to 'nilrt'
+            if grains.get('lsb_distrib_id', '').lower().startswith('nilrt'):
+                grains['osfullname'] = 'nilrt'
+            else:
+                grains['osfullname'] = grains.get('lsb_distrib_id', osname).strip()
         if 'osrelease' not in grains:
             # NOTE: This is a workaround for CentOS 7 os-release bug
             # https://bugs.centos.org/view.php?id=8359


### PR DESCRIPTION
NI fixed lsb_distrib_id to correctly differentiate
between older distribution vs current distribution
which have different behavior for multiple module
functionality, but it should continue to populate
'osfullname' as 'NILinuxRT' not to break existing code

Signed-off-by: Rares POP <rares.pop@ni.com>

This should also be backported in 2018.3

### What does this PR do?
National Instruments used to have a custom set of commits in-house, for the older Linux RT distribution, but it makes more sense to upstream that too and expand salt's support. In order to do that, we have to differentiate between those two platforms, and we do that now through this 'lsb_distrib_id' grain.

It also clean up the nilrt-xfce distribution that was never a distribution.

### Previous Behavior
grains['lsb_distrib_id'] was always showing 'nilrt' previously and it was some custom code that differentiate between older distribution and the new distribution of Linux RT. That had to be spread around multiple modules that needed that logic.

### New Behavior
Modules can use the grains['lsb_distrib_id'] info to differentiate between newer vs. older linux distribution for National Instruments Linux RT platform
For the older distribution is showing 'nilrt', as for the newer distribution 'nilrt-nxg'.

### Tests written?

No

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
