### PR TITLE
[2018.8] Ensure x509 passphrase is a string

### DIFF
--- a/salt/modules/x509.py
+++ b/salt/modules/x509.py
@@ -837,7 +837,6 @@ def create_private_key(path=None,
     bio = M2Crypto.BIO.MemoryBuffer()
     if passphrase is None:
         cipher = None
-
     rsa.save_key_bio(
         bio,
         cipher=cipher,

--- a/salt/modules/x509.py
+++ b/salt/modules/x509.py
@@ -376,7 +376,7 @@ def _passphrase_callback(passphrase):
     Returns a callback function used to supply a passphrase for private keys
     '''
     def f(*args):
-        return passphrase
+        return salt.utils.stringutils.to_str(passphrase)
     return f
 
 
@@ -837,6 +837,7 @@ def create_private_key(path=None,
     bio = M2Crypto.BIO.MemoryBuffer()
     if passphrase is None:
         cipher = None
+
     rsa.save_key_bio(
         bio,
         cipher=cipher,

--- a/tests/unit/modules/test_x509.py
+++ b/tests/unit/modules/test_x509.py
@@ -164,3 +164,13 @@ c9bcgp7D7xD+TxWWNj4CSXEccJgGr91StV+gFg4ARQ==
                                       days_valid=3650,
                                       days_remaining=0)
         self.assertIn(b'BEGIN CERTIFICATE', ret)
+
+    @skipIf(not HAS_M2CRYPTO, 'Skipping, M2Crypt is unavailble')
+    def test_create_key(self):
+        '''
+        Test that x509.create_key returns a private key
+        :return:
+        '''
+        ret = x509.create_private_key(text=True,
+                                      passphrase='super_secret_passphrase')
+        self.assertIn(b'BEGIN RSA PRIVATE KEY', ret)


### PR DESCRIPTION
### What does this PR do?
Ensuring that when a passphrase is passed in, it is returned as a string from the passphrase callback.

### What issues does this PR fix or reference?
#47236 

### Tests written?
Yes

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
