### PR TITLE
Fix failing test when service doesn't exist

### DIFF
--- a/tests/integration/modules/test_service.py
+++ b/tests/integration/modules/test_service.py
@@ -11,7 +11,6 @@ from tests.support.unit import skipIf
 # Import Salt libs
 import salt.utils
 import salt.utils.systemd
-from salt.exceptions import CommandExecutionError
 
 
 @destructiveTest

--- a/tests/integration/modules/test_service.py
+++ b/tests/integration/modules/test_service.py
@@ -11,6 +11,7 @@ from tests.support.unit import skipIf
 # Import Salt libs
 import salt.utils
 import salt.utils.systemd
+from salt.exceptions import CommandExecutionError
 
 
 @destructiveTest
@@ -128,7 +129,11 @@ class ServiceModuleTest(ModuleCase):
             # currently upstart does not have a mechanism to report if disabling a service fails if does not exist
             self.assertTrue(self.run_function('service.disable', [srv_name]))
         else:
-            self.assertFalse(self.run_function('service.disable', [srv_name]))
+            if salt.utils.is_windows():
+                disable = self.run_function('service.disable', [srv_name])
+                self.assertTrue('error' in disable.lower())
+            else:
+                self.assertFalse(self.run_function('service.disable', [srv_name]))
 
         if salt.utils.is_darwin():
             self.assertFalse(self.run_function('service.disabled', [srv_name]))


### PR DESCRIPTION
### What does this PR do?
Fixes issue with failing test. For some reason `self.assertIn` wasn't working. So, I used `self.assertTrue(`error' in ret)`

### What issues does this PR fix or reference?
Failing test

### Tests written?
Yes

### Commits signed with GPG?
Yes