### PR TITLE
Fix 47921

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -6298,6 +6298,9 @@ def serialize(name,
                 }
 
     if serializer_opts:
+        if not options.get(serializer_name, {}):
+            options[serializer_name] = {}
+
         options.get(serializer_name, {}).update(
             salt.utils.data.repack_dictlist(serializer_opts)
         )
@@ -6312,7 +6315,11 @@ def serialize(name,
                         'result': False}
 
             with salt.utils.files.fopen(name, 'r') as fhr:
-                existing_data = __serializers__[deserializer_name](fhr, **options.get(serializer_name, {}))
+                try:
+                    existing_data = __serializers__[deserializer_name](fhr, **options.get(serializer_name, {}))
+                except (TypeError, salt.serializers.DeserializationError):
+                    fhr.seek(0)
+                    existing_data = __serializers__[deserializer_name](fhr)
 
             if existing_data is not None:
                 merged_data = salt.utils.dictupdate.merge_recurse(existing_data, dataset)

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -6318,6 +6318,7 @@ def serialize(name,
                 try:
                     existing_data = __serializers__[deserializer_name](fhr, **options.get(serializer_name, {}))
                 except (TypeError, salt.serializers.DeserializationError):
+                    log.debug('DeserializationError exception caught, trying to merge without serializer_opts: %s', options.get(serializer_name, {}))
                     fhr.seek(0)
                     existing_data = __serializers__[deserializer_name](fhr)
 


### PR DESCRIPTION
### What does this PR do?
Attempts to use same `serializer_opts` for deserialization during `merge_if_exists`, if it's not working (`JSONDecode` class for example doesn't accept kwargs it doesn't know about) try deserializing without custom options.

Ideally we would also have `deserializer_opts` for this but I think it would just clutter the state. If there is a legitimate use when you need to pass something to both serializer and deserializer, but for example deserializer doesn't accept only one of the options, this would all fail. I'm not sure if there is a legitimate case for that yet.

Also fixes `serializer_opts` not being passed down if the serialize_name doesn't exist in options dict.

### What issues does this PR fix or reference?
Fixes #47921

### Tests written?

No

### Commits signed with GPG?

Yes