### PR TITLE
Fix postfix.set_main's assumption of prefix-free key names

### DIFF
--- a/salt/modules/postfix.py
+++ b/salt/modules/postfix.py
@@ -288,9 +288,10 @@ def set_main(key, value, path=MAIN_CF):
     pairs, conf_list = _parse_main(path)
 
     new_conf = []
+    key_line_match = re.compile("^{0}([\\s=]|$)".format(re.escape(key)))
     if key in pairs:
         for line in conf_list:
-            if line.startswith(key):
+            if re.match(key_line_match, line):
                 new_conf.append('{0} = {1}'.format(key, value))
             else:
                 new_conf.append(line)


### PR DESCRIPTION
Salt's "postfix.set_main" module function used "line.startswith()"
for determining which entries from "main.cf" to keep and which to
overwrite. This matched more lines that intended, though, as the names
of Postfix' configuration options aren't prefix-free.

For example, both "virtual_transport" and
"virtual_transport_rate_delay" are valid and known keys. Therefore
trying to set "virtual_transport" would lead to
"virtual_transport_rate_delay" being replaced, too, by another
instance of "virtual_transport".

The new method matches the line based on the key name being terminated
by whitespace, an equal sign or the end of the line.

Fixes #47888.

### Tests written?

No

### Commits signed with GPG?

Yes