### PR TITLE
Capture and log output of processes that timed out and were killed

### DIFF
--- a/tests/integration/shell/test_call.py
+++ b/tests/integration/shell/test_call.py
@@ -233,20 +233,17 @@ class CallTest(ShellCase, testprogram.TestProgramCase, ShellCaseCommonTestsMixin
             with salt.utils.files.fopen(minion_config_file, 'w') as fh_:
                 salt.utils.yaml.safe_dump(minion_config, fh_, default_flow_style=False)
 
-            out = self.run_script(
+            _, timed_out = self.run_script(
                 'salt-call',
                 '--config-dir {0} cmd.run "echo foo"'.format(
                     config_dir
                 ),
                 timeout=timeout,
+                catch_timeout=True,
             )
 
             try:
-                self.assertIn(
-                    'Process took more than {0} seconds to complete. '
-                    'Process Killed!'.format(timeout),
-                    out
-                )
+                self.assertTrue(timed_out)
             except AssertionError:
                 if os.path.isfile(minion_config_file):
                     os.unlink(minion_config_file)

--- a/tests/support/case.py
+++ b/tests/support/case.py
@@ -245,6 +245,7 @@ class ShellTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
                    arg_str,
                    catch_stderr=False,
                    with_retcode=False,
+                   catch_timeout=False,
                    # FIXME A timeout of zero or disabling timeouts may not return results!
                    timeout=15,
                    raw=False,
@@ -338,6 +339,8 @@ class ShellTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
                 ret.append(stderr)
             if with_retcode:
                 ret.append(retcode)
+            if catch_timeout:
+                ret.append(timed_out)
 
             return ret[0] if len(ret) == 1 else tuple(ret)
 


### PR DESCRIPTION
Before, `tests.support.case.ShellTestCase.run_script` would just go `¯\_(ツ)_/¯` and return that it killed the process. But you can still run `.communicate()` on a process that was terminated, so this commit does that and uses it to log the output from the killed process.

Refs: https://github.com/saltstack/salt-jenkins/issues/1000