### PR TITLE
Use @property instead of @staticmethod for config_dir

### DIFF
--- a/tests/integration/cloud/providers/test_ec2.py
+++ b/tests/integration/cloud/providers/test_ec2.py
@@ -118,7 +118,7 @@ class EC2Test(ShellCase):
         self.INSTALLER = self._ensure_installer()
 
     def override_profile_config(self, name, data):
-        conf_path = os.path.join(self.get_config_dir(), 'cloud.profiles.d', 'ec2.conf')
+        conf_path = os.path.join(self.config_dir, 'cloud.profiles.d', 'ec2.conf')
         with salt.utils.files.fopen(conf_path, 'r') as fp:
             conf = yaml.safe_load(fp)
         conf[name].update(data)
@@ -132,7 +132,7 @@ class EC2Test(ShellCase):
         returned.
         '''
         src = os.path.join(FILES, name)
-        dst = os.path.join(self.get_config_dir(), name)
+        dst = os.path.join(self.config_dir, name)
         with salt.utils.files.fopen(src, 'rb') as sfp:
             with salt.utils.files.fopen(dst, 'wb') as dfp:
                 dfp.write(sfp.read())

--- a/tests/integration/runners/test_runner_returns.py
+++ b/tests/integration/runners/test_runner_returns.py
@@ -30,7 +30,7 @@ class RunnerReturnsTest(ShellCase):
         '''
         self.job_dir = os.path.join(self.master_opts['cachedir'], 'jobs')
         self.hash_type = self.master_opts['hash_type']
-        self.master_d_dir = os.path.join(self.get_config_dir(), 'master.d')
+        self.master_d_dir = os.path.join(self.config_dir, 'master.d')
         try:
             os.makedirs(self.master_d_dir)
         except OSError as exc:

--- a/tests/integration/runners/test_state.py
+++ b/tests/integration/runners/test_state.py
@@ -292,7 +292,7 @@ class OrchEventTest(ShellCase):
     '''
     def setUp(self):
         self.timeout = 60
-        self.master_d_dir = os.path.join(self.get_config_dir(), 'master.d')
+        self.master_d_dir = os.path.join(self.config_dir, 'master.d')
         try:
             os.makedirs(self.master_d_dir)
         except OSError as exc:

--- a/tests/integration/shell/test_call.py
+++ b/tests/integration/shell/test_call.py
@@ -378,7 +378,7 @@ class CallTest(ShellCase, testprogram.TestProgramCase, ShellCaseCommonTestsMixin
             _ = self.run_script(
                 'salt-call',
                 '-c {0} --output-file={1} test.versions'.format(
-                    self.get_config_dir(),
+                    self.config_dir,
                     output_file_append
                 ),
                 catch_stderr=True,
@@ -391,7 +391,7 @@ class CallTest(ShellCase, testprogram.TestProgramCase, ShellCaseCommonTestsMixin
             self.run_script(
                 'salt-call',
                 '-c {0} --output-file={1} --output-file-append test.versions'.format(
-                    self.get_config_dir(),
+                    self.config_dir,
                     output_file_append
                 ),
                 catch_stderr=True,
@@ -438,7 +438,7 @@ class CallTest(ShellCase, testprogram.TestProgramCase, ShellCaseCommonTestsMixin
                 self.run_script(
                     'salt-call',
                     '-c {0} --output-file={1} --output-file-append -g'.format(
-                        self.get_config_dir(),
+                        self.config_dir,
                         output_file
                     ),
                     catch_stderr=True,
@@ -456,7 +456,7 @@ class CallTest(ShellCase, testprogram.TestProgramCase, ShellCaseCommonTestsMixin
                 self.run_script(
                     'salt-call',
                     '-c {0} --output-file={1} -g'.format(
-                        self.get_config_dir(),
+                        self.config_dir,
                         output_file
                     ),
                     catch_stderr=True,

--- a/tests/support/case.py
+++ b/tests/support/case.py
@@ -127,7 +127,7 @@ class ShellTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
                     data = '\n'.join(data)
                     self.assertIn('minion', data)
         '''
-        arg_str = '-c {0} -t {1} {2}'.format(self.get_config_dir(), timeout, arg_str)
+        arg_str = '-c {0} -t {1} {2}'.format(self.config_dir, timeout, arg_str)
         return self.run_script('salt', arg_str, with_retcode=with_retcode, catch_stderr=catch_stderr, timeout=timeout)
 
     def run_ssh(self, arg_str, with_retcode=False, timeout=25,
@@ -138,7 +138,7 @@ class ShellTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
         arg_str = '{0} {1} -c {2} -i --priv {3} --roster-file {4} localhost {5} --out=json'.format(
             ' -W' if wipe else '',
             ' -r' if raw else '',
-            self.get_config_dir(),
+            self.config_dir,
             os.path.join(RUNTIME_VARS.TMP_CONF_DIR, 'key_test'),
             os.path.join(RUNTIME_VARS.TMP_CONF_DIR, 'roster'),
             arg_str
@@ -156,7 +156,7 @@ class ShellTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
         Execute salt-run
         '''
         arg_str = '-c {0}{async_flag} -t {timeout} {1}'.format(
-                config_dir or self.get_config_dir(),
+                config_dir or self.config_dir,
                 arg_str,
                 timeout=timeout,
                 async_flag=' --async' if async else '')
@@ -212,7 +212,7 @@ class ShellTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
         '''
         Execute salt-key
         '''
-        arg_str = '-c {0} {1}'.format(self.get_config_dir(), arg_str)
+        arg_str = '-c {0} {1}'.format(self.config_dir, arg_str)
         return self.run_script(
             'salt-key',
             arg_str,
@@ -224,12 +224,12 @@ class ShellTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
         '''
         Execute salt-cp
         '''
-        arg_str = '--config-dir {0} {1}'.format(self.get_config_dir(), arg_str)
+        arg_str = '--config-dir {0} {1}'.format(self.config_dir, arg_str)
         return self.run_script('salt-cp', arg_str, with_retcode=with_retcode, catch_stderr=catch_stderr)
 
     def run_call(self, arg_str, with_retcode=False, catch_stderr=False, local=False):
         arg_str = '{0} --config-dir {1} {2}'.format('--local' if local else '',
-                                                    self.get_config_dir(), arg_str)
+                                                    self.config_dir, arg_str)
 
         return self.run_script('salt-call', arg_str, with_retcode=with_retcode, catch_stderr=catch_stderr)
 
@@ -237,7 +237,7 @@ class ShellTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
         '''
         Execute salt-cloud
         '''
-        arg_str = '-c {0} {1}'.format(self.get_config_dir(), arg_str)
+        arg_str = '-c {0} {1}'.format(self.config_dir, arg_str)
         return self.run_script('salt-cloud', arg_str, catch_stderr, timeout)
 
     def run_script(self,
@@ -468,7 +468,7 @@ class ShellCase(ShellTestCase, AdaptedConfigurationTestCaseMixin, ScriptPathMixi
         '''
         Execute salt
         '''
-        arg_str = '-c {0} {1}'.format(self.get_config_dir(), arg_str)
+        arg_str = '-c {0} {1}'.format(self.config_dir, arg_str)
         ret = self.run_script('salt',
                               arg_str,
                               with_retcode=with_retcode,
@@ -497,7 +497,7 @@ class ShellCase(ShellTestCase, AdaptedConfigurationTestCaseMixin, ScriptPathMixi
         arg_str = '{0} -ldebug{1} -c {2} -i --priv {3} --roster-file {4} --out=json localhost {5}'.format(
             ' -W' if wipe else '',
             ' -r' if raw else '',
-            self.get_config_dir(),
+            self.config_dir,
             os.path.join(RUNTIME_VARS.TMP_CONF_DIR, 'key_test'),
             os.path.join(RUNTIME_VARS.TMP_CONF_DIR, 'roster'),
             arg_str)
@@ -514,7 +514,7 @@ class ShellCase(ShellTestCase, AdaptedConfigurationTestCaseMixin, ScriptPathMixi
         '''
         Execute salt-run
         '''
-        arg_str = '-c {0}{async_flag} -t {timeout} {1}'.format(config_dir or self.get_config_dir(),
+        arg_str = '-c {0}{async_flag} -t {timeout} {1}'.format(config_dir or self.config_dir,
                                                                arg_str,
                                                                timeout=timeout,
                                                                async_flag=' --async' if async else '')
@@ -570,7 +570,7 @@ class ShellCase(ShellTestCase, AdaptedConfigurationTestCaseMixin, ScriptPathMixi
         '''
         Execute salt-key
         '''
-        arg_str = '-c {0} {1}'.format(self.get_config_dir(), arg_str)
+        arg_str = '-c {0} {1}'.format(self.config_dir, arg_str)
         ret = self.run_script('salt-key',
                               arg_str,
                               catch_stderr=catch_stderr,
@@ -585,7 +585,7 @@ class ShellCase(ShellTestCase, AdaptedConfigurationTestCaseMixin, ScriptPathMixi
         '''
         # Note: not logging result of run_cp because it will log a bunch of
         # bytes which will not be very helpful.
-        arg_str = '--config-dir {0} {1}'.format(self.get_config_dir(), arg_str)
+        arg_str = '--config-dir {0} {1}'.format(self.config_dir, arg_str)
         return self.run_script('salt-cp',
                                arg_str,
                                with_retcode=with_retcode,
@@ -597,7 +597,7 @@ class ShellCase(ShellTestCase, AdaptedConfigurationTestCaseMixin, ScriptPathMixi
         Execute salt-call.
         '''
         arg_str = '{0} --config-dir {1} {2}'.format('--local' if local else '',
-                                                    self.get_config_dir(), arg_str)
+                                                    self.config_dir, arg_str)
         ret = self.run_script('salt-call',
                               arg_str,
                               with_retcode=with_retcode,
@@ -610,7 +610,7 @@ class ShellCase(ShellTestCase, AdaptedConfigurationTestCaseMixin, ScriptPathMixi
         '''
         Execute salt-cloud
         '''
-        arg_str = '-c {0} {1}'.format(self.get_config_dir(), arg_str)
+        arg_str = '-c {0} {1}'.format(self.config_dir, arg_str)
         ret = self.run_script('salt-cloud',
                               arg_str,
                               catch_stderr,

--- a/tests/support/mixins.py
+++ b/tests/support/mixins.py
@@ -171,9 +171,13 @@ class AdaptedConfigurationTestCaseMixin(object):
                 )
         return RUNTIME_VARS.RUNTIME_CONFIGS[config_for]
 
-    @staticmethod
-    def get_config_dir():
+    @property
+    def config_dir(self):
         return RUNTIME_VARS.TMP_CONF_DIR
+
+    def get_config_dir(self):
+        log.warning('Use the config_dir attribute instead of calling get_config_dir()')
+        return self.config_dir
 
     @staticmethod
     def get_config_file_path(filename):

--- a/tests/unit/ssh/test_ssh.py
+++ b/tests/unit/ssh/test_ssh.py
@@ -31,7 +31,7 @@ class SSHPasswordTests(ShellCase):
         opts['selected_target_option'] = 'glob'
         opts['tgt'] = 'localhost'
         opts['arg'] = []
-        roster = os.path.join(self.get_config_dir(), 'roster')
+        roster = os.path.join(self.config_dir, 'roster')
         handle_ssh_ret = [
             {'localhost': {'retcode': 255, 'stderr': u'Permission denied (publickey).\r\n', 'stdout': ''}},
         ]


### PR DESCRIPTION
We're not passing arguments and we're just getting back a string contstant, so there's no need to make this a staticmethod.