### PR TITLE
Write S3 buckets pillar cache file as binary.

### DIFF
--- a/salt/pillar/s3.py
+++ b/salt/pillar/s3.py
@@ -337,7 +337,7 @@ def _refresh_buckets_cache_file(creds, cache_file, multiple_env, environment, pr
 
     log.debug('Writing S3 buckets pillar cache file')
 
-    with salt.utils.fopen(cache_file, 'w') as fp_:
+    with salt.utils.fopen(cache_file, 'wb') as fp_:
         pickle.dump(metadata, fp_)
 
     return metadata


### PR DESCRIPTION
This is necessary or the pickling operation will fail.

### What does this PR do?
Write S3 buckets pillar cache file as binary. Fixes loading pillar data from S3.

### What issues does this PR fix or reference?
```
[ERROR   ] Execption caught loading ext_pillar 's3':
  File "/usr/local/lib/python3.6/site-packages/salt/pillar/__init__.py", line 833, in ext_pillar
    key)
  File "/usr/local/lib/python3.6/site-packages/salt/pillar/__init__.py", line 755, in _external_pillar_data
    ext = self.ext_pillars[key](self.minion_id, pillar, **val)
  File "/usr/local/lib/python3.6/site-packages/salt/pillar/s3.py", line 161, in ext_pillar
    metadata = _init(s3_creds, bucket, multiple_env, environment, prefix, s3_cache_expire)
  File "/usr/local/lib/python3.6/site-packages/salt/pillar/s3.py", line 214, in _init
    environment, prefix)
  File "/usr/local/lib/python3.6/site-packages/salt/pillar/s3.py", line 341, in _refresh_buckets_cache_file
    pickle.dump(metadata, fp_)

[CRITICAL] Pillar render error: Failed to load ext_pillar s3: write() argument must be str, not bytes
```
### Tests written?

No

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
