### PR TITLE
Fix `unit.modules.test_win_dns_client` tests

### DIFF
--- a/tests/unit/modules/test_win_dns_client.py
+++ b/tests/unit/modules/test_win_dns_client.py
@@ -20,6 +20,7 @@ from tests.support.mock import (
 
 # Import Salt Libs
 import salt.modules.win_dns_client as win_dns_client
+import salt.utils.stringutils
 
 try:
     import wmi
@@ -73,7 +74,9 @@ class WinDnsClientTestCase(TestCase, LoaderModuleMockMixin):
 
     def setup_loader_modules(self):
         # wmi and pythoncom modules are platform specific...
-        mock_pythoncom = types.ModuleType('pythoncom')
+        mock_pythoncom = types.ModuleType(
+            salt.utils.stringutils.to_str('pythoncom')
+        )
         sys_modules_patcher = patch.dict('sys.modules',
                                          {'pythoncom': mock_pythoncom})
         sys_modules_patcher.start()


### PR DESCRIPTION
### What does this PR do?
Fixes issue where `ModuleType` is expecting a string type.

### What issues does this PR fix or reference?
Found in Jenkins

### Tests written?
Yes

### Commits signed with GPG?
Yes