### PR TITLE
Fix `unit.utils.test_hashutils` unicode issues

### DIFF
--- a/salt/utils/hashutils.py
+++ b/salt/utils/hashutils.py
@@ -13,6 +13,7 @@ import random
 # Import Salt libs
 from salt.ext import six
 import salt.utils.files
+import salt.utils.platform
 import salt.utils.stringutils
 
 from salt.utils.decorators.jinja import jinja_filter
@@ -27,7 +28,8 @@ def base64_b64encode(instr):
     newline ('\\n') characters in the encoded output.
     '''
     return salt.utils.stringutils.to_unicode(
-        base64.b64encode(salt.utils.stringutils.to_bytes(instr))
+        base64.b64encode(salt.utils.stringutils.to_bytes(instr)),
+        encoding='utf8' if salt.utils.platform.is_windows() else None
     )
 
 
@@ -38,7 +40,10 @@ def base64_b64decode(instr):
     '''
     decoded = base64.b64decode(salt.utils.stringutils.to_bytes(instr))
     try:
-        return salt.utils.stringutils.to_unicode(decoded)
+        return salt.utils.stringutils.to_unicode(
+            decoded,
+            encoding='utf8' if salt.utils.platform.is_windows() else None
+        )
     except UnicodeDecodeError:
         return decoded
 
@@ -52,7 +57,8 @@ def base64_encodestring(instr):
     at the end of the encoded string.
     '''
     return salt.utils.stringutils.to_unicode(
-        base64.encodestring(salt.utils.stringutils.to_bytes(instr))
+        base64.encodestring(salt.utils.stringutils.to_bytes(instr)),
+        encoding='utf8' if salt.utils.platform.is_windows() else None
     )
 
 
@@ -68,7 +74,10 @@ def base64_decodestring(instr):
         # PY2
         decoded = base64.decodestring(b)
     try:
-        return salt.utils.stringutils.to_unicode(decoded)
+        return salt.utils.stringutils.to_unicode(
+            decoded,
+            encoding='utf8' if salt.utils.platform.is_windows() else None
+        )
     except UnicodeDecodeError:
         return decoded
 

--- a/tests/unit/utils/test_hashutils.py
+++ b/tests/unit/utils/test_hashutils.py
@@ -8,8 +8,6 @@ from tests.support.unit import TestCase
 
 # Import Salt libs
 import salt.utils.hashutils
-import salt.utils.stringutils
-import salt.utils.platform
 
 
 class HashutilsTestCase(TestCase):
@@ -59,13 +57,9 @@ class HashutilsTestCase(TestCase):
             salt.utils.hashutils.base64_b64decode(self.str_b64encode_result),
             self.str
         )
-        try:
-            check_value = salt.utils.stringutils.to_unicode(self.bytes)
-        except UnicodeDecodeError:
-            check_value = self.bytes
         self.assertEqual(
             salt.utils.hashutils.base64_b64decode(self.bytes_b64encode_result),
-            check_value
+            self.bytes
         )
 
     def test_base64_encodestring(self):
@@ -92,13 +86,9 @@ class HashutilsTestCase(TestCase):
             salt.utils.hashutils.base64_decodestring(self.str_encodestring_result),
             self.str
         )
-        try:
-            check_value = salt.utils.stringutils.to_unicode(self.bytes)
-        except UnicodeDecodeError:
-            check_value = self.bytes
         self.assertEqual(
             salt.utils.hashutils.base64_decodestring(self.bytes_encodestring_result),
-            check_value
+            self.bytes
         )
 
     def test_md5_digest(self):

--- a/tests/unit/utils/test_hashutils.py
+++ b/tests/unit/utils/test_hashutils.py
@@ -9,6 +9,7 @@ from tests.support.unit import TestCase
 # Import Salt libs
 import salt.utils.hashutils
 import salt.utils.stringutils
+import salt.utils.platform
 
 
 class HashutilsTestCase(TestCase):
@@ -58,9 +59,13 @@ class HashutilsTestCase(TestCase):
             salt.utils.hashutils.base64_b64decode(self.str_b64encode_result),
             self.str
         )
+        try:
+            check_value = salt.utils.stringutils.to_unicode(self.bytes)
+        except UnicodeDecodeError:
+            check_value = self.bytes
         self.assertEqual(
             salt.utils.hashutils.base64_b64decode(self.bytes_b64encode_result),
-            salt.utils.stringutils.to_unicode(self.bytes)
+            check_value
         )
 
     def test_base64_encodestring(self):
@@ -87,9 +92,13 @@ class HashutilsTestCase(TestCase):
             salt.utils.hashutils.base64_decodestring(self.str_encodestring_result),
             self.str
         )
+        try:
+            check_value = salt.utils.stringutils.to_unicode(self.bytes)
+        except UnicodeDecodeError:
+            check_value = self.bytes
         self.assertEqual(
             salt.utils.hashutils.base64_decodestring(self.bytes_encodestring_result),
-            salt.utils.stringutils.to_unicode(self.bytes)
+            check_value
         )
 
     def test_md5_digest(self):

--- a/tests/unit/utils/test_hashutils.py
+++ b/tests/unit/utils/test_hashutils.py
@@ -8,6 +8,7 @@ from tests.support.unit import TestCase
 
 # Import Salt libs
 import salt.utils.hashutils
+import salt.utils.stringutils
 
 
 class HashutilsTestCase(TestCase):
@@ -59,7 +60,7 @@ class HashutilsTestCase(TestCase):
         )
         self.assertEqual(
             salt.utils.hashutils.base64_b64decode(self.bytes_b64encode_result),
-            self.bytes
+            salt.utils.stringutils.to_unicode(self.bytes)
         )
 
     def test_base64_encodestring(self):
@@ -88,7 +89,7 @@ class HashutilsTestCase(TestCase):
         )
         self.assertEqual(
             salt.utils.hashutils.base64_decodestring(self.bytes_encodestring_result),
-            self.bytes
+            salt.utils.stringutils.to_unicode(self.bytes)
         )
 
     def test_md5_digest(self):


### PR DESCRIPTION
### What does this PR do?
Fixes an issue where the hash was being returned as unicode, but was being compared with a bytestring, so the assert was failing... I think.

### What issues does this PR fix or reference?
Found in Jenkins testing

### Tests written?
Yes

### Commits signed with GPG?
Yes