### PR TITLE
Running fix

### DIFF
--- a/salt/states/virt.py
+++ b/salt/states/virt.py
@@ -158,14 +158,14 @@ def _virt_call(domain, function, section, comment, **kwargs):
     targeted_domains = fnmatch.filter(__salt__['virt.list_domains'](), domain)
     changed_domains = list()
     ignored_domains = list()
-    for domain in targeted_domains:
+    for targeted_domain in targeted_domains:
         try:
-            response = __salt__['virt.{0}'.format(function)](domain, **kwargs)
+            response = __salt__['virt.{0}'.format(function)](targeted_domain, **kwargs)
             if isinstance(response, dict):
                 response = response['name']
-            changed_domains.append({'domain': domain, function: response})
+            changed_domains.append({'domain': targeted_domain, function: response})
         except libvirt.libvirtError as err:
-            ignored_domains.append({'domain': domain, 'issue': six.text_type(err)})
+            ignored_domains.append({'domain': targeted_domain, 'issue': six.text_type(err)})
     if not changed_domains:
         ret['result'] = False
         ret['comment'] = 'No changes had happened'
@@ -333,7 +333,7 @@ def saved(name, suffix=None):
     return _virt_call(name, 'snapshot', 'saved', 'Snapshots has been taken', suffix=suffix)
 
 
-def reverted(name, snapshot=None, cleanup=False):
+def reverted(name, snapshot=None, cleanup=False):  # pylint: disable=redefined-outer-name
     '''
     .. deprecated:: 2016.3.0
 

--- a/salt/states/virt.py
+++ b/salt/states/virt.py
@@ -247,13 +247,17 @@ def running(name, **kwargs):
                 __salt__['virt.start'](name)
                 ret['changes'][name] = 'Domain started'
                 ret['comment'] = 'Domain {0} started'.format(name)
+            else:
+                ret['comment'] = 'Domain {0} exists and is running'.format(name)
         except CommandExecutionError:
             kwargs = salt.utils.args.clean_kwargs(**kwargs)
             __salt__['virt.init'](name, cpu=cpu, mem=mem, image=image, **kwargs)
             ret['changes'][name] = 'Domain defined and started'
             ret['comment'] = 'Domain {0} defined and started'.format(name)
-    except libvirt.libvirtError:
-        ret['comment'] = 'Domain {0} exists and is running'.format(name)
+    except libvirt.libvirtError as err:
+        # Something bad happened when starting the VM, report it
+        ret['comment'] = six.text_type(err)
+        ret['result'] = False
 
     return ret
 

--- a/tests/unit/states/test_libvirt.py
+++ b/tests/unit/states/test_libvirt.py
@@ -2,6 +2,8 @@
 '''
     :codeauthor: Jayesh Kariya <jayeshk@saltstack.com>
 '''
+# pylint: disable=3rd-party-module-not-gated
+
 # Import Python libs
 from __future__ import absolute_import, print_function, unicode_literals
 import tempfile
@@ -56,17 +58,17 @@ class LibvirtTestCase(TestCase, LoaderModuleMockMixin):
 
             mock = MagicMock(side_effect=[[], ['libvirt.servercert.pem'],
                                           {'libvirt.servercert.pem': 'A'}])
-            with patch.dict(virt.__salt__, {'pillar.ext': mock}):
+            with patch.dict(virt.__salt__, {'pillar.ext': mock}):  # pylint: disable=no-member
                 comt = ('All keys are correct')
                 ret.update({'comment': comt})
                 self.assertDictEqual(virt.keys(name, basepath=self.pki_dir), ret)
 
-                with patch.dict(virt.__opts__, {'test': True}):
+                with patch.dict(virt.__opts__, {'test': True}):  # pylint: disable=no-member
                     comt = ('Libvirt keys are set to be updated')
                     ret.update({'comment': comt, 'result': None})
                     self.assertDictEqual(virt.keys(name, basepath=self.pki_dir), ret)
 
-                with patch.dict(virt.__opts__, {'test': False}):
+                with patch.dict(virt.__opts__, {'test': False}):  # pylint: disable=no-member
                     with patch.object(salt.utils.files, 'fopen', MagicMock(mock_open())):
                         comt = ('Updated libvirt certs and keys')
                         ret.update({'comment': comt, 'result': True,
@@ -87,21 +89,21 @@ class LibvirtTestCase(TestCase, LoaderModuleMockMixin):
 
             mock = MagicMock(side_effect=[[], ['libvirt.servercert.pem'],
                                           {'libvirt.servercert.pem': 'A'}])
-            with patch.dict(virt.__salt__, {'pillar.ext': mock}):
+            with patch.dict(virt.__salt__, {'pillar.ext': mock}):  # pylint: disable=no-member
                 comt = ('All keys are correct')
                 ret.update({'comment': comt})
                 self.assertDictEqual(virt.keys(name,
                                                basepath=self.pki_dir,
                                                expiration_days=700), ret)
 
-                with patch.dict(virt.__opts__, {'test': True}):
+                with patch.dict(virt.__opts__, {'test': True}):  # pylint: disable=no-member
                     comt = ('Libvirt keys are set to be updated')
                     ret.update({'comment': comt, 'result': None})
                     self.assertDictEqual(virt.keys(name,
                                                    basepath=self.pki_dir,
                                                    expiration_days=700), ret)
 
-                with patch.dict(virt.__opts__, {'test': False}):
+                with patch.dict(virt.__opts__, {'test': False}):  # pylint: disable=no-member
                     with patch.object(salt.utils.files, 'fopen', MagicMock(mock_open())):
                         comt = ('Updated libvirt certs and keys')
                         ret.update({'comment': comt, 'result': True,
@@ -124,21 +126,21 @@ class LibvirtTestCase(TestCase, LoaderModuleMockMixin):
 
             mock = MagicMock(side_effect=[[], ['libvirt.servercert.pem'],
                                           {'libvirt.servercert.pem': 'A'}])
-            with patch.dict(virt.__salt__, {'pillar.ext': mock}):
+            with patch.dict(virt.__salt__, {'pillar.ext': mock}):  # pylint: disable=no-member
                 comt = ('All keys are correct')
                 ret.update({'comment': comt})
                 self.assertDictEqual(virt.keys(name,
                                                basepath=self.pki_dir,
                                                st='California'), ret)
 
-                with patch.dict(virt.__opts__, {'test': True}):
+                with patch.dict(virt.__opts__, {'test': True}):  # pylint: disable=no-member
                     comt = ('Libvirt keys are set to be updated')
                     ret.update({'comment': comt, 'result': None})
                     self.assertDictEqual(virt.keys(name,
                                                    basepath=self.pki_dir,
                                                    st='California'), ret)
 
-                with patch.dict(virt.__opts__, {'test': False}):
+                with patch.dict(virt.__opts__, {'test': False}):  # pylint: disable=no-member
                     with patch.object(salt.utils.files, 'fopen', MagicMock(mock_open())):
                         comt = ('Updated libvirt certs and keys')
                         ret.update({'comment': comt, 'result': True,
@@ -161,7 +163,7 @@ class LibvirtTestCase(TestCase, LoaderModuleMockMixin):
 
             mock = MagicMock(side_effect=[[], ['libvirt.servercert.pem'],
                                           {'libvirt.servercert.pem': 'A'}])
-            with patch.dict(virt.__salt__, {'pillar.ext': mock}):
+            with patch.dict(virt.__salt__, {'pillar.ext': mock}):  # pylint: disable=no-member
                 comt = ('All keys are correct')
                 ret.update({'comment': comt})
                 self.assertDictEqual(virt.keys(name,
@@ -172,7 +174,7 @@ class LibvirtTestCase(TestCase, LoaderModuleMockMixin):
                                                organization='SaltStack',
                                                expiration_days=700), ret)
 
-                with patch.dict(virt.__opts__, {'test': True}):
+                with patch.dict(virt.__opts__, {'test': True}):  # pylint: disable=no-member
                     comt = ('Libvirt keys are set to be updated')
                     ret.update({'comment': comt, 'result': None})
                     self.assertDictEqual(virt.keys(name,
@@ -183,7 +185,7 @@ class LibvirtTestCase(TestCase, LoaderModuleMockMixin):
                                                    organization='SaltStack',
                                                    expiration_days=700), ret)
 
-                with patch.dict(virt.__opts__, {'test': False}):
+                with patch.dict(virt.__opts__, {'test': False}):  # pylint: disable=no-member
                     with patch.object(salt.utils.files, 'fopen', MagicMock(mock_open())):
                         comt = ('Updated libvirt certs and keys')
                         ret.update({'comment': comt, 'result': True,

--- a/tests/unit/states/test_libvirt.py
+++ b/tests/unit/states/test_libvirt.py
@@ -25,13 +25,29 @@ import salt.states.virt as virt
 import salt.utils.files
 
 
+class LibvirtMock(MagicMock):  # pylint: disable=too-many-ancestors
+    '''
+    libvirt library mockup
+    '''
+
+    class libvirtError(Exception):  # pylint: disable=invalid-name
+        '''
+        libvirt error mockup
+        '''
+
+
 @skipIf(NO_MOCK, NO_MOCK_REASON)
 class LibvirtTestCase(TestCase, LoaderModuleMockMixin):
     '''
     Test cases for salt.states.libvirt
     '''
     def setup_loader_modules(self):
-        return {virt: {}}
+        self.mock_libvirt = LibvirtMock()  # pylint: disable=attribute-defined-outside-init
+        self.addCleanup(delattr, self, 'mock_libvirt')
+        loader_globals = {
+            'libvirt': self.mock_libvirt
+        }
+        return {virt: loader_globals}
 
     @classmethod
     def setUpClass(cls):
@@ -197,3 +213,26 @@ class LibvirtTestCase(TestCase, LoaderModuleMockMixin):
                                                        locality='Los_Angeles',
                                                        organization='SaltStack',
                                                        expiration_days=700), ret)
+
+    def test_running(self):
+        '''
+        running state test cases.
+        '''
+        ret = {'name': 'myvm',
+               'changes': {},
+               'result': True,
+               'comment': 'myvm is running'}
+        with patch.dict(virt.__salt__, {  # pylint: disable=no-member
+                    'virt.vm_state': MagicMock(return_value='stopped'),
+                    'virt.start': MagicMock(return_value=0)
+                }):
+            ret.update({'changes': {'myvm': 'Domain started'},
+                        'comment': 'Domain myvm started'})
+            self.assertDictEqual(virt.running('myvm'), ret)
+
+        with patch.dict(virt.__salt__, {  # pylint: disable=no-member
+                    'virt.vm_state': MagicMock(return_value='stopped'),
+                    'virt.start': MagicMock(side_effect=[self.mock_libvirt.libvirtError('libvirt error msg')])
+                }):
+            ret.update({'changes': {}, 'result': False, 'comment': 'libvirt error msg'})
+            self.assertDictEqual(virt.running('myvm'), ret)


### PR DESCRIPTION
### What does this PR do?

Report an error when a VM fails to start while applying `virt.running` state

### What issues does this PR fix or reference?

issue #47972 

### Previous Behavior

When applying `virt.running` state to a VM that fails to work (like network not started) the return message was that the domain was already up and running

### New Behavior

When applying `virt.running` state to a VM that fails to work (like network not started) the return message will be the libvirt error and the result will be set to `False`.

### Tests written?

Yes, added virt.running test cases

### Commits signed with GPG?

Yes
