### PR TITLE
[WIP] Add environment variable to know if yum is invoked from Salt

### DIFF
--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -465,7 +465,8 @@ def latest_version(*names, **kwargs):
     out = __salt__['cmd.run_all'](cmd,
                                   output_loglevel='trace',
                                   ignore_retcode=True,
-                                  python_shell=False)
+                                  python_shell=False,
+                                  env={"SALT_RUNNING": '1'})
     if out['retcode'] != 0:
         if out['stderr']:
             # Check first if this is just a matter of the packages being
@@ -885,7 +886,8 @@ def list_repo_pkgs(*args, **kwargs):
                 cmd_prefix + [pkg_src],
                 output_loglevel='trace',
                 ignore_retcode=True,
-                python_shell=False
+                python_shell=False,
+                env={"SALT_RUNNING": '1'}
             )
             if out['retcode'] == 0:
                 _parse_output(out['stdout'], strict=True)
@@ -902,7 +904,8 @@ def list_repo_pkgs(*args, **kwargs):
                 cmd_prefix + [pkg_src],
                 output_loglevel='trace',
                 ignore_retcode=True,
-                python_shell=False
+                python_shell=False,
+                env={"SALT_RUNNING": '1'}
             )
             if out['retcode'] == 0:
                 _parse_output(out['stdout'], strict=True)
@@ -918,7 +921,8 @@ def list_repo_pkgs(*args, **kwargs):
             out = __salt__['cmd.run_all'](cmd,
                                           output_loglevel='trace',
                                           ignore_retcode=True,
-                                          python_shell=False)
+                                          python_shell=False,
+                                          env={"SALT_RUNNING": '1'})
             if out['retcode'] != 0 and 'Error:' in out['stdout']:
                 continue
             _parse_output(out['stdout'])
@@ -975,7 +979,8 @@ def list_upgrades(refresh=True, **kwargs):
     out = __salt__['cmd.run_all'](cmd,
                                   output_loglevel='trace',
                                   ignore_retcode=True,
-                                  python_shell=False)
+                                  python_shell=False,
+                                  env={"SALT_RUNNING": '1'})
     if out['retcode'] != 0 and 'Error:' in out:
         return {}
 
@@ -1116,12 +1121,13 @@ def refresh_db(**kwargs):
     clean_cmd.extend(options)
     update_cmd.extend(options)
 
-    __salt__['cmd.run'](clean_cmd, python_shell=False)
+    __salt__['cmd.run'](clean_cmd, python_shell=False, env={"SALT_RUNNING": '1'})
     if check_update_:
         result = __salt__['cmd.retcode'](update_cmd,
                                          output_loglevel='trace',
                                          ignore_retcode=True,
-                                         python_shell=False)
+                                         python_shell=False,
+                                         env={"SALT_RUNNING": '1'})
         return retcodes.get(result, False)
     return True
 
@@ -1672,7 +1678,8 @@ def install(name=None,
                 cmd,
                 output_loglevel='trace',
                 python_shell=False,
-                redirect_stderr=True
+                redirect_stderr=True,
+                env={"SALT_RUNNING": '1'}
             )
             if out['retcode'] != 0:
                 errors.append(out['stdout'])
@@ -1692,7 +1699,8 @@ def install(name=None,
                 cmd,
                 output_loglevel='trace',
                 python_shell=False,
-                redirect_stderr=True
+                redirect_stderr=True,
+                env={"SALT_RUNNING": '1'}
             )
             if out['retcode'] != 0:
                 errors.append(out['stdout'])
@@ -1712,7 +1720,8 @@ def install(name=None,
                 cmd,
                 output_loglevel='trace',
                 python_shell=False,
-                redirect_stderr=True
+                redirect_stderr=True,
+                env={"SALT_RUNNING": '1'}
             )
             if out['retcode'] != 0:
                 errors.append(out['stdout'])
@@ -1943,7 +1952,8 @@ def upgrade(name=None,
 
     result = __salt__['cmd.run_all'](cmd,
                                      output_loglevel='trace',
-                                     python_shell=False)
+                                     python_shell=False,
+                                     env={"SALT_RUNNING": '1'})
     __context__.pop('pkg.list_pkgs', None)
     new = list_pkgs()
     ret = salt.utils.data.compare_dicts(old, new)
@@ -2057,7 +2067,8 @@ def remove(name=None, pkgs=None, **kwargs):  # pylint: disable=W0613
     out = __salt__['cmd.run_all'](
         [_yum(), '-y', 'remove'] + targets,
         output_loglevel='trace',
-        python_shell=False
+        python_shell=False,
+        env={"SALT_RUNNING": '1'}
     )
 
     if out['retcode'] != 0 and out['stderr']:
@@ -2194,7 +2205,8 @@ def hold(name=None, pkgs=None, sources=None, normalize=True, **kwargs):  # pylin
             else:
                 out = __salt__['cmd.run_all'](
                     [_yum(), 'versionlock', target],
-                    python_shell=False
+                    python_shell=False,
+                    env={"SALT_RUNNING": '1'}
                 )
 
                 if out['retcode'] == 0:
@@ -2303,7 +2315,8 @@ def unhold(name=None, pkgs=None, sources=None, **kwargs):  # pylint: disable=W06
             else:
                 out = __salt__['cmd.run_all'](
                     [_yum(), 'versionlock', 'delete'] + search_locks,
-                    python_shell=False
+                    python_shell=False,
+                    env={"SALT_RUNNING": '1'}
                 )
 
                 if out['retcode'] == 0:
@@ -2354,7 +2367,8 @@ def list_holds(pattern=__HOLD_PATTERN, full=True):
     _check_versionlock()
 
     out = __salt__['cmd.run']([_yum(), 'versionlock', 'list'],
-                              python_shell=False)
+                              python_shell=False,
+                              env={"SALT_RUNNING": '1'})
     ret = []
     for line in salt.utils.itertools.split(out, '\n'):
         match = _get_hold(line, pattern=pattern, full=full)
@@ -2419,7 +2433,8 @@ def group_list():
     out = __salt__['cmd.run_stdout'](
         [_yum(), 'grouplist', 'hidden'],
         output_loglevel='trace',
-        python_shell=False
+        python_shell=False,
+        env={"SALT_RUNNING": '1'}
     )
     key = None
     for line in salt.utils.itertools.split(out, '\n'):
@@ -2486,7 +2501,8 @@ def group_info(name, expand=False):
     out = __salt__['cmd.run_stdout'](
         cmd,
         output_loglevel='trace',
-        python_shell=False
+        python_shell=False,
+        env={"SALT_RUNNING": '1'}
     )
 
     g_info = {}
@@ -3154,7 +3170,8 @@ def download(*packages):
     __salt__['cmd.run'](
         cmd,
         output_loglevel='trace',
-        python_shell=False
+        python_shell=False,
+        env={"SALT_RUNNING": '1'}
     )
     ret = {}
     for dld_result in os.listdir(CACHE_DIR):
@@ -3229,7 +3246,8 @@ def _get_patches(installed_only=False):
     cmd = [_yum(), '--quiet', 'updateinfo', 'list', 'all']
     ret = __salt__['cmd.run_stdout'](
         cmd,
-        python_shell=False
+        python_shell=False,
+        env={"SALT_RUNNING": '1'}
     )
     for line in salt.utils.itertools.split(ret, os.linesep):
         inst, advisory_id, sev, pkg = re.match(r'([i|\s]) ([^\s]+) +([^\s]+) +([^\s]+)',


### PR DESCRIPTION
### What does this PR do?
[WIP] Add an environment variable in the yum invocation to know if yum is invoked from Salt
Since yum (and zypper) allow plugins, it is very useful knowing if yum/zypper is invoked from Salt

### Previous Behavior
Evrytime yum is called from Salt, there's no way to know where was it called from.

### New Behavior
Everytime yum is called from Salt, we can actually know if was invoked from Salt so plugins could react accordingly in case it's needed (like zypper module is already doing).

### Tests written?

No

### Commits signed with GPG?

No