### PR TITLE
Find job pause

### DIFF
--- a/salt/runners/jobs.py
+++ b/salt/runners/jobs.py
@@ -77,6 +77,7 @@ def active(display_progress=False):
 
     return ret
 
+
 def lookup_jid(jid,
                ext_source=None,
                returned=True,

--- a/salt/runners/jobs.py
+++ b/salt/runners/jobs.py
@@ -70,12 +70,12 @@ def active(display_progress=False):
     for jid in ret:
         returner = _get_returner((__opts__['ext_job_cache'], __opts__['master_job_cache']))
         data = mminion.returners['{0}.get_jid'.format(returner)](jid)
-        for minion in data:
-            if minion not in ret[jid]['Returned']:
-                ret[jid]['Returned'].append(minion)
+        if data:
+            for minion in data:
+                if minion not in ret[jid]['Returned']:
+                    ret[jid]['Returned'].append(minion)
 
     return ret
-
 
 def lookup_jid(jid,
                ext_source=None,
@@ -541,6 +541,10 @@ def _format_job_instance(job):
     '''
     Helper to format a job instance
     '''
+    if not job:
+        ret = {'Error': 'Cannot contact returner or no job with this jid'}
+        return ret
+
     ret = {'Function': job.get('fun', 'unknown-function'),
            'Arguments': list(job.get('arg', [])),
            # unlikely but safeguard from invalid returns

--- a/salt/runners/jobs.py
+++ b/salt/runners/jobs.py
@@ -133,15 +133,16 @@ def lookup_jid(jid,
     targeted_minions = data.get('Minions', [])
     returns = data.get('Result', {})
 
-    for minion in returns:
-        if display_progress:
-            __jid_event__.fire_event({'message': minion}, 'progress')
-        if u'return' in returns[minion]:
-            if returned:
-                ret[minion] = returns[minion].get(u'return')
-        else:
-            if returned:
-                ret[minion] = returns[minion].get('return')
+    if returns:
+        for minion in returns:
+            if display_progress:
+                __jid_event__.fire_event({'message': minion}, 'progress')
+            if u'return' in returns[minion]:
+                if returned:
+                    ret[minion] = returns[minion].get(u'return')
+            else:
+                if returned:
+                    ret[minion] = returns[minion].get('return')
     if missing:
         for minion_id in (x for x in targeted_minions if x not in returns):
             ret[minion_id] = 'Minion did not return'


### PR DESCRIPTION
### What does this PR do?

Fixes a few cases where the jobs runner would stacktrace if it could not communicate with a returner or external job cache.

### Previous Behavior

If a returner could not be contacted, functions in the jobs runner (like jobs.active) would stacktrace.

### New Behavior

Stacktraces are avoided, and in some cases a more helpful error message is presented.

### Tests written?

No

### Commits signed with GPG?

Yes
