### PR TITLE
win_wua state: fix function name in examples

### DIFF
--- a/salt/states/win_wua.py
+++ b/salt/states/win_wua.py
@@ -410,18 +410,18 @@ def uptodate(name,
 
         # Update the system using the state defaults
         update_system:
-          wua.up_to_date
+          wua.uptodate
 
         # Update the drivers
         update_drivers:
-          wua.up_to_date:
+          wua.uptodate:
             - software: False
             - drivers: True
             - skip_reboot: False
 
         # Apply all critical updates
         update_critical:
-          wua.up_to_date:
+          wua.uptodate:
             - severities:
               - Critical
     '''


### PR DESCRIPTION
### What does this PR do?
Fixes function name in examples for win_wua state module
(Changes 'up_to_date' to 'uptodate')