### PR TITLE
Fix Salt-Syndic Show [No Response] on syndic minions

### DIFF
--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -1329,8 +1329,8 @@ class LocalClient(object):
             for minion in list((minions - found)):
                 yield {minion: {'failed': True}}
 
-        if missing:
-            for minion in missing:
+        if set(missing) - found:
+            for minion in set(missing) - found:
                 yield {minion: {'failed': True}}
 
     def get_returns(


### PR DESCRIPTION
Fixes: 48000

### What does this PR do?
Fix Salt-Syndic Show [No Response] on syndic minions, the issue number is: 48000

### What issues does this PR fix or reference?



### Previous Behavior
```bash
vagrant@master:~$ bash cherry-t.sh
+ curl http://localhost:8000/login -c ./cookies.txt -H 'Accept: application/x-yaml' -d username=saltdev -d password=saltdev -d eauth=pam
return:
- eauth: pam
  expire: 1528336871.5202
  perms:
  - '*':
    - test.*
    - state.*
    - grains.*
    - pkg.*
  start: 1528293671.520196
  token: 8ec97d066c7aa6fd104c70fcb04c523231d13dc6
  user: saltdev
+ curl http://localhost:8000 -b ./cookies.txt -H 'Accept: application/x-yaml' -d client=local -d tgt=minion01,minion02,master-syndic -d fun=state.sls -d tgt_type=list -d arg=test
return:
- master-syndic:
    cmd_|-test cmd_|-uptime_|-run:
      __id__: test cmd
      __run_num__: 0
      __sls__: test
      changes:
        pid: 24026
        retcode: 0
        stderr: ''
        stdout: ' 14:01:12 up  6:28,  1 user,  load average: 0.07, 0.03, 0.00'
      comment: Command "uptime" run
      duration: 20.197
      name: uptime
      result: true
      start_time: '14:01:12.172091'
  minion01: Minion did not return. [No response]
  minion02: Minion did not return. [No response]
```

### New Behavior
```bash
vagrant@master:~$ bash cherry-t.sh
+ curl http://localhost:8000/login -c ./cookies.txt -H 'Accept: application/x-yaml' -d username=saltdev -d password=saltdev -d eauth=pam
return:
- eauth: pam
  expire: 1528405432.097989
  perms:
  - '*':
    - test.*
    - state.*
    - grains.*
    - pkg.*
  start: 1528362232.097989
  token: b8106a8022751138a75108b35e3bd54bc72f5354
  user: saltdev
+ curl http://localhost:8000 -b ./cookies.txt -H 'Accept: application/x-yaml' -d client=local -d tgt=minion01,minion02,master-syndic -d fun=state.sls -d arg=test -d tgt_type=list
return:
- master-syndic:
    cmd_|-test cmd_|-uptime_|-run:
      __id__: test cmd
      __run_num__: 0
      __sls__: test
      changes:
        pid: 17250
        retcode: 0
        stderr: ''
        stdout: ' 09:03:53 up 1 day,  1:31,  0 users,  load average: 0.00, 0.00, 0.00'
      comment: Command "uptime" run
      duration: 20.268
      name: uptime
      result: true
      start_time: '09:03:53.179470'
  minion01:
    cmd_|-testing_|-uptime_|-run:
      __id__: testing
      __run_num__: 0
      __sls__: test
      changes:
        pid: 6372
        retcode: 0
        stderr: ''
        stdout: ' 09:03:53 up 1 day,  1:26,  0 users,  load average: 0.00, 0.00, 0.00'
      comment: Command "uptime" run
      duration: 13.106
      name: uptime
      result: true
      start_time: '09:03:53.096773'
  minion02:
    cmd_|-testing_|-uptime_|-run:
      __id__: testing
      __run_num__: 0
      __sls__: test
      changes:
        pid: 6234
        retcode: 0
        stderr: ''
        stdout: ' 09:03:52 up 1 day,  1:24,  0 users,  load average: 0.00, 0.00, 0.00'
      comment: Command "uptime" run
      duration: 10.034
      name: uptime
      result: true
      start_time: '09:03:52.753170'
```
### Tests written?

No

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
