### PR TITLE
recommend --force-with-lease when rebasing

### DIFF
--- a/doc/topics/development/contributing.rst
+++ b/doc/topics/development/contributing.rst
@@ -154,7 +154,7 @@ Fork a Repo Guide_>`_ and is well worth reading.
             nothing to commit, working tree clean
 
         Do **NOT** perform a ``git pull`` or ``git merge`` here. Instead, add
-        ``--force`` to the end of the ``git push`` command to get the changes
+        ``--force-with-lease`` to the end of the ``git push`` command to get the changes
         pushed to your fork. Pulling or merging, while they will resolve the
         non-fast-forward issue, will likely add extra commits to the pull
         request which were not part of your changes.


### PR DESCRIPTION
Using `--force-with-lease` allows one to force push without the risk of
unintentionally overwriting someone else's work.

## The git-push(1) man page states:

Usually, "git push" refuses to update a remote ref that is not an ancestor of the local ref used to overwrite it.

This option overrides this restriction if the current value of the remote ref is the expected value. "git push" fails otherwise.

Imagine that you have to rebase what you have already published. You will have to bypass the "must fast-forward" rule in order to replace the history you originally published with the rebased history. If somebody else built on top of your original history while you are rebasing, the tip of the branch at the remote may advance with her commit, and blindly pushing with --force will lose her work.

This option allows you to say that you expect the history you are updating is what you rebased and want to replace. If the remote ref still points at the commit you specified, you can be sure that no other people did anything to the ref. It is like taking a "lease" on the ref without explicitly locking it, and the remote ref is updated only if the "lease" is still valid.

## Additional References:
- https://developer.atlassian.com/blog/2015/04/force-with-lease/
- https://github.com/thoughtbot/guides/pull/363

### What does this PR do?
Update contributing doc to recommend using the --force-with-lease option instead of --force with `git push`.

### What issues does this PR fix or reference?
n/a

### Tests written?

No

### Commits signed with GPG?

Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
