### PR TITLE
restart salt-syndic when salt-master restart

### DIFF
--- a/pkg/deb/salt-syndic.service
+++ b/pkg/deb/salt-syndic.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=The Salt Syndic daemon
 After=network.target
+PartOf=salt-master.service
 
 [Service]
 Type=notify

--- a/pkg/salt-syndic.service
+++ b/pkg/salt-syndic.service
@@ -2,6 +2,7 @@
 Description=The Salt Master Server
 Documentation=man:salt-syndic(1) file:///usr/share/doc/salt/html/contents.html https://docs.saltstack.com/en/latest/contents.html
 After=network.target
+PartOf=salt-master.service
 
 [Service]
 Type=notify


### PR DESCRIPTION


### What does this PR do?

add salt-syndic as part of salt-master, which will make auto-restart salt-syndic when salt-master restart.  when a salt-master work as a syndic, restart salt-master but not restart salt-syndic will cause syndic cache the auth_key, and will lead to auth failed, this PR will not completely solve the problem from the source code side. but will make salt-syndic work properly.

### What issues does this PR fix or reference?

Fixes:  #48029


### Tests written?

No

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
