### PR TITLE
Provide python version mismatch solutions

### DIFF
--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -1393,6 +1393,26 @@ ARGS = {arguments}\n'''.format(config=self.minion_config,
         perm_error_fmt = 'Permissions problem, target user may need '\
                          'to be root or use sudo:\n {0}'
 
+        python_mismatch_options = {
+            '3.x': (
+                'Depending on the Python version on the target, you need to' +
+                ' install Python2.7 compatible salt on origin to add support for Python2.7 targets or' +
+                ' install Python2.6 compatible salt on origin to add support for Python2.6 targets or' +
+                ' upgrade to Python==3.x on target'
+            ),
+            '2.7': (
+                'Depending on the Python version on the target, you need to' +
+                ' upgrade to Python3 on origin to match Python3 on target or' +
+                ' install Python2.7 compatible Salt on origin to add support for Python2.7 targets or' +
+                ' install Python2.6 compatible Salt on origin to add support for Python2.6 targets'
+            ),
+            '2.6': (
+                'Upgrade Python on origin to match the Python version available on target' +
+                ' and install the corresponding Salt package(Python2 compatible Salt or Python3 compatible Salt).'
+            ),
+            'default': 'Matching Python>=2.6 version needed both on origin and target.'
+        }
+
         errors = [
             (
                 (),
@@ -1401,8 +1421,15 @@ ARGS = {arguments}\n'''.format(config=self.minion_config,
             ),
             (
                 (salt.defaults.exitcodes.EX_THIN_PYTHON_INVALID,),
-                'Python interpreter is too old',
-                'salt requires python 2.6 or newer on target hosts, must have same major version as origin host'
+                'Python version mismatched',
+                python_mismatch_options.get(
+                    # check for major.minor first
+                    '%s.%s' % sys.version_info[0:2]
+                ) or python_mismatch_options.get(
+                    # check for major.any
+                    '%s.x' % sys.version_info[0]
+                    # show the default
+                ) or python_mismatch_options['default']
             ),
             (
                 (salt.defaults.exitcodes.EX_THIN_CHECKSUM,),

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -1421,13 +1421,13 @@ ARGS = {arguments}\n'''.format(config=self.minion_config,
             ),
             (
                 (salt.defaults.exitcodes.EX_THIN_PYTHON_INVALID,),
-                'Python version mismatched',
+                'Python interpreter is too old',
                 python_mismatch_options.get(
                     # check for major.minor first
-                    '%s.%s' % sys.version_info[0:2]
+                    '{ver[0]}.{ver[1]}'.format(ver=sys.version_info)
                 ) or python_mismatch_options.get(
                     # check for major.any
-                    '%s.x' % sys.version_info[0]
+                    '{ver[0]}.x'.format(ver=sys.version_info)
                     # show the default
                 ) or python_mismatch_options['default']
             ),


### PR DESCRIPTION
### What does this PR do?

Improves the error message when Python version mismatch detected by providing solutions.

### What issues does this PR fix or reference?

See below.

### Previous Behavior (Python3 origin - Python2.7 target)

```bash
bash-4.4# salt-ssh -l quiet -i --out json --key-deploy --passwd admin123 container__wjQFc test.ping
{
    "container__wjQFc": {
        "stdout": "ERROR: salt requires python 2.6 or newer on target hosts, must have same major version as origin host",                                                                                                                  
        "stderr": "",
        "retcode": 10
    }
}
```

### New Behavior (Python3 origin - Python2.7 target)

```bash
bash-4.4# salt-ssh -l quiet -i --out json --key-deploy --passwd admin123 container__wjQFc test.ping
{
    "container__wjQFc": {
        "stdout": "ERROR: Depending on the Python version on the target, you need to install python2-salt on origin to add support for Python2.7 targets or install py26-compat-salt on origin to add support for Python2.6 targets or upgrade to Python==3.x on target",
        "stderr": "",
        "retcode": 10
    }
}
```

### Tests written?

No

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
