### PR TITLE
Add "sync_mods" argument to state.apply/state.sls

### DIFF
--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -150,17 +150,13 @@ Why aren't my custom modules/states/etc. available on my Minions?
 Custom modules are synced to Minions when
 :mod:`saltutil.sync_modules <salt.modules.saltutil.sync_modules>`,
 or :mod:`saltutil.sync_all <salt.modules.saltutil.sync_all>` is run.
-Custom modules are also synced by :mod:`state.apply` when run without
-any arguments.
 
+Similarly, custom states are synced to Minions when :mod:`saltutil.sync_states
+<salt.modules.saltutil.sync_states>`, or :mod:`saltutil.sync_all
+<salt.modules.saltutil.sync_all>` is run.
 
-Similarly, custom states are synced to Minions
-when :mod:`state.apply <salt.modules.state.apply_>`,
-:mod:`saltutil.sync_states <salt.modules.saltutil.sync_states>`, or
-:mod:`saltutil.sync_all <salt.modules.saltutil.sync_all>` is run.
-
-Custom states are also synced by :mod:`state.apply<salt.modules.state.apply_>`
-when run without any arguments.
+They are both also synced when a :ref:`highstate <running-highstate>` is
+triggered.
 
 Other custom types (renderers, outputters, etc.) have similar behavior, see the
 documentation for the :mod:`saltutil <salt.modules.saltutil>` module for more

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -148,18 +148,23 @@ Why aren't my custom modules/states/etc. available on my Minions?
 -----------------------------------------------------------------
 
 Custom modules are synced to Minions when
-:mod:`saltutil.sync_modules <salt.modules.saltutil.sync_modules>`,
-or :mod:`saltutil.sync_all <salt.modules.saltutil.sync_all>` is run.
+:py:func:`saltutil.sync_modules <salt.modules.saltutil.sync_modules>`,
+or :py:func:`saltutil.sync_all <salt.modules.saltutil.sync_all>` is run.
 
-Similarly, custom states are synced to Minions when :mod:`saltutil.sync_states
-<salt.modules.saltutil.sync_states>`, or :mod:`saltutil.sync_all
+Similarly, custom states are synced to Minions when :py:func:`saltutil.sync_states
+<salt.modules.saltutil.sync_states>`, or :py:func:`saltutil.sync_all
 <salt.modules.saltutil.sync_all>` is run.
 
 They are both also synced when a :ref:`highstate <running-highstate>` is
 triggered.
 
+As of the Fluorine release, as well as 2017.7.7 and 2018.3.2 in their
+respective release cycles, the ``sync`` argument to :py:func:`state.apply
+<salt.modules.state.apply_>`/:py:func:`state.sls <salt.modules.state.sls>` can
+be used to sync custom types when running individual SLS files.
+
 Other custom types (renderers, outputters, etc.) have similar behavior, see the
-documentation for the :mod:`saltutil <salt.modules.saltutil>` module for more
+documentation for the :py:func:`saltutil <salt.modules.saltutil>` module for more
 information.
 
 :ref:`This reactor example <minion-start-reactor>` can be used to automatically

--- a/doc/topics/utils/index.rst
+++ b/doc/topics/utils/index.rst
@@ -135,9 +135,9 @@ where it is necessary to invoke the same function from a custom :ref:`outputter
 <all-salt.output>`/returner, as well as an execution module.
 
 Utility modules placed in ``salt://_utils/`` will be synced to the minions when
-any of the following Salt functions are called:
+a :ref:`highstate <running-highstate>` is run, as well as when any of the
+following Salt functions are called:
 
-* :mod:`state.apply <salt.modules.state.apply_>`
 * :mod:`saltutil.sync_utils <salt.modules.saltutil.sync_utils>`
 * :mod:`saltutil.sync_all <salt.modules.saltutil.sync_all>`
 

--- a/doc/topics/utils/index.rst
+++ b/doc/topics/utils/index.rst
@@ -138,10 +138,15 @@ Utility modules placed in ``salt://_utils/`` will be synced to the minions when
 a :ref:`highstate <running-highstate>` is run, as well as when any of the
 following Salt functions are called:
 
-* :mod:`saltutil.sync_utils <salt.modules.saltutil.sync_utils>`
-* :mod:`saltutil.sync_all <salt.modules.saltutil.sync_all>`
+* :py:func:`saltutil.sync_utils <salt.modules.saltutil.sync_utils>`
+* :py:func:`saltutil.sync_all <salt.modules.saltutil.sync_all>`
+
+As of the Fluorine release, as well as 2017.7.7 and 2018.3.2 in their
+respective release cycles, the ``sync`` argument to :py:func:`state.apply
+<salt.modules.state.apply_>`/:py:func:`state.sls <salt.modules.state.sls>` can
+be used to sync custom types when running individual SLS files.
 
 To sync to the Master, use either of the following:
 
-* :mod:`saltutil.sync_utils <salt.runners.saltutil.sync_utils>`
-* :mod:`saltutil.sync_all <salt.runners.saltutil.sync_all>`
+* :py:func:`saltutil.sync_utils <salt.runners.saltutil.sync_utils>`
+* :py:func:`saltutil.sync_all <salt.runners.saltutil.sync_all>`

--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -613,7 +613,7 @@ def apply_(mods=None, **kwargs):
             :ref:`highstate <running-highstate>` automatically syncs all custom
             module types.
 
-        .. versionadded:: 2017.7.7,2018.3.3,Fluorine
+        .. versionadded:: 2017.7.8,2018.3.3,Fluorine
     '''
     if mods:
         return sls(mods, **kwargs)
@@ -1043,7 +1043,7 @@ def sls(mods, test=None, exclude=None, queue=False, sync_mods=None, **kwargs):
             salt '*' state.sls test sync_mods=states,modules
             salt '*' state.sls test sync_mods=all
 
-        .. versionadded:: 2017.7.7,2018.3.3,Fluorine
+        .. versionadded:: 2017.7.8,2018.3.3,Fluorine
 
     CLI Example:
 

--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -599,14 +599,14 @@ def apply_(mods=None, **kwargs):
 
             salt '*' state.apply test localconfig=/path/to/minion.yml
 
-    sync
+    sync_mods
         If specified, the desired custom module types will be synced prior to
         running the SLS files:
 
         .. code-block:: bash
 
-            salt '*' state.apply test sync=states,modules
-            salt '*' state.apply test sync=all
+            salt '*' state.apply test sync_mods=states,modules
+            salt '*' state.apply test sync_mods=all
 
         .. note::
             This option is ignored when no SLS files are specified, as a
@@ -943,7 +943,7 @@ def highstate(test=None, queue=False, **kwargs):
     return ret
 
 
-def sls(mods, test=None, exclude=None, queue=False, sync=None, **kwargs):
+def sls(mods, test=None, exclude=None, queue=False, sync_mods=None, **kwargs):
     '''
     Execute the states in one or more SLS files
 
@@ -1034,14 +1034,14 @@ def sls(mods, test=None, exclude=None, queue=False, sync=None, **kwargs):
 
         .. versionadded:: 2015.8.4
 
-    sync
+    sync_mods
         If specified, the desired custom module types will be synced prior to
         running the SLS files:
 
         .. code-block:: bash
 
-            salt '*' state.sls test sync=states,modules
-            salt '*' state.sls test sync=all
+            salt '*' state.sls test sync_mods=states,modules
+            salt '*' state.sls test sync_mods=all
 
         .. versionadded:: 2017.7.7,2018.3.2,Fluorine
 
@@ -1113,18 +1113,18 @@ def sls(mods, test=None, exclude=None, queue=False, sync=None, **kwargs):
             '{0}.cache.p'.format(kwargs.get('cache_name', 'highstate'))
             )
 
-    if sync is True:
-        sync = ['all']
-    if sync is not None:
-        sync = salt.utils.split_input(sync)
+    if sync_mods is True:
+        sync_mods = ['all']
+    if sync_mods is not None:
+        sync_mods = salt.utils.split_input(sync_mods)
     else:
-        sync = []
+        sync_mods = []
 
-    if 'all' in sync and sync != ['all']:
+    if 'all' in sync_mods and sync_mods != ['all']:
         # Prevent unnecessary extra syncing
-        sync = ['all']
+        sync_mods = ['all']
 
-    for module_type in sync:
+    for module_type in sync_mods:
         try:
             __salt__['saltutil.sync_{0}'.format(module_type)](
                 saltenv=opts['environment']

--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -613,7 +613,7 @@ def apply_(mods=None, **kwargs):
             :ref:`highstate <running-highstate>` automatically syncs all custom
             module types.
 
-        .. versionadded:: 2017.7.7,2018.3.2,Fluorine
+        .. versionadded:: 2017.7.7,2018.3.3,Fluorine
     '''
     if mods:
         return sls(mods, **kwargs)
@@ -1043,7 +1043,7 @@ def sls(mods, test=None, exclude=None, queue=False, sync_mods=None, **kwargs):
             salt '*' state.sls test sync_mods=states,modules
             salt '*' state.sls test sync_mods=all
 
-        .. versionadded:: 2017.7.7,2018.3.2,Fluorine
+        .. versionadded:: 2017.7.7,2018.3.3,Fluorine
 
     CLI Example:
 

--- a/tests/unit/modules/test_state.py
+++ b/tests/unit/modules/test_state.py
@@ -960,7 +960,7 @@ class StateTestCase(TestCase, LoaderModuleMockMixin):
                 'saltutil.sync_states': Mock(),
             }
             with patch.dict(state.__salt__, sync_mocks):
-                state.sls('foo', sync='modules,states')
+                state.sls('foo', sync_mods='modules,states')
 
             for key in sync_mocks:
                 call_count = sync_mocks[key].call_count
@@ -973,7 +973,7 @@ class StateTestCase(TestCase, LoaderModuleMockMixin):
             # Test syncing all
             sync_mocks = {'saltutil.sync_all': Mock()}
             with patch.dict(state.__salt__, sync_mocks):
-                state.sls('foo', sync='all')
+                state.sls('foo', sync_mods='all')
 
             for key in sync_mocks:
                 call_count = sync_mocks[key].call_count
@@ -983,10 +983,10 @@ class StateTestCase(TestCase, LoaderModuleMockMixin):
                         key, call_count, expected
                     )
 
-            # sync=True should be interpreted as sync=all
+            # sync_mods=True should be interpreted as sync_mods=all
             sync_mocks = {'saltutil.sync_all': Mock()}
             with patch.dict(state.__salt__, sync_mocks):
-                state.sls('foo', sync=True)
+                state.sls('foo', sync_mods=True)
 
             for key in sync_mocks:
                 call_count = sync_mocks[key].call_count
@@ -1001,7 +1001,7 @@ class StateTestCase(TestCase, LoaderModuleMockMixin):
             # extra syncing.
             sync_mocks = {'saltutil.sync_all': Mock()}
             with patch.dict(state.__salt__, sync_mocks):
-                state.sls('foo', sync='modules,all')
+                state.sls('foo', sync_mods='modules,all')
 
             for key in sync_mocks:
                 call_count = sync_mocks[key].call_count

--- a/tests/unit/modules/test_state.py
+++ b/tests/unit/modules/test_state.py
@@ -756,28 +756,25 @@ class StateTestCase(TestCase, LoaderModuleMockMixin):
                                           "whitelist=sls1.sls",
                                           pillar="A")
 
-                        mock = MagicMock(return_value=True)
-                        with patch.dict(state.__salt__,
-                                        {'config.option': mock}):
-                            mock = MagicMock(return_value="A")
+                        mock = MagicMock(return_value="A")
+                        with patch.object(state, '_filter_running',
+                                          mock):
+                            mock = MagicMock(return_value=True)
                             with patch.object(state, '_filter_running',
                                               mock):
                                 mock = MagicMock(return_value=True)
-                                with patch.object(state, '_filter_running',
+                                with patch.object(salt.payload, 'Serial',
                                                   mock):
-                                    mock = MagicMock(return_value=True)
-                                    with patch.object(salt.payload, 'Serial',
-                                                      mock):
-                                        with patch.object(os.path,
-                                                          'join', mock):
-                                            with patch.object(
-                                                              state,
-                                                              '_set'
-                                                              '_retcode',
-                                                              mock):
-                                                self.assertTrue(state.
-                                                                highstate
-                                                                (arg))
+                                    with patch.object(os.path,
+                                                      'join', mock):
+                                        with patch.object(
+                                                          state,
+                                                          '_set'
+                                                          '_retcode',
+                                                          mock):
+                                            self.assertTrue(state.
+                                                            highstate
+                                                            (arg))
 
     def test_clear_request(self):
         '''
@@ -918,17 +915,11 @@ class StateTestCase(TestCase, LoaderModuleMockMixin):
 
                                     MockState.HighState.flag = False
                                     mock = MagicMock(return_value=True)
-                                    with patch.dict(state.__salt__,
-                                                    {'config.option':
-                                                     mock}):
-                                        mock = MagicMock(return_value=
-                                                         True)
-                                        with patch.object(
-                                                          state,
-                                                          '_filter_'
-                                                          'running',
-                                                          mock):
-                                            self.sub_test_sls()
+                                    with patch.object(state,
+                                                      '_filter_'
+                                                      'running',
+                                                      mock):
+                                        self.sub_test_sls()
 
     def sub_test_sls(self):
         '''


### PR DESCRIPTION
The docs inaccurately stated that custom module types were synced when `state.apply` is run, but this is only the case when run without SLS targets (i.e. when a highstate is run). This PR does the following:

1. Updates the docs

2. Adds a "sync" argument to provide the functionality that the docs suggested was already present

Resolves #48025.