### PR TITLE
states/github.py fix for incorrect positional argument

### DIFF
--- a/salt/states/github.py
+++ b/salt/states/github.py
@@ -715,8 +715,8 @@ def repo_present(
                         ret['result'] = None
                     else:
                         result = __salt__['github.add_team_repo'](name, team_name,
-                                                                  permission,
-                                                                  profile=profile)
+                                                                  profile=profile,
+                                                                  permission=permission)
                         if result:
                             ret['changes'][team_name] = team_change
                         else:


### PR DESCRIPTION
### What does this PR do?
Updated add_team_repo to not put the permission positional argument into the profile variable.  Syntax used is the same as the 2 other uses of add_team_repo in this same file.

### What issues does this PR fix or reference?
#48039

### Previous Behavior
Stack trace and state failure

### New Behavior
works 
### Tests written?
No

### Commits signed with GPG?
no

