### PR TITLE
salt.utils.hashutils: Only decode to utf-8 on Windows

### DIFF
--- a/salt/utils/hashutils.py
+++ b/salt/utils/hashutils.py
@@ -13,6 +13,7 @@ import random
 # Import Salt libs
 from salt.ext import six
 import salt.utils.files
+import salt.utils.platform
 import salt.utils.stringutils
 
 from salt.utils.decorators.jinja import jinja_filter
@@ -27,7 +28,8 @@ def base64_b64encode(instr):
     newline ('\\n') characters in the encoded output.
     '''
     return salt.utils.stringutils.to_unicode(
-        base64.b64encode(salt.utils.stringutils.to_bytes(instr))
+        base64.b64encode(salt.utils.stringutils.to_bytes(instr)),
+        encoding='utf8' if salt.utils.platform.is_windows() else None
     )
 
 
@@ -38,7 +40,10 @@ def base64_b64decode(instr):
     '''
     decoded = base64.b64decode(salt.utils.stringutils.to_bytes(instr))
     try:
-        return salt.utils.stringutils.to_unicode(decoded)
+        return salt.utils.stringutils.to_unicode(
+            decoded,
+            encoding='utf8' if salt.utils.platform.is_windows() else None
+        )
     except UnicodeDecodeError:
         return decoded
 
@@ -52,7 +57,8 @@ def base64_encodestring(instr):
     at the end of the encoded string.
     '''
     return salt.utils.stringutils.to_unicode(
-        base64.encodestring(salt.utils.stringutils.to_bytes(instr))
+        base64.encodestring(salt.utils.stringutils.to_bytes(instr)),
+        encoding='utf8' if salt.utils.platform.is_windows() else None
     )
 
 
@@ -68,7 +74,10 @@ def base64_decodestring(instr):
         # PY2
         decoded = base64.decodestring(b)
     try:
-        return salt.utils.stringutils.to_unicode(decoded)
+        return salt.utils.stringutils.to_unicode(
+            decoded,
+            encoding='utf8' if salt.utils.platform.is_windows() else None
+        )
     except UnicodeDecodeError:
         return decoded
 


### PR DESCRIPTION
We only decode to unicode so that we can use some of these functions in Jinja filters. Since CP1252 will incorrectly decode certain bytestrings, force utf8 decoding on Windows.