### PR TITLE
Add ability to pass Azure image resource ID

### DIFF
--- a/doc/topics/cloud/azurearm.rst
+++ b/doc/topics/cloud/azurearm.rst
@@ -169,12 +169,18 @@ fields, separated by the pipe (``|``) character:
     sku: Such as 14.04.5-LTS or 2012-R2-Datacenter
     version: Such as 14.04.201612050 or latest
 
-It is possible to specify the URL of a custom image that you have access to,
-such as:
+It is possible to specify the URL or resource ID path of a custom image that you
+have access to, such as:
 
 .. code-block:: yaml
 
     https://<mystorage>.blob.core.windows.net/system/Microsoft.Compute/Images/<mystorage>/template-osDisk.01234567-890a-bcdef0123-4567890abcde.vhd
+
+or:
+
+.. code-block:: yaml
+
+    /subscriptions/XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX/resourceGroups/myRG/providers/Microsoft.Compute/images/myImage
 
 size
 ----

--- a/salt/cloud/clouds/azurearm.py
+++ b/salt/cloud/clouds/azurearm.py
@@ -544,7 +544,7 @@ def list_nodes_full(call=None):
             try:
                 node['image'] = node['storage_profile']['os_disk']['image']['uri']
             except (TypeError, KeyError):
-                node['image'] = None
+                node['image'] = node.get('storage_profile', {}).get('image_reference', {}).get('id')
         try:
             netifaces = node['network_profile']['network_interfaces']
             for index, netiface in enumerate(netifaces):
@@ -1177,19 +1177,22 @@ def request_instance(vm_):
             volume['create_option'] = 'empty'
         data_disks.append(DataDisk(**volume))
 
+    img_ref = None
     if vm_['image'].startswith('http') or vm_.get('vhd') == 'unmanaged':
         if vm_['image'].startswith('http'):
             source_image = VirtualHardDisk(vm_['image'])
-            img_ref = None
         else:
             source_image = None
-            img_pub, img_off, img_sku, img_ver = vm_['image'].split('|')
-            img_ref = ImageReference(
-                publisher=img_pub,
-                offer=img_off,
-                sku=img_sku,
-                version=img_ver,
-            )
+            if '|' in vm_['image']:
+                img_pub, img_off, img_sku, img_ver = vm_['image'].split('|')
+                img_ref = ImageReference(
+                    publisher=img_pub,
+                    offer=img_off,
+                    sku=img_sku,
+                    version=img_ver,
+                )
+            elif vm_['image'].startswith('/subscriptions'):
+                img_ref = ImageReference(id=vm_['image'])
         if win_installer:
             os_type = 'Windows'
         else:
@@ -1210,19 +1213,22 @@ def request_instance(vm_):
             disk_size_gb=vm_.get('os_disk_size_gb')
         )
     else:
-        img_pub, img_off, img_sku, img_ver = vm_['image'].split('|')
         source_image = None
         os_type = None
         os_disk = OSDisk(
             create_option=DiskCreateOptionTypes.from_image,
             disk_size_gb=vm_.get('os_disk_size_gb')
         )
-        img_ref = ImageReference(
-            publisher=img_pub,
-            offer=img_off,
-            sku=img_sku,
-            version=img_ver,
-        )
+        if '|' in vm_['image']:
+            img_pub, img_off, img_sku, img_ver = vm_['image'].split('|')
+            img_ref = ImageReference(
+                publisher=img_pub,
+                offer=img_off,
+                sku=img_sku,
+                version=img_ver,
+            )
+        elif vm_['image'].startswith('/subscriptions'):
+            img_ref = ImageReference(id=vm_['image'])
 
     userdata_file = config.get_cloud_config_value(
         'userdata_file', vm_, __opts__, search_global=False, default=None


### PR DESCRIPTION
### What does this PR do?
Add the ability to pass an Azure image resource ID to use during VM creation.

### What issues does this PR fix or reference?
#48019 

### Previous Behavior
Images could only be referenced by web URL or pipe-delimited image name.

### New Behavior
Images can now be referenced by their resource ID.

### Tests written?
No

### Commits signed with GPG?
Yes