### PR TITLE
cloud/aws: allow users to provide role_arn in configuration

### DIFF
--- a/doc/topics/cloud/aws.rst
+++ b/doc/topics/cloud/aws.rst
@@ -57,6 +57,10 @@ parameters are discussed in more detail below.
       id: 'use-instance-role-credentials'
       key: 'use-instance-role-credentials'
 
+      # If 'role_arn' is specified the above credentials are used to
+      # to assume to the role. By default, role_arn is set to None.
+      role_arn: arn:aws:iam::012345678910:role/SomeRoleName
+
       # Make sure this key is owned by corresponding user (default 'salt') with permissions 0400.
       #
       private_key: /etc/salt/my_test_key.pem
@@ -723,7 +727,7 @@ them have never been used, much less tested, by the Salt Stack team.
 
 NOTE: If ``image`` of a profile does not start with ``ami-``, latest
 image with that name will be used. For example, to create a CentOS 7
-profile, instead of using the AMI like ``image: ami-1caef165``, we 
+profile, instead of using the AMI like ``image: ami-1caef165``, we
 can use its name like ``image: 'CentOS Linux 7 x86_64 HVM EBS ENA 1803_01'``.
 We can also use a pattern like below to get the latest CentOS 7:
 

--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -16,6 +16,9 @@ To use the EC2 cloud module, set up the cloud configuration at
       # EC2 metadata set both id and key to 'use-instance-role-credentials'
       id: GKTADJGHEIQSXMKKRBJ08H
       key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
+      # If 'role_arn' is specified the above credentials are used to
+      # to assume to the role.
+      role_arn: None
       # The ssh keyname to use
       keyname: default
       # The amazon security group

--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -16,9 +16,11 @@ To use the EC2 cloud module, set up the cloud configuration at
       # EC2 metadata set both id and key to 'use-instance-role-credentials'
       id: GKTADJGHEIQSXMKKRBJ08H
       key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
+
       # If 'role_arn' is specified the above credentials are used to
-      # to assume to the role.
-      role_arn: None
+      # to assume to the role. By default, role_arn is set to None.
+      role_arn: arn:aws:iam::012345678910:role/SomeRoleName
+
       # The ssh keyname to use
       keyname: default
       # The amazon security group

--- a/salt/utils/aws.py
+++ b/salt/utils/aws.py
@@ -132,8 +132,8 @@ def creds(provider):
     else:
         ret_credentials = provider['id'], provider['key'], ''
 
-    if provider['role_arn'] is not None:
-        ret_credentials = assumed_creds(provider, role_arn=provider['role_arn'], location=None)
+    if provider.get('role_arn') is not None:
+        ret_credentials = assumed_creds(provider, role_arn=provider.get('role_arn'), location=None)
 
     return ret_credentials
 

--- a/salt/utils/aws.py
+++ b/salt/utils/aws.py
@@ -137,6 +137,7 @@ def creds(provider):
 
     return ret_credentials
 
+
 def sig2(method, endpoint, params, provider, aws_api_version):
     '''
     Sign a query against AWS services using Signature Version 2 Signing

--- a/salt/utils/aws.py
+++ b/salt/utils/aws.py
@@ -125,9 +125,15 @@ def creds(provider):
         __SecretAccessKey__ = data['SecretAccessKey']
         __Token__ = data['Token']
         __Expiration__ = data['Expiration']
-        return __AccessKeyId__, __SecretAccessKey__, __Token__
+        if provider['role_arn'] is None:
+            return __AccessKeyId__, __SecretAccessKey__, __Token__
+        else:
+            return assumed_creds(provider, role_arn=provider['role_arn'], location=None)
     else:
-        return provider['id'], provider['key'], ''
+        if provider['role_arn'] is None:
+            return provider['id'], provider['key'], ''
+        else:
+            return assumed_creds(provider, role_arn=provider['role_arn'], location=None)
 
 
 def sig2(method, endpoint, params, provider, aws_api_version):

--- a/salt/utils/aws.py
+++ b/salt/utils/aws.py
@@ -132,10 +132,10 @@ def creds(provider):
     else:
         ret_credentials = provider['id'], provider['key'], ''
 
-    if provider['role_arn'] is None:
-        return ret_credentials
-    else:
-        return assumed_creds(provider, role_arn=provider['role_arn'], location=None)
+    if provider['role_arn'] is not None:
+        ret_credentials = assumed_creds(provider, role_arn=provider['role_arn'], location=None)
+
+    return ret_credentials
 
 def sig2(method, endpoint, params, provider, aws_api_version):
     '''

--- a/salt/utils/aws.py
+++ b/salt/utils/aws.py
@@ -88,6 +88,8 @@ def creds(provider):
     # Declare globals
     global __AccessKeyId__, __SecretAccessKey__, __Token__, __Expiration__
 
+    ret_credentials = ()
+
     # if id or key is 'use-instance-role-credentials', pull them from meta-data
     ## if needed
     if provider['id'] == IROLE_CODE or provider['key'] == IROLE_CODE:
@@ -125,16 +127,15 @@ def creds(provider):
         __SecretAccessKey__ = data['SecretAccessKey']
         __Token__ = data['Token']
         __Expiration__ = data['Expiration']
-        if provider['role_arn'] is None:
-            return __AccessKeyId__, __SecretAccessKey__, __Token__
-        else:
-            return assumed_creds(provider, role_arn=provider['role_arn'], location=None)
-    else:
-        if provider['role_arn'] is None:
-            return provider['id'], provider['key'], ''
-        else:
-            return assumed_creds(provider, role_arn=provider['role_arn'], location=None)
 
+        ret_credentials = __AccessKeyId__, __SecretAccessKey__, __Token__
+    else:
+        ret_credentials = provider['id'], provider['key'], ''
+
+    if provider['role_arn'] is None:
+        return ret_credentials
+    else:
+        return assumed_creds(provider, role_arn=provider['role_arn'], location=None)
 
 def sig2(method, endpoint, params, provider, aws_api_version):
     '''


### PR DESCRIPTION
### What does this PR do?

Allow users to provide `role_arn` in configuration for `aws` cloud provider.

### What issues does this PR fix or reference?

### Previous Behavior
Remove this section if not relevant

### New Behavior
Remove this section if not relevant

### Tests written?

TODO

### Commits signed with GPG?

Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
