### PR TITLE
Fixes zabbix_template reports.

### DIFF
--- a/salt/states/zabbix_template.py
+++ b/salt/states/zabbix_template.py
@@ -502,6 +502,8 @@ def present(name, params, static_host_list=True, **kwargs):
     ret = {'name': name, 'result': False, 'comment': '', 'changes': {}}
     params['host'] = name
 
+    del CHANGE_STACK[:]
+
     # Divide template yaml definition into parts
     # - template definition itself
     # - simple template components


### PR DESCRIPTION
### What does this PR do?
Fixes wrong zabbix_template change report. When multiple templates are to be created, variable carrying the information about changes made is not cleared every time when state "is_present" is called.

### Tests written?

Yes

### Commits signed with GPG?

Yes
