### PR TITLE
mark test as expensive

### DIFF
--- a/tests/integration/runners/test_state.py
+++ b/tests/integration/runners/test_state.py
@@ -20,7 +20,7 @@ from salt.ext.six.moves import queue
 from tests.support.case import ShellCase
 from tests.support.unit import skipIf
 from tests.support.paths import TMP
-from tests.support.helpers import flaky
+from tests.support.helpers import flaky, expensiveTest
 from tests.support.mock import MagicMock, patch
 
 # Import Salt Libs
@@ -479,6 +479,7 @@ class OrchEventTest(ShellCase):
             del listener
             signal.alarm(0)
 
+    @expensiveTest
     def test_orchestration_soft_kill(self):
         '''
         Test to confirm that the parallel state requisite works in orch


### PR DESCRIPTION
### What does this PR do?
This tests takes a large amount of cpu to run, and is causing tests to
hang.

Mark it as an expensive test so it only runs with the cloud tests.

### What issues does this PR fix or reference?
Trying to clean up some tests that might be causing 2018.3 to take a long time to run.

### Commits signed with GPG?

Yes