### PR TITLE
salt/utils/cloud: Allow to customize ssh gateway command/options

### DIFF
--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -48,6 +48,10 @@ To use the EC2 cloud module, set up the cloud configuration at
       # Optional
       ssh_gateway_username: root
 
+      # Default to nc -q0 %h %p
+      # Optional
+      ssh_gateway_command: "-W %h:%p"
+
       # One authentication method is required. If both
       # are specified, Private key wins.
 

--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -1082,6 +1082,12 @@ def get_ssh_gateway_config(vm_):
         search_global=False
     )
 
+    # ssh_gateway_command
+    ssh_gateway_config['ssh_gateway_command'] = config.get_cloud_config_value(
+        'ssh_gateway_command', vm_, __opts__, default=None,
+        search_global=False
+    )
+
     # Check if private key exists
     key_filename = ssh_gateway_config['ssh_gateway_key']
     if key_filename is not None and not os.path.isfile(key_filename):

--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -139,11 +139,12 @@ def __render_script(path, vm_=None, opts=None, minion=''):
 def __ssh_gateway_arguments(kwargs):
     extended_arguments = ""
 
-    if 'ssh_gateway' in kwargs:
-      ssh_gateway = kwargs['ssh_gateway']
-      ssh_gateway_port = 22
-      if ':' in ssh_gateway:
-          ssh_gateway, ssh_gateway_port = ssh_gateway.split(':')
+    ssh_gateway = kwargs.get('ssh_gateway', '')
+    ssh_gateway_port = 22
+    if ':' in ssh_gateway:
+        ssh_gateway, ssh_gateway_port = ssh_gateway.split(':')
+
+    if ssh_gateway:
       ssh_gateway_port = kwargs.get('ssh_gateway_port', ssh_gateway_port)
       ssh_gateway_key = '-i {0}'.format(kwargs['ssh_gateway_key']) if 'ssh_gateway_key' in kwargs else ''
       ssh_gateway_user = kwargs.get('ssh_gateway_user', 'root')

--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -136,6 +136,7 @@ def __render_script(path, vm_=None, opts=None, minion=''):
         with salt.utils.files.fopen(path, 'r') as fp_:
             return six.text_type(fp_.read())
 
+
 def __ssh_gateway_arguments(kwargs):
     extended_arguments = ""
 
@@ -145,30 +146,30 @@ def __ssh_gateway_arguments(kwargs):
         ssh_gateway, ssh_gateway_port = ssh_gateway.split(':')
 
     if ssh_gateway:
-      ssh_gateway_port = kwargs.get('ssh_gateway_port', ssh_gateway_port)
-      ssh_gateway_key = '-i {0}'.format(kwargs['ssh_gateway_key']) if 'ssh_gateway_key' in kwargs else ''
-      ssh_gateway_user = kwargs.get('ssh_gateway_user', 'root')
-      ssh_gateway_command = kwargs.get('ssh_gateway_command', 'nc -q0 %h %p')
+        ssh_gateway_port = kwargs.get('ssh_gateway_port', ssh_gateway_port)
+        ssh_gateway_key = '-i {0}'.format(kwargs['ssh_gateway_key']) if 'ssh_gateway_key' in kwargs else ''
+        ssh_gateway_user = kwargs.get('ssh_gateway_user', 'root')
+        ssh_gateway_command = kwargs.get('ssh_gateway_command', 'nc -q0 %h %p')
 
-      # Setup ProxyCommand
-      extended_arguments = '-oProxyCommand="ssh {0} {1} {2} {3} {4}@{5} -p {6} {7}"'.format(
-              # Don't add new hosts to the host key database
-              '-oStrictHostKeyChecking=no',
-              # Set hosts key database path to /dev/null, i.e., non-existing
-              '-oUserKnownHostsFile=/dev/null',
-              # Don't re-use the SSH connection. Less failures.
-              '-oControlPath=none',
-              ssh_gateway_key,
-              ssh_gateway_user,
-              ssh_gateway,
-              ssh_gateway_port,
-              ssh_gateway_command
-          )
+        # Setup ProxyCommand
+        extended_arguments = '-oProxyCommand="ssh {0} {1} {2} {3} {4}@{5} -p {6} {7}"'.format(
+                # Don't add new hosts to the host key database
+                '-oStrictHostKeyChecking=no',
+                # Set hosts key database path to /dev/null, i.e., non-existing
+                '-oUserKnownHostsFile=/dev/null',
+                # Don't re-use the SSH connection. Less failures.
+                '-oControlPath=none',
+                ssh_gateway_key,
+                ssh_gateway_user,
+                ssh_gateway,
+                ssh_gateway_port,
+                ssh_gateway_command
+            )
 
-      log.info(
-          'Using SSH gateway %s@%s:%s %s',
-          ssh_gateway_user, ssh_gateway, ssh_gateway_port, ssh_gateway_command
-      )
+    log.info(
+        'Using SSH gateway %s@%s:%s %s',
+        ssh_gateway_user, ssh_gateway, ssh_gateway_port, ssh_gateway_command
+    )
 
     return extended_arguments
 

--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -2062,6 +2062,7 @@ def scp_file(dest_path, contents=None, kwargs=None, local_file=None):
             ssh_gateway_port = 22
             ssh_gateway_key = ''
             ssh_gateway_user = 'root'
+            ssh_gateway_command = 'nc -q0 %h %p'
             if ':' in ssh_gateway:
                 ssh_gateway, ssh_gateway_port = ssh_gateway.split(':')
             if 'ssh_gateway_port' in kwargs:
@@ -2070,10 +2071,12 @@ def scp_file(dest_path, contents=None, kwargs=None, local_file=None):
                 ssh_gateway_key = '-i {0}'.format(kwargs['ssh_gateway_key'])
             if 'ssh_gateway_user' in kwargs:
                 ssh_gateway_user = kwargs['ssh_gateway_user']
+            if 'ssh_gateway_command' in kwargs:
+                ssh_gateway_command = kwargs['ssh_gateway_command']
 
             ssh_args.append(
                 # Setup ProxyCommand
-                '-oProxyCommand="ssh {0} {1} {2} {3} {4}@{5} -p {6} nc -q0 %h %p"'.format(
+                '-oProxyCommand="ssh {0} {1} {2} {3} {4}@{5} -p {6} {7}"'.format(
                     # Don't add new hosts to the host key database
                     '-oStrictHostKeyChecking=no',
                     # Set hosts key database path to /dev/null, i.e., non-existing
@@ -2083,7 +2086,8 @@ def scp_file(dest_path, contents=None, kwargs=None, local_file=None):
                     ssh_gateway_key,
                     ssh_gateway_user,
                     ssh_gateway,
-                    ssh_gateway_port
+                    ssh_gateway_port,
+                    ssh_gateway_command
                 )
             )
 
@@ -2197,6 +2201,7 @@ def sftp_file(dest_path, contents=None, kwargs=None, local_file=None):
             ssh_gateway_port = 22
             ssh_gateway_key = ''
             ssh_gateway_user = 'root'
+            ssh_gateway_command = 'nc -q0 %h %p'
             if ':' in ssh_gateway:
                 ssh_gateway, ssh_gateway_port = ssh_gateway.split(':')
             if 'ssh_gateway_port' in kwargs:
@@ -2205,10 +2210,12 @@ def sftp_file(dest_path, contents=None, kwargs=None, local_file=None):
                 ssh_gateway_key = '-i {0}'.format(kwargs['ssh_gateway_key'])
             if 'ssh_gateway_user' in kwargs:
                 ssh_gateway_user = kwargs['ssh_gateway_user']
+            if 'ssh_gateway_command' in kwargs:
+                ssh_gateway_command = kwargs['ssh_gateway_command']
 
             ssh_args.append(
                 # Setup ProxyCommand
-                '-oProxyCommand="ssh {0} {1} {2} {3} {4}@{5} -p {6} nc -q0 %h %p"'.format(
+                '-oProxyCommand="ssh {0} {1} {2} {3} {4}@{5} -p {6} {7}"'.format(
                     # Don't add new hosts to the host key database
                     '-oStrictHostKeyChecking=no',
                     # Set hosts key database path to /dev/null, i.e., non-existing
@@ -2218,7 +2225,8 @@ def sftp_file(dest_path, contents=None, kwargs=None, local_file=None):
                     ssh_gateway_key,
                     ssh_gateway_user,
                     ssh_gateway,
-                    ssh_gateway_port
+                    ssh_gateway_port,
+                    ssh_gateway_command
                 )
             )
 
@@ -2359,6 +2367,7 @@ def root_cmd(command, tty, sudo, allow_failure=False, **kwargs):
         ssh_gateway_port = 22
         ssh_gateway_key = ''
         ssh_gateway_user = 'root'
+        ssh_gateway_command = 'nc -q0 %h %p'
         if ':' in ssh_gateway:
             ssh_gateway, ssh_gateway_port = ssh_gateway.split(':')
         if 'ssh_gateway_port' in kwargs:
@@ -2367,10 +2376,12 @@ def root_cmd(command, tty, sudo, allow_failure=False, **kwargs):
             ssh_gateway_key = '-i {0}'.format(kwargs['ssh_gateway_key'])
         if 'ssh_gateway_user' in kwargs:
             ssh_gateway_user = kwargs['ssh_gateway_user']
+        if 'ssh_gateway_command' in kwargs:
+            ssh_gateway_command = kargs['ssh_gateway_command']
 
         ssh_args.extend([
             # Setup ProxyCommand
-            '-oProxyCommand="ssh {0} {1} {2} {3} {4}@{5} -p {6} nc -q0 %h %p"'.format(
+            '-oProxyCommand="ssh {0} {1} {2} {3} {4}@{5} -p {6} {7}"'.format(
                 # Don't add new hosts to the host key database
                 '-oStrictHostKeyChecking=no',
                 # Set hosts key database path to /dev/null, i.e., non-existing
@@ -2380,7 +2391,8 @@ def root_cmd(command, tty, sudo, allow_failure=False, **kwargs):
                 ssh_gateway_key,
                 ssh_gateway_user,
                 ssh_gateway,
-                ssh_gateway_port
+                ssh_gateway_port,
+                ssh_gateway_command
             )
         ])
         log.info(

--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -2377,7 +2377,7 @@ def root_cmd(command, tty, sudo, allow_failure=False, **kwargs):
         if 'ssh_gateway_user' in kwargs:
             ssh_gateway_user = kwargs['ssh_gateway_user']
         if 'ssh_gateway_command' in kwargs:
-            ssh_gateway_command = kargs['ssh_gateway_command']
+            ssh_gateway_command = kwargs['ssh_gateway_command']
 
         ssh_args.extend([
             # Setup ProxyCommand

--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -143,18 +143,15 @@ def __ssh_gateway_arguments(kwargs):
       ssh_gateway = kwargs['ssh_gateway']
       ssh_gateway_port = 22
       ssh_gateway_key = ''
-      ssh_gateway_user = 'root'
-      ssh_gateway_command = 'nc -q0 %h %p'
       if ':' in ssh_gateway:
           ssh_gateway, ssh_gateway_port = ssh_gateway.split(':')
       if 'ssh_gateway_port' in kwargs:
           ssh_gateway_port = kwargs['ssh_gateway_port']
       if 'ssh_gateway_key' in kwargs:
           ssh_gateway_key = '-i {0}'.format(kwargs['ssh_gateway_key'])
-      if 'ssh_gateway_user' in kwargs:
-          ssh_gateway_user = kwargs['ssh_gateway_user']
-      if 'ssh_gateway_command' in kwargs:
-          ssh_gateway_command = kwargs['ssh_gateway_command']
+
+      ssh_gateway_user = kwargs.get('ssh_gateway_user', 'root')
+      ssh_gateway_command = kwargs.get('ssh_gateway_command', 'nc -q0 %h %p')
 
       # Setup ProxyCommand
       extended_arguments = '-oProxyCommand="ssh {0} {1} {2} {3} {4}@{5} -p {6} {7}"'.format(

--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -142,13 +142,10 @@ def __ssh_gateway_arguments(kwargs):
     if 'ssh_gateway' in kwargs:
       ssh_gateway = kwargs['ssh_gateway']
       ssh_gateway_port = 22
-      ssh_gateway_key = ''
       if ':' in ssh_gateway:
           ssh_gateway, ssh_gateway_port = ssh_gateway.split(':')
       ssh_gateway_port = kwargs.get('ssh_gateway_port', ssh_gateway_port)
-      if 'ssh_gateway_key' in kwargs:
-          ssh_gateway_key = '-i {0}'.format(kwargs['ssh_gateway_key'])
-
+      ssh_gateway_key = '-i {0}'.format(kwargs['ssh_gateway_key']) if 'ssh_gateway_key' in kwargs else ''
       ssh_gateway_user = kwargs.get('ssh_gateway_user', 'root')
       ssh_gateway_command = kwargs.get('ssh_gateway_command', 'nc -q0 %h %p')
 

--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -2340,7 +2340,7 @@ def root_cmd(command, tty, sudo, allow_failure=False, **kwargs):
     if 'ssh_timeout' in kwargs:
         ssh_args.extend(['-oConnectTimeout={0}'.format(kwargs['ssh_timeout'])])
 
-    ssh_args.extend([__ssh_gateway_arguments(kwargs))
+    ssh_args.extend([__ssh_gateway_arguments(kwargs)])
 
     if 'port' in kwargs:
         ssh_args.extend(['-p {0}'.format(kwargs['port'])])

--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -145,8 +145,7 @@ def __ssh_gateway_arguments(kwargs):
       ssh_gateway_key = ''
       if ':' in ssh_gateway:
           ssh_gateway, ssh_gateway_port = ssh_gateway.split(':')
-      if 'ssh_gateway_port' in kwargs:
-          ssh_gateway_port = kwargs['ssh_gateway_port']
+      ssh_gateway_port = kwargs.get('ssh_gateway_port', ssh_gateway_port)
       if 'ssh_gateway_key' in kwargs:
           ssh_gateway_key = '-i {0}'.format(kwargs['ssh_gateway_key'])
 


### PR DESCRIPTION
### What does this PR do?

By default, nc command (`nc -q0 %h %p`) is used to create gateway. This is not
always possible in some restricted environments. An alternative is to use
native support from ssh: `-W %h:%p`.

This commit allows user to provide a customize option for gateway. Please note
the (wait_for_port) process may need another patch.


### What issues does this PR fix or reference?

### Previous Behavior

Users are forced to use `nc -q0 %h %p` command to create ssh proxy for `salt-cloud`

### New Behavior

Users can use a customized command to create ssh proxy for `salt-cloud`

### Tests written?

NO

### Commits signed with GPG?

Yes