### PR TITLE
Fix {set/get}_zone NILinuxRT CurrentGen

### DIFF
--- a/doc/topics/cloud/aws.rst
+++ b/doc/topics/cloud/aws.rst
@@ -57,6 +57,10 @@ parameters are discussed in more detail below.
       id: 'use-instance-role-credentials'
       key: 'use-instance-role-credentials'
 
+      # If 'role_arn' is specified the above credentials are used to
+      # to assume to the role. By default, role_arn is set to None.
+      role_arn: arn:aws:iam::012345678910:role/SomeRoleName
+
       # Make sure this key is owned by corresponding user (default 'salt') with permissions 0400.
       #
       private_key: /etc/salt/my_test_key.pem
@@ -723,7 +727,7 @@ them have never been used, much less tested, by the Salt Stack team.
 
 NOTE: If ``image`` of a profile does not start with ``ami-``, latest
 image with that name will be used. For example, to create a CentOS 7
-profile, instead of using the AMI like ``image: ami-1caef165``, we 
+profile, instead of using the AMI like ``image: ami-1caef165``, we
 can use its name like ``image: 'CentOS Linux 7 x86_64 HVM EBS ENA 1803_01'``.
 We can also use a pattern like below to get the latest CentOS 7:
 

--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -16,6 +16,9 @@ To use the EC2 cloud module, set up the cloud configuration at
       # EC2 metadata set both id and key to 'use-instance-role-credentials'
       id: GKTADJGHEIQSXMKKRBJ08H
       key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
+      # If 'role_arn' is specified the above credentials are used to
+      # to assume to the role.
+      role_arn: None
       # The ssh keyname to use
       keyname: default
       # The amazon security group

--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -16,9 +16,11 @@ To use the EC2 cloud module, set up the cloud configuration at
       # EC2 metadata set both id and key to 'use-instance-role-credentials'
       id: GKTADJGHEIQSXMKKRBJ08H
       key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
+
       # If 'role_arn' is specified the above credentials are used to
-      # to assume to the role.
-      role_arn: None
+      # to assume to the role. By default, role_arn is set to None.
+      role_arn: arn:aws:iam::012345678910:role/SomeRoleName
+
       # The ssh keyname to use
       keyname: default
       # The amazon security group

--- a/salt/modules/timezone.py
+++ b/salt/modules/timezone.py
@@ -98,7 +98,7 @@ def _get_zone_sysconfig():
 
 
 def _get_zone_etc_localtime():
-    tzfile = '/etc/localtime'
+    tzfile = _get_localtime_path()
     tzdir = '/usr/share/zoneinfo/'
     tzdir_len = len(tzdir)
     try:
@@ -281,8 +281,9 @@ def set_zone(timezone):
     if not os.path.exists(zonepath) and 'AIX' not in __grains__['os_family']:
         return 'Zone does not exist: {0}'.format(zonepath)
 
-    if os.path.exists('/etc/localtime'):
-        os.unlink('/etc/localtime')
+    tzfile = _get_localtime_path()
+    if os.path.exists(tzfile):
+        os.unlink(tzfile)
 
     if 'Solaris' in __grains__['os_family']:
         __salt__['file.sed'](
@@ -300,7 +301,7 @@ def set_zone(timezone):
         __salt__['cmd.retcode'](cmd, python_shell=False)
         return False
     else:
-        os.symlink(zonepath, '/etc/localtime')
+        os.symlink(zonepath, tzfile)
 
     if 'RedHat' in __grains__['os_family']:
         __salt__['file.sed'](
@@ -345,10 +346,10 @@ def zone_compare(timezone):
         return timezone == get_zone()
 
     if 'FreeBSD' in __grains__['os_family']:
-        if not os.path.isfile(_get_etc_localtime_path()):
+        if not os.path.isfile(_get_localtime_path()):
             return timezone == get_zone()
 
-    tzfile = _get_etc_localtime_path()
+    tzfile = _get_localtime_path()
     zonepath = _get_zone_file(timezone)
     try:
         return filecmp.cmp(tzfile, zonepath, shallow=False)
@@ -364,7 +365,9 @@ def zone_compare(timezone):
         raise
 
 
-def _get_etc_localtime_path():
+def _get_localtime_path():
+    if 'nilrt' in __grains__['lsb_distrib_id']:
+        return '/etc/natinst/share/localtime'
     return '/etc/localtime'
 
 
@@ -529,8 +532,9 @@ def set_hwclock(clock):
                 'Zone \'{0}\' does not exist'.format(zonepath)
             )
 
-        os.unlink('/etc/localtime')
-        os.symlink(zonepath, '/etc/localtime')
+        tzfile = _get_localtime_path()
+        os.unlink(tzfile)
+        os.symlink(zonepath, tzfile)
 
         if 'Arch' in __grains__['os_family']:
             cmd = ['timezonectl', 'set-local-rtc',

--- a/salt/modules/timezone.py
+++ b/salt/modules/timezone.py
@@ -55,6 +55,7 @@ def _timedatectl():
 
     return ret
 
+
 def _get_zone_solaris():
     tzfile = '/etc/TIMEZONE'
     with salt.utils.files.fopen(tzfile, 'r') as fp_:

--- a/salt/utils/aws.py
+++ b/salt/utils/aws.py
@@ -132,8 +132,8 @@ def creds(provider):
     else:
         ret_credentials = provider['id'], provider['key'], ''
 
-    if provider['role_arn'] is not None:
-        ret_credentials = assumed_creds(provider, role_arn=provider['role_arn'], location=None)
+    if provider.get('role_arn') is not None:
+        ret_credentials = assumed_creds(provider, role_arn=provider.get('role_arn'), location=None)
 
     return ret_credentials
 

--- a/salt/utils/aws.py
+++ b/salt/utils/aws.py
@@ -137,6 +137,7 @@ def creds(provider):
 
     return ret_credentials
 
+
 def sig2(method, endpoint, params, provider, aws_api_version):
     '''
     Sign a query against AWS services using Signature Version 2 Signing

--- a/salt/utils/aws.py
+++ b/salt/utils/aws.py
@@ -125,9 +125,15 @@ def creds(provider):
         __SecretAccessKey__ = data['SecretAccessKey']
         __Token__ = data['Token']
         __Expiration__ = data['Expiration']
-        return __AccessKeyId__, __SecretAccessKey__, __Token__
+        if provider['role_arn'] is None:
+            return __AccessKeyId__, __SecretAccessKey__, __Token__
+        else:
+            return assumed_creds(provider, role_arn=provider['role_arn'], location=None)
     else:
-        return provider['id'], provider['key'], ''
+        if provider['role_arn'] is None:
+            return provider['id'], provider['key'], ''
+        else:
+            return assumed_creds(provider, role_arn=provider['role_arn'], location=None)
 
 
 def sig2(method, endpoint, params, provider, aws_api_version):

--- a/salt/utils/aws.py
+++ b/salt/utils/aws.py
@@ -132,10 +132,10 @@ def creds(provider):
     else:
         ret_credentials = provider['id'], provider['key'], ''
 
-    if provider['role_arn'] is None:
-        return ret_credentials
-    else:
-        return assumed_creds(provider, role_arn=provider['role_arn'], location=None)
+    if provider['role_arn'] is not None:
+        ret_credentials = assumed_creds(provider, role_arn=provider['role_arn'], location=None)
+
+    return ret_credentials
 
 def sig2(method, endpoint, params, provider, aws_api_version):
     '''

--- a/salt/utils/aws.py
+++ b/salt/utils/aws.py
@@ -88,6 +88,8 @@ def creds(provider):
     # Declare globals
     global __AccessKeyId__, __SecretAccessKey__, __Token__, __Expiration__
 
+    ret_credentials = ()
+
     # if id or key is 'use-instance-role-credentials', pull them from meta-data
     ## if needed
     if provider['id'] == IROLE_CODE or provider['key'] == IROLE_CODE:
@@ -125,16 +127,15 @@ def creds(provider):
         __SecretAccessKey__ = data['SecretAccessKey']
         __Token__ = data['Token']
         __Expiration__ = data['Expiration']
-        if provider['role_arn'] is None:
-            return __AccessKeyId__, __SecretAccessKey__, __Token__
-        else:
-            return assumed_creds(provider, role_arn=provider['role_arn'], location=None)
-    else:
-        if provider['role_arn'] is None:
-            return provider['id'], provider['key'], ''
-        else:
-            return assumed_creds(provider, role_arn=provider['role_arn'], location=None)
 
+        ret_credentials = __AccessKeyId__, __SecretAccessKey__, __Token__
+    else:
+        ret_credentials = provider['id'], provider['key'], ''
+
+    if provider['role_arn'] is None:
+        return ret_credentials
+    else:
+        return assumed_creds(provider, role_arn=provider['role_arn'], location=None)
 
 def sig2(method, endpoint, params, provider, aws_api_version):
     '''

--- a/tests/unit/modules/test_timezone.py
+++ b/tests/unit/modules/test_timezone.py
@@ -326,6 +326,21 @@ class TimezoneModuleTestCase(TestCase, LoaderModuleMockMixin):
             assert timezone.get_hwclock() == hwclock
 
     @skipIf(salt.utils.platform.is_windows(), 'os.symlink not available in Windows')
+    @patch('salt.utils.path.which', MagicMock(return_value=True))
+    def test_set_hwclock_timedatectl(self):
+        '''
+        Test set hwclock with timedatectl
+        :return:
+        '''
+        timezone.set_hwclock('UTC')
+        name, args, kwargs = timezone.__salt__['cmd.retcode'].mock_calls[0]
+        assert args == (['timedatectl', 'set-local-rtc', 'false'],)
+
+        timezone.set_hwclock('localtime')
+        name, args, kwargs = timezone.__salt__['cmd.retcode'].mock_calls[1]
+        assert args == (['timedatectl', 'set-local-rtc', 'true'],)
+
+    @skipIf(salt.utils.platform.is_windows(), 'os.symlink not available in Windows')
     @patch('salt.utils.path.which', MagicMock(return_value=False))
     @patch('os.path.exists', MagicMock(return_value=True))
     @patch('os.unlink', MagicMock())


### PR DESCRIPTION
On legacy version of NILinuxRT, /etc/localtime is a
symlink to /etc/natinst/share/localtime.
On this systems, {set/get}_zone must work directly on
/etc/natinst/share/localtime, instead of default file.

Signed-off-by: Rares Pop <rares.pop@ni.com>

### What does this PR do?
National Instruments supports two Linux RT distributions, and the former one, also known as CurrentGen works directly with /etc/natinst/share/localtime for the timezone.

### Previous Behavior
Timezone wasn't working correctly

### Tests written?

No

### Commits signed with GPG?

No
