### PR TITLE
Fix system.set_computer_name on NILinuxRT CurrentGen

### DIFF
--- a/salt/modules/network.py
+++ b/salt/modules/network.py
@@ -1354,6 +1354,12 @@ def mod_hostname(hostname):
     elif __grains__['os_family'] in ('Debian', 'NILinuxRT'):
         with salt.utils.files.fopen('/etc/hostname', 'w') as fh_:
             fh_.write(salt.utils.stringutils.to_str(hostname + '\n'))
+        if __grains__['lsb_distrib_id'] == 'nilrt':
+            str_hostname = salt.utils.stringutils.to_str(hostname)
+            nirtcfg_cmd = '/usr/local/natinst/bin/nirtcfg'
+            nirtcfg_cmd += ' --set section=SystemSettings,token=\'Host_Name\',value=\'{0}\''.format(str_hostname)
+            if __salt__['cmd.run_all'](nirtcfg_cmd)['retcode'] != 0:
+                raise CommandExecutionError('Couldn\'t set hostname to: {0}\n'.format(str_hostname))
     elif __grains__['os_family'] == 'OpenBSD':
         with salt.utils.files.fopen('/etc/myname', 'w') as fh_:
             fh_.write(salt.utils.stringutils.to_str(hostname + '\n'))


### PR DESCRIPTION
On Current-Gen, we also need to modify the bootloader variable
`hostname`. This is due to `populateconfig` calling `nirtcfg --migrate` on
startup so that the bootloader variables end up in `ni-rt.ini`.
`ni-rt.ini` is the source used to set the hostname when the `hostname`
init script is invoked.

Signed-off-by: Sergey Kizunov <sergey.kizunov@ni.com>
Signed-off-by: Rares Pop <rares.pop@ni.com>

### What does this PR do?
National Instruments supports two Linux RT distributions, and the former one, also known as CurrentGen is using an utility 'nirtcfg' for storing system settings in order to be persisted across reboots.

### What issues does this PR fix or reference?
Without this change, any system setting change won't be persisted across reboots.

### Previous Behavior
Any system setting change isn't persisted across reboots.

### New Behavior
Settings are persisted.

### Tests written?

No

### Commits signed with GPG?

No
