### PR TITLE
[2017.7] Ensure that the shared list of jids is passed

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -935,7 +935,7 @@ class Minion(MinionBase):
         # Flag meaning minion has finished initialization including first connect to the master.
         # True means the Minion is fully functional and ready to handle events.
         self.ready = False
-        self.jid_queue = jid_queue or []
+        self.jid_queue = [] if jid_queue is None else jid_queue
         self.periodic_callbacks = {}
 
         if io_loop is None:


### PR DESCRIPTION
### What does this PR do?
Ensure that the shared list of jids is passed when creating the Minion.  Fixes an issue when minions are pointed at multiple syndics.

### What issues does this PR fix or reference?
#48038 

### Previous Behavior
When using multiple syndic servers commands would result in multiple returns as the de-duplication function was not functioning correctly.

### New Behavior
When the minion is created set the jid_queue to an empty list only if the value passed in is actually None, otherwise set it to the value that is passed in.

### Tests written?
No.  Unfortunately this issue only occurs when a minion is pointed at multiple syndic servers and the command is issued from the master of masters.  Current testing setup doesn't support multiple syndics.

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
