### PR TITLE
Fix issue with `salt.utils.parsers` on Windows

### DIFF
--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -968,17 +968,17 @@ class DaemonMixIn(six.with_metaclass(MixInMeta, object)):
                     # Log error only when running salt-master as a root user.
                     # Otherwise this can be ignored, since salt-master is able to
                     # overwrite the PIDfile on the next start.
-                    def log_error():
-                        logger.info('PIDfile could not be deleted: %s',
-                                    six.text_type(self.config['pidfile']))
-                        logger.debug(six.text_type(err))
+                    err_msg = ('PIDfile could not be deleted: %s',
+                               six.text_type(self.config['pidfile']))
                     if salt.utils.platform.is_windows():
                         user = salt.utils.win_functions.get_current_user()
                         if salt.utils.win_functions.is_admin(user):
-                            log_error()
+                            logger.info(*err_msg)
+                            logger.debug(six.text_type(err))
                     else:
                         if not os.getuid():
-                            log_error()
+                            logger.info(*err_msg)
+                            logger.debug(six.text_type(err))
 
     def set_pidfile(self):
         from salt.utils.process import set_pidfile

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -968,9 +968,17 @@ class DaemonMixIn(six.with_metaclass(MixInMeta, object)):
                     # Log error only when running salt-master as a root user.
                     # Otherwise this can be ignored, since salt-master is able to
                     # overwrite the PIDfile on the next start.
-                    if not os.getuid():
-                        logger.info('PIDfile could not be deleted: %s', six.text_type(self.config['pidfile']))
+                    def log_error():
+                        logger.info('PIDfile could not be deleted: %s',
+                                    six.text_type(self.config['pidfile']))
                         logger.debug(six.text_type(err))
+                    if salt.utils.platform.is_windows():
+                        user = salt.utils.win_functions.get_current_user()
+                        if salt.utils.win_functions.is_admin(user):
+                            log_error()
+                    else:
+                        if not os.getuid():
+                            log_error()
 
     def set_pidfile(self):
         from salt.utils.process import set_pidfile

--- a/tests/unit/utils/test_parsers.py
+++ b/tests/unit/utils/test_parsers.py
@@ -1036,30 +1036,44 @@ class DaemonMixInTestCase(TestCase):
 
     @patch('os.unlink', MagicMock(side_effect=OSError()))
     @patch('os.path.isfile', MagicMock(return_value=True))
-    @patch('os.getuid', MagicMock(return_value=0))
     @patch('salt.utils.parsers.logger', MagicMock())
     def test_pid_deleted_oserror_as_root(self):
         '''
         PIDfile deletion with exception, running as root.
         '''
-        self.daemon_mixin._mixin_before_exit()
-        assert salt.utils.parsers.os.unlink.call_count == 1
-        salt.utils.parsers.logger.info.assert_called_with('PIDfile could not be deleted: %s',
-                                                          format(self.daemon_mixin.config['pidfile']))
-        salt.utils.parsers.logger.debug.assert_called()
+        if salt.utils.platform.is_windows():
+            patch_args = ('salt.utils.win_functions.is_admin',
+                          MagicMock(return_value=True))
+        else:
+            patch_args = ('os.getuid', MagicMock(return_value=0))
+
+        with patch(*patch_args):
+            self.daemon_mixin._mixin_before_exit()
+            assert salt.utils.parsers.os.unlink.call_count == 1
+            salt.utils.parsers.logger.info.assert_called_with(
+                'PIDfile could not be deleted: %s',
+                format(self.daemon_mixin.config['pidfile'])
+            )
+            salt.utils.parsers.logger.debug.assert_called()
 
     @patch('os.unlink', MagicMock(side_effect=OSError()))
     @patch('os.path.isfile', MagicMock(return_value=True))
-    @patch('os.getuid', MagicMock(return_value=1000))
     @patch('salt.utils.parsers.logger', MagicMock())
     def test_pid_deleted_oserror_as_non_root(self):
         '''
         PIDfile deletion with exception, running as non-root.
         '''
-        self.daemon_mixin._mixin_before_exit()
-        assert salt.utils.parsers.os.unlink.call_count == 1
-        salt.utils.parsers.logger.info.assert_not_called()
-        salt.utils.parsers.logger.debug.assert_not_called()
+        if salt.utils.platform.is_windows():
+            patch_args = ('salt.utils.win_functions.is_admin',
+                          MagicMock(return_value=True))
+        else:
+            patch_args = ('os.getuid', MagicMock(return_value=0))
+
+        with patch(*patch_args):
+            self.daemon_mixin._mixin_before_exit()
+            assert salt.utils.parsers.os.unlink.call_count == 1
+            salt.utils.parsers.logger.info.assert_not_called()
+            salt.utils.parsers.logger.debug.assert_not_called()
 
 
 # Hide the class from unittest framework when it searches for TestCase classes in the module

--- a/tests/unit/utils/test_parsers.py
+++ b/tests/unit/utils/test_parsers.py
@@ -1065,9 +1065,9 @@ class DaemonMixInTestCase(TestCase):
         '''
         if salt.utils.platform.is_windows():
             patch_args = ('salt.utils.win_functions.is_admin',
-                          MagicMock(return_value=True))
+                          MagicMock(return_value=False))
         else:
-            patch_args = ('os.getuid', MagicMock(return_value=0))
+            patch_args = ('os.getuid', MagicMock(return_value=1000))
 
         with patch(*patch_args):
             self.daemon_mixin._mixin_before_exit()


### PR DESCRIPTION
### What does this PR do?
Fixes an issue with `salt.utils.parsers` on Windows. There is no `os.getuid` function in Windows. The `_mixin_before_exit` function uses `os.getuid` to check for root which fails on Windows. This function detects root/admin differently if it's on a Windows box. Both methods are also mocked properly in the tests.

### What issues does this PR fix or reference?
Found via failing tests on Jenkins

### Previous Behavior
The following tests were failing:
unit.utils.test_parsers.DaemonMixInTestCase.test_pid_deleted_oserror_as_non_root
unit.utils.test_parsers.DaemonMixInTestCase.test_pid_deleted_oserror_as_root

### New Behavior
The tests now pass.

### Tests written?
Yes

### Commits signed with GPG?
Yes