### PR TITLE
Fix patching sysctl.conf on FreeBSD.

### DIFF
--- a/salt/modules/freebsd_sysctl.py
+++ b/salt/modules/freebsd_sysctl.py
@@ -165,7 +165,7 @@ def persist(name, value, config='/etc/sysctl.conf'):
     if not edited:
         nlines.append("{0}\n".format(_formatfor(name, value, config)))
     with salt.utils.files.fopen(config, 'w+') as ofile:
-        nlines = [salt.utils.stringutils.to_str(_l) for _l in nlines]
+        nlines = [salt.utils.stringutils.to_str(_l) + '\n' for _l in nlines]
         ofile.writelines(nlines)
     if config != '/boot/loader.conf':
         assign(name, value)


### PR DESCRIPTION
In b3c1be27fb the lines were stripped of their ending \n, but the \n was
never added back to the lines, so calling writelines generates a broken
one line file.

### Previous Behavior
Using sysctl.present would change /etc/sysctl.conf to have all its content on one line.

### New Behavior
Keep the lines as lines and make it work again.

### Tests written?

No

### Commits signed with GPG?

Yes