### PR TITLE
Update release versions for the 2018.3 branch 

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -250,8 +250,8 @@ on_saltstack = 'SALT_ON_SALTSTACK' in os.environ
 project = 'Salt'
 
 version = salt.version.__version__
-latest_release = '2018.3.0'  # latest release
-previous_release = '2017.7.5'  # latest release from previous branch
+latest_release = '2018.3.1'  # latest release
+previous_release = '2017.7.6'  # latest release from previous branch
 previous_release_dir = '2017.7'  # path on web server for previous branch
 next_release = ''  # next release
 next_release_dir = ''  # path on web server for next release branch

--- a/doc/topics/releases/2017.7.6.rst
+++ b/doc/topics/releases/2017.7.6.rst
@@ -1,10 +1,9 @@
-========================================
-In Progress: Salt 2017.7.6 Release Notes
-========================================
+===========================
+Salt 2017.7.6 Release Notes
+===========================
 
-Version 2017.7.6 is an **unreleased** bugfix release for :ref:`2017.7.0
-<release-2017-7-0>`.  This release is still in progress and has not been
-released yet.
+Version 2017.7.6 is a bugfix release for :ref:`2017.7.0
+<release-2017-7-0>`.
 
 
 Statistics

--- a/doc/topics/releases/2018.3.1.rst
+++ b/doc/topics/releases/2018.3.1.rst
@@ -1,9 +1,8 @@
-========================================
-In Progress: Salt 2018.3.1 Release Notes
-========================================
+===========================
+Salt 2018.3.1 Release Notes
+===========================
 
-Version 2018.3.1 is an **unreleased** bugfix release for :ref:`2018.3.0 <release-2018-3-0>`.
-This release is still in progress and has not been released yet.
+Version 2018.3.1 is a bugfix release for :ref:`2018.3.0 <release-2018-3-0>`.
 
 Statistics
 ==========


### PR DESCRIPTION
Also removes the "In Progress" notation for the 2017.7.6 and 2018.3.1 release notes files