### PR TITLE
Reverse monkeypatching after test_symlink_list finishes

### DIFF
--- a/tests/unit/fileserver/test_roots.py
+++ b/tests/unit/fileserver/test_roots.py
@@ -174,10 +174,15 @@ class RootsTest(TestCase, AdaptedConfigurationTestCaseMixin, LoaderModuleMockMix
         self.assertIn('empty_dir', ret)
 
     def test_symlink_list(self):
-        if self.test_symlink_list_file_roots:
-            self.opts['file_roots'] = self.test_symlink_list_file_roots
-        ret = roots.symlink_list({'saltenv': 'base'})
-        self.assertDictEqual(ret, {'dest_sym': 'source_sym'})
+        orig_file_roots = self.opts['file_roots']
+        try:
+            if self.test_symlink_list_file_roots:
+                self.opts['file_roots'] = self.test_symlink_list_file_roots
+            ret = roots.symlink_list({'saltenv': 'base'})
+            self.assertDictEqual(ret, {'dest_sym': 'source_sym'})
+        finally:
+            if self.test_symlink_list_file_roots:
+                self.opts['file_roots'] = orig_file_roots
 
 
 class RootsLimitTraversalTest(TestCase, AdaptedConfigurationTestCaseMixin):


### PR DESCRIPTION
On Windows, in `test_symlink_list` we monkeypatch the `file_roots`. However, we don't ever reverse that monkeypatching.

This would not have affected other test classes, because the opts we are monkeypatching are ones created specifically for that test class. And due to the lexicographic order in which the tests are run, `test_symlink_list` is run last. However, if we were to ever add a test to that test class which would run after `test_symlink_list`, it would be affected by the monkeypatching.