### PR TITLE
ethtool: properly handle adaptive-(rx|tx) in coalesce state

### DIFF
--- a/salt/states/ethtool.py
+++ b/salt/states/ethtool.py
@@ -107,8 +107,6 @@ def coalesce(name, **kwargs):
 
         # Retreive changes to made
         for key, value in kwargs.items():
-            if key in ['adaptive_rx', 'adaptive_tx']:
-                value = value and "on" or "off"
             if key in old and value != old[key]:
                 new.update({key: value})
                 diff.append('{0}: {1}'.format(key, value))


### PR DESCRIPTION
Execution of module ethtool.set_coalesce maps on/off value
into True/False:

salt-call ethtool.set_coalesce eth0 adaptive_rx=on adaptive_tx=on
DEBUG:  eth0 {'__pub_pid': 26508, 'adaptive_rx': True,
'__pub_fun': 'ethtool.set_coalesce',
'__pub_jid': '20180528151557666327', '__pub_tgt': 'salt-call',
'adaptive_tx': True}

Because on/off inside state configuration are also mapped to True/False:

eth0:
  ethtool.coalesce:
      - name: eth0
          - adaptive_rx: on

There is no need to do additional mapping.

### What does this PR do?
Fix inproper handling of adaptive-rx and adaptive-tx parameter in ethtool.coalesce state

### What issues does this PR fix or reference?
#47713 

### Previous Behavior
Can not set adaptive-rx and adaptive-tx parameter

### New Behavior
Properly set adaptive-rx and adaptive-tx parameter

### Tests written?

No

### Commits signed with GPG?

No
