### PR TITLE
Fix `unit.modules.test_win_status`

### DIFF
--- a/tests/unit/modules/test_win_status.py
+++ b/tests/unit/modules/test_win_status.py
@@ -146,11 +146,7 @@ class TestProcsWMIGetOwnerErrorsAreLogged(TestProcsBase):
     def test_error_logged_if_process_get_owner_fails(self):
         with patch('salt.modules.win_status.log') as log:
             self.call_procs()
-        log.warning.assert_called_once_with(ANY)
-        self.assertIn(
-            str(self.expected_error_code),
-            log.warning.call_args[0][0]
-        )
+        log.warning.assert_called_once_with(ANY, ANY, self.expected_error_code)
 
 
 class TestEmptyCommandLine(TestProcsBase):


### PR DESCRIPTION
### What does this PR do?
Fixes an issue with the test for `win_status`.

### What issues does this PR fix or reference?
Jenkins

### Previous Behavior
In the transition to unicode, some of the log messages changed from the `'{0}'.format('something')` format to `'this %s', 'something'` format. In the test it was checking that the `log.warning` was called with a single item which works with the `.format` method. The new method considers each element and item, so the test would fail.

### New Behavior
Add's an additional `ANY` to the assertion in the test. Also adds the `self.expected_error_code` to the first test which removes the need for the second assertion (`assertIn`)

### Tests written?
Yes

### Commits signed with GPG?
Yes