### PR TITLE
service.disabled on Windows

### DIFF
--- a/salt/states/service.py
+++ b/salt/states/service.py
@@ -255,7 +255,12 @@ def _disable(name, started, result=True, **kwargs):
         return ret
 
     # Service can be disabled
-    before_toggle_disable_status = __salt__['service.disabled'](name)
+    if salt.utils.is_windows():
+        # service.disabled in Windows returns True for services that are set to
+        # Manual start, so we need to check specifically for Disabled
+        before_toggle_disable_status = __salt__['service.info'](name)['StartType'] in ['Disabled']
+    else:
+        before_toggle_disable_status = __salt__['service.disabled'](name)
     if before_toggle_disable_status:
         # Service is disabled
         if started is True:
@@ -549,7 +554,12 @@ def dead(name,
     # command, so it is just an indicator but can not be fully trusted
     before_toggle_status = __salt__['service.status'](name, sig)
     if 'service.enabled' in __salt__:
-        before_toggle_enable_status = __salt__['service.enabled'](name)
+        if salt.utils.is_windows():
+            # service.enabled in Windows returns True for services that are set
+            # to Auto start, but services set to Manual can also be disabled
+            before_toggle_enable_status = __salt__['service.info'](name)['StartType'] in ['Auto', 'Manual']
+        else:
+            before_toggle_enable_status = __salt__['service.enabled'](name)
     else:
         before_toggle_enable_status = True
 


### PR DESCRIPTION
### What does this PR do?
Disable services that are set to manual on Windows using `service.disabled` and `service.dead` when `enable: False`

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/48026

### Previous Behavior
`service.dead` and `service.disabled` would not disable a service if the start_type was set to Manual.

### New Behavior
Now manual start types are properly disabled.

### Tests written?
Yes

### Commits signed with GPG?
Yes