### PR TITLE
Update the 2017.7.7 and 2017.7.8 release notes

### DIFF
--- a/doc/topics/releases/2017.7.7.rst
+++ b/doc/topics/releases/2017.7.7.rst
@@ -18,8 +18,8 @@ Statistics
 
 - Contributors: **2** (`garethgreenaway`_, `rallytime`_)
 
-Changelog for v2017.7.6..2017.7.7
-=================================
+Changelog for v2017.7.6..v2017.7.7
+==================================
 
 *Generated at: 2018-06-14 15:43:34 UTC*
 

--- a/doc/topics/releases/2017.7.7.rst
+++ b/doc/topics/releases/2017.7.7.rst
@@ -1,0 +1,41 @@
+===========================
+Salt 2017.7.7 Release Notes
+===========================
+
+Version 2017.7.7 is a bugfix release for :ref:`2017.7.0 <release-2017-7-0>`.
+
+The ``2017.7.7`` release contains only a single fix for Issue `#48038`_, which
+is a critical bug that occurs in a multi-syndic setup where the same job is run
+multiple times on a minion.
+
+Statistics
+==========
+
+- Total Merges: **1**
+- Total Issue References: **1**
+- Total PR References: **2**
+
+- Contributors: **2** (`garethgreenaway`_, `rallytime`_)
+
+Changelog for v2017.7.6..2017.7.7
+=================================
+
+*Generated at: 2018-06-14 15:43:34 UTC*
+
+* **ISSUE** `#48038`_: (`austinpapp`_) jobs are not dedup'ing minion side (refs: `#48075`_)
+
+* **PR** `#48098`_: (`rallytime`_) Back-port `#48075`_ to 2017.7.7
+  @ *2018-06-14 12:53:42 UTC*
+
+  * **PR** `#48075`_: (`garethgreenaway`_) [2017.7] Ensure that the shared list of jids is passed (refs: `#48098`_)
+
+  * 084de927fe Merge pull request `#48098`_ from rallytime/bp-48075-2017.7.7
+
+  * e4e62e8b3a Ensure that the shared list of jids is passed when creating the Minion.  Fixes an issue when minions are pointed at multiple syndics.
+
+.. _`#48038`: https://github.com/saltstack/salt/issues/48038
+.. _`#48075`: https://github.com/saltstack/salt/pull/48075
+.. _`#48098`: https://github.com/saltstack/salt/pull/48098
+.. _`austinpapp`: https://github.com/austinpapp
+.. _`garethgreenaway`: https://github.com/garethgreenaway
+.. _`rallytime`: https://github.com/rallytime

--- a/doc/topics/releases/2017.7.7.rst
+++ b/doc/topics/releases/2017.7.7.rst
@@ -1,8 +1,9 @@
-===========================
-Salt 2017.7.7 Release Notes
-===========================
+========================================
+In Progress: Salt 2017.7.7 Release Notes
+========================================
 
-Version 2017.7.7 is a bugfix release for :ref:`2017.7.0 <release-2017-7-0>`.
+Version 2017.7.7 is an **unreleased** bugfix release for :ref:`2017.7.0 <release-2017-7-0>`.
+This release is still in progress and has not been released yet.
 
 The ``2017.7.7`` release contains only a single fix for Issue `#48038`_, which
 is a critical bug that occurs in a multi-syndic setup where the same job is run

--- a/doc/topics/releases/2017.7.8.rst
+++ b/doc/topics/releases/2017.7.8.rst
@@ -1,8 +1,8 @@
 ========================================
-In Progress: Salt 2017.7.7 Release Notes
+In Progress: Salt 2017.7.8 Release Notes
 ========================================
 
-Version 2017.7.7 is an **unreleased** bugfix release for :ref:`2017.7.0 <release-2017-7-0>`.
+Version 2017.7.8 is an **unreleased** bugfix release for :ref:`2017.7.0 <release-2017-7-0>`.
 This release is still in progress and has not been released yet.
 
 New win_snmp behavior
@@ -16,4 +16,3 @@ New win_snmp behavior
 - :py:func:`win_snmp.set_community_names
   <salt.modules.win_snmp.set_community_names>` now raises an error when SNMP
   settings are being managed by GroupPolicy.
-


### PR DESCRIPTION
Moves the current 2017.7.7 release notes to 2017.7.8, then grabs the release notes for 2017.7.7 from #48134 and adds "in progress" to the new 2017.7.7 release notes.