### PR TITLE
Add timeout argument to run_salt for ShellCase

### DIFF
--- a/tests/support/case.py
+++ b/tests/support/case.py
@@ -451,7 +451,7 @@ class ShellCase(ShellTestCase, AdaptedConfigurationTestCaseMixin, ScriptPathMixi
         '''
         Execute salt
         '''
-        arg_str = '-c {0} {1}'.format(self.get_config_dir(), arg_str)
+        arg_str = '-c {0} -t {1} {2}'.format(self.get_config_dir(), timeout, arg_str)
         return self.run_script('salt',
                                arg_str,
                                with_retcode=with_retcode,


### PR DESCRIPTION
### What does this PR do?
This PR https://github.com/saltstack/salt/pull/47304 added the timeout variable for `run_salt` in the `ShellTestCase` Class but the `integration.minion.test_timeout.MinionTimeoutTestCase.test_long_running_job` test uses the `ShellTest` Class so updating this `run_salt` method with timeout argument
