### PR TITLE
Fix for sorting of multi-version packages

### DIFF
--- a/salt/modules/rpm.py
+++ b/salt/modules/rpm.py
@@ -9,7 +9,7 @@ import logging
 import os
 import re
 import datetime
-from distutils.version import LooseVersion
+from salt.utils.versions import LooseVersion
 
 # Import Salt libs
 import salt.utils.decorators.path

--- a/salt/modules/rpm.py
+++ b/salt/modules/rpm.py
@@ -9,6 +9,7 @@ import logging
 import os
 import re
 import datetime
+from distutils.version import LooseVersion
 
 # Import Salt libs
 import salt.utils.decorators.path
@@ -604,7 +605,7 @@ def info(*packages, **attr):
     # pick only latest versions
     # (in case multiple packages installed, e.g. kernel)
     ret = dict()
-    for pkg_data in reversed(sorted(_ret, key=lambda x: x['edition'])):
+    for pkg_data in reversed(sorted(_ret, key=lambda x: LooseVersion(x['edition']))):
         pkg_name = pkg_data.pop('name')
         # Filter out GPG public keys packages
         if pkg_name.startswith('gpg-pubkey'):


### PR DESCRIPTION
### What does this PR do?

[This commit](https://github.com/saltstack/salt/commit/6b7ba078415852cc5fa0d0b68da7f5cf3197907b#diff-ca9dbe21cd7fbb90ec283fff26da4748L602) introduced a regression for the multi version support. Since version numbers are not correctly sorted, older packages might be reported as the most recent version.

Since we can only use `key` as a parameter to `sorted` (because of Python3), we can't use `version_cmp` as is. Instead we would have to introduce a [wrapper to do so](https://docs.python.org/3/howto/sorting.html#the-old-way-using-the-cmp-parameter). Or, like suggested in this PR, use `LooseVersion` from `distutils.version`. 

### What issues does this PR fix or reference?

None

### Previous Behavior

Old version of multi version packages might be reported as the most recent ones.

### New Behavior

Only the most recent versions for multi version packages are reported as installed.

### Tests written?

No

### Commits signed with GPG?

Yes