### PR TITLE
Remove Azure <1.0 Old Dependency Change Note

### DIFF
--- a/doc/topics/cloud/azure.rst
+++ b/doc/topics/cloud/azure.rst
@@ -21,18 +21,6 @@ Dependencies
 * `Salt <https://github.com/saltstack/salt>`_
 
 
-.. note::
-
-    The Azure driver is currently being updated to work with the new version of
-    the Python Azure SDK, 1.0.0. However until that process is complete, this
-    driver will not work with Azure 1.0.0. Please be sure you're running on a
-    minimum version of 0.10.2 and less than version 1.0.0.
-
-    See `Issue #27980`_ for more information.
-
-.. _Issue #27980: https://github.com/saltstack/salt/issues/27980
-
-
 Configuration
 =============
 


### PR DESCRIPTION
I understand there was a period where pyazure 1.0 was not working with salt per #27980 and seeing as this was resolved with newer versions, the note is no longer relevant.

### What does this PR do?
Amends doc to remove old warning note given new azure dependency fix

### What issues does this PR fix or reference?
Conflicting documentation information

### Previous Behavior
Talk about a dependency problem that used to exist

### New Behavior
Issue 27980 closed and azure dependency updated

### Tests written?

Not required?

### Commits signed with GPG?

No

