### PR TITLE
Add docker.update_mine config option

### DIFF
--- a/doc/ref/configuration/minion.rst
+++ b/doc/ref/configuration/minion.rst
@@ -1176,11 +1176,11 @@ Docker Configuration
 
 Default: ``True``
 
-If enabled, when containers are added or removed the :ref:`mine <salt-mine>`
-will be updated with the results of :py:func:`docker.ps verbose=True all=True
-host=True <salt.modules.dockermod.ps>`. This mine data is used by
-:py:func:`mine.get_docker <salt.modules.mine.get_docker>`. Set this option to
-``False`` to keep Salt from updating the mine with this information.
+If enabled, when containers are added, removed, stopped, started, etc., the
+:ref:`mine <salt-mine>` will be updated with the results of :py:func:`docker.ps
+verbose=True all=True host=True <salt.modules.dockermod.ps>`. This mine data is
+used by :py:func:`mine.get_docker <salt.modules.mine.get_docker>`. Set this
+option to ``False`` to keep Salt from updating the mine with this information.
 
 .. note::
     This option can also be set in Grains or Pillar data, with Grains

--- a/doc/ref/configuration/minion.rst
+++ b/doc/ref/configuration/minion.rst
@@ -1170,7 +1170,7 @@ Docker Configuration
 ``docker.update_mine``
 ----------------------
 
-.. versionadded:: 2017.7.7,2018.3.3
+.. versionadded:: 2017.7.8,2018.3.3
 .. versionchanged:: Fluorine
     The default value is now ``False``
 

--- a/doc/ref/configuration/minion.rst
+++ b/doc/ref/configuration/minion.rst
@@ -1162,6 +1162,40 @@ The password used for HTTP proxy access.
 
     proxy_password: obolus
 
+Docker Configuration
+====================
+
+.. conf_minion:: docker.update_mine
+
+``docker.update_mine``
+----------------------
+
+.. versionadded:: 2017.7.7,2018.3.3
+.. versionchanged:: Fluorine
+    The default value is now ``False``
+
+Default: ``True``
+
+If enabled, when containers are added or removed the :ref:`mine <salt-mine>`
+will be updated with the results of :py:func:`docker.ps verbose=True all=True
+host=True <salt.modules.dockermod.ps>`. This mine data is used by
+:py:func:`mine.get_docker <salt.modules.mine.get_docker>`. Set this option to
+``False`` to keep Salt from updating the mine with this information.
+
+.. note::
+    This option can also be set in Grains or Pillar data, with Grains
+    overriding Pillar and the minion config file overriding Grains.
+
+.. note::
+    Disabling this will of course keep :py:func:`mine.get_docker
+    <salt.modules.mine.get_docker>` from returning any information for a given
+    minion.
+
+.. code-block:: yaml
+
+    docker.update_mine: False
+
+
 Minion Module Management
 ========================
 

--- a/doc/topics/releases/2017.7.8.rst
+++ b/doc/topics/releases/2017.7.8.rst
@@ -20,8 +20,8 @@ New win_snmp behavior
 Option Added to Disable Docker Mine Updates
 ===========================================
 
-When a docker container is added or removed, the results of a
-:py:func:`docker.ps verbose=True all=True host=True
+When a docker container is added, removed, started, stopped, etc., the results
+of a :py:func:`docker.ps verbose=True all=True host=True
 <salt.modules.dockermod.ps>` are sent to the :ref:`mine <salt-mine>`, to be
 used by :py:func:`mine.get_docker <salt.modules.mine.get_docker>`.
 

--- a/doc/topics/releases/2017.7.8.rst
+++ b/doc/topics/releases/2017.7.8.rst
@@ -16,3 +16,16 @@ New win_snmp behavior
 - :py:func:`win_snmp.set_community_names
   <salt.modules.win_snmp.set_community_names>` now raises an error when SNMP
   settings are being managed by GroupPolicy.
+
+Option Added to Disable Docker Mine Updates
+===========================================
+
+When a docker container is added or removed, the results of a
+:py:func:`docker.ps verbose=True all=True host=True
+<salt.modules.dockermod.ps>` are sent to the :ref:`mine <salt-mine>`, to be
+used by :py:func:`mine.get_docker <salt.modules.mine.get_docker>`.
+
+A new config option (:conf_minion:`docker.update_mine`) has been added.  When
+set to ``False``, Salt will not send this information to the mine. This is
+useful in cases where sensitive information is stored in the container's
+environment.

--- a/salt/modules/dockermod.py
+++ b/salt/modules/dockermod.py
@@ -436,9 +436,18 @@ def _refresh_mine_cache(wrapped):
         refresh salt mine on exit.
         '''
         returned = wrapped(*args, **salt.utils.clean_kwargs(**kwargs))
-        __salt__['mine.send']('docker.ps', verbose=True, all=True, host=True)
+        if _check_update_mine():
+            __salt__['mine.send']('docker.ps', verbose=True, all=True, host=True)
         return returned
     return wrapper
+
+
+def _check_update_mine():
+    try:
+        ret = __context__['docker.update_mine']
+    except KeyError:
+        ret = __context__['docker.update_mine'] = __salt__['config.get']('docker.update_mine', default=True)
+    return ret
 
 
 # Helper functions

--- a/salt/modules/mine.py
+++ b/salt/modules/mine.py
@@ -374,7 +374,7 @@ def flush():
 
 def get_docker(interfaces=None, cidrs=None, with_container_id=False):
     '''
-    .. versionchanged:: 2017.7.7,2018.3.3
+    .. versionchanged:: 2017.7.8,2018.3.3
         When :conf_minion:`docker.update_mine` is set to ``False`` for a given
         minion, no mine data will be populated for that minion, and thus none
         will be returned for it.

--- a/salt/modules/mine.py
+++ b/salt/modules/mine.py
@@ -375,8 +375,9 @@ def flush():
 def get_docker(interfaces=None, cidrs=None, with_container_id=False):
     '''
     .. versionchanged:: 2017.7.7,2018.3.3
-        When :conf_minion:`docker.update_mine` is set to ``False``, no mine
-        data will be populated
+        When :conf_minion:`docker.update_mine` is set to ``False`` for a given
+        minion, no mine data will be populated for that minion, and thus none
+        will be returned for it.
     .. versionchanged:: Fluorine
         :conf_minion:`docker.update_mine` now defaults to ``False``
 

--- a/salt/modules/mine.py
+++ b/salt/modules/mine.py
@@ -374,10 +374,17 @@ def flush():
 
 def get_docker(interfaces=None, cidrs=None, with_container_id=False):
     '''
-    Get all mine data for 'docker.get_containers' and run an aggregation
-    routine. The "interfaces" parameter allows for specifying which network
-    interfaces to select ip addresses from. The "cidrs" parameter allows for
-    specifying a list of cidrs which the ip address must match.
+    .. versionchanged:: 2017.7.7,2018.3.3
+        When :conf_minion:`docker.update_mine` is set to ``False``, no mine
+        data will be populated
+    .. versionchanged:: Fluorine
+        :conf_minion:`docker.update_mine` now defaults to ``False``
+
+    Get all mine data for :py:func:`docker.ps <salt.modules.dockermod.ps_>` and
+    run an aggregation routine. The ``interfaces`` parameter allows for
+    specifying the network interfaces from which to select IP addresses. The
+    ``cidrs`` parameter allows for specifying a list of subnets which the IP
+    address must match.
 
     with_container_id
         Boolean, to expose container_id in the list of results

--- a/tests/unit/modules/test_dockermod.py
+++ b/tests/unit/modules/test_dockermod.py
@@ -136,6 +136,7 @@ class DockerTestCase(TestCase, LoaderModuleMockMixin):
                 with patch.dict(docker_mod.__salt__,
                                 {'mine.send': mine_send,
                                  'container_resource.run': MagicMock(),
+                                 'config.get': MagicMock(return_value=True),
                                  'cp.cache_file': MagicMock(return_value=False)}):
                     with patch.dict(docker_mod.__utils__,
                                     {'docker.get_client_args': client_args_mock}):

--- a/tests/unit/modules/test_dockermod.py
+++ b/tests/unit/modules/test_dockermod.py
@@ -144,6 +144,44 @@ class DockerTestCase(TestCase, LoaderModuleMockMixin):
                 mine_send.assert_called_with('docker.ps', verbose=True, all=True,
                                              host=True)
 
+    def test_update_mine(self):
+        '''
+        Test the docker.update_mine config option
+        '''
+        def config_get_disabled(val, default):
+            return {'base_url': docker_mod.NOTSET,
+                    'version': docker_mod.NOTSET,
+                    'docker.url': docker_mod.NOTSET,
+                    'docker.version': docker_mod.NOTSET,
+                    'docker.machine': docker_mod.NOTSET,
+                    'docker.update_mine': False}[val]
+
+        def config_get_enabled(val, default):
+            return {'base_url': docker_mod.NOTSET,
+                    'version': docker_mod.NOTSET,
+                    'docker.url': docker_mod.NOTSET,
+                    'docker.version': docker_mod.NOTSET,
+                    'docker.machine': docker_mod.NOTSET,
+                    'docker.update_mine': True}[val]
+
+        mine_mock = Mock()
+        dunder_salt = {
+            'config.get': MagicMock(side_effect=config_get_disabled),
+            'mine.send': mine_mock,
+        }
+        with patch.dict(docker_mod.__salt__, dunder_salt), \
+                patch.dict(docker_mod.__context__, {'docker.client': Mock()}), \
+                patch.object(docker_mod, 'state', MagicMock(return_value='stopped')):
+            docker_mod.stop('foo', timeout=1)
+            mine_mock.assert_not_called()
+
+        with patch.dict(docker_mod.__salt__, dunder_salt), \
+                patch.dict(docker_mod.__context__, {'docker.client': Mock()}), \
+                patch.object(docker_mod, 'state', MagicMock(return_value='stopped')):
+            dunder_salt['config.get'].side_effect = config_get_enabled
+            docker_mod.stop('foo', timeout=1)
+            self.assert_called_once(mine_mock)
+
     @skipIf(_docker_py_version() < (1, 5, 0),
             'docker module must be installed to run this test or is too old. >=1.5.0')
     def test_list_networks(self, *args):


### PR DESCRIPTION
This allows for the mine refresh to be disabled via configuring this option in the minion config, grains, or pillar.