### PR TITLE
Teach salt.utils.minions.CkMinions.connected_ids() about IPv6

### DIFF
--- a/doc/ref/configuration/master.rst
+++ b/doc/ref/configuration/master.rst
@@ -803,8 +803,7 @@ Causes the master to periodically look for actively connected minions.
 :ref:`Presence events <event-master_presence>` are fired on the event bus on a
 regular interval with a list of connected minions, as well as events with lists
 of newly connected or disconnected minions. This is a master-only operation
-that does not send executions to minions. Note, this does not detect minions
-that connect to a master via localhost.
+that does not send executions to minions.
 
 .. code-block:: yaml
 

--- a/salt/runners/manage.py
+++ b/salt/runners/manage.py
@@ -201,9 +201,24 @@ def up(tgt='*', tgt_type='glob', timeout=None, gather_job_timeout=None):  # pyli
     return ret
 
 
-def list_state(subset=None, show_ipv4=False, state=None):
+def _show_ip_migration(show_ip, show_ipv4):
+    if show_ipv4 is not None:
+        salt.utils.versions.warn_until(
+            'Sodium',
+            'The \'show_ipv4\' argument has been renamed to \'show_ip\' as'
+            'it now also includes IPv6 addresses for IPv6-connected'
+            'minions.'
+        )
+        return show_ipv4
+    return show_ip
+
+
+def list_state(subset=None, show_ip=False, show_ipv4=None, state=None):
     '''
     .. versionadded:: 2015.8.0
+    .. versionchanged:: Fluorine
+        The 'show_ipv4' argument has been renamed to 'show_ip' as it now
+        includes IPv6 addresses for IPv6-connected minions.
 
     Print a list of all minions that are up according to Salt's presence
     detection (no commands will be sent to minions)
@@ -211,7 +226,7 @@ def list_state(subset=None, show_ipv4=False, state=None):
     subset : None
         Pass in a CIDR range to filter minions by IP address.
 
-    show_ipv4 : False
+    show_ip : False
         Also show the IP address each minion is connecting from.
 
     state : 'available'
@@ -224,6 +239,7 @@ def list_state(subset=None, show_ipv4=False, state=None):
 
         salt-run manage.list_state
     '''
+    show_ip = _show_ip_migration(show_ip, show_ipv4)
     conf_file = __opts__['conf_file']
     opts = salt.config.client_config(conf_file)
     if opts['transport'] == 'raet':
@@ -240,16 +256,19 @@ def list_state(subset=None, show_ipv4=False, state=None):
         # Always return 'present' for 0MQ for now
         # TODO: implement other states support for 0MQ
         ckminions = salt.utils.minions.CkMinions(__opts__)
-        minions = ckminions.connected_ids(show_ipv4=show_ipv4, subset=subset)
+        minions = ckminions.connected_ids(show_ip=show_ip, subset=subset)
 
-    connected = dict(minions) if show_ipv4 else sorted(minions)
+    connected = dict(minions) if show_ip else sorted(minions)
 
     return connected
 
 
-def list_not_state(subset=None, show_ipv4=False, state=None):
+def list_not_state(subset=None, show_ip=False, show_ipv4=None, state=None):
     '''
     .. versionadded:: 2015.8.0
+    .. versionchanged:: Fluorine
+        The 'show_ipv4' argument has been renamed to 'show_ip' as it now
+        includes IPv6 addresses for IPv6-connected minions.
 
     Print a list of all minions that are NOT up according to Salt's presence
     detection (no commands will be sent to minions)
@@ -257,7 +276,7 @@ def list_not_state(subset=None, show_ipv4=False, state=None):
     subset : None
         Pass in a CIDR range to filter minions by IP address.
 
-    show_ipv4 : False
+    show_ip : False
         Also show the IP address each minion is connecting from.
 
     state : 'available'
@@ -270,7 +289,8 @@ def list_not_state(subset=None, show_ipv4=False, state=None):
 
         salt-run manage.list_not_state
     '''
-    connected = list_state(subset=None, show_ipv4=show_ipv4, state=state)
+    show_ip = _show_ip_migration(show_ip, show_ipv4)
+    connected = list_state(subset=None, show_ip=show_ip, state=state)
 
     key = salt.key.get_key(__opts__)
     keys = key.list_keys()
@@ -290,15 +310,19 @@ def list_not_state(subset=None, show_ipv4=False, state=None):
     return not_connected
 
 
-def present(subset=None, show_ipv4=False):
+def present(subset=None, show_ip=False, show_ipv4=None):
     '''
+    .. versionchanged:: Fluorine
+        The 'show_ipv4' argument has been renamed to 'show_ip' as it now
+        includes IPv6 addresses for IPv6-connected minions.
+
     Print a list of all minions that are up according to Salt's presence
     detection (no commands will be sent to minions)
 
     subset : None
         Pass in a CIDR range to filter minions by IP address.
 
-    show_ipv4 : False
+    show_ip : False
         Also show the IP address each minion is connecting from.
 
     CLI Example:
@@ -307,12 +331,16 @@ def present(subset=None, show_ipv4=False):
 
         salt-run manage.present
     '''
-    return list_state(subset=subset, show_ipv4=show_ipv4)
+    show_ip = _show_ip_migration(show_ip, show_ipv4)
+    return list_state(subset=subset, show_ip=show_ip)
 
 
-def not_present(subset=None, show_ipv4=False):
+def not_present(subset=None, show_ip=False, show_ipv4=None):
     '''
     .. versionadded:: 2015.5.0
+    .. versionchanged:: Fluorine
+        The 'show_ipv4' argument has been renamed to 'show_ip' as it now
+        includes IPv6 addresses for IPv6-connected minions.
 
     Print a list of all minions that are NOT up according to Salt's presence
     detection (no commands will be sent)
@@ -320,7 +348,7 @@ def not_present(subset=None, show_ipv4=False):
     subset : None
         Pass in a CIDR range to filter minions by IP address.
 
-    show_ipv4 : False
+    show_ip : False
         Also show the IP address each minion is connecting from.
 
     CLI Example:
@@ -329,12 +357,16 @@ def not_present(subset=None, show_ipv4=False):
 
         salt-run manage.not_present
     '''
-    return list_not_state(subset=subset, show_ipv4=show_ipv4)
+    show_ip = _show_ip_migration(show_ip, show_ipv4)
+    return list_not_state(subset=subset, show_ip=show_ip)
 
 
-def joined(subset=None, show_ipv4=False):
+def joined(subset=None, show_ip=False, show_ipv4=None):
     '''
     .. versionadded:: 2015.8.0
+    .. versionchanged:: Fluorine
+        The 'show_ipv4' argument has been renamed to 'show_ip' as it now
+        includes IPv6 addresses for IPv6-connected minions.
 
     Print a list of all minions that are up according to Salt's presence
     detection (no commands will be sent to minions)
@@ -342,7 +374,7 @@ def joined(subset=None, show_ipv4=False):
     subset : None
         Pass in a CIDR range to filter minions by IP address.
 
-    show_ipv4 : False
+    show_ip : False
         Also show the IP address each minion is connecting from.
 
     CLI Example:
@@ -351,12 +383,16 @@ def joined(subset=None, show_ipv4=False):
 
         salt-run manage.joined
     '''
-    return list_state(subset=subset, show_ipv4=show_ipv4, state='joined')
+    show_ip = _show_ip_migration(show_ip, show_ipv4)
+    return list_state(subset=subset, show_ip=show_ip, state='joined')
 
 
-def not_joined(subset=None, show_ipv4=False):
+def not_joined(subset=None, show_ip=False, show_ipv4=None):
     '''
     .. versionadded:: 2015.8.0
+    .. versionchanged:: Fluorine
+        The 'show_ipv4' argument has been renamed to 'show_ip' as it now
+        includes IPv6 addresses for IPv6-connected minions.
 
     Print a list of all minions that are NOT up according to Salt's presence
     detection (no commands will be sent)
@@ -364,7 +400,7 @@ def not_joined(subset=None, show_ipv4=False):
     subset : None
         Pass in a CIDR range to filter minions by IP address.
 
-    show_ipv4 : False
+    show_ip : False
         Also show the IP address each minion is connecting from.
 
     CLI Example:
@@ -373,12 +409,16 @@ def not_joined(subset=None, show_ipv4=False):
 
         salt-run manage.not_joined
     '''
-    return list_not_state(subset=subset, show_ipv4=show_ipv4, state='joined')
+    show_ip = _show_ip_migration(show_ip, show_ipv4)
+    return list_not_state(subset=subset, show_ip=show_ip, state='joined')
 
 
-def allowed(subset=None, show_ipv4=False):
+def allowed(subset=None, show_ip=False, show_ipv4=None):
     '''
     .. versionadded:: 2015.8.0
+    .. versionchanged:: Fluorine
+        The 'show_ipv4' argument has been renamed to 'show_ip' as it now
+        includes IPv6 addresses for IPv6-connected minions.
 
     Print a list of all minions that are up according to Salt's presence
     detection (no commands will be sent to minions)
@@ -386,7 +426,7 @@ def allowed(subset=None, show_ipv4=False):
     subset : None
         Pass in a CIDR range to filter minions by IP address.
 
-    show_ipv4 : False
+    show_ip : False
         Also show the IP address each minion is connecting from.
 
     CLI Example:
@@ -395,12 +435,16 @@ def allowed(subset=None, show_ipv4=False):
 
         salt-run manage.allowed
     '''
-    return list_state(subset=subset, show_ipv4=show_ipv4, state='allowed')
+    show_ip = _show_ip_migration(show_ip, show_ipv4)
+    return list_state(subset=subset, show_ip=show_ip, state='allowed')
 
 
-def not_allowed(subset=None, show_ipv4=False):
+def not_allowed(subset=None, show_ip=False, show_ipv4=None):
     '''
     .. versionadded:: 2015.8.0
+    .. versionchanged:: Fluorine
+        The 'show_ipv4' argument has been renamed to 'show_ip' as it now
+        includes IPv6 addresses for IPv6-connected minions.
 
     Print a list of all minions that are NOT up according to Salt's presence
     detection (no commands will be sent)
@@ -408,7 +452,7 @@ def not_allowed(subset=None, show_ipv4=False):
     subset : None
         Pass in a CIDR range to filter minions by IP address.
 
-    show_ipv4 : False
+    show_ip : False
         Also show the IP address each minion is connecting from.
 
     CLI Example:
@@ -417,12 +461,16 @@ def not_allowed(subset=None, show_ipv4=False):
 
         salt-run manage.not_allowed
     '''
-    return list_not_state(subset=subset, show_ipv4=show_ipv4, state='allowed')
+    show_ip = _show_ip_migration(show_ip, show_ipv4)
+    return list_not_state(subset=subset, show_ip=show_ip, state='allowed')
 
 
-def alived(subset=None, show_ipv4=False):
+def alived(subset=None, show_ip=False, show_ipv4=None):
     '''
     .. versionadded:: 2015.8.0
+    .. versionchanged:: Fluorine
+        The 'show_ipv4' argument has been renamed to 'show_ip' as it now
+        includes IPv6 addresses for IPv6-connected minions.
 
     Print a list of all minions that are up according to Salt's presence
     detection (no commands will be sent to minions)
@@ -430,7 +478,7 @@ def alived(subset=None, show_ipv4=False):
     subset : None
         Pass in a CIDR range to filter minions by IP address.
 
-    show_ipv4 : False
+    show_ip : False
         Also show the IP address each minion is connecting from.
 
     CLI Example:
@@ -439,12 +487,16 @@ def alived(subset=None, show_ipv4=False):
 
         salt-run manage.alived
     '''
-    return list_state(subset=subset, show_ipv4=show_ipv4, state='alived')
+    show_ip = _show_ip_migration(show_ip, show_ipv4)
+    return list_state(subset=subset, show_ip=show_ip, state='alived')
 
 
-def not_alived(subset=None, show_ipv4=False):
+def not_alived(subset=None, show_ip=False, show_ipv4=None):
     '''
     .. versionadded:: 2015.8.0
+    .. versionchanged:: Fluorine
+        The 'show_ipv4' argument has been renamed to 'show_ip' as it now
+        includes IPv6 addresses for IPv6-connected minions.
 
     Print a list of all minions that are NOT up according to Salt's presence
     detection (no commands will be sent)
@@ -452,7 +504,7 @@ def not_alived(subset=None, show_ipv4=False):
     subset : None
         Pass in a CIDR range to filter minions by IP address.
 
-    show_ipv4 : False
+    show_ip : False
         Also show the IP address each minion is connecting from.
 
     CLI Example:
@@ -461,12 +513,16 @@ def not_alived(subset=None, show_ipv4=False):
 
         salt-run manage.not_alived
     '''
-    return list_not_state(subset=subset, show_ipv4=show_ipv4, state='alived')
+    show_ip = _show_ip_migration(show_ip, show_ipv4)
+    return list_not_state(subset=subset, show_ip=show_ip, state='alived')
 
 
-def reaped(subset=None, show_ipv4=False):
+def reaped(subset=None, show_ip=False, show_ipv4=None):
     '''
     .. versionadded:: 2015.8.0
+    .. versionchanged:: Fluorine
+        The 'show_ipv4' argument has been renamed to 'show_ip' as it now
+        includes IPv6 addresses for IPv6-connected minions.
 
     Print a list of all minions that are up according to Salt's presence
     detection (no commands will be sent to minions)
@@ -474,7 +530,7 @@ def reaped(subset=None, show_ipv4=False):
     subset : None
         Pass in a CIDR range to filter minions by IP address.
 
-    show_ipv4 : False
+    show_ip : False
         Also show the IP address each minion is connecting from.
 
     CLI Example:
@@ -483,12 +539,16 @@ def reaped(subset=None, show_ipv4=False):
 
         salt-run manage.reaped
     '''
-    return list_state(subset=subset, show_ipv4=show_ipv4, state='reaped')
+    show_ip = _show_ip_migration(show_ip, show_ipv4)
+    return list_state(subset=subset, show_ip=show_ip, state='reaped')
 
 
-def not_reaped(subset=None, show_ipv4=False):
+def not_reaped(subset=None, show_ip=False, show_ipv4=None):
     '''
     .. versionadded:: 2015.8.0
+    .. versionchanged:: Fluorine
+        The 'show_ipv4' argument has been renamed to 'show_ip' as it now
+        includes IPv6 addresses for IPv6-connected minions.
 
     Print a list of all minions that are NOT up according to Salt's presence
     detection (no commands will be sent)
@@ -496,7 +556,7 @@ def not_reaped(subset=None, show_ipv4=False):
     subset : None
         Pass in a CIDR range to filter minions by IP address.
 
-    show_ipv4 : False
+    show_ip : False
         Also show the IP address each minion is connecting from.
 
     CLI Example:
@@ -505,7 +565,8 @@ def not_reaped(subset=None, show_ipv4=False):
 
         salt-run manage.not_reaped
     '''
-    return list_not_state(subset=subset, show_ipv4=show_ipv4, state='reaped')
+    show_ip = _show_ip_migration(show_ip, show_ipv4)
+    return list_not_state(subset=subset, show_ip=show_ip, state='reaped')
 
 
 def get_stats(estate=None, stack='road'):

--- a/salt/runners/manage.py
+++ b/salt/runners/manage.py
@@ -240,7 +240,7 @@ def list_state(subset=None, show_ipv4=False, state=None):
         # Always return 'present' for 0MQ for now
         # TODO: implement other states support for 0MQ
         ckminions = salt.utils.minions.CkMinions(__opts__)
-        minions = ckminions.connected_ids(show_ipv4=show_ipv4, subset=subset, include_localhost=True)
+        minions = ckminions.connected_ids(show_ipv4=show_ipv4, subset=subset)
 
     connected = dict(minions) if show_ipv4 else sorted(minions)
 

--- a/salt/utils/minions.py
+++ b/salt/utils/minions.py
@@ -614,10 +614,16 @@ class CkMinions(object):
         return {'minions': list(minions),
                 'missing': []}
 
-    def connected_ids(self, subset=None, show_ipv4=False, include_localhost=False):
+    def connected_ids(self, subset=None, show_ipv4=False, include_localhost=None):
         '''
         Return a set of all connected minion ids, optionally within a subset
         '''
+        if include_localhost is not None:
+            salt.utils.versions.warn_until(
+                'Sodium',
+                'The \'include_localhost\' argument is no longer required; any'
+                'connected localhost minion will always be included.'
+            )
         minions = set()
         if self.opts.get('minion_data_cache', False):
             search = self.cache.list('minions')

--- a/salt/utils/minions.py
+++ b/salt/utils/minions.py
@@ -627,7 +627,7 @@ class CkMinions(object):
             if '127.0.0.1' in addrs:
                 # Add in the address of a possible locally-connected minion.
                 addrs.discard('127.0.0.1')
-                addrs.update(set(salt.utils.network.ip_addrs(include_loopback=include_localhost)))
+                addrs.update(set(salt.utils.network.ip_addrs(include_loopback=False)))
             if subset:
                 search = subset
             for id_ in search:
@@ -643,8 +643,6 @@ class CkMinions(object):
                     continue
                 grains = mdata.get('grains', {})
                 for ipv4 in grains.get('ipv4', []):
-                    if ipv4 == '127.0.0.1' and not include_localhost:
-                        continue
                     if ipv4 in addrs:
                         if show_ipv4:
                             minions.add((id_, ipv4))

--- a/salt/utils/minions.py
+++ b/salt/utils/minions.py
@@ -634,6 +634,10 @@ class CkMinions(object):
                 # Add in the address of a possible locally-connected minion.
                 addrs.discard('127.0.0.1')
                 addrs.update(set(salt.utils.network.ip_addrs(include_loopback=False)))
+            if '::1' in addrs:
+                # Add in the address of a possible locally-connected minion.
+                addrs.discard('::1')
+                addrs.update(set(salt.utils.network.ip_addrs6(include_loopback=False)))
             if subset:
                 search = subset
             for id_ in search:
@@ -652,6 +656,13 @@ class CkMinions(object):
                     if ipv4 in addrs:
                         if show_ipv4:
                             minions.add((id_, ipv4))
+                        else:
+                            minions.add(id_)
+                        break
+                for ipv6 in grains.get('ipv6', []):
+                    if ipv6 in addrs:
+                        if show_ipv4:
+                            minions.add((id_, ipv6))
                         else:
                             minions.add(id_)
                         break

--- a/salt/utils/minions.py
+++ b/salt/utils/minions.py
@@ -645,8 +645,6 @@ class CkMinions(object):
                 for ipv4 in grains.get('ipv4', []):
                     if ipv4 == '127.0.0.1' and not include_localhost:
                         continue
-                    if ipv4 == '0.0.0.0':
-                        continue
                     if ipv4 in addrs:
                         if show_ipv4:
                             minions.add((id_, ipv4))

--- a/salt/utils/minions.py
+++ b/salt/utils/minions.py
@@ -614,7 +614,7 @@ class CkMinions(object):
         return {'minions': list(minions),
                 'missing': []}
 
-    def connected_ids(self, subset=None, show_ipv4=False, include_localhost=None):
+    def connected_ids(self, subset=None, show_ip=False, show_ipv4=None, include_localhost=None):
         '''
         Return a set of all connected minion ids, optionally within a subset
         '''
@@ -623,6 +623,13 @@ class CkMinions(object):
                 'Sodium',
                 'The \'include_localhost\' argument is no longer required; any'
                 'connected localhost minion will always be included.'
+            )
+        if show_ipv4 is not None:
+            salt.utils.versions.warn_until(
+                'Sodium',
+                'The \'show_ipv4\' argument has been renamed to \'show_ip\' as'
+                'it now also includes IPv6 addresses for IPv6-connected'
+                'minions.'
             )
         minions = set()
         if self.opts.get('minion_data_cache', False):
@@ -654,14 +661,14 @@ class CkMinions(object):
                 grains = mdata.get('grains', {})
                 for ipv4 in grains.get('ipv4', []):
                     if ipv4 in addrs:
-                        if show_ipv4:
+                        if show_ip:
                             minions.add((id_, ipv4))
                         else:
                             minions.add(id_)
                         break
                 for ipv6 in grains.get('ipv6', []):
                     if ipv6 in addrs:
-                        if show_ipv4:
+                        if show_ip:
                             minions.add((id_, ipv6))
                         else:
                             minions.add(id_)

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -1278,7 +1278,11 @@ def active_tcp():
                     line = salt.utils.stringutils.to_unicode(line)
                     if line.strip().startswith('sl'):
                         continue
-                    ret.update(_parse_tcp_line(line))
+                    iret = _parse_tcp_line(line)
+                    sl = next(iter(iret))
+                    if iret[sl]['state'] == 1:  # 1 is ESTABLISHED
+                        del iret[sl]['state']
+                        ret.update(iret)
     return ret
 
 
@@ -1316,7 +1320,7 @@ def _remotes_on(port, which_end):
                         continue
                     iret = _parse_tcp_line(line)
                     sl = next(iter(iret))
-                    if iret[sl][which_end] == port:
+                    if iret[sl][which_end] == port and iret[sl]['state'] == 1:  # 1 is ESTABLISHED
                         ret.add(iret[sl]['remote_addr'])
 
     if not proc_available:  # Fallback to use OS specific tools
@@ -1352,6 +1356,7 @@ def _parse_tcp_line(line):
     ret[sl]['local_port'] = int(l_port, 16)
     ret[sl]['remote_addr'] = hex2ip(r_addr, True)
     ret[sl]['remote_port'] = int(r_port, 16)
+    ret[sl]['state'] = int(comps[3], 16)
     return ret
 
 

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -1282,7 +1282,7 @@ def active_tcp():
                     sl = next(iter(iret))
                     if iret[sl]['state'] == 1:  # 1 is ESTABLISHED
                         del iret[sl]['state']
-                        ret.update(iret)
+                        ret[len(ret)] = iret[sl]
     return ret
 
 

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -1225,7 +1225,11 @@ def hex2ip(hex_ip, invert=False):
             else:
                 ip.append("{0[0]}{0[1]}:{0[2]}{0[3]}".format(ip_part))
         try:
-            return ipaddress.IPv6Address(":".join(ip)).compressed
+            address = ipaddress.IPv6Address(":".join(ip))
+            if address.ipv4_mapped:
+                return str(address.ipv4_mapped)
+            else:
+                return address.compressed
         except ipaddress.AddressValueError as ex:
             log.error('hex2ip - ipv6 address error: {0}'.format(ex))
             return hex_ip

--- a/tests/unit/utils/test_network.py
+++ b/tests/unit/utils/test_network.py
@@ -209,6 +209,10 @@ class NetworkTestCase(TestCase):
     def test_hex2ip(self):
         self.assertEqual(network.hex2ip('0x4A7D2B63'), '74.125.43.99')
         self.assertEqual(network.hex2ip('0x4A7D2B63', invert=True), '99.43.125.74')
+        self.assertEqual(network.hex2ip('00000000000000000000FFFF7F000001'), '127.0.0.1')
+        self.assertEqual(network.hex2ip('0000000000000000FFFF00000100007F', invert=True), '127.0.0.1')
+        self.assertEqual(network.hex2ip('20010DB8000000000000000000000000'), '2001:db8::')
+        self.assertEqual(network.hex2ip('B80D0120000000000000000000000000', invert=True), '2001:db8::')
 
     def test_interfaces_ifconfig_linux(self):
         interfaces = network._interfaces_ifconfig(LINUX)


### PR DESCRIPTION
### What does this PR do?

This teaches salt.utils.minions.CkMinions.connected_ids() about IPv6, so that IPv6 minions show up in the manage.list_state and family runners, as well as presence events, when the master runs on a system with /proc/net/tcp{,6}.

### What issues does this PR fix or reference?

While I was in this section of code, I fixed some logic issues around including any localhost minion (including IPv6 localhost minion), while avoiding including any minion that isn't connected.  This allows any localhost minion to always show up in presence events.

I also fixed salt.utils.network.local_port_tcp() and salt.utils.network.active_tcp() so they don't include listening ports when /proc/net/tcp is available, to match their OS-specific implementations, and made it so IPv6 connections don't overwrite IPv4 connections in active_tcp() results.

### Previous Behavior

IPv6 minions don't show up in manage.list_state and family runner results or presence events on masters with /proc/net/tcp{,6}.  salt.utils.network.local_port_tcp() and salt.utils.network.active_tcp() include listening ports when /proc/net/tcp{,6} is available.  salt.utils.network.active_tcp() is missing some IPv4 connections when there are IPv6 connections.

### New Behavior

IPv6 minions are included in manage.list_state and family runner results and presence events on masters with /proc/net/tcp{,6}.  salt.utils.network.local_port_tcp() and salt.utils.network.active_tcp() don't include listening ports when /proc/net/tcp{,6} is available.  salt.utils.network.active_tcp() includes all IPv4 and IPv6 connections.

### Tests written?

No

### Commits signed with GPG?

Yes

### Miscellaneous notes

I opened this PR against develop because I changed the API of CkMinions.connected_ids() as the include_localhost parameter was no longer needed.  I would like to see this backported to at least 2018.3, though, and preferably make it in before 2018.3.2 is released, so I don't have to continue to apply this fix locally.  If changing the API of this function in a stable release is an issue, then the function could still accept the parameter but just not do anything with it.

I'm still not happy with how CkMinions.connected_ids() is implemented, because there's one presumably common case and a few edge cases that are not handled:

* NATed minions won't be listed (presumably common case)
* If there are multiple minions with the same IP address, they will all be listed if at least one is connected from that address
* If there are multiple masters listening on the same port but different addresses, minions can be listed that aren't connected to the master being interrogated
* (possibly Linux-specific) If a localhost minion connects to the master using an address in 127.0.0.0/8 that either is not explicitly configured on the loopback interface or the master is not explicitly listening on, it won't be listed

Fixing any of these would require a lot more work.