### PR TITLE
2018.3 auth

### DIFF
--- a/salt/auth/__init__.py
+++ b/salt/auth/__init__.py
@@ -283,7 +283,7 @@ class LoadAuth(object):
             return False
 
         if load['eauth'] not in self.opts['external_auth']:
-            # The eauth system is not enabled, fail
+            log.debug('The eauth system "%s" is not enabled', load['eauth'])
             log.warning('Authentication failure of type "eauth" occurred.')
             return False
 
@@ -361,6 +361,7 @@ class LoadAuth(object):
         eauth = token['eauth'] if token else load['eauth']
         if eauth not in self.opts['external_auth']:
             # No matching module is allowed in config
+            log.debug('The eauth system "%s" is not enabled', eauth)
             log.warning('Authorization failure occurred.')
             return None
 
@@ -371,6 +372,9 @@ class LoadAuth(object):
             name = self.load_name(load)  # The username we are attempting to auth with
             groups = self.get_groups(load)  # The groups this user belongs to
         eauth_config = self.opts['external_auth'][eauth]
+        if not eauth_config:
+            log.debug('eauth "%s" configuration is empty', eauth)
+
         if not groups:
             groups = []
 
@@ -690,6 +694,7 @@ class Resolver(object):
         if fstr not in self.auth:
             print(('The specified external authentication system "{0}" is '
                    'not available').format(eauth))
+            print("Available eauth types: {0}".format(", ".join(self.auth.file_mapping.keys())))
             return ret
 
         args = salt.utils.args.arg_lookup(self.auth[fstr])

--- a/salt/master.py
+++ b/salt/master.py
@@ -2046,6 +2046,8 @@ class ClearFuncs(object):
 
             if not authorized:
                 # Authorization error occurred. Do not continue.
+                if auth_type == 'eauth' and not auth_list and 'username' in extra and 'eauth' in extra:
+                    log.debug('Auth configuration for eauth "%s" and user "%s" is empty', extra['eauth'], extra['username'])
                 log.warning(err_msg)
                 return {'error': {'name': 'AuthorizationError',
                                   'message': 'Authorization error occurred.'}}

--- a/tests/integration/shell/test_key.py
+++ b/tests/integration/shell/test_key.py
@@ -232,7 +232,9 @@ class KeyTest(ShellCase, ShellCaseCommonTestsMixin):
         test salt-key -l with wrong eauth
         '''
         data = self.run_key('-l acc --eauth wrongeauth --username {0} --password {1}'.format(USERA, USERA_PWD))
-        expect = ['The specified external authentication system "wrongeauth" is not available']
+        expect = ['The specified external authentication system "wrongeauth" is not available',
+                  'Available eauth types: auto, django, file, keystone, ldap, mysql, pam, ',
+                  'pki, rest, sharedsecret, yubico']
         self.assertEqual(data, expect)
 
     def test_list_un(self):

--- a/tests/integration/shell/test_key.py
+++ b/tests/integration/shell/test_key.py
@@ -232,10 +232,8 @@ class KeyTest(ShellCase, ShellCaseCommonTestsMixin):
         test salt-key -l with wrong eauth
         '''
         data = self.run_key('-l acc --eauth wrongeauth --username {0} --password {1}'.format(USERA, USERA_PWD))
-        expect = ['The specified external authentication system "wrongeauth" is not available',
-                  'Available eauth types: auto, django, file, keystone, ldap, mysql, pam, ',
-                  'pki, rest, sharedsecret, yubico']
-        self.assertEqual(data, expect)
+        expect = r"^The specified external authentication system \"wrongeauth\" is not available\tAvailable eauth types: auto, .*"
+        self.assertRegex("\t".join(data), expect)
 
     def test_list_un(self):
         '''

--- a/tests/integration/shell/test_runner.py
+++ b/tests/integration/shell/test_runner.py
@@ -208,5 +208,7 @@ class RunTest(ShellCase, testprogram.TestProgramCase, ShellCaseCommonTestsMixin)
         '''
         run_cmd = self.run_run('-a wrongeauth --username {0} --password {1}\
                                test.arg arg kwarg=kwarg1'.format(USERA, USERA_PWD))
-        expect = ['The specified external authentication system "wrongeauth" is not available']
+        expect = ['The specified external authentication system "wrongeauth" is not available',
+                  'Available eauth types: auto, django, file, keystone, ldap, mysql, pam, ',
+                  'pki, rest, sharedsecret, yubico']
         self.assertEqual(expect, run_cmd)

--- a/tests/integration/shell/test_runner.py
+++ b/tests/integration/shell/test_runner.py
@@ -208,7 +208,5 @@ class RunTest(ShellCase, testprogram.TestProgramCase, ShellCaseCommonTestsMixin)
         '''
         run_cmd = self.run_run('-a wrongeauth --username {0} --password {1}\
                                test.arg arg kwarg=kwarg1'.format(USERA, USERA_PWD))
-        expect = ['The specified external authentication system "wrongeauth" is not available',
-                  'Available eauth types: auto, django, file, keystone, ldap, mysql, pam, ',
-                  'pki, rest, sharedsecret, yubico']
-        self.assertEqual(expect, run_cmd)
+        expect = r"^The specified external authentication system \"wrongeauth\" is not available\tAvailable eauth types: auto, .*"
+        self.assertRegex("\t".join(run_cmd), expect)


### PR DESCRIPTION
What does this PR do?
Add more verbose debug messages for auth subsystem.
It is the updated version of #46807

What issues does this PR fix or reference?
#46806

Previous Behavior
The useless "Authorization failure occurred" message

New Behavior
New log messages at debug log level.

Tests written?
No (Updated)

Commits signed with GPG?
No

Please review Salt's Contributing Guide for best practices.

See GitHub's page on GPG signing for more information about signing commits with GPG.