### PR TITLE
Don't call .exception() on future unless it's done.

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1032,10 +1032,11 @@ class Minion(MinionBase):
         # I made the following 3 line oddity to preserve traceback.
         # Please read PR #23978 before changing, hopefully avoiding regressions.
         # Good luck, we're all counting on you.  Thanks.
-        future_exception = self._connect_master_future.exception()
-        if future_exception:
-            # This needs to be re-raised to preserve restart_on_error behavior.
-            raise six.reraise(*future_exception)
+        if self._connect_master_future.done():
+            future_exception = self._connect_master_future.exception()
+            if future_exception:
+                # This needs to be re-raised to preserve restart_on_error behavior.
+                raise six.reraise(*future_exception)
         if timeout and self._sync_connect_master_success is False:
             raise SaltDaemonNotRunning('Failed to connect to the salt-master')
 

--- a/salt/transport/ipc.py
+++ b/salt/transport/ipc.py
@@ -752,9 +752,9 @@ class IPCMessageSubscriber(IPCClient):
             # This will prevent this message from showing up:
             # '[ERROR   ] Future exception was never retrieved:
             # StreamClosedError'
-            if self._read_sync_future is not None:
+            if self._read_sync_future is not None and self._read_sync_future.done():
                 self._read_sync_future.exception()
-            if self._read_stream_future is not None:
+            if self._read_stream_future is not None and self._read_stream_future.done():
                 self._read_stream_future.exception()
 
     def __del__(self):

--- a/salt/transport/tcp.py
+++ b/salt/transport/tcp.py
@@ -896,10 +896,9 @@ class SaltMessageClient(object):
                     # This happens because the logic is always waiting to read
                     # the next message and the associated read future is marked
                     # 'StreamClosedError' when the stream is closed.
-                    self._read_until_future.exception()
-                    if (not self._stream_return_future.done() and
-                            self.io_loop != tornado.ioloop.IOLoop.current(
-                                instance=False)):
+                    if self._read_until_future.done():
+                        self._read_until_future.exception()
+                    elif self.io_loop != tornado.ioloop.IOLoop.current(instance=False):
                         self.io_loop.add_future(
                             self._stream_return_future,
                             lambda future: self.io_loop.stop()
@@ -1134,7 +1133,7 @@ class Subscriber(object):
         self._closing = True
         if not self.stream.closed():
             self.stream.close()
-            if self._read_until_future is not None:
+            if self._read_until_future is not None and self._read_until_future.done():
                 # This will prevent this message from showing up:
                 # '[ERROR   ] Future exception was never retrieved:
                 # StreamClosedError'


### PR DESCRIPTION
### What does this PR do?
Avoid calling `future.exception()` unless the future is done. This prevents an exception to be raised from tornado code that checks is the future done before retrieving the exception.

### What issues does this PR fix or reference?
Fix #47901 

### Tests written?
No

### Commits signed with GPG?
Yes