### PR TITLE
If pip binary is passed to bin_env, use that pip binary

### DIFF
--- a/salt/modules/pip.py
+++ b/salt/modules/pip.py
@@ -172,20 +172,7 @@ def _get_pip_bin(bin_env):
             # If the python binary was passed, return it
             if 'python' in os.path.basename(bin_env):
                 return [os.path.normpath(bin_env), '-m', 'pip']
-            # Try to find the python binary based on the location of pip in a
-            # virtual environment, should be relative
-            if 'pip' in os.path.basename(bin_env):
-                # Look in the same directory as the pip binary, and also its
-                # parent directories.
-                pip_dirname = os.path.dirname(bin_env)
-                pip_parent_dir = os.path.dirname(pip_dirname)
-                for bin_path in _search_paths(pip_dirname, pip_parent_dir):
-                    if os.path.isfile(bin_path):
-                        logger.debug('pip: Found python binary: %s', bin_path)
-                        return [os.path.normpath(bin_path), '-m', 'pip']
-
-            # Couldn't find python, use the passed pip binary
-            # This has the limitation of being unable to update pip itself
+            # We have been passed a pip binary, use the pip binary.
             return [os.path.normpath(bin_env)]
 
         raise CommandExecutionError(
@@ -464,6 +451,13 @@ def install(pkgs=None,  # pylint: disable=R0912,R0913,R0914
         to the pip to use when more than one Python release is installed (e.g.
         ``/usr/bin/pip-2.7`` or ``/usr/bin/pip-2.6``. If a directory path is
         specified, it is assumed to be a virtualenv.
+
+        .. note::
+
+            For Windows, if the pip module is being used to upgrade the pip
+            package, bin_env should be the path to the virtualenv or to the
+            python binary that should be used.  The pip command is unable to
+            upgrade itself in Windows.
 
     use_wheel
         Prefer wheel archives (requires pip>=1.4)

--- a/tests/integration/modules/test_pip.py
+++ b/tests/integration/modules/test_pip.py
@@ -431,6 +431,16 @@ class PipModuleTest(ModuleCase):
             pprint.pprint(ret)
             raise
 
+    @skipIf(not os.path.isfile('pip3'), 'test where pip3 is installed')
+    @skipIf(salt.utils.platform.is_windows(), 'test specific for linux usage of /bin/python')
+    def test_system_pip3(self):
+        self.run_function('pip.install', pkgs=['lazyimport==0.0.1'], bin_env='/bin/pip3')
+        ret1 = self.run_function('cmd.run', '/bin/pip3 freeze | grep lazyimport')
+        self.run_function('pip.uninstall', pkgs=['lazyimport'], bin_env='/bin/pip3')
+        ret2 = self.run_function('cmd.run', '/bin/pip3 freeze | grep lazyimport')
+        assert 'lazyimport==0.0.1' in ret1
+        assert ret2 == ''
+
     def tearDown(self):
         super(PipModuleTest, self).tearDown()
         if os.path.isdir(self.venv_test_dir):


### PR DESCRIPTION
### What does this PR do?
We don't need to do a lookup for python to then run `python -m pip`
because we already know where pip is.

Fixes using /bin/pip3

### What issues does this PR fix or reference?
Fixes #48122

### Tests written?

Yes

### Commits signed with GPG?

Yes