### PR TITLE
Minor improvements and fixes for related PR: #48062

### DIFF
--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -152,6 +152,13 @@ def __ssh_gateway_config_dict(gateway):
 
 
 def __ssh_gateway_arguments(kwargs):
+    '''
+    Return ProxyCommand configuration string for ssh/scp command.
+
+    All gateway options should not include quotes (' or "). To support
+    future user configuration, please make sure to update the dictionary
+    from __ssh_gateway_config_dict and get_ssh_gateway_config (ec2.py)
+    '''
     extended_arguments = ""
 
     ssh_gateway = kwargs.get('ssh_gateway', '')

--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -137,6 +137,20 @@ def __render_script(path, vm_=None, opts=None, minion=''):
             return six.text_type(fp_.read())
 
 
+def __ssh_gateway_config_dict(gateway):
+    '''
+    Return a dictionary with gateway options. The result is used
+    to provide arguments to __ssh_gateway_arguments method.
+    '''
+    extended_kwargs = {}
+    if gateway:
+        extended_kwargs['ssh_gateway'] = gateway['ssh_gateway']
+        extended_kwargs['ssh_gateway_key'] = gateway['ssh_gateway_key']
+        extended_kwargs['ssh_gateway_user'] = gateway['ssh_gateway_user']
+        extended_kwargs['ssh_gateway_command'] = gateway['ssh_gateway_command']
+    return extended_kwargs
+
+
 def __ssh_gateway_arguments(kwargs):
     extended_arguments = ""
 
@@ -1122,11 +1136,7 @@ def wait_for_passwd(host, port=22, ssh_timeout=15, username='root',
                       'known_hosts_file': known_hosts_file,
                       'ssh_timeout': ssh_timeout,
                       'hard_timeout': hard_timeout}
-            if gateway:
-                kwargs['ssh_gateway'] = gateway['ssh_gateway']
-                kwargs['ssh_gateway_key'] = gateway['ssh_gateway_key']
-                kwargs['ssh_gateway_user'] = gateway['ssh_gateway_user']
-                kwargs['ssh_gateway_command'] = gateway['ssh_gateway_command']
+            kwargs.update(__ssh_gateway_config_dict(gateway))
 
             if key_filename:
                 if not os.path.isfile(key_filename):
@@ -1461,11 +1471,7 @@ def deploy_script(host,
                 'sudo_password': sudo_password,
                 'sftp': opts.get('use_sftp', False)
             }
-            if gateway:
-                ssh_kwargs['ssh_gateway'] = gateway['ssh_gateway']
-                ssh_kwargs['ssh_gateway_key'] = gateway['ssh_gateway_key']
-                ssh_kwargs['ssh_gateway_user'] = gateway['ssh_gateway_user']
-                ssh_kwargs['ssh_gateway_command'] = gateway['ssh_gateway_command']
+            ssh_kwargs.update(__ssh_gateway_config_dict(gateway))
             if key_filename:
                 log.debug('Using %s as the key_filename', key_filename)
                 ssh_kwargs['key_filename'] = key_filename
@@ -1905,11 +1911,7 @@ def run_inline_script(host,
                 'sudo_password': sudo_password,
                 'sftp': opts.get('use_sftp', False)
             }
-            if gateway:
-                ssh_kwargs['ssh_gateway'] = gateway['ssh_gateway']
-                ssh_kwargs['ssh_gateway_key'] = gateway['ssh_gateway_key']
-                ssh_kwargs['ssh_gateway_user'] = gateway['ssh_gateway_user']
-                ssh_kwargs['ssh_gateway_command'] = gateway['ssh_gateway_command']
+            ssh_kwargs.update(__ssh_gateway_config_dict(gateway))
             if key_filename:
                 log.debug('Using %s as the key_filename', key_filename)
                 ssh_kwargs['key_filename'] = key_filename

--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -144,12 +144,12 @@ def __ssh_gateway_arguments(kwargs):
     ssh_gateway_port = 22
     if ':' in ssh_gateway:
         ssh_gateway, ssh_gateway_port = ssh_gateway.split(':')
+    ssh_gateway_command = kwargs.get('ssh_gateway_command', 'nc -q0 %h %p')
 
     if ssh_gateway:
         ssh_gateway_port = kwargs.get('ssh_gateway_port', ssh_gateway_port)
         ssh_gateway_key = '-i {0}'.format(kwargs['ssh_gateway_key']) if 'ssh_gateway_key' in kwargs else ''
         ssh_gateway_user = kwargs.get('ssh_gateway_user', 'root')
-        ssh_gateway_command = kwargs.get('ssh_gateway_command', 'nc -q0 %h %p')
 
         # Setup ProxyCommand
         extended_arguments = '-oProxyCommand="ssh {0} {1} {2} {3} {4}@{5} -p {6} {7}"'.format(

--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -1126,6 +1126,7 @@ def wait_for_passwd(host, port=22, ssh_timeout=15, username='root',
                 kwargs['ssh_gateway'] = gateway['ssh_gateway']
                 kwargs['ssh_gateway_key'] = gateway['ssh_gateway_key']
                 kwargs['ssh_gateway_user'] = gateway['ssh_gateway_user']
+                kwargs['ssh_gateway_command'] = gateway['ssh_gateway_command']
 
             if key_filename:
                 if not os.path.isfile(key_filename):
@@ -1464,6 +1465,7 @@ def deploy_script(host,
                 ssh_kwargs['ssh_gateway'] = gateway['ssh_gateway']
                 ssh_kwargs['ssh_gateway_key'] = gateway['ssh_gateway_key']
                 ssh_kwargs['ssh_gateway_user'] = gateway['ssh_gateway_user']
+                ssh_kwargs['ssh_gateway_command'] = gateway['ssh_gateway_command']
             if key_filename:
                 log.debug('Using %s as the key_filename', key_filename)
                 ssh_kwargs['key_filename'] = key_filename
@@ -1907,6 +1909,7 @@ def run_inline_script(host,
                 ssh_kwargs['ssh_gateway'] = gateway['ssh_gateway']
                 ssh_kwargs['ssh_gateway_key'] = gateway['ssh_gateway_key']
                 ssh_kwargs['ssh_gateway_user'] = gateway['ssh_gateway_user']
+                ssh_kwargs['ssh_gateway_command'] = gateway['ssh_gateway_command']
             if key_filename:
                 log.debug('Using %s as the key_filename', key_filename)
                 ssh_kwargs['key_filename'] = key_filename


### PR DESCRIPTION
### What does this PR do?

Minor improvements and fixes for related PR: #48062.

The dictionary item `ssh_gateway_command` needs to be duplicated before being used in `__ssh_gateway_arguments`.

### What issues does this PR fix or reference?

Minor improvements and fixes for related PR: #48062.

### Previous Behavior

`ssh_gateway_command` setting is not known when running `salt-cloud`

### New Behavior

`ssh_gateway_command` setting is known correctly when running `salt-cloud`

### Tests written?

NO

Manual tests at developer's side: yes (by running `salt-cloud` with different configuration). See the transcript log in the first command on this thread.

### Commits signed with GPG?

Yes
