### PR TITLE
Fixes to LXC bootstrap when alternate lxcpath is provided.

### DIFF
--- a/salt/modules/lxc.py
+++ b/salt/modules/lxc.py
@@ -870,7 +870,7 @@ def _network_conf(conf_tuples=None, **kwargs):
     # on old versions of lxc, still support the gateway auto mode
     # if we didn't explicitly say no to
     # (lxc.network.ipv4.gateway: auto)
-    if _LooseVersion(version()) <= '1.0.7' and \
+    if _LooseVersion(version()) <= _LooseVersion('1.0.7') and \
             True not in ['lxc.network.ipv4.gateway' in a for a in ret] and \
             True in ['lxc.network.ipv4' in a for a in ret]:
         ret.append({'lxc.network.ipv4.gateway': 'auto'})
@@ -2079,7 +2079,7 @@ def clone(name,
     if backing in ('dir', 'overlayfs', 'btrfs'):
         size = None
     # LXC commands and options changed in 2.0 - CF issue #34086 for details
-    if version() >= _LooseVersion('2.0'):
+    if _LooseVersion(version()) >= _LooseVersion('2.0'):
         # https://linuxcontainers.org/lxc/manpages//man1/lxc-copy.1.html
         cmd = 'lxc-copy'
         cmd += ' {0} -n {1} -N {2}'.format(snapshot, orig, name)
@@ -3507,7 +3507,9 @@ def bootstrap(name,
                 configdir = '/var/tmp/.c_{0}'.format(rstr)
 
                 cmd = 'install -m 0700 -d {0}'.format(configdir)
-                if run(name, cmd, python_shell=False):
+                if run_all(
+                    name, cmd, path=path, python_shell=False
+                )['retcode'] != 0:
                     log.error('tmpdir {0} creation failed ({1}'
                               .format(configdir, cmd))
                     return False
@@ -3518,6 +3520,7 @@ def bootstrap(name,
                 copy_to(name, bs_, script, path=path)
                 result = run_all(name,
                                  'sh -c "chmod +x {0}"'.format(script),
+                                 path=path,
                                  python_shell=True)
 
                 copy_to(name, cfg_files['config'],
@@ -3544,6 +3547,7 @@ def bootstrap(name,
                 run_all(name,
                         'sh -c \'if [ -f "{0}" ];then rm -f "{0}";fi\''
                         ''.format(script),
+                        path=path,
                         ignore_retcode=True,
                         python_shell=True)
             else:


### PR DESCRIPTION
### What does this PR do?

* Fixes errorneous "tmpdir creation failed" reports breaking `lxc.bootstrap` whenever LXC command execution returns complaints about legacy configuration key usage in command output by replacing `run()` for `run_all()['retcode']` in condition
* Adds missing path arguments to in-container command executions
* Fixes version comparisons potentially causing unintended tracebacks

### Tests written?

No

### Commits signed with GPG?

No