### PR TITLE
salt/utils/aws: fix infinite loop issue and sts location

### DIFF
--- a/salt/utils/aws.py
+++ b/salt/utils/aws.py
@@ -133,7 +133,10 @@ def creds(provider):
         ret_credentials = provider['id'], provider['key'], ''
 
     if provider.get('role_arn') is not None:
-        ret_credentials = assumed_creds(provider, role_arn=provider.get('role_arn'), location=None)
+        provider_shadow = provider.copy()
+        provider_shadow.pop("role_arn", None)
+        log.info("Assuming the role: %s", provider.get('role_arn'))
+        ret_credentials = assumed_creds(provider_shadow, role_arn=provider.get('role_arn'), location='us-east-1')
 
     return ret_credentials
 


### PR DESCRIPTION
### What does this PR do?

`creds` may invoke `assumed_creds` which will invoke `creds` to get the original credentials.
To avoid the infinite loop issue, we need to delete `role_arn` from provider information
when calling `assumed_creds`.

`assumed_creds` will need to use `location=us-east-1` otherwise we may encounter error

```
  AssumeRole response: Credential should be scoped to a valid region.
```

### What issues does this PR fix or reference?

Fix problem from PR #48048 

### Previous Behavior

When user specify `role_arn` for `aws` provider, `salt-cloud` goes into an infinite loop and assumeRole doesn't work

### New Behavior

`role_arn` for `aws` provider works well.

### Tests written?

NO

Manual test at developer's side: https://gist.github.com/icy/6d49238803260d85820c7386065f2b9d

### Commits signed with GPG?

Yes