### PR TITLE
[Py3] Fix get_disks test in virt module unittests

### DIFF
--- a/tests/unit/modules/test_virt.py
+++ b/tests/unit/modules/test_virt.py
@@ -643,10 +643,10 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         self.set_mock_vm("test-vm", xml)
 
         disks = virt.get_disks('test-vm')
-        disk = disks[list(disks)[0]]
+        disk = disks.get('vda')
         self.assertEqual('/disks/test.qcow2', disk['file'])
         self.assertEqual('disk', disk['type'])
-        cdrom = disks[list(disks)[1]]
+        cdrom = disks.get('hda')
         self.assertEqual('/disks/test-cdrom.iso', cdrom['file'])
         self.assertEqual('cdrom', cdrom['type'])
 


### PR DESCRIPTION
### What does this PR do?
When using the `list()` function in Python3, the order that items are added to the list is not always the same.

Instead of wrapping the disks dict in a `list` and the getting the first and second element, just get the elements we want directly and test against those.

This makes the test much more stable on Python 3.

### What issues does this PR fix or reference?
Original test was added in #46901

### Previous Behavior
`unit.modules.test_virt.VirtTestCase.test_get_disks` was failing occasionally on Python 3 runs.

### New Behavior
`unit.modules.test_virt.VirtTestCase.test_get_disks` passes every time.

### Tests written?
Yes - fixes a test

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
