### PR TITLE
Fix python3 ec2 salt-cloud TypeError when installing salt

### DIFF
--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -2421,7 +2421,7 @@ def wait_for_instance(
                 )
                 pprint.pprint(console)
                 time.sleep(5)
-            output = console['output_decoded']
+            output = salt.utils.stringutils.to_unicode(console['output_decoded'])
             comps = output.split('-----BEGIN SSH HOST KEY KEYS-----')
             if len(comps) < 2:
                 # Fail; there are no host keys


### PR DESCRIPTION
### What does this PR do?
Fixes TypeError when trying to install salt on VM during creation.

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/48206

### Tests written?

Yes - This was found due to tests that were failing

### Commits signed with GPG?

Yes