### PR TITLE
Only call remove() on a list when the item is present

### DIFF
--- a/salt/states/linux_acl.py
+++ b/salt/states/linux_acl.py
@@ -338,17 +338,17 @@ def list_present(name, acl_type, acl_names=None, perms='', recurse=False, force=
         _origin_group = _current_perms.get('comment', {}).get('group', None)
         _origin_owner = _current_perms.get('comment', {}).get('owner', None)
 
-        _current_acl_types = list()
+        _current_acl_types = []
         diff_perms = False
         for key in _current_perms[acl_type]:
             for current_acl_name in key.keys():
                 _current_acl_types.append(current_acl_name.encode('utf-8'))
                 diff_perms = _octal_perms == key[current_acl_name]['octal']
         if acl_type == 'user':
-            if _origin_owner:
+            if _origin_owner and _origin_owner in _current_acl_types:
                 _current_acl_types.remove(_origin_owner)
         else:
-            if _origin_group:
+            if _origin_group and _origin_group in _current_acl_types:
                 _current_acl_types.remove(_origin_group)
         diff_acls = set(_current_acl_types) ^ set(acl_names)
         if not diff_acls and diff_perms and not force:


### PR DESCRIPTION
### What does this PR do?
The Python 3 tests were failing the `unit.states.test_linux_acl.LinuxAclTestCase.test_list_present` test with the following stacktrace:

```
Traceback (most recent call last):
  File "/testing/tests/unit/states/test_linux_acl.py", line 237, in test_list_present
    ret = linux_acl.list_present(name, acl_type, acl_names, perms)
  File "/testing/salt/states/linux_acl.py", line 353, in list_present
    _current_acl_types.remove(_origin_owner)
ValueError: list.remove(x): x not in list
```

We need to check if the item is contained in the list before trying to remove it.

### Previous Behavior
Test was failing on Python 3.

### New Behavior
Test passes.

### Tests written?
Yes - test fix

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
