### PR TITLE
Fix UnicodeDecodeError when reading file to determine virtual grain

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -947,7 +947,7 @@ def _virtual(osdata):
         if os.path.isfile('/sys/devices/virtual/dmi/id/product_name'):
             try:
                 with salt.utils.files.fopen('/sys/devices/virtual/dmi/id/product_name', 'r') as fhr:
-                    output = fhr.read()
+                    output = salt.utils.stringutils.to_unicode(fhr.read())
                     if 'VirtualBox' in output:
                         grains['virtual'] = 'VirtualBox'
                     elif 'RHEV Hypervisor' in output:

--- a/tests/unit/grains/test_core.py
+++ b/tests/unit/grains/test_core.py
@@ -946,3 +946,32 @@ class CoreGrainsTestCase(TestCase, LoaderModuleMockMixin):
         grains = {k: v for k, v in os_grains.items()
                   if k in set(['product', 'productname'])}
         self.assertEqual(grains, expectation)
+
+    @patch('os.path.isfile')
+    @patch('os.path.isdir')
+    def test_core_virtual_unicode(self, mock_file, mock_dir):
+        '''
+        test virtual grain with unicode character in product_name file
+        '''
+        def path_side_effect(path):
+            if path == '/sys/devices/virtual/dmi/id/product_name':
+                return True
+            return False
+
+        virt = 'kvm'
+        mock_file.side_effect = path_side_effect
+        mock_dir.side_effect = path_side_effect
+        with patch.object(salt.utils.platform, 'is_windows',
+                          MagicMock(return_value=False)):
+            with patch.object(salt.utils.path, 'which',
+                              MagicMock(return_value=True)):
+                with patch.dict(core.__salt__, {'cmd.run_all':
+                                                MagicMock(return_value={'pid': 78,
+                                                                        'retcode': 0,
+                                                                        'stderr': '',
+                                                                        'stdout': virt})}):
+                    with patch('salt.utils.files.fopen',
+                               mock_open(read_data='嗨')):
+                        osdata = {'kernel': 'Linux', }
+                        ret = core._virtual(osdata)
+                        self.assertEqual(ret['virtual'], virt)


### PR DESCRIPTION
### What does this PR do?
Fixes the UnicodeDecodeError when trying to read `/sys/devices/virtual/dmi/id/product_name` file when it contains non ascii characters.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/48184
