### PR TITLE
Fix: LXC legacy configuration key warnings falsely report errors during state change

### DIFF
--- a/salt/modules/lxc.py
+++ b/salt/modules/lxc.py
@@ -2270,22 +2270,22 @@ def _change_state(cmd,
     # as te command itself mess with double forks; we must not
     # communicate with it, but just wait for the exit status
     pkwargs = {'python_shell': False,
+               'redirect_stderr': True,
                'with_communicate': with_communicate,
                'use_vt': use_vt,
                'stdin': stdin,
-               'stdout': stdout,
-               'stderr': stderr}
+               'stdout': stdout}
     for i in [a for a in pkwargs]:
         val = pkwargs[i]
         if val is _marker:
             pkwargs.pop(i, None)
 
-    error = __salt__['cmd.run_stderr'](cmd, **pkwargs)
+    _cmdout = __salt__['cmd.run_all'](cmd, **pkwargs)
 
-    if error:
+    if _cmdout['retcode'] != 0:
         raise CommandExecutionError(
             'Error changing state for container \'{0}\' using command '
-            '\'{1}\': {2}'.format(name, cmd, error)
+            '\'{1}\': {2}'.format(name, cmd, _cmdout['stdout'])
         )
     if expected is not None:
         # some commands do not wait, so we will


### PR DESCRIPTION
### What does this PR do?

Fixes another case where a condition based on LXC command's output, instead of retcode could cause false error reporting and pre-emptive bailout on a task.

### Tests written?
No

### Commits signed with GPG?

No