### PR TITLE
2 fixes for when Salt is installed using -OO

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1528,7 +1528,9 @@ class Minion(MinionBase):
                 )
                 ret['out'] = 'nested'
             except TypeError as exc:
-                msg = 'Passed invalid arguments to {0}: {1}\n{2}'.format(function_name, exc, func.__doc__, )
+                msg = 'Passed invalid arguments to {0}: {1}\n{2}'.format(
+                    function_name, exc, func.__doc__ or ''
+                )
                 log.warning(msg, exc_info_on_loglevel=logging.DEBUG)
                 ret['return'] = msg
                 ret['out'] = 'nested'

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -2360,7 +2360,7 @@ def alias_function(fun, name, doc=None):
         orig_name = fun.__name__
         alias_msg = ('\nThis function is an alias of '
                      '``{0}``.\n'.format(orig_name))
-        alias_fun.__doc__ = alias_msg + fun.__doc__
+        alias_fun.__doc__ = alias_msg + (fun.__doc__ or '')
 
     return alias_fun
 


### PR DESCRIPTION
This fixes the following two issues:

1. Since a function's `.__doc__` attribute will be `None`, an exception is raised when we try to concatentate it when creating an aliased function.
2. The string we print out for SaltInvocationError tries to include the docstring in the message, but since it is `None` we instead see "Passed invalid arguments to foo.bar: <some error message>", followed by a line break and then "None".

This PR fixes both of those issues.