### PR TITLE
Skip new sha256 files on repo.saltstack.com/windows

### DIFF
--- a/tests/support/win_installer.py
+++ b/tests/support/win_installer.py
@@ -29,7 +29,7 @@ def iter_installers(content):
         x = m.groups()[0]
         if not x.startswith(PREFIX):
             continue
-        if x.endswith('zip'):
+        if x.endswith(('zip', 'sha256')):
             continue
         if installer:
             if x != installer + '.md5':


### PR DESCRIPTION
### What does this PR do?
Fixes the tests `integration.cloud.providers.test_ec2` when trying to determine the latest windows installer. In the 2017.7.6 release we started adding sha256 files alongside md5. This simply skips the sha256 files since we aren't testing the packages/sha files themselves but testing windows works with salt-cloud

### Previous Behavior
Tests would fail during the setUp() because they could not determine the latest release.

### New Behavior
Tests run

### Tests written?

Yes - this fixes a test

### Commits signed with GPG?

Yes
