### PR TITLE
[2018.3] Fixes to mysql module

### DIFF
--- a/tests/unit/modules/test_mysql.py
+++ b/tests/unit/modules/test_mysql.py
@@ -54,10 +54,12 @@ class MySQLTestCase(TestCase, LoaderModuleMockMixin):
 
         # test_user_create_when_user_exists(self):
         # ensure we don't try to create a user when one already exists
-        with patch.object(mysql, 'user_exists', MagicMock(return_value=True)):
-            with patch.dict(mysql.__salt__, {'config.option': MagicMock()}):
-                ret = mysql.user_create('testuser')
-                self.assertEqual(False, ret)
+        # mock the version of MySQL
+        with patch.object(mysql, 'version', MagicMock(return_value='8.0.10')):
+            with patch.object(mysql, 'user_exists', MagicMock(return_value=True)):
+                with patch.dict(mysql.__salt__, {'config.option': MagicMock()}):
+                    ret = mysql.user_create('testuser')
+                    self.assertEqual(False, ret)
 
     def test_user_create(self):
         '''


### PR DESCRIPTION
### What does this PR do?
Updating the mysql module to not use the PASSWORD when MySQL is version 8.0.11 or higher, where the PASSWORD function has been removed.

### What issues does this PR fix or reference?
#48204 

### Tests written?
Yes.  Existing tests updated.

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
