### PR TITLE
do not expand kwargs for cloud.action

### DIFF
--- a/salt/runners/cloud.py
+++ b/salt/runners/cloud.py
@@ -154,7 +154,7 @@ def action(func=None,
     info = {}
     client = _get_client()
     try:
-        info = client.action(func, cloudmap, instances, provider, instance, **_filter_kwargs(kwargs))
+        info = client.action(func, cloudmap, instances, provider, instance, _filter_kwargs(kwargs))
     except SaltCloudConfigError as err:
         log.error(err)
     return info


### PR DESCRIPTION
### What does this PR do?
We do not want to expand kwargs when passed into the cloud.action function on the client.  This should just pass to the kwargs variable.

### What issues does this PR fix or reference?
Brought up in community slack

### Commits signed with GPG?

Yes