### PR TITLE
Fix py2 thin dir issues

### DIFF
--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -1106,7 +1106,10 @@ ARGS = {10}\n'''.format(self.minion_config,
             shim_tmp_file.write(salt.utils.to_bytes(cmd_str))
 
         # Copy shim to target system, under $HOME/.<randomized name>
-        target_shim_file = '.{0}.{1}'.format(binascii.hexlify(os.urandom(6)), extension)
+        target_shim_file = '.{0}.{1}'.format(
+            binascii.hexlify(os.urandom(6)).decode('ascii'),
+            extension
+        )
         if self.winrm:
             target_shim_file = saltwinshell.get_target_shim_file(self, target_shim_file)
         self.shell.send(shim_tmp_file.name, target_shim_file, makedirs=True)

--- a/salt/utils/thin.py
+++ b/salt/utils/thin.py
@@ -14,6 +14,7 @@ import tarfile
 import zipfile
 import tempfile
 import subprocess
+import concurrent
 
 # Import third party libs
 import jinja2
@@ -106,6 +107,8 @@ def get_tops(extra_mods='', so_mods=''):
             os.path.dirname(msgpack.__file__),
             ]
 
+    if _six.PY2:
+        tops.append(os.path.dirname(concurrent.__file__))
     tops.append(_six.__file__.replace('.pyc', '.py'))
     tops.append(backports_abc.__file__.replace('.pyc', '.py'))
 

--- a/tests/integration/utils/test_thin.py
+++ b/tests/integration/utils/test_thin.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+import tarfile
+import tempfile
+import subprocess
+import sys
+import os
+
+from tests.support.unit import TestCase
+
+import salt.utils
+import salt.utils.thin
+try:
+    import virtualenv
+    HAS_VENV = True
+except ImportError:
+    HAS_VENV = False
+
+
+class TestThinDir(TestCase):
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        salt.utils.rm_rf(self.tmpdir)
+
+    def test_thin_dir(self):
+        '''
+        Test the thin dir to make sure salt-call can run
+
+        Run salt call via a python in a new virtual environment to ensure
+        salt-call has all dependencies needed.
+        '''
+        venv_dir = os.path.join(self.tmpdir, 'venv')
+        virtualenv.create_environment(venv_dir)
+        salt.utils.thin.gen_thin(self.tmpdir)
+        thin_dir = os.path.join(self.tmpdir, 'thin')
+        thin_archive = os.path.join(thin_dir, 'thin.tgz')
+        tar = tarfile.open(thin_archive)
+        tar.extractall(thin_dir)
+        tar.close()
+        bins = 'bin'
+        if sys.platform == 'win32':
+            bins = 'Scripts'
+        cmd = [
+            os.path.join(venv_dir, bins, 'python'),
+            os.path.join(thin_dir, 'salt-call'),
+            '--version',
+        ]
+        proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        stdout, stderr = proc.communicate()
+        proc.wait()
+        assert proc.returncode == 0, (stdout, stderr, proc.returncode)


### PR DESCRIPTION
### What does this PR do?

Fixes a missing thin directory dependency when running under python2 and adds regression test for fix.

### What issues does this PR fix or reference?

#46507

### Previous Behavior

Running salt-call in thin directory will fail due to missing concurrent.futures import which can break salt-ssh under Python 2.


### New Behavior

salt-ssh runs under both Python 2 and Python 3

### Tests written?

Yes

### Commits signed with GPG?

Yes