### PR TITLE
[2018.3] Fix to cmd_batch

### DIFF
--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -559,6 +559,10 @@ class LocalClient(object):
             {'stewart': {...}}
         '''
         if 'expr_form' in kwargs:
+            # We need to report salt.utils.versions here
+            # even though it has already been imported.
+            # when cmd_batch is called via the NetAPI
+            # the module is unavailable.
             import salt.utils.versions
             salt.utils.versions.warn_until(
                 'Fluorine',

--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -559,7 +559,7 @@ class LocalClient(object):
             {'stewart': {...}}
         '''
         if 'expr_form' in kwargs:
-            # We need to report salt.utils.versions here
+            # We need to re-import salt.utils.versions here
             # even though it has already been imported.
             # when cmd_batch is called via the NetAPI
             # the module is unavailable.

--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -559,6 +559,7 @@ class LocalClient(object):
             {'stewart': {...}}
         '''
         if 'expr_form' in kwargs:
+            import salt.utils.versions
             salt.utils.versions.warn_until(
                 'Fluorine',
                 'The target type should be passed using the \'tgt_type\' '

--- a/tests/integration/netapi/test_client.py
+++ b/tests/integration/netapi/test_client.py
@@ -37,6 +37,16 @@ class NetapiClientTest(TestCase):
         ret = self.netapi.run(low)
         self.assertEqual(ret, {'minion': True, 'sub_minion': True, 'localhost': True})
 
+    def test_local_batch(self):
+        low = {'client': 'local_batch', 'tgt': '*', 'fun': 'test.ping'}
+        low.update(self.eauth_creds)
+
+        ret = self.netapi.run(low)
+        rets = []
+        for _ret in ret:
+            rets.append(_ret)
+        self.assertEqual(rets, [{u'sub_minion': True}, {u'minion': True}, {'localhost': True}])
+
     def test_local_async(self):
         low = {'client': 'local_async', 'tgt': '*', 'fun': 'test.ping'}
         low.update(self.eauth_creds)

--- a/tests/integration/netapi/test_client.py
+++ b/tests/integration/netapi/test_client.py
@@ -45,7 +45,9 @@ class NetapiClientTest(TestCase):
         rets = []
         for _ret in ret:
             rets.append(_ret)
-        self.assertEqual(rets, [{u'sub_minion': True}, {u'minion': True}, {'localhost': True}])
+        self.assertEqual(rets.sort(), [{'localhost': True},
+                                       {'sub_minion': True},
+                                       {'minion': True}].sort())
 
     def test_local_async(self):
         low = {'client': 'local_async', 'tgt': '*', 'fun': 'test.ping'}

--- a/tests/integration/netapi/test_client.py
+++ b/tests/integration/netapi/test_client.py
@@ -45,9 +45,9 @@ class NetapiClientTest(TestCase):
         rets = []
         for _ret in ret:
             rets.append(_ret)
-        self.assertEqual(rets.sort(), [{'localhost': True},
-                                       {'sub_minion': True},
-                                       {'minion': True}].sort())
+        self.assertEqual(rets, [{'localhost': True},
+                                {'sub_minion': True},
+                                {'minion': True}])
 
     def test_local_async(self):
         low = {'client': 'local_async', 'tgt': '*', 'fun': 'test.ping'}

--- a/tests/integration/netapi/test_client.py
+++ b/tests/integration/netapi/test_client.py
@@ -45,9 +45,9 @@ class NetapiClientTest(TestCase):
         rets = []
         for _ret in ret:
             rets.append(_ret)
-        self.assertEqual(rets, [{'localhost': True},
-                                {'sub_minion': True},
-                                {'minion': True}])
+        self.assertIn({'localhost': True}, rets)
+        self.assertIn({'sub_minion': True}, rets)
+        self.assertIn({'minion': True}, rets)
 
     def test_local_async(self):
         low = {'client': 'local_async', 'tgt': '*', 'fun': 'test.ping'}


### PR DESCRIPTION
### What does this PR do?
Fixing cmd_batch to work correctly when called via salt-api.

### What issues does this PR fix or reference?
#48141 

### Previous Behavior
When running from the salt-api this would result in an exception, presumably because salt.utils.versions was unavailable.

### New Behavior
import salt.utils.versions inside cmd_batch.

### Tests written?
Yes

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
