### PR TITLE
SDB cache module: AttributeError: 'Cache' object has no attribute 'set'

### DIFF
--- a/salt/sdb/cache.py
+++ b/salt/sdb/cache.py
@@ -69,7 +69,7 @@ def set_(key, value, service=None, profile=None):  # pylint: disable=W0613
     '''
     key, profile = _parse_key(key, profile)
     cache = salt.cache.Cache(__opts__)
-    cache.set(profile['bank'], key=key, value=value)
+    cache.store(profile['bank'], key, value)
     return get(key, service, profile)
 
 


### PR DESCRIPTION
I was looking at the [SDB cache module](https://docs.saltstack.com/en/latest/ref/sdb/all/salt.sdb.cache.html#module-salt.sdb.cache) and it appears that there's a little bug (probably caused by some recent changes in the caching system):

```bash
# salt-run sdb.set sdb://sdb_master_cache/foo bar
Exception occurred in runner sdb.set: Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/salt/client/mixins.py", line 382, in _low
    data['return'] = self.functions[fun](*args, **kwargs)
  File "/usr/lib/python2.7/dist-packages/salt/runners/sdb.py", line 42, in set_
    return salt.utils.sdb.sdb_set(uri, value, __opts__, __utils__)
  File "/usr/lib/python2.7/dist-packages/salt/utils/sdb.py", line 77, in sdb_set
    return loaded_db[fun](query, value, profile=profile)
  File "/usr/lib/python2.7/dist-packages/salt/sdb/cache.py", line 72, in set_
    cache.set(profile['bank'], key=key, value=value)
AttributeError: 'Cache' object has no attribute 'set'
```

The `set` method doesn't exist: https://github.com/saltstack/salt/blob/2017.7.7/salt/cache/__init__.py#L134 (it's called ``store``).

This change is enough to fix the issue:

```bash
# salt-run sdb.set sdb://sdb_master_cache/foo bar
bar
```

Moreover it seems to fix both the Execution Module and the Runner, as the Runner
simply invokes the same code, via ``salt.utils.sdb``.