### PR TITLE
Fixed apache.configfile to work with multiple same sections.

### DIFF
--- a/salt/modules/apache.py
+++ b/salt/modules/apache.py
@@ -32,6 +32,7 @@ from salt.ext.six.moves.urllib.request import (
 import salt.utils.data
 import salt.utils.files
 import salt.utils.path
+from salt.exceptions import SaltException
 
 log = logging.getLogger(__name__)
 
@@ -399,6 +400,12 @@ def server_status(profile='default'):
 
 
 def _parse_config(conf, slot=None):
+    '''
+    Recursively goes through config structure and builds final Apache configuration
+
+    :param conf: defined config structure
+    :param slot: name of section container if needed
+    '''
     ret = cStringIO()
     if isinstance(conf, six.string_types):
         if slot:
@@ -406,22 +413,36 @@ def _parse_config(conf, slot=None):
         else:
             print('{0}'.format(conf), file=ret, end='')
     elif isinstance(conf, list):
-        print('{0} {1}'.format(slot, ' '.join(conf)), file=ret, end='')
+        is_section = False
+        for item in conf:
+            if 'this' in item:
+                is_section = True
+                slot_this = six.text_type(item['this'])
+        if is_section:
+            print('<{0} {1}>'.format(slot, slot_this), file=ret)
+            for item in conf:
+                for key, val in item.items():
+                    if key != 'this':
+                        print(_parse_config(val, six.text_type(key)), file=ret)
+            print('</{0}>'.format(slot), file=ret)
+        else:
+            for value in conf:
+                print(_parse_config(value, six.text_type(slot)), file=ret)
     elif isinstance(conf, dict):
-        print('<{0} {1}>'.format(
-            slot,
-            _parse_config(conf['this'])),
-              file=ret
-             )
-        del conf['this']
+        try:
+            print('<{0} {1}>'.format(slot, conf['this']), file=ret)
+        except KeyError:
+            raise SaltException('Apache section container "<{0}>" expects attribute. '
+                                'Specify it using key "this".'.format(slot))
         for key, value in six.iteritems(conf):
-            if isinstance(value, six.string_types):
-                print('{0} {1}'.format(key, value), file=ret)
-            elif isinstance(value, list):
-                print(_parse_config(value, key), file=ret)
-            elif isinstance(value, dict):
-                print(_parse_config(value, key), file=ret)
-        print('</{0}>'.format(slot), file=ret, end='')
+            if key != 'this':
+                if isinstance(value, six.string_types):
+                    print('{0} {1}'.format(key, value), file=ret)
+                elif isinstance(value, list):
+                    print(_parse_config(value, key), file=ret)
+                elif isinstance(value, dict):
+                    print(_parse_config(value, key), file=ret)
+        print('</{0}>'.format(slot), file=ret)
 
     ret.seek(0)
     return ret.read()

--- a/salt/states/apache.py
+++ b/salt/states/apache.py
@@ -36,7 +36,55 @@ the above word between angle brackets (<>).
                   - Indexes
                   - FollowSymlinks
                 AllowOverride: All
+
+.. versionchanged:: 2018.3
+
+Allows having the same section container multiple times (e.g. <Directory /path/to/dir>).
+
+YAML structure stays the same only replace dictionary with a list.
+
+When a section container does not have mandatory attribute, such as <Else>,
+it still needs keyword ``this`` with empty string (or "\b" if nicer output is required - without space).
+
+.. code-block:: yaml
+
+    /etc/httpd/conf.d/website.com.conf:
+      apache.configfile:
+        - config:
+          - VirtualHost:
+              - this: '*:80'
+              - ServerName:
+                - website.com
+              - DocumentRoot: /var/www/vhosts/website.com
+              - Directory:
+                  this: /var/www/vhosts/website.com
+                  Order: Deny,Allow
+                  Deny from: all
+                  Allow from:
+                    - 127.0.0.1
+                    - 192.168.100.0/24
+                  Options:
+                    - Indexes
+                    - FollowSymlinks
+                  AllowOverride: All
+              - Directory:
+                - this: /var/www/vhosts/website.com/private
+                - Order: Deny,Allow
+                - Deny from: all
+                - Allow from:
+                  - 127.0.0.1
+                  - 192.168.100.0/24
+                - If:
+                    this: some condition
+                    do: something
+                - Else:
+                    this:
+                    do: something else
+                - Else:
+                    this: "\b"
+                    do: another thing
 '''
+
 from __future__ import absolute_import, with_statement, print_function, unicode_literals
 
 # Import python libs
@@ -63,7 +111,7 @@ def configfile(name, config):
         with salt.utils.files.fopen(name) as config_file:
             current_configs = salt.utils.stringutils.to_unicode(config_file.read())
 
-    if configs == current_configs.strip():
+    if configs.strip() == current_configs.strip():
         ret['result'] = True
         ret['comment'] = 'Configuration is up to date.'
         return ret


### PR DESCRIPTION
### What does this PR do?
Fixes `apache.configfile` so that it allows to create Apache config files with multiple same section containers. It is possible to define structure like before (through a dict) and newly also through lists which allows sections with same name, e.g. `<Directory>`. Behavior is backward compatible and the new one is described in updated doc section in `apache` state module.

As side-effect it also fixes issue that when two structures were used at the same salt state run, the second structure was wrong since the previous run removed all `this:` items. So intended `<Directory /some/path>` was always generated as `<Directory>`.

### What issues does this PR fix or reference?
[#38306 - The `apache.configfile` state does not allow multiple same sections](https://github.com/saltstack/salt/issues/38306)

### Tests written?

Yes

### Commits signed with GPG?

Yes