### PR TITLE
Virt init improvements

### DIFF
--- a/doc/topics/tutorials/cloud_controller.rst
+++ b/doc/topics/tutorials/cloud_controller.rst
@@ -246,7 +246,7 @@ the new virtual machine on. Using ``salt://`` assumes that the CentOS virtual
 machine image is located in the root of the :ref:`file-server` on the master.
 When images are cloned (i.e. copied locatlly after retrieval from the file server)
 the destination directory on the hypervisor minion is determined by the ``virt:images``
-config option; by default this is ``/srv/salt/salt-images/``.
+config option; by default this is ``/srv/salt-images/``.
 
 When a VM is initialized using ``virt.init`` the image is copied to the hypervisor
 using ``cp.cache_file`` and will be mounted and seeded with a minion. Seeding includes

--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -915,8 +915,8 @@ def _disk_profile(profile, hypervisor, disks=None, vm_name=None, image=None, poo
     if vm_name:
         for disk in disklist:
             for disk_name, args in six.iteritems(disk):
-                args['filename'] = '{0}.{1}'.format(disk_name, args['format'])
-                args['source_file'] = os.path.join(args['pool'], vm_name, args['filename'])
+                args['filename'] = '{0}_{1}.{2}'.format(vm_name, disk_name, args['format'])
+                args['source_file'] = os.path.join(args['pool'], args['filename'])
 
     return disklist
 

--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -1278,7 +1278,7 @@ def init(name,
 
     The disk images will be created in an image folder within the directory
     defined by the ``virt:images`` option. Its default value is
-    ``/srv/salt/salt-images/`` but this can changed with such a configuration:
+    ``/srv/salt-images/`` but this can changed with such a configuration:
 
     .. code-block:: yaml
 

--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -4258,6 +4258,9 @@ def pool_info(name, **kwargs):
         infos = pool.info()
         states = ['inactive', 'building', 'running', 'degraded', 'inaccessible']
         state = states[infos[0]] if infos[0] < len(states) else 'unknown'
+        desc = minidom.parseString(pool.XMLDesc())
+        pool_node = _get_xml_first_element_by_tag_name(desc, 'pool')
+        path_node = _get_xml_first_element_by_tag_name(desc, 'path')
         result = {
             'uuid': pool.UUIDString(),
             'state': state,
@@ -4265,7 +4268,9 @@ def pool_info(name, **kwargs):
             'allocation': infos[2],
             'free': infos[3],
             'autostart': pool.autostart(),
-            'persistent': pool.isPersistent()
+            'persistent': pool.isPersistent(),
+            'target_path': _get_xml_element_text(path_node) if path_node else None,
+            'type': pool_node.getAttribute('type')
         }
     except libvirt.libvirtError as err:
         log.debug('Silenced libvirt error: %s', str(err))

--- a/salt/templates/virt/libvirt_domain.jinja
+++ b/salt/templates/virt/libvirt_domain.jinja
@@ -33,8 +33,23 @@
                     <model type='{{ nic.model }}'/>
                 </interface>
                 {% endfor %}
-                {% if enable_vnc %}
-                <graphics type='vnc' listen='0.0.0.0' autoport='yes' />
+                {% if graphics %}
+                <graphics type='{{ graphics.type }}'
+                          {% if graphics.listen.address %}
+                          listen='{{ graphics.listen.address }}'
+                          {% endif %}
+                          {% if graphics.port %}
+                          port='{{ graphics.port }}'
+                          {% endif %}
+                          {% if graphics.type == 'spice' and graphics.tls_port %}
+                          tlsPort='{{ graphics.tls_port }}'
+                          {% endif %}
+                          autoport='{{ 'no' if graphics.port or graphics.tls_port else 'yes' }}'>
+                    <listen type='{{ graphics.listen.type }}'
+                            {% if graphics.listen.address %}
+                            address='{{ graphics.listen.address }}'
+                            {% endif %}/>
+                </graphics>
                 {% endif %}
                 {% if serial_type == 'pty' %}
                 <serial type='pty'>

--- a/tests/unit/modules/test_virt.py
+++ b/tests/unit/modules/test_virt.py
@@ -242,7 +242,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         '''
         mock = MagicMock(return_value={})
         with patch.dict(virt.__salt__, {'config.get': mock}):  # pylint: disable=no-member
-            ret = virt._disk_profile('nonexistent', 'esxi')
+            ret = virt._disk_profile('nonexistent', 'vmware')
             self.assertTrue(len(ret) == 1)
             self.assertIn('system', ret[0])
             system = ret[0]['system']
@@ -270,7 +270,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         '''
         mock = MagicMock(return_value={})
         with patch.dict(virt.__salt__, {'config.get': mock}):  # pylint: disable=no-member
-            ret = virt._nic_profile('nonexistent', 'esxi')
+            ret = virt._nic_profile('nonexistent', 'vmware')
             self.assertTrue(len(ret) == 1)
             eth0 = ret[0]
             self.assertEqual(eth0['name'], 'eth0')
@@ -347,17 +347,17 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
 
     def test_gen_xml_for_esxi_default_profile(self):
         '''
-        Test virt._gen_xml(), ESXi default profile case
+        Test virt._gen_xml(), ESXi/vmware default profile case
         '''
-        diskp = virt._disk_profile('default', 'esxi')
-        nicp = virt._nic_profile('default', 'esxi')
+        diskp = virt._disk_profile('default', 'vmware')
+        nicp = virt._nic_profile('default', 'vmware')
         xml_data = virt._gen_xml(
             'hello',
             1,
             512,
             diskp,
             nicp,
-            'esxi',
+            'vmware',
             )
         root = ET.fromstring(xml_data)
         self.assertEqual(root.attrib['type'], 'vmware')
@@ -387,7 +387,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
 
     def test_gen_xml_for_esxi_custom_profile(self):
         '''
-        Test virt._gen_xml(), ESXi custom profile case
+        Test virt._gen_xml(), ESXi/vmware custom profile case
         '''
         diskp_yaml = '''
 - first:
@@ -417,15 +417,15 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
                 patch('salt.modules.virt._disk_profile') as disk_profile:
             disk_profile.return_value = salt.utils.yaml.safe_load(diskp_yaml)
             nic_profile.return_value = salt.utils.yaml.safe_load(nicp_yaml)
-            diskp = virt._disk_profile('noeffect', 'esxi')
-            nicp = virt._nic_profile('noeffect', 'esxi')
+            diskp = virt._disk_profile('noeffect', 'vmware')
+            nicp = virt._nic_profile('noeffect', 'vmware')
             xml_data = virt._gen_xml(
                 'hello',
                 1,
                 512,
                 diskp,
                 nicp,
-                'esxi',
+                'vmware',
                 )
             root = ET.fromstring(xml_data)
             self.assertEqual(root.attrib['type'], 'vmware')
@@ -487,17 +487,17 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
 
     def test_controller_for_esxi(self):
         '''
-        Test virt._gen_xml() generated device controller for ESXi
+        Test virt._gen_xml() generated device controller for ESXi/vmware
         '''
-        diskp = virt._disk_profile('default', 'esxi')
-        nicp = virt._nic_profile('default', 'esxi')
+        diskp = virt._disk_profile('default', 'vmware')
+        nicp = virt._nic_profile('default', 'vmware')
         xml_data = virt._gen_xml(
             'hello',
             1,
             512,
             diskp,
             nicp,
-            'esxi'
+            'vmware'
             )
         root = ET.fromstring(xml_data)
         controllers = root.findall('.//devices/controller')

--- a/tests/unit/modules/test_virt.py
+++ b/tests/unit/modules/test_virt.py
@@ -1573,6 +1573,23 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         pool_mock.info.return_value = [0, 1234, 5678, 123]
         pool_mock.autostart.return_value = True
         pool_mock.isPersistent.return_value = True
+        pool_mock.XMLDesc.return_value = '''<pool type='dir'>
+  <name>default</name>
+  <uuid>d92682d0-33cf-4e10-9837-a216c463e158</uuid>
+  <capacity unit='bytes'>854374301696</capacity>
+  <allocation unit='bytes'>596275986432</allocation>
+  <available unit='bytes'>258098315264</available>
+  <source>
+  </source>
+  <target>
+    <path>/srv/vms</path>
+    <permissions>
+      <mode>0755</mode>
+      <owner>0</owner>
+      <group>0</group>
+    </permissions>
+  </target>
+</pool>'''
         self.mock_conn.storagePoolLookupByName.return_value = pool_mock
         # pylint: enable=no-member
 
@@ -1584,7 +1601,9 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
             'allocation': 5678,
             'free': 123,
             'autostart': True,
-            'persistent': True}, pool)
+            'persistent': True,
+            'type': 'dir',
+            'target_path': '/srv/vms'}, pool)
 
     def test_pool_info_notfound(self):
         '''

--- a/tests/unit/modules/test_virt.py
+++ b/tests/unit/modules/test_virt.py
@@ -79,11 +79,38 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         # Return state as shutdown
         mock_domain.info.return_value = [4, 0, 0, 0]  # pylint: disable=no-member
 
+    def test_disk_profile_merge(self):
+        '''
+        Test virt._disk_profile() when merging with user-defined disks
+        '''
+        userdisks = [{'name': 'data', 'size': 16384, 'format': 'raw'}]
+
+        disks = virt._disk_profile('default', 'kvm', userdisks, 'myvm', image='/path/to/image')
+        self.assertEqual(
+            [{'system': {
+                'size': 8192,
+                'format': 'qcow2',
+                'model': 'virtio',
+                'pool': '/srv/salt-images',
+                'filename': 'system.qcow2',
+                'image': '/path/to/image',
+                'source_file': '/srv/salt-images/myvm/system.qcow2'}},
+             {'data': {
+                'name': 'data',
+                'size': 16384,
+                'format': 'raw',
+                'model': 'virtio',
+                'pool': '/srv/salt-images',
+                'filename': 'data.raw',
+                'source_file': '/srv/salt-images/myvm/data.raw'}}],
+            disks
+        )
+
     def test_boot_default_dev(self):
         '''
         Test virt._gen_xml() default boot device
         '''
-        diskp = virt._disk_profile('default', 'kvm')
+        diskp = virt._disk_profile('default', 'kvm', [], 'hello')
         nicp = virt._nic_profile('default', 'kvm')
         xml_data = virt._gen_xml(
             'hello',
@@ -100,7 +127,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         '''
         Test virt._gen_xml() custom boot device
         '''
-        diskp = virt._disk_profile('default', 'kvm')
+        diskp = virt._disk_profile('default', 'kvm', [], 'hello')
         nicp = virt._nic_profile('default', 'kvm')
         xml_data = virt._gen_xml(
             'hello',
@@ -118,7 +145,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         '''
         Test virt._gen_xml() multiple boot devices
         '''
-        diskp = virt._disk_profile('default', 'kvm')
+        diskp = virt._disk_profile('default', 'kvm', [], 'hello')
         nicp = virt._nic_profile('default', 'kvm')
         xml_data = virt._gen_xml(
             'hello',
@@ -137,7 +164,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         '''
         Test virt._gen_xml() serial console
         '''
-        diskp = virt._disk_profile('default', 'kvm')
+        diskp = virt._disk_profile('default', 'kvm', [], 'hello')
         nicp = virt._nic_profile('default', 'kvm')
         xml_data = virt._gen_xml(
             'hello',
@@ -157,7 +184,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         '''
         Test virt._gen_xml() telnet console
         '''
-        diskp = virt._disk_profile('default', 'kvm')
+        diskp = virt._disk_profile('default', 'kvm', [], 'hello')
         nicp = virt._nic_profile('default', 'kvm')
         xml_data = virt._gen_xml(
             'hello',
@@ -179,7 +206,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         '''
         Test virt._gen_xml() telnet console without any specified port
         '''
-        diskp = virt._disk_profile('default', 'kvm')
+        diskp = virt._disk_profile('default', 'kvm', [], 'hello')
         nicp = virt._nic_profile('default', 'kvm')
         xml_data = virt._gen_xml(
             'hello',
@@ -200,7 +227,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         '''
         Test virt._gen_xml() with no serial console
         '''
-        diskp = virt._disk_profile('default', 'kvm')
+        diskp = virt._disk_profile('default', 'kvm', [], 'hello')
         nicp = virt._nic_profile('default', 'kvm')
         xml_data = virt._gen_xml(
             'hello',
@@ -220,7 +247,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         '''
         Test virt._gen_xml() with no telnet console
         '''
-        diskp = virt._disk_profile('default', 'kvm')
+        diskp = virt._disk_profile('default', 'kvm', [], 'hello')
         nicp = virt._nic_profile('default', 'kvm')
         xml_data = virt._gen_xml(
             'hello',
@@ -240,7 +267,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         '''
         Test virt._gen_xml() with default no graphics device
         '''
-        diskp = virt._disk_profile('default', 'kvm')
+        diskp = virt._disk_profile('default', 'kvm', [], 'hello')
         nicp = virt._nic_profile('default', 'kvm')
         xml_data = virt._gen_xml(
             'hello',
@@ -257,7 +284,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         '''
         Test virt._gen_xml() with default vnc graphics device
         '''
-        diskp = virt._disk_profile('default', 'kvm')
+        diskp = virt._disk_profile('default', 'kvm', [], 'hello')
         nicp = virt._nic_profile('default', 'kvm')
         xml_data = virt._gen_xml(
             'hello',
@@ -282,7 +309,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         '''
         Test virt._gen_xml() with default spice graphics device
         '''
-        diskp = virt._disk_profile('default', 'kvm')
+        diskp = virt._disk_profile('default', 'kvm', [], 'hello')
         nicp = virt._nic_profile('default', 'kvm')
         xml_data = virt._gen_xml(
             'hello',
@@ -304,7 +331,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         '''
         Test virt._gen_xml() with spice graphics device
         '''
-        diskp = virt._disk_profile('default', 'kvm')
+        diskp = virt._disk_profile('default', 'kvm', [], 'hello')
         nicp = virt._nic_profile('default', 'kvm')
         xml_data = virt._gen_xml(
             'hello',
@@ -395,7 +422,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         '''
         Test virt._gen_xml(), KVM default profile case
         '''
-        diskp = virt._disk_profile('default', 'kvm')
+        diskp = virt._disk_profile('default', 'kvm', [], 'hello')
         nicp = virt._nic_profile('default', 'kvm')
         xml_data = virt._gen_xml(
             'hello',
@@ -437,7 +464,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         '''
         Test virt._gen_xml(), ESXi/vmware default profile case
         '''
-        diskp = virt._disk_profile('default', 'vmware')
+        diskp = virt._disk_profile('default', 'vmware', [], 'hello')
         nicp = virt._nic_profile('default', 'vmware')
         xml_data = virt._gen_xml(
             'hello',
@@ -477,35 +504,21 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         '''
         Test virt._gen_xml(), ESXi/vmware custom profile case
         '''
-        diskp_yaml = '''
-- first:
-    size: 8192
-    format: vmdk
-    model: scsi
-    pool: datastore1
-- second:
-    size: 4096
-    format: vmdk
-    model: scsi
-    pool: datastore2
-'''
-        nicp_yaml = '''
-- type: bridge
-  name: eth1
-  source: ONENET
-  model: e1000
-  mac: '00:00:00:00:00:00'
-- name: eth2
-  type: bridge
-  source: TWONET
-  model: e1000
-  mac: '00:00:00:00:00:00'
-'''
-        with patch('salt.modules.virt._nic_profile') as nic_profile, \
-                patch('salt.modules.virt._disk_profile') as disk_profile:
-            disk_profile.return_value = salt.utils.yaml.safe_load(diskp_yaml)
-            nic_profile.return_value = salt.utils.yaml.safe_load(nicp_yaml)
-            diskp = virt._disk_profile('noeffect', 'vmware')
+        disks = {
+            'noeffect': [
+                {'first': {'size': 8192, 'pool': 'datastore1'}},
+                {'second': {'size': 4096, 'pool': 'datastore2'}}
+            ]
+        }
+        nics = {
+            'noeffect': [
+                {'name': 'eth1', 'source': 'ONENET'},
+                {'name': 'eth2', 'source': 'TWONET'}
+            ]
+        }
+        with patch.dict(virt.__salt__,  # pylint: disable=no-member
+                        {'config.get': MagicMock(side_effect=[disks, nics])}):
+            diskp = virt._disk_profile('noeffect', 'vmware', [], 'hello')
             nicp = virt._nic_profile('noeffect', 'vmware')
             xml_data = virt._gen_xml(
                 'hello',
@@ -527,35 +540,21 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         '''
         Test virt._gen_xml(), KVM custom profile case
         '''
-        diskp_yaml = '''
-- first:
-    size: 8192
-    format: qcow2
-    model: virtio
-    pool: /var/lib/images
-- second:
-    size: 4096
-    format: qcow2
-    model: virtio
-    pool: /var/lib/images
-'''
-        nicp_yaml = '''
-- type: bridge
-  name: eth1
-  source: b2
-  model: virtio
-  mac: '00:00:00:00:00:00'
-- name: eth2
-  type: bridge
-  source: b2
-  model: virtio
-  mac: '00:00:00:00:00:00'
-'''
-        with patch('salt.modules.virt._nic_profile') as nic_profile, \
-                patch('salt.modules.virt._disk_profile') as disk_profile:
-            disk_profile.return_value = salt.utils.yaml.safe_load(diskp_yaml)
-            nic_profile.return_value = salt.utils.yaml.safe_load(nicp_yaml)
-            diskp = virt._disk_profile('noeffect', 'kvm')
+        disks = {
+            'noeffect': [
+                {'first': {'size': 8192, 'pool': '/var/lib/images'}},
+                {'second': {'size': 4096, 'pool': '/var/lib/images'}}
+            ]
+        }
+        nics = {
+            'noeffect': [
+                {'name': 'eth1', 'source': 'b2'},
+                {'name': 'eth2', 'source': 'b2'}
+            ]
+        }
+        with patch.dict(virt.__salt__, {'config.get': MagicMock(side_effect=[  # pylint: disable=no-member
+                "/srv/salt-images", disks, nics])}):
+            diskp = virt._disk_profile('noeffect', 'kvm', [], 'hello')
             nicp = virt._nic_profile('noeffect', 'kvm')
             xml_data = virt._gen_xml(
                 'hello',
@@ -577,7 +576,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         '''
         Test virt._gen_xml() generated device controller for ESXi/vmware
         '''
-        diskp = virt._disk_profile('default', 'vmware')
+        diskp = virt._disk_profile('default', 'vmware', [], 'hello')
         nicp = virt._nic_profile('default', 'vmware')
         xml_data = virt._gen_xml(
             'hello',
@@ -597,7 +596,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         '''
         Test virt._gen_xml() generated device controller for KVM
         '''
-        diskp = virt._disk_profile('default', 'kvm')
+        diskp = virt._disk_profile('default', 'kvm', [], 'hello')
         nicp = virt._nic_profile('default', 'kvm')
         xml_data = virt._gen_xml(
             'hello',

--- a/tests/unit/modules/test_virt.py
+++ b/tests/unit/modules/test_virt.py
@@ -618,7 +618,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         '''
         Make sure that qemu-img info output is properly parsed
         '''
-        qemu_infos = '''{
+        qemu_infos = '''[{
             "snapshots": [
                 {
                     "vm-clock-nsec": 0,
@@ -656,13 +656,62 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
             "full-backing-filename": "/disks/mybacking.qcow2",
             "backing-filename": "mybacking.qcow2",
             "dirty-flag": false
-        }'''
+        },
+        {
+            "virtual-size": 25769803776,
+            "filename": "/disks/mybacking.qcow2",
+            "cluster-size": 65536,
+            "format": "qcow2",
+            "actual-size": 393744384,
+            "format-specific": {
+                "type": "qcow2",
+                "data": {
+                    "compat": "1.1",
+                    "lazy-refcounts": false,
+                    "refcount-bits": 16,
+                    "corrupt": false
+                }
+            },
+            "full-backing-filename": "/disks/root.qcow2",
+            "backing-filename": "root.qcow2",
+            "dirty-flag": false
+        },
+        {
+            "virtual-size": 25769803776,
+            "filename": "/disks/root.qcow2",
+            "cluster-size": 65536,
+            "format": "qcow2",
+            "actual-size": 196872192,
+            "format-specific": {
+                "type": "qcow2",
+                "data": {
+                    "compat": "1.1",
+                    "lazy-refcounts": false,
+                    "refcount-bits": 16,
+                    "corrupt": false
+                }
+            },
+            "dirty-flag": false
+        }]'''
 
         self.assertEqual(
             {
                 'file': '/disks/test.qcow2',
                 'file format': 'qcow2',
-                'backing file': '/disks/mybacking.qcow2',
+                'backing file': {
+                    'file': '/disks/mybacking.qcow2',
+                    'file format': 'qcow2',
+                    'disk size': 393744384,
+                    'virtual size': 25769803776,
+                    'cluster size': 65536,
+                    'backing file': {
+                        'file': '/disks/root.qcow2',
+                        'file format': 'qcow2',
+                        'disk size': 196872192,
+                        'virtual size': 25769803776,
+                        'cluster size': 65536,
+                    }
+                },
                 'disk size': 217088,
                 'virtual size': 25769803776,
                 'cluster size': 65536,
@@ -709,7 +758,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         '''
         self.set_mock_vm("test-vm", xml)
 
-        qemu_infos = '''{
+        qemu_infos = '''[{
             "virtual-size": 25769803776,
             "filename": "/disks/test.qcow2",
             "cluster-size": 65536,
@@ -727,14 +776,31 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
             "full-backing-filename": "/disks/mybacking.qcow2",
             "backing-filename": "mybacking.qcow2",
             "dirty-flag": false
-        }'''
+        },
+        {
+            "virtual-size": 25769803776,
+            "filename": "/disks/mybacking.qcow2",
+            "cluster-size": 65536,
+            "format": "qcow2",
+            "actual-size": 393744384,
+            "format-specific": {
+                "type": "qcow2",
+                "data": {
+                    "compat": "1.1",
+                    "lazy-refcounts": false,
+                    "refcount-bits": 16,
+                    "corrupt": false
+                }
+            },
+            "dirty-flag": false
+        }]'''
 
         self.mock_popen.communicate.return_value = [qemu_infos]  # pylint: disable=no-member
         disks = virt.get_disks('test-vm')
         disk = disks.get('vda')
         self.assertEqual('/disks/test.qcow2', disk['file'])
         self.assertEqual('disk', disk['type'])
-        self.assertEqual('/disks/mybacking.qcow2', disk['backing file'])
+        self.assertEqual('/disks/mybacking.qcow2', disk['backing file']['file'])
         cdrom = disks.get('hda')
         self.assertEqual('/disks/test-cdrom.iso', cdrom['file'])
         self.assertEqual('cdrom', cdrom['type'])
@@ -766,7 +832,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         '''
         self.set_mock_vm("test-vm", xml)
 
-        qemu_infos = '''{
+        qemu_infos = '''[{
             "virtual-size": 25769803776,
             "filename": "/disks/test.qcow2",
             "cluster-size": 65536,
@@ -782,7 +848,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
                 }
             },
             "dirty-flag": false
-        }'''
+        }]'''
 
         self.mock_popen.communicate.return_value = [qemu_infos]  # pylint: disable=no-member
 
@@ -823,7 +889,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         '''
         self.set_mock_vm("test-vm", xml)
 
-        qemu_infos = '''{
+        qemu_infos = '''[{
             "virtual-size": 25769803776,
             "filename": "/disks/test.qcow2",
             "cluster-size": 65536,
@@ -839,7 +905,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
                 }
             },
             "dirty-flag": false
-        }'''
+        }]'''
 
         self.mock_popen.communicate.return_value = [qemu_infos]  # pylint: disable=no-member
 

--- a/tests/unit/modules/test_virt.py
+++ b/tests/unit/modules/test_virt.py
@@ -86,22 +86,21 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
 
         disks = virt._disk_profile('default', 'kvm', userdisks, 'myvm', image='/path/to/image')
         self.assertEqual(
-            [{'system': {
-                'size': 8192,
-                'format': 'qcow2',
-                'model': 'virtio',
-                'pool': '/srv/salt-images',
-                'filename': 'myvm_system.qcow2',
-                'image': '/path/to/image',
-                'source_file': '/srv/salt-images/myvm_system.qcow2'}},
-             {'data': {
-                'name': 'data',
-                'size': 16384,
-                'format': 'raw',
-                'model': 'virtio',
-                'pool': '/srv/salt-images',
-                'filename': 'myvm_data.raw',
-                'source_file': '/srv/salt-images/myvm_data.raw'}}],
+            [{'name': 'system',
+              'size': 8192,
+              'format': 'qcow2',
+              'model': 'virtio',
+              'pool': '/srv/salt-images',
+              'filename': 'myvm_system.qcow2',
+              'image': '/path/to/image',
+              'source_file': '/srv/salt-images/myvm_system.qcow2'},
+             {'name': 'data',
+              'size': 16384,
+              'format': 'raw',
+              'model': 'virtio',
+              'pool': '/srv/salt-images',
+              'filename': 'myvm_data.raw',
+              'source_file': '/srv/salt-images/myvm_data.raw'}],
             disks
         )
 
@@ -358,8 +357,9 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         with patch.dict(virt.__salt__, {'config.get': mock}):  # pylint: disable=no-member
             ret = virt._disk_profile('nonexistent', 'vmware')
             self.assertTrue(len(ret) == 1)
-            self.assertIn('system', ret[0])
-            system = ret[0]['system']
+            found = [disk for disk in ret if disk['name'] == 'system']
+            self.assertTrue(bool(found))
+            system = found[0]
             self.assertEqual(system['format'], 'vmdk')
             self.assertEqual(system['model'], 'scsi')
             self.assertTrue(int(system['size']) >= 1)
@@ -372,8 +372,9 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         with patch.dict(virt.__salt__, {'config.get': mock}):  # pylint: disable=no-member
             ret = virt._disk_profile('nonexistent', 'kvm')
             self.assertTrue(len(ret) == 1)
-            self.assertIn('system', ret[0])
-            system = ret[0]['system']
+            found = [disk for disk in ret if disk['name'] == 'system']
+            self.assertTrue(bool(found))
+            system = found[0]
             self.assertEqual(system['format'], 'qcow2')
             self.assertEqual(system['model'], 'virtio')
             self.assertTrue(int(system['size']) >= 1)

--- a/tests/unit/modules/test_virt.py
+++ b/tests/unit/modules/test_virt.py
@@ -8,7 +8,6 @@ virt execution module unit tests
 # Import python libs
 from __future__ import absolute_import, print_function, unicode_literals
 import re
-import os
 import datetime
 
 # Import Salt Testing libs
@@ -92,17 +91,17 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
                 'format': 'qcow2',
                 'model': 'virtio',
                 'pool': '/srv/salt-images',
-                'filename': 'system.qcow2',
+                'filename': 'myvm_system.qcow2',
                 'image': '/path/to/image',
-                'source_file': '/srv/salt-images/myvm/system.qcow2'}},
+                'source_file': '/srv/salt-images/myvm_system.qcow2'}},
              {'data': {
                 'name': 'data',
                 'size': 16384,
                 'format': 'raw',
                 'model': 'virtio',
                 'pool': '/srv/salt-images',
-                'filename': 'data.raw',
-                'source_file': '/srv/salt-images/myvm/data.raw'}}],
+                'filename': 'myvm_data.raw',
+                'source_file': '/srv/salt-images/myvm_data.raw'}}],
             disks
         )
 
@@ -443,7 +442,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         disk = disks[0]
         root_dir = salt.config.DEFAULT_MINION_OPTS.get('root_dir')
         self.assertTrue(disk.find('source').attrib['file'].startswith(root_dir))
-        self.assertTrue(os.path.join('hello', 'system') in disk.find('source').attrib['file'])
+        self.assertTrue('hello_system' in disk.find('source').attrib['file'])
         self.assertEqual(disk.find('target').attrib['dev'], 'vda')
         self.assertEqual(disk.find('target').attrib['bus'], 'virtio')
         self.assertEqual(disk.find('driver').attrib['name'], 'qemu')
@@ -484,7 +483,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         self.assertEqual(len(disks), 1)
         disk = disks[0]
         self.assertTrue('[0]' in disk.find('source').attrib['file'])
-        self.assertTrue(os.path.join('hello', 'system') in disk.find('source').attrib['file'])
+        self.assertTrue('hello_system' in disk.find('source').attrib['file'])
         self.assertEqual(disk.find('target').attrib['dev'], 'sda')
         self.assertEqual(disk.find('target').attrib['bus'], 'scsi')
         self.assertEqual(disk.find('address').attrib['unit'], '0')


### PR DESCRIPTION
### What does this PR do?

This PR makes `virt.init` more flexible for users. Rather than forcing all domain configuration in the minion configuration, `virt.init` now allows defining and/or overriding default disks and network interfaces. It also allows more graphic types than the VNC.

As an effort to understand `virt.init` before modifying it, the virt documentation has been improved a lot.

Note: this PR has been split in two: the first commits that are more independent have been submitted in PR #48262 

### What issues does this PR fix or reference?

Issue #48085 is also fixed in this PR.

### Previous Behavior

See description.

### New Behavior

See description

### Tests written?

Yes

### Commits signed with GPG?

Yes