### PR TITLE
Adding a few helpers to gate functionality from netmiko into the NAPALM proxy minions

### DIFF
--- a/salt/modules/napalm.py
+++ b/salt/modules/napalm.py
@@ -7,10 +7,10 @@ Helpers for the NAPALM modules.
 
 .. versionadded:: 2017.7.0
 '''
-
 from __future__ import absolute_import, unicode_literals, print_function
 
 # Import python stdlib
+import inspect
 import logging
 log = logging.getLogger(__file__)
 
@@ -20,6 +20,18 @@ from salt.utils.napalm import proxy_napalm_wrap
 
 # Import Salt modules
 from salt.ext import six
+from salt.exceptions import CommandExecutionError
+try:
+    from netmiko import BaseConnection
+    HAS_NETMIKO = True
+except ImportError:
+    HAS_NETMIKO = False
+
+try:
+    import napalm.base.netmiko_helpers
+    HAS_NETMIKO_HELPERS = True
+except ImportError:
+    HAS_NETMIKO_HELPERS = False
 
 # ----------------------------------------------------------------------------------------------------------------------
 # module properties
@@ -43,6 +55,46 @@ def __virtual__():
 # ----------------------------------------------------------------------------------------------------------------------
 # helper functions -- will not be exported
 # ----------------------------------------------------------------------------------------------------------------------
+
+
+def _get_netmiko_args(optional_args):
+    '''
+    Check for Netmiko arguments that were passed in as NAPALM optional arguments.
+
+    Return a dictionary of these optional args that will be passed into the
+    Netmiko ConnectHandler call.
+
+    .. note::
+
+        This is a port of the NAPALM helper for backwards compatibility with
+        older versions of NAPALM, and stability across Salt features.
+        If the netmiko helpers module is available however, it will prefer that
+        implementation nevertheless.
+    '''
+    if HAS_NETMIKO_HELPERS:
+        return napalm.base.netmiko_helpers.netmiko_args(optional_args)
+    # Older version don't have the netmiko_helpers module, the following code is
+    # simply a port from the NAPALM code base, for backwards compatibility:
+    # https://github.com/napalm-automation/napalm/blob/develop/napalm/base/netmiko_helpers.py
+    netmiko_args, _, _, netmiko_defaults = inspect.getargspec(BaseConnection.__init__)
+    check_self = netmiko_args.pop(0)
+    if check_self != 'self':
+        raise ValueError('Error processing Netmiko arguments')
+    netmiko_argument_map = dict(six.moves.zip(netmiko_args, netmiko_defaults))
+    # Netmiko arguments that are integrated into NAPALM already
+    netmiko_filter = ['ip', 'host', 'username', 'password', 'device_type', 'timeout']
+    # Filter out all of the arguments that are integrated into NAPALM
+    for k in netmiko_filter:
+        netmiko_argument_map.pop(k)
+    # Check if any of these arguments were passed in as NAPALM optional_args
+    netmiko_optional_args = {}
+    for k, v in six.iteritems(netmiko_argument_map):
+        try:
+            netmiko_optional_args[k] = optional_args[k]
+        except KeyError:
+            pass
+    # Return these arguments for use with establishing Netmiko SSH connection
+    return netmiko_optional_args
 
 # ----------------------------------------------------------------------------------------------------------------------
 # callable functions
@@ -241,3 +293,170 @@ def compliance_report(filepath, **kwargs):
         'compliance_report',
         validation_file=filepath
     )
+
+
+@proxy_napalm_wrap
+def netmiko_args(**kwargs):
+    '''
+    .. versionadded:: Fluorine
+
+    Return the key-value arguments used for the authentication arguments for
+    the netmiko module.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' napalm.netmiko_args
+    '''
+    if not HAS_NETMIKO:
+        raise CommandExecutionError('Please install netmiko to be able to use this feature.')
+    kwargs = {}
+    napalm_opts = salt.utils.napalm.get_device_opts(__opts__, salt_obj=__salt__)
+    optional_args = napalm_opts['OPTIONAL_ARGS']
+    netmiko_args = _get_netmiko_args(optional_args)
+    kwargs['host'] = napalm_opts['HOSTNAME']
+    kwargs['username'] = napalm_opts['USERNAME']
+    kwargs['password'] = napalm_opts['PASSWORD']
+    kwargs['timeout'] = napalm_opts['TIMEOUT']
+    kwargs.update(netmiko_args)
+    netmiko_device_type_map = {
+        'junos': 'juniper_junos',
+        'ios': 'cisco_ios',
+        'iosxr': 'cisco_xr',
+        'eos': 'arista_eos',
+        'nxos_ssh': 'cisco_nxos',
+        'asa': 'cisco_asa',
+        'fortios': 'fortinet',
+        'panos': 'paloalto_panos',
+        'aos': 'alcatel_aos',
+        'vyos': 'vyos'
+    }
+    # If you have a device type that is not listed here, please submit a PR
+    # to add it, and/or add the map into your opts/Pillar: netmiko_device_type_map
+    # Example:
+    #
+    # netmiko_device_type_map:
+    #   junos: juniper_junos
+    #   ios: cisco_ios
+    #
+    #etc.
+    netmiko_device_type_map.update(__salt__['config.get']('netmiko_device_type_map', {}))
+    kwargs['device_type'] = netmiko_device_type_map[__grains__['os']]
+    return kwargs
+
+
+@proxy_napalm_wrap
+def netmiko_fun(fun, *args, **kwargs):
+    '''
+    .. versionadded:: Fluorine
+
+    Call an arbitrary function from the :mod:`Netmiko<salt.modules.netmiko_mod>`
+    module, passing the authentication details from the existing NAPALM
+    connection.
+
+    fun
+        The name of the function from the :mod:`Netmiko<salt.modules.netmiko_mod>`
+        to invoke.
+
+    args
+        List of arguments to send to the execution function specified in
+        ``fun``.
+
+    kwargs
+        Key-value arguments to send to the execution function specified in
+        ``fun``.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' napalm.netmiko_fun send_command 'show version'
+    '''
+    if 'netmiko.' not in fun:
+        fun = 'netmiko.{fun}'.format(fun=fun)
+    netmiko_kwargs = netmiko_args()
+    kwargs.update(netmiko_kwargs)
+    return __salt__[fun](*args, **kwargs)
+
+
+@proxy_napalm_wrap
+def netmiko_call(method, *args, **kwargs):
+    '''
+    .. versionadded:: Fluorine
+
+    Execute an arbitrary Netmiko method, passing the authentication details from
+    the existing NAPALM connection.
+
+    method
+        The name of the Netmiko method to execute.
+
+    args
+        List of arguments to send to the Netmiko method specified in ``method``.
+
+    kwargs
+        Key-value arguments to send to the execution function specified in
+        ``method``.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' napalm.netmiko_call send_command 'show version'
+    '''
+    netmiko_kwargs = netmiko_args()
+    kwargs.update(netmiko_kwargs)
+    return __salt__['netmiko.call'](method, *args, **kwargs)
+
+
+@proxy_napalm_wrap
+def netmiko_multi_call(*methods, **kwargs):
+    '''
+    .. versionadded:: Fluorine
+
+    Execute a list of arbitrary Netmiko methods, passing the authentication
+    details from the existing NAPALM connection.
+
+    methods
+        List of dictionaries with the following keys:
+
+        - ``name``: the name of the Netmiko function to invoke.
+        - ``args``: list of arguments to send to the ``name`` method.
+        - ``kwargs``: key-value arguments to send to the ``name`` method.
+
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' napalm.netmiko_multi_call "{'name': 'send_command', 'args': ['show version']}" "{'name': 'send_command', 'args': ['show interfaces']}"
+    '''
+    netmiko_kwargs = netmiko_args()
+    kwargs.update(netmiko_kwargs)
+    return __salt__['netmiko.multi_call'](*methods, **kwargs)
+
+
+@proxy_napalm_wrap
+def netmiko_conn(**kwargs):
+    '''
+    .. versionadded:: Fluorine
+
+    Return the connection object with the network device, over Netmiko, passing
+    the authentication details from the existing NAPALM connection.
+
+    .. warning::
+
+        This function is not suitable for CLI usage, more rather to be used
+        in various Salt modules.
+
+    USAGE Example:
+
+    .. code-block:: python
+
+        conn = __salt__['napalm.netmiko_conn']()
+        res = conn.send_command('show interfaces')
+        conn.disconnect()
+    '''
+    netmiko_kwargs = netmiko_args()
+    kwargs.update(netmiko_kwargs)
+    return __salt__['netmiko.get_connection'](**kwargs)


### PR DESCRIPTION
``netmiko`` is already a dependency of ``napalm``, therefore we are able to
expose all the ``netmiko`` functionalities from the ``netmiko`` execution
module without having to run under a netmiko Proxy Minion: see
https://github.com/saltstack/salt/pull/48260, which is the PR adding the netmiko
execution module.

These new functions added to the existing napalm module gate netmiko's features
to be reused into the napalm Proxy Minions, by forwarding the authentication
details and options which are already there.

For example, the following function goes through the ``netmiko`` Execution
Module, and napalm users can invoke it straight away to get direct access to
basic SSH primitives: ``salt '*' napalm.netmiko_call send_command 'show version'``.
(without any further configuration needed).