### PR TITLE
Group fix for gid comparison

### DIFF
--- a/salt/states/group.py
+++ b/salt/states/group.py
@@ -73,8 +73,14 @@ def _changes(name,
 
     change = {}
     if gid:
-        if lgrp['gid'] != int(gid):
-            change['gid'] = gid
+       try:
+           gid = int(gid)
+           if lgrp['gid'] != gid:
+                change['gid'] = gid
+       except (TypeError, ValueError):
+           ret['result'] = False
+           ret['comment'] = 'Invalid gid'
+           return ret 
 
     if members:
         # -- if new member list if different than the current

--- a/salt/states/group.py
+++ b/salt/states/group.py
@@ -65,22 +65,25 @@ def _changes(name,
         if lgrp['members']:
             lgrp['members'] = [user.lower() for user in lgrp['members']]
         if members:
-            members = [salt.utils.win_functions.get_sam_name(user).lower() for user in members]
+            members = [salt.utils.win_functions.get_sam_name(
+                user).lower() for user in members]
         if addusers:
-            addusers = [salt.utils.win_functions.get_sam_name(user).lower() for user in addusers]
+            addusers = [salt.utils.win_functions.get_sam_name(
+                user).lower() for user in addusers]
         if delusers:
-            delusers = [salt.utils.win_functions.get_sam_name(user).lower() for user in delusers]
+            delusers = [salt.utils.win_functions.get_sam_name(
+                user).lower() for user in delusers]
 
     change = {}
     if gid:
-       try:
-           gid = int(gid)
-           if lgrp['gid'] != gid:
+        try:
+            gid = int(gid)
+            if lgrp['gid'] != gid:
                 change['gid'] = gid
-       except (TypeError, ValueError):
-           ret['result'] = False
-           ret['comment'] = 'Invalid gid'
-           return ret 
+        except (TypeError, ValueError):
+            ret['result'] = False
+            ret['comment'] = 'Invalid gid'
+            return ret
 
     if members:
         # -- if new member list if different than the current
@@ -213,7 +216,7 @@ def present(name,
         # Clear cached group data
         sys.modules[
             __salt__['test.ping'].__module__
-            ].__context__.pop('group.getent', None)
+        ].__context__.pop('group.getent', None)
         changes = _changes(name,
                            gid,
                            addusers,

--- a/salt/states/group.py
+++ b/salt/states/group.py
@@ -73,7 +73,7 @@ def _changes(name,
 
     change = {}
     if gid:
-        if lgrp['gid'] != gid:
+        if lgrp['gid'] != int(gid):
             change['gid'] = gid
 
     if members:


### PR DESCRIPTION
### What does this PR do?

Fixes the _changes() function to correctly evaluate  the group id.


### What issues does this PR fix or reference?

gid was being passed as a string, while the lgrp['gid'] was being passed as an integer.

Added casting or string ``gid`` to integer for accurate comparison.


### Previous Behavior

The return was false even though the group was successfully created.



### New Behavior

This updated code now compares an integer with an integer for the gid.

### Tests written?

No

### Commits signed with GPG?

No

###  Previous Error 

**Evaluation**

``` python
gid  == <type 'str'>
lgrp['gid'] == <type 'int'>
```

**Output**

```

    [ERROR   ] {'Failed': {'gid': '1030'}}
    local:
    ----------
           ID: oinstall_group
     Function: group.present
        Name: oinstall
      Result: False
      Comment: Group {0} has been created but, some changes could not be applied
     Started: 08:59:43.531683
     Duration: 88.538 ms
     Changes:   
              ----------
              Failed:
                  ----------
                  gid:
                      1030
```
###  Fixed Evaluation

**Evaluation**

``` python
gid  == <type 'int'>
lgrp['gid'] == <type 'int'>
```

Changed evaluation from (string != int) to (int != int) 

###  Versions tested

**SLES12SP3** / Salt 2016.11.4 (Carbon)
**Oracle Linux 7** / Salt 2018.3.1 (Oxygen)

State used for testing:

```
oinstall_group:
  group.present:
    - name: oinstall
    - gid: '1030'
```
