### PR TITLE
virt module: Allow NVRAM unlinking on DOM undefine

### DIFF
--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -2381,7 +2381,11 @@ def undefine(vm_, **kwargs):
     '''
     conn = __get_conn(**kwargs)
     dom = _get_domain(conn, vm_)
-    ret = dom.undefine() == 0
+    if getattr(libvirt, 'VIR_DOMAIN_UNDEFINE_NVRAM', False):
+        # This one is only in 1.2.8+
+        ret = dom.undefineFlags(libvirt.VIR_DOMAIN_UNDEFINE_NVRAM) == 0
+    else:
+        ret = dom.undefine() == 0
     conn.close()
     return ret
 
@@ -2439,7 +2443,11 @@ def purge(vm_, dirs=False, removables=None, **kwargs):
     if dirs:
         for dir_ in directories:
             shutil.rmtree(dir_)
-    dom.undefine()
+    if getattr(libvirt, 'VIR_DOMAIN_UNDEFINE_NVRAM', False):
+        # This one is only in 1.2.8+
+        dom.undefineFlags(libvirt.VIR_DOMAIN_UNDEFINE_NVRAM)
+    else:
+        dom.undefine()
     conn.close()
     return True
 


### PR DESCRIPTION
UEFI-enabled VMs usually have pflash (NVRAM) devices attached,
which require one additional libvirt flag to be passed at 'undefine'.

This is usually the case for AArch64 (arm64) VMs, where AAVMF (AA64
UEFI) is the only supported guest bootloader.

### What does this PR do?
Prepares virt module for AArch64 support by allowing undefine operations on UEFI-enabled VMs.

### What issues does this PR fix or reference?
N/A

### Previous Behavior
undefine fails since VMs were booted with an NVRAM device attached.

### New Behavior
NVRAM devices are destroyed as well on VM undefine.

### Tests written?

No

### Commits signed with GPG?

Yes