### PR TITLE
Don't load the grains again when printing them via salt-call -g

### DIFF
--- a/salt/cli/caller.py
+++ b/salt/cli/caller.py
@@ -120,7 +120,7 @@ class BaseCaller(object):
         '''
         Print out the grains
         '''
-        grains = salt.loader.grains(self.opts)
+        grains = self.minion.opts.get('grains') or salt.loader.grains(self.opts)
         salt.output.display_output({'local': grains}, 'grains', self.opts)
 
     def run(self):


### PR DESCRIPTION
The `BaseCaller` instance already has an `SMinion` stored in `self.minion`, and that `SMinion` instance compiles grains in its dunder init. This commit uses the `SMinion`'s grains if it can find them, and only compiles fresh grains as a last resort. Even that seems to be erring on the side of caution, since the `SMinion` should always have grains.

This prevents `salt-call` from compiling grains twice in a single run, resulting in a 40-50% speed reduction when running `salt-call -g`.