### PR TITLE
fix lsattr.get in file.check_perms

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -4459,7 +4459,7 @@ def check_perms(name, ret, user, group, mode, attrs=None, follow_symlinks=False)
         lattrs = lsattr(name)
         if lattrs is not None:
             # List attributes on file
-            perms['lattrs'] = ''.join(lattrs.get('name', ''))
+            perms['lattrs'] = ''.join(lattrs.get(name, ''))
             # Remove attributes on file so changes can be enforced.
             if perms['lattrs']:
                 chattr(name, operator='remove', attributes=perms['lattrs'])


### PR DESCRIPTION
### What does this PR do?

fix `lsattr.get` not matching correct filename in `file.check_perms` module

### What issues does this PR fix or reference?

fix https://github.com/saltstack/salt/issues/48287

### Tests written?

No

### Commits signed with GPG?

No
