### PR TITLE
Enhance the proxy_napalm_wrap decorator to allow "proxyless" execution

### DIFF
--- a/salt/utils/napalm.py
+++ b/salt/utils/napalm.py
@@ -17,6 +17,7 @@ Utils for the NAPALM modules and proxy.
 
 # Import Python libs
 from __future__ import absolute_import, unicode_literals, print_function
+import copy
 import traceback
 import logging
 import importlib
@@ -422,7 +423,7 @@ def proxy_napalm_wrap(func):
                 napalm_opts.update(inventory_opts)
                 log.debug('Merging the config for %s with the details found in the napalm inventory:', host)
                 log.debug(napalm_opts)
-            opts = opts.copy()  # make sure we don't override the original
+            opts = copy.deepcopy(opts)  # make sure we don't override the original
             # opts, but just inject the CLI args from the kwargs to into the
             # object manipulated by ``get_device_opts`` to extract the
             # connection details, then use then to establish the connection.

--- a/salt/utils/napalm.py
+++ b/salt/utils/napalm.py
@@ -405,12 +405,23 @@ def proxy_napalm_wrap(func):
             log.debug('Not running in a NAPALM Proxy Minion')
             _salt_obj = wrapped_global_namespace.get('__salt__')
             napalm_opts = _salt_obj['config.get']('napalm', {})
+            napalm_inventory = _salt_obj['config.get']('napalm_inventory', {})
             log.debug('NAPALM opts found in the Minion config')
             log.debug(napalm_opts)
             clean_kwargs = salt.utils.args.clean_kwargs(**kwargs)
             napalm_opts.update(clean_kwargs)  # no need for deeper merge
             log.debug('Merging the found opts with the CLI args')
             log.debug(napalm_opts)
+            host = napalm_opts.get('host') or napalm_opts.get('hostname') or\
+                   napalm_opts.get('fqdn') or napalm_opts.get('ip')
+            if host and napalm_inventory and isinstance(napalm_inventory, dict) and\
+               host in napalm_inventory:
+                inventory_opts = napalm_inventory[host]
+                log.debug('Found %s in the NAPALM inventory:', host)
+                log.debug(inventory_opts)
+                napalm_opts.update(inventory_opts)
+                log.debug('Merging the config for %s with the details found in the napalm inventory:', host)
+                log.debug(napalm_opts)
             opts = opts.copy()  # make sure we don't override the original
             # opts, but just inject the CLI args from the kwargs to into the
             # object manipulated by ``get_device_opts`` to extract the

--- a/salt/utils/napalm.py
+++ b/salt/utils/napalm.py
@@ -26,6 +26,7 @@ from functools import wraps
 from salt.ext import six as six
 import salt.output
 import salt.utils.platform
+import salt.utils.args
 
 # Import third party libs
 try:
@@ -93,14 +94,14 @@ def virtual(opts, virtualname, filename):
     '''
     Returns the __virtual__.
     '''
-    if ((HAS_NAPALM and NAPALM_MAJOR >= 2) or HAS_NAPALM_BASE) and (is_proxy(opts) or is_minion(opts)):
+    if (HAS_NAPALM and NAPALM_MAJOR >= 2) or HAS_NAPALM_BASE:
         return virtualname
     else:
         return (
             False,
             (
                 '"{vname}"" {filename} cannot be loaded: '
-                'NAPALM is not installed or not running in a (proxy) minion'
+                'NAPALM is not installed: ``pip install napalm``'
             ).format(
                 vname=virtualname,
                 filename='({filename})'.format(filename=filename)
@@ -255,15 +256,12 @@ def get_device_opts(opts, salt_obj=None):
     '''
     network_device = {}
     # by default, look in the proxy config details
-    device_dict = opts.get('proxy', {}) or opts.get('napalm', {})
+    device_dict = opts.get('proxy', {}) if is_proxy(opts) else opts.get('napalm', {})
     if opts.get('proxy') or opts.get('napalm'):
         opts['multiprocessing'] = device_dict.get('multiprocessing', False)
         # Most NAPALM drivers are SSH-based, so multiprocessing should default to False.
         # But the user can be allows one to have a different value for the multiprocessing, which will
         #   override the opts.
-    if salt_obj and not device_dict:
-        # get the connection details from the opts
-        device_dict = salt_obj['config.merge']('napalm')
     if not device_dict:
         # still not able to setup
         log.error('Incorrect minion config. Please specify at least the napalm driver name!')
@@ -367,11 +365,12 @@ def proxy_napalm_wrap(func):
         # the execution modules will make use of this variable from now on
         # previously they were accessing the device properties through the __proxy__ object
         always_alive = opts.get('proxy', {}).get('always_alive', True)
-        if salt.utils.platform.is_proxy() and always_alive:
-            # if it is running in a proxy and it's using the default always alive behaviour,
-            # will get the cached copy of the network device
+        if is_proxy(opts) and always_alive:
+            # if it is running in a NAPALM Proxy and it's using the default
+            # always alive behaviour, will get the cached copy of the network
+            # device object which should preserve the connection.
             wrapped_global_namespace['napalm_device'] = proxy['napalm.get_device']()
-        elif salt.utils.platform.is_proxy() and not always_alive:
+        elif is_proxy(opts) and not always_alive:
             # if still proxy, but the user does not want the SSH session always alive
             # get a new device instance
             # which establishes a new connection
@@ -398,10 +397,25 @@ def proxy_napalm_wrap(func):
                 # otherwise we risk to open multiple sessions
                 wrapped_global_namespace['napalm_device'] = kwargs['inherit_napalm_device']
         else:
-            # if no proxy
+            # if not a NAPLAM proxy
             # thus it is running on a regular minion, directly on the network device
+            # or another flavour of Minion from where we can invoke arbitrary
+            # NAPALM commands
             # get __salt__ from func_globals
+            log.debug('Not running in a NAPALM Proxy Minion')
             _salt_obj = wrapped_global_namespace.get('__salt__')
+            napalm_opts = _salt_obj['config.get']('napalm', {})
+            log.debug('NAPALM opts found in the Minion config')
+            log.debug(napalm_opts)
+            clean_kwargs = salt.utils.args.clean_kwargs(**kwargs)
+            napalm_opts.update(clean_kwargs)  # no need for deeper merge
+            log.debug('Merging the found opts with the CLI args')
+            log.debug(napalm_opts)
+            opts = opts.copy()  # make sure we don't override the original
+            # opts, but just inject the CLI args from the kwargs to into the
+            # object manipulated by ``get_device_opts`` to extract the
+            # connection details, then use then to establish the connection.
+            opts['napalm'] = napalm_opts
             if 'inherit_napalm_device' not in kwargs or ('inherit_napalm_device' in kwargs and
                                                          not kwargs['inherit_napalm_device']):
                 # try to open a new connection


### PR DESCRIPTION
Usually the Salt proxies have been designed using a single methodology: for
each device you aim to manage, start one Proxy Minion. The NAPALM modules didn't
make an exception, however, beginning with https://github.com/saltstack/salt/pull/38339
(therefore starting with release Nitrogen), the functionality has been enhanced
in such a way that we can execute the code when we are able to install the
regular Minion directly on the network hardware.

There is another use case, for something, let's call it "proxyless" when we
don't particularly need to start a Proxy process for each device, but rather
simply invoke arbitrary functions. These changes make this possible, so with one
single Minion (whether Proxy or regular), one is able to execute Salt commands
going through the NAPALM library to connect to the remote network device by
specifying the connection details from the command line and/or opts/pillar, e.g.
``salt server1 bgp.neighbors driver=junos host=1.2.3.4 username=salt``.

If the ``server1`` Minion has the following block in the Pillar (for example):

```yaml
napalm:
  driver: junos
  username: salt
```

The user would only need to provide the rest of the credentials (depending on
each individual case):

``salt server1 bgp.neighbors host=1.2.3.4``.

-----

Having the following configuration in the opts/pillar, for example:

```yaml
napalm:
  username: salt
  password: test

napalm_inventory:
  1.2.3.4:
    driver: eos
  edge01.bzr01:
    driver: junos
```

With the above available in the opts/pillar for a Minion, say ``server1``, the
user would be able to execute: ``salt 'server1' bgp.neighbors host=1.2.3.4`` or
``salt 'server1' net.arp host=edge01.bzr01``, etc.