### PR TITLE
Mask rendered data (in logs)

### DIFF
--- a/salt/roster/flat.py
+++ b/salt/roster/flat.py
@@ -42,6 +42,7 @@ def targets(tgt, tgt_type='glob', **kwargs):
                            __opts__['renderer'],
                            __opts__['renderer_blacklist'],
                            __opts__['renderer_whitelist'],
+                           mask_value='passw*',
                            **kwargs)
     conditioned_raw = {}
     for minion in raw:

--- a/salt/template.py
+++ b/salt/template.py
@@ -16,6 +16,7 @@ import salt.utils.data
 import salt.utils.files
 import salt.utils.stringio
 import salt.utils.versions
+import salt.utils.sanitizers
 
 # Import 3rd-party libs
 from salt.ext import six
@@ -43,6 +44,13 @@ def compile_template(template,
     '''
     Take the path to a template and return the high data structure
     derived from the template.
+
+    Helpers:
+
+    :param mask_value:
+        Mask value for debugging purposes (prevent sensitive information etc)
+        example: "mask_value="pass*". All "passwd", "password", "pass" will
+        be masked (as text).
     '''
 
     # if any error occurs, we return an empty dictionary
@@ -107,10 +115,9 @@ def compile_template(template,
             # yaml, mako, or another engine which renders to a data
             # structure) we don't want to log this.
             if salt.utils.stringio.is_readable(ret):
-                log.debug(
-                    'Rendered data from file: %s:\n%s',
-                    template,
-                    salt.utils.data.decode(ret.read()))  # pylint: disable=no-member
+                log.debug('Rendered data from file: %s:\n%s', template,
+                          salt.utils.sanitizers.mask_args_value(salt.utils.data.decode(ret.read()),
+                                                                kwargs.get('mask_value')))  # pylint: disable=no-member
                 ret.seek(0)  # pylint: disable=no-member
 
     # Preserve newlines from original template

--- a/salt/utils/sanitizers.py
+++ b/salt/utils/sanitizers.py
@@ -74,9 +74,11 @@ def mask_args_value(data, mask):
     but you certainly do not want to put there an actual IP address,
     passwords, user names etc.
 
-    Note, this is working only when data is a single string,
-    ready for print or dump to the log. Also, when the data is formatted
-    as "key: value" in YAML syntax.
+    This can be used for cases where keys in your roster file may contain
+    sensitive data such as IP addresses, passwords, user names, etc.
+
+    Note that this works only when ``data`` is a single string (i.e. when the
+    data in the roster is formatted as ``key: value`` pairs in YAML syntax).
 
     :param data: String data, already rendered.
     :param mask: Mask that matches a single line

--- a/salt/utils/sanitizers.py
+++ b/salt/utils/sanitizers.py
@@ -77,8 +77,9 @@ def mask_args_value(data, mask):
     ready for print or dump to the log. Also, when the data is formatted
     as "key: value" in YAML syntax.
 
-    :param data:
-    :param mask:
+    :param data: String data, already rendered.
+    :param mask: Mask that matches a single line
+
     :return:
     '''
     if not mask:

--- a/salt/utils/sanitizers.py
+++ b/salt/utils/sanitizers.py
@@ -70,11 +70,7 @@ def mask_args_value(data, mask):
     '''
     Mask a line in the data, which matches "mask".
 
-    In case you want to put to the logs rosters or other data,
-    but you certainly do not want to put there an actual IP address,
-    passwords, user names etc.
-
-    This can be used for cases where keys in your roster file may contain
+    This can be used for cases where values in your roster file may contain
     sensitive data such as IP addresses, passwords, user names, etc.
 
     Note that this works only when ``data`` is a single string (i.e. when the

--- a/salt/utils/sanitizers.py
+++ b/salt/utils/sanitizers.py
@@ -18,6 +18,7 @@
 from __future__ import absolute_import, print_function, unicode_literals
 import re
 import os.path
+import fnmatch
 
 # Import Salt libs
 from salt.ext import six
@@ -62,3 +63,33 @@ class InputSanitizer(object):
 
 
 clean = InputSanitizer()
+
+
+def mask_args_value(data, mask):
+    '''
+    Mask a line in the data, which matches "mask".
+
+    In case you want to put to the logs rosters or other data,
+    but you certainly do not want to put there an actual IP address,
+    passwords, user names etc.
+
+    Note, this is working only when data is a single string,
+    ready for print or dump to the log. Also, when the data is formatted
+    as "key: value" in YAML syntax.
+
+    :param data:
+    :param mask:
+    :return:
+    '''
+    if not mask:
+        return data
+
+    out = []
+    for line in data.split(os.linesep):
+        if fnmatch.fnmatch(line.strip(), mask) and ':' in line:
+            key, value = line.split(':', 1)
+            out.append('{}: {}'.format(key.strip(), '** hidden **'))
+        else:
+            out.append(line)
+
+    return '\n'.join(out)

--- a/salt/utils/sanitizers.py
+++ b/salt/utils/sanitizers.py
@@ -23,6 +23,7 @@ import fnmatch
 # Import Salt libs
 from salt.ext import six
 from salt.exceptions import CommandExecutionError
+import salt.utils.stringutils
 
 
 class InputSanitizer(object):
@@ -89,7 +90,7 @@ def mask_args_value(data, mask):
     for line in data.split(os.linesep):
         if fnmatch.fnmatch(line.strip(), mask) and ':' in line:
             key, value = line.split(':', 1)
-            out.append('{}: {}'.format(key.strip(), '** hidden **'))
+            out.append('{}: {}'.format(salt.utils.stringutils.to_unicode(key.strip()), '** hidden **'))
         else:
             out.append(line)
 

--- a/tests/unit/utils/test_sanitizers.py
+++ b/tests/unit/utils/test_sanitizers.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import, print_function, unicode_literals
 from salt.ext.six import text_type as text
 
 # Import Salt Libs
-from salt.utils.sanitizers import clean
+from salt.utils.sanitizers import clean, mask_args_value
 
 # Import Salt Testing Libs
 from tests.support.unit import TestCase, skipIf
@@ -47,3 +47,11 @@ class SanitizersTestCase(TestCase):
         assert response == 'somedubioushostname'
 
     test_sanitized_id = test_sanitized_hostname
+
+    def test_value_masked(self):
+        '''
+        Test if the values are masked.
+        :return:
+        '''
+        out = mask_args_value('quantum: fluctuations', 'quant*')
+        assert out == 'quantum: ** hidden **'

--- a/tests/unit/utils/test_sanitizers.py
+++ b/tests/unit/utils/test_sanitizers.py
@@ -55,3 +55,11 @@ class SanitizersTestCase(TestCase):
         '''
         out = mask_args_value('quantum: fluctuations', 'quant*')
         assert out == 'quantum: ** hidden **'
+
+    def test_value_not_masked(self):
+        '''
+        Test if the values are not masked.
+        :return:
+        '''
+        out = mask_args_value('quantum fluctuations', 'quant*')
+        assert out == 'quantum fluctuations'


### PR DESCRIPTION
### What does this PR do?

- Fixes a security issue
- Adds an utility to further fix such cases

### What issues does this PR fix or reference?

When you call `salt-ssh -l debug`, you will get the entire roster with the passwords directly in the log. This PR fixes this by matching `key: value` strings in the output data and replaces YAML values with the `** hidden **` string. This can be applied for passwords, user IDs, actual IP addresses etc.

NOTE: this is so far is limited only to `key: value` where `value` is replaced. Feel free to extend it for IP addresses etc.

### Tests written?

Yes
