### PR TITLE
Handle packages with multiple versions properly with zypper 

### DIFF
--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -727,7 +727,7 @@ def list_pkgs(versions_as_list=False, **kwargs):
                 line,
                 osarch=__grains__['osarch']
             )
-            if pkginfo is not None:
+            if pkginfo:
                 # see rpm version string rules available at https://goo.gl/UGKPNd
                 pkgver = pkginfo.version
                 epoch = ''

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -1372,14 +1372,6 @@ def install(name=None,
 
     _clean_cache()
     new = list_pkgs(attr=diff_attr) if not downloadonly else list_downloaded()
-
-    # Handle packages which report multiple new versions
-    # (affects only kernel packages at this point)
-    for pkg_name in new:
-        pkg_data = new[pkg_name]
-        if isinstance(pkg_data, six.string_types):
-            new[pkg_name] = pkg_data.split(',')[-1]
-
     ret = salt.utils.data.compare_dicts(old, new)
 
     if errors:

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -415,16 +415,6 @@ def _find_remove_targets(name=None,
 
         if __grains__['os'] == 'FreeBSD' and origin:
             cver = [k for k, v in six.iteritems(cur_pkgs) if v['origin'] == pkgname]
-        elif __grains__['os_family'] == 'Suse':
-            # On SUSE systems. Zypper returns packages without "arch" in name
-            try:
-                namepart, archpart = pkgname.rsplit('.', 1)
-            except ValueError:
-                cver = cur_pkgs.get(pkgname, [])
-            else:
-                if archpart in salt.utils.pkg.rpm.ARCHES + ("noarch",):
-                    pkgname = namepart
-                cver = cur_pkgs.get(pkgname, [])
         else:
             cver = cur_pkgs.get(pkgname, [])
 

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -854,17 +854,6 @@ def _verify_install(desired, new_pkgs, ignore_epoch=False, new_caps=None):
             cver = new_pkgs.get(pkgname.split('%')[0])
         elif __grains__['os_family'] == 'Debian':
             cver = new_pkgs.get(pkgname.split('=')[0])
-        elif __grains__['os_family'] == 'Suse':
-            # On SUSE systems. Zypper returns packages without "arch" in name
-            try:
-                namepart, archpart = pkgname.rsplit('.', 1)
-            except ValueError:
-                cver = new_pkgs.get(pkgname)
-            else:
-                if archpart in salt.utils.pkg.rpm.ARCHES + ("noarch",):
-                    cver = new_pkgs.get(namepart)
-                else:
-                    cver = new_pkgs.get(pkgname)
         else:
             cver = new_pkgs.get(pkgname)
             if not cver and pkgname in new_caps:

--- a/tests/unit/modules/test_zypper.py
+++ b/tests/unit/modules/test_zypper.py
@@ -476,7 +476,7 @@ class ZypperTestCase(TestCase, LoaderModuleMockMixin):
                     with patch('salt.modules.zypper.list_pkgs', MagicMock(side_effect=[
                         {"kernel-default": "3.12.49-11.1"}, {"kernel-default": "3.12.49-11.1,3.12.51-60.20.2"}])):
                         ret = zypper.install('kernel-default', '--auto-agree-with-licenses')
-                        self.assertDictEqual(ret, {"kernel-default": {"old": "3.12.49-11.1", "new": "3.12.51-60.20.2"}})
+                        self.assertDictEqual(ret, {"kernel-default": {"old": "3.12.49-11.1", "new": "3.12.49-11.1,3.12.51-60.20.2"}})
 
     def test_upgrade_failure(self):
         '''
@@ -541,27 +541,36 @@ Repository 'DUMMY' not found by its alias, number, or URI.
             data.setdefault(key, []).append(value)
 
         rpm_out = [
-            'protobuf-java_|-2.6.1_|-3.1.develHead_|-noarch_|-_|-1499257756',
-            'yast2-ftp-server_|-3.1.8_|-8.1_|-x86_64_|-_|-1499257798',
-            'jose4j_|-0.4.4_|-2.1.develHead_|-noarch_|-_|-1499257756',
-            'apache-commons-cli_|-1.2_|-1.233_|-noarch_|-_|-1498636510',
-            'jakarta-commons-discovery_|-0.4_|-129.686_|-noarch_|-_|-1498636511',
-            'susemanager-build-keys-web_|-12.0_|-5.1.develHead_|-noarch_|-_|-1498636510',
+            'protobuf-java_|-(none)_|-2.6.1_|-3.1.develHead_|-noarch_|-(none)_|-1499257756',
+            'yast2-ftp-server_|-(none)_|-3.1.8_|-8.1_|-x86_64_|-(none)_|-1499257798',
+            'jose4j_|-(none)_|-0.4.4_|-2.1.develHead_|-noarch_|-(none)_|-1499257756',
+            'apache-commons-cli_|-(none)_|-1.2_|-1.233_|-noarch_|-(none)_|-1498636510',
+            'jakarta-commons-discovery_|-(none)_|-0.4_|-129.686_|-noarch_|-(none)_|-1498636511',
+            'susemanager-build-keys-web_|-(none)_|-12.0_|-5.1.develHead_|-noarch_|-(none)_|-1498636510',
+            'gpg-pubkey_|-(none)_|-39db7c82_|-5847eb1f_|-(none)_|-(none)_|-1519203802',
+            'gpg-pubkey_|-(none)_|-8a7c64f9_|-5aaa93ca_|-(none)_|-(none)_|-1529925595',
+            'kernel-default_|-(none)_|-4.4.138_|-94.39.1_|-x86_64_|-(none)_|-1529936067',
+            'kernel-default_|-(none)_|-4.4.73_|-5.1_|-x86_64_|-(none)_|-1503572639',
+            'perseus-dummy_|-(none)_|-1.1_|-1.1_|-i586_|-(none)_|-1529936062',
         ]
-        with patch.dict(zypper.__salt__, {'cmd.run': MagicMock(return_value=os.linesep.join(rpm_out))}), \
+        with patch.dict(zypper.__grains__, {'osarch': 'x86_64'}), \
+             patch.dict(zypper.__salt__, {'cmd.run': MagicMock(return_value=os.linesep.join(rpm_out))}), \
              patch.dict(zypper.__salt__, {'pkg_resource.add_pkg': _add_data}), \
              patch.dict(zypper.__salt__, {'pkg_resource.format_pkg_list': pkg_resource.format_pkg_list}), \
              patch.dict(zypper.__salt__, {'pkg_resource.stringify': MagicMock()}):
             pkgs = zypper.list_pkgs(versions_as_list=True)
+            self.assertFalse(pkgs.get('gpg-pubkey', False))
             for pkg_name, pkg_version in {
-                'jakarta-commons-discovery': '0.4-129.686',
-                'yast2-ftp-server': '3.1.8-8.1',
-                'protobuf-java': '2.6.1-3.1.develHead',
-                'susemanager-build-keys-web': '12.0-5.1.develHead',
-                'apache-commons-cli': '1.2-1.233',
-                'jose4j': '0.4.4-2.1.develHead'}.items():
+                'jakarta-commons-discovery': ['0.4-129.686'],
+                'yast2-ftp-server': ['3.1.8-8.1'],
+                'protobuf-java': ['2.6.1-3.1.develHead'],
+                'susemanager-build-keys-web': ['12.0-5.1.develHead'],
+                'apache-commons-cli': ['1.2-1.233'],
+                'kernel-default': ['4.4.138-94.39.1', '4.4.73-5.1'],
+                'perseus-dummy.i586': ['1.1-1.1'],
+                'jose4j': ['0.4.4-2.1.develHead']}.items():
                 self.assertTrue(pkgs.get(pkg_name))
-                self.assertEqual(pkgs[pkg_name], [pkg_version])
+                self.assertEqual(pkgs[pkg_name], pkg_version)
 
     def test_list_pkgs_with_attr(self):
         '''
@@ -573,57 +582,82 @@ Repository 'DUMMY' not found by its alias, number, or URI.
             data.setdefault(key, []).append(value)
 
         rpm_out = [
-            'protobuf-java_|-2.6.1_|-3.1.develHead_|-noarch_|-_|-1499257756',
-            'yast2-ftp-server_|-3.1.8_|-8.1_|-x86_64_|-_|-1499257798',
-            'jose4j_|-0.4.4_|-2.1.develHead_|-noarch_|-_|-1499257756',
-            'apache-commons-cli_|-1.2_|-1.233_|-noarch_|-_|-1498636510',
-            'jakarta-commons-discovery_|-0.4_|-129.686_|-noarch_|-_|-1498636511',
-            'susemanager-build-keys-web_|-12.0_|-5.1.develHead_|-noarch_|-_|-1498636510',
+            'protobuf-java_|-(none)_|-2.6.1_|-3.1.develHead_|-noarch_|-(none)_|-1499257756',
+            'yast2-ftp-server_|-(none)_|-3.1.8_|-8.1_|-x86_64_|-(none)_|-1499257798',
+            'jose4j_|-(none)_|-0.4.4_|-2.1.develHead_|-noarch_|-(none)_|-1499257756',
+            'apache-commons-cli_|-(none)_|-1.2_|-1.233_|-noarch_|-(none)_|-1498636510',
+            'jakarta-commons-discovery_|-(none)_|-0.4_|-129.686_|-noarch_|-(none)_|-1498636511',
+            'susemanager-build-keys-web_|-(none)_|-12.0_|-5.1.develHead_|-noarch_|-(none)_|-1498636510',
+            'gpg-pubkey_|-(none)_|-39db7c82_|-5847eb1f_|-(none)_|-(none)_|-1519203802',
+            'gpg-pubkey_|-(none)_|-8a7c64f9_|-5aaa93ca_|-(none)_|-(none)_|-1529925595',
+            'kernel-default_|-(none)_|-4.4.138_|-94.39.1_|-x86_64_|-(none)_|-1529936067',
+            'kernel-default_|-(none)_|-4.4.73_|-5.1_|-x86_64_|-(none)_|-1503572639',
+            'perseus-dummy_|-(none)_|-1.1_|-1.1_|-i586_|-(none)_|-1529936062',
         ]
         with patch.dict(zypper.__salt__, {'cmd.run': MagicMock(return_value=os.linesep.join(rpm_out))}), \
+             patch.dict(zypper.__grains__, {'osarch': 'x86_64'}), \
              patch.dict(zypper.__salt__, {'pkg_resource.add_pkg': _add_data}), \
              patch.dict(zypper.__salt__, {'pkg_resource.format_pkg_list': pkg_resource.format_pkg_list}), \
              patch.dict(zypper.__salt__, {'pkg_resource.stringify': MagicMock()}):
             pkgs = zypper.list_pkgs(attr=['epoch', 'release', 'arch', 'install_date_time_t'])
+            self.assertFalse(pkgs.get('gpg-pubkey', False))
             for pkg_name, pkg_attr in {
-                'jakarta-commons-discovery': {
+                'jakarta-commons-discovery': [{
                     'version': '0.4',
                     'release': '129.686',
                     'arch': 'noarch',
                     'install_date_time_t': 1498636511,
-                },
-                'yast2-ftp-server': {
+                }],
+                'yast2-ftp-server': [{
                     'version': '3.1.8',
                     'release': '8.1',
                     'arch': 'x86_64',
                     'install_date_time_t': 1499257798,
-                },
-                'protobuf-java': {
+                }],
+                'protobuf-java': [{
                     'version': '2.6.1',
                     'release': '3.1.develHead',
                     'install_date_time_t': 1499257756,
                     'arch': 'noarch',
-                },
-                'susemanager-build-keys-web': {
+                }],
+                'susemanager-build-keys-web': [{
                     'version': '12.0',
                     'release': '5.1.develHead',
                     'arch': 'noarch',
                     'install_date_time_t': 1498636510,
-                },
-                'apache-commons-cli': {
+                }],
+                'apache-commons-cli': [{
                     'version': '1.2',
                     'release': '1.233',
                     'arch': 'noarch',
                     'install_date_time_t': 1498636510,
+                }],
+                'kernel-default': [{
+                    'version': '4.4.138',
+                    'release': '94.39.1',
+                    'arch': 'x86_64',
+                    'install_date_time_t': 1529936067
                 },
-                'jose4j': {
+                {
+                    'version': '4.4.73',
+                    'release': '5.1',
+                    'arch': 'x86_64',
+                    'install_date_time_t': 1503572639,
+                }],
+                'perseus-dummy.i586': [{
+                    'version': '1.1',
+                    'release': '1.1',
+                    'arch': 'i586',
+                    'install_date_time_t': 1529936062,
+                }],
+                'jose4j': [{
                     'arch': 'noarch',
                     'version': '0.4.4',
                     'release': '2.1.develHead',
                     'install_date_time_t': 1499257756,
-                }}.items():
+                }]}.items():
                 self.assertTrue(pkgs.get(pkg_name))
-                self.assertEqual(pkgs[pkg_name], [pkg_attr])
+                self.assertEqual(pkgs[pkg_name], pkg_attr)
 
     def test_list_patches(self):
         '''


### PR DESCRIPTION
### What does this PR do?
This PR fixes some issues introduced after merging https://github.com/saltstack/salt/pull/47678 . 

### What issues does this PR fix or reference?
- Exclude `gpg-pubkey` entries from `zypper.list_pkg`
- Fix `changes` on `pkg.installed` output when dealing with packages with multiple versions installed.
- Fix `changes` on `pkg.installed` output when packages name include "arch".

### Previous Behavior
On a SUSE systems, given this SLS state file: 
```yaml
my_tests:
  pkg.installed:
    - pkgs:
      - kernel-default.x86_64: 4.4.138-94.39.1
      - iotop.noarch: 0.6-3.10
      - apache2.x86_64: 2.4.23-29.18.2
      - apache2-doc: 2.4.23-29.18.2
      - perseus-dummy.i586: 1.1-1.1
      - orion-dummy: 1.1-1.1
```

Applying `my_tests` state will produce:
```yaml
local:
----------
          ID: my_tests
    Function: pkg.installed
      Result: True
     Comment: 6 targeted packages were installed/updated.
     Started: 16:05:56.124001
    Duration: 24153.705 ms
     Changes:   
              ----------
              apache2:
                  ----------
                  new:
                      2.4.23-29.18.2
                  old:
              apache2-doc:
                  ----------
                  new:
                      2.4.23-29.18.2
                  old:
              apache2-prefork:
                  ----------
                  new:
                      2.4.23-29.18.2
                  old:
              gpg-pubkey:
                  ----------
                  new:
                      e6e5a213-5b291a5f
                  old:
                      39db7c82-5847eb1f,8a7c64f9-5aaa93ca,e6e5a213-5b291a5f
              iotop:
                  ----------
                  new:
                      0.6-3.10
                  old:
              orion-dummy:
                  ----------
                  new:
                      1.1-1.1
                  old:

Summary for local
------------
Succeeded: 1 (changed=1)
Failed:    0
------------
Total states run:     1
Total run time:  24.154 s
```

Notice that `perseus-dummy.x586` package, as well as `kernel-default`, are actually installed but not reported on `changes` (and they should). Also the non-desired `gpg-pubkey` entry is not excluded from `changes` since it's not actually a real package.

### New Behavior
Given the same SLS file:

```yaml
local:
----------
          ID: my_tests
    Function: pkg.installed
      Result: True
     Comment: 6 targeted packages were installed/updated.
     Started: 16:14:13.955445
    Duration: 24761.717 ms
     Changes:   
              ----------
              apache2:
                  ----------
                  new:
                      2.4.23-29.18.2
                  old:
              apache2-doc:
                  ----------
                  new:
                      2.4.23-29.18.2
                  old:
              apache2-prefork:
                  ----------
                  new:
                      2.4.23-29.18.2
                  old:
              iotop:
                  ----------
                  new:
                      0.6-3.10
                  old:
              kernel-default:
                  ----------
                  new:
                      4.4.138-94.39.1,4.4.73-5.1
                  old:
                      4.4.73-5.1
              orion-dummy:
                  ----------
                  new:
                      1.1-1.1
                  old:
              perseus-dummy.i586:
                  ----------
                  new:
                      1.1-1.1
                  old:

Summary for local
------------
Succeeded: 1 (changed=1)
Failed:    0
------------
Total states run:     1
Total run time:  24.762 s
```

Now, both `perseus-dummy.i586` and `kernel-default` are successfully reported on `changes`, and the `gpg-pubkey` entry is excluded.

### Tests written?

Yes

### Commits signed with GPG?

Yes