### PR TITLE
Fix macosx grains when swapusage returns comma

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -448,7 +448,7 @@ def _osx_memdata():
     sysctl = salt.utils.path.which('sysctl')
     if sysctl:
         mem = __salt__['cmd.run']('{0} -n hw.memsize'.format(sysctl))
-        swap_total = __salt__['cmd.run']('{0} -n vm.swapusage'.format(sysctl)).split()[2]
+        swap_total = __salt__['cmd.run']('{0} -n vm.swapusage'.format(sysctl)).split()[2].replace(',', '.')
         if swap_total.endswith('K'):
             _power = 2**10
         elif swap_total.endswith('M'):

--- a/tests/unit/grains/test_core.py
+++ b/tests/unit/grains/test_core.py
@@ -908,3 +908,33 @@ class CoreGrainsTestCase(TestCase, LoaderModuleMockMixin):
                         osdata = {'kernel': 'Linux', }
                         ret = core._virtual(osdata)
                         self.assertEqual(ret['virtual'], virt)
+
+    @patch('salt.utils.path.which', MagicMock(return_value='/usr/sbin/sysctl'))
+    def test_osx_memdata_with_comma(self):
+        '''
+        test osx memdata method when comma returns
+        '''
+        def _cmd_side_effect(cmd):
+            if 'hw.memsize' in cmd:
+                return '4294967296'
+            elif 'vm.swapusage' in cmd:
+                return 'total = 1024,00M  used = 160,75M  free = 863,25M  (encrypted)'
+        with patch.dict(core.__salt__, {'cmd.run': MagicMock(side_effect=_cmd_side_effect)}):
+            ret = core._osx_memdata()
+            assert ret['swap_total'] == 1024
+            assert ret['mem_total'] == 4096
+
+    @patch('salt.utils.path.which', MagicMock(return_value='/usr/sbin/sysctl'))
+    def test_osx_memdata(self):
+        '''
+        test osx memdata
+        '''
+        def _cmd_side_effect(cmd):
+            if 'hw.memsize' in cmd:
+                return '4294967296'
+            elif 'vm.swapusage' in cmd:
+                return 'total = 0.00M  used = 0.00M  free = 0.00M  (encrypted)'
+        with patch.dict(core.__salt__, {'cmd.run': MagicMock(side_effect=_cmd_side_effect)}):
+            ret = core._osx_memdata()
+            assert ret['swap_total'] == 0
+            assert ret['mem_total'] == 4096


### PR DESCRIPTION
### What does this PR do?
Apparently macosx can return a comman when running `vm.swapusage`. This handles those cases and adds tests.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/48078

### Previous Behavior
salt-minion does not start due to valuerror

### New Behavior
salt-minion starts

### Tests written?

Yes

### Commits signed with GPG?

Yes