### PR TITLE
add support for tagging ec2 instance spot requests

### DIFF
--- a/doc/topics/cloud/aws.rst
+++ b/doc/topics/cloud/aws.rst
@@ -464,13 +464,26 @@ following example will request that spot instances be used and your
 maximum bid will be $0.10. Keep in mind that different spot prices
 may be needed based on the current value of the various EC2 instance
 sizes. You can check current and past spot instance pricing via the
-EC2 API or AWS Console.
+EC2 API or AWS Console. 
 
 .. code-block:: yaml
 
     my-ec2-config:
       spot_config:
         spot_price: 0.10
+
+You can optionally specify tags to apply to the EC2 spot instance request.
+A spot instance request itself is an object in AWS. The following example
+will set two tags on the spot instance request.
+
+.. code-block:: yaml
+
+    my-ec2-config:
+      spot_config:
+        spot_price: 0.10
+        tag:
+          tag0: value
+          tag1: value
 
 By default, the spot instance type is set to 'one-time', meaning it will
 be launched and, if it's ever terminated for whatever reason, it will not

--- a/doc/topics/cloud/aws.rst
+++ b/doc/topics/cloud/aws.rst
@@ -464,7 +464,7 @@ following example will request that spot instances be used and your
 maximum bid will be $0.10. Keep in mind that different spot prices
 may be needed based on the current value of the various EC2 instance
 sizes. You can check current and past spot instance pricing via the
-EC2 API or AWS Console. 
+EC2 API or AWS Console.
 
 .. code-block:: yaml
 

--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -2683,7 +2683,6 @@ def create(vm_=None, call=None):
         location=location
     )
 
-
     # Once instance tags are set, tag the spot request if configured
     if 'spot_config' in vm_ and 'tag' in vm_['spot_config']:
 
@@ -2701,7 +2700,7 @@ def create(vm_=None, call=None):
 
         spot_request_tags = {}
 
-        if not 'spotRequestId' in vm_:
+        if 'spotRequestId' not in vm_:
             raise SaltCloudConfigError('Failed to find spotRequestId')
 
         sir_id = vm_['spotRequestId']

--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -2059,6 +2059,8 @@ def request_instance(vm_=None, call=None):
     if spot_config:
         sir_id = data[0]['spotInstanceRequestId']
 
+        vm_['spotRequestId'] = sir_id
+
         def __query_spot_instance_request(sir_id, location):
             params = {'Action': 'DescribeSpotInstanceRequests',
                       'SpotInstanceRequestId.1': sir_id}
@@ -2681,6 +2683,53 @@ def create(vm_=None, call=None):
         location=location
     )
 
+
+    # Once instance tags are set, tag the spot request if configured
+    if 'spot_config' in vm_ and 'tag' in vm_['spot_config']:
+
+        if not isinstance(vm_['spot_config']['tag'], dict):
+            raise SaltCloudConfigError(
+                '\'tag\' should be a dict.'
+            )
+
+        for value in six.itervalues(vm_['spot_config']['tag']):
+            if not isinstance(value, str):
+                raise SaltCloudConfigError(
+                    '\'tag\' values must be strings. Try quoting the values. '
+                    'e.g. "2013-09-19T20:09:46Z".'
+                )
+
+        spot_request_tags = {}
+
+        if not 'spotRequestId' in vm_:
+            raise SaltCloudConfigError('Failed to find spotRequestId')
+
+        sir_id = vm_['spotRequestId']
+
+        spot_request_tags['Name'] = vm_['name']
+
+        for k,v in vm_['spot_config']['tag'].iteritems():
+          spot_request_tags[k] = v
+
+        __utils__['cloud.fire_event'](
+            'event',
+            'setting tags',
+            'salt/cloud/spot_request_{0}/tagging'.format(sir_id),
+            args={'tags': spot_request_tags},
+            sock_dir=__opts__['sock_dir'],
+            transport=__opts__['transport']
+        )       
+        salt.utils.cloud.wait_for_fun(
+            set_tags,
+            timeout=30,
+            name=vm_['name'],
+            tags=spot_request_tags,
+            instance_id=sir_id,
+            call='action',
+            location=location
+        )
+
+    
     network_interfaces = config.get_cloud_config_value(
         'network_interfaces',
         vm_,

--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -2708,8 +2708,8 @@ def create(vm_=None, call=None):
 
         spot_request_tags['Name'] = vm_['name']
 
-        for k,v in vm_['spot_config']['tag'].iteritems():
-          spot_request_tags[k] = v
+        for k, v in six.iteritems(vm_['spot_config']['tag']):
+            spot_request_tags[k] = v
 
         __utils__['cloud.fire_event'](
             'event',
@@ -2718,7 +2718,7 @@ def create(vm_=None, call=None):
             args={'tags': spot_request_tags},
             sock_dir=__opts__['sock_dir'],
             transport=__opts__['transport']
-        )       
+        )
         salt.utils.cloud.wait_for_fun(
             set_tags,
             timeout=30,
@@ -2729,7 +2729,6 @@ def create(vm_=None, call=None):
             location=location
         )
 
-    
     network_interfaces = config.get_cloud_config_value(
         'network_interfaces',
         vm_,


### PR DESCRIPTION
This change enabled support for creating tags for aws ec2 spot instance requests using salt-cloud configuration file.

Salt-cloud does not currently support this.

Tags can be set on AWS ec2 spot instance with the following salt-cloud configuration. 
my-ec2-config:
  spot_config:
    spot_price: 0.10
    tag:
        first_tag: first tag value
        second_tag: second tag value
        ... 
        ...

Tests have not been written

### Commits signed with GPG?
No
