### PR TITLE
Drop support for Python 2 unicode string literals in YAML renderer

### DIFF
--- a/doc/topics/jinja/index.rst
+++ b/doc/topics/jinja/index.rst
@@ -886,7 +886,7 @@ Example:
     encoding (usually a ``unicode`` type). This filter was incorrectly-named
     when it was added. ``json_decode_list`` will be supported until the Neon
     release.
-.. deprecated:: Fluorine
+.. deprecated:: 2018.3.3,Fluorine
     The :jinja_ref:`tojson` filter accomplishes what this filter was designed
     to do, making this filter redundant.
 
@@ -919,7 +919,7 @@ Returns:
     encoding (usually a ``unicode`` type). This filter was incorrectly-named
     when it was added. ``json_decode_dict`` will be supported until the Neon
     release.
-.. deprecated:: Fluorine
+.. deprecated:: 2018.3.3,Fluorine
     The :jinja_ref:`tojson` filter accomplishes what this filter was designed
     to do, making this filter redundant.
 
@@ -946,7 +946,7 @@ Returns:
 ``tojson``
 ----------
 
-.. versionadded:: Fluorine
+.. versionadded:: 2018.3.3,Fluorine
 
 Dumps a data structure to JSON.
 

--- a/doc/topics/jinja/index.rst
+++ b/doc/topics/jinja/index.rst
@@ -886,6 +886,10 @@ Example:
     encoding (usually a ``unicode`` type). This filter was incorrectly-named
     when it was added. ``json_decode_list`` will be supported until the Neon
     release.
+.. deprecated:: Fluorine
+    The :jinja_ref:`tojson` filter accomplishes what this filter was designed
+    to do, making this filter redundant.
+
 
 Recursively encodes all string elements of the list to bytes.
 
@@ -915,6 +919,9 @@ Returns:
     encoding (usually a ``unicode`` type). This filter was incorrectly-named
     when it was added. ``json_decode_dict`` will be supported until the Neon
     release.
+.. deprecated:: Fluorine
+    The :jinja_ref:`tojson` filter accomplishes what this filter was designed
+    to do, making this filter redundant.
 
 Recursively encodes all string items in the dictionary to bytes.
 
@@ -933,6 +940,22 @@ Returns:
 
   {'a': '\xd0\x94'}
 
+
+.. jinja_ref:: tojson
+
+``tojson``
+----------
+
+.. versionadded:: Fluorine
+
+Dumps a data structure to JSON.
+
+This filter was added to provide this functionality to hosts which have a
+Jinja release older than version 2.9 installed. If Jinja 2.9 or newer is
+installed, then the upstream version of the filter will be used. See the
+`upstream docs`__ for more information.
+
+.. __: http://jinja.pocoo.org/docs/2.10/templates/#tojson
 
 .. jinja_ref:: random_hash
 

--- a/doc/topics/releases/fluorine.rst
+++ b/doc/topics/releases/fluorine.rst
@@ -8,8 +8,7 @@ Non-Backward-Compatible Change to YAML Renderer
 ===============================================
 
 In earlier releases, this was considered valid usage in Python 2, assuming that
-``data`` was a dictionary containing keys/values which are unicode string
-types:
+``data`` was a dictionary containing keys/values which are ``unicode`` types:
 
 .. code-block:: jinja
 
@@ -20,8 +19,9 @@ types:
         - context:
             data: {{ data }}
 
-Jinja will render the unicode string types in Python 2 with the "u" prefix.
-While not valid YAML, earlier releases would successfully load these values.
+Jinja will render the ``unicode`` string types in Python 2 with the "u" prefix
+(e.g. ``{u'foo': u'bar'}``). While not valid YAML, earlier releases would
+successfully load these values.
 
 As of this release, the above SLS would result in an error message. To allow
 for a data structure to be dumped directly into your SLS file, use the `tojson

--- a/doc/topics/releases/fluorine.rst
+++ b/doc/topics/releases/fluorine.rst
@@ -42,10 +42,10 @@ Jinja filter`_:
             data: {{ data|tojson }}
 
 .. note::
-    This filter was added in Jinja 2.9. However, fear not! The Fluorine release
-    also adds a ``tojson`` filter which will be used if this filter is not
-    already present, making it available on platforms like RHEL 7 and Ubuntu
-    14.04 which provide older versions of Jinja.
+    This filter was added in Jinja 2.9. However, fear not! The 2018.3.3 release
+    added a ``tojson`` filter which will be used if this filter is not already
+    present, making it available on platforms like RHEL 7 and Ubuntu 14.04
+    which provide older versions of Jinja.
 
 .. important::
     The :jinja_ref:`json_encode_dict` and :jinja_ref:`json_encode_list` filters

--- a/doc/topics/releases/fluorine.rst
+++ b/doc/topics/releases/fluorine.rst
@@ -8,7 +8,8 @@ Non-Backward-Compatible Change to YAML Renderer
 ===============================================
 
 In earlier releases, this was considered valid usage in Python 2, assuming that
-``data`` was a dictionary containing keys/values which are ``unicode`` types:
+``data`` was a list or dictionary containing keys/values which are ``unicode``
+types:
 
 .. code-block:: jinja
 
@@ -19,9 +20,13 @@ In earlier releases, this was considered valid usage in Python 2, assuming that
         - context:
             data: {{ data }}
 
-Jinja will render the ``unicode`` string types in Python 2 with the "u" prefix
-(e.g. ``{u'foo': u'bar'}``). While not valid YAML, earlier releases would
-successfully load these values.
+One common use case for this is when using one of Salt's :jinja_ref:`custom
+Jinja filters <custom-jinja-filters>` which return lists or dictionaries, such
+as the :jinja_ref:`ipv4` filter.
+
+In Python 2, Jinja will render the ``unicode`` string types within the
+list/dictionary with the "u" prefix (e.g. ``{u'foo': u'bar'}``). While not
+valid YAML, earlier releases would successfully load these values.
 
 As of this release, the above SLS would result in an error message. To allow
 for a data structure to be dumped directly into your SLS file, use the `tojson
@@ -41,6 +46,14 @@ Jinja filter`_:
     also adds a ``tojson`` filter which will be used if this filter is not
     already present, making it available on platforms like RHEL 7 and Ubuntu
     14.04 which provide older versions of Jinja.
+
+.. important::
+    The :jinja_ref:`json_encode_dict` and :jinja_ref:`json_encode_list` filters
+    do not actually dump the results to JSON. Since ``tojson`` accomplishes
+    what those filters were designed to do, they are now deprecated and will be
+    removed in the Neon release. The ``tojson`` filter should be used in all
+    cases where :jinja_ref:`json_encode_dict` and :jinja_ref:`json_encode_list`
+    would have been used.
 
 .. _`tojson Jinja filter`: http://jinja.pocoo.org/docs/2.10/templates/#tojson
 

--- a/doc/topics/releases/fluorine.rst
+++ b/doc/topics/releases/fluorine.rst
@@ -42,7 +42,7 @@ Jinja filter`_:
     already present, making it available on platforms like RHEL 7 and Ubuntu
     14.04 which provide older versions of Jinja.
 
-.. _`tojson Jinja filter`_: http://jinja.pocoo.org/docs/2.10/templates/#tojson
+.. _`tojson Jinja filter`: http://jinja.pocoo.org/docs/2.10/templates/#tojson
 
 New Docker Proxy Minion
 =======================

--- a/doc/topics/releases/fluorine.rst
+++ b/doc/topics/releases/fluorine.rst
@@ -4,6 +4,46 @@
 Salt Release Notes - Codename Fluorine
 ======================================
 
+Non-Backward-Compatible Change to YAML Renderer
+===============================================
+
+In earlier releases, this was considered valid usage in Python 2, assuming that
+``data`` was a dictionary containing keys/values which are unicode string
+types:
+
+.. code-block:: jinja
+
+    /etc/foo.conf:
+      file.managed:
+        - source: salt://foo.conf.jinja
+        - template: jinja
+        - context:
+            data: {{ data }}
+
+Jinja will render the unicode string types in Python 2 with the "u" prefix.
+While not valid YAML, earlier releases would successfully load these values.
+
+As of this release, the above SLS would result in an error message. To allow
+for a data structure to be dumped directly into your SLS file, use the `tojson
+Jinja filter`_:
+
+.. code-block:: jinja
+
+    /etc/foo.conf:
+      file.managed:
+        - source: salt://foo.conf.jinja
+        - template: jinja
+        - context:
+            data: {{ data|tojson }}
+
+.. note::
+    This filter was added in Jinja 2.9. However, fear not! The Fluorine release
+    also adds a ``tojson`` filter which will be used if this filter is not
+    already present, making it available on platforms like RHEL 7 and Ubuntu
+    14.04 which provide older versions of Jinja.
+
+.. _`tojson Jinja filter`_: http://jinja.pocoo.org/docs/2.10/templates/#tojson
+
 New Docker Proxy Minion
 =======================
 
@@ -21,7 +61,6 @@ module.
     proxy:
       proxytype: docker
       name: keen_proskuriakova
-
 
 Grains Dictionary Passed into Custom Grains
 ===========================================

--- a/salt/utils/data.py
+++ b/salt/utils/data.py
@@ -274,7 +274,7 @@ def encode(data, encoding=None, errors='strict', keep=False,
 
 
 @jinja_filter('json_decode_dict')  # Remove this for Neon
-@jinja_filter('json_encode_dict')
+@jinja_filter('json_encode_dict')  # Remove this for Neon
 def encode_dict(data, encoding=None, errors='strict', keep=False,
                 preserve_dict_class=False, preserve_tuples=False):
     '''
@@ -327,7 +327,7 @@ def encode_dict(data, encoding=None, errors='strict', keep=False,
 
 
 @jinja_filter('json_decode_list')  # Remove this for Neon
-@jinja_filter('json_encode_list')
+@jinja_filter('json_encode_list')  # Remove this for Neon
 def encode_list(data, encoding=None, errors='strict', keep=False,
                 preserve_dict_class=False, preserve_tuples=False):
     '''

--- a/salt/utils/jinja.py
+++ b/salt/utils/jinja.py
@@ -309,6 +309,26 @@ def to_bool(val):
     return False
 
 
+@jinja_filter('tojson')
+def tojson(val, indent=None):
+    '''
+    Implementation of tojson filter (only present in Jinja 2.9 and later). If
+    Jinja 2.9 or later is installed, then the upstream version of this filter
+    will be used.
+    '''
+    options = {'ensure_ascii': True}
+    if indent is not None:
+        options['indent'] = indent
+    return (
+        salt.utils.json.dumps(
+            val, **options
+        ).replace('<', '\\u003c')
+         .replace('>', '\\u003e')
+         .replace('&', '\\u0026')
+         .replace("'", '\\u0027')
+    )
+
+
 @jinja_filter('quote')
 def quote(txt):
     '''

--- a/salt/utils/templates.py
+++ b/salt/utils/templates.py
@@ -357,8 +357,12 @@ def render_jinja_tmpl(tmplstr, context, tmplpath=None):
         jinja_env = jinja2.Environment(undefined=jinja2.StrictUndefined,
                                        **env_args)
 
+    tojson_filter = jinja_env.filters.get('tojson')
     jinja_env.tests.update(JinjaTest.salt_jinja_tests)
     jinja_env.filters.update(JinjaFilter.salt_jinja_filters)
+    if tojson_filter is not None:
+        # Use the existing tojson filter, if present (jinja2 >= 2.9)
+        jinja_env.filters['tojson'] = tojson_filter
     jinja_env.globals.update(JinjaGlobal.salt_jinja_globals)
 
     # globals

--- a/salt/utils/yamlloader.py
+++ b/salt/utils/yamlloader.py
@@ -116,11 +116,6 @@ class SaltYamlSafeLoader(yaml.SafeLoader):
                 # an empty string. Change it to '0'.
                 if node.value == '':
                     node.value = '0'
-        elif node.tag == 'tag:yaml.org,2002:str':
-            # If any string comes in as a quoted unicode literal, eval it into
-            # the proper unicode string type.
-            if re.match(r'^u([\'"]).+\1$', node.value, flags=re.IGNORECASE):
-                node.value = eval(node.value, {}, {})  # pylint: disable=W0123
         return super(SaltYamlSafeLoader, self).construct_scalar(node)
 
     def construct_yaml_str(self, node):

--- a/salt/utils/yamlloader.py
+++ b/salt/utils/yamlloader.py
@@ -14,6 +14,8 @@ from yaml.constructor import ConstructorError
 try:
     yaml.Loader = yaml.CLoader
     yaml.Dumper = yaml.CDumper
+    yaml.SafeLoader = yaml.CSafeLoader
+    yaml.SafeDumper = yaml.CSafeDumper
 except Exception:
     pass
 

--- a/salt/utils/yamlloader.py
+++ b/salt/utils/yamlloader.py
@@ -5,7 +5,6 @@ Custom YAML loading in Salt
 
 # Import python libs
 from __future__ import absolute_import, print_function, unicode_literals
-import re
 import warnings
 
 import yaml  # pylint: disable=blacklisted-import

--- a/tests/integration/files/file/base/jinja_filters/data_compare_dicts.sls
+++ b/tests/integration/files/file/base/jinja_filters/data_compare_dicts.sls
@@ -3,4 +3,4 @@
 
 {% set result = dict_one | compare_dicts(dict_two) %}
 
-{% include 'jinja_filters/common.sls' %}
+{% include 'jinja_filters/tojson.sls' %}

--- a/tests/integration/files/file/base/jinja_filters/data_compare_lists.sls
+++ b/tests/integration/files/file/base/jinja_filters/data_compare_lists.sls
@@ -3,4 +3,4 @@
 
 {% set result = list_one | compare_lists(list_two) %}
 
-{% include 'jinja_filters/common.sls' %}
+{% include 'jinja_filters/tojson.sls' %}

--- a/tests/integration/files/file/base/jinja_filters/data_mysql_to_dict.sls
+++ b/tests/integration/files/file/base/jinja_filters/data_mysql_to_dict.sls
@@ -6,4 +6,4 @@
 
 {% set result = test_mysql_output | mysql_to_dict('Info') %}
 
-{% include 'jinja_filters/common.sls' %}
+{% include 'jinja_filters/tojson.sls' %}

--- a/tests/integration/files/file/base/jinja_filters/network_ipv4.sls
+++ b/tests/integration/files/file/base/jinja_filters/network_ipv4.sls
@@ -1,3 +1,3 @@
 {% set result = ['127.0.0.1', '::1'] | ipv4() %}
 
-{% include 'jinja_filters/common.sls' %}
+{% include 'jinja_filters/tojson.sls' %}

--- a/tests/integration/files/file/base/jinja_filters/network_network_hosts.sls
+++ b/tests/integration/files/file/base/jinja_filters/network_network_hosts.sls
@@ -1,3 +1,3 @@
 {% set result = '192.168.1.0/30' | network_hosts() %}
 
-{% include 'jinja_filters/common.sls' %}
+{% include 'jinja_filters/tojson.sls' %}

--- a/tests/integration/files/file/base/jinja_filters/tojson.sls
+++ b/tests/integration/files/file/base/jinja_filters/tojson.sls
@@ -1,0 +1,4 @@
+test:
+  module.run:
+    - name: test.echo
+    - text: {{ result|tojson }}

--- a/tests/integration/files/file/base/tojson/init.sls
+++ b/tests/integration/files/file/base/tojson/init.sls
@@ -1,4 +1,4 @@
-{%- set data = '{"Zucker": "süß", "Webseite": "https://saltstack.com"}'|load_json -%}
+{%- set data = '{"Der Zucker": "süß", "Die Webseite": "https://saltstack.com"}'|load_json -%}
 {{ pillar['tojson-file'] }}:
   file.managed:
     - source: salt://tojson/template.jinja

--- a/tests/integration/files/file/base/tojson/init.sls
+++ b/tests/integration/files/file/base/tojson/init.sls
@@ -1,0 +1,7 @@
+{%- set data = '{"Zucker": "süß", "Webseite": "https://saltstack.com"}'|load_json -%}
+{{ pillar['tojson-file'] }}:
+  file.managed:
+    - source: salt://tojson/template.jinja
+    - template: jinja
+    - context:
+        data: {{ data|tojson }}

--- a/tests/integration/files/file/base/tojson/template.jinja
+++ b/tests/integration/files/file/base/tojson/template.jinja
@@ -1,0 +1,3 @@
+{%- for a, b in data.items() -%}
+{{ a }} ist {{ b }}.
+{% endfor -%}

--- a/tests/integration/files/file/base/tojson/template.jinja
+++ b/tests/integration/files/file/base/tojson/template.jinja
@@ -1,3 +1,3 @@
-{%- for key in data|sort -%}
+{%- for key in ('Die Webseite', 'Der Zucker') -%}
 {{ key }} ist {{ data[key] }}.
 {% endfor -%}

--- a/tests/integration/files/file/base/tojson/template.jinja
+++ b/tests/integration/files/file/base/tojson/template.jinja
@@ -1,3 +1,3 @@
-{%- for a, b in data.items() -%}
-{{ a }} ist {{ b }}.
+{%- for key in data|sort -%}
+{{ key }} ist {{ data[key] }}.
 {% endfor -%}

--- a/tests/integration/shell/test_cp.py
+++ b/tests/integration/shell/test_cp.py
@@ -84,7 +84,7 @@ class CopyTest(ShellCase, ShellCaseCommonTestsMixin):
                 pipes.quote(minion_testfile)
             ))
 
-            data = eval('\n'.join(ret), {}, {})
+            data = eval('\n'.join(ret), {}, {})  # pylint: disable=eval-used
             for part in six.itervalues(data):
                 self.assertTrue(part[minion_testfile])
 

--- a/tests/integration/shell/test_cp.py
+++ b/tests/integration/shell/test_cp.py
@@ -84,7 +84,7 @@ class CopyTest(ShellCase, ShellCaseCommonTestsMixin):
                 pipes.quote(minion_testfile)
             ))
 
-            data = salt.utils.yaml.safe_load('\n'.join(ret))
+            data = eval('\n'.join(ret), {}, {})
             for part in six.itervalues(data):
                 self.assertTrue(part[minion_testfile])
 

--- a/tests/integration/states/test_file.py
+++ b/tests/integration/states/test_file.py
@@ -692,8 +692,8 @@ class FileTest(ModuleCase, SaltReturnAssertsMixin):
         with salt.utils.files.fopen(test_file) as fp_:
             managed = salt.utils.stringutils.to_unicode(fp_.read())
         expected = textwrap.dedent('''\
-            Zucker ist süß.
             Webseite ist https://saltstack.com.
+            Zucker ist süß.
 
             ''')
         assert managed == expected, '{0!r} != {1!r}'.format(managed, expected)  # pylint: disable=repr-flag-used-in-string

--- a/tests/integration/states/test_file.py
+++ b/tests/integration/states/test_file.py
@@ -656,6 +656,48 @@ class FileTest(ModuleCase, SaltReturnAssertsMixin):
             self.assertIn(
                 'does not exist', ret['comment'])
 
+    def test_managed_unicode_jinja_with_tojson_filter(self):
+        '''
+        Using {{ varname }} with a list or dictionary which contains unicode
+        types on Python 2 will result in Jinja rendering the "u" prefix on each
+        string. This tests that using the "tojson" jinja filter will dump them
+        to a format which can be successfully loaded by our YAML loader.
+
+        The two lines that should end up being rendered are meant to test two
+        issues that would trip up PyYAML if the "tojson" filter were not used:
+
+        1. A unicode string type would be loaded as a unicode literal with the
+           leading "u" as well as the quotes, rather than simply being loaded
+           as the proper unicode type which matches the content of the string
+           literal. In other wordss, u'foo' would be loaded literally as
+           u"u'foo'". This test includes actual non-ascii unicode in one of the
+           strings to confirm that this also handles these international
+           characters properly.
+
+        2. Any unicode string type (such as a URL) which contains a colon would
+           cause a ScannerError in PyYAML, as it would be assumed to delimit a
+           mapping node.
+
+        Dumping the data structure to JSON using the "tojson" jinja filter
+        should produce an inline data structure which is valid YAML and will be
+        loaded properly by our YAML loader.
+        '''
+        test_file = os.path.join(TMP, 'test-tojson.txt')
+        ret = self.run_function(
+            'state.apply',
+            mods='tojson',
+            pillar={'tojson-file': test_file})
+        ret = ret[next(iter(ret))]
+        assert ret['result'], ret
+        with salt.utils.files.fopen(test_file) as fp_:
+            managed = salt.utils.stringutils.to_unicode(fp_.read())
+        expected = textwrap.dedent('''\
+            Zucker ist süß.
+            Webseite ist https://saltstack.com.
+
+            ''')
+        assert managed == expected, '{0!r} != {1!r}'.format(managed, expected)
+
     def test_directory(self):
         '''
         file.directory

--- a/tests/integration/states/test_file.py
+++ b/tests/integration/states/test_file.py
@@ -692,8 +692,8 @@ class FileTest(ModuleCase, SaltReturnAssertsMixin):
         with salt.utils.files.fopen(test_file) as fp_:
             managed = salt.utils.stringutils.to_unicode(fp_.read())
         expected = textwrap.dedent('''\
-            Webseite ist https://saltstack.com.
-            Zucker ist süß.
+            Die Webseite ist https://saltstack.com.
+            Der Zucker ist süß.
 
             ''')
         assert managed == expected, '{0!r} != {1!r}'.format(managed, expected)  # pylint: disable=repr-flag-used-in-string

--- a/tests/integration/states/test_file.py
+++ b/tests/integration/states/test_file.py
@@ -696,7 +696,7 @@ class FileTest(ModuleCase, SaltReturnAssertsMixin):
             Webseite ist https://saltstack.com.
 
             ''')
-        assert managed == expected, '{0!r} != {1!r}'.format(managed, expected)
+        assert managed == expected, '{0!r} != {1!r}'.format(managed, expected)  # pylint: disable=repr-flag-used-in-string
 
     def test_directory(self):
         '''

--- a/tests/unit/modules/test_yumpkg.py
+++ b/tests/unit/modules/test_yumpkg.py
@@ -671,9 +671,8 @@ class YumTestCase(TestCase, LoaderModuleMockMixin):
                 for info in pkg_info_list:
                     self.assertTrue(info['arch'] in ('x86_64', 'i686'))
 
+    @skipIf(not yumpkg.HAS_YUM, 'Could not import yum')
     def test_yum_base_error(self):
-        if not yumpkg.HAS_YUM:
-            sys.modules['yum'] = Mock()
         with patch('yum.YumBase') as mock_yum_yumbase:
             mock_yum_yumbase.side_effect = CommandExecutionError
             with pytest.raises(CommandExecutionError):

--- a/tests/unit/modules/test_yumpkg.py
+++ b/tests/unit/modules/test_yumpkg.py
@@ -3,7 +3,6 @@
 # Import Python Libs
 from __future__ import absolute_import, unicode_literals, print_function
 import os
-import sys
 
 # Import Salt Testing Libs
 from tests.support.mixins import LoaderModuleMockMixin

--- a/tests/unit/templates/test_jinja.py
+++ b/tests/unit/templates/test_jinja.py
@@ -749,7 +749,7 @@ class TestCustomExtensions(TestCase):
                                    '{{ document.foo }}').render(document="{foo: it works}")
         self.assertEqual(rendered, "it works")
 
-        with self.assertRaises(exceptions.TemplateRuntimeError):
+        with self.assertRaises((TypeError, exceptions.TemplateRuntimeError)):
             env.from_string('{% set document = document|load_yaml %}'
                                        '{{ document.foo }}').render(document={"foo": "it works"})
 

--- a/tests/unit/utils/test_jinja.py
+++ b/tests/unit/utils/test_jinja.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+'''
+Tests for salt.utils.jinja
+'''
+# Import Python libs
+from __future__ import absolute_import, unicode_literals, print_function
+
+# Import Salt libs
+import salt.utils.jinja
+from tests.support.unit import TestCase
+
+
+class JinjaTestCase(TestCase):
+    def test_tojson(self):
+        '''
+        Test the tojson filter for those using Jinja < 2.9. Non-ascii unicode
+        content should be dumped with ensure_ascii=True.
+        '''
+        data = {'Non-ascii words': ['süß', 'спам', 'яйца']}
+        result = salt.utils.jinja.tojson(data)
+        expected = '{"Non-ascii words": ["s\\u00fc\\u00df", "\\u0441\\u043f\\u0430\\u043c", "\\u044f\\u0439\\u0446\\u0430"]}'
+        assert result == expected, result

--- a/tests/unit/utils/test_yamlloader.py
+++ b/tests/unit/utils/test_yamlloader.py
@@ -138,29 +138,6 @@ class YamlLoaderTestCase(TestCase):
                   v2: beta
                   v2: betabeta'''))
 
-    def test_yaml_with_unicode_literals(self):
-        '''
-        Test proper loading of unicode literals
-        '''
-        self.assert_matches(
-            self.render_yaml(textwrap.dedent('''\
-                foo:
-                  a: Д
-                  b: {'a': u'\\u0414'}''')),
-            {'foo': {'a': u'\u0414', 'b': {'a': u'\u0414'}}}
-        )
-
-    def test_yaml_with_colon_in_inline_dict(self):
-        '''
-        Test proper loading of unicode literal strings in inline dicts
-        '''
-        self.assert_matches(
-            self.render_yaml(textwrap.dedent('''\
-                foo:
-                  b: {u'c': u'https://foo.com'}''')),
-            {'foo': {'b': {'c': 'https://foo.com'}}}
-        )
-
     def test_yaml_with_plain_scalars(self):
         '''
         Test that plain (i.e. unqoted) string and non-string scalars are


### PR DESCRIPTION
In earlier releases, the below was considered valid usage in Python 2, assuming that `data` was a dictionary containing keys/values which are `unicode` types:


```yaml
/etc/foo.conf:
  file.managed:
    - source: salt://foo.conf.jinja
    - template: jinja
    - context:
        data: {{ data }}
```

Jinja will render the unicode string types in Python 2 with the "u" prefix (e.g. `{u'foo': u'bar'}`. While not valid YAML, earlier releases would successfully load these values.

This pull request drops this support, effective in the upcoming Fluorine release. Instead, it will now be necessary to use Jinja's ["tojson" filter](http://jinja.pocoo.org/docs/2.10/templates/#tojson).


```yaml
/etc/foo.conf:
  file.managed:
    - source: salt://foo.conf.jinja
    - template: jinja
    - context:
        data: {{ data|tojson }}
```

The ["tojson" filter](http://jinja.pocoo.org/docs/2.10/templates/#tojson) was added to Jinja in version 2.9, but several LTS releases (RHEL 7, Ubuntu 14.04, etc.) ship with earlier versions in their repositories. Therefore, this PR also adds an implementation of this filter, which will be used if Jinja doesn't already provide it (when it does, the upstream version of the filter will be used).

These changes allow Salt's custom YAML SafeLoader to use the libyaml versions of PyYAML's SafeLoader and SafeDumper (i.e. ``yaml.CSafeLoader`` and ``yaml.CSafeDumper``) if PyYAML was built with libyaml support.

Thanks to @jacksontj for working with me on this.