### PR TITLE
Add new netmiko and junos functions to the napalm module

### DIFF
--- a/salt/modules/napalm.py
+++ b/salt/modules/napalm.py
@@ -33,6 +33,12 @@ try:
 except ImportError:
     HAS_NETMIKO_HELPERS = False
 
+try:
+    import jxmlease
+    HAS_JXMLEASE = True
+except ImportError:
+    HAS_JXMLEASE = False
+
 # ----------------------------------------------------------------------------------------------------------------------
 # module properties
 # ----------------------------------------------------------------------------------------------------------------------
@@ -95,6 +101,46 @@ def _get_netmiko_args(optional_args):
             pass
     # Return these arguments for use with establishing Netmiko SSH connection
     return netmiko_optional_args
+
+
+def _inject_junos_proxy(napalm_device):
+    '''
+    Inject the junos.conn key into the __proxy__, reusing the existing NAPALM
+    connection to the Junos device.
+    '''
+    def _ret_device():
+        return napalm_device['DRIVER'].device
+    __proxy__['junos.conn'] = _ret_device
+    # Injecting the junos.conn key into the __proxy__ object, we can then
+    # access the features that already exist into the junos module, as long
+    # as the rest of the dependencies are installed (jxmlease).
+    # junos-eznc is already installed, as part of NAPALM, and the napalm
+    # driver for junos already makes use of the Device class from this lib.
+    # So pointing the __proxy__ object to this object already loaded into
+    # memory, we can go and re-use the features from the existing junos
+    # Salt module.
+
+
+def _junos_prep_fun(napalm_device):
+    '''
+    Prepare the Junos function.
+    '''
+    if __grains__['os'] != 'junos':
+        return {
+            'out': None,
+            'result': False,
+            'comment': 'This function is only available on Junos'
+        }
+    if not HAS_JXMLEASE:
+        return {
+            'out': None,
+            'result': False,
+            'comment': 'Please install jxmlease (``pip install jxmlease``) to be able to use this function.'
+        }
+    _inject_junos_proxy(napalm_device)
+    return {
+        'result': True
+    }
 
 # ----------------------------------------------------------------------------------------------------------------------
 # callable functions
@@ -437,6 +483,127 @@ def netmiko_multi_call(*methods, **kwargs):
 
 
 @proxy_napalm_wrap
+def netmiko_commands(*commands, **kwargs):
+    '''
+    .. versionadded:: Fluorine
+
+    Invoke one or more commands to be executed on the remote device, via Netmiko.
+    Returns a list of strings, with the output from each command.
+
+    commands
+        A list of commands to be executed.
+
+    expect_string
+        Regular expression pattern to use for determining end of output.
+        If left blank will default to being based on router prompt.
+
+    delay_factor: ``1``
+        Multiplying factor used to adjust delays (default: ``1``).
+
+    max_loops: ``500``
+        Controls wait time in conjunction with delay_factor. Will default to be
+        based upon self.timeout.
+
+    auto_find_prompt: ``True``
+        Whether it should try to auto-detect the prompt (default: ``True``).
+
+    strip_prompt: ``True``
+        Remove the trailing router prompt from the output (default: ``True``).
+
+    strip_command: ``True``
+        Remove the echo of the command from the output (default: ``True``).
+
+    normalize: ``True``
+        Ensure the proper enter is sent at end of command (default: ``True``).
+
+    use_textfsm: ``False``
+        Process command output through TextFSM template (default: ``False``).
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' napalm.netmiko_commands 'show version' 'show interfaces'
+    '''
+    conn = netmiko_conn(**kwargs)
+    ret = []
+    for cmd in commands:
+        ret.append(conn.send_command(cmd))
+    return ret
+
+
+@proxy_napalm_wrap
+def netmiko_config(*config_commands, **kwargs):
+    '''
+    .. versionadded:: Fluorine
+
+    Load a list of configuration commands on the remote device, via Netmiko.
+
+    .. warning::
+
+        Please remember that ``netmiko`` does not have any rollback safeguards
+        and any configuration change will be directly loaded into the running
+        config if the platform doesn't have the concept of ``candidate`` config.
+
+        On Junos, or other platforms that have this capability, the changes will
+        not be loaded into the running config, and the user must set the
+        ``commit`` argument to ``True`` to transfer the changes from the
+        candidate into the running config before exiting.
+
+    config_commands
+        A list of configuration commands to be loaded on the remote device.
+
+    config_file
+        Read the configuration commands from a file. The file can equally be a
+        template that can be rendered using the engine of choice (see
+        ``template_engine``).
+
+        This can be specified using the absolute path to the file, or using one
+        of the following URL schemes:
+
+        - ``salt://``, to fetch the file from the Salt fileserver.
+        - ``http://`` or ``https://``
+        - ``ftp://``
+        - ``s3://``
+        - ``swift://``
+
+    exit_config_mode: ``True``
+        Determines whether or not to exit config mode after complete.
+
+    delay_factor: ``1``
+        Factor to adjust delays.
+
+    max_loops: ``150``
+        Controls wait time in conjunction with delay_factor (default: ``150``).
+
+    strip_prompt: ``False``
+        Determines whether or not to strip the prompt (default: ``False``).
+
+    strip_command: ``False``
+        Determines whether or not to strip the command (default: ``False``).
+
+    config_mode_command
+        The command to enter into config mode.
+
+    commit: ``False``
+        Commit the configuration changes before exiting the config mode. This
+        option is by default disabled, as many platforms don't have this
+        capability natively.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' napalm.netmiko_config 'set system ntp peer 1.2.3.4' commit=True
+        salt '*' napalm.netmiko_config https://bit.ly/2sgljCB
+    '''
+    netmiko_kwargs = netmiko_args()
+    kwargs.update(netmiko_kwargs)
+    return __salt__['netmiko.send_config'](config_commands=config_commands,
+                                           **kwargs)
+
+
+@proxy_napalm_wrap
 def netmiko_conn(**kwargs):
     '''
     .. versionadded:: Fluorine
@@ -460,3 +627,237 @@ def netmiko_conn(**kwargs):
     netmiko_kwargs = netmiko_args()
     kwargs.update(netmiko_kwargs)
     return __salt__['netmiko.get_connection'](**kwargs)
+
+
+@proxy_napalm_wrap
+def junos_rpc(cmd=None, dest=None, format=None, **kwargs):
+    '''
+    .. versionadded:: Fluorine
+
+    Execute an RPC request on the remote Junos device.
+
+    cmd
+        The RPC request to the executed. To determine the RPC request, you can
+        check the from the command line of the device, by executing the usual
+        command followed by ``| display xml rpc``, e.g.,
+        ``show lldp neighbors | display xml rpc``.
+
+    dest
+        Destination file where the RPC output is stored. Note that the file will
+        be stored on the Proxy Minion. To push the files to the Master, use
+        :mod:`cp.push <salt.modules.cp.push>` Execution function.
+
+    format: ``xml``
+        The format in which the RPC reply is received from the device.
+
+    dev_timeout: ``30``
+        The NETCONF RPC timeout.
+
+    filter
+        Used with the ``get-config`` RPC request to filter out the config tree.
+
+    terse: ``False``
+        Whether to return terse output.
+
+        .. note::
+
+            Some RPC requests may not support this argument.
+
+    interface_name
+        Name of the interface to query.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' napalm.junos_rpc get-lldp-neighbors-information
+        salt '*' napalm.junos_rcp get-config <configuration><system><ntp/></system></configuration>
+    '''
+    prep = _junos_prep_fun(napalm_device)
+    if not prep['result']:
+        return prep
+    if not format:
+        format = 'xml'
+    rpc_ret = __salt__['junos.rpc'](cmd=cmd,
+                                    dest=dest,
+                                    format=format,
+                                    **kwargs)
+    rpc_ret['comment'] = rpc_ret.pop('message', '')
+    rpc_ret['result'] = rpc_ret.pop('out', False)
+    rpc_ret['out'] = rpc_ret.pop('rpc_reply', None)
+    # The comment field is "message" in the Junos module
+    return rpc_ret
+
+
+@proxy_napalm_wrap
+def junos_install_os(path=None, **kwargs):
+    '''
+    .. versionadded:: Fluorine
+
+    Installs the given image on the device.
+
+    path
+        The image file source. This argument supports the following URIs:
+
+        - Absolute path on the Minion.
+        - ``salt://`` to fetch from the Salt fileserver.
+        - ``http://`` and ``https://``
+        - ``ftp://``
+        - ``swift:/``
+        - ``s3://``
+
+    dev_timeout: ``30``
+        The NETCONF RPC timeout (in seconds)
+
+    reboot: ``False``
+        Whether to reboot the device after the installation is complete.
+
+    no_copy: ``False``
+        If ``True`` the software package will not be copied to the remote
+        device.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' napalm.junos_install_os salt://images/junos_16_1.tgz reboot=True
+    '''
+    prep = _junos_prep_fun(napalm_device)
+    if not prep['result']:
+        return prep
+    return __salt__['junos.install_os'](path=path, **kwargs)
+
+
+@proxy_napalm_wrap
+def junos_facts(**kwargs):
+    '''
+    .. versionadded:: Fluorine
+
+    The complete list of Junos facts collected by ``junos-eznc``.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' napalm.junos_facts
+    '''
+    prep = _junos_prep_fun(napalm_device)
+    if not prep['result']:
+        return prep
+    facts = dict(napalm_device['DRIVER'].device.facts)
+    if 'version_info' in facts:
+        facts['version_info'] = \
+            dict(facts['version_info'])
+    # For backward compatibility. 'junos_info' is present
+    # only of in newer versions of facts.
+    if 'junos_info' in facts:
+        for re in facts['junos_info']:
+            facts['junos_info'][re]['object'] = \
+                dict(facts['junos_info'][re]['object'])
+    return facts
+
+
+@proxy_napalm_wrap
+def junos_cli(command, format=None, dev_timeout=None, dest=None, **kwargs):
+    '''
+    .. versionadded:: Fluorine
+
+    Execute a CLI command and return the output in the specified format.
+
+    command
+        The command to execute on the Junos CLI.
+
+    format: ``text``
+        Format in which to get the CLI output (either ``text`` or ``xml``).
+
+    dev_timeout: ``30``
+        The NETCONF RPC timeout (in seconds).
+
+    dest
+        Destination file where the RPC output is stored. Note that the file will
+        be stored on the Proxy Minion. To push the files to the Master, use
+        :mod:`cp.push <salt.modules.cp.push>`.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' napalm.junos_cli 'show lldp neighbors'
+    '''
+    prep = _junos_prep_fun(napalm_device)
+    if not prep['result']:
+        return prep
+    return __salt__['junos.cli'](command,
+                                 format=format,
+                                 dev_timeout=dev_timeout,
+                                 dest=dest,
+                                 **kwargs)
+
+
+@proxy_napalm_wrap
+def junos_copy_file(src, dst, **kwargs):
+    '''
+    .. versionadded:: Fluorine
+
+    Copies the file on the remote Junos device.
+
+    src
+        The source file path. This argument accepts the usual Salt URIs (e.g.,
+        ``salt://``, ``http://``, ``https://``, ``s3://``, ``ftp://``, etc.).
+
+    dst
+        The destination path on the device where to copy the file.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' napalm.junos_copy_file https://example.com/junos.cfg /var/tmp/myjunos.cfg
+    '''
+    prep = _junos_prep_fun(napalm_device)
+    if not prep['result']:
+        return prep
+    cached_src = __salt__['cp.cache_file'](src)
+    return __salt__['junos.file_copy'](cached_src, dst)
+
+
+@proxy_napalm_wrap
+def junos_call(fun, *args, **kwargs):
+    '''
+    .. versionadded:: Fluorine
+
+    Execute an arbitrary function from the
+    :mod:`junos execution module <salt.module.junos>`. To check what ``args``
+    and ``kwargs`` you must send to the function, please consult the appropriate
+    documentation.
+
+    fun
+        The name of the function. E.g., ``set_hostname``.
+
+    args
+        List of arguments to send to the ``junos`` function invoked.
+
+    kwargs
+        Dictionary of key-value arguments to send to the ``juno`` function
+        invoked.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' napalm.junos_fun cli 'show system commit'
+    '''
+    prep = _junos_prep_fun(napalm_device)
+    if not prep['result']:
+        return prep
+    if 'junos.' not in fun:
+        mod_fun = 'junos.{}'.format(fun)
+    else:
+        mod_fun = fun
+    if mod_fun not in __salt__:
+        return {
+            'out': None,
+            'result': False,
+            'comment': '{} is not a valid function'.format(fun)
+        }
+    return __salt__[mod_fun](*args, **kwargs)

--- a/salt/modules/napalm.py
+++ b/salt/modules/napalm.py
@@ -34,7 +34,7 @@ except ImportError:
     HAS_NETMIKO_HELPERS = False
 
 try:
-    import jxmlease
+    import jxmlease  # pylint: disable=unused-import
     HAS_JXMLEASE = True
 except ImportError:
     HAS_JXMLEASE = False
@@ -673,7 +673,7 @@ def junos_rpc(cmd=None, dest=None, format=None, **kwargs):
         salt '*' napalm.junos_rpc get-lldp-neighbors-information
         salt '*' napalm.junos_rcp get-config <configuration><system><ntp/></system></configuration>
     '''
-    prep = _junos_prep_fun(napalm_device)
+    prep = _junos_prep_fun(napalm_device)  # pylint: disable=undefined-variable
     if not prep['result']:
         return prep
     if not format:
@@ -722,7 +722,7 @@ def junos_install_os(path=None, **kwargs):
 
         salt '*' napalm.junos_install_os salt://images/junos_16_1.tgz reboot=True
     '''
-    prep = _junos_prep_fun(napalm_device)
+    prep = _junos_prep_fun(napalm_device)  # pylint: disable=undefined-variable
     if not prep['result']:
         return prep
     return __salt__['junos.install_os'](path=path, **kwargs)
@@ -741,10 +741,10 @@ def junos_facts(**kwargs):
 
         salt '*' napalm.junos_facts
     '''
-    prep = _junos_prep_fun(napalm_device)
+    prep = _junos_prep_fun(napalm_device)  # pylint: disable=undefined-variable
     if not prep['result']:
         return prep
-    facts = dict(napalm_device['DRIVER'].device.facts)
+    facts = dict(napalm_device['DRIVER'].device.facts)  # pylint: disable=undefined-variable
     if 'version_info' in facts:
         facts['version_info'] = \
             dict(facts['version_info'])
@@ -784,7 +784,7 @@ def junos_cli(command, format=None, dev_timeout=None, dest=None, **kwargs):
 
         salt '*' napalm.junos_cli 'show lldp neighbors'
     '''
-    prep = _junos_prep_fun(napalm_device)
+    prep = _junos_prep_fun(napalm_device)  # pylint: disable=undefined-variable
     if not prep['result']:
         return prep
     return __salt__['junos.cli'](command,
@@ -814,7 +814,7 @@ def junos_copy_file(src, dst, **kwargs):
 
         salt '*' napalm.junos_copy_file https://example.com/junos.cfg /var/tmp/myjunos.cfg
     '''
-    prep = _junos_prep_fun(napalm_device)
+    prep = _junos_prep_fun(napalm_device)  # pylint: disable=undefined-variable
     if not prep['result']:
         return prep
     cached_src = __salt__['cp.cache_file'](src)
@@ -847,7 +847,7 @@ def junos_call(fun, *args, **kwargs):
 
         salt '*' napalm.junos_fun cli 'show system commit'
     '''
-    prep = _junos_prep_fun(napalm_device)
+    prep = _junos_prep_fun(napalm_device)  # pylint: disable=undefined-variable
     if not prep['result']:
         return prep
     if 'junos.' not in fun:

--- a/salt/modules/netmiko_mod.py
+++ b/salt/modules/netmiko_mod.py
@@ -493,6 +493,7 @@ def exit_config_mode(**kwargs):
 def send_config(config_file=None,
                 config_commands=None,
                 template_engine='jinja',
+                commit=False,
                 source_hash=None,
                 source_hash_name=None,
                 user=None,
@@ -538,6 +539,11 @@ def send_config(config_file=None,
         The template engine to use when rendering the source file. Default:
         ``jinja``. To simply fetch the file without attempting to render, set
         this argument to ``None``.
+
+    commit: ``False``
+        Commit the configuration changes before exiting the config mode. This
+        option is by default disabled, as many platforms don't have this
+        capability natively.
 
     source_hash
         The hash of the ``config_file``
@@ -622,9 +628,19 @@ def send_config(config_file=None,
                 raise CommandExecutionError('Source file {} not found'.format(config_file))
         config_commands = file_str.splitlines()
     if isinstance(config_commands, (six.string_types, six.text_type)):
-        config_commands = [config_commands]
-    call('send_config_set', config_commands=config_commands, **kwargs)
-    return config_commands
+        config_commands = [ config_commands ]
+    kwargs = clean_kwargs(**kwargs)
+    if 'netmiko.conn' in __proxy__:
+        conn = __proxy__['netmiko.conn']()
+    else:
+        conn, kwargs = _prepare_connection(**kwargs)
+    if commit:
+        kwargs['exit_config_mode'] = False  # don't exit config mode after
+        # loading the commands, wait for explicit commit
+    ret = conn.send_config_set(config_commands=config_commands, **kwargs)
+    if commit:
+        ret += conn.commit()
+    return ret
 
 
 def commit(**kwargs):

--- a/salt/modules/netmiko_mod.py
+++ b/salt/modules/netmiko_mod.py
@@ -628,7 +628,7 @@ def send_config(config_file=None,
                 raise CommandExecutionError('Source file {} not found'.format(config_file))
         config_commands = file_str.splitlines()
     if isinstance(config_commands, (six.string_types, six.text_type)):
-        config_commands = [ config_commands ]
+        config_commands = [config_commands]
     kwargs = clean_kwargs(**kwargs)
     if 'netmiko.conn' in __proxy__:
         conn = __proxy__['netmiko.conn']()


### PR DESCRIPTION
To gate functionality from the ``junos`` Execution Module, by reusing the
existing connection from NAPALM.
At the same time, add two more handy functions that leverage the connection via the Netmiko module by reusing the connection arguments: `send_commands` and `send_config`.