### PR TITLE
[ssh] support bootstrapping multiple remote nodes

### DIFF
--- a/salt/cli/ssh.py
+++ b/salt/cli/ssh.py
@@ -16,6 +16,17 @@ class SaltSSH(salt.utils.parsers.SaltSSHOptionParser):
         if '-H' in sys.argv or '--hosts' in sys.argv:
             sys.argv += ['x', 'x']  # Hack: pass a mandatory two options
                                     # that won't be used anyways with -H or --hosts
+        if '--bootstrap' == sys.argv[1]:
+            sys.argv.remove('--bootstrap')
+            sys.argv += ['-r', '\
+                if grep -q "SUSE" /etc/os-release ; then\
+                    zypper -n in python python-xml ;\
+                elif [ -e /etc/debian_version ] ; then\
+                    apt --yes install python ;\
+                else\
+                    echo "please add support for your OS to salt-ssh bootstrap" ;\
+                    exit 6 ;\
+                fi']
         self.parse_args()
         self.setup_logfile_logger()
         verify_log(self.config)


### PR DESCRIPTION
PoC patch to support bootstrapping multiple remote nodes
using salt-ssh raw mode

In case nodes do not have python we can only run raw commands
but we use OS-detection logic
to allow for diverse remote OSes to be bootstrapped in one simple command:
`salt-ssh --bootstrap '*'`

Fixes #48224

maybe it could be moved into salt/client/ssh/client.py
to be in a better place?