### PR TITLE
Add backward-compatibility for older python-consul package dependencies

### DIFF
--- a/tests/unit/pillar/test_consul.py
+++ b/tests/unit/pillar/test_consul.py
@@ -38,7 +38,7 @@ SIMPLE_DICT = {'key1': {'key2': 'val1'}}
 
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
-@skipIf(not consul_pillar.HAS_CONSUL, 'python-consul module not installed')
+@skipIf(not consul_pillar.consul, 'python-consul module not installed')
 class ConsulPillarTestCase(TestCase, LoaderModuleMockMixin):
     '''
     Test cases for salt.pillar.consul_pillar


### PR DESCRIPTION
### What does this PR do?

Bugfix

### Previous Behavior

With an older `python-consul` dependency package you will get this:

```
[ERROR   ] Failed to import pillar consul_pillar, this is due most likely to a syntax error:
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/salt/loader.py", line 1333, in _load_module
    mod = imp.load_module(mod_namespace, fn_, fpath, desc)
  File "/usr/lib/python2.7/site-packages/salt/pillar/consul_pillar.py", line 138, in <module>
    CONSUL_VERSION = consul.__version__
AttributeError: 'module' object has no attribute '__version__'
```

### Tests written?

No
