### PR TITLE
Trigger review requests for team-ssh for roster files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -48,6 +48,7 @@ salt/spm/*                          @saltstack/team-spm
 # Team SSH
 salt/cli/ssh.py                     @saltstack/team-ssh
 salt/client/ssh/*                   @saltstack/team-ssh
+salt/roster/*                       @saltstack/team-ssh
 salt/runners/ssh.py                 @saltstack/team-ssh
 salt/**/thin.py                     @saltstack/team-ssh
 


### PR DESCRIPTION
Changes to files in `salt/roster` should be reviewed by `@saltstack/team-ssh`.

Adding this line to the CODEOWNERS file will trigger the salt-jenkins bot to automatically request a review from team-ssh when changes occur in the roster files.