### PR TITLE
Fix behavior of powercfg module and state

### DIFF
--- a/salt/modules/win_powercfg.py
+++ b/salt/modules/win_powercfg.py
@@ -7,8 +7,10 @@ powercfg.
 
 .. code-block:: bash
 
+    # Set monitor to never turn off
     salt '*' powercfg.set_monitor_timeout 0 power=dc
-    salt '*' powercfg.set_disk_timeout 120 power=ac
+    # Set disk timeout to 120 minutes
+    salt '*' powercfg.set_disk_timeout 7200 power=ac
 '''
 
 # Import Python Libs
@@ -77,154 +79,243 @@ def _set_powercfg_value(scheme, sub_group, setting_guid, power, value):
 
 def set_monitor_timeout(timeout, power="ac", scheme=None):
     '''
-    Set the monitor timeout in minutes for the given power scheme
+    Set the monitor timeout in seconds for the given power scheme
+
+    Args:
+        timeout (int):
+            The amount of time in seconds before the monitor will timeout
+
+        power (str):
+            Set the value for AC or DC (battery). Valid options are:
+            - ``ac`` (AC Power)
+            - ``dc`` (Battery)
+            Default is ``ac``
+
+        scheme (str):
+            The scheme to use, leave as None to use the current. Default is
+            ``None``
+
+    Returns:
+        str: The stdout of the powercfg command
 
     CLI Example:
 
     .. code-block:: bash
 
-        salt '*' powercfg.set_monitor_timeout 30 power=ac
-
-    timeout
-        The amount of time in minutes before the monitor will timeout
-
-    power
-        Should we set the value for AC or DC (battery)? Valid options ac,dc.
-
-    scheme
-        The scheme to use, leave as None to use the current.
-
+        # Sets the monitor timeout to 30 minutes
+        salt '*' powercfg.set_monitor_timeout 1800
     '''
-    return _set_powercfg_value(scheme, "SUB_VIDEO", "VIDEOIDLE", power, timeout)
+    return _set_powercfg_value(
+        scheme=scheme,
+        sub_group="SUB_VIDEO",
+        setting_guid="VIDEOIDLE",
+        power=power,
+        value=timeout)
 
 
 def get_monitor_timeout(scheme=None):
     '''
     Get the current monitor timeout of the given scheme
 
+    Args:
+        scheme (str):
+            The scheme to use, leave as None to use the current. Default is
+            ``None``
+
+    Returns:
+        dict: A dictionary of both the AC and DC settings
+
     CLI Example:
 
     .. code-block:: bash
 
         salt '*' powercfg.get_monitor_timeout
-
-    scheme
-        The scheme to use, leave as None to use the current.
     '''
-    return _get_powercfg_minute_values(scheme, "SUB_VIDEO", "VIDEOIDLE", "Turn off display after")
+    return _get_powercfg_minute_values(
+        scheme=scheme,
+        guid="SUB_VIDEO",
+        subguid="VIDEOIDLE",
+        safe_name="Turn off display after")
 
 
 def set_disk_timeout(timeout, power="ac", scheme=None):
     '''
-    Set the disk timeout in minutes for the given power scheme
+    Set the disk timeout in seconds for the given power scheme
+
+    Args:
+        timeout (int):
+            The amount of time in seconds before the disk will timeout
+
+        power (str):
+            Set the value for AC or DC (battery). Valid options are:
+            - ``ac`` (AC Power)
+            - ``dc`` (Battery)
+            Default is ``ac``
+
+        scheme (str):
+            The scheme to use, leave as None to use the current. Default is
+            ``None``
+
+    Returns:
+        str: The stdout of the powercfg command
 
     CLI Example:
 
     .. code-block:: bash
 
-        salt '*' powercfg.set_disk_timeout 30 power=dc
-
-    timeout
-        The amount of time in minutes before the disk will timeout
-
-    power
-        Should we set the value for AC or DC (battery)? Valid options ac,dc.
-
-    scheme
-        The scheme to use, leave as None to use the current.
-
+        # Sets the disk timeout to 30 minutes on battery
+        salt '*' powercfg.set_disk_timeout 1800 power=dc
     '''
-    return _set_powercfg_value(scheme, "SUB_DISK", "DISKIDLE", power, timeout)
+    return _set_powercfg_value(
+        scheme=scheme,
+        sub_group="SUB_DISK",
+        setting_guid="DISKIDLE",
+        power=power,
+        value=timeout)
 
 
 def get_disk_timeout(scheme=None):
     '''
     Get the current disk timeout of the given scheme
 
+    Args:
+        scheme (str):
+            The scheme to use, leave as None to use the current. Default is
+            ``None``
+
+    Returns:
+        dict: A dictionary of both the AC and DC settings
+
     CLI Example:
 
     .. code-block:: bash
 
         salt '*' powercfg.get_disk_timeout
-
-    scheme
-        The scheme to use, leave as None to use the current.
     '''
-    return _get_powercfg_minute_values(scheme, "SUB_DISK", "DISKIDLE", "Turn off hard disk after")
+    return _get_powercfg_minute_values(
+        scheme=scheme,
+        guid="SUB_DISK",
+        subguid="DISKIDLE",
+        safe_name="Turn off hard disk after")
 
 
 def set_standby_timeout(timeout, power="ac", scheme=None):
     '''
-    Set the standby timeout in minutes for the given power scheme
+    Set the standby timeout in seconds for the given power scheme
+
+    Args:
+        timeout (int):
+            The amount of time in seconds before the computer sleeps
+
+        power (str):
+            Set the value for AC or DC (battery). Valid options are:
+            - ``ac`` (AC Power)
+            - ``dc`` (Battery)
+            Default is ``ac``
+
+        scheme (str):
+            The scheme to use, leave as None to use the current. Default is
+            ``None``
+
+    Returns:
+        str: The stdout of the powercfg command
 
     CLI Example:
 
     .. code-block:: bash
 
-        salt '*' powercfg.set_standby_timeout 30 power=dc
-
-    timeout
-        The amount of time in minutes before the computer sleeps
-
-    power
-        Should we set the value for AC or DC (battery)? Valid options ac,dc.
-
-    scheme
-        The scheme to use, leave as None to use the current.
-
+        # Sets the system standby timeout to 30 minutes on Battery
+        salt '*' powercfg.set_standby_timeout 1800 power=dc
     '''
-    return _set_powercfg_value(scheme, "SUB_SLEEP", "STANDBYIDLE", power, timeout)
+    return _set_powercfg_value(
+        scheme=scheme,
+        sub_group="SUB_SLEEP",
+        setting_guid="STANDBYIDLE",
+        power=power,
+        value=timeout)
 
 
 def get_standby_timeout(scheme=None):
     '''
     Get the current standby timeout of the given scheme
 
+    Args:
+        scheme (str):
+            The scheme to use, leave as None to use the current. Default is
+            ``None``
+
+    Returns:
+        dict: A dictionary of both the AC and DC settings
+
     CLI Example:
 
     .. code-block:: bash
 
         salt '*' powercfg.get_standby_timeout
-
-    scheme
-        The scheme to use, leave as None to use the current.
     '''
-    return _get_powercfg_minute_values(scheme, "SUB_SLEEP", "STANDBYIDLE", "Sleep after")
+    return _get_powercfg_minute_values(
+        scheme=scheme,
+        guid="SUB_SLEEP",
+        subguid="STANDBYIDLE",
+        safe_name="Sleep after")
 
 
 def set_hibernate_timeout(timeout, power="ac", scheme=None):
     '''
-    Set the hibernate timeout in minutes for the given power scheme
+    Set the hibernate timeout in seconds for the given power scheme
+
+    Args:
+        timeout (int):
+            The amount of time in seconds before the computer hibernates
+
+        power (str):
+            Set the value for AC or DC (battery). Valid options are:
+            - ``ac`` (AC Power)
+            - ``dc`` (Battery)
+            Default is ``ac``
+
+        scheme (str):
+            The scheme to use, leave as None to use the current. Default is
+            ``None``
+
+    Returns:
+        str: The stdout of the powercfg command
 
     CLI Example:
 
     .. code-block:: bash
 
-        salt '*' powercfg.set_hibernate_timeout 30 power=pc
-
-    timeout
-        The amount of time in minutes before the computer hibernates
-
-    power
-        Should we set the value for AC or DC (battery)? Valid options ac,dc.
-
-    scheme
-        The scheme to use, leave as None to use the current.
+        # Sets the hibernate timeout to 30 minutes on Battery
+        salt '*' powercfg.set_hibernate_timeout 1800 power=dc
     '''
-    return _set_powercfg_value(scheme, "SUB_SLEEP", "HIBERNATEIDLE", power, timeout)
+    return _set_powercfg_value(
+        scheme=scheme,
+        sub_group="SUB_SLEEP",
+        setting_guid="HIBERNATEIDLE",
+        power=power,
+        value=timeout)
 
 
 def get_hibernate_timeout(scheme=None):
     '''
     Get the current hibernate timeout of the given scheme
 
+    Args:
+        scheme (str):
+            The scheme to use, leave as None to use the current. Default is
+            ``None``
+
+    Returns:
+        dict: A dictionary of both the AC and DC settings
+
     CLI Example:
 
     .. code-block:: bash
 
         salt '*' powercfg.get_hibernate_timeout
-
-    scheme
-        The scheme to use, leave as None to use the current.
     '''
-    return _get_powercfg_minute_values(scheme, "SUB_SLEEP", "HIBERNATEIDLE", "Hibernate after")
+    return _get_powercfg_minute_values(
+        scheme=scheme,
+        guid="SUB_SLEEP",
+        subguid="HIBERNATEIDLE",
+        safe_name="Hibernate after")

--- a/salt/modules/win_powercfg.py
+++ b/salt/modules/win_powercfg.py
@@ -73,6 +73,11 @@ def _set_powercfg_value(scheme, sub_group, setting_guid, power, value):
     '''
     Sets the AC/DC values of a setting with the given power for the given scheme
     '''
+    salt.utils.warn_until(
+        'Fluorine',
+        'This function now expects the timeout value in minutes instead of '
+        'seconds as stated in the documentation. This warning will be removed '
+        'in Salt Fluorine.')
     if scheme is None:
         scheme = _get_current_scheme()
 

--- a/salt/modules/win_powercfg.py
+++ b/salt/modules/win_powercfg.py
@@ -118,7 +118,7 @@ def set_monitor_timeout(timeout, power='ac', scheme=None):
     .. code-block:: bash
 
         # Sets the monitor timeout to 30 minutes
-        salt '*' powercfg.set_monitor_timeout 1800
+        salt '*' powercfg.set_monitor_timeout 30
     '''
     return _set_powercfg_value(
         scheme=scheme,
@@ -190,7 +190,7 @@ def set_disk_timeout(timeout, power='ac', scheme=None):
     .. code-block:: bash
 
         # Sets the disk timeout to 30 minutes on battery
-        salt '*' powercfg.set_disk_timeout 1800 power=dc
+        salt '*' powercfg.set_disk_timeout 30 power=dc
     '''
     return _set_powercfg_value(
         scheme=scheme,
@@ -262,7 +262,7 @@ def set_standby_timeout(timeout, power='ac', scheme=None):
     .. code-block:: bash
 
         # Sets the system standby timeout to 30 minutes on Battery
-        salt '*' powercfg.set_standby_timeout 1800 power=dc
+        salt '*' powercfg.set_standby_timeout 30 power=dc
     '''
     return _set_powercfg_value(
         scheme=scheme,
@@ -333,7 +333,7 @@ def set_hibernate_timeout(timeout, power='ac', scheme=None):
     .. code-block:: bash
 
         # Sets the hibernate timeout to 30 minutes on Battery
-        salt '*' powercfg.set_hibernate_timeout 1800 power=dc
+        salt '*' powercfg.set_hibernate_timeout 30 power=dc
     '''
     return _set_powercfg_value(
         scheme=scheme,

--- a/salt/states/win_powercfg.py
+++ b/salt/states/win_powercfg.py
@@ -138,10 +138,12 @@ def set_timeout(name, value, power='ac', scheme=None):
         ret['changes'] = {name: changes}
         ret['comment'] = '{0} timeout on {1} power set to {2}' \
                          ''.format(name.capitalize(), power.upper(), value)
+        log.debug(ret['comment'])
     else:
         ret['changes'] = {}
         ret['comment'] = 'Failed to set {0} timeout on {1} power to {2}' \
                          ''.format(name, power.upper(), value)
+        log.debug(ret['comment'])
         ret['result'] = False
 
     return ret

--- a/salt/states/win_powercfg.py
+++ b/salt/states/win_powercfg.py
@@ -8,6 +8,7 @@ powercfg.
 
 .. code-block:: yaml
 
+    # Set timeout to 30 minutes on battery power
     monitor:
         powercfg.set_timeout:
             - value: 30
@@ -18,82 +19,129 @@ powercfg.
 from __future__ import absolute_import
 import logging
 
+# Import Salt Libs
+import salt.utils
+
 log = logging.getLogger(__name__)
 
-__virtualname__ = "powercfg"
+__virtualname__ = 'powercfg'
 
 
 def __virtual__():
     '''
     Only work on Windows
     '''
-    if __grains__['os'] == 'Windows':
-        return __virtualname__
-    return False
+    if not salt.utils.is_windows():
+        return False, 'PowerCFG: Module only works on Windows'
+    return __virtualname__
 
 
-def _check_or_set(check_func, set_func, value, power):
-    values = check_func()
-    if values[power] == value:
-        return True
-    else:
-        set_func(value, power)
-        return False
-
-
-def set_timeout(name, value, power="ac", scheme=None):
+def set_timeout(name, value, power='ac', scheme=None):
     '''
-    Set the sleep timeouts of specific items such as disk, monitor.
+    Set the sleep timeouts of specific items such as disk, monitor, etc.
+
+    Args:
+
+        name (str)
+            The setting to change, can be one of the following:
+
+                - ``monitor``
+                - ``disk``
+                - ``standby``
+                - ``hibernate``
+
+        value (int):
+            The amount of time in minutes before the item will timeout
+
+        power (str):
+            Set the value for AC or DC power. Default is ``ac``. Valid options
+            are:
+
+                - ``ac`` (AC Power)
+                - ``dc`` (Battery)
+
+        scheme (str):
+            The scheme to use, leave as ``None`` to use the current. Default is
+            ``None``. This can be the GUID or the Alias for the Scheme. Known
+            Aliases are:
+
+                - ``SCHEME_BALANCED`` - Balanced
+                - ``SCHEME_MAX`` - Power saver
+                - ``SCHEME_MIN`` - High performance
 
     CLI Example:
 
     .. code-block:: yaml
 
+        # Set monitor timeout to 30 minutes on Battery
         monitor:
-            powercfg.set_timeout:
-                - value: 30
-                - power: dc
+          powercfg.set_timeout:
+            - value: 30
+            - power: dc
 
+        # Set disk timeout to 10 minutes on AC Power
         disk:
-            powercfg.set_timeout:
-                - value: 12
-                - power: ac
-
-    name
-        The setting to change, can be one of the following: monitor, disk, standby, hibernate
-
-    timeout
-        The amount of time in minutes before the item will timeout i.e the monitor
-
-    power
-        Should we set the value for AC or DC (battery)? Valid options ac,dc.
-
-    scheme
-        The scheme to use, leave as None to use the current.
+          powercfg.set_timeout:
+            - value: 10
+            - power: ac
     '''
     ret = {'name': name,
            'result': True,
            'comment': '',
            'changes': {}}
 
-    comment = []
+    # Validate name values
+    name = name.lower()
+    if name not in ['monitor', 'disk', 'standby', 'hibernate']:
+        ret['result'] = False
+        ret['comment'] = '"{0}" is not a valid setting'.format(name)
+        log.debug(ret['comment'])
+        return ret
 
-    if name not in ["monitor", "disk", "standby", "hibernate"]:
-        ret["result"] = False
-        comment.append("{0} is not a valid setting".format(name))
-    elif power not in ["ac", "dc"]:
-        ret["result"] = False
-        comment.append("{0} is not a power type".format(power))
+    # Validate power values
+    power = power.lower()
+    if power not in ['ac', 'dc']:
+        ret['result'] = False
+        ret['comment'] = '"{0}" is not a power type'.format(power)
+        log.debug(ret['comment'])
+        return ret
+
+    # Get current settings
+    old = __salt__['powercfg.get_{0}_timeout'.format(name)](scheme=scheme)
+
+    # Check current settings
+    if old[power] == value:
+        ret['comment'] = '{0} timeout on {1} power is already set to {2}' \
+                         ''.format(name.capitalize(), power.upper(), value)
+        return ret
     else:
-        check_func = __salt__["powercfg.get_{0}_timeout".format(name)]
-        set_func = __salt__["powercfg.set_{0}_timeout".format(name)]
+        ret['comment'] = '{0} timeout on {1} power will be set to {2}' \
+                         ''.format(name.capitalize(), power.upper(), value)
 
-        values = check_func(scheme=scheme)
-        if values[power] == value:
-            comment.append("{0} {1} is already set with the value {2}.".format(name, power, value))
-        else:
-            ret['changes'] = {name: {power: value}}
-            set_func(value, power, scheme=scheme)
+    # Check for test=True
+    if __opts__['test']:
+        ret['result'] = None
+        return ret
 
-    ret['comment'] = ' '.join(comment)
+    # Set the timeout value
+    __salt__['powercfg.set_{0}_timeout'.format(name)](
+        timeout=value,
+        power=power,
+        scheme=scheme)
+
+    # Get the setting after the change
+    new = __salt__['powercfg.get_{0}_timeout'.format(name)](scheme=scheme)
+
+    changes = salt.utils.compare_dicts(old, new)
+
+    if changes:
+        ret['changes'] = {name: changes}
+        ret['comment'] = '{0} timeout on {1} power set to {2}' \
+                         ''.format(name.capitalize(), power.upper(), value)
+    else:
+        ret['changes'] = {}
+        ret['comment'] = 'Failed to set {0} timeout on {1} power to {2}' \
+                         ''.format(name, power.upper(), value)
+        ret['result'] = False
+
     return ret

--- a/tests/unit/modules/test_win_powercfg.py
+++ b/tests/unit/modules/test_win_powercfg.py
@@ -21,7 +21,7 @@ from tests.support.mock import (
 @skipIf(NO_MOCK, NO_MOCK_REASON)
 class PowerCfgTestCase(TestCase, LoaderModuleMockMixin):
     '''
-        Validate the powercfg state
+    Validate the powercfg state
     '''
 
     def setup_loader_modules(self):
@@ -40,76 +40,103 @@ class PowerCfgTestCase(TestCase, LoaderModuleMockMixin):
 
     def test_set_monitor_timeout(self):
         '''
-            Test to make sure we can set the monitor timeout value
+        Test to make sure we can set the monitor timeout value
         '''
-        mock = MagicMock()
-        mock.side_effect = ["Power Scheme GUID: 381b4222-f694-41f0-9685-ff5bb260df2e  (Balanced)", self.query_output]
+        mock = MagicMock(return_value=0)
+        mock.side_effect = [
+            'Power Scheme GUID: 381b4222-f694-41f0-9685-ff5bb260df2e  (Balanced)',
+            self.query_output]
+
+        mock_retcode = MagicMock(return_value=0)
 
         with patch.dict(powercfg.__salt__, {'cmd.run': mock}):
-            powercfg.set_monitor_timeout(0, "dc")
-            calls = [
-                call('powercfg /getactivescheme', python_shell=False),
-                call('powercfg /setdcvalueindex 381b4222-f694-41f0-9685-ff5bb260df2e SUB_VIDEO VIDEOIDLE 0', python_shell=False)
-            ]
-            mock.assert_has_calls(calls)
+            with patch.dict(powercfg.__salt__, {'cmd.retcode': mock_retcode}):
+                powercfg.set_monitor_timeout(0, 'dc')
+                mock.assert_called_once_with(
+                    'powercfg /getactivescheme',
+                    python_shell=False)
+                mock_retcode.assert_called_once_with(
+                    'powercfg /setdcvalueindex 381b4222-f694-41f0-9685-ff5bb260df2e SUB_VIDEO VIDEOIDLE 0',
+                    python_shell=False)
 
     def test_set_disk_timeout(self):
         '''
-            Test to make sure we can set the disk timeout value
+        Test to make sure we can set the disk timeout value
         '''
         mock = MagicMock()
-        mock.side_effect = ["Power Scheme GUID: 381b4222-f694-41f0-9685-ff5bb260df2e  (Balanced)", self.query_output]
+        mock.side_effect = [
+            'Power Scheme GUID: 381b4222-f694-41f0-9685-ff5bb260df2e  (Balanced)',
+            self.query_output]
+
+        mock_retcode = MagicMock(return_value=0)
 
         with patch.dict(powercfg.__salt__, {'cmd.run': mock}):
-            powercfg.set_disk_timeout(0, "dc")
-            calls = [
-                call('powercfg /getactivescheme', python_shell=False),
-                call('powercfg /setdcvalueindex 381b4222-f694-41f0-9685-ff5bb260df2e SUB_DISK DISKIDLE 0', python_shell=False)
-            ]
-            mock.assert_has_calls(calls)
+            with patch.dict(powercfg.__salt__, {'cmd.retcode': mock_retcode}):
+                powercfg.set_disk_timeout(0, 'dc')
+                mock.assert_called_once_with(
+                    'powercfg /getactivescheme',
+                    python_shell=False)
+                mock_retcode.assert_called_once_with(
+                    'powercfg /setdcvalueindex 381b4222-f694-41f0-9685-ff5bb260df2e SUB_DISK DISKIDLE 0',
+                    python_shell=False)
 
     def test_set_standby_timeout(self):
         '''
-            Test to make sure we can set the standby timeout value
+        Test to make sure we can set the standby timeout value
         '''
-        mock = MagicMock()
-        mock.side_effect = ["Power Scheme GUID: 381b4222-f694-41f0-9685-ff5bb260df2e  (Balanced)", self.query_output]
+        mock = MagicMock(return_value=0)
+        mock.side_effect = [
+            'Power Scheme GUID: 381b4222-f694-41f0-9685-ff5bb260df2e  (Balanced)',
+            self.query_output]
+
+        mock_retcode = MagicMock(return_value=0)
 
         with patch.dict(powercfg.__salt__, {'cmd.run': mock}):
-            powercfg.set_standby_timeout(0, "dc")
-            calls = [
-                call('powercfg /getactivescheme', python_shell=False),
-                call('powercfg /setdcvalueindex 381b4222-f694-41f0-9685-ff5bb260df2e SUB_SLEEP STANDBYIDLE 0', python_shell=False)
-            ]
-            mock.assert_has_calls(calls)
+            with patch.dict(powercfg.__salt__, {'cmd.retcode': mock_retcode}):
+                powercfg.set_standby_timeout(0, 'dc')
+                mock.assert_called_once_with(
+                    'powercfg /getactivescheme',
+                    python_shell=False)
+                mock_retcode.assert_called_once_with(
+                    'powercfg /setdcvalueindex 381b4222-f694-41f0-9685-ff5bb260df2e SUB_SLEEP STANDBYIDLE 0',
+                    python_shell=False)
 
     def test_set_hibernate_timeout(self):
         '''
-            Test to make sure we can set the hibernate timeout value
+        Test to make sure we can set the hibernate timeout value
         '''
-        mock = MagicMock()
-        mock.side_effect = ["Power Scheme GUID: 381b4222-f694-41f0-9685-ff5bb260df2e  (Balanced)", self.query_output]
+        mock = MagicMock(return_value=0)
+        mock.side_effect = [
+            'Power Scheme GUID: 381b4222-f694-41f0-9685-ff5bb260df2e  (Balanced)',
+            self.query_output]
+
+        mock_retcode = MagicMock(return_value=0)
 
         with patch.dict(powercfg.__salt__, {'cmd.run': mock}):
-            powercfg.set_hibernate_timeout(0, "dc")
-            calls = [
-                call('powercfg /getactivescheme', python_shell=False),
-                call('powercfg /setdcvalueindex 381b4222-f694-41f0-9685-ff5bb260df2e SUB_SLEEP HIBERNATEIDLE 0', python_shell=False)
-            ]
-            mock.assert_has_calls(calls)
+            with patch.dict(powercfg.__salt__, {'cmd.retcode': mock_retcode}):
+                powercfg.set_hibernate_timeout(0, 'dc')
+                mock.assert_called_once_with(
+                    'powercfg /getactivescheme',
+                    python_shell=False)
+                mock_retcode.assert_called_once_with(
+                    'powercfg /setdcvalueindex 381b4222-f694-41f0-9685-ff5bb260df2e SUB_SLEEP HIBERNATEIDLE 0',
+                    python_shell=False)
 
     def test_get_monitor_timeout(self):
         '''
-            Test to make sure we can get the monitor timeout value
+        Test to make sure we can get the monitor timeout value
         '''
         mock = MagicMock()
-        mock.side_effect = ["Power Scheme GUID: 381b4222-f694-41f0-9685-ff5bb260df2e  (Balanced)", self.query_output]
+        mock.side_effect = [
+            'Power Scheme GUID: 381b4222-f694-41f0-9685-ff5bb260df2e  (Balanced)',
+            self.query_output]
 
         with patch.dict(powercfg.__salt__, {'cmd.run': mock}):
             ret = powercfg.get_monitor_timeout()
             calls = [
                 call('powercfg /getactivescheme', python_shell=False),
-                call('powercfg /q 381b4222-f694-41f0-9685-ff5bb260df2e SUB_VIDEO VIDEOIDLE', python_shell=False)
+                call('powercfg /q 381b4222-f694-41f0-9685-ff5bb260df2e SUB_VIDEO VIDEOIDLE',
+                     python_shell=False)
             ]
             mock.assert_has_calls(calls)
 
@@ -117,16 +144,19 @@ class PowerCfgTestCase(TestCase, LoaderModuleMockMixin):
 
     def test_get_disk_timeout(self):
         '''
-            Test to make sure we can get the disk timeout value
+        Test to make sure we can get the disk timeout value
         '''
         mock = MagicMock()
-        mock.side_effect = ["Power Scheme GUID: 381b4222-f694-41f0-9685-ff5bb260df2e  (Balanced)", self.query_output]
+        mock.side_effect = [
+            'Power Scheme GUID: 381b4222-f694-41f0-9685-ff5bb260df2e  (Balanced)',
+            self.query_output]
 
         with patch.dict(powercfg.__salt__, {'cmd.run': mock}):
             ret = powercfg.get_disk_timeout()
             calls = [
                 call('powercfg /getactivescheme', python_shell=False),
-                call('powercfg /q 381b4222-f694-41f0-9685-ff5bb260df2e SUB_DISK DISKIDLE', python_shell=False)
+                call('powercfg /q 381b4222-f694-41f0-9685-ff5bb260df2e SUB_DISK DISKIDLE',
+                     python_shell=False)
             ]
             mock.assert_has_calls(calls)
 
@@ -134,16 +164,19 @@ class PowerCfgTestCase(TestCase, LoaderModuleMockMixin):
 
     def test_get_standby_timeout(self):
         '''
-            Test to make sure we can get the standby timeout value
+        Test to make sure we can get the standby timeout value
         '''
         mock = MagicMock()
-        mock.side_effect = ["Power Scheme GUID: 381b4222-f694-41f0-9685-ff5bb260df2e  (Balanced)", self.query_output]
+        mock.side_effect = [
+            'Power Scheme GUID: 381b4222-f694-41f0-9685-ff5bb260df2e  (Balanced)',
+            self.query_output]
 
         with patch.dict(powercfg.__salt__, {'cmd.run': mock}):
             ret = powercfg.get_standby_timeout()
             calls = [
                 call('powercfg /getactivescheme', python_shell=False),
-                call('powercfg /q 381b4222-f694-41f0-9685-ff5bb260df2e SUB_SLEEP STANDBYIDLE', python_shell=False)
+                call('powercfg /q 381b4222-f694-41f0-9685-ff5bb260df2e SUB_SLEEP STANDBYIDLE',
+                     python_shell=False)
             ]
             mock.assert_has_calls(calls)
 
@@ -151,16 +184,19 @@ class PowerCfgTestCase(TestCase, LoaderModuleMockMixin):
 
     def test_get_hibernate_timeout(self):
         '''
-            Test to make sure we can get the hibernate timeout value
+        Test to make sure we can get the hibernate timeout value
         '''
         mock = MagicMock()
-        mock.side_effect = ["Power Scheme GUID: 381b4222-f694-41f0-9685-ff5bb260df2e  (Balanced)", self.query_output]
+        mock.side_effect = [
+            'Power Scheme GUID: 381b4222-f694-41f0-9685-ff5bb260df2e  (Balanced)',
+            self.query_output]
 
         with patch.dict(powercfg.__salt__, {'cmd.run': mock}):
             ret = powercfg.get_hibernate_timeout()
             calls = [
                 call('powercfg /getactivescheme', python_shell=False),
-                call('powercfg /q 381b4222-f694-41f0-9685-ff5bb260df2e SUB_SLEEP HIBERNATEIDLE', python_shell=False)
+                call('powercfg /q 381b4222-f694-41f0-9685-ff5bb260df2e SUB_SLEEP HIBERNATEIDLE',
+                     python_shell=False)
             ]
             mock.assert_has_calls(calls)
 
@@ -168,17 +204,20 @@ class PowerCfgTestCase(TestCase, LoaderModuleMockMixin):
 
     def test_windows_7(self):
         '''
-            Test to make sure we can get the hibernate timeout value on windows 7
+        Test to make sure we can get the hibernate timeout value on windows 7
         '''
         mock = MagicMock()
-        mock.side_effect = ["Power Scheme GUID: 381b4222-f694-41f0-9685-ff5bb260df2e  (Balanced)", self.query_output]
+        mock.side_effect = [
+            'Power Scheme GUID: 381b4222-f694-41f0-9685-ff5bb260df2e  (Balanced)',
+            self.query_output]
 
         with patch.dict(powercfg.__salt__, {'cmd.run': mock}):
             with patch.dict(powercfg.__grains__, {'osrelease': '7'}):
                 ret = powercfg.get_hibernate_timeout()
                 calls = [
                     call('powercfg /getactivescheme', python_shell=False),
-                    call('powercfg /q 381b4222-f694-41f0-9685-ff5bb260df2e SUB_SLEEP', python_shell=False)
+                    call('powercfg /q 381b4222-f694-41f0-9685-ff5bb260df2e SUB_SLEEP',
+                         python_shell=False)
                 ]
                 mock.assert_has_calls(calls)
 
@@ -186,30 +225,29 @@ class PowerCfgTestCase(TestCase, LoaderModuleMockMixin):
 
     def test_set_hibernate_timeout_scheme(self):
         '''
-            Test to make sure we can set the hibernate timeout value
+        Test to make sure we can set the hibernate timeout value
         '''
-        mock = MagicMock()
+        mock = MagicMock(return_value=0)
         mock.side_effect = [self.query_output]
 
-        with patch.dict(powercfg.__salt__, {'cmd.run': mock}):
-            powercfg.set_hibernate_timeout(0, "dc", scheme="SCHEME_MIN")
-            calls = [
-                call('powercfg /setdcvalueindex SCHEME_MIN SUB_SLEEP HIBERNATEIDLE 0', python_shell=False)
-            ]
-            mock.assert_has_calls(calls)
+        with patch.dict(powercfg.__salt__, {'cmd.retcode': mock}):
+            powercfg.set_hibernate_timeout(0, 'dc', scheme='SCHEME_MIN')
+            mock.assert_called_once_with(
+                'powercfg /setdcvalueindex SCHEME_MIN SUB_SLEEP HIBERNATEIDLE 0',
+                python_shell=False)
 
     def test_get_hibernate_timeout_scheme(self):
         '''
-            Test to make sure we can get the hibernate timeout value with a specified scheme
+        Test to make sure we can get the hibernate timeout value with a
+        specified scheme
         '''
         mock = MagicMock()
         mock.side_effect = [self.query_output]
 
         with patch.dict(powercfg.__salt__, {'cmd.run': mock}):
-            ret = powercfg.get_hibernate_timeout(scheme="SCHEME_MIN")
-            calls = [
-                call('powercfg /q SCHEME_MIN SUB_SLEEP HIBERNATEIDLE', python_shell=False)
-            ]
-            mock.assert_has_calls(calls)
+            ret = powercfg.get_hibernate_timeout(scheme='SCHEME_MIN')
+            mock.assert_called_once_with(
+                'powercfg /q SCHEME_MIN SUB_SLEEP HIBERNATEIDLE',
+                python_shell=False)
 
             self.assertEqual({'ac': 30, 'dc': 15}, ret)

--- a/tests/unit/states/test_win_powercfg.py
+++ b/tests/unit/states/test_win_powercfg.py
@@ -27,36 +27,71 @@ class PowerCfgTestCase(TestCase, LoaderModuleMockMixin):
 
     def test_set_monitor(self):
         '''
-            Test to make sure we can set the monitor timeout value
+        Test to make sure we can set the monitor timeout value
         '''
-        ret = {'changes': {'monitor': {'ac': 0}}, 'comment': '', 'name': 'monitor', 'result': True}
-        monitor_val = {"ac": 45, "dc": 22}
-        with patch.dict(powercfg.__salt__, {"powercfg.get_monitor_timeout": MagicMock(return_value=monitor_val),
-                                             "powercfg.set_monitor_timeout": MagicMock(return_value=True)}):
-
-            self.assertEqual(powercfg.set_timeout("monitor", 0), ret)
+        ret = {
+            'changes': {
+                'monitor': {
+                    'ac': {
+                        'new': 0,
+                        'old': 45
+                    }
+                }
+            },
+            'comment': 'Monitor timeout on AC power set to 0',
+            'name': 'monitor',
+            'result': True}
+        get_monitor_side_effect = MagicMock(side_effect=[{"ac": 45, "dc": 22},
+                                                         {"ac": 0, "dc": 22}])
+        with patch.dict(powercfg.__salt__,
+                        {"powercfg.get_monitor_timeout": get_monitor_side_effect,
+                         "powercfg.set_monitor_timeout": MagicMock(return_value=True)}):
+            with patch.dict(powercfg.__opts__, {"test": False}):
+                self.assertEqual(powercfg.set_timeout("monitor", 0), ret)
 
     def test_set_monitor_already_set(self):
         '''
-            Test to make sure we can set the monitor timeout value
+        Test to make sure we can set the monitor timeout value
         '''
-        ret = {'changes': {}, 'comment': 'monitor ac is already set with the value 0.', 'name': 'monitor', 'result': True}
-        monitor_val = {"ac": 0, "dc": 0}
-        with patch.dict(powercfg.__salt__, {"powercfg.get_monitor_timeout": MagicMock(return_value=monitor_val),
-                                             "powercfg.set_monitor_timeout": MagicMock(return_value=True)}):
-
+        ret = {'changes': {},
+               'comment': 'Monitor timeout on AC power is already set to 0',
+               'name': 'monitor',
+               'result': True}
+        monitor_val = MagicMock(return_value={"ac": 0, "dc": 0})
+        with patch.dict(powercfg.__salt__, {"powercfg.get_monitor_timeout": monitor_val}):
             self.assertEqual(powercfg.set_timeout("monitor", 0), ret)
+
+    def test_set_monitor_test_true_with_change(self):
+        '''
+        Test to make sure set monitor works correctly with test=True with
+        changes
+        '''
+        ret = {'changes': {},
+               'comment': 'Monitor timeout on AC power will be set to 0',
+               'name': 'monitor',
+               'result': None}
+        get_monitor_return_value = MagicMock(return_value={"ac": 45, "dc": 22})
+        with patch.dict(powercfg.__salt__, {"powercfg.get_monitor_timeout": get_monitor_return_value}):
+            with patch.dict(powercfg.__opts__, {"test": True}):
+                self.assertEqual(powercfg.set_timeout("monitor", 0), ret)
 
     def test_fail_invalid_setting(self):
         '''
-            Test to make sure we can set the monitor timeout value
+        Test to make sure we can set the monitor timeout value
         '''
-        ret = {'changes': {}, 'comment': 'fakesetting is not a valid setting', 'name': 'fakesetting', 'result': False}
+        ret = {'changes': {},
+               'comment': '"fakesetting" is not a valid setting',
+               'name': 'fakesetting',
+               'result': False}
         self.assertEqual(powercfg.set_timeout("fakesetting", 0), ret)
 
     def test_fail_invalid_power(self):
         '''
-            Test to make sure we can set the monitor timeout value
+        Test to make sure we can set the monitor timeout value
         '''
-        ret = {'changes': {}, 'comment': 'fakepower is not a power type', 'name': 'monitor', 'result': False}
-        self.assertEqual(powercfg.set_timeout("monitor", 0, power="fakepower"), ret)
+        ret = {'changes': {},
+               'comment': '"fakepower" is not a power type',
+               'name': 'monitor',
+               'result': False}
+        self.assertEqual(powercfg.set_timeout("monitor", 0, power="fakepower"),
+                         ret)


### PR DESCRIPTION
### What does this PR do?
Improves documentation
Uses `'` instead of `"`
Uses minutes for the set function instead of seconds to be consistent with the documentation and the get function which returns everything in minutes.
Warn until Fluorine that the function expects seconds for settings as stated in the docs.
Adds the `test=True` option to the powercfg state module.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/48169

### Previous Behavior
The value that was passed was set directly without converting to seconds. For example, if the user was trying to set a timeout of 120 minutes it was actually setting 120 seconds.

### New Behavior
Now the value can be passed as minutes and it will be converted to seconds.

### Tests written?
Yes

### Commits signed with GPG?
Yes