### PR TITLE
Fixes fileserver maintenance process on Windows

### DIFF
--- a/salt/master.py
+++ b/salt/master.py
@@ -359,13 +359,11 @@ class FileserverUpdate(salt.utils.process.SignalHandlingMultiprocessingProcess):
         self.__init__(
             state['opts'],
             log_queue=state['log_queue'],
-            log_queue_level=state['log_queue_level']
         )
 
     def __getstate__(self):
         return {'opts': self.opts,
                 'log_queue': self.log_queue,
-                'log_queue_level': self.log_queue_level
         }
 
     def fill_buckets(self):


### PR DESCRIPTION
### What does this PR do?

Fixes `FileserverUpdate` class so that the process starts on windows.

This will resolve errors which can be seen when the master starts up in windows kitchen tests:
```
12:55:48          File "<string>", line 1, in <module>
12:55:48          File "C:\Python35\lib\multiprocessing\spawn.py", line 106, in spawn_main
12:55:48            exitcode = _main(fd)
12:55:48          File "C:\Python35\lib\multiprocessing\spawn.py", line 116, in _main
12:55:48            self = pickle.load(from_parent)
12:55:48        EOFError: Ran out of input
```

### Tests written?

No - Fixes existing tests

### Commits signed with GPG?

Yes