### PR TITLE
Disable the "service" module on Manjaro since it is using systemd

### DIFF
--- a/salt/modules/service.py
+++ b/salt/modules/service.py
@@ -35,6 +35,7 @@ def __virtual__():
         'Devuan',
         'Arch',
         'Arch ARM',
+        'Manjaro',
         'ALT',
         'SUSE  Enterprise Server',
         'SUSE',


### PR DESCRIPTION
### What does this PR do?
Disable the `service` module on Manjaro since it is using systemd
### What issues does this PR fix or reference?
Fix  #48316
### Previous Behavior
 The init system used for service module seems to be sysvinit despite systemd is the default init on Manjaro

### Tests written?

No

### Commits signed with GPG?

No