### PR TITLE
Fix stacktrace when registry entries are missing

### DIFF
--- a/salt/modules/proxy.py
+++ b/salt/modules/proxy.py
@@ -377,7 +377,6 @@ def get_proxy_bypass(network_service="Ethernet"):
 
         return reg_val.replace('<local>', '').split(';')
 
-
     out = __salt__['cmd.run']('networksetup -getproxybypassdomains {0}'.format(network_service))
 
     return out.split("\n")

--- a/salt/modules/proxy.py
+++ b/salt/modules/proxy.py
@@ -25,13 +25,13 @@ def __virtual__():
     '''
     if salt.utils.is_darwin() or salt.utils.is_windows():
         return True
-    return (False, 'Module proxy: module only works on Windows or MacOS systems')
+    return False, 'Module proxy: module only works on Windows or MacOS systems'
 
 
-def _get_proxy_osx(function, network_service):
+def _get_proxy_osx(cmd_function, network_service):
     ret = {}
 
-    out = __salt__['cmd.run']('networksetup -{0} {1}'.format(function, network_service))
+    out = __salt__['cmd.run']('networksetup -{0} {1}'.format(cmd_function, network_service))
     match = re.match('Enabled: (.*)\nServer: (.*)\nPort: (.*)\n', out)
     if match is not None:
         g = match.groups()
@@ -41,8 +41,8 @@ def _get_proxy_osx(function, network_service):
     return ret
 
 
-def _set_proxy_osx(function, server, port, user, password, network_service):
-    cmd = 'networksetup -{0} {1} {2} {3}'.format(function, network_service, server, port)
+def _set_proxy_osx(cmd_function, server, port, user, password, network_service):
+    cmd = 'networksetup -{0} {1} {2} {3}'.format(cmd_function, network_service, server, port)
 
     if user is not None and password is not None:
         cmd = cmd + ' On {0} {1}'.format(user, password)
@@ -58,10 +58,10 @@ def _get_proxy_windows(types=None):
     if types is None:
         types = ['http', 'https', 'ftp']
 
-    reg_val = __salt__['reg.read_value']('HKEY_CURRENT_USER',
-                                         r'SOFTWARE\Microsoft\Windows\CurrentVersion\Internet Settings',
-                                         'ProxyServer')
-    servers = reg_val['vdata']
+    servers = __salt__['reg.read_value'](
+        hive='HKEY_CURRENT_USER',
+        key=r'SOFTWARE\Microsoft\Windows\CurrentVersion\Internet Settings',
+        vname='ProxyServer')['vdata']
 
     if servers and "=" in servers:
         split = servers.split(";")
@@ -87,16 +87,19 @@ def _get_proxy_windows(types=None):
                 del ret[key]
 
     # Return enabled info
-    reg_val = __salt__['reg.read_value']('HKEY_CURRENT_USER',
-                                         r'SOFTWARE\Microsoft\Windows\CurrentVersion\Internet Settings',
-                                         'ProxyEnable')
-    enabled = reg_val.get('vdata', 0)
-    ret['enabled'] = True if enabled == 1 else False
+    ret['enabled'] = __salt__['reg.read_value'](
+        hive='HKEY_CURRENT_USER',
+        key=r'SOFTWARE\Microsoft\Windows\CurrentVersion\Internet Settings',
+        vname='ProxyEnable')['vdata'] == 1
 
     return ret
 
 
-def _set_proxy_windows(server, port, types=None, bypass_hosts=None, import_winhttp=True):
+def _set_proxy_windows(server,
+                       port,
+                       types=None,
+                       bypass_hosts=None,
+                       import_winhttp=True):
     if types is None:
         types = ['http', 'https', 'ftp']
 
@@ -104,17 +107,27 @@ def _set_proxy_windows(server, port, types=None, bypass_hosts=None, import_winht
     for t in types:
         server_str += '{0}={1}:{2};'.format(t, server, port)
 
-    __salt__['reg.set_value']('HKEY_CURRENT_USER', r'SOFTWARE\Microsoft\Windows\CurrentVersion\Internet Settings',
-                              'ProxyServer', server_str)
+    __salt__['reg.set_value'](
+        hive='HKEY_CURRENT_USER',
+        key=r'SOFTWARE\Microsoft\Windows\CurrentVersion\Internet Settings',
+        vname='ProxyServer',
+        vdata=server_str)
 
-    __salt__['reg.set_value']('HKEY_CURRENT_USER', r'SOFTWARE\Microsoft\Windows\CurrentVersion\Internet Settings',
-                              'ProxyEnable', 1, vtype='REG_DWORD')
+    __salt__['reg.set_value'](
+        hive='HKEY_CURRENT_USER',
+        key=r'SOFTWARE\Microsoft\Windows\CurrentVersion\Internet Settings',
+        vname='ProxyEnable',
+        vdata=1,
+        vtype='REG_DWORD')
 
     if bypass_hosts is not None:
         bypass_hosts_str = '<local>;{0}'.format(';'.join(bypass_hosts))
 
-        __salt__['reg.set_value']('HKEY_CURRENT_USER', r'SOFTWARE\Microsoft\Windows\CurrentVersion\Internet Settings',
-                                  'ProxyOverride', bypass_hosts_str)
+        __salt__['reg.set_value'](
+            hive='HKEY_CURRENT_USER',
+            key=r'SOFTWARE\Microsoft\Windows\CurrentVersion\Internet Settings',
+            vname='ProxyOverride',
+            vdata=bypass_hosts_str)
 
     if import_winhttp:
         cmd = 'netsh winhttp import proxy source=ie'
@@ -138,15 +151,22 @@ def get_http_proxy(network_service="Ethernet"):
         salt '*' proxy.get_http_proxy Ethernet
     '''
     if __grains__['os'] == 'Windows':
-        return _get_proxy_windows(['http'])
+        return _get_proxy_windows(types=['http'])
 
-    return _get_proxy_osx("getwebproxy", network_service)
+    return _get_proxy_osx(cmd_function="getwebproxy",
+                          network_service=network_service)
 
 
-def set_http_proxy(server, port, user=None, password=None, network_service="Ethernet", bypass_hosts=None):
+def set_http_proxy(server,
+                   port,
+                   user=None,
+                   password=None,
+                   network_service="Ethernet",
+                   bypass_hosts=None):
     '''
-    Sets the http proxy settings. Note: On Windows this will override any other proxy settings you have,
-    the preferred method of updating proxies on windows is using set_proxy.
+    Sets the http proxy settings. Note: On Windows this will override any other
+    proxy settings you have, the preferred method of updating proxies on windows
+    is using set_proxy.
 
     server
         The proxy server to use
@@ -165,8 +185,8 @@ def set_http_proxy(server, port, user=None, password=None, network_service="Ethe
         macOS
 
     bypass_hosts
-        The hosts that are allowed to by pass the proxy. Only used on Windows for other OS's use
-        set_proxy_bypass to edit the bypass hosts.
+        The hosts that are allowed to by pass the proxy. Only used on Windows
+        for other OS's use set_proxy_bypass to edit the bypass hosts.
 
     CLI Example:
 
@@ -175,9 +195,17 @@ def set_http_proxy(server, port, user=None, password=None, network_service="Ethe
         salt '*' proxy.set_http_proxy example.com 1080 user=proxy_user password=proxy_pass network_service=Ethernet
     '''
     if __grains__['os'] == 'Windows':
-        return _set_proxy_windows(server, port, ['http'], bypass_hosts)
+        return _set_proxy_windows(server=server,
+                                  port=port,
+                                  types=['http'],
+                                  bypass_hosts=bypass_hosts)
 
-    return _set_proxy_osx("setwebproxy", server, port, user, password, network_service)
+    return _set_proxy_osx(cmd_function="setwebproxy",
+                          server=server,
+                          port=port,
+                          user=user,
+                          password=password,
+                          network_service=network_service)
 
 
 def get_https_proxy(network_service="Ethernet"):
@@ -195,15 +223,22 @@ def get_https_proxy(network_service="Ethernet"):
         salt '*' proxy.get_https_proxy Ethernet
     '''
     if __grains__['os'] == 'Windows':
-        return _get_proxy_windows(['https'])
+        return _get_proxy_windows(types=['https'])
 
-    return _get_proxy_osx("getsecurewebproxy", network_service)
+    return _get_proxy_osx(cmd_function="getsecurewebproxy",
+                          network_service=network_service)
 
 
-def set_https_proxy(server, port, user=None, password=None, network_service="Ethernet", bypass_hosts=None):
+def set_https_proxy(server,
+                    port,
+                    user=None,
+                    password=None,
+                    network_service="Ethernet",
+                    bypass_hosts=None):
     '''
-    Sets the https proxy settings. Note: On Windows this will override any other proxy settings you have,
-    the preferred method of updating proxies on windows is using set_proxy.
+    Sets the https proxy settings. Note: On Windows this will override any other
+    proxy settings you have, the preferred method of updating proxies on windows
+    is using set_proxy.
 
     server
         The proxy server to use
@@ -222,8 +257,8 @@ def set_https_proxy(server, port, user=None, password=None, network_service="Eth
         macOS
 
     bypass_hosts
-        The hosts that are allowed to by pass the proxy. Only used on Windows for other OS's use
-        set_proxy_bypass to edit the bypass hosts.
+        The hosts that are allowed to by pass the proxy. Only used on Windows
+        for other OS's use set_proxy_bypass to edit the bypass hosts.
 
     CLI Example:
 
@@ -232,9 +267,17 @@ def set_https_proxy(server, port, user=None, password=None, network_service="Eth
         salt '*' proxy.set_https_proxy example.com 1080 user=proxy_user password=proxy_pass network_service=Ethernet
     '''
     if __grains__['os'] == 'Windows':
-        return _set_proxy_windows(server, port, ['https'], bypass_hosts)
+        return _set_proxy_windows(server=server,
+                                  port=port,
+                                  types=['https'],
+                                  bypass_hosts=bypass_hosts)
 
-    return _set_proxy_osx("setsecurewebproxy", server, port, user, password, network_service)
+    return _set_proxy_osx(cmd_function="setsecurewebproxy",
+                          server=server,
+                          port=port,
+                          user=user,
+                          password=password,
+                          network_service=network_service)
 
 
 def get_ftp_proxy(network_service="Ethernet"):
@@ -252,12 +295,18 @@ def get_ftp_proxy(network_service="Ethernet"):
         salt '*' proxy.get_ftp_proxy Ethernet
     '''
     if __grains__['os'] == 'Windows':
-        return _get_proxy_windows(['ftp'])
+        return _get_proxy_windows(types=['ftp'])
 
-    return _get_proxy_osx("getftpproxy", network_service)
+    return _get_proxy_osx(cmd_function="getftpproxy",
+                          network_service=network_service)
 
 
-def set_ftp_proxy(server, port, user=None, password=None, network_service="Ethernet", bypass_hosts=None):
+def set_ftp_proxy(server,
+                  port,
+                  user=None,
+                  password=None,
+                  network_service="Ethernet",
+                  bypass_hosts=None):
     '''
     Sets the ftp proxy settings
 
@@ -278,8 +327,8 @@ def set_ftp_proxy(server, port, user=None, password=None, network_service="Ether
         macOS
 
     bypass_hosts
-        The hosts that are allowed to by pass the proxy. Only used on Windows for other OS's use
-        set_proxy_bypass to edit the bypass hosts.
+        The hosts that are allowed to by pass the proxy. Only used on Windows
+        for other OS's use set_proxy_bypass to edit the bypass hosts.
 
     CLI Example:
 
@@ -288,9 +337,17 @@ def set_ftp_proxy(server, port, user=None, password=None, network_service="Ether
         salt '*' proxy.set_ftp_proxy example.com 1080 user=proxy_user password=proxy_pass network_service=Ethernet
     '''
     if __grains__['os'] == 'Windows':
-        return _set_proxy_windows(server, port, ['ftp'], bypass_hosts)
+        return _set_proxy_windows(server=server,
+                                  port=port,
+                                  types=['ftp'],
+                                  bypass_hosts=bypass_hosts)
 
-    return _set_proxy_osx("setftpproxy", server, port, user, password, network_service)
+    return _set_proxy_osx(cmd_function="setftpproxy",
+                          server=server,
+                          port=port,
+                          user=user,
+                          password=password,
+                          network_service=network_service)
 
 
 def get_proxy_bypass(network_service="Ethernet"):
@@ -309,14 +366,17 @@ def get_proxy_bypass(network_service="Ethernet"):
 
     '''
     if __grains__['os'] == 'Windows':
-        reg_val = __salt__['reg.read_value']('HKEY_CURRENT_USER',
-                                         r'SOFTWARE\Microsoft\Windows\CurrentVersion\Internet Settings',
-                                         'ProxyOverride')
-        bypass_servers = []
-        if reg_val['vdata']:
-            bypass_servers = reg_val['vdata'].replace("<local>", "").split(";")
+        reg_val = __salt__['reg.read_value'](
+            hive='HKEY_CURRENT_USER',
+            key=r'SOFTWARE\Microsoft\Windows\CurrentVersion\Internet Settings',
+            vname='ProxyOverride')['vdata']
 
-        return bypass_servers
+        # `reg.read_value` returns None if the key doesn't exist
+        if reg_val is None:
+            return []
+
+        return reg_val.replace('<local>', '').split(';')
+
 
     out = __salt__['cmd.run']('networksetup -getproxybypassdomains {0}'.format(network_service))
 
@@ -359,7 +419,12 @@ def set_proxy_win(server, port, types=None, bypass_hosts=None):
         The password to use if required by the server
 
     types
-        The types of proxy connections should be setup with this server. Valid types are http and https.
+        The types of proxy connections should be setup with this server. Valid
+        types are:
+
+            - ``http``
+            - ``https``
+            - ``ftp``
 
     bypass_hosts
         The hosts that are allowed to by pass the proxy.
@@ -371,7 +436,10 @@ def set_proxy_win(server, port, types=None, bypass_hosts=None):
         salt '*' proxy.set_http_proxy example.com 1080 types="['http', 'https']"
     '''
     if __grains__['os'] == 'Windows':
-        return _set_proxy_windows(server, port, types, bypass_hosts)
+        return _set_proxy_windows(server=server,
+                                  port=port,
+                                  types=types,
+                                  bypass_hosts=bypass_hosts)
 
 
 def get_proxy_win():

--- a/salt/modules/proxy.py
+++ b/salt/modules/proxy.py
@@ -63,7 +63,7 @@ def _get_proxy_windows(types=None):
                                          'ProxyServer')
     servers = reg_val['vdata']
 
-    if "=" in servers:
+    if servers and "=" in servers:
         split = servers.split(";")
         for s in split:
             if len(s) == 0:
@@ -312,7 +312,9 @@ def get_proxy_bypass(network_service="Ethernet"):
         reg_val = __salt__['reg.read_value']('HKEY_CURRENT_USER',
                                          r'SOFTWARE\Microsoft\Windows\CurrentVersion\Internet Settings',
                                          'ProxyOverride')
-        bypass_servers = reg_val['vdata'].replace("<local>", "").split(";")
+        bypass_servers = []
+        if reg_val['vdata']:
+            bypass_servers = reg_val['vdata'].replace("<local>", "").split(";")
 
         return bypass_servers
 

--- a/tests/unit/modules/test_proxy.py
+++ b/tests/unit/modules/test_proxy.py
@@ -126,65 +126,56 @@ class ProxyTestCase(TestCase, LoaderModuleMockMixin):
 
     def test_get_http_proxy_windows(self):
         '''
-            Test to make sure that we correctly get the current proxy info
-            on Windows
+        Test to make sure that we correctly get the current proxy info on
+        Windows
         '''
+        result = {'vdata': 'http=192.168.0.1:3128;https=192.168.0.2:3128;ftp=192.168.0.3:3128'}
+        mock = MagicMock(return_value=result)
+        expected = {'server': '192.168.0.1',
+                    'port': '3128'}
         with patch.dict(proxy.__grains__, {'os': 'Windows'}):
-            result = {
-                'vdata': 'http=192.168.0.1:3128;https=192.168.0.2:3128;ftp=192.168.0.3:3128'
-            }
-            mock = MagicMock(return_value=result)
-            expected = {
-                'server': '192.168.0.1',
-                'port': '3128'
-            }
             with patch.dict(proxy.__salt__, {'reg.read_value': mock}):
                 out = proxy.get_http_proxy()
-                mock.assert_called_once_with('HKEY_CURRENT_USER',
-                                             'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Internet Settings',
-                                             'ProxyServer')
+                mock.assert_called_once_with(
+                    hive='HKEY_CURRENT_USER',
+                    key='SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Internet Settings',
+                    vname='ProxyServer')
                 self.assertEqual(expected, out)
 
     def test_get_https_proxy_windows(self):
         '''
-            Test to make sure that we correctly get the current proxy info
-            on Windows
+        Test to make sure that we correctly get the current proxy info on
+        Windows
         '''
+        result = {'vdata': 'http=192.168.0.1:3128;https=192.168.0.2:3128;ftp=192.168.0.3:3128'}
+        mock = MagicMock(return_value=result)
+        expected = {'server': '192.168.0.2',
+                    'port': '3128'}
         with patch.dict(proxy.__grains__, {'os': 'Windows'}):
-            result = {
-                'vdata': 'http=192.168.0.1:3128;https=192.168.0.2:3128;ftp=192.168.0.3:3128'
-            }
-            mock = MagicMock(return_value=result)
-            expected = {
-                'server': '192.168.0.2',
-                'port': '3128'
-            }
             with patch.dict(proxy.__salt__, {'reg.read_value': mock}):
                 out = proxy.get_https_proxy()
-                mock.assert_called_once_with('HKEY_CURRENT_USER',
-                                             'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Internet Settings',
-                                             'ProxyServer')
+                mock.assert_called_once_with(
+                    hive='HKEY_CURRENT_USER',
+                    key='SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Internet Settings',
+                    vname='ProxyServer')
                 self.assertEqual(expected, out)
 
     def test_get_ftp_proxy_windows(self):
         '''
-            Test to make sure that we correctly get the current proxy info
-            on Windows
+        Test to make sure that we correctly get the current proxy info on
+        Windows
         '''
+        result = {'vdata': 'http=192.168.0.1:3128;https=192.168.0.2:3128;ftp=192.168.0.3:3128'}
+        mock = MagicMock(return_value=result)
+        expected = {'server': '192.168.0.3',
+                    'port': '3128'}
         with patch.dict(proxy.__grains__, {'os': 'Windows'}):
-            result = {
-                'vdata': 'http=192.168.0.1:3128;https=192.168.0.2:3128;ftp=192.168.0.3:3128'
-            }
-            mock = MagicMock(return_value=result)
-            expected = {
-                'server': '192.168.0.3',
-                'port': '3128'
-            }
             with patch.dict(proxy.__salt__, {'reg.read_value': mock}):
                 out = proxy.get_ftp_proxy()
-                mock.assert_called_once_with('HKEY_CURRENT_USER',
-                                             'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Internet Settings',
-                                             'ProxyServer')
+                mock.assert_called_once_with(
+                    hive='HKEY_CURRENT_USER',
+                    key='SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Internet Settings',
+                    vname='ProxyServer')
                 self.assertEqual(expected, out)
 
     def test_get_all_proxies_macos_fails(self):
@@ -196,201 +187,179 @@ class ProxyTestCase(TestCase, LoaderModuleMockMixin):
 
     def test_get_all_proxies_windows(self):
         '''
-            Test to make sure that we correctly get the current proxy info
-            on Windows
+        Test to make sure that we correctly get the current proxy info on
+        Windows
         '''
+        results = [{'vdata': 'http=192.168.0.1:3128;https=192.168.0.2:3128;ftp=192.168.0.3:3128'},
+                   {'vdata': 1}]
+        mock = MagicMock(side_effect=results)
+        expected = {'enabled': True,
+                    'http': {'server': '192.168.0.1',
+                             'port': '3128'},
+                    'https': {'server': '192.168.0.2',
+                              'port': '3128'},
+                    'ftp': {'server': '192.168.0.3',
+                            'port': '3128'}}
+        calls = [
+            call(hive='HKEY_CURRENT_USER',
+                 key='SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Internet Settings',
+                 vname='ProxyServer'),
+            call(hive='HKEY_CURRENT_USER',
+                 key='SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Internet Settings',
+                 vname='ProxyEnable')]
         with patch.dict(proxy.__grains__, {'os': 'Windows'}):
-            results = [
-                {
-                    'vdata': 'http=192.168.0.1:3128;https=192.168.0.2:3128;ftp=192.168.0.3:3128'
-                },
-                {
-                    'vdata': 1
-                }
-            ]
-            mock = MagicMock(side_effect=results)
-
-            expected = {
-                'enabled': True,
-                'http': {
-                    'server': '192.168.0.1',
-                    'port': '3128'
-                },
-                'https': {
-                    'server': '192.168.0.2',
-                    'port': '3128'
-                },
-                'ftp': {
-                    'server': '192.168.0.3',
-                    'port': '3128'
-                }
-            }
             with patch.dict(proxy.__salt__, {'reg.read_value': mock}):
                 out = proxy.get_proxy_win()
-                calls = [
-                    call('HKEY_CURRENT_USER',
-                         'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Internet Settings',
-                         'ProxyServer'),
-                    call('HKEY_CURRENT_USER',
-                         'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Internet Settings',
-                         'ProxyEnable'),
-                ]
-
                 mock.assert_has_calls(calls)
                 self.assertEqual(expected, out)
 
     def test_set_http_proxy_windows(self):
         '''
-            Test to make sure that we correctly set the proxy info
-            on Windows
+        Test to make sure that we correctly set the proxy info on Windows
         '''
+        calls = [
+            call(hive='HKEY_CURRENT_USER',
+                 key='SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Internet Settings',
+                 vname='ProxyServer',
+                 vdata='http=192.168.0.1:3128;'),
+            call(hive='HKEY_CURRENT_USER',
+                 key='SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Internet Settings',
+                 vname='ProxyEnable',
+                 vdata=1,
+                 vtype='REG_DWORD'),
+            call(hive='HKEY_CURRENT_USER',
+                 key='SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Internet Settings',
+                 vname='ProxyOverride',
+                 vdata='<local>;.moo.com;.salt.com')]
+        mock_reg = MagicMock()
+        mock_cmd = MagicMock()
         with patch.dict(proxy.__grains__, {'os': 'Windows'}):
-            mock_reg = MagicMock()
-            mock_cmd = MagicMock()
-
-            with patch.dict(proxy.__salt__, {'reg.set_value': mock_reg, 'cmd.run': mock_cmd}):
-                out = proxy.set_http_proxy('192.168.0.1', 3128, bypass_hosts=['.moo.com', '.salt.com'])
-
-                calls = [
-                    call('HKEY_CURRENT_USER',
-                         'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Internet Settings',
-                         'ProxyServer',
-                         'http=192.168.0.1:3128;'),
-                    call('HKEY_CURRENT_USER',
-                         'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Internet Settings',
-                         'ProxyEnable',
-                         1,
-                         vtype='REG_DWORD'),
-                    call('HKEY_CURRENT_USER',
-                         'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Internet Settings',
-                         'ProxyOverride',
-                         '<local>;.moo.com;.salt.com')
-                ]
+            with patch.dict(proxy.__salt__, {'reg.set_value': mock_reg,
+                                             'cmd.run': mock_cmd}):
+                out = proxy.set_http_proxy(server='192.168.0.1',
+                                           port=3128,
+                                           bypass_hosts=['.moo.com', '.salt.com'])
                 mock_reg.assert_has_calls(calls)
                 mock_cmd.assert_called_once_with('netsh winhttp import proxy source=ie')
                 self.assertTrue(out)
 
     def test_set_https_proxy_windows(self):
         '''
-            Test to make sure that we correctly set the proxy info
-            on Windows
+        Test to make sure that we correctly set the proxy info on Windows
         '''
+        calls = [
+            call(hive='HKEY_CURRENT_USER',
+                 key='SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Internet Settings',
+                 vname='ProxyServer',
+                 vdata='https=192.168.0.1:3128;'),
+            call(hive='HKEY_CURRENT_USER',
+                 key='SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Internet Settings',
+                 vname='ProxyEnable',
+                 vdata=1,
+                 vtype='REG_DWORD'),
+            call(hive='HKEY_CURRENT_USER',
+                 key='SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Internet Settings',
+                 vname='ProxyOverride',
+                 vdata='<local>;.moo.com;.salt.com')]
+        mock_reg = MagicMock()
+        mock_cmd = MagicMock()
         with patch.dict(proxy.__grains__, {'os': 'Windows'}):
-            mock_reg = MagicMock()
-            mock_cmd = MagicMock()
-
-            with patch.dict(proxy.__salt__, {'reg.set_value': mock_reg, 'cmd.run': mock_cmd}):
-                out = proxy.set_https_proxy('192.168.0.1', 3128, bypass_hosts=['.moo.com', '.salt.com'])
-
-                calls = [
-                    call('HKEY_CURRENT_USER',
-                         'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Internet Settings',
-                         'ProxyServer',
-                         'https=192.168.0.1:3128;'),
-                    call('HKEY_CURRENT_USER',
-                         'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Internet Settings',
-                         'ProxyEnable',
-                         1,
-                         vtype='REG_DWORD'),
-                    call('HKEY_CURRENT_USER',
-                         'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Internet Settings',
-                         'ProxyOverride',
-                         '<local>;.moo.com;.salt.com')
-                ]
+            with patch.dict(proxy.__salt__, {'reg.set_value': mock_reg,
+                                             'cmd.run': mock_cmd}):
+                out = proxy.set_https_proxy(server='192.168.0.1',
+                                            port=3128,
+                                            bypass_hosts=['.moo.com', '.salt.com'])
                 mock_reg.assert_has_calls(calls)
                 mock_cmd.assert_called_once_with('netsh winhttp import proxy source=ie')
                 self.assertTrue(out)
 
     def test_set_ftp_proxy_windows(self):
         '''
-            Test to make sure that we correctly set the proxy info
-            on Windows
+        Test to make sure that we correctly set the proxy info on Windows
         '''
+        calls = [
+            call(hive='HKEY_CURRENT_USER',
+                 key='SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Internet Settings',
+                 vname='ProxyServer',
+                 vdata='ftp=192.168.0.1:3128;'),
+            call(hive='HKEY_CURRENT_USER',
+                 key='SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Internet Settings',
+                 vname='ProxyEnable',
+                 vdata=1,
+                 vtype='REG_DWORD'),
+            call(hive='HKEY_CURRENT_USER',
+                 key='SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Internet Settings',
+                 vname='ProxyOverride',
+                 vdata='<local>;.moo.com;.salt.com')]
+        mock_reg = MagicMock()
+        mock_cmd = MagicMock()
         with patch.dict(proxy.__grains__, {'os': 'Windows'}):
-            mock_reg = MagicMock()
-            mock_cmd = MagicMock()
-
-            with patch.dict(proxy.__salt__, {'reg.set_value': mock_reg, 'cmd.run': mock_cmd}):
-                out = proxy.set_ftp_proxy('192.168.0.1', 3128, bypass_hosts=['.moo.com', '.salt.com'])
-
-                calls = [
-                    call('HKEY_CURRENT_USER',
-                         'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Internet Settings',
-                         'ProxyServer',
-                         'ftp=192.168.0.1:3128;'),
-                    call('HKEY_CURRENT_USER',
-                         'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Internet Settings',
-                         'ProxyEnable',
-                         1,
-                         vtype='REG_DWORD'),
-                    call('HKEY_CURRENT_USER',
-                         'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Internet Settings',
-                         'ProxyOverride',
-                         '<local>;.moo.com;.salt.com')
-                ]
+            with patch.dict(proxy.__salt__, {'reg.set_value': mock_reg,
+                                             'cmd.run': mock_cmd}):
+                out = proxy.set_ftp_proxy(server='192.168.0.1',
+                                          port=3128,
+                                          bypass_hosts=['.moo.com', '.salt.com'])
                 mock_reg.assert_has_calls(calls)
                 mock_cmd.assert_called_once_with('netsh winhttp import proxy source=ie')
                 self.assertTrue(out)
 
     def test_set_proxy_windows(self):
         '''
-            Test to make sure that we correctly set the proxy info
-            on Windows
+        Test to make sure that we correctly set the proxy info on Windows
         '''
+        calls = [
+            call(hive='HKEY_CURRENT_USER',
+                 key='SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Internet Settings',
+                 vname='ProxyServer',
+                 vdata='http=192.168.0.1:3128;https=192.168.0.1:3128;ftp=192.168.0.1:3128;'),
+            call(hive='HKEY_CURRENT_USER',
+                 key='SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Internet Settings',
+                 vname='ProxyEnable',
+                 vdata=1,
+                 vtype='REG_DWORD'),
+            call(hive='HKEY_CURRENT_USER',
+                 key='SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Internet Settings',
+                 vname='ProxyOverride',
+                 vdata='<local>;.moo.com;.salt.com')]
+        mock_reg = MagicMock()
+        mock_cmd = MagicMock()
         with patch.dict(proxy.__grains__, {'os': 'Windows'}):
-            mock_reg = MagicMock()
-            mock_cmd = MagicMock()
-
-            with patch.dict(proxy.__salt__, {'reg.set_value': mock_reg, 'cmd.run': mock_cmd}):
-                out = proxy.set_proxy_win('192.168.0.1', 3128, bypass_hosts=['.moo.com', '.salt.com'])
-
-                calls = [
-                    call('HKEY_CURRENT_USER',
-                         'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Internet Settings',
-                         'ProxyServer',
-                         'http=192.168.0.1:3128;https=192.168.0.1:3128;ftp=192.168.0.1:3128;'),
-                    call('HKEY_CURRENT_USER',
-                         'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Internet Settings',
-                         'ProxyEnable',
-                         1,
-                         vtype='REG_DWORD'),
-                    call('HKEY_CURRENT_USER',
-                         'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Internet Settings',
-                         'ProxyOverride',
-                         '<local>;.moo.com;.salt.com')
-                ]
+            with patch.dict(proxy.__salt__, {'reg.set_value': mock_reg,
+                                             'cmd.run': mock_cmd}):
+                out = proxy.set_proxy_win(server='192.168.0.1',
+                                          port=3128,
+                                          bypass_hosts=['.moo.com', '.salt.com'])
                 mock_reg.assert_has_calls(calls)
                 mock_cmd.assert_called_once_with('netsh winhttp import proxy source=ie')
                 self.assertTrue(out)
 
     def test_set_proxy_windows_no_ftp(self):
         '''
-            Test to make sure that we correctly set the proxy info
-            on Windows
+        Test to make sure that we correctly set the proxy info on Windows
         '''
+        calls = [
+            call(hive='HKEY_CURRENT_USER',
+                 key='SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Internet Settings',
+                 vname='ProxyServer',
+                 vdata='http=192.168.0.1:3128;https=192.168.0.1:3128;'),
+            call(hive='HKEY_CURRENT_USER',
+                 key='SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Internet Settings',
+                 vname='ProxyEnable',
+                 vdata=1,
+                 vtype='REG_DWORD'),
+            call(hive='HKEY_CURRENT_USER',
+                 key='SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Internet Settings',
+                 vname='ProxyOverride',
+                 vdata='<local>;.moo.com;.salt.com')]
+        mock_reg = MagicMock()
+        mock_cmd = MagicMock()
         with patch.dict(proxy.__grains__, {'os': 'Windows'}):
-            mock_reg = MagicMock()
-            mock_cmd = MagicMock()
-
-            with patch.dict(proxy.__salt__, {'reg.set_value': mock_reg, 'cmd.run': mock_cmd}):
-                out = proxy.set_proxy_win('192.168.0.1', 3128, types=['http', 'https'],
+            with patch.dict(proxy.__salt__, {'reg.set_value': mock_reg,
+                                             'cmd.run': mock_cmd}):
+                out = proxy.set_proxy_win(server='192.168.0.1',
+                                          port=3128,
+                                          types=['http', 'https'],
                                           bypass_hosts=['.moo.com', '.salt.com'])
-
-                calls = [
-                    call('HKEY_CURRENT_USER',
-                         'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Internet Settings',
-                         'ProxyServer',
-                         'http=192.168.0.1:3128;https=192.168.0.1:3128;'),
-                    call('HKEY_CURRENT_USER',
-                         'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Internet Settings',
-                         'ProxyEnable',
-                         1,
-                         vtype='REG_DWORD'),
-                    call('HKEY_CURRENT_USER',
-                         'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Internet Settings',
-                         'ProxyOverride',
-                         '<local>;.moo.com;.salt.com')
-                ]
                 mock_reg.assert_has_calls(calls)
                 mock_cmd.assert_called_once_with('netsh winhttp import proxy source=ie')
                 self.assertTrue(out)


### PR DESCRIPTION
### What does this PR do?
Fixes an issue where there is a stacktrace if there are missing registry entries. If a machine has never been set up to use proxy the registry entries are not there.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/48276

### Tests written?
No

### Commits signed with GPG?
Yes