### PR TITLE
Changing debug to info for logging

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -31,7 +31,7 @@ provisioner:
   salt_version: latest
   salt_bootstrap_url: https://bootstrap.saltstack.com
   salt_bootstrap_options: -X -p rsync stable <%= version %>
-  log_level: debug
+  log_level: info
   sudo: true
   require_chef: false
   retry_on_exit_code:


### PR DESCRIPTION
### What does this PR do?
Changes the log level on Kitchen provisioner from debug to info.

### What issues does this PR fix or reference?
logs are pretty large and we need to reduce the amount of space they are consuming in Jenkins

### Commits signed with GPG?
YES!!!!

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
