### PR TITLE
mongo_future_return: MongoDb Connection string support

### DIFF
--- a/salt/modules/config.py
+++ b/salt/modules/config.py
@@ -42,7 +42,6 @@ __proxyenabled__ = ['*']
 
 # Set up the default values for all systems
 DEFAULTS = {'mongo.db': 'salt',
-            'mongo.host': 'salt',
             'mongo.password': '',
             'mongo.port': 27017,
             'mongo.user': '',

--- a/salt/returners/mongo_future_return.py
+++ b/salt/returners/mongo_future_return.py
@@ -176,8 +176,6 @@ def _get_conn(ret):
         if uri and host:
             raise salt.exceptions.SaltConfigurationError(
                     "Mongo returner expects either uri or host configuration. Both were provided")
-
-
         pymongo.uri_parser.parse_uri(uri)
         conn = pymongo.MongoClient(uri)
         mdb = conn.get_database()

--- a/salt/returners/mongo_future_return.py
+++ b/salt/returners/mongo_future_return.py
@@ -174,8 +174,9 @@ def _get_conn(ret):
     # a bunch of these sections that need to be supported
     if uri and PYMONGO_VERSION > _LooseVersion('2.3'):
         if uri and host:
-            warnlog = 'Specified both URI and host. URI {0} will be taken'.format(uri)
-            log.warn(warnlog)
+            raise salt.exceptions.SaltConfigurationError(
+                    "Mongo returner expects either uri or host configuration. Both were provided")
+
 
         pymongo.uri_parser.parse_uri(uri)
         conn = pymongo.MongoClient(uri)
@@ -184,6 +185,9 @@ def _get_conn(ret):
         if PYMONGO_VERSION > _LooseVersion('2.3'):
             conn = pymongo.MongoClient(host, port)
         else:
+            if uri:
+                raise salt.exceptions.SaltConfigurationError(
+                    "pymongo <= 2.3 does not support uri format")
             conn = pymongo.Connection(host, port)
 
         mdb = conn[db_]

--- a/salt/returners/mongo_future_return.py
+++ b/salt/returners/mongo_future_return.py
@@ -7,8 +7,8 @@ Required python modules: pymongo
 
 This returner will send data from the minions to a MongoDB server. MongoDB
 server can be configured by using host, port, db, user and password settings
-or by URI (for pymongo > 2.3). To configure the settings for your MongoDB
-server, add the following lines to the minion config files:
+or by connection string URI (for pymongo > 2.3). To configure the settings
+for your MongoDB server, add the following lines to the minion config files:
 
 .. code-block:: yaml
 
@@ -23,6 +23,23 @@ Or single URI:
 .. code-block:: yaml
 
    mongo.uri: URI
+
+where uri is in the format:
+
+.. code-block:: text
+
+    mongodb://[username:password@]host1[:port1][,host2[:port2],...[,hostN[:portN]]][/[database][?options]]
+
+Example:
+
+.. code-block:: text
+
+    mongodb://db1.example.net:27017/mydatabase
+    mongodb://db1.example.net:27017,db2.example.net:2500/?replicaSet=test
+    mongodb://db1.example.net:27017,db2.example.net:2500/?replicaSet=test&connectTimeoutMS=300000
+
+More information on URI format can be found in
+https://docs.mongodb.com/manual/reference/connection-string/
 
 You can also ask for indexes creation on the most common used fields, which
 should greatly improve performance. Indexes are not created by default.

--- a/salt/returners/mongo_return.py
+++ b/salt/returners/mongo_return.py
@@ -69,12 +69,12 @@ import logging
 import salt.utils.jid
 import salt.returners
 from salt.ext import six
+from salt.utils.versions import LooseVersion as _LooseVersion
 
 # Import third party libs
 try:
     import pymongo
-    version = pymongo.version
-    version = '.'.join(version.split('.')[:2])
+    PYMONGO_VERSION = _LooseVersion(pymongo.version)
     HAS_PYMONGO = True
 except ImportError:
     HAS_PYMONGO = False
@@ -141,7 +141,7 @@ def _get_conn(ret):
     # pymongo versions < 2.3 until then there are
     # a bunch of these sections that need to be supported
 
-    if float(version) > 2.3:
+    if PYMONGO_VERSION > _LooseVersion('2.3'):
         conn = pymongo.MongoClient(host, port)
     else:
         conn = pymongo.Connection(host, port)
@@ -151,7 +151,7 @@ def _get_conn(ret):
         mdb.authenticate(user, password)
 
     if indexes:
-        if float(version) > 2.3:
+        if PYMONGO_VERSION > _LooseVersion('2.3'):
             mdb.saltReturns.create_index('minion')
             mdb.saltReturns.create_index('jid')
 
@@ -193,7 +193,7 @@ def returner(ret):
 
     # again we run into the issue with deprecated code from previous versions
 
-    if float(version) > 2.3:
+    if PYMONGO_VERSION > _LooseVersion('2.3'):
         #using .copy() to ensure original data for load is unchanged
         mdb.saltReturns.insert_one(sdata.copy())
     else:


### PR DESCRIPTION
### What does this PR do?

PR adds MongoDB connection string support (URI), what enables using replica set and other connection options. 
Those features are already supported in pymongo so this PR only adds URI config and passes it to pymongo. 

### What issues does this PR fix or reference?

### Tests written?

No

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
