### PR TITLE
Add user and group to makedirs cmd in file.copy

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -5663,7 +5663,7 @@ def copy(
     if not os.path.isdir(dname):
         if makedirs:
             try:
-                _makedirs(name=name)
+                _makedirs(name=name, user=user, group=group)
             except CommandExecutionError as exc:
                 return _error(ret, 'Drive {0} is not mapped'.format(exc.message))
         else:

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -5663,7 +5663,7 @@ def copy(
     if not os.path.isdir(dname):
         if makedirs:
             try:
-                _makedirs(name=name, user=user, group=group)
+                _makedirs(name=name, user=user, group=group, dir_mode=mode)
             except CommandExecutionError as exc:
                 return _error(ret, 'Drive {0} is not mapped'.format(exc.message))
         else:

--- a/tests/integration/states/test_file.py
+++ b/tests/integration/states/test_file.py
@@ -25,6 +25,7 @@ from tests.support.case import ModuleCase
 from tests.support.unit import skipIf
 from tests.support.paths import FILES, TMP, TMP_STATE_TREE
 from tests.support.helpers import (
+    destructiveTest,
     skip_if_not_root,
     with_system_user_and_group,
     with_tempfile,
@@ -137,6 +138,10 @@ class FileTest(ModuleCase, SaltReturnAssertsMixin):
         '''
         remove files created in previous tests
         '''
+        user = 'salt'
+        if user in str(self.run_function('user.list_users', [user])):
+            self.run_function('user.delete', [user])
+
         for path in (FILEPILLAR, FILEPILLARDEF, FILEPILLARGIT):
             try:
                 os.remove(path)
@@ -2477,6 +2482,23 @@ class FileTest(ModuleCase, SaltReturnAssertsMixin):
 
         os.remove(source)
         os.remove(dest)
+
+    @destructiveTest
+    @with_tempfile
+    def test_file_copy_make_dirs(self, source):
+        '''
+        ensure make_dirs creates correct user perms
+        '''
+        shutil.copyfile(os.path.join(FILES, 'hosts'), source)
+        dest = os.path.join(TMP, 'dir1', 'dir2', 'copied_file.txt')
+
+        user = 'salt'
+        self.run_function('user.add', [user])
+        ret = self.run_state('file.copy', name=dest, source=source, user=user, makedirs=True)
+        file_checks = [dest, os.path.join(TMP, 'dir1'), os.path.join(TMP, 'dir1', 'dir2')]
+        for check in file_checks:
+            ret = self.run_function('file.get_user', [check])
+            assert ret == user
 
     def test_contents_pillar_with_pillar_list(self):
         '''

--- a/tests/integration/states/test_file.py
+++ b/tests/integration/states/test_file.py
@@ -2493,12 +2493,16 @@ class FileTest(ModuleCase, SaltReturnAssertsMixin):
         dest = os.path.join(TMP, 'dir1', 'dir2', 'copied_file.txt')
 
         user = 'salt'
+        mode = '0644'
         self.run_function('user.add', [user])
-        ret = self.run_state('file.copy', name=dest, source=source, user=user, makedirs=True)
+        ret = self.run_state('file.copy', name=dest, source=source, user=user,
+                             makedirs=True, mode=mode)
         file_checks = [dest, os.path.join(TMP, 'dir1'), os.path.join(TMP, 'dir1', 'dir2')]
         for check in file_checks:
-            ret = self.run_function('file.get_user', [check])
-            assert ret == user
+            user_check = self.run_function('file.get_user', [check])
+            mode_check = self.run_function('file.get_mode', [check])
+            assert user_check == user
+            assert salt.utils.normalize_mode(mode_check) == mode
 
     def test_contents_pillar_with_pillar_list(self):
         '''


### PR DESCRIPTION
### What does this PR do?
Ensures we are setting user and group when creating the directories before copying. @terminalmage one thing I was not certain about was the case when a user would use `preserve: True`. Should I be grabbing the user perms of the original file and then create the directories with those permissions? Or would it be expected that the user would not user `preserve` with make_dirs?

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/35595

### Previous Behavior
Created directories with root user/group owners, not the ones specified in the state.

### New Behavior
Creates directories with correct user/group owners 

### Tests written?

Yes
### Commits signed with GPG?

Yes