### PR TITLE
Documentation - Fix the /srv/formulas dir for 'apache-formula' in the documentation

### DIFF
--- a/doc/topics/development/conventions/formulas.rst
+++ b/doc/topics/development/conventions/formulas.rst
@@ -77,9 +77,9 @@ or zip file of the repository. The directory structure is designed to work with
 
     .. code-block:: bash
 
-        mkdir -p /srv/formulas/apache-formula
-        cd /srv/formulas/apache-formula
-        git clone https://github.com/saltstack-formulas/apache-formula.git
+        mkdir -p /srv/formulas
+        cd /srv/formulas
+        git clone https://github.com/saltstack-formulas/apache-formula.git /srv/formulas/apache-formula
 
         # or
 

--- a/doc/topics/development/conventions/formulas.rst
+++ b/doc/topics/development/conventions/formulas.rst
@@ -77,14 +77,14 @@ or zip file of the repository. The directory structure is designed to work with
 
     .. code-block:: bash
 
-        mkdir -p /srv/formulas
-        cd /srv/formulas
+        mkdir -p /srv/formulas/apache-formula
+        cd /srv/formulas/apache-formula
         git clone https://github.com/saltstack-formulas/apache-formula.git
 
         # or
 
-        mkdir -p /srv/formulas
-        cd /srv/formulas
+        mkdir -p /srv/formulas/apache-formula
+        cd /srv/formulas/apache-formula
         wget https://github.com/saltstack-formulas/apache-formula/archive/master.tar.gz
         tar xf apache-formula-master.tar.gz
 


### PR DESCRIPTION
### What does this PR do?
https://docs.saltstack.com/en/2017.7/topics/development/conventions/formulas.html#adding-a-formula-directory-manually

### What issues does this PR fix or reference?
N/A

### Tests written?

No

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
