### PR TITLE
Cisco nxos proxy prompt fix

### DIFF
--- a/salt/proxy/nxos.py
+++ b/salt/proxy/nxos.py
@@ -32,7 +32,7 @@ password
     (REQUIRED) password to use to login with
 
 prompt_name
-    (REQUIRED, this or `prompt_regexp` below, but not both)
+    (REQUIRED, this or `prompt_regex` below, but not both)
     The name in the prompt on the switch.  Recommended to use your
     device's hostname.
 
@@ -63,7 +63,7 @@ prompt_regex
         Flash complete.  Reboot this switch (y/n)? [n]
 
 
-    If neither `prompt_name` nor `prompt_regexp` is specified the prompt will be
+    If neither `prompt_name` nor `prompt_regex` is specified the prompt will be
     defaulted to
 
     .. code-block:: shell
@@ -132,8 +132,8 @@ def init(opts=None):
         opts = __opts__
     try:
         this_prompt = None
-        if 'prompt_regexp' in opts['proxy']:
-            this_prompt = opts['proxy']['prompt_regexp']
+        if 'prompt_regex' in opts['proxy']:
+            this_prompt = opts['proxy']['prompt_regex']
         elif 'prompt_name' in opts['proxy']:
             this_prompt = '{0}.*#'.format(opts['proxy']['prompt_name'])
         else:

--- a/salt/proxy/nxos.py
+++ b/salt/proxy/nxos.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-'''
+r'''
 Proxy Minion for Cisco NX OS Switches
 
 .. versionadded: 2016.11.0

--- a/salt/proxy/nxos.py
+++ b/salt/proxy/nxos.py
@@ -32,8 +32,46 @@ password
     (REQUIRED) password to use to login with
 
 prompt_name
-    (REQUIRED) The name in the prompt on the switch.  By default, use your
-    devices hostname.
+    (REQUIRED, this or `prompt_regexp` below, but not both)
+    The name in the prompt on the switch.  Recommended to use your
+    device's hostname.
+
+prompt_regex
+    (REQUIRED, this or `prompt_name` above, but not both)
+    A regular expression that matches the prompt on the switch
+    and any other possible prompt at which you need the proxy minion
+    to continue sending input.  This feature was specifically developed
+    for situations where the switch may ask for confirmation.  `prompt_name`
+    above would not match these, and so the session would timeout.
+
+    Example:
+
+    .. code-block:: yaml
+
+        dc01-switch-01#.*|\(y\/n\)\?.*
+
+    This should match
+
+    .. code-block:: shell
+
+        dc01-switch-01#
+
+    or
+
+    .. code-block:: shell
+
+        Flash complete.  Reboot this switch (y/n)? [n]
+
+
+    If neither `prompt_name` nor `prompt_regexp` is specified the prompt will be
+    defaulted to
+
+    .. code-block:: shell
+
+        .+#$
+
+    which should match any number of characters followed by a `#` at the end
+    of the line.  This may be far too liberal for most installations.
 
 ssh_args
     Any extra args to use to connect to the switch.
@@ -93,13 +131,22 @@ def init(opts=None):
     if opts is None:
         opts = __opts__
     try:
+        this_prompt = None
+        if 'prompt_regexp' in opts['proxy']:
+            this_prompt = opts['proxy']['prompt_regexp']
+        elif 'prompt_name' in opts['proxy']:
+            this_prompt = '{0}.*#'.format(opts['proxy']['prompt_name'])
+        else:
+            log.warning('nxos proxy configuration does not specify a prompt match.')
+            this_prompt = '.+#$'
+
         DETAILS[_worker_name()] = SSHConnection(
             host=opts['proxy']['host'],
             username=opts['proxy']['username'],
             password=opts['proxy']['password'],
             key_accept=opts['proxy'].get('key_accept', False),
             ssh_args=opts['proxy'].get('ssh_args', ''),
-            prompt='{0}.*#'.format(opts['proxy']['prompt_name']))
+            prompt=this_prompt)
         out, err = DETAILS[_worker_name()].sendline('terminal length 0')
 
     except TerminalException as e:


### PR DESCRIPTION
### What does this PR do?

Makes it easier to execute commands that don't return a standard prompt--for example, firmware upgrades will ask for confirmation.  The current setup just looks for `<hostname>#`.

### What issues does this PR fix or reference?

#48366

### Previous Behavior

The proxy would not recognize prompts other than `<hostname>#`

### New Behavior

A new config option for this proxy was added called `prompt_regex`.  This will be used in place of `prompt_name` if present.  This is treated as a Python regular expression, and thus allows description of any prompt that can take the form of a regexp.

This new parameter is documented in the nxos.py header docstring.

### Tests written?

No

### Commits signed with GPG?

Yes
