### PR TITLE
Detect and preserve line endings

### DIFF
--- a/salt/modules/win_file.py
+++ b/salt/modules/win_file.py
@@ -38,7 +38,8 @@ import glob  # do not remove, used in imported file.py functions
 import salt.ext.six as six  # pylint: disable=import-error,no-name-in-module
 from salt.ext.six.moves.urllib.parse import urlparse as _urlparse  # pylint: disable=import-error,no-name-in-module
 import salt.utils.atomicfile  # do not remove, used in imported file.py functions
-from salt.exceptions import CommandExecutionError, SaltInvocationError
+from salt.exceptions import CommandExecutionError, SaltInvocationError, \
+    get_error_message as _get_error_message
 # pylint: enable=W0611
 
 # Import salt libs

--- a/salt/modules/win_file.py
+++ b/salt/modules/win_file.py
@@ -59,7 +59,7 @@ from salt.modules.file import (check_hash,  # pylint: disable=W0611
         lstat, path_exists_glob, write, pardir, join, HASHES, HASHES_REVMAP,
         comment, uncomment, _add_flags, comment_line, _regex_to_static,
         _get_line_indent, apply_template_on_contents, dirname, basename,
-        list_backups_dir, _assert_occurrence, _starts_till)
+        list_backups_dir, _assert_occurrence, _starts_till, _get_line_sep)
 from salt.modules.file import normpath as normpath_
 
 from salt.utils import namespaced_function as _namespaced_function
@@ -112,7 +112,7 @@ def __virtual__():
             global get_diff, line, _get_flags, extract_hash, comment_line
             global access, copy, readdir, read, rmdir, truncate, replace, search
             global _binary_replace, _get_bkroot, list_backups, restore_backup
-            global _splitlines_preserving_trailing_newline
+            global _splitlines_preserving_trailing_newline, _get_line_sep
             global blockreplace, prepend, seek_read, seek_write, rename, lstat
             global write, pardir, join, _add_flags, apply_template_on_contents
             global path_exists_glob, comment, uncomment, _mkstemp_copy
@@ -183,6 +183,7 @@ def __virtual__():
             normpath_ = _namespaced_function(normpath_, globals())
             _assert_occurrence = _namespaced_function(_assert_occurrence, globals())
             _starts_till = _namespaced_function(_starts_till, globals())
+            _get_line_sep = _namespaced_function(_get_line_sep, globals())
 
         else:
             return False, 'Module win_file: Missing Win32 modules'

--- a/tests/unit/modules/test_file.py
+++ b/tests/unit/modules/test_file.py
@@ -775,6 +775,324 @@ class FileModuleTestCase(TestCase, LoaderModuleMockMixin):
         empty_file.close()
         os.remove(empty_file.name)
 
+    def test_line_delete_win(self):
+        # Create test file
+        temp_file = tempfile.NamedTemporaryFile(delete=False,
+                                                prefix='linetmp_win_',
+                                                mode='w+b')
+        temp_file.write(b'test1\r\ntest2\r\ntest3')
+        temp_file.close()
+        try:
+            filemod.line(path=temp_file.name,
+                         mode='delete',
+                         match='test2')
+            with salt.utils.fopen(temp_file.name, 'rb') as fp:
+                filecontent = fp.read()
+            self.assertEqual(b'test1\r\ntest3', filecontent)
+        finally:
+            # Close and remove the file
+            temp_file.close()
+            os.remove(temp_file.name)
+
+    def test_line_delete_unix(self):
+        # Create test file
+        temp_file = tempfile.NamedTemporaryFile(delete=False,
+                                                prefix='linetmp_unix_',
+                                                mode='w+b')
+        temp_file.write(b'test1\ntest2\ntest3')
+        temp_file.close()
+        try:
+            filemod.line(path=temp_file.name,
+                         mode='delete',
+                         match='test2')
+            with salt.utils.fopen(temp_file.name, 'rb') as fp:
+                filecontent = fp.read()
+            self.assertEqual(b'test1\ntest3', filecontent)
+        finally:
+            # Close and remove the file
+            temp_file.close()
+            os.remove(temp_file.name)
+
+    def test_line_insert_before_win(self):
+        # Create test file
+        temp_file = tempfile.NamedTemporaryFile(delete=False,
+                                                prefix='linetmp_win_',
+                                                mode='w+b')
+        temp_file.write(b'test1\r\ntest2\r\ntest3')
+        temp_file.close()
+        try:
+            filemod.line(path=temp_file.name,
+                         mode='insert',
+                         content='test1.5',
+                         before='test2')
+            with salt.utils.fopen(temp_file.name, 'rb') as fp:
+                filecontent = fp.read()
+            self.assertEqual(b'test1\r\ntest1.5\r\ntest2\r\ntest3', filecontent)
+        finally:
+            # Close and remove the file
+            temp_file.close()
+            os.remove(temp_file.name)
+
+    def test_line_insert_before_unix(self):
+        # Create test file
+        temp_file = tempfile.NamedTemporaryFile(delete=False,
+                                                prefix='linetmp_unix_',
+                                                mode='w+b')
+        temp_file.write(b'test1\ntest2\ntest3')
+        temp_file.close()
+        try:
+            filemod.line(path=temp_file.name,
+                         mode='insert',
+                         content='test1.5',
+                         before='test2')
+            with salt.utils.fopen(temp_file.name, 'rb') as fp:
+                filecontent = fp.read()
+            self.assertEqual(b'test1\ntest1.5\ntest2\ntest3', filecontent)
+        finally:
+            # Close and remove the file
+            temp_file.close()
+            os.remove(temp_file.name)
+
+    def test_line_insert_after_win(self):
+        # Create test file
+        temp_file = tempfile.NamedTemporaryFile(delete=False,
+                                                prefix='linetmp_win_',
+                                                mode='w+b')
+        temp_file.write(b'test1\r\ntest2\r\ntest3')
+        temp_file.close()
+        try:
+            filemod.line(path=temp_file.name,
+                         mode='insert',
+                         content='test2.5',
+                         after='test2')
+            with salt.utils.fopen(temp_file.name, 'rb') as fp:
+                filecontent = fp.read()
+            self.assertEqual(b'test1\r\ntest2\r\ntest2.5\r\ntest3', filecontent)
+        finally:
+            # Close and remove the file
+            temp_file.close()
+            os.remove(temp_file.name)
+
+    def test_line_insert_after_unix(self):
+        # Create test file
+        temp_file = tempfile.NamedTemporaryFile(delete=False,
+                                                prefix='linetmp_unix_',
+                                                mode='w+b')
+        temp_file.write(b'test1\ntest2\ntest3')
+        temp_file.close()
+        try:
+            filemod.line(path=temp_file.name,
+                         mode='insert',
+                         content='test2.5',
+                         after='test2')
+            with salt.utils.fopen(temp_file.name, 'rb') as fp:
+                filecontent = fp.read()
+            self.assertEqual(b'test1\ntest2\ntest2.5\ntest3', filecontent)
+        finally:
+            # Close and remove the file
+            temp_file.close()
+            os.remove(temp_file.name)
+
+    def test_line_insert_start_win(self):
+        # Create test file
+        temp_file = tempfile.NamedTemporaryFile(delete=False,
+                                                prefix='linetmp_win_',
+                                                mode='w+b')
+        temp_file.write(b'test1\r\ntest2\r\ntest3')
+        temp_file.close()
+        try:
+            filemod.line(path=temp_file.name,
+                         mode='insert',
+                         content='test0.5',
+                         location='start')
+            with salt.utils.fopen(temp_file.name, 'rb') as fp:
+                filecontent = fp.read()
+            self.assertEqual(b'test0.5\r\ntest1\r\ntest2\r\ntest3', filecontent)
+        finally:
+            # Close and remove the file
+            temp_file.close()
+            os.remove(temp_file.name)
+
+    def test_line_insert_start_unix(self):
+        # Create test file
+        temp_file = tempfile.NamedTemporaryFile(delete=False,
+                                                prefix='linetmp_unix_',
+                                                mode='w+b')
+        temp_file.write(b'test1\ntest2\ntest3')
+        temp_file.close()
+        try:
+            filemod.line(path=temp_file.name,
+                         mode='insert',
+                         content='test0.5',
+                         location='start')
+            with salt.utils.fopen(temp_file.name, 'rb') as fp:
+                filecontent = fp.read()
+            self.assertEqual(b'test0.5\ntest1\ntest2\ntest3', filecontent)
+        finally:
+            # Close and remove the file
+            temp_file.close()
+            os.remove(temp_file.name)
+
+    def test_line_insert_end_win(self):
+        # Create test file
+        temp_file = tempfile.NamedTemporaryFile(delete=False,
+                                                prefix='linetmp_win_',
+                                                mode='w+b')
+        temp_file.write(b'test1\r\ntest2\r\ntest3')
+        temp_file.close()
+        try:
+            filemod.line(path=temp_file.name,
+                         mode='insert',
+                         content='test3.5',
+                         location='end')
+            with salt.utils.fopen(temp_file.name, 'rb') as fp:
+                filecontent = fp.read()
+            self.assertEqual(b'test1\r\ntest2\r\ntest3\r\ntest3.5', filecontent)
+        finally:
+            # Close and remove the file
+            temp_file.close()
+            os.remove(temp_file.name)
+
+    def test_line_insert_end_unix(self):
+        # Create test file
+        temp_file = tempfile.NamedTemporaryFile(delete=False,
+                                                prefix='linetmp_unix_',
+                                                mode='w+b')
+        temp_file.write(b'test1\ntest2\ntest3')
+        temp_file.close()
+        try:
+            filemod.line(path=temp_file.name,
+                         mode='insert',
+                         content='test3.5',
+                         location='end')
+            with salt.utils.fopen(temp_file.name, 'rb') as fp:
+                filecontent = fp.read()
+            self.assertEqual(b'test1\ntest2\ntest3\ntest3.5', filecontent)
+        finally:
+            # Close and remove the file
+            temp_file.close()
+            os.remove(temp_file.name)
+
+    def test_line_replace_win(self):
+        # Create test file
+        temp_file = tempfile.NamedTemporaryFile(delete=False,
+                                                prefix='linetmp_win_',
+                                                mode='w+b')
+        temp_file.write(b'test1\r\ntest2\r\ntest3')
+        temp_file.close()
+        try:
+            filemod.line(path=temp_file.name,
+                         mode='replace',
+                         content='test2 new',
+                         match='test2')
+            with salt.utils.fopen(temp_file.name, 'rb') as fp:
+                filecontent = fp.read()
+            self.assertEqual(b'test1\r\ntest2 new\r\ntest3', filecontent)
+        finally:
+            # Close and remove the file
+            temp_file.close()
+            os.remove(temp_file.name)
+
+    def test_line_replace_unix(self):
+        # Create test file
+        temp_file = tempfile.NamedTemporaryFile(delete=False,
+                                                prefix='linetmp_unix_',
+                                                mode='w+b')
+        temp_file.write(b'test1\ntest2\ntest3')
+        temp_file.close()
+        try:
+            changes = filemod.line(path=temp_file.name,
+                                   mode='replace',
+                                   content='test2 new',
+                                   match='test2')
+            with salt.utils.fopen(temp_file.name, 'rb') as fp:
+                filecontent = fp.read()
+            self.assertEqual(b'test1\ntest2 new\ntest3', filecontent)
+        finally:
+            # Close and remove the file
+            temp_file.close()
+            os.remove(temp_file.name)
+
+    def test_line_ensure_before_win(self):
+        # Create test file
+        temp_file = tempfile.NamedTemporaryFile(delete=False,
+                                                prefix='linetmp_win_',
+                                                mode='w+b')
+        temp_file.write(b'test1\r\ntest2\r\ntest3')
+        temp_file.close()
+        try:
+            filemod.line(path=temp_file.name,
+                         mode='ensure',
+                         content='test1.5',
+                         before='test2')
+            with salt.utils.fopen(temp_file.name, 'rb') as fp:
+                filecontent = fp.read()
+            self.assertEqual(b'test1\r\ntest1.5\r\ntest2\r\ntest3', filecontent)
+        finally:
+            # Close and remove the file
+            temp_file.close()
+            os.remove(temp_file.name)
+
+    def test_line_ensure_before_unix(self):
+        # Create test file
+        temp_file = tempfile.NamedTemporaryFile(delete=False,
+                                                prefix='linetmp_unix_',
+                                                mode='w+b')
+        temp_file.write(b'test1\ntest2\ntest3')
+        temp_file.close()
+        try:
+            filemod.line(path=temp_file.name,
+                         mode='ensure',
+                         content='test1.5',
+                         before='test2')
+            with salt.utils.fopen(temp_file.name, 'rb') as fp:
+                filecontent = fp.read()
+            self.assertEqual(b'test1\ntest1.5\ntest2\ntest3', filecontent)
+        finally:
+            # Close and remove the file
+            temp_file.close()
+            os.remove(temp_file.name)
+
+    def test_line_ensure_after_win(self):
+        # Create test file
+        temp_file = tempfile.NamedTemporaryFile(delete=False,
+                                                prefix='linetmp_win_',
+                                                mode='w+b')
+        temp_file.write(b'test1\r\ntest2\r\ntest3')
+        temp_file.close()
+        try:
+            filemod.line(path=temp_file.name,
+                         mode='ensure',
+                         content='test2.5',
+                         after='test2')
+            with salt.utils.fopen(temp_file.name, 'rb') as fp:
+                filecontent = fp.read()
+            self.assertEqual(b'test1\r\ntest2\r\ntest2.5\r\ntest3', filecontent)
+        finally:
+            # Close and remove the file
+            temp_file.close()
+            os.remove(temp_file.name)
+
+    def test_line_ensure_after_unix(self):
+        # Create test file
+        temp_file = tempfile.NamedTemporaryFile(delete=False,
+                                                prefix='linetmp_unix_',
+                                                mode='w+b')
+        temp_file.write(b'test1\ntest2\ntest3')
+        temp_file.close()
+        try:
+            filemod.line(path=temp_file.name,
+                         mode='ensure',
+                         content='test2.5',
+                         after='test2')
+            with salt.utils.fopen(temp_file.name, 'rb') as fp:
+                filecontent = fp.read()
+            self.assertEqual(b'test1\ntest2\ntest2.5\ntest3', filecontent)
+        finally:
+            # Close and remove the file
+            temp_file.close()
+            os.remove(temp_file.name)
+
 
 class FileBasicsTestCase(TestCase, LoaderModuleMockMixin):
     def setup_loader_modules(self):


### PR DESCRIPTION
### What does this PR do?
Detects the line endings for the file and uses those to parse the file. Preserves the line endings when the file is written.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/48110

### Previous Behavior
On Windows, files with Unix line endings were writing back an empty file.

### New Behavior
Now the file is edited properly.

### Tests written?
No

### Commits signed with GPG?
Yes