### PR TITLE
[2018.3] reset file_roots for renderers after compile_pillar

### DIFF
--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -1037,6 +1037,11 @@ class Pillar(object):
         decrypt_errors = self.decrypt_pillar(pillar)
         if decrypt_errors:
             pillar.setdefault('_errors', []).extend(decrypt_errors)
+
+        # Reset the file_roots for the renderers
+        for mod_name in sys.modules:
+            if mod_name.startswith('salt.loaded.int.render.'):
+                sys.modules[mod_name].__opts__['file_roots'] = self.actual_file_roots
         return pillar
 
     def decrypt_pillar(self, pillar):

--- a/tests/integration/runners/test_state.py
+++ b/tests/integration/runners/test_state.py
@@ -542,3 +542,88 @@ class OrchEventTest(ShellCase):
             self.assertTrue(received)
             del listener
             signal.alarm(0)
+
+    def test_orchestration_with_pillar_dot_items(self):
+        '''
+        Test to confirm when using a state file that includes other state file, if
+        one of those state files includes pillar related functions that will not 
+        be pulling from the pillar cache that all the state files are available and
+        the file_roots has been preserved.  See issues #48277 and #46986.
+        '''
+        self.write_conf({
+            'fileserver_backend': ['roots'],
+            'file_roots': {
+                'base': [self.base_env],
+            },
+        })
+
+        orch_sls = os.path.join(self.base_env, 'main.sls')
+        with salt.utils.fopen(orch_sls, 'w') as fp_:
+            fp_.write(textwrap.dedent('''
+                include:
+                  - one
+                  - two
+                  - three
+            '''))
+
+        orch_sls = os.path.join(self.base_env, 'one.sls')
+        with salt.utils.fopen(orch_sls, 'w') as fp_:
+            fp_.write(textwrap.dedent('''
+                {%- set foo = salt['saltutil.runner']('pillar.show_pillar') %}
+                placeholder_one:
+                  test.succeed_without_changes
+            '''))
+
+        orch_sls = os.path.join(self.base_env, 'two.sls')
+        with salt.utils.fopen(orch_sls, 'w') as fp_:
+            fp_.write(textwrap.dedent('''
+                placeholder_two:
+                  test.succeed_without_changes
+            '''))
+
+        orch_sls = os.path.join(self.base_env, 'three.sls')
+        with salt.utils.fopen(orch_sls, 'w') as fp_:
+            fp_.write(textwrap.dedent('''
+                placeholder_three:
+                  test.succeed_without_changes
+            '''))
+
+        orch_sls = os.path.join(self.base_env, 'main.sls')
+
+        listener = salt.utils.event.get_event(
+            'master',
+            sock_dir=self.master_opts['sock_dir'],
+            transport=self.master_opts['transport'],
+            opts=self.master_opts)
+
+        start_time = time.time()
+        jid = self.run_run_plus(
+            'state.orchestrate',
+            'main',
+            __reload_config=True).get('jid')
+
+        if jid is None:
+            raise Exception('jid missing from run_run_plus output')
+
+        signal.signal(signal.SIGALRM, self.alarm_handler)
+        signal.alarm(self.timeout)
+        received = False
+        try:
+            while True:
+                event = listener.get_event(full=True)
+                if event is None:
+                    continue
+                if event['tag'] == 'salt/run/{0}/ret'.format(jid):
+                    received = True
+                    # Don't wrap this in a try/except. We want to know if the
+                    # data structure is different from what we expect!
+                    ret = event['data']['return']['data']['master']
+                    for state in ret:
+                        data = ret[state]
+                        # Each state should be successful
+                        self.assertEqual(data['comment'], 'Success!')
+                    break
+        finally:
+            self.assertTrue(received)
+            del listener
+            signal.alarm(0)

--- a/tests/integration/runners/test_state.py
+++ b/tests/integration/runners/test_state.py
@@ -546,7 +546,7 @@ class OrchEventTest(ShellCase):
     def test_orchestration_with_pillar_dot_items(self):
         '''
         Test to confirm when using a state file that includes other state file, if
-        one of those state files includes pillar related functions that will not 
+        one of those state files includes pillar related functions that will not
         be pulling from the pillar cache that all the state files are available and
         the file_roots has been preserved.  See issues #48277 and #46986.
         '''

--- a/tests/integration/runners/test_state.py
+++ b/tests/integration/runners/test_state.py
@@ -603,7 +603,7 @@ class OrchEventTest(ShellCase):
             __reload_config=True).get('jid')
 
         if jid is None:
-            raise Exception('jid missing from run_run_plus output')
+            raise salt.exceptions.SaltInvocationError('jid missing from run_run_plus output')
 
         signal.signal(signal.SIGALRM, self.alarm_handler)
         signal.alarm(self.timeout)
@@ -613,7 +613,7 @@ class OrchEventTest(ShellCase):
                 event = listener.get_event(full=True)
                 if event is None:
                     continue
-                if event['tag'] == 'salt/run/{0}/ret'.format(jid):
+                if event.get('tag', '') == 'salt/run/{0}/ret'.format(jid):
                     received = True
                     # Don't wrap this in a try/except. We want to know if the
                     # data structure is different from what we expect!

--- a/tests/integration/runners/test_state.py
+++ b/tests/integration/runners/test_state.py
@@ -596,7 +596,6 @@ class OrchEventTest(ShellCase):
             transport=self.master_opts['transport'],
             opts=self.master_opts)
 
-        start_time = time.time()
         jid = self.run_run_plus(
             'state.orchestrate',
             'main',


### PR DESCRIPTION
### What does this PR do?
When pillar items are compiled a new render is instantiated but the file_roots is the pillar_roots.  This change forces the __opts__['file_roots'] to be set to what is set in actual_file_roots for all renderers once compile_pillar has finished.  Adding a test when this situation is run via a orchestration runner.

### What issues does this PR fix or reference?
#48277 
#46986

### Tests written?
Yes

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
