### PR TITLE
Fix dependancy for esky build on SmartOS

### DIFF
--- a/pkg/smartos/esky/requirements.txt
+++ b/pkg/smartos/esky/requirements.txt
@@ -1,5 +1,5 @@
 GitPython==0.3.2.RC1
-dateutils
+python-dateutil
 pyghmi
 croniter
 Mako

--- a/setup.py
+++ b/setup.py
@@ -1095,7 +1095,7 @@ class SaltDistribution(distutils.dist.Distribution):
             # all these should be safe to force include
             freezer_includes.extend([
                 'cherrypy',
-                'dateutils',
+                'python-dateutil',
                 'pyghmi',
                 'croniter',
                 'mako',


### PR DESCRIPTION
### What does this PR do?
Corrects incorrect dependencies for SmartOS esky that accidentally pulled in the right one.

### What issues does this PR fix or reference?
#48374

### Previous Behavior
Pulled in the wrong dependency

### New Behavior
Pull in the right one.

### Tests written?
No

### Commits signed with GPG?
No