### PR TITLE
Fix file.symlink state test for windows

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -1396,19 +1396,25 @@ def symlink(
     preflight_errors = []
     if salt.utils.is_windows():
         # Make sure the passed owner exists
-        if not salt.utils.win_functions.get_sid_from_name(win_owner):
+        try:
+            salt.utils.win_functions.get_sid_from_name(win_owner)
+        except CommandExecutionError as exc:
             preflight_errors.append('User {0} does not exist'.format(win_owner))
 
         # Make sure users passed in win_perms exist
         if win_perms:
             for name_check in win_perms:
-                if not salt.utils.win_functions.get_sid_from_name(name_check):
+                try:
+                    salt.utils.win_functions.get_sid_from_name(name_check)
+                except CommandExecutionError as exc:
                     preflight_errors.append('User {0} does not exist'.format(name_check))
 
         # Make sure users passed in win_deny_perms exist
         if win_deny_perms:
             for name_check in win_deny_perms:
-                if not salt.utils.win_functions.get_sid_from_name(name_check):
+                try:
+                    salt.utils.win_functions.get_sid_from_name(name_check)
+                except CommandExecutionError as exc:
                     preflight_errors.append('User {0} does not exist'.format(name_check))
     else:
         uid = __salt__['file.user_to_uid'](user)


### PR DESCRIPTION
### What does this PR do?

Fixes failing symlink test on windows:

https://jenkinsci.saltstack.com/job/2017.7/job/salt-windows-2016-py2/220/testReport/junit/unit.states.test_file/TestFileState/test_symlink/

### Tests written?

No - Fixing existing tests

### Commits signed with GPG?

Yes