### PR TITLE
Beacons for imgadm and vmadm on SmartOS

### DIFF
--- a/salt/beacons/smartos_imgadm.py
+++ b/salt/beacons/smartos_imgadm.py
@@ -1,0 +1,119 @@
+# -*- coding: utf-8 -*-
+'''
+Beacon that fires events on image import/delete.
+
+.. code-block:: yaml
+
+    ## minimal
+    # - check for new images every 1 second (salt default)
+    # - does not send events at startup
+    beacons:
+      imgadm: []
+
+    ## standard
+    # - check for new images every 60 seconds
+    # - send import events at startup for all images
+    beacons:
+      imgadm:
+        - interval: 60
+        - startup_import_event: True
+'''
+
+# Import Python libs
+from __future__ import absolute_import, unicode_literals
+import logging
+
+# Import 3rd-party libs
+# pylint: disable=import-error
+from salt.ext.six.moves import map
+# pylint: enable=import-error
+
+__virtualname__ = 'imgadm'
+IMGADM_STATE = {
+  'first_run': True,
+  'images': [],
+}
+
+log = logging.getLogger(__name__)
+
+
+def __virtual__():
+    '''
+    Provides imgadm beacon on SmartOS
+    '''
+    if 'imgadm.list' in __salt__:
+        return True
+    else:
+        return (
+            False,
+            '{0} beacon can only be loaded on SmartOS compute nodes'.format(
+                __virtualname__
+            )
+        )
+
+
+def validate(config):
+    '''
+    Validate the beacon configuration
+    '''
+    vcfg_ret = True
+    vcfg_msg = 'Valid beacon configuration'
+
+    if not isinstance(config, list):
+        vcfg_ret = False
+        vcfg_msg = 'Configuration for imgadm beacon must be a list!'
+
+    return vcfg_ret, vcfg_msg
+
+
+def beacon(config):
+    '''
+    Poll imgadm and compare available images
+    '''
+    ret = []
+
+    # NOTE: lookup current images
+    current_images = __salt__['imgadm.list'](verbose=True)
+
+    # NOTE: apply configuration
+    if IMGADM_STATE['first_run']:
+        log.info('Applying configuration for imgadm beacon')
+
+        _config = {}
+        list(map(_config.update, config))
+
+        if 'startup_import_event' not in _config or not _config['startup_import_event']:
+            IMGADM_STATE['images'] = current_images
+
+    # NOTE: import events
+    for uuid in current_images:
+        event = {}
+        if uuid not in IMGADM_STATE['images']:
+            event['tag'] = "imported/{}".format(uuid)
+            for label in current_images[uuid]:
+                event[label] = current_images[uuid][label]
+
+        if event:
+            ret.append(event)
+
+    # NOTE: delete events
+    for uuid in IMGADM_STATE['images']:
+        event = {}
+        if uuid not in current_images:
+            event['tag'] = "deleted/{}".format(uuid)
+            for label in IMGADM_STATE['images'][uuid]:
+                event[label] = IMGADM_STATE['images'][uuid][label]
+
+        if event:
+            ret.append(event)
+
+    # NOTE: update stored state
+    IMGADM_STATE['images'] = current_images
+
+    # NOTE: disable first_run
+    if IMGADM_STATE['first_run']:
+        IMGADM_STATE['first_run'] = False
+
+    return ret
+
+# vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4

--- a/salt/beacons/smartos_vmadm.py
+++ b/salt/beacons/smartos_vmadm.py
@@ -1,0 +1,141 @@
+# -*- coding: utf-8 -*-
+'''
+Beacon that fires events on vm state changes
+
+.. code-block:: yaml
+
+    ## minimal
+    # - check for vm changes every 1 second (salt default)
+    # - does not send events at startup
+    beacons:
+      vmadm: []
+
+    ## standard
+    # - check for vm changes every 60 seconds
+    # - send create event at startup for all vms
+    beacons:
+      vmadm:
+        - interval: 60
+        - startup_create_event: True
+'''
+
+# Import Python libs
+from __future__ import absolute_import, unicode_literals
+import logging
+
+# Import 3rd-party libs
+# pylint: disable=import-error
+from salt.ext.six.moves import map
+# pylint: enable=import-error
+
+__virtualname__ = 'vmadm'
+VMADM_STATE = {
+  'first_run': True,
+  'vms': [],
+}
+
+log = logging.getLogger(__name__)
+
+
+def __virtual__():
+    '''
+    Provides vmadm beacon on SmartOS
+    '''
+    if 'vmadm.list' in __salt__:
+        return True
+    else:
+        return (
+            False,
+            '{0} beacon can only be loaded on SmartOS compute nodes'.format(
+                __virtualname__
+            )
+        )
+
+
+def validate(config):
+    '''
+    Validate the beacon configuration
+    '''
+    vcfg_ret = True
+    vcfg_msg = 'Valid beacon configuration'
+
+    if not isinstance(config, list):
+        vcfg_ret = False
+        vcfg_msg = 'Configuration for vmadm beacon must be a list!'
+
+    return vcfg_ret, vcfg_msg
+
+
+def beacon(config):
+    '''
+    Poll vmadm for changes
+    '''
+    ret = []
+
+    # NOTE: lookup current images
+    current_vms = __salt__['vmadm.list'](
+        keyed=True,
+        order='uuid,state,alias,hostname,dns_domain',
+    )
+
+    # NOTE: apply configuration
+    if VMADM_STATE['first_run']:
+        log.info('Applying configuration for vmadm beacon')
+
+        _config = {}
+        list(map(_config.update, config))
+
+        if 'startup_create_event' not in _config or not _config['startup_create_event']:
+            VMADM_STATE['vms'] = current_vms
+
+    # NOTE: create events
+    for uuid in current_vms:
+        event = {}
+        if uuid not in VMADM_STATE['vms']:
+            event['tag'] = "created/{}".format(uuid)
+            for label in current_vms[uuid]:
+                if label == 'state':
+                    continue
+                event[label] = current_vms[uuid][label]
+
+        if event:
+            ret.append(event)
+
+    # NOTE: deleted events
+    for uuid in VMADM_STATE['vms']:
+        event = {}
+        if uuid not in current_vms:
+            event['tag'] = "deleted/{}".format(uuid)
+            for label in VMADM_STATE['vms'][uuid]:
+                if label == 'state':
+                    continue
+                event[label] = VMADM_STATE['vms'][uuid][label]
+
+        if event:
+            ret.append(event)
+
+    # NOTE: state change events
+    for uuid in current_vms:
+        event = {}
+        if VMADM_STATE['first_run'] or \
+           uuid not in VMADM_STATE['vms'] or \
+           current_vms[uuid].get('state', 'unknown') != VMADM_STATE['vms'][uuid].get('state', 'unknown'):
+            event['tag'] = "{}/{}".format(current_vms[uuid].get('state', 'unknown'), uuid)
+            for label in current_vms[uuid]:
+                if label == 'state':
+                    continue
+                event[label] = current_vms[uuid][label]
+
+        if event:
+            ret.append(event)
+
+    # NOTE: update stored state
+    VMADM_STATE['vms'] = current_vms
+
+    # NOTE: disable first_run
+    if VMADM_STATE['first_run']:
+        VMADM_STATE['first_run'] = False
+
+    return ret
+
+# vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4

--- a/tests/unit/beacons/test_smartos_imgadm_beacon.py
+++ b/tests/unit/beacons/test_smartos_imgadm_beacon.py
@@ -1,0 +1,214 @@
+# coding: utf-8
+
+# Python libs
+from __future__ import absolute_import
+
+# Salt testing libs
+from tests.support.unit import skipIf, TestCase
+from tests.support.mock import NO_MOCK, NO_MOCK_REASON, patch, MagicMock
+from tests.support.mixins import LoaderModuleMockMixin
+
+# Salt libs
+import salt.beacons.smartos_imgadm as imgadm
+
+
+# Mock Results
+MOCK_CLEAN_STATE = {'first_run': True, 'images': []}
+MOCK_IMAGE_NONE = {}
+MOCK_IMAGE_ONE = {
+    '00000000-0000-0000-0000-000000000001': {
+        'description': 'Example Image 1',
+        'name': 'example-1',
+        'os': 'smartos',
+        'published': '2018-01-01T00:42:00Z',
+        'source': 'https://images.joyent.com',
+        'version': '18.1.0',
+    },
+}
+MOCK_IMAGE_TWO = {
+    '00000000-0000-0000-0000-000000000001': {
+        'description': 'Example Image 1',
+        'name': 'example-1',
+        'os': 'smartos',
+        'published': '2018-01-01T00:42:00Z',
+        'source': 'https://images.joyent.com',
+        'version': '18.1.0',
+    },
+    '00000000-0000-0000-0000-000000000002': {
+        'description': 'Example Image 2',
+        'name': 'example-2',
+        'os': 'smartos',
+        'published': '2018-01-01T00:42:00Z',
+        'source': 'https://images.joyent.com',
+        'version': '18.2.0',
+    },
+}
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class SmartOSImgAdmBeaconTestCase(TestCase, LoaderModuleMockMixin):
+    '''
+    Test case for salt.beacons.imgadm
+    '''
+
+    def setup_loader_modules(self):
+        return {
+            imgadm: {
+                '__context__': {},
+                '__salt__': {},
+            }
+        }
+
+    def test_non_list_config(self):
+        '''
+        We only have minimal validation so we test that here
+        '''
+        config = {}
+
+        ret = imgadm.validate(config)
+
+        self.assertEqual(ret, (False, 'Configuration for imgadm beacon must be a list!'))
+
+    def test_imported_startup(self):
+        '''
+        Test with one image and startup_import_event
+        '''
+        # NOTE: this should yield 1 imported event
+        with patch.dict(imgadm.IMGADM_STATE, MOCK_CLEAN_STATE), \
+             patch.dict(imgadm.__salt__, {'imgadm.list': MagicMock(return_value=MOCK_IMAGE_ONE)}):
+
+            config = [{'startup_import_event': True}]
+
+            ret = imgadm.validate(config)
+            self.assertEqual(ret, (True, 'Valid beacon configuration'))
+
+            ret = imgadm.beacon(config)
+            res = [{'description': 'Example Image 1',
+                    'name': 'example-1',
+                    'os': 'smartos',
+                    'published': '2018-01-01T00:42:00Z',
+                    'source': 'https://images.joyent.com',
+                    'tag': 'imported/00000000-0000-0000-0000-000000000001',
+                    'version': '18.1.0'}]
+            self.assertEqual(ret, res)
+
+    def test_imported_nostartup(self):
+        '''
+        Test with one image and startup_import_event unset/false
+        '''
+        # NOTE: this should yield 0 imported event
+        with patch.dict(imgadm.IMGADM_STATE, MOCK_CLEAN_STATE), \
+             patch.dict(imgadm.__salt__, {'imgadm.list': MagicMock(return_value=MOCK_IMAGE_ONE)}):
+
+            config = []
+
+            ret = imgadm.validate(config)
+            self.assertEqual(ret, (True, 'Valid beacon configuration'))
+
+            ret = imgadm.beacon(config)
+            res = []
+
+            self.assertEqual(ret, res)
+
+    def test_imported(self):
+        '''
+        Test with one image and a new image added on the 2nd pass
+        '''
+        # NOTE: this should yield 1 imported event
+        with patch.dict(imgadm.IMGADM_STATE, MOCK_CLEAN_STATE), \
+             patch.dict(imgadm.__salt__, {'imgadm.list': MagicMock(side_effect=[MOCK_IMAGE_ONE, MOCK_IMAGE_TWO])}):
+
+            config = []
+
+            ret = imgadm.validate(config)
+            self.assertEqual(ret, (True, 'Valid beacon configuration'))
+
+            # Initial pass (Initialized state and do not yield imported imagesd at startup)
+            ret = imgadm.beacon(config)
+
+            # Second pass (After importing a new image)
+            ret = imgadm.beacon(config)
+            res = [{'description': 'Example Image 2',
+                    'name': 'example-2',
+                    'os': 'smartos',
+                    'published': '2018-01-01T00:42:00Z',
+                    'source': 'https://images.joyent.com',
+                    'tag': 'imported/00000000-0000-0000-0000-000000000002',
+                    'version': '18.2.0'}]
+
+            self.assertEqual(ret, res)
+
+    def test_deleted(self):
+        '''
+        Test with two images and one gets deletes
+        '''
+        # NOTE: this should yield 1 deleted event
+        with patch.dict(imgadm.IMGADM_STATE, MOCK_CLEAN_STATE), \
+             patch.dict(imgadm.__salt__, {'imgadm.list': MagicMock(side_effect=[MOCK_IMAGE_TWO, MOCK_IMAGE_ONE])}):
+
+            config = []
+
+            ret = imgadm.validate(config)
+            self.assertEqual(ret, (True, 'Valid beacon configuration'))
+
+            # Initial pass (Initialized state and do not yield imported imagesd at startup)
+            ret = imgadm.beacon(config)
+
+            # Second pass (After deleting one image)
+            ret = imgadm.beacon(config)
+            res = [{'description': 'Example Image 2',
+                    'name': 'example-2',
+                    'os': 'smartos',
+                    'published': '2018-01-01T00:42:00Z',
+                    'source': 'https://images.joyent.com',
+                    'tag': 'deleted/00000000-0000-0000-0000-000000000002',
+                    'version': '18.2.0'}]
+
+            self.assertEqual(ret, res)
+
+    def test_complex(self):
+        '''
+        Test with one image, delete both, import 2
+        '''
+        # NOTE: this should yield 1 delete and 2 import events
+        with patch.dict(imgadm.IMGADM_STATE, MOCK_CLEAN_STATE), \
+             patch.dict(imgadm.__salt__, {'imgadm.list': MagicMock(side_effect=[MOCK_IMAGE_ONE, MOCK_IMAGE_NONE, MOCK_IMAGE_TWO])}):
+
+            config = []
+
+            ret = imgadm.validate(config)
+            self.assertEqual(ret, (True, 'Valid beacon configuration'))
+
+            # Initial pass (Initialized state and do not yield imported imagesd at startup)
+            ret = imgadm.beacon(config)
+
+            # Second pass (After deleting one image)
+            ret = imgadm.beacon(config)
+            res = [{'description': 'Example Image 1',
+                    'name': 'example-1',
+                    'os': 'smartos',
+                    'published': '2018-01-01T00:42:00Z',
+                    'source': 'https://images.joyent.com',
+                    'tag': 'deleted/00000000-0000-0000-0000-000000000001',
+                    'version': '18.1.0'}]
+
+            self.assertEqual(ret, res)
+
+            # Third pass (After importing two images)
+            ret = imgadm.beacon(config)
+            res = [{'description': 'Example Image 1',
+                    'name': 'example-1',
+                    'os': 'smartos',
+                    'published': '2018-01-01T00:42:00Z',
+                    'source': 'https://images.joyent.com',
+                    'tag': 'imported/00000000-0000-0000-0000-000000000001',
+                    'version': '18.1.0'},
+                   {'description': 'Example Image 2',
+                    'name': 'example-2',
+                    'os': 'smartos',
+                    'published': '2018-01-01T00:42:00Z',
+                    'source': 'https://images.joyent.com',
+                    'tag': 'imported/00000000-0000-0000-0000-000000000002',
+                    'version': '18.2.0'}]
+
+            self.assertEqual(ret, res)

--- a/tests/unit/beacons/test_smartos_vmadm_beacon.py
+++ b/tests/unit/beacons/test_smartos_vmadm_beacon.py
@@ -1,0 +1,210 @@
+# coding: utf-8
+
+# Python libs
+from __future__ import absolute_import
+
+# Salt testing libs
+from tests.support.unit import skipIf, TestCase
+from tests.support.mock import NO_MOCK, NO_MOCK_REASON, patch, MagicMock
+from tests.support.mixins import LoaderModuleMockMixin
+
+# Salt libs
+import salt.beacons.smartos_vmadm as vmadm
+
+# Mock Results
+MOCK_CLEAN_STATE = {'first_run': True, 'vms': []}
+MOCK_VM_NONE = {}
+MOCK_VM_ONE = {
+    '00000000-0000-0000-0000-000000000001': {
+        'state': 'running',
+        'alias': 'vm1',
+        'hostname': 'vm1',
+        'dns_domain': 'example.org',
+    },
+}
+MOCK_VM_TWO_STOPPED = {
+    '00000000-0000-0000-0000-000000000001': {
+        'state': 'running',
+        'alias': 'vm1',
+        'hostname': 'vm1',
+        'dns_domain': 'example.org',
+    },
+    '00000000-0000-0000-0000-000000000002': {
+        'state': 'stopped',
+        'alias': 'vm2',
+        'hostname': 'vm2',
+        'dns_domain': 'example.org',
+    },
+}
+MOCK_VM_TWO_STARTED = {
+    '00000000-0000-0000-0000-000000000001': {
+        'state': 'running',
+        'alias': 'vm1',
+        'hostname': 'vm1',
+        'dns_domain': 'example.org',
+    },
+    '00000000-0000-0000-0000-000000000002': {
+        'state': 'running',
+        'alias': 'vm2',
+        'hostname': 'vm2',
+        'dns_domain': 'example.org',
+    },
+}
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class SmartOSImgAdmBeaconTestCase(TestCase, LoaderModuleMockMixin):
+    '''
+    Test case for salt.beacons.vmadm
+    '''
+
+    def setup_loader_modules(self):
+        return {
+            vmadm: {
+                '__context__': {},
+                '__salt__': {},
+            }
+        }
+
+    def test_non_list_config(self):
+        '''
+        We only have minimal validation so we test that here
+        '''
+        config = {}
+
+        ret = vmadm.validate(config)
+
+        self.assertEqual(ret, (False, 'Configuration for vmadm beacon must be a list!'))
+
+    def test_created_startup(self):
+        '''
+        Test with one vm and startup_create_event
+        '''
+        # NOTE: this should yield 1 created event + one state event
+        with patch.dict(vmadm.VMADM_STATE, MOCK_CLEAN_STATE), \
+             patch.dict(vmadm.__salt__, {'vmadm.list': MagicMock(return_value=MOCK_VM_ONE)}):
+
+            config = [{'startup_create_event': True}]
+
+            ret = vmadm.validate(config)
+            self.assertEqual(ret, (True, 'Valid beacon configuration'))
+
+            ret = vmadm.beacon(config)
+            res = [{'alias': 'vm1',
+                    'tag': 'created/00000000-0000-0000-0000-000000000001',
+                    'hostname': 'vm1',
+                    'dns_domain': 'example.org'},
+                   {'alias': 'vm1',
+                    'tag': 'running/00000000-0000-0000-0000-000000000001',
+                    'hostname': 'vm1',
+                    'dns_domain': 'example.org'}]
+            self.assertEqual(ret, res)
+
+    def test_created_nostartup(self):
+        '''
+        Test with one image and startup_import_event unset/false
+        '''
+        # NOTE: this should yield 0 created event _ one state event
+        with patch.dict(vmadm.VMADM_STATE, MOCK_CLEAN_STATE), \
+             patch.dict(vmadm.__salt__, {'vmadm.list': MagicMock(return_value=MOCK_VM_ONE)}):
+
+            config = []
+
+            ret = vmadm.validate(config)
+            self.assertEqual(ret, (True, 'Valid beacon configuration'))
+
+            ret = vmadm.beacon(config)
+            res = [{'alias': 'vm1',
+                    'tag': 'running/00000000-0000-0000-0000-000000000001',
+                    'hostname': 'vm1',
+                    'dns_domain': 'example.org'}]
+
+            self.assertEqual(ret, res)
+
+    def test_created(self):
+        '''
+        Test with one vm, create a 2nd one
+        '''
+        # NOTE: this should yield 1 created event + state event
+        with patch.dict(vmadm.VMADM_STATE, MOCK_CLEAN_STATE), \
+             patch.dict(vmadm.__salt__, {'vmadm.list': MagicMock(side_effect=[MOCK_VM_ONE, MOCK_VM_TWO_STARTED])}):
+
+            config = []
+
+            ret = vmadm.validate(config)
+            self.assertEqual(ret, (True, 'Valid beacon configuration'))
+
+            # Initial pass (Initialized state and do not yield created events at startup)
+            ret = vmadm.beacon(config)
+
+            # Second pass (After create a new vm)
+            ret = vmadm.beacon(config)
+            res = [{'alias': 'vm2',
+                    'tag': 'created/00000000-0000-0000-0000-000000000002',
+                    'hostname': 'vm2',
+                    'dns_domain': 'example.org'},
+                   {'alias': 'vm2',
+                    'tag': 'running/00000000-0000-0000-0000-000000000002',
+                    'hostname': 'vm2',
+                    'dns_domain': 'example.org'}]
+
+            self.assertEqual(ret, res)
+
+    def test_deleted(self):
+        '''
+        Test with two vms and one gets destroyed
+        '''
+        # NOTE: this should yield 1 destroyed event
+        with patch.dict(vmadm.VMADM_STATE, MOCK_CLEAN_STATE), \
+             patch.dict(vmadm.__salt__, {'vmadm.list': MagicMock(side_effect=[MOCK_VM_TWO_STOPPED, MOCK_VM_ONE])}):
+
+            config = []
+
+            ret = vmadm.validate(config)
+            self.assertEqual(ret, (True, 'Valid beacon configuration'))
+
+            # Initial pass (Initialized state and do not yield created vms at startup)
+            ret = vmadm.beacon(config)
+
+            # Second pass (Destroying one vm)
+            ret = vmadm.beacon(config)
+            res = [{'alias': 'vm2',
+                    'tag': 'deleted/00000000-0000-0000-0000-000000000002',
+                    'hostname': 'vm2',
+                    'dns_domain': 'example.org'}]
+
+            self.assertEqual(ret, res)
+
+    def test_complex(self):
+        '''
+        Test with two vms, stop one, delete one
+        '''
+        # NOTE: this should yield 1 delete and 2 import events
+        with patch.dict(vmadm.VMADM_STATE, MOCK_CLEAN_STATE), \
+             patch.dict(vmadm.__salt__, {'vmadm.list': MagicMock(side_effect=[MOCK_VM_TWO_STARTED, MOCK_VM_TWO_STOPPED, MOCK_VM_ONE])}):
+
+            config = []
+
+            ret = vmadm.validate(config)
+            self.assertEqual(ret, (True, 'Valid beacon configuration'))
+
+            # Initial pass (Initialized state and do not yield created events at startup)
+            ret = vmadm.beacon(config)
+
+            # Second pass (Stop one vm)
+            ret = vmadm.beacon(config)
+            res = [{'alias': 'vm2',
+                    'tag': 'stopped/00000000-0000-0000-0000-000000000002',
+                    'hostname': 'vm2',
+                    'dns_domain': 'example.org'}]
+
+            self.assertEqual(ret, res)
+
+            # Third pass (Delete one vm)
+            ret = vmadm.beacon(config)
+            res = [{'alias': 'vm2',
+                    'tag': 'deleted/00000000-0000-0000-0000-000000000002',
+                    'hostname': 'vm2',
+                    'dns_domain': 'example.org'}]
+
+            self.assertEqual(ret, res)


### PR DESCRIPTION
### What does this PR do?
This PR adds 2 new beacons for SmartOS. Events will be injected for vm state changes, image import/deletion, ...

This should make it possible to react to new vms being create and for example use the minion in the global zone to reach in and configure the salt minion for the newly creates vm. (Guess what I am going to do soon :p)


### What issues does this PR fix or reference?
N/a

### Previous Behavior
No beacons

### New Behavior
We have beacons

### Tests written?
Yes

### Commits signed with GPG?
No