### PR TITLE
[2018.3] fixes to module/file.py

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -4463,27 +4463,6 @@ def check_perms(name, ret, user, group, mode, attrs=None, follow_symlinks=False)
             if perms['lattrs']:
                 chattr(name, operator='remove', attributes=perms['lattrs'])
 
-    # Mode changes if needed
-    if mode is not None:
-        # File is a symlink, ignore the mode setting
-        # if follow_symlinks is False
-        if os.path.islink(name) and not follow_symlinks:
-            pass
-        else:
-            mode = salt.utils.files.normalize_mode(mode)
-            if mode != perms['lmode']:
-                if __opts__['test'] is True:
-                    ret['changes']['mode'] = mode
-                else:
-                    set_mode(name, mode)
-                    if mode != salt.utils.files.normalize_mode(get_mode(name)):
-                        ret['result'] = False
-                        ret['comment'].append(
-                            'Failed to change mode to {0}'.format(mode)
-                        )
-                    else:
-                        ret['changes']['mode'] = mode
-
     # user/group changes if needed, then check if it worked
     if user:
         if isinstance(user, int):
@@ -4571,6 +4550,27 @@ def check_perms(name, ret, user, group, mode, attrs=None, follow_symlinks=False)
         # Replace attributes on file if it had been removed
         if perms.get('lattrs', ''):
             chattr(name, operator='add', attributes=perms['lattrs'])
+
+    # Mode changes if needed
+    if mode is not None:
+        # File is a symlink, ignore the mode setting
+        # if follow_symlinks is False
+        if os.path.islink(name) and not follow_symlinks:
+            pass
+        else:
+            mode = salt.utils.files.normalize_mode(mode)
+            if mode != perms['lmode']:
+                if __opts__['test'] is True:
+                    ret['changes']['mode'] = mode
+                else:
+                    set_mode(name, mode)
+                    if mode != salt.utils.files.normalize_mode(get_mode(name)):
+                        ret['result'] = False
+                        ret['comment'].append(
+                            'Failed to change mode to {0}'.format(mode)
+                        )
+                    else:
+                        ret['changes']['mode'] = mode
 
     # Modify attributes of file if needed
     if attrs is not None and not is_dir:

--- a/tests/integration/states/test_file.py
+++ b/tests/integration/states/test_file.py
@@ -2294,7 +2294,8 @@ class FileTest(ModuleCase, SaltReturnAssertsMixin):
         # Check that the owner and group are correct, and
         # the mode is what we expect
         temp_file_stats = os.stat(tempfile)
-        self.assertEqual(six.text_type(oct(stat.S_IMODE(temp_file_stats.st_mode))), '04750')
+        temp_file_mode = six.text_type(oct(stat.S_IMODE(temp_file_stats.st_mode)))
+        self.assertEqual(temp_file_mode, '4750')
         self.assertEqual(pwd.getpwuid(temp_file_stats.st_uid).pw_name, user)
         self.assertEqual(grp.getgrgid(temp_file_stats.st_gid).gr_name, group)
 

--- a/tests/integration/states/test_file.py
+++ b/tests/integration/states/test_file.py
@@ -2271,6 +2271,33 @@ class FileTest(ModuleCase, SaltReturnAssertsMixin):
             except OSError:
                 pass
 
+    @skip_if_not_root
+    @skipIf(not HAS_PWD, "pwd not available. Skipping test")
+    @skipIf(not HAS_GRP, "grp not available. Skipping test")
+    @with_system_user_and_group('user12209', 'group12209',
+                                on_existing='delete', delete=True)
+    @with_tempdir()
+    def test_issue_48336_file_managed_mode_setuid(self, tempdir, user, group):
+        '''
+        Ensure that mode is correct with changing of ownership and group
+        symlinks)
+        '''
+        tempfile = os.path.join(tempdir, 'temp_file_issue_48336')
+
+        # Run the state
+        ret = self.run_state(
+            'file.managed', name=tempfile,
+            user=user, group=group, mode='4750',
+        )
+        self.assertSaltTrueReturn(ret)
+
+        # Check that the owner and group are correct, and
+        # the mode is what we expect
+        temp_file_stats = os.stat(tempfile)
+        self.assertEqual(six.text_type(oct(stat.S_IMODE(temp_file_stats.st_mode))), '04750')
+        self.assertEqual(pwd.getpwuid(temp_file_stats.st_uid).pw_name, user)
+        self.assertEqual(grp.getgrgid(temp_file_stats.st_gid).gr_name, group)
+
 
 class BlockreplaceTest(ModuleCase, SaltReturnAssertsMixin):
     marker_start = '# start'

--- a/tests/integration/states/test_file.py
+++ b/tests/integration/states/test_file.py
@@ -2294,7 +2294,11 @@ class FileTest(ModuleCase, SaltReturnAssertsMixin):
         # Check that the owner and group are correct, and
         # the mode is what we expect
         temp_file_stats = os.stat(tempfile)
+
+        # Normalize the mode
         temp_file_mode = six.text_type(oct(stat.S_IMODE(temp_file_stats.st_mode)))
+        temp_file_mode = salt.utils.files.normalize_mode(temp_file_mode)
+
         self.assertEqual(temp_file_mode, '4750')
         self.assertEqual(pwd.getpwuid(temp_file_stats.st_uid).pw_name, user)
         self.assertEqual(grp.getgrgid(temp_file_stats.st_gid).gr_name, group)


### PR DESCRIPTION
### What does this PR do?
Setting the mode with setuid or setgid bits in addition to setting the owner and group will force the setuid & setgid bits to reset.  This change ensures that we set the mode after setting the owner & group.

### What issues does this PR fix or reference?
#48336 

### Previous Behavior
Setuid and setgid bits were wiped out with the chown action.

### New Behavior
Chown is done last, preserving the chmod actions.

### Tests written?
Yes

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
