### PR TITLE
[2017.7] fixes to module/file.py

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -4262,26 +4262,6 @@ def check_perms(name, ret, user, group, mode, follow_symlinks=False):
     perms['lgroup'] = cur['group']
     perms['lmode'] = salt.utils.normalize_mode(cur['mode'])
 
-    # Mode changes if needed
-    if mode is not None:
-        # File is a symlink, ignore the mode setting
-        # if follow_symlinks is False
-        if os.path.islink(name) and not follow_symlinks:
-            pass
-        else:
-            mode = salt.utils.normalize_mode(mode)
-            if mode != perms['lmode']:
-                if __opts__['test'] is True:
-                    ret['changes']['mode'] = mode
-                else:
-                    set_mode(name, mode)
-                    if mode != salt.utils.normalize_mode(get_mode(name)):
-                        ret['result'] = False
-                        ret['comment'].append(
-                            'Failed to change mode to {0}'.format(mode)
-                        )
-                    else:
-                        ret['changes']['mode'] = mode
     # user/group changes if needed, then check if it worked
     if user:
         if isinstance(user, int):
@@ -4357,6 +4337,27 @@ def check_perms(name, ret, user, group, mode, follow_symlinks=False):
                                       .format(group))
         elif 'cgroup' in perms and user != '':
             ret['changes']['group'] = group
+
+    # Mode changes if needed
+    if mode is not None:
+        # File is a symlink, ignore the mode setting
+        # if follow_symlinks is False
+        if os.path.islink(name) and not follow_symlinks:
+            pass
+        else:
+            mode = salt.utils.normalize_mode(mode)
+            if mode != perms['lmode']:
+                if __opts__['test'] is True:
+                    ret['changes']['mode'] = mode
+                else:
+                    set_mode(name, mode)
+                    if mode != salt.utils.normalize_mode(get_mode(name)):
+                        ret['result'] = False
+                        ret['comment'].append(
+                            'Failed to change mode to {0}'.format(mode)
+                        )
+                    else:
+                        ret['changes']['mode'] = mode
 
     if isinstance(orig_comment, six.string_types):
         if orig_comment:

--- a/tests/integration/states/test_file.py
+++ b/tests/integration/states/test_file.py
@@ -2510,7 +2510,12 @@ class FileTest(ModuleCase, SaltReturnAssertsMixin):
         # Check that the owner and group are correct, and
         # the mode is what we expect
         temp_file_stats = os.stat(tempfile)
-        self.assertEqual(six.text_type(oct(stat.S_IMODE(temp_file_stats.st_mode))), '04750')
+
+        # Normalize the mode
+        temp_file_mode = six.text_type(oct(stat.S_IMODE(temp_file_stats.st_mode)))
+        temp_file_mode = salt.utils.normalize_mode(temp_file_mode)
+
+        self.assertEqual(temp_file_mode, '4750')
         self.assertEqual(pwd.getpwuid(temp_file_stats.st_uid).pw_name, user)
         self.assertEqual(grp.getgrgid(temp_file_stats.st_gid).gr_name, group)
 


### PR DESCRIPTION
### What does this PR do?
Setting the mode with setuid or setgid bits in addition to setting the owner and group will force the setuid & setgid bits to reset.  This change ensures that we set the mode after setting the owner & group.

### What issues does this PR fix or reference?
#48336 

### Previous Behavior
Setuid and setgid bits were wiped out with the chown action.

### New Behavior
Chown is done last, preserving the chmod actions.

### Tests written?
Yes

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
