### PR TITLE
Fix archive.extracted to handle UNC paths

### DIFF
--- a/salt/states/archive.py
+++ b/salt/states/archive.py
@@ -80,6 +80,8 @@ def _checksum_file_path(path):
                 drive.rstrip(':'),
                 path.lstrip('/\\'),
             )
+        elif str(exc).startswith('Cannot mix UNC'):
+            relpath = salt.utils.path_join('unc', path)
         else:
             raise
     ret = salt.utils.path_join(__opts__['cachedir'], 'archive_hash', relpath)


### PR DESCRIPTION
### What does this PR do?
Fixes `archive.extracted` to handle UNC paths properly

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/47811

### Tests written?
No

### Commits signed with GPG?
Yes