### PR TITLE
Fix service integration test (py3)

### DIFF
--- a/salt/modules/win_service.py
+++ b/salt/modules/win_service.py
@@ -683,7 +683,7 @@ def modify(name,
             win32service.SERVICE_QUERY_CONFIG)
     except pywintypes.error as exc:
         raise CommandExecutionError(
-            'Failed To Open {0}: {1}'.format(name, exc[2]))
+            'Failed To Open {0}: {1}'.format(name, exc))
 
     config_info = win32service.QueryServiceConfig(handle_svc)
 


### PR DESCRIPTION
### What does this PR do?

Fixes service integration test:

https://jenkinsci.saltstack.com/job/2017.7/view/Python3/job/salt-windows-2016-py3/75/testReport/junit/integration.modules.test_service/ServiceModuleTest/test_service_disable_doesnot_exist/

### Tests written?

No - Fixes existing tests

### Commits signed with GPG?

Yes