### PR TITLE
Fix multi-sls `salt.state` orchestration in masterless systems

### DIFF
--- a/salt/states/saltmod.py
+++ b/salt/states/saltmod.py
@@ -321,7 +321,7 @@ def state(name,
         if top:
             cmd_kw['topfn'] = ''.join(cmd_kw.pop('arg'))
         elif sls:
-            cmd_kw['mods'] = cmd_kw.pop('arg')
+            cmd_kw['mods'] = ''.join(cmd_kw.pop('arg'))
         cmd_kw.update(cmd_kw.pop('kwarg'))
         tmp_ret = __salt__[fun](**cmd_kw)
         cmd_ret = {__opts__['id']: {


### PR DESCRIPTION
### What does this PR do?

Fix multi-sls `salt.state` orchestration in masterless systems

### Previous Behavior

When `salt.state` orchestration on masterless systems was introduced (in 8e3abb11), only the single-string in `sls` case was supported:

```yaml
<name>:
  salt.state:
    - sls: '...'
```

The documentation for `salt.state` says multiple sls files can be supplied in a list:

```yaml
<name>:
  salt.state:
    - sls:
      - ...
      - ...
      - ...
```

But with masterless orchestration, this does not work because the original patch passes a list containing a joined string of comma-separated sls files instead of the joined string itself:

```
 No matching sls found for 'common,postgresql.repo,postgresql.server' in env 'base'
```

### New Behavior

Multiple sls files passed as a list works on masterless systems by individually running each sls file.

### Tests written?

No

### Commits signed with GPG?

Yes

### Other notes

Originally submitted on salt-users: https://groups.google.com/forum/#!topic/salt-users/fhJYB2ELEM8
