### PR TITLE
Fix #48223: broken pip extra-index-url param support at the pip_state 

### DIFF
--- a/salt/modules/pip.py
+++ b/salt/modules/pip.py
@@ -1484,14 +1484,14 @@ def list_all_versions(pkg,
                 '\'{0}\' is not a valid URL'.format(index_url)
             )
         cmd.extend(['--index-url', index_url])
-    
+
     if extra_index_url:
         if not salt.utils.url.validate(extra_index_url, VALID_PROTOS):
             raise CommandExecutionError(
                 '\'{0}\' is not a valid URL'.format(extra_index_url)
             )
         cmd.extend(['--extra-index-url', extra_index_url])
-        
+
     cmd_kwargs = dict(cwd=cwd, runas=user, output_loglevel='quiet', redirect_stderr=True)
     if bin_env and os.path.isdir(bin_env):
         cmd_kwargs['env'] = {'VIRTUAL_ENV': bin_env}

--- a/salt/modules/pip.py
+++ b/salt/modules/pip.py
@@ -1430,7 +1430,8 @@ def list_all_versions(pkg,
                       include_rc=False,
                       user=None,
                       cwd=None,
-                      index_url=None):
+                      index_url=None,
+                      extra_index_url=None):
     '''
     .. versionadded:: 2017.7.3
 
@@ -1464,6 +1465,10 @@ def list_all_versions(pkg,
         Base URL of Python Package Index
         .. versionadded:: Fluorine
 
+    extra_index_url
+        Additional URL of Python Package Index
+        .. versionadded:: Fluorine
+
     CLI Example:
 
     .. code-block:: bash
@@ -1479,7 +1484,14 @@ def list_all_versions(pkg,
                 '\'{0}\' is not a valid URL'.format(index_url)
             )
         cmd.extend(['--index-url', index_url])
-
+    
+    if extra_index_url:
+        if not salt.utils.url.validate(extra_index_url, VALID_PROTOS):
+            raise CommandExecutionError(
+                '\'{0}\' is not a valid URL'.format(extra_index_url)
+            )
+        cmd.extend(['--extra-index-url', extra_index_url])
+        
     cmd_kwargs = dict(cwd=cwd, runas=user, output_loglevel='quiet', redirect_stderr=True)
     if bin_env and os.path.isdir(bin_env):
         cmd_kwargs['env'] = {'VIRTUAL_ENV': bin_env}

--- a/salt/states/pip_state.py
+++ b/salt/states/pip_state.py
@@ -193,6 +193,7 @@ def _check_if_installed(prefix,
                         bin_env,
                         env_vars,
                         index_url,
+                        extra_index_url,
                         **kwargs):
     # result: None means the command failed to run
     # result: True means the package is installed
@@ -235,7 +236,7 @@ def _check_if_installed(prefix,
             available_versions = __salt__['pip.list_all_versions'](
                 prefix_realname, bin_env=bin_env, include_alpha=include_alpha,
                 include_beta=include_beta, include_rc=include_rc, user=user,
-                cwd=cwd, index_url=index_url)
+                cwd=cwd, index_url=index_url, extra_index_url=extra_index_url)
             desired_version = ''
             if any(version_spec):
                 for version in reversed(available_versions):
@@ -732,7 +733,7 @@ def installed(name,
                 out = _check_if_installed(prefix, state_pkg_name, version_spec,
                                           ignore_installed, force_reinstall,
                                           upgrade, user, cwd, bin_env, env_vars,
-                                          index_url, **kwargs)
+                                          index_url, extra_index_url, **kwargs)
                 # If _check_if_installed result is None, something went wrong with
                 # the command running. This way we keep stateful output.
                 if out['result'] is None:


### PR DESCRIPTION
### What does this PR do?
Fixes support of the pip extra-index-url parameter at the pip_state

### What issues does this PR fix or reference?
#48223

### Previous Behavior
pip.installed state fails on packages available only from pypi specified in extra_index_url parameter

### Tests written?
No

### Commits signed with GPG?
No

