### PR TITLE
Fix log.warn to log.warning

### DIFF
--- a/salt/cloud/clouds/azurearm.py
+++ b/salt/cloud/clouds/azurearm.py
@@ -886,7 +886,7 @@ def create_network_interface(call=None, kwargs=None):
     try:
         poller.wait()
     except Exception as exc:
-        log.warn('Network interface creation could not be polled. '
+        log.warning('Network interface creation could not be polled. '
                  'It is likely that we are reusing an existing interface. (%s)', exc)
 
     count = 0
@@ -1751,7 +1751,7 @@ def list_blobs(call=None, kwargs=None):  # pylint: disable=unused-argument
                                'server_encrypted': blob.properties.server_encrypted,
                              }
     except Exception as exc:
-        log.warn(six.text_type(exc))
+        log.warning(six.text_type(exc))
 
     return ret
 

--- a/salt/cloud/clouds/xen.py
+++ b/salt/cloud/clouds/xen.py
@@ -712,7 +712,7 @@ def _wait_for_ip(name, session):
             delta.seconds, name
         )
         if delta.seconds > 180:
-            log.warn('Timeout getting IP address')
+            log.warning('Timeout getting IP address')
             break
         time.sleep(5)
 

--- a/salt/engines/slack.py
+++ b/salt/engines/slack.py
@@ -216,8 +216,8 @@ class SlackClient(object):
         try:
             groups_gen = itertools.chain(self._groups_from_pillar(groups_pillar_name).items(), use_groups.items())
         except AttributeError:
-            log.warn('Failed to get groups from %s: %s', groups_pillar_name, self._groups_from_pillar(groups_pillar_name))
-            log.warn('or from config: %s', use_groups)
+            log.warning('Failed to get groups from %s: %s', groups_pillar_name, self._groups_from_pillar(groups_pillar_name))
+            log.warning('or from config: %s', use_groups)
             groups_gen = []
         for name, config in groups_gen:
             log.info('Trying to get %s and %s to be useful', name, config)
@@ -231,7 +231,7 @@ class SlackClient(object):
                 ret_groups[name]['default_target'].update(config.get('default_target', {}))
                 ret_groups[name]['targets'].update(config.get('targets', {}))
             except (IndexError, AttributeError):
-                log.warn("Couldn't use group %s. Check that targets is a dict and not a list", name)
+                log.warning("Couldn't use group %s. Check that targets is a dict and not a list", name)
 
         log.debug('Got the groups: %s', ret_groups)
         return ret_groups
@@ -683,11 +683,11 @@ class SlackClient(object):
                 # 10 times without taking a break.
                 log.trace('Got a message from the generator: %s', msg.keys())
                 if count > 10:
-                    log.warn('Breaking in getting messages because count is exceeded')
+                    log.warning('Breaking in getting messages because count is exceeded')
                     break
                 if len(msg) == 0:
                     count += 1
-                    log.warn('len(msg) is zero')
+                    log.warning('len(msg) is zero')
                     continue  # This one is a dud, get the next message
                 if msg.get('done'):
                     log.trace('msg is done')

--- a/salt/engines/slack.py
+++ b/salt/engines/slack.py
@@ -216,8 +216,11 @@ class SlackClient(object):
         try:
             groups_gen = itertools.chain(self._groups_from_pillar(groups_pillar_name).items(), use_groups.items())
         except AttributeError:
-            log.warning('Failed to get groups from %s: %s', groups_pillar_name, self._groups_from_pillar(groups_pillar_name))
-            log.warning('or from config: %s', use_groups)
+            log.warning('Failed to get groups from %s: %s or from config: %s',
+                groups_pillar_name,
+                self._groups_from_pillar(groups_pillar_name),
+                use_groups
+            )
             groups_gen = []
         for name, config in groups_gen:
             log.info('Trying to get %s and %s to be useful', name, config)
@@ -231,7 +234,7 @@ class SlackClient(object):
                 ret_groups[name]['default_target'].update(config.get('default_target', {}))
                 ret_groups[name]['targets'].update(config.get('targets', {}))
             except (IndexError, AttributeError):
-                log.warning("Couldn't use group %s. Check that targets is a dict and not a list", name)
+                log.warning("Couldn't use group %s. Check that targets is a dictionary and not a list", name)
 
         log.debug('Got the groups: %s', ret_groups)
         return ret_groups
@@ -687,7 +690,7 @@ class SlackClient(object):
                     break
                 if len(msg) == 0:
                     count += 1
-                    log.warning('len(msg) is zero')
+                    log.warning('Skipping an empty message.')
                     continue  # This one is a dud, get the next message
                 if msg.get('done'):
                     log.trace('msg is done')

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1455,7 +1455,7 @@ class Minion(MinionBase):
         if process_count_max > 0:
             process_count = len(salt.utils.minion.running(self.opts))
             while process_count >= process_count_max:
-                log.warn("Maximum number of processes reached while executing jid {0}, waiting...".format(data['jid']))
+                log.warning("Maximum number of processes reached while executing jid {0}, waiting...".format(data['jid']))
                 yield tornado.gen.sleep(10)
                 process_count = len(salt.utils.minion.running(self.opts))
 

--- a/salt/modules/cryptdev.py
+++ b/salt/modules/cryptdev.py
@@ -124,7 +124,7 @@ def active():
             dev_info = match.groupdict()
             ret[dev_info['devname']] = dev_info
         else:
-            log.warn('dmsetup output does not match expected format')
+            log.warning('dmsetup output does not match expected format')
 
     return ret
 

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -2374,7 +2374,7 @@ def resolve_capabilities(pkgs, refresh, **kwargs):
                     if len(result) == 1:
                         name = result.keys()[0]
                     elif len(result) > 1:
-                        log.warn("Found ambiguous match for capability '%s'.", pkg)
+                        log.warning("Found ambiguous match for capability '%s'.", pkg)
                 except CommandExecutionError as exc:
                     # when search throws an exception stay with original name and version
                     log.debug("Search failed with: %s", exc)

--- a/salt/pillar/netbox.py
+++ b/salt/pillar/netbox.py
@@ -82,7 +82,7 @@ def ext_pillar(minion_id, pillar, *args, **kwargs):
 
     # Check status code for API call
     if device_results.status_code != requests.codes.ok:
-        log.warn('API query failed for "%s", status code: %d',
+        log.warning('API query failed for "%s", status code: %d',
                  minion_id, device_results.status_code)
 
     # Assign results from API call to "netbox" key

--- a/salt/spm/__init__.py
+++ b/salt/spm/__init__.py
@@ -700,7 +700,7 @@ class SPMClient(object):
 
         def _read_metadata(repo, repo_info):
             if cache.updated('.', repo) is None:
-                log.warn('Updating repo metadata')
+                log.warning('Updating repo metadata')
                 self._download_repo_metadata({})
 
             metadata[repo] = {

--- a/salt/states/cryptdev.py
+++ b/salt/states/cryptdev.py
@@ -100,7 +100,7 @@ def mapped(name,
         if name not in active.keys():
             # Open the map using cryptsetup. This does not pass any options.
             if opts:
-                log.warning('passed cryptdev options are ignored when mapping immediately')
+                log.warning('Ignore cryptdev configuration when mapping immediately')
 
             if __opts__['test']:
                 ret['result'] = None

--- a/salt/states/cryptdev.py
+++ b/salt/states/cryptdev.py
@@ -100,7 +100,7 @@ def mapped(name,
         if name not in active.keys():
             # Open the map using cryptsetup. This does not pass any options.
             if opts:
-                log.warn('passed cryptdev options are ignored when mapping immediately')
+                log.warning('passed cryptdev options are ignored when mapping immediately')
 
             if __opts__['test']:
                 ret['result'] = None

--- a/salt/utils/smb.py
+++ b/salt/utils/smb.py
@@ -426,7 +426,7 @@ def _delete_directory_smbprotocol(path, share='C$', conn=None, host=None, userna
         conn = get_conn(host, username, password)
     if conn is False:
         return False
-    log.warning("PATH: %s %s", share, path)
+    log.debug("_delete_directory_smbprotocol - share: %s, path: %s", share, path)
     tree = conn.tree_connect(share)
 
     dir_open = Open(tree, path)

--- a/salt/utils/smb.py
+++ b/salt/utils/smb.py
@@ -426,7 +426,7 @@ def _delete_directory_smbprotocol(path, share='C$', conn=None, host=None, userna
         conn = get_conn(host, username, password)
     if conn is False:
         return False
-    log.warn("PATH: %s %s", share, path)
+    log.warning("PATH: %s %s", share, path)
     tree = conn.tree_connect(share)
 
     dir_open = Open(tree, path)

--- a/tests/integration/utils/test_smb.py
+++ b/tests/integration/utils/test_smb.py
@@ -117,7 +117,7 @@ class TestSmb(TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        log.warn('teardown')
+        log.warning('teardown')
         os.kill(cls._pid, signal.SIGTERM)
 
     def test_write_file(self):


### PR DESCRIPTION
log.warn got deprecated and this commit addresses the few places
where was still in use

Signed-off-by: Rares POP <rares.pop@ni.com>

### What does this PR do?
Fix the deprecation warnings

### Tests written?

No

### Commits signed with GPG?

Yes