### PR TITLE
Virt states improvements

### DIFF
--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -3909,7 +3909,7 @@ def cpu_baseline(full=False, migratable=False, out='libvirt', **kwargs):
     return cpu.toxml()
 
 
-def net_define(name, bridge, forward, **kwargs):
+def network_define(name, bridge, forward, **kwargs):
     '''
     Create libvirt network.
 
@@ -3928,7 +3928,7 @@ def net_define(name, bridge, forward, **kwargs):
 
     .. code-block:: bash
 
-        salt '*' virt.net_define network main bridge openvswitch
+        salt '*' virt.network_define network main bridge openvswitch
 
     .. versionadded:: Fluorine
     '''

--- a/salt/states/virt.py
+++ b/salt/states/virt.py
@@ -250,7 +250,9 @@ def running(name,
             install=True,
             pub_key=None,
             priv_key=None,
-            **kwargs):
+            connection=None,
+            username=None,
+            password=None):
     '''
     Starts an existing guest, or defines and starts a new VM with specified arguments.
 
@@ -368,8 +370,6 @@ def running(name,
            'comment': '{0} is running'.format(name)
            }
 
-    kwargs = salt.utils.args.clean_kwargs(**kwargs)
-
     try:
         try:
             __salt__['virt.vm_state'](name)
@@ -380,7 +380,6 @@ def running(name,
             else:
                 ret['comment'] = 'Domain {0} exists and is running'.format(name)
         except CommandExecutionError:
-            kwargs = salt.utils.args.clean_kwargs(**kwargs)
             if image:
                 salt.utils.versions.warn_until(
                     'Sodium',
@@ -401,7 +400,9 @@ def running(name,
                                   install=install,
                                   pub_key=pub_key,
                                   priv_key=priv_key,
-                                  **kwargs)
+                                  connection=connection,
+                                  username=username,
+                                  password=password)
             ret['changes'][name] = 'Domain defined and started'
             ret['comment'] = 'Domain {0} defined and started'.format(name)
     except libvirt.libvirtError as err:
@@ -567,7 +568,15 @@ def reverted(name, snapshot=None, cleanup=False):  # pylint: disable=redefined-o
     return ret
 
 
-def network_running(name, bridge, forward, connection=None, username=None, password=None, **kwargs):
+def network_running(name,
+                    bridge,
+                    forward,
+                    vport=None,
+                    tag=None,
+                    autostart=True,
+                    connection=None,
+                    username=None,
+                    password=None):
     '''
     Defines and starts a new network with specified arguments.
 
@@ -602,11 +611,6 @@ def network_running(name, bridge, forward, connection=None, username=None, passw
            'result': True,
            'comment': ''
            }
-
-    kwargs = salt.utils.args.clean_kwargs(**kwargs)
-    vport = kwargs.pop('vport', None)
-    tag = kwargs.pop('tag', None)
-    autostart = kwargs.pop('autostart', True)
 
     try:
         info = __salt__['virt.network_info'](name, connection=connection, username=username, password=password)

--- a/salt/states/virt.py
+++ b/salt/states/virt.py
@@ -145,7 +145,8 @@ def keys(name, basepath='/etc/pki', **kwargs):
     return ret
 
 
-def _virt_call(domain, function, section, comment, **kwargs):
+def _virt_call(domain, function, section, comment,
+               connection=None, username=None, password=None, **kwargs):
     '''
     Helper to call the virt functions. Wildcards supported.
 
@@ -161,7 +162,11 @@ def _virt_call(domain, function, section, comment, **kwargs):
     ignored_domains = list()
     for targeted_domain in targeted_domains:
         try:
-            response = __salt__['virt.{0}'.format(function)](targeted_domain, **kwargs)
+            response = __salt__['virt.{0}'.format(function)](targeted_domain,
+                                                             connection=connection,
+                                                             username=username,
+                                                             password=password,
+                                                             **kwargs)
             if isinstance(response, dict):
                 response = response['name']
             changed_domains.append({'domain': targeted_domain, function: response})
@@ -179,34 +184,56 @@ def _virt_call(domain, function, section, comment, **kwargs):
     return ret
 
 
-def stopped(name):
+def stopped(name, connection=None, username=None, password=None):
     '''
     Stops a VM by shutting it down nicely.
 
     .. versionadded:: 2016.3.0
 
+    :param connection: libvirt connection URI, overriding defaults
+
+        .. versionadded:: Fluorine
+    :param username: username to connect with, overriding defaults
+
+        .. versionadded:: Fluorine
+    :param password: password to connect with, overriding defaults
+
+        .. versionadded:: Fluorine
+
     .. code-block:: yaml
 
         domain_name:
           virt.stopped
     '''
 
-    return _virt_call(name, 'shutdown', 'stopped', "Machine has been shut down")
+    return _virt_call(name, 'shutdown', 'stopped', "Machine has been shut down",
+                      connection=connection, username=username, password=password)
 
 
-def powered_off(name):
+def powered_off(name, connection=None, username=None, password=None):
     '''
     Stops a VM by power off.
 
     .. versionadded:: 2016.3.0
 
+    :param connection: libvirt connection URI, overriding defaults
+
+        .. versionadded:: Fluorine
+    :param username: username to connect with, overriding defaults
+
+        .. versionadded:: Fluorine
+    :param password: password to connect with, overriding defaults
+
+        .. versionadded:: Fluorine
+
     .. code-block:: yaml
 
         domain_name:
           virt.stopped
     '''
 
-    return _virt_call(name, 'stop', 'unpowered', 'Machine has been powered off')
+    return _virt_call(name, 'stop', 'unpowered', 'Machine has been powered off',
+                      connection=connection, username=username, password=password)
 
 
 def running(name,
@@ -385,11 +412,21 @@ def running(name,
     return ret
 
 
-def snapshot(name, suffix=None):
+def snapshot(name, suffix=None, connection=None, username=None, password=None):
     '''
     Takes a snapshot of a particular VM or by a UNIX-style wildcard.
 
     .. versionadded:: 2016.3.0
+
+    :param connection: libvirt connection URI, overriding defaults
+
+        .. versionadded:: Fluorine
+    :param username: username to connect with, overriding defaults
+
+        .. versionadded:: Fluorine
+    :param password: password to connect with, overriding defaults
+
+        .. versionadded:: Fluorine
 
     .. code-block:: yaml
 
@@ -402,21 +439,32 @@ def snapshot(name, suffix=None):
             - suffix: periodic
     '''
 
-    return _virt_call(name, 'snapshot', 'saved', 'Snapshot has been taken', suffix=suffix)
+    return _virt_call(name, 'snapshot', 'saved', 'Snapshot has been taken', suffix=suffix,
+                      connection=connection, username=username, password=password)
 
 
 # Deprecated states
-def rebooted(name):
+def rebooted(name, connection=None, username=None, password=None):
     '''
     Reboots VMs
 
     .. versionadded:: 2016.3.0
 
     :param name:
-    :return:
+
+    :param connection: libvirt connection URI, overriding defaults
+
+        .. versionadded:: Fluorine
+    :param username: username to connect with, overriding defaults
+
+        .. versionadded:: Fluorine
+    :param password: password to connect with, overriding defaults
+
+        .. versionadded:: Fluorine
     '''
 
-    return _virt_call(name, 'reboot', 'rebooted', "Machine has been rebooted")
+    return _virt_call(name, 'reboot', 'rebooted', "Machine has been rebooted",
+                      connection=connection, username=username, password=password)
 
 
 def unpowered(name):
@@ -519,9 +567,19 @@ def reverted(name, snapshot=None, cleanup=False):  # pylint: disable=redefined-o
     return ret
 
 
-def network_define(name, bridge, forward, **kwargs):
+def network_define(name, bridge, forward, connection=None, username=None, password=None, **kwargs):
     '''
     Defines and starts a new network with specified arguments.
+
+    :param connection: libvirt connection URI, overriding defaults
+
+        .. versionadded:: Fluorine
+    :param username: username to connect with, overriding defaults
+
+        .. versionadded:: Fluorine
+    :param password: password to connect with, overriding defaults
+
+        .. versionadded:: Fluorine
 
     .. code-block:: yaml
 
@@ -553,7 +611,16 @@ def network_define(name, bridge, forward, **kwargs):
     start = kwargs.pop('start', True)
 
     try:
-        result = __salt__['virt.net_define'](name, bridge, forward, vport, tag=tag, autostart=autostart, start=start)
+        result = __salt__['virt.net_define'](name,
+                                             bridge,
+                                             forward,
+                                             vport,
+                                             tag=tag,
+                                             autostart=autostart,
+                                             start=start,
+                                             connection=connection,
+                                             username=username,
+                                             password=password)
         if result:
             ret['changes'][name] = 'Network {0} has been created'.format(name)
             ret['result'] = True
@@ -569,9 +636,19 @@ def network_define(name, bridge, forward, **kwargs):
     return ret
 
 
-def pool_define(name, **kwargs):
+def pool_define(name, connection=None, username=None, password=None, **kwargs):
     '''
     Defines and starts a new pool with specified arguments.
+
+    :param connection: libvirt connection URI, overriding defaults
+
+        .. versionadded:: Fluorine
+    :param username: username to connect with, overriding defaults
+
+        .. versionadded:: Fluorine
+    :param password: password to connect with, overriding defaults
+
+        .. versionadded:: Fluorine
 
     .. code-block:: yaml
 
@@ -603,8 +680,15 @@ def pool_define(name, **kwargs):
     start = kwargs.pop('start', True)
 
     try:
-        result = __salt__['virt.pool_define_build'](name, ptype=ptype, target=target,
-                                                    source=source, autostart=autostart, start=start)
+        result = __salt__['virt.pool_define_build'](name,
+                                                    ptype=ptype,
+                                                    target=target,
+                                                    source=source,
+                                                    autostart=autostart,
+                                                    start=start,
+                                                    connection=connection,
+                                                    username=username,
+                                                    password=password)
         if result:
             if 'Pool exist' in result:
                 if 'Pool update' in result:

--- a/salt/templates/virt/libvirt_pool.jinja
+++ b/salt/templates/virt/libvirt_pool.jinja
@@ -1,9 +1,64 @@
 <pool type='{{ ptype }}'>
   <name>{{ name }}</name>
+  {% if target.path or target.permissions %}
   <target>
-    <path>/dev/{{ target }}</path>
-  </target>{% if source != None %}
+    {% if target.path %}
+    <path>{{ target.path }}</path>
+    {% endif %}
+    {% if target.permissions %}
+    <permissions>
+      {% for key in ['mode', 'owner', 'group', 'label'] %}
+      {% if key in target.permissions %}
+      <{{ key }}>{{ target.permissions[key] }}</{{ key }}>
+      {% endif %}
+      {% endfor %}
+    </permissions>
+    {% endif %}
+  </target>
+  {% endif %}
+  {% if source %}
   <source>
-    <device path='/dev/{{ source }}'/>
-  </source>{% endif %}
+    {% if ptype in ['fs', 'logical', 'disk', 'iscsi', 'zfs', 'vstorage'] %}
+    {% for device in source.devices %}
+    <device path='{{ device.path }}'
+            {% if 'part_separator' in device %}part_separator='{{ device.part_separator }}'{% endif %}/>
+    {% endfor %}
+    {% elif ptype in ['dir', 'netfs', 'gluster'] %}
+    <dir path='{{ source.dir }}'/>
+    {% elif ptype == 'scsi' %}
+    <adapter type='{{ source.adapter.type }}'
+         {% for key in ['name', 'parent', 'managed', 'parent_wwnn', 'parent_wwpn', 'parent_fabric_wwn', 'wwnn', 'wwpn'] %}
+         {% if key in source.adapter %}{{ key }}='{{ source.adapter[key] }}'{% endif %}
+         {% endfor %}>
+         {% if 'parent_address' in source.adapter %}
+         <parentaddr
+            {% if 'unique_id' in source.adapter.parent_address %}
+            unique_id='{{ source.adapter.parent_address.unique_id }}'
+            {% endif %}>
+           <address
+             {% for key in source.adapter.parent_address.address %}
+             {{ key }}='{{ source.adapter.parent_address.address[key] }}'
+             {% endfor %}/>
+         </parentaddr>
+         {% endif %}
+    </adapter>
+    {% endif %}
+    {% if ptype in ['netfs', 'iscsi', 'rbd', 'sheepdog', 'gluster'] and source.hosts %}
+    {% for host in source.hosts %}
+    <host name='{{ host.name }}' {% if host.port %}port='{{ host.port }}'{% endif %}/>
+    {% endfor %}
+    {% endif %}
+    {% if ptype in ['iscsi', 'rbd'] and source.auth %}
+    <auth type='{{source.auth.type}}' username='{{ source.auth.username }}'>
+      <secret type='{{ source.auth.secret.type }}' {{ source.auth.secret.type }}='{{source.auth.secret.value}}'/>
+    </auth>
+    {% endif %}
+    {% if ptype in ['logical', 'rbd', 'sheepdog', 'gluster'] and source.name %}
+    <name>{{ source.name }}</name>
+    {% endif %}
+    {% if ptype in ['fs', 'netfs', 'logical', 'disk'] and source.format %}
+    <format type='{{ source.format }}'/>
+    {% endif %}
+  </source>
+  {% endif %}
 </pool>

--- a/tests/unit/states/test_libvirt.py
+++ b/tests/unit/states/test_libvirt.py
@@ -239,8 +239,76 @@ class LibvirtTestCase(TestCase, LoaderModuleMockMixin):
                 }):
             ret.update({'changes': {'myvm': 'Domain defined and started'},
                         'comment': 'Domain myvm defined and started'})
-            self.assertDictEqual(virt.running('myvm', cpu=2, mem=2048, image='/path/to/img.qcow2'), ret)
-            init_mock.assert_called_with('myvm', cpu=2, mem=2048, image='/path/to/img.qcow2')
+            self.assertDictEqual(virt.running('myvm',
+                                              cpu=2,
+                                              mem=2048,
+                                              image='/path/to/img.qcow2'), ret)
+            init_mock.assert_called_with('myvm', cpu=2, mem=2048, image='/path/to/img.qcow2',
+                                         disk=None, disks=None, nic=None, interfaces=None,
+                                         graphics=None, hypervisor=None,
+                                         seed=True, install=True, pub_key=None, priv_key=None)
+
+        with patch.dict(virt.__salt__, {  # pylint: disable=no-member
+                    'virt.vm_state': MagicMock(side_effect=CommandExecutionError('not found')),
+                    'virt.init': init_mock,
+                    'virt.start': MagicMock(return_value=0)
+                }):
+            ret.update({'changes': {'myvm': 'Domain defined and started'},
+                        'comment': 'Domain myvm defined and started'})
+            disks = [{
+                        'name': 'system',
+                        'size': 8192,
+                        'overlay_image': True,
+                        'pool': 'default',
+                        'image': '/path/to/image.qcow2'
+                     },
+                     {
+                        'name': 'data',
+                        'size': 16834
+                     }]
+            ifaces = [{
+                         'name': 'eth0',
+                         'mac': '01:23:45:67:89:AB'
+                      },
+                      {
+                         'name': 'eth1',
+                         'type': 'network',
+                         'source': 'admin'
+                      }]
+            graphics = {'type': 'spice', 'listen': {'type': 'address', 'address': '192.168.0.1'}}
+            self.assertDictEqual(virt.running('myvm',
+                                              cpu=2,
+                                              mem=2048,
+                                              vm_type='qemu',
+                                              disk_profile='prod',
+                                              disks=disks,
+                                              nic_profile='prod',
+                                              interfaces=ifaces,
+                                              graphics=graphics,
+                                              seed=False,
+                                              install=False,
+                                              pub_key='/path/to/key.pub',
+                                              priv_key='/path/to/key',
+                                              connection='someconnection',
+                                              username='libvirtuser',
+                                              password='supersecret'), ret)
+            init_mock.assert_called_with('myvm',
+                                         cpu=2,
+                                         mem=2048,
+                                         image=None,
+                                         disk='prod',
+                                         disks=disks,
+                                         nic='prod',
+                                         interfaces=ifaces,
+                                         graphics=graphics,
+                                         hypervisor='qemu',
+                                         seed=False,
+                                         install=False,
+                                         pub_key='/path/to/key.pub',
+                                         priv_key='/path/to/key',
+                                         connection='someconnection',
+                                         username='libvirtuser',
+                                         password='supersecret')
 
         with patch.dict(virt.__salt__, {  # pylint: disable=no-member
                     'virt.vm_state': MagicMock(return_value='stopped'),

--- a/tests/unit/states/test_libvirt.py
+++ b/tests/unit/states/test_libvirt.py
@@ -25,6 +25,9 @@ import salt.states.virt as virt
 import salt.utils.files
 from salt.exceptions import CommandExecutionError
 
+# Import 3rd-party libs
+from salt.ext import six
+
 
 class LibvirtMock(MagicMock):  # pylint: disable=too-many-ancestors
     '''
@@ -35,6 +38,12 @@ class LibvirtMock(MagicMock):  # pylint: disable=too-many-ancestors
         '''
         libvirt error mockup
         '''
+
+        def get_error_message(self):
+            '''
+            Fake function return error message
+            '''
+            return six.text_type(self)
 
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
@@ -316,3 +325,335 @@ class LibvirtTestCase(TestCase, LoaderModuleMockMixin):
                 }):
             ret.update({'changes': {}, 'result': False, 'comment': 'libvirt error msg'})
             self.assertDictEqual(virt.running('myvm'), ret)
+
+    def test_stopped(self):
+        '''
+        stopped state test cases.
+        '''
+        ret = {'name': 'myvm',
+               'changes': {},
+               'result': True}
+
+        shutdown_mock = MagicMock(return_value=True)
+        with patch.dict(virt.__salt__, {  # pylint: disable=no-member
+                    'virt.list_domains': MagicMock(return_value=['myvm', 'vm1']),
+                    'virt.shutdown': shutdown_mock
+                }):
+            ret.update({'changes': {
+                            'stopped': [{'domain': 'myvm', 'shutdown': True}]
+                        },
+                        'comment': 'Machine has been shut down'})
+            self.assertDictEqual(virt.stopped('myvm'), ret)
+            shutdown_mock.assert_called_with('myvm', connection=None, username=None, password=None)
+
+        with patch.dict(virt.__salt__, {  # pylint: disable=no-member
+                    'virt.list_domains': MagicMock(return_value=['myvm', 'vm1']),
+                    'virt.shutdown': shutdown_mock,
+                }):
+            self.assertDictEqual(virt.stopped('myvm',
+                                              connection='myconnection',
+                                              username='user',
+                                              password='secret'), ret)
+            shutdown_mock.assert_called_with('myvm', connection='myconnection', username='user', password='secret')
+
+        with patch.dict(virt.__salt__, {  # pylint: disable=no-member
+                    'virt.list_domains': MagicMock(return_value=['myvm', 'vm1']),
+                    'virt.shutdown': MagicMock(side_effect=self.mock_libvirt.libvirtError('Some error'))
+                }):
+            ret.update({'changes': {'ignored': [{'domain': 'myvm', 'issue': 'Some error'}]},
+                        'result': False,
+                        'comment': 'No changes had happened'})
+            self.assertDictEqual(virt.stopped('myvm'), ret)
+
+        with patch.dict(virt.__salt__, {'virt.list_domains': MagicMock(return_value=[])}):  # pylint: disable=no-member
+            ret.update({'changes': {}, 'result': False, 'comment': 'No changes had happened'})
+            self.assertDictEqual(virt.stopped('myvm'), ret)
+
+    def test_powered_off(self):
+        '''
+        powered_off state test cases.
+        '''
+        ret = {'name': 'myvm',
+               'changes': {},
+               'result': True}
+
+        stop_mock = MagicMock(return_value=True)
+        with patch.dict(virt.__salt__, {  # pylint: disable=no-member
+                    'virt.list_domains': MagicMock(return_value=['myvm', 'vm1']),
+                    'virt.stop': stop_mock
+                }):
+            ret.update({'changes': {
+                            'unpowered': [{'domain': 'myvm', 'stop': True}]
+                        },
+                        'comment': 'Machine has been powered off'})
+            self.assertDictEqual(virt.powered_off('myvm'), ret)
+            stop_mock.assert_called_with('myvm', connection=None, username=None, password=None)
+
+        with patch.dict(virt.__salt__, {  # pylint: disable=no-member
+                    'virt.list_domains': MagicMock(return_value=['myvm', 'vm1']),
+                    'virt.stop': stop_mock,
+                }):
+            self.assertDictEqual(virt.powered_off('myvm',
+                                                  connection='myconnection',
+                                                  username='user',
+                                                  password='secret'), ret)
+            stop_mock.assert_called_with('myvm', connection='myconnection', username='user', password='secret')
+
+        with patch.dict(virt.__salt__, {  # pylint: disable=no-member
+                    'virt.list_domains': MagicMock(return_value=['myvm', 'vm1']),
+                    'virt.stop': MagicMock(side_effect=self.mock_libvirt.libvirtError('Some error'))
+                }):
+            ret.update({'changes': {'ignored': [{'domain': 'myvm', 'issue': 'Some error'}]},
+                        'result': False,
+                        'comment': 'No changes had happened'})
+            self.assertDictEqual(virt.powered_off('myvm'), ret)
+
+        with patch.dict(virt.__salt__, {'virt.list_domains': MagicMock(return_value=[])}):  # pylint: disable=no-member
+            ret.update({'changes': {}, 'result': False, 'comment': 'No changes had happened'})
+            self.assertDictEqual(virt.powered_off('myvm'), ret)
+
+    def test_snapshot(self):
+        '''
+        snapshot state test cases.
+        '''
+        ret = {'name': 'myvm',
+               'changes': {},
+               'result': True}
+
+        snapshot_mock = MagicMock(return_value=True)
+        with patch.dict(virt.__salt__, {  # pylint: disable=no-member
+                    'virt.list_domains': MagicMock(return_value=['myvm', 'vm1']),
+                    'virt.snapshot': snapshot_mock
+                }):
+            ret.update({'changes': {
+                            'saved': [{'domain': 'myvm', 'snapshot': True}]
+                        },
+                        'comment': 'Snapshot has been taken'})
+            self.assertDictEqual(virt.snapshot('myvm'), ret)
+            snapshot_mock.assert_called_with('myvm', suffix=None, connection=None, username=None, password=None)
+
+        with patch.dict(virt.__salt__, {  # pylint: disable=no-member
+                    'virt.list_domains': MagicMock(return_value=['myvm', 'vm1']),
+                    'virt.snapshot': snapshot_mock,
+                }):
+            self.assertDictEqual(virt.snapshot('myvm',
+                                               suffix='snap',
+                                               connection='myconnection',
+                                               username='user',
+                                               password='secret'), ret)
+            snapshot_mock.assert_called_with('myvm',
+                                             suffix='snap',
+                                             connection='myconnection',
+                                             username='user',
+                                             password='secret')
+
+        with patch.dict(virt.__salt__, {  # pylint: disable=no-member
+                    'virt.list_domains': MagicMock(return_value=['myvm', 'vm1']),
+                    'virt.snapshot': MagicMock(side_effect=self.mock_libvirt.libvirtError('Some error'))
+                }):
+            ret.update({'changes': {'ignored': [{'domain': 'myvm', 'issue': 'Some error'}]},
+                        'result': False,
+                        'comment': 'No changes had happened'})
+            self.assertDictEqual(virt.snapshot('myvm'), ret)
+
+        with patch.dict(virt.__salt__, {'virt.list_domains': MagicMock(return_value=[])}):  # pylint: disable=no-member
+            ret.update({'changes': {}, 'result': False, 'comment': 'No changes had happened'})
+            self.assertDictEqual(virt.snapshot('myvm'), ret)
+
+    def test_rebooted(self):
+        '''
+        rebooted state test cases.
+        '''
+        ret = {'name': 'myvm',
+               'changes': {},
+               'result': True}
+
+        reboot_mock = MagicMock(return_value=True)
+        with patch.dict(virt.__salt__, {  # pylint: disable=no-member
+                    'virt.list_domains': MagicMock(return_value=['myvm', 'vm1']),
+                    'virt.reboot': reboot_mock
+                }):
+            ret.update({'changes': {
+                            'rebooted': [{'domain': 'myvm', 'reboot': True}]
+                        },
+                        'comment': 'Machine has been rebooted'})
+            self.assertDictEqual(virt.rebooted('myvm'), ret)
+            reboot_mock.assert_called_with('myvm', connection=None, username=None, password=None)
+
+        with patch.dict(virt.__salt__, {  # pylint: disable=no-member
+                    'virt.list_domains': MagicMock(return_value=['myvm', 'vm1']),
+                    'virt.reboot': reboot_mock,
+                }):
+            self.assertDictEqual(virt.rebooted('myvm',
+                                               connection='myconnection',
+                                               username='user',
+                                               password='secret'), ret)
+            reboot_mock.assert_called_with('myvm',
+                                           connection='myconnection',
+                                           username='user',
+                                           password='secret')
+
+        with patch.dict(virt.__salt__, {  # pylint: disable=no-member
+                    'virt.list_domains': MagicMock(return_value=['myvm', 'vm1']),
+                    'virt.reboot': MagicMock(side_effect=self.mock_libvirt.libvirtError('Some error'))
+                }):
+            ret.update({'changes': {'ignored': [{'domain': 'myvm', 'issue': 'Some error'}]},
+                        'result': False,
+                        'comment': 'No changes had happened'})
+            self.assertDictEqual(virt.rebooted('myvm'), ret)
+
+        with patch.dict(virt.__salt__, {'virt.list_domains': MagicMock(return_value=[])}):  # pylint: disable=no-member
+            ret.update({'changes': {}, 'result': False, 'comment': 'No changes had happened'})
+            self.assertDictEqual(virt.rebooted('myvm'), ret)
+
+    def test_network_running(self):
+        '''
+        network_running state test cases.
+        '''
+        ret = {'name': 'mynet', 'changes': {}, 'result': True, 'comment': ''}
+        define_mock = MagicMock(return_value=True)
+        with patch.dict(virt.__salt__, {  # pylint: disable=no-member
+                    'virt.network_info': MagicMock(return_value={}),
+                    'virt.network_define': define_mock
+                }):
+            ret.update({'changes': {'mynet': 'Network defined and started'},
+                        'comment': 'Network mynet defined and started'})
+            self.assertDictEqual(virt.network_running('mynet',
+                                                      'br2',
+                                                      'bridge',
+                                                      vport='openvswitch',
+                                                      tag=180,
+                                                      autostart=False,
+                                                      connection='myconnection',
+                                                      username='user',
+                                                      password='secret'), ret)
+            define_mock.assert_called_with('mynet',
+                                           'br2',
+                                           'bridge',
+                                           'openvswitch',
+                                           tag=180,
+                                           autostart=False,
+                                           start=True,
+                                           connection='myconnection',
+                                           username='user',
+                                           password='secret')
+
+        with patch.dict(virt.__salt__, {  # pylint: disable=no-member
+                    'virt.network_info': MagicMock(return_value={'active': True}),
+                    'virt.network_define': define_mock,
+                }):
+            ret.update({'changes': {}, 'comment': 'Network mynet exists and is running'})
+            self.assertDictEqual(virt.network_running('mynet', 'br2', 'bridge'), ret)
+
+        start_mock = MagicMock(return_value=True)
+        with patch.dict(virt.__salt__, {  # pylint: disable=no-member
+                    'virt.network_info': MagicMock(return_value={'active': False}),
+                    'virt.network_start': start_mock,
+                    'virt.network_define': define_mock,
+                }):
+            ret.update({'changes': {'mynet': 'Network started'}, 'comment': 'Network mynet started'})
+            self.assertDictEqual(virt.network_running('mynet',
+                                                      'br2',
+                                                      'bridge',
+                                                      connection='myconnection',
+                                                      username='user',
+                                                      password='secret'), ret)
+            start_mock.assert_called_with('mynet', connection='myconnection', username='user', password='secret')
+
+        with patch.dict(virt.__salt__, {  # pylint: disable=no-member
+                    'virt.network_info': MagicMock(return_value={}),
+                    'virt.network_define': MagicMock(side_effect=self.mock_libvirt.libvirtError('Some error'))
+                }):
+            ret.update({'changes': {}, 'comment': 'Some error', 'result': False})
+            self.assertDictEqual(virt.network_running('mynet', 'br2', 'bridge'), ret)
+
+    def test_pool_running(self):
+        '''
+        pool_running state test cases.
+        '''
+        ret = {'name': 'mypool', 'changes': {}, 'result': True, 'comment': ''}
+        mocks = {mock: MagicMock(return_value=True) for mock in ['define', 'autostart', 'build', 'start']}
+        with patch.dict(virt.__salt__, {  # pylint: disable=no-member
+                    'virt.pool_info': MagicMock(return_value={}),
+                    'virt.pool_define': mocks['define'],
+                    'virt.pool_build': mocks['build'],
+                    'virt.pool_start': mocks['start'],
+                    'virt.pool_set_autostart': mocks['autostart']
+                }):
+            ret.update({'changes': {'mypool': 'Pool defined and started'},
+                        'comment': 'Pool mypool defined and started'})
+            self.assertDictEqual(virt.pool_running('mypool',
+                                                   ptype='logical',
+                                                   target='/dev/base',
+                                                   permissions={'mode': '0770',
+                                                                'owner': 1000,
+                                                                'group': 100,
+                                                                'label': 'seclabel'},
+                                                   source={'devices': [{'path': '/dev/sda'}]},
+                                                   transient=True,
+                                                   autostart=True,
+                                                   connection='myconnection',
+                                                   username='user',
+                                                   password='secret'), ret)
+            mocks['define'].assert_called_with('mypool',
+                                               ptype='logical',
+                                               target='/dev/base',
+                                               permissions={'mode': '0770',
+                                                            'owner': 1000,
+                                                            'group': 100,
+                                                            'label': 'seclabel'},
+                                               source_devices=[{'path': '/dev/sda'}],
+                                               source_dir=None,
+                                               source_adapter=None,
+                                               source_hosts=None,
+                                               source_auth=None,
+                                               source_name=None,
+                                               source_format=None,
+                                               transient=True,
+                                               start=True,
+                                               connection='myconnection',
+                                               username='user',
+                                               password='secret')
+            mocks['autostart'].assert_called_with('mypool',
+                                                  state='on',
+                                                  connection='myconnection',
+                                                  username='user',
+                                                  password='secret')
+            mocks['build'].assert_called_with('mypool',
+                                              connection='myconnection',
+                                              username='user',
+                                              password='secret')
+
+        with patch.dict(virt.__salt__, {  # pylint: disable=no-member
+                    'virt.pool_info': MagicMock(return_value={'state': 'running'}),
+                }):
+            ret.update({'changes': {}, 'comment': 'Pool mypool exists and is running'})
+            self.assertDictEqual(virt.pool_running('mypool',
+                                                   ptype='logical',
+                                                   target='/dev/base',
+                                                   source={'devices': [{'path': '/dev/sda'}]}), ret)
+
+        for mock in mocks:
+            mocks[mock].reset_mock()
+        with patch.dict(virt.__salt__, {  # pylint: disable=no-member
+                    'virt.pool_info': MagicMock(return_value={'state': 'stopped'}),
+                    'virt.pool_build': mocks['build'],
+                    'virt.pool_start': mocks['start']
+                }):
+            ret.update({'changes': {'mypool': 'Pool started'}, 'comment': 'Pool mypool started'})
+            self.assertDictEqual(virt.pool_running('mypool',
+                                                   ptype='logical',
+                                                   target='/dev/base',
+                                                   source={'devices': [{'path': '/dev/sda'}]}), ret)
+            mocks['start'].assert_called_with('mypool', connection=None, username=None, password=None)
+            mocks['build'].assert_not_called()
+
+        with patch.dict(virt.__salt__, {  # pylint: disable=no-member
+                    'virt.pool_info': MagicMock(return_value={}),
+                    'virt.pool_define': MagicMock(side_effect=self.mock_libvirt.libvirtError('Some error'))
+                }):
+            ret.update({'changes': {}, 'comment': 'Some error', 'result': False})
+            self.assertDictEqual(virt.pool_running('mypool',
+                                                   ptype='logical',
+                                                   target='/dev/base',
+                                                   source={'devices': [{'path': '/dev/sda'}]}), ret)

--- a/tests/unit/states/test_libvirt.py
+++ b/tests/unit/states/test_libvirt.py
@@ -255,7 +255,8 @@ class LibvirtTestCase(TestCase, LoaderModuleMockMixin):
             init_mock.assert_called_with('myvm', cpu=2, mem=2048, image='/path/to/img.qcow2',
                                          disk=None, disks=None, nic=None, interfaces=None,
                                          graphics=None, hypervisor=None,
-                                         seed=True, install=True, pub_key=None, priv_key=None)
+                                         seed=True, install=True, pub_key=None, priv_key=None,
+                                         connection=None, username=None, password=None)
 
         with patch.dict(virt.__salt__, {  # pylint: disable=no-member
                     'virt.vm_state': MagicMock(side_effect=CommandExecutionError('not found')),

--- a/tests/unit/states/test_libvirt.py
+++ b/tests/unit/states/test_libvirt.py
@@ -23,6 +23,7 @@ from tests.support.mock import (
 # Import Salt Libs
 import salt.states.virt as virt
 import salt.utils.files
+from salt.exceptions import CommandExecutionError
 
 
 class LibvirtMock(MagicMock):  # pylint: disable=too-many-ancestors
@@ -229,6 +230,17 @@ class LibvirtTestCase(TestCase, LoaderModuleMockMixin):
             ret.update({'changes': {'myvm': 'Domain started'},
                         'comment': 'Domain myvm started'})
             self.assertDictEqual(virt.running('myvm'), ret)
+
+        init_mock = MagicMock(return_value=True)
+        with patch.dict(virt.__salt__, {  # pylint: disable=no-member
+                    'virt.vm_state': MagicMock(side_effect=CommandExecutionError('not found')),
+                    'virt.init': init_mock,
+                    'virt.start': MagicMock(return_value=0)
+                }):
+            ret.update({'changes': {'myvm': 'Domain defined and started'},
+                        'comment': 'Domain myvm defined and started'})
+            self.assertDictEqual(virt.running('myvm', cpu=2, mem=2048, image='/path/to/img.qcow2'), ret)
+            init_mock.assert_called_with('myvm', cpu=2, mem=2048, image='/path/to/img.qcow2')
 
         with patch.dict(virt.__salt__, {  # pylint: disable=no-member
                     'virt.vm_state': MagicMock(return_value='stopped'),


### PR DESCRIPTION
### What does this PR do?

This PR improves the virt states by using the new ``virt.init`` parameters in ``virt.running``, rewriting ``virt.pool_define`` to handle more pool types, complete unit tests and documentation as well as some cleanup like some kwargs removal.

### What issues does this PR fix or reference?

None

### Tests written?

Yes

### Commits signed with GPG?

Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
