### PR TITLE
Allow file.managed to work with uppercase source_hash in test=true mode 

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -4484,6 +4484,11 @@ def check_managed_changes(
             defaults,
             skip_verify,
             **kwargs)
+
+        # Ensure that user-provided hash string is lowercase
+        if source_sum and ('hsum' in source_sum):
+            source_sum['hsum'] = source_sum['hsum'].lower()
+
         if comments:
             __clean_tmp(sfn)
             return False, comments

--- a/tests/integration/files/file/base/hello_world.txt
+++ b/tests/integration/files/file/base/hello_world.txt
@@ -1,0 +1,1 @@
+Hello, World!


### PR DESCRIPTION
### What does this PR do?
Allows the user to pass a `source_hash` to `file.managed` that is case indifferent when using `test=true`.

Using an uppercase source_hash was fixed for normal `file.managed` execution in PR #40754 to fix #38914, but the `test=true` behavior still showed changes when using an uppercase source_hash.

### What issues does this PR fix or reference?
Fixes #48230

### Previous Behavior
Given the following test state:
```
# cat /srv/salt/test.sls
test1:
  file.managed:
    - name: /tmp/test1
    - source: /testing/tests/integration/files/file/base/hello_world.txt
    - source_hash: c98c24b677eff44860afea6f493bbaec5bb1c4cbb209c6fc2bbb47f66ff2ad31

test2:
  file.managed:
    - name: /tmp/test2
    - source: /testing/tests/integration/files/file/base/hello_world.txt
    - source_hash: C98C24B677EFF44860AFEA6F493BBAEC5BB1C4CBB209C6FC2BBB47F66FF2AD31
```

Previously, this would show that the file had changed:
```
# salt-call --local state.sls test test=true
local:
----------
          ID: test1
    Function: file.managed
        Name: /tmp/test1
      Result: True
     Comment: The file /tmp/test1 is in the correct state
     Started: 14:42:43.254849
    Duration: 18.324 ms
     Changes:
----------
          ID: test2
    Function: file.managed
        Name: /tmp/test2
      Result: None
     Comment: The file /tmp/test2 is set to be changed
     Started: 14:42:43.273313
    Duration: 3.627 ms
     Changes:
              ----------
              diff:

Summary for local
------------
Succeeded: 2 (unchanged=1, changed=1)
Failed:    0
------------
Total states run:     2
Total run time:  21.951 ms
```

### New Behavior
Now, the state returns `True`, with no changes. This matches the regular behavior.
```
# salt-call --local state.sls test test=true
local:
----------
          ID: test1
    Function: file.managed
        Name: /tmp/test1
      Result: True
     Comment: The file /tmp/test1 is in the correct state
     Started: 14:41:45.302508
    Duration: 20.832 ms
     Changes:
----------
          ID: test2
    Function: file.managed
        Name: /tmp/test2
      Result: True
     Comment: The file /tmp/test2 is in the correct state
     Started: 14:41:45.323483
    Duration: 0.889 ms
     Changes:

Summary for local
------------
Succeeded: 2
Failed:    0
------------
Total states run:     2
Total run time:  21.721 ms
```

### Tests written?

Yes

### Commits signed with GPG?

Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
