### PR TITLE
Oxygen should be Fluorine in state.show_states addition

### DIFF
--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -1584,7 +1584,7 @@ def show_states(queue=False, **kwargs):
 
         salt '*' state.show_states
 
-    .. versionadded:: Oxygen
+    .. versionadded:: Fluorine
 
     '''
     conflict = _check_queue(queue, kwargs)


### PR DESCRIPTION
This feature was added in PR #44475, which is presently only in the `develop` branch. Therefore, the `versionadded` tag should be `Fluorine` instead of `Oxygen`.
