### PR TITLE
Add RCFS directory to team-core review list

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,6 +15,7 @@
 salt/**/*boto*                      @saltstack/team-boto
 
 # Team Core
+rfcs/*                              @saltstack/team-core
 salt/auth/*                         @saltstack/team-core
 salt/cache/*                        @saltstack/team-core
 salt/cli/*                          @saltstack/team-core


### PR DESCRIPTION
Any additions/changes to the files in the `rfcs` directory should be reviewed by `@saltstack/team-core`.
