### PR TITLE
[2017.7] fixes to states/pkg.py

### DIFF
--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -1685,45 +1685,40 @@ def installed(
             # checks reinstall targets works.
             pkg_ret = {}
 
-    if 'pkg.hold' in __salt__:
-        if 'hold' in kwargs:
-            try:
-                if kwargs['hold']:
-                    hold_ret = __salt__['pkg.hold'](
-                        name=name, pkgs=desired, sources=sources
-                    )
-                else:
-                    hold_ret = __salt__['pkg.unhold'](
-                        name=name, pkgs=desired, sources=sources
-                    )
-            except (CommandExecutionError, SaltInvocationError) as exc:
-                comment.append(str(exc))
+    if 'pkg.hold' in __salt__ and 'hold' in kwargs:
+        try:
+            action = 'pkg.hold' if kwargs['hold'] else 'pkg.unhold'
+            hold_ret = __salt__[action](
+                name=name, pkgs=desired, sources=sources
+            )
+        except (CommandExecutionError, SaltInvocationError) as exc:
+            comment.append(str(exc))
+            ret = {'name': name,
+                   'changes': changes,
+                   'result': False,
+                   'comment': '\n'.join(comment)}
+            if warnings:
+                ret.setdefault('warnings', []).extend(warnings)
+            return ret
+        else:
+            if 'result' in hold_ret and not hold_ret['result']:
                 ret = {'name': name,
-                       'changes': changes,
+                       'changes': {},
                        'result': False,
-                       'comment': '\n'.join(comment)}
+                       'comment': 'An error was encountered while '
+                                  'holding/unholding package(s): {0}'
+                                  .format(hold_ret['comment'])}
                 if warnings:
                     ret.setdefault('warnings', []).extend(warnings)
                 return ret
             else:
-                if 'result' in hold_ret and not hold_ret['result']:
-                    ret = {'name': name,
-                           'changes': {},
-                           'result': False,
-                           'comment': 'An error was encountered while '
-                                      'holding/unholding package(s): {0}'
-                                      .format(hold_ret['comment'])}
-                    if warnings:
-                        ret.setdefault('warnings', []).extend(warnings)
-                    return ret
-                else:
-                    modified_hold = [hold_ret[x] for x in hold_ret
-                                     if hold_ret[x]['changes']]
-                    not_modified_hold = [hold_ret[x] for x in hold_ret
-                                         if not hold_ret[x]['changes']
-                                         and hold_ret[x]['result']]
-                    failed_hold = [hold_ret[x] for x in hold_ret
-                                   if not hold_ret[x]['result']]
+                modified_hold = [hold_ret[x] for x in hold_ret
+                                 if hold_ret[x]['changes']]
+                not_modified_hold = [hold_ret[x] for x in hold_ret
+                                     if not hold_ret[x]['changes']
+                                     and hold_ret[x]['result']]
+                failed_hold = [hold_ret[x] for x in hold_ret
+                               if not hold_ret[x]['result']]
 
     if to_unpurge:
         changes['purge_desired'] = __salt__['lowpkg.unpurge'](*to_unpurge)

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -1524,48 +1524,45 @@ def installed(
 
         # check that the hold function is available
         if 'pkg.hold' in __salt__ and 'hold' in kwargs:
-                try:
-                    action = 'pkg.hold' if kwargs['hold'] else 'pkg.unhold'
-                    hold_ret = __salt__[action](
-                        name=name, pkgs=pkgs, sources=sources
-                    )
-                except (CommandExecutionError, SaltInvocationError) as exc:
-                    return {'name': name,
-                            'changes': {},
-                            'result': False,
-                            'comment': str(exc)}
+            try:
+                action = 'pkg.hold' if kwargs['hold'] else 'pkg.unhold'
+                hold_ret = __salt__[action](
+                    name=name, pkgs=pkgs, sources=sources
+                )
+            except (CommandExecutionError, SaltInvocationError) as exc:
+                return {'name': name,
+                        'changes': {},
+                        'result': False,
+                        'comment': str(exc)}
 
-                if 'result' in hold_ret and not hold_ret['result']:
-                    return {'name': name,
-                            'changes': {},
-                            'result': False,
-                            'comment': 'An error was encountered while '
-                                       'holding/unholding package(s): {0}'
-                                       .format(hold_ret['comment'])}
-                else:
-                    modified_hold = [hold_ret[x] for x in hold_ret
-                                     if hold_ret[x]['changes']]
-                    not_modified_hold = [hold_ret[x] for x in hold_ret
-                                         if not hold_ret[x]['changes']
-                                         and hold_ret[x]['result']]
-                    failed_hold = [hold_ret[x] for x in hold_ret
-                                   if not hold_ret[x]['result']]
+            if 'result' in hold_ret and not hold_ret['result']:
+                return {'name': name,
+                        'changes': {},
+                        'result': False,
+                        'comment': 'An error was encountered while '
+                                   'holding/unholding package(s): {0}'
+                                   .format(hold_ret['comment'])}
+            else:
+                modified_hold = [hold_ret[x] for x in hold_ret
+                                 if hold_ret[x]['changes']]
+                not_modified_hold = [hold_ret[x] for x in hold_ret
+                                     if not hold_ret[x]['changes']
+                                     and hold_ret[x]['result']]
+                failed_hold = [hold_ret[x] for x in hold_ret
+                               if not hold_ret[x]['result']]
 
-                    if modified_hold:
-                        for i in modified_hold:
-                            result['comment'] += '.\n{0}'.format(i['comment'])
-                            result['result'] = i['result']
-                            result['changes'][i['name']] = i['changes']
+                for i in modified_hold:
+                    result['comment'] += '.\n{0}'.format(i['comment'])
+                    result['result'] = i['result']
+                    result['changes'][i['name']] = i['changes']
 
-                    if not_modified_hold:
-                        for i in not_modified_hold:
-                            result['comment'] += '.\n{0}'.format(i['comment'])
-                            result['result'] = i['result']
+                for i in not_modified_hold:
+                    result['comment'] += '.\n{0}'.format(i['comment'])
+                    result['result'] = i['result']
 
-                    if failed_hold:
-                        for i in failed_hold:
-                            result['comment'] += '.\n{0}'.format(i['comment'])
-                            result['result'] = i['result']
+                for i in failed_hold:
+                    result['comment'] += '.\n{0}'.format(i['comment'])
+                    result['result'] = i['result']
         return result
 
     if to_unpurge and 'lowpkg.unpurge' not in __salt__:

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -1523,17 +1523,12 @@ def installed(
         # _find_install_targets() found no targets or encountered an error
 
         # check that the hold function is available
-        if 'pkg.hold' in __salt__:
-            if 'hold' in kwargs:
+        if 'pkg.hold' in __salt__ and 'hold' in kwargs:
                 try:
-                    if kwargs['hold']:
-                        hold_ret = __salt__['pkg.hold'](
-                            name=name, pkgs=pkgs, sources=sources
-                        )
-                    else:
-                        hold_ret = __salt__['pkg.unhold'](
-                            name=name, pkgs=pkgs, sources=sources
-                        )
+                    action = 'pkg.hold' if kwargs['hold'] else 'pkg.unhold'
+                    hold_ret = __salt__[action](
+                        name=name, pkgs=pkgs, sources=sources
+                    )
                 except (CommandExecutionError, SaltInvocationError) as exc:
                     return {'name': name,
                             'changes': {},

--- a/tests/integration/states/test_pkg.py
+++ b/tests/integration/states/test_pkg.py
@@ -736,3 +736,52 @@ class PkgTest(ModuleCase, SaltReturnAssertsMixin):
         self.assertEqual(ret_comment, 'An error was encountered while installing/updating group '
                                       '\'handle_missing_pkg_group\': Group \'handle_missing_pkg_group\' '
                                       'not found.')
+
+    @requires_system_grains
+    def test_pkg_015_installed_held(self, grains=None):  # pylint: disable=unused-argument
+        '''
+        Tests that a version number missing the release portion still resolves
+        as correctly installed. For example, version 2.0.2 instead of 2.0.2-1.el7
+        '''
+        os_family = grains.get('os_family', '')
+
+        if os_family.lower() != 'redhat' and os_family.lower() != 'debian':
+            self.skipTest('Test only runs on RedHat or Debian family')
+
+        pkg_targets = _PKG_TARGETS.get(os_family, [])
+
+        # Make sure that we have targets that match the os_family. If this
+        # fails then the _PKG_TARGETS dict above needs to have an entry added,
+        # with two packages that are not installed before these tests are run
+        self.assertTrue(pkg_targets)
+
+        target = pkg_targets[0]
+
+        # First we ensure that the package is installed
+        ret = self.run_state(
+            'pkg.installed',
+            name=target,
+            refresh=False,
+        )
+        self.assertSaltTrueReturn(ret)
+
+        # Then we check that the package is now held
+        ret = self.run_state(
+            'pkg.installed',
+            name=target,
+            hold=True,
+            refresh=False,
+        )
+
+        try:
+            tag = 'pkg_|-{0}_|-{0}_|-installed'.format(target)
+            self.assertSaltTrueReturn(ret)
+            self.assertIn(tag, ret)
+            self.assertIn('changes', ret[tag])
+            self.assertIn(target, ret[tag]['changes'])
+            self.assertEqual(ret[tag]['changes'][target], {'new': 'hold', 'old': 'install'})
+        finally:
+            # Clean up, unhold package and remove
+            self.run_function('pkg.unhold', name=target)
+            ret = self.run_state('pkg.removed', name=target)
+            self.assertSaltTrueReturn(ret)

--- a/tests/integration/states/test_pkg.py
+++ b/tests/integration/states/test_pkg.py
@@ -737,11 +737,11 @@ class PkgTest(ModuleCase, SaltReturnAssertsMixin):
                                       '\'handle_missing_pkg_group\': Group \'handle_missing_pkg_group\' '
                                       'not found.')
 
+    @requires_salt_modules('pkg.hold', 'pkg.unhold')
     @requires_system_grains
     def test_pkg_015_installed_held(self, grains=None):  # pylint: disable=unused-argument
         '''
-        Tests that a version number missing the release portion still resolves
-        as correctly installed. For example, version 2.0.2 instead of 2.0.2-1.el7
+        Tests that a package can be held even when the package is already installed.
         '''
         os_family = grains.get('os_family', '')
 

--- a/tests/support/helpers.py
+++ b/tests/support/helpers.py
@@ -1093,7 +1093,7 @@ def requires_salt_modules(*names):
                 )
 
             for name in names:
-                if name not in cls.run_function('sys.doc'):
+                if name not in cls.run_function('sys.doc', [name]):
                     cls.skipTest(
                         'Salt module {0!r} is not available'.format(name)
                     )


### PR DESCRIPTION
### What does this PR do?
Fixing a situation when a package is already installed via salt or manually and a state attempts to set that package to be held.  

### What issues does this PR fix or reference?
#46689 

### Previous Behavior
Previously the holding/unholding logic was only being run against packages that were being installed.

### New Behavior
This change moves the holding logic outside and runs it against all desired packages.  Adding a new test to test holding logic.

### Tests written?
Yes

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
