### PR TITLE
Fix outputter detection in jobs.lookup_jid runner

### DIFF
--- a/salt/runners/jobs.py
+++ b/salt/runners/jobs.py
@@ -150,7 +150,7 @@ def lookup_jid(jid,
     try:
         # Check if the return data has an 'out' key. We'll use that as the
         # outputter in the absence of one being passed on the CLI.
-        outputter = data[next(iter(data))].get('out')
+        outputter = returns[next(iter(returns))].get('out')
     except (StopIteration, AttributeError):
         outputter = None
 


### PR DESCRIPTION
The outputter detection was always failing because `data` is the return from the `jobs.list_job` runner, which has an extra dictionary level at the top.