### PR TITLE
Prepend test needs file.touch method

### DIFF
--- a/tests/unit/states/test_file.py
+++ b/tests/unit/states/test_file.py
@@ -1202,6 +1202,7 @@ class TestFileState(TestCase, LoaderModuleMockMixin):
                         {'file.directory_exists': mock_f,
                          'file.makedirs': mock_t,
                          'file.stats': mock_f,
+                         'file.touch': mock_t,
                          'cp.get_template': mock_f,
                          'file.search': mock_f,
                          'file.prepend': mock_t}):


### PR DESCRIPTION
### What does this PR do?

Fixes `file.test_prepend` when run with full integration test suite. 

https://jenkinsci.saltstack.com/job/2017.7/view/Python3/job/salt-windows-2016-py3/76/testReport/junit/unit.states.test_file/TestFileState/test_prepend/

### Tests written?

No - Fixes existing test

### Commits signed with GPG?

Yes