### PR TITLE
Fix issue with redismod.hmset method

### DIFF
--- a/salt/modules/redismod.py
+++ b/salt/modules/redismod.py
@@ -395,7 +395,14 @@ def hmset(key, **fieldsvals):
     database = fieldsvals.pop('db', None)
     password = fieldsvals.pop('password', None)
     server = _connect(host, port, database, password)
-    return server.hmset(key, fieldsvals)
+    # orchestration passes several private key/var pairs in that we don't want
+    # to set in redis.
+    redispairs = {}
+    for field, value in fieldsvals.iteritems():
+        if not field.startswith('__'):
+            redispairs[field] = value
+
+    return server.hmset(key, redispairs)
 
 
 def hset(key, field, value, host=None, port=None, db=None, password=None):

--- a/salt/modules/redismod.py
+++ b/salt/modules/redismod.py
@@ -395,7 +395,7 @@ def hmset(key, **fieldsvals):
     database = fieldsvals.pop('db', None)
     password = fieldsvals.pop('password', None)
     server = _connect(host, port, database, password)
-    return server.hmset(key, **fieldsvals)
+    return server.hmset(key, fieldsvals)
 
 
 def hset(key, field, value, host=None, port=None, db=None, password=None):

--- a/salt/modules/redismod.py
+++ b/salt/modules/redismod.py
@@ -19,6 +19,7 @@ Module to provide redis functionality to Salt
 from __future__ import absolute_import
 from salt.ext.six.moves import zip
 from salt.ext import six
+from salt.utils import clean_kwargs
 from datetime import datetime
 
 # Import third party libs
@@ -395,14 +396,7 @@ def hmset(key, **fieldsvals):
     database = fieldsvals.pop('db', None)
     password = fieldsvals.pop('password', None)
     server = _connect(host, port, database, password)
-    # orchestration passes several private key/var pairs in that we don't want
-    # to set in redis.
-    redispairs = {}
-    for field, value in fieldsvals.iteritems():
-        if not field.startswith('__'):
-            redispairs[field] = value
-
-    return server.hmset(key, redispairs)
+    return server.hmset(key, clean_kwargs(**fieldsvals))
 
 
 def hset(key, field, value, host=None, port=None, db=None, password=None):


### PR DESCRIPTION
redis.StrictRedis.hmset expects a dict as its second arg, not a series of keyword args.

hmset(self, name, mapping) method of redis.client.StrictRedis instance
    Set key to value within hash ``name`` for each corresponding
    key and value from the ``mapping`` dict.

### What does this PR do?

Fixes the call to redis.StrictRedis.hmset in the redismod.hmset method

### What issues does this PR fix or reference?

N/A

### Previous Behavior

Calling the redismod.hmset method either from the command line or a state/orchestration would return an invalid arguments error because the `fieldsvars` dict would be unpacked and passed as individual args:

`Passed invalid arguments: hmset() got an unexpected keyword argument 'test1'.`

### New Behavior

`fieldsvars` dict is passed as a dict, method runs successfully.

### Tests written?

No

### Commits signed with GPG?

Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
