### PR TITLE
Added support for using passwd to use for sudo authentication

### DIFF
--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -1175,7 +1175,12 @@ class Single(object):
         '''
         Prepare the command string
         '''
-        sudo = 'sudo' if self.target['sudo'] else ''
+        if self.target['sudo']:
+            sudo = 'sudo'
+            # set the sudo promtp parameter with the unique prompt if the password is set
+            sudo += ' -p \"{0}\"'.format(shell.SUDO_PROMPT) if self.target['passwd'] else ''
+        else:
+            sudo = ''
         sudo_user = self.target['sudo_user']
         if '_caller_cachedir' in self.opts:
             cachedir = self.opts['_caller_cachedir']

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -1175,10 +1175,8 @@ class Single(object):
         '''
         Prepare the command string
         '''
-        if self.target['sudo']:
-            sudo = 'sudo'
-            # set the sudo promtp parameter with the unique prompt if the password is set
-            sudo += ' -p \"{0}\"'.format(shell.SUDO_PROMPT) if self.target['passwd'] else ''
+        if self.target.get('sudo'):
+            sudo = 'sudo -p \"{0}\"'.format(shell.SUDO_PROMPT) if self.target.get('passwd') else 'sudo'
         else:
             sudo = ''
         sudo_user = self.target['sudo_user']


### PR DESCRIPTION
Fixes 
#8882
If sudo and passwd is set in the roster file, salt-ssh will generate
the sudo command with the -p parameter with the unique string. This
string is used to identify sudo asking for the sudo password. The
passwd provided is used.
This fix should work when passwd is used for ssh authentication and
when a seperate private key is used for ssh authentication.

### What does this PR do?

It allows a user to provide a sudo password using the passwd field in the roster file (or the command line overwrite I suppose)

### What issues does this PR fix or reference?

#8882

### Previous Behavior

If the ssh user wanted to use sudo and had not NOPASSWD set, sudo would not succeed as a password should be provided, but salt-ssh was not expecting it. 

### New Behavior

If the passwd field is set, the -p parameter will be added to the sudo command, like
sudo -p [salt:sudo:d11bd4221135c33324a6bdc09674146fbfdf519989847491e34a689369bbce23]passwd:
if the sudo requires a password the prompt is returned. salt.ssh.client.shell will recognize the prompt and return the password.
The above allows a user to use sudo with a password and without NOPASSWD set.

### Tests written?

No
This should be tested with an integration test, which requires different accounts to be setup.

### Commits signed with GPG?

Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
