### PR TITLE
Avoid logging inside the varstack __virtual__ function

### DIFF
--- a/salt/pillar/varstack_pillar.py
+++ b/salt/pillar/varstack_pillar.py
@@ -21,27 +21,20 @@ varstack on how this file is evaluated.
 
 from __future__ import absolute_import, print_function, unicode_literals
 
-# Import python libs
-import logging
-
-HAS_VARSTACK = False
 try:
     import varstack
-    HAS_VARSTACK = True
 except ImportError:
-    pass
-
-# Set up logging
-log = logging.getLogger(__name__)
+    varstack = None
 
 # Define the module's virtual name
 __virtualname__ = 'varstack'
 
 
 def __virtual__():
-    if not HAS_VARSTACK:
-        return False
-    return __virtualname__
+    return (
+        varstack and __virtualname__ or False,
+        'The varstack module could not be loaded: varstack dependency is missing.'
+    )
 
 
 def ext_pillar(minion_id,  # pylint: disable=W0613

--- a/salt/tops/varstack_top.py
+++ b/salt/tops/varstack_top.py
@@ -45,28 +45,20 @@ managed by salt as if given from a top.sls file.
 
 from __future__ import absolute_import, print_function, unicode_literals
 
-# Import python libs
-import logging
-
 try:
-    HAS_VARSTACK = False
     import varstack
-    HAS_VARSTACK = True
 except ImportError:
-    pass
-
-# Set up logging
-log = logging.getLogger(__name__)
+    varstack = None
 
 # Define the module's virtual name
 __virtualname__ = 'varstack'
 
 
 def __virtual__():
-    if not HAS_VARSTACK:
-        log.error("Can't find varstack master_top")
-        return False
-    return __virtualname__
+    return (
+        varstack and __virtualname__ or False,
+        'The varstack module could not be loaded: varstack dependency is missing.'
+    )
 
 
 def top(**kwargs):


### PR DESCRIPTION
### What does this PR do?

Removes the `[ERROR   ] Can't find varstack master_top` from logs when varstack is not used.  This seems to be the recommended practice:  https://docs.saltstack.com/en/latest/ref/modules/#logging-restrictions

### Tests written?

No

### Commits signed with GPG?

No
