### PR TITLE
Make core.py tolerant of invalid chars in DMI data

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -947,7 +947,7 @@ def _virtual(osdata):
         if os.path.isfile('/sys/devices/virtual/dmi/id/product_name'):
             try:
                 with salt.utils.files.fopen('/sys/devices/virtual/dmi/id/product_name', 'r') as fhr:
-                    output = salt.utils.stringutils.to_unicode(fhr.read())
+                    output = salt.utils.stringutils.to_unicode(fhr.read(), errors='replace')
                     if 'VirtualBox' in output:
                         grains['virtual'] = 'VirtualBox'
                     elif 'RHEV Hypervisor' in output:
@@ -2288,7 +2288,7 @@ def _hw_data(osdata):
             if os.path.exists(contents_file):
                 try:
                     with salt.utils.files.fopen(contents_file, 'r') as ifile:
-                        grains[key] = ifile.read().strip()
+                        grains[key] = salt.utils.stringutils.to_unicode(ifile.read().strip(), errors='replace')
                         if key == 'uuid':
                             grains['uuid'] = grains['uuid'].lower()
                 except (IOError, OSError) as err:


### PR DESCRIPTION
### What does this PR do?
Avoids unicode errors when DMI data has invalid characters in it. Solves issue #48184. Improves on PR #48216.

### What issues does this PR fix or reference?

https://github.com/saltstack/salt/issues/48184

### Previous Behavior
UnicodeDecodeError raised and prevent salt-minion from running.

### New Behavior
These errors are not raised because invalid characters are replaced.

### Tests written?

No - but @Ch3LL has already added one test for this in PR #48216. I suppose a further test could be added with \xff as file contents.

### Commits signed with GPG?

Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
