### PR TITLE
Switch init system log message to debug

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1597,7 +1597,7 @@ def os_data():
                     # my_init as pid1
                     grains['init'] = 'runit'
                 else:
-                    log.info(
+                    log.debug(
                         'Could not determine init system from command line: (%s)',
                         ' '.join(init_cmdline)
                     )


### PR DESCRIPTION
This prevents unnecessarily info logging when running Salt in environments without an init system (e.g. Docker).

Resolves #48402.