### PR TITLE
Fix for elasticsearch.index_template_present fails on ES <6.x #48442

### DIFF
--- a/salt/states/elasticsearch.py
+++ b/salt/states/elasticsearch.py
@@ -275,10 +275,16 @@ def index_template_present(name, definition, check_definition=False):
                     ret['comment'] = 'Cannot create index template {0}, {1}'.format(name, output)
         else:
             if check_definition:
-                definition_to_diff = {'aliases': {}, 'mappings': {}, 'settings': {}}
-                definition_to_diff.update(definition)
+                if type(definition) == str:
+                    definition_parsed = salt.utils.json.loads(definition)
+                else:
+                    definition_parsed = definition
                 current_template = __salt__['elasticsearch.index_template_get'](name=name)[name]
-                diff = __utils__['dictdiffer.deep_diff'](current_template, definition_to_diff)
+                # Prune empty keys (avoid false positive diff)
+                for key in ("mappings", "aliases", "settings"):
+                    if current_template[key] == {}:
+                        del(current_template[key])
+                diff = __utils__['dictdiffer.deep_diff'](current_template, definition_parsed)
                 if len(diff) != 0:
                     if __opts__['test']:
                         ret['comment'] = 'Index template {0} exist but need to be updated'.format(name)

--- a/salt/states/elasticsearch.py
+++ b/salt/states/elasticsearch.py
@@ -275,7 +275,7 @@ def index_template_present(name, definition, check_definition=False):
                     ret['comment'] = 'Cannot create index template {0}, {1}'.format(name, output)
         else:
             if check_definition:
-                if type(definition) == str:
+                if isinstance(definition, str):
                     definition_parsed = salt.utils.json.loads(definition)
                 else:
                     definition_parsed = definition
@@ -283,7 +283,7 @@ def index_template_present(name, definition, check_definition=False):
                 # Prune empty keys (avoid false positive diff)
                 for key in ("mappings", "aliases", "settings"):
                     if current_template[key] == {}:
-                        del(current_template[key])
+                        del current_template[key]
                 diff = __utils__['dictdiffer.deep_diff'](current_template, definition_parsed)
                 if len(diff) != 0:
                     if __opts__['test']:


### PR DESCRIPTION
### What does this PR do?

It resolv a bug related to index template for Elasticsearch before 6.x

### What issues does this PR fix or reference?

It fixes issue #48442.

### Tests written?

No

### Commits signed with GPG?

No
