### PR TITLE
Influx module user fixes

### DIFF
--- a/doc/topics/releases/fluorine.rst
+++ b/doc/topics/releases/fluorine.rst
@@ -720,6 +720,34 @@ The :py:func:`event.send <salt.states.event.send>` state does not know the
 results of the sent event, so returns changed every state run.  It can now be
 set to return changed or unchanged.
 
+:py:mod:`influxdb_user.present <salt.states.influxdb_user>` Influxdb User Module State
+---------------------------------------------------------------------------------------
+
+The ``password`` parameter has been changed to ``passwd`` to remove the
+name collusion with the influxdb client configuration (``client_kwargs``)
+allowing management of users when authentication is enabled on the influxdb
+instance
+
+Old behavior:
+
+.. code-block:: example user in influxdb
+
+    influxdb_user.present:
+      - name: exampleuser
+      - password: exampleuserpassword
+      - user: admin
+      - password: adminpassword
+
+New behavior:
+
+.. code-block:: example user in influxdb
+
+    influxdb_user.present:
+      - name: exampleuser
+      - passwd: exampleuserpassword
+      - user: admin
+      - password: adminpassword
+
 LDAP External Authentication
 ============================
 

--- a/salt/modules/influx.py
+++ b/salt/modules/influx.py
@@ -22,7 +22,7 @@ version 0.9+)
     Most functions in this module allow you to override or provide some or all
     of these settings via keyword arguments::
 
-        salt '*' influxdb.foo_function user='influxadmin' password='s3cr1t'
+        salt '*' influxdb.foo_function user='influxadmin' passwd='s3cr1t'
 
     would override ``user`` and ``password`` while still using the defaults for
     ``host`` and ``port``.
@@ -213,14 +213,14 @@ def user_info(name, **client_args):
         pass
 
 
-def create_user(name, password, admin=False, **client_args):
+def create_user(name, passwd, admin=False, **client_args):
     '''
     Create a user.
 
     name
         Name of the user to create.
 
-    password
+    passwd
         Password of the new user.
 
     admin : False
@@ -239,19 +239,19 @@ def create_user(name, password, admin=False, **client_args):
         return False
 
     client = _client(**client_args)
-    client.create_user(name, password, admin)
+    client.create_user(name, passwd, admin)
 
     return True
 
 
-def set_user_password(name, password, **client_args):
+def set_user_password(name, passwd, **client_args):
     '''
     Change password of a user.
 
     name
         Name of the user for whom to set the password.
 
-    password
+    passwd
         New password of the user.
 
     CLI Example:
@@ -265,7 +265,7 @@ def set_user_password(name, password, **client_args):
         return False
 
     client = _client(**client_args)
-    client.set_user_password(name, password)
+    client.set_user_password(name, passwd)
 
     return True
 

--- a/salt/states/influxdb_user.py
+++ b/salt/states/influxdb_user.py
@@ -20,7 +20,7 @@ def __virtual__():
 
 
 def present(name,
-            password,
+            passwd,
             admin=False,
             grants=None,
             **client_args):
@@ -30,7 +30,7 @@ def present(name,
     name
         Name of the user to manage
 
-    password
+    passwd
         Password of the user
 
     admin : False
@@ -52,7 +52,7 @@ def present(name,
         example user present in influxdb:
           influxdb_user.present:
             - name: example
-            - password: somepassword
+            - passwd: somepassword
             - admin: False
             - grants:
                 foo_db: read
@@ -72,7 +72,7 @@ def present(name,
             return ret
         else:
             if not __salt__['influxdb.create_user'](
-                    name, password, admin=admin, **client_args):
+                    name, passwd, admin=admin, **client_args):
                 ret['comment'] = 'Failed to create user {0}'.format(name)
                 ret['result'] = False
                 return ret


### PR DESCRIPTION
### What does this PR do?
Removes a collision between the client_args parameter and the inputs to user creation and updating in the salt module and state for Influxdb. This allows user management on a system require authentication.

Also updates the documentation for the grants parameter to make its usage more clear.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/37670

### Tests written?

No

### Commits signed with GPG?

No
