### PR TITLE
Do not call VT terminal if no command or an empty password passed.

### DIFF
--- a/salt/client/ssh/shell.py
+++ b/salt/client/ssh/shell.py
@@ -374,6 +374,9 @@ class Shell(object):
         Execute a shell command via VT. This is blocking and assumes that ssh
         is being run
         '''
+        if not cmd:
+            return '', 'No command or passphrase', 245
+
         term = salt.utils.vt.Terminal(
                 cmd,
                 shell=True,


### PR DESCRIPTION
### What does this PR do?

Bugfix

### What issues does this PR fix or reference?

Crash on empty passphrase.

### Previous Behavior

SaltSSH somewhere, when asks for a passphrase, do not give any, just hit ENTER. You will get this:

```
[ERROR   ] An un-handled exception was caught by salt's global exception handler:
TerminalException: You need to pass at least one of "args", "executable" 
Traceback (most recent call last):
  File "/usr/bin/salt-ssh", line 10, in <module>
    salt_ssh()
  File "/usr/lib/python2.7/site-packages/salt/scripts.py", line 425, in salt_ssh
    client.run()
  File "/usr/lib/python2.7/site-packages/salt/cli/ssh.py", line 24, in run
    ssh.run()
  File "/usr/lib/python2.7/site-packages/salt/client/ssh/__init__.py", line 753, in run
    ret = self.key_deploy(host, ret)
  File "/usr/lib/python2.7/site-packages/salt/client/ssh/__init__.py", line 451, in key_deploy
    return self._key_deploy_run(host, target, True)
  File "/usr/lib/python2.7/site-packages/salt/client/ssh/__init__.py", line 474, in _key_deploy_run
    stdout, stderr, retcode = single.shell.copy_id()
  File "/usr/lib/python2.7/site-packages/salt/client/ssh/shell.py", line 236, in copy_id
    stdout, stderr, retcode = self._run_cmd(self._copy_id_str_old())
  File "/usr/lib/python2.7/site-packages/salt/client/ssh/shell.py", line 382, in _run_cmd
    stream_stderr=False)
  File "/usr/lib/python2.7/site-packages/salt/utils/vt.py", line 128, in __init__
    'You need to pass at least one of "args", "executable" '
TerminalException: You need to pass at least one of "args", "executable"
Traceback (most recent call last):
  File "/usr/bin/salt-ssh", line 10, in <module>
    salt_ssh()
  File "/usr/lib/python2.7/site-packages/salt/scripts.py", line 425, in salt_ssh
    client.run()
  File "/usr/lib/python2.7/site-packages/salt/cli/ssh.py", line 24, in run
    ssh.run()
  File "/usr/lib/python2.7/site-packages/salt/client/ssh/__init__.py", line 753, in run
    ret = self.key_deploy(host, ret)
  File "/usr/lib/python2.7/site-packages/salt/client/ssh/__init__.py", line 451, in key_deploy
    return self._key_deploy_run(host, target, True)
  File "/usr/lib/python2.7/site-packages/salt/client/ssh/__init__.py", line 474, in _key_deploy_run
    stdout, stderr, retcode = single.shell.copy_id()
  File "/usr/lib/python2.7/site-packages/salt/client/ssh/shell.py", line 236, in copy_id
    stdout, stderr, retcode = self._run_cmd(self._copy_id_str_old())
  File "/usr/lib/python2.7/site-packages/salt/client/ssh/shell.py", line 382, in _run_cmd
    stream_stderr=False)
  File "/usr/lib/python2.7/site-packages/salt/utils/vt.py", line 128, in __init__
    'You need to pass at least one of "args", "executable" '
salt.utils.vt.TerminalException: You need to pass at least one of "args", "executable" 
Exception AttributeError: "'Terminal' object has no attribute 'pid'" in <bound method Terminal.__del__ of <salt.utils.vt.Terminal object at 0x7fc2169acad0>> ignored
```

### New Behavior

You will get this:

```
$ salt-ssh -i localhost test.ping
Permission denied for host localhost, do you want to deploy the salt-ssh key? (password required):
[Y/n] 
Password for root@localhost: 
localhost:
    Permission denied (publickey,password).
```

### Tests written?

No
