### PR TITLE
support RunOnce in the VMware salt-cloud driver

### DIFF
--- a/doc/topics/cloud/vmware.rst
+++ b/doc/topics/cloud/vmware.rst
@@ -549,6 +549,11 @@ Set up an initial profile at ``/etc/salt/cloud.profiles`` or
 ``win_installer``
     Specify windows minion client installer path
 
+``win_run_once``
+    Specify a list of commands to run on first login to a windows minion
+
+    https://www.vmware.com/support/developer/vc-sdk/visdk25pubs/ReferenceGuide/vim.vm.customization.GuiRunOnce.html
+
 Cloning a VM
 ============
 

--- a/salt/cloud/clouds/vmware.py
+++ b/salt/cloud/clouds/vmware.py
@@ -2534,6 +2534,9 @@ def create(vm_):
     win_user_fullname = config.get_cloud_config_value(
         'win_user_fullname', vm_, __opts__, search_global=False, default='Windows User'
     )
+    win_run_once = config.get_cloud_config_value(
+        'win_run_once', vm_, __opts__, search_global=False, default=None
+    )
 
     # Get service instance object
     si = _get_si()
@@ -2806,6 +2809,9 @@ def create(vm_):
                 identity.guiUnattended.password = vim.vm.customization.Password()
                 identity.guiUnattended.password.value = win_password
                 identity.guiUnattended.password.plainText = plain_text
+                if win_run_once:
+                    identity.guiRunOnce = vim.vm.customization.GuiRunOnce()
+                    identity.guiRunOnce.commandList = win_run_once
                 identity.userData = vim.vm.customization.UserData()
                 identity.userData.fullName = win_user_fullname
                 identity.userData.orgName = win_organization_name


### PR DESCRIPTION

Add support for GuiRunOnce for Windows machines in the salt-cloud VMware driver. The driver already sets autoLogon=True and autoLoginCount=1 so the commands are run automatically.
The commands are run post customization so there is no real way to get their result directly. It must be saved to a file and checked independently.

Implements #48455 
