### PR TITLE
Fixes #48474 - Send Token in All Requests in NetBox Execution Module 

### DIFF
--- a/salt/modules/netbox.py
+++ b/salt/modules/netbox.py
@@ -67,8 +67,8 @@ def _config():
 
 def _nb_obj(auth_required=False):
     pynb_kwargs = {}
+    pynb_kwargs['token'] = _config().get('token')
     if auth_required:
-        pynb_kwargs['token'] = _config().get('token')
         pynb_kwargs['private_key_file'] = _config().get('keyfile')
     return pynetbox.api(_config().get('url'), **pynb_kwargs)
 

--- a/tests/unit/modules/test_netbox.py
+++ b/tests/unit/modules/test_netbox.py
@@ -80,3 +80,10 @@ class NetBoxTestCase(TestCase, LoaderModuleMockMixin):
             self.assertTrue(
                 'token' and 'private_key_file' in mock.call_args[1]
             )
+
+    def test_token_present(self):
+        with patch('pynetbox.api', MagicMock()) as mock:
+            netbox.get('dcim', 'devices', name='test')
+            self.assertTrue(
+                'token' in mock.call_args[1]
+            )


### PR DESCRIPTION
### What does this PR do?
Decouples token and private_key_file config options. We'll send the token, if it's set, in all cases so that we can authenticate when LOGIN_REQUIRED is True.

### What issues does this PR fix or reference?
#48474 

### Previous Behavior
Execution module would only send token on queries to the secrets endpoint.

### New Behavior
We send the token, if present in the configuration, on requests to all endpoints.

### Tests written?

Yes

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
