### PR TITLE
Make example Saltfile work by default

### DIFF
--- a/doc/topics/ssh/index.rst
+++ b/doc/topics/ssh/index.rst
@@ -213,6 +213,7 @@ YAML contents:
 
     salt-ssh:
       config_dir: path/to/config/dir
+      ssh_log_file: salt-ssh.log
       ssh_max_procs: 30
       ssh_wipe: True
 


### PR DESCRIPTION
### What does this PR do?

Improve documentation for `salt-ssh` to make the example Saltfile work. Without specifying a log file salt-ssh will fail like this:

```
$ salt-ssh '*' test.ping
No permissions to access "/var/log/salt/ssh", are you running as the correct user?
```

Adding a log file to the example Saltfile makes everything work as expected. The error is very hard to trace, every time I start a new project on salt-ssh I run into this and it took me some time to figure out how to solve it.

### What issues does this PR fix or reference?

Related to #38336, there is a lot of discussion about possible options so I am not sure it is fixed completely.

### Commits signed with GPG?

Yes