### PR TITLE
Return IP if socket.gethostbyaddr fails

### DIFF
--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -223,7 +223,7 @@ def ip_to_host(ip):
         hostname, aliaslist, ipaddrlist = socket.gethostbyaddr(ip)
     except Exception as exc:
         log.debug('salt.utils.network.ip_to_host(%r) failed: %s', ip, exc)
-        hostname = None
+        hostname = ip
     return hostname
 
 # pylint: enable=C0103


### PR DESCRIPTION
The function `ip_to_host` will return the ip value, that was given as argument, if `socket.gethostbyaddr` raises an exception.


Roster:

```yaml
artemis:
  host: artemis
```

```
$ salt-ssh artemis -r "/bin/bash -c 'cowsay foo'"
[ERROR   ] An un-handled exception was caught by salt's global exception handler:
TypeError: expected str, bytes or os.PathLike object, not NoneType
Traceback (most recent call last):
  File "/usr/bin/salt-ssh", line 10, in <module>
    salt_ssh()
  File "/usr/lib/python3.6/site-packages/salt/scripts.py", line 425, in salt_ssh
    client.run()
  File "/usr/lib/python3.6/site-packages/salt/cli/ssh.py", line 23, in run
    ssh = salt.client.ssh.SSH(self.config)
  File "/usr/lib/python3.6/site-packages/salt/client/ssh/__init__.py", line 231, in __init__
    self.tgt_type)
  File "/usr/lib/python3.6/site-packages/salt/roster/__init__.py", line 105, in targets
    targets.update(self.rosters[f_str](tgt, tgt_type))
  File "/usr/lib/python3.6/site-packages/salt/roster/flat.py", line 50, in targets
    return rmatcher.targets()
  File "/usr/lib/python3.6/site-packages/salt/roster/flat.py", line 68, in targets
    return getattr(self, 'ret_{0}_minions'.format(self.tgt_type))()
  File "/usr/lib/python3.6/site-packages/salt/roster/flat.py", line 78, in ret_glob_minions
    if fnmatch.fnmatch(minion, self.tgt):
  File "/usr/lib64/python3.6/fnmatch.py", line 35, in fnmatch
    pat = os.path.normcase(pat)
  File "/usr/lib64/python3.6/posixpath.py", line 54, in normcase
    s = os.fspath(s)
TypeError: expected str, bytes or os.PathLike object, not NoneType
```

The above happens if the dns resolver returns `NXDOMAIN` for reverse lookups.
This happens because the `self.opts['tgt']` got overwritten with the `None` return value
from `ip_to_host` in `_expand_target` in `client/ssh/__init__.py`.

In the described setup salt will for some reason pass the value of `host:` to the `ip_to_host` function.
`ip_to_host` will then pass it to `socket.gethostbyaddr`.
`socket.gethostbyaddr` when given a hostname (like `artemis`) will use the dns search domain to first resolve that hostname to an IP and then try to resolve it back to a hostname (resulting in `artemis.suse.de`, if the DNS server supports reverse lookups for local ip ranges - my local unbound server doesn't resolve such addresses by default, resulting in the described error).

Now the error doesn't appear anymore.