### PR TITLE
[2018.3] Fix 2 bugs found in the file.check_perms function

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -4539,27 +4539,6 @@ def check_perms(name, ret, user, group, mode, attrs=None, follow_symlinks=False)
         elif 'cgroup' in perms and user != '':
             ret['changes']['group'] = group
 
-    # Mode changes if needed
-    if mode is not None:
-        # File is a symlink, ignore the mode setting
-        # if follow_symlinks is False
-        if os.path.islink(name) and not follow_symlinks:
-            pass
-        else:
-            mode = salt.utils.files.normalize_mode(mode)
-            if mode != perms['lmode']:
-                if __opts__['test'] is True:
-                    ret['changes']['mode'] = mode
-                else:
-                    set_mode(name, mode)
-                    if mode != salt.utils.files.normalize_mode(get_mode(name)):
-                        ret['result'] = False
-                        ret['comment'].append(
-                            'Failed to change mode to {0}'.format(mode)
-                        )
-                    else:
-                        ret['changes']['mode'] = mode
-
     if isinstance(orig_comment, six.string_types):
         if orig_comment:
             ret['comment'].insert(0, orig_comment)

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -4519,6 +4519,7 @@ def check_perms(name, ret, user, group, mode, attrs=None, follow_symlinks=False)
                                           .format(user))
         elif 'cuser' in perms and user != '':
             ret['changes']['user'] = user
+
     if group:
         if isinstance(group, int):
             group = gid_to_group(group)
@@ -4538,13 +4539,6 @@ def check_perms(name, ret, user, group, mode, attrs=None, follow_symlinks=False)
                                       .format(group))
         elif 'cgroup' in perms and user != '':
             ret['changes']['group'] = group
-
-    if isinstance(orig_comment, six.string_types):
-        if orig_comment:
-            ret['comment'].insert(0, orig_comment)
-        ret['comment'] = '; '.join(ret['comment'])
-    if __opts__['test'] is True and ret['changes']:
-        ret['result'] = None
 
     if not salt.utils.platform.is_windows() and not is_dir:
         # Replace attributes on file if it had been removed
@@ -4597,6 +4591,18 @@ def check_perms(name, ret, user, group, mode, attrs=None, follow_symlinks=False)
                             )
                         else:
                             ret['changes']['attrs'] = attrs
+
+    # Only combine the comment list into a string
+    # after all comments are added above
+    if isinstance(orig_comment, six.string_types):
+        if orig_comment:
+            ret['comment'].insert(0, orig_comment)
+        ret['comment'] = '; '.join(ret['comment'])
+
+    # Set result to None at the very end of the function,
+    # after all changes have been recorded above
+    if __opts__['test'] is True and ret['changes']:
+        ret['result'] = None
 
     return ret, perms
 


### PR DESCRIPTION
### What does this PR do?
This PR fixes 2 bugs found in the file.check_perms function. 
- Removes the duplicate `mode` changes check. This was accidentally added during a merge forward from 2017.7 as PRs #48398 and #48399 made similar changes, and the duplicate mode section came in from the merge forward.
- Move comment string join and test/changes check to bottom of file.check_perms

### What issues does this PR fix or reference?
Fixes https://github.com/saltstack/salt-jenkins/issues/1021

### Previous Behavior
The `integration.states.test_user.UserTest.test_user_if_present` test was failing:
```
Traceback (most recent call last):
  File "/testing/tests/support/mixins.py", line 550, in assertSaltTrueReturn
    self.assertTrue(saltret)
  File "/usr/lib/python3.5/unittest/case.py", line 677, in assertTrue
    raise self.failureException(msg)
AssertionError: False is not true

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/testing/tests/integration/states/test_user.py", line 59, in test_user_if_present
    self.assertSaltTrueReturn(ret)
  File "/testing/tests/support/mixins.py", line 556, in assertSaltTrueReturn
    **(next(six.itervalues(ret)))
AssertionError: False is not True. Salt Comment:
An exception occurred in this state: Traceback (most recent call last):
  File "/testing/salt/state.py", line 1913, in call
    **cdata['kwargs'])
  File "/testing/salt/loader.py", line 1834, in wrapper
    return f(*args, **kwargs)
  File "/testing/salt/states/user.py", line 613, in present
    __salt__['file.mkdir'](val, pre['uid'], pre['gid'], 0o755)
  File "/testing/salt/modules/file.py", line 5554, in mkdir
    makedirs_perms(directory, user, group, mode)
  File "/testing/salt/modules/file.py", line 5659, in makedirs_perms
    int('{0}'.format(mode)) if mode else None)
  File "/testing/salt/modules/file.py", line 4590, in check_perms
    ret['comment'].append(
AttributeError: 'str' object has no attribute 'append'
```

### New Behavior
The `integration.states.test_user.UserTest.test_user_if_present` test passes.

In 2018.3, file attribute checks were added to file.check_perms and then the mode checks were moved down lower in the function. However, there is some logic to handle original comments where the list of comments is joined into a single string. There is also some logic to return `None` when changes are
present.

This logic is (correctly) at the bottom of the file.check_perms function in the 2017.7 branch.

This commit moves that logic back down to the bottom of the file.check_perms function for the 2018.3 branch.

We need this logic at the bottom of the function for the following reasons:

1. We must wait to detect if changes occur until the very end. If changes occur during the file attribute check, then the `None` return will not get set when it should be.
2. We cannot join the comment strings together until all of the potential comments have been added to the comment list. Otherwise the function will stacktrace because you cannot `append` to a unicode type.

### Tests written?

No - tests already written, which found this bug because it was failing.

### Commits signed with GPG?

Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
