### PR TITLE
upgrade dependencies for pytest tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ skip_missing_interpreters = True
 skipsdist = True
 
 [testenv]
-deps = -r{toxinidir}/requirements/tests.txt
+deps = -Ur{toxinidir}/requirements/tests.txt
 commands = pytest --rootdir {toxinidir} {posargs}
 passenv = LANG HOME
 sitepackages = True


### PR DESCRIPTION
When using sitepackages so that we can test stuff like importing yum and stuff, we need to upgrade packages in case stuff is installed already like psutils on the system.

### Commits signed with GPG?

Yes