### PR TITLE
Rollback python-certifi-win32

### DIFF
--- a/pkg/windows/req.txt
+++ b/pkg/windows/req.txt
@@ -24,7 +24,7 @@ pycrypto==2.6.1
 pycurl==7.43.0
 PyMySQL==0.7.11
 pyOpenSSL==17.0.0
-python-certifi-win32==1.2
+#python-certifi-win32==1.2
 python-dateutil==2.6.0
 python-gnupg==0.4.0
 pywin32==223


### PR DESCRIPTION
### What does this PR do?
Rolls back the `python-certifi-win32` dependency addition. This has been causing some problems with the test suite. We need to look into this further before adding this dependency to see exactly how it's patching things.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/46644

Added in:
https://github.com/saltstack/salt/pull/48476

### Tests written?
No

### Commits signed with GPG?
Yes