### PR TITLE
Fix behaviour of function latest_version in zypper module when multip…

### DIFF
--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -581,6 +581,8 @@ def latest_version(*names, **kwargs):
         status = pkg_info.get('status', '').lower()
         if status.find('not installed') > -1 or status.find('out-of-date') > -1:
             ret[name] = pkg_info.get('version')
+        else:
+            ret[name] = ''
 
     # Return a string if only one package name passed
     if len(names) == 1 and len(ret):

--- a/tests/unit/modules/test_zypper.py
+++ b/tests/unit/modules/test_zypper.py
@@ -363,7 +363,6 @@ class ZypperTestCase(TestCase, LoaderModuleMockMixin):
             self.assertEqual(zypper.latest_version('vim'), '7.4.326-2.62')
             self.assertDictEqual(zypper.latest_version('vim', 'fakepkg'), {'vim': '7.4.326-2.62', 'fakepkg': ''})
 
-
     def test_upgrade_success(self):
         '''
         Test system upgrade and dist-upgrade success.

--- a/tests/unit/modules/test_zypper.py
+++ b/tests/unit/modules/test_zypper.py
@@ -361,6 +361,8 @@ class ZypperTestCase(TestCase, LoaderModuleMockMixin):
                    ZyppCallMock(return_value=get_test_data('zypper-available.txt'))), \
                 patch('salt.modules.zypper.refresh_db', MagicMock(return_value=True)):
             self.assertEqual(zypper.latest_version('vim'), '7.4.326-2.62')
+            self.assertDictEqual(zypper.latest_version('vim', 'fakepkg'), {'vim': '7.4.326-2.62', 'fakepkg': ''})
+
 
     def test_upgrade_success(self):
         '''


### PR DESCRIPTION
### What does this PR do?
This PR fixes behaviour of latest_version function in zypper module to properly return empty string as version when multiple packages is passed. 

Previously if multiple packages were passed to latest_version the returning dict did not contain packages with latest version installed. This behaviour broke the state module/function "pkg.installed" since it then assumes package needs to be installed with version specified in state configuration ('latest'). 

### What issues does this PR fix or reference?
Valid configuration
```
pkg_latest:
  pkg.installed:
      - pkgs:
          - 'bash': 'latest'
          - 'logrotate': 'latest'
```
Giving result
```
          ID: pkg_latest
    Function: pkg.installed
      Result: False
     Comment: An error was encountered while installing package(s): Zypper command failure: Package 'bash=latest' not found.
     Started: 22:17:36.159457
    Duration: 4062.173 ms
     Changes:
 
```

### Previous Behavior
Example shows bash being up to date and logrotate needing a upgrade.
```
root@appsrv~ # salt-call pkg.latest_version bash logrotate
local:
    ----------
    logrotate:
        3.11.0-2.11.1
root@appsrv:~ #
```

### New Behavior
```
root@appsrv:~ # salt-call pkg.latest_version bash logrotate
local:
    ----------
    bash:
    logrotate:
        3.11.0-2.11.1
root@appsrv:~ #
```

### Tests written?
No
