### PR TITLE
Fix unreachable ssh-id-wrapper template when root_dir is relative

### DIFF
--- a/salt/modules/git.py
+++ b/salt/modules/git.py
@@ -265,10 +265,10 @@ def _git_run(command, cwd=None, user=None, password=None, identity=None,
 
             # copy wrapper to area accessible by ``runas`` user
             # currently no support in windows for wrapping git ssh
-            ssh_id_wrapper = os.path.join(
+            ssh_id_wrapper = os.path.abspath(os.path.join(
                 salt.utils.templates.TEMPLATE_DIRNAME,
                 'git/ssh-id-wrapper'
-            )
+            ))
             tmp_ssh_wrapper = None
             if salt.utils.platform.is_windows():
                 ssh_exe = _find_ssh_exe()


### PR DESCRIPTION
Since the git commands will be executed from the user home directory, if
salt root_dir is set to a relative path (for example using `root_dir: ./.tmp/` in salt config),
then the git/ssh-id-wrapper template may be unreachable and we may
encouter the following error that this patch is fixing:

```
[ERROR   ] Command '[u'git', u'ls-remote', u'git@github.com:bbinet/salt-formula-linux.git']' failed with return code: 128
[ERROR   ] stderr: error: cannot run .tmp/thin/py2/salt/templates/git/ssh-id-wrapper: No such file or directory
fatal: unable to fork
[ERROR   ] retcode: 128
[ERROR   ] Failed to check remote refs: Unable to authenticate using identity file:

error: cannot run .tmp/thin/py2/salt/templates/git/ssh-id-wrapper: No such file or directory
fatal: unable to fork
```

### What does this PR do?

### What issues does this PR fix or reference?

### Previous Behavior
Remove this section if not relevant

### New Behavior
Remove this section if not relevant

### Tests written?

Yes/No

### Commits signed with GPG?

Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
