### PR TITLE
Fix state.sls_id not running on ssh minion

### DIFF
--- a/salt/client/ssh/wrapper/state.py
+++ b/salt/client/ssh/wrapper/state.py
@@ -33,6 +33,9 @@ log = logging.getLogger(__name__)
 
 def _ssh_state(chunks, __opts__, __context__, __pillar__, __salt__, st_kwargs,
               kwargs, test=False):
+    '''
+    funciton to run a state with the given chunk via salt-ssh
+    '''
     file_refs = salt.client.ssh.state.lowstate_file_refs(
             chunks,
             _merge_extra_filerefs(

--- a/salt/client/ssh/wrapper/state.py
+++ b/salt/client/ssh/wrapper/state.py
@@ -31,6 +31,7 @@ __func_alias__ = {
 }
 log = logging.getLogger(__name__)
 
+
 def _ssh_state(chunks, __opts__, __context__, __pillar__, __salt__, st_kwargs,
               kwargs, test=False):
     '''
@@ -78,7 +79,7 @@ def _ssh_state(chunks, __opts__, __context__, __pillar__, __salt__, st_kwargs,
     try:
         return json.loads(stdout, object_hook=salt.utils.decode_dict)
     except Exception as e:
-        log.error("JSON Render failed for: {0}\n{1}".format(stdout, stderr))
+        log.error("JSON Render failed for: %s\n%s", stdout, stderr)
         log.error(str(e))
 
     # If for some reason the json load fails, return the stdout

--- a/tests/integration/files/file/base/ssh_state_tests.sls
+++ b/tests/integration/files/file/base/ssh_state_tests.sls
@@ -3,3 +3,7 @@ ssh-file-test:
   file.managed:
     - name: /tmp/{{ jinja }}
     - contents: 'test'
+
+second_id:
+  cmd.run:
+    - name: echo test

--- a/tests/integration/ssh/test_state.py
+++ b/tests/integration/ssh/test_state.py
@@ -67,7 +67,6 @@ class SSHStateTest(SSHCase):
         self._check_dict_ret(ret=ret, val='__id__',
                              exp_ret='second_id', equal=False)
 
-
         check_file = self.run_function('file.file_exists', ['/tmp/test'])
         self.assertTrue(check_file)
 

--- a/tests/integration/ssh/test_state.py
+++ b/tests/integration/ssh/test_state.py
@@ -24,9 +24,12 @@ class SSHStateTest(SSHCase):
     '''
     testing the state system with salt-ssh
     '''
-    def _check_dict_ret(self, ret, val, exp_ret):
+    def _check_dict_ret(self, ret, val, exp_ret, equal=True):
         for key, value in ret.items():
-            self.assertEqual(value[val], exp_ret)
+            if equal:
+                self.assertEqual(value[val], exp_ret)
+            else:
+                self.assertNotEqual(value[val], exp_ret)
 
     def _check_request(self, empty=False):
         check = self.run_function('state.check_request', wipe=False)
@@ -50,11 +53,31 @@ class SSHStateTest(SSHCase):
         '''
         test state.sls_id with salt-ssh
         '''
+        # check state.sls_id with test=True
+        ret = self.run_function('state.sls_id', ['ssh-file-test', SSH_SLS,
+                                                 'test=True'])
+        self._check_dict_ret(ret=ret, val='comment',
+                             exp_ret='The file /tmp/test is set to be changed')
+
+        # check state.sls_id without test=True
         ret = self.run_function('state.sls_id', ['ssh-file-test', SSH_SLS])
         self._check_dict_ret(ret=ret, val='__sls__', exp_ret=SSH_SLS)
 
+        # make sure the other id in the state was not run
+        self._check_dict_ret(ret=ret, val='__id__',
+                             exp_ret='second_id', equal=False)
+
+
         check_file = self.run_function('file.file_exists', ['/tmp/test'])
         self.assertTrue(check_file)
+
+    def test_state_sls_wrong_id(self):
+        '''
+        test state.sls_id when id does not exist
+        '''
+        # check state.sls_id with test=True
+        ret = self.run_function('state.sls_id', ['doesnotexist', SSH_SLS])
+        assert 'No matches for ID' in ret
 
     def test_state_show_sls(self):
         '''


### PR DESCRIPTION
### What does this PR do?
`state.sls_id` was running on the master and not the salt-ssh minion. This PR makes sure we are running the state on the salt-ssh minion. I noticed we are calling a lot of the same functions in the state.py wrapper for salt-ssh so I created this funciton: `_ssh_state`. I hope to move the other ones to this but in develop to make sure we don't ruin something in a point release once this is merged forward

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/48318

### Tests written?

Yes

### Commits signed with GPG?

Yes