### PR TITLE
Remove which mock to get the test passing

### DIFF
--- a/tests/unit/states/test_file.py
+++ b/tests/unit/states/test_file.py
@@ -1202,7 +1202,6 @@ class TestFileState(TestCase, LoaderModuleMockMixin):
                         {'file.directory_exists': mock_f,
                          'file.makedirs': mock_t,
                          'file.stats': mock_f,
-                         'file.touch': mock_t,
                          'cp.get_template': mock_f,
                          'file.search': mock_f,
                          'file.prepend': mock_t}):


### PR DESCRIPTION
This test passes in my local kitchen tests when the `which` mock is
removed. However, I added this mock to try and get the test passing in
jenkins. The original failure that caused me to add it was removed from
jenkins. This will either fix the test or reveal the other error that
needs to be fixed.


### Tests written?

No

### Commits signed with GPG?

Yes