### PR TITLE
Log npm json out as debug, not error

### DIFF
--- a/salt/modules/npm.py
+++ b/salt/modules/npm.py
@@ -180,7 +180,7 @@ def install(pkg=None,
 
 def _extract_json(npm_output):
     lines = npm_output.splitlines()
-    log.error(lines)
+    log.debug(lines)
 
     # Strip all lines until JSON output starts
     while lines and not lines[0].startswith('{') and not lines[0].startswith('['):


### PR DESCRIPTION
### What does this PR do?
The output from `npm install ... --json` is logged during the `_extract_json()` function, but at this point, I'd say it's more informational (if that). In a case where there _is_ a failure, the command failing should still already (separately) return an error with the full stdout / stderr.

```
       [ERROR   ] Command 'npm install --json --silent --global '[...]'' failed with return code: 1
       [ERROR   ] stdout: {
         "error": {
           "code": "E404",
           "summary": "Not Found: @xyz",
           "detail": ""
         }
       }
       [ERROR   ] retcode: 1
```

See also #48492 

### What issues does this PR fix or reference?
The output showing up as "error" is (IMHO) confusing. Maybe we can / should log an error if parsing fails?

### Previous Behavior
When npm runs, there's a log message like 

### New Behavior
The message will be printed, but as debug, if the user is running at a debug level that shows info messages.

### Tests written?
N/A

### Commits signed with GPG?
Yes