### PR TITLE
Add timeouts to all s3 queries

### DIFF
--- a/salt/utils/s3.py
+++ b/salt/utils/s3.py
@@ -162,20 +162,23 @@ def query(key, keyid, method='GET', params=None, headers=None,
                                       headers=headers,
                                       data=data,
                                       verify=verify_ssl,
-                                      stream=True)
+                                      stream=True,
+                                      timeout=300)
         elif method == 'GET' and local_file and not return_bin:
             result = requests.request(method,
                                       requesturl,
                                       headers=headers,
                                       data=data,
                                       verify=verify_ssl,
-                                      stream=True)
+                                      stream=True,
+                                      timeout=300)
         else:
             result = requests.request(method,
                                       requesturl,
                                       headers=headers,
                                       data=data,
-                                      verify=verify_ssl)
+                                      verify=verify_ssl,
+                                      timeout=300)
     finally:
         if fh is not None:
             fh.close()


### PR DESCRIPTION
### What does this PR do?

Add timeouts to all s3 queries

### What issues does this PR fix or reference?

n/a

### Previous Behavior

According to http://docs.python-requests.org/en/master/user/advanced/#timeouts:

> By default, requests do not time out unless a timeout value is set explicitly.

This is undesirable behavior.

### New Behavior

Will timeout after 5 minutes. This would be pretty trivial to make into a config option, but for now I figured an insanely long timeout is better than none.

### Tests written?

No

### Commits signed with GPG?

Yes