### PR TITLE
Fix failing prepend test

### DIFF
--- a/tests/unit/states/test_file.py
+++ b/tests/unit/states/test_file.py
@@ -61,6 +61,15 @@ class TestFileState(TestCase, LoaderModuleMockMixin):
             }
         }
 
+    def tearDown(self):
+        remove_dir = '/etc'
+        if salt.utils.is_windows():
+            remove_dir = 'c:\\etc'
+        try:
+            os.remove(remove_dir)
+        except OSError:
+            pass
+
     def test_serialize(self):
         def returner(contents, *args, **kwargs):
             returner.returned = contents
@@ -1174,6 +1183,7 @@ class TestFileState(TestCase, LoaderModuleMockMixin):
         '''
         Test to ensure that some text appears at the beginning of a file.
         '''
+        assert not os.path.exists('c:\\etc')
         name = '/etc/motd'
         if salt.utils.is_windows():
             name = 'c:\\etc\\motd'


### PR DESCRIPTION
The prepend test is failing when jenkins runs kithchen but is passing in
my test environment. Make sure each test starts without the 'etc' path
existing.


### Tests written?

No

### Commits signed with GPG?

Yes