### PR TITLE
Fix python2 syslog returner expecting string bytes not unicode

### DIFF
--- a/salt/returners/syslog_return.py
+++ b/salt/returners/syslog_return.py
@@ -192,14 +192,10 @@ def returner(ret):
         logoption = logoption | getattr(syslog, opt)
 
     # Open syslog correctly based on options and tag
-    try:
-        if 'tag' in _options:
-            syslog.openlog(ident=_options['tag'], logoption=logoption)
-        else:
-            syslog.openlog(logoption=logoption)
-    except TypeError:
-        # Python 2.6 syslog.openlog does not accept keyword args
-        syslog.openlog(_options.get('tag', 'salt-minion'), logoption)
+    if 'tag' in _options:
+        syslog.openlog(ident=salt.utils.stringutils.to_str(_options['tag']), logoption=logoption)
+    else:
+        syslog.openlog(logoption=logoption)
 
     # Send log of given level and facility
     syslog.syslog(facility | level, salt.utils.json.dumps(ret))

--- a/tests/unit/returners/test_syslog_return.py
+++ b/tests/unit/returners/test_syslog_return.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+'''
+    :codeauthor: :email:`Megan Wilhite (mwilhite@saltstack.com)`
+
+
+    tests.unit.returners.test_syslog_return
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+'''
+
+# Import Python libs
+from __future__ import absolute_import, print_function, unicode_literals
+
+# Import Salt Testing libs
+from tests.support.mixins import LoaderModuleMockMixin
+from tests.support.unit import TestCase, skipIf
+from tests.support.mock import NO_MOCK, NO_MOCK_REASON, MagicMock, patch
+
+# Import salt libs
+import salt.returners.syslog_return as syslog
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class SyslogReturnerTestCase(TestCase, LoaderModuleMockMixin):
+    '''
+    Test Syslog returner
+    '''
+    def setup_loader_modules(self):
+        return {syslog: {}}
+
+    def test_syslog_returner_unicode(self):
+        '''
+        test syslog returner with unicode
+        '''
+        ret = {'fun_args': [], 'jid': '20180713160901624786', 'return': True,
+               'retcode': 0, 'success': True, 'fun': 'test.ping', 'id': '02e10e971a30'}
+        opts = {u'level': u'LOG_INFO', u'options': [],
+                u'facility': u'LOG_USER', 'tag': u'salt-minion'}
+
+        with patch('salt.returners.syslog_return._get_options',
+                   MagicMock(return_value=opts)):
+            try:
+                syslog.returner(ret)
+            except Exception as e:
+                self.fail('syslog.returner() failed with exception: {0}'.format(e))

--- a/tests/unit/returners/test_syslog_return.py
+++ b/tests/unit/returners/test_syslog_return.py
@@ -34,7 +34,7 @@ class SyslogReturnerTestCase(TestCase, LoaderModuleMockMixin):
         ret = {'fun_args': [], 'jid': '20180713160901624786', 'return': True,
                'retcode': 0, 'success': True, 'fun': 'test.ping', 'id': '02e10e971a30'}
         opts = {u'level': u'LOG_INFO', u'options': [],
-                u'facility': u'LOG_USER', 'tag': u'salt-minion'}
+                u'facility': u'LOG_USER', u'tag': u'salt-minion'}
 
         with patch('salt.returners.syslog_return._get_options',
                    MagicMock(return_value=opts)):


### PR DESCRIPTION
### What does this PR do?
Ensures we are passing string bytes for python2 and unicode for python3 for the tag to syslog.open(). Also removed some unnecessary python2.6 code.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/48548


### Tests written?

Yes

### Commits signed with GPG?

Yes