### PR TITLE
Don't error on retcode 0 in libcrypto.OPENSSL_init_crypto call

### DIFF
--- a/salt/utils/rsax931.py
+++ b/salt/utils/rsax931.py
@@ -70,10 +70,9 @@ def _init_libcrypto():
     libcrypto.RSA_public_decrypt.argtypes = (c_int, c_char_p, c_char_p, c_void_p, c_int)
 
     try:
-        if libcrypto.OPENSSL_init_crypto(OPENSSL_INIT_NO_LOAD_CONFIG |
-                                         OPENSSL_INIT_ADD_ALL_CIPHERS |
-                                         OPENSSL_INIT_ADD_ALL_DIGESTS, None) != 1:
-            raise OSError("Failed to initialize OpenSSL library (OPENSSL_init_crypto failed)")
+        libcrypto.OPENSSL_init_crypto(OPENSSL_INIT_NO_LOAD_CONFIG |
+                                      OPENSSL_INIT_ADD_ALL_CIPHERS |
+                                      OPENSSL_INIT_ADD_ALL_DIGESTS, None)
     except AttributeError:
         # Support for OpenSSL < 1.1 (OPENSSL_API_COMPAT < 0x10100000L)
         libcrypto.OPENSSL_no_config()


### PR DESCRIPTION
### What does this PR do?
Removes the check for the `libcrypto.OPENSSL_init_crypto` to raise an error if the call does not return `1`.

This check was added in #37772 some time ago to work around a backward-incompatible change introduced in `OpenSSL1.1`. Originally, `libcrypto.OPENSSL_init_crypto` returned `1`. However, newer versions of `OpenSSL`, which are now available in openSUSE Tumbleweed and openSUSE Leap 15, return `0`.

This commit fixes #46884 by removing the check for `!= 1`, but maintains the older behavior of `OpenSSL` by excepting the `AttributeError`.

### What issues does this PR fix or reference?
Fixes #46884
Refs https://github.com/saltstack/salt-bootstrap/pull/1263

### Previous Behavior
Minion would fail to start, or really do anything:
```
localhost:~ # salt-call --versions
Traceback (most recent call last):
  File "/usr/bin/salt-call", line 11, in <module>
    salt_call()
  File "/usr/lib/python2.7/site-packages/salt/scripts.py", line 391, in salt_call
    import salt.cli.call
  File "/usr/lib/python2.7/site-packages/salt/cli/call.py", line 9, in <module>
    import salt.cli.caller
  File "/usr/lib/python2.7/site-packages/salt/cli/caller.py", line 18, in <module>
    import salt.loader
  File "/usr/lib/python2.7/site-packages/salt/loader.py", line 28, in <module>
    import salt.utils.event
  File "/usr/lib/python2.7/site-packages/salt/utils/event.py", line 74, in <module>
    import salt.payload
  File "/usr/lib/python2.7/site-packages/salt/payload.py", line 17, in <module>
    import salt.crypt
  File "/usr/lib/python2.7/site-packages/salt/crypt.py", line 55, in <module>
    import salt.utils.rsax931
  File "/usr/lib/python2.7/site-packages/salt/utils/rsax931.py", line 85, in <module>
    libcrypto = _init_libcrypto()
  File "/usr/lib/python2.7/site-packages/salt/utils/rsax931.py", line 76, in _init_libcrypto
    raise OSError("Failed to initialize OpenSSL library (OPENSSL_init_crypto failed)")
OSError: Failed to initialize OpenSSL library (OPENSSL_init_crypto failed)
```

### New Behavior
Minion starts just fine and all is well.
