### PR TITLE
Fix grp import for mac in test_user integration test

### DIFF
--- a/tests/integration/states/test_user.py
+++ b/tests/integration/states/test_user.py
@@ -22,6 +22,11 @@ from tests.support.mixins import SaltReturnAssertsMixin
 # Import salt libs
 import salt.utils
 
+try:
+    import grp
+except ImportError:
+    grp = None
+
 if salt.utils.is_darwin():
     USER = 'macuser'
     GROUP = 'macuser'
@@ -32,13 +37,11 @@ elif salt.utils.is_windows():
     GROUP = 'winuser'
     GID = randint(400, 500)
     NOGROUPGID = randint(400, 500)
-    grp = None
 else:
     USER = 'nobody'
     GROUP = 'nobody'
     GID = 'nobody'
     NOGROUPGID = 'nogroup'
-    import grp
 
 
 @destructiveTest


### PR DESCRIPTION
### What does this PR do?
the mac test_user integration tests are failing on mac with:

```
Traceback (most recent call last):
  File "/testing/tests/integration/states/test_user.py", line 176, in test_user_present_gid_from_name
    group_name = grp.getgrgid(ret['gid']).gr_name
NameError: global name 'grp' is not defined
```

this makes sure we are importing grp on mac

