### PR TITLE
[2017.7] event send multi master

### DIFF
--- a/salt/crypt.py
+++ b/salt/crypt.py
@@ -520,9 +520,18 @@ class AsyncAuth(object):
                     error = SaltClientError('Detect mode is on')
                     break
                 if self.opts.get('caller'):
-                    print('Minion failed to authenticate with the master, '
-                          'has the minion key been accepted?')
-                    sys.exit(2)
+                    # We have a list of masters, so we should break
+                    # and try the next one in the list.
+                    if self.opts.get('local_masters', None):
+                        log.debug('=== opts %s ===', self.opts['master'])
+                        error = SaltClientError('Minion failed to authenticate'
+                                                'with the master, has the has'
+                                                'the minion key been accepted?')
+                        break
+                    else:
+                        print('Minion failed to authenticate with the master, '
+                              'has the minion key been accepted?')
+                        sys.exit(2)
                 if acceptance_wait_time:
                     log.info('Waiting {0} seconds before retry.'.format(acceptance_wait_time))
                     yield tornado.gen.sleep(acceptance_wait_time)

--- a/salt/crypt.py
+++ b/salt/crypt.py
@@ -523,10 +523,9 @@ class AsyncAuth(object):
                     # We have a list of masters, so we should break
                     # and try the next one in the list.
                     if self.opts.get('local_masters', None):
-                        log.debug('=== opts %s ===', self.opts['master'])
                         error = SaltClientError('Minion failed to authenticate'
-                                                'with the master, has the has'
-                                                'the minion key been accepted?')
+                                                ' with the master, has the '
+                                                'minion key been accepted?')
                         break
                     else:
                         print('Minion failed to authenticate with the master, '

--- a/salt/modules/event.py
+++ b/salt/modules/event.py
@@ -84,6 +84,8 @@ def fire_master(data, tag, preload=None):
             channel = salt.transport.Channel.factory(__opts__, master_uri=master)
             try:
                 channel.send(load)
+                # channel.send was successful.
+                # Ensure ret is True.
                 ret = True
             except Exception:
                 ret = False

--- a/salt/modules/event.py
+++ b/salt/modules/event.py
@@ -84,6 +84,7 @@ def fire_master(data, tag, preload=None):
             channel = salt.transport.Channel.factory(__opts__, master_uri=master)
             try:
                 channel.send(load)
+                ret = True
             except Exception:
                 ret = False
         return ret


### PR DESCRIPTION
### What does this PR do?
When using Salt multi-master, if we encounter a salt master that has not accepted the minion key yet we should not exit right away, rather continue on and try the next salt master available in the list.  If the channel.send is successful, ensure that `ret` is True in case previous attempts at contacting masters had set it to False.

### What issues does this PR fix or reference?
#48415 

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
