### PR TITLE
Match npm packages with leading at-sign

### DIFF
--- a/salt/states/npm.py
+++ b/salt/states/npm.py
@@ -24,6 +24,7 @@ from __future__ import absolute_import, unicode_literals, print_function
 from salt.exceptions import CommandExecutionError, CommandNotFoundError
 
 # Import 3rd-party libs
+import re
 from salt.ext import six
 
 
@@ -138,8 +139,14 @@ def installed(name,
                     pass
         return False
     for pkg in pkg_list:
-        pkg_name, _, pkg_ver = pkg.partition('@')
-        pkg_name = pkg_name.strip()
+        # Valid:
+        #
+        # @google-cloud/bigquery@^0.9.6
+        # @foobar
+        # buffer-equal-constant-time@1.0.1
+        # coffee-script
+        matches = re.search(r'^(@?[^@\s]+)(?:@(\S+))?', pkg)
+        pkg_name, pkg_ver = matches.group(1), matches.group(2) or None
 
         if force_reinstall is True:
             pkgs_to_install.append(pkg)


### PR DESCRIPTION
### What does this PR do?
The `npm` state uses `partition()` to split the package name and version, however, many npm packages have an organization with a leading @, which breaks this. Do a slightly more complicated split with regex instead. I tried using `rpartition()` / `rsplit()`, but then there's an issue if there's a leading @ but no no version specified (e.g., `@foo/bar`).

```
@myorg/foobar-widget@^0.0.1
@foobar/somepackage
@google-cloud/bigquery@0.9.6
buffer-equal-constant-time@1.0.1
```
(I didn't use the same regex, but https://www.npmjs.com/package/validate-npm-package-name has examples of valid / invalid package names).

### What issues does this PR fix or reference?
If you log or print out the package name when there's a leading @, the state doesn't pick up the package name correctly. While the provider still may sometimes install every time if the version doesn't match exactly, or maybe if the package is deduped, this does seem to help avoid having it re-install the package every time in certain cases (see the second two examples above, for example).

I originally tried using regex, but that made it hard to also match bare names. This approach maybe could be made a little more readable, but seems to work. I couldn't get it to work properly with `rpartition()`

### New Behavior
The package name should be extracted correctly, and at least in some cases, packages should not be installed on every run.

### Tests written?
No - current tests pass, but I'd like to add some test cases that deal with this use case. The existing tests are pretty dense, though - maybe they can be parameterized to accept names / expectations? syslog-ng seems to be the main example where you all do something like that? Would appreciate suggestions on how to improve the existing test and test for this issue. Maybe just unit test `_pkg_is_installed` separately? or do something like https://github.com/saltstack/salt/blob/develop/tests/unit/states/test_syslog_ng.py#L306 for a variety of valid packages? At any rate, the current tests still pass.

### Commits signed with GPG?
Yes