### PR TITLE
Fix importlib pyc loading order

### DIFF
--- a/salt/loader.py
+++ b/salt/loader.py
@@ -64,10 +64,10 @@ if USE_IMPORTLIB:
     SUFFIXES = []
     for suffix in importlib.machinery.EXTENSION_SUFFIXES:
         SUFFIXES.append((suffix, 'rb', MODULE_KIND_EXTENSION))
-    for suffix in importlib.machinery.BYTECODE_SUFFIXES:
-        SUFFIXES.append((suffix, 'rb', MODULE_KIND_COMPILED))
     for suffix in importlib.machinery.SOURCE_SUFFIXES:
         SUFFIXES.append((suffix, 'rb', MODULE_KIND_SOURCE))
+    for suffix in importlib.machinery.BYTECODE_SUFFIXES:
+        SUFFIXES.append((suffix, 'rb', MODULE_KIND_COMPILED))
     MODULE_KIND_MAP = {
         MODULE_KIND_SOURCE: importlib.machinery.SourceFileLoader,
         MODULE_KIND_COMPILED: importlib.machinery.SourcelessFileLoader,


### PR DESCRIPTION
### What does this PR do?

Fixes the order in `SUFFIXES` to place `'.py'` before `'.pyc'` when using `importlib` (i.e., on Python versions 3.5 and above), the same order that `imp.get_suffixes()` (deprecated from Python 3.5 onwards) returns its result in.

### What issues does this PR fix or reference?

Fixes #46924

Also see: https://github.com/saltstack/salt/pull/48195#issuecomment-398898394

### Previous Behavior

On Python 3.5 and newer, `.pyc` files are preferred by the loader to `.py` files.

### New Behavior

`.py` files are preferred by the loader to `.pyc` files.

### Tests written?

No

### Commits signed with GPG?

Yes

### Additional Notes

The patch in this PR has been verified to apply cleanly when cherry-picked onto `v2018.3`.