### PR TITLE
git.latest: Add support for shallow-cloning tags

### DIFF
--- a/salt/states/git.py
+++ b/salt/states/git.py
@@ -471,8 +471,12 @@ def latest(name,
     depth
         Defines depth in history when git a clone is needed in order to ensure
         latest. E.g. ``depth: 1`` is useful when deploying from a repository
-        with a long history. Use rev to specify branch. This is not compatible
-        with tags or revision IDs.
+        with a long history. Use rev to specify branch or tag. This is not
+        compatible with revision IDs.
+
+        .. versionchanged:: Fluorine
+            This option now supports tags as well as branches, on Git 1.8.0 and
+            newer.
 
     identity
         Path to a private key to use for ssh URLs. This can be either a single
@@ -830,11 +834,11 @@ def latest(name,
             )
             remote_loc = None
 
-    if depth is not None and remote_rev_type != 'branch':
+    if depth is not None and remote_rev_type not in ('branch', 'tag'):
         return _fail(
             ret,
             'When \'depth\' is used, \'rev\' must be set to the name of a '
-            'branch on the remote repository'
+            'branch or tag on the remote repository'
         )
 
     if remote_rev is None and not bare:


### PR DESCRIPTION
### What does this PR do?

Adds support for specifying a tag in the `rev` option when `depth` is used
with `git.latest`.

For long, we've supported shallow clones of branches only, since git-clone
supports only a `--branch` option but no `--tag` options.

Turns out, the same `--branch` option [supports tag names since Git
1.8.0](https://git-scm.com/docs/git-clone/1.8.0#git-clone---branchltnamegt) (released Oct 2012), so it's a good idea for us to support it too.

### Previous Behavior

Only branch names in `rev` allowed when `depth` is used.

### New Behavior

Tag names also allowed in `rev` when `depth` is used.

### Tests written?

No

### Commits signed with GPG?

Yes