### PR TITLE
Discard unicode type

### DIFF
--- a/salt/log/setup.py
+++ b/salt/log/setup.py
@@ -100,7 +100,7 @@ LOG_COLORS = {
 
 # Make a list of log level names sorted by log level
 SORTED_LEVEL_NAMES = [
-    l[0] for l in sorted(six.iteritems(LOG_LEVELS), key=lambda x: x[1])
+    str(l[0]) for l in sorted(six.iteritems(LOG_LEVELS), key=lambda x: x[1])
 ]
 
 # Store an instance of the current logging logger class


### PR DESCRIPTION
### What does this PR do?

Bugfix

### What issues does this PR fix or reference?

Removes `u''` in front of displayed strings in CLI

### Previous Behavior

Command `salt --help` produces this:

```
 -l LOG_LEVEL, --log-level=LOG_LEVEL
                        Console logging log level. One of u'all', u'garbage',
                        u'trace', u'debug', u'profile', u'info', u'warning',
                        u'error', u'critical', u'quiet'. Default: 'warning'.
    --log-file=LOG_FILE
                        Log file path. Default: '/var/log/salt/master'.
    --log-file-level=LOG_LEVEL_LOGFILE
                        Logfile logging log level. One of u'all', u'garbage',
                        u'trace', u'debug', u'profile', u'info', u'warning',
                        u'error', u'critical', u'quiet'. Default: 'warning'.
```

### New Behavior

Command `salt --help` is now produces this:

```
 -l LOG_LEVEL, --log-level=LOG_LEVEL
                        Console logging log level. One of 'all', 'garbage',
                        'trace', 'debug', 'profile', 'info', 'warning',
                        'error', 'critical', 'quiet'. Default: 'warning'.
    --log-file=LOG_FILE
                        Log file path. Default: '/var/log/salt/master'.
    --log-file-level=LOG_LEVEL_LOGFILE
                        Logfile logging log level. One of 'all', 'garbage',
                        'trace', 'debug', 'profile', 'info', 'warning',
                        'error', 'critical', 'quiet'. Default: 'warning'.
```

### Tests written?

No

