### PR TITLE
modules/nilrt_ip.py: Add EtherCAT Support

### DIFF
--- a/salt/modules/nilrt_ip.py
+++ b/salt/modules/nilrt_ip.py
@@ -274,7 +274,7 @@ def _load_config(section, options, default_value='', file=INI_FILE):
         return results
     with salt.utils.files.fopen(file, 'r') as config_file:
         config_parser = configparser.RawConfigParser(dict_type=CaseInsensitiveDict)
-        config_parser.read_file(config_file)
+        config_parser.readfp(config_file)
         for option in options:
             if six.PY2:
                 results[option] = _remove_quotes(config_parser.get(section, option)) \
@@ -789,7 +789,7 @@ def _configure_static_interface(interface, **settings):
     if os.path.exists(INTERFACES_CONFIG):
         try:
             with salt.utils.files.fopen(INTERFACES_CONFIG, 'r') as config_file:
-                parser.read_file(config_file)
+                parser.readfp(config_file)
         except configparser.MissingSectionHeaderError:
             pass
     hwaddr = interface.hwaddr[:-1]

--- a/salt/modules/nilrt_ip.py
+++ b/salt/modules/nilrt_ip.py
@@ -368,7 +368,7 @@ def _get_static_info(interface):
     }
     hwaddr_section_number = ''.join(data['hwaddr'].split(':'))
     if os.path.exists(INTERFACES_CONFIG):
-        information = _load_config(hwaddr_section_number, ['IPv4', 'Nameservers'], file=INTERFACES_CONFIG)
+        information = _load_config(hwaddr_section_number, ['IPv4', 'Nameservers'], filename=INTERFACES_CONFIG)
         if information['IPv4'] != '':
             ipv4_information = information['IPv4'].split('/')
             data['ipv4']['address'] = ipv4_information[0]


### PR DESCRIPTION
* modules/nilrt_ip.py: Add EtherCAT Support

The possibilities for adapter mode are: `TCP/IP`, `EhterCAT` and `Disabled`.

Signed-off-by: Alexandru Vasiu <alexandru.vasiu@ni.com>
Signed-off-by: Ovidiu-Adrian Vancea <ovidiu.vancea@ni.com>

* modules/nilrt_ip.py: Fix configparser compatibility

read_file is available only since python 3.2 so readfp should
be used instead

Signed-off-by: Alexandru Vasiu <alexandru.vasiu@ni.com>