### PR TITLE
Sync modules for state tests

### DIFF
--- a/tests/integration/modules/test_state.py
+++ b/tests/integration/modules/test_state.py
@@ -74,6 +74,8 @@ class StateModuleTest(ModuleCase, SaltReturnAssertsMixin):
         reline(destpath, destpath, force=True)
         destpath = os.path.join(FILES, 'file', 'base', 'testappend', 'secondif')
         reline(destpath, destpath, force=True)
+        sls = self.run_function('saltutil.sync_modules')
+        assert isinstance(sls, list)
 
     def test_show_highstate(self):
         '''
@@ -299,6 +301,7 @@ class StateModuleTest(ModuleCase, SaltReturnAssertsMixin):
 
         '''
         testfile = os.path.join(TMP, 'issue-1876')
+
         sls = self.run_function('state.sls', mods='issue-1876')
         self.assertIn(
             'ID \'{0}\' in SLS \'issue-1876\' contains multiple state '


### PR DESCRIPTION
### What does this PR do?

Sync the custom modules from file_roots to the minion before running state tests. This fixes multiple integration test failures:

https://jenkinsci.saltstack.com/job/2018.3/view/Python3/job/salt-windows-2016-py3/94/testReport/junit/integration.modules.test_state/StateModuleTest/test_issue_1876_syntax_error/

### What issues does this PR fix or reference?

### Previous Behavior
Remove this section if not relevant

### New Behavior
Remove this section if not relevant

### Tests written?

No - Fixes tests

### Commits signed with GPG?

Yes