### PR TITLE
Bug fixes in the acme module & state

### DIFF
--- a/salt/modules/acme.py
+++ b/salt/modules/acme.py
@@ -180,7 +180,7 @@ def cert(name,
         comment = 'Certificate {0} obtained'.format(name)
     ret = {'comment': comment, 'not_after': expires(name)}
 
-    res = __salt__['file.check_perms'](_cert_file(name, 'privkey'), {}, owner, group, '0600', follow_symlinks=True)
+    res = __salt__['file.check_perms'](_cert_file(name, 'privkey'), {}, owner, group, '0640', follow_symlinks=True)
 
     if res is None:
         ret['result'] = False

--- a/salt/modules/acme.py
+++ b/salt/modules/acme.py
@@ -101,6 +101,7 @@ def cert(name,
          server=None,
          owner='root',
          group='root',
+         mode='0640',
          certname=None):
     '''
     Obtain/renew a certificate from an ACME CA, probably Let's Encrypt.
@@ -113,8 +114,9 @@ def cert(name,
     :param renew: True/'force' to force a renewal, or a window of renewal before expiry in days
     :param keysize: RSA key bits
     :param server: API endpoint to talk to
-    :param owner: owner of private key
-    :param group: group of private key
+    :param owner: owner of the private key file
+    :param group: group of the private key file
+    :param mode: mode of the private key file
     :param certname: Name of the certificate to save
     :return: dict with 'result' True/False/None, 'comment' and certificate's expiry date ('not_after')
 
@@ -178,7 +180,7 @@ def cert(name,
 
     ret = __salt__['file.check_perms'](_cert_file(name, 'privkey'),
                                        {'comment': comment, 'not_after': expires(name)},
-                                       owner, group, '0640',
+                                       owner, group, mode,
                                        follow_symlinks=True)
 
     return ret

--- a/salt/modules/acme.py
+++ b/salt/modules/acme.py
@@ -179,10 +179,10 @@ def cert(name,
         comment = 'Certificate {0} obtained'.format(name)
 
     ret = {'comment': comment, 'not_after': expires(name), 'changes': {}, 'result': True}
-    ret, perms = __salt__['file.check_perms'](_cert_file(name, 'privkey'),
-                                              ret,
-                                              owner, group, mode,
-                                              follow_symlinks=True)
+    ret, _ = __salt__['file.check_perms'](_cert_file(name, 'privkey'),
+                                          ret,
+                                          owner, group, mode,
+                                          follow_symlinks=True)
 
     return ret
 

--- a/salt/modules/acme.py
+++ b/salt/modules/acme.py
@@ -175,19 +175,11 @@ def cert(name,
         comment = 'Certificate {0} renewed'.format(name)
     else:
         comment = 'Certificate {0} obtained'.format(name)
-    ret = {'comment': comment, 'not_after': expires(name)}
 
-    res = __salt__['file.check_perms'](_cert_file(name, 'privkey'), {}, owner, group, '0640', follow_symlinks=True)
-
-    if res is None:
-        ret['result'] = False
-        ret['comment'] += ', but setting permissions failed.'
-    elif not res[0].get('result', False):
-        ret['result'] = False
-        ret['comment'] += ', but setting permissions failed with \n{0}'.format(res[0]['comment'])
-    else:
-        ret['result'] = True
-        ret['comment'] += '.'
+    ret = __salt__['file.check_perms'](_cert_file(name, 'privkey'),
+                                       {'comment': comment, 'not_after': expires(name)},
+                                       owner, group, '0640',
+                                       follow_symlinks=True)
 
     return ret
 

--- a/salt/modules/acme.py
+++ b/salt/modules/acme.py
@@ -178,10 +178,11 @@ def cert(name,
     else:
         comment = 'Certificate {0} obtained'.format(name)
 
-    ret = __salt__['file.check_perms'](_cert_file(name, 'privkey'),
-                                       {'comment': comment, 'not_after': expires(name)},
-                                       owner, group, mode,
-                                       follow_symlinks=True)
+    ret = {'comment': comment, 'not_after': expires(name), 'changes': {}, 'result': True}
+    ret, perms = __salt__['file.check_perms'](_cert_file(name, 'privkey'),
+                                              ret,
+                                              owner, group, mode,
+                                              follow_symlinks=True)
 
     return ret
 

--- a/salt/modules/acme.py
+++ b/salt/modules/acme.py
@@ -170,11 +170,8 @@ def cert(name,
         return {'result': False, 'comment': 'Certificate {0} renewal failed with:\n{1}'.format(name, res['stderr'])}
 
     if 'no action taken' in res['stdout']:
-        return {'result': None,
-                'comment': 'No action taken on certificate {0}'.format(cert_file),
-                'not_after': expires(name)}
-
-    if renew:
+        comment = 'Certificate {0} unchanged'.format(cert_file)
+    elif renew:
         comment = 'Certificate {0} renewed'.format(name)
     else:
         comment = 'Certificate {0} obtained'.format(name)

--- a/salt/states/acme.py
+++ b/salt/states/acme.py
@@ -49,6 +49,7 @@ def cert(name,
          server=None,
          owner='root',
          group='root',
+         mode='0640',
          certname=None):
     '''
     Obtain/renew a certificate from an ACME CA, probably Let's Encrypt.
@@ -61,8 +62,9 @@ def cert(name,
     :param renew: True/'force' to force a renewal, or a window of renewal before expiry in days
     :param keysize: RSA key bits
     :param server: API endpoint to talk to
-    :param owner: owner of private key
-    :param group: group of private key
+    :param owner: owner of the private key file
+    :param group: group of the private key file
+    :param mode: mode of the private key file
     :param certname: Name of the certificate to save
     '''
 
@@ -105,7 +107,8 @@ def cert(name,
         keysize=keysize,
         server=server,
         owner=owner,
-        group=group
+        group=group,
+        mode=mode
     )
 
     ret = {


### PR DESCRIPTION
### What does this PR do?
- [x] Fix #48626: acme module fails to set file permissions if the certificate is already present
- [x] Fix #48627: acme module's group parameter is non-functional
- [x] Add a `mode` parameter to the `acme.cert` functions in the state and execution modules.

### What issues does this PR fix or reference?
#48626, #48626

### Previous Behavior
- `acme.cert` fails to set private key file permissions if the certificate is already present;
- `acme.cert` sets the private key file mode to `0600`, making the specified `group` unable to read the private key.

### New Behavior
- `acme.cert` sets the private key file permissions at all times;
- `acme.cert` sets the private key file mode to `0640`, unless overrode by the (optional) `mode` parameter.

### Tests written?

No

### Commits signed with GPG?

Yes