### PR TITLE
Properly handle optimized .pyc files in loader in PY3

### DIFF
--- a/doc/ref/configuration/master.rst
+++ b/doc/ref/configuration/master.rst
@@ -1612,6 +1612,22 @@ the master will drop the request and the minion's key will remain accepted.
 
     allow_minion_key_revoke: False
 
+.. conf_master:: optimization_order
+
+``optimization_order``
+----------------------
+
+Default: ``[0, 1, 2]``
+
+In cases where Salt is distributed without .py files, this option determines
+the priority of optimization level(s) Salt's module loader should prefer.
+
+.. code-block:: yaml
+
+    optimization_order:
+      - 2
+      - 0
+      - 1
 
 Master Large Scale Tuning Settings
 ==================================

--- a/doc/ref/configuration/master.rst
+++ b/doc/ref/configuration/master.rst
@@ -1622,6 +1622,9 @@ Default: ``[0, 1, 2]``
 In cases where Salt is distributed without .py files, this option determines
 the priority of optimization level(s) Salt's module loader should prefer.
 
+.. note::
+    This option is only supported on Python 3.5+.
+
 .. code-block:: yaml
 
     optimization_order:

--- a/doc/ref/configuration/minion.rst
+++ b/doc/ref/configuration/minion.rst
@@ -1195,6 +1195,22 @@ option to ``False`` to keep Salt from updating the mine with this information.
 
     docker.update_mine: False
 
+.. conf_master:: optimization_order
+
+``optimization_order``
+----------------------
+
+Default: ``[0, 1, 2]``
+
+In cases where Salt is distributed without .py files, this option determines
+the priority of optimization level(s) Salt's module loader should prefer.
+
+.. code-block:: yaml
+
+    optimization_order:
+      - 2
+      - 0
+      - 1
 
 Minion Module Management
 ========================

--- a/doc/ref/configuration/minion.rst
+++ b/doc/ref/configuration/minion.rst
@@ -1195,7 +1195,7 @@ option to ``False`` to keep Salt from updating the mine with this information.
 
     docker.update_mine: False
 
-.. conf_master:: optimization_order
+.. conf_minion:: optimization_order
 
 ``optimization_order``
 ----------------------

--- a/doc/ref/configuration/minion.rst
+++ b/doc/ref/configuration/minion.rst
@@ -1205,6 +1205,9 @@ Default: ``[0, 1, 2]``
 In cases where Salt is distributed without .py files, this option determines
 the priority of optimization level(s) Salt's module loader should prefer.
 
+.. note::
+    This option is only supported on Python 3.5+.
+
 .. code-block:: yaml
 
     optimization_order:

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -286,6 +286,9 @@ VALID_OPTS = {
     # The type of hashing algorithm to use when doing file comparisons
     'hash_type': str,
 
+    # Order of preference for optimized .pyc files (PY3 only)
+    'optimization_order': list,
+
     # Refuse to load these modules
     'disable_modules': list,
 
@@ -1218,6 +1221,7 @@ DEFAULT_MINION_OPTS = {
     'gitfs_saltenv': [],
     'gitfs_refspecs': _DFLT_REFSPECS,
     'hash_type': 'sha256',
+    'optimization_order': [0, 1, 2],
     'disable_modules': [],
     'disable_returners': [],
     'whitelist_modules': [],
@@ -1511,6 +1515,7 @@ DEFAULT_MASTER_OPTS = {
     'fileserver_verify_config': True,
     'max_open_files': 100000,
     'hash_type': 'sha256',
+    'optimization_order': [0, 1, 2],
     'conf_file': os.path.join(salt.syspaths.CONFIG_DIR, 'master'),
     'open_mode': False,
     'auto_accept': False,

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -1210,6 +1210,7 @@ class LazyLoader(salt.utils.lazy.LazyDict):
         self.file_mapping = salt.utils.odict.OrderedDict()
 
         opt_match = []
+
         def _replace_pre_ext(obj):
             '''
             Hack so we can get the optimization level that we replaced (if

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -1104,6 +1104,15 @@ class LazyLoader(salt.utils.lazy.LazyDict):
         self.disabled = set(self.opts.get('disable_{0}{1}'.format(
             self.tag, '' if self.tag[-1] == 's' else 's'), []))
 
+        # A map of suffix to description for imp
+        self.suffix_map = {}
+        # A list to determine precedence of extensions
+        # Prefer packages (directories) over modules (single files)!
+        self.suffix_order = ['']
+        for (suffix, mode, kind) in SUFFIXES:
+            self.suffix_map[suffix] = (suffix, mode, kind)
+            self.suffix_order.append(suffix)
+
         self._lock = threading.RLock()
         self._refresh_file_mapping()
 
@@ -1177,14 +1186,6 @@ class LazyLoader(salt.utils.lazy.LazyDict):
         refresh the mapping of the FS on disk
         '''
         # map of suffix to description for imp
-        self.suffix_map = {}
-        suffix_order = ['']  # local list to determine precedence of extensions
-                             # Prefer packages (directories) over modules (single files)!
-
-        for (suffix, mode, kind) in SUFFIXES:
-            self.suffix_map[suffix] = (suffix, mode, kind)
-            suffix_order.append(suffix)
-
         if self.opts.get('cython_enable', True) is True:
             try:
                 global pyximport
@@ -1287,7 +1288,7 @@ class LazyLoader(salt.utils.lazy.LazyDict):
                     if ext == '':
                         # is there something __init__?
                         subfiles = os.listdir(fpath)
-                        for suffix in suffix_order:
+                        for suffix in self.suffix_order:
                             if '' == suffix:
                                 continue  # Next suffix (__init__ must have a suffix)
                             init_file = '__init__{0}'.format(suffix)
@@ -1315,7 +1316,7 @@ class LazyLoader(salt.utils.lazy.LazyDict):
                                 # Module name match, but a higher-priority
                                 # optimization level was already matched, skipping.
                                 continue
-                        elif not curr_ext or suffix_order.index(ext) >= suffix_order.index(curr_ext):
+                        elif not curr_ext or self.suffix_order.index(ext) >= self.suffix_order.index(curr_ext):
                             # Match found but a higher-priorty match already
                             # exists, so skip this.
                             continue

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -1223,7 +1223,9 @@ class LazyLoader(salt.utils.lazy.LazyDict):
             try:
                 # Make sure we have a sorted listdir in order to have
                 # expectable override results
-                files = sorted(os.listdir(mod_dir))
+                files = sorted(
+                    x for x in os.listdir(mod_dir) if x != '__pycache__'
+                )
             except OSError:
                 continue  # Next mod_dir
             if six.PY3:

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -1239,8 +1239,7 @@ class LazyLoader(salt.utils.lazy.LazyDict):
                 except OSError:
                     pass
                 else:
-                    pycache_files.extend(files)
-                    files = pycache_files
+                    files.extend(pycache_files)
 
             for filename in files:
                 try:

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -1260,7 +1260,6 @@ class LazyLoader(salt.utils.lazy.LazyDict):
 
                     if f_noext in self.file_mapping:
                         curr_ext = self.file_mapping[f_noext][1]
-                        #log.debug("****** curr_ext={0} ext={1} suffix_order={2}".format(curr_ext, ext, suffix_order))
                         if '' in (curr_ext, ext) and curr_ext != ext:
                             log.error(
                                 'Module/package collision: \'%s\' and \'%s\'',

--- a/tests/integration/minion/test_pillar.py
+++ b/tests/integration/minion/test_pillar.py
@@ -37,6 +37,7 @@ GPG_SLS = os.path.join(PILLAR_BASE, 'gpg.sls')
 DEFAULT_OPTS = {
     'cachedir': os.path.join(TMP, 'rootdir', 'cache'),
     'config_dir': TMP_CONF_DIR,
+    'optimization_order': [0, 1, 2],
     'extension_modules': os.path.join(TMP,
                                       'test-decrypt-pillar',
                                       'extmods'),

--- a/tests/support/gitfs.py
+++ b/tests/support/gitfs.py
@@ -330,11 +330,14 @@ class GitPillarTestBase(GitTestBase, LoaderModuleMockMixin):
         '''
         cachedir = tempfile.mkdtemp(dir=TMP)
         self.addCleanup(shutil.rmtree, cachedir, ignore_errors=True)
-        ext_pillar_opts = yaml.safe_load(
-            ext_pillar_conf.format(
-                cachedir=cachedir,
-                extmods=os.path.join(cachedir, 'extmods'),
-                **self.ext_opts
+        ext_pillar_opts = {'optimization_order': [0, 1, 2]}
+        ext_pillar_opts.update(
+            yaml.safe_load(
+                ext_pillar_conf.format(
+                    cachedir=cachedir,
+                    extmods=os.path.join(cachedir, 'extmods'),
+                    **self.ext_opts
+                )
             )
         )
         with patch.dict(git_pillar.__opts__, ext_pillar_opts):

--- a/tests/unit/loader/test_loader.py
+++ b/tests/unit/loader/test_loader.py
@@ -981,7 +981,7 @@ class LazyLoaderOptimizationOrderTest(TestCase):
             compileall.compile_file(self.module_file, quiet=1, optimize=1)
             compileall.compile_file(self.module_file, quiet=1, optimize=2)
         else:
-            compileall.compile_file(self.module_file)
+            compileall.compile_file(self.module_file, quiet=1)
 
         # Clean up the original file so that we can be assured we're only
         # loading the byte-compiled files(s).

--- a/tests/unit/loader/test_loader.py
+++ b/tests/unit/loader/test_loader.py
@@ -983,9 +983,14 @@ class LazyLoaderOptimizationOrderTest(TestCase):
 
     def _byte_compile(self):
         if USE_IMPORTLIB:
+            # Skip this check as "optimize" is unique to PY3's compileall
+            # module, and this will be a false error when Pylint is run on
+            # Python 2.
+            # pylint: disable=unexpected-keyword-arg
             compileall.compile_file(self.module_file, quiet=1, optimize=0)
             compileall.compile_file(self.module_file, quiet=1, optimize=1)
             compileall.compile_file(self.module_file, quiet=1, optimize=2)
+            # pylint: enable=unexpected-keyword-arg
         else:
             compileall.compile_file(self.module_file, quiet=1)
 

--- a/tests/unit/loader/test_loader.py
+++ b/tests/unit/loader/test_loader.py
@@ -8,9 +8,11 @@
 
 # Import Python libs
 from __future__ import absolute_import
+import compileall
 import inspect
 import logging
 import tempfile
+import textwrap
 import shutil
 import os
 import collections
@@ -916,3 +918,106 @@ class LazyLoaderDeepSubmodReloadingTest(TestCase):
                 self.update_lib(lib)
                 self.loader.clear()
                 self._verify_libs()
+
+
+class LazyLoaderOptimizationOrderTest(TestCase):
+    '''
+    Test the optimization order priority in the loader (PY3)
+    '''
+    module_name = 'lazyloadertest'
+    module_fullname = 'salt.loaded.ext.module.lazyloadertest'
+    module_content = textwrap.dedent('''\
+        # -*- coding: utf-8 -*-
+        from __future__ import absolute_import
+
+        def test():
+            return True
+        ''')
+
+    @classmethod
+    def setUpClass(cls):
+        cls.opts = salt.config.minion_config(None)
+        cls.opts['grains'] = grains(cls.opts)
+
+    def setUp(self):
+        # Setup the module
+        self.module_dir = tempfile.mkdtemp(dir=TMP)
+        self.module_file = os.path.join(self.module_dir,
+                                        '{0}.py'.format(self.module_name))
+
+    def _get_loader(self, order=None):
+        opts = copy.deepcopy(self.opts)
+        if order is not None:
+            opts['optimization_order'] = order
+        # Return a loader
+        return LazyLoader([self.module_dir], opts, tag='module')
+
+    def _get_module_filename(self):
+        # The act of referencing the loader entry forces the module to be
+        # loaded by the LazyDict.
+        mod_fullname = self.loader[next(iter(self.loader))].__module__
+        return sys.modules[mod_fullname].__file__
+
+    def _expected(self, optimize=0):
+        if six.PY3:
+            return 'lazyloadertest.cpython-{0}{1}{2}.pyc'.format(
+                sys.version_info[0],
+                sys.version_info[1],
+                '' if not optimize else '.opt-{0}'.format(optimize)
+            )
+        else:
+            return 'lazyloadertest.pyc'
+
+    def _test_optimization_level(self, order):
+        # Write the file
+        with salt.utils.fopen(self.module_file, 'w') as fh:
+            fh.write(self.module_content)
+            fh.flush()
+            os.fsync(fh.fileno())
+
+        # Byte-compile it
+        if six.PY3:
+            compileall.compile_file(self.module_file, quiet=1, optimize=0)
+            compileall.compile_file(self.module_file, quiet=1, optimize=1)
+            compileall.compile_file(self.module_file, quiet=1, optimize=2)
+        else:
+            compileall.compile_file(self.module_file)
+
+        # Clean up the original file so that we can be assured we're only
+        # loading the byte-compiled files(s).
+        os.remove(self.module_file)
+
+        self.loader = self._get_loader(order)
+        filename = self._get_module_filename()
+        basename = os.path.basename(filename)
+        assert basename == self._expected(order[0]), basename
+
+        if six.PY2:
+            # We are only testing multiple optimization levels on Python 3.
+            return
+
+        # Remove the file and make a new loader. We should now load the
+        # byte-compiled file with an optimization level matching the 2nd
+        # element of the order list.
+        os.remove(filename)
+        self.loader = self._get_loader(order)
+        filename = self._get_module_filename()
+        basename = os.path.basename(filename)
+        assert basename == self._expected(order[1]), basename
+
+        # Remove the file and make a new loader. We should now load the
+        # byte-compiled file with an optimization level matching the 3rd
+        # element of the order list.
+        os.remove(filename)
+        self.loader = self._get_loader(order)
+        filename = self._get_module_filename()
+        basename = os.path.basename(filename)
+        assert basename == self._expected(order[2]), basename
+
+    def test_optimization_level(self):
+        self._test_optimization_level([0, 1, 2])
+        self._test_optimization_level([0, 2, 1])
+        self._test_optimization_level([1, 2, 0])
+        self._test_optimization_level([1, 0, 2])
+        self._test_optimization_level([2, 0, 1])
+        self._test_optimization_level([2, 1, 0])

--- a/tests/unit/output/test_highstate_out.py
+++ b/tests/unit/output/test_highstate_out.py
@@ -27,6 +27,7 @@ class JsonTestCase(TestCase, LoaderModuleMockMixin):
             highstate: {
                 '__opts__': {
                     'extension_modules': '',
+                    'optimization_order': [0, 1, 2],
                     'color': False,
                 }
             }

--- a/tests/unit/pillar/test_git.py
+++ b/tests/unit/pillar/test_git.py
@@ -60,6 +60,7 @@ class GitPillarTestCase(TestCase, AdaptedConfigurationTestCaseMixin, LoaderModul
                     'file_roots': {},
                     'state_top': 'top.sls',
                     'extension_modules': '',
+                    'optimization_order': [0, 1, 2],
                     'renderer': 'yaml_jinja',
                     'renderer_blacklist': [],
                     'renderer_whitelist': [],

--- a/tests/unit/returners/test_smtp_return.py
+++ b/tests/unit/returners/test_smtp_return.py
@@ -31,7 +31,25 @@ class SMTPReturnerTestCase(TestCase, LoaderModuleMockMixin):
     Test SMTP returner
     '''
     def setup_loader_modules(self):
-        return {smtp: {}}
+        return {
+            smtp: {
+                '__opts__': {
+                    'extension_modules': '',
+                    'optimization_order': [0, 1, 2],
+                    'renderer': 'jinja|yaml',
+                    'renderer_blacklist': [],
+                    'renderer_whitelist': [],
+                    'file_roots': {},
+                    'pillar_roots': {},
+                    'cachedir': '/',
+                    'master_uri': 'tcp://127.0.0.1:4505',
+                    'pki_dir': '/',
+                    'keysize': 2048,
+                    'id': 'test',
+                    '__role': 'minion',
+                }
+            }
+        }
 
     def _test_returner(self, mocked_smtplib):  # pylint: disable=unused-argument
         '''
@@ -60,25 +78,11 @@ class SMTPReturnerTestCase(TestCase, LoaderModuleMockMixin):
 
     if HAS_GNUPG:
         def test_returner(self):
-            with patch.dict(smtp.__opts__, {'extension_modules': '',
-                                            'renderer': 'jinja|yaml',
-                                            'renderer_blacklist': [],
-                                            'renderer_whitelist': [],
-                                            'file_roots': {},
-                                            'pillar_roots': {},
-                                            'cachedir': '/'}), \
-                    patch('salt.returners.smtp_return.gnupg'), \
+            with patch('salt.returners.smtp_return.gnupg'), \
                     patch('salt.returners.smtp_return.smtplib.SMTP') as mocked_smtplib:
                 self._test_returner(mocked_smtplib)
 
     else:
         def test_returner(self):
-            with patch.dict(smtp.__opts__, {'extension_modules': '',
-                                            'renderer': 'jinja|yaml',
-                                            'renderer_blacklist': [],
-                                            'renderer_whitelist': [],
-                                            'file_roots': {},
-                                            'pillar_roots': {},
-                                            'cachedir': '/'}), \
-                    patch('salt.returners.smtp_return.smtplib.SMTP') as mocked_smtplib:
+            with patch('salt.returners.smtp_return.smtplib.SMTP') as mocked_smtplib:
                 self._test_returner(mocked_smtplib)

--- a/tests/unit/runners/test_winrepo.py
+++ b/tests/unit/runners/test_winrepo.py
@@ -86,6 +86,7 @@ class WinrepoTest(TestCase, LoaderModuleMockMixin):
             winrepo: {
                 '__opts__': {
                     'winrepo_cachefile': 'winrepo.p',
+                    'optimization_order': [0, 1, 2],
                     'renderer': 'yaml',
                     'renderer_blacklist': [],
                     'renderer_whitelist': [],

--- a/tests/unit/test_map_conf.py
+++ b/tests/unit/test_map_conf.py
@@ -85,6 +85,7 @@ class MapConfTest(TestCase):
                 patch('salt.cloud.Map.read', MagicMock(return_value=EXAMPLE_MAP)):
             self.maxDiff = None
             opts = {'extension_modules': '/var/cache/salt/master/extmods',
+                    'optimization_order': [0, 1, 2],
                     'providers': EXAMPLE_PROVIDERS, 'profiles': EXAMPLE_PROFILES}
             cloud_map = salt.cloud.Map(opts)
             merged_profile = {

--- a/tests/unit/test_pillar.py
+++ b/tests/unit/test_pillar.py
@@ -33,6 +33,7 @@ class PillarTestCase(TestCase):
     def test_pillarenv_from_saltenv(self):
         with patch('salt.pillar.compile_template') as compile_template:
             opts = {
+                'optimization_order': [0, 1, 2],
                 'renderer': 'json',
                 'renderer_blacklist': [],
                 'renderer_whitelist': [],
@@ -51,6 +52,7 @@ class PillarTestCase(TestCase):
 
     def test_dynamic_pillarenv(self):
         opts = {
+            'optimization_order': [0, 1, 2],
             'renderer': 'json',
             'renderer_blacklist': [],
             'renderer_whitelist': [],
@@ -65,6 +67,7 @@ class PillarTestCase(TestCase):
 
     def test_ignored_dynamic_pillarenv(self):
         opts = {
+            'optimization_order': [0, 1, 2],
             'renderer': 'json',
             'renderer_blacklist': [],
             'renderer_whitelist': [],
@@ -79,6 +82,7 @@ class PillarTestCase(TestCase):
     def test_malformed_pillar_sls(self):
         with patch('salt.pillar.compile_template') as compile_template:
             opts = {
+                'optimization_order': [0, 1, 2],
                 'renderer': 'json',
                 'renderer_blacklist': [],
                 'renderer_whitelist': [],
@@ -188,6 +192,7 @@ class PillarTestCase(TestCase):
 
     def test_includes_override_sls(self):
         opts = {
+            'optimization_order': [0, 1, 2],
             'renderer': 'json',
             'renderer_blacklist': [],
             'renderer_whitelist': [],
@@ -250,6 +255,7 @@ class PillarTestCase(TestCase):
         with patch('salt.pillar.salt.fileclient.get_file_client', autospec=True) as get_file_client, \
                 patch('salt.pillar.salt.minion.Matcher') as Matcher:  # autospec=True disabled due to py3 mock bug
             opts = {
+                'optimization_order': [0, 1, 2],
                 'renderer': 'yaml',
                 'renderer_blacklist': [],
                 'renderer_whitelist': [],


### PR DESCRIPTION
See https://github.com/saltstack/salt/pull/48195#pullrequestreview-130530059 for some background.

This PR properly handles optimized .pyc files in the loader. It also introduces a new config option, `optimization_order`, which allows for the priority to be set so that optimized .pyc files are preferred.

It also fixes issue #46924 (separately fixed in #48593) in which the loader preferred .pyc files over .py files of the same name in Python 3, causing updated .py files not to be loaded. Note that this means that `optimization_order` only comes into play when Salt is distributed without .py files. ***NOTE: since #48593 was merged, my commit that made the same fix was a no-op and has disappeared in my latest rebase.***

Unit tests added to confirm that the `optimization_order` option works as expected.

In addition to the above, this PR makes the following two changes:

1. Because we do an `os.listdir()` on each module directory processed by the loader, this means that the `__pycache__` dir was in the results. It would never end up being loaded, so this didn't break anything, but I have nonetheless excluded it from the `os.listdir()` results so that the loader doesn't waste any effort processing it.

2. The suffix map/order are now compiled in the LazyLoader's dunder init. The values which are used to build both are module-level globals, so there is no need to repeat this every time the file mapping is refreshed.

@cachedout due to the fact that the `optimization_order` only matters when there is no .py file for that module, I decided not to add release notes for this. It is the corner-iest of corner cases.