### PR TITLE
Remove vcredist 2015 from Py3 installer

### DIFF
--- a/pkg/windows/build_pkg.bat
+++ b/pkg/windows/build_pkg.bat
@@ -136,22 +136,18 @@ If Defined ProgramFiles(x86) (
 If NOT Exist "%PreDir%" mkdir "%PreDir%"
 
 :: Set the location of the vcredist to download
-If %Python%==3 (
-    Set Url64="http://repo.saltstack.com/windows/dependencies/64/vcredist_x64_2015.exe"
-    Set Url32="http://repo.saltstack.com/windows/dependencies/32/vcredist_x86_2015.exe"
-
-) Else (
+If %Python%==2 (
     Set Url64="http://repo.saltstack.com/windows/dependencies/64/vcredist_x64_2008_mfc.exe"
     Set Url32="http://repo.saltstack.com/windows/dependencies/32/vcredist_x86_2008_mfc.exe"
-)
 
-:: Check for 64 bit by finding the Program Files (x86) directory
-If Defined ProgramFiles(x86) (
-    powershell -ExecutionPolicy RemoteSigned -File download_url_file.ps1 -url "%Url64%" -file "%PreDir%\vcredist.exe"
-) Else (
-    powershell -ExecutionPolicy RemoteSigned -File download_url_file.ps1 -url "%Url32%" -file "%PreDir%\vcredist.exe"
+    :: Check for 64 bit by finding the Program Files (x86) directory
+    If Defined ProgramFiles(x86) (
+        powershell -ExecutionPolicy RemoteSigned -File download_url_file.ps1 -url "%Url64%" -file "%PreDir%\vcredist.exe"
+    ) Else (
+        powershell -ExecutionPolicy RemoteSigned -File download_url_file.ps1 -url "%Url32%" -file "%PreDir%\vcredist.exe"
+    )
+    @echo.
 )
-@echo.
 
 :: Remove the fixed path in .exe files
 @echo Removing fixed path from .exe files

--- a/pkg/windows/build_pkg.bat
+++ b/pkg/windows/build_pkg.bat
@@ -130,24 +130,28 @@ If Defined ProgramFiles(x86) (
 )
 @echo.
 
-@echo Copying VCRedist to Prerequisites
-@echo ----------------------------------------------------------------------
 :: Make sure the "prereq" directory exists
 If NOT Exist "%PreDir%" mkdir "%PreDir%"
 
-:: Set the location of the vcredist to download
-If %Python%==2 (
-    Set Url64="http://repo.saltstack.com/windows/dependencies/64/vcredist_x64_2008_mfc.exe"
-    Set Url32="http://repo.saltstack.com/windows/dependencies/32/vcredist_x86_2008_mfc.exe"
+:: Don't include the vcredist for Py3 installations
+If %Python%==3 goto :vcredist_end
 
-    :: Check for 64 bit by finding the Program Files (x86) directory
-    If Defined ProgramFiles(x86) (
-        powershell -ExecutionPolicy RemoteSigned -File download_url_file.ps1 -url "%Url64%" -file "%PreDir%\vcredist.exe"
-    ) Else (
-        powershell -ExecutionPolicy RemoteSigned -File download_url_file.ps1 -url "%Url32%" -file "%PreDir%\vcredist.exe"
-    )
-    @echo.
+@echo Copying VCRedist to Prerequisites
+@echo ----------------------------------------------------------------------
+
+:: Set the location of the vcredist to download
+Set Url64="http://repo.saltstack.com/windows/dependencies/64/vcredist_x64_2008_mfc.exe"
+Set Url32="http://repo.saltstack.com/windows/dependencies/32/vcredist_x86_2008_mfc.exe"
+
+:: Check for 64 bit by finding the Program Files (x86) directory
+If Defined ProgramFiles(x86) (
+    powershell -ExecutionPolicy RemoteSigned -File download_url_file.ps1 -url "%Url64%" -file "%PreDir%\vcredist.exe"
+) Else (
+    powershell -ExecutionPolicy RemoteSigned -File download_url_file.ps1 -url "%Url32%" -file "%PreDir%\vcredist.exe"
 )
+@echo.
+
+:vcredist_end
 
 :: Remove the fixed path in .exe files
 @echo Removing fixed path from .exe files

--- a/pkg/windows/installer/Salt-Minion-Setup.nsi
+++ b/pkg/windows/installer/Salt-Minion-Setup.nsi
@@ -211,26 +211,13 @@ Section -Prerequisites
     Var /Global CheckVcRedist
     StrCpy $CheckVcRedist "False"
 
-    # Visual C++ 2015 redist packages
-    !define PY3_VC_REDIST_NAME "VC_Redist_2015"
-    !define PY3_VC_REDIST_X64_GUID "{50A2BC33-C9CD-3BF1-A8FF-53C10A0B183C}"
-    !define PY3_VC_REDIST_X86_GUID "{BBF2AC74-720C-3CB3-8291-5E34039232FA}"
-
     # Visual C++ 2008 SP1 MFC Security Update redist packages
     !define PY2_VC_REDIST_NAME "VC_Redist_2008_SP1_MFC"
     !define PY2_VC_REDIST_X64_GUID "{5FCE6D76-F5DC-37AB-B2B8-22AB8CEDB1D4}"
     !define PY2_VC_REDIST_X86_GUID "{9BE518E6-ECC6-35A9-88E4-87755C07200F}"
 
-    ${If} ${PYTHON_VERSION} == 3
-        StrCpy $VcRedistName ${PY3_VC_REDIST_NAME}
-        ${If} ${CPUARCH} == "AMD64"
-            StrCpy $VcRedistGuid ${PY3_VC_REDIST_X64_GUID}
-        ${Else}
-            StrCpy $VcRedistGuid ${PY3_VC_REDIST_X86_GUID}
-        ${EndIf}
-        StrCpy $CheckVcRedist "True"
-
-    ${Else}
+    # VCRedist only needs to be installed for Python 2
+    ${If} ${PYTHON_VERSION} == 2
 
         StrCpy $VcRedistName ${PY2_VC_REDIST_NAME}
         ${If} ${CPUARCH} == "AMD64"


### PR DESCRIPTION
### What does this PR do?
Removes the VC 2015 redistributable from the Py3 Salt installer. Python bundles the needed `vcruntime140.dll` in the root python directory, so the vcredist installation we've been doing is redundant.

The Py2 installer still needs the VC 2008 redistributable.

### What issues does this PR fix or reference?
Related issue in Zendesk 2671 where the vcredist installation was corrupted, poss by the salt installer.

https://github.com/saltstack/salt/issues/48592

### Tests written?
NA

### Commits signed with GPG?
Yes