### PR TITLE
Add restart on-failure option in systemd unit file

### DIFF
--- a/pkg/salt-minion.service
+++ b/pkg/salt-minion.service
@@ -5,6 +5,7 @@ After=network.target salt-master.service
 
 [Service]
 KillMode=process
+Restart=on-failure
 Type=notify
 NotifyAccess=all
 LimitNOFILE=8192


### PR DESCRIPTION
As I can see this option is already enabled inside `pkg/suse/salt-minion.service.rhel7` unit file, but not in general one.

### What does this PR do?
This PR adds Restart option inside salt-minion systemd unit file.

### What issues does this PR fix or reference?
Service auto restart on failure.

### Previous Behavior
Service salt-minion doesn't restart on failure or unclear exit code.

### New Behavior
Service salt-minion will restart on failure or unclear exit code.

### Tests written?

No

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
