### PR TITLE
docker_container.running: Fix regression in test mode

### DIFF
--- a/salt/states/docker_container.py
+++ b/salt/states/docker_container.py
@@ -1989,6 +1989,7 @@ def running(name,
         if __opts__['test']:
             ret['result'] = None
             comments.append('Container would be started')
+            return _format_comments(ret, comments)
         else:
             try:
                 post_state = __salt__['docker.start'](name)['state']['new']


### PR DESCRIPTION
In the process of overhauling `docker_container.running` to support network management for 2018.3.0, [this line](https://github.com/saltstack/salt/commit/64aa4fb#diff-3de3ca67cca4d4c99133a50b8dd4453dL1807) was deleted when it should not have been. Adding it back to ensure we exit the state at the proper place when state is run in test mode.