### PR TITLE
Improve handling of json output (#43138)

### DIFF
--- a/salt/modules/npm.py
+++ b/salt/modules/npm.py
@@ -160,7 +160,11 @@ def install(pkg=None,
             env.update({'SUDO_UID': uid, 'SUDO_USER': ''})
 
     cmd = ' '.join(cmd)
-    result = __salt__['cmd.run_all'](cmd, python_shell=True, cwd=dir, runas=runas, env=env)
+    result = __salt__['cmd.run_all'](cmd,
+                                     python_shell=True,
+                                     cwd=dir,
+                                     runas=runas,
+                                     env=env)
 
     if result['retcode'] != 0:
         raise CommandExecutionError(result['stderr'])
@@ -168,33 +172,9 @@ def install(pkg=None,
     # npm >1.2.21 is putting the output to stderr even though retcode is 0
     npm_output = result['stdout'] or result['stderr']
     try:
-        return json.loads(npm_output)
+        return salt.utils.find_json(npm_output)
     except ValueError:
-        pass
-
-    json_npm_output = _extract_json(npm_output)
-    return json_npm_output or npm_output
-
-
-def _extract_json(npm_output):
-    lines = npm_output.splitlines()
-    log.error(lines)
-
-    # Strip all lines until JSON output starts
-    while lines and not lines[0].startswith('{') and not lines[0].startswith('['):
-        lines = lines[1:]
-    while lines and not lines[-1].startswith('}') and not lines[-1].startswith(']'):
-        lines = lines[:-1]
-    # macOS with fsevents includes the following line in the return
-    # when a new module is installed which is invalid JSON:
-    #     [fsevents] Success: "..."
-    while lines and (lines[0].startswith('[fsevents]') or lines[0].startswith('Pass ')):
-        lines = lines[1:]
-    try:
-        return json.loads(''.join(lines))
-    except ValueError:
-        pass
-    return None
+        return npm_output
 
 
 def uninstall(pkg, dir=None, runas=None, env=None):

--- a/tests/unit/modules/test_npm.py
+++ b/tests/unit/modules/test_npm.py
@@ -6,6 +6,7 @@
 # Import Python Libs
 from __future__ import absolute_import
 import json
+import textwrap
 
 # Import Salt Testing Libs
 from tests.support.mixins import LoaderModuleMockMixin
@@ -34,43 +35,87 @@ class NpmTestCase(TestCase, LoaderModuleMockMixin):
         self.addCleanup(patcher.stop)
         return {npm: {}}
 
-    # 'install' function tests: 1
+    # 'install' function tests: 4
 
     def test_install(self):
         '''
-        Test if it install an NPM package.
+        Test if it installs an NPM package.
         '''
         mock = MagicMock(return_value={'retcode': 1, 'stderr': 'error'})
         with patch.dict(npm.__salt__, {'cmd.run_all': mock}):
             self.assertRaises(CommandExecutionError, npm.install,
                               'coffee-script')
 
-        mock = MagicMock(return_value={'retcode': 0, 'stderr': 'error',
-                                       'stdout': '{"salt": ["SALT"]}'})
-        with patch.dict(npm.__salt__, {'cmd.run_all': mock}):
-            mock_err = MagicMock(return_value='SALT')
-            with patch.object(json, 'loads', mock_err):
-                self.assertEqual(npm.install('coffee-script'), 'SALT')
+        # This is at least somewhat closer to the actual output format.
+        mock_json_out = textwrap.dedent('''\
+        [
+          {
+            "salt": "SALT"
+          }
+        ]''')
 
-        mock = MagicMock(return_value={'retcode': 0, 'stderr': 'error',
-                                       'stdout': '{"salt": ["SALT"]}'})
+        # Successful run, expected output format
+        mock = MagicMock(return_value={'retcode': 0, 'stderr': '',
+                                       'stdout': mock_json_out})
+        with patch.dict(npm.__salt__, {'cmd.run_all': mock}):
+            self.assertEqual(npm.install('coffee-script'),
+                             [{u'salt': u'SALT'}])
+
+        mock_json_out_extra = textwrap.dedent('''\
+        Compilation output here
+
+        [bcrypt] Success: "/tmp/node_modules/bcrypt/foo" is installed via remote"
+        [grpc] Success: "/usr/lib/node_modules/@foo/bar" is installed via remote"
+        [
+           {
+              "from" : "express@",
+              "name" : "express",
+              "dependencies" : {
+                 "escape-html" : {
+                    "from" : "escape-html@~1.0.3",
+                    "dependencies" : {},
+                    "version" : "1.0.3"
+                 }
+              },
+              "version" : "4.16.3"
+           }
+        ]''')
+        extra_expected = [{u'dependencies':
+            {u'escape-html': {
+                u'dependencies': {},
+                u'from': u'escape-html@~1.0.3',
+                u'version': u'1.0.3'}
+            },
+            u'from': u'express@',
+            u'name': u'express',
+            u'version': u'4.16.3'}]
+
+        # Successful run, expected output format with additional leading text
+        mock = MagicMock(return_value={'retcode': 0, 'stderr': '',
+                                       'stdout': mock_json_out_extra})
+        with patch.dict(npm.__salt__, {'cmd.run_all': mock}):
+            self.assertEqual(npm.install('coffee-script'), extra_expected)
+
+        # Successful run, unexpected output format
+        mock = MagicMock(return_value={'retcode': 0, 'stderr': '',
+                                       'stdout': 'SALT'})
         with patch.dict(npm.__salt__, {'cmd.run_all': mock}):
             mock_err = MagicMock(side_effect=ValueError())
+            # When JSON isn't successfully parsed, return should equal input
             with patch.object(json, 'loads', mock_err):
-                self.assertEqual(npm.install('coffee-script'),
-                                 '{"salt": ["SALT"]}')
+                self.assertEqual(npm.install('coffee-script'), 'SALT')
 
     # 'uninstall' function tests: 1
 
     def test_uninstall(self):
         '''
-        Test if it uninstall an NPM package.
+        Test if it uninstalls an NPM package.
         '''
         mock = MagicMock(return_value={'retcode': 1, 'stderr': 'error'})
         with patch.dict(npm.__salt__, {'cmd.run_all': mock}):
             self.assertFalse(npm.uninstall('coffee-script'))
 
-        mock = MagicMock(return_value={'retcode': 0, 'stderr': 'error'})
+        mock = MagicMock(return_value={'retcode': 0, 'stderr': ''})
         with patch.dict(npm.__salt__, {'cmd.run_all': mock}):
             self.assertTrue(npm.uninstall('coffee-script'))
 


### PR DESCRIPTION
### What does this PR do?
(This is #48492, but cherry-picked against 2017.7)
Rather than look for [ or { at the beginning of a line, it looks for equality. Since the JSON output of `npm install` seems to have the first character on its own, this seems to work, at least for the npm version I looked at -- however, I'm open to better / other approaches that would be better. I think the previous approach was a bit too limited, since there could be other output in the future that matches `^[` or `^{`.

Not sure if we could just ignore either stdout or stderr (I think some versions of node send the json output to stdout), or if there's another way this could be fixed. I am guessing the json output is reasonably consistent, but haven't tested older versions. [edit, checked, and currently, the message is going to stdout as well as the json output, so that won't work here]

### What issues does this PR fix or reference?
Idempotency issue - first run will "fail" with an error, even when packages get installed, if the output has a string like:
`[grpc] Success: "/usr/lib/node_modules/@google-cloud/monitoring/node_modules/grpc/src/node/extension_binary/node-v57-linux-x64-glibc/grpc_node.node" is installed via remote`, the first run will fail because the json parsing routine fails.

More details in #43138; replaces #48492

### Tests written?
Yes

### Commits signed with GPG?
Yes