### PR TITLE
Excluding relative dirs in state.file.retention_schedule

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -3737,6 +3737,8 @@ def retention_schedule(name, retain, strptime_format=None, timezone=None):
             return (None, None)
 
     def get_file_time_from_mtime(f):
+        if f == '.' or f == '..':
+            return (None,None)
         lstat = __salt__['file.lstat'](os.path.join(name, f))
         if lstat:
             mtime = lstat['st_mtime']

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -3738,7 +3738,7 @@ def retention_schedule(name, retain, strptime_format=None, timezone=None):
 
     def get_file_time_from_mtime(f):
         if f == '.' or f == '..':
-            return (None,None)
+            return (None, None)
         lstat = __salt__['file.lstat'](os.path.join(name, f))
         if lstat:
             mtime = lstat['st_mtime']


### PR DESCRIPTION
### What does this PR do?
It makes salt.state.file.retention_schedule ignoring relative directories `.` and `..` when using it without specifying a strpformat (using getmtime() )

### What issues does this PR fix or reference?
This commit should resolve #48637

### Previous Behavior
`.` and `..` were treated like the other files

### New Behavior
`.` and `..` are ignored.

### Tests written?

No

### Commits signed with GPG?

Yes

