### PR TITLE
[2018.3] Fix service.disabled test for macosx

### DIFF
--- a/salt/modules/mac_service.py
+++ b/salt/modules/mac_service.py
@@ -433,7 +433,6 @@ def disabled(name, runas=None, domain='system'):
     disabled = launchctl('print-disabled',
                          domain,
                          return_stdout=True,
-                         output_loglevel='trace',
                          runas=runas)
     for service in disabled.split("\n"):
         if name in service:

--- a/tests/integration/modules/test_service.py
+++ b/tests/integration/modules/test_service.py
@@ -129,9 +129,9 @@ class ServiceModuleTest(ModuleCase):
         else:
             try:
                 disable = self.run_function('service.disable', [srv_name])
-                self.assertTrue('error' in disable.lower())
-            except AssertionError:
                 self.assertFalse(disable)
+            except AssertionError:
+                self.assertTrue('error' in disable.lower())
 
         if salt.utils.platform.is_darwin():
             self.assertFalse(self.run_function('service.disabled', [srv_name]))

--- a/tests/integration/modules/test_service.py
+++ b/tests/integration/modules/test_service.py
@@ -117,21 +117,21 @@ class ServiceModuleTest(ModuleCase):
         systemd = salt.utils.systemd.booted()
 
         # check service was not enabled
-        if systemd or salt.utils.platform.is_windows():
-            self.assertIn('ERROR', enable)
-        else:
+        try:
             self.assertFalse(enable)
+        except AssertionError:
+            self.assertIn('ERROR', enable)
 
         # check service was not disabled
         if tuple(self.run_function('grains.item', ['osrelease_info'])['osrelease_info']) == (14, 0o4) and not systemd:
             # currently upstart does not have a mechanism to report if disabling a service fails if does not exist
             self.assertTrue(self.run_function('service.disable', [srv_name]))
         else:
-            if salt.utils.platform.is_windows():
+            try:
                 disable = self.run_function('service.disable', [srv_name])
                 self.assertTrue('error' in disable.lower())
-            else:
-                self.assertFalse(self.run_function('service.disable', [srv_name]))
+            except AssertionError:
+                self.assertFalse(disable)
 
         if salt.utils.platform.is_darwin():
             self.assertFalse(self.run_function('service.disabled', [srv_name]))


### PR DESCRIPTION
### What does this PR do?
Fixes the test: integration.modules.test_service.ServiceModuleTest.test_service_disable_doesnot_exist 

Failing with the following traceback:

```
Traceback (most recent call last):
  File "/testing/tests/integration/modules/test_service.py", line 123, in test_service_disable_doesnot_exist
    self.assertFalse(enable)
AssertionError: u'ERROR: Service not found: doesnotexist' is not false
```

