### PR TITLE
[2017.7] Fix service.disabled test for macosx

### DIFF
--- a/tests/integration/modules/test_service.py
+++ b/tests/integration/modules/test_service.py
@@ -129,9 +129,9 @@ class ServiceModuleTest(ModuleCase):
             self.assertTrue(self.run_function('service.disable', [srv_name]))
         else:
             try:
+                disable = self.run_function('service.disable', [srv_name])
                 self.assertFalse(disable)
             except AssertionError:
-                disable = self.run_function('service.disable', [srv_name])
                 self.assertTrue('error' in disable.lower())
 
         if salt.utils.is_darwin():

--- a/tests/integration/modules/test_service.py
+++ b/tests/integration/modules/test_service.py
@@ -118,9 +118,9 @@ class ServiceModuleTest(ModuleCase):
         systemd = salt.utils.systemd.booted()
 
         # check service was not enabled
-        if systemd or salt.utils.is_windows():
+        try:
             self.assertIn('ERROR', enable)
-        else:
+        except AssertionError:
             self.assertFalse(enable)
 
         # check service was not disabled
@@ -128,11 +128,11 @@ class ServiceModuleTest(ModuleCase):
             # currently upstart does not have a mechanism to report if disabling a service fails if does not exist
             self.assertTrue(self.run_function('service.disable', [srv_name]))
         else:
-            if salt.utils.is_windows():
+            try:
                 disable = self.run_function('service.disable', [srv_name])
                 self.assertTrue('error' in disable.lower())
-            else:
-                self.assertFalse(self.run_function('service.disable', [srv_name]))
+            except AssertionError:
+                self.assertFalse(disable)
 
         if salt.utils.is_darwin():
             self.assertFalse(self.run_function('service.disabled', [srv_name]))

--- a/tests/integration/modules/test_service.py
+++ b/tests/integration/modules/test_service.py
@@ -119,9 +119,9 @@ class ServiceModuleTest(ModuleCase):
 
         # check service was not enabled
         try:
-            self.assertIn('ERROR', enable)
-        except AssertionError:
             self.assertFalse(enable)
+        except AssertionError:
+            self.assertIn('ERROR', enable)
 
         # check service was not disabled
         if tuple(self.run_function('grains.item', ['osrelease_info'])['osrelease_info']) == (14, 0o4) and not systemd:

--- a/tests/integration/modules/test_service.py
+++ b/tests/integration/modules/test_service.py
@@ -129,10 +129,10 @@ class ServiceModuleTest(ModuleCase):
             self.assertTrue(self.run_function('service.disable', [srv_name]))
         else:
             try:
+                self.assertFalse(disable)
+            except AssertionError:
                 disable = self.run_function('service.disable', [srv_name])
                 self.assertTrue('error' in disable.lower())
-            except AssertionError:
-                self.assertFalse(disable)
 
         if salt.utils.is_darwin():
             self.assertFalse(self.run_function('service.disabled', [srv_name]))


### PR DESCRIPTION
### What does this PR do?
similar to https://github.com/saltstack/salt/pull/48663 but don't need to add salt/modules/mac_service.py change

Fixes the test: integration.modules.test_service.ServiceModuleTest.test_service_disable_doesnot_exist

Failing with the following traceback:

```
Traceback (most recent call last):
  File "/testing/tests/integration/modules/test_service.py", line 123, in test_service_disable_doesnot_exist
    self.assertFalse(enable)
AssertionError: u'ERROR: Service not found: doesnotexist' is not false
```