### PR TITLE
Add the "traverse" jinja filter

### DIFF
--- a/doc/topics/jinja/index.rst
+++ b/doc/topics/jinja/index.rst
@@ -1152,7 +1152,7 @@ Returns:
 .. jinja_ref:: traverse
 
 ``traverse``
---------------
+------------
 
 .. versionadded:: 2018.3.3
 

--- a/doc/topics/jinja/index.rst
+++ b/doc/topics/jinja/index.rst
@@ -1148,6 +1148,40 @@ Returns:
     }'
   }
 
+
+.. jinja_ref:: traverse
+
+``traverse``
+--------------
+
+.. versionadded:: 2018.3.3
+
+Traverse a dict or list using a colon-delimited target string.
+The target 'foo:bar:0' will return data['foo']['bar'][0] if this value exists,
+and will otherwise return the provided default value.
+
+Example:
+
+.. code-block:: jinja
+
+  {{ {'a1': {'b1': {'c1': 'foo'}}, 'a2': 'bar'} | traverse('a1:b1', 'default') }}
+
+Returns:
+
+.. code-block:: python
+
+  {'c1': 'foo'}
+
+.. code-block:: jinja
+
+  {{ {'a1': {'b1': {'c1': 'foo'}}, 'a2': 'bar'} | traverse('a2:b2', 'default') }}
+
+Returns:
+
+.. code-block:: python
+
+  'default'
+
 .. _`builtin filters`: http://jinja.pocoo.org/docs/templates/#builtin-filters
 .. _`timelib`: https://github.com/pediapress/timelib/
 

--- a/salt/utils/data.py
+++ b/salt/utils/data.py
@@ -460,6 +460,7 @@ def traverse_dict(data, key, default=None, delimiter=DEFAULT_TARGET_DELIM):
     return data
 
 
+@jinja_filter('traverse')
 def traverse_dict_and_list(data, key, default=None, delimiter=DEFAULT_TARGET_DELIM):
     '''
     Traverse a dict or list using a colon-delimited (or otherwise delimited,


### PR DESCRIPTION
This filter can be really useful in states to select some leaf pillar data or fallback with a default value.

The code is trivial as it is just a matter of exposing the existing `traverse_dict_and_list` function as a jinja filter through the `@jinja_filter('traverse')` decorator.
That is the reason why it seems safe to merge it in the 2018.3 branch instead of the develop branch.
