### PR TITLE
Use different pub and ret ports for testprogram integration tests

### DIFF
--- a/tests/integration/utils/testprogram.py
+++ b/tests/integration/utils/testprogram.py
@@ -14,6 +14,7 @@ import logging
 import os
 import shutil
 import signal
+import socket
 import subprocess
 import sys
 import tempfile
@@ -590,8 +591,24 @@ class TestSaltProgram(six.with_metaclass(TestSaltProgramMeta, TestProgram)):
         'log_dir',
         'script_dir',
     ])
+
+    pub_port = 4505
+    ret_port = 4506
+    for port in [pub_port, ret_port]:
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        try:
+            connect = sock.bind(('localhost', port))
+        except:
+            # these ports are already in use, use different ones
+            pub_port = 4606
+            ret_port = 4607
+            break
+        sock.close()
+
     config_base = {
         'root_dir': '{test_dir}',
+        'publish_port': pub_port,
+        'ret_port': ret_port,
     }
     configs = {}
     config_dir = os.path.join('etc', 'salt')


### PR DESCRIPTION
### What does this PR do?
Currently this test is failing on macosx: `integration.shell.test_master.MasterTest.test_exit_status_correct_usage` with this error:

```
Exit status was 4, must be 0 (salt.default.exitcodes.EX_OK) (correct usage) stderr: [u'WARNING: Unable to bind socket 0.0.0.0:4505, error: [Errno 48] Address already in use; Is there another salt-master running?', u'The salt master is shutdown. The ports are not available to bind']
```

This is because the salt-master process is running on the host outside of the test runner. I'm hoping by adding this logic this way this will prevent this test from failing if any machine happens to be running the salt-master already.

