### PR TITLE
Remove static windows build cache

### DIFF
--- a/pkg/windows/build_env_2.ps1
+++ b/pkg/windows/build_env_2.ps1
@@ -191,44 +191,21 @@ If (!($Path.ToLower().Contains("$($ini['Settings']['Scripts2Dir'])".ToLower())))
 
 #==============================================================================
 # Update PIP and SetupTools
-#    caching depends on environment variable SALT_PIP_LOCAL_CACHE
 #==============================================================================
 Write-Output " ----------------------------------------------------------------"
 Write-Output " - $script_name :: Updating PIP and SetupTools . . ."
 Write-Output " ----------------------------------------------------------------"
-if ( ! [bool]$Env:SALT_PIP_LOCAL_CACHE) {
-    Start_Process_and_test_exitcode "cmd" "/c $($ini['Settings']['Python2Dir'])\python.exe -m pip --disable-pip-version-check --no-cache-dir install -r $($script_path)\req_pip.txt" "python pip"
-} else {
-    $p = New-Item $Env:SALT_PIP_LOCAL_CACHE -ItemType Directory -Force # Ensure directory exists
-    if ( (Get-ChildItem $Env:SALT_PIP_LOCAL_CACHE | Measure-Object).Count -eq 0 ) {
-        # folder empty
-        Write-Output "    pip download from req_pip.txt into empty local cache SALT_REQ_PIP $Env:SALT_PIP_LOCAL_CACHE"
-        Start_Process_and_test_exitcode "cmd" "/c $($ini['Settings']['Python2Dir'])\python.exe -m pip --disable-pip-version-check download --dest $Env:SALT_PIP_LOCAL_CACHE -r $($script_path)\req_pip.txt" "pip download"
-    }
-    Write-Output "    reading from local pip cache $Env:SALT_PIP_LOCAL_CACHE"
-    Write-Output "    If a (new) resource is missing, please delete all files in this cache, go online and repeat"
-  Start_Process_and_test_exitcode "cmd" "/c $($ini['Settings']['Python2Dir'])\python.exe -m pip --disable-pip-version-check install --no-index --find-links=$Env:SALT_PIP_LOCAL_CACHE -r $($script_path)\req_pip.txt" "pip install"
-}
+Start_Process_and_test_exitcode "cmd" "/c $($ini['Settings']['Python2Dir'])\python.exe -m pip --disable-pip-version-check --no-cache-dir install -r $($script_path)\req_pip.txt" "python pip"
+
 
 #==============================================================================
 # Install pypi resources using pip
-#    caching depends on environment variable SALT_REQ_LOCAL_CACHE
 #==============================================================================
 Write-Output " ----------------------------------------------------------------"
 Write-Output " - $script_name :: Installing pypi resources using pip . . ."
 Write-Output " ----------------------------------------------------------------"
-if ( ! [bool]$Env:SALT_REQ_LOCAL_CACHE) {
-    Start_Process_and_test_exitcode "cmd" "/c $($ini['Settings']['Python2Dir'])\python.exe -m pip --disable-pip-version-check --no-cache-dir install -r $($script_path)\req.txt" "pip install"
-} else {
-    if ( (Get-ChildItem $Env:SALT_REQ_LOCAL_CACHE | Measure-Object).Count -eq 0 ) {
-        # folder empty
-        Write-Output "    pip download from req.txt into empty local cache SALT_REQ $Env:SALT_REQ_LOCAL_CACHE"
-        Start_Process_and_test_exitcode "cmd" "/c $($ini['Settings']['Python2Dir'])\python.exe -m pip --disable-pip-version-check download --dest $Env:SALT_REQ_LOCAL_CACHE -r $($script_path)\req.txt" "pip download"
-    }
-    Write-Output "    reading from local pip cache $Env:SALT_REQ_LOCAL_CACHE"
-    Write-Output "    If a (new) resource is missing, please delete all files in this cache, go online and repeat"
-  Start_Process_and_test_exitcode "cmd" "/c $($ini['Settings']['Python2Dir'])\python.exe -m pip --disable-pip-version-check install --no-index --find-links=$Env:SALT_REQ_LOCAL_CACHE -r $($script_path)\req.txt" "pip install"
-}
+Start_Process_and_test_exitcode "cmd" "/c $($ini['Settings']['Python2Dir'])\python.exe -m pip --disable-pip-version-check --no-cache-dir install -r $($script_path)\req.txt" "pip install"
+
 
 #==============================================================================
 # Cleaning Up PyWin32
@@ -295,9 +272,7 @@ If (-Not $Silent) {
 # Remove the temporary download directory
 #------------------------------------------------------------------------------
 Write-Output " ----------------------------------------------------------------"
-Write-Output " - $script_name :: Cleaning up downloaded files unless you use SALTREPO_LOCAL_CACHE"
+Write-Output " - $script_name :: Cleaning up downloaded files"
 Write-Output " ----------------------------------------------------------------"
 Write-Output ""
-if ( ! [bool]$Env:SALTREPO_LOCAL_CACHE ) {
-    Remove-Item $($ini['Settings']['DownloadDir']) -Force -Recurse
-}
+Remove-Item $($ini['Settings']['DownloadDir']) -Force -Recurse

--- a/pkg/windows/build_env_3.ps1
+++ b/pkg/windows/build_env_3.ps1
@@ -191,44 +191,19 @@ If (!($Path.ToLower().Contains("$($ini['Settings']['Scripts3Dir'])".ToLower())))
 
 #==============================================================================
 # Update PIP and SetupTools
-#    caching depends on environment variable SALT_PIP_LOCAL_CACHE
 #==============================================================================
 Write-Output " ----------------------------------------------------------------"
 Write-Output " - $script_name :: Updating PIP and SetupTools . . ."
 Write-Output " ----------------------------------------------------------------"
-if ( ! [bool]$Env:SALT_PIP_LOCAL_CACHE) {
-    Start_Process_and_test_exitcode "cmd" "/c $($ini['Settings']['Python3Dir'])\python.exe -m pip --disable-pip-version-check --no-cache-dir install -r $($script_path)\req_pip.txt" "python pip"
-} else {
-    $p = New-Item $Env:SALT_PIP_LOCAL_CACHE -ItemType Directory -Force # Ensure directory exists
-    if ( (Get-ChildItem $Env:SALT_PIP_LOCAL_CACHE | Measure-Object).Count -eq 0 ) {
-        # folder empty
-        Write-Output "    pip download from req_pip.txt into empty local cache SALT_REQ_PIP $Env:SALT_PIP_LOCAL_CACHE"
-        Start_Process_and_test_exitcode "cmd" "/c $($ini['Settings']['Python3Dir'])\python.exe -m pip --disable-pip-version-check download --dest $Env:SALT_PIP_LOCAL_CACHE -r $($script_path)\req_pip.txt" "pip download"
-    }
-    Write-Output "    reading from local pip cache $Env:SALT_PIP_LOCAL_CACHE"
-    Write-Output "    If a (new) resource is missing, please delete all files in this cache, go online and repeat"
-  Start_Process_and_test_exitcode "cmd" "/c $($ini['Settings']['Python3Dir'])\python.exe -m pip --disable-pip-version-check install --no-index --find-links=$Env:SALT_PIP_LOCAL_CACHE -r $($script_path)\req_pip.txt" "pip install"
-}
+Start_Process_and_test_exitcode "cmd" "/c $($ini['Settings']['Python3Dir'])\python.exe -m pip --disable-pip-version-check --no-cache-dir install -r $($script_path)\req_pip.txt" "python pip"
 
 #==============================================================================
 # Install pypi resources using pip
-#    caching depends on environment variable SALT_REQ_LOCAL_CACHE
 #==============================================================================
 Write-Output " ----------------------------------------------------------------"
 Write-Output " - $script_name :: Installing pypi resources using pip . . ."
 Write-Output " ----------------------------------------------------------------"
-if ( ! [bool]$Env:SALT_REQ_LOCAL_CACHE) {
-    Start_Process_and_test_exitcode "cmd" "/c $($ini['Settings']['Python3Dir'])\python.exe -m pip --disable-pip-version-check --no-cache-dir install -r $($script_path)\req.txt" "pip install"
-} else {
-    if ( (Get-ChildItem $Env:SALT_REQ_LOCAL_CACHE | Measure-Object).Count -eq 0 ) {
-        # folder empty
-        Write-Output "    pip download from req.txt into empty local cache SALT_REQ $Env:SALT_REQ_LOCAL_CACHE"
-        Start_Process_and_test_exitcode "cmd" "/c $($ini['Settings']['Python3Dir'])\python.exe -m pip --disable-pip-version-check download --dest $Env:SALT_REQ_LOCAL_CACHE -r $($script_path)\req.txt" "pip download"
-    }
-    Write-Output "    reading from local pip cache $Env:SALT_REQ_LOCAL_CACHE"
-    Write-Output "    If a (new) resource is missing, please delete all files in this cache, go online and repeat"
-  Start_Process_and_test_exitcode "cmd" "/c $($ini['Settings']['Python3Dir'])\python.exe -m pip --disable-pip-version-check install --no-index --find-links=$Env:SALT_REQ_LOCAL_CACHE -r $($script_path)\req.txt" "pip install"
-}
+Start_Process_and_test_exitcode "cmd" "/c $($ini['Settings']['Python3Dir'])\python.exe -m pip --disable-pip-version-check --no-cache-dir install -r $($script_path)\req.txt" "pip install"
 
 #==============================================================================
 # Cleaning Up PyWin32
@@ -304,9 +279,7 @@ If (-Not $Silent) {
 # Remove the temporary download directory
 #------------------------------------------------------------------------------
 Write-Output " ----------------------------------------------------------------"
-Write-Output " - $script_name :: Cleaning up downloaded files unless you use SALTREPO_LOCAL_CACHE"
+Write-Output " - $script_name :: Cleaning up downloaded files"
 Write-Output " ----------------------------------------------------------------"
 Write-Output ""
-if ( ! [bool]$Env:SALTREPO_LOCAL_CACHE ) {
-    Remove-Item $($ini['Settings']['DownloadDir']) -Force -Recurse
-}
+Remove-Item $($ini['Settings']['DownloadDir']) -Force -Recurse

--- a/pkg/windows/download_url_file.ps1
+++ b/pkg/windows/download_url_file.ps1
@@ -1,5 +1,5 @@
 #
-# Download url to file. Optionally, store in cache
+# Download url to file.
 #
 #
 Param(
@@ -7,33 +7,8 @@ Param(
     [Parameter(Mandatory=$true)][string]$file
 )
 
-
-$VerbosePreference = 'Continue'
-
-
 Import-Module ./Modules/download-module.psm1
 
-if ( [bool]$Env:SALTREPO_LOCAL_CACHE) {
-    Write-Verbose "found SALTREPO_LOCAL_CACHE environment variable $Env:SALTREPO_LOCAL_CACHE"
-} else {
-    Write-Verbose "no SALTREPO_LOCAL_CACHE environment variable "
-}
-
-$saltrepo_url = "http://repo.saltstack.com/windows/dependencies/"
-
-if ( [bool]$Env:SALTREPO_LOCAL_CACHE -And $url.StartsWith($saltrepo_url) ) {
-    Write-Verbose "found SALTREPO_LOCAL_CACHE environment variable and url is saltrepo"
-    $url_relative__slash     = $url                 -replace [regex]::Escape($saltrepo_url), ""
-    $url_relative__backslash = $url_relative__slash -replace [regex]::Escape("/"), "\\"
-    $localCacheFile          = Join-Path $Env:SALTREPO_LOCAL_CACHE $url_relative__backslash
-    if (-Not (Test-Path $localCacheFile)) {
-        Write-Verbose "downloading to cache   $localCacheFile"
-        DownloadFileWithProgress $url $localCacheFile
-    }
-    Write-Verbose "copying from cache $file"
-    Copy-Item $localCacheFile  -destination $file
-} else {
-    Write-Verbose "no SALTREPO_LOCAL_CACHE environment variable, or URL not saltrepo, downloading directly"
-    DownloadFileWithProgress $url $file
-}
+Write-Host -ForegroundColor Green "  download_url_file $url $file"
+DownloadFileWithProgress $url $file
 

--- a/pkg/windows/download_url_file.ps1
+++ b/pkg/windows/download_url_file.ps1
@@ -1,5 +1,5 @@
 #
-# Download url to file.
+# ps1 wrapper for psm1
 #
 #
 Param(
@@ -9,6 +9,5 @@ Param(
 
 Import-Module ./Modules/download-module.psm1
 
-Write-Host -ForegroundColor DarkGreen "  download_url_file $url $file"
 DownloadFileWithProgress $url $file
 

--- a/pkg/windows/download_url_file.ps1
+++ b/pkg/windows/download_url_file.ps1
@@ -9,6 +9,6 @@ Param(
 
 Import-Module ./Modules/download-module.psm1
 
-Write-Host -ForegroundColor Green "  download_url_file $url $file"
+Write-Host -ForegroundColor DarkGreen "  download_url_file $url $file"
 DownloadFileWithProgress $url $file
 

--- a/pkg/windows/modules/download-module.psm1
+++ b/pkg/windows/modules/download-module.psm1
@@ -17,7 +17,7 @@ Function DownloadFileWithProgress {
 
 
     begin {
-        Write-Host -ForegroundColor Green "  download-module.DownloadFileWithProgress  $url  $localFile"
+        Write-Host -ForegroundColor DarkGreen "  download-module.DownloadFileWithProgress  $url  $localFile"
         $client = New-Object System.Net.WebClient
         $Global:downloadComplete = $false
         $eventDataComplete = Register-ObjectEvent $client DownloadFileCompleted `

--- a/pkg/windows/modules/download-module.psm1
+++ b/pkg/windows/modules/download-module.psm1
@@ -17,7 +17,7 @@ Function DownloadFileWithProgress {
 
 
     begin {
-        Write-Host -ForegroundColor DarkGreen "  download-module.DownloadFileWithProgress  $url  $localFile"
+        Write-Host -ForegroundColor DarkGreen "  download-module.DownloadFileWithProgress  $url"
         $client = New-Object System.Net.WebClient
         $Global:downloadComplete = $false
         $eventDataComplete = Register-ObjectEvent $client DownloadFileCompleted `

--- a/pkg/windows/modules/download-module.psm1
+++ b/pkg/windows/modules/download-module.psm1
@@ -8,12 +8,6 @@ Function DownloadFileWithProgress {
     #    $url - the file source
     #    $localfile - the file destination on the local machine
 
-    # Originally, DownLoadDir is deleted for each install, therefore
-    # this function did not expect that the file exists.
-    # You may want to set an environment variable SALTREPO_LOCAL_CACHE, a cache which lives as long as you decide.
-    # Therefore this function must test if the file exists.
-
-
     param(
         [Parameter(Mandatory=$true)]
         [String] $url,
@@ -21,56 +15,46 @@ Function DownloadFileWithProgress {
         [String] $localFile = (Join-Path $pwd.Path $url.SubString($url.LastIndexOf('/')))
     )
 
+
     begin {
-        $Global:NEED_PROCESS_AND_END = $true
-        Write-Verbose " **** DownloadFileWithProgress looking for **** $localFile ********"
-        if ( [bool]$Env:SALTREPO_LOCAL_CACHE -and (Test-Path $localFile) ) {
-            Write-Verbose " **** found **** $localFile ********"
-            $Global:NEED_PROCESS_AND_END = $false
-        } else {
-            Write-Verbose " ++++++ BEGIN DOWNLOADING ++++++ $localFile +++++++"
-            $client = New-Object System.Net.WebClient
-            $Global:downloadComplete = $false
-            $eventDataComplete = Register-ObjectEvent $client DownloadFileCompleted `
+        Write-Host -ForegroundColor Green "  download-module.DownloadFileWithProgress  $url  $localFile"
+        $client = New-Object System.Net.WebClient
+        $Global:downloadComplete = $false
+        $eventDataComplete = Register-ObjectEvent $client DownloadFileCompleted `
             -SourceIdentifier WebClient.DownloadFileComplete `
             -Action {$Global:downloadComplete = $true}
-            $eventDataProgress = Register-ObjectEvent $client DownloadProgressChanged `
+        $eventDataProgress = Register-ObjectEvent $client DownloadProgressChanged `
             -SourceIdentifier WebClient.DownloadProgressChanged `
             -Action { $Global:DPCEventArgs = $EventArgs }
-        }
-}
+    }
     process {
-        if ( $Global:NEED_PROCESS_AND_END ) {
-            Write-Verbose " ++++++ actually DOWNLOADING ++++++ $localFile +++++++"
-            Write-Progress -Activity 'Downloading file' -Status $url
-            $client.DownloadFileAsync($url, $localFile)
+        Write-Progress -Activity 'Downloading file' -Status $url
+        $client.DownloadFileAsync($url, $localFile)
 
-            while (!($Global:downloadComplete)) {
-                $pc = $Global:DPCEventArgs.ProgressPercentage
-                if ($pc -ne $null) {
-                    Write-Progress -Activity 'Downloading file' -Status $url -PercentComplete $pc
-                }
+        while (!($Global:downloadComplete)) {
+            $pc = $Global:DPCEventArgs.ProgressPercentage
+            if ($pc -ne $null) {
+                Write-Progress -Activity 'Downloading file' -Status $url -PercentComplete $pc
             }
-            Write-Progress -Activity 'Downloading file' -Status $url -Complete
         }
+        Write-Progress -Activity 'Downloading file' -Status $url -Complete
     }
 
     end {
-        if ( $Global:NEED_PROCESS_AND_END ) {
-            Unregister-Event -SourceIdentifier WebClient.DownloadProgressChanged
-            Unregister-Event -SourceIdentifier WebClient.DownloadFileComplete
-            $client.Dispose()
-            $Global:downloadComplete = $null
-            $Global:DPCEventArgs     = $null
-            Remove-Variable client
-            Remove-Variable eventDataComplete
-            Remove-Variable eventDataProgress
-            [GC]::Collect()
-            # Errorchecking
-            If (!((Test-Path "$localfile") -and ((Get-Item "$localfile").length -gt 0kb))) {
-                Write-Error "download-module.psm1 exits in error, download is missing or has zero-length: $localfile"
-                exit 2
-            }
+        Unregister-Event -SourceIdentifier WebClient.DownloadProgressChanged
+        Unregister-Event -SourceIdentifier WebClient.DownloadFileComplete
+        $client.Dispose()
+        $Global:downloadComplete = $null
+        $Global:DPCEventArgs = $null
+        Remove-Variable client
+        Remove-Variable eventDataComplete
+        Remove-Variable eventDataProgress
+        [GC]::Collect()
+        # 2016-07-06  mkr  Errorchecking added. nice-to-have: integration into the above code.
+        If (!((Test-Path "$localfile") -and ((Get-Item "$localfile").length -gt 0kb))) {
+            Write-Error "Exiting because download missing or zero-length:    $localfile"
+            exit 2
         }
+
     }
 }

--- a/pkg/windows/modules/get-settings.psm1
+++ b/pkg/windows/modules/get-settings.psm1
@@ -24,11 +24,6 @@ Function Get-Settings {
             "SitePkgs3Dir" = "C:\Python35\Lib\site-packages"
             "DownloadDir" = "$env:Temp\DevSalt"
             }
-        # The script deletes the DownLoadDir (above) for each install.
-        # You may want to set an environment variable SALTREPO_LOCAL_CACHE, a cache which lives as long as you decide.
-        if ( [bool]$Env:SALTREPO_LOCAL_CACHE ) {
-          $Settings.Set_Item("DownloadDir", "$Env:SALTREPO_LOCAL_CACHE")
-        }
 
         $ini.Add("Settings", $Settings)
         Write-Verbose "DownloadDir === $($ini['Settings']['DownloadDir']) ==="

--- a/setup.py
+++ b/setup.py
@@ -328,28 +328,6 @@ if WITH_SETUPTOOLS:
             develop.run(self)
 
 
-def uri_to_resource(resource_file):
-    # ## Returns the URI for a resource
-    # The basic case is that the resource is on saltstack.com
-    # It could be the case that the resource is cached.
-    salt_uri = 'https://repo.saltstack.com/windows/dependencies/' + resource_file
-    if os.getenv('SALTREPO_LOCAL_CACHE') is None:
-        # if environment variable not set, return the basic case
-        return salt_uri
-    if not os.path.isdir(os.getenv('SALTREPO_LOCAL_CACHE')):
-        # if environment variable is not a directory, return the basic case
-        return salt_uri
-    cached_resource = os.path.join(os.getenv('SALTREPO_LOCAL_CACHE'), resource_file)
-    cached_resource = cached_resource.replace('/', '\\')
-    if not os.path.isfile(cached_resource):
-        # if file does not exist, return the basic case
-        return salt_uri
-    if os.path.getsize(cached_resource) == 0:
-        # if file has zero size, return the basic case
-        return salt_uri
-    return cached_resource
-
-
 class DownloadWindowsDlls(Command):
 
     description = 'Download required DLL\'s for windows'


### PR DESCRIPTION
### What does this PR do?
It removes an optional cache for building the windows salt minion.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/48575

### Previous Behavior
The cache 
 - was only active when 3 environment variables were set (SALTREPO_LOCAL_CACHE, SALT_REQ_LOCAL_CACHE, SALT_PIP_LOCAL_CACHE).
 - was for repo.saltstack.com/windows/dependencies and pypy 
 - needed to be manually filled.

### New Behavior
The cache no longer exists.

### Tests written?
Yes, I build the windows minion and executed smoke tests.

### Commits signed with GPG?
No


