### PR TITLE
Fix mac service.disable tests

### DIFF
--- a/tests/integration/modules/test_mac_service.py
+++ b/tests/integration/modules/test_mac_service.py
@@ -197,11 +197,12 @@ class MacServiceModuleTest(ModuleCase):
         self.assertFalse(
             self.run_function('service.disabled', [SERVICE_NAME]))
 
-        self.assertTrue(self.run_function('service.stop', [SERVICE_NAME]))
+        self.assertTrue(self.run_function('service.disable', [SERVICE_NAME]))
         self.assertTrue(
             self.run_function('service.disabled', [SERVICE_NAME]))
+        self.assertTrue(self.run_function('service.enable', [SERVICE_NAME]))
 
-        self.assertTrue(self.run_function('service.disabled', ['spongebob']))
+        self.assertFalse(self.run_function('service.disabled', ['spongebob']))
 
     def test_get_all(self):
         '''


### PR DESCRIPTION
### What does this PR do?
Since we are now accurately querying the disabled status of a service in macosx after this PR: https://github.com/saltstack/salt/pull/47578  we need to update this other mac service.disabled test to make sure we are disabling the service and not stopping it to determine if its disabled or not. 

### What issues does this PR fix or reference?
Fixes the failing test: `integration.modules.test_mac_service.MacServiceModuleTest.test_disabled`

```
Traceback (most recent call last):
  File "/testing/tests/support/helpers.py", line 122, in wrap
    return caller(cls)
  File "/testing/tests/integration/modules/test_mac_service.py", line 202, in test_disabled
    self.run_function('service.disabled', [SERVICE_NAME]))
AssertionError: False is not true
```
