### PR TITLE
Fix for issue #48677 - return clean npm.bootstrap on no changes

### DIFF
--- a/salt/states/npm.py
+++ b/salt/states/npm.py
@@ -275,9 +275,13 @@ def bootstrap(name, user=None, silent=True):
     if __opts__['test']:
         try:
             call = __salt__['npm.install'](dir=name, runas=user, pkg=None, silent=silent, dry_run=True)
-            ret['result'] = None
-            ret['changes'] = {'old': [], 'new': call}
-            ret['comment'] = '{0} is set to be bootstrapped'.format(name)
+            if call:
+                ret['result'] = None
+                ret['changes'] = {'old': [], 'new': call}
+                ret['comment'] = '{0} is set to be bootstrapped'.format(name)
+            else:
+                ret['result'] = True
+                ret['comment'] = '{0} is already bootstrapped'.format(name)
         except (CommandNotFoundError, CommandExecutionError) as err:
             ret['result'] = False
             ret['comment'] = 'Error Bootstrapping \'{0}\': {1}'.format(name, err)


### PR DESCRIPTION
### What does this PR do?
Returns a clean status when using npm.bootstrap in test mode with no changes to be made


### What issues does this PR fix or reference?

#48677 


### Previous Behavior
test=true on npm.bootstrap state always returns "None"

### New Behavior
Applying npm.bootstrap state with test=true returns "True" if no changes are flagged

### Tests written?

No

### Commits signed with GPG?

No

