### PR TITLE
Read all pillar_roots, not just the first one

### DIFF
--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -507,18 +507,23 @@ class Pillar(object):
                 if self.opts.get('pillar_source_merging_strategy', None) == "none":
                     saltenvs &= set([self.saltenv or 'base'])
 
+            top_file = salt.utils.url.strip_proto(self.opts['state_top'])
+
             for saltenv in saltenvs:
-                top = self.client.cache_file(self.opts['state_top'], saltenv)
-                if top:
-                    tops[saltenv].append(compile_template(
-                        top,
-                        self.rend,
-                        self.opts['renderer'],
-                        self.opts['renderer_blacklist'],
-                        self.opts['renderer_whitelist'],
-                        saltenv=saltenv,
-                        _pillar_rend=True,
-                    ))
+                for pillarloc in self.opts['file_roots'][self.opts['pillarenv']]:
+                    pillar_top = salt.utils.path.join(pillarloc, top_file)
+
+                    top = self.client.cache_file(pillar_top, self.opts['pillarenv'])
+                    if top:
+                        tops[saltenv].append(compile_template(
+                            top,
+                            self.rend,
+                            self.opts['renderer'],
+                            self.opts['renderer_blacklist'],
+                            self.opts['renderer_whitelist'],
+                            saltenv=saltenv,
+                            _pillar_rend=True,
+                        ))
         except Exception as exc:
             errors.append(
                     ('Rendering Primary Top file failed, render error:\n{0}'


### PR DESCRIPTION
fixes #37990

Hi,

A small attempt at fixing this issue; it quite likely needs some work, I'm not familiar with Salt internals... Don't know if it's correct to iterate over the pillar_roots and just add the state_top on the end, but it works here.

Matthew

### What does this PR do?

Read top files in all locations under pillar_roots, rather than just the first one

### What issues does this PR fix or reference?

#37990

### Previous Behavior

Only the first top.sls pillar file listed is read (but all top.sls files under file_roots are read)

### New Behavior

Read all pillar_roots, to behave the same as file_roots

### Tests written?

No

### Commits signed with GPG?

Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
