### PR TITLE
Add query current minion config with config.items

### DIFF
--- a/salt/modules/config.py
+++ b/salt/modules/config.py
@@ -461,3 +461,16 @@ def gather_bootstrap_script(bootstrap=None):
     ret = salt.utils.cloud.update_bootstrap(__opts__, url=bootstrap)
     if 'Success' in ret and len(ret['Success']['Files updated']) > 0:
         return ret['Success']['Files updated'][0]
+
+def items():
+    '''
+    Return the complete config from the currently running minion process.
+    This includes defaults for values not set in the config file.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' config.items
+    '''
+    return __opts__


### PR DESCRIPTION
### What does this PR do?
Adds an `items` function to the `config` execution module to query minions for their current running config.

### What issues does this PR fix or reference?
Fixes #48680 

### Previous Behavior
The current running config could not be queried completely instead it hat to be cobbled together with `config.get`. This was cumbersome and required the caller to already know the item key name beforehand.

### New Behavior
One can simply call `salt '*' config.items` to retrieve the current configuration of all minions.

### Tests written?

No

### Commits signed with GPG?

Yes