### PR TITLE
Fixed zabbix host inventory manipulation.

### DIFF
--- a/salt/states/zabbix_host.py
+++ b/salt/states/zabbix_host.py
@@ -268,8 +268,7 @@ def present(host, groups, interfaces, **kwargs):
             if update_inventory:
                 # combine connection_args, inventory, and clear_old
                 sum_kwargs = dict(new_inventory)
-                for elem in connection_args:
-                    sum_kwargs = new_inventory.get(elem, 0) + connection_args[elem]
+                sum_kwargs.update(connection_args)
                 sum_kwargs['clear_old'] = True
 
                 hostupdate = __salt__['zabbix.host_inventory_set'](hostid, **sum_kwargs)


### PR DESCRIPTION
### What does this PR do?
Fixes wrong manipulation with zabbix host inventory (exception).

### Previous Behavior
When try to change or update host inventory it threw this exception:
```
     Comment: An exception occurred in this state: Traceback (most recent call last):
                File "/usr/lib/python2.7/dist-packages/salt/state.py", line 1745, in call                                                                                                                         
                  **cdata['kwargs'])                                                                                                                                                                              
                File "/usr/lib/python2.7/dist-packages/salt/loader.py", line 1702, in wrapper                                                                                                                     
                  return f(*args, **kwargs)                                                                                                                                                                       
                File "/var/cache/salt/minion/extmods/states/zabbix_host.py", line 280, in present                                                                                                                 
                  sum_kwargs = new_inventory.get(elem, 0) + connection_args[elem]                                                                                                                                 
              TypeError: unsupported operand type(s) for +: 'int' and 'str'                                                                                                                                       
```

### Tests written?

No

### Commits signed with GPG?

Yes