### PR TITLE
Use empty dict for 'changes' instead of None

### DIFF
--- a/salt/states/esxvm.py
+++ b/salt/states/esxvm.py
@@ -434,10 +434,8 @@ def vm_created(name, vm_name, cpu, memory, image, version, interfaces,
               'comment': ''}
 
     if __opts__['test']:
-        result.update({'result': None,
-                       'changes': None,
-                       'comment': 'Virtual machine '
-                                  '{0} will be created'.format(vm_name)})
+        result['comment'] = 'Virtual machine {0} will be created'.format(
+                vm_name)
         return result
 
     service_instance = __salt__['vsphere.get_service_instance_via_proxy']()

--- a/salt/states/grafana_datasource.py
+++ b/salt/states/grafana_datasource.py
@@ -83,7 +83,7 @@ def present(name,
     if isinstance(profile, string_types):
         profile = __salt__['config.option'](profile)
 
-    ret = {'name': name, 'result': None, 'comment': None, 'changes': None}
+    ret = {'name': name, 'result': None, 'comment': None, 'changes': {}}
     datasource = _get_datasource(profile, name)
     data = _get_json_data(name, type, url, access, user, password, database,
         basic_auth, basic_auth_user, basic_auth_password, is_default, json_data)
@@ -126,7 +126,7 @@ def absent(name, profile='grafana'):
     if isinstance(profile, string_types):
         profile = __salt__['config.option'](profile)
 
-    ret = {'result': None, 'comment': None, 'changes': None}
+    ret = {'result': None, 'comment': None, 'changes': {}}
     datasource = _get_datasource(profile, name)
 
     if not datasource:

--- a/salt/states/vault.py
+++ b/salt/states/vault.py
@@ -55,7 +55,7 @@ def policy_present(name, rules):
     except Exception as e:
         return {
             'name': name,
-            'changes': None,
+            'changes': {},
             'result': False,
             'comment': 'Failed to get policy: {0}'.format(e)
         }
@@ -76,7 +76,7 @@ def _create_new_policy(name, rules):
     if response.status_code != 204:
         return {
             'name': name,
-            'changes': None,
+            'changes': {},
             'result': False,
             'comment': 'Failed to create policy: {0}'.format(response.reason)
         }
@@ -93,7 +93,7 @@ def _handle_existing_policy(name, new_rules, existing_rules):
     ret = {'name': name}
     if new_rules == existing_rules:
         ret['result'] = True
-        ret['changes'] = None
+        ret['changes'] = {}
         ret['comment'] = 'Policy exists, and has the correct content'
         return ret
 
@@ -111,7 +111,7 @@ def _handle_existing_policy(name, new_rules, existing_rules):
     if response.status_code != 204:
         return {
             'name': name,
-            'changes': None,
+            'changes': {},
             'result': False,
             'comment': 'Failed to change policy: {0}'.format(response.reason)
         }


### PR DESCRIPTION
See #47059 #46985 for previous similar changes.

This PR fixes the missing occurences of changes=None to replace None by an empty dict (this can result in state failures: "An exception occurred in this state: 'Changes' should be a dictionary."):

```
$ git grep "'changes': *None"
salt/states/esxvm.py:                       'changes': None,
salt/states/grafana4_datasource.py:    ret = {'name': name, 'result': None, 'comment': None, 'changes': None}
salt/states/grafana_datasource.py:    ret = {'name': name, 'result': None, 'comment': None, 'changes': None}
salt/states/grafana_datasource.py:    ret = {'result': None, 'comment': None, 'changes': None}
salt/states/vault.py:            'changes': None,
salt/states/vault.py:            'changes': None,
salt/states/vault.py:            'changes': None,
```

Note that I've not changed the `salt/states/grafana4_datasource.py` file in this PR as this is already fixed in upcoming PR #48671.