### PR TITLE
Fix ext_pillar remote checkout using tag (pygit2)

### DIFF
--- a/salt/utils/gitfs.py
+++ b/salt/utils/gitfs.py
@@ -1534,9 +1534,9 @@ class Pygit2(GitProvider):
 
             elif tag_ref in refs:
                 tag_obj = self.repo.revparse_single(tag_ref)
-                if not isinstance(tag_obj, pygit2.Tag):
+                if not isinstance(tag_obj, pygit2.Commit):
                     log.error(
-                        '%s does not correspond to pygit2.Tag object',
+                        '%s does not correspond to pygit2.Commit object',
                         tag_ref
                     )
                 else:
@@ -1556,9 +1556,10 @@ class Pygit2(GitProvider):
                                 exc_info=True
                             )
                             return None
+                    log.debug('SHA of tag %s: %s', tgt_ref, tag_sha)
 
-                    if head_sha != target_sha:
-                        if not _perform_checkout(local_ref, branch=False):
+                    if head_sha != tag_sha:
+                        if not _perform_checkout(tag_ref, branch=False):
                             return None
 
                     # Return the relative root, if present


### PR DESCRIPTION
### What does this PR do?

Fixes a bug that prohibits one from checking out a git ext_pillar remote by its tag

### What issues does this PR fix or reference?

Fixes #38310

### Tests written?

No

### Commits signed with GPG?

Yes
