### PR TITLE
Feature: ldap authentication with starttls

### DIFF
--- a/doc/topics/eauth/index.rst
+++ b/doc/topics/eauth/index.rst
@@ -236,6 +236,9 @@ Server configuration values and their defaults:
     # Use TLS when connecting
     auth.ldap.tls: False
 
+    # Use STARTTLS when connecting
+    auth.ldap.starttls: False
+
     # LDAP scope level, almost always 2
     auth.ldap.scope: 2
 


### PR DESCRIPTION
fix #48655

### What does this PR do?
Add starttls support for ldap authentication module

### What issues does this PR fix or reference?
issue 48655

### New Behavior
support starttls protocol and check if either only starttls or tls is enabled

### Tests written?
No

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
