### PR TITLE
Call sync_modules to fix Windows test case

### DIFF
--- a/tests/integration/loader/test_ext_modules.py
+++ b/tests/integration/loader/test_ext_modules.py
@@ -21,6 +21,9 @@ from tests.support.paths import TMP
 
 class LoaderOverridesTest(ModuleCase):
 
+    def setUp(self):
+        self.run_function('saltutil.sync_modules')
+
     def test_overridden_internal(self):
         # To avoid a race condition on Windows, we need to make sure the
         # `override_test.py` file is present in the _modules directory before


### PR DESCRIPTION
### What does this PR do?

Fixes test case:

https://jenkinsci.saltstack.com/job/2018.3/view/Python3/job/salt-windows-2016-py3/97/testReport/junit/integration.loader.test_ext_modules/LoaderOverridesTest/test_overridden_internal/


### Tests written?

No - Fixes teast

### Commits signed with GPG?

Yes