### PR TITLE
Add usergroup support to user.present

### DIFF
--- a/salt/modules/useradd.py
+++ b/salt/modules/useradd.py
@@ -136,7 +136,8 @@ def add(name,
         createhome=True,
         loginclass=None,
         nologinit=False,
-        root=None):
+        root=None,
+        usergroup=None):
     '''
     Add a user to the minion
 
@@ -191,6 +192,9 @@ def add(name,
     root
         Directory to chroot into
 
+    usergroup
+        Create and add the user to a new primary group of the same name
+
     CLI Example:
 
     .. code-block:: bash
@@ -204,6 +208,10 @@ def add(name,
         cmd.extend(['-u', uid])
     if gid not in (None, ''):
         cmd.extend(['-g', gid])
+    elif usergroup:
+        cmd.append('-U')
+        if __grains__['kernel'] != 'Linux':
+            log.warning("'usergroup' is only supported on GNU/Linux hosts.")
     elif groups is not None and name in groups:
         defs_file = '/etc/login.defs'
         if __grains__['kernel'] != 'OpenBSD':
@@ -244,6 +252,11 @@ def add(name,
             except OSError:
                 # /etc/usermgmt.conf not present: defaults will be used
                 pass
+    # Setting usergroup to False adds the -N command argument. If
+    # usergroup is None, no arguments are added to allow useradd to go
+    # with the defaults defined for the OS.
+    if usergroup is False:
+        cmd.append('-N')
 
     if createhome:
         cmd.append('-m')

--- a/salt/modules/useradd.py
+++ b/salt/modules/useradd.py
@@ -148,7 +148,7 @@ def add(name,
         User ID of the new account
 
     gid
-        Name or ID of the primary group of the new accoun
+        Name or ID of the primary group of the new account
 
     groups
         List of supplementary groups of the new account
@@ -160,7 +160,7 @@ def add(name,
         Login shell of the new account
 
     unique
-        Allow to create users with duplicate
+        If not True, the user account can have a non-unique UID
 
     system
         Create a system account

--- a/salt/states/user.py
+++ b/salt/states/user.py
@@ -225,7 +225,7 @@ def _changes(name,
 def present(name,
             uid=None,
             gid=None,
-            gid_from_name=False,
+            usergroup=None,
             groups=None,
             optional_groups=None,
             remove_groups=True,
@@ -272,11 +272,6 @@ def present(name,
         or gid can be used. If not specified, and the user does not exist, then
         the next available gid will be assigned.
 
-    gid_from_name : False
-        If ``True``, the default group id will be set to the id of the group
-        with the same name as the user. If the group does not exist the state
-        will fail.
-
     allow_uid_change : False
         Set to ``True`` to allow the state to update the uid.
 
@@ -286,6 +281,17 @@ def present(name,
         Set to ``True`` to allow the state to update the gid.
 
         .. versionadded:: 2018.3.1
+
+    usergroup
+        If True, a group with the same name as the user will be created. If
+        False, a group with the same name as the user will not be created. The
+        default is distribution-specific. See the USERGROUPS_ENAB section of
+        the login.defs(5) man page.
+
+        .. note::
+            Only supported on GNU/Linux distributions
+
+        .. versionadded:: Fluorine
 
     groups
         A list of groups to assign the user to, pass a list object. If a group
@@ -526,17 +532,18 @@ def present(name,
                 'for user %s', isected, name
             )
 
-    if gid_from_name:
-        gid = __salt__['file.group_to_gid'](name)
-        if gid == '':
-            ret['comment'] = 'Default group with name "{0}" is not present'.format(name)
-            ret['result'] = False
-            return ret
+    # If usergroup was specified, we'll also be creating a new
+    # group. We should report this change without setting the gid
+    # variable.
+    if usergroup and __salt__['file.group_to_gid'](name) != '':
+        changes_gid = name
+    else:
+        changes_gid = gid
 
     try:
         changes = _changes(name,
                            uid,
-                           gid,
+                           changes_gid,
                            groups,
                            present_optgroups,
                            remove_groups,
@@ -741,7 +748,8 @@ def present(name,
                       'other': other,
                       'createhome': createhome,
                       'nologinit': nologinit,
-                      'loginclass': loginclass}
+                      'loginclass': loginclass,
+                      'usergroup': usergroup}
         else:
             params = ({'name': name,
                        'password': password,

--- a/tests/integration/files/file/base/git_pillar/ssh/user/init.sls
+++ b/tests/integration/files/file/base/git_pillar/ssh/user/init.sls
@@ -2,7 +2,7 @@
 
 {{ user }}:
   user.present:
-    - gid_from_name: True
+    - usergroup: False
     - password: '$6$saYbZFw2$rtmvt2LOYchvlM22y34mCs7FiIN4Fq27rmv/whr/M.oPrgfCDhP5uJqnfe6uwFj90FvwA45rhZplnRNMgiY.J.'
     - require:
       - group: {{ user }}

--- a/tests/integration/states/test_user.py
+++ b/tests/integration/states/test_user.py
@@ -20,6 +20,7 @@ from tests.support.helpers import destructiveTest, requires_system_grains, skip_
 from tests.support.mixins import SaltReturnAssertsMixin
 
 # Import Salt libs
+import salt.utils.files
 import salt.utils.platform
 
 try:
@@ -126,43 +127,8 @@ class UserTest(ModuleCase, SaltReturnAssertsMixin):
         else:
             self.assertEqual(group_name, self.user_name)
 
-    @skipIf(salt.utils.platform.is_windows(), 'windows minion does not support gid_from_name')
-    @requires_system_grains
-    def test_user_present_gid_from_name_default(self, grains=None):
-        '''
-        This is a DESTRUCTIVE TEST. It creates a new user on the on the minion.
-        This is an integration test. Not all systems will automatically create
-        a group of the same name as the user, but I don't have access to any.
-        If you run the test and it fails, please fix the code it's testing to
-        work on your operating system.
-        '''
-        # MacOS users' primary group defaults to staff (20), not the name of
-        # user
-        gid_from_name = False if grains['os_family'] == 'MacOS' else True
-
-        ret_user_present = self.run_state('user.present', name=self.user_name,
-                             gid_from_name=gid_from_name, home=self.user_home)
-
-        if gid_from_name:
-            self.assertSaltFalseReturn(ret_user_present)
-            ret_user_present = ret_user_present[next(iter(ret_user_present))]
-            self.assertTrue('is not present' in ret_user_present['comment'])
-        else:
-            self.assertSaltTrueReturn(ret_user_present)
-            ret_user_info = self.run_function('user.info', [self.user_name])
-            self.assertReturnNonEmptySaltType(ret_user_info)
-            group_name = grp.getgrgid(ret_user_info['gid']).gr_name
-            if not salt.utils.platform.is_darwin():
-                self.assertTrue(os.path.isdir(self.user_home))
-            if grains['os_family'] in ('Suse',):
-                self.assertEqual(group_name, 'users')
-            elif grains['os_family'] == 'MacOS':
-                self.assertEqual(group_name, 'staff')
-            else:
-                self.assertEqual(group_name, self.user_name)
-
-    @skipIf(salt.utils.platform.is_windows(), 'windows minion does not support gid_from_name')
-    def test_user_present_gid_from_name(self):
+    @skipIf(salt.utils.platform.is_windows(), 'windows minion does not support usergroup')
+    def test_user_present_usergroup_false(self):
         '''
         This is a DESTRUCTIVE TEST it creates a new user on the on the minion.
         This is a unit test, NOT an integration test. We create a group of the
@@ -170,8 +136,32 @@ class UserTest(ModuleCase, SaltReturnAssertsMixin):
         '''
         ret = self.run_state('group.present', name=self.user_name)
         self.assertSaltTrueReturn(ret)
+
         ret = self.run_state('user.present', name=self.user_name,
-                             gid_from_name=True, home=self.user_home)
+                             gid=self.user_name, usergroup=False,
+                             home=self.user_home)
+        self.assertSaltTrueReturn(ret)
+
+        ret = self.run_function('user.info', [self.user_name])
+        self.assertReturnNonEmptySaltType(ret)
+        group_name = grp.getgrgid(ret['gid']).gr_name
+
+        if not salt.utils.platform.is_darwin():
+            self.assertTrue(os.path.isdir(self.user_home))
+        self.assertEqual(group_name, self.user_name)
+        ret = self.run_state('user.absent', name=self.user_name)
+        self.assertSaltTrueReturn(ret)
+        ret = self.run_state('group.absent', name=self.user_name)
+        self.assertSaltTrueReturn(ret)
+
+    @skipIf(salt.utils.platform.is_windows(), 'windows minion does not support usergroup')
+    def test_user_present_usergroup(self):
+        '''
+        This is a DESTRUCTIVE TEST it creates a new user on the on the minion.
+        This is a unit test, NOT an integration test.
+        '''
+        ret = self.run_state('user.present', name=self.user_name,
+                             usergroup=True, home=self.user_home)
         self.assertSaltTrueReturn(ret)
 
         ret = self.run_function('user.info', [self.user_name])

--- a/tests/unit/modules/test_useradd.py
+++ b/tests/unit/modules/test_useradd.py
@@ -60,16 +60,13 @@ class UserAddTestCase(TestCase, LoaderModuleMockMixin):
         Test for adding a user
         '''
         with patch.dict(useradd.__grains__, {'kernel': 'OpenBSD'}):
-            mock_primary = MagicMock(return_value='Salt')
-            with patch.dict(useradd.__salt__,
-                            {'file.gid_to_group': mock_primary}):
-                mock = MagicMock(return_value={'retcode': 0})
-                with patch.dict(useradd.__salt__, {'cmd.run_all': mock}):
-                    self.assertTrue(useradd.add('Salt'))
+            mock = MagicMock(return_value={'retcode': 0})
+            with patch.dict(useradd.__salt__, {'cmd.run_all': mock}):
+                self.assertTrue(useradd.add('Salt'))
 
-                mock = MagicMock(return_value={'retcode': 1})
-                with patch.dict(useradd.__salt__, {'cmd.run_all': mock}):
-                    self.assertFalse(useradd.add('Salt'))
+            mock = MagicMock(return_value={'retcode': 1})
+            with patch.dict(useradd.__salt__, {'cmd.run_all': mock}):
+                self.assertFalse(useradd.add('Salt'))
 
     # 'getent' function tests: 2
 


### PR DESCRIPTION
### What does this PR do?
Replaces the seemingly redundant `gid_from_name` argument from `user.present` and replaces it with a `usergroup` argument that has the effect of adding the `--user-group` argument to the `useradd` command on GNU/Linux hosts.

I whitelisted it to GNU/Linux for now since I don't know which other operating systems support the `-U`/`--user-group` argument.

I tested it on an OpenSUSE 42.3 and Debian Stretch by creating a basic state sls:
```
test:
  user.present:
    - usergroup: True

test2:
  user.present:
    - usergroup: False
```

On both hosts the intended behaviour was observed.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/48640

### Previous Behavior
`gid_from_name` has been removed. AFAICT this command no longer has any practical benefit - please correct me if I'm overlooking something. The behaviour it intended to provide can be simulated just as easily by:
```
test:
  user.present:
    - gid: test
```
(where we want a `test` group to match a test user). This is much easier to read and understand. It's also clearer that the group will not be automatically created in this case.

Regardless of the `gid_from_name` option, the group will not be created since 2017.7.5 due to the regression referenced. This PR does not revert that regression (which is actually a pain to deal with on a stable release and IMO really should be fixed), but I believe this is a better approach for the long-term.

### New Behavior
We now mimic the existing `--user-group` option behaviour of the `useradd` command which I believe is closer to user expectations - even for users of distributions such as SuSE that don't typically use this.

If `usergroup: True` is set in the user state sls file, the `-U` argument will be passed to the `useradd` command causing the group with the same name as the user name to be created. If `usergroup: False` is set, the `-N`/`--no-user-group` argument is added instead. If left undefined, the defaults that the distribution or user typically defines in `/etc/default/useradd` and `/etc/login.defs` are used as usual.

### Tests written?

No. There are no existing tests for `gid_from_name` either. I'm not sure what the best way to do this would be, but I suspect it would involve having the test inspect the constructed `cmd` list in the `useradd.add` function to check for the presence of `-U` instead, as opposed to just inspecting a return value of a mocked command.

### Commits signed with GPG?

Yes
