### PR TITLE
cloudstack: fix wrong attribute name in doc

### DIFF
--- a/doc/topics/cloud/cloudstack.rst
+++ b/doc/topics/cloud/cloudstack.rst
@@ -152,18 +152,18 @@ command:
 CloudStack specific settings
 ============================
 
-security_group
+securitygroup
 ~~~~~~~~~~~~~~
-.. versionadded:: next-release
+.. versionadded:: 2017.7.0
 
 You can specify a list of security groups (by name or id) that should be
-assigned to the VM.
+assigned to the VM:
 
 .. code-block:: yaml
 
     exoscale:
       provider: cloudstack
-      security_group:
+      securitygroup:
         - default
         - salt-master
 


### PR DESCRIPTION
### What does this PR do?

Fix documentation example for CloudStack cloud provider, the attribute for the security groups was incorrect. Add a reference when the security groups were added into the CloudStack module.

### What issues does this PR fix or reference?

Original commit 974f11a4ee0a60c5ceb88a4ab10fa6b2be893276 with the code change

### Tests written?

No

### Commits signed with GPG?

Yes