### PR TITLE
[develop] Fix up new lint failures

### DIFF
--- a/salt/modules/solarisips.py
+++ b/salt/modules/solarisips.py
@@ -314,7 +314,7 @@ def version(*names, **kwargs):
         ret[_ips_get_pkgname(line)] = _ips_get_pkgversion(line)
 
     # Append package names which are not installed/found
-    unmatched = list([name for name in names if not reduce(lambda x, y: x or name in y, ret, False)])
+    unmatched = list([name for name in names if not reduce(lambda x, y: x or name in y, ret, False)])  # pylint: disable=W0640
     ret.update(zip(unmatched, itertools.cycle(('',))))
 
     # Return a string if only one package name passed

--- a/tests/integration/sdb/test_vault.py
+++ b/tests/integration/sdb/test_vault.py
@@ -28,7 +28,7 @@ class VaultTestCase(ModuleCase, ShellCase):
         '''
         config = '{"backend": {"file": {"path": "/vault/file"}}, "default_lease_ttl": "168h", "max_lease_ttl": "720h"}'
         self.run_state('docker_image.present', name='vault', tag='0.9.6')
-        ret = self.run_state(
+        self.run_state(
             'docker_container.running',
             name='vault',
             image='vault:0.9.6',
@@ -39,12 +39,12 @@ class VaultTestCase(ModuleCase, ShellCase):
             },
             cap_add='IPC_LOCK',
         )
-        ret = self.run_function(
+        self.run_function(
             'cmd.run',
-            cmd='vault login token=testsecret'.format(FILES),
+            cmd='vault login token=testsecret',
             env={'VAULT_ADDR': 'http://127.0.0.1:8200'},
         )
-        ret = self.run_function(
+        self.run_function(
             'cmd.run',
             cmd='vault policy write testpolicy {0}/vault.hcl'.format(FILES),
             env={'VAULT_ADDR': 'http://127.0.0.1:8200'},

--- a/tests/unit/modules/test_file.py
+++ b/tests/unit/modules/test_file.py
@@ -1598,40 +1598,6 @@ class FilemodLineTests(TestCase, LoaderModuleMockMixin):
             assert writelines_content[0] == expected, (writelines_content[0], expected)
 
     @with_tempfile()
-    def test_line_insert_ensure_before_first_line(self, name):
-        '''
-        Test for file.line for insertion ensuring the line is before first line
-        :return:
-        '''
-        cfg_content = '#!/bin/bash'
-        file_content = os.linesep.join([
-            '/etc/init.d/someservice restart',
-            'exit 0'
-        ])
-        file_modified = os.linesep.join([
-            cfg_content,
-            '/etc/init.d/someservice restart',
-            'exit 0'
-        ])
-
-        isfile_mock = MagicMock(side_effect=lambda x: True if x == name else DEFAULT)
-        with patch('os.path.isfile', isfile_mock), \
-                patch('os.stat', MagicMock(return_value=DummyStat())), \
-                patch('salt.utils.files.fopen',
-                      mock_open(read_data=file_content)), \
-                patch('salt.utils.atomicfile.atomic_open',
-                      mock_open()) as atomic_open_mock:
-            filemod.line(name, content=cfg_content, before='/etc/init.d/someservice restart', mode='ensure')
-            handles = atomic_open_mock.filehandles[name]
-            # We should only have opened the file once
-            open_count = len(handles)
-            assert open_count == 1, open_count
-            # We should only have invoked .writelines() once...
-            writelines_content = handles[0].writelines_calls
-            writelines_count = len(writelines_content)
-            assert writelines_count == 1, writelines_count
-
-    @with_tempfile()
     def test_line_insert_ensure_after(self, name):
         '''
         Test for file.line for insertion ensuring the line is after


### PR DESCRIPTION
There are a handful of new lint failures that popped up on PRs today that are unrelated to the changes in the PRs. This fixes those errors.

In `test_file`, that test is being removed because it is a duplicate. In `test_vault` the `ret = ` is removed because those variables are never used. We just need to run the state function. 