### PR TITLE
Remove old hack when reporting multiversion packages

### DIFF
--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -1481,11 +1481,6 @@ def upgrade(refresh=True,
     __zypper__(systemd_scope=_systemd_scope()).noraise.call(*cmd_update)
     _clean_cache()
     new = list_pkgs()
-
-    # Handle packages which report multiple new versions
-    # (affects only kernel packages at this point)
-    for pkg in new:
-        new[pkg] = new[pkg].split(',')[-1]
     ret = salt.utils.data.compare_dicts(old, new)
 
     if __zypper__.exit_code not in __zypper__.SUCCESS_EXIT_CODES:

--- a/tests/unit/modules/test_zypper.py
+++ b/tests/unit/modules/test_zypper.py
@@ -430,7 +430,13 @@ class ZypperTestCase(TestCase, LoaderModuleMockMixin):
                     zypper_mock.assert_any_call('update', '--auto-agree-with-licenses')
 
                 with patch('salt.modules.zypper.list_pkgs',
-                           MagicMock(side_effect=[{"vim": "1.1"}, {"vim": "1.1,1.2"}])):
+                           MagicMock(side_effect=[{"kernel-default": "1.1"}, {"kernel-default": "1.1,1.2"}])):
+                    ret = zypper.upgrade()
+                    self.assertDictEqual(ret, {"kernel-default": {"old": "1.1", "new": "1.1,1.2"}})
+                    zypper_mock.assert_any_call('update', '--auto-agree-with-licenses')
+
+                with patch('salt.modules.zypper.list_pkgs',
+                           MagicMock(side_effect=[{"vim": "1.1"}, {"vim": "1.2"}])):
                     ret = zypper.upgrade()
                     self.assertDictEqual(ret, {"vim": {"old": "1.1", "new": "1.2"}})
                     zypper_mock.assert_any_call('update', '--auto-agree-with-licenses')


### PR DESCRIPTION
### What does this PR do?
This PR fixes an issue with zypper `pkg.upgrade` after adding multiversion package support. 

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/48701

### Previous Behavior
Even if the minion is upgraded, each call to `pkg.upgrade` report wrong output for multiversion packages:
```
# salt-call --local pkg.upgrade
local:
    ----------
    kernel-default:
        ----------
        new:
            4.4.21-69.1
        old:
            4.4.120-92.70.1,4.4.21-69.1
```

### New Behavior
The results are the expected since the minion is already upgraded:
```
# salt-call --local pkg.upgrade
local:
    ----------
```

### Tests written?

No

### Commits signed with GPG?

Yes
