### PR TITLE
Always transfer bytes from fileserver roots

### DIFF
--- a/salt/fileserver/roots.py
+++ b/salt/fileserver/roots.py
@@ -129,8 +129,6 @@ def serve_file(load, fnd):
     with salt.utils.files.fopen(fpath, 'rb') as fp_:
         fp_.seek(load['loc'])
         data = fp_.read(__opts__['file_buffer_size'])
-        if data and six.PY3 and not salt.utils.files.is_binary(fpath):
-            data = data.decode(__salt_system_encoding__)
         if gzip and data:
             data = salt.utils.gzip_util.compress(data, gzip)
             ret['gzip'] = gzip

--- a/tests/integration/files/file/base/issue-46672-a.sls
+++ b/tests/integration/files/file/base/issue-46672-a.sls
@@ -1,0 +1,3 @@
+echo1:
+  cmd.run:
+    - name: "echo 'This is Æ test!'"

--- a/tests/integration/files/file/base/testfile
+++ b/tests/integration/files/file/base/testfile
@@ -1,6 +1,6 @@
 Scene 24
 
- 
+
   OLD MAN:  Ah, hee he he ha!
   ARTHUR:  And this enchanter of whom you speak, he has seen the grail?
   OLD MAN:  Ha ha he he he he!

--- a/tests/integration/modules/test_state.py
+++ b/tests/integration/modules/test_state.py
@@ -1942,6 +1942,20 @@ class StateModuleTest(ModuleCase, SaltReturnAssertsMixin):
         _expected = "cmd_|-echo1_|-echo 'This is Æ test!'_|-run"
         self.assertIn(_expected, ret)
 
+    def test_state_sls_unicode_characters_cmd_output(self):
+        '''
+        test the output from running and echo command with non-ascii
+        characters.
+        '''
+        ret = self.run_function('state.sls', ['issue-46672-a'])
+        key = list(ret.keys())[0]
+        log.debug('== ret %s ==', type(ret))
+        _expected = 'This is Æ test!'
+        if salt.utils.platform.is_windows():
+            # Windows cmd.exe will mangle the output using cmd's codepage.
+            _expected = "'This is ’ test!'"
+        self.assertEqual(_expected, ret[key]['changes']['stdout'])
+
     def tearDown(self):
         nonbase_file = os.path.join(TMP, 'nonbase_env')
         if os.path.isfile(nonbase_file):

--- a/tests/unit/fileserver/test_roots.py
+++ b/tests/unit/fileserver/test_roots.py
@@ -108,34 +108,34 @@ class RootsTest(TestCase, AdaptedConfigurationTestCaseMixin, LoaderModuleMockMix
                    'rel': 'testfile'}
             ret = roots.serve_file(load, fnd)
 
-            data = 'Scene 24\n\n \n  OLD MAN:  Ah, hee he he ha!\n  ' \
-                   'ARTHUR:  And this enchanter of whom you speak, he ' \
-                   'has seen the grail?\n  OLD MAN:  Ha ha he he he ' \
-                   'he!\n  ARTHUR:  Where does he live?  Old man, where ' \
-                   'does he live?\n  OLD MAN:  He knows of a cave, a ' \
-                   'cave which no man has entered.\n  ARTHUR:  And the ' \
-                   'Grail... The Grail is there?\n  OLD MAN:  Very much ' \
-                   'danger, for beyond the cave lies the Gorge\n      ' \
-                   'of Eternal Peril, which no man has ever crossed.\n  ' \
-                   'ARTHUR:  But the Grail!  Where is the Grail!?\n  ' \
-                   'OLD MAN:  Seek you the Bridge of Death.\n  ARTHUR:  ' \
-                   'The Bridge of Death, which leads to the Grail?\n  ' \
-                   'OLD MAN:  Hee hee ha ha!\n\n'
+            data = b'Scene 24\n\n \n  OLD MAN:  Ah, hee he he ha!\n  ' \
+                   b'ARTHUR:  And this enchanter of whom you speak, he ' \
+                   b'has seen the grail?\n  OLD MAN:  Ha ha he he he ' \
+                   b'he!\n  ARTHUR:  Where does he live?  Old man, where ' \
+                   b'does he live?\n  OLD MAN:  He knows of a cave, a ' \
+                   b'cave which no man has entered.\n  ARTHUR:  And the ' \
+                   b'Grail... The Grail is there?\n  OLD MAN:  Very much ' \
+                   b'danger, for beyond the cave lies the Gorge\n      ' \
+                   b'of Eternal Peril, which no man has ever crossed.\n  ' \
+                   b'ARTHUR:  But the Grail!  Where is the Grail!?\n  ' \
+                   b'OLD MAN:  Seek you the Bridge of Death.\n  ARTHUR:  ' \
+                   b'The Bridge of Death, which leads to the Grail?\n  ' \
+                   b'OLD MAN:  Hee hee ha ha!\n\n'
             if salt.utils.platform.is_windows():
-                data = 'Scene 24\r\n\r\n \r\n  OLD MAN:  Ah, hee he he ' \
-                       'ha!\r\n  ARTHUR:  And this enchanter of whom you ' \
-                       'speak, he has seen the grail?\r\n  OLD MAN:  Ha ha ' \
-                       'he he he he!\r\n  ARTHUR:  Where does he live?  Old ' \
-                       'man, where does he live?\r\n  OLD MAN:  He knows of ' \
-                       'a cave, a cave which no man has entered.\r\n  ' \
-                       'ARTHUR:  And the Grail... The Grail is there?\r\n  ' \
-                       'OLD MAN:  Very much danger, for beyond the cave lies ' \
-                       'the Gorge\r\n      of Eternal Peril, which no man ' \
-                       'has ever crossed.\r\n  ARTHUR:  But the Grail!  ' \
-                       'Where is the Grail!?\r\n  OLD MAN:  Seek you the ' \
-                       'Bridge of Death.\r\n  ARTHUR:  The Bridge of Death, ' \
-                       'which leads to the Grail?\r\n  OLD MAN:  Hee hee ha ' \
-                       'ha!\r\n\r\n'
+                data = b'Scene 24\r\n\r\n \r\n  OLD MAN:  Ah, hee he he ' \
+                       b'ha!\r\n  ARTHUR:  And this enchanter of whom you ' \
+                       b'speak, he has seen the grail?\r\n  OLD MAN:  Ha ha ' \
+                       b'he he he he!\r\n  ARTHUR:  Where does he live?  Old ' \
+                       b'man, where does he live?\r\n  OLD MAN:  He knows of ' \
+                       b'a cave, a cave which no man has entered.\r\n  ' \
+                       b'ARTHUR:  And the Grail... The Grail is there?\r\n  ' \
+                       b'OLD MAN:  Very much danger, for beyond the cave lies ' \
+                       b'the Gorge\r\n      of Eternal Peril, which no man ' \
+                       b'has ever crossed.\r\n  ARTHUR:  But the Grail!  ' \
+                       b'Where is the Grail!?\r\n  OLD MAN:  Seek you the ' \
+                       b'Bridge of Death.\r\n  ARTHUR:  The Bridge of Death, ' \
+                       b'which leads to the Grail?\r\n  OLD MAN:  Hee hee ha ' \
+                       b'ha!\r\n\r\n'
 
             self.assertDictEqual(
                 ret,

--- a/tests/unit/fileserver/test_roots.py
+++ b/tests/unit/fileserver/test_roots.py
@@ -68,9 +68,7 @@ class RootsTest(TestCase, AdaptedConfigurationTestCaseMixin, LoaderModuleMockMix
         with salt.utils.files.fopen(full_path_to_file, 'rb') as s_fp:
             with salt.utils.files.fopen(os.path.join(cls.tmp_dir, 'testfile'), 'wb') as d_fp:
                 for line in s_fp:
-                    d_fp.write(
-                        line.rstrip(b'\n').rstrip(b'\r') + os.linesep.encode('utf-8')
-                    )
+                    d_fp.write(line.rstrip(b'\n').rstrip(b'\r') + b'\n')
 
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
### What does this PR do?

Fixes a state test on windows (py3) where utf-8 data was getting
improperly decoded before fileserver sends the data to a client.

### What issues does this PR fix or reference?

https://jenkinsci.saltstack.com/job/2018.3/view/Python3/job/salt-windows-2016-py3/100/testReport/junit/integration.modules.test_state/StateModuleTest/test_state_sls_unicode_characters/

### Tests written?

Yes - Adding new test to show command output nuances on windows.

### Commits signed with GPG?

Yes