### PR TITLE
[2018.3] beacon diskusage fixes

### DIFF
--- a/salt/beacons/diskusage.py
+++ b/salt/beacons/diskusage.py
@@ -83,13 +83,19 @@ def beacon(config):
     it will override the previously defined threshold.
 
     '''
-    parts = psutil.disk_partitions(all=False)
+    parts = psutil.disk_partitions(all=True)
     ret = []
     for mounts in config:
         mount = next(iter(mounts))
 
+        # Because we're using regular expressions
+        # if our mount doesn't end with a $, insert one.
+        mount_re = mount
+        if not mount.endswith('$'):
+            mount_re = '{0}$'.format(mount)
+
         for part in parts:
-            if re.match(mount, part.mountpoint):
+            if re.match(mount_re, part.mountpoint):
                 _mount = part.mountpoint
 
                 try:
@@ -100,7 +106,7 @@ def beacon(config):
 
                 current_usage = _current_usage.percent
                 monitor_usage = mounts[mount]
-                log.info('current_usage %s', current_usage)
+                log.debug('current_usage %s', current_usage)
                 if '%' in monitor_usage:
                     monitor_usage = re.sub('%', '', monitor_usage)
                 monitor_usage = float(monitor_usage)

--- a/tests/unit/beacons/test_diskusage_beacon.py
+++ b/tests/unit/beacons/test_diskusage_beacon.py
@@ -68,10 +68,10 @@ class DiskUsageBeaconTestCase(TestCase, LoaderModuleMockMixin):
             self.assertEqual(ret, [{'diskusage': 50, 'mount': '/'}])
 
     def test_diskusage_nomatch(self):
+        disk_usage_mock = Mock(side_effect=STUB_DISK_USAGE)
         with patch('psutil.disk_partitions',
                    MagicMock(return_value=STUB_DISK_PARTITION)), \
-                patch('psutil.disk_usage',
-                      MagicMock(return_value=STUB_DISK_USAGE)):
+                patch('psutil.disk_usage', disk_usage_mock):
             config = [{'/': '70%'}]
 
             ret = diskusage.validate(config)
@@ -82,10 +82,10 @@ class DiskUsageBeaconTestCase(TestCase, LoaderModuleMockMixin):
             self.assertNotEqual(ret, [{'diskusage': 50, 'mount': '/'}])
 
     def test_diskusage_match_regex(self):
+        disk_usage_mock = Mock(side_effect=STUB_DISK_USAGE)
         with patch('psutil.disk_partitions',
                    MagicMock(return_value=STUB_DISK_PARTITION)), \
-                patch('psutil.disk_usage',
-                      MagicMock(return_value=STUB_DISK_USAGE)):
+                patch('psutil.disk_usage', disk_usage_mock):
             config = [{r'^\/': '50%'}]
 
             ret = diskusage.validate(config)


### PR DESCRIPTION
### What does this PR do?

- Updating psutil.disk_partitions to pull in all mounts not just the physical ones.  
- Check to see if the mount point from the configuration ends with a $ (regular expression end of line) if not we add one in to ensure that a simple / does not end up matching all mount points. 
- Updating tests accordingly.

### What issues does this PR fix or reference?
#48536 

### Tests written?
Yes.  Existing tests updated.

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
