### PR TITLE
Enable service if disabled before running state service tests

### DIFF
--- a/tests/integration/states/test_service.py
+++ b/tests/integration/states/test_service.py
@@ -41,8 +41,18 @@ class ServiceTest(ModuleCase, SaltReturnAssertsMixin):
             self.stopped = ''
             self.running = '[0-9]'
 
+        self.pre_srv_enabled = True if self.service_name in self.run_function('service.get_enabled') else False
+        self.post_srv_disable = False
+        if not self.pre_srv_enabled:
+            self.run_function('service.enable', name=self.service_name)
+            self.post_srv_disable = True
+
         if salt.utils.which(cmd_name) is None:
             self.skipTest('{0} is not installed'.format(cmd_name))
+
+    def tearDown(self):
+        if self.post_srv_disable:
+            self.run_function('service.disable', name=self.service_name)
 
     def check_service_status(self, exp_return):
         '''


### PR DESCRIPTION
### What does this PR do?
These tests are failing on macosx:

integration.states.test_service.ServiceTest.test_service_dead_init_delay
integration.states.test_service.ServiceTest.test_service_running

because the service is disabled. This will make sure we enable the service in the setUp and disable it if it was initially disabled in the teardown.