### PR TITLE
Fix test_managed_source_hash_indifferent_case on macosx to correct tmp path

### DIFF
--- a/tests/integration/states/test_file.py
+++ b/tests/integration/states/test_file.py
@@ -668,8 +668,8 @@ class FileTest(ModuleCase, SaltReturnAssertsMixin):
         This is a regression test for Issue #38914 and Issue #48230 (test=true use).
         '''
         name = os.path.join(TMP, 'source_hash_indifferent_case')
-        state_name = 'file_|-/tmp/salt-tests-tmpdir/source_hash_indifferent_case_|' \
-                     '-/tmp/salt-tests-tmpdir/source_hash_indifferent_case_|-managed'
+        state_name = 'file_|-{0}_|' \
+                     '-{0}_|-managed'.format(name)
         local_path = os.path.join(FILES, 'file', 'base', 'hello_world.txt')
         actual_hash = 'c98c24b677eff44860afea6f493bbaec5bb1c4cbb209c6fc2bbb47f66ff2ad31'
         uppercase_hash = actual_hash.upper()


### PR DESCRIPTION
The following test is failing on mac: `integration.states.test_file.FileTest.test_managed_source_hash_indifferent_case` with error:

```
Traceback (most recent call last):
  File "/testing/tests/integration/states/test_file.py", line 693, in test_managed_source_hash_indifferent_case
    assert ret[state_name]['result'] is True
KeyError: 'file_|-/tmp/salt-tests-tmpdir/source_hash_indifferent_case_|-/tmp/salt-tests-tmpdir/source_hash_indifferent_case_|-managed'
```

This is because mac's path is /private/tmp/....

Updating the test to use the `name` variable in the `state_name`