### PR TITLE
[develop] Fix apache tests that fail on python 3

### DIFF
--- a/salt/modules/apache.py
+++ b/salt/modules/apache.py
@@ -32,6 +32,7 @@ from salt.ext.six.moves.urllib.request import (
 import salt.utils.data
 import salt.utils.files
 import salt.utils.path
+import salt.utils.stringutils
 from salt.exceptions import SaltException
 
 log = logging.getLogger(__name__)

--- a/tests/unit/modules/test_apache.py
+++ b/tests/unit/modules/test_apache.py
@@ -20,6 +20,7 @@ from tests.support.mock import (
 # Import Salt Libs
 import salt.modules.apache as apache
 from salt.ext.six.moves.urllib.error import URLError  # pylint: disable=import-error,no-name-in-module
+from salt.utils.odict import OrderedDict
 
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
@@ -40,7 +41,7 @@ class ApacheTestCase(TestCase, LoaderModuleMockMixin):
                    MagicMock(return_value='apachectl')):
             mock = MagicMock(return_value="Server version: Apache/2.4.7")
             with patch.dict(apache.__salt__, {'cmd.run': mock}):
-                self.assertEqual(apache.version(), 'Apache/2.4.7')
+                assert apache.version() == 'Apache/2.4.7'
 
     # 'fullversion' function tests: 1
 
@@ -52,9 +53,8 @@ class ApacheTestCase(TestCase, LoaderModuleMockMixin):
                    MagicMock(return_value='apachectl')):
             mock = MagicMock(return_value="Server version: Apache/2.4.7")
             with patch.dict(apache.__salt__, {'cmd.run': mock}):
-                self.assertEqual(apache.fullversion(),
-                                 {'compiled_with': [],
-                                  'server_version': 'Apache/2.4.7'})
+                assert apache.fullversion() == {'compiled_with': [],
+                                                'server_version': 'Apache/2.4.7'}
 
     # 'modules' function tests: 1
 
@@ -68,9 +68,8 @@ class ApacheTestCase(TestCase, LoaderModuleMockMixin):
                              "unixd_module (static)\n \
                              access_compat_module (shared)")
             with patch.dict(apache.__salt__, {'cmd.run': mock}):
-                self.assertEqual(apache.modules(),
-                                 {'shared': ['access_compat_module'],
-                                  'static': ['unixd_module']})
+                assert apache.modules() == {'shared': ['access_compat_module'],
+                                            'static': ['unixd_module']}
 
     # 'servermods' function tests: 1
 
@@ -82,7 +81,7 @@ class ApacheTestCase(TestCase, LoaderModuleMockMixin):
                    MagicMock(return_value='apachectl')):
             mock = MagicMock(return_value="core.c\nmod_so.c")
             with patch.dict(apache.__salt__, {'cmd.run': mock}):
-                self.assertEqual(apache.servermods(), ['core.c', 'mod_so.c'])
+                assert apache.servermods() == ['core.c', 'mod_so.c']
 
     # 'directives' function tests: 1
 
@@ -94,7 +93,7 @@ class ApacheTestCase(TestCase, LoaderModuleMockMixin):
                    MagicMock(return_value='apachectl')):
             mock = MagicMock(return_value="Salt")
             with patch.dict(apache.__salt__, {'cmd.run': mock}):
-                self.assertEqual(apache.directives(), {'Salt': ''})
+                assert apache.directives() == {'Salt': ''}
 
     # 'vhosts' function tests: 1
 
@@ -106,7 +105,7 @@ class ApacheTestCase(TestCase, LoaderModuleMockMixin):
                    MagicMock(return_value='apachectl')):
             mock = MagicMock(return_value='')
             with patch.dict(apache.__salt__, {'cmd.run': mock}):
-                self.assertEqual(apache.vhosts(), {})
+                assert apache.vhosts() == {}
 
     # 'signal' function tests: 2
 
@@ -118,7 +117,7 @@ class ApacheTestCase(TestCase, LoaderModuleMockMixin):
                    MagicMock(return_value='apachectl')):
             mock = MagicMock(return_value='')
             with patch.dict(apache.__salt__, {'cmd.run': mock}):
-                self.assertEqual(apache.signal(None), None)
+                assert apache.signal(None) is None
 
     def test_signal_args(self):
         '''
@@ -131,25 +130,25 @@ class ApacheTestCase(TestCase, LoaderModuleMockMixin):
                                            'stderr': '',
                                            'stdout': ''})
             with patch.dict(apache.__salt__, {'cmd.run_all': mock}):
-                self.assertEqual(apache.signal('start'), ret)
+                assert apache.signal('start') == ret
 
             mock = MagicMock(return_value={'retcode': 1,
                                            'stderr': 'Syntax OK',
                                            'stdout': ''})
             with patch.dict(apache.__salt__, {'cmd.run_all': mock}):
-                self.assertEqual(apache.signal('start'), 'Syntax OK')
+                assert apache.signal('start') == 'Syntax OK'
 
             mock = MagicMock(return_value={'retcode': 0,
                                            'stderr': 'Syntax OK',
                                            'stdout': ''})
             with patch.dict(apache.__salt__, {'cmd.run_all': mock}):
-                self.assertEqual(apache.signal('start'), 'Syntax OK')
+                assert apache.signal('start') == 'Syntax OK'
 
             mock = MagicMock(return_value={'retcode': 1,
                                            'stderr': '',
                                            'stdout': 'Salt'})
             with patch.dict(apache.__salt__, {'cmd.run_all': mock}):
-                self.assertEqual(apache.signal('start'), 'Salt')
+                assert apache.signal('start') == 'Salt'
 
     # 'useradd' function tests: 1
 
@@ -159,7 +158,7 @@ class ApacheTestCase(TestCase, LoaderModuleMockMixin):
         '''
         mock = MagicMock(return_value=True)
         with patch.dict(apache.__salt__, {'webutil.useradd': mock}):
-            self.assertTrue(apache.useradd('htpasswd', 'salt', 'badpassword'))
+            assert apache.useradd('htpasswd', 'salt', 'badpassword') is True
 
     # 'userdel' function tests: 1
 
@@ -169,7 +168,7 @@ class ApacheTestCase(TestCase, LoaderModuleMockMixin):
         '''
         mock = MagicMock(return_value=True)
         with patch.dict(apache.__salt__, {'webutil.userdel': mock}):
-            self.assertTrue(apache.userdel('htpasswd', 'salt'))
+            assert apache.userdel('htpasswd', 'salt') is True
 
     # 'server_status' function tests: 2
 
@@ -180,7 +179,7 @@ class ApacheTestCase(TestCase, LoaderModuleMockMixin):
         with patch('salt.modules.apache.server_status', MagicMock(return_value={})):
             mock = MagicMock(return_value='')
             with patch.dict(apache.__salt__, {'config.get': mock}):
-                self.assertEqual(apache.server_status(), {})
+                assert apache.server_status() == {}
 
     def test_server_status_error(self):
         '''
@@ -190,7 +189,7 @@ class ApacheTestCase(TestCase, LoaderModuleMockMixin):
         with patch.object(apache, '_urlopen', mock):
             mock = MagicMock(return_value='')
             with patch.dict(apache.__salt__, {'config.get': mock}):
-                self.assertEqual(apache.server_status(), 'error')
+                assert apache.server_status() == 'error'
 
     # 'config' function tests: 1
 
@@ -201,8 +200,7 @@ class ApacheTestCase(TestCase, LoaderModuleMockMixin):
         with patch('salt.modules.apache._parse_config',
                    MagicMock(return_value='Listen 22')):
             with patch('salt.utils.files.fopen', mock_open()):
-                self.assertEqual(apache.config('/ports.conf',
-                                               [{'Listen': '22'}]), 'Listen 22')
+                assert apache.config('/ports.conf', [{'Listen': '22'}]) == 'Listen 22'
 
     # '_parse_config' function tests: 2
 
@@ -223,13 +221,15 @@ class ApacheTestCase(TestCase, LoaderModuleMockMixin):
                     - 192.168.100.0/24
 
         '''
-        datain = {'this': '*:80',
-                  'ServerName': 'website.com',
-                  'ServerAlias': ['www', 'dev'],
-                  'Directory': {'this': '/var/www/vhosts/website.com',
-                                'Order': 'Deny,Allow',
-                                'Allow from': ['127.0.0.1', '192.168.100.0/24']}
-                  }
+        data_in = OrderedDict([
+            ('Directory', OrderedDict([
+                ('this', '/var/www/vhosts/website.com'),
+                ('Order', 'Deny,Allow'),
+                ('Allow from', ['127.0.0.1', '192.168.100.0/24'])])),
+            ('this', '*:80'),
+            ('ServerName', 'website.com'),
+            ('ServerAlias', ['www', 'dev'])
+        ])
         dataout = '<VirtualHost *:80>\n' \
                   '<Directory /var/www/vhosts/website.com>\n' \
                   'Order Deny,Allow\n' \
@@ -241,8 +241,8 @@ class ApacheTestCase(TestCase, LoaderModuleMockMixin):
                   'ServerAlias dev\n\n' \
                   '</VirtualHost>\n'
         # pylint: disable=protected-access
-        parse = apache._parse_config(datain, 'VirtualHost')
-        self.assertEqual(parse, dataout)
+        parse = apache._parse_config(data_in, 'VirtualHost')
+        assert parse == dataout
 
     def test__parse_config_list(self):
         '''
@@ -270,27 +270,21 @@ class ApacheTestCase(TestCase, LoaderModuleMockMixin):
                     this: some condition
                     do: something
         '''
-        datain = [{'this': '*:80'},
-                  {'ServerName': 'website.com'},
-                  {'ServerAlias': ['www', 'dev']},
-                  {'Directory': {'this': '/var/www/vhosts/website.com',
-                                 'Order': 'Deny,Allow',
-                                 'Allow from': ['127.0.0.1', '192.168.100.0/24']}},
-                  {'Directory': [{'this': '/var/www/vhosts/website.com/private'},
-                                 {'Order': 'Deny,Allow'},
-                                 {'Allow from': ['127.0.0.1', '192.168.100.0/24']},
-                                 {'If': {'this': 'some condition', 'do': 'something'}}
-                                 ]}
-                  ]
+        data_in = [OrderedDict([
+            ('ServerName', 'website.com'),
+            ('ServerAlias', ['www', 'dev']),
+            ('Directory', [OrderedDict([
+                ('this', '/var/www/vhosts/website.com/private'),
+                ('Order', 'Deny,Allow'),
+                ('Allow from', ['127.0.0.1', '192.168.100.0/24']),
+                ('If', {'this': 'some condition', 'do': 'something'})
+            ])]),
+            ('this', '*:80')
+        ])]
         dataout = '<VirtualHost *:80>\n' \
                   'ServerName website.com\n' \
                   'ServerAlias www\n' \
                   'ServerAlias dev\n\n' \
-                  '<Directory /var/www/vhosts/website.com>\n' \
-                  'Order Deny,Allow\n' \
-                  'Allow from 127.0.0.1\n' \
-                  'Allow from 192.168.100.0/24\n\n' \
-                  '</Directory>\n\n' \
                   '<Directory /var/www/vhosts/website.com/private>\n' \
                   'Order Deny,Allow\n' \
                   'Allow from 127.0.0.1\n' \
@@ -301,5 +295,5 @@ class ApacheTestCase(TestCase, LoaderModuleMockMixin):
                   '</Directory>\n\n' \
                   '</VirtualHost>\n'
         # pylint: disable=protected-access
-        parse = apache._parse_config(datain, 'VirtualHost')
-        self.assertEqual(parse, dataout)
+        parse = apache._parse_config(data_in, 'VirtualHost')
+        assert parse == dataout


### PR DESCRIPTION
Also update the test file to use pytest syntax instead of unittest

### What does this PR do?
This change ensures that the `test__parse_config_dict` and `test__parse_config_list` tests pass every time when running with Python 3. These tests are flaky with python 3, but this update ensures they will pass/fail consistently.

This change also updates the test file to use pytest notation instead of unittest notation.

I also added a missing import to the apache module file.

### What issues does this PR fix or reference?
Fixes https://github.com/saltstack/salt-jenkins/issues/1039

### Tests written?

Yes - fixes flaky tests

### Commits signed with GPG?

Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
