### PR TITLE
Added check to ignore "-t" on unsupported versions of "zfs get"

### DIFF
--- a/salt/modules/zfs.py
+++ b/salt/modules/zfs.py
@@ -1214,7 +1214,11 @@ def get(*dataset, **kwargs):
     fields.insert(1, 'property')
     opts['-o'] = ",".join(fields)
     if kwargs.get('type', False):
-        opts['-t'] = kwargs.get('type')
+        zfs_cmd = salt.utils.path.which('zfs')
+        res = __salt__['cmd.run_stderr']('{0} get -t'.format(zfs_cmd),
+                                         output_loglevel='quiet')
+        if 'invalid option' not in res:
+            opts['-t'] = kwargs.get('type')
     if kwargs.get('source', False):
         opts['-s'] = kwargs.get('source')
 


### PR DESCRIPTION
### What does this PR do?
Allows the zfs.get function to ignore the "type" argument on versions of Solaris that do not have the "-t" option for the "zfs get" subcommand.

### What issues does this PR fix or reference?
None that I know of

### Previous Behavior
On recent versions of Oracle Solaris (within the last year or so), the zfs.get function will fail because at some point in that time Oracle removed the "-t" option from "zfs get".

### New Behavior
Causes the module to test for validity of "-t" and ignore the zfs.get function's "type" argument if "-t" is not supported, otherwise resume previous behavior.

### Tests written?
No

### Commits signed with GPG?
No
