### PR TITLE
test_vcenter_connection should raise system exception when it fails

### DIFF
--- a/salt/cloud/clouds/vmware.py
+++ b/salt/cloud/clouds/vmware.py
@@ -1470,7 +1470,7 @@ def test_vcenter_connection(kwargs=None, call=None):
         # Get the service instance object
         _get_si()
     except Exception as exc:
-        return 'failed to connect: {0}'.format(exc)
+        raise SaltCloudSystemExit('failed to connect: {0}'.format(exc))
 
     return 'connection successful'
 


### PR DESCRIPTION
### What does this PR do?
This PR allows 

### What issues does this PR fix or reference?

### Previous Behavior
The cloud.vmware.test_vscenter_connection function returned a exit 0 even when it failed to connect to vsphere

### New Behavior
The cloud.vmware.test_vscener_connection function now raises the SaltCloudSystemExit exception on failure. This allows for the shell to receive the correct "failed" exit code.

### Tests written?

No

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
