### PR TITLE
Skip test when syslog not available

### DIFF
--- a/tests/unit/returners/test_syslog_return.py
+++ b/tests/unit/returners/test_syslog_return.py
@@ -27,6 +27,7 @@ class SyslogReturnerTestCase(TestCase, LoaderModuleMockMixin):
     def setup_loader_modules(self):
         return {syslog: {}}
 
+    @skipIf(not syslog.HAS_SYSLOG, 'Skip when syslog not installed')
     def test_syslog_returner_unicode(self):
         '''
         test syslog returner with unicode


### PR DESCRIPTION
### What does this PR do?

Skip test when syslog not available (Python windows py2 does not have a syslog module)

https://jenkinsci.saltstack.com/job/2018.3/job/salt-windows-2016-py2/108/testReport/junit/unit.returners.test_syslog_return/SyslogReturnerTestCase/test_syslog_returner_unicode/

### Tests written?

No - Fixing test

### Commits signed with GPG?

Yes