### PR TITLE
[2018.3] Fix when state file is integers

### DIFF
--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -1301,6 +1301,10 @@ def sls(mods, test=None, exclude=None, queue=False, sync_mods=None, **kwargs):
                     high_ = serial.load(fp_)
                     return st_.state.call_high(high_, orchestration_jid)
 
+    # If the state file is an integer, convert to a string then to unicode
+    if isinstance(mods, six.integer_types):
+        mods = salt.utils.stringutils.to_unicode(str(mods))  # future lint: disable=blacklisted-function
+
     if isinstance(mods, six.string_types):
         mods = mods.split(',')
 

--- a/tests/integration/files/file/base/12345.sls
+++ b/tests/integration/files/file/base/12345.sls
@@ -1,0 +1,2 @@
+always-passes:
+  test.succeed_without_changes

--- a/tests/integration/modules/test_state.py
+++ b/tests/integration/modules/test_state.py
@@ -1957,3 +1957,19 @@ class StateModuleTest(ModuleCase, SaltReturnAssertsMixin):
         state_file = os.path.join(TMP, 'testfile')
         if os.path.isfile(state_file):
             os.remove(state_file)
+
+    def test_state_sls_integer_name(self):
+        '''
+        This tests the case where the state file is named
+        only with integers
+        '''
+        state_run = self.run_function(
+            'state.sls',
+            mods='12345'
+        )
+
+        state_id = 'test_|-always-passes_|-always-passes_|-succeed_without_changes'
+        self.assertIn(state_id, state_run)
+        self.assertEqual(state_run[state_id]['comment'],
+                         'Success!')
+        self.assertTrue(state_run[state_id]['result'])


### PR DESCRIPTION
### What does this PR do?
Fixing a case where the state module would fail if the state file being passed was all integers.  Added a new tests for this edge case.

### What issues does this PR fix or reference?
N/A

### Tests written?
Yes

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
