### PR TITLE
send proxy/ca_cert parameters as strings (not unicode) to tornado httpclient 

### DIFF
--- a/salt/utils/http.py
+++ b/salt/utils/http.py
@@ -488,7 +488,8 @@ def query(url,
             data = _urlencode(data)
 
         if verify_ssl:
-            req_kwargs['ca_certs'] = ca_bundle
+            # tornado requires a str, cannot be unicode str in py2
+            req_kwargs['ca_certs'] = salt.utils.stringutils.to_str(ca_bundle)
 
         max_body = opts.get('http_max_body', salt.config.DEFAULT_MINION_OPTS['http_max_body'])
         timeout = opts.get('http_request_timeout', salt.config.DEFAULT_MINION_OPTS['http_request_timeout'])
@@ -496,9 +497,18 @@ def query(url,
         client_argspec = None
 
         proxy_host = opts.get('proxy_host', None)
+        if proxy_host:
+            # tornado requires a str for proxy_host, cannot be a unicode str in py2
+            proxy_host = salt.utils.stringutils.to_str(proxy_host)
         proxy_port = opts.get('proxy_port', None)
         proxy_username = opts.get('proxy_username', None)
+        if proxy_username:
+            # tornado requires a str, cannot be unicode str in py2
+            proxy_username = salt.utils.stringutils.to_str(proxy_username)
         proxy_password = opts.get('proxy_password', None)
+        if proxy_password:
+            # tornado requires a str, cannot be unicode str in py2
+            proxy_password = salt.utils.stringutils.to_str(proxy_password)
 
         # We want to use curl_http if we have a proxy defined
         if proxy_host and proxy_port:


### PR DESCRIPTION
### What does this PR do?
send proxy_user, proxy_password, proxy_host, and ca_bundle through salt.utils.stringutils.to_str()

tornado in py2 requires standard str not unicode strings

### What issues does this PR fix or reference?
fixes #46896

### Previous Behavior
proxy_host, proxy_username, proxy_password, and ca_bundle were passed as unicode strings which would cause an "TypeError: invalid arguments to setopt" when attempting to use the tornado backend to access http/https through a proxy 

### New Behavior
proxy_host, proxy_username, proxy_password, and ca_bundle are passed through the salt.utils.stringutils.to_str to convert them to a string object for PY2 before being sent to the tornado httpclient

### Tests written?
No

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
