### PR TITLE
Update carbon_return.py

### DIFF
--- a/salt/returners/carbon_return.py
+++ b/salt/returners/carbon_return.py
@@ -200,7 +200,7 @@ def _walk(path, value, metrics, timestamp, skip):
         to a float. Defaults to `False`.
     '''
     log.trace(
-        'Carbon return walking path: %s, value: %s, metrics: %s, ',
+        'Carbon return walking path: %s, value: %s, metrics: %s, '
         'timestamp: %s', path, value, metrics, timestamp
     )
     if isinstance(value, collections.Mapping):


### PR DESCRIPTION
fix TypeError: not all arguments converted during string formatting
caused by extra comma accidentally being added to log statement in unicode literals update

### What does this PR do?
fixes saltstack#47999
### What issues does this PR fix or reference?
saltstack#47999

### Tests written?

No, i character removed

### Commits signed with GPG?
No
