### PR TITLE
only do reverse dns lookup on ips for salt-ssh

### DIFF
--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -350,7 +350,9 @@ class SSH(object):
             return
 
         hostname = self.opts['tgt'].split('@')[-1]
-        needs_expansion = '*' not in hostname and salt.utils.network.is_reachable_host(hostname)
+        needs_expansion = '*' not in hostname and \
+                          salt.utils.network.is_reachable_host(hostname) and \
+                          salt.utils.network.is_ip(hostname)
         if needs_expansion:
             hostname = salt.utils.network.ip_to_host(hostname)
             if hostname is None:


### PR DESCRIPTION
### What does this PR do?
Salt-ssh tries to do a reverse dns lookup on domain names it cannot resolve, which it should not.  see #48676


### What issues does this PR fix or reference?
Fixes #48676

### Tests written?

No

### Commits signed with GPG?

Yes