### PR TITLE
Added ability to create replica 3 arbiter 1 gluster volumes

### DIFF
--- a/salt/modules/glusterfs.py
+++ b/salt/modules/glusterfs.py
@@ -217,7 +217,7 @@ def peer(name):
     return _gluster(cmd)
 
 
-def create_volume(name, bricks, stripe=False, replica=False, device_vg=False, 
+def create_volume(name, bricks, stripe=False, replica=False, device_vg=False,
                   transport='tcp', start=False, force=False, arbiter=False):
     '''
     Create a glusterfs volume

--- a/salt/modules/glusterfs.py
+++ b/salt/modules/glusterfs.py
@@ -217,8 +217,8 @@ def peer(name):
     return _gluster(cmd)
 
 
-def create_volume(name, bricks, stripe=False, replica=False, arbiter=False,
-        device_vg=False, transport='tcp', start=False, force=False):
+def create_volume(name, bricks, stripe=False, replica=False, device_vg=False, 
+                  transport='tcp', start=False, force=False, arbiter=False):
     '''
     Create a glusterfs volume
 
@@ -238,6 +238,7 @@ def create_volume(name, bricks, stripe=False, replica=False, arbiter=False,
         Replica count, the number of bricks should be a multiple of the \
         replica count for a distributed replicated volume
 
+    .. versionadded:: Fluorine
     arbiter
         If true, specifies volume should use arbiter brick(s). \
         Valid configuration limited to "replica 3 arbiter 1" per \

--- a/salt/modules/glusterfs.py
+++ b/salt/modules/glusterfs.py
@@ -288,7 +288,7 @@ def create_volume(name, bricks, stripe=False, replica=False, arbiter=False,
                 'Brick syntax is <peer>:<path> got {0}'.format(brick))
 
     # Validate arbiter config
-    if arbiter and not replica == 3:
+    if arbiter and replica != 3:
         raise SaltInvocationError('Arbiter configuration only valid ' +
                                   'in replica 3 volume')
 

--- a/salt/modules/glusterfs.py
+++ b/salt/modules/glusterfs.py
@@ -238,12 +238,13 @@ def create_volume(name, bricks, stripe=False, replica=False, device_vg=False,
         Replica count, the number of bricks should be a multiple of the \
         replica count for a distributed replicated volume
 
-    .. versionadded:: Fluorine
     arbiter
         If true, specifies volume should use arbiter brick(s). \
         Valid configuration limited to "replica 3 arbiter 1" per \
         Gluster documentation. Every third brick in the brick list \
         is used as an arbiter brick.
+
+        .. versionadded:: Fluorine
 
     device_vg
         If true, specifies volume should use block backend instead of regular \

--- a/salt/states/glusterfs.py
+++ b/salt/states/glusterfs.py
@@ -108,7 +108,7 @@ def peered(name):
     return ret
 
 
-def volume_present(name, bricks, stripe=False, replica=False, device_vg=False, 
+def volume_present(name, bricks, stripe=False, replica=False, device_vg=False,
                    transport='tcp', start=False, force=False, arbiter=False):
     '''
     Ensure that the volume exists

--- a/salt/states/glusterfs.py
+++ b/salt/states/glusterfs.py
@@ -108,8 +108,8 @@ def peered(name):
     return ret
 
 
-def volume_present(name, bricks, stripe=False, replica=False, arbiter=False,
-                   device_vg=False, transport='tcp', start=False, force=False):
+def volume_present(name, bricks, stripe=False, replica=False, device_vg=False, 
+                   transport='tcp', start=False, force=False, arbiter=False):
     '''
     Ensure that the volume exists
 
@@ -122,6 +122,7 @@ def volume_present(name, bricks, stripe=False, replica=False, arbiter=False,
     replica
         replica count for volume
 
+    .. versionadded:: Fluorine
     arbiter
         use every third brick as arbiter (metadata only)
 
@@ -155,6 +156,7 @@ def volume_present(name, bricks, stripe=False, replica=False, arbiter=False,
             - replica: 3
             - arbiter: True
             - start: True
+
     '''
     ret = {'name': name,
            'changes': {},
@@ -177,8 +179,8 @@ def volume_present(name, bricks, stripe=False, replica=False, arbiter=False,
 
         vol_created = __salt__['glusterfs.create_volume'](
             name, bricks, stripe,
-            replica, arbiter, device_vg,
-            transport, start, force)
+            replica, device_vg,
+            transport, start, force, arbiter)
 
         if not vol_created:
             ret['comment'] = 'Creation of volume {0} failed'.format(name)

--- a/salt/states/glusterfs.py
+++ b/salt/states/glusterfs.py
@@ -122,9 +122,10 @@ def volume_present(name, bricks, stripe=False, replica=False, device_vg=False,
     replica
         replica count for volume
 
-    .. versionadded:: Fluorine
     arbiter
         use every third brick as arbiter (metadata only)
+
+        .. versionadded:: Fluorine
 
     start
         ensure that the volume is also started

--- a/salt/states/glusterfs.py
+++ b/salt/states/glusterfs.py
@@ -108,8 +108,8 @@ def peered(name):
     return ret
 
 
-def volume_present(name, bricks, stripe=False, replica=False, device_vg=False,
-                   transport='tcp', start=False, force=False):
+def volume_present(name, bricks, stripe=False, replica=False, arbiter=False,
+                   device_vg=False, transport='tcp', start=False, force=False):
     '''
     Ensure that the volume exists
 
@@ -118,6 +118,12 @@ def volume_present(name, bricks, stripe=False, replica=False, device_vg=False,
 
     bricks
         list of brick paths
+
+    replica
+        replica count for volume
+
+    arbiter
+        use every third brick as arbiter (metadata only)
 
     start
         ensure that the volume is also started
@@ -137,6 +143,17 @@ def volume_present(name, bricks, stripe=False, replica=False, device_vg=False,
               - host1:/srv/gluster/drive2
               - host2:/srv/gluster/drive3
             - replica: 2
+            - start: True
+
+        Replicated Volume with arbiter brick:
+          glusterfs.volume_present:
+            - name: volume3
+            - bricks:
+              - host1:/srv/gluster/drive2
+              - host2:/srv/gluster/drive3
+              - host3:/srv/gluster/drive4
+            - replica: 3
+            - arbiter: True
             - start: True
     '''
     ret = {'name': name,
@@ -160,7 +177,7 @@ def volume_present(name, bricks, stripe=False, replica=False, device_vg=False,
 
         vol_created = __salt__['glusterfs.create_volume'](
             name, bricks, stripe,
-            replica, device_vg,
+            replica, arbiter, device_vg,
             transport, start, force)
 
         if not vol_created:


### PR DESCRIPTION
### What does this PR do?
Adds the ability to create replica 3 arbiter 1 gluster volumes

### What issues does this PR fix or reference?
 #42955

### Previous Behavior
Arbiter configuration was not exposed in glusterfs volume creation

### New Behavior
Volumes can be created with arbiter (metadata-only replication) bricks

### Tests written?

No

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.


```
jdito@sum-dev-03:/data/salt/salt/gluster$ cat cluster-startup.sls 
peer-cluster:
  glusterfs.peered:
    - names:
      - sum-glfiler-01.storage.dy.gl
      - sum-glfiler-02.storage.dy.gl
      - sum-glfiler-03.storage.dy.gl

{% for volume in ['users','public'] %}
{{ volume }}:
  glusterfs.volume_present:
    - bricks:
      - sum-glfiler-01.storage.dy.gl:/gluster/{{ volume }}/brick
      - sum-glfiler-02.storage.dy.gl:/gluster/{{ volume }}/brick
      - sum-glfiler-03.storage.dy.gl:/gluster/{{ volume }}/brick
    - replica: 3
    - arbiter: True
    - start: True
    - force: True

{% endfor %}
```
```
[root@sum-glfiler-03 ~]# salt-call state.apply gluster.cluster-startup
local:
----------
          ID: peer-cluster
    Function: glusterfs.peered
        Name: sum-glfiler-01.storage.dy.gl
      Result: True
     Comment: Host sum-glfiler-01.storage.dy.gl already peered
     Started: 15:31:24.035879
    Duration: 64.799 ms
     Changes:   
----------
          ID: peer-cluster
    Function: glusterfs.peered
        Name: sum-glfiler-02.storage.dy.gl
      Result: True
     Comment: Host sum-glfiler-02.storage.dy.gl already peered
     Started: 15:31:24.101094
    Duration: 58.168 ms
     Changes:   
----------
          ID: peer-cluster
    Function: glusterfs.peered
        Name: sum-glfiler-03.storage.dy.gl
      Result: True
     Comment: Peering with localhost is not needed
     Started: 15:31:24.159656
    Duration: 33.415 ms
     Changes:   
----------
          ID: users
    Function: glusterfs.volume_present
      Result: True
     Comment: Volume users is created and is started
     Started: 15:31:24.193509
    Duration: 4356.89 ms
     Changes:   
              ----------
              new:
                  - users
              old:
----------
          ID: public
    Function: glusterfs.volume_present
      Result: True
     Comment: Volume public is created and is started
     Started: 15:31:28.550847
    Duration: 3752.007 ms
     Changes:   
              ----------
              new:
                  - public
                  - users
              old:
                  - users

Summary for local
------------
Succeeded: 5 (changed=2)
Failed:    0
------------
Total states run:     5
Total run time:   8.265 s
[root@sum-glfiler-03 ~]# gluster volume info
 
Volume Name: public
Type: Replicate
Volume ID: 395e9b53-434f-4a07-9f55-5500ba7499ff
Status: Started
Snapshot Count: 0
Number of Bricks: 1 x (2 + 1) = 3
Transport-type: tcp
Bricks:
Brick1: sum-glfiler-01.storage.dy.gl:/gluster/public/brick
Brick2: sum-glfiler-02.storage.dy.gl:/gluster/public/brick
Brick3: sum-glfiler-03.storage.dy.gl:/gluster/public/brick (arbiter)
Options Reconfigured:
transport.address-family: inet
nfs.disable: on
performance.client-io-threads: off
 
Volume Name: users
Type: Replicate
Volume ID: 787af828-f09b-47fb-b7b9-88486899438d
Status: Started
Snapshot Count: 0
Number of Bricks: 1 x (2 + 1) = 3
Transport-type: tcp
Bricks:
Brick1: sum-glfiler-01.storage.dy.gl:/gluster/users/brick
Brick2: sum-glfiler-02.storage.dy.gl:/gluster/users/brick
Brick3: sum-glfiler-03.storage.dy.gl:/gluster/users/brick (arbiter)
Options Reconfigured:
transport.address-family: inet
nfs.disable: on
performance.client-io-threads: off
```

