### PR TITLE
Check dmidecoder executable on each "smbios" call to avoid race condition

### DIFF
--- a/salt/modules/smbios.py
+++ b/salt/modules/smbios.py
@@ -32,11 +32,15 @@ log = logging.getLogger(__name__)
 
 DMIDECODER = salt.utils.path.which_bin(['dmidecode', 'smbios'])
 
+def _refresh_dmidecoder():
+    global DMIDECODER
+    DMIDECODER = salt.utils.path.which_bin(['dmidecode', 'smbios'])
 
 def __virtual__():
     '''
     Only work when dmidecode is installed.
     '''
+    _refresh_dmidecoder()
     if DMIDECODER is None:
         log.debug('SMBIOS: neither dmidecode nor smbios found!')
         return (False, 'The smbios execution module failed to load: neither dmidecode nor smbios in the path.')
@@ -328,6 +332,7 @@ def _dmidecoder(args=None):
     '''
     Call DMIdecode
     '''
+    _refresh_dmidecoder()
     if DMIDECODER is None:
         raise CommandExecutionError('SMBIOS: neither dmidecode nor smbios found!')
 

--- a/salt/modules/smbios.py
+++ b/salt/modules/smbios.py
@@ -19,6 +19,7 @@ import re
 
 # Import salt libs
 import salt.utils.path
+from salt.exceptions import CommandExecutionError
 
 # Solve the Chicken and egg problem where grains need to run before any
 # of the modules are loaded and are generally available for any usage.
@@ -327,6 +328,9 @@ def _dmidecoder(args=None):
     '''
     Call DMIdecode
     '''
+    if DMIDECODER is None:
+        raise CommandExecutionError('SMBIOS: neither dmidecode nor smbios found!')
+
     if args is None:
         return salt.modules.cmdmod._run_quiet(DMIDECODER)
     else:

--- a/salt/modules/smbios.py
+++ b/salt/modules/smbios.py
@@ -32,9 +32,11 @@ log = logging.getLogger(__name__)
 
 DMIDECODER = salt.utils.path.which_bin(['dmidecode', 'smbios'])
 
+
 def _refresh_dmidecoder():
     global DMIDECODER
     DMIDECODER = salt.utils.path.which_bin(['dmidecode', 'smbios'])
+
 
 def __virtual__():
     '''


### PR DESCRIPTION
### What does this PR do?
This PR fixes a race condition happening during core grains generation in case `dmidecode` or `smbios` are installed/removed during `salt-minion` execution.

As described on #35505, `smbios.DMIDECODER` is fixed to the `dmidecode` or `smbios` executables, and this is happening only **once while the module is loaded**. Then there are some calls to `smbios.get` performed while calculating the "core" grains which produces a race condition in case the results of `salt.utils.path.which_bin(['dmidecode', 'smbios'])` changes during execution time.

### What issues does this PR fix or reference?
Hopefully fixes https://github.com/saltstack/salt/issues/35505

### Previous Behavior
The situation appears in case neither `dmidecode` nor `smbios` are installed at the time of `salt-minion` is started, therefore `smbios.DMIDECODER` is set to `None`. Then, at some point, either `dmidecode` or `smbios` are installed on the minion and eventually the grains will be recalculated.
At this particular moment, when the "core" grains are being recalculated, https://github.com/saltstack/salt/blob/2018.3/salt/grains/core.py#L2310 is checking again if executables are now available, and if so, it would produce a call to `smbios.get` which will crash since `smbios.DMIDECODER` is set to `None`:

```
ERROR: Unable to run command '['None', '-s', 'bios-version']' with the context '{'timeout': None, 'with_communicate': True, 'shell': False, 'bg': False, 'stderr': -2, 'env': {'LC_NUMERIC': 'C', 'NOTIFY_SOCKET': '/run/systemd/notify', 'LC_MESSAGES': 'C', 'LC_IDENTIFICATION': 'C', 'LC_MONETARY': 'C', 'LC_COLLATE': 'C', 'LC_CTYPE': 'C', 'LC_ADDRESS': 'C', 'LC_MEASUREMENT': 'C', 'LC_TELEPHONE': 'C', 'LC_PAPER': 'C', 'LC_NAME': 'C', 'PATH': '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin', 'LC_TIME': 'C'}, 'stdout': -1, 'close_fds': True, 'stdin': None, 'cwd': '/root'}', reason: [Errno 2] No such file or directory
```

### New Behavior
Now `smbios.DMIDECODER` is refreshed on each `smbios` module call to prevent the race condition with the "core" grains. Besides of that, this PR introduces also a comprehensive error message in case of crashing:

```
2018-07-26 17:04:40,063 [salt.modules.smbios:337 ][ERROR   ][16331] SMBIOS: neither dmidecode nor smbios found!
```

### Tests written?

No

### Commits signed with GPG?

Yes