### PR TITLE
Only run lint checks against changed files

### DIFF
--- a/.ci/lint
+++ b/.ci/lint
@@ -29,13 +29,13 @@ pipeline {
             parallel {
                 stage('salt linting') {
                     steps {
-                        sh 'eval "$(pyenv init -)"; tox -e pylint-salt | tee pylint-report.xml'
+                        sh 'eval "$(pyenv init -)"; tox -e pylint-salt $(find salt/ -name "*.py" -exec git diff --name-only "origin/$CHANGE_TARGET" "origin/$BRANCH_NAME" setup.py {} +) | tee pylint-report.xml'
                         archiveArtifacts artifacts: 'pylint-report.xml'
                     }
                 }
                 stage('test linting') {
                     steps {
-                        sh 'eval "$(pyenv init -)"; tox -e pylint-tests | tee pylint-report-tests.xml'
+                        sh 'eval "$(pyenv init -)"; tox -e pylint-tests $(find tests/ -name "*.py" -exec git diff --name-only "origin/$CHANGE_TARGET" "origin/$BRANCH_NAME" {} +) | tee pylint-report-tests.xml'
                         archiveArtifacts artifacts: 'pylint-report-tests.xml'
                     }
                 }

--- a/.ci/lint
+++ b/.ci/lint
@@ -49,7 +49,9 @@ pipeline {
                     parserName: 'PyLint',
                     pattern: 'pylint-report*.xml'
                 ]],
-                failedTotalAll: '1',
+                failedTotalAll: '0',
+                useDeltaValues: false,
+                canRunOnFailed: true,
                 usePreviousBuildAsReference: true
             ])
             cleanWs()

--- a/tests/integration/utils/testprogram.py
+++ b/tests/integration/utils/testprogram.py
@@ -598,7 +598,7 @@ class TestSaltProgram(six.with_metaclass(TestSaltProgramMeta, TestProgram)):
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         try:
             connect = sock.bind(('localhost', port))
-        except:
+        except OSError:
             # these ports are already in use, use different ones
             pub_port = 4606
             ret_port = 4607


### PR DESCRIPTION
### What does this PR do?

Changes the behaviour of `pr-lint` to only check the files that git says changed between the merge target and the PR branch.

### What issues does this PR fix or reference?

Re-does #48610 

### Previous Behavior
Runs pylint on every file in the repo

### New Behavior
Only runs on changed files using find and git diff

### Tests written?

These are the tests.

### Commits signed with GPG?

Yes

@gtmanfred @dubb-b 