### PR TITLE
Add timzeone windows integration tests and fix get_zone

### DIFF
--- a/salt/modules/win_timezone.py
+++ b/salt/modules/win_timezone.py
@@ -10,7 +10,7 @@ import logging
 import re
 
 try:
-    import tzlocal  # pylint: disable=unused-import
+    import tzlocal
     HAS_TZLOCAL = True
 except ImportError:
     HAS_TZLOCAL = False

--- a/salt/modules/win_timezone.py
+++ b/salt/modules/win_timezone.py
@@ -10,7 +10,7 @@ import logging
 import re
 
 try:
-    import tzlocal  # pylint: disable=import-error
+    import tzlocal  # pylint: disable=unused-import
     HAS_TZLOCAL = True
 except ImportError:
     HAS_TZLOCAL = False

--- a/salt/modules/win_timezone.py
+++ b/salt/modules/win_timezone.py
@@ -10,7 +10,7 @@ import logging
 import re
 
 try:
-    import tzlocal
+    import tzlocal  # pylint: disable=import-error
     HAS_TZLOCAL = True
 except ImportError:
     HAS_TZLOCAL = False

--- a/salt/modules/win_timezone.py
+++ b/salt/modules/win_timezone.py
@@ -9,6 +9,12 @@ import salt.utils
 import logging
 import re
 
+try:
+    import tzlocal
+    HAS_TZLOCAL = True
+except ImportError:
+    HAS_TZLOCAL = False
+
 log = logging.getLogger(__name__)
 
 # Maybe put in a different file ... ? %-0
@@ -473,6 +479,10 @@ def get_zone():
 
         salt '*' timezone.get_zone
     '''
+    if HAS_TZLOCAL:
+        return tzlocal.get_localzone().zone
+
+    log.warning('tzutil not installed. get_zone might be inaccurate')
     winzone = __salt__['cmd.run'](['tzutil', '/g'], python_shell=False)
     for key in LINTOWIN:
         if LINTOWIN[key] == winzone:

--- a/tests/integration/modules/test_timezone.py
+++ b/tests/integration/modules/test_timezone.py
@@ -9,7 +9,7 @@ Linux and Solaris are supported
 from __future__ import absolute_import
 
 try:
-    import tzlocal
+    import tzlocal  # pylint: disable=unused-import
     HAS_TZLOCAL = True
 except ImportError:
     HAS_TZLOCAL = False

--- a/tests/integration/modules/test_timezone.py
+++ b/tests/integration/modules/test_timezone.py
@@ -8,8 +8,19 @@ Linux and Solaris are supported
 # Import python libs
 from __future__ import absolute_import
 
+try:
+    import tzlocal
+    HAS_TZLOCAL = True
+except ImportError:
+    HAS_TZLOCAL = False
+
 # Import Salt Testing libs
 from tests.support.case import ModuleCase
+from tests.support.helpers import destructiveTest
+from tests.support.unit import skipIf
+
+# Import salt libs
+import salt.utils
 
 
 class TimezoneLinuxModuleTest(ModuleCase):
@@ -42,3 +53,44 @@ class TimezoneSolarisModuleTest(ModuleCase):
         timescale = ['UTC', 'localtime']
         ret = self.run_function('timezone.get_hwclock')
         self.assertIn(ret, timescale)
+
+
+@skipIf(not salt.utils.is_windows(), 'windows test only')
+class TimezoneWindowsModuleTest(ModuleCase):
+    def setUp(self):
+        self.pre = self.run_function('timezone.get_zone')
+
+    def tearDown(self):
+        post = self.run_function('timezone.get_zone')
+        if self.pre != post:
+            self.run_function('timezone.set_zone', [self.pre])
+
+    def test_get_hwclock(self):
+        timescale = ['UTC', 'localtime']
+        ret = self.run_function('timezone.get_hwclock')
+        self.assertIn(ret, timescale)
+
+    @destructiveTest
+    def test_get_zone(self):
+        '''
+        test timezone.set_zone, get_zone and zone_compare
+        '''
+
+        zone = 'America/Inuvik' if not HAS_TZLOCAL else 'America/Denver'
+
+        # first set the zone
+        assert self.run_function('timezone.set_zone', [zone])
+
+        # check it set the correct zone
+        ret = self.run_function('timezone.get_zone')
+        assert zone in ret
+
+        # compare zones
+        assert self.run_function('timezone.zone_compare', [zone])
+
+    def test_get_offset(self):
+        '''
+        test timezone.get_offset
+        '''
+        ret = self.run_function('timezone.get_offset')
+        self.assertIn('-', ret)


### PR DESCRIPTION
### What does this PR do?
Adds timezone integration tests for windows and fixes an issue found while writing the tests.

Here is the issue:

```
PS C:\testing> salt-call --local timezone.set_zone 'America/Denver' -lerror
local:
    True
PS C:\testing> salt-call --local timezone.get_zone
[INFO    ] Executing command ['tzutil', '/g'] in directory 'C:\Users\Administrator'
local:
    America/Inuvik
PS C:\testing>
```

I believe this occurs because the mapping here: https://github.com/saltstack/salt/blob/v2017.7.7/salt/modules/win_timezone.py#L114-L121

has multiple 'Mountain Standard Times'

I changed it to use `tzlocal` but i'm not certain this is the *best* way to grab the windows timezone accurately and I am definitely up for other ideas on how to approach this on the windows side of things and was hoping to get feedback from @dwoz and @twangboy 

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/45007

