### PR TITLE
Fix salt.utils.process.py set_pidfile regression

### DIFF
--- a/salt/utils/process.py
+++ b/salt/utils/process.py
@@ -188,7 +188,7 @@ def set_pidfile(pidfile, user):
         uid = pwnam[2]
         gid = pwnam[3]
         #groups = [g.gr_gid for g in grp.getgrall() if user in g.gr_mem]
-    except IndexError:
+    except (KeyError, IndexError):
         sys.stderr.write(
             'Failed to set the pid to user: {0}. The user is not '
             'available.\n'.format(


### PR DESCRIPTION
Doing a pwd.getpwnam() will raise a KeyError
exception that is not caught anymore, after
a change that happened in 2012. Do catch that now.

Signed-off-by: Rares POP <rares.pop@ni.com>

### What does this PR do?
Adds logging on why starting salt-minion fails when you try to run it with an invalid user

This documentations:
https://docs.python.org/3.6/library/pwd.html
https://docs.python.org/2.7/library/pwd.html
mention that doing a pwd.getpwnam() can raise KeyError.

### What issues does this PR fix or reference?

### Previous Behavior
Silent failing to start salt-minion

### New Behavior
At least is logging on what happens.

### Tests written?

No

### Commits signed with GPG?

Yes
