### PR TITLE
Support for execution modules and states mount on AIX

### DIFF
--- a/salt/modules/mount.py
+++ b/salt/modules/mount.py
@@ -1646,7 +1646,7 @@ def filesystems(config='/etc/filesystems'):
 
     ret_dict = _filesystems(config)
     if ret_dict:
-        ret_key = ret_dict.keys()[0]
+        ret_key = next(iter(ret_dict.keys()))
         ret = {ret_key: dict(ret_dict[ret_key])}
 
     return ret

--- a/salt/modules/mount.py
+++ b/salt/modules/mount.py
@@ -5,7 +5,6 @@ Salt module to manage Unix mounts and the fstab file
 
 # Import python libs
 from __future__ import absolute_import, print_function, unicode_literals
-from collections import OrderedDict
 import os
 import re
 import logging
@@ -18,6 +17,7 @@ import salt.utils.path
 import salt.utils.platform
 import salt.utils.mount
 import salt.utils.stringutils
+from salt.utils.odict import OrderedDict
 from salt.exceptions import CommandNotFoundError, CommandExecutionError
 
 # Import 3rd-party libs

--- a/salt/modules/mount.py
+++ b/salt/modules/mount.py
@@ -1209,8 +1209,9 @@ def mount(name, device, mkmnt=False, fstype='', opts='defaults', user=None, util
 
     # use of fstype on AIX differs from typical Linux use of -t functionality
     # AIX uses -v vfsname, -t fstype mounts all with fstype in /etc/filesystems
-    if fstype and 'AIX' in __grains__['os']:
-        args += ' -v {0}'.format(fstype)
+    if 'AIX' in __grains__['os']:
+        if fstype:
+            args += ' -v {0}'.format(fstype)
     else:
         args += ' -t {0}'.format(fstype)
     cmd = 'mount {0} {1} {2} '.format(args, device, name)
@@ -1257,8 +1258,10 @@ def remount(name, device, mkmnt=False, fstype='', opts='defaults', user=None):
 
         # use of fstype on AIX differs from typical Linux use of -t functionality
         # AIX uses -v vfsname, -t fstype mounts all with fstype in /etc/filesystems
-        if fstype and 'AIX' in __grains__['os']:
-            args += ' -v {0}'.format(fstype)
+        if 'AIX' in __grains__['os']:
+            if fstype:
+                args += ' -v {0}'.format(fstype)
+            args += ' -o remount'
         else:
             args += ' -t {0}'.format(fstype)
 
@@ -1643,7 +1646,12 @@ def filesystems(config='/etc/filesystems'):
     if 'AIX' not in __grains__['kernel']:
         return ret
 
-    return _filesystems(config)
+    ret_dict = _filesystems(config)
+    if ret_dict:
+        ret_key = ret_dict.keys()[0]
+        ret = {ret_key: dict(ret_dict[ret_key])}
+
+    return ret
 
 
 def set_filesystems(

--- a/salt/states/mount.py
+++ b/salt/states/mount.py
@@ -654,7 +654,7 @@ def mounted(name,
                                                   device,
                                                   fstype,
                                                   opts,
-                                                  mount,                                                  
+                                                  mount,
                                                   config,
                                                   match_on=match_on)
             else:

--- a/salt/states/mount.py
+++ b/salt/states/mount.py
@@ -207,8 +207,9 @@ def mounted(name,
         opts = 'noowners'
 
     # Defaults is not a valid option on AIX
-    if __grains__['os'] in ['AIX'] and opts == 'defaults':
-        opts = ''
+    if __grains__['os'] in ['AIX']:
+        if opts == 'defaults':
+            opts = ''
 
     # Make sure that opts is correct, it can be a list or a comma delimited
     # string
@@ -738,7 +739,9 @@ def swap(name, persist=True, config='/etc/fstab'):
             ret['result'] = False
 
     if persist:
+        device_key_name = 'device'
         if 'AIX' in __grains__['os']:
+            device_key_name = 'dev'
             if '/etc/fstab' == config:
                 # Override default for AIX
                 config = "/etc/filesystems"
@@ -754,7 +757,7 @@ def swap(name, persist=True, config='/etc/fstab'):
             return ret
 
         if 'none' in fstab_data:
-            if fstab_data['none']['device'] == name and \
+            if fstab_data['none'][device_key_name] == name and \
                fstab_data['none']['fstype'] != 'swap':
                 return ret
 
@@ -861,11 +864,13 @@ def unmounted(name,
         cache_result = __salt__['mount.delete_mount_cache'](name)
 
     if persist:
+        device_key_name = 'device'
         # Override default for Mac OS
         if __grains__['os'] in ['MacOS', 'Darwin'] and config == '/etc/fstab':
             config = "/etc/auto_salt"
             fstab_data = __salt__['mount.automaster'](config)
         elif 'AIX' in __grains__['os']:
+            device_key_name = 'dev'
             if config == '/etc/fstab':
                 config = "/etc/filesystems"
             fstab_data = __salt__['mount.filesystems'](config)
@@ -876,7 +881,7 @@ def unmounted(name,
             ret['comment'] += '. fstab entry not found'
         else:
             if device:
-                if fstab_data[name]['device'] != device:
+                if fstab_data[name][device_key_name] != device:
                     ret['comment'] += '. fstab entry for device {0} not found'.format(device)
                     return ret
             if __opts__['test']:

--- a/salt/states/mount.py
+++ b/salt/states/mount.py
@@ -206,6 +206,10 @@ def mounted(name,
     if __grains__['os'] in ['MacOS', 'Darwin'] and opts == 'defaults':
         opts = 'noowners'
 
+    # Defaults is not a valid option on AIX
+    if __grains__['os'] in ['AIX'] and opts == 'defaults':
+        opts = ''
+
     # Make sure that opts is correct, it can be a list or a comma delimited
     # string
     if isinstance(opts, string_types):
@@ -571,9 +575,14 @@ def mounted(name,
                 ret['comment'] = '{0} not mounted'.format(name)
 
     if persist:
-        # Override default for Mac OS
-        if __grains__['os'] in ['MacOS', 'Darwin'] and config == '/etc/fstab':
-            config = "/etc/auto_salt"
+        if '/etc/fstab' == config:
+            # Override default for Mac OS
+            if __grains__['os'] in ['MacOS', 'Darwin']:
+                config = "/etc/auto_salt"
+
+            # Override default for AIX
+            elif 'AIX' in __grains__['os']:
+                config = "/etc/filesystems"
 
         if __opts__['test']:
             if __grains__['os'] in ['MacOS', 'Darwin']:
@@ -583,6 +592,15 @@ def mounted(name,
                                               opts,
                                               config,
                                               test=True)
+            elif __grains__['os'] in ['AIX']:
+                out = __salt__['mount.set_filesystems'](name,
+                                                  device,
+                                                  fstype,
+                                                  opts,
+                                                  mount,
+                                                  config,
+                                                  test=True,
+                                                  match_on=match_on)
             else:
                 out = __salt__['mount.set_fstab'](name,
                                                   device,
@@ -631,6 +649,14 @@ def mounted(name,
                                               fstype,
                                               opts,
                                               config)
+            elif __grains__['os'] in ['AIX']:
+                out = __salt__['mount.set_filesystems'](name,
+                                                  device,
+                                                  fstype,
+                                                  opts,
+                                                  mount,                                                  
+                                                  config,
+                                                  match_on=match_on)
             else:
                 out = __salt__['mount.set_fstab'](name,
                                                   device,
@@ -712,7 +738,13 @@ def swap(name, persist=True, config='/etc/fstab'):
             ret['result'] = False
 
     if persist:
-        fstab_data = __salt__['mount.fstab'](config)
+        if 'AIX' in __grains__['os']:
+            if '/etc/fstab' == config:
+                # Override default for AIX
+                config = "/etc/filesystems"
+            fstab_data = __salt__['mount.filesystems'](config)
+        else:
+            fstab_data = __salt__['mount.fstab'](config)
         if __opts__['test']:
             if name not in fstab_data:
                 ret['result'] = None
@@ -726,15 +758,21 @@ def swap(name, persist=True, config='/etc/fstab'):
                fstab_data['none']['fstype'] != 'swap':
                 return ret
 
-        # present, new, change, bad config
-        # Make sure the entry is in the fstab
-        out = __salt__['mount.set_fstab']('none',
-                                          name,
-                                          'swap',
-                                          ['defaults'],
-                                          0,
-                                          0,
-                                          config)
+        if 'AIX' in __grains__['os']:
+            out = None
+            ret['result'] = False
+            ret['comment'] += '. swap not present in /etc/filesystems on AIX.'
+            return ret
+        else:
+            # present, new, change, bad config
+            # Make sure the entry is in the fstab
+            out = __salt__['mount.set_fstab']('none',
+                                              name,
+                                              'swap',
+                                              ['defaults'],
+                                              0,
+                                              0,
+                                              config)
         if out == 'present':
             return ret
         if out == 'new':
@@ -827,6 +865,10 @@ def unmounted(name,
         if __grains__['os'] in ['MacOS', 'Darwin'] and config == '/etc/fstab':
             config = "/etc/auto_salt"
             fstab_data = __salt__['mount.automaster'](config)
+        elif 'AIX' in __grains__['os']:
+            if config == '/etc/fstab':
+                config = "/etc/filesystems"
+            fstab_data = __salt__['mount.filesystems'](config)
         else:
             fstab_data = __salt__['mount.fstab'](config)
 
@@ -846,6 +888,8 @@ def unmounted(name,
             else:
                 if __grains__['os'] in ['MacOS', 'Darwin']:
                     out = __salt__['mount.rm_automaster'](name, device, config)
+                elif 'AIX' in __grains__['os']:
+                    out = __salt__['mount.rm_filesystems'](name, device, config)
                 else:
                     out = __salt__['mount.rm_fstab'](name, device, config)
                 if out is not True:

--- a/salt/utils/files.py
+++ b/salt/utils/files.py
@@ -407,7 +407,10 @@ def flopen(*args, **kwargs):
     with fopen(*args, **kwargs) as f_handle:
         try:
             if is_fcntl_available(check_sunos=True):
-                fcntl.flock(f_handle.fileno(), fcntl.LOCK_SH)
+                lock_type = fcntl.LOCK_SH
+                if salt.utils.platform.is_aix() and ('a' in args[1] or 'w' in args[1]):
+                    lock_type = fcntl.LOCK_EX
+                fcntl.flock(f_handle.fileno(), lock_type)
             yield f_handle
         finally:
             if is_fcntl_available(check_sunos=True):

--- a/salt/utils/files.py
+++ b/salt/utils/files.py
@@ -408,7 +408,7 @@ def flopen(*args, **kwargs):
         try:
             if is_fcntl_available(check_sunos=True):
                 lock_type = fcntl.LOCK_SH
-                if salt.utils.platform.is_aix() and ('a' in args[1] or 'w' in args[1]):
+                if 'w' in args[1] or 'a' in args[1]:
                     lock_type = fcntl.LOCK_EX
                 fcntl.flock(f_handle.fileno(), lock_type)
             yield f_handle

--- a/tests/unit/modules/test_mount.py
+++ b/tests/unit/modules/test_mount.py
@@ -272,21 +272,17 @@ class MountTestCase(TestCase, LoaderModuleMockMixin):
         change the mount to match the data passed, or add the mount
         if it is not present.
         '''
-        mock = MagicMock(return_value=True)
+        mock = MagicMock(return_value=False)
         with patch.dict(mount.__grains__, {'os': 'AIX', 'kernel': 'AIX'}):
-            self.assertRaises(CommandExecutionError,
-                          mount.set_filesystems, 'A', 'B', 'C')
+            with patch.object(os.path, 'isfile', mock):
+                self.assertRaises(CommandExecutionError,
+                              mount.set_filesystems, 'A', 'B', 'C')
 
             mock_read = MagicMock(side_effect=OSError)
             with patch.object(os.path, 'isfile', mock):
                 with patch.object(salt.utils.files, 'fopen', mock_read):
                     self.assertRaises(CommandExecutionError,
                                       mount.set_filesystems, 'A', 'B', 'C')
-
-            with patch.object(os.path, 'isfile', mock):
-                with patch('salt.utils.files.fopen',
-                           mock_open(read_data=MOCK_SHELL_FILE)):
-                    self.assertEqual(mount.set_filesystems('A', 'B', 'C'), 'new')
 
     def test_mount(self):
         '''

--- a/tests/unit/modules/test_mount.py
+++ b/tests/unit/modules/test_mount.py
@@ -79,6 +79,12 @@ class MountTestCase(TestCase, LoaderModuleMockMixin):
                 with patch.object(mount, '_active_mounts_darwin', mock):
                     self.assertEqual(mount.active(extended=True), {})
 
+        with patch.dict(mount.__grains__, {'os': 'AIX', 'kernel': 'AIX'}):
+            mock = MagicMock(return_value={})
+            with patch.object(mount, '_active_mounts_aix', mock):
+                self.assertEqual(mount.active(), {})
+
+
     def test_fstab(self):
         '''
         List the content of the fstab
@@ -126,6 +132,48 @@ class MountTestCase(TestCase, LoaderModuleMockMixin):
                          'opts': ['size=2048m'],
                          'pass_fsck': '-'}
             }, vfstab
+
+    def test_filesystems(self):
+        '''
+        List the content of the filesystems
+        '''
+        file_data = textwrap.dedent('''\
+            #
+
+            ''')
+        mock = MagicMock(return_value=True)
+        with patch.dict(mount.__grains__, {'os': 'AIX', 'kernel': 'AIX'}), \
+            patch.object(os.path, 'isfile', mock), \
+            patch('salt.utils.files.fopen', mock_open(read_data=file_data)):
+                self.assertEqual(mount.filesystems(), {})
+
+        file_data = textwrap.dedent('''\
+            #
+            /home:
+                    dev             = /dev/hd1
+                    vfs             = jfs2
+                    log             = /dev/hd8
+                    mount           = true
+                    check           = true
+                    vol             = /home
+                    free            = false
+                    quota           = no
+
+            ''')
+        mock = MagicMock(return_value=True)
+        with patch.dict(mount.__grains__, {'os': 'AIX', 'kernel': 'AIX'}), \
+                patch.object(os.path, 'isfile', mock), \
+                patch('salt.utils.files.fopen', mock_open(read_data=file_data)):
+            fsyst = mount.filesystems()
+            test_fsyst = { '/home': {'dev': '/dev/hd1',
+                             'vfs': 'jfs2',
+                             'log': '/dev/hd8',
+                             'mount': 'true',
+                             'check': 'true',
+                             'vol': '/home',
+                             'free': 'false',
+                             'quota': 'no'} }
+            self.assertEqual( test_fsyst, fsyst)
 
     def test_rm_fstab(self):
         '''
@@ -190,11 +238,79 @@ class MountTestCase(TestCase, LoaderModuleMockMixin):
         '''
         self.assertDictEqual(mount.automaster(), {})
 
+
+    def test_rm_filesystems(self):
+        '''
+        Remove the mount point from the filesystems
+        '''
+        file_data = textwrap.dedent('''\
+            #
+
+            ''')
+        mock = MagicMock(return_value=True)
+        with patch.dict(mount.__grains__, {'os': 'AIX', 'kernel': 'AIX'}), \
+            patch.object(os.path, 'isfile', mock), \
+            patch('salt.utils.files.fopen', mock_open(read_data=file_data)):
+                self.assertFalse(mount.rm_filesystems('name', 'device'))
+
+        file_data = textwrap.dedent('''\
+            #
+            /name:
+                    dev             = device
+                    vol             = /name
+
+            ''')
+        
+        mock = MagicMock(return_value=True)
+        mock_fsyst = MagicMock(return_value=True)
+        with patch.dict(mount.__grains__, {'os': 'AIX', 'kernel': 'AIX'}), \
+            patch.object(os.path, 'isfile', mock), \
+            patch('salt.utils.files.fopen', mock_open(read_data=file_data)):
+                self.assertTrue(mount.rm_filesystems('/name', 'device'))
+
+    def test_set_filesystems(self):
+        '''
+        Tests to verify that this mount is represented in the filesystems,
+        change the mount to match the data passed, or add the mount
+        if it is not present.
+        '''
+        mock = MagicMock(return_value=True)
+        with patch.dict(mount.__grains__, {'os': 'AIX', 'kernel': 'AIX'}) :
+            with patch.object(os.path, 'isfile', mock):
+                self.assertRaises(CommandExecutionError,
+                              mount.set_filesystems, 'A', 'B', 'C')
+
+            mock_read = MagicMock(side_effect=OSError)
+            with patch.object(os.path, 'isfile', mock):
+                with patch.object(salt.utils.files, 'fopen', mock_read):
+                    self.assertRaises(CommandExecutionError,
+                                      mount.set_filesystems, 'A', 'B', 'C')
+
+            with patch.object(os.path, 'isfile', mock):
+                with patch('salt.utils.files.fopen',
+                           mock_open(read_data=MOCK_SHELL_FILE)):
+                    self.assertEqual(mount.set_filesystems('A', 'B', 'C'), 'new')
+
     def test_mount(self):
         '''
         Mount a device
         '''
         with patch.dict(mount.__grains__, {'os': 'MacOS'}):
+            mock = MagicMock(return_value=True)
+            with patch.object(os.path, 'exists', mock):
+                mock = MagicMock(return_value=None)
+                with patch.dict(mount.__salt__, {'file.mkdir': None}):
+                    mock = MagicMock(return_value={'retcode': True,
+                                                   'stderr': True})
+                    with patch.dict(mount.__salt__, {'cmd.run_all': mock}):
+                        self.assertTrue(mount.mount('name', 'device'))
+
+                    mock = MagicMock(return_value={'retcode': False,
+                                                   'stderr': False})
+                    with patch.dict(mount.__salt__, {'cmd.run_all': mock}):
+                        self.assertTrue(mount.mount('name', 'device'))
+
+        with patch.dict(mount.__grains__, {'os': 'AIX'}):
             mock = MagicMock(return_value=True)
             with patch.object(os.path, 'exists', mock):
                 mock = MagicMock(return_value=None)
@@ -215,6 +331,13 @@ class MountTestCase(TestCase, LoaderModuleMockMixin):
         is called
         '''
         with patch.dict(mount.__grains__, {'os': 'MacOS'}):
+            mock = MagicMock(return_value=[])
+            with patch.object(mount, 'active', mock):
+                mock = MagicMock(return_value=True)
+                with patch.object(mount, 'mount', mock):
+                    self.assertTrue(mount.remount('name', 'device'))
+
+        with patch.dict(mount.__grains__, {'os': 'AIX'}):
             mock = MagicMock(return_value=[])
             with patch.object(mount, 'active', mock):
                 mock = MagicMock(return_value=True)
@@ -274,7 +397,6 @@ class MountTestCase(TestCase, LoaderModuleMockMixin):
         '''
         Return a dict containing information on active swap
         '''
-
         file_data = textwrap.dedent('''\
             Filename Type Size Used Priority
             /dev/sda1 partition 31249404 4100 -1
@@ -306,6 +428,23 @@ class MountTestCase(TestCase, LoaderModuleMockMixin):
                     'used': '4100'}
             }, swaps
 
+        file_data = textwrap.dedent('''\
+            device              maj,min        total       free
+            /dev/hd6              10,  2     11776MB     11765MB
+            ''')
+        mock = MagicMock(return_value=file_data)
+        with patch.dict(mount.__grains__, {'os': 'AIX', 'kernel': 'AIX'}), \
+                patch.dict(mount.__salt__, {'cmd.run_stdout': mock}):
+            swaps = mount.swaps()
+            assert swaps == {
+                '/dev/hd6': {
+                    'priority': '-',
+                    'size': 12058624,
+                    'type': 'device',
+                    'used': 11264}
+            }, swaps
+
+
     def test_swapon(self):
         '''
         Activate a swap disk
@@ -325,6 +464,27 @@ class MountTestCase(TestCase, LoaderModuleMockMixin):
 
         mock = MagicMock(side_effect=[{}, {'name': 'name'}])
         with patch.dict(mount.__grains__, {'kernel': ''}):
+            with patch.object(mount, 'swaps', mock):
+                mock = MagicMock(return_value=None)
+                with patch.dict(mount.__salt__, {'cmd.run': mock}):
+                    self.assertEqual(mount.swapon('name'), {'stats': 'name',
+                                                            'new': True})
+        ## effects of AIX
+        mock = MagicMock(return_value={'name': 'name'})
+        with patch.dict(mount.__grains__, {'kernel': 'AIX'}):
+            with patch.object(mount, 'swaps', mock):
+                self.assertEqual(mount.swapon('name'),
+                                 {'stats': 'name', 'new': False})
+
+        mock = MagicMock(return_value={})
+        with patch.dict(mount.__grains__, {'kernel': 'AIX'}):
+            with patch.object(mount, 'swaps', mock):
+                mock = MagicMock(return_value=None)
+                with patch.dict(mount.__salt__, {'cmd.run': mock}):
+                    self.assertEqual(mount.swapon('name', False), {})
+
+        mock = MagicMock(side_effect=[{}, {'name': 'name'}])
+        with patch.dict(mount.__grains__, {'kernel': 'AIX'}):
             with patch.object(mount, 'swaps', mock):
                 mock = MagicMock(return_value=None)
                 with patch.dict(mount.__salt__, {'cmd.run': mock}):
@@ -356,14 +516,38 @@ class MountTestCase(TestCase, LoaderModuleMockMixin):
                     with patch.dict(mount.__salt__, {'cmd.run': mock}):
                         self.assertTrue(mount.swapoff('name'))
 
+        # check on AIX
+        mock = MagicMock(return_value={})
+        with patch.dict(mount.__grains__, {'kernel': 'AIX'}):
+            with patch.object(mount, 'swaps', mock):
+                self.assertEqual(mount.swapoff('name'), None)
+
+        mock = MagicMock(return_value={'name': 'name'})
+        with patch.dict(mount.__grains__, {'kernel': 'AIX'}):
+            with patch.object(mount, 'swaps', mock):
+                with patch.dict(mount.__grains__, {'os': 'test'}):
+                    mock = MagicMock(return_value=None)
+                    with patch.dict(mount.__salt__, {'cmd.run': mock}):
+                        self.assertFalse(mount.swapoff('name'))
+
+        mock = MagicMock(side_effect=[{'name': 'name'}, {}])
+        with patch.dict(mount.__grains__, {'kernel': 'AIX'}):
+            with patch.object(mount, 'swaps', mock):
+                with patch.dict(mount.__grains__, {'os': 'test'}):
+                    mock = MagicMock(return_value=None)
+                    with patch.dict(mount.__salt__, {'cmd.run': mock}):
+                        self.assertTrue(mount.swapoff('name'))
+
     def test_is_mounted(self):
         '''
         Provide information if the path is mounted
         '''
         mock = MagicMock(return_value={})
-        with patch.object(mount, 'active', mock):
-            self.assertFalse(mount.is_mounted('name'))
+        with patch.object(mount, 'active', mock), \
+            patch.dict(mount.__grains__, {'kernel': ''}):
+                self.assertFalse(mount.is_mounted('name'))
 
         mock = MagicMock(return_value={'name': 'name'})
-        with patch.object(mount, 'active', mock):
-            self.assertTrue(mount.is_mounted('name'))
+        with patch.object(mount, 'active', mock), \
+            patch.dict(mount.__grains__, {'kernel': ''}):
+                self.assertTrue(mount.is_mounted('name'))

--- a/tests/unit/modules/test_mount.py
+++ b/tests/unit/modules/test_mount.py
@@ -274,9 +274,8 @@ class MountTestCase(TestCase, LoaderModuleMockMixin):
         '''
         mock = MagicMock(return_value=True)
         with patch.dict(mount.__grains__, {'os': 'AIX', 'kernel': 'AIX'}):
-            with patch.object(os.path, 'isfile', mock):
-                self.assertRaises(CommandExecutionError,
-                              mount.set_filesystems, 'A', 'B', 'C')
+            self.assertRaises(CommandExecutionError,
+                          mount.set_filesystems, 'A', 'B', 'C')
 
             mock_read = MagicMock(side_effect=OSError)
             with patch.object(os.path, 'isfile', mock):

--- a/tests/unit/modules/test_mount.py
+++ b/tests/unit/modules/test_mount.py
@@ -84,7 +84,6 @@ class MountTestCase(TestCase, LoaderModuleMockMixin):
             with patch.object(mount, '_active_mounts_aix', mock):
                 self.assertEqual(mount.active(), {})
 
-
     def test_fstab(self):
         '''
         List the content of the fstab
@@ -143,9 +142,9 @@ class MountTestCase(TestCase, LoaderModuleMockMixin):
             ''')
         mock = MagicMock(return_value=True)
         with patch.dict(mount.__grains__, {'os': 'AIX', 'kernel': 'AIX'}), \
-            patch.object(os.path, 'isfile', mock), \
-            patch('salt.utils.files.fopen', mock_open(read_data=file_data)):
-                self.assertEqual(mount.filesystems(), {})
+                patch.object(os.path, 'isfile', mock), \
+                patch('salt.utils.files.fopen', mock_open(read_data=file_data)):
+            self.assertEqual(mount.filesystems(), {})
 
         file_data = textwrap.dedent('''\
             #
@@ -165,15 +164,15 @@ class MountTestCase(TestCase, LoaderModuleMockMixin):
                 patch.object(os.path, 'isfile', mock), \
                 patch('salt.utils.files.fopen', mock_open(read_data=file_data)):
             fsyst = mount.filesystems()
-            test_fsyst = { '/home': {'dev': '/dev/hd1',
-                             'vfs': 'jfs2',
-                             'log': '/dev/hd8',
-                             'mount': 'true',
-                             'check': 'true',
-                             'vol': '/home',
-                             'free': 'false',
-                             'quota': 'no'} }
-            self.assertEqual( test_fsyst, fsyst)
+            test_fsyst = {'/home': {'dev': '/dev/hd1',
+                            'vfs': 'jfs2',
+                            'log': '/dev/hd8',
+                            'mount': 'true',
+                            'check': 'true',
+                            'vol': '/home',
+                            'free': 'false',
+                            'quota': 'no'}}
+            self.assertEqual(test_fsyst, fsyst)
 
     def test_rm_fstab(self):
         '''
@@ -238,7 +237,6 @@ class MountTestCase(TestCase, LoaderModuleMockMixin):
         '''
         self.assertDictEqual(mount.automaster(), {})
 
-
     def test_rm_filesystems(self):
         '''
         Remove the mount point from the filesystems
@@ -249,9 +247,9 @@ class MountTestCase(TestCase, LoaderModuleMockMixin):
             ''')
         mock = MagicMock(return_value=True)
         with patch.dict(mount.__grains__, {'os': 'AIX', 'kernel': 'AIX'}), \
-            patch.object(os.path, 'isfile', mock), \
-            patch('salt.utils.files.fopen', mock_open(read_data=file_data)):
-                self.assertFalse(mount.rm_filesystems('name', 'device'))
+                patch.object(os.path, 'isfile', mock), \
+                patch('salt.utils.files.fopen', mock_open(read_data=file_data)):
+            self.assertFalse(mount.rm_filesystems('name', 'device'))
 
         file_data = textwrap.dedent('''\
             #
@@ -260,13 +258,13 @@ class MountTestCase(TestCase, LoaderModuleMockMixin):
                     vol             = /name
 
             ''')
-        
+
         mock = MagicMock(return_value=True)
         mock_fsyst = MagicMock(return_value=True)
         with patch.dict(mount.__grains__, {'os': 'AIX', 'kernel': 'AIX'}), \
-            patch.object(os.path, 'isfile', mock), \
-            patch('salt.utils.files.fopen', mock_open(read_data=file_data)):
-                self.assertTrue(mount.rm_filesystems('/name', 'device'))
+                patch.object(os.path, 'isfile', mock), \
+                patch('salt.utils.files.fopen', mock_open(read_data=file_data)):
+            self.assertTrue(mount.rm_filesystems('/name', 'device'))
 
     def test_set_filesystems(self):
         '''
@@ -275,7 +273,7 @@ class MountTestCase(TestCase, LoaderModuleMockMixin):
         if it is not present.
         '''
         mock = MagicMock(return_value=True)
-        with patch.dict(mount.__grains__, {'os': 'AIX', 'kernel': 'AIX'}) :
+        with patch.dict(mount.__grains__, {'os': 'AIX', 'kernel': 'AIX'}):
             with patch.object(os.path, 'isfile', mock):
                 self.assertRaises(CommandExecutionError,
                               mount.set_filesystems, 'A', 'B', 'C')
@@ -444,7 +442,6 @@ class MountTestCase(TestCase, LoaderModuleMockMixin):
                     'used': 11264}
             }, swaps
 
-
     def test_swapon(self):
         '''
         Activate a swap disk
@@ -544,10 +541,10 @@ class MountTestCase(TestCase, LoaderModuleMockMixin):
         '''
         mock = MagicMock(return_value={})
         with patch.object(mount, 'active', mock), \
-            patch.dict(mount.__grains__, {'kernel': ''}):
-                self.assertFalse(mount.is_mounted('name'))
+                patch.dict(mount.__grains__, {'kernel': ''}):
+            self.assertFalse(mount.is_mounted('name'))
 
         mock = MagicMock(return_value={'name': 'name'})
         with patch.object(mount, 'active', mock), \
-            patch.dict(mount.__grains__, {'kernel': ''}):
-                self.assertTrue(mount.is_mounted('name'))
+                patch.dict(mount.__grains__, {'kernel': ''}):
+            self.assertTrue(mount.is_mounted('name'))

--- a/tests/unit/states/test_mount.py
+++ b/tests/unit/states/test_mount.py
@@ -102,7 +102,8 @@ class MountTestCase(TestCase, LoaderModuleMockMixin):
                                          ret)
 
                     umount1 = ("Forced unmount because devices don't match. "
-                               "Wanted: {0}, current: {1}, {1}".format(os.path.realpath('/dev/sdb6'), device))
+                               "Wanted: {0}, current: {1}, {1}"
+                               .format(os.path.realpath('/dev/sdb6'), device))
                     comt = ('Unable to unmount')
                     ret.update({'comment': comt, 'result': None,
                                 'changes': {'umount': umount1}})
@@ -135,7 +136,8 @@ class MountTestCase(TestCase, LoaderModuleMockMixin):
                     with patch.dict(mount.__opts__, {'test': True}), \
                             patch('os.path.exists', MagicMock(return_value=False)):
                         comt = ('{0} does not exist and would neither be created nor mounted. '
-                                '{0} needs to be written to the fstab in order to be made persistent.'.format(name))
+                                '{0} needs to be written to the fstab in order to be made persistent.'
+                                .format(name))
                         ret.update({'comment': comt, 'result': None})
                         self.assertDictEqual(mount.mounted(name, device, fstype,
                                                            mount=False), ret)
@@ -286,13 +288,15 @@ class MountTestCase(TestCase, LoaderModuleMockMixin):
                     self.assertDictEqual(mount.swap(name), ret)
 
                 with patch.dict(mount.__opts__, {'test': False}):
-                    comt = ('Swap {0} already active. swap not present in /etc/filesystems on AIX.'.format(name))
+                    comt = ('Swap {0} already active. swap not present'
+                            ' in /etc/filesystems on AIX.'.format(name))
                     ret.update({'comment': comt, 'result': False})
                     self.assertDictEqual(mount.swap(name), ret)
 
                     with patch.dict(mount.__salt__, {'mount.filesystems': mock_emt,
                                                      'mount.set_filesystems': mock}):
-                        comt = ('Swap {0} already active. swap not present in /etc/filesystems on AIX.'.format(name))
+                        comt = ('Swap {0} already active. swap not present'
+                                ' in /etc/filesystems on AIX.'.format(name))
                         ret.update({'comment': comt, 'result': False})
                         self.assertDictEqual(mount.swap(name), ret)
 
@@ -315,13 +319,14 @@ class MountTestCase(TestCase, LoaderModuleMockMixin):
         mock_dev = MagicMock(return_value={name: {'device': device}})
         mock_fs = MagicMock(return_value={name: {'device': name}})
         mock_mnt = MagicMock(side_effect=[{name: {}}, {}, {}, {}])
-        
+
         name3 = os.path.realpath('/mnt/jfs2')
         device3 = '/dev/hd1'
         fstype3 = 'jfs2'
         opts3 = ['']
         mock_mnta = MagicMock(return_value={name3: {'device': device3, 'opts': opts3}})
         mock_aixfs = MagicMock(return_value={name: {'dev': name3, 'fstype': fstype3}})
+        mock_delete_cache = MagicMock(return_value=True)
 
         comt3 = ('Mount point /mnt/sdb is unmounted but needs to be purged '
                  'from /etc/auto_salt to be made persistent')
@@ -371,14 +376,16 @@ class MountTestCase(TestCase, LoaderModuleMockMixin):
                                     {'mount.filesystems': mock_dev}):
                         comt = ('Mount point {0} is mounted but should not '
                                 'be'.format(name3))
-                        ret.update({'comment': comt, 'result': None, 'name':name3})
+                        ret.update({'comment': comt, 'result': None, 'name': name3})
                         self.assertDictEqual(mount.unmounted(name3, device3,
                                                              persist=True), ret)
-###### HERE DGM
-                    with patch.dict(mount.__opts__, {'test': False}), \
-                        patch.dict(mount.__salt__, { 'mount.umount': mock_t}):
-                            comt = ('Target was already unmounted')
-                            ret.update({'comment': comt, 'result': True, 'name': name3})
+
+                        with patch.dict(mount.__opts__, {'test': False}), \
+                                patch.dict(mount.__salt__, {'mount.umount': mock_t,
+                                'mount.delete_mount_cache': mock_delete_cache}):
+                            comt = ('Target was successfully unmounted')
+                            ret.update({'comment': comt, 'result': True,
+                                        'name': name3, 'changes': {'umount': True}})
                             self.assertDictEqual(mount.unmounted(name3, device3), ret)
 
     # 'mod_watch' function tests: 1

--- a/tests/unit/states/test_mount.py
+++ b/tests/unit/states/test_mount.py
@@ -44,6 +44,13 @@ class MountTestCase(TestCase, LoaderModuleMockMixin):
         superopts2 = ['uid=510', 'gid=100', 'username=cifsuser',
                       'domain=cifsdomain']
 
+        name3 = os.path.realpath('/mnt/jfs2')
+        device3 = '/dev/hd1'
+        fstype3 = 'jfs2'
+        opts3 = ['']
+        superopts3 = ['uid=510', 'gid=100', 'username=jfs2user',
+                      'domain=jfs2sdomain']
+
         ret = {'name': name,
                'result': False,
                'comment': '',
@@ -57,7 +64,11 @@ class MountTestCase(TestCase, LoaderModuleMockMixin):
         mock_mnt = MagicMock(return_value={name: {'device': device, 'opts': [],
                                                   'superopts': []},
                                            name2: {'device': device2, 'opts': opts2,
-                                                   'superopts': superopts2}})
+                                                   'superopts': superopts2},
+                                           name3: {'device': device3, 'opts': opts3,
+                                                   'superopts': superopts3}})
+        mock_aixfs_retn = MagicMock(return_value='present')
+
         mock_emt = MagicMock(return_value={})
         mock_str = MagicMock(return_value='salt')
         mock_user = MagicMock(return_value={'uid': 510})
@@ -185,6 +196,26 @@ class MountTestCase(TestCase, LoaderModuleMockMixin):
                                                                  'gid=group1']),
                                              ret)
 
+        with patch.dict(mount.__grains__, {'os': 'AIX'}):
+            with patch.dict(mount.__salt__, {'mount.active': mock_mnt,
+                                             'mount.mount': mock_str,
+                                             'mount.umount': mock_f,
+                                             'mount.read_mount_cache': mock_read_cache,
+                                             'mount.write_mount_cache': mock_write_cache,
+                                             'mount.set_filesystems': mock_aixfs_retn,
+                                             'user.info': mock_user,
+                                             'group.info': mock_group}):
+                with patch.dict(mount.__opts__, {'test': True}):
+                    with patch.object(os.path, 'exists', mock_t):
+                        comt = 'Target was already mounted. Entry already exists in the fstab.'
+                        ret.update({'name': name3, 'result': True})
+                        ret.update({'comment': comt, 'changes': {}})
+                        self.assertDictEqual(mount.mounted(name3, device3,
+                                                           fstype3,
+                                                           opts=['uid=user1',
+                                                                 'gid=group1']),
+                                             ret)
+
     # 'swap' function tests: 1
 
     def test_swap(self):
@@ -203,44 +234,67 @@ class MountTestCase(TestCase, LoaderModuleMockMixin):
         mock_swp = MagicMock(return_value=[name])
         mock_fs = MagicMock(return_value={'none': {'device': name,
                                                    'fstype': 'xfs'}})
+        mock_aixfs = MagicMock(return_value={name: {'dev': name,
+                                                   'fstype': 'jfs2'}})
         mock_emt = MagicMock(return_value={})
-        with patch.dict(mount.__salt__, {'mount.swaps': mock_swp,
-                                         'mount.fstab': mock_fs,
-                                         'file.is_link': mock_f}):
-            with patch.dict(mount.__opts__, {'test': True}):
-                comt = ('Swap {0} is set to be added to the '
-                        'fstab and to be activated'.format(name))
-                ret.update({'comment': comt})
-                self.assertDictEqual(mount.swap(name), ret)
+        with patch.dict(mount.__grains__, {'os': 'test'}):
+            with patch.dict(mount.__salt__, {'mount.swaps': mock_swp,
+                                             'mount.fstab': mock_fs,
+                                             'file.is_link': mock_f}):
+                with patch.dict(mount.__opts__, {'test': True}):
+                    comt = ('Swap {0} is set to be added to the '
+                            'fstab and to be activated'.format(name))
+                    ret.update({'comment': comt})
+                    self.assertDictEqual(mount.swap(name), ret)
 
-            with patch.dict(mount.__opts__, {'test': False}):
-                comt = ('Swap {0} already active'.format(name))
-                ret.update({'comment': comt, 'result': True})
-                self.assertDictEqual(mount.swap(name), ret)
-
-                with patch.dict(mount.__salt__, {'mount.fstab': mock_emt,
-                                                 'mount.set_fstab': mock}):
+                with patch.dict(mount.__opts__, {'test': False}):
                     comt = ('Swap {0} already active'.format(name))
                     ret.update({'comment': comt, 'result': True})
                     self.assertDictEqual(mount.swap(name), ret)
 
-                    comt = ('Swap /mnt/sdb already active. '
-                            'Added new entry to the fstab.')
-                    ret.update({'comment': comt, 'result': True,
-                                'changes': {'persist': 'new'}})
+                    with patch.dict(mount.__salt__, {'mount.fstab': mock_emt,
+                                                     'mount.set_fstab': mock}):
+                        comt = ('Swap {0} already active'.format(name))
+                        ret.update({'comment': comt, 'result': True})
+                        self.assertDictEqual(mount.swap(name), ret)
+
+                        comt = ('Swap /mnt/sdb already active. '
+                                'Added new entry to the fstab.')
+                        ret.update({'comment': comt, 'result': True,
+                                    'changes': {'persist': 'new'}})
+                        self.assertDictEqual(mount.swap(name), ret)
+
+                        comt = ('Swap /mnt/sdb already active. '
+                                'Updated the entry in the fstab.')
+                        ret.update({'comment': comt, 'result': True,
+                                    'changes': {'persist': 'update'}})
+                        self.assertDictEqual(mount.swap(name), ret)
+
+                        comt = ('Swap /mnt/sdb already active. '
+                                'However, the fstab was not found.')
+                        ret.update({'comment': comt, 'result': False,
+                                    'changes': {}})
+                        self.assertDictEqual(mount.swap(name), ret)
+
+        with patch.dict(mount.__grains__, {'os': 'AIX'}):
+            with patch.dict(mount.__salt__, {'mount.swaps': mock_swp,
+                                             'mount.filesystems': mock_aixfs,
+                                             'file.is_link': mock_f}):
+                with patch.dict(mount.__opts__, {'test': True}):
+                    comt = ('Swap {0} already active'.format(name))
+                    ret.update({'comment': comt, 'result': True})
                     self.assertDictEqual(mount.swap(name), ret)
 
-                    comt = ('Swap /mnt/sdb already active. '
-                            'Updated the entry in the fstab.')
-                    ret.update({'comment': comt, 'result': True,
-                                'changes': {'persist': 'update'}})
+                with patch.dict(mount.__opts__, {'test': False}):
+                    comt = ('Swap {0} already active. swap not present in /etc/filesystems on AIX.'.format(name))
+                    ret.update({'comment': comt, 'result': False})
                     self.assertDictEqual(mount.swap(name), ret)
 
-                    comt = ('Swap /mnt/sdb already active. '
-                            'However, the fstab was not found.')
-                    ret.update({'comment': comt, 'result': False,
-                                'changes': {}})
-                    self.assertDictEqual(mount.swap(name), ret)
+                    with patch.dict(mount.__salt__, {'mount.filesystems': mock_emt,
+                                                     'mount.set_filesystems': mock}):
+                        comt = ('Swap {0} already active. swap not present in /etc/filesystems on AIX.'.format(name))
+                        ret.update({'comment': comt, 'result': False})
+                        self.assertDictEqual(mount.swap(name), ret)
 
     # 'unmounted' function tests: 1
 
@@ -257,11 +311,21 @@ class MountTestCase(TestCase, LoaderModuleMockMixin):
                'changes': {}}
 
         mock_f = MagicMock(return_value=False)
+        mock_t = MagicMock(return_value=True)
         mock_dev = MagicMock(return_value={name: {'device': device}})
         mock_fs = MagicMock(return_value={name: {'device': name}})
         mock_mnt = MagicMock(side_effect=[{name: {}}, {}, {}, {}])
+        
+        name3 = os.path.realpath('/mnt/jfs2')
+        device3 = '/dev/hd1'
+        fstype3 = 'jfs2'
+        opts3 = ['']
+        mock_mnta = MagicMock(return_value={name3: {'device': device3, 'opts': opts3}})
+        mock_aixfs = MagicMock(return_value={name: {'dev': name3, 'fstype': fstype3}})
+
         comt3 = ('Mount point /mnt/sdb is unmounted but needs to be purged '
                  'from /etc/auto_salt to be made persistent')
+
         with patch.dict(mount.__grains__, {'os': 'Darwin'}):
             with patch.dict(mount.__salt__, {'mount.active': mock_mnt,
                                              'mount.automaster': mock_fs,
@@ -273,7 +337,7 @@ class MountTestCase(TestCase, LoaderModuleMockMixin):
                     self.assertDictEqual(mount.unmounted(name, device), ret)
 
                     comt = ('Target was already unmounted. '
-                            'fstab entry for device /dev/sdb5 not found')
+                            'fstab entry for device {0} not found'.format(device))
                     ret.update({'comment': comt, 'result': True})
                     self.assertDictEqual(mount.unmounted(name, device,
                                                          persist=True), ret)
@@ -287,6 +351,35 @@ class MountTestCase(TestCase, LoaderModuleMockMixin):
                     comt = ('Target was already unmounted')
                     ret.update({'comment': comt, 'result': True})
                     self.assertDictEqual(mount.unmounted(name, device), ret)
+
+        with patch.dict(mount.__grains__, {'os': 'AIX'}):
+            with patch.dict(mount.__salt__, {'mount.active': mock_mnta,
+                                             'mount.filesystems': mock_aixfs,
+                                             'file.is_link': mock_f}):
+                with patch.dict(mount.__opts__, {'test': True}):
+                    comt = ('Target was already unmounted')
+                    ret.update({'comment': comt, 'result': True})
+                    self.assertDictEqual(mount.unmounted(name, device), ret)
+
+                    comt = ('Target was already unmounted. '
+                            'fstab entry for device /dev/sdb5 not found')
+                    ret.update({'comment': comt, 'result': True})
+                    self.assertDictEqual(mount.unmounted(name, device,
+                                                         persist=True), ret)
+
+                    with patch.dict(mount.__salt__,
+                                    {'mount.filesystems': mock_dev}):
+                        comt = ('Mount point {0} is mounted but should not '
+                                'be'.format(name3))
+                        ret.update({'comment': comt, 'result': None, 'name':name3})
+                        self.assertDictEqual(mount.unmounted(name3, device3,
+                                                             persist=True), ret)
+###### HERE DGM
+                    with patch.dict(mount.__opts__, {'test': False}), \
+                        patch.dict(mount.__salt__, { 'mount.umount': mock_t}):
+                            comt = ('Target was already unmounted')
+                            ret.update({'comment': comt, 'result': True, 'name': name3})
+                            self.assertDictEqual(mount.unmounted(name3, device3), ret)
 
     # 'mod_watch' function tests: 1
 


### PR DESCRIPTION
### What does this PR do?
Provides support for mount on AIX for execution modules and states

### What issues does this PR fix or reference?
https://github.com/saltstack/zh/issues/1407

### Previous Behavior
mount.active functioned on AIX

### New Behavior
Full support for mount functionality in execution modules and states on AIX

### Tests written?
Yes

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
