### PR TITLE
Use Adler32 algorithm to compute string checksums

### DIFF
--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -1200,6 +1200,10 @@ VALID_OPTS = {
 
     # Thorium top file location
     'thorium_top': six.string_types,
+
+    # Use Adler32 hashing algorithm for server_id (default False until Sodium, "adler32" after)
+    # Possible values are: False, adler32, crc32
+    'server_id_use_crc': (bool, six.string_types),
 }
 
 # default configurations

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -1508,7 +1508,8 @@ DEFAULT_MINION_OPTS = {
     },
     'discovery': False,
     'schedule': {},
-    'ssh_merge_pillar': True
+    'ssh_merge_pillar': True,
+    'server_id_use_crc': False,
 }
 
 DEFAULT_MASTER_OPTS = {

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -2684,7 +2684,12 @@ def get_server_id():
     if salt.utils.platform.is_proxy():
         server_id = {}
     else:
-        server_id = {'server_id': zlib.adler32(__opts__.get('id', '').encode()) & 0xffffffff}
+        use_crc = __opts__.get('server_id_use_crc')
+        if bool(use_crc):
+            id_hash = getattr(zlib, use_crc, zlib.adler32)(__opts__.get('id', '').encode()) & 0xffffffff
+        else:
+            id_hash = _get_hash_by_shell()
+        server_id = {'server_id': id_hash}
 
     return server_id
 

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -2659,7 +2659,7 @@ def get_server_id():
     if salt.utils.platform.is_proxy():
         server_id = {}
     else:
-        server_id = {'server_id': zlib.adler32(__opts__.get('id', '').encode())}
+        server_id = {'server_id': zlib.adler32(__opts__.get('id', '').encode()) & 0xffffffff}
 
     return server_id
 

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -55,6 +55,7 @@ import salt.utils.network
 import salt.utils.path
 import salt.utils.platform
 import salt.utils.stringutils
+import salt.utils.versions
 from salt.ext import six
 from salt.ext.six.moves import range
 
@@ -2688,6 +2689,10 @@ def get_server_id():
         if bool(use_crc):
             id_hash = getattr(zlib, use_crc, zlib.adler32)(__opts__.get('id', '').encode()) & 0xffffffff
         else:
+            salt.utils.versions.warn_until('Sodium', 'This server_id is computed nor by Adler32 neither by CRC32. '
+                                                     'Please use "server_id_use_crc" option and define algorithm you'
+                                                     'prefer (default "Adler32"). The server_id will be computed with'
+                                                     'Adler32 by default.')
             id_hash = _get_hash_by_shell()
         server_id = {'server_id': id_hash}
 


### PR DESCRIPTION
### What does this PR do?

An alternative to https://github.com/saltstack/salt/pull/46649

### Previous Behavior

`server_id` is changing due to Python 3 is salting `hash` function. A workaround is to shell-out Python with environment variable `PYTHONHASHSEED=0`. Unfortunately, this is the only option.

However, what if we use Adler-32 instead of hash? This would avoid shell-out Python.
@terminalmage what do you think?

### Tests written?

Should apply existing
