### PR TITLE
Fix parse_cookie_header function cookie name always None

### DIFF
--- a/salt/utils/http.py
+++ b/salt/utils/http.py
@@ -921,6 +921,7 @@ def parse_cookie_header(header):
         for item in list(cookie):
             if item in attribs:
                 continue
+            name = item
             value = cookie.pop(item)
 
         # cookielib.Cookie() requires an epoch


### PR DESCRIPTION
### What does this PR do?

Fix parse_cookie_header function cookie name is always None‘s bug

### Previous Behavior
parse_cookie_header function is used when backend is tornado. But cookie name is always None, because programe not set name correct value

### New Behavior

cookie name is correct value

### Tests written?

No

### Commits signed with GPG?

No
