### PR TITLE
[develop] Fluorine deprecations in cloud util (and related functions)

### DIFF
--- a/doc/topics/cloud/windows.rst
+++ b/doc/topics/cloud/windows.rst
@@ -12,7 +12,7 @@ Requirements
 
 .. note::
    Support ``winexe`` and ``impacket`` has been deprecated and will be removed in
-   Fluorine. These dependencies are replaced by ``pypsexec`` and ``smbprotocol``
+   Sodium. These dependencies are replaced by ``pypsexec`` and ``smbprotocol``
    respectivly. These are pure python alternatives that are compatible with all
    supported python versions.
 

--- a/doc/topics/releases/fluorine.rst
+++ b/doc/topics/releases/fluorine.rst
@@ -683,6 +683,11 @@ State Deprecations
 Utils Deprecations
 ------------------
 
+The ``cloud`` utils module had the following changes:
+
+- Support for the ``cache_nodes_ip`` function in :mod:`salt utils module <salt.utils.cloud>`
+  has been removed. The function was incomplete and non-functional.
+
 The ``vault`` utils module had the following changes:
 
 - Support for specifying Vault connection data within a 'profile' has been removed.

--- a/doc/topics/targeting/nodegroups.rst
+++ b/doc/topics/targeting/nodegroups.rst
@@ -64,7 +64,7 @@ To match a nodegroup on the CLI, use the ``-N`` command-line option:
 
     The ``N@`` classifier historically could not be used in compound matches
     within the CLI or :term:`top file`, it was only recognized in the
-    :conf_master:`nodegroups` master config file parameter. As of Fluorine
+    :conf_master:`nodegroups` master config file parameter. As of the Fluorine
     release, this limitation no longer exists.
 
 To match a nodegroup in your :term:`top file`, make sure to put ``- match:

--- a/salt/states/git.py
+++ b/salt/states/git.py
@@ -2701,7 +2701,7 @@ def cloned(name,
            https_pass=None,
            output_encoding=None):
     '''
-    .. versionadded:: 2018.3.3, Fluorine
+    .. versionadded:: 2018.3.3,Fluorine
 
     Ensure that a repository has been cloned to the specified target directory.
     If not, clone that repository. No fetches will be performed once cloned.

--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -1224,8 +1224,8 @@ def deploy_windows(host,
 
     if not use_winrm and has_winexe() and not HAS_PSEXEC:
         salt.utils.versions.warn_until(
-            'Fluorine',
-            'Support for winexe has been depricated and will be remove in '
+            'Sodium',
+            'Support for winexe has been deprecated and will be removed in '
             'Sodium, please install pypsexec instead.'
         )
 
@@ -2846,22 +2846,6 @@ def list_cache_nodes_full(opts=None, provider=None, base=None):
                     minions[driver][prov][minion_id] = salt.utils.data.decode(msgpack.load(fh_, encoding=MSGPACK_ENCODING))
 
     return minions
-
-
-def cache_nodes_ip(opts, base=None):
-    '''
-    Retrieve a list of all nodes from Salt Cloud cache, and any associated IP
-    addresses. Returns a dict.
-    '''
-    salt.utils.versions.warn_until(
-        'Fluorine',
-        'This function is incomplete and non-functional '
-        'and will be removed in Salt Fluorine.'
-    )
-    if base is None:
-        base = opts['cachedir']
-
-    minions = list_cache_nodes_full(opts, base=base)
 
 
 def update_bootstrap(config, url=None):

--- a/salt/utils/smb.py
+++ b/salt/utils/smb.py
@@ -179,7 +179,7 @@ def get_conn(host='', username=None, password=None, port=445):
     '''
     if HAS_IMPACKET and not HAS_SMBPROTOCOL:
         salt.utils.versions.warn_until(
-            'Fluorine',
+            'Sodium',
             'Support of impacket has been depricated and will be '
             'removed in Sodium. Please install smbprotocol instead.'
         )


### PR DESCRIPTION
Since `Fluorine` was misspelled in a couple of places and subsequently fixed, the removal of the `cache_nodes_ip` function was missed.

This PR removes the deprecated `cache_nodes_ip` function from salt.utils.cloud.

This PR also updates some of the warn_util versions to match the removal/support warning message. The `warn_util` version was set to `Fluorine`, but the "will be removed in version" message stated Sodium. Sodium is the correct version, so the docs and warn_until versions have been corrected.

Refs: #41983 and #47028