### PR TITLE
Fix salt-ssh state.sls_id TypeError key must be a string

### DIFF
--- a/salt/client/ssh/wrapper/state.py
+++ b/salt/client/ssh/wrapper/state.py
@@ -80,13 +80,13 @@ def _ssh_state(chunks, st_kwargs,
 
     # Read in the JSON data and return the data structure
     try:
-        return salt.utils.json.loads(stdout, object_hook=salt.utils.data.encode_dict)
+        return salt.utils.data.decode(salt.utils.json.loads(stdout, object_hook=salt.utils.data.encode_dict))
     except Exception as e:
         log.error("JSON Render failed for: %s\n%s", stdout, stderr)
         log.error(str(e))
 
     # If for some reason the json load fails, return the stdout
-    return stdout
+    return salt.utils.data.decode(stdout)
 
 
 def _set_retcode(ret, highstate=None):


### PR DESCRIPTION
### What does this PR do?
Currently the test `integration.ssh.test_state.SSHStateTest.test_state_sls_id ` is failing with error:

```
Traceback (most recent call last):
  File "/tmp/kitchen/testing/tests/integration/ssh/test_state.py", line 65, in test_state_sls_id
    exp_ret='The file /tmp/test is set to be changed')
  File "/tmp/kitchen/testing/tests/integration/ssh/test_state.py", line 31, in _check_dict_ret
    self.assertIsInstance(ret, dict)
AssertionError: "Target 'localhost' did not return any data, probably due to an error." is not an instance of <class 'dict'>
```

I found out its not returning any data because of this stack trace when running salt-ssh 


```
Traceback (most recent call last):
  File "/usr/lib/python3.6/multiprocessing/process.py", line 258, in _bootstrap
    self.run()
  File "/home/ch3ll/git/salt/salt/utils/process.py", line 747, in _run
    return self._original_run()
  File "/usr/lib/python3.6/multiprocessing/process.py", line 93, in run
    self._target(*self._args, **self._kwargs)
  File "/home/ch3ll/git/salt/salt/client/ssh/__init__.py", line 522, in handle_routine
    stdout, stderr, retcode = single.run()
  File "/home/ch3ll/git/salt/salt/client/ssh/__init__.py", line 995, in run
    stdout, retcode = self.run_wfunc()
  File "/home/ch3ll/git/salt/salt/client/ssh/__init__.py", line 1170, in run_wfunc
    ret = salt.utils.json.dumps({'local': {'return': result}})
  File "/home/ch3ll/git/salt/salt/utils/json.py", line 145, in dumps
    return json_module.dumps(obj, **kwargs)  # future lint: blacklisted-function
  File "/usr/lib/python3.6/json/__init__.py", line 238, in dumps
    **kw).encode(obj)
  File "/usr/lib/python3.6/json/encoder.py", line 199, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/usr/lib/python3.6/json/encoder.py", line 257, in iterencode
    return _iterencode(o, 0)
TypeError: keys must be a string
```

This is because state.sls_id is returning bytes on 2018.3 so using decode() to convert the returned dict's keys back to strings.

### What issues does this PR fix or reference?
Fixes https://github.com/saltstack/salt-jenkins/issues/1043


### Tests written?

Fixes a test

### Commits signed with GPG?

Yes