### PR TITLE
Remove deprecation warnings for "no_chown" option

### DIFF
--- a/doc/topics/releases/fluorine.rst
+++ b/doc/topics/releases/fluorine.rst
@@ -538,6 +538,11 @@ Module Deprecations
       function. This is because support for NAPALM native templates has been
       dropped.
 
+- The :py:mod:`pip <salt.modules.pip>` module has been changed as follows:
+
+    - Support for the ``no_chown`` option has been removed from
+      :py:func:`pip.install <salt.modules.pip.install>` function.
+
 - The :py:mod:`trafficserver <salt.modules.trafficserver>` module has been
   changed as follows:
 
@@ -673,9 +678,16 @@ State Deprecations
   <salt.states.netconfig.managed` state has been removed. This is because
   support for NAPALM native templates has been dropped.
 
+- Support for the ``no_chown`` option in the
+  :py:func:`pip.insalled <salt.states.pip.installed>` state has been removed.
+
 - The :py:func:`trafficserver.set_var <salt.states.trafficserver.set_var>`
   state has been removed. Please use :py:func:`trafficserver.config
   <salt.states.trafficserver.config>` instead.
+
+- Support for the ``no_chown`` option in the
+  :py:func`virtualenv.managed <salt.states.virtualenv.managed>` function has
+  been removed.
 
 - The ``win_update`` state module has been removed. It has been replaced by
   :py:mod:`win_wua <salt.states.win_wua>`.

--- a/salt/modules/pip.py
+++ b/salt/modules/pip.py
@@ -619,12 +619,6 @@ def install(pkgs=None,  # pylint: disable=R0912,R0913,R0914
                 editable=git+https://github.com/worldcompany/djangoembed.git#egg=djangoembed upgrade=True no_deps=True
 
     '''
-    if 'no_chown' in kwargs:
-        salt.utils.versions.warn_until(
-            'Fluorine',
-            'The no_chown argument has been deprecated and is no longer used. '
-            'Its functionality was removed in Boron.')
-        kwargs.pop('no_chown')
     cmd = _get_pip_bin(bin_env)
     cmd.append('install')
 

--- a/salt/modules/zfs.py
+++ b/salt/modules/zfs.py
@@ -422,7 +422,7 @@ def mount(name=None, **kwargs):
 
     .. warning::
 
-            Passing '-a' as name is deprecated and will be removed 2 verions after Fluorine.
+            Passing '-a' as name is deprecated and will be removed in Sodium.
 
     CLI Example:
 
@@ -489,7 +489,7 @@ def unmount(name, **kwargs):
 
     .. warning::
 
-            Passing '-a' as name is deprecated and will be removed 2 verions after Fluorine.
+            Passing '-a' as name is deprecated and will be removed in Sodium.
 
     CLI Example:
 
@@ -507,7 +507,7 @@ def unmount(name, **kwargs):
         flags.append('-f')
     if name in [None, '-a']:
         # NOTE: still accept '-a' as name for backwards compatibility
-        #       two versions after Fluorine this should just simplify
+        #       until Salt Sodium this should just simplify
         #       this to just set '-a' if name is not set.
         flags.append('-a')
         name = None

--- a/salt/states/pip_state.py
+++ b/salt/states/pip_state.py
@@ -594,13 +594,6 @@ def installed(name,
 
     .. _`virtualenv`: http://www.virtualenv.org/en/latest/
     '''
-    if 'no_chown' in kwargs:
-        salt.utils.versions.warn_until(
-            'Fluorine',
-            'The no_chown argument has been deprecated and is no longer used. '
-            'Its functionality was removed in Boron.')
-        kwargs.pop('no_chown')
-
     if pip_bin and not bin_env:
         bin_env = pip_bin
 

--- a/salt/states/virtualenv_mod.py
+++ b/salt/states/virtualenv_mod.py
@@ -135,13 +135,6 @@ def managed(name,
             - env_vars:
                 PATH_VAR: '/usr/local/bin/'
     '''
-    if 'no_chown' in kwargs:
-        salt.utils.versions.warn_until(
-            'Fluorine',
-            'The no_chown argument has been deprecated and is no longer used. '
-            'Its functionality was removed in Boron.')
-        kwargs.pop('no_chown')
-
     ret = {'name': name, 'result': True, 'comment': '', 'changes': {}}
 
     if 'virtualenv.create' not in __salt__:


### PR DESCRIPTION
The `no_chown` option in various functions was marked for removal in Fluorine. This PR removes those warnings and updates the release notes accordingly.

This PR also updates some of the Fluorine references in the zfs module as the documentation can be more specific.

Refs #47196