### PR TITLE
Bump deprecation in win_servermanager state to Neon

### DIFF
--- a/salt/states/win_servermanager.py
+++ b/salt/states/win_servermanager.py
@@ -115,10 +115,10 @@ def installed(name,
     '''
     if 'force' in kwargs:
         salt.utils.versions.warn_until(
-            'Fluorine',
+            'Neon',
             'Parameter \'force\' has been detected in the argument list. This'
             'parameter is no longer used and has been replaced by \'recurse\''
-            'as of Salt 2018.3.0. This warning will be removed in Salt Fluorine.'
+            'as of Salt 2018.3.0. This warning will be removed in Salt Neon.'
         )
         kwargs.pop('force')
 


### PR DESCRIPTION
The original deprecation notice says the "force" option in win_servermanager.installed will be removed in Fluorine. However, this change was recently made in 2018.3.0. We need to give 2 feature releases before removal.
