### PR TITLE
Remove deprecation warning in win_powercfg module

### DIFF
--- a/salt/modules/win_powercfg.py
+++ b/salt/modules/win_powercfg.py
@@ -19,7 +19,6 @@ import logging
 
 # Import Salt Libs
 import salt.utils.platform
-import salt.utils.versions
 
 log = logging.getLogger(__name__)
 
@@ -74,11 +73,6 @@ def _set_powercfg_value(scheme, sub_group, setting_guid, power, value):
     '''
     Sets the AC/DC values of a setting with the given power for the given scheme
     '''
-    salt.utils.versions.warn_until(
-        'Fluorine',
-        'This function now expects the timeout value in minutes instead of '
-        'seconds as stated in the documentation. This warning will be removed '
-        'in Salt Fluorine.')
     if scheme is None:
         scheme = _get_current_scheme()
 


### PR DESCRIPTION
This behavior was changed and a warning added in #48345. I didn't change anything in the release notes because it's just removing the warning. The regular docs have already been updated and earlier release notes adjusted.