### PR TITLE
[2018.3] Fixes to file.grep

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -6213,6 +6213,16 @@ def grep(path,
     '''
     path = os.path.expanduser(path)
 
+    # Backup the path in case the glob returns nothing
+    _path = path
+    path = glob.glob(path)
+
+    # If the list is empty no files exist
+    # so we revert back to the original path
+    # so the result is an error.
+    if not path:
+        path = _path
+
     split_opts = []
     for opt in opts:
         try:
@@ -6227,7 +6237,10 @@ def grep(path,
             )
         split_opts.extend(split)
 
-    cmd = ['grep'] + split_opts + [pattern, path]
+    if isinstance(path, list):
+        cmd = ['grep'] + split_opts + [pattern] + path
+    else:
+        cmd = ['grep'] + split_opts + [pattern, path]
     try:
         ret = __salt__['cmd.run_all'](cmd, python_shell=False)
     except (IOError, OSError) as exc:

--- a/tests/unit/modules/test_file.py
+++ b/tests/unit/modules/test_file.py
@@ -30,7 +30,7 @@ import salt.utils.stringutils
 import salt.modules.file as filemod
 import salt.modules.config as configmod
 import salt.modules.cmdmod as cmdmod
-from salt.exceptions import CommandExecutionError
+from salt.exceptions import CommandExecutionError, SaltInvocationError
 from salt.utils.jinja import SaltCacheLoader
 
 SED_CONTENT = '''test
@@ -522,8 +522,89 @@ class FileBlockReplaceTestCase(TestCase, LoaderModuleMockMixin):
             backup=False
         )
 
+
+class FileGrepTestCase(TestCase, LoaderModuleMockMixin):
+    def setup_loader_modules(self):
+        return {
+            filemod: {
+                '__salt__': {
+                    'config.manage_mode': configmod.manage_mode,
+                    'cmd.run': cmdmod.run,
+                    'cmd.run_all': cmdmod.run_all
+                },
+                '__opts__': {
+                    'test': False,
+                    'file_roots': {'base': 'tmp'},
+                    'pillar_roots': {'base': 'tmp'},
+                    'cachedir': 'tmp',
+                    'grains': {},
+                },
+                '__grains__': {'kernel': 'Linux'},
+                '__utils__': {'files.is_text': MagicMock(return_value=True)},
+            }
+        }
+
+    MULTILINE_STRING = textwrap.dedent('''\
+        Lorem ipsum dolor sit amet, consectetur
+        adipiscing elit. Nam rhoncus enim ac
+        bibendum vulputate.
+        ''')
+
+    MULTILINE_STRING = os.linesep.join(MULTILINE_STRING.splitlines())
+
+    def setUp(self):
+        self.tfile = tempfile.NamedTemporaryFile(delete=False, mode='w+')
+        self.tfile.write(self.MULTILINE_STRING)
+        self.tfile.close()
+
+    def tearDown(self):
+        os.remove(self.tfile.name)
+        del self.tfile
+
+    def test_grep_query_exists(self):
+        result = filemod.grep(self.tfile.name,
+                     'Lorem ipsum')
+
+        self.assertTrue(result, None)
+        self.assertTrue(result['retcode'] == 0)
+        self.assertTrue(result['stdout'] == 'Lorem ipsum dolor sit amet, consectetur')
+        self.assertTrue(result['stderr'] == '')
+
+    def test_grep_query_not_exists(self):
+        result = filemod.grep(self.tfile.name,
+                     'Lorem Lorem')
+
+        self.assertTrue(result['retcode'] == 1)
+        self.assertTrue(result['stdout'] == '')
+        self.assertTrue(result['stderr'] == '')
+
+    def test_grep_query_exists_with_opt(self):
+        result = filemod.grep(self.tfile.name,
+                     'Lorem ipsum',
+                     '-i')
+
+        self.assertTrue(result, None)
+        self.assertTrue(result['retcode'] == 0)
+        self.assertTrue(result['stdout'] == 'Lorem ipsum dolor sit amet, consectetur')
+        self.assertTrue(result['stderr'] == '')
+
+    def test_grep_query_not_exists_opt(self):
+        result = filemod.grep(self.tfile.name,
+                     'Lorem Lorem',
+                     '-v')
+
+        self.assertTrue(result['retcode'] == 0)
+        self.assertTrue(result['stdout'] == FileGrepTestCase.MULTILINE_STRING)
+        self.assertTrue(result['stderr'] == '')
+
+    def test_grep_query_too_many_opts(self):
+        with self.assertRaisesRegex(SaltInvocationError, '^Passing multiple command line arg') as cm:
+            result = filemod.grep(self.tfile.name,
+                                  'Lorem Lorem',
+                                  '-i -b2')
+
     def test_grep_query_exists_wildcard(self):
-        _file = '{0}-junk*'.format(self.tfile.name)
+        _file = '{0}*'.format(self.tfile.name)
         result = filemod.grep(_file,
                      'Lorem ipsum')
 

--- a/tests/unit/modules/test_file.py
+++ b/tests/unit/modules/test_file.py
@@ -522,6 +522,27 @@ class FileBlockReplaceTestCase(TestCase, LoaderModuleMockMixin):
             backup=False
         )
 
+    def test_grep_query_exists_wildcard(self):
+        _file = '{0}-junk*'.format(self.tfile.name)
+        result = filemod.grep(_file,
+                     'Lorem ipsum')
+
+        self.assertTrue(result, None)
+        self.assertTrue(result['retcode'] == 0)
+        self.assertTrue(result['stdout'] == 'Lorem ipsum dolor sit amet, consectetur')
+        self.assertTrue(result['stderr'] == '')
+
+    def test_grep_file_not_exists_wildcard(self):
+        _file = '{0}-junk*'.format(self.tfile.name)
+        result = filemod.grep(_file,
+                     'Lorem ipsum')
+
+        self.assertTrue(result, None)
+        self.assertFalse(result['retcode'] == 0)
+        self.assertFalse(result['stdout'] == 'Lorem ipsum dolor sit amet, consectetur')
+        _expected_stderr = 'grep: {0}-junk*: No such file or directory'.format(self.tfile.name)
+        self.assertTrue(result['stderr'] == _expected_stderr)
+
 
 class FileModuleTestCase(TestCase, LoaderModuleMockMixin):
     def setup_loader_modules(self):


### PR DESCRIPTION
### What does this PR do?
Fixing a bug that prevents specifying wildcards for filenames.

### What issues does this PR fix or reference?
#48659 

### Previous Behavior
When including a wildcard in the path for file.grep, the path is not being expanded because python_shell is set to False.

### New Behavior
Updating file.grep to use glob.glob on the path to gather a list of potential files, then pass that list along to cmd.run_all.  If the glob results in an empty list then pass along the original path string to report the error properly.

### Tests written?
Yes

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
