### PR TITLE
Changed Solaris default for disk.usage to 1 K blocks

### DIFF
--- a/salt/modules/disk.py
+++ b/salt/modules/disk.py
@@ -85,6 +85,10 @@ def usage(args=None):
     '''
     Return usage information for volumes mounted on this minion
 
+    .. versionchanged:: Fluorine
+
+        Default for SunOS changed to 1 kilobyte blocks
+
     CLI Example:
 
     .. code-block:: bash
@@ -103,6 +107,8 @@ def usage(args=None):
         cmd = 'df -P'
     elif __grains__['kernel'] == 'OpenBSD' or __grains__['kernel'] == 'AIX':
         cmd = 'df -kP'
+    elif __grains__['kernel'] == 'SunOS':
+        cmd = 'df -k'
     else:
         cmd = 'df'
     if flags:


### PR DESCRIPTION
### What does this PR do?
Changes the default for Solaris disk.usage output to 1K Blocks rather than bytes

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/48427

### Previous Behavior
Previously on Solaris, disk.usage was output in bytes.  However this is now proving to be problematic with larger disk sizes causing fields to run up against each other, resulting parsing errors.  Simple solution and requested by customer is to output in 1K blocks, that is, df -k as the default.

### New Behavior
Output of disk.usage for Solaris is output in 1K blocks, rather than bytes.

### Tests written?
No, tested by hand.

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
