### PR TITLE
Fix unicode directory listing on py2

### DIFF
--- a/salt/utils/path.py
+++ b/salt/utils/path.py
@@ -406,8 +406,9 @@ def os_walk(top, *args, **kwargs):
     This is a helper than ensures that all paths returned from os.walk are
     unicode.
     '''
-    top_query = salt.utils.stringutils.to_str(top)
-    if salt.utils.platform.is_windows() and six.PY2:
+    if six.PY2 and salt.utils.platform.is_windows():
         top_query = top
+    else:
+        top_query = salt.utils.stringutils.to_str(top)
     for item in os.walk(top_query, *args, **kwargs):
         yield salt.utils.data.decode(item, preserve_tuples=True)

--- a/salt/utils/path.py
+++ b/salt/utils/path.py
@@ -406,5 +406,8 @@ def os_walk(top, *args, **kwargs):
     This is a helper than ensures that all paths returned from os.walk are
     unicode.
     '''
-    for item in os.walk(salt.utils.stringutils.to_str(top), *args, **kwargs):
+    top_query = salt.utils.stringutils.to_str(top)
+    if salt.utils.platform.is_windows() and six.PY2:
+        top_query = top
+    for item in os.walk(top_query, *args, **kwargs):
         yield salt.utils.data.decode(item, preserve_tuples=True)


### PR DESCRIPTION
### What does this PR do?

Fix unicode directory listing on py2 after upstream fixes.

https://github.com/WinRb/winrm-fs/pull/67

The combination of the above and this change allow our window fileserver roots tests to pass on both python 2 and python 3. This change is needed to work around python 2's encoding limitations on windows.

I think this might be related too and/or fix:

https://github.com/saltstack/salt/issues/41018

### Tests written?

No - Fixing existing tests

### Commits signed with GPG?

Yes