### PR TITLE
Check file_recv_max_size early

### DIFF
--- a/salt/daemons/masterapi.py
+++ b/salt/daemons/masterapi.py
@@ -661,6 +661,13 @@ class RemoteFuncs(object):
             log.error('Invalid file pointer: load[loc] < 0')
             return False
 
+        if 'size' in load and load['size'] > file_recv_max_size:
+            log.error(
+                'Exceeding file_recv_max_size limit: %s',
+                file_recv_max_size
+            )
+            return False
+
         if len(load['data']) + load.get('loc', 0) > file_recv_max_size:
             log.error(
                 'Exceeding file_recv_max_size limit: %s',

--- a/salt/daemons/masterapi.py
+++ b/salt/daemons/masterapi.py
@@ -661,7 +661,7 @@ class RemoteFuncs(object):
             log.error('Invalid file pointer: load[loc] < 0')
             return False
 
-        if 'size' in load and load['size'] > file_recv_max_size:
+        if load.get('size', 0) > file_recv_max_size:
             log.error(
                 'Exceeding file_recv_max_size limit: %s',
                 file_recv_max_size

--- a/salt/modules/cp.py
+++ b/salt/modules/cp.py
@@ -812,6 +812,7 @@ def push(path, keep_symlinks=False, upload_path=None, remove_source=False):
     load = {'cmd': '_file_recv',
             'id': __opts__['id'],
             'path': load_path_list,
+            'size': os.path.getsize(path),
             'tok': auth.gen_token(b'salt')}
     channel = salt.transport.Channel.factory(__opts__)
     with salt.utils.files.fopen(path, 'rb') as fp_:

--- a/tests/unit/modules/test_cp.py
+++ b/tests/unit/modules/test_cp.py
@@ -137,6 +137,8 @@ class CpTestCase(TestCase, LoaderModuleMockMixin):
             filename = 'c:\\saltines\\test.file'
         with patch('salt.modules.cp.os.path',
                    MagicMock(isfile=Mock(return_value=True), wraps=cp.os.path)), \
+                patch('salt.modules.cp.os.path',
+                      MagicMock(getsize=MagicMock(return_value=10), wraps=cp.os.path)), \
                 patch.multiple('salt.modules.cp',
                                _auth=MagicMock(**{'return_value.gen_token.return_value': 'token'}),
                                __opts__={'id': 'abc', 'file_buffer_size': 10}), \

--- a/tests/unit/modules/test_cp.py
+++ b/tests/unit/modules/test_cp.py
@@ -156,6 +156,7 @@ class CpTestCase(TestCase, LoaderModuleMockMixin):
                     cmd='_file_recv',
                     tok='token',
                     path=['saltines', 'test.file'],
+                    size=10,
                     data=b'',  # data is empty here because load['data'] is overwritten
                     id='abc'
                 )


### PR DESCRIPTION
### What does this PR do?
Check size of the file transferred by cp.push early, preventing transferring files that exceeds file_recv_max_size

### What issues does this PR fix or reference?
None

### Previous Behavior
Current behaviour of cp.push is that salt master checks file_recv_max_size
during file transfer process. Given that by default this limit is
about 100MB if we try to send 101MB then 100MB would be sent anyway,
and only after that master interrupts the transfer. Such useless
transfers should be avoided.

### New Behavior
This commit adds additional field 'size' to 'load' structure that
minion sends to master, transfrerring file size in every message,
so that master can check the size recieving just the first chunk
of data, saving the queue bandwith.

### Tests written?

No

### Commits signed with GPG?

No