### PR TITLE
Fixed: added additional return code 200 for succeeded vault api request

### DIFF
--- a/salt/states/vault.py
+++ b/salt/states/vault.py
@@ -73,7 +73,7 @@ def _create_new_policy(name, rules):
     payload = {'rules': rules}
     url = "v1/sys/policy/{0}".format(name)
     response = __utils__['vault.make_request']('PUT', url, json=payload)
-    if response.status_code != 204:
+    if response.status_code not in [200, 204]:
         return {
             'name': name,
             'changes': {},
@@ -108,7 +108,7 @@ def _handle_existing_policy(name, new_rules, existing_rules):
 
     url = "v1/sys/policy/{0}".format(name)
     response = __utils__['vault.make_request']('PUT', url, json=payload)
-    if response.status_code != 204:
+    if response.status_code not in [200, 204]:
         return {
             'name': name,
             'changes': {},


### PR DESCRIPTION
### What does this PR do?
Adds an additional successful return code from the Vault API. The API also responses with HTTP code 200 when the request for changes is successful, not only 204. 

### What issues does this PR fix or reference?
The vault.policy_preset state returns failed status even if the API request is succeeded. 

### Previous Behavior
vault.policy_preset state returns a failed status even if the API request is succeeded.

### New Behavior
vault.policy_preset state returns a success status due to a succeeded API request.

### Tests written?

No

### Commits signed with GPG?

No