### PR TITLE
Fixed Python 3 incompatibility in methods in nilrt_ip and debian_ip.

### DIFF
--- a/salt/modules/debian_ip.py
+++ b/salt/modules/debian_ip.py
@@ -391,20 +391,14 @@ def __within(within=None, errmsg=None, dtype=None):
 
 def __space_delimited_list(value):
     '''validate that a value contains one or more space-delimited values'''
-    valid, _value, errmsg = False, value, 'space-delimited string'
-    try:
-        if hasattr(value, '__iter__'):
-            valid = True  # TODO:
-        else:
-            _value = value.split()
-            if _value == []:
-                raise ValueError
-            valid = True
-    except AttributeError:
-        pass
-    except ValueError:
-        pass
-    return (valid, _value, errmsg)
+    if isinstance(value, str):
+        value = value.strip().split()
+
+    if hasattr(value, '__iter__') and value != []:
+        return (True, value, 'space-delimited string')
+    else:
+        return (False, value, '{0} is not a valid space-delimited value.\n'.format(value))
+
 
 SALT_ATTR_TO_DEBIAN_ATTR_MAP = {
     'dns': 'dns-nameservers',

--- a/salt/modules/nilrt_ip.py
+++ b/salt/modules/nilrt_ip.py
@@ -99,20 +99,16 @@ def _space_delimited_list(value):
     '''
     validate that a value contains one or more space-delimited values
     '''
-    valid, _value, errmsg = False, value, 'space-delimited string'
-    try:
-        if hasattr(value, '__iter__'):
-            valid = True
-        else:
-            _value = value.split()
-            if _value == []:
-                raise ValueError
-            valid = True
-    except AttributeError:
-        errmsg = '{0} is not a valid list.\n'.format(value)
-    except ValueError:
-        errmsg = '{0} is not a valid list.\n'.format(value)
-    return (valid, errmsg)
+    if isinstance(value, str):
+        items = value.split(' ')
+        valid = items and all(items)
+    else:
+        valid = hasattr(value, '__iter__') and (value != [])
+
+    if valid:
+        return (True, 'space-delimited string')
+    else:
+        return (False, '{0} is not a valid list.\n'.format(value))
 
 
 def _validate_ipv4(value):


### PR DESCRIPTION
### What does this PR do?
The fixed the methods parsing network interface settings which are space-delimited. The previous implementations used the `__iter__` attribute to detect whether or not the given value is a string. This breaks in Python 3, since they made the strings iterable.

### What issues does this PR fix or reference?
When executing something like:
```bash
salt 'minion' ip.get_interface br1
```

The result when using Python 3 was:
```yaml
minion:
    - auto br1
    - iface br1 inet static
    -     address 10.0.0.1
    -     netmask 255.255.0.0
    -     broadcast 10.0.255.255
    -     dns-nameservers x x x . x x . 2 . 4   x x x . x x . 2 . 5 
    -     bridge_ports none
    - 
```
Note the extra spaces in the dns-nameservers. This PR should remove those spaces under Python 3, (hopefully) without breaking Python 2.

### Previous Behavior
See previous section.

### New Behavior
Now when executing:
```bash
salt 'minion' ip.get_interface br1
```

The following result will be returned:
```yaml
minion:
    - auto br1
    - iface br1 inet static
    -     address 10.0.0.1
    -     netmask 255.255.0.0
    -     broadcast 10.0.255.255
    -     dns-nameservers xxx.xx.2.4 xxx.xx.2.5
    -     bridge_ports none
    - 
```

### Tests written?

No

### Commits signed with GPG?

No
