### PR TITLE
Fix doc for renamed execution module

### DIFF
--- a/doc/ref/modules/all/index.rst
+++ b/doc/ref/modules/all/index.rst
@@ -271,9 +271,9 @@ execution modules
     namecheap_ns
     namecheap_ssl
     namecheap_users
-    napalm
     napalm_acl
     napalm_bgp
+    napalm_mod
     napalm_network
     napalm_ntp
     napalm_probes

--- a/doc/ref/modules/all/salt.modules.napalm_mod.rst
+++ b/doc/ref/modules/all/salt.modules.napalm_mod.rst
@@ -2,6 +2,6 @@
 salt.modules.napalm module
 ==========================
 
-.. automodule:: salt.modules.napalm
+.. automodule:: salt.modules.napalm_mod
     :members:
 


### PR DESCRIPTION
### What does this PR do?

In one of my previous Pull Requests, I've renamed the `napalm.py` module to `napalm_mod.py` (the virtual name is still `napalm`), though I forgot to update the autoconf doc which caused https://docs.saltstack.com/en/develop/ref/modules/all/salt.modules.napalm.html to become outdated.