### PR TITLE
Skip tests in integration.shell.test_master

### DIFF
--- a/tests/integration/shell/test_master.py
+++ b/tests/integration/shell/test_master.py
@@ -22,9 +22,11 @@ import tests.integration.utils
 from tests.support.case import ShellCase
 from tests.support.paths import TMP
 from tests.support.mixins import ShellCaseCommonTestsMixin
+from tests.support.unit import skipIf
 from tests.integration.utils import testprogram
 
 
+@skipIf(True, 'This test file should be in an isolated test space.')
 class MasterTest(ShellCase, testprogram.TestProgramCase, ShellCaseCommonTestsMixin):
 
     _call_binary_ = 'salt-master'


### PR DESCRIPTION
Related to https://github.com/saltstack/salt-jenkins/issues/378

This is likely causing all of the flakiness we're seeing on test runs when the master stops responding.

These tests should be in their own, isolated run, rather than with the rest of the test suite.