### PR TITLE
 Add module for Cisco IOS configuration manipulation 

### DIFF
--- a/doc/ref/modules/all/index.rst
+++ b/doc/ref/modules/all/index.rst
@@ -187,6 +187,7 @@ execution modules
     inspectlib.query
     inspector
     introspect
+    iosconfig
     ipmi
     ipset
     iptables

--- a/doc/ref/modules/all/salt.modules.iosconfig.rst
+++ b/doc/ref/modules/all/salt.modules.iosconfig.rst
@@ -1,0 +1,7 @@
+=============================
+salt.modules.iosconfig module
+=============================
+
+.. automodule:: salt.modules.iosconfig
+    :members:
+

--- a/salt/modules/iosconfig.py
+++ b/salt/modules/iosconfig.py
@@ -1,0 +1,452 @@
+# -*- coding: utf-8 -*-
+'''
+Cisco IOS configuration manipulation helpers
+
+.. versionadded:: Fluorine
+
+This module provides a collection of helper functions for Cisco IOS style
+configuration manipulation. This module does not have external dependencies
+and can be used from any Proxy or regular Minion.
+'''
+# Import Python Libs
+from __future__ import absolute_import, unicode_literals, print_function
+
+# Import python stdlib
+import difflib
+from collections import OrderedDict
+
+# Import Salt modules
+from salt.ext import six
+import salt.utils.dictupdate
+import salt.utils.dictdiffer
+from salt.exceptions import SaltException
+
+# ------------------------------------------------------------------------------
+# module properties
+# ------------------------------------------------------------------------------
+
+__virtualname__ = 'iosconfig'
+__proxyenabled__ = ['*']
+
+# ------------------------------------------------------------------------------
+# helper functions -- will not be exported
+# ------------------------------------------------------------------------------
+
+
+def _attach_data_to_path(obj, ele, data):
+    if ele not in obj:
+        obj[ele] = OrderedDict()
+        obj[ele] = data
+    else:
+        obj[ele].update(data)
+
+
+def _attach_data_to_path_tags(obj, path, data, list_=False):
+    if "#list" not in obj:
+        obj["#list"] = []
+    path = [path]
+    obj_tmp = obj
+    first = True
+    while True:
+        obj_tmp["#text"] = " ".join(path)
+        path_item = path.pop(0)
+        if not path:
+            break
+        else:
+            if path_item not in obj_tmp:
+                obj_tmp[path_item] = OrderedDict()
+            obj_tmp = obj_tmp[path_item]
+
+            if first and list_:
+                obj["#list"].append({path_item: obj_tmp})
+                first = False
+    if path_item in obj_tmp:
+        obj_tmp[path_item].update(data)
+    else:
+        obj_tmp[path_item] = data
+    obj_tmp[path_item]["#standalone"] = True
+
+
+def _parse_text_config(config_lines,
+                       with_tags=False,
+                       current_indent=0,
+                       nested=False):
+    struct_cfg = OrderedDict()
+    while config_lines:
+        line = config_lines.pop(0)
+        if not line.strip() or line.lstrip().startswith('!'):
+            # empty or comment
+            continue
+        current_line = line.lstrip()
+        leading_spaces = len(line) - len(current_line)
+        if leading_spaces > current_indent:
+            current_block = _parse_text_config(config_lines,
+                                               current_indent=leading_spaces,
+                                               with_tags=with_tags,
+                                               nested=True)
+            if with_tags:
+                _attach_data_to_path_tags(struct_cfg,
+                                          current_line,
+                                          current_block,
+                                          nested)
+            else:
+                _attach_data_to_path(struct_cfg, current_line, current_block)
+        elif leading_spaces < current_indent:
+            config_lines.insert(0, line)
+            break
+        else:
+            if not nested:
+                current_block = _parse_text_config(config_lines,
+                                                   current_indent=leading_spaces,
+                                                   with_tags=with_tags,
+                                                   nested=True)
+                if with_tags:
+                    _attach_data_to_path_tags(struct_cfg,
+                                              current_line,
+                                              current_block,
+                                              nested)
+                else:
+                    _attach_data_to_path(struct_cfg, current_line, current_block)
+            else:
+                config_lines.insert(0, line)
+                break
+    return struct_cfg
+
+
+def _get_diff_text(old, new):
+    '''
+    Returns the diff of two text blobs.
+    '''
+    diff = difflib.unified_diff(old.splitlines(1),
+                                new.splitlines(1))
+    return ''.join([x.replace('\r', '') for x in diff])
+
+
+def _print_config_text(tree, indentation=0):
+    '''
+    Return the config as text from a config tree.
+    '''
+    config = ''
+    for key, value in six.iteritems(tree):
+        config += '{indent}{line}\n'.format(indent=' '*indentation, line=key)
+        if value:
+            config += _print_config_text(value, indentation=indentation+1)
+    return config
+
+# ------------------------------------------------------------------------------
+# callable functions
+# ------------------------------------------------------------------------------
+
+
+def tree(config=None,
+         path=None,
+         with_tags=False,
+         saltenv='base'):
+    '''
+    Transform Cisco IOS style configuration to structured Python dictionary.
+    Depending on the value of the ``with_tags`` argument, this function may
+    provide different views, valuable in different situations.
+
+    config
+        The configuration sent as text. This argument is ignored when ``path``
+        is configured.
+
+    path
+        Absolute or remote path from where to load the configuration text. This
+        argument allows any URI supported by
+        :py:func:`cp.get_url <salt.modules.cp.get_url>`), e.g., ``salt://``,
+        ``https://``, ``s3://``, ``ftp:/``, etc.
+
+    with_tags: ``False``
+        Whether this function should return a detailed view, with tags.
+
+    saltenv: ``base``
+        Salt fileserver environment from which to retrieve the file.
+        Ignored if ``path`` is not a ``salt://`` URL.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' iosconfig.tree path=salt://path/to/my/config.txt
+        salt '*' iosconfig.tree path=https://bit.ly/2mAdq7z
+    '''
+    if path:
+        config = __salt__['cp.get_file_str'](path, saltenv=saltenv)
+        if config is False:
+            raise SaltException('{} is not available'.format(path))
+    config_lines = config.splitlines()
+    return _parse_text_config(config_lines, with_tags=with_tags)
+
+
+def clean(config=None, path=None, saltenv='base'):
+    '''
+    Return a clean version of the config, without any special signs (such as
+    ``!`` as an individual line) or empty lines, but just lines with significant
+    value in the configuration of the network device.
+
+    config
+        The configuration sent as text. This argument is ignored when ``path``
+        is configured.
+
+    path
+        Absolute or remote path from where to load the configuration text. This
+        argument allows any URI supported by
+        :py:func:`cp.get_url <salt.modules.cp.get_url>`), e.g., ``salt://``,
+        ``https://``, ``s3://``, ``ftp:/``, etc.
+
+    saltenv: ``base``
+        Salt fileserver environment from which to retrieve the file.
+        Ignored if ``path`` is not a ``salt://`` URL.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' iosconfig.clean path=salt://path/to/my/config.txt
+        salt '*' iosconfig.clean path=https://bit.ly/2mAdq7z
+    '''
+    config_tree = tree(config=config, path=path, saltenv=saltenv)
+    return _print_config_text(config_tree)
+
+
+def merge_tree(initial_config=None,
+               initial_path=None,
+               merge_config=None,
+               merge_path=None,
+               saltenv='base'):
+    '''
+    Return the merge tree of the ``initial_config`` with the ``merge_config``,
+    as a Python dictionary.
+
+    initial_config
+        The initial configuration sent as text. This argument is ignored when
+        ``initial_path`` is set.
+
+    initial_path
+        Absolute or remote path from where to load the initial configuration
+        text. This argument allows any URI supported by
+        :py:func:`cp.get_url <salt.modules.cp.get_url>`), e.g., ``salt://``,
+        ``https://``, ``s3://``, ``ftp:/``, etc.
+
+    merge_config
+        The config to be merged into the initial config, sent as text. This
+        argument is ignored when ``merge_path`` is set.
+
+    merge_path
+        Absolute or remote path from where to load the merge configuration
+        text. This argument allows any URI supported by
+        :py:func:`cp.get_url <salt.modules.cp.get_url>`), e.g., ``salt://``,
+        ``https://``, ``s3://``, ``ftp:/``, etc.
+
+    saltenv: ``base``
+        Salt fileserver environment from which to retrieve the file.
+        Ignored if ``initial_path`` or ``merge_path`` is not a ``salt://`` URL.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' iosconfig.merge_tree initial_path=salt://path/to/running.cfg merge_path=salt://path/to/merge.cfg
+    '''
+    merge_tree = tree(config=merge_config,
+                      path=merge_path,
+                      saltenv=saltenv)
+    initial_tree = tree(config=initial_config,
+                        path=initial_path,
+                        saltenv=saltenv)
+    return salt.utils.dictupdate.merge(initial_tree, merge_tree)
+
+
+def merge_text(initial_config=None,
+               initial_path=None,
+               merge_config=None,
+               merge_path=None,
+               saltenv='base'):
+    '''
+    Return the merge result of the ``initial_config`` with the ``merge_config``,
+    as plain text.
+
+    initial_config
+        The initial configuration sent as text. This argument is ignored when
+        ``initial_path`` is set.
+
+    initial_path
+        Absolute or remote path from where to load the initial configuration
+        text. This argument allows any URI supported by
+        :py:func:`cp.get_url <salt.modules.cp.get_url>`), e.g., ``salt://``,
+        ``https://``, ``s3://``, ``ftp:/``, etc.
+
+    merge_config
+        The config to be merged into the initial config, sent as text. This
+        argument is ignored when ``merge_path`` is set.
+
+    merge_path
+        Absolute or remote path from where to load the merge configuration
+        text. This argument allows any URI supported by
+        :py:func:`cp.get_url <salt.modules.cp.get_url>`), e.g., ``salt://``,
+        ``https://``, ``s3://``, ``ftp:/``, etc.
+
+    saltenv: ``base``
+        Salt fileserver environment from which to retrieve the file.
+        Ignored if ``initial_path`` or ``merge_path`` is not a ``salt://`` URL.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' iosconfig.merge_text initial_path=salt://path/to/running.cfg merge_path=salt://path/to/merge.cfg
+    '''
+    candidate_tree = merge_tree(initial_config=initial_config,
+                                initial_path=initial_path,
+                                merge_config=merge_config,
+                                merge_path=merge_path,
+                                saltenv=saltenv)
+    return _print_config_text(candidate_tree)
+
+
+def merge_diff(initial_config=None,
+               initial_path=None,
+               merge_config=None,
+               merge_path=None,
+               saltenv='base'):
+    '''
+    Return the merge diff, as text, after merging the merge config into the
+    initial config.
+
+    initial_config
+        The initial configuration sent as text. This argument is ignored when
+        ``initial_path`` is set.
+
+    initial_path
+        Absolute or remote path from where to load the initial configuration
+        text. This argument allows any URI supported by
+        :py:func:`cp.get_url <salt.modules.cp.get_url>`), e.g., ``salt://``,
+        ``https://``, ``s3://``, ``ftp:/``, etc.
+
+    merge_config
+        The config to be merged into the initial config, sent as text. This
+        argument is ignored when ``merge_path`` is set.
+
+    merge_path
+        Absolute or remote path from where to load the merge configuration
+        text. This argument allows any URI supported by
+        :py:func:`cp.get_url <salt.modules.cp.get_url>`), e.g., ``salt://``,
+        ``https://``, ``s3://``, ``ftp:/``, etc.
+
+    saltenv: ``base``
+        Salt fileserver environment from which to retrieve the file.
+        Ignored if ``initial_path`` or ``merge_path`` is not a ``salt://`` URL.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' iosconfig.merge_diff initial_path=salt://path/to/running.cfg merge_path=salt://path/to/merge.cfg
+    '''
+    if initial_path:
+        initial_config = __salt__['cp.get_file_str'](initial_path, saltenv=saltenv)
+    candidate_config = merge_text(initial_config=initial_config,
+                                  merge_config=merge_config,
+                                  merge_path=merge_path,
+                                  saltenv=saltenv)
+    clean_running_dict = tree(config=initial_config)
+    clean_running = _print_config_text(clean_running_dict)
+    return _get_diff_text(clean_running, candidate_config)
+
+
+def diff_tree(candidate_config=None,
+              candidate_path=None,
+              running_config=None,
+              running_path=None,
+              saltenv='base'):
+    '''
+    Return the diff, as Python dictionary, between the candidate and the running
+    configuration.
+
+    candidate_config
+        The candidate configuration sent as text. This argument is ignored when
+        ``candidate_path`` is set.
+
+    candidate_path
+        Absolute or remote path from where to load the candidate configuration
+        text. This argument allows any URI supported by
+        :py:func:`cp.get_url <salt.modules.cp.get_url>`), e.g., ``salt://``,
+        ``https://``, ``s3://``, ``ftp:/``, etc.
+
+    running_config
+        The running configuration sent as text. This argument is ignored when
+        ``running_path`` is set.
+
+    running_path
+        Absolute or remote path from where to load the runing configuration
+        text. This argument allows any URI supported by
+        :py:func:`cp.get_url <salt.modules.cp.get_url>`), e.g., ``salt://``,
+        ``https://``, ``s3://``, ``ftp:/``, etc.
+
+    saltenv: ``base``
+        Salt fileserver environment from which to retrieve the file.
+        Ignored if ``candidate_path`` or ``running_path`` is not a
+        ``salt://`` URL.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' iosconfig.diff_tree candidate_path=salt://path/to/candidate.cfg running_path=salt://path/to/running.cfg
+    '''
+    candidate_tree = tree(config=candidate_config,
+                          path=candidate_path,
+                          saltenv=saltenv)
+    running_tree = tree(config=running_config,
+                        path=running_path,
+                        saltenv=saltenv)
+    return salt.utils.dictdiffer.deep_diff(running_tree, candidate_tree)
+
+
+def diff_text(candidate_config=None,
+              candidate_path=None,
+              running_config=None,
+              running_path=None,
+              saltenv='base'):
+    '''
+    Return the diff, as text, between the candidate and the running config.
+
+    candidate_config
+        The candidate configuration sent as text. This argument is ignored when
+        ``candidate_path`` is set.
+
+    candidate_path
+        Absolute or remote path from where to load the candidate configuration
+        text. This argument allows any URI supported by
+        :py:func:`cp.get_url <salt.modules.cp.get_url>`), e.g., ``salt://``,
+        ``https://``, ``s3://``, ``ftp:/``, etc.
+
+    running_config
+        The running configuration sent as text. This argument is ignored when
+        ``running_path`` is set.
+
+    running_path
+        Absolute or remote path from where to load the runing configuration
+        text. This argument allows any URI supported by
+        :py:func:`cp.get_url <salt.modules.cp.get_url>`), e.g., ``salt://``,
+        ``https://``, ``s3://``, ``ftp:/``, etc.
+
+    saltenv: ``base``
+        Salt fileserver environment from which to retrieve the file.
+        Ignored if ``candidate_path`` or ``running_path`` is not a
+        ``salt://`` URL.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' iosconfig.diff_text candidate_path=salt://path/to/candidate.cfg running_path=salt://path/to/running.cfg
+    '''
+    candidate_text = clean(config=candidate_config,
+                           path=candidate_path,
+                           saltenv=saltenv)
+    running_text = clean(config=running_config,
+                         path=running_path,
+                         saltenv=saltenv)
+    return _get_diff_text(running_text, candidate_text)

--- a/salt/modules/iosconfig.py
+++ b/salt/modules/iosconfig.py
@@ -13,12 +13,12 @@ from __future__ import absolute_import, unicode_literals, print_function
 
 # Import python stdlib
 import difflib
-from collections import OrderedDict
 
 # Import Salt modules
 from salt.ext import six
 import salt.utils.dictupdate
 import salt.utils.dictdiffer
+from salt.utils.odict import OrderedDict
 from salt.exceptions import SaltException
 
 # ------------------------------------------------------------------------------

--- a/salt/modules/napalm_mod.py
+++ b/salt/modules/napalm_mod.py
@@ -12,7 +12,6 @@ from __future__ import absolute_import, unicode_literals, print_function
 # Import python stdlib
 import inspect
 import logging
-log = logging.getLogger(__file__)
 
 # import NAPALM utils
 import salt.utils.napalm
@@ -22,6 +21,7 @@ from salt.utils.napalm import proxy_napalm_wrap
 from salt.ext import six
 from salt.utils.decorators import depends
 from salt.exceptions import CommandExecutionError
+
 try:
     from netmiko import BaseConnection
     HAS_NETMIKO = True
@@ -53,6 +53,8 @@ except ImportError:
 __virtualname__ = 'napalm'
 __proxyenabled__ = ['napalm']
 # uses NAPALM-based proxy to interact with network devices
+
+log = logging.getLogger(__file__)
 
 # ----------------------------------------------------------------------------------------------------------------------
 # property functions
@@ -1446,3 +1448,271 @@ def config_filter_lines(parent_regex, child_regex, source='running'):
     return __salt__['ciscoconfparse.filter_lines'](config=config_txt,
                                                    parent_regex=parent_regex,
                                                    child_regex=child_regex)
+
+
+def config_tree(source='running', with_tags=False):
+    '''
+    .. versionadded:: Fluorine
+
+    Transform Cisco IOS style configuration to structured Python dictionary.
+    Depending on the value of the ``with_tags`` argument, this function may
+    provide different views, valuable in different situations.
+
+    source: ``running``
+        The configuration type to retrieve from the network device. Default:
+        ``running``. Available options: ``running``, ``startup``, ``candidate``.
+
+    with_tags: ``False``
+        Whether this function should return a detailed view, with tags.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' napalm.config_tree
+    '''
+    config_txt = __salt__['net.config'](source=source)['out'][source]
+    return __salt__['iosconfig.tree'](config=config_txt)
+
+
+def config_merge_tree(source='running',
+                      merge_config=None,
+                      merge_path=None,
+                      saltenv='base'):
+    '''
+    .. versionadded:: Fluorine
+
+    Return the merge tree of the ``initial_config`` with the ``merge_config``,
+    as a Python dictionary.
+
+    source: ``running``
+        The configuration type to retrieve from the network device. Default:
+        ``running``. Available options: ``running``, ``startup``, ``candidate``.
+
+    merge_config
+        The config to be merged into the initial config, sent as text. This
+        argument is ignored when ``merge_path`` is set.
+
+    merge_path
+        Absolute or remote path from where to load the merge configuration
+        text. This argument allows any URI supported by
+        :py:func:`cp.get_url <salt.modules.cp.get_url>`), e.g., ``salt://``,
+        ``https://``, ``s3://``, ``ftp:/``, etc.
+
+    saltenv: ``base``
+        Salt fileserver environment from which to retrieve the file.
+        Ignored if ``merge_path`` is not a ``salt://`` URL.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' napalm.config_merge_tree merge_path=salt://path/to/merge.cfg
+    '''
+    config_txt = __salt__['net.config'](source=source)['out'][source]
+    return __salt__['iosconfig.merge_tree'](initial_config=config_txt,
+                                            merge_config=merge_config,
+                                            merge_path=merge_path,
+                                            saltenv=saltenv)
+
+
+def config_merge_text(source='running',
+                      merge_config=None,
+                      merge_path=None,
+                      saltenv='base'):
+    '''
+    .. versionadded:: Fluorine
+
+    Return the merge result of the configuration from ``source`` with the
+    merge configuration, as plain text (without loading the config on the
+    device).
+
+    source: ``running``
+        The configuration type to retrieve from the network device. Default:
+        ``running``. Available options: ``running``, ``startup``, ``candidate``.
+
+    merge_config
+        The config to be merged into the initial config, sent as text. This
+        argument is ignored when ``merge_path`` is set.
+
+    merge_path
+        Absolute or remote path from where to load the merge configuration
+        text. This argument allows any URI supported by
+        :py:func:`cp.get_url <salt.modules.cp.get_url>`), e.g., ``salt://``,
+        ``https://``, ``s3://``, ``ftp:/``, etc.
+
+    saltenv: ``base``
+        Salt fileserver environment from which to retrieve the file.
+        Ignored if ``merge_path`` is not a ``salt://`` URL.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' napalm.config_merge_text merge_path=salt://path/to/merge.cfg
+    '''
+    config_txt = __salt__['net.config'](source=source)['out'][source]
+    return __salt__['iosconfig.merge_text'](initial_config=config_txt,
+                                            merge_config=merge_config,
+                                            merge_path=merge_path,
+                                            saltenv=saltenv)
+
+
+def config_merge_diff(source='running',
+                      merge_config=None,
+                      merge_path=None,
+                      saltenv='base'):
+    '''
+    .. versionadded:: Fluorine
+
+    Return the merge diff, as text, after merging the merge config into the
+    configuration source requested (without loading the config on the device).
+
+    source: ``running``
+        The configuration type to retrieve from the network device. Default:
+        ``running``. Available options: ``running``, ``startup``, ``candidate``.
+
+    merge_config
+        The config to be merged into the initial config, sent as text. This
+        argument is ignored when ``merge_path`` is set.
+
+    merge_path
+        Absolute or remote path from where to load the merge configuration
+        text. This argument allows any URI supported by
+        :py:func:`cp.get_url <salt.modules.cp.get_url>`), e.g., ``salt://``,
+        ``https://``, ``s3://``, ``ftp:/``, etc.
+
+    saltenv: ``base``
+        Salt fileserver environment from which to retrieve the file.
+        Ignored if ``merge_path`` is not a ``salt://`` URL.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' napalm.config_merge_diff merge_path=salt://path/to/merge.cfg
+    '''
+    config_txt = __salt__['net.config'](source=source)['out'][source]
+    return __salt__['iosconfig.merge_diff'](initial_config=config_txt,
+                                            merge_config=merge_config,
+                                            merge_path=merge_path,
+                                            saltenv=saltenv)
+
+
+def config_diff_tree(source1='candidate',
+                     candidate_path=None,
+                     source2='running',
+                     running_path=None):
+    '''
+    .. versionadded:: Fluorine
+
+    Return the diff, as Python dictionary, between two different sources.
+    The sources can be either specified using the ``source1`` and ``source2``
+    arguments when retrieving from the managed network device.
+
+    source1: ``candidate``
+        The source from where to retrieve the configuration to be compared with.
+        Available options: ``candidate``, ``running``, ``startup``. Default:
+        ``candidate``.
+
+    candidate_path
+        Absolute or remote path from where to load the candidate configuration
+        text. This argument allows any URI supported by
+        :py:func:`cp.get_url <salt.modules.cp.get_url>`), e.g., ``salt://``,
+        ``https://``, ``s3://``, ``ftp:/``, etc.
+
+    source2: ``running``
+        The source from where to retrieve the configuration to compare with.
+        Available options: ``candidate``, ``running``, ``startup``. Default:
+        ``running``.
+
+    running_path
+        Absolute or remote path from where to load the runing configuration
+        text. This argument allows any URI supported by
+        :py:func:`cp.get_url <salt.modules.cp.get_url>`), e.g., ``salt://``,
+        ``https://``, ``s3://``, ``ftp:/``, etc.
+
+    saltenv: ``base``
+        Salt fileserver environment from which to retrieve the file.
+        Ignored if ``candidate_path`` or ``running_path`` is not a
+        ``salt://`` URL.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' napalm.config_diff_text
+        salt '*' napalm.config_diff_text candidate_path=https://bit.ly/2mAdq7z
+        # Would compare the running config with the configuration available at
+        # https://bit.ly/2mAdq7z
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' napalm.config_diff_tree
+        salt '*' napalm.config_diff_tree running startup
+    '''
+    get_config = __salt__['net.config']()['out']
+    candidate_cfg = get_config[source1]
+    running_cfg = get_config[source2]
+    return __salt__['iosconfig.diff_tree'](candidate_config=candidate_cfg,
+                                           candidate_path=candidate_path,
+                                           running_config=running_cfg,
+                                           running_path=running_path)
+
+
+def config_diff_text(source1='candidate',
+                     candidate_path=None,
+                     source2='running',
+                     running_path=None):
+    '''
+    .. versionadded:: Fluorine
+
+    Return the diff, as text, between the two different configuration sources.
+    The sources can be either specified using the ``source1`` and ``source2``
+    arguments when retrieving from the managed network device.
+
+    source1: ``candidate``
+        The source from where to retrieve the configuration to be compared with.
+        Available options: ``candidate``, ``running``, ``startup``. Default:
+        ``candidate``.
+
+    candidate_path
+        Absolute or remote path from where to load the candidate configuration
+        text. This argument allows any URI supported by
+        :py:func:`cp.get_url <salt.modules.cp.get_url>`), e.g., ``salt://``,
+        ``https://``, ``s3://``, ``ftp:/``, etc.
+
+    source2: ``running``
+        The source from where to retrieve the configuration to compare with.
+        Available options: ``candidate``, ``running``, ``startup``. Default:
+        ``running``.
+
+    running_path
+        Absolute or remote path from where to load the runing configuration
+        text. This argument allows any URI supported by
+        :py:func:`cp.get_url <salt.modules.cp.get_url>`), e.g., ``salt://``,
+        ``https://``, ``s3://``, ``ftp:/``, etc.
+
+    saltenv: ``base``
+        Salt fileserver environment from which to retrieve the file.
+        Ignored if ``candidate_path`` or ``running_path`` is not a
+        ``salt://`` URL.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' napalm.config_diff_text
+        salt '*' napalm.config_diff_text candidate_path=https://bit.ly/2mAdq7z
+        # Would compare the running config with the configuration available at
+        # https://bit.ly/2mAdq7z
+    '''
+    get_config = __salt__['net.config']()['out']
+    candidate_cfg = get_config[source1]
+    running_cfg = get_config[source2]
+    return __salt__['iosconfig.diff_text'](candidate_config=candidate_cfg,
+                                           candidate_path=candidate_path,
+                                           running_config=running_cfg,
+                                           running_path=running_path)

--- a/tests/unit/modules/test_iosconfig.py
+++ b/tests/unit/modules/test_iosconfig.py
@@ -1,0 +1,202 @@
+# -*- coding: utf-8 -*-
+'''
+Test the iosconfig Execution module.
+'''
+from __future__ import absolute_import, print_function, unicode_literals
+
+# Import Python libs
+import textwrap
+from collections import OrderedDict
+
+# Import Salt Testing libs
+from tests.support.mixins import LoaderModuleMockMixin
+from tests.support.unit import skipIf, TestCase
+from tests.support.mock import NO_MOCK, NO_MOCK_REASON, patch
+
+# Import Salt modules
+import salt.modules.iosconfig as iosconfig
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class TestModulesIOSConfig(TestCase, LoaderModuleMockMixin):
+
+    running_config = textwrap.dedent('''\
+        interface GigabitEthernet1
+         ip address dhcp
+         negotiation auto
+         no mop enabled
+        !
+        interface GigabitEthernet2
+         ip address 172.20.0.1 255.255.255.0
+         shutdown
+         negotiation auto
+        !
+        interface GigabitEthernet3
+         no ip address
+         shutdown
+         negotiation auto
+        !''')
+
+    candidate_config = textwrap.dedent('''\
+        interface GigabitEthernet1
+         ip address dhcp
+         negotiation auto
+         no mop enabled
+        !
+        interface GigabitEthernet2
+         no ip address
+         shutdown
+         negotiation auto
+        !
+        interface GigabitEthernet3
+         no ip address
+         negotiation auto
+        !
+        router bgp 65000
+         bgp log-neighbor-changes
+         neighbor 1.1.1.1 remote-as 12345
+        !
+        !''')
+
+    merge_config = textwrap.dedent('''\
+        router bgp 65000
+         bgp log-neighbor-changes
+         neighbor 1.1.1.1 remote-as 12345
+        !
+        !
+        virtual-service csr_mgmt
+        !
+        ip forward-protocol nd
+        !''')
+
+    def setup_loader_modules(self):
+        return {}
+
+    def test_tree(self):
+        running_config_tree = OrderedDict([
+            (u'interface GigabitEthernet1', OrderedDict([
+                (u'ip address dhcp', OrderedDict()),
+                (u'negotiation auto', OrderedDict()),
+                (u'no mop enabled', OrderedDict())
+            ])),
+            (u'interface GigabitEthernet2', OrderedDict([
+                (u'ip address 172.20.0.1 255.255.255.0', OrderedDict()),
+                (u'shutdown', OrderedDict()),
+                (u'negotiation auto', OrderedDict())
+            ])),
+            (u'interface GigabitEthernet3', OrderedDict([
+                (u'no ip address', OrderedDict()),
+                (u'shutdown', OrderedDict()),
+                (u'negotiation auto', OrderedDict())
+            ]))
+        ])
+        tree = iosconfig.tree(config=self.running_config)
+        self.assertEqual(tree, running_config_tree)
+
+    def test_clean(self):
+        clean_running_config = textwrap.dedent('''\
+            interface GigabitEthernet1
+             ip address dhcp
+             negotiation auto
+             no mop enabled
+            interface GigabitEthernet2
+             ip address 172.20.0.1 255.255.255.0
+             shutdown
+             negotiation auto
+            interface GigabitEthernet3
+             no ip address
+             shutdown
+             negotiation auto
+        ''')
+        clean = iosconfig.clean(config=self.running_config)
+        self.assertEqual(clean, clean_running_config)
+
+    def test_merge_tree(self):
+        expected_merge_tree = OrderedDict([
+            (u'interface GigabitEthernet1', OrderedDict([
+                (u'ip address dhcp', OrderedDict()),
+                (u'negotiation auto', OrderedDict()),
+                (u'no mop enabled', OrderedDict())
+            ])),
+            (u'interface GigabitEthernet2', OrderedDict([
+                (u'ip address 172.20.0.1 255.255.255.0', OrderedDict()),
+                (u'shutdown', OrderedDict()),
+                (u'negotiation auto', OrderedDict())
+            ])),
+            (u'interface GigabitEthernet3', OrderedDict([
+                (u'no ip address', OrderedDict()),
+                (u'shutdown', OrderedDict()),
+                (u'negotiation auto', OrderedDict())
+            ])),
+            (u'router bgp 65000', OrderedDict([
+                (u'bgp log-neighbor-changes', OrderedDict()),
+                (u'neighbor 1.1.1.1 remote-as 12345', OrderedDict())
+            ])),
+            (u'virtual-service csr_mgmt', OrderedDict()),
+            (u'ip forward-protocol nd', OrderedDict())
+        ])
+        merge_tree = iosconfig.merge_tree(initial_config=self.running_config,
+                                          merge_config=self.merge_config)
+        self.assertEqual(merge_tree, expected_merge_tree)
+
+    def test_merge_text(self):
+        extected_merge_text = textwrap.dedent('''\
+            interface GigabitEthernet1
+             ip address dhcp
+             negotiation auto
+             no mop enabled
+            interface GigabitEthernet2
+             ip address 172.20.0.1 255.255.255.0
+             shutdown
+             negotiation auto
+            interface GigabitEthernet3
+             no ip address
+             shutdown
+             negotiation auto
+            router bgp 65000
+             bgp log-neighbor-changes
+             neighbor 1.1.1.1 remote-as 12345
+            virtual-service csr_mgmt
+            ip forward-protocol nd
+        ''')
+        merge_text = iosconfig.merge_text(initial_config=self.running_config,
+                                          merge_config=self.merge_config)
+        self.assertEqual(merge_text, extected_merge_text)
+
+    def test_merge_diff(self):
+        expected_diff = textwrap.dedent('''\
+            @@ -10,3 +10,8 @@
+              no ip address
+              shutdown
+              negotiation auto
+            +router bgp 65000
+            + bgp log-neighbor-changes
+            + neighbor 1.1.1.1 remote-as 12345
+            +virtual-service csr_mgmt
+            +ip forward-protocol nd
+        ''')
+        diff = iosconfig.merge_diff(initial_config=self.running_config,
+                                    merge_config=self.merge_config)
+        self.assertEqual(diff.splitlines()[2:], expected_diff.splitlines())
+
+    def test_diff_text(self):
+        expected_diff = textwrap.dedent('''\
+            @@ -3,10 +3,12 @@
+              negotiation auto
+              no mop enabled
+             interface GigabitEthernet2
+            - ip address 172.20.0.1 255.255.255.0
+            + no ip address
+              shutdown
+              negotiation auto
+             interface GigabitEthernet3
+              no ip address
+            - shutdown
+              negotiation auto
+            +router bgp 65000
+            + bgp log-neighbor-changes
+            + neighbor 1.1.1.1 remote-as 12345
+            ''')
+        diff = iosconfig.diff_text(candidate_config=self.candidate_config,
+                                   running_config=self.running_config)
+        self.assertEqual(diff.splitlines()[2:], expected_diff.splitlines())

--- a/tests/unit/modules/test_iosconfig.py
+++ b/tests/unit/modules/test_iosconfig.py
@@ -10,7 +10,7 @@ import textwrap
 # Import Salt Testing libs
 from tests.support.mixins import LoaderModuleMockMixin
 from tests.support.unit import skipIf, TestCase
-from tests.support.mock import NO_MOCK, NO_MOCK_REASON, patch
+from tests.support.mock import NO_MOCK, NO_MOCK_REASON
 
 # Import Salt modules
 from salt.utils.odict import OrderedDict

--- a/tests/unit/modules/test_iosconfig.py
+++ b/tests/unit/modules/test_iosconfig.py
@@ -6,7 +6,6 @@ from __future__ import absolute_import, print_function, unicode_literals
 
 # Import Python libs
 import textwrap
-from collections import OrderedDict
 
 # Import Salt Testing libs
 from tests.support.mixins import LoaderModuleMockMixin
@@ -14,6 +13,7 @@ from tests.support.unit import skipIf, TestCase
 from tests.support.mock import NO_MOCK, NO_MOCK_REASON, patch
 
 # Import Salt modules
+from salt.utils.odict import OrderedDict
 import salt.modules.iosconfig as iosconfig
 
 


### PR DESCRIPTION
### What does this PR do?

Adds a new module for Cisco IOS style configuration manipulation, and use the functionality into the NAPALM module to have the features directly applied on the configuration(s) of the managed device.