### PR TITLE
Add execution module to SCP files on devices where we can't install the Salt Minion

### DIFF
--- a/doc/ref/modules/all/index.rst
+++ b/doc/ref/modules/all/index.rst
@@ -384,6 +384,7 @@ execution modules
     saltcloudmod
     saltutil
     schedule
+    scp_mod
     scsi
     sdb
     seed

--- a/doc/ref/modules/all/salt.modules.scp_mod.rst
+++ b/doc/ref/modules/all/salt.modules.scp_mod.rst
@@ -1,0 +1,7 @@
+=======================
+salt.modules.scp module
+=======================
+
+.. automodule:: salt.modules.scp_mod
+    :members:
+

--- a/salt/modules/napalm_mod.py
+++ b/salt/modules/napalm_mod.py
@@ -46,6 +46,12 @@ try:
 except ImportError:
     HAS_CISCOCONFPARSE = False
 
+try:
+    import scp  # pylint: disable=unused-import
+    HAS_SCP = True
+except ImportError:
+    HAS_SCP = False
+
 # ----------------------------------------------------------------------------------------------------------------------
 # module properties
 # ----------------------------------------------------------------------------------------------------------------------
@@ -1765,3 +1771,187 @@ def config_diff_text(source1='candidate',
                                            candidate_path=candidate_path,
                                            running_config=running_cfg,
                                            running_path=running_path)
+
+
+@depends(HAS_SCP)
+def scp_get(remote_path,
+            local_path='',
+            recursive=False,
+            preserve_times=False,
+            **kwargs):
+    '''
+    .. versionadded:: Fluorine
+
+    Transfer files and directories from remote network device to the localhost
+    of the Minion.
+
+    .. note::
+        This function is only available only when the underlying library
+        `scp <https://github.com/jbardin/scp.py>`_
+        is installed. See
+        :mod:`scp module <salt.modules.scp_mod>` for
+        more details.
+
+    remote_path
+        Path to retrieve from remote host. Since this is evaluated by scp on the
+        remote host, shell wildcards and environment variables may be used.
+
+    recursive: ``False``
+        Transfer files and directories recursively.
+
+    preserve_times: ``False``
+        Preserve ``mtime`` and ``atime`` of transferred files and directories.
+
+    passphrase
+        Used for decrypting private keys.
+
+    pkey
+        An optional private key to use for authentication.
+
+    key_filename
+        The filename, or list of filenames, of optional private key(s) and/or
+        certificates to try for authentication.
+
+    timeout
+        An optional timeout (in seconds) for the TCP connect.
+
+    socket_timeout: ``10``
+        The channel socket timeout in seconds.
+
+    buff_size: ``16384``
+        The size of the SCP send buffer.
+
+    allow_agent: ``True``
+        Set to ``False`` to disable connecting to the SSH agent.
+
+    look_for_keys: ``True``
+        Set to ``False`` to disable searching for discoverable private key
+        files in ``~/.ssh/``
+
+    banner_timeout
+        An optional timeout (in seconds) to wait for the SSH banner to be
+        presented.
+
+    auth_timeout
+        An optional timeout (in seconds) to wait for an authentication
+        response.
+
+    auto_add_policy: ``False``
+        Automatically add the host to the ``known_hosts``.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' napalm.scp_get /var/tmp/file /tmp/file auto_add_policy=True
+    '''
+    conn_args = netmiko_args(**kwargs)
+    conn_args['hostname'] = conn_args['host']
+    kwargs.update(conn_args)
+    return __salt__['scp.get'](remote_path,
+                               local_path=local_path,
+                               recursive=recursive,
+                               preserve_times=preserve_times,
+                               **kwargs)
+
+
+@depends(HAS_SCP)
+def scp_put(files,
+            remote_path=None,
+            recursive=False,
+            preserve_times=False,
+            saltenv='base',
+            **kwargs):
+    '''
+    .. versionadded:: Fluorine
+
+    Transfer files and directories to remote network device.
+
+    .. note::
+        This function is only available only when the underlying library
+        `scp <https://github.com/jbardin/scp.py>`_
+        is installed. See
+        :mod:`scp module <salt.modules.scp_mod>` for
+        more details.
+
+    files
+        A single path or a list of paths to be transferred.
+
+    remote_path
+        The path on the remote device where to store the files.
+
+    recursive: ``True``
+        Transfer files and directories recursively.
+
+    preserve_times: ``False``
+        Preserve ``mtime`` and ``atime`` of transferred files and directories.
+
+    saltenv: ``base``
+        The name of the Salt environment. Ignored when ``files`` is not a
+        ``salt://`` URL.
+
+    hostname
+        The hostname of the remote device.
+
+    port: ``22``
+        The port of the remote device.
+
+    username
+        The username required for SSH authentication on the device.
+
+    password
+        Used for password authentication. It is also used for private key
+        decryption if ``passphrase`` is not given.
+
+    passphrase
+        Used for decrypting private keys.
+
+    pkey
+        An optional private key to use for authentication.
+
+    key_filename
+        The filename, or list of filenames, of optional private key(s) and/or
+        certificates to try for authentication.
+
+    timeout
+        An optional timeout (in seconds) for the TCP connect.
+
+    socket_timeout: ``10``
+        The channel socket timeout in seconds.
+
+    buff_size: ``16384``
+        The size of the SCP send buffer.
+
+    allow_agent: ``True``
+        Set to ``False`` to disable connecting to the SSH agent.
+
+    look_for_keys: ``True``
+        Set to ``False`` to disable searching for discoverable private key
+        files in ``~/.ssh/``
+
+    banner_timeout
+        An optional timeout (in seconds) to wait for the SSH banner to be
+        presented.
+
+    auth_timeout
+        An optional timeout (in seconds) to wait for an authentication
+        response.
+
+    auto_add_policy: ``False``
+        Automatically add the host to the ``known_hosts``.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' napalm.scp_put /path/to/file /var/tmp/file auto_add_policy=True
+    '''
+    conn_args = netmiko_args(**kwargs)
+    conn_args['hostname'] = conn_args['host']
+    kwargs.update(conn_args)
+    return __salt__['scp.put'](files,
+                               remote_path=remote_path,
+                               recursive=recursive,
+                               preserve_times=preserve_times,
+                               saltenv=saltenv,
+                               **kwargs)

--- a/salt/modules/scp_mod.py
+++ b/salt/modules/scp_mod.py
@@ -1,0 +1,244 @@
+# -*- coding: utf-8 -*-
+'''
+SCP Module
+==========
+
+.. versionadded:: Fluorine
+
+Module to copy files via `SCP <https://man.openbsd.org/scp>`_
+'''
+from __future__ import absolute_import, print_function, unicode_literals
+
+# Import python libs
+import logging
+import inspect
+
+# Import salt modules
+from salt.ext import six
+
+try:
+    import scp
+    import paramiko
+    HAS_SCP = True
+except ImportError:
+    HAS_SCP = False
+
+__proxyenabled__ = ['*']
+__virtualname__ = 'scp'
+
+log = logging.getLogger(__name__)
+
+
+def __virtual__():
+    if not HAS_SCP:
+        return False, 'Please install SCP for this modules: pip install scp'
+    return __virtualname__
+
+
+def _select_kwargs(**kwargs):
+    paramiko_kwargs = {}
+    scp_kwargs = {}
+    PARAMIKO_KWARGS, _, _, _ = inspect.getargspec(paramiko.SSHClient.connect)
+    PARAMIKO_KWARGS.pop(0)  # strip self
+    PARAMIKO_KWARGS.append('auto_add_policy')
+    SCP_KWARGS, _, _, _ = inspect.getargspec(scp.SCPClient.__init__)
+    SCP_KWARGS.pop(0)  # strip self
+    SCP_KWARGS.pop(0)  # strip transport arg (it is passed in _prepare_connection)
+    for karg, warg in six.iteritems(kwargs):
+        if karg in PARAMIKO_KWARGS and warg is not None:
+            paramiko_kwargs[karg] = warg
+        if karg in SCP_KWARGS and warg is not None:
+            scp_kwargs[karg] = warg
+    return paramiko_kwargs, scp_kwargs
+
+
+def _prepare_connection(**kwargs):
+    '''
+    Prepare the underlying SSH connection with the remote target.
+    '''
+    paramiko_kwargs, scp_kwargs = _select_kwargs(**kwargs)
+    ssh = paramiko.SSHClient()
+    if paramiko_kwargs.pop('auto_add_policy', False):
+        ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+    ssh.connect(**paramiko_kwargs)
+    scp_client = scp.SCPClient(ssh.get_transport(),
+                               **scp_kwargs)
+    return scp_client
+
+
+def get(remote_path,
+        local_path='',
+        recursive=False,
+        preserve_times=False,
+        **kwargs):
+    '''
+    Transfer files and directories from remote host to the localhost of the
+    Minion.
+
+    remote_path
+        Path to retrieve from remote host. Since this is evaluated by scp on the
+        remote host, shell wildcards and environment variables may be used.
+
+    recursive: ``False``
+        Transfer files and directories recursively.
+
+    preserve_times: ``False``
+        Preserve ``mtime`` and ``atime`` of transferred files and directories.
+
+    hostname
+        The hostname of the remote device.
+
+    port: ``22``
+        The port of the remote device.
+
+    username
+        The username required for SSH authentication on the device.
+
+    password
+        Used for password authentication. It is also used for private key
+        decryption if ``passphrase`` is not given.
+
+    passphrase
+        Used for decrypting private keys.
+
+    pkey
+        An optional private key to use for authentication.
+
+    key_filename
+        The filename, or list of filenames, of optional private key(s) and/or
+        certificates to try for authentication.
+
+    timeout
+        An optional timeout (in seconds) for the TCP connect.
+
+    socket_timeout: ``10``
+        The channel socket timeout in seconds.
+
+    buff_size: ``16384``
+        The size of the SCP send buffer.
+
+    allow_agent: ``True``
+        Set to ``False`` to disable connecting to the SSH agent.
+
+    look_for_keys: ``True``
+        Set to ``False`` to disable searching for discoverable private key
+        files in ``~/.ssh/``
+
+    banner_timeout
+        An optional timeout (in seconds) to wait for the SSH banner to be
+        presented.
+
+    auth_timeout
+        An optional timeout (in seconds) to wait for an authentication
+        response.
+
+    auto_add_policy: ``False``
+        Automatically add the host to the ``known_hosts``.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' scp.get /var/tmp/file /tmp/file hostname=10.10.10.1 auto_add_policy=True
+    '''
+    scp_client = _prepare_connection(**kwargs)
+    get_kwargs = {
+        'recursive': recursive,
+        'preserve_times': preserve_times
+    }
+    if local_path:
+        get_kwargs['local_path'] = local_path
+    return scp_client.get(remote_path, **get_kwargs)
+
+
+def put(files,
+        remote_path=None,
+        recursive=False,
+        preserve_times=False,
+        saltenv='base',
+        **kwargs):
+    '''
+    Transfer files and directories to remote host.
+
+    files
+        A single path or a list of paths to be transferred.
+
+    remote_path
+        The path on the remote device where to store the files.
+
+    recursive: ``True``
+        Transfer files and directories recursively.
+
+    preserve_times: ``False``
+        Preserve ``mtime`` and ``atime`` of transferred files and directories.
+
+    hostname
+        The hostname of the remote device.
+
+    port: ``22``
+        The port of the remote device.
+
+    username
+        The username required for SSH authentication on the device.
+
+    password
+        Used for password authentication. It is also used for private key
+        decryption if ``passphrase`` is not given.
+
+    passphrase
+        Used for decrypting private keys.
+
+    pkey
+        An optional private key to use for authentication.
+
+    key_filename
+        The filename, or list of filenames, of optional private key(s) and/or
+        certificates to try for authentication.
+
+    timeout
+        An optional timeout (in seconds) for the TCP connect.
+
+    socket_timeout: ``10``
+        The channel socket timeout in seconds.
+
+    buff_size: ``16384``
+        The size of the SCP send buffer.
+
+    allow_agent: ``True``
+        Set to ``False`` to disable connecting to the SSH agent.
+
+    look_for_keys: ``True``
+        Set to ``False`` to disable searching for discoverable private key
+        files in ``~/.ssh/``
+
+    banner_timeout
+        An optional timeout (in seconds) to wait for the SSH banner to be
+        presented.
+
+    auth_timeout
+        An optional timeout (in seconds) to wait for an authentication
+        response.
+
+    auto_add_policy: ``False``
+        Automatically add the host to the ``known_hosts``.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' scp.put /path/to/file /var/tmp/file hostname=server1 auto_add_policy=True
+    '''
+    scp_client = _prepare_connection(**kwargs)
+    put_kwargs = {
+        'recursive': recursive,
+        'preserve_times': preserve_times
+    }
+    if remote_path:
+        put_kwargs['remote_path'] = remote_path
+    cached_files = []
+    if not isinstance(files, (list, tuple)):
+        files = [files]
+    for file_ in files:
+        cached_file = __salt__['cp.cache_file'](file_, saltenv=saltenv)
+        cached_files.append(cached_file)
+    return scp_client.put(cached_files, **put_kwargs)


### PR DESCRIPTION
### What does this PR do?

This is one of the major downsides of managing devices (such as network gear) where we can't install the Salt Minion and use `salt-cp`.
This module can be used alone, as-is, but it will be used in future modules and states such as upgrading the firmware on network devices, etc.