### PR TITLE
Decode file contents for python2 as well

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -1123,8 +1123,7 @@ def _get_template_texts(source_list=None,
             tmplines = None
             with salt.utils.files.fopen(rndrd_templ_fn, 'rb') as fp_:
                 tmplines = fp_.read()
-                if six.PY3:
-                    tmplines = tmplines.decode(__salt_system_encoding__)
+                tmplines = tmplines.decode(__salt_system_encoding__)
                 tmplines = tmplines.splitlines(True)
             if not tmplines:
                 msg = 'Failed to read rendered template file {0} ({1})'


### PR DESCRIPTION
### What does this PR do?
In file.blockreplace function, when user specify a source file which has some non-ascii characters. Then similar error as following was appearing
``` UnicodeDecodeError: 'ascii' codec can't decode byte 0xc2 in > position 17: ordinal not in range(128) ```

This happens with python2 only. There was already check for python3, not sure why it was limited to python3 though. With this PR, decoding will be performed no matter what version.

### What issues does this PR fix or reference?



### Tests written?

No

### Commits signed with GPG?

Yes

