### PR TITLE
Add cmd module integration tests for windows and fix space in path issue

### DIFF
--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -2128,11 +2128,11 @@ def script(source,
         os.chown(path, __salt__['file.user_to_uid'](runas), -1)
 
     if salt.utils.is_windows() and shell.lower() != 'powershell':
-        path = _cmd_quote(path, escape=False)
+        cmd_path = _cmd_quote(path, escape=False)
     else:
-        path = _cmd_quote(path)
+        cmd_path = _cmd_quote(path)
 
-    ret = _run(path + ' ' + str(args) if args else path,
+    ret = _run(cmd_path + ' ' + str(args) if args else cmd_path,
                cwd=cwd,
                stdin=stdin,
                output_loglevel=output_loglevel,

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -2127,7 +2127,7 @@ def script(source,
         os.chmod(path, 320)
         os.chown(path, __salt__['file.user_to_uid'](runas), -1)
 
-    if salt.utils.is_windows() and shell != 'powershell':
+    if salt.utils.is_windows() and shell.lower() != 'powershell':
         path = _cmd_quote(path, escape=False)
     else:
         path = _cmd_quote(path)

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -2127,7 +2127,10 @@ def script(source,
         os.chmod(path, 320)
         os.chown(path, __salt__['file.user_to_uid'](runas), -1)
 
-    path = _cmd_quote(path)
+    if salt.utils.is_windows() and shell != 'powershell':
+        path = _cmd_quote(path, escape=False)
+    else:
+        path = _cmd_quote(path)
 
     ret = _run(path + ' ' + str(args) if args else path,
                cwd=cwd,

--- a/salt/utils/win_functions.py
+++ b/salt/utils/win_functions.py
@@ -166,7 +166,7 @@ def get_sam_name(username):
     return '\\'.join([domain, username])
 
 
-def escape_argument(arg):
+def escape_argument(arg, escape=True):
     '''
     Escape the argument for the cmd.exe shell.
     See http://blogs.msdn.com/b/twistylittlepassagesallalike/archive/2011/04/23/everyone-quotes-arguments-the-wrong-way.aspx
@@ -183,6 +183,8 @@ def escape_argument(arg):
     if not arg or re.search(r'(["\s])', arg):
         arg = '"' + arg.replace('"', r'\"') + '"'
 
+    if not escape:
+        return arg
     return escape_for_cmd_exe(arg)
 
 

--- a/salt/utils/win_functions.py
+++ b/salt/utils/win_functions.py
@@ -177,6 +177,11 @@ def escape_argument(arg, escape=True):
     Args:
         arg (str): a single command line argument to escape for the cmd.exe shell
 
+    Kwargs:
+        escape (bool): True will call the escape_for_cmd_exe() function
+                       which escapes the characters '()%!^"<>&|'. False
+                       will not call the function and only quotes the cmd
+
     Returns:
         str: an escaped string suitable to be passed as a program argument to the cmd.exe shell
     '''

--- a/tests/integration/modules/test_cmdmod.py
+++ b/tests/integration/modules/test_cmdmod.py
@@ -9,6 +9,7 @@ import textwrap
 
 # Import Salt Testing libs
 from tests.support.case import ModuleCase
+from tests.support.unit import skipIf
 from tests.support.helpers import (
     destructiveTest,
     skip_if_binaries_missing,
@@ -71,7 +72,7 @@ class CMDModuleTest(ModuleCase):
         '''
         self.assertEqual(self.run_function('cmd.run_stdout',
                                            ['echo "cheese"']).rstrip(),
-                         'cheese')
+                         'cheese' if not salt.utils.is_windows() else '"cheese"')
 
     def test_stderr(self):
         '''
@@ -86,7 +87,7 @@ class CMDModuleTest(ModuleCase):
                                            ['echo "cheese" 1>&2',
                                             'shell={0}'.format(shell)], python_shell=True
                                            ).rstrip(),
-                         'cheese')
+                         'cheese' if not salt.utils.is_windows() else '"cheese"')
 
     def test_run_all(self):
         '''
@@ -107,7 +108,7 @@ class CMDModuleTest(ModuleCase):
         self.assertTrue(isinstance(ret.get('retcode'), int))
         self.assertTrue(isinstance(ret.get('stdout'), six.string_types))
         self.assertTrue(isinstance(ret.get('stderr'), six.string_types))
-        self.assertEqual(ret.get('stderr').rstrip(), 'cheese')
+        self.assertEqual(ret.get('stderr').rstrip(), 'cheese' if not salt.utils.is_windows() else '"cheese"')
 
     def test_retcode(self):
         '''
@@ -217,10 +218,13 @@ class CMDModuleTest(ModuleCase):
         '''
         cmd = '''echo 'SELECT * FROM foo WHERE bar="baz"' '''
         expected_result = 'SELECT * FROM foo WHERE bar="baz"'
+        if salt.utils.is_windows():
+            expected_result = '\'SELECT * FROM foo WHERE bar="baz"\''
         result = self.run_function('cmd.run_stdout', [cmd]).strip()
         self.assertEqual(result, expected_result)
 
     @skip_if_not_root
+    @skipIf(salt.utils.is_windows, 'skip windows, requires password')
     def test_quotes_runas(self):
         '''
         cmd.run with quoted command
@@ -234,6 +238,7 @@ class CMDModuleTest(ModuleCase):
                                    runas=runas).strip()
         self.assertEqual(result, expected_result)
 
+    @skipIf(not salt.utils.which_bin('sleep'), 'sleep cmd not installed')
     def test_timeout(self):
         '''
         cmd.run trigger timeout
@@ -244,6 +249,7 @@ class CMDModuleTest(ModuleCase):
                                 python_shell=True)
         self.assertTrue('Timed out' in out)
 
+    @skipIf(not salt.utils.which_bin('sleep'), 'sleep cmd not installed')
     def test_timeout_success(self):
         '''
         cmd.run sufficient timeout to succeed

--- a/tests/whitelist.txt
+++ b/tests/whitelist.txt
@@ -8,6 +8,7 @@ integration.modules.test_autoruns
 integration.modules.test_beacons
 integration.modules.test_config
 integration.modules.test_cp
+integration.modules.test_cmdmod
 integration.modules.test_data
 integration.modules.test_disk
 integration.modules.test_firewall


### PR DESCRIPTION
### What does this PR do?
Adds the cmdmod module integration tests to run on windows and fixes an issue on windows when there is a space in the path name of the `cwd` argument.

Given this state file:

```
test:
  cmd.script:
    - source: salt://test.py
    - cwd: "c:\\test 2"
    - args: 'saltine crackers biscuits=yes'
```

When run I see this error:

```
----------
          ID: test
    Function: cmd.script
      Result: False
     Comment: Command 'test' run
     Started: 12:11:28.997000
    Duration: 454.0 ms
     Changes:
              ----------
              pid:
                  38548
              retcode:
                  1
              stderr:
                  '"c:\test' is not recognized as an internal or external command,
                  operable program or batch file.
              stdout:

Summary for local
------------
Succeeded: 0 (changed=1)
Failed:    1
------------
Total states run:     1
Total run time: 454.000 ms
PS C:\testing>
```

If i use the powershell shell it works:

```
test:
  cmd.script:
    - source: salt://test.ps1
    - cwd: "c:\\test 2"
    - args: 'saltine crackers biscuits=yes'
    - shell: powershell
```

```
local:
----------
          ID: test
    Function: cmd.script
      Result: True
     Comment: Command 'test' run
     Started: 12:14:27.200000
    Duration: 954.0 ms
     Changes:
              ----------
              pid:
                  39572
              retcode:
                  0
              stderr:
              stdout:
                  hello

Summary for local
------------
Succeeded: 1 (changed=1)
Failed:    0
------------
```

The reason this is occurring is because it tries to escape the quotes around the command leaving hte space unescaped. So the resulting command is this:

`chcp 437 > nul & ^"c:\test 2\__salt.tmp.al96jv.py^"` and if run in cmd.exe:

```
C:\Users\Administrator>chcp 437 > nul & ^"c:\test 2\__salt.tmp.al96jv.py^"
'"c:\test' is not recognized as an internal or external command,
operable program or batch file.
```

Also fixes an issue when it it attempts to clean the temp file here: https://github.com/saltstack/salt/blob/v2017.7.7/salt/modules/cmdmod.py#L2141

it cannot delete the temp file because it quotes the path `'"<path>"'` and whne it checks to see if its a valid path it fails. So this ensures we are using the inital path created from here: https://github.com/saltstack/salt/blob/v2017.7.7/salt/modules/cmdmod.py#L2084

Also this PR changes the expected return in windows on the tests so I could use some review if those returns are expected behavior or not.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/44997

### Tests written?

Yes - adds tests and fixes something a test found

### Commits signed with GPG?

Yes