### PR TITLE
Catch socket.error exception in testprogram

### DIFF
--- a/tests/integration/utils/testprogram.py
+++ b/tests/integration/utils/testprogram.py
@@ -598,7 +598,7 @@ class TestSaltProgram(six.with_metaclass(TestSaltProgramMeta, TestProgram)):
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         try:
             connect = sock.bind(('localhost', port))
-        except OSError:
+        except (socket.error, OSError):
             # these ports are already in use, use different ones
             pub_port = 4606
             ret_port = 4607


### PR DESCRIPTION
### What does this PR do?
Fixes shell tests on mac. We need to make sure we are also catching `socket.error` when trying to bind to the port to determine if its already being used.

Here's an example of one of the shell test failures on mac:

```
ImportError: Failed to import test module: integration.shell.test_call
Traceback (most recent call last):
  File "/opt/salt/lib/python2.7/unittest/loader.py", line 254, in _find_tests
    module = self._get_module_from_name(name)
  File "/opt/salt/lib/python2.7/unittest/loader.py", line 232, in _get_module_from_name
    __import__(name)
  File "/testing/tests/integration/shell/test_call.py", line 29, in <module>
    from tests.integration.utils import testprogram
  File "/testing/tests/integration/utils/testprogram.py", line 584, in <module>
    class TestSaltProgram(six.with_metaclass(TestSaltProgramMeta, TestProgram)):
  File "/testing/tests/integration/utils/testprogram.py", line 600, in TestSaltProgram
    connect = sock.bind(('localhost', port))
  File "/opt/salt/lib/python2.7/socket.py", line 228, in meth
    return getattr(self._sock,name)(*args)
error: [Errno 48] Address already in use
```