### PR TITLE
Remove unicode key pairs from environ after test

### DIFF
--- a/tests/integration/modules/test_pip.py
+++ b/tests/integration/modules/test_pip.py
@@ -43,6 +43,14 @@ class PipModuleTest(ModuleCase):
         os.environ['PIP_SOURCE_DIR'] = os.environ['PIP_BUILD_DIR'] = ''
 
     def tearDown(self):
+        super(PipModuleTest, self).tearDown()
+        if os.path.isdir(self.venv_test_dir):
+            shutil.rmtree(self.venv_test_dir, ignore_errors=True)
+        if os.path.isdir(self.pip_temp):
+            shutil.rmtree(self.pip_temp, ignore_errors=True)
+        del self.venv_dir
+        del self.venv_test_dir
+        del self.pip_temp
         if 'PIP_SOURCE_DIR' in os.environ:
             os.environ.pop('PIP_SOURCE_DIR')
 
@@ -444,13 +452,3 @@ class PipModuleTest(ModuleCase):
         ret2 = self.run_function('cmd.run', '/bin/pip3 freeze | grep lazyimport')
         assert 'lazyimport==0.0.1' in ret1
         assert ret2 == ''
-
-    def tearDown(self):
-        super(PipModuleTest, self).tearDown()
-        if os.path.isdir(self.venv_test_dir):
-            shutil.rmtree(self.venv_test_dir, ignore_errors=True)
-        if os.path.isdir(self.pip_temp):
-            shutil.rmtree(self.pip_temp, ignore_errors=True)
-        del self.venv_dir
-        del self.venv_test_dir
-        del self.pip_temp

--- a/tests/integration/modules/test_pip.py
+++ b/tests/integration/modules/test_pip.py
@@ -42,6 +42,10 @@ class PipModuleTest(ModuleCase):
             os.makedirs(self.pip_temp)
         os.environ['PIP_SOURCE_DIR'] = os.environ['PIP_BUILD_DIR'] = ''
 
+    def tearDown(self):
+        if 'PIP_SOURCE_DIR' in os.environ:
+            os.environ.pop('PIP_SOURCE_DIR')
+
     def _check_download_error(self, ret):
         '''
         Checks to see if a download error looks transitory


### PR DESCRIPTION
### What does this PR do?

Fixes failure in test setUp method:

https://jenkinsci.saltstack.com/job/2018.3/job/salt-windows-2016-py2/3/testReport/junit/setUpClass%20(unit.fileserver/test_gitfs/GitPythonTest_/

This PR fixes the above error by removing unicode values added to the environment from other test cases. This just makes sure the other test removes what it added to the environment.


### Tests written?

No - Fixing tests

### Commits signed with GPG?

Yes