### PR TITLE
Update writing.rst

### DIFF
--- a/doc/ref/states/writing.rst
+++ b/doc/ref/states/writing.rst
@@ -153,6 +153,9 @@ distributed manually to minions by running :mod:`saltutil.sync_states
 <salt.modules.saltutil.sync_all>`. Alternatively, when running a
 :ref:`highstate <running-highstate>` custom types will automatically be synced.
 
+NOTE: Writing state modules with hyphens in the filename will cause issues
+with !pyobjects routines.  Best practice to stick to underscores.
+
 Any custom states which have been synced to a minion, that are named the same
 as one of Salt's default set of states, will take the place of the default
 state with the same name. Note that a state module's name defaults to one based


### PR DESCRIPTION
We identified this issue, which was very difficult to track down.  Don't think it's really a bug, and likely state names should never contain a hyphen anyways.  

Basically it renders the name as (first - second) = function(). (first-second.py), and you get a "can't assign to operator" exception.
