### PR TITLE
Make IP_LEARNING optional

### DIFF
--- a/salt/cloud/clouds/libvirt.py
+++ b/salt/cloud/clouds/libvirt.py
@@ -371,7 +371,8 @@ def create(vm_):
             for iface_xml in domain_xml.findall('./devices/interface'):
                 iface_xml.remove(iface_xml.find('./mac'))
                 # enable IP learning, this might be a default behaviour...
-                if iface_xml.find("./filterref/parameter[@name='CTRL_IP_LEARNING']") is None:
+                # Don't always enable since it can cause problems through libvirt-4.5
+                if ip_source == 'ip-learning' and iface_xml.find("./filterref/parameter[@name='CTRL_IP_LEARNING']") is None:
                     iface_xml.append(ElementTree.fromstring(IP_LEARNING_XML))
 
             # If a qemu agent is defined we need to fix the path to its socket


### PR DESCRIPTION
### What does this PR do?
Not always put a certain piece of XML in place, depending on how we intend to learn the network address.

### What issues does this PR fix or reference?
In a network with one VM serving dhcp addresses, and other VMs connecting to it, the following problems were observed:

- Issue observed where in libvirt 4.4.0 the filterref block would ignore dhcp if set to 'any'.
- Issue observed where in libvirt 4.5.0 (latest at time of writing) the filterref block would permit the client to get an address, but then not permit any more traffic.

### Previous Behavior
Always make sure the filterref xml clause is added to the network configuration.

### New Behavior
If `ip_source` is not `ip-learning` (or blank, defaults to ip-learning), then don't alter the vm network configuration beyond removing the MAC address.

### Tests written?

No

### Commits signed with GPG?

No