### PR TITLE
Wrap ElementTree.tostring to make strs, not bytes

### DIFF
--- a/salt/cloud/clouds/libvirt.py
+++ b/salt/cloud/clouds/libvirt.py
@@ -422,7 +422,7 @@ def create(vm_):
                 else:
                     raise SaltCloudExecutionFailure("Disk type '{0}' not supported".format(disk_type))
 
-            clone_xml = ElementTree.tostring(domain_xml)
+            clone_xml = salt.utils.stringutils.to_str(ElementTree.tostring(domain_xml))
             log.debug("Clone XML '%s'", clone_xml)
 
             validate_flags = libvirt.VIR_DOMAIN_DEFINE_VALIDATE if validate_xml else 0
@@ -615,7 +615,7 @@ def create_volume_xml(volume):
     log.debug("Volume: %s", dir(volume))
     volume_xml.find('capacity').text = six.text_type(volume.info()[1])
     volume_xml.find('./target/path').text = volume.path()
-    xml_string = ElementTree.tostring(volume_xml)
+    xml_string = salt.utils.stringutils.to_str(ElementTree.tostring(volume_xml))
     log.debug("Creating %s", xml_string)
     return xml_string
 
@@ -641,7 +641,7 @@ def create_volume_with_backing_store_xml(volume):
     log.debug("volume: %s", dir(volume))
     volume_xml.find('capacity').text = six.text_type(volume.info()[1])
     volume_xml.find('./backingStore/path').text = volume.path()
-    xml_string = ElementTree.tostring(volume_xml)
+    xml_string = salt.utils.stringutils.to_str(ElementTree.tostring(volume_xml))
     log.debug("Creating %s", xml_string)
     return xml_string
 


### PR DESCRIPTION
This is in use on a setup running python3 right now.
 Without this patch, assertions were thrown by python3-libvirt code that expected strings, not bytes.

### What does this PR do?
Make salt work better with python3. Untested with python2.
### What issues does this PR fix or reference?
I didn't look for issue numbers.
### Previous Behavior
Within "/usr/lib/python3/dist-packages/libvirt.py"
```
def defineXMLFlags(self, xml, flags=0):
    ret = libvirtmod.virDomainDefineXMLFlags(self._o, xml, flags)
    if ret is None:raise libvirtError('virDomainDefineXMLFlags() failed', conn=self)
```

### New Behavior
Within "/usr/lib/python3/dist-packages/libvirt.py"
```
def defineXMLFlags(self, xml, flags=0):
    ret = libvirtmod.virDomainDefineXMLFlags(self._o, xml, flags)
    if ret is None:raise libvirtError('virDomainDefineXMLFlags() failed', conn=self)
    __tmp = virDomain(self,_obj=ret)
    return __tmp
```
### Tests written?

No

### Commits signed with GPG?

No.