### PR TITLE
Ensure topic as bytes when zmq_filtering enabled

### DIFF
--- a/salt/transport/zeromq.py
+++ b/salt/transport/zeromq.py
@@ -832,7 +832,7 @@ class ZeroMQPubServerChannel(salt.transport.server.PubServerChannel):
                                 log.trace('Sending filtered data over publisher %s', pub_uri)
                                 # zmq filters are substring match, hash the topic
                                 # to avoid collisions
-                                htopic = hashlib.sha1(topic).hexdigest()
+                                htopic = salt.utils.stringutils.to_bytes(hashlib.sha1(topic).hexdigest())
                                 pub_sock.send(htopic, flags=zmq.SNDMORE)
                                 pub_sock.send(payload)
                                 log.trace('Filtered data has been sent')
@@ -840,7 +840,7 @@ class ZeroMQPubServerChannel(salt.transport.server.PubServerChannel):
                         else:
                             # TODO: constants file for "broadcast"
                             log.trace('Sending broadcasted data over publisher %s', pub_uri)
-                            pub_sock.send('broadcast', flags=zmq.SNDMORE)
+                            pub_sock.send(b'broadcast', flags=zmq.SNDMORE)
                             pub_sock.send(payload)
                             log.trace('Broadcasted data has been sent')
                     else:


### PR DESCRIPTION
### What does this PR do?

Ensure first data as bytes when send multipart in zeromq

### Previous Behavior

The first data is unicode, it's invalid. It will raise exception in ZeroMQPubServerChannel process when `zmq_filtering` enabled

### New Behavior

The first data is bytes

### Tests written?

No
