### PR TITLE
Fix failing git worktree tests

### DIFF
--- a/tests/integration/modules/test_git.py
+++ b/tests/integration/modules/test_git.py
@@ -619,8 +619,6 @@ class GitModuleTest(ModuleCase):
 
         shutil.rmtree(new_repo)
 
-    # Test for git.is_worktree is in test_worktree_add_rm
-
     def test_list_branches(self):
         '''
         Test git.list_branches
@@ -943,6 +941,7 @@ class GitModuleTest(ModuleCase):
         worktree_path = tempfile.mkdtemp(dir=TMP)
         worktree_basename = os.path.basename(worktree_path)
         worktree_path2 = tempfile.mkdtemp(dir=TMP)
+        worktree_basename2 = os.path.basename(worktree_path2)
 
         # Even though this is Windows, git commands return a unix style path
         if salt.utils.is_windows():
@@ -953,11 +952,13 @@ class GitModuleTest(ModuleCase):
         ret = self.run_function(
             'git.worktree_add', [self.repo, worktree_path],
         )
-        self.assertTrue(worktree_add_prefix + worktree_path in ret)
+        self.assertTrue(worktree_add_prefix in ret)
+        self.assertTrue(worktree_basename in ret)
         ret = self.run_function(
             'git.worktree_add', [self.repo, worktree_path2]
         )
-        self.assertTrue(worktree_add_prefix + worktree_path2 in ret)
+        self.assertTrue(worktree_add_prefix in ret)
+        self.assertTrue(worktree_basename2 in ret)
         # Check if this new path is a worktree
         self.assertTrue(self.run_function('git.is_worktree', [worktree_path]))
         # Check if the main repo is a worktree


### PR DESCRIPTION
Git 2.18.0 changed the output format against which some of the asserts in this test are performed. Instead of displaying the full path to the worktree, it now references the branch name instead. This test updates the asserts to look for the basename instead, which should allow it to pass on Git releases both before and after 2.18.0.