### PR TITLE
Separate compound matcher tests into individual tests

### DIFF
--- a/tests/integration/shell/test_matcher.py
+++ b/tests/integration/shell/test_matcher.py
@@ -41,55 +41,67 @@ class MatchTest(ShellCase, ShellCaseCommonTestsMixin):
         self.assertIn('minion', data)
         self.assertIn('sub_minion', data)
 
-    def test_compound(self):
+    # compound matcher tests: 11
+
+    def test_compound_min_with_grain(self):
         '''
         test salt compound matcher
         '''
         data = self.run_salt('-C "min* and G@test_grain:cheese" test.ping')
-        self.assertTrue(minion_in_returns('minion', data))
-        self.assertFalse(minion_in_returns('sub_minion', data))
-        time.sleep(2)
+        assert minion_in_returns('minion', data) is True
+        assert minion_in_returns('sub_minion', data) is False
+
+    def test_compound_and_not_grain(self):
         data = self.run_salt('-C "min* and not G@test_grain:foo" test.ping')
-        self.assertTrue(minion_in_returns('minion', data))
-        self.assertFalse(minion_in_returns('sub_minion', data))
-        time.sleep(2)
+        assert minion_in_returns('minion', data) is True
+        assert minion_in_returns('sub_minion', data) is False
+
+    def test_compound_not_grain(self):
         data = self.run_salt('-C "min* not G@test_grain:foo" test.ping')
-        self.assertTrue(minion_in_returns('minion', data))
-        self.assertFalse(minion_in_returns('sub_minion', data))
-        time.sleep(2)
+        assert minion_in_returns('minion', data) is True
+        assert minion_in_returns('sub_minion', data) is False
+
+    def test_compound_pcre_grain_and_grain(self):
         match = 'P@test_grain:^cheese$ and * and G@test_grain:cheese'
         data = self.run_salt('-t 1 -C \'{0}\' test.ping'.format(match))
-        self.assertTrue(minion_in_returns('minion', data))
-        self.assertFalse(minion_in_returns('sub_minion', data))
-        time.sleep(2)
+        assert minion_in_returns('minion', data) is True
+        assert minion_in_returns('sub_minion', data) is False
+
+    def test_compound_list_and_pcre_minion(self):
         match = 'L@sub_minion and E@.*'
         data = self.run_salt('-t 1 -C "{0}" test.ping'.format(match))
-        self.assertTrue(minion_in_returns('sub_minion', data))
-        self.assertFalse(minion_in_returns('minion', data))
-        time.sleep(2)
+        assert minion_in_returns('sub_minion', data) is True
+        assert minion_in_returns('minion', data) is False
+
+    def test_compound_not_sub_minion(self):
         data = self.run_salt("-C 'not sub_minion' test.ping")
-        self.assertTrue(minion_in_returns('minion', data))
-        self.assertFalse(minion_in_returns('sub_minion', data))
-        time.sleep(2)
+        assert minion_in_returns('minion', data) is True
+        assert minion_in_returns('sub_minion', data) is False
+
+    def test_compound_all_and_not_grains(self):
         data = self.run_salt("-C '* and ( not G@test_grain:cheese )' test.ping")
-        self.assertFalse(minion_in_returns('minion', data))
-        self.assertTrue(minion_in_returns('sub_minion', data))
-        time.sleep(2)
+        assert minion_in_returns('minion', data) is False
+        assert minion_in_returns('sub_minion', data) is True
+
+    def test_compound_grain_regex(self):
         data = self.run_salt("-C 'G%@planets%merc*' test.ping")
-        self.assertTrue(minion_in_returns('minion', data))
-        self.assertFalse(minion_in_returns('sub_minion', data))
-        time.sleep(2)
+        assert minion_in_returns('minion', data) is True
+        assert minion_in_returns('sub_minion', data) is False
+
+    def test_coumpound_pcre_grain_regex(self):
         data = self.run_salt("-C 'P%@planets%^(mercury|saturn)$' test.ping")
-        self.assertTrue(minion_in_returns('minion', data))
-        self.assertTrue(minion_in_returns('sub_minion', data))
-        time.sleep(2)
+        assert minion_in_returns('minion', data) is True
+        assert minion_in_returns('sub_minion', data) is True
+
+    def test_compound_pillar(self):
         data = self.run_salt("-C 'I%@companions%three%sarah*' test.ping")
-        self.assertTrue(minion_in_returns('minion', data))
-        self.assertTrue(minion_in_returns('sub_minion', data))
-        time.sleep(2)
+        assert minion_in_returns('minion', data) is True
+        assert minion_in_returns('sub_minion', data) is True
+
+    def test_coumpound_pillar_pcre(self):
         data = self.run_salt("-C 'J%@knights%^(Lancelot|Galahad)$' test.ping")
-        self.assertTrue(minion_in_returns('minion', data))
-        self.assertTrue(minion_in_returns('sub_minion', data))
+        assert minion_in_returns('minion', data) is True
+        assert minion_in_returns('sub_minion', data) is True
 
     def test_nodegroup(self):
         '''


### PR DESCRIPTION
When one match fails (and some of these can be flaky) the whole test fails.

This makes it somewhat difficult to track down why the test fails.

I am hoping we won't need the sleeps in this change when the tests are separate, but let's see how that goes. It worked fine in my testing.

I also updated the test to use pytest notation, rather than unittest.
