### PR TITLE
add sleep in test_cmd integration test

### DIFF
--- a/tests/integration/states/test_cmd.py
+++ b/tests/integration/states/test_cmd.py
@@ -8,6 +8,7 @@ import errno
 import os
 import textwrap
 import tempfile
+import time
 
 # Import Salt Testing libs
 from tests.support.case import ModuleCase
@@ -69,6 +70,7 @@ class CMDRunRedirectTest(ModuleCase, SaltReturnAssertsMixin):
         super(CMDRunRedirectTest, self).setUp()
 
     def tearDown(self):
+        time.sleep(1)
         for path in (self.state_file, self.test_tmp_path, self.test_file):
             try:
                 os.remove(path)


### PR DESCRIPTION
### What does this PR do?
The `integration.states.test_cmd.` tests are failing sometimes on macosx after this PR: https://github.com/saltstack/salt/pull/47700

This is because the tests run so quick that sometimes the cache file has the same mtime as the `run_redirect.sls` file,  even though we just edited the file in the test. Adding a quick sleep to make sure this does not occur. 

To make note this might be causing other state tests to fail if each tests runs quick. If thats the case we could possibly look into a different solution for all state tests.