### PR TITLE
win_pkg: Fix issue introduced in Jan 2018 DisplayVersion missing should result…

### DIFF
--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -461,18 +461,13 @@ def _get_reg_software():
                                                     '{0}\\{1}'.format(key, reg_key),
                                                     'DisplayVersion',
                                                     use_32bit)
-        if (not d_vers_regdata['success'] or
-            d_vers_regdata['vtype'] not in ['REG_SZ', 'REG_EXPAND_SZ', 'REG_DWORD'] or
-                d_vers_regdata['vdata'] in [None, False]):
-            return
-
-        if isinstance(d_vers_regdata['vdata'], int):
-            d_vers = six.text_type(d_vers_regdata['vdata'])
-        else:
-            d_vers = d_vers_regdata['vdata']
-
-        if not d_vers or d_vers == '(value not set)':
-            d_vers = 'Not Found'
+        d_vers = 'Not Found'
+        if (d_vers_regdata['success'] and
+            d_vers_regdata['vtype'] in ['REG_SZ', 'REG_EXPAND_SZ', 'REG_DWORD']):
+            if isinstance(d_vers_regdata['vdata'], int):
+                d_vers = six.text_type(d_vers_regdata['vdata'])
+            elif d_vers_regdata['vdata'] and d_vers_regdata['vdata'] != '(value not set)':  # Check for blank values
+                d_vers = d_vers_regdata['vdata']
 
         check_ok = False
         for check_reg in ['UninstallString', 'QuietUninstallString', 'ModifyPath']:


### PR DESCRIPTION
### What does this PR do?
Fix a unintended behavioural change Jan 2018.

### What issues does this PR fix or reference?
Windows packages are hidden in pkg.list_pkgs if they have no DisplayVersion #48865

### Previous Behavior
Packages without DisplayVersion are skipped.

### New Behavior
Packages without DisplayVersion, version is returned as "Not Found"

### Tests written?

No

### Commits signed with GPG?

Yes