### PR TITLE
handle when ca_certs is None in utils.http

### DIFF
--- a/salt/utils/http.py
+++ b/salt/utils/http.py
@@ -489,7 +489,10 @@ def query(url,
 
         if verify_ssl:
             # tornado requires a str, cannot be unicode str in py2
-            req_kwargs['ca_certs'] = salt.utils.stringutils.to_str(ca_bundle)
+            if ca_bundle is None:
+                req_kwargs['ca_certs'] = ca_bundle
+            else:
+                req_kwargs['ca_certs'] = salt.utils.stringutils.to_str(ca_bundle)
 
         max_body = opts.get('http_max_body', salt.config.DEFAULT_MINION_OPTS['http_max_body'])
         timeout = opts.get('http_request_timeout', salt.config.DEFAULT_MINION_OPTS['http_request_timeout'])


### PR DESCRIPTION
### What does this PR do?
The following tests are failing on macosx:

```
integration.modules.test_cp.CPModuleTest.test_get_file_str_https
integration.modules.test_cp.CPModuleTest.test_get_url_https
integration.modules.test_cp.CPModuleTest.test_get_url_https_no_dest
integration.modules.test_cp.CPModuleTest.test_get_url_https_dest_empty
```

here is the traceback:

```
u'Bootstrap' not found in u"Passed invalid arguments to cp.get_file_str: expected str, bytearray, or unicode\n\n    Download a file from a URL to the Minion cache directory and return the\n    contents of that file\n\n    Returns ``False`` if Salt was unable to cache a file from a URL.\n\n    CLI Example:\n\n    .. code-block:: bash\n\n        salt '*' cp.get_file_str salt://my/file\n    "
```

This was due to this PR: 

https://github.com/saltstack/salt/pull/48754

because sometimes ca_certs can be None. From the tornado docs (http://www.tornadoweb.org/en/stable/httpclient.html) 

> ca_certs (str) – filename of CA certificates in PEM format, or None to use defaults.

And we are trying to convert a None variable to a string which causes a TypeError.