### PR TITLE
remove base_top_file file in teardown and add sleep

### DIFF
--- a/tests/unit/modules/test_state.py
+++ b/tests/unit/modules/test_state.py
@@ -10,6 +10,7 @@ import os
 import shutil
 import tempfile
 import textwrap
+import time
 
 # Import Salt Testing Libs
 from tests.support.mixins import LoaderModuleMockMixin
@@ -1312,6 +1313,10 @@ class TopFileMergingCase(TestCase, LoaderModuleMockMixin):
                             - {saltenv}_{env_name}
                         '''.format(env_name=env_name, saltenv=saltenv)))
 
+    def tearDown(self):
+        time.sleep(1)
+        os.remove(self.base_top_file)
+
     def show_top(self, **kwargs):
         local_opts = copy.deepcopy(self.dunder_opts)
         local_opts.update(kwargs)
@@ -1334,6 +1339,7 @@ class TopFileMergingCase(TestCase, LoaderModuleMockMixin):
                   '*':
                     - base_base
                 '''))
+        time.sleep(1)
 
     def test_merge_strategy_merge(self):
         '''


### PR DESCRIPTION
### What does this PR do?
These tests:

```
unit.modules.test_state.TopFileMergingCase.test_merge_strategy_merge_limited_base
unit.modules.test_state.TopFileMergingCase.test_merge_strategy_merge_state_top_saltenv_base
unit.modules.test_state.TopFileMergingCase.test_merge_strategy_same_limited_base
```
are failing on macosx for the same reasons outline in: 
https://github.com/saltstack/salt/pull/48890

adding the time.sleep() to ensure the mtime on the files are not the same in between tests and we don't use the cached file. Also making sure we remove the `base_top_file` file between tests.