### PR TITLE
skip getpwnam check on mac in unit test_cmdmod

### DIFF
--- a/tests/unit/modules/test_cmdmod.py
+++ b/tests/unit/modules/test_cmdmod.py
@@ -324,7 +324,8 @@ class CMDMODTestCase(TestCase, LoaderModuleMockMixin):
 
                     self.assertEqual(environment, environment2)
 
-                    getpwnam_mock.assert_called_with('foobar')
+                    if not salt.utils.platform.is_darwin():
+                        getpwnam_mock.assert_called_with('foobar')
 
     def test_run_cwd_doesnt_exist_issue_7154(self):
         '''


### PR DESCRIPTION
### What does this PR do?
After this PR: https://github.com/saltstack/salt/pull/47212 we aren't hitting the `pwd.getpwnam(runas) ` code on mac anymore. This PR skips the assert_called_with test for macosx.