### PR TITLE
[2018.3] fix to auth/ldap.py

### DIFF
--- a/salt/auth/ldap.py
+++ b/salt/auth/ldap.py
@@ -283,9 +283,15 @@ def auth(username, password):
         log.error('LDAP authentication requires python-ldap module')
         return False
 
-    # If bind credentials are configured, use them instead of user's
+    # If bind credentials are configured, verify that we can a valid bind
     if _config('binddn', mandatory=False) and _config('bindpw', mandatory=False):
         bind = _bind_for_search(anonymous=_config('anonymous', mandatory=False))
+
+        # If username & password are not None, attempt to verify they are valid
+        if bind and username and password:
+            bind = _bind(username, password,
+                         anonymous=_config('auth_by_group_membership_only', mandatory=False)
+                         and _config('anonymous', mandatory=False))
     else:
         bind = _bind(username, password,
                      anonymous=_config('auth_by_group_membership_only', mandatory=False)

--- a/salt/auth/ldap.py
+++ b/salt/auth/ldap.py
@@ -283,7 +283,7 @@ def auth(username, password):
         log.error('LDAP authentication requires python-ldap module')
         return False
 
-    # If bind credentials are configured, verify that we can a valid bind
+    # If bind credentials are configured, verify that we receive a valid bind
     if _config('binddn', mandatory=False) and _config('bindpw', mandatory=False):
         bind = _bind_for_search(anonymous=_config('anonymous', mandatory=False))
 


### PR DESCRIPTION
### What does this PR do?
Fixing issue when a valid token is generated by the salt-api even when invalid user credentials are passed.  This change verifies that the binddn credentials are valid, then verifies that the username & password (if not None) are also valid.

### What issues does this PR fix or reference?
#48665 

### Previous Behavior
When binddn credentials are included in the configuration, a valid token is generated by the salt-api regardless of whether the username & password is valid.

### New Behavior
If binddn credentials are configured, first the binddn credentials are verified and if they are valid, then the username & password credentials are verified.

### Tests written?
No.

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
