### PR TITLE
No rehashing in parallel

### DIFF
--- a/.ci/lint
+++ b/.ci/lint
@@ -29,13 +29,13 @@ pipeline {
             parallel {
                 stage('salt linting') {
                     steps {
-                        sh 'eval "$(pyenv init -)"; tox -e pylint-salt $(find salt/ -name "*.py" -exec git diff --name-only "origin/$CHANGE_TARGET" "origin/$BRANCH_NAME" setup.py {} +) | tee pylint-report.xml'
+                        sh 'eval "$(pyenv init - --no-rehash)"; tox -e pylint-salt $(find salt/ -name "*.py" -exec git diff --name-only "origin/$CHANGE_TARGET" "origin/$BRANCH_NAME" setup.py {} +) | tee pylint-report.xml'
                         archiveArtifacts artifacts: 'pylint-report.xml'
                     }
                 }
                 stage('test linting') {
                     steps {
-                        sh 'eval "$(pyenv init -)"; tox -e pylint-tests $(find tests/ -name "*.py" -exec git diff --name-only "origin/$CHANGE_TARGET" "origin/$BRANCH_NAME" {} +) | tee pylint-report-tests.xml'
+                        sh 'eval "$(pyenv init - --no-rehash)"; tox -e pylint-tests $(find tests/ -name "*.py" -exec git diff --name-only "origin/$CHANGE_TARGET" "origin/$BRANCH_NAME" {} +) | tee pylint-report-tests.xml'
                         archiveArtifacts artifacts: 'pylint-report-tests.xml'
                     }
                 }


### PR DESCRIPTION
Rehashing in parallel causes pyenv to fail, if they're run at almost the
exact same time. It's breaking our lint tests pretty horribly.

### What does this PR do?

Allows our lint tests to pass

### Previous Behavior
Lint tests would fail in either `salt linting` or `test linting` during the rehash.

### New Behavior
Tests pass.

@gtmanfred @dubb-b 