### PR TITLE
Git commit in Windows internal version

### DIFF
--- a/salt/version.py
+++ b/salt/version.py
@@ -753,7 +753,7 @@ def msi_conformant_version():
     noc = __saltstack_version__.noc
     if noc == 0:
         noc = 65535
-    return '{}.{}.{}'.format(short_year, 20*(month-1)+BUGFIX, minor, noc)
+    return '{}.{}.{}'.format(short_year, 20*(month-1)+bugfix, minor, noc)
 
 if __name__ == '__main__':
     if len(sys.argv) == 2 and sys.argv[1] == 'msi':

--- a/salt/version.py
+++ b/salt/version.py
@@ -747,7 +747,7 @@ def msi_conformant_version():
     short_year = int(six.text_type(__saltstack_version__.major)[2:])
     month = __saltstack_version__.minor
     bugfix = __saltstack_version__.bugfix
-    if bugfix>19:
+    if bugfix > 19:
         bugfix = 19
     noc = __saltstack_version__.noc
     if noc == 0:

--- a/salt/version.py
+++ b/salt/version.py
@@ -724,24 +724,23 @@ def msi_conformant_version():
     An msi installer uninstalls/replaces a lower "internal version" of itself.
     "internal version" is the 3-tuple ivMAJOR.ivMINOR.ivBUILD with max values 255.255.65535.
     Using the build nr allows continuous integration of the installer.
-    "Display version" is indipendent and free format: 3-tuple Year.Month.Bugfix as in Salt 2016.11.3.
-    We must combine Month and Bugfix into ivMINOR to free ivBUILD for the build number
+    "Display version" is indipendent and free format: 3-tuple Year.Month.Bugfix as in Salt 2016.11.3.    
     Calculation of the internal version fields:
         ivMAJOR = 'short year' (2 digits).
         ivMINOR = 20*(month-1) + Bugfix
-            To prevent overflow of ivMINOR, Bugfix must be <= 20.
-            If Bugifx exceeds 20, the installer will not uninstall the previous version.
-            The develop branch has bugfix 0
+            We must combine Month and Bugfix into ivMINOR to free ivBUILD for the build number
+            To prevent overflow of ivMINOR, Bugfix must be <= 20, a reasonable assumption.
+            Should Bugifx exceed 20, the installer will not uninstall the previous version.
         ivBUILD = git commit count (noc)
             noc for tags is 0, representing the final word, translates to the highest build number (65535).
 
     Examples:
-      git checkout    Display version               Internal version
-      develop         2016.11.0-742-g5ca4d20        16.200.742
+      git checkout    Display version               Internal version    Remark
+      develop         2016.11.0-742-g5ca4d20        16.200.742          The develop branch has bugfix 0
       2016.11         2016.11.2-78-gce1f01f         16.202.78
       2016.11         2016.11.9-88-g3e844ed1df      16.209.88
       2018.8          2018.3.2-1306-g1e150923aa     18.42.1306
-      v2016.11.0      2016.11.0                     16.200.65535
+      v2016.11.0      2016.11.0                     16.200.65535        Tags have noc 0
       v2016.11.2      2016.11.2                     16.202.65535
 
     '''

--- a/salt/version.py
+++ b/salt/version.py
@@ -723,9 +723,9 @@ def msi_conformant_version():
     '''
     An msi installer uninstalls/replaces a lower "internal version" of itself.
     "internal version" is the 3-tuple ivMAJOR.ivMINOR.ivBUILD with max values 255.255.65535.
-    Using the build nr allows for continuous integration of the installer.
+    Using the build nr allows continuous integration of the installer.
     "Display version" is indipendent and free format: 3-tuple Year.Month.Bugfix as in Salt 2016.11.3.
-    We must compress Month and Bugfix into the second field to free the third field for the build number
+    We must combine Month and Bugfix into ivMINOR to free ivBUILD for the build number
     Calculation of the internal version fields:
         ivMAJOR = 'short year' (2 digits).
         ivMINOR = 20*(month-1) + Bugfix

--- a/salt/version.py
+++ b/salt/version.py
@@ -740,6 +740,7 @@ def msi_conformant_version():
       Branch/Tag             Display version            Internal version
       develop (branch)       2016.11.0-742-g5ca4d20     16.200.742
       2016.11 (branch)       2016.11.2-78-gce1f01f      16.202.78
+      2016.11 (branch)       2016.11.9-88-g3e844ed1df   16.209.88
       v2016.11.0 (tag)       2016.11.0                  16.200.65535
       v2016.11.2 (tag)       2016.11.2                  16.202.65535
 

--- a/salt/version.py
+++ b/salt/version.py
@@ -729,8 +729,8 @@ def msi_conformant_version():
         ivMAJOR = 'short year' (2 digits).
         ivMINOR = 20*(month-1) + Bugfix
             Combine Month and Bugfix to free ivBUILD for the build number
-            Limit Bugfix < 20 to prevent overflow of ivMINOR.
-            If Bugifx > 19, the git branch msi wont replace the previous version.
+            This limits Bugfix < 20.
+            The msi automatically replaces only 19 bugfixes of a month, one must uninstall manually.
         ivBUILD = git commit count (noc)
             noc for tags is 0, representing the final word, translates to the highest build number (65535).
 
@@ -740,9 +740,6 @@ def msi_conformant_version():
       2016.11         2016.11.2-78         16.202.78
       2016.11         2016.11.9-88         16.209.88
       2018.8          2018.3.2-1306        18.42.1306
-      2081.1          2081.1.1-66          81.1.66
-      2081.1          2081.1.19-66         81.19.66
-      2081.1          2081.1.20-66         81.19.66            19 bugfixes on branch
       v2016.11.0      2016.11.0            16.200.65535        Tags have noc 0
       v2016.11.2      2016.11.2            16.202.65535
 

--- a/salt/version.py
+++ b/salt/version.py
@@ -732,17 +732,17 @@ def msi_conformant_version():
             To prevent overflow of ivMINOR, Bugfix must be <= 20.
             If Bugifx exceeds 20, the installer will not uninstall the previous version.
             The develop branch has bugfix 0
-        ivBUILD = git commit count (noc)
+        ivBUILD = git commit count 
             noc on develop and a branch count independently.
             noc for tags is 0, representing the final word, translates to the highest build number (65535).
 
     Examples:
-      Branch/Tag             Display version            Internal version
-      develop (branch)       2016.11.0-742-g5ca4d20     16.200.742
-      2016.11 (branch)       2016.11.2-78-gce1f01f      16.202.78
-      2016.11 (branch)       2016.11.9-88-g3e844ed1df   16.209.88
-      v2016.11.0 (tag)       2016.11.0                  16.200.65535
-      v2016.11.2 (tag)       2016.11.2                  16.202.65535
+      git checkout    Display version            Internal version
+      develop         2016.11.0-742-g5ca4d20     16.200.742
+      2016.11         2016.11.2-78-gce1f01f      16.202.78
+      2016.11         2016.11.9-88-g3e844ed1df   16.209.88
+      v2016.11.0      2016.11.0                  16.200.65535
+      v2016.11.2      2016.11.2                  16.202.65535
 
     '''
     short_year = int(six.text_type(__saltstack_version__.major)[2:])

--- a/salt/version.py
+++ b/salt/version.py
@@ -724,7 +724,7 @@ def msi_conformant_version():
     An msi installer uninstalls/replaces a lower "internal version" of itself.
     "internal version" is the 3-tuple ivMAJOR.ivMINOR.ivBUILD with max values 255.255.65535.
     Using the build nr allows for continuous integration of the installer.
-    "Display version" is indipendent and free format, e.g. 3-tuple Year.Month.Bugfix as in Salt 2016.11.3.
+    "Display version" is indipendent and free format: 3-tuple Year.Month.Bugfix as in Salt 2016.11.3.
     We must compress Month and Bugfix into the second field to free the third field for the build number
     Calculation of the internal version fields:
         ivMAJOR = 'short year' (2 digits).
@@ -732,8 +732,7 @@ def msi_conformant_version():
             To prevent overflow of ivMINOR, Bugfix must be <= 20.
             If Bugifx exceeds 20, the installer will not uninstall the previous version.
             The develop branch has bugfix 0
-        ivBUILD = git commit count 
-            noc on develop and a branch count independently.
+        ivBUILD = git commit count (noc)
             noc for tags is 0, representing the final word, translates to the highest build number (65535).
 
     Examples:
@@ -748,9 +747,9 @@ def msi_conformant_version():
     '''
     short_year = int(six.text_type(__saltstack_version__.major)[2:])
     month = __saltstack_version__.minor
-    BUGFIX = __saltstack_version__.bugfix
-    if BUGFIX>20:
-        BUGFIX = 20
+    bugfix = __saltstack_version__.bugfix
+    if bugfix>20:
+        bugfix = 20
     noc = __saltstack_version__.noc
     if noc == 0:
         noc = 65535

--- a/salt/version.py
+++ b/salt/version.py
@@ -739,9 +739,9 @@ def msi_conformant_version():
     Examples:
       Branch/Tag             Display version            Internal version
       develop (branch)       2016.11.0-742-g5ca4d20     16.200.742
-      20166.11 (branch)      2016.11.2-78-gce1f01f      16.202.78
-      v20166.11.0 (tag)      2016.11.0                  16.200.65535
-      v20166.11.2 (tag)      2016.11.2                  16.202.65535
+      2016.11 (branch)       2016.11.2-78-gce1f01f      16.202.78
+      v2016.11.0 (tag)       2016.11.0                  16.200.65535
+      v2016.11.2 (tag)       2016.11.2                  16.202.65535
 
     '''
     short_year = int(six.text_type(__saltstack_version__.major)[2:])

--- a/salt/version.py
+++ b/salt/version.py
@@ -722,33 +722,36 @@ def versions_report(include_salt_cloud=False):
 def msi_conformant_version():
     '''
     An msi installer uninstalls/replaces a lower "internal version" of itself.
-    "internal version" is the 3-tuple ivMAJOR.ivMINOR.ivBUILD with max values 255.255.65535.
+    "internal version" is ivMAJOR.ivMINOR.ivBUILD with max values 255.255.65535.
     Using the build nr allows continuous integration of the installer.
-    "Display version" is indipendent and free format: 3-tuple Year.Month.Bugfix as in Salt 2016.11.3.    
+    "Display version" is indipendent and free format: Year.Month.Bugfix as in Salt 2016.11.3.
     Calculation of the internal version fields:
         ivMAJOR = 'short year' (2 digits).
         ivMINOR = 20*(month-1) + Bugfix
-            We must combine Month and Bugfix into ivMINOR to free ivBUILD for the build number
-            To prevent overflow of ivMINOR, Bugfix must be <= 20, a reasonable assumption.
-            Should Bugifx exceed 20, the installer will not uninstall the previous version.
+            Combine Month and Bugfix to free ivBUILD for the build number
+            Limit Bugfix < 20 to prevent overflow of ivMINOR.
+            If Bugifx > 19, the git branch msi wont replace the previous version.
         ivBUILD = git commit count (noc)
             noc for tags is 0, representing the final word, translates to the highest build number (65535).
 
     Examples:
-      git checkout    Display version               Internal version    Remark
-      develop         2016.11.0-742-g5ca4d20        16.200.742          The develop branch has bugfix 0
-      2016.11         2016.11.2-78-gce1f01f         16.202.78
-      2016.11         2016.11.9-88-g3e844ed1df      16.209.88
-      2018.8          2018.3.2-1306-g1e150923aa     18.42.1306
-      v2016.11.0      2016.11.0                     16.200.65535        Tags have noc 0
-      v2016.11.2      2016.11.2                     16.202.65535
+      git checkout    Display version      Internal version    Remark
+      develop         2016.11.0-742        16.200.742          The develop branch has bugfix 0
+      2016.11         2016.11.2-78         16.202.78
+      2016.11         2016.11.9-88         16.209.88
+      2018.8          2018.3.2-1306        18.42.1306
+      2081.1          2081.1.1-66          81.1.66
+      2081.1          2081.1.19-66         81.19.66
+      2081.1          2081.1.20-66         81.19.66            19 bugfixes on branch
+      v2016.11.0      2016.11.0            16.200.65535        Tags have noc 0
+      v2016.11.2      2016.11.2            16.202.65535
 
     '''
     short_year = int(six.text_type(__saltstack_version__.major)[2:])
     month = __saltstack_version__.minor
     bugfix = __saltstack_version__.bugfix
-    if bugfix>20:
-        bugfix = 20
+    if bugfix>19:
+        bugfix = 19
     noc = __saltstack_version__.noc
     if noc == 0:
         noc = 65535

--- a/salt/version.py
+++ b/salt/version.py
@@ -737,12 +737,13 @@ def msi_conformant_version():
             noc for tags is 0, representing the final word, translates to the highest build number (65535).
 
     Examples:
-      git checkout    Display version            Internal version
-      develop         2016.11.0-742-g5ca4d20     16.200.742
-      2016.11         2016.11.2-78-gce1f01f      16.202.78
-      2016.11         2016.11.9-88-g3e844ed1df   16.209.88
-      v2016.11.0      2016.11.0                  16.200.65535
-      v2016.11.2      2016.11.2                  16.202.65535
+      git checkout    Display version               Internal version
+      develop         2016.11.0-742-g5ca4d20        16.200.742
+      2016.11         2016.11.2-78-gce1f01f         16.202.78
+      2016.11         2016.11.9-88-g3e844ed1df      16.209.88
+      2018.8          2018.3.2-1306-g1e150923aa     18.42.1306
+      v2016.11.0      2016.11.0                     16.200.65535
+      v2016.11.2      2016.11.2                     16.202.65535
 
     '''
     short_year = int(six.text_type(__saltstack_version__.major)[2:])

--- a/salt/version.py
+++ b/salt/version.py
@@ -753,7 +753,7 @@ def msi_conformant_version():
     noc = __saltstack_version__.noc
     if noc == 0:
         noc = 65535
-    return '{}.{}.{}'.format(short_year, 20*(month-1)+bugfix, minor, noc)
+    return '{}.{}.{}'.format(short_year, 20*(month-1)+bugfix, noc)
 
 if __name__ == '__main__':
     if len(sys.argv) == 2 and sys.argv[1] == 'msi':


### PR DESCRIPTION
### What does this PR do?
Use git commit count in the Windows "internal version" for the msi installer.

### Previous Behavior
The Windows msi installer recognized previous versions by bugfix.
One had to manually uninstall previous git commit changes.

### New Behavior
The msi installer recognizes previous versions by git commit.

### Tests written?
By building the msi.


