### PR TITLE
Handle ifconfig output differently for NetBSD >= 8.0

### DIFF
--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -36,6 +36,7 @@ import salt.utils.zeromq
 from salt._compat import ipaddress
 from salt.exceptions import SaltClientError, SaltSystemExit
 from salt.utils.decorators.jinja import jinja_filter
+from salt.utils.versions import LooseVersion
 
 # inet_pton does not exist in Windows, this is a workaround
 if salt.utils.platform.is_windows():
@@ -865,6 +866,82 @@ def linux_interfaces():
         ifaces = _interfaces_ifconfig(salt.utils.stringutils.to_str(cmd))
     return ifaces
 
+def _netbsd_interfaces_ifconfig(out):
+    '''
+    Uses ifconfig to return a dictionary of interfaces with various information
+    about each (up/down state, ip address, netmask, and hwaddr)
+    '''
+    ret = dict()
+
+    piface = re.compile(r'^([^\s:]+)')
+    pmac = re.compile('.*?address: ([0-9a-f:]+)')
+
+    pip = re.compile(r'.*?inet [^\d]*(.*?)/([\d]*)\s')
+    pip6 = re.compile('.*?inet6 ([0-9a-f:]+)%([a-zA-Z0-9]*)/([\d]*)\s')
+
+    pupdown = re.compile('UP')
+    pbcast = re.compile(r'.*?broadcast ([\d\.]+)')
+
+    groups = re.compile('\r?\n(?=\\S)').split(out)
+    for group in groups:
+        data = dict()
+        iface = ''
+        updown = False
+        for line in group.splitlines():
+            miface = piface.match(line)
+            mmac = pmac.match(line)
+            mip = pip.match(line)
+            mip6 = pip6.match(line)
+            mupdown = pupdown.search(line)
+            if miface:
+                iface = miface.group(1)
+            if mmac:
+                data['hwaddr'] = mmac.group(1)
+            if mip:
+                if 'inet' not in data:
+                    data['inet'] = list()
+                addr_obj = dict()
+                addr_obj['address'] = mip.group(1)
+                mmask = mip.group(2)
+                if mip.group(2):
+                    addr_obj['netmask'] = cidr_to_ipv4_netmask(mip.group(2))
+                mbcast = pbcast.match(line)
+                if mbcast:
+                    addr_obj['broadcast'] = mbcast.group(1)
+                data['inet'].append(addr_obj)
+            if mupdown:
+                updown = True
+            if mip6:
+                if 'inet6' not in data:
+                    data['inet6'] = list()
+                addr_obj = dict()
+                addr_obj['address'] = mip6.group(1)
+                mmask6 = mip6.group(3)
+                addr_obj['scope'] = mip6.group(2)
+                addr_obj['prefixlen'] = mip6.group(3)
+                data['inet6'].append(addr_obj)
+        data['up'] = updown
+        ret[iface] = data
+        del data
+    return ret
+
+def netbsd_interfaces():
+    '''
+    Obtain interface information for NetBSD >= 8 where the ifconfig
+    output diverged from other BSD variants (Netmask is now part of the
+    address)
+    '''
+    # NetBSD versions prior to 8.0 can still use linux_interfaces()
+    if LooseVersion(os.uname()[2]) < LooseVersion('8.0'):
+        return linux_interfaces()
+
+    ifconfig_path = salt.utils.path.which('ifconfig')
+    cmd = subprocess.Popen(
+        '{0} -a'.format(ifconfig_path),
+        shell=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT).communicate()[0]
+    return _netbsd_interfaces_ifconfig(salt.utils.stringutils.to_str(cmd))
 
 def _interfaces_ipconfig(out):
     '''
@@ -967,6 +1044,8 @@ def interfaces():
     '''
     if salt.utils.platform.is_windows():
         return win_interfaces()
+    elif salt.utils.platform.is_netbsd():
+        return netbsd_interfaces()
     else:
         return linux_interfaces()
 

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -866,6 +866,7 @@ def linux_interfaces():
         ifaces = _interfaces_ifconfig(salt.utils.stringutils.to_str(cmd))
     return ifaces
 
+
 def _netbsd_interfaces_ifconfig(out):
     '''
     Uses ifconfig to return a dictionary of interfaces with various information
@@ -877,7 +878,7 @@ def _netbsd_interfaces_ifconfig(out):
     pmac = re.compile('.*?address: ([0-9a-f:]+)')
 
     pip = re.compile(r'.*?inet [^\d]*(.*?)/([\d]*)\s')
-    pip6 = re.compile('.*?inet6 ([0-9a-f:]+)%([a-zA-Z0-9]*)/([\d]*)\s')
+    pip6 = re.compile(r'.*?inet6 ([0-9a-f:]+)%([a-zA-Z0-9]*)/([\d]*)\s')
 
     pupdown = re.compile('UP')
     pbcast = re.compile(r'.*?broadcast ([\d\.]+)')
@@ -925,6 +926,7 @@ def _netbsd_interfaces_ifconfig(out):
         del data
     return ret
 
+
 def netbsd_interfaces():
     '''
     Obtain interface information for NetBSD >= 8 where the ifconfig
@@ -942,6 +944,7 @@ def netbsd_interfaces():
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT).communicate()[0]
     return _netbsd_interfaces_ifconfig(salt.utils.stringutils.to_str(cmd))
+
 
 def _interfaces_ipconfig(out):
     '''

--- a/tests/unit/utils/test_network.py
+++ b/tests/unit/utils/test_network.py
@@ -96,6 +96,19 @@ vpn0: flags=120002200850<POINTOPOINT,RUNNING,MULTICAST,NONUD,IPv6,PHYSRUNNING> m
         inet6 ::/0 --> fe80::b2d6:7c10
 '''
 
+NETBSD = '''\
+vioif0: flags=0x8943<UP,BROADCAST,RUNNING,PROMISC,SIMPLEX,MULTICAST> mtu 1500
+        ec_capabilities=1<VLAN_MTU>
+        ec_enabled=0
+        address: 00:a0:98:e6:83:18
+        inet 192.168.1.80/24 broadcast 192.168.1.255 flags 0x0
+        inet6 fe80::2a0:98ff:fee6:8318%vioif0/64 flags 0x0 scopeid 0x1
+lo0: flags=0x8049<UP,LOOPBACK,RUNNING,MULTICAST> mtu 33624
+        inet 127.0.0.1/8 flags 0x0
+        inet6 ::1/128 flags 0x20<NODAD>
+        inet6 fe80::1%lo0/64 flags 0x0 scopeid 0x2
+'''
+
 FREEBSD_SOCKSTAT = '''\
 USER    COMMAND     PID     FD  PROTO  LOCAL ADDRESS    FOREIGN ADDRESS
 root    python2.7   1294    41  tcp4   127.0.0.1:61115  127.0.0.1:4506
@@ -314,6 +327,24 @@ class NetworkTestCase(TestCase):
                                              'address': '10.10.10.38'}],
                                             'up': True}}
             self.assertEqual(interfaces, expected_interfaces)
+
+    def test_interfaces_ifconfig_netbsd(self):
+        interfaces = network._netbsd_interfaces_ifconfig(NETBSD)
+        self.assertEqual(interfaces,
+                          {'lo0': {'inet': [{'address': '127.0.0.1', 'netmask': '255.0.0.0'}],
+                                   'inet6': [{'address': 'fe80::1',
+                                               'prefixlen': '64',
+                                               'scope': 'lo0'}],
+                                   'up': True},
+                           'vioif0': {'hwaddr': '00:a0:98:e6:83:18',
+                                      'inet': [{'address': '192.168.1.80',
+                                                 'broadcast': '192.168.1.255',
+                                                 'netmask': '255.255.255.0'}],
+                                      'inet6': [{'address': 'fe80::2a0:98ff:fee6:8318',
+                                                  'prefixlen': '64',
+                                                  'scope': 'vioif0'}],
+                                      'up': True}}
+        )
 
     def test_freebsd_remotes_on(self):
         with patch('salt.utils.platform.is_sunos', lambda: False):


### PR DESCRIPTION
### What does this PR do?
Calls a new function: ``netbsd_interfaces()`` to get networking info on NetBSD.

If the NetBSD version is >= 8.0 ``_netbsd_interfaces_ifconfig()`` is used to parse the output of ifconfig.

### What issues does this PR fix or reference?
#48856

### Previous Behavior
Salt fails to start on NetBSD 8.0 due to changes in ifconfig output.

### New Behavior
Salt no longer fails to start and the new ifconfig output is parsed.

### Tests written?

Yes

### Commits signed with GPG?

Yes