### PR TITLE
fix test_runas integration test for macosx

### DIFF
--- a/tests/integration/modules/test_cmdmod.py
+++ b/tests/integration/modules/test_cmdmod.py
@@ -38,6 +38,7 @@ class CMDModuleTest(ModuleCase):
     '''
     Validate the cmd module
     '''
+    @destructiveTest
     def setUp(self):
         if self._testMethodName == 'test_runas':
             # only need to manage this user for the test_runas test
@@ -47,6 +48,7 @@ class CMDModuleTest(ModuleCase):
                 if self.runas_usr not in self.run_function('user.info', [self.runas_usr]).values():
                     self.run_function('user.add', [self.runas_usr])
 
+    @destructiveTest
     def tearDown(self):
         if self._testMethodName == 'test_runas':
             if salt.utils.platform.is_darwin():
@@ -281,7 +283,6 @@ class CMDModuleTest(ModuleCase):
 
     @skipIf(salt.utils.platform.is_windows(), 'minion is windows')
     @skip_if_not_root
-    @destructiveTest
     def test_runas(self):
         '''
         Ensure that the env is the runas user's

--- a/tests/integration/modules/test_cmdmod.py
+++ b/tests/integration/modules/test_cmdmod.py
@@ -38,6 +38,21 @@ class CMDModuleTest(ModuleCase):
     '''
     Validate the cmd module
     '''
+    def setUp(self):
+        if self._testMethodName == 'test_runas':
+            # only need to manage this user for the test_runas test
+            self.runas_usr = 'nobody'
+            if salt.utils.platform.is_darwin():
+                self.runas_usr = 'macsalttest'
+                if self.runas_usr not in self.run_function('user.info', [self.runas_usr]).values():
+                    self.run_function('user.add', [self.runas_usr])
+
+    def tearDown(self):
+        if self._testMethodName == 'test_runas':
+            if salt.utils.platform.is_darwin():
+                if self.runas_usr in self.run_function('user.info', [self.runas_usr]).values():
+                    self.run_function('user.delete', [self.runas_usr], remove=True)
+
     def test_run(self):
         '''
         cmd.run
@@ -266,12 +281,13 @@ class CMDModuleTest(ModuleCase):
 
     @skipIf(salt.utils.platform.is_windows(), 'minion is windows')
     @skip_if_not_root
+    @destructiveTest
     def test_runas(self):
         '''
         Ensure that the env is the runas user's
         '''
-        out = self.run_function('cmd.run', ['env'], runas='nobody').splitlines()
-        self.assertIn('USER=nobody', out)
+        out = self.run_function('cmd.run', ['env'], runas=self.runas_usr).splitlines()
+        self.assertIn('USER={0}'.format(self.runas_usr), out)
 
     def test_timeout(self):
         '''

--- a/tests/integration/modules/test_cmdmod.py
+++ b/tests/integration/modules/test_cmdmod.py
@@ -39,7 +39,6 @@ class CMDModuleTest(ModuleCase):
     Validate the cmd module
     '''
     def setUp(self):
-        # only need to manage this user for the test_runas test
         self.runas_usr = 'nobody'
         if salt.utils.platform.is_darwin():
             self.runas_usr = 'macsalttest'

--- a/tests/integration/modules/test_cmdmod.py
+++ b/tests/integration/modules/test_cmdmod.py
@@ -38,17 +38,12 @@ class CMDModuleTest(ModuleCase):
     '''
     Validate the cmd module
     '''
-    @destructiveTest
     def setUp(self):
-        if self._testMethodName == 'test_runas':
-            # only need to manage this user for the test_runas test
-            self.runas_usr = 'nobody'
-            if salt.utils.platform.is_darwin():
-                self.runas_usr = 'macsalttest'
-                if self.runas_usr not in self.run_function('user.info', [self.runas_usr]).values():
-                    self.run_function('user.add', [self.runas_usr])
+        # only need to manage this user for the test_runas test
+        self.runas_usr = 'nobody'
+        if salt.utils.platform.is_darwin():
+            self.runas_usr = 'macsalttest'
 
-    @destructiveTest
     def tearDown(self):
         if self._testMethodName == 'test_runas':
             if salt.utils.platform.is_darwin():
@@ -283,10 +278,15 @@ class CMDModuleTest(ModuleCase):
 
     @skipIf(salt.utils.platform.is_windows(), 'minion is windows')
     @skip_if_not_root
+    @destructiveTest
     def test_runas(self):
         '''
         Ensure that the env is the runas user's
         '''
+        if salt.utils.platform.is_darwin():
+            if self.runas_usr not in self.run_function('user.info', [self.runas_usr]).values():
+                self.run_function('user.add', [self.runas_usr])
+
         out = self.run_function('cmd.run', ['env'], runas=self.runas_usr).splitlines()
         self.assertIn('USER={0}'.format(self.runas_usr), out)
 


### PR DESCRIPTION
### What does this PR do?
The test `integration.modules.test_cmdmod.CMDModuleTest.test_runas` which was recently added is failing on macosx because it can't use the nobody user. Adding some setup and teardown logic which will add a mac user to test the runas functionality.