### PR TITLE
Fix pkg.install when pkg already installed

### DIFF
--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -1097,7 +1097,8 @@ def install(name=None, refresh=False, pkgs=None, **kwargs):
             .. versionadded:: 2016.11.0
 
     Returns:
-        dict: Return a dict containing the new package names and versions
+        dict: Return a dict containing the new package names and versions. If
+        the package is already installed, an empty dict is returned.
 
         If the package is installed by ``pkg.install``:
 
@@ -1105,12 +1106,6 @@ def install(name=None, refresh=False, pkgs=None, **kwargs):
 
             {'<package>': {'old': '<old-version>',
                            'new': '<new-version>'}}
-
-        If the package is already installed:
-
-        .. code-block:: cfg
-
-            {'<package>': {'current': '<current-version>'}}
 
     The following example will refresh the winrepo and install a single
     package, 7zip.
@@ -1205,7 +1200,6 @@ def install(name=None, refresh=False, pkgs=None, **kwargs):
 
     # Loop through each package
     changed = []
-    latest = []
     for pkg_name, options in six.iteritems(pkg_params):
 
         # Load package information for the package
@@ -1250,9 +1244,6 @@ def install(name=None, refresh=False, pkgs=None, **kwargs):
                       version_num, pkg_name)
             ret[pkg_name] = {'not found': version_num}
             continue
-
-        if 'latest' in pkginfo:
-            latest.append(pkg_name)
 
         # Get the installer settings from winrepo.p
         installer = pkginfo[version_num].get('installer', '')
@@ -1467,15 +1458,6 @@ def install(name=None, refresh=False, pkgs=None, **kwargs):
     # Take the "old" package list and convert the values to strings in
     # preparation for the comparison below.
     __salt__['pkg_resource.stringify'](old)
-
-    # For installers that have no specific version (ie: chrome)
-    # The software definition file will have a version of 'latest'
-    # In that case there's no way to know which version has been installed
-    # Just return the current installed version
-    if latest:
-        for pkg_name in latest:
-            if old.get(pkg_name, 'old') == new.get(pkg_name, 'new'):
-                ret[pkg_name] = {'current': new[pkg_name]}
 
     # Check for changes in the registry
     difference = salt.utils.data.compare_dicts(old, new)

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -1235,7 +1235,7 @@ def install(name=None, refresh=False, pkgs=None, **kwargs):
 
         if version_num.lower() == 'latest' and 'latest' not in pkginfo:
             # Get the most recent version number available from winrepo.p
-            # May also return `latest` or and empty string
+            # May also return `latest` or an empty string
             version_num = _get_latest_pkg_version(pkginfo)
 
         # Check if the version is already installed

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -1236,6 +1236,7 @@ def install(name=None, refresh=False, pkgs=None, **kwargs):
 
         if version_num.lower() == 'latest' and 'latest' not in pkginfo:
             # Get the most recent version number available from winrepo.p
+            # May also return `latest` or and empty string
             version_num = _get_latest_pkg_version(pkginfo)
 
         # Check if the version is already installed

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -1217,31 +1217,36 @@ def install(name=None, refresh=False, pkgs=None, **kwargs):
             ret[pkg_name] = 'Unable to locate package {0}'.format(pkg_name)
             continue
 
-        version_num = options.get('version', '')
+        version_num = options.get('version')
         #  Using the salt cmdline with version=5.3 might be interpreted
         #  as a float it must be converted to a string in order for
         #  string matching to work.
         if not isinstance(version_num, six.string_types) and version_num is not None:
             version_num = six.text_type(version_num)
 
+        # If the version was not passed, version_num will be None
         if not version_num:
             if pkg_name in old:
-                log.debug('A version (%s) already installed for package '
-                          '%s', version_num, pkg_name)
+                log.debug('"%s" version "%s" is already installed',
+                          pkg_name, old[pkg_name][0])
+                ret[pkg_name] = {'current': old[pkg_name][0]}
                 continue
-            # following can be version number or latest or Not Found
+            # Get the most recent version number available from winrepo.p
             version_num = _get_latest_pkg_version(pkginfo)
 
-        if version_num == 'latest' and 'latest' not in pkginfo:
+        if version_num.lower() == 'latest' and 'latest' not in pkginfo:
+            # Get the most recent version number available from winrepo.p
             version_num = _get_latest_pkg_version(pkginfo)
 
         # Check if the version is already installed
         if version_num in old.get(pkg_name, []):
             # Desired version number already installed
+            log.debug('"%s" version "%s" is already installed',
+                      pkg_name, version_num)
             ret[pkg_name] = {'current': version_num}
             continue
         # If version number not installed, is the version available?
-        elif version_num != 'latest' and version_num not in pkginfo:
+        elif version_num.lower() != 'latest' and version_num not in pkginfo:
             log.error('Version %s not found for package %s',
                       version_num, pkg_name)
             ret[pkg_name] = {'not found': version_num}

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -1221,13 +1221,14 @@ def install(name=None, refresh=False, pkgs=None, **kwargs):
         # If the version was not passed, version_num will be None
         if not version_num:
             if pkg_name in old:
-                log.debug('"%s" version "%s" is already installed',
+                log.debug('pkg.install: \'%s\' version \'%s\' is already installed',
                           pkg_name, old[pkg_name][0])
                 continue
             # Get the most recent version number available from winrepo.p
+            # May also return `latest` or an empty string
             version_num = _get_latest_pkg_version(pkginfo)
 
-        if version_num.lower() == 'latest' and 'latest' not in pkginfo:
+        if version_num == 'latest' and 'latest' not in pkginfo:
             # Get the most recent version number available from winrepo.p
             # May also return `latest` or an empty string
             version_num = _get_latest_pkg_version(pkginfo)
@@ -1235,11 +1236,11 @@ def install(name=None, refresh=False, pkgs=None, **kwargs):
         # Check if the version is already installed
         if version_num in old.get(pkg_name, []):
             # Desired version number already installed
-            log.debug('"%s" version "%s" is already installed',
+            log.debug('pkg.install: \'%s\' version \'%s\' is already installed',
                       pkg_name, version_num)
             continue
         # If version number not installed, is the version available?
-        elif version_num.lower() != 'latest' and version_num not in pkginfo:
+        elif version_num != 'latest' and version_num not in pkginfo:
             log.error('Version %s not found for package %s',
                       version_num, pkg_name)
             ret[pkg_name] = {'not found': version_num}
@@ -1335,12 +1336,12 @@ def install(name=None, refresh=False, pkgs=None, **kwargs):
         source_hash = pkginfo[version_num].get('source_hash', False)
         if source_hash:
             source_sum = _get_source_sum(source_hash, cached_pkg, saltenv)
-            log.debug('Source %s hash: %s',
+            log.debug('pkg.install: Source %s hash: %s',
                       source_sum['hash_type'], source_sum['hsum'])
 
             cached_pkg_sum = salt.utils.hashutils.get_hash(cached_pkg,
                                                            source_sum['hash_type'])
-            log.debug('Package %s hash: %s',
+            log.debug('pkg.install: Package %s hash: %s',
                       source_sum['hash_type'], cached_pkg_sum)
 
             if source_sum['hsum'] != cached_pkg_sum:
@@ -1348,7 +1349,7 @@ def install(name=None, refresh=False, pkgs=None, **kwargs):
                     ("Source hash '{0}' does not match package hash"
                      " '{1}'").format(source_sum['hsum'], cached_pkg_sum)
                 )
-            log.debug('Source hash matches package hash.')
+            log.debug('pkg.install: Source hash matches package hash.')
 
         # Get install flags
 

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -1229,7 +1229,6 @@ def install(name=None, refresh=False, pkgs=None, **kwargs):
             if pkg_name in old:
                 log.debug('"%s" version "%s" is already installed',
                           pkg_name, old[pkg_name][0])
-                ret[pkg_name] = {'current': old[pkg_name][0]}
                 continue
             # Get the most recent version number available from winrepo.p
             version_num = _get_latest_pkg_version(pkginfo)
@@ -1244,7 +1243,6 @@ def install(name=None, refresh=False, pkgs=None, **kwargs):
             # Desired version number already installed
             log.debug('"%s" version "%s" is already installed',
                       pkg_name, version_num)
-            ret[pkg_name] = {'current': version_num}
             continue
         # If version number not installed, is the version available?
         elif version_num.lower() != 'latest' and version_num not in pkginfo:

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -1340,7 +1340,7 @@ def install(name=None, refresh=False, pkgs=None, **kwargs):
 
         # Fix non-windows slashes
         cached_pkg = cached_pkg.replace('/', '\\')
-        cache_path, _ = os.path.split(cached_pkg)
+        cache_path = os.path.dirname(cached_pkg)
 
         # Compare the hash sums
         source_hash = pkginfo[version_num].get('source_hash', False)

--- a/tests/unit/modules/test_win_pkg.py
+++ b/tests/unit/modules/test_win_pkg.py
@@ -1,0 +1,159 @@
+# -*- coding: utf-8 -*-
+'''
+Tests for the win_pkg module
+'''
+
+# Import Python Libs
+from __future__ import absolute_import, unicode_literals, print_function
+import os
+
+# Import Salt Testing Libs
+from tests.support.helpers import destructiveTest
+from tests.support.mixins import LoaderModuleMockMixin
+from tests.support.mock import MagicMock, patch
+from tests.support.paths import TMP
+from tests.support.unit import TestCase, skipIf
+
+# Import Salt Libs
+import salt.modules.pkg_resource as pkg_resource
+import salt.modules.win_pkg as win_pkg
+import salt.utils.platform
+
+
+@destructiveTest
+@skipIf(not salt.utils.platform.is_windows(), 'System is not Windows')
+class WinPkgInstallTestCase(TestCase, LoaderModuleMockMixin):
+    '''
+    Test cases for salt.modules.win_pkg
+    '''
+    def setup_loader_modules(self):
+        pkg_info = {
+            '3.03': {
+                'full_name': 'Nullsoft Install System',
+                'installer': 'http://download.sourceforge.net/project/nsis/NSIS%203/3.03/nsis-3.03-setup.exe',
+                'install_flags': '/S',
+                'uninstaller': '%PROGRAMFILES(x86)%\\NSIS\\uninst-nsis.exe',
+                'uninstall_flags': '/S',
+                'msiexec': False,
+                'reboot': False
+            },
+            '3.02': {
+                'full_name': 'Nullsoft Install System',
+                'installer': 'http://download.sourceforge.net/project/nsis/NSIS%203/3.02/nsis-3.02-setup.exe',
+                'install_flags': '/S',
+                'uninstaller': '%PROGRAMFILES(x86)%\\NSIS\\uninst-nsis.exe',
+                'uninstall_flags': '/S',
+                'msiexec': False,
+                'reboot': False
+            }
+        }
+
+        return{
+            win_pkg: {
+                '_get_latest_package_version': MagicMock(return_value='3.03'),
+                '_get_package_info': MagicMock(return_value=pkg_info),
+                '__salt__': {
+                    'pkg_resource.add_pkg': pkg_resource.add_pkg,
+                    'pkg_resource.parse_targets': pkg_resource.parse_targets,
+                    'pkg_resource.sort_pkglist': pkg_resource.sort_pkglist,
+                    'pkg_resource.stringify': pkg_resource.stringify,
+                },
+            },
+            pkg_resource: {
+                '__grains__': {
+                    'os': 'Windows'
+                }
+            },
+        }
+
+    def test_pkg_install_not_found(self):
+        '''
+        Test pkg.install when the Version is NOT FOUND in the Software
+        Definition
+        '''
+        ret_reg = {'Nullsoft Install System': '3.03'}
+        # The 2nd time it's run with stringify
+        se_list_pkgs = {'nsis': ['3.03']}
+        with patch.object(win_pkg, 'list_pkgs', return_value=se_list_pkgs), \
+                patch.object(win_pkg, '_get_reg_software', return_value=ret_reg):
+            expected = {'nsis': {'not found': '3.01'}}
+            result = win_pkg.install(name='nsis', version='3.01')
+            self.assertDictEqual(expected, result)
+
+    def test_pkg_install_rollback(self):
+        '''
+        test pkg.install rolling back to a previous version
+        '''
+        ret_reg = {'Nullsoft Install System': '3.03'}
+        # The 2nd time it's run, pkg.list_pkgs uses with stringify
+        se_list_pkgs = [{'nsis': ['3.03']},
+                        {'nsis': '3.02'}]
+        with patch.object(win_pkg, 'list_pkgs', side_effect=se_list_pkgs), \
+                patch.object(
+                    win_pkg, '_get_reg_software', return_value=ret_reg), \
+                patch.dict(
+                    win_pkg.__salt__,
+                    {'cp.is_cached': MagicMock(return_value=False)}), \
+                patch.dict(
+                    win_pkg.__salt__,
+                    {'cp.cache_file':
+                         MagicMock(return_value='C:\\fake\\path.exe')}), \
+                patch.dict(
+                    win_pkg.__salt__,
+                    {'cmd.run_all':
+                         MagicMock(return_value={'retcode': 0})}):
+            expected = {'nsis': {'new': '3.02', 'old': '3.03'}}
+            result = win_pkg.install(name='nsis', version='3.02')
+            self.assertDictEqual(expected, result)
+
+    def test_pkg_install_existing(self):
+        '''
+        test pkg.install when the package is already installed
+        no version passed
+        '''
+        ret_reg = {'Nullsoft Install System': '3.03'}
+        # The 2nd time it's run, pkg.list_pkgs uses with stringify
+        se_list_pkgs = {'nsis': ['3.03']}
+        with patch.object(win_pkg, 'list_pkgs', return_value=se_list_pkgs), \
+                patch.object(
+                    win_pkg, '_get_reg_software', return_value=ret_reg), \
+                patch.dict(
+                    win_pkg.__salt__,
+                    {'cp.is_cached': MagicMock(return_value=False)}), \
+                patch.dict(
+                    win_pkg.__salt__,
+                    {'cp.cache_file':
+                         MagicMock(return_value='C:\\fake\\path.exe')}), \
+                patch.dict(
+                    win_pkg.__salt__,
+                    {'cmd.run_all':
+                         MagicMock(return_value={'retcode': 0})}):
+            expected = {'nsis': {'current': '3.03'}}
+            result = win_pkg.install(name='nsis')
+            self.assertDictEqual(expected, result)
+
+    def test_pkg_install_existing_with_version(self):
+        '''
+        test pkg.install when the package is already installed
+        A version is passed
+        '''
+        ret_reg = {'Nullsoft Install System': '3.03'}
+        # The 2nd time it's run, pkg.list_pkgs uses with stringify
+        se_list_pkgs = {'nsis': ['3.03']}
+        with patch.object(win_pkg, 'list_pkgs', return_value=se_list_pkgs), \
+                patch.object(
+                    win_pkg, '_get_reg_software', return_value=ret_reg), \
+                patch.dict(
+                    win_pkg.__salt__,
+                    {'cp.is_cached': MagicMock(return_value=False)}), \
+                patch.dict(
+                    win_pkg.__salt__,
+                    {'cp.cache_file':
+                         MagicMock(return_value='C:\\fake\\path.exe')}), \
+                patch.dict(
+                    win_pkg.__salt__,
+                    {'cmd.run_all':
+                         MagicMock(return_value={'retcode': 0})}):
+            expected = {'nsis': {'current': '3.03'}}
+            result = win_pkg.install(name='nsis', version='3.03')
+            self.assertDictEqual(expected, result)

--- a/tests/unit/modules/test_win_pkg.py
+++ b/tests/unit/modules/test_win_pkg.py
@@ -5,23 +5,17 @@ Tests for the win_pkg module
 
 # Import Python Libs
 from __future__ import absolute_import, unicode_literals, print_function
-import os
 
 # Import Salt Testing Libs
-from tests.support.helpers import destructiveTest
 from tests.support.mixins import LoaderModuleMockMixin
 from tests.support.mock import MagicMock, patch
-from tests.support.paths import TMP
-from tests.support.unit import TestCase, skipIf
+from tests.support.unit import TestCase
 
 # Import Salt Libs
 import salt.modules.pkg_resource as pkg_resource
 import salt.modules.win_pkg as win_pkg
-import salt.utils.platform
 
 
-@destructiveTest
-@skipIf(not salt.utils.platform.is_windows(), 'System is not Windows')
 class WinPkgInstallTestCase(TestCase, LoaderModuleMockMixin):
     '''
     Test cases for salt.modules.win_pkg

--- a/tests/unit/modules/test_win_pkg.py
+++ b/tests/unit/modules/test_win_pkg.py
@@ -122,7 +122,7 @@ class WinPkgInstallTestCase(TestCase, LoaderModuleMockMixin):
                     win_pkg.__salt__,
                     {'cmd.run_all':
                          MagicMock(return_value={'retcode': 0})}):
-            expected = {'nsis': {'current': '3.03'}}
+            expected = {}
             result = win_pkg.install(name='nsis')
             self.assertDictEqual(expected, result)
 
@@ -148,6 +148,6 @@ class WinPkgInstallTestCase(TestCase, LoaderModuleMockMixin):
                     win_pkg.__salt__,
                     {'cmd.run_all':
                          MagicMock(return_value={'retcode': 0})}):
-            expected = {'nsis': {'current': '3.03'}}
+            expected = {}
             result = win_pkg.install(name='nsis', version='3.03')
             self.assertDictEqual(expected, result)


### PR DESCRIPTION
### What does this PR do?
Fixes an issue with pkg.install on Windows where the `current: <version>` was being returned if you passed the same version that was installed. Correct behavior, when there are no changes, is to return an empty dictionary.

Adds tests to test valid output.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/48931

### Tests written?
Yes

### Commits signed with GPG?
Yes