### PR TITLE
[2017.7] Fix to test_service_disable_doesnot_exist

### DIFF
--- a/tests/integration/modules/test_service.py
+++ b/tests/integration/modules/test_service.py
@@ -127,6 +127,8 @@ class ServiceModuleTest(ModuleCase):
         if tuple(self.run_function('grains.item', ['osrelease_info'])['osrelease_info']) == (14, 0o4) and not systemd:
             # currently upstart does not have a mechanism to report if disabling a service fails if does not exist
             self.assertTrue(self.run_function('service.disable', [srv_name]))
+        elif self.run_function('grains.item', ['osfullname'])['osfullname'] == 'Debian' and systemd:
+            self.assertTrue(self.run_function('service.disable', [srv_name]))
         else:
             try:
                 disable = self.run_function('service.disable', [srv_name])


### PR DESCRIPTION
### What does this PR do?
Fixing failing test, integration.modules.test_service.ServiceModuleTest.test_service_disable_doesnot_exist, on Debian 8 and higher.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt-jenkins/issues/1022

### Tests written?
Yes.  Test updated.

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
