### PR TITLE
Add grain kernelparams

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -49,6 +49,7 @@ except ImportError:
 # Import salt libs
 import salt.exceptions
 import salt.log
+import salt.utils.args
 import salt.utils.dns
 import salt.utils.files
 import salt.utils.network
@@ -2774,4 +2775,25 @@ def default_gateway():
                     break
         except Exception:
             continue
+    return grains
+
+
+def kernelparams():
+    '''
+    Return the kernel boot parameters
+    '''
+    try:
+        with salt.utils.files.fopen('/proc/cmdline', 'r') as fhr:
+            cmdline = fhr.read()
+            grains = {'kernelparams': []}
+            for data in [item.split('=') for item in salt.utils.args.shlex_split(cmdline)]:
+                value = None
+                if len(data) == 2:
+                    value = data[1].strip('"')
+
+                grains['kernelparams'] += [(data[0], value)]
+    except IOError as exc:
+        grains = {}
+        log.debug('Failed to read /proc/cmdline: %s', exc)
+
     return grains

--- a/tests/unit/grains/test_core.py
+++ b/tests/unit/grains/test_core.py
@@ -1004,3 +1004,32 @@ class CoreGrainsTestCase(TestCase, LoaderModuleMockMixin):
                 assert ret[count]['model'] == device[2]
                 assert ret[count]['vendor'] == device[3]
                 count += 1
+
+    @skipIf(not salt.utils.platform.is_linux(), 'System is not Linux')
+    def test_kernelparams_return(self):
+        expectations = [
+            ('BOOT_IMAGE=/vmlinuz-3.10.0-693.2.2.el7.x86_64',
+             {'kernelparams': [('BOOT_IMAGE', '/vmlinuz-3.10.0-693.2.2.el7.x86_64')]}),
+            ('root=/dev/mapper/centos_daemon-root',
+             {'kernelparams': [('root', '/dev/mapper/centos_daemon-root')]}),
+            ('rhgb quiet ro',
+             {'kernelparams': [('rhgb', None), ('quiet', None), ('ro', None)]}),
+            ('param="value1"',
+             {'kernelparams': [('param', 'value1')]}),
+            ('param="value1 value2 value3"',
+             {'kernelparams': [('param', 'value1 value2 value3')]}),
+            ('param="value1 value2 value3" LANG="pl" ro',
+             {'kernelparams': [('param', 'value1 value2 value3'), ('LANG', 'pl'), ('ro', None)]}),
+            ('ipv6.disable=1',
+             {'kernelparams': [('ipv6.disable', '1')]}),
+            ('param="value1:value2:value3"',
+             {'kernelparams': [('param', 'value1:value2:value3')]}),
+            ('param="value1,value2,value3"',
+             {'kernelparams': [('param', 'value1,value2,value3')]}),
+            ('param="value1" param="value2" param="value3"',
+             {'kernelparams': [('param', 'value1'), ('param', 'value2'), ('param', 'value3')]}),
+        ]
+
+        for cmdline, expectation in expectations:
+            with patch('salt.utils.files.fopen', mock_open(read_data=cmdline)):
+                self.assertEqual(core.kernelparams(), expectation)


### PR DESCRIPTION
### What does this PR do?
Parse /proc/cmdline on Linux and provide grain with list of
kernel parameters.

### What issues does this PR fix or reference?
#48501

### New Behavior
Provide grain `kernelparams` on Linux with list of kernel boot parameters:

Example:
```
    kernelparams:
        ----------
        BOOT_IMAGE:
            /vmlinuz-3.10.0-862.3.2.el7.x86_64
        LANG:
            en_US.UTF-8
        quiet:
            None
        rd.lvm.lv:
            centos_daemon/swap
        rhgb:
            None
        ro:
            None
        root:
            /dev/mapper/centos_daemon-root
```
### Tests written?
Yes