### PR TITLE
Rethinking the way configuration management for network devices is handled

### DIFF
--- a/salt/modules/napalm_network.py
+++ b/salt/modules/napalm_network.py
@@ -2033,6 +2033,13 @@ def load_template(template_name=None,
                 }
             )
     else:
+        salt.utils.versions.warn_until(
+            'Sodium',
+            'Native NAPALM templates support will be removed in the Sodium '
+            'release. Please consider using the Salt rendering pipeline instead.'
+            'If you are using the \'netntp\', \'netsnmp\', or \'netusers\' Salt '
+            'State modules, you can ignore this message'
+        )
         # otherwise, use NAPALM render system, injecting pillar/grains/opts vars
         load_templates_params = defaults if defaults else {}
         load_templates_params.update(template_vars)

--- a/salt/modules/napalm_network.py
+++ b/salt/modules/napalm_network.py
@@ -1547,7 +1547,7 @@ def load_config(filename=None,
 
 
 @salt.utils.napalm.proxy_napalm_wrap
-def load_template(template_name,
+def load_template(template_name=None,
                   template_source=None,
                   template_hash=None,
                   template_hash_name=None,

--- a/salt/modules/napalm_network.py
+++ b/salt/modules/napalm_network.py
@@ -1373,7 +1373,7 @@ def load_config(filename=None,
             applies a manual configuration change, or a different process or
             command changes the configuration in the meanwhile).
 
-        .. versionadded: Fluorine
+        .. versionadded:: Fluorine
 
     commit_at: ``None``
         Commit the changes at a specific time. Example of accepted formats:
@@ -1397,7 +1397,7 @@ def load_config(filename=None,
             applies a manual configuration change, or a different process or
             command changes the configuration in the meanwhile).
 
-        .. versionadded: Fluorine
+        .. versionadded:: Fluorine
 
     revert_in: ``None``
         Commit and revert the changes in a specific number of minutes / hours.
@@ -1428,7 +1428,7 @@ def load_config(filename=None,
             commit and till the changes are reverted), these changes would be
             equally reverted, as Salt cannot be aware of them.
 
-        .. versionadded: Fluorine
+        .. versionadded:: Fluorine
 
     revert_at: ``None``
         Commit and revert the changes at a specific time. Example of accepted
@@ -1458,7 +1458,7 @@ def load_config(filename=None,
             commit and till the changes are reverted), these changes would be
             equally reverted, as Salt cannot be aware of them.
 
-        .. versionadded: Fluorine
+        .. versionadded:: Fluorine
 
     saltenv: ``base``
         Specifies the Salt environment name.
@@ -1715,7 +1715,7 @@ def load_template(template_name=None,
             applies a manual configuration change, or a different process or
             command changes the configuration in the meanwhile).
 
-        .. versionadded: Fluorine
+        .. versionadded:: Fluorine
 
     commit_at: ``None``
         Commit the changes at a specific time. Example of accepted formats:
@@ -1739,7 +1739,7 @@ def load_template(template_name=None,
             applies a manual configuration change, or a different process or
             command changes the configuration in the meanwhile).
 
-        .. versionadded: Fluorine
+        .. versionadded:: Fluorine
 
     revert_in: ``None``
         Commit and revert the changes in a specific number of minutes / hours.
@@ -1770,7 +1770,7 @@ def load_template(template_name=None,
             commit and till the changes are reverted), these changes would be
             equally reverted, as Salt cannot be aware of them.
 
-        .. versionadded: Fluorine
+        .. versionadded:: Fluorine
 
     revert_at: ``None``
         Commit and revert the changes at a specific time. Example of accepted
@@ -1800,7 +1800,7 @@ def load_template(template_name=None,
             commit and till the changes are reverted), these changes would be
             equally reverted, as Salt cannot be aware of them.
 
-        .. versionadded: Fluorine
+        .. versionadded:: Fluorine
 
     defaults: None
         Default variables/context passed to the template.
@@ -2219,7 +2219,7 @@ def cancel_commit(jid):
     Cancel a commit scheduled to be executed via the ``commit_in`` and
     ``commit_at`` arguments from the
     :py:func:`net.load_template <salt.modules.napalm_network.load_template>` or
-    :py:func:`net.load_config <salt.modules.napalm_network.load_config`
+    :py:func:`net.load_config <salt.modules.napalm_network.load_config>`
     execution functions. The commit ID is displayed when the commit is scheduled
     via the functions named above.
 
@@ -2246,7 +2246,7 @@ def confirm_commit(jid):
     Confirm a commit scheduled to be reverted via the ``revert_in`` and
     ``revert_at``  arguments from the
     :mod:`net.load_template <salt.modules.napalm_network.load_template>` or
-    :mod:`net.load_config <salt.modules.napalm_network.load_config`
+    :mod:`net.load_config <salt.modules.napalm_network.load_config>`
     execution functions. The commit ID is displayed when the commit confirmed
     is scheduled via the functions named above.
 

--- a/salt/modules/napalm_network.py
+++ b/salt/modules/napalm_network.py
@@ -29,13 +29,18 @@ import datetime
 log = logging.getLogger(__name__)
 
 # Import Salt libs
+from salt.ext import six
 import salt.utils.files
 import salt.utils.napalm
 import salt.utils.versions
 import salt.utils.templates
 
 # Import 3rd-party libs
-from salt.ext import six
+try:
+    import jxmlease  # pylint: disable=unused-import
+    HAS_JXMLEASE = True
+except ImportError:
+    HAS_JXMLEASE = False
 
 # ----------------------------------------------------------------------------------------------------------------------
 # module properties
@@ -275,7 +280,7 @@ def _config_logic(napalm_device,
                 revert_time = __utils__['timeutil.get_time_at'](time_in=revert_in,
                                                                 time_at=revert_at)
                 if __grains__['os'] == 'junos':
-                    if 'napalm.junos_rpc' not in __salt__:
+                    if not HAS_JXMLEASE:
                         loaded_result['comment'] = ('This feature requires the library jxmlease to be installed.\n'
                                 'To install, please execute: ``pip install jxmlease``.')
                         loaded_result['result'] = False

--- a/salt/modules/napalm_network.py
+++ b/salt/modules/napalm_network.py
@@ -1895,6 +1895,7 @@ def load_template(template_name=None,
     deprecated_args = ('template_user', 'template_attrs', 'template_group', 'template_mode')
     for deprecated_arg in deprecated_args:
         if template_vars.get(deprecated_arg):
+            del template_vars[deprecated_arg]
             salt.utils.versions.warn_until(
                 'Sodium',
                 ('The \'{arg}\' argument to \'net.load_template\' is deprecated '

--- a/salt/modules/napalm_network.py
+++ b/salt/modules/napalm_network.py
@@ -1616,6 +1616,11 @@ def load_template(template_name=None,
         - ``https:/example.com/template.mako``
         - ``ftp://example.com/template.py``
 
+        .. versionchanged:: Fluorine
+            This argument can now support a list of templates to be rendered.
+            The resulting configuration text is loaded at once, as a single
+            configuration chunk.
+
     template_source: None
         Inline config template to be rendered and loaded on the device.
 
@@ -1798,10 +1803,13 @@ def load_template(template_name=None,
         Dictionary with the arguments/context to be used when the template is rendered.
 
         .. note::
-
             Do not explicitly specify this argument. This represents any other
             variable that will be sent to the template rendering system.
             Please see the examples below!
+
+        .. note::
+            It is more recommended to use the ``context`` argument to avoid
+            conflicts between CLI arguments and template variables.
 
     :return: a dictionary having the following keys:
 
@@ -1838,33 +1846,31 @@ def load_template(template_name=None,
         salt '*' net.load_template set_ntp_peers peers=[192.168.0.1]  # uses NAPALM default templates
 
         # inline template:
-        salt -G 'os:junos' net.load_template set_hostname template_source='system { host-name {{host_name}}; }' \
+        salt -G 'os:junos' net.load_template template_source='system { host-name {{host_name}}; }' \
         host_name='MX480.lab'
 
         # inline template using grains info:
-        salt -G 'os:junos' net.load_template set_hostname \
+        salt -G 'os:junos' net.load_template \
         template_source='system { host-name {{grains.model}}.lab; }'
         # if the device is a MX480, the command above will set the hostname as: MX480.lab
 
         # inline template using pillar data:
-        salt -G 'os:junos' net.load_template set_hostname template_source='system { host-name {{pillar.proxy.host}}; }'
+        salt -G 'os:junos' net.load_template template_source='system { host-name {{pillar.proxy.host}}; }'
 
-        salt '*' net.load_template my_template my_param='aaa'  # will commit
-        salt '*' net.load_template my_template my_param='aaa' test=True  # dry run
+        salt '*' net.load_template https://bit.ly/2OhSgqP hostname=example  # will commit
+        salt '*' net.load_template https://bit.ly/2OhSgqP hostname=example test=True  # dry run
 
-        salt '*' net.load_template salt://templates/my_stuff.jinja debug=True  # equivalent of the next command
-        salt '*' net.load_template my_stuff.jinja debug=True
-
-        # in case the template needs to include files that are not under the same path (e.g. http://),
-        # to help the templating engine find it, you will need to specify the `saltenv` argument:
-        salt '*' net.load_template my_stuff.jinja saltenv=/path/to/includes debug=True
+        salt '*' net.load_template salt://templates/example.jinja debug=True  # Using the salt:// URI
 
         # render a mako template:
-        salt '*' net.load_template salt://templates/my_stuff.mako template_engine=mako debug=True
+        salt '*' net.load_template salt://templates/example.mako template_engine=mako debug=True
 
         # render remote template
         salt -G 'os:junos' net.load_template http://bit.ly/2fReJg7 test=True debug=True peers=['192.168.0.1']
         salt -G 'os:ios' net.load_template http://bit.ly/2gKOj20 test=True debug=True peers=['192.168.0.1']
+
+        # render multiple templates at once
+        salt '*' net.load_template "['https://bit.ly/2OhSgqP', 'salt://templates/example.jinja']" context="{'hostname': 'example'}"
 
     Example output:
 

--- a/salt/states/netconfig.py
+++ b/salt/states/netconfig.py
@@ -598,7 +598,7 @@ def managed(name,
             applies a manual configuration change, or a different process or
             command changes the configuration in the meanwhile).
 
-        .. versionadded: Fluorine
+        .. versionadded:: Fluorine
 
     commit_at: ``None``
         Commit the changes at a specific time. Example of accepted formats:
@@ -622,7 +622,7 @@ def managed(name,
             applies a manual configuration change, or a different process or
             command changes the configuration in the meanwhile).
 
-        .. versionadded: Fluorine
+        .. versionadded:: Fluorine
 
     revert_in: ``None``
         Commit and revert the changes in a specific number of minutes / hours.
@@ -653,7 +653,7 @@ def managed(name,
             commit and till the changes are reverted), these changes would be
             equally reverted, as Salt cannot be aware of them.
 
-        .. versionadded: Fluorine
+        .. versionadded:: Fluorine
 
     revert_at: ``None``
         Commit and revert the changes at a specific time. Example of accepted
@@ -683,7 +683,7 @@ def managed(name,
             commit and till the changes are reverted), these changes would be
             equally reverted, as Salt cannot be aware of them.
 
-        .. versionadded: Fluorine
+        .. versionadded:: Fluorine
 
     replace: False
         Load and replace the configuration. Default: ``False`` (will apply load merge).
@@ -842,7 +842,7 @@ def commit_cancelled(name):
     Cancel a commit scheduled to be executed via the ``commit_in`` and
     ``commit_at`` arguments from the
     :py:func:`net.load_template <salt.modules.napalm_network.load_template>` or
-    :py:func:`net.load_config <salt.modules.napalm_network.load_config`
+    :py:func:`net.load_config <salt.modules.napalm_network.load_config>`
     execution functions. The commit ID is displayed when the commit is scheduled
     via the functions named above.
 
@@ -874,7 +874,7 @@ def commit_confirmed(name):
     Confirm a commit scheduled to be reverted via the ``revert_in`` and
     ``revert_at`` arguments from the
     :mod:`net.load_template <salt.modules.napalm_network.load_template>` or
-    :mod:`net.load_config <salt.modules.napalm_network.load_config`
+    :mod:`net.load_config <salt.modules.napalm_network.load_config>`
     execution functions. The commit ID is displayed when the commit confirmed
     is scheduled via the functions named above.
 

--- a/salt/states/netconfig.py
+++ b/salt/states/netconfig.py
@@ -452,17 +452,14 @@ def saved(name,
 
 
 def managed(name,
-            template_name,
+            template_name=None,
             template_source=None,
             template_hash=None,
             template_hash_name=None,
-            template_user='root',
-            template_group='root',
-            template_mode='755',
-            template_attrs='--------------e----',
-            saltenv=None,
+            saltenv='base',
             template_engine='jinja',
             skip_verify=False,
+            context=None,
             defaults=None,
             test=False,
             commit=True,
@@ -473,7 +470,6 @@ def managed(name,
             revert_in=None,
             revert_at=None,
             **template_vars):
-
     '''
     Manages the configuration on network devices.
 
@@ -523,20 +519,6 @@ def managed(name,
 
     template_hash_name: None
         When ``template_hash`` refers to a remote file, this specifies the filename to look for in that file.
-
-    template_group: root
-        Owner of file.
-
-    template_user: root
-        Group owner of file.
-
-    template_mode: 755
-        Permissions of file
-
-    template_attrs: "--------------e----"
-        Attributes of file (see `man lsattr`)
-
-        .. versionadded:: 2018.3.0
 
     saltenv: base
         Specifies the template environment. This will influence the relative imports inside the templates.
@@ -810,17 +792,14 @@ def managed(name,
     revert_in = __salt__['config.merge']('revert_in', revert_in)
     revert_at = __salt__['config.merge']('revert_at', revert_at)
 
-    config_update_ret = _update_config(template_name,
+    config_update_ret = _update_config(template_name=template_name,
                                        template_source=template_source,
                                        template_hash=template_hash,
                                        template_hash_name=template_hash_name,
-                                       template_user=template_user,
-                                       template_group=template_group,
-                                       template_mode=template_mode,
-                                       template_attrs=template_attrs,
                                        saltenv=saltenv,
                                        template_engine=template_engine,
                                        skip_verify=skip_verify,
+                                       context=context,
                                        defaults=defaults,
                                        test=test,
                                        commit=commit,

--- a/salt/states/netconfig.py
+++ b/salt/states/netconfig.py
@@ -675,6 +675,11 @@ def managed(name,
     replace: False
         Load and replace the configuration. Default: ``False`` (will apply load merge).
 
+    context: None
+        Overrides default context variables passed to the template.
+
+        .. versionadded:: Fluorine
+
     defaults: None
         Default variables/context passed to the template.
 

--- a/salt/states/netconfig.py
+++ b/salt/states/netconfig.py
@@ -511,6 +511,11 @@ def managed(name,
         - ``https:/example.com/template.mako``
         - ``ftp://example.com/template.py``
 
+        .. versionchanged:: Fluorine
+            This argument can now support a list of templates to be rendered.
+            The resulting configuration text is loaded at once, as a single
+            configuration chunk.
+
     template_source: None
         Inline config template to be rendered and loaded on the device.
 
@@ -679,6 +684,10 @@ def managed(name,
         see an example below! In both ``ntp_peers_example_using_pillar`` and ``ntp_peers_example``, ``peers`` is sent as
         template variable.
 
+        .. note::
+            It is more recommended to use the ``context`` argument instead, to
+            avoid any conflicts with other arguments.
+
     SLS Example (e.g.: under salt://router/config.sls) :
 
     .. code-block:: yaml
@@ -709,6 +718,26 @@ def managed(name,
             netconfig.managed:
                 - template_name: http://bit.ly/2gKOj20
                 - peers: {{ pillar.get('ntp.peers', []) }}
+
+    Multi template example:
+
+    .. code-block:: yaml
+
+        hostname_and_ntp:
+          netconfig.managed:
+            - template_name:
+                - https://bit.ly/2OhSgqP
+                - https://bit.ly/2M6C4Lx
+                - https://bit.ly/2OIWVTs
+            - debug: true
+            - context:
+                hostname: {{ opts.id }}
+                servers:
+                  - 172.17.17.1
+                  - 172.17.17.2
+                peers:
+                  - 192.168.0.1
+                  - 192.168.0.2
 
     Usage examples:
 


### PR DESCRIPTION
### What does this PR do?

There are two root causes for these changes:

1. The community asked several times to be able to render ore than one template in one go. This is due to the fact that many would prefer having the templates grouped logically and eventually reuse them in other contexts. In other words, break a big Jinja template into smaller and easier to digest parts, that can be later reused in other states.

I agree with this, and with these changes, this is going to be possible from now on. For example, a state such as:

```sls
hostname_and_ntp:
  netconfig.managed:
    - template_name:
        - https://bit.ly/2OhSgqP
        - https://bit.ly/2M6C4Lx
        - https://bit.ly/2OIWVTs
    - debug: true
    - context:
        hostname: {{ opts.id }}
        servers:
          - 172.17.17.1
          - 172.17.17.2
        peers:
          - 192.168.0.1
          - 192.168.0.2
```

Would totally be valid (previously only `template_name: https://bit.ly/2OhSgqP` was possible).

2. When I firstly implemented the `net.load_template` function more than 2 years ago, I still wasn't fully comfortable with Salt and I didn't have enough experience to evaluate what's the best way to render templates on the fly. This is why I ended up using `file.get_managed`: I was reading the template contents, dumping the rendered result into a temporary file, then reading the contents from there and load them into the device. Not only this is suboptimal, but Salt already has `file.apply_template_on_contents` for this exact purpose, without creating temporary files and all that mess. Using `file.get_managed` made me add a bunch of arguments such as `template_user`, `template_mode` etc., which never made sense, nobody actually used those as they refer to the temporary file which is anyway removed after this function is executed.

With this said, I'm swapping the usage of the `file.get_managed` with the more appropriate `file.apply_template_on_contents`. This also means that the `template_user`, `template_mode`, `template_group` et. al. arguments would no longer be used.

I have removed these arguments in https://github.com/saltstack/salt/commit/b5a642e1171dab75bff247ef22bfa27cf93b6969, but in case this should better be done in a later release I am happy to revert this commit and have the deprecated tags for the time being: https://github.com/saltstack/salt/commit/2ea0cbe159f4b7cbe0a5706b9488f00cff8c309a

CC @gtmanfred 

Notable byproducts:

- Faster template rendering.
- Fewer lines of code to maintain.


--------

After discussion with @gtmanfred, @rallytime and @terminalmage, (2) is not enough good reason to drop the template hash arguments, therefore we'll continue using `file.get_managed`. However, deprecating `template_user`, `template_group`, etc.