### PR TITLE
Fixed Python 3 incompatibility in methods in nilrt_ip and debian_ip.

### DIFF
--- a/salt/modules/debian_ip.py
+++ b/salt/modules/debian_ip.py
@@ -379,20 +379,14 @@ def __within(within=None, errmsg=None, dtype=None):
 
 def __space_delimited_list(value):
     '''validate that a value contains one or more space-delimited values'''
-    valid, _value, errmsg = False, value, 'space-delimited string'
-    try:
-        if hasattr(value, '__iter__'):
-            valid = True  # TODO:
-        else:
-            _value = value.split()
-            if _value == []:
-                raise ValueError
-            valid = True
-    except AttributeError:
-        pass
-    except ValueError:
-        pass
-    return (valid, _value, errmsg)
+    if isinstance(value, str):
+        value = value.strip().split()
+
+    if hasattr(value, '__iter__') and value != []:
+        return (True, value, 'space-delimited string')
+    else:
+        return (False, value, '{0} is not a valid space-delimited value.\n'.format(value))
+
 
 SALT_ATTR_TO_DEBIAN_ATTR_MAP = {
     'dns': 'dns-nameservers',

--- a/salt/modules/nilrt_ip.py
+++ b/salt/modules/nilrt_ip.py
@@ -130,20 +130,16 @@ def _space_delimited_list(value):
     '''
     validate that a value contains one or more space-delimited values
     '''
-    valid, _value, errmsg = False, value, 'space-delimited string'
-    try:
-        if hasattr(value, '__iter__'):
-            valid = True
-        else:
-            _value = value.split()
-            if _value == []:
-                raise ValueError
-            valid = True
-    except AttributeError:
-        errmsg = '{0} is not a valid list.\n'.format(value)
-    except ValueError:
-        errmsg = '{0} is not a valid list.\n'.format(value)
-    return (valid, errmsg)
+    if isinstance(value, str):
+        items = value.split(' ')
+        valid = items and all(items)
+    else:
+        valid = hasattr(value, '__iter__') and (value != [])
+
+    if valid:
+        return (True, 'space-delimited string')
+    else:
+        return (False, '{0} is not a valid list.\n'.format(value))
 
 
 def _validate_ipv4(value):


### PR DESCRIPTION
This is a forward-port (cherry-pick) of this:
https://github.com/saltstack/salt/pull/48844

after I successfully mislead @rallytime here:
https://github.com/saltstack/salt/pull/48917

@rallytime - sorry man, I was wrong. I wasn't aware of the first PR and I tested our implementation fairly recently, but only with py2. Now I did test it on NILinuxRT with py2 with the new changes and works as a charm. So we should keep those.
