### PR TITLE
Add force reconnection feature to NAPALM Proxy Minions

### DIFF
--- a/salt/proxy/napalm.py
+++ b/salt/proxy/napalm.py
@@ -3,6 +3,8 @@
 NAPALM: Network Automation and Programmability Abstraction Layer with Multivendor support
 =========================================================================================
 
+.. versionadded:: 2016.11.0
+
 Proxy minion for managing network devices via NAPALM_ library.
 
 :codeauthor: Mircea Ulinic <mircea@cloudflare.com> & Jerome Fleury <jf@cloudflare.com>
@@ -132,7 +134,28 @@ Example using a user-specific library, extending NAPALM's capabilities, e.g. ``c
     - :mod:`SNMP configuration module <salt.modules.napalm_snmp>`
     - :mod:`Users configuration management <salt.modules.napalm_users>`
 
-.. versionadded:: 2016.11.0
+.. note::
+    Beginning with release codename Fluorine, any NAPALM command executed when
+    running under a NAPALM Proxy Minion supports the ``force_reconnect``
+    magic argument.
+
+    Proxy Minions generally establish a connection with the remote network
+    device at the time of the Minion startup and that connection is going to be
+    used forever.
+
+    If one would need execute a command on the device but connecting using
+    different parameters (due to various causes, e.g., unable to authenticate
+    the user specified in the Pillar as the authentication system - say
+    TACACS+ is not available, or the DNS resolver is currently down and would
+    like to temporarily use the IP address instead, etc.), it implies updating
+    the Pillar data and restarting the Proxy Minion process restart.
+    In particular cases like that, you can pass the ``force_reconnect=True``
+    keyword argument, together with the alternative connection details, to
+    enforce the command to be executed over a separate connection.
+
+    For example, if the usual command is ``salt '*' net.arp``, you can use the
+    following to connect using a different username instead:
+    ``salt '*' net.arp username=my-alt-usr force_reconnect=True``.
 '''
 
 from __future__ import absolute_import, print_function, unicode_literals

--- a/salt/utils/napalm.py
+++ b/salt/utils/napalm.py
@@ -155,6 +155,15 @@ def call(napalm_device, method, *args, **kwargs):
     out = None
     opts = napalm_device.get('__opts__', {})
     retry = kwargs.pop('__retry', True)  # retry executing the task?
+    force_reconnect = kwargs.get('force_reconnect', False)
+    if force_reconnect:
+        log.debug('Forced reconnection initiated')
+        log.debug('The current opts (under the proxy key):')
+        log.debug(opts['proxy'])
+        opts['proxy'].update(**kwargs)
+        log.debug('Updated to:')
+        log.debug(opts['proxy'])
+        napalm_device = get_device(opts)
     try:
         if not napalm_device.get('UP', False):
             raise Exception('not connected')
@@ -361,16 +370,31 @@ def proxy_napalm_wrap(func):
         wrapped_global_namespace = func.__globals__
         # get __opts__ and __proxy__ from func_globals
         proxy = wrapped_global_namespace.get('__proxy__')
-        opts = wrapped_global_namespace.get('__opts__')
+        opts = copy.deepcopy(wrapped_global_namespace.get('__opts__'))
         # in any case, will inject the `napalm_device` global
         # the execution modules will make use of this variable from now on
         # previously they were accessing the device properties through the __proxy__ object
         always_alive = opts.get('proxy', {}).get('always_alive', True)
+        # force_reconnect is a magic keyword arg that allows one to establish
+        # a separate connection to the network device running under an always
+        # alive Proxy Minion, using new credentials (overriding the ones
+        # configured in the opts / pillar.
+        force_reconnect = kwargs.get('force_reconnect', False)
+        if force_reconnect:
+            log.debug('Usage of reconnect force detected')
+            log.debug('Opts before merging')
+            log.debug(opts['proxy'])
+            opts['proxy'].update(**kwargs)
+            log.debug('Opts after merging')
+            log.debug(opts['proxy'])
         if is_proxy(opts) and always_alive:
             # if it is running in a NAPALM Proxy and it's using the default
             # always alive behaviour, will get the cached copy of the network
             # device object which should preserve the connection.
-            wrapped_global_namespace['napalm_device'] = proxy['napalm.get_device']()
+            if force_reconnect:
+                wrapped_global_namespace['napalm_device'] = get_device(opts)
+            else:
+                wrapped_global_namespace['napalm_device'] = proxy['napalm.get_device']()
         elif is_proxy(opts) and not always_alive:
             # if still proxy, but the user does not want the SSH session always alive
             # get a new device instance
@@ -453,7 +477,12 @@ def proxy_napalm_wrap(func):
             # inject the __opts__ only when not always alive
             # otherwise, we don't want to overload the always-alive proxies
             wrapped_global_namespace['napalm_device']['__opts__'] = opts
-        return func(*args, **kwargs)
+        ret = func(*args, **kwargs)
+        if force_reconnect:
+            log.debug('That was a forced reconnect, gracefully clearing up')
+            device = wrapped_global_namespace['napalm_device']
+            closing = call(device, 'close', __retry=False)
+        return ret
     return func_wrapper
 
 


### PR DESCRIPTION
### What does this PR do?

One of the major disadvantages of the Proxy Minions is their rigidity in terms of connectivity: the connection with the remote device is established with the remote device at the time of the Minion startup and that connection is going to be used forever.

If one would execute a command on the device using different parameters (due to various causes, such as unable to authenticate with the user specified in the Pillar and the authentication system - say TACACS+ is not available, or the user has a DNS in the Pillar and the resolver is currently down and would like to use temporarily the IP address instead, etc.), it requires a updating the Pillar data and Proxy Minion process restart. This is less than ideal.

Salt fortunately is as always flexible enough and we can add a magic argument, say `force_reconnect` which tells to establish a separate connection with the args specified in-line. Example:

Regular behaviour:

```bash
root@salt-master:/# salt napalm net.arp
napalm:
    ----------
    comment:
    out:
        |_
          ----------
          age:
              None
          interface:
              em1.0
          ip:
              128.0.0.16
          mac:
              02:00:00:00:00:10
        |_
          ----------
          age:
              1275.0
          interface:
              fxp0.0
          ip:
              172.31.0.1
          mac:
              02:8B:CA:89:F9:35
    result:
        True
```

With `force_reconnect`:

```
root@salt-master:/# salt napalm net.arp force_reconnect=True host=fake
napalm:
    The minion function caused an exception: Traceback (most recent call last):
      File "/usr/lib/python2.7/dist-packages/salt/minion.py", line 1635, in _thread_return
        return_data = minion_instance.executors[fname](opts, data, func, args, kwargs)
      File "/usr/lib/python2.7/dist-packages/salt/executors/direct_call.py", line 12, in execute
        return func(*args, **kwargs)
      File "/usr/lib/python2.7/dist-packages/salt/utils/napalm.py", line 393, in func_wrapper
        wrapped_global_namespace['napalm_device'] = get_device(opts)
      File "/usr/lib/python2.7/dist-packages/salt/utils/napalm.py", line 340, in get_device
        network_device.get('DRIVER').open()
      File "/usr/local/lib/python2.7/dist-packages/napalm/junos/junos.py", line 107, in open
        self.device.open()
      File "/usr/local/lib/python2.7/dist-packages/jnpr/junos/device.py", line 1284, in open
        raise EzErrors.ConnectUnknownHostError(self)
    ConnectUnknownHostError: ConnectUnknownHostError(fake)
```

The above was used as an example proving that when `force_reconnect=True` it would indeed attempt to initiate a separate connection.