### PR TITLE
if booted from volume, use string from image

### DIFF
--- a/salt/cloud/clouds/openstack.py
+++ b/salt/cloud/clouds/openstack.py
@@ -466,7 +466,10 @@ def show_instance(name, conn=None, call=None):
     ret['public_ips'] = _get_ips(node, 'public')
     ret['floating_ips'] = _get_ips(node, 'floating')
     ret['fixed_ips'] = _get_ips(node, 'fixed')
-    ret['image'] = conn.get_image(node.image.id).name
+    if isinstance(node.image, six.string_types):
+        ret['image'] = node.image
+    else:
+        ret['image'] = conn.get_image(node.image.id).name
     return ret
 
 


### PR DESCRIPTION
### What does this PR do?
If cloud servers in openstack are booted with a volume as their root
partition, they do not have an image assigned to them, so they won't
have an image id.  In these cases just pass the string from node.image
to the image information about that machine.

### What issues does this PR fix or reference?
Fixes #47766


### Tests written?

No

### Commits signed with GPG?

Yes