### PR TITLE
Update salt.beacons.log to reflect that re module is used for matching.

### DIFF
--- a/salt/beacons/log.py
+++ b/salt/beacons/log.py
@@ -69,6 +69,12 @@ def beacon(config):
               file: <path>
               <tag>:
                 regex: <pattern>
+
+    .. note::
+
+        regex matching is based on the `re`_ module
+
+    .. _re: https://docs.python.org/3.6/library/re.html#regular-expression-syntax
     '''
     ret = []
 


### PR DESCRIPTION
### What does this PR do?

As more non-python users are starting to use Salt, it would be useful to
point out which regular expression engines are in use so that users can
adapt accordingly.

### What issues does this PR fix or reference?

### Tests written?


No, Documentation change.

### Commits signed with GPG?

Yes