### PR TITLE
Skip file state tests on windows

### DIFF
--- a/tests/integration/states/test_file.py
+++ b/tests/integration/states/test_file.py
@@ -54,7 +54,6 @@ import salt.ext.six as six
 from salt.ext.six.moves import range  # pylint: disable=import-error,redefined-builtin
 
 IS_WINDOWS = salt.utils.is_windows()
-
 STATE_DIR = os.path.join(FILES, 'file', 'base')
 if IS_WINDOWS:
     FILEPILLAR = 'C:\\Windows\\Temp\\filepillar-python'
@@ -131,6 +130,7 @@ def _test_managed_file_mode_keep_helper(testcase, local=False):
         os.chmod(grail_fs_path, grail_fs_mode)
 
 
+@skipIf(salt.utils.is_windows(), 'skipping windows')
 class FileTest(ModuleCase, SaltReturnAssertsMixin):
     '''
     Validate the file state
@@ -2598,6 +2598,7 @@ class FileTest(ModuleCase, SaltReturnAssertsMixin):
         self.assertEqual(grp.getgrgid(temp_file_stats.st_gid).gr_name, group)
 
 
+@skipIf(salt.utils.is_windows(), 'skipping windows')
 class BlockreplaceTest(ModuleCase, SaltReturnAssertsMixin):
     marker_start = '# start'
     marker_end = '# end'
@@ -3799,6 +3800,7 @@ class BlockreplaceTest(ModuleCase, SaltReturnAssertsMixin):
             self.with_matching_block_and_marker_end_not_after_newline)
 
 
+@skipIf(salt.utils.is_windows(), 'skipping windows')
 class RemoteFileTest(ModuleCase, SaltReturnAssertsMixin):
     '''
     Uses a local tornado webserver to test http(s) file.managed states with and


### PR DESCRIPTION
### What does this PR do?
Currently the following file tests are failing on windows:

integration.states.test_file.FileTest.test_issue_8343_accumulated_require_in
integration.states.test_file.FileTest.test_managed_local_source_does_not_exist
integration.states.test_file.FileTest.test_managed_local_source_with_source_hash
integration.states.test_file.FileTest.test_recurse_issue_34945
integration.states.test_file.FileTest.test_replace_issue_18612_append
integration.states.test_file.FileTest.test_replace_issue_18612_append_not_found_content
integration.states.test_file.FileTest.test_replace_issue_18612_prepend
integration.states.test_file.FileTest.test_serialize
integration.states.test_file.FileTest.test_template_local_file
integration.states.test_file.FileTest.test_template_local_file_noclobber
integration.states.test_file.FileTest.test_test_directory_clean_exclude
integration.states.test_file.BlockreplaceTest.test_append
integration.states.test_file.BlockreplaceTest.test_append_append_newline
integration.states.test_file.BlockreplaceTest.test_append_no_append_newline
integration.states.test_file.BlockreplaceTest.test_prepend
integration.states.test_file.BlockreplaceTest.test_prepend_append_newline
integration.states.test_file.BlockreplaceTest.test_prepend_no_append_newline

windows file state tests were initially added here: https://github.com/saltstack/salt/pull/48742 but the other classes were not skipped for windows.

