### PR TITLE
Add warning to mac runas docs about escaping characters

### DIFF
--- a/doc/topics/releases/2018.3.3.rst
+++ b/doc/topics/releases/2018.3.3.rst
@@ -31,3 +31,15 @@ renderer. For example:
     foo:
       bar.baz:
         - some_arg: {{ mydict|tojson }}
+
+MacOSX escape characters with runas
+===================================
+
+You are now required to escape quotes when using the runas argument with the
+cmd module on macosx.
+
+Example:
+
+.. code-block:: bash
+
+    cmd.run 'echo '\''h=\"baz\"'\''' runas=macuser

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -908,6 +908,18 @@ def run(cmd,
         on a Windows minion you must also use the ``password`` argument, and
         the target user account must be in the Administrators group.
 
+        .. warning::
+
+            For versions 2018.3.3 and above on macosx while using runas,
+            to pass special characters to the command you need to escape
+            the characters on the shell.
+
+            Example:
+
+            .. code-block:: bash
+
+                cmd.run 'echo '\''h=\"baz\"'\''' runas=macuser
+
     :param str password: Windows only. Required when specifying ``runas``. This
         parameter will be ignored on non-Windows platforms.
 
@@ -1145,6 +1157,19 @@ def shell(cmd,
         on a Windows minion you must also use the ``password`` argument, and
         the target user account must be in the Administrators group.
 
+        .. warning::
+
+            For versions 2018.3.3 and above on macosx while using runas,
+            to pass special characters to the command you need to escape
+            the characters on the shell.
+
+            Example:
+
+            .. code-block:: bash
+
+                cmd.shell 'echo '\\''h=\\"baz\\"'\\\''' runas=macuser
+
+
     :param str password: Windows only. Required when specifying ``runas``. This
         parameter will be ignored on non-Windows platforms.
 
@@ -1343,6 +1368,18 @@ def run_stdout(cmd,
         on a Windows minion you must also use the ``password`` argument, and
         the target user account must be in the Administrators group.
 
+        .. warning::
+
+            For versions 2018.3.3 and above on macosx while using runas,
+            to pass special characters to the command you need to escape
+            the characters on the shell.
+
+            Example:
+
+            .. code-block:: bash
+
+                cmd.run_stdout 'echo '\\''h=\\"baz\\"'\\\''' runas=macuser
+
     :param str password: Windows only. Required when specifying ``runas``. This
         parameter will be ignored on non-Windows platforms.
 
@@ -1518,6 +1555,18 @@ def run_stderr(cmd,
         behavior is to run as the user under which Salt is running. If running
         on a Windows minion you must also use the ``password`` argument, and
         the target user account must be in the Administrators group.
+
+        .. warning::
+
+            For versions 2018.3.3 and above on macosx while using runas,
+            to pass special characters to the command you need to escape
+            the characters on the shell.
+
+            Example:
+
+            .. code-block:: bash
+
+                cmd.run_stderr 'echo '\\''h=\\"baz\\"'\\\''' runas=macuser
 
     :param str password: Windows only. Required when specifying ``runas``. This
         parameter will be ignored on non-Windows platforms.
@@ -1696,6 +1745,18 @@ def run_all(cmd,
         behavior is to run as the user under which Salt is running. If running
         on a Windows minion you must also use the ``password`` argument, and
         the target user account must be in the Administrators group.
+
+        .. warning::
+
+            For versions 2018.3.3 and above on macosx while using runas,
+            to pass special characters to the command you need to escape
+            the characters on the shell.
+
+            Example:
+
+            .. code-block:: bash
+
+                cmd.run_all 'echo '\\''h=\\"baz\\"'\\\''' runas=macuser
 
     :param str password: Windows only. Required when specifying ``runas``. This
         parameter will be ignored on non-Windows platforms.
@@ -1896,6 +1957,19 @@ def retcode(cmd,
         behavior is to run as the user under which Salt is running. If running
         on a Windows minion you must also use the ``password`` argument, and
         the target user account must be in the Administrators group.
+
+        .. warning::
+
+            For versions 2018.3.3 and above on macosx while using runas,
+            to pass special characters to the command you need to escape
+            the characters on the shell.
+
+            Example:
+
+            .. code-block:: bash
+
+                cmd.retcode 'echo '\\''h=\\"baz\\"'\\\''' runas=macuser
+
 
     :param str password: Windows only. Required when specifying ``runas``. This
         parameter will be ignored on non-Windows platforms.
@@ -3649,6 +3723,19 @@ def run_bg(cmd,
         behavior is to run as the user under which Salt is running. If running
         on a Windows minion you must also use the ``password`` argument, and
         the target user account must be in the Administrators group.
+
+        .. warning::
+
+            For versions 2018.3.3 and above on macosx while using runas,
+            to pass special characters to the command you need to escape
+            the characters on the shell.
+
+            Example:
+
+            .. code-block:: bash
+
+                cmd.run_bg 'echo '\''h=\"baz\"'\''' runas=macuser
+
 
     :param str password: Windows only. Required when specifying ``runas``. This
         parameter will be ignored on non-Windows platforms.

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -1169,7 +1169,6 @@ def shell(cmd,
 
                 cmd.shell 'echo '\\''h=\\"baz\\"'\\\''' runas=macuser
 
-
     :param str password: Windows only. Required when specifying ``runas``. This
         parameter will be ignored on non-Windows platforms.
 
@@ -1969,7 +1968,6 @@ def retcode(cmd,
             .. code-block:: bash
 
                 cmd.retcode 'echo '\\''h=\\"baz\\"'\\\''' runas=macuser
-
 
     :param str password: Windows only. Required when specifying ``runas``. This
         parameter will be ignored on non-Windows platforms.
@@ -3735,7 +3733,6 @@ def run_bg(cmd,
             .. code-block:: bash
 
                 cmd.run_bg 'echo '\''h=\"baz\"'\''' runas=macuser
-
 
     :param str password: Windows only. Required when specifying ``runas``. This
         parameter will be ignored on non-Windows platforms.

--- a/tests/integration/modules/test_cmdmod.py
+++ b/tests/integration/modules/test_cmdmod.py
@@ -267,6 +267,9 @@ class CMDModuleTest(ModuleCase):
         cmd.run with quoted command
         '''
         cmd = '''echo 'SELECT * FROM foo WHERE bar="baz"' '''
+        if salt.utils.platform.is_darwin():
+            cmd = '''echo 'SELECT * FROM foo WHERE bar=\\"baz\\"' '''
+
         expected_result = 'SELECT * FROM foo WHERE bar="baz"'
 
         runas = this_user()


### PR DESCRIPTION
### What does this PR do?
currently the test `integration.modules.test_cmdmod.CMDModuleTest.test_quotes_runas` is failing with error:

```
Traceback (most recent call last):
  File "/testing/tests/integration/modules/test_cmdmod.py", line 276, in test_quotes_runas
    self.assertEqual(result, expected_result)
AssertionError: u'SELECT * FROM foo WHERE bar=baz' != u'SELECT * FROM foo WHERE bar="baz"'
- SELECT * FROM foo WHERE bar=baz
+ SELECT * FROM foo WHERE bar="baz"
?                             +   +
```

This is due to this fix recently added: https://github.com/saltstack/salt/pull/47212

It changed the call to `su -l <user> -c "<cmd>"`

As you can see below quotes are handled differently when calling from `su`

without su:

```
jk-sierra-base:testing root# echo '"baz"'
"baz"
```

```
jk-sierra-base:testing root# su -l root -c "echo '"baz"'"
baz
```

as you can see when using su it does not include the quotes only when you escape the quotes like below:

```
jk-sierra-base:testing root# su -l root -c "echo '\"baz\"'"
"baz"
```

I tried using `_cmd_quote` but that only created failures so I do not see a good way to fix this other then documenting that when you use the cmd module on macosx with runas you need to escape quotes. If anyone has a better approach I'm up for approaching it differently.

fyi @weswhet 


