### PR TITLE
Pass cmd as a list to _call_apt, not a string

### DIFF
--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -2552,7 +2552,7 @@ def set_selections(path=None, selection=None, clear=False, saltenv='base'):
             )
 
         if clear:
-            cmd = 'dpkg --clear-selections'
+            cmd = ['dpkg', '--clear-selections']
             if not __opts__['test']:
                 result = _call_apt(cmd, scope=False)
                 if result['retcode'] != 0:
@@ -2569,7 +2569,7 @@ def set_selections(path=None, selection=None, clear=False, saltenv='base'):
             for _pkg in _pkgs:
                 if _state == sel_revmap.get(_pkg):
                     continue
-                cmd = 'dpkg --set-selections'
+                cmd = ['dpkg', '--set-selections']
                 cmd_in = '{0} {1}'.format(_pkg, _state)
                 if not __opts__['test']:
                     result = _call_apt(cmd, scope=False, stdin=cmd_in)


### PR DESCRIPTION
### What does this PR do?
Fixes a bug where the cmd was being passed as a sting, instead of a list. Functions further down the line split the string into each letter instead of command pieces.

### What issues does this PR fix or reference?
Fixes https://github.com/saltstack/salt-jenkins/issues/1048

### Previous Behavior
Calling the `pkg.hold` function on Debian-based distros was broken.

### New Behavior
`pkg.hold` now works.
Remove this section if not relevant

### Tests written?

Yes - a test failure found this bug.

### Commits signed with GPG?

Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
