### PR TITLE
 [2018.3] Fix to salt/modules/file.py

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -4454,7 +4454,8 @@ def check_perms(name, ret, user, group, mode, attrs=None, follow_symlinks=False)
     perms['lmode'] = salt.utils.files.normalize_mode(cur['mode'])
 
     is_dir = os.path.isdir(name)
-    if not salt.utils.platform.is_windows() and not is_dir:
+    is_link = os.path.islink(name)
+    if not salt.utils.platform.is_windows() and not is_dir and not is_link:
         lattrs = lsattr(name)
         if lattrs is not None:
             # List attributes on file

--- a/tests/integration/states/test_file.py
+++ b/tests/integration/states/test_file.py
@@ -1043,6 +1043,37 @@ class FileTest(ModuleCase, SaltReturnAssertsMixin):
         self.assertTrue(os.path.exists(good_file))
         self.assertFalse(os.path.exists(wrong_file))
 
+    def test_directory_broken_symlink(self):
+        '''
+        Ensure that file.directory works even if a directory
+        contains broken symbolic link
+        '''
+        try:
+            tmp_dir = os.path.join(TMP, 'foo')
+            null_file = '{0}/null'.format(tmp_dir)
+            broken_link = '{0}/broken'.format(tmp_dir)
+
+            if IS_WINDOWS:
+                self.run_function('file.mkdir', [tmp_dir, 'Administrators'])
+            else:
+                os.mkdir(tmp_dir, 0o700)
+
+            self.run_function('file.symlink', [null_file, broken_link])
+
+            if IS_WINDOWS:
+                ret = self.run_state(
+                    'file.directory', name=tmp_dir, recurse={'mode'},
+                    follow_symlinks=True, win_owner='Administrators')
+            else:
+                ret = self.run_state(
+                    'file.directory', name=tmp_dir, recurse={'mode'},
+                    file_mode=644, dir_mode=755)
+
+            self.assertSaltTrueReturn(ret)
+        finally:
+            if os.path.isdir(tmp_dir):
+                self.run_function('file.remove', [tmp_dir])
+
     @with_tempdir(create=False)
     def test_recurse(self, name):
         '''


### PR DESCRIPTION
### What does this PR do?
Fixing the issue when using the file.directory state with recurse if the directory contains a broken symbolic link. This fix adds an additional conditional, is_link, before running lsattr since lsattr does not work on symlinks and causes issues when that symlink is broken.

### What issues does this PR fix or reference?
#48123

### Tests written?
Yes

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
