### PR TITLE
Fixed Python 3 related bug in highstate_return.py

### DIFF
--- a/salt/returners/highstate_return.py
+++ b/salt/returners/highstate_return.py
@@ -187,8 +187,8 @@ def _generate_html_table(data, out, level=0, extra_style=''):
             else:
                 new_extra_style = extra_style
             if len(subdata) == 1:
-                name = subdata.keys()[0]
-                value = subdata.values()[0]
+                name = list(subdata.keys())[0]
+                value = list(subdata.values())[0]
                 print('<tr style="{0}">'.format(
                     _lookup_style('tr', [row_style])
                 ), file=out)


### PR DESCRIPTION
In Python 3 key sets of dicts no longer support indexing:
`TypeError: 'dict_keys' object does not support indexing`

### What does this PR do?
It makes the highstate returner function under Python 3.

### What issues does this PR fix or reference?
None that I know of.

### Previous Behavior
```
2018-08-08 11:37:53,693 [salt.utils.schedule:740 ][ERROR   ][26560] Unhandled exception running state.highstate
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/salt/utils/schedule.py", line 732, in handle_func
    self.returners[ret_str](ret)
  File "/usr/lib/python3/dist-packages/salt/returners/highstate_return.py", line 481, in returner
    _produce_output(report, failed, setup)
  File "/usr/lib/python3/dist-packages/salt/returners/highstate_return.py", line 434, in _produce_output
    _generate_html(report, string_file)
  File "/usr/lib/python3/dist-packages/salt/returners/highstate_return.py", line 270, in _generate_html
    _generate_html_table(data, out, 0)
  File "/usr/lib/python3/dist-packages/salt/returners/highstate_return.py", line 190, in _generate_html_table
    name = subdata.keys()[0]
TypeError: 'dict_keys' object does not support indexing
```

### New Behavior
You get a mail about the highstate. Also when using Python 2.

### Tests written?

No

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
