### PR TITLE
Update expected return value in boto test

### DIFF
--- a/tests/unit/modules/test_boto_secgroup.py
+++ b/tests/unit/modules/test_boto_secgroup.py
@@ -210,7 +210,7 @@ class BotoSecgroupTestCase(TestCase, LoaderModuleMockMixin):
         from_port = 22
         to_port = 22
         cidr_ip = u'0.0.0.0/0'
-        rules_egress = [{'to_port': -1, 'from_port': -1, 'ip_protocol': u'-1', 'cidr_ip': u'0.0.0.0/0'}]
+        rules_egress = [{'to_port': None, 'from_port': None, 'ip_protocol': u'-1', 'cidr_ip': u'0.0.0.0/0'}]
 
         conn = boto.ec2.connect_to_region(region, **boto_conn_parameters)
         group = conn.create_security_group(name=group_name, description=group_name)


### PR DESCRIPTION
The expected return from moto has changed from `-1` to `None` in the latest version of moto (1.3.4). This PR updates the test to be in line with the return from moto.
