### PR TITLE
Skip test_jinja_deep_error on Debian 8

### DIFF
--- a/tests/integration/states/test_compiler.py
+++ b/tests/integration/states/test_compiler.py
@@ -9,6 +9,16 @@ from __future__ import absolute_import
 # Import Salt Testing libs
 from tests.support.case import ModuleCase
 
+# Import Salt libs
+import salt.utils
+
+# Import 3rd-Party libs
+HAS_LSB_RELEASE = True
+try:
+    import lsb_release
+except ImportError:
+    HAS_LSB_RELEASE = False
+
 
 class CompileTest(ModuleCase):
     '''
@@ -27,6 +37,11 @@ class CompileTest(ModuleCase):
         Test when we have an error in a execution module
         called by jinja
         '''
+        if salt.utils.is_linux() and HAS_LSB_RELEASE:
+            release = lsb_release.get_distro_information()
+            if release.get('ID') == 'Debian' and int(release.get('RELEASE', 0)) < 9:
+                self.skipTest('This test is flaky on Debian 8. Skipping.')
+
         ret = self.run_function('state.sls', ['issue-10010'])
         self.assertTrue(
             ', in jinja_error' in ret[0].strip())


### PR DESCRIPTION
This is a flaky test on Debian 8, so let's skip it for now.

Fixes https://github.com/saltstack/salt-jenkins/issues/1053
