### PR TITLE
[2018.3] Fix to scheduler when global enabled key is present

### DIFF
--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -843,14 +843,14 @@ class Schedule(object):
                    'skip_during_range']
         for job, data in six.iteritems(schedule):
 
+            if job in _hidden:
+                continue
+
             # Clear out _skip_reason from previous runs
             if '_skip_reason' in data:
                 del data['_skip_reason']
 
             run = False
-
-            if job in _hidden:
-                continue
 
             if not isinstance(data, dict):
                 log.error(

--- a/tests/integration/scheduler/test_eval.py
+++ b/tests/integration/scheduler/test_eval.py
@@ -428,4 +428,3 @@ class SchedulerEvalTest(ModuleCase, SaltReturnAssertsMixin):
         self.schedule.eval(now=run_time2)
         ret = self.schedule.job_status('job1')
         self.assertEqual(ret['_last_run'], run_time2)
-

--- a/tests/integration/scheduler/test_eval.py
+++ b/tests/integration/scheduler/test_eval.py
@@ -397,3 +397,35 @@ class SchedulerEvalTest(ModuleCase, SaltReturnAssertsMixin):
         self.schedule.eval(now=run_time)
         ret = self.schedule.job_status('job1')
         self.assertEqual(ret['_last_run'], run_time)
+
+    def test_eval_enabled(self):
+        '''
+        verify that scheduled job runs
+        when the enabled key is in place
+        https://github.com/saltstack/salt/issues/47695
+        '''
+        job = {
+          'schedule': {
+            'enabled': True,
+            'job1': {
+              'function': 'test.ping',
+              'when': '11/29/2017 4:00pm',
+            }
+          }
+        }
+        run_time2 = dateutil_parser.parse('11/29/2017 4:00pm')
+        run_time1 = run_time2 - datetime.timedelta(seconds=1)
+
+        # Add the job to the scheduler
+        self.schedule.opts.update(job)
+
+        # Evaluate 1 second before the run time
+        self.schedule.eval(now=run_time1)
+        ret = self.schedule.job_status('job1')
+        self.assertNotIn('_last_run', ret)
+
+        # Evaluate 1 second at the run time
+        self.schedule.eval(now=run_time2)
+        ret = self.schedule.job_status('job1')
+        self.assertEqual(ret['_last_run'], run_time2)
+


### PR DESCRIPTION
### What does this PR do?
Fixing a bug that occurs if the global "enabled" key is present in the scheduler items dictionary.
Adding a test to ensure scheduler runs as expected when that key is present.

### What issues does this PR fix or reference?
#47695 

### Tests written?
Yes

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
