### PR TITLE
Make grains integration test more robust

### DIFF
--- a/tests/integration/modules/test_grains.py
+++ b/tests/integration/modules/test_grains.py
@@ -163,16 +163,23 @@ class GrainsAppendTestCase(ModuleCase):
 
     def test_grains_append_val_already_present(self):
         '''
-        Tests the return of a grains.append call when the value is already present in the grains list.
+        Tests the return of a grains.append call when the value is already
+        present in the grains list.
         '''
-        messaging = 'The val {0} was already in the list salttesting-grain-key'.format(self.GRAIN_VAL)
+        msg = 'The val {0} was already in the list ' \
+              'salttesting-grain-key'.format(self.GRAIN_VAL)
 
         # First, make sure the test grain is present
         self.run_function('grains.append', [self.GRAIN_KEY, self.GRAIN_VAL])
 
         # Now try to append again
         ret = self.run_function('grains.append', [self.GRAIN_KEY, self.GRAIN_VAL])
-        self.assertEqual(messaging, ret)
+        if not ret or isinstance(ret, dict):
+            # Sleep for a bit, sometimes the second "append" runs too quickly
+            time.sleep(5)
+            ret = self.run_function('grains.append', [self.GRAIN_KEY, self.GRAIN_VAL])
+
+        assert msg == ret
 
     def test_grains_append_val_is_list(self):
         '''


### PR DESCRIPTION
The `test_grains_append_val_already_present` test can be flaky, especially on CentOS 7 when it gets bogged down. Let's give the test a little breathing room by adding a sleep so the grains.append calls don't stack up too quickly.

Fixes https://github.com/saltstack/salt-jenkins/issues/1052