### PR TITLE
Salt SSH appends IdentityFile=agent-forwarding

### DIFF
--- a/salt/client/ssh/shell.py
+++ b/salt/client/ssh/shell.py
@@ -138,7 +138,7 @@ class Shell(object):
             options.append('UserKnownHostsFile={0}'.format(known_hosts))
         if self.port:
             options.append('Port={0}'.format(self.port))
-        if self.priv:
+        if self.priv and self.priv != 'agent-forwarding':
             options.append('IdentityFile={0}'.format(self.priv))
         if self.user:
             options.append('User={0}'.format(self.user))


### PR DESCRIPTION
Salt SSH cannot authenticate when SSH agent is used.

### What does this PR do?
Fix the problem by preventing invalid config option on CLI

### Previous Behavior
When `ssh_priv: agent-forwarding` is defined in master opts, authentication fails.
This is due to Salt SSH launching with `ssh -o IdentityFile=agent-forwarding`, which doesn't exist as file (doh).
Might very well happen to `priv: agent-forwarding` in roster entries too, but haven' tested.

### New Behavior
Authentication succeeds as the CLI option isn't filled anymore.

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
