### PR TITLE
Update netapi client tests

### DIFF
--- a/tests/integration/netapi/test_client.py
+++ b/tests/integration/netapi/test_client.py
@@ -3,10 +3,11 @@
 # Import Python libs
 from __future__ import absolute_import
 import os
+import time
 
 # Import Salt Testing libs
-from tests.support.unit import TestCase
 from tests.support.paths import TMP_CONF_DIR
+from tests.support.unit import TestCase, skipIf
 
 # Import Salt libs
 import salt.config
@@ -73,6 +74,8 @@ class NetapiClientTest(TestCase):
         self.assertTrue(set(['master.pem', 'master.pub']).issubset(set(ret['data']['return']['local'])))
 
     def test_wheel_async(self):
+        # Give this test a little breathing room
+        time.sleep(3)
         low = {'client': 'wheel_async', 'fun': 'key.list_all'}
         low.update(self.eauth_creds)
 
@@ -80,6 +83,7 @@ class NetapiClientTest(TestCase):
         self.assertIn('jid', ret)
         self.assertIn('tag', ret)
 
+    @skipIf(True, 'This is not testing anything. Skipping for now.')
     def test_runner(self):
         # TODO: fix race condition in init of event-- right now the event class
         # will finish init even if the underlying zmq socket hasn't connected yet
@@ -91,6 +95,7 @@ class NetapiClientTest(TestCase):
 
         ret = self.netapi.run(low)
 
+    @skipIf(True, 'This is not testing anything. Skipping for now.')
     def test_runner_async(self):
         low = {'client': 'runner', 'fun': 'cache.grains'}
         low.update(self.eauth_creds)


### PR DESCRIPTION
This change does 2 things:
- Skip 2 tests: they are not actually _testing_ anything, just running functions Let's skip these for now until we can dedicate some time to investigate what should be tested here. This will also help the tests breath a little bit.
- Add a small sleep to the async test. This test needs a little breathing room so the procs don't get stepped on. I think this is what is causing the master to shut down sometimes during test runs:
```
08:41:47          test_wheel_async (integration.netapi.test_client.NetapiClientTest)
08:41:47        [CPU:0.0%|MEM:13.2%]  ... 12:41:47,280 [salt.utils.process                         :670 ][ERROR   ] An un-handled exception from the multiprocessing process 'SignalHandlingMultiprocessingProcess-24' was caught:
08:41:47        Traceback (most recent call last):
08:41:47          File "/tmp/kitchen/testing/salt/utils/process.py", line 663, in _run
08:41:47            return self._original_run()
08:41:47          File "/usr/lib/python3.5/multiprocessing/process.py", line 93, in run
08:41:47            self._target(*self._args, **self._kwargs)
08:41:47          File "/tmp/kitchen/testing/salt/client/mixins.py", line 457, in _proc_function
08:41:47            salt.utils.daemonize()
08:41:47          File "/tmp/kitchen/testing/salt/utils/__init__.py", line 514, in daemonize
08:41:47            os.dup2(dev_null.fileno(), sys.stdout.fileno())
08:41:47        io.UnsupportedOperation: fileno
08:41:47        Process SignalHandlingMultiprocessingProcess-24:
08:41:47        Traceback (most recent call last):
08:41:47          File "/usr/lib/python3.5/multiprocessing/process.py", line 249, in _bootstrap
08:41:47            self.run()
08:41:47          File "/tmp/kitchen/testing/salt/utils/process.py", line 663, in _run
08:41:47            return self._original_run()
08:41:47          File "/usr/lib/python3.5/multiprocessing/process.py", line 93, in run
08:41:47            self._target(*self._args, **self._kwargs)
08:41:47          File "/tmp/kitchen/testing/salt/client/mixins.py", line 457, in _proc_function
08:41:47            salt.utils.daemonize()
08:41:47          File "/tmp/kitchen/testing/salt/utils/__init__.py", line 514, in daemonize
08:41:47            os.dup2(dev_null.fileno(), sys.stdout.fileno())
08:41:47        io.UnsupportedOperation: fileno
```