### PR TITLE
Fix file.get_diff for remote files

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -4988,7 +4988,7 @@ def get_diff(file1,
         )
 
     args = []
-    for filename in files:
+    for filename in paths:
         try:
             with salt.utils.files.fopen(filename, 'rb') as fp_:
                 args.append(fp_.readlines())
@@ -5006,12 +5006,12 @@ def get_diff(file1,
         elif not show_changes:
             ret = '<show_changes=False>'
         else:
-            bdiff = _binary_replace(*files)
+            bdiff = _binary_replace(*paths)
             if bdiff:
                 ret = bdiff
             else:
                 if show_filenames:
-                    args.extend(files)
+                    args.extend(paths)
                 ret = __utils__['stringutils.get_diff'](*args)
         return ret
     return ''

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -5006,7 +5006,7 @@ def get_diff(file1,
         elif not show_changes:
             ret = '<show_changes=False>'
         else:
-            bdiff = _binary_replace(*paths)
+            bdiff = _binary_replace(*paths)  # pylint: disable=no-value-for-parameter
             if bdiff:
                 ret = bdiff
             else:


### PR DESCRIPTION
Once the files were cached, the function was still trying to open the paths passed into it, not the cached paths. This fixes that and adds additional unit tests.

Fixes #48996.