### PR TITLE
Fix case where args or kwargs are not specified in loop state

### DIFF
--- a/salt/states/loop.py
+++ b/salt/states/loop.py
@@ -94,7 +94,11 @@ def until(name,
         ret['comment'] = 'The execution module {0} will be run'.format(name)
         ret['result'] = None
         return ret
-
+    if not m_args:
+        m_args = []
+    if not m_kwargs:
+        m_kwargs = {}
+    
     def timed_out():
         if time.time() >= timeout:
             return True

--- a/salt/states/loop.py
+++ b/salt/states/loop.py
@@ -98,7 +98,7 @@ def until(name,
         m_args = []
     if not m_kwargs:
         m_kwargs = {}
-    
+
     def timed_out():
         if time.time() >= timeout:
             return True


### PR DESCRIPTION
Currently, the m_ret line will error if the loop state definition does not specify values for args or kwargs, because None is neither iterable nor a map. If not specified, those values should be set to an empty list and empty dict.

### What does this PR do?
Fixes an error with the loop state when the definition did not specify values for the m_args or m_kwargs parameters.

### What issues does this PR fix or reference?
See above. I couldn't find an open issue for this, but it's an easy fix.

### Previous Behavior
If those values were not specified, the state would fail and log a stack trace.

### New Behavior
If those those values are not specified, the state will succeed without them.

### Tests written?

No

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
