### PR TITLE
disable enable_ssh_minions to see if it is slowing down 2018.3 tests

### DIFF
--- a/tests/integration/files/conf/master
+++ b/tests/integration/files/conf/master
@@ -104,5 +104,5 @@ autosign_file: autosign_file
 discovery: false
 
 # enable using ssh minions and regular minions
-enable_ssh_minions: True
-ignore_host_keys: True
+#enable_ssh_minions: True
+#ignore_host_keys: True

--- a/tests/integration/netapi/rest_tornado/test_app.py
+++ b/tests/integration/netapi/rest_tornado/test_app.py
@@ -179,7 +179,7 @@ class TestSaltAPIHandler(_SaltnadoIntegrationTestCase):
         # TODO: verify pub function? Maybe look at how we test the publisher
         self.assertEqual(len(ret), 1)
         self.assertIn('jid', ret[0])
-        self.assertEqual(ret[0]['minions'], sorted(['minion', 'sub_minion', 'localhost']))
+        self.assertEqual(ret[0]['minions'], sorted(['minion', 'sub_minion']))
 
     def test_multi_local_async_post(self):
         low = [{'client': 'local_async',
@@ -205,8 +205,8 @@ class TestSaltAPIHandler(_SaltnadoIntegrationTestCase):
         self.assertEqual(len(ret), 2)
         self.assertIn('jid', ret[0])
         self.assertIn('jid', ret[1])
-        self.assertEqual(ret[0]['minions'], sorted(['minion', 'sub_minion', 'localhost']))
-        self.assertEqual(ret[1]['minions'], sorted(['minion', 'sub_minion', 'localhost']))
+        self.assertEqual(ret[0]['minions'], sorted(['minion', 'sub_minion']))
+        self.assertEqual(ret[1]['minions'], sorted(['minion', 'sub_minion']))
 
     def test_multi_local_async_post_multitoken(self):
         low = [{'client': 'local_async',
@@ -240,8 +240,8 @@ class TestSaltAPIHandler(_SaltnadoIntegrationTestCase):
         self.assertIn('jid', ret[0])  # the first 2 are regular returns
         self.assertIn('jid', ret[1])
         self.assertIn('Authentication error occurred.', ret[2])  # bad auth
-        self.assertEqual(ret[0]['minions'], sorted(['minion', 'sub_minion', 'localhost']))
-        self.assertEqual(ret[1]['minions'], sorted(['minion', 'sub_minion', 'localhost']))
+        self.assertEqual(ret[0]['minions'], sorted(['minion', 'sub_minion']))
+        self.assertEqual(ret[1]['minions'], sorted(['minion', 'sub_minion']))
 
     def test_simple_local_async_post_no_tgt(self):
         low = [{'client': 'local_async',
@@ -299,7 +299,7 @@ class TestSaltAPIHandler(_SaltnadoIntegrationTestCase):
                               )
         response_obj = salt.utils.json.loads(response.body)
         self.assertEqual(len(response_obj['return']), 1)
-        self.assertEqual(set(response_obj['return'][0]), set(['localhost', 'minion', 'sub_minion']))
+        self.assertEqual(set(response_obj['return'][0]), set(['minion', 'sub_minion']))
 
     # runner_async tests
     def test_simple_local_runner_async_post(self):

--- a/tests/integration/netapi/test_client.py
+++ b/tests/integration/netapi/test_client.py
@@ -35,7 +35,7 @@ class NetapiClientTest(TestCase):
         low.update(self.eauth_creds)
 
         ret = self.netapi.run(low)
-        self.assertEqual(ret, {'minion': True, 'sub_minion': True, 'localhost': True})
+        self.assertEqual(ret, {'minion': True, 'sub_minion': True})
 
     def test_local_batch(self):
         low = {'client': 'local_batch', 'tgt': '*', 'fun': 'test.ping'}
@@ -45,7 +45,6 @@ class NetapiClientTest(TestCase):
         rets = []
         for _ret in ret:
             rets.append(_ret)
-        self.assertIn({'localhost': True}, rets)
         self.assertIn({'sub_minion': True}, rets)
         self.assertIn({'minion': True}, rets)
 
@@ -59,7 +58,7 @@ class NetapiClientTest(TestCase):
         self.assertIn('jid', ret)
         ret.pop('jid', None)
         ret['minions'] = sorted(ret['minions'])
-        self.assertEqual(ret, {'minions': sorted(['minion', 'sub_minion', 'localhost'])})
+        self.assertEqual(ret, {'minions': sorted(['minion', 'sub_minion'])})
 
     def test_wheel(self):
         low = {'client': 'wheel', 'fun': 'key.list_all'}


### PR DESCRIPTION
### What does this PR do?
Testing if this is what is making 2018.3 tests take 4 hours.

### Commits signed with GPG?

Yes