### PR TITLE
[2017.7] Another fix to tests/integration/modules/test_service.py

### DIFF
--- a/tests/integration/modules/test_service.py
+++ b/tests/integration/modules/test_service.py
@@ -127,7 +127,7 @@ class ServiceModuleTest(ModuleCase):
         if tuple(self.run_function('grains.item', ['osrelease_info'])['osrelease_info']) == (14, 0o4) and not systemd:
             # currently upstart does not have a mechanism to report if disabling a service fails if does not exist
             self.assertTrue(self.run_function('service.disable', [srv_name]))
-        elif self.run_function('grains.item', ['osfullname'])['osfullname'] == 'Debian' and \
+        elif self.run_function('grains.item', ['os'])['os'] == 'Debian' and \
              self.run_function('grains.item', ['osmajorrelease'])['osmajorrelease'] < 9 and systemd:
              # currently disabling a service via systemd that does not exist
              # on Debian 8 results in a True return code


### PR DESCRIPTION
### What does this PR do?
The osfullname grain differs when using Python2 vs Python3, swapping this out in tests/integration/modules/test_service.py for the "OS" grain which is consistent.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt-jenkins/issues/1022

### Tests written?
Yes

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
