### PR TITLE
make ssh_known_hosts' fingerprint(sha256) support base64 format

### DIFF
--- a/tests/unit/modules/test_ssh.py
+++ b/tests/unit/modules/test_ssh.py
@@ -16,6 +16,7 @@ from tests.support.mock import (
 
 # Import Salt Libs
 import salt.utils
+import salt.modules.cmdmod
 import salt.modules.ssh as ssh
 from salt.exceptions import CommandExecutionError
 
@@ -141,3 +142,172 @@ class SSHAuthKeyTestCase(TestCase, LoaderModuleMockMixin):
             self.assertIn(email, file_txt)
             self.assertIn(empty_line, file_txt)
             self.assertIn(comment_line, file_txt)
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class SSHKnownHostTestCase(TestCase, LoaderModuleMockMixin):
+    '''
+    TestCase for salt.modules.ssh
+    '''
+    def setup_loader_modules(self):
+        return {
+            ssh: {
+                '__salt__': {
+                    'ssh.hash_known_hosts': ssh.hash_known_hosts,
+                }
+            }
+        }
+
+    def setUp(self):
+        temp_file = tempfile.NamedTemporaryFile(delete=False, mode='w+')
+        temp_file.close()
+
+        self.temp_file_name = temp_file.name
+        self.key = 'AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6' \
+                   'rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJ' \
+                   'izHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/' \
+                   'yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B' \
+                   '+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6g' \
+                   'bODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ=='
+        self.fingerprints = {
+            'md5': '16:27:ac:a5:76:28:2d:36:63:1b:56:4d:eb:df:a6:48',
+            'sha256': 'nThbg6kXUpJWGl7E1IGOCspRomTxdCARLviKw6E5SY8',
+            'sha256_': '9d:38:5b:83:a9:17:52:92:56:1a:5e:c4:d4:81:8e:0a:' \
+                       'ca:51:a2:64:f1:74:20:11:2e:f8:8a:c3:a1:39:49:8f'
+        }
+
+
+    def tearDown(self):
+        salt.utils.safe_rm(self.temp_file_name)
+        try:
+            delattr(self, 'fingerprints')
+            delattr(self, 'temp_file_name')
+            delattr(self, 'key')
+        except AttributeError:
+            pass
+
+
+    def cmd_run_side_effect(self, *args, **kwargs):
+        if args[0][0] == 'ssh-keyscan':
+            return '# github.com:22 SSH-2.0-libssh_0.7.0\n' \
+                   '|1|UFlpWi7zJTnF3YR5VBgJiJ3tXGo=|4uqGHkc2vi2fQ7OEZThf5ncFPDs= ' \
+                   'ssh-rsa ' + self.key
+        else:
+            return salt.modules.cmdmod.run(*args, **kwargs)
+
+    def test_set_known_host(self):
+        user = 'root'
+        hostname = 'github.com'
+        enc = 'ssh-rsa'
+        config = self.temp_file_name
+        fingerprints = self.fingerprints
+        user_info_mock = MagicMock(return_value={'home': '/dev/null'})
+        ssh_keyscan_mock = MagicMock(side_effect = self.cmd_run_side_effect)
+
+        values = {
+            'user.info': user_info_mock,
+            'cmd.run': ssh_keyscan_mock
+        }
+
+        expect_result = {
+            'old': None,
+            'new': {
+                'enc': 'ssh-rsa',
+                'key': self.key,
+                'fingerprint': '',
+                'hostname': '|1|UFlpWi7zJTnF3YR5VBgJiJ3tXGo=|4uqGHkc2vi2fQ7OEZThf5ncFPDs='
+            },
+            'status': 'updated'
+        }
+        for hash_type in ['md5', 'sha256']:
+            with patch.dict(ssh.__salt__, values):
+                expect_result['new']['fingerprint'] = fingerprints[hash_type if hash_type == 'md5' else 'sha256_']
+                ret = ssh.set_known_host(user=user,
+                                    hostname=hostname,
+                                    fingerprint=fingerprints[hash_type],
+                                    enc=enc,
+                                    config=config,
+                                    fingerprint_hash_type=hash_type)
+                self.assertDictEqual(expect_result, ret)
+
+                expect_result_2 = {'status': 'exists', 'key': self.key}
+                ret = ssh.set_known_host(user=user,
+                                    hostname=hostname,
+                                    key=self.key,
+                                    enc=enc,
+                                    config=config,
+                                    fingerprint_hash_type=hash_type)
+                self.assertDictEqual(expect_result_2, ret)
+
+                ret = ssh.set_known_host(user=user,
+                                    hostname=hostname,
+                                    fingerprint=fingerprints[hash_type],
+                                    enc=enc,
+                                    config=config,
+                                    fingerprint_hash_type=hash_type)
+                self.assertDictEqual(expect_result_2, ret)
+
+                with salt.utils.fopen(self.temp_file_name, 'rb+') as seek_fh:
+                    seek_fh.truncate(0)
+
+    def test_check_known_host(self):
+        user = 'root'
+        hostname = 'github.com'
+        enc = 'ssh-rsa'
+        config = self.temp_file_name
+        fingerprints = self.fingerprints
+        user_info_mock = MagicMock(return_value={'home': '/dev/null'})
+        ssh_keyscan_mock = MagicMock(side_effect = self.cmd_run_side_effect)
+
+        values = {
+            'user.info': user_info_mock,
+            'cmd.run': ssh_keyscan_mock
+        }
+
+        for hash_type in ['md5', 'sha256']:
+            with patch.dict(ssh.__salt__, values):
+                ret = ssh.check_known_host(user=user,
+                                    hostname=hostname,
+                                    fingerprint=fingerprints[hash_type],
+                                    config=config,
+                                    fingerprint_hash_type=hash_type)
+                self.assertEqual('add', ret)
+
+                ret = ssh.check_known_host(user=user,
+                                    hostname=hostname,
+                                    key=self.key,
+                                    config=config,
+                                    fingerprint_hash_type=hash_type)
+                self.assertEqual('add', ret)
+
+                ret = ssh.set_known_host(user=user,
+                                    hostname=hostname,
+                                    key=self.key,
+                                    fingerprint=fingerprints[hash_type],
+                                    enc=enc,
+                                    config=config,
+                                    fingerprint_hash_type=hash_type)
+
+                ret = ssh.check_known_host(user=user,
+                                    hostname=hostname,
+                                    fingerprint=fingerprints[hash_type],
+                                    config=config,
+                                    fingerprint_hash_type=hash_type)
+                self.assertEqual('exists', ret)
+
+                ret = ssh.check_known_host(user=user,
+                                    hostname=hostname,
+                                    key=self.key,
+                                    config=config,
+                                    fingerprint_hash_type=hash_type)
+                self.assertEqual('exists', ret)
+
+                ret = ssh.check_known_host(user=user,
+                                    hostname=hostname,
+                                    fingerprint=fingerprints[hash_type] + ':11',
+                                    config=config,
+                                    fingerprint_hash_type=hash_type)
+                self.assertEqual('update', ret)
+
+                with salt.utils.fopen(self.temp_file_name, 'rb+') as seek_fh:
+                    seek_fh.truncate(0)


### PR DESCRIPTION
### What does this PR do?
make ssh_known_hosts' fingerprint(sha256) support base64 format

### What issues does this PR fix or reference?
#41653

### Previous Behavior
fingerprint should be xx:xx:xx format if fingerprint_hash_type is sha256

### New Behavior
1. both xx:xx:xx and base64 format are supported for sha256 hash type
2. with or without the trailing '=' are supported for base64 string

### Tests written?
Yes

### Commits signed with GPG?
No