### PR TITLE
Add orch runner with mine.get integration tests

### DIFF
--- a/tests/integration/files/file/base/orch/mine.sls
+++ b/tests/integration/files/file/base/orch/mine.sls
@@ -1,0 +1,10 @@
+{% set minion = '*' %}
+{% set mine = salt.saltutil.runner('mine.get',
+        tgt=minion,
+        fun='test.ping') %}
+
+{% if mine %}
+test.ping:
+  salt.function:
+    - tgt: "{{ minion }}"
+{% endif %}

--- a/tests/integration/runners/test_state.py
+++ b/tests/integration/runners/test_state.py
@@ -97,10 +97,18 @@ class StateRunnerTest(ShellCase):
         '''
         test salt-run state.orchestrate with mine.get call in sls
         '''
-        test = self.run_run('mine.update "*"')
-        ret = self.run_run('state.orchestrate orch.mine')
+        fail_time = time.time() + 120
+        self.run_run('mine.update "*"')
 
-        assert 'Succeeded: 1 (changed=1)' in ret
+        exp_ret = 'Succeeded: 1 (changed=1)'
+        while True:
+            ret = self.run_run('state.orchestrate orch.mine')
+            try:
+                assert exp_ret in ret
+                break
+            except AssertionError:
+                if time.time() > fail_time:
+                    self.fail('"{0}" was not found in the orchestration call'.format(exp_ret))
 
     def test_orchestrate_state_and_function_failure(self):
         '''

--- a/tests/integration/runners/test_state.py
+++ b/tests/integration/runners/test_state.py
@@ -93,6 +93,15 @@ class StateRunnerTest(ShellCase):
         assert os.path.exists('/tmp/ewu-2016-12-13') is False
         assert code != 0
 
+    def test_orchestrate_with_mine(self):
+        '''
+        test salt-run state.orchestrate with mine.get call in sls
+        '''
+        test = self.run_run('mine.update "*"')
+        ret = self.run_run('state.orchestrate orch.mine')
+
+        assert 'Succeeded: 1 (changed=1)' in ret
+
     def test_orchestrate_state_and_function_failure(self):
         '''
         Ensure that returns from failed minions are in the changes dict where


### PR DESCRIPTION
### What does this PR do?
adds state.orchestration test with `mine.get` call in the sls file.

### What issues does this PR fix or reference?
fixes https://github.com/saltstack/salt/issues/49016
