### PR TITLE
fix memoize on available macOS services

### DIFF
--- a/salt/modules/mac_service.py
+++ b/salt/modules/mac_service.py
@@ -51,19 +51,19 @@ def __virtual__():
     return __virtualname__
 
 
-def _get_service(name):
+def _name_in_services(name, services):
     '''
-    Get information about a service.  If the service is not found, raise an
-    error
+    Checks to see if the given service is in the given services.
 
     :param str name: Service label, file name, or full path
 
-    :return: The service information for the service, otherwise an Error
+    :param dict services: The currently available services.
+
+    :return: The service information for the service, otherwise
+    an empty dictionary
+
     :rtype: dict
     '''
-    services = __utils__['mac_utils.available_services']()
-    name = name.lower()
-
     if name in services:
         # Match on label
         return services[name]
@@ -77,8 +77,50 @@ def _get_service(name):
             # Match on basename
             return service
 
-    # Could not find service
-    raise CommandExecutionError('Service not found: {0}'.format(name))
+    return dict()
+
+
+def _get_service(name):
+    '''
+    Get information about a service.  If the service is not found, raise an
+    error
+
+    :param str name: Service label, file name, or full path
+
+    :return: The service information for the service, otherwise an Error
+    :rtype: dict
+    '''
+    services = __utils__['mac_utils.available_services']()
+    name = name.lower()
+
+    service = _name_in_services(name, services)
+
+    # if we would the service we can return it
+    if service:
+        return service
+
+    # if we got here our service is not available, now we can check to see if
+    # we received a cached batch of services, if not we did a fresh check
+    # so we need to raise that the service could not be found.
+    try:
+        if not __context__['using_cached_services']:
+            raise CommandExecutionError('Service not found: {0}'.format(name))
+    except KeyError:
+        pass
+
+    # we used a cached version to check, a service could have been made
+    # between now and then, we should refresh our available services.
+    services = __utils__['mac_utils.available_services'](refresh=True)
+
+    # check to see if we found the service we are looking for.
+    service = _name_in_services(name, services)
+
+    if not service:
+        # Could not find the service after refresh raise.
+        raise CommandExecutionError('Service not found: {0}'.format(name))
+
+    # found it :)
+    return service
 
 
 def show(name):
@@ -429,7 +471,7 @@ def disabled(name, runas=None, domain='system'):
 
         salt '*' service.disabled org.cups.cupsd
     '''
-    ret = False
+
     disabled = launchctl('print-disabled',
                          domain,
                          return_stdout=True,

--- a/salt/utils/mac_utils.py
+++ b/salt/utils/mac_utils.py
@@ -299,14 +299,18 @@ def launchctl(sub_cmd, *args, **kwargs):
         return ret['stdout'] if return_stdout else True
 
 
-def _available_services():
+def _available_services(refresh=False):
     '''
-    This is a helper function needed for testing. We are using the memoziation
-    decorator on the `available_services` function, which causes the function
-    to run once and then return the results of the first run on subsequent
-    calls. This causes problems when trying to test the functionality of the
-    `available_services` function.
+    This is a helper function for getting the available macOS services.
     '''
+    try:
+        if __context__['available_services'] and not refresh:
+            log.debug('Found context for available services.')
+            __context__['available_services_cached'] = True
+            return __context__['available_services']
+    except KeyError:
+        pass
+
     launchd_paths = [
         '/Library/LaunchAgents',
         '/Library/LaunchDaemons',
@@ -359,13 +363,21 @@ def _available_services():
                         'file_path': true_path,
                         'plist': plist}
 
-    return _available_services
+    # put this in __context__ as this is a time consuming function.
+    # a fix for this issue. https://github.com/saltstack/salt/issues/48414
+    __context__['available_services'] = _available_services
+    # this is a fresh gathering of services, set cached to false
+    __context__['available_services_cached'] = False
+
+    return __context__['available_services']
 
 
-@decorators.memoize
-def available_services():
+def available_services(refresh=False):
     '''
     Return a dictionary of all available services on the system
+
+    :param bool refresh: If you wish to refresh the available services
+    as this data is cached on the first run.
 
     Returns:
         dict: All available services
@@ -377,4 +389,5 @@ def available_services():
         import salt.utils.mac_service
         salt.utils.mac_service.available_services()
     '''
-    return _available_services()
+    log.debug('Loading available services')
+    return _available_services(refresh)

--- a/salt/utils/mac_utils.py
+++ b/salt/utils/mac_utils.py
@@ -15,7 +15,6 @@ import time
 # Import Salt Libs
 import salt.modules.cmdmod
 import salt.utils.args
-import salt.utils.decorators as decorators
 import salt.utils.files
 import salt.utils.path
 import salt.utils.platform
@@ -306,7 +305,7 @@ def _available_services(refresh=False):
     try:
         if __context__['available_services'] and not refresh:
             log.debug('Found context for available services.')
-            __context__['available_services_cached'] = True
+            __context__['using_cached_services'] = True
             return __context__['available_services']
     except KeyError:
         pass
@@ -367,7 +366,7 @@ def _available_services(refresh=False):
     # a fix for this issue. https://github.com/saltstack/salt/issues/48414
     __context__['available_services'] = _available_services
     # this is a fresh gathering of services, set cached to false
-    __context__['available_services_cached'] = False
+    __context__['using_cached_services'] = False
 
     return __context__['available_services']
 

--- a/tests/unit/utils/test_mac_utils.py
+++ b/tests/unit/utils/test_mac_utils.py
@@ -10,6 +10,7 @@ import os
 # Import Salt Testing Libs
 from tests.support.unit import TestCase, skipIf
 from tests.support.mock import MagicMock, patch, NO_MOCK, NO_MOCK_REASON, call
+from tests.support.mixins import LoaderModuleMockMixin
 
 # Import Salt libs
 import salt.utils.mac_utils as mac_utils
@@ -21,10 +22,13 @@ from salt.ext import six
 
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
-class MacUtilsTestCase(TestCase):
+class MacUtilsTestCase(TestCase, LoaderModuleMockMixin):
     '''
     test mac_utils salt utility
     '''
+    def setup_loader_modules(self):
+        return {mac_utils: {}}
+
     def test_execute_return_success_not_supported(self):
         '''
         test execute_return_success function


### PR DESCRIPTION
### What does this PR do?

Changes macOS services to using the __context__ dictionary versus the memoize decorator. And some other pylint fixes.  Would love to get this into 2018.3.3 if possible 😃 

### What issues does this PR fix or reference?

https://github.com/saltstack/salt/issues/48414

### Previous Behavior
Previously on the macOS services module, it would use the memoize decorator to capture available services. This was causing an issue with newly created services. See the referenced issue for more details.

### New Behavior

Now uses the `__context__` dictionary, to avoid the previous issue and still maintain efficient runtimes. 

### Tests written?

No

### Commits signed with GPG?

Yes

cc @gtmanfred @terminalmage as they recommended this fix. 