### PR TITLE
added MSI authentication support for Azure

### DIFF
--- a/salt/utils/azurearm.py
+++ b/salt/utils/azurearm.py
@@ -47,6 +47,9 @@ try:
         UserPassCredentials,
         ServicePrincipalCredentials,
     )
+    from msrestazure.azure_active_directory import (
+        MSIAuthentication
+    )
     from msrestazure.azure_cloud import (
         MetadataEndpointError,
         get_cloud_from_metadata_endpoint,
@@ -110,6 +113,9 @@ def _determine_auth(**kwargs):
             credentials = UserPassCredentials(kwargs['username'],
                                               kwargs['password'],
                                               cloud_environment=cloud_env)
+    elif 'subscription_id' in kwargs:
+        credentials = MSIAuthentication(cloud_environment=cloud_env)
+
     else:
         raise SaltInvocationError(
             'Unable to determine credentials. '


### PR DESCRIPTION
### What does this PR do?

Enable rudimentary support for Azure MSI-style authentication described here:
https://docs.microsoft.com/en-us/azure/active-directory/managed-service-identity/overview
This prevents the requirement to put secure credentials into config files.

This is similar to a **salt-cloud** feature when using IAM authentication in EC2 described here:
https://docs.saltstack.com/en/latest/topics/cloud/aws.html#iam-profile

### What issues does this PR fix or reference?

No public sources known

### Previous Behavior
No support currently exists in salt-cloud for MSI authentication so credentials are often placed in
salt-cloud config files.

### New Behavior
When running salt-cloud in a VM, with appropriate MSI "roles"  assigned to it, the VM can perform all valid salt-cloud functions in Azure.
No credentials need to be placed in config files.

### Tests written?

No

### Commits signed with GPG?

No
