### PR TITLE
Stop running lint on all files when no changes

### DIFF
--- a/.ci/lint
+++ b/.ci/lint
@@ -20,8 +20,15 @@ pipeline {
         }
         stage('setup') {
             steps {
-                sh 'eval "$(pyenv init -)"; pyenv install 2.7.14 || echo "We already have this python."; pyenv local 2.7.14; pyenv shell 2.7.14'
-                sh 'eval "$(pyenv init -)"; pip install tox'
+                sh '''
+                eval "$(pyenv init -)"
+                pyenv --version
+                pyenv install --skip-existing 2.7.14
+                pyenv local 2.7.14
+                pyenv shell 2.7.14
+                python --version
+                pip install tox
+                '''
             }
         }
         stage('linting') {
@@ -29,13 +36,32 @@ pipeline {
             parallel {
                 stage('salt linting') {
                     steps {
-                        sh 'eval "$(pyenv init - --no-rehash)"; tox -e pylint-salt $(find salt/ -name "*.py" -exec git diff --name-only "origin/$CHANGE_TARGET" "origin/$BRANCH_NAME" setup.py {} +) | tee pylint-report.xml'
+                        sh '''
+                        eval "$(pyenv init - --no-rehash)"
+                        _FILES="$(find salt/ -name "*.py" -exec git diff --name-only "origin/$CHANGE_TARGET" "origin/$BRANCH_NAME" {} +)"
+                        _FILES="$_FILES $(git diff --name-only "origin/$CHANGE_TARGET" "origin/$BRANCH_NAME" setup.py)"
+                        if [[ -z ${_FILES} ]]; then
+                            echo "No pylint run, no changes found in the files"
+                            echo "empty" pylint-reports.xml
+                        else
+                            tox -e pylint-salt ${_FILES} | tee pylint-report.xml
+                        fi
+                        '''
                         archiveArtifacts artifacts: 'pylint-report.xml'
                     }
                 }
                 stage('test linting') {
                     steps {
-                        sh 'eval "$(pyenv init - --no-rehash)"; tox -e pylint-tests $(find tests/ -name "*.py" -exec git diff --name-only "origin/$CHANGE_TARGET" "origin/$BRANCH_NAME" {} +) | tee pylint-report-tests.xml'
+                        sh '''
+                        eval "$(pyenv init - --no-rehash)"
+                        _FILES="$(find tests/ -name "*.py" -exec git diff --name-only "origin/$CHANGE_TARGET" "origin/$BRANCH_NAME" setup.py {} +)"
+                        if [[ -z ${_FILES} ]]; then
+                            echo "No pylint run, no changes found in the files"
+                            touch pylint-report-tests.xml
+                        else
+                            tox -e pylint-tests ${_FILES} | tee pylint-report-tests.xml
+                        fi
+                        '''
                         archiveArtifacts artifacts: 'pylint-report-tests.xml'
                     }
                 }


### PR DESCRIPTION
Stops our lint from running on all of the files in `salt/` or `test/`
when no files were modified. By default, when tox is told to run with no
positional arguments, it'll run on all files we'd look at. When run with
positional arguments it'll run only on those files. This makes it so
that tox, by default, will only run lint checks on commits that actually
change the files in `salt/` or `test/`.

It also kinda cleans up the sh calls a bit.

### What issues does this PR fix or reference?

saltstack/devops#103

### Previous Behavior
Run all tests when no files were changed (ie doc changes)

### New Behavior
Only run tests when actual changes are made

### Commits signed with GPG?

Yes

Pending completion of:

https://jenkinsci.saltstack.com/job/pr-lint/view/change-requests/job/PR-49063/5/console

@gtmanfred 