### PR TITLE
raise SaltInvocationError more detailed

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -562,7 +562,7 @@ def lsattr(path):
         return None
 
     if not os.path.exists(path):
-        raise SaltInvocationError("File or directory does not exist.")
+        raise SaltInvocationError("File or directory does not exist: " + path)
 
     cmd = ['lsattr', path]
     result = __salt__['cmd.run'](cmd, ignore_retcode=True, python_shell=False)


### PR DESCRIPTION
In case a symlink is broken it fails. Add the detail of the file which fails saves hours to people...

### What does this PR do?
Add the detail of the file which fails in case of error

### What issues does this PR fix or reference?
n/a

### Previous Behavior
In case a symlink is broken it fails

### New Behavior
In case a symlink is broken it fails but shows what is the error

### Tests written?

No

### Commits signed with GPG?

Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
