### PR TITLE
Filter out scheme's that are not valid

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -3886,7 +3886,10 @@ def get_managed(
     # If we have a source defined, let's figure out what the hash is
     if source:
         urlparsed_source = _urlparse(source)
-        parsed_scheme = urlparsed_source.scheme
+        if urlparsed_source.scheme in salt.utils.files.VALID_PROTOS:
+            parsed_scheme = urlparsed_source.scheme
+        else:
+            parsed_scheme = ''
         parsed_path = os.path.join(
                 urlparsed_source.netloc, urlparsed_source.path).rstrip(os.sep)
         unix_local_source = parsed_scheme in ('file', '')


### PR DESCRIPTION
### What does this PR do?

We don't want to honor schemes that are not valid an example of this is
a string like 'c:\\foo' will have a scheme of 'c' after being parsed.

This will fix multiple failing tests in `integration.states.test_file`.


### Tests written?

No - Fixing existing tests

### Commits signed with GPG?

Yes
