### PR TITLE
Search for (but do not include) CRLF line ending

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -2111,7 +2111,7 @@ def replace(path,
                 if prepend_if_not_found or append_if_not_found:
                     # Search for content, to avoid pre/appending the
                     # content if it was pre/appended in a previous run.
-                    if re.search(salt.utils.to_bytes('^{0}$'.format(re.escape(content))),
+                    if re.search(salt.utils.to_bytes('^{0}($|(?=\r\n))'.format(re.escape(content))),
                                  r_data,
                                  flags=flags_num):
                         # Content was found, so set found.


### PR DESCRIPTION
### What does this PR do?

When searching for a line in a file that has CRLF line endings, the
normal $ regex will not match a line. With this change, we will match on
but not include LF, CRLF, and the end of a file.

This fixes line insert tests like:

`integration.states.test_file.FileTest.test_replace_issue_18612_append`


### Tests written?

No - Fixes existing test

### Commits signed with GPG?

Yes