### PR TITLE
skip gpg tests if not installed

### DIFF
--- a/tests/unit/modules/test_gpg.py
+++ b/tests/unit/modules/test_gpg.py
@@ -21,6 +21,7 @@ from tests.support.mock import (
 
 # Import Salt Libs
 import salt.modules.gpg as gpg
+import salt.utils.path
 
 
 try:
@@ -30,6 +31,7 @@ except ImportError:
     HAS_GPG = False
 
 
+@skipIf(not salt.utils.path.which('gpg'), 'gpg not installed skipping')
 @skipIf(NO_MOCK, NO_MOCK_REASON)
 class GpgTestCase(TestCase, LoaderModuleMockMixin):
     '''

--- a/tests/unit/modules/test_gpg.py
+++ b/tests/unit/modules/test_gpg.py
@@ -31,7 +31,7 @@ except ImportError:
     HAS_GPG = False
 
 
-@skipIf(not salt.utils.path.which('gpg'), 'gpg not installed skipping')
+@skipIf(not salt.utils.path.which('gpg'), 'GPG not installed. Skipping')
 @skipIf(NO_MOCK, NO_MOCK_REASON)
 class GpgTestCase(TestCase, LoaderModuleMockMixin):
     '''


### PR DESCRIPTION
### What does this PR do?
The test `unit.modules.test_gpg.GpgTestCase.test_delete_key` is failing on macosx because gpg is not installed. 

I added this salt-jenkins state: https://github.com/saltstack/salt-jenkins/pull/1063 to install it but figured it would be good to add the skipif to make sure we skip if its not installed for other OS's.

