### PR TITLE
Add ARPCHECK option to rh7_eth template

### DIFF
--- a/salt/templates/rh_ip/rh7_eth.jinja
+++ b/salt/templates/rh_ip/rh7_eth.jinja
@@ -25,6 +25,7 @@ IPADDR{{loop.index}}="{{i['ipaddr']}}"
 PREFIX{{loop.index}}="{{i['prefix']}}"
 {% endfor -%}
 {%endif%}{% if gateway %}GATEWAY="{{gateway}}"
+{%endif%}{% if arpcheck %}ARPCHECK="{{arpcheck}}"
 {%endif%}{% if enable_ipv6 %}IPV6INIT="yes"
 {% if ipv6_autoconf %}IPV6_AUTOCONF="{{ipv6_autoconf}}"
 {%endif%}{% if dhcpv6c %}DHCPV6C="{{dhcpv6c}}"


### PR DESCRIPTION
### What does this PR do?
Add support for setting ARPCHECK config on RedHat 7

### What issues does this PR fix or reference?
#49074 

### Previous Behavior
Not setting arpcheck.

### New Behavior
Setting arpcheck to value provided when used in `network.managed` state.

### Tests written?

No

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.