### PR TITLE
Use the minion's region if use_grain is enabled

### DIFF
--- a/salt/pillar/ec2_pillar.py
+++ b/salt/pillar/ec2_pillar.py
@@ -184,6 +184,10 @@ def ext_pillar(minion_id,
     # Get the Master's instance info, primarily the region
     (_, region) = _get_instance_info()
 
+    # If the Minion's region is available, use it instead
+    if use_grain:
+        region = __grains__.get('ec2', {}).get('region', region)
+
     try:
         conn = boto.ec2.connect_to_region(region)
     except boto.exception.AWSConnectionError as exc:


### PR DESCRIPTION
This makes it possible for the master to be in a different region
than the minion and still fetch ec2 pillars. This requires the
use_grain configuration to be set to True and will fall back to the
master's region if there is no region grain.

Credit to John Nielsen for the code.

Signed-off-by: Carson Anderson <ca@carsonoid.net>

### Previous Behavior

The salt-master had to be in the same region as all salt-minions

### New Behavior

The master can use minion metadata to determine which api to call

### Tests written?

No

### Commits signed with GPG?

Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
