### PR TITLE
[fluorine] Fixes to scheduler for jobs with seconds, minutes, etc.

### DIFF
--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -1564,45 +1564,49 @@ class Schedule(object):
                            'by {0} seconds)'.format(abs(seconds))
 
             try:
-                # Job is disabled, continue
-                if 'enabled' in data and not data['enabled']:
-                    log.debug('Job: %s is disabled', job_name)
-                    data['_skip_reason'] = 'disabled'
-                    data['_skipped_time'] = now
-                    data['_skipped'] = True
-                    continue
+                if run:
+                    # Job is disabled, continue
+                    if 'enabled' in data and not data['enabled']:
+                        log.debug('Job: %s is disabled', job_name)
+                        data['_skip_reason'] = 'disabled'
+                        data['_skipped_time'] = now
+                        data['_skipped'] = True
+                        continue
 
-                if 'jid_include' not in data or data['jid_include']:
-                    data['jid_include'] = True
-                    log.debug('schedule: Job %s was scheduled with jid_include, '
-                              'adding to cache (jid_include defaults to True)',
-                              job_name)
-                    if 'maxrunning' in data:
-                        log.debug('schedule: Job %s was scheduled with a max '
-                                  'number of %s', job_name, data['maxrunning'])
-                    else:
-                        log.info('schedule: maxrunning parameter was not specified for '
-                                 'job %s, defaulting to 1.', job_name)
-                        data['maxrunning'] = 1
+                    if 'jid_include' not in data or data['jid_include']:
+                        data['jid_include'] = True
+                        log.debug('schedule: Job %s was scheduled with jid_include, '
+                                  'adding to cache (jid_include defaults to True)',
+                                  job_name)
+                        if 'maxrunning' in data:
+                            log.debug('schedule: Job %s was scheduled with a max '
+                                      'number of %s', job_name, data['maxrunning'])
+                        else:
+                            log.info('schedule: maxrunning parameter was not specified for '
+                                     'job %s, defaulting to 1.', job_name)
+                            data['maxrunning'] = 1
 
-                if not self.standalone:
-                    data['run'] = run
-                    data = self._check_max_running(func,
-                                                   data,
-                                                   self.opts,
-                                                   now)
-                    run = data['run']
+                    if not self.standalone:
+                        data['run'] = run
+                        data = self._check_max_running(func,
+                                                       data,
+                                                       self.opts,
+                                                       now)
+                        run = data['run']
 
+                # Check run again, just in case _check_max_running
+                # set run to False
                 if run:
                     log.info('Running scheduled job: %s%s', job_name, miss_msg)
                     self._run_job(func, data)
+
             finally:
                 # Only set _last_run if the job ran
                 if run:
                     data['_last_run'] = now
                     data['_splay'] = None
-                if '_seconds' in data:
-                    data['_next_fire_time'] = now + datetime.timedelta(seconds=data['_seconds'])
+                    if '_seconds' in data:
+                        data['_next_fire_time'] = now + datetime.timedelta(seconds=data['_seconds'])
 
     def _run_job(self, func, data):
         job_dry_run = data.get('dry_run', False)

--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -1605,8 +1605,8 @@ class Schedule(object):
                 if run:
                     data['_last_run'] = now
                     data['_splay'] = None
-                    if '_seconds' in data:
-                        data['_next_fire_time'] = now + datetime.timedelta(seconds=data['_seconds'])
+                if '_seconds' in data:
+                    data['_next_fire_time'] = now + datetime.timedelta(seconds=data['_seconds'])
 
     def _run_job(self, func, data):
         job_dry_run = data.get('dry_run', False)

--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -1606,7 +1606,13 @@ class Schedule(object):
                     data['_last_run'] = now
                     data['_splay'] = None
                 if '_seconds' in data:
-                    data['_next_fire_time'] = now + datetime.timedelta(seconds=data['_seconds'])
+                    if not self.standalone and run:
+                        # If we are not in standalone mode and the job has run
+                        # set the next_fire_time
+                        data['_next_fire_time'] = now + datetime.timedelta(seconds=data['_seconds'])
+                    else:
+                        # If we are standalone mode set the _next_fire_time
+                        data['_next_fire_time'] = now + datetime.timedelta(seconds=data['_seconds'])
 
     def _run_job(self, func, data):
         job_dry_run = data.get('dry_run', False)

--- a/tests/integration/scheduler/test_eval.py
+++ b/tests/integration/scheduler/test_eval.py
@@ -9,6 +9,7 @@ import os
 import random
 
 import dateutil.parser as dateutil_parser
+import datetime
 
 # Import Salt Testing libs
 from tests.support.case import ModuleCase
@@ -606,26 +607,41 @@ class SchedulerEvalTest(ModuleCase, SaltReturnAssertsMixin):
 
         # eval at 2:00pm to prime, simulate minion start up.
         run_time = dateutil_parser.parse('11/29/2017 2:00pm')
+        next_run_time = run_time + datetime.timedelta(seconds=30)
         self.schedule.eval(now=run_time)
         ret = self.schedule.job_status('job_eval_seconds')
+        self.assertEqual(ret['_next_fire_time'], next_run_time)
+
+        # eval at 2:00:01pm, will not run.
+        run_time = dateutil_parser.parse('11/29/2017 2:00:01pm')
+        self.schedule.eval(now=run_time)
+        ret = self.schedule.job_status('job_eval_seconds')
+        self.assertNotIn('_last_run', ret)
+        self.assertEqual(ret['_next_fire_time'], next_run_time)
 
         # eval at 2:00:30pm, will run.
         run_time = dateutil_parser.parse('11/29/2017 2:00:30pm')
+        next_run_time = run_time + datetime.timedelta(seconds=30)
         self.schedule.eval(now=run_time)
         ret = self.schedule.job_status('job_eval_seconds')
         self.assertEqual(ret['_last_run'], run_time)
+        self.assertEqual(ret['_next_fire_time'], next_run_time)
 
         # eval at 2:01:00pm, will run.
         run_time = dateutil_parser.parse('11/29/2017 2:01:00pm')
+        next_run_time = run_time + datetime.timedelta(seconds=30)
         self.schedule.eval(now=run_time)
         ret = self.schedule.job_status('job_eval_seconds')
         self.assertEqual(ret['_last_run'], run_time)
+        self.assertEqual(ret['_next_fire_time'], next_run_time)
 
         # eval at 2:01:30pm, will run.
         run_time = dateutil_parser.parse('11/29/2017 2:01:30pm')
+        next_run_time = run_time + datetime.timedelta(seconds=30)
         self.schedule.eval(now=run_time)
         ret = self.schedule.job_status('job_eval_seconds')
         self.assertEqual(ret['_last_run'], run_time)
+        self.assertEqual(ret['_next_fire_time'], next_run_time)
 
     def test_eval_minutes(self):
         '''
@@ -645,8 +661,17 @@ class SchedulerEvalTest(ModuleCase, SaltReturnAssertsMixin):
 
         # eval at 2:00pm to prime, simulate minion start up.
         run_time = dateutil_parser.parse('11/29/2017 2:00pm')
+        next_run_time = run_time + datetime.timedelta(minutes=30)
         self.schedule.eval(now=run_time)
         ret = self.schedule.job_status('job_eval_minutes')
+        self.assertEqual(ret['_next_fire_time'], next_run_time)
+
+        # eval at 2:00:01pm, will not run.
+        run_time = dateutil_parser.parse('11/29/2017 2:00:01pm')
+        self.schedule.eval(now=run_time)
+        ret = self.schedule.job_status('job_eval_minutes')
+        self.assertNotIn('_last_run', ret)
+        self.assertEqual(ret['_next_fire_time'], next_run_time)
 
         # eval at 2:30:00pm, will run.
         run_time = dateutil_parser.parse('11/29/2017 2:30:00pm')
@@ -684,8 +709,17 @@ class SchedulerEvalTest(ModuleCase, SaltReturnAssertsMixin):
 
         # eval at 2:00pm to prime, simulate minion start up.
         run_time = dateutil_parser.parse('11/29/2017 2:00pm')
+        next_run_time = run_time + datetime.timedelta(hours=2)
         self.schedule.eval(now=run_time)
         ret = self.schedule.job_status('job_eval_hours')
+        self.assertEqual(ret['_next_fire_time'], next_run_time)
+
+        # eval at 2:00:01pm, will not run.
+        run_time = dateutil_parser.parse('11/29/2017 2:00:01pm')
+        self.schedule.eval(now=run_time)
+        ret = self.schedule.job_status('job_eval_hours')
+        self.assertNotIn('_last_run', ret)
+        self.assertEqual(ret['_next_fire_time'], next_run_time)
 
         # eval at 4:00:00pm, will run.
         run_time = dateutil_parser.parse('11/29/2017 4:00:00pm')
@@ -723,23 +757,47 @@ class SchedulerEvalTest(ModuleCase, SaltReturnAssertsMixin):
 
         # eval at 11/23/2017 2:00pm to prime, simulate minion start up.
         run_time = dateutil_parser.parse('11/23/2017 2:00pm')
+        next_run_time = run_time + datetime.timedelta(days=2)
         self.schedule.eval(now=run_time)
         ret = self.schedule.job_status('job_eval_days')
+        self.assertEqual(ret['_next_fire_time'], next_run_time)
 
         # eval at 11/25/2017 2:00:00pm, will run.
         run_time = dateutil_parser.parse('11/25/2017 2:00:00pm')
+        next_run_time = run_time + datetime.timedelta(days=2)
         self.schedule.eval(now=run_time)
         ret = self.schedule.job_status('job_eval_days')
         self.assertEqual(ret['_last_run'], run_time)
+        self.assertEqual(ret['_next_fire_time'], next_run_time)
 
-        # eval at 11/23/2017 2:00:00pm, will run.
+        # eval at 11/26/2017 2:00:00pm, will not run.
+        run_time = dateutil_parser.parse('11/26/2017 2:00:00pm')
+        last_run_time = run_time - datetime.timedelta(days=1)
+        self.schedule.eval(now=run_time)
+        ret = self.schedule.job_status('job_eval_days')
+        self.assertEqual(ret['_last_run'], last_run_time)
+        self.assertEqual(ret['_next_fire_time'], next_run_time)
+
+        # eval at 11/27/2017 2:00:00pm, will run.
         run_time = dateutil_parser.parse('11/27/2017 2:00:00pm')
+        next_run_time = run_time + datetime.timedelta(days=2)
         self.schedule.eval(now=run_time)
         ret = self.schedule.job_status('job_eval_days')
         self.assertEqual(ret['_last_run'], run_time)
+        self.assertEqual(ret['_next_fire_time'], next_run_time)
 
-        # eval at 11/23/2017 2:00:00pm, will run.
+        # eval at 11/28/2017 2:00:00pm, will not run.
+        run_time = dateutil_parser.parse('11/28/2017 2:00:00pm')
+        last_run_time = run_time - datetime.timedelta(days=1)
+        self.schedule.eval(now=run_time)
+        ret = self.schedule.job_status('job_eval_days')
+        self.assertEqual(ret['_last_run'], last_run_time)
+        self.assertEqual(ret['_next_fire_time'], next_run_time)
+
+        # eval at 11/29/2017 2:00:00pm, will run.
         run_time = dateutil_parser.parse('11/29/2017 2:00:00pm')
+        next_run_time = run_time + datetime.timedelta(days=2)
         self.schedule.eval(now=run_time)
         ret = self.schedule.job_status('job_eval_days')
         self.assertEqual(ret['_last_run'], run_time)
+        self.assertEqual(ret['_next_fire_time'], next_run_time)

--- a/tests/integration/scheduler/test_eval.py
+++ b/tests/integration/scheduler/test_eval.py
@@ -587,3 +587,159 @@ class SchedulerEvalTest(ModuleCase, SaltReturnAssertsMixin):
             self.schedule.eval(now=run_time)
             ret = self.schedule.job_status('job_eval_splay')
             self.assertEqual(ret['_last_run'], run_time)
+
+    def test_eval_seconds(self):
+        '''
+        verify that scheduled job run mutiple times with seconds
+        '''
+        job = {
+          'schedule': {
+            'job_eval_seconds': {
+              'function': 'test.ping',
+              'seconds': '30',
+            }
+          }
+        }
+
+        # Add job to schedule
+        self.schedule.opts.update(job)
+
+        # eval at 2:00pm to prime, simulate minion start up.
+        run_time = dateutil_parser.parse('11/29/2017 2:00pm')
+        self.schedule.eval(now=run_time)
+        ret = self.schedule.job_status('job_eval_seconds')
+
+        # eval at 2:00:30pm, will run.
+        run_time = dateutil_parser.parse('11/29/2017 2:00:30pm')
+        self.schedule.eval(now=run_time)
+        ret = self.schedule.job_status('job_eval_seconds')
+        self.assertEqual(ret['_last_run'], run_time)
+
+        # eval at 2:01:00pm, will run.
+        run_time = dateutil_parser.parse('11/29/2017 2:01:00pm')
+        self.schedule.eval(now=run_time)
+        ret = self.schedule.job_status('job_eval_seconds')
+        self.assertEqual(ret['_last_run'], run_time)
+
+        # eval at 2:01:30pm, will run.
+        run_time = dateutil_parser.parse('11/29/2017 2:01:30pm')
+        self.schedule.eval(now=run_time)
+        ret = self.schedule.job_status('job_eval_seconds')
+        self.assertEqual(ret['_last_run'], run_time)
+
+    def test_eval_minutes(self):
+        '''
+        verify that scheduled job run mutiple times with minutes
+        '''
+        job = {
+          'schedule': {
+            'job_eval_minutes': {
+              'function': 'test.ping',
+              'minutes': '30',
+            }
+          }
+        }
+
+        # Add job to schedule
+        self.schedule.opts.update(job)
+
+        # eval at 2:00pm to prime, simulate minion start up.
+        run_time = dateutil_parser.parse('11/29/2017 2:00pm')
+        self.schedule.eval(now=run_time)
+        ret = self.schedule.job_status('job_eval_minutes')
+
+        # eval at 2:30:00pm, will run.
+        run_time = dateutil_parser.parse('11/29/2017 2:30:00pm')
+        self.schedule.eval(now=run_time)
+        ret = self.schedule.job_status('job_eval_minutes')
+        self.assertEqual(ret['_last_run'], run_time)
+
+        # eval at 3:00:00pm, will run.
+        run_time = dateutil_parser.parse('11/29/2017 3:00:00pm')
+        self.schedule.eval(now=run_time)
+        ret = self.schedule.job_status('job_eval_minutes')
+        self.assertEqual(ret['_last_run'], run_time)
+
+        # eval at 3:30:00pm, will run.
+        run_time = dateutil_parser.parse('11/29/2017 3:30:00pm')
+        self.schedule.eval(now=run_time)
+        ret = self.schedule.job_status('job_eval_minutes')
+        self.assertEqual(ret['_last_run'], run_time)
+
+    def test_eval_hours(self):
+        '''
+        verify that scheduled job run mutiple times with hours
+        '''
+        job = {
+          'schedule': {
+            'job_eval_hours': {
+              'function': 'test.ping',
+              'hours': '2',
+            }
+          }
+        }
+
+        # Add job to schedule
+        self.schedule.opts.update(job)
+
+        # eval at 2:00pm to prime, simulate minion start up.
+        run_time = dateutil_parser.parse('11/29/2017 2:00pm')
+        self.schedule.eval(now=run_time)
+        ret = self.schedule.job_status('job_eval_hours')
+
+        # eval at 4:00:00pm, will run.
+        run_time = dateutil_parser.parse('11/29/2017 4:00:00pm')
+        self.schedule.eval(now=run_time)
+        ret = self.schedule.job_status('job_eval_hours')
+        self.assertEqual(ret['_last_run'], run_time)
+
+        # eval at 6:00:00pm, will run.
+        run_time = dateutil_parser.parse('11/29/2017 6:00:00pm')
+        self.schedule.eval(now=run_time)
+        ret = self.schedule.job_status('job_eval_hours')
+        self.assertEqual(ret['_last_run'], run_time)
+
+        # eval at 8:00:00pm, will run.
+        run_time = dateutil_parser.parse('11/29/2017 8:00:00pm')
+        self.schedule.eval(now=run_time)
+        ret = self.schedule.job_status('job_eval_hours')
+        self.assertEqual(ret['_last_run'], run_time)
+
+    def test_eval_days(self):
+        '''
+        verify that scheduled job run mutiple times with days
+        '''
+        job = {
+          'schedule': {
+            'job_eval_days': {
+              'function': 'test.ping',
+              'days': '2',
+            }
+          }
+        }
+
+        # Add job to schedule
+        self.schedule.opts.update(job)
+
+        # eval at 11/23/2017 2:00pm to prime, simulate minion start up.
+        run_time = dateutil_parser.parse('11/23/2017 2:00pm')
+        self.schedule.eval(now=run_time)
+        ret = self.schedule.job_status('job_eval_days')
+
+        # eval at 11/25/2017 2:00:00pm, will run.
+        run_time = dateutil_parser.parse('11/25/2017 2:00:00pm')
+        self.schedule.eval(now=run_time)
+        ret = self.schedule.job_status('job_eval_days')
+        self.assertEqual(ret['_last_run'], run_time)
+
+        # eval at 11/23/2017 2:00:00pm, will run.
+        run_time = dateutil_parser.parse('11/27/2017 2:00:00pm')
+        self.schedule.eval(now=run_time)
+        ret = self.schedule.job_status('job_eval_days')
+        self.assertEqual(ret['_last_run'], run_time)
+
+        # eval at 11/23/2017 2:00:00pm, will run.
+        run_time = dateutil_parser.parse('11/29/2017 2:00:00pm')
+        self.schedule.eval(now=run_time)
+        ret = self.schedule.job_status('job_eval_days')
+        self.assertEqual(ret['_last_run'], run_time)


### PR DESCRIPTION
### What does this PR do?
Do not log about various things like jid_include and max_running unless the job is set to run.  If the job contains _seconds, eg. it's using seconds, minutes, hours, etc. then only set the _next_fire_time if the job actually runs.  Adding more tests to test simple scenarios when seconds, minutes, hours and days to ensure we get multiple scheduled job runs when they're expected to run.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/49082
https://github.com/saltstack/salt/issues/49093

### Tests written?
Yes

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
