### PR TITLE
salt/utils/cloud: fix crash issue. Thanks @rklaren

### DIFF
--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -187,10 +187,10 @@ def __ssh_gateway_arguments(kwargs):
                 ssh_gateway_command
             )
 
-    log.info(
-        'Using SSH gateway %s@%s:%s %s',
-        ssh_gateway_user, ssh_gateway, ssh_gateway_port, ssh_gateway_command
-    )
+        log.info(
+            'Using SSH gateway %s@%s:%s %s',
+            ssh_gateway_user, ssh_gateway, ssh_gateway_port, ssh_gateway_command
+        )
 
     return extended_arguments
 


### PR DESCRIPTION
Some variables are not in their right scope; that makes salt crashed
when user settings do not include some gateway settings.

Cf: #48062

### What does this PR do?

Fix a crash introduced in #48062

### What issues does this PR fix or reference?

### Previous Behavior

`salt-cloud` may crash if some gateway settings are not provided in configuration file.

### New Behavior

No crash if some gateway settings are missing.

### Tests written?

NO

### Commits signed with GPG?

Yes