### PR TITLE
Fix windows installer script

### DIFF
--- a/pkg/windows/installer/Salt-Minion-Setup.nsi
+++ b/pkg/windows/installer/Salt-Minion-Setup.nsi
@@ -244,7 +244,9 @@ Section -Prerequisites
 
             # The Correct version of VCRedist is copied over by "build_pkg.bat"
             SetOutPath "$INSTDIR\"
-            File "..\prereqs\vcredist.exe"
+            # This will throw an error on Py3 since we're no longer including VCRedist
+            # So, we'll add the /nonfatal switch
+            File /nonfatal "..\prereqs\vcredist.exe"
             # If an output variable is specified ($0 in the case below),
             # ExecWait sets the variable with the exit code (and only sets the
             # error flag if an error occurs; if an error occurs, the contents


### PR DESCRIPTION
### What does this PR do?
Adds the `/nonfatal` switch to the file command for VCRedist

We used to include the VCredist for the Py3 build on Windows. It is not necessary since Py3 includes the required DLL. Additionally, the vcredist installation resulted in a corrupt installation of vcredist in random instances. So, we removed it.

The installer script was failing when it couldn't find the vcredist file (the line is still needed for the Py2 installation). So, we added the `/nonfatal` switch to the `file` command.

### What issues does this PR fix or reference?
Found during build

### Tests written?
NA

### Commits signed with GPG?
Yes