### PR TITLE
Add pathstate to keepalive check in mac_service

### DIFF
--- a/tests/unit/modules/test_mac_service.py
+++ b/tests/unit/modules/test_mac_service.py
@@ -67,3 +67,115 @@ class MacServiceTestCase(TestCase, LoaderModuleMockMixin):
 
         with patch.object(mac_service, 'launchctl', MagicMock(return_value=cmd)):
             self.assertTrue(mac_service.disabled(srv_name))
+
+    def test_service_keep_alive_pathstate_file_rm(self):
+        '''
+        test _always_running_service when keep_alive
+        has pathstate set in plist file and file doesn't exist
+        '''
+        srv_name = 'com.apple.atrun'
+        info = {'plist': {'EnableTransactions': True,
+                         'ProgramArguments': ['/usr/libexec/ntpd-wrapper'],
+                         'Label': 'org.ntp.ntpd',
+                         'KeepAlive': {'PathState': {'/private/etc/ntp.conf': True}}}}
+
+        with patch.object(mac_service, 'show', MagicMock(return_value=info)):
+            with patch('os.path.exists', MagicMock(return_value=False)):
+                assert mac_service._always_running_service(srv_name) is False
+
+    def test_service_keep_alive_empty(self):
+        '''
+        test _always_running_service when keep_alive
+        is empty
+        '''
+        srv_name = 'com.apple.atrun'
+        info = {'plist': {'EnableTransactions': True,
+                         'ProgramArguments': ['/usr/libexec/ntpd-wrapper'],
+                         'Label': 'org.ntp.ntpd',
+                         'KeepAlive': {}}}
+
+        with patch.object(mac_service, 'show', MagicMock(return_value=info)):
+            with patch('os.path.exists', MagicMock(return_value=False)):
+                assert mac_service._always_running_service(srv_name) is False
+
+    def test_service_keep_alive_pathstate_false(self):
+        '''
+        test _always_running_service when keep_alive
+        has pathstate set in plist file and file is false
+        '''
+        srv_name = 'com.apple.atrun'
+        info = {'plist': {'EnableTransactions': True,
+                         'ProgramArguments': ['/usr/libexec/ntpd-wrapper'],
+                         'Label': 'org.ntp.ntpd',
+                         'KeepAlive': {'PathState': {'/private/etc/ntp.conf': False}}}}
+
+        with patch.object(mac_service, 'show', MagicMock(return_value=info)):
+            with patch('os.path.exists', MagicMock(return_value=False)):
+                assert mac_service._always_running_service(srv_name) is True
+
+    def test_service_keep_alive_pathstate(self):
+        '''
+        test _always_running_service when keep_alive
+        has pathstate set in plist file
+        '''
+        srv_name = 'com.apple.atrun'
+        info = {'plist': {'EnableTransactions': True,
+                         'ProgramArguments': ['/usr/libexec/ntpd-wrapper'],
+                         'Label': 'org.ntp.ntpd',
+                         'KeepAlive': {'PathState': {'/private/etc/ntp.conf': True}}}}
+
+        with patch.object(mac_service, 'show', MagicMock(return_value=info)):
+            with patch('os.path.exists', MagicMock(return_value=True)):
+                assert mac_service._always_running_service(srv_name) is True
+
+    def test_service_keep_alive(self):
+        '''
+        test _always_running_service when keep_alive set
+        '''
+        srv_name = 'com.apple.atrun'
+        info = {'plist': {'EnableTransactions': True,
+                         'ProgramArguments': ['/usr/libexec/ntpd-wrapper'],
+                         'Label': 'org.ntp.ntpd',
+                         'KeepAlive': True}}
+
+        with patch.object(mac_service, 'show', MagicMock(return_value=info)):
+            assert mac_service._always_running_service(srv_name) is True
+
+    def test_service_keep_alive_false(self):
+        '''
+        test _always_running_service when keep_alive False
+        '''
+        srv_name = 'com.apple.atrun'
+        info = {'plist': {'EnableTransactions': True,
+                         'ProgramArguments': ['/usr/libexec/ntpd-wrapper'],
+                         'Label': 'org.ntp.ntpd',
+                         'KeepAlive': False}}
+
+        with patch.object(mac_service, 'show', MagicMock(return_value=info)):
+            assert mac_service._always_running_service(srv_name) is False
+
+    def test_service_keep_alive_missing(self):
+        '''
+        test _always_running_service when keep_alive not in dict
+        '''
+        srv_name = 'com.apple.atrun'
+        info = {'plist': {'EnableTransactions': True,
+                         'ProgramArguments': ['/usr/libexec/ntpd-wrapper'],
+                         'Label': 'org.ntp.ntpd'}}
+
+        with patch.object(mac_service, 'show', MagicMock(return_value=info)):
+            assert mac_service._always_running_service(srv_name) is False
+
+    def test_service_keep_alive_wrong_setting(self):
+        '''
+        test _always_running_service when keep_alive
+        has pathstate set in plist file
+        '''
+        srv_name = 'com.apple.atrun'
+        info = {'plist': {'EnableTransactions': True,
+                         'ProgramArguments': ['/usr/libexec/ntpd-wrapper'],
+                         'Label': 'org.ntp.ntpd',
+                         'KeepAlive': {'Doesnotexist': {'doesnt_exist': True}}}}
+
+        with patch.object(mac_service, 'show', MagicMock(return_value=info)):
+            assert mac_service._always_running_service(srv_name) is False


### PR DESCRIPTION
### What does this PR do?
The following tests:

```
integration.states.test_service.ServiceTest.test_service_dead
integration.states.test_service.ServiceTest.test_service_dead_init_delay
integration.states.test_service.ServiceTest.test_service_running
```

are failing on macosx after this PR: https://github.com/saltstack/salt/pull/46206

The service we use in our test suite sets keepalive with PathState setting. From the launchd docs there are also other ways to set keepalive besides just setting it to be True. This PR only handles PathState so more cases will need to be added. I moved the `_always_running_service` check after we check for pids to try to retain backwards compatibility. If the service actually returns a pid we return that and not loaded if the check for KeepAlive is not added to the code yet.

