### PR TITLE
Fix for #49100: Avoid yamldumper's dump/safe_dump from returning a non-unicode object under python2.7, as this breaks jinja/yaml rendering.

### DIFF
--- a/salt/utils/yamldumper.py
+++ b/salt/utils/yamldumper.py
@@ -18,6 +18,8 @@ except ImportError:
 import yaml  # pylint: disable=blacklisted-import
 import collections
 
+import salt.utils.stringutils
+import salt.ext.six as six
 from salt.utils.odict import OrderedDict
 
 try:
@@ -107,8 +109,11 @@ def dump(data, stream=None, **kwargs):
     '''
     if 'allow_unicode' not in kwargs:
         kwargs['allow_unicode'] = True
-    return yaml.dump(data, stream, **kwargs)
 
+    result = yaml.dump(data, stream, **kwargs)
+    if six.PY2 and isinstance(result, str):
+        result = salt.utils.stringutils.to_unicode(result)
+    return result
 
 def safe_dump(data, stream=None, **kwargs):
     '''
@@ -118,4 +123,7 @@ def safe_dump(data, stream=None, **kwargs):
     '''
     if 'allow_unicode' not in kwargs:
         kwargs['allow_unicode'] = True
-    return yaml.dump(data, stream, Dumper=SafeOrderedDumper, **kwargs)
+    result = yaml.dump(data, stream, Dumper=SafeOrderedDumper, **kwargs)
+    if six.PY2 and isinstance(result, str):
+        result = salt.utils.stringutils.to_unicode(result)
+    return result


### PR DESCRIPTION
### What does this PR do?

This change ensures yamldumper's dump/safe_dump methods, do not return non-unicode objects on python 2.7.

Hopefully this applies cleanly to salt 2018.3.3+.. as this is a reversion of salt 2018.3, previous versions (at least 2017.7.*) did not have this issue (when using the now deprecated yaml_utf8 setting)

### What issues does this PR fix or reference?

This is a proposed fix for issue #49100. 

### Tests written?

No

### Commits signed with GPG?

No
