### PR TITLE
Fix return of tls.cert_info extensions

### DIFF
--- a/salt/modules/tls.py
+++ b/salt/modules/tls.py
@@ -1636,7 +1636,8 @@ def cert_info(cert_path, digest='sha256'):
         for i in _range(cert.get_extension_count()):
             try:
                 ext = cert.get_extension(i)
-                ret['extensions'][ext.get_short_name()] = str(ext)
+                key = salt.utils.stringutils.to_unicode(ext.get_short_name())
+                ret['extensions'][key] = str(ext)
             except AttributeError:
                 continue
 


### PR DESCRIPTION
extension keys in tls.cert_info return are still in `b''` because OpenSSL's return is not fixxed.

### Previous Behavior
```
[root@testbak1 ~]# salt-call --local tls.cert_info /etc/vault/ca.pem                                                                                                                                               
local:                                                                                                                                                                                                             
    ----------                                                                                                                                                                                                     
    extensions:                                                                                                                                                                                                    
        ----------                                                                                                                                                                                                 
        b'basicConstraints':                                                                                                                                                                                       
            CA:TRUE                                                                                                                                                                                                
        b'keyUsage':                                                                                                                                                                                               
            Certificate Sign, CRL Sign                                                                                                                                                                             
```
### New Behavior
```
local:
    ----------
    extensions:
        ----------
        extendedKeyUsage:
            TLS Web Server Authentication, TLS Web Client Authentication
```
