### PR TITLE
remove brew from cask and info cmds

### DIFF
--- a/salt/modules/mac_brew.py
+++ b/salt/modules/mac_brew.py
@@ -123,7 +123,7 @@ def list_pkgs(versions_as_list=False, **kwargs):
             return ret
 
     ret = {}
-    cmd = 'brew info --json=v1 --installed'
+    cmd = 'info --json=v1 --installed'
     package_info = salt.utils.json.loads(_call_brew(cmd)['stdout'])
 
     for package in package_info:
@@ -143,7 +143,7 @@ def list_pkgs(versions_as_list=False, **kwargs):
     # Grab packages from brew cask, if available.
     # Brew Cask doesn't provide a JSON interface, must be parsed the old way.
     try:
-        cask_cmd = 'brew cask list --versions'
+        cask_cmd = 'cask list --versions'
         out = _call_brew(cask_cmd)['stdout']
 
         for line in out.splitlines():


### PR DESCRIPTION
### What does this PR do?
the tests:

```
integration.modules.test_pkg.PkgModuleTest.test_install_remove
integration.modules.test_pkg.PkgModuleTest.test_list
```

are failing on macosx because we are now removing `brew` from the cmds and finding the brew path before making the call. These commands were never fixed for fluorine.