### PR TITLE
Ensure that we don't feed jinja2.Markup() a str type

### DIFF
--- a/salt/utils/jinja.py
+++ b/salt/utils/jinja.py
@@ -817,14 +817,21 @@ class SerializerExtension(Extension, object):
         return explore(data)
 
     def format_json(self, value, sort_keys=True, indent=None):
-        return Markup(salt.utils.json.dumps(value, sort_keys=sort_keys, indent=indent).strip())
+        json_txt = salt.utils.json.dumps(value, sort_keys=sort_keys, indent=indent).strip()
+        try:
+            return Markup(json_txt)
+        except UnicodeDecodeError:
+            return Markup(salt.utils.stringutils.to_unicode(json_txt))
 
     def format_yaml(self, value, flow_style=True):
         yaml_txt = salt.utils.yaml.safe_dump(
             value, default_flow_style=flow_style).strip()
-        if yaml_txt.endswith('\n...'):
+        if yaml_txt.endswith(str('\n...')):  # future lint: disable=blacklisted-function
             yaml_txt = yaml_txt[:len(yaml_txt)-4]
-        return Markup(yaml_txt)
+        try:
+            return Markup(yaml_txt)
+        except UnicodeDecodeError:
+            return Markup(salt.utils.stringutils.to_unicode(yaml_txt))
 
     def format_xml(self, value):
         """Render a formatted multi-line XML string from a complex Python

--- a/tests/integration/files/file/base/jinja_filters/json.sls
+++ b/tests/integration/files/file/base/jinja_filters/json.sls
@@ -1,0 +1,6 @@
+{% set result = {"Question": "Quieres Café?"} %}
+
+test:
+  module.run:
+    - name: test.echo
+    - text: '{{ result | json }}'

--- a/tests/integration/files/file/base/jinja_filters/yaml.sls
+++ b/tests/integration/files/file/base/jinja_filters/yaml.sls
@@ -1,0 +1,6 @@
+{% set result = {"Question": "Quieres Café?"} %}
+
+test:
+  module.run:
+    - name: test.echo
+    - text: "{{ result | yaml }}"

--- a/tests/support/jinja_filters.py
+++ b/tests/support/jinja_filters.py
@@ -713,3 +713,23 @@ class JinjaFiltersTest(object):
         self.assertIn('module_|-test_|-test.echo_|-run', ret)
         self.assertEqual(ret['module_|-test_|-test.echo_|-run']['changes'],
                          _expected)
+
+    def test_yaml(self):
+        '''
+        test yaml filter
+        '''
+        _expected = {'ret': "{Question: 'Quieres Café?'}"}
+        ret = self.run_function('state.sls', ['jinja_filters.yaml'])
+        self.assertIn('module_|-test_|-test.echo_|-run', ret)
+        self.assertEqual(ret['module_|-test_|-test.echo_|-run']['changes'],
+                         _expected)
+
+    def test_json(self):
+        '''
+        test json filter
+        '''
+        _expected = {'ret': '{"Question": "Quieres Café?"}'}
+        ret = self.run_function('state.sls', ['jinja_filters.json'])
+        self.assertIn('module_|-test_|-test.echo_|-run', ret)
+        self.assertEqual(ret['module_|-test_|-test.echo_|-run']['changes'],
+                         _expected)


### PR DESCRIPTION
If the dumped contents contain non-ascii unicode, this will cause a UnicodeDecodeError.

Fixes #49100.