### PR TITLE
fix letsencrypt cert verification path on freebsd

### DIFF
--- a/salt/modules/acme.py
+++ b/salt/modules/acme.py
@@ -48,7 +48,8 @@ log = logging.getLogger(__name__)
 LEA = salt.utils.path.which_bin(['certbot', 'letsencrypt',
                                  'certbot-auto', 'letsencrypt-auto',
                                  '/opt/letsencrypt/letsencrypt-auto'])
-LE_LIVE = '/etc/letsencrypt/live/'
+if salt.utils.platform.is_freebsd():
+    LE_LIVE = '/usr/local' + LE_LIVE
 
 
 def __virtual__():

--- a/salt/modules/acme.py
+++ b/salt/modules/acme.py
@@ -48,6 +48,8 @@ log = logging.getLogger(__name__)
 LEA = salt.utils.path.which_bin(['certbot', 'letsencrypt',
                                  'certbot-auto', 'letsencrypt-auto',
                                  '/opt/letsencrypt/letsencrypt-auto'])
+LE_LIVE = '/etc/letsencrypt/live/'
+
 if salt.utils.platform.is_freebsd():
     LE_LIVE = '/usr/local' + LE_LIVE
 


### PR DESCRIPTION
### What does this PR do?
'/usr/local' is the path prefix on freebsd. this fixes:

```
     Comment: An exception occurred in this state: Traceback (most recent call last):
                File "/usr/local/lib/python2.7/site-packages/salt/state.py", line 1905, in call
                  **cdata['kwargs'])
                File "/usr/local/lib/python2.7/site-packages/salt/loader.py", line 1830, in wrapper
                  return f(*args, **kwargs)
                File "/usr/local/lib/python2.7/site-packages/salt/states/acme.py", line 108, in cert
                  group=group
                File "/usr/local/lib/python2.7/site-packages/salt/modules/acme.py", line 181, in cert
                  ret = {'comment': comment, 'not_after': expires(name)}
                File "/usr/local/lib/python2.7/site-packages/salt/modules/acme.py", line 253, in expires
                  return _expires(name).isoformat()
                File "/usr/local/lib/python2.7/site-packages/salt/modules/acme.py", line 67, in _expires
                  expiry = __salt__['tls.cert_info'](cert_file)['not_after']
                File "/usr/local/lib/python2.7/site-packages/salt/modules/tls.py", line 1595, in cert_info
                  with salt.utils.files.fopen(cert_path) as cert_file:
                File "/usr/local/lib/python2.7/site-packages/salt/utils/files.py", line 386, in fopen
                  f_handle = open(*args, **kwargs)  # pylint: disable=resource-leakage
              IOError: [Errno 2] No such file or directory: u'/etc/letsencrypt/live/somedomain/cert.pem'
```

### Tests written?
No

### Commits signed with GPG?

Yes

