### PR TITLE
allow for using multiple on* requisites on the same state

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -2391,7 +2391,7 @@ class State(object):
             status = 'onchanges'
         elif 'change' in fun_stats:
             status = 'change'
-        else:
+        if any(stat.endswith('met') for stat in fun_stats):
             status = 'met'
 
         return status, reqs

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -18,7 +18,7 @@ from tests.support.mock import (
     MagicMock,
     patch)
 from tests.support.mixins import AdaptedConfigurationTestCaseMixin
-from tests.support.paths import BASE_FILES, TMP
+from tests.support.paths import BASE_FILES
 
 # Import Salt libs
 import salt.exceptions
@@ -401,7 +401,7 @@ class CheckRequisitesTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
                 '__id__': u'changes_state',
             },
         }
-        chunks =[
+        chunks = [
             {
                 'name': 'changes_state',
                 'state': 'test',


### PR DESCRIPTION

### What does this PR do?
onchanges and onfail in this case

### What issues does this PR fix or reference?
Fixes #49120

### Previous Behavior
If onchanges and onfail were both set, if the onfail state did not fail but had changes, checking onchanges was skipped.

### New Behavior
If onfail and onchanges are both specified, and either of them are `met` it will run the state.

### Tests written?

Yes

### Commits signed with GPG?

Yes