### PR TITLE
Fix broken pkg integration test

### DIFF
--- a/tests/integration/states/test_pkg.py
+++ b/tests/integration/states/test_pkg.py
@@ -728,6 +728,7 @@ class PkgTest(ModuleCase, SaltReturnAssertsMixin):
             ret = self.run_state('pkg.removed', name=target)
             self.assertSaltTrueReturn(ret)
 
+    @requires_system_grains
     def test_pkg_014_installed_missing_release(self, grains=None):  # pylint: disable=unused-argument
         '''
         Tests that a version number missing the release portion still resolves

--- a/tests/integration/states/test_pkg.py
+++ b/tests/integration/states/test_pkg.py
@@ -168,7 +168,7 @@ class PkgTest(ModuleCase, SaltReturnAssertsMixin):
             __testcontext__['refresh'] = True
 
     @requires_system_grains
-    def test_pkg_001_installed(self, grains=None):
+    def test_pkg_001_installed(self, grains):
         '''
         This is a destructive test as it installs and then removes a package
         '''
@@ -198,7 +198,7 @@ class PkgTest(ModuleCase, SaltReturnAssertsMixin):
         self.assertSaltTrueReturn(ret)
 
     @requires_system_grains
-    def test_pkg_002_installed_with_version(self, grains=None):
+    def test_pkg_002_installed_with_version(self, grains):
         '''
         This is a destructive test as it installs and then removes a package
         '''
@@ -245,7 +245,7 @@ class PkgTest(ModuleCase, SaltReturnAssertsMixin):
         self.assertSaltTrueReturn(ret)
 
     @requires_system_grains
-    def test_pkg_003_installed_multipkg(self, grains=None):
+    def test_pkg_003_installed_multipkg(self, grains):
         '''
         This is a destructive test as it installs and then removes two packages
         '''
@@ -281,7 +281,7 @@ class PkgTest(ModuleCase, SaltReturnAssertsMixin):
             self.assertSaltTrueReturn(ret)
 
     @requires_system_grains
-    def test_pkg_004_installed_multipkg_with_version(self, grains=None):
+    def test_pkg_004_installed_multipkg_with_version(self, grains):
         '''
         This is a destructive test as it installs and then removes two packages
         '''
@@ -331,7 +331,7 @@ class PkgTest(ModuleCase, SaltReturnAssertsMixin):
             self.assertSaltTrueReturn(ret)
 
     @requires_system_grains
-    def test_pkg_005_installed_32bit(self, grains=None):
+    def test_pkg_005_installed_32bit(self, grains):
         '''
         This is a destructive test as it installs and then removes a package
         '''
@@ -367,7 +367,7 @@ class PkgTest(ModuleCase, SaltReturnAssertsMixin):
             self.assertSaltTrueReturn(ret)
 
     @requires_system_grains
-    def test_pkg_006_installed_32bit_with_version(self, grains=None):
+    def test_pkg_006_installed_32bit_with_version(self, grains):
         '''
         This is a destructive test as it installs and then removes a package
         '''
@@ -414,7 +414,7 @@ class PkgTest(ModuleCase, SaltReturnAssertsMixin):
         self.assertSaltTrueReturn(ret)
 
     @requires_system_grains
-    def test_pkg_007_with_dot_in_pkgname(self, grains=None):
+    def test_pkg_007_with_dot_in_pkgname(self, grains):
         '''
         This tests for the regression found in the following issue:
         https://github.com/saltstack/salt/issues/8614
@@ -444,7 +444,7 @@ class PkgTest(ModuleCase, SaltReturnAssertsMixin):
         self.assertSaltTrueReturn(ret)
 
     @requires_system_grains
-    def test_pkg_008_epoch_in_version(self, grains=None):
+    def test_pkg_008_epoch_in_version(self, grains):
         '''
         This tests for the regression found in the following issue:
         https://github.com/saltstack/salt/issues/8614
@@ -513,7 +513,7 @@ class PkgTest(ModuleCase, SaltReturnAssertsMixin):
         self.assertTrue(pkgquery in six.text_type(ret))
 
     @requires_system_grains
-    def test_pkg_011_latest(self, grains=None):
+    def test_pkg_011_latest(self, grains):
         '''
         This tests pkg.latest with a package that has no epoch (or a zero
         epoch).
@@ -544,7 +544,7 @@ class PkgTest(ModuleCase, SaltReturnAssertsMixin):
         self.assertSaltTrueReturn(ret)
 
     @requires_system_grains
-    def test_pkg_012_latest_only_upgrade(self, grains=None):
+    def test_pkg_012_latest_only_upgrade(self, grains):
         '''
         WARNING: This test will pick a package with an available upgrade (if
         there is one) and upgrade it to the latest version.
@@ -610,7 +610,7 @@ class PkgTest(ModuleCase, SaltReturnAssertsMixin):
             )
 
     @requires_system_grains
-    def test_pkg_013_installed_with_wildcard_version(self, grains=None):
+    def test_pkg_013_installed_with_wildcard_version(self, grains):
         '''
         This is a destructive test as it installs and then removes a package
         '''
@@ -679,7 +679,7 @@ class PkgTest(ModuleCase, SaltReturnAssertsMixin):
         self.assertSaltTrueReturn(ret)
 
     @requires_system_grains
-    def test_pkg_014_installed_with_comparison_operator(self, grains=None):
+    def test_pkg_014_installed_with_comparison_operator(self, grains):
         '''
         This is a destructive test as it installs and then removes a package
         '''
@@ -729,7 +729,7 @@ class PkgTest(ModuleCase, SaltReturnAssertsMixin):
             self.assertSaltTrueReturn(ret)
 
     @requires_system_grains
-    def test_pkg_014_installed_missing_release(self, grains=None):  # pylint: disable=unused-argument
+    def test_pkg_014_installed_missing_release(self, grains):
         '''
         Tests that a version number missing the release portion still resolves
         as correctly installed. For example, version 2.0.2 instead of 2.0.2-1.el7
@@ -767,8 +767,7 @@ class PkgTest(ModuleCase, SaltReturnAssertsMixin):
         self.assertSaltTrueReturn(ret)
 
     @requires_salt_modules('pkg.group_install')
-    @requires_system_grains
-    def test_group_installed_handle_missing_package_group(self, grains=None):  # pylint: disable=unused-argument
+    def test_group_installed_handle_missing_package_group(self):  # pylint: disable=unused-argument
         '''
         Tests that a CommandExecutionError is caught and the state returns False when
         the package group is missing. Before this fix, the state would stacktrace.
@@ -798,7 +797,7 @@ class PkgTest(ModuleCase, SaltReturnAssertsMixin):
 
     @skipIf(salt.utils.platform.is_windows(), 'minion is windows')
     @requires_system_grains
-    def test_pkg_cap_001_installed(self, grains=None):
+    def test_pkg_cap_001_installed(self, grains):
         '''
         This is a destructive test as it installs and then removes a package
         '''
@@ -830,7 +829,7 @@ class PkgTest(ModuleCase, SaltReturnAssertsMixin):
 
     @skipIf(salt.utils.platform.is_windows(), 'minion is windows')
     @requires_system_grains
-    def test_pkg_cap_002_already_installed(self, grains=None):
+    def test_pkg_cap_002_already_installed(self, grains):
         '''
         This is a destructive test as it installs and then removes a package
         '''
@@ -868,7 +867,7 @@ class PkgTest(ModuleCase, SaltReturnAssertsMixin):
 
     @skipIf(salt.utils.platform.is_windows(), 'minion is windows')
     @requires_system_grains
-    def test_pkg_cap_003_installed_multipkg_with_version(self, grains=None):
+    def test_pkg_cap_003_installed_multipkg_with_version(self, grains):
         '''
         This is a destructive test as it installs and then removes two packages
         '''
@@ -940,7 +939,7 @@ class PkgTest(ModuleCase, SaltReturnAssertsMixin):
 
     @skipIf(salt.utils.platform.is_windows(), 'minion is windows')
     @requires_system_grains
-    def test_pkg_cap_004_latest(self, grains=None):
+    def test_pkg_cap_004_latest(self, grains):
         '''
         This tests pkg.latest with a package that has no epoch (or a zero
         epoch).
@@ -978,7 +977,7 @@ class PkgTest(ModuleCase, SaltReturnAssertsMixin):
 
     @skipIf(salt.utils.platform.is_windows(), 'minion is windows')
     @requires_system_grains
-    def test_pkg_cap_005_downloaded(self, grains=None):
+    def test_pkg_cap_005_downloaded(self, grains):
         '''
         This is a destructive test as it installs and then removes a package
         '''
@@ -1012,7 +1011,7 @@ class PkgTest(ModuleCase, SaltReturnAssertsMixin):
 
     @skipIf(salt.utils.platform.is_windows(), 'minion is windows')
     @requires_system_grains
-    def test_pkg_cap_006_uptodate(self, grains=None):
+    def test_pkg_cap_006_uptodate(self, grains):
         '''
         This is a destructive test as it installs and then removes a package
         '''
@@ -1055,7 +1054,7 @@ class PkgTest(ModuleCase, SaltReturnAssertsMixin):
 
     @requires_salt_modules('pkg.hold', 'pkg.unhold')
     @requires_system_grains
-    def test_pkg_015_installed_held(self, grains=None):  # pylint: disable=unused-argument
+    def test_pkg_015_installed_held(self, grains):
         '''
         Tests that a package can be held even when the package is already installed.
         '''


### PR DESCRIPTION
This decorator looks to have been removed in a prior merge conflict resolution.

This also removes the default value for the `grains` argument, as it is unnecessary when using the `requires_system_grains` decorator, and is what kept us from discovering this problem with the test earlier.