### PR TITLE
Add documentation for filename map and test file naming convention

### DIFF
--- a/doc/topics/development/tests/index.rst
+++ b/doc/topics/development/tests/index.rst
@@ -32,6 +32,46 @@ or the integration testing factions contain respective integration or unit
 test files for Salt execution modules.
 
 
+.. note::
+    Salt's test framework provides for the option to only run tests which
+    correspond to a given file (or set of files), via the ``--from-filenames``
+    argument to ``runtests.py``:
+
+    .. code-block:: bash
+
+        python /path/to/runtests.py --from-filenames=salt/modules/foo.py
+
+    Therefore, where possible, test files should be named to match the source
+    files they are testing. For example, when writing tests for
+    ``salt/modules/foo.py``, unit tests should go into
+    ``tests/unit/modules/test_foo.py``, and integration tests should go into
+    ``tests/integration/modules/test_foo.py``.
+
+    However, integration tests are organized differently from unit tests, and
+    this may not always be plausible. In these cases, to ensure that the proper
+    tests are run for these files, they must be mapped in
+    `tests/filename_map.yml`__.
+
+    The filename map is used to supplement the test framework's filename
+    matching logic. This allows one to ensure that states correspnding to an
+    execution module are also tested when ``--from-filenames`` includes that
+    execution module. It can also be used for those cases where the path to a
+    test file doesn't correspond directly to the file which is being tested
+    (e.g. the ``shell``, ``spm``, and ``ssh`` integration tests, among others).
+    Both glob expressions and regular expressions are permitted in the filename
+    map.
+
+
+    .. important::
+        Test modules which don't map directly to the source file they are
+        testing (using the naming convention described above), **must** be
+        added to the ``ignore`` tuple in ``tests/unit/test_module_names.py``,
+        in the ``test_module_name_source_match`` function. This unit test
+        ensures that we maintain the naming convention for test files.
+
+    .. __: https://github.com/saltstack/salt/blob/develop/tests/filename_map.yml
+
+
 Integration Tests
 -----------------
 
@@ -445,8 +485,8 @@ successfully. If a network connection is not detected, the test will not run.
 order for the test to be executed. Otherwise, the test is skipped.
 
 `@requires_system_grains` -- Loads and passes the grains on the system as an
-keyword argument to the test function with the name `grains`. 
-    
+keyword argument to the test function with the name `grains`.
+
 `@skip_if_binaries_missing(['list', 'of', 'binaries'])` -- If called from inside a test,
 the test will be skipped if the binaries are not all present on the system.
 

--- a/tests/support/parser/__init__.py
+++ b/tests/support/parser/__init__.py
@@ -220,8 +220,9 @@ class SaltTestingParser(optparse.OptionParser):
             dest='filename_map',
             default=None,
             help=('Path to a YAML file mapping paths/path globs to a list '
-                  'of test names to run. See tests/files_map.yml '
-                  'for example usage.')
+                  'of test names to run. See tests/filename_map.yml '
+                  'for example usage (when --from-filenames is used, this '
+                  'map file will be the default one used).')
         )
         self.add_option_group(self.test_selection_group)
 
@@ -464,6 +465,14 @@ class SaltTestingParser(optparse.OptionParser):
 
         if self.options.from_filenames is not None:
             self.options.from_filenames = self._expand_paths(self.options.from_filenames)
+
+            # Locate the default map file if one was not passed
+            if self.options.filename_map is None:
+                self.options.filename_map = salt.utils.path.join(
+                    tests.support.paths.TESTS_DIR,
+                    'filename_map.yml'
+                )
+
             mapped_mods = self._map_files(self.options.from_filenames)
             if mapped_mods:
                 if self.options.name is None:


### PR DESCRIPTION
This also sets a default path for the filename map, so that it is not necessary to specify it separately when using ``--from-filenames``.

This is a companion to PR https://github.com/saltstack/salt/pull/47337