### PR TITLE
Remove -Z script_arg for cloud tests

### DIFF
--- a/tests/integration/files/conf/cloud.profiles.d/azure.conf
+++ b/tests/integration/files/conf/cloud.profiles.d/azure.conf
@@ -7,4 +7,4 @@ azure-test:
   ssh_username: ''
   ssh_password: ''
   media_link: ''
-  script_args: '-P -Z'
+  script_args: '-P'

--- a/tests/integration/files/conf/cloud.profiles.d/digitalocean.conf
+++ b/tests/integration/files/conf/cloud.profiles.d/digitalocean.conf
@@ -2,4 +2,4 @@ digitalocean-test:
   provider: digitalocean-config
   image: 14.04.5 x64
   size: 2GB
-  script_args: '-P -Z'
+  script_args: '-P'

--- a/tests/integration/files/conf/cloud.profiles.d/ec2.conf
+++ b/tests/integration/files/conf/cloud.profiles.d/ec2.conf
@@ -3,7 +3,7 @@ ec2-test:
   image: ami-98aa1cf0
   size: m1.large
   sh_username: ec2-user
-  script_args: '-P -Z'
+  script_args: '-P'
 ec2-win2012r2-test:
   provider: ec2-config
   size: m1.large

--- a/tests/integration/files/conf/cloud.profiles.d/gogrid.conf
+++ b/tests/integration/files/conf/cloud.profiles.d/gogrid.conf
@@ -2,4 +2,4 @@ gogrid-test:
   provider: gogrid-config
   size: 512MB
   image: Ubuntu 14.04 LTS Server (64-bit) w/ None
-  script_args: '-P -Z'
+  script_args: '-P'

--- a/tests/integration/files/conf/cloud.profiles.d/joyent.conf
+++ b/tests/integration/files/conf/cloud.profiles.d/joyent.conf
@@ -3,4 +3,4 @@ joyent-test:
   size: k4-highcpu-kvm-250M
   image: ubuntu-16.04
   location: us-east-1
-  script_args: '-P -Z'
+  script_args: '-P'

--- a/tests/integration/files/conf/cloud.profiles.d/linode.conf
+++ b/tests/integration/files/conf/cloud.profiles.d/linode.conf
@@ -2,4 +2,4 @@ linode-test:
   provider: linode-config
   size: Linode 2GB
   image: Ubuntu 14.04 LTS
-  script_args: '-P -Z'
+  script_args: '-P'

--- a/tests/integration/files/conf/cloud.profiles.d/rackspace.conf
+++ b/tests/integration/files/conf/cloud.profiles.d/rackspace.conf
@@ -2,4 +2,4 @@ rackspace-test:
   provider: openstack-config
   size: 2 GB Performance
   image: Ubuntu 14.04 LTS (Trusty Tahr) (PVHVM)
-  script_args: '-P -Z'
+  script_args: '-P'


### PR DESCRIPTION
### What does this PR do?
The `-Z` argument was removed in the bootstrap script in this PR: https://github.com/saltstack/salt-bootstrap/pull/1239

and this commit: https://github.com/saltstack/salt-bootstrap/pull/1239

This should fix the following issues:

https://github.com/saltstack/salt-jenkins/issues/1067
https://github.com/saltstack/salt-jenkins/issues/1066
https://github.com/saltstack/salt-jenkins/issues/1065
https://github.com/saltstack/salt-jenkins/issues/1064