### PR TITLE
Add timeout parameter to win_service functions

### DIFF
--- a/salt/modules/win_service.py
+++ b/salt/modules/win_service.py
@@ -128,13 +128,14 @@ def _status_wait(service_name, end_time, service_states):
         # than 10 seconds.
         # https://docs.microsoft.com/en-us/windows/desktop/services/starting-a-service
         # https://docs.microsoft.com/en-us/windows/desktop/services/stopping-a-service
-        wait_time = info_results['Status_WaitHint'] / 1000
-        if wait_time < 1000:
+        # Wait hint is in ms
+        wait_time = info_results['Status_WaitHint']
+        # Convert to seconds or 0
+        wait_time = wait_time / 1000 if wait_time else 0
+        if wait_time < 1:
             wait_time = 1
-        elif wait_time > 10000:
+        elif wait_time > 10:
             wait_time = 10
-        else:
-            wait_time = wait_time / 1000  # convert ms to seconds
 
         time.sleep(wait_time)
         info_results = info(service_name)

--- a/salt/modules/win_service.py
+++ b/salt/modules/win_service.py
@@ -438,15 +438,6 @@ def stop(name, timeout=90):
 
         salt '*' service.stop <service name>
     '''
-    # net stop issues a stop command and waits briefly (~30s), but will give
-    # up if the service takes too long to stop with a misleading
-    # "service could not be stopped" message and RC 0.
-
-    cmd = ['net', 'stop', '/y', name]
-    res = __salt__['cmd.run'](cmd, python_shell=False)
-    if 'service was stopped' in res:
-        return True
-
     try:
         win32serviceutil.StopService(name)
     except pywintypes.error as exc:
@@ -543,7 +534,7 @@ def execute_salt_restart_task():
     return __salt__['task.run'](name='restart-salt-minion')
 
 
-def status(name, **kwargs):
+def status(name, *args, **kwargs):
     '''
     Return the status for a service
 

--- a/salt/modules/win_service.py
+++ b/salt/modules/win_service.py
@@ -495,10 +495,6 @@ def stop(name, timeout=90):
                               end_time=time.time() + int(timeout),
                               service_states=['Running', 'Stop Pending'])
 
-    log.debug('TEST ' * 20)
-    log.debug(srv_status)
-    log.debug('TEST ' * 20)
-
     return srv_status['Status'] == 'Stopped'
 
 

--- a/salt/modules/win_service.py
+++ b/salt/modules/win_service.py
@@ -108,10 +108,10 @@ def _status_wait(service_name, end_time, service_states):
     Args:
         service_name (str):
             The name of the service
-        
+
         end_time (float):
             A future time. e.g. time.time() + 10
-        
+
         service_states (list):
             Services statuses to wait for as returned by info()
 

--- a/salt/states/service.py
+++ b/salt/states/service.py
@@ -434,15 +434,14 @@ def running(name,
         ret['comment'] = 'Service {0} is set to start'.format(name)
         return ret
 
-    if salt.utils.is_windows():
-        if enable is True:
-            ret.update(_enable(name, False, result=False, **kwargs))
-
     # Conditionally add systemd-specific args to call to service.start
     start_kwargs, warnings = \
         _get_systemd_only(__salt__['service.start'], locals())
     if warnings:
         ret.setdefault('warnings', []).extend(warnings)
+
+    if salt.utils.is_windows() and kwargs.get('timeout', False):
+        start_kwargs.update({'timeout': kwargs.get('timeout')})
 
     try:
         func_ret = __salt__['service.start'](name, **start_kwargs)
@@ -582,6 +581,9 @@ def dead(name,
     stop_kwargs, warnings = _get_systemd_only(__salt__['service.stop'], kwargs)
     if warnings:
         ret.setdefault('warnings', []).extend(warnings)
+
+    if salt.utils.is_windows() and kwargs.get('timeout', False):
+        stop_kwargs.update({'timeout': kwargs.get('timeout')})
 
     func_ret = __salt__['service.stop'](name, **stop_kwargs)
     if not func_ret:


### PR DESCRIPTION
### What does this PR do?
Adds a timeout parameter to the following functions in win_service:

- start
- stop
- restart
- delete

Fix some documentation formatting issues

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/48163

### Tests written?
No

### Commits signed with GPG?
Yes