### PR TITLE
Add FreeBSD support to pf executor

### DIFF
--- a/salt/modules/pf.py
+++ b/salt/modules/pf.py
@@ -22,13 +22,16 @@ log = logging.getLogger(__name__)
 
 def __virtual__():
     '''
-    Only works on OpenBSD for now; other systems with pf (macOS, FreeBSD, etc)
-    need to be tested before enabling them.
+    Only works on OpenBSD and FreeBSD for now; other systems with pf (macOS,
+    FreeBSD, etc) need to be tested before enabling them.
     '''
-    if __grains__['os'] == 'OpenBSD' and salt.utils.path.which('pfctl'):
+    tested_oses = ['FreeBSD', 'OpenBSD']
+    if __grains__['os'] in tested_oses and salt.utils.path.which('pfctl'):
         return True
 
-    return (False, 'The pf execution module cannot be loaded: either the system is not OpenBSD or the pfctl binary was not found')
+    return (False, 'The pf execution module cannot be loaded: either the '
+            'OS (' + __grains__['os'] + ') is not tested or the pfctl binary '
+            'was not found')
 
 
 def enable():
@@ -99,7 +102,7 @@ def loglevel(level):
 
     level:
         Log level. Should be one of the following: emerg, alert, crit, err, warning, notice,
-        info or debug.
+        info or debug (OpenBSD); or none, urgent, misc, loud (FreeBSD).
 
     CLI example:
 
@@ -111,7 +114,11 @@ def loglevel(level):
     # always made a change.
     ret = {'changes': True}
 
-    all_levels = ['emerg', 'alert', 'crit', 'err', 'warning', 'notice', 'info', 'debug']
+    myos = __grains__['os']
+    if myos == 'FreeBSD':
+        all_levels = ['none', 'urgent', 'misc', 'loud']
+    else:
+        all_levels = ['emerg', 'alert', 'crit', 'err', 'warning', 'notice', 'info', 'debug']
     if level not in all_levels:
         raise SaltInvocationError('Unknown loglevel: {0}'.format(level))
 

--- a/tests/unit/modules/test_pf.py
+++ b/tests/unit/modules/test_pf.py
@@ -66,14 +66,29 @@ class PfTestCase(TestCase, LoaderModuleMockMixin):
         with patch.dict(pf.__salt__, {'cmd.run_all': mock_cmd}):
             self.assertFalse(pf.disable()['changes'])
 
-    def test_loglevel(self):
+    def test_loglevel_freebsd(self):
         '''
         Tests setting a loglevel.
         '''
         ret = {}
         ret['retcode'] = 0
         mock_cmd = MagicMock(return_value=ret)
-        with patch.dict(pf.__salt__, {'cmd.run_all': mock_cmd}):
+        with patch.dict(pf.__salt__, {'cmd.run_all': mock_cmd}), \
+                patch.dict(pf.__grains__, {'os': 'FreeBSD'}):
+            res = pf.loglevel('urgent')
+            mock_cmd.assert_called_once_with('pfctl -x urgent',
+                    output_loglevel='trace', python_shell=False)
+            self.assertTrue(res['changes'])
+
+    def test_loglevel_openbsd(self):
+        '''
+        Tests setting a loglevel.
+        '''
+        ret = {}
+        ret['retcode'] = 0
+        mock_cmd = MagicMock(return_value=ret)
+        with patch.dict(pf.__salt__, {'cmd.run_all': mock_cmd}), \
+                patch.dict(pf.__grains__, {'os': 'OpenBSD'}):
             res = pf.loglevel('crit')
             mock_cmd.assert_called_once_with('pfctl -x crit',
                     output_loglevel='trace', python_shell=False)

--- a/tests/unit/modules/test_pf.py
+++ b/tests/unit/modules/test_pf.py
@@ -66,12 +66,13 @@ class PfTestCase(TestCase, LoaderModuleMockMixin):
         with patch.dict(pf.__salt__, {'cmd.run_all': mock_cmd}):
             self.assertFalse(pf.disable()['changes'])
 
-    def test_loglevel_freebsd(self):
+    def test_loglevel(self):
         '''
         Tests setting a loglevel.
         '''
         ret = {}
         ret['retcode'] = 0
+        # FreeBSD and OpenBSD have different log levels available.
         mock_cmd = MagicMock(return_value=ret)
         with patch.dict(pf.__salt__, {'cmd.run_all': mock_cmd}), \
                 patch.dict(pf.__grains__, {'os': 'FreeBSD'}):
@@ -79,13 +80,6 @@ class PfTestCase(TestCase, LoaderModuleMockMixin):
             mock_cmd.assert_called_once_with('pfctl -x urgent',
                     output_loglevel='trace', python_shell=False)
             self.assertTrue(res['changes'])
-
-    def test_loglevel_openbsd(self):
-        '''
-        Tests setting a loglevel.
-        '''
-        ret = {}
-        ret['retcode'] = 0
         mock_cmd = MagicMock(return_value=ret)
         with patch.dict(pf.__salt__, {'cmd.run_all': mock_cmd}), \
                 patch.dict(pf.__grains__, {'os': 'OpenBSD'}):


### PR DESCRIPTION
### What does this PR do?
Enables FreeBSD support for the pf module; adds FreeBSD to OS whitelist and makes list of available loglevels OS-dependent.
### What issues does this PR fix or reference?
This PR fixes #33248.
### Previous Behavior
Does not execute under FreeBSD.
### New Behavior
Will now execute on FreeBSD or OpenBSD.
### Tests written?
Yes
### Commits signed with GPG?
Yes