### PR TITLE
Update core.py to fix num_cpus in _linux_cpudata

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -132,6 +132,7 @@ def _linux_cpudata():
     # Parse over the cpuinfo file
     if os.path.isfile(cpuinfo):
         with salt.utils.files.fopen(cpuinfo, 'r') as _fp:
+            grains['num_cpus'] = 0
             for line in _fp:
                 comps = line.split(':')
                 if not len(comps) > 1:
@@ -139,7 +140,7 @@ def _linux_cpudata():
                 key = comps[0].strip()
                 val = comps[1].strip()
                 if key == 'processor':
-                    grains['num_cpus'] = int(val) + 1
+                    grains['num_cpus'] += 1
                 elif key == 'model name':
                     grains['cpu_model'] = val
                 elif key == 'flags':


### PR DESCRIPTION
### What does this PR do?
Fixed grain num_cpus get wrong CPUs count in case of  inconsistent CPU numbering.

### What issues does this PR fix or reference?
In case of  inconsistent CPU numbering, such in one of my system (Linux kernel 4.9.2, 2 * Intel Xeon E5620, 16 cores total):
```
$ cat /proc/cpuinfo |grep processor
processor	: 0
processor	: 1
processor	: 4
processor	: 5
processor	: 6
processor	: 7
processor	: 10
processor	: 11
processor	: 12
processor	: 13
processor	: 16
processor	: 17
processor	: 18
processor	: 19
processor	: 22
processor	: 23
```

### Previous Behavior
The original num_cpus scheme is get the last cpu number from /proc/cpuinfo. In some system with inconsistent CPU numbering (such as some cores are disabled, or by ), this value is not the acutal number of CPUs.

In the above system, core.py get num_cpus=24(wrong).

### New Behavior
Changed algorithm to calculate number of 'processor' line. Modified code get num_cpus=16 (correct).

### Tests written?

No

### Commits signed with GPG?

No
