### PR TITLE
clarifies behaviour `creates` parameter is a list of files

### DIFF
--- a/salt/states/cmd.py
+++ b/salt/states/cmd.py
@@ -33,7 +33,8 @@ touch /tmp/foo if it does not exist:
       cmd.run:
         - creates: /tmp/foo
 
-``creates`` also accepts a list of files:
+``creates`` also accepts a list of files, in which case this state will
+run if **any** of the files does not exist:
 
 .. code-block:: yaml
 
@@ -490,7 +491,9 @@ def wait(name,
         a state. For more information, see the :ref:`stateful-argument` section.
 
     creates
-        Only run if the file or files specified by ``creates`` do not exist.
+        Only run if the file specified by ``creates`` do not exist. If you
+        specify a list of files then this state will only run if **any** of
+        the files does not exist.
 
         .. versionadded:: 2014.7.0
 
@@ -801,7 +804,9 @@ def run(name,
         .. versionadded:: 2015.8.0
 
     creates
-        Only run if the file or files specified by ``creates`` do not exist.
+        Only run if the file specified by ``creates`` do not exist. If you
+        specify a list of files then this state will only run if **any** of
+        the files does not exist.
 
         .. versionadded:: 2014.7.0
 
@@ -1053,7 +1058,9 @@ def script(name,
         'arg two' arg3"
 
     creates
-        Only run if the file or files specified by ``creates`` do not exist.
+        Only run if the file specified by ``creates`` do not exist. If you
+        specify a list of files then this state will only run if **any** of
+        the files does not exist.
 
         .. versionadded:: 2014.7.0
 


### PR DESCRIPTION
### What does this PR do?

Updates documentation of the `creates` parameter in the `cmd` states.

### What issues does this PR fix or reference?

None, it's an opportunistic fix.

### Tests written?

No

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
