### PR TITLE
unserialized kwargs['region'] causes traceback

### DIFF
--- a/salt/cloud/clouds/gce.py
+++ b/salt/cloud/clouds/gce.py
@@ -1250,6 +1250,8 @@ def create_address(kwargs=None, call=None):
     name = kwargs['name']
     ex_region = kwargs['region']
     ex_address = kwargs.get("address", None)
+    tmp = {}
+    kwargs['region'] = tmp.update(kwargs['region'].__dict__)
 
     conn = get_conn()
 


### PR DESCRIPTION


### What does this PR do?

serializing kwargs['region'] which by default is: `<GCERegion id="1100" name="europe-west1", status="UP">` and causes a traceback in 2018.3.2 when kwargs is passed to cloud.fire_event.
There might be a better way or place to do this.

```TRACE: can't serialize <GCERegion id="1100" name="europe-west1", status="UP">
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/site-packages/salt/cloud/__init__.py", line 67, in _call
    ret = func(*args, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/salt/cloud/__init__.py", line 2317, in create_multiprocessing
    local_master=parallel_data['local_master']
  File "/usr/local/lib/python2.7/site-packages/salt/cloud/__init__.py", line 1284, in create
    output = self.clouds[func](vm_)
  File "/usr/local/lib/python2.7/site-packages/salt/cloud/clouds/gce.py", line 2585, in create
    node_info = request_instance(vm_)
  File "/usr/local/lib/python2.7/site-packages/salt/cloud/clouds/gce.py", line 2491, in request_instance
    external_ip = __create_orget_address(conn, external_ip, region)
  File "/usr/local/lib/python2.7/site-packages/salt/cloud/clouds/gce.py", line 528, in __create_orget_address
    new_addy = create_address(addr_kwargs, "function")
  File "/usr/local/lib/python2.7/site-packages/salt/cloud/clouds/gce.py", line 1274, in create_address
    transport=__opts__['transport']
  File "/usr/local/lib/python2.7/site-packages/salt/utils/cloud.py", line 1786, in fire_event
    event.fire_event(args, tag)
  File "/usr/local/lib/python2.7/site-packages/salt/utils/event.py", line 725, in fire_event
    dump_data = self.serial.dumps(data)
  File "/usr/local/lib/python2.7/site-packages/salt/payload.py", line 217, in dumps
    return msgpack.dumps(msg, default=ext_type_encoder, use_bin_type=use_bin_type)
  File "/usr/local/lib/python2.7/site-packages/msgpack/__init__.py", line 47, in packb
    return Packer(**kwargs).pack(o)
  File "msgpack/_packer.pyx", line 284, in msgpack._packer.Packer.pack
  File "msgpack/_packer.pyx", line 290, in msgpack._packer.Packer.pack
  File "msgpack/_packer.pyx", line 287, in msgpack._packer.Packer.pack
  File "msgpack/_packer.pyx", line 234, in msgpack._packer.Packer._pack
  File "msgpack/_packer.pyx", line 281, in msgpack._packer.Packer._pack
TypeError: can't serialize <GCERegion id="1100" name="europe-west1", status="UP">```

### Tests written?

No

### Commits signed with GPG?

Yes