### PR TITLE
Fix bug in keep_source for non-templated salt:// file sources

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -2596,8 +2596,15 @@ def managed(name,
             ret['changes'] = {}
             log.debug(traceback.format_exc())
             salt.utils.files.remove(tmp_filename)
-            if not keep_source and sfn:
-                salt.utils.files.remove(sfn)
+            if not keep_source:
+                if not sfn \
+                        and source \
+                        and _urlparse(source).scheme == 'salt':
+                    # The file would not have been cached until manage_file was
+                    # run, so check again here for a cached copy.
+                    sfn = __salt__['cp.is_cached'](source, __env__)
+                if sfn:
+                    salt.utils.files.remove(sfn)
             return _error(ret, 'Unable to check_cmd file: {0}'.format(exc))
 
         # file being updated to verify using check_cmd
@@ -2667,8 +2674,15 @@ def managed(name,
         finally:
             if tmp_filename:
                 salt.utils.files.remove(tmp_filename)
-            if not keep_source and sfn:
-                salt.utils.files.remove(sfn)
+            if not keep_source:
+                if not sfn \
+                        and source \
+                        and _urlparse(source).scheme == 'salt':
+                    # The file would not have been cached until manage_file was
+                    # run, so check again here for a cached copy.
+                    sfn = __salt__['cp.is_cached'](source, __env__)
+                if sfn:
+                    salt.utils.files.remove(sfn)
 
 
 _RECURSE_TYPES = ['user', 'group', 'mode', 'ignore_files', 'ignore_dirs']


### PR DESCRIPTION
Unless the file is one of A) a remote file source (http/https/ftp/etc.) or B) being templated, then `file.get_managed` does not cache the file. Thus, the variable we rely on to tell us the cached path is an empty string, and we don't remove it even though the file would eventually later be cached when we run `file.manage_file`. This adds some additional logic to ensure that we do check if the file has been cached if `sfn` is an empty string.


Fixes #49154.