### PR TITLE
Account for normalized dirs in unit tests

### DIFF
--- a/tests/unit/states/test_file.py
+++ b/tests/unit/states/test_file.py
@@ -867,12 +867,12 @@ class TestFileState(TestCase, LoaderModuleMockMixin):
                         else:
                             comt = ('The following files will be changed:\n{0}:'
                                     ' directory - new\n'.format(name))
-                        p_chg = {'/etc/testdir': {'directory': 'new'}}
+                        p_chg = {name: {'directory': 'new'}}
                         ret.update({
                             'comment': comt,
                             'result': None,
                             'pchanges': p_chg,
-                            'changes': {'/etc/testdir': {'directory': 'new'}}
+                            'changes': {name: {'directory': 'new'}}
                         })
                         self.assertDictEqual(filestate.directory(name,
                                                                  user=user,

--- a/tests/unit/states/test_file.py
+++ b/tests/unit/states/test_file.py
@@ -769,6 +769,8 @@ class TestFileState(TestCase, LoaderModuleMockMixin):
         name = '/etc/testdir'
         user = 'salt'
         group = 'saltstack'
+        if salt.utils.is_windows():
+            name = name.replace('/', '\\')
 
         ret = {'name': name,
                'result': False,
@@ -917,6 +919,8 @@ class TestFileState(TestCase, LoaderModuleMockMixin):
         source = 'salt://code/flask'
         user = 'salt'
         group = 'saltstack'
+        if salt.utils.is_windows():
+            name = name.replace('/', '\\')
 
         ret = {'name': name,
                'result': False,


### PR DESCRIPTION
### What does this PR do?

Account for normalized directory names in unit tests, fixes:

```
unit.states.test_file.TestFileState.test_directory
unit.states.test_file.TestFileState.test_recurse
```

### Tests written?

No - Fixing tests

### Commits signed with GPG?

Yes