### PR TITLE
Fix hanging syndic test

### DIFF
--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -742,6 +742,7 @@ class TestDaemon(object):
         master_opts['config_dir'] = RUNTIME_VARS.TMP_CONF_DIR
         master_opts['root_dir'] = os.path.join(TMP, 'rootdir')
         master_opts['pki_dir'] = os.path.join(TMP, 'rootdir', 'pki', 'master')
+        master_opts['syndic_master'] = 'localhost'
 
         # This is the syndic for master
         # Let's start with a copy of the syndic master configuration


### PR DESCRIPTION
There was no `syndic_master` and the fallback DNS lookup failed. This caused a traceback which hung the test suite.

Refs: https://github.com/saltstack/salt-jenkins/issues/1078

This may not be the best solution, the best solution may be to add the config option in the test itself rather than in `tests/integration/__init__.py`. We'll have to see how it affects the rest of the test suite, if it affects it at all.