### PR TITLE
[develop] fix vault tests

### DIFF
--- a/tests/integration/sdb/test_vault.py
+++ b/tests/integration/sdb/test_vault.py
@@ -41,12 +41,12 @@ class VaultTestCase(ModuleCase, ShellCase):
         )
         self.run_function(
             'cmd.run',
-            cmd='vault login token=testsecret',
+            cmd='/usr/local/bin/vault login token=testsecret',
             env={'VAULT_ADDR': 'http://127.0.0.1:8200'},
         )
         self.run_function(
             'cmd.run',
-            cmd='vault policy write testpolicy {0}/vault.hcl'.format(FILES),
+            cmd='/usr/local/bin/vault policy write testpolicy {0}/vault.hcl'.format(FILES),
             env={'VAULT_ADDR': 'http://127.0.0.1:8200'},
         )
 


### PR DESCRIPTION
### What does this PR do?
This should fix the failing tests in develop, it needs to be backported to fluorine before 1c02e7840cab78dd7f0840e7e0e66add2be60f47 is merged into fluorine.

Apparently the vault dev server just lets to do stuff after you try 5 times? i am still not sure why it was ever succeeding, but it was never finding the vault binary to setup the correct hcl rules, but now that it does, it succeeds.

### Tests written?

Yes

### Commits signed with GPG?

Yes