### PR TITLE
Remove obsolete documentation on external_nodes setting

### DIFF
--- a/conf/master
+++ b/conf/master
@@ -529,12 +529,6 @@
 #
 #master_tops: {}
 
-# The external_nodes option allows Salt to gather data that would normally be
-# placed in a top file. The external_nodes option is the executable that will
-# return the ENC data. Remember that Salt will look for external nodes AND top
-# files and combine the results if both are enabled!
-#external_nodes: None
-
 # The renderer to use on the minions to render the state data
 #renderer: yaml_jinja
 

--- a/conf/suse/master
+++ b/conf/suse/master
@@ -528,12 +528,6 @@ syndic_user: salt
 #
 #master_tops: {}
 
-# The external_nodes option allows Salt to gather data that would normally be
-# placed in a top file. The external_nodes option is the executable that will
-# return the ENC data. Remember that Salt will look for external nodes AND top
-# files and combine the results if both are enabled!
-#external_nodes: None
-
 # The renderer to use on the minions to render the state data
 #renderer: yaml_jinja
 

--- a/doc/ref/configuration/master.rst
+++ b/doc/ref/configuration/master.rst
@@ -1918,23 +1918,6 @@ following configuration:
     master_tops:
       ext_nodes: <Shell command which returns yaml>
 
-.. conf_master:: external_nodes
-
-``external_nodes``
-------------------
-
-Default: None
-
-The external_nodes option allows Salt to gather data that would normally be
-placed in a top file from and external node controller. The external_nodes
-option is the executable that will return the ENC data. Remember that Salt
-will look for external nodes AND top files and combine the results if both
-are enabled and available!
-
-.. code-block:: yaml
-
-    external_nodes: cobbler-ext-nodes
-
 .. conf_master:: renderer
 
 ``renderer``


### PR DESCRIPTION
### What does this PR do?

Removes documentation on obsolete `external_nodes` setting which is no longer used anywhere in the codebase. The replacement setting is `master_tops` which was introduced many releases ago.

### What issues does this PR fix or reference?

None

### Tests written?

N/A

### Commits signed with GPG?

Yes
