### PR TITLE
Update documentation to correctly state enable_gpu_grains default

### DIFF
--- a/conf/master
+++ b/conf/master
@@ -125,7 +125,7 @@
 # The master can take a while to start up when lspci and/or dmidecode is used
 # to populate the grains for the master. Enable if you want to see GPU hardware
 # data for your master.
-# enable_gpu_grains: False
+# enable_gpu_grains: True
 
 # The master maintains a job cache. While this is a great addition, it can be
 # a burden on the master for larger deployments (over 5000 minions).

--- a/conf/suse/master
+++ b/conf/suse/master
@@ -127,7 +127,7 @@ syndic_user: salt
 # The master can take a while to start up when lspci and/or dmidecode is used
 # to populate the grains for the master. Enable if you want to see GPU hardware
 # data for your master.
-# enable_gpu_grains: False
+# enable_gpu_grains: True
 
 # The master maintains a job cache. While this is a great addition, it can be
 # a burden on the master for larger deployments (over 5000 minions).

--- a/doc/ref/configuration/master.rst
+++ b/doc/ref/configuration/master.rst
@@ -440,7 +440,7 @@ communication.
 ``enable_gpu_grains``
 ---------------------
 
-Default: ``True``
+Default: ``False``
 
 Enable GPU hardware data for your master. Be aware that the master can
 take a while to start up when lspci and/or dmidecode is used to populate the


### PR DESCRIPTION
### What does this PR do?

While the relevant code in `grains/core.py` does enable GPU grains by default, the default in `config/__init__.py` for the **DEFAULT_MASTER_OPTS** dictionary is disabled. This takes precedence over the default in `grains/core.py` which would only take effect if the `enable_gpu_grains` setting was not specified at all.

This commit updates the documentation rather than change the defaults of Salt itself. Note that this commit effectively reverts https://github.com/saltstack/salt/issues/24163 which doesn't appear to have factored in the default set in **DEFAULT_MASTER_OPTS**.

### What issues does this PR fix or reference?

None

### Tests written?

N/A

### Commits signed with GPG?

Yes