### PR TITLE
Fix for #45620: "Salt CLI is rounding floats to 2 decimal places"

### DIFF
--- a/salt/output/nested.py
+++ b/salt/output/nested.py
@@ -81,12 +81,14 @@ class NestDisplay(object):
             )
         # Number includes all python numbers types
         #  (float, int, long, complex, ...)
+        # use repr() to get the full precision also for older python versions 
+        # as until about python32 it was limited to 12 digits only by default
         elif isinstance(ret, Number):
             out.append(
                 self.ustring(
                     indent,
                     self.LIGHT_YELLOW,
-                    ret,
+                    repr(ret),
                     prefix=prefix
                 )
             )

--- a/salt/output/nested.py
+++ b/salt/output/nested.py
@@ -81,7 +81,7 @@ class NestDisplay(object):
             )
         # Number includes all python numbers types
         #  (float, int, long, complex, ...)
-        # use repr() to get the full precision also for older python versions 
+        # use repr() to get the full precision also for older python versions
         # as until about python32 it was limited to 12 digits only by default
         elif isinstance(ret, Number):
             out.append(


### PR DESCRIPTION
### What does this PR do?
This PR fixes a number representation issue under older Python versions.

### What issues does this PR fix or reference?
#45620 

### Previous Behavior
Numbers were represented with a maximum of 12 digits of precision.

### New Behavior
Numbers are represented with the maximum precision.
For the DOUBLE format that is used, that is about 16 digits.

In python issue https://bugs.python.org/issue9337 it was decided that the artificial limitation to 12 digits should be removed. Therefore starting with Python3.2 it behaves differently (better).

### Tests written?
No
Test with `salt-call test.echo 1234567890.123456`
When using python27 the result previously was `1234567890.12`
When using python34 the result previously was `1234567890.123456`
Now the result is `1234567890.123456` in all cases.