### PR TITLE
decode_reponses=True on all Redis API interfaces

### DIFF
--- a/salt/cache/redis_cache.py
+++ b/salt/cache/redis_cache.py
@@ -238,7 +238,8 @@ def _get_redis_server(opts=None):
                                    opts['port'],
                                    unix_socket_path=opts['unix_socket_path'],
                                    db=opts['db'],
-                                   password=opts['password'])
+                                   password=opts['password'],
+                                   decode_responses=True)
     return REDIS_SERVER
 
 

--- a/salt/cache/redis_cache.py
+++ b/salt/cache/redis_cache.py
@@ -231,15 +231,13 @@ def _get_redis_server(opts=None):
 
     if opts['cluster_mode']:
         REDIS_SERVER = StrictRedisCluster(startup_nodes=opts['startup_nodes'],
-                                          skip_full_coverage_check=opts['skip_full_coverage_check'],
-                                          decode_responses=True)
+                                          skip_full_coverage_check=opts['skip_full_coverage_check'])
     else:
         REDIS_SERVER = redis.StrictRedis(opts['host'],
                                    opts['port'],
                                    unix_socket_path=opts['unix_socket_path'],
                                    db=opts['db'],
-                                   password=opts['password'],
-                                   decode_responses=True)
+                                   password=opts['password'])
     return REDIS_SERVER
 
 

--- a/salt/engines/redis_sentinel.py
+++ b/salt/engines/redis_sentinel.py
@@ -63,7 +63,7 @@ class Listener(object):
             tag = 'salt/engine/redis_sentinel'
         super(Listener, self).__init__()
         self.tag = tag
-        self.redis = redis.StrictRedis(host=host, port=port)
+        self.redis = redis.StrictRedis(host=host, port=port, decode_responses=True)
         self.pubsub = self.redis.pubsub()
         self.pubsub.psubscribe(channels)
         self.fire_master = salt.utils.event.get_master_event(__opts__, __opts__['sock_dir']).fire_event

--- a/salt/modules/redismod.py
+++ b/salt/modules/redismod.py
@@ -55,7 +55,7 @@ def _connect(host=None, port=None, db=None, password=None):
     if not password:
         password = __salt__['config.option']('redis.password')
 
-    return redis.StrictRedis(host, port, db, password)
+    return redis.StrictRedis(host, port, db, password, decode_responses=True)
 
 
 def _sconnect(host=None, port=None, password=None):
@@ -69,7 +69,7 @@ def _sconnect(host=None, port=None, password=None):
     if password is None:
         password = __salt__['config.option']('redis_sentinel.password')
 
-    return redis.StrictRedis(host, port, password=password)
+    return redis.StrictRedis(host, port, password=password, decode_responses=True)
 
 
 def bgrewriteaof(host=None, port=None, db=None, password=None):

--- a/salt/returners/redis_return.py
+++ b/salt/returners/redis_return.py
@@ -188,7 +188,8 @@ def _get_serv(ret=None):
         REDIS_POOL = redis.StrictRedis(host=_options.get('host'),
                                        port=_options.get('port'),
                                        unix_socket_path=_options.get('unix_socket_path', None),
-                                       db=_options.get('db'))
+                                       db=_options.get('db'),
+                                       decode_responses=True)
     return REDIS_POOL
 
 

--- a/salt/tokens/rediscluster.py
+++ b/salt/tokens/rediscluster.py
@@ -53,7 +53,7 @@ def _redis_client(opts):
     redis_host = opts.get("eauth_redis_host", "localhost")
     redis_port = opts.get("eauth_redis_port", 6379)
     try:
-        return rediscluster.StrictRedisCluster(host=redis_host, port=redis_port)
+        return rediscluster.StrictRedisCluster(host=redis_host, port=redis_port, decode_responses=True)
     except rediscluster.exceptions.RedisClusterException as err:
         log.warning(
             'Failed to connect to redis at %s:%s - %s',


### PR DESCRIPTION
### What does this PR do?
Set `decode_responses=True` on all instantiations of the Redis API.
See discussion in #49060

### What issues does this PR fix or reference?
fixes #49060

### Previous Behavior
Some Redis returns were in binary

### New Behavior
All Redis returns are in unicode

