### PR TITLE
Make salt.utils.vault._get_connection publicly available

### DIFF
--- a/salt/utils/vault.py
+++ b/salt/utils/vault.py
@@ -91,7 +91,7 @@ def _get_token_and_url_from_master():
            }
 
 
-def _get_vault_connection():
+def get_vault_connection():
     '''
     Get the connection details for calling Vault, from local configuration if
     it exists, or from the master otherwise
@@ -139,7 +139,7 @@ def make_request(method, resource, profile=None, **args):
         # Deprecated code path
         return make_request_with_profile(method, resource, profile, **args)
 
-    connection = _get_vault_connection()
+    connection = get_vault_connection()
     token, vault_url = connection['token'], connection['url']
     if 'verify' not in args:
         args['verify'] = connection['verify']


### PR DESCRIPTION
### What does this PR do?
`salt.utils.vault._get_connection` -> `salt.utils.vault.get_connection`

### What issues does this PR fix or reference?
While writing some addon Vault functionality, we want to bypass the Salt vault module and use `hvac`. 
To initialize it within Salt consistently, it makes sense to unhide this function to allow this and other integrations to easily reuse this piece of logic. 
