### PR TITLE
Test fixes flaky test and unicode environment key/value

### DIFF
--- a/tests/integration/modules/test_pip.py
+++ b/tests/integration/modules/test_pip.py
@@ -53,6 +53,8 @@ class PipModuleTest(ModuleCase):
         del self.pip_temp
         if 'PIP_SOURCE_DIR' in os.environ:
             os.environ.pop('PIP_SOURCE_DIR')
+        if 'PIP_BUILD_DIR' in os.environ:
+            os.environ.pop('PIP_BUILD_DIR')
 
     def _check_download_error(self, ret):
         '''

--- a/tests/integration/modules/test_system.py
+++ b/tests/integration/modules/test_system.py
@@ -12,7 +12,7 @@ import textwrap
 # Import Salt Testing libs
 from tests.support.case import ModuleCase
 from tests.support.unit import skipIf
-from tests.support.helpers import destructiveTest, skip_if_not_root
+from tests.support.helpers import destructiveTest, skip_if_not_root, flaky
 
 # Import Salt libs
 import salt.utils.files
@@ -255,6 +255,7 @@ class SystemModuleTest(ModuleCase):
         self.assertTrue(self._same_times(time_now, cmp_time), msg=msg)
         self._test_hwclock_sync()
 
+    @flaky
     @destructiveTest
     @skip_if_not_root
     def test_set_system_time(self):


### PR DESCRIPTION
### What does this PR do?

- Fix tearDown method to remove unicode environment key.
- Mark flaky test as such, test_set_system_time fails when run at
  certian times of the day.



### Tests written?

No - Fixing existing tests

### Commits signed with GPG?

Yes