### PR TITLE
Saltcheck: add assertEmpty and assertNotEmpty

### DIFF
--- a/salt/modules/saltcheck.py
+++ b/salt/modules/saltcheck.py
@@ -380,7 +380,7 @@ class SaltCheck(object):
             args = test_dict.get('args', None)
             kwargs = test_dict.get('kwargs', None)
             assertion = test_dict['assertion']
-            expected_return = test_dict['expected-return']
+            expected_return = test_dict.get('expected-return', None)
             actual_return = self.call_salt_command(mod_and_func, args, kwargs)
             if assertion not in ["assertIn", "assertNotIn", "assertEmpty", "assertNotEmpty",
                                  "assertTrue", "assertFalse"]:
@@ -410,7 +410,7 @@ class SaltCheck(object):
             elif assertion == "assertNotEmpty":
                 value = self.__assert_not_empty(actual_return)
             else:
-                value = "Fail - bas assertion"
+                value = "Fail - bad assertion"
         else:
             return "Fail - invalid test"
         return value
@@ -580,10 +580,11 @@ class SaltCheck(object):
         '''
         result = "Pass"
         try:
-            assert (returned), "{0} is empty".format(returned)
+            assert (returned), "value is empty".format(returned)
         except AssertionError as err:
             result = "Fail: " + six.text_type(err)
         return result
+
     @staticmethod
     def get_state_search_path_list():
         '''

--- a/salt/modules/saltcheck.py
+++ b/salt/modules/saltcheck.py
@@ -301,8 +301,9 @@ class SaltCheck(object):
                                   assertLess assertLessEqual
                                   assertEmpty assertNotEmpty'''.split()
         self.auto_update_master_cache = _get_auto_update_cache_value
-        # self.salt_lc = salt.client.Caller(mopts=__opts__)
-        self.salt_lc = salt.client.Caller()
+        local_opts = salt.config.minion_config(__opts__['conf_file'])
+        local_opts['file_client'] = 'local'
+        self.salt_lc = salt.client.Caller(mopts=local_opts)
         if self.auto_update_master_cache:
             update_master_cache()
 

--- a/salt/modules/saltcheck.py
+++ b/salt/modules/saltcheck.py
@@ -42,7 +42,7 @@ Example:
       assertion: assertEqual
       expected-return:  'hello'
 
-Support assertions:
+Supported assertions:
 assertEqual assertNotEqual assertTrue assertFalse assertIn assertNotIn assertGreater
 assertGreaterEqual assertLess assertLessEqual assertEmpty assertNotEmpty
 
@@ -289,7 +289,6 @@ class SaltCheck(object):
     '''
 
     def __init__(self):
-        # self.sls_list_top = []
         self.sls_list_state = []
         self.modules = []
         self.results_dict = {}

--- a/tests/unit/modules/test_saltcheck.py
+++ b/tests/unit/modules/test_saltcheck.py
@@ -321,6 +321,42 @@ class LinuxSysctlTestCase(TestCase, LoaderModuleMockMixin):
             mybool = sc_instance._SaltCheck__assert_less_equal(aaa, bbb)
             self.assertEqual(mybool, 'Pass')
 
+    def test__assert_empty(self):
+        '''test'''
+        with patch.dict(saltcheck.__salt__, {'config.get': MagicMock(return_value=True),
+                                             'cp.cache_master': MagicMock(return_value=[True])
+                                             }):
+            sc_instance = saltcheck.SaltCheck()
+            mybool = sc_instance._SaltCheck__assert_empty("")
+            self.assertEqual(mybool, 'Pass')
+
+    def test__assert_empty_fail(self):
+        '''test'''
+        with patch.dict(saltcheck.__salt__, {'config.get': MagicMock(return_value=True),
+                                             'cp.cache_master': MagicMock(return_value=[True])
+                                             }):
+            sc_instance = saltcheck.SaltCheck()
+            mybool = sc_instance._SaltCheck__assert_empty("data")
+            self.assertNotEqual(mybool, 'Pass')
+
+    def test__assert__not_empty(self):
+        '''test'''
+        with patch.dict(saltcheck.__salt__, {'config.get': MagicMock(return_value=True),
+                                             'cp.cache_master': MagicMock(return_value=[True])
+                                             }):
+            sc_instance = saltcheck.SaltCheck()
+            mybool = sc_instance._SaltCheck__assert_not_empty("data")
+            self.assertEqual(mybool, 'Pass')
+
+    def test__assert__not_empty_fail(self):
+        '''test'''
+        with patch.dict(saltcheck.__salt__, {'config.get': MagicMock(return_value=True),
+                                             'cp.cache_master': MagicMock(return_value=[True])
+                                             }):
+            sc_instance = saltcheck.SaltCheck()
+            mybool = sc_instance._SaltCheck__assert_not_empty("")
+            self.assertNotEqual(mybool, 'Pass')
+
     def test_run_test_1(self):
         '''test'''
         with patch.dict(saltcheck.__salt__, {'config.get': MagicMock(return_value=True),


### PR DESCRIPTION
### What does this PR do?
 - Adds empty and not empty assertions to saltcheck
 - Removes the requirement to specify the expected-return key (for use by assertEmpty or assertTrue)
 - Attempt to cleanup web docs https://docs.saltstack.com/en/develop/ref/modules/all/salt.modules.saltcheck.html by marking class functions as private (I'm not sure what is proper here)




For the state
```
install_common_package:
  pkg.installed:
    - pkgs:
      - vim
      - avahi-daemon
      - libnss-mdns
```

This allows for the following saltchecks:
```
{%- set package_list = ["vim", "avahi-daemon", "libnss-mdns", "lua-unit"] %}

{% for package in package_list %}
verify_{{ package }}:
  module_and_function: pkg.version
  args:
    - {{ package }}
  assertion: assertNotEmpty
{% endfor %}
```
providing the output
```
local:
    |_
      ----------
      common:
          ----------
          verify_avahi-daemon:
              Pass
          verify_libnss-mdns:
              Pass
          verify_lua-unit:
              Fail: value is empty
          verify_vim:
              Pass
    |_
      ----------
      TEST RESULTS:
          ----------
          Failed:
              1
          Missing Tests:
              0
          Passed:
              3
```


### Tests written?
Yes

### Commits signed with GPG?
No