### PR TITLE
Fixes bug #41214

### DIFF
--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -4136,11 +4136,14 @@ def create_keypair(kwargs=None, call=None):
 
     data = aws.query(params,
                      return_url=True,
+                     return_root=True,
                      location=get_location(),
                      provider=get_provider(),
                      opts=__opts__,
                      sigver='4')
-    return data
+    keys = [ x for x in data[0] if 'requestId' not in x ]
+    
+    return ( keys, data[1] )
 
 
 def import_keypair(kwargs=None, call=None):

--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -4142,7 +4142,7 @@ def create_keypair(kwargs=None, call=None):
                      opts=__opts__,
                      sigver='4')
     keys = [x for x in data[0] if 'requestId' not in x]
-    
+
     return (keys, data[1])
 
 

--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -4141,9 +4141,9 @@ def create_keypair(kwargs=None, call=None):
                      provider=get_provider(),
                      opts=__opts__,
                      sigver='4')
-    keys = [ x for x in data[0] if 'requestId' not in x ]
+    keys = [x for x in data[0] if 'requestId' not in x]
     
-    return ( keys, data[1] )
+    return (keys, data[1])
 
 
 def import_keypair(kwargs=None, call=None):


### PR DESCRIPTION
Fixes #41214: On AWS EC2: salt-cloud create -f create_keypair does not returns the private key

### What does this PR do?
Now it returns the private key

### What issues does this PR fix or reference?
None


### Tests written?
No

### Commits signed with GPG?
No


