### PR TITLE
Fix typeerror unicode

### DIFF
--- a/salt/modules/omapi.py
+++ b/salt/modules/omapi.py
@@ -13,8 +13,7 @@ config or pillar:
 '''
 
 # Import python libs
-# Not importing unicode_literals as pypureomapi needs byte strings not unicode
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, print_function, unicode_literals
 import logging
 import struct
 

--- a/salt/modules/omapi.py
+++ b/salt/modules/omapi.py
@@ -13,9 +13,13 @@ config or pillar:
 '''
 
 # Import python libs
-from __future__ import absolute_import, print_function, unicode_literals
+# Not importing unicode_literals as pypureomapi needs byte strings not unicode
+from __future__ import absolute_import, print_function
 import logging
 import struct
+
+# Import salt libs
+import salt.utils.stringutils
 
 
 log = logging.getLogger(__name__)
@@ -47,6 +51,10 @@ def _conn():
             __opts__.get('omapi.key', None))
     username = __pillar__.get('omapi.user',
             __opts__.get('omapi.user', None))
+    if key:
+        key = salt.utils.stringutils.to_bytes(key)
+    if username:
+        username = salt.utils.stringutils.to_bytes(username)
     return omapi.Omapi(server_ip, server_port, username=username, key=key)
 
 
@@ -70,22 +78,22 @@ def add_host(mac, name=None, ip=None, ddns=False, group=None,
     statements = ''
     o = _conn()
     msg = omapi.OmapiMessage.open(b'host')
-    msg.message.append(('create', struct.pack(b'!I', 1)))
-    msg.message.append(('exclusive', struct.pack(b'!I', 1)))
-    msg.obj.append(('hardware-address', omapi.pack_mac(mac)))
-    msg.obj.append(('hardware-type', struct.pack(b'!I', 1)))
+    msg.message.append((b'create', struct.pack(b'!I', 1)))
+    msg.message.append((b'exclusive', struct.pack(b'!I', 1)))
+    msg.obj.append((b'hardware-address', omapi.pack_mac(mac)))
+    msg.obj.append((b'hardware-type', struct.pack(b'!I', 1)))
     if ip:
-        msg.obj.append(('ip-address', omapi.pack_ip(ip)))
+        msg.obj.append((b'ip-address', omapi.pack_ip(ip)))
     if name:
-        msg.obj.append(('name', name))
+        msg.obj.append((b'name', salt.utils.stringutils.to_bytes(name)))
     if group:
-        msg.obj.append(('group', group))
+        msg.obj.append((b'group', salt.utils.stringutils.to_bytes(group)))
     if supersede_host:
         statements += 'option host-name "{0}"; '.format(name)
     if ddns and name:
         statements += 'ddns-hostname "{0}"; '.format(name)
     if statements:
-        msg.obj.append(('statements', statements))
+        msg.obj.append((b'statements', salt.utils.stringutils.to_bytes(statements)))
     response = o.query_server(msg)
     if response.opcode != omapi.OMAPI_OP_UPDATE:
         return False
@@ -108,10 +116,10 @@ def delete_host(mac=None, name=None):
     o = _conn()
     msg = omapi.OmapiMessage.open(b'host')
     if mac:
-        msg.obj.append(('hardware-address', omapi.pack_mac(mac)))
-        msg.obj.append(('hardware-type', struct.pack(b'!I', 1)))
+        msg.obj.append((b'hardware-address', omapi.pack_mac(mac)))
+        msg.obj.append((b'hardware-type', struct.pack(b'!I', 1)))
     if name:
-        msg.obj.append(('name', name))
+        msg.obj.append((b'name', salt.utils.stringutils.to_bytes(name)))
     response = o.query_server(msg)
     if response.opcode != omapi.OMAPI_OP_UPDATE:
         return None


### PR DESCRIPTION
fix TypeError: 'unicode' does not have the buffer interface and updates for python 3 support

`from __future__ import unicode_literals` - breaks this module in python 2. I found python 3 to not be supported as well. It appears that the pypureomapi library leverages sockets that are designed to only take byte strings. In python 2, strings are already byte strings and using unicode_literals causes the TypeError. In python 3 strings are unicode by default and thus need to be encoded to byte strings. This update encodes string literals into byte strings and provides support for both python 2 and 3.

### What does this PR do?
fix TypeError: 'unicode' does not have the buffer interface introduced by `from __future__ import unicode_literals` and handles python 3 support

### What issues does this PR fix or reference?
n/a

### Tests written?

No

### Commits signed with GPG?

Yes


