### PR TITLE
Suppress pchanges output by adding new silent recurse option to file.directory state

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -2902,7 +2902,7 @@ def managed(name,
                 salt.utils.files.remove(sfn)
 
 
-_RECURSE_TYPES = ['user', 'group', 'mode', 'ignore_files', 'ignore_dirs']
+_RECURSE_TYPES = ['user', 'group', 'mode', 'ignore_files', 'ignore_dirs', 'silent']
 
 
 def _get_recurse_set(recurse):
@@ -2982,7 +2982,8 @@ def directory(name,
         a list of strings representing what you would like to recurse.  If
         ``mode`` is defined, will recurse on both ``file_mode`` and ``dir_mode`` if
         they are defined.  If ``ignore_files`` or ``ignore_dirs`` is included, files or
-        directories will be left unchanged respectively.
+        directories will be left unchanged respectively. If ``silent`` is defined,
+        individual file/directory change notifications will be suppressed.
         Example:
 
         .. code-block:: yaml
@@ -3393,6 +3394,9 @@ def directory(name,
         if 'mode' not in recurse_set:
             file_mode = None
             dir_mode = None
+
+        if 'silent' in recurse_set:
+            ret['pchanges'] = 'Changes silenced'
 
         check_files = 'ignore_files' not in recurse_set
         check_dirs = 'ignore_dirs' not in recurse_set


### PR DESCRIPTION
### What does this PR do?
Suppress file.directory state's pchanges output by adding new silent recurse option. Useful for large directories which using file.directory via the saltapi.

### What issues does this PR fix or reference?
#44553

### Previous Behavior
Salt api output on file.directory changes
```json
{"return": [{"master": {"jid": "20180820070645166471", "retcode": 0, "ret": 
{"file_|-/tmp/dirtest_|-/tmp/dirtest_|-directory": {"comment": "Directory /tmp/dirtest updated", 
"pchanges": {"/tmp/dirtest/base/tests/files/grains.sh": {"user": "jenkins"}, "/tmp/dirtest/base/dir": 
{"user": "jenkins", "mode": "0644"}, "/tmp/dirtest/base/saltapi/files/saltapi.conf": {"user": "jenkins"}, "/tmp/dirtest/base/ntp/init.sls": {"user": "jenkins"}, "/tmp/dirtest/base/tests/files/runner2.sh": {"user": 
"jenkins"}, "/tmp/dirtest/base/tests/files/cmd-run-missingminion.sh": {"user": "jenkins"}, "/tmp/dirtest/base/errors/dup.sls": {"user": "jenkins"}, "/tmp/dirtest/base/_modules/zabbix.py": 
{"user": "jenkins"}, "/tmp/dirtest/base/top.sls": {"user": "jenkins"}, "/tmp/dirtest/base/saltapi": {"user": "jenkins", "mode": "0644"}, "/tmp/dirtest/base/tests/files/python.py": {"user": "jenkins"}, 
"/tmp/dirtest/base/common/saltcheck-tests/init.tst": {"user": "jenkins"}, "/tmp/dirtest/base": {"user": "jenkins", "mode": "0644"}, "/tmp/dirtest/base/ntp": {"user": "jenkins", "mode": "0644"}, 
"/tmp/dirtest/base/tests/files/batch-wait.sh": {"user": "jenkins"}, "/tmp/dirtest/base/dir/init.sls": {"user": "jenkins"}, "/tmp/dirtest/base/tests/files/local_async.sh": {"user": "jenkins"}, 
"/tmp/dirtest/base/tests/files/multi-equals2.sh": {"user": "jenkins"}, "/tmp/dirtest/base/tests/files/multi-equals.sh": {"user": "jenkins"}, 
"/tmp/dirtest/base/_modules/saltcheck.py": {"user": "jenkins"}, "/tmp/dirtest/base/common/saltcheck-tests": {"user": "jenkins", "mode": "0644"}, "/tmp/dirtest/base/saltapi/init.sls": {"user": "jenkins"}, 
"/tmp/dirtest/create.sh": {"user": "jenkins"}, "/tmp/dirtest/base/tests/files/cmd-run.sh": {"user": "jenkins"}, "/tmp/dirtest/base/zabrun.sls": {"user": "jenkins"}, "/tmp/dirtest/base/common": {"user": 
"jenkins", "mode": "0644"}, "/tmp/dirtest/base/common/init.sls": {"user": "jenkins"}, "/tmp/dirtest/base/tests/files": {"user": "jenkins", "mode": "0644"}, 
"/tmp/dirtest/base/orchestrate/pillar.sls": {"user": "jenkins"}, "/tmp/dirtest/base/orchestrate": {"user": "jenkins", "mode": "0644"}, "/tmp/dirtest/base/tests/files/batch2.sh": {"user": "jenkins"}, 
"/tmp/dirtest/base/tests/files/cmd-run-adv.sh": {"user": "jenkins"}, "/tmp/dirtest/base/tests/files/runner.sh": {"user": "jenkins"}, "/tmp/dirtest/base/saltapi/files": {"user": 
"jenkins", "mode": "0644"}, "/tmp/dirtest/base/tests/files/orchestrate-pillar.sh": {"user": "jenkins"}, "/tmp/dirtest/base/tests": {"user": "jenkins", "mode": "0644"}, "/tmp/dirtest/base/tests/files/drop-
packet.sh": {"user": "jenkins"}, "/tmp/dirtest/base/tests/pillar-show.sls": {"user": "jenkins"}, "/tmp/dirtest": {"user": "jenkins", "mode": "0644"}, "/tmp/dirtest/base/tests/files/cmd-run2.sh": 
{"user": "jenkins"}, "/tmp/dirtest/base/tests/files/hook.sh": {"user": "jenkins"}, "/tmp/dirtest/base/tests/files/.local_async.sh.swp": {"user": "jenkins"}, "/tmp/dirtest/base/roles": 
{"user": "jenkins", "mode": "0644"}, "/tmp/dirtest/base/_modules": {"user": "jenkins", "mode": "0644"}, "/tmp/dirtest/base/tests/files/batch.sh": {"user": "jenkins"}, "/tmp/dirtest/base/errors": {"user": 
"jenkins", "mode": "0644"}, "/tmp/dirtest/base/tests/files/local_async-bad.sh": {"user": "jenkins"}}, "name": "/tmp/dirtest", "start_time": "07:06:45.350633", "result": true, "duration": 384.501, 
"__run_num__": 0, "__sls__": "dir", "changes": {"mode": "0644", "user": "jenkins"}, "__id__": "/tmp/dirtest"}}, "out": "highstate"}}]}
```
### New Behavior
Note: `"pchanges": "Changes silenced"`
```json
{"return": [{"master": {"jid": "20180820071219149957", "retcode": 0, "ret": 
{"file_|-/tmp/dirtest_|-/tmp/dirtest_|-directory": {"comment": "Directory /tmp/dirtest updated", 
"pchanges": "Changes silenced", "name": "/tmp/dirtest", "start_time": "07:12:19.324289", "result": true, 
"duration": 371.104, "__run_num__": 0, "__sls__": "dir", "changes": {"user": "root"}, "__id__": 
"/tmp/dirtest"}}, "out": "highstate"}}]}
```

### Tests written?
No

### Commits signed with GPG?
No