### PR TITLE
Add the saltcli tests to the filename map salt/client/*

### DIFF
--- a/tests/filename_map.yml
+++ b/tests/filename_map.yml
@@ -103,6 +103,7 @@ salt/cli/salt.py:
 salt/client/*:
   - integration.client.test_kwarg
   - integration.client.test_runner
+  - integration.client.test_saltcli
   - integration.client.test_standard
 
 salt/cloud/*:


### PR DESCRIPTION
This updates the filename map added in #47337 to ensure that the salt CLI tests are run when anything in salt.client files are updated.