### PR TITLE
Set a nonzero retcode when minions fail to return

### DIFF
--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -29,6 +29,7 @@ from datetime import datetime
 # Import salt libs
 import salt.config
 import salt.cache
+import salt.defaults.exitcodes
 import salt.payload
 import salt.transport
 import salt.loader
@@ -1526,13 +1527,23 @@ class LocalClient(object):
                             and connected_minions \
                             and id_ not in connected_minions:
 
-                        yield {id_: {'out': 'no_return',
-                                     'ret': 'Minion did not return. [Not connected]'}}
+                        yield {
+                            id_: {
+                                'out': 'no_return',
+                                'ret': 'Minion did not return. [Not connected]',
+                                'retcode': salt.defaults.exitcodes.EX_GENERIC
+                            }
+                        }
                     else:
                         # don't report syndics as unresponsive minions
                         if not os.path.exists(os.path.join(self.opts['syndic_dir'], id_)):
-                            yield {id_: {'out': 'no_return',
-                                         'ret': 'Minion did not return. [No response]'}}
+                            yield {
+                                id_: {
+                                    'out': 'no_return',
+                                    'ret': 'Minion did not return. [No response]',
+                                    'retcode': salt.defaults.exitcodes.EX_GENERIC
+                                }
+                            }
                 else:
                     yield {id_: min_ret}
 

--- a/tests/integration/shell/test_saltcli.py
+++ b/tests/integration/shell/test_saltcli.py
@@ -12,6 +12,11 @@
 # Import python libs
 from __future__ import absolute_import
 import logging
+import os
+
+# Import Salt libs
+import salt.utils.files
+import salt.utils.path
 
 # Import Salt Testing libs
 from tests.support.case import ShellCase
@@ -79,9 +84,9 @@ class RetcodeTestCase(ShellCase):
     # Hard-coding these instead of substituting values from
     # salt.defaults.exitcodes will give us a heads-up in the event that someone
     # tries to do something daft like change these values.
-    error_status = 1  # i.e. EX_GENERIC
-    state_compiler_error = 1
-    state_failure = 2
+    error_status = salt.defaults.exitcodes.EX_GENERIC
+    state_compiler_error = salt.defaults.exitcodes.EX_STATE_COMPILER_ERROR
+    state_failure = salt.defaults.exitcodes.EX_STATE_FAILURE
 
     def _salt(self, command):
         cmdline = 'minion ' + command
@@ -175,3 +180,31 @@ class RetcodeTestCase(ShellCase):
         '''
         self._test_error()
         self._test_error(salt_call=True)
+
+    def test_missing_minion(self):
+        '''
+        Test that a minion which doesn't respond results in a nonzeo exit code
+        '''
+        good = salt.utils.path.join(self.master_opts['pki_dir'], 'minions', 'minion')
+        bad = salt.utils.path.join(self.master_opts['pki_dir'], 'minions', 'minion2')
+        try:
+            # Copy the key
+            with salt.utils.files.fopen(good, 'rb') as fhr, \
+                    salt.utils.files.fopen(bad, 'wb') as fhw:
+                fhw.write(fhr.read())
+            retcode = self.run_script(
+                'salt',
+                '-c {0} -t 5 minion2 test.ping'.format(self.config_dir),
+                with_retcode=True,
+                timeout=20)[1]
+            assert retcode == salt.defaults.exitcodes.EX_GENERIC, retcode
+        finally:
+            # Now get rid of it
+            try:
+                os.remove(bad)
+            except OSError as exc:
+                if exc.errno != os.errno.ENOENT:
+                    log.error(
+                        'Failed to remove %s, this may affect other tests: %s',
+                        bad, exc
+                    )


### PR DESCRIPTION
This PR has been opened against fluorine since that is where the rest of the recent exit codes work has been done.

Fixes https://github.com/saltstack/salt/issues/47235.