### PR TITLE
Fix Windows and OSX installers

### DIFF
--- a/pkg/osx/req.txt
+++ b/pkg/osx/req.txt
@@ -6,6 +6,7 @@ cffi==1.10.0
 CherryPy==11.0.0
 click==6.7
 enum34==1.1.6
+futures==3.1.1
 gitdb==0.6.4
 GitPython==2.1.1
 idna==2.5

--- a/pkg/windows/build_pkg.bat
+++ b/pkg/windows/build_pkg.bat
@@ -68,11 +68,11 @@ If not Exist "%PyDir%\python.exe" (
 )
 
 Set "CurDir=%~dp0"
-Set "BldDir=%CurDir%\buildenv"
-Set "BinDir=%CurDir%\buildenv\bin"
-Set "CnfDir=%CurDir%\buildenv\conf"
-Set "InsDir=%CurDir%\installer"
-Set "PreDir=%CurDir%\prereqs"
+Set "BldDir=%CurDir%buildenv"
+Set "BinDir=%CurDir%buildenv\bin"
+Set "CnfDir=%CurDir%buildenv\conf"
+Set "InsDir=%CurDir%installer"
+Set "PreDir=%CurDir%prereqs"
 for /f "delims=" %%a in ('git rev-parse --show-toplevel') do @set "SrcDir=%%a"
 
 :: Find the NSIS Installer
@@ -115,8 +115,6 @@ xcopy /Q /Y "%SrcDir%\conf\minion" "%CnfDir%\"
 
 @echo Copying NSSM to buildenv
 @echo ----------------------------------------------------------------------
-:: Make sure the "prereq" directory exists
-If NOT Exist "%PreDir%" mkdir "%PreDir%"
 
 :: Set the location of the nssm to download
 Set Url64="https://repo.saltstack.com/windows/dependencies/64/nssm-2.24-101-g897c7ad.exe"
@@ -130,12 +128,48 @@ If Defined ProgramFiles(x86) (
 )
 @echo.
 
-:: Make sure the "prereq" directory exists
-If NOT Exist "%PreDir%" mkdir "%PreDir%"
+:: Make sure the "prereq" directory exists and is empty
+If Exist "%PreDir%" rd /s /q "%PreDir%"
+mkdir "%PreDir%"
 
-:: Don't include the vcredist for Py3 installations
-If %Python%==3 goto :vcredist_end
+:: Skip KB2999226 if on Py3
+If %Python%==2 goto get_vcredist
 
+:: For PY 3, include KB2999226
+@echo Copying KB2999226 to Prerequisites
+@echo ----------------------------------------------------------------------
+If Defined ProgramFiles(x86) (
+    set Url60=http://repo.saltstack.com/windows/dependencies/64/ucrt/Windows6.0-KB2999226-x64.msu
+    set Name60=Windows6.0-KB2999226-x64.msu
+    set Url61=http://repo.saltstack.com/windows/dependencies/64/ucrt/Windows6.1-KB2999226-x64.msu
+    set Name61=Windows6.1-KB2999226-x64.msu
+    set Url80=http://repo.saltstack.com/windows/dependencies/64/ucrt/Windows8-RT-KB2999226-x64.msu
+    set Name80=Windows8-RT-KB2999226-x64.msu
+    set Url81=http://repo.saltstack.com/windows/dependencies/64/ucrt/Windows8.1-KB2999226-x64.msu
+    set Name81=Windows8.1-KB2999226-x64.msu
+) Else (
+    set Url60=http://repo.saltstack.com/windows/dependencies/32/ucrt/Windows6.0-KB2999226-x86.msu
+    set Name60=Windows6.0-KB2999226-x86.msu
+    set Url61=http://repo.saltstack.com/windows/dependencies/32/ucrt/Windows6.1-KB2999226-x86.msu
+    set Name61=Windows6.1-KB2999226-x86.msu
+    set Url80=http://repo.saltstack.com/windows/dependencies/32/ucrt/Windows8-RT-KB2999226-x86.msu
+    set Name80=Windows8-RT-KB2999226-x86.msu
+    set Url81=http://repo.saltstack.com/windows/dependencies/32/ucrt/Windows8.1-KB2999226-x86.msu
+    set Name81=Windows8.1-KB2999226-x86.msu
+)
+@echo - Downloading %Name60%
+powershell -ExecutionPolicy RemoteSigned -File download_url_file.ps1 -url %Url60% -file "%PreDir%\%Name60%"
+@echo - Downloading %Name61%
+powershell -ExecutionPolicy RemoteSigned -File download_url_file.ps1 -url %Url61% -file "%PreDir%\%Name61%"
+@echo - Downloading %Name80%
+powershell -ExecutionPolicy RemoteSigned -File download_url_file.ps1 -url %Url80% -file "%PreDir%\%Name80%"
+@echo - Downloading %Name81%
+powershell -ExecutionPolicy RemoteSigned -File download_url_file.ps1 -url %Url81% -file "%PreDir%\%Name81%"
+
+goto prereq_end
+
+:: For PY 2, include VCRedist
+:get_vcredist
 @echo Copying VCRedist to Prerequisites
 @echo ----------------------------------------------------------------------
 
@@ -151,7 +185,7 @@ If Defined ProgramFiles(x86) (
 )
 @echo.
 
-:vcredist_end
+:prereq_end
 
 :: Remove the fixed path in .exe files
 @echo Removing fixed path from .exe files

--- a/pkg/windows/installer/Salt-Minion-Setup.nsi
+++ b/pkg/windows/installer/Salt-Minion-Setup.nsi
@@ -248,7 +248,7 @@ Section -install_ucrt
     Pop $1 # Gets the stdout, which should be KB2999226 if it's installed
     ${IfNot} $R0 == 0
         detailPrint "error: $R0"
-        detailPrint "output: $R2"
+        detailPrint "KB2999226 not found"
     ${EndIf}
 
     # If it returned KB2999226 it's already installed

--- a/pkg/windows/installer/Salt-Minion-Setup.nsi
+++ b/pkg/windows/installer/Salt-Minion-Setup.nsi
@@ -344,7 +344,7 @@ Section -install_vcredist
             # of the user variable are undefined).
             # http://nsis.sourceforge.net/Reference/ExecWait
             ClearErrors
-            ExecWait '"$PLUGINSDIR\vcredist.exe" /qb!' $0
+            ExecWait '"$PLUGINSDIR\vcredist.exe" /q' $0
             IfErrors 0 CheckVcRedistErrorCode
                 MessageBox MB_OK \
                     "$VcRedistName failed to install. Try installing the package manually." \

--- a/pkg/windows/installer/Salt-Minion-Setup.nsi
+++ b/pkg/windows/installer/Salt-Minion-Setup.nsi
@@ -200,15 +200,111 @@ InstallDirRegKey HKLM "${PRODUCT_DIR_REGKEY}" ""
 ShowInstDetails show
 ShowUnInstDetails show
 
+Section -copy_prereqs
+    # Copy prereqs to the Plugins Directory
+    # These files will be vcredist 2008 and KB2999226 for Win8.1 and below
+    # These files are downloaded by build_pkg.bat
+    # This directory gets removed upon completion
+    SetOutPath "$PLUGINSDIR\"
+    File /r "..\prereqs\"
+SectionEnd
+
+# Check and install the Windows 10 Universal C Runtime (KB2999226)
+# ucrt is needed on Windows 8.1 and lower
+# They are installed as a Microsoft Update package (.msu)
+# ucrt for Windows 8.1 RT is only available via Windows Update
+Section -install_ucrt
+
+    Var /GLOBAL MsuPrefix
+    Var /GLOBAL MsuFileName
+
+    # UCRT only needs to be installed for Python 3
+    StrCmp ${PYTHON_VERSION} 2 lbl_done
+
+    # Get the Major.Minor version Number
+    # Windows 10 introduced CurrentMajorVersionNumber
+    ReadRegStr $R0 HKLM "SOFTWARE\Microsoft\Windows NT\CurrentVersion" \
+        CurrentMajorVersionNumber
+
+    # Windows 10/2016 will return a value here, skip to the end if returned
+    StrCmp $R0 '' lbl_needs_ucrt 0
+
+    # Found Windows 10
+    detailPrint "KB2999226 does not apply to this machine"
+    goto lbl_done
+
+    lbl_needs_ucrt:
+    # UCRT only needed on Windows Server 2012R2/Windows 8.1 and below
+    # The first ReadRegStr command above should have skipped to lbl_done if on
+    # Windows 10 box
+
+    # Is the update already installed
+    ClearErrors
+
+    # Use WMI to check if it's installed
+    detailPrint "Checking for existing KB2999226 installation"
+    nsExec::ExecToStack 'cmd /q /c wmic qfe get hotfixid | findstr "^KB2999226"'
+    Pop $0 # Gets the ErrorCode
+    Pop $1 # Gets the stdout, which should be KB2999226 if it's installed
+    ${IfNot} $R0 == 0
+        detailPrint "error: $R0"
+        detailPrint "output: $R2"
+    ${EndIf}
+
+    # If it returned KB2999226 it's already installed
+    StrCmp $1 'KB2999226' lbl_done
+
+    # All lower versions of Windows
+    ReadRegStr $R0 HKLM "SOFTWARE\Microsoft\Windows NT\CurrentVersion" \
+        CurrentVersion
+
+    # Get the name of the .msu file based on the value of $R0
+    ${Switch} "$R0"
+        ${Case} "6.3"
+            StrCpy $MsuPrefix "Windows8.1"
+            ${break}
+        ${Case} "6.2"
+            StrCpy $MsuPrefix "Windows8-RT"
+            ${break}
+        ${Case} "6.1"
+            StrCpy $MsuPrefix "Windows6.1"
+            ${break}
+        ${Case} "6.0"
+            StrCpy $MsuPrefix "Windows6.0"
+            ${break}
+    ${EndSwitch}
+
+    ${If} ${CPUARCH} == "AMD64"
+        StrCpy $MsuFileName "$MsuPrefix-KB2999226-x64.msu"
+    ${Else}
+        StrCpy $MsuFileName "$MsuPrefix-KB2999226-x86.msu"
+    ${EndIf}
+
+    ClearErrors
+
+    detailPrint "Installing KB2999226 using file $MsuFileName"
+    nsExec::ExecToStack 'cmd /c wusa "$PLUGINSDIR\$MsuFileName" /quiet /norestart'
+    Pop $R0  # Get Error
+    Pop $R1  # Get stdout
+    ${IfNot} $R0 == 0
+        detailPrint "error: $R0"
+        detailPrint "output: $R2"
+    ${EndIf}
+
+    lbl_done:
+
+SectionEnd
+
 
 # Check and install Visual C++ redist packages
 # See http://blogs.msdn.com/b/astebner/archive/2009/01/29/9384143.aspx for more info
-Section -Prerequisites
+# Hidden section (-) to install VCRedist
+Section -install_vcredist
 
     Var /GLOBAL VcRedistName
     Var /GLOBAL VcRedistGuid
     Var /GLOBAL NeedVcRedist
-    Var /Global CheckVcRedist
+    Var /GLOBAL CheckVcRedist
     StrCpy $CheckVcRedist "False"
 
     # Visual C++ 2008 SP1 MFC Security Update redist packages
@@ -242,21 +338,13 @@ Section -Prerequisites
                 "$VcRedistName is currently not installed. Would you like to install?" \
                 /SD IDYES IDNO endVcRedist
 
-            # The Correct version of VCRedist is copied over by "build_pkg.bat"
-            SetOutPath "$INSTDIR\"
-            # This will throw an error on Py3 since we're no longer including VCRedist
-            # So, we'll add the /nonfatal switch
-            File /nonfatal "..\prereqs\vcredist.exe"
             # If an output variable is specified ($0 in the case below),
             # ExecWait sets the variable with the exit code (and only sets the
             # error flag if an error occurs; if an error occurs, the contents
             # of the user variable are undefined).
             # http://nsis.sourceforge.net/Reference/ExecWait
-            # /passive used by 2015 installer
-            # /qb! used by 2008 installer
-            # It just ignores the unrecognized switches...
             ClearErrors
-            ExecWait '"$INSTDIR\vcredist.exe" /qb! /quiet /norestart' $0
+            ExecWait '"$PLUGINSDIR\vcredist.exe" /qb!' $0
             IfErrors 0 CheckVcRedistErrorCode
                 MessageBox MB_OK \
                     "$VcRedistName failed to install. Try installing the package manually." \
@@ -399,8 +487,6 @@ Section -Post
 
     Push "C:\salt"
     Call AddToPath
-
-    Delete "$INSTDIR\vcredist.exe"
 
 SectionEnd
 


### PR DESCRIPTION
### What does this PR do?
Adds support to Universal C Runtime Libraries (UCRT) for Windows
Adds futures to the req.txt for OSX

### What issues does this PR fix or reference?
Found in testing

### Previous Behavior
On fresh versions of Windows 8.1 and below the minion would fail to start on Py3 installs due to missing Universal C Runtime Support
Also an issue with futures missing on Mac installations

### Tests written?
NA

### Commits signed with GPG?
Yes