### PR TITLE
Fix token_file creation using external auth with salt-key

### DIFF
--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -2522,7 +2522,7 @@ class SaltKeyOptionParser(six.with_metaclass(OptionParserMeta,
     process_config_dir._mixin_prio_ = ConfigDirMixIn._mixin_prio_
 
     def setup_config(self):
-        keys_config = config.master_config(self.get_config_file_path())
+        keys_config = config.client_config(self.get_config_file_path())
         if self.options.gen_keys:
             # Since we're generating the keys, some defaults can be assumed
             # or tweaked

--- a/tests/unit/utils/test_parsers.py
+++ b/tests/unit/utils/test_parsers.py
@@ -712,7 +712,7 @@ class SaltKeyOptionParserTestCase(LogSettingsParserTests):
         self.log_file = '/tmp/salt_key_parser_test'
         self.key_logfile = '/tmp/key_logfile'
         # Function to patch
-        self.config_func = 'salt.config.master_config'
+        self.config_func = 'salt.config.client_config'
 
         # Mock log setup
         self.setup_log()


### PR DESCRIPTION
### What does this PR do?
Fix salt-key external auth using token file. salt-key with `--auth` and `--make-token` options needs to create token file. Options `token_file` which is used as a path for token file is provided by `config.client_config`.

### What issues does this PR fix or reference?
#49222

### Previous Behavior
```
$ salt-key -T --auth=pam
username: example
password:
Error: 'token_file'

$ ls salt_token
ls: cannot access salt_token: No such file or directory
```

### New Behavior
```
$ salt-key -T --auth=pam
username: example
password:
Accepted Keys:
example1
example2
Denied Keys:
Unaccepted Keys:
Rejected Keys:

$ ls salt_token
salt_token
```

### Tests written?
No

### Commits signed with GPG?
No
