### PR TITLE
Make sure salt.defaults.exitcodes is imported in saltcli tests

### DIFF
--- a/tests/integration/shell/test_saltcli.py
+++ b/tests/integration/shell/test_saltcli.py
@@ -15,6 +15,7 @@ import logging
 import os
 
 # Import Salt libs
+import salt.defaults.exitcodes
 import salt.utils.files
 import salt.utils.path
 


### PR DESCRIPTION
https://github.com/saltstack/salt/pull/49217 added references to this value in the test module, but the exitcodes module isn't imported. It happened to already be imported elsewhere, but that was just a stroke of luck. This makes the import explicit to avoid changes elsewhere in the codebase causing these tests to suddenly start failing.