### PR TITLE
Use os.linesep.join instead of textwrap.dedent

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -3893,8 +3893,12 @@ def get_managed(
         parsed_path = os.path.join(
                 urlparsed_source.netloc, urlparsed_source.path).rstrip(os.sep)
         unix_local_source = parsed_scheme in ('file', '')
-
-        if unix_local_source:
+        if parsed_scheme == '':
+            parsed_path = sfn = source
+            if not os.path.exists(sfn):
+                msg = 'Local file source {0} does not exist'.format(sfn)
+                return '', {}, msg
+        elif parsed_scheme == 'file':
             sfn = parsed_path
             if not os.path.exists(sfn):
                 msg = 'Local file source {0} does not exist'.format(sfn)

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -2111,7 +2111,7 @@ def replace(path,
                 if prepend_if_not_found or append_if_not_found:
                     # Search for content, to avoid pre/appending the
                     # content if it was pre/appended in a previous run.
-                    if re.search(salt.utils.to_bytes('^{0}$'.format(re.escape(content))),
+                    if re.search(salt.utils.to_bytes('^{0}($|(?=\r\n))'.format(re.escape(content))),
                                  r_data,
                                  flags=flags_num):
                         # Content was found, so set found.

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -3886,7 +3886,10 @@ def get_managed(
     # If we have a source defined, let's figure out what the hash is
     if source:
         urlparsed_source = _urlparse(source)
-        parsed_scheme = urlparsed_source.scheme
+        if urlparsed_source.scheme in salt.utils.files.VALID_PROTOS:
+            parsed_scheme = urlparsed_source.scheme
+        else:
+            parsed_scheme = ''
         parsed_path = os.path.join(
                 urlparsed_source.netloc, urlparsed_source.path).rstrip(os.sep)
         unix_local_source = parsed_scheme in ('file', '')

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -2377,7 +2377,9 @@ def managed(name,
                     'contents_grains is not a string or list of strings, and '
                     'is not binary data. SLS is likely malformed.'
                 )
-            contents = os.linesep.join(validated_contents)
+            contents = os.linesep.join(
+                [line.rstrip('\n').rstrip('\r') for line in validated_contents]
+            )
             if contents_newline and not contents.endswith(os.linesep):
                 contents += os.linesep
         if template:

--- a/tests/integration/states/test_file.py
+++ b/tests/integration/states/test_file.py
@@ -844,13 +844,9 @@ class FileTest(ModuleCase, SaltReturnAssertsMixin):
         finally:
             shutil.rmtree(name, ignore_errors=True)
 
-    @skipIf(salt.utils.is_windows(), 'Skip on windows')
     def test_directory_clean_exclude(self):
         '''
         file.directory with clean=True and exclude_pat set
-
-        Skipped on windows because clean and exclude_pat not supported by
-        salt.sates.file._check_directory_win
         '''
         name = os.path.join(TMP, 'directory_clean_dir')
         if not os.path.isdir(name):
@@ -889,9 +885,13 @@ class FileTest(ModuleCase, SaltReturnAssertsMixin):
         finally:
             shutil.rmtree(name, ignore_errors=True)
 
+    @skipIf(salt.utils.is_windows(), 'Skip on windows')
     def test_test_directory_clean_exclude(self):
         '''
         file.directory with test=True, clean=True and exclude_pat set
+
+        Skipped on windows because clean and exclude_pat not supported by
+        salt.sates.file._check_directory_win
         '''
         name = os.path.join(TMP, 'directory_clean_dir')
         if not os.path.isdir(name):

--- a/tests/integration/states/test_file.py
+++ b/tests/integration/states/test_file.py
@@ -2624,31 +2624,31 @@ class FileTest(ModuleCase, SaltReturnAssertsMixin):
 class BlockreplaceTest(ModuleCase, SaltReturnAssertsMixin):
     marker_start = '# start'
     marker_end = '# end'
-    content = os.linesep.join([
+    content = six.text_type(os.linesep.join([
         'Line 1 of block',
         'Line 2 of block',
-        '']).decode('utf-8')
-    without_block = os.linesep.join([
+        '']))
+    without_block = six.text_type(os.linesep.join([
         'Hello world!',
         '',
         '# comment here',
-        '']).decode('utf-8')
-    with_non_matching_block = os.linesep.join([
+        '']))
+    with_non_matching_block = six.text_type(os.linesep.join([
         'Hello world!',
         '',
         '# start',
         'No match here',
         '# end',
         '# comment here',
-        '']).decode('utf-8')
-    with_non_matching_block_and_marker_end_not_after_newline = os.linesep.join([
+        '']))
+    with_non_matching_block_and_marker_end_not_after_newline = six.text_type(os.linesep.join([
         'Hello world!',
         '',
         '# start',
         'No match here# end',
         '# comment here',
-        '']).decode('utf-8')
-    with_matching_block = os.linesep.join([
+        '']))
+    with_matching_block = six.text_type(os.linesep.join([
         'Hello world!',
         '',
         '# start',
@@ -2656,8 +2656,8 @@ class BlockreplaceTest(ModuleCase, SaltReturnAssertsMixin):
         'Line 2 of block',
         '# end',
         '# comment here',
-        '']).decode('utf-8')
-    with_matching_block_and_extra_newline = os.linesep.join([
+        '']))
+    with_matching_block_and_extra_newline = six.text_type(os.linesep.join([
         'Hello world!',
         '',
         '# start',
@@ -2666,15 +2666,15 @@ class BlockreplaceTest(ModuleCase, SaltReturnAssertsMixin):
         '',
         '# end',
         '# comment here',
-        '']).decode('utf-8')
-    with_matching_block_and_marker_end_not_after_newline = os.linesep.join([
+        '']))
+    with_matching_block_and_marker_end_not_after_newline = six.text_type(os.linesep.join([
         'Hello world!',
         '',
         '# start',
         'Line 1 of block',
         'Line 2 of block# end',
         '# comment here',
-        '']).decode('utf-8')
+        '']))
     content_explicit_posix_newlines = ('Line 1 of block\n'
                                        'Line 2 of block\n')
     content_explicit_windows_newlines = ('Line 1 of block\r\n'

--- a/tests/integration/states/test_file.py
+++ b/tests/integration/states/test_file.py
@@ -5,7 +5,7 @@ Tests for the file state
 '''
 
 # Import python libs
-from __future__ import absolute_import
+from __future__ import absolute_import, unicode_literals
 import errno
 import glob
 import logging
@@ -2601,57 +2601,57 @@ class FileTest(ModuleCase, SaltReturnAssertsMixin):
 class BlockreplaceTest(ModuleCase, SaltReturnAssertsMixin):
     marker_start = '# start'
     marker_end = '# end'
-    content = textwrap.dedent('''\
-        Line 1 of block
-        Line 2 of block
-        ''')
-    without_block = textwrap.dedent('''\
-        Hello world!
-
-        # comment here
-        ''')
-    with_non_matching_block = textwrap.dedent('''\
-        Hello world!
-
-        # start
-        No match here
-        # end
-        # comment here
-        ''')
-    with_non_matching_block_and_marker_end_not_after_newline = textwrap.dedent('''\
-        Hello world!
-
-        # start
-        No match here# end
-        # comment here
-        ''')
-    with_matching_block = textwrap.dedent('''\
-        Hello world!
-
-        # start
-        Line 1 of block
-        Line 2 of block
-        # end
-        # comment here
-        ''')
-    with_matching_block_and_extra_newline = textwrap.dedent('''\
-        Hello world!
-
-        # start
-        Line 1 of block
-        Line 2 of block
-
-        # end
-        # comment here
-        ''')
-    with_matching_block_and_marker_end_not_after_newline = textwrap.dedent('''\
-        Hello world!
-
-        # start
-        Line 1 of block
-        Line 2 of block# end
-        # comment here
-        ''')
+    content = os.linesep.join([
+        'Line 1 of block',
+        'Line 2 of block',
+        ''])
+    without_block = os.linesep.join([
+        'Hello world!',
+        '',
+        '# comment here',
+        ''])
+    with_non_matching_block = os.linesep.join([
+        'Hello world!',
+        '',
+        '# start',
+        'No match here',
+        '# end',
+        '# comment here',
+        ''])
+    with_non_matching_block_and_marker_end_not_after_newline = os.linesep.join([
+        'Hello world!',
+        '',
+        '# start',
+        'No match here# end',
+        '# comment here',
+        ''])
+    with_matching_block = os.linesep.join([
+        'Hello world!',
+        '',
+        '# start',
+        'Line 1 of block',
+        'Line 2 of block',
+        '# end',
+        '# comment here',
+        ''])
+    with_matching_block_and_extra_newline = os.linesep.join([
+        'Hello world!',
+        '',
+        '# start',
+        'Line 1 of block',
+        'Line 2 of block',
+        '',
+        '# end',
+        '# comment here',
+        ''])
+    with_matching_block_and_marker_end_not_after_newline = os.linesep.join([
+        'Hello world!',
+        '',
+        '# start',
+        'Line 1 of block',
+        'Line 2 of block# end',
+        '# comment here',
+        ''])
     content_explicit_posix_newlines = ('Line 1 of block\n'
                                        'Line 2 of block\n')
     content_explicit_windows_newlines = ('Line 1 of block\r\n'

--- a/tests/integration/states/test_file.py
+++ b/tests/integration/states/test_file.py
@@ -30,7 +30,7 @@ from tests.support.helpers import (
     with_system_user_and_group,
     with_tempfile,
     Webserver,
-    destructiveTest
+    destructiveTest,
     dedent,
 )
 from tests.support.mixins import SaltReturnAssertsMixin

--- a/tests/integration/states/test_file.py
+++ b/tests/integration/states/test_file.py
@@ -363,7 +363,11 @@ class FileTest(ModuleCase, SaltReturnAssertsMixin):
         with salt.utils.fopen(grain_path, 'r') as fp_:
             file_contents = fp_.readlines()
 
-        self.assertTrue(re.match('^minion$', file_contents[0]))
+        if salt.utils.is_windows():
+            match = '^minion\r\n'
+        else:
+            match = '^minion\n'
+        self.assertTrue(re.match(match, file_contents[0]))
 
     def test_managed_file_with_pillar_sls(self):
         '''
@@ -591,6 +595,9 @@ class FileTest(ModuleCase, SaltReturnAssertsMixin):
         name = os.path.join(TMP, 'local_source_with_source_hash')
         local_path = os.path.join(FILES, 'file', 'base', 'grail', 'scene33')
         actual_hash = '567fd840bf1548edc35c48eb66cdd78bfdfcccff'
+        if salt.utils.is_windows():
+            # CRLF vs LF causes a differnt hash on windows
+            actual_hash = 'f658a0ec121d9c17088795afcc6ff3c43cb9842a'
         # Reverse the actual hash
         bad_hash = actual_hash[::-1]
 
@@ -673,6 +680,9 @@ class FileTest(ModuleCase, SaltReturnAssertsMixin):
                      '-{0}_|-managed'.format(name)
         local_path = os.path.join(FILES, 'file', 'base', 'hello_world.txt')
         actual_hash = 'c98c24b677eff44860afea6f493bbaec5bb1c4cbb209c6fc2bbb47f66ff2ad31'
+        if salt.utils.is_windows():
+            # CRLF vs LF causes a differnt hash on windows
+            actual_hash = '92b772380a3f8e27a93e57e6deeca6c01da07f5aadce78bb2fbb20de10a66925'
         uppercase_hash = actual_hash.upper()
 
         try:
@@ -834,9 +844,13 @@ class FileTest(ModuleCase, SaltReturnAssertsMixin):
         finally:
             shutil.rmtree(name, ignore_errors=True)
 
+    @skipIf(salt.utils.is_windows(), 'Skip on windows')
     def test_directory_clean_exclude(self):
         '''
         file.directory with clean=True and exclude_pat set
+
+        Skipped on windows because clean and exclude_pat not supported by
+        salt.sates.file._check_directory_win
         '''
         name = os.path.join(TMP, 'directory_clean_dir')
         if not os.path.isdir(name):
@@ -1206,6 +1220,7 @@ class FileTest(ModuleCase, SaltReturnAssertsMixin):
         finally:
             shutil.rmtree(name, ignore_errors=True)
 
+    @skipIf(salt.utils.is_windows(), 'Skip on windows')
     def test_recurse_issue_34945(self):
         '''
         This tests the case where the source dir for the file.recurse state
@@ -1220,6 +1235,8 @@ class FileTest(ModuleCase, SaltReturnAssertsMixin):
         repaired.
 
         This was fixed in https://github.com/saltstack/salt/pull/35309
+
+        Skipped on windows because dir_mode is not supported.
         '''
         dir_mode = '2775'
         issue_dir = 'issue-34945'
@@ -1458,7 +1475,7 @@ class FileTest(ModuleCase, SaltReturnAssertsMixin):
         ret = []
         for x in range(0, 3):
             ret.append(self.run_state('file.replace',
-                name=path_test, pattern='^#foo=bar$', repl='foo=salt', append_if_not_found=True))
+                name=path_test, pattern='^#foo=bar($|(?=\r\n))', repl='foo=salt', append_if_not_found=True))
 
         try:
             # ensure, the resulting file contains the expected lines
@@ -1550,16 +1567,18 @@ class FileTest(ModuleCase, SaltReturnAssertsMixin):
         with salt.utils.fopen(path_test, 'r') as fp_:
             serialized_file = fp_.read()
 
-        expected_file = '''{
-  "a_list": [
-    "first_element",
-    "second_element"
-  ],
-  "description": "A basic test",
-  "finally": "the last item",
-  "name": "naive"
-}
-'''
+        expected_file = os.linesep.join([
+            '{',
+            '  "a_list": [',
+            '    "first_element",',
+            '    "second_element"',
+            '  ],',
+            '  "description": "A basic test",',
+            '  "finally": "the last item",',
+            '  "name": "naive"',
+            '}',
+            '',
+        ])
         self.assertEqual(serialized_file, expected_file)
 
     def test_replace_issue_18841_omit_backup(self):
@@ -2067,6 +2086,10 @@ class FileTest(ModuleCase, SaltReturnAssertsMixin):
     def test_issue_8343_accumulated_require_in(self):
         template_path = os.path.join(TMP_STATE_TREE, 'issue-8343.sls')
         testcase_filedest = os.path.join(TMP, 'issue-8343.txt')
+        if os.path.exists(template_path):
+            os.remove(template_path)
+        if os.path.exists(testcase_filedest):
+            os.remove(testcase_filedest)
         sls_template = [
             '{0}:',
             '  file.managed:',
@@ -3809,7 +3832,11 @@ class RemoteFileTest(ModuleCase, SaltReturnAssertsMixin):
         cls.webserver = Webserver()
         cls.webserver.start()
         cls.source = cls.webserver.url('grail/scene33')
-        cls.source_hash = 'd2feb3beb323c79fc7a0f44f1408b4a3'
+        if salt.utils.is_windows():
+            # CRLF vs LF causes a differnt hash on windows
+            cls.source_hash = '21438b3d5fd2c0028bcab92f7824dc69'
+        else:
+            cls.source_hash = 'd2feb3beb323c79fc7a0f44f1408b4a3'
 
     @classmethod
     def tearDownClass(cls):

--- a/tests/integration/states/test_file.py
+++ b/tests/integration/states/test_file.py
@@ -5,7 +5,7 @@ Tests for the file state
 '''
 
 # Import python libs
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import
 import errno
 import glob
 import logging
@@ -2627,12 +2627,12 @@ class BlockreplaceTest(ModuleCase, SaltReturnAssertsMixin):
     content = os.linesep.join([
         'Line 1 of block',
         'Line 2 of block',
-        ''])
+        '']).decode('utf-8')
     without_block = os.linesep.join([
         'Hello world!',
         '',
         '# comment here',
-        ''])
+        '']).decode('utf-8')
     with_non_matching_block = os.linesep.join([
         'Hello world!',
         '',
@@ -2640,14 +2640,14 @@ class BlockreplaceTest(ModuleCase, SaltReturnAssertsMixin):
         'No match here',
         '# end',
         '# comment here',
-        ''])
+        '']).decode('utf-8')
     with_non_matching_block_and_marker_end_not_after_newline = os.linesep.join([
         'Hello world!',
         '',
         '# start',
         'No match here# end',
         '# comment here',
-        ''])
+        '']).decode('utf-8')
     with_matching_block = os.linesep.join([
         'Hello world!',
         '',
@@ -2656,7 +2656,7 @@ class BlockreplaceTest(ModuleCase, SaltReturnAssertsMixin):
         'Line 2 of block',
         '# end',
         '# comment here',
-        ''])
+        '']).decode('utf-8')
     with_matching_block_and_extra_newline = os.linesep.join([
         'Hello world!',
         '',
@@ -2666,7 +2666,7 @@ class BlockreplaceTest(ModuleCase, SaltReturnAssertsMixin):
         '',
         '# end',
         '# comment here',
-        ''])
+        '']).decode('utf-8')
     with_matching_block_and_marker_end_not_after_newline = os.linesep.join([
         'Hello world!',
         '',
@@ -2674,7 +2674,7 @@ class BlockreplaceTest(ModuleCase, SaltReturnAssertsMixin):
         'Line 1 of block',
         'Line 2 of block# end',
         '# comment here',
-        ''])
+        '']).decode('utf-8')
     content_explicit_posix_newlines = ('Line 1 of block\n'
                                        'Line 2 of block\n')
     content_explicit_windows_newlines = ('Line 1 of block\r\n'

--- a/tests/integration/states/test_file.py
+++ b/tests/integration/states/test_file.py
@@ -31,6 +31,7 @@ from tests.support.helpers import (
     with_tempfile,
     Webserver,
     destructiveTest
+    dedent,
 )
 from tests.support.mixins import SaltReturnAssertsMixin
 
@@ -2624,57 +2625,57 @@ class FileTest(ModuleCase, SaltReturnAssertsMixin):
 class BlockreplaceTest(ModuleCase, SaltReturnAssertsMixin):
     marker_start = '# start'
     marker_end = '# end'
-    content = six.text_type(os.linesep.join([
-        'Line 1 of block',
-        'Line 2 of block',
-        '']))
-    without_block = six.text_type(os.linesep.join([
-        'Hello world!',
-        '',
-        '# comment here',
-        '']))
-    with_non_matching_block = six.text_type(os.linesep.join([
-        'Hello world!',
-        '',
-        '# start',
-        'No match here',
-        '# end',
-        '# comment here',
-        '']))
-    with_non_matching_block_and_marker_end_not_after_newline = six.text_type(os.linesep.join([
-        'Hello world!',
-        '',
-        '# start',
-        'No match here# end',
-        '# comment here',
-        '']))
-    with_matching_block = six.text_type(os.linesep.join([
-        'Hello world!',
-        '',
-        '# start',
-        'Line 1 of block',
-        'Line 2 of block',
-        '# end',
-        '# comment here',
-        '']))
-    with_matching_block_and_extra_newline = six.text_type(os.linesep.join([
-        'Hello world!',
-        '',
-        '# start',
-        'Line 1 of block',
-        'Line 2 of block',
-        '',
-        '# end',
-        '# comment here',
-        '']))
-    with_matching_block_and_marker_end_not_after_newline = six.text_type(os.linesep.join([
-        'Hello world!',
-        '',
-        '# start',
-        'Line 1 of block',
-        'Line 2 of block# end',
-        '# comment here',
-        '']))
+    content = dedent(six.text_type('''\
+        Line 1 of block
+        Line 2 of block
+        '''))
+    without_block = dedent(six.text_type('''\
+        Hello world!
+
+        # comment here
+        '''))
+    with_non_matching_block = dedent(six.text_type('''\
+        Hello world!
+
+        # start
+        No match here
+        # end
+        # comment here
+        '''))
+    with_non_matching_block_and_marker_end_not_after_newline = dedent(six.text_type('''\
+        Hello world!
+
+        # start
+        No match here# end
+        # comment here
+        '''))
+    with_matching_block = dedent(six.text_type('''\
+        Hello world!
+
+        # start
+        Line 1 of block
+        Line 2 of block
+        # end
+        # comment here
+        '''))
+    with_matching_block_and_extra_newline = dedent(six.text_type('''\
+        Hello world!
+
+        # start
+        Line 1 of block
+        Line 2 of block
+
+        # end
+        # comment here
+        '''))
+    with_matching_block_and_marker_end_not_after_newline = dedent(six.text_type('''\
+        Hello world!
+
+        # start
+        Line 1 of block
+        Line 2 of block# end
+        # comment here
+        '''))
     content_explicit_posix_newlines = ('Line 1 of block\n'
                                        'Line 2 of block\n')
     content_explicit_windows_newlines = ('Line 1 of block\r\n'

--- a/tests/support/helpers.py
+++ b/tests/support/helpers.py
@@ -25,6 +25,7 @@ import socket
 import subprocess
 import sys
 import tempfile
+import textwrap
 import threading
 import time
 import tornado.ioloop

--- a/tests/support/helpers.py
+++ b/tests/support/helpers.py
@@ -1574,5 +1574,5 @@ def dedent(text, linesep=os.linesep):
     if isinstance(text, six.text_type):
         linesep = salt.utils.stringutils.to_unicode(linesep)
     else:
-        linesep = salt.utils.stringutils.to_bytes(linesep)
+        linesep = salt.utils.stringutils.to_str(linesep)
     return linesep.join(textwrap.dedent(text).splitlines())

--- a/tests/support/helpers.py
+++ b/tests/support/helpers.py
@@ -1565,3 +1565,14 @@ def this_user():
     if salt.utils.is_windows():
         return salt.utils.win_functions.get_current_user(with_domain=False)
     return pwd.getpwuid(os.getuid())[0]
+
+
+def dedent(text, linesep=os.linesep):
+    '''
+    A wrapper around textwrap.dedent that also sets line endings.
+    '''
+    if isinstance(text, six.text_type):
+        linesep = salt.utils.stringutils.to_unicode(linesep)
+    else:
+        linesep = salt.utils.stringutils.to_bytes(linesep)
+    return linesep.join(textwrap.dedent(text).splitlines())

--- a/tests/unit/states/test_file.py
+++ b/tests/unit/states/test_file.py
@@ -769,6 +769,8 @@ class TestFileState(TestCase, LoaderModuleMockMixin):
         name = '/etc/testdir'
         user = 'salt'
         group = 'saltstack'
+        if salt.utils.is_windows():
+            name = name.replace('/', '\\')
 
         ret = {'name': name,
                'result': False,
@@ -865,12 +867,12 @@ class TestFileState(TestCase, LoaderModuleMockMixin):
                         else:
                             comt = ('The following files will be changed:\n{0}:'
                                     ' directory - new\n'.format(name))
-                        p_chg = {'/etc/testdir': {'directory': 'new'}}
+                        p_chg = {name: {'directory': 'new'}}
                         ret.update({
                             'comment': comt,
                             'result': None,
                             'pchanges': p_chg,
-                            'changes': {'/etc/testdir': {'directory': 'new'}}
+                            'changes': {name: {'directory': 'new'}}
                         })
                         self.assertDictEqual(filestate.directory(name,
                                                                  user=user,
@@ -917,6 +919,8 @@ class TestFileState(TestCase, LoaderModuleMockMixin):
         source = 'salt://code/flask'
         user = 'salt'
         group = 'saltstack'
+        if salt.utils.is_windows():
+            name = name.replace('/', '\\')
 
         ret = {'name': name,
                'result': False,


### PR DESCRIPTION
### What does this PR do?
Uses `os.linesep.join` instead of `textwrap.dedent` to create the text strings. The problem with `textwrap.dedent` is that it always uses `posix-style` line endings.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/pull/48960

### Tests written?
Yes

### Commits signed with GPG?
Yes