### PR TITLE
Allow compound matching in eauth config expressions

### DIFF
--- a/salt/utils/minions.py
+++ b/salt/utils/minions.py
@@ -670,7 +670,7 @@ class CkMinions(object):
                'S': 'ipcidr',
                'E': 'pcre',
                'N': 'node',
-               None: 'glob'}
+               None: 'compound'}
 
         target_info = parse_target(auth_entry)
         if not target_info:


### PR DESCRIPTION
When we try to match the configured expression, we look for a match type (e.g. `I@`, `G@`, etc.) at the beginning, and when we don't find one we were falling back to a glob. This changes the fallback to compound so that we can support compound matches. Note that the compound matching engine will act just like the glob match engine when the host passed to it is a single minion ID glob, so using compound as the fallback gets you glob matching for free.

Fixes #32737