### PR TITLE
Use yaml's safe_dump in windows ec2 tests

### DIFF
--- a/tests/integration/cloud/providers/test_ec2.py
+++ b/tests/integration/cloud/providers/test_ec2.py
@@ -121,7 +121,7 @@ class EC2Test(ShellCase):
             conf = yaml.safe_load(fp)
         conf[name].update(data)
         with salt.utils.files.fopen(conf_path, 'w') as fp:
-            yaml.dump(conf, fp)
+            salt.utils.yaml.safe_dump(conf, fp)
 
     def copy_file(self, name):
         '''

--- a/tests/integration/cloud/providers/test_ec2.py
+++ b/tests/integration/cloud/providers/test_ec2.py
@@ -12,6 +12,7 @@ import yaml
 from salt.config import cloud_providers_config
 import salt.utils.cloud
 import salt.utils.files
+import salt.utils.yaml
 
 # Import Salt Testing Libs
 from tests.support.case import ShellCase


### PR DESCRIPTION
### What does this PR do?
the tests:

```
integration.cloud.providers.test_ec2.EC2Test.test_win2012r2_winrm
integration.cloud.providers.test_ec2.EC2Test.test_win2016_winrm
```

are failing because a `!!python/unicode`  tag is getting added to the configuration file. So when we go to the next test and it tries to read the file we see this error:

```
ConstructorError: could not determine a constructor for the tag 'tag:yaml.org,2002:python/unicode'
```

changing to a safe_dump to make sure we are not producing python tags.

### What issues does this PR fix or reference?
fixes https://github.com/saltstack/salt-jenkins/issues/1064
