### PR TITLE
Don't silently catch SystemExit

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -2948,7 +2948,7 @@ class SyndicManager(MinionBase):
                 if auth_wait < self.max_auth_wait:
                     auth_wait += self.auth_wait
                 yield tornado.gen.sleep(auth_wait)  # TODO: log?
-            except KeyboardInterrupt:
+            except (KeyboardInterrupt, SystemExit):
                 raise
             except Exception:
                 failed = True

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -2950,7 +2950,7 @@ class SyndicManager(MinionBase):
                 yield tornado.gen.sleep(auth_wait)  # TODO: log?
             except KeyboardInterrupt:
                 raise
-            except:  # pylint: disable=W0702
+            except Exception:
                 failed = True
                 log.critical(
                     'Unexpected error while connecting to %s',


### PR DESCRIPTION
In `integration.shell.test_syndic.SyndicTest.test_issue_7754`, we use `run_script` to start up a syndic and make sure that it starts with specific logging configuration. `run_script` is configured to timeout after 5 seconds, at which time the process is killed via SIGTERM. Our signal handler then raises a `SystemExit` to kill the Python process. However, if this `SystemExit` is raised while `_connect_syndic()` is attempting to connect to the master-of-masters, it gets swallowed and the Python process never exits, causing the test suite to hang indefinitely (until test-kitchen kills it).

This PR ensures we re-raise a `SystemExit` if it is caught during this connection attempt.

In addition, it removes the bare `except` that was being used in this same `try` block. Friends don't let friends use bare excepts.


Refs: https://github.com/saltstack/salt-jenkins/issues/1078