### PR TITLE
Revert newline translation change

### DIFF
--- a/tests/unit/fileserver/test_roots.py
+++ b/tests/unit/fileserver/test_roots.py
@@ -68,7 +68,7 @@ class RootsTest(TestCase, AdaptedConfigurationTestCaseMixin, LoaderModuleMockMix
         with salt.utils.files.fopen(full_path_to_file, 'rb') as s_fp:
             with salt.utils.files.fopen(os.path.join(cls.tmp_dir, 'testfile'), 'wb') as d_fp:
                 for line in s_fp:
-                    d_fp.write(line.rstrip(b'\n').rstrip(b'\r') + b'\n')
+                    d_fp.write(line)
 
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
### What does this PR do?

Revert un-needed newline translation. On windows, newlines will be CRLF since we added unix2dos to kitchen.

fixes https://jenkinsci.saltstack.com/job/2018.3/job/salt-windows-2016-py2/28/#showFailuresLink
```
unit.fileserver.test_roots.RootsTest.test_file_hash
unit.fileserver.test_roots.RootsTest.test_serve_file
```


### Tests written?

No - Fixing tests

### Commits signed with GPG?

Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
