### PR TITLE
Test fixes: unit.fileserver.test_gitfs

### DIFF
--- a/salt/utils/files.py
+++ b/salt/utils/files.py
@@ -547,8 +547,11 @@ def rm_rf(path):
     if os.path.islink(path) or not os.path.isdir(path):
         os.remove(path)
     else:
-        if six.PY2 and salt.utils.platform.is_windows() and isinstance(path, six.string_types):
-            path = path.decode('utf-8')
+        if salt.utils.platform.is_windows():
+            try:
+                path = salt.utils.stringutils.to_unicode(path)
+            except TypeError:
+                pass
         shutil.rmtree(path, onerror=_onerror)
 
 

--- a/salt/utils/files.py
+++ b/salt/utils/files.py
@@ -547,6 +547,8 @@ def rm_rf(path):
     if os.path.islink(path) or not os.path.isdir(path):
         os.remove(path)
     else:
+        if six.PY2 and salt.utils.platform.is_windows() and isinstance(path, six.string_types):
+            path = path.decode('utf-8')
         shutil.rmtree(path, onerror=_onerror)
 
 

--- a/tests/unit/fileserver/test_gitfs.py
+++ b/tests/unit/fileserver/test_gitfs.py
@@ -62,6 +62,8 @@ log = logging.getLogger(__name__)
 
 TMP_SOCK_DIR = tempfile.mkdtemp(dir=TMP)
 TMP_REPO_DIR = os.path.join(TMP, 'gitfs_root')
+if salt.utils.platform.is_windows():
+    TMP_REPO_DIR = TMP_REPO_DIR.replace('\\', '/')
 INTEGRATION_BASE_FILES = os.path.join(FILES, 'file', 'base')
 UNICODE_FILENAME = 'питон.txt'
 UNICODE_DIRNAME = UNICODE_ENVNAME = 'соль'
@@ -422,6 +424,7 @@ class GitFSTestBase(object):
 
             # Add a tag
             repo.create_tag(TAG_NAME, 'HEAD')
+            repo.close()
         finally:
             if orig_username is not None:
                 os.environ[username_key] = orig_username
@@ -436,10 +439,12 @@ class GitFSTestBase(object):
         '''
         for path in (cls.tmp_cachedir, cls.tmp_sock_dir, TMP_REPO_DIR):
             try:
-                shutil.rmtree(path, onerror=_rmtree_error)
+                salt.utils.files.rm_rf(path)
             except OSError as exc:
                 if exc.errno != errno.EEXIST:
                     raise
+            except Exception:
+                log.exception("Exception encountered durring recursive remove: %s", path)
 
     def setUp(self):
         '''
@@ -457,7 +462,7 @@ class GitFSTestBase(object):
         _clear_instance_map()
         for subdir in ('gitfs', 'file_lists'):
             try:
-                shutil.rmtree(os.path.join(self.tmp_cachedir, subdir))
+                salt.utils.files.rm_rf(os.path.join(self.tmp_cachedir, subdir))
             except OSError as exc:
                 if exc.errno != errno.ENOENT:
                     raise

--- a/tests/unit/fileserver/test_gitfs.py
+++ b/tests/unit/fileserver/test_gitfs.py
@@ -424,7 +424,9 @@ class GitFSTestBase(object):
 
             # Add a tag
             repo.create_tag(TAG_NAME, 'HEAD')
-            repo.close()
+            # Older GitPython versions do not have a close method.
+            if hasattr(repo, 'close'):
+                repo.close()
         finally:
             if orig_username is not None:
                 os.environ[username_key] = orig_username
@@ -443,8 +445,6 @@ class GitFSTestBase(object):
             except OSError as exc:
                 if exc.errno != errno.EEXIST:
                     raise
-            except Exception:
-                log.exception("Exception encountered durring recursive remove: %s", path)
 
     def setUp(self):
         '''


### PR DESCRIPTION
### What does this PR do?

Multiple fixes for unit.fileserver.test_gitfs:
- file:// source repos need all forward slashes
- Use `salt.utils.files.rm_rf` for recursive removes
- Patch `salt.utils.files.rm_rf` to work with unicode filenames on windows python 2

Fixes:
```
unit.fileserver.test_gitfs.GitPythonTest.test_dir_list
unit.fileserver.test_gitfs.GitPythonTest.test_disable_saltenv_mapping_global_with_mapping_defined_globally
unit.fileserver.test_gitfs.GitPythonTest.test_disable_saltenv_mapping_global_with_mapping_defined_per_remote
unit.fileserver.test_gitfs.GitPythonTest.test_disable_saltenv_mapping_per_remote_with_mapping_defined_globally
unit.fileserver.test_gitfs.GitPythonTest.test_disable_saltenv_mapping_per_remote_with_mapping_defined_per_remote
unit.fileserver.test_gitfs.GitPythonTest.test_envs
unit.fileserver.test_gitfs.GitPythonTest.test_file_list
unit.fileserver.test_gitfs.GitPythonTest.test_ref_types_global
unit.fileserver.test_gitfs.GitPythonTest.test_ref_types_per_remote
```
https://jenkinsci.saltstack.com/job/2018.3/job/salt-windows-2016-py2/28/#showFailuresLink



### Tests written?

Yes - fixing tests

### Commits signed with GPG?

Yes