### PR TITLE
Added downloadonly to zypper upgrade

### DIFF
--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -1370,6 +1370,7 @@ def upgrade(refresh=True,
             fromrepo=None,
             novendorchange=False,
             skip_verify=False,
+            downloadonly=None,
             **kwargs):  # pylint: disable=unused-argument
     '''
     .. versionchanged:: 2015.8.12,2016.3.3,2016.11.0
@@ -1409,6 +1410,10 @@ def upgrade(refresh=True,
     skip_verify
         Skip the GPG verification check (e.g., ``--no-gpg-checks``)
 
+    downloadonly
+        Only download packages, but do not upgrade. Cached in ``/var/cache/zypp``.
+        Allows for pre-caching of packages before upgrade.
+
     Returns a dictionary containing the changes:
 
     .. code-block:: python
@@ -1425,6 +1430,9 @@ def upgrade(refresh=True,
         salt '*' pkg.upgrade dist-upgrade=True dryrun=True
     '''
     cmd_update = (['dist-upgrade'] if dist_upgrade else ['update']) + ['--auto-agree-with-licenses']
+
+    if downloadonly:
+        cmd_update.append('--download-only')
 
     if skip_verify:
         # The '--no-gpg-checks' needs to be placed before the Zypper command.


### PR DESCRIPTION
### What does this PR do?

This PR adds a downloadonly option for the pre-caching of updates so that packages will
be cached before update.

### What issues does this PR fix or reference?

Not being able to pre-cache packages even though functionality is already in zypper binary.

### Previous Behavior
No download only option

### New Behavior
Updates and dist updates now support download only of packages

### Tests written?

No

### Commits signed with GPG?

No

### Versions Report

```
salt --versions-report
Salt Version:
           Salt: 2018.3.0
 
Dependency Versions:
           cffi: 1.5.2
       cherrypy: 3.6.0
       dateutil: 2.4.2
      docker-py: Not Installed
          gitdb: Not Installed
      gitpython: Not Installed
          ioflo: Not Installed
         Jinja2: 2.8
        libgit2: 0.24.0
        libnacl: Not Installed
       M2Crypto: 0.21.1
           Mako: Not Installed
   msgpack-pure: Not Installed
 msgpack-python: 0.4.6
   mysql-python: Not Installed
      pycparser: 2.10
       pycrypto: 2.6.1
   pycryptodome: Not Installed
         pygit2: 0.24.0
         Python: 2.7.13 (default, Jan 11 2017, 10:56:06) [GCC]
   python-gnupg: Not Installed
         PyYAML: 3.12
          PyZMQ: 14.0.0
           RAET: Not Installed
          smmap: Not Installed
        timelib: Not Installed
        Tornado: 4.2.1
            ZMQ: 4.0.4
 
System Versions:
           dist: SuSE 12 x86_64
         locale: UTF-8
        machine: x86_64
        release: 4.4.140-94.42-default
         system: Linux
        version: SUSE Linux Enterprise Server  12 x86_64
 

```
