### PR TITLE
skip ID 7 for vmware hard drives

### DIFF
--- a/salt/cloud/clouds/vmware.py
+++ b/salt/cloud/clouds/vmware.py
@@ -674,6 +674,19 @@ def _get_size_spec(device, size_gb=None, size_kb=None):
     return disk_spec
 
 
+def _iter_disk_unit_number(unit_number):
+    '''
+    Apparently vmware reserves ID 7 for SCSI controllers, so we cannot specify
+    hard drives for 7.
+
+    Skip 7 to make sure.
+    '''
+    unit_number += 1
+    if unit_number == 7:
+        unit_number += 1
+    return unit_number
+
+
 def _manage_devices(devices, vm=None, container_ref=None, new_vm_name=None):
     unit_number = 0
     bus_number = 0
@@ -695,7 +708,7 @@ def _manage_devices(devices, vm=None, container_ref=None, new_vm_name=None):
                 # this is a hard disk
                 if 'disk' in list(devices.keys()):
                     # there is atleast one disk specified to be created/configured
-                    unit_number += 1
+                    unit_number = _iter_disk_unit_number(unit_number)
                     existing_disks_label.append(device.deviceInfo.label)
                     if device.deviceInfo.label in list(devices['disk'].keys()):
                         disk_spec = None
@@ -862,7 +875,7 @@ def _manage_devices(devices, vm=None, container_ref=None, new_vm_name=None):
                         break
 
             device_specs.append(disk_spec)
-            unit_number += 1
+            unit_number = _iter_disk_unit_number(unit_number)
 
     if 'cd' in list(devices.keys()):
         cd_drives_to_create = list(set(devices['cd'].keys()) - set(existing_cd_drives_label))


### PR DESCRIPTION
### What does this PR do?

Skip 7 as the id for vmware hard disks, because it is reserved to the SCSI Controller

Same from our friends.

https://github.com/ansible/ansible/blob/devel/lib/ansible/modules/cloud/vmware/vmware_guest.py#L670

### Tests written?

Yes

### Commits signed with GPG?

Yes