### PR TITLE
extend #48588 to cover SyncAuth class

### DIFF
--- a/salt/crypt.py
+++ b/salt/crypt.py
@@ -1097,9 +1097,17 @@ class SAuth(AsyncAuth):
             creds = self.sign_in(channel=channel)
             if creds == 'retry':
                 if self.opts.get('caller'):
-                    print('Minion failed to authenticate with the master, '
-                          'has the minion key been accepted?')
-                    sys.exit(2)
+                    # We have a list of masters, so we should break
+                    # and try the next one in the list.
+                    if self.opts.get('local_masters', None):
+                        error = SaltClientError('Minion failed to authenticate'
+                                                ' with the master, has the '
+                                                'minion key been accepted?')
+                        break
+                    else:
+                        print('Minion failed to authenticate with the master, '
+                              'has the minion key been accepted?')
+                        sys.exit(2)
                 if acceptance_wait_time:
                     log.info('Waiting {0} seconds before retry.'.format(acceptance_wait_time))
                     time.sleep(acceptance_wait_time)


### PR DESCRIPTION
### What does this PR do?
The original fix in #48588 was only covered asyncauth, but the syncauth method overrode the fix. This patch duplicates it so behavior should be consistent in both codepaths.

### What issues does this PR fix or reference?
#48415

### Tests written?
No

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
