### PR TITLE
Fix failing unit file module unit tests

### DIFF
--- a/tests/unit/modules/test_file.py
+++ b/tests/unit/modules/test_file.py
@@ -527,7 +527,7 @@ class FileBlockReplaceTestCase(TestCase, LoaderModuleMockMixin):
         )
 
 
-@skipIf(salt.platform.is_windows(), 'Skip on windows')
+@skipIf(salt.utils.platform.is_windows(), 'Skip on windows')
 class FileGrepTestCase(TestCase, LoaderModuleMockMixin):
     def setup_loader_modules(self):
         return {


### PR DESCRIPTION
This just looks to have been incorrectly handled in a merge-forward.