### PR TITLE
Add async helper to test_sock_path_len

### DIFF
--- a/tests/unit/test_minion.py
+++ b/tests/unit/test_minion.py
@@ -19,7 +19,9 @@ import salt.utils.event as event
 from salt.exceptions import SaltSystemExit
 import salt.syspaths
 import tornado
+import tornado.testing
 from salt.ext.six.moves import range
+
 
 __opts__ = {}
 
@@ -101,33 +103,6 @@ class MinionTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
                                                          'master_uri': 'tcp://127.0.0.1:4555',
                                                          'source_ip': '111.1.0.1',
                                                          'master_ip': '127.0.0.1'}
-
-    @skip_if_not_root
-    def test_sock_path_len(self):
-        '''
-        This tests whether or not a larger hash causes the sock path to exceed
-        the system's max sock path length. See the below link for more
-        information.
-
-        https://github.com/saltstack/salt/issues/12172#issuecomment-43903643
-        '''
-        opts = {
-            'id': 'salt-testing',
-            'hash_type': 'sha512',
-            'sock_dir': os.path.join(salt.syspaths.SOCK_DIR, 'minion'),
-            'extension_modules': ''
-        }
-        with patch.dict(__opts__, opts):
-            try:
-                event_publisher = event.AsyncEventPublisher(__opts__)
-                result = True
-            except ValueError:
-                #  There are rare cases where we operate a closed socket, especially in containers.
-                # In this case, don't fail the test because we'll catch it down the road.
-                result = True
-            except SaltSystemExit:
-                result = False
-        self.assertTrue(result)
 
     # Tests for _handle_decoded_payload in the salt.minion.Minion() class: 3
 
@@ -306,3 +281,34 @@ class MinionTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
                 self.assertTrue('beacons' not in minion.periodic_callbacks)
             finally:
                 minion.destroy()
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class MinionAsyncTestCase(TestCase, AdaptedConfigurationTestCaseMixin, tornado.testing.AsyncTestCase):
+
+    @skip_if_not_root
+    def test_sock_path_len(self):
+        '''
+        This tests whether or not a larger hash causes the sock path to exceed
+        the system's max sock path length. See the below link for more
+        information.
+
+        https://github.com/saltstack/salt/issues/12172#issuecomment-43903643
+        '''
+        opts = {
+            'id': 'salt-testing',
+            'hash_type': 'sha512',
+            'sock_dir': os.path.join(salt.syspaths.SOCK_DIR, 'minion'),
+            'extension_modules': ''
+        }
+        with patch.dict(__opts__, opts):
+            try:
+                event_publisher = event.AsyncEventPublisher(__opts__)
+                result = True
+            except ValueError:
+                #  There are rare cases where we operate a closed socket, especially in containers.
+                # In this case, don't fail the test because we'll catch it down the road.
+                result = True
+            except SaltSystemExit:
+                result = False
+        self.assertTrue(result)


### PR DESCRIPTION
### What does this PR do?

This test function is causing another test:

unit.utils.test_event.TestAsyncEventPublisher.test_event_subscription

To fail with `Async operation timed out after 5 seconds`, Adding the
tornado Async test helper so that both tests pass.

https://jenkinsci.saltstack.com/job/2018.3/job/salt-windows-2016-py2/lastCompletedBuild/testReport/unit.utils.test_event/TestAsyncEventPublisher/test_event_subscription/

### Tests written?

No

### Commits signed with GPG?

Yes