### PR TITLE
Add 64 bit binaries for KB2999226 to the x86 installer

### DIFF
--- a/pkg/windows/build_pkg.bat
+++ b/pkg/windows/build_pkg.bat
@@ -138,25 +138,39 @@ If %Python%==2 goto get_vcredist
 :: For PY 3, include KB2999226
 @echo Copying KB2999226 to Prerequisites
 @echo ----------------------------------------------------------------------
-If Defined ProgramFiles(x86) (
-    set Url60=http://repo.saltstack.com/windows/dependencies/64/ucrt/Windows6.0-KB2999226-x64.msu
-    set Name60=Windows6.0-KB2999226-x64.msu
-    set Url61=http://repo.saltstack.com/windows/dependencies/64/ucrt/Windows6.1-KB2999226-x64.msu
-    set Name61=Windows6.1-KB2999226-x64.msu
-    set Url80=http://repo.saltstack.com/windows/dependencies/64/ucrt/Windows8-RT-KB2999226-x64.msu
-    set Name80=Windows8-RT-KB2999226-x64.msu
-    set Url81=http://repo.saltstack.com/windows/dependencies/64/ucrt/Windows8.1-KB2999226-x64.msu
-    set Name81=Windows8.1-KB2999226-x64.msu
-) Else (
-    set Url60=http://repo.saltstack.com/windows/dependencies/32/ucrt/Windows6.0-KB2999226-x86.msu
-    set Name60=Windows6.0-KB2999226-x86.msu
-    set Url61=http://repo.saltstack.com/windows/dependencies/32/ucrt/Windows6.1-KB2999226-x86.msu
-    set Name61=Windows6.1-KB2999226-x86.msu
-    set Url80=http://repo.saltstack.com/windows/dependencies/32/ucrt/Windows8-RT-KB2999226-x86.msu
-    set Name80=Windows8-RT-KB2999226-x86.msu
-    set Url81=http://repo.saltstack.com/windows/dependencies/32/ucrt/Windows8.1-KB2999226-x86.msu
-    set Name81=Windows8.1-KB2999226-x86.msu
-)
+:: 64 bit binaries required for AMD64 and x86
+:: Copy down the 64 bit binaries
+set Url60=http://repo.saltstack.com/windows/dependencies/64/ucrt/Windows6.0-KB2999226-x64.msu
+set Name60=Windows6.0-KB2999226-x64.msu
+set Url61=http://repo.saltstack.com/windows/dependencies/64/ucrt/Windows6.1-KB2999226-x64.msu
+set Name61=Windows6.1-KB2999226-x64.msu
+set Url80=http://repo.saltstack.com/windows/dependencies/64/ucrt/Windows8-RT-KB2999226-x64.msu
+set Name80=Windows8-RT-KB2999226-x64.msu
+set Url81=http://repo.saltstack.com/windows/dependencies/64/ucrt/Windows8.1-KB2999226-x64.msu
+set Name81=Windows8.1-KB2999226-x64.msu
+@echo - Downloading %Name60%
+powershell -ExecutionPolicy RemoteSigned -File download_url_file.ps1 -url %Url60% -file "%PreDir%\%Name60%"
+@echo - Downloading %Name61%
+powershell -ExecutionPolicy RemoteSigned -File download_url_file.ps1 -url %Url61% -file "%PreDir%\%Name61%"
+@echo - Downloading %Name80%
+powershell -ExecutionPolicy RemoteSigned -File download_url_file.ps1 -url %Url80% -file "%PreDir%\%Name80%"
+@echo - Downloading %Name81%
+powershell -ExecutionPolicy RemoteSigned -File download_url_file.ps1 -url %Url81% -file "%PreDir%\%Name81%"
+
+:: 32 bit binaries only needed for x86 installer
+:: ProgramFiles(x86) is defined on AMD64 systems
+:: If it's defined, skip the x86 binaries
+If Defined ProgramFiles(x86) goto prereq_end
+
+:: Copy down the 32 bit binaries
+set Url60=http://repo.saltstack.com/windows/dependencies/32/ucrt/Windows6.0-KB2999226-x86.msu
+set Name60=Windows6.0-KB2999226-x86.msu
+set Url61=http://repo.saltstack.com/windows/dependencies/32/ucrt/Windows6.1-KB2999226-x86.msu
+set Name61=Windows6.1-KB2999226-x86.msu
+set Url80=http://repo.saltstack.com/windows/dependencies/32/ucrt/Windows8-RT-KB2999226-x86.msu
+set Name80=Windows8-RT-KB2999226-x86.msu
+set Url81=http://repo.saltstack.com/windows/dependencies/32/ucrt/Windows8.1-KB2999226-x86.msu
+set Name81=Windows8.1-KB2999226-x86.msu
 @echo - Downloading %Name60%
 powershell -ExecutionPolicy RemoteSigned -File download_url_file.ps1 -url %Url60% -file "%PreDir%\%Name60%"
 @echo - Downloading %Name61%


### PR DESCRIPTION
### What does this PR do?
Fix logic where it detects the Architecture of the system running the installer instead of the one building the installer
Add a 3 seconds pause to actually see the error code if it throws one

### What issues does this PR fix or reference?
Found in QA

### Tests written?
NA

### Commits signed with GPG?
Yes