### PR TITLE
Fix paths to moved functions

### DIFF
--- a/salt/modules/redismod.py
+++ b/salt/modules/redismod.py
@@ -19,8 +19,8 @@ Module to provide redis functionality to Salt
 from __future__ import absolute_import, unicode_literals, print_function
 from salt.ext.six.moves import zip
 from salt.ext import six
-from salt.utils import clean_kwargs
 from datetime import datetime
+import salt.utils.args
 
 # Import third party libs
 try:
@@ -396,7 +396,7 @@ def hmset(key, **fieldsvals):
     database = fieldsvals.pop('db', None)
     password = fieldsvals.pop('password', None)
     server = _connect(host, port, database, password)
-    return server.hmset(key, clean_kwargs(**fieldsvals))
+    return server.hmset(key, salt.utils.args.clean_kwargs(**fieldsvals))
 
 
 def hset(key, field, value, host=None, port=None, db=None, password=None):

--- a/tests/unit/modules/test_state.py
+++ b/tests/unit/modules/test_state.py
@@ -29,6 +29,7 @@ from tests.support.mock import (
 import salt.config
 import salt.loader
 import salt.state
+import salt.utils.args
 import salt.utils.files
 import salt.utils.json
 import salt.utils.hashutils
@@ -533,7 +534,7 @@ class StateTestCase(TestCase, LoaderModuleMockMixin):
                 mock = MagicMock(return_value={"test": ""})
                 with patch.object(salt.utils.state, 'get_sls_opts', mock):
                     mock = MagicMock(return_value=True)
-                    with patch.object(salt.utils, 'test_mode', mock):
+                    with patch.object(salt.utils.args, 'test_mode', mock):
                         self.assertRaises(SaltInvocationError,
                                           state.single,
                                           "pkg.installed",
@@ -637,7 +638,7 @@ class StateTestCase(TestCase, LoaderModuleMockMixin):
                 )
                 with patch.object(salt.utils.state, 'get_sls_opts', mock):
                     mock = MagicMock(return_value=True)
-                    with patch.object(salt.utils, 'test_mode', mock):
+                    with patch.object(salt.utils.args, 'test_mode', mock):
                         MockState.State.flag = True
                         MockState.HighState.flag = True
                         self.assertEqual(state.sls_id("apache", "http"), 2)
@@ -686,7 +687,7 @@ class StateTestCase(TestCase, LoaderModuleMockMixin):
                 )
                 with patch.object(salt.utils.state, 'get_sls_opts', mock):
                     mock = MagicMock(return_value=True)
-                    with patch.object(salt.utils, 'test_mode', mock):
+                    with patch.object(salt.utils.args, 'test_mode', mock):
                         self.assertRaises(SaltInvocationError,
                                           state.show_sls,
                                           "foo",
@@ -717,7 +718,7 @@ class StateTestCase(TestCase, LoaderModuleMockMixin):
                     mock = MagicMock(return_value={'test': True})
                     with patch.object(salt.utils.state, 'get_sls_opts', mock):
                         mock = MagicMock(return_value=True)
-                        with patch.object(salt.utils, 'test_mode', mock):
+                        with patch.object(salt.utils.args, 'test_mode', mock):
                             self.assertRaises(SaltInvocationError,
                                               state.top,
                                               "reverse_top.sls",
@@ -878,7 +879,7 @@ class StateTestCase(TestCase, LoaderModuleMockMixin):
                                                        "saltenv": None})
                         with patch.object(salt.utils.state, 'get_sls_opts', mock):
                             mock = MagicMock(return_value=True)
-                            with patch.object(salt.utils,
+                            with patch.object(salt.utils.args,
                                               'test_mode',
                                               mock):
                                 self.assertRaises(

--- a/tests/unit/utils/test_reactor.py
+++ b/tests/unit/utils/test_reactor.py
@@ -9,6 +9,7 @@ import textwrap
 
 import salt.loader
 import salt.utils.data
+import salt.utils.files
 import salt.utils.reactor as reactor
 import salt.utils.yaml
 
@@ -441,7 +442,7 @@ class TestReactor(TestCase, AdaptedConfigurationTestCaseMixin):
                             os.path, 'isfile',
                             MagicMock(return_value=True)):
                         with patch.object(
-                                salt.utils, 'is_empty',
+                                salt.utils.files, 'is_empty',
                                 MagicMock(return_value=False)):
                             with patch.object(
                                     codecs, 'open',


### PR DESCRIPTION
These funcs were moved out of salt.utils for 2018.3