### PR TITLE
Prepend current directory when path is just filename

### DIFF
--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -591,10 +591,19 @@ class LogLevelMixIn(six.with_metaclass(MixInMeta, object)):
                 )
             )
 
+        def _logfile_callback(option, opt, value, parser, *args, **kwargs):
+            if not os.path.dirname(value):
+                # if the path is only a file name (no parent directory), assume current directory
+                value = os.path.join(os.path.curdir, value)
+            setattr(parser.values, self._logfile_config_setting_name_, value)
+
         group.add_option(
             '--log-file',
             dest=self._logfile_config_setting_name_,
             default=None,
+            action='callback',
+            type='string',
+            callback=_logfile_callback,
             help='Log file path. Default: \'{0}\'.'.format(
                 self._default_logging_logfile_
             )


### PR DESCRIPTION
### What does this PR do?

Calling salt-ssh with `--log-file=ssh.log` (simple file name without parent directory) fails like this:

```
bash-4.3# salt-ssh -l quiet -i --out json --key-deploy --passwd admin123 container__NkZlb --log-file-level=trace --log-file=ssh.log test.ping                                                                                                                                 
Failed to create path "ssh.log" - [Errno 2] No such file or directory: ''
```

### New Behavior

When no parent directory is found, it uses `os.path.curdir` (the current directory) as the parent for the filepath.

### Tests written?

No

### Commits signed with GPG?

No