### PR TITLE
Fix path to libsodium tarball

### DIFF
--- a/pkg/osx/build_env.sh
+++ b/pkg/osx/build_env.sh
@@ -161,7 +161,7 @@ sudo -H $MAKE install
 ############################################################################
 echo -n -e "\033]0;Build_Env: libsodium\007"
 
-PKGURL="https://download.libsodium.org/libsodium/releases/libsodium-1.0.13.tar.gz"
+PKGURL="https://download.libsodium.org/libsodium/releases/old/libsodium-1.0.13.tar.gz"
 PKGDIR="libsodium-1.0.13"
 
 download $PKGURL


### PR DESCRIPTION
### What does this PR do?
Libsodium changed the location of the tarball for the version we're using in the 2017.7 branch. This PR updates the url to reflect the new location.

### What issues does this PR fix or reference?
Found in building

### Tests written?
NA

### Commits signed with GPG?
Yes