### PR TITLE
Work around cmd.run unicode issues in test for now

### DIFF
--- a/tests/integration/states/test_file.py
+++ b/tests/integration/states/test_file.py
@@ -2257,7 +2257,7 @@ class FileTest(ModuleCase, SaltReturnAssertsMixin):
             else:
                 self.assertEqual(
                     ret['some-utf8-file-content-test']['comment'],
-                    'Command "cat "{1}"" run'.format(
+                    'Command "cat "{0}"" run'.format(
                         test_file_encoded
                     )
                 )

--- a/tests/integration/states/test_file.py
+++ b/tests/integration/states/test_file.py
@@ -2257,8 +2257,7 @@ class FileTest(ModuleCase, SaltReturnAssertsMixin):
             else:
                 self.assertEqual(
                     ret['some-utf8-file-content-test']['comment'],
-                    'Command "{0} "{1}"" run'.format(
-                        'type' if salt.utils.platform.is_windows() else 'cmd',
+                    'Command "cat "{1}"" run'.format(
                         test_file_encoded
                     )
                 )

--- a/tests/integration/states/test_file.py
+++ b/tests/integration/states/test_file.py
@@ -776,7 +776,6 @@ class FileTest(ModuleCase, SaltReturnAssertsMixin):
                 ret = self.run_state(
                     'file.directory', test=True, name=sym_dir,
                     follow_symlinks=True, mode=700)
-
             self.assertSaltTrueReturn(ret)
         finally:
             if os.path.isdir(tmp_dir):
@@ -2098,7 +2097,7 @@ class FileTest(ModuleCase, SaltReturnAssertsMixin):
             '#-- end salt managed zoneend --',
             '']
 
-        self.assertEqual(expected, contents)
+        self.assertEqual([line.encode('utf-8') for line in expected], contents)
 
     @with_tempdir()
     def test_issue_11003_immutable_lazy_proxy_sum(self, base_dir):
@@ -2190,6 +2189,10 @@ class FileTest(ModuleCase, SaltReturnAssertsMixin):
                    {korean_3}
                 - replace: True
                 - show_diff: True
+            '''.format(**locals()))
+
+        if not salt.utils.platform.is_windows():
+            template += textwrap.dedent('''\
             some-utf8-file-content-test:
               cmd.run:
                 - name: 'cat "{test_file}"'
@@ -2240,18 +2243,29 @@ class FileTest(ModuleCase, SaltReturnAssertsMixin):
                 ret['some-utf8-file-create2']['changes'],
                 {'diff': diff}
             )
-
-            # Confirm that the file has the expected contents as specified in
-            # the prior state.
-            self.assertEqual(
-                ret['some-utf8-file-content-test']['comment'],
-                'Command "cat "{0}"" run'.format(test_file_encoded)
-            )
-            self.assertEqual(
-                ret['some-utf8-file-content-test']['changes']['stdout'],
-                '\n'.join((korean_2, korean_1, korean_3))
-            )
-
+            if salt.utils.platform.is_windows():
+                import subprocess
+                import win32api
+                p = subprocess.Popen(salt.utils.to_str('type {}'.format(win32api.GetShortPathName(test_file))),
+                    shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                p.poll()
+                out = p.stdout.read()
+                self.assertEqual(
+                        out.decode('utf-8'),
+                        os.linesep.join((korean_2, korean_1, korean_3)) + os.linesep
+                )
+            else:
+                self.assertEqual(
+                    ret['some-utf8-file-content-test']['comment'],
+                    'Command "{0} "{1}"" run'.format(
+                        'type' if salt.utils.platform.is_windows() else 'cmd',
+                        test_file_encoded
+                    )
+                )
+                self.assertEqual(
+                    ret['some-utf8-file-content-test']['changes']['stdout'],
+                    '\n'.join((korean_2, korean_1, korean_3))
+                )
         finally:
             try:
                 os.remove(template_path)


### PR DESCRIPTION
Cat is missing on windows. I tired unsuccesfully to make this work with
the 'type' command on windows. This is maybe not ideal but it stablizes
the test suite for now.

### Tests written?

No

### Commits signed with GPG?

Yes