### PR TITLE
use os._exit instead of sys.exit when daemonizing

### DIFF
--- a/salt/utils/process.py
+++ b/salt/utils/process.py
@@ -71,7 +71,7 @@ def daemonize(redirect_out=True):
         if pid > 0:
             # exit first parent
             salt.utils.crypt.reinit_crypto()
-            sys.exit(salt.defaults.exitcodes.EX_OK)
+            os._exit(salt.defaults.exitcodes.EX_OK)
     except OSError as exc:
         log.error('fork #1 failed: %s (%s)', exc.errno, exc)
         sys.exit(salt.defaults.exitcodes.EX_GENERIC)


### PR DESCRIPTION
### What does this PR do?
According to the docs [here](https://docs.python.org/3/library/os.html#os._exit)

> `os._exit` should should normally only be used in the child process after a fork().

This will exit the process with status n, without calling cleanup
handlers, flushing stdio buffers, etc.

do not merge, this is just testing to see if it breaks any other tests for python<3.7 at least.

### What issues does this PR fix or reference?
Fixes saltstack/salt-jenkins#1075

### Tests written?

Yes

### Commits signed with GPG?

Yes