### PR TITLE
Allow to users to touch file with Unix date of birth

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -3168,9 +3168,13 @@ def touch(name, atime=None, mtime=None):
     simply update the atime and mtime if it already does.
 
     atime:
-        Access time in Unix epoch time
+        Access time in Unix epoch time. Set it to 0 to set atime of the
+        file with Unix date of birth. If this parameter isn't set, atime
+        will be set with current time.
     mtime:
-        Last modification in Unix epoch time
+        Last modification in Unix epoch time. Set it to 0 to set mtime of
+        the file with Unix date of birth. If this parameter isn't set,
+        mtime will be set with current time.
 
     CLI Example:
 

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -3189,11 +3189,11 @@ def touch(name, atime=None, mtime=None):
             with salt.utils.files.fopen(name, 'a'):
                 pass
 
-        if not atime and not mtime:
+        if atime is None and mtime is None:
             times = None
-        elif not mtime and atime:
+        elif mtime is None and atime is not None:
             times = (atime, time.time())
-        elif not atime and mtime:
+        elif atime is None and mtime is not None:
             times = (time.time(), mtime)
         else:
             times = (atime, mtime)


### PR DESCRIPTION
### What does this PR do?
Change file.touch management to allow users to specify atime or mtime values of '0' to touch file with Unix epoch time 1970-01-01 01:00:00.000000000. 

### What issues does this PR fix or reference?
None

### Previous Behavior
Setting atime or mtime with "0" touched the file with current timestamp instead of Unix date of birth.

### New Behavior
Now users can set atime or mtime values to '0' to get Unix date of birth, set them to other positive values or unset them to touch file with current time.

### Tests written?
No but I've tested the code like this :
```
$ salt 'ulgcicpi50' file.touch name=/etc/salt/grains atime="\"0\""
ulgcicpi50:
    True
$ stat /etc/salt/grains
  File: '/etc/salt/grains'
  Size: 848             Blocks: 8          IO Block: 4096   regular file
Device: fc00h/64512d    Inode: 14893       Links: 1
Access: (0640/-rw-r-----)  Uid: (    0/    root)   Gid: (    0/    root)
Access: 1970-01-01 01:00:00.000000000 +0100
Modify: 2018-08-24 15:36:46.491617000 +0200
Change: 2018-08-24 15:36:46.488108473 +0200
 Birth: -
$ salt 'ulgcicpi50' file.touch name=/etc/salt/grains mtime="\"0\""
ulgcicpi50:
    True
$ stat /etc/salt/grains
  File: '/etc/salt/grains'
  Size: 848             Blocks: 8          IO Block: 4096   regular file
Device: fc00h/64512d    Inode: 14893       Links: 1
Access: (0640/-rw-r-----)  Uid: (    0/    root)   Gid: (    0/    root)
Access: 2018-08-24 15:37:06.700995000 +0200
Modify: 1970-01-01 01:00:00.000000000 +0100
Change: 2018-08-24 15:37:06.696237885 +0200
 Birth: -
$ salt 'ulgcicpi50' file.touch name=/etc/salt/grains mtime="\"0\"" atime="\"0\""
ulgcicpi50:
    True
$ stat /etc/salt/grains
  File: '/etc/salt/grains'
  Size: 848             Blocks: 8          IO Block: 4096   regular file
Device: fc00h/64512d    Inode: 14893       Links: 1
Access: (0640/-rw-r-----)  Uid: (    0/    root)   Gid: (    0/    root)
Access: 1970-01-01 01:00:00.000000000 +0100
Modify: 1970-01-01 01:00:00.000000000 +0100
Change: 2018-08-24 15:37:28.344376504 +0200
 Birth: -
$ salt 'ulgcicpi50' file.touch name=/etc/salt/grains
ulgcicpi50:
    True
$ stat /etc/salt/grains
  File: '/etc/salt/grains'
  Size: 848             Blocks: 8          IO Block: 4096   regular file
Device: fc00h/64512d    Inode: 14893       Links: 1
Access: (0640/-rw-r-----)  Uid: (    0/    root)   Gid: (    0/    root)
Access: 2018-08-24 15:37:42.732468628 +0200
Modify: 2018-08-24 15:37:42.732468628 +0200
Change: 2018-08-24 15:37:42.732468628 +0200
 Birth: -
```

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
