### PR TITLE
Fix keyerror in manage.bootstrap

### DIFF
--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -702,7 +702,7 @@ class SSH(object):
         '''
         Execute the overall routine, print results via outputters
         '''
-        if self.opts['list_hosts']:
+        if self.opts.get('list_hosts'):
             self._get_roster()
             ret = {}
             for roster_file in self.__parsed_rosters:


### PR DESCRIPTION
### What does this PR do?
since `list_hosts` is an optional arg passed through the parser we can change it to a .get() call as it should not be required to be in opts.

### What issues does this PR fix or reference?
Fixes https://github.com/saltstack/salt/issues/49296
