### PR TITLE
Update documentation for #48694 and add deprecation warning

### DIFF
--- a/salt/runners/cache.py
+++ b/salt/runners/cache.py
@@ -35,13 +35,25 @@ def grains(tgt=None, tgt_type='glob', **kwargs):
         The ``expr_form`` argument has been renamed to ``tgt_type``, earlier
         releases must use ``expr_form``.
 
-    Return cached grains of the targeted minions
+    Return cached grains of the targeted minions.
+
+    tgt
+        Target to match minion ids.
+
+        .. versionchanged:: 2017.7.5,2018.3.0
+            The ``tgt`` argument is now required to display cached grains. If
+            not used, the function will not return grains. This optional
+            argument will become mandatory in the Salt ``Sodium`` release.
+
+    tgt_type
+        The type of targeting to use for matching, such as ``glob``, ``list``,
+        etc.
 
     CLI Example:
 
     .. code-block:: bash
 
-        salt-run cache.grains
+        salt-run cache.grains '*'
     '''
     if 'expr_form' in kwargs:
         salt.utils.warn_until(
@@ -51,6 +63,16 @@ def grains(tgt=None, tgt_type='glob', **kwargs):
             '\'expr_form\' will be removed in Salt Fluorine.'
         )
         tgt_type = kwargs.pop('expr_form')
+
+    if tgt is None:
+        # Change ``tgt=None`` to ``tgt`` (mandatory kwarg) in Salt Sodium.
+        # This behavior was changed in PR #45588 to fix Issue #45489.
+        salt.utils.warn_until(
+            'Sodium',
+            'Detected missing \'tgt\' option. Cached grains will not be returned '
+            'without a specified \'tgt\'. This option will be required starting in '
+            'Salt Sodium and this warning will be removed.'
+        )
 
     pillar_util = salt.utils.master.MasterPillarUtil(tgt, tgt_type,
                                                      use_cached_grains=True,


### PR DESCRIPTION
There was a behavior change when using `salt-run cache.grains` beginning with the 2017.7.5 release.

The behavior change happened in PR #45588, which was back-ported to the 2017.7 branch in PR #45751. This was done in order to fix the bug reported in #45489.

In order to be helpful to users, a deprecation warning was added. If ``tgt`` is not passed, no grains will be listed. Instead of suddenly requiring a ``tgt`` argument in a dot release, let's keep this optional arg around until Sodium.

When Salt Sodium is released, we can remove the warning and change ``tgt`` to be a mandatory argument.

Fixes the last parts of #48694.
