### PR TITLE
Encode shell commands explicitly.

### DIFF
--- a/salt/utils/timed_subprocess.py
+++ b/salt/utils/timed_subprocess.py
@@ -40,6 +40,8 @@ class TimedProc(object):
 
         if self.timeout and not isinstance(self.timeout, (int, float)):
             raise salt.exceptions.TimedProcTimeoutError('Error: timeout {0} must be a number'.format(self.timeout))
+        if kwargs.get('shell', False):
+            args = salt.utils.stringutils.to_bytes(args)
 
         try:
             self.process = subprocess.Popen(args, **kwargs)

--- a/tests/integration/modules/test_state.py
+++ b/tests/integration/modules/test_state.py
@@ -1953,7 +1953,10 @@ class StateModuleTest(ModuleCase, SaltReturnAssertsMixin):
         _expected = 'This is Æ test!'
         if salt.utils.platform.is_windows():
             # Windows cmd.exe will mangle the output using cmd's codepage.
-            _expected = "'This is ’ test!'"
+            if six.PY2:
+                _expected = "'This is A+ test!'"
+            else:
+                _expected = "'This is ’ test!'"
         self.assertEqual(_expected, ret[key]['changes']['stdout'])
 
     def tearDown(self):


### PR DESCRIPTION
### What does this PR do?

Fixes this test failure: https://jenkinsci.saltstack.com/job/2018.3/job/salt-windows-2016-py2/lastCompletedBuild/testReport/junit/integration.modules.test_state/StateModuleTest/test_state_sls_unicode_characters_cmd_output/

- Do not raise an exception if passing non ascii data to `subprocess.Popen`, encode the command first so that it's not implicitly encoded using the default codepage on Python 2. This should also fix the exception found in #48880
- Account for the differences in the way py2 and py3 handles Popen output encoding.

If we want to support this stuff on python 2 we'll need to bypass the subprocess module and do something like we do in `salt.utils.win_runas` we may even be able to leverage the work already done there.


### Tests written?

No

### Commits signed with GPG?

Yes
