### PR TITLE
Skip nonexistent branch test for git versions <1.7.10

### DIFF
--- a/tests/integration/states/test_git.py
+++ b/tests/integration/states/test_git.py
@@ -51,11 +51,13 @@ def __check_git_version(caller, min_version, skip_msg):
     return wrapper
 
 
-def ensure_min_git(caller):
+def ensure_min_git(caller=None, min_version='1.6.5'):
     '''
     Skip test if minimum supported git version is not installed
     '''
-    min_version = '1.6.5'
+    if caller is None:
+        return functools.partial(ensure_min_git, min_version=min_version)
+
     return __check_git_version(
         caller,
         min_version,
@@ -624,6 +626,7 @@ class GitTest(ModuleCase, SaltReturnAssertsMixin):
         )
 
     @with_tempdir(create=False)
+    @ensure_min_git(min_version='1.7.10')
     def test_cloned_with_nonexistant_branch(self, target):
         '''
         Test git.cloned state with a nonexistant branch provided


### PR DESCRIPTION
### What does this PR do?
skips `test_cloned_with_nonexistant_branch` test if git version is lower then 1.7.10

### What issues does this PR fix or reference?
Fixes https://github.com/saltstack/salt-jenkins/issues/1068
