### PR TITLE
mssql.tsql_query: add autocommit connection option

### DIFF
--- a/salt/modules/mssql.py
+++ b/salt/modules/mssql.py
@@ -41,7 +41,8 @@ _DEFAULTS = {
     'user': 'sysdba',
     'password': '',
     'database': '',
-    'as_dict': False
+    'as_dict': False,
+    'autocommit': False
 }
 
 
@@ -56,7 +57,7 @@ def __virtual__():
 
 def _get_connection(**kwargs):
     connection_args = {}
-    for arg in ('server', 'port', 'user', 'password', 'database', 'as_dict'):
+    for arg in ('server', 'port', 'user', 'password', 'database', 'as_dict', 'autocommit'):
         if arg in kwargs:
             connection_args[arg] = kwargs[arg]
         else:


### PR DESCRIPTION
### What does this PR do?

When making schema changes (e.g. `ALTER DATABASE`) we need to configure the connection such that the driver manages committing changes, e.g.:

```yaml
mssql.database.create:
  mssql.db_create:
    - name: mydb

mssql.database.alter:
  mssql.tsql_query:
    - name: ALTER mydb COLLATE Latin1_General_CS_AS
    - autocommit: True
```

Without `autocommit` enabled we'll receive a `pymssql.OperationalError` like the following:

```
(226, 'ALTER DATABASE statement not allowed within multi-
statement transaction.DB-Lib error message 226, severity 16:\\nGeneral SQL Serve
r error: Check messages from the SQL Server\\n')
```

### What issues does this PR fix or reference?

_None_

### Tests written?

No -- `develop` doesn't seem to contain any tests for this module.

### Commits signed with GPG?

No