### PR TITLE
Update dynamic git_pillar docs to enclose env name in quotes

### DIFF
--- a/salt/pillar/git_pillar.py
+++ b/salt/pillar/git_pillar.py
@@ -126,7 +126,7 @@ The corresponding Pillar top file would look like this:
 
 .. code-block:: yaml
 
-    {{saltenv}}:
+    "{{saltenv}}":
       '*':
         - bar
 


### PR DESCRIPTION
This will help prevent confusion (such as in #48717) when numeric branches are used.