### PR TITLE
Increase run_script timeout to fix failing test

### DIFF
--- a/tests/integration/shell/test_saltcli.py
+++ b/tests/integration/shell/test_saltcli.py
@@ -197,7 +197,7 @@ class RetcodeTestCase(ShellCase):
                 'salt',
                 '-c {0} -t 5 minion2 test.ping'.format(self.config_dir),
                 with_retcode=True,
-                timeout=20)[1]
+                timeout=60)[1]
             assert retcode == salt.defaults.exitcodes.EX_GENERIC, retcode
         finally:
             # Now get rid of it


### PR DESCRIPTION
**NOTE: This PR initially _removed_ the timeout argument rather than increasing its value. See [here](https://github.com/saltstack/salt/pull/49342#issuecomment-416988592) for explanation of why this PR was updated.**

There was a call to `run_script` in `integration.shell.test_saltcli.RetcodeTestCase.test_missing_minion` which I had set to timeout after 20 seconds. The problem with this is that on my laptop, which has a Core i7 and plentiful quantities of RAM with which to run the test, it still takes about 17 seconds to complete.  So, on any slightly-less-powerful machine, the test is likely to (at least occasionally) reach that artificial 20-second limit and time out, which will cause the test to fail.

Increasing the timeout should reduce the likelihood that this happens.