### PR TITLE
Vault policy parser add pillar support

### DIFF
--- a/salt/modules/vault.py
+++ b/salt/modules/vault.py
@@ -93,16 +93,16 @@ Functions to interact with Hashicorp Vault.
         Policies that are assigned to minions when requesting a token. These can
         either be static, eg saltstack/minions, or templated, eg
         ``saltstack/minion/{minion}``. ``{minion}`` is shorthand for grains[id].
-        Grains are also available, for example like this:
+        Grains and pillar are also available, for example like this:
         ``my-policies/{grains[os]}``
 
-        If a template contains a grain which evaluates to a list, it will be
+        If a template contains a value which evaluates to a list, it will be
         expanded into multiple policies. For example, given the template
-        ``saltstack/by-role/{grains[roles]}``, and a minion having these grains:
+        ``saltstack/by-role/{pillar[roles]}``, and a minion having this pillar:
 
         .. code-block: yaml
 
-            grains:
+            pillar:
                 roles:
                     - web
                     - database
@@ -115,6 +115,9 @@ Functions to interact with Hashicorp Vault.
 
         Optional. If policies is not configured, ``saltstack/minions`` and
         ``saltstack/{minion}`` are used as defaults.
+
+        .. versionchanged:: Fluorine
+            Support for pillardata added.
 
     keys
         List of keys to use to unseal vault server with the vault.unseal runner.

--- a/salt/runners/vault.py
+++ b/salt/runners/vault.py
@@ -167,12 +167,12 @@ def _get_policies(minion_id, config):
     '''
     Get the policies that should be applied to a token for minion_id
     '''
-    _, grains, _ = salt.utils.minions.get_minion_data(minion_id, __opts__)
+    _, grains, pillar = salt.utils.minions.get_minion_data(minion_id, __opts__)
     policy_patterns = config.get(
                                  'policies',
                                  ['saltstack/minion/{minion}', 'saltstack/minions']
                                 )
-    mappings = {'minion': minion_id, 'grains': grains or {}}
+    mappings = {'minion': minion_id, 'grains': grains or {}, 'pillar': pillar or {}}
 
     policies = []
     for pattern in policy_patterns:


### PR DESCRIPTION
### What does this PR do?
The Salt/Vault integration allows grains to be referenced in the policy mapping:
```yaml
vault:
  policies:
  - salt/base
  - salt/minions/{grains[os]}
```
This adds pillar to the possibilities.
```yaml
vault:
  policies:
  - salt/base
  - salt/minions/{grains[os]}
  - salt/minions/{pillar[roles]}
``
### Previous Behavior
Only `{grains}` could be defined in the Salt minion's token policies.

### New Behavior
Also `{pillar}` can be used.
