### PR TITLE
Fix tests that use timed_subprocess for py3

### DIFF
--- a/salt/utils/timed_subprocess.py
+++ b/salt/utils/timed_subprocess.py
@@ -40,7 +40,7 @@ class TimedProc(object):
 
         if self.timeout and not isinstance(self.timeout, (int, float)):
             raise salt.exceptions.TimedProcTimeoutError('Error: timeout {0} must be a number'.format(self.timeout))
-        if kwargs.get('shell', False):
+        if six.PY2 and kwargs.get('shell', False):
             args = salt.utils.stringutils.to_bytes(args)
 
         try:


### PR DESCRIPTION
### What does this PR do?

Fixes multiple tests in the 2018.3 py3 windows suite.
```
integration.modules.test_useradd.UseraddModuleTestWindows.test_add_user_addgroup
integration.modules.test_useradd.UseraddModuleTestWindows.test_user_removegroup
integration.modules.test_cmdmod.CMDModuleTest.test_cmd_run_whoami
integration.modules.test_cmdmod.CMDModuleTest.test_quotes
integration.modules.test_cmdmod.CMDModuleTest.test_run_all
integration.modules.test_cmdmod.CMDModuleTest.test_stderr
integration.modules.test_cmdmod.CMDModuleTest.test_stdout
```

### Tests written?

No

### Commits signed with GPG?

Yes