### PR TITLE
Bugfix: issue#49150 hosts.rm_host changes /etc/hosts with odd characters

### DIFF
--- a/salt/modules/hosts.py
+++ b/salt/modules/hosts.py
@@ -212,19 +212,21 @@ def rm_host(ip, alias):
             continue
         if tmpline.startswith(b'#'):
             continue
-        comps = salt.utils.stringutils.to_unicode(tmpline).split()
-        if comps[0] == ip:
-            newline = '{0}\t\t'.format(comps[0])
+        comps = tmpline.split()
+        b_ip  = salt.utils.stringutils.to_bytes(ip)
+        b_alias = salt.utils.stringutils.to_bytes(alias)
+        if comps[0] == b_ip:
+            newline = comps[0] + b'\t\t'
             for existing in comps[1:]:
-                if existing == alias:
+                if existing == b_alias:
                     continue
-                newline += ' {0}'.format(existing)
-            if newline.strip() == ip:
+                newline += existing + b' '
+            if newline.strip() == b_ip:
                 # No aliases exist for the line, make it empty
                 lines[ind] = b''
             else:
                 # Only an alias was removed
-                lines[ind] = newline + os.linesep
+                lines[ind] = newline + salt.utils.stringutils.to_bytes(os.linesep)
     with salt.utils.files.fopen(hfn, 'wb') as ofile:
         ofile.writelines(lines)
     return True


### PR DESCRIPTION
### What does this PR do?
improve the problem that hosts.rm_host change /etc/hosts with odd characters

### What issues does this PR fix or reference?
fix the bug mentioned in issue [49150](https://github.com/saltstack/salt/issues/49150)
Be sure to transfer all 'content' to bytes before writing into file.
### Tests written?
No

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
