### PR TITLE
Fix issue with duplicates in user.list_users on OSX

### DIFF
--- a/pkg/osx/build_env.sh
+++ b/pkg/osx/build_env.sh
@@ -161,7 +161,7 @@ sudo -H $MAKE install
 ############################################################################
 echo -n -e "\033]0;Build_Env: libsodium\007"
 
-PKGURL="https://download.libsodium.org/libsodium/releases/libsodium-1.0.13.tar.gz"
+PKGURL="https://download.libsodium.org/libsodium/releases/old/libsodium-1.0.13.tar.gz"
 PKGDIR="libsodium-1.0.13"
 
 download $PKGURL

--- a/salt/modules/mac_user.py
+++ b/salt/modules/mac_user.py
@@ -467,8 +467,8 @@ def list_users():
 
         salt '*' user.list_users
     '''
-    # Use a set to not allow duplicates
-    return sorted(set(user.pw_name for user in pwd.getpwall()))
+    users = _dscl(['/users'], 'list')['stdout']
+    return users.split()
 
 
 def rename(name, new_name):

--- a/salt/modules/mac_user.py
+++ b/salt/modules/mac_user.py
@@ -467,7 +467,8 @@ def list_users():
 
         salt '*' user.list_users
     '''
-    return sorted([user.pw_name for user in pwd.getpwall()])
+    # Use a set to not allow duplicates
+    return sorted(set(user.pw_name for user in pwd.getpwall()))
 
 
 def rename(name, new_name):

--- a/tests/unit/modules/test_mac_user.py
+++ b/tests/unit/modules/test_mac_user.py
@@ -312,6 +312,11 @@ class MacUserTestCase(TestCase, LoaderModuleMockMixin):
         '''
         Tests the list of all users
         '''
-        with patch('pwd.getpwall', MagicMock(return_value=self.mock_pwall)):
-            ret = ['_amavisd', '_appleevents', '_appowner']
-            self.assertEqual(mac_user.list_users(), ret)
+        expected = ['spongebob', 'patrick', 'squidward']
+        mock_run = MagicMock(return_value={'pid': 4948,
+                                           'retcode': 0,
+                                           'stderr': '',
+                                           'stdout': '\n'.join(expected)})
+        with patch.dict(mac_user.__grains__, {'osrelease_info': (10, 9, 1)}), \
+                patch.dict(mac_user.__salt__, {'cmd.run_all': mock_run}):
+            self.assertEqual(mac_user.list_users(), expected)


### PR DESCRIPTION
### What does this PR do?
Fixes the issue where `user.list_users` was showing duplicate users names. Uses a set to do this as a set does not allow duplicates.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/48608

### Tests written?
No

### Commits signed with GPG?
Yes