### PR TITLE
Fix winrepo.update_git_repos for masterless minion

### DIFF
--- a/salt/modules/win_repo.py
+++ b/salt/modules/win_repo.py
@@ -26,7 +26,8 @@ from salt.runners.winrepo import (
     genrepo as _genrepo,
     update_git_repos as _update_git_repos,
     PER_REMOTE_OVERRIDES,
-    PER_REMOTE_ONLY
+    PER_REMOTE_ONLY,
+    GLOBAL_ONLY
 )
 from salt.ext import six
 try:


### PR DESCRIPTION
### What does this PR do?
Fixes an issue where the minion would stacktrace when running the following:
```
salt-call --local -l debug winrepo.update_git_repos
```
Stacktrace:
```
[ERROR   ] Failed to update winrepo_remotes: name 'GLOBAL_ONLY' is not defined
Traceback (most recent call last):
  File "c:\dev\salt\salt\runners\winrepo.py", line 225, in update_git_repos
    GLOBAL_ONLY)
NameError: name 'GLOBAL_ONLY' is not defined
```

### What issues does this PR fix or reference?
None. Found while preparing presentation

### Tests written?
No

### Commits signed with GPG?
Yes