### PR TITLE
Avoid raising exceptions when calling Fileserver.envs

### DIFF
--- a/salt/fileserver/__init__.py
+++ b/salt/fileserver/__init__.py
@@ -489,11 +489,12 @@ class Fileserver(object):
                 ret[fsb] = self.servers[fstr]()
         return ret
 
-    def envs(self, back=None, sources=False):
+    def envs(self, load={}, back=None, sources=False):
         '''
         Return the environments for the named backend or all backends
         '''
-        back = self.backends(back)
+        back = self.backends(load.get('back', back))
+        sources = load.get('sources', sources)
         ret = set()
         if sources:
             ret = {}


### PR DESCRIPTION
### What does this PR do?

Fixing the following errors seen in the tests:
```
2018-08-28 21:13:10,130 [salt.loader      :1710][ERROR   ][5176] Failed to load function {'cmd': '_file_envs.envs because its module ({'cmd': '_file_envs) is not in the whitelist: [u'sseapi', u'roots']
```

`salt.fileserver.Fileserver.envs` sanitizes it's batch keyword arg but that is not designed to handle dictionaries. This method get's called from the following line with a dictionary:

https://github.com/saltstack/salt/blob/2018.3.3/salt/master.py#L1788

This `load` argument is not synonymous with either of the keyword args accepted by `salt.fileserver.Fileserver.envs`. Adding a proxy method that prevents passing anything to `salt.fileserver.Fileserver.envs`.



### Tests written?

No

### Commits signed with GPG?

Yes