### PR TITLE
Add utility functions to slsutil module

### DIFF
--- a/salt/modules/slsutil.py
+++ b/salt/modules/slsutil.py
@@ -336,3 +336,41 @@ def banner(width=72, commentchar='#', borderchar='#', blockstart=None, blockend=
         return result + '\n'
 
     return result
+
+
+def boolstr(value, true='true', false='false'):
+    '''
+    Convert a boolean value into a string. This function is
+    intended to be used from within file templates to provide
+    an easy way to take boolean values stored in Pillars or
+    Grains, and write them out in the apprpriate syntax for
+    a particular file template.
+
+    :param value: The boolean value to be converted
+    :param true: The value to return if ``value`` is ``True``
+    :param false: The value to return if ``value`` is ``False``
+
+    In this example, a pillar named ``smtp:encrypted`` stores a boolean
+    value, but the template that uses that value needs ``yes`` or ``no``
+    to be written, based on the boolean value.
+
+    *Note: this is written on two lines for clarity. The same result
+    could be achieved in one line.*
+
+    .. code-block:: jinja
+
+        {% set encrypted = salt[pillar.get]('smtp:encrypted', false) %}
+        use_tls: {{ salt['slsutil.boolstr'](encrypted, 'yes', 'no') }}
+
+    Result (assuming the value is ``True``):
+
+    .. code-block:: none
+
+        use_tls: yes
+
+    '''
+
+    if value:
+        return true
+
+    return false

--- a/salt/modules/slsutil.py
+++ b/salt/modules/slsutil.py
@@ -5,6 +5,7 @@ Utility functions for use with or in SLS files
 
 # Import Python libs
 from __future__ import absolute_import, unicode_literals, print_function
+import textwrap
 
 # Import Salt libs
 import salt.exceptions
@@ -246,3 +247,92 @@ def deserialize(serializer, stream_or_string, **mod_kwargs):
     kwargs = salt.utils.args.clean_kwargs(**mod_kwargs)
     return _get_serialize_fn(serializer, 'deserialize')(stream_or_string,
             **kwargs)
+
+
+def banner(width=72, commentchar='#', borderchar='#', blockstart=None, blockend=None,
+           title=None, text=None, newline=False):
+    '''
+    Create a standardized comment block to include in a templated file.
+
+    A common technique in configuration management is to include a comment
+    block in managed files, warning users not to modify the file. This
+    function simplifies and standardizes those comment blocks.
+
+    :param width: The width, in characters, of the banner. Default is 72.
+    :param commentchar: The character to be used in the starting position of
+        each line. This value should be set to a valid line comment character
+        for the syntax of the file in which the banner is being inserted.
+        Multiple character sequences, like '//' are supported.
+        If the file's syntax does not support line comments (such as XML),
+        use the ``blockstart`` and ``blockend`` options.
+    :param borderchar: The character to use in the top and bottom border of
+        the comment box. Must be a single character.
+    :param blockstart: The character sequence to use at the beginning of a
+        block comment. Should be used in conjunction with ``blockend``
+    :param blockend: The character sequence to use at the end of a
+        block comment. Should be used in conjunction with ``blockstart``
+    :param title: The first field of the comment block. This field appears
+        centered at the top of the box.
+    :param text: The second filed of the comment block. This field appears
+        left-justifed at the bottom of the box.
+    :param newline: Boolean value to indicate whether the comment block should
+        end with a newline. Default is ``False``.
+
+    This banner can be injected into any templated file, for example:
+
+    .. code-block:: jinja
+
+        {{ salt['slsutil.banner'](width=120, commentchar='//') }}
+
+    The default banner:
+
+    .. code-block:: none
+
+        ########################################################################
+        #                                                                      #
+        #              THIS FILE IS MANAGED BY SALT - DO NOT EDIT              #
+        #                                                                      #
+        # The contents of this file are managed by Salt. Any changes to this   #
+        # file may be overwritten automatically and without warning.           #
+        ########################################################################
+    '''
+
+    if title is None:
+        title = 'THIS FILE IS MANAGED BY SALT - DO NOT EDIT'
+
+    if text is None:
+        text = ('The contents of this file are managed by Salt. '
+                'Any changes to this file may be overwritten '
+                'automatically and without warning')
+
+    # Set up some typesetting variables
+    lgutter = commentchar.strip() + ' '
+    rgutter = ' ' + commentchar.strip()
+    textwidth = width - len(lgutter) - len(rgutter)
+    border_line = commentchar + borderchar[:1] * (width - len(commentchar) * 2) + commentchar
+    spacer_line = commentchar + ' ' * (width - len(commentchar) * 2) + commentchar
+    wrapper = textwrap.TextWrapper(width=(width - len(lgutter) - len(rgutter)))
+    block = list()
+
+    # Create the banner
+    if blockstart is not None:
+        block.append(blockstart)
+    block.append(border_line)
+    block.append(spacer_line)
+    for line in wrapper.wrap(title):
+        block.append(lgutter + line.center(textwidth) + rgutter)
+    block.append(spacer_line)
+    for line in wrapper.wrap(text):
+        block.append(lgutter + line + ' ' * (textwidth - len(line)) + rgutter)
+    block.append(border_line)
+    if blockend is not None:
+        block.append(blockend)
+
+    # Convert list to multiline string
+    result = '\n'.join(block)
+
+    # Add a newline character to the end of the banner
+    if newline:
+        return result + '\n'
+
+    return result

--- a/salt/modules/slsutil.py
+++ b/salt/modules/slsutil.py
@@ -6,6 +6,7 @@ Utility functions for use with or in SLS files
 # Import Python libs
 from __future__ import absolute_import, unicode_literals, print_function
 import textwrap
+import os
 
 # Import Salt libs
 import salt.exceptions
@@ -328,12 +329,12 @@ def banner(width=72, commentchar='#', borderchar='#', blockstart=None, blockend=
     if blockend is not None:
         block.append(blockend)
 
-    # Convert list to multiline string
-    result = '\n'.join(block)
+    # Convert list to multi-line string
+    result = os.linesep.join(block)
 
     # Add a newline character to the end of the banner
     if newline:
-        return result + '\n'
+        return result + os.linesep
 
     return result
 

--- a/tests/unit/modules/test_slsutil.py
+++ b/tests/unit/modules/test_slsutil.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+
+# Import Python libs
+from __future__ import absolute_import
+import logging
+
+# Import Salt Testing Libs
+from tests.support.unit import TestCase, skipIf
+from tests.support.mock import (
+    NO_MOCK,
+    NO_MOCK_REASON
+)
+
+# Import Salt Libs
+import salt.modules.slsutil as slsutil
+
+log = logging.getLogger(__name__)
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class SlsUtilTestCase(TestCase):
+    '''
+    Test cases for salt.modules.slsutil
+    '''
+
+    def test_banner(self):
+        '''
+        Test banner function
+        '''
+        self.check_banner()
+        self.check_banner(width=81)
+        self.check_banner(width=20)
+        self.check_banner(commentchar='//', borderchar='-')
+        self.check_banner(title='title here', text='text here')
+
+    def check_banner(self, width=72, commentchar='#', borderchar='#', blockstart=None, blockend=None,
+                     title=None, text=None, newline=True):
+
+        result = slsutil.banner(width=width, commentchar=commentchar, borderchar=borderchar,
+                                blockstart=blockstart, blockend=blockend, title=title, text=text,
+                                newline=newline).splitlines()
+        for line in result:
+            self.assertEqual(len(line), width)
+            self.assertTrue(line.startswith(commentchar))
+            self.assertTrue(line.endswith(commentchar))

--- a/tests/unit/modules/test_slsutil.py
+++ b/tests/unit/modules/test_slsutil.py
@@ -43,3 +43,10 @@ class SlsUtilTestCase(TestCase):
             self.assertEqual(len(line), width)
             self.assertTrue(line.startswith(commentchar))
             self.assertTrue(line.endswith(commentchar))
+
+    def test_boolstr(self):
+        '''
+        Test boolstr function
+        '''
+        self.assertEqual('yes', slsutil.boolstr(True, true='yes', false='no'))
+        self.assertEqual('no', slsutil.boolstr(False, true='yes', false='no'))


### PR DESCRIPTION
### What does this PR do?
Add two utility functions to the `slsutil` execution module. These functions are for convenience when creating template files.

#### Banner
`slsutil.banner` creates a standard warning banner like this:
```
        ########################################################################
        #                                                                      #
        #              THIS FILE IS MANAGED BY SALT - DO NOT EDIT              #
        #                                                                      #
        # The contents of this file are managed by Salt. Any changes to this   #
        # file may be overwritten automatically and without warning.           #
        ########################################################################
```
The banner is fully customizable in its content and appearance.

#### Boolstr
`slsutil.boolstr` is for converting boolean values stored in Pillar to an appropriate string representation within templated files. This can obviously be done in Jinja, but it requires an entire if/else block and managing whitespace becomes difficult.

See embedded documentation for more details.

### What issues does this PR fix or reference?
None

### Tests written?
Yes

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
