### PR TITLE
Back-port #49321 to 2017.7

### DIFF
--- a/tests/unit/serializers/test_serializers.py
+++ b/tests/unit/serializers/test_serializers.py
@@ -24,7 +24,7 @@ from salt.utils.odict import OrderedDict
 # Import test support libs
 from tests.support.helpers import flaky
 
-SKIP_MESSAGE = '%s is unavailable, do prerequisites have been met?'
+SKIP_MESSAGE = '%s is unavailable, have prerequisites been met?'
 
 
 @flaky(condition=six.PY3)
@@ -93,6 +93,7 @@ class TestSerializers(TestCase):
 
     @skipIf(not yaml.available, SKIP_MESSAGE % 'yaml')
     @skipIf(not yamlex.available, SKIP_MESSAGE % 'sls')
+    @flaky
     def test_compare_sls_vs_yaml_with_jinja(self):
         tpl = '{{ data }}'
         env = jinja2.Environment()


### PR DESCRIPTION
Back-port #49321 to 2017.7

Mark one of the serializer tests as flaky.