### PR TITLE
Add parameter named user_agent

### DIFF
--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -1090,6 +1090,9 @@ VALID_OPTS = {
     # Useful when a returner is the source of truth for a job result
     'pub_ret': bool,
 
+    # HTTP request settings. Used in tornado fetch functions
+    'user_agent': six.string_types,
+
     # HTTP proxy settings. Used in tornado fetch functions, apt-key etc
     'proxy_host': six.string_types,
     'proxy_username': six.string_types,
@@ -1488,6 +1491,7 @@ DEFAULT_MINION_OPTS = {
     'event_match_type': 'startswith',
     'minion_restart_command': [],
     'pub_ret': True,
+    'user_agent': '',
     'proxy_host': '',
     'proxy_username': '',
     'proxy_password': '',

--- a/salt/utils/http.py
+++ b/salt/utils/http.py
@@ -292,7 +292,10 @@ def query(url,
             auth = (username, password)
 
     if agent == USERAGENT:
-        agent = '{0} http.query()'.format(opts.get('user_agent', agent))
+        user_agent = opts.get('user_agent', None)
+        if user_agent:
+            agent = user_agent
+        agent = '{0} http.query()'.format(agent)
     header_dict['User-agent'] = agent
 
     if backend == 'requests':

--- a/salt/utils/http.py
+++ b/salt/utils/http.py
@@ -292,7 +292,7 @@ def query(url,
             auth = (username, password)
 
     if agent == USERAGENT:
-        agent = '{0} http.query()'.format(agent)
+        agent = '{0} http.query()'.format(opts.get('user_agent', agent))
     header_dict['User-agent'] = agent
 
     if backend == 'requests':


### PR DESCRIPTION
### What does this PR do?
Add parameter named user_agent to customize the UA header of http request.

### What issues does this PR fix or reference?
No

### Previous Behavior
UA always 'Salt/{0}'.format(salt.version.__version__)

### New Behavior
UA will firstly get the user_agent parameter from the configuration, otherwise it will be 'Salt/{0}'.format(salt.version.__version__)

### Tests written?
No

### Commits signed with GPG?
No