### PR TITLE
Allow our custom yaml dumper to NamespacedDictWrapper objects

### DIFF
--- a/salt/loader.py
+++ b/salt/loader.py
@@ -1357,11 +1357,11 @@ class LazyLoader(salt.utils.lazy.LazyDict):
         '''
         if '__grains__' not in self.pack:
             self.context_dict['grains'] = opts.get('grains', {})
-            self.pack['__grains__'] = salt.utils.context.NamespacedDictWrapper(self.context_dict, 'grains', override_name='grains')
+            self.pack['__grains__'] = salt.utils.context.NamespacedDictWrapper(self.context_dict, 'grains')
 
         if '__pillar__' not in self.pack:
             self.context_dict['pillar'] = opts.get('pillar', {})
-            self.pack['__pillar__'] = salt.utils.context.NamespacedDictWrapper(self.context_dict, 'pillar', override_name='pillar')
+            self.pack['__pillar__'] = salt.utils.context.NamespacedDictWrapper(self.context_dict, 'pillar')
 
         mod_opts = {}
         for key, val in list(opts.items()):

--- a/salt/utils/yamldumper.py
+++ b/salt/utils/yamldumper.py
@@ -17,6 +17,7 @@ except ImportError:
 
 import yaml
 import collections
+import salt.utils.context
 from salt.utils.odict import OrderedDict
 
 try:
@@ -52,6 +53,14 @@ OrderedDumper.add_representer(
 )
 SafeOrderedDumper.add_representer(
     collections.defaultdict,
+    yaml.representer.SafeRepresenter.represent_dict
+)
+OrderedDumper.add_representer(
+    salt.utils.context.NamespacedDictWrapper,
+    yaml.representer.SafeRepresenter.represent_dict
+)
+SafeOrderedDumper.add_representer(
+    salt.utils.context.NamespacedDictWrapper,
     yaml.representer.SafeRepresenter.represent_dict
 )
 

--- a/tests/integration/output/test_output.py
+++ b/tests/integration/output/test_output.py
@@ -7,6 +7,7 @@
 from __future__ import absolute_import
 import os
 import traceback
+import yaml
 
 # Import Salt Testing Libs
 from tests.support.case import ShellCase
@@ -80,6 +81,20 @@ class OutputReturnTest(ShellCase):
         expected = ['local: true']
         ret = self.run_call('test.ping --out=yaml')
         self.assertEqual(ret, expected)
+
+    def test_output_yaml_namespaced_dict_wrapper(self):
+        '''
+        Tests the ability to dump a NamespacedDictWrapper instance, as used in
+        magic dunders like __grains__ and __pillar__
+
+        See https://github.com/saltstack/salt/issues/49269
+        '''
+        dumped_yaml = '\n'.join(self.run_call('grains.items --out=yaml'))
+        loaded_yaml = yaml.load(dumped_yaml)
+        # We just want to check that the dumped YAML loades as a dict with a
+        # single top-level key, we don't care about the real contents.
+        assert isinstance(loaded_yaml, dict)
+        assert list(loaded_yaml) == ['local']
 
     def test_output_unicodebad(self):
         '''


### PR DESCRIPTION
This special dict class did not have a representer assigned to it, so PyYAML would raise an exception when attempting to dump it.

This also removes the class name overriding, as its implementation was ill-conceived and will be deprecated in a later branch (it's only used in this one place so deprecating should be of no-to-minimal impact).