### PR TITLE
Allow our custom yaml dumper to NamespacedDictWrapper objects (2018.3 branch)

### DIFF
--- a/salt/loader.py
+++ b/salt/loader.py
@@ -1380,11 +1380,11 @@ class LazyLoader(salt.utils.lazy.LazyDict):
         '''
         if '__grains__' not in self.pack:
             self.context_dict['grains'] = opts.get('grains', {})
-            self.pack['__grains__'] = salt.utils.context.NamespacedDictWrapper(self.context_dict, 'grains', override_name='grains')
+            self.pack['__grains__'] = salt.utils.context.NamespacedDictWrapper(self.context_dict, 'grains')
 
         if '__pillar__' not in self.pack:
             self.context_dict['pillar'] = opts.get('pillar', {})
-            self.pack['__pillar__'] = salt.utils.context.NamespacedDictWrapper(self.context_dict, 'pillar', override_name='pillar')
+            self.pack['__pillar__'] = salt.utils.context.NamespacedDictWrapper(self.context_dict, 'pillar')
 
         mod_opts = {}
         for key, val in list(opts.items()):

--- a/salt/utils/context.py
+++ b/salt/utils/context.py
@@ -203,10 +203,14 @@ class NamespacedDictWrapper(collections.MutableMapping, dict):
             self.pre_keys = (pre_keys,)
         else:
             self.pre_keys = pre_keys
-        if override_name:
-            self.__class__.__module__ = 'salt'
-            # __name__ can't be assigned a unicode
-            self.__class__.__name__ = str(override_name)  # future lint: disable=blacklisted-function
+        if override_name is not None:
+            import salt.utils.versions
+            salt.utils.versions.warn_until(
+                'Neon',
+                'Overriding the class name is no longer supported. Please '
+                'remove the override_name argument before it is removed in '
+                'Salt Sodium.'
+            )
         super(NamespacedDictWrapper, self).__init__(self._dict())
 
     def _dict(self):

--- a/salt/utils/yamldumper.py
+++ b/salt/utils/yamldumper.py
@@ -17,7 +17,7 @@ except ImportError:
 
 import yaml  # pylint: disable=blacklisted-import
 import collections
-
+import salt.utils.context
 from salt.utils.odict import OrderedDict
 
 try:
@@ -75,6 +75,14 @@ OrderedDumper.add_representer(
 )
 SafeOrderedDumper.add_representer(
     collections.defaultdict,
+    yaml.representer.SafeRepresenter.represent_dict
+)
+OrderedDumper.add_representer(
+    salt.utils.context.NamespacedDictWrapper,
+    yaml.representer.SafeRepresenter.represent_dict
+)
+SafeOrderedDumper.add_representer(
+    salt.utils.context.NamespacedDictWrapper,
     yaml.representer.SafeRepresenter.represent_dict
 )
 

--- a/tests/integration/output/test_output.py
+++ b/tests/integration/output/test_output.py
@@ -14,6 +14,7 @@ from tests.support.mixins import RUNTIME_VARS
 
 # Import Salt libs
 import salt.config
+import salt.utils.yaml
 from salt.output import display_output
 from salt.ext import six
 
@@ -81,6 +82,20 @@ class OutputReturnTest(ShellCase):
         expected = ['local: true']
         ret = self.run_call('test.ping --out=yaml')
         self.assertEqual(ret, expected)
+
+    def test_output_yaml_namespaced_dict_wrapper(self):
+        '''
+        Tests the ability to dump a NamespacedDictWrapper instance, as used in
+        magic dunders like __grains__ and __pillar__
+
+        See https://github.com/saltstack/salt/issues/49269
+        '''
+        dumped_yaml = '\n'.join(self.run_call('grains.items --out=yaml'))
+        loaded_yaml = salt.utils.yaml.safe_load(dumped_yaml)
+        # We just want to check that the dumped YAML loades as a dict with a
+        # single top-level key, we don't care about the real contents.
+        assert isinstance(loaded_yaml, dict)
+        assert list(loaded_yaml) == ['local']
 
     def test_output_unicodebad(self):
         '''


### PR DESCRIPTION
_(This is https://github.com/saltstack/salt/pull/49408 opened against the 2018.3 branch)_

This special dict class did not have a representer assigned to it, so PyYAML would raise an exception when attempting to dump it.

This also removes the class name overriding and deprecates the NamespacedDictWrapper's ability to do so, as it was A) incorrectly implmented and B) is no longer used by anything in Salt.