### PR TITLE
Add support to avoid calling refresh_db in opkg.del_repo

### DIFF
--- a/salt/modules/opkg.py
+++ b/salt/modules/opkg.py
@@ -1255,6 +1255,7 @@ def del_repo(alias, **kwargs):  # pylint: disable=unused-argument
 
         salt '*' pkg.del_repo alias
     '''
+    refresh = salt.utils.data.is_true(kwargs.get('refresh', True))
     repos = list_repos()
     if repos:
         deleted_from = dict()
@@ -1280,8 +1281,8 @@ def del_repo(alias, **kwargs):  # pylint: disable=unused-argument
                     except OSError:
                         pass
                 ret += msg.format(alias, repo_file)
-            # explicit refresh after a repo is deleted
-            refresh_db()
+            if refresh:
+                refresh_db()
             return ret
 
     return "Repo {0} doesn't exist in the opkg repo lists".format(alias)


### PR DESCRIPTION
### What does this PR do?
Since refresh_db is a costly operation we should have the option of not calling that

### Previous Behavior
Will always call refresh_db

### New Behavior
Checks in kwargs for 'refresh' key. If is false it will not call refresh_db.

### Tests written?

No

### Commits signed with GPG?

No
