### PR TITLE
Back-port #49258 to 2018.3.3

### DIFF
--- a/tests/integration/runners/test_state.py
+++ b/tests/integration/runners/test_state.py
@@ -38,6 +38,7 @@ from salt.ext.six.moves import queue
 log = logging.getLogger(__name__)
 
 
+@flaky
 class StateRunnerTest(ShellCase):
     '''
     Test the state runner.
@@ -51,7 +52,6 @@ class StateRunnerTest(ShellCase):
         q.put(ret)
         q.task_done()
 
-    @flaky
     def test_orchestrate_output(self):
         '''
         Ensure the orchestrate runner outputs useful state data.
@@ -284,6 +284,7 @@ class StateRunnerTest(ShellCase):
 
 
 @skipIf(salt.utils.platform.is_windows(), '*NIX-only test')
+@flaky
 class OrchEventTest(ShellCase):
     '''
     Tests for orchestration events

--- a/tests/integration/shell/test_call.py
+++ b/tests/integration/shell/test_call.py
@@ -161,6 +161,7 @@ class CallTest(ShellCase, testprogram.TestProgramCase, ShellCaseCommonTestsMixin
         self.assertTrue(True in ['returnTOmaster' in a for a in master_out])
 
     @skipIf(sys.platform.startswith('win'), 'This test does not apply on Win')
+    @flaky
     def test_issue_2731_masterless(self):
         root_dir = os.path.join(TMP, 'issue-2731')
         config_dir = os.path.join(root_dir, 'conf')
@@ -366,6 +367,7 @@ class CallTest(ShellCase, testprogram.TestProgramCase, ShellCaseCommonTestsMixin
             if os.path.isdir(config_dir):
                 shutil.rmtree(config_dir)
 
+    @flaky
     def test_issue_15074_output_file_append(self):
         output_file_append = os.path.join(TMP, 'issue-15074')
         try:


### PR DESCRIPTION
Back-port #49258 to 2018.3.3