### PR TITLE
Remove string conversion on frame object in sigusr1 handler

### DIFF
--- a/salt/utils/debug.py
+++ b/salt/utils/debug.py
@@ -41,7 +41,7 @@ def _handle_sigusr1(sig, stack):
         filename = 'salt-debug-{0}.log'.format(int(time.time()))
         destfile = os.path.join(tempfile.gettempdir(), filename)
         with salt.utils.files.fopen(destfile, 'w') as output:
-            _makepretty(output, salt.utils.stringutils.to_str(stack))
+            _makepretty(output, stack)
 
 
 def _handle_sigusr2(sig, stack):


### PR DESCRIPTION
### What does this PR do?
remove to_str conversion on frame object.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/49463

### Previous Behavior
stack trace when sending sigusr1 signal to master

```
TypeError: expected str, bytearray, or unicode
```

### New Behavior
correctly prints out the frame object information to the debug file.

### Tests written?

No

### Commits signed with GPG?

Yes