### PR TITLE
OmniOS also supports pkgin

### DIFF
--- a/salt/modules/pkgin.py
+++ b/salt/modules/pkgin.py
@@ -91,16 +91,21 @@ def _supports_parsing():
     return tuple([int(i) for i in _get_version()]) > (0, 6)
 
 
+@decorators.memoize
+def _get_provider():
+    '''
+    Check if we are the default provider for this platform
+    '''
+    return __grains__['os'] in ['NetBSD', 'DragonFly', 'Minix', 'Darwin', 'SmartOS'] or 'pkgin'
+
+
 def __virtual__():
     '''
     Set the virtual pkg module if the os is supported by pkgin
     '''
-    supported = ['NetBSD', 'SunOS', 'DragonFly', 'Minix', 'Darwin', 'SmartOS']
-
-    if __grains__['os'] in supported and _check_pkgin():
-        return __virtualname__
-    return (False, 'The pkgin execution module cannot be loaded: only '
-            'available on {0} systems.'.format(', '.join(supported)))
+    return (_check_pkgin() and _get_provider() or False,
+            'The pkgin execution module cannot be loaded: pkgin was '
+            'not detected on this platform.')
 
 
 def _splitpkg(name):


### PR DESCRIPTION
### What does this PR do?
As discovered in #49469 OmniOS is not loading the pkgin module while it is supported.
We remove SunOS and SmartOS from the OS list and enable pkgin for all members of the
Solaris family instead.

### What issues does this PR fix or reference?
This is a **partial** fix for #49469

### Previous Behavior
Only Sun/Oracle Solaris and SmartOS had pkgin support.

### New Behavior
The entire Solaris family has pkgin support, including OpenIndiana, OmniOS, ...

### Tests written?
No

### Commits signed with GPG?
No