### PR TITLE
Test fixes

### DIFF
--- a/salt/modules/pip.py
+++ b/salt/modules/pip.py
@@ -303,7 +303,7 @@ def _process_requirements(requirements, cmd, cwd, saltenv, user):
                 # In Windows, just being owner of a file isn't enough. You also
                 # need permissions
                 if salt.utils.platform.is_windows():
-                    __utils__['win_dacl.set_permissions'](
+                    __utils__['dacl.set_permissions'](
                         obj_name=treq,
                         principal=user,
                         permissions='read_execute')

--- a/salt/platform/win.py
+++ b/salt/platform/win.py
@@ -1080,7 +1080,7 @@ def enumerate_tokens(sid=None, session_id=None, privs=None):
             )
             th = win32security.OpenProcessToken(ph, access)
         except Exception as exc:
-            log.exception("OpenProcessToken failed pid=%d name=%s user%s", p.pid, p.name(), p.username())
+            log.debug("OpenProcessToken failed pid=%d name=%s user%s", p.pid, p.name(), p.username())
             continue
         try:
             process_sid = win32security.GetTokenInformation(th, win32security.TokenUser)[0]

--- a/tests/integration/files/file/base/issue-30161.sls
+++ b/tests/integration/files/file/base/issue-30161.sls
@@ -1,44 +1,44 @@
 unless_false_onlyif_true:
   file.managed:
     - name: {{ salt['runtests_helpers.get_salt_temp_dir_for_path']('test.txt') }}
-{% if grains['os'] != 'Windows' %}
-    - unless: /bin/false
-    - onlyif: /bin/true
-{% else %}
+{% if grains['os'] == 'Windows' %}
     - unless: cmd.exe /c exit 1
     - onlyif: cmd.exe /c exit 0
+{% else %}
+    - unless: /bin/false
+    - onlyif: /bin/true
 {% endif %}
 
 unless_true_onlyif_false:
   file.managed:
     - name: {{ salt['runtests_helpers.get_salt_temp_dir_for_path']('test.txt') }}
-{% if grains['os'] != 'Windows' %}
-    - unless: /bin/true
-    - onlyif: /bin/false
-{% else %}
+{% if grains['os'] == 'Windows' %}
     - unless: cmd.exe /c exit 0
     - onlyif: cmd.exe /c exit 1
+{% else %}
+    - unless: /bin/true
+    - onlyif: /bin/false
 {% endif %}
 
 unless_true_onlyif_true:
   file.managed:
     - name: {{ salt['runtests_helpers.get_salt_temp_dir_for_path']('test.txt') }}
-{% if grains['os'] != 'Windows' %}
-    - unless: /bin/true
-    - onlyif: /bin/true
-{% else %}
+{% if grains['os'] == 'Windows' %}
     - unless: cmd.exe /c exit 0
     - onlyif: cmd.exe /c exit 0
+{% else %}
+    - unless: /bin/true
+    - onlyif: /bin/true
 {% endif %}
 
 unless_false_onlyif_false:
   file.managed:
     - name: {{ salt['runtests_helpers.get_salt_temp_dir_for_path']('test.txt') }}
     - contents: test
-{% if grains['os'] != 'Windows' %}
-    - unless: /bin/false
-    - onlyif: /bin/false
-{% else %}
+{% if grains['os'] == 'Windows' %}
     - unless: cmd.exe /c exit 1
     - onlyif: cmd.exe /c exit 1
+{% else %}
+    - unless: /bin/false
+    - onlyif: /bin/false
 {% endif %}

--- a/tests/integration/files/file/base/issue-30161.sls
+++ b/tests/integration/files/file/base/issue-30161.sls
@@ -1,24 +1,44 @@
 unless_false_onlyif_true:
   file.managed:
     - name: {{ salt['runtests_helpers.get_salt_temp_dir_for_path']('test.txt') }}
+{% if grains['os'] != 'Windows' %}
     - unless: /bin/false
     - onlyif: /bin/true
+{% else %}
+    - unless: cmd.exe /c exit 1
+    - onlyif: cmd.exe /c exit 0
+{% endif %}
 
 unless_true_onlyif_false:
   file.managed:
     - name: {{ salt['runtests_helpers.get_salt_temp_dir_for_path']('test.txt') }}
+{% if grains['os'] != 'Windows' %}
     - unless: /bin/true
     - onlyif: /bin/false
+{% else %}
+    - unless: cmd.exe /c exit 0
+    - onlyif: cmd.exe /c exit 1
+{% endif %}
 
 unless_true_onlyif_true:
   file.managed:
     - name: {{ salt['runtests_helpers.get_salt_temp_dir_for_path']('test.txt') }}
+{% if grains['os'] != 'Windows' %}
     - unless: /bin/true
     - onlyif: /bin/true
+{% else %}
+    - unless: cmd.exe /c exit 0
+    - onlyif: cmd.exe /c exit 0
+{% endif %}
 
 unless_false_onlyif_false:
   file.managed:
     - name: {{ salt['runtests_helpers.get_salt_temp_dir_for_path']('test.txt') }}
     - contents: test
+{% if grains['os'] != 'Windows' %}
     - unless: /bin/false
     - onlyif: /bin/false
+{% else %}
+    - unless: cmd.exe /c exit 1
+    - onlyif: cmd.exe /c exit 1
+{% endif %}

--- a/tests/integration/modules/test_state.py
+++ b/tests/integration/modules/test_state.py
@@ -1957,29 +1957,29 @@ class StateModuleTest(ModuleCase, SaltReturnAssertsMixin):
         # command in the state. If the comment reads "unless condition is true", or similar,
         # then the unless state run bailed out after the first unless command succeeded,
         # which is the bug we're regression testing for.
-        _expected = {'file_|-unless_false_onlyif_false_|-{0}/test.txt_|-managed'.format(TMP):
+        _expected = {'file_|-unless_false_onlyif_false_|-{0}{1}test.txt_|-managed'.format(TMP, os.path.sep):
                      {'comment': 'onlyif condition is false\nunless condition is false',
-                      'name': '{0}/test.txt'.format(TMP),
+                      'name': '{0}{1}test.txt'.format(TMP, os.path.sep),
                       'skip_watch': True,
                       'changes': {},
                       'result': True},
-                     'file_|-unless_false_onlyif_true_|-{0}/test.txt_|-managed'.format(TMP):
+                     'file_|-unless_false_onlyif_true_|-{0}{1}test.txt_|-managed'.format(TMP, os.path.sep):
                      {'comment': 'Empty file',
                       'pchanges': {},
-                      'name': '{0}/test.txt'.format(TMP),
+                      'name': '{0}{1}test.txt'.format(TMP, os.path.sep),
                       'start_time': '18:10:20.341753',
                       'result': True,
-                      'changes': {'new': 'file {0}/test.txt created'.format(TMP)}},
-                     'file_|-unless_true_onlyif_false_|-{0}/test.txt_|-managed'.format(TMP):
+                      'changes': {'new': 'file {0}{1}test.txt created'.format(TMP, os.path.sep)}},
+                     'file_|-unless_true_onlyif_false_|-{0}{1}test.txt_|-managed'.format(TMP, os.path.sep):
                      {'comment': 'onlyif condition is false\nunless condition is true',
-                      'name': '{0}/test.txt'.format(TMP),
+                      'name': '{0}{1}test.txt'.format(TMP, os.path.sep),
                       'start_time': '18:10:22.936446',
                       'skip_watch': True,
                       'changes': {},
                       'result': True},
-                     'file_|-unless_true_onlyif_true_|-{0}/test.txt_|-managed'.format(TMP):
+                     'file_|-unless_true_onlyif_true_|-{0}{1}test.txt_|-managed'.format(TMP, os.path.sep):
                      {'comment': 'onlyif condition is true\nunless condition is true',
-                      'name': '{0}/test.txt'.format(TMP),
+                      'name': '{0}{1}test.txt'.format(TMP, os.path.sep),
                       'skip_watch': True,
                       'changes': {},
                       'result': True}}

--- a/tests/integration/states/test_reg.py
+++ b/tests/integration/states/test_reg.py
@@ -55,7 +55,10 @@ class RegTest(ModuleCase, SaltReturnAssertsMixin):
             'reg': {
                 'Added': {
                     'Entry': 'test_reg_sz',
+                    'Inheritance': True,
                     'Key': 'HKLM\\{0}'.format(FAKE_KEY),
+                    'Owner': None,
+                    'Perms': {'Deny': None, 'Grant': None},
                     'Value': 'fake string data'}}}
         self.assertSaltStateChangesEqual(ret, expected)
 
@@ -85,7 +88,10 @@ class RegTest(ModuleCase, SaltReturnAssertsMixin):
             'reg': {
                 'Added': {
                     'Entry': 'test_reg_sz',
+                    'Inheritance': True,
                     'Key': 'HKLM\\{0}'.format(FAKE_KEY),
+                    'Owner': None,
+                    'Perms': {'Deny': None, 'Grant': None},
                     'Value': UNICODE_VALUE}}}
         self.assertSaltStateChangesEqual(ret, expected)
 
@@ -114,7 +120,10 @@ class RegTest(ModuleCase, SaltReturnAssertsMixin):
             'reg': {
                 'Added': {
                     'Entry': '(Default)',
+                    'Inheritance': True,
                     'Key': 'HKLM\\{0}'.format(FAKE_KEY),
+                    'Owner': None,
+                    'Perms': {'Deny': None, 'Grant': None},
                     'Value': UNICODE_VALUE}}}
         self.assertSaltStateChangesEqual(ret, expected)
 
@@ -145,7 +154,10 @@ class RegTest(ModuleCase, SaltReturnAssertsMixin):
             'reg': {
                 'Added': {
                     'Entry': UNICODE_VALUE_NAME,
+                    'Inheritance': True,
                     'Key': 'HKLM\\{0}'.format(FAKE_KEY),
+                    'Owner': None,
+                    'Perms': {'Deny': None, 'Grant': None},
                     'Value': 'fake string data'}}}
         self.assertSaltStateChangesEqual(ret, expected)
 
@@ -178,7 +190,10 @@ class RegTest(ModuleCase, SaltReturnAssertsMixin):
             'reg': {
                 'Added': {
                     'Entry': 'test_reg_binary',
+                    'Inheritance': True,
                     'Key': 'HKLM\\{0}'.format(FAKE_KEY),
+                    'Owner': None,
+                    'Perms': {'Deny': None, 'Grant': None},
                     'Value': test_data}}}
         self.assertSaltStateChangesEqual(ret, expected)
 
@@ -209,7 +224,10 @@ class RegTest(ModuleCase, SaltReturnAssertsMixin):
             'reg': {
                 'Added': {
                     'Entry': 'test_reg_multi_sz',
+                    'Inheritance': True,
                     'Key': 'HKLM\\{0}'.format(FAKE_KEY),
+                    'Owner': None,
+                    'Perms': {'Deny': None, 'Grant': None},
                     'Value': ['item1', 'item2']}}}
         self.assertSaltStateChangesEqual(ret, expected)
 
@@ -243,7 +261,10 @@ class RegTest(ModuleCase, SaltReturnAssertsMixin):
             'reg': {
                 'Added': {
                     'Entry': 'test_reg_sz',
+                    'Inheritance': True,
                     'Key': 'HKLM\\{0}'.format(FAKE_KEY),
+                    'Owner': None,
+                    'Perms': {'Deny': None, 'Grant': None},
                     'Value': 'fake string data'}}}
         self.assertSaltStateChangesEqual(ret, expected)
 


### PR DESCRIPTION
### What does this PR do?

Fixing multiple tests failure from the Flourine Windows builds:

https://jenkinsci.saltstack.com/job/fluorine/job/salt-windows-2016-py2/22/

- The loader uses win_dacl's virtual name
   fixes: `integration.states.test_pip_state.PipStateTest.test_issue_6912_wrong_owner_requirements_file`
- Account for changes in Windows reg state
  fixes:

   ```
    integration.states.test_reg.RegTest.test_present_32_bit
    integration.states.test_reg.RegTest.test_present_reg_binary
    integration.states.test_reg.RegTest.test_present_reg_multi_sz
    integration.states.test_reg.RegTest.test_present_reg_sz
    integration.states.test_reg.RegTest.test_present_reg_sz_unicode_default_value
    integration.states.test_reg.RegTest.test_present_reg_sz_unicode_value
    integration.states.test_reg.RegTest.test_present_reg_sz_unicode_value_name
    ```

- Fix file unless onlyif tests on windows
  fixes: `integration.modules.test_state.StateModuleTest.test_issue_30161_unless_and_onlyif_together`

- Set log message from expected exception to debug so it won't confuse people.


### Tests written?

No - Fixing tests

### Commits signed with GPG?

Yes