### PR TITLE
fix "_salt_list_functions" function

### DIFF
--- a/pkg/salt.bash
+++ b/pkg/salt.bash
@@ -41,11 +41,11 @@ _salt_list_functions(){
     # sort: chop out doubled entries, so overhead is minimal later during actual completion
     if [ "$1" = 'local' ] ; then
         salt-call --log-level=quiet --out=txt -- sys.list_functions \
-          | sed "s/^.*\[//;s/[],u']//g;s/ /\n/g" \
+          | sed "s/^.*\[//;s/[],']\|u'//g;s/ /\n/g" \
           | sort -u
     else
         salt '*' --timeout 2 --hide-timeout --log-level=quiet --out=txt -- sys.list_functions \
-          | sed "s/^.*\[//;s/[],u']//g;s/ /\n/g" \
+          | sed "s/^.*\[//;s/[],']\|u'//g;s/ /\n/g" \
           | sort -u
     fi
 }

--- a/pkg/salt.bash
+++ b/pkg/salt.bash
@@ -41,11 +41,11 @@ _salt_list_functions(){
     # sort: chop out doubled entries, so overhead is minimal later during actual completion
     if [ "$1" = 'local' ] ; then
         salt-call --log-level=quiet --out=txt -- sys.list_functions \
-          | sed "s/^.*\[//;s/[],']//g;s/ /\n/g" \
+          | sed "s/^.*\[//;s/[],u']//g;s/ /\n/g" \
           | sort -u
     else
         salt '*' --timeout 2 --hide-timeout --log-level=quiet --out=txt -- sys.list_functions \
-          | sed "s/^.*\[//;s/[],']//g;s/ /\n/g" \
+          | sed "s/^.*\[//;s/[],u']//g;s/ /\n/g" \
           | sort -u
     fi
 }


### PR DESCRIPTION
Salt Version:
           Salt: 2018.3.2
System Versions:
           dist: Ubuntu 18.04 bionic

### What does this PR do?
fix "_salt_list_functions" function by updating sed command for generating ".cache/salt-local-comp-cache_functions" and ".cache/salt-remote-comp-cache_functions" bash completion files

### What issues does this PR fix or reference?
incomplete/malformed list of functions for salt bash completion 
