### PR TITLE
add cmd_blacklist_regex and cmd_whitelist_regex

### DIFF
--- a/doc/ref/configuration/master.rst
+++ b/doc/ref/configuration/master.rst
@@ -1470,6 +1470,40 @@ specific file.
 
     permissive_pki_access: False
 
+.. conf_master:: cmd_whitelist
+.. conf_master:: cmd_blacklist
+
+``cmd_whitelist/cmd_blacklist``
+-------------------------------
+
+Default: ``[]``
+
+By using this list, the shell command called over remote execution or
+via salt-call will be compared against each of the expressions in this list.
+Any shell command which match the blacklist will be blocked. If whitelist is SET,
+only the shell command which match the whitelist will be permitted.
+Exact matches, glob matches, and regular expressions are supported.
+
+.. note::
+
+    This whitelist/blacklist is only applied to direct executions made by the `salt`
+    and `salt-call` commands. This does NOT restrict commands called from states or
+    shell commands executed from other modules.
+
+.. versionadded:: Neon
+
+.. code-block:: yaml
+
+    cmd_whitelist:
+      - uptime
+      - ls*
+      - cat\s+.*
+
+    cmd_blacklist:
+      - reboot
+      - reboot*
+      - reboot($|\s+-.*)
+
 .. conf_master:: publisher_acl
 
 ``publisher_acl``

--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -1684,7 +1684,7 @@ class LocalClient(object):
             )
             raise SaltClientError
 
-        self._check_cmd_avail(fun, tgt, expr_form, arg)
+        self._check_cmd_avail(fun, tgt, tgt_type, arg)
 
         payload_kwargs = self._prep_pub(
                 tgt,
@@ -1793,7 +1793,7 @@ class LocalClient(object):
             )
             raise SaltClientError
 
-        self._check_cmd_avail(fun, tgt, expr_form, arg)
+        self._check_cmd_avail(fun, tgt, tgt_type, arg)
 
         payload_kwargs = self._prep_pub(
                 tgt,
@@ -1860,7 +1860,7 @@ class LocalClient(object):
         raise tornado.gen.Return({'jid': payload['load']['jid'],
                                   'minions': payload['load']['minions']})
 
-    def _check_cmd_avail(self, fun, tgt, expr_form, arg):
+    def _check_cmd_avail(self, fun, tgt, tgt_type, arg):
         '''
         Check to see if the given command can be run
         '''

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -244,6 +244,12 @@ VALID_OPTS = {
     # Rendrerer blacklist. Renderers from this list are disalloed even if specified in whitelist.
     'renderer_blacklist': list,
 
+    # Cmdmod whitelist. The only command from this list are allowed.
+    'cmd_whitelist': list,
+
+    # Cmdmod blacklist. Command from this list are disalloed even if specified in whitelist.
+    'cmd_blacklist': list,
+
     # A flag indicating that a highstate run should immediately cease if a failure occurs.
     'failhard': bool,
 
@@ -1245,6 +1251,8 @@ DEFAULT_MINION_OPTS = {
     'renderer': 'jinja|yaml',
     'renderer_whitelist': [],
     'renderer_blacklist': [],
+    'cmd_whitelist': [],
+    'cmd_blacklist': [],
     'random_startup_delay': 0,
     'failhard': False,
     'autoload_dynamic_modules': True,


### PR DESCRIPTION
### What does this PR do?
Although we now have some ways to limit the dangerous commands, there seems to be a lack of a convenient and efficient way to really solve this problem.

### What issues does this PR fix or reference?
No

### Previous Behavior
Maybe cmd_blacklist_glob and cmd_whitelist_glob can solve the dangerous command problems on the client side.
And publisher_acl can solve the dangerous command problems for non-root user on the server side.

### New Behavior
Now cmd_blacklist_regex and cmd_whitelist_regex can solve the dangerous command problems on the server side.

### Tests written?
No

### Commits signed with GPG?
No