### PR TITLE
Pin CherryPy version to < 18.0.0 in requirements files for PY2

### DIFF
--- a/requirements/opt.txt
+++ b/requirements/opt.txt
@@ -4,5 +4,6 @@ yappi>=0.8.2
 --allow-unverified python-novaclient>2.17.0
 --allow-unverified python-neutronclient>2.3.6
 python-gnupg
-cherrypy>=3.2.2
+cherrypy>=3.2.2,<18.0.0; python_version < '3.5'
+cherrypy>=3.2.2; python_version >= '3.5'
 libnacl

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -21,7 +21,8 @@ kubernetes<4.0
 psutil
 pyvmomi
 setproctitle
-cherrypy; sys.platform != 'win32' and sys.platform != 'darwin'
+cherrypy>=3.2.2,<18.0.0; python_version < '3.5' and sys.platform != 'win32' and sys.platform != 'darwin'
+cherrypy>=3.2.2; python_version >= '3.5' and sys.platform != 'win32' and sys.platform != 'darwin'
 ldap; sys.platform != 'win32' and sys.platform != 'darwin'
 pyinotify; sys.platform != 'win32' and sys.platform != 'darwin'
 PyMySQL; sys.platform != 'win32' and sys.platform != 'darwin'


### PR DESCRIPTION
Version 18.0 now requires Python 3.5, so we need to pin this for Py2.