### PR TITLE
Fix X509 remote signing on python3

### DIFF
--- a/salt/modules/x509.py
+++ b/salt/modules/x509.py
@@ -651,7 +651,7 @@ def read_crl(crl):
     text = get_pem_entry(text, pem_type='X509 CRL')
 
     crltempfile = tempfile.NamedTemporaryFile()
-    crltempfile.write(text)
+    crltempfile.write(salt.utils.stringutils.to_str(text))
     crltempfile.flush()
     crlparsed = _parse_openssl_crl(crltempfile.name)
     crltempfile.close()
@@ -756,8 +756,7 @@ def write_pem(text, path, overwrite=True, pem_type=None):
         text = get_pem_entry(text, pem_type=pem_type)
         _dhparams = ''
         _private_key = ''
-        if pem_type and pem_type == 'CERTIFICATE' and os.path.isfile(path) and \
-                not overwrite:
+        if pem_type and pem_type == 'CERTIFICATE' and os.path.isfile(path) and not overwrite:
             _filecontents = _text_or_file(path)
             try:
                 _dhparams = get_pem_entry(_filecontents, 'DH PARAMETERS')
@@ -770,7 +769,7 @@ def write_pem(text, path, overwrite=True, pem_type=None):
         with salt.utils.files.fopen(path, 'w') as _fp:
             if pem_type and pem_type == 'CERTIFICATE' and _private_key:
                 _fp.write(salt.utils.stringutils.to_str(_private_key))
-            _fp.write(text)
+            _fp.write(salt.utils.stringutils.to_str(text))
             if pem_type and pem_type == 'CERTIFICATE' and _dhparams:
                 _fp.write(salt.utils.stringutils.to_str(_dhparams))
     return 'PEM written to {0}'.format(path)
@@ -1759,13 +1758,13 @@ def verify_crl(crl, cert):
     crltext = _text_or_file(crl)
     crltext = get_pem_entry(crltext, pem_type='X509 CRL')
     crltempfile = tempfile.NamedTemporaryFile()
-    crltempfile.write(crltext)
+    crltempfile.write(salt.utils.stringutils.to_str(crltext))
     crltempfile.flush()
 
     certtext = _text_or_file(cert)
     certtext = get_pem_entry(certtext, pem_type='CERTIFICATE')
     certtempfile = tempfile.NamedTemporaryFile()
-    certtempfile.write(certtext)
+    certtempfile.write(salt.utils.stringutils.to_str(certtext))
     certtempfile.flush()
 
     cmd = ('openssl crl -noout -in {0} -CAfile {1}'.format(

--- a/salt/modules/x509.py
+++ b/salt/modules/x509.py
@@ -760,12 +760,14 @@ def write_pem(text, path, overwrite=True, pem_type=None):
             _filecontents = _text_or_file(path)
             try:
                 _dhparams = get_pem_entry(_filecontents, 'DH PARAMETERS')
-            except salt.exceptions.SaltInvocationError:
-                pass
+            except salt.exceptions.SaltInvocationError as err:
+                log.debug("Error when getting DH PARAMETERS: %s", err)
+                log.trace(err, exc_info=err)
             try:
                 _private_key = get_pem_entry(_filecontents, '(?:RSA )?PRIVATE KEY')
-            except salt.exceptions.SaltInvocationError:
-                pass
+            except salt.exceptions.SaltInvocationError as err:
+                log.debug("Error when getting PRIVATE KEY: %s", err)
+                log.trace(err, exc_info=err)
         with salt.utils.files.fopen(path, 'w') as _fp:
             if pem_type and pem_type == 'CERTIFICATE' and _private_key:
                 _fp.write(salt.utils.stringutils.to_str(_private_key))

--- a/salt/modules/x509.py
+++ b/salt/modules/x509.py
@@ -1362,9 +1362,9 @@ def create_certificate(
                 pem_type='CERTIFICATE REQUEST').replace('\n', '')
         if 'public_key' in kwargs:
             # Strip newlines to make passing through as cli functions easier
-            kwargs['public_key'] = get_public_key(
+            kwargs['public_key'] = salt.utils.stringutils.to_str(get_public_key(
                 kwargs['public_key'],
-                passphrase=kwargs['public_key_passphrase']).replace('\n', '')
+                passphrase=kwargs['public_key_passphrase'])).replace('\n', '')
 
         # Remove system entries in kwargs
         # Including listen_in and preqreuired because they are not included

--- a/salt/states/x509.py
+++ b/salt/states/x509.py
@@ -582,7 +582,7 @@ def certificate_managed(name,
             if not private_ret['result']:
                 return private_ret
 
-    file_args['contents'] += certificate
+    file_args['contents'] += salt.utils.stringutils.to_str(certificate)
 
     if not append_certs:
         append_certs = []


### PR DESCRIPTION
### What does this PR do?

It fixes the `x509` module to work, when using the `sign_remote_certificate` functionality.

### What issues does this PR fix or reference?

Another part for fixing https://bugzilla.suse.com/show_bug.cgi?id=1106382.

### Previous Behavior

Remote signing would not work and fail with an error `salt.exceptions.SaltInvocationError: PEM does not contain a single entry of type CERTIFICATE:`

### New Behavior

Remote signing works again.

### Tests written?

No, however a repository with a reproducer can be found [here](https://github.com/bergmannf/salt_x509_reproducer).

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
