### PR TITLE
Skip service module integration tests on CentOS 7

### DIFF
--- a/tests/integration/modules/test_service.py
+++ b/tests/integration/modules/test_service.py
@@ -25,6 +25,8 @@ class ServiceModuleTest(ModuleCase):
         os_family = self.run_function('grains.get', ['os_family'])
         os_release = self.run_function('grains.get', ['osrelease'])
         if os_family == 'RedHat':
+            if os_release[0] == '7':
+                self.skipTest('Disabled on CentOS 7 until we can fix SSH connection issues.')
             self.service_name = 'crond'
         elif os_family == 'Arch':
             self.service_name = 'sshd'


### PR DESCRIPTION
These are occassionally killing the SSH connection in our Jenkins tests. Let's skip them for now until we can delve more deeply into this.
