### PR TITLE
Revert "use the minion configured publish_port, not what is provided in auth payload"

### DIFF
--- a/salt/transport/tcp.py
+++ b/salt/transport/tcp.py
@@ -509,16 +509,9 @@ class AsyncTCPPubChannel(salt.transport.mixins.auth.AESPubClientMixin, salt.tran
             if not self.auth.authenticated:
                 yield self.auth.authenticate()
             if self.auth.authenticated:
-                # if this is changed from the default, we assume it was intentional
-                if int(self.opts.get('publish_port', 4506)) != 4506:
-                    self.publish_port = self.opts.get('publish_port')
-                # else take the relayed publish_port master reports
-                else:
-                    self.publish_port = self.auth.creds['publish_port']
-
                 self.message_client = SaltMessageClientPool(
                     self.opts,
-                    args=(self.opts, self.opts['master_ip'], int(self.publish_port),),
+                    args=(self.opts, self.opts['master_ip'], int(self.auth.creds['publish_port']),),
                     kwargs={'io_loop': self.io_loop,
                             'connect_callback': self.connect_callback,
                             'disconnect_callback': self.disconnect_callback,

--- a/salt/transport/zeromq.py
+++ b/salt/transport/zeromq.py
@@ -436,14 +436,7 @@ class AsyncZeroMQPubChannel(salt.transport.mixins.auth.AESPubClientMixin, salt.t
     def connect(self):
         if not self.auth.authenticated:
             yield self.auth.authenticate()
-
-        # if this is changed from the default, we assume it was intentional
-        if int(self.opts.get('publish_port', 4506)) != 4506:
-            self.publish_port = self.opts.get('publish_port')
-        # else take the relayed publish_port master reports
-        else:
-            self.publish_port = self.auth.creds['publish_port']
-
+        self.publish_port = self.auth.creds['publish_port']
         log.debug('Connecting the Minion to the Master publish port, using the URI: %s', self.master_pub)
         self._socket.connect(self.master_pub)
 


### PR DESCRIPTION
This reverts commit a0d723f78f3f6196e11f70058dd9056fbed16676, which
caused the auth errors in https://github.com/saltstack/salt-jenkins/issues/1117