### PR TITLE
[2018.3] Disable boto tests under 3.7

### DIFF
--- a/tests/unit/modules/test_boto_elb.py
+++ b/tests/unit/modules/test_boto_elb.py
@@ -6,6 +6,7 @@ import logging
 from copy import deepcopy
 import pkg_resources
 import os.path
+import sys
 
 # imprt salt paths
 from tests.support.paths import TESTS_DIR
@@ -121,6 +122,7 @@ class BotoElbTestCase(TestCase, LoaderModuleMockMixin):
 
     @mock_ec2_deprecated
     @mock_elb_deprecated
+    @skipIf(sys.version_info > (3, 6), 'Disabled for 3.7+ pending https://github.com/spulec/moto/issues/1706.')
     def test_register_instances_valid_id_result_true(self):
         '''
         tests that given a valid instance id and valid ELB that
@@ -140,6 +142,7 @@ class BotoElbTestCase(TestCase, LoaderModuleMockMixin):
 
     @mock_ec2_deprecated
     @mock_elb_deprecated
+    @skipIf(sys.version_info > (3, 6), 'Disabled for 3.7+ pending https://github.com/spulec/moto/issues/1706.')
     def test_register_instances_valid_id_string(self):
         '''
         tests that given a string containing a instance id and valid ELB that
@@ -163,6 +166,7 @@ class BotoElbTestCase(TestCase, LoaderModuleMockMixin):
 
     @mock_ec2_deprecated
     @mock_elb_deprecated
+    @skipIf(sys.version_info > (3, 6), 'Disabled for 3.7+ pending https://github.com/spulec/moto/issues/1706.')
     def test_deregister_instances_valid_id_result_true(self):
         '''
         tests that given an valid id the boto_elb deregister_instances method
@@ -184,6 +188,7 @@ class BotoElbTestCase(TestCase, LoaderModuleMockMixin):
 
     @mock_ec2_deprecated
     @mock_elb_deprecated
+    @skipIf(sys.version_info > (3, 6), 'Disabled for 3.7+ pending https://github.com/spulec/moto/issues/1706.')
     def test_deregister_instances_valid_id_string(self):
         '''
         tests that given an valid id the boto_elb deregister_instances method
@@ -210,6 +215,7 @@ class BotoElbTestCase(TestCase, LoaderModuleMockMixin):
 
     @mock_ec2_deprecated
     @mock_elb_deprecated
+    @skipIf(sys.version_info > (3, 6), 'Disabled for 3.7+ pending https://github.com/spulec/moto/issues/1706.')
     def test_deregister_instances_valid_id_list(self):
         '''
         tests that given an valid ids in the form of a list that the boto_elb

--- a/tests/unit/modules/test_boto_route53.py
+++ b/tests/unit/modules/test_boto_route53.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import, print_function, unicode_literals
 import logging
 import pkg_resources
 import os.path
+import sys
 
 # Import Salt Libs
 import salt.config
@@ -69,6 +70,7 @@ def _has_required_moto():
 @skipIf(HAS_MOTO is False, 'The moto module must be installed.')
 @skipIf(_has_required_moto() is False, 'The moto module must be >= to {0} for '
                                        'PY2 or {1} for PY3.'.format(required_moto, required_moto_py3))
+@skipIf(sys.version_info > (3, 6), 'Disabled for 3.7+ pending https://github.com/spulec/moto/issues/1706.')
 class BotoRoute53TestCase(TestCase, LoaderModuleMockMixin):
     '''
     TestCase for salt.modules.boto_route53 module

--- a/tests/unit/modules/test_boto_secgroup.py
+++ b/tests/unit/modules/test_boto_secgroup.py
@@ -6,6 +6,7 @@ import random
 import string
 from copy import deepcopy
 import os.path
+import sys
 
 # Import Salt Testing Libs
 from tests.support.mixins import LoaderModuleMockMixin
@@ -120,6 +121,7 @@ class BotoSecgroupTestCase(TestCase, LoaderModuleMockMixin):
                        {'to_port': 80, 'from_port': 80, 'ip_protocol': u'tcp', 'cidr_ip': u'0.0.0.0/0'}]
         self.assertEqual(boto_secgroup._split_rules(rules), split_rules)
 
+    @skipIf(sys.version_info > (3, 6), 'Disabled for 3.7+ pending https://github.com/spulec/moto/issues/1706.')
     @mock_ec2_deprecated
     def test_create_ec2_classic(self):
         '''
@@ -140,6 +142,7 @@ class BotoSecgroupTestCase(TestCase, LoaderModuleMockMixin):
                                   secgroup_created_group[0].vpc_id]
         self.assertEqual(expected_create_result, secgroup_create_result)
 
+    @skipIf(sys.version_info > (3, 6), 'Disabled for 3.7+ pending https://github.com/spulec/moto/issues/1706.')
     @mock_ec2_deprecated
     def test_create_ec2_vpc(self):
         '''
@@ -158,6 +161,7 @@ class BotoSecgroupTestCase(TestCase, LoaderModuleMockMixin):
         secgroup_create_result = [secgroup_created_group[0].name, secgroup_created_group[0].description, secgroup_created_group[0].vpc_id]
         self.assertEqual(expected_create_result, secgroup_create_result)
 
+    @skipIf(sys.version_info > (3, 6), 'Disabled for 3.7+ pending https://github.com/spulec/moto/issues/1706.')
     @mock_ec2_deprecated
     def test_get_group_id_ec2_classic(self):
         '''
@@ -200,6 +204,7 @@ class BotoSecgroupTestCase(TestCase, LoaderModuleMockMixin):
                                                         **conn_parameters)
         self.assertEqual(group_vpc.id, retrieved_group_id)
 
+    @skipIf(sys.version_info > (3, 6), 'Disabled for 3.7+ pending https://github.com/spulec/moto/issues/1706.')
     @mock_ec2_deprecated
     def test_get_config_single_rule_group_name(self):
         '''
@@ -224,6 +229,7 @@ class BotoSecgroupTestCase(TestCase, LoaderModuleMockMixin):
         secgroup_get_config_result = boto_secgroup.get_config(group_id=group.id, **conn_parameters)
         self.assertEqual(expected_get_config_result, secgroup_get_config_result)
 
+    @skipIf(sys.version_info > (3, 6), 'Disabled for 3.7+ pending https://github.com/spulec/moto/issues/1706.')
     @mock_ec2_deprecated
     def test_exists_true_name_classic(self):
         '''
@@ -237,10 +243,12 @@ class BotoSecgroupTestCase(TestCase, LoaderModuleMockMixin):
         salt_exists_result = boto_secgroup.exists(name=group_name, **conn_parameters)
         self.assertTrue(salt_exists_result)
 
+    @skipIf(sys.version_info > (3, 6), 'Disabled for 3.7+ pending https://github.com/spulec/moto/issues/1706.')
     @mock_ec2_deprecated
     def test_exists_false_name_classic(self):
         pass
 
+    @skipIf(sys.version_info > (3, 6), 'Disabled for 3.7+ pending https://github.com/spulec/moto/issues/1706.')
     @mock_ec2_deprecated
     def test_exists_true_name_vpc(self):
         '''
@@ -253,6 +261,7 @@ class BotoSecgroupTestCase(TestCase, LoaderModuleMockMixin):
         salt_exists_result = boto_secgroup.exists(name=group_name, vpc_id=vpc_id, **conn_parameters)
         self.assertTrue(salt_exists_result)
 
+    @skipIf(sys.version_info > (3, 6), 'Disabled for 3.7+ pending https://github.com/spulec/moto/issues/1706.')
     @mock_ec2_deprecated
     def test_exists_false_name_vpc(self):
         '''
@@ -262,6 +271,7 @@ class BotoSecgroupTestCase(TestCase, LoaderModuleMockMixin):
         salt_exists_result = boto_secgroup.exists(group_name, vpc_id=vpc_id, **conn_parameters)
         self.assertFalse(salt_exists_result)
 
+    @skipIf(sys.version_info > (3, 6), 'Disabled for 3.7+ pending https://github.com/spulec/moto/issues/1706.')
     @mock_ec2_deprecated
     def test_exists_true_group_id(self):
         '''
@@ -274,6 +284,7 @@ class BotoSecgroupTestCase(TestCase, LoaderModuleMockMixin):
         salt_exists_result = boto_secgroup.exists(group_id=group.id, **conn_parameters)
         self.assertTrue(salt_exists_result)
 
+    @skipIf(sys.version_info > (3, 6), 'Disabled for 3.7+ pending https://github.com/spulec/moto/issues/1706.')
     @mock_ec2_deprecated
     def test_exists_false_group_id(self):
         '''
@@ -283,6 +294,7 @@ class BotoSecgroupTestCase(TestCase, LoaderModuleMockMixin):
         salt_exists_result = boto_secgroup.exists(group_id=group_id, **conn_parameters)
         self.assertFalse(salt_exists_result)
 
+    @skipIf(sys.version_info > (3, 6), 'Disabled for 3.7+ pending https://github.com/spulec/moto/issues/1706.')
     @mock_ec2_deprecated
     def test_delete_group_ec2_classic(self):
         '''
@@ -309,10 +321,12 @@ class BotoSecgroupTestCase(TestCase, LoaderModuleMockMixin):
         actual_groups = [group.id for group in conn.get_all_security_groups()]
         self.assertEqual(expected_groups, actual_groups)
 
+    @skipIf(sys.version_info > (3, 6), 'Disabled for 3.7+ pending https://github.com/spulec/moto/issues/1706.')
     @mock_ec2_deprecated
     def test_delete_group_name_ec2_vpc(self):
         pass
 
+    @skipIf(sys.version_info > (3, 6), 'Disabled for 3.7+ pending https://github.com/spulec/moto/issues/1706.')
     @mock_ec2_deprecated
     def test__get_conn_true(self):
         '''

--- a/tests/unit/modules/test_boto_vpc.py
+++ b/tests/unit/modules/test_boto_vpc.py
@@ -8,6 +8,7 @@ from __future__ import absolute_import, print_function, unicode_literals
 import random
 import string
 import os.path
+import sys
 # pylint: disable=3rd-party-module-not-gated
 import pkg_resources
 from pkg_resources import DistributionNotFound
@@ -271,6 +272,7 @@ class BotoVpcTestCaseMixin(object):
         return rtbl
 
 
+@skipIf(sys.version_info > (3, 6), 'Disabled for 3.7+ pending https://github.com/spulec/moto/issues/1706.')
 class BotoVpcTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
     '''
     TestCase for salt.modules.boto_vpc module
@@ -369,7 +371,6 @@ class BotoVpcTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
         self.assertFalse(vpc_exists_result['exists'])
 
     @mock_ec2_deprecated
-    @skipIf(True, 'Disabled pending https://github.com/spulec/moto/issues/493')
     def test_that_when_checking_if_a_vpc_exists_but_providing_no_filters_the_vpc_exists_method_raises_a_salt_invocation_error(self):
         '''
         Tests checking vpc existence when no filters are provided
@@ -446,7 +447,6 @@ class BotoVpcTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
         self.assertEqual(get_id_result['id'], None)
 
     @mock_ec2_deprecated
-    @skipIf(True, 'Disabled pending https://github.com/spulec/moto/issues/493')
     def test_get_vpc_id_method_when_not_providing_filters_raises_a_salt_invocation_error(self):
         '''
         Tests getting vpc id but providing no filters
@@ -591,6 +591,7 @@ class BotoVpcTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
                                        ' or equal to version {}. Installed: {}'
         .format(required_boto_version, _get_boto_version()))
 @skipIf(_has_required_moto() is False, 'The moto version must be >= to version {0}'.format(required_moto_version))
+@skipIf(sys.version_info > (3, 6), 'Disabled for 3.7+ pending https://github.com/spulec/moto/issues/1706.')
 class BotoVpcSubnetsTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
     @mock_ec2_deprecated
     def test_get_subnet_association_single_subnet(self):
@@ -893,6 +894,7 @@ class BotoVpcSubnetsTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 @skipIf(_has_required_boto() is False, 'The boto module must be greater than'
                                        ' or equal to version {}. Installed: {}'
         .format(required_boto_version, _get_boto_version()))
+@skipIf(sys.version_info > (3, 6), 'Disabled for 3.7+ pending https://github.com/spulec/moto/issues/1706.')
 class BotoVpcInternetGatewayTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
     @mock_ec2_deprecated
     def test_that_when_creating_an_internet_gateway_the_create_internet_gateway_method_returns_true(self):
@@ -954,6 +956,7 @@ class BotoVpcInternetGatewayTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 @skipIf(_has_required_boto() is False, 'The boto module must be greater than'
                                        ' or equal to version {}. Installed: {}'
         .format(required_boto_version, _get_boto_version()))
+@skipIf(sys.version_info > (3, 6), 'Disabled for 3.7+ pending https://github.com/spulec/moto/issues/1706.')
 class BotoVpcNatGatewayTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
     @mock_ec2_deprecated
     def test_that_when_creating_an_nat_gateway_the_create_nat_gateway_method_returns_true(self):
@@ -1042,6 +1045,7 @@ class BotoVpcCustomerGatewayTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
                                        ' or equal to version {}. Installed: {}'
         .format(required_boto_version, _get_boto_version()))
 @skipIf(_has_required_moto() is False, 'The moto version must be >= to version {0}'.format(required_moto_version))
+@skipIf(sys.version_info > (3, 6), 'Disabled for 3.7+ pending https://github.com/spulec/moto/issues/1706.')
 class BotoVpcDHCPOptionsTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
     @mock_ec2_deprecated
     def test_that_when_creating_dhcp_options_succeeds_the_create_dhcp_options_method_returns_true(self):
@@ -1209,6 +1213,7 @@ class BotoVpcDHCPOptionsTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 @skipIf(_has_required_boto() is False, 'The boto module must be greater than'
                                        ' or equal to version {}. Installed: {}'
         .format(required_boto_version, _get_boto_version()))
+@skipIf(sys.version_info > (3, 6), 'Disabled for 3.7+ pending https://github.com/spulec/moto/issues/1706.')
 class BotoVpcNetworkACLTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
     @mock_ec2_deprecated
     def test_that_when_creating_network_acl_for_an_existing_vpc_the_create_network_acl_method_returns_true(self):
@@ -1792,6 +1797,7 @@ class BotoVpcRouteTablesTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
                                        ' or equal to version {}. Installed: {}'
         .format(required_boto_version, _get_boto_version()))
 @skipIf(_has_required_moto() is False, 'The moto version must be >= to version {0}'.format(required_moto_version))
+@skipIf(sys.version_info > (3, 6), 'Disabled for 3.7+ pending https://github.com/spulec/moto/issues/1706.')
 class BotoVpcPeeringConnectionsTest(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
     @mock_ec2_deprecated


### PR DESCRIPTION
### What does this PR do?
Disable various boto tests when run under python 3.7 because of http://github.com/spulec/moto/issues/1706. which was causing the test suite to hang on unit tests.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt-jenkins/issues/1075

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
