### PR TITLE
Fix wrong 'recurse' behavior on for linux_acl.present/absent states

### DIFF
--- a/salt/states/linux_acl.py
+++ b/salt/states/linux_acl.py
@@ -66,7 +66,7 @@ def present(name, acl_type, acl_name='', perms='', recurse=False):
         ret['result'] = False
         return ret
 
-    __current_perms = __salt__['acl.getfacl'](name)
+    __current_perms = __salt__['acl.getfacl'](name, recursive=recurse)
 
     if acl_type.startswith(('d:', 'default:')):
         _acl_type = ':'.join(acl_type.split(':')[1:])
@@ -97,7 +97,18 @@ def present(name, acl_type, acl_name='', perms='', recurse=False):
             user = None
 
         if user:
-            if user[_search_name]['octal'] == sum([_octal.get(i, i) for i in perms]):
+            octal_sum = sum([_octal.get(i, i) for i in perms])
+            need_refresh = False
+            for path in __current_perms:
+                acl_found = False
+                for user_acl in __current_perms[path].get(_acl_type, []):
+                    if _search_name in user_acl and user_acl[_search_name]['octal'] == octal_sum:
+                        acl_found = True
+                        break
+                if not acl_found:
+                    need_refresh = True
+                    break
+            if not need_refresh:
                 ret['comment'] = 'Permissions are in the desired state'
             else:
                 changes = {'new': {'acl_name': acl_name,
@@ -169,7 +180,7 @@ def absent(name, acl_type, acl_name='', perms='', recurse=False):
         ret['result'] = False
         return ret
 
-    __current_perms = __salt__['acl.getfacl'](name)
+    __current_perms = __salt__['acl.getfacl'](name, recursive=rescurse)
 
     if acl_type.startswith(('d:', 'default:')):
         _acl_type = ':'.join(acl_type.split(':')[1:])

--- a/salt/states/linux_acl.py
+++ b/salt/states/linux_acl.py
@@ -180,7 +180,7 @@ def absent(name, acl_type, acl_name='', perms='', recurse=False):
         ret['result'] = False
         return ret
 
-    __current_perms = __salt__['acl.getfacl'](name, recursive=rescurse)
+    __current_perms = __salt__['acl.getfacl'](name, recursive=recurse)
 
     if acl_type.startswith(('d:', 'default:')):
         _acl_type = ':'.join(acl_type.split(':')[1:])

--- a/salt/states/linux_acl.py
+++ b/salt/states/linux_acl.py
@@ -210,7 +210,18 @@ def absent(name, acl_type, acl_name='', perms='', recurse=False):
         except (AttributeError, IndexError, StopIteration, KeyError):
             user = None
 
-        if user:
+        need_refresh = False
+        for path in __current_perms:
+            acl_found = False
+            for user_acl in __current_perms[path].get(_acl_type, []):
+                if _search_name in user_acl:
+                    acl_found = True
+                    break
+            if acl_found:
+                need_refresh = True
+                break
+
+        if user or need_refresh:
             ret['comment'] = 'Removing permissions'
 
             if __opts__['test']:

--- a/tests/unit/states/test_linux_acl.py
+++ b/tests/unit/states/test_linux_acl.py
@@ -234,7 +234,7 @@ class LinuxAclTestCase(TestCase, LoaderModuleMockMixin):
                'changes': {}}
 
         mock = MagicMock(side_effect=[
-            {name: {acl_type: [{acl_name: {'octal': 'rwx'}}]}, name+"/foo": {acl_type: [{acl_name: {'octal': 'A'}}]}}
+            {name: {acl_type: [{acl_name: {'octal': 7}}]}, name+"/foo": {acl_type: [{acl_name: {'octal': 'A'}}]}}
         ])
         with patch.dict(linux_acl.__salt__, {'acl.getfacl': mock}):
             with patch.dict(linux_acl.__opts__, {'test': True}):

--- a/tests/unit/states/test_linux_acl.py
+++ b/tests/unit/states/test_linux_acl.py
@@ -51,8 +51,14 @@ class LinuxAclTestCase(TestCase, LoaderModuleMockMixin):
                                       {name: {acl_type: [{}]}},
                                       {name: {acl_type: [{}]}},
                                       {name: {acl_type: [{}]}},
-                                      {name: {acl_type: [{acl_name: {'octal': 7}}]}, name+"/foo": {acl_type: [{acl_name: {'octal': 'A'}}]}},
-                                      {name: {acl_type: [{acl_name: {'octal': 7}}]}, name+"/foo": {acl_type: [{acl_name: {'octal': 7}}]}},
+                                      {
+                                          name: {acl_type: [{acl_name: {'octal': 7}}]},
+                                          name+"/foo": {acl_type: [{acl_name: {'octal': 'A'}}]}
+                                      },
+                                      {
+                                          name: {acl_type: [{acl_name: {'octal': 7}}]},
+                                          name+"/foo": {acl_type: [{acl_name: {'octal': 7}}]}
+                                      },
                                       {name: {acl_type: ''}}])
         mock_modfacl = MagicMock(return_value=True)
 
@@ -217,7 +223,6 @@ class LinuxAclTestCase(TestCase, LoaderModuleMockMixin):
             comt = ('ACL Type does not exist')
             ret.update({'comment': comt, 'result': False})
             self.assertDictEqual(linux_acl.absent(name, acl_type, acl_name, perms), ret)
-
 
     def test_absent_recursive(self):
         '''

--- a/tests/unit/states/test_linux_acl.py
+++ b/tests/unit/states/test_linux_acl.py
@@ -51,6 +51,8 @@ class LinuxAclTestCase(TestCase, LoaderModuleMockMixin):
                                       {name: {acl_type: [{}]}},
                                       {name: {acl_type: [{}]}},
                                       {name: {acl_type: [{}]}},
+                                      {name: {acl_type: [{acl_name: {'octal': 7}}]}, name+"/foo": {acl_type: [{acl_name: {'octal': 'A'}}]}},
+                                      {name: {acl_type: [{acl_name: {'octal': 7}}]}, name+"/foo": {acl_type: [{acl_name: {'octal': 7}}]}},
                                       {name: {acl_type: ''}}])
         mock_modfacl = MagicMock(return_value=True)
 
@@ -146,6 +148,41 @@ class LinuxAclTestCase(TestCase, LoaderModuleMockMixin):
                     self.assertDictEqual(linux_acl.present(name, acl_type,
                                                            acl_name, perms),
                                          ret)
+
+            # New - recurse true
+            with patch.dict(linux_acl.__salt__, {'acl.getfacl': mock}):
+                # Update - test=True
+                with patch.dict(linux_acl.__opts__, {'test': True}):
+                    comt = ('Updated permissions will be applied for {0}: 7 -> {1}'
+                            ''.format(acl_name, perms))
+                    ret = {'name': name,
+                           'comment': comt,
+                           'changes': {},
+                           'pchanges': {'new': {'acl_name': acl_name,
+                                                'acl_type': acl_type,
+                                                'perms': perms},
+                                        'old': {'acl_name': acl_name,
+                                                'acl_type': acl_type,
+                                                'perms': '7'}},
+                           'result': None}
+
+                    self.assertDictEqual(linux_acl.present(name, acl_type, acl_name,
+                                                           perms, recurse=False), ret)
+
+            # New - recurse true - nothing to do
+            with patch.dict(linux_acl.__salt__, {'acl.getfacl': mock}):
+                # Update - test=True
+                with patch.dict(linux_acl.__opts__, {'test': True}):
+                    comt = ('Permissions are in the desired state')
+                    ret = {'name': name,
+                           'comment': comt,
+                           'changes': {},
+                           'pchanges': {},
+                           'result': True}
+
+                    self.assertDictEqual(linux_acl.present(name, acl_type, acl_name,
+                                                           perms, recurse=True), ret)
+
             # No acl type
             comt = ('ACL Type does not exist')
             ret = {'name': name, 'comment': comt, 'result': False,
@@ -153,7 +190,7 @@ class LinuxAclTestCase(TestCase, LoaderModuleMockMixin):
             self.assertDictEqual(linux_acl.present(name, acl_type, acl_name,
                                                    perms), ret)
 
-    # 'absent' function tests: 1
+    # 'absent' function tests: 2
 
     def test_absent(self):
         '''
@@ -180,3 +217,27 @@ class LinuxAclTestCase(TestCase, LoaderModuleMockMixin):
             comt = ('ACL Type does not exist')
             ret.update({'comment': comt, 'result': False})
             self.assertDictEqual(linux_acl.absent(name, acl_type, acl_name, perms), ret)
+
+
+    def test_absent_recursive(self):
+        '''
+        Test to ensure a Linux ACL does not exist
+        '''
+        name = '/root'
+        acl_type = 'users'
+        acl_name = 'damian'
+        perms = 'rwx'
+
+        ret = {'name': name,
+               'result': None,
+               'comment': '',
+               'changes': {}}
+
+        mock = MagicMock(side_effect=[
+            {name: {acl_type: [{acl_name: {'octal': 'rwx'}}]}, name+"/foo": {acl_type: [{acl_name: {'octal': 'A'}}]}}
+        ])
+        with patch.dict(linux_acl.__salt__, {'acl.getfacl': mock}):
+            with patch.dict(linux_acl.__opts__, {'test': True}):
+                comt = ('Removing permissions')
+                ret.update({'comment': comt})
+                self.assertDictEqual(linux_acl.absent(name, acl_type, acl_name, perms, recurse=True), ret)


### PR DESCRIPTION
### What does this PR do?
This PR fixes an issue on the behavior of the `linux_acl.present` and `linux_acl.absent` states when using `recurse=True`.

Currently, when the `recurse` parameter is set to `True` for a `linux_acl.present` state, it will only be recursively fixing the ACL in case main directory (the `name` parameter) is in a wrong state, otherwise nothing is done even when subdirectories are actually in a wrong state.

Given this SLS file:
```yaml
change_acls_for_user:
  acl.present:
    - name: /srv/acl_test
    - acl_type: user
    - acl_name: salt
    - perms: rw
    - recurse: True
```

And we have this ACL setup on `/srv/acl_test`:
```console
# find /srv/acl_test/
/srv/acl_test/
/srv/acl_test/test1
/srv/acl_test/test2

# getfacl -R /srv/acl_test
# file: srv/acl_test/
# owner: tomcat
# group: tomcat
user::rwx
user:salt:rw-
group::r-x
mask::rwx
other::r-x

# file: srv/acl_test/test2
# owner: root
# group: root
user::rwx
group::r-x
other::r-x

# file: srv/acl_test/test1
# owner: root
# group: root
user::rwx
group::r-x
other::r-x
```
As you can see the defined `ACL` on the SLS  is prorperly set for `/srv/acl_test` but not either `/srv/acl_test/test1` nor `/srv/acl_test/test2`.

So, if I apply the previous state on the SLS now, I would expect those the subdirectories will be fixed with the right ACL but they won't. Salt will report that `/srv/acl_test` is on the right state and nothing happens:

```
local:
----------
          ID: change_acls_for_user
    Function: acl.present
        Name: /srv/acl_test
      Result: True
     Comment: Permissions are in the desired state
     Started: 12:50:29.117809
    Duration: 10.405 ms
     Changes:   
----------
```

But in case the main `/srv/acl_test` is on a wrong state, then `linux_acl.present` will properly set the defined ACL also for ALL subdirectories (which IMHO is the right behavior when using `recurse=True`:

```
          ID: change_acls_for_user
    Function: acl.present
        Name: /srv/acl_test
      Result: True
     Comment: Updated permissions for salt
     Started: 12:50:27.251659
    Duration: 11.322 ms
     Changes:   
              ----------
              new:
                  ----------
                  acl_name:
                      salt
                  acl_type:
                      user
                  perms:
                      rw
              old:
                  ----------
                  acl_name:
                      salt
                  acl_type:
                      user
                  perms:
                      6
```

### Previous Behavior
Even with `recurse=True`, the `linux_acl.present` and `linux_acl.absent` states only work recursively when the main path (set by `name` parameter) is in a wrong ACL state. Otherwise it will return "no changes" even when subdirectories needs to be fixed with the right ACL.

### New Behavior
Now with this PR, both `linux_acl.present` and `linux_acl.absent` states will check into all subdirectories to figure out if changes needs to be make or not.

### Tests written?

Yes

### Commits signed with GPG?

Yes