### PR TITLE
Skip test_virt and pip_state requirements tests on macosx

### DIFF
--- a/tests/integration/states/test_pip_state.py
+++ b/tests/integration/states/test_pip_state.py
@@ -338,6 +338,7 @@ class PipStateTest(ModuleCase, SaltReturnAssertsMixin):
 
     @destructiveTest
     @skip_if_not_root
+    @skipIf(salt.utils.platform.is_darwin(), 'Test is flaky on macosx')
     @skipIf(not CAN_RUNAS, 'Runas support required')
     @with_system_user('issue-6912', on_existing='delete', delete=True,
                       password='PassWord1!')

--- a/tests/integration/states/test_virtualenv.py
+++ b/tests/integration/states/test_virtualenv.py
@@ -28,6 +28,7 @@ from salt.modules.virtualenv_mod import KNOWN_BINARY_NAMES
 
 @skipIf(salt.utils.path.which_bin(KNOWN_BINARY_NAMES) is None, 'virtualenv not installed')
 class VirtualenvTest(ModuleCase, SaltReturnAssertsMixin):
+    @skipIf(salt.utils.platform.is_darwin(), 'Test is flaky on macosx')
     @destructiveTest
     @skip_if_not_root
     def test_issue_1959_virtualenv_runas(self):


### PR DESCRIPTION
Fixes https://github.com/saltstack/salt-jenkins/issues/1055