### PR TITLE
Fix for SUSE Expanded Support detection

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1769,8 +1769,16 @@ def os_data():
                                     comps[3].replace('(', '').replace(')', '')
                 elif os.path.isfile('/etc/centos-release'):
                     log.trace('Parsing distrib info from /etc/centos-release')
-                    # CentOS Linux
-                    grains['lsb_distrib_id'] = 'CentOS'
+                    # Maybe CentOS Linux; could also be SUSE Expanded Support.
+                    # SUSE ES has both, centos-release and redhat-release.
+                    if os.path.isfile('/etc/redhat-release'):
+                        with salt.utils.files.fopen('/etc/redhat-release') as ifile:
+                            for line in ifile:
+                                if "red hat enterprise linux server" in line.lower():
+                                    # This is a SUSE Expanded Support Rhel installation
+                                    grains['lsb_distrib_id'] = 'RedHat'
+                                    break
+                    grains.setdefault('lsb_distrib_id', 'CentOS')
                     with salt.utils.files.fopen('/etc/centos-release') as ifile:
                         for line in ifile:
                             # Need to pull out the version and codename


### PR DESCRIPTION
### What does this PR do?

A SUSE ES installation has both, the `centos-release` and `redhat-release`
file. Since `os_data()` only used the `centos-release` file to detect a
CentOS installation, this lead to SUSE ES being detected as CentOS.

This change also adds a check for `redhat-release` and then marks the
`lsb_distrib_id` as RedHat.

### Previous Behavior

```
$ salt-call --local grains.get os
local:
    CentOS
```

### New Behavior

```
$ salt-call --local grains.get os
local:
    RedHat
```

### Tests written?

No

### Commits signed with GPG?

Yes
