### PR TITLE
Remove redundant execution in salt-call

### DIFF
--- a/salt/cli/caller.py
+++ b/salt/cli/caller.py
@@ -223,7 +223,6 @@ class BaseCaller(object):
             if isinstance(executors, six.string_types):
                 executors = [executors]
             try:
-                ret['return'] = func(*args, **kwargs)
                 for name in executors:
                     fname = '{0}.execute'.format(name)
                     if fname not in self.minion.executors:

--- a/tests/integration/shell/test_call.py
+++ b/tests/integration/shell/test_call.py
@@ -9,7 +9,6 @@
 
 # Import python libs
 from __future__ import absolute_import
-import getpass
 import os
 import sys
 import re
@@ -25,7 +24,6 @@ from tests.support.mixins import ShellCaseCommonTestsMixin
 from tests.support.helpers import (
     destructiveTest,
     flaky,
-    requires_system_grains,
     skip_if_not_root,
 )
 from tests.integration.utils import testprogram


### PR DESCRIPTION
Pull #48344 added logic to salt-call which runs the desired function using all
of the executors, or just the direct_call one if none are configured.

However, the previous code which ran the function was not removed, which
results in the function being run twice.

This removes the (now) redundant function call.