### PR TITLE
[2017.7.8] Use correct path for is_true function

### DIFF
--- a/salt/modules/pkgng.py
+++ b/salt/modules/pkgng.py
@@ -836,7 +836,7 @@ def install(name=None,
         opts += 'x'
     if salt.utils.is_true(pcre):
         opts += 'X'
-    if salt.utils.data.is_true(batch):
+    if salt.utils.is_true(batch):
         env = {
                 "BATCH": "true",
                 "ASSUME_ALWAYS_YES": "YES"


### PR DESCRIPTION
`data.py` does not exist in the salt/utils/ dir in the 2017.7 branch. We need to use the old path.

This occurred from a backport and I missed the path change.

Found by https://github.com/saltstack/salt/pull/48896#issuecomment-419434648