### PR TITLE
saltnado: don't use gather_job_timeout as a timeout signal in job_not_running

### DIFF
--- a/salt/netapi/rest_tornado/saltnado.py
+++ b/salt/netapi/rest_tornado/saltnado.py
@@ -977,7 +977,7 @@ class SaltAPIHandler(BaseSaltAPIHandler):  # pylint: disable=W0223
             min_wait_time = tornado.gen.sleep(self.application.opts['syndic_wait'])
 
         # To ensure job_not_running and all_return are terminated by each other, communicate using a future
-        is_finished = tornado.gen.sleep(self.application.opts['gather_job_timeout'])
+        is_finished = Future()
 
         # ping until the job is not running, while doing so, if we see new minions returning
         # that they are running the job, add them to the list
@@ -1059,14 +1059,11 @@ class SaltAPIHandler(BaseSaltAPIHandler):  # pylint: disable=W0223
                 event = self.application.event_listener.get_event(self,
                                                                   tag=ping_tag,
                                                                   timeout=self.application.opts['gather_job_timeout'])
-                f = yield Any([event, is_finished])
-                # When finished entire routine, cleanup other futures and return result
-                if f is is_finished:
-                    if not event.done():
-                        event.set_result(None)
-                    raise tornado.gen.Return(True)
-                event = f.result()
+                event = yield event
             except TimeoutException:
+                if not event.done():
+                    event.set_result(None)
+
                 if not minion_running:
                     raise tornado.gen.Return(True)
                 else:


### PR DESCRIPTION
because the future was generated from tornado.gen.sleep, its eventual timer
still fires regardless of if the future is manually set with set_result. When
set_result is called twice (once manually by saltnado, once by tornado call_later),
a stacktrace like so is thrown:

```
[ERROR   ] Uncaught exception POST / (::1)
Traceback (most recent call last):
  File "/home/mphillips81/.pyenv/versions/3.6.5/lib/python3.6/site-packages/tornado/web.py", line 1369, in _stack_context_handle_exception
    raise_exc_info((type, value, traceback))
  File "<string>", line 3, in raise_exc_info
  File "/home/mphillips81/.pyenv/versions/3.6.5/lib/python3.6/site-packages/tornado/stack_context.py", line 314, in wrapped
    ret = fn(*args, **kwargs)
  File "/home/mphillips81/.pyenv/versions/3.6.5/lib/python3.6/site-packages/tornado/gen.py", line 771, in later
    f.set_result(None)
  File "/home/mphillips81/.pyenv/versions/3.6.5/lib/python3.6/site-packages/tornado/concurrent.py", line 254, in set_result
    self._set_done()
  File "/home/mphillips81/.pyenv/versions/3.6.5/lib/python3.6/site-packages/tornado/concurrent.py", line 298, in _set_done
    for cb in self._callbacks:
TypeError: 'NoneType' object is not iterable

```
This patch attempts to fix that. @jacksontj would appreciate a review I'm not hugely familiar with the saltnado/tornado code here.

### What does this PR do?
fixes a stack thrown after every call.

fixes https://github.com/saltstack/salt/issues/49572

### Tests written?
No

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
