### PR TITLE
Use setup.py clean --all

### DIFF
--- a/pkg/windows/build.bat
+++ b/pkg/windows/build.bat
@@ -113,8 +113,14 @@ if not %errorLevel%==0 (
 :: Remove build and dist directories
 @echo %0 :: Remove build and dist directories...
 @echo ---------------------------------------------------------------------
-rd /s /q "%SrcDir%\build"
-rd /s /q "%SrcDir%\dist"
+"%PyDir%\python.exe" "%SrcDir%\setup.py" clean --all
+if not %errorLevel%==0 (
+    goto eof
+)
+If Exist "%SrcDir%\dist" (
+    @echo removing %SrcDir%\dist
+    rd /S /Q "%SrcDir%\dist"
+)
 @echo.
 
 :: Install Current Version of salt


### PR DESCRIPTION
### What does this PR do?
Changes the way the salt repo is cleaned during the build process. Uses `setup.py clean --all` for the `build` directory. Checks for the existence of the `dist` directory before attempting to delete it.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/49566

### Tests written?
NA

### Commits signed with GPG?
Yes