### PR TITLE
Update old utils paths to use new utils paths

### DIFF
--- a/tests/integration/states/test_file.py
+++ b/tests/integration/states/test_file.py
@@ -2246,7 +2246,9 @@ class FileTest(ModuleCase, SaltReturnAssertsMixin):
             if salt.utils.platform.is_windows():
                 import subprocess
                 import win32api
-                p = subprocess.Popen(salt.utils.to_str('type {}'.format(win32api.GetShortPathName(test_file))),
+                p = subprocess.Popen(
+                    salt.utils.stringutils.to_str(
+                        'type {}'.format(win32api.GetShortPathName(test_file))),
                     shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
                 p.poll()
                 out = p.stdout.read()

--- a/tests/support/helpers.py
+++ b/tests/support/helpers.py
@@ -59,6 +59,7 @@ from tests.support.paths import FILES, TMP
 # Import Salt libs
 import salt.utils.files
 import salt.utils.platform
+import salt.utils.stringutils
 
 if salt.utils.platform.is_windows():
     import salt.utils.win_functions
@@ -1611,11 +1612,11 @@ def dedent(text, linesep=os.linesep):
     '''
     A wrapper around textwrap.dedent that also sets line endings.
     '''
-    linesep = salt.utils.to_unicode(linesep)
-    unicode_text = textwrap.dedent(salt.utils.to_unicode(text))
+    linesep = salt.utils.stringutils.to_unicode(linesep)
+    unicode_text = textwrap.dedent(salt.utils.stringutils.to_unicode(text))
     clean_text = linesep.join(unicode_text.splitlines())
     if unicode_text.endswith(u'\n'):
         clean_text += linesep
     if not isinstance(text, six.text_type):
-        return salt.utils.to_bytes(clean_text)
+        return salt.utils.stringutils.to_bytes(clean_text)
     return clean_text


### PR DESCRIPTION
I found some places where we are using the old utils paths when these should have been updated to use the new paths. This is probably because of some cherry-picking to the new branch from fixes in 2017.7.

This should fix all of the old paths in the 2018.3.3 branch.