### PR TITLE
Add regex pattern matching to ps.pgrep

### DIFF
--- a/salt/modules/ps.py
+++ b/salt/modules/ps.py
@@ -301,7 +301,7 @@ def pkill(pattern, user=None, signal=15, full=False):
         return {'killed': killed}
 
 
-def pgrep(pattern, user=None, full=False):
+def pgrep(pattern, user=None, full=False, pattern_is_regex=False):
     '''
     Return the pids for processes matching a pattern.
 
@@ -322,6 +322,12 @@ def pgrep(pattern, user=None, full=False):
         A boolean value indicating whether only the name of the command or
         the full command line should be matched against the pattern.
 
+    pattern_is_regex
+        This flag enables ps.pgrep to mirror the regex search functionality
+         found in the pgrep command line utility.
+
+        .. versionadded:: Neon
+
     **Examples:**
 
     Find all httpd processes on all 'www' minions:
@@ -336,14 +342,28 @@ def pgrep(pattern, user=None, full=False):
 
         salt '*' ps.pgrep bash user=tom
     '''
+    procs = []
+
+    if pattern_is_regex:
+        pattern = re.compile(str(pattern))
 
     procs = []
     for proc in psutil.process_iter():
-        name_match = pattern in ' '.join(_get_proc_cmdline(proc)) if full \
-            else pattern in _get_proc_name(proc)
+        if full:
+            process_line = ' '.join(_get_proc_cmdline(proc))
+        else:
+            process_line = _get_proc_name(proc)
+
+        if pattern_is_regex:
+            name_match = re.search(pattern, process_line)
+        else:
+            name_match = pattern in process_line
+
         user_match = True if user is None else user == _get_proc_username(proc)
+
         if name_match and user_match:
             procs.append(_get_proc_pid(proc))
+
     return procs or None
 
 

--- a/salt/modules/ps.py
+++ b/salt/modules/ps.py
@@ -301,7 +301,7 @@ def pkill(pattern, user=None, signal=15, full=False):
         return {'killed': killed}
 
 
-def pgrep(pattern, user=None, full=False, pattern_is_regex=False):
+def pgrep(pattern, user=None, full=False):
     '''
     Return the pids for processes matching a pattern.
 
@@ -322,12 +322,6 @@ def pgrep(pattern, user=None, full=False, pattern_is_regex=False):
         A boolean value indicating whether only the name of the command or
         the full command line should be matched against the pattern.
 
-    pattern_is_regex
-        This flag enables ps.pgrep to mirror the regex search functionality
-         found in the pgrep command line utility.
-
-        .. versionadded:: Neon
-
     **Examples:**
 
     Find all httpd processes on all 'www' minions:
@@ -342,28 +336,14 @@ def pgrep(pattern, user=None, full=False, pattern_is_regex=False):
 
         salt '*' ps.pgrep bash user=tom
     '''
-    procs = []
-
-    if pattern_is_regex:
-        pattern = re.compile(str(pattern))
 
     procs = []
     for proc in psutil.process_iter():
-        if full:
-            process_line = ' '.join(_get_proc_cmdline(proc))
-        else:
-            process_line = _get_proc_name(proc)
-
-        if pattern_is_regex:
-            name_match = re.search(pattern, process_line)
-        else:
-            name_match = pattern in process_line
-
+        name_match = pattern in ' '.join(_get_proc_cmdline(proc)) if full \
+            else pattern in _get_proc_name(proc)
         user_match = True if user is None else user == _get_proc_username(proc)
-
         if name_match and user_match:
             procs.append(_get_proc_pid(proc))
-
     return procs or None
 
 


### PR DESCRIPTION
### What does this PR do?
This PR adds the ability to use a regex pattern to match processes with `ps.pgrep`, which mirrors the functionality of the command line utility.

### What issues does this PR fix or reference?
#49565 

### Previous Behavior
Only string matching was available

### New Behavior
Regex patterns can now be used in the `pattern` parameter

### Tests written?
No

### Commits signed with GPG?
Yes