### PR TITLE
Fix #49247 -- Changed log_access and log_error to log.access and log.error

### DIFF
--- a/salt/netapi/rest_cherrypy/app.py
+++ b/salt/netapi/rest_cherrypy/app.py
@@ -68,12 +68,12 @@ A REST API for Salt
     debug : ``False``
         Starts the web server in development mode. It will reload itself when
         the underlying code is changed and will output more debugging info.
-    log_access_file
+    log.access_file
         Path to a file to write HTTP access logs.
 
         .. versionadded:: 2016.11.0
 
-    log_error_file
+    log.error_file
         Path to a file to write HTTP error logs.
 
         .. versionadded:: 2016.11.0


### PR DESCRIPTION
### What does this PR do?
This fixes the docs which reference deprecated log parameters `log_access` and `log_error`. They are now, according to CherryPy, `log.access` and `log.error`.

### What issues does this PR fix or reference?
Fixes #49247 .

### Tests written?

No

### Commits signed with GPG?

Yes