### PR TITLE
ping_interval: use service.restart instead of signaling

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -2619,8 +2619,20 @@ class Minion(MinionBase):
                             log.error('** Master Ping failed. Attempting to restart minion**')
                             delay = self.opts.get('random_reauth_delay', 5)
                             log.info('delaying random_reauth_delay %ss', delay)
-                            # regular sys.exit raises an exception -- which isn't sufficient in a thread
-                            os._exit(salt.defaults.exitcodes.SALT_KEEPALIVE)
+                            try:
+                                self.functions['service.restart'](
+                                    'salt_minion' if 'bsd' in sys.platform
+                                    else 'salt-minion'
+                                )
+                            except KeyError:
+                                # Probably no init system (running in docker?)
+                                log.warning(
+                                    'ping_interval reached without response '
+                                    'from the master, but service.restart '
+                                    'could not be run to restart the minion '
+                                    'daemon. ping_interval requires that the '
+                                    'minion is running under an init system.'
+                                )
 
                     self._fire_master('ping', 'minion_ping', sync=False, timeout_handler=ping_timeout_handler)
                 except Exception:

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -410,6 +410,13 @@ def master_event(type, master=None):
     return event_map.get(type, None)
 
 
+def service_name():
+    '''
+    Return the proper service name based on platform
+    '''
+    return 'salt_minion' if 'bsd' in sys.platform else 'salt-minion'
+
+
 class MinionBase(object):
     def __init__(self, opts):
         self.opts = opts
@@ -2620,10 +2627,7 @@ class Minion(MinionBase):
                             delay = self.opts.get('random_reauth_delay', 5)
                             log.info('delaying random_reauth_delay %ss', delay)
                             try:
-                                self.functions['service.restart'](
-                                    'salt_minion' if 'bsd' in sys.platform
-                                    else 'salt-minion'
-                                )
+                                self.functions['service.restart'](service_name())
                             except KeyError:
                                 # Probably no init system (running in docker?)
                                 log.warning(


### PR DESCRIPTION
When multiprocessing does not relay the signal properly, ping_interval will fail to respawn the multiprocessing.Process instance and the minion will end up in a bad state, where there are still salt-minion procs running but the minion is not connected to the master and thus does not respond to pubs from it.

This commit ditches signaling in favor of using `service.restart` to restart the minion daemon.