### PR TITLE
modules/nilrt_ip.py: Fix enable/disable function

### DIFF
--- a/salt/modules/nilrt_ip.py
+++ b/salt/modules/nilrt_ip.py
@@ -536,7 +536,8 @@ def _change_state(interface, new_state):
     service = _interface_to_service(interface)
     if not service:
         raise salt.exceptions.CommandExecutionError('Invalid interface name: {0}'.format(interface))
-    if not _connected(service):
+    connected = _connected(service)
+    if (not connected and new_state == 'up') or (connected and new_state == 'down'):
         service = pyconnman.ConnService(os.path.join(SERVICE_PATH, service))
         try:
             state = service.connect() if new_state == 'up' else service.disconnect()


### PR DESCRIPTION
    The enable function shouldn't take any action if the service is already
    enabled and same for the disable function if the service is already
    disabled.
    
    Signed-off-by: Alexandru Vasiu <alexandru.vasiu@ni.com>