### PR TITLE
[2018.3] Fixing integration.states.test_file.FileTest.test_directory_max_depth

### DIFF
--- a/tests/integration/states/test_file.py
+++ b/tests/integration/states/test_file.py
@@ -829,7 +829,13 @@ class FileTest(ModuleCase, SaltReturnAssertsMixin):
 
         initial_mode = '0111'
         changed_mode = '0555'
-        default_mode = '0755'
+
+        initial_modes = {0: {sub: '0755',
+                             subsub: '0111'},
+                         1: {sub: '0111',
+                             subsub: '0111'},
+                         2: {sub: '0111',
+                             subsub: '0111'}}
 
         if not os.path.isdir(subsub):
             os.makedirs(subsub, int(initial_mode, 8))
@@ -850,7 +856,8 @@ class FileTest(ModuleCase, SaltReturnAssertsMixin):
                     # the mode of intermediate directories to the mode that
                     # is passed.
                     if sys.version_info >= (3, 7):
-                        self.assertEqual(default_mode,
+                        _mode = initial_modes[depth][untouched_dir]
+                        self.assertEqual(_mode,
                                          _get_oct_mode(untouched_dir))
                     else:
                         self.assertEqual(initial_mode,


### PR DESCRIPTION
### What does this PR do?
Fixing failing test under python 3.7 causaed by changes to how os.makedirs sets initial permissions.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt-jenkins/issues/1075

### Previous Behavior
integration.states.test_file.FileTest.test_directory_max_depth failed

### New Behavior
integration.states.test_file.FileTest.test_directory_max_depth succeeds.

### Tests written?
Existing test updated.

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
