### PR TITLE
[2018.3.3] Moving test_build_whitespace_split_regex to TestBuildWhitespaceRegex

### DIFF
--- a/tests/unit/utils/test_stringutils.py
+++ b/tests/unit/utils/test_stringutils.py
@@ -105,20 +105,6 @@ class TestBuildWhitespaceRegex(TestCase):
         regex = salt.utils.stringutils.build_whitespace_split_regex(SINGLE_DOUBLE_SAME_LINE_TXT)
         self.assertTrue(re.search(regex, MATCH))
 
-    def test_build_whitespace_split_regex(self):
-        # With 3.7+,  re.escape only escapes special characters, no longer
-        # escaping all characters other than ASCII letters, numbers and
-        # underscores.  This includes commas.
-        if sys.version_info >= (3, 7):
-            expected_regex = '(?m)^(?:[\\s]+)?Lorem(?:[\\s]+)?ipsum(?:[\\s]+)?dolor(?:[\\s]+)?sit(?:[\\s]+)?amet,' \
-                             '(?:[\\s]+)?$'
-        else:
-            expected_regex = '(?m)^(?:[\\s]+)?Lorem(?:[\\s]+)?ipsum(?:[\\s]+)?dolor(?:[\\s]+)?sit(?:[\\s]+)?amet\\,' \
-                             '(?:[\\s]+)?$'
-        ret = salt.utils.stringutils.build_whitespace_split_regex(' '.join(LOREM_IPSUM.split()[:5]))
-        self.assertEqual(ret, expected_regex)
-
-
 class StringutilsTestCase(TestCase):
     def test_contains_whitespace(self):
         does_contain_whitespace = 'A brown fox jumped over the red hen.'
@@ -262,8 +248,15 @@ class StringutilsTestCase(TestCase):
         assert result == LATIN1_UNICODE
 
     def test_build_whitespace_split_regex(self):
-        expected_regex = '(?m)^(?:[\\s]+)?Lorem(?:[\\s]+)?ipsum(?:[\\s]+)?dolor(?:[\\s]+)?sit(?:[\\s]+)?amet\\,' \
-                         '(?:[\\s]+)?$'
+        # With 3.7+,  re.escape only escapes special characters, no longer
+        # escaping all characters other than ASCII letters, numbers and
+        # underscores.  This includes commas.
+        if sys.version_info >= (3, 7):
+            expected_regex = '(?m)^(?:[\\s]+)?Lorem(?:[\\s]+)?ipsum(?:[\\s]+)?dolor(?:[\\s]+)?sit(?:[\\s]+)?amet,' \
+                             '(?:[\\s]+)?$'
+        else:
+            expected_regex = '(?m)^(?:[\\s]+)?Lorem(?:[\\s]+)?ipsum(?:[\\s]+)?dolor(?:[\\s]+)?sit(?:[\\s]+)?amet\\,' \
+                             '(?:[\\s]+)?$'
         ret = salt.utils.stringutils.build_whitespace_split_regex(' '.join(LOREM_IPSUM.split()[:5]))
         self.assertEqual(ret, expected_regex)
 

--- a/tests/unit/utils/test_stringutils.py
+++ b/tests/unit/utils/test_stringutils.py
@@ -105,6 +105,7 @@ class TestBuildWhitespaceRegex(TestCase):
         regex = salt.utils.stringutils.build_whitespace_split_regex(SINGLE_DOUBLE_SAME_LINE_TXT)
         self.assertTrue(re.search(regex, MATCH))
 
+
 class StringutilsTestCase(TestCase):
     def test_contains_whitespace(self):
         does_contain_whitespace = 'A brown fox jumped over the red hen.'


### PR DESCRIPTION
### What does this PR do?
Moving the test_build_whitespace_split_regex test into the TestBuildWhitespaceRegex class.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt-jenkins/issues/1075

### Previous Behavior
Test ended up under wrong class.

### New Behavior
Test is now under the right class.

### Tests written?
Existing tests moved.

### Commits signed with GPG?

Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
