### PR TITLE
publish.publish trim mods after comma split

### DIFF
--- a/salt/client/ssh/wrapper/state.py
+++ b/salt/client/ssh/wrapper/state.py
@@ -182,7 +182,7 @@ def sls(mods, saltenv='base', test=None, exclude=None, **kwargs):
             __context__['fileclient'])
     st_.push_active()
     if isinstance(mods, six.string_types):
-        mods = mods.split(',')
+        mods = [item.strip() for item in mods.split(',')]
     high_data, errors = st_.render_highstate({saltenv: mods})
     if exclude:
         if isinstance(exclude, six.string_types):
@@ -923,7 +923,7 @@ def sls_id(id_, mods, test=None, queue=False, **kwargs):
         return err
 
     if isinstance(mods, six.string_types):
-        split_mods = mods.split(',')
+        split_mods = [item.strip() for item in mods.split(',')]
     st_.push_active()
     high_, errors = st_.render_highstate({opts['saltenv']: split_mods})
     errors += st_.state.verify_high(high_)
@@ -981,7 +981,7 @@ def show_sls(mods, saltenv='base', test=None, **kwargs):
             __context__['fileclient'])
     st_.push_active()
     if isinstance(mods, six.string_types):
-        mods = mods.split(',')
+        mods = [item.strip() for item in mods.split(',')]
     high_data, errors = st_.render_highstate({saltenv: mods})
     high_data, ext_errors = st_.state.reconcile_extend(high_data)
     errors += ext_errors
@@ -1026,7 +1026,7 @@ def show_low_sls(mods, saltenv='base', test=None, **kwargs):
             __context__['fileclient'])
     st_.push_active()
     if isinstance(mods, six.string_types):
-        mods = mods.split(',')
+        mods = [item.strip() for item in mods.split(',')]
     high_data, errors = st_.render_highstate({saltenv: mods})
     high_data, ext_errors = st_.state.reconcile_extend(high_data)
     errors += ext_errors

--- a/salt/client/ssh/wrapper/state.py
+++ b/salt/client/ssh/wrapper/state.py
@@ -167,6 +167,16 @@ def _cleanup_slsmod_high_data(high_data):
                 stateconf_data['slsmod'] = None
 
 
+def _parse_mods(mods):
+    '''
+    Parse modules.
+    '''
+    if isinstance(mods, six.string_types):
+        mods = [item.strip() for item in mods.split(',') if item.strip()]
+
+    return mods
+
+
 def sls(mods, saltenv='base', test=None, exclude=None, **kwargs):
     '''
     Create the seed file for a state.sls run
@@ -181,8 +191,7 @@ def sls(mods, saltenv='base', test=None, exclude=None, **kwargs):
             __salt__,
             __context__['fileclient'])
     st_.push_active()
-    if isinstance(mods, six.string_types):
-        mods = [item.strip() for item in mods.split(',')]
+    mods = _parse_mods(mods)
     high_data, errors = st_.render_highstate({saltenv: mods})
     if exclude:
         if isinstance(exclude, six.string_types):
@@ -922,8 +931,7 @@ def sls_id(id_, mods, test=None, queue=False, **kwargs):
         err += __pillar__['_errors']
         return err
 
-    if isinstance(mods, six.string_types):
-        split_mods = [item.strip() for item in mods.split(',')]
+    split_mods = _parse_mods(mods)
     st_.push_active()
     high_, errors = st_.render_highstate({opts['saltenv']: split_mods})
     errors += st_.state.verify_high(high_)
@@ -980,8 +988,7 @@ def show_sls(mods, saltenv='base', test=None, **kwargs):
             __salt__,
             __context__['fileclient'])
     st_.push_active()
-    if isinstance(mods, six.string_types):
-        mods = [item.strip() for item in mods.split(',')]
+    mods = _parse_mods(mods)
     high_data, errors = st_.render_highstate({saltenv: mods})
     high_data, ext_errors = st_.state.reconcile_extend(high_data)
     errors += ext_errors
@@ -1025,8 +1032,7 @@ def show_low_sls(mods, saltenv='base', test=None, **kwargs):
             __salt__,
             __context__['fileclient'])
     st_.push_active()
-    if isinstance(mods, six.string_types):
-        mods = [item.strip() for item in mods.split(',')]
+    mods = _parse_mods(mods)
     high_data, errors = st_.render_highstate({saltenv: mods})
     high_data, ext_errors = st_.state.reconcile_extend(high_data)
     errors += ext_errors


### PR DESCRIPTION
### What does this PR do?
Fixes a bug I found when applying states via publish.publish.
__salt__['publish.publish'](......fun='state.apply', arg='["mods=state1.latest,state2.latest"]'...)
If the mods inside the arg contains spaces, the process will fail.

### What issues does this PR fix or reference?
Did not open a bug report.

### Previous Behavior
Salt publish.publish fails if the mods inside arg contains white spaces after the comma split.
This Fails: "state1.latest, state2.latest"

### New Behavior
Salt publish.publish works as expected since the state names are now trimmed.
This now works: "state1.latest, state2.latest"
Also generalized the trim for other mods splits

### Tests written?
No

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
