### PR TITLE
Bugfix: In log file the value of file_recv_max_size limit was error

### DIFF
--- a/salt/master.py
+++ b/salt/master.py
@@ -1441,18 +1441,17 @@ class AESFuncs(object):
             return False
         if not salt.utils.verify.valid_id(self.opts, load['id']):
             return False
-        file_recv_max_size = 1024*1024 * self.opts['file_recv_max_size']
 
         if 'loc' in load and load['loc'] < 0:
             log.error('Invalid file pointer: load[loc] < 0')
             return False
 
-        if len(load['data']) + load.get('loc', 0) > file_recv_max_size:
+        if len(load['data']) + load.get('loc', 0) > 1024 * 1024 * self.opts['file_recv_max_size']:
             log.error(
                 'file_recv_max_size limit of %d MB exceeded! %s will be '
                 'truncated. To successfully push this file, adjust '
                 'file_recv_max_size to an integer (in MB) large enough to '
-                'accommodate it.', file_recv_max_size, load['path']
+                'accommodate it.', self.opts['file_recv_max_size'], load['path']
             )
             return False
         if 'tok' not in load:


### PR DESCRIPTION
Signed-off-by: shen yanfen <shen.yanfen@zte.com.cn>

### What does this PR do?
Correct the value of file_recv_max_size limit in log file

### What issues does this PR fix or reference?
I found the follow log in ` /var/log/salt/master` :
```
2018-09-13 04:06:28,493 [salt.master      ][ERROR   ][44649] file_recv_max_size limit of 1073741824 MB exceeded! ['SystemLog', 'ceph-osd.80.log-2018091303'] will be truncated. To successfully push this file, adjust file_recv_max_size to an integer (in MB) large enough to accommodate it.
```
`1073741824 MB`  was larger than  `file_recv_max_size: 1024` what I set in `/etc/salt/master`

### Tests written?

No

### Commits signed with GPG?

No
