### PR TITLE
Retire MD5 checksum for pkg mgmt plugins

### DIFF
--- a/scripts/suse/yum/plugins/yumnotify.py
+++ b/scripts/suse/yum/plugins/yumnotify.py
@@ -32,7 +32,8 @@ def _get_checksum():
     Returns:
         hexdigest
     """
-    digest = hashlib.md5()
+
+    digest = hashlib.sha256()
     with open(RPM_PATH, "rb") as rpm_db_fh:
         while True:
             buff = rpm_db_fh.read(0x1000)

--- a/scripts/suse/yum/plugins/yumnotify.py
+++ b/scripts/suse/yum/plugins/yumnotify.py
@@ -32,7 +32,6 @@ def _get_checksum():
     Returns:
         hexdigest
     """
-
     digest = hashlib.sha256()
     with open(RPM_PATH, "rb") as rpm_db_fh:
         while True:

--- a/scripts/suse/zypper/plugins/commit/zyppnotify
+++ b/scripts/suse/zypper/plugins/commit/zyppnotify
@@ -35,7 +35,7 @@ class DriftDetector(Plugin):
         Returns:
             hexdigest
         '''
-        digest = hashlib.md5()
+        digest = hashlib.sha256()
         with open(self.rpm_path, "rb") as rpm_db_fh:
             while True:
                 buff = rpm_db_fh.read(0x1000)


### PR DESCRIPTION
### What does this PR do?

Yum Notify and Zypper Notification plugins are still using MD5 algorithm, which is missing on FIPS-enabled Python builds.

Time to just say goodbye to MD5.