### PR TITLE
Fix salt.module.pdbedit with samba 4.8

### DIFF
--- a/salt/modules/pdbedit.py
+++ b/salt/modules/pdbedit.py
@@ -96,15 +96,15 @@ def list_users(verbose=True, hashes=False):
             user_data = {}
             for user in res['stdout'].splitlines():
                 if user.startswith('-'):
-                    if len(user_data) > 0:
+                    if user_data:
                         users[user_data['unix username']] = user_data
                     user_data = {}
-                else:
+                elif ':' in user:
                     label = user[:user.index(':')].strip().lower()
                     data = user[(user.index(':')+1):].strip()
                     user_data[label] = data
 
-            if len(user_data) > 0:
+            if user_data:
                 users[user_data['unix username']] = user_data
     else:
         # list users
@@ -342,9 +342,8 @@ def modify(
                 new = []
                 for f in val.upper():
                     if f not in ['N', 'D', 'H', 'L', 'X']:
-                        log.warning(
-                            'pdbedit.modify - unknown {f} flag for account_control, ignored'.format(f=f)
-                        )
+                        logmsg = 'pdbedit.modify - unknown {} flag for account_control, ignored'.format(f)
+                        log.warning(logmsg)
                     else:
                         new.append(f)
                 changes[key] = "[{flags}]".format(flags="".join(new))
@@ -353,7 +352,7 @@ def modify(
                 changes[key] = val
 
     # apply changes
-    if len(changes) > 0 or reset_login_hours or reset_bad_password_count:
+    if changes or reset_login_hours or reset_bad_password_count:
         cmds = []
         for change in changes:
             cmds.append('{flag}{value}'.format(


### PR DESCRIPTION
### What does this PR do?

I noticed the pdbedit module was showing a trace when using samba 4.8.x

```
Traceback (most recent call last):
  File "/opt/local/bin/salt-call", line 11, in <module>
    salt_call()
  File "/opt/local/lib/python2.7/site-packages/salt/scripts.py", line 400, in salt_call
    client.run()
  File "/opt/local/lib/python2.7/site-packages/salt/cli/call.py", line 57, in run
    caller.run()
  File "/opt/local/lib/python2.7/site-packages/salt/cli/caller.py", line 134, in run
    ret = self.call()
  File "/opt/local/lib/python2.7/site-packages/salt/cli/caller.py", line 212, in call
    ret['return'] = func(*args, **kwargs)
  File "/opt/local/lib/python2.7/site-packages/salt/modules/pdbedit.py", line 104, in list_users
    label = user[:user.index(':')].strip().lower()
ValueError: substring not found
```

We fix this by checking for ':' instead of assuming it is there. Also some additional lint fixes.

### What issues does this PR fix or reference?
N/a

### Previous Behavior
pdbedit would throw a trace.

### New Behavior
pdbedit works as expected

### Tests written?
No

### Commits signed with GPG?
No
