### PR TITLE
Fix for issue 49649, allows s3.put calls to set headers

### DIFF
--- a/salt/modules/s3.py
+++ b/salt/modules/s3.py
@@ -247,7 +247,7 @@ def head(bucket, path='', key=None, keyid=None, service_url=None,
 def put(bucket, path=None, return_bin=False, action=None, local_file=None,
         key=None, keyid=None, service_url=None, verify_ssl=None,
         kms_keyid=None, location=None, role_arn=None, path_style=None,
-        https_enable=None):
+        https_enable=None, headers=None, full_headers=False):
     '''
     Create a new bucket, or upload an object to a bucket.
 
@@ -263,6 +263,12 @@ def put(bucket, path=None, return_bin=False, action=None, local_file=None,
 
         salt myminion s3.put mybucket remotepath local_file=/path/to/file
     '''
+
+    if not headers:
+        headers = {}
+    else:
+        full_headers = True
+
     key, keyid, service_url, verify_ssl, kms_keyid, location, role_arn, path_style, https_enable = _get_key(
         key,
         keyid,
@@ -289,7 +295,9 @@ def put(bucket, path=None, return_bin=False, action=None, local_file=None,
                                  location=location,
                                  role_arn=role_arn,
                                  path_style=path_style,
-                                 https_enable=https_enable)
+                                 https_enable=https_enable,
+                                 headers=headers,
+                                 full_headers=full_headers)
 
 
 def _get_key(key, keyid, service_url, verify_ssl, kms_keyid, location, role_arn, path_style, https_enable):


### PR DESCRIPTION
### What does this PR do?

Fixes issue #49649

e.g. allows setting custom headers on s3.put execution, principally to allow explicit definition of Content-Type to text/html etc.

### What issues does this PR fix or reference?

#49649

### Previous Behavior

S3 default Content-Type of binary/octet-stream gets set on all objects placed in S3 bucket using s3.put

### New Behavior

Headers can be passed, which allows Content-Type (and other S3 accepted headers) to be used to define correct metadata for S3 objects.

### Tests written?

No

### Commits signed with GPG?

Yes