### PR TITLE
Fix spelling in user.py state

### DIFF
--- a/salt/states/user.py
+++ b/salt/states/user.py
@@ -270,7 +270,7 @@ def present(name,
     gid
         The id of the default group to assign to the user. Either a group name
         or gid can be used. If not specified, and the user does not exist, then
-        he next available gid will be assigned.
+        the next available gid will be assigned.
 
     gid_from_name : False
         If ``True``, the default group id will be set to the id of the group


### PR DESCRIPTION
### What does this PR do?
Fix a spelling error in `salt/states/user.py` documentation

### What issues does this PR fix or reference?
None

### Previous Behavior
Bad enough spelling in `salt/states/user.py` to warrant this PR ;-)

### Tests written?
N/A
