### PR TITLE
blockdev: fix url from comment

### DIFF
--- a/salt/states/blockdev.py
+++ b/salt/states/blockdev.py
@@ -163,7 +163,7 @@ def formatted(name, fs_type='ext4', force=False, **kwargs):
 
     # Repeat fstype check up to 10 times with 3s sleeping between each
     # to avoid detection failing although mkfs has succeeded
-    # see https://github.com/saltstack/salt/issues/25775i
+    # see https://github.com/saltstack/salt/issues/25775
     # This retry maybe superfluous - switching to blkid
     for i in range(10):
 


### PR DESCRIPTION
Fix a URL from a comment in the `formatted` state.