### PR TITLE
Documentation: fix typo in "equivalent"

### DIFF
--- a/doc/topics/tutorials/states_pt3.rst
+++ b/doc/topics/tutorials/states_pt3.rst
@@ -141,7 +141,7 @@ The following example illustrates calling the ``group_to_gid`` function in the
         - gid: {{ salt['file.group_to_gid']('some_group_that_exists') }}
 
 One way to think about this might be that the ``gid`` key is being assigned
-a value equivelent to the following python pseudo-code:
+a value equivalent to the following python pseudo-code:
 
 .. code-block:: python
 


### PR DESCRIPTION
Fix typo in the "equivalent" word in the tutorial and in the manual page