### PR TITLE
Use py3-preferred plistlib API to load service plists.

### DIFF
--- a/salt/utils/mac_utils.py
+++ b/salt/utils/mac_utils.py
@@ -350,7 +350,11 @@ def _available_services(refresh=False):
                 try:
                     # This assumes most of the plist files
                     # will be already in XML format
-                    plist = plistlib.readPlist(true_path)
+                    if six.PY2:
+                        plist = plistlib.readPlist(true_path)
+                    else:
+                        with open(true_path, 'rb') as plist_handle:
+                            plist = plistlib.load(plist_handle)
 
                 except Exception:
                     # If plistlib is unable to read the file we'll need to use

--- a/salt/utils/mac_utils.py
+++ b/salt/utils/mac_utils.py
@@ -353,7 +353,7 @@ def _available_services(refresh=False):
                     if six.PY2:
                         plist = plistlib.readPlist(true_path)
                     else:
-                        with open(true_path, 'rb') as plist_handle:
+                        with salt.utils.files.fopen(true_path, 'rb') as plist_handle:
                             plist = plistlib.load(plist_handle)
 
                 except Exception:

--- a/salt/utils/mac_utils.py
+++ b/salt/utils/mac_utils.py
@@ -353,7 +353,7 @@ def _available_services(refresh=False):
                     if six.PY2:
                         plist = plistlib.readPlist(true_path)
                     else:
-                        with salt.utils.files.fopen(true_path, 'rb') as plist_handle:
+                        with open(true_path, 'rb') as plist_handle:
                             plist = plistlib.load(plist_handle)
 
                 except Exception:

--- a/tests/unit/utils/test_mac_utils.py
+++ b/tests/unit/utils/test_mac_utils.py
@@ -254,7 +254,6 @@ class MacUtilsTestCase(TestCase, LoaderModuleMockMixin):
         else:
             ret = mac_utils._available_services()
 
-
         # Make sure it's a dict with 8 items
         self.assertTrue(isinstance(ret, dict))
         self.assertEqual(len(ret), 8)

--- a/tests/unit/utils/test_mac_utils.py
+++ b/tests/unit/utils/test_mac_utils.py
@@ -9,7 +9,7 @@ import os
 
 # Import Salt Testing Libs
 from tests.support.unit import TestCase, skipIf
-from tests.support.mock import MagicMock, patch, NO_MOCK, NO_MOCK_REASON, call
+from tests.support.mock import MagicMock, patch, NO_MOCK, NO_MOCK_REASON, call, mock_open
 from tests.support.mixins import LoaderModuleMockMixin
 
 # Import Salt libs
@@ -215,18 +215,22 @@ class MacUtilsTestCase(TestCase, LoaderModuleMockMixin):
 
     @patch('salt.utils.path.os_walk')
     @patch('os.path.exists')
-    @patch('plistlib.readPlist')
+    @patch('plistlib.readPlist' if six.PY2 else 'plistlib.load')
     def test_available_services(self, mock_read_plist, mock_exists, mock_os_walk):
         '''
         test available_services
         '''
-        mock_os_walk.side_effect = [
-            [('/Library/LaunchAgents', [], ['com.apple.lla1.plist', 'com.apple.lla2.plist'])],
-            [('/Library/LaunchDaemons', [], ['com.apple.lld1.plist', 'com.apple.lld2.plist'])],
-            [('/System/Library/LaunchAgents', [], ['com.apple.slla1.plist', 'com.apple.slla2.plist'])],
-            [('/System/Library/LaunchDaemons', [], ['com.apple.slld1.plist', 'com.apple.slld2.plist'])],
-        ]
+        def walk_side_effect(*args, **kwargs):
+            path = args[0]
+            results = {
+                '/Library/LaunchAgents': ['com.apple.lla1.plist', 'com.apple.lla2.plist'],
+                '/Library/LaunchDaemons': ['com.apple.lld1.plist', 'com.apple.lld2.plist'],
+                '/System/Library/LaunchAgents': ['com.apple.slla1.plist', 'com.apple.slla2.plist'],
+                '/System/Library/LaunchDaemons': ['com.apple.slld1.plist', 'com.apple.slld2.plist']}
+            files = results.get(path, [])
+            return [(path, [], files)]
 
+        mock_os_walk.side_effect = walk_side_effect
         mock_read_plist.side_effect = [
             MagicMock(Label='com.apple.lla1'),
             MagicMock(Label='com.apple.lla2'),
@@ -239,7 +243,17 @@ class MacUtilsTestCase(TestCase, LoaderModuleMockMixin):
         ]
 
         mock_exists.return_value = True
-        ret = mac_utils._available_services()
+
+        if six.PY3:
+            # Py3's plistlib.load does not handle opening and closing a
+            # file, unlike py2's plistlib.readPlist. Therefore, we have
+            # to patch open for py3 since we're using it in addition
+            # to the plistlib.load call.
+            with patch('salt.utils.files.fopen', mock_open()):
+                ret = mac_utils._available_services()
+        else:
+            ret = mac_utils._available_services()
+
 
         # Make sure it's a dict with 8 items
         self.assertTrue(isinstance(ret, dict))
@@ -265,17 +279,22 @@ class MacUtilsTestCase(TestCase, LoaderModuleMockMixin):
 
     @patch('salt.utils.path.os_walk')
     @patch('os.path.exists')
-    @patch('plistlib.readPlist')
+    @patch('plistlib.readPlist' if six.PY2 else 'plistlib.load')
     def test_available_services_broken_symlink(self, mock_read_plist, mock_exists, mock_os_walk):
         '''
         test available_services
         '''
-        mock_os_walk.side_effect = [
-            [('/Library/LaunchAgents', [], ['com.apple.lla1.plist', 'com.apple.lla2.plist'])],
-            [('/Library/LaunchDaemons', [], ['com.apple.lld1.plist', 'com.apple.lld2.plist'])],
-            [('/System/Library/LaunchAgents', [], ['com.apple.slla1.plist', 'com.apple.slla2.plist'])],
-            [('/System/Library/LaunchDaemons', [], ['com.apple.slld1.plist', 'com.apple.slld2.plist'])],
-        ]
+        def walk_side_effect(*args, **kwargs):
+            path = args[0]
+            results = {
+                '/Library/LaunchAgents': ['com.apple.lla1.plist', 'com.apple.lla2.plist'],
+                '/Library/LaunchDaemons': ['com.apple.lld1.plist', 'com.apple.lld2.plist'],
+                '/System/Library/LaunchAgents': ['com.apple.slla1.plist', 'com.apple.slla2.plist'],
+                '/System/Library/LaunchDaemons': ['com.apple.slld1.plist', 'com.apple.slld2.plist']}
+            files = results.get(path, [])
+            return [(path, [], files)]
+
+        mock_os_walk.side_effect = walk_side_effect
 
         mock_read_plist.side_effect = [
             MagicMock(Label='com.apple.lla1'),
@@ -287,7 +306,15 @@ class MacUtilsTestCase(TestCase, LoaderModuleMockMixin):
         ]
 
         mock_exists.side_effect = [True, True, True, True, False, False, True, True]
-        ret = mac_utils._available_services()
+        if six.PY3:
+            # Py3's plistlib.load does not handle opening and closing a
+            # file, unlike py2's plistlib.readPlist. Therefore, we have
+            # to patch open for py3 since we're using it in addition
+            # to the plistlib.load call.
+            with patch('salt.utils.files.fopen', mock_open()):
+                ret = mac_utils._available_services()
+        else:
+            ret = mac_utils._available_services()
 
         # Make sure it's a dict with 6 items
         self.assertTrue(isinstance(ret, dict))
@@ -325,12 +352,17 @@ class MacUtilsTestCase(TestCase, LoaderModuleMockMixin):
         '''
         test available_services
         '''
-        mock_os_walk.side_effect = [
-            [('/Library/LaunchAgents', [], ['com.apple.lla1.plist', 'com.apple.lla2.plist'])],
-            [('/Library/LaunchDaemons', [], ['com.apple.lld1.plist', 'com.apple.lld2.plist'])],
-            [('/System/Library/LaunchAgents', [], ['com.apple.slla1.plist', 'com.apple.slla2.plist'])],
-            [('/System/Library/LaunchDaemons', [], ['com.apple.slld1.plist', 'com.apple.slld2.plist'])],
-        ]
+        def walk_side_effect(*args, **kwargs):
+            path = args[0]
+            results = {
+                '/Library/LaunchAgents': ['com.apple.lla1.plist', 'com.apple.lla2.plist'],
+                '/Library/LaunchDaemons': ['com.apple.lld1.plist', 'com.apple.lld2.plist'],
+                '/System/Library/LaunchAgents': ['com.apple.slla1.plist', 'com.apple.slla2.plist'],
+                '/System/Library/LaunchDaemons': ['com.apple.slld1.plist', 'com.apple.slld2.plist']}
+            files = results.get(path, [])
+            return [(path, [], files)]
+
+        mock_os_walk.side_effect = walk_side_effect
         attrs = {'cmd.run': MagicMock(return_value='<some xml>')}
 
         def getitem(name):
@@ -410,12 +442,17 @@ class MacUtilsTestCase(TestCase, LoaderModuleMockMixin):
         '''
         test available_services
         '''
-        mock_os_walk.side_effect = [
-            [('/Library/LaunchAgents', [], ['com.apple.lla1.plist', 'com.apple.lla2.plist'])],
-            [('/Library/LaunchDaemons', [], ['com.apple.lld1.plist', 'com.apple.lld2.plist'])],
-            [('/System/Library/LaunchAgents', [], ['com.apple.slla1.plist', 'com.apple.slla2.plist'])],
-            [('/System/Library/LaunchDaemons', [], ['com.apple.slld1.plist', 'com.apple.slld2.plist'])],
-        ]
+        def walk_side_effect(*args, **kwargs):
+            path = args[0]
+            results = {
+                '/Library/LaunchAgents': ['com.apple.lla1.plist', 'com.apple.lla2.plist'],
+                '/Library/LaunchDaemons': ['com.apple.lld1.plist', 'com.apple.lld2.plist'],
+                '/System/Library/LaunchAgents': ['com.apple.slla1.plist', 'com.apple.slla2.plist'],
+                '/System/Library/LaunchDaemons': ['com.apple.slld1.plist', 'com.apple.slld2.plist']}
+            files = results.get(path, [])
+            return [(path, [], files)]
+
+        mock_os_walk.side_effect = walk_side_effect
         attrs = {'cmd.run': MagicMock(return_value='<some xml>')}
 
         def getitem(name):


### PR DESCRIPTION
### What does this PR do?
This PR simply creates a conditional for py2 vs. py3 plistlib calls in the mac_utils module. In py3 on macOS, the updated func gets called during a bunch of salt calls; each time the log gets a warning about the deprecation of `plistlib.readPlist`. So, specifically, this PR uses the new API for plistlib (matches the json API) to read plists.

### What issues does this PR fix or reference?
Prevents python 3 from issuing deprecation notices during normal salt execution.

### Previous Behavior
```
# salt-call state.apply
...
[WARNING ] /opt/salt/lib/python3.5/site-packages/salt/utils/mac_utils.py:323: DeprecationWarning: The readPlist function is deprecated, use load() instead
  plist = plistlib.readPlist(true_path)

[WARNING ] /opt/salt/lib/python3.5/site-packages/salt/utils/mac_utils.py:345: DeprecationWarning: Attribute access from plist dicts is deprecated, use d[key] notation instead
  'plist': plist}
...
```

### New Behavior
No warnings issues.

### Tests written?
No

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.