### PR TITLE
Add latency calculation to master_stats

### DIFF
--- a/doc/ref/configuration/master.rst
+++ b/doc/ref/configuration/master.rst
@@ -883,8 +883,8 @@ Default: False
 
 Turning on the master stats enables runtime throughput and statistics events
 to be fired from the master event bus. These events will report on what
-functions have been run on the master and how long these runs have, on
-average, taken over a given period of time.
+functions have been run on the master along with their average latency and
+duration, taken over a given period of time.
 
 .. conf_master:: master_stats_event_iter
 

--- a/salt/master.py
+++ b/salt/master.py
@@ -1069,7 +1069,10 @@ class MWorker(salt.utils.process.SignalHandlingMultiprocessingProcess):
         try:
             jid = data['jid']
         except KeyError:
-            return
+            try:
+                jid = data['data']['__pub_jid']
+            except KeyError:
+                return
 
         create_time = int(time.mktime(time.strptime(jid, '%Y%m%d%H%M%S%f')))
         latency = start_time - create_time

--- a/salt/master.py
+++ b/salt/master.py
@@ -1065,16 +1065,15 @@ class MWorker(salt.utils.process.SignalHandlingMultiprocessingProcess):
         '''
         end_time = time.time()
         cmd = data['cmd']
+        # the jid is used as the create time
         try:
             jid = data['jid']
         except KeyError:
-            jid = None
+            return
 
-        if jid:
-            # Only calculate latency if the payload contains a jid
-            create_time = int(time.mktime(time.strptime(jid, '%Y%m%d%H%M%S%f')))
-            latency = start_time - create_time
-            self.stats[cmd]['latency'] = (self.stats[cmd]['latency'] * (self.stats[cmd]['runs'] - 1) + latency) / self.stats[cmd]['runs']
+        create_time = int(time.mktime(time.strptime(jid, '%Y%m%d%H%M%S%f')))
+        latency = start_time - create_time
+        self.stats[cmd]['latency'] = (self.stats[cmd]['latency'] * (self.stats[cmd]['runs'] - 1) + latency) / self.stats[cmd]['runs']
 
         duration = end_time - start_time
         self.stats[cmd]['mean'] = (self.stats[cmd]['mean'] * (self.stats[cmd]['runs'] - 1) + duration) / self.stats[cmd]['runs']

--- a/salt/master.py
+++ b/salt/master.py
@@ -1098,7 +1098,6 @@ class MWorker(salt.utils.process.SignalHandlingMultiprocessingProcess):
         :return: The result of passing the load to a function in AESFuncs corresponding to
                  the command specified in the load's 'cmd' key.
         '''
-
         if 'cmd' not in data:
             log.error('Received malformed command %s', data)
             return {}

--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -207,6 +207,32 @@ def tagify(suffix='', prefix='', base=SALT):
     return TAGPARTER.join([part for part in parts if part])
 
 
+def update_stats(stats, start_time, data):
+    '''
+    Calculate the master stats and return the updated stat info
+    '''
+    end_time = time.time()
+    cmd = data['cmd']
+    # the jid is used as the create time
+    try:
+        jid = data['jid']
+    except KeyError:
+        try:
+            jid = data['data']['__pub_jid']
+        except KeyError:
+            log.info('jid not found in data, stats not updated')
+            return stats
+    create_time = int(time.mktime(time.strptime(jid, '%Y%m%d%H%M%S%f')))
+    latency = start_time - create_time
+    duration = end_time - start_time
+
+    stats[cmd]['runs'] += 1
+    stats[cmd]['latency'] = (stats[cmd]['latency'] * (stats[cmd]['runs'] - 1) + latency) / stats[cmd]['runs']
+    stats[cmd]['mean'] = (stats[cmd]['mean'] * (stats[cmd]['runs'] - 1) + duration) / stats[cmd]['runs']
+
+    return stats
+
+
 class SaltEvent(object):
     '''
     Warning! Use the get_event function or the code will not be

--- a/salt/utils/reactor.py
+++ b/salt/utils/reactor.py
@@ -313,7 +313,6 @@ class Reactor(salt.utils.process.SignalHandlingMultiprocessingProcess, salt.stat
                         log.warning('Exit ignored by reactor')
 
                     if self.opts['master_stats']:
-                        #if cmd is not None:
                         self._post_stats(start, _data)
 
 


### PR DESCRIPTION
### What does this PR do?

Adds a latency measurement to the master_stats data. Latency is measured as the time between the JID being created and the job being picked up by an mworker process.

### Previous Behavior

Currently, only mean job duration is collected.

### New Behavior

Adds mean job latency to master stats collection.

### Tests written?

No

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
