### PR TITLE
Detect when system needs reboot after domain join

### DIFF
--- a/salt/modules/win_system.py
+++ b/salt/modules/win_system.py
@@ -1205,29 +1205,24 @@ def get_pending_domain_join():
 
         salt '*' system.get_pending_domain_join
     '''
-    vname = '(Default)'
     base_key = r'SYSTEM\CurrentControlSet\Services\Netlogon'
     avoid_key = r'{0}\AvoidSpnSet'.format(base_key)
     join_key = r'{0}\JoinDomain'.format(base_key)
 
     # If either the avoid_key or join_key is present,
     # then there is a reboot pending.
-
-    avoid_reg_ret = __salt__['reg.read_value']('HKLM', avoid_key, vname)
-
-    if avoid_reg_ret['success']:
-        log.debug('Found key: %s', avoid_key)
+    if __utils__['reg.key_exists']('HKLM', avoid_key):
+        log.debug('Key exists: %s', avoid_key)
         return True
     else:
-        log.debug('Unable to access key: %s', avoid_key)
+        log.debug('Key does not exist: %s', avoid_key)
 
-    join_reg_ret = __salt__['reg.read_value']('HKLM', join_key, vname)
-
-    if join_reg_ret['success']:
-        log.debug('Found key: %s', join_key)
+    if __utils__['reg.key_exists']('HKLM', join_key):
+        log.debug('Key exists: %s', join_key)
         return True
     else:
-        log.debug('Unable to access key: %s', join_key)
+        log.debug('Key does not exist: %s', join_key)
+
     return False
 
 

--- a/salt/modules/win_system.py
+++ b/salt/modules/win_system.py
@@ -1174,17 +1174,15 @@ def get_pending_component_servicing():
 
         salt '*' system.get_pending_component_servicing
     '''
-    vname = '(Default)'
     key = r'SOFTWARE\Microsoft\Windows\CurrentVersion\Component Based Servicing\RebootPending'
 
-    reg_ret = __salt__['reg.read_value']('HKLM', key, vname)
-
     # So long as the registry key exists, a reboot is pending.
-    if reg_ret['success']:
-        log.debug('Found key: %s', key)
+    if __utils__['reg.key_exists']('HKLM', key):
+        log.debug('Key exists: %s', key)
         return True
     else:
-        log.debug('Unable to access key: %s', key)
+        log.debug('Key does not exist: %s', key)
+
     return False
 
 
@@ -1316,17 +1314,15 @@ def get_pending_update():
 
         salt '*' system.get_pending_update
     '''
-    vname = '(Default)'
     key = r'SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Auto Update\RebootRequired'
 
-    reg_ret = __salt__['reg.read_value']('HKLM', key, vname)
-
     # So long as the registry key exists, a reboot is pending.
-    if reg_ret['success']:
-        log.debug('Found key: %s', key)
+    if __utils__['reg.key_exists']('HKLM', key):
+        log.debug('Key exists: %s', key)
         return True
     else:
-        log.debug('Unable to access key: %s', key)
+        log.debug('Key does not exist: %s', key)
+
     return False
 
 
@@ -1416,7 +1412,9 @@ def get_pending_reboot():
     '''
 
     # Order the checks for reboot pending in most to least likely.
-    checks = (get_pending_update, get_pending_file_rename, get_pending_servermanager,
+    checks = (get_pending_update,
+              get_pending_file_rename,
+              get_pending_servermanager,
               get_pending_component_servicing,
               get_reboot_required_witnessed,
               get_pending_computer_name,

--- a/salt/utils/win_reg.py
+++ b/salt/utils/win_reg.py
@@ -39,6 +39,7 @@ try:
     import win32gui
     import win32api
     import win32con
+    import pywintypes
     HAS_WINDOWS_MODULES = True
 except ImportError:
     HAS_WINDOWS_MODULES = False
@@ -161,7 +162,7 @@ class Registry(object):  # pylint: disable=R0903
 def key_exists(hive, key, use_32bit_registry=False):
     '''
     Check that the key is found in the registry. This refers to keys and not
-    value/data pairs.
+    value/data pairs. To check value/data pairs, use ``value_exists``
 
     Args:
 
@@ -195,7 +196,64 @@ def key_exists(hive, key, use_32bit_registry=False):
         handle = win32api.RegOpenKeyEx(hkey, local_key, 0, access_mask)
         win32api.RegCloseKey(handle)
         return True
-    except Exception:  # pylint: disable=E0602
+    except pywintypes.error:
+        return False
+
+
+def value_exists(hive, key, vname, use_32bit_registry=False):
+    '''
+    Check that the value/data pair is found in the registry.
+
+    .. version-added:: 2018.3.4
+
+    Args:
+
+        hive (str): The hive to connect to
+
+        key (str): The key to check in
+
+        vname (str): The name of the value/data pair you're checking
+
+        use_32bit_registry (bool): Look in the 32bit portion of the registry
+
+    Returns:
+        bool: True if exists, otherwise False
+
+    Usage:
+
+        .. code-block:: python
+
+            import salt.utils.win_reg
+            winreg.key_exists(hive='HKLM', key='SOFTWARE\\Microsoft')
+    '''
+    local_hive = _to_unicode(hive)
+    local_key = _to_unicode(key)
+    local_vname = _to_unicode(vname)
+
+    registry = Registry()
+    try:
+        hkey = registry.hkeys[local_hive]
+    except KeyError:
+        raise CommandExecutionError('Invalid Hive: {0}'.format(local_hive))
+    access_mask = registry.registry_32[use_32bit_registry]
+
+    try:
+        handle = win32api.RegOpenKeyEx(hkey, local_key, 0, access_mask)
+        try:
+            # RegQueryValueEx returns and accepts unicode data
+            _, _ = win32api.RegQueryValueEx(handle, local_vname)
+            win32api.RegCloseKey(handle)
+            # value/data pair exists
+            return True
+        except pywintypes.error as exc:
+            if exc.winerror == 2 and vname is None:
+                # value/data pair exists but is empty
+                return True
+            else:
+                # value/data pair not found
+                return False
+    except pywintypes.error:
+        # The key containing the value/data pair does not exist
         return False
 
 

--- a/tests/integration/modules/test_system.py
+++ b/tests/integration/modules/test_system.py
@@ -398,6 +398,7 @@ class WinSystemModuleTest(ModuleCase):
         now = datetime.datetime.now()
         self.assertEqual(now.strftime("%I:%M"), ret.rsplit(':', 1)[0])
 
+    @flaky
     @destructiveTest
     def test_set_system_time(self):
         '''


### PR DESCRIPTION
### What does this PR do?
Properly detects if the system requires reboot after Joining a domain.
Adds value_exists function
Uses key_exists instead of reading and failing

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/49675

### Tests written?
No

### Commits signed with GPG?
Yes