### PR TITLE
Fix heading line-lengths

### DIFF
--- a/salt/pillar/cmd_yamlex.py
+++ b/salt/pillar/cmd_yamlex.py
@@ -1,14 +1,12 @@
 # -*- coding: utf-8 -*-
 '''
-Execute a command and read the output as YAMLEX. The YAMLEX data is then directly overlaid onto the minion's Pillar data
+Execute a command and read the output as YAMLEX.
+
+The YAMLEX data is then directly overlaid onto the minion's Pillar data
 '''
 
-# Don't "fix" the above docstring to put it on two lines, as the sphinx
-# autosummary pulls only the first line for its description.
-
-from __future__ import absolute_import
-
 # Import python libs
+from __future__ import absolute_import
 import logging
 
 # Import salt libs

--- a/salt/pillar/cmd_yamlex.py
+++ b/salt/pillar/cmd_yamlex.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 '''
-Execute a command and read the output as YAMLEX. The YAMLEX data is then
-directly overlaid onto the minion's Pillar data
+Execute a command and read the output as YAMLEX. The YAMLEX data is then directly overlaid onto the minion's Pillar data
 '''
 
 # Don't "fix" the above docstring to put it on two lines, as the sphinx

--- a/salt/pillar/makostack.py
+++ b/salt/pillar/makostack.py
@@ -103,7 +103,7 @@ would actually end up in pillar after all merging was complete:
           - baz
 
 MakoStack configuration files
--------------------------------
+-----------------------------
 
 The config files that are referenced in the above ``ext_pillar`` configuration
 are mako templates which must render as a simple ordered list of ``yaml``

--- a/salt/pillar/mysql.py
+++ b/salt/pillar/mysql.py
@@ -12,7 +12,7 @@ This module is a concrete implementation of the sql_base ext_pillar for MySQL.
 :platform: all
 
 Configuring the mysql ext_pillar
-=====================================
+================================
 
 Use the 'mysql' key under ext_pillar for configuration of queries.
 
@@ -22,7 +22,7 @@ mysql.pass, mysql.port, mysql.host) for database connection info.
 Required python modules: MySQLdb
 
 Complete example
-=====================================
+================
 
 .. code-block:: yaml
 

--- a/salt/pillar/postgres.py
+++ b/salt/pillar/postgres.py
@@ -8,8 +8,8 @@ Retrieve Pillar data by doing a postgres query
 :depends: psycopg2
 :platform: all
 
-Complete example
-=====================================
+Complete Example
+================
 
 .. code-block:: yaml
 

--- a/salt/pillar/sql_base.py
+++ b/salt/pillar/sql_base.py
@@ -10,7 +10,7 @@ It exposes a python ABC that can be subclassed for new database providers.
 :platform: all
 
 Theory of sql_base ext_pillar
-=====================================
+=============================
 
 Ok, here's the theory for how this works...
 
@@ -32,7 +32,7 @@ You can retrieve as many fields as you like, how they get used depends on the
 exact settings.
 
 Configuring a sql_base ext_pillar
-=====================================
+=================================
 
 The sql_base ext_pillar cannot be used directly, but shares query configuration
 with its implementations. These examples use a fake 'sql_base' adapter, which

--- a/salt/pillar/sqlcipher.py
+++ b/salt/pillar/sqlcipher.py
@@ -37,8 +37,8 @@ Example configuration
       pass: strong_pass_phrase
       timeout: 5.0
 
-Complete example
-=================
+Complete Example
+================
 
 .. code-block:: yaml
 


### PR DESCRIPTION
This should clean up some of the warnings found by building the documentation:

```
/root/SaltStack/salt/doc/ref/pillar/all/index.rst:55:<autosummary>:1: WARNING: Unexpected section title or transition.

=================
```

I should check the doc build result before merging. I am not sure if I got all of them.