### PR TITLE
Order the runtests suites

### DIFF
--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -11,6 +11,7 @@ import os
 import sys
 import time
 import warnings
+import collections
 
 TESTS_DIR = os.path.dirname(os.path.normpath(os.path.abspath(__file__)))
 if os.name == 'nt':
@@ -97,7 +98,7 @@ MAX_OPEN_FILES = {
 
 # Combine info from command line options and test suite directories.  A test
 # suite is a python package of test modules relative to the tests directory.
-TEST_SUITES = {
+TEST_SUITES_UNORDERED = {
     'unit':
        {'display_name': 'Unit',
         'path': 'unit'},
@@ -186,6 +187,9 @@ TEST_SUITES = {
         {'display_name': 'Logging',
          'path': 'integration/logging'},
 }
+
+TEST_SUITES = collections.OrderedDict(sorted(TEST_SUITES_UNORDERED.items(),
+    key=lambda x: x[0]))
 
 
 class SaltTestsuiteParser(SaltCoverageTestingParser):


### PR DESCRIPTION
### What does this PR do?

Uses an ordered dictionary instead of a default python dict when
describing the `TEST_SUITES` variable. Sorts alphabetically based on the
name of the suite.

Fixes the test suite being run out of order, should make troubleshooting a bit easier for the tests, as they'll run in a consistent order (should see failures in consistent places).