### PR TITLE
loosen azure sdk dependencies in azurearm cloud driver

### DIFF
--- a/salt/cloud/clouds/azurearm.py
+++ b/salt/cloud/clouds/azurearm.py
@@ -68,7 +68,6 @@ import salt.utils.data
 import salt.utils.files
 import salt.utils.stringutils
 import salt.utils.yaml
-from salt.utils.versions import LooseVersion
 from salt.ext import six
 import salt.version
 from salt.exceptions import (

--- a/salt/cloud/clouds/azurearm.py
+++ b/salt/cloud/clouds/azurearm.py
@@ -60,6 +60,7 @@ import logging
 import pprint
 import base64
 import collections
+import pkgutil
 import salt.cache
 import salt.config as config
 import salt.utils.cloud
@@ -117,9 +118,12 @@ try:
     from azure.mgmt.storage import StorageManagementClient
     from azure.mgmt.web import WebSiteManagementClient
     from msrestazure.azure_exceptions import CloudError
-    from azure.multiapi.storage.v2016_05_31 import CloudStorageAccount
-    from azure.cli import core
-    HAS_LIBS = LooseVersion(core.__version__) >= LooseVersion("2.0.12")
+    if pkgutil.find_loader('azure.multiapi'):
+        # use multiapi version if available
+        from azure.multiapi.storage.v2016_05_31 import CloudStorageAccount
+    else:
+        from azure.storage import CloudStorageAccount
+    HAS_LIBS = True
 except ImportError:
     pass
 # pylint: enable=wrong-import-position,wrong-import-order
@@ -152,8 +156,7 @@ def __virtual__():
             False,
             'The following dependencies are required to use the AzureARM driver: '
             'Microsoft Azure SDK for Python >= 2.0rc5, '
-            'Microsoft Azure Storage SDK for Python >= 0.32, '
-            'Microsoft Azure CLI >= 2.0.12'
+            'Microsoft Azure Storage SDK for Python >= 0.32'
         )
 
     global cache  # pylint: disable=global-statement,invalid-name


### PR DESCRIPTION
### What does this PR do?
This PR removes the dependency on azure-cli from the azurearm cloud driver, which is not used at all. It also changes the driver to import the azure-storage sdk package in lieu of the multiapi storage package, in case the latter is not available.

### What issues does this PR fix or reference?
Allows the azurearm cloud driver to be used on platforms that do not have the azure-cli or azure-multiapi-storage packages.

### Tests written?
Manually tested with azure-storage 0.36 and azure-multiapi-storage 0.1.4.

### Commits signed with GPG?
Yes