### PR TITLE
Fix set_static_all, always display requestmode and refactor _change_state

### DIFF
--- a/salt/modules/nilrt_ip.py
+++ b/salt/modules/nilrt_ip.py
@@ -216,12 +216,15 @@ def _get_service_info(service):
         data['ipv4']['dns'] = nameservers
     else:
         data['up'] = False
+        data['ipv4'] = {
+            'requestmode': 'disabled'
+        }
 
-    if 'ipv4' in data:
-        data['ipv4']['supportedrequestmodes'] = [
-            'static',
-            'dhcp_linklocal'
-        ]
+    data['ipv4']['supportedrequestmodes'] = [
+        'static',
+        'dhcp_linklocal',
+        'disabled'
+    ]
     return data
 
 
@@ -355,7 +358,7 @@ def _get_static_info(interface):
         'hwaddr': interface.hwaddr[:-1],
         'up': False,
         'ipv4': {
-            'supportedrequestmodes': ['static', 'dhcp_linklocal'],
+            'supportedrequestmodes': ['static', 'dhcp_linklocal', 'disabled'],
             'requestmode': 'static'
         },
         'wireless': False

--- a/salt/modules/nilrt_ip.py
+++ b/salt/modules/nilrt_ip.py
@@ -871,7 +871,7 @@ def set_static_all(interface, address, netmask, gateway, nameservers=None):
     ipv4['Gateway'] = dbus.String('{0}'.format(gateway), variant_level=1)
     try:
         service.set_property('IPv4.Configuration', ipv4)
-        if not nameservers:
+        if nameservers:
             service.set_property('Nameservers.Configuration', [dbus.String('{0}'.format(d)) for d in nameservers])
     except Exception as exc:
         exc_msg = 'Couldn\'t set manual settings for service: {0}\nError: {1}\n'.format(service, exc)

--- a/salt/modules/nilrt_ip.py
+++ b/salt/modules/nilrt_ip.py
@@ -50,6 +50,7 @@ __virtualname__ = 'ip'
 
 SERVICE_PATH = '/net/connman/service/'
 INTERFACES_CONFIG = '/var/lib/connman/interfaces.config'
+CONNMAN_MAIN_CONFIG = '/etc/connman/main.conf'
 NIRTCFG_PATH = '/usr/local/natinst/bin/nirtcfg'
 INI_FILE = '/etc/natinst/share/ni-rt.ini'
 _CONFIG_TRUE = ['yes', 'on', 'true', '1', True]
@@ -221,9 +222,9 @@ def _get_service_info(service):
         }
 
     data['ipv4']['supportedrequestmodes'] = [
-        'static',
         'dhcp_linklocal',
-        'disabled'
+        'disabled',
+        'static'
     ]
     return data
 
@@ -358,20 +359,27 @@ def _get_static_info(interface):
         'hwaddr': interface.hwaddr[:-1],
         'up': False,
         'ipv4': {
-            'supportedrequestmodes': ['static', 'dhcp_linklocal', 'disabled'],
-            'requestmode': 'static'
+            'supportedrequestmodes': ['dhcp_linklocal', 'disabled', 'static'],
+            'requestmode': 'dhcp_linklocal'
         },
         'wireless': False
     }
     hwaddr_section_number = ''.join(data['hwaddr'].split(':'))
     if os.path.exists(INTERFACES_CONFIG):
-        information = _load_config(hwaddr_section_number, ['IPv4', 'Nameservers'], filename=INTERFACES_CONFIG)
-        if information['IPv4'] != '':
+        information = _load_config('service_' + hwaddr_section_number, ['IPv4', 'Nameservers', 'IPv4.method'],
+                                   filename=INTERFACES_CONFIG)
+        if information['IPv4.method'] == 'manual' and information['IPv4'] != '':
             ipv4_information = information['IPv4'].split('/')
             data['ipv4']['address'] = ipv4_information[0]
             data['ipv4']['dns'] = information['Nameservers'].split(',')
             data['ipv4']['netmask'] = ipv4_information[1]
             data['ipv4']['gateway'] = ipv4_information[2]
+            data['ipv4']['requestmode'] = 'static'
+        else:
+            information = _load_config('General', ['NetworkInterfaceBlacklist'], filename=CONNMAN_MAIN_CONFIG)
+            if data['label'] in information['NetworkInterfaceBlacklist']:
+                data['ipv4']['requestmode'] = 'disabled'
+
     return data
 
 
@@ -537,6 +545,93 @@ def _change_state_legacy(interface, new_state):
     return True
 
 
+def _remove_interface_section(interface):
+    '''
+    Remove interface section from connman config file
+    '''
+    parser = configparser.ConfigParser()
+    parser.optionxform = str
+    if os.path.exists(INTERFACES_CONFIG):
+        try:
+            with salt.utils.files.fopen(INTERFACES_CONFIG, 'r') as config_file:
+                parser.readfp(config_file)
+        except configparser.MissingSectionHeaderError:
+            pass
+    interface = pyiface.Interface(name=interface)
+    hwaddr = interface.hwaddr[:-1]
+    hwaddr_section_number = ''.join(hwaddr.split(':'))
+    if parser.has_section('service_{0}'.format(hwaddr_section_number)):
+        parser.remove_section('service_{0}'.format(hwaddr_section_number))
+    with salt.utils.files.fopen(INTERFACES_CONFIG, 'w') as config_file:
+        parser.write(config_file)
+    return True
+
+
+def _change_connman_backlist(interface, add=True):
+    '''
+    Remove or add an interface to connman blacklist
+
+    :param interface: interface label
+    :param add: True to add interface to blacklist, False otherwise. Default is True.
+    '''
+    parser = configparser.ConfigParser()
+    parser.optionxform = str
+    if os.path.exists(CONNMAN_MAIN_CONFIG):
+        try:
+            with salt.utils.files.fopen(CONNMAN_MAIN_CONFIG, 'r') as config_file:
+                parser.readfp(config_file)
+        except configparser.MissingSectionHeaderError:
+            pass
+    if not parser.has_section('General'):
+        parser.add_section('General')
+        parser.set('General', 'AlwaysConnectedTechnologies', 'wifi,ehternet,bluetooth')
+    if parser.has_option('General', 'NetworkInterfaceBlacklist'):
+        blacklist = parser.get('General', 'NetworkInterfaceBlacklist')
+        blacklist = [] if blacklist == '' else blacklist.split(',')
+        if add:
+            blacklist.append(interface)
+        else:
+            blacklist.remove(interface)
+        blacklist = ','.join(blacklist)
+    else:
+        blacklist = interface if add else ""
+    parser.set('General', 'NetworkInterfaceBlacklist', blacklist)
+    with salt.utils.files.fopen(CONNMAN_MAIN_CONFIG, 'w') as config_file:
+        parser.write(config_file)
+    if add:
+        return _remove_interface_section(interface)
+    return _enable_dhcp(interface)
+
+
+def _enable_dhcp(interface):
+    '''
+    Enable dhcp for an interface which isn't a service
+
+    :param interface: interface label
+    '''
+    parser = configparser.ConfigParser()
+    parser.optionxform = str
+    if os.path.exists(INTERFACES_CONFIG):
+        try:
+            with salt.utils.files.fopen(INTERFACES_CONFIG, 'r') as config_file:
+                parser.readfp(config_file)
+        except configparser.MissingSectionHeaderError:
+            pass
+    interface = pyiface.Interface(name=interface)
+    hwaddr = interface.hwaddr[:-1]
+    hwaddr_section_number = ''.join(hwaddr.split(':'))
+    if parser.has_section('service_{0}'.format(hwaddr_section_number)):
+        parser.remove_section('service_{0}'.format(hwaddr_section_number))
+    parser.add_section('service_{0}'.format(hwaddr_section_number))
+    parser.set('service_{0}'.format(hwaddr_section_number), 'MAC', hwaddr)
+    parser.set('service_{0}'.format(hwaddr_section_number), 'Name', 'ethernet_cable_{0}'.format(hwaddr_section_number))
+    parser.set('service_{0}'.format(hwaddr_section_number), 'IPv4.method', 'dhcp')
+    parser.set('service_{0}'.format(hwaddr_section_number), 'AutoConnect', 'true')
+    with salt.utils.files.fopen(INTERFACES_CONFIG, 'w') as config_file:
+        parser.write(config_file)
+    return True
+
+
 def _change_state(interface, new_state):
     '''
     Enable or disable an interface
@@ -552,12 +647,16 @@ def _change_state(interface, new_state):
         return _change_state_legacy(interface, new_state)
     service = _interface_to_service(interface)
     if not service:
+        if interface in map(lambda x: x.name, pyiface.getIfaces()):
+            ret = _change_connman_backlist(interface, add=new_state == 'down')
+            return ret and __salt__['cmd.run_all']('/etc/init.d/connman restart')['retcode'] == 0
         raise salt.exceptions.CommandExecutionError('Invalid interface name: {0}'.format(interface))
     connected = _connected(service)
     if (not connected and new_state == 'up') or (connected and new_state == 'down'):
         service = pyconnman.ConnService(os.path.join(SERVICE_PATH, service))
         try:
             state = service.connect() if new_state == 'up' else service.disconnect()
+            _change_connman_backlist(interface, add=new_state == 'down')
             return state is None
         except Exception:
             raise salt.exceptions.CommandExecutionError('Couldn\'t {0} service: {1}\n'
@@ -713,6 +812,8 @@ def set_dhcp_linklocal_all(interface):
         return True
     service = _interface_to_service(interface)
     if not service:
+        if interface in map(lambda x: x.name, pyiface.getIfaces()):
+            return _enable_dhcp(interface)
         raise salt.exceptions.CommandExecutionError('Invalid interface name: {0}'.format(interface))
     service = pyconnman.ConnService(os.path.join(SERVICE_PATH, service))
     ipv4 = service.get_property('IPv4.Configuration')
@@ -803,6 +904,7 @@ def _configure_static_interface(interface, **settings):
     '''
     interface = pyiface.Interface(name=interface)
     parser = configparser.ConfigParser()
+    parser.optionxform = str
     if os.path.exists(INTERFACES_CONFIG):
         try:
             with salt.utils.files.fopen(INTERFACES_CONFIG, 'r') as config_file:
@@ -811,19 +913,21 @@ def _configure_static_interface(interface, **settings):
             pass
     hwaddr = interface.hwaddr[:-1]
     hwaddr_section_number = ''.join(hwaddr.split(':'))
-    if not parser.has_section('interface_{0}'.format(hwaddr_section_number)):
-        parser.add_section('interface_{0}'.format(hwaddr_section_number))
+    if parser.has_section('service_{0}'.format(hwaddr_section_number)):
+        parser.remove_section('service_{0}'.format(hwaddr_section_number))
+    parser.add_section('service_{0}'.format(hwaddr_section_number))
     ip_address = settings.get('ip', '0.0.0.0')
     netmask = settings.get('netmask', '0.0.0.0')
     gateway = settings.get('gateway', '0.0.0.0')
     dns_servers = settings.get('dns', '')
     name = settings.get('name', 'ethernet_cable_{0}'.format(hwaddr_section_number))
-    parser.set('interface_{0}'.format(hwaddr_section_number), 'IPv4', '{0}/{1}/{2}'.
+    parser.set('service_{0}'.format(hwaddr_section_number), 'IPv4', '{0}/{1}/{2}'.
                format(ip_address, netmask, gateway))
-    parser.set('interface_{0}'.format(hwaddr_section_number), 'Nameservers', dns_servers)
-    parser.set('interface_{0}'.format(hwaddr_section_number), 'Name', name)
-    parser.set('interface_{0}'.format(hwaddr_section_number), 'MAC', hwaddr)
-    parser.set('interface_{0}'.format(hwaddr_section_number), 'Type', 'ethernet')
+    parser.set('service_{0}'.format(hwaddr_section_number), 'Nameservers', dns_servers)
+    parser.set('service_{0}'.format(hwaddr_section_number), 'Name', name)
+    parser.set('service_{0}'.format(hwaddr_section_number), 'MAC', hwaddr)
+    parser.set('service_{0}'.format(hwaddr_section_number), 'Type', 'ethernet')
+    parser.set('service_{0}'.format(hwaddr_section_number), 'IPv4.method', 'manual')
     with salt.utils.files.fopen(INTERFACES_CONFIG, 'w') as config_file:
         parser.write(config_file)
     return True
@@ -873,27 +977,15 @@ def set_static_all(interface, address, netmask, gateway, nameservers=None):
         else:
             _restart(interface)
         return True
-    service = _interface_to_service(interface)
-    if not service:
-        if interface in pyiface.getIfaces():
-            return _configure_static_interface(interface, **{'ip': address,
-                                                             'dns': ','.join(nameservers) if nameservers else '',
-                                                             'netmask': netmask, 'gateway': gateway})
-        raise salt.exceptions.CommandExecutionError('Invalid interface name: {0}'.format(interface))
-    service = pyconnman.ConnService(os.path.join(SERVICE_PATH, service))
-    ipv4 = service.get_property('IPv4.Configuration')
-    ipv4['Method'] = dbus.String('manual', variant_level=1)
-    ipv4['Address'] = dbus.String('{0}'.format(address), variant_level=1)
-    ipv4['Netmask'] = dbus.String('{0}'.format(netmask), variant_level=1)
-    ipv4['Gateway'] = dbus.String('{0}'.format(gateway), variant_level=1)
-    try:
-        service.set_property('IPv4.Configuration', ipv4)
-        if nameservers:
-            service.set_property('Nameservers.Configuration', [dbus.String('{0}'.format(d)) for d in nameservers])
-    except Exception as exc:
-        exc_msg = 'Couldn\'t set manual settings for service: {0}\nError: {1}\n'.format(service, exc)
-        raise salt.exceptions.CommandExecutionError(exc_msg)
-    return True
+    if interface in map(lambda x: x.name, pyiface.getIfaces()):
+        ret_value = _configure_static_interface(interface, **{'ip': address,
+                                                              'dns': ','.join(nameservers) if nameservers else '',
+                                                              'netmask': netmask, 'gateway': gateway})
+        service = _interface_to_service(interface)
+        if service:
+            ret_value = ret_value and __salt__['cmd.run_all']('/etc/init.d/connman restart')['retcode'] == 0
+        return ret_value
+    raise salt.exceptions.CommandExecutionError('Invalid interface name: {0}'.format(interface))
 
 
 def get_interface(iface):


### PR DESCRIPTION
* modules/nilrt_ip.py: Display requestmode even if service is offline
This will keep parity between older and newer nilrt distro.

* modules/nilrt_ip.py: Split _change_state function
Split the logic of _change_state function for older and newer disto.

* modules/nilrt_ip.py: Fix set_static_all
If there are no nameservers specified, we shouldn't set any property
for nameservers configuration to the service.