### PR TITLE
Mark orchestration test as expensive

### DIFF
--- a/tests/integration/runners/test_state.py
+++ b/tests/integration/runners/test_state.py
@@ -340,6 +340,7 @@ class OrchEventTest(ShellCase):
         self.conf.write(salt.utils.yaml.safe_dump(data, default_flow_style=False))
         self.conf.flush()
 
+    @expensiveTest
     def test_jid_in_ret_event(self):
         '''
         Test to confirm that the ret event for the orchestration contains the


### PR DESCRIPTION
This test is causing errors with the test suite - it takes a very long time to run when it runs successfully, but sometimes causes OOM errors.