### PR TITLE
[DOC] Add missing `mock` argument for `state.apply`

### DIFF
--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -481,6 +481,13 @@ def apply_(mods=None, **kwargs):
     test
         Run states in test-only (dry-run) mode
 
+    mock
+        The mock option allows for the state run to execute without actually
+        calling any states. This then returns a mocked return which will show
+        the requisite ordering as well as fully validate the state run.
+
+        .. versionadded:: 2015.8.4
+
     pillar
         Custom Pillar values, passed as a dictionary of key-value pairs
 
@@ -540,6 +547,13 @@ def apply_(mods=None, **kwargs):
 
     test
         Run states in test-only (dry-run) mode
+
+    mock
+        The mock option allows for the state run to execute without actually
+        calling any states. This then returns a mocked return which will show
+        the requisite ordering as well as fully validate the state run.
+
+        .. versionadded:: 2015.8.4
 
     pillar
         Custom Pillar values, passed as a dictionary of key-value pairs


### PR DESCRIPTION
### What does this PR do?
It adds missing `mock` keyword argument to the `state.apply` function docstring. It is supported by both underlying `state.highstate` and `state.sls` functions.

### Commits signed with GPG?
Yes

