### PR TITLE
Get proper endpoint for password verification in keystone module

### DIFF
--- a/salt/modules/keystone.py
+++ b/salt/modules/keystone.py
@@ -1124,11 +1124,15 @@ def user_verify_password(user_id=None, name=None, password=None,
     if 'connection_endpoint' in connection_args:
         auth_url = connection_args.get('connection_endpoint')
     else:
+        auth_url_opt = 'keystone.auth_url'
+        if __salt__['config.option']('keystone.token'):
+            auth_url_opt = 'keystone.endpoint'
+
         if _OS_IDENTITY_API_VERSION > 2:
-            auth_url = __salt__['config.option']('keystone.endpoint',
+            auth_url = __salt__['config.option'](auth_url_opt,
                                                  'http://127.0.0.1:35357/v3')
         else:
-            auth_url = __salt__['config.option']('keystone.endpoint',
+            auth_url = __salt__['config.option'](auth_url_opt,
                                                  'http://127.0.0.1:35357/v2.0')
 
     if user_id:


### PR DESCRIPTION
Keystone module could be configured to use admin token which use
option keystone.endpoint and without admin token which use
keystone.auth_url. Function user_verify_password should distinguish
these cases and get endpoint from proper option. Otherwise password
will be always updated if admin token is not used causing tokens
revocation.

### What does this PR do?
Get proper keystone endpoint in function user_verify_password of keystone module.

### Previous Behavior
When admin token is not used then user password is always updated causing tokens revocation.

### New Behavior
When admin token is not used then user password is updated only if changed.

### Tests written?
No

### Commits signed with GPG?
No
