### PR TITLE
Fixes some issues on the Zypper module

### DIFF
--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -2266,7 +2266,7 @@ def list_provides(**kwargs):
     '''
     ret = __context__.get('pkg.list_provides')
     if not ret:
-        cmd = ['rpm', '-qa', '--queryformat', '[%{PROVIDES}_|-%{NAME}\n]']
+        cmd = ['rpm', '-qa', '--queryformat', '%{PROVIDES}_|-%{NAME}\n']
         ret = dict()
         for line in __salt__['cmd.run'](cmd, output_loglevel='trace', python_shell=False).splitlines():
             provide, realname = line.split('_|-')

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -2331,7 +2331,7 @@ def resolve_capabilities(pkgs, refresh, **kwargs):
                 try:
                     result = search(name, provides=True, match='exact')
                     if len(result) == 1:
-                        name = result.keys()[0]
+                        name = next(iter(result.keys()))
                     elif len(result) > 1:
                         log.warn("Found ambiguous match for capability '%s'.", pkg)
                 except CommandExecutionError as exc:


### PR DESCRIPTION
### What does this PR do?
This PR fixes two issues on the Zypper module:

- Fix an error happening in some cases when running `resolve_capabilities` on Python 3.
- Fix a wrong queryformat for RPM which produces an exception when running `pkg.list_provides` on Zypper module.

### Previous Behavior
```
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
    File "/usr/lib/python3.6/site-packages/salt/state.py", line 1878, in call
      **cdata['kwargs'])
    File "/usr/lib/python3.6/site-packages/salt/loader.py", line 1823, in wrapper
      return f(*args, **kwargs)
    File "/usr/lib/python3.6/site-packages/salt/states/pkg.py", line 1487, in installed
      pkgs, refresh = _resolve_capabilities(pkgs, refresh=refresh, **kwargs)
    File "/usr/lib/python3.6/site-packages/salt/states/pkg.py", line 899, in _resolve_capabilities
      ret = __salt__['pkg.resolve_capabilities'](pkgs, refresh=refresh, **kwargs)
    File "/usr/lib/python3.6/site-packages/salt/modules/zypper.py", line 2255, in resolve_capabilities
      name = result.keys()[0]
TypeError: 'dict_keys' object does not support indexing
```

and also:

```
An exception occurred in this state: Traceback (most recent call last):
    File "/usr/lib/python3.6/site-packages/salt/state.py", line 1878, in call
      **cdata['kwargs'])
    File "/usr/lib/python3.6/site-packages/salt/loader.py", line 1823, in wrapper
      return f(*args, **kwargs)
    File "/usr/lib/python3.6/site-packages/salt/states/pkg.py", line 1511, in installed
      **kwargs)
    File "/usr/lib/python3.6/site-packages/salt/states/pkg.py", line 512, in _find_install_targets
      cur_prov = resolve_capabilities and __salt__['pkg.list_provides'](**kwargs) or dict()
    File "/usr/lib/python3.6/site-packages/salt/modules/zypper.py", line 2193, in list_provides
      provide, realname = line.split('_|-')
ValueError: not enough values to unpack (expected 2, got 1)
```

### New Behavior
No exceptions are produced. It run successfully.

### Tests written?

No

### Commits signed with GPG?

Yes