### PR TITLE
Skip test_local_pkg_install test again for RedHat distros.

### DIFF
--- a/tests/integration/shell/test_call.py
+++ b/tests/integration/shell/test_call.py
@@ -92,6 +92,18 @@ class CallTest(ShellCase, testprogram.TestProgramCase, ShellCaseCommonTestsMixin
             return salt.utils.json.loads(''.join(self.run_call(cmd)))['local']
 
         os_family = _run_call('grains.get os_family')
+        if os_family == 'RedHat':
+            # This test errors in odd ways on some distros (namely Fedora, CentOS).
+            # There is a bug somewhere either in the test suite or Python versions
+            # that causes a SyntaxError. This test was skipped entirely long ago,
+            # likely due to this same issue. For now, let's skip the test for these
+            # distros and let the other OSes catch regressions here.
+            # The actual commands work fine, it's the test suite that has problems.
+            # See https://github.com/saltstack/salt-jenkins/issues/1122 and also see
+            # https://github.com/saltstack/salt/pull/49552 for more info.
+            self.skipTest('Test throws SyntaxErrors due to deep bug. Skipping until '
+                          'issue can be resolved.')
+
         try:
             target = _PKG_TARGETS.get(os_family, [])[0]
         except IndexError:


### PR DESCRIPTION
There is a deep bug that I was not able to track down that is causing a SyntaxError within the test suite.

Until we have time to dedicate more resources to tracking this down, let's skip it again (recently re-enabled) for the RedHat family.

The test is used to catch an error where the salt-call command was running twice, so we can rely on the other OSes that don't have this deep bug to catch regressions.

The test was unskipped in #49552. There is more explanation in https://github.com/saltstack/salt-jenkins/issues/1122 about the errors found.
