### PR TITLE
catch socket.error too; and reflow for readability (why list?)

### DIFF
--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -216,7 +216,7 @@ def get_fqhostname():
         pass  # NOTE: this used to log.error() but it was later disabled
     except socket.error as err:
         log.debug('socket.getaddrinfo() failure while finding fqdn: %s', err)
-    if fqdn is not None:
+    if fqdn is None:
         fqdn = socket.getfqdn()
     return fqdn
 

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -198,9 +198,7 @@ def get_fqhostname():
     '''
     Returns the fully qualified hostname
     '''
-    l = [socket.getfqdn()]
-
-    # try socket.getaddrinfo
+    # try getaddrinfo()
     try:
         addrinfo = socket.getaddrinfo(
             socket.gethostname(), 0, socket.AF_UNSPEC, socket.SOCK_STREAM,
@@ -211,11 +209,15 @@ def get_fqhostname():
             # On Windows `canonname` can be an empty string
             # This can cause the function to return `None`
             if len(info) >= 4 and info[3]:
-                l = [info[3]]
+                return info[3]
     except socket.gaierror:
         pass
-
-    return l and l[0] or None
+    except socket.error:
+        pass
+    # if that fails, try getfqdn()
+    fqdn = socket.getfqdn()
+    if fqdn:
+        return fqdn
 
 
 def ip_to_host(ip):

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -213,7 +213,7 @@ def get_fqhostname():
                 fqdn = info[3]
                 break
     except socket.gaierror:
-        pass # NOTE: this used to log.error() but it was later disabled
+        pass  # NOTE: this used to log.error() but it was later disabled
     except socket.error as err:
         log.debug('socket.getaddrinfo() failure while finding fqdn: %s', err)
     if fqdn is not None:

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -199,6 +199,7 @@ def get_fqhostname():
     Returns the fully qualified hostname
     '''
     # try getaddrinfo()
+    fqdn = None
     try:
         addrinfo = socket.getaddrinfo(
             socket.gethostname(), 0, socket.AF_UNSPEC, socket.SOCK_STREAM,
@@ -208,16 +209,16 @@ def get_fqhostname():
             # info struct [family, socktype, proto, canonname, sockaddr]
             # On Windows `canonname` can be an empty string
             # This can cause the function to return `None`
-            if len(info) >= 4 and info[3]:
-                return info[3]
+            if len(info) > 3 and info[3]:
+                fqdn = info[3]
+                break
     except socket.gaierror:
-        pass
-    except socket.error:
-        pass
-    # if that fails, try getfqdn()
-    fqdn = socket.getfqdn()
-    if fqdn:
-        return fqdn
+        pass # NOTE: this used to log.error() but it was later disabled
+    except socket.error as err:
+        log.debug('socket.getaddrinfo() failure while finding fqdn: %s', err)
+    if fqdn is not None:
+        fqdn = socket.getfqdn()
+    return fqdn
 
 
 def ip_to_host(ip):


### PR DESCRIPTION
### What does this PR do?
I'm having an odd and occasional crash in salt.utils.network.get_fqhostname() during getaddrinfo.
Seems other people were having it in 2014:  #11660

I'm not running this in Salt at all though, I'm in the development version of Hubblestack, which imports the latest salt-ssh from pip (salt_ssh-2018.3.2.dist-info); and in any case, the code in get_fqhostname() is identical to that found in the develop branch.

It manifests like this (snipped the stack trace to the end):
```
Traceback (most recent call last):                                                                                     
… snip …                                                                                       
  File "/usr/local/python/hubble.python/lib/python2.7/site-packages/hubblestack-2.4.4-py2.7.egg/hubblestack/daemon.py",
 line 641, in refresh_grains                                                                                           
    __grains__ = salt.loader.grains(__opts__)                                                                          
  File "/usr/local/python/hubble.python/lib/python2.7/site-packages/salt/loader.py", line 734, in grains               
    ret = funcs[key]()                                                                                                 
  File "/usr/local/python/hubble.python/lib/python2.7/site-packages/salt/grains/core.py", line 1858, in hostname       
    __FQDN__ = salt.utils.network.get_fqhostname()                                                                     
  File "/usr/local/python/hubble.python/lib/python2.7/site-packages/salt/utils/network.py", line 203, in get_fqhostnam$
    socket.SOL_TCP, socket.AI_CANONNAME                                                                         
socket.error: [Errno 0] Error                     
```

I was flipping through patches to that file that touched getaddrinfo and the function has a long history. I suspect some of the things in it are leftover kruft.

I'd like to add an except for socket.error and reflow the whole method slightly. Why should we populate a list and then only ever use the first element of it in the return? Also, why call socket.getfqdn() at all if the getaddrinfo() succeeds?

Is there any harm in this? did I do it wrong?
