### PR TITLE
zsh-completion: strip out u'' unicode __repr__ of function names

### DIFF
--- a/pkg/zsh_completion.zsh
+++ b/pkg/zsh_completion.zsh
@@ -25,7 +25,7 @@ _modules(){
     fi
 
     if _cache_invalid salt/modules || ! _retrieve_cache salt/modules; then
-        _funcs=( ${${(Q)${${(s. .)"$(_call_program salt-call-cmd salt-call --local --log-level error --out txt sys.list_functions)"}%%[],]##}#\[}:#local:} )
+        _funcs=( ${${(Q)${${${(s. .)"$(_call_program salt-call-cmd salt-call --local --log-level error --out txt sys.list_functions)"}%%[],]##}#\[#u}#\[}:#local:} )
         _store_cache salt/modules _funcs
     fi
 
@@ -40,7 +40,7 @@ _runners(){
     fi
 
     if _cache_invalid salt/runners || ! _retrieve_cache salt/runners; then
-        _runs=( ${${(Q)${${(s. .)"$(_call_program salt-call-cmd salt-call --local --log-level error --out txt sys.list_runner_functions)"}%%[],]##}#\[}:#local:} )
+        _runs=( ${${(Q)${${${(s. .)"$(_call_program salt-call-cmd salt-call --local --log-level error --out txt sys.list_runner_functions)"}%%[],]##}#\[#u}#\[}:#local:} )
         _store_cache salt/runners _runs
     fi
 


### PR DESCRIPTION
The elements in the array returned by sys.list_{,runners_}functions
recently started to be enclosed by u'' so when the completer parses
salt-call --local --out txt sys.$func, the incorrect module is
presented.