### PR TITLE
Fixes issue #49672 by allowing a map between the rpm host_cpu and the…

### DIFF
--- a/salt/utils/pkg/rpm.py
+++ b/salt/utils/pkg/rpm.py
@@ -37,7 +37,8 @@ ARCHES = ARCHES_64 + ARCHES_32 + ARCHES_PPC + ARCHES_S390 + \
 QUERYFORMAT = '%{NAME}_|-%{EPOCH}_|-%{VERSION}_|-%{RELEASE}_|-%{ARCH}_|-%{REPOID}_|-%{INSTALLTIME}'
 
 # on some archs, the rpm _host_cpu macro doesn't match the pkg name arch
-ARCHMAP = {'powerpc64le' : 'ppc64le'}
+ARCHMAP = {'powerpc64le': 'ppc64le'}
+
 
 def get_osarch():
     '''

--- a/salt/utils/pkg/rpm.py
+++ b/salt/utils/pkg/rpm.py
@@ -36,6 +36,8 @@ ARCHES = ARCHES_64 + ARCHES_32 + ARCHES_PPC + ARCHES_S390 + \
 # EPOCHNUM can't be used until RHEL5 is EOL as it is not present
 QUERYFORMAT = '%{NAME}_|-%{EPOCH}_|-%{VERSION}_|-%{RELEASE}_|-%{ARCH}_|-%{REPOID}_|-%{INSTALLTIME}'
 
+# on some archs, the rpm _host_cpu macro doesn't match the pkg name arch
+ARCHMAP = {'powerpc64le' : 'ppc64le'}
 
 def get_osarch():
     '''
@@ -80,7 +82,7 @@ def resolve_name(name, arch, osarch=None):
     if osarch is None:
         osarch = get_osarch()
 
-    if not check_32(arch, osarch) and arch not in (osarch, 'noarch'):
+    if not check_32(arch, osarch) and arch not in (ARCHMAP.get(osarch, osarch), 'noarch'):
         name += '.{0}'.format(arch)
     return name
 


### PR DESCRIPTION
… name used in pkgs

### What does this PR do?
Allows the `rpm.py` utils file to map between the value from `rpm --eval "%{_host_cpu}"` which is used to determine the host architecture and the correct value used in the rpm package name. 

### What issues does this PR fix or reference?
#49672 

### Previous Behavior
The rpm.py util incorrectly expected packages to be called (e.g.) `iptables.powerpc64le` when infact they are called `iptables.ppc64le`.

### New Behavior
A new dict is used to allow mapping between the output of eval and the correct packaging name. When no entry is in the dict, behaviour is as before so this change only impacts users (currently) running on ppc64le systems.

### Tests written?

No

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
