### PR TITLE
Fix test opts in append, prepend states/file.py

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -4905,7 +4905,9 @@ def append(name,
     check_res, check_msg = _check_file(name)
     if not check_res:
         # Try to create the file
-        touch(name, makedirs=makedirs)
+        touch_ret = touch(name, makedirs=makedirs)
+        if __opts__['test']:
+            return touch_ret
         retry_res, retry_msg = _check_file(name)
         if not retry_res:
             return _error(ret, check_msg)
@@ -5186,7 +5188,9 @@ def prepend(name,
     check_res, check_msg = _check_file(name)
     if not check_res:
         # Try to create the file
-        touch(name, makedirs=makedirs)
+        touch_ret = touch(name, makedirs=makedirs)
+        if __opts__['test']:
+            return touch_ret
         retry_res, retry_msg = _check_file(name)
         if not retry_res:
             return _error(ret, check_msg)


### PR DESCRIPTION
### What does this PR do?
This PR fixes the test option when trying to append or prepend a file

### What issues does this PR fix or reference?
#49604 
### Previous Behavior

```
Result: False
Comment: /root/output.txt: file not found
```

### New Behavior

```
Result: None
Comment: File /root/output.txt is set to be created
```

### Tests written?

No

### Commits signed with GPG?

No