### PR TITLE
Isbm pkg resources crash

### DIFF
--- a/salt/modules/pip.py
+++ b/salt/modules/pip.py
@@ -79,7 +79,10 @@ from __future__ import absolute_import, print_function, unicode_literals
 # Import python libs
 import logging
 import os
-import pkg_resources
+try:
+    import pkg_resources
+except ImportError:
+    pkg_resources = None
 import re
 import shutil
 import sys
@@ -116,7 +119,12 @@ def __virtual__():
     entire filesystem.  If it's not installed in a conventional location, the
     user is required to provide the location of pip each time it is used.
     '''
-    return 'pip'
+    if pkg_resources is None:
+        ret = False, 'Package dependency "pkg_resource" is missing'
+    else:
+        ret = 'pip'
+
+    return ret
 
 
 def _clear_context(bin_env=None):

--- a/salt/states/pip_state.py
+++ b/salt/states/pip_state.py
@@ -23,7 +23,10 @@ requisite to a pkg.installed state for the package which provides pip
 from __future__ import absolute_import, print_function, unicode_literals
 import re
 import logging
-import pkg_resources
+try:
+    import pkg_resources
+except ImportError:
+    pkg_resources = None
 
 # Import salt libs
 import salt.utils.versions
@@ -71,9 +74,7 @@ def __virtual__():
     '''
     Only load if the pip module is available in __salt__
     '''
-    if 'pip.list' in __salt__:
-        return __virtualname__
-    return False
+    return 'pip.list' in __salt__ and __virtualname__ or False
 
 
 def _find_key(prefix, pip_list):


### PR DESCRIPTION
### What does this PR do?

Bugfix:
```
2018-08-13 09:02:25,748 [salt.loaded.ext.grains.cpuinfo:25  ][DEBUG   ][29825] Trying lscpu to get CPU socket count
2018-08-13 09:02:25,898 [salt.loader      :1469][DEBUG   ][30005] Failed to import module pip:
Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/salt/loader.py", line 1452, in _load_module
    mod = spec.loader.load_module()
  File "<frozen importlib._bootstrap_external>", line 399, in _check_name_wrapper
  File "<frozen importlib._bootstrap_external>", line 823, in load_module
  File "<frozen importlib._bootstrap_external>", line 682, in load_module
  File "<frozen importlib._bootstrap>", line 265, in _load_module_shim
  File "<frozen importlib._bootstrap>", line 684, in _load
  File "<frozen importlib._bootstrap>", line 665, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 678, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/usr/lib/python3.6/site-packages/salt/modules/pip.py", line 82, in <module>
    import pkg_resources
ModuleNotFoundError: No module named 'pkg_resources'
2018-08-13 09:02:26,061 [salt.utils.lazy  :100 ][DEBUG   ][29825] LazyLoaded config.merge
2018-08-13 09:02:26,062 [salt.utils.lazy  :100 ][DEBUG   ][29825] LazyLoaded mine.update
```