### PR TITLE
Remove all users from group when members list is empty.

### DIFF
--- a/salt/states/group.py
+++ b/salt/states/group.py
@@ -83,14 +83,13 @@ def _changes(name,
             ret['comment'] = 'Invalid gid'
             return ret
 
-    if members is not None:
-        if members:
-            # -- if new member list if different than the current
-            if set(lgrp['members']).symmetric_difference(members):
-                change['members'] = members
-        else:
-            if set(lgrp['members']).symmetric_difference(members):
-                change['delusers'] = set(lgrp['members'])
+    if members is not None and not members:
+        if set(lgrp['members']).symmetric_difference(members):
+            change['delusers'] = set(lgrp['members'])
+    elif members:
+        # if new member list if different than the current
+        if set(lgrp['members']).symmetric_difference(members):
+            change['members'] = members
 
     if addusers:
         users_2add = [user for user in addusers if user not in lgrp['members']]

--- a/salt/states/group.py
+++ b/salt/states/group.py
@@ -83,10 +83,14 @@ def _changes(name,
             ret['comment'] = 'Invalid gid'
             return ret
 
-    if members:
-        # -- if new member list if different than the current
-        if set(lgrp['members']).symmetric_difference(members):
-            change['members'] = members
+    if members is not None:
+        if members:
+            # -- if new member list if different than the current
+            if set(lgrp['members']).symmetric_difference(members):
+                change['members'] = members
+        else:
+            if set(lgrp['members']).symmetric_difference(members):
+                change['delusers'] = set(lgrp['members'])
 
     if addusers:
         users_2add = [user for user in addusers if user not in lgrp['members']]
@@ -165,7 +169,7 @@ def present(name,
            'result': True,
            'comment': 'Group {0} is present and up to date'.format(name)}
 
-    if members and (addusers or delusers):
+    if members is not None and (addusers is not None or delusers is not None):
         ret['result'] = None
         ret['comment'] = (
             'Error: Conflicting options "members" with "addusers" and/or'


### PR DESCRIPTION
### What does this PR do?

This patch allows an empty list to be supplied to the members argument for the ```group.present``` state.

### What issues does this PR fix or reference?

- #49744

### Previous Behavior

An empty list would be interpreted as a False-like value and cause no-op during group members check.

### New Behavior

An empty members list will invoke the remove_user behavior for all list members.

### Tests written?

No

### Commits signed with GPG?

Yes