### PR TITLE
salt/states/boto_route53.py: fix parsing the deets dictionary

### DIFF
--- a/salt/states/boto_route53.py
+++ b/salt/states/boto_route53.py
@@ -442,7 +442,7 @@ def hosted_zone_present(name, domain_name=None, private_zone=False, caller_ref=N
             create = True
         else:
             if private_zone:
-                for v, d in deets.get('VPCs', {}).items():
+                for d in deets.get('VPCs', {}):
                     if (d['VPCId'] == vpc_id
                             and d['VPCRegion'] == vpc_region):
                         create = False


### PR DESCRIPTION
In case of private hosted zones, the validation fails because the
data format is incompatible with the parsing code.

Example:
deets: {u'VPCs': [{u'VPCId': u'vpc-f2e7c094', u'VPCRegion':
u'eu-west-1'}], u'HostedZone': {u'ResourceRecord SetCount': u'2',
u'CallerReference': u'0beecc60-279a-4981-878d-663d3228c042', u'Config':
{u'PrivateZone': u'true'}, u'Id': u'/hostedzone/Z1ANNYV58T6IGH',
u'Name': u'foo.bar.'}}

Parsing the example without this patch results in:
  File "/usr/lib/python2.7/site-packages/salt/state.py", line 1905, in
call
    **cdata['kwargs'])
  File "/usr/lib/python2.7/site-packages/salt/loader.py", line 1830, in
wrapper
    return f(*args, **kwargs)
  File "/usr/lib/python2.7/site-packages/salt/states/boto_route53.py",
line 442, in hosted_zone_present
    for v, d in deets.get('VPCs', {}).items():
AttributeError: 'ListElement' object has no attribute 'items'

### What does this PR do?

Fix private hosted zone validation in boto_route53 state

### What issues does this PR fix or reference?

No related issues found when searching for "boto_route53"

### Previous Behavior

State run results in an `AttributeError: 'ListElement' object has no attribute 'items'`

### New Behavior

State run correctly detects the existence of the specified private hosted zone without generating errors

### Tests written?

No

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.