### PR TITLE
fixed link in documentation

### DIFF
--- a/salt/modules/pacman.py
+++ b/salt/modules/pacman.py
@@ -921,7 +921,7 @@ def owner(*paths):
     .. versionadded:: 2014.7.0
 
     Return the name of the package that owns the file. Multiple file paths can
-    be passed. Like :mod:`pkg.version <salt.modules.yumpkg.version`, if a
+    be passed. Like :mod:`pkg.version <salt.modules.yumpkg.version>`, if a
     single path is passed, a string will be returned, and if multiple paths are
     passed, a dictionary of file/package name pairs will be returned.
 

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -2774,7 +2774,7 @@ def owner(*paths):
     .. versionadded:: 2014.7.0
 
     Return the name of the package that owns the file. Multiple file paths can
-    be passed. Like :mod:`pkg.version <salt.modules.yumpkg.version`, if a
+    be passed. Like :mod:`pkg.version <salt.modules.yumpkg.version>`, if a
     single path is passed, a string will be returned, and if multiple paths are
     passed, a dictionary of file/package name pairs will be returned.
 


### PR DESCRIPTION
### What does this PR do?
The PR fixes 2 small documentation errors where a missing `>` caused a link to be not recognized by the documentation formatter(s).

### What issues does this PR fix or reference?
None

### Previous Behavior
Documentation for `pkg.owner` in both the `yumpkg` and `pacman` alternative show the stray text `<salt.modules.yumpkg.version`.

### New Behavior
The link is properly presented in the documentation for `pkg.ower`.

### Tests written?
No
I've verified all regular `sys.doc` output for this and found no other occurrences. Note that the search was against a regular CentOS 7.2 system and did not include the alternative packages.

### Commits signed with GPG?
No