### PR TITLE
add support for clonenum parameter

### DIFF
--- a/salt/templates/rh_ip/rh7_eth.jinja
+++ b/salt/templates/rh_ip/rh7_eth.jinja
@@ -18,6 +18,7 @@ DEVICE="{{name}}"
 {%endif%}{% if ipaddr %}IPADDR="{{ipaddr}}"
 {%endif%}{% if ipaddr_start %}IPADDR_START="{{ipaddr_start}}"
 {%endif%}{% if ipaddr_end %}IPADDR_END="{{ipaddr_end}}"
+{%endif%}{% if clonenum_start %}CLONENUM_START="{{clonenum_start}}"
 {%endif%}{% if netmask %}NETMASK="{{netmask}}"
 {%endif%}{% if prefix %}PREFIX="{{prefix}}"
 {%endif%}{% if ipaddrs %}{% for i in ipaddrs -%}


### PR DESCRIPTION
### What does this PR do?

It adds support for the `clonenum_start` parameter for RHEL7 based systems as documented in https://docs.saltstack.com/en/latest/ref/states/all/salt.states.network.html.

### What issues does this PR fix or reference?

https://github.com/saltstack/salt/issues/49751

### Tests written?

No

### Commits signed with GPG?

Yes