### PR TITLE
fix #49754 minion zmq connecting to master configured explicitly as IPv6 address or IPv6 only master

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -259,8 +259,8 @@ def prep_ip_port(opts):
     # Use given master IP if "ip_only" is set or if master_ip is an ipv6 address without
     # a port specified. The is_ipv6 check returns False if brackets are used in the IP
     # definition such as master: '[::1]:1234'.
-    if opts['master_uri_format'] == 'ip_only' or salt.utils.network.is_ipv6(opts['master']):
-        ret['master'] = str(ipaddress.ip_address(opts['master']))
+    if opts['master_uri_format'] == 'ip_only':
+        ret['master'] = ipaddress.ip_address(opts['master'])
     else:
         host, port = parse_host_port(opts['master'])
         ret = {'master': host}

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -27,6 +27,7 @@ from binascii import crc32
 # pylint: disable=import-error,no-name-in-module,redefined-builtin
 from salt.ext import six
 from salt._compat import ipaddress
+from salt.utils.network import parse_host_port
 from salt.ext.six.moves import range
 from salt.utils.zeromq import zmq, ZMQDefaultLoop, install_zmq, ZMQ_VERSION_INFO
 
@@ -243,27 +244,29 @@ def resolve_dns(opts, fallback=True):
 
 
 def prep_ip_port(opts):
+    '''
+    parse host:port values from opts['master'] and return valid:
+        master: ip address or hostname as a string
+        master_port: (optional) master returner port as integer
+
+    e.g.:
+      - master: 'localhost:1234' -> {'master': 'localhost', 'master_port': 1234}
+      - master: '127.0.0.1:1234' -> {'master': '127.0.0.1', 'master_port' :1234}
+      - master: '[::1]:1234' -> {'master': '::1', 'master_port': 1234}
+      - master: 'fe80::a00:27ff:fedc:ba98' -> {'master': 'fe80::a00:27ff:fedc:ba98'}
+    '''
     ret = {}
     # Use given master IP if "ip_only" is set or if master_ip is an ipv6 address without
     # a port specified. The is_ipv6 check returns False if brackets are used in the IP
     # definition such as master: '[::1]:1234'.
     if opts['master_uri_format'] == 'ip_only' or salt.utils.network.is_ipv6(opts['master']):
-        ret['master'] = opts['master']
+        ret['master'] = str(ipaddress.ip_address(opts['master']))
     else:
-        ip_port = opts['master'].rsplit(':', 1)
-        if len(ip_port) == 1:
-            # e.g. master: mysaltmaster
-            ret['master'] = ip_port[0]
-        else:
-            # e.g. master: localhost:1234
-            # e.g. master: 127.0.0.1:1234
-            # e.g. master: [::1]:1234
-            # Strip off brackets for ipv6 support
-            ret['master'] = ip_port[0].strip('[]')
+        host, port = parse_host_port(opts['master'])
+        ret = {'master': host}
+        if port:
+            ret.update({'master_port': port})
 
-            # Cast port back to an int! Otherwise a TypeError is thrown
-            # on some of the socket calls elsewhere in the minion and utils code.
-            ret['master_port'] = int(ip_port[1])
     return ret
 
 

--- a/salt/transport/zeromq.py
+++ b/salt/transport/zeromq.py
@@ -33,6 +33,7 @@ import salt.transport.server
 import salt.transport.mixins.auth
 from salt.ext import six
 from salt.exceptions import SaltReqTimeoutError
+from salt._compat import ipaddress
 
 from salt.utils.zeromq import zmq, ZMQDefaultLoop, install_zmq, ZMQ_VERSION_INFO, LIBZMQ_VERSION_INFO
 import zmq.error
@@ -71,33 +72,38 @@ def _get_master_uri(master_ip,
     '''
     Return the ZeroMQ URI to connect the Minion to the Master.
     It supports different source IP / port, given the ZeroMQ syntax:
-
     // Connecting using a IP address and bind to an IP address
     rc = zmq_connect(socket, "tcp://192.168.1.17:5555;192.168.1.1:5555"); assert (rc == 0);
-
     Source: http://api.zeromq.org/4-1:zmq-tcp
     '''
-    if LIBZMQ_VERSION_INFO >= (4, 1, 6) and ZMQ_VERSION_INFO >= (16, 0, 1):
-        # The source:port syntax for ZeroMQ has been added in libzmq 4.1.6
-        # which is included in the pyzmq wheels starting with 16.0.1.
-        if source_ip or source_port:
-            if source_ip and source_port:
-                return 'tcp://{source_ip}:{source_port};{master_ip}:{master_port}'.format(
-                        source_ip=source_ip, source_port=source_port,
-                        master_ip=master_ip, master_port=master_port)
-            elif source_ip and not source_port:
-                return 'tcp://{source_ip}:0;{master_ip}:{master_port}'.format(
-                        source_ip=source_ip,
-                        master_ip=master_ip, master_port=master_port)
-            elif not source_ip and source_port:
-                return 'tcp://0.0.0.0:{source_port};{master_ip}:{master_port}'.format(
-                        source_port=source_port,
-                        master_ip=master_ip, master_port=master_port)
+    from salt.utils.zeromq import ip_bracket
+
+    master_uri = 'tcp://{master_ip}:{master_port}'.format(
+                  master_ip=ip_bracket(master_ip), master_port=master_port)
+
     if source_ip or source_port:
-        log.warning('Unable to connect to the Master using a specific source IP / port')
-        log.warning('Consider upgrading to pyzmq >= 16.0.1 and libzmq >= 4.1.6')
-    return 'tcp://{master_ip}:{master_port}'.format(
-                master_ip=master_ip, master_port=master_port)
+        if LIBZMQ_VERSION_INFO >= (4, 1, 6) and ZMQ_VERSION_INFO >= (16, 0, 1):
+            # The source:port syntax for ZeroMQ has been added in libzmq 4.1.6
+            # which is included in the pyzmq wheels starting with 16.0.1.
+            if source_ip and source_port:
+                master_uri = 'tcp://{source_ip}:{source_port};{master_ip}:{master_port}'.format(
+                             source_ip=ip_bracket(source_ip), source_port=source_port,
+                             master_ip=ip_bracket(master_ip), master_port=master_port)
+            elif source_ip and not source_port:
+                master_uri = 'tcp://{source_ip}:0;{master_ip}:{master_port}'.format(
+                             source_ip=ip_bracket(source_ip),
+                             master_ip=ip_bracket(master_ip), master_port=master_port)
+            elif source_port and not source_ip:
+                ip_any = '0.0.0.0' if ipaddress.ip_address(master_ip).version == 4 else ip_bracket('::')
+                master_uri = 'tcp://{ip_any}:{source_port};{master_ip}:{master_port}'.format(
+                             ip_any=ip_any, source_port=source_port,
+                             master_ip=ip_bracket(master_ip), master_port=master_port)
+        else:
+            log.warning('Unable to connect to the Master using a specific source IP / port')
+            log.warning('Consider upgrading to pyzmq >= 16.0.1 and libzmq >= 4.1.6')
+            log.warning('Specific source IP / port for connecting to master returner port: configuraion ignored')
+
+    return master_uri
 
 
 class AsyncZeroMQReqChannel(salt.transport.client.ReqChannel):

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -1934,7 +1934,7 @@ def parse_host_port(host_port):
             else:
                 if len(_s_) > 1:
                     raise ValueError('found ambiguous "{}" port in "{}"'.format(_s_, host_port))
-        host = ipaddress.ipv6IPv6Address(host)
+        host = ipaddress.IPv6Address(host)
     else:
         if _s_.count(":") == 1:
             host, _hostport_separator_, port = _s_.partition(":")

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -1905,7 +1905,11 @@ def dns_check(addr, port, safe=False, ipv6=None):
 
 
 def parse_host_port(host_port):
+<<<<<<< HEAD
     """
+=======
+    '''
+>>>>>>> fix minion zmq connecting to master configured as IPv6 address
     Takes a string argument specifying host or host:port.
 
     Returns a (hostname, port) or (ip_address, port) tuple. If no port is given,
@@ -1920,6 +1924,7 @@ def parse_host_port(host_port):
       - 1234::5
       - 10.11.12.13:4567
       - 10.11.12.13
+<<<<<<< HEAD
     """
     host, port = None, None  # default
 
@@ -1929,11 +1934,21 @@ def parse_host_port(host_port):
             host, _s_ = _s_.lstrip("[]").rsplit("]", 1)
             if _s_[0] == ":":
                 port = int(_s_.lstrip(":"))
+=======
+    '''
+    _s_ = host_port[:]
+    if _s_[0] == '[':
+        if ']' in host_port[0]:
+            host, _s_ = _s_.lstrip('[]').rsplit(']', 1)
+            if _s_[0] == ':':
+                port = int(_s_.lstrip(':'))
+>>>>>>> fix minion zmq connecting to master configured as IPv6 address
             else:
                 if len(_s_) > 1:
                     raise ValueError('found ambiguous "{}" port in "{}"'.format(_s_, host_port))
         host = ipaddress.ipv6IPv6Address(host)
     else:
+<<<<<<< HEAD
         if _s_.count(":") == 1:
             host, _hostport_separator_, port = _s_.parttion(":")
             if port:
@@ -1944,5 +1959,14 @@ def parse_host_port(host_port):
             host = ipaddress.ip_address(host)
         except ValueError:
             log.debug('"%s" Not an IP address? Assuming it is a hostname.', host)
+=======
+        if _s_.count(':') == 1:
+            host, port = _s_.split(':')
+            port = int(port)
+        else:
+            raise ValueError('too many ":" separators in host:port "{}"'.format(host_port))
+        if ipaddress.is_ip(host):
+            host = ipaddress.ip_address(host)
+>>>>>>> fix minion zmq connecting to master configured as IPv6 address
 
     return host, port

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -220,8 +220,13 @@ def get_fqhostname():
     """
     Returns the fully qualified hostname
     """
+<<<<<<< HEAD
     fqdn = []
     fqdn.append(socket.getfqdn())
+=======
+    l = []
+    l.append(socket.getfqdn())
+>>>>>>> fix parse_host_port() parse error on hostname only arg
 
     # try socket.getaddrinfo
     try:

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -1877,7 +1877,7 @@ def dns_check(addr, port, safe=False, ipv6=None):
 
                 try:
                     s = socket.socket(h[0], socket.SOCK_STREAM)
-                    s.connect(candidate_addr, port)
+                    s.connect((candidate_addr, port))
                     s.close()
 
                     resolved = candidate_addr

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -1883,7 +1883,7 @@ def dns_check(addr, port, safe=False, ipv6=None):
                 except socket.error:
                     pass
             if not resolved:
-                if len(candidates) > 0:
+                if candidates:
                     resolved = candidates[0]
                 else:
                     error = True

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -1940,7 +1940,9 @@ def parse_host_port(host_port):
                 port = int(port)
         if port and ":" in port:
             raise ValueError('too many ":" separators in host:port "{}"'.format(host_port))
-        if is_ip(host):
+        try:
             host = ipaddress.ip_address(host)
+        except ValueError:
+            log.debug('"%s" Not an IP address? Assuming it is a hostname.' % host)
 
     return host, port

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -1943,15 +1943,15 @@ def parse_host_port(host_port):
             host, _hostport_separator_, port = _s_.parttion(":")
             if port:
                 port = int(port)
-        if port and ":" in port:
-            raise ValueError('too many ":" separators in host:port "{}"'.format(host_port))
-        try:
-            host_ip = ipaddress.ip_address(host)
-            host = host_ip
-        except ValueError:
-            log.debug('"%s" Not an IP address? Assuming it is a hostname.', host)
-        except TypeError as _e_:
-            log.error('"%s" generated a TypeError exception', host)
-            raise _e_
+            if port and ":" in port:
+                raise ValueError('too many ":" separators in host:port "{}"'.format(host_port))
+    try:
+        host_ip = ipaddress.ip_address(host)
+        host = host_ip
+    except ValueError:
+        log.debug('"%s" Not an IP address? Assuming it is a hostname.', host)
+    except TypeError as _e_:
+        log.error('"%s" generated a TypeError exception', host)
+        raise _e_
 
     return host, port

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -1951,7 +1951,7 @@ def parse_host_port(host_port):
         except ValueError:
             log.debug('"%s" Not an IP address? Assuming it is a hostname.', host)
         except TypeError as _e_:
-            log.warn('"%s" generated a TypeError exception', host)
+            log.error('"%s" generated a TypeError exception', host)
             raise _e_
 
     return host, port

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -220,13 +220,8 @@ def get_fqhostname():
     """
     Returns the fully qualified hostname
     """
-<<<<<<< HEAD
     fqdn = []
     fqdn.append(socket.getfqdn())
-=======
-    l = []
-    l.append(socket.getfqdn())
->>>>>>> fix parse_host_port() parse error on hostname only arg
 
     # try socket.getaddrinfo
     try:

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -1905,11 +1905,7 @@ def dns_check(addr, port, safe=False, ipv6=None):
 
 
 def parse_host_port(host_port):
-<<<<<<< HEAD
     """
-=======
-    '''
->>>>>>> fix minion zmq connecting to master configured as IPv6 address
     Takes a string argument specifying host or host:port.
 
     Returns a (hostname, port) or (ip_address, port) tuple. If no port is given,
@@ -1924,7 +1920,6 @@ def parse_host_port(host_port):
       - 1234::5
       - 10.11.12.13:4567
       - 10.11.12.13
-<<<<<<< HEAD
     """
     host, port = None, None  # default
 
@@ -1934,21 +1929,11 @@ def parse_host_port(host_port):
             host, _s_ = _s_.lstrip("[]").rsplit("]", 1)
             if _s_[0] == ":":
                 port = int(_s_.lstrip(":"))
-=======
-    '''
-    _s_ = host_port[:]
-    if _s_[0] == '[':
-        if ']' in host_port[0]:
-            host, _s_ = _s_.lstrip('[]').rsplit(']', 1)
-            if _s_[0] == ':':
-                port = int(_s_.lstrip(':'))
->>>>>>> fix minion zmq connecting to master configured as IPv6 address
             else:
                 if len(_s_) > 1:
                     raise ValueError('found ambiguous "{}" port in "{}"'.format(_s_, host_port))
         host = ipaddress.ipv6IPv6Address(host)
     else:
-<<<<<<< HEAD
         if _s_.count(":") == 1:
             host, _hostport_separator_, port = _s_.parttion(":")
             if port:
@@ -1959,14 +1944,5 @@ def parse_host_port(host_port):
             host = ipaddress.ip_address(host)
         except ValueError:
             log.debug('"%s" Not an IP address? Assuming it is a hostname.', host)
-=======
-        if _s_.count(':') == 1:
-            host, port = _s_.split(':')
-            port = int(port)
-        else:
-            raise ValueError('too many ":" separators in host:port "{}"'.format(host_port))
-        if ipaddress.is_ip(host):
-            host = ipaddress.ip_address(host)
->>>>>>> fix minion zmq connecting to master configured as IPv6 address
 
     return host, port

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -60,8 +60,10 @@ except (ImportError, OSError, AttributeError, TypeError):
 def sanitize_host(host):
     """
     Sanitize host string.
+    https://tools.ietf.org/html/rfc1123#section-2.1
     """
-    return "".join([c for c in host[0:255] if c in (ascii_letters + digits + ".-")])
+    RFC952_characters = ascii_letters + digits + ".-"
+    return "".join([c for c in host[0:255] if c in RFC952_characters])
 
 
 def isportopen(host, port):

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -1940,11 +1940,14 @@ def parse_host_port(host_port):
         host = ipaddress.ipv6IPv6Address(host)
     else:
         if _s_.count(":") == 1:
-            host, _hostport_separator_, port = _s_.parttion(":")
-            if port:
+            host, _hostport_separator_, port = _s_.partition(":")
+            try:
                 port = int(port)
-            if port and ":" in port:
-                raise ValueError('too many ":" separators in host:port "{}"'.format(host_port))
+            except ValueError as _e_:
+                log.error('host_port "%s" port value "%s" is not an integer.', host_port, port)
+                raise _e_
+        else:
+            host = _s_
     try:
         host_ip = ipaddress.ip_address(host)
         host = host_ip

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -1913,7 +1913,7 @@ def parse_host_port(host_port):
     Takes a string argument specifying host or host:port.
 
     Returns a (hostname, port) or (ip_address, port) tuple. If no port is given,
-    the second element of the returned tuple will be None.
+    the second (port) element of the returned tuple will be None.
 
     host:port argument, for example, is accepted in the forms of:
       - hostname

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -1912,7 +1912,7 @@ def parse_host_port(host_port):
     """
     Takes a string argument specifying host or host:port.
 
-    Returns a (hostname, port) or (ipaddress.ip_address, port) tuple. If no port is given,
+    Returns a (hostname, port) or (ip_address, port) tuple. If no port is given,
     the second (port) element of the returned tuple will be None.
 
     host:port argument, for example, is accepted in the forms of:

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -1929,7 +1929,7 @@ def parse_host_port(host_port):
 
     _s_ = host_port[:]
     if _s_[0] == "[":
-        if "]" in host_port[0]:
+        if "]" in host_port:
             host, _s_ = _s_.lstrip("[").rsplit("]", 1)
             host = ipaddress.IPv6Address(host)
             if _s_[0] == ":":
@@ -1948,13 +1948,10 @@ def parse_host_port(host_port):
         else:
             host = _s_
     try:
-        host_ip = ipaddress.ip_address(host)
-        host = host_ip
+        if not isinstance(host, ipaddress._BaseAddress):
+            host_ip = ipaddress.ip_address(host)
+            host = host_ip
     except ValueError:
         log.debug('"%s" Not an IP address? Assuming it is a hostname.', host)
-# Todo: uncomment and handle
-#    except TypeError as _e_:
-#        log.error('"%s" generated a TypeError exception', host)
-#        raise _e_
 
     return host, port

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -1953,5 +1953,8 @@ def parse_host_port(host_port):
             host = host_ip
     except ValueError:
         log.debug('"%s" Not an IP address? Assuming it is a hostname.', host)
+        if host != sanitize_host(host):
+            log.error('bad hostname: "%s"', host)
+            raise ValueError('bad hostname: "{}"'.format(host))
 
     return host, port

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -56,10 +56,10 @@ except (ImportError, OSError, AttributeError, TypeError):
 
 
 def sanitize_host(host):
-    """
+    '''
     Sanitize host string.
     https://tools.ietf.org/html/rfc1123#section-2.1
-    """
+    '''
     RFC952_characters = ascii_letters + digits + ".-"
     return "".join([c for c in host[0:255] if c in RFC952_characters])
 

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
-"""
+'''
 Define some generic socket functions for network modules
-"""
+'''
 
 # Import python libs
 from __future__ import absolute_import, unicode_literals, print_function
@@ -19,7 +19,6 @@ from string import ascii_letters, digits
 # Import 3rd-party libs
 from salt.ext import six
 from salt.ext.six.moves import range  # pylint: disable=import-error,redefined-builtin
-
 # Attempt to import wmi
 try:
     import wmi
@@ -48,7 +47,6 @@ log = logging.getLogger(__name__)
 try:
     import ctypes
     import ctypes.util
-
     libc = ctypes.cdll.LoadLibrary(ctypes.util.find_library("c"))
     res_init = libc.__res_init
 except (ImportError, OSError, AttributeError, TypeError):
@@ -67,9 +65,9 @@ def sanitize_host(host):
 
 
 def isportopen(host, port):
-    """
+    '''
     Return status of a port
-    """
+    '''
 
     if not 1 <= int(port) <= 65535:
         return False
@@ -81,14 +79,13 @@ def isportopen(host, port):
 
 
 def host_to_ips(host):
-    """
+    '''
     Returns a list of IP addresses of a given hostname or None if not found.
-    """
+    '''
     ips = []
     try:
         for family, socktype, proto, canonname, sockaddr in socket.getaddrinfo(
-            host, 0, socket.AF_UNSPEC, socket.SOCK_STREAM
-        ):
+                host, 0, socket.AF_UNSPEC, socket.SOCK_STREAM):
             if family == socket.AF_INET:
                 ip, port = sockaddr
             elif family == socket.AF_INET6:
@@ -102,34 +99,24 @@ def host_to_ips(host):
 
 
 def _generate_minion_id():
-    """
+    '''
     Get list of possible host names and convention names.
 
     :return:
-    """
+    '''
     # There are three types of hostnames:
     # 1. Network names. How host is accessed from the network.
     # 2. Host aliases. They might be not available in all the network or only locally (/etc/hosts)
     # 3. Convention names, an internal nodename.
 
     class DistinctList(list):
-        """
+        '''
         List, which allows one to append only distinct objects.
         Needs to work on Python 2.6, because of collections.OrderedDict only since 2.7 version.
         Override 'filter()' for custom filtering.
-        """
-
-        localhost_matchers = [
-            r"localhost.*",
-            r"ip6-.*",
-            r"127[.]\d",
-            r"0\.0\.0\.0",
-            r"::1.*",
-            r"ipv6-.*",
-            r"fe00::.*",
-            r"fe02::.*",
-            r"1.0.0.*.ip6.arpa",
-        ]
+        '''
+        localhost_matchers = [r'localhost.*', r'ip6-.*', r'127[.]\d', r'0\.0\.0\.0',
+                              r'::1.*', r'ipv6-.*', r'fe00::.*', r'fe02::.*', r'1.0.0.*.ip6.arpa']
 
         def append(self, p_object):
             if p_object and p_object not in self and not self.filter(p_object):
@@ -142,7 +129,7 @@ def _generate_minion_id():
             return self
 
         def filter(self, element):
-            "Returns True if element needs to be filtered"
+            'Returns True if element needs to be filtered'
             for rgx in self.localhost_matchers:
                 if re.match(rgx, element):
                     return True
@@ -153,62 +140,51 @@ def _generate_minion_id():
     hosts = DistinctList().append(socket.getfqdn()).append(platform.node()).append(socket.gethostname())
     if not hosts:
         try:
-            for a_nfo in socket.getaddrinfo(
-                hosts.first() or "localhost",
-                None,
-                socket.AF_INET,
-                socket.SOCK_RAW,
-                socket.IPPROTO_IP,
-                socket.AI_CANONNAME,
-            ):
+            for a_nfo in socket.getaddrinfo(hosts.first() or 'localhost', None, socket.AF_INET,
+                                            socket.SOCK_RAW, socket.IPPROTO_IP, socket.AI_CANONNAME):
                 if len(a_nfo) > 3:
                     hosts.append(a_nfo[3])
         except socket.gaierror:
-            log.warning(
-                "Cannot resolve address {addr} info via socket: {message}".format(
-                    addr=hosts.first() or "localhost (N/A)", message=socket.gaierror
-                )
+            log.warning('Cannot resolve address {addr} info via socket: {message}'.format(
+                addr=hosts.first() or 'localhost (N/A)', message=socket.gaierror)
             )
     # Universal method for everywhere (Linux, Slowlaris, Windows etc)
-    for f_name in (
-        "/etc/hostname",
-        "/etc/nodename",
-        "/etc/hosts",
-        r"{win}\system32\drivers\etc\hosts".format(win=os.getenv("WINDIR")),
-    ):
+    for f_name in ('/etc/hostname', '/etc/nodename', '/etc/hosts',
+                   r'{win}\system32\drivers\etc\hosts'.format(win=os.getenv('WINDIR'))):
         try:
             with salt.utils.files.fopen(f_name) as f_hdl:
                 for line in f_hdl:
                     line = salt.utils.stringutils.to_unicode(line)
-                    hst = line.strip().split("#")[0].strip().split()
+                    hst = line.strip().split('#')[0].strip().split()
                     if hst:
-                        if hst[0][:4] in ("127.", "::1") or len(hst) == 1:
+                        if hst[0][:4] in ('127.', '::1') or len(hst) == 1:
                             hosts.extend(hst)
         except IOError:
             pass
 
     # include public and private ipaddresses
-    return hosts.extend([addr for addr in ip_addrs() if not ipaddress.ip_address(addr).is_loopback])
+    return hosts.extend([addr for addr in ip_addrs()
+                         if not ipaddress.ip_address(addr).is_loopback])
 
 
 def generate_minion_id():
-    """
+    '''
     Return only first element of the hostname from all possible list.
 
     :return:
-    """
+    '''
     try:
         ret = salt.utils.stringutils.to_unicode(_generate_minion_id().first())
     except TypeError:
         ret = None
-    return ret or "localhost"
+    return ret or 'localhost'
 
 
 def get_socket(addr, type=socket.SOCK_STREAM, proto=0):
-    """
+    '''
     Return a socket object for the addr
     IP-version agnostic
-    """
+    '''
 
     version = ipaddress.ip_address(addr).version
     if version == 4:
@@ -219,48 +195,48 @@ def get_socket(addr, type=socket.SOCK_STREAM, proto=0):
 
 
 def get_fqhostname():
-    """
+    '''
     Returns the fully qualified hostname
-    """
-    fqdn = []
-    fqdn.append(socket.getfqdn())
+    '''
+    l = []
+    l.append(socket.getfqdn())
 
     # try socket.getaddrinfo
     try:
         addrinfo = socket.getaddrinfo(
-            socket.gethostname(), 0, socket.AF_UNSPEC, socket.SOCK_STREAM, socket.SOL_TCP, socket.AI_CANONNAME
+            socket.gethostname(), 0, socket.AF_UNSPEC, socket.SOCK_STREAM,
+            socket.SOL_TCP, socket.AI_CANONNAME
         )
         for info in addrinfo:
             # info struct [family, socktype, proto, canonname, sockaddr]
             if len(info) >= 4:
-                fqdn.append(info[3])
+                l.append(info[3])
     except socket.gaierror:
         pass
 
-    return fqdn and fqdn[0] or None
+    return l and l[0] or None
 
 
 def ip_to_host(ip):
-    """
+    '''
     Returns the hostname of a given IP
-    """
+    '''
     try:
         hostname, aliaslist, ipaddrlist = socket.gethostbyaddr(ip)
     except Exception as exc:
-        log.debug("salt.utils.network.ip_to_host(%r) failed: %s", ip, exc)
+        log.debug('salt.utils.network.ip_to_host(%r) failed: %s', ip, exc)
         hostname = None
     return hostname
-
 
 # pylint: enable=C0103
 
 
 def is_reachable_host(entity_name):
-    """
+    '''
     Returns a bool telling if the entity name is a reachable host (IPv4/IPv6/FQDN/etc).
     :param hostname:
     :return:
-    """
+    '''
     try:
         assert type(socket.getaddrinfo(entity_name, 0, 0, 0, 0)) == list
         ret = True
@@ -271,16 +247,16 @@ def is_reachable_host(entity_name):
 
 
 def is_ip(ip):
-    """
+    '''
     Returns a bool telling if the passed IP is a valid IPv4 or IPv6 address.
-    """
+    '''
     return is_ipv4(ip) or is_ipv6(ip)
 
 
 def is_ipv4(ip):
-    """
+    '''
     Returns a bool telling if the value passed to it was a valid IPv4 address
-    """
+    '''
     try:
         return ipaddress.ip_address(ip).version == 4
     except ValueError:
@@ -288,9 +264,9 @@ def is_ipv4(ip):
 
 
 def is_ipv6(ip):
-    """
+    '''
     Returns a bool telling if the value passed to it was a valid IPv6 address
-    """
+    '''
     try:
         return ipaddress.ip_address(ip).version == 6
     except ValueError:
@@ -298,37 +274,37 @@ def is_ipv6(ip):
 
 
 def is_subnet(cidr):
-    """
+    '''
     Returns a bool telling if the passed string is an IPv4 or IPv6 subnet
-    """
+    '''
     return is_ipv4_subnet(cidr) or is_ipv6_subnet(cidr)
 
 
 def is_ipv4_subnet(cidr):
-    """
+    '''
     Returns a bool telling if the passed string is an IPv4 subnet
-    """
+    '''
     try:
-        return "/" in cidr and bool(ipaddress.IPv4Network(cidr))
+        return '/' in cidr and bool(ipaddress.IPv4Network(cidr))
     except Exception:
         return False
 
 
 def is_ipv6_subnet(cidr):
-    """
+    '''
     Returns a bool telling if the passed string is an IPv6 subnet
-    """
+    '''
     try:
-        return "/" in cidr and bool(ipaddress.IPv6Network(cidr))
+        return '/' in cidr and bool(ipaddress.IPv6Network(cidr))
     except Exception:
         return False
 
 
-@jinja_filter("is_ip")
+@jinja_filter('is_ip')
 def is_ip_filter(ip, options=None):
-    """
+    '''
     Returns a bool telling if the passed IP is a valid IPv4 or IPv6 address.
-    """
+    '''
     return is_ipv4_filter(ip, options=options) or is_ipv6_filter(ip, options=options)
 
 
@@ -370,27 +346,27 @@ def _ip_options(ip_obj, version, options=None):
 
     # will process and IP options
     options_fun_map = {
-        "global": _ip_options_global,
-        "link-local": _ip_options_link_local,
-        "linklocal": _ip_options_link_local,
-        "ll": _ip_options_link_local,
-        "link_local": _ip_options_link_local,
-        "loopback": _ip_options_loopback,
-        "lo": _ip_options_loopback,
-        "multicast": _ip_options_multicast,
-        "private": _ip_options_private,
-        "public": _ip_options_global,
-        "reserved": _ip_options_reserved,
-        "site-local": _ip_options_site_local,
-        "sl": _ip_options_site_local,
-        "site_local": _ip_options_site_local,
-        "unspecified": _ip_options_unspecified,
+        'global': _ip_options_global,
+        'link-local': _ip_options_link_local,
+        'linklocal': _ip_options_link_local,
+        'll': _ip_options_link_local,
+        'link_local': _ip_options_link_local,
+        'loopback': _ip_options_loopback,
+        'lo': _ip_options_loopback,
+        'multicast': _ip_options_multicast,
+        'private': _ip_options_private,
+        'public': _ip_options_global,
+        'reserved': _ip_options_reserved,
+        'site-local': _ip_options_site_local,
+        'sl': _ip_options_site_local,
+        'site_local': _ip_options_site_local,
+        'unspecified': _ip_options_unspecified
     }
 
     if not options:
         return six.text_type(ip_obj)  # IP version already checked
 
-    options_list = [option.strip() for option in options.split(",")]
+    options_list = [option.strip() for option in options.split(',')]
 
     for option, fun in options_fun_map.items():
         if option in options_list:
@@ -427,9 +403,9 @@ def _is_ipv(ip, version, options=None):
     return _ip_options(ip_obj, version, options=options)
 
 
-@jinja_filter("is_ipv4")
+@jinja_filter('is_ipv4')
 def is_ipv4_filter(ip, options=None):
-    """
+    '''
     Returns a bool telling if the value passed to it was a valid IPv4 address.
 
     ip
@@ -440,14 +416,14 @@ def is_ipv4_filter(ip, options=None):
 
     options
         CSV of options regarding the nature of the IP address. E.g.: loopback, multicast, private etc.
-    """
+    '''
     _is_ipv4 = _is_ipv(ip, 4, options=options)
     return isinstance(_is_ipv4, six.string_types)
 
 
-@jinja_filter("is_ipv6")
+@jinja_filter('is_ipv6')
 def is_ipv6_filter(ip, options=None):
-    """
+    '''
     Returns a bool telling if the value passed to it was a valid IPv6 address.
 
     ip
@@ -458,7 +434,7 @@ def is_ipv6_filter(ip, options=None):
 
     options
         CSV of options regarding the nature of the IP address. E.g.: loopback, multicast, private etc.
-    """
+    '''
     _is_ipv6 = _is_ipv(ip, 6, options=options)
     return isinstance(_is_ipv6, six.string_types)
 
@@ -481,27 +457,27 @@ def _ipv_filter(value, version, options=None):
     return None
 
 
-@jinja_filter("ipv4")
+@jinja_filter('ipv4')
 def ipv4(value, options=None):
-    """
+    '''
     Filters a list and returns IPv4 values only.
-    """
+    '''
     return _ipv_filter(value, 4, options=options)
 
 
-@jinja_filter("ipv6")
+@jinja_filter('ipv6')
 def ipv6(value, options=None):
-    """
+    '''
     Filters a list and returns IPv6 values only.
-    """
+    '''
     return _ipv_filter(value, 6, options=options)
 
 
-@jinja_filter("ipaddr")
+@jinja_filter('ipaddr')
 def ipaddr(value, options=None):
-    """
+    '''
     Filters and returns only valid IP objects.
-    """
+    '''
     ipv4_obj = ipv4(value, options=options)
     ipv6_obj = ipv6(value, options=options)
     if ipv4_obj is None or ipv6_obj is None:
@@ -529,11 +505,11 @@ def _filter_ipaddr(value, options, version=None):
     return ipaddr_filter_out
 
 
-@jinja_filter("ip_host")
+@jinja_filter('ip_host')
 def ip_host(value, options=None, version=None):
-    """
+    '''
     Returns the interfaces IP address, e.g.: 192.168.0.1/28.
-    """
+    '''
     ipaddr_filter_out = _filter_ipaddr(value, options=options, version=version)
     if not ipaddr_filter_out:
         return
@@ -543,206 +519,219 @@ def ip_host(value, options=None, version=None):
 
 
 def _network_hosts(ip_addr_entry):
-    return [six.text_type(host) for host in ipaddress.ip_network(ip_addr_entry, strict=False).hosts()]
+    return [
+        six.text_type(host)
+        for host in ipaddress.ip_network(ip_addr_entry, strict=False).hosts()
+    ]
 
 
-@jinja_filter("network_hosts")
+@jinja_filter('network_hosts')
 def network_hosts(value, options=None, version=None):
-    """
+    '''
     Return the list of hosts within a network.
 
     .. note::
 
         When running this command with a large IPv6 network, the command will
         take a long time to gather all of the hosts.
-    """
+    '''
     ipaddr_filter_out = _filter_ipaddr(value, options=options, version=version)
     if not ipaddr_filter_out:
         return
     if not isinstance(value, (list, tuple, types.GeneratorType)):
         return _network_hosts(ipaddr_filter_out[0])
-    return [_network_hosts(ip_a) for ip_a in ipaddr_filter_out]
+    return [
+        _network_hosts(ip_a)
+        for ip_a in ipaddr_filter_out
+    ]
 
 
 def _network_size(ip_addr_entry):
     return ipaddress.ip_network(ip_addr_entry, strict=False).num_addresses
 
 
-@jinja_filter("network_size")
+@jinja_filter('network_size')
 def network_size(value, options=None, version=None):
-    """
+    '''
     Get the size of a network.
-    """
+    '''
     ipaddr_filter_out = _filter_ipaddr(value, options=options, version=version)
     if not ipaddr_filter_out:
         return
     if not isinstance(value, (list, tuple, types.GeneratorType)):
         return _network_size(ipaddr_filter_out[0])
-    return [_network_size(ip_a) for ip_a in ipaddr_filter_out]
+    return [
+        _network_size(ip_a)
+        for ip_a in ipaddr_filter_out
+    ]
 
 
-def natural_ipv4_netmask(ip, fmt="prefixlen"):
-    """
+def natural_ipv4_netmask(ip, fmt='prefixlen'):
+    '''
     Returns the "natural" mask of an IPv4 address
-    """
+    '''
     bits = _ipv4_to_bits(ip)
 
-    if bits.startswith("11"):
-        mask = "24"
-    elif bits.startswith("1"):
-        mask = "16"
+    if bits.startswith('11'):
+        mask = '24'
+    elif bits.startswith('1'):
+        mask = '16'
     else:
-        mask = "8"
+        mask = '8'
 
-    if fmt == "netmask":
+    if fmt == 'netmask':
         return cidr_to_ipv4_netmask(mask)
     else:
-        return "/" + mask
+        return '/' + mask
 
 
 def rpad_ipv4_network(ip):
-    """
+    '''
     Returns an IP network address padded with zeros.
 
     Ex: '192.168.3' -> '192.168.3.0'
         '10.209' -> '10.209.0.0'
-    """
-    return ".".join(itertools.islice(itertools.chain(ip.split("."), "0000"), 0, 4))
+    '''
+    return '.'.join(itertools.islice(itertools.chain(ip.split('.'), '0000'), 0,
+                                     4))
 
 
 def cidr_to_ipv4_netmask(cidr_bits):
-    """
+    '''
     Returns an IPv4 netmask
-    """
+    '''
     try:
         cidr_bits = int(cidr_bits)
         if not 1 <= cidr_bits <= 32:
-            return ""
+            return ''
     except ValueError:
-        return ""
+        return ''
 
-    netmask = ""
+    netmask = ''
     for idx in range(4):
         if idx:
-            netmask += "."
+            netmask += '.'
         if cidr_bits >= 8:
-            netmask += "255"
+            netmask += '255'
             cidr_bits -= 8
         else:
-            netmask += "{0:d}".format(256 - (2 ** (8 - cidr_bits)))
+            netmask += '{0:d}'.format(256 - (2 ** (8 - cidr_bits)))
             cidr_bits = 0
     return netmask
 
 
 def _number_of_set_bits_to_ipv4_netmask(set_bits):  # pylint: disable=C0103
-    """
+    '''
     Returns an IPv4 netmask from the integer representation of that mask.
 
     Ex. 0xffffff00 -> '255.255.255.0'
-    """
+    '''
     return cidr_to_ipv4_netmask(_number_of_set_bits(set_bits))
 
 
 # pylint: disable=C0103
 def _number_of_set_bits(x):
-    """
+    '''
     Returns the number of bits that are set in a 32bit int
-    """
+    '''
     # Taken from http://stackoverflow.com/a/4912729. Many thanks!
     x -= (x >> 1) & 0x55555555
     x = ((x >> 2) & 0x33333333) + (x & 0x33333333)
-    x = ((x >> 4) + x) & 0x0F0F0F0F
+    x = ((x >> 4) + x) & 0x0f0f0f0f
     x += x >> 8
     x += x >> 16
-    return x & 0x0000003F
-
+    return x & 0x0000003f
 
 # pylint: enable=C0103
 
 
 def _interfaces_ip(out):
-    """
+    '''
     Uses ip to return a dictionary of interfaces with various information about
     each (up/down state, ip address, netmask, and hwaddr)
-    """
+    '''
     ret = dict()
 
     def parse_network(value, cols):
-        """
+        '''
         Return a tuple of ip, netmask, broadcast
         based on the current set of cols
-        """
+        '''
         brd = None
         scope = None
-        if "/" in value:  # we have a CIDR in this address
-            ip, cidr = value.split("/")  # pylint: disable=C0103
+        if '/' in value:  # we have a CIDR in this address
+            ip, cidr = value.split('/')  # pylint: disable=C0103
         else:
             ip = value  # pylint: disable=C0103
             cidr = 32
 
-        if type_ == "inet":
+        if type_ == 'inet':
             mask = cidr_to_ipv4_netmask(int(cidr))
-            if "brd" in cols:
-                brd = cols[cols.index("brd") + 1]
-        elif type_ == "inet6":
+            if 'brd' in cols:
+                brd = cols[cols.index('brd') + 1]
+        elif type_ == 'inet6':
             mask = cidr
-            if "scope" in cols:
-                scope = cols[cols.index("scope") + 1]
+            if 'scope' in cols:
+                scope = cols[cols.index('scope') + 1]
         return (ip, mask, brd, scope)
 
-    groups = re.compile("\r?\n\\d").split(out)
+    groups = re.compile('\r?\n\\d').split(out)
     for group in groups:
         iface = None
         data = dict()
 
         for line in group.splitlines():
-            if " " not in line:
+            if ' ' not in line:
                 continue
-            match = re.match(r"^\d*:\s+([\w.\-]+)(?:@)?([\w.\-]+)?:\s+<(.+)>", line)
+            match = re.match(r'^\d*:\s+([\w.\-]+)(?:@)?([\w.\-]+)?:\s+<(.+)>', line)
             if match:
                 iface, parent, attrs = match.groups()
-                if "UP" in attrs.split(","):
-                    data["up"] = True
+                if 'UP' in attrs.split(','):
+                    data['up'] = True
                 else:
-                    data["up"] = False
+                    data['up'] = False
                 if parent:
-                    data["parent"] = parent
+                    data['parent'] = parent
                 continue
 
             cols = line.split()
             if len(cols) >= 2:
                 type_, value = tuple(cols[0:2])
                 iflabel = cols[-1:][0]
-                if type_ in ("inet", "inet6"):
-                    if "secondary" not in cols:
+                if type_ in ('inet', 'inet6'):
+                    if 'secondary' not in cols:
                         ipaddr, netmask, broadcast, scope = parse_network(value, cols)
-                        if type_ == "inet":
-                            if "inet" not in data:
-                                data["inet"] = list()
+                        if type_ == 'inet':
+                            if 'inet' not in data:
+                                data['inet'] = list()
                             addr_obj = dict()
-                            addr_obj["address"] = ipaddr
-                            addr_obj["netmask"] = netmask
-                            addr_obj["broadcast"] = broadcast
-                            addr_obj["label"] = iflabel
-                            data["inet"].append(addr_obj)
-                        elif type_ == "inet6":
-                            if "inet6" not in data:
-                                data["inet6"] = list()
+                            addr_obj['address'] = ipaddr
+                            addr_obj['netmask'] = netmask
+                            addr_obj['broadcast'] = broadcast
+                            addr_obj['label'] = iflabel
+                            data['inet'].append(addr_obj)
+                        elif type_ == 'inet6':
+                            if 'inet6' not in data:
+                                data['inet6'] = list()
                             addr_obj = dict()
-                            addr_obj["address"] = ipaddr
-                            addr_obj["prefixlen"] = netmask
-                            addr_obj["scope"] = scope
-                            data["inet6"].append(addr_obj)
+                            addr_obj['address'] = ipaddr
+                            addr_obj['prefixlen'] = netmask
+                            addr_obj['scope'] = scope
+                            data['inet6'].append(addr_obj)
                     else:
-                        if "secondary" not in data:
-                            data["secondary"] = list()
+                        if 'secondary' not in data:
+                            data['secondary'] = list()
                         ip_, mask, brd, scp = parse_network(value, cols)
-                        data["secondary"].append(
-                            {"type": type_, "address": ip_, "netmask": mask, "broadcast": brd, "label": iflabel}
-                        )
+                        data['secondary'].append({
+                            'type': type_,
+                            'address': ip_,
+                            'netmask': mask,
+                            'broadcast': brd,
+                            'label': iflabel,
+                        })
                         del ip_, mask, brd, scp
-                elif type_.startswith("link"):
-                    data["hwaddr"] = value
+                elif type_.startswith('link'):
+                    data['hwaddr'] = value
         if iface:
             ret[iface] = data
             del iface, data
@@ -750,32 +739,30 @@ def _interfaces_ip(out):
 
 
 def _interfaces_ifconfig(out):
-    """
+    '''
     Uses ifconfig to return a dictionary of interfaces with various information
     about each (up/down state, ip address, netmask, and hwaddr)
-    """
+    '''
     ret = dict()
 
-    piface = re.compile(r"^([^\s:]+)")
-    pmac = re.compile(".*?(?:HWaddr|ether|address:|lladdr) ([0-9a-fA-F:]+)")
+    piface = re.compile(r'^([^\s:]+)')
+    pmac = re.compile('.*?(?:HWaddr|ether|address:|lladdr) ([0-9a-fA-F:]+)')
     if salt.utils.platform.is_sunos():
-        pip = re.compile(r".*?(?:inet\s+)([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)(.*)")
-        pip6 = re.compile(".*?(?:inet6 )([0-9a-fA-F:]+)")
-        pmask6 = re.compile(r".*?(?:inet6 [0-9a-fA-F:]+/(\d+)).*")
+        pip = re.compile(r'.*?(?:inet\s+)([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)(.*)')
+        pip6 = re.compile('.*?(?:inet6 )([0-9a-fA-F:]+)')
+        pmask6 = re.compile(r'.*?(?:inet6 [0-9a-fA-F:]+/(\d+)).*')
     else:
-        pip = re.compile(r".*?(?:inet addr:|inet [^\d]*)(.*?)\s")
-        pip6 = re.compile(".*?(?:inet6 addr: (.*?)/|inet6 )([0-9a-fA-F:]+)")
-        pmask6 = re.compile(
-            r".*?(?:inet6 addr: [0-9a-fA-F:]+/(\d+)|prefixlen (\d+))(?: Scope:([a-zA-Z]+)| scopeid (0x[0-9a-fA-F]))?"
-        )
-    pmask = re.compile(r".*?(?:Mask:|netmask )(?:((?:0x)?[0-9a-fA-F]{8})|([\d\.]+))")
-    pupdown = re.compile("UP")
-    pbcast = re.compile(r".*?(?:Bcast:|broadcast )([\d\.]+)")
+        pip = re.compile(r'.*?(?:inet addr:|inet [^\d]*)(.*?)\s')
+        pip6 = re.compile('.*?(?:inet6 addr: (.*?)/|inet6 )([0-9a-fA-F:]+)')
+        pmask6 = re.compile(r'.*?(?:inet6 addr: [0-9a-fA-F:]+/(\d+)|prefixlen (\d+))(?: Scope:([a-zA-Z]+)| scopeid (0x[0-9a-fA-F]))?')
+    pmask = re.compile(r'.*?(?:Mask:|netmask )(?:((?:0x)?[0-9a-fA-F]{8})|([\d\.]+))')
+    pupdown = re.compile('UP')
+    pbcast = re.compile(r'.*?(?:Bcast:|broadcast )([\d\.]+)')
 
-    groups = re.compile("\r?\n(?=\\S)").split(out)
+    groups = re.compile('\r?\n(?=\\S)').split(out)
     for group in groups:
         data = dict()
-        iface = ""
+        iface = ''
         updown = False
         for line in group.splitlines():
             miface = piface.match(line)
@@ -786,45 +773,48 @@ def _interfaces_ifconfig(out):
             if miface:
                 iface = miface.group(1)
             if mmac:
-                data["hwaddr"] = mmac.group(1)
+                data['hwaddr'] = mmac.group(1)
                 if salt.utils.platform.is_sunos():
                     expand_mac = []
-                    for chunk in data["hwaddr"].split(":"):
-                        expand_mac.append("0{0}".format(chunk) if len(chunk) < 2 else "{0}".format(chunk))
-                    data["hwaddr"] = ":".join(expand_mac)
+                    for chunk in data['hwaddr'].split(':'):
+                        expand_mac.append('0{0}'.format(chunk) if len(chunk) < 2 else '{0}'.format(chunk))
+                    data['hwaddr'] = ':'.join(expand_mac)
             if mip:
-                if "inet" not in data:
-                    data["inet"] = list()
+                if 'inet' not in data:
+                    data['inet'] = list()
                 addr_obj = dict()
-                addr_obj["address"] = mip.group(1)
+                addr_obj['address'] = mip.group(1)
                 mmask = pmask.match(line)
                 if mmask:
                     if mmask.group(1):
-                        mmask = _number_of_set_bits_to_ipv4_netmask(int(mmask.group(1), 16))
+                        mmask = _number_of_set_bits_to_ipv4_netmask(
+                            int(mmask.group(1), 16))
                     else:
                         mmask = mmask.group(2)
-                    addr_obj["netmask"] = mmask
+                    addr_obj['netmask'] = mmask
                 mbcast = pbcast.match(line)
                 if mbcast:
-                    addr_obj["broadcast"] = mbcast.group(1)
-                data["inet"].append(addr_obj)
+                    addr_obj['broadcast'] = mbcast.group(1)
+                data['inet'].append(addr_obj)
             if mupdown:
                 updown = True
             if mip6:
-                if "inet6" not in data:
-                    data["inet6"] = list()
+                if 'inet6' not in data:
+                    data['inet6'] = list()
                 addr_obj = dict()
-                addr_obj["address"] = mip6.group(1) or mip6.group(2)
+                addr_obj['address'] = mip6.group(1) or mip6.group(2)
                 mmask6 = pmask6.match(line)
                 if mmask6:
-                    addr_obj["prefixlen"] = mmask6.group(1) or mmask6.group(2)
+                    addr_obj['prefixlen'] = mmask6.group(1) or mmask6.group(2)
                     if not salt.utils.platform.is_sunos():
                         ipv6scope = mmask6.group(3) or mmask6.group(4)
-                        addr_obj["scope"] = ipv6scope.lower() if ipv6scope is not None else ipv6scope
+                        addr_obj['scope'] = ipv6scope.lower() if ipv6scope is not None else ipv6scope
                 # SunOS sometimes has ::/0 as inet6 addr when using addrconf
-                if not salt.utils.platform.is_sunos() or addr_obj["address"] != "::" and addr_obj["prefixlen"] != 0:
-                    data["inet6"].append(addr_obj)
-        data["up"] = updown
+                if not salt.utils.platform.is_sunos() \
+                        or addr_obj['address'] != '::' \
+                        and addr_obj['prefixlen'] != 0:
+                    data['inet6'].append(addr_obj)
+        data['up'] = updown
         if iface in ret:
             # SunOS optimization, where interfaces occur twice in 'ifconfig -a'
             # output with the same name: for ipv4 and then for ipv6 addr family.
@@ -834,10 +824,10 @@ def _interfaces_ifconfig(out):
             # merge items with higher priority for older values
             # after that merge the inet and inet6 sub items for both
             ret[iface] = dict(list(data.items()) + list(ret[iface].items()))
-            if "inet" in data:
-                ret[iface]["inet"].extend(x for x in data["inet"] if x not in ret[iface]["inet"])
-            if "inet6" in data:
-                ret[iface]["inet6"].extend(x for x in data["inet6"] if x not in ret[iface]["inet6"])
+            if 'inet' in data:
+                ret[iface]['inet'].extend(x for x in data['inet'] if x not in ret[iface]['inet'])
+            if 'inet6' in data:
+                ret[iface]['inet6'].extend(x for x in data['inet6'] if x not in ret[iface]['inet6'])
         else:
             ret[iface] = data
         del data
@@ -845,58 +835,58 @@ def _interfaces_ifconfig(out):
 
 
 def linux_interfaces():
-    """
+    '''
     Obtain interface information for *NIX/BSD variants
-    """
+    '''
     ifaces = dict()
-    ip_path = salt.utils.path.which("ip")
-    ifconfig_path = None if ip_path else salt.utils.path.which("ifconfig")
+    ip_path = salt.utils.path.which('ip')
+    ifconfig_path = None if ip_path else salt.utils.path.which('ifconfig')
     if ip_path:
         cmd1 = subprocess.Popen(
-            "{0} link show".format(ip_path),
+            '{0} link show'.format(ip_path),
             shell=True,
             close_fds=True,
             stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-        ).communicate()[0]
+            stderr=subprocess.STDOUT).communicate()[0]
         cmd2 = subprocess.Popen(
-            "{0} addr show".format(ip_path),
+            '{0} addr show'.format(ip_path),
             shell=True,
             close_fds=True,
             stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-        ).communicate()[0]
-        ifaces = _interfaces_ip(
-            "{0}\n{1}".format(salt.utils.stringutils.to_str(cmd1), salt.utils.stringutils.to_str(cmd2))
-        )
+            stderr=subprocess.STDOUT).communicate()[0]
+        ifaces = _interfaces_ip("{0}\n{1}".format(
+            salt.utils.stringutils.to_str(cmd1),
+            salt.utils.stringutils.to_str(cmd2)))
     elif ifconfig_path:
         cmd = subprocess.Popen(
-            "{0} -a".format(ifconfig_path), shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
-        ).communicate()[0]
+            '{0} -a'.format(ifconfig_path),
+            shell=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT).communicate()[0]
         ifaces = _interfaces_ifconfig(salt.utils.stringutils.to_str(cmd))
     return ifaces
 
 
 def _netbsd_interfaces_ifconfig(out):
-    """
+    '''
     Uses ifconfig to return a dictionary of interfaces with various information
     about each (up/down state, ip address, netmask, and hwaddr)
-    """
+    '''
     ret = dict()
 
-    piface = re.compile(r"^([^\s:]+)")
-    pmac = re.compile(".*?address: ([0-9a-f:]+)")
+    piface = re.compile(r'^([^\s:]+)')
+    pmac = re.compile('.*?address: ([0-9a-f:]+)')
 
-    pip = re.compile(r".*?inet [^\d]*(.*?)/([\d]*)\s")
-    pip6 = re.compile(r".*?inet6 ([0-9a-f:]+)%([a-zA-Z0-9]*)/([\d]*)\s")
+    pip = re.compile(r'.*?inet [^\d]*(.*?)/([\d]*)\s')
+    pip6 = re.compile(r'.*?inet6 ([0-9a-f:]+)%([a-zA-Z0-9]*)/([\d]*)\s')
 
-    pupdown = re.compile("UP")
-    pbcast = re.compile(r".*?broadcast ([\d\.]+)")
+    pupdown = re.compile('UP')
+    pbcast = re.compile(r'.*?broadcast ([\d\.]+)')
 
-    groups = re.compile("\r?\n(?=\\S)").split(out)
+    groups = re.compile('\r?\n(?=\\S)').split(out)
     for group in groups:
         data = dict()
-        iface = ""
+        iface = ''
         updown = False
         for line in group.splitlines():
             miface = piface.match(line)
@@ -907,152 +897,154 @@ def _netbsd_interfaces_ifconfig(out):
             if miface:
                 iface = miface.group(1)
             if mmac:
-                data["hwaddr"] = mmac.group(1)
+                data['hwaddr'] = mmac.group(1)
             if mip:
-                if "inet" not in data:
-                    data["inet"] = list()
+                if 'inet' not in data:
+                    data['inet'] = list()
                 addr_obj = dict()
-                addr_obj["address"] = mip.group(1)
+                addr_obj['address'] = mip.group(1)
                 mmask = mip.group(2)
                 if mip.group(2):
-                    addr_obj["netmask"] = cidr_to_ipv4_netmask(mip.group(2))
+                    addr_obj['netmask'] = cidr_to_ipv4_netmask(mip.group(2))
                 mbcast = pbcast.match(line)
                 if mbcast:
-                    addr_obj["broadcast"] = mbcast.group(1)
-                data["inet"].append(addr_obj)
+                    addr_obj['broadcast'] = mbcast.group(1)
+                data['inet'].append(addr_obj)
             if mupdown:
                 updown = True
             if mip6:
-                if "inet6" not in data:
-                    data["inet6"] = list()
+                if 'inet6' not in data:
+                    data['inet6'] = list()
                 addr_obj = dict()
-                addr_obj["address"] = mip6.group(1)
+                addr_obj['address'] = mip6.group(1)
                 mmask6 = mip6.group(3)
-                addr_obj["scope"] = mip6.group(2)
-                addr_obj["prefixlen"] = mip6.group(3)
-                data["inet6"].append(addr_obj)
-        data["up"] = updown
+                addr_obj['scope'] = mip6.group(2)
+                addr_obj['prefixlen'] = mip6.group(3)
+                data['inet6'].append(addr_obj)
+        data['up'] = updown
         ret[iface] = data
         del data
     return ret
 
 
 def netbsd_interfaces():
-    """
+    '''
     Obtain interface information for NetBSD >= 8 where the ifconfig
     output diverged from other BSD variants (Netmask is now part of the
     address)
-    """
+    '''
     # NetBSD versions prior to 8.0 can still use linux_interfaces()
-    if LooseVersion(os.uname()[2]) < LooseVersion("8.0"):
+    if LooseVersion(os.uname()[2]) < LooseVersion('8.0'):
         return linux_interfaces()
 
-    ifconfig_path = salt.utils.path.which("ifconfig")
+    ifconfig_path = salt.utils.path.which('ifconfig')
     cmd = subprocess.Popen(
-        "{0} -a".format(ifconfig_path), shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
-    ).communicate()[0]
+        '{0} -a'.format(ifconfig_path),
+        shell=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT).communicate()[0]
     return _netbsd_interfaces_ifconfig(salt.utils.stringutils.to_str(cmd))
 
 
 def _interfaces_ipconfig(out):
-    """
+    '''
     Returns a dictionary of interfaces with various information about each
     (up/down state, ip address, netmask, and hwaddr)
 
     NOTE: This is not used by any function and may be able to be removed in the
     future.
-    """
+    '''
     ifaces = dict()
     iface = None
-    adapter_iface_regex = re.compile(r"adapter (\S.+):$")
+    adapter_iface_regex = re.compile(r'adapter (\S.+):$')
 
     for line in out.splitlines():
         if not line:
             continue
         # TODO what does Windows call Infiniband and 10/40gige adapters
-        if line.startswith("Ethernet"):
+        if line.startswith('Ethernet'):
             iface = ifaces[adapter_iface_regex.search(line).group(1)]
-            iface["up"] = True
+            iface['up'] = True
             addr = None
             continue
         if iface:
-            key, val = line.split(",", 1)
-            key = key.strip(" .")
+            key, val = line.split(',', 1)
+            key = key.strip(' .')
             val = val.strip()
-            if addr and key == "Subnet Mask":
-                addr["netmask"] = val
-            elif key in ("IP Address", "IPv4 Address"):
-                if "inet" not in iface:
-                    iface["inet"] = list()
-                addr = {
-                    "address": val.rstrip("(Preferred)"),
-                    "netmask": None,
-                    "broadcast": None,
-                }  # TODO find the broadcast
-                iface["inet"].append(addr)
-            elif "IPv6 Address" in key:
-                if "inet6" not in iface:
-                    iface["inet"] = list()
+            if addr and key == 'Subnet Mask':
+                addr['netmask'] = val
+            elif key in ('IP Address', 'IPv4 Address'):
+                if 'inet' not in iface:
+                    iface['inet'] = list()
+                addr = {'address': val.rstrip('(Preferred)'),
+                        'netmask': None,
+                        'broadcast': None}  # TODO find the broadcast
+                iface['inet'].append(addr)
+            elif 'IPv6 Address' in key:
+                if 'inet6' not in iface:
+                    iface['inet'] = list()
                 # XXX What is the prefixlen!?
-                addr = {"address": val.rstrip("(Preferred)"), "prefixlen": None}
-                iface["inet6"].append(addr)
-            elif key == "Physical Address":
-                iface["hwaddr"] = val
-            elif key == "Media State":
+                addr = {'address': val.rstrip('(Preferred)'),
+                        'prefixlen': None}
+                iface['inet6'].append(addr)
+            elif key == 'Physical Address':
+                iface['hwaddr'] = val
+            elif key == 'Media State':
                 # XXX seen used for tunnel adaptors
                 # might be useful
-                iface["up"] = val != "Media disconnected"
+                iface['up'] = (val != 'Media disconnected')
 
 
 def win_interfaces():
-    """
+    '''
     Obtain interface information for Windows systems
-    """
+    '''
     with salt.utils.winapi.Com():
         c = wmi.WMI()
         ifaces = {}
         for iface in c.Win32_NetworkAdapterConfiguration(IPEnabled=1):
             ifaces[iface.Description] = dict()
             if iface.MACAddress:
-                ifaces[iface.Description]["hwaddr"] = iface.MACAddress
+                ifaces[iface.Description]['hwaddr'] = iface.MACAddress
             if iface.IPEnabled:
-                ifaces[iface.Description]["up"] = True
+                ifaces[iface.Description]['up'] = True
                 for ip in iface.IPAddress:
-                    if "." in ip:
-                        if "inet" not in ifaces[iface.Description]:
-                            ifaces[iface.Description]["inet"] = []
-                        item = {"address": ip, "label": iface.Description}
+                    if '.' in ip:
+                        if 'inet' not in ifaces[iface.Description]:
+                            ifaces[iface.Description]['inet'] = []
+                        item = {'address': ip,
+                                'label': iface.Description}
                         if iface.DefaultIPGateway:
-                            broadcast = next((i for i in iface.DefaultIPGateway if "." in i), "")
+                            broadcast = next((i for i in iface.DefaultIPGateway if '.' in i), '')
                             if broadcast:
-                                item["broadcast"] = broadcast
+                                item['broadcast'] = broadcast
                         if iface.IPSubnet:
-                            netmask = next((i for i in iface.IPSubnet if "." in i), "")
+                            netmask = next((i for i in iface.IPSubnet if '.' in i), '')
                             if netmask:
-                                item["netmask"] = netmask
-                        ifaces[iface.Description]["inet"].append(item)
-                    if ":" in ip:
-                        if "inet6" not in ifaces[iface.Description]:
-                            ifaces[iface.Description]["inet6"] = []
-                        item = {"address": ip}
+                                item['netmask'] = netmask
+                        ifaces[iface.Description]['inet'].append(item)
+                    if ':' in ip:
+                        if 'inet6' not in ifaces[iface.Description]:
+                            ifaces[iface.Description]['inet6'] = []
+                        item = {'address': ip}
                         if iface.DefaultIPGateway:
-                            broadcast = next((i for i in iface.DefaultIPGateway if ":" in i), "")
+                            broadcast = next((i for i in iface.DefaultIPGateway if ':' in i), '')
                             if broadcast:
-                                item["broadcast"] = broadcast
+                                item['broadcast'] = broadcast
                         if iface.IPSubnet:
-                            netmask = next((i for i in iface.IPSubnet if ":" in i), "")
+                            netmask = next((i for i in iface.IPSubnet if ':' in i), '')
                             if netmask:
-                                item["netmask"] = netmask
-                        ifaces[iface.Description]["inet6"].append(item)
+                                item['netmask'] = netmask
+                        ifaces[iface.Description]['inet6'].append(item)
             else:
-                ifaces[iface.Description]["up"] = False
+                ifaces[iface.Description]['up'] = False
     return ifaces
 
 
 def interfaces():
-    """
+    '''
     Return a dictionary of information about all the interfaces on the minion
-    """
+    '''
     if salt.utils.platform.is_windows():
         return win_interfaces()
     elif salt.utils.platform.is_netbsd():
@@ -1062,132 +1054,130 @@ def interfaces():
 
 
 def get_net_start(ipaddr, netmask):
-    """
+    '''
     Return the address of the network
-    """
-    net = ipaddress.ip_network("{0}/{1}".format(ipaddr, netmask), strict=False)
+    '''
+    net = ipaddress.ip_network('{0}/{1}'.format(ipaddr, netmask), strict=False)
     return six.text_type(net.network_address)
 
 
 def get_net_size(mask):
-    """
+    '''
     Turns an IPv4 netmask into it's corresponding prefix length
     (255.255.255.0 -> 24 as in 192.168.1.10/24).
-    """
-    binary_str = ""
-    for octet in mask.split("."):
+    '''
+    binary_str = ''
+    for octet in mask.split('.'):
         binary_str += bin(int(octet))[2:].zfill(8)
-    return len(binary_str.rstrip("0"))
+    return len(binary_str.rstrip('0'))
 
 
 def calc_net(ipaddr, netmask=None):
-    """
+    '''
     Takes IP (CIDR notation supported) and optionally netmask
     and returns the network in CIDR-notation.
     (The IP can be any IP inside the subnet)
-    """
+    '''
     if netmask is not None:
-        ipaddr = "{0}/{1}".format(ipaddr, netmask)
+        ipaddr = '{0}/{1}'.format(ipaddr, netmask)
 
     return six.text_type(ipaddress.ip_network(ipaddr, strict=False))
 
 
 def _ipv4_to_bits(ipaddr):
-    """
+    '''
     Accepts an IPv4 dotted quad and returns a string representing its binary
     counterpart
-    """
-    return "".join([bin(int(x))[2:].rjust(8, "0") for x in ipaddr.split(".")])
+    '''
+    return ''.join([bin(int(x))[2:].rjust(8, '0') for x in ipaddr.split('.')])
 
 
 def _get_iface_info(iface):
-    """
+    '''
     If `iface` is available, return interface info and no error, otherwise
     return no info and log and return an error
-    """
+    '''
     iface_info = interfaces()
 
     if iface in iface_info.keys():
         return iface_info, False
     else:
-        error_msg = 'Interface "{0}" not in available interfaces: "{1}"' "".format(
-            iface, '", "'.join(iface_info.keys())
-        )
+        error_msg = ('Interface "{0}" not in available interfaces: "{1}"'
+                     ''.format(iface, '", "'.join(iface_info.keys())))
         log.error(error_msg)
         return None, error_msg
 
 
 def _hw_addr_aix(iface):
-    """
+    '''
     Return the hardware address (a.k.a. MAC address) for a given interface on AIX
     MAC address not available in through interfaces
-    """
+    '''
     cmd = subprocess.Popen(
-        "entstat -d {0} | grep 'Hardware Address'".format(iface),
+        'entstat -d {0} | grep \'Hardware Address\''.format(iface),
         shell=True,
         stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-    ).communicate()[0]
+        stderr=subprocess.STDOUT).communicate()[0]
 
     if cmd:
-        comps = cmd.split(" ")
+        comps = cmd.split(' ')
         if len(comps) == 3:
-            mac_addr = comps[2].strip("'").strip()
+            mac_addr = comps[2].strip('\'').strip()
             return mac_addr
 
-    error_msg = 'Interface "{0}" either not available or does not contain a hardware address'.format(iface)
+    error_msg = ('Interface "{0}" either not available or does not contain a hardware address'.format(iface))
     log.error(error_msg)
     return error_msg
 
 
 def hw_addr(iface):
-    """
+    '''
     Return the hardware address (a.k.a. MAC address) for a given interface
 
     .. versionchanged:: 2016.11.4
         Added support for AIX
 
-    """
+    '''
     if salt.utils.platform.is_aix():
         return _hw_addr_aix
 
     iface_info, error = _get_iface_info(iface)
 
     if error is False:
-        return iface_info.get(iface, {}).get("hwaddr", "")
+        return iface_info.get(iface, {}).get('hwaddr', '')
     else:
         return error
 
 
 def interface(iface):
-    """
+    '''
     Return the details of `iface` or an error if it does not exist
-    """
+    '''
     iface_info, error = _get_iface_info(iface)
 
     if error is False:
-        return iface_info.get(iface, {}).get("inet", "")
+        return iface_info.get(iface, {}).get('inet', '')
     else:
         return error
 
 
 def interface_ip(iface):
-    """
+    '''
     Return `iface` IPv4 addr or an error if `iface` does not exist
-    """
+    '''
     iface_info, error = _get_iface_info(iface)
 
     if error is False:
-        inet = iface_info.get(iface, {}).get("inet", None)
-        return inet[0].get("address", "") if inet else ""
+        inet = iface_info.get(iface, {}).get('inet', None)
+        return inet[0].get('address', '') if inet else ''
     else:
         return error
 
 
-def _subnets(proto="inet", interfaces_=None):
-    """
+def _subnets(proto='inet', interfaces_=None):
+    '''
     Returns a list of subnets to which the host belongs
-    """
+    '''
     if interfaces_ is None:
         ifaces = interfaces()
     elif isinstance(interfaces_, list):
@@ -1200,52 +1190,52 @@ def _subnets(proto="inet", interfaces_=None):
 
     ret = set()
 
-    if proto == "inet":
-        subnet = "netmask"
+    if proto == 'inet':
+        subnet = 'netmask'
         dflt_cidr = 32
-    elif proto == "inet6":
-        subnet = "prefixlen"
+    elif proto == 'inet6':
+        subnet = 'prefixlen'
         dflt_cidr = 128
     else:
-        log.error("Invalid proto {0} calling subnets()".format(proto))
+        log.error('Invalid proto {0} calling subnets()'.format(proto))
         return
 
     for ip_info in six.itervalues(ifaces):
         addrs = ip_info.get(proto, [])
-        addrs.extend([addr for addr in ip_info.get("secondary", []) if addr.get("type") == proto])
+        addrs.extend([addr for addr in ip_info.get('secondary', []) if addr.get('type') == proto])
 
         for intf in addrs:
             if subnet in intf:
-                intf = ipaddress.ip_interface("{0}/{1}".format(intf["address"], intf[subnet]))
+                intf = ipaddress.ip_interface('{0}/{1}'.format(intf['address'], intf[subnet]))
             else:
-                intf = ipaddress.ip_interface("{0}/{1}".format(intf["address"], dflt_cidr))
+                intf = ipaddress.ip_interface('{0}/{1}'.format(intf['address'], dflt_cidr))
             if not intf.is_loopback:
                 ret.add(intf.network)
     return [six.text_type(net) for net in sorted(ret)]
 
 
 def subnets(interfaces=None):
-    """
+    '''
     Returns a list of IPv4 subnets to which the host belongs
-    """
-    return _subnets("inet", interfaces_=interfaces)
+    '''
+    return _subnets('inet', interfaces_=interfaces)
 
 
 def subnets6():
-    """
+    '''
     Returns a list of IPv6 subnets to which the host belongs
-    """
-    return _subnets("inet6")
+    '''
+    return _subnets('inet6')
 
 
 def in_subnet(cidr, addr=None):
-    """
+    '''
     Returns True if host or (any of) addrs is within specified subnet, otherwise False
-    """
+    '''
     try:
         cidr = ipaddress.ip_network(cidr)
     except ValueError:
-        log.error("Invalid CIDR '{0}'".format(cidr))
+        log.error('Invalid CIDR \'{0}\''.format(cidr))
         return False
 
     if addr is None:
@@ -1260,60 +1250,63 @@ def in_subnet(cidr, addr=None):
     return False
 
 
-def _ip_addrs(interface=None, include_loopback=False, interface_data=None, proto="inet"):
-    """
+def _ip_addrs(interface=None, include_loopback=False, interface_data=None, proto='inet'):
+    '''
     Return the full list of IP adresses matching the criteria
 
     proto = inet|inet6
-    """
+    '''
     ret = set()
 
-    ifaces = interface_data if isinstance(interface_data, dict) else interfaces()
+    ifaces = interface_data \
+        if isinstance(interface_data, dict) \
+        else interfaces()
     if interface is None:
         target_ifaces = ifaces
     else:
-        target_ifaces = dict([(k, v) for k, v in six.iteritems(ifaces) if k == interface])
+        target_ifaces = dict([(k, v) for k, v in six.iteritems(ifaces)
+                              if k == interface])
         if not target_ifaces:
-            log.error("Interface {0} not found.".format(interface))
+            log.error('Interface {0} not found.'.format(interface))
     for ip_info in six.itervalues(target_ifaces):
         addrs = ip_info.get(proto, [])
-        addrs.extend([addr for addr in ip_info.get("secondary", []) if addr.get("type") == proto])
+        addrs.extend([addr for addr in ip_info.get('secondary', []) if addr.get('type') == proto])
 
         for addr in addrs:
-            addr = ipaddress.ip_address(addr.get("address"))
+            addr = ipaddress.ip_address(addr.get('address'))
             if not addr.is_loopback or include_loopback:
                 ret.add(addr)
     return [six.text_type(addr) for addr in sorted(ret)]
 
 
 def ip_addrs(interface=None, include_loopback=False, interface_data=None):
-    """
+    '''
     Returns a list of IPv4 addresses assigned to the host. 127.0.0.1 is
     ignored, unless 'include_loopback=True' is indicated. If 'interface' is
     provided, then only IP addresses from that interface will be returned.
-    """
-    return _ip_addrs(interface, include_loopback, interface_data, "inet")
+    '''
+    return _ip_addrs(interface, include_loopback, interface_data, 'inet')
 
 
 def ip_addrs6(interface=None, include_loopback=False, interface_data=None):
-    """
+    '''
     Returns a list of IPv6 addresses assigned to the host. ::1 is ignored,
     unless 'include_loopback=True' is indicated. If 'interface' is provided,
     then only IP addresses from that interface will be returned.
-    """
-    return _ip_addrs(interface, include_loopback, interface_data, "inet6")
+    '''
+    return _ip_addrs(interface, include_loopback, interface_data, 'inet6')
 
 
 def hex2ip(hex_ip, invert=False):
-    """
+    '''
     Convert a hex string to an ip, if a failure occurs the original hex is
     returned. If 'invert=True' assume that ip from /proc/net/<proto>
-    """
+    '''
     if len(hex_ip) == 32:  # ipv6
         ip = []
         for i in range(0, 32, 8):
-            ip_part = hex_ip[i: i + 8]
-            ip_part = [ip_part[x: x + 2] for x in range(0, 8, 2)]
+            ip_part = hex_ip[i:i + 8]
+            ip_part = [ip_part[x:x + 2] for x in range(0, 8, 2)]
             if invert:
                 ip.append("{0[3]}{0[2]}:{0[1]}{0[0]}".format(ip_part))
             else:
@@ -1321,7 +1314,7 @@ def hex2ip(hex_ip, invert=False):
         try:
             return ipaddress.IPv6Address(":".join(ip)).compressed
         except ipaddress.AddressValueError as ex:
-            log.error("hex2ip - ipv6 address error: %s", ex)
+            log.error('hex2ip - ipv6 address error: {0}'.format(ex))
             return hex_ip
 
     try:
@@ -1329,83 +1322,89 @@ def hex2ip(hex_ip, invert=False):
     except ValueError:
         return hex_ip
     if invert:
-        return "{3}.{2}.{1}.{0}".format(hip >> 24 & 255, hip >> 16 & 255, hip >> 8 & 255, hip & 255)
-    return "{0}.{1}.{2}.{3}".format(hip >> 24 & 255, hip >> 16 & 255, hip >> 8 & 255, hip & 255)
+        return '{3}.{2}.{1}.{0}'.format(hip >> 24 & 255,
+                                        hip >> 16 & 255,
+                                        hip >> 8 & 255,
+                                        hip & 255)
+    return '{0}.{1}.{2}.{3}'.format(hip >> 24 & 255,
+                                    hip >> 16 & 255,
+                                    hip >> 8 & 255,
+                                    hip & 255)
 
 
 def mac2eui64(mac, prefix=None):
-    """
+    '''
     Convert a MAC address to a EUI64 identifier
     or, with prefix provided, a full IPv6 address
-    """
+    '''
     # http://tools.ietf.org/html/rfc4291#section-2.5.1
-    eui64 = re.sub(r"[.:-]", "", mac).lower()
-    eui64 = eui64[0:6] + "fffe" + eui64[6:]
+    eui64 = re.sub(r'[.:-]', '', mac).lower()
+    eui64 = eui64[0:6] + 'fffe' + eui64[6:]
     eui64 = hex(int(eui64[0:2], 16) | 2)[2:].zfill(2) + eui64[2:]
 
     if prefix is None:
-        return ":".join(re.findall(r".{4}", eui64))
+        return ':'.join(re.findall(r'.{4}', eui64))
     else:
         try:
             net = ipaddress.ip_network(prefix, strict=False)
-            euil = int("0x{0}".format(eui64), 16)
-            return "{0}/{1}".format(net[euil], net.prefixlen)
+            euil = int('0x{0}'.format(eui64), 16)
+            return '{0}/{1}'.format(net[euil], net.prefixlen)
         except Exception:
             return
 
 
 def active_tcp():
-    """
+    '''
     Return a dict describing all active tcp connections as quickly as possible
-    """
+    '''
     ret = {}
-    for statf in ["/proc/net/tcp", "/proc/net/tcp6"]:
+    for statf in ['/proc/net/tcp', '/proc/net/tcp6']:
         if os.path.isfile(statf):
-            with salt.utils.files.fopen(statf, "rb") as fp_:
+            with salt.utils.files.fopen(statf, 'rb') as fp_:
                 for line in fp_:
                     line = salt.utils.stringutils.to_unicode(line)
-                    if line.strip().startswith("sl"):
+                    if line.strip().startswith('sl'):
                         continue
                     ret.update(_parse_tcp_line(line))
     return ret
 
 
 def local_port_tcp(port):
-    """
+    '''
     Return a set of remote ip addrs attached to the specified local port
-    """
-    ret = _remotes_on(port, "local_port")
+    '''
+    ret = _remotes_on(port, 'local_port')
     return ret
 
 
 def remote_port_tcp(port):
-    """
+    '''
     Return a set of ip addrs the current host is connected to on given port
-    """
-    ret = _remotes_on(port, "remote_port")
+    '''
+    ret = _remotes_on(port, 'remote_port')
     return ret
 
 
 def _remotes_on(port, which_end):
-    """
+    '''
     Return a set of ip addrs active tcp connections
-    """
+    '''
     port = int(port)
     ret = set()
 
     proc_available = False
-    for statf in ["/proc/net/tcp", "/proc/net/tcp6"]:
+    for statf in ['/proc/net/tcp', '/proc/net/tcp6']:
         if os.path.isfile(statf):
             proc_available = True
-            with salt.utils.files.fopen(statf, "r") as fp_:
+            with salt.utils.files.fopen(statf, 'r') as fp_:
                 for line in fp_:
                     line = salt.utils.stringutils.to_unicode(line)
-                    if line.strip().startswith("sl"):
+                    if line.strip().startswith('sl'):
                         continue
                     iret = _parse_tcp_line(line)
                     sl = next(iter(iret))
                     if iret[sl][which_end] == port:
-                        ret.add(iret[sl]["remote_addr"])
+                        ret.add(iret[sl]['remote_addr'])
 
     if not proc_available:  # Fallback to use OS specific tools
         if salt.utils.platform.is_sunos():
@@ -1427,24 +1426,24 @@ def _remotes_on(port, which_end):
 
 
 def _parse_tcp_line(line):
-    """
+    '''
     Parse a single line from the contents of /proc/net/tcp or /proc/net/tcp6
-    """
+    '''
     ret = {}
     comps = line.strip().split()
-    sl = comps[0].rstrip(":")
+    sl = comps[0].rstrip(':')
     ret[sl] = {}
-    l_addr, l_port = comps[1].split(":")
-    r_addr, r_port = comps[2].split(":")
-    ret[sl]["local_addr"] = hex2ip(l_addr, True)
-    ret[sl]["local_port"] = int(l_port, 16)
-    ret[sl]["remote_addr"] = hex2ip(r_addr, True)
-    ret[sl]["remote_port"] = int(r_port, 16)
+    l_addr, l_port = comps[1].split(':')
+    r_addr, r_port = comps[2].split(':')
+    ret[sl]['local_addr'] = hex2ip(l_addr, True)
+    ret[sl]['local_port'] = int(l_port, 16)
+    ret[sl]['remote_addr'] = hex2ip(r_addr, True)
+    ret[sl]['remote_port'] = int(r_port, 16)
     return ret
 
 
 def _sunos_remotes_on(port, which_end):
-    """
+    '''
     SunOS specific helper function.
     Returns set of ipv4 host addresses of remote established connections
     on local or remote tcp port.
@@ -1457,32 +1456,32 @@ def _sunos_remotes_on(port, which_end):
        -------------------- -------------------- ----- ------ ----- ------ -----------
        10.0.0.101.4505      10.0.0.1.45329       1064800      0 1055864      0 ESTABLISHED
        10.0.0.101.4505      10.0.0.100.50798     1064800      0 1055864      0 ESTABLISHED
-    """
+    '''
     remotes = set()
     try:
-        data = subprocess.check_output(["netstat", "-f", "inet", "-n"])  # pylint: disable=minimum-python-version
+        data = subprocess.check_output(['netstat', '-f', 'inet', '-n'])  # pylint: disable=minimum-python-version
     except subprocess.CalledProcessError:
-        log.error("Failed netstat")
+        log.error('Failed netstat')
         raise
 
-    lines = salt.utils.stringutils.to_str(data).split("\n")
+    lines = salt.utils.stringutils.to_str(data).split('\n')
     for line in lines:
-        if "ESTABLISHED" not in line:
+        if 'ESTABLISHED' not in line:
             continue
         chunks = line.split()
-        local_host, local_port = chunks[0].rsplit(".", 1)
-        remote_host, remote_port = chunks[1].rsplit(".", 1)
+        local_host, local_port = chunks[0].rsplit('.', 1)
+        remote_host, remote_port = chunks[1].rsplit('.', 1)
 
-        if which_end == "remote_port" and int(remote_port) != port:
+        if which_end == 'remote_port' and int(remote_port) != port:
             continue
-        if which_end == "local_port" and int(local_port) != port:
+        if which_end == 'local_port' and int(local_port) != port:
             continue
         remotes.add(remote_host)
     return remotes
 
 
 def _freebsd_remotes_on(port, which_end):
-    """
+    '''
     Returns set of ipv4 host addresses of remote established connections
     on local tcp port port.
 
@@ -1499,19 +1498,19 @@ def _freebsd_remotes_on(port, which_end):
     $ sudo sockstat -4 -c -p 4506
     USER    COMMAND     PID     FD  PROTO  LOCAL ADDRESS    FOREIGN ADDRESS
     root    python2.7   1294    41  tcp4   127.0.0.1:61115  127.0.0.1:4506
-    """
+    '''
 
     port = int(port)
     remotes = set()
 
     try:
-        cmd = salt.utils.args.shlex_split("sockstat -4 -c -p {0}".format(port))
+        cmd = salt.utils.args.shlex_split('sockstat -4 -c -p {0}'.format(port))
         data = subprocess.check_output(cmd)  # pylint: disable=minimum-python-version
     except subprocess.CalledProcessError as ex:
         log.error('Failed "sockstat" with returncode = {0}'.format(ex.returncode))
         raise
 
-    lines = salt.utils.stringutils.to_str(data).split("\n")
+    lines = salt.utils.stringutils.to_str(data).split('\n')
 
     for line in lines:
         chunks = line.split()
@@ -1520,7 +1519,7 @@ def _freebsd_remotes_on(port, which_end):
         # ['root', 'python2.7', '1456', '37', 'tcp4',
         #  '127.0.0.1:4505-', '127.0.0.1:55703']
         # print chunks
-        if "COMMAND" in chunks[1]:
+        if 'COMMAND' in chunks[1]:
             continue  # ignore header
         if len(chunks) < 2:
             continue
@@ -1529,11 +1528,11 @@ def _freebsd_remotes_on(port, which_end):
         # salt-master python2.781106 35 tcp4  192.168.12.34:4506    192.168.12.45:60143
         local = chunks[-2]
         remote = chunks[-1]
-        lhost, lport = local.split(":")
-        rhost, rport = remote.split(":")
-        if which_end == "local" and int(lport) != port:  # ignore if local port not port
+        lhost, lport = local.split(':')
+        rhost, rport = remote.split(':')
+        if which_end == 'local' and int(lport) != port:  # ignore if local port not port
             continue
-        if which_end == "remote" and int(rport) != port:  # ignore if remote port not port
+        if which_end == 'remote' and int(rport) != port:  # ignore if remote port not port
             continue
 
         remotes.add(rhost)
@@ -1542,7 +1541,7 @@ def _freebsd_remotes_on(port, which_end):
 
 
 def _netbsd_remotes_on(port, which_end):
-    """
+    '''
     Returns set of ipv4 host addresses of remote established connections
     on local tcp port port.
 
@@ -1559,19 +1558,19 @@ def _netbsd_remotes_on(port, which_end):
     $ sudo sockstat -4 -c -n -p 4506
     USER    COMMAND     PID     FD  PROTO  LOCAL ADDRESS    FOREIGN ADDRESS
     root    python2.7   1294    41  tcp    127.0.0.1.61115  127.0.0.1.4506
-    """
+    '''
 
     port = int(port)
     remotes = set()
 
     try:
-        cmd = salt.utils.args.shlex_split("sockstat -4 -c -n -p {0}".format(port))
+        cmd = salt.utils.args.shlex_split('sockstat -4 -c -n -p {0}'.format(port))
         data = subprocess.check_output(cmd)  # pylint: disable=minimum-python-version
     except subprocess.CalledProcessError as ex:
         log.error('Failed "sockstat" with returncode = {0}'.format(ex.returncode))
         raise
 
-    lines = salt.utils.stringutils.to_str(data).split("\n")
+    lines = salt.utils.stringutils.to_str(data).split('\n')
 
     for line in lines:
         chunks = line.split()
@@ -1580,19 +1579,19 @@ def _netbsd_remotes_on(port, which_end):
         # ['root', 'python2.7', '1456', '37', 'tcp',
         #  '127.0.0.1.4505-', '127.0.0.1.55703']
         # print chunks
-        if "COMMAND" in chunks[1]:
+        if 'COMMAND' in chunks[1]:
             continue  # ignore header
         if len(chunks) < 2:
             continue
-        local = chunks[5].split(".")
+        local = chunks[5].split('.')
         lport = local.pop()
-        lhost = ".".join(local)
-        remote = chunks[6].split(".")
+        lhost = '.'.join(local)
+        remote = chunks[6].split('.')
         rport = remote.pop()
-        rhost = ".".join(remote)
-        if which_end == "local" and int(lport) != port:  # ignore if local port not port
+        rhost = '.'.join(remote)
+        if which_end == 'local' and int(lport) != port:  # ignore if local port not port
             continue
-        if which_end == "remote" and int(rport) != port:  # ignore if remote port not port
+        if which_end == 'remote' and int(rport) != port:  # ignore if remote port not port
             continue
 
         remotes.add(rhost)
@@ -1601,7 +1600,7 @@ def _netbsd_remotes_on(port, which_end):
 
 
 def _openbsd_remotes_on(port, which_end):
-    """
+    '''
     OpenBSD specific helper function.
     Returns set of ipv4 host addresses of remote established connections
     on local or remote tcp port.
@@ -1613,32 +1612,32 @@ def _openbsd_remotes_on(port, which_end):
     Proto   Recv-Q Send-Q  Local Address          Foreign Address        (state)
     tcp          0      0  10.0.0.101.4505        10.0.0.1.45329         ESTABLISHED
     tcp          0      0  10.0.0.101.4505        10.0.0.100.50798       ESTABLISHED
-    """
+    '''
     remotes = set()
     try:
-        data = subprocess.check_output(["netstat", "-nf", "inet"])  # pylint: disable=minimum-python-version
+        data = subprocess.check_output(['netstat', '-nf', 'inet'])  # pylint: disable=minimum-python-version
     except subprocess.CalledProcessError:
-        log.error("Failed netstat")
+        log.error('Failed netstat')
         raise
 
-    lines = data.split("\n")
+    lines = data.split('\n')
     for line in lines:
-        if "ESTABLISHED" not in line:
+        if 'ESTABLISHED' not in line:
             continue
         chunks = line.split()
-        local_host, local_port = chunks[3].rsplit(".", 1)
-        remote_host, remote_port = chunks[4].rsplit(".", 1)
+        local_host, local_port = chunks[3].rsplit('.', 1)
+        remote_host, remote_port = chunks[4].rsplit('.', 1)
 
-        if which_end == "remote_port" and int(remote_port) != port:
+        if which_end == 'remote_port' and int(remote_port) != port:
             continue
-        if which_end == "local_port" and int(local_port) != port:
+        if which_end == 'local_port' and int(local_port) != port:
             continue
         remotes.add(remote_host)
     return remotes
 
 
 def _windows_remotes_on(port, which_end):
-    r"""
+    r'''
     Windows specific helper function.
     Returns set of ipv4 host addresses of remote established connections
     on local or remote tcp port.
@@ -1652,31 +1651,31 @@ def _windows_remotes_on(port, which_end):
        Proto  Local Address          Foreign Address        State
        TCP    10.2.33.17:3007        130.164.12.233:10123   ESTABLISHED
        TCP    10.2.33.17:3389        130.164.30.5:10378     ESTABLISHED
-    """
+    '''
     remotes = set()
     try:
-        data = subprocess.check_output(["netstat", "-n"])  # pylint: disable=minimum-python-version
+        data = subprocess.check_output(['netstat', '-n'])  # pylint: disable=minimum-python-version
     except subprocess.CalledProcessError:
-        log.error("Failed netstat")
+        log.error('Failed netstat')
         raise
 
-    lines = salt.utils.stringutils.to_str(data).split("\n")
+    lines = salt.utils.stringutils.to_str(data).split('\n')
     for line in lines:
-        if "ESTABLISHED" not in line:
+        if 'ESTABLISHED' not in line:
             continue
         chunks = line.split()
-        local_host, local_port = chunks[1].rsplit(":", 1)
-        remote_host, remote_port = chunks[2].rsplit(":", 1)
-        if which_end == "remote_port" and int(remote_port) != port:
+        local_host, local_port = chunks[1].rsplit(':', 1)
+        remote_host, remote_port = chunks[2].rsplit(':', 1)
+        if which_end == 'remote_port' and int(remote_port) != port:
             continue
-        if which_end == "local_port" and int(local_port) != port:
+        if which_end == 'local_port' and int(local_port) != port:
             continue
         remotes.add(remote_host)
     return remotes
 
 
 def _linux_remotes_on(port, which_end):
-    """
+    '''
     Linux specific helper function.
     Returns set of ip host addresses of remote established connections
     on local tcp port port.
@@ -1691,12 +1690,12 @@ def _linux_remotes_on(port, which_end):
     Python  10152 root   22u  IPv4 0x18a8464a29c8cab5      0t0  TCP 127.0.0.1:55703->127.0.0.1:4505 (ESTABLISHED)
     Python  10153 root   22u  IPv4 0x18a8464a29c8cab5      0t0  TCP [fe80::249a]:4505->[fe80::150]:59367 (ESTABLISHED)
 
-    """
+    '''
     remotes = set()
 
     try:
         data = subprocess.check_output(
-            ["lsof", "-iTCP:{0:d}".format(port), "-n", "-P"]  # pylint: disable=minimum-python-version
+            ['lsof', '-iTCP:{0:d}'.format(port), '-n', '-P']  # pylint: disable=minimum-python-version
         )
     except subprocess.CalledProcessError as ex:
         if ex.returncode == 1:
@@ -1707,7 +1706,7 @@ def _linux_remotes_on(port, which_end):
         log.error('Failed "lsof" with returncode = {0}'.format(ex.returncode))
         raise
 
-    lines = salt.utils.stringutils.to_str(data).split("\n")
+    lines = salt.utils.stringutils.to_str(data).split('\n')
     for line in lines:
         chunks = line.split()
         if not chunks:
@@ -1715,17 +1714,17 @@ def _linux_remotes_on(port, which_end):
         # ['Python', '9971', 'root', '37u', 'IPv4', '0x18a8464a29b2b29d', '0t0',
         # 'TCP', '127.0.0.1:4505->127.0.0.1:55703', '(ESTABLISHED)']
         # print chunks
-        if "COMMAND" in chunks[0]:
+        if 'COMMAND' in chunks[0]:
             continue  # ignore header
-        if "ESTABLISHED" not in chunks[-1]:
+        if 'ESTABLISHED' not in chunks[-1]:
             continue  # ignore if not ESTABLISHED
         # '127.0.0.1:4505->127.0.0.1:55703'
-        local, remote = chunks[8].split("->")
-        _, lport = local.rsplit(":", 1)
-        rhost, rport = remote.rsplit(":", 1)
-        if which_end == "remote_port" and int(rport) != port:
+        local, remote = chunks[8].split('->')
+        _, lport = local.rsplit(':', 1)
+        rhost, rport = remote.rsplit(':', 1)
+        if which_end == 'remote_port' and int(rport) != port:
             continue
-        if which_end == "local_port" and int(lport) != port:
+        if which_end == 'local_port' and int(lport) != port:
             continue
         remotes.add(rhost.strip("[]"))
 
@@ -1733,7 +1732,7 @@ def _linux_remotes_on(port, which_end):
 
 
 def _aix_remotes_on(port, which_end):
-    """
+    '''
     AIX specific helper function.
     Returns set of ipv4 host addresses of remote established connections
     on local or remote tcp port.
@@ -1758,33 +1757,33 @@ def _aix_remotes_on(port, which_end):
     tcp        0      0  127.0.0.1.32777        127.0.0.1.32771        ESTABLISHED
     tcp4       0      0  127.0.0.1.32771        127.0.0.1.32778        ESTABLISHED
     tcp        0      0  127.0.0.1.32778        127.0.0.1.32771        ESTABLISHED
-    """
+    '''
     remotes = set()
     try:
-        data = subprocess.check_output(["netstat", "-f", "inet", "-n"])  # pylint: disable=minimum-python-version
+        data = subprocess.check_output(['netstat', '-f', 'inet', '-n'])  # pylint: disable=minimum-python-version
     except subprocess.CalledProcessError:
-        log.error("Failed netstat")
+        log.error('Failed netstat')
         raise
 
-    lines = salt.utils.stringutils.to_str(data).split("\n")
+    lines = salt.utils.stringutils.to_str(data).split('\n')
     for line in lines:
-        if "ESTABLISHED" not in line:
+        if 'ESTABLISHED' not in line:
             continue
         chunks = line.split()
-        local_host, local_port = chunks[3].rsplit(".", 1)
-        remote_host, remote_port = chunks[4].rsplit(".", 1)
+        local_host, local_port = chunks[3].rsplit('.', 1)
+        remote_host, remote_port = chunks[4].rsplit('.', 1)
 
-        if which_end == "remote_port" and int(remote_port) != port:
+        if which_end == 'remote_port' and int(remote_port) != port:
             continue
-        if which_end == "local_port" and int(local_port) != port:
+        if which_end == 'local_port' and int(local_port) != port:
             continue
         remotes.add(remote_host)
     return remotes
 
 
-@jinja_filter("gen_mac")
-def gen_mac(prefix="AC:DE:48"):
-    """
+@jinja_filter('gen_mac')
+def gen_mac(prefix='AC:DE:48'):
+    '''
     Generates a MAC address with the defined OUI prefix.
 
     Common prefixes:
@@ -1800,37 +1799,38 @@ def gen_mac(prefix="AC:DE:48"):
      - http://standards.ieee.org/develop/regauth/oui/oui.txt
      - https://www.wireshark.org/tools/oui-lookup.html
      - https://en.wikipedia.org/wiki/MAC_address
-    """
-    return "{0}:{1:02X}:{2:02X}:{3:02X}".format(
-        prefix, random.randint(0, 0xFF), random.randint(0, 0xFF), random.randint(0, 0xFF)
-    )
+    '''
+    return '{0}:{1:02X}:{2:02X}:{3:02X}'.format(prefix,
+                                                random.randint(0, 0xff),
+                                                random.randint(0, 0xff),
+                                                random.randint(0, 0xff))
 
 
-@jinja_filter("mac_str_to_bytes")
+@jinja_filter('mac_str_to_bytes')
 def mac_str_to_bytes(mac_str):
-    """
+    '''
     Convert a MAC address string into bytes. Works with or without separators:
 
     b1 = mac_str_to_bytes('08:00:27:13:69:77')
     b2 = mac_str_to_bytes('080027136977')
     assert b1 == b2
     assert isinstance(b1, bytes)
-    """
+    '''
     if len(mac_str) == 12:
         pass
     elif len(mac_str) == 17:
         sep = mac_str[2]
-        mac_str = mac_str.replace(sep, "")
+        mac_str = mac_str.replace(sep, '')
     else:
-        raise ValueError("Invalid MAC address")
-    chars = (int(mac_str[s: s + 2], 16) for s in range(0, 12, 2))
-    return bytes(chars) if six.PY3 else b"".join(chr(x) for x in chars)
+        raise ValueError('Invalid MAC address')
+    chars = (int(mac_str[s:s+2], 16) for s in range(0, 12, 2))
+    return bytes(chars) if six.PY3 else b''.join(chr(x) for x in chars)
 
 
 def refresh_dns():
-    """
+    '''
     issue #21397: force glibc to re-read resolv.conf
-    """
+    '''
     try:
         res_init()
     except NameError:
@@ -1838,20 +1838,22 @@ def refresh_dns():
         pass
 
 
-@jinja_filter("dns_check")
+@jinja_filter('dns_check')
 def dns_check(addr, port, safe=False, ipv6=None):
-    """
+    '''
     Return the ip resolved by dns, but do not exit on failure, only raise an
     exception. Obeys system preference for IPv4/6 address resolution.
     Tries to connect to the address before considering it useful. If no address
     can be reached, the first one resolved is used as a fallback.
-    """
+    '''
     error = False
     lookup = addr
     seen_ipv6 = False
     try:
         refresh_dns()
-        hostnames = socket.getaddrinfo(addr, None, socket.AF_UNSPEC, socket.SOCK_STREAM)
+        hostnames = socket.getaddrinfo(
+            addr, None, socket.AF_UNSPEC, socket.SOCK_STREAM
+        )
         if not hostnames:
             error = True
         else:
@@ -1875,7 +1877,7 @@ def dns_check(addr, port, safe=False, ipv6=None):
 
                 try:
                     s = socket.socket(h[0], socket.SOCK_STREAM)
-                    s.connect((candidate_addr.strip("[]"), port))
+                    s.connect((candidate_addr.strip('[]'), port))
                     s.close()
 
                     resolved = candidate_addr
@@ -1883,18 +1885,18 @@ def dns_check(addr, port, safe=False, ipv6=None):
                 except socket.error:
                     pass
             if not resolved:
-                if candidates:
+                if len(candidates) > 0:
                     resolved = candidates[0]
                 else:
                     error = True
     except TypeError:
-        err = ("Attempt to resolve address '{0}' failed. Invalid or unresolveable address").format(lookup)
+        err = ('Attempt to resolve address \'{0}\' failed. Invalid or unresolveable address').format(lookup)
         raise SaltSystemExit(code=42, msg=err)
     except socket.error:
         error = True
 
     if error:
-        err = ("DNS lookup or connection check of '{0}' failed.").format(addr)
+        err = ('DNS lookup or connection check of \'{0}\' failed.').format(addr)
         if safe:
             if salt.log.is_console_configured():
                 # If logging is not configured it also means that either

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -1946,8 +1946,12 @@ def parse_host_port(host_port):
         if port and ":" in port:
             raise ValueError('too many ":" separators in host:port "{}"'.format(host_port))
         try:
-            host = ipaddress.ip_address(host)
+            host_ip = ipaddress.ip_address(host)
+            host = host_ip
         except ValueError:
             log.debug('"%s" Not an IP address? Assuming it is a hostname.', host)
+        except TypeError as _e_:
+            log.warn('"%s" generated a TypeError exception', host)
+            raise _e_
 
     return host, port

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -1870,14 +1870,14 @@ def dns_check(addr, port, safe=False, ipv6=None):
                 if h[0] == socket.AF_INET6 and ipv6 is False:
                     continue
 
-                candidate_addr = salt.utils.zeromq.ip_bracket(h[4][0])
+                candidate_addr = h[4][0]
 
                 if h[0] != socket.AF_INET6 or ipv6 is not None:
                     candidates.append(candidate_addr)
 
                 try:
                     s = socket.socket(h[0], socket.SOCK_STREAM)
-                    s.connect((candidate_addr.strip('[]'), port))
+                    s.connect((candidate_addr), port))
                     s.close()
 
                     resolved = candidate_addr

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -1877,7 +1877,7 @@ def dns_check(addr, port, safe=False, ipv6=None):
 
                 try:
                     s = socket.socket(h[0], socket.SOCK_STREAM)
-                    s.connect((candidate_addr), port))
+                    s.connect(candidate_addr, port)
                     s.close()
 
                     resolved = candidate_addr

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -1940,7 +1940,7 @@ def parse_host_port(host_port):
                 port = int(port)
         if port and ":" in port:
             raise ValueError('too many ":" separators in host:port "{}"'.format(host_port))
-        if ipaddress.is_ip(host):
+        if is_ip(host):
             host = ipaddress.ip_address(host)
 
     return host, port

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -1912,7 +1912,7 @@ def parse_host_port(host_port):
     """
     Takes a string argument specifying host or host:port.
 
-    Returns a (hostname, port) or (ip_address, port) tuple. If no port is given,
+    Returns a (hostname, port) or (ipaddress.ip_address, port) tuple. If no port is given,
     the second (port) element of the returned tuple will be None.
 
     host:port argument, for example, is accepted in the forms of:

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -1952,8 +1952,9 @@ def parse_host_port(host_port):
         host = host_ip
     except ValueError:
         log.debug('"%s" Not an IP address? Assuming it is a hostname.', host)
-    except TypeError as _e_:
-        log.error('"%s" generated a TypeError exception', host)
-        raise _e_
+# Todo: uncomment and handle
+#    except TypeError as _e_:
+#        log.error('"%s" generated a TypeError exception', host)
+#        raise _e_
 
     return host, port

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -1943,6 +1943,6 @@ def parse_host_port(host_port):
         try:
             host = ipaddress.ip_address(host)
         except ValueError:
-            log.debug('"%s" Not an IP address? Assuming it is a hostname.' % host)
+            log.debug('"%s" Not an IP address? Assuming it is a hostname.', host)
 
     return host, port

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -1310,8 +1310,8 @@ def hex2ip(hex_ip, invert=False):
     if len(hex_ip) == 32:  # ipv6
         ip = []
         for i in range(0, 32, 8):
-            ip_part = hex_ip[i : i + 8]
-            ip_part = [ip_part[x : x + 2] for x in range(0, 8, 2)]
+            ip_part = hex_ip[i: i + 8]
+            ip_part = [ip_part[x: x + 2] for x in range(0, 8, 2)]
             if invert:
                 ip.append("{0[3]}{0[2]}:{0[1]}{0[0]}".format(ip_part))
             else:
@@ -1821,7 +1821,7 @@ def mac_str_to_bytes(mac_str):
         mac_str = mac_str.replace(sep, "")
     else:
         raise ValueError("Invalid MAC address")
-    chars = (int(mac_str[s : s + 2], 16) for s in range(0, 12, 2))
+    chars = (int(mac_str[s: s + 2], 16) for s in range(0, 12, 2))
     return bytes(chars) if six.PY3 else b"".join(chr(x) for x in chars)
 
 

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -1925,6 +1925,8 @@ def parse_host_port(host_port):
       - 10.11.12.13:4567
       - 10.11.12.13
     '''
+    host, port = None, None  # default
+
     _s_ = host_port[:]
     if _s_[0] == '[':
         if ']' in host_port[0]:
@@ -1937,9 +1939,10 @@ def parse_host_port(host_port):
         host = ipaddress.ipv6IPv6Address(host)
     else:
         if _s_.count(':') == 1:
-            host, port = _s_.split(':')
-            port = int(port)
-        else:
+            host, _hostport_separator_, port = _s_.parttion(':')
+            if port:
+                port = int(port)
+        if ':' in port:
             raise ValueError('too many ":" separators in host:port "{}"'.format(host_port))
         if ipaddress.is_ip(host):
             host = ipaddress.ip_address(host)

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -1930,13 +1930,13 @@ def parse_host_port(host_port):
     _s_ = host_port[:]
     if _s_[0] == "[":
         if "]" in host_port[0]:
-            host, _s_ = _s_.lstrip("[]").rsplit("]", 1)
+            host, _s_ = _s_.lstrip("[").rsplit("]", 1)
+            host = ipaddress.IPv6Address(host)
             if _s_[0] == ":":
                 port = int(_s_.lstrip(":"))
             else:
                 if len(_s_) > 1:
                     raise ValueError('found ambiguous "{}" port in "{}"'.format(_s_, host_port))
-        host = ipaddress.IPv6Address(host)
     else:
         if _s_.count(":") == 1:
             host, _hostport_separator_, port = _s_.partition(":")

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -220,8 +220,8 @@ def get_fqhostname():
     """
     Returns the fully qualified hostname
     """
-    l = []
-    l.append(socket.getfqdn())
+    fqdn = []
+    fqdn.append(socket.getfqdn())
 
     # try socket.getaddrinfo
     try:
@@ -231,11 +231,11 @@ def get_fqhostname():
         for info in addrinfo:
             # info struct [family, socktype, proto, canonname, sockaddr]
             if len(info) >= 4:
-                l.append(info[3])
+                fqdn.append(info[3])
     except socket.gaierror:
         pass
 
-    return l and l[0] or None
+    return fqdn and fqdn[0] or None
 
 
 def ip_to_host(ip):

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
-'''
+"""
 Define some generic socket functions for network modules
-'''
+"""
 
 # Import python libs
 from __future__ import absolute_import, unicode_literals, print_function
@@ -19,6 +19,7 @@ from string import ascii_letters, digits
 # Import 3rd-party libs
 from salt.ext import six
 from salt.ext.six.moves import range  # pylint: disable=import-error,redefined-builtin
+
 # Attempt to import wmi
 try:
     import wmi
@@ -47,6 +48,7 @@ log = logging.getLogger(__name__)
 try:
     import ctypes
     import ctypes.util
+
     libc = ctypes.cdll.LoadLibrary(ctypes.util.find_library("c"))
     res_init = libc.__res_init
 except (ImportError, OSError, AttributeError, TypeError):
@@ -56,18 +58,16 @@ except (ImportError, OSError, AttributeError, TypeError):
 
 
 def sanitize_host(host):
-    '''
+    """
     Sanitize host string.
-    '''
-    return ''.join([
-        c for c in host[0:255] if c in (ascii_letters + digits + '.-')
-    ])
+    """
+    return "".join([c for c in host[0:255] if c in (ascii_letters + digits + ".-")])
 
 
 def isportopen(host, port):
-    '''
+    """
     Return status of a port
-    '''
+    """
 
     if not 1 <= int(port) <= 65535:
         return False
@@ -79,13 +79,14 @@ def isportopen(host, port):
 
 
 def host_to_ips(host):
-    '''
+    """
     Returns a list of IP addresses of a given hostname or None if not found.
-    '''
+    """
     ips = []
     try:
         for family, socktype, proto, canonname, sockaddr in socket.getaddrinfo(
-                host, 0, socket.AF_UNSPEC, socket.SOCK_STREAM):
+            host, 0, socket.AF_UNSPEC, socket.SOCK_STREAM
+        ):
             if family == socket.AF_INET:
                 ip, port = sockaddr
             elif family == socket.AF_INET6:
@@ -99,24 +100,34 @@ def host_to_ips(host):
 
 
 def _generate_minion_id():
-    '''
+    """
     Get list of possible host names and convention names.
 
     :return:
-    '''
+    """
     # There are three types of hostnames:
     # 1. Network names. How host is accessed from the network.
     # 2. Host aliases. They might be not available in all the network or only locally (/etc/hosts)
     # 3. Convention names, an internal nodename.
 
     class DistinctList(list):
-        '''
+        """
         List, which allows one to append only distinct objects.
         Needs to work on Python 2.6, because of collections.OrderedDict only since 2.7 version.
         Override 'filter()' for custom filtering.
-        '''
-        localhost_matchers = [r'localhost.*', r'ip6-.*', r'127[.]\d', r'0\.0\.0\.0',
-                              r'::1.*', r'ipv6-.*', r'fe00::.*', r'fe02::.*', r'1.0.0.*.ip6.arpa']
+        """
+
+        localhost_matchers = [
+            r"localhost.*",
+            r"ip6-.*",
+            r"127[.]\d",
+            r"0\.0\.0\.0",
+            r"::1.*",
+            r"ipv6-.*",
+            r"fe00::.*",
+            r"fe02::.*",
+            r"1.0.0.*.ip6.arpa",
+        ]
 
         def append(self, p_object):
             if p_object and p_object not in self and not self.filter(p_object):
@@ -129,7 +140,7 @@ def _generate_minion_id():
             return self
 
         def filter(self, element):
-            'Returns True if element needs to be filtered'
+            "Returns True if element needs to be filtered"
             for rgx in self.localhost_matchers:
                 if re.match(rgx, element):
                     return True
@@ -140,51 +151,62 @@ def _generate_minion_id():
     hosts = DistinctList().append(socket.getfqdn()).append(platform.node()).append(socket.gethostname())
     if not hosts:
         try:
-            for a_nfo in socket.getaddrinfo(hosts.first() or 'localhost', None, socket.AF_INET,
-                                            socket.SOCK_RAW, socket.IPPROTO_IP, socket.AI_CANONNAME):
+            for a_nfo in socket.getaddrinfo(
+                hosts.first() or "localhost",
+                None,
+                socket.AF_INET,
+                socket.SOCK_RAW,
+                socket.IPPROTO_IP,
+                socket.AI_CANONNAME,
+            ):
                 if len(a_nfo) > 3:
                     hosts.append(a_nfo[3])
         except socket.gaierror:
-            log.warning('Cannot resolve address {addr} info via socket: {message}'.format(
-                addr=hosts.first() or 'localhost (N/A)', message=socket.gaierror)
+            log.warning(
+                "Cannot resolve address {addr} info via socket: {message}".format(
+                    addr=hosts.first() or "localhost (N/A)", message=socket.gaierror
+                )
             )
     # Universal method for everywhere (Linux, Slowlaris, Windows etc)
-    for f_name in ('/etc/hostname', '/etc/nodename', '/etc/hosts',
-                   r'{win}\system32\drivers\etc\hosts'.format(win=os.getenv('WINDIR'))):
+    for f_name in (
+        "/etc/hostname",
+        "/etc/nodename",
+        "/etc/hosts",
+        r"{win}\system32\drivers\etc\hosts".format(win=os.getenv("WINDIR")),
+    ):
         try:
             with salt.utils.files.fopen(f_name) as f_hdl:
                 for line in f_hdl:
                     line = salt.utils.stringutils.to_unicode(line)
-                    hst = line.strip().split('#')[0].strip().split()
+                    hst = line.strip().split("#")[0].strip().split()
                     if hst:
-                        if hst[0][:4] in ('127.', '::1') or len(hst) == 1:
+                        if hst[0][:4] in ("127.", "::1") or len(hst) == 1:
                             hosts.extend(hst)
         except IOError:
             pass
 
     # include public and private ipaddresses
-    return hosts.extend([addr for addr in ip_addrs()
-                         if not ipaddress.ip_address(addr).is_loopback])
+    return hosts.extend([addr for addr in ip_addrs() if not ipaddress.ip_address(addr).is_loopback])
 
 
 def generate_minion_id():
-    '''
+    """
     Return only first element of the hostname from all possible list.
 
     :return:
-    '''
+    """
     try:
         ret = salt.utils.stringutils.to_unicode(_generate_minion_id().first())
     except TypeError:
         ret = None
-    return ret or 'localhost'
+    return ret or "localhost"
 
 
 def get_socket(addr, type=socket.SOCK_STREAM, proto=0):
-    '''
+    """
     Return a socket object for the addr
     IP-version agnostic
-    '''
+    """
 
     version = ipaddress.ip_address(addr).version
     if version == 4:
@@ -195,17 +217,16 @@ def get_socket(addr, type=socket.SOCK_STREAM, proto=0):
 
 
 def get_fqhostname():
-    '''
+    """
     Returns the fully qualified hostname
-    '''
+    """
     l = []
     l.append(socket.getfqdn())
 
     # try socket.getaddrinfo
     try:
         addrinfo = socket.getaddrinfo(
-            socket.gethostname(), 0, socket.AF_UNSPEC, socket.SOCK_STREAM,
-            socket.SOL_TCP, socket.AI_CANONNAME
+            socket.gethostname(), 0, socket.AF_UNSPEC, socket.SOCK_STREAM, socket.SOL_TCP, socket.AI_CANONNAME
         )
         for info in addrinfo:
             # info struct [family, socktype, proto, canonname, sockaddr]
@@ -218,25 +239,26 @@ def get_fqhostname():
 
 
 def ip_to_host(ip):
-    '''
+    """
     Returns the hostname of a given IP
-    '''
+    """
     try:
         hostname, aliaslist, ipaddrlist = socket.gethostbyaddr(ip)
     except Exception as exc:
-        log.debug('salt.utils.network.ip_to_host(%r) failed: %s', ip, exc)
+        log.debug("salt.utils.network.ip_to_host(%r) failed: %s", ip, exc)
         hostname = None
     return hostname
+
 
 # pylint: enable=C0103
 
 
 def is_reachable_host(entity_name):
-    '''
+    """
     Returns a bool telling if the entity name is a reachable host (IPv4/IPv6/FQDN/etc).
     :param hostname:
     :return:
-    '''
+    """
     try:
         assert type(socket.getaddrinfo(entity_name, 0, 0, 0, 0)) == list
         ret = True
@@ -247,16 +269,16 @@ def is_reachable_host(entity_name):
 
 
 def is_ip(ip):
-    '''
+    """
     Returns a bool telling if the passed IP is a valid IPv4 or IPv6 address.
-    '''
+    """
     return is_ipv4(ip) or is_ipv6(ip)
 
 
 def is_ipv4(ip):
-    '''
+    """
     Returns a bool telling if the value passed to it was a valid IPv4 address
-    '''
+    """
     try:
         return ipaddress.ip_address(ip).version == 4
     except ValueError:
@@ -264,9 +286,9 @@ def is_ipv4(ip):
 
 
 def is_ipv6(ip):
-    '''
+    """
     Returns a bool telling if the value passed to it was a valid IPv6 address
-    '''
+    """
     try:
         return ipaddress.ip_address(ip).version == 6
     except ValueError:
@@ -274,37 +296,37 @@ def is_ipv6(ip):
 
 
 def is_subnet(cidr):
-    '''
+    """
     Returns a bool telling if the passed string is an IPv4 or IPv6 subnet
-    '''
+    """
     return is_ipv4_subnet(cidr) or is_ipv6_subnet(cidr)
 
 
 def is_ipv4_subnet(cidr):
-    '''
+    """
     Returns a bool telling if the passed string is an IPv4 subnet
-    '''
+    """
     try:
-        return '/' in cidr and bool(ipaddress.IPv4Network(cidr))
+        return "/" in cidr and bool(ipaddress.IPv4Network(cidr))
     except Exception:
         return False
 
 
 def is_ipv6_subnet(cidr):
-    '''
+    """
     Returns a bool telling if the passed string is an IPv6 subnet
-    '''
+    """
     try:
-        return '/' in cidr and bool(ipaddress.IPv6Network(cidr))
+        return "/" in cidr and bool(ipaddress.IPv6Network(cidr))
     except Exception:
         return False
 
 
-@jinja_filter('is_ip')
+@jinja_filter("is_ip")
 def is_ip_filter(ip, options=None):
-    '''
+    """
     Returns a bool telling if the passed IP is a valid IPv4 or IPv6 address.
-    '''
+    """
     return is_ipv4_filter(ip, options=options) or is_ipv6_filter(ip, options=options)
 
 
@@ -346,27 +368,27 @@ def _ip_options(ip_obj, version, options=None):
 
     # will process and IP options
     options_fun_map = {
-        'global': _ip_options_global,
-        'link-local': _ip_options_link_local,
-        'linklocal': _ip_options_link_local,
-        'll': _ip_options_link_local,
-        'link_local': _ip_options_link_local,
-        'loopback': _ip_options_loopback,
-        'lo': _ip_options_loopback,
-        'multicast': _ip_options_multicast,
-        'private': _ip_options_private,
-        'public': _ip_options_global,
-        'reserved': _ip_options_reserved,
-        'site-local': _ip_options_site_local,
-        'sl': _ip_options_site_local,
-        'site_local': _ip_options_site_local,
-        'unspecified': _ip_options_unspecified
+        "global": _ip_options_global,
+        "link-local": _ip_options_link_local,
+        "linklocal": _ip_options_link_local,
+        "ll": _ip_options_link_local,
+        "link_local": _ip_options_link_local,
+        "loopback": _ip_options_loopback,
+        "lo": _ip_options_loopback,
+        "multicast": _ip_options_multicast,
+        "private": _ip_options_private,
+        "public": _ip_options_global,
+        "reserved": _ip_options_reserved,
+        "site-local": _ip_options_site_local,
+        "sl": _ip_options_site_local,
+        "site_local": _ip_options_site_local,
+        "unspecified": _ip_options_unspecified,
     }
 
     if not options:
         return six.text_type(ip_obj)  # IP version already checked
 
-    options_list = [option.strip() for option in options.split(',')]
+    options_list = [option.strip() for option in options.split(",")]
 
     for option, fun in options_fun_map.items():
         if option in options_list:
@@ -403,9 +425,9 @@ def _is_ipv(ip, version, options=None):
     return _ip_options(ip_obj, version, options=options)
 
 
-@jinja_filter('is_ipv4')
+@jinja_filter("is_ipv4")
 def is_ipv4_filter(ip, options=None):
-    '''
+    """
     Returns a bool telling if the value passed to it was a valid IPv4 address.
 
     ip
@@ -416,14 +438,14 @@ def is_ipv4_filter(ip, options=None):
 
     options
         CSV of options regarding the nature of the IP address. E.g.: loopback, multicast, private etc.
-    '''
+    """
     _is_ipv4 = _is_ipv(ip, 4, options=options)
     return isinstance(_is_ipv4, six.string_types)
 
 
-@jinja_filter('is_ipv6')
+@jinja_filter("is_ipv6")
 def is_ipv6_filter(ip, options=None):
-    '''
+    """
     Returns a bool telling if the value passed to it was a valid IPv6 address.
 
     ip
@@ -434,7 +456,7 @@ def is_ipv6_filter(ip, options=None):
 
     options
         CSV of options regarding the nature of the IP address. E.g.: loopback, multicast, private etc.
-    '''
+    """
     _is_ipv6 = _is_ipv(ip, 6, options=options)
     return isinstance(_is_ipv6, six.string_types)
 
@@ -457,27 +479,27 @@ def _ipv_filter(value, version, options=None):
     return None
 
 
-@jinja_filter('ipv4')
+@jinja_filter("ipv4")
 def ipv4(value, options=None):
-    '''
+    """
     Filters a list and returns IPv4 values only.
-    '''
+    """
     return _ipv_filter(value, 4, options=options)
 
 
-@jinja_filter('ipv6')
+@jinja_filter("ipv6")
 def ipv6(value, options=None):
-    '''
+    """
     Filters a list and returns IPv6 values only.
-    '''
+    """
     return _ipv_filter(value, 6, options=options)
 
 
-@jinja_filter('ipaddr')
+@jinja_filter("ipaddr")
 def ipaddr(value, options=None):
-    '''
+    """
     Filters and returns only valid IP objects.
-    '''
+    """
     ipv4_obj = ipv4(value, options=options)
     ipv6_obj = ipv6(value, options=options)
     if ipv4_obj is None or ipv6_obj is None:
@@ -505,11 +527,11 @@ def _filter_ipaddr(value, options, version=None):
     return ipaddr_filter_out
 
 
-@jinja_filter('ip_host')
+@jinja_filter("ip_host")
 def ip_host(value, options=None, version=None):
-    '''
+    """
     Returns the interfaces IP address, e.g.: 192.168.0.1/28.
-    '''
+    """
     ipaddr_filter_out = _filter_ipaddr(value, options=options, version=version)
     if not ipaddr_filter_out:
         return
@@ -519,219 +541,206 @@ def ip_host(value, options=None, version=None):
 
 
 def _network_hosts(ip_addr_entry):
-    return [
-        six.text_type(host)
-        for host in ipaddress.ip_network(ip_addr_entry, strict=False).hosts()
-    ]
+    return [six.text_type(host) for host in ipaddress.ip_network(ip_addr_entry, strict=False).hosts()]
 
 
-@jinja_filter('network_hosts')
+@jinja_filter("network_hosts")
 def network_hosts(value, options=None, version=None):
-    '''
+    """
     Return the list of hosts within a network.
 
     .. note::
 
         When running this command with a large IPv6 network, the command will
         take a long time to gather all of the hosts.
-    '''
+    """
     ipaddr_filter_out = _filter_ipaddr(value, options=options, version=version)
     if not ipaddr_filter_out:
         return
     if not isinstance(value, (list, tuple, types.GeneratorType)):
         return _network_hosts(ipaddr_filter_out[0])
-    return [
-        _network_hosts(ip_a)
-        for ip_a in ipaddr_filter_out
-    ]
+    return [_network_hosts(ip_a) for ip_a in ipaddr_filter_out]
 
 
 def _network_size(ip_addr_entry):
     return ipaddress.ip_network(ip_addr_entry, strict=False).num_addresses
 
 
-@jinja_filter('network_size')
+@jinja_filter("network_size")
 def network_size(value, options=None, version=None):
-    '''
+    """
     Get the size of a network.
-    '''
+    """
     ipaddr_filter_out = _filter_ipaddr(value, options=options, version=version)
     if not ipaddr_filter_out:
         return
     if not isinstance(value, (list, tuple, types.GeneratorType)):
         return _network_size(ipaddr_filter_out[0])
-    return [
-        _network_size(ip_a)
-        for ip_a in ipaddr_filter_out
-    ]
+    return [_network_size(ip_a) for ip_a in ipaddr_filter_out]
 
 
-def natural_ipv4_netmask(ip, fmt='prefixlen'):
-    '''
+def natural_ipv4_netmask(ip, fmt="prefixlen"):
+    """
     Returns the "natural" mask of an IPv4 address
-    '''
+    """
     bits = _ipv4_to_bits(ip)
 
-    if bits.startswith('11'):
-        mask = '24'
-    elif bits.startswith('1'):
-        mask = '16'
+    if bits.startswith("11"):
+        mask = "24"
+    elif bits.startswith("1"):
+        mask = "16"
     else:
-        mask = '8'
+        mask = "8"
 
-    if fmt == 'netmask':
+    if fmt == "netmask":
         return cidr_to_ipv4_netmask(mask)
     else:
-        return '/' + mask
+        return "/" + mask
 
 
 def rpad_ipv4_network(ip):
-    '''
+    """
     Returns an IP network address padded with zeros.
 
     Ex: '192.168.3' -> '192.168.3.0'
         '10.209' -> '10.209.0.0'
-    '''
-    return '.'.join(itertools.islice(itertools.chain(ip.split('.'), '0000'), 0,
-                                     4))
+    """
+    return ".".join(itertools.islice(itertools.chain(ip.split("."), "0000"), 0, 4))
 
 
 def cidr_to_ipv4_netmask(cidr_bits):
-    '''
+    """
     Returns an IPv4 netmask
-    '''
+    """
     try:
         cidr_bits = int(cidr_bits)
         if not 1 <= cidr_bits <= 32:
-            return ''
+            return ""
     except ValueError:
-        return ''
+        return ""
 
-    netmask = ''
+    netmask = ""
     for idx in range(4):
         if idx:
-            netmask += '.'
+            netmask += "."
         if cidr_bits >= 8:
-            netmask += '255'
+            netmask += "255"
             cidr_bits -= 8
         else:
-            netmask += '{0:d}'.format(256 - (2 ** (8 - cidr_bits)))
+            netmask += "{0:d}".format(256 - (2 ** (8 - cidr_bits)))
             cidr_bits = 0
     return netmask
 
 
 def _number_of_set_bits_to_ipv4_netmask(set_bits):  # pylint: disable=C0103
-    '''
+    """
     Returns an IPv4 netmask from the integer representation of that mask.
 
     Ex. 0xffffff00 -> '255.255.255.0'
-    '''
+    """
     return cidr_to_ipv4_netmask(_number_of_set_bits(set_bits))
 
 
 # pylint: disable=C0103
 def _number_of_set_bits(x):
-    '''
+    """
     Returns the number of bits that are set in a 32bit int
-    '''
+    """
     # Taken from http://stackoverflow.com/a/4912729. Many thanks!
     x -= (x >> 1) & 0x55555555
     x = ((x >> 2) & 0x33333333) + (x & 0x33333333)
-    x = ((x >> 4) + x) & 0x0f0f0f0f
+    x = ((x >> 4) + x) & 0x0F0F0F0F
     x += x >> 8
     x += x >> 16
-    return x & 0x0000003f
+    return x & 0x0000003F
+
 
 # pylint: enable=C0103
 
 
 def _interfaces_ip(out):
-    '''
+    """
     Uses ip to return a dictionary of interfaces with various information about
     each (up/down state, ip address, netmask, and hwaddr)
-    '''
+    """
     ret = dict()
 
     def parse_network(value, cols):
-        '''
+        """
         Return a tuple of ip, netmask, broadcast
         based on the current set of cols
-        '''
+        """
         brd = None
         scope = None
-        if '/' in value:  # we have a CIDR in this address
-            ip, cidr = value.split('/')  # pylint: disable=C0103
+        if "/" in value:  # we have a CIDR in this address
+            ip, cidr = value.split("/")  # pylint: disable=C0103
         else:
             ip = value  # pylint: disable=C0103
             cidr = 32
 
-        if type_ == 'inet':
+        if type_ == "inet":
             mask = cidr_to_ipv4_netmask(int(cidr))
-            if 'brd' in cols:
-                brd = cols[cols.index('brd') + 1]
-        elif type_ == 'inet6':
+            if "brd" in cols:
+                brd = cols[cols.index("brd") + 1]
+        elif type_ == "inet6":
             mask = cidr
-            if 'scope' in cols:
-                scope = cols[cols.index('scope') + 1]
+            if "scope" in cols:
+                scope = cols[cols.index("scope") + 1]
         return (ip, mask, brd, scope)
 
-    groups = re.compile('\r?\n\\d').split(out)
+    groups = re.compile("\r?\n\\d").split(out)
     for group in groups:
         iface = None
         data = dict()
 
         for line in group.splitlines():
-            if ' ' not in line:
+            if " " not in line:
                 continue
-            match = re.match(r'^\d*:\s+([\w.\-]+)(?:@)?([\w.\-]+)?:\s+<(.+)>', line)
+            match = re.match(r"^\d*:\s+([\w.\-]+)(?:@)?([\w.\-]+)?:\s+<(.+)>", line)
             if match:
                 iface, parent, attrs = match.groups()
-                if 'UP' in attrs.split(','):
-                    data['up'] = True
+                if "UP" in attrs.split(","):
+                    data["up"] = True
                 else:
-                    data['up'] = False
+                    data["up"] = False
                 if parent:
-                    data['parent'] = parent
+                    data["parent"] = parent
                 continue
 
             cols = line.split()
             if len(cols) >= 2:
                 type_, value = tuple(cols[0:2])
                 iflabel = cols[-1:][0]
-                if type_ in ('inet', 'inet6'):
-                    if 'secondary' not in cols:
+                if type_ in ("inet", "inet6"):
+                    if "secondary" not in cols:
                         ipaddr, netmask, broadcast, scope = parse_network(value, cols)
-                        if type_ == 'inet':
-                            if 'inet' not in data:
-                                data['inet'] = list()
+                        if type_ == "inet":
+                            if "inet" not in data:
+                                data["inet"] = list()
                             addr_obj = dict()
-                            addr_obj['address'] = ipaddr
-                            addr_obj['netmask'] = netmask
-                            addr_obj['broadcast'] = broadcast
-                            addr_obj['label'] = iflabel
-                            data['inet'].append(addr_obj)
-                        elif type_ == 'inet6':
-                            if 'inet6' not in data:
-                                data['inet6'] = list()
+                            addr_obj["address"] = ipaddr
+                            addr_obj["netmask"] = netmask
+                            addr_obj["broadcast"] = broadcast
+                            addr_obj["label"] = iflabel
+                            data["inet"].append(addr_obj)
+                        elif type_ == "inet6":
+                            if "inet6" not in data:
+                                data["inet6"] = list()
                             addr_obj = dict()
-                            addr_obj['address'] = ipaddr
-                            addr_obj['prefixlen'] = netmask
-                            addr_obj['scope'] = scope
-                            data['inet6'].append(addr_obj)
+                            addr_obj["address"] = ipaddr
+                            addr_obj["prefixlen"] = netmask
+                            addr_obj["scope"] = scope
+                            data["inet6"].append(addr_obj)
                     else:
-                        if 'secondary' not in data:
-                            data['secondary'] = list()
+                        if "secondary" not in data:
+                            data["secondary"] = list()
                         ip_, mask, brd, scp = parse_network(value, cols)
-                        data['secondary'].append({
-                            'type': type_,
-                            'address': ip_,
-                            'netmask': mask,
-                            'broadcast': brd,
-                            'label': iflabel,
-                        })
+                        data["secondary"].append(
+                            {"type": type_, "address": ip_, "netmask": mask, "broadcast": brd, "label": iflabel}
+                        )
                         del ip_, mask, brd, scp
-                elif type_.startswith('link'):
-                    data['hwaddr'] = value
+                elif type_.startswith("link"):
+                    data["hwaddr"] = value
         if iface:
             ret[iface] = data
             del iface, data
@@ -739,30 +748,32 @@ def _interfaces_ip(out):
 
 
 def _interfaces_ifconfig(out):
-    '''
+    """
     Uses ifconfig to return a dictionary of interfaces with various information
     about each (up/down state, ip address, netmask, and hwaddr)
-    '''
+    """
     ret = dict()
 
-    piface = re.compile(r'^([^\s:]+)')
-    pmac = re.compile('.*?(?:HWaddr|ether|address:|lladdr) ([0-9a-fA-F:]+)')
+    piface = re.compile(r"^([^\s:]+)")
+    pmac = re.compile(".*?(?:HWaddr|ether|address:|lladdr) ([0-9a-fA-F:]+)")
     if salt.utils.platform.is_sunos():
-        pip = re.compile(r'.*?(?:inet\s+)([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)(.*)')
-        pip6 = re.compile('.*?(?:inet6 )([0-9a-fA-F:]+)')
-        pmask6 = re.compile(r'.*?(?:inet6 [0-9a-fA-F:]+/(\d+)).*')
+        pip = re.compile(r".*?(?:inet\s+)([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)(.*)")
+        pip6 = re.compile(".*?(?:inet6 )([0-9a-fA-F:]+)")
+        pmask6 = re.compile(r".*?(?:inet6 [0-9a-fA-F:]+/(\d+)).*")
     else:
-        pip = re.compile(r'.*?(?:inet addr:|inet [^\d]*)(.*?)\s')
-        pip6 = re.compile('.*?(?:inet6 addr: (.*?)/|inet6 )([0-9a-fA-F:]+)')
-        pmask6 = re.compile(r'.*?(?:inet6 addr: [0-9a-fA-F:]+/(\d+)|prefixlen (\d+))(?: Scope:([a-zA-Z]+)| scopeid (0x[0-9a-fA-F]))?')
-    pmask = re.compile(r'.*?(?:Mask:|netmask )(?:((?:0x)?[0-9a-fA-F]{8})|([\d\.]+))')
-    pupdown = re.compile('UP')
-    pbcast = re.compile(r'.*?(?:Bcast:|broadcast )([\d\.]+)')
+        pip = re.compile(r".*?(?:inet addr:|inet [^\d]*)(.*?)\s")
+        pip6 = re.compile(".*?(?:inet6 addr: (.*?)/|inet6 )([0-9a-fA-F:]+)")
+        pmask6 = re.compile(
+            r".*?(?:inet6 addr: [0-9a-fA-F:]+/(\d+)|prefixlen (\d+))(?: Scope:([a-zA-Z]+)| scopeid (0x[0-9a-fA-F]))?"
+        )
+    pmask = re.compile(r".*?(?:Mask:|netmask )(?:((?:0x)?[0-9a-fA-F]{8})|([\d\.]+))")
+    pupdown = re.compile("UP")
+    pbcast = re.compile(r".*?(?:Bcast:|broadcast )([\d\.]+)")
 
-    groups = re.compile('\r?\n(?=\\S)').split(out)
+    groups = re.compile("\r?\n(?=\\S)").split(out)
     for group in groups:
         data = dict()
-        iface = ''
+        iface = ""
         updown = False
         for line in group.splitlines():
             miface = piface.match(line)
@@ -773,48 +784,45 @@ def _interfaces_ifconfig(out):
             if miface:
                 iface = miface.group(1)
             if mmac:
-                data['hwaddr'] = mmac.group(1)
+                data["hwaddr"] = mmac.group(1)
                 if salt.utils.platform.is_sunos():
                     expand_mac = []
-                    for chunk in data['hwaddr'].split(':'):
-                        expand_mac.append('0{0}'.format(chunk) if len(chunk) < 2 else '{0}'.format(chunk))
-                    data['hwaddr'] = ':'.join(expand_mac)
+                    for chunk in data["hwaddr"].split(":"):
+                        expand_mac.append("0{0}".format(chunk) if len(chunk) < 2 else "{0}".format(chunk))
+                    data["hwaddr"] = ":".join(expand_mac)
             if mip:
-                if 'inet' not in data:
-                    data['inet'] = list()
+                if "inet" not in data:
+                    data["inet"] = list()
                 addr_obj = dict()
-                addr_obj['address'] = mip.group(1)
+                addr_obj["address"] = mip.group(1)
                 mmask = pmask.match(line)
                 if mmask:
                     if mmask.group(1):
-                        mmask = _number_of_set_bits_to_ipv4_netmask(
-                            int(mmask.group(1), 16))
+                        mmask = _number_of_set_bits_to_ipv4_netmask(int(mmask.group(1), 16))
                     else:
                         mmask = mmask.group(2)
-                    addr_obj['netmask'] = mmask
+                    addr_obj["netmask"] = mmask
                 mbcast = pbcast.match(line)
                 if mbcast:
-                    addr_obj['broadcast'] = mbcast.group(1)
-                data['inet'].append(addr_obj)
+                    addr_obj["broadcast"] = mbcast.group(1)
+                data["inet"].append(addr_obj)
             if mupdown:
                 updown = True
             if mip6:
-                if 'inet6' not in data:
-                    data['inet6'] = list()
+                if "inet6" not in data:
+                    data["inet6"] = list()
                 addr_obj = dict()
-                addr_obj['address'] = mip6.group(1) or mip6.group(2)
+                addr_obj["address"] = mip6.group(1) or mip6.group(2)
                 mmask6 = pmask6.match(line)
                 if mmask6:
-                    addr_obj['prefixlen'] = mmask6.group(1) or mmask6.group(2)
+                    addr_obj["prefixlen"] = mmask6.group(1) or mmask6.group(2)
                     if not salt.utils.platform.is_sunos():
                         ipv6scope = mmask6.group(3) or mmask6.group(4)
-                        addr_obj['scope'] = ipv6scope.lower() if ipv6scope is not None else ipv6scope
+                        addr_obj["scope"] = ipv6scope.lower() if ipv6scope is not None else ipv6scope
                 # SunOS sometimes has ::/0 as inet6 addr when using addrconf
-                if not salt.utils.platform.is_sunos() \
-                        or addr_obj['address'] != '::' \
-                        and addr_obj['prefixlen'] != 0:
-                    data['inet6'].append(addr_obj)
-        data['up'] = updown
+                if not salt.utils.platform.is_sunos() or addr_obj["address"] != "::" and addr_obj["prefixlen"] != 0:
+                    data["inet6"].append(addr_obj)
+        data["up"] = updown
         if iface in ret:
             # SunOS optimization, where interfaces occur twice in 'ifconfig -a'
             # output with the same name: for ipv4 and then for ipv6 addr family.
@@ -824,10 +832,10 @@ def _interfaces_ifconfig(out):
             # merge items with higher priority for older values
             # after that merge the inet and inet6 sub items for both
             ret[iface] = dict(list(data.items()) + list(ret[iface].items()))
-            if 'inet' in data:
-                ret[iface]['inet'].extend(x for x in data['inet'] if x not in ret[iface]['inet'])
-            if 'inet6' in data:
-                ret[iface]['inet6'].extend(x for x in data['inet6'] if x not in ret[iface]['inet6'])
+            if "inet" in data:
+                ret[iface]["inet"].extend(x for x in data["inet"] if x not in ret[iface]["inet"])
+            if "inet6" in data:
+                ret[iface]["inet6"].extend(x for x in data["inet6"] if x not in ret[iface]["inet6"])
         else:
             ret[iface] = data
         del data
@@ -835,58 +843,58 @@ def _interfaces_ifconfig(out):
 
 
 def linux_interfaces():
-    '''
+    """
     Obtain interface information for *NIX/BSD variants
-    '''
+    """
     ifaces = dict()
-    ip_path = salt.utils.path.which('ip')
-    ifconfig_path = None if ip_path else salt.utils.path.which('ifconfig')
+    ip_path = salt.utils.path.which("ip")
+    ifconfig_path = None if ip_path else salt.utils.path.which("ifconfig")
     if ip_path:
         cmd1 = subprocess.Popen(
-            '{0} link show'.format(ip_path),
+            "{0} link show".format(ip_path),
             shell=True,
             close_fds=True,
             stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT).communicate()[0]
+            stderr=subprocess.STDOUT,
+        ).communicate()[0]
         cmd2 = subprocess.Popen(
-            '{0} addr show'.format(ip_path),
+            "{0} addr show".format(ip_path),
             shell=True,
             close_fds=True,
             stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT).communicate()[0]
-        ifaces = _interfaces_ip("{0}\n{1}".format(
-            salt.utils.stringutils.to_str(cmd1),
-            salt.utils.stringutils.to_str(cmd2)))
+            stderr=subprocess.STDOUT,
+        ).communicate()[0]
+        ifaces = _interfaces_ip(
+            "{0}\n{1}".format(salt.utils.stringutils.to_str(cmd1), salt.utils.stringutils.to_str(cmd2))
+        )
     elif ifconfig_path:
         cmd = subprocess.Popen(
-            '{0} -a'.format(ifconfig_path),
-            shell=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT).communicate()[0]
+            "{0} -a".format(ifconfig_path), shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
+        ).communicate()[0]
         ifaces = _interfaces_ifconfig(salt.utils.stringutils.to_str(cmd))
     return ifaces
 
 
 def _netbsd_interfaces_ifconfig(out):
-    '''
+    """
     Uses ifconfig to return a dictionary of interfaces with various information
     about each (up/down state, ip address, netmask, and hwaddr)
-    '''
+    """
     ret = dict()
 
-    piface = re.compile(r'^([^\s:]+)')
-    pmac = re.compile('.*?address: ([0-9a-f:]+)')
+    piface = re.compile(r"^([^\s:]+)")
+    pmac = re.compile(".*?address: ([0-9a-f:]+)")
 
-    pip = re.compile(r'.*?inet [^\d]*(.*?)/([\d]*)\s')
-    pip6 = re.compile(r'.*?inet6 ([0-9a-f:]+)%([a-zA-Z0-9]*)/([\d]*)\s')
+    pip = re.compile(r".*?inet [^\d]*(.*?)/([\d]*)\s")
+    pip6 = re.compile(r".*?inet6 ([0-9a-f:]+)%([a-zA-Z0-9]*)/([\d]*)\s")
 
-    pupdown = re.compile('UP')
-    pbcast = re.compile(r'.*?broadcast ([\d\.]+)')
+    pupdown = re.compile("UP")
+    pbcast = re.compile(r".*?broadcast ([\d\.]+)")
 
-    groups = re.compile('\r?\n(?=\\S)').split(out)
+    groups = re.compile("\r?\n(?=\\S)").split(out)
     for group in groups:
         data = dict()
-        iface = ''
+        iface = ""
         updown = False
         for line in group.splitlines():
             miface = piface.match(line)
@@ -897,154 +905,152 @@ def _netbsd_interfaces_ifconfig(out):
             if miface:
                 iface = miface.group(1)
             if mmac:
-                data['hwaddr'] = mmac.group(1)
+                data["hwaddr"] = mmac.group(1)
             if mip:
-                if 'inet' not in data:
-                    data['inet'] = list()
+                if "inet" not in data:
+                    data["inet"] = list()
                 addr_obj = dict()
-                addr_obj['address'] = mip.group(1)
+                addr_obj["address"] = mip.group(1)
                 mmask = mip.group(2)
                 if mip.group(2):
-                    addr_obj['netmask'] = cidr_to_ipv4_netmask(mip.group(2))
+                    addr_obj["netmask"] = cidr_to_ipv4_netmask(mip.group(2))
                 mbcast = pbcast.match(line)
                 if mbcast:
-                    addr_obj['broadcast'] = mbcast.group(1)
-                data['inet'].append(addr_obj)
+                    addr_obj["broadcast"] = mbcast.group(1)
+                data["inet"].append(addr_obj)
             if mupdown:
                 updown = True
             if mip6:
-                if 'inet6' not in data:
-                    data['inet6'] = list()
+                if "inet6" not in data:
+                    data["inet6"] = list()
                 addr_obj = dict()
-                addr_obj['address'] = mip6.group(1)
+                addr_obj["address"] = mip6.group(1)
                 mmask6 = mip6.group(3)
-                addr_obj['scope'] = mip6.group(2)
-                addr_obj['prefixlen'] = mip6.group(3)
-                data['inet6'].append(addr_obj)
-        data['up'] = updown
+                addr_obj["scope"] = mip6.group(2)
+                addr_obj["prefixlen"] = mip6.group(3)
+                data["inet6"].append(addr_obj)
+        data["up"] = updown
         ret[iface] = data
         del data
     return ret
 
 
 def netbsd_interfaces():
-    '''
+    """
     Obtain interface information for NetBSD >= 8 where the ifconfig
     output diverged from other BSD variants (Netmask is now part of the
     address)
-    '''
+    """
     # NetBSD versions prior to 8.0 can still use linux_interfaces()
-    if LooseVersion(os.uname()[2]) < LooseVersion('8.0'):
+    if LooseVersion(os.uname()[2]) < LooseVersion("8.0"):
         return linux_interfaces()
 
-    ifconfig_path = salt.utils.path.which('ifconfig')
+    ifconfig_path = salt.utils.path.which("ifconfig")
     cmd = subprocess.Popen(
-        '{0} -a'.format(ifconfig_path),
-        shell=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT).communicate()[0]
+        "{0} -a".format(ifconfig_path), shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
+    ).communicate()[0]
     return _netbsd_interfaces_ifconfig(salt.utils.stringutils.to_str(cmd))
 
 
 def _interfaces_ipconfig(out):
-    '''
+    """
     Returns a dictionary of interfaces with various information about each
     (up/down state, ip address, netmask, and hwaddr)
 
     NOTE: This is not used by any function and may be able to be removed in the
     future.
-    '''
+    """
     ifaces = dict()
     iface = None
-    adapter_iface_regex = re.compile(r'adapter (\S.+):$')
+    adapter_iface_regex = re.compile(r"adapter (\S.+):$")
 
     for line in out.splitlines():
         if not line:
             continue
         # TODO what does Windows call Infiniband and 10/40gige adapters
-        if line.startswith('Ethernet'):
+        if line.startswith("Ethernet"):
             iface = ifaces[adapter_iface_regex.search(line).group(1)]
-            iface['up'] = True
+            iface["up"] = True
             addr = None
             continue
         if iface:
-            key, val = line.split(',', 1)
-            key = key.strip(' .')
+            key, val = line.split(",", 1)
+            key = key.strip(" .")
             val = val.strip()
-            if addr and key == 'Subnet Mask':
-                addr['netmask'] = val
-            elif key in ('IP Address', 'IPv4 Address'):
-                if 'inet' not in iface:
-                    iface['inet'] = list()
-                addr = {'address': val.rstrip('(Preferred)'),
-                        'netmask': None,
-                        'broadcast': None}  # TODO find the broadcast
-                iface['inet'].append(addr)
-            elif 'IPv6 Address' in key:
-                if 'inet6' not in iface:
-                    iface['inet'] = list()
+            if addr and key == "Subnet Mask":
+                addr["netmask"] = val
+            elif key in ("IP Address", "IPv4 Address"):
+                if "inet" not in iface:
+                    iface["inet"] = list()
+                addr = {
+                    "address": val.rstrip("(Preferred)"),
+                    "netmask": None,
+                    "broadcast": None,
+                }  # TODO find the broadcast
+                iface["inet"].append(addr)
+            elif "IPv6 Address" in key:
+                if "inet6" not in iface:
+                    iface["inet"] = list()
                 # XXX What is the prefixlen!?
-                addr = {'address': val.rstrip('(Preferred)'),
-                        'prefixlen': None}
-                iface['inet6'].append(addr)
-            elif key == 'Physical Address':
-                iface['hwaddr'] = val
-            elif key == 'Media State':
+                addr = {"address": val.rstrip("(Preferred)"), "prefixlen": None}
+                iface["inet6"].append(addr)
+            elif key == "Physical Address":
+                iface["hwaddr"] = val
+            elif key == "Media State":
                 # XXX seen used for tunnel adaptors
                 # might be useful
-                iface['up'] = (val != 'Media disconnected')
+                iface["up"] = val != "Media disconnected"
 
 
 def win_interfaces():
-    '''
+    """
     Obtain interface information for Windows systems
-    '''
+    """
     with salt.utils.winapi.Com():
         c = wmi.WMI()
         ifaces = {}
         for iface in c.Win32_NetworkAdapterConfiguration(IPEnabled=1):
             ifaces[iface.Description] = dict()
             if iface.MACAddress:
-                ifaces[iface.Description]['hwaddr'] = iface.MACAddress
+                ifaces[iface.Description]["hwaddr"] = iface.MACAddress
             if iface.IPEnabled:
-                ifaces[iface.Description]['up'] = True
+                ifaces[iface.Description]["up"] = True
                 for ip in iface.IPAddress:
-                    if '.' in ip:
-                        if 'inet' not in ifaces[iface.Description]:
-                            ifaces[iface.Description]['inet'] = []
-                        item = {'address': ip,
-                                'label': iface.Description}
+                    if "." in ip:
+                        if "inet" not in ifaces[iface.Description]:
+                            ifaces[iface.Description]["inet"] = []
+                        item = {"address": ip, "label": iface.Description}
                         if iface.DefaultIPGateway:
-                            broadcast = next((i for i in iface.DefaultIPGateway if '.' in i), '')
+                            broadcast = next((i for i in iface.DefaultIPGateway if "." in i), "")
                             if broadcast:
-                                item['broadcast'] = broadcast
+                                item["broadcast"] = broadcast
                         if iface.IPSubnet:
-                            netmask = next((i for i in iface.IPSubnet if '.' in i), '')
+                            netmask = next((i for i in iface.IPSubnet if "." in i), "")
                             if netmask:
-                                item['netmask'] = netmask
-                        ifaces[iface.Description]['inet'].append(item)
-                    if ':' in ip:
-                        if 'inet6' not in ifaces[iface.Description]:
-                            ifaces[iface.Description]['inet6'] = []
-                        item = {'address': ip}
+                                item["netmask"] = netmask
+                        ifaces[iface.Description]["inet"].append(item)
+                    if ":" in ip:
+                        if "inet6" not in ifaces[iface.Description]:
+                            ifaces[iface.Description]["inet6"] = []
+                        item = {"address": ip}
                         if iface.DefaultIPGateway:
-                            broadcast = next((i for i in iface.DefaultIPGateway if ':' in i), '')
+                            broadcast = next((i for i in iface.DefaultIPGateway if ":" in i), "")
                             if broadcast:
-                                item['broadcast'] = broadcast
+                                item["broadcast"] = broadcast
                         if iface.IPSubnet:
-                            netmask = next((i for i in iface.IPSubnet if ':' in i), '')
+                            netmask = next((i for i in iface.IPSubnet if ":" in i), "")
                             if netmask:
-                                item['netmask'] = netmask
-                        ifaces[iface.Description]['inet6'].append(item)
+                                item["netmask"] = netmask
+                        ifaces[iface.Description]["inet6"].append(item)
             else:
-                ifaces[iface.Description]['up'] = False
+                ifaces[iface.Description]["up"] = False
     return ifaces
 
 
 def interfaces():
-    '''
+    """
     Return a dictionary of information about all the interfaces on the minion
-    '''
+    """
     if salt.utils.platform.is_windows():
         return win_interfaces()
     elif salt.utils.platform.is_netbsd():
@@ -1054,130 +1060,132 @@ def interfaces():
 
 
 def get_net_start(ipaddr, netmask):
-    '''
+    """
     Return the address of the network
-    '''
-    net = ipaddress.ip_network('{0}/{1}'.format(ipaddr, netmask), strict=False)
+    """
+    net = ipaddress.ip_network("{0}/{1}".format(ipaddr, netmask), strict=False)
     return six.text_type(net.network_address)
 
 
 def get_net_size(mask):
-    '''
+    """
     Turns an IPv4 netmask into it's corresponding prefix length
     (255.255.255.0 -> 24 as in 192.168.1.10/24).
-    '''
-    binary_str = ''
-    for octet in mask.split('.'):
+    """
+    binary_str = ""
+    for octet in mask.split("."):
         binary_str += bin(int(octet))[2:].zfill(8)
-    return len(binary_str.rstrip('0'))
+    return len(binary_str.rstrip("0"))
 
 
 def calc_net(ipaddr, netmask=None):
-    '''
+    """
     Takes IP (CIDR notation supported) and optionally netmask
     and returns the network in CIDR-notation.
     (The IP can be any IP inside the subnet)
-    '''
+    """
     if netmask is not None:
-        ipaddr = '{0}/{1}'.format(ipaddr, netmask)
+        ipaddr = "{0}/{1}".format(ipaddr, netmask)
 
     return six.text_type(ipaddress.ip_network(ipaddr, strict=False))
 
 
 def _ipv4_to_bits(ipaddr):
-    '''
+    """
     Accepts an IPv4 dotted quad and returns a string representing its binary
     counterpart
-    '''
-    return ''.join([bin(int(x))[2:].rjust(8, '0') for x in ipaddr.split('.')])
+    """
+    return "".join([bin(int(x))[2:].rjust(8, "0") for x in ipaddr.split(".")])
 
 
 def _get_iface_info(iface):
-    '''
+    """
     If `iface` is available, return interface info and no error, otherwise
     return no info and log and return an error
-    '''
+    """
     iface_info = interfaces()
 
     if iface in iface_info.keys():
         return iface_info, False
     else:
-        error_msg = ('Interface "{0}" not in available interfaces: "{1}"'
-                     ''.format(iface, '", "'.join(iface_info.keys())))
+        error_msg = 'Interface "{0}" not in available interfaces: "{1}"' "".format(
+            iface, '", "'.join(iface_info.keys())
+        )
         log.error(error_msg)
         return None, error_msg
 
 
 def _hw_addr_aix(iface):
-    '''
+    """
     Return the hardware address (a.k.a. MAC address) for a given interface on AIX
     MAC address not available in through interfaces
-    '''
+    """
     cmd = subprocess.Popen(
-        'entstat -d {0} | grep \'Hardware Address\''.format(iface),
+        "entstat -d {0} | grep 'Hardware Address'".format(iface),
         shell=True,
         stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT).communicate()[0]
+        stderr=subprocess.STDOUT,
+    ).communicate()[0]
 
     if cmd:
-        comps = cmd.split(' ')
+        comps = cmd.split(" ")
         if len(comps) == 3:
-            mac_addr = comps[2].strip('\'').strip()
+            mac_addr = comps[2].strip("'").strip()
             return mac_addr
 
-    error_msg = ('Interface "{0}" either not available or does not contain a hardware address'.format(iface))
+    error_msg = 'Interface "{0}" either not available or does not contain a hardware address'.format(iface)
     log.error(error_msg)
     return error_msg
 
 
 def hw_addr(iface):
-    '''
+    """
     Return the hardware address (a.k.a. MAC address) for a given interface
 
     .. versionchanged:: 2016.11.4
         Added support for AIX
 
-    '''
+    """
     if salt.utils.platform.is_aix():
         return _hw_addr_aix
 
     iface_info, error = _get_iface_info(iface)
 
     if error is False:
-        return iface_info.get(iface, {}).get('hwaddr', '')
+        return iface_info.get(iface, {}).get("hwaddr", "")
     else:
         return error
 
 
 def interface(iface):
-    '''
+    """
     Return the details of `iface` or an error if it does not exist
-    '''
+    """
     iface_info, error = _get_iface_info(iface)
 
     if error is False:
-        return iface_info.get(iface, {}).get('inet', '')
+        return iface_info.get(iface, {}).get("inet", "")
     else:
         return error
 
 
 def interface_ip(iface):
-    '''
+    """
     Return `iface` IPv4 addr or an error if `iface` does not exist
-    '''
+    """
     iface_info, error = _get_iface_info(iface)
 
     if error is False:
-        inet = iface_info.get(iface, {}).get('inet', None)
-        return inet[0].get('address', '') if inet else ''
+        inet = iface_info.get(iface, {}).get("inet", None)
+        return inet[0].get("address", "") if inet else ""
     else:
         return error
 
 
-def _subnets(proto='inet', interfaces_=None):
-    '''
+def _subnets(proto="inet", interfaces_=None):
+    """
     Returns a list of subnets to which the host belongs
-    '''
+    """
     if interfaces_ is None:
         ifaces = interfaces()
     elif isinstance(interfaces_, list):
@@ -1190,52 +1198,52 @@ def _subnets(proto='inet', interfaces_=None):
 
     ret = set()
 
-    if proto == 'inet':
-        subnet = 'netmask'
+    if proto == "inet":
+        subnet = "netmask"
         dflt_cidr = 32
-    elif proto == 'inet6':
-        subnet = 'prefixlen'
+    elif proto == "inet6":
+        subnet = "prefixlen"
         dflt_cidr = 128
     else:
-        log.error('Invalid proto {0} calling subnets()'.format(proto))
+        log.error("Invalid proto {0} calling subnets()".format(proto))
         return
 
     for ip_info in six.itervalues(ifaces):
         addrs = ip_info.get(proto, [])
-        addrs.extend([addr for addr in ip_info.get('secondary', []) if addr.get('type') == proto])
+        addrs.extend([addr for addr in ip_info.get("secondary", []) if addr.get("type") == proto])
 
         for intf in addrs:
             if subnet in intf:
-                intf = ipaddress.ip_interface('{0}/{1}'.format(intf['address'], intf[subnet]))
+                intf = ipaddress.ip_interface("{0}/{1}".format(intf["address"], intf[subnet]))
             else:
-                intf = ipaddress.ip_interface('{0}/{1}'.format(intf['address'], dflt_cidr))
+                intf = ipaddress.ip_interface("{0}/{1}".format(intf["address"], dflt_cidr))
             if not intf.is_loopback:
                 ret.add(intf.network)
     return [six.text_type(net) for net in sorted(ret)]
 
 
 def subnets(interfaces=None):
-    '''
+    """
     Returns a list of IPv4 subnets to which the host belongs
-    '''
-    return _subnets('inet', interfaces_=interfaces)
+    """
+    return _subnets("inet", interfaces_=interfaces)
 
 
 def subnets6():
-    '''
+    """
     Returns a list of IPv6 subnets to which the host belongs
-    '''
-    return _subnets('inet6')
+    """
+    return _subnets("inet6")
 
 
 def in_subnet(cidr, addr=None):
-    '''
+    """
     Returns True if host or (any of) addrs is within specified subnet, otherwise False
-    '''
+    """
     try:
         cidr = ipaddress.ip_network(cidr)
     except ValueError:
-        log.error('Invalid CIDR \'{0}\''.format(cidr))
+        log.error("Invalid CIDR '{0}'".format(cidr))
         return False
 
     if addr is None:
@@ -1250,63 +1258,60 @@ def in_subnet(cidr, addr=None):
     return False
 
 
-def _ip_addrs(interface=None, include_loopback=False, interface_data=None, proto='inet'):
-    '''
+def _ip_addrs(interface=None, include_loopback=False, interface_data=None, proto="inet"):
+    """
     Return the full list of IP adresses matching the criteria
 
     proto = inet|inet6
-    '''
+    """
     ret = set()
 
-    ifaces = interface_data \
-        if isinstance(interface_data, dict) \
-        else interfaces()
+    ifaces = interface_data if isinstance(interface_data, dict) else interfaces()
     if interface is None:
         target_ifaces = ifaces
     else:
-        target_ifaces = dict([(k, v) for k, v in six.iteritems(ifaces)
-                              if k == interface])
+        target_ifaces = dict([(k, v) for k, v in six.iteritems(ifaces) if k == interface])
         if not target_ifaces:
-            log.error('Interface {0} not found.'.format(interface))
+            log.error("Interface {0} not found.".format(interface))
     for ip_info in six.itervalues(target_ifaces):
         addrs = ip_info.get(proto, [])
-        addrs.extend([addr for addr in ip_info.get('secondary', []) if addr.get('type') == proto])
+        addrs.extend([addr for addr in ip_info.get("secondary", []) if addr.get("type") == proto])
 
         for addr in addrs:
-            addr = ipaddress.ip_address(addr.get('address'))
+            addr = ipaddress.ip_address(addr.get("address"))
             if not addr.is_loopback or include_loopback:
                 ret.add(addr)
     return [six.text_type(addr) for addr in sorted(ret)]
 
 
 def ip_addrs(interface=None, include_loopback=False, interface_data=None):
-    '''
+    """
     Returns a list of IPv4 addresses assigned to the host. 127.0.0.1 is
     ignored, unless 'include_loopback=True' is indicated. If 'interface' is
     provided, then only IP addresses from that interface will be returned.
-    '''
-    return _ip_addrs(interface, include_loopback, interface_data, 'inet')
+    """
+    return _ip_addrs(interface, include_loopback, interface_data, "inet")
 
 
 def ip_addrs6(interface=None, include_loopback=False, interface_data=None):
-    '''
+    """
     Returns a list of IPv6 addresses assigned to the host. ::1 is ignored,
     unless 'include_loopback=True' is indicated. If 'interface' is provided,
     then only IP addresses from that interface will be returned.
-    '''
-    return _ip_addrs(interface, include_loopback, interface_data, 'inet6')
+    """
+    return _ip_addrs(interface, include_loopback, interface_data, "inet6")
 
 
 def hex2ip(hex_ip, invert=False):
-    '''
+    """
     Convert a hex string to an ip, if a failure occurs the original hex is
     returned. If 'invert=True' assume that ip from /proc/net/<proto>
-    '''
+    """
     if len(hex_ip) == 32:  # ipv6
         ip = []
         for i in range(0, 32, 8):
-            ip_part = hex_ip[i:i + 8]
-            ip_part = [ip_part[x:x + 2] for x in range(0, 8, 2)]
+            ip_part = hex_ip[i : i + 8]
+            ip_part = [ip_part[x : x + 2] for x in range(0, 8, 2)]
             if invert:
                 ip.append("{0[3]}{0[2]}:{0[1]}{0[0]}".format(ip_part))
             else:
@@ -1314,7 +1319,7 @@ def hex2ip(hex_ip, invert=False):
         try:
             return ipaddress.IPv6Address(":".join(ip)).compressed
         except ipaddress.AddressValueError as ex:
-            log.error('hex2ip - ipv6 address error: {0}'.format(ex))
+            log.error("hex2ip - ipv6 address error: {0}".format(ex))
             return hex_ip
 
     try:
@@ -1322,89 +1327,83 @@ def hex2ip(hex_ip, invert=False):
     except ValueError:
         return hex_ip
     if invert:
-        return '{3}.{2}.{1}.{0}'.format(hip >> 24 & 255,
-                                        hip >> 16 & 255,
-                                        hip >> 8 & 255,
-                                        hip & 255)
-    return '{0}.{1}.{2}.{3}'.format(hip >> 24 & 255,
-                                    hip >> 16 & 255,
-                                    hip >> 8 & 255,
-                                    hip & 255)
+        return "{3}.{2}.{1}.{0}".format(hip >> 24 & 255, hip >> 16 & 255, hip >> 8 & 255, hip & 255)
+    return "{0}.{1}.{2}.{3}".format(hip >> 24 & 255, hip >> 16 & 255, hip >> 8 & 255, hip & 255)
 
 
 def mac2eui64(mac, prefix=None):
-    '''
+    """
     Convert a MAC address to a EUI64 identifier
     or, with prefix provided, a full IPv6 address
-    '''
+    """
     # http://tools.ietf.org/html/rfc4291#section-2.5.1
-    eui64 = re.sub(r'[.:-]', '', mac).lower()
-    eui64 = eui64[0:6] + 'fffe' + eui64[6:]
+    eui64 = re.sub(r"[.:-]", "", mac).lower()
+    eui64 = eui64[0:6] + "fffe" + eui64[6:]
     eui64 = hex(int(eui64[0:2], 16) | 2)[2:].zfill(2) + eui64[2:]
 
     if prefix is None:
-        return ':'.join(re.findall(r'.{4}', eui64))
+        return ":".join(re.findall(r".{4}", eui64))
     else:
         try:
             net = ipaddress.ip_network(prefix, strict=False)
-            euil = int('0x{0}'.format(eui64), 16)
-            return '{0}/{1}'.format(net[euil], net.prefixlen)
+            euil = int("0x{0}".format(eui64), 16)
+            return "{0}/{1}".format(net[euil], net.prefixlen)
         except Exception:
             return
 
 
 def active_tcp():
-    '''
+    """
     Return a dict describing all active tcp connections as quickly as possible
-    '''
+    """
     ret = {}
-    for statf in ['/proc/net/tcp', '/proc/net/tcp6']:
+    for statf in ["/proc/net/tcp", "/proc/net/tcp6"]:
         if os.path.isfile(statf):
-            with salt.utils.files.fopen(statf, 'rb') as fp_:
+            with salt.utils.files.fopen(statf, "rb") as fp_:
                 for line in fp_:
                     line = salt.utils.stringutils.to_unicode(line)
-                    if line.strip().startswith('sl'):
+                    if line.strip().startswith("sl"):
                         continue
                     ret.update(_parse_tcp_line(line))
     return ret
 
 
 def local_port_tcp(port):
-    '''
+    """
     Return a set of remote ip addrs attached to the specified local port
-    '''
-    ret = _remotes_on(port, 'local_port')
+    """
+    ret = _remotes_on(port, "local_port")
     return ret
 
 
 def remote_port_tcp(port):
-    '''
+    """
     Return a set of ip addrs the current host is connected to on given port
-    '''
-    ret = _remotes_on(port, 'remote_port')
+    """
+    ret = _remotes_on(port, "remote_port")
     return ret
 
 
 def _remotes_on(port, which_end):
-    '''
+    """
     Return a set of ip addrs active tcp connections
-    '''
+    """
     port = int(port)
     ret = set()
 
     proc_available = False
-    for statf in ['/proc/net/tcp', '/proc/net/tcp6']:
+    for statf in ["/proc/net/tcp", "/proc/net/tcp6"]:
         if os.path.isfile(statf):
             proc_available = True
-            with salt.utils.files.fopen(statf, 'r') as fp_:
+            with salt.utils.files.fopen(statf, "r") as fp_:
                 for line in fp_:
                     line = salt.utils.stringutils.to_unicode(line)
-                    if line.strip().startswith('sl'):
+                    if line.strip().startswith("sl"):
                         continue
                     iret = _parse_tcp_line(line)
                     sl = next(iter(iret))
                     if iret[sl][which_end] == port:
-                        ret.add(iret[sl]['remote_addr'])
+                        ret.add(iret[sl]["remote_addr"])
 
     if not proc_available:  # Fallback to use OS specific tools
         if salt.utils.platform.is_sunos():
@@ -1426,24 +1425,24 @@ def _remotes_on(port, which_end):
 
 
 def _parse_tcp_line(line):
-    '''
+    """
     Parse a single line from the contents of /proc/net/tcp or /proc/net/tcp6
-    '''
+    """
     ret = {}
     comps = line.strip().split()
-    sl = comps[0].rstrip(':')
+    sl = comps[0].rstrip(":")
     ret[sl] = {}
-    l_addr, l_port = comps[1].split(':')
-    r_addr, r_port = comps[2].split(':')
-    ret[sl]['local_addr'] = hex2ip(l_addr, True)
-    ret[sl]['local_port'] = int(l_port, 16)
-    ret[sl]['remote_addr'] = hex2ip(r_addr, True)
-    ret[sl]['remote_port'] = int(r_port, 16)
+    l_addr, l_port = comps[1].split(":")
+    r_addr, r_port = comps[2].split(":")
+    ret[sl]["local_addr"] = hex2ip(l_addr, True)
+    ret[sl]["local_port"] = int(l_port, 16)
+    ret[sl]["remote_addr"] = hex2ip(r_addr, True)
+    ret[sl]["remote_port"] = int(r_port, 16)
     return ret
 
 
 def _sunos_remotes_on(port, which_end):
-    '''
+    """
     SunOS specific helper function.
     Returns set of ipv4 host addresses of remote established connections
     on local or remote tcp port.
@@ -1456,32 +1455,32 @@ def _sunos_remotes_on(port, which_end):
        -------------------- -------------------- ----- ------ ----- ------ -----------
        10.0.0.101.4505      10.0.0.1.45329       1064800      0 1055864      0 ESTABLISHED
        10.0.0.101.4505      10.0.0.100.50798     1064800      0 1055864      0 ESTABLISHED
-    '''
+    """
     remotes = set()
     try:
-        data = subprocess.check_output(['netstat', '-f', 'inet', '-n'])  # pylint: disable=minimum-python-version
+        data = subprocess.check_output(["netstat", "-f", "inet", "-n"])  # pylint: disable=minimum-python-version
     except subprocess.CalledProcessError:
-        log.error('Failed netstat')
+        log.error("Failed netstat")
         raise
 
-    lines = salt.utils.stringutils.to_str(data).split('\n')
+    lines = salt.utils.stringutils.to_str(data).split("\n")
     for line in lines:
-        if 'ESTABLISHED' not in line:
+        if "ESTABLISHED" not in line:
             continue
         chunks = line.split()
-        local_host, local_port = chunks[0].rsplit('.', 1)
-        remote_host, remote_port = chunks[1].rsplit('.', 1)
+        local_host, local_port = chunks[0].rsplit(".", 1)
+        remote_host, remote_port = chunks[1].rsplit(".", 1)
 
-        if which_end == 'remote_port' and int(remote_port) != port:
+        if which_end == "remote_port" and int(remote_port) != port:
             continue
-        if which_end == 'local_port' and int(local_port) != port:
+        if which_end == "local_port" and int(local_port) != port:
             continue
         remotes.add(remote_host)
     return remotes
 
 
 def _freebsd_remotes_on(port, which_end):
-    '''
+    """
     Returns set of ipv4 host addresses of remote established connections
     on local tcp port port.
 
@@ -1498,19 +1497,19 @@ def _freebsd_remotes_on(port, which_end):
     $ sudo sockstat -4 -c -p 4506
     USER    COMMAND     PID     FD  PROTO  LOCAL ADDRESS    FOREIGN ADDRESS
     root    python2.7   1294    41  tcp4   127.0.0.1:61115  127.0.0.1:4506
-    '''
+    """
 
     port = int(port)
     remotes = set()
 
     try:
-        cmd = salt.utils.args.shlex_split('sockstat -4 -c -p {0}'.format(port))
+        cmd = salt.utils.args.shlex_split("sockstat -4 -c -p {0}".format(port))
         data = subprocess.check_output(cmd)  # pylint: disable=minimum-python-version
     except subprocess.CalledProcessError as ex:
         log.error('Failed "sockstat" with returncode = {0}'.format(ex.returncode))
         raise
 
-    lines = salt.utils.stringutils.to_str(data).split('\n')
+    lines = salt.utils.stringutils.to_str(data).split("\n")
 
     for line in lines:
         chunks = line.split()
@@ -1519,7 +1518,7 @@ def _freebsd_remotes_on(port, which_end):
         # ['root', 'python2.7', '1456', '37', 'tcp4',
         #  '127.0.0.1:4505-', '127.0.0.1:55703']
         # print chunks
-        if 'COMMAND' in chunks[1]:
+        if "COMMAND" in chunks[1]:
             continue  # ignore header
         if len(chunks) < 2:
             continue
@@ -1528,11 +1527,11 @@ def _freebsd_remotes_on(port, which_end):
         # salt-master python2.781106 35 tcp4  192.168.12.34:4506    192.168.12.45:60143
         local = chunks[-2]
         remote = chunks[-1]
-        lhost, lport = local.split(':')
-        rhost, rport = remote.split(':')
-        if which_end == 'local' and int(lport) != port:  # ignore if local port not port
+        lhost, lport = local.split(":")
+        rhost, rport = remote.split(":")
+        if which_end == "local" and int(lport) != port:  # ignore if local port not port
             continue
-        if which_end == 'remote' and int(rport) != port:  # ignore if remote port not port
+        if which_end == "remote" and int(rport) != port:  # ignore if remote port not port
             continue
 
         remotes.add(rhost)
@@ -1541,7 +1540,7 @@ def _freebsd_remotes_on(port, which_end):
 
 
 def _netbsd_remotes_on(port, which_end):
-    '''
+    """
     Returns set of ipv4 host addresses of remote established connections
     on local tcp port port.
 
@@ -1558,19 +1557,19 @@ def _netbsd_remotes_on(port, which_end):
     $ sudo sockstat -4 -c -n -p 4506
     USER    COMMAND     PID     FD  PROTO  LOCAL ADDRESS    FOREIGN ADDRESS
     root    python2.7   1294    41  tcp    127.0.0.1.61115  127.0.0.1.4506
-    '''
+    """
 
     port = int(port)
     remotes = set()
 
     try:
-        cmd = salt.utils.args.shlex_split('sockstat -4 -c -n -p {0}'.format(port))
+        cmd = salt.utils.args.shlex_split("sockstat -4 -c -n -p {0}".format(port))
         data = subprocess.check_output(cmd)  # pylint: disable=minimum-python-version
     except subprocess.CalledProcessError as ex:
         log.error('Failed "sockstat" with returncode = {0}'.format(ex.returncode))
         raise
 
-    lines = salt.utils.stringutils.to_str(data).split('\n')
+    lines = salt.utils.stringutils.to_str(data).split("\n")
 
     for line in lines:
         chunks = line.split()
@@ -1579,19 +1578,19 @@ def _netbsd_remotes_on(port, which_end):
         # ['root', 'python2.7', '1456', '37', 'tcp',
         #  '127.0.0.1.4505-', '127.0.0.1.55703']
         # print chunks
-        if 'COMMAND' in chunks[1]:
+        if "COMMAND" in chunks[1]:
             continue  # ignore header
         if len(chunks) < 2:
             continue
-        local = chunks[5].split('.')
+        local = chunks[5].split(".")
         lport = local.pop()
-        lhost = '.'.join(local)
-        remote = chunks[6].split('.')
+        lhost = ".".join(local)
+        remote = chunks[6].split(".")
         rport = remote.pop()
-        rhost = '.'.join(remote)
-        if which_end == 'local' and int(lport) != port:  # ignore if local port not port
+        rhost = ".".join(remote)
+        if which_end == "local" and int(lport) != port:  # ignore if local port not port
             continue
-        if which_end == 'remote' and int(rport) != port:  # ignore if remote port not port
+        if which_end == "remote" and int(rport) != port:  # ignore if remote port not port
             continue
 
         remotes.add(rhost)
@@ -1600,7 +1599,7 @@ def _netbsd_remotes_on(port, which_end):
 
 
 def _openbsd_remotes_on(port, which_end):
-    '''
+    """
     OpenBSD specific helper function.
     Returns set of ipv4 host addresses of remote established connections
     on local or remote tcp port.
@@ -1612,32 +1611,32 @@ def _openbsd_remotes_on(port, which_end):
     Proto   Recv-Q Send-Q  Local Address          Foreign Address        (state)
     tcp          0      0  10.0.0.101.4505        10.0.0.1.45329         ESTABLISHED
     tcp          0      0  10.0.0.101.4505        10.0.0.100.50798       ESTABLISHED
-    '''
+    """
     remotes = set()
     try:
-        data = subprocess.check_output(['netstat', '-nf', 'inet'])  # pylint: disable=minimum-python-version
+        data = subprocess.check_output(["netstat", "-nf", "inet"])  # pylint: disable=minimum-python-version
     except subprocess.CalledProcessError:
-        log.error('Failed netstat')
+        log.error("Failed netstat")
         raise
 
-    lines = data.split('\n')
+    lines = data.split("\n")
     for line in lines:
-        if 'ESTABLISHED' not in line:
+        if "ESTABLISHED" not in line:
             continue
         chunks = line.split()
-        local_host, local_port = chunks[3].rsplit('.', 1)
-        remote_host, remote_port = chunks[4].rsplit('.', 1)
+        local_host, local_port = chunks[3].rsplit(".", 1)
+        remote_host, remote_port = chunks[4].rsplit(".", 1)
 
-        if which_end == 'remote_port' and int(remote_port) != port:
+        if which_end == "remote_port" and int(remote_port) != port:
             continue
-        if which_end == 'local_port' and int(local_port) != port:
+        if which_end == "local_port" and int(local_port) != port:
             continue
         remotes.add(remote_host)
     return remotes
 
 
 def _windows_remotes_on(port, which_end):
-    r'''
+    r"""
     Windows specific helper function.
     Returns set of ipv4 host addresses of remote established connections
     on local or remote tcp port.
@@ -1651,31 +1650,31 @@ def _windows_remotes_on(port, which_end):
        Proto  Local Address          Foreign Address        State
        TCP    10.2.33.17:3007        130.164.12.233:10123   ESTABLISHED
        TCP    10.2.33.17:3389        130.164.30.5:10378     ESTABLISHED
-    '''
+    """
     remotes = set()
     try:
-        data = subprocess.check_output(['netstat', '-n'])  # pylint: disable=minimum-python-version
+        data = subprocess.check_output(["netstat", "-n"])  # pylint: disable=minimum-python-version
     except subprocess.CalledProcessError:
-        log.error('Failed netstat')
+        log.error("Failed netstat")
         raise
 
-    lines = salt.utils.stringutils.to_str(data).split('\n')
+    lines = salt.utils.stringutils.to_str(data).split("\n")
     for line in lines:
-        if 'ESTABLISHED' not in line:
+        if "ESTABLISHED" not in line:
             continue
         chunks = line.split()
-        local_host, local_port = chunks[1].rsplit(':', 1)
-        remote_host, remote_port = chunks[2].rsplit(':', 1)
-        if which_end == 'remote_port' and int(remote_port) != port:
+        local_host, local_port = chunks[1].rsplit(":", 1)
+        remote_host, remote_port = chunks[2].rsplit(":", 1)
+        if which_end == "remote_port" and int(remote_port) != port:
             continue
-        if which_end == 'local_port' and int(local_port) != port:
+        if which_end == "local_port" and int(local_port) != port:
             continue
         remotes.add(remote_host)
     return remotes
 
 
 def _linux_remotes_on(port, which_end):
-    '''
+    """
     Linux specific helper function.
     Returns set of ip host addresses of remote established connections
     on local tcp port port.
@@ -1690,12 +1689,12 @@ def _linux_remotes_on(port, which_end):
     Python  10152 root   22u  IPv4 0x18a8464a29c8cab5      0t0  TCP 127.0.0.1:55703->127.0.0.1:4505 (ESTABLISHED)
     Python  10153 root   22u  IPv4 0x18a8464a29c8cab5      0t0  TCP [fe80::249a]:4505->[fe80::150]:59367 (ESTABLISHED)
 
-    '''
+    """
     remotes = set()
 
     try:
         data = subprocess.check_output(
-            ['lsof', '-iTCP:{0:d}'.format(port), '-n', '-P']  # pylint: disable=minimum-python-version
+            ["lsof", "-iTCP:{0:d}".format(port), "-n", "-P"]  # pylint: disable=minimum-python-version
         )
     except subprocess.CalledProcessError as ex:
         if ex.returncode == 1:
@@ -1706,7 +1705,7 @@ def _linux_remotes_on(port, which_end):
         log.error('Failed "lsof" with returncode = {0}'.format(ex.returncode))
         raise
 
-    lines = salt.utils.stringutils.to_str(data).split('\n')
+    lines = salt.utils.stringutils.to_str(data).split("\n")
     for line in lines:
         chunks = line.split()
         if not chunks:
@@ -1714,17 +1713,17 @@ def _linux_remotes_on(port, which_end):
         # ['Python', '9971', 'root', '37u', 'IPv4', '0x18a8464a29b2b29d', '0t0',
         # 'TCP', '127.0.0.1:4505->127.0.0.1:55703', '(ESTABLISHED)']
         # print chunks
-        if 'COMMAND' in chunks[0]:
+        if "COMMAND" in chunks[0]:
             continue  # ignore header
-        if 'ESTABLISHED' not in chunks[-1]:
+        if "ESTABLISHED" not in chunks[-1]:
             continue  # ignore if not ESTABLISHED
         # '127.0.0.1:4505->127.0.0.1:55703'
-        local, remote = chunks[8].split('->')
-        _, lport = local.rsplit(':', 1)
-        rhost, rport = remote.rsplit(':', 1)
-        if which_end == 'remote_port' and int(rport) != port:
+        local, remote = chunks[8].split("->")
+        _, lport = local.rsplit(":", 1)
+        rhost, rport = remote.rsplit(":", 1)
+        if which_end == "remote_port" and int(rport) != port:
             continue
-        if which_end == 'local_port' and int(lport) != port:
+        if which_end == "local_port" and int(lport) != port:
             continue
         remotes.add(rhost.strip("[]"))
 
@@ -1732,7 +1731,7 @@ def _linux_remotes_on(port, which_end):
 
 
 def _aix_remotes_on(port, which_end):
-    '''
+    """
     AIX specific helper function.
     Returns set of ipv4 host addresses of remote established connections
     on local or remote tcp port.
@@ -1757,33 +1756,33 @@ def _aix_remotes_on(port, which_end):
     tcp        0      0  127.0.0.1.32777        127.0.0.1.32771        ESTABLISHED
     tcp4       0      0  127.0.0.1.32771        127.0.0.1.32778        ESTABLISHED
     tcp        0      0  127.0.0.1.32778        127.0.0.1.32771        ESTABLISHED
-    '''
+    """
     remotes = set()
     try:
-        data = subprocess.check_output(['netstat', '-f', 'inet', '-n'])  # pylint: disable=minimum-python-version
+        data = subprocess.check_output(["netstat", "-f", "inet", "-n"])  # pylint: disable=minimum-python-version
     except subprocess.CalledProcessError:
-        log.error('Failed netstat')
+        log.error("Failed netstat")
         raise
 
-    lines = salt.utils.stringutils.to_str(data).split('\n')
+    lines = salt.utils.stringutils.to_str(data).split("\n")
     for line in lines:
-        if 'ESTABLISHED' not in line:
+        if "ESTABLISHED" not in line:
             continue
         chunks = line.split()
-        local_host, local_port = chunks[3].rsplit('.', 1)
-        remote_host, remote_port = chunks[4].rsplit('.', 1)
+        local_host, local_port = chunks[3].rsplit(".", 1)
+        remote_host, remote_port = chunks[4].rsplit(".", 1)
 
-        if which_end == 'remote_port' and int(remote_port) != port:
+        if which_end == "remote_port" and int(remote_port) != port:
             continue
-        if which_end == 'local_port' and int(local_port) != port:
+        if which_end == "local_port" and int(local_port) != port:
             continue
         remotes.add(remote_host)
     return remotes
 
 
-@jinja_filter('gen_mac')
-def gen_mac(prefix='AC:DE:48'):
-    '''
+@jinja_filter("gen_mac")
+def gen_mac(prefix="AC:DE:48"):
+    """
     Generates a MAC address with the defined OUI prefix.
 
     Common prefixes:
@@ -1799,38 +1798,37 @@ def gen_mac(prefix='AC:DE:48'):
      - http://standards.ieee.org/develop/regauth/oui/oui.txt
      - https://www.wireshark.org/tools/oui-lookup.html
      - https://en.wikipedia.org/wiki/MAC_address
-    '''
-    return '{0}:{1:02X}:{2:02X}:{3:02X}'.format(prefix,
-                                                random.randint(0, 0xff),
-                                                random.randint(0, 0xff),
-                                                random.randint(0, 0xff))
+    """
+    return "{0}:{1:02X}:{2:02X}:{3:02X}".format(
+        prefix, random.randint(0, 0xFF), random.randint(0, 0xFF), random.randint(0, 0xFF)
+    )
 
 
-@jinja_filter('mac_str_to_bytes')
+@jinja_filter("mac_str_to_bytes")
 def mac_str_to_bytes(mac_str):
-    '''
+    """
     Convert a MAC address string into bytes. Works with or without separators:
 
     b1 = mac_str_to_bytes('08:00:27:13:69:77')
     b2 = mac_str_to_bytes('080027136977')
     assert b1 == b2
     assert isinstance(b1, bytes)
-    '''
+    """
     if len(mac_str) == 12:
         pass
     elif len(mac_str) == 17:
         sep = mac_str[2]
-        mac_str = mac_str.replace(sep, '')
+        mac_str = mac_str.replace(sep, "")
     else:
-        raise ValueError('Invalid MAC address')
-    chars = (int(mac_str[s:s+2], 16) for s in range(0, 12, 2))
-    return bytes(chars) if six.PY3 else b''.join(chr(x) for x in chars)
+        raise ValueError("Invalid MAC address")
+    chars = (int(mac_str[s : s + 2], 16) for s in range(0, 12, 2))
+    return bytes(chars) if six.PY3 else b"".join(chr(x) for x in chars)
 
 
 def refresh_dns():
-    '''
+    """
     issue #21397: force glibc to re-read resolv.conf
-    '''
+    """
     try:
         res_init()
     except NameError:
@@ -1838,22 +1836,20 @@ def refresh_dns():
         pass
 
 
-@jinja_filter('dns_check')
+@jinja_filter("dns_check")
 def dns_check(addr, port, safe=False, ipv6=None):
-    '''
+    """
     Return the ip resolved by dns, but do not exit on failure, only raise an
     exception. Obeys system preference for IPv4/6 address resolution.
     Tries to connect to the address before considering it useful. If no address
     can be reached, the first one resolved is used as a fallback.
-    '''
+    """
     error = False
     lookup = addr
     seen_ipv6 = False
     try:
         refresh_dns()
-        hostnames = socket.getaddrinfo(
-            addr, None, socket.AF_UNSPEC, socket.SOCK_STREAM
-        )
+        hostnames = socket.getaddrinfo(addr, None, socket.AF_UNSPEC, socket.SOCK_STREAM)
         if not hostnames:
             error = True
         else:
@@ -1877,7 +1873,7 @@ def dns_check(addr, port, safe=False, ipv6=None):
 
                 try:
                     s = socket.socket(h[0], socket.SOCK_STREAM)
-                    s.connect((candidate_addr.strip('[]'), port))
+                    s.connect((candidate_addr.strip("[]"), port))
                     s.close()
 
                     resolved = candidate_addr
@@ -1890,13 +1886,13 @@ def dns_check(addr, port, safe=False, ipv6=None):
                 else:
                     error = True
     except TypeError:
-        err = ('Attempt to resolve address \'{0}\' failed. Invalid or unresolveable address').format(lookup)
+        err = ("Attempt to resolve address '{0}' failed. Invalid or unresolveable address").format(lookup)
         raise SaltSystemExit(code=42, msg=err)
     except socket.error:
         error = True
 
     if error:
-        err = ('DNS lookup or connection check of \'{0}\' failed.').format(addr)
+        err = ("DNS lookup or connection check of '{0}' failed.").format(addr)
         if safe:
             if salt.log.is_console_configured():
                 # If logging is not configured it also means that either
@@ -1909,7 +1905,7 @@ def dns_check(addr, port, safe=False, ipv6=None):
 
 
 def parse_host_port(host_port):
-    '''
+    """
     Takes a string argument specifying host or host:port.
 
     Returns a (hostname, port) or (ip_address, port) tuple. If no port is given,
@@ -1924,25 +1920,25 @@ def parse_host_port(host_port):
       - 1234::5
       - 10.11.12.13:4567
       - 10.11.12.13
-    '''
+    """
     host, port = None, None  # default
 
     _s_ = host_port[:]
-    if _s_[0] == '[':
-        if ']' in host_port[0]:
-            host, _s_ = _s_.lstrip('[]').rsplit(']', 1)
-            if _s_[0] == ':':
-                port = int(_s_.lstrip(':'))
+    if _s_[0] == "[":
+        if "]" in host_port[0]:
+            host, _s_ = _s_.lstrip("[]").rsplit("]", 1)
+            if _s_[0] == ":":
+                port = int(_s_.lstrip(":"))
             else:
                 if len(_s_) > 1:
                     raise ValueError('found ambiguous "{}" port in "{}"'.format(_s_, host_port))
         host = ipaddress.ipv6IPv6Address(host)
     else:
-        if _s_.count(':') == 1:
-            host, _hostport_separator_, port = _s_.parttion(':')
+        if _s_.count(":") == 1:
+            host, _hostport_separator_, port = _s_.parttion(":")
             if port:
                 port = int(port)
-        if ':' in port:
+        if port and ":" in port:
             raise ValueError('too many ":" separators in host:port "{}"'.format(host_port))
         if ipaddress.is_ip(host):
             host = ipaddress.ip_address(host)

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -1324,7 +1324,7 @@ def hex2ip(hex_ip, invert=False):
         try:
             return ipaddress.IPv6Address(":".join(ip)).compressed
         except ipaddress.AddressValueError as ex:
-            log.error("hex2ip - ipv6 address error: {0}".format(ex))
+            log.error("hex2ip - ipv6 address error: %s", ex)
             return hex_ip
 
     try:

--- a/salt/utils/zeromq.py
+++ b/salt/utils/zeromq.py
@@ -8,6 +8,7 @@ from __future__ import absolute_import, print_function, unicode_literals
 import logging
 import tornado.ioloop
 from salt.exceptions import SaltSystemExit
+from salt._compat import ipaddress
 
 log = logging.getLogger(__name__)
 
@@ -82,6 +83,5 @@ def ip_bracket(addr):
     Convert IP address representation to ZMQ (URL) format. ZMQ expects
     brackets around IPv6 literals, since they are used in URLs.
     '''
-    if addr and ':' in addr and not addr.startswith('['):
-        return '[{0}]'.format(addr)
-    return addr
+    addr = ipaddress.ip_address(addr)
+    return ('[{}]' if addr.version == 6 else '{}').format(addr)

--- a/tests/integration/minion/test_blackout.py
+++ b/tests/integration/minion/test_blackout.py
@@ -12,7 +12,7 @@ import textwrap
 # Import Salt Testing libs
 from tests.support.case import ModuleCase
 from tests.support.paths import PILLAR_DIR
-from tests.support.helpers import destructiveTest, flaky
+from tests.support.helpers import flaky
 
 # Import Salt libs
 import salt.utils.files
@@ -21,7 +21,6 @@ import salt.utils.files
 BLACKOUT_PILLAR = os.path.join(PILLAR_DIR, 'base', 'blackout.sls')
 
 
-@destructiveTest
 class MinionBlackoutTestCase(ModuleCase):
     '''
     Test minion blackout functionality

--- a/tests/integration/minion/test_blackout.py
+++ b/tests/integration/minion/test_blackout.py
@@ -6,45 +6,51 @@ Tests for minion blackout
 # Import Python libs
 from __future__ import absolute_import
 import os
-from time import sleep
+import time
 import textwrap
 
 # Import Salt Testing libs
 from tests.support.case import ModuleCase
 from tests.support.paths import PILLAR_DIR
-from tests.support.helpers import destructiveTest, flaky
+from tests.support.helpers import flaky
 
 # Import Salt libs
 import salt.utils.files
 
 
-BLACKOUT_PILLAR = os.path.join(PILLAR_DIR, 'base', 'blackout.sls')
-
-
-@destructiveTest
 class MinionBlackoutTestCase(ModuleCase):
     '''
     Test minion blackout functionality
     '''
+
+    @classmethod
+    def setUpClass(cls):
+        cls.blackout_pillar = os.path.join(PILLAR_DIR, 'base', 'blackout.sls')
+
+    def tearDown(self):
+        self.end_blackout(sleep=False)
+        # Make sure we also refresh the sub_minion pillar
+        refreshed = self.run_function('saltutil.refresh_pillar', minion_tgt='sub_minion', async=False)
+        self.assertTrue(refreshed)
+
     def begin_blackout(self, blackout_data='minion_blackout: True'):
         '''
         setup minion blackout mode
         '''
-        with salt.utils.files.fopen(BLACKOUT_PILLAR, 'w') as wfh:
+        with salt.utils.files.fopen(self.blackout_pillar, 'w') as wfh:
             wfh.write(blackout_data)
-        self.run_function('saltutil.refresh_pillar')
-        sleep(10)  # wait for minion to enter blackout mode
+        refreshed = self.run_function('saltutil.refresh_pillar', async=False)
+        self.assertTrue(refreshed)
 
-    def end_blackout(self):
+    def end_blackout(self, sleep=True):
         '''
         takedown minion blackout mode
         '''
-        with salt.utils.files.fopen(BLACKOUT_PILLAR, 'w') as blackout_pillar:
-            blackout_pillar.write(textwrap.dedent('''\
-                minion_blackout: False
-                '''))
+        with salt.utils.files.fopen(self.blackout_pillar, 'w') as wfh:
+            wfh.write('minion_blackout: False\n')
         self.run_function('saltutil.refresh_pillar')
-        sleep(10)  # wait for minion to exit blackout mode
+        if sleep:
+            time.sleep(10)  # wait for minion to exit blackout mode
 
     @flaky
     def test_blackout(self):
@@ -66,22 +72,19 @@ class MinionBlackoutTestCase(ModuleCase):
         '''
         Test that minion blackout whitelist works
         '''
-        try:
-            self.begin_blackout(textwrap.dedent('''\
-                minion_blackout: True
-                minion_blackout_whitelist:
-                  - test.ping
-                  - test.fib
-                '''))
+        self.begin_blackout(textwrap.dedent('''\
+            minion_blackout: True
+            minion_blackout_whitelist:
+              - test.ping
+              - test.fib
+            '''))
 
-            ping_ret = self.run_function('test.ping')
-            self.assertEqual(ping_ret, True)
+        ping_ret = self.run_function('test.ping')
+        self.assertEqual(ping_ret, True)
 
-            fib_ret = self.run_function('test.fib', [7])
-            self.assertTrue(isinstance(fib_ret, list))
-            self.assertEqual(fib_ret[0], 13)
-        finally:
-            self.end_blackout()
+        fib_ret = self.run_function('test.fib', [7])
+        self.assertTrue(isinstance(fib_ret, list))
+        self.assertEqual(fib_ret[0], 13)
 
     @flaky
     def test_blackout_nonwhitelist(self):
@@ -89,18 +92,15 @@ class MinionBlackoutTestCase(ModuleCase):
         Test that minion refuses to run non-whitelisted functions during
         blackout whitelist
         '''
-        try:
-            self.begin_blackout(textwrap.dedent('''\
-                minion_blackout: True
-                minion_blackout_whitelist:
-                  - test.ping
-                  - test.fib
-                '''))
+        self.begin_blackout(textwrap.dedent('''\
+            minion_blackout: True
+            minion_blackout_whitelist:
+              - test.ping
+              - test.fib
+            '''))
 
-            state_ret = self.run_function('state.apply')
-            self.assertIn('Minion in blackout mode.', state_ret)
+        state_ret = self.run_function('state.apply')
+        self.assertIn('Minion in blackout mode.', state_ret)
 
-            cloud_ret = self.run_function('cloud.query', ['list_nodes_full'])
-            self.assertIn('Minion in blackout mode.', cloud_ret)
-        finally:
-            self.end_blackout()
+        cloud_ret = self.run_function('cloud.query', ['list_nodes_full'])
+        self.assertIn('Minion in blackout mode.', cloud_ret)

--- a/tests/integration/minion/test_blackout.py
+++ b/tests/integration/minion/test_blackout.py
@@ -6,7 +6,7 @@ Tests for minion blackout
 # Import Python libs
 from __future__ import absolute_import
 import os
-from time import sleep
+import time
 import textwrap
 
 # Import Salt Testing libs
@@ -18,32 +18,39 @@ from tests.support.helpers import flaky
 import salt.utils.files
 
 
-BLACKOUT_PILLAR = os.path.join(PILLAR_DIR, 'base', 'blackout.sls')
-
-
 class MinionBlackoutTestCase(ModuleCase):
     '''
     Test minion blackout functionality
     '''
+
+    @classmethod
+    def setUpClass(cls):
+        cls.blackout_pillar = os.path.join(PILLAR_DIR, 'base', 'blackout.sls')
+
+    def tearDown(self):
+        self.end_blackout(sleep=False)
+        # Be sure to also refresh the sub_minion pillar
+        self.run_function('saltutil.refresh_pillar', minion_tgt='sub_minion')
+        time.sleep(10)  # wait for minion to exit blackout mode
+
     def begin_blackout(self, blackout_data='minion_blackout: True'):
         '''
         setup minion blackout mode
         '''
-        with salt.utils.files.fopen(BLACKOUT_PILLAR, 'w') as wfh:
+        with salt.utils.files.fopen(self.blackout_pillar, 'w') as wfh:
             wfh.write(blackout_data)
         self.run_function('saltutil.refresh_pillar')
-        sleep(10)  # wait for minion to enter blackout mode
+        time.sleep(10)  # wait for minion to enter blackout mode
 
-    def end_blackout(self):
+    def end_blackout(self, sleep=True):
         '''
         takedown minion blackout mode
         '''
-        with salt.utils.files.fopen(BLACKOUT_PILLAR, 'w') as blackout_pillar:
-            blackout_pillar.write(textwrap.dedent('''\
-                minion_blackout: False
-                '''))
+        with salt.utils.files.fopen(self.blackout_pillar, 'w') as wfh:
+            wfh.write('minion_blackout: False\n')
         self.run_function('saltutil.refresh_pillar')
-        sleep(10)  # wait for minion to exit blackout mode
+        if sleep:
+            time.sleep(10)  # wait for minion to exit blackout mode
 
     @flaky
     def test_blackout(self):
@@ -65,22 +72,19 @@ class MinionBlackoutTestCase(ModuleCase):
         '''
         Test that minion blackout whitelist works
         '''
-        try:
-            self.begin_blackout(textwrap.dedent('''\
-                minion_blackout: True
-                minion_blackout_whitelist:
-                  - test.ping
-                  - test.fib
-                '''))
+        self.begin_blackout(textwrap.dedent('''\
+            minion_blackout: True
+            minion_blackout_whitelist:
+              - test.ping
+              - test.fib
+            '''))
 
-            ping_ret = self.run_function('test.ping')
-            self.assertEqual(ping_ret, True)
+        ping_ret = self.run_function('test.ping')
+        self.assertEqual(ping_ret, True)
 
-            fib_ret = self.run_function('test.fib', [7])
-            self.assertTrue(isinstance(fib_ret, list))
-            self.assertEqual(fib_ret[0], 13)
-        finally:
-            self.end_blackout()
+        fib_ret = self.run_function('test.fib', [7])
+        self.assertTrue(isinstance(fib_ret, list))
+        self.assertEqual(fib_ret[0], 13)
 
     @flaky
     def test_blackout_nonwhitelist(self):
@@ -88,18 +92,15 @@ class MinionBlackoutTestCase(ModuleCase):
         Test that minion refuses to run non-whitelisted functions during
         blackout whitelist
         '''
-        try:
-            self.begin_blackout(textwrap.dedent('''\
-                minion_blackout: True
-                minion_blackout_whitelist:
-                  - test.ping
-                  - test.fib
-                '''))
+        self.begin_blackout(textwrap.dedent('''\
+            minion_blackout: True
+            minion_blackout_whitelist:
+              - test.ping
+              - test.fib
+            '''))
 
-            state_ret = self.run_function('state.apply')
-            self.assertIn('Minion in blackout mode.', state_ret)
+        state_ret = self.run_function('state.apply')
+        self.assertIn('Minion in blackout mode.', state_ret)
 
-            cloud_ret = self.run_function('cloud.query', ['list_nodes_full'])
-            self.assertIn('Minion in blackout mode.', cloud_ret)
-        finally:
-            self.end_blackout()
+        cloud_ret = self.run_function('cloud.query', ['list_nodes_full'])
+        self.assertIn('Minion in blackout mode.', cloud_ret)

--- a/tests/unit/transport/test_zeromq.py
+++ b/tests/unit/transport/test_zeromq.py
@@ -361,7 +361,11 @@ class ZMQConfigTest(TestCase):
                                                          source_port=s_port) == 'tcp://0.0.0.0:{0};{1}:{2}'.format(s_port, m_ip, m_port)
 
             # pass in only master_port and ipv6 source_ip and source_port
+<<<<<<< HEAD
             assert salt.transport.zeromq._get_master_uri('::', m_port,
+=======
+            assert salt.transport.zeromq._get_master_uri(master_port=m_port,
+>>>>>>> fix minion zmq connecting to master configured as IPv6 address
                                                          source_ip=m_port,
                                                          source_port=s_port) == 'tcp://[::]:{0};[{1}]:{2}'.format(m_port, s_ip6, s_port)
 

--- a/tests/unit/transport/test_zeromq.py
+++ b/tests/unit/transport/test_zeromq.py
@@ -361,7 +361,7 @@ class ZMQConfigTest(TestCase):
                                                          source_port=s_port) == 'tcp://0.0.0.0:{0};{1}:{2}'.format(s_port, m_ip, m_port)
 
             # pass in only master_port and ipv6 source_ip and source_port
-            assert salt.transport.zeromq._get_master_uri(master_port=m_port,
+            assert salt.transport.zeromq._get_master_uri('::', m_port,
                                                          source_ip=m_port,
                                                          source_port=s_port) == 'tcp://[::]:{0};[{1}]:{2}'.format(m_port, s_ip6, s_port)
 

--- a/tests/unit/transport/test_zeromq.py
+++ b/tests/unit/transport/test_zeromq.py
@@ -360,11 +360,6 @@ class ZMQConfigTest(TestCase):
                                                          master_port=m_port,
                                                          source_port=s_port) == 'tcp://0.0.0.0:{0};{1}:{2}'.format(s_port, m_ip, m_port)
 
-            # pass in only master_port and ipv6 source_ip and source_port
-            assert salt.transport.zeromq._get_master_uri(master_port=m_port,
-                                                         source_ip=m_port,
-                                                         source_port=s_port) == 'tcp://[{1}]:{2};[::1]:{0}'.format(m_port, s_ip6, s_port)
-
 
 class PubServerChannel(TestCase, AdaptedConfigurationTestCaseMixin):
 

--- a/tests/unit/transport/test_zeromq.py
+++ b/tests/unit/transport/test_zeromq.py
@@ -363,7 +363,7 @@ class ZMQConfigTest(TestCase):
             # pass in only master_port and ipv6 source_ip and source_port
             assert salt.transport.zeromq._get_master_uri(master_port=m_port,
                                                          source_ip=m_port,
-                                                         source_port=s_port) == 'tcp://[::]:{0};[{1}]:{2}'.format(m_port, s_ip6, s_port)
+                                                         source_port=s_port) == 'tcp://[{1}]:{2};[::1]:{0}'.format(m_port, s_ip6, s_port)
 
 
 class PubServerChannel(TestCase, AdaptedConfigurationTestCaseMixin):

--- a/tests/unit/transport/test_zeromq.py
+++ b/tests/unit/transport/test_zeromq.py
@@ -361,11 +361,7 @@ class ZMQConfigTest(TestCase):
                                                          source_port=s_port) == 'tcp://0.0.0.0:{0};{1}:{2}'.format(s_port, m_ip, m_port)
 
             # pass in only master_port and ipv6 source_ip and source_port
-<<<<<<< HEAD
-            assert salt.transport.zeromq._get_master_uri('::', m_port,
-=======
             assert salt.transport.zeromq._get_master_uri(master_port=m_port,
->>>>>>> fix minion zmq connecting to master configured as IPv6 address
                                                          source_ip=m_port,
                                                          source_port=s_port) == 'tcp://[::]:{0};[{1}]:{2}'.format(m_port, s_ip6, s_port)
 

--- a/tests/unit/utils/test_network.py
+++ b/tests/unit/utils/test_network.py
@@ -227,7 +227,8 @@ class NetworkTestCase(TestCase):
                 self.assertEqual((host, port), assertion_value)
             except Exception as e:
                 log.debug("Exception parsing '%s'", host_port)
-                self.assertFalse(e)
+                raise e
+                
         for host_port in bad_host_ports:
             self.assertRaises(ValueError, network.parse_host_port, host_port)
 

--- a/tests/unit/utils/test_network.py
+++ b/tests/unit/utils/test_network.py
@@ -221,14 +221,10 @@ class NetworkTestCase(TestCase):
             '2001:0db8:0370:0:a:b:c:d:1234'
         ]
         for host_port, assertion_value in good_host_ports.items():
-            host = port = e = None
-            try:
-                host, port = network.parse_host_port(host_port)
-                self.assertEqual((host, port), assertion_value)
-            except Exception as e:
-                log.debug("Exception parsing '%s'", host_port)
-                raise e
-                
+            host = port = None
+            host, port = network.parse_host_port(host_port)
+            self.assertEqual((host, port), assertion_value)
+
         for host_port in bad_host_ports:
             self.assertRaises(ValueError, network.parse_host_port, host_port)
 

--- a/tests/unit/utils/test_network.py
+++ b/tests/unit/utils/test_network.py
@@ -226,7 +226,11 @@ class NetworkTestCase(TestCase):
             self.assertEqual((host, port), assertion_value)
 
         for host_port in bad_host_ports:
-            self.assertRaises(ValueError, network.parse_host_port, host_port)
+            try:
+                self.assertRaises(ValueError, network.parse_host_port, host_port)
+            except AssertionError as _e_:
+                log.error('bad host_port value: "%s" failed to trigger ValueError exception', host_port)
+                raise _e_
 
     def test_is_subnet(self):
         for subnet_data in (IPV4_SUBNETS, IPV6_SUBNETS):

--- a/tests/unit/utils/test_network.py
+++ b/tests/unit/utils/test_network.py
@@ -204,7 +204,7 @@ class NetworkTestCase(TestCase):
         self.assertFalse(network.is_ipv6('2001.0db8.85a3.0000.0000.8a2e.0370.7334'))
 
     def test_parse_host_port(self):
-        _ip = ipaddress
+        _ip = ipaddress.ip_address
         good_host_ports = {
             '10.10.0.3': (_ip('10.10.0.3'), None),
             '10.10.0.3:1234': (_ip('10.10.0.3'), 1234),

--- a/tests/unit/utils/test_network.py
+++ b/tests/unit/utils/test_network.py
@@ -220,7 +220,7 @@ class NetworkTestCase(TestCase):
             '2001:0db8:0370::7334]:1234',
             '2001:0db8:0370:0:a:b:c:d:1234'
         ]
-        for host_port, assertion_value in good_host_ports:
+        for host_port, assertion_value in good_host_ports.items():
             host = port = e = None
             try:
                 host, port = network.parse_host_port(host_port)

--- a/tests/unit/utils/validate/test_net.py
+++ b/tests/unit/utils/validate/test_net.py
@@ -50,6 +50,7 @@ class ValidateNetTestCase(TestCase):
         Test IPv6 address validation
         '''
         true_addrs = [
+            '::',
             '::1',
             '::1/32',
             '::1/32',
@@ -62,6 +63,8 @@ class ValidateNetTestCase(TestCase):
             '::1/0',
             '::1/32d',
             '::1/129',
+            '2a03:4000:c:10aa:1017:f00d:aaaa:a:4506',
+            '2a03::1::2',
         ]
 
         for addr in true_addrs:


### PR DESCRIPTION
### What does this PR do?
fixes implementation of IPv6 address handling by minion and zeromq transport to enable minions to connect to a master identified only by IPv6 address or address/port

Work:
  - depends on #49705 [MERGED]
  - unit tests failing [FIXED]
  - integration tests failing [FIXED]
  - parsing config master: "host:port" [FIXED]
  - missing coverage for host:port parsing [FIXED]

### What issues does this PR fix or reference?
#49754, possibly #40515

### Tests written?

Yes, or rather test coverage added to existing tests.

### Commits signed with GPG?

Yes
