### PR TITLE
runners.state.orch: generate jid if missing

### DIFF
--- a/salt/runners/state.py
+++ b/salt/runners/state.py
@@ -10,6 +10,7 @@ import logging
 import salt.loader
 import salt.utils.event
 import salt.utils.functools
+import salt.utils.jid
 from salt.exceptions import SaltInvocationError
 
 LOGGER = logging.getLogger(__name__)
@@ -110,6 +111,8 @@ def orchestrate(mods,
         pillarenv = __opts__['pillarenv']
     if saltenv is None and 'saltenv' in __opts__:
         saltenv = __opts__['saltenv']
+    if orchestration_jid is None:
+        orchestration_jid = salt.utils.jid.gen_jid(__opts__)
 
     running = minion.functions['state.sls'](
             mods,


### PR DESCRIPTION
### What does this PR do?
via salt-run cli a jid is generated in RunnerClient via gen_async_pub and passed on via orchestration_jid if the func is orchestration, but in other callsites this jid generation doesn't happen (ie, the netapi client, since it directly invokes AsyncMixins.cmd_sync). There seems to be no obvious way to correct this at the netapi level so we just default to a new jid if orch_jid is missing. there may be other calling contexts where this could have been occurring.

### What issues does this PR fix or reference?
n/a

### Previous Behavior
nested / parallel orchestrations called from salt-api failed/threw a stacktrace resulting from a missing jid like:

```                "return": "Exception occurred in runner state.orchestrate: Traceback (most recent call last):
  File \"/home/mphillips81/repos/salt/salt/client/mixins.py\", line 374, in low
    data['return'] = func(*args, **kwargs)
  File \"/home/mphillips81/repos/salt/salt/runners/state.py\", line 123, in orchestrate
    orchestration_jid=orchestration_jid)
  File \"/home/mphillips81/repos/salt/salt/modules/state.py\", line 1326, in sls
    ret = st_.state.call_high(high_, orchestration_jid)
  File \"/home/mphillips81/repos/salt/salt/state.py\", line 2789, in call_high
    ret = self.call_chunks(chunks)
  File \"/home/mphillips81/repos/salt/salt/state.py\", line 2159, in call_chunks
    if self.reconcile_procs(running):
  File \"/home/mphillips81/repos/salt/salt/state.py\", line 2232, in reconcile_procs
    ret_cache = os.path.join(self.opts['cachedir'], self.jid, _clean_tag(tag))
  File \"/home/mphillips81/.pyenv/versions/2.7.14/lib/python2.7/posixpath.py\", line 68, in join
    if b.startswith('/'):
AttributeError: 'NoneType' object has no attribute 'startswith'
```

### New Behavior
they work, as a jid is always generated.

### Tests written?
No

### Commits signed with GPG?

Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
