### PR TITLE
Add mdadm as dependency in mdadm state docs

### DIFF
--- a/salt/states/mdadm.py
+++ b/salt/states/mdadm.py
@@ -3,6 +3,8 @@
 Managing software RAID with mdadm
 ==================================
 
+:depends:    mdadm
+
 A state module for creating or destroying software RAID devices.
 
 .. code-block:: yaml


### PR DESCRIPTION
### What does this PR do?
i'm not quit sure if we can include non-python libraries in this `depends` portion of the docs. If we are not suppose to I can just leave a note somewhere else in the docs. 

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/49740
