### PR TITLE
Handle Auth exceptions in run_job

### DIFF
--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -349,6 +349,10 @@ class LocalClient(object):
             raise SaltClientError(
                 'The salt master could not be contacted. Is master running?'
             )
+        except AuthenticationError as err:
+            raise AuthenticationError(err)
+        except AuthorizationError as err:
+            raise AuthorizationError(err)
         except Exception as general_exception:
             # Convert to generic client error and pass along message
             raise SaltClientError(general_exception)
@@ -415,6 +419,10 @@ class LocalClient(object):
             raise SaltClientError(
                 'The salt master could not be contacted. Is master running?'
             )
+        except AuthenticationError as err:
+            raise AuthenticationError(err)
+        except AuthorizationError as err:
+            raise AuthorizationError(err)
         except Exception as general_exception:
             # Convert to generic client error and pass along message
             raise SaltClientError(general_exception)

--- a/tests/integration/netapi/rest_tornado/test_app.py
+++ b/tests/integration/netapi/rest_tornado/test_app.py
@@ -239,7 +239,7 @@ class TestSaltAPIHandler(_SaltnadoIntegrationTestCase):
         self.assertEqual(len(ret), 3)  # make sure we got 3 responses
         self.assertIn('jid', ret[0])  # the first 2 are regular returns
         self.assertIn('jid', ret[1])
-        self.assertIn('Authentication error occurred.', ret[2])  # bad auth
+        self.assertIn('Failed to authenticate', ret[2])  # bad auth
         self.assertEqual(ret[0]['minions'], sorted(['minion', 'sub_minion']))
         self.assertEqual(ret[1]['minions'], sorted(['minion', 'sub_minion']))
 


### PR DESCRIPTION
### What does this PR do?
Handles both AuthenticationError and AuthorizationError in run_job so we return a 401 instead of a 500 when using incorrect authentication in salt-api

### Previous Behavior

```
[root@702f242dd208 testing]# curl -sS localhost:8000/run     -H 'Accept: application/x-yaml'     -H 'Content-type: application/json'     -d '[{
        "client": "local",
        "tgt": "*",
        "fun": "test.ping",
        "token": "bad"
    }]' 
return: "Traceback (most recent call last):\n  File \"/testing/salt/netapi/rest_cherrypy/app.py\",
  line 858, in hypermedia_handler\n    ret = cherrypy.serving.request._hypermedia_inner_handler(*args,
  **kwargs)\n  File \"/usr/lib/python2.7/site-packages/cherrypy/_cpdispatch.py\",
  line 34, in __call__\n    return self.callable(*self.args, **self.kwargs)\n  File
  \"/testing/salt/netapi/rest_cherrypy/app.py\", line 2128, in POST\n    'return':
  list(self.exec_lowstate()),\n  File \"/testing/salt/netapi/rest_cherrypy/app.py\",
  line 1178, in exec_lowstate\n    ret = self.api.run(chunk)\n  File \"/testing/salt/netapi/__init__.py\",
  line 75, in run\n    return l_fun(*f_call.get('args', ()), **f_call.get('kwargs',
  {}))\n  File \"/testing/salt/netapi/__init__.py\", line 103, in local\n    return
  local.cmd(*args, **kwargs)\n  File \"/testing/salt/client/__init__.py\", line 741,
  in cmd\n  File \"/testing/salt/client/__init__.py\", line 335, in run_job\n    try:\nSaltClientError:
  Authentication error occurred.\n"
status: 500
```

### New Behavior

```
[root@bf115f35ab7a /]# curl -sS localhost:8000/run     -H 'Accept: application/x-yaml'     -H 'Content-type: application/json'     -d '[{
        "client": "local",
        "tgt": "*",
        "fun": "test.ping",
        "token": "bad"
    }]' 
<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
<html>
<head>
    <meta http-equiv="Content-Type" content="text/html; charset=utf-8"></meta>
    <title>401 Unauthorized</title>
    <style type="text/css">
    #powered_by {
        margin-top: 20px;
        border-top: 2px solid black;
        font-style: italic;
    }

    #traceback {
        color: red;
    }
    </style>
</head>
    <body>
        <h2>401 Unauthorized</h2>
        <p>No permission -- see authorization schemes</p>
        <pre id="traceback">Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/cherrypy/_cprequest.py", line 656, in respond
    response.body = self.handler()
  File "/usr/lib/python2.7/site-packages/cherrypy/lib/encoding.py", line 188, in __call__
    self.body = self.oldhandler(*args, **kwargs)
  File "/testing/salt/netapi/rest_cherrypy/app.py", line 863, in hypermedia_handler
    raise cherrypy.HTTPError(401)
HTTPError: (401, None)
</pre>
    <div id="powered_by">
    <span>Powered by <a href="http://www.cherrypy.org">CherryPy 3.2.2</a></span>
    </div>
    </body>
</html>
```

