### PR TITLE
Documentation update for bluecoat sslv proxy (PR #49557)

### DIFF
--- a/doc/ref/grains/all/salt.grains.bluecoat_sslv.rst
+++ b/doc/ref/grains/all/salt.grains.bluecoat_sslv.rst
@@ -1,6 +1,6 @@
-=================
+=========================
 salt.grains.bluecoat_sslv
-=================
+=========================
 
 .. automodule:: salt.grains.bluecoat_sslv
     :members:

--- a/doc/ref/modules/all/salt.modules.bluecoat_sslv.rst
+++ b/doc/ref/modules/all/salt.modules.bluecoat_sslv.rst
@@ -1,6 +1,6 @@
-==================
+==========================
 salt.modules.bluecoat_sslv
-==================
+==========================
 
 .. automodule:: salt.modules.bluecoat_sslv
     :members:

--- a/doc/ref/proxy/all/salt.proxy.bluecoat_sslv.rst
+++ b/doc/ref/proxy/all/salt.proxy.bluecoat_sslv.rst
@@ -1,5 +1,5 @@
 salt.proxy.bluecoat_sslv module
-=======================
+===============================
 
 .. automodule:: salt.proxy.bluecoat_sslv
     :members:

--- a/doc/ref/states/all/salt.states.bluecoat_sslv.rst
+++ b/doc/ref/states/all/salt.states.bluecoat_sslv.rst
@@ -1,6 +1,6 @@
-=================
+=========================
 salt.states.bluecoat_sslv
-=================
+=========================
 
 .. automodule:: salt.states.bluecoat_sslv
     :members:

--- a/salt/grains/bluecoat_sslv.py
+++ b/salt/grains/bluecoat_sslv.py
@@ -1,11 +1,10 @@
 # -*- coding: utf-8 -*-
 '''
 Generate baseline proxy minion grains for bluecoat_sslv hosts.
-
 '''
 
 # Import Python Libs
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function, unicode_literals
 import logging
 
 # Import Salt Libs

--- a/salt/modules/bluecoat_sslv.py
+++ b/salt/modules/bluecoat_sslv.py
@@ -10,6 +10,7 @@ Module to provide Blue Coat SSL Visibility compatibility to Salt.
 
 Configuration
 =============
+
 This module accepts connection configuration details either as
 parameters, or as configuration settings in pillar as a Salt proxy.
 Options passed into opts will be ignored if options are passed into pillar.
@@ -19,13 +20,14 @@ Options passed into opts will be ignored if options are passed into pillar.
 
 About
 =====
+
 This execution module was designed to handle connections to a Blue Coat SSL Visibility server.
 This module adds support to send connections directly to the device through the rest API.
 
 '''
 
 # Import Python Libs
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function, unicode_literals
 import logging
 
 # Import Salt Libs

--- a/salt/proxy/bluecoat_sslv.py
+++ b/salt/proxy/bluecoat_sslv.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 '''
 Proxy Minion interface module for managing Blue Coat SSL Decryption devices
-=====================================================================
+
 :codeauthor: ``Spencer Ervin <spencer_ervin@hotmail.com>``
 :maturity:   new
 :depends:    none
@@ -12,8 +12,7 @@ The bluecoat_sslv proxy leverages the JSON API functionality on the Blue Coat SS
 Visibility devices. The Salt proxy must have access to the Blue Coat device on
 HTTPS (tcp/443).
 More in-depth conceptual reading on Proxy Minions can be found in the
-:ref:`Proxy Minion <proxy-minion>` section of Salt's
-documentation.
+:ref:`Proxy Minion <proxy-minion>` section of Salt's documentation.
 
 Configuration
 =============
@@ -61,7 +60,7 @@ password
 The password used to login to the bluecoat_sslv host. Required.
 
 auth
-^^^^^^^^
+^^^^
 
 The authentication type used to by the system. Use ``local`` to use the local user database. For
 TACACS+ set this value to ``tacacs``.

--- a/salt/states/bluecoat_sslv.py
+++ b/salt/states/bluecoat_sslv.py
@@ -10,6 +10,7 @@ A state module to manage Blue Coat SSL Visibility Devices.
 
 About
 =====
+
 This state module was designed to handle connections to a Blue Coat SSL Visibility device. This
 module relies on the bluecoat_sslv proxy module to interface with the device.
 
@@ -19,7 +20,7 @@ module relies on the bluecoat_sslv proxy module to interface with the device.
 '''
 
 # Import Python Libs
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function, unicode_literals
 import logging
 
 # Import Salt Libs


### PR DESCRIPTION
I noticed some documentation that needed to be cleaned up after merging PR #49557. This fixes some places where doc build warnings will occur and also fixes some of the Python `__future__` imports where things like `print_function` and `unicode_literals` were missing.

Refs #49557
