### PR TITLE
Add ability to clear DNS entries on static DNS

### DIFF
--- a/salt/modules/win_ip.py
+++ b/salt/modules/win_ip.py
@@ -319,6 +319,19 @@ def set_static_dns(iface, *addrs):
     '''
     Set static DNS configuration on a Windows NIC
 
+    Args:
+
+        iface (str): The name of the interface to set
+
+        addrs (*):
+            One or more DNS servers to be added
+
+            .. note::
+                If no DNS servers are passed the list will be cleared.
+
+    Returns:
+        dict: A dictionary containing the new DNS settings
+
     CLI Example:
 
     .. code-block:: bash
@@ -326,6 +339,15 @@ def set_static_dns(iface, *addrs):
         salt -G 'os_family:Windows' ip.set_static_dns 'Local Area Connection' '192.168.1.1'
         salt -G 'os_family:Windows' ip.set_static_dns 'Local Area Connection' '192.168.1.252' '192.168.1.253'
     '''
+    # Clear the list of DNS servers if not passed
+    if not addrs:
+        log.debug('Clearing list of DNS servers')
+        cmd = ['netsh', 'int', 'ip', 'set', 'dns',
+               'name={0}'.format(iface),
+               'source=static',
+               'address=none']
+        __salt__['cmd.run'](cmd, python_shell=False)
+        return {'Interface': iface, 'DNS Server': []}
     addr_index = 1
     for addr in addrs:
         if addr_index == 1:

--- a/salt/modules/win_ip.py
+++ b/salt/modules/win_ip.py
@@ -178,7 +178,9 @@ def enable(iface):
     '''
     if is_enabled(iface):
         return True
-    cmd = ['netsh', 'interface', 'set', 'interface', iface, 'admin=ENABLED']
+    cmd = ['netsh', 'interface', 'set', 'interface',
+           'name={0}'.format(iface),
+           'admin=ENABLED']
     __salt__['cmd.run'](cmd, python_shell=False)
     return is_enabled(iface)
 
@@ -195,7 +197,9 @@ def disable(iface):
     '''
     if is_disabled(iface):
         return True
-    cmd = ['netsh', 'interface', 'set', 'interface', iface, 'admin=DISABLED']
+    cmd = ['netsh', 'interface', 'set', 'interface',
+           'name={0}'.format(iface),
+           'admin=DISABLED']
     __salt__['cmd.run'](cmd, python_shell=False)
     return is_disabled(iface)
 
@@ -343,7 +347,7 @@ def set_static_dns(iface, *addrs):
     # Clear the list of DNS servers if [] is passed
     if str(addrs[0]).lower() == '[]':
         log.debug('Clearing list of DNS servers')
-        cmd = ['netsh', 'int', 'ip', 'set', 'dns',
+        cmd = ['netsh', 'interface', 'ip', 'set', 'dns',
                'name={0}'.format(iface),
                'source=static',
                'address=none']
@@ -352,14 +356,17 @@ def set_static_dns(iface, *addrs):
     addr_index = 1
     for addr in addrs:
         if addr_index == 1:
-            cmd = ['netsh', 'int', 'ip', 'set', 'dns',
-                   iface, 'static', addrs[0], 'primary']
+            cmd = ['netsh', 'interface', 'ip', 'set', 'dns',
+                   'name={0}'.format(iface),
+                   'source=static',
+                   'address={0}'.format(addr),
+                   'register=primary']
             __salt__['cmd.run'](cmd, python_shell=False)
             addr_index = addr_index + 1
         else:
             cmd = ['netsh', 'interface', 'ip', 'add', 'dns',
                    'name={0}'.format(iface),
-                   'addr={0}'.format(addr),
+                   'address={0}'.format(addr),
                    'index={0}'.format(addr_index)]
             __salt__['cmd.run'](cmd, python_shell=False)
             addr_index = addr_index + 1

--- a/salt/modules/win_ip.py
+++ b/salt/modules/win_ip.py
@@ -324,10 +324,9 @@ def set_static_dns(iface, *addrs):
         iface (str): The name of the interface to set
 
         addrs (*):
-            One or more DNS servers to be added
-
-            .. note::
-                If no DNS servers are passed the list will be cleared.
+            One or more DNS servers to be added. To clear the list of DNS
+            servers pass an empty list (``[]``). If undefined or ``None`` no
+            changes will be made.
 
     Returns:
         dict: A dictionary containing the new DNS settings
@@ -339,8 +338,10 @@ def set_static_dns(iface, *addrs):
         salt -G 'os_family:Windows' ip.set_static_dns 'Local Area Connection' '192.168.1.1'
         salt -G 'os_family:Windows' ip.set_static_dns 'Local Area Connection' '192.168.1.252' '192.168.1.253'
     '''
-    # Clear the list of DNS servers if not passed
-    if not addrs:
+    if addrs is () or str(addrs[0]).lower() == 'none':
+        return {'Interface': iface, 'DNS Server': 'No Changes'}
+    # Clear the list of DNS servers if [] is passed
+    if str(addrs[0]).lower() == '[]':
         log.debug('Clearing list of DNS servers')
         cmd = ['netsh', 'int', 'ip', 'set', 'dns',
                'name={0}'.format(iface),

--- a/salt/states/win_network.py
+++ b/salt/states/win_network.py
@@ -100,20 +100,20 @@ def _validate(dns_proto, dns_servers, ip_proto, ip_addrs, gateway):
         if dns_servers is not None:
             errors.append(
                 'The dns_servers param cannot be set if unless dns_proto is '
-                'set to \'static\'.'
+                'set to \'static\''
             )
     else:
         if str(dns_servers).lower() in ['none', '[]']:
             pass
         elif not isinstance(dns_servers, list):
             errors.append(
-                'The dns_servers param must be formatted as a list.'
+                'The dns_servers param must be formatted as a list'
             )
         else:
             bad_ips = [x for x in dns_servers
                        if not salt.utils.validate.net.ipv4_addr(x)]
             if bad_ips:
-                errors.append('Invalid DNS server IPs: {0}.'
+                errors.append('Invalid DNS server IPs: {0}'
                               .format(', '.join(bad_ips)))
 
     # Validate IP configuration
@@ -121,33 +121,33 @@ def _validate(dns_proto, dns_servers, ip_proto, ip_addrs, gateway):
         if ip_addrs is not None:
             errors.append(
                 'The ip_addrs param cannot be set if unless ip_proto is set '
-                'to \'static\'.'
+                'to \'static\''
             )
         if gateway is not None:
             errors.append(
                 'A gateway IP cannot be set if unless ip_proto is set to '
-                '\'static\'.'
+                '\'static\''
             )
     else:
         if not ip_addrs:
             errors.append(
-                'The ip_addrs param is required to set static IPs.'
+                'The ip_addrs param is required to set static IPs'
             )
         elif not isinstance(ip_addrs, list):
             errors.append(
-                'The ip_addrs param must be formatted as a list.'
+                'The ip_addrs param must be formatted as a list'
             )
         else:
             bad_ips = [x for x in ip_addrs
                        if not salt.utils.validate.net.ipv4_addr(x)]
             if bad_ips:
                 errors.append('The following static IPs are invalid: '
-                              '{0}.'.format(', '.join(bad_ips)))
+                              '{0}'.format(', '.join(bad_ips)))
 
             # Validate default gateway
             if gateway is not None:
                 if not salt.utils.validate.net.ipv4_addr(gateway):
-                    errors.append('Gateway IP {0} is invalid.'.format(gateway))
+                    errors.append('Gateway IP {0} is invalid'.format(gateway))
 
     return errors
 
@@ -174,7 +174,10 @@ def _changes(cur, dns_proto, dns_servers, ip_proto, ip_addrs, gateway):
         else 'dhcp'
     )
     if cur_dns_proto == 'static':
-        cur_dns_servers = cur['Statically Configured DNS Servers']
+        if isinstance(cur['Statically Configured DNS Servers'], list):
+            cur_dns_servers = cur['Statically Configured DNS Servers']
+        else:
+            cur_dns_servers = [cur['Statically Configured DNS Servers']]
         if set(dns_servers or ['None']) != set(cur_dns_servers):
             changes['dns_servers'] = dns_servers
     elif 'DNS servers configured through DHCP' in cur:
@@ -224,7 +227,7 @@ def managed(name,
 
         dns_servers (list): None
             A list of static DNS servers. To clear the list of DNS servers pass
-            an empty list. ``[]``
+            an empty list (``[]``). ``None`` will make no changes.
 
         ip_proto (str): None
             Set to ``static`` and use the ``ip_addrs`` and (optionally)
@@ -271,7 +274,7 @@ def managed(name,
         'name': name,
         'changes': {},
         'result': True,
-        'comment': 'Interface \'{0}\' is up to date.'.format(name)
+        'comment': 'Interface \'{0}\' is up to date'.format(name)
     }
 
     dns_proto = str(dns_proto).lower()
@@ -280,16 +283,16 @@ def managed(name,
     errors = []
     if dns_proto not in __VALID_PROTO:
         ret['result'] = False
-        errors.append('dns_proto must be one of the following: {0}.'
+        errors.append('dns_proto must be one of the following: {0}'
                       .format(', '.join(__VALID_PROTO)))
 
     if ip_proto not in __VALID_PROTO:
-        errors.append('ip_proto must be one of the following: {0}.'
+        errors.append('ip_proto must be one of the following: {0}'
                       .format(', '.join(__VALID_PROTO)))
 
     if errors:
         ret['result'] = False
-        ret['comment'] = ' '.join(errors)
+        ret['comment'] = '\n'.join(errors)
         return ret
 
     try:
@@ -328,7 +331,7 @@ def managed(name,
         if errors:
             ret['result'] = False
             ret['comment'] = ('The following SLS configuration errors were '
-                              'detected: {0}'.format(' '.join(errors)))
+                              'detected:\n- {0}'.format('\n- '.join(errors)))
             return ret
 
         old = __salt__['ip.get_interface'](name)
@@ -348,7 +351,7 @@ def managed(name,
         # If dns_servers is the default `None` make no changes
         # To clear the list, pass an empty dict
         if str(dns_servers).lower() == 'none':
-            changes.pop('dns_servers')
+            changes.pop('dns_servers', None)
 
         if not changes:
             return ret
@@ -356,31 +359,31 @@ def managed(name,
         if __opts__['test']:
             comments = []
             if 'dns_proto' in changes:
-                comments.append('DNS protocol will be changed to: {0}.'
+                comments.append('DNS protocol will be changed to: {0}'
                                 .format(changes['dns_proto']))
             if dns_proto == 'static' and 'dns_servers' in changes:
                 if len(changes['dns_servers']) == 0:
-                    comments.append('The list of DNS servers will be cleared.')
+                    comments.append('The list of DNS servers will be cleared')
                 else:
                     comments.append(
-                        'DNS servers will be set to the following: {0}.'
+                        'DNS servers will be set to the following: {0}'
                         .format(', '.join(changes['dns_servers']))
                     )
             if 'ip_proto' in changes:
-                comments.append('IP protocol will be changed to: {0}.'
+                comments.append('IP protocol will be changed to: {0}'
                                 .format(changes['ip_proto']))
             if ip_proto == 'static':
                 if 'ip_addrs' in changes:
                     comments.append(
-                        'IP addresses will be set to the following: {0}.'
+                        'IP addresses will be set to the following: {0}'
                         .format(', '.join(changes['ip_addrs']))
                     )
                 if 'gateway' in changes:
                     if changes['gateway'] is None:
-                        comments.append('Default gateway will be removed.')
+                        comments.append('Default gateway will be removed')
                     else:
                         comments.append(
-                            'Default gateway will be set to {0}.'
+                            'Default gateway will be set to {0}'
                             .format(changes['gateway'])
                         )
 

--- a/tests/unit/modules/test_win_ip.py
+++ b/tests/unit/modules/test_win_ip.py
@@ -13,7 +13,8 @@ from tests.support.mock import (
     MagicMock,
     patch,
     NO_MOCK,
-    NO_MOCK_REASON
+    NO_MOCK_REASON,
+    call
 )
 
 # Import Salt Libs
@@ -124,13 +125,21 @@ class WinShadowTestCase(TestCase, LoaderModuleMockMixin):
         '''
         Test if it enable an interface.
         '''
-        mock_cmd = MagicMock(return_value=ETHERNET_ENABLE)
-        with patch.dict(win_ip.__salt__, {'cmd.run': mock_cmd}):
+        # Test with enabled interface
+        with patch.object(win_ip, 'is_enabled', return_value=True):
             self.assertTrue(win_ip.enable('Ethernet'))
 
-        mock_cmd = MagicMock(return_value='Connect state: Disconnected')
-        with patch.dict(win_ip.__salt__, {'cmd.run': mock_cmd}):
-            self.assertFalse(win_ip.enable('Ethernet'))
+        mock_cmd = MagicMock()
+        with patch.object(win_ip, 'is_enabled', side_effect=[False, True]), \
+                patch.dict(win_ip.__salt__, {'cmd.run': mock_cmd}):
+            self.assertTrue(win_ip.enable('Ethernet'))
+
+        mock_cmd.called_once_with(
+            ['netsh', 'interface', 'set', 'interface',
+             'name=Ethernet',
+             'admin=ENABLED'],
+            python_shell=False
+        )
 
     # 'disable' function tests: 1
 
@@ -138,13 +147,20 @@ class WinShadowTestCase(TestCase, LoaderModuleMockMixin):
         '''
         Test if it disable an interface.
         '''
-        mock_cmd = MagicMock(return_value=ETHERNET_ENABLE)
-        with patch.dict(win_ip.__salt__, {'cmd.run': mock_cmd}):
-            self.assertFalse(win_ip.disable('Ethernet'))
-
-        mock_cmd = MagicMock(return_value='Connect state: Disconnected')
-        with patch.dict(win_ip.__salt__, {'cmd.run': mock_cmd}):
+        with patch.object(win_ip, 'is_disabled', return_value=True):
             self.assertTrue(win_ip.disable('Ethernet'))
+
+        mock_cmd = MagicMock()
+        with patch.object(win_ip, 'is_disabled', side_effect=[False, True]),\
+                patch.dict(win_ip.__salt__, {'cmd.run': mock_cmd}):
+            self.assertTrue(win_ip.disable('Ethernet'))
+
+        mock_cmd.called_once_with(
+            ['netsh', 'interface', 'set', 'interface',
+             'name=Ethernet',
+             'admin=DISABLED'],
+            python_shell=False
+        )
 
     # 'get_subnet_length' function tests: 1
 
@@ -203,7 +219,7 @@ class WinShadowTestCase(TestCase, LoaderModuleMockMixin):
         '''
         Test if it set static DNS configuration on a Windows NIC.
         '''
-        mock_cmd = MagicMock(return_value=ETHERNET_CONFIG)
+        mock_cmd = MagicMock()
         with patch.dict(win_ip.__salt__, {'cmd.run': mock_cmd}):
             self.assertDictEqual(win_ip.set_static_dns('Ethernet',
                                                        '192.168.1.252',
@@ -211,6 +227,54 @@ class WinShadowTestCase(TestCase, LoaderModuleMockMixin):
                                  {'DNS Server': ('192.168.1.252',
                                                  '192.168.1.253'),
                                   'Interface': 'Ethernet'})
+            mock_cmd.assert_has_calls([
+                call(['netsh', 'interface', 'ip', 'set', 'dns',
+                      'name=Ethernet',
+                      'source=static',
+                      'address=192.168.1.252',
+                      'register=primary'],
+                     python_shell=False),
+                call(['netsh', 'interface', 'ip', 'add', 'dns',
+                      'name=Ethernet',
+                      'address=192.168.1.253',
+                      'index=2'],
+                     python_shell=False)]
+            )
+
+    def test_set_static_dns_clear(self):
+        '''
+        Test if it set static DNS configuration on a Windows NIC.
+        '''
+        mock_cmd = MagicMock()
+        with patch.dict(win_ip.__salt__, {'cmd.run': mock_cmd}):
+            self.assertDictEqual(win_ip.set_static_dns('Ethernet', []),
+                                 {'DNS Server': [],
+                                  'Interface': 'Ethernet'})
+            mock_cmd.assert_called_once_with(
+                ['netsh', 'interface', 'ip', 'set', 'dns',
+                 'name=Ethernet',
+                 'source=static',
+                 'address=none'],
+                python_shell=False
+            )
+
+    def test_set_static_dns_no_action(self):
+        '''
+        Test if it set static DNS configuration on a Windows NIC.
+        '''
+        # Test passing nothing
+        self.assertDictEqual(win_ip.set_static_dns('Ethernet'),
+                             {'DNS Server': 'No Changes',
+                              'Interface': 'Ethernet'})
+        # Test passing None
+        self.assertDictEqual(win_ip.set_static_dns('Ethernet', None),
+                             {'DNS Server': 'No Changes',
+                              'Interface': 'Ethernet'})
+
+        # Test passing string None
+        self.assertDictEqual(win_ip.set_static_dns('Ethernet', 'None'),
+                             {'DNS Server': 'No Changes',
+                              'Interface': 'Ethernet'})
 
     # 'set_dhcp_dns' function tests: 1
 

--- a/tests/unit/states/test_win_network.py
+++ b/tests/unit/states/test_win_network.py
@@ -28,93 +28,242 @@ class WinNetworkTestCase(TestCase, LoaderModuleMockMixin):
     def setup_loader_modules(self):
         return {win_network: {}}
 
-    def test_managed(self):
+    def test_managed_missing_parameters(self):
         '''
-            Test to ensure that the named interface is configured properly.
+        Test to ensure that the named interface is configured properly.
         '''
         ret = {'name': 'salt',
                'changes': {},
                'result': False,
-               'comment': ''}
-        ret.update({'comment': 'dns_proto must be one of the following:'
-                    ' static, dhcp. ip_proto must be one of the following:'
-                    ' static, dhcp.'})
+               'comment': 'dns_proto must be one of the following: static, dhcp\n'
+                          'ip_proto must be one of the following: static, dhcp'}
         self.assertDictEqual(win_network.managed('salt'), ret)
 
+    def test_managed_static_enabled_false(self):
+        ret = {'name': 'salt',
+               'changes': {},
+               'result': True,
+               'comment': 'Interface \'salt\' is up to date (already disabled)'}
         mock_false = MagicMock(return_value=False)
-        mock_true = MagicMock(return_value=True)
-        mock1 = MagicMock(side_effect=[False, True, True, True, True, True,
-                                       True])
-        mock2 = MagicMock(side_effect=[False, True, True, {'salt': 'True'},
-                                       {'salt': 'True'}])
+        with patch.dict(win_network.__salt__, {"ip.is_enabled": mock_false}):
+            self.assertDictEqual(
+                win_network.managed(
+                    'salt', dns_proto='static', ip_proto='static', enabled=False),
+                ret)
+
+    def test_managed_test_true(self):
+        ret = {'name': 'salt',
+               'changes': {},
+               'result': False,
+               'comment': 'Failed to enable interface \'salt\' to make changes'}
+        mock_false = MagicMock(return_value=False)
         with patch.dict(win_network.__salt__, {"ip.is_enabled": mock_false,
-                                               "ip.is_disabled": mock1,
-                                               "ip.enable": mock_false,
-                                               "ip.get_interface": mock2,
-                                               "ip.set_dhcp_dns": mock_false,
-                                               "ip.set_dhcp_ip": mock_false}):
-            ret.update({'comment': "Interface 'salt' is up to date."
-                        " (already disabled)", 'result': True})
-            self.assertDictEqual(win_network.managed('salt',
-                                                     dns_proto='static',
-                                                     ip_proto='static',
-                                                     enabled=False), ret)
+                                               "ip.enable": mock_false}), \
+                patch.dict(win_network.__opts__, {"test": False}):
+            self.assertDictEqual(
+                win_network.managed(
+                    'salt', dns_proto='static', ip_proto='static'),
+                ret)
 
-            with patch.dict(win_network.__opts__, {"test": False}):
-                ret.update({'comment': "Failed to enable interface 'salt'"
-                            " to make changes", 'result': False})
-                self.assertDictEqual(win_network.managed('salt',
-                                                     dns_proto='static',
-                                                     ip_proto='static'),
-                                     ret)
-            mock_false = MagicMock(side_effect=['True', False, False, False, False,
-                                          False])
+    def test_managed_validate_errors(self):
+        ret = {'name': 'salt',
+               'changes': {},
+               'result': False,
+               'comment': 'The following SLS configuration errors were '
+                          'detected:\n'
+                          '- First Error\n'
+                          '- Second Error'}
+        mock_true = MagicMock(return_value=True)
+        mock_validate = MagicMock(return_value=['First Error', 'Second Error'])
+        with patch.dict(win_network.__salt__, {"ip.is_enabled": mock_true}),\
+                patch.object(win_network, '_validate', mock_validate):
+            self.assertDictEqual(
+                win_network.managed(
+                    'salt', dns_proto='static', ip_proto='static'),
+                ret)
 
-            with patch.dict(win_network.__salt__, {"ip.is_enabled": mock_true}):
-                with patch.object(win_network, '_validate', mock_false):
-                    ret.update({'comment': 'The following SLS configuration'
-                                ' errors were detected: T r u e'})
-                    self.assertDictEqual(win_network.managed('salt',
-                                                             dns_proto='static',
-                                                             ip_proto='static'),
-                                         ret)
+    def test_managed_get_current_config_failed(self):
+        ret = {'name': 'salt',
+               'changes': {},
+               'result': False,
+               'comment': 'Unable to get current configuration for interface '
+                          '\'salt\''}
+        mock_true = MagicMock(return_value=True)
+        mock_false = MagicMock(return_value=False)
+        mock_validate = MagicMock(return_value=[])
+        with patch.dict(win_network.__salt__, {'ip.is_enabled': mock_true,
+                                               'ip.get_interface': mock_false}), \
+                patch.object(win_network, '_validate', mock_validate):
 
-                    ret.update({'comment': "Unable to get current"
-                                " configuration for interface 'salt'",
-                                'result': False})
-                    self.assertDictEqual(win_network.managed('salt',
-                                                             dns_proto='dhcp',
-                                                             ip_proto='dhcp'),
-                                         ret)
+            self.assertDictEqual(
+                win_network.managed('salt', dns_proto='dhcp', ip_proto='dhcp'),
+                ret)
 
-                    mock_false = MagicMock(side_effect=[False, [''],
-                                                  {'dns_proto': 'dhcp',
-                                                   'ip_proto': 'dhcp'},
-                                                  {'dns_proto': 'dhcp',
-                                                   'ip_proto': 'dhcp'}])
-                    ret.update({'comment': "Interface 'salt' is up to date.",
-                                'result': True})
-                    with patch.object(win_network, '_changes', mock_false):
-                        self.assertDictEqual(win_network.managed('salt',
-                                                                 dns_proto='dhcp',
-                                                                 ip_proto='dhcp'
-                                                                 ), ret)
+    def test_managed_test_true_no_changes(self):
+        ret = {'name': 'salt',
+               'changes': {},
+               'result': True,
+               'comment': 'Interface \'salt\' is up to date'}
+        mock_true = MagicMock(return_value=True)
+        mock_validate = MagicMock(return_value=[])
+        mock_get_int = MagicMock(return_value={
+            'DHCP enabled': 'yes',
+            'DNS servers configured through DHCP': '192.168.0.10'})
+        with patch.dict(win_network.__salt__, {'ip.is_enabled': mock_true,
+                                               'ip.get_interface': mock_get_int}), \
+                patch.dict(win_network.__opts__, {"test": True}), \
+                patch.object(win_network, '_validate', mock_validate):
+            self.assertDictEqual(
+                win_network.managed('salt', dns_proto='dhcp', ip_proto='dhcp'),
+                ret)
 
-                        ret.update({'comment': "The following changes will be made"
-                                    " to interface 'salt': ", 'result': None})
-                        with patch.dict(win_network.__opts__, {"test": True}):
-                            self.assertDictEqual(win_network.managed('salt',
-                                                                     dns_proto='dh'
-                                                                     'cp',
-                                                                     ip_proto='dhcp'
-                                                                     ), ret)
+    def test_managed_test_true_changes(self):
+        ret = {'name': 'salt',
+               'changes': {},
+               'result': None,
+               'comment': 'The following changes will be made to interface '
+                          '\'salt\':\n'
+                          '- DNS protocol will be changed to: dhcp'}
+        mock_true = MagicMock(return_value=True)
+        mock_validate = MagicMock(return_value=[])
+        mock_get_int = MagicMock(return_value={
+            'DHCP enabled': 'no',
+            'Statically Configured DNS Servers': '192.168.0.10'})
+        with patch.dict(win_network.__salt__, {'ip.is_enabled': mock_true,
+                                               'ip.get_interface': mock_get_int}), \
+                patch.dict(win_network.__opts__, {"test": True}), \
+                patch.object(win_network, '_validate', mock_validate):
 
-                        with patch.dict(win_network.__opts__, {"test": False}):
-                            ret.update({'comment': "Failed to set desired"
-                                        " configuration settings for interface"
-                                        " 'salt'", 'result': False})
-                            self.assertDictEqual(win_network.managed('salt',
-                                                                     dns_proto='dh'
-                                                                     'cp',
-                                                                     ip_proto='dhcp'
-                                                                     ), ret)
+            self.assertDictEqual(
+                win_network.managed('salt', dns_proto='dhcp', ip_proto='dhcp'),
+                ret)
+
+    def test_managed_failed(self):
+        ret = {'name': 'salt',
+               'changes': {},
+               'result': False,
+               'comment': 'Failed to set desired configuration settings for '
+                          'interface \'salt\''}
+        mock_true = MagicMock(return_value=True)
+        mock_validate = MagicMock(return_value=[])
+        mock_get_int = MagicMock(return_value={
+            'DHCP enabled': 'no',
+            'Statically Configured DNS Servers': '192.168.0.10'})
+        with patch.dict(win_network.__salt__, {'ip.is_enabled': mock_true,
+                                               'ip.get_interface': mock_get_int,
+                                               'ip.set_dhcp_dns': mock_true,
+                                               'ip.set_dhcp_ip': mock_true}), \
+                patch.dict(win_network.__opts__, {"test": False}), \
+                patch.object(win_network, '_validate', mock_validate):
+            self.assertDictEqual(
+                win_network.managed('salt', dns_proto='dhcp', ip_proto='dhcp'),
+                ret)
+
+    def test_managed(self):
+        ret = {'name': 'salt',
+               'changes': {
+                   'DHCP enabled': {
+                       'new': 'yes',
+                       'old': 'no'},
+                   'DNS servers configured through DHCP': {
+                       'new': '192.168.0.10',
+                       'old': ''},
+                   'Statically Configured DNS Servers': {
+                       'new': '',
+                       'old': '192.168.0.10'
+                   }
+               },
+               'result': True,
+               'comment': 'Successfully updated configuration for interface '
+                          '\'salt\''}
+        mock_true = MagicMock(return_value=True)
+        mock_validate = MagicMock(return_value=[])
+        mock_get_int = MagicMock(side_effect=[
+            {'DHCP enabled': 'no', 'Statically Configured DNS Servers': '192.168.0.10'},
+            {'DHCP enabled': 'yes', 'DNS servers configured through DHCP': '192.168.0.10'},
+        ])
+        with patch.dict(win_network.__salt__, {'ip.is_enabled': mock_true,
+                                               'ip.get_interface': mock_get_int,
+                                               'ip.set_dhcp_dns': mock_true,
+                                               'ip.set_dhcp_ip': mock_true}), \
+             patch.dict(win_network.__opts__, {"test": False}), \
+             patch.object(win_network, '_validate', mock_validate):
+            self.assertDictEqual(
+                win_network.managed('salt', dns_proto='dhcp', ip_proto='dhcp'),
+                ret)
+
+    def test_managed_static_dns_clear(self):
+        expected = {'name': 'salt',
+                    'changes': {
+                        'Statically Configured DNS Servers': {
+                            'new': 'None',
+                            'old': '192.168.0.10'
+                        }
+                    },
+                    'result': True,
+                    'comment': 'Successfully updated configuration for '
+                               'interface \'salt\''}
+        mock_true = MagicMock(return_value=True)
+        mock_validate = MagicMock(return_value=[])
+        mock_get_int = MagicMock(side_effect=[
+            {'DHCP enabled': 'no', 'Statically Configured DNS Servers': '192.168.0.10'},
+            {'DHCP enabled': 'no', 'Statically Configured DNS Servers': 'None'},
+        ])
+        with patch.dict(win_network.__salt__, {'ip.is_enabled': mock_true,
+                                               'ip.get_interface': mock_get_int,
+                                               'ip.set_static_dns': mock_true}), \
+                patch.dict(win_network.__opts__, {"test": False}), \
+                patch.object(win_network, '_validate', mock_validate):
+            ret = win_network.managed(
+                'salt', dns_proto='static', dns_servers=[], ip_proto='dhcp')
+            self.assertDictEqual(ret, expected)
+
+    def test_managed_static_dns(self):
+        expected = {'name': 'salt',
+                    'changes': {
+                        'Statically Configured DNS Servers': {
+                            'new': '192.168.0.10',
+                            'old': 'None'
+                        }
+                    },
+                    'result': True,
+                    'comment': 'Successfully updated configuration for '
+                               'interface \'salt\''}
+        mock_true = MagicMock(return_value=True)
+        mock_validate = MagicMock(return_value=[])
+        mock_get_int = MagicMock(side_effect=[
+            {'DHCP enabled': 'no', 'Statically Configured DNS Servers': 'None'},
+            {'DHCP enabled': 'no', 'Statically Configured DNS Servers': '192.168.0.10'},
+        ])
+        with patch.dict(win_network.__salt__, {'ip.is_enabled': mock_true,
+                                               'ip.get_interface': mock_get_int,
+                                               'ip.set_static_dns': mock_true}), \
+                patch.dict(win_network.__opts__, {"test": False}), \
+                patch.object(win_network, '_validate', mock_validate):
+            ret = win_network.managed(
+                'salt', dns_proto='static', dns_servers=['192.168.0.10'], ip_proto='dhcp')
+            self.assertDictEqual(ret, expected)
+
+    def test_managed_static_dns_no_action(self):
+        expected = {'name': 'salt',
+                    'changes': {},
+                    'result': True,
+                    'comment': 'Interface \'salt\' is up to date'}
+        mock_true = MagicMock(return_value=True)
+        mock_validate = MagicMock(return_value=[])
+        mock_get_int = MagicMock(return_value={
+            'DHCP enabled': 'no',
+            'Statically Configured DNS Servers': '192.168.0.10'
+        })
+        with patch.dict(win_network.__salt__, {'ip.is_enabled': mock_true,
+                                               'ip.get_interface': mock_get_int,
+                                               'ip.set_static_dns': mock_true}), \
+                patch.dict(win_network.__opts__, {"test": False}), \
+                patch.object(win_network, '_validate', mock_validate):
+            # Don't pass dns_servers
+            ret = win_network.managed('salt', dns_proto='static', ip_proto='dhcp')
+            self.assertDictEqual(ret, expected)
+            # Pass dns_servers=None
+            ret = win_network.managed(
+                'salt', dns_proto='static', dns_servers=None, ip_proto='dhcp')
+            self.assertDictEqual(ret, expected)


### PR DESCRIPTION
### What does this PR do?
Adds the ability to clear the list of DNS entries in Windows by passing an empty list.

Execution Module:
- Passing no DNS servers will clear the list because it is using *args.
- Update documentation
- Added a note about clearing DNS entries

State Module
- An empty list in `dns_servers` will clear the entires
- `None` in `dns_servers` will do nothing (default behavior)
- Update Documentation

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/49730

### Tests written?
No

### Commits signed with GPG?
Yes