### PR TITLE
[2018.3] Adding retry_dns_count to minion

### DIFF
--- a/conf/minion
+++ b/conf/minion
@@ -66,6 +66,11 @@
 # Set to zero if the minion should shutdown and not retry.
 # retry_dns: 30
 
+# Set the number of times to attempt to resolve
+# the master hostname if name resolution fails. Defaults to None,
+# which will attempt the resolution indefinitely.
+# retry_dns_count: 3
+
 # Set the port used by the master reply and authentication server.
 #master_port: 4506
 

--- a/doc/ref/configuration/minion.rst
+++ b/doc/ref/configuration/minion.rst
@@ -307,10 +307,12 @@ Set to zero if the minion should shutdown and not retry.
 
     retry_dns: 30
 
-.. conf_minion:: retry_dns
+.. conf_minion:: retry_dns_count
 
 ``retry_dns_count``
--------------
+-------------------
+
+.. versionadded:: 2018.3.4
 
 Default: ``None``
 

--- a/doc/ref/configuration/minion.rst
+++ b/doc/ref/configuration/minion.rst
@@ -307,6 +307,21 @@ Set to zero if the minion should shutdown and not retry.
 
     retry_dns: 30
 
+.. conf_minion:: retry_dns
+
+``retry_dns_count``
+-------------
+
+Default: ``None``
+
+Set the number of attempts to perform when resolving
+the master hostname if name resolution fails.
+By default the minion will retry indefinitely.
+
+.. code-block:: yaml
+
+    retry_dns_count: 3
+
 .. conf_minion:: master_port
 
 ``master_port``

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -518,6 +518,7 @@ VALID_OPTS = {
     # The number of seconds to sleep between retrying an attempt to resolve the hostname of a
     # salt master
     'retry_dns': float,
+    'retry_dns_count': int,
 
     # In the case when the resolve of the salt master hostname fails, fall back to localhost
     'resolve_dns_fallback': bool,
@@ -1397,6 +1398,7 @@ DEFAULT_MINION_OPTS = {
     'update_url': False,
     'update_restart_services': [],
     'retry_dns': 30,
+    'retry_dns_count': None,
     'resolve_dns_fallback': True,
     'recon_max': 10000,
     'recon_default': 1000,

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -518,7 +518,7 @@ VALID_OPTS = {
     # The number of seconds to sleep between retrying an attempt to resolve the hostname of a
     # salt master
     'retry_dns': float,
-    'retry_dns_count': int,
+    'retry_dns_count': (type(None), int),
 
     # In the case when the resolve of the salt master hostname fails, fall back to localhost
     'resolve_dns_fallback': bool,

--- a/salt/exceptions.py
+++ b/salt/exceptions.py
@@ -96,6 +96,12 @@ class SaltSyndicMasterError(SaltException):
     '''
 
 
+class SaltMasterUnresolvableError(SaltException):
+    '''
+    Problem resolving the name of the Salt master
+    '''
+
+
 class MasterExit(SystemExit):
     '''
     Rise when the master exits

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -163,7 +163,6 @@ def resolve_dns(opts, fallback=True):
                 while True:
                     if retry_dns_count is not None:
                         if retry_dns_count == 0:
-                            ret['master_ip'] = '127.0.0.1'
                             raise SaltMasterUnresolvableError
                         retry_dns_count -= 1
                     import salt.log
@@ -995,7 +994,6 @@ class MinionManager(MinionBase):
 
             self._connect_minion(minion)
 
-        log.error(self.minions)
         if not self.minions:
             err = ('Minion unable to successfully connect to '
                    'a Salt Master.  Exiting.')

--- a/tests/unit/test_minion.py
+++ b/tests/unit/test_minion.py
@@ -16,7 +16,7 @@ from tests.support.helpers import skip_if_not_root
 # Import salt libs
 import salt.minion
 import salt.utils.event as event
-from salt.exceptions import SaltSystemExit
+from salt.exceptions import SaltSystemExit, SaltMasterUnresolvableError
 import salt.syspaths
 import tornado
 import tornado.testing
@@ -281,6 +281,17 @@ class MinionTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
                 self.assertTrue('beacons' not in minion.periodic_callbacks)
             finally:
                 minion.destroy()
+
+    def test_minion_retry_dns_count(self):
+        '''
+        Tests that the resolve_dns will retry dns look ups for a maximum of
+        3 times before raising a SaltMasterUnresolvableError exception.
+        '''
+        with patch.dict(__opts__, {'ipv6': False, 'master': 'dummy',
+                                   'master_port': '4555',
+                                   'retry_dns': 1, 'retry_dns_count': 3}):
+            self.assertRaises(SaltMasterUnresolvableError,
+                              salt.minion.resolve_dns, __opts__)
 
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)


### PR DESCRIPTION
### What does this PR do?
Updating the resolve_dns function in minion.py to include a new minion configuration option which will control how many attempts will be made when the master hostname is unable to be resolved before giving up.

### What issues does this PR fix or reference?
#49520 

### Previous Behavior
When a including a master hostname that doesn't resolve, particular in a multi-master setup, the resolve_dns function in the minion will continue indefinitely and never move onto other minions.

### New Behavior
This change updates that function to look for a new minion configuration option, `retry_dns_count`, which will allow the minion to either move on or exit following a specified number of attempts.

### Tests written?
Yes

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
