### PR TITLE
Protect nxos grain with proper __virtual__() check

### DIFF
--- a/salt/grains/nxos.py
+++ b/salt/grains/nxos.py
@@ -22,6 +22,11 @@ __virtualname__ = 'nxos'
 
 
 def __virtual__():
+    try:
+        salt.utils.nxos.version_info()
+    except RuntimeError as err:
+        return False, err
+
     return __virtualname__
 
 


### PR DESCRIPTION
The changes in PR #49676 made the following stacktrace occur when running on a system that doesn't have the proper NXOS/NXAPIClient settings exposed:

```
[CRITICAL] Failed to load grains defined in grain file nxos.system_information in function <function system_information at 0x3aeb758>, error:
Traceback (most recent call last):
  File "/testing/salt/loader.py", line 773, in grains
    ret = funcs[key](**kwargs)
  File "/testing/salt/grains/nxos.py", line 36, in system_information
    data = salt.utils.nxos.version_info()
  File "/testing/salt/utils/nxos.py", line 318, in version_info
    client = NxapiClient()
  File "/testing/salt/utils/nxos.py", line 78, in __init__
    raise RuntimeError("No host specified and no UDS found at {0}\n".format(self.NXAPI_UDS))
RuntimeError: No host specified and no UDS found at /tmp/nginx_local/nginx_1_be_nxapi.sock

local:
    True
```
🙁 

We need to protect the grains from loading when the settings are missing.

New Behavior:
```
# salt-call --local test.ping
local:
    True
```
😄 
