### PR TITLE
Move all pipelines to be fully scripted

### DIFF
--- a/.ci/kitchen-centos7-py2
+++ b/.ci/kitchen-centos7-py2
@@ -1,73 +1,75 @@
-pipeline {
-    agent { label 'kitchen-slave' }
-    options {
-        timestamps()
-        ansiColor('xterm')
-    }
-    environment {
-        SALT_KITCHEN_PLATFORMS = "/var/jenkins/workspace/platforms.yml"
-        SALT_KITCHEN_DRIVER = "/var/jenkins/workspace/driver.yml"
-        PATH = "/usr/local/rbenv/shims/:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/root/bin:/root/bin"
-        RBENV_VERSION = "2.4.2"
-        TEST_SUITE = "py2"
-        TEST_PLATFORM = "centos-7"
-        PY_COLORS = 1
-    }
-    stages {
-        stage('github-pending') {
-            steps {
-                githubNotify credentialsId: 'test-jenkins-credentials',
-                    description: "running ${TEST_SUITE}-${TEST_PLATFORM}...",
-                    status: 'PENDING',
-                    context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
-            }
-        }
-        stage('setup') {
-            steps {
-                sh 'bundle install --with ec2 windows --without opennebula docker'
-            }
-        }
-        stage('run kitchen') {
-            steps {
-                script { withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
-                    sshagent(credentials: ['jenkins-testing-ssh-key']) {
-                        sh 'ssh-add ~/.ssh/jenkins-testing.pem'
-                        sh 'bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM || bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM'
-                        sh 'bundle exec kitchen verify $TEST_SUITE-$TEST_PLATFORM'
+node('kitchen-slave') {
+    timestamps {
+        ansiColor('xterm') {
+            withEnv([
+                'SALT_KITCHEN_PLATFORMS=/var/jenkins/workspace/platforms.yml',
+                'SALT_KITCHEN_DRIVER=/var/jenkins/workspace/driver.yml',
+                'PATH=/usr/local/rbenv/shims/:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/root/bin:/root/bin',
+                'RBENV_VERSION=2.4.2',
+                'TEST_SUITE=py2',
+                'TEST_PLATFORM=centos-7',
+                'PY_COLORS=1',
+            {
+                stage('checkout-scm') {
+                    cleanWs notFailBuild: true
+                    checkout scm
+                }
+                try {
+                    stage('github-pending') {
+                        githubNotify credentialsId: 'test-jenkins-credentials',
+                            description: "running ${TEST_SUITE}-${TEST_PLATFORM}...",
+                            status: 'PENDING',
+                            context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
                     }
-                }}
-            }
-            post {
-                always {
-                    script { withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
-                        sshagent(credentials: ['jenkins-testing-ssh-key']) {
-                            sh 'ssh-add ~/.ssh/jenkins-testing.pem'
-                            sh 'bundle exec kitchen destroy $TEST_SUITE-$TEST_PLATFORM'
+                    stage('setup-bundle') {
+                        sh 'bundle install --with ec2 windows --without opennebula docker'
+                    }
+                    try {
+                        stage('run kitchen') {
+                            withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
+                                sshagent(credentials: ['jenkins-testing-ssh-key']) {
+                                    sh 'ssh-add ~/.ssh/jenkins-testing.pem'
+                                    sh 'bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM || bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM'
+                                    sh 'bundle exec kitchen verify $TEST_SUITE-$TEST_PLATFORM'
+                                }
+                            }
                         }
-                    }}
-                    archiveArtifacts artifacts: 'artifacts/xml-unittests-output/*.xml'
-                    archiveArtifacts artifacts: 'artifacts/logs/minion'
-                    archiveArtifacts artifacts: 'artifacts/logs/salt-runtests.log'
+                    }
+                    finally {
+                        stage('cleanup kitchen') {
+                            script { withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
+                                sshagent(credentials: ['jenkins-testing-ssh-key']) {
+                                    sh 'ssh-add ~/.ssh/jenkins-testing.pem'
+                                    sh 'bundle exec kitchen destroy $TEST_SUITE-$TEST_PLATFORM'
+                                }
+                            }}
+                            archiveArtifacts artifacts: 'artifacts/xml-unittests-output/*.xml'
+                            archiveArtifacts artifacts: 'artifacts/logs/minion'
+                            archiveArtifacts artifacts: 'artifacts/logs/salt-runtests.log'
+                        }
+                    }
+                }
+                finally {
+                    try {
+                        junit 'artifacts/xml-unittests-output/*.xml'
+                    }
+                    finally {
+                        cleanWs notFailBuild: true
+                        if (currentBuild.result == 'SUCCESS') {
+                            githubNotify credentialsId: 'test-jenkins-credentials',
+                                description: "The ${TEST_SUITE}-${TEST_PLATFORM} job has passed",
+                                status: 'SUCCESS',
+                                context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
+                        }
+                        else {
+                            githubNotify credentialsId: 'test-jenkins-credentials',
+                                description: "The ${TEST_SUITE}-${TEST_PLATFORM} job has failed",
+                                status: 'FAILURE',
+                                context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
+                        }
+                    }
                 }
             }
-        }
-    }
-    post {
-        always {
-            junit 'artifacts/xml-unittests-output/*.xml'
-            cleanWs()
-        }
-        success {
-            githubNotify credentialsId: 'test-jenkins-credentials',
-                description: "The ${TEST_SUITE}-${TEST_PLATFORM} job has passed",
-                status: 'SUCCESS',
-                context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
-        }
-        failure {
-            githubNotify credentialsId: 'test-jenkins-credentials',
-                description: "The ${TEST_SUITE}-${TEST_PLATFORM} job has failed",
-                status: 'FAILURE',
-                context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
         }
     }
 }

--- a/.ci/kitchen-centos7-py3
+++ b/.ci/kitchen-centos7-py3
@@ -1,73 +1,75 @@
-pipeline {
-    agent { label 'kitchen-slave' }
-    options {
-        timestamps()
-        ansiColor('xterm')
-    }
-    environment {
-        SALT_KITCHEN_PLATFORMS = "/var/jenkins/workspace/platforms.yml"
-        SALT_KITCHEN_DRIVER = "/var/jenkins/workspace/driver.yml"
-        PATH = "/usr/local/rbenv/shims/:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/root/bin:/root/bin"
-        RBENV_VERSION = "2.4.2"
-        TEST_SUITE = "py3"
-        TEST_PLATFORM = "centos-7"
-        PY_COLORS = 1
-    }
-    stages {
-        stage('github-pending') {
-            steps {
-                githubNotify credentialsId: 'test-jenkins-credentials',
-                    description: "running ${TEST_SUITE}-${TEST_PLATFORM}...",
-                    status: 'PENDING',
-                    context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
-            }
-        }
-        stage('setup') {
-            steps {
-                sh 'bundle install --with ec2 windows --without opennebula docker'
-            }
-        }
-        stage('run kitchen') {
-            steps {
-                script { withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
-                    sshagent(credentials: ['jenkins-testing-ssh-key']) {
-                        sh 'ssh-add ~/.ssh/jenkins-testing.pem'
-                        sh 'bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM || bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM'
-                        sh 'bundle exec kitchen verify $TEST_SUITE-$TEST_PLATFORM'
+node('kitchen-slave') {
+    timestamps {
+        ansiColor('xterm') {
+            withEnv([
+                'SALT_KITCHEN_PLATFORMS=/var/jenkins/workspace/platforms.yml',
+                'SALT_KITCHEN_DRIVER=/var/jenkins/workspace/driver.yml',
+                'PATH=/usr/local/rbenv/shims/:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/root/bin:/root/bin',
+                'RBENV_VERSION=2.4.2',
+                'TEST_SUITE=py3',
+                'TEST_PLATFORM=centos-7',
+                'PY_COLORS=1',
+            {
+                stage('checkout-scm') {
+                    cleanWs notFailBuild: true
+                    checkout scm
+                }
+                try {
+                    stage('github-pending') {
+                        githubNotify credentialsId: 'test-jenkins-credentials',
+                            description: "running ${TEST_SUITE}-${TEST_PLATFORM}...",
+                            status: 'PENDING',
+                            context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
                     }
-                }}
-            }
-            post {
-                always {
-                    script { withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
-                        sshagent(credentials: ['jenkins-testing-ssh-key']) {
-                            sh 'ssh-add ~/.ssh/jenkins-testing.pem'
-                            sh 'bundle exec kitchen destroy $TEST_SUITE-$TEST_PLATFORM'
+                    stage('setup-bundle') {
+                        sh 'bundle install --with ec2 windows --without opennebula docker'
+                    }
+                    try {
+                        stage('run kitchen') {
+                            withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
+                                sshagent(credentials: ['jenkins-testing-ssh-key']) {
+                                    sh 'ssh-add ~/.ssh/jenkins-testing.pem'
+                                    sh 'bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM || bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM'
+                                    sh 'bundle exec kitchen verify $TEST_SUITE-$TEST_PLATFORM'
+                                }
+                            }
                         }
-                    }}
-                    archiveArtifacts artifacts: 'artifacts/xml-unittests-output/*.xml'
-                    archiveArtifacts artifacts: 'artifacts/logs/minion'
-                    archiveArtifacts artifacts: 'artifacts/logs/salt-runtests.log'
+                    }
+                    finally {
+                        stage('cleanup kitchen') {
+                            script { withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
+                                sshagent(credentials: ['jenkins-testing-ssh-key']) {
+                                    sh 'ssh-add ~/.ssh/jenkins-testing.pem'
+                                    sh 'bundle exec kitchen destroy $TEST_SUITE-$TEST_PLATFORM'
+                                }
+                            }}
+                            archiveArtifacts artifacts: 'artifacts/xml-unittests-output/*.xml'
+                            archiveArtifacts artifacts: 'artifacts/logs/minion'
+                            archiveArtifacts artifacts: 'artifacts/logs/salt-runtests.log'
+                        }
+                    }
+                }
+                finally {
+                    try {
+                        junit 'artifacts/xml-unittests-output/*.xml'
+                    }
+                    finally {
+                        cleanWs notFailBuild: true
+                        if (currentBuild.result == 'SUCCESS') {
+                            githubNotify credentialsId: 'test-jenkins-credentials',
+                                description: "The ${TEST_SUITE}-${TEST_PLATFORM} job has passed",
+                                status: 'SUCCESS',
+                                context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
+                        }
+                        else {
+                            githubNotify credentialsId: 'test-jenkins-credentials',
+                                description: "The ${TEST_SUITE}-${TEST_PLATFORM} job has failed",
+                                status: 'FAILURE',
+                                context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
+                        }
+                    }
                 }
             }
-        }
-    }
-    post {
-        always {
-            junit 'artifacts/xml-unittests-output/*.xml'
-            cleanWs()
-        }
-        success {
-            githubNotify credentialsId: 'test-jenkins-credentials',
-                description: "The ${TEST_SUITE}-${TEST_PLATFORM} job has passed",
-                status: 'SUCCESS',
-                context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
-        }
-        failure {
-            githubNotify credentialsId: 'test-jenkins-credentials',
-                description: "The ${TEST_SUITE}-${TEST_PLATFORM} job has failed",
-                status: 'FAILURE',
-                context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
         }
     }
 }

--- a/.ci/kitchen-ubuntu1604-py2
+++ b/.ci/kitchen-ubuntu1604-py2
@@ -1,73 +1,75 @@
-pipeline {
-    agent { label 'kitchen-slave' }
-    options {
-        timestamps()
-        ansiColor('xterm')
-    }
-    environment {
-        SALT_KITCHEN_PLATFORMS = "/var/jenkins/workspace/platforms.yml"
-        SALT_KITCHEN_DRIVER = "/var/jenkins/workspace/driver.yml"
-        PATH = "/usr/local/rbenv/shims/:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/root/bin:/root/bin"
-        RBENV_VERSION = "2.4.2"
-        TEST_SUITE = "py2"
-        TEST_PLATFORM = "ubuntu-1604"
-        PY_COLORS = 1
-    }
-    stages {
-        stage('github-pending') {
-            steps {
-                githubNotify credentialsId: 'test-jenkins-credentials',
-                    description: "running ${TEST_SUITE}-${TEST_PLATFORM}...",
-                    status: 'PENDING',
-                    context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
-            }
-        }
-        stage('setup') {
-            steps {
-                sh 'bundle install --with ec2 windows --without opennebula docker'
-            }
-        }
-        stage('run kitchen') {
-            steps {
-                script { withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
-                    sshagent(credentials: ['jenkins-testing-ssh-key']) {
-                        sh 'ssh-add ~/.ssh/jenkins-testing.pem'
-                        sh 'bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM || bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM'
-                        sh 'bundle exec kitchen verify $TEST_SUITE-$TEST_PLATFORM'
+node('kitchen-slave') {
+    timestamps {
+        ansiColor('xterm') {
+            withEnv([
+                'SALT_KITCHEN_PLATFORMS=/var/jenkins/workspace/platforms.yml',
+                'SALT_KITCHEN_DRIVER=/var/jenkins/workspace/driver.yml',
+                'PATH=/usr/local/rbenv/shims/:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/root/bin:/root/bin',
+                'RBENV_VERSION=2.4.2',
+                'TEST_SUITE=py2',
+                'TEST_PLATFORM=ubuntu-1604',
+                'PY_COLORS=1',
+            {
+                stage('checkout-scm') {
+                    cleanWs notFailBuild: true
+                    checkout scm
+                }
+                try {
+                    stage('github-pending') {
+                        githubNotify credentialsId: 'test-jenkins-credentials',
+                            description: "running ${TEST_SUITE}-${TEST_PLATFORM}...",
+                            status: 'PENDING',
+                            context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
                     }
-                }}
-            }
-            post {
-                always {
-                    script { withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
-                        sshagent(credentials: ['jenkins-testing-ssh-key']) {
-                            sh 'ssh-add ~/.ssh/jenkins-testing.pem'
-                            sh 'bundle exec kitchen destroy $TEST_SUITE-$TEST_PLATFORM'
+                    stage('setup-bundle') {
+                        sh 'bundle install --with ec2 windows --without opennebula docker'
+                    }
+                    try {
+                        stage('run kitchen') {
+                            withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
+                                sshagent(credentials: ['jenkins-testing-ssh-key']) {
+                                    sh 'ssh-add ~/.ssh/jenkins-testing.pem'
+                                    sh 'bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM || bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM'
+                                    sh 'bundle exec kitchen verify $TEST_SUITE-$TEST_PLATFORM'
+                                }
+                            }
                         }
-                    }}
-                    archiveArtifacts artifacts: 'artifacts/xml-unittests-output/*.xml'
-                    archiveArtifacts artifacts: 'artifacts/logs/minion'
-                    archiveArtifacts artifacts: 'artifacts/logs/salt-runtests.log'
+                    }
+                    finally {
+                        stage('cleanup kitchen') {
+                            script { withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
+                                sshagent(credentials: ['jenkins-testing-ssh-key']) {
+                                    sh 'ssh-add ~/.ssh/jenkins-testing.pem'
+                                    sh 'bundle exec kitchen destroy $TEST_SUITE-$TEST_PLATFORM'
+                                }
+                            }}
+                            archiveArtifacts artifacts: 'artifacts/xml-unittests-output/*.xml'
+                            archiveArtifacts artifacts: 'artifacts/logs/minion'
+                            archiveArtifacts artifacts: 'artifacts/logs/salt-runtests.log'
+                        }
+                    }
+                }
+                finally {
+                    try {
+                        junit 'artifacts/xml-unittests-output/*.xml'
+                    }
+                    finally {
+                        cleanWs notFailBuild: true
+                        if (currentBuild.result == 'SUCCESS') {
+                            githubNotify credentialsId: 'test-jenkins-credentials',
+                                description: "The ${TEST_SUITE}-${TEST_PLATFORM} job has passed",
+                                status: 'SUCCESS',
+                                context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
+                        }
+                        else {
+                            githubNotify credentialsId: 'test-jenkins-credentials',
+                                description: "The ${TEST_SUITE}-${TEST_PLATFORM} job has failed",
+                                status: 'FAILURE',
+                                context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
+                        }
+                    }
                 }
             }
-        }
-    }
-    post {
-        always {
-            junit 'artifacts/xml-unittests-output/*.xml'
-            cleanWs()
-        }
-        success {
-            githubNotify credentialsId: 'test-jenkins-credentials',
-                description: "The ${TEST_SUITE}-${TEST_PLATFORM} job has passed",
-                status: 'SUCCESS',
-                context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
-        }
-        failure {
-            githubNotify credentialsId: 'test-jenkins-credentials',
-                description: "The ${TEST_SUITE}-${TEST_PLATFORM} job has failed",
-                status: 'FAILURE',
-                context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
         }
     }
 }

--- a/.ci/kitchen-ubuntu1604-py3
+++ b/.ci/kitchen-ubuntu1604-py3
@@ -1,73 +1,75 @@
-pipeline {
-    agent { label 'kitchen-slave' }
-    options {
-        timestamps()
-        ansiColor('xterm')
-    }
-    environment {
-        SALT_KITCHEN_PLATFORMS = "/var/jenkins/workspace/platforms.yml"
-        SALT_KITCHEN_DRIVER = "/var/jenkins/workspace/driver.yml"
-        PATH = "/usr/local/rbenv/shims/:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/root/bin:/root/bin"
-        RBENV_VERSION = "2.4.2"
-        TEST_SUITE = "py3"
-        TEST_PLATFORM = "ubuntu-1604"
-        PY_COLORS = 1
-    }
-    stages {
-        stage('github-pending') {
-            steps {
-                githubNotify credentialsId: 'test-jenkins-credentials',
-                    description: "running ${TEST_SUITE}-${TEST_PLATFORM}...",
-                    status: 'PENDING',
-                    context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
-            }
-        }
-        stage('setup') {
-            steps {
-                sh 'bundle install --with ec2 windows --without opennebula docker'
-            }
-        }
-        stage('run kitchen') {
-            steps {
-                script { withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
-                    sshagent(credentials: ['jenkins-testing-ssh-key']) {
-                        sh 'ssh-add ~/.ssh/jenkins-testing.pem'
-                        sh 'bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM || bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM'
-                        sh 'bundle exec kitchen verify $TEST_SUITE-$TEST_PLATFORM'
+node('kitchen-slave') {
+    timestamps {
+        ansiColor('xterm') {
+            withEnv([
+                'SALT_KITCHEN_PLATFORMS=/var/jenkins/workspace/platforms.yml',
+                'SALT_KITCHEN_DRIVER=/var/jenkins/workspace/driver.yml',
+                'PATH=/usr/local/rbenv/shims/:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/root/bin:/root/bin',
+                'RBENV_VERSION=2.4.2',
+                'TEST_SUITE=py3',
+                'TEST_PLATFORM=ubuntu-1604',
+                'PY_COLORS=1',
+            {
+                stage('checkout-scm') {
+                    cleanWs notFailBuild: true
+                    checkout scm
+                }
+                try {
+                    stage('github-pending') {
+                        githubNotify credentialsId: 'test-jenkins-credentials',
+                            description: "running ${TEST_SUITE}-${TEST_PLATFORM}...",
+                            status: 'PENDING',
+                            context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
                     }
-                }}
-            }
-            post {
-                always {
-                    script { withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
-                        sshagent(credentials: ['jenkins-testing-ssh-key']) {
-                            sh 'ssh-add ~/.ssh/jenkins-testing.pem'
-                            sh 'bundle exec kitchen destroy $TEST_SUITE-$TEST_PLATFORM'
+                    stage('setup-bundle') {
+                        sh 'bundle install --with ec2 windows --without opennebula docker'
+                    }
+                    try {
+                        stage('run kitchen') {
+                            withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
+                                sshagent(credentials: ['jenkins-testing-ssh-key']) {
+                                    sh 'ssh-add ~/.ssh/jenkins-testing.pem'
+                                    sh 'bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM || bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM'
+                                    sh 'bundle exec kitchen verify $TEST_SUITE-$TEST_PLATFORM'
+                                }
+                            }
                         }
-                    }}
-                    archiveArtifacts artifacts: 'artifacts/xml-unittests-output/*.xml'
-                    archiveArtifacts artifacts: 'artifacts/logs/minion'
-                    archiveArtifacts artifacts: 'artifacts/logs/salt-runtests.log'
+                    }
+                    finally {
+                        stage('cleanup kitchen') {
+                            script { withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
+                                sshagent(credentials: ['jenkins-testing-ssh-key']) {
+                                    sh 'ssh-add ~/.ssh/jenkins-testing.pem'
+                                    sh 'bundle exec kitchen destroy $TEST_SUITE-$TEST_PLATFORM'
+                                }
+                            }}
+                            archiveArtifacts artifacts: 'artifacts/xml-unittests-output/*.xml'
+                            archiveArtifacts artifacts: 'artifacts/logs/minion'
+                            archiveArtifacts artifacts: 'artifacts/logs/salt-runtests.log'
+                        }
+                    }
+                }
+                finally {
+                    try {
+                        junit 'artifacts/xml-unittests-output/*.xml'
+                    }
+                    finally {
+                        cleanWs notFailBuild: true
+                        if (currentBuild.result == 'SUCCESS') {
+                            githubNotify credentialsId: 'test-jenkins-credentials',
+                                description: "The ${TEST_SUITE}-${TEST_PLATFORM} job has passed",
+                                status: 'SUCCESS',
+                                context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
+                        }
+                        else {
+                            githubNotify credentialsId: 'test-jenkins-credentials',
+                                description: "The ${TEST_SUITE}-${TEST_PLATFORM} job has failed",
+                                status: 'FAILURE',
+                                context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
+                        }
+                    }
                 }
             }
-        }
-    }
-    post {
-        always {
-            junit 'artifacts/xml-unittests-output/*.xml'
-            cleanWs()
-        }
-        success {
-            githubNotify credentialsId: 'test-jenkins-credentials',
-                description: "The ${TEST_SUITE}-${TEST_PLATFORM} job has passed",
-                status: 'SUCCESS',
-                context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
-        }
-        failure {
-            githubNotify credentialsId: 'test-jenkins-credentials',
-                description: "The ${TEST_SUITE}-${TEST_PLATFORM} job has failed",
-                status: 'FAILURE',
-                context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
         }
     }
 }

--- a/.ci/kitchen-windows2016-py2
+++ b/.ci/kitchen-windows2016-py2
@@ -1,73 +1,75 @@
-pipeline {
-    agent { label 'kitchen-slave' }
-    options {
-        timestamps()
-        ansiColor('xterm')
-    }
-    environment {
-        SALT_KITCHEN_PLATFORMS = "/var/jenkins/workspace/platforms.yml"
-        SALT_KITCHEN_DRIVER = "/var/jenkins/workspace/driver.yml"
-        PATH = "/usr/local/rbenv/shims/:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/root/bin:/root/bin"
-        RBENV_VERSION = "2.4.2"
-        TEST_SUITE = "py2"
-        TEST_PLATFORM = "windows-2016"
-        PY_COLORS = 1
-    }
-    stages {
-        stage('github-pending') {
-            steps {
-                githubNotify credentialsId: 'test-jenkins-credentials',
-                    description: "running ${TEST_SUITE}-${TEST_PLATFORM}...",
-                    status: 'PENDING',
-                    context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
-            }
-        }
-        stage('setup') {
-            steps {
-                sh 'bundle install --with ec2 windows --without opennebula docker'
-            }
-        }
-        stage('run kitchen') {
-            steps {
-                script { withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
-                    sshagent(credentials: ['jenkins-testing-ssh-key']) {
-                        sh 'ssh-add ~/.ssh/jenkins-testing.pem'
-                        sh 'bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM || bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM'
-                        sh 'bundle exec kitchen verify $TEST_SUITE-$TEST_PLATFORM'
+node('kitchen-slave') {
+    timestamps {
+        ansiColor('xterm') {
+            withEnv([
+                'SALT_KITCHEN_PLATFORMS=/var/jenkins/workspace/platforms.yml',
+                'SALT_KITCHEN_DRIVER=/var/jenkins/workspace/driver.yml',
+                'PATH=/usr/local/rbenv/shims/:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/root/bin:/root/bin',
+                'RBENV_VERSION=2.4.2',
+                'TEST_SUITE=py2',
+                'TEST_PLATFORM=windows-2016',
+                'PY_COLORS=1',
+            {
+                stage('checkout-scm') {
+                    cleanWs notFailBuild: true
+                    checkout scm
+                }
+                try {
+                    stage('github-pending') {
+                        githubNotify credentialsId: 'test-jenkins-credentials',
+                            description: "running ${TEST_SUITE}-${TEST_PLATFORM}...",
+                            status: 'PENDING',
+                            context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
                     }
-                }}
-            }
-            post {
-                always {
-                    script { withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
-                        sshagent(credentials: ['jenkins-testing-ssh-key']) {
-                            sh 'ssh-add ~/.ssh/jenkins-testing.pem'
-                            sh 'bundle exec kitchen destroy $TEST_SUITE-$TEST_PLATFORM'
+                    stage('setup-bundle') {
+                        sh 'bundle install --with ec2 windows --without opennebula docker'
+                    }
+                    try {
+                        stage('run kitchen') {
+                            withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
+                                sshagent(credentials: ['jenkins-testing-ssh-key']) {
+                                    sh 'ssh-add ~/.ssh/jenkins-testing.pem'
+                                    sh 'bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM || bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM'
+                                    sh 'bundle exec kitchen verify $TEST_SUITE-$TEST_PLATFORM'
+                                }
+                            }
                         }
-                    }}
-                    archiveArtifacts artifacts: 'artifacts/xml-unittests-output/*.xml'
-                    archiveArtifacts artifacts: 'artifacts/logs/minion'
-                    archiveArtifacts artifacts: 'artifacts/logs/salt-runtests.log'
+                    }
+                    finally {
+                        stage('cleanup kitchen') {
+                            script { withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
+                                sshagent(credentials: ['jenkins-testing-ssh-key']) {
+                                    sh 'ssh-add ~/.ssh/jenkins-testing.pem'
+                                    sh 'bundle exec kitchen destroy $TEST_SUITE-$TEST_PLATFORM'
+                                }
+                            }}
+                            archiveArtifacts artifacts: 'artifacts/xml-unittests-output/*.xml'
+                            archiveArtifacts artifacts: 'artifacts/logs/minion'
+                            archiveArtifacts artifacts: 'artifacts/logs/salt-runtests.log'
+                        }
+                    }
+                }
+                finally {
+                    try {
+                        junit 'artifacts/xml-unittests-output/*.xml'
+                    }
+                    finally {
+                        cleanWs notFailBuild: true
+                        if (currentBuild.result == 'SUCCESS') {
+                            githubNotify credentialsId: 'test-jenkins-credentials',
+                                description: "The ${TEST_SUITE}-${TEST_PLATFORM} job has passed",
+                                status: 'SUCCESS',
+                                context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
+                        }
+                        else {
+                            githubNotify credentialsId: 'test-jenkins-credentials',
+                                description: "The ${TEST_SUITE}-${TEST_PLATFORM} job has failed",
+                                status: 'FAILURE',
+                                context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
+                        }
+                    }
                 }
             }
-        }
-    }
-    post {
-        always {
-            junit 'artifacts/xml-unittests-output/*.xml'
-            cleanWs()
-        }
-        success {
-            githubNotify credentialsId: 'test-jenkins-credentials',
-                description: "The ${TEST_SUITE}-${TEST_PLATFORM} job has passed",
-                status: 'SUCCESS',
-                context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
-        }
-        failure {
-            githubNotify credentialsId: 'test-jenkins-credentials',
-                description: "The ${TEST_SUITE}-${TEST_PLATFORM} job has failed",
-                status: 'FAILURE',
-                context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
         }
     }
 }

--- a/.ci/kitchen-windows2016-py3
+++ b/.ci/kitchen-windows2016-py3
@@ -1,73 +1,75 @@
-pipeline {
-    agent { label 'kitchen-slave' }
-    options {
-        timestamps()
-        ansiColor('xterm')
-    }
-    environment {
-        SALT_KITCHEN_PLATFORMS = "/var/jenkins/workspace/platforms.yml"
-        SALT_KITCHEN_DRIVER = "/var/jenkins/workspace/driver.yml"
-        PATH = "/usr/local/rbenv/shims/:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/root/bin:/root/bin"
-        RBENV_VERSION = "2.4.2"
-        TEST_SUITE = "py3"
-        TEST_PLATFORM = "windows-2016"
-        PY_COLORS = 1
-    }
-    stages {
-        stage('github-pending') {
-            steps {
-                githubNotify credentialsId: 'test-jenkins-credentials',
-                    description: "running ${TEST_SUITE}-${TEST_PLATFORM}...",
-                    status: 'PENDING',
-                    context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
-            }
-        }
-        stage('setup') {
-            steps {
-                sh 'bundle install --with ec2 windows --without opennebula docker'
-            }
-        }
-        stage('run kitchen') {
-            steps {
-                script { withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
-                    sshagent(credentials: ['jenkins-testing-ssh-key']) {
-                        sh 'ssh-add ~/.ssh/jenkins-testing.pem'
-                        sh 'bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM || bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM'
-                        sh 'bundle exec kitchen verify $TEST_SUITE-$TEST_PLATFORM'
+node('kitchen-slave') {
+    timestamps {
+        ansiColor('xterm') {
+            withEnv([
+                'SALT_KITCHEN_PLATFORMS=/var/jenkins/workspace/platforms.yml',
+                'SALT_KITCHEN_DRIVER=/var/jenkins/workspace/driver.yml',
+                'PATH=/usr/local/rbenv/shims/:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/root/bin:/root/bin',
+                'RBENV_VERSION=2.4.2',
+                'TEST_SUITE=py3',
+                'TEST_PLATFORM=windows-2016',
+                'PY_COLORS=1',
+            {
+                stage('checkout-scm') {
+                    cleanWs notFailBuild: true
+                    checkout scm
+                }
+                try {
+                    stage('github-pending') {
+                        githubNotify credentialsId: 'test-jenkins-credentials',
+                            description: "running ${TEST_SUITE}-${TEST_PLATFORM}...",
+                            status: 'PENDING',
+                            context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
                     }
-                }}
-            }
-            post {
-                always {
-                    script { withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
-                        sshagent(credentials: ['jenkins-testing-ssh-key']) {
-                            sh 'ssh-add ~/.ssh/jenkins-testing.pem'
-                            sh 'bundle exec kitchen destroy $TEST_SUITE-$TEST_PLATFORM'
+                    stage('setup-bundle') {
+                        sh 'bundle install --with ec2 windows --without opennebula docker'
+                    }
+                    try {
+                        stage('run kitchen') {
+                            withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
+                                sshagent(credentials: ['jenkins-testing-ssh-key']) {
+                                    sh 'ssh-add ~/.ssh/jenkins-testing.pem'
+                                    sh 'bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM || bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM'
+                                    sh 'bundle exec kitchen verify $TEST_SUITE-$TEST_PLATFORM'
+                                }
+                            }
                         }
-                    }}
-                    archiveArtifacts artifacts: 'artifacts/xml-unittests-output/*.xml'
-                    archiveArtifacts artifacts: 'artifacts/logs/minion'
-                    archiveArtifacts artifacts: 'artifacts/logs/salt-runtests.log'
+                    }
+                    finally {
+                        stage('cleanup kitchen') {
+                            script { withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
+                                sshagent(credentials: ['jenkins-testing-ssh-key']) {
+                                    sh 'ssh-add ~/.ssh/jenkins-testing.pem'
+                                    sh 'bundle exec kitchen destroy $TEST_SUITE-$TEST_PLATFORM'
+                                }
+                            }}
+                            archiveArtifacts artifacts: 'artifacts/xml-unittests-output/*.xml'
+                            archiveArtifacts artifacts: 'artifacts/logs/minion'
+                            archiveArtifacts artifacts: 'artifacts/logs/salt-runtests.log'
+                        }
+                    }
+                }
+                finally {
+                    try {
+                        junit 'artifacts/xml-unittests-output/*.xml'
+                    }
+                    finally {
+                        cleanWs notFailBuild: true
+                        if (currentBuild.result == 'SUCCESS') {
+                            githubNotify credentialsId: 'test-jenkins-credentials',
+                                description: "The ${TEST_SUITE}-${TEST_PLATFORM} job has passed",
+                                status: 'SUCCESS',
+                                context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
+                        }
+                        else {
+                            githubNotify credentialsId: 'test-jenkins-credentials',
+                                description: "The ${TEST_SUITE}-${TEST_PLATFORM} job has failed",
+                                status: 'FAILURE',
+                                context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
+                        }
+                    }
                 }
             }
-        }
-    }
-    post {
-        always {
-            junit 'artifacts/xml-unittests-output/*.xml'
-            cleanWs()
-        }
-        success {
-            githubNotify credentialsId: 'test-jenkins-credentials',
-                description: "The ${TEST_SUITE}-${TEST_PLATFORM} job has passed",
-                status: 'SUCCESS',
-                context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
-        }
-        failure {
-            githubNotify credentialsId: 'test-jenkins-credentials',
-                description: "The ${TEST_SUITE}-${TEST_PLATFORM} job has failed",
-                status: 'FAILURE',
-                context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
         }
     }
 }


### PR DESCRIPTION
This allows us to properly clean out the workspace before a job run.

### What does this PR do?

Changes the Jenkinsfiles to use scripted pipelines, not declarative pipelines. Should fix the failures we were getting with old workspaces being used. Not sure exactly how it's going to work if we are actually using old workspaces...but this should make new builds work.

### What issues does this PR fix or reference?

Not cleaning up our workspace before the build. We now clean the workspace, clone the git repo, and then do the build.

### Commits signed with GPG?

Yes

@gtmanfred @dubb-b @rallytime 