### PR TITLE
Add mod_aggregate to ssh_auth to manage authorized_keys

### DIFF
--- a/salt/states/ssh_auth.py
+++ b/salt/states/ssh_auth.py
@@ -263,7 +263,7 @@ def present(
     aggregate
         Removes any existing ssh keys except for those managed by subsequent ``ssh_auth.present``
 
-        .. versionadded:: Fluorine
+        .. versionadded:: Neon
     '''
     ret = {'name': name,
            'changes': {},


### PR DESCRIPTION
Not sure if this is an appropriate way to handle this scenario. Comments requested!

### What does this PR do?
Adds a mod_aggregate function to the ssh_auth state. This then builds up a list of the ssh keys from this and subsequent ssh_auth.present declarations, for each user. The present function then uses this list to determine what ssh_keys are being managed by salt, and removes the rest.

### What issues does this PR fix or reference?
#13340

### Previous Behavior
ssh_auth.present was only able to add keys. Any old keys not managed by salt need to be removed by specifying them in a ssh_auth.absent state.

### New Behavior
By specifying `aggregate: True` for the ssh_auth.present state, ssh keys not added by salt will be removed.

####  Example
When adding the Asomekeyh ssh key, another Aoldkey= was found for this user. Since it was not provisioned by salt, it was removed.

Here is a state to ensure that Asomekeyh is present. In the past Aoldkey= had been added to the host, but has been forgotten and is not managed by salt.
```
key1:
  ssh_auth.present:
    - user: testuser
    - enc: ssh-rsa
    - comment: testuser 1
    - aggregate: True
    - names:
      - Asomekeyh
      - MotherkeyB

#key2:
#  ssh_auth.present:
#    - user: testuser
#    - enc: ssh-rsa
#    - comment: 2
#    - names:
#      - Aoldkey=
```

By running this state, ssh_auth.present ensured the Asomekeyh was present, but also removed any keys found for the testuser user which were not managed by salt.
```
          ID: key1
    Function: ssh_auth.present
        Name: Asomekeyh
      Result: True
     Comment: The authorized host key Asomekeyh is already present for user testuser
     Started: 16:08:57.859383
    Duration: 9.498 ms
     Changes:
              ----------
              Aoldkey=:
                  Key removed
```
### Tests written?
No

### Commits signed with GPG?
No