### PR TITLE
Fix parallel states with long ID dec or name

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -1735,7 +1735,7 @@ class State(object):
         troot = os.path.join(self.opts['cachedir'], self.jid)
         tfile = os.path.join(
             troot,
-            salt.utils.hashutils.base64_b64encode(tag)[:32])
+            salt.utils.hashutils.sha1_digest(tag))
         if not os.path.isdir(troot):
             try:
                 os.makedirs(troot)
@@ -2097,7 +2097,7 @@ class State(object):
                     ret_cache = os.path.join(
                         self.opts['cachedir'],
                         self.jid,
-                        salt.utils.hashutils.base64_b64encode(tag)[:32])
+                        salt.utils.hashutils.sha1_digest(tag))
                     if not os.path.isfile(ret_cache):
                         ret = {'result': False,
                                'comment': 'Parallel process failed to return',

--- a/salt/state.py
+++ b/salt/state.py
@@ -35,6 +35,7 @@ import salt.fileclient
 import salt.utils.crypt
 import salt.utils.dictupdate
 import salt.utils.event
+import salt.utils.hashutils
 import salt.utils.url
 import salt.utils.process
 import salt.utils.files

--- a/salt/state.py
+++ b/salt/state.py
@@ -1732,7 +1732,9 @@ class State(object):
         ret['duration'] = duration
 
         troot = os.path.join(self.opts['cachedir'], self.jid)
-        tfile = os.path.join(troot, _clean_tag(tag))
+        tfile = os.path.join(
+            troot,
+            salt.utils.hashutils.base64_b64encode(tag)[:32])
         if not os.path.isdir(troot):
             try:
                 os.makedirs(troot)
@@ -2091,7 +2093,10 @@ class State(object):
             proc = running[tag].get('proc')
             if proc:
                 if not proc.is_alive():
-                    ret_cache = os.path.join(self.opts['cachedir'], self.jid, _clean_tag(tag))
+                    ret_cache = os.path.join(
+                        self.opts['cachedir'],
+                        self.jid,
+                        salt.utils.hashutils.base64_b64encode(tag)[:32])
                     if not os.path.isfile(ret_cache):
                         ret = {'result': False,
                                'comment': 'Parallel process failed to return',

--- a/salt/utils/hashutils.py
+++ b/salt/utils/hashutils.py
@@ -82,6 +82,16 @@ def md5_digest(instr):
     return hashlib.md5(instr).hexdigest()
 
 
+def sha1_digest(instr):
+    '''
+    Generate an sha1 hash of a given string.
+    '''
+    if six.PY3:
+        b = salt.utils.to_bytes(instr)
+        return hashlib.sha1(b).hexdigest()
+    return hashlib.sha1(instr).hexdigest()
+
+
 def sha256_digest(instr):
     '''
     Generate an sha256 hash of a given string.

--- a/tests/integration/files/file/base/issue-49738/init.sls
+++ b/tests/integration/files/file/base/issue-49738/init.sls
@@ -1,0 +1,9 @@
+test_cmd_too_long:
+  cmd.run:
+    - name: {{ pillar['long_command'] }}
+    - parallel: True
+
+test_cmd_not_found:
+  cmd.run:
+    - name: {{ pillar['short_command'] }}
+    - parallel: True

--- a/tests/integration/modules/test_state.py
+++ b/tests/integration/modules/test_state.py
@@ -4,6 +4,7 @@
 from __future__ import absolute_import
 import os
 import shutil
+import sys
 import tempfile
 import textwrap
 import threading
@@ -1422,6 +1423,7 @@ class StateModuleTest(ModuleCase, SaltReturnAssertsMixin):
             except OSError:
                 pass
 
+    @skipIf(sys.platform.startswith('win'), 'Skipped until parallel states can be fixed on Windows')
     def test_parallel_state_with_long_tag(self):
         '''
         This tests the case where the state being executed has a long ID dec or

--- a/tests/integration/modules/test_state.py
+++ b/tests/integration/modules/test_state.py
@@ -1431,10 +1431,9 @@ class StateModuleTest(ModuleCase, SaltReturnAssertsMixin):
         parallel state cache were previously based on the tag for each chunk,
         and longer ID decs or name params can cause the cache file to be longer
         than the operating system's max file name length. To counter this we
-        instead base64-encode the chunk's tag (as this is a bit faster than
-        doing a sha256) and use up to the first 32 characters from that result
-        as the cache filename. This test will ensure that long tags don't cause
-        caching failures.
+        instead generate a SHA1 hash of the chunk's tag to use as the cache
+        filename. This test will ensure that long tags don't cause caching
+        failures.
 
         See https://github.com/saltstack/salt/issues/49738 for more info.
         '''

--- a/tests/integration/modules/test_state.py
+++ b/tests/integration/modules/test_state.py
@@ -1448,4 +1448,4 @@ class StateModuleTest(ModuleCase, SaltReturnAssertsMixin):
         comments = sorted([x['comment'] for x in six.itervalues(ret)])
         expected = sorted(['Command "{0}" run'.format(x)
                            for x in (short_command, long_command)])
-        assert comments == expected
+        assert comments == expected, '{0} != {1}'.format(comments, expected)


### PR DESCRIPTION
The cache files used for these are based on the state's tag, so longer ID decs or names will cause errors when the filename's length exceeds the max allowed by the kernel.

This fixes these errors by taking (up to) the first 32 chars of the result of base64-encoding the tag, and using that as the parallel cache filename.

Fixes #49738.