### PR TITLE
Fix issue 49043

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -1118,7 +1118,7 @@ def _get_template_texts(source_list=None,
             tmplines = None
             with salt.utils.files.fopen(rndrd_templ_fn, 'rb') as fp_:
                 tmplines = fp_.read()
-                tmplines = tmplines.decode(__salt_system_encoding__)
+                tmplines = salt.utils.stringutils.to_unicode(tmplines)
                 tmplines = tmplines.splitlines(True)
             if not tmplines:
                 msg = 'Failed to read rendered template file {0} ({1})'

--- a/salt/utils/files.py
+++ b/salt/utils/files.py
@@ -791,10 +791,10 @@ def backup_minion(path, bkroot):
 def get_encoding(path):
     '''
     Detect a file's encoding using the following:
-    - Check for ascii
     - Check for Byte Order Marks (BOM)
     - Check for UTF-8 Markers
     - Check System Encoding
+    - Check for ascii
 
     Args:
 
@@ -867,10 +867,6 @@ def get_encoding(path):
     except os.error:
         raise CommandExecutionError('Failed to open file')
 
-    # Check for ASCII first
-    if check_ascii(data):
-        return 'ASCII'
-
     # Check for Unicode BOM
     encoding = check_bom(data)
     if encoding:
@@ -883,5 +879,9 @@ def get_encoding(path):
     # Check system encoding
     if check_system_encoding(data):
         return __salt_system_encoding__
+
+    # Check for ASCII first
+    if check_ascii(data):
+        return 'ASCII'
 
     raise CommandExecutionError('Could not detect file encoding')

--- a/salt/utils/stringutils.py
+++ b/salt/utils/stringutils.py
@@ -558,6 +558,8 @@ def get_diff(a, b, *args, **kwargs):
     with unicode on PY2.
     '''
     encoding = ('utf-8', 'latin-1', __salt_system_encoding__)
+    if 'lineterm' not in kwargs:
+        kwargs['lineterm'] = os.linesep
     # Late import to avoid circular import
     import salt.utils.data
     return ''.join(

--- a/salt/utils/stringutils.py
+++ b/salt/utils/stringutils.py
@@ -558,8 +558,6 @@ def get_diff(a, b, *args, **kwargs):
     with unicode on PY2.
     '''
     encoding = ('utf-8', 'latin-1', __salt_system_encoding__)
-    if 'lineterm' not in kwargs:
-        kwargs['lineterm'] = os.linesep
     # Late import to avoid circular import
     import salt.utils.data
     return ''.join(

--- a/tests/integration/files/file/base/issue-49043
+++ b/tests/integration/files/file/base/issue-49043
@@ -1,0 +1,1 @@
+{{unicode_string}}

--- a/tests/integration/files/file/base/issue-49043.sls
+++ b/tests/integration/files/file/base/issue-49043.sls
@@ -1,0 +1,16 @@
+somefile-exists:
+  file:
+    - managed
+    - name: {{ pillar['name'] }}
+
+somefile-blockreplace:
+  file:
+    - blockreplace
+    - append_if_not_found: true
+    - name: {{ pillar['name'] }}
+    - template: jinja
+    - source: salt://issue-49043
+    - require:
+      - file: somefile-exists
+    - context:
+        unicode_string: "\xe4\xf6\xfc"

--- a/tests/integration/states/test_file.py
+++ b/tests/integration/states/test_file.py
@@ -3755,10 +3755,8 @@ class BlockreplaceTest(ModuleCase, SaltReturnAssertsMixin):
             pillar={'name': name},
         )
         log.error("ret = %s", repr(ret))
-        diff = dedent('''\
-        --- 
-        +++ 
-        @@ -0,0 +1,3 @@
+        diff = '--- \n+++ \n@@ -0,0 +1,3 @@\n'
+        diff += dedent('''\
         +#-- start managed zone --
         +äöü
         +#-- end managed zone --

--- a/tests/integration/states/test_file.py
+++ b/tests/integration/states/test_file.py
@@ -3747,6 +3747,27 @@ class BlockreplaceTest(ModuleCase, SaltReturnAssertsMixin):
             self._read(name),
             self.with_matching_block_and_marker_end_not_after_newline)
 
+    @with_tempfile()
+    def test_issue_49043(self, name):
+        ret = self.run_function(
+            'state.sls',
+            mods='issue-49043',
+            pillar={'name': name},
+        )
+        log.error("ret = %s", repr(ret))
+        diff = dedent('''\
+        --- 
+        +++ 
+        @@ -0,0 +1,3 @@
+        +#-- start managed zone --
+        +äöü
+        +#-- end managed zone --
+        ''')
+        job = 'file_|-somefile-blockreplace_|-{}_|-blockreplace'.format(name)
+        self.assertEqual(
+            ret[job]['changes']['diff'],
+            diff)
+
 
 class RemoteFileTest(ModuleCase, SaltReturnAssertsMixin):
     '''


### PR DESCRIPTION
### What does this PR do?

- Detect `utf-8` before `ascii` in `get_encoding` method.
- Default to `os.linesep` in diff output from `get_diff` method.
- Fix template render out encoding on windows platform.

### What issues does this PR fix or reference?

#49043

### Previous Behavior

- Exception raised by get_encoding method when given `utf-8` 

### New Behavior

- Blockreplace succeeds as expected.

### Tests written?

Yes

### Commits signed with GPG?

Yes