### PR TITLE
Fix possible issue with test_groupadd

### DIFF
--- a/tests/integration/modules/test_groupadd.py
+++ b/tests/integration/modules/test_groupadd.py
@@ -160,7 +160,8 @@ class GroupModuleTest(ModuleCase):
         self.run_function('user.add', [self._user])
         self.run_function('user.add', [self._user1])
         m = '{0},{1}'.format(self._user, self._user1)
-        self.assertTrue(self.run_function('group.members', [self._group, m]))
+        self.assertTrue(
+            self.run_function('group.members', [self._group, m])['result'])
         group_info = self.run_function('group.info', [self._group])
         self.assertIn(self._user, str(group_info['members']))
         self.assertIn(self._user1, str(group_info['members']))

--- a/tests/integration/modules/test_groupadd.py
+++ b/tests/integration/modules/test_groupadd.py
@@ -160,8 +160,11 @@ class GroupModuleTest(ModuleCase):
         self.run_function('user.add', [self._user])
         self.run_function('user.add', [self._user1])
         m = '{0},{1}'.format(self._user, self._user1)
-        self.assertTrue(
-            self.run_function('group.members', [self._group, m])['result'])
+        ret = self.run_function('group.members', [self._group, m])
+        if salt.utils.is_windows():
+            self.assertTrue(ret['result'])
+        else:
+            self.assertTrue(ret)
         group_info = self.run_function('group.info', [self._group])
         self.assertIn(self._user, str(group_info['members']))
         self.assertIn(self._user1, str(group_info['members']))


### PR DESCRIPTION
### What does this PR do?
In Windows, the `group.members` function returns a dicts where the `result` key returns true if successful. On Linux it just returns True or False. The way the test was written the check would always be True even on failure because an empty Dict results in True if you're just checking with `assertTrue`.

### What issues does this PR fix or reference?
This checks the value in `result` on Windows

### Tests written?
Yes

### Commits signed with GPG?
Yes