### PR TITLE
fix test_managed_file_with_grains_data

### DIFF
--- a/tests/integration/files/conf/minion
+++ b/tests/integration/files/conf/minion
@@ -25,6 +25,7 @@ integration.test: True
 # Grains addons
 grains:
   test_grain: cheese
+  grain_path: /tmp/salt-tests-tmpdir/file-grain-test
   script: grail
   alot: many
   planets:

--- a/tests/integration/states/test_file.py
+++ b/tests/integration/states/test_file.py
@@ -355,7 +355,6 @@ class FileTest(ModuleCase, SaltReturnAssertsMixin):
         file.
         '''
         grain_path = os.path.join(TMP, 'file-grain-test')
-        self.run_function('grains.set', ['grain_path', grain_path])
         state_file = 'file-grainget'
 
         self.run_function('state.sls', [state_file])


### PR DESCRIPTION
### What does this PR do?
Put grain_path into the test minions grains, instead of trying to to set it at test time.

### What issues does this PR fix or reference?
Closes saltstack/salt-jenkins#1121

### Tests written?

Yes

### Commits signed with GPG?

Yes