### PR TITLE
Clean up install of package from shell test

### DIFF
--- a/tests/integration/shell/test_call.py
+++ b/tests/integration/shell/test_call.py
@@ -114,11 +114,14 @@ class CallTest(ShellCase, testprogram.TestProgramCase, ShellCaseCommonTestsMixin
         if target in cur_pkgs:
             self.fail('Target package \'{0}\' already installed'.format(target))
 
-        out = ''.join(self.run_call('--local pkg.install {0}'.format(target)))
-        self.assertIn('local:    ----------', out)
-        self.assertIn('{0}:        ----------'.format(target), out)
-        self.assertIn('new:', out)
-        self.assertIn('old:', out)
+        try:
+            out = ''.join(self.run_call('--local pkg.install {0}'.format(target)))
+            self.assertIn('local:    ----------', out)
+            self.assertIn('{0}:        ----------'.format(target), out)
+            self.assertIn('new:', out)
+            self.assertIn('old:', out)
+        finally:
+            self.run_call('--local pkg.remove {0}'.format(target))
 
     @skipIf(sys.platform.startswith('win'), 'This test does not apply on Win')
     @flaky


### PR DESCRIPTION
5125a55 modified this test and un-skipped it. But since this installed
one of the package targets and didn't clean it up, it causes later tests
to fail. This fixes that oversight.