### PR TITLE
Bugfix: zypper ZYPPER_EXIT_NO_REPOS exit code

### DIFF
--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -187,7 +187,15 @@ class _Zypper(object):
 
         :return:
         '''
-        return self.exit_code not in self.SUCCESS_EXIT_CODES
+        if self.exit_code:
+            msg = self.SUCCESS_EXIT_CODES.get(self.exit_code)
+            if msg:
+                log.info(msg)
+            msg = self.WARNING_EXIT_CODES.get(self.exit_code)
+            if msg:
+                log.warning(msg)
+
+        return self.exit_code not in self.SUCCESS_EXIT_CODES and self.exit_code not in self.WARNING_EXIT_CODES
 
     def _is_lock(self):
         '''

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -74,7 +74,25 @@ class _Zypper(object):
     Allows serial zypper calls (first came, first won).
     '''
 
-    SUCCESS_EXIT_CODES = [0, 100, 101, 102, 103]
+    SUCCESS_EXIT_CODES = {
+        0: 'Successful run of zypper with no special info.',
+        100: 'Patches are available for installation.',
+        101: 'Security patches are available for installation.',
+        102: 'Installation successful, reboot required.',
+        103: 'Installation succesful, restart of the package manager itself required.',
+    }
+
+    WARNING_EXIT_CODES = {
+        6: 'No repositories are defined.',
+        7: 'The ZYPP library is locked.',
+        106: 'Some repository had to be disabled temporarily because it failed to refresh. '
+             'You should check your repository configuration (e.g. zypper ref -f).',
+        107: 'Installation basically succeeded, but some of the packages %post install scripts returned an error. '
+             'These packages were successfully unpacked to disk and are registered in the rpm database, '
+             'but due to the failed install script they may not work as expected. The failed scripts output might '
+             'reveal what actually went wrong. Any scripts output is also logged to /var/log/zypp/history.'
+    }
+
     LOCK_EXIT_CODE = 7
     XML_DIRECTIVES = ['-x', '--xmlout']
     ZYPPER_LOCK = '/var/run/zypp.pid'


### PR DESCRIPTION
### What does this PR do?

`pkg.installed` reports failed if the following conditions are met:

1. No repos configured
2. Package already installed anyway

### What issues does this PR fix or reference?

`pkg.installed` does not report failed if the following conditions above are met.

### Caveats

Zypper (all versions) still contains a bug (which is already fixed as of today) — https://bugzilla.suse.com/show_bug.cgi?id=1109893 — where new package installation fails with the same exit code. That said, `pkg.installed` will work, but `pkg.install` from execution command will not fail, if you did not upgrade zypper.

### Tests written?

No

Should just pass existing.
