### PR TITLE
Add additional asserts to help investigate test_win_pkg failure

### DIFF
--- a/salt/fileserver/__init__.py
+++ b/salt/fileserver/__init__.py
@@ -131,7 +131,10 @@ def check_file_list_cache(opts, form, list_cache, w_lock):
                 if os.path.exists(list_cache):
                     # calculate filelist age is possible
                     cache_stat = os.stat(list_cache)
-                    age = time.time() - cache_stat.st_mtime
+                    # st_time can have a greater precision than time, removing
+                    # float precision makes sure age will never be a negative
+                    # number.
+                    age = int(time.time()) - int(cache_stat.st_mtime)
                 else:
                     # if filelist does not exists yet, mark it as expired
                     age = opts.get('fileserver_list_cache_time', 20) + 1

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -693,12 +693,13 @@ def refresh_db(**kwargs):
 
     # Cache repo-ng locally
     log.info('Fetching *.sls files from {0}'.format(repo_details.winrepo_source_dir))
-    __salt__['cp.cache_dir'](
+    ret = __salt__['cp.cache_dir'](
         path=repo_details.winrepo_source_dir,
         saltenv=saltenv,
         include_pat='*.sls',
         exclude_pat=r'E@\/\..*?\/'  # Exclude all hidden directories (.git)
     )
+    log.debug("refresh_db - Return from cache_dir %s", repr(ret))
 
     return genrepo(saltenv=saltenv, verbose=verbose, failhard=failhard)
 

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -693,14 +693,12 @@ def refresh_db(**kwargs):
 
     # Cache repo-ng locally
     log.info('Fetching *.sls files from {0}'.format(repo_details.winrepo_source_dir))
-    ret = __salt__['cp.cache_dir'](
+    __salt__['cp.cache_dir'](
         path=repo_details.winrepo_source_dir,
         saltenv=saltenv,
         include_pat='*.sls',
         exclude_pat=r'E@\/\..*?\/'  # Exclude all hidden directories (.git)
     )
-    log.debug("refresh_db - Return from cache_dir %s", repr(ret))
-
     return genrepo(saltenv=saltenv, verbose=verbose, failhard=failhard)
 
 

--- a/tests/integration/modules/test_win_pkg.py
+++ b/tests/integration/modules/test_win_pkg.py
@@ -76,6 +76,7 @@ class WinPKGTest(ModuleCase):
                     reboot: False
                 '''))
             fp_.flush()
+            os.fsync(fp_.fileno())
         # now check if curl is also in cache and repo query
         pkgs.append('curl')
         for pkg in pkgs:

--- a/tests/integration/modules/test_win_pkg.py
+++ b/tests/integration/modules/test_win_pkg.py
@@ -75,8 +75,6 @@ class WinPKGTest(ModuleCase):
                     locale: en_US
                     reboot: False
                 '''))
-            fp_.flush()
-            os.fsync(fp_.fileno())
         # now check if curl is also in cache and repo query
         pkgs.append('curl')
         for pkg in pkgs:

--- a/tests/integration/modules/test_win_pkg.py
+++ b/tests/integration/modules/test_win_pkg.py
@@ -43,9 +43,9 @@ class WinPKGTest(ModuleCase):
                         self.assertEqual(0, refresh['failed'],
                              msg='failed returned {0}. Expected return: 0'.format(refresh['failed']))
                         self.assertEqual(check_refresh, refresh['total'],
-                             msg='total returned {0}. Expected return {1}'.format(check_refresh, refresh['total']))
+                             msg='total returned {0}. Expected return {1}'.format(refresh['total'], check_refresh))
                         self.assertEqual(check_refresh, refresh['success'],
-                             msg='success returned {0}. Expected return {1}'.format(check_refresh, refresh['success']))
+                             msg='success returned {0}. Expected return {1}'.format(refresh['success'], check_refresh))
                         count = 0
                     except AssertionError as err:
                         if count == 1:


### PR DESCRIPTION
### What does this PR do?
Currently the `test_win_pkg` module integration tests is failing sometimes on windows. I cannot replicate this failure so I'm adding additional asserts and running the `refresh_db` one more time if it does initially fail. 
