### PR TITLE
[minion][scheduler] The master_alive job never deleted

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -2393,7 +2393,8 @@ class Minion(MinionBase):
                 else:
                     # delete the scheduled job to don't interfere with the failover process
                     if self.opts['transport'] != 'tcp':
-                        self.schedule.delete_job(name=master_event(type='alive'))
+                        self.schedule.delete_job(name=master_event(type='alive', master=self.opts['master']),
+                                                 persist=True)
 
                     log.info('Trying to tune in to next master from master-list')
 


### PR DESCRIPTION
### What does this PR do?

Fixes removing of the `master_alive` job from scheduler on `disconnected` event.

### Issue

The master_alive job never deleted because of name of the master does not specified .
Each time when one of the master is lost,  the minion creates new one, but never deletes previous job.  