### PR TITLE
[2018.3] Fixing vault when being used from Pillar

### DIFF
--- a/salt/utils/vault.py
+++ b/salt/utils/vault.py
@@ -123,7 +123,8 @@ def get_vault_connection():
             raise salt.exceptions.CommandExecutionError(errmsg)
 
     if 'vault' in __opts__ and __opts__.get('__role', 'minion') == 'master':
-        return _use_local_config()
+        log.debug('Contacting master for Vault connection details')
+        return _get_token_and_url_from_master()
     elif any((__opts__['local'], __opts__['file_client'] == 'local', __opts__['master_type'] == 'disable')):
         return _use_local_config()
     else:


### PR DESCRIPTION
### What does this PR do?
Fixing the scenario when vault values are used in Pillar, but due to a previous change the minion was not being granted token based access.

### What issues does this PR fix or reference?
#49671 

### Previous Behavior
Reading vault values from Pillar failed because of previous changes to allow vault access via salt-ssh.

### New Behavior
Swapping out the call when the vault read is happening on the Salt master from using 
`_use_local_config` to use `_get_token_and_url_from_master()`

### Tests written?
No.  Manual tests with output provided.

### Commits signed with GPG?

Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
