### PR TITLE
Adding timeout to all pipelines so that the build aborts

### DIFF
--- a/.ci/docs
+++ b/.ci/docs
@@ -3,6 +3,7 @@ pipeline {
     options {
         timestamps()
         ansiColor('xterm')
+        timeout(time: 6, unit: 'HOURS') 
     }
     environment {
         PYENV_ROOT = "/usr/local/pyenv"

--- a/.ci/docs
+++ b/.ci/docs
@@ -1,9 +1,11 @@
 pipeline {
-    agent { label 'docs' }
+    agent {
+        label 'docs'
+    }
     options {
         timestamps()
         ansiColor('xterm')
-        timeout(time: 6, unit: 'HOURS') 
+        timeout(time: 2, unit: 'HOURS')
     }
     environment {
         PYENV_ROOT = "/usr/local/pyenv"

--- a/.ci/kitchen-centos7-py2
+++ b/.ci/kitchen-centos7-py2
@@ -1,4 +1,5 @@
-node('kitchen-slave') {
+timeout(time: 6, unit: 'HOURS') {
+  node('kitchen-slave') {
     timestamps {
         ansiColor('xterm') {
             withEnv([
@@ -66,10 +67,11 @@ node('kitchen-slave') {
                                 description: "The ${TEST_SUITE}-${TEST_PLATFORM} job has failed",
                                 status: 'FAILURE',
                                 context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
-                        }
-                    }
-                }
-            }
-        }
-    }
+                          }
+                      }
+                  }
+              }
+          }
+      }
+   }
 }

--- a/.ci/kitchen-centos7-py2
+++ b/.ci/kitchen-centos7-py2
@@ -59,7 +59,8 @@ timeout(time: 6, unit: 'HOURS') {
                             junit 'artifacts/xml-unittests-output/*.xml'
                         } finally {
                             cleanWs notFailBuild: true
-                            if (currentBuild.result == 'SUCCESS') {
+                            def currentResult = currentBuild.result ?: 'SUCCESS'
+                            if (currentResult == 'SUCCESS') {
                                 githubNotify credentialsId: 'test-jenkins-credentials',
                                     description: "The ${TEST_SUITE}-${TEST_PLATFORM} job has passed",
                                     status: 'SUCCESS',

--- a/.ci/kitchen-centos7-py2
+++ b/.ci/kitchen-centos7-py2
@@ -1,77 +1,79 @@
 timeout(time: 6, unit: 'HOURS') {
-  node('kitchen-slave') {
-    timestamps {
-        ansiColor('xterm') {
-            withEnv([
-                'SALT_KITCHEN_PLATFORMS=/var/jenkins/workspace/platforms.yml',
-                'SALT_KITCHEN_DRIVER=/var/jenkins/workspace/driver.yml',
-                'PATH=/usr/local/rbenv/shims/:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/root/bin:/root/bin',
-                'RBENV_VERSION=2.4.2',
-                'TEST_SUITE=py2',
-                'TEST_PLATFORM=centos-7',
-                'PY_COLORS=1',])
-            {
-                stage('checkout-scm') {
-                    cleanWs notFailBuild: true
-                    checkout scm
-                }
-                try {
-                    stage('github-pending') {
-                        githubNotify credentialsId: 'test-jenkins-credentials',
-                            description: "running ${TEST_SUITE}-${TEST_PLATFORM}...",
-                            status: 'PENDING',
-                            context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
-                    }
-                    stage('setup-bundle') {
-                        sh 'bundle install --with ec2 windows --without opennebula docker'
+    node('kitchen-slave') {
+        timestamps {
+            ansiColor('xterm') {
+                withEnv([
+                    'SALT_KITCHEN_PLATFORMS=/var/jenkins/workspace/platforms.yml',
+                    'SALT_KITCHEN_DRIVER=/var/jenkins/workspace/driver.yml',
+                    'PATH=/usr/local/rbenv/shims/:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/root/bin:/root/bin',
+                    'RBENV_VERSION=2.4.2',
+                    'TEST_SUITE=py2',
+                    'TEST_PLATFORM=centos-7',
+                    'PY_COLORS=1',
+                ]) {
+                    stage('checkout-scm') {
+                        cleanWs notFailBuild: true
+                        checkout scm
                     }
                     try {
-                        stage('run kitchen') {
-                            withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
-                                sshagent(credentials: ['jenkins-testing-ssh-key']) {
-                                    sh 'ssh-add ~/.ssh/jenkins-testing.pem'
-                                    sh 'bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM || bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM'
-                                    sh 'bundle exec kitchen verify $TEST_SUITE-$TEST_PLATFORM'
+                        stage('github-pending') {
+                            githubNotify credentialsId: 'test-jenkins-credentials',
+                                description: "running ${TEST_SUITE}-${TEST_PLATFORM}...",
+                                status: 'PENDING',
+                                context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
+                        }
+                        stage('setup-bundle') {
+                            sh 'bundle install --with ec2 windows --without opennebula docker'
+                        }
+                        try {
+                            stage('run kitchen') {
+                                withCredentials([
+                                    [$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']
+                                ]) {
+                                    sshagent(credentials: ['jenkins-testing-ssh-key']) {
+                                        sh 'ssh-add ~/.ssh/jenkins-testing.pem'
+                                        sh 'bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM || bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM'
+                                        sh 'bundle exec kitchen verify $TEST_SUITE-$TEST_PLATFORM'
+                                    }
                                 }
+                            }
+                        } finally {
+                            stage('cleanup kitchen') {
+                                script {
+                                    withCredentials([
+                                        [$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']
+                                    ]) {
+                                        sshagent(credentials: ['jenkins-testing-ssh-key']) {
+                                            sh 'ssh-add ~/.ssh/jenkins-testing.pem'
+                                            sh 'bundle exec kitchen destroy $TEST_SUITE-$TEST_PLATFORM'
+                                        }
+                                    }
+                                }
+                                archiveArtifacts artifacts: 'artifacts/xml-unittests-output/*.xml'
+                                archiveArtifacts artifacts: 'artifacts/logs/minion'
+                                archiveArtifacts artifacts: 'artifacts/logs/salt-runtests.log'
+                            }
+                        }
+                    } finally {
+                        try {
+                            junit 'artifacts/xml-unittests-output/*.xml'
+                        } finally {
+                            cleanWs notFailBuild: true
+                            if (currentBuild.result == 'SUCCESS') {
+                                githubNotify credentialsId: 'test-jenkins-credentials',
+                                    description: "The ${TEST_SUITE}-${TEST_PLATFORM} job has passed",
+                                    status: 'SUCCESS',
+                                    context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
+                            } else {
+                                githubNotify credentialsId: 'test-jenkins-credentials',
+                                    description: "The ${TEST_SUITE}-${TEST_PLATFORM} job has failed",
+                                    status: 'FAILURE',
+                                    context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
                             }
                         }
                     }
-                    finally {
-                        stage('cleanup kitchen') {
-                            script { withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
-                                sshagent(credentials: ['jenkins-testing-ssh-key']) {
-                                    sh 'ssh-add ~/.ssh/jenkins-testing.pem'
-                                    sh 'bundle exec kitchen destroy $TEST_SUITE-$TEST_PLATFORM'
-                                }
-                            }}
-                            archiveArtifacts artifacts: 'artifacts/xml-unittests-output/*.xml'
-                            archiveArtifacts artifacts: 'artifacts/logs/minion'
-                            archiveArtifacts artifacts: 'artifacts/logs/salt-runtests.log'
-                        }
-                    }
                 }
-                finally {
-                    try {
-                        junit 'artifacts/xml-unittests-output/*.xml'
-                    }
-                    finally {
-                        cleanWs notFailBuild: true
-                        if (currentBuild.result == 'SUCCESS') {
-                            githubNotify credentialsId: 'test-jenkins-credentials',
-                                description: "The ${TEST_SUITE}-${TEST_PLATFORM} job has passed",
-                                status: 'SUCCESS',
-                                context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
-                        }
-                        else {
-                            githubNotify credentialsId: 'test-jenkins-credentials',
-                                description: "The ${TEST_SUITE}-${TEST_PLATFORM} job has failed",
-                                status: 'FAILURE',
-                                context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
-                          }
-                      }
-                  }
-              }
-          }
-      }
-   }
+            }
+        }
+    }
 }

--- a/.ci/kitchen-centos7-py3
+++ b/.ci/kitchen-centos7-py3
@@ -1,77 +1,79 @@
 timeout(time: 6, unit: 'HOURS') {
-  node('kitchen-slave') {
-    timestamps {
-        ansiColor('xterm') {
-            withEnv([
-                'SALT_KITCHEN_PLATFORMS=/var/jenkins/workspace/platforms.yml',
-                'SALT_KITCHEN_DRIVER=/var/jenkins/workspace/driver.yml',
-                'PATH=/usr/local/rbenv/shims/:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/root/bin:/root/bin',
-                'RBENV_VERSION=2.4.2',
-                'TEST_SUITE=py3',
-                'TEST_PLATFORM=centos-7',
-                'PY_COLORS=1',])
-            {
-                stage('checkout-scm') {
-                    cleanWs notFailBuild: true
-                    checkout scm
-                }
-                try {
-                    stage('github-pending') {
-                        githubNotify credentialsId: 'test-jenkins-credentials',
-                            description: "running ${TEST_SUITE}-${TEST_PLATFORM}...",
-                            status: 'PENDING',
-                            context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
-                    }
-                    stage('setup-bundle') {
-                        sh 'bundle install --with ec2 windows --without opennebula docker'
+    node('kitchen-slave') {
+        timestamps {
+            ansiColor('xterm') {
+                withEnv([
+                    'SALT_KITCHEN_PLATFORMS=/var/jenkins/workspace/platforms.yml',
+                    'SALT_KITCHEN_DRIVER=/var/jenkins/workspace/driver.yml',
+                    'PATH=/usr/local/rbenv/shims/:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/root/bin:/root/bin',
+                    'RBENV_VERSION=2.4.2',
+                    'TEST_SUITE=py3',
+                    'TEST_PLATFORM=centos-7',
+                    'PY_COLORS=1',
+                ]) {
+                    stage('checkout-scm') {
+                        cleanWs notFailBuild: true
+                        checkout scm
                     }
                     try {
-                        stage('run kitchen') {
-                            withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
-                                sshagent(credentials: ['jenkins-testing-ssh-key']) {
-                                    sh 'ssh-add ~/.ssh/jenkins-testing.pem'
-                                    sh 'bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM || bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM'
-                                    sh 'bundle exec kitchen verify $TEST_SUITE-$TEST_PLATFORM'
+                        stage('github-pending') {
+                            githubNotify credentialsId: 'test-jenkins-credentials',
+                                description: "running ${TEST_SUITE}-${TEST_PLATFORM}...",
+                                status: 'PENDING',
+                                context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
+                        }
+                        stage('setup-bundle') {
+                            sh 'bundle install --with ec2 windows --without opennebula docker'
+                        }
+                        try {
+                            stage('run kitchen') {
+                                withCredentials([
+                                    [$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']
+                                ]) {
+                                    sshagent(credentials: ['jenkins-testing-ssh-key']) {
+                                        sh 'ssh-add ~/.ssh/jenkins-testing.pem'
+                                        sh 'bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM || bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM'
+                                        sh 'bundle exec kitchen verify $TEST_SUITE-$TEST_PLATFORM'
+                                    }
                                 }
+                            }
+                        } finally {
+                            stage('cleanup kitchen') {
+                                script {
+                                    withCredentials([
+                                        [$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']
+                                    ]) {
+                                        sshagent(credentials: ['jenkins-testing-ssh-key']) {
+                                            sh 'ssh-add ~/.ssh/jenkins-testing.pem'
+                                            sh 'bundle exec kitchen destroy $TEST_SUITE-$TEST_PLATFORM'
+                                        }
+                                    }
+                                }
+                                archiveArtifacts artifacts: 'artifacts/xml-unittests-output/*.xml'
+                                archiveArtifacts artifacts: 'artifacts/logs/minion'
+                                archiveArtifacts artifacts: 'artifacts/logs/salt-runtests.log'
+                            }
+                        }
+                    } finally {
+                        try {
+                            junit 'artifacts/xml-unittests-output/*.xml'
+                        } finally {
+                            cleanWs notFailBuild: true
+                            if (currentBuild.result == 'SUCCESS') {
+                                githubNotify credentialsId: 'test-jenkins-credentials',
+                                    description: "The ${TEST_SUITE}-${TEST_PLATFORM} job has passed",
+                                    status: 'SUCCESS',
+                                    context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
+                            } else {
+                                githubNotify credentialsId: 'test-jenkins-credentials',
+                                    description: "The ${TEST_SUITE}-${TEST_PLATFORM} job has failed",
+                                    status: 'FAILURE',
+                                    context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
                             }
                         }
                     }
-                    finally {
-                        stage('cleanup kitchen') {
-                            script { withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
-                                sshagent(credentials: ['jenkins-testing-ssh-key']) {
-                                    sh 'ssh-add ~/.ssh/jenkins-testing.pem'
-                                    sh 'bundle exec kitchen destroy $TEST_SUITE-$TEST_PLATFORM'
-                                }
-                            }}
-                            archiveArtifacts artifacts: 'artifacts/xml-unittests-output/*.xml'
-                            archiveArtifacts artifacts: 'artifacts/logs/minion'
-                            archiveArtifacts artifacts: 'artifacts/logs/salt-runtests.log'
-                        }
-                    }
                 }
-                finally {
-                    try {
-                        junit 'artifacts/xml-unittests-output/*.xml'
-                    }
-                    finally {
-                        cleanWs notFailBuild: true
-                        if (currentBuild.result == 'SUCCESS') {
-                            githubNotify credentialsId: 'test-jenkins-credentials',
-                                description: "The ${TEST_SUITE}-${TEST_PLATFORM} job has passed",
-                                status: 'SUCCESS',
-                                context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
-                        }
-                        else {
-                            githubNotify credentialsId: 'test-jenkins-credentials',
-                                description: "The ${TEST_SUITE}-${TEST_PLATFORM} job has failed",
-                                status: 'FAILURE',
-                                context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
-                        }
-                     }
-                  }
-              }
-          }
-      }
-  }
+            }
+        }
+    }
 }

--- a/.ci/kitchen-centos7-py3
+++ b/.ci/kitchen-centos7-py3
@@ -1,4 +1,5 @@
-node('kitchen-slave') {
+timeout(time: 6, unit: 'HOURS') {
+  node('kitchen-slave') {
     timestamps {
         ansiColor('xterm') {
             withEnv([
@@ -67,9 +68,10 @@ node('kitchen-slave') {
                                 status: 'FAILURE',
                                 context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
                         }
-                    }
-                }
-            }
-        }
-    }
+                     }
+                  }
+              }
+          }
+      }
+  }
 }

--- a/.ci/kitchen-centos7-py3
+++ b/.ci/kitchen-centos7-py3
@@ -59,7 +59,8 @@ timeout(time: 6, unit: 'HOURS') {
                             junit 'artifacts/xml-unittests-output/*.xml'
                         } finally {
                             cleanWs notFailBuild: true
-                            if (currentBuild.result == 'SUCCESS') {
+                            def currentResult = currentBuild.result ?: 'SUCCESS'
+                            if (currentResult == 'SUCCESS') {
                                 githubNotify credentialsId: 'test-jenkins-credentials',
                                     description: "The ${TEST_SUITE}-${TEST_PLATFORM} job has passed",
                                     status: 'SUCCESS',

--- a/.ci/kitchen-ubuntu1604-py2
+++ b/.ci/kitchen-ubuntu1604-py2
@@ -1,77 +1,79 @@
 timeout(time: 6, unit: 'HOURS') {
-  node('kitchen-slave') {
-    timestamps {
-        ansiColor('xterm') {
-            withEnv([
-                'SALT_KITCHEN_PLATFORMS=/var/jenkins/workspace/platforms.yml',
-                'SALT_KITCHEN_DRIVER=/var/jenkins/workspace/driver.yml',
-                'PATH=/usr/local/rbenv/shims/:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/root/bin:/root/bin',
-                'RBENV_VERSION=2.4.2',
-                'TEST_SUITE=py2',
-                'TEST_PLATFORM=ubuntu-1604',
-                'PY_COLORS=1',])
-            {
-                stage('checkout-scm') {
-                    cleanWs notFailBuild: true
-                    checkout scm
-                }
-                try {
-                    stage('github-pending') {
-                        githubNotify credentialsId: 'test-jenkins-credentials',
-                            description: "running ${TEST_SUITE}-${TEST_PLATFORM}...",
-                            status: 'PENDING',
-                            context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
-                    }
-                    stage('setup-bundle') {
-                        sh 'bundle install --with ec2 windows --without opennebula docker'
+    node('kitchen-slave') {
+        timestamps {
+            ansiColor('xterm') {
+                withEnv([
+                    'SALT_KITCHEN_PLATFORMS=/var/jenkins/workspace/platforms.yml',
+                    'SALT_KITCHEN_DRIVER=/var/jenkins/workspace/driver.yml',
+                    'PATH=/usr/local/rbenv/shims/:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/root/bin:/root/bin',
+                    'RBENV_VERSION=2.4.2',
+                    'TEST_SUITE=py2',
+                    'TEST_PLATFORM=ubuntu-1604',
+                    'PY_COLORS=1',
+                ]) {
+                    stage('checkout-scm') {
+                        cleanWs notFailBuild: true
+                        checkout scm
                     }
                     try {
-                        stage('run kitchen') {
-                            withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
-                                sshagent(credentials: ['jenkins-testing-ssh-key']) {
-                                    sh 'ssh-add ~/.ssh/jenkins-testing.pem'
-                                    sh 'bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM || bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM'
-                                    sh 'bundle exec kitchen verify $TEST_SUITE-$TEST_PLATFORM'
+                        stage('github-pending') {
+                            githubNotify credentialsId: 'test-jenkins-credentials',
+                                description: "running ${TEST_SUITE}-${TEST_PLATFORM}...",
+                                status: 'PENDING',
+                                context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
+                        }
+                        stage('setup-bundle') {
+                            sh 'bundle install --with ec2 windows --without opennebula docker'
+                        }
+                        try {
+                            stage('run kitchen') {
+                                withCredentials([
+                                    [$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']
+                                ]) {
+                                    sshagent(credentials: ['jenkins-testing-ssh-key']) {
+                                        sh 'ssh-add ~/.ssh/jenkins-testing.pem'
+                                        sh 'bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM || bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM'
+                                        sh 'bundle exec kitchen verify $TEST_SUITE-$TEST_PLATFORM'
+                                    }
                                 }
+                            }
+                        } finally {
+                            stage('cleanup kitchen') {
+                                script {
+                                    withCredentials([
+                                        [$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']
+                                    ]) {
+                                        sshagent(credentials: ['jenkins-testing-ssh-key']) {
+                                            sh 'ssh-add ~/.ssh/jenkins-testing.pem'
+                                            sh 'bundle exec kitchen destroy $TEST_SUITE-$TEST_PLATFORM'
+                                        }
+                                    }
+                                }
+                                archiveArtifacts artifacts: 'artifacts/xml-unittests-output/*.xml'
+                                archiveArtifacts artifacts: 'artifacts/logs/minion'
+                                archiveArtifacts artifacts: 'artifacts/logs/salt-runtests.log'
+                            }
+                        }
+                    } finally {
+                        try {
+                            junit 'artifacts/xml-unittests-output/*.xml'
+                        } finally {
+                            cleanWs notFailBuild: true
+                            if (currentBuild.result == 'SUCCESS') {
+                                githubNotify credentialsId: 'test-jenkins-credentials',
+                                    description: "The ${TEST_SUITE}-${TEST_PLATFORM} job has passed",
+                                    status: 'SUCCESS',
+                                    context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
+                            } else {
+                                githubNotify credentialsId: 'test-jenkins-credentials',
+                                    description: "The ${TEST_SUITE}-${TEST_PLATFORM} job has failed",
+                                    status: 'FAILURE',
+                                    context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
                             }
                         }
                     }
-                    finally {
-                        stage('cleanup kitchen') {
-                            script { withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
-                                sshagent(credentials: ['jenkins-testing-ssh-key']) {
-                                    sh 'ssh-add ~/.ssh/jenkins-testing.pem'
-                                    sh 'bundle exec kitchen destroy $TEST_SUITE-$TEST_PLATFORM'
-                                }
-                            }}
-                            archiveArtifacts artifacts: 'artifacts/xml-unittests-output/*.xml'
-                            archiveArtifacts artifacts: 'artifacts/logs/minion'
-                            archiveArtifacts artifacts: 'artifacts/logs/salt-runtests.log'
-                        }
-                    }
                 }
-                finally {
-                    try {
-                        junit 'artifacts/xml-unittests-output/*.xml'
-                    }
-                    finally {
-                        cleanWs notFailBuild: true
-                        if (currentBuild.result == 'SUCCESS') {
-                            githubNotify credentialsId: 'test-jenkins-credentials',
-                                description: "The ${TEST_SUITE}-${TEST_PLATFORM} job has passed",
-                                status: 'SUCCESS',
-                                context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
-                        }
-                        else {
-                            githubNotify credentialsId: 'test-jenkins-credentials',
-                                description: "The ${TEST_SUITE}-${TEST_PLATFORM} job has failed",
-                                status: 'FAILURE',
-                                context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
-                        }
-                    }
-                }
-              }
-          }
-      }
-  }
+            }
+        }
+    }
 }

--- a/.ci/kitchen-ubuntu1604-py2
+++ b/.ci/kitchen-ubuntu1604-py2
@@ -1,4 +1,5 @@
-node('kitchen-slave') {
+timeout(time: 6, unit: 'HOURS') {
+  node('kitchen-slave') {
     timestamps {
         ansiColor('xterm') {
             withEnv([
@@ -69,7 +70,8 @@ node('kitchen-slave') {
                         }
                     }
                 }
-            }
-        }
-    }
+              }
+          }
+      }
+  }
 }

--- a/.ci/kitchen-ubuntu1604-py2
+++ b/.ci/kitchen-ubuntu1604-py2
@@ -59,7 +59,8 @@ timeout(time: 6, unit: 'HOURS') {
                             junit 'artifacts/xml-unittests-output/*.xml'
                         } finally {
                             cleanWs notFailBuild: true
-                            if (currentBuild.result == 'SUCCESS') {
+                            def currentResult = currentBuild.result ?: 'SUCCESS'
+                            if ( currentResult == 'SUCCESS') {
                                 githubNotify credentialsId: 'test-jenkins-credentials',
                                     description: "The ${TEST_SUITE}-${TEST_PLATFORM} job has passed",
                                     status: 'SUCCESS',

--- a/.ci/kitchen-ubuntu1604-py3
+++ b/.ci/kitchen-ubuntu1604-py3
@@ -1,4 +1,5 @@
-node('kitchen-slave') {
+timeout(time: 6, unit: 'HOURS') {
+  node('kitchen-slave') {
     timestamps {
         ansiColor('xterm') {
             withEnv([
@@ -67,9 +68,10 @@ node('kitchen-slave') {
                                 status: 'FAILURE',
                                 context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
                         }
-                    }
-                }
-            }
-        }
-    }
+                     }
+                  }
+              }
+          }
+      }
+  }
 }

--- a/.ci/kitchen-ubuntu1604-py3
+++ b/.ci/kitchen-ubuntu1604-py3
@@ -59,7 +59,8 @@ timeout(time: 6, unit: 'HOURS') {
                             junit 'artifacts/xml-unittests-output/*.xml'
                         } finally {
                             cleanWs notFailBuild: true
-                            if (currentBuild.result == 'SUCCESS') {
+                            def currentResult = currentBuild.result ?: 'SUCCESS'
+                            if (currentResult == 'SUCCESS') {
                                 githubNotify credentialsId: 'test-jenkins-credentials',
                                     description: "The ${TEST_SUITE}-${TEST_PLATFORM} job has passed",
                                     status: 'SUCCESS',

--- a/.ci/kitchen-ubuntu1604-py3
+++ b/.ci/kitchen-ubuntu1604-py3
@@ -1,77 +1,79 @@
 timeout(time: 6, unit: 'HOURS') {
-  node('kitchen-slave') {
-    timestamps {
-        ansiColor('xterm') {
-            withEnv([
-                'SALT_KITCHEN_PLATFORMS=/var/jenkins/workspace/platforms.yml',
-                'SALT_KITCHEN_DRIVER=/var/jenkins/workspace/driver.yml',
-                'PATH=/usr/local/rbenv/shims/:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/root/bin:/root/bin',
-                'RBENV_VERSION=2.4.2',
-                'TEST_SUITE=py3',
-                'TEST_PLATFORM=ubuntu-1604',
-                'PY_COLORS=1',])
-            {
-                stage('checkout-scm') {
-                    cleanWs notFailBuild: true
-                    checkout scm
-                }
-                try {
-                    stage('github-pending') {
-                        githubNotify credentialsId: 'test-jenkins-credentials',
-                            description: "running ${TEST_SUITE}-${TEST_PLATFORM}...",
-                            status: 'PENDING',
-                            context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
-                    }
-                    stage('setup-bundle') {
-                        sh 'bundle install --with ec2 windows --without opennebula docker'
+    node('kitchen-slave') {
+        timestamps {
+            ansiColor('xterm') {
+                withEnv([
+                    'SALT_KITCHEN_PLATFORMS=/var/jenkins/workspace/platforms.yml',
+                    'SALT_KITCHEN_DRIVER=/var/jenkins/workspace/driver.yml',
+                    'PATH=/usr/local/rbenv/shims/:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/root/bin:/root/bin',
+                    'RBENV_VERSION=2.4.2',
+                    'TEST_SUITE=py3',
+                    'TEST_PLATFORM=ubuntu-1604',
+                    'PY_COLORS=1',
+                ]) {
+                    stage('checkout-scm') {
+                        cleanWs notFailBuild: true
+                        checkout scm
                     }
                     try {
-                        stage('run kitchen') {
-                            withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
-                                sshagent(credentials: ['jenkins-testing-ssh-key']) {
-                                    sh 'ssh-add ~/.ssh/jenkins-testing.pem'
-                                    sh 'bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM || bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM'
-                                    sh 'bundle exec kitchen verify $TEST_SUITE-$TEST_PLATFORM'
+                        stage('github-pending') {
+                            githubNotify credentialsId: 'test-jenkins-credentials',
+                                description: "running ${TEST_SUITE}-${TEST_PLATFORM}...",
+                                status: 'PENDING',
+                                context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
+                        }
+                        stage('setup-bundle') {
+                            sh 'bundle install --with ec2 windows --without opennebula docker'
+                        }
+                        try {
+                            stage('run kitchen') {
+                                withCredentials([
+                                    [$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']
+                                ]) {
+                                    sshagent(credentials: ['jenkins-testing-ssh-key']) {
+                                        sh 'ssh-add ~/.ssh/jenkins-testing.pem'
+                                        sh 'bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM || bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM'
+                                        sh 'bundle exec kitchen verify $TEST_SUITE-$TEST_PLATFORM'
+                                    }
                                 }
+                            }
+                        } finally {
+                            stage('cleanup kitchen') {
+                                script {
+                                    withCredentials([
+                                        [$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']
+                                    ]) {
+                                        sshagent(credentials: ['jenkins-testing-ssh-key']) {
+                                            sh 'ssh-add ~/.ssh/jenkins-testing.pem'
+                                            sh 'bundle exec kitchen destroy $TEST_SUITE-$TEST_PLATFORM'
+                                        }
+                                    }
+                                }
+                                archiveArtifacts artifacts: 'artifacts/xml-unittests-output/*.xml'
+                                archiveArtifacts artifacts: 'artifacts/logs/minion'
+                                archiveArtifacts artifacts: 'artifacts/logs/salt-runtests.log'
+                            }
+                        }
+                    } finally {
+                        try {
+                            junit 'artifacts/xml-unittests-output/*.xml'
+                        } finally {
+                            cleanWs notFailBuild: true
+                            if (currentBuild.result == 'SUCCESS') {
+                                githubNotify credentialsId: 'test-jenkins-credentials',
+                                    description: "The ${TEST_SUITE}-${TEST_PLATFORM} job has passed",
+                                    status: 'SUCCESS',
+                                    context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
+                            } else {
+                                githubNotify credentialsId: 'test-jenkins-credentials',
+                                    description: "The ${TEST_SUITE}-${TEST_PLATFORM} job has failed",
+                                    status: 'FAILURE',
+                                    context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
                             }
                         }
                     }
-                    finally {
-                        stage('cleanup kitchen') {
-                            script { withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
-                                sshagent(credentials: ['jenkins-testing-ssh-key']) {
-                                    sh 'ssh-add ~/.ssh/jenkins-testing.pem'
-                                    sh 'bundle exec kitchen destroy $TEST_SUITE-$TEST_PLATFORM'
-                                }
-                            }}
-                            archiveArtifacts artifacts: 'artifacts/xml-unittests-output/*.xml'
-                            archiveArtifacts artifacts: 'artifacts/logs/minion'
-                            archiveArtifacts artifacts: 'artifacts/logs/salt-runtests.log'
-                        }
-                    }
                 }
-                finally {
-                    try {
-                        junit 'artifacts/xml-unittests-output/*.xml'
-                    }
-                    finally {
-                        cleanWs notFailBuild: true
-                        if (currentBuild.result == 'SUCCESS') {
-                            githubNotify credentialsId: 'test-jenkins-credentials',
-                                description: "The ${TEST_SUITE}-${TEST_PLATFORM} job has passed",
-                                status: 'SUCCESS',
-                                context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
-                        }
-                        else {
-                            githubNotify credentialsId: 'test-jenkins-credentials',
-                                description: "The ${TEST_SUITE}-${TEST_PLATFORM} job has failed",
-                                status: 'FAILURE',
-                                context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
-                        }
-                     }
-                  }
-              }
-          }
-      }
-  }
+            }
+        }
+    }
 }

--- a/.ci/kitchen-windows2016-py2
+++ b/.ci/kitchen-windows2016-py2
@@ -1,77 +1,79 @@
 timeout(time: 6, unit: 'HOURS') {
-  node('kitchen-slave') {
-    timestamps {
-        ansiColor('xterm') {
-            withEnv([
-                'SALT_KITCHEN_PLATFORMS=/var/jenkins/workspace/platforms.yml',
-                'SALT_KITCHEN_DRIVER=/var/jenkins/workspace/driver.yml',
-                'PATH=/usr/local/rbenv/shims/:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/root/bin:/root/bin',
-                'RBENV_VERSION=2.4.2',
-                'TEST_SUITE=py2',
-                'TEST_PLATFORM=windows-2016',
-                'PY_COLORS=1',])
-            {
-                stage('checkout-scm') {
-                    cleanWs notFailBuild: true
-                    checkout scm
-                }
-                try {
-                    stage('github-pending') {
-                        githubNotify credentialsId: 'test-jenkins-credentials',
-                            description: "running ${TEST_SUITE}-${TEST_PLATFORM}...",
-                            status: 'PENDING',
-                            context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
-                    }
-                    stage('setup-bundle') {
-                        sh 'bundle install --with ec2 windows --without opennebula docker'
+    node('kitchen-slave') {
+        timestamps {
+            ansiColor('xterm') {
+                withEnv([
+                    'SALT_KITCHEN_PLATFORMS=/var/jenkins/workspace/platforms.yml',
+                    'SALT_KITCHEN_DRIVER=/var/jenkins/workspace/driver.yml',
+                    'PATH=/usr/local/rbenv/shims/:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/root/bin:/root/bin',
+                    'RBENV_VERSION=2.4.2',
+                    'TEST_SUITE=py2',
+                    'TEST_PLATFORM=windows-2016',
+                    'PY_COLORS=1',
+                ]) {
+                    stage('checkout-scm') {
+                        cleanWs notFailBuild: true
+                        checkout scm
                     }
                     try {
-                        stage('run kitchen') {
-                            withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
-                                sshagent(credentials: ['jenkins-testing-ssh-key']) {
-                                    sh 'ssh-add ~/.ssh/jenkins-testing.pem'
-                                    sh 'bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM || bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM'
-                                    sh 'bundle exec kitchen verify $TEST_SUITE-$TEST_PLATFORM'
+                        stage('github-pending') {
+                            githubNotify credentialsId: 'test-jenkins-credentials',
+                                description: "running ${TEST_SUITE}-${TEST_PLATFORM}...",
+                                status: 'PENDING',
+                                context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
+                        }
+                        stage('setup-bundle') {
+                            sh 'bundle install --with ec2 windows --without opennebula docker'
+                        }
+                        try {
+                            stage('run kitchen') {
+                                withCredentials([
+                                    [$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']
+                                ]) {
+                                    sshagent(credentials: ['jenkins-testing-ssh-key']) {
+                                        sh 'ssh-add ~/.ssh/jenkins-testing.pem'
+                                        sh 'bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM || bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM'
+                                        sh 'bundle exec kitchen verify $TEST_SUITE-$TEST_PLATFORM'
+                                    }
                                 }
+                            }
+                        } finally {
+                            stage('cleanup kitchen') {
+                                script {
+                                    withCredentials([
+                                        [$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']
+                                    ]) {
+                                        sshagent(credentials: ['jenkins-testing-ssh-key']) {
+                                            sh 'ssh-add ~/.ssh/jenkins-testing.pem'
+                                            sh 'bundle exec kitchen destroy $TEST_SUITE-$TEST_PLATFORM'
+                                        }
+                                    }
+                                }
+                                archiveArtifacts artifacts: 'artifacts/xml-unittests-output/*.xml'
+                                archiveArtifacts artifacts: 'artifacts/logs/minion'
+                                archiveArtifacts artifacts: 'artifacts/logs/salt-runtests.log'
+                            }
+                        }
+                    } finally {
+                        try {
+                            junit 'artifacts/xml-unittests-output/*.xml'
+                        } finally {
+                            cleanWs notFailBuild: true
+                            if (currentBuild.result == 'SUCCESS') {
+                                githubNotify credentialsId: 'test-jenkins-credentials',
+                                    description: "The ${TEST_SUITE}-${TEST_PLATFORM} job has passed",
+                                    status: 'SUCCESS',
+                                    context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
+                            } else {
+                                githubNotify credentialsId: 'test-jenkins-credentials',
+                                    description: "The ${TEST_SUITE}-${TEST_PLATFORM} job has failed",
+                                    status: 'FAILURE',
+                                    context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
                             }
                         }
                     }
-                    finally {
-                        stage('cleanup kitchen') {
-                            script { withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
-                                sshagent(credentials: ['jenkins-testing-ssh-key']) {
-                                    sh 'ssh-add ~/.ssh/jenkins-testing.pem'
-                                    sh 'bundle exec kitchen destroy $TEST_SUITE-$TEST_PLATFORM'
-                                }
-                            }}
-                            archiveArtifacts artifacts: 'artifacts/xml-unittests-output/*.xml'
-                            archiveArtifacts artifacts: 'artifacts/logs/minion'
-                            archiveArtifacts artifacts: 'artifacts/logs/salt-runtests.log'
-                        }
-                    }
                 }
-                finally {
-                    try {
-                        junit 'artifacts/xml-unittests-output/*.xml'
-                    }
-                    finally {
-                        cleanWs notFailBuild: true
-                        if (currentBuild.result == 'SUCCESS') {
-                            githubNotify credentialsId: 'test-jenkins-credentials',
-                                description: "The ${TEST_SUITE}-${TEST_PLATFORM} job has passed",
-                                status: 'SUCCESS',
-                                context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
-                        }
-                        else {
-                            githubNotify credentialsId: 'test-jenkins-credentials',
-                                description: "The ${TEST_SUITE}-${TEST_PLATFORM} job has failed",
-                                status: 'FAILURE',
-                                context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
-                        }
-                    }
-                 }
-              }
-          }
-      }
-  }
+            }
+        }
+    }
 }

--- a/.ci/kitchen-windows2016-py2
+++ b/.ci/kitchen-windows2016-py2
@@ -59,7 +59,8 @@ timeout(time: 6, unit: 'HOURS') {
                             junit 'artifacts/xml-unittests-output/*.xml'
                         } finally {
                             cleanWs notFailBuild: true
-                            if (currentBuild.result == 'SUCCESS') {
+                            def currentResult = currentBuild.result ?: 'SUCCESS'
+                            if (currentResult == 'SUCCESS') {
                                 githubNotify credentialsId: 'test-jenkins-credentials',
                                     description: "The ${TEST_SUITE}-${TEST_PLATFORM} job has passed",
                                     status: 'SUCCESS',

--- a/.ci/kitchen-windows2016-py2
+++ b/.ci/kitchen-windows2016-py2
@@ -1,4 +1,5 @@
-node('kitchen-slave') {
+timeout(time: 6, unit: 'HOURS') {
+  node('kitchen-slave') {
     timestamps {
         ansiColor('xterm') {
             withEnv([
@@ -68,8 +69,9 @@ node('kitchen-slave') {
                                 context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
                         }
                     }
-                }
-            }
-        }
-    }
+                 }
+              }
+          }
+      }
+  }
 }

--- a/.ci/kitchen-windows2016-py3
+++ b/.ci/kitchen-windows2016-py3
@@ -59,7 +59,8 @@ timeout(time: 6, unit: 'HOURS') {
                             junit 'artifacts/xml-unittests-output/*.xml'
                         } finally {
                             cleanWs notFailBuild: true
-                            if (currentBuild.result == 'SUCCESS') {
+                            def currentResult = currentBuild.result ?: 'SUCCESS'
+                            if (currentResult == 'SUCCESS') {
                                 githubNotify credentialsId: 'test-jenkins-credentials',
                                     description: "The ${TEST_SUITE}-${TEST_PLATFORM} job has passed",
                                     status: 'SUCCESS',

--- a/.ci/kitchen-windows2016-py3
+++ b/.ci/kitchen-windows2016-py3
@@ -1,4 +1,5 @@
-node('kitchen-slave') {
+timeout(time: 6, unit: 'HOURS') {
+  node('kitchen-slave') {
     timestamps {
         ansiColor('xterm') {
             withEnv([
@@ -68,8 +69,9 @@ node('kitchen-slave') {
                                 context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
                         }
                     }
-                }
-            }
-        }
-    }
+                 }
+              }
+          }
+      }
+  }
 }

--- a/.ci/kitchen-windows2016-py3
+++ b/.ci/kitchen-windows2016-py3
@@ -1,77 +1,79 @@
 timeout(time: 6, unit: 'HOURS') {
-  node('kitchen-slave') {
-    timestamps {
-        ansiColor('xterm') {
-            withEnv([
-                'SALT_KITCHEN_PLATFORMS=/var/jenkins/workspace/platforms.yml',
-                'SALT_KITCHEN_DRIVER=/var/jenkins/workspace/driver.yml',
-                'PATH=/usr/local/rbenv/shims/:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/root/bin:/root/bin',
-                'RBENV_VERSION=2.4.2',
-                'TEST_SUITE=py3',
-                'TEST_PLATFORM=windows-2016',
-                'PY_COLORS=1',])
-            {
-                stage('checkout-scm') {
-                    cleanWs notFailBuild: true
-                    checkout scm
-                }
-                try {
-                    stage('github-pending') {
-                        githubNotify credentialsId: 'test-jenkins-credentials',
-                            description: "running ${TEST_SUITE}-${TEST_PLATFORM}...",
-                            status: 'PENDING',
-                            context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
-                    }
-                    stage('setup-bundle') {
-                        sh 'bundle install --with ec2 windows --without opennebula docker'
+    node('kitchen-slave') {
+        timestamps {
+            ansiColor('xterm') {
+                withEnv([
+                    'SALT_KITCHEN_PLATFORMS=/var/jenkins/workspace/platforms.yml',
+                    'SALT_KITCHEN_DRIVER=/var/jenkins/workspace/driver.yml',
+                    'PATH=/usr/local/rbenv/shims/:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/root/bin:/root/bin',
+                    'RBENV_VERSION=2.4.2',
+                    'TEST_SUITE=py3',
+                    'TEST_PLATFORM=windows-2016',
+                    'PY_COLORS=1',
+                ]) {
+                    stage('checkout-scm') {
+                        cleanWs notFailBuild: true
+                        checkout scm
                     }
                     try {
-                        stage('run kitchen') {
-                            withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
-                                sshagent(credentials: ['jenkins-testing-ssh-key']) {
-                                    sh 'ssh-add ~/.ssh/jenkins-testing.pem'
-                                    sh 'bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM || bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM'
-                                    sh 'bundle exec kitchen verify $TEST_SUITE-$TEST_PLATFORM'
+                        stage('github-pending') {
+                            githubNotify credentialsId: 'test-jenkins-credentials',
+                                description: "running ${TEST_SUITE}-${TEST_PLATFORM}...",
+                                status: 'PENDING',
+                                context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
+                        }
+                        stage('setup-bundle') {
+                            sh 'bundle install --with ec2 windows --without opennebula docker'
+                        }
+                        try {
+                            stage('run kitchen') {
+                                withCredentials([
+                                    [$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']
+                                ]) {
+                                    sshagent(credentials: ['jenkins-testing-ssh-key']) {
+                                        sh 'ssh-add ~/.ssh/jenkins-testing.pem'
+                                        sh 'bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM || bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM'
+                                        sh 'bundle exec kitchen verify $TEST_SUITE-$TEST_PLATFORM'
+                                    }
                                 }
+                            }
+                        } finally {
+                            stage('cleanup kitchen') {
+                                script {
+                                    withCredentials([
+                                        [$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']
+                                    ]) {
+                                        sshagent(credentials: ['jenkins-testing-ssh-key']) {
+                                            sh 'ssh-add ~/.ssh/jenkins-testing.pem'
+                                            sh 'bundle exec kitchen destroy $TEST_SUITE-$TEST_PLATFORM'
+                                        }
+                                    }
+                                }
+                                archiveArtifacts artifacts: 'artifacts/xml-unittests-output/*.xml'
+                                archiveArtifacts artifacts: 'artifacts/logs/minion'
+                                archiveArtifacts artifacts: 'artifacts/logs/salt-runtests.log'
+                            }
+                        }
+                    } finally {
+                        try {
+                            junit 'artifacts/xml-unittests-output/*.xml'
+                        } finally {
+                            cleanWs notFailBuild: true
+                            if (currentBuild.result == 'SUCCESS') {
+                                githubNotify credentialsId: 'test-jenkins-credentials',
+                                    description: "The ${TEST_SUITE}-${TEST_PLATFORM} job has passed",
+                                    status: 'SUCCESS',
+                                    context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
+                            } else {
+                                githubNotify credentialsId: 'test-jenkins-credentials',
+                                    description: "The ${TEST_SUITE}-${TEST_PLATFORM} job has failed",
+                                    status: 'FAILURE',
+                                    context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
                             }
                         }
                     }
-                    finally {
-                        stage('cleanup kitchen') {
-                            script { withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
-                                sshagent(credentials: ['jenkins-testing-ssh-key']) {
-                                    sh 'ssh-add ~/.ssh/jenkins-testing.pem'
-                                    sh 'bundle exec kitchen destroy $TEST_SUITE-$TEST_PLATFORM'
-                                }
-                            }}
-                            archiveArtifacts artifacts: 'artifacts/xml-unittests-output/*.xml'
-                            archiveArtifacts artifacts: 'artifacts/logs/minion'
-                            archiveArtifacts artifacts: 'artifacts/logs/salt-runtests.log'
-                        }
-                    }
                 }
-                finally {
-                    try {
-                        junit 'artifacts/xml-unittests-output/*.xml'
-                    }
-                    finally {
-                        cleanWs notFailBuild: true
-                        if (currentBuild.result == 'SUCCESS') {
-                            githubNotify credentialsId: 'test-jenkins-credentials',
-                                description: "The ${TEST_SUITE}-${TEST_PLATFORM} job has passed",
-                                status: 'SUCCESS',
-                                context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
-                        }
-                        else {
-                            githubNotify credentialsId: 'test-jenkins-credentials',
-                                description: "The ${TEST_SUITE}-${TEST_PLATFORM} job has failed",
-                                status: 'FAILURE',
-                                context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
-                        }
-                    }
-                 }
-              }
-          }
-      }
-  }
+            }
+        }
+    }
 }

--- a/.ci/lint
+++ b/.ci/lint
@@ -3,6 +3,7 @@ pipeline {
     options {
         timestamps()
         ansiColor('xterm')
+        timeout(time: 6, unit: 'HOURS') 
     }
     environment {
         PYENV_ROOT = "/usr/local/pyenv"

--- a/.ci/lint
+++ b/.ci/lint
@@ -3,7 +3,7 @@ pipeline {
     options {
         timestamps()
         ansiColor('xterm')
-        timeout(time: 6, unit: 'HOURS') 
+        timeout(time: 1, unit: 'HOURS') 
     }
     environment {
         PYENV_ROOT = "/usr/local/pyenv"


### PR DESCRIPTION
### What does this PR do?
Adds a timeout to the pipelines so that the jobs fail if they run longer than the duration specified in the pipeline.

### What issues does this PR fix or reference?
Jobs running for > 13 hours or forever

### New Behavior
We should see them timeout now.

### Tests written?
Code testing was performed via 
https://jenkins.io/doc/book/pipeline/development/#linter


### Commits signed with GPG?

Yes


