### PR TITLE
Skip test_local_pkg_install for now: this is causing the test suite to hang

### DIFF
--- a/tests/integration/shell/test_call.py
+++ b/tests/integration/shell/test_call.py
@@ -77,6 +77,7 @@ class CallTest(ShellCase, testprogram.TestProgramCase, ShellCaseCommonTestsMixin
         self.assertIn('hello', ''.join(out))
         self.assertIn('Succeeded: 1', ''.join(out))
 
+    @skipIf(True, 'This test causes the test to hang. Skipping until further investigation can occur.')
     @destructiveTest
     @skip_if_not_root
     @skipIf(salt.utils.platform.is_windows(), 'This test does not apply on Windows')


### PR DESCRIPTION
The test suite is hanging on this test. We need to skip it until we can look into this further.

This test was recently enabled again in #49552. However, the test suite is now hanging on this test both in the fluorine and develop branches.

I spoke with @terminalmage about this today and he is going to look into some other testing alternatives to look for a regression test to ensure the behavior the `test_local_pkg_install` behavior of a duplicated `salt-call` is addressed.

Other recent related changes for this test:

- #49725
- #49799


