### PR TITLE
Remove warnings/support for force option for Neon

### DIFF
--- a/doc/topics/releases/neon.rst
+++ b/doc/topics/releases/neon.rst
@@ -212,3 +212,13 @@ Module Deprecations
     - Support for the ``ssh.recv_known_host`` function has been removed. Please use the
       :py:func:`ssh.recv_known_host_entries <salt.modules.ssh.recv_known_host_entries>`
       function instead.
+
+State Deprecations
+------------------
+
+- The :py:mod:`win_servermanager <salt.states.win_servermanager>` state has been
+  changed as follows:
+
+    - Support for the ``force`` kwarg has been removed from the
+      :py:func:`win_servermanager.installed <salt.statues.win_servermanager.installed>`
+      function. Please use ``recurse`` instead.

--- a/salt/states/win_servermanager.py
+++ b/salt/states/win_servermanager.py
@@ -27,8 +27,7 @@ def installed(name,
               recurse=False,
               restart=False,
               source=None,
-              exclude=None,
-              **kwargs):
+              exclude=None):
     '''
     Install the windows feature. To install a single feature, use the ``name``
     parameter. To install multiple features, use the ``features`` parameter.
@@ -113,15 +112,6 @@ def installed(name,
             - exclude:
               - Web-Server
     '''
-    if 'force' in kwargs:
-        salt.utils.versions.warn_until(
-            'Neon',
-            'Parameter \'force\' has been detected in the argument list. This'
-            'parameter is no longer used and has been replaced by \'recurse\''
-            'as of Salt 2018.3.0. This warning will be removed in Salt Neon.'
-        )
-        kwargs.pop('force')
-
     ret = {'name': name,
            'result': True,
            'changes': {},


### PR DESCRIPTION
The `win_servermanager.installed` function no longer supports the "force" option. This change removes the warning for Neon and updates the release notes.

Fixes #49421
