### PR TITLE
fixing mis-spelling of lattrs in file.py, referncing #49204 

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -4511,7 +4511,7 @@ def check_perms(name, ret, user, group, mode, attrs=None, follow_symlinks=False)
         try:
             lattrs = lsattr(name)
         except SaltInvocationError:
-            lsattrs = None
+            lattrs = None
         if lattrs is not None:
             # List attributes on file
             perms['lattrs'] = ''.join(lattrs.get(name, ''))


### PR DESCRIPTION
per request from @gtmanfred, creating a pull request

### What does this PR do?

Correct the mis-spelling of lattrs in the except block, line 4514

### What issues does this PR fix or reference?

when running a file action that recurses (e.g. recurse owner, group, mode, etc), the state would fail.  Found this issue in 2018.1 and discovered that it was being fixed in latest develop branch.

lattrs is mis-spelled in this line. if the except condition fires, then the following `if lattrs is not None:` line will throw an `local variable 'lattrs' referenced before assignment` error.

### Previous Behavior
`local variable 'lattrs' referenced before assignment` error

### Tests written?

No

### Commits signed with GPG?

No