### PR TITLE
Use utf-8 encoding for salt-runtests.log

### DIFF
--- a/tests/support/parser/__init__.py
+++ b/tests/support/parser/__init__.py
@@ -431,7 +431,8 @@ class SaltTestingParser(optparse.OptionParser):
         if self.options.tests_logfile:
             filehandler = logging.FileHandler(
                 mode='w',           # Not preserved between re-runs
-                filename=self.options.tests_logfile
+                filename=self.options.tests_logfile,
+                encoding='utf-8',
             )
             # The logs of the file are the most verbose possible
             filehandler.setLevel(logging.DEBUG)


### PR DESCRIPTION
### What does this PR do?

Do not raise exceptions when tests log utf-8 data.

### Tests written?

No

### Commits signed with GPG?

Yes