### PR TITLE
Option print_result should be true by default

### DIFF
--- a/salt/modules/saltcheck.py
+++ b/salt/modules/saltcheck.py
@@ -570,7 +570,7 @@ class SaltCheck(object):
             else:
                 assertion = test_dict['assertion']
             expected_return = test_dict.get('expected-return', None)
-            assert_print_result = test_dict.get('print_result', None)
+            assert_print_result = test_dict.get('print_result', True)
             actual_return = self._call_salt_command(mod_and_func, args, kwargs, assertion_section)
             if assertion not in ["assertIn", "assertNotIn", "assertEmpty", "assertNotEmpty",
                                  "assertTrue", "assertFalse"]:


### PR DESCRIPTION
### What does this PR do?
According documentation default value for print_result should be `true`
> Defaults to True

### What issues does this PR fix or reference?

### Previous Behavior
Failed test result was not displayed by default as described in docs
```
status:
  Fail: Result is not equal
```

### New Behavior
Failed test now properly show status
```
status:
  Fail: True is not equal to False
```

### Tests written?

No

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
