### PR TITLE
Don't return False when target exists (file.rename)

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -6375,7 +6375,6 @@ def rename(name, source, force=False, makedirs=False):
         if not force:
             ret['comment'] = ('The target file "{0}" exists and will not be '
                               'overwritten'.format(name))
-            ret['result'] = False
             return ret
         elif not __opts__['test']:
             # Remove the destination to prevent problems later

--- a/tests/unit/states/test_file.py
+++ b/tests/unit/states/test_file.py
@@ -1500,7 +1500,7 @@ class TestFileState(TestCase, LoaderModuleMockMixin):
             with patch.object(os.path, 'lexists', mock_lex):
                 comt = ('The target file "{0}" exists and will not be '
                         'overwritten'.format(name))
-                ret.update({'comment': comt, 'result': False})
+                ret.update({'comment': comt, 'result': True})
                 self.assertDictEqual(filestate.rename(name, source), ret)
 
         mock_lex = MagicMock(side_effect=[True, True, True])


### PR DESCRIPTION
### What does this PR do?

This PR applies the change recommended by @DickerDackel in #49748.

### Previous Behavior

When using file.rename and then creating a new file in it's place, subsequent executions will fail due to a file existing in it's place.

### New Behavior

This patch removes the ``False`` return when a destination file exists if ``-force:False``.

### Tests written?

Yes

### Commits signed with GPG?

Yes