### PR TITLE
Fix badly formatted versionadded directive (2018.3 branch)

### DIFF
--- a/salt/states/git.py
+++ b/salt/states/git.py
@@ -2732,7 +2732,7 @@ def cloned(name,
            https_pass=None,
            output_encoding=None):
     '''
-    .. versionadded:: 2018.3.3, Fluorine
+    .. versionadded:: 2018.3.3,Fluorine
 
     Ensure that a repository has been cloned to the specified target directory.
     If not, clone that repository. No fetches will be performed once cloned.


### PR DESCRIPTION
A space here will cause the Sphinx role to treat whatever is after the comma as the comment for the directive, so it will be rendered with different CSS and look weird.