### PR TITLE
Fix badly formatted versionadded directive (2017.7 branch)

### DIFF
--- a/salt/client/ssh/wrapper/grains.py
+++ b/salt/client/ssh/wrapper/grains.py
@@ -242,7 +242,7 @@ def filter_by(lookup_dict,
         each case to be collected in the base and overridden by the grain
         selection dictionary and the merge dictionary. Default is None.
 
-        .. versionadded:: 2015.8.11, 2016.3.2
+        .. versionadded:: 2015.8.11,2016.3.2
 
     CLI Example:
 

--- a/salt/grains/esxi.py
+++ b/salt/grains/esxi.py
@@ -2,7 +2,7 @@
 '''
 Generate baseline proxy minion grains for ESXi hosts.
 
-., versionadded:: 2015.8.4
+.. versionadded:: 2015.8.4
 
 '''
 

--- a/salt/modules/npm.py
+++ b/salt/modules/npm.py
@@ -261,7 +261,7 @@ def list_(pkg=None, dir=None, runas=None, env=None, depth=None):
     depth
         Limit the depth of the packages listed
 
-        .. versionadded:: 2016.11.6, 2017.7.0
+        .. versionadded:: 2016.11.6,2017.7.0
 
     CLI Example:
 

--- a/salt/modules/win_service.py
+++ b/salt/modules/win_service.py
@@ -106,7 +106,7 @@ def _status_wait(service_name, end_time, service_states):
     Helper function that will wait for the status of the service to match the
     provided status before an end time expires. Used for service stop and start
 
-    .. versionadded:: 2017.7.9, 2018.3.4
+    .. versionadded:: 2017.7.9,2018.3.4
 
     Args:
         service_name (str):
@@ -459,7 +459,7 @@ def start(name, timeout=90):
             The time in seconds to wait for the service to start before
             returning. Default is 90 seconds
 
-            .. versionadded:: 2017.7.9, 2018.3.4
+            .. versionadded:: 2017.7.9,2018.3.4
 
     Returns:
         bool: ``True`` if successful, otherwise ``False``. Also returns ``True``
@@ -501,7 +501,7 @@ def stop(name, timeout=90):
             The time in seconds to wait for the service to stop before
             returning. Default is 90 seconds
 
-            .. versionadded:: 2017.7.9, 2018.3.4
+            .. versionadded:: 2017.7.9,2018.3.4
 
     Returns:
         bool: ``True`` if successful, otherwise ``False``. Also returns ``True``
@@ -548,7 +548,7 @@ def restart(name, timeout=90):
                 then to the start command. A timeout of 90 could take up to 180
                 seconds if the service is long in stopping and starting
 
-            .. versionadded:: 2017.7.9, 2018.3.4
+            .. versionadded:: 2017.7.9,2018.3.4
 
     Returns:
         bool: ``True`` if successful, otherwise ``False``
@@ -1369,7 +1369,7 @@ def delete(name, timeout=90):
             returning. This is necessary because a service must be stopped
             before it can be deleted. Default is 90 seconds
 
-            .. versionadded:: 2017.7.9, 2018.3.4
+            .. versionadded:: 2017.7.9,2018.3.4
 
     Returns:
         bool: ``True`` if successful, otherwise ``False``. Also returns ``True``


### PR DESCRIPTION
A space here will cause the Sphinx role to treat whatever is after the comma as the comment for the directive, so it will be rendered with different CSS and look weird. Also, this fixes one syntactically incorrect versionadded which included a typo.