### PR TITLE
Change versionadded for loadable matchers to Neon

### DIFF
--- a/doc/topics/matchers/index.rst
+++ b/doc/topics/matchers/index.rst
@@ -4,7 +4,7 @@
 Matchers
 ========
 
-.. versionadded:: Flourine
+.. versionadded:: Neon
 
 Matchers are modules that provide Salt's targeting abilities.  As of the
 Flourine release, matchers can be dynamically loaded.  Currently new matchers


### PR DESCRIPTION
### What does this PR do?

Loadable matchers are a new feature, but lack CLI support in Fluorine.  It's a little too late to get the CLI support into this release, so we're marking this feature as new for Neon.
