### PR TITLE
Actually catch the exception when we fail

### DIFF
--- a/.ci/kitchen-centos7-py2
+++ b/.ci/kitchen-centos7-py2
@@ -54,6 +54,8 @@ timeout(time: 6, unit: 'HOURS') {
                                 archiveArtifacts artifacts: 'artifacts/logs/salt-runtests.log'
                             }
                         }
+                    } catch (Exception e) {
+                        currentBuild.result = 'FAILURE'
                     } finally {
                         try {
                             junit 'artifacts/xml-unittests-output/*.xml'

--- a/.ci/kitchen-centos7-py3
+++ b/.ci/kitchen-centos7-py3
@@ -54,6 +54,8 @@ timeout(time: 6, unit: 'HOURS') {
                                 archiveArtifacts artifacts: 'artifacts/logs/salt-runtests.log'
                             }
                         }
+                    } catch (Exception e) {
+                        currentBuild.result = 'FAILURE'
                     } finally {
                         try {
                             junit 'artifacts/xml-unittests-output/*.xml'

--- a/.ci/kitchen-ubuntu1604-py2
+++ b/.ci/kitchen-ubuntu1604-py2
@@ -54,13 +54,15 @@ timeout(time: 6, unit: 'HOURS') {
                                 archiveArtifacts artifacts: 'artifacts/logs/salt-runtests.log'
                             }
                         }
+                    } catch (Exception e) {
+                        currentBuild.result = 'FAILURE'
                     } finally {
                         try {
                             junit 'artifacts/xml-unittests-output/*.xml'
                         } finally {
                             cleanWs notFailBuild: true
                             def currentResult = currentBuild.result ?: 'SUCCESS'
-                            if ( currentResult == 'SUCCESS') {
+                            if (currentResult == 'SUCCESS') {
                                 githubNotify credentialsId: 'test-jenkins-credentials',
                                     description: "The ${TEST_SUITE}-${TEST_PLATFORM} job has passed",
                                     status: 'SUCCESS',

--- a/.ci/kitchen-ubuntu1604-py3
+++ b/.ci/kitchen-ubuntu1604-py3
@@ -54,6 +54,8 @@ timeout(time: 6, unit: 'HOURS') {
                                 archiveArtifacts artifacts: 'artifacts/logs/salt-runtests.log'
                             }
                         }
+                    } catch (Exception e) {
+                        currentBuild.result = 'FAILURE'
                     } finally {
                         try {
                             junit 'artifacts/xml-unittests-output/*.xml'

--- a/.ci/kitchen-windows2016-py2
+++ b/.ci/kitchen-windows2016-py2
@@ -54,6 +54,8 @@ timeout(time: 6, unit: 'HOURS') {
                                 archiveArtifacts artifacts: 'artifacts/logs/salt-runtests.log'
                             }
                         }
+                    } catch (Exception e) {
+                        currentBuild.result = 'FAILURE'
                     } finally {
                         try {
                             junit 'artifacts/xml-unittests-output/*.xml'

--- a/.ci/kitchen-windows2016-py3
+++ b/.ci/kitchen-windows2016-py3
@@ -54,6 +54,8 @@ timeout(time: 6, unit: 'HOURS') {
                                 archiveArtifacts artifacts: 'artifacts/logs/salt-runtests.log'
                             }
                         }
+                    } catch (Exception e) {
+                        currentBuild.result = 'FAILURE'
                     } finally {
                         try {
                             junit 'artifacts/xml-unittests-output/*.xml'


### PR DESCRIPTION
This should actually cause builds to fail when any part in the try block
fails. We still delete instances and try junit rendering, but if things
fail then they get marked on github as failed.

@dubb-b @rallytime @gtmanfred 