### PR TITLE
Fix issues with windows file permissions when using reset=True

### DIFF
--- a/salt/modules/win_file.py
+++ b/salt/modules/win_file.py
@@ -1935,8 +1935,8 @@ def check_perms(path,
             if grant_perms is not None and \
                     user_name.lower() not in dict(
                         (k.lower(), v) for k, v in grant_perms.iteritems()):
-                if 'grant' in cur_perms[user_name] and not \
-                        cur_perms[user_name]['grant']['inherited']:
+                if 'grant' in cur_perms[user_name] and \
+                        not cur_perms[user_name]['grant']['inherited']:
                     if __opts__['test'] is True:
                         if 'remove_perms' not in ret['pchanges']:
                             ret['pchanges']['remove_perms'] = {}
@@ -1954,8 +1954,8 @@ def check_perms(path,
             if deny_perms is not None and \
                     user_name.lower() not in dict(
                         (k.lower(), v) for k, v in deny_perms.iteritems()):
-                if 'deny' in cur_perms[user_name] and not \
-                        cur_perms[user_name]['deny']['inherited']:
+                if 'deny' in cur_perms[user_name] and \
+                        not cur_perms[user_name]['deny']['inherited']:
                     if __opts__['test'] is True:
                         if 'remove_perms' not in ret['pchanges']:
                             ret['pchanges']['remove_perms'] = {}

--- a/salt/modules/win_file.py
+++ b/salt/modules/win_file.py
@@ -1700,7 +1700,7 @@ def check_perms(path,
                 if isinstance(deny_perms[user]['perms'], six.string_types):
                     if not salt.utils.win_dacl.has_permission(
                             obj_name=path,
-                            principal=user,
+                            principal=user_name,
                             permission=deny_perms[user]['perms'],
                             access_mode='deny',
                             exact=False):
@@ -1708,7 +1708,11 @@ def check_perms(path,
                 else:
                     for perm in deny_perms[user]['perms']:
                         if not salt.utils.win_dacl.has_permission(
-                                path, user, perm, 'deny', exact=False):
+                                obj_name=path,
+                                principal=user_name,
+                                permission=perm,
+                                access_mode='deny',
+                                exact=False):
                             if user not in changes:
                                 changes[user] = {'perms': []}
                             changes[user]['perms'].append(deny_perms[user]['perms'])
@@ -1775,7 +1779,7 @@ def check_perms(path,
                 try:
                     salt.utils.win_dacl.set_permissions(
                         obj_name=path,
-                        principal=user,
+                        principal=user_name,
                         permissions=perms,
                         access_mode='deny',
                         applies_to=applies_to)
@@ -1819,7 +1823,7 @@ def check_perms(path,
                 if isinstance(grant_perms[user]['perms'], six.string_types):
                     if not salt.utils.win_dacl.has_permission(
                             obj_name=path,
-                            principal=user,
+                            principal=user_name,
                             permission=grant_perms[user]['perms'],
                             access_mode='grant'):
                         changes[user] = {'perms': grant_perms[user]['perms']}
@@ -1827,7 +1831,7 @@ def check_perms(path,
                     for perm in grant_perms[user]['perms']:
                         if not salt.utils.win_dacl.has_permission(
                                 obj_name=path,
-                                principal=user,
+                                principal=user_name,
                                 permission=perm,
                                 access_mode='grant',
                                 exact=False):
@@ -1894,7 +1898,7 @@ def check_perms(path,
                 try:
                     salt.utils.win_dacl.set_permissions(
                         obj_name=path,
-                        principal=user,
+                        principal=user_name,
                         permissions=perms,
                         access_mode='grant',
                         applies_to=applies_to)
@@ -1925,10 +1929,14 @@ def check_perms(path,
     # Check reset
     # If reset=True, which users will be removed as a result
     if reset:
+        # Reload perms so you can reset them
+        cur_perms = salt.utils.win_dacl.get_permissions(obj_name=path)
         for user_name in cur_perms:
-            if user_name not in grant_perms:
+            if grant_perms is not None and \
+                    user_name.lower() not in dict(
+                        (k.lower(), v) for k, v in grant_perms.iteritems()):
                 if 'grant' in cur_perms[user_name] and not \
-                cur_perms[user_name]['grant']['inherited']:
+                        cur_perms[user_name]['grant']['inherited']:
                     if __opts__['test'] is True:
                         if 'remove_perms' not in ret['pchanges']:
                             ret['pchanges']['remove_perms'] = {}
@@ -1943,9 +1951,11 @@ def check_perms(path,
                             ace_type='grant')
                         ret['changes']['remove_perms'].update(
                             {user_name: cur_perms[user_name]})
-            if user_name not in deny_perms:
+            if deny_perms is not None and \
+                    user_name.lower() not in dict(
+                        (k.lower(), v) for k, v in deny_perms.iteritems()):
                 if 'deny' in cur_perms[user_name] and not \
-                cur_perms[user_name]['deny']['inherited']:
+                        cur_perms[user_name]['deny']['inherited']:
                     if __opts__['test'] is True:
                         if 'remove_perms' not in ret['pchanges']:
                             ret['pchanges']['remove_perms'] = {}

--- a/salt/modules/win_file.py
+++ b/salt/modules/win_file.py
@@ -35,7 +35,7 @@ import fnmatch  # do not remove, used in imported file.py functions
 import mmap  # do not remove, used in imported file.py functions
 import glob  # do not remove, used in imported file.py functions
 # do not remove, used in imported file.py functions
-import salt.ext.six as six  # pylint: disable=import-error,no-name-in-module
+from salt.ext import six
 from salt.ext.six.moves.urllib.parse import urlparse as _urlparse  # pylint: disable=import-error,no-name-in-module
 import salt.utils.atomicfile  # do not remove, used in imported file.py functions
 from salt.exceptions import CommandExecutionError, SaltInvocationError
@@ -1934,7 +1934,7 @@ def check_perms(path,
         for user_name in cur_perms:
             if grant_perms is not None and \
                     user_name.lower() not in dict(
-                        (k.lower(), v) for k, v in grant_perms.iteritems()):
+                        (k.lower(), v) for k, v in six.iteritems(grant_perms)):
                 if 'grant' in cur_perms[user_name] and \
                         not cur_perms[user_name]['grant']['inherited']:
                     if __opts__['test'] is True:
@@ -1953,7 +1953,7 @@ def check_perms(path,
                             {user_name: cur_perms[user_name]})
             if deny_perms is not None and \
                     user_name.lower() not in dict(
-                        (k.lower(), v) for k, v in deny_perms.iteritems()):
+                        (k.lower(), v) for k, v in six.iteritems(deny_perms)):
                 if 'deny' in cur_perms[user_name] and \
                         not cur_perms[user_name]['deny']['inherited']:
                     if __opts__['test'] is True:

--- a/salt/utils/win_functions.py
+++ b/salt/utils/win_functions.py
@@ -123,6 +123,12 @@ def get_current_user(with_domain=True):
     '''
     Gets the user executing the process
 
+    Args:
+
+        with_domain (bool):
+            ``True`` will prepend the user name with the machine name or domain
+            separated by a backslash
+
     Returns:
         str: The user name
     '''

--- a/tests/unit/modules/test_win_file.py
+++ b/tests/unit/modules/test_win_file.py
@@ -64,9 +64,10 @@ class WinFileCheckPermsTestCase(TestCase, LoaderModuleMockMixin):
     Test cases for the check_perms function in salt.modules.win_file
     '''
     temp_file = ''
-    current_user = salt.utils.win_functions.get_current_user(False)
+    current_user = ''
 
     def setup_loader_modules(self):
+        self.current_user = salt.utils.win_functions.get_current_user(False)
         return {
             win_file: {
                 '__opts__': {

--- a/tests/unit/modules/test_win_file.py
+++ b/tests/unit/modules/test_win_file.py
@@ -5,19 +5,24 @@
 # Import Python Libs
 from __future__ import absolute_import, unicode_literals, print_function
 import os
+import tempfile
 
 # Import Salt Testing Libs
+from tests.support.mixins import LoaderModuleMockMixin
 from tests.support.unit import TestCase, skipIf
 from tests.support.mock import (
     patch,
     NO_MOCK,
     NO_MOCK_REASON
 )
+from tests.support.helpers import destructiveTest
 
 # Import Salt Libs
 import salt.modules.win_file as win_file
 from salt.exceptions import CommandExecutionError
 import salt.utils.platform
+import salt.utils.win_functions
+import salt.utils.win_dacl
 
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
@@ -49,3 +54,254 @@ class WinFileTestCase(TestCase):
         with patch('os.path.exists', return_value=False):
             self.assertRaises(
                 CommandExecutionError, win_file.check_perms, self.FAKE_PATH)
+
+
+@destructiveTest
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class WinFileCheckPermsTestCase(TestCase, LoaderModuleMockMixin):
+    '''
+    Test cases for the check_perms function in salt.modules.win_file
+    '''
+    temp_file = ''
+    current_user = salt.utils.win_functions.get_current_user(False)
+
+    def setup_loader_modules(self):
+        return {
+            win_file: {
+                '__opts__': {
+                    'test': False}}}
+
+    def setUp(self):
+        self.temp_file = tempfile.NamedTemporaryFile(delete=False)
+        self.temp_file.close()
+        salt.utils.win_dacl.set_owner(obj_name=self.temp_file.name,
+                                      principal=self.current_user)
+        salt.utils.win_dacl.set_inheritance(obj_name=self.temp_file.name,
+                                            enabled=True)
+        self.assertEqual(
+            salt.utils.win_dacl.get_owner(obj_name=self.temp_file.name),
+            self.current_user)
+
+    def tearDown(self):
+        os.remove(self.temp_file.name)
+
+    def test_check_perms_set_owner_test_true(self):
+        '''
+        Test setting the owner of a file with test=True
+        '''
+        with patch.dict(win_file.__opts__, {'test': True}):
+            expected = {'comment': '',
+                        'changes': {},
+                        'pchanges': {'owner': 'Administrators'},
+                        'name': self.temp_file.name,
+                        'result': None}
+            ret = win_file.check_perms(path=self.temp_file.name,
+                                       owner='Administrators',
+                                       inheritance=None)
+            self.assertDictEqual(expected, ret)
+
+    def test_check_perms_set_owner(self):
+        '''
+        Test setting the owner of a file
+        '''
+        expected = {'comment': '',
+                    'pchanges': {},
+                    'changes': {'owner': 'Administrators'},
+                    'name': self.temp_file.name,
+                    'result': True}
+        ret = win_file.check_perms(path=self.temp_file.name,
+                                   owner='Administrators',
+                                   inheritance=None)
+        self.assertDictEqual(expected, ret)
+
+    def test_check_perms_deny_test_true(self):
+        '''
+        Test setting deny perms on a file with test=True
+        '''
+        with patch.dict(win_file.__opts__, {'test': True}):
+            expected = {'comment': '',
+                        'pchanges': {
+                            'deny_perms': {
+                                'Users': {'perms': 'read_execute'}}},
+                        'changes': {'deny_perms': {}},
+                        'name': self.temp_file.name,
+                        'result': None}
+            ret = win_file.check_perms(
+                path=self.temp_file.name,
+                deny_perms={
+                    'Users': {
+                        'perms': 'read_execute'}},
+                inheritance=None)
+            self.assertDictEqual(expected, ret)
+
+    def test_check_perms_deny(self):
+        '''
+        Test setting deny perms on a file
+        '''
+        expected = {'comment': '',
+                    'pchanges': {'deny_perms': {}},
+                    'changes': {
+                        'deny_perms': {
+                            'Users': {'perms': 'read_execute'}}},
+                    'name': self.temp_file.name,
+                    'result': True}
+        ret = win_file.check_perms(path=self.temp_file.name,
+                                   deny_perms={
+                                       'Users': {
+                                           'perms': 'read_execute'}},
+                                   inheritance=None)
+        self.assertDictEqual(expected, ret)
+
+    def test_check_perms_grant_test_true(self):
+        '''
+        Test setting grant perms on a file with test=True
+        '''
+        with patch.dict(win_file.__opts__, {'test': True}):
+            expected = {'comment': '',
+                        'pchanges': {
+                            'grant_perms': {
+                                'Users': {'perms': 'read_execute'}}},
+                        'changes': {'grant_perms': {}},
+                        'name': self.temp_file.name,
+                        'result': None}
+            ret = win_file.check_perms(
+                path=self.temp_file.name,
+                grant_perms={
+                    'Users': {
+                        'perms': 'read_execute'}},
+                inheritance=None)
+            self.assertDictEqual(expected, ret)
+
+    def test_check_perms_grant(self):
+        '''
+        Test setting grant perms on a file
+        '''
+        expected = {'comment': '',
+                    'pchanges': {'grant_perms': {}},
+                    'changes': {
+                        'grant_perms': {
+                            'Users': {'perms': 'read_execute'}}},
+                    'name': self.temp_file.name,
+                    'result': True}
+        ret = win_file.check_perms(path=self.temp_file.name,
+                                   grant_perms={
+                                       'Users': {
+                                           'perms': 'read_execute'}},
+                                   inheritance=None)
+        self.assertDictEqual(expected, ret)
+
+    def test_check_perms_inheritance_false_test_true(self):
+        '''
+        Test setting inheritance to False with test=True
+        '''
+        with patch.dict(win_file.__opts__, {'test': True}):
+            expected = {'comment': '',
+                        'pchanges': {'inheritance': False},
+                        'changes': {},
+                        'name': self.temp_file.name,
+                        'result': None}
+            ret = win_file.check_perms(path=self.temp_file.name,
+                                       inheritance=False)
+            self.assertDictEqual(expected, ret)
+
+    def test_check_perms_inheritance_false(self):
+        '''
+        Test setting inheritance to False
+        '''
+        expected = {'comment': '',
+                    'pchanges': {},
+                    'changes': {'inheritance': False},
+                    'name': self.temp_file.name,
+                    'result': True}
+        ret = win_file.check_perms(path=self.temp_file.name,
+                                   inheritance=False)
+        self.assertDictEqual(expected, ret)
+
+    def test_check_perms_inheritance_true(self):
+        '''
+        Test setting inheritance to true when it's already true (default)
+        '''
+        expected = {'comment': '',
+                    'pchanges': {},
+                    'changes': {},
+                    'name': self.temp_file.name,
+                    'result': True}
+        ret = win_file.check_perms(path=self.temp_file.name,
+                                   inheritance=True)
+        self.assertDictEqual(expected, ret)
+
+    def test_check_perms_reset_test_true(self):
+        '''
+        Test resetting perms with test=True. This shows minimal changes
+        '''
+        # Turn off inheritance
+        salt.utils.win_dacl.set_inheritance(obj_name=self.temp_file.name,
+                                            enabled=False,
+                                            clear=True)
+        # Set some permissions
+        salt.utils.win_dacl.set_permissions(obj_name=self.temp_file.name,
+                                            principal='Administrator',
+                                            permissions='full_control')
+
+        with patch.dict(win_file.__opts__, {'test': True}):
+            expected = {
+                'comment': '',
+                'pchanges': {
+                    'remove_perms': {
+                        'Administrator': {
+                            'grant': {
+                                'applies to': 'Not Inherited (file)',
+                                'permissions': ['Full control'],
+                                'inherited': False}}},
+                    'grant_perms': {
+                        'Administrators': {'perms': 'full_control'},
+                        'Users': {'perms': 'read_execute'}}},
+                'changes': {'grant_perms': {}},
+                'name': self.temp_file.name,
+                'result': None}
+            ret = win_file.check_perms(path=self.temp_file.name,
+                                       grant_perms={
+                                           'Users': {
+                                               'perms': 'read_execute'},
+                                           'Administrators': {
+                                               'perms': 'full_control'}},
+                                       inheritance=False,
+                                       reset=True)
+            self.assertDictEqual(expected, ret)
+
+    def test_check_perms_reset(self):
+        '''
+        Test resetting perms on a File
+        '''
+        # Turn off inheritance
+        salt.utils.win_dacl.set_inheritance(obj_name=self.temp_file.name,
+                                            enabled=False,
+                                            clear=True)
+        # Set some permissions
+        salt.utils.win_dacl.set_permissions(obj_name=self.temp_file.name,
+                                            principal='Administrator',
+                                            permissions='full_control')
+        expected = {
+            'comment': '',
+            'pchanges': {'grant_perms': {}},
+            'changes': {
+                'remove_perms': {
+                    'Administrator': {
+                        'grant': {
+                            'applies to': 'Not Inherited (file)',
+                            'permissions': ['Full control'],
+                            'inherited': False}}},
+                'grant_perms': {
+                    'Administrators': {'perms': 'full_control'},
+                    'Users': {'perms': 'read_execute'}}},
+            'name': self.temp_file.name,
+            'result': True}
+        ret = win_file.check_perms(path=self.temp_file.name,
+                                   grant_perms={
+                                       'Users': {
+                                           'perms': 'read_execute'},
+                                       'Administrators': {
+                                           'perms': 'full_control'}},
+                                   inheritance=False,
+                                   reset=True)
+        self.assertDictEqual(expected, ret)

--- a/tests/unit/modules/test_win_file.py
+++ b/tests/unit/modules/test_win_file.py
@@ -58,6 +58,7 @@ class WinFileTestCase(TestCase):
 
 @destructiveTest
 @skipIf(NO_MOCK, NO_MOCK_REASON)
+@skipIf(not salt.utils.platform.is_windows(), 'Requires Pywin32 libraries')
 class WinFileCheckPermsTestCase(TestCase, LoaderModuleMockMixin):
     '''
     Test cases for the check_perms function in salt.modules.win_file


### PR DESCRIPTION
### What does this PR do?
Fix issues with file permissions:
- Fix stacktrace when attempting to iterate over None
- Check permissions using the resolved username
- Set permissions using the resolved username
- Reload file permissions prior to resetting
- Compare usernames using lower()

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/49861

### Tests written?
Yes

### Commits signed with GPG?
Yes