### PR TITLE
[develop] Retry DNS for ipv4 if ipv6 enabled

### DIFF
--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -1868,8 +1868,10 @@ def dns_check(addr, port=80, safe=False, ipv6=None):
     hostnames = []
     try:
         refresh_dns()
-        hostnames = socket.getaddrinfo(addr, port,
-                                       family, socket.SOCK_STREAM)
+        hostnames = socket.getaddrinfo(addr, port, family, socket.SOCK_STREAM)
+    except TypeError:
+        err = ('Attempt to resolve address \'{0}\' failed. Invalid or unresolveable address').format(lookup)
+        raise SaltSystemExit(code=42, msg=err)
     except socket.error:
         error = True
 
@@ -1882,6 +1884,9 @@ def dns_check(addr, port=80, safe=False, ipv6=None):
             hostnames = socket.getaddrinfo(addr, port,
                                            socket.AF_INET,
                                            socket.SOCK_STREAM)
+        except TypeError:
+            err = ('Attempt to resolve address \'{0}\' failed. Invalid or unresolveable address').format(lookup)
+            raise SaltSystemExit(code=42, msg=err)
         except socket.error:
             error = True
 

--- a/tests/unit/test_minion.py
+++ b/tests/unit/test_minion.py
@@ -282,6 +282,30 @@ class MinionTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
             finally:
                 minion.destroy()
 
+    def test_valid_ipv4_master_address_ipv6_enabled(self):
+        '''
+        Tests that the 'scheduler_before_connect' option causes the scheduler to be initialized before connect.
+        '''
+        interfaces = {'bond0.1234': {'hwaddr': '01:01:01:d0:d0:d0',
+                                     'up': False, 'inet':
+                                     [{'broadcast': '111.1.111.255',
+                                       'netmask': '111.1.0.0',
+                                       'label': 'bond0',
+                                       'address': '111.1.0.1'}]}}
+        with patch.dict(__opts__, {'ipv6': True, 'master': '127.0.0.1',
+                                   'master_port': '4555', 'retry_dns': False,
+                                   'source_address': '111.1.0.1',
+                                   'source_interface_name': 'bond0.1234',
+                                   'source_ret_port': 49017,
+                                   'source_publish_port': 49018}), \
+            patch('salt.utils.network.interfaces',
+                  MagicMock(return_value=interfaces)):
+            expected = {'source_publish_port': 49018,
+                        'master_uri': 'tcp://127.0.0.1:4555',
+                        'source_ret_port': 49017,
+                        'master_ip': '127.0.0.1'}
+            assert salt.minion.resolve_dns(__opts__) == expected
+
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
 class MinionAsyncTestCase(TestCase, AdaptedConfigurationTestCaseMixin, tornado.testing.AsyncTestCase):


### PR DESCRIPTION
### What does this PR do?
Fixes a scenario where ipv6 is enabled but the master is configured as an ipv4 IP address.

### What issues does this PR fix or reference?
#49835 

### Previous Behavior
Would result in a DNS lookup fail.

### New Behavior
If the initial lookup via IPv6 methods fails, try the lookup using IPv4 methods.

### Tests written?
Yes

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
