### PR TITLE
Mark one of the cherrypy tests as flaky

### DIFF
--- a/tests/integration/netapi/rest_cherrypy/test_app.py
+++ b/tests/integration/netapi/rest_cherrypy/test_app.py
@@ -9,6 +9,7 @@ import salt.utils.stringutils
 
 # Import test support libs
 import tests.support.cherrypy_testclasses as cptc
+from tests.support.helpers import flaky
 
 # Import 3rd-party libs
 from salt.ext.six.moves.urllib.parse import urlencode  # pylint: disable=no-name-in-module,import-error
@@ -241,6 +242,7 @@ class TestJobs(cptc.BaseRestCherryPyTest):
         })
         self.assertEqual(response.status, '200 OK')
 
+    @flaky
     def test_all_jobs(self):
         '''
         test query to /jobs returns job data


### PR DESCRIPTION
This test fails occasionally, but not consistently. Let's mark it as flaky for now.

I saw this test fail in fluorine here: https://jenkinsci.saltstack.com/job/fluorine/job/salt-ubuntu-1804-py3/3/

But it may need to be back-ported to another branch. I can do so if I see if failing in other places.