### PR TITLE
[WIP] Allow reactor to react to more events quickly

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -4056,7 +4056,8 @@ class HighState(BaseHighState):
             mocked=False,
             loader='states',
             initial_pillar=None):
-        self.opts = opts
+        self.opts = copy.deepcopy(opts)
+        self.opts['file_client'] = 'local' if self.opts['__role'] == 'master' else self.opts['file_client']
         self.client = salt.fileclient.get_file_client(self.opts)
         BaseHighState.__init__(self, opts)
         self.state = State(self.opts,


### PR DESCRIPTION
### What does this PR do?
Fix reactor threads not being able to see files on the fileserver

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/47539

### Previous Behavior
Uses Remote fileclient to get orchestration files

### New Behavior
Uses local file_client to get orchestration files

### Tests written?

Yes

### Commits signed with GPG?

Yes