### PR TITLE
Add salt_version execution module

### DIFF
--- a/doc/topics/releases/version_numbers.rst
+++ b/doc/topics/releases/version_numbers.rst
@@ -23,7 +23,7 @@ Code Names
 To distinguish future releases from the current release, code names are used.
 The periodic table is used to derive the next codename. The first release in
 the date based system was code named ``Hydrogen``, each subsequent release will
-go to the next `atomic number <https://en.wikipedia.org/wiki/List_of_elements>`.
+go to the next `atomic number <https://en.wikipedia.org/wiki/List_of_elements>`_.
 
 Assigned codenames:
 
@@ -36,6 +36,8 @@ Assigned codenames:
 - Nitrogen: ``2017.7.0``
 - Oxygen: ``2018.3.0``
 - Fluorine: ``TBD``
+- Neon: ``TBD``
+- Sodium: ``TBD``
 
 Example
 -------

--- a/salt/modules/salt_version.py
+++ b/salt/modules/salt_version.py
@@ -1,0 +1,174 @@
+# -*- coding: utf-8 -*-
+'''
+Access Salt's elemental release code-names.
+
+.. versionadded:: Neon
+
+Salt's feature release schedule is based on the Periodic Table, as described
+in the :ref:`Version Numbers <version-numbers>` documentation.
+
+Since deprecation notices often use the elemental release code-name when warning
+users about deprecated changes, it can be difficult to build out future-proof
+functionality that are dependent on a naming scheme that moves.
+
+For example, a state syntax needs to change to support an option that will be
+removed in the future, but there are many Minion versions in use across an
+infrastructure. It would be handy to use some Jinja syntax to check for these
+instances to perform one state syntax over another.
+
+A simple example might be something like the following:
+
+.. code-block:: jinja
+
+    {# a boolean check #}
+    {% set option_deprecated = salt['salt_version.is_older']("Sodium") %}
+
+    {% if option_deprecated %}
+      <use old syntax>
+    {% else %}
+      <use new syntax>
+    {% endif %}
+
+'''
+
+# Import Python libs
+from __future__ import absolute_import, print_function, unicode_literals
+import logging
+
+# Import Salt libs
+from salt.ext import six
+import salt.version
+import salt.utils.versions
+
+
+log = logging.getLogger(__name__)
+
+__virtualname__ = 'salt_version'
+
+
+def __virtual__():
+    '''
+    Only work on POSIX-like systems
+    '''
+    return __virtualname__
+
+
+def get_release_number(name):
+    '''
+    Returns the release number of a given release code name in a
+    ``<year>.<month>`` context.
+
+    If the release name has not been given an assigned release number, the
+    function returns a string. If the release cannot be found, it returns
+    ``None``.
+
+    name
+        The release codename for which to find a release number.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' salt_version.get_release_number 'Oxygen'
+    '''
+    name = name.lower()
+    version_map = salt.version.SaltStackVersion.LNAMES
+    version = version_map.get(name)
+    if version is None:
+        log.info('Version {} not found.'.format(name))
+        return None
+
+    if version[1] == 0:
+        log.info('Version {} found, but no release number has been assigned '
+                 'yet.'.format(name))
+        return 'No version assigned.'
+
+    return '.'.join(str(item) for item in version)
+
+
+def is_equal(name):
+    '''
+    Returns a boolean if the named version matches the minion's current Salt
+    version.
+
+    name
+        The release codename to check the version against.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' salt_version.is_equal 'Oxygen'
+    '''
+    if _check_release_cmp(name) == 0:
+        log.info('Release codename \'{}\' equals the minion\'s '
+                 'version.'.format(name))
+        return True
+
+    return False
+
+
+def is_newer(name):
+    '''
+    Returns a boolean if the named version is newer that the minion's current
+    Salt version.
+
+    name
+        The release codename to check the version against.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' salt_version.is_newer 'Sodium'
+    '''
+    if _check_release_cmp(name) == 1:
+        log.info('Release codename \'{}\' is newer than the minion\'s '
+                 'version.'.format(name))
+        return True
+
+    return False
+
+
+def is_older(name):
+    '''
+    Returns a boolean if the named version is older that the minion's current
+    Salt version.
+
+    name
+        The release codename to check the version against.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' salt_version.is_newer 'Sodium'
+    '''
+    if _check_release_cmp(name) == -1:
+        log.info('Release codename \'{}\' is older than the minion\'s '
+                 'version.'.format(name))
+        return True
+
+    return False
+
+
+def _check_release_cmp(name):
+    '''
+    Helper function to compare release codename versions to the minion's current
+    Salt version.
+
+    If release codename isn't found, the function returns None. Otherwise, it
+    returns the results of the version comparison as documented by the
+    ``versions_cmp`` function in ``salt.utils.versions.py``.
+    '''
+    map_version = get_release_number(name)
+    if map_version is None:
+        log.info('Release codename {} was not found.'.format(name))
+        return None
+
+    current_version = six.text_type(salt.version.SaltStackVersion(
+        *salt.version.__version_info__))
+    current_version = current_version.rsplit('.', 1)[0]
+    version_cmp = salt.utils.versions.version_cmp(map_version, current_version)
+
+    return version_cmp

--- a/tests/unit/modules/test_salt_version.py
+++ b/tests/unit/modules/test_salt_version.py
@@ -1,0 +1,143 @@
+# -*- coding: utf-8 -*-
+'''
+Unit tests for salt/modules/salt_version.py
+'''
+
+# Import Python libs
+from __future__ import absolute_import, print_function, unicode_literals
+
+# Import Salt Testing libs
+from tests.support.unit import TestCase, skipIf
+from tests.support.mock import (
+    MagicMock,
+    patch,
+    NO_MOCK,
+    NO_MOCK_REASON
+)
+
+# Import Salt libs
+import salt.modules.salt_version as salt_version
+import salt.version
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class SaltVersionTestCase(TestCase):
+    '''
+    Test cases for salt.modules.salt_version
+    '''
+
+    # get_release_number tests: 3
+
+    def test_get_release_number_no_version(self):
+        '''
+        Test that None is returned when the codename isn't found.
+        '''
+        assert salt_version.get_release_number('foo') is None
+
+    @patch('salt.version.SaltStackVersion.LNAMES', {'foo': (12345, 0)})
+    def test_get_release_number_unassigned(self):
+        '''
+        Test that a string is returned when a version is found, but unassigned.
+        '''
+        mock_str = 'No version assigned.'
+        assert salt_version.get_release_number('foo') == mock_str
+
+    def test_get_release_number_success(self):
+        '''
+        Test that a version is returned for a released codename
+        '''
+        assert salt_version.get_release_number('Oxygen') == '2018.3'
+
+    # is_equal tests: 3
+
+    @patch('salt.version.SaltStackVersion.LNAMES', {'foo': (1900, 5)})
+    @patch('salt.version.SaltStackVersion', MagicMock(return_value='1900.5.0'))
+    def test_is_equal_success(self):
+        '''
+        Test that the current version is equal to the codename
+        '''
+        assert salt_version.is_equal('foo') is True
+
+    @patch('salt.version.SaltStackVersion.LNAMES', {'Oxygen': (2018, 3),
+                                                    'Nitrogen': (2017, 7)})
+    @patch('salt.version.SaltStackVersion', MagicMock(return_value='2018.3.2'))
+    def test_is_equal_older_version(self):
+        '''
+        Test that when an older codename is passed in, the function returns False.
+        '''
+        assert salt_version.is_equal('Nitrogen') is False
+
+    @patch('salt.version.SaltStackVersion.LNAMES', {'Fluorine': (salt.version.MAX_SIZE - 100, 0)})
+    @patch('salt.version.SaltStackVersion', MagicMock(return_value='2018.3.2'))
+    def test_is_equal_newer_version(self):
+        '''
+        Test that when a newer codename is passed in, the function returns False
+        '''
+        assert salt_version.is_equal('Fluorine') is False
+
+    # is_newer tests: 3
+
+    @patch('salt.modules.salt_version.get_release_number', MagicMock(return_value='No version assigned.'))
+    @patch('salt.version.SaltStackVersion', MagicMock(return_value='2018.3.2'))
+    def test_is_newer_success(self):
+        '''
+        Test that the current version is newer than the codename
+        '''
+        assert salt_version.is_newer('Fluorine') is True
+
+    @patch('salt.version.SaltStackVersion.LNAMES', {'Oxygen': (2018, 3)})
+    @patch('salt.version.SaltStackVersion', MagicMock(return_value='2018.3.2'))
+    def test_is_newer_with_equal_version(self):
+        '''
+        Test that when an equal codename is passed in, the function returns False.
+        '''
+        assert salt_version.is_newer('Oxygen') is False
+
+    @patch('salt.version.SaltStackVersion.LNAMES', {'Oxygen': (2018, 3),
+                                                    'Nitrogen': (2017, 7)})
+    @patch('salt.version.SaltStackVersion', MagicMock(return_value='2018.3.2'))
+    def test_is_newer_with_older_version(self):
+        '''
+        Test that when an older codename is passed in, the function returns False.
+        '''
+        assert salt_version.is_newer('Nitrogen') is False
+
+    # is_older tests: 3
+
+    @patch('salt.modules.salt_version.get_release_number', MagicMock(return_value='2017.7'))
+    @patch('salt.version.SaltStackVersion', MagicMock(return_value='2018.3.2'))
+    def test_is_older_success(self):
+        '''
+        Test that the current version is older than the codename
+        '''
+        assert salt_version.is_older('Nitrogen') is True
+
+    @patch('salt.version.SaltStackVersion', MagicMock(return_value='2018.3.2'))
+    @patch('salt.version.SaltStackVersion.LNAMES', {'Oxygen': (2018, 3)})
+    def test_is_older_with_equal_version(self):
+        '''
+        Test that when an equal codename is passed in, the function returns False.
+        '''
+        assert salt_version.is_older('Oxygen') is False
+
+    @patch('salt.modules.salt_version.get_release_number', MagicMock(return_value='No version assigned.'))
+    @patch('salt.version.SaltStackVersion', MagicMock(return_value='2018.3.2'))
+    def test_is_older_with_newer_version(self):
+        '''
+        Test that when an newer codename is passed in, the function returns False.
+        '''
+        assert salt_version.is_older('Fluorine') is False
+
+    # _check_release_cmp tests: 2
+
+    def test_check_release_cmp_no_codename(self):
+        '''
+        Test that None is returned when the codename isn't found.
+        '''
+        assert salt_version._check_release_cmp('foo') is None
+
+    def test_check_release_cmp_success(self):
+        '''
+        Test that an int is returned from the version compare
+        '''
+        assert isinstance(salt_version._check_release_cmp('Oxygen'), int)


### PR DESCRIPTION
### What does this PR do?
This execution module exposes Salt's release codenames as functions that can be used to make comparison's to the minion's Salt version.

This is useful when writing states that handle deprecations. By exposing the release codenames, people can use these comparisons in Jinja statements in state files. This is only one example and the use case I wanted to cover here. There may be more that I haven't thought of, but this is a start!

### What issues does this PR fix or reference?
None that I know of.

### Tests written?

Yes

### Commits signed with GPG?

Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
