### PR TITLE
Skip ansiblegate state integration test on CentOS 6

### DIFF
--- a/tests/integration/states/test_ansiblegate.py
+++ b/tests/integration/states/test_ansiblegate.py
@@ -16,7 +16,11 @@ import salt.utils.path
 
 # Import testing libraries
 from tests.support.case import ModuleCase
-from tests.support.helpers import destructiveTest, requires_sshd_server
+from tests.support.helpers import (
+    destructiveTest,
+    requires_sshd_server,
+    requires_system_grains
+)
 from tests.support.mixins import SaltReturnAssertsMixin
 from tests.support.runtests import RUNTIME_VARS
 from tests.support.unit import skipIf
@@ -29,7 +33,12 @@ class AnsiblePlaybooksTestCase(ModuleCase, SaltReturnAssertsMixin):
     '''
     Test ansible.playbooks states
     '''
-    def setUp(self):
+
+    @requires_system_grains
+    def setUp(self, grains=None):
+        if grains.get('os_family') == 'RedHat' and grains.get('osmajorrelease') == 6:
+            self.skipTest('This test hangs the test suite on RedHat 6. Skipping for now.')
+
         priv_file = os.path.join(RUNTIME_VARS.TMP_CONF_DIR, 'key_test')
         data = {
             'all': {


### PR DESCRIPTION
This test is hanging the test suite when running on CentOS 6. I don't think this has ever worked properly (this test is new to fluorine) on CentOS 6, so this will need some further investigation.

Fixes https://github.com/saltstack/salt-jenkins/issues/1138

Skipping for now until we can come back to this.

```
04:45:15          test_install_set_and_remove (integration.states.test_alternatives.AlterantivesStateTest) ... OK (42.623s)
05:15:15 Build timed out (after 30 minutes). Marking the build as aborted.
```

The test that runs directly after the `integration.states.test_alternatives` tests are the `integration.states.test_ansiblegate` tests, which is where the build aborts above.