### PR TITLE
Fix issues with startup in Windows

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -2782,18 +2782,22 @@ def kernelparams():
     '''
     Return the kernel boot parameters
     '''
-    try:
-        with salt.utils.files.fopen('/proc/cmdline', 'r') as fhr:
-            cmdline = fhr.read()
-            grains = {'kernelparams': []}
-            for data in [item.split('=') for item in salt.utils.args.shlex_split(cmdline)]:
-                value = None
-                if len(data) == 2:
-                    value = data[1].strip('"')
+    if salt.utils.platform.is_windows():
+        # TODO: add grains using `bcdedit /enum {current}`
+        return {}
+    else:
+        try:
+            with salt.utils.files.fopen('/proc/cmdline', 'r') as fhr:
+                cmdline = fhr.read()
+                grains = {'kernelparams': []}
+                for data in [item.split('=') for item in salt.utils.args.shlex_split(cmdline)]:
+                    value = None
+                    if len(data) == 2:
+                        value = data[1].strip('"')
 
-                grains['kernelparams'] += [(data[0], value)]
-    except IOError as exc:
-        grains = {}
-        log.debug('Failed to read /proc/cmdline: %s', exc)
+                    grains['kernelparams'] += [(data[0], value)]
+        except IOError as exc:
+            grains = {}
+            log.debug('Failed to read /proc/cmdline: %s', exc)
 
-    return grains
+        return grains

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -208,6 +208,8 @@ def get_fqhostname():
         )
         for info in addrinfo:
             # info struct [family, socktype, proto, canonname, sockaddr]
+            # On Windows `canonname` can be an empty string
+            # This can cause the function to return `None`
             if len(info) >= 4 and info[3]:
                 l = [info[3]]
     except socket.gaierror:

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -208,7 +208,7 @@ def get_fqhostname():
         )
         for info in addrinfo:
             # info struct [family, socktype, proto, canonname, sockaddr]
-            if len(info) >= 4:
+            if len(info) >= 4 and info[3]:
                 l = [info[3]]
     except socket.gaierror:
         pass


### PR DESCRIPTION
### What does this PR do?
Don't load the kernelparams grains on Windows
Properly detect the hostname

### What issues does this PR fix or reference?
Found in testing

### Previous Behavior
The following lines were showing up in the minion start up:
```
[ERROR   ] Having trouble getting a hostname.  Does this machine have its hostname and domain set properly?
[DEBUG   ] Failed to read /proc/cmdline: [Errno 2] No such file or directory: u'/proc/cmdline'
```

### Tests written?
No

### Commits signed with GPG?
Yes