### PR TITLE
lgpo better comments on user right assignments

### DIFF
--- a/salt/states/win_lgpo.py
+++ b/salt/states/win_lgpo.py
@@ -289,10 +289,13 @@ def set_(name,
                         ) == {}
 
                     if not policies_are_equal:
+                        additional_policy_comments = []
                         if policy_data['policy_lookup'][policy_name]['rights_assignment'] and cumulative_rights_assignments:
                             for user in policy_data['requested_policy'][policy_name]:
                                 if user not in current_policy[policy_data['output_section']][pol_id]:
                                     changes = True
+                                else:
+                                    additional_policy_comments.append('"{0}" is already granted the right'.format(user))
                         else:
                             changes = True
                         if changes:
@@ -303,6 +306,11 @@ def set_(name,
                                 requested_policy_json, current_policy_json
                             )
                             policy_changes.append(policy_name)
+                        else:
+                            if additional_policy_comments:
+                                ret['comment'] = '"{0}" is already set ({1}).\n'.format(policy_name, ', '.join(additional_policy_comments))
+                            else:
+                                ret['comment'] = '"{0}" is already set.\n'.format(policy_name) + ret['comment']
                     else:
                         log.debug('%s current setting matches '
                                   'the requested setting', policy_name)


### PR DESCRIPTION
### What does this PR do?
Ensure that a comment is set if a user right assignment is already properly configured and add a note that the user/group(s) already has the right if cumulative_rights_assignments is True

### What issues does this PR fix or reference?
#48661
#49582

### Previous Behavior
A comment was not always provided that the policy was already configured.  Also adds an additional comment when cumulative_rights_assignemtns is True noting that the user/group in question already has the right.

### New Behavior
Comments state that the user rights assignment is already configured.

### Tests written?
No

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
