### PR TITLE
Fix bug in gem.installed related to rvm

### DIFF
--- a/salt/states/gem.py
+++ b/salt/states/gem.py
@@ -86,7 +86,7 @@ def installed(name,          # pylint: disable=C0103
     gems = __salt__['gem.list'](name, ruby, gem_bin=gem_bin, runas=user)
 
     if name in gems:
-        versions = list(map(lambda x: x.replace('default: ', ''), gems[name]))
+        versions = list([x.replace('default: ', '') for x in gems[name]])
         if version is not None and str(version) in versions:
             ret['result'] = True
             ret['comment'] = 'Gem is already installed.'

--- a/salt/states/gem.py
+++ b/salt/states/gem.py
@@ -84,14 +84,17 @@ def installed(name,          # pylint: disable=C0103
             'Use of argument ruby found, but neither rvm or rbenv is installed'
         )
     gems = __salt__['gem.list'](name, ruby, gem_bin=gem_bin, runas=user)
-    if name in gems and version is not None and str(version) in gems[name]:
-        ret['result'] = True
-        ret['comment'] = 'Gem is already installed.'
-        return ret
-    elif name in gems and version is None:
-        ret['result'] = True
-        ret['comment'] = 'Gem is already installed.'
-        return ret
+
+    if name in gems:
+        versions = list(map(lambda x: x.replace('default: ', ''), gems[name]))
+        if version is not None and str(version) in versions:
+            ret['result'] = True
+            ret['comment'] = 'Gem is already installed.'
+            return ret
+        elif version is None:
+            ret['result'] = True
+            ret['comment'] = 'Gem is already installed.'
+            return ret
 
     if __opts__['test']:
         ret['comment'] = 'The gem {0} would have been installed'.format(name)

--- a/tests/unit/states/test_gem.py
+++ b/tests/unit/states/test_gem.py
@@ -47,6 +47,48 @@ class TestGemState(TestCase, LoaderModuleMockMixin):
                     ri=False, gem_bin=None
                 )
 
+    def test_installed_with_version(self):
+        gems = {'foo': ['1.0'], 'bar': ['2.0']}
+        gem_list = MagicMock(return_value=gems)
+        gem_install_succeeds = MagicMock(return_value=True)
+        gem_install_fails = MagicMock(return_value=False)
+
+        with patch.dict(gem.__salt__, {'gem.list': gem_list}):
+            with patch.dict(gem.__salt__,
+                            {'gem.install': gem_install_succeeds}):
+                ret = gem.installed('foo')
+                self.assertEqual(True, ret['result'])
+                ret = gem.installed('quux', version='1.0')
+                self.assertEqual(True, ret['result'])
+                gem_install_succeeds.assert_called_once_with(
+                    'quux', pre_releases=False, ruby=None, runas=None,
+                    version='1.0', proxy=None, rdoc=False, source=None,
+                    ri=False, gem_bin=None
+                )
+
+            with patch.dict(gem.__salt__,
+                            {'gem.install': gem_install_fails}):
+                ret = gem.installed('quux')
+                self.assertEqual(False, ret['result'])
+                gem_install_fails.assert_called_once_with(
+                    'quux', pre_releases=False, ruby=None, runas=None,
+                    version=None, proxy=None, rdoc=False, source=None,
+                    ri=False, gem_bin=None
+                )
+
+    def test_installed_with_version_with_rvm_output_style(self):
+        gems = {'foo': ['1.0'], 'bar': ['2.0'], 'baz': ['default: 3.0']}
+        gem_list = MagicMock(return_value=gems)
+        gem_install_succeeds = MagicMock(return_value=True)
+        gem_install_fails = MagicMock(return_value=False)
+
+        with patch.dict(gem.__salt__, {'gem.list': gem_list}):
+            with patch.dict(gem.__salt__,
+                            {'gem.install': gem_install_succeeds}):
+                ret = gem.installed('baz', version='3.0')
+                self.assertEqual(True, ret['result'])
+                self.assertEqual('Gem is already installed.', ret['comment'])
+
     def test_removed(self):
         gems = ['foo', 'bar']
         gem_list = MagicMock(return_value=gems)


### PR DESCRIPTION
### What does this PR do?
Fixes a bug in gem.installed in not stripping the string 'default: ' from the output of gem list when using rvm
### What issues does this PR fix or reference?
#49866 
### Previous Behavior
It would always try to install the supplied version, say 3.0.0 because it would compare against 'default: 3.0.0' instead of doing nothing since it's already installed.

### New Behavior
Will not install the gem if it already exists

### Tests written?
yes
Yes/No

### Commits signed with GPG?

No
