### PR TITLE
Fix zypper.list_pkgs for armv7

### DIFF
--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -751,10 +751,7 @@ def list_pkgs(versions_as_list=False, **kwargs):
                                      python_shell=False,
                                      output_loglevel='trace')
         for line in output.splitlines():
-            pkginfo = salt.utils.pkg.rpm.parse_pkginfo(
-                line,
-                osarch=__grains__['osarch']
-            )
+            pkginfo = salt.utils.pkg.rpm.parse_pkginfo(line)
             if pkginfo:
                 # see rpm version string rules available at https://goo.gl/UGKPNd
                 pkgver = pkginfo.version
@@ -1590,8 +1587,8 @@ def normalize_name(name):
             return name
     except ValueError:
         return name
-    if arch in (__grains__['osarch'], 'noarch') \
-            or salt.utils.pkg.rpm.check_32(arch, osarch=__grains__['osarch']):
+    if arch in (salt.utils.pkg.rpm.getosarch(), 'noarch') \
+            or salt.utils.pkg.rpm.check_32(arch):
         return name[:-(len(arch) + 1)]
     return name
 

--- a/salt/utils/pkg/rpm.py
+++ b/salt/utils/pkg/rpm.py
@@ -49,7 +49,7 @@ def get_osarch():
         shell=True,
         close_fds=True,
         stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE).communicate()[0]
+        stderr=subprocess.PIPE).communicate()[0].decode().rstrip()
     return ret or 'unknown'
 
 


### PR DESCRIPTION
`__grains__['osarch']` returns 'armv7l'
`salt.utils.pkg.rpm.getosarch()` returns 'armv7hl'
openSUSE RPM packages for armv7 are '*.armv7hl.rpm'

Consequence of mismatched architecture is broken 'state.installed'.
salt.utils.pkg.rpm.resolve name() appends 'armv7hl' to package name and
installation check is failed.

### What does this PR do?

Fix state.installed at openSUSE armv7l installations

### What issues does this PR fix or reference?

https://bugzilla.suse.com/show_bug.cgi?id=1109384

### Previous Behavior

```
# cat top.sls
base:
  '*':
    - git
# cat git.sls
git:
  pkg.installed: []
# rpm -q git
git-2.16.4-lp150.2.3.1.armv7hl
```

```
local:
----------
          ID: git
    Function: pkg.installed
      Result: False
     Comment: The following packages failed to install/update: git
     Started: 18:24:07.730221
    Duration: 169840.00000000015 ms
     Changes:   

Summary for local                                                                                                                      
------------                                                                                                                           
Succeeded: 0
Failed:    1
------------
Total states run:     1                                                                                                                
Total run time: 169.840 s
```


### New Behavior

```
local:
----------
          ID: git
    Function: pkg.installed
      Result: True
     Comment: All specified packages are already installed
     Started: 18:55:25.719224
    Duration: 108889.99999999942 ms
     Changes:   

Summary for local                                                                                                                      
------------                                                                                                                           
Succeeded: 1
Failed:    0
------------
Total states run:     1                                                                                                                
Total run time: 108.890 s
```


### Tests written?

No

### Commits signed with GPG?

Yes