### PR TITLE
Get os_family for RPM distros from the RPM macros

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -46,6 +46,7 @@ import salt.utils.files
 import salt.utils.network
 import salt.utils.path
 import salt.utils.platform
+import salt.utils.pkg.rpm
 from salt.ext import six
 from salt.ext.six.moves import range
 
@@ -1896,8 +1897,8 @@ def os_data():
     # architecture.
     if grains.get('os_family') == 'Debian':
         osarch = __salt__['cmd.run']('dpkg --print-architecture').strip()
-    elif grains.get('os_family') == 'RedHat':
-        osarch = __salt__['cmd.run']('rpm --eval %{_host_cpu}').strip()
+    elif grains.get('os_family') in ['RedHat', 'Suse']:
+        osarch = salt.utils.pkg.rpm.get_osarch()
     elif grains.get('os_family') in ('NILinuxRT', 'Poky'):
         archinfo = {}
         for line in __salt__['cmd.run']('opkg print-architecture').splitlines():

--- a/salt/utils/pkg/rpm.py
+++ b/salt/utils/pkg/rpm.py
@@ -9,6 +9,7 @@ import collections
 import datetime
 import logging
 import subprocess
+from salt.utils.stringutils import to_str
 
 # Import 3rd-party libs
 from salt.ext import six
@@ -47,7 +48,7 @@ def get_osarch():
         close_fds=True,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE).communicate()[0]
-    return ret or 'unknown'
+    return to_str(ret).strip() or 'unknown'
 
 
 def check_32(arch, osarch=None):

--- a/salt/utils/pkg/rpm.py
+++ b/salt/utils/pkg/rpm.py
@@ -9,7 +9,7 @@ import collections
 import datetime
 import logging
 import subprocess
-from salt.utils.stringutils import to_str
+import salt.utils.stringutils
 
 # Import 3rd-party libs
 from salt.ext import six
@@ -48,7 +48,7 @@ def get_osarch():
         close_fds=True,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE).communicate()[0]
-    return to_str(ret).strip() or 'unknown'
+    return salt.utils.stringutils.to_str(ret).strip() or 'unknown'
 
 
 def check_32(arch, osarch=None):


### PR DESCRIPTION
### What issues does this PR fix or reference?

Bugfix: sometimes `uname -m` is not what RPM macros returns. Therefore copying `cpuarch` over `osarch` is not the best idea, as it results to unwanted effects while installing packages on less used systems (ARM for example).

It is also that original `get_osarch` function returns `bytes` type with the `os.linesep` attached alongside Unicode string.

### Tests written?

No, should just apply existing
