### PR TITLE
Remove event_publisher_pub_hwm and salt_event_pub_hwm from documentation

### DIFF
--- a/conf/master
+++ b/conf/master
@@ -261,24 +261,6 @@
 # The publisher interface ZeroMQPubServerChannel
 #pub_hwm: 1000
 
-# These two ZMQ HWM settings, salt_event_pub_hwm and event_publisher_pub_hwm
-# are significant for masters with thousands of minions.  When these are
-# insufficiently high it will manifest in random responses missing in the CLI
-# and even missing from the job cache.  Masters that have fast CPUs and many
-# cores with appropriate worker_threads will not need these set as high.
-
-# On deployment with 8,000 minions, 2.4GHz CPUs, 24 cores, 32GiB memory has
-# these settings:
-#
-#   salt_event_pub_hwm: 128000
-#   event_publisher_pub_hwm: 64000
-
-# ZMQ high-water-mark for SaltEvent pub socket
-#salt_event_pub_hwm: 20000
-
-# ZMQ high-water-mark for EventPublisher pub socket
-#event_publisher_pub_hwm: 10000
-
 # The master may allocate memory per-event and not
 # reclaim it.
 # To set a high-water mark for memory allocation, use

--- a/conf/suse/master
+++ b/conf/suse/master
@@ -263,24 +263,6 @@ syndic_user: salt
 # The publisher interface ZeroMQPubServerChannel
 #pub_hwm: 1000
 
-# These two ZMQ HWM settings, salt_event_pub_hwm and event_publisher_pub_hwm
-# are significant for masters with thousands of minions.  When these are
-# insufficiently high it will manifest in random responses missing in the CLI
-# and even missing from the job cache.  Masters that have fast CPUs and many
-# cores with appropriate worker_threads will not need these set as high.
-
-# On deployment with 8,000 minions, 2.4GHz CPUs, 24 cores, 32GiB memory has
-# these settings:
-#
-#   salt_event_pub_hwm: 128000
-#   event_publisher_pub_hwm: 64000
-
-# ZMQ high-water-mark for SaltEvent pub socket
-#salt_event_pub_hwm: 20000
-
-# ZMQ high-water-mark for EventPublisher pub socket
-#event_publisher_pub_hwm: 10000
-
 # The master may allocate memory per-event and not
 # reclaim it.
 # To set a high-water mark for memory allocation, use

--- a/doc/ref/configuration/master.rst
+++ b/doc/ref/configuration/master.rst
@@ -1723,40 +1723,6 @@ The listen queue size of the ZeroMQ backlog.
 
     zmq_backlog: 1000
 
-.. conf_master:: salt_event_pub_hwm
-.. conf_master:: event_publisher_pub_hwm
-
-``salt_event_pub_hwm`` and ``event_publisher_pub_hwm``
-------------------------------------------------------
-
-These two ZeroMQ High Water Mark settings, ``salt_event_pub_hwm`` and
-``event_publisher_pub_hwm`` are significant for masters with thousands of
-minions. When these are insufficiently high it will manifest in random
-responses missing in the CLI and even missing from the job cache. Masters
-that have fast CPUs and many cores with appropriate ``worker_threads``
-will not need these set as high.
-
-The ZeroMQ high-water-mark for the ``SaltEvent`` pub socket default is:
-
-.. code-block:: yaml
-
-    salt_event_pub_hwm: 20000
-
-The ZeroMQ high-water-mark for the ``EventPublisher`` pub socket default is:
-
-.. code-block:: yaml
-
-    event_publisher_pub_hwm: 10000
-
-As an example, on single master deployment with 8,000 minions, 2.4GHz CPUs,
-24 cores, and 32GiB memory has these settings:
-
-.. code-block:: yaml
-
-    salt_event_pub_hwm: 128000
-    event_publisher_pub_hwm: 64000
-
-
 .. _master-module-management:
 
 Master Module Management


### PR DESCRIPTION
Fixes #49925

The `event_publisher_pub_hwm` and `salt_event_pub_hwm` configuration options were removed in #38723. (They are obsolete and not used within salt any longer.)

When those options were removed, I neglected to remove them from the docs. This PR cleans up the references in the docs.

Refs #38674 as well.
