### PR TITLE
Fix value of `virtual` grain when using `virt-what`

### DIFF
--- a/doc/topics/releases/fluorine.rst
+++ b/doc/topics/releases/fluorine.rst
@@ -488,6 +488,18 @@ in.  Because of the non-deterministic order that grains are rendered in, the
 only grains that can be relied upon to be passed in are ``core.py`` grains,
 since those are compiled first.
 
+More Precise ``virtual`` Grain
+==============================
+
+This release improves the accuracy of the ``virtual`` grain when running Salt in
+a nested virtualization environment (e.g. ``systemd-nspawn`` container inside a
+VM) and having ``virt-what`` installed.
+
+Until now, the ``virtual`` grain was determined by matching against all output
+lines of ``virt-what`` instead of individual items which could lead to not quite
+precise results (e.g. reporting ``HyperV`` inside a ``systemd-nspawn`` container
+running within a Hyper-V-based VM.
+
 Configurable Module Environment
 ===============================
 

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -781,6 +781,7 @@ def _virtual(osdata):
                 grains['virtual'] = 'LXC'
                 break
         elif command == 'virt-what':
+            output = output.splitlines()[-1]
             if output in ('kvm', 'qemu', 'uml', 'xen', 'lxc'):
                 grains['virtual'] = output
                 break


### PR DESCRIPTION
### What does this PR do?

`virt-what` might return multiple lines, depending on what it detected (e.g. `lxc` inside a `HyperV` VM), where the last line corresponds to the most likely match.

Until now, Salt evaluated the whole multi-line output as a single string, which caused quite inaccurate matches. This commit changes this behavior to only evaluate the last line of the `virt-what` output.

### What issues does this PR fix or reference?

A similar issue is described in #25697, but might actually have a different root cause.

### Previous Behavior
The `virtual` grain reported `HyperV`, although Salt was executed in a `systemd-nspawn` container inside a HyperV-based Ubuntu VM.

### New Behavior

The `virtual` grain reports now `lxc` which reflects what `virt-what` determines.

### Tests written?

No

### Commits signed with GPG?

Yes