### PR TITLE
Handle missing `pkg_resources` package

### DIFF
--- a/salt/states/pip_state.py
+++ b/salt/states/pip_state.py
@@ -23,7 +23,11 @@ requisite to a pkg.installed state for the package which provides pip
 from __future__ import absolute_import, print_function, unicode_literals
 import re
 import logging
-import pkg_resources
+try:
+    import pkg_resources
+    HAS_PKG_RESOURCES = True
+except ImportError:
+    HAS_PKG_RESOURCES = False
 
 # Import salt libs
 import salt.utils.versions
@@ -71,6 +75,8 @@ def __virtual__():
     '''
     Only load if the pip module is available in __salt__
     '''
+    if HAS_PKG_RESOURCES is False:
+        return False, 'The pkg_resources python library is not installed'
     if 'pip.list' in __salt__:
         return __virtualname__
     return False


### PR DESCRIPTION
### What does this PR do?
See title

### Previous Behavior
Salt loader logged a traceback
```
2018-10-08 17:44:05,790 [salt.loader      :1469][DEBUG   ][7386] Failed to import states pip_state:
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/salt/loader.py", line 1459, in _load_module
    mod = imp.load_module(mod_namespace, fn_, fpath, desc)
  File "/usr/lib/python2.7/site-packages/salt/states/pip_state.py", line 26, in <module>
    import pkg_resources
ImportError: No module named pkg_resources
2018-10-08 17:44:05,792 [salt.utils.lazy  :100 ][DEBUG   ][7386] LazyLoaded portage_config.get_missing_flags
```

### New Behavior
No logged traceback and module still does not load if package is missing.

### Tests written?

No

### Commits signed with GPG?

Yes