### PR TITLE
Add some doc tests to the filemap that should run on every PR

### DIFF
--- a/tests/filename_map.yml
+++ b/tests/filename_map.yml
@@ -1,5 +1,7 @@
 '*':
   - unit.test_module_names
+  - unit.test_doc
+  - integration.modules.test_sysmod
 
 salt/modules/(apk|aptpkg|ebuild|dpkg|freebsdpkg|mac_brew|mac_ports|openbsdpkg|opkg|pacman|pkgin|pkgng|pkg_resource|rpm|solarisips|solarispkg|win_pkg|xbpspkg|yumpkg|zypper)\.py:
   - unit.states.test_pkg


### PR DESCRIPTION
These files test aspects of the documentation that are not covered by the pylint or doc build runs. Therefore, these should run on all incoming PRs.

@terminalmage This is a follow-up PR from our discussion from your filemap demo the other day. :)
