### PR TITLE
osversion/osversion_info/osmajorrelease grains fixes

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1679,7 +1679,9 @@ def os_data():
                         grains['lsb_distrib_codename'] = codename
                     if 'CPE_NAME' in os_release:
                         cpe = _parse_cpe_name(os_release['CPE_NAME'])
-                        if cpe['vendor'].lower() in ['suse', 'opensuse']:
+                        if not cpe:
+                            log.error('Broken CPE_NAME format in /etc/os-release!')
+                        elif cpe.get('vendor', '').lower() in ['suse', 'opensuse']:
                             grains['os'] = "SUSE"
                             # openSUSE `osfullname` grain normalization
                             if os_release.get("NAME") == "openSUSE Leap":

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1695,9 +1695,9 @@ def os_data():
                                 grains['osfullname'] = "Leap"
                             elif os_release.get("VERSION") == "Tumbleweed":
                                 grains['osfullname'] = os_release["VERSION"]
-                        # Override VERSION_ID, if CPE_NAME around
-                        if cpe.get('version'):
-                            grains['lsb_distrib_release'] = cpe['version']
+                            # Override VERSION_ID, if CPE_NAME around
+                            if cpe.get('version') and cpe.get('vendor') == 'opensuse':  # Keep VERSION_ID for SLES
+                                grains['lsb_distrib_release'] = cpe['version']
 
                 elif os.path.isfile('/etc/SuSE-release'):
                     log.trace('Parsing distrib info from /etc/SuSE-release')

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1466,6 +1466,27 @@ def _parse_os_release(*os_release_files):
     return ret
 
 
+def _parse_cpe_name(cpe):
+    '''
+    Parse CPE_NAME data from the os-release
+
+    Info: https://csrc.nist.gov/projects/security-content-automation-protocol/scap-specifications/cpe
+
+    :param cpe:
+    :return:
+    '''
+    ret = {}
+    cpe = (cpe or '').split(':')
+    if len(cpe) > 4 and cpe[0] == 'cpe':
+        if cpe[1].startswith('/'):  # WFN
+            ret['vendor'], ret['product'], ret['version'] = cpe[2:5]
+            ret['phase'] = cpe[5] if len(cpe) > 5 else None
+        elif len(cpe) == 13 and cpe[1] == '2.3':  # v2.3
+            ret['vendor'], ret['product'], ret['version'], ret['phase'] = [x if x != '*' else None for x in cpe[3:7]]
+
+    return ret
+
+
 def os_data():
     '''
     Return grains pertaining to the operating system

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1842,8 +1842,7 @@ def os_data():
                         r'((?:Open|Oracle )?Solaris|OpenIndiana|OmniOS) (Development)?'
                         r'\s*(\d+\.?\d*|v\d+)\s?[A-Z]*\s?(r\d+|\d+\/\d+|oi_\S+|snv_\S+)?'
                     )
-                    osname, development, osmajorrelease, osminorrelease = \
-                        release_re.search(rel_data).groups()
+                    osname, development, osmajorrelease, osminorrelease = release_re.search(rel_data).groups()
                 except AttributeError:
                     # Set a blank osrelease grain and fallback to 'Solaris'
                     # as the 'os' grain.

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1475,14 +1475,21 @@ def _parse_cpe_name(cpe):
     :param cpe:
     :return:
     '''
+    part = {
+        'o': 'operating system',
+        'h': 'hardware',
+        'a': 'application',
+    }
     ret = {}
     cpe = (cpe or '').split(':')
     if len(cpe) > 4 and cpe[0] == 'cpe':
-        if cpe[1].startswith('/'):  # WFN
+        if cpe[1].startswith('/'):  # WFN to URI
             ret['vendor'], ret['product'], ret['version'] = cpe[2:5]
             ret['phase'] = cpe[5] if len(cpe) > 5 else None
-        elif len(cpe) == 13 and cpe[1] == '2.3':  # v2.3
+            ret['part'] = part.get(cpe[1][1:])
+        elif len(cpe) == 13 and cpe[1] == '2.3':  # WFN to a string
             ret['vendor'], ret['product'], ret['version'], ret['phase'] = [x if x != '*' else None for x in cpe[3:7]]
+            ret['part'] = part.get(cpe[2])
 
     return ret
 

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1790,8 +1790,7 @@ def os_data():
             # Commit introducing this comment should be reverted after the upstream bug is released.
             if 'CentOS Linux 7' in grains.get('lsb_distrib_codename', ''):
                 grains.pop('lsb_distrib_release', None)
-            grains['osrelease'] = \
-                grains.get('lsb_distrib_release', osrelease).strip()
+            grains['osrelease'] = grains.get('lsb_distrib_release', osrelease).strip()
         grains['oscodename'] = grains.get('lsb_distrib_codename', '').strip() or oscodename
         if 'Red Hat' in grains['oscodename']:
             grains['oscodename'] = oscodename

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1678,13 +1678,18 @@ def os_data():
                                 codename = codename_match.group(1)
                         grains['lsb_distrib_codename'] = codename
                     if 'CPE_NAME' in os_release:
-                        if ":suse:" in os_release['CPE_NAME'] or ":opensuse:" in os_release['CPE_NAME']:
+                        cpe = _parse_cpe_name(os_release['CPE_NAME'])
+                        if cpe['vendor'].lower() in ['suse', 'opensuse']:
                             grains['os'] = "SUSE"
                             # openSUSE `osfullname` grain normalization
                             if os_release.get("NAME") == "openSUSE Leap":
                                 grains['osfullname'] = "Leap"
                             elif os_release.get("VERSION") == "Tumbleweed":
                                 grains['osfullname'] = os_release["VERSION"]
+                        # Override VERSION_ID, if CPE_NAME around
+                        if cpe.get('version'):
+                            grains['lsb_distrib_release'] = cpe['version']
+
                 elif os.path.isfile('/etc/SuSE-release'):
                     log.trace('Parsing distrib info from /etc/SuSE-release')
                     grains['lsb_distrib_id'] = 'SUSE'

--- a/tests/unit/grains/test_core.py
+++ b/tests/unit/grains/test_core.py
@@ -97,6 +97,20 @@ class CoreGrainsTestCase(TestCase, LoaderModuleMockMixin):
             for key in cpe_ret:
                 assert key in ret
                 assert cpe_ret[key] == ret[key]
+
+    def test_parse_cpe_name_v23(self):
+        '''
+        Parse correct CPE_NAME data v2.3 formatted
+        :return:
+        '''
+        for cpe, cpe_ret in [('cpe:2.3:a:microsoft:windows_xp:5.1.601:beta:*:*:*:*:*:*',
+                              {'phase': 'beta', 'version': '5.1.601', 'product': 'windows_xp', 'vendor': 'microsoft'}),
+                             ('cpe:2.3:x:corellian:millenium_falcon:1.0:*:*:*:*:*:*:*',
+                              {'phase': None, 'version': '1.0', 'product': 'millenium_falcon', 'vendor': 'corellian'})]:
+            ret = core._parse_cpe_name(cpe)
+            for key in cpe_ret:
+                assert key in ret
+                assert cpe_ret[key] == ret[key]
     def test_missing_os_release(self):
         with patch('salt.utils.files.fopen', mock_open(read_data={})):
             os_release = core._parse_os_release('/etc/os-release', '/usr/lib/os-release')

--- a/tests/unit/grains/test_core.py
+++ b/tests/unit/grains/test_core.py
@@ -105,10 +105,15 @@ class CoreGrainsTestCase(TestCase, LoaderModuleMockMixin):
         Parse correct CPE_NAME data v2.3 formatted
         :return:
         '''
-        for cpe, cpe_ret in [('cpe:2.3:a:microsoft:windows_xp:5.1.601:beta:*:*:*:*:*:*',
-                              {'phase': 'beta', 'version': '5.1.601', 'product': 'windows_xp', 'vendor': 'microsoft'}),
-                             ('cpe:2.3:x:corellian:millenium_falcon:1.0:*:*:*:*:*:*:*',
-                              {'phase': None, 'version': '1.0', 'product': 'millenium_falcon', 'vendor': 'corellian'})]:
+        for cpe, cpe_ret in [('cpe:2.3:o:microsoft:windows_xp:5.1.601:beta:*:*:*:*:*:*',
+                              {'phase': 'beta', 'version': '5.1.601', 'product': 'windows_xp',
+                               'vendor': 'microsoft', 'part': 'operating system'}),
+                             ('cpe:2.3:h:corellian:millenium_falcon:1.0:*:*:*:*:*:*:*',
+                              {'phase': None, 'version': '1.0', 'product': 'millenium_falcon',
+                               'vendor': 'corellian', 'part': 'hardware'}),
+                             ('cpe:2.3:*:dark_empire:light_saber:3.0:beta:*:*:*:*:*:*',
+                              {'phase': 'beta', 'version': '3.0', 'product': 'light_saber',
+                               'vendor': 'dark_empire', 'part': None})]:
             ret = core._parse_cpe_name(cpe)
             for key in cpe_ret:
                 assert key in ret

--- a/tests/unit/grains/test_core.py
+++ b/tests/unit/grains/test_core.py
@@ -84,6 +84,19 @@ class CoreGrainsTestCase(TestCase, LoaderModuleMockMixin):
             "UBUNTU_CODENAME": "artful",
         })
 
+    def test_parse_cpe_name_wfn(self):
+        '''
+        Parse correct CPE_NAME data WFN formatted
+        :return:
+        '''
+        for cpe, cpe_ret in [('cpe:/o:opensuse:leap:15.0',
+                              {'phase': None, 'version': '15.0', 'product': 'leap', 'vendor': 'opensuse'}),
+                             ('cpe:/o:vendor:product:42:beta',
+                              {'phase': 'beta', 'version': '42', 'product': 'product', 'vendor': 'vendor'})]:
+            ret = core._parse_cpe_name(cpe)
+            for key in cpe_ret:
+                assert key in ret
+                assert cpe_ret[key] == ret[key]
     def test_missing_os_release(self):
         with patch('salt.utils.files.fopen', mock_open(read_data={})):
             os_release = core._parse_os_release('/etc/os-release', '/usr/lib/os-release')

--- a/tests/unit/grains/test_core.py
+++ b/tests/unit/grains/test_core.py
@@ -111,6 +111,16 @@ class CoreGrainsTestCase(TestCase, LoaderModuleMockMixin):
             for key in cpe_ret:
                 assert key in ret
                 assert cpe_ret[key] == ret[key]
+
+    def test_parse_cpe_name_broken(self):
+        '''
+        Parse broken CPE_NAME data
+        :return:
+        '''
+        for cpe in ['cpe:broken', 'cpe:broken:in:all:ways:*:*:*:*',
+                    'cpe:x:still:broken:123', 'who:/knows:what:is:here']:
+            assert core._parse_cpe_name(cpe) == {}
+
     def test_missing_os_release(self):
         with patch('salt.utils.files.fopen', mock_open(read_data={})):
             os_release = core._parse_os_release('/etc/os-release', '/usr/lib/os-release')

--- a/tests/unit/grains/test_core.py
+++ b/tests/unit/grains/test_core.py
@@ -90,9 +90,11 @@ class CoreGrainsTestCase(TestCase, LoaderModuleMockMixin):
         :return:
         '''
         for cpe, cpe_ret in [('cpe:/o:opensuse:leap:15.0',
-                              {'phase': None, 'version': '15.0', 'product': 'leap', 'vendor': 'opensuse'}),
+                              {'phase': None, 'version': '15.0', 'product': 'leap',
+                               'vendor': 'opensuse', 'part': 'operating system'}),
                              ('cpe:/o:vendor:product:42:beta',
-                              {'phase': 'beta', 'version': '42', 'product': 'product', 'vendor': 'vendor'})]:
+                              {'phase': 'beta', 'version': '42', 'product': 'product',
+                               'vendor': 'vendor', 'part': 'operating system'})]:
             ret = core._parse_cpe_name(cpe)
             for key in cpe_ret:
                 assert key in ret


### PR DESCRIPTION
### What does this PR do?

Bugfix for `osversion`, `osversion_info` and `osmajorrelease` grains on SUSE systems.

### What issues does this PR fix or reference?

As per documentation of [`/etc/os-release`](https://www.linux.org/docs/man5/os-release.html) file:

> VERSION_ID= 
A lower-case string (mostly numeric, no spaces or other characters outside of 0-9, a-z, ".", "_" and "-") identifying the operating system version, excluding any OS name information or release code name, and suitable for processing by scripts or usage in generated filenames. This field is optional.
Example:
"VERSION_ID=17" or "VERSION_ID=11.04".

This in reality this so far always worked, because nobody adds there anything else but numbers and dots. However, it allows symbols. And thus if one is adding something like `VERSION_ID=foo.bar` which is still allowed, the grain `osmajorrelease` will disappear, since it is expected to be an integer.

`CPE_NAME`, in contrary, has a clear definition between version number and its phase (for "beta", "alpha" etc). Unfortunately, `CPE_NAME` is still optional. But it is provided on the systems where no `/etc/lsb-release` with `DISTRIB_RELEASE` like in Debian, for example. Therefore Salt should try look up for `CPE_NAME` as well and fall-back to `VERSION_ID` only if nothing else has been found to figure out distribution version. Also, on some distributions `CPE_NAME` is still broken (only major version specified).

### Previous Behavior

```
# cat /etc/os-release | grep VERSION_ID
VERSION_ID="foo.bar"

$ salt-call --local grains.get osrelease
local:
    foo.bar

$ salt-call --local grains.get osrelease_info
local:
    - foo
    - bar

$ salt-call --local grains.get osmajorrelease
local:
```

### New Behavior

```
# cat /etc/os-release | grep VERSION_ID
VERSION_ID="foo.bar"

$ salt-call --local grains.get osrelease
local:
    15.0

$ salt-call --local grains.get osrelease_info
local:
    - 15
    - 0

# salt-call --local grains.get osmajorrelease
local:
    15

# salt-call --local grains.get osmajorrelease --out json
{
    "local": 15
}
```


### Tests written?

Yes
