### PR TITLE
Skip pillar refresh test

### DIFF
--- a/tests/integration/modules/test_saltutil.py
+++ b/tests/integration/modules/test_saltutil.py
@@ -13,6 +13,7 @@ import textwrap
 from tests.support.case import ModuleCase
 from tests.support.helpers import flaky
 from tests.support.paths import TMP_PILLAR_TREE
+from tests.support.unit import skipIf
 
 # Import Salt Libs
 import salt.utils.files
@@ -169,6 +170,7 @@ class SaltUtilSyncModuleTest(ModuleCase):
         self.assertEqual(ret, expected_return)
 
 
+@skipIf(True, 'Pillar refresh test is flaky. Skipping for now.')
 class SaltUtilSyncPillarTest(ModuleCase):
     '''
     Testcase for the saltutil sync pillar module


### PR DESCRIPTION
This test is flaky and fails intermittently, even with the `flaky` decorator.

Skipping for now until we can debug further.