### PR TITLE
Fix file patch tests on CentOS 6

### DIFF
--- a/tests/integration/states/test_file.py
+++ b/tests/integration/states/test_file.py
@@ -3935,11 +3935,10 @@ class PatchTest(ModuleCase, SaltReturnAssertsMixin):
         '''
         patch version check
         '''
-        if not salt.utils.path.which('patch'):
-            self.skipTest('patch is not installed')
-        version = re.search(r'\d\.\d\.\d', self.run_function('cmd.run', ['patch --version'])).group(0)
+        version = self.run_function('cmd.run', ['patch --version']).splitlines()[0]
+        version = version.split()[1]
         if _LooseVersion(version) < _LooseVersion(min_version):
-            self.skipTest('Mininum patch version required: {0}.'
+            self.skipTest('Minimum patch version required: {0}. '
                           'Patch version installed: {1}'.format(min_version, version))
 
     @classmethod
@@ -4064,7 +4063,7 @@ class PatchTest(ModuleCase, SaltReturnAssertsMixin):
         Test file.patch using a patch applied to a directory, with changes
         spanning multiple files.
         '''
-        self._check_patch_version('2.6.1')
+        self._check_patch_version('2.6')
         ret = self.run_state(
             'file.patch',
             name=self.base_dir,
@@ -4092,7 +4091,7 @@ class PatchTest(ModuleCase, SaltReturnAssertsMixin):
         '''
         Test that we successfuly parse -p/--strip when included in the options
         '''
-        self._check_patch_version('2.6.1')
+        self._check_patch_version('2.6')
         # Run the state using -p1
         ret = self.run_state(
             'file.patch',
@@ -4267,7 +4266,7 @@ class PatchTest(ModuleCase, SaltReturnAssertsMixin):
         spanning multiple files, and the patch file coming from a remote
         source.
         '''
-        self._check_patch_version('2.6.1')
+        self._check_patch_version('2.6')
         # Try without a source_hash and without skip_verify=True, this should
         # fail with a message about the source_hash
         ret = self.run_state(
@@ -4342,7 +4341,7 @@ class PatchTest(ModuleCase, SaltReturnAssertsMixin):
         spanning multiple files, and with jinja templating applied to the patch
         file.
         '''
-        self._check_patch_version('2.6.1')
+        self._check_patch_version('2.6')
         ret = self.run_state(
             'file.patch',
             name=self.base_dir,
@@ -4422,7 +4421,7 @@ class PatchTest(ModuleCase, SaltReturnAssertsMixin):
         spanning multiple files, and the patch file coming from a remote
         source.
         '''
-        self._check_patch_version('2.6.1')
+        self._check_patch_version('2.6')
         # Try without a source_hash and without skip_verify=True, this should
         # fail with a message about the source_hash
         ret = self.run_state(


### PR DESCRIPTION
### What does this PR do?
Fix the `integration.states.test_file.PatchTest` tests that are failing on CentOS 6.

Some logic was added in PR #49568 to skip the patch tests on patch whose version is < 2.6.1. However, CentOS 6 has patch `2.6` installed (note the `2.6` notation instead of something like `2.6.0`)  and the logic was failing in the check like so:
```
Traceback (most recent call last):
  File "/tmp/kitchen/testing/tests/integration/states/test_file.py", line 4067, in test_patch_directory
    self._check_patch_version('2.6.1')
  File "/tmp/kitchen/testing/tests/integration/states/test_file.py", line 3940, in _check_patch_version
    version = re.search(r'\d\.\d\.\d', self.run_function('cmd.run', ['patch --version'])).group(0)
AttributeError: 'NoneType' object has no attribute 'group'
```

This PR changes the logic to not fail when the version installed reports either 2 (`2.6`) or 3 (`2.6.1`) version "pieces" of the notation.

While fixing this problem, I also ran the tests to see if they would pass on the `2.6` version, rather than requiring `2.6.1` or newer. They all pass just fine, so I loosened the minimum version from `2.6.1` to simply `2.6`. 

### What issues does this PR fix or reference?
Fixes https://github.com/saltstack/salt-jenkins/issues/1154

Refs https://github.com/saltstack/salt/pull/49568

### Previous Behavior
Tests would fail with a stacktrace on CentOS 6.

### New Behavior
Stacktrace is no longer present and the tests run successfully.

### Tests written?

Yes - fixes tests and enables them again on CentOS 6

### Commits signed with GPG?

Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
