### PR TITLE
Fix test `unit.modules.test_kubernetes` on Windows

### DIFF
--- a/tests/unit/modules/test_kubernetes.py
+++ b/tests/unit/modules/test_kubernetes.py
@@ -176,7 +176,8 @@ class KubernetesTestCase(TestCase, LoaderModuleMockMixin):
             with patch.dict(kubernetes.__salt__, {'config.option': Mock(side_effect=self.settings)}):
                 mock_kubernetes_lib.config.load_kube_config = Mock()
                 config = kubernetes._setup_conn(kubeconfig_data='MTIzNDU2Nzg5MAo=', context='newcontext')
-                self.assertTrue(config['kubeconfig'].startswith('/tmp/salt-kubeconfig-'))
+                check_path = os.path.join(os.environ.get('temp'), 'salt-kubeconfig-')
+                self.assertTrue(config['kubeconfig'].startswith(check_path.lower()))
                 self.assertTrue(os.path.exists(config['kubeconfig']))
                 with salt.utils.files.fopen(config['kubeconfig'], 'r') as kcfg:
                     self.assertEqual('1234567890\n', kcfg.read())

--- a/tests/unit/modules/test_kubernetes.py
+++ b/tests/unit/modules/test_kubernetes.py
@@ -20,6 +20,7 @@ from tests.support.mock import (
 )
 
 import salt.utils.files
+import salt.utils.platform
 from salt.modules import kubernetes
 
 
@@ -176,8 +177,10 @@ class KubernetesTestCase(TestCase, LoaderModuleMockMixin):
             with patch.dict(kubernetes.__salt__, {'config.option': Mock(side_effect=self.settings)}):
                 mock_kubernetes_lib.config.load_kube_config = Mock()
                 config = kubernetes._setup_conn(kubeconfig_data='MTIzNDU2Nzg5MAo=', context='newcontext')
-                check_path = os.path.join(os.environ.get('TMP'), 'salt-kubeconfig-')
-                self.assertTrue(config['kubeconfig'].startswith(check_path.lower()))
+                check_path = os.path.join('/tmp', 'salt-kubeconfig-')
+                if salt.utils.platform.is_windows()
+                    check_path = os.path.join(os.environ.get('TMP'), 'salt-kubeconfig-')
+                self.assertTrue(config['kubeconfig'].lower().startswith(check_path.lower()))
                 self.assertTrue(os.path.exists(config['kubeconfig']))
                 with salt.utils.files.fopen(config['kubeconfig'], 'r') as kcfg:
                     self.assertEqual('1234567890\n', kcfg.read())

--- a/tests/unit/modules/test_kubernetes.py
+++ b/tests/unit/modules/test_kubernetes.py
@@ -176,7 +176,7 @@ class KubernetesTestCase(TestCase, LoaderModuleMockMixin):
             with patch.dict(kubernetes.__salt__, {'config.option': Mock(side_effect=self.settings)}):
                 mock_kubernetes_lib.config.load_kube_config = Mock()
                 config = kubernetes._setup_conn(kubeconfig_data='MTIzNDU2Nzg5MAo=', context='newcontext')
-                check_path = os.path.join(os.environ.get('temp'), 'salt-kubeconfig-')
+                check_path = os.path.join(os.environ.get('TMP'), 'salt-kubeconfig-')
                 self.assertTrue(config['kubeconfig'].startswith(check_path.lower()))
                 self.assertTrue(os.path.exists(config['kubeconfig']))
                 with salt.utils.files.fopen(config['kubeconfig'], 'r') as kcfg:

--- a/tests/unit/modules/test_kubernetes.py
+++ b/tests/unit/modules/test_kubernetes.py
@@ -178,7 +178,7 @@ class KubernetesTestCase(TestCase, LoaderModuleMockMixin):
                 mock_kubernetes_lib.config.load_kube_config = Mock()
                 config = kubernetes._setup_conn(kubeconfig_data='MTIzNDU2Nzg5MAo=', context='newcontext')
                 check_path = os.path.join('/tmp', 'salt-kubeconfig-')
-                if salt.utils.platform.is_windows()
+                if salt.utils.platform.is_windows():
                     check_path = os.path.join(os.environ.get('TMP'), 'salt-kubeconfig-')
                 self.assertTrue(config['kubeconfig'].lower().startswith(check_path.lower()))
                 self.assertTrue(os.path.exists(config['kubeconfig']))


### PR DESCRIPTION
### What does this PR do?
Fixes the `test_kubernetes` unit tests in Windows. It's an issue with the path that's being checked. It's looking in `/tmp/`  by default... this needs to be os agnostic, so we'll use the `temp` environment variable to get the first portion.

### Tests written?
Yes

### Commits signed with GPG?
Yes