### PR TITLE
Fix `unit.modules.test_cmdmod` for Windows

### DIFF
--- a/salt/utils/win_runas.py
+++ b/salt/utils/win_runas.py
@@ -26,9 +26,13 @@ try:
     import win32profile
     import msvcrt
     import salt.platform.win
+    import pywintypes
     HAS_WIN32 = True
 except ImportError:
     HAS_WIN32 = False
+
+# Import Salt Libs
+from salt.exceptions import CommandExecutionError
 
 log = logging.getLogger(__name__)
 
@@ -57,10 +61,10 @@ def split_username(username):
 
 def runas(cmdLine, username, password=None, cwd=None):
     '''
-    Run a command as another user. It the proccess is running as an admin or
+    Run a command as another user. If the process is running as an admin or
     system account this method does not require a password. Other non
-    priviledged accounts need to provide a password for the user to runas.
-    Commands are run in with the highest level priviledges possible for the
+    privileged accounts need to provide a password for the user to runas.
+    Commands are run in with the highest level privileges possible for the
     account provided.
     '''
 
@@ -72,7 +76,7 @@ def runas(cmdLine, username, password=None, cwd=None):
     th = win32security.OpenProcessToken(win32api.GetCurrentProcess(), access)
     salt.platform.win.elevate_token(th)
 
-    # Try to impersonate the SYSTEM user. This process needs to be runnung as a
+    # Try to impersonate the SYSTEM user. This process needs to be running as a
     # user who as been granted the SeImpersonatePrivilege, Administrator
     # accounts have this permission by default.
     try:
@@ -85,7 +89,7 @@ def runas(cmdLine, username, password=None, cwd=None):
         log.debug("Unable to impersonate SYSTEM user")
         impersonation_token = None
 
-    # Impersonation of the SYSTEM user failed. Fallback to an un-priviledged
+    # Impersonation of the SYSTEM user failed. Fallback to an un-privileged
     # runas.
     if not impersonation_token:
         log.debug("No impersonation token, using unprivileged runas")
@@ -93,7 +97,12 @@ def runas(cmdLine, username, password=None, cwd=None):
 
     username, domain = split_username(username)
     # Validate the domain and sid exist for the username
-    sid, domain, sidType = win32security.LookupAccountName(domain, username)
+    try:
+        _, domain, _ = win32security.LookupAccountName(domain, username)
+    except pywintypes.error as exc:
+        message = win32api.FormatMessage(exc.winerror).rstrip('\n')
+        raise CommandExecutionError(message)
+
     if domain == 'NT AUTHORITY':
         # Logon as a system level account, SYSTEM, LOCAL SERVICE, or NETWORK
         # SERVICE.

--- a/tests/unit/modules/test_cmdmod.py
+++ b/tests/unit/modules/test_cmdmod.py
@@ -180,10 +180,12 @@ class CMDMODTestCase(TestCase, LoaderModuleMockMixin):
         '''
         Tests return when runas user is not available
         '''
-        with patch('salt.modules.cmdmod._is_valid_shell', MagicMock(return_value=True)):
-            with patch('os.path.isfile', MagicMock(return_value=True)):
-                with patch('os.access', MagicMock(return_value=True)):
-                    self.assertRaises(CommandExecutionError, cmdmod._run, 'foo', 'bar', runas='baz')
+        mock_true = MagicMock(return_value=True)
+        with patch('salt.modules.cmdmod._is_valid_shell', mock_true), \
+                patch('os.path.isfile', mock_true), \
+                patch('os.access', mock_true):
+            self.assertRaises(CommandExecutionError,
+                              cmdmod._run, 'foo', 'bar', runas='baz')
 
     def test_run_zero_umask(self):
         '''
@@ -355,9 +357,11 @@ class CMDMODTestCase(TestCase, LoaderModuleMockMixin):
 
         # stdout with the non-decodable bits replaced with the unicode
         # replacement character U+FFFD.
-        stdout_unicode = '\ufffd\x1b\ufffd\ufffd\n'
-        stderr_bytes = b'1+0 records in\n1+0 records out\n' \
-                       b'4 bytes copied, 9.1522e-05 s, 43.7 kB/s\n'
+        stdout_unicode = '\ufffd\x1b\ufffd\ufffd' + os.linesep
+        stderr_bytes = os.linesep.join([
+            b'1+0 records in',
+            b'1+0 records out',
+            b'4 bytes copied, 9.1522e-05 s, 43.7 kB/s']) + os.linesep
         stderr_unicode = stderr_bytes.decode()
 
         proc = MagicMock(

--- a/tests/unit/modules/test_cmdmod.py
+++ b/tests/unit/modules/test_cmdmod.py
@@ -358,10 +358,10 @@ class CMDMODTestCase(TestCase, LoaderModuleMockMixin):
         # stdout with the non-decodable bits replaced with the unicode
         # replacement character U+FFFD.
         stdout_unicode = '\ufffd\x1b\ufffd\ufffd' + os.linesep
-        stderr_bytes = os.linesep.join([
+        stderr_bytes = os.linesep.encode().join([
             b'1+0 records in',
             b'1+0 records out',
-            b'4 bytes copied, 9.1522e-05 s, 43.7 kB/s']) + os.linesep
+            b'4 bytes copied, 9.1522e-05 s, 43.7 kB/s']) + os.linesep.encode()
         stderr_unicode = stderr_bytes.decode()
 
         proc = MagicMock(


### PR DESCRIPTION
Fixes the `unit.modules.test_cmdmod` test on Windows.

salt.utils.win_runas
- Returns CommandExecutionError when the users does not exist
- Fixes some spelling

tests.unit.modules.test_cmdmod
- Fixes some linesep issues
- Combines some mocking

### Tests written?
Yes

### Commits signed with GPG?
Yes