### PR TITLE
Fix aix grains test for prtconf present

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -2516,7 +2516,7 @@ def _hw_data(osdata):
                     break
     elif osdata['kernel'] == 'AIX':
         cmd = salt.utils.path.which('prtconf')
-        if data:
+        if cmd:
             data = __salt__['cmd.run']('{0}'.format(cmd)) + os.linesep
             for dest, regstring in (('serialnumber', r'(?im)^\s*Machine\s+Serial\s+Number:\s+(\S+)'),
                                     ('systemfirmware', r'(?im)^\s*Firmware\s+Version:\s+(.*)')):


### PR DESCRIPTION
### What does this PR do?
Corrects test for presence of utility prtconf on AIX systems.

### What issues does this PR fix or reference?
The Salt 2018.3.3 point release was patched for this fix, this PR adds the fix to upstream

### Previous Behavior
The error was in code added for the 2018.3.3 release, not present in earlier versions of Salt.

### New Behavior
Adds fix to upstream from Salt 2018.3.3 point release patch.

### Tests written?
No, fix was tested during build/package process for Salt 2018.3.3

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
