### PR TITLE
Return the nginx version without prefix

### DIFF
--- a/salt/modules/nginx.py
+++ b/salt/modules/nginx.py
@@ -43,7 +43,7 @@ def version():
     '''
     cmd = '{0} -v'.format(__detect_os())
     out = __salt__['cmd.run'](cmd).splitlines()
-    ret = out[0].split(': ')
+    ret = out[0].split(': ')[-1].split('/')
     return ret[-1]
 
 


### PR DESCRIPTION
### What does this PR do?
This PR removes the unnecessary `nginx/` prefix of the version return, so it can actually be used in functions like `pkg.version_cmp`

### Previous Behavior
Output:
```
root@salt:~# salt-call nginx.version
local:
    nginx/1.14.0
```

### New Behavior
```
root@salt:~# salt-call nginx.version
local:
    1.14.0
```

### Tests written?

No

### Commits signed with GPG?

No