### PR TITLE
Introduce 'ignore_deprecation_warnings' to avoid logging deprecation warnings

### DIFF
--- a/salt/utils/decorators/__init__.py
+++ b/salt/utils/decorators/__init__.py
@@ -423,7 +423,8 @@ class _IsDeprecated(_DeprecationDecorator):
                                                                     version_name=self._exp_version_name)]
                 if self._successor:
                     msg.append('Use successor "{successor}" instead.'.format(successor=self._successor))
-                log.warning(' '.join(msg))
+                if not self._ignore_deprecation_warnings:
+                    log.warning(' '.join(msg))
             else:
                 msg = ['The lifetime of the function "{f_name}" expired.'.format(f_name=self._function.__name__)]
                 if self._successor:
@@ -606,7 +607,8 @@ class _WithDeprecated(_DeprecationDecorator):
                         msg.append('The function "{f_name}" is using its deprecated version and will '
                                    'expire in version "{version_name}".'.format(f_name=func_path,
                                                                                 version_name=self._exp_version_name))
-                    log.warning(' '.join(msg))
+                    if not self._ignore_deprecation_warnings:
+                        log.warning(' '.join(msg))
                 else:
                     msg_patt = 'The lifetime of the function "{f_name}" expired.'
                     if '_' + self._orig_f_name == self._function.__name__:

--- a/salt/utils/decorators/__init__.py
+++ b/salt/utils/decorators/__init__.py
@@ -338,6 +338,7 @@ class _DeprecationDecorator(object):
         '''
         self._function = function
         self._orig_f_name = self._function.__name__
+        opts = self._globals.get('__opts__', '{}')
         self._ignore_deprecation_warnings = self._orig_f_name in opts.get(self.CFG_IGNORE_DEPRECATION_WARNINGS, list())
 
 

--- a/salt/utils/decorators/__init__.py
+++ b/salt/utils/decorators/__init__.py
@@ -267,6 +267,7 @@ class _DeprecationDecorator(object):
 
     OPT_IN = 1
     OPT_OUT = 2
+    CFG_IGNORE_DEPRECATION_WARNINGS = 'ignore_deprecation_warnings'
 
     def __init__(self, globals, version):
         '''
@@ -284,6 +285,7 @@ class _DeprecationDecorator(object):
         self._raise_later = None
         self._function = None
         self._orig_f_name = None
+        self._ignore_deprecation_warnings = None
 
     def _get_args(self, kwargs):
         '''
@@ -336,6 +338,7 @@ class _DeprecationDecorator(object):
         '''
         self._function = function
         self._orig_f_name = self._function.__name__
+        self._ignore_deprecation_warnings = self._orig_f_name in opts.get(self.CFG_IGNORE_DEPRECATION_WARNINGS, list())
 
 
 class _IsDeprecated(_DeprecationDecorator):

--- a/salt/utils/decorators/__init__.py
+++ b/salt/utils/decorators/__init__.py
@@ -429,7 +429,7 @@ class _IsDeprecated(_DeprecationDecorator):
                 msg = ['The lifetime of the function "{f_name}" expired.'.format(f_name=self._function.__name__)]
                 if self._successor:
                     msg.append('Please use its successor "{successor}" instead.'.format(successor=self._successor))
-                log.warning(' '.join(msg))
+                log.error(' '.join(msg))
                 raise CommandExecutionError(' '.join(msg))
             return self._call_function(kwargs)
         return _decorate


### PR DESCRIPTION
### What does this PR do?
This PR introduces `ignore_deprecation_warnings` as a minion settings in order to avoid logging deprecation warnings messages coming a particular function that makes use of the `@with_deprecated` decorator. This way, we can avoid excessive logging on the minion files.

### Previous Behavior
```
2018-10-10 11:41:23,020 [salt.utils.decorators:544 ][WARNING ][21264] The function "module.run" is using its deprecated version and will expire in version "Sodium".
```

### New Behavior
Having the following in our `/etc/salt/minion`:
```
...
ignore_deprecation_warnings:
  - module.run
...
```

No more deprecation warning messages from `module.run`.

### Tests written?

No

### Commits signed with GPG?

Yes