### PR TITLE
Fix nova module cooperation with python-novaclient

### DIFF
--- a/salt/modules/nova.py
+++ b/salt/modules/nova.py
@@ -223,9 +223,7 @@ def volume_list(search_opts=None, profile=None):
 
     .. code-block:: bash
 
-        salt '*' nova.volume_list \
-                search_opts='{"display_name": "myblock"}' \
-                profile=openstack
+        salt '*' nova.volume_list search_opts='{"display_name": "myblock"}' profile=openstack
 
     '''
     conn = _auth(profile)
@@ -364,8 +362,7 @@ def volume_attach(name,
     .. code-block:: bash
 
         salt '*' nova.volume_attach myblock slice.example.com profile=openstack
-        salt '*' nova.volume_attach myblock server.example.com \
-                device='/dev/xvdb' profile=openstack
+        salt '*' nova.volume_attach myblock server.example.com device='/dev/xvdb' profile=openstack
 
     '''
     conn = _auth(profile)
@@ -488,8 +485,7 @@ def flavor_create(name,      # pylint: disable=C0103
 
     .. code-block:: bash
 
-        salt '*' nova.flavor_create myflavor flavor_id=6 \
-                ram=4096 disk=10 vcpus=1
+        salt '*' nova.flavor_create myflavor flavor_id=6 ram=4096 disk=10 vcpus=1
     '''
     conn = _auth(profile)
     return conn.flavor_create(
@@ -556,7 +552,7 @@ def keypair_delete(name, profile=None):
 
     .. code-block:: bash
 
-        salt '*' nova.keypair_delete mykey'
+        salt '*' nova.keypair_delete mykey
     '''
     conn = _auth(profile)
     return conn.keypair_delete(name)
@@ -589,8 +585,7 @@ def image_meta_set(image_id=None,
 
     .. code-block:: bash
 
-        salt '*' nova.image_meta_set 6f52b2ff-0b31-4d84-8fd1-af45b84824f6 \
-                cheese=gruyere
+        salt '*' nova.image_meta_set 6f52b2ff-0b31-4d84-8fd1-af45b84824f6 cheese=gruyere
         salt '*' nova.image_meta_set name=myimage salad=pasta beans=baked
     '''
     conn = _auth(profile)
@@ -613,8 +608,7 @@ def image_meta_delete(image_id=None,     # pylint: disable=C0103
 
     .. code-block:: bash
 
-        salt '*' nova.image_meta_delete \
-                6f52b2ff-0b31-4d84-8fd1-af45b84824f6 keys=cheese
+        salt '*' nova.image_meta_delete 6f52b2ff-0b31-4d84-8fd1-af45b84824f6 keys=cheese
         salt '*' nova.image_meta_delete name=myimage keys=salad,beans
     '''
     conn = _auth(profile)

--- a/salt/modules/nova.py
+++ b/salt/modules/nova.py
@@ -96,6 +96,9 @@ __func_alias__ = {
     'list_': 'list'
 }
 
+# Define the module's virtual name
+__virtualname__ = 'nova'
+
 
 def __virtual__():
     '''

--- a/salt/modules/nova.py
+++ b/salt/modules/nova.py
@@ -53,10 +53,17 @@ Module for handling OpenStack Nova calls
         keystone.user: admin
         keystone.password: verybadpass
         keystone.tenant: admin
-        keystone.auth_url: 'http://127.0.0.1:5000/v3/'
-        keystone.use_keystoneauth: true
+        keystone.auth_url: 'http://127.0.0.1:5000'
+        keystone.use_keystoneauth: True
+        keystone.region_name: RegionOne
+        keystone.project_id: befcf35ea5094743b81ee12fb43484f5
+        keystone.user_domain_name: Default
+        # Optional
         keystone.verify: '/path/to/custom/certs/ca-bundle.crt'
 
+    .. note::
+        Auto detection of API version is added so there is no need to add /v3
+        to auth_url.
 
     .. note::
         By default the nova module will attempt to verify its connection
@@ -67,12 +74,19 @@ Module for handling OpenStack Nova calls
         path to a bundle or CA certs to check against, or None to allow
         keystoneauth to search for the certificates on its own. (defaults to
         True)
+
 '''
 from __future__ import absolute_import, unicode_literals, print_function
 
 # Import python libs
 import logging
 
+# Import salt libs
+try:
+    import salt.utils.openstack.nova as suon
+    HAS_NOVA = True
+except ImportError as exc:
+    HAS_NOVA = False
 
 # Get logging started
 log = logging.getLogger(__name__)
@@ -82,19 +96,16 @@ __func_alias__ = {
     'list_': 'list'
 }
 
-try:
-    import salt.utils.openstack.nova as suon
-    HAS_NOVA = True
-except NameError as exc:
-    HAS_NOVA = False
-
 
 def __virtual__():
     '''
     Only load this module if nova
     is installed on this minion.
     '''
-    return HAS_NOVA
+    if HAS_NOVA:
+        return __virtualname__
+    return (False, 'The nova execution module failed to load: '
+            'only available if nova client is installed.')
 
 
 __opts__ = {}
@@ -114,7 +125,6 @@ def _auth(profile=None):
         api_key = credentials.get('keystone.api_key', None)
         os_auth_system = credentials.get('keystone.os_auth_system', None)
         use_keystoneauth = credentials.get('keystone.use_keystoneauth', False)
-        verify = credentials.get('keystone.verify', None)
     else:
         user = __salt__['config.option']('keystone.user')
         password = __salt__['config.option']('keystone.password')
@@ -124,16 +134,23 @@ def _auth(profile=None):
         api_key = __salt__['config.option']('keystone.api_key')
         os_auth_system = __salt__['config.option']('keystone.os_auth_system')
         use_keystoneauth = __salt__['config.option']('keystone.use_keystoneauth')
-        verify = __salt__['config.option']('keystone.verify')
 
     if use_keystoneauth is True:
-        project_domain_name = credentials['keystone.project_domain_name']
-        user_domain_name = credentials['keystone.user_domain_name']
+        if profile:
+            project_id = credentials.get('keystone.project_id', None)
+            user_domain_name = credentials.get('keystone.user_domain_name', None)
+            project_domain_name = credentials.get('keystone.project_domain_name', None)
+            verify = credentials.get('keystone.verify', None)
+        else:
+            project_id = __salt__['config.option']('keystone.project_id')
+            user_domain_name = __salt__['config.option']('keystone.user_domain_name')
+            project_domain_name = __salt__['config.option']('keystone.project_domain_name')
+            verify = __salt__['config.option']('keystone.verify')
 
         kwargs = {
             'username': user,
             'password': password,
-            'project_id': tenant,
+            'project_id': project_id,
             'auth_url': auth_url,
             'region_name': region_name,
             'use_keystoneauth': use_keystoneauth,
@@ -206,7 +223,9 @@ def volume_list(search_opts=None, profile=None):
 
     .. code-block:: bash
 
-        salt '*' nova.volume_list search_opts='{"display_name": "myblock"}' profile=openstack
+        salt '*' nova.volume_list \
+                search_opts='{"display_name": "myblock"}' \
+                profile=openstack
 
     '''
     conn = _auth(profile)
@@ -345,7 +364,8 @@ def volume_attach(name,
     .. code-block:: bash
 
         salt '*' nova.volume_attach myblock slice.example.com profile=openstack
-        salt '*' nova.volume_attach myblock server.example.com device=/dev/xvdb profile=openstack
+        salt '*' nova.volume_attach myblock server.example.com \
+                device='/dev/xvdb' profile=openstack
 
     '''
     conn = _auth(profile)
@@ -468,7 +488,8 @@ def flavor_create(name,      # pylint: disable=C0103
 
     .. code-block:: bash
 
-        salt '*' nova.flavor_create myflavor flavor_id=6 ram=4096 disk=10 vcpus=1
+        salt '*' nova.flavor_create myflavor flavor_id=6 \
+                ram=4096 disk=10 vcpus=1
     '''
     conn = _auth(profile)
     return conn.flavor_create(
@@ -516,7 +537,7 @@ def keypair_add(name, pubfile=None, pubkey=None, profile=None):
 
     .. code-block:: bash
 
-        salt '*' nova.keypair_add mykey pubfile=/home/myuser/.ssh/id_rsa.pub
+        salt '*' nova.keypair_add mykey pubfile='/home/myuser/.ssh/id_rsa.pub'
         salt '*' nova.keypair_add mykey pubkey='ssh-rsa <key> myuser@mybox'
     '''
     conn = _auth(profile)
@@ -535,7 +556,7 @@ def keypair_delete(name, profile=None):
 
     .. code-block:: bash
 
-        salt '*' nova.keypair_delete mykey
+        salt '*' nova.keypair_delete mykey'
     '''
     conn = _auth(profile)
     return conn.keypair_delete(name)
@@ -568,7 +589,8 @@ def image_meta_set(image_id=None,
 
     .. code-block:: bash
 
-        salt '*' nova.image_meta_set 6f52b2ff-0b31-4d84-8fd1-af45b84824f6 cheese=gruyere
+        salt '*' nova.image_meta_set 6f52b2ff-0b31-4d84-8fd1-af45b84824f6 \
+                cheese=gruyere
         salt '*' nova.image_meta_set name=myimage salad=pasta beans=baked
     '''
     conn = _auth(profile)
@@ -591,7 +613,8 @@ def image_meta_delete(image_id=None,     # pylint: disable=C0103
 
     .. code-block:: bash
 
-        salt '*' nova.image_meta_delete 6f52b2ff-0b31-4d84-8fd1-af45b84824f6 keys=cheese
+        salt '*' nova.image_meta_delete \
+                6f52b2ff-0b31-4d84-8fd1-af45b84824f6 keys=cheese
         salt '*' nova.image_meta_delete name=myimage keys=salad,beans
     '''
     conn = _auth(profile)

--- a/salt/utils/openstack/nova.py
+++ b/salt/utils/openstack/nova.py
@@ -8,6 +8,8 @@ from __future__ import absolute_import, with_statement, unicode_literals, print_
 import inspect
 import logging
 import time
+import re
+import json
 
 # Import third party libs
 from salt.ext import six
@@ -18,7 +20,6 @@ try:
     from novaclient import client
     from novaclient.shell import OpenStackComputeShell
     import novaclient.utils
-    import novaclient.auth_plugin
     import novaclient.exceptions
     import novaclient.extension
     import novaclient.base
@@ -64,19 +65,24 @@ CLIENT_BDM2_KEYS = {
 
 
 def check_nova():
+    '''
+    Check version of novaclient
+    '''
     if HAS_NOVA:
         novaclient_ver = _LooseVersion(novaclient.__version__)
         min_ver = _LooseVersion(NOVACLIENT_MINVER)
-        max_ver = _LooseVersion(NOVACLIENT_MAXVER)
-        if min_ver <= novaclient_ver <= max_ver:
+        if min_ver <= novaclient_ver:
             return HAS_NOVA
-        elif novaclient_ver > max_ver:
-            log.debug('Older novaclient version required. Maximum: %s',
-                      NOVACLIENT_MAXVER)
-            return False
         log.debug('Newer novaclient version required.  Minimum: %s',
                   NOVACLIENT_MINVER)
     return False
+
+if check_nova:
+    try:
+        import novaclient.auth_plugin
+    except ImportError:
+        log.debug('Using novaclient version 7.0.0 or newer. Authentication '
+                  'plugin auth_plugin.py is not available anymore.')
 
 
 # kwargs has to be an object instead of a dictionary for the __post_parse_arg__
@@ -199,7 +205,7 @@ def get_endpoint_url_v3(catalog, service_type, region_name):
         if service_entry['type'] == service_type:
             for endpoint_entry in service_entry['endpoints']:
                 if (endpoint_entry['region'] == region_name and
-                            endpoint_entry['interface'] == 'public'):
+                        endpoint_entry['interface'] == 'public'):
                     return endpoint_entry['url']
     return None
 
@@ -259,9 +265,43 @@ class SaltNova(object):
                            os_auth_plugin=os_auth_plugin,
                            **kwargs)
 
-    def _new_init(self, username, project_id, auth_url, region_name, password, os_auth_plugin, auth=None, verify=True, **kwargs):
+    def _get_version_from_url(self, url):
+        '''
+        Exctract API version from provided URL
+        '''
+        regex = re.compile(r"^https?:\/\/.*\/(v[0-9])(\.[0-9])?(\/)?$")
+        try:
+            ver = regex.match(url)
+            if ver.group(1):
+                retver = ver.group(1)
+                if ver.group(2):
+                    retver = retver + ver.group(2)
+            return retver
+        except AttributeError:
+            return ''
+
+    def _discover_ks_version(self, url):
+        '''
+        Keystone API version discovery
+        '''
+        result = salt.utils.http.query(url, backend='requests', status=True, decode=True, decode_type='json')
+        versions = json.loads(result['body'])
+        try:
+            links = [ver['links'] for ver in versions['versions']['values'] if ver['status'] == 'stable'][0] \
+                    if result['status'] == 300 else versions['version']['links']
+            resurl = [link['href'] for link in links if link['rel'] == 'self'][0]
+            return self._get_version_from_url(resurl)
+        except KeyError as exc:
+            raise SaltCloudSystemExit('KeyError: key {0} not found in API response: {1}'.format(exc, versions))
+
+    def _new_init(self, username, project_id, auth_url, region_name, password, os_auth_plugin, auth=None, **kwargs):
         if auth is None:
             auth = {}
+
+        ks_version = self._get_version_from_url(auth_url)
+        if not ks_version:
+            ks_version = self._discover_ks_version(auth_url)
+            auth_url = '{0}/{1}'.format(auth_url, ks_version)
 
         loader = keystoneauth1.loading.get_plugin_loader(os_auth_plugin or 'password')
 
@@ -278,6 +318,7 @@ class SaltNova(object):
 
         self.kwargs['username'] = username
         self.kwargs['project_name'] = project_id
+        self.kwargs['project_id'] = project_id
         self.kwargs['auth_url'] = auth_url
         self.kwargs['password'] = password
         if auth_url.endswith('3'):
@@ -303,8 +344,16 @@ class SaltNova(object):
         conn = client.Client(version=self.version, session=self.session, **self.client_kwargs)
         self.kwargs['auth_token'] = conn.client.session.get_token()
         identity_service_type = kwargs.get('identity_service_type', 'identity')
-        self.catalog = conn.client.session.get('/auth/catalog', endpoint_filter={'service_type': identity_service_type}).json().get('catalog', [])
-        if conn.client.get_endpoint(service_type=identity_service_type).endswith('v3'):
+        self.catalog = conn.client.session.get('/' + ks_version + '/auth/catalog',
+                                               endpoint_filter={'service_type': identity_service_type}
+                                               ).json().get('catalog', [])
+        for ep_type in self.catalog:
+            if ep_type['type'] == identity_service_type:
+                for ep_id in ep_type['endpoints']:
+                    ep_ks_version = self._get_version_from_url(ep_id['url'])
+                    if not ep_ks_version:
+                        ep_id['url'] = '{0}/{1}'.format(ep_id['url'], ks_version)
+        if ks_version == 'v3':
             self._v3_setup(region_name)
         else:
             self._v2_setup(region_name)

--- a/salt/utils/openstack/nova.py
+++ b/salt/utils/openstack/nova.py
@@ -297,6 +297,7 @@ class SaltNova(object):
     def _new_init(self, username, project_id, auth_url, region_name, password, os_auth_plugin, auth=None, **kwargs):
         if auth is None:
             auth = {}
+        verify = kwargs.get('verify', False)
 
         ks_version = self._get_version_from_url(auth_url)
         if not ks_version:

--- a/salt/utils/openstack/nova.py
+++ b/salt/utils/openstack/nova.py
@@ -77,7 +77,7 @@ def check_nova():
                   NOVACLIENT_MINVER)
     return False
 
-if check_nova:
+if check_nova():
     try:
         import novaclient.auth_plugin
     except ImportError:


### PR DESCRIPTION
### What does this PR do?

Fixes `nova` module and `salt.utils.openstack.nova` module:
- fixed Keystone API v3 cooperation
- added Keystone API version detection (based on HTTP status 301 - multiple choices)
- removed novaclient max version restriction

### Previous Behavior
It was not possible to use `nova` module when `python-novaclient > 6.0.1` installed.

### New Behavior
Now `nova` module works with newer version of `python-novaclient`.

### Tests written?

Yes

### Commits signed with GPG?

Yes