### PR TITLE
remove the incomplete exclude list.

### DIFF
--- a/salt/beacons/inotify.py
+++ b/salt/beacons/inotify.py
@@ -11,7 +11,6 @@ Watch files and translate the changes into salt events
             the beacon configuration.
 
 :note: The `inotify` beacon only works on OSes that have `inotify` kernel support.
-       Currently this excludes FreeBSD, macOS, and Windows.
 
 '''
 # Import Python libs


### PR DESCRIPTION
using an exclude list that does not list every operating system leaves open the possibility that it would work on those not listed

### What does this PR do?
Minor doc change to inotify beacon to remove exclude list as it is incomplete. Leaving the original definition as just those operating systems that have itnofy kernel 

### What issues does this PR fix or reference?

### Tests written?

No - Doc change

### Commits signed with GPG?

No
