### PR TITLE
Add support for AddPrinterDrivers

### DIFF
--- a/salt/modules/win_lgpo.py
+++ b/salt/modules/win_lgpo.py
@@ -1437,6 +1437,21 @@ class _policy_info(object):
                         },
                         'Transform': self.enabled_one_disabled_zero_transform,
                     },
+                    'AddPrinterDrivers': {
+                        'Policy': 'Devices: Prevent users from installing '
+                                  'printer drivers',
+                        'Settings': self.enabled_one_disabled_zero_strings.keys(),
+                        'lgpo_section': self.security_options_gpedit_path,
+                        'Registry': {
+                            'Hive': 'HKEY_LOCAL_MACHINE',
+                            'Path': 'System\\CurrentControlSet\\Control\\'
+                                    'Print\\Providers\\LanMan Print Services\\'
+                                    'Servers',
+                            'Value': 'AddPrinterDrivers',
+                            'Type': 'REG_DWORD',
+                        },
+                        'Transform': self.enabled_one_disabled_zero_strings_transform,
+                    },
                     'AllocateDASD': {
                         'Policy': 'Devices: Allowed to format and eject '
                                   'removable media',


### PR DESCRIPTION
### What does this PR do?
Adds support for the "Devices: Prevent users from installing printer drivers" Group Policy Object.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/49971

### Previous Behavior
```
[ERROR   ]  Unable to find Machine policy Devices: Prevent users from installing printer drivers
local:
----------
          ID: prevent_users_installing_printer_drivers
    Function: lgpo.set
      Result: False
     Comment: Unable to find Machine policy Devices: Prevent users from installing printer drivers
     Started: 20:01:55.460000
    Duration: 672.0 ms
     Changes:
```

### New Behavior
Successfully sets the Group Policy

### Tests written?
No

### Commits signed with GPG?
Yes