### PR TITLE
Improved error logging for win_task.create_task_from_xml

### DIFF
--- a/salt/modules/win_task.py
+++ b/salt/modules/win_task.py
@@ -566,8 +566,8 @@ def create_task_from_xml(name,
         the task to run whether the user is logged in or not, but is currently
         not working.
 
-    :return: True if successful, False if unsuccessful
-    :rtype: bool
+    :return: True if successful, False if unsuccessful, A string with the error message if there is an error
+    :rtype: bool or str
 
     CLI Example:
 
@@ -609,6 +609,7 @@ def create_task_from_xml(name,
                 logon_type = TASK_LOGON_INTERACTIVE_TOKEN
     else:
         password = None
+        logon_type = TASK_LOGON_NONE
 
     # Save the task
     try:

--- a/salt/modules/win_task.py
+++ b/salt/modules/win_task.py
@@ -17,7 +17,7 @@ from datetime import datetime
 
 # Import Salt libs
 import salt.utils.platform
-import salt.exceptions
+from salt.exceptions import ArgumentValueError, CommandExecutionError
 
 # Import 3rd-party libraries
 try:
@@ -583,7 +583,7 @@ def create_task_from_xml(name,
         return '{0} already exists'.format(name)
 
     if not xml_text and not xml_path:
-        raise salt.exceptions.ArgumentValueError('Must specify either xml_text or xml_path')
+        raise ArgumentValueError('Must specify either xml_text or xml_path')
 
     # Create the task service object
     pythoncom.CoInitialize()
@@ -649,10 +649,10 @@ def create_task_from_xml(name,
         try:
             failure_code = fc[error_code]
         except KeyError:
-            failure_code = 'CommandExecutionErrUnknown Failure: {0}'.format(error_code)
+            failure_code = 'Unknown Failure: {0}'.format(error_code)
         finally:
             log.debug('Failed to create task: %s', failure_code)
-        raise salt.exceptions.CommandExecutionError(failure_code)
+        raise CommandExecutionError(failure_code)
 
     # Verify creation
     return name in list_tasks(location)

--- a/salt/modules/win_task.py
+++ b/salt/modules/win_task.py
@@ -17,6 +17,7 @@ from datetime import datetime
 
 # Import Salt libs
 import salt.utils.platform
+import salt.exceptions
 
 # Import 3rd-party libraries
 try:
@@ -567,7 +568,8 @@ def create_task_from_xml(name,
         not working.
 
     :return: True if successful, False if unsuccessful, A string with the error message if there is an error
-    :rtype: bool or str
+    :rtype: bool
+    :raises: CommandExecutionError
 
     CLI Example:
 
@@ -581,7 +583,7 @@ def create_task_from_xml(name,
         return '{0} already exists'.format(name)
 
     if not xml_text and not xml_path:
-        return 'Must specify either xml_text or xml_path'
+        raise salt.exceptions.ArgumentValueError('Must specify either xml_text or xml_path')
 
     # Create the task service object
     pythoncom.CoInitialize()
@@ -647,10 +649,10 @@ def create_task_from_xml(name,
         try:
             failure_code = fc[error_code]
         except KeyError:
-            failure_code = 'Unknown Failure: {0}'.format(error_code)
+            failure_code = 'CommandExecutionErrUnknown Failure: {0}'.format(error_code)
         finally:
             log.debug('Failed to create task: %s', failure_code)
-        return failure_code
+        raise salt.exceptions.CommandExecutionError(failure_code)
 
     # Verify creation
     return name in list_tasks(location)

--- a/salt/modules/win_task.py
+++ b/salt/modules/win_task.py
@@ -621,21 +621,38 @@ def create_task_from_xml(name,
 
     except pythoncom.com_error as error:
         hr, msg, exc, arg = error.args  # pylint: disable=W0633
-        fc = {-2147216615: 'Required element or attribute missing',
-              -2147216616: 'Value incorrectly formatted or out of range',
-              -2147352571: 'Access denied'}
+        error_code = hex(exc[5] + 2**32)
+        failure_code = error_code
+        fc = {'0x80041319L': 'Required element or attribute missing',
+              '0x80041318L': 'Value incorrectly formatted or out of range',
+              '0x80020005L': 'Access denied',
+              '0x80041309L': "A task's trigger is not found",
+              '0x8004130aL': "One or more of the properties required to run this task have not been set",
+              '0x8004130cL': "The Task Scheduler service is not installed on this computer",
+              '0x8004130dL': "The task object could not be opened",
+              '0x8004130eL': "The object is either an invalid task object or is not a task object",
+              '0x8004130fL': "No account information could be found in the Task Scheduler security database for the task indicated",
+              '0x80041310L': "Unable to establish existence of the account specified",
+              '0x80041311L': "Corruption was detected in the Task Scheduler security database; the database has been reset",
+              '0x80041313L': "The task object version is either unsupported or invalid",
+              '0x80041314L': "The task has been configured with an unsupported combination of account settings and run time options",
+              '0x80041315L': "The Task Scheduler Service is not running",
+              '0x80041316L': "The task XML contains an unexpected node",
+              '0x80041317L': "The task XML contains an element or attribute from an unexpected namespace",
+              '0x8004131aL': "The task XML is malformed",
+              '0x0004131cL': "The task is registered, but may fail to start. Batch logon privilege needs to be enabled for the task principal",
+              '0x8004131dL': "The task XML contains too many nodes of the same type",
+              }
         try:
-            failure_code = fc[exc[5]]
+            failure_code = fc[error_code]
         except KeyError:
-            failure_code = 'Unknown Failure: {0}'.format(error)
-
-        log.debug('Failed to create task: %s', failure_code)
+            failure_code = 'Unknown Failure: {0}'.format(error_code)
+        finally:
+            log.debug('Failed to create task: %s', failure_code)
+        return failure_code
 
     # Verify creation
-    if name in list_tasks(location):
-        return True
-    else:
-        return False
+    return name in list_tasks(location)
 
 
 def create_folder(name, location='\\'):

--- a/tests/integration/modules/test_win_task.py
+++ b/tests/integration/modules/test_win_task.py
@@ -3,6 +3,7 @@ from tests.support.case import ModuleCase
 from tests.support.unit import skipIf
 from tests.support.helpers import destructiveTest
 
+import salt.exceptions
 import salt.utils.platform
 
 @skipIf(not salt.utils.platform.is_windows(), 'windows test only')
@@ -71,6 +72,5 @@ class WinTasksTest(ModuleCase):
         Test adding a task using xml
         '''
         xml_text = r"""<Malformed"""
-        self.assertEquals(
-            self.assertEquals(
-                self.run_function('task.create_task_from_xml', 'foo', xml_text=xml_text), "The task XML is malformed"))
+        with self.assertRaises(salt.exceptions.CommandExecutionError):
+            self.run_function('task.create_task_from_xml', 'foo', xml_text=xml_text)

--- a/tests/integration/modules/test_win_task.py
+++ b/tests/integration/modules/test_win_task.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+from tests.support.case import ModuleCase
+from tests.support.unit import skipIf
+from tests.support.helpers import destructiveTest
+
+import salt.utils.platform
+
+@skipIf(not salt.utils.platform.is_windows(), 'windows test only')
+class WinTasksTest(ModuleCase):
+    """
+    Tests for salt.modules.win_task.
+    """
+    @destructiveTest
+    def test_adding_task_with_xml(self):
+        '''
+        Test adding a task using xml
+        '''
+        xml_text = r"""
+        <Task version="1.2" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">
+          <RegistrationInfo>
+            <Date>2015-06-12T15:59:35.691983</Date>
+            <Author>System</Author>
+          </RegistrationInfo>
+          <Triggers>
+            <LogonTrigger>
+              <Enabled>true</Enabled>
+              <Delay>PT30S</Delay>
+            </LogonTrigger>
+          </Triggers>
+          <Principals>
+            <Principal id="Author">
+              <UserId>System</UserId>
+              <LogonType>InteractiveToken</LogonType>
+              <RunLevel>HighestAvailable</RunLevel>
+            </Principal>
+          </Principals>
+          <Settings>
+            <MultipleInstancesPolicy>IgnoreNew</MultipleInstancesPolicy>
+            <DisallowStartIfOnBatteries>true</DisallowStartIfOnBatteries>
+            <StopIfGoingOnBatteries>true</StopIfGoingOnBatteries>
+            <AllowHardTerminate>true</AllowHardTerminate>
+            <StartWhenAvailable>false</StartWhenAvailable>
+            <RunOnlyIfNetworkAvailable>false</RunOnlyIfNetworkAvailable>
+            <IdleSettings>
+              <StopOnIdleEnd>true</StopOnIdleEnd>
+              <RestartOnIdle>false</RestartOnIdle>
+            </IdleSettings>
+            <AllowStartOnDemand>true</AllowStartOnDemand>
+            <Enabled>true</Enabled>
+            <Hidden>false</Hidden>
+            <RunOnlyIfIdle>false</RunOnlyIfIdle>
+            <WakeToRun>false</WakeToRun>
+            <ExecutionTimeLimit>P3D</ExecutionTimeLimit>
+            <Priority>4</Priority>
+          </Settings>
+          <Actions Context="Author">
+            <Exec>
+              <Command>echo</Command>
+              <Arguments>"hello"</Arguments>
+            </Exec>
+          </Actions>
+        </Task>
+        """
+        self.assertEquals(self.run_function('task.create_task_from_xml', 'foo', xml_text=xml_text), True)
+        all_tasks = self.run_function('task.list_tasks')
+        self.assertIn('foo', all_tasks)
+
+    @destructiveTest
+    def test_adding_task_with_invalid_xml(self):
+        '''
+        Test adding a task using xml
+        '''
+        xml_text = r"""<Malformed"""
+        self.assertEquals(
+            self.assertEquals(
+                self.run_function('task.create_task_from_xml', 'foo', xml_text=xml_text), "The task XML is malformed"))

--- a/tests/integration/modules/test_win_task.py
+++ b/tests/integration/modules/test_win_task.py
@@ -1,10 +1,14 @@
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import, unicode_literals
+
 from tests.support.case import ModuleCase
 from tests.support.unit import skipIf
 from tests.support.helpers import destructiveTest
 
-import salt.exceptions
+import salt.modules.win_task as task
+from salt.exceptions import CommandExecutionError
 import salt.utils.platform
+
 
 @skipIf(not salt.utils.platform.is_windows(), 'windows test only')
 class WinTasksTest(ModuleCase):
@@ -69,8 +73,8 @@ class WinTasksTest(ModuleCase):
     @destructiveTest
     def test_adding_task_with_invalid_xml(self):
         '''
-        Test adding a task using xml
+        Test adding a task using a malformed xml
         '''
         xml_text = r"""<Malformed"""
-        with self.assertRaises(salt.exceptions.CommandExecutionError):
-            self.run_function('task.create_task_from_xml', 'foo', xml_text=xml_text)
+        with self.assertRaises(CommandExecutionError):
+            task.create_task_from_xml('foo', xml_text=xml_text)


### PR DESCRIPTION
### What does this PR do?
Instead of only returning True or False when create_task_from_xml fail to add the scheduled task, the actual error message is returned to the user. If the error is unknown, the hex error code is returned. That way, it's easier to search for as this is the format Microsoft is using in their documentation.

### Previous Behavior
Previously, when there was an error, the module only returned False, only logging the error message in the debug logs.

### New Behavior
A proper exception containing the error message is now returned to the user when there is an error. New code will have to catch the exception.

### Tests written?
I added 2 new tests.

### Commits signed with GPG?
The commit was not signe with GPG.