### PR TITLE
Make Pillar no longer munge file_roots

### DIFF
--- a/doc/ref/configuration/master.rst
+++ b/doc/ref/configuration/master.rst
@@ -2436,6 +2436,12 @@ Master will not be returned to the Minion.
 ------------------------------
 
 .. versionadded:: 2014.1.0
+.. deprecated:: 2018.3.4
+   This option is now ignored. Firstly, it only traversed
+   :conf_master:`file_roots`, which means it did not work for the other
+   fileserver backends. Secondly, since this option was added we have added
+   caching to the code that traverses the file_roots (and gitfs, etc.), which
+   greatly reduces the amount of traversal that is done.
 
 Default: ``False``
 

--- a/salt/utils/jinja.py
+++ b/salt/utils/jinja.py
@@ -59,16 +59,16 @@ class SaltCacheLoader(BaseLoader):
         self.opts = opts
         self.saltenv = saltenv
         self.encoding = encoding
-        if self.opts['file_roots'] is self.opts['pillar_roots']:
-            if saltenv not in self.opts['file_roots']:
+        self.pillar_rend = pillar_rend
+        if self.pillar_rend:
+            if saltenv not in self.opts['pillar_roots']:
                 self.searchpath = []
             else:
-                self.searchpath = opts['file_roots'][saltenv]
+                self.searchpath = opts['pillar_roots'][saltenv]
         else:
             self.searchpath = [os.path.join(opts['cachedir'], 'files', saltenv)]
         log.debug('Jinja search path: %s', self.searchpath)
         self.cached = []
-        self.pillar_rend = pillar_rend
         self._file_client = None
         # Instantiate the fileclient
         self.file_client()

--- a/tests/integration/pillar/test_git_pillar.py
+++ b/tests/integration/pillar/test_git_pillar.py
@@ -101,13 +101,13 @@ from salt.utils.gitfs import (
 # Check for requisite components
 try:
     HAS_GITPYTHON = GITPYTHON_VERSION >= GITPYTHON_MINVER
-except ImportError:
+except Exception:
     HAS_GITPYTHON = False
 
 try:
     HAS_PYGIT2 = PYGIT2_VERSION >= PYGIT2_MINVER \
         and LIBGIT2_VERSION >= LIBGIT2_MINVER
-except AttributeError:
+except Exception:
     HAS_PYGIT2 = False
 
 HAS_SSHD = bool(salt.utils.path.which('sshd'))

--- a/tests/unit/fileserver/test_roots.py
+++ b/tests/unit/fileserver/test_roots.py
@@ -168,24 +168,3 @@ class RootsTest(TestCase, AdaptedConfigurationTestCaseMixin, LoaderModuleMockMix
         finally:
             if self.test_symlink_list_file_roots:
                 self.opts['file_roots'] = orig_file_roots
-
-
-class RootsLimitTraversalTest(TestCase, AdaptedConfigurationTestCaseMixin):
-
-    def test_limit_traversal(self):
-        '''
-        1) Set up a deep directory structure
-        2) Enable the configuration option 'fileserver_limit_traversal'
-        3) Ensure that we can find SLS files in a directory so long as there is
-           an SLS file in a directory above.
-        4) Ensure that we cannot find an SLS file in a directory that does not
-           have an SLS file in a directory above.
-
-        '''
-        file_client_opts = self.get_temp_config('master')
-        file_client_opts['fileserver_limit_traversal'] = True
-
-        ret = salt.fileclient.Client(file_client_opts).list_states('base')
-        self.assertIn('test_deep.test', ret)
-        self.assertIn('test_deep.a.test', ret)
-        self.assertNotIn('test_deep.b.2.test', ret)

--- a/tests/unit/test_pillar.py
+++ b/tests/unit/test_pillar.py
@@ -314,7 +314,7 @@ class PillarTestCase(TestCase):
             'extension_modules': '',
         }
         pillar = salt.pillar.Pillar(opts, {}, 'mocked-minion', 'base', pillarenv='dev')
-        self.assertEqual(pillar.opts['file_roots'],
+        self.assertEqual(pillar.opts['pillar_roots'],
                          {'base': ['/srv/pillar/base'], 'dev': ['/srv/pillar/__env__']})
 
     def test_ignored_dynamic_pillarenv(self):
@@ -329,7 +329,7 @@ class PillarTestCase(TestCase):
             'extension_modules': '',
         }
         pillar = salt.pillar.Pillar(opts, {}, 'mocked-minion', 'base', pillarenv='base')
-        self.assertEqual(pillar.opts['file_roots'], {'base': ['/srv/pillar/base']})
+        self.assertEqual(pillar.opts['pillar_roots'], {'base': ['/srv/pillar/base']})
 
     def test_malformed_pillar_sls(self):
         with patch('salt.pillar.compile_template') as compile_template:


### PR DESCRIPTION
Pillar and the local fileclient used to use the same class, but this changed a few years ago with the introduction of FSClient (which enabled non-roots fileserver backends in masterless Salt). Since Pillar is the only thing that uses this client, there is no longer a reason to make Pillar modify file_roots.

Fixes https://github.com/saltstack/salt/issues/47539