### PR TITLE
Increase centos7-py2 kitchen pr timeout to 8 hours

### DIFF
--- a/.ci/kitchen-centos7-py2
+++ b/.ci/kitchen-centos7-py2
@@ -1,4 +1,4 @@
-timeout(time: 6, unit: 'HOURS') {
+timeout(time: 8, unit: 'HOURS') {
     node('kitchen-slave') {
         timestamps {
             ansiColor('xterm') {


### PR DESCRIPTION
The centos7-py2 tests have been consistently failing to finish before
the timeout. I am increasing the timeout for these tests to 8 hours in
order to see if we can finish a few of them. They should get much closer
to finishing as the branch tests have been finishing at around the 6:30
or 7:00 mark sometimes.