### PR TITLE
Virt fixes

### DIFF
--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -4824,7 +4824,7 @@ def list_pools(**kwargs):
         conn.close()
 
 
-def pool_info(name, **kwargs):
+def pool_info(name=None, **kwargs):
     '''
     Return informations on a storage pool provided its name.
 
@@ -4832,6 +4832,8 @@ def pool_info(name, **kwargs):
     :param connection: libvirt connection URI, overriding defaults
     :param username: username to connect with, overriding defaults
     :param password: password to connect with, overriding defaults
+
+    If no name is provided, return the infos for all defined storage pools.
 
     .. versionadded:: Fluorine
 
@@ -4843,14 +4845,19 @@ def pool_info(name, **kwargs):
     '''
     result = {}
     conn = __get_conn(**kwargs)
-    try:
-        pool = conn.storagePoolLookupByName(name)
-        infos = pool.info()
+
+    def _pool_extract_infos(pool):
+        '''
+        Format the pool info dictionary
+
+        :param pool: the libvirt pool object
+        '''
         states = ['inactive', 'building', 'running', 'degraded', 'inaccessible']
+        infos = pool.info()
         state = states[infos[0]] if infos[0] < len(states) else 'unknown'
         desc = ElementTree.fromstring(pool.XMLDesc())
         path_node = desc.find('target/path')
-        result = {
+        return {
             'uuid': pool.UUIDString(),
             'state': state,
             'capacity': infos[1],
@@ -4861,6 +4868,10 @@ def pool_info(name, **kwargs):
             'target_path': path_node.text if path_node is not None else None,
             'type': desc.get('type')
         }
+
+    try:
+        pools = [pool for pool in conn.listAllStoragePools() if name is None or pool.name() == name]
+        result = {pool.name(): _pool_extract_infos(pool) for pool in pools}
     except libvirt.libvirtError as err:
         log.debug('Silenced libvirt error: %s', str(err))
     finally:

--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -4483,7 +4483,7 @@ def list_networks(**kwargs):
         conn.close()
 
 
-def network_info(name, **kwargs):
+def network_info(name=None, **kwargs):
     '''
     Return informations on a virtual network provided its name.
 
@@ -4491,6 +4491,8 @@ def network_info(name, **kwargs):
     :param connection: libvirt connection URI, overriding defaults
     :param username: username to connect with, overriding defaults
     :param password: password to connect with, overriding defaults
+
+    If no name is provided, return the infos for all defined virtual networks.
 
     .. versionadded:: Fluorine
 
@@ -4502,8 +4504,11 @@ def network_info(name, **kwargs):
     '''
     result = {}
     conn = __get_conn(**kwargs)
-    try:
-        net = conn.networkLookupByName(name)
+
+    def _net_get_leases(net):
+        '''
+        Get all DHCP leases for a network
+        '''
         leases = net.DHCPLeases()
         for lease in leases:
             if lease['type'] == libvirt.VIR_IP_ADDR_TYPE_IPV4:
@@ -4512,15 +4517,17 @@ def network_info(name, **kwargs):
                 lease['type'] = 'ipv6'
             else:
                 lease['type'] = 'unknown'
+        return leases
 
-        result = {
-            'uuid': net.UUIDString(),
-            'bridge': net.bridgeName(),
-            'autostart': net.autostart(),
-            'active': net.isActive(),
-            'persistent': net.isPersistent(),
-            'leases': leases
-        }
+    try:
+        nets = [net for net in conn.listAllNetworks() if name is None or net.name() == name]
+        result = {net.name(): {
+                       'uuid': net.UUIDString(),
+                       'bridge': net.bridgeName(),
+                       'autostart': net.autostart(),
+                       'active': net.isActive(),
+                       'persistent': net.isPersistent(),
+                       'leases': _net_get_leases(net)} for net in nets}
     except libvirt.libvirtError as err:
         log.debug('Silenced libvirt error: %s', str(err))
     finally:

--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -1377,7 +1377,7 @@ def init(name,
 
     Disk dictionaries can contain the following properties:
 
-    disk_name
+    name
         Name of the disk. This is mostly used in the name of the disk image and as a key to merge
         with the profile data.
 

--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -795,8 +795,7 @@ def _zfs_image_create(vm_name,
             .format(destination_fs, existing_disk['error'])
         )
     elif destination_fs in existing_disk:
-        log.info('ZFS filesystem {0} already exists. Skipping creation'
-                 .format(destination_fs))
+        log.info('ZFS filesystem %s already exists. Skipping creation', destination_fs)
         blockdevice_path = os.path.join('/dev/zvol', pool, vm_name)
         return blockdevice_path
 
@@ -3308,7 +3307,7 @@ def purge(vm_, dirs=False, removables=None, **kwargs):
             # TODO create solution for 'dataset is busy'
             time.sleep(3)
             fs_name = disks[disk]['file'][len('/dev/zvol/'):]
-            log.info('Destroying VM ZFS volume {0}'.format(fs_name))
+            log.info('Destroying VM ZFS volume %s', fs_name)
             __salt__['zfs.destroy'](
                     name=fs_name,
                     force=True)
@@ -3322,7 +3321,7 @@ def purge(vm_, dirs=False, removables=None, **kwargs):
         # This one is only in 1.2.8+
         try:
             dom.undefineFlags(libvirt.VIR_DOMAIN_UNDEFINE_NVRAM)
-        except Exception:
+        except libvirt.libvirtError:
             dom.undefine()
     else:
         dom.undefine()
@@ -3444,6 +3443,9 @@ def get_hypervisor():
 
 
 def _is_bhyve_hyper():
+    '''
+    Returns a bool whether or not this node is a bhyve hypervisor
+    '''
     sysctl_cmd = 'sysctl hw.vmm.create'
     vmm_enabled = False
     try:

--- a/tests/unit/modules/test_virt.py
+++ b/tests/unit/modules/test_virt.py
@@ -2145,6 +2145,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         '''
         # pylint: disable=no-member
         pool_mock = MagicMock()
+        pool_mock.name.return_value = 'foo'
         pool_mock.UUIDString.return_value = 'some-uuid'
         pool_mock.info.return_value = [0, 1234, 5678, 123]
         pool_mock.autostart.return_value = True
@@ -2166,11 +2167,11 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
     </permissions>
   </target>
 </pool>'''
-        self.mock_conn.storagePoolLookupByName.return_value = pool_mock
+        self.mock_conn.listAllStoragePools.return_value = [pool_mock]
         # pylint: enable=no-member
 
         pool = virt.pool_info('foo')
-        self.assertEqual({
+        self.assertEqual({'foo': {
             'uuid': 'some-uuid',
             'state': 'inactive',
             'capacity': 1234,
@@ -2179,7 +2180,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
             'autostart': True,
             'persistent': True,
             'type': 'dir',
-            'target_path': '/srv/vms'}, pool)
+            'target_path': '/srv/vms'}}, pool)
 
     def test_pool_info_notarget(self):
         '''
@@ -2187,6 +2188,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         '''
         # pylint: disable=no-member
         pool_mock = MagicMock()
+        pool_mock.name.return_value = 'ceph'
         pool_mock.UUIDString.return_value = 'some-uuid'
         pool_mock.info.return_value = [0, 0, 0, 0]
         pool_mock.autostart.return_value = True
@@ -2206,11 +2208,11 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
     </auth>
   </source>
 </pool>'''
-        self.mock_conn.storagePoolLookupByName.return_value = pool_mock
+        self.mock_conn.listAllStoragePools.return_value = [pool_mock]
         # pylint: enable=no-member
 
         pool = virt.pool_info('ceph')
-        self.assertEqual({
+        self.assertEqual({'ceph': {
             'uuid': 'some-uuid',
             'state': 'inactive',
             'capacity': 0,
@@ -2219,18 +2221,77 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
             'autostart': True,
             'persistent': True,
             'type': 'rbd',
-            'target_path': None}, pool)
+            'target_path': None}}, pool)
 
     def test_pool_info_notfound(self):
         '''
         Test virt.pool_info() when the pool can't be found
         '''
         # pylint: disable=no-member
-        self.mock_conn.storagePoolLookupByName.side_effect = \
-            self.mock_libvirt.libvirtError("Pool not found")
+        self.mock_conn.listAllStoragePools.return_value = []
         # pylint: enable=no-member
         pool = virt.pool_info('foo')
         self.assertEqual({}, pool)
+
+    def test_pool_info_all(self):
+        '''
+        Test virt.pool_info()
+        '''
+        # pylint: disable=no-member
+        pool_mocks = []
+        for i in range(2):
+            pool_mock = MagicMock()
+            pool_mock.name.return_value = 'pool{0}'.format(i)
+            pool_mock.UUIDString.return_value = 'some-uuid-{0}'.format(i)
+            pool_mock.info.return_value = [0, 1234, 5678, 123]
+            pool_mock.autostart.return_value = True
+            pool_mock.isPersistent.return_value = True
+            pool_mock.XMLDesc.return_value = '''<pool type='dir'>
+  <name>default</name>
+  <uuid>d92682d0-33cf-4e10-9837-a216c463e158</uuid>
+  <capacity unit='bytes'>854374301696</capacity>
+  <allocation unit='bytes'>596275986432</allocation>
+  <available unit='bytes'>258098315264</available>
+  <source>
+  </source>
+  <target>
+    <path>/srv/vms</path>
+    <permissions>
+      <mode>0755</mode>
+      <owner>0</owner>
+      <group>0</group>
+    </permissions>
+  </target>
+</pool>'''
+            pool_mocks.append(pool_mock)
+        self.mock_conn.listAllStoragePools.return_value = pool_mocks
+        # pylint: enable=no-member
+
+        pool = virt.pool_info()
+        self.assertEqual({
+            'pool0':
+            {
+                'uuid': 'some-uuid-0',
+                'state': 'inactive',
+                'capacity': 1234,
+                'allocation': 5678,
+                'free': 123,
+                'autostart': True,
+                'persistent': True,
+                'type': 'dir',
+                'target_path': '/srv/vms'
+            }, 'pool1': {
+                'uuid': 'some-uuid-1',
+                'state': 'inactive',
+                'capacity': 1234,
+                'allocation': 5678,
+                'free': 123,
+                'autostart': True,
+                'persistent': True,
+                'type': 'dir',
+                'target_path': '/srv/vms'
+            }
+        }, pool)
 
     def test_pool_list_volumes(self):
         '''

--- a/tests/unit/modules/test_virt.py
+++ b/tests/unit/modules/test_virt.py
@@ -25,6 +25,8 @@ from salt.exceptions import CommandExecutionError
 
 # Import third party libs
 from salt.ext import six
+# pylint: disable=import-error
+from salt.ext.six.moves import range  # pylint: disable=redefined-builtin
 
 
 # pylint: disable=invalid-name,protected-access,attribute-defined-outside-init,too-many-public-methods,unused-argument
@@ -1899,6 +1901,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         net_mock = MagicMock()
 
         # pylint: disable=no-member
+        net_mock.name.return_value = 'foo'
         net_mock.UUIDString.return_value = 'some-uuid'
         net_mock.bridgeName.return_value = 'br0'
         net_mock.autostart.return_value = True
@@ -1917,11 +1920,11 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
                 'iaid': None
             }
         ]
-        self.mock_conn.networkLookupByName.return_value = net_mock
+        self.mock_conn.listAllNetworks.return_value = [net_mock]
         # pylint: enable=no-member
 
         net = virt.network_info('foo')
-        self.assertEqual({
+        self.assertEqual({'foo': {
             'uuid': 'some-uuid',
             'bridge': 'br0',
             'autostart': True,
@@ -1939,15 +1942,58 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
                     'clientid': '01:52:54:00:01:71:bd',
                     'iaid': None
                 }
-            ]}, net)
+            ]}}, net)
+
+    def test_network_info_all(self):
+        '''
+        Test virt.network_info()
+        '''
+        self.mock_libvirt.VIR_IP_ADDR_TYPE_IPV4 = 0
+        self.mock_libvirt.VIR_IP_ADDR_TYPE_IPV6 = 1
+
+        net_mocks = []
+        for i in range(2):
+            net_mock = MagicMock()
+
+            # pylint: disable=no-member
+            net_mock.name.return_value = 'net{0}'.format(i)
+            net_mock.UUIDString.return_value = 'some-uuid'
+            net_mock.bridgeName.return_value = 'br{0}'.format(i)
+            net_mock.autostart.return_value = True
+            net_mock.isActive.return_value = False
+            net_mock.isPersistent.return_value = True
+            net_mock.DHCPLeases.return_value = []
+            net_mocks.append(net_mock)
+        self.mock_conn.listAllNetworks.return_value = net_mocks
+        # pylint: enable=no-member
+
+        net = virt.network_info()
+        self.assertEqual({
+            'net0':
+            {
+                'uuid': 'some-uuid',
+                'bridge': 'br0',
+                'autostart': True,
+                'active': False,
+                'persistent': True,
+                'leases': []
+            }, 'net1':
+            {
+                'uuid': 'some-uuid',
+                'bridge': 'br1',
+                'autostart': True,
+                'active': False,
+                'persistent': True,
+                'leases': []
+            }
+        }, net)
 
     def test_network_info_notfound(self):
         '''
         Test virt.network_info() when the network can't be found
         '''
         # pylint: disable=no-member
-        self.mock_conn.networkLookupByName.side_effect = \
-            self.mock_libvirt.libvirtError("Network not found")
+        self.mock_conn.listAllNetworks.return_value = []
         # pylint: enable=no-member
         net = virt.network_info('foo')
         self.assertEqual({}, net)


### PR DESCRIPTION
### What does this PR do?

This PR brings a few changes to features of the virt execution module introduced for fluorine:
`network_info` and `pool_info` are return the data for all networks or pools if no name is provided.
Thus the output of these calls has been slightly modified to include the names of the networks/pools.

This PR also includes doc and pylint fixes

Note that we may want to backport this fo Fluorine (at least the tiny doc fix) to avoid later disruptive change.

### What issues does this PR fix or reference?

None

### Previous Behavior

The name parameter in `virt.network_info` and `virt.pool_info` where mandatory.
The output returned the info as a dict.

### New Behavior

The name parameter in `virt.network_info` and `virt.pool_info` is now optional.
The output returns dicts following this scheme:

    { 'thename': previously_return_dict}

### Tests written?

Yes

### Commits signed with GPG?

Yes