### PR TITLE
Elasticsearch returner update

### DIFF
--- a/salt/returners/elasticsearch_return.py
+++ b/salt/returners/elasticsearch_return.py
@@ -287,7 +287,7 @@ def returner(ret):
         # not in a dict as expected. This prevents elasticsearch from
         # complaining about a mapping error
         elif not isinstance(ret['data'], dict):
-            ret['data'] = { job_fun_escaped: { 'return': ret['data'] } }
+            ret['data'] = {job_fun_escaped: {'return': ret['data']}}
 
         # Need to count state successes and failures
         if options['states_count']:
@@ -385,12 +385,12 @@ def save_load(jid, load, minions=None):
 
     _ensure_index(index)
 
-    # addressing multiple types (bool, string, dict, ...) issue in master_job_cache index for return key (#20826) 
-    if not load.get('return', None) is None: 
+    # addressing multiple types (bool, string, dict, ...) issue in master_job_cache index for return key (#20826)
+    if not load.get('return', None) is None:
         # if load.return is not a dict, moving the result to load.return.<job_fun_escaped>.return
         if not isinstance(load['return'], dict):
             job_fun_escaped = load['fun'].replace('.', '_')
-            load['return'] = { job_fun_escaped: { 'return': load['return'] } }
+            load['return'] = {job_fun_escaped: {'return': load['return']}}
         # rename load.return to load.data in order to have the same key in all indices (master_job_cache, job)
         load['data'] = load.pop('return')
 

--- a/salt/returners/elasticsearch_return.py
+++ b/salt/returners/elasticsearch_return.py
@@ -226,7 +226,7 @@ def returner(ret):
         )
         return
 
-    if ret.get('return', None) is None:
+    if ret.get('data', None) is None:
         log.info(
             'Won\'t push new data to Elasticsearch, job with jid=%s was '
             'not successful', job_id
@@ -254,23 +254,23 @@ def returner(ret):
                 'failed':   0,
             }
 
-        # Prepend each state execution key in ret['return'] with a zero-padded
+        # Prepend each state execution key in ret['data'] with a zero-padded
         # version of the '__run_num__' field allowing the states to be ordered
         # more easily. Change the index to be
         # index to be '<index>-ordered' so as not to clash with the unsorted
         # index data format
-        if options['states_order_output'] and isinstance(ret['return'], dict):
+        if options['states_order_output'] and isinstance(ret['data'], dict):
             index = '{0}-ordered'.format(index)
-            max_chars = len(six.text_type(len(ret['return'])))
+            max_chars = len(six.text_type(len(ret['data'])))
 
-            for uid, data in six.iteritems(ret['return']):
+            for uid, data in six.iteritems(ret['data']):
                 # Skip keys we've already prefixed
                 if uid.startswith(tuple('0123456789')):
                     continue
 
                 # Store the function being called as it's a useful key to search
                 decoded_uid = uid.split('_|-')
-                ret['return'][uid]['_func'] = '{0}.{1}'.format(
+                ret['data'][uid]['_func'] = '{0}.{1}'.format(
                     decoded_uid[0],
                     decoded_uid[-1]
                 )
@@ -281,17 +281,17 @@ def returner(ret):
                     uid,
                 )
 
-                ret['return'][new_uid] = ret['return'].pop(uid)
+                ret['data'][new_uid] = ret['data'].pop(uid)
 
         # Catch a state output that has failed and where the error message is
         # not in a dict as expected. This prevents elasticsearch from
         # complaining about a mapping error
-        elif not isinstance(ret['return'], dict):
-            ret['return'] = {'return': ret['return']}
+        elif not isinstance(ret['data'], dict):
+            ret['data'] = { job_fun_escaped: { 'return': ret['data'] } }
 
         # Need to count state successes and failures
         if options['states_count']:
-            for state_data in ret['return'].values():
+            for state_data in ret['data'].values():
                 if state_data['result'] is False:
                     counts['failed'] += 1
                 else:
@@ -320,7 +320,7 @@ def returner(ret):
         'fun': job_fun,
         'jid': job_id,
         'counts': counts,
-        'data': _convert_keys(ret['return'])
+        'data': _convert_keys(ret['data'])
     }
 
     if options['debug_returner_payload']:
@@ -379,7 +379,20 @@ def save_load(jid, load, minions=None):
     index = options['master_job_cache_index']
     doc_type = options['master_job_cache_doc_type']
 
+    if options['index_date']:
+        index = '{0}-{1}'.format(index,
+            datetime.date.today().strftime('%Y.%m.%d'))
+
     _ensure_index(index)
+
+    # addressing multiple types (bool, string, dict, ...) issue in master_job_cache index for return key (#20826) 
+    if not load.get('return', None) is None: 
+        # if load.return is not a dict, moving the result to load.return.<job_fun_escaped>.return
+        if not isinstance(load['return'], dict):
+            job_fun_escaped = load['fun'].replace('.', '_')
+            load['return'] = { job_fun_escaped: { 'return': load['return'] } }
+        # rename load.return to load.data in order to have the same key in all indices (master_job_cache, job)
+        load['data'] = load.pop('return')
 
     data = {
         'jid': jid,
@@ -403,9 +416,14 @@ def get_load(jid):
     index = options['master_job_cache_index']
     doc_type = options['master_job_cache_doc_type']
 
+    if options['index_date']:
+        index = '{0}-{1}'.format(index,
+            datetime.date.today().strftime('%Y.%m.%d'))
+
     data = __salt__['elasticsearch.document_get'](index=index,
                                                   id=jid,
                                                   doc_type=doc_type)
     if data:
-        return salt.utils.json.loads(data)
+        # Use salt.utils.json.dumps to convert elasticsearch unicode json to standard json
+        return salt.utils.json.loads(salt.utils.json.dumps(data))
     return {}


### PR DESCRIPTION
### What does this PR do?
this PR:
- fixes load.return multiple types issue in salt-master-job-cache index (bool for test.ping, string for cmd.run and dict for state.apply)
- fixes "[WARNING ] Returner unavailable: expected string or buffer message" returned by get_load function
- adds date to salt-master-job-cache index name if index_date is True
- replaces load.return by load.data in salt-master-job-cache index in order to have the same key in all indices (master-job-cache and jobs indices)

### What issues does this PR fix or reference?
The 1st fix addresses multiple types issues discussed in #20826

### Previous Behavior
Elasticsearch returner directly puts to load.return key of salt-master-job-cache index the return value.

### New Behavior
Now if the return value is not a dictionary, a dictionary is created with inside a key named with an escaped string of load.fun then inside the return value
```
"load": {
  "return": <return_value>
}
```
-->
```
"load": {
  "data": {
    "<escaped_job_function_name>": {
      "return": <return_value>
    }
  }
}
```

### Tests written?
No
Tested with test.ping, cmd.run and state.apply

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
