### PR TITLE
https://github.com/saltstack/salt/issues/49883

### DIFF
--- a/salt/cloud/clouds/azurearm.py
+++ b/salt/cloud/clouds/azurearm.py
@@ -854,7 +854,7 @@ def create_network_interface(call=None, kwargs=None):
                 )
                 if pub_ip_data.ip_address:  # pylint: disable=no-member
                     ip_kwargs['public_ip_address'] = PublicIPAddress(
-                        six.text_type(pub_ip_data.id),  # pylint: disable=no-member
+                        id=six.text_type(pub_ip_data.id),  # pylint: disable=no-member
                     )
                     ip_configurations = [
                         NetworkInterfaceIPConfiguration(


### PR DESCRIPTION
Using named argument in `PublicIPAddress` azure network_models API call

### What does this PR do?
Fixes azure network api usage when creating public IP

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/49883

### Previous Behavior
```
[ERROR   ] There was a profile error: __init__() takes exactly 1 argument (2 given)
Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/salt/cloud/cli.py", line 281, in run
    self.config.get('names')
  File "/usr/lib/python2.7/dist-packages/salt/cloud/__init__.py", line 1454, in run_profile
    ret[name] = self.create(vm_)
  File "/usr/lib/python2.7/dist-packages/salt/cloud/__init__.py", line 1284, in create
    output = self.clouds[func](vm_)
  File "/var/cache/salt/master/extmods/clouds/azurearm.py", line 1418, in create
    vm_request = request_instance(vm_=vm_)
  File "/var/cache/salt/master/extmods/clouds/azurearm.py", line 1013, in request_instance
    kwargs=vm_
  File "/var/cache/salt/master/extmods/clouds/azurearm.py", line 859, in create_network_interface
    six.text_type(pub_ip_data.id),  # pylint: disable=no-member
TypeError: __init__() takes exactly 1 argument (2 given)
```