### PR TITLE
Only check against changed files

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -222,6 +222,7 @@ verifier:
   name: runtests
   sudo: true
   run_destructive: true
+  enable_filenames: true
   transport: zeromq
   types:
     - ssh


### PR DESCRIPTION
This should make PR's run only the tests related to files that have
changed in the PR.

@gtmanfred @terminalmage 

This does rely on the kitchen-salt release, which is out, so we're good there.