### PR TITLE
Passed kwargs to db_exists in db_remove method

### DIFF
--- a/salt/modules/mssql.py
+++ b/salt/modules/mssql.py
@@ -175,7 +175,7 @@ def db_remove(database_name, **kwargs):
         salt minion mssql.db_remove database_name='DBNAME'
     '''
     try:
-        if db_exists(database_name) and database_name not in ['master', 'model', 'msdb', 'tempdb']:
+        if db_exists(database_name, **kwargs) and database_name not in ['master', 'model', 'msdb', 'tempdb']:
             conn = _get_connection(**kwargs)
             conn.autocommit(True)
             cur = conn.cursor()


### PR DESCRIPTION
### What does this PR do?
Add kwargs to the db_exists function call

### What issues does this PR fix or reference?
The function db_remove fails because the call to the dbexists function needs kwargs to connect to the db if you're passing all connection parameters from cli.

### Previous Behavior
db_remove function fails passing connection parameters from cli

### New Behavior
db_remove works

### Tests written?
No

### Commits signed with GPG?

No