### PR TITLE
Add multi-file support and globbing to the filetree

### DIFF
--- a/salt/cli/support/intfunc.py
+++ b/salt/cli/support/intfunc.py
@@ -6,6 +6,7 @@ Internal functions.
 
 from __future__ import absolute_import, print_function, unicode_literals
 import os
+import glob
 from salt.cli.support.console import MessagesOutput
 import salt.utils.files
 
@@ -21,9 +22,15 @@ def filetree(collector, *paths):
     :param path: File or directory
     :return:
     '''
+    _paths = []
+    # Unglob
     for path in paths:
+        _paths += glob.glob(path)
+    for path in set(_paths):
         if not path:
             out.error('Path not defined', ident=2)
+        elif not os.path.exists(path):
+            out.warning('Path {} does not exists'.format(path))
         else:
             # The filehandler needs to be explicitly passed here, so PyLint needs to accept that.
             # pylint: disable=W8470
@@ -37,12 +44,10 @@ def filetree(collector, *paths):
                 except Exception as err:
                     out.error(err, ident=4)
             # pylint: enable=W8470
-            elif os.path.exists(path):
+            else:
                 try:
                     for fname in os.listdir(path):
                         fname = os.path.join(path, fname)
                         filetree(collector, [fname])
                 except Exception as err:
                     out.error(err, ident=4)
-            else:
-                out.warning('Path {} does not exists'.format(path))

--- a/salt/cli/support/intfunc.py
+++ b/salt/cli/support/intfunc.py
@@ -36,7 +36,9 @@ def filetree(collector, path):
             except Exception as err:
                 out.error(err, ident=4)
         # pylint: enable=W8470
-        else:
+        elif os.path.exists(path):
             for fname in os.listdir(path):
                 fname = os.path.join(path, fname)
                 filetree(collector, fname)
+        else:
+            out.warning('Path {} does not exists'.format(path))

--- a/salt/cli/support/intfunc.py
+++ b/salt/cli/support/intfunc.py
@@ -13,7 +13,7 @@ import salt.utils.files
 out = MessagesOutput()
 
 
-def filetree(collector, path):
+def filetree(collector, *paths):
     '''
     Add all files in the tree. If the "path" is a file,
     only that file will be added.
@@ -21,24 +21,28 @@ def filetree(collector, path):
     :param path: File or directory
     :return:
     '''
-    if not path:
-        out.error('Path not defined', ident=2)
-    else:
-        # The filehandler needs to be explicitly passed here, so PyLint needs to accept that.
-        # pylint: disable=W8470
-        if os.path.isfile(path):
-            filename = os.path.basename(path)
-            try:
-                file_ref = salt.utils.files.fopen(path)  # pylint: disable=W
-                out.put('Add {}'.format(filename), indent=2)
-                collector.add(filename)
-                collector.link(title=path, path=file_ref)
-            except Exception as err:
-                out.error(err, ident=4)
-        # pylint: enable=W8470
-        elif os.path.exists(path):
-            for fname in os.listdir(path):
-                fname = os.path.join(path, fname)
-                filetree(collector, fname)
+    for path in paths:
+        if not path:
+            out.error('Path not defined', ident=2)
         else:
-            out.warning('Path {} does not exists'.format(path))
+            # The filehandler needs to be explicitly passed here, so PyLint needs to accept that.
+            # pylint: disable=W8470
+            if os.path.isfile(path):
+                filename = os.path.basename(path)
+                try:
+                    file_ref = salt.utils.files.fopen(path)  # pylint: disable=W
+                    out.put('Add {}'.format(filename), indent=2)
+                    collector.add(filename)
+                    collector.link(title=path, path=file_ref)
+                except Exception as err:
+                    out.error(err, ident=4)
+            # pylint: enable=W8470
+            elif os.path.exists(path):
+                try:
+                    for fname in os.listdir(path):
+                        fname = os.path.join(path, fname)
+                        filetree(collector, [fname])
+                except Exception as err:
+                    out.error(err, ident=4)
+            else:
+                out.warning('Path {} does not exists'.format(path))

--- a/salt/cli/support/profiles/default.yml
+++ b/salt/cli/support/profiles/default.yml
@@ -66,8 +66,7 @@ boot_log:
   - filetree:
       info: Collect boot logs
       args:
-        - /var/log/boot.log
-        - /var/log/boot.msg
+        - /var/log/boot.*
 
 system.log:
   # This works on any file system object.
@@ -75,8 +74,5 @@ system.log:
       info: Add system log
       args:
         - /var/log/syslog
-  - filetree:
-      info: Add messages log
-      args:
         - /var/log/messages
 

--- a/salt/cli/support/profiles/default.yml
+++ b/salt/cli/support/profiles/default.yml
@@ -62,10 +62,21 @@ general-health:
   - ps.top:
       info: Top CPU consuming processes
 
+boot_log:
+  - filetree:
+      info: Collect boot logs
+      args:
+        - /var/log/boot.log
+        - /var/log/boot.msg
+
 system.log:
   # This works on any file system object.
   - filetree:
       info: Add system log
       args:
         - /var/log/syslog
+  - filetree:
+      info: Add messages log
+      args:
+        - /var/log/messages
 


### PR DESCRIPTION
### What does this PR do?

- Feature for support conf
- Prevents crash, if file does not exists :fearful: 

### Previous Behavior

Before `filetree` collector could take only _one_ file or the entire directory. In order to take several files you would need to repeat it, like this:

```yaml
system.log:
   - filetree:
      info: Collect syslog
         - /var/log/syslog
   - filetree:
      info: Collect messages log
         - /var/log/messages
```

### New Behavior

Added support for:

- Several files at once
- Patterns (yay!)

Example
```yaml
boot.log:
   - filetree:
      info: Collect boot logs
         - /var/log/boot.*

system.log:
   - filetree:
      info: Collect system logs
         - /var/log/syslog
         - /var/log/messages
```

### Tests written?

No (should pass existing)

