### PR TITLE
Add a `windowsdomaintype` grain

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1203,6 +1203,7 @@ def _windows_platform_data():
     #    osfullname
     #    timezone
     #    windowsdomain
+    #    windowsdomaintype
     #    motherboard.productname
     #    motherboard.serialnumber
     #    virtual

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1234,6 +1234,7 @@ def _windows_platform_data():
         os_release = platform.release()
         kernel_version = platform.version()
         info = salt.utils.win_osinfo.get_os_version_info()
+        net_info = salt.utils.win_osinfo.get_join_info()
         server = {'Vista': '2008Server',
                   '7': '2008ServerR2',
                   '8': '2012Server',
@@ -1268,7 +1269,8 @@ def _windows_platform_data():
             'serialnumber': _clean_value('serialnumber', biosinfo.SerialNumber),
             'osfullname': _clean_value('osfullname', osinfo.Caption),
             'timezone': _clean_value('timezone', timeinfo.Description),
-            'windowsdomain': _clean_value('windowsdomain', systeminfo.Domain),
+            'windowsdomain': _clean_value('windowsdomain', net_info['Domain']),
+            'windowsdomaintype': _clean_value('windowsdomaintype', net_info['DomainType']),
             'motherboard': {
                 'productname': _clean_value('motherboard.productname', motherboard['product']),
                 'serialnumber': _clean_value('motherboard.serialnumber', motherboard['serial']),

--- a/salt/modules/win_system.py
+++ b/salt/modules/win_system.py
@@ -18,6 +18,7 @@ from __future__ import absolute_import, unicode_literals, print_function
 import ctypes
 import logging
 import time
+import platform
 from datetime import datetime
 
 # Import salt libs
@@ -513,11 +514,28 @@ def get_system_info():
 
         salt 'minion-id' system.get_system_info
     '''
+    def byte_calc(val):
+        val = float(val)
+        if val < 2**10:
+            return '{0:.3f}B'.format(val)
+        elif val < 2**20:
+            return '{0:.3f}KB'.format(val / 2**10)
+        elif val < 2**30:
+            return '{0:.3f}MB'.format(val / 2**20)
+        elif val < 2**40:
+            return '{0:.3f}GB'.format(val / 2**30)
+        else:
+            return '{0:.3f}TB'.format(val / 2**40)
+
+    # Connect to WMI
+    pythoncom.CoInitialize()
+    conn = wmi.WMI()
+
+    # Lookup dicts for Win32_OperatingSystem
     os_type = {1: 'Work Station',
                2: 'Domain Controller',
                3: 'Server'}
-    pythoncom.CoInitialize()
-    conn = wmi.WMI()
+
     system = conn.Win32_OperatingSystem()[0]
     ret = {'name': get_computer_name(),
            'description': system.Description,
@@ -535,12 +553,73 @@ def get_system_info():
            'system_drive': system.SystemDrive,
            'os_version': system.Version,
            'windows_directory': system.WindowsDirectory}
+
+    # lookup dicts for Win32_ComputerSystem
+    domain_role = {0: 'Standalone Workstation',
+                   1: 'Member Workstation',
+                   2: 'Standalone Server',
+                   3: 'Member Server',
+                   4: 'Backup Domain Controller',
+                   5: 'Primary Domain Controller'}
+    warning_states = {1: 'Other',
+                      2: 'Unknown',
+                      3: 'Safe',
+                      4: 'Warning',
+                      5: 'Critical',
+                      6: 'Non-recoverable'}
+    pc_system_types = {0: 'Unspecified',
+                       1: 'Desktop',
+                       2: 'Mobile',
+                       3: 'Workstation',
+                       4: 'Enterprise Server',
+                       5: 'SOHO Server',
+                       6: 'Appliance PC',
+                       7: 'Performance Server',
+                       8: 'Maximum'}
     system = conn.Win32_ComputerSystem()[0]
-    ret.update({'hardware_manufacturer': system.Manufacturer,
-                'hardware_model': system.Model,
-                'processors': system.NumberOfProcessors,
-                'processors_logical': system.NumberOfLogicalProcessors,
-                'system_type': system.SystemType})
+    # Get pc_system_type depending on Windows version
+    if platform.release() in ['Vista', '7', '8']:
+        # Types for Vista, 7, and 8
+        pc_system_type = pc_system_types[system.PCSystemType]
+    else:
+        # New types were added with 8.1 and newer
+        pc_system_types.update({8: 'Slate', 9: 'Maximum'})
+        pc_system_type = pc_system_types[system.PCSystemType]
+    ret.update({
+        'bootup_state': system.BootupState,
+        'caption': system.Caption,
+        'chassis_bootup_state': warning_states[system.ChassisBootupState],
+        'chassis_sku_number': system.ChassisSKUNumber,
+        'dns_hostname': system.DNSHostname,
+        'domain': system.Domain,
+        'domain_role': domain_role[system.DomainRole],
+        'hardware_manufacturer': system.Manufacturer,
+        'hardware_model': system.Model,
+        'network_server_mode_enabled': system.NetworkServerModeEnabled,
+        'part_of_domain': system.PartOfDomain,
+        'pc_system_type': pc_system_type,
+        'power_state': system.PowerState,
+        'status': system.Status,
+        'system_type': system.SystemType,
+        'total_physical_memory': byte_calc(system.TotalPhysicalMemory),
+        'total_physical_memory_raw': system.TotalPhysicalMemory,
+        'thermal_state': warning_states[system.ThermalState],
+        'workgroup': system.Workgroup
+    })
+    # Get processor information
+    processors = conn.Win32_Processor()
+    ret['processors'] = 0
+    ret['processors_logical'] = 0
+    ret['processor_cores'] = 0
+    ret['processor_cores_enabled'] = 0
+    ret['processor_manufacturer'] = processors[0].Manufacturer
+    ret['processor_max_clock_speed'] = six.text_type(processors[0].MaxClockSpeed) + 'MHz'
+    for system in processors:
+        ret['processors'] += 1
+        ret['processors_logical'] += system.NumberOfLogicalProcessors
+        ret['processor_cores'] += system.NumberOfCores
+        ret['processor_cores_enabled'] += system.NumberOfEnabledCore
+
     system = conn.Win32_BIOS()[0]
     ret.update({'hardware_serial': system.SerialNumber,
                 'bios_manufacturer': system.Manufacturer,

--- a/salt/utils/win_osinfo.py
+++ b/salt/utils/win_osinfo.py
@@ -7,9 +7,11 @@ from __future__ import absolute_import, print_function, unicode_literals
 
 # Import Third Party Libs
 import ctypes
+HAS_WIN32 = True
 try:
     from ctypes.wintypes import BYTE, WORD, DWORD, WCHAR
-    HAS_WIN32 = True
+    import win32net
+    import win32netcon
 except (ImportError, ValueError):
     HAS_WIN32 = False
 
@@ -76,3 +78,22 @@ def get_os_version_info():
            'ProductType': info.wProductType}
 
     return ret
+
+
+def get_join_info():
+    '''
+    Gets information about the domain/workgroup. This will tell you if the
+    system is joined to a domain or a workgroup
+
+    .. version-added:: 2018.3.4
+
+    Returns:
+        dict: A dictionary containing the domain/workgroup and it's status
+    '''
+    info = win32net.NetGetJoinInformation()
+    status = {win32netcon.NetSetupUnknown: 'Unknown',
+              win32netcon.NetSetupUnjoined: 'Unjoined',
+              win32netcon.NetSetupWorkgroupName: 'Workgroup',
+              win32netcon.NetSetupDomainName: 'Domain'}
+    return {'Domain': info[0],
+            'DomainType': status[info[1]]}

--- a/tests/unit/grains/test_core.py
+++ b/tests/unit/grains/test_core.py
@@ -583,6 +583,27 @@ class CoreGrainsTestCase(TestCase, LoaderModuleMockMixin):
         }
         self._run_os_grains_tests("ubuntu-17.10", _os_release_map, expectation)
 
+    @skipIf(not salt.utils.platform.is_windows(), 'System is not Windows')
+    def test_windows_platform_data(self):
+        '''
+        Test the _windows_platform_data function
+        '''
+        grains = ['biosversion', 'kernelrelease', 'kernelversion',
+                  'manufacturer', 'motherboard', 'osfullname', 'osmanufacturer',
+                  'osrelease', 'osservicepack', 'osversion', 'productname',
+                  'serialnumber', 'timezone', 'virtual', 'windowsdomain',
+                  'windowsdomaintype']
+        returned_grains = core._windows_platform_data()
+        for grain in grains:
+            self.assertIn(grain, returned_grains)
+
+        valid_types = ['Unknown', 'Unjoined', 'Workgroup', 'Domain']
+        self.assertIn(returned_grains['windowsdomaintype'], valid_types)
+        valid_releases = ['Vista', '7', '8', '8.1', '10', '2008Server',
+                          '2008ServerR2', '2012Server', '2012ServerR2',
+                          '2016Server']
+        self.assertIn(returned_grains['osrelease'], valid_releases)
+
     @skipIf(not salt.utils.platform.is_linux(), 'System is not Linux')
     def test_linux_memdata(self):
         '''

--- a/tests/unit/modules/test_win_system.py
+++ b/tests/unit/modules/test_win_system.py
@@ -55,7 +55,7 @@ class WinSystemTestCase(TestCase, LoaderModuleMockMixin):
         self.assertEqual(win_system.init(3),
                          'Not implemented on Windows at this time.')
 
-    @skipIf(not win_system.HAS_WIN32NET_MODS, 'this test needs the w32net library')
+    @skipIf(not win_system.HAS_WIN32NET_MODS, 'Missing win32 libraries')
     def test_poweroff(self):
         '''
             Test to poweroff a running system
@@ -64,7 +64,7 @@ class WinSystemTestCase(TestCase, LoaderModuleMockMixin):
         with patch.object(win_system, 'shutdown', mock):
             self.assertEqual(win_system.poweroff(), 'salt')
 
-    @skipIf(not win_system.HAS_WIN32NET_MODS, 'this test needs the w32net library')
+    @skipIf(not win_system.HAS_WIN32NET_MODS, 'Missing win32 libraries')
     def test_reboot(self):
         '''
             Test to reboot the system
@@ -73,7 +73,7 @@ class WinSystemTestCase(TestCase, LoaderModuleMockMixin):
                    MagicMock(return_value=True)) as shutdown:
             self.assertEqual(win_system.reboot(), True)
 
-    @skipIf(not win_system.HAS_WIN32NET_MODS, 'this test needs the w32net library')
+    @skipIf(not win_system.HAS_WIN32NET_MODS, 'Missing win32 libraries')
     def test_reboot_with_timeout_in_minutes(self):
         '''
             Test to reboot the system with a timeout
@@ -84,7 +84,7 @@ class WinSystemTestCase(TestCase, LoaderModuleMockMixin):
             shutdown.assert_called_with(timeout=5, in_seconds=False, reboot=True,
                                         only_on_pending_reboot=False)
 
-    @skipIf(not win_system.HAS_WIN32NET_MODS, 'this test needs the w32net library')
+    @skipIf(not win_system.HAS_WIN32NET_MODS, 'Missing win32 libraries')
     def test_reboot_with_timeout_in_seconds(self):
         '''
             Test to reboot the system with a timeout
@@ -95,7 +95,7 @@ class WinSystemTestCase(TestCase, LoaderModuleMockMixin):
             shutdown.assert_called_with(timeout=5, in_seconds=True, reboot=True,
                                         only_on_pending_reboot=False)
 
-    @skipIf(not win_system.HAS_WIN32NET_MODS, 'this test needs the w32net library')
+    @skipIf(not win_system.HAS_WIN32NET_MODS, 'Missing win32 libraries')
     def test_reboot_with_wait(self):
         '''
             Test to reboot the system with a timeout and
@@ -108,7 +108,7 @@ class WinSystemTestCase(TestCase, LoaderModuleMockMixin):
             self.assertEqual(win_system.reboot(wait_for_reboot=True), True)
             time.assert_called_with(330)
 
-    @skipIf(not win_system.HAS_WIN32NET_MODS, 'this test needs the w32net library')
+    @skipIf(not win_system.HAS_WIN32NET_MODS, 'Missing win32 libraries')
     def test_shutdown(self):
         '''
             Test to shutdown a running system
@@ -117,7 +117,7 @@ class WinSystemTestCase(TestCase, LoaderModuleMockMixin):
                    MagicMock()):
             self.assertEqual(win_system.shutdown(), True)
 
-    @skipIf(not win_system.HAS_WIN32NET_MODS, 'this test needs the w32net library')
+    @skipIf(not win_system.HAS_WIN32NET_MODS, 'Missing win32 libraries')
     def test_shutdown_hard(self):
         '''
             Test to shutdown a running system with no timeout or warning
@@ -127,7 +127,7 @@ class WinSystemTestCase(TestCase, LoaderModuleMockMixin):
             self.assertEqual(win_system.shutdown_hard(), True)
             shutdown.assert_called_with(timeout=0)
 
-    @skipIf(not win_system.HAS_WIN32NET_MODS, 'this test needs the w32net library')
+    @skipIf(not win_system.HAS_WIN32NET_MODS, 'Missing win32 libraries')
     def test_set_computer_name(self):
         '''
             Test to set the Windows computer name
@@ -146,7 +146,7 @@ class WinSystemTestCase(TestCase, LoaderModuleMockMixin):
                    MagicMock(return_value=False)):
             self.assertFalse(win_system.set_computer_name("salt"))
 
-    @skipIf(not win_system.HAS_WIN32NET_MODS, 'this test needs the w32net library')
+    @skipIf(not win_system.HAS_WIN32NET_MODS, 'Missing win32 libraries')
     def test_get_pending_computer_name(self):
         '''
             Test to get a pending computer name.
@@ -162,7 +162,7 @@ class WinSystemTestCase(TestCase, LoaderModuleMockMixin):
                 self.assertEqual(win_system.get_pending_computer_name(),
                                  'salt_pending')
 
-    @skipIf(not win_system.HAS_WIN32NET_MODS, 'this test needs the w32net library')
+    @skipIf(not win_system.HAS_WIN32NET_MODS, 'Missing win32 libraries')
     def test_get_computer_name(self):
         '''
             Test to get the Windows computer name
@@ -172,7 +172,7 @@ class WinSystemTestCase(TestCase, LoaderModuleMockMixin):
             self.assertEqual(win_system.get_computer_name(), 'computer name')
             self.assertFalse(win_system.get_computer_name())
 
-    @skipIf(not win_system.HAS_WIN32NET_MODS, 'this test needs the w32net library')
+    @skipIf(not win_system.HAS_WIN32NET_MODS, 'Missing win32 libraries')
     def test_set_computer_desc(self):
         '''
             Test to set the Windows computer description
@@ -186,7 +186,7 @@ class WinSystemTestCase(TestCase, LoaderModuleMockMixin):
                                                                   ),
                                      {'Computer Description': "Salt's comp"})
 
-    @skipIf(not win_system.HAS_WIN32NET_MODS, 'this test needs the w32net library')
+    @skipIf(not win_system.HAS_WIN32NET_MODS, 'Missing win32 libraries')
     def test_get_computer_desc(self):
         '''
             Test to get the Windows computer description
@@ -197,7 +197,7 @@ class WinSystemTestCase(TestCase, LoaderModuleMockMixin):
             self.assertEqual(win_system.get_computer_desc(), 'salt description')
             self.assertFalse(win_system.get_computer_desc())
 
-    @skipIf(not win_system.HAS_WIN32NET_MODS, 'this test needs w32net and other windows libraries')
+    @skipIf(not win_system.HAS_WIN32NET_MODS, 'Missing win32 libraries')
     def test_join_domain(self):
         '''
             Test to join a computer to an Active Directory domain
@@ -230,7 +230,7 @@ class WinSystemTestCase(TestCase, LoaderModuleMockMixin):
             import re
             self.assertTrue(re.search(r'^\d{2}:\d{2} \w{2}$', win_tm))
 
-    @skipIf(not win_system.HAS_WIN32NET_MODS, 'this test needs the w32net library')
+    @skipIf(not win_system.HAS_WIN32NET_MODS, 'Missing win32 libraries')
     def test_set_system_time(self):
         '''
             Test to set system time
@@ -247,7 +247,7 @@ class WinSystemTestCase(TestCase, LoaderModuleMockMixin):
         date = datetime.strftime(datetime.now(), "%m/%d/%Y")
         self.assertEqual(win_system.get_system_date(), date)
 
-    @skipIf(not win_system.HAS_WIN32NET_MODS, 'this test needs the w32net library')
+    @skipIf(not win_system.HAS_WIN32NET_MODS, 'Missing win32 libraries')
     def test_set_system_date(self):
         '''
             Test to set system date
@@ -295,6 +295,7 @@ class WinSystemTestCase(TestCase, LoaderModuleMockMixin):
             self.assertEqual(ret, "MINION")
         cmd_run_mock.assert_called_once_with(cmd="hostname")
 
+    @skipIf(not win_system.HAS_WIN32NET_MODS, 'Missing win32 libraries')
     def test_get_system_info(self):
         fields = ['bios_caption', 'bios_description', 'bios_details',
                   'bios_manufacturer', 'bios_version', 'bootup_state',

--- a/tests/unit/modules/test_win_system.py
+++ b/tests/unit/modules/test_win_system.py
@@ -294,3 +294,41 @@ class WinSystemTestCase(TestCase, LoaderModuleMockMixin):
             ret = win_system.get_hostname()
             self.assertEqual(ret, "MINION")
         cmd_run_mock.assert_called_once_with(cmd="hostname")
+
+    def test_get_system_info(self):
+        fields = ['bios_caption', 'bios_description', 'bios_details',
+                  'bios_manufacturer', 'bios_version', 'bootup_state',
+                  'caption', 'chassis_bootup_state', 'chassis_sku_number',
+                  'description', 'dns_hostname', 'domain', 'domain_role',
+                  'hardware_manufacturer', 'hardware_model', 'hardware_serial',
+                  'install_date', 'last_boot', 'name',
+                  'network_server_mode_enabled', 'organization',
+                  'os_architecture', 'os_manufacturer', 'os_name', 'os_type',
+                  'os_version', 'part_of_domain', 'pc_system_type',
+                  'power_state', 'primary', 'processor_cores',
+                  'processor_cores_enabled', 'processor_manufacturer',
+                  'processor_max_clock_speed', 'processors',
+                  'processors_logical', 'registered_user', 'status',
+                  'system_directory', 'system_drive', 'system_type',
+                  'thermal_state', 'total_physical_memory',
+                  'total_physical_memory_raw', 'users', 'windows_directory',
+                  'workgroup']
+        ret = win_system.get_system_info()
+        # Make sure all the fields are in the return
+        for field in fields:
+            self.assertIn(field, ret)
+        # os_type
+        os_types = ['Work Station', 'Domain Controller', 'Server']
+        self.assertIn(ret['os_type'], os_types)
+        domain_roles = ['Standalone Workstation', 'Member Workstation',
+                        'Standalone Server', 'Member Server',
+                        'Backup Domain Controller', 'Primary Domain Controller']
+        self.assertIn(ret['domain_role'], domain_roles)
+        system_types = ['Unspecified', 'Desktop', 'Mobile', 'Workstation',
+                        'Enterprise Server', 'SOHO Server', 'Appliance PC',
+                        'Performance Server', 'Slate', 'Maximum']
+        self.assertIn(ret['pc_system_type'], system_types)
+        warning_states = ['Other', 'Unknown', 'Safe', 'Warning', 'Critical',
+                          'Non-recoverable']
+        self.assertIn(ret['chassis_bootup_state'], warning_states)
+        self.assertIn(ret['thermal_state'], warning_states)

--- a/tests/unit/utils/test_win_osinfo.py
+++ b/tests/unit/utils/test_win_osinfo.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+'''
+:codeauthor: Shane Lee <slee@saltstack.com>
+'''
+# Import Python Libs
+from __future__ import absolute_import, unicode_literals, print_function
+import sys
+
+# Import 3rd Party Libs
+from salt.ext import six
+
+# Import Salt Testing Libs
+from tests.support.unit import TestCase, skipIf
+from tests.support.mock import (
+    NO_MOCK,
+    NO_MOCK_REASON
+)
+
+# Import Salt Libs
+import salt.utils.win_osinfo as win_osinfo
+import salt.utils.platform
+
+
+@skipIf(not salt.utils.platform.is_windows(), 'Requires Windows')
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class WinOsInfo(TestCase):
+    '''
+    Test cases for salt/utils/win_osinfo.py
+    '''
+    def test_get_os_version_info(self):
+        sys_info = sys.getwindowsversion()
+        get_info = win_osinfo.get_os_version_info()
+        self.assertEqual(sys_info.major, int(get_info['MajorVersion']))
+        self.assertEqual(sys_info.minor, int(get_info['MinorVersion']))
+        self.assertEqual(sys_info.platform, int(get_info['PlatformID']))
+        self.assertEqual(sys_info.build, int(get_info['BuildNumber']))
+        # Platform ID is the reason for this function
+        # Since we can't get the actual value another way, we will just check
+        # that it exists and is a number
+        self.assertIn('PlatformID', get_info)
+        self.assertTrue(isinstance(get_info['BuildNumber'], six.integer_types))
+
+    def test_get_join_info(self):
+        join_info = win_osinfo.get_join_info()
+        self.assertIn('Domain', join_info)
+        self.assertIn('DomainType', join_info)
+        valid_types = ['Unknown', 'Unjoined', 'Workgroup', 'Domain']
+        self.assertIn(join_info['DomainType'], valid_types)


### PR DESCRIPTION
### What does this PR do?
Adds the `windowsdomaintype` grain
Adds the get_join_info util to populate said grain
Adds additional information to the output of `get_system_info` since we're already pulling the data anyway with the WMI call

### What issues does this PR fix or reference?
SSE Support

### Tests written?
No

### Commits signed with GPG?
Yes