### PR TITLE
Make test check_pillar more lenient

### DIFF
--- a/salt/states/test.py
+++ b/salt/states/test.py
@@ -334,7 +334,7 @@ def _check_key_type(key_str, key_type=None):
     value = __salt__['pillar.get'](key_str, None)
     if value is None:
         return None
-    elif type(value) is not key_type and key_type is not None:
+    elif key_type is not None and not isinstance(value, key_type):
         return False
     else:
         return True
@@ -415,7 +415,7 @@ def check_pillar(name,
     checks[int] = integer
     # those should be str:
     string = _if_str_then_list(string)
-    checks[str] = string
+    checks[six.string_types] = string
     # those should be list:
     listing = _if_str_then_list(listing)
     checks[list] = listing

--- a/tests/unit/states/test_test.py
+++ b/tests/unit/states/test_test.py
@@ -19,6 +19,8 @@ from tests.support.mock import (
 # Import Salt Libs
 from salt.exceptions import SaltInvocationError
 import salt.states.test as test
+from salt.utils.odict import OrderedDict
+from salt.ext import six
 
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
@@ -310,6 +312,48 @@ class TestTestCase(TestCase, LoaderModuleMockMixin):
         with patch.dict(test.__salt__, {'pillar.get': pillar_mock}):
             self.assertEqual(test.check_pillar('salt', present='my_pillar'), ret)
 
+    def test_check_pillar_string(self):
+        '''
+            Test to ensure the check_pillar function
+            works properly with the 'key_type' checks,
+            using the string key_type.
+        '''
+        ret = {
+            'name': 'salt',
+            'changes': {},
+            'result': True,
+            'comment': ''
+        }
+        pillar_return = 'I am a pillar.'
+        pillar_mock = MagicMock(return_value=pillar_return)
+        with patch.dict(test.__salt__, {'pillar.get': pillar_mock}):
+            self.assertEqual(test.check_pillar('salt', string='my_pillar'), ret)
+        # With unicode (py2) or str (py3) strings
+        pillar_return = six.text_type('I am a pillar.')
+        pillar_mock = MagicMock(return_value=pillar_return)
+        with patch.dict(test.__salt__, {'pillar.get': pillar_mock}):
+            self.assertEqual(test.check_pillar('salt', string='my_pillar'), ret)
+        # With a dict
+        pillar_return = {'this': 'dictionary'}
+        pillar_mock = MagicMock(return_value=pillar_return)
+        with patch.dict(test.__salt__, {'pillar.get': pillar_mock}):
+            self.assertFalse(test.check_pillar('salt', string='my_pillar')['result'])
+        # With a list
+        pillar_return = ['I am a pillar.']
+        pillar_mock = MagicMock(return_value=pillar_return)
+        with patch.dict(test.__salt__, {'pillar.get': pillar_mock}):
+            self.assertFalse(test.check_pillar('salt', string='my_pillar')['result'])
+        # With a boolean
+        pillar_return = True
+        pillar_mock = MagicMock(return_value=pillar_return)
+        with patch.dict(test.__salt__, {'pillar.get': pillar_mock}):
+            self.assertFalse(test.check_pillar('salt', string='my_pillar')['result'])
+        # With an int
+        pillar_return = 1
+        pillar_mock = MagicMock(return_value=pillar_return)
+        with patch.dict(test.__salt__, {'pillar.get': pillar_mock}):
+            self.assertFalse(test.check_pillar('salt', string='my_pillar')['result'])
+
     def test_check_pillar_dictionary(self):
         '''
             Test to ensure the check_pillar function
@@ -326,3 +370,28 @@ class TestTestCase(TestCase, LoaderModuleMockMixin):
         pillar_mock = MagicMock(return_value=pillar_return)
         with patch.dict(test.__salt__, {'pillar.get': pillar_mock}):
             self.assertEqual(test.check_pillar('salt', dictionary='my_pillar'), ret)
+        # With an ordered dict
+        pillar_return = OrderedDict({'this': 'dictionary'})
+        pillar_mock = MagicMock(return_value=pillar_return)
+        with patch.dict(test.__salt__, {'pillar.get': pillar_mock}):
+            self.assertEqual(test.check_pillar('salt', dictionary='my_pillar'), ret)
+        # With a string
+        pillar_return = 'I am a pillar.'
+        pillar_mock = MagicMock(return_value=pillar_return)
+        with patch.dict(test.__salt__, {'pillar.get': pillar_mock}):
+            self.assertFalse(test.check_pillar('salt', dictionary='my_pillar')['result'])
+        # With a list
+        pillar_return = ['I am a pillar.']
+        pillar_mock = MagicMock(return_value=pillar_return)
+        with patch.dict(test.__salt__, {'pillar.get': pillar_mock}):
+            self.assertFalse(test.check_pillar('salt', dictionary='my_pillar')['result'])
+        # With a boolean
+        pillar_return = True
+        pillar_mock = MagicMock(return_value=pillar_return)
+        with patch.dict(test.__salt__, {'pillar.get': pillar_mock}):
+            self.assertFalse(test.check_pillar('salt', dictionary='my_pillar')['result'])
+        # With an int
+        pillar_return = 1
+        pillar_mock = MagicMock(return_value=pillar_return)
+        with patch.dict(test.__salt__, {'pillar.get': pillar_mock}):
+            self.assertFalse(test.check_pillar('salt', dictionary='my_pillar')['result'])


### PR DESCRIPTION
### What does this PR do?

It makes the test.check_pillar state a bit more lenient when it comes to pillar loaded in using flat files. These values can be loaded as OrderedDict's and unicode strings, where currently the state checks for dict and str types only.

### What issues does this PR fix or reference?

I did not create a corresponding issue since this was an extremely easy fix, but I can.

### Previous Behavior

Using flat pillar files would load as OrderedDict's and unicode strings for me (not sure if this is just due to our current setup). These would fail simple test.check_pillar tests for dictionary and string types.

### New Behavior

These values are seen as correct by test.check_pillar and pass with no issues.

### Tests written?

Yes, and added a new test for the string types.

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
