### PR TITLE
Jenkins CI Lint Improvements

### DIFF
--- a/.ci/lint
+++ b/.ci/lint
@@ -24,11 +24,10 @@ pipeline {
                 sh '''
                 # Need -M to detect renames otherwise they are reported as Delete and Add, need -C to detect copies, -C includes -M
                 # -M is on by default in git 2.9+
-                git diff --name-status -C "origin/$CHANGE_TARGET" "origin/$BRANCH_NAME" > file-list-status.log
-                # '--diff-filter=ACMRTUXB' can be changed to '--diff-filter=d' when git version >=1.8.5 is available
-                # on renames --name-only outputs the destination only
-                git diff --name-only '--diff-filter=ACMRTUXB' -C "origin/$CHANGE_TARGET" "origin/$BRANCH_NAME" > file-list-changed.log
-                git diff --name-only '--diff-filter=D' -C "origin/$CHANGE_TARGET" "origin/$BRANCH_NAME" > file-list-deleted.log
+                git diff --name-status -l99999 -C "origin/$CHANGE_TARGET" "origin/$BRANCH_NAME" > file-list-status.log
+                # the -l increase the search limit, lets use awk so we do not need to repeat the search above.
+                gawk 'BEGIN {FS="\\t"} {if ($1 != "D") {print $NF}}' file-list-status.log > file-list-changed.log
+                gawk 'BEGIN {FS="\\t"} {if ($1 == "D") {print $NF}}' file-list-status.log > file-list-deleted.log
                 touch pylint-report-salt.log pylint-report-tests.log
                 eval "$(pyenv init -)"
                 pyenv --version

--- a/.ci/lint
+++ b/.ci/lint
@@ -22,6 +22,14 @@ pipeline {
         stage('setup') {
             steps {
                 sh '''
+                # Need -M to detect renames otherwise they are reported as Delete and Add, need -C to detect copies, -C includes -M
+                # -M is on by default in git 2.9+
+                git diff --name-status -C "origin/$CHANGE_TARGET" "origin/$BRANCH_NAME" > file-list-status.log
+                # '--diff-filter=ACMRTUXB' can be changed to '--diff-filter=d' when git version >=1.8.5 is available
+                # on renames --name-only outputs the destination only
+                git diff --name-only '--diff-filter=ACMRTUXB' -C "origin/$CHANGE_TARGET" "origin/$BRANCH_NAME" > file-list-changed.log
+                git diff --name-only '--diff-filter=D' -C "origin/$CHANGE_TARGET" "origin/$BRANCH_NAME" > file-list-deleted.log
+                touch pylint-report-salt.log pylint-report-tests.log
                 eval "$(pyenv init -)"
                 pyenv --version
                 pyenv install --skip-existing 2.7.14
@@ -30,40 +38,38 @@ pipeline {
                 python --version
                 pip install tox
                 '''
+                archiveArtifacts artifacts: 'file-list-status.log,file-list-changed.log,file-list-deleted.log'
             }
         }
         stage('linting') {
             failFast false
             parallel {
                 stage('salt linting') {
+                    when {
+                        expression { return readFile('file-list-changed.log') =~ /(?i)(^|\n)(salt\/.*\.py|setup\.py)\n/ }
+                    }
                     steps {
                         sh '''
                         eval "$(pyenv init - --no-rehash)"
-                        _FILES="$(find salt/ -name "*.py" -exec git diff --name-only "origin/$CHANGE_TARGET" "origin/$BRANCH_NAME" {} +)"
-                        _FILES="$_FILES $(git diff --name-only "origin/$CHANGE_TARGET" "origin/$BRANCH_NAME" setup.py)"
-                        if [[ -z ${_FILES} ]]; then
-                            echo "No pylint run, no changes found in the files"
-                            echo "empty" pylint-reports.xml
-                        else
-                            tox -e pylint-salt ${_FILES} | tee pylint-report.xml
-                        fi
+                        grep -Ei '^salt/.*\\.py$|^setup\\.py$' file-list-changed.log | xargs -r '--delimiter=\\n' tox -e pylint-salt | tee pylint-report-salt.log
+                        # remove color escape coding
+                        sed -ri 's/\\x1B\\[([0-9]{1,2}(;[0-9]{1,2})?)?[m|K]//g' pylint-report-salt.log
                         '''
-                        archiveArtifacts artifacts: 'pylint-report.xml'
+                        archiveArtifacts artifacts: 'pylint-report-salt.log'
                     }
                 }
                 stage('test linting') {
+                    when {
+                        expression { return readFile('file-list-changed.log') =~ /(?i)(^|\n)tests\/.*\.py\n/ }
+                    }
                     steps {
                         sh '''
                         eval "$(pyenv init - --no-rehash)"
-                        _FILES="$(find tests/ -name "*.py" -exec git diff --name-only "origin/$CHANGE_TARGET" "origin/$BRANCH_NAME" setup.py {} +)"
-                        if [[ -z ${_FILES} ]]; then
-                            echo "No pylint run, no changes found in the files"
-                            touch pylint-report-tests.xml
-                        else
-                            tox -e pylint-tests ${_FILES} | tee pylint-report-tests.xml
-                        fi
+                        grep -Ei '^tests/.*\\.py$' file-list-changed.log | xargs -r '--delimiter=\\n' tox -e pylint-tests | tee pylint-report-tests.log
+                        # remove color escape coding
+                        sed -ri 's/\\x1B\\[([0-9]{1,2}(;[0-9]{1,2})?)?[m|K]//g' pylint-report-tests.log
                         '''
-                        archiveArtifacts artifacts: 'pylint-report-tests.xml'
+                        archiveArtifacts artifacts: 'pylint-report-tests.log'
                     }
                 }
             }
@@ -74,7 +80,7 @@ pipeline {
             step([$class: 'WarningsPublisher',
                 parserConfigurations: [[
                     parserName: 'PyLint',
-                    pattern: 'pylint-report*.xml'
+                    pattern: 'pylint-report*.log'
                 ]],
                 failedTotalAll: '0',
                 useDeltaValues: false,


### PR DESCRIPTION
### What does this PR do?
Improvements in .ci/lint
* Change the output extension from .xml to .log (plain text) so Jenkins sends the correct mime type to browsers.
* Remove the colour escape codes from the logs, so Artifact  does not contain them, but the console output record by Jenkins does. 
* Store an Artifact of which files have changed, and also the files which have been deleted, for debugging/verifying the files that have been reviewed by pylint.
*Remove the need to use find to scan the file system and call git multiple times. (small decrease in overhead)
*Only run a stage if required.

### What issues does this PR fix or reference?
Some general improvements.
