### PR TITLE
Fix #50015, Windows grain defaults to physical as unix grain

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -445,7 +445,7 @@ def _windows_virtual(osdata):
     grains = dict()
     if osdata['kernel'] != 'Windows':
         return grains
-    
+
     grains['virtual'] = 'physical'
 
     # It is possible that the 'manufacturer' and/or 'productname' grains

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -445,6 +445,8 @@ def _windows_virtual(osdata):
     grains = dict()
     if osdata['kernel'] != 'Windows':
         return grains
+    
+    grains['virtual'] = 'physical'
 
     # It is possible that the 'manufacturer' and/or 'productname' grains
     # exist but have a value of None.


### PR DESCRIPTION
### What does this PR do?
Changes Windows "virtual" grain to default to physical. 

### What issues does this PR fix or reference?
Issue #50015 
### Previous Behavior
No key for virtual is currently being returned and it causes errors if the grain is used in a multi-platform environment that includes windows.
### New Behavior
The Windows "virtual" assumes phyisical unless a specific type of vm is detected, matching the unix grain behavior.

