### PR TITLE
[fluorine] Updates to integration.sdb.test_vault

### DIFF
--- a/tests/integration/sdb/test_vault.py
+++ b/tests/integration/sdb/test_vault.py
@@ -31,7 +31,7 @@ class VaultTestCase(ModuleCase, ShellCase):
         '''
         SetUp vault container
         '''
-        if self.count == 0:
+        if VaultTestCase.count == 0:
             config = '{"backend": {"file": {"path": "/vault/file"}}, "default_lease_ttl": "168h", "max_lease_ttl": "720h"}'
             self.run_state('docker_image.present', name='vault', tag='0.9.6')
             self.run_state(
@@ -51,8 +51,31 @@ class VaultTestCase(ModuleCase, ShellCase):
                 cmd='/usr/local/bin/vault login token=testsecret',
                 env={'VAULT_ADDR': 'http://127.0.0.1:8200'},
             )
-            if ret != 0:
-                self.skipTest('unable to login to vault')
+            login_attempts = 1
+            # If the login failed, container might have stopped
+            # attempt again, maximum of three times before
+            # skipping.
+            while ret != 0:
+                self.run_state(
+                    'docker_container.running',
+                    name='vault',
+                    image='vault:0.9.6',
+                    port_bindings='8200:8200',
+                    environment={
+                        'VAULT_DEV_ROOT_TOKEN_ID': 'testsecret',
+                        'VAULT_LOCAL_CONFIG': config,
+                    },
+                    cap_add='IPC_LOCK',
+                )
+                time.sleep(5)
+                ret = self.run_function(
+                    'cmd.retcode',
+                    cmd='/usr/local/bin/vault login token=testsecret',
+                    env={'VAULT_ADDR': 'http://127.0.0.1:8200'},
+                )
+                login_attempts += 1
+                if login_attempts >= 3:
+                    self.skipTest('unable to login to vault')
             ret = self.run_function(
                 'cmd.retcode',
                 cmd='/usr/local/bin/vault policy write testpolicy {0}/vault.hcl'.format(FILES),
@@ -60,7 +83,7 @@ class VaultTestCase(ModuleCase, ShellCase):
             )
             if ret != 0:
                 self.skipTest('unable to assign policy to vault')
-        self.count += 1
+        VaultTestCase.count += 1
 
     def tearDown(self):
         '''
@@ -69,7 +92,7 @@ class VaultTestCase(ModuleCase, ShellCase):
         def count_tests(funcobj):
             return inspect.ismethod(funcobj) and funcobj.__name__.startswith('test_')
         numtests = len(inspect.getmembers(VaultTestCase, predicate=count_tests))
-        if self.count >= numtests:
+        if VaultTestCase.count >= numtests:
             self.run_state('docker_container.stopped', name='vault')
             self.run_state('docker_container.absent', name='vault')
             self.run_state('docker_image.absent', name='vault', force=True)

--- a/tests/integration/sdb/test_vault.py
+++ b/tests/integration/sdb/test_vault.py
@@ -90,7 +90,9 @@ class VaultTestCase(ModuleCase, ShellCase):
         TearDown vault container
         '''
         def count_tests(funcobj):
-            return inspect.ismethod(funcobj) and funcobj.__name__.startswith('test_')
+            return inspect.ismethod(funcobj) or \
+                inspect.isfunction(funcobj) and \
+                funcobj.__name__.startswith('test_')
         numtests = len(inspect.getmembers(VaultTestCase, predicate=count_tests))
         if VaultTestCase.count >= numtests:
             self.run_state('docker_container.stopped', name='vault')


### PR DESCRIPTION
### What does this PR do?
Updating the integration.sdb.test_vault setup function to attempt to recreate the container if the login test fails.  Also updating the internal counter to use VaultTestCase instead of self, following a successful run when all tests ran, the vault container was not stopped and deleted because the counter was not being incremented properly.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/pull/49878

### Previous Behavior
The first test run in the integration.sdb.test_vault test would randomly fail because the vault container was not running.

### New Behavior
Try to recreate the vault container if the initial login attempt fails.  Try a maximum of three times before skipping the test.

### Tests written?
Yes. Existing tests updated.

### Commits signed with GPG?

Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
