### PR TITLE
[WIP] Fix grains file test on Windows

### DIFF
--- a/tests/integration/states/test_file.py
+++ b/tests/integration/states/test_file.py
@@ -155,6 +155,7 @@ class FileTest(ModuleCase, SaltReturnAssertsMixin):
             except OSError as exc:
                 if exc.errno != errno.ENOENT:
                     log.error('Failed to remove %s: %s', path, exc)
+        salt.utils.files.rm_rf('/tmp/salt-tests-tmpdir')
 
     def test_symlink(self):
         '''
@@ -354,10 +355,18 @@ class FileTest(ModuleCase, SaltReturnAssertsMixin):
         Test to ensure we can render grains data into a managed
         file.
         '''
-        grain_path = os.path.join(TMP, 'file-grain-test')
+        grain_path = '/tmp/salt-tests-tmpdir/file-grain-test'
+        try:
+            os.makedirs(os.path.dirname(grain_path))
+        except OSError as exc:
+            log.exception(
+                "Exception creating test dir %s",
+                os.path.dirname(grain_path),
+            )
         state_file = 'file-grainget'
 
-        self.run_function('state.sls', [state_file])
+        ret = self.run_function('state.sls', [state_file])
+        log.debug("RET is %s", ret)
         self.assertTrue(os.path.exists(grain_path))
 
         with salt.utils.files.fopen(grain_path, 'r') as fp_:

--- a/tests/integration/states/test_file.py
+++ b/tests/integration/states/test_file.py
@@ -143,12 +143,13 @@ class FileTest(ModuleCase, SaltReturnAssertsMixin):
     '''
 
     def setUp(self):
+        self.grain_path = '/tmp/salt-tests-tmpdir'
         try:
-            os.makedirs('/tmp/salt-tests-tmpdir')
+            os.makedirs(self.grain_path)
         except OSError as exc:
             log.exception(
                 "Exception creating test tmp dir %s",
-                os.path.dirname(grain_path),
+                os.path.dirname(self.grain_path),
             )
 
     def tearDown(self):
@@ -165,7 +166,7 @@ class FileTest(ModuleCase, SaltReturnAssertsMixin):
             except OSError as exc:
                 if exc.errno != errno.ENOENT:
                     log.error('Failed to remove %s: %s', path, exc)
-        salt.utils.files.rm_rf('/tmp/salt-tests-tmpdir')
+        salt.utils.files.rm_rf(self.grain_path)
 
     def test_symlink(self):
         '''
@@ -365,7 +366,7 @@ class FileTest(ModuleCase, SaltReturnAssertsMixin):
         Test to ensure we can render grains data into a managed
         file.
         '''
-        grain_path = '/tmp/salt-tests-tmpdir/file-grain-test'
+        grain_path = '{}/file-grain-test'.format(self.grain_path)
         state_file = 'file-grainget'
 
         ret = self.run_function('state.sls', [state_file])

--- a/tests/integration/states/test_file.py
+++ b/tests/integration/states/test_file.py
@@ -141,6 +141,16 @@ class FileTest(ModuleCase, SaltReturnAssertsMixin):
     '''
     Validate the file state
     '''
+
+    def setUp(self):
+        try:
+            os.makedirs('/tmp/salt-tests-tmpdir')
+        except OSError as exc:
+            log.exception(
+                "Exception creating test tmp dir %s",
+                os.path.dirname(grain_path),
+            )
+
     def tearDown(self):
         '''
         remove files created in previous tests
@@ -356,13 +366,6 @@ class FileTest(ModuleCase, SaltReturnAssertsMixin):
         file.
         '''
         grain_path = '/tmp/salt-tests-tmpdir/file-grain-test'
-        try:
-            os.makedirs(os.path.dirname(grain_path))
-        except OSError as exc:
-            log.exception(
-                "Exception creating test dir %s",
-                os.path.dirname(grain_path),
-            )
         state_file = 'file-grainget'
 
         ret = self.run_function('state.sls', [state_file])


### PR DESCRIPTION
### What does this PR do?

The `grain_create_file` state uses the `grain_path` grain which is set to `grain_path: /tmp/salt-tests-tmpdir/file-grain-test` in the minion config. This PR fixes the `test_managed_file_with_grains_data` test on Windows:

https://jenkinsci.saltstack.com/job/2018.3/job/salt-windows-2016-py2/15/


### Tests written?

No

### Commits signed with GPG?

Yes