### PR TITLE
Fluorine backport of virt module fixes

### DIFF
--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -1263,7 +1263,7 @@ def init(name,
 
     Disk dictionaries can contain the following properties:
 
-    disk_name
+    name
         Name of the disk. This is mostly used in the name of the disk image and as a key to merge
         with the profile data.
 


### PR DESCRIPTION
### What does this PR do?

Backport PR #49994 

### What issues does this PR fix or reference?

None

### Previous Behavior

The name parameter in `virt.network_info` and `virt.pool_info` where mandatory.
The output returned the info as a dict.

### New Behavior

The name parameter in `virt.network_info` and `virt.pool_info` is now optional.
The output returns dicts following this scheme:

    { 'thename': previously_return_dict}

### Tests written?

Yes

### Commits signed with GPG?

Yes
