### PR TITLE
Don't squash the traceback

### DIFF
--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -1182,7 +1182,7 @@ class LocalClient(object):
                 # stop the iteration, since the jid is invalid
                 raise StopIteration()
         except Exception as exc:
-            log.warning('Returner unavailable: %s', exc)
+            log.warning('Returner unavailable: %s', exc, exc_info_on_loglevel=logging.DEBUG)
         # Wait for the hosts to check in
         last_time = False
         # iterator for this job's return


### PR DESCRIPTION
### What does this PR do?
Shows the traceback instead of squashing it when logging at the debug level