### PR TITLE
Don't throw exceptions just because tablespace exists

### DIFF
--- a/salt/states/postgres_tablespace.py
+++ b/salt/states/postgres_tablespace.py
@@ -118,14 +118,14 @@ def present(name,
             return ret
 
     # already exists, make sure it's got the right config
-    if tblspaces[name]['Location'] != directory and not __opts__['test']:
+    if name in tblspaces and tblspaces[name]['Location'] != directory and not __opts__['test']:
         ret['comment'] = """Tablespace {0} is not at the right location. This is
             unfixable without dropping and recreating the tablespace.""".format(
                 name)
         ret['result'] = False
         return ret
 
-    if owner and not tblspaces[name]['Owner'] == owner:
+    if owner and name in tblspaces and not tblspaces[name]['Owner'] == owner:
         if __opts__['test']:
             ret['result'] = None
             ret['comment'] = 'Tablespace {0} owner to be altered'.format(name)


### PR DESCRIPTION
### What does this PR do?

Resolves 'KeyError' exception.

### What issues does this PR fix or reference?

See https://github.com/saltstack-formulas/postgres-formula/issues/186

### Previous Behavior
'KeyError` if object already exists

### New Behavior
No  'KeyError' if object pre-exists.

### Tests written?

No

Manual tested:
https://github.com/saltstack-formulas/postgres-formula/issues/186#issuecomment-429872828

### Commits signed with GPG?

Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
