### PR TITLE
add http basis auth

### DIFF
--- a/salt/pillar/http_yaml.py
+++ b/salt/pillar/http_yaml.py
@@ -13,7 +13,6 @@ Set the following Salt config to setup an http endpoint as the external pillar s
   ext_pillar:
     - http_yaml:
         url: http://example.com/api/minion_id
-        ::TODO::
         username: username
         password: password
 
@@ -67,12 +66,15 @@ def __virtual__():
 def ext_pillar(minion_id,
                pillar,  # pylint: disable=W0613
                url,
-               with_grains=False):
+               with_grains=False,
+               **kwargs):
     '''
     Read pillar data from HTTP response.
 
     :param str url: Url to request.
     :param bool with_grains: Whether to substitute strings in the url with their grain values.
+    :param str username: Username for http basic auth
+    :param str password: Password for http basic auth
 
     :return: A dictionary of the pillar data to add.
     :rtype: dict
@@ -97,7 +99,12 @@ def ext_pillar(minion_id,
             url = re.sub('<{0}>'.format(grain_name), grain_value, url)
 
     log.debug('Getting url: %s', url)
-    data = __salt__['http.query'](url=url, decode=True, decode_type='yaml')
+
+    if 'username' in kwargs and 'password' in kwargs:
+        data = __salt__['http.query'](url=url, decode=True, decode_type='yaml',
+                                      username=kwargs['username'], password=kwargs['password'])
+    else:
+        data = __salt__['http.query'](url=url, decode=True, decode_type='yaml')
 
     if 'dict' in data:
         return data['dict']

--- a/salt/pillar/http_yaml.py
+++ b/salt/pillar/http_yaml.py
@@ -66,9 +66,9 @@ def __virtual__():
 def ext_pillar(minion_id,
                pillar,  # pylint: disable=W0613
                url,
+               with_grains=False,
                username=None,
-               password=None,
-               with_grains=False):
+               password=None):
     '''
     Read pillar data from HTTP response.
 

--- a/salt/pillar/http_yaml.py
+++ b/salt/pillar/http_yaml.py
@@ -66,8 +66,9 @@ def __virtual__():
 def ext_pillar(minion_id,
                pillar,  # pylint: disable=W0613
                url,
-               with_grains=False,
-               **kwargs):
+               username=None,
+               password=None,
+               with_grains=False):
     '''
     Read pillar data from HTTP response.
 
@@ -100,11 +101,7 @@ def ext_pillar(minion_id,
 
     log.debug('Getting url: %s', url)
 
-    if 'username' in kwargs and 'password' in kwargs:
-        data = __salt__['http.query'](url=url, decode=True, decode_type='yaml',
-                                      username=kwargs['username'], password=kwargs['password'])
-    else:
-        data = __salt__['http.query'](url=url, decode=True, decode_type='yaml')
+    data = __salt__['http.query'](url=url, username=username, password=password, decode=True, decode_type='yaml')
 
     if 'dict' in data:
         return data['dict']


### PR DESCRIPTION
Adds username and password parameters for the http call.

### What does this PR do?

It adds the option to use http-basis-auth with the http_yaml pillar module. 

### What issues does this PR fix or reference?

The username and password parameters are marked as TODO in the current Documentation and i tried to implement them with this PR. 

