### PR TITLE
Preserving signature in "module.run" state

### DIFF
--- a/salt/states/module.py
+++ b/salt/states/module.py
@@ -323,7 +323,7 @@ def _call_function(name, returner=None, **kwargs):
 
     # func_args is initialized to a list of positional arguments that the function to be run accepts
     func_args = argspec.args[:len(argspec.args or []) - len(argspec.defaults or [])]
-    arg_type, na_type, kw_type = [], {}, False
+    arg_type, kw_to_arg_type, na_type, kw_type = [], {}, {}, False
     for funcset in reversed(kwargs.get('func_args') or []):
         if not isinstance(funcset, dict):
             # We are just receiving a list of args to the function to be run, so just append
@@ -334,13 +334,16 @@ def _call_function(name, returner=None, **kwargs):
                 # We are going to pass in a keyword argument. The trick here is to make certain
                 # that if we find that in the *args* list that we pass it there and not as a kwarg
                 if kwarg_key in func_args:
-                    arg_type.append(funcset[kwarg_key])
+                    kw_to_arg_type[kwarg_key] = funcset[kwarg_key]
                     continue
                 else:
                     # Otherwise, we're good and just go ahead and pass the keyword/value pair into
                     # the kwargs list to be run.
                     func_kw.update(funcset)
     arg_type.reverse()
+    for arg in func_args:
+        if arg in kw_to_arg_type:
+            arg_type.append(kw_to_arg_type[arg])
     _exp_prm = len(argspec.args or []) - len(argspec.defaults or [])
     _passed_prm = len(arg_type)
     missing = []


### PR DESCRIPTION
### What does this PR do?

Bugfix for: https://github.com/saltstack/salt/issues/49295

### Previous Behavior

Keyword argument's ordering was still by order, not by key. That is, with the signature of `(src, dst)` these two statements were equal (and thus wrong):

```
foo:
  module.run
    - file.copy
      - dst: /tmp/dst
      - src: /tmp/src

bar:
  module.run
    - file.copy
      - /tmp/dst
      - /tmp/src
```

Expected behaviour is that `src` should be prior to `dst`, regardless how it is positioned, as long as it is designated with the key. Positional arguments only should be according to their order in the second example.

### New Behaviour

Function signature is now respected. For e.g. `file.copy(src, dst, **kw)`, these statements are all equally aligned to src/dst ordering:

```
foo:
  module.run
    - file.copy
      - dst: /tmp/dst
      - src: /tmp/src

foo:
  module.run
    - file.copy
      - src: /tmp/src
      - dst: /tmp/dst

fred:
  module.run
    - file.copy
      - /tmp/src
      - /tmp/dst
```


### Tests written?

No (existing should apply)
