### PR TITLE
https://github.com/saltstack/salt/issues/49945

### DIFF
--- a/salt/beacons/telegram_bot_msg.py
+++ b/salt/beacons/telegram_bot_msg.py
@@ -89,10 +89,11 @@ def beacon(config):
 
     latest_update_id = 0
     for update in updates:
+
         if update.message:
-          message = update.message
+            message = update.message
         else:
-          message = update.edited_message
+            message = update.edited_message
 
         if update.update_id > latest_update_id:
             latest_update_id = update.update_id

--- a/salt/beacons/telegram_bot_msg.py
+++ b/salt/beacons/telegram_bot_msg.py
@@ -89,7 +89,10 @@ def beacon(config):
 
     latest_update_id = 0
     for update in updates:
-        message = update.message
+        if update.message:
+          message = update.message
+        else:
+          message = update.edited_message
 
         if update.update_id > latest_update_id:
             latest_update_id = update.update_id


### PR DESCRIPTION
Key received from telegram can be "message" or "edited_message"

Resulting in the following message:
2018-10-05 17:07:28,740 [salt.minion :2494][CRITICAL][17641] The beacon errored:
Traceback (most recent call last):
File "/usr/lib/python2.7/dist-packages/salt/minion.py", line 2492, in handle_beacons
beacons = self.process_beacons(self.functions)
File "/usr/lib/python2.7/dist-packages/salt/minion.py", line 444, in process_beacons
return self.beacons.process(b_conf, self.opts['grains']) # pylint: disable=no-member
File "/usr/lib/python2.7/dist-packages/salt/beacons/init.py", line 112, in process
raw = self.beaconsfun_str
File "/usr/lib/python2.7/dist-packages/salt/beacons/telegram_bot_msg.py", line 98, in beacon
if message.chat.username in _config['accept_from']:
AttributeError: 'NoneType' object has no attribute 'chat'

Fixes saltstack#49945

### What does this PR do?
Fix error message AttributeError: 'NoneType' object has no attribute 'chat'
### What issues does this PR fix or reference?
#49945

### Tests written?

No

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
