### PR TITLE
[2018.3] Fix some pylint issues that have popped up recently

### DIFF
--- a/salt/engines/slack.py
+++ b/salt/engines/slack.py
@@ -593,7 +593,7 @@ class SlackClient(object):
         Run each of them through ``get_configured_target(('foo', f), 'pillar.get')`` and confirm a valid target
 
         '''
-        # Default to targetting all minions with a type of glob
+        # Default to targeting all minions with a type of glob
         null_target = {'target': '*', 'tgt_type': 'glob'}
 
         def check_cmd_against_group(cmd):
@@ -627,14 +627,12 @@ class SlackClient(object):
                 return checked
         return null_target
 
-
-# emulate the yaml_out output formatter.  It relies on a global __opts__ object which we can't
-# obviously pass in
-
     def format_return_text(self, data, function, **kwargs):  # pylint: disable=unused-argument
         '''
         Print out YAML using the block mode
         '''
+        # emulate the yaml_out output formatter. It relies on a global __opts__ object which
+        # we can't obviously pass in
         try:
             # Format results from state runs with highstate output
             if function.startswith('state'):

--- a/salt/modules/consul.py
+++ b/salt/modules/consul.py
@@ -214,7 +214,7 @@ def get(consul_url=None, key=None, token=None, recurse=False, decode=False, raw=
     if ret['res']:
         if decode:
             for item in ret['data']:
-                if item['Value'] != None:
+                if item['Value'] is not None:
                     item['Value'] = base64.b64decode(item['Value'])
                 else:
                     item['Value'] = ""

--- a/salt/modules/lxc.py
+++ b/salt/modules/lxc.py
@@ -4689,7 +4689,7 @@ def get_pid(name, path=None):
     if name not in list_(limit='running', path=path):
         raise CommandExecutionError('Container {0} is not running, can\'t determine PID'.format(name))
     info = __salt__['cmd.run']('lxc-info -n {0}'.format(name)).split("\n")
-    pid = [line.split(':')[1].strip() for line in info if re.match(r'\s*PID', line) != None][0]
+    pid = [line.split(':')[1].strip() for line in info if re.match(r'\s*PID', line) is not None][0]
     return pid
 
 

--- a/salt/modules/win_lgpo.py
+++ b/salt/modules/win_lgpo.py
@@ -4337,7 +4337,7 @@ def _writeAdminTemplateRegPolFile(admtemplate_data,
                                   adml_policy_resources=None,
                                   display_language='en-US',
                                   registry_class='Machine'):
-    u'''
+    r'''
     helper function to prep/write adm template data to the Registry.pol file
 
     each file begins with REGFILE_SIGNATURE (u'\u5250\u6765') and


### PR DESCRIPTION
```
13:19:51 [salt linting] ************* Module salt.engines.slack
13:19:51 [salt linting] salt/engines/slack.py:634: [E8301(expected-1-blank-line-found-0), ] PEP8 E301: expected 1 blank line, found 0
13:19:51 [salt linting] ************* Module salt.modules.consul
13:19:51 [salt linting] salt/modules/consul.py:217: [E8711(comparison-to-None-should-be-if-cond-is-None), ] PEP8 E711: comparison to None should be 'if cond is None:'
13:19:51 [salt linting] ************* Module salt.modules.lxc
13:19:51 [salt linting] salt/modules/lxc.py:4692: [E8711(comparison-to-None-should-be-if-cond-is-None), ] PEP8 E711: comparison to None should be 'if cond is None:'
13:19:51 [salt linting] ************* Module salt.modules.win_lgpo
13:19:51 [salt linting] salt/modules/win_lgpo.py:4340: [E1400(null-byte-unicode-literal), ] Null byte used in unicode string literal (should be wrapped in str())
```