### PR TITLE
Use long when setting REG_QWORD

### DIFF
--- a/salt/utils/win_reg.py
+++ b/salt/utils/win_reg.py
@@ -767,6 +767,9 @@ def cast_vdata(vdata=None, vtype='REG_SZ'):
     # Make sure REG_MULTI_SZ is a list of strings
     elif vtype_value == win32con.REG_MULTI_SZ:
         return [_to_unicode(i) for i in vdata]
+    # Make sure REG_QWORD is a 64 bit integer
+    elif vtype_value == win32con.REG_QWORD:
+        return vdata if six.PY3 else long(vdata)
     # Everything else is int
     else:
         return int(vdata)

--- a/salt/utils/win_reg.py
+++ b/salt/utils/win_reg.py
@@ -769,7 +769,7 @@ def cast_vdata(vdata=None, vtype='REG_SZ'):
         return [_to_unicode(i) for i in vdata]
     # Make sure REG_QWORD is a 64 bit integer
     elif vtype_value == win32con.REG_QWORD:
-        return vdata if six.PY3 else long(vdata)
+        return vdata if six.PY3 else long(vdata)  # pylint: disable=W1699
     # Everything else is int
     else:
         return int(vdata)

--- a/tests/unit/utils/test_win_reg.py
+++ b/tests/unit/utils/test_win_reg.py
@@ -308,6 +308,74 @@ class WinFunctionsTestCase(TestCase):
             win_reg.delete_key_recursive(hive='HKLM', key=FAKE_KEY)
 
     @destructiveTest
+    def test_set_value_reg_dword(self):
+        '''
+        Test the set_value function on a unicode value
+        '''
+        try:
+            self.assertTrue(
+                win_reg.set_value(
+                    hive='HKLM',
+                    key=FAKE_KEY,
+                    vname='dword_value',
+                    vdata=123,
+                    vtype='REG_DWORD'
+                )
+            )
+            expected = {
+                'hive': 'HKLM',
+                'key': FAKE_KEY,
+                'success': True,
+                'vdata': 123,
+                'vname': 'dword_value',
+                'vtype': 'REG_DWORD'
+            }
+            self.assertEqual(
+                win_reg.read_value(
+                    hive='HKLM',
+                    key=FAKE_KEY,
+                    vname='dword_value'
+                ),
+                expected
+            )
+        finally:
+            win_reg.delete_key_recursive(hive='HKLM', key=FAKE_KEY)
+
+    @destructiveTest
+    def test_set_value_reg_qword(self):
+        '''
+        Test the set_value function on a unicode value
+        '''
+        try:
+            self.assertTrue(
+                win_reg.set_value(
+                    hive='HKLM',
+                    key=FAKE_KEY,
+                    vname='qword_value',
+                    vdata=123,
+                    vtype='REG_QWORD'
+                )
+            )
+            expected = {
+                'hive': 'HKLM',
+                'key': FAKE_KEY,
+                'success': True,
+                'vdata': 123,
+                'vname': 'qword_value',
+                'vtype': 'REG_QWORD'
+            }
+            self.assertEqual(
+                win_reg.read_value(
+                    hive='HKLM',
+                    key=FAKE_KEY,
+                    vname='qword_value'
+                ),
+                expected
+            )
+        finally:
+            win_reg.delete_key_recursive(hive='HKLM', key=FAKE_KEY)
+
+    @destructiveTest
     def test_delete_value(self):
         '''
         Test the delete_value function


### PR DESCRIPTION
### What does this PR do?
Uses long for REG_QWORD values in Py2

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/50039

### Tests written?
Yes

### Commits signed with GPG?
Yes