### PR TITLE
runtests.py: Fix IndexError in --from-filenames

### DIFF
--- a/tests/support/parser/__init__.py
+++ b/tests/support/parser/__init__.py
@@ -432,9 +432,14 @@ class SaltTestingParser(optparse.OptionParser):
                     # State matches for execution modules of the same name
                     # (e.g. unit.states.test_archive if
                     # unit.modules.test_archive is being run)
-                    if comps[-2] == 'modules':
-                        comps[-2] = 'states'
-                        _add(comps)
+                    try:
+                        if comps[-2] == 'modules':
+                            comps[-2] = 'states'
+                            _add(comps)
+                    except IndexError:
+                        # Not an execution module. This is either directly in
+                        # the salt/ directory, or salt/something/__init__.py
+                        pass
 
                 # Make sure to run a test module if it's been modified
                 elif match.group(1).startswith('tests/'):


### PR DESCRIPTION
Without this PR, paths like `salt/config/__init__.py` or `salt/master.py` would cause `IndexError`s like so:

```pytb
Traceback (most recent call last):
  File "/tmp/kitchen/testing/tests/runtests.py", line 914, in <module>
    main()
  File "/tmp/kitchen/testing/tests/runtests.py", line 886, in main
    parser.parse_args()
  File "/tmp/kitchen/testing/tests/support/parser/__init__.py", line 490, in parse_args
    self.options.name.extend(self._map_files(self.options.from_filenames))
  File "/tmp/kitchen/testing/tests/support/parser/__init__.py", line 435, in _map_files
    if comps[-2] == 'modules':
IndexError: list index out of range
```