### PR TITLE
Fix a couple of doc build warnings for community section

### DIFF
--- a/doc/contents.rst
+++ b/doc/contents.rst
@@ -8,7 +8,7 @@ Salt Table of Contents
     :maxdepth: 2
 
     topics/index
-    topics/community
+    topics/community/index
     topics/installation/index
     topics/configuration/index
     topics/using_salt

--- a/doc/topics/community/index.rst
+++ b/doc/topics/community/index.rst
@@ -1,3 +1,5 @@
+.. _salt-community:
+
 ========================
 Salt Community Resources
 ========================


### PR DESCRIPTION
There were a couple of doc build warnings left over in the console log from #49611. This cleans those related warnings up.