### PR TITLE
Fix `test_win_pkg` yet again

### DIFF
--- a/salt/fileserver/__init__.py
+++ b/salt/fileserver/__init__.py
@@ -134,7 +134,17 @@ def check_file_list_cache(opts, form, list_cache, w_lock):
                     # st_time can have a greater precision than time, removing
                     # float precision makes sure age will never be a negative
                     # number.
-                    age = int(time.time()) - int(cache_stat.st_mtime)
+                    current_time = int(time.time())
+                    file_mtime = int(cache_stat.st_mtime)
+                    if file_mtime > current_time:
+                        log.debug(
+                            'Cache file modified time is in the future, ignoring. '
+                            'file=%s mtime=%s current_time=%s',
+                            list_cache, current_time, file_mtime
+                        )
+                        age = 0
+                    else:
+                        age = current_time - file_mtime
                 else:
                     # if filelist does not exists yet, mark it as expired
                     age = opts.get('fileserver_list_cache_time', 20) + 1

--- a/salt/fileserver/__init__.py
+++ b/salt/fileserver/__init__.py
@@ -141,9 +141,9 @@ def check_file_list_cache(opts, form, list_cache, w_lock):
                 if age < opts.get('fileserver_list_cache_time', 20):
                     # Young enough! Load this sucker up!
                     with salt.utils.files.fopen(list_cache, 'rb') as fp_:
-                        log.trace(
-                            'Returning file_lists cache data from %s',
-                            list_cache
+                        log.debug(
+                            "Returning file list from cache: age=%s cache_time=%s %s",
+                            age, opts.get('fileserver_list_cache_time', 20), list_cache
                         )
                         return salt.utils.data.decode(serial.load(fp_).get(form, [])), False, False
                 elif _lock_cache(w_lock):

--- a/salt/fileserver/roots.py
+++ b/salt/fileserver/roots.py
@@ -310,7 +310,6 @@ def _file_lists(load, form):
             __opts__, form, list_cache, w_lock
         )
     if cache_match is not None:
-        log.debug("Returning file list from cache: %s", list_cache)
         return cache_match
     if refresh_cache:
         ret = {

--- a/salt/fileserver/roots.py
+++ b/salt/fileserver/roots.py
@@ -310,6 +310,7 @@ def _file_lists(load, form):
             __opts__, form, list_cache, w_lock
         )
     if cache_match is not None:
+        log.debug("Returning file list from cache")
         return cache_match
     if refresh_cache:
         ret = {

--- a/salt/fileserver/roots.py
+++ b/salt/fileserver/roots.py
@@ -310,7 +310,7 @@ def _file_lists(load, form):
             __opts__, form, list_cache, w_lock
         )
     if cache_match is not None:
-        log.debug("Returning file list from cache")
+        log.debug("Returning file list from cache: %s", list_cache)
         return cache_match
     if refresh_cache:
         ret = {

--- a/tests/integration/modules/test_win_pkg.py
+++ b/tests/integration/modules/test_win_pkg.py
@@ -38,7 +38,7 @@ class WinPKGTest(ModuleCase):
             refresh = self.run_function('pkg.refresh_db')
             self.assertEqual(check_refresh, refresh['total'],
                  msg='total returned {0}. Expected return {1}'.format(refresh['total'], check_refresh))
-            repo_data = self.run_function('pkg.get_repo_data', timeout=300)
+            repo_data = self.run_function('pkg.get_repo_data')
             repo_cache = os.path.join(RUNTIME_VARS.TMP, 'rootdir', 'cache', 'files', 'base', 'win', 'repo-ng')
             for pkg in pkgs:
                 if exists:
@@ -75,6 +75,8 @@ class WinPKGTest(ModuleCase):
                     locale: en_US
                     reboot: False
                 '''))
+            fp_.flush()
+            os.fsync(fp_.fileno())
         # now check if curl is also in cache and repo query
         pkgs.append('curl')
         for pkg in pkgs:

--- a/tests/integration/modules/test_win_pkg.py
+++ b/tests/integration/modules/test_win_pkg.py
@@ -75,8 +75,6 @@ class WinPKGTest(ModuleCase):
                     locale: en_US
                     reboot: False
                 '''))
-            fp_.flush()
-            os.fsync(fp_.fileno())
         # now check if curl is also in cache and repo query
         pkgs.append('curl')
         for pkg in pkgs:


### PR DESCRIPTION
### What does this PR do?

We just fixed a bug in `check_file_list_cache` which should have resolved the `test_win_pkg` failure but this test still fails intermittently. This PR adds flushes and syncs the new file to make sure it's available. In addition to adding a debug log when file_list is returned from a cache.

### Tests written?

No

### Commits signed with GPG?

Yes