### PR TITLE
Fix incorrect user/group id handling in file state

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -3188,7 +3188,7 @@ def directory(name,
             # NOTE: Should this be enough to stop the whole check altogether?
     if recurse_set:
         if 'user' in recurse_set:
-            if user:
+            if user or isinstance(user, int):
                 uid = __salt__['file.user_to_uid'](user)
                 # file.user_to_uid returns '' if user does not exist. Above
                 # check for user is not fatal, so we need to be sure user
@@ -3206,7 +3206,7 @@ def directory(name,
         else:
             user = None
         if 'group' in recurse_set:
-            if group:
+            if group or isinstance(group, int):
                 gid = __salt__['file.group_to_gid'](group)
                 # As above with user, we need to make sure group exists.
                 if isinstance(gid, six.string_types):


### PR DESCRIPTION
### What does this PR do?

It fixes error in salt.states.file. 

### What issues does this PR fix or reference?

Issues messages are:
```
user not specified, but configured as a target for recursive ownership
group not specified, but configured as a target for recursive ownership
```

Issue occurs when user or group is set to 0 and 'recurse' is used: 

```
/var/log/test/:
  file.directory:
    - user:  0
    - group: 0
    - recurse:
      - user
      - group
```

### Tests written?

No

### Commits signed with GPG?

Yes