### PR TITLE
[2018.3] Fix to utils/vault.py

### DIFF
--- a/salt/utils/vault.py
+++ b/salt/utils/vault.py
@@ -123,8 +123,11 @@ def get_vault_connection():
             raise salt.exceptions.CommandExecutionError(errmsg)
 
     if 'vault' in __opts__ and __opts__.get('__role', 'minion') == 'master':
-        log.debug('Contacting master for Vault connection details')
-        return _get_token_and_url_from_master()
+        if 'id' in __grains__:
+            log.debug('Contacting master for Vault connection details')
+            return _get_token_and_url_from_master()
+        else:
+            return _use_local_config()
     elif any((__opts__['local'], __opts__['file_client'] == 'local', __opts__['master_type'] == 'disable')):
         return _use_local_config()
     else:


### PR DESCRIPTION
### What does this PR do?
Due to a previous PR the test_sdb_runner in sdb.test_vault from the Fluorine branch was failing because of a exception that was being swallowed in the test run_run function. 

The cause was that when vault related functions were being run, if they were being run on the master then they were being forced to run through the _get_token_and_url_from_master() function, which is pull the id element out of the grains dictionary.  

When the call was taking place from a runner, the exception was popping up since there is no id when called from a runner.  This fix checks to see if the id exists in the dictionary first, if it is there then _get_token_and_url_from_master() is called, otherwise _use_local_config is called.

### What issues does this PR fix or reference?
N/A

### Tests written?
No.  Verified that sdb tests from Fluorine pass as well as manual tests from previous PRs work as expected.

### Commits signed with GPG?

Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
