### PR TITLE
Bugfix: supportconfig non-root permission issues

### DIFF
--- a/salt/cli/support/collector.py
+++ b/salt/cli/support/collector.py
@@ -406,7 +406,10 @@ class SaltSupport(salt.utils.parsers.SaltSupportOptionParser):
            and self.config.get('support_archive')
            and os.path.exists(self.config['support_archive'])):
             self.out.warning('Terminated earlier, cleaning up')
-            os.unlink(self.config['support_archive'])
+            try:
+                os.unlink(self.config['support_archive'])
+            except Exception as err:
+                log.error(err)
 
     def _check_existing_archive(self):
         '''

--- a/salt/cli/support/collector.py
+++ b/salt/cli/support/collector.py
@@ -409,7 +409,8 @@ class SaltSupport(salt.utils.parsers.SaltSupportOptionParser):
             try:
                 os.unlink(self.config['support_archive'])
             except Exception as err:
-                log.error(err)
+                log.debug(err)
+                self.out.error('{} while cleaning up.'.format(err))
 
     def _check_existing_archive(self):
         '''

--- a/salt/cli/support/collector.py
+++ b/salt/cli/support/collector.py
@@ -422,7 +422,11 @@ class SaltSupport(salt.utils.parsers.SaltSupportOptionParser):
         if os.path.exists(self.config['support_archive']):
             if self.config['support_archive_force_overwrite']:
                 self.out.warning('Overwriting existing archive: {}'.format(self.config['support_archive']))
-                os.unlink(self.config['support_archive'])
+                try:
+                    os.unlink(self.config['support_archive'])
+                except Exception as err:
+                    log.debug(err)
+                    self.out.error('{} while trying to overwrite existing archive.'.format(err))
                 ret = True
             else:
                 self.out.warning('File {} already exists.'.format(self.config['support_archive']))

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -1960,7 +1960,7 @@ class SaltSupportOptionParser(six.with_metaclass(OptionParserMeta, OptionParser,
         '''
         _opts, _args = optparse.OptionParser.parse_args(self)
         configs = self.find_existing_configs(_opts.support_unit)
-        if cfg not in configs:
+        if configs and cfg not in configs:
             cfg = configs[0]
 
         return config.master_config(self.get_config_file_path(cfg))


### PR DESCRIPTION
### What does this PR do?

Support config will not nicely show tracebacks crashing here/there instead of say "Permission denied". A cosmetic change, but less noise on the CLI.

### Tests written?

No
