### PR TITLE
Merge Forward 49872 to Fluorine

### DIFF
--- a/salt/modules/win_file.py
+++ b/salt/modules/win_file.py
@@ -35,7 +35,7 @@ import fnmatch  # do not remove, used in imported file.py functions
 import mmap  # do not remove, used in imported file.py functions
 import glob  # do not remove, used in imported file.py functions
 # do not remove, used in imported file.py functions
-import salt.ext.six as six  # pylint: disable=import-error,no-name-in-module
+from salt.ext import six
 from salt.ext.six.moves.urllib.parse import urlparse as _urlparse  # pylint: disable=import-error,no-name-in-module
 import salt.utils.atomicfile  # do not remove, used in imported file.py functions
 from salt.exceptions import CommandExecutionError, SaltInvocationError

--- a/salt/utils/win_dacl.py
+++ b/salt/utils/win_dacl.py
@@ -1924,7 +1924,7 @@ def _check_perms(obj_name, obj_type, new_perms, cur_perms, access_mode, ret):
             # Check Perms for basic perms
             if isinstance(new_perms[user]['perms'], six.string_types):
                 if not has_permission(obj_name=obj_name,
-                                      principal=user,
+                                      principal=user_name,
                                       permission=new_perms[user]['perms'],
                                       access_mode=access_mode,
                                       obj_type=obj_type,
@@ -1937,7 +1937,7 @@ def _check_perms(obj_name, obj_type, new_perms, cur_perms, access_mode, ret):
             else:
                 for perm in new_perms[user]['perms']:
                     if not has_permission(obj_name=obj_name,
-                                          principal=user,
+                                          principal=user_name,
                                           permission=perm,
                                           access_mode=access_mode,
                                           obj_type=obj_type,
@@ -2015,7 +2015,7 @@ def _check_perms(obj_name, obj_type, new_perms, cur_perms, access_mode, ret):
                 try:
                     set_permissions(
                         obj_name=obj_name,
-                        principal=user,
+                        principal=user_name,
                         permissions=perms,
                         access_mode=access_mode,
                         applies_to=applies_to,
@@ -2199,7 +2199,8 @@ def check_perms(obj_name,
         cur_perms = get_permissions(obj_name=obj_name, obj_type=obj_type)
         for user_name in cur_perms['Not Inherited']:
             # case insensitive dictionary search
-            if user_name.lower() not in set(k.lower() for k in grant_perms):
+            if grant_perms is not None and \
+                    user_name.lower() not in set(k.lower() for k in grant_perms):
                 if 'grant' in cur_perms['Not Inherited'][user_name]:
                     if __opts__['test'] is True:
                         if 'remove_perms' not in ret['pchanges']:
@@ -2217,7 +2218,8 @@ def check_perms(obj_name,
                         ret['changes']['remove_perms'].update(
                             {user_name: cur_perms['Not Inherited'][user_name]})
             # case insensitive dictionary search
-            if user_name.lower() not in set(k.lower() for k in deny_perms):
+            if deny_perms is not None and \
+                    user_name.lower() not in set(k.lower() for k in deny_perms):
                 if 'deny' in cur_perms['Not Inherited'][user_name]:
                     if __opts__['test'] is True:
                         if 'remove_perms' not in ret['pchanges']:

--- a/salt/utils/win_functions.py
+++ b/salt/utils/win_functions.py
@@ -123,6 +123,12 @@ def get_current_user(with_domain=True):
     '''
     Gets the user executing the process
 
+    Args:
+
+        with_domain (bool):
+            ``True`` will prepend the user name with the machine name or domain
+            separated by a backslash
+
     Returns:
         str: The user name
     '''

--- a/tests/unit/modules/test_win_file.py
+++ b/tests/unit/modules/test_win_file.py
@@ -8,11 +8,7 @@ import os
 
 # Import Salt Testing Libs
 from tests.support.unit import TestCase, skipIf
-from tests.support.mock import (
-    patch,
-    NO_MOCK,
-    NO_MOCK_REASON
-)
+from tests.support.mock import patch, NO_MOCK, NO_MOCK_REASON
 
 # Import Salt Libs
 import salt.modules.win_file as win_file


### PR DESCRIPTION
### What does this PR do?
Bring changes in https://github.com/saltstack/salt/pull/49872 to Fluorine. The check_perms function has been moved to `salt.utils.win_dacl`. Testing for `check_perms` was written for files and registry entries for the salt.util, so I didn't bring over the tests for the check_perms function that used to be in win_file.

### Tests written?
Yes

### Commits signed with GPG?
Yes