### PR TITLE
Add parameter named pillar_cache_env

### DIFF
--- a/conf/master
+++ b/conf/master
@@ -1006,6 +1006,10 @@
 # pillar is recompiled and stored. A value of 0 will cause the cache to always be valid.
 #pillar_cache_ttl: 3600
 
+# If and only if a master has set ``pillar_cache: True``, the cache env controls the
+# pillarenv of pillar data, before the cache is considered stored by a master.
+#pillar_cache_env: 'base'
+
 # If and only if a master has set `pillar_cache: True`, one of several storage providers
 # can be utilized.
 #

--- a/conf/suse/master
+++ b/conf/suse/master
@@ -960,6 +960,10 @@ syndic_user: salt
 # pillar is recompiled and stored. A value of 0 will cause the cache to always be valid.
 #pillar_cache_ttl: 3600
 
+# If and only if a master has set ``pillar_cache: True``, the cache env controls the
+# pillarenv of pillar data, before the cache is considered stored by a master.
+#pillar_cache_env: 'base'
+
 # If and only if a master has set `pillar_cache: True`, one of several storage providers
 # can be utililzed.
 #

--- a/doc/ref/configuration/master.rst
+++ b/doc/ref/configuration/master.rst
@@ -4599,6 +4599,18 @@ If and only if a master has set ``pillar_cache: True``, the cache TTL controls t
 of time, in seconds, before the cache is considered invalid by a master and a fresh
 pillar is recompiled and stored. A value of 0 will cause the cache to always be valid.
 
+.. conf_master:: pillar_cache_env
+
+``pillar_cache_env``
+********************
+
+.. versionadded:: Neon
+
+Default: ``base``
+
+If and only if a master has set ``pillar_cache: True``, the cache env controls the
+pillarenv of pillar data, before the cache is considered stored by a master.
+
 .. conf_master:: pillar_cache_backend
 
 ``pillar_cache_backend``

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -738,6 +738,9 @@ VALID_OPTS = {
     # Pillar cache backend. Defaults to `disk` which stores caches in the master cache
     'pillar_cache_backend': six.string_types,
 
+    # The master will not store pillar cache unless `pillarenv` is meet. Defaults to `base`
+    'pillar_cache_env': str,
+
     'pillar_safe_render_error': bool,
 
     # When creating a pillar, there are several strategies to choose from when
@@ -1251,11 +1254,12 @@ DEFAULT_MINION_OPTS = {
     'pillar_source_merging_strategy': 'smart',
     'pillar_merge_lists': False,
     'pillar_includes_override_sls': False,
-    # ``pillar_cache``, ``pillar_cache_ttl`` and ``pillar_cache_backend``
+    # ``pillar_cache``, ``pillar_cache_ttl``, ``pillar_cache_env`` and ``pillar_cache_backend``
     # are not used on the minion but are unavoidably in the code path
     'pillar_cache': False,
     'pillar_cache_ttl': 3600,
     'pillar_cache_backend': 'disk',
+    'pillar_cache_env': 'base',
     'extension_modules': os.path.join(salt.syspaths.CACHE_DIR, 'minion', 'extmods'),
     'state_top': 'top.sls',
     'state_top_saltenv': None,
@@ -1630,6 +1634,7 @@ DEFAULT_MASTER_OPTS = {
     'pillar_cache': False,
     'pillar_cache_ttl': 3600,
     'pillar_cache_backend': 'disk',
+    'pillar_cache_env': 'base',
     'ping_on_rotate': False,
     'peer': {},
     'preserve_minion_cache': False,

--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -320,15 +320,19 @@ class PillarCache(object):
                 log.debug('Pillar cache hit for minion %s and pillarenv %s', self.minion_id, self.pillarenv)
                 return self.cache[self.minion_id][self.pillarenv]
             else:
-                # We found the minion but not the env. Store it.
+                # We found the minion but not the env. Store it based on pillar_cache_env.
                 fresh_pillar = self.fetch_pillar()
-                self.cache[self.minion_id][self.pillarenv] = fresh_pillar
+                if self.pillarenv == self.opts['pillar_cache_env']:
+                    log.debug('Pillar cache store for pillarenv {0} for minion {1}'.format(self.pillarenv, self.minion_id))
+                    self.cache[self.minion_id][self.pillarenv] = fresh_pillar
                 log.debug('Pillar cache miss for pillarenv %s for minion %s', self.pillarenv, self.minion_id)
                 return fresh_pillar
         else:
-            # We haven't seen this minion yet in the cache. Store it.
+            # We haven't seen this minion yet in the cache. Store it based on pillar_cache_env.
             fresh_pillar = self.fetch_pillar()
-            self.cache[self.minion_id] = {self.pillarenv: fresh_pillar}
+            if self.pillarenv == self.opts['pillar_cache_env']:
+                log.debug('Pillar cache store for pillarenv {0} for minion {1}'.format(self.pillarenv, self.minion_id))
+                self.cache[self.minion_id] = {self.pillarenv: fresh_pillar}
             log.debug('Pillar cache miss for minion %s', self.minion_id)
             log.debug('Current pillar cache: %s', self.cache._dict)  # FIXME hack!
             return fresh_pillar


### PR DESCRIPTION
### What does this PR do?
Considering the production environment, the difference in the frequency of use of different pillar environments is huge and should be treated differently.

### What issues does this PR fix or reference?
No

### Previous Behavior
No matter what pillarenv is, always store the pillar cache.

### New Behavior
Only cache the pillar data for specified environment. Default is base.

### Tests written?
No

### Commits signed with GPG?
No