### PR TITLE
Squelch spurious errors logged in unit tests

### DIFF
--- a/tests/unit/modules/test_boto_apigateway.py
+++ b/tests/unit/modules/test_boto_apigateway.py
@@ -174,7 +174,9 @@ class BotoApiGatewayTestCaseBase(TestCase, LoaderModuleMockMixin):
 
     def setup_loader_modules(self):
         self.opts = opts = salt.config.DEFAULT_MINION_OPTS
-        utils = salt.loader.utils(opts, whitelist=['boto3'])
+        utils = salt.loader.utils(
+            opts,
+            whitelist=['boto3', 'args', 'systemd', 'path', 'platform'])
         return {
             boto_apigateway: {
                 '__opts__': opts,

--- a/tests/unit/modules/test_boto_cloudtrail.py
+++ b/tests/unit/modules/test_boto_cloudtrail.py
@@ -102,7 +102,10 @@ class BotoCloudTrailTestCaseBase(TestCase, LoaderModuleMockMixin):
 
     def setup_loader_modules(self):
         self.opts = opts = salt.config.DEFAULT_MINION_OPTS
-        utils = salt.loader.utils(opts, whitelist=['boto3'], context={})
+        utils = salt.loader.utils(
+            opts,
+            whitelist=['boto3', 'args', 'systemd', 'path', 'platform'],
+            context={})
         return {
             boto_cloudtrail: {
                 '__utils__': utils,

--- a/tests/unit/modules/test_boto_cloudwatch_event.py
+++ b/tests/unit/modules/test_boto_cloudwatch_event.py
@@ -92,7 +92,10 @@ class BotoCloudWatchEventTestCaseBase(TestCase, LoaderModuleMockMixin):
 
     def setup_loader_modules(self):
         self.opts = opts = salt.config.DEFAULT_MINION_OPTS
-        utils = salt.loader.utils(opts, whitelist=['boto3'], context={})
+        utils = salt.loader.utils(
+            opts,
+            whitelist=['boto3', 'args', 'systemd', 'path', 'platform'],
+            context={})
         return {boto_cloudwatch_event: {'__utils__': utils}}
 
     def setUp(self):

--- a/tests/unit/modules/test_boto_cognitoidentity.py
+++ b/tests/unit/modules/test_boto_cognitoidentity.py
@@ -117,7 +117,10 @@ class BotoCognitoIdentityTestCaseBase(TestCase, LoaderModuleMockMixin):
 
     def setup_loader_modules(self):
         self.opts = opts = salt.config.DEFAULT_MINION_OPTS
-        utils = salt.loader.utils(opts, whitelist=['boto3'], context={})
+        utils = salt.loader.utils(
+            opts,
+            whitelist=['boto3', 'args', 'systemd', 'path', 'platform'],
+            context={})
         return {boto_cognitoidentity: {'__utils__': utils}}
 
     def setUp(self):

--- a/tests/unit/modules/test_boto_elasticsearch_domain.py
+++ b/tests/unit/modules/test_boto_elasticsearch_domain.py
@@ -89,7 +89,10 @@ class BotoElasticsearchDomainTestCaseBase(TestCase, LoaderModuleMockMixin):
 
     def setup_loader_modules(self):
         self.opts = salt.config.DEFAULT_MINION_OPTS
-        utils = salt.loader.utils(self.opts, whitelist=['boto3'], context={})
+        utils = salt.loader.utils(
+            self.opts,
+            whitelist=['boto3', 'args', 'systemd', 'path', 'platform'],
+            context={})
         return {boto_elasticsearch_domain: {'__utils__': utils}}
 
     def setUp(self):

--- a/tests/unit/modules/test_boto_elb.py
+++ b/tests/unit/modules/test_boto_elb.py
@@ -105,7 +105,9 @@ class BotoElbTestCase(TestCase, LoaderModuleMockMixin):
 
     def setup_loader_modules(self):
         opts = salt.config.DEFAULT_MASTER_OPTS
-        utils = salt.loader.utils(opts, whitelist=['boto'])
+        utils = salt.loader.utils(
+            opts,
+            whitelist=['boto', 'args', 'systemd', 'path', 'platform'])
         funcs = salt.loader.minion_mods(opts, utils=utils)
         return {
             boto_elb: {

--- a/tests/unit/modules/test_boto_iot.py
+++ b/tests/unit/modules/test_boto_iot.py
@@ -128,7 +128,10 @@ class BotoIoTTestCaseBase(TestCase, LoaderModuleMockMixin):
 
     def setup_loader_modules(self):
         self.opts = opts = salt.config.DEFAULT_MINION_OPTS
-        utils = salt.loader.utils(opts, whitelist=['boto3'], context={})
+        utils = salt.loader.utils(
+            opts,
+            whitelist=['boto3', 'args', 'systemd', 'path', 'platform'],
+            context={})
         return {boto_iot: {'__utils__': utils}}
 
     def setUp(self):

--- a/tests/unit/modules/test_boto_lambda.py
+++ b/tests/unit/modules/test_boto_lambda.py
@@ -123,7 +123,10 @@ class BotoLambdaTestCaseBase(TestCase, LoaderModuleMockMixin):
 
     def setup_loader_modules(self):
         self.opts = opts = salt.config.DEFAULT_MINION_OPTS
-        utils = salt.loader.utils(opts, whitelist=['boto3'], context={})
+        utils = salt.loader.utils(
+            opts,
+            whitelist=['boto3', 'args', 'systemd', 'path', 'platform'],
+            context={})
         return {boto_lambda: {'__utils__': utils}}
 
     def setUp(self):

--- a/tests/unit/modules/test_boto_s3_bucket.py
+++ b/tests/unit/modules/test_boto_s3_bucket.py
@@ -205,7 +205,10 @@ class BotoS3BucketTestCaseBase(TestCase, LoaderModuleMockMixin):
 
     def setup_loader_modules(self):
         self.opts = opts = salt.config.DEFAULT_MINION_OPTS
-        utils = salt.loader.utils(opts, whitelist=['boto3'], context={})
+        utils = salt.loader.utils(
+            opts,
+            whitelist=['boto3', 'args', 'systemd', 'path', 'platform'],
+            context={})
         return {boto_s3_bucket: {'__utils__': utils}}
 
     def setUp(self):

--- a/tests/unit/modules/test_boto_secgroup.py
+++ b/tests/unit/modules/test_boto_secgroup.py
@@ -96,7 +96,9 @@ class BotoSecgroupTestCase(TestCase, LoaderModuleMockMixin):
 
     def setup_loader_modules(self):
         opts = salt.config.DEFAULT_MASTER_OPTS
-        utils = salt.loader.utils(opts, whitelist=['boto'])
+        utils = salt.loader.utils(
+            opts,
+            whitelist=['boto', 'args', 'systemd', 'path', 'platform'])
         funcs = salt.loader.minion_mods(opts, utils=utils)
         return {
             boto_secgroup: {

--- a/tests/unit/modules/test_boto_vpc.py
+++ b/tests/unit/modules/test_boto_vpc.py
@@ -141,7 +141,9 @@ class BotoVpcTestCaseBase(TestCase, LoaderModuleMockMixin):
 
     def setup_loader_modules(self):
         self.opts = opts = salt.config.DEFAULT_MINION_OPTS
-        utils = salt.loader.utils(opts, whitelist=['boto', 'boto3'])
+        utils = salt.loader.utils(
+            opts,
+            whitelist=['boto', 'boto3', 'args', 'systemd', 'path', 'platform'])
         return {boto_vpc: {'__utils__': utils}}
 
     # Set up MagicMock to replace the boto3 session

--- a/tests/unit/modules/test_dockermod.py
+++ b/tests/unit/modules/test_dockermod.py
@@ -45,7 +45,8 @@ class DockerTestCase(TestCase, LoaderModuleMockMixin):
     def setup_loader_modules(self):
         utils = salt.loader.utils(
             salt.config.DEFAULT_MINION_OPTS,
-            whitelist=['args', 'docker', 'json', 'state', 'thin']
+            whitelist=['args', 'docker', 'json', 'state', 'thin',
+                       'systemd', 'path', 'platform']
         )
         return {docker_mod: {'__context__': {'docker.docker_version': ''},
                              '__utils__': utils}}

--- a/tests/unit/modules/test_state.py
+++ b/tests/unit/modules/test_state.py
@@ -345,7 +345,7 @@ class StateTestCase(TestCase, LoaderModuleMockMixin):
     def setup_loader_modules(self):
         utils = salt.loader.utils(
             salt.config.DEFAULT_MINION_OPTS,
-            whitelist=['state']
+            whitelist=['state', 'args', 'systemd', 'path', 'platform']
         )
         utils.keys()
         patcher = patch('salt.modules.state.salt.state', MockState())

--- a/tests/unit/modules/test_zfs.py
+++ b/tests/unit/modules/test_zfs.py
@@ -43,7 +43,9 @@ class ZfsTestCase(TestCase, LoaderModuleMockMixin):
     '''
     def setup_loader_modules(self):
         self.opts = opts = salt.config.DEFAULT_MINION_OPTS
-        utils = salt.loader.utils(opts, whitelist=['zfs'])
+        utils = salt.loader.utils(
+            opts,
+            whitelist=['zfs', 'args', 'systemd', 'path', 'platform'])
         zfs_obj = {
             zfs: {
                 '__opts__': opts,

--- a/tests/unit/modules/test_zpool.py
+++ b/tests/unit/modules/test_zpool.py
@@ -44,7 +44,9 @@ class ZpoolTestCase(TestCase, LoaderModuleMockMixin):
     '''
     def setup_loader_modules(self):
         self.opts = opts = salt.config.DEFAULT_MINION_OPTS
-        utils = salt.loader.utils(opts, whitelist=['zfs'])
+        utils = salt.loader.utils(
+            opts,
+            whitelist=['zfs', 'args', 'systemd', 'path', 'platform'])
         zpool_obj = {
             zpool: {
                 '__opts__': opts,

--- a/tests/unit/states/test_boto_apigateway.py
+++ b/tests/unit/states/test_boto_apigateway.py
@@ -406,7 +406,10 @@ class BotoApiGatewayStateTestCaseBase(TestCase, LoaderModuleMockMixin):
 
     def setup_loader_modules(self):
         context = {}
-        utils = salt.loader.utils(self.opts, whitelist=['boto', 'boto3'], context=context)
+        utils = salt.loader.utils(
+            self.opts,
+            whitelist=['boto', 'boto3', 'args', 'systemd', 'path', 'platform'],
+            context=context)
         serializers = salt.loader.serializers(self.opts)
         self.funcs = salt.loader.minion_mods(self.opts, context=context, utils=utils, whitelist=['boto_apigateway'])
         self.salt_states = salt.loader.states(opts=self.opts, functions=self.funcs, utils=utils, whitelist=['boto_apigateway'], serializers=serializers)

--- a/tests/unit/states/test_boto_cloudfront.py
+++ b/tests/unit/states/test_boto_cloudfront.py
@@ -26,9 +26,8 @@ class BotoCloudfrontTestCase(TestCase, LoaderModuleMockMixin):
     def setup_loader_modules(self):
         utils = salt.loader.utils(
             self.opts,
-            whitelist=['boto3', 'dictdiffer', 'yaml'],
-            context={},
-        )
+            whitelist=['boto3', 'dictdiffer', 'yaml', 'args', 'systemd', 'path', 'platform'],
+            context={})
         return {
             boto_cloudfront: {
                 '__utils__': utils,

--- a/tests/unit/states/test_boto_cloudtrail.py
+++ b/tests/unit/states/test_boto_cloudtrail.py
@@ -107,7 +107,10 @@ class BotoCloudTrailStateTestCaseBase(TestCase, LoaderModuleMockMixin):
 
     def setup_loader_modules(self):
         ctx = {}
-        utils = salt.loader.utils(self.opts, whitelist=['boto', 'boto3'], context=ctx)
+        utils = salt.loader.utils(
+            self.opts,
+            whitelist=['boto', 'boto3', 'args', 'systemd', 'path', 'platform'],
+            context=ctx)
         serializers = salt.loader.serializers(self.opts)
         self.funcs = funcs = salt.loader.minion_mods(self.opts, context=ctx, utils=utils, whitelist=['boto_cloudtrail'])
         self.salt_states = salt.loader.states(opts=self.opts, functions=funcs, utils=utils, whitelist=['boto_cloudtrail'],

--- a/tests/unit/states/test_boto_cloudwatch_event.py
+++ b/tests/unit/states/test_boto_cloudwatch_event.py
@@ -85,7 +85,10 @@ class BotoCloudWatchEventStateTestCaseBase(TestCase, LoaderModuleMockMixin):
 
     def setup_loader_modules(self):
         ctx = {}
-        utils = salt.loader.utils(self.opts, whitelist=['boto3'], context=ctx)
+        utils = salt.loader.utils(
+            self.opts,
+            whitelist=['boto3', 'args', 'systemd', 'path', 'platform'],
+            context=ctx)
         serializers = salt.loader.serializers(self.opts)
         self.funcs = funcs = salt.loader.minion_mods(self.opts, context=ctx, utils=utils, whitelist=['boto_cloudwatch_event'])
         self.salt_states = salt.loader.states(opts=self.opts, functions=funcs, utils=utils, whitelist=['boto_cloudwatch_event'],

--- a/tests/unit/states/test_boto_cognitoidentity.py
+++ b/tests/unit/states/test_boto_cognitoidentity.py
@@ -130,7 +130,10 @@ class BotoCognitoIdentityStateTestCaseBase(TestCase, LoaderModuleMockMixin):
 
     def setup_loader_modules(self):
         ctx = {}
-        utils = salt.loader.utils(self.opts, whitelist=['boto', 'boto3'], context=ctx)
+        utils = salt.loader.utils(
+            self.opts,
+            whitelist=['boto', 'boto3', 'args', 'systemd', 'path', 'platform'],
+            context=ctx)
         serializers = salt.loader.serializers(self.opts)
         self.funcs = funcs = salt.loader.minion_mods(self.opts, context=ctx, utils=utils, whitelist=['boto_cognitoidentity'])
         self.salt_states = salt.loader.states(opts=self.opts, functions=funcs, utils=utils, whitelist=['boto_cognitoidentity'],

--- a/tests/unit/states/test_boto_elasticsearch_domain.py
+++ b/tests/unit/states/test_boto_elasticsearch_domain.py
@@ -87,7 +87,10 @@ class BotoElasticsearchDomainStateTestCaseBase(TestCase, LoaderModuleMockMixin):
 
     def setup_loader_modules(self):
         ctx = {}
-        utils = salt.loader.utils(self.opts, whitelist=['boto3'], context=ctx)
+        utils = salt.loader.utils(
+            self.opts,
+            whitelist=['boto3', 'args', 'systemd', 'path', 'platform'],
+            context=ctx)
         serializers = salt.loader.serializers(self.opts)
         self.funcs = funcs = salt.loader.minion_mods(self.opts, context=ctx, utils=utils, whitelist=['boto_elasticsearch_domain'])
         self.salt_states = salt.loader.states(opts=self.opts, functions=funcs, utils=utils, whitelist=['boto_elasticsearch_domain'],

--- a/tests/unit/states/test_boto_iot.py
+++ b/tests/unit/states/test_boto_iot.py
@@ -138,7 +138,10 @@ class BotoIoTStateTestCaseBase(TestCase, LoaderModuleMockMixin):
 
     def setup_loader_modules(self):
         ctx = {}
-        utils = salt.loader.utils(self.opts, whitelist=['boto3'], context=ctx)
+        utils = salt.loader.utils(
+            self.opts,
+            whitelist=['boto3', 'args', 'systemd', 'path', 'platform'],
+            context=ctx)
         serializers = salt.loader.serializers(self.opts)
         self.funcs = funcs = salt.loader.minion_mods(self.opts, context=ctx, utils=utils, whitelist=['boto_iot'])
         self.salt_states = salt.loader.states(opts=self.opts, functions=funcs, utils=utils, whitelist=['boto_iot'],

--- a/tests/unit/states/test_boto_lambda.py
+++ b/tests/unit/states/test_boto_lambda.py
@@ -107,7 +107,10 @@ class BotoLambdaStateTestCaseBase(TestCase, LoaderModuleMockMixin):
 
     def setup_loader_modules(self):
         ctx = {}
-        utils = salt.loader.utils(self.opts, whitelist=['boto', 'boto3'], context=ctx)
+        utils = salt.loader.utils(
+            self.opts,
+            whitelist=['boto', 'boto3', 'args', 'systemd', 'path', 'platform'],
+            context=ctx)
         serializers = salt.loader.serializers(self.opts)
         self.funcs = funcs = salt.loader.minion_mods(self.opts, context=ctx, utils=utils, whitelist=['boto_lambda'])
         self.salt_states = salt.loader.states(opts=self.opts, functions=funcs, utils=utils, whitelist=['boto_lambda'],

--- a/tests/unit/states/test_boto_s3_bucket.py
+++ b/tests/unit/states/test_boto_s3_bucket.py
@@ -269,7 +269,10 @@ class BotoS3BucketStateTestCaseBase(TestCase, LoaderModuleMockMixin):
 
     def setup_loader_modules(self):
         ctx = {}
-        utils = salt.loader.utils(self.opts, whitelist=['boto', 'boto3'], context=ctx)
+        utils = salt.loader.utils(
+            self.opts,
+            whitelist=['boto', 'boto3', 'args', 'systemd', 'path', 'platform'],
+            context=ctx)
         serializers = salt.loader.serializers(self.opts)
         self.funcs = funcs = salt.loader.minion_mods(self.opts, context=ctx, utils=utils, whitelist=['boto_s3_bucket'])
         self.salt_states = salt.loader.states(opts=self.opts, functions=funcs, utils=utils, whitelist=['boto_s3_bucket'],

--- a/tests/unit/states/test_boto_sqs.py
+++ b/tests/unit/states/test_boto_sqs.py
@@ -25,9 +25,8 @@ class BotoSqsTestCase(TestCase, LoaderModuleMockMixin):
     def setup_loader_modules(self):
         utils = salt.loader.utils(
             self.opts,
-            whitelist=['boto3', 'yaml'],
-            context={}
-        )
+            whitelist=['boto3', 'yaml', 'args', 'systemd', 'path', 'platform'],
+            context={})
         return {
             boto_sqs: {
                 '__utils__': utils,

--- a/tests/unit/states/test_boto_vpc.py
+++ b/tests/unit/states/test_boto_vpc.py
@@ -89,7 +89,10 @@ def _has_required_boto():
 class BotoVpcStateTestCaseBase(TestCase, LoaderModuleMockMixin):
     def setup_loader_modules(self):
         ctx = {}
-        utils = salt.loader.utils(self.opts, whitelist=['boto', 'boto3'], context=ctx)
+        utils = salt.loader.utils(
+            self.opts,
+            whitelist=['boto', 'boto3', 'args', 'systemd', 'path', 'platform'],
+            context=ctx)
         serializers = salt.loader.serializers(self.opts)
         self.funcs = salt.loader.minion_mods(self.opts, context=ctx, utils=utils, whitelist=['boto_vpc', 'config'])
         self.salt_states = salt.loader.states(opts=self.opts, functions=self.funcs, utils=utils, whitelist=['boto_vpc'],


### PR DESCRIPTION
We are getting errors in the LazyLoader because certain functions are not present in the LazyDict due to being left out of the whitelist.  These don't cause the tests to fail, but they do result in a lot of spurious errors in the test suite.