### PR TITLE
Fix bad merge conflict resolution

### DIFF
--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -1052,10 +1052,10 @@ class Single(object):
             opts_pkg['module_dirs'] = self.opts['module_dirs']
             opts_pkg['_ssh_version'] = self.opts['_ssh_version']
             opts_pkg['__master_opts__'] = self.context['master_opts']
-            if '_caller_cachedir' in self.opts:
-                opts_pkg['_caller_cachedir'] = self.opts['_caller_cachedir']
             if 'known_hosts_file' in self.opts:
                 opts_pkg['known_hosts_file'] = self.opts['known_hosts_file']
+            if '_caller_cachedir' in self.opts:
+                opts_pkg['_caller_cachedir'] = self.opts['_caller_cachedir']
             else:
                 opts_pkg['_caller_cachedir'] = self.opts['cachedir']
             # Use the ID defined in the roster file
@@ -1347,12 +1347,20 @@ ARGS = {10}\n'''.format(self.minion_config,
                     if not self.tty:
                         # If RSTR is not seen in both stdout and stderr then there
                         # was a thin deployment problem.
-                        log.error('ERROR: Failure deploying thin, retrying: %s\n%s', stdout, stderr)
+                        log.error(
+                            'ERROR: Failure deploying thin, retrying:\n'
+                            'STDOUT:\n%s\nSTDERR:\n%s\nRETCODE: %s',
+                            stdout, stderr, retcode
+                        )
                         return self.cmd_block()
                     elif not re.search(RSTR_RE, stdout):
                         # If RSTR is not seen in stdout with tty, then there
                         # was a thin deployment problem.
-                        log.error('ERROR: Failure deploying thin, retrying: %s\n%s', stdout, stderr)
+                        log.error(
+                            'ERROR: Failure deploying thin, retrying:\n'
+                            'STDOUT:\n%s\nSTDERR:\n%s\nRETCODE: %s',
+                            stdout, stderr, retcode
+                        )
                 while re.search(RSTR_RE, stdout):
                     stdout = re.split(RSTR_RE, stdout, 1)[1].strip()
                 if self.tty:


### PR DESCRIPTION
b98df6d was incorrectly merged forward into 2018.3 (or into develop, before 2018.3 was branched). This causes failures to redeploy the thin tarball when it has changed, under certain circumstances.

This commit fixes the problem. I'm also leaving in some changes to the logging that I made in the course of troubleshooting this, as they make the border between stdout and stderr more explicit, as well as adding the shim command's retcode.

Fixes https://github.com/saltstack/salt-jenkins/issues/1137.