### PR TITLE
Workaround for py2 builtin, =<3.3 imp and >=3.4 libimport quirks

### DIFF
--- a/salt/modules/ebuild.py
+++ b/salt/modules/ebuild.py
@@ -61,13 +61,29 @@ def __virtual__():
 
 def _vartree():
     import portage  # pylint: disable=3rd-party-module-not-gated
-    portage = reload(portage)
+    try:
+        reload(portage)
+    except NameError:
+        try:
+            from importlib import reload
+            reload(portage)
+        except ImportError:
+            from imp import reload
+            reload(portage)
     return portage.db[portage.root]['vartree']
 
 
 def _porttree():
     import portage  # pylint: disable=3rd-party-module-not-gated
-    portage = reload(portage)
+    try:
+        reload(portage)
+    except NameError:
+        try:
+            from importlib import reload
+            reload(portage)
+        except ImportError:
+            from imp import reload
+            reload(portage)
     return portage.db[portage.root]['porttree']
 
 

--- a/salt/modules/ebuild.py
+++ b/salt/modules/ebuild.py
@@ -69,13 +69,13 @@ def __virtual__():
 
 def _vartree():
     import portage  # pylint: disable=3rd-party-module-not-gated
-    reload(portage)
+    portage = reload(portage)
     return portage.db[portage.root]['vartree']
 
 
 def _porttree():
     import portage  # pylint: disable=3rd-party-module-not-gated
-    reload(portage)
+    portage = reload(portage)
     return portage.db[portage.root]['porttree']
 
 

--- a/salt/modules/ebuild.py
+++ b/salt/modules/ebuild.py
@@ -29,7 +29,7 @@ import salt.ext.six as six
 
 # Workaround for 'reload' builtin of py2.7
 if six.PY3:
-    from importlib import reload  # pylint: disable=W0611
+    from importlib import reload  # pylint: disable=no-name-in-module
 
 # Import third party libs
 HAS_PORTAGE = False

--- a/salt/modules/ebuild.py
+++ b/salt/modules/ebuild.py
@@ -29,7 +29,7 @@ import salt.ext.six as six
 
 # Workaround for 'reload' builtin of py2.7
 if six.PY3:
-    from importlib import reload
+    from importlib import reload # pylint: disable=W0611
 
 # Import third party libs
 HAS_PORTAGE = False
@@ -245,6 +245,7 @@ def latest_version(*names, **kwargs):
     if len(names) == 1:
         return ret[names[0]]
     return ret
+
 
 # available_version is being deprecated
 available_version = salt.utils.alias_function(latest_version, 'available_version')

--- a/salt/modules/ebuild.py
+++ b/salt/modules/ebuild.py
@@ -19,14 +19,6 @@ from __future__ import absolute_import
 import copy
 import logging
 import re
-try:
-    if globals()['__builtins__'].reload:
-        pass
-except AttributeError:
-    try:
-        from importlib import reload
-    except ImportError:
-        from imp import reload
 
 # Import salt libs
 import salt.utils
@@ -34,6 +26,10 @@ import salt.utils.pkg
 import salt.utils.systemd
 from salt.exceptions import CommandExecutionError, MinionError
 import salt.ext.six as six
+
+# Workaround for 'reload' builtin of py2.7
+if six.PY3:
+    from importlib import reload
 
 # Import third party libs
 HAS_PORTAGE = False

--- a/salt/modules/ebuild.py
+++ b/salt/modules/ebuild.py
@@ -29,7 +29,7 @@ import salt.ext.six as six
 
 # Workaround for 'reload' builtin of py2.7
 if six.PY3:
-    from importlib import reload # pylint: disable=W0611
+    from importlib import reload  # pylint: disable=W0611
 
 # Import third party libs
 HAS_PORTAGE = False

--- a/salt/modules/ebuild.py
+++ b/salt/modules/ebuild.py
@@ -19,6 +19,14 @@ from __future__ import absolute_import
 import copy
 import logging
 import re
+try:
+    if globals()['__builtins__'].reload:
+        pass
+except AttributeError:
+    try:
+        from importlib import reload
+    except ImportError:
+        from imp import reload
 
 # Import salt libs
 import salt.utils
@@ -61,29 +69,13 @@ def __virtual__():
 
 def _vartree():
     import portage  # pylint: disable=3rd-party-module-not-gated
-    try:
-        reload(portage)
-    except NameError:
-        try:
-            from importlib import reload
-            reload(portage)
-        except ImportError:
-            from imp import reload
-            reload(portage)
+    reload(portage)
     return portage.db[portage.root]['vartree']
 
 
 def _porttree():
     import portage  # pylint: disable=3rd-party-module-not-gated
-    try:
-        reload(portage)
-    except NameError:
-        try:
-            from importlib import reload
-            reload(portage)
-        except ImportError:
-            from imp import reload
-            reload(portage)
+    reload(portage)
     return portage.db[portage.root]['porttree']
 
 

--- a/salt/utils/virtualbox.py
+++ b/salt/utils/virtualbox.py
@@ -13,6 +13,15 @@ import logging
 import re
 import time
 
+try:
+    if globals()['__builtins__'].reload:
+        pass
+except AttributeError:
+    try:
+        from importlib import reload
+    except ImportError:
+        from imp import reload
+
 # Import salt libs
 from salt.utils.timeout import wait_for
 
@@ -132,22 +141,7 @@ def vb_get_manager():
     '''
     global _virtualboxManager
     if _virtualboxManager is None and HAS_LIBS:
-        try:
-            from importlib import reload
-        except ImportError:
-            # If we get here, we are in py2 and reload is a built-in.
-            pass
-
-        # Reloading the API extends sys.paths for subprocesses of multiprocessing, since they seem to share contexts
-        try:
-            reload(vboxapi)
-        except NameError:
-            try:
-                from importlib import reload
-                reload(vboxapi)
-            except ImportError:
-                from imp import reload
-                reload(vboxapi)
+        reload(vboxapi)
         _virtualboxManager = vboxapi.VirtualBoxManager(None, None)
 
     return _virtualboxManager

--- a/salt/utils/virtualbox.py
+++ b/salt/utils/virtualbox.py
@@ -139,7 +139,15 @@ def vb_get_manager():
             pass
 
         # Reloading the API extends sys.paths for subprocesses of multiprocessing, since they seem to share contexts
-        reload(vboxapi)
+        try:
+            reload(vboxapi)
+        except NameError:
+            try:
+                from importlib import reload
+                reload(vboxapi)
+            except ImportError:
+                from imp import reload
+                reload(vboxapi)
         _virtualboxManager = vboxapi.VirtualBoxManager(None, None)
 
     return _virtualboxManager

--- a/salt/utils/virtualbox.py
+++ b/salt/utils/virtualbox.py
@@ -19,7 +19,7 @@ import salt.ext.six as six
 
 # Workaround for 'reload' builtin of py2.7
 if six.PY3:
-    from importlib import reload
+    from importlib import reload # pylint: disable=W0611
 
 log = logging.getLogger(__name__)
 

--- a/salt/utils/virtualbox.py
+++ b/salt/utils/virtualbox.py
@@ -19,7 +19,7 @@ import salt.ext.six as six
 
 # Workaround for 'reload' builtin of py2.7
 if six.PY3:
-    from importlib import reload  # pylint: disable=W0611
+    from importlib import reload  # pylint: disable=no-name-in-module
 
 log = logging.getLogger(__name__)
 

--- a/salt/utils/virtualbox.py
+++ b/salt/utils/virtualbox.py
@@ -19,7 +19,7 @@ import salt.ext.six as six
 
 # Workaround for 'reload' builtin of py2.7
 if six.PY3:
-    from importlib import reload # pylint: disable=W0611
+    from importlib import reload  # pylint: disable=W0611
 
 log = logging.getLogger(__name__)
 

--- a/salt/utils/virtualbox.py
+++ b/salt/utils/virtualbox.py
@@ -13,17 +13,13 @@ import logging
 import re
 import time
 
-try:
-    if globals()['__builtins__'].reload:
-        pass
-except AttributeError:
-    try:
-        from importlib import reload
-    except ImportError:
-        from imp import reload
-
 # Import salt libs
 from salt.utils.timeout import wait_for
+import salt.ext.six as six
+
+# Workaround for 'reload' builtin of py2.7
+if six.PY3:
+    from importlib import reload
 
 log = logging.getLogger(__name__)
 


### PR DESCRIPTION


### What does this PR do?
Python 2 has a builtin for "reload"
Python lower than 3.3 has the "imp" module
And Python 3.4 and up switched to "importlib"
This patches to fall back through the different implementations

### What issues does this PR fix or reference?
solves #50127

### Previous Behavior
NameError: name 'reload' is not defined

### New Behavior
Works

### Tests written?

No

### Commits signed with GPG?

Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
