### PR TITLE
For the saltify cloud provider, use minion name as ssh_host

### DIFF
--- a/salt/cloud/clouds/saltify.py
+++ b/salt/cloud/clouds/saltify.py
@@ -252,6 +252,10 @@ def create(vm_):
     deploy_config = config.get_cloud_config_value(
         'deploy', vm_, __opts__, default=False)
 
+    # If ssh_host is not set, default to the minion name
+    if not config.get_cloud_config_value('ssh_host', vm_, __opts__, default=''):
+        vm_['ssh_host'] = vm_['name']
+
     if deploy_config:
         wol_mac = config.get_cloud_config_value(
             'wake_on_lan_mac', vm_, __opts__, default='')


### PR DESCRIPTION
### What does this PR do?
For all cloud providers other than `saltify`, the IP address is not known until the new VM is provisioned. That address is stored in a dictionary as `vm_['ssh_host']` and used to complete the minion deployment.

Saltify works differently, because it does not actually provision a new VM. It just deploys the minion to an existing system. The only way to make it work is to pass `ssh_host` in the cloud map, like this:
```
my-profile:
  - myvm1.example.com:
      ssh_host: myvm1.example.com
  - myvm2.example.com:
      ssh_host: myvm2.example.com
```
Omitting the `ssh_host` attribute results in an error:
```
[ERROR   ] Failed to create VM 159.65.73.175. Configuration value u'ssh_host' needs to be set
Traceback (most recent call last):
  File "/salt/salt/cloud/__init__.py", line 1291, in create
    output = self.clouds[func](vm_)
  File "/salt/salt/cloud/clouds/saltify.py", line 289, in create
    ret = _verify(vm_)
  File "/salt/salt/cloud/clouds/saltify.py", line 370, in _verify
    'host': vm_['ssh_host'],
KeyError: u'ssh_host'
```
As shown in the example above, specifying the minion name and `ssh_host` attribute often results in duplicate data when using Saltify. This PR makes `ssh_host` optional. If `ssh_host` is not provided in the cloud map, it will use the minion name as a DNS name of the target system. This results in a much cleaner cloud map with no duplicate names:
```
my-profile:
  - myvm1.example.com
  - myvm2.example.com
```

### What issues does this PR fix or reference?
None

### Tests written?
No

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
