### PR TITLE
Add some debug logging before and after states gather pillar data

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -732,6 +732,7 @@ class State(object):
             except AttributeError:
                 pillar_enc = six.text_type(pillar_enc).lower()
         self._pillar_enc = pillar_enc
+        log.debug('Gathering pillar data for state run')
         if initial_pillar and not self._pillar_override:
             self.opts['pillar'] = initial_pillar
         else:
@@ -745,6 +746,7 @@ class State(object):
                     self.opts.get('pillar_source_merging_strategy', 'smart'),
                     self.opts.get('renderer', 'yaml'),
                     self.opts.get('pillar_merge_lists', False))
+        log.debug('Finished gathering pillar data for state run')
         self.state_con = context or {}
         self.load_modules()
         self.active = set()


### PR DESCRIPTION
This will help definitively identify instances where a salt-call is delayed because it is waiting for pillar data from the master.