### PR TITLE
create ssh_auth.manage

### DIFF
--- a/doc/topics/releases/neon.rst
+++ b/doc/topics/releases/neon.rst
@@ -214,6 +214,9 @@ State Changes
 - The ``onchanges`` and ``prereq`` :ref:`requisites <requisites>` now behave
   properly in test mode.
 
+- Added new :py:func:`ssh_auth.manage <salt.states.ssh_auth.manage>` state to
+  ensure only the specified ssh keys are present for the specified user.
+
 Module Changes
 ==============
 

--- a/salt/states/ssh_auth.py
+++ b/salt/states/ssh_auth.py
@@ -265,14 +265,7 @@ def present(
 
     fingerprint_hash_type
         The public key fingerprint hash type that the public key fingerprint
-        was originally hashed with. This defaults to ``md5`` if not specified.
-
-        .. versionadded:: 2016.11.7
-
-        .. note::
-
-            The default value of the ``fingerprint_hash_type`` will change to
-            ``sha256`` in Salt 2017.7.0.
+        was originally hashed with. This defaults to ``sha256`` if not specified.
     '''
     ret = {'name': name,
            'changes': {},
@@ -437,15 +430,9 @@ def absent(name,
 
     fingerprint_hash_type
         The public key fingerprint hash type that the public key fingerprint
-        was originally hashed with. This defaults to ``md5`` if not specified.
+        was originally hashed with. This defaults to ``sha256`` if not specified.
 
         .. versionadded:: 2016.11.7
-
-        .. note::
-
-            The default value of the ``fingerprint_hash_type`` will change to
-            ``sha256`` in Salt 2017.7.0.
-
     '''
     ret = {'name': name,
            'changes': {},
@@ -578,12 +565,7 @@ def manage(
 
     fingerprint_hash_type
         The public key fingerprint hash type that the public key fingerprint
-        was originally hashed with. This defaults to ``md5`` if not specified.
-
-        .. note::
-
-            The default value of the ``fingerprint_hash_type`` will change to
-            ``sha256`` in Salt 2017.7.0.
+        was originally hashed with. This defaults to ``sha256`` if not specified.
     '''
     ret = {'name': '',
            'changes': {},

--- a/salt/states/ssh_auth.py
+++ b/salt/states/ssh_auth.py
@@ -44,6 +44,20 @@ to use a YAML 'explicit key', as demonstrated in the second example below.
           - ssh-dss AAAAB3NzaCL0sQ9fJ5bYTEyY== user@domain
           - option3="value3" ssh-dss AAAAB3NzaC1kcQ9J5bYTEyY== other@testdomain
           - AAAAB3NzaC1kcQ9fJFF435bYTEyY== newcomment
+
+    sshkeys:
+      ssh_auth.manage:
+        - user: root
+        - enc: ssh-rsa
+        - options:
+          - option1="value1"
+          - option2="value2 flag2"
+        - comment: myuser
+        - ssh_keys:
+          - AAAAB3NzaC1kc3MAAACBAL0sQ9fJ5bYTEyY==
+          - ssh-dss AAAAB3NzaCL0sQ9fJ5bYTEyY== user@domain
+          - option3="value3" ssh-dss AAAAB3NzaC1kcQ9J5bYTEyY== other@testdomain
+          - AAAAB3NzaC1kcQ9fJFF435bYTEyY== newcomment
 '''
 
 # Import python libs
@@ -125,7 +139,7 @@ def _present_test(user, name, enc, comment, options, source, config, fingerprint
     elif check == 'exists':
         result = True
         comment = ('The authorized host key {0} is already present '
-                          'for user {1}'.format(name, user))
+                   'for user {1}'.format(name, user))
 
     return result, comment
 
@@ -325,7 +339,7 @@ def present(
                         saltenv=__env__,
                         fingerprint_hash_type=fingerprint_hash_type)
             else:
-                # Split keyline to get key und comment
+                # Split keyline to get key and comment
                 keyline = keyline.split(' ')
                 key_type = keyline[0]
                 key_value = keyline[1]
@@ -504,5 +518,106 @@ def absent(name,
         return ret
     elif ret['comment'] == 'Key removed':
         ret['changes'][name] = 'Removed'
+
+    return ret
+
+
+def manage(
+        name,
+        ssh_keys,
+        user,
+        enc='ssh-rsa',
+        comment='',
+        source='',
+        options=None,
+        config='.ssh/authorized_keys',
+        fingerprint_hash_type=None,
+        **kwargs):
+    '''
+    .. versionadded:: Neon
+
+    Ensures that only the specified ssh_keys are present for the specified user
+
+    ssh_keys
+        The SSH key to manage
+
+    user
+        The user who owns the SSH authorized keys file to modify
+
+    enc
+        Defines what type of key is being used; can be ed25519, ecdsa, ssh-rsa
+        or ssh-dss
+
+    comment
+        The comment to be placed with the SSH public key
+
+    source
+        The source file for the key(s). Can contain any number of public keys,
+        in standard "authorized_keys" format. If this is set, comment and enc
+        will be ignored.
+
+    .. note::
+        The source file must contain keys in the format ``<enc> <key>
+        <comment>``. If you have generated a keypair using PuTTYgen, then you
+        will need to do the following to retrieve an OpenSSH-compatible public
+        key.
+
+        1. In PuTTYgen, click ``Load``, and select the *private* key file (not
+           the public key), and click ``Open``.
+        2. Copy the public key from the box labeled ``Public key for pasting
+           into OpenSSH authorized_keys file``.
+        3. Paste it into a new file.
+
+    options
+        The options passed to the keys, pass a list object
+
+    config
+        The location of the authorized keys file relative to the user's home
+        directory, defaults to ".ssh/authorized_keys". Token expansion %u and
+        %h for username and home path supported.
+
+    fingerprint_hash_type
+        The public key fingerprint hash type that the public key fingerprint
+        was originally hashed with. This defaults to ``md5`` if not specified.
+
+        .. note::
+
+            The default value of the ``fingerprint_hash_type`` will change to
+            ``sha256`` in Salt 2017.7.0.
+    '''
+    ret = {'name': '',
+           'changes': {},
+           'result': True,
+           'comment': ''}
+
+    all_potential_keys = []
+    for ssh_key in ssh_keys:
+        # gather list potential ssh keys for removal comparison
+        # options, enc, and comments could be in the mix
+        all_potential_keys.extend(ssh_key.split(' '))
+    existing_keys = __salt__['ssh.auth_keys'](user=user).keys()
+    remove_keys = set(existing_keys).difference(all_potential_keys)
+    for remove_key in remove_keys:
+        if __opts__['test']:
+            remove_comment = '{0} Key set for removal'.format(remove_key)
+            ret['comment'] = remove_comment
+            ret['result'] = None
+        else:
+            remove_comment = absent(remove_key, user)['comment']
+            ret['changes'][remove_key] = remove_comment
+
+    for ssh_key in ssh_keys:
+        run_return = present(ssh_key, user, enc, comment, source,
+                             options, config, fingerprint_hash_type, **kwargs)
+        if run_return['changes']:
+            ret['changes'].update(run_return['changes'])
+        else:
+            ret['comment'] += '\n' + run_return['comment']
+            ret['comment'].strip()
+
+        if run_return['result'] is None:
+            ret['result'] = None
+        elif not run_return['result']:
+            ret['result'] = False
 
     return ret


### PR DESCRIPTION
### What does this PR do?
Replacement for #49776

Creates a new ssh_auth.manage state to be used to both add *and remove* ssh keys

### What issues does this PR fix or reference?
#13340
#18252

### Previous Behavior
ssh_auth.present was only able to add keys. Any old keys not managed by salt need to be removed by specifying them in a ssh_auth.absent state.

### New Behavior
By using ssh_auth.manage, ssh keys not added by salt will be removed.

state example
```
all_ssh_keys:
  ssh_auth.manage:
    - user: testuser
    - enc: ssh-dss
    - options:
      - option1="value1"
    - ssh_keys:
      - AQCs0iRPhge71mk8W9VPee5geA38T9I6AzDX8nLZ4JyJtF9Pv/QpthDikBu0oe/vNSaNFrFbfGir1MLm15bw+9aZeAJ6p61UqkXS/yxCFiWOVUwLu59kLk+Zltt9QR2pReMVjABbLkaeSguhUO+N2Sx0t/xc+7DDpDGK7Uj/76YwQAL5C4Jj+K6UKdVyXoaA4ONrFWtFhTyZmCHIY+sFZbosu7M+JsJbzn/36E6Zg8noCvdfEZZMUPR7qMEl1TlHMDJZ8IDvDQMLLR02T7/vnCT59ahuutUGtaGpJT9RrodlJdDMyMwKR8dEhGqs+t3zl7p2yCiURSJf/zosikWFEUVr
      - ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAklOUpkDHrfHY17SbrmTIpNLTGK9Tjom/BWDSUGPl+nafzlHDTYW7hdI4yZ5ew18JH4JW9jbhUFrviQzM7xlELEVf4h9lFX5QVkbPppSwg0cda3Pbv7kOdJ/MTyBlWXFCR+HAo3FXRitBqxiX1nKhXpHAZsMciLq8V6RjsNAQwdsdMFvSlVK/7XAt3FaoJoAsncM1Q9x5+3V0Ww68/eIFmb1zuUFljQJKprrX88XypNDvjYNby6vw/Pb0rwert/EnmZ+AW4OZPnTPI89ZPmVMLuayrD2cE86Z/il8b+gw3r3+1nKatmIkjn2so1d01QraTlMqVSsbxNrRFi9wrf+M7Q== schacon@mylaptop.local
      - AAAAB3NzaC1kcQ9J5bYTEyY== other@testdomain
```

add key result
```
local:
----------
          ID: all_ssh_keys
    Function: ssh_auth.manage
      Result: True
     Comment: The authorized host key AQCs0iRPhge71mk8W9VPee5geA38T9I6AzDX8nLZ4JyJtF9Pv/QpthDikBu0oe/vNSaNFrFbfGir1MLm15bw+9aZeAJ6p61UqkXS/yxCFiWOVUwLu59kLk+Zltt9QR2pReMVjABbLkaeSguhUO+N2Sx0t/xc+7DDpDGK7Uj/76YwQAL5C4Jj+K6UKdVyXoaA4ONrFWtFhTyZmCHIY+sFZbosu7M+JsJbzn/36E6Zg8noCvdfEZZMUPR7qMEl1TlHMDJZ8IDvDQMLLR02T7/vnCT59ahuutUGtaGpJT9RrodlJdDMyMwKR8dEhGqs+t3zl7p2yCiURSJf/zosikWFEUVr is already present for user testuser
              The authorized host key AAAAB3NzaC1yc2EAAAABIwAAAQEAklOUpkDHrfHY17SbrmTIpNLTGK9Tjom/BWDSUGPl+nafzlHDTYW7hdI4yZ5ew18JH4JW9jbhUFrviQzM7xlELEVf4h9lFX5QVkbPppSwg0cda3Pbv7kOdJ/MTyBlWXFCR+HAo3FXRitBqxiX1nKhXpHAZsMciLq8V6RjsNAQwdsdMFvSlVK/7XAt3FaoJoAsncM1Q9x5+3V0Ww68/eIFmb1zuUFljQJKprrX88XypNDvjYNby6vw/Pb0rwert/EnmZ+AW4OZPnTPI89ZPmVMLuayrD2cE86Z/il8b+gw3r3+1nKatmIkjn2so1d01QraTlMqVSsbxNrRFi9wrf+M7Q== is already present for user testuser
     Started: 04:35:14.598329
    Duration: 8.24 ms
     Changes:
              ----------
              AAAAB3NzaC1kcQ9J5bYTEyY==:
                  New

Summary for local
------------
Succeeded: 1 (changed=1)
Failed:    0
------------
Total states run:     1
Total run time:   8.240 ms
```

remove key result
```
local:
----------
          ID: all_ssh_keys
    Function: ssh_auth.manage
      Result: True
     Comment: The authorized host key AQCs0iRPhge71mk8W9VPee5geA38T9I6AzDX8nLZ4JyJtF9Pv/QpthDikBu0oe/vNSaNFrFbfGir1MLm15bw+9aZeAJ6p61UqkXS/yxCFiWOVUwLu59kLk+Zltt9QR2pReMVjABbLkaeSguhUO+N2Sx0t/xc+7DDpDGK7Uj/76YwQAL5C4Jj+K6UKdVyXoaA4ONrFWtFhTyZmCHIY+sFZbosu7M+JsJbzn/36E6Zg8noCvdfEZZMUPR7qMEl1TlHMDJZ8IDvDQMLLR02T7/vnCT59ahuutUGtaGpJT9RrodlJdDMyMwKR8dEhGqs+t3zl7p2yCiURSJf/zosikWFEUVr is already present for user testuser
              The authorized host key AAAAB3NzaC1yc2EAAAABIwAAAQEAklOUpkDHrfHY17SbrmTIpNLTGK9Tjom/BWDSUGPl+nafzlHDTYW7hdI4yZ5ew18JH4JW9jbhUFrviQzM7xlELEVf4h9lFX5QVkbPppSwg0cda3Pbv7kOdJ/MTyBlWXFCR+HAo3FXRitBqxiX1nKhXpHAZsMciLq8V6RjsNAQwdsdMFvSlVK/7XAt3FaoJoAsncM1Q9x5+3V0Ww68/eIFmb1zuUFljQJKprrX88XypNDvjYNby6vw/Pb0rwert/EnmZ+AW4OZPnTPI89ZPmVMLuayrD2cE86Z/il8b+gw3r3+1nKatmIkjn2so1d01QraTlMqVSsbxNrRFi9wrf+M7Q== is already present for user testuser
     Started: 04:34:56.420524
    Duration: 8.936 ms
     Changes:
              ----------
              AAAAB3NzaC1kcQ9J5bYTEyY==:
                  Key removed

Summary for local
------------
Succeeded: 1 (changed=1)
Failed:    0
------------
Total states run:     1
Total run time:   8.936 ms
```

add with test
```
# salt-call --local state.sls ssh_test test=True
local:
----------
          ID: all_ssh_keys
    Function: ssh_auth.manage
      Result: None
     Comment: The authorized host key AQCs0iRPhge71mk8W9VPee5geA38T9I6AzDX8nLZ4JyJtF9Pv/QpthDikBu0oe/vNSaNFrFbfGir1MLm15bw+9aZeAJ6p61UqkXS/yxCFiWOVUwLu59kLk+Zltt9QR2pReMVjABbLkaeSguhUO+N2Sx0t/xc+7DDpDGK7Uj/76YwQAL5C4Jj+K6UKdVyXoaA4ONrFWtFhTyZmCHIY+sFZbosu7M+JsJbzn/36E6Zg8noCvdfEZZMUPR7qMEl1TlHMDJZ8IDvDQMLLR02T7/vnCT59ahuutUGtaGpJT9RrodlJdDMyMwKR8dEhGqs+t3zl7p2yCiURSJf/zosikWFEUVr is already present for user testuser
              The authorized host key AAAAB3NzaC1yc2EAAAABIwAAAQEAklOUpkDHrfHY17SbrmTIpNLTGK9Tjom/BWDSUGPl+nafzlHDTYW7hdI4yZ5ew18JH4JW9jbhUFrviQzM7xlELEVf4h9lFX5QVkbPppSwg0cda3Pbv7kOdJ/MTyBlWXFCR+HAo3FXRitBqxiX1nKhXpHAZsMciLq8V6RjsNAQwdsdMFvSlVK/7XAt3FaoJoAsncM1Q9x5+3V0Ww68/eIFmb1zuUFljQJKprrX88XypNDvjYNby6vw/Pb0rwert/EnmZ+AW4OZPnTPI89ZPmVMLuayrD2cE86Z/il8b+gw3r3+1nKatmIkjn2so1d01QraTlMqVSsbxNrRFi9wrf+M7Q== is already present for user testuser
              Key AAAAB3NzaC1kcQ9J5bYTEyY== for user testuser is set to be added
     Started: 04:35:08.432708
    Duration: 7.18 ms
     Changes:

Summary for local
------------
Succeeded: 1 (unchanged=1)
Failed:    0
------------
Total states run:     1
Total run time:   7.180 ms
```

### Tests written?
No

### Commits signed with GPG?
No