### PR TITLE
Fix #50142, stringutils.to_none

### DIFF
--- a/salt/utils/stringutils.py
+++ b/salt/utils/stringutils.py
@@ -183,7 +183,7 @@ def to_none(text):
     '''
     Convert a string to None if the string is empty or contains only spaces.
     '''
-    if six.tex_type(text).strip():
+    if six.text_type(text).strip():
         return text
     return None
 

--- a/tests/unit/utils/test_stringutils.py
+++ b/tests/unit/utils/test_stringutils.py
@@ -122,6 +122,13 @@ class StringutilsTestCase(TestCase):
         self.assertEqual(salt.utils.stringutils.to_num('Seven'), 'Seven')
         self.assertIsInstance(salt.utils.stringutils.to_num('Seven'), six.text_type)
 
+    def test_to_none(self):
+        self.assertIsNone(salt.utils.stringutils.to_none(''))
+        self.assertIsNone(salt.utils.stringutils.to_none('  '))
+        # Ensure that we do not inadvertently convert certain strings or 0 to None
+        self.assertIsNotNone(salt.utils.stringutils.to_none('None'))
+        self.assertIsNotNone(salt.utils.stringutils.to_none(0))
+
     def test_is_binary(self):
         self.assertFalse(salt.utils.stringutils.is_binary(LOREM_IPSUM))
         # Also test bytestring


### PR DESCRIPTION
### What does this PR do?

Fixes an AttributeError in `stringutils.to_none` by correcting the typo `tex_type`, which was introduced in PR #45429.

### What issues does this PR fix or reference?

#50142

### Previous Behavior

The `to_none` function was broken.

### New Behavior

The `to_none` function is no longer broken.

### Tests written?

Yes

### Commits signed with GPG?

Yes
