### PR TITLE
Use newest winrm-fs release

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ end
 
 group :windows do
   gem 'winrm', '~>2.0'
-  gem 'winrm-fs', :git => 'https://github.com/dwoz/winrm-fs.git', :branch => 'chunked_downloads'
+  gem 'winrm-fs', '~>1.3.1' 
 end
 
 group :ec2 do


### PR DESCRIPTION
### What does this PR do?

Switch `winrm-fs` to use the newest release.

### Tests written?

No

### Commits signed with GPG?

Yes