### PR TITLE
make toml serializer discoverable in docs

### DIFF
--- a/doc/ref/serializers/all/index.rst
+++ b/doc/ref/serializers/all/index.rst
@@ -14,5 +14,6 @@ serializer modules
     json
     msgpack
     python
+    toml
     yaml
     yamlex

--- a/doc/ref/serializers/all/salt.serializers.toml.rst
+++ b/doc/ref/serializers/all/salt.serializers.toml.rst
@@ -1,0 +1,6 @@
+=====================
+salt.serializers.toml
+=====================
+
+.. automodule:: salt.serializers.toml
+    :members:


### PR DESCRIPTION
### What does this PR do?
Simply adds toml to serializer docs.
Toml was added in #45054, so this may need to be backported. 