### PR TITLE
Improve handling of non-ascii characters in terminal output. (Fixes: #49523)

### DIFF
--- a/salt/utils/vt.py
+++ b/salt/utils/vt.py
@@ -53,6 +53,7 @@ except ImportError:
 
 # Import salt libs
 import salt.utils.crypt
+import salt.utils.data
 import salt.utils.stringutils
 from salt.ext.six import string_types
 from salt.log.setup import LOG_LEVELS
@@ -685,7 +686,7 @@ class Terminal(object):
                         stdout = None
                     else:
                         if self.stream_stdout:
-                            self.stream_stdout.write(stdout)
+                            self.stream_stdout.write(salt.utils.data.encode(stdout))
                             self.stream_stdout.flush()
 
                         if self.stdout_logger:
@@ -703,7 +704,7 @@ class Terminal(object):
                     if self.child_fd is not None:
                         fcntl.fcntl(self.child_fd, fcntl.F_SETFL, fd_flags)
             # <---- Process STDOUT -------------------------------------------
-            return stdout, stderr
+            return salt.utils.data.encode(stdout), salt.utils.data.encode(stderr)
 
         def __detect_parent_terminal_size(self):
             try:


### PR DESCRIPTION
### What does this PR do?

Prevents exception when stdout contains non-ascii characters.

### What issues does this PR fix or reference?

- #49523

### Tests written?

No

### Commits signed with GPG?

Yes