### PR TITLE
[2018.3] Fix to modules/network.py

### DIFF
--- a/salt/modules/network.py
+++ b/salt/modules/network.py
@@ -1704,7 +1704,7 @@ def get_route(ip):
     if __grains__['kernel'] == 'Linux':
         cmd = 'ip route get {0}'.format(ip)
         out = __salt__['cmd.run'](cmd, python_shell=True)
-        regexp = re.compile(r'(via\s+(?P<gateway>[\w\.:]+))?\s+dev\s+(?P<interface>[\w\.\:]+)\s+.*src\s+(?P<source>[\w\.:]+)')
+        regexp = re.compile(r'(via\s+(?P<gateway>[\w\.:]+))?\s+dev\s+(?P<interface>[\w\.\:\-]+)\s+.*src\s+(?P<source>[\w\.:]+)')
         m = regexp.search(out.splitlines()[0])
         ret = {
             'destination': ip,

--- a/tests/unit/modules/test_network.py
+++ b/tests/unit/modules/test_network.py
@@ -5,6 +5,7 @@
 
 # Import Python Libs
 from __future__ import absolute_import, unicode_literals, print_function
+import logging
 import socket
 import os.path
 
@@ -26,7 +27,6 @@ import salt.modules.network as network
 from salt.exceptions import CommandExecutionError
 from salt._compat import ipaddress
 
-import logging
 log = logging.getLogger(__name__)
 
 

--- a/tests/unit/modules/test_network.py
+++ b/tests/unit/modules/test_network.py
@@ -26,6 +26,9 @@ import salt.modules.network as network
 from salt.exceptions import CommandExecutionError
 from salt._compat import ipaddress
 
+import logging
+log = logging.getLogger(__name__)
+
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
 class NetworkTestCase(TestCase, LoaderModuleMockMixin):
@@ -355,3 +358,47 @@ class NetworkTestCase(TestCase, LoaderModuleMockMixin):
 
             with patch.dict(network.__grains__, {'kernel': 'Linux'}):
                 self.assertListEqual(network.default_route('inet'), [])
+
+    def test_get_route(self):
+        '''
+        Test for return output from get_route
+        '''
+        mock_iproute = MagicMock(return_value='8.8.8.8 via 10.10.10.1 dev eth0 src 10.10.10.10 uid 0\ncache')
+        with patch.dict(network.__grains__, {'kernel': 'Linux'}):
+            with patch.dict(network.__salt__, {'cmd.run': mock_iproute}):
+                expected = {'interface': 'eth0',
+                            'source': '10.10.10.10',
+                            'destination': '8.8.8.8',
+                            'gateway': '10.10.10.1'}
+                ret = network.get_route('8.8.8.8')
+                self.assertEqual(ret, expected)
+
+        mock_iproute = MagicMock(return_value='8.8.8.8 via 10.10.10.1 dev eth0.1 src 10.10.10.10 uid 0\ncache')
+        with patch.dict(network.__grains__, {'kernel': 'Linux'}):
+            with patch.dict(network.__salt__, {'cmd.run': mock_iproute}):
+                expected = {'interface': 'eth0.1',
+                            'source': '10.10.10.10',
+                            'destination': '8.8.8.8',
+                            'gateway': '10.10.10.1'}
+                ret = network.get_route('8.8.8.8')
+                self.assertEqual(ret, expected)
+
+        mock_iproute = MagicMock(return_value='8.8.8.8 via 10.10.10.1 dev eth0:1 src 10.10.10.10 uid 0\ncache')
+        with patch.dict(network.__grains__, {'kernel': 'Linux'}):
+            with patch.dict(network.__salt__, {'cmd.run': mock_iproute}):
+                expected = {'interface': 'eth0:1',
+                            'source': '10.10.10.10',
+                            'destination': '8.8.8.8',
+                            'gateway': '10.10.10.1'}
+                ret = network.get_route('8.8.8.8')
+                self.assertEqual(ret, expected)
+
+        mock_iproute = MagicMock(return_value='8.8.8.8 via 10.10.10.1 dev lan-br0 src 10.10.10.10 uid 0\ncache')
+        with patch.dict(network.__grains__, {'kernel': 'Linux'}):
+            with patch.dict(network.__salt__, {'cmd.run': mock_iproute}):
+                expected = {'interface': 'lan-br0',
+                            'source': '10.10.10.10',
+                            'destination': '8.8.8.8',
+                            'gateway': '10.10.10.1'}
+                ret = network.get_route('8.8.8.8')
+                self.assertEqual(ret, expected)


### PR DESCRIPTION
### What does this PR do?
Fixing scenario where the interface for the default route has a dash in it, the regular expression used in get_route currently doesn't not account for this..  Adding some additional tests for network.get_route.

### What issues does this PR fix or reference?
#50129 

### Tests written?
Yes

### Commits signed with GPG?

Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
