### PR TITLE
Support regex status types in http.query state

### DIFF
--- a/salt/modules/http.py
+++ b/salt/modules/http.py
@@ -32,6 +32,9 @@ def query(url, **kwargs):
             params='key1=val1&key2=val2'
         salt '*' http.query http://somelink.com/ method=POST \
             data='<xml>somecontent</xml>'
+
+    For more information about the ``http.query`` module, refer to the
+    :ref:`HTTP Tutorial <tutorial-http>`.
     '''
     opts = __opts__.copy()
     if 'opts' in kwargs:

--- a/salt/states/http.py
+++ b/salt/states/http.py
@@ -20,7 +20,7 @@ __monitor__ = [
 log = logging.getLogger(__name__)
 
 
-def query(name, match=None, match_type='string', status=None, wait_for=None, **kwargs):
+def query(name, match=None, match_type='string', status=None, status_type='string', wait_for=None, **kwargs):
     '''
     Perform an HTTP query and statefully return the result
 
@@ -36,7 +36,7 @@ def query(name, match=None, match_type='string', status=None, wait_for=None, **k
         text.
 
     match_type
-        Specifies the type of pattern matching to use. Default is ``string``, but
+        Specifies the type of pattern matching to use on match. Default is ``string``, but
         can also be set to ``pcre`` to use regular expression matching if a more
         complex pattern matching is required.
 
@@ -49,6 +49,19 @@ def query(name, match=None, match_type='string', status=None, wait_for=None, **k
     status
         The status code for a URL for which to be checked. Can be used instead of
         or in addition to the ``match`` setting.
+
+    status_type
+        Specifies the type of pattern matching to use for status. Default is ``string``, but
+        can also be set to ``pcre`` to use regular expression matching if a more
+        complex pattern matching is required.
+
+        .. versionadded:: Neon
+
+        .. note::
+
+            Despite the name of ``match_type`` for this argument, this setting
+            actually uses Python's ``re.search()`` function rather than Python's
+            ``re.match()`` function.
 
     If both ``match`` and ``status`` options are set, both settings will be checked.
     However, note that if only one option is ``True`` and the other is ``False``,
@@ -94,14 +107,14 @@ def query(name, match=None, match_type='string', status=None, wait_for=None, **k
 
     if match is not None:
         if match_type == 'string':
-            if match in data.get('text', ''):
+            if str(match) in data.get('text', ''):
                 ret['result'] = True
                 ret['comment'] += ' Match text "{0}" was found.'.format(match)
             else:
                 ret['result'] = False
                 ret['comment'] += ' Match text "{0}" was not found.'.format(match)
         elif match_type == 'pcre':
-            if re.search(match, data.get('text', '')):
+            if re.search(str(match), str(data.get('text', ''))):
                 ret['result'] = True
                 ret['comment'] += ' Match pattern "{0}" was found.'.format(match)
             else:
@@ -109,13 +122,22 @@ def query(name, match=None, match_type='string', status=None, wait_for=None, **k
                 ret['comment'] += ' Match pattern "{0}" was not found.'.format(match)
 
     if status is not None:
-        if data.get('status', '') == status:
-            ret['comment'] += 'Status {0} was found, as specified.'.format(status)
-            if ret['result'] is None:
-                ret['result'] = True
-        else:
-            ret['comment'] += 'Status {0} was not found, as specified.'.format(status)
-            ret['result'] = False
+        if status_type == 'string':
+            if data.get('status', '') == str(status)x:
+                ret['comment'] += 'Status {0} was found.'.format(status)
+                if ret['result'] is None:
+                    ret['result'] = True
+            else:
+                ret['comment'] += 'Status {0} was not found.'.format(status)
+                ret['result'] = False
+        elif status_type == 'pcre':
+            if re.search(str(status), str(data.get('status', ''))):
+                ret['comment'] += ' Status pattern "{0}" was found.'.format(status)
+                if ret['result'] is None:
+                    ret['result'] = True
+            else:
+                ret['comment'] += ' Status pattern "{0}" was not found.'.format(status)
+                ret['result'] = False
 
     if __opts__['test'] is True:
         ret['result'] = None

--- a/salt/states/http.py
+++ b/salt/states/http.py
@@ -124,11 +124,11 @@ def query(name, match=None, match_type='string', status=None, status_type='strin
     if status is not None:
         if status_type == 'string':
             if data.get('status', '') == str(status):
-                ret['comment'] += 'Status {0} was found.'.format(status)
+                ret['comment'] += ' Status {0} was found.'.format(status)
                 if ret['result'] is None:
                     ret['result'] = True
             else:
-                ret['comment'] += 'Status {0} was not found.'.format(status)
+                ret['comment'] += ' Status {0} was not found.'.format(status)
                 ret['result'] = False
         elif status_type == 'pcre':
             if re.search(str(status), str(data.get('status', ''))):
@@ -138,6 +138,9 @@ def query(name, match=None, match_type='string', status=None, status_type='strin
             else:
                 ret['comment'] += ' Status pattern "{0}" was not found.'.format(status)
                 ret['result'] = False
+
+    # cleanup spaces in comment
+    ret['comment'] = ret['comment'].strip()
 
     if __opts__['test'] is True:
         ret['result'] = None

--- a/salt/states/http.py
+++ b/salt/states/http.py
@@ -123,7 +123,7 @@ def query(name, match=None, match_type='string', status=None, status_type='strin
 
     if status is not None:
         if status_type == 'string':
-            if data.get('status', '') == str(status)x:
+            if data.get('status', '') == str(status):
                 ret['comment'] += 'Status {0} was found.'.format(status)
                 if ret['result'] is None:
                     ret['result'] = True

--- a/salt/utils/http.py
+++ b/salt/utils/http.py
@@ -754,7 +754,7 @@ def update_ca_bundle(
         source=None,
         opts=None,
         merge_files=None,
-    ):
+        ):
     '''
     Attempt to update the CA bundle file from a URL
 

--- a/tests/unit/states/test_http.py
+++ b/tests/unit/states/test_http.py
@@ -44,3 +44,27 @@ class HttpTestCase(TestCase, LoaderModuleMockMixin):
             with patch.dict(http.__salt__, {'http.query': mock}):
                 self.assertDictEqual(http.query("salt", "Dude", "stack"),
                                      ret[1])
+
+    def test_query_statustype(self):
+        '''
+            Test to perform an HTTP query and statefully return the result
+        '''
+        testurl = "salturl"
+        http_result = {
+                        "text": "This page returned a 201 status code",
+                        "status": "201"
+                      }
+        state_return = {'changes': {},
+                        'comment': 'Match text "This page returned" was found. Status pattern "200|201" was found.',
+                        'data': {'status': '201', 'text': 'This page returned a 201 status code'},
+                        'name': testurl,
+                        'result': True}
+
+        with patch.dict(http.__opts__, {'test': False}):
+            mock = MagicMock(return_value=http_result)
+            with patch.dict(http.__salt__, {'http.query': mock}):
+                self.assertDictEqual(http.query(testurl,
+                                                match="This page returned",
+                                                status="200|201",
+                                                status_type='pcre'
+                                                ), state_return)


### PR DESCRIPTION
### What does this PR do?
Adds `status_type` to http.query state to support pcre expressions

### What issues does this PR fix or reference?
#50067

### New Behavior
Supports states like the following (note `status_type` and `status`)
```
{% set statuses = [200, 201] %}
{% for status in statuses %}
verifty_status_{{ status }}:
  http.query:
    - name: http://the-internet.herokuapp.com/status_codes/{{ status }}
    - status: 200|201
    - status_type: pcre
    - match: "This page returned a"
{% endfor %}
```

### Tests written?
Yes

### Commits signed with GPG?
No