### PR TITLE
Method-calling filter for use in Jinja's `map` filter.

### DIFF
--- a/doc/topics/jinja/index.rst
+++ b/doc/topics/jinja/index.rst
@@ -642,6 +642,56 @@ Returns:
   1, 4
 
 
+.. jinja_ref:: method_call
+
+``method_call``
+---------------
+
+.. versionadded:: develop
+
+Returns a result of object's method call.
+
+Example #1:
+
+.. code-block:: jinja
+
+  {{ [1, 2, 1, 3, 4] | method_call('index', 1, 1, 3) }}
+
+Returns:
+
+.. code-block:: text
+
+  2
+
+This filter can be used with the `map filter`_ to apply object methods without
+using loop constructs or temporary variables.
+
+Example #2:
+
+.. code-block:: jinja
+
+  {% set host_list = ['web01.example.com', 'db01.example.com'] %}
+  {% set host_list_split = [] %}
+  {% for item in host_list %}
+    {% do host_list_split.append(item.split('.', 1)) %}
+  {% endfor %}
+  {{ host_list_split }}
+
+Example #3:
+
+.. code-block:: jinja
+
+  {{ host_list|map('method_call', 'split', '.', 1)|list }}
+
+Return of examples #2 and #3:
+
+.. code-block:: text
+
+  [[web01, example.com], [db01, example.com]]
+
+.. _`map filter`: http://jinja.pocoo.org/docs/2.10/templates/#map
+
+
 .. jinja_ref:: is_sorted
 
 ``is_sorted``

--- a/doc/topics/jinja/index.rst
+++ b/doc/topics/jinja/index.rst
@@ -647,7 +647,7 @@ Returns:
 ``method_call``
 ---------------
 
-.. versionadded:: develop
+.. versionadded:: Neon
 
 Returns a result of object's method call.
 

--- a/salt/utils/jinja.py
+++ b/salt/utils/jinja.py
@@ -636,6 +636,11 @@ def symmetric_difference(lst1, lst2):
     return unique([ele for ele in union(lst1, lst2) if ele not in intersect(lst1, lst2)])
 
 
+@jinja_filter('method_call')
+def method_call(obj, f_name, *f_args, **f_kwargs):
+    return getattr(obj, f_name, lambda *args, **kwargs: None)(*f_args, **f_kwargs)
+
+
 @jinja2.contextfunction
 def show_full_context(ctx):
     return salt.utils.data.simple_types_filter({key: value for key, value in ctx.items()})

--- a/tests/unit/utils/test_jinja.py
+++ b/tests/unit/utils/test_jinja.py
@@ -1231,6 +1231,33 @@ class TestCustomExtensions(TestCase):
                                      dict(opts=self.local_opts, saltenv='test', salt=self.local_salt))
         self.assertEqual(rendered, '1, 4')
 
+    def test_method_call(self):
+        '''
+        Test the `method_call` Jinja filter.
+        '''
+        rendered = render_jinja_tmpl("{{ 6|method_call('bit_length') }}",
+                                     dict(opts=self.local_opts, saltenv='test', salt=self.local_salt))
+        self.assertEqual(rendered, "3")
+        rendered = render_jinja_tmpl("{{ 6.7|method_call('is_integer') }}",
+                                     dict(opts=self.local_opts, saltenv='test', salt=self.local_salt))
+        self.assertEqual(rendered, "False")
+        rendered = render_jinja_tmpl("{{ 'absaltba'|method_call('strip', 'ab') }}",
+                                     dict(opts=self.local_opts, saltenv='test', salt=self.local_salt))
+        self.assertEqual(rendered, "salt")
+        rendered = render_jinja_tmpl("{{ [1, 2, 1, 3, 4]|method_call('index', 1, 1, 3) }}",
+                                     dict(opts=self.local_opts, saltenv='test', salt=self.local_salt))
+        self.assertEqual(rendered, "2")
+
+        # have to use `dictsort` to keep test result deterministic
+        rendered = render_jinja_tmpl("{{ {}|method_call('fromkeys', ['a', 'b', 'c'], 0)|dictsort }}",
+                                     dict(opts=self.local_opts, saltenv='test', salt=self.local_salt))
+        self.assertEqual(rendered, "[('a', 0), ('b', 0), ('c', 0)]")
+
+        # missing object method test
+        rendered = render_jinja_tmpl("{{ 6|method_call('bit_width') }}",
+                                     dict(opts=self.local_opts, saltenv='test', salt=self.local_salt))
+        self.assertEqual(rendered, "None")
+
     def test_md5(self):
         '''
         Test the `md5` Jinja filter.


### PR DESCRIPTION
### What does this PR do?
The purpose of this PR is to introduce a `method_call` Jinja filter which by itself doesn't expose new functionality, but when carefully used with other filters, like [`map()`](http://jinja.pocoo.org/docs/2.10/templates/#map), can lead to significant reduction in templating boilerplate.