### PR TITLE
[DOC] Fix JSON payload example in HTTP tutorial

### DIFF
--- a/doc/topics/tutorials/http.rst
+++ b/doc/topics/tutorials/http.rst
@@ -74,15 +74,15 @@ be overridden with the ``method`` argument:
     salt.utils.http.query('http://example.com/delete/url', 'DELETE')
 
 When using the ``POST`` method (and others, such as ``PUT``), extra data is usually
-sent as well. This data can be sent directly, in whatever format is
-required by the remote server (XML, JSON, plain text, etc).
+sent as well. This data can be sent directly (would be URL encoded when necessary),
+or in whatever format is required by the remote server (XML, JSON, plain text, etc).
 
 .. code-block:: python
 
     salt.utils.http.query(
-        'http://example.com/delete/url',
+        'http://example.com/post/url',
         method='POST',
-        data=json.loads(mydict)
+        data=json.dumps(mydict)
     )
 
 Data Formatting and Templating


### PR DESCRIPTION
### What does this PR do?
It corrects the HTTP tutorial doc page in the `POST` method with JSON example.

The `http.query` method will try to urlencode Python dictionary if supplied as `data` kwarg.
If you'd like to sent a JSON payload, the internal dictionary representation must be serialized with `json.dumps()` method instead of `loads()`.

### Tests written?
No

### Commits signed with GPG?
Yes