### PR TITLE
Add 2 second timeout on DNS socket check

### DIFF
--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -1909,6 +1909,7 @@ def dns_check(addr, port=80, safe=False, ipv6=None):
 
                 try:
                     s = socket.socket(h[0], socket.SOCK_STREAM)
+                    s.settimeout(2)
                     s.connect((candidate_addr.strip('[]'), h[4][1]))
                     s.close()
 


### PR DESCRIPTION
### What does this PR do?
Adds a 2 second timeout to the socket connect test in the check_dns function of network util.

### What issues does this PR fix or reference?
#50137 

### Previous Behavior
Attempt to connect to resolved address with default timeout.

### New Behavior
Attempt to connect to resolved address with 2 second timeout.

### Tests written?
No

### Commits signed with GPG?
No
