### PR TITLE
Skip the win_runas util test on non-windows

### DIFF
--- a/tests/integration/utils/test_win_runas.py
+++ b/tests/integration/utils/test_win_runas.py
@@ -20,9 +20,9 @@ import time
 
 import yaml
 from tests.support.case import ModuleCase
-from tests.support.helpers import with_system_user
 from tests.support.mock import Mock
 from tests.support.paths import CODE_DIR
+from tests.support.unit import skipIf
 
 from tests.support.helpers import (
     with_system_user,


### PR DESCRIPTION
This commit was added to a merge-forward to develop fix some test failures there. (See #50058.)

The fix is also needed on the Fluorine branch. (Replaces #50167.)