### PR TITLE
fix pillar_cache support for cacheing multi pillarenv

### DIFF
--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -322,7 +322,9 @@ class PillarCache(object):
             else:
                 # We found the minion but not the env. Store it.
                 fresh_pillar = self.fetch_pillar()
-                self.cache[self.minion_id][self.pillarenv] = fresh_pillar
+                self.cache[self.minion_id] = dict(self.cache[self.minion_id], **{
+                    self.pillarenv: fresh_pillar
+                })
                 log.debug('Pillar cache miss for pillarenv %s for minion %s', self.pillarenv, self.minion_id)
                 return fresh_pillar
         else:


### PR DESCRIPTION
### What does this PR do?
fix pillar_cache support for cacheing multi pillarenv

### What issues does this PR fix or reference?
No

### Previous Behavior
pillar_cache cannot support for cacheing multi pillarenv

### New Behavior
pillar_cache can support for cacheing multi pillarenv

### Tests written?
No

### Commits signed with GPG?
No