### PR TITLE
Revert curly braces example for nested dictionaries

### DIFF
--- a/doc/topics/troubleshooting/yaml_idiosyncrasies.rst
+++ b/doc/topics/troubleshooting/yaml_idiosyncrasies.rst
@@ -77,11 +77,11 @@ deeply-nested dict can be declared with curly braces:
         - group: root
         - mode: 644
         - template: jinja
-        - context:
-          custom_var: "override"
-        - defaults:
-            custom_var: "default value"
-            other_var: 123
+        - context: {
+          custom_var: "override" }
+        - defaults: {
+          custom_var: "default value",
+          other_var: 123 }
 
 Here is a more concrete example of how YAML actually handles these
 indentations, using the Python interpreter on the command line:


### PR DESCRIPTION
### What does this PR do?

The snippet in the docs with curly braces for nested dictionaries is incorrect (almost identical to the previous one): https://docs.saltstack.com/en/latest/topics/troubleshooting/yaml_idiosyncrasies.html#nested-dictionaries. The change was introduced in #47860.

This PR reverts the snippet to previous state. I did a test build with `make html` and `sphinx==1.7.9` and found no new warnings.

### Commits signed with GPG?

No


