### PR TITLE
Testinfra has a python packaging issue that is making version 1.17.0 fail to install some places

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,7 +4,7 @@ mock>=2.0.0
 SaltPyLint>=v2017.3.6
 pytest>=3.5.0
 git+https://github.com/saltstack/pytest-salt.git@master#egg=pytest-salt
-testinfra>=1.7.0
+testinfra>=1.7.0,!=1.17.0
 
 # httpretty Needs to be here for now even though it's a dependency of boto.
 # A pip install on a fresh system will decide to target httpretty 0.8.10 to


### PR DESCRIPTION
### What does this PR do?

Makes sure we don't try to install testinfra 1.17.0.

### What issues does this PR fix or reference?

```
Collecting testinfra>=1.7.0 (from -r /dev.txt (line 7))
  Downloading https://files.pythonhosted.org/packages/c7/db/1a46e12f5cab12c1b1a29f4ee680f06e1d107a1efd5b4c8769cdbe112558/testinfra-1.17.0.tar.gz (62kB)
    Complete output from command python setup.py egg_info:
    error in testinfra setup command: 'install_requires' must be a string or list of strings containing valid project/version requirement specifiers

    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-install-K4VeFO/testinfra/
The command '/bin/sh -c pip2 install -r /dev_python27.txt &&   pip2 install -r /zeromq.txt &&   pip2 install --upgrade 'tornado<5.0'' returned a non-zero code: 1
```

### New Behavior

testinfra installs properly.

### Commits signed with GPG?

Yes
