### PR TITLE
Added handling for minion return exceptions containing the word "return"

### DIFF
--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -1283,6 +1283,13 @@ class LocalClient(object):
                 if raw['data']['return'] == {}:
                     continue
 
+                # if the minion throws an exception containing the word "return"
+                # the master will try to handle the string as a dict in the next
+                # step. Check if we have a string, log the issue and continue.
+                if isinstance(raw['data']['return'], six.string_types):
+                    log.error("unexpected return from minion: %s", raw)
+                    continue
+
                 if 'return' in raw['data']['return'] and \
                     raw['data']['return']['return'] == {}:
                     continue


### PR DESCRIPTION
### What does this PR do?
This PR adds a check for the object type of the minion return to ensure we are dealing with a dict rather than a string containing 'return' (the key that the dict is looking for). This prevents a bad minion return from negatively impacting the master.

This bug was seen as far back as 2016.3 release

### What issues does this PR fix or reference?
I didn't find any existing issues documenting this case, but there is certainly the chance I missed one.

### Tests written?

No

### Commits signed with GPG?

Yes

