### PR TITLE
[2018.3] fixes to diskusage beacon

### DIFF
--- a/salt/beacons/diskusage.py
+++ b/salt/beacons/diskusage.py
@@ -12,6 +12,8 @@ from __future__ import absolute_import, unicode_literals
 import logging
 import re
 
+import salt.utils.platform
+
 # Import Third Party Libs
 try:
     import psutil
@@ -94,6 +96,9 @@ def beacon(config):
         if not mount.endswith('$'):
             mount_re = '{0}$'.format(mount)
 
+        if salt.utils.platform.is_windows():
+            mount_re = re.sub('\\$', '\\\\', mount_re)
+
         for part in parts:
             if re.match(mount_re, part.mountpoint):
                 _mount = part.mountpoint
@@ -106,7 +111,6 @@ def beacon(config):
 
                 current_usage = _current_usage.percent
                 monitor_usage = mounts[mount]
-                log.debug('current_usage %s', current_usage)
                 if '%' in monitor_usage:
                     monitor_usage = re.sub('%', '', monitor_usage)
                 monitor_usage = float(monitor_usage)

--- a/tests/unit/beacons/test_diskusage.py
+++ b/tests/unit/beacons/test_diskusage.py
@@ -41,7 +41,11 @@ STUB_DISK_USAGE = [namedtuple('usage',
                    namedtuple('usage',
                               'total used free percent')(100, 75, 25, 25)]
 
-WINDOWS_STUB_DISK_USAGE = namedtuple('usage','total used free percent')(1000, 500, 500, 50)
+WINDOWS_STUB_DISK_USAGE = namedtuple('usage',
+                                     'total used free percent')(1000,
+                                                                500,
+                                                                500,
+                                                                50)
 
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)

--- a/tests/unit/beacons/test_diskusage.py
+++ b/tests/unit/beacons/test_diskusage.py
@@ -23,10 +23,25 @@ STUB_DISK_PARTITION = [
         'device mountpoint fstype, opts')(
             '/dev/disk0s2', '/', 'hfs',
             'rw,local,rootfs,dovolfs,journaled,multilabel')]
+
+WINDOWS_STUB_DISK_PARTITION = [
+    namedtuple(
+        'partition',
+        'device mountpoint fstype, opts')(
+            'C:\\', 'C:\\', 'NTFS',
+            'rw,fixed'),
+    namedtuple(
+        'partition',
+        'device mountpoint fstype, opts')(
+            'D:\\', 'D:\\', 'CDFS',
+            'ro,cdrom')]
+
 STUB_DISK_USAGE = [namedtuple('usage',
                               'total used free percent')(1000, 500, 500, 50),
                    namedtuple('usage',
                               'total used free percent')(100, 75, 25, 25)]
+
+WINDOWS_STUB_DISK_USAGE = namedtuple('usage','total used free percent')(1000, 500, 500, 50)
 
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
@@ -94,3 +109,37 @@ class DiskUsageBeaconTestCase(TestCase, LoaderModuleMockMixin):
 
             ret = diskusage.beacon(config)
             self.assertEqual(ret, [{'diskusage': 50, 'mount': '/'}])
+
+    def test_diskusage_windows(self):
+        disk_usage_mock = Mock(return_value=WINDOWS_STUB_DISK_USAGE)
+        with patch('salt.utils.platform.is_windows',
+                   MagicMock(return_value=True)):
+            with patch('psutil.disk_partitions',
+                       MagicMock(return_value=WINDOWS_STUB_DISK_PARTITION)), \
+                    patch('psutil.disk_usage', disk_usage_mock):
+                config = [{'C:\\': '50%'}]
+
+                ret = diskusage.validate(config)
+
+                self.assertEqual(ret, (True, 'Valid beacon configuration'))
+
+                ret = diskusage.beacon(config)
+                self.assertEqual(ret, [{'diskusage': 50, 'mount': 'C:\\'}])
+
+    def test_diskusage_windows_match_regex(self):
+        disk_usage_mock = Mock(return_value=WINDOWS_STUB_DISK_USAGE)
+        with patch('salt.utils.platform.is_windows',
+                   MagicMock(return_value=True)):
+            with patch('psutil.disk_partitions',
+                       MagicMock(return_value=WINDOWS_STUB_DISK_PARTITION)), \
+                    patch('psutil.disk_usage', disk_usage_mock):
+                config = [{'^[a-zA-Z]:\\': '50%'}]
+
+                ret = diskusage.validate(config)
+
+                self.assertEqual(ret, (True, 'Valid beacon configuration'))
+
+                ret = diskusage.beacon(config)
+                _expected = [{u'diskusage': 50, u'mount': 'C:\\'},
+                             {u'diskusage': 50, u'mount': 'D:\\'}]
+                self.assertEqual(ret, _expected)


### PR DESCRIPTION
### What does this PR do?
Fixing a bug in the diskusage beacon that prevented it from working on Windows.  Adding a couple tests to test functionality on Windows.

### What issues does this PR fix or reference?
#49965 

### Previous Behavior
Diskusage beacon previously does not work under Windows because the mount (drive) that is based in the configuration is being interrupted as a pattern by the re library, so the result from psutil.disk_partitions does not match.

### New Behavior
In the event that the diskusage beacon is running on Windows, ensure that the necessary pattern is escaped so the interrupted result will match what is returned from psutil.

### Tests written?
Yes

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
