### PR TITLE
Allow IP detection via qemu-agent (proxmox salt-cloud)

### DIFF
--- a/doc/topics/cloud/proxmox.rst
+++ b/doc/topics/cloud/proxmox.rst
@@ -200,6 +200,9 @@ QEMU profile file (for a new VM):
     # Enable QEMU Guest Agent (0 / 1)
     agent: 1
 
+    # Use the QEMU Guest agent to determine the VM's IP (0 / 1)
+    agent_get_ip: 1
+
     # VM name
     name: Test
 

--- a/salt/cloud/clouds/proxmox.py
+++ b/salt/cloud/clouds/proxmox.py
@@ -595,7 +595,7 @@ def create(vm_):
     host = data['node']       # host which we have received
     nodeType = data['technology']  # VM tech (Qemu / OpenVZ)
 
-    if not nodeType == 'qemu':
+    if not 'agent_get_ip' in vm_ or vm_['agent_get_ip'] == 0:
         # Determine which IP to use in order of preference:
         if 'ip_address' in vm_:
             ip_address = six.text_type(vm_['ip_address'])
@@ -605,8 +605,6 @@ def create(vm_):
             ip_address = six.text_type(data['private_ips'][0])  # first IP
         else:
             raise SaltCloudExecutionFailure("Could not determine an IP address to use")
-
-        log.debug('Using IP address %s', ip_address)
 
     # wait until the vm has been created so we can start it
     if not wait_for_created(data['upid'], timeout=300):
@@ -774,21 +772,39 @@ def create(vm_):
         return {'Error': 'Unable to start {0}, command timed out'.format(name)}
 
     # For QEMU VMs, we can get the IP Address from qemu-agent
-    if nodeType == 'qemu':
+    if 'agent_get_ip' in vm_ and vm_['agent_get_ip'] == 1:
+        def __query_node(vm_):
+            log.debug("Waiting for qemu-agent to start...")
+            endpoint = 'nodes/{0}/qemu/{1}/agent/network-get-interfaces'.format(vm_['host'], vmid)
+            interfaces = query('get', endpoint)
+            if 'result' in interfaces:
+                for interface in interfaces['result']:
+                    if_name = interface['name']
+                    if if_name.startswith('eth') or if_name.startswith('ens'):
+                        for if_addr in interface['ip-addresses']:
+                            if if_addr['ip-address-type'] == 'ipv4':
+                                if if_addr['ip-address'] != None:
+                                    return six.text_type(if_addr['ip-address'])
+                raise SaltCloudExecutionFailure
+            else:
+                raise SaltCloudExecutionFailure
+        
         # We have to wait for a bit for qemu-agent to start
-        log.debug("Waiting for qemu-agent to start...")
-        time.sleep(20)
-        endpoint = 'nodes/{0}/qemu/{1}/agent/network-get-interfaces'.format(vm_['host'], vmid)
-        interfaces = query('get', endpoint)
-        if 'data' in interfaces and 'result' in interfaces['data']:
-            for interface in interfaces['data']['result']:
-                if_name = interface['name']
-                if if_name.startswith('eth') or if_name.startswith('ens'):
-                    for if_addr in interface['ip-addresses']:
-                        if if_addr['ip-address-type'] == 'ipv4':
-                            ip_address = six.text_type(if_addr['ip-address'])
-        else:
-            raise SaltCloudExecutionFailure
+        try:
+            ip_address = __utils__['cloud.wait_for_fun'](
+                __query_node,
+                vm_=vm_
+            )
+        except (SaltCloudExecutionTimeout, SaltCloudExecutionFailure) as exc:
+            try:
+                # If VM was created but we can't connect, destroy it.
+                destroy(vm_['name'])
+            except SaltCloudSystemExit:
+                pass
+            finally:
+                raise SaltCloudSystemExit(six.text_type(exc))
+
+    log.debug('Using IP address %s', ip_address)
 
     ssh_username = config.get_cloud_config_value(
         'ssh_username', vm_, __opts__, default='root'

--- a/salt/cloud/clouds/proxmox.py
+++ b/salt/cloud/clouds/proxmox.py
@@ -778,7 +778,7 @@ def create(vm_):
         # We have to wait for a bit for qemu-agent to start
         log.debug("Waiting for qemu-agent to start...")
         time.sleep(20)
-        endpoint = 'nodes/{0}/qemu/{1}/agent/network-get-interfaces'.format(vm['host'], vmid)
+        endpoint = 'nodes/{0}/qemu/{1}/agent/network-get-interfaces'.format(vm_['host'], vmid)
         interfaces = query('get', endpoint)
         if 'data' in interfaces and 'result' in interfaces['data']:
             for interface in interfaces['data']['result']:

--- a/salt/cloud/clouds/proxmox.py
+++ b/salt/cloud/clouds/proxmox.py
@@ -786,7 +786,7 @@ def create(vm_):
                                 if if_addr['ip-address'] is not None:
                                     return six.text_type(if_addr['ip-address'])
             raise SaltCloudExecutionFailure
-        
+
         # We have to wait for a bit for qemu-agent to start
         try:
             ip_address = __utils__['cloud.wait_for_fun'](

--- a/salt/cloud/clouds/proxmox.py
+++ b/salt/cloud/clouds/proxmox.py
@@ -595,7 +595,7 @@ def create(vm_):
     host = data['node']       # host which we have received
     nodeType = data['technology']  # VM tech (Qemu / OpenVZ)
 
-    if not 'agent_get_ip' in vm_ or vm_['agent_get_ip'] == 0:
+    if 'agent_get_ip' not in vm_ or vm_['agent_get_ip'] == 0:
         # Determine which IP to use in order of preference:
         if 'ip_address' in vm_:
             ip_address = six.text_type(vm_['ip_address'])
@@ -783,11 +783,9 @@ def create(vm_):
                     if if_name.startswith('eth') or if_name.startswith('ens'):
                         for if_addr in interface['ip-addresses']:
                             if if_addr['ip-address-type'] == 'ipv4':
-                                if if_addr['ip-address'] != None:
+                                if if_addr['ip-address'] is not None:
                                     return six.text_type(if_addr['ip-address'])
-                raise SaltCloudExecutionFailure
-            else:
-                raise SaltCloudExecutionFailure
+            raise SaltCloudExecutionFailure
         
         # We have to wait for a bit for qemu-agent to start
         try:


### PR DESCRIPTION
### What does this PR do?
Allows salt-cloud to create QEMU VMs and get their IP via the agent when using a Proxmox cloud.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/47771

### Previous Behavior
Would silently error out during a clone, as no IP address was determined for the new VM

### New Behavior
Checks if new VM is of type `qemu`, and uses the qemu agent to determine the IP.  This requires that qemu-guest-agent be installed to the source VM.

### Tests written?
No

### Commits signed with GPG?
No

This isn't really a solution so much as a workaround, looks like the develop branch may take an entirely different approach to the cloning process and I haven't had time to see if the issue persists in that branch.  These are simply the changes I made to my local installation in order to get it working for the time being.  

There is likely a more elegant way to detect whether the qemu-agent is running on the target VM than sleeping for 20 seconds, but I can't think of a way other than checking the URL repeatedly, which still won't work if qemu-agent isn't installed.

EDIT:  After a bit more review, looks like the develop branch doesn't actually change this behavior, so this may still be relevant there.