### PR TITLE
Add new key '__func__' to state event payloads 

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -2704,6 +2704,7 @@ class State(object):
             else:
                 running[tag] = self.call(low, chunks, running)
         if tag in running:
+            running[tag]['__func__'] = '{0}.{1}'.format(low['state'], low['fun'])
             self.event(running[tag], len(chunks), fire_event=low.get('fire_event'))
         return running
 

--- a/salt/state.py
+++ b/salt/state.py
@@ -2704,7 +2704,7 @@ class State(object):
             else:
                 running[tag] = self.call(low, chunks, running)
         if tag in running:
-            running[tag]['__func__'] = '{0}.{1}'.format(low['state'], low['fun'])
+            running[tag]['__saltfunc__'] = '{0}.{1}'.format(low['state'], low['fun'])
             self.event(running[tag], len(chunks), fire_event=low.get('fire_event'))
         return running
 


### PR DESCRIPTION
### What does this PR do?
Adds a new key '__func__' to the state event payloads containing '<state>.<command>'. This makes is a far easier to review the operation a state performed when using the event stream for job data analysis. Please feel free to re-name the key but this seemed to follow the current naming convention for internally-generated data.

### What issues does this PR fix or reference?
None

### Tests written?
No

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
