### PR TITLE
minion: avoid blocking dns resolution on connect

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -147,7 +147,8 @@ def resolve_dns(opts, fallback=True):
                 opts['master'],
                 int(opts['master_port']),
                 True,
-                opts['ipv6'])
+                opts['ipv6'],
+                attempt_connect=False)
         except SaltClientError:
             retry_dns_count = opts.get('retry_dns_count', None)
             if opts['retry_dns']:
@@ -169,7 +170,8 @@ def resolve_dns(opts, fallback=True):
                             opts['master'],
                             int(opts['master_port']),
                             True,
-                            opts['ipv6'])
+                            opts['ipv6'],
+                            attempt_connect=False)
                         break
                     except SaltClientError:
                         pass
@@ -221,7 +223,8 @@ def resolve_dns(opts, fallback=True):
             opts['source_address'],
             int(opts['source_ret_port']),
             True,
-            opts['ipv6'])
+            opts['ipv6'],
+            attempt_connect=False)
         log.debug('Using %s as source IP address', ret['source_ip'])
     if opts['source_ret_port']:
         ret['source_ret_port'] = int(opts['source_ret_port'])

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -1854,7 +1854,7 @@ def connection_check(addr, port=80, safe=False, ipv6=None):
 
 
 @jinja_filter('dns_check')
-def dns_check(addr, port=80, safe=False, ipv6=None):
+def dns_check(addr, port=80, safe=False, ipv6=None, attempt_connect=True):
     '''
     Return the ip resolved by dns, but do not exit on failure, only raise an
     exception. Obeys system preference for IPv4/6 address resolution - this
@@ -1905,18 +1905,24 @@ def dns_check(addr, port=80, safe=False, ipv6=None):
                     break
 
                 candidate_addr = salt.utils.zeromq.ip_bracket(h[4][0])
+
+                # sometimes /etc/hosts contains ::1 localhost
+                if not ipv6 and candidate_addr == '[::1]':
+                    continue
+
                 candidates.append(candidate_addr)
 
-                try:
-                    s = socket.socket(h[0], socket.SOCK_STREAM)
-                    s.settimeout(2)
-                    s.connect((candidate_addr.strip('[]'), h[4][1]))
-                    s.close()
+                if attempt_connect:
+                    try:
+                        s = socket.socket(h[0], socket.SOCK_STREAM)
+                        s.settimeout(2)
+                        s.connect((candidate_addr.strip('[]'), h[4][1]))
+                        s.close()
 
-                    resolved = candidate_addr
-                    break
-                except socket.error:
-                    pass
+                        resolved = candidate_addr
+                        break
+                    except socket.error:
+                        pass
             if not resolved:
                 if len(candidates) > 0:
                     resolved = candidates[0]


### PR DESCRIPTION
### What does this PR do?
the salt.utils.network.dns_check function used for resolution also
includes a blocking socket.connect to attempt to confirm the service on
the other side. This is a problem in salt.minion, as it's used as part
of eval_master continually to evaluate the master list; when a master
entry isn't alive / reachable, the socket.connect timeout will block the
minion entirely. This patch turns off that socket.connect for all
eval_master dns_check calls.

### What issues does this PR fix or reference?
n/a.

### Previous Behavior
salt.minion would block on dns resolution (actually, socket.connect inside dns_check)

### New Behavior
salt.minion no longer attempts a socket.connect

### Tests written?
no

### Commits signed with GPG?
no

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
