### PR TITLE
[2017.7] Ensure that tokens are hex to avoid hanging/errors in cherrypy

### DIFF
--- a/salt/netapi/rest_cherrypy/app.py
+++ b/salt/netapi/rest_cherrypy/app.py
@@ -2089,7 +2089,7 @@ class Events(object):
         # than hex, this will raise a ValueError.
         try:
             int(auth_token, 16)
-        except ValueError:
+        except (TypeError, ValueError):
             return False
 
         # First check if the given token is in our session table; if so it's a

--- a/salt/netapi/rest_cherrypy/app.py
+++ b/salt/netapi/rest_cherrypy/app.py
@@ -1078,6 +1078,13 @@ class LowDataAdapter(object):
                 if cherrypy.session.get('groups'):
                     chunk['__current_eauth_groups'] = cherrypy.session.get('groups')
 
+            if 'token' in chunk:
+                # Make sure that auth token is hex
+                try:
+                    int(chunk['token'], 16)
+                except (TypeError, ValueError):
+                    raise cherrypy.HTTPError(401, 'Invalid token')
+
             if client:
                 chunk['client'] = client
 
@@ -2078,7 +2085,11 @@ class Events(object):
 
         :return bool: True if valid, False if not valid.
         '''
-        if auth_token is None:
+        # Make sure that auth token is hex. If it's None, or something other
+        # than hex, this will raise a ValueError.
+        try:
+            int(auth_token, 16)
+        except ValueError:
             return False
 
         # First check if the given token is in our session table; if so it's a

--- a/tests/integration/netapi/rest_cherrypy/test_app.py
+++ b/tests/integration/netapi/rest_cherrypy/test_app.py
@@ -124,6 +124,45 @@ class TestRun(cptc.BaseRestCherryPyTest):
         })
         self.assertEqual(response.status, '401 Unauthorized')
 
+    def test_run_empty_token(self):
+        '''
+        Test the run URL with empty token
+        '''
+        cmd = dict(self.low, **{'token': ''})
+        body = urlencode(cmd)
+
+        request, response = self.request('/run', method='POST', body=body,
+            headers={
+                'content-type': 'application/x-www-form-urlencoded'
+        })
+        assert response.status == '401 Unauthorized'
+
+    def test_run_empty_token_upercase(self):
+        '''
+        Test the run URL with empty token with upercase characters
+        '''
+        cmd = dict(self.low, **{'ToKen': ''})
+        body = urlencode(cmd)
+
+        request, response = self.request('/run', method='POST', body=body,
+            headers={
+                'content-type': 'application/x-www-form-urlencoded'
+        })
+        assert response.status == '401 Unauthorized'
+
+    def test_run_wrong_token(self):
+        '''
+        Test the run URL with incorrect token
+        '''
+        cmd = dict(self.low, **{'token': 'bad'})
+        body = urlencode(cmd)
+
+        request, response = self.request('/run', method='POST', body=body,
+            headers={
+                'content-type': 'application/x-www-form-urlencoded'
+        })
+        assert response.status == '401 Unauthorized'
+
 
 class TestWebhookDisableAuth(cptc.BaseRestCherryPyTest):
 

--- a/tests/integration/netapi/rest_cherrypy/test_app.py
+++ b/tests/integration/netapi/rest_cherrypy/test_app.py
@@ -2,6 +2,7 @@
 
 # Import python libs
 from __future__ import absolute_import
+import os
 import json
 
 # Import salt libs
@@ -155,6 +156,32 @@ class TestRun(cptc.BaseRestCherryPyTest):
         Test the run URL with incorrect token
         '''
         cmd = dict(self.low, **{'token': 'bad'})
+        body = urlencode(cmd)
+
+        request, response = self.request('/run', method='POST', body=body,
+            headers={
+                'content-type': 'application/x-www-form-urlencoded'
+        })
+        assert response.status == '401 Unauthorized'
+
+    def test_run_pathname_token(self):
+        '''
+        Test the run URL with path that exists in token
+        '''
+        cmd = dict(self.low, **{'token': os.path.join('etc', 'passwd')})
+        body = urlencode(cmd)
+
+        request, response = self.request('/run', method='POST', body=body,
+            headers={
+                'content-type': 'application/x-www-form-urlencoded'
+        })
+        assert response.status == '401 Unauthorized'
+
+    def test_run_pathname_not_exists_token(self):
+        '''
+        Test the run URL with path that does not exist in token
+        '''
+        cmd = dict(self.low, **{'token': os.path.join('tmp', 'doesnotexist')})
         body = urlencode(cmd)
 
         request, response = self.request('/run', method='POST', body=body,


### PR DESCRIPTION
### What does this PR do?
Ensure that tokens are hex to avoid hanging/errors in cherrypy
