### PR TITLE
Fix broken install of additionnal modules in SPM packages

### DIFF
--- a/salt/spm/pkgfiles/local.py
+++ b/salt/spm/pkgfiles/local.py
@@ -129,7 +129,7 @@ def install_file(package, formula_tar, member, formula_def, conn=None):
             elif tag in ('s', 'm'):
                 pass
 
-    if new_name.startswith('{0}/_'.format(package)):
+    if member.name.startswith('{0}/_'.format(package)):
         if node_type in ('master', 'minion'):
             # Module files are distributed via extmods directory
             member.name = member.name.replace('{0}/_'.format(package), '')
@@ -141,7 +141,7 @@ def install_file(package, formula_tar, member, formula_def, conn=None):
         else:
             # Module files are distributed via _modules, _states, etc
             member.name = member.name.replace('{0}/'.format(package), '')
-    elif new_name == '{0}/pillar.example'.format(package):
+    elif member.name == '{0}/pillar.example'.format(package):
         # Pillars are automatically put in the pillar_path
         member.name = '{0}.sls.orig'.format(package)
         out_path = conn['pillar_path']


### PR DESCRIPTION
### What issues does this PR fix or reference?

Fixes #44554

Since the merging of PR #39543, the installation of additionnal modules presents in SPM packages (all directories starting with '_') has been broken.

### Tests written?

No

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
