### PR TITLE
Do not fail if process already ended

### DIFF
--- a/tests/support/helpers.py
+++ b/tests/support/helpers.py
@@ -1548,7 +1548,11 @@ def win32_kill_process_tree(pid, sig=signal.SIGTERM, include_parent=True,
     '''
     if pid == os.getpid():
         raise RuntimeError("I refuse to kill myself")
-    parent = psutil.Process(pid)
+    try:
+        parent = psutil.Process(pid)
+    except psutil.NoSuchProcess:
+        log.debug("PID not found alive: %d", pid)
+        return ([], [])
     children = parent.children(recursive=True)
     if include_parent:
         children.append(parent)


### PR DESCRIPTION
### What does this PR do?

We can expect the subprocess has already ended by the time we're
checking for child processes. Handle this case gracefully so that tests
do not fail with an exception.

https://jenkinsci.saltstack.com/view/all/job/dwoz-salt-windows-2016-py2/22/testReport/junit/integration.cli.test_batch/BatchTest/test_batch_run/

### Tests written?

No - Reduce flakiness in existing tests

### Commits signed with GPG?

Yes