### PR TITLE
[2018.3] Fixes to scheduler, list of whens plus splay

### DIFF
--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -1059,6 +1059,13 @@ class Schedule(object):
                         # last scheduled time in the past.
                         when = _when[0]
 
+                        if when < now - loop_interval and \
+                                not data.get('_run', False) and \
+                                not run and \
+                                not data['_splay']:
+                            data['_next_fire_time'] = None
+                            continue
+
                         if '_run' not in data:
                             # Prevent run of jobs from the past
                             data['_run'] = bool(when >= now - loop_interval)
@@ -1179,6 +1186,8 @@ class Schedule(object):
                 if data['_splay']:
                     # The "splay" configuration has been already processed, just use it
                     seconds = (data['_splay'] - now).total_seconds()
+                    if 'when' in data:
+                        data['_next_fire_time'] = data['_splay']
 
             if '_seconds' in data:
                 if seconds <= 0:


### PR DESCRIPTION
### What does this PR do?
Fixing an issue when a combination of the when parameter as a list plus using the splay parameter would cause the schedule to continuously run jobs in an endless loop, regardless of if their scheduled time had been receached.  Also fixing a related issue where scheduled jobs that rely on _next_fire_time were not being run as the corrected splayed time but rather running at the original scheduled time.  Adding new tests.

### What issues does this PR fix or reference?
#50162 

### Tests written?
Yes

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
