### PR TITLE
Fix 50227 malformed plists

### DIFF
--- a/salt/utils/mac_utils.py
+++ b/salt/utils/mac_utils.py
@@ -45,6 +45,11 @@ __salt__ = {
     'cmd.run': salt.modules.cmdmod._run_quiet,
 }
 
+if six.PY2:
+    class InvalidFileException(Exception):
+        pass
+    plistlib.InvalidFileException = InvalidFileException
+
 
 def __virtual__():
     '''

--- a/salt/utils/mac_utils.py
+++ b/salt/utils/mac_utils.py
@@ -11,6 +11,7 @@ import subprocess
 import os
 import plistlib
 import time
+import xml.parsers.expat
 try:
     import pwd
 except ImportError:
@@ -311,6 +312,12 @@ def launchctl(sub_cmd, *args, **kwargs):
 def _available_services(refresh=False):
     '''
     This is a helper function for getting the available macOS services.
+
+    The strategy is to look through the known system locations for
+    launchd plist files, parse them, and use their information for
+    populating the list of services. Services can run without a plist
+    file present, but normally services which have an automated startup
+    will have a plist file, so this is a minor compromise.
     '''
     try:
         if __context__['available_services'] and not refresh:
@@ -353,43 +360,47 @@ def _available_services(refresh=False):
                     continue
 
                 try:
-                    # This assumes most of the plist files
-                    # will be already in XML format
                     if six.PY2:
+                        # py2 plistlib can't read binary plists, and
+                        # uses a different API than py3.
                         plist = plistlib.readPlist(true_path)
                     else:
-                        with salt.utils.files.fopen(true_path, 'rb') as plist_handle:
-                            plist = plistlib.load(plist_handle)
+                        with salt.utils.files.fopen(true_path, 'rb') as handle:
+                            plist = plistlib.load(handle)
 
-                except Exception:
-                    # If plistlib is unable to read the file we'll need to use
-                    # the system provided plutil program to attempt conversion
-                    # from binary.
+                except plistlib.InvalidFileException:
+                    # Raised in python3 if the file is not XML.
+                    # There's nothing we can do; move on to the next one.
+                    msg = 'Unable to parse "%s" as it is invalid XML: InvalidFileException.'
+                    logging.warning(msg, true_path)
+                    continue
+
+                except xml.parsers.expat.ExpatError:
+                    # Raised by py2 for all errors.
+                    # Raised by py3 if the file is XML, but with errors.
+                    if six.PY3:
+                        # There's an error in the XML, so move on.
+                        msg = 'Unable to parse "%s" as it is invalid XML: xml.parsers.expat.ExpatError.'
+                        logging.warning(msg, true_path)
+                        continue
+
+                    # Use the system provided plutil program to attempt
+                    # conversion from binary.
                     cmd = '/usr/bin/plutil -convert xml1 -o - -- "{0}"'.format(
                         true_path)
                     try:
                         plist_xml = __salt__['cmd.run'](cmd)
-                        if six.PY2:
-                            plist = plistlib.readPlistFromString(plist_xml)
-                        else:
-                            plist = plistlib.loads(
-                                salt.utils.stringutils.to_bytes(plist_xml))
-                    except Exception:
-                        # If the file is actually just invalid XML, move on to
-                        # the next one.
+                        plist = plistlib.readPlistFromString(plist_xml)
+                    except xml.parsers.expat.ExpatError:
+                        # There's still an error in the XML, so move on.
+                        msg = 'Unable to parse "%s" as it is invalid XML: xml.parsers.expat.ExpatError.'
+                        logging.warning(msg, true_path)
                         continue
 
-                try:
-                    _available_services[plist.Label.lower()] = {
-                        'file_name': file_name,
-                        'file_path': true_path,
-                        'plist': plist}
-                except AttributeError:
-                    # Handle malformed plist files
-                    _available_services[os.path.basename(file_name).lower()] = {
-                        'file_name': file_name,
-                        'file_path': true_path,
-                        'plist': plist}
+                _available_services[plist['Label'].lower()] = {
+                    'file_name': file_name,
+                    'file_path': true_path,
+                    'plist': plist}
 
     # put this in __context__ as this is a time consuming function.
     # a fix for this issue. https://github.com/saltstack/salt/issues/48414

--- a/salt/utils/mac_utils.py
+++ b/salt/utils/mac_utils.py
@@ -336,7 +336,7 @@ def _available_services(refresh=False):
 
     try:
         for user in os.listdir('/Users/'):
-            agent_path = '/Users/{}/Library/LaunchAgents/'.format(user)
+            agent_path = '/Users/{}/Library/LaunchAgents'.format(user)
             if os.path.isdir(agent_path):
                 launchd_paths.append(agent_path)
     except OSError:

--- a/tests/unit/utils/test_mac_utils.py
+++ b/tests/unit/utils/test_mac_utils.py
@@ -215,15 +215,6 @@ class MacUtilsTestCase(TestCase, LoaderModuleMockMixin):
             except CommandExecutionError as exc:
                 self.assertEqual(exc.message, error)
 
-    def _get_walk_side_effects(self, results):
-        '''
-        Data generation helper function for service tests.
-        '''
-        def walk_side_effect(*args, **kwargs):
-            return [(args[0], [], results.get(args[0], []))]
-        return walk_side_effect
-
-
     @patch('salt.utils.path.os_walk')
     @patch('os.path.exists')
     def test_available_services_result(self, mock_exists, mock_os_walk):
@@ -231,18 +222,11 @@ class MacUtilsTestCase(TestCase, LoaderModuleMockMixin):
         test available_services results are properly formed dicts.
         '''
         results = {'/Library/LaunchAgents': ['com.apple.lla1.plist']}
-        mock_os_walk.side_effect = self._get_walk_side_effects(results)
+        mock_os_walk.side_effect = _get_walk_side_effects(results)
         mock_exists.return_value = True
 
-        mock_plist = {'Label': 'com.apple.lla1'}
-        if six.PY2:
-            mock_read_plist = MagicMock(return_value=mock_plist)
-            with patch('plistlib.readPlist', mock_read_plist):
-                ret = mac_utils._available_services()
-        else:
-            mock_load = MagicMock(return_value=mock_plist)
-            with patch('salt.utils.files.fopen', mock_open()), patch('plistlib.load', mock_load):
-                ret = mac_utils._available_services()
+        plists = [{'Label': 'com.apple.lla1'}]
+        ret = _run_available_services(plists)
 
         self.assertTrue(isinstance(ret, dict))
         self.assertEqual(len(ret), 1)
@@ -271,7 +255,7 @@ class MacUtilsTestCase(TestCase, LoaderModuleMockMixin):
             '/Users/saltymcsaltface/Library/LaunchAgents': [
                 'com.apple.uslla1.plist']}
 
-        mock_os_walk.side_effect = self._get_walk_side_effects(results)
+        mock_os_walk.side_effect = _get_walk_side_effects(results)
         mock_listdir.return_value = ['saltymcsaltface']
         mock_isdir.return_value = True
         mock_exists.return_value = True
@@ -282,18 +266,57 @@ class MacUtilsTestCase(TestCase, LoaderModuleMockMixin):
             {'Label': 'com.apple.slla1'},
             {'Label': 'com.apple.slld1'},
             {'Label': 'com.apple.uslla1'}]
-
-        if six.PY2:
-            mock_read_plist = MagicMock()
-            mock_read_plist.side_effect = plists
-            with patch('plistlib.readPlist', mock_read_plist):
-                ret = mac_utils._available_services()
-        else:
-            mock_load = MagicMock()
-            mock_load.side_effect = plists
-            with patch('salt.utils.files.fopen', mock_open()):
-                with patch('plistlib.load', mock_load):
-                    ret = mac_utils._available_services()
+        ret = _run_available_services(plists)
 
         self.assertEqual(len(ret), 5)
 
+    @patch('salt.utils.path.os_walk')
+    @patch('os.path.exists')
+    @patch('plistlib.readPlist' if six.PY2 else 'plistlib.load')
+    def test_available_services_broken_symlink(self, mock_read_plist, mock_exists, mock_os_walk):
+        '''
+        test available_services when it encounters a broken symlink.
+        '''
+        results = {'/Library/LaunchAgents': ['com.apple.lla1.plist', 'com.apple.lla2.plist']}
+        mock_os_walk.side_effect = _get_walk_side_effects(results)
+        mock_exists.side_effect = [True, False]
+
+        plists = [{'Label': 'com.apple.lla1'}]
+        ret = _run_available_services(plists)
+
+        # self.assertTrue(isinstance(ret, dict))
+        self.assertEqual(len(ret), 1)
+        # Ensure the correct, first plist, is returned.
+        self.assertEqual(
+            ret['com.apple.lla1']['file_name'],
+            'com.apple.lla1.plist')
+        self.assertEqual(
+            ret['com.apple.lla1']['file_path'],
+            os.path.realpath(
+                os.path.join('/Library/LaunchAgents', 'com.apple.lla1.plist')))
+
+
+
+
+def _get_walk_side_effects(results):
+    '''
+    Data generation helper function for service tests.
+    '''
+    def walk_side_effect(*args, **kwargs):
+        return [(args[0], [], results.get(args[0], []))]
+    return walk_side_effect
+
+
+def _run_available_services(plists):
+    if six.PY2:
+        mock_read_plist = MagicMock()
+        mock_read_plist.side_effect = plists
+        with patch('plistlib.readPlist', mock_read_plist):
+            ret = mac_utils._available_services()
+    else:
+        mock_load = MagicMock()
+        mock_load.side_effect = plists
+        with patch('salt.utils.files.fopen', mock_open()):
+            with patch('plistlib.load', mock_load):
+                ret = mac_utils._available_services()
+    return ret

--- a/tests/unit/utils/test_mac_utils.py
+++ b/tests/unit/utils/test_mac_utils.py
@@ -5,7 +5,6 @@ mac_utils tests
 
 # Import python libs
 from __future__ import absolute_import, unicode_literals
-import os
 import plistlib
 import xml.parsers.expat
 
@@ -341,7 +340,6 @@ class MacUtilsTestCase(TestCase, LoaderModuleMockMixin):
 
         if six.PY2:
             mock_run.assert_has_calls(calls, any_order=True)
-
 
     @patch('salt.utils.path.os_walk')
     @patch('os.path.exists')

--- a/tests/unit/utils/test_mac_utils.py
+++ b/tests/unit/utils/test_mac_utils.py
@@ -461,7 +461,7 @@ class MacUtilsTestCase(TestCase, LoaderModuleMockMixin):
         mock_run.configure_mock(**attrs)
         mock_exists.return_value = True
         mock_read_plist.side_effect = Exception()
-        mock_read_plist_from_string.return_value = 'malformedness'
+        mock_read_plist_from_string.return_value = Exception()
 
         ret = mac_utils._available_services()
 

--- a/tests/unit/utils/test_mac_utils.py
+++ b/tests/unit/utils/test_mac_utils.py
@@ -228,12 +228,12 @@ class MacUtilsTestCase(TestCase, LoaderModuleMockMixin):
         plists = [{'Label': 'com.apple.lla1'}]
         ret = _run_available_services(plists)
 
-        self.assertTrue(isinstance(ret, dict))
-        self.assertEqual(len(ret), 1)
-        self.assertEqual(ret['com.apple.lla1']['file_name'], 'com.apple.lla1.plist')
-        self.assertEqual(
-            ret['com.apple.lla1']['file_path'],
-            os.path.realpath(os.path.join('/Library/LaunchAgents', 'com.apple.lla1.plist')))
+        expected = {
+            'com.apple.lla1': {
+                'file_name': 'com.apple.lla1.plist',
+                'file_path': '/Library/LaunchAgents/com.apple.lla1.plist',
+                'plist': plists[0]}}
+        self.assertEqual(ret, expected)
 
     @patch('salt.utils.path.os_walk')
     @patch('os.path.exists')
@@ -284,16 +284,63 @@ class MacUtilsTestCase(TestCase, LoaderModuleMockMixin):
         plists = [{'Label': 'com.apple.lla1'}]
         ret = _run_available_services(plists)
 
-        # self.assertTrue(isinstance(ret, dict))
-        self.assertEqual(len(ret), 1)
-        # Ensure the correct, first plist, is returned.
-        self.assertEqual(
-            ret['com.apple.lla1']['file_name'],
-            'com.apple.lla1.plist')
-        self.assertEqual(
-            ret['com.apple.lla1']['file_path'],
-            os.path.realpath(
-                os.path.join('/Library/LaunchAgents', 'com.apple.lla1.plist')))
+        expected = {
+            'com.apple.lla1': {
+                'file_name': 'com.apple.lla1.plist',
+                'file_path': '/Library/LaunchAgents/com.apple.lla1.plist',
+                'plist': plists[0]}}
+        self.assertEqual(ret, expected)
+
+    @patch('salt.utils.path.os_walk')
+    @patch('os.path.exists')
+    @patch('plistlib.readPlist')
+    @patch('salt.utils.mac_utils.__salt__')
+    @patch('plistlib.readPlistFromString', create=True)
+    def test_available_services_binary_plist(self,
+                                             mock_read_plist_from_string,
+                                             mock_run,
+                                             mock_read_plist,
+                                             mock_exists,
+                                             mock_os_walk):
+        '''
+        test available_services handles binary plist files.
+        '''
+        results = {'/Library/LaunchAgents': ['com.apple.lla1.plist']}
+        mock_os_walk.side_effect = _get_walk_side_effects(results)
+        mock_exists.return_value = True
+
+        plists = [{'Label': 'com.apple.lla1'}]
+
+        if six.PY2:
+            attrs = {'cmd.run': MagicMock()}
+
+            def getitem(name):
+                return attrs[name]
+
+            mock_run.__getitem__.side_effect = getitem
+            mock_run.configure_mock(**attrs)
+            cmd = '/usr/bin/plutil -convert xml1 -o - -- "{}"'.format(
+                '/Library/LaunchAgents/com.apple.lla1.plist')
+            calls = [call.cmd.run(cmd)]
+
+            mock_read_plist.side_effect = xml.parsers.expat.ExpatError
+            mock_read_plist_from_string.side_effect = plists
+            ret = mac_utils._available_services()
+        else:
+            # Py3 plistlib knows how to handle binary plists without
+            # any extra work, so this test doesn't really do anything
+            # new.
+            ret = _run_available_services(plists)
+
+        expected = {
+            'com.apple.lla1': {
+                'file_name': 'com.apple.lla1.plist',
+                'file_path': '/Library/LaunchAgents/com.apple.lla1.plist',
+                'plist': plists[0]}}
+        self.assertEqual(ret, expected)
+
+        if six.PY2:
+            mock_run.assert_has_calls(calls, any_order=True)
 
 
 


### PR DESCRIPTION
### What does this PR do?
This PR updates the tests for the mac_utils module to not incorrectly pass malformed binary plists and then fixes the handling of that situation in the mac_utils module itself.

### What issues does this PR fix or reference?
#50227 

### Previous Behavior
Raised unhandled `plistlib.InvalidFileException`.

### New Behavior
Skips the poorly formed plist file by `continue`-ing the for loop.

### Tests written?

Yes (updated)

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
