### PR TITLE
runners.pillar: trigger a sys.reload_modules after compilation

### DIFF
--- a/salt/runners/pillar.py
+++ b/salt/runners/pillar.py
@@ -33,6 +33,10 @@ def show_top(minion=None, saltenv='base'):
         __jid_event__.fire_event({'data': errors, 'outputter': 'nested'}, 'progress')
         return errors
 
+    # needed because pillar compilation clobbers grains etc via lazyLoader
+    # this resets the masterminion back to known state
+    __salt__['salt.cmd']('sys.reload_modules')
+
     return top
 
 
@@ -105,4 +109,9 @@ def show_pillar(minion='*', **kwargs):
         pillarenv=pillarenv)
 
     compiled_pillar = pillar.compile_pillar()
+
+    # needed because pillar compilation clobbers grains etc via lazyLoader
+    # this resets the masterminion back to known state
+    __salt__['salt.cmd']('sys.reload_modules')
+
     return compiled_pillar


### PR DESCRIPTION
### What does this PR do?
pillar can tentatively be destructive in terms of replacing dunders like __grains__ on certain modules. firing a sys.gen_modules/reload_modules sets the masterminion back into a known state.


### Previous Behavior
generating pillar clobbered grains

### New Behavior
grains is maintained across runner.pillar calls

### Tests written?
No

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
