### PR TITLE
Add various ssh tests to the filemap for salt/utils/vt.py changes

### DIFF
--- a/tests/filename_map.yml
+++ b/tests/filename_map.yml
@@ -224,6 +224,16 @@ salt/utils/schedule.py:
   - integration.scheduler.test_postpone
   - integration.scheduler.test_skip
 
+salt/utils/vt.py:
+  - integration.cli.test_custom_module
+  - integration.cli.test_grains
+  - integration.ssh.test_grains
+  - integration.ssh.test_jinja_filters
+  - integration.ssh.test_mine
+  - integration.ssh.test_pillar
+  - integration.ssh.test_raw
+  - integration.ssh.test_state
+
 salt/wheel/*:
   - integration.wheel.test_client
 


### PR DESCRIPTION
Some of the salt-ssh tests use the salt/utils/vt.py functions. A recent change in that file caused about 90 tests to start failing on the branch.

We need to make sure these tests run when changes to the vt.py util are made in PRs.