### PR TITLE
Don't encode the return values in utils/vt.py

### DIFF
--- a/salt/utils/vt.py
+++ b/salt/utils/vt.py
@@ -704,7 +704,7 @@ class Terminal(object):
                     if self.child_fd is not None:
                         fcntl.fcntl(self.child_fd, fcntl.F_SETFL, fd_flags)
             # <---- Process STDOUT -------------------------------------------
-            return salt.utils.data.encode(stdout), salt.utils.data.encode(stderr)
+            return stdout, stderr
 
         def __detect_parent_terminal_size(self):
             try:


### PR DESCRIPTION
These encodings were causing the salt-ssh tests to fail.

This is a partial revert of #50146.

In order to see if the tests succeed completely on a PR, PR #50230 will need to be merged first.