### PR TITLE
Fix salt-cloud UnicodeEncodeError when writing to stdout

### DIFF
--- a/salt/utils/vt.py
+++ b/salt/utils/vt.py
@@ -53,6 +53,7 @@ except ImportError:
 
 # Import salt libs
 import salt.utils.crypt
+import salt.utils.data
 import salt.utils.stringutils
 from salt.ext.six import string_types
 from salt.log.setup import LOG_LEVELS
@@ -685,7 +686,7 @@ class Terminal(object):
                         stdout = None
                     else:
                         if self.stream_stdout:
-                            self.stream_stdout.write(stdout)
+                            self.stream_stdout.write(salt.utils.data.encode(stdout))
                             self.stream_stdout.flush()
 
                         if self.stdout_logger:


### PR DESCRIPTION
This is a partial back-port of #50146.

The full back-port was reverted due to the original change causing all of the salt-ssh tests to fail.

This change fixes the salt-cloud error, but allows salt-ssh to work correctly.

Refs #49523, #50146, #50174, #50231, and #50235