### PR TITLE
Fix `unit.modules.test_cmdmod` on Windows in Kitchen

### DIFF
--- a/tests/unit/modules/test_cmdmod.py
+++ b/tests/unit/modules/test_cmdmod.py
@@ -355,6 +355,12 @@ class CMDMODTestCase(TestCase, LoaderModuleMockMixin):
         with salt.utils.files.fopen(rand_bytes_file, 'rb') as fp_:
             stdout_bytes = fp_.read()
 
+        # kitchen-salt uses unix2dos on all the files before copying them over
+        # to the vm that will be running the tests. It skips binary files though
+        # The file specified in `rand_bytes_file` is detected as binary so the
+        # Unix-style line ending remains. This should account for that.
+        stdout_bytes = stdout_bytes.rstrip() + os.linesep
+
         # stdout with the non-decodable bits replaced with the unicode
         # replacement character U+FFFD.
         stdout_unicode = '\ufffd\x1b\ufffd\ufffd' + os.linesep

--- a/tests/unit/modules/test_cmdmod.py
+++ b/tests/unit/modules/test_cmdmod.py
@@ -359,7 +359,7 @@ class CMDMODTestCase(TestCase, LoaderModuleMockMixin):
         # to the vm that will be running the tests. It skips binary files though
         # The file specified in `rand_bytes_file` is detected as binary so the
         # Unix-style line ending remains. This should account for that.
-        stdout_bytes = stdout_bytes.rstrip() + os.linesep
+        stdout_bytes = stdout_bytes.rstrip() + os.linesep.encode()
 
         # stdout with the non-decodable bits replaced with the unicode
         # replacement character U+FFFD.


### PR DESCRIPTION
### What does this PR do?
Ensures the correct line ending is present in the file.

Kitchen-salt runs `unix2dos` on all files before being copied over to the VM used to run the tests. `unix2dos` skips binary files. The `unit.modules.test_cmdmod.CMDMODTestCase.test_run_all_binary_replace` test reads the contents of a binary file to mock the stdout of the `cmd.run` command. Since it is a binary file, the line endings aren't changed by the `unix2dos` command, causing the test to fail.

### Tests written?
Yes

### Commits signed with GPG?
Yes