### PR TITLE
put variables in apostrophe in dracr module

### DIFF
--- a/salt/modules/dracr.py
+++ b/salt/modules/dracr.py
@@ -176,7 +176,7 @@ def get_property(host=None, admin_username=None, admin_password=None, property=N
     '''
     if property is None:
         raise SaltException('No property specified!')
-    ret = __execute_ret('get {0}'.format(property), host=host,
+    ret = __execute_ret('get \'{0}\''.format(property), host=host,
                         admin_username=admin_username,
                         admin_password=admin_password)
     return ret
@@ -212,7 +212,7 @@ def set_property(host=None, admin_username=None, admin_password=None, property=N
         raise SaltException('No property specified!')
     elif value is None:
         raise SaltException('No value specified!')
-    ret = __execute_ret('set {0} {1}'.format(property, value), host=host,
+    ret = __execute_ret('set \'{0}\' \'{1}\''.format(property, value), host=host,
                         admin_username=admin_username,
                         admin_password=admin_password)
     return ret


### PR DESCRIPTION
### What does this PR do?
Fixes bug introduced in #48148. Variables used for setting idrac property can contain space which should be in quotes so that it is interpreted as one argument. 

### Tests written?
No. There were no tests

### Commits signed with GPG?
No