### PR TITLE
Adding securitygroupname as the config instead of securitygroup

### DIFF
--- a/tests/integration/cloud/providers/test_ec2.py
+++ b/tests/integration/cloud/providers/test_ec2.py
@@ -110,7 +110,7 @@ class EC2Test(ShellCase):
         id_ = config[profile_str][PROVIDER_NAME]['id']
         key = config[profile_str][PROVIDER_NAME]['key']
         key_name = config[profile_str][PROVIDER_NAME]['keyname']
-        sec_group = config[profile_str][PROVIDER_NAME]['securitygroup']
+        sec_group = config[profile_str][PROVIDER_NAME]['securitygroupname'][0]
         private_key = config[profile_str][PROVIDER_NAME]['private_key']
         location = config[profile_str][PROVIDER_NAME]['location']
 


### PR DESCRIPTION
### What does this PR do?
Fixes the cloud tests so that the security group is passed into the config correctly.

### What issues does this PR fix or reference?
Cloud tests that are broken



### Tests written?

No

### Commits signed with GPG?

Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
