### PR TITLE
fix locale setting when data is set to not None

### DIFF
--- a/salt/modules/localemod.py
+++ b/salt/modules/localemod.py
@@ -102,7 +102,7 @@ def _localectl_set(locale=''):
     '''
     locale_params = _parse_dbus_locale() if dbus is not None else _localectl_status().get('system_locale', {})
     locale_params['LANG'] = six.text_type(locale)
-    args = ' '.join(['{0}="{1}"'.format(k, v) for k, v in six.iteritems(locale_params) if v is not None])
+    args = ' '.join(['{0}="{1}"'.format(k, v) for k, v in six.iteritems(locale_params) if v and k is not 'data'])
     return not __salt__['cmd.retcode']('localectl set-locale {0}'.format(args), python_shell=False)
 
 


### PR DESCRIPTION
### What does this PR do?
Data is a key for us that is used to display what is in the output of localectl, but `localectl set` does not use that key.  The data keyword is just used when we are interpreting the output of localectl status.
```
            if '=' in ctl_data:
                loc_set = ctl_data.split('=')
                if len(loc_set) == 2:
                    if ctl_key not in ret:
                        ret[ctl_key] = {}
                    ret[ctl_key][loc_set[0]] = loc_set[1]
            else:
                ret[ctl_key] = {'data': None if ctl_data == 'n/a' else ctl_data}
```

When the output of a localectl status includes information like

```
[root@blog ~]# localectl status
   System Locale: LANG=en_US.UTF-8
       VC Keymap: us
      X11 Layout: us
```
### What issues does this PR fix or reference?
Fix for salt-jenkins https://github.com/saltstack/salt-jenkins/pull/1182

### Tests written?

Yes

### Commits signed with GPG?

Yes