### PR TITLE
apt: speedup installing packages with '>=' or '<=' and reduced memory…

### DIFF
--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -18,7 +18,6 @@ from __future__ import absolute_import, print_function, unicode_literals
 
 # Import python libs
 import copy
-import fnmatch
 import os
 import re
 import logging
@@ -1660,11 +1659,11 @@ def list_repo_pkgs(*args, **kwargs):  # pylint: disable=unused-import
         salt '*' pkg.list_repo_pkgs foo bar baz
     '''
     if args:
-        # get only information about packages in args
-        cmd = ['apt-cache', 'show' ] + [arg for arg in args]
+        # Get only information about packages in args
+        cmd = ['apt-cache', 'show'] + [arg for arg in args]
     else:
-        # get information about all available packages
-        cmd = ['apt-cache', 'show', '.']
+        # Get information about all available packages
+        cmd = ['apt-cache', 'dump']
 
     out = __salt__['cmd.run_all'](
         cmd,
@@ -1678,7 +1677,7 @@ def list_repo_pkgs(*args, **kwargs):  # pylint: disable=unused-import
     skip_pkg = False
     new_pkg = re.compile('^Package: (.+)')
     for line in salt.utils.itertools.split(out['stdout'], '\n'):
-        if len(line.strip()) == 0:
+        if not line.strip():
             continue
         try:
             cur_pkg = new_pkg.match(line).group(1)

--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -1659,8 +1659,15 @@ def list_repo_pkgs(*args, **kwargs):  # pylint: disable=unused-import
         salt '*' pkg.list_repo_pkgs
         salt '*' pkg.list_repo_pkgs foo bar baz
     '''
+    if args:
+        # get only information about packages in args
+        cmd = ['apt-cache', 'show' ] + [arg for arg in args]
+    else:
+        # get information about all available packages
+        cmd = ['apt-cache', 'show', '.']
+
     out = __salt__['cmd.run_all'](
-        ['apt-cache', 'dump'],
+        cmd,
         output_loglevel='trace',
         ignore_retcode=True,
         python_shell=False
@@ -1671,6 +1678,8 @@ def list_repo_pkgs(*args, **kwargs):  # pylint: disable=unused-import
     skip_pkg = False
     new_pkg = re.compile('^Package: (.+)')
     for line in salt.utils.itertools.split(out['stdout'], '\n'):
+        if len(line.strip()) == 0:
+            continue
         try:
             cur_pkg = new_pkg.match(line).group(1)
         except AttributeError:
@@ -1678,22 +1687,10 @@ def list_repo_pkgs(*args, **kwargs):  # pylint: disable=unused-import
         else:
             if cur_pkg != pkg_name:
                 pkg_name = cur_pkg
-                if args:
-                    for arg in args:
-                        if fnmatch.fnmatch(pkg_name, arg):
-                            skip_pkg = False
-                            break
-                    else:
-                        # Package doesn't match any of the passed args, skip it
-                        skip_pkg = True
-                else:
-                    # No args passed, we're getting all packages
-                    skip_pkg = False
                 continue
-        if not skip_pkg:
-            comps = line.strip().split(None, 1)
-            if comps[0] == 'Version:':
-                ret.setdefault(pkg_name, []).append(comps[1])
+        comps = line.strip().split(None, 1)
+        if comps[0] == 'Version:':
+            ret.setdefault(pkg_name, []).append(comps[1])
 
     return ret
 

--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -321,6 +321,7 @@ def latest_version(*names, **kwargs):
         return ret[names[0]]
     return ret
 
+
 # available_version is being deprecated
 available_version = salt.utils.functools.alias_function(latest_version, 'available_version')
 


### PR DESCRIPTION
… consumption

### What does this PR do?
Speedup salt work and reduce memory comsumption in aptpkg.py when installing packages with operators '>=' and '<='.

### What issues does this PR fix or reference?

### Previous Behavior
For each pkg.installed with '>=' or '<=' salt saved output of "apt-cache dump" to variable and then read it. But this output could be huge. For example, on my system it took 47 Gb, but I didn't have 47 Gb of memory, so salt couldn't work.

### New Behavior
Salt just saves output of "apt-cache show <pkg>" if pkg is given, or full output: "apt-cache show .". It is much shorter than "apt-cache dump" (380 Mb on the same system) but contains the same useful information.

### Tests written?

No

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
