### PR TITLE
Compare sorted docker environment

### DIFF
--- a/salt/modules/dockermod.py
+++ b/salt/modules/dockermod.py
@@ -948,6 +948,9 @@ def compare_containers(first, second, ignore=None):
                 if item == 'Ulimits':
                     val1 = _ulimit_sort(val1)
                     val2 = _ulimit_sort(val2)
+                if item == 'Env':
+                    val1 = sorted(val1)
+                    val2 = sorted(val2)
                 if val1 != val2:
                     ret.setdefault(conf_dict, {})[item] = {'old': val1, 'new': val2}
         # Check for optionally-present items that were in the second container


### PR DESCRIPTION
### What does this PR do?
I have experienced bug on windows only minions, regarding docker_container.running, where container is replaced on each state.apply whether it has changes or not.

If there are many "environment"  variables specified, the environment list is having random order each time state is applied. As a result existing container and the temporarily created container are seen to have different environment variables ( although only order is different) and docker container is replaced each time salt is doing state.apply.
 
Argument reorder happens only on windows and it happens in salt/utils/docker/__init__.py function translate_input) . (Maybe it would make sense to see why it happens in translate_input. As for my system I just compare sorted list instead.) It has been introduced between 2017.7 and 2018.3.0

### Previous Behavior
docker container recreated on each state.apply despite no configuration changes.

### New Behavior

docker container modified only on changes.

### Tests written?

No - tested manually on linux and windows.

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
