### PR TITLE
Fix out of order docker Env comparison

### DIFF
--- a/salt/modules/dockermod.py
+++ b/salt/modules/dockermod.py
@@ -5589,6 +5589,7 @@ def pause(name):
                             .format(name))}
     return _change_state(name, 'pause', 'paused')
 
+
 freeze = salt.utils.functools.alias_function(pause, 'freeze')
 
 
@@ -5790,6 +5791,7 @@ def unpause(name):
                 'comment': ('Container \'{0}\' is stopped, cannot unpause'
                             .format(name))}
     return _change_state(name, 'unpause', 'running')
+
 
 unfreeze = salt.utils.functools.alias_function(unpause, 'unfreeze')
 

--- a/salt/modules/dockermod.py
+++ b/salt/modules/dockermod.py
@@ -948,6 +948,9 @@ def compare_containers(first, second, ignore=None):
                 if item == 'Ulimits':
                     val1 = _ulimit_sort(val1)
                     val2 = _ulimit_sort(val2)
+                if item == 'Env':
+                    val1 = sorted(val1)
+                    val2 = sorted(val2)
                 if val1 != val2:
                     ret.setdefault(conf_dict, {})[item] = {'old': val1, 'new': val2}
         # Check for optionally-present items that were in the second container
@@ -974,6 +977,9 @@ def compare_containers(first, second, ignore=None):
                 if item == 'Ulimits':
                     val1 = _ulimit_sort(val1)
                     val2 = _ulimit_sort(val2)
+                if item == 'Env':
+                    val1 = sorted(val1)
+                    val2 = sorted(val2)
                 if val1 != val2:
                     ret.setdefault(conf_dict, {})[item] = {'old': val1, 'new': val2}
     return ret

--- a/tests/unit/modules/test_dockermod.py
+++ b/tests/unit/modules/test_dockermod.py
@@ -841,6 +841,35 @@ class DockerTestCase(TestCase, LoaderModuleMockMixin):
             ret = docker_mod.compare_container('container1', 'container2')
             self.assertEqual(ret, {})
 
+    def test_compare_container_env_order(self):
+        '''
+        Test comparing two containers when the order of the Env HostConfig
+        values are different, but the values are the same.
+        '''
+        def _inspect_container_effect(id_):
+            return {
+                'container1': {'Config': {},
+                               'HostConfig': {
+                                   'Env': [
+                                       'FOO=bar',
+                                       'HELLO=world',
+                                   ]
+                               }},
+                'container2': {'Config': {},
+                               'HostConfig': {
+                                   'Env': [
+                                       'HELLO=world',
+                                       'FOO=bar',
+                                   ]
+                               }},
+            }[id_]
+
+        inspect_container_mock = MagicMock(side_effect=_inspect_container_effect)
+
+        with patch.object(docker_mod, 'inspect_container', inspect_container_mock):
+            ret = docker_mod.compare_container('container1', 'container2')
+            self.assertEqual(ret, {})
+
     def test_resolve_tag(self):
         '''
         Test the resolve_tag function. It runs docker.insect_image on the image

--- a/tests/unit/modules/test_dockermod.py
+++ b/tests/unit/modules/test_dockermod.py
@@ -822,15 +822,15 @@ class DockerTestCase(TestCase, LoaderModuleMockMixin):
                 'container1': {'Config': {},
                                'HostConfig': {
                                    'Ulimits': [
-                                       {u'Hard': -1, u'Soft': -1, u'Name': u'core'},
-                                       {u'Hard': 65536, u'Soft': 65536, u'Name': u'nofile'}
+                                       {'Hard': -1, 'Soft': -1, 'Name': 'core'},
+                                       {'Hard': 65536, 'Soft': 65536, 'Name': 'nofile'}
                                    ]
                                }},
                 'container2': {'Config': {},
                                'HostConfig': {
                                    'Ulimits': [
-                                       {u'Hard': 65536, u'Soft': 65536, u'Name': u'nofile'},
-                                       {u'Hard': -1, u'Soft': -1, u'Name': u'core'}
+                                       {'Hard': 65536, 'Soft': 65536, 'Name': 'nofile'},
+                                       {'Hard': -1, 'Soft': -1, 'Name': 'core'}
                                    ]
                                }},
             }[id_]


### PR DESCRIPTION
### What does this PR do?
I have experienced bug on windows only minions, regarding docker_container.running, where container is replaced on each state.apply whether it has changes or not.

If there are many "environment" variables specified, the environment list is having random order each time state is applied. As a result existing container and the temporarily created container are seen to have different environment variables ( although only order is different) and docker container is replaced each time salt is doing state.apply.

Argument reorder happens only on windows and it happens in salt/utils/docker/init.py function translate_input) . (Maybe it would make sense to see why it happens in translate_input. As for my system I just compare sorted list instead.) It has been introduced between 2017.7 and 2018.3.0

### Previous Behavior
docker container placed on each state.apply despite no configuration changes.

### New Behavior
docker container modified only on changes.

### Tests written?

No

### Commits signed with GPG?

No
