### PR TITLE
Virt disk fixes

### DIFF
--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -1671,8 +1671,13 @@ def _disks_equal(disk1, disk2):
     '''
     Test if two disk elements should be considered like the same device
     '''
+    target1 = disk1.find('target')
+    target2 = disk2.find('target')
+
     return ElementTree.tostring(disk1.find('source')) == \
-        ElementTree.tostring(disk2.find('source'))
+        ElementTree.tostring(disk2.find('source')) and \
+        target1 is not None and target2 is not None and \
+        target1.get('bus') == target2.get('bus')
 
 
 def _nics_equal(nic1, nic2):

--- a/tests/unit/modules/test_virt.py
+++ b/tests/unit/modules/test_virt.py
@@ -829,6 +829,10 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
                 <source file='/path/to/img2.qcow2'/>
                 <target dev='hda' bus='ide'/>
               </disk>
+              <disk type='file' device='disk'>
+                <source file='/path/to/img4.qcow2'/>
+                <target dev='hdb' bus='ide'/>
+              </disk>
             </devices>
         ''').findall('disk')
 
@@ -842,16 +846,22 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
                 <source file='/path/to/img0.qcow2'/>
                 <target dev='vdb' bus='virtio'/>
               </disk>
+              <disk type='file' device='disk'>
+                <source file='/path/to/img4.qcow2'/>
+                <target dev='vdc' bus='virtio'/>
+              </disk>
             </devices>
         ''').findall('disk')
         ret = virt._diff_disk_lists(old_disks, new_disks)
         self.assertEqual([disk.find('source').get('file') for disk in ret['deleted']],
-                         ['/path/to/img1.qcow2', '/path/to/img2.qcow2'])
+                         ['/path/to/img1.qcow2', '/path/to/img2.qcow2', '/path/to/img4.qcow2'])
         self.assertEqual([disk.find('source').get('file') for disk in ret['unchanged']],
                          ['/path/to/img0.qcow2'])
         self.assertEqual([disk.find('source').get('file') for disk in ret['new']],
-                         ['/path/to/img3.qcow2'])
+                         ['/path/to/img3.qcow2', '/path/to/img4.qcow2'])
         self.assertEqual(ret['new'][0].find('target').get('dev'), 'vdb')
+        self.assertEqual(ret['new'][1].find('target').get('dev'), 'vdc')
+        self.assertEqual(ret['new'][1].find('target').get('bus'), 'virtio')
 
     def test_diff_nics(self):
         '''

--- a/tests/unit/modules/test_virt.py
+++ b/tests/unit/modules/test_virt.py
@@ -723,6 +723,19 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
             self.assertTrue(diskp[0]['source_file'].startswith(pools_path))
             self.assertTrue(diskp[1]['source_file'].startswith(default_path))
 
+    def test_disk_profile_kvm_disk_external_image(self):
+        '''
+        Test virt._gen_xml(), KVM case with an external image.
+        '''
+        diskp = virt._disk_profile(None, 'kvm', [
+            {
+                'name': 'mydisk',
+                'source_file': '/path/to/my/image.qcow2'
+            }], 'hello')
+
+        self.assertEqual(len(diskp), 1)
+        self.assertEqual(diskp[0]['source_file'], ('/path/to/my/image.qcow2'))
+
     @patch('salt.modules.virt.pool_info', return_value={})
     def test_disk_profile_kvm_disk_pool_notfound(self, mock_poolinfo):
         '''


### PR DESCRIPTION
### What does this PR do?

The `virt.update` function introduced in Fluorine as well as the new `virt.init` disk parameters are suffering two flaws:

* disk images created from outside the salt virt module are now handled
* possible disk changes from the user perspective are only the source file.

The two commits from this PR are fixing this by introducing a `source_file` property in the disk description and comparing the disks against more than just the source file.

### What issues does this PR fix or reference?

None filed yet

### Tests written?

Yes

### Commits signed with GPG?

Yes
