### PR TITLE
minor correction to boto_vpc.route_table_present example

### DIFF
--- a/salt/states/boto_vpc.py
+++ b/salt/states/boto_vpc.py
@@ -906,9 +906,9 @@ def route_table_present(name, vpc_name=None, vpc_id=None, routes=None,
               interface_id: eni-123456
             - destination_cidr_block: 10.10.13.0/24
               instance_name: mygatewayserver
-            - subnet_names:
-              - subnet1
-              - subnet2
+          - subnet_names:
+            - subnet1
+            - subnet2
 
     name
         Name of the route table.


### PR DESCRIPTION
subnet_names was on wrong indent level

### What does this PR do?

Fix documentation example for boto_vpc.route_table_present. 

### Tests written?

No - Documentation change

### Commits signed with GPG?

Yes