### PR TITLE
Address issues highlighted in #50286 for libcloud_dns

### DIFF
--- a/doc/ref/states/all/salt.states.libcloud_dns.rst
+++ b/doc/ref/states/all/salt.states.libcloud_dns.rst
@@ -1,6 +1,8 @@
 salt.states.libcloud_dns module
 ===============================
 
+The ``libcloud_dns`` module is a standalone state module, separate to the libcloud functionality in the `salt-cloud` API. ``salt.states.libcloud_dns`` can be used to deploy, configure and validate DNS records and zones in any of the supported DNS providers in Apache libcloud.
+
 .. automodule:: salt.states.libcloud_dns
     :members:
     :undoc-members:

--- a/salt/modules/libcloud_dns.py
+++ b/salt/modules/libcloud_dns.py
@@ -34,6 +34,7 @@ from __future__ import absolute_import, unicode_literals, print_function
 import logging
 
 # Import salt libs
+import salt.utils.args
 import salt.utils.compat
 from salt.utils.versions import LooseVersion as _LooseVersion
 
@@ -380,7 +381,7 @@ def extra(method, profile, **libcloud_kwargs):
 
         salt myminion libcloud_dns.extra ex_get_permissions google container_name=my_container object_name=me.jpg --out=yaml
     '''
-    _sanitize_kwargs(libcloud_kwargs)
+    salt.utils.args.clean_kwargs(**libcloud_kwargs)
     conn = _get_driver(profile=profile)
     connection_method = getattr(conn, method)
     return connection_method(**libcloud_kwargs)

--- a/salt/modules/libcloud_dns.py
+++ b/salt/modules/libcloud_dns.py
@@ -187,7 +187,7 @@ def get_record(zone_id, record_id, profile):
     return _simple_record(conn.get_record(zone_id, record_id))
 
 
-def create_zone(domain, profile, type='master', ttl=None):
+def create_zone(domain, profile, type='master', ttl=None, extra={}):
     '''
     Create a new zone.
 
@@ -203,6 +203,9 @@ def create_zone(domain, profile, type='master', ttl=None):
     :param ttl: TTL for new records. (optional)
     :type  ttl: ``int``
 
+    :param extra: Extra data (optional)
+    :type  extra: ``dict``
+
     CLI Example:
 
     .. code-block:: bash
@@ -210,7 +213,7 @@ def create_zone(domain, profile, type='master', ttl=None):
         salt myminion libcloud_dns.create_zone google.com profile1
     '''
     conn = _get_driver(profile=profile)
-    zone = conn.create_record(domain, type=type, ttl=ttl)
+    zone = conn.create_zone(domain, type=type, ttl=ttl, extra=extra)
     return _simple_zone(zone)
 
 

--- a/salt/modules/libcloud_dns.py
+++ b/salt/modules/libcloud_dns.py
@@ -187,7 +187,7 @@ def get_record(zone_id, record_id, profile):
     return _simple_record(conn.get_record(zone_id, record_id))
 
 
-def create_zone(domain, profile, type='master', ttl=None, extra={}):
+def create_zone(domain, profile, type='master', ttl=None, extra=None):
     '''
     Create a new zone.
 
@@ -217,7 +217,7 @@ def create_zone(domain, profile, type='master', ttl=None, extra={}):
     return _simple_zone(zone)
 
 
-def update_zone(zone_id, domain, profile, type='master', ttl=None):
+def update_zone(zone_id, domain, profile, type='master', ttl=None, extra=None):
     '''
     Update an existing zone.
 
@@ -244,7 +244,7 @@ def update_zone(zone_id, domain, profile, type='master', ttl=None):
     '''
     conn = _get_driver(profile=profile)
     zone = conn.get_zone(zone_id)
-    return _simple_zone(conn.update_zone(zone=zone, domain=domain, type=type, ttl=ttl))
+    return _simple_zone(conn.update_zone(zone=zone, domain=domain, type=type, ttl=ttl, extra=extra))
 
 
 def create_record(name, zone_id, type, data, profile):

--- a/salt/modules/libcloud_dns.py
+++ b/salt/modules/libcloud_dns.py
@@ -236,6 +236,9 @@ def update_zone(zone_id, domain, profile, type='master', ttl=None, extra=None):
     :param ttl: TTL for new records. (optional)
     :type  ttl: ``int``
 
+    :param extra: Extra data (optional)
+    :type  extra: ``dict``
+
     CLI Example:
 
     .. code-block:: bash
@@ -247,7 +250,7 @@ def update_zone(zone_id, domain, profile, type='master', ttl=None, extra=None):
     return _simple_zone(conn.update_zone(zone=zone, domain=domain, type=type, ttl=ttl, extra=extra))
 
 
-def create_record(name, zone_id, type, data, profile):
+def create_record(name, zone_id, type, data, profile, extra=None):
     '''
     Create a new record.
 
@@ -269,6 +272,9 @@ def create_record(name, zone_id, type, data, profile):
     :param profile: The profile key
     :type  profile: ``str``
 
+    :param extra: Extra data (optional)
+    :type  extra: ``dict``
+
     CLI Example:
 
     .. code-block:: bash
@@ -278,7 +284,8 @@ def create_record(name, zone_id, type, data, profile):
     conn = _get_driver(profile=profile)
     record_type = _string_to_record_type(type)
     zone = conn.get_zone(zone_id)
-    return _simple_record(conn.create_record(name, zone, record_type, data))
+    return _simple_record(conn.create_record(name=name, zone=zone,
+                                             type=record_type, data=data, extra=extra))
 
 
 def delete_zone(zone_id, profile):

--- a/salt/modules/libcloud_dns.py
+++ b/salt/modules/libcloud_dns.py
@@ -307,7 +307,7 @@ def delete_zone(zone_id, profile):
         salt myminion libcloud_dns.delete_zone google.com profile1
     '''
     conn = _get_driver(profile=profile)
-    zone = conn.get_zone(zone_id=zone_id)
+    zone = conn.get_zone(zone_id)
     return conn.delete_zone(zone)
 
 

--- a/salt/states/libcloud_dns.py
+++ b/salt/states/libcloud_dns.py
@@ -210,7 +210,7 @@ def record_absent(name, zone, type, data, profile):
     if len(matching_records) > 0:
         result = []
         if __opts__['test']:
-            return state_result(True, 'Removed {0} records'.format(len(matching_records)))
+            return state_result(True, 'Removed {0} records'.format(len(matching_records)), name)
         else:
             for record in matching_records:
                 result.append(__salt__['libcloud_dns.delete_record'](

--- a/salt/states/libcloud_dns.py
+++ b/salt/states/libcloud_dns.py
@@ -72,7 +72,7 @@ def state_result(result, message, name, changes=None):
             'changes': changes}
 
 
-def zone_present(domain, type, profile):
+def zone_present(domain, type, profile, ttl=None, extra=None):
     '''
     Ensures a record is present.
 
@@ -84,6 +84,12 @@ def zone_present(domain, type, profile):
 
     :param profile: The profile key
     :type  profile: ``str``
+
+    :param ttl: TTL for new records. (optional)
+    :type  ttl: ``int``
+
+    :param extra: Extra data (optional)
+    :type  extra: ``dict``
     '''
     zones = __salt__['libcloud_dns.list_zones'](profile)
     if not type:
@@ -92,7 +98,8 @@ def zone_present(domain, type, profile):
     if len(matching_zone) > 0:
         return state_result(True, 'Zone already exists', domain)
     else:
-        result = __salt__['libcloud_dns.create_zone'](domain, profile, type)
+        result = __salt__['libcloud_dns.create_zone'](
+            domain=domain, profile=profile, type=type, ttl=ttl, extra=extra)
         return state_result(True, 'Created new zone', domain, result)
 
 

--- a/salt/states/libcloud_dns.py
+++ b/salt/states/libcloud_dns.py
@@ -128,7 +128,7 @@ def zone_absent(domain, profile):
             return state_result(result, 'Deleted zone', domain)
 
 
-def record_present(name, zone, type, data, profile):
+def record_present(name, zone, type, data, profile, extra=None):
     '''
     Ensures a record is present.
 
@@ -149,6 +149,9 @@ def record_present(name, zone, type, data, profile):
 
     :param profile: The profile key
     :type  profile: ``str``
+
+    :param extra: Extra data (optional)
+    :type  extra: ``dict``
     '''
     zones = __salt__['libcloud_dns.list_zones'](profile)
     try:
@@ -166,7 +169,7 @@ def record_present(name, zone, type, data, profile):
         else:
             result = __salt__['libcloud_dns.create_record'](
                 name, matching_zone['id'],
-                type, data, profile)
+                type, data, profile, extra=extra)
             return state_result(True, 'Created new record', name, result)
     else:
         return state_result(True, 'Record already exists', name)

--- a/salt/states/libcloud_dns.py
+++ b/salt/states/libcloud_dns.py
@@ -72,7 +72,7 @@ def state_result(result, message, name, changes=None):
             'changes': changes}
 
 
-def zone_present(domain, type, profile, ttl=None, extra=None):
+def zone_present(domain, profile, type=None, ttl=None, extra=None):
     '''
     Ensures a record is present.
 
@@ -92,15 +92,18 @@ def zone_present(domain, type, profile, ttl=None, extra=None):
     :type  extra: ``dict``
     '''
     zones = __salt__['libcloud_dns.list_zones'](profile)
-    if not type:
+    if type is None:
         type = 'master'
     matching_zone = [z for z in zones if z['domain'] == domain]
     if len(matching_zone) > 0:
         return state_result(True, 'Zone already exists', domain)
     else:
-        result = __salt__['libcloud_dns.create_zone'](
-            domain=domain, profile=profile, type=type, ttl=ttl, extra=extra)
-        return state_result(True, 'Created new zone', domain, result)
+        if __opts__['test']:
+            return state_result(True, 'Created new zone', domain)
+        else:
+            result = __salt__['libcloud_dns.create_zone'](
+                domain=domain, profile=profile, type=type, ttl=ttl, extra=extra)
+            return state_result(True, 'Created new zone', domain, result)
 
 
 def zone_absent(domain, profile):
@@ -118,8 +121,11 @@ def zone_absent(domain, profile):
     if len(matching_zone) == 0:
         return state_result(True, 'Zone already absent', domain)
     else:
-        result = __salt__['libcloud_dns.delete_zone'](matching_zone[0]['id'], profile)
-        return state_result(result, 'Deleted zone', domain)
+        if __opts__['test']:
+            return state_result(True, 'Deleted zone', domain)
+        else:
+            result = __salt__['libcloud_dns.delete_zone'](matching_zone[0]['id'], profile)
+            return state_result(result, 'Deleted zone', domain)
 
 
 def record_present(name, zone, type, data, profile):
@@ -155,10 +161,13 @@ def record_present(name, zone, type, data, profile):
                         record['type'] == type and
                         record['data'] == data]
     if len(matching_records) == 0:
-        result = __salt__['libcloud_dns.create_record'](
-            name, matching_zone['id'],
-            type, data, profile)
-        return state_result(True, 'Created new record', name, result)
+        if __opts__['test']:
+            return state_result(True, 'Created new record', name, {})
+        else:
+            result = __salt__['libcloud_dns.create_record'](
+                name, matching_zone['id'],
+                type, data, profile)
+            return state_result(True, 'Created new record', name, result)
     else:
         return state_result(True, 'Record already exists', name)
 
@@ -197,11 +206,14 @@ def record_absent(name, zone, type, data, profile):
                         record['data'] == data]
     if len(matching_records) > 0:
         result = []
-        for record in matching_records:
-            result.append(__salt__['libcloud_dns.delete_record'](
-                matching_zone['id'],
-                record['id'],
-                profile))
-        return state_result(all(result), 'Removed {0} records'.format(len(result)), name)
+        if __opts__['test']:
+            return state_result(True, 'Removed {0} records'.format(len(matching_records)))
+        else:
+            for record in matching_records:
+                result.append(__salt__['libcloud_dns.delete_record'](
+                    matching_zone['id'],
+                    record['id'],
+                    profile))
+            return state_result(all(result), 'Removed {0} records'.format(len(result)), name)
     else:
         return state_result(True, 'Records already absent', name)

--- a/salt/states/libcloud_dns.py
+++ b/salt/states/libcloud_dns.py
@@ -31,7 +31,8 @@ Example:
 
     my-zone:
       libcloud_dns.zone_present:
-        - name: mywebsite.com
+        - domain: mywebsite.com
+        - type: master
         - profile: profile1
     my-website:
       libcloud_dns.record_present:

--- a/tests/unit/modules/test_libcloud_dns.py
+++ b/tests/unit/modules/test_libcloud_dns.py
@@ -74,9 +74,6 @@ class TestZone(object):
     extra = {'k': 'v'}
 
 
-'''
-Dictionary version of the test zone
-'''
 _DICT_TEST_ZONE = {
     'id': '12345',
     'domain': 'test.com',
@@ -100,9 +97,6 @@ class TestRecord(object):
     extra = {'y': 'x'}
 
 
-'''
-Dictionary version of the test zone
-'''
 _DICT_TEST_RECORD = {
     'id': '45678',
     'name': 'www',
@@ -228,7 +222,7 @@ class LibcloudDnsModuleTestCase(TestCase, LoaderModuleMockMixin):
                 self.assertEqual(record, _DICT_TEST_RECORD)
                 create_record.assert_called_once()
                 create_record.assert_called_with(name='www', zone=test_zone, type='A', data='1.2.3.4',
-                                               extra={'extra': 'data'})
+                                                 extra={'extra': 'data'})
                 get_zone.assert_called_once()
                 get_zone.assert_called_with('12345')
 
@@ -272,5 +266,6 @@ class LibcloudDnsModuleTestCase(TestCase, LoaderModuleMockMixin):
         with patch('tests.unit.modules.test_libcloud_dns.MockDNSDriver.ex_foo',
                    return_value='test') as ex_foo:
             result = libcloud_dns.extra('ex_foo', 'test', arg1=1, kwarg2=2)
+            self.assertEqual(result, 'test')
             ex_foo.assert_called_once()
             ex_foo.assert_called_with(arg1=1, kwarg2=2)

--- a/tests/unit/modules/test_libcloud_dns.py
+++ b/tests/unit/modules/test_libcloud_dns.py
@@ -225,3 +225,15 @@ class LibcloudDnsModuleTestCase(TestCase, LoaderModuleMockMixin):
                                                extra={'extra': 'data'})
                 get_zone.assert_called_once()
                 get_zone.assert_called_with('12345')
+
+    def test_delete_zone(self):
+        test_zone = TestZone()
+        with patch('tests.unit.modules.test_libcloud_dns.MockDNSDriver.get_zone', return_value=test_zone) as get_zone:
+            with patch('tests.unit.modules.test_libcloud_dns.MockDNSDriver.delete_zone',
+                           return_value=True) as delete_zone:
+                result = libcloud_dns.delete_zone('12345', 'test')
+                self.assertTrue(result)
+                delete_zone.assert_called_once()
+                delete_zone.assert_called_with(test_zone)
+                get_zone.assert_called_once()
+                get_zone.assert_called_with('12345')

--- a/tests/unit/modules/test_libcloud_dns.py
+++ b/tests/unit/modules/test_libcloud_dns.py
@@ -211,3 +211,17 @@ class LibcloudDnsModuleTestCase(TestCase, LoaderModuleMockMixin):
                 update_zone.assert_called_with(zone=test_zone, domain='test.com', type='slave', ttl=400, extra={'extra': 'data'})
                 get_zone.assert_called_once()
                 get_zone.assert_called_with('12345')
+
+    def test_create_record(self):
+        test_zone = TestZone()
+        test_record = TestRecord()
+        with patch('tests.unit.modules.test_libcloud_dns.MockDNSDriver.get_zone', return_value=test_zone) as get_zone:
+            with patch('tests.unit.modules.test_libcloud_dns.MockDNSDriver.create_record',
+                       return_value=test_record) as create_record:
+                record = libcloud_dns.create_record('www', '12345', 'A', '1.2.3.4', 'test', extra={'extra': 'data'})
+                self.assertEqual(record, _DICT_TEST_RECORD)
+                create_record.assert_called_once()
+                create_record.assert_called_with(name='www', zone=test_zone, type='A', data='1.2.3.4',
+                                               extra={'extra': 'data'})
+                get_zone.assert_called_once()
+                get_zone.assert_called_with('12345')

--- a/tests/unit/modules/test_libcloud_dns.py
+++ b/tests/unit/modules/test_libcloud_dns.py
@@ -199,4 +199,4 @@ class LibcloudDnsModuleTestCase(TestCase, LoaderModuleMockMixin):
             zone = libcloud_dns.create_zone('test.com', 'test', type='slave', ttl=400, extra={'extra': 'data'})
             self.assertEqual(zone, _DICT_TEST_ZONE)
             create_zone.assert_called_once()
-            create_zone.assert_called_with('test.com', 'slave', 400, {'extra': 'data'})
+            create_zone.assert_called_with('test.com', type='slave', ttl=400, extra={'extra': 'data'})

--- a/tests/unit/modules/test_libcloud_dns.py
+++ b/tests/unit/modules/test_libcloud_dns.py
@@ -184,3 +184,19 @@ class LibcloudDnsModuleTestCase(TestCase, LoaderModuleMockMixin):
             self.assertEqual(zone, _DICT_TEST_ZONE)
             get_zone.assert_called_once()
             get_zone.assert_called_with('12345')
+
+    def test_get_record(self):
+        record = TestRecord()
+        with patch('tests.unit.modules.test_libcloud_dns.MockDNSDriver.get_record', return_value=record) as get_record:
+            record = libcloud_dns.get_record('12345', '45678', 'test')
+            self.assertEqual(record, _DICT_TEST_RECORD)
+            get_record.assert_called_once()
+            get_record.assert_called_with('12345', '45678')
+
+    def test_create_zone(self):
+        zone = TestZone()
+        with patch('tests.unit.modules.test_libcloud_dns.MockDNSDriver.create_zone', return_value=zone) as create_zone:
+            zone = libcloud_dns.create_zone('test.com', 'test', type='slave', ttl=400, extra={'extra': 'data'})
+            self.assertEqual(zone, _DICT_TEST_ZONE)
+            create_zone.assert_called_once()
+            create_zone.assert_called_with('test.com', 'slave', 400, {'extra': 'data'})

--- a/tests/unit/modules/test_libcloud_dns.py
+++ b/tests/unit/modules/test_libcloud_dns.py
@@ -142,14 +142,14 @@ class LibcloudDnsModuleTestCase(TestCase, LoaderModuleMockMixin):
             dunder.assert_called_with('salt.modules.libcloud_dns')
 
     def test_list_record_types(self):
-        with patch('tests.unit.modules.test_libcloud_dns.MockDNSDriver.list_record_types', return_value=[]) as method:
+        with patch.object(MockDNSDriver, 'list_record_types', return_value=[]) as method:
             types = libcloud_dns.list_record_types('test')
             self.assertEqual(types, [])
             method.assert_called_once()
             method.assert_called_with()
 
     def test_list_zones(self):
-        with patch('tests.unit.modules.test_libcloud_dns.MockDNSDriver.list_zones', return_value=[TestZone()]) as method:
+        with patch.object(MockDNSDriver, 'list_zones', return_value=[TestZone()]) as method:
             types = libcloud_dns.list_zones('test')
             self.assertEqual(types, [_DICT_TEST_ZONE])
             method.assert_called_once()
@@ -157,8 +157,8 @@ class LibcloudDnsModuleTestCase(TestCase, LoaderModuleMockMixin):
 
     def test_list_records(self):
         zone = TestZone()
-        with patch('tests.unit.modules.test_libcloud_dns.MockDNSDriver.get_zone', return_value=zone) as get_zone:
-            with patch('tests.unit.modules.test_libcloud_dns.MockDNSDriver.list_records', return_value=[TestRecord()]) as method:
+        with patch.object(MockDNSDriver, 'get_zone', return_value=zone) as get_zone:
+            with patch.object(MockDNSDriver, 'list_records', return_value=[TestRecord()]) as method:
                 types = libcloud_dns.list_records('12345', 'test')
                 self.assertEqual(types, [_DICT_TEST_RECORD])
                 method.assert_called_once()
@@ -168,8 +168,8 @@ class LibcloudDnsModuleTestCase(TestCase, LoaderModuleMockMixin):
 
     def test_list_records_by_type(self):
         zone = TestZone()
-        with patch('tests.unit.modules.test_libcloud_dns.MockDNSDriver.get_zone', return_value=zone) as get_zone:
-            with patch('tests.unit.modules.test_libcloud_dns.MockDNSDriver.list_records', return_value=[TestRecord()]) as method:
+        with patch.object(MockDNSDriver, 'get_zone', return_value=zone) as get_zone:
+            with patch.object(MockDNSDriver, 'list_records', return_value=[TestRecord()]) as method:
                 types = libcloud_dns.list_records('12345', 'test', 'NS')
                 self.assertEqual(types, [])
                 method.assert_called_once()
@@ -179,7 +179,7 @@ class LibcloudDnsModuleTestCase(TestCase, LoaderModuleMockMixin):
 
     def test_get_zone(self):
         zone = TestZone()
-        with patch('tests.unit.modules.test_libcloud_dns.MockDNSDriver.get_zone', return_value=zone) as get_zone:
+        with patch.object(MockDNSDriver, 'get_zone', return_value=zone) as get_zone:
             zone = libcloud_dns.get_zone('12345', 'test')
             self.assertEqual(zone, _DICT_TEST_ZONE)
             get_zone.assert_called_once()
@@ -187,7 +187,7 @@ class LibcloudDnsModuleTestCase(TestCase, LoaderModuleMockMixin):
 
     def test_get_record(self):
         record = TestRecord()
-        with patch('tests.unit.modules.test_libcloud_dns.MockDNSDriver.get_record', return_value=record) as get_record:
+        with patch.object(MockDNSDriver, 'get_record', return_value=record) as get_record:
             record = libcloud_dns.get_record('12345', '45678', 'test')
             self.assertEqual(record, _DICT_TEST_RECORD)
             get_record.assert_called_once()
@@ -195,7 +195,7 @@ class LibcloudDnsModuleTestCase(TestCase, LoaderModuleMockMixin):
 
     def test_create_zone(self):
         zone = TestZone()
-        with patch('tests.unit.modules.test_libcloud_dns.MockDNSDriver.create_zone', return_value=zone) as create_zone:
+        with patch.object(MockDNSDriver, 'create_zone', return_value=zone) as create_zone:
             zone = libcloud_dns.create_zone('test.com', 'test', type='slave', ttl=400, extra={'extra': 'data'})
             self.assertEqual(zone, _DICT_TEST_ZONE)
             create_zone.assert_called_once()
@@ -203,8 +203,8 @@ class LibcloudDnsModuleTestCase(TestCase, LoaderModuleMockMixin):
 
     def test_update_zone(self):
         test_zone = TestZone()
-        with patch('tests.unit.modules.test_libcloud_dns.MockDNSDriver.get_zone', return_value=test_zone) as get_zone:
-            with patch('tests.unit.modules.test_libcloud_dns.MockDNSDriver.update_zone', return_value=test_zone) as update_zone:
+        with patch.object(MockDNSDriver, 'get_zone', return_value=test_zone) as get_zone:
+            with patch.object(MockDNSDriver, 'update_zone', return_value=test_zone) as update_zone:
                 zone = libcloud_dns.update_zone('12345', 'test.com', 'test', type='slave', ttl=400, extra={'extra': 'data'})
                 self.assertEqual(zone, _DICT_TEST_ZONE)
                 update_zone.assert_called_once()
@@ -215,8 +215,8 @@ class LibcloudDnsModuleTestCase(TestCase, LoaderModuleMockMixin):
     def test_create_record(self):
         test_zone = TestZone()
         test_record = TestRecord()
-        with patch('tests.unit.modules.test_libcloud_dns.MockDNSDriver.get_zone', return_value=test_zone) as get_zone:
-            with patch('tests.unit.modules.test_libcloud_dns.MockDNSDriver.create_record',
+        with patch.object(MockDNSDriver, 'get_zone', return_value=test_zone) as get_zone:
+            with patch.object(MockDNSDriver, 'create_record',
                        return_value=test_record) as create_record:
                 record = libcloud_dns.create_record('www', '12345', 'A', '1.2.3.4', 'test', extra={'extra': 'data'})
                 self.assertEqual(record, _DICT_TEST_RECORD)
@@ -228,8 +228,8 @@ class LibcloudDnsModuleTestCase(TestCase, LoaderModuleMockMixin):
 
     def test_delete_zone(self):
         test_zone = TestZone()
-        with patch('tests.unit.modules.test_libcloud_dns.MockDNSDriver.get_zone', return_value=test_zone) as get_zone:
-            with patch('tests.unit.modules.test_libcloud_dns.MockDNSDriver.delete_zone',
+        with patch.object(MockDNSDriver, 'get_zone', return_value=test_zone) as get_zone:
+            with patch.object(MockDNSDriver, 'delete_zone',
                            return_value=True) as delete_zone:
                 result = libcloud_dns.delete_zone('12345', 'test')
                 self.assertTrue(result)
@@ -240,8 +240,8 @@ class LibcloudDnsModuleTestCase(TestCase, LoaderModuleMockMixin):
 
     def test_delete_record(self):
         test_record = TestRecord()
-        with patch('tests.unit.modules.test_libcloud_dns.MockDNSDriver.get_record', return_value=test_record) as get_record:
-            with patch('tests.unit.modules.test_libcloud_dns.MockDNSDriver.delete_record',
+        with patch.object(MockDNSDriver, 'get_record', return_value=test_record) as get_record:
+            with patch.object(MockDNSDriver, 'delete_record',
                        return_value=True) as delete_record:
                 result = libcloud_dns.delete_record('12345', '45678', 'test')
                 self.assertTrue(result)
@@ -252,8 +252,8 @@ class LibcloudDnsModuleTestCase(TestCase, LoaderModuleMockMixin):
 
     def test_get_bind_data(self):
         test_zone = TestZone()
-        with patch('tests.unit.modules.test_libcloud_dns.MockDNSDriver.get_zone', return_value=test_zone) as get_zone:
-            with patch('tests.unit.modules.test_libcloud_dns.MockDNSDriver.export_zone_to_bind_format',
+        with patch.object(MockDNSDriver, 'get_zone', return_value=test_zone) as get_zone:
+            with patch.object(MockDNSDriver, 'export_zone_to_bind_format',
                        return_value='test') as get_bind_data:
                 result = libcloud_dns.get_bind_data('12345', 'test')
                 self.assertEqual(result, 'test')
@@ -263,7 +263,7 @@ class LibcloudDnsModuleTestCase(TestCase, LoaderModuleMockMixin):
                 get_zone.assert_called_with('12345')
 
     def test_extra(self):
-        with patch('tests.unit.modules.test_libcloud_dns.MockDNSDriver.ex_foo',
+        with patch.object(MockDNSDriver, 'ex_foo',
                    return_value='test') as ex_foo:
             result = libcloud_dns.extra('ex_foo', 'test', arg1=1, kwarg2=2)
             self.assertEqual(result, 'test')

--- a/tests/unit/modules/test_libcloud_dns.py
+++ b/tests/unit/modules/test_libcloud_dns.py
@@ -55,6 +55,12 @@ class MockDNSDriver(object):
     def delete_record(self, record):
         raise NotImplementedError()
 
+    def export_zone_to_bind_format(self, zone):
+        raise NotImplementedError()
+
+    def ex_foo(self, arg1, kwarg2=None):
+        raise NotImplementedError()
+
 
 class TestZone(object):
     '''
@@ -249,3 +255,22 @@ class LibcloudDnsModuleTestCase(TestCase, LoaderModuleMockMixin):
                 delete_record.assert_called_with(test_record)
                 get_record.assert_called_once()
                 get_record.assert_called_with(zone_id='12345', record_id='45678')
+
+    def test_get_bind_data(self):
+        test_zone = TestZone()
+        with patch('tests.unit.modules.test_libcloud_dns.MockDNSDriver.get_zone', return_value=test_zone) as get_zone:
+            with patch('tests.unit.modules.test_libcloud_dns.MockDNSDriver.export_zone_to_bind_format',
+                       return_value='test') as get_bind_data:
+                result = libcloud_dns.get_bind_data('12345', 'test')
+                self.assertEqual(result, 'test')
+                get_bind_data.assert_called_once()
+                get_bind_data.assert_called_with(test_zone)
+                get_zone.assert_called_once()
+                get_zone.assert_called_with('12345')
+
+    def test_extra(self):
+        with patch('tests.unit.modules.test_libcloud_dns.MockDNSDriver.ex_foo',
+                   return_value='test') as ex_foo:
+            result = libcloud_dns.extra('ex_foo', 'test', arg1=1, kwarg2=2)
+            ex_foo.assert_called_once()
+            ex_foo.assert_called_with(arg1=1, kwarg2=2)

--- a/tests/unit/modules/test_libcloud_dns.py
+++ b/tests/unit/modules/test_libcloud_dns.py
@@ -237,3 +237,15 @@ class LibcloudDnsModuleTestCase(TestCase, LoaderModuleMockMixin):
                 delete_zone.assert_called_with(test_zone)
                 get_zone.assert_called_once()
                 get_zone.assert_called_with('12345')
+
+    def test_delete_record(self):
+        test_record = TestRecord()
+        with patch('tests.unit.modules.test_libcloud_dns.MockDNSDriver.get_record', return_value=test_record) as get_record:
+            with patch('tests.unit.modules.test_libcloud_dns.MockDNSDriver.delete_record',
+                       return_value=True) as delete_record:
+                result = libcloud_dns.delete_record('12345', '45678', 'test')
+                self.assertTrue(result)
+                delete_record.assert_called_once()
+                delete_record.assert_called_with(test_record)
+                get_record.assert_called_once()
+                get_record.assert_called_with(zone_id='12345', record_id='45678')

--- a/tests/unit/modules/test_libcloud_dns.py
+++ b/tests/unit/modules/test_libcloud_dns.py
@@ -200,3 +200,14 @@ class LibcloudDnsModuleTestCase(TestCase, LoaderModuleMockMixin):
             self.assertEqual(zone, _DICT_TEST_ZONE)
             create_zone.assert_called_once()
             create_zone.assert_called_with('test.com', type='slave', ttl=400, extra={'extra': 'data'})
+
+    def test_update_zone(self):
+        test_zone = TestZone()
+        with patch('tests.unit.modules.test_libcloud_dns.MockDNSDriver.get_zone', return_value=test_zone) as get_zone:
+            with patch('tests.unit.modules.test_libcloud_dns.MockDNSDriver.update_zone', return_value=test_zone) as update_zone:
+                zone = libcloud_dns.update_zone('12345', 'test.com', 'test', type='slave', ttl=400, extra={'extra': 'data'})
+                self.assertEqual(zone, _DICT_TEST_ZONE)
+                update_zone.assert_called_once()
+                update_zone.assert_called_with(zone=test_zone, domain='test.com', type='slave', ttl=400, extra={'extra': 'data'})
+                get_zone.assert_called_once()
+                get_zone.assert_called_with('12345')

--- a/tests/unit/states/test_libcloud_dns.py
+++ b/tests/unit/states/test_libcloud_dns.py
@@ -51,16 +51,16 @@ class LibcloudDnsModuleTestCase(TestCase, LoaderModuleMockMixin):
         def list_records(zone_id, profile):
             return test_records[zone_id]
 
-        def create_record(*args):
+        def create_record(*args, **kwargs):
             return True
 
         def delete_record(*args):
             return True
 
-        def create_zone(*args):
+        def create_zone(*args, **kwargs):
             return True
 
-        def delete_zone(*args):
+        def delete_zone(*args, **kwargs):
             return True
 
         return {
@@ -72,6 +72,9 @@ class LibcloudDnsModuleTestCase(TestCase, LoaderModuleMockMixin):
                     'libcloud_dns.delete_record': delete_record,
                     'libcloud_dns.create_zone': create_zone,
                     'libcloud_dns.delete_zone': delete_zone
+                },
+                '__opts__': {
+                    'test': False
                 }
             }
         }


### PR DESCRIPTION
### What does this PR do?

Fixes a number of issues in the `libcloud_dns` state and execution modules

- [x] Documentation doesn't mention that libcloud is not a cloud module
- [x]  `create_zone` didn't work, called the wrong method and was missing a kwarg
- [x] Bug in Create_record
- [x] Incorrect test methods
- [x] 'name' is an invalid keyword argument for 'libcloud_dns.zone_present'
- [x] test argument not passed
- [x] TypeError: argument of type 'NoneType' is not iterable

### What issues does this PR fix or reference?

#50286 

### Tests written?

Yes

### Commits signed with GPG?

Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
