### PR TITLE
Add missing return to secretbox_decrypt()

### DIFF
--- a/salt/utils/nacl.py
+++ b/salt/utils/nacl.py
@@ -402,3 +402,5 @@ def secretbox_decrypt(data, **kwargs):
 
     key = _get_sk(**kwargs)
     b = libnacl.secret.SecretBox(key=key)
+
+    return b.decrypt(base64.b64decode(data))


### PR DESCRIPTION
### What does this PR do?
Adds missing return to secretbox_decrypt in the nacl salt util. It looks like it was never finished.

### What issues does this PR fix or reference?
Tests were failing on Windows.

### Tests written?
Yes

### Commits signed with GPG?
Yes