### PR TITLE
Fixes issues raised in #47425 for states.netyang

### DIFF
--- a/salt/states/netyang.py
+++ b/salt/states/netyang.py
@@ -77,7 +77,6 @@ def __virtual__():
 
 def managed(name,
             data,
-            *models,
             **kwargs):
     '''
     Manage the device configuration given the input data structured
@@ -141,6 +140,7 @@ def managed(name,
                 config:
                   description: "description example"
     '''
+    models = kwargs.get('models', None)
     if isinstance(models, tuple) and isinstance(models[0], list):
         models = models[0]
     ret = salt.utils.napalm.default_ret(name)
@@ -204,7 +204,6 @@ def managed(name,
 
 def configured(name,
                data,
-               *models,
                **kwargs):
     '''
     Configure the network device, given the input data strucuted
@@ -274,6 +273,7 @@ def configured(name,
                 config:
                   description: "description example"
     '''
+    models = kwargs.get('models', None)
     if isinstance(models, tuple) and isinstance(models[0], list):
         models = models[0]
     ret = salt.utils.napalm.default_ret(name)

--- a/tests/unit/states/test_netyang.py
+++ b/tests/unit/states/test_netyang.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+'''
+    :codeauthor: Anthony Shaw <anthonyshaw@apache.org>
+'''
+# Import Python libs
+from __future__ import absolute_import, print_function, unicode_literals
+import os
+
+# Import Salt Libs
+import salt.states.netyang as netyang
+
+# Import Salt Testing Libs
+from tests.support.mixins import LoaderModuleMockMixin
+from tests.support.unit import skipIf, TestCase
+from tests.support.mock import (
+    NO_MOCK,
+    NO_MOCK_REASON,
+    MagicMock,
+    patch
+)
+
+TEST_DATA = {
+    'foo': 'bar'
+}
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class NetyangTestCase(TestCase, LoaderModuleMockMixin):
+    def setup_loader_modules(self):
+        return {netyang: {}}
+
+
+    def test_managed(self):
+        ret = {'changes': {}, 'comment': '',
+               'name': 'salt', 'result': True}
+        revision_mock = MagicMock(return_value='abcdef')
+
+        with patch.dict(netyang.__salt__,
+                        {'hg.revision': revision_mock,}):
+            with patch.dict(netyang.__opts__, {'test': False}):
+                self.assertDictEqual(netyang.managed('test', ('model1',)), ret)
+                assert revision_mock.called

--- a/tests/unit/states/test_netyang.py
+++ b/tests/unit/states/test_netyang.py
@@ -4,7 +4,6 @@
 '''
 # Import Python libs
 from __future__ import absolute_import, print_function, unicode_literals
-import os
 
 # Import Salt Libs
 import salt.states.netyang as netyang

--- a/tests/unit/states/test_netyang.py
+++ b/tests/unit/states/test_netyang.py
@@ -23,19 +23,45 @@ TEST_DATA = {
     'foo': 'bar'
 }
 
+
 @skipIf(NO_MOCK, NO_MOCK_REASON)
 class NetyangTestCase(TestCase, LoaderModuleMockMixin):
     def setup_loader_modules(self):
         return {netyang: {}}
 
-
     def test_managed(self):
-        ret = {'changes': {}, 'comment': '',
-               'name': 'salt', 'result': True}
-        revision_mock = MagicMock(return_value='abcdef')
+        ret = {'changes': {}, 'comment': 'Loaded.',
+               'name': 'test', 'result': False}
+        parse = MagicMock(return_value='abcdef')
+        temp_file = MagicMock(return_value='')
+        compliance_report = MagicMock(return_value={'complies': False})
+        load_config = MagicMock(return_value={'comment': 'Loaded.'})
+        file_remove = MagicMock()
 
-        with patch.dict(netyang.__salt__,
-                        {'hg.revision': revision_mock,}):
-            with patch.dict(netyang.__opts__, {'test': False}):
-                self.assertDictEqual(netyang.managed('test', ('model1',)), ret)
-                assert revision_mock.called
+        with patch('salt.utils.files.fopen'):
+            with patch.dict(netyang.__salt__,
+                            {'temp.file': temp_file,
+                             'napalm_yang.parse': parse,
+                             'napalm_yang.load_config': load_config,
+                             'napalm_yang.compliance_report': compliance_report,
+                             'file.remove': file_remove}):
+                with patch.dict(netyang.__opts__, {'test': False}):
+                    self.assertDictEqual(netyang.managed('test', 'test', models=('model1',)), ret)
+                    assert parse.called
+                    assert temp_file.called
+                    assert compliance_report.called
+                    assert load_config.called
+                    assert file_remove.called
+
+    def test_configured(self):
+        ret = {'changes': {}, 'comment': 'Loaded.',
+               'name': 'test', 'result': False}
+        load_config = MagicMock(return_value={'comment': 'Loaded.'})
+
+        with patch('salt.utils.files.fopen'):
+            with patch.dict(netyang.__salt__,
+                            {'napalm_yang.load_config': load_config}):
+                with patch.dict(netyang.__opts__, {'test': False}):
+                    self.assertDictEqual(netyang.configured('test', 'test', models=('model1',)), ret)
+
+                    assert load_config.called


### PR DESCRIPTION
### What does this PR do?
Fixes an issue with tuple unpacking in the netyang states module.

### What issues does this PR fix or reference?
See #47425 

### Previous Behavior
Remove this section if not relevant

### New Behavior
Remove this section if not relevant

### Tests written?

Yes

### Commits signed with GPG?

Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
