### PR TITLE
Add 'noaction' flag for install/remove in the opkg execution module 

### DIFF
--- a/salt/modules/opkg.py
+++ b/salt/modules/opkg.py
@@ -368,7 +368,7 @@ def install(name=None,
 
     if bool(kwargs.get('test') or __opts__.get('test')):
         cmd_prefix.append('--noaction')
-    
+
     if pkg_params is None or len(pkg_params) == 0:
         return {}
     elif pkg_type == 'file':

--- a/salt/modules/opkg.py
+++ b/salt/modules/opkg.py
@@ -366,6 +366,8 @@ def install(name=None,
     to_reinstall = []
     to_downgrade = []
 
+    if kwargs.get('noaction', False):
+        cmd_prefix.append('--noaction')
     if pkg_params is None or len(pkg_params) == 0:
         return {}
     elif pkg_type == 'file':
@@ -540,6 +542,8 @@ def remove(name=None, pkgs=None, **kwargs):  # pylint: disable=unused-argument
     if not targets:
         return {}
     cmd = ['opkg', 'remove']
+    if kwargs.get('noaction', False):
+        cmd.append('--noaction')
     if kwargs.get('remove_dependencies', False):
         cmd.append('--force-removal-of-dependent-packages')
     if kwargs.get('auto_remove_deps', False):

--- a/salt/modules/opkg.py
+++ b/salt/modules/opkg.py
@@ -366,8 +366,9 @@ def install(name=None,
     to_reinstall = []
     to_downgrade = []
 
-    if kwargs.get('noaction', False):
+    if bool(kwargs.get('test') or __opts__.get('test')):
         cmd_prefix.append('--noaction')
+    
     if pkg_params is None or len(pkg_params) == 0:
         return {}
     elif pkg_type == 'file':
@@ -542,7 +543,7 @@ def remove(name=None, pkgs=None, **kwargs):  # pylint: disable=unused-argument
     if not targets:
         return {}
     cmd = ['opkg', 'remove']
-    if kwargs.get('noaction', False):
+    if bool(kwargs.get('test') or __opts__.get('test')):
         cmd.append('--noaction')
     if kwargs.get('remove_dependencies', False):
         cmd.append('--force-removal-of-dependent-packages')

--- a/salt/modules/opkg.py
+++ b/salt/modules/opkg.py
@@ -269,6 +269,14 @@ def refresh_db(failhard=False, **kwargs):  # pylint: disable=unused-argument
     return ret
 
 
+def _append_noaction_if_testmode(cmd, **kwargs):
+    '''
+    Adds the --noaction flag to the command if it's running in the test mode.
+    '''
+    if bool(kwargs.get('test') or __opts__.get('test')):
+        cmd.append('--noaction')
+
+
 def install(name=None,
             refresh=False,
             pkgs=None,
@@ -366,9 +374,7 @@ def install(name=None,
     to_reinstall = []
     to_downgrade = []
 
-    if bool(kwargs.get('test') or __opts__.get('test')):
-        cmd_prefix.append('--noaction')
-
+    _append_noaction_if_testmode(cmd_prefix, **kwargs)
     if pkg_params is None or len(pkg_params) == 0:
         return {}
     elif pkg_type == 'file':
@@ -543,8 +549,7 @@ def remove(name=None, pkgs=None, **kwargs):  # pylint: disable=unused-argument
     if not targets:
         return {}
     cmd = ['opkg', 'remove']
-    if bool(kwargs.get('test') or __opts__.get('test')):
-        cmd.append('--noaction')
+    _append_noaction_if_testmode(cmd, **kwargs)
     if kwargs.get('remove_dependencies', False):
         cmd.append('--force-removal-of-dependent-packages')
     if kwargs.get('auto_remove_deps', False):

--- a/tests/unit/modules/test_opkg.py
+++ b/tests/unit/modules/test_opkg.py
@@ -158,7 +158,7 @@ class OpkgTestCase(TestCase, LoaderModuleMockMixin):
                 }
             }
             with patch.multiple(opkg, **patch_kwargs):
-                self.assertEqual(opkg.install('vim:7.4', noaction=True), {})
+                self.assertEqual(opkg.install('vim:7.4', test=True), {})
 
     def test_remove(self):
         '''
@@ -192,7 +192,7 @@ class OpkgTestCase(TestCase, LoaderModuleMockMixin):
                 }
             }
             with patch.multiple(opkg, **patch_kwargs):
-                self.assertEqual(opkg.remove('vim:7.4', noaction=True), {})
+                self.assertEqual(opkg.remove('vim:7.4', test=True), {})
 
     def test_info_installed(self):
         '''

--- a/tests/unit/modules/test_opkg.py
+++ b/tests/unit/modules/test_opkg.py
@@ -143,6 +143,23 @@ class OpkgTestCase(TestCase, LoaderModuleMockMixin):
             with patch.multiple(opkg, **patch_kwargs):
                 self.assertEqual(opkg.install('vim:7.4'), INSTALLED)
 
+    def test_install_noaction(self):
+        '''
+        Test - Install packages.
+        '''
+        with patch('salt.modules.opkg.list_pkgs', MagicMock(return_value=({}))):
+            ret_value = {'retcode': 0}
+            mock = MagicMock(return_value=ret_value)
+            patch_kwargs = {
+                '__salt__': {
+                    'cmd.run_all': mock,
+                    'pkg_resource.parse_targets': MagicMock(return_value=({'vim': '7.4'}, 'repository')),
+                    'restartcheck.restartcheck': MagicMock(return_value='No packages seem to need to be restarted')
+                }
+            }
+            with patch.multiple(opkg, **patch_kwargs):
+                self.assertEqual(opkg.install('vim:7.4', noaction=True), {})
+
     def test_remove(self):
         '''
         Test - Remove packages.
@@ -159,6 +176,23 @@ class OpkgTestCase(TestCase, LoaderModuleMockMixin):
             }
             with patch.multiple(opkg, **patch_kwargs):
                 self.assertEqual(opkg.remove('vim'), REMOVED)
+
+    def test_remove_noaction(self):
+        '''
+        Test - Remove packages.
+        '''
+        with patch('salt.modules.opkg.list_pkgs', MagicMock(return_value=({}))):
+            ret_value = {'retcode': 0}
+            mock = MagicMock(return_value=ret_value)
+            patch_kwargs = {
+                '__salt__': {
+                    'cmd.run_all': mock,
+                    'pkg_resource.parse_targets': MagicMock(return_value=({'vim': '7.4'}, 'repository')),
+                    'restartcheck.restartcheck': MagicMock(return_value='No packages seem to need to be restarted')
+                }
+            }
+            with patch.multiple(opkg, **patch_kwargs):
+                self.assertEqual(opkg.remove('vim:7.4', noaction=True), {})
 
     def test_info_installed(self):
         '''


### PR DESCRIPTION
### What does this PR do?
Adding the 'noaction' flags when installing/removing software. Basically it's just testing if the operations will succeed or not without actually doing the operation.

### Previous Behavior
opkg wasn't providing this functionality.

### New Behavior
you can pass the noaction=True flag

### Tests written?

Yes

### Commits signed with GPG?

Yes
