### PR TITLE
Fix matcher grain file

### DIFF
--- a/tests/integration/files/file/base/_grains/matcher_grain.py
+++ b/tests/integration/files/file/base/_grains/matcher_grain.py
@@ -3,5 +3,5 @@
 
 def myfunction():
     grains = {}
-    grains['a_custom'] = {'k1': 'v1'}
+    grains['match'] = 'maker'
     return grains


### PR DESCRIPTION
### What does this PR do?
This was inadvertently changed in the filename_map backport.

This commit restores the matcher grain file to match all branches previous to the inadvertent change.

This PR fixes the 2 tests that are currently failing on the 2018.3 branch: 
- integration.loader.test_ext_grains.LoaderGrainsTest.test_grains_overwrite
- integration.shell.test_matcher.MatchTest.test_grai

### What issues does this PR fix or reference?
Refs #50182 and #50050

### Tests written?

No - fixes test failures

### Commits signed with GPG?

Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
