### PR TITLE
salt/dpkg.py: fix path to package.list for different architectures

### DIFF
--- a/salt/modules/dpkg.py
+++ b/salt/modules/dpkg.py
@@ -342,16 +342,23 @@ def _get_pkg_install_time(pkg, arch=None):
     :return:
     '''
     iso_time = None
+    loc_root = '/var/lib/dpkg/info'
     if pkg is not None:
+        locations = []
         if arch is not None and arch != 'all':
-            location = "/var/lib/dpkg/info/{0}:{1}.list".format(pkg, arch)
-            if os.path.exists(location):
-                iso_time = datetime.datetime.utcfromtimestamp(int(os.path.getmtime(location))).isoformat() + "Z"
+            locations.append(os.path.join(loc_root, '{0}:{1}.list'.format(pkg, arch)))
+
+        locations.append(os.path.join(loc_root, '{0}.list'.format(pkg)))
+        for location in locations:
+            try:
+                iso_time = datetime.datetime.utcfromtimestamp(
+                            int(os.path.getmtime(location))).isoformat() + 'Z'
+                break
+            except:
+                pass
 
         if iso_time is None:
-            location = "/var/lib/dpkg/info/{0}.list".format(pkg)
-            if os.path.exists(location):
-                iso_time = datetime.datetime.utcfromtimestamp(int(os.path.getmtime(location))).isoformat() + "Z"
+            log.debug('Unable to get package installation time for package "%s".', pkg)
 
     return iso_time
 

--- a/salt/modules/dpkg.py
+++ b/salt/modules/dpkg.py
@@ -307,9 +307,9 @@ def _get_pkg_info(*packages, **kwargs):
             key, value = pkg_info_line.split(":", 1)
             if value:
                 pkg_data[key] = value
-            install_date = _get_pkg_install_time(pkg_data.get('package'))
-            if install_date:
-                pkg_data['install_date'] = install_date
+        install_date = _get_pkg_install_time(pkg_data.get('package'), pkg_data.get('architecture'))
+        if install_date:
+            pkg_data['install_date'] = install_date
         pkg_data['description'] = pkg_descr.split(":", 1)[-1]
         ret.append(pkg_data)
 
@@ -335,7 +335,7 @@ def _get_pkg_license(pkg):
     return ", ".join(sorted(licenses))
 
 
-def _get_pkg_install_time(pkg):
+def _get_pkg_install_time(pkg, arch=None):
     '''
     Return package install time, based on the /var/lib/dpkg/info/<package>.list
 
@@ -343,9 +343,15 @@ def _get_pkg_install_time(pkg):
     '''
     iso_time = None
     if pkg is not None:
-        location = "/var/lib/dpkg/info/{0}.list".format(pkg)
-        if os.path.exists(location):
-            iso_time = datetime.datetime.utcfromtimestamp(int(os.path.getmtime(location))).isoformat() + "Z"
+        if arch is not None and arch != 'all':
+            location = "/var/lib/dpkg/info/{0}:{1}.list".format(pkg, arch)
+            if os.path.exists(location):
+                iso_time = datetime.datetime.utcfromtimestamp(int(os.path.getmtime(location))).isoformat() + "Z"
+
+        if iso_time is None:
+            location = "/var/lib/dpkg/info/{0}.list".format(pkg)
+            if os.path.exists(location):
+                iso_time = datetime.datetime.utcfromtimestamp(int(os.path.getmtime(location))).isoformat() + "Z"
 
     return iso_time
 

--- a/salt/modules/dpkg.py
+++ b/salt/modules/dpkg.py
@@ -354,7 +354,7 @@ def _get_pkg_install_time(pkg, arch=None):
                 iso_time = datetime.datetime.utcfromtimestamp(
                             int(os.path.getmtime(location))).isoformat() + 'Z'
                 break
-            except:
+            except OSError as err:
                 pass
 
         if iso_time is None:


### PR DESCRIPTION
The 'install_date' is missing for many packages, because the <package>.list file sometimes
contains the architecture seperated by ':'. So first try this file location and
fall back, if that did not work.

### What does this PR do?
It fixes the ```install_date``` for debian packages that is missing for many packages because the file that is used to get the ```install_date``` is wrong.

### What issues does this PR fix or reference?
None found. This issue has been found while trying to integrate Debian systems as Salt clients into Uyuni server.

### Previous Behavior
```install_date``` missing for many packages

### New Behavior
```install_date``` returned for every package

### Tests written?

No (sorry.)

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
