### PR TITLE
Un-fix path seperators for Windows

### DIFF
--- a/tests/integration/shell/test_cp.py
+++ b/tests/integration/shell/test_cp.py
@@ -97,10 +97,7 @@ class CopyTest(ShellCase, ShellCaseCommonTestsMixin):
 
             data = eval('\n'.join(ret), {}, {})  # pylint: disable=eval-used
             for part in six.itervalues(data):
-                if salt.utils.platform.is_windows():
-                    key = minion_testfile.replace('\\', '\\\\')
-                else:
-                    key = minion_testfile
+                key = minion_testfile
                 self.assertTrue(part[key])
 
             ret = self.run_salt(


### PR DESCRIPTION
### What does this PR do?
Fixes `integration.shell.test_cp.CopyTest.test_cp_testfile` for Windows. An earlier fix acced path seperators. This was causing the test to fail.

### What issues does this PR fix or reference?
Found by Jenkins

### Tests written?
Yes

### Commits signed with GPG?
Yes