### PR TITLE
Fix double logging to file and syslog.

### DIFF
--- a/pkg/deb/salt-master.service
+++ b/pkg/deb/salt-master.service
@@ -6,6 +6,8 @@ After=network.target
 LimitNOFILE=16384
 Type=notify
 NotifyAccess=all
+StandardOutput=null                                                                                                     
+StandardError=null 
 ExecStart=/usr/bin/salt-master
 
 [Install]

--- a/pkg/deb/salt-minion.service
+++ b/pkg/deb/salt-minion.service
@@ -7,6 +7,8 @@ Type=notify
 KillMode=process
 NotifyAccess=all
 LimitNOFILE=8192
+StandardOutput=null                                                                                                     
+StandardError=null 
 ExecStart=/usr/bin/salt-minion
 
 [Install]


### PR DESCRIPTION
### What does this PR do?
In Ubuntu/Debian with systemd (e.g. `Ubuntu 16.04`), salt minion and master were logging to custom file (`/var/log/salt/*`) and syslog (`/var/log/syslog`) at the same time.

So this PR disable send logs to `syslog` and keep the file managed in Salt config.

### What issues does this PR fix or reference?
This a fix for issue no. #45626

### Previous Behavior
Salt minion and master were logging to custom file and syslog at the same time.
```
/var/log/syslog
/var/log/salt/master
/var/log/salt/minion
```

### New Behavior
Salt minion and master logging only to configured log file.
```
/var/log/salt/master
/var/log/salt/minion
```

### Tests written?
N/A

### Commits signed with GPG?
Yes

### Info
```
salt-minion -V
Salt Version:
           Salt: 2017.7.6
 
Dependency Versions:
           cffi: 1.5.2
       cherrypy: Not Installed
       dateutil: 2.4.2
      docker-py: Not Installed
          gitdb: Not Installed
      gitpython: Not Installed
          ioflo: Not Installed
         Jinja2: 2.8
        libgit2: 0.24.0
        libnacl: Not Installed
       M2Crypto: 0.21.1
           Mako: 1.0.3
   msgpack-pure: Not Installed
 msgpack-python: 0.4.6
   mysql-python: Not Installed
      pycparser: 2.14
       pycrypto: 2.6.1
   pycryptodome: Not Installed
         pygit2: 0.24.0
         Python: 2.7.12 (default, Nov 20 2017, 18:23:56)
   python-gnupg: Not Installed
         PyYAML: 3.11
          PyZMQ: 15.2.0
           RAET: Not Installed
          smmap: Not Installed
        timelib: Not Installed
        Tornado: 4.2.1
            ZMQ: 4.1.4
 
System Versions:
           dist: Ubuntu 16.04 xenial
         locale: UTF-8
        machine: x86_64
        release: 4.4.0-62-generic
         system: Linux
        version: Ubuntu 16.04 xenial
```