### PR TITLE
Fix issue with salt-run jobs.list_jobs where Target: unknown-target 

### DIFF
--- a/salt/utils/job.py
+++ b/salt/utils/job.py
@@ -103,10 +103,12 @@ def store_job(opts, load, event=None, mminion=None):
         log.error(emsg)
         raise KeyError(emsg)
 
-    try:
-        mminion.returners[savefstr](load['jid'], load)
-    except KeyError as e:
-        log.error("Load does not contain 'jid': %s", e)
+    if job_cache != 'local_cache':
+        try:
+            mminion.returners[savefstr](load['jid'], load)
+        except KeyError as e:
+            log.error("Load does not contain 'jid': %s", e)
+
     mminion.returners[fstr](load)
 
     if (opts.get('job_cache_store_endtime')

--- a/tests/integration/runners/test_jobs.py
+++ b/tests/integration/runners/test_jobs.py
@@ -62,10 +62,11 @@ class LocalCacheTargetTest(ShellCase):
 
         This is a regression test for fixing the local_cache behavior.
         '''
-        self.run_salt('minion test.ping')
+        self.run_salt('minion test.echo target_info_test')
         ret = self.run_run_plus('jobs.list_jobs')
         for item in ret['return'].values():
-            if item['Function'] == 'test.ping':
+            if item['Function'] == 'test.echo' and \
+                item['Arguments'][0] == 'target_info_test':
                 job_ret = item
         tgt = job_ret['Target']
         tgt_type = job_ret['Target-type']

--- a/tests/integration/runners/test_jobs.py
+++ b/tests/integration/runners/test_jobs.py
@@ -37,3 +37,36 @@ class ManageTest(ShellCase):
         '''
         ret = self.run_run_plus('jobs.list_jobs')
         self.assertIsInstance(ret['return'], dict)
+
+
+class LocalCacheTargetTest(ShellCase):
+    '''
+    Test that a job stored in the local_cache has target information
+    '''
+
+    def test_target_info(self):
+        '''
+        This is a test case for issue #48734
+
+        PR #43454 fixed an issue where "jobs.lookup_jid" was not working
+        correctly with external job caches. However, this fix for external
+        job caches broke some inner workings of job storage when using the
+        local_cache.
+
+        We need to preserve the previous behavior for the local_cache, but
+        keep the new behavior for other external job caches.
+
+        If "savefstr" is called in the local cache, the target data does not
+        get written to the local_cache, and the target-type gets listed as a
+        "list" type instead of "glob".
+
+        This is a regression test for fixing the local_cache behavior.
+        '''
+        ret = self.run_run_plus('jobs.list_jobs')
+        keys = ret['return'].keys()
+        tgt = ret['return'][keys[0]]['Target']
+        tgt_type = ret['return'][keys[0]]['Target-type']
+
+        assert tgt != 'unknown-target'
+        assert tgt in ['minion', 'sub_minion']
+        assert tgt_type == 'glob'

--- a/tests/integration/runners/test_jobs.py
+++ b/tests/integration/runners/test_jobs.py
@@ -62,10 +62,13 @@ class LocalCacheTargetTest(ShellCase):
 
         This is a regression test for fixing the local_cache behavior.
         '''
+        self.run_salt('minion test.ping')
         ret = self.run_run_plus('jobs.list_jobs')
-        ret_key = list(ret['return'].keys())[0]
-        tgt = ret['return'][ret_key]['Target']
-        tgt_type = ret['return'][ret_key]['Target-type']
+        for item in ret['return'].values():
+            if item['Function'] == 'test.ping':
+                job_ret = item
+        tgt = job_ret['Target']
+        tgt_type = job_ret['Target-type']
 
         assert tgt != 'unknown-target'
         assert tgt in ['minion', 'sub_minion']

--- a/tests/integration/runners/test_jobs.py
+++ b/tests/integration/runners/test_jobs.py
@@ -63,9 +63,9 @@ class LocalCacheTargetTest(ShellCase):
         This is a regression test for fixing the local_cache behavior.
         '''
         ret = self.run_run_plus('jobs.list_jobs')
-        keys = ret['return'].keys()
-        tgt = ret['return'][keys[0]]['Target']
-        tgt_type = ret['return'][keys[0]]['Target-type']
+        ret_key = list(ret['return'].keys())[0]
+        tgt = ret['return'][ret_key]['Target']
+        tgt_type = ret['return'][ret_key]['Target-type']
 
         assert tgt != 'unknown-target'
         assert tgt in ['minion', 'sub_minion']


### PR DESCRIPTION
### What does this PR do?
This PR fixes a regression in the local_cache where when running `salt-run jobs.list_jobs`, the data would contain variables such as `Target: unknown-target` and `Target-type: list` instead of the name of the minion for the target, and the correct target type.

A fix in #43454 changed the logic for when `mminion.returners[savefstr](load['jid'], load)` would be called in `salt.utils.job.store_job` in order to fix a bug with external job caches. However, this caused a regression when using this with the `local_cache`.

My PR restores the previous behavior of the `local_cache`, but keeps the fix for external job caches.

### What issues does this PR fix or reference?
Fixes #48734

### Previous Behavior
```
➜  ~ salt rallytime test.ping
rallytime:
    True
➜  ~ salt-run jobs.list_jobs search_function="test.ping"
20181031144832045674:
    ----------
    Arguments:
    Function:
        test.ping
    StartTime:
        2018, Oct 31 14:48:32.045674
    Target:
        unknown-target
    Target-type:
        list
    User:
        root
```
The `Target` and `Target-type` data above are incorrect ^

### New Behavior
```
➜  ~ salt rallytime test.ping
rallytime:
    True
➜  ~ salt-run jobs.list_jobs search_function="test.ping"
20181031155610176789:
    ----------
    Arguments:
    Function:
        test.ping
    StartTime:
        2018, Oct 31 15:56:10.176789
    Target:
        rallytime
    Target-type:
        glob
    User:
        root
```
The `Target` and `Target-type` data above are restored ^

### Tests written?

Yes

### Commits signed with GPG?

Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
