### PR TITLE
Check WinRM port before initiating connection

### DIFF
--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -850,6 +850,9 @@ def wait_for_winrm(host, port, username, password, timeout=900, use_ssl=True, ve
     '''
     Wait until WinRM connection can be established.
     '''
+    # Ensure the winrm service is listening before attempting to connect
+    wait_for_port(host=host, port=port, timeout=timeout)
+
     start = time.time()
     log.debug(
         'Attempting WinRM connection to host {0} on port {1}'.format(


### PR DESCRIPTION
### What does this PR do?
Fixes a timeout issue when connecting to a Windows VM on VMWare (or any other provider for that matter). The connection to WinRM was timing out before the WinRM service was listening on the port. This adds an additional wait on the WinRM port before trying to connect. The default is 15 minutes.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/44889

### Tests written?
No

### Commits signed with GPG?
Yes