### PR TITLE
nilrt_ip: _get_service_info(): Touch "ipv6" item in `data` map before use

### DIFF
--- a/salt/modules/nilrt_ip.py
+++ b/salt/modules/nilrt_ip.py
@@ -208,6 +208,8 @@ def _get_service_info(service):
             if value is None:
                 log.warning('Unable to get IPv6 %s for service %s\n', info, service)
                 continue
+            if 'ipv6' not in data:
+                data['ipv6'] = {}
             data['ipv6'][info.lower()] = [six.text_type(value)]
 
         nameservers = []


### PR DESCRIPTION
### What does this PR do?
### What issues does this PR fix or reference?
Touch `data['ipv6']` before referencing it to avoid exception.

### Previous Behavior
### New Behavior
I verified `salt-call --local ip.set_dhcp_linklocal_all ens3` now works on a QEMU x64 machine with usermode IPv6 networking.
