### PR TITLE
[2018.3] Fix to pkg.installed for sources and hold: True

### DIFF
--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -1720,7 +1720,7 @@ def installed(
         try:
             action = 'pkg.hold' if kwargs['hold'] else 'pkg.unhold'
             hold_ret = __salt__[action](
-                name=name, pkgs=desired, sources=sources
+                name=name, pkgs=desired
             )
         except (CommandExecutionError, SaltInvocationError) as exc:
             comment.append(six.text_type(exc))


### PR DESCRIPTION
### What does this PR do?
pkg.installed currently fails when sources is used along with hold: True.  This was due to a change in #48426 that swapped out sending the pkgs variable for the desired variable instead.  This caused problems with pkg.hold because desired and sources are always populated, and pkg.hold can only include one or the other.  This change just includes desired in the call to pkg.hold since desired has the same value for sources.

### What issues does this PR fix or reference?
#50311 

### Tests written?
No.  Existing tests for pkg.hold functions, but including a test to test installing from a source location seems prone to failure.

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
