### PR TITLE
states.gpg: fix missing existing keys; modules.gpg: fix set trust lev…

### DIFF
--- a/salt/modules/gpg.py
+++ b/salt/modules/gpg.py
@@ -924,7 +924,7 @@ def trust_key(keyid=None,
 
     if user == 'salt':
         homeDir = os.path.join(__salt__['config.get']('config_dir'), 'gpgkeys')
-        cmd.extend([' --homedir', homeDir])
+        cmd.extend(['--homedir', homeDir])
         _user = 'root'
     res = __salt__['cmd.run_all'](cmd,
                                   stdin=stdin,

--- a/salt/states/gpg.py
+++ b/salt/states/gpg.py
@@ -70,7 +70,7 @@ def present(name,
            'changes': {},
            'comment': []}
 
-    _current_keys = __salt__['gpg.list_keys']()
+    _current_keys = __salt__['gpg.list_keys'](user=user, gnupghome=gnupghome)
 
     current_keys = {}
     for key in _current_keys:


### PR DESCRIPTION
### What does this PR do?

It fixes errors

### What issues does this PR fix or reference?

* salt/modules/gpg.py:

Command:
```
salt minion gpg.trust_key trust_level='ultimately' user=salt keyid=E274A67DE7EE6770
```

produces:
```
2018-11-01 09:35:19,557 [salt.loader.salt.*.int.module.cmdmod:774 ][ERROR   ][32736] Command '[u'/usr/bin/gpg', u'--import-ownertrust', u' --homedir', u'/etc/salt/gpgkeys']' failed with return code: 2
2018-11-01 09:35:19,629 [salt.loader.salt.*.int.module.cmdmod:778 ][ERROR   ][32736] stderr: usage: gpg [options] --import-ownertrust [file]
2018-11-01 09:35:19,692 [salt.loader.salt.*.int.module.cmdmod:780 ][ERROR   ][32736] retcode: 2
```

* alt/states/gpg.py:

GPG state ignored exising keys when user or gpghome parameters provided.

Example state:
```
salt_public_gpg:
  gpg.present:
    - name: E274A67DE7EE6770
    - keyserver: sks.daylightpirates.org
    - gnupghome: /etc/salt/gpgkeys/
    - user: salt
    - trust: ultimately
```

Always produces:
```
ID: salt_public_gpg
    Function: gpg.present
        Name: E274A67DE7EE6770
      Result: True
     Comment: Adding E274A67DE7EE6770 to GPG keychain
...
```

### Tests written?

No

### Commits signed with GPG?

Yes

PS. Previous versions also affected.
