### PR TITLE
FIX #49469 - Add normalize_name to pkgin module

### DIFF
--- a/salt/modules/pkgin.py
+++ b/salt/modules/pkgin.py
@@ -695,4 +695,17 @@ def file_dict(*packages):
             del ret[field]
     return ret
 
+
+def normalize_name(pkgs, **kwargs):
+    '''
+    Normalize package names
+
+    .. note::
+        Nothing special to do to normalize, just return
+        the original. (We do need it to be comaptible
+        with the pkg_resource provider.)
+    '''
+    return pkgs
+
+
 # vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4


### PR DESCRIPTION
### What does this PR do?
This is a simple pass through function that was propose in #49469.
I had a quick look at solarisips on how they implement it, there is
nothing to expand in the case of pkgin. On missing or multiple matches
solarisips also does a passthrough.

I personally feel OK with as is. I retested on OmniOS and now it
appears everything is fine with adding the provider property to the
state.

### What issues does this PR fix or reference?
#49469

### Previous Behavior
The normalize_name from the default provider was used, causing incorrect behavior.

### New Behavior
The normalize_name from pkgin is used, which makes everythign work.

### Tests written?
No

### Commits signed with GPG?
No

### Backports?
It might be worth pulling this into flourine, this is not a feature but a bug fix.