### PR TITLE
The driver requires dependency, not the other way around.

### DIFF
--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -93,6 +93,7 @@ def _gather_buffer_space():
     # Return the higher number between 5% of the system memory and 10MiB
     return max([total_mem * 0.05, 10 << 20])
 
+
 # For the time being this will be a fixed calculation
 # TODO: Allow user configuration
 _DFLT_IPC_WBUFFER = _gather_buffer_space() * .5

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -3474,7 +3474,7 @@ def check_driver_dependencies(driver, dependencies):
         if value is False:
             log.warning(
                 "Missing dependency: '%s'. The %s driver requires "
-                "'%s' to be installed.", key, key, driver
+                "'%s' to be installed.", key, driver, key
             )
             ret = False
 


### PR DESCRIPTION
Updated a very annoying (personal opinion) incorrect error message.

### What does this PR do?
It fixes the behavior that I got this error message:

`Missing dependency: 'shade'. The shade driver requires 'openstack' to be installed.`

instead of:

`Missing dependency: 'shade'. The openstack driver requires 'shade' to be installed.`

### What issues does this PR fix or reference?
I haven't created an issue, just fixed it

### Previous Behavior
`Missing dependency: 'shade'. The shade driver requires 'openstack' to be installed.`

### New Behavior
`Missing dependency: 'shade'. The openstack driver requires 'shade' to be installed.`

### Tests written?
No

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
