### PR TITLE
Fix test_issue_30161_unless_and_onlyif_together for MacOSX

### DIFF
--- a/tests/integration/files/file/base/issue-30161.sls
+++ b/tests/integration/files/file/base/issue-30161.sls
@@ -1,44 +1,35 @@
+{% if grains['os'] == 'Windows' %}
+  {% set test_false = 'cmd.exe /c exit 1' %}
+  {% set test_true = 'cmd.exe /c exit 0' %}
+{% elif grains['os'] == 'MacOS' %}
+  {% set test_false = '/usr/bin/false' %}
+  {% set test_true = '/usr/bin/true' %}
+{% else %}
+  {% set test_false = '/bin/false' %}
+  {% set test_true = '/bin/true' %}
+{% endif %}
+
 unless_false_onlyif_true:
   file.managed:
     - name: {{ salt['runtests_helpers.get_salt_temp_dir_for_path']('test.txt') }}
-{% if grains['os'] == 'Windows' %}
-    - unless: cmd.exe /c exit 1
-    - onlyif: cmd.exe /c exit 0
-{% else %}
-    - unless: /bin/false
-    - onlyif: /bin/true
-{% endif %}
+    - unless: {{ test_false }}
+    - onlyif: {{ test_true }}
 
 unless_true_onlyif_false:
   file.managed:
     - name: {{ salt['runtests_helpers.get_salt_temp_dir_for_path']('test.txt') }}
-{% if grains['os'] == 'Windows' %}
-    - unless: cmd.exe /c exit 0
-    - onlyif: cmd.exe /c exit 1
-{% else %}
-    - unless: /bin/true
-    - onlyif: /bin/false
-{% endif %}
+    - unless: {{ test_true }}
+    - onlyif: {{ test_false }}
 
 unless_true_onlyif_true:
   file.managed:
     - name: {{ salt['runtests_helpers.get_salt_temp_dir_for_path']('test.txt') }}
-{% if grains['os'] == 'Windows' %}
-    - unless: cmd.exe /c exit 0
-    - onlyif: cmd.exe /c exit 0
-{% else %}
-    - unless: /bin/true
-    - onlyif: /bin/true
-{% endif %}
+    - unless: {{ test_true }}
+    - onlyif: {{ test_true }}
 
 unless_false_onlyif_false:
   file.managed:
     - name: {{ salt['runtests_helpers.get_salt_temp_dir_for_path']('test.txt') }}
     - contents: test
-{% if grains['os'] == 'Windows' %}
-    - unless: cmd.exe /c exit 1
-    - onlyif: cmd.exe /c exit 1
-{% else %}
-    - unless: /bin/false
-    - onlyif: /bin/false
-{% endif %}
+    - unless: {{ test_false }}
+    - onlyif: {{ test_false }}


### PR DESCRIPTION
### What does this PR do?
The test `integration.modules.test_state.StateModuleTest.test_issue_30161_unless_and_onlyif_together` is failing on MacOSX. This simply updates the paths for true and false for MacOSX.