### PR TITLE
Handle the deprecation options in the firewalld module and state for Neon

### DIFF
--- a/doc/topics/releases/neon.rst
+++ b/doc/topics/releases/neon.rst
@@ -360,6 +360,18 @@ Module Deprecations
         - :py:func:`dockermod.load <salt.modules.dockermod.load>`
         - :py:func:`dockermod.tag <salt.modules.dockermod.tag_>`
 
+- The :py:mod`firewalld <salt.modules.firewalld>` module has been changed as
+  follows:
+
+    - Support for the ``force_masquerade`` option has been removed from the
+      :py:func:`firewalld.add_port <salt.module.firewalld.add_port` function. Please
+      use the :py:func:`firewalld.add_masquerade <salt.modules.firewalld.add_masquerade`
+      function instead.
+    - Support for the ``force_masquerade`` option has been removed from the
+      :py:func:`firewalld.add_port_fwd <salt.module.firewalld.add_port_fwd` function. Please
+      use the :py:func:`firewalld.add_masquerade <salt.modules.firewalld.add_masquerade`
+      function instead.
+
 - The :py:mod:`ssh <salt.modules.ssh>` execution module has been
   changed as follows:
 
@@ -373,9 +385,15 @@ Module Deprecations
 State Deprecations
 ------------------
 
+- The :py:mod`firewalld <salt.states.firewalld>` state has been changed as follows:
+
+    - The default setting for the ``prune_services`` option in the
+      :py:func:`firewalld.present <salt.states.firewalld.present>` function has changed
+      from ``True`` to ``False``.
+
 - The :py:mod:`win_servermanager <salt.states.win_servermanager>` state has been
   changed as follows:
 
     - Support for the ``force`` kwarg has been removed from the
-      :py:func:`win_servermanager.installed <salt.statues.win_servermanager.installed>`
+      :py:func:`win_servermanager.installed <salt.states.win_servermanager.installed>`
       function. Please use ``recurse`` instead.

--- a/salt/modules/firewalld.py
+++ b/salt/modules/firewalld.py
@@ -13,7 +13,6 @@ import re
 # Import Salt Libs
 from salt.exceptions import CommandExecutionError
 import salt.utils.path
-import salt.utils.versions
 
 log = logging.getLogger(__name__)
 
@@ -618,8 +617,7 @@ def remove_masquerade(zone=None, permanent=True):
     return __firewall_cmd(cmd)
 
 
-# TODO: remove force_masquerade parameter in future release
-def add_port(zone, port, permanent=True, force_masquerade=None):
+def add_port(zone, port, permanent=True):
     '''
     Allow specific ports in a zone.
 
@@ -631,21 +629,6 @@ def add_port(zone, port, permanent=True, force_masquerade=None):
 
         salt '*' firewalld.add_port internal 443/tcp
     '''
-
-    # Previously, masquerading was always enabled here
-    # This will be deprecated in a future release
-    if force_masquerade is None:
-        force_masquerade = True
-        salt.utils.versions.warn_until(
-            'Neon',
-            'add_port function will no longer force enable masquerading '
-            'in future releases. Use add_masquerade to enable masquerading.')
-
-    # (DEPRECATED) Force enable masquerading
-    # TODO: remove in future release
-    if force_masquerade and not get_masquerade(zone):
-        add_masquerade(zone)
-
     cmd = '--zone={0} --add-port={1}'.format(zone, port)
 
     if permanent:
@@ -694,8 +677,7 @@ def list_ports(zone, permanent=True):
     return __firewall_cmd(cmd).split()
 
 
-# TODO: remove force_masquerade parameter in future release
-def add_port_fwd(zone, src, dest, proto='tcp', dstaddr='', permanent=True, force_masquerade=None):
+def add_port_fwd(zone, src, dest, proto='tcp', dstaddr='', permanent=True):
     '''
     Add port forwarding.
 
@@ -707,21 +689,6 @@ def add_port_fwd(zone, src, dest, proto='tcp', dstaddr='', permanent=True, force
 
         salt '*' firewalld.add_port_fwd public 80 443 tcp
     '''
-
-    # Previously, masquerading was always enabled here
-    # This will be deprecated in a future release
-    if force_masquerade is None:
-        force_masquerade = True
-        salt.utils.versions.warn_until(
-            'Neon',
-            'add_port_fwd function will no longer force enable masquerading '
-            'in future releases. Use add_masquerade to enable masquerading.')
-
-    # (DEPRECATED) Force enable masquerading
-    # TODO: remove in future release
-    if force_masquerade and not get_masquerade(zone):
-        add_masquerade(zone)
-
     cmd = '--zone={0} --add-forward-port=port={1}:proto={2}:toport={3}:toaddr={4}'.format(
         zone,
         src,

--- a/salt/states/firewalld.py
+++ b/salt/states/firewalld.py
@@ -84,7 +84,6 @@ import logging
 from salt.exceptions import CommandExecutionError
 from salt.output import nested
 import salt.utils.path
-import salt.utils.versions
 
 log = logging.getLogger(__name__)
 
@@ -163,9 +162,7 @@ def present(name,
             port_fwd=None,
             prune_port_fwd=False,
             services=None,
-            # TODO: prune_services=False in future release
-            # prune_services=False,
-            prune_services=None,
+            prune_services=False,
             interfaces=None,
             prune_interfaces=False,
             sources=None,
@@ -206,7 +203,7 @@ def present(name,
     services : None
         List of services to add to the zone.
 
-    prune_services : True
+    prune_services : False
         If ``True``, remove all but the specified services from the zone.
         .. note:: Currently defaults to True for compatibility, but will be changed to False in a future release.
 
@@ -228,15 +225,6 @@ def present(name,
     prune_rich_rules : False
         If ``True``, remove all but the specified rich rules from the zone.
     '''
-
-    # if prune_services == None, set to True and log a deprecation warning
-    if prune_services is None:
-        prune_services = True
-        salt.utils.versions.warn_until(
-            'Neon',
-            'The \'prune_services\' argument default is currently True, '
-            'but will be changed to False in the Neon release.')
-
     ret = _present(name, block_icmp, prune_block_icmp, default, masquerade, ports, prune_ports,
             port_fwd, prune_port_fwd, services, prune_services, interfaces, prune_interfaces,
             sources, prune_sources, rich_rules, prune_rich_rules)


### PR DESCRIPTION
These were set for removal/change for the Neon release. This PR handles the clean up for Neon.

Fixes https://github.com/saltstack/salt/issues/49415