### PR TITLE
Handle deprecation of test.rand_str for Neon

### DIFF
--- a/doc/topics/releases/neon.rst
+++ b/doc/topics/releases/neon.rst
@@ -370,6 +370,12 @@ Module Deprecations
       :py:func:`ssh.recv_known_host_entries <salt.modules.ssh.recv_known_host_entries>`
       function instead.
 
+- The :py:mod:`test <salt.modules.test>` execution module has been changed as follows:
+
+    - Support for the :py:func:`test.rand_str <salt.modules.test.rand_str>` has been
+      removed. Please use the :py:func:`test.random_hash <salt.modules.test.random_hash>`
+      function instead.
+
 State Deprecations
 ------------------
 

--- a/salt/modules/test.py
+++ b/salt/modules/test.py
@@ -18,7 +18,6 @@ import salt.utils.args
 import salt.utils.functools
 import salt.utils.hashutils
 import salt.utils.platform
-import salt.utils.versions
 import salt.version
 import salt.loader
 from salt.ext import six
@@ -494,14 +493,6 @@ def opts_pkg():
     ret.update(__opts__)
     ret['grains'] = __grains__
     return ret
-
-
-def rand_str(size=9999999999, hash_type=None):
-    salt.utils.versions.warn_until(
-        'Neon',
-        'test.rand_str has been renamed to test.random_hash'
-    )
-    return random_hash(size=size, hash_type=hash_type)
 
 
 def random_hash(size=9999999999, hash_type=None):

--- a/salt/utils/hashutils.py
+++ b/salt/utils/hashutils.py
@@ -137,7 +137,6 @@ def hmac_signature(string, shared_secret, challenge_hmac):
     return valid_hmac == challenge
 
 
-@jinja_filter('rand_str')  # Remove this for Neon
 @jinja_filter('random_hash')
 def random_hash(size=9999999999, hash_type=None):
     '''


### PR DESCRIPTION
This function was marked for removal in the Neon release in favor of using the more complete random_hash function.

Fixes https://github.com/saltstack/salt/issues/49416