### PR TITLE
Extend deprecation warning for enable_legacy_startup_events to Sodium

### DIFF
--- a/conf/minion
+++ b/conf/minion
@@ -409,7 +409,7 @@
 # `minion_start`. This duplication can cause a lot of clutter on the event bus
 # when there are many minions. Set `enable_legacy_startup_events: False` in the
 # minion config to ensure only the `salt/minion/<minion_id>/start` events are
-# sent. Beginning with the `Neon` Salt release this option will default to
+# sent. Beginning with the `Sodium` Salt release this option will default to
 # `False`
 #enable_legacy_startup_events: True
 

--- a/doc/ref/configuration/minion.rst
+++ b/doc/ref/configuration/minion.rst
@@ -218,13 +218,13 @@ minion event bus. The value is expressed in bytes.
 Default: ``True``
 
 When a minion starts up it sends a notification on the event bus with a tag
-that looks like this: `salt/minion/<minion_id>/start`. For historical reasons
+that looks like this: ``salt/minion/<minion_id>/start``. For historical reasons
 the minion also sends a similar event with an event tag like this:
-`minion_start`. This duplication can cause a lot of clutter on the event bus
-when there are many minions. Set `enable_legacy_startup_events: False` in the
-minion config to ensure only the `salt/minion/<minion_id>/start` events are
-sent. Beginning with the `Neon` Salt release this option will default to
-`False`
+``minion_start``. This duplication can cause a lot of clutter on the event bus
+when there are many minions. Set ``enable_legacy_startup_events: False`` in the
+minion config to ensure only the ``salt/minion/<minion_id>/start`` events are
+sent. Beginning with the ``Sodium`` Salt release this option will default to
+``False``.
 
 .. code-block:: yaml
 

--- a/doc/topics/releases/fluorine.rst
+++ b/doc/topics/releases/fluorine.rst
@@ -812,7 +812,7 @@ sent.
 
 The new :conf_minion:`enable_legacy_startup_events` minion config option
 defaults to ``True``, but will be set to default to ``False`` beginning with
-the Neon release of Salt.
+the Sodium release of Salt.
 
 The Salt Syndic currently sends an old style ``syndic_start`` event as well. The
 syndic respects :conf_minion:`enable_legacy_startup_events` as well.

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -93,6 +93,7 @@ def _gather_buffer_space():
     # Return the higher number between 5% of the system memory and 10MiB
     return max([total_mem * 0.05, 10 << 20])
 
+
 # For the time being this will be a fixed calculation
 # TODO: Allow user configuration
 _DFLT_IPC_WBUFFER = _gather_buffer_space() * .5

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -437,7 +437,7 @@ VALID_OPTS = {
     # If an event is above this size, it will be trimmed before putting it on the event bus
     'max_event_size': int,
 
-    # Enable old style events to be sent on minion_startup. Change default to False in Neon release
+    # Enable old style events to be sent on minion_startup. Change default to False in Sodium release
     'enable_legacy_startup_events': bool,
 
     # Always execute states with test=True if this flag is set

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -2135,7 +2135,7 @@ class Minion(MinionBase):
     def _fire_master_minion_start(self):
         # Send an event to the master that the minion is live
         if self.opts['enable_legacy_startup_events']:
-            # old style event. Defaults to False in Neon Salt release
+            # Old style event. Defaults to False in Sodium release.
             self._fire_master(
                 'Minion {0} started at {1}'.format(
                 self.opts['id'],
@@ -2861,7 +2861,7 @@ class Syndic(Minion):
     def fire_master_syndic_start(self):
         # Send an event to the master that the minion is live
         if self.opts['enable_legacy_startup_events']:
-            # old style event. Defaults to false in Neon Salt release.
+            # Old style event. Defaults to false in Sodium release.
             self._fire_master(
                 'Syndic {0} started at {1}'.format(
                     self.opts['id'],


### PR DESCRIPTION
This deprecation warning only went in recently and is new in Salt "Fluorine". We need 2 full feature releases for deprecation warnings and "Neon" would have only been 1 feature release cycle.

Refs #46272, #46336, and #49433.