### PR TITLE
Virt disk fixes

### DIFF
--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -617,8 +617,9 @@ def _gen_xml(name,
     disk_bus_map = {'virtio': 'vd', 'xen': 'xvd', 'fdc': 'fd', 'ide': 'hd'}
     for i, disk in enumerate(diskp):
         context['disks'][disk['name']] = {}
-        context['disks'][disk['name']]['file_name'] = disk['filename']
-        context['disks'][disk['name']]['source_file'] = disk['source_file']
+        context['disks'][disk['name']]['device'] = disk.get('device', 'disk')
+        if 'source_file' and disk['source_file']:
+            context['disks'][disk['name']]['source_file'] = disk['source_file']
         prefix = disk_bus_map.get(disk['model'], 'sd')
         context['disks'][disk['name']]['target_dev'] = '{0}{1}'.format(prefix, string.ascii_lowercase[i])
         if hypervisor in ['qemu', 'kvm', 'bhyve', 'xen']:
@@ -960,12 +961,15 @@ def _disk_profile(profile, hypervisor, disks=None, vm_name=None, image=None, poo
     if hypervisor == 'vmware':
         overlay = {'format': 'vmdk',
                    'model': 'scsi',
+                   'device': 'disk',
                    'pool': '[{0}] '.format(pool if pool else '0')}
     elif hypervisor in ['qemu', 'kvm']:
         overlay = {'format': 'qcow2',
+                   'device': 'disk',
                    'model': 'virtio'}
     elif hypervisor in ['bhyve']:
         overlay = {'format': 'raw',
+                   'device': 'disk',
                    'model': 'virtio',
                    'sparse_volume': False}
     else:
@@ -1005,9 +1009,9 @@ def _disk_profile(profile, hypervisor, disks=None, vm_name=None, image=None, poo
                 disk[key] = val
 
         # We may have an already computed source_file (i.e. image not created by our module)
-        if 'source_file' in disk:
+        if 'source_file' in disk and disk['source_file']:
             disk['filename'] = os.path.basename(disk['source_file'])
-        else:
+        elif 'source_file' not in disk:
             _fill_disk_filename(vm_name, disk, hypervisor, **kwargs)
 
     return disklist
@@ -1447,7 +1451,12 @@ def init(name,
 
     source_file
         Absolute path to the disk image to use. Not to be confused with ``image`` parameter. This
-        parameter is useful to use disk images that are created outside of this module.
+        parameter is useful to use disk images that are created outside of this module. Can also
+        be ``None`` for devices that have no associated image like cdroms.
+
+    device
+        Type of device of the disk. Can be one of 'disk', 'cdrom', 'floppy' or 'lun'.
+        (Default: ``'disk'``)
 
     .. _init-graphics-def:
 
@@ -1598,13 +1607,15 @@ def init(name,
             else:
                 create_overlay = _disk.get('overlay_image', False)
 
-            if os.path.exists(_disk['source_file']):
+            if _disk['source_file'] and os.path.exists(_disk['source_file']):
                 img_dest = _disk['source_file']
-            else:
+            elif 'source_file' not in _disk:
                 img_dest = _qemu_image_create(_disk, create_overlay, saltenv)
+            else:
+                img_dest = None
 
             # Seed only if there is an image specified
-            if seed and _disk.get('image', None):
+            if seed and img_dest and _disk.get('image', None):
                 log.debug('Seed command is %s', seed_cmd)
                 __salt__[seed_cmd](
                     img_dest,
@@ -1678,7 +1689,8 @@ def _disks_equal(disk1, disk2):
 
     return source1 == source2 and \
         target1 is not None and target2 is not None and \
-        target1.get('bus') == target2.get('bus')
+        target1.get('bus') == target2.get('bus') and \
+        disk1.get('device', 'disk') == disk2.get('device', 'disk')
 
 
 def _nics_equal(nic1, nic2):

--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -1751,7 +1751,10 @@ def _diff_lists(old, new, comparator):
 
     :param old: old list
     :param new: new list
-    :return: a dictionary with ``unchanged``, ``new`` and ``deleted`` keys
+    :return: a dictionary with ``unchanged``, ``new``, ``deleted`` and ``sorted`` keys
+
+    The sorted list is the union of unchanged and new lists, but keeping the original
+    order from the new list.
     '''
     def _remove_indent(node):
         '''
@@ -1763,15 +1766,19 @@ def _diff_lists(old, new, comparator):
             item.tail = None
         return node_copy
 
-    diff = {'unchanged': [], 'new': [], 'deleted': []}
+    diff = {'unchanged': [], 'new': [], 'deleted': [], 'sorted': []}
+    # We don't want to alter old since it may be used later by caller
+    old_devices = copy.deepcopy(old)
     for new_item in new:
-        found = [item for item in old if comparator(_remove_indent(item), _remove_indent(new_item))]
+        found = [item for item in old_devices if comparator(_remove_indent(item), _remove_indent(new_item))]
         if found:
-            old.remove(found[0])
+            old_devices.remove(found[0])
             diff['unchanged'].append(found[0])
+            diff['sorted'].append(found[0])
         else:
             diff['new'].append(new_item)
-    diff['deleted'] = old
+            diff['sorted'].append(new_item)
+    diff['deleted'] = old_devices
     return diff
 
 
@@ -1956,7 +1963,7 @@ def update(name,
             if changes[dev_type]['deleted'] or changes[dev_type]['new']:
                 for item in old:
                     devices_node.remove(item)
-                devices_node.extend(new)
+                devices_node.extend(changes[dev_type]['sorted'])
                 need_update = True
 
     # Set the new definition

--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -613,24 +613,27 @@ def _gen_xml(name,
         else:
             context['console'] = True
 
-    context['disks'] = {}
+    context['disks'] = []
     disk_bus_map = {'virtio': 'vd', 'xen': 'xvd', 'fdc': 'fd', 'ide': 'hd'}
     for i, disk in enumerate(diskp):
-        context['disks'][disk['name']] = {}
-        context['disks'][disk['name']]['device'] = disk.get('device', 'disk')
-        if 'source_file' and disk['source_file']:
-            context['disks'][disk['name']]['source_file'] = disk['source_file']
         prefix = disk_bus_map.get(disk['model'], 'sd')
-        context['disks'][disk['name']]['target_dev'] = '{0}{1}'.format(prefix, string.ascii_lowercase[i])
+        disk_context = {
+            'device': disk.get('device', 'disk'),
+            'target_dev': '{0}{1}'.format(prefix, string.ascii_lowercase[i]),
+            'disk_bus': disk['model'],
+            'type': disk['format'],
+            'index': six.text_type(i),
+        }
+        if 'source_file' and disk['source_file']:
+            disk_context['source_file'] = disk['source_file']
+
         if hypervisor in ['qemu', 'kvm', 'bhyve', 'xen']:
-            context['disks'][disk['name']]['address'] = False
-            context['disks'][disk['name']]['driver'] = True
+            disk_context['address'] = False
+            disk_context['driver'] = True
         elif hypervisor in ['esxi', 'vmware']:
-            context['disks'][disk['name']]['address'] = True
-            context['disks'][disk['name']]['driver'] = False
-        context['disks'][disk['name']]['disk_bus'] = disk['model']
-        context['disks'][disk['name']]['type'] = disk['format']
-        context['disks'][disk['name']]['index'] = six.text_type(i)
+            disk_context['address'] = True
+            disk_context['driver'] = False
+        context['disks'].append(disk_context)
     context['nics'] = nicp
 
     context['os_type'] = os_type

--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -1693,7 +1693,8 @@ def _disks_equal(disk1, disk2):
     return source1 == source2 and \
         target1 is not None and target2 is not None and \
         target1.get('bus') == target2.get('bus') and \
-        disk1.get('device', 'disk') == disk2.get('device', 'disk')
+        disk1.get('device', 'disk') == disk2.get('device', 'disk') and \
+        target1.get('dev') == target2.get('dev')
 
 
 def _nics_equal(nic1, nic2):
@@ -1789,25 +1790,21 @@ def _diff_disk_lists(old, new):
     :param old: list of ElementTree nodes representing the old disks
     :param new: list of ElementTree nodes representing the new disks
     '''
-    diff = _diff_lists(old, new, _disks_equal)
-
-    # Fix the target device to avoid duplicates with the unchanged disks
-    # The requested device names may not be honoured by hypervisor and will
-    # likely be set right at the next start of the VM
-    targets = [disk.find('target').get('dev') for disk in diff['unchanged']]
+    # Fix the target device to avoid duplicates before diffing: this may lead
+    # to additional changes. Think of unchanged disk 'hda' and another disk listed
+    # before it becoming 'hda' too... the unchanged need to turn into 'hdb'.
+    targets = []
     prefixes = ['fd', 'hd', 'vd', 'sd', 'xvd', 'ubd']
-    for disk in diff['new']:
+    for disk in new:
         target_node = disk.find('target')
         target = target_node.get('dev')
-        if target in targets:
-            prefix = [item for item in prefixes if target.startswith(item)][0]
-            for i in range(1024):
-                attempt = '{0}{1}'.format(prefix, string.ascii_lowercase[i])
-                if attempt not in targets:
-                    target_node.set('dev', attempt)
-                    targets.append(attempt)
-                    break
-    return diff
+        prefix = [item for item in prefixes if target.startswith(item)][0]
+        new_target = ['{0}{1}'.format(prefix, string.ascii_lowercase[i]) for i in range(len(new))
+                      if '{0}{1}'.format(prefix, string.ascii_lowercase[i]) not in targets][0]
+        target_node.set('dev', new_target)
+        targets.append(new_target)
+
+    return _diff_lists(old, new, _disks_equal)
 
 
 def _diff_interface_lists(old, new):

--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -1673,9 +1673,10 @@ def _disks_equal(disk1, disk2):
     '''
     target1 = disk1.find('target')
     target2 = disk2.find('target')
+    source1 = ElementTree.tostring(disk1.find('source')) if disk1.find('source') is not None else None
+    source2 = ElementTree.tostring(disk2.find('source')) if disk2.find('source') is not None else None
 
-    return ElementTree.tostring(disk1.find('source')) == \
-        ElementTree.tostring(disk2.find('source')) and \
+    return source1 == source2 and \
         target1 is not None and target2 is not None and \
         target1.get('bus') == target2.get('bus')
 

--- a/salt/templates/virt/libvirt_domain.jinja
+++ b/salt/templates/virt/libvirt_domain.jinja
@@ -12,7 +12,7 @@
 		{% endif %}
         </os>
         <devices>
-                {% for diskname, disk in disks.items() %}
+                {% for disk in disks %}
                 <disk type='file' device='{{ disk.device }}'>
                         {% if 'source_file' in disk %}
                         <source file='{{ disk.source_file }}' />

--- a/salt/templates/virt/libvirt_domain.jinja
+++ b/salt/templates/virt/libvirt_domain.jinja
@@ -13,8 +13,10 @@
         </os>
         <devices>
                 {% for diskname, disk in disks.items() %}
-                <disk type='file' device='disk'>
+                <disk type='file' device='{{ disk.device }}'>
+                        {% if 'source_file' in disk %}
                         <source file='{{ disk.source_file }}' />
+                        {% endif %}
                         <target dev='{{ disk.target_dev }}' bus='{{ disk.disk_bus }}' />
                         {% if disk.address -%}
                         <address type='drive' controller='0' bus='0' target='0' unit='{{ disk.index }}' />

--- a/tests/unit/modules/test_virt.py
+++ b/tests/unit/modules/test_virt.py
@@ -94,6 +94,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         disks = virt._disk_profile('default', 'kvm', userdisks, 'myvm', image='/path/to/image')
         self.assertEqual(
             [{'name': 'system',
+              'device': 'disk',
               'size': 8192,
               'format': 'qcow2',
               'model': 'virtio',
@@ -101,6 +102,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
               'image': '/path/to/image',
               'source_file': '{0}{1}myvm_system.qcow2'.format(root_dir, os.sep)},
              {'name': 'data',
+              'device': 'disk',
               'size': 16384,
               'format': 'raw',
               'model': 'virtio',
@@ -765,6 +767,31 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
                 disks, "/default/path/"])}):
             with self.assertRaises(CommandExecutionError):
                 virt._disk_profile('noeffect', 'kvm', [], 'hello')
+
+    def test_gen_xml_cdrom(self):
+        '''
+        Test virt._gen_xml(), generating a cdrom device (different disk type, no source)
+        '''
+        diskp = virt._disk_profile(None, 'kvm', [{
+            'name': 'tested',
+            'device': 'cdrom',
+            'source_file': None,
+            'model': 'ide'}], 'hello')
+        nicp = virt._nic_profile(None, 'kvm')
+        xml_data = virt._gen_xml(
+            'hello',
+            1,
+            512,
+            diskp,
+            nicp,
+            'kvm',
+            'hvm',
+            'x86_64',
+            )
+        root = ET.fromstring(xml_data)
+        disk = root.findall('.//disk')[0]
+        self.assertEqual(disk.attrib['device'], 'cdrom')
+        self.assertIsNone(disk.find('source'))
 
     def test_controller_for_esxi(self):
         '''

--- a/tests/unit/modules/test_virt.py
+++ b/tests/unit/modules/test_virt.py
@@ -874,28 +874,39 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
               </disk>
               <disk type='file' device='disk' cache='default'>
                 <source file='/path/to/img0.qcow2'/>
-                <target dev='vdb' bus='virtio'/>
+                <target dev='vda' bus='virtio'/>
               </disk>
               <disk type='file' device='disk'>
                 <source file='/path/to/img4.qcow2'/>
-                <target dev='vdc' bus='virtio'/>
+                <target dev='vda' bus='virtio'/>
               </disk>
               <disk type='file' device='cdrom'>
-                <target dev='hdc' bus='ide'/>
+                <target dev='hda' bus='ide'/>
               </disk>
             </devices>
         ''').findall('disk')
         ret = virt._diff_disk_lists(old_disks, new_disks)
-        self.assertEqual([disk.find('source').get('file') for disk in ret['deleted']],
-                         ['/path/to/img1.qcow2', '/path/to/img2.qcow2', '/path/to/img4.qcow2'])
         self.assertEqual([disk.find('source').get('file') if disk.find('source') is not None else None
-                          for disk in ret['unchanged']],
-                         ['/path/to/img0.qcow2', None])
-        self.assertEqual([disk.find('source').get('file') for disk in ret['new']],
-                         ['/path/to/img3.qcow2', '/path/to/img4.qcow2'])
-        self.assertEqual(ret['new'][0].find('target').get('dev'), 'vdb')
-        self.assertEqual(ret['new'][1].find('target').get('dev'), 'vdc')
+                          for disk in ret['unchanged']], [])
+        self.assertEqual([disk.find('source').get('file') if disk.find('source') is not None else None
+                          for disk in ret['new']],
+                         ['/path/to/img3.qcow2', '/path/to/img0.qcow2', '/path/to/img4.qcow2', None])
+        self.assertEqual([disk.find('target').get('dev') for disk in ret['sorted']],
+                         ['vda', 'vdb', 'vdc', 'hda'])
+        self.assertEqual([disk.find('source').get('file') if disk.find('source') is not None else None
+                          for disk in ret['sorted']],
+                         ['/path/to/img3.qcow2',
+                          '/path/to/img0.qcow2',
+                          '/path/to/img4.qcow2',
+                          None])
         self.assertEqual(ret['new'][1].find('target').get('bus'), 'virtio')
+        self.assertEqual([disk.find('source').get('file') if disk.find('source') is not None else None
+                          for disk in ret['deleted']],
+                         ['/path/to/img0.qcow2',
+                          '/path/to/img1.qcow2',
+                          '/path/to/img2.qcow2',
+                          '/path/to/img4.qcow2',
+                          None])
 
     def test_diff_nics(self):
         '''
@@ -1105,7 +1116,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
                   <driver name='qemu' type='qcow2'/>
                   <source file='{0}{1}myvm_data.qcow2'/>
                   <backingStore/>
-                  <target dev='vda' bus='virtio'/>
+                  <target dev='vdb' bus='virtio'/>
                   <alias name='virtio-disk1'/>
                   <address type='pci' domain='0x0000' bus='0x00' slot='0x07' function='0x1'/>
                 </disk>

--- a/tests/unit/modules/test_virt.py
+++ b/tests/unit/modules/test_virt.py
@@ -833,6 +833,9 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
                 <source file='/path/to/img4.qcow2'/>
                 <target dev='hdb' bus='ide'/>
               </disk>
+              <disk type='file' device='cdrom'>
+                <target dev='hdc' bus='ide'/>
+              </disk>
             </devices>
         ''').findall('disk')
 
@@ -850,13 +853,17 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
                 <source file='/path/to/img4.qcow2'/>
                 <target dev='vdc' bus='virtio'/>
               </disk>
+              <disk type='file' device='cdrom'>
+                <target dev='hdc' bus='ide'/>
+              </disk>
             </devices>
         ''').findall('disk')
         ret = virt._diff_disk_lists(old_disks, new_disks)
         self.assertEqual([disk.find('source').get('file') for disk in ret['deleted']],
                          ['/path/to/img1.qcow2', '/path/to/img2.qcow2', '/path/to/img4.qcow2'])
-        self.assertEqual([disk.find('source').get('file') for disk in ret['unchanged']],
-                         ['/path/to/img0.qcow2'])
+        self.assertEqual([disk.find('source').get('file') if disk.find('source') is not None else None
+                          for disk in ret['unchanged']],
+                         ['/path/to/img0.qcow2', None])
         self.assertEqual([disk.find('source').get('file') for disk in ret['new']],
                          ['/path/to/img3.qcow2', '/path/to/img4.qcow2'])
         self.assertEqual(ret['new'][0].find('target').get('dev'), 'vdb')


### PR DESCRIPTION
### What does this PR do?

This PR handles cdrom disks devices in the virt module. When updating VMs created outside of salt virt module we would hit problems since these devices can have no attached source.

### What issues does this PR fix or reference?

None 

### Previous Behavior

Run a `virt.update` on a VM that has a cdrom device with no ISO attached. The salt call will fail with a message saying None is not an iterable type.

### New Behavior

Running a `virt.update` doesn't trigger an exception and keeps the cdrom (or floppy) device intact.

### Tests written?

Yes

### Commits signed with GPG?

Yes
