### PR TITLE
Fix test_matcher on Windows

### DIFF
--- a/tests/integration/shell/test_matcher.py
+++ b/tests/integration/shell/test_matcher.py
@@ -352,17 +352,20 @@ class MatchTest(ShellCase, ShellCaseCommonTestsMixin):
             self.skipTest('This test is failing in Arch due to a bug in salt-testing. '
                           'Skipping until salt-testing can be upgraded. For more information, '
                           'see https://github.com/saltstack/salt-jenkins/issues/324.')
-        data = self.run_salt('-d -t 20')
+        timeout = 20
+        if os_family == 'Windows':
+            timeout = 60
+        data = self.run_salt('-d', timeout=timeout)
         if data:
             assert 'user.add:' in data
-        data = self.run_salt('"*" -d -t 20')
+        data = self.run_salt('"*" -d', timeout=timeout)
         if data:
             assert 'user.add:' in data
-        data = self.run_salt('"*" -d user -t 20')
+        data = self.run_salt('"*" -d user', timeout=timeout)
         assert 'user.add:' in data
-        data = self.run_salt('"*" sys.doc -d user -t 20')
+        data = self.run_salt('"*" sys.doc -d user', timeout=timeout)
         assert 'user.add:' in data
-        data = self.run_salt('"*" sys.doc user -t 20')
+        data = self.run_salt('"*" sys.doc user', timeout=timeout)
         assert 'user.add:' in data
 
     def test_salt_documentation_too_many_arguments(self):

--- a/tests/integration/shell/test_matcher.py
+++ b/tests/integration/shell/test_matcher.py
@@ -342,32 +342,6 @@ class MatchTest(ShellCase, ShellCaseCommonTestsMixin):
         data = self.run_salt('-d "*" user')
         self.assertIn('user.add:', data)
 
-    @flaky
-    def test_salt_documentation_arguments_not_assumed(self):
-        '''
-        Test to see if we're not auto-adding '*' and 'sys.doc' to the call
-        '''
-        os_family = self.run_call('--local grains.get os_family')[1].strip()
-        if os_family == 'Arch':
-            self.skipTest('This test is failing in Arch due to a bug in salt-testing. '
-                          'Skipping until salt-testing can be upgraded. For more information, '
-                          'see https://github.com/saltstack/salt-jenkins/issues/324.')
-        timeout = 20
-        if os_family == 'Windows':
-            timeout = 60
-        data = self.run_salt('-d', timeout=timeout)
-        if data:
-            assert 'user.add:' in data
-        data = self.run_salt('"*" -d', timeout=timeout)
-        if data:
-            assert 'user.add:' in data
-        data = self.run_salt('"*" -d user', timeout=timeout)
-        assert 'user.add:' in data
-        data = self.run_salt('"*" sys.doc -d user', timeout=timeout)
-        assert 'user.add:' in data
-        data = self.run_salt('"*" sys.doc user', timeout=timeout)
-        assert 'user.add:' in data
-
     def test_salt_documentation_too_many_arguments(self):
         '''
         Test to see if passing additional arguments shows an error


### PR DESCRIPTION
### What does this PR do?
Fixes a timeout issue in the following test:
```
integration.shell.test_matcher.MatchTest.test_salt_documentation_arguments_not_assumed
```

The `self.run_salt` function has been recently modified to add the `-t` option to the command being run. Additionally, increased the timeout in Windows since things run a little slower there.

Update: We opted to remove the test altogether.

### What issues does this PR fix or reference?
Found in Jenkins testing.
https://jenkinsci.saltstack.com/job/fluorine/view/Python3/job/salt-windows-2016-py3/25/testReport/junit/integration.shell.test_matcher/MatchTest/test_salt_documentation_arguments_not_assumed/

### Tests written?
Yes

### Commits signed with GPG?
Yes