### PR TITLE
Fix `integration.runners.test_manage` on Windows

### DIFF
--- a/salt/runners/manage.py
+++ b/salt/runners/manage.py
@@ -149,7 +149,7 @@ def key_regen():
     return msg
 
 
-def down(removekeys=False, tgt='*', tgt_type='glob'):
+def down(removekeys=False, tgt='*', tgt_type='glob', timeout=None, gather_job_timeout=None):
     '''
     .. versionchanged:: 2017.7.0
         The ``expr_form`` argument has been renamed to ``tgt_type``, earlier
@@ -167,7 +167,12 @@ def down(removekeys=False, tgt='*', tgt_type='glob'):
         salt-run manage.down tgt="webservers" tgt_type="nodegroup"
 
     '''
-    ret = status(output=False, tgt=tgt, tgt_type=tgt_type).get('down', [])
+    ret = status(output=False,
+                 tgt=tgt,
+                 tgt_type=tgt_type,
+                 timeout=timeout,
+                 gather_job_timeout=gather_job_timeout
+    ).get('down', [])
     for minion in ret:
         if removekeys:
             wheel = salt.wheel.Wheel(__opts__)

--- a/tests/integration/runners/test_manage.py
+++ b/tests/integration/runners/test_manage.py
@@ -17,7 +17,7 @@ class ManageTest(ShellCase):
         '''
         manage.up
         '''
-        ret = self.run_run_plus('manage.up')
+        ret = self.run_run_plus('manage.up', timeout=60)
         self.assertIn('minion', ret['return'])
         self.assertIn('sub_minion', ret['return'])
         self.assertTrue(any('- minion' in out for out in ret['out']))
@@ -27,7 +27,7 @@ class ManageTest(ShellCase):
         '''
         manage.down
         '''
-        ret = self.run_run_plus('manage.down')
+        ret = self.run_run_plus('manage.down', timeout=60)
         self.assertNotIn('minion', ret['return'])
         self.assertNotIn('sub_minion', ret['return'])
         self.assertNotIn('minion', ret['out'])


### PR DESCRIPTION
### What does this PR do?
Fixes the `integration.runners.test_manage.ManageTest.test_down` test in Windows. Adds timeouts to the manage.down runner. Passes timeouts to the runner from the test.

### What issues does this PR fix or reference?
https://jenkinsci.saltstack.com/job/fluorine/view/Python3/job/salt-windows-2016-py3/25/testReport/junit/integration.runners.test_manage/ManageTest/test_down/

### Tests written?
Yes

### Commits signed with GPG?
Yes