### PR TITLE
Fix `integration.client.test_standard` on Windows

### DIFF
--- a/tests/integration/client/test_standard.py
+++ b/tests/integration/client/test_standard.py
@@ -23,6 +23,7 @@ class StdTest(ModuleCase):
         cmd_iter = self.client.cmd_cli(
                 'minion',
                 'test.ping',
+                timeout=20,
                 )
         for ret in cmd_iter:
             self.assertTrue(ret['minion'])
@@ -31,7 +32,8 @@ class StdTest(ModuleCase):
         cmd_iter = self.client.cmd_cli(
                 'minion',
                 'test.sleep',
-                [6]
+                [6],
+                timeout=20,
                 )
         num_ret = 0
         for ret in cmd_iter:
@@ -50,6 +52,7 @@ class StdTest(ModuleCase):
             cmd_iter = self.client.cmd_cli(
                     'footest',
                     'test.ping',
+                    timeout=20,
                     )
             num_ret = 0
             for ret in cmd_iter:
@@ -113,6 +116,7 @@ class StdTest(ModuleCase):
         ret = self.client.cmd_full_return(
                 'minion',
                 'test.ping',
+                timeout=20,
                 )
         self.assertIn('minion', ret)
         self.assertEqual({'ret': True, 'success': True}, ret['minion'])


### PR DESCRIPTION
### What does this PR do?
Fix `integration.client.test_standard.StdTest.test_cli` on Windows. `test.ping` was timing out on Windows because it takes a little longer for those to return in Windows. So, I added some timeouts.

### What issues does this PR fix or reference?
https://jenkinsci.saltstack.com/job/fluorine/view/Python3/job/salt-windows-2016-py3/25/testReport/junit/integration.client.test_standard/StdTest/test_cli/

### Tests written?
Yes

### Commits signed with GPG?
Yes