### PR TITLE
Fix `integration.cli.test_batch` for Window

### DIFF
--- a/tests/support/case.py
+++ b/tests/support/case.py
@@ -925,6 +925,7 @@ class ClientCase(AdaptedConfigurationTestCaseMixin, TestCase):
             else:
                 raise
 
+
 # ----- Backwards Compatible Imports -------------------------------------------------------------------------------->
 from tests.support.mixins import ShellCaseCommonTestsMixin  # pylint: disable=unused-import
 # <---- Backwards Compatible Imports ---------------------------------------------------------------------------------

--- a/tests/support/case.py
+++ b/tests/support/case.py
@@ -485,7 +485,7 @@ class ShellCase(ShellTestCase, AdaptedConfigurationTestCaseMixin, ScriptPathMixi
         except OSError:
             os.chdir(INTEGRATION_TEST_DIR)
 
-    def run_salt(self, arg_str, with_retcode=False, catch_stderr=False, timeout=60):  # pylint: disable=W0221
+    def run_salt(self, arg_str, with_retcode=False, catch_stderr=False, timeout=90):  # pylint: disable=W0221
         '''
         Execute salt
         '''


### PR DESCRIPTION
### What does this PR do?
Increase the timeout on the `run_salt` function. This may fix a bunch of other tests as well.
Fixes `integration.cli.test_batch.BatchTest.test_batch_exit_code`

### What issues does this PR fix or reference?
https://jenkinsci.saltstack.com/job/fluorine/view/Python3/job/salt-windows-2016-py3/25/testReport/junit/integration.cli.test_batch/BatchTest/test_batch_exit_code/

### Tests written?
Yes

### Commits signed with GPG?
Yes