### PR TITLE
Don't fail on git_pillar tests when destructive tests are not enable

### DIFF
--- a/tests/support/gitfs.py
+++ b/tests/support/gitfs.py
@@ -478,6 +478,8 @@ class GitPillarSSHTestBase(GitPillarTestBase, SSHDMixin):
 
     @classmethod
     def tearDownClass(cls):
+        if cls.case is None:
+            return
         if cls.case.sshd_proc is not None:
             cls.case.sshd_proc.send_signal(signal.SIGTERM)
         cls.case.run_state('user.absent', name=cls.username, purge=True)


### PR DESCRIPTION
### What does this PR do?

This fixes the following when running `python tests/runtests.py --ext-pillar`:

```
 --------  Tests with Errors  ------------------------------------------------------------------------------------------------------------------------
   -> tearDownClass (integration.pillar.test_git_pillar.TestGitPythonSSH)  ...........................................................................
       Traceback (most recent call last):
         File ".../salt/tests/support/gitfs.py", line 481, in tearDownClass
           if cls.case.sshd_proc is not None:
       AttributeError: 'NoneType' object has no attribute 'sshd_proc'
   ...................................................................................................................................................
   -> tearDownClass (integration.pillar.test_git_pillar.TestPygit2SSH)  ..............................................................................
       Traceback (most recent call last):
         File ".../salt/tests/support/gitfs.py", line 481, in tearDownClass
           if cls.case.sshd_proc is not None:
       AttributeError: 'NoneType' object has no attribute 'sshd_proc'
   ...................................................................................................................................................
``` 

### What issues does this PR fix or reference?

None

### Tests written?

No, but fixed.

### Commits signed with GPG?

Yes