### PR TITLE
Virt disk fixes - Fluorine backport

### DIFF
--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -1541,9 +1541,10 @@ def _disks_equal(disk1, disk2):
     '''
     target1 = disk1.find('target')
     target2 = disk2.find('target')
+    source1 = ElementTree.tostring(disk1.find('source')) if disk1.find('source') is not None else None
+    source2 = ElementTree.tostring(disk2.find('source')) if disk2.find('source') is not None else None
 
-    return ElementTree.tostring(disk1.find('source')) == \
-        ElementTree.tostring(disk2.find('source')) and \
+    return source1 == source2 and \
         target1 is not None and target2 is not None and \
         target1.get('bus') == target2.get('bus')
 

--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -581,25 +581,27 @@ def _gen_xml(name,
         else:
             context['console'] = True
 
-    context['disks'] = {}
+    context['disks'] = []
     disk_bus_map = {'virtio': 'vd', 'xen': 'xvd', 'fdc': 'fd', 'ide': 'hd'}
     for i, disk in enumerate(diskp):
-        context['disks'][disk['name']] = {}
-        context['disks'][disk['name']]['device'] = disk.get('device', 'disk')
-        if 'source_file' and disk['source_file']:
-            context['disks'][disk['name']]['source_file'] = disk['source_file']
         prefix = disk_bus_map.get(disk['model'], 'sd')
-        context['disks'][disk['name']]['target_dev'] = '{0}{1}'.format(prefix, string.ascii_lowercase[i])
-        if hypervisor in ['qemu', 'kvm', 'xen']:
-            context['disks'][disk['name']]['address'] = False
-            context['disks'][disk['name']]['driver'] = True
-        elif hypervisor in ['esxi', 'vmware']:
-            context['disks'][disk['name']]['address'] = True
-            context['disks'][disk['name']]['driver'] = False
-        context['disks'][disk['name']]['disk_bus'] = disk['model']
-        context['disks'][disk['name']]['type'] = disk['format']
-        context['disks'][disk['name']]['index'] = six.text_type(i)
+        disk_context = {
+            'device': disk.get('device', 'disk'),
+            'target_dev': '{0}{1}'.format(prefix, string.ascii_lowercase[i]),
+            'disk_bus': disk['model'],
+            'type': disk['format'],
+            'index': six.text_type(i),
+        }
+        if 'source_file' and disk['source_file']:
+            disk_context['source_file'] = disk['source_file']
 
+        if hypervisor in ['qemu', 'kvm', 'bhyve', 'xen']:
+            disk_context['address'] = False
+            disk_context['driver'] = True
+        elif hypervisor in ['esxi', 'vmware']:
+            disk_context['address'] = True
+            disk_context['driver'] = False
+        context['disks'].append(disk_context)
     context['nics'] = nicp
 
     context['os_type'] = os_type

--- a/salt/templates/virt/libvirt_domain.jinja
+++ b/salt/templates/virt/libvirt_domain.jinja
@@ -9,7 +9,7 @@
                 {% endfor %}
         </os>
         <devices>
-                {% for diskname, disk in disks.items() %}
+                {% for disk in disks %}
                 <disk type='file' device='{{ disk.device }}'>
                         {% if 'source_file' in disk %}
                         <source file='{{ disk.source_file }}' />

--- a/salt/templates/virt/libvirt_domain.jinja
+++ b/salt/templates/virt/libvirt_domain.jinja
@@ -10,8 +10,10 @@
         </os>
         <devices>
                 {% for diskname, disk in disks.items() %}
-                <disk type='file' device='disk'>
+                <disk type='file' device='{{ disk.device }}'>
+                        {% if 'source_file' in disk %}
                         <source file='{{ disk.source_file }}' />
+                        {% endif %}
                         <target dev='{{ disk.target_dev }}' bus='{{ disk.disk_bus }}' />
                         {% if disk.address -%}
                         <address type='drive' controller='0' bus='0' target='0' unit='{{ disk.index }}' />

--- a/tests/unit/modules/test_virt.py
+++ b/tests/unit/modules/test_virt.py
@@ -94,6 +94,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         disks = virt._disk_profile('default', 'kvm', userdisks, 'myvm', image='/path/to/image')
         self.assertEqual(
             [{'name': 'system',
+              'device': 'disk',
               'size': 8192,
               'format': 'qcow2',
               'model': 'virtio',
@@ -101,6 +102,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
               'image': '/path/to/image',
               'source_file': '{0}{1}myvm_system.qcow2'.format(root_dir, os.sep)},
              {'name': 'data',
+              'device': 'disk',
               'size': 16384,
               'format': 'raw',
               'model': 'virtio',
@@ -703,6 +705,31 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
                 disks, "/default/path/"])}):
             with self.assertRaises(CommandExecutionError):
                 virt._disk_profile('noeffect', 'kvm', [], 'hello')
+
+    def test_gen_xml_cdrom(self):
+        '''
+        Test virt._gen_xml(), generating a cdrom device (different disk type, no source)
+        '''
+        diskp = virt._disk_profile(None, 'kvm', [{
+            'name': 'tested',
+            'device': 'cdrom',
+            'source_file': None,
+            'model': 'ide'}], 'hello')
+        nicp = virt._nic_profile(None, 'kvm')
+        xml_data = virt._gen_xml(
+            'hello',
+            1,
+            512,
+            diskp,
+            nicp,
+            'kvm',
+            'hvm',
+            'x86_64',
+            )
+        root = ET.fromstring(xml_data)
+        disk = root.findall('.//disk')[0]
+        self.assertEqual(disk.attrib['device'], 'cdrom')
+        self.assertIsNone(disk.find('source'))
 
     def test_controller_for_esxi(self):
         '''

--- a/tests/unit/modules/test_virt.py
+++ b/tests/unit/modules/test_virt.py
@@ -771,6 +771,9 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
                 <source file='/path/to/img4.qcow2'/>
                 <target dev='hdb' bus='ide'/>
               </disk>
+              <disk type='file' device='cdrom'>
+                <target dev='hdc' bus='ide'/>
+              </disk>
             </devices>
         ''').findall('disk')
 
@@ -788,13 +791,17 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
                 <source file='/path/to/img4.qcow2'/>
                 <target dev='vdc' bus='virtio'/>
               </disk>
+              <disk type='file' device='cdrom'>
+                <target dev='hdc' bus='ide'/>
+              </disk>
             </devices>
         ''').findall('disk')
         ret = virt._diff_disk_lists(old_disks, new_disks)
         self.assertEqual([disk.find('source').get('file') for disk in ret['deleted']],
                          ['/path/to/img1.qcow2', '/path/to/img2.qcow2', '/path/to/img4.qcow2'])
-        self.assertEqual([disk.find('source').get('file') for disk in ret['unchanged']],
-                         ['/path/to/img0.qcow2'])
+        self.assertEqual([disk.find('source').get('file') if disk.find('source') is not None else None
+                          for disk in ret['unchanged']],
+                         ['/path/to/img0.qcow2', None])
         self.assertEqual([disk.find('source').get('file') for disk in ret['new']],
                          ['/path/to/img3.qcow2', '/path/to/img4.qcow2'])
         self.assertEqual(ret['new'][0].find('target').get('dev'), 'vdb')

--- a/tests/unit/modules/test_virt.py
+++ b/tests/unit/modules/test_virt.py
@@ -812,28 +812,39 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
               </disk>
               <disk type='file' device='disk' cache='default'>
                 <source file='/path/to/img0.qcow2'/>
-                <target dev='vdb' bus='virtio'/>
+                <target dev='vda' bus='virtio'/>
               </disk>
               <disk type='file' device='disk'>
                 <source file='/path/to/img4.qcow2'/>
-                <target dev='vdc' bus='virtio'/>
+                <target dev='vda' bus='virtio'/>
               </disk>
               <disk type='file' device='cdrom'>
-                <target dev='hdc' bus='ide'/>
+                <target dev='hda' bus='ide'/>
               </disk>
             </devices>
         ''').findall('disk')
         ret = virt._diff_disk_lists(old_disks, new_disks)
-        self.assertEqual([disk.find('source').get('file') for disk in ret['deleted']],
-                         ['/path/to/img1.qcow2', '/path/to/img2.qcow2', '/path/to/img4.qcow2'])
         self.assertEqual([disk.find('source').get('file') if disk.find('source') is not None else None
-                          for disk in ret['unchanged']],
-                         ['/path/to/img0.qcow2', None])
-        self.assertEqual([disk.find('source').get('file') for disk in ret['new']],
-                         ['/path/to/img3.qcow2', '/path/to/img4.qcow2'])
-        self.assertEqual(ret['new'][0].find('target').get('dev'), 'vdb')
-        self.assertEqual(ret['new'][1].find('target').get('dev'), 'vdc')
+                          for disk in ret['unchanged']], [])
+        self.assertEqual([disk.find('source').get('file') if disk.find('source') is not None else None
+                          for disk in ret['new']],
+                         ['/path/to/img3.qcow2', '/path/to/img0.qcow2', '/path/to/img4.qcow2', None])
+        self.assertEqual([disk.find('target').get('dev') for disk in ret['sorted']],
+                         ['vda', 'vdb', 'vdc', 'hda'])
+        self.assertEqual([disk.find('source').get('file') if disk.find('source') is not None else None
+                          for disk in ret['sorted']],
+                         ['/path/to/img3.qcow2',
+                          '/path/to/img0.qcow2',
+                          '/path/to/img4.qcow2',
+                          None])
         self.assertEqual(ret['new'][1].find('target').get('bus'), 'virtio')
+        self.assertEqual([disk.find('source').get('file') if disk.find('source') is not None else None
+                          for disk in ret['deleted']],
+                         ['/path/to/img0.qcow2',
+                          '/path/to/img1.qcow2',
+                          '/path/to/img2.qcow2',
+                          '/path/to/img4.qcow2',
+                          None])
 
     def test_diff_nics(self):
         '''
@@ -1043,7 +1054,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
                   <driver name='qemu' type='qcow2'/>
                   <source file='{0}{1}myvm_data.qcow2'/>
                   <backingStore/>
-                  <target dev='vda' bus='virtio'/>
+                  <target dev='vdb' bus='virtio'/>
                   <alias name='virtio-disk1'/>
                   <address type='pci' domain='0x0000' bus='0x00' slot='0x07' function='0x1'/>
                 </disk>


### PR DESCRIPTION
Backport of PR #50356 

### What does this PR do?

This PR handles cdrom disks devices in the virt module. When updating VMs created outside of salt virt module we would hit problems since these devices can have no attached source.

### What issues does this PR fix or reference?

None 

### Previous Behavior

Run a `virt.update` on a VM that has a cdrom device with no ISO attached. The salt call will fail with a message saying None is not an iterable type.

### New Behavior

Running a `virt.update` doesn't trigger an exception and keeps the cdrom (or floppy) device intact.

### Tests written?

Yes

### Commits signed with GPG?

Yes
