### PR TITLE
[2018.3] Fix to utils/dicttrim.py to honor max_event_size with nested dictionaries

### DIFF
--- a/salt/utils/dicttrim.py
+++ b/salt/utils/dicttrim.py
@@ -6,6 +6,22 @@ import sys
 import salt.payload
 
 
+def _trim_dict_in_dict(data, max_val_size, replace_with):
+    '''
+    Takes a dictionary, max_val_size and replace_with
+    and recursively loops through and replaces any values
+    that are greater than max_val_size.
+    '''
+    for key in data:
+        if isinstance(data[key], dict):
+            _trim_dict_in_dict(data[key],
+                               max_val_size,
+                               replace_with)
+        else:
+            if sys.getsizeof(data[key]) > max_val_size:
+                data[key] = replace_with
+
+
 def trim_dict(
         data,
         max_dict_bytes,
@@ -63,8 +79,13 @@ def trim_dict(
             max_val_size = float(max_dict_bytes * (percent / 100))
             try:
                 for key in data:
-                    if sys.getsizeof(data[key]) > max_val_size:
-                        data[key] = replace_with
+                    if isinstance(data[key], dict):
+                        _trim_dict_in_dict(data[key],
+                                           max_val_size,
+                                           replace_with)
+                    else:
+                        if sys.getsizeof(data[key]) > max_val_size:
+                            data[key] = replace_with
                 percent = percent - stepper_size
                 max_val_size = float(max_dict_bytes * (percent / 100))
                 if use_bin_type:

--- a/tests/unit/utils/test_dicttrim.py
+++ b/tests/unit/utils/test_dicttrim.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+
+# Import python libs
+from __future__ import absolute_import, print_function, unicode_literals
+
+# Import Salt Testing libs
+from tests.support.unit import TestCase
+
+# Import Salt libs
+import salt.utils.dicttrim as dicttrimmer
+
+import logging
+log = logging.getLogger(__name__)
+
+
+class DictTrimTestCase(TestCase):
+
+    def setUp(self):
+        self.old_dict = {'a': 'b', 'c': 'x' * 10000}
+        self.new_dict = {'a': 'b', 'c': 'VALUE_TRIMMED'}
+
+    def test_trim_dict(self):
+        ret = dicttrimmer.trim_dict(self.old_dict, 100)
+        self.assertEqual(ret, self.new_dict)
+
+
+class RecursiveDictTrimTestCase(TestCase):
+
+    def setUp(self):
+        self.old_dict = {'a': {'b': 1, 'c': 2, 'e': 'x' * 10000, 'f': '3'}}
+        self.new_dict = {'a': {'b': 1, 'c': 2, 'e': 'VALUE_TRIMMED', 'f': '3'}}
+
+    def test_trim_dict(self):
+        ret = dicttrimmer.trim_dict(self.old_dict, 100)
+        self.assertEqual(ret, self.new_dict)

--- a/tests/unit/utils/test_dicttrim.py
+++ b/tests/unit/utils/test_dicttrim.py
@@ -20,7 +20,7 @@ class DictTrimTestCase(TestCase):
         self.new_dict = {'a': 'b', 'c': 'VALUE_TRIMMED'}
 
     def test_trim_dict(self):
-        ret = dicttrimmer.trim_dict(self.old_dict, 100)
+        ret = dicttrimmer.trim_dict(self.old_dict, 1000)
         self.assertEqual(ret, self.new_dict)
 
 
@@ -31,5 +31,5 @@ class RecursiveDictTrimTestCase(TestCase):
         self.new_dict = {'a': {'b': 1, 'c': 2, 'e': 'VALUE_TRIMMED', 'f': '3'}}
 
     def test_trim_dict(self):
-        ret = dicttrimmer.trim_dict(self.old_dict, 100)
+        ret = dicttrimmer.trim_dict(self.old_dict, 1000)
         self.assertEqual(ret, self.new_dict)


### PR DESCRIPTION
### What does this PR do?
Adding _trim_dict_in_dict to utils/dictrim.py to be called from trim_dict when data contains a nested dictionary.  This will ensure that values will still be trimmed correctly.

### What issues does this PR fix or reference?
#50062 

### Previous Behavior
Event data that contained nested dictionaries that exceeded the max_event_size would not be trimmed because the size of the key was reported, not the actual data inside the dictionary.

### New Behavior
If a nested dictionary is found in the event data dictionary, the `_trim_dict_in_dict` is called recursively, ensuring all values are trimmed correctly.

### Tests written?
Not yet.

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
