### PR TITLE
Fix libcrypto search for sparc solaris 64-bit

### DIFF
--- a/salt/utils/rsax931.py
+++ b/salt/utils/rsax931.py
@@ -36,6 +36,9 @@ def _load_libcrypto():
             'libcrypto.so*'))[0])
     else:
         lib = find_library('crypto')
+        if not lib and sys.platform.startswith('sunos5'):
+            # ctypes.util.find_library defaults to 32 bit library path on sunos5, test for 64 bit python execution
+            lib = find_library('crypto', sys.maxsize > 2**32) 
         if not lib and salt.utils.platform.is_sunos():
             # Solaris-like distribution that use pkgsrc have
             # libraries in a non standard location.

--- a/salt/utils/rsax931.py
+++ b/salt/utils/rsax931.py
@@ -38,7 +38,7 @@ def _load_libcrypto():
         lib = find_library('crypto')
         if not lib and sys.platform.startswith('sunos5'):
             # ctypes.util.find_library defaults to 32 bit library path on sunos5, test for 64 bit python execution
-            lib = find_library('crypto', sys.maxsize > 2**32) 
+            lib = find_library('crypto', sys.maxsize > 2**32)
         if not lib and salt.utils.platform.is_sunos():
             # Solaris-like distribution that use pkgsrc have
             # libraries in a non standard location.


### PR DESCRIPTION
On solaris sparc the python ctypes.util.find_library() method defaults to the 32 bit library path.  This will test if python is running in 64 bit and request the appropriate library search path.

### What does this PR do?

On Solaris sparc systems this will test if python is running in 64 bit and request the appropriate library search path.

### What issues does this PR fix or reference?
#50388 

### Previous Behavior
Always checked only the 32 bit library path

### New Behavior
If the library is not found and the platform is sunos5, it will run the test to see if it is 64 bit and check the appropriate library path.

### Tests written?

No

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
