### PR TITLE
Add compatibility with other package modules for "list_repos" function

### DIFF
--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -1595,6 +1595,7 @@ def list_repos():
         repo['file'] = source.file
         repo['comps'] = getattr(source, 'comps', [])
         repo['disabled'] = source.disabled
+        repo['enabled'] = not repo['disabled']  # This is for compatibility with the other modules
         repo['dist'] = source.dist
         repo['type'] = source.type
         repo['uri'] = source.uri.rstrip('/')


### PR DESCRIPTION
### What does this PR do?
Adds common return value to the `list_repos` function.

### What issues does this PR fix or reference?
For Debian it is inverted `disabled: boolean` while others using `enabled: boolean`.

### Previous Behavior
When repo is enabled, `list_repos` function returns:

```json
{
    "disabled": false
}
```

Now it returns also inverted expression of the above:
```json
{
    "disabled": false,
    "enabled": true
}
```
