### PR TITLE
Add Win WUSA management, to install Windows Update files (.msu).

### DIFF
--- a/salt/modules/win_wusa.py
+++ b/salt/modules/win_wusa.py
@@ -28,7 +28,7 @@ def __virtual__():
     if not salt.utils.platform.is_windows():
         return False, 'Only available on Windows systems'
 
-    powershell_info = __salt__['cmd.shell_info']('powershell', True)
+    powershell_info = __salt__['cmd.shell_info'](shell='powershell', list_modules=True)
     if not powershell_info['installed']:
         return False, 'PowerShell not available'
 

--- a/salt/modules/win_wusa.py
+++ b/salt/modules/win_wusa.py
@@ -37,22 +37,57 @@ def __virtual__():
 
 
 def is_installed(kb):
+    '''
+    Check if a specific KB is installed.
 
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' win_wusa.is_installed KB123456
+    '''
     get_hotfix_result = __salt__['cmd.powershell_all']('Get-HotFix -Id {0}'.format(kb), ignore_retcode=True)
 
     return get_hotfix_result['retcode'] == 0
 
 
 def install(path):
+    '''
+    Install a KB from a .msu file.
+    Some KBs will need a reboot, but this function does not manage it.
+    You may have to manage reboot yourself after installation.
 
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' win_wusa.install C:/temp/KB123456.msu
+    '''
     return __salt__['cmd.run_all']('wusa.exe {0} /quiet /norestart'.format(path), ignore_retcode=True)
 
 
 def uninstall(kb):
+    '''
+    Uninstall a specific KB.
 
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' win_wusa.uninstall KB123456
+    '''
     return __salt__['cmd.run_all']('wusa.exe /uninstall /kb:{0} /quiet /norestart'.format(kb[2:]), ignore_retcode=True)
 
 
 def list_kbs():
+    '''
+    Return a list of dictionaries, one dictionary for each installed KB.
+    The HotFixID key contains the ID of the KB.
 
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' win_wusa.list_kbs
+    '''
     return __salt__['cmd.powershell']('Get-HotFix')

--- a/salt/modules/win_wusa.py
+++ b/salt/modules/win_wusa.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+'''
+Microsoft Update files management via wusa.exe
+
+:maintainer:    Thomas Lemarchand
+:platform:      Windows
+:depends:       PowerShell
+
+'''
+
+# Import python libs
+from __future__ import absolute_import
+import logging
+
+# Import salt libs
+import salt.utils.platform
+
+log = logging.getLogger(__name__)
+
+# Define the module's virtual name
+__virtualname__ = 'win_wusa'
+
+
+def __virtual__():
+    '''
+    Load only on Windows
+    '''
+    if not salt.utils.platform.is_windows():
+        return False, 'Only available on Windows systems'
+
+    powershell_info = __salt__['cmd.shell_info']('powershell', True)
+    if not powershell_info['installed']:
+        return False, 'PowerShell not available'
+
+    return __virtualname__
+
+
+def is_installed(kb):
+
+    get_hotfix_result = __salt__['cmd.powershell_all']('Get-HotFix -Id {0}'.format(kb), ignore_retcode=True)
+
+    return get_hotfix_result['retcode'] == 0
+
+
+def install(path):
+
+    return __salt__['cmd.run_all']('wusa.exe {0} /quiet /norestart'.format(path), ignore_retcode=True)
+
+
+def uninstall(kb):
+
+    return __salt__['cmd.run_all']('wusa.exe /uninstall /kb:{0} /quiet /norestart'.format(kb[2:]), ignore_retcode=True)

--- a/salt/modules/win_wusa.py
+++ b/salt/modules/win_wusa.py
@@ -6,10 +6,11 @@ Microsoft Update files management via wusa.exe
 :platform:      Windows
 :depends:       PowerShell
 
+.. versionadded:: Neon
 '''
 
 # Import python libs
-from __future__ import absolute_import
+from __future__ import absolute_import, unicode_literals
 import logging
 
 # Import salt libs

--- a/salt/modules/win_wusa.py
+++ b/salt/modules/win_wusa.py
@@ -28,7 +28,7 @@ def __virtual__():
     if not salt.utils.platform.is_windows():
         return False, 'Only available on Windows systems'
 
-    powershell_info = __salt__['cmd.shell_info'](shell='powershell', list_modules=True)
+    powershell_info = __salt__['cmd.shell_info'](shell='powershell', list_modules=False)
     if not powershell_info['installed']:
         return False, 'PowerShell not available'
 
@@ -50,3 +50,8 @@ def install(path):
 def uninstall(kb):
 
     return __salt__['cmd.run_all']('wusa.exe /uninstall /kb:{0} /quiet /norestart'.format(kb[2:]), ignore_retcode=True)
+
+
+def list_kbs():
+
+    return __salt__['cmd.powershell']('Get-HotFix')

--- a/salt/states/win_wusa.py
+++ b/salt/states/win_wusa.py
@@ -47,7 +47,6 @@ def installed(name, source):
         'changes': {},
         'result': False,
         'comment': '',
-        'pchanges': {},
         }
 
     # Start with basic error-checking. Do all the passed parameters make sense
@@ -68,7 +67,7 @@ def installed(name, source):
     # in ``test=true`` mode.
     if __opts__['test'] is True:
         ret['comment'] = 'The KB "{0}" will be installed.'.format(name)
-        ret['pchanges'] = {
+        ret['changes'] = {
             'old': current_state,
             'new': True,
         }

--- a/salt/states/win_wusa.py
+++ b/salt/states/win_wusa.py
@@ -1,0 +1,115 @@
+# -*- coding: utf-8 -*-
+'''
+Microsoft Updates (KB) Management
+
+This module provides the ability to enforce KB installations
+from files (.msu), without WSUS.
+
+'''
+
+# Import python libs
+from __future__ import absolute_import
+import logging
+
+# Import salt libs
+import salt.utils.platform
+import salt.exceptions
+
+log = logging.getLogger(__name__)
+
+
+# Define the module's virtual name
+__virtualname__ = 'win_wusa'
+
+
+def __virtual__():
+    '''
+    Load only on Windows
+    '''
+    if not salt.utils.platform.is_windows():
+        return False, 'Only available on Windows systems'
+
+    return __virtualname__
+
+
+def installed(name, source):
+    '''
+    Enforce the installed state of a KB
+
+    name
+        Name of the Windows KB ("KB123456")
+    source
+        Source of .msu file corresponding to the KB
+
+    '''
+    ret = {
+        'name': name,
+        'changes': {},
+        'result': False,
+        'comment': '',
+        'pchanges': {},
+        }
+
+    # Start with basic error-checking. Do all the passed parameters make sense
+    # and agree with each-other?
+    if not name or not source:
+        raise salt.exceptions.SaltInvocationError(
+            'Arguments "name" and "source" are mandatory.')
+
+    # Check the current state of the system. Does anything need to change?
+    current_state = __salt__['win_wusa.is_installed'](name)
+
+    if current_state:
+        ret['result'] = True
+        ret['comment'] = 'KB already installed'
+        return ret
+
+    # The state of the system does need to be changed. Check if we're running
+    # in ``test=true`` mode.
+    if __opts__['test'] is True:
+        ret['comment'] = 'The KB "{0}" will be installed.'.format(name)
+        ret['pchanges'] = {
+            'old': current_state,
+            'new': True,
+        }
+
+        # Return ``None`` when running with ``test=true``.
+        ret['result'] = None
+
+        return ret
+
+    try:
+        result = __states__['file.cached'](source,
+                                           skip_verify=True,
+                                           saltenv=__env__)
+    except Exception as exc:
+        msg = 'Failed to cache {0}: {1}'.format(
+                salt.utils.url.redact_http_basic_auth(source),
+                exc.__str__())
+        log.exception(msg)
+        ret['comment'] = msg
+        return ret
+
+    if result['result']:
+        # Get the path of the file in the minion cache
+        cached = __salt__['cp.is_cached'](source, saltenv=__env__)
+    else:
+        log.debug(
+            'failed to download %s',
+            salt.utils.url.redact_http_basic_auth(source)
+        )
+        return result
+
+    # Finally, make the actual change and return the result.
+    new_state = __salt__['win_wusa.install'](cached)
+
+    ret['comment'] = 'The KB "{0}" was installed!'.format(name)
+
+    ret['changes'] = {
+        'old': current_state,
+        'new': new_state,
+    }
+
+    ret['result'] = True
+
+    return ret

--- a/salt/states/win_wusa.py
+++ b/salt/states/win_wusa.py
@@ -5,10 +5,11 @@ Microsoft Updates (KB) Management
 This module provides the ability to enforce KB installations
 from files (.msu), without WSUS.
 
+.. versionadded:: Neon
 '''
 
 # Import python libs
-from __future__ import absolute_import
+from __future__ import absolute_import, unicode_literals
 import logging
 
 # Import salt libs


### PR DESCRIPTION
### What does this PR do?
This PR adds an execution module and a state module to manage .msu files with WUSA.
With this state we can ensure that a specific KB is installed, even if Windows Update is disabled.
I've chosen to add a win_wusa module and state, and not to extend win_wua, because when Windows Update is disabled centrally, win_wua module is not functioning correctly.

### What issues does this PR fix or reference?
#46292

### Tests written?
No

### Commits signed with GPG?
No
