### PR TITLE
supportconfig: examine your infrastructure in just one go

### DIFF
--- a/salt/cli/support/__init__.py
+++ b/salt/cli/support/__init__.py
@@ -40,7 +40,7 @@ def get_profile(profile, caller, runner):
         if os.path.exists(profile_path):
             try:
                 rendered_template = _render_profile(profile_path, caller, runner)
-                log.trace('\n{d}\n{t}\n{d}\n'.format(d='-' * 80, t=rendered_template))
+                log.debug('\n{d}\n{t}\n{d}\n'.format(d='-' * 80, t=rendered_template))
                 data.update(yaml.load(rendered_template))
             except Exception as ex:
                 log.debug(ex, exc_info=True)

--- a/salt/cli/support/collector.py
+++ b/salt/cli/support/collector.py
@@ -354,7 +354,7 @@ class SaltSupport(salt.utils.parsers.SaltSupportOptionParser):
 
         return data
 
-    def collect_local_data(self):
+    def collect_local_data(self, profile=None):
         '''
         Collects master system data.
         :return:
@@ -375,7 +375,7 @@ class SaltSupport(salt.utils.parsers.SaltSupportOptionParser):
             '''
             return self._extract_return(self._local_run({'fun': func, 'arg': args, 'kwarg': kwargs}))
 
-        scenario = salt.cli.support.get_profile(self.config['support_profile'], call, run)
+        scenario = salt.cli.support.get_profile(profile or self.config['support_profile'], call, run)
         for category_name in scenario:
             self.out.put(category_name)
             self.collector.add(category_name)

--- a/salt/cli/support/collector.py
+++ b/salt/cli/support/collector.py
@@ -415,13 +415,6 @@ class SaltSupport(salt.utils.parsers.SaltSupportOptionParser):
 
         return action_name.split(':')[0] or None
 
-    def collect_targets_data(self):
-        '''
-        Collects minion targets data
-        :return:
-        '''
-        # TODO: remote collector?
-
     def _cleanup(self):
         '''
         Cleanup if crash/exception
@@ -511,7 +504,6 @@ class SaltSupport(salt.utils.parsers.SaltSupportOptionParser):
                             self.collector.open()
                             self.collect_local_data()
                             self.collect_internal_data()
-                            self.collect_targets_data()
                             self.collector.close()
 
                             archive_path = self.collector.archive_path

--- a/salt/cli/support/collector.py
+++ b/salt/cli/support/collector.py
@@ -354,7 +354,7 @@ class SaltSupport(salt.utils.parsers.SaltSupportOptionParser):
 
         return data
 
-    def collect_local_data(self, profile=None):
+    def collect_local_data(self, profile=None, profile_source=None):
         '''
         Collects master system data.
         :return:
@@ -375,7 +375,7 @@ class SaltSupport(salt.utils.parsers.SaltSupportOptionParser):
             '''
             return self._extract_return(self._local_run({'fun': func, 'arg': args, 'kwarg': kwargs}))
 
-        scenario = salt.cli.support.get_profile(profile or self.config['support_profile'], call, run)
+        scenario = profile_source or salt.cli.support.get_profile(profile or self.config['support_profile'], call, run)
         for category_name in scenario:
             self.out.put(category_name)
             self.collector.add(category_name)

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -1709,8 +1709,10 @@ class LazyLoader(salt.utils.lazy.LazyDict):
         ))
 
         for attr in getattr(mod, '__load__', dir(mod)):
-            if attr.startswith('_'):
-                # private functions are skipped
+            if attr.startswith('_') and attr != '__call__':
+                # private functions are skipped,
+                # except __call__ which is default entrance
+                # for multi-function batch-like state syntax
                 continue
             func = getattr(mod, attr)
             if not inspect.isfunction(func) and not isinstance(func, functools.partial):

--- a/salt/modules/saltsupport.py
+++ b/salt/modules/saltsupport.py
@@ -1,6 +1,21 @@
-# coding=utf-8
+# -*- coding: utf-8 -*-
+#
+# Author: Bo Maryniuk <bo@suse.de>
+#
+# Copyright 2018 SUSE LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 '''
-Module to run salt-support within Salt
+Module to run salt-support within Salt.
 '''
 from __future__ import unicode_literals, print_function, absolute_import
 

--- a/salt/modules/saltsupport.py
+++ b/salt/modules/saltsupport.py
@@ -1,0 +1,43 @@
+# coding=utf-8
+'''
+Module to run salt-support within Salt
+'''
+from __future__ import unicode_literals, print_function, absolute_import
+
+from salt.cli.support.collector import SaltSupport
+import logging
+
+
+log = logging.getLogger(__name__)
+
+
+class SaltSupportModule(SaltSupport):
+    '''
+    Salt Support module class.
+    '''
+    def setup_config(self):
+        '''
+        Return current configuration
+        :return:
+        '''
+        return __opts__
+
+    def run(self):
+        '''
+
+        :return:
+        '''
+        return 'stub'
+
+
+def __virtual__():
+    return True
+
+
+def run():
+    '''
+
+    :return:
+    '''
+    support = SaltSupportModule()
+    return support.run()

--- a/salt/modules/saltsupport.py
+++ b/salt/modules/saltsupport.py
@@ -140,7 +140,7 @@ class SaltSupportModule(SaltSupport):
             _archives.append(os.path.basename(archive))
         archives = _archives[:]
 
-        ret = {'failed': {}, 'deleted': {}}
+        ret = {'failed': 0, 'deleted': 0, 'errors': {}}
         for archive in self.archives():
             arc_dir = os.path.dirname(archive)
             archive = os.path.basename(archive)
@@ -148,9 +148,10 @@ class SaltSupportModule(SaltSupport):
                 archive = os.path.join(arc_dir, archive)
                 try:
                     os.unlink(archive)
-                    ret['deleted'][archive] = True
+                    ret['deleted'] += 1
                 except Exception as err:
-                    ret['failed'][archive] = str(err)
+                    ret['errors'][archive] = str(err)
+                    ret['failed'] += 1
 
         return ret
 

--- a/salt/modules/saltsupport.py
+++ b/salt/modules/saltsupport.py
@@ -34,6 +34,8 @@ import salt.cli.support
 from salt.cli.support.collector import SaltSupport, SupportDataCollector
 import salt.exceptions
 import salt.utils.stringutils
+import salt.defaults.exitcodes
+import salt.utils.odict
 
 __virtualname__ = 'support'
 log = logging.getLogger(__name__)
@@ -183,6 +185,25 @@ class SaltSupportModule(SaltSupport):
                     ret['files'][archive] = 'left'
 
         return ret
+
+    def format_sync_stats(self, cnt):
+        '''
+        Format stats of the sync output.
+
+        :param cnt:
+        :return:
+        '''
+        stats = salt.utils.odict.OrderedDict()
+        if cnt.get('retcode') == salt.defaults.exitcodes.EX_OK:
+            for line in cnt.get('stdout', '').split(os.linesep):
+                line = line.split(': ')
+                if len(line) == 2:
+                    stats[line[0].lower().replace(' ', '_')] = line[1]
+            cnt['transfer'] = stats
+            for section in ['stderr', 'stdout']:
+                del cnt[section]
+
+        return cnt
 
     @salt.utils.decorators.depends('rsync')
     @salt.utils.decorators.external

--- a/salt/modules/saltsupport.py
+++ b/salt/modules/saltsupport.py
@@ -95,17 +95,17 @@ class SaltSupportModule(SaltSupport):
             'custom': [],
         }
 
-    def run(self, archive=None, output='nested'):
+    @salt.utils.decorators.external
+    def run(self, profile='default', archive=None, output='nested'):
         '''
         Something
         '''
-        self.config = self.setup_config()
-        self.config['support_profile'] = 'default'
+        #self.config['support_profile'] = profile
         self.out = LogCollector()
         self.collector = SupportDataCollector(archive or self._get_default_archive_name(), output)
 
         self.collector.open()
-        self.collect_local_data()
+        self.collect_local_data(profile=profile)
         self.collect_internal_data()
         self.collector.close()
 

--- a/salt/modules/saltsupport.py
+++ b/salt/modules/saltsupport.py
@@ -99,7 +99,7 @@ class SaltSupportModule(SaltSupport):
 
         :return:
         '''
-        self.config = __opts__
+        self.config = self.setup_config()
         self.config['support_profile'] = 'default'
         self.out = LogCollector()
         self.collector = SupportDataCollector(archive or self._get_default_archive_name(), output)

--- a/salt/modules/saltsupport.py
+++ b/salt/modules/saltsupport.py
@@ -115,6 +115,32 @@ class SaltSupportModule(SaltSupport):
         return arc_files
 
     @salt.utils.decorators.external
+    def delete_archives(self, *archives):
+        '''
+        Delete archives
+        :return:
+        '''
+        # Remove paths
+        _archives = []
+        for archive in archives:
+            _archives.append(os.path.basename(archive))
+        archives = _archives[:]
+
+        ret = {'failed': {}, 'deleted': {}}
+        for archive in self.archives():
+            arc_dir = os.path.dirname(archive)
+            archive = os.path.basename(archive)
+            if archives and archive in archives or not archives:
+                archive = os.path.join(arc_dir, archive)
+                try:
+                    os.unlink(archive)
+                    ret['deleted'][archive] = True
+                except Exception as err:
+                    ret['failed'][archive] = str(err)
+
+        return ret
+
+    @salt.utils.decorators.external
     def run(self, profile='default', archive=None, output='nested'):
         '''
         Something

--- a/salt/modules/saltsupport.py
+++ b/salt/modules/saltsupport.py
@@ -64,7 +64,7 @@ class _Util(object):  # This might get moved elsewhere in a future.
         return exportable
 
 
-class SaltSupportModule(SaltSupport):
+class SaltSupportModule(SaltSupport, _Util):
     '''
     Salt Support module class.
     '''
@@ -81,7 +81,6 @@ class SaltSupportModule(SaltSupport):
 
         :return:
         '''
-        host = None
         for grain in ['fqdn', 'host', 'localhost', 'nodename']:
             host = __grains__.get(grain)
             if host:
@@ -96,8 +95,7 @@ class SaltSupportModule(SaltSupport):
     @salt.utils.decorators.external
     def run(self, archive=None, output='nested'):
         '''
-
-        :return:
+        Something
         '''
         self.config = self.setup_config()
         self.config['support_profile'] = 'default'
@@ -114,12 +112,8 @@ class SaltSupportModule(SaltSupport):
 
 
 def __virtual__():
-    return True
-
-
-def run():
     '''
-
+    Set method references as module functions aliases
     :return:
     '''
     support = SaltSupportModule()
@@ -147,4 +141,3 @@ def run():
         setattr(sys.modules[__name__], method_name, _set_function(obj))
 
     return True
-    return support.run()

--- a/salt/modules/saltsupport.py
+++ b/salt/modules/saltsupport.py
@@ -51,6 +51,12 @@ class SaltSupportModule(SaltSupport):
     '''
     Salt Support module class.
     '''
+    def __init__(self):
+        '''
+        Constructor
+        '''
+        self.config = self.setup_config()
+
     def setup_config(self):
         '''
         Return current configuration

--- a/salt/modules/saltsupport.py
+++ b/salt/modules/saltsupport.py
@@ -166,7 +166,7 @@ class SaltSupportModule(SaltSupport):
             _archives.append(os.path.basename(archive))
         archives = _archives[:]
 
-        ret = {'failed': 0, 'deleted': 0, 'errors': {}}
+        ret = {'files': {}, 'errors': {}}
         for archive in self.archives():
             arc_dir = os.path.dirname(archive)
             archive = os.path.basename(archive)
@@ -174,10 +174,12 @@ class SaltSupportModule(SaltSupport):
                 archive = os.path.join(arc_dir, archive)
                 try:
                     os.unlink(archive)
-                    ret['deleted'] += 1
+                    ret['files'][archive] = 'removed'
                 except Exception as err:
                     ret['errors'][archive] = str(err)
-                    ret['failed'] += 1
+                    ret['files'][archive] = 'left'
+
+        return ret
 
         return ret
 

--- a/salt/modules/saltsupport.py
+++ b/salt/modules/saltsupport.py
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 '''
+:codeauthor: :email:`Bo Maryniuk <bo@suse.de>`
+
 Module to run salt-support within Salt.
 '''
 from __future__ import unicode_literals, print_function, absolute_import

--- a/salt/modules/saltsupport.py
+++ b/salt/modules/saltsupport.py
@@ -154,8 +154,6 @@ class SaltSupportModule(SaltSupport):
 
         return archives[max(archives)]
 
-
-
     @salt.utils.decorators.external
     def delete_archives(self, *archives):
         '''

--- a/salt/modules/saltsupport.py
+++ b/salt/modules/saltsupport.py
@@ -15,7 +15,6 @@ import sys
 import time
 import logging
 
-
 __virtualname__ = 'support'
 log = logging.getLogger(__name__)
 

--- a/salt/modules/saltsupport.py
+++ b/salt/modules/saltsupport.py
@@ -52,12 +52,24 @@ class SaltSupportModule(SaltSupport):
         '''
         return __opts__
 
+    def _get_default_archive_name(self):
     def run(self):
         '''
+        Create default archive name.
 
         :return:
         '''
-        return 'stub'
+        host = None
+        for grain in ['fqdn', 'host', 'localhost', 'nodename']:
+            host = __grains__.get(grain)
+            if host:
+                break
+        if not host:
+            host = 'localhost'
+
+        return os.path.join(tempfile.gettempdir(),
+                            '{hostname}-support-{date}-{time}.bz2'.format(
+                                hostname=host, date=time.strftime('%Y%m%d'), time=time.strftime('%H%M%S')))
 
 
 def __virtual__():

--- a/salt/modules/saltsupport.py
+++ b/salt/modules/saltsupport.py
@@ -207,7 +207,7 @@ class SaltSupportModule(SaltSupport):
 
     @salt.utils.decorators.depends('rsync')
     @salt.utils.decorators.external
-    def sync(self, group, name=None, host=None, location=None, cleanup=False, all=False):
+    def sync(self, group, name=None, host=None, location=None, move=False, all=False):
         '''
         Sync the latest archive to the host on given location.
 
@@ -224,6 +224,9 @@ class SaltSupportModule(SaltSupport):
         :param name: name of the archive. Latest, if not specified.
         :param host: name of the destination host for rsync. Default is master, if not specified.
         :param location: local destination directory, default temporary if not specified
+        :param move: move archive file[s]. Default is False.
+        :param all: work with all available archives. Default is False (i.e. latest available)
+
         :return:
         '''
         import salt.utils.dictupdate

--- a/salt/modules/saltsupport.py
+++ b/salt/modules/saltsupport.py
@@ -19,10 +19,6 @@ Module to run salt-support within Salt.
 '''
 from __future__ import unicode_literals, print_function, absolute_import
 
-from salt.cli.support.collector import SaltSupport, SupportDataCollector
-
-import salt.utils.decorators
-import salt.cli.support
 import tempfile
 import re
 import os
@@ -30,6 +26,11 @@ import sys
 import time
 import datetime
 import logging
+
+import salt.cli.support.intfunc
+import salt.utils.decorators
+import salt.cli.support
+from salt.cli.support.collector import SaltSupport, SupportDataCollector
 
 __virtualname__ = 'support'
 log = logging.getLogger(__name__)

--- a/salt/modules/saltsupport.py
+++ b/salt/modules/saltsupport.py
@@ -121,4 +121,28 @@ def run():
     :return:
     '''
     support = SaltSupportModule()
+
+    def _set_function(obj):
+        '''
+        Create a Salt function for the SaltSupport class.
+        '''
+        def _cmd(*args, **kw):
+            '''
+            Call support method as a function from the Salt.
+            '''
+            kwargs = {}
+            if kw.get('__pub_arg'):
+                for _kw in kw.get('__pub_arg', []):
+                    if isinstance(_kw, dict):
+                        kwargs = _kw
+                        break
+
+            return obj(*args, **kwargs)
+        _cmd.__doc__ = obj.__doc__
+        return _cmd
+
+    for method_name, obj in support.get_exportable_methods():
+        setattr(sys.modules[__name__], method_name, _set_function(obj))
+
+    return True
     return support.run()

--- a/salt/modules/saltsupport.py
+++ b/salt/modules/saltsupport.py
@@ -5,8 +5,10 @@ Module to run salt-support within Salt
 from __future__ import unicode_literals, print_function, absolute_import
 
 from salt.cli.support.collector import SaltSupport, SupportDataCollector
+import salt.utils.decorators
 import tempfile
 import os
+import sys
 import time
 import logging
 

--- a/salt/modules/saltsupport.py
+++ b/salt/modules/saltsupport.py
@@ -141,15 +141,15 @@ class SaltSupportModule(SaltSupport):
         return ret
 
     @salt.utils.decorators.external
-    def run(self, profile='default', archive=None, output='nested'):
+    def run(self, profile='default', pillar=None, archive=None, output='nested'):
         '''
         Something
         '''
         self.out = LogCollector()
-        self.collector = SupportDataCollector(archive or self._get_archive_name(archname=archive), output)
 
+        self.collector = SupportDataCollector(archive or self._get_archive_name(archname=archive), output)
         self.collector.open()
-        self.collect_local_data(profile=profile)
+        self.collect_local_data(profile=profile, profile_source=__pillar__.get(pillar))
         self.collect_internal_data()
         self.collector.close()
 

--- a/salt/modules/saltsupport.py
+++ b/salt/modules/saltsupport.py
@@ -200,8 +200,15 @@ class SaltSupportModule(SaltSupport):
                 if len(line) == 2:
                     stats[line[0].lower().replace(' ', '_')] = line[1]
             cnt['transfer'] = stats
-            for section in ['stderr', 'stdout']:
-                del cnt[section]
+            del cnt['stdout']
+
+        # Remove empty
+        empty_sections = []
+        for section in cnt:
+            if not cnt[section]:
+                empty_sections.append(section)
+        for section in empty_sections:
+            del cnt[section]
 
         return cnt
 

--- a/salt/modules/saltsupport.py
+++ b/salt/modules/saltsupport.py
@@ -13,6 +13,7 @@ import time
 import logging
 
 
+__virtualname__ = 'support'
 log = logging.getLogger(__name__)
 
 
@@ -124,4 +125,4 @@ def __virtual__():
         if getattr(obj, 'external', False):
             setattr(sys.modules[__name__], m_name, _set_function(obj))
 
-    return True
+    return __virtualname__

--- a/salt/modules/saltsupport.py
+++ b/salt/modules/saltsupport.py
@@ -5,7 +5,9 @@ Module to run salt-support within Salt
 from __future__ import unicode_literals, print_function, absolute_import
 
 from salt.cli.support.collector import SaltSupport, SupportDataCollector
+
 import salt.utils.decorators
+import salt.cli.support
 import tempfile
 import os
 import sys
@@ -82,6 +84,17 @@ class SaltSupportModule(SaltSupport):
                                 hostname=host, date=time.strftime('%Y%m%d'), time=time.strftime('%H%M%S')))
 
     @salt.utils.decorators.external
+    def profiles(self):
+        '''
+        Get list of profiles.
+
+        :return:
+        '''
+        return {
+            'standard': salt.cli.support.get_profiles(self.config),
+            'custom': [],
+        }
+
     def run(self, archive=None, output='nested'):
         '''
         Something

--- a/salt/modules/saltsupport.py
+++ b/salt/modules/saltsupport.py
@@ -4,7 +4,10 @@ Module to run salt-support within Salt
 '''
 from __future__ import unicode_literals, print_function, absolute_import
 
-from salt.cli.support.collector import SaltSupport
+from salt.cli.support.collector import SaltSupport, SupportDataCollector
+import tempfile
+import os
+import time
 import logging
 
 

--- a/salt/modules/saltsupport.py
+++ b/salt/modules/saltsupport.py
@@ -9,6 +9,7 @@ from salt.cli.support.collector import SaltSupport, SupportDataCollector
 import salt.utils.decorators
 import salt.cli.support
 import tempfile
+import re
 import os
 import sys
 import time
@@ -66,12 +67,13 @@ class SaltSupportModule(SaltSupport):
         '''
         return __opts__
 
-    def _get_default_archive_name(self):
+    def _get_archive_name(self, archname=None):
         '''
         Create default archive name.
 
         :return:
         '''
+        archname = re.sub('[^a-z0-9]', '', (archname or '').lower()) or 'support'
         for grain in ['fqdn', 'host', 'localhost', 'nodename']:
             host = __grains__.get(grain)
             if host:
@@ -80,8 +82,10 @@ class SaltSupportModule(SaltSupport):
             host = 'localhost'
 
         return os.path.join(tempfile.gettempdir(),
-                            '{hostname}-support-{date}-{time}.bz2'.format(
-                                hostname=host, date=time.strftime('%Y%m%d'), time=time.strftime('%H%M%S')))
+                            '{hostname}-{archname}-{date}-{time}.bz2'.format(archname=archname,
+                                                                             hostname=host,
+                                                                             date=time.strftime('%Y%m%d'),
+                                                                             time=time.strftime('%H%M%S')))
 
     @salt.utils.decorators.external
     def profiles(self):

--- a/salt/modules/saltsupport.py
+++ b/salt/modules/saltsupport.py
@@ -19,6 +19,8 @@
 
 Module to run salt-support within Salt.
 '''
+# pylint: disable=W0231,W0221
+
 from __future__ import unicode_literals, print_function, absolute_import
 
 import tempfile
@@ -145,7 +147,7 @@ class SaltSupportModule(SaltSupport):
         arc_files = []
         tmpdir = tempfile.gettempdir()
         for filename in os.listdir(tmpdir):
-            mtc = re.match('\w+-\w+-\d+-\d+\.bz2', filename)
+            mtc = re.match(r'\w+-\w+-\d+-\d+\.bz2', filename)
             if mtc and len(filename) == mtc.span()[-1]:
                 arc_files.append(os.path.join(tmpdir, filename))
 

--- a/salt/modules/saltsupport.py
+++ b/salt/modules/saltsupport.py
@@ -56,7 +56,6 @@ class SaltSupportModule(SaltSupport):
         return __opts__
 
     def _get_default_archive_name(self):
-    def run(self):
         '''
         Create default archive name.
 
@@ -73,6 +72,25 @@ class SaltSupportModule(SaltSupport):
         return os.path.join(tempfile.gettempdir(),
                             '{hostname}-support-{date}-{time}.bz2'.format(
                                 hostname=host, date=time.strftime('%Y%m%d'), time=time.strftime('%H%M%S')))
+
+    def run(self, archive=None, output='nested'):
+        '''
+
+        :return:
+        '''
+        self.config = __opts__
+        self.config['support_profile'] = 'default'
+        self.out = LogCollector()
+        self.collector = SupportDataCollector(archive or self._get_default_archive_name(), output)
+
+        self.collector.open()
+        self.collect_local_data()
+        #self.collect_internal_data()
+        #self.collect_targets_data()
+        self.collector.close()
+
+        return {'archive': self.collector.archive_path,
+                'messages': self.out.messages}
 
 
 def __virtual__():

--- a/salt/modules/saltsupport.py
+++ b/salt/modules/saltsupport.py
@@ -43,25 +43,32 @@ class LogCollector(object):
     ERROR = 'error'
 
     def __init__(self):
-        self.messages = []
+        self.messages = {
+            self.INFO: [],
+            self.WARNING: [],
+            self.ERROR: [],
+        }
 
     def msg(self, message, *args, **kwargs):
-        self.messages.append({self.INFO: message})
+        title = kwargs.get('title')
+        if title:
+            message = '{}: {}'.format(title, message)
+        self.messages[self.INFO].append(message)
 
     def info(self, message, *args, **kwargs):
         self.msg(message)
 
     def warning(self, message, *args, **kwargs):
-        self.messages.append({self.WARNING: message})
+        self.messages[self.WARNING].append(message)
 
     def error(self, message, *args, **kwargs):
-        self.messages.append({self.ERROR: message})
+        self.messages[self.ERROR].append(message)
 
     def put(self, message, *args, **kwargs):
-        self.messages.append({self.INFO: message})
+        self.messages[self.INFO].append(message)
 
-    def highlight(self, message, *args, **kwargs):
-        self.msg(message)
+    def highlight(self, message, *values, **kwargs):
+        self.msg(message.format(*values))
 
 
 class SaltSupportModule(SaltSupport):

--- a/salt/modules/saltsupport.py
+++ b/salt/modules/saltsupport.py
@@ -244,7 +244,8 @@ class SaltSupportModule(SaltSupport):
         processed_archives = []
         src_uri = uri = None
 
-        for name in [name] if name else self.archives() if all else [self.last_archive()]:
+        last_arc = self.last_archive()
+        for name in [name] if name else self.archives() if all else [last_arc] if last_arc else []:
             err = None
             if not name:
                 err = 'No support archive has been defined.'

--- a/salt/modules/saltsupport.py
+++ b/salt/modules/saltsupport.py
@@ -28,6 +28,7 @@ import re
 import os
 import sys
 import time
+import datetime
 import logging
 
 __virtualname__ = 'support'
@@ -42,30 +43,35 @@ class LogCollector(object):
     WARNING = 'warning'
     ERROR = 'error'
 
+    class MessagesList(list):
+        def append(self, obj):
+            list.append(self, '{} - {}'.format(datetime.datetime.utcnow().strftime('%T.%f')[:-3], obj))
+        __call__ = append
+
     def __init__(self):
         self.messages = {
-            self.INFO: [],
-            self.WARNING: [],
-            self.ERROR: [],
+            self.INFO: self.MessagesList(),
+            self.WARNING: self.MessagesList(),
+            self.ERROR: self.MessagesList(),
         }
 
     def msg(self, message, *args, **kwargs):
         title = kwargs.get('title')
         if title:
             message = '{}: {}'.format(title, message)
-        self.messages[self.INFO].append(message)
+        self.messages[self.INFO](message)
 
     def info(self, message, *args, **kwargs):
         self.msg(message)
 
     def warning(self, message, *args, **kwargs):
-        self.messages[self.WARNING].append(message)
+        self.messages[self.WARNING](message)
 
     def error(self, message, *args, **kwargs):
-        self.messages[self.ERROR].append(message)
+        self.messages[self.ERROR](message)
 
     def put(self, message, *args, **kwargs):
-        self.messages[self.INFO].append(message)
+        self.messages[self.INFO](message)
 
     def highlight(self, message, *values, **kwargs):
         self.msg(message.format(*values))

--- a/salt/modules/saltsupport.py
+++ b/salt/modules/saltsupport.py
@@ -289,7 +289,27 @@ class SaltSupportModule(SaltSupport):
     @salt.utils.decorators.external
     def run(self, profile='default', pillar=None, archive=None, output='nested'):
         '''
-        Something
+        Run Salt Support on the minion.
+
+        profile
+            Set available profile name. Default is "default".
+
+        pillar
+            Set available profile from the pillars.
+
+        archive
+            Override archive name. Default is "support". This results to "hostname-support-YYYYMMDD-hhmmss.bz2".
+
+        output
+            Change the default outputter. Default is "nested".
+
+        CLI Example:
+
+        .. code-block:: bash
+
+            salt '*' support.run
+            salt '*' support.run profile=network
+            salt '*' support.run pillar=something_special
         '''
         class outputswitch(object):
             '''

--- a/salt/modules/saltsupport.py
+++ b/salt/modules/saltsupport.py
@@ -46,25 +46,7 @@ class LogCollector(object):
         self.msg(message)
 
 
-class _Util(object):  # This might get moved elsewhere in a future.
-    '''
-    Utility class.
-    '''
-    def get_exportable_methods(self):
-        '''
-        Get exportable methods that are not marked as internal in __doc__.
-        :return:
-        '''
-        exportable = []
-        for obj_name in dir(self):
-            obj = getattr(self, obj_name)
-            if getattr(obj, 'external', False):
-                exportable.append((obj_name, obj))
-
-        return exportable
-
-
-class SaltSupportModule(SaltSupport, _Util):
+class SaltSupportModule(SaltSupport):
     '''
     Salt Support module class.
     '''
@@ -137,7 +119,9 @@ def __virtual__():
         _cmd.__doc__ = obj.__doc__
         return _cmd
 
-    for method_name, obj in support.get_exportable_methods():
-        setattr(sys.modules[__name__], method_name, _set_function(obj))
+    for m_name in dir(support):
+        obj = getattr(support, m_name)
+        if getattr(obj, 'external', False):
+            setattr(sys.modules[__name__], m_name, _set_function(obj))
 
     return True

--- a/salt/modules/saltsupport.py
+++ b/salt/modules/saltsupport.py
@@ -152,7 +152,7 @@ class SaltSupportModule(SaltSupport):
         for archive in self.archives():
             archives[int(archive.split('.')[0].split('-')[-1])] = archive
 
-        return archives[max(archives)]
+        return archives and archives[max(archives)] or None
 
     @salt.utils.decorators.external
     def delete_archives(self, *archives):

--- a/salt/modules/saltsupport.py
+++ b/salt/modules/saltsupport.py
@@ -207,7 +207,7 @@ class SaltSupportModule(SaltSupport):
         # Remove empty
         empty_sections = []
         for section in cnt:
-            if not cnt[section]:
+            if not cnt[section] and section != 'retcode':
                 empty_sections.append(section)
         for section in empty_sections:
             del cnt[section]

--- a/salt/modules/saltsupport.py
+++ b/salt/modules/saltsupport.py
@@ -31,11 +31,13 @@ import salt.cli.support.intfunc
 import salt.utils.decorators
 import salt.utils.path
 import salt.cli.support
-from salt.cli.support.collector import SaltSupport, SupportDataCollector
 import salt.exceptions
 import salt.utils.stringutils
 import salt.defaults.exitcodes
 import salt.utils.odict
+import salt.utils.dictupdate
+
+from salt.cli.support.collector import SaltSupport, SupportDataCollector
 
 __virtualname__ = 'support'
 log = logging.getLogger(__name__)
@@ -236,7 +238,6 @@ class SaltSupportModule(SaltSupport):
 
         :return:
         '''
-        import salt.utils.dictupdate
         tfh, tfn = tempfile.mkstemp()
         processed_archives = []
         src_uri = uri = None

--- a/salt/modules/saltsupport.py
+++ b/salt/modules/saltsupport.py
@@ -91,6 +91,7 @@ class SaltSupportModule(SaltSupport):
                             '{hostname}-support-{date}-{time}.bz2'.format(
                                 hostname=host, date=time.strftime('%Y%m%d'), time=time.strftime('%H%M%S')))
 
+    @salt.utils.decorators.external
     def run(self, archive=None, output='nested'):
         '''
 

--- a/salt/modules/saltsupport.py
+++ b/salt/modules/saltsupport.py
@@ -119,9 +119,8 @@ class SaltSupportModule(SaltSupport):
         '''
         Something
         '''
-        #self.config['support_profile'] = profile
         self.out = LogCollector()
-        self.collector = SupportDataCollector(archive or self._get_default_archive_name(), output)
+        self.collector = SupportDataCollector(archive or self._get_archive_name(archname=archive), output)
 
         self.collector.open()
         self.collect_local_data(profile=profile)

--- a/salt/modules/saltsupport.py
+++ b/salt/modules/saltsupport.py
@@ -100,6 +100,21 @@ class SaltSupportModule(SaltSupport):
         }
 
     @salt.utils.decorators.external
+    def archives(self):
+        '''
+        Get list of existing archives.
+        :return:
+        '''
+        arc_files = []
+        tmpdir = tempfile.gettempdir()
+        for filename in os.listdir(tmpdir):
+            mtc = re.match('\w+-\w+-\d+-\d+\.bz2', filename)
+            if mtc and len(filename) == mtc.span()[-1]:
+                arc_files.append(os.path.join(tmpdir, filename))
+
+        return arc_files
+
+    @salt.utils.decorators.external
     def run(self, profile='default', archive=None, output='nested'):
         '''
         Something

--- a/salt/modules/saltsupport.py
+++ b/salt/modules/saltsupport.py
@@ -11,6 +11,36 @@ import logging
 log = logging.getLogger(__name__)
 
 
+class LogCollector(object):
+    '''
+    Output collector.
+    '''
+    INFO = 'info'
+    WARNING = 'warning'
+    ERROR = 'error'
+
+    def __init__(self):
+        self.messages = []
+
+    def msg(self, message, *args, **kwargs):
+        self.messages.append({self.INFO: message})
+
+    def info(self, message, *args, **kwargs):
+        self.msg(message)
+
+    def warning(self, message, *args, **kwargs):
+        self.messages.append({self.WARNING: message})
+
+    def error(self, message, *args, **kwargs):
+        self.messages.append({self.ERROR: message})
+
+    def put(self, message, *args, **kwargs):
+        self.messages.append({self.INFO: message})
+
+    def highlight(self, message, *args, **kwargs):
+        self.msg(message)
+
+
 class SaltSupportModule(SaltSupport):
     '''
     Salt Support module class.

--- a/salt/modules/saltsupport.py
+++ b/salt/modules/saltsupport.py
@@ -85,8 +85,7 @@ class SaltSupportModule(SaltSupport):
 
         self.collector.open()
         self.collect_local_data()
-        #self.collect_internal_data()
-        #self.collect_targets_data()
+        self.collect_internal_data()
         self.collector.close()
 
         return {'archive': self.collector.archive_path,

--- a/salt/modules/saltsupport.py
+++ b/salt/modules/saltsupport.py
@@ -247,7 +247,16 @@ class SaltSupportModule(SaltSupport):
         src_uri = uri = None
 
         last_arc = self.last_archive()
-        for name in [name] if name else self.archives() if all else [last_arc] if last_arc else []:
+        if name:
+            archives = [name]
+        elif all:
+            archives = self.archives()
+        elif last_arc:
+            archives = [last_arc]
+        else:
+            archives = []
+
+        for name in archives:
             err = None
             if not name:
                 err = 'No support archive has been defined.'

--- a/salt/modules/saltsupport.py
+++ b/salt/modules/saltsupport.py
@@ -44,6 +44,24 @@ class LogCollector(object):
         self.msg(message)
 
 
+class _Util(object):  # This might get moved elsewhere in a future.
+    '''
+    Utility class.
+    '''
+    def get_exportable_methods(self):
+        '''
+        Get exportable methods that are not marked as internal in __doc__.
+        :return:
+        '''
+        exportable = []
+        for obj_name in dir(self):
+            obj = getattr(self, obj_name)
+            if getattr(obj, 'external', False):
+                exportable.append((obj_name, obj))
+
+        return exportable
+
+
 class SaltSupportModule(SaltSupport):
     '''
     Salt Support module class.

--- a/salt/modules/saltsupport.py
+++ b/salt/modules/saltsupport.py
@@ -142,18 +142,15 @@ def __virtual__():
         '''
         Create a Salt function for the SaltSupport class.
         '''
-        def _cmd(*args, **kw):
+        def _cmd(*args, **kwargs):
             '''
             Call support method as a function from the Salt.
             '''
-            kwargs = {}
-            if kw.get('__pub_arg'):
-                for _kw in kw.get('__pub_arg', []):
-                    if isinstance(_kw, dict):
-                        kwargs = _kw
-                        break
-
-            return obj(*args, **kwargs)
+            _kwargs = {}
+            for kw in kwargs:
+                if not kw.startswith('__'):
+                    _kwargs[kw] = kwargs[kw]
+            return obj(*args, **_kwargs)
         _cmd.__doc__ = obj.__doc__
         return _cmd
 

--- a/salt/modules/saltsupport.py
+++ b/salt/modules/saltsupport.py
@@ -143,6 +143,20 @@ class SaltSupportModule(SaltSupport):
         return arc_files
 
     @salt.utils.decorators.external
+    def last_archive(self):
+        '''
+        Get the last available archive
+        :return:
+        '''
+        archives = {}
+        for archive in self.archives():
+            archives[int(archive.split('.')[0].split('-')[-1])] = archive
+
+        return archives[max(archives)]
+
+
+
+    @salt.utils.decorators.external
     def delete_archives(self, *archives):
         '''
         Delete archives

--- a/salt/state.py
+++ b/salt/state.py
@@ -1942,7 +1942,7 @@ class State(object):
                         ret = self.call_parallel(cdata, low)
                     else:
                         self.format_slots(cdata)
-                        if cdata['full'].endswith('.__call__'):
+                        if cdata['full'].split('.')[-1] == '__call__':
                             # __call__ requires OrderedDict to preserve state order
                             # kwargs are also invalid overall
                             ret = self.states[cdata['full']](cdata['args'], module=None, state=cdata['kwargs'])

--- a/salt/state.py
+++ b/salt/state.py
@@ -2796,10 +2796,31 @@ class State(object):
         running.update(errors)
         return running
 
+    def inject_default_call(self, high):
+        '''
+        Sets .call function to a state, if not there.
+
+        :param high:
+        :return:
+        '''
+        for chunk in high:
+            state = high[chunk]
+            for state_ref in state:
+                needs_default = True
+                for argset in state[state_ref]:
+                    if isinstance(argset, six.string_types):
+                        needs_default = False
+                        break
+                if needs_default:
+                    order = state[state_ref].pop(-1)
+                    state[state_ref].append('__call__')
+                    state[state_ref].append(order)
+
     def call_high(self, high, orchestration_jid=None):
         '''
         Process a high data call and ensure the defined states.
         '''
+        self.inject_default_call(high)
         errors = []
         # If there is extension data reconcile it
         high, ext_errors = self.reconcile_extend(high)

--- a/salt/states/saltsupport.py
+++ b/salt/states/saltsupport.py
@@ -169,6 +169,9 @@ class SaltSupportState(object):
         return ret
 
 
+_support_state = SaltSupportState()
+
+
 def __call__(*args, **kwargs):
     '''
     SLS single-ID syntax processing.
@@ -184,12 +187,21 @@ def __call__(*args, **kwargs):
     :param kwargs:
     :return:
     '''
-    return SaltSupportState()(kwargs.get('state', {}))
+    return _support_state(kwargs.get('state', {}))
+
+
+def taken(name, profile='default', pillar=None, archive=None, output='nested'):
+    return _support_state.taken(profile=profile, pillar=pillar,
+                                archive=archive, output=output)
+
+
+def collected(name, group, filename=None, host=None, location=None, move=True, all=True):
+    return _support_state.collected(group=group, filename=filename,
+                                    host=host, location=location, move=move, all=all)
 
 
 def __virtual__():
     '''
     Salt Support state
     '''
-    setattr(sys.modules[__name__], '__call__', lambda **kwargs: SaltSupportState()(**kwargs))   # pylint: disable=W0108
     return __virtualname__

--- a/salt/states/saltsupport.py
+++ b/salt/states/saltsupport.py
@@ -49,38 +49,97 @@ log = logging.getLogger(__name__)
 __virtualname__ = 'support'
 
 
-def taken(name, profile='default', pillar=None, archive=None, output='nested'):
+class SaltSupportState(object):
     '''
-    Takes minion support config data.
-
-    :param profile:
-    :param pillar:
-    :param archive:
-    :param output:
-    :return:
+    Salt-support.
     '''
-    ret = {
-        'name': 'support.taken',
-        'changes': {},
-        'result': True,
-    }
+    def get_kwargs(self, data):
+        kwargs = {}
+        for keyset in data:
+            kwargs.update(keyset)
 
-    result = __salt__['support.run'](profile=profile, pillar=pillar, archive=archive, output=output)
-    if result.get('archive'):
-        ret['comment'] = 'Information about this system has been saved to {} file.'.format(result['archive'])
-        ret['changes']['archive'] = result['archive']
-        ret['changes']['messages'] = {}
-        for key in ['info', 'error', 'warning']:
-            if result.get('messages', {}).get(key):
-                ret['changes']['messages'][key] = result['messages'][key]
-    else:
-        ret['comment'] = ''
+        return kwargs
 
-    return ret
+    def __call__(self, *args, **kwargs):
+        '''
+        Call support.
+
+        :param args:
+        :param kwargs:
+        :return:
+        '''
+        ret = {
+            'name': kwargs.pop('name'),
+            'changes': {},
+            'result': True,
+            'comment': 'args: ' + str(args) + '\nkwargs: ' + str(kwargs),
+        }
+
+        out = {}
+        for ref_func, ref_kwargs in kwargs.items():
+            out[ref_func] = getattr(self, ref_func)(**self.get_kwargs(ref_kwargs))
+        ret['changes'] = out
+
+        return ret
+
+    def collected(self, group, filename=None, host=None, location=None, move=True, all=True):
+        '''
+        Sync archives to a central place.
+
+        :param name:
+        :param group:
+        :param filename:
+        :param host:
+        :param location:
+        :param move:
+        :param all:
+        :return:
+        '''
+        ret = {
+            'name': 'support.collected',
+            'changes': {},
+            'result': True,
+            'comment': '',
+        }
+
+        result = __salt__['support.sync'](group, name=filename, host=host, location=location, move=move, all=all)
+        ret['changes'] = result
+
+        return ret
+
+    def taken(self, profile='default', pillar=None, archive=None, output='nested'):
+        '''
+        Takes minion support config data.
+
+        :param profile:
+        :param pillar:
+        :param archive:
+        :param output:
+        :return:
+        '''
+        ret = {
+            'name': 'support.taken',
+            'changes': {},
+            'result': True,
+        }
+
+        result = __salt__['support.run'](profile=profile, pillar=pillar, archive=archive, output=output)
+        if result.get('archive'):
+            ret['comment'] = 'Information about this system has been saved to {} file.'.format(result['archive'])
+            ret['changes']['archive'] = result['archive']
+            ret['changes']['messages'] = {}
+            for key in ['info', 'error', 'warning']:
+                if result.get('messages', {}).get(key):
+                    ret['changes']['messages'][key] = result['messages'][key]
+        else:
+            ret['comment'] = ''
+
+        return ret
 
 
 def __virtual__():
     '''
     Salt Support state
     '''
+    setattr(sys.modules[__name__], 'call', lambda **kwargs: SaltSupportState()(**kwargs))   # pylint: disable=W0108
     return __virtualname__

--- a/salt/states/saltsupport.py
+++ b/salt/states/saltsupport.py
@@ -72,7 +72,7 @@ class SaltSupportState(object):
             'name': kwargs.pop('name'),
             'changes': {},
             'result': True,
-            'comment': 'args: ' + str(args) + '\nkwargs: ' + str(kwargs),
+            'comment': '',
         }
 
         out = {}
@@ -141,5 +141,5 @@ def __virtual__():
     '''
     Salt Support state
     '''
-    setattr(sys.modules[__name__], 'call', lambda **kwargs: SaltSupportState()(**kwargs))   # pylint: disable=W0108
+    setattr(sys.modules[__name__], '__call__', lambda **kwargs: SaltSupportState()(**kwargs))   # pylint: disable=W0108
     return __virtualname__

--- a/salt/states/saltsupport.py
+++ b/salt/states/saltsupport.py
@@ -42,8 +42,6 @@ import sys
 
 # Import salt modules
 import salt.fileclient
-import salt.ext.six as six
-from salt.utils.decorators import depends
 import salt.utils.decorators.path
 import salt.exceptions
 

--- a/salt/states/saltsupport.py
+++ b/salt/states/saltsupport.py
@@ -102,8 +102,11 @@ class SaltSupportState(object):
             destination = os.path.join(location, group)
             if os.path.exists(destination) and not os.path.isdir(destination):
                 raise salt.exceptions.SaltException('Destination "{}" should be directory!'.format(destination))
-            os.makedirs(destination, exist_ok=True)
-            log.debug('Created destination directory for archives: %s', destination)
+            if not os.path.exists(destination):
+                os.makedirs(destination)
+                log.debug('Created destination directory for archives: %s', destination)
+            else:
+                log.debug('Archives destination directory %s already exists', destination)
         except OSError as err:
             log.error(err)
 

--- a/salt/states/saltsupport.py
+++ b/salt/states/saltsupport.py
@@ -44,6 +44,7 @@ import salt.fileclient
 import salt.ext.six as six
 from salt.utils.decorators import depends
 import salt.utils.decorators.path
+import salt.exceptions
 
 log = logging.getLogger(__name__)
 __virtualname__ = 'support'
@@ -68,6 +69,7 @@ class SaltSupportState(object):
         :param kwargs:
         :return:
         '''
+        allowed_functions = ['collected', 'taken']
         ret = {
             'name': kwargs.pop('name'),
             'changes': {},
@@ -77,6 +79,8 @@ class SaltSupportState(object):
 
         out = {}
         for ref_func, ref_kwargs in kwargs.items():
+            if ref_func not in allowed_functions:
+                raise salt.exceptions.SaltInvocationError('Function {} is not found'.format(ref_func))
             out[ref_func] = getattr(self, ref_func)(**self.get_kwargs(ref_kwargs))
         ret['changes'] = out
 

--- a/salt/states/saltsupport.py
+++ b/salt/states/saltsupport.py
@@ -37,6 +37,7 @@ State to collect support data from the systems:
 from __future__ import absolute_import, print_function, unicode_literals
 import logging
 import os
+import tempfile
 import sys
 
 # Import salt modules
@@ -86,6 +87,20 @@ class SaltSupportState(object):
 
         return ret
 
+    def check_destination(self, location, group):
+        '''
+        Check destination for the archives.
+        :return:
+        '''
+        # Pre-create destination, since rsync will
+        # put one file named as group
+        try:
+            destination = os.path.join(location, group)
+            os.makedirs(destination, exist_ok=True)
+            log.debug('Created destination directory for archives: %s', destination)
+        except OSError as err:
+            log.error(err)
+
     def collected(self, group, filename=None, host=None, location=None, move=True, all=True):
         '''
         Sync archives to a central place.
@@ -105,7 +120,8 @@ class SaltSupportState(object):
             'result': True,
             'comment': '',
         }
-
+        location = location or tempfile.gettempdir()
+        self.check_destination(location, group)
         result = __salt__['support.sync'](group, name=filename, host=host, location=location, move=move, all=all)
         ret['changes'] = result
 

--- a/salt/states/saltsupport.py
+++ b/salt/states/saltsupport.py
@@ -38,7 +38,6 @@ from __future__ import absolute_import, print_function, unicode_literals
 import logging
 import os
 import tempfile
-import sys
 
 # Import salt modules
 import salt.fileclient

--- a/salt/states/saltsupport.py
+++ b/salt/states/saltsupport.py
@@ -1,0 +1,86 @@
+# -*- coding: utf-8 -*-
+#
+# Author: Bo Maryniuk <bo@suse.de>
+#
+# Copyright 2018 SUSE LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+r'''
+:codeauthor: :email:`Bo Maryniuk <bo@suse.de>`
+
+Execution of Salt Support from within states
+============================================
+
+State to collect support data from the systems:
+
+.. code-block:: yaml
+
+    examine_my_systems:
+      support.taken:
+        - profile: default
+
+      support.collected:
+        - group: somewhere
+        - move: true
+
+'''
+from __future__ import absolute_import, print_function, unicode_literals
+import logging
+import os
+import sys
+
+# Import salt modules
+import salt.fileclient
+import salt.ext.six as six
+from salt.utils.decorators import depends
+import salt.utils.decorators.path
+
+log = logging.getLogger(__name__)
+__virtualname__ = 'support'
+
+
+def taken(name, profile='default', pillar=None, archive=None, output='nested'):
+    '''
+    Takes minion support config data.
+
+    :param profile:
+    :param pillar:
+    :param archive:
+    :param output:
+    :return:
+    '''
+    ret = {
+        'name': 'support.taken',
+        'changes': {},
+        'result': True,
+    }
+
+    result = __salt__['support.run'](profile=profile, pillar=pillar, archive=archive, output=output)
+    if result.get('archive'):
+        ret['comment'] = 'Information about this system has been saved to {} file.'.format(result['archive'])
+        ret['changes']['archive'] = result['archive']
+        ret['changes']['messages'] = {}
+        for key in ['info', 'error', 'warning']:
+            if result.get('messages', {}).get(key):
+                ret['changes']['messages'][key] = result['messages'][key]
+    else:
+        ret['comment'] = ''
+
+    return ret
+
+
+def __virtual__():
+    '''
+    Salt Support state
+    '''
+    return __virtualname__

--- a/salt/states/saltsupport.py
+++ b/salt/states/saltsupport.py
@@ -169,6 +169,24 @@ class SaltSupportState(object):
         return ret
 
 
+def __call__(*args, **kwargs):
+    '''
+    SLS single-ID syntax processing.
+
+    module:
+        This module reference, equals to sys.modules[__name__]
+
+    state:
+        Compiled state in preserved order. The function supposed to look
+        at first level array of functions.
+
+    :param cdata:
+    :param kwargs:
+    :return:
+    '''
+    return SaltSupportState()(kwargs.get('state', {}))
+
+
 def __virtual__():
     '''
     Salt Support state

--- a/salt/utils/args.py
+++ b/salt/utils/args.py
@@ -19,7 +19,7 @@ import salt.utils.data
 import salt.utils.jid
 import salt.utils.versions
 import salt.utils.yaml
-
+from salt.utils.odict import OrderedDict
 
 if six.PY3:
     KWARG_REGEX = re.compile(r'^([^\d\W][\w.-]*)=(?!=)(.*)$', re.UNICODE)
@@ -417,7 +417,7 @@ def format_call(fun,
     ret = initial_ret is not None and initial_ret or {}
 
     ret['args'] = []
-    ret['kwargs'] = {}
+    ret['kwargs'] = OrderedDict()
 
     aspec = get_function_argspec(fun, is_class_method=is_class_method)
 

--- a/salt/utils/decorators/__init__.py
+++ b/salt/utils/decorators/__init__.py
@@ -665,3 +665,27 @@ def ensure_unicode_args(function):
         else:
             return function(*args, **kwargs)
     return wrapped
+
+
+def external(func):
+    '''
+    Mark function as external.
+
+    :param func:
+    :return:
+    '''
+
+    def f(*args, **kwargs):
+        '''
+        Stub.
+
+        :param args:
+        :param kwargs:
+        :return:
+        '''
+        return func(*args, **kwargs)
+
+    f.external = True
+    f.__doc__ = func.__doc__
+
+    return f

--- a/tests/unit/modules/test_saltsupport.py
+++ b/tests/unit/modules/test_saltsupport.py
@@ -260,6 +260,33 @@ professor: Farnsworth
                          (0, b'\n'), (0, b'two-support-111-111.bz2'), (0, b'\n'),
                          (0, b'three-support-222-222.bz2'), (0, b'\n')]
 
+    @patch('salt.modules.saltsupport.__pillar__', {})
+    def test_run_support(self):
+        '''
+        Test run support
+        :return:
+        '''
+        saltsupport.SupportDataCollector = MagicMock()
+        saltsupport.SupportDataCollector().archive_path = 'dummy'
+        support = saltsupport.SaltSupportModule()
+        support.collect_internal_data = MagicMock()
+        support.collect_local_data = MagicMock()
+        out = support.run()
+
+        for section in ['messages', 'archive']:
+            assert section in out
+        assert out['archive'] == 'dummy'
+        for section in ['warning', 'error', 'info']:
+            assert section in out['messages']
+        ld_call = support.collect_local_data.call_args_list[0][1]
+        assert 'profile' in ld_call
+        assert ld_call['profile'] == 'default'
+        assert 'profile_source' in ld_call
+        assert ld_call['profile_source'] is None
+        assert support.collector.open.call_count == 1
+        assert support.collector.close.call_count == 1
+        assert support.collect_internal_data.call_count == 1
+
 
 @skipIf(not bool(pytest), 'Pytest required')
 @skipIf(NO_MOCK, NO_MOCK_REASON)

--- a/tests/unit/modules/test_saltsupport.py
+++ b/tests/unit/modules/test_saltsupport.py
@@ -69,3 +69,18 @@ class LogCollectorTestCase(TestCase, LoaderModuleMockMixin):
             assert 'info' in out.messages
             assert type(out.messages['info']) == saltsupport.LogCollector.MessagesList
             assert out.messages['info'] == ['00:00:00.000 - {}'.format(msg)]
+    def test_warning_message(self):
+        '''
+        Test set warning message to the log collector.
+
+        :return:
+        '''
+        utcmock = MagicMock()
+        utcmock.utcnow = MagicMock(return_value=datetime.datetime.utcfromtimestamp(0))
+        with patch('datetime.datetime', utcmock):
+            msg = 'Your e-mail is now being delivered by USPS'
+            out = saltsupport.LogCollector()
+            out.warning(msg)
+            assert saltsupport.LogCollector.WARNING in out.messages
+            assert type(out.messages[saltsupport.LogCollector.WARNING]) == saltsupport.LogCollector.MessagesList
+            assert out.messages[saltsupport.LogCollector.WARNING] == ['00:00:00.000 - {}'.format(msg)]

--- a/tests/unit/modules/test_saltsupport.py
+++ b/tests/unit/modules/test_saltsupport.py
@@ -198,6 +198,24 @@ professor: Farnsworth
             support.sync('group-name')
         assert ' Support archive "/mnt/storage/three-support-222-222.bz2" was not found' in str(err)
 
+    @patch('tempfile.mkstemp', MagicMock(return_value=(0, 'dummy')))
+    @patch('os.path.exists', MagicMock(return_value=False))
+    def test_sync_specified_archive_not_found_failure(self):
+        '''
+        Test sync failed when archive was not found (last picked)
+
+        :return:
+        '''
+        support = saltsupport.SaltSupportModule()
+        support.archives = MagicMock(return_value=['/mnt/storage/one-support-000-000.bz2',
+                                                   '/mnt/storage/two-support-111-111.bz2',
+                                                   '/mnt/storage/three-support-222-222.bz2'])
+
+        with pytest.raises(salt.exceptions.SaltInvocationError) as err:
+            support.sync('group-name', name='lost.bz2')
+        assert ' Support archive "lost.bz2" was not found' in str(err)
+
+
 
 @skipIf(not bool(pytest), 'Pytest required')
 @skipIf(NO_MOCK, NO_MOCK_REASON)

--- a/tests/unit/modules/test_saltsupport.py
+++ b/tests/unit/modules/test_saltsupport.py
@@ -70,6 +70,22 @@ class LogCollectorTestCase(TestCase, LoaderModuleMockMixin):
             assert type(out.messages[saltsupport.LogCollector.INFO]) == saltsupport.LogCollector.MessagesList
             assert out.messages[saltsupport.LogCollector.INFO] == ['00:00:00.000 - {}'.format(msg)]
 
+    def test_put_message(self):
+        '''
+        Test put message to the log collector.
+
+        :return:
+        '''
+        utcmock = MagicMock()
+        utcmock.utcnow = MagicMock(return_value=datetime.datetime.utcfromtimestamp(0))
+        with patch('datetime.datetime', utcmock):
+            msg = 'Webmaster kidnapped by evil cult'
+            out = saltsupport.LogCollector()
+            out.put(msg)
+            assert saltsupport.LogCollector.INFO in out.messages
+            assert type(out.messages[saltsupport.LogCollector.INFO]) == saltsupport.LogCollector.MessagesList
+            assert out.messages[saltsupport.LogCollector.INFO] == ['00:00:00.000 - {}'.format(msg)]
+
     def test_warning_message(self):
         '''
         Test set warning message to the log collector.

--- a/tests/unit/modules/test_saltsupport.py
+++ b/tests/unit/modules/test_saltsupport.py
@@ -181,6 +181,22 @@ professor: Farnsworth
             support.sync('group-name')
         assert 'No support archive has been defined' in str(err)
 
+    @patch('tempfile.mkstemp', MagicMock(return_value=(0, 'dummy')))
+    @patch('os.path.exists', MagicMock(return_value=False))
+    def test_sync_last_picked_archive_not_found_failure(self):
+        '''
+        Test sync failed when archive was not found (last picked)
+
+        :return:
+        '''
+        support = saltsupport.SaltSupportModule()
+        support.archives = MagicMock(return_value=['/mnt/storage/one-support-000-000.bz2',
+                                                   '/mnt/storage/two-support-111-111.bz2',
+                                                   '/mnt/storage/three-support-222-222.bz2'])
+
+        with pytest.raises(salt.exceptions.SaltInvocationError) as err:
+            support.sync('group-name')
+        assert ' Support archive "/mnt/storage/three-support-222-222.bz2" was not found' in str(err)
 
 
 @skipIf(not bool(pytest), 'Pytest required')

--- a/tests/unit/modules/test_saltsupport.py
+++ b/tests/unit/modules/test_saltsupport.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 '''
-    :codeauthor: Bo Maryniuk <bo@maryniuk.net>
+    :codeauthor: Bo Maryniuk <bo@suse.de>
 '''
 
 # Import Python libs
@@ -9,8 +9,9 @@ from __future__ import absolute_import, print_function, unicode_literals
 # Import Salt Testing Libs
 from tests.support.mixins import LoaderModuleMockMixin
 from tests.support.unit import TestCase, skipIf
-from tests.support.mock import patch, NO_MOCK, NO_MOCK_REASON
+from tests.support.mock import patch, MagicMock, NO_MOCK, NO_MOCK_REASON
 from salt.modules import saltsupport
+import datetime
 
 try:
     import pytest
@@ -37,3 +38,18 @@ class LogCollectorTestCase(TestCase, LoaderModuleMockMixin):
     def setup_loader_modules(self):
         return {saltsupport: {}}
 
+    def test_msg(self):
+        '''
+        Test set message to the log collector.
+
+        :return:
+        '''
+        utcmock = MagicMock()
+        utcmock.utcnow = MagicMock(return_value=datetime.datetime.utcfromtimestamp(0))
+        with patch('datetime.datetime', utcmock):
+            msg = 'Upgrading /dev/null device'
+            out = saltsupport.LogCollector()
+            out.msg(msg)
+            assert 'info' in out.messages
+            assert type(out.messages['info']) == saltsupport.LogCollector.MessagesList
+            assert out.messages['info'] == ['00:00:00.000 - {}'.format(msg)]

--- a/tests/unit/modules/test_saltsupport.py
+++ b/tests/unit/modules/test_saltsupport.py
@@ -60,6 +60,7 @@ class SaltSupportModuleTestCase(TestCase, LoaderModuleMockMixin):
     def test_profiles_format(self):
         '''
         Test profiles format.
+
         :return:
         '''
         profiles = saltsupport.SaltSupportModule().profiles()
@@ -68,6 +69,23 @@ class SaltSupportModuleTestCase(TestCase, LoaderModuleMockMixin):
         assert 'message' in profiles['standard']
         assert profiles['custom'] == []
         assert profiles['standard']['message'] == 'Feature was not beta tested'
+
+    @patch('tempfile.gettempdir', MagicMock(return_value='/mnt/storage'))
+    @patch('os.listdir', MagicMock(return_value=['one-support-000-000.bz2', 'two-support-111-111.bz2', 'trash.bz2',
+                                                 'hostname-000-000.bz2', 'three-support-wrong222-222.bz2',
+                                                 '000-support-000-000.bz2']))
+    def test_get_existing_archives(self):
+        '''
+        Get list of existing archives.
+
+        :return:
+        '''
+        support = saltsupport.SaltSupportModule()
+        out = support.archives()
+        assert len(out) == 3
+        for name in ['/mnt/storage/one-support-000-000.bz2', '/mnt/storage/two-support-111-111.bz2',
+                     '/mnt/storage/000-support-000-000.bz2']:
+            assert name in out
 
 
 @skipIf(not bool(pytest), 'Pytest required')

--- a/tests/unit/modules/test_saltsupport.py
+++ b/tests/unit/modules/test_saltsupport.py
@@ -85,3 +85,19 @@ class LogCollectorTestCase(TestCase, LoaderModuleMockMixin):
             assert saltsupport.LogCollector.WARNING in out.messages
             assert type(out.messages[saltsupport.LogCollector.WARNING]) == saltsupport.LogCollector.MessagesList
             assert out.messages[saltsupport.LogCollector.WARNING] == ['00:00:00.000 - {}'.format(msg)]
+
+    def test_error_message(self):
+        '''
+        Test set error message to the log collector.
+
+        :return:
+        '''
+        utcmock = MagicMock()
+        utcmock.utcnow = MagicMock(return_value=datetime.datetime.utcfromtimestamp(0))
+        with patch('datetime.datetime', utcmock):
+            msg = 'Learning curve appears to be fractal'
+            out = saltsupport.LogCollector()
+            out.error(msg)
+            assert saltsupport.LogCollector.ERROR in out.messages
+            assert type(out.messages[saltsupport.LogCollector.ERROR]) == saltsupport.LogCollector.MessagesList
+            assert out.messages[saltsupport.LogCollector.ERROR] == ['00:00:00.000 - {}'.format(msg)]

--- a/tests/unit/modules/test_saltsupport.py
+++ b/tests/unit/modules/test_saltsupport.py
@@ -216,6 +216,20 @@ professor: Farnsworth
             support.sync('group-name', name='lost.bz2')
         assert ' Support archive "lost.bz2" was not found' in str(err)
 
+    @patch('tempfile.mkstemp', MagicMock(return_value=(0, 'dummy')))
+    @patch('os.path.exists', MagicMock(return_value=False))
+    @patch('os.close', MagicMock())
+    def test_sync_no_archive_to_transfer_failure(self):
+        '''
+        Test sync failed when no archive was found to transfer
+
+        :return:
+        '''
+        support = saltsupport.SaltSupportModule()
+        support.archives = MagicMock(return_value=[])
+        with pytest.raises(salt.exceptions.SaltInvocationError) as err:
+            support.sync('group-name', all=True)
+        assert 'No archives found to transfer' in str(err)
 
 
 @skipIf(not bool(pytest), 'Pytest required')

--- a/tests/unit/modules/test_saltsupport.py
+++ b/tests/unit/modules/test_saltsupport.py
@@ -267,7 +267,7 @@ professor: Farnsworth
         Test run support
         :return:
         '''
-        saltsupport.SupportDataCollector().archive_path = 'dummy'
+        saltsupport.SupportDataCollector(None, None).archive_path = 'dummy'
         support = saltsupport.SaltSupportModule()
         support.collect_internal_data = MagicMock()
         support.collect_local_data = MagicMock()

--- a/tests/unit/modules/test_saltsupport.py
+++ b/tests/unit/modules/test_saltsupport.py
@@ -39,6 +39,23 @@ class SaltSupportModuleTestCase(TestCase, LoaderModuleMockMixin):
         '''
         assert saltsupport.SaltSupportModule()._get_archive_name() == '/mnt/storage/c-3po-support-000-000.bz2'
 
+    @patch('tempfile.gettempdir', MagicMock(return_value='/mnt/storage'))
+    @patch('salt.modules.saltsupport.__grains__', {'fqdn': 'c-3po'})
+    @patch('time.strftime', MagicMock(return_value='000'))
+    def test_get_custom_archive_name(self):
+        '''
+        Test archive name construction.
+
+        :return:
+        '''
+        support = saltsupport.SaltSupportModule()
+        temp_name = support._get_archive_name(archname='Darth Wader')
+        assert temp_name == '/mnt/storage/c-3po-darthwader-000-000.bz2'
+        temp_name = support._get_archive_name(archname='Яйця з сіллю')
+        assert temp_name == '/mnt/storage/c-3po-support-000-000.bz2'
+        temp_name = support._get_archive_name(archname='!@#$%^&*()Fillip J. Fry')
+        assert temp_name == '/mnt/storage/c-3po-fillipjfry-000-000.bz2'
+
 
 @skipIf(not bool(pytest), 'Pytest required')
 @skipIf(NO_MOCK, NO_MOCK_REASON)

--- a/tests/unit/modules/test_saltsupport.py
+++ b/tests/unit/modules/test_saltsupport.py
@@ -44,7 +44,7 @@ class SaltSupportModuleTestCase(TestCase, LoaderModuleMockMixin):
     @patch('time.strftime', MagicMock(return_value='000'))
     def test_get_custom_archive_name(self):
         '''
-        Test archive name construction.
+        Test get custom archive name.
 
         :return:
         '''

--- a/tests/unit/modules/test_saltsupport.py
+++ b/tests/unit/modules/test_saltsupport.py
@@ -40,7 +40,7 @@ class LogCollectorTestCase(TestCase, LoaderModuleMockMixin):
 
     def test_msg(self):
         '''
-        Test set message to the log collector.
+        Test message to the log collector.
 
         :return:
         '''
@@ -56,7 +56,7 @@ class LogCollectorTestCase(TestCase, LoaderModuleMockMixin):
 
     def test_info_message(self):
         '''
-        Test set info message to the log collector.
+        Test info message to the log collector.
 
         :return:
         '''
@@ -88,7 +88,7 @@ class LogCollectorTestCase(TestCase, LoaderModuleMockMixin):
 
     def test_warning_message(self):
         '''
-        Test set warning message to the log collector.
+        Test warning message to the log collector.
 
         :return:
         '''
@@ -104,7 +104,7 @@ class LogCollectorTestCase(TestCase, LoaderModuleMockMixin):
 
     def test_error_message(self):
         '''
-        Test set error message to the log collector.
+        Test error message to the log collector.
 
         :return:
         '''

--- a/tests/unit/modules/test_saltsupport.py
+++ b/tests/unit/modules/test_saltsupport.py
@@ -50,11 +50,11 @@ class LogCollectorTestCase(TestCase, LoaderModuleMockMixin):
             msg = 'Upgrading /dev/null device'
             out = saltsupport.LogCollector()
             out.msg(msg)
-            assert 'info' in out.messages
-            assert type(out.messages['info']) == saltsupport.LogCollector.MessagesList
-            assert out.messages['info'] == ['00:00:00.000 - {}'.format(msg)]
+            assert saltsupport.LogCollector.INFO in out.messages
+            assert type(out.messages[saltsupport.LogCollector.INFO]) == saltsupport.LogCollector.MessagesList
+            assert out.messages[saltsupport.LogCollector.INFO] == ['00:00:00.000 - {}'.format(msg)]
 
-    def test_info(self):
+    def test_info_message(self):
         '''
         Test set info message to the log collector.
 
@@ -63,12 +63,13 @@ class LogCollectorTestCase(TestCase, LoaderModuleMockMixin):
         utcmock = MagicMock()
         utcmock.utcnow = MagicMock(return_value=datetime.datetime.utcfromtimestamp(0))
         with patch('datetime.datetime', utcmock):
-            msg = 'Upgrading /dev/null device'
+            msg = 'SIMM crosstalk during tectonic stress'
             out = saltsupport.LogCollector()
             out.info(msg)
-            assert 'info' in out.messages
-            assert type(out.messages['info']) == saltsupport.LogCollector.MessagesList
-            assert out.messages['info'] == ['00:00:00.000 - {}'.format(msg)]
+            assert saltsupport.LogCollector.INFO in out.messages
+            assert type(out.messages[saltsupport.LogCollector.INFO]) == saltsupport.LogCollector.MessagesList
+            assert out.messages[saltsupport.LogCollector.INFO] == ['00:00:00.000 - {}'.format(msg)]
+
     def test_warning_message(self):
         '''
         Test set warning message to the log collector.

--- a/tests/unit/modules/test_saltsupport.py
+++ b/tests/unit/modules/test_saltsupport.py
@@ -149,6 +149,23 @@ class SaltSupportModuleTestCase(TestCase, LoaderModuleMockMixin):
         assert ret['errors']['/mnt/storage/one-support-000-000.bz2'] == 'Decreasing electron flux'
         assert ret['errors']['/mnt/storage/two-support-111-111.bz2'] == 'Solar flares interference'
 
+    def test_format_sync_stats(self):
+        '''
+        Test format rsync stats for preserving ordering of the keys
+
+        :return:
+        '''
+        support = saltsupport.SaltSupportModule()
+        stats = '''
+robot: Bender
+cute: Leela
+weird: Zoidberg
+professor: Farnsworth
+        '''
+        f_stats = support.format_sync_stats({'retcode': 0, 'stdout': stats})
+        assert list(f_stats['transfer'].keys()) == ['robot', 'cute', 'weird', 'professor']
+        assert list(f_stats['transfer'].values()) == ['Bender', 'Leela', 'Zoidberg', 'Farnsworth']
+
 
 @skipIf(not bool(pytest), 'Pytest required')
 @skipIf(NO_MOCK, NO_MOCK_REASON)

--- a/tests/unit/modules/test_saltsupport.py
+++ b/tests/unit/modules/test_saltsupport.py
@@ -11,6 +11,7 @@ from tests.support.mixins import LoaderModuleMockMixin
 from tests.support.unit import TestCase, skipIf
 from tests.support.mock import patch, MagicMock, NO_MOCK, NO_MOCK_REASON
 from salt.modules import saltsupport
+import salt.exceptions
 import datetime
 
 try:
@@ -165,6 +166,21 @@ professor: Farnsworth
         f_stats = support.format_sync_stats({'retcode': 0, 'stdout': stats})
         assert list(f_stats['transfer'].keys()) == ['robot', 'cute', 'weird', 'professor']
         assert list(f_stats['transfer'].values()) == ['Bender', 'Leela', 'Zoidberg', 'Farnsworth']
+
+    @patch('tempfile.mkstemp', MagicMock(return_value=(0, 'dummy')))
+    def test_sync_no_archives_failure(self):
+        '''
+        Test sync failed when no archives specified.
+
+        :return:
+        '''
+        support = saltsupport.SaltSupportModule()
+        support.archives = MagicMock(return_value=[])
+
+        with pytest.raises(salt.exceptions.SaltInvocationError) as err:
+            support.sync('group-name')
+        assert 'No support archive has been defined' in str(err)
+
 
 
 @skipIf(not bool(pytest), 'Pytest required')

--- a/tests/unit/modules/test_saltsupport.py
+++ b/tests/unit/modules/test_saltsupport.py
@@ -56,6 +56,19 @@ class SaltSupportModuleTestCase(TestCase, LoaderModuleMockMixin):
         temp_name = support._get_archive_name(archname='!@#$%^&*()Fillip J. Fry')
         assert temp_name == '/mnt/storage/c-3po-fillipjfry-000-000.bz2'
 
+    @patch('salt.cli.support.get_profiles', MagicMock(return_value={'message': 'Feature was not beta tested'}))
+    def test_profiles_format(self):
+        '''
+        Test profiles format.
+        :return:
+        '''
+        profiles = saltsupport.SaltSupportModule().profiles()
+        assert 'custom' in profiles
+        assert 'standard' in profiles
+        assert 'message' in profiles['standard']
+        assert profiles['custom'] == []
+        assert profiles['standard']['message'] == 'Feature was not beta tested'
+
 
 @skipIf(not bool(pytest), 'Pytest required')
 @skipIf(NO_MOCK, NO_MOCK_REASON)

--- a/tests/unit/modules/test_saltsupport.py
+++ b/tests/unit/modules/test_saltsupport.py
@@ -261,12 +261,12 @@ professor: Farnsworth
                          (0, b'three-support-222-222.bz2'), (0, b'\n')]
 
     @patch('salt.modules.saltsupport.__pillar__', {})
+    @patch('salt.modules.saltsupport.SupportDataCollector', MagicMock())
     def test_run_support(self):
         '''
         Test run support
         :return:
         '''
-        saltsupport.SupportDataCollector = MagicMock()
         saltsupport.SupportDataCollector().archive_path = 'dummy'
         support = saltsupport.SaltSupportModule()
         support.collect_internal_data = MagicMock()

--- a/tests/unit/modules/test_saltsupport.py
+++ b/tests/unit/modules/test_saltsupport.py
@@ -101,3 +101,19 @@ class LogCollectorTestCase(TestCase, LoaderModuleMockMixin):
             assert saltsupport.LogCollector.ERROR in out.messages
             assert type(out.messages[saltsupport.LogCollector.ERROR]) == saltsupport.LogCollector.MessagesList
             assert out.messages[saltsupport.LogCollector.ERROR] == ['00:00:00.000 - {}'.format(msg)]
+
+    def test_hl_message(self):
+        '''
+        Test highlighter message to the log collector.
+
+        :return:
+        '''
+        utcmock = MagicMock()
+        utcmock.utcnow = MagicMock(return_value=datetime.datetime.utcfromtimestamp(0))
+        with patch('datetime.datetime', utcmock):
+            out = saltsupport.LogCollector()
+            out.highlight('The {} TTYs became {} TTYs and vice versa', 'real', 'pseudo')
+            assert saltsupport.LogCollector.INFO in out.messages
+            assert type(out.messages[saltsupport.LogCollector.INFO]) == saltsupport.LogCollector.MessagesList
+            assert out.messages[saltsupport.LogCollector.INFO] == ['00:00:00.000 - The real TTYs became '
+                                                                   'pseudo TTYs and vice versa']

--- a/tests/unit/modules/test_saltsupport.py
+++ b/tests/unit/modules/test_saltsupport.py
@@ -168,6 +168,7 @@ professor: Farnsworth
         assert list(f_stats['transfer'].values()) == ['Bender', 'Leela', 'Zoidberg', 'Farnsworth']
 
     @patch('tempfile.mkstemp', MagicMock(return_value=(0, 'dummy')))
+    @patch('os.close', MagicMock())
     def test_sync_no_archives_failure(self):
         '''
         Test sync failed when no archives specified.
@@ -179,7 +180,7 @@ professor: Farnsworth
 
         with pytest.raises(salt.exceptions.SaltInvocationError) as err:
             support.sync('group-name')
-        assert 'No support archive has been defined' in str(err)
+        assert 'No archives found to transfer' in str(err)
 
     @patch('tempfile.mkstemp', MagicMock(return_value=(0, 'dummy')))
     @patch('os.path.exists', MagicMock(return_value=False))

--- a/tests/unit/modules/test_saltsupport.py
+++ b/tests/unit/modules/test_saltsupport.py
@@ -87,6 +87,17 @@ class SaltSupportModuleTestCase(TestCase, LoaderModuleMockMixin):
                      '/mnt/storage/000-support-000-000.bz2']:
             assert name in out
 
+    def test_last_archive(self):
+        '''
+        Get last archive name
+        :return:
+        '''
+        support = saltsupport.SaltSupportModule()
+        support.archives = MagicMock(return_value=['/mnt/storage/one-support-000-000.bz2',
+                                                   '/mnt/storage/two-support-111-111.bz2',
+                                                   '/mnt/storage/three-support-222-222.bz2'])
+        assert support.last_archive() == '/mnt/storage/three-support-222-222.bz2'
+
 
 @skipIf(not bool(pytest), 'Pytest required')
 @skipIf(NO_MOCK, NO_MOCK_REASON)

--- a/tests/unit/modules/test_saltsupport.py
+++ b/tests/unit/modules/test_saltsupport.py
@@ -49,10 +49,10 @@ class LogCollectorTestCase(TestCase, LoaderModuleMockMixin):
         with patch('datetime.datetime', utcmock):
             msg = 'Upgrading /dev/null device'
             out = saltsupport.LogCollector()
-            out.msg(msg)
+            out.msg(msg, title='Here')
             assert saltsupport.LogCollector.INFO in out.messages
             assert type(out.messages[saltsupport.LogCollector.INFO]) == saltsupport.LogCollector.MessagesList
-            assert out.messages[saltsupport.LogCollector.INFO] == ['00:00:00.000 - {}'.format(msg)]
+            assert out.messages[saltsupport.LogCollector.INFO] == ['00:00:00.000 - {0}: {1}'.format('Here', msg)]
 
     def test_info_message(self):
         '''

--- a/tests/unit/modules/test_saltsupport.py
+++ b/tests/unit/modules/test_saltsupport.py
@@ -100,6 +100,27 @@ class SaltSupportModuleTestCase(TestCase, LoaderModuleMockMixin):
                                                    '/mnt/storage/three-support-222-222.bz2'])
         assert support.last_archive() == '/mnt/storage/three-support-222-222.bz2'
 
+    @patch('os.unlink', MagicMock(return_value=True))
+    def test_delete_all_archives_success(self):
+        '''
+        Test delete archives
+        :return:
+        '''
+        support = saltsupport.SaltSupportModule()
+        support.archives = MagicMock(return_value=['/mnt/storage/one-support-000-000.bz2',
+                                                   '/mnt/storage/two-support-111-111.bz2',
+                                                   '/mnt/storage/three-support-222-222.bz2'])
+        ret = support.delete_archives()
+        assert 'files' in ret
+        assert 'errors' in ret
+        assert not bool(ret['errors'])
+        assert bool(ret['files'])
+        assert isinstance(ret['errors'], dict)
+        assert isinstance(ret['files'], dict)
+
+        for arc in support.archives():
+            assert ret['files'][arc] == 'removed'
+
 
 @skipIf(not bool(pytest), 'Pytest required')
 @skipIf(NO_MOCK, NO_MOCK_REASON)

--- a/tests/unit/modules/test_saltsupport.py
+++ b/tests/unit/modules/test_saltsupport.py
@@ -37,7 +37,8 @@ class SaltSupportModuleTestCase(TestCase, LoaderModuleMockMixin):
 
         :return:
         '''
-        assert saltsupport.SaltSupportModule()._get_archive_name() == '/mnt/storage/c-3po-support-000-000.bz2'
+        support = saltsupport.SaltSupportModule()
+        assert support._get_archive_name() == '/mnt/storage/c-3po-support-000-000.bz2'
 
     @patch('tempfile.gettempdir', MagicMock(return_value='/mnt/storage'))
     @patch('salt.modules.saltsupport.__grains__', {'fqdn': 'c-3po'})
@@ -63,7 +64,8 @@ class SaltSupportModuleTestCase(TestCase, LoaderModuleMockMixin):
 
         :return:
         '''
-        profiles = saltsupport.SaltSupportModule().profiles()
+        support = saltsupport.SaltSupportModule()
+        profiles = support.profiles()
         assert 'custom' in profiles
         assert 'standard' in profiles
         assert 'message' in profiles['standard']

--- a/tests/unit/modules/test_saltsupport.py
+++ b/tests/unit/modules/test_saltsupport.py
@@ -53,3 +53,19 @@ class LogCollectorTestCase(TestCase, LoaderModuleMockMixin):
             assert 'info' in out.messages
             assert type(out.messages['info']) == saltsupport.LogCollector.MessagesList
             assert out.messages['info'] == ['00:00:00.000 - {}'.format(msg)]
+
+    def test_info(self):
+        '''
+        Test set info message to the log collector.
+
+        :return:
+        '''
+        utcmock = MagicMock()
+        utcmock.utcnow = MagicMock(return_value=datetime.datetime.utcfromtimestamp(0))
+        with patch('datetime.datetime', utcmock):
+            msg = 'Upgrading /dev/null device'
+            out = saltsupport.LogCollector()
+            out.info(msg)
+            assert 'info' in out.messages
+            assert type(out.messages['info']) == saltsupport.LogCollector.MessagesList
+            assert out.messages['info'] == ['00:00:00.000 - {}'.format(msg)]

--- a/tests/unit/modules/test_saltsupport.py
+++ b/tests/unit/modules/test_saltsupport.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+'''
+    :codeauthor: Bo Maryniuk <bo@maryniuk.net>
+'''
+
+# Import Python libs
+from __future__ import absolute_import, print_function, unicode_literals
+
+# Import Salt Testing Libs
+from tests.support.mixins import LoaderModuleMockMixin
+from tests.support.unit import TestCase, skipIf
+from tests.support.mock import patch, NO_MOCK, NO_MOCK_REASON
+from salt.modules import saltsupport
+
+try:
+    import pytest
+except ImportError:
+    pytest = None
+
+
+@skipIf(not bool(pytest), 'Pytest required')
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class SaltSupportModuleTestCase(TestCase, LoaderModuleMockMixin):
+    '''
+    Test cases for salt.modules.support::SaltSupportModule
+    '''
+    def setup_loader_modules(self):
+        return {saltsupport: {}}
+
+
+@skipIf(not bool(pytest), 'Pytest required')
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class LogCollectorTestCase(TestCase, LoaderModuleMockMixin):
+    '''
+    Test cases for salt.modules.support::LogCollector
+    '''
+    def setup_loader_modules(self):
+        return {saltsupport: {}}
+

--- a/tests/unit/modules/test_saltsupport.py
+++ b/tests/unit/modules/test_saltsupport.py
@@ -28,6 +28,17 @@ class SaltSupportModuleTestCase(TestCase, LoaderModuleMockMixin):
     def setup_loader_modules(self):
         return {saltsupport: {}}
 
+    @patch('tempfile.gettempdir', MagicMock(return_value='/mnt/storage'))
+    @patch('salt.modules.saltsupport.__grains__', {'fqdn': 'c-3po'})
+    @patch('time.strftime', MagicMock(return_value='000'))
+    def test_get_archive_name(self):
+        '''
+        Test archive name construction.
+
+        :return:
+        '''
+        assert saltsupport.SaltSupportModule()._get_archive_name() == '/mnt/storage/c-3po-support-000-000.bz2'
+
 
 @skipIf(not bool(pytest), 'Pytest required')
 @skipIf(NO_MOCK, NO_MOCK_REASON)


### PR DESCRIPTION
### What does this PR do?

- Allows to run `salt-support` command on the Minion remotely and via SaltSSH[1].
- Adds state runner

NOTE: Documentation to Salt Support and module/state usage is coming in a separate doc-only PR.

### General Usage

If you are familiar with the Salt Support feature, you already know that you can just call `salt-support` command in CLI and it will examine your _current_ Salt installed components. Now this is possible to do on remote minions.

- get list of existing archives: `support.archives`
- delete archives: `support.delete_archives` 
- get the last available archive `support.last_archive`
- list available profiles on the minion: `support.profiles`
- Run the support: `support.run`
- Sync the latest archive to the host on given location: `support.sync`

It goes as usual, e.g.: `salt \* support.run profile=network`

### State Usage

Now, if you can collect the support data from the minions that matches your criteria, how about collecting all that data in one central place? In that way you can just examine your entire cluster in just one go:

```yaml
examine_my_systems:
  support:
    - taken:
      - profile: network
      - output: nested

    - collected:
      - group: my-cluster
```

The state above will call support on all the machines you're applying this state collecting Networking data using `network` profile and writing it down using `nested` outputter. Then it will collect it under the `/tmp/my-cluster/` directory.

### Pillars

You can configure your own profile scenario in pillar under `support_config` section and point it out right away from the master. For example:

```yaml
support_config:
  pillar_logfile:  # <-- Point this profile ID!
    - filetree:
        info: Add current logfile, by pillar
        args:
          - /var/log/messages
          - /var/log/syslog
          - {{ salt['config.get']('log_file') }}
```

### Tests written?

Of course. :wink: 

_________________
1. This is still limited to the SaltSSH-copied instance, i.e. no examination of system-installed Salt components.