### PR TITLE
Fix integration.modules.test_decorators for Windows

### DIFF
--- a/salt/utils/decorators/__init__.py
+++ b/salt/utils/decorators/__init__.py
@@ -23,6 +23,10 @@ from salt.log import LOG_LEVELS
 # Import 3rd-party libs
 from salt.ext import six
 
+IS_WINDOWS = False
+if getattr(sys, 'getwindowsversion', False):
+    IS_WINDOWS = True
+
 log = logging.getLogger(__name__)
 
 
@@ -88,11 +92,11 @@ class Depends(object):
         '''
         The decorator is "__call__"d with the function, we take that function
         and determine which module and function name it is to store in the
-        class wide depandancy_dict
+        class wide dependency_dict
         '''
         try:
-            # This inspect call may fail under certain conditions in the loader. Possibly related to
-            # a Python bug here:
+            # This inspect call may fail under certain conditions in the loader.
+            # Possibly related to a Python bug here:
             # http://bugs.python.org/issue17735
             frame = inspect.stack()[1][0]
             # due to missing *.py files under esky we cannot use inspect.getmodule
@@ -112,8 +116,11 @@ class Depends(object):
     def run_command(dependency, mod_name, func_name):
         full_name = '{0}.{1}'.format(mod_name, func_name)
         log.trace('Running \'%s\' for \'%s\'', dependency, full_name)
-        import salt.utils.args
-        args = salt.utils.args.shlex_split(dependency)
+        if IS_WINDOWS:
+            args = salt.utils.args.shlex_split(dependency, posix=False)
+        else:
+            args = salt.utils.args.shlex_split(dependency)
+        log.trace('Command after shlex_split: %s', args)
         proc = subprocess.Popen(args,
                                 shell=False,
                                 stdout=subprocess.PIPE,

--- a/tests/integration/files/file/base/_modules/runtests_decorators.py
+++ b/tests/integration/files/file/base/_modules/runtests_decorators.py
@@ -10,10 +10,14 @@ import salt.utils.decorators
 from tests.support.paths import BASE_FILES
 
 EXIT_CODE_SH = os.path.join(BASE_FILES, 'exit_code.sh')
+EXIT_CODE_CMD = os.path.join(BASE_FILES, 'exit_code.cmd')
 
 
 def _exit_code(code):
-    return '/usr/bin/env sh {0} {1}'.format(EXIT_CODE_SH, code)
+    if os.name == 'nt':
+        return 'cmd /c {0} {1}'.format(EXIT_CODE_CMD, code)
+    else:
+        return '/usr/bin/env sh {0} {1}'.format(EXIT_CODE_SH, code)
 
 
 def _fallbackfunc():

--- a/tests/integration/files/file/base/exit_code.cmd
+++ b/tests/integration/files/file/base/exit_code.cmd
@@ -1,0 +1,3 @@
+@echo off
+if "%1"=="" exit 127
+exit %1


### PR DESCRIPTION
### What does this PR do?
Fixes 5 failing tests in `integration.modules.test_decorators` on Windows

Adds a exit_code.cmd file for Windows
Uses `posix=True` for shlex_split on Windows

### What issues does this PR fix or reference?
found in jenkins testing
## Tests written?
Yes

### Commits signed with GPG?
Yes