### PR TITLE
Fix test mode for mount state if device_name_regex is used.

### DIFF
--- a/salt/states/mount.py
+++ b/salt/states/mount.py
@@ -515,16 +515,16 @@ def mounted(name,
                         if re.match(regex, _device):
                             _device_mismatch_is_ignored = _device
                             break
-                if __opts__['test']:
-                    ret['result'] = None
-                    ret['comment'] = "An umount would have been forced " \
-                                     + "because devices do not match.  Watched: " \
-                                     + device
-                elif _device_mismatch_is_ignored:
+                if _device_mismatch_is_ignored:
                     ret['result'] = True
                     ret['comment'] = "An umount will not be forced " \
                                      + "because device matched device_name_regex: " \
                                      + _device_mismatch_is_ignored
+                elif __opts__['test']:
+                    ret['result'] = None
+                    ret['comment'] = "An umount would have been forced " \
+                                     + "because devices do not match.  Watched: " \
+                                     + device
                 else:
                     ret['changes']['umount'] = "Forced unmount because devices " \
                                                + "don't match. Wanted: " + device


### PR DESCRIPTION
### What does this PR do?

If mount.mounted is used for NFS or ceph-fuse, device_name_regex is
often needed to avoid remounting every time. If run with test=True, Salt
is always telling that it needs to remount while it is not remounting if
run with test=False. This commit changes the order of checks to first
check for a matching regex and then for the test mode and not the other
way around.

### What issues does this PR fix or reference?

None

### Tests written?

No

### Commits signed with GPG?

Yes