### PR TITLE
Add a new drbd monitor function via drbdadm to deprecate the old method of drbd-overview

### DIFF
--- a/salt/modules/drbd.py
+++ b/salt/modules/drbd.py
@@ -11,6 +11,9 @@ log = logging.getLogger(__name__)
 
 
 def _analyse_overview_field(content):
+    '''
+    Split the field in drbd-overview
+    '''
     if "(" in content:
         # Output like "Connected(2*)" or "UpToDate(2*)"
         return content.split("(")[0], content.split("(")[0]
@@ -22,6 +25,9 @@ def _analyse_overview_field(content):
 
 
 def _count_spaces_startswith(line):
+    '''
+    Count the number of spaces before the first character
+    '''
     if line.split('#')[0].strip() == "":
         return None
 
@@ -34,6 +40,9 @@ def _count_spaces_startswith(line):
 
 
 def _analyse_status_type(line):
+    '''
+    Figure out the sections in drbdadm status
+    '''
     spaces = _count_spaces_startswith(line)
 
     if spaces is None:
@@ -59,6 +68,9 @@ def _analyse_status_type(line):
 
 
 def _add_res(line):
+    '''
+    Analyse the line of local resource of ``drbdadm status``
+    '''
     global resource
     fields = line.strip().split()
 
@@ -73,6 +85,9 @@ def _add_res(line):
 
 
 def _add_volume(line):
+    '''
+    Analyse the line of volumes of ``drbdadm status``
+    '''
     section = _analyse_status_type(line)
     fields = line.strip().split()
 
@@ -88,6 +103,9 @@ def _add_volume(line):
 
 
 def _add_peernode(line):
+    '''
+    Analyse the line of peer nodes of ``drbdadm status``
+    '''
     global lastpnodevolumes
 
     fields = line.strip().split()
@@ -102,15 +120,24 @@ def _add_peernode(line):
 
 
 def _empty(dummy):
+    '''
+    Action of empty line of ``drbdadm status``
+    '''
     pass
 
 
 def _unknown_parser(line):
+    '''
+    Action of unsupported line of ``drbdadm status``
+    '''
     global ret
     ret = {"Unknown parser": line}
 
 
 def _line_parser(line):
+    '''
+    Call action for different lines
+    '''
     section = _analyse_status_type(line)
     fields = line.strip().split()
 

--- a/salt/modules/drbd.py
+++ b/salt/modules/drbd.py
@@ -37,7 +37,7 @@ def _analyse_status_type(line):
     spaces = _count_spaces_startswith(line)
 
     if spaces is None:
-        return None
+        return ''
 
     switch = {
         0: 'RESOURCE',
@@ -56,6 +56,75 @@ def _analyse_status_type(line):
             return ret[x]
 
     return 'UNKNOWN'
+
+
+def _add_res(line):
+    global resource
+    fields = line.strip().split()
+
+    if resource:
+        ret.append(resource)
+        resource = {}
+
+    resource["resource name"] = fields[0]
+    resource["local role"] = fields[1].split(":")[1]
+    resource["local volumes"] = []
+    resource["peer nodes"] = []
+
+
+def _add_volume(line):
+    section = _analyse_status_type(line)
+    fields = line.strip().split()
+
+    volume = {}
+    for field in fields:
+        volume[field.split(':')[0]] = field.split(':')[1]
+
+    if section == 'LOCALDISK':
+        resource['local volumes'].append(volume)
+    else:
+        # 'PEERDISK'
+        lastpnodevolumes.append(volume)
+
+
+def _add_peernode(line):
+    global lastpnodevolumes
+
+    fields = line.strip().split()
+
+    peernode = {}
+    peernode["peernode name"] = fields[0]
+    #Could be role or connection:
+    peernode[fields[1].split(":")[0]] = fields[1].split(":")[1]
+    peernode["peer volumes"] = []
+    resource["peer nodes"].append(peernode)
+    lastpnodevolumes = peernode["peer volumes"]
+
+
+def _empty(dummy):
+    pass
+
+
+def _unknown_parser(line):
+    global ret
+    ret = {"Unknown parser": line}
+
+
+def _line_parser(line):
+    section = _analyse_status_type(line)
+    fields = line.strip().split()
+
+    switch = {
+        '': _empty,
+        'RESOURCE': _add_res,
+        'PEERNODE': _add_peernode,
+        'LOCALDISK': _add_volume,
+        'PEERDISK': _add_volume,
+    }
+
+    func = switch.get(section, _unknown_parser)
+
+    func(line)
 
 
 def overview():
@@ -132,6 +201,12 @@ def overview():
     return ret
 
 
+# Global para for func status
+ret = []
+resource = {}
+lastpnodevolumes = None
+
+
 def status(name='all'):
     '''
     Using drbdadm to show status of the DRBD devices,
@@ -153,11 +228,14 @@ def status(name='all'):
         salt '*' drbd.status name=<resource name>
     '''
 
-    cmd = ['drbdadm', 'status']
-    cmd.append(name)
-
+    # Initialize for multiple times test cases
+    global ret
+    global resource
     ret = []
     resource = {}
+
+    cmd = ['drbdadm', 'status']
+    cmd.append(name)
 
     #One possible output: (number of resource/node/vol are flexible)
     #resource role:Secondary
@@ -170,43 +248,7 @@ def status(name='all'):
     #    volume:0 peer-disk:Inconsistent resync-suspended:peer
     #    volume:1 peer-disk:Inconsistent resync-suspended:peer
     for line in __salt__['cmd.run'](cmd).splitlines():
-        section = _analyze_status_type(line)
-        fields = line.strip().split()
-
-        if not section:
-            continue
-
-        elif section == 'RESOURCE':
-            if resource:
-                ret.append(resource)
-                resource = {}
-
-            resource['resource name'] = fields[0]
-            resource['local role'] = fields[1].split(':')[1]
-            resource['local volumes'] = []
-            resource['peer nodes'] = []
-
-        elif section == 'PEERNODE':
-            peernode = {}
-            peernode['peernode name'] = fields[0]
-            # Could be "role:" or "connection:", depends on connect state
-            peernode[fields[1].split(':')[0]] = fields[1].split(':')[1]
-            peernode['peer volumes'] = []
-            lastpnodevolumes = peernode['peer volumes']
-            resource['peer nodes'].append(peernode)
-
-        elif section in ('LOCALDISK', 'PEERDISK'):
-            volume = {}
-            for field in fields:
-                volume[field.split(':')[0]] = field.split(':')[1]
-            if section == 'LOCALDISK':
-                resource['local volumes'].append(volume)
-            else:
-                lastpnodevolumes.append(volume)
-
-        else:
-            ret = {'UNKNOWN parser' + str(section): line}
-            return ret
+        _line_parser(line)
 
     if resource:
         ret.append(resource)

--- a/salt/modules/drbd.py
+++ b/salt/modules/drbd.py
@@ -20,9 +20,46 @@ def _analyse_overview_field(content):
     return content, ""
 
 
+def _count_spaces_startswith(line):
+    if line.split('#')[0].strip() == "":
+        return None
+
+    spaces = 0
+    for i in line:
+        if i.isspace():
+            spaces += 1
+        else:
+            return spaces
+
+
+def _analyse_status_type(line):
+    spaces = _count_spaces_startswith(line)
+
+    if spaces is None:
+        return None
+    elif spaces == 0:
+        return 'RESOURCE'
+    elif spaces == 2:
+        if ' disk:' in line:
+            return 'LOCALDISK'
+        elif ' role:' in line or ' connection:' in line:
+            return 'PEERNODE'
+        else:
+            return 'UNKNOWN'
+    elif spaces == 4:
+        if ' peer-disk:' in line:
+            return 'PEERDISK'
+        else:
+            return 'UNKNOWN'
+    else:
+        return 'UNKNOWN'
+
+
 def overview():
     '''
     Show status of the DRBD devices, support two nodes only.
+    drbd-overview is removed since drbd-utils-9.6.0,
+    use status instead.
 
     CLI Example:
 
@@ -89,4 +126,90 @@ def overview():
                     'synchronisation: ': syncbar,
                     'synched': sync,
                 }
+    return ret
+
+
+def status(name=''):
+    '''
+    Using drbdadm to show status of the DRBD devices,
+        available in the latest drbd9.
+    Support multiple nodes and/or multiple volumes.
+
+    :type name: str
+    :param name:
+        Resource name.
+
+    :return: drbd status of resource.
+    :rtype: list(dict(res))
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' drbd.status
+        salt '*' drbd.status name=<resource name>
+    '''
+
+    cmd = ['drbdadm', 'status']
+    if len(name) != 0:
+        cmd.append(name)
+
+    ret = []
+    resource = {}
+
+    #One possible output: (number of resource/node/vol are flexible)
+    #resource role:Secondary
+    #  volume:0 disk:Inconsistent
+    #  volume:1 disk:Inconsistent
+    #  drbd-node1 role:Primary
+    #    volume:0 replication:SyncTarget peer-disk:UpToDate done:10.17
+    #    volume:1 replication:SyncTarget peer-disk:UpToDate done:74.08
+    #  drbd-node2 role:Secondary
+    #    volume:0 peer-disk:Inconsistent resync-suspended:peer
+    #    volume:1 peer-disk:Inconsistent resync-suspended:peer
+    for line in __salt__['cmd.run'](cmd).splitlines():
+        section = _analyse_status_type(line)
+        fields = line.strip().split()
+
+        if section is None:
+            continue
+
+        elif section == 'RESOURCE':
+            if resource:
+                ret.append(resource)
+                resource = {}
+
+            resource['resource name'] = fields[0]
+            resource['local role'] = fields[1].split(':')[1]
+            resource['local volumes'] = []
+            resource['peer nodes'] = []
+
+        elif section == 'LOCALDISK':
+                volume = {}
+                for field in fields:
+                    volume[field.split(':')[0]] = field.split(':')[1]
+                resource['local volumes'].append(volume)
+
+        elif section == 'PEERNODE':
+                peernode = {}
+                peernode['peernode name'] = fields[0]
+                # Could be "role:" or "connection:", depends on connect state
+                peernode[fields[1].split(':')[0]] = fields[1].split(':')[1]
+                peernode['peer volumes'] = []
+                lastpnodevolumes = peernode['peer volumes']
+                resource['peer nodes'].append(peernode)
+
+        elif section == 'PEERDISK':
+                volume = {}
+                for field in fields:
+                    volume[field.split(':')[0]] = field.split(':')[1]
+                lastpnodevolumes.append(volume)
+
+        else:
+            ret = {'UNKNOWN parser': line}
+            return ret
+
+    if resource:
+        ret.append(resource)
+
     return ret

--- a/tests/unit/modules/test_drbd.py
+++ b/tests/unit/modules/test_drbd.py
@@ -66,15 +66,14 @@ class DrbdTestCase(TestCase, LoaderModuleMockMixin):
         with patch.dict(drbd.__salt__, {'cmd.run': mock}):
             self.assertDictEqual(drbd.overview(), ret)
 
-
     def test_status(self):
         '''
         Test if it shows status of the DRBD resources via drbdadm
         '''
         ret = [{'local role': 'Primary',
                 'local volumes': [{'disk': 'UpToDate'}],
-                'peer nodes': [{'peer volumes': [{'done': '96.47', \
-                   'peer-disk': 'Inconsistent', 'replication': 'SyncSource'}],
+                'peer nodes': [{'peer volumes': [{'done': '96.47',
+                    'peer-disk': 'Inconsistent', 'replication': 'SyncSource'}],
                 'peernode name': 'opensuse-node2',
                 'role': 'Secondary'}],
                 'resource name': 'single'}]

--- a/tests/unit/modules/test_drbd.py
+++ b/tests/unit/modules/test_drbd.py
@@ -65,3 +65,91 @@ class DrbdTestCase(TestCase, LoaderModuleMockMixin):
         UpToDate/partner syncbar None 50 50')
         with patch.dict(drbd.__salt__, {'cmd.run': mock}):
             self.assertDictEqual(drbd.overview(), ret)
+
+
+    def test_status(self):
+        '''
+        Test if it shows status of the DRBD resources via drbdadm
+        '''
+        ret = [{'local role': 'Primary',
+                'local volumes': [{'disk': 'UpToDate'}],
+                'peer nodes': [{'peer volumes': [{'done': '96.47', \
+                   'peer-disk': 'Inconsistent', 'replication': 'SyncSource'}],
+                'peernode name': 'opensuse-node2',
+                'role': 'Secondary'}],
+                'resource name': 'single'}]
+
+        mock = MagicMock(return_value='''
+single role:Primary
+  disk:UpToDate
+  opensuse-node2 role:Secondary
+    replication:SyncSource peer-disk:Inconsistent done:96.47
+''')
+
+        with patch.dict(drbd.__salt__, {'cmd.run': mock}):
+            try:  # python2
+                self.assertItemsEqual(drbd.status(), ret)
+            except AttributeError:  # python3
+                self.assertCountEqual(drbd.status(), ret)
+
+        ret = [{'local role': 'Primary',
+                'local volumes': [{'disk': 'UpToDate', 'volume': '0'},
+                                  {'disk': 'UpToDate', 'volume': '1'}
+                                 ],
+                'peer nodes': [{'peer volumes': [{'peer-disk': 'UpToDate', 'volume': '0'},
+                                                 {'peer-disk': 'UpToDate', 'volume': '1'}
+                                                ],
+                                'peernode name': 'node2',
+                                'role': 'Secondary'},
+                               {'peer volumes': [{'peer-disk': 'UpToDate', 'volume': '0'},
+                                                 {'peer-disk': 'UpToDate', 'volume': '1'}
+                                                ],
+                                'peernode name': 'node3',
+                                'role': 'Secondary'}
+                              ],
+                'resource name': 'test'},
+               {'local role': 'Primary',
+                'local volumes': [{'disk': 'UpToDate', 'volume': '0'},
+                                  {'disk': 'UpToDate', 'volume': '1'}
+                                 ],
+                'peer nodes': [{'peer volumes': [{'peer-disk': 'UpToDate', 'volume': '0'},
+                                                 {'peer-disk': 'UpToDate', 'volume': '1'}
+                                                ],
+                                'peernode name': 'node2',
+                                'role': 'Secondary'},
+                               {'peer volumes': [{'peer-disk': 'UpToDate', 'volume': '0'},
+                                                 {'peer-disk': 'UpToDate', 'volume': '1'}
+                                                ],
+                                'peernode name': 'node3',
+                                'role': 'Secondary'}
+                              ],
+                'resource name': 'res'}
+               ]
+
+        mock = MagicMock(return_value='''
+res role:Primary
+  volume:0 disk:UpToDate
+  volume:1 disk:UpToDate
+  node2 role:Secondary
+    volume:0 peer-disk:UpToDate
+    volume:1 peer-disk:UpToDate
+  node3 role:Secondary
+    volume:0 peer-disk:UpToDate
+    volume:1 peer-disk:UpToDate
+
+test role:Primary
+  volume:0 disk:UpToDate
+  volume:1 disk:UpToDate
+  node2 role:Secondary
+    volume:0 peer-disk:UpToDate
+    volume:1 peer-disk:UpToDate
+  node3 role:Secondary
+    volume:0 peer-disk:UpToDate
+    volume:1 peer-disk:UpToDate
+
+''')
+        with patch.dict(drbd.__salt__, {'cmd.run': mock}):
+            try:  # python2
+                self.assertItemsEqual(drbd.status(), ret)
+            except AttributeError:  # python3
+                self.assertCountEqual(drbd.status(), ret)


### PR DESCRIPTION
### What does this PR do?
Add a new method to monitor the drbd resources status.

### What issues does this PR fix or reference?
drbd-overview is removed in the latest drbd-utils-9.6.0. Refer to [drbd-utils commit](https://github.com/LINBIT/drbd-utils/commit/811b67219101e18eafdaee34a94621042123b404)
The original solution with drbd-overview is deprecated/removed in the latest version, the original salt function only support show 2 nodes with 1 volume. Add another monitor approach with "drbdadm status" to support all drbd versions, new function also support multiple drbd resources, including multiple volumes/peernodes of each resource.

### Previous Behavior
Show drbd status in 2 nodes(1 volume) scenario via drbd-overview. Leave the old method in case some users still using salt with the old drbd version/method.

### New Behavior
Add a new method to show drbd status via drbdadm, which also support more than 2 nodes/volumes.
drbdadm also support multiple drbd versions including the latest version.

### Tests written?

Yes

### Commits signed with GPG?

No