### PR TITLE
use exc.winerror not exc[0] to avoid python3 TypeError

### DIFF
--- a/salt/utils/win_runas.py
+++ b/salt/utils/win_runas.py
@@ -310,8 +310,8 @@ def runas_system(cmd, username, password):
 
     except win32security.error as exc:
         # User doesn't have admin, use existing token
-        if exc[0] == winerror.ERROR_NO_SUCH_LOGON_SESSION \
-                or exc[0] == winerror.ERROR_PRIVILEGE_NOT_HELD:
+        if exc.winerror == winerror.ERROR_NO_SUCH_LOGON_SESSION \
+                or exc.winerror == winerror.ERROR_PRIVILEGE_NOT_HELD:
             elevated_token = token
         else:
             raise


### PR DESCRIPTION
Fixes #50413

### What does this PR do?

python3 does not provide an exc[] dict to access the error details, so instead we need to use the winerror attribute

The whole problem is gone with the HEAD due to refactoring of that module, but it would be really cool if these two lines could be merged to at least 2018.3 so that any future 2018.3.x would not break our manually fixed minions again

### What issues does this PR fix or reference?

Fixes #50413

### Previous Behavior
Remove this section if not relevant

### New Behavior
Remove this section if not relevant

### Tests written?

No

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
