### PR TITLE
cwd needs to be passed from runas() to runas_system()

### DIFF
--- a/salt/utils/win_runas.py
+++ b/salt/utils/win_runas.py
@@ -271,7 +271,7 @@ def make_inheritable(token):
                                     win32con.DUPLICATE_SAME_ACCESS)
 
 
-def runas_system(cmd, username, password):
+def runas_system(cmd, username, password, cwd=None):
     # This only works as system, when salt is running as a service for example
 
     # Check for a domain
@@ -352,7 +352,7 @@ def runas_system(cmd, username, password):
                 1,
                 0,
                 user_environment,
-                None,
+                cwd,
                 startup_info)
 
     hProcess, hThread, PId, TId = \
@@ -397,7 +397,7 @@ def runas(cmd, username, password, cwd=None):
     # This only works when not running under the system account
     # Debug mode for example
     if salt.utils.win_functions.get_current_user() == 'SYSTEM':
-        return runas_system(cmd, username, password)
+        return runas_system(cmd, username, password, cwd)
 
     # Create a pipe to set as stdout in the child. The write handle needs to be
     # inheritable.


### PR DESCRIPTION
Fixes parts of #47787

### What does this PR do?

47787 ends with a comment that something has fixed in develop which could be backported.
Since this might be a major effort, my suggestion is to first merge my little fix which is much easier to do.
While I'm no expert neither in salt nor in windows, my change seems straightforward enough to be harmless ;)

### What issues does this PR fix or reference?

with my fix, the cwd parameter gets gets passed into the runas_system() method

### Previous Behavior

salt myminion cmd.run "dir" runas=myuser password=mysecret cwd=C:/Windows/Temp
would be executed in C:/salt

### New Behavior

salt myminion cmd.run "dir" runas=myuser password=mysecret cwd=C:/Windows/Temp
would be executed in C:/Windows/Temp

### Tests written?

No

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
