### PR TITLE
Fix issue in nilrt_ip when using python3

### DIFF
--- a/salt/modules/nilrt_ip.py
+++ b/salt/modules/nilrt_ip.py
@@ -275,11 +275,8 @@ def _load_config(section, options, default_value='', filename=INI_FILE):
         config_parser = configparser.RawConfigParser(dict_type=CaseInsensitiveDict)
         config_parser.readfp(config_file)
         for option in options:
-            if six.PY2:
-                results[option] = _remove_quotes(config_parser.get(section, option)) \
-                    if config_parser.has_option(section, option) else default_value
-            else:
-                results[option] = _remove_quotes(config_parser.get(section, option, fallback=default_value))
+            results[option] = _remove_quotes(config_parser.get(section, option)) \
+                if config_parser.has_option(section, option) else default_value
 
     return results
 


### PR DESCRIPTION
### What does this PR do?
Fix "TypeError: object of type 'int' has no len() error assistance needed" exception thrown when calling nilrt_ip.get_interfaces_details if the minion is running with python3.

### Previous Behavior
When using salt-minion with python3, the call to nilrt_ip.get_interfaces_details eventually called _load_config with a default value of -1. That default value ended up being passed to the _remove_quotes function which threw an exception because since -1 is not a string, it was not able to call len on it.

### New Behavior
The new behavior is the same that is currently present when salt-minion uses python2. Basically, _remove_quotes is not called anymore if the config parser does not find the requested option. If the requested option is present, it will surely be a string, therefore it is safe to call _remove_quotes on it.

### Tests written?

No

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
