### PR TITLE
[2018.3] Fixes to sysctl modules and state

### DIFF
--- a/salt/modules/freebsd_sysctl.py
+++ b/salt/modules/freebsd_sysctl.py
@@ -6,6 +6,7 @@ Module for viewing and modifying sysctl parameters
 # Import Python libs
 from __future__ import absolute_import, unicode_literals, print_function
 import logging
+import os
 
 # Import salt libs
 import salt.utils.files
@@ -66,6 +67,10 @@ def show(config_file=False):
     comps = ['']
 
     if config_file:
+        # If the file doesn't exist, return an empty list
+        if not os.path.exists(config_file):
+            return []
+
         try:
             with salt.utils.files.fopen(config_file, 'r') as f:
                 for line in f.readlines():

--- a/salt/modules/linux_sysctl.py
+++ b/salt/modules/linux_sysctl.py
@@ -71,6 +71,10 @@ def show(config_file=False):
     '''
     ret = {}
     if config_file:
+        # If the file doesn't exist, return an empty list
+        if not os.path.exists(config_file):
+            return []
+
         try:
             with salt.utils.files.fopen(config_file) as fp_:
                 for line in fp_:

--- a/salt/states/sysctl.py
+++ b/salt/states/sysctl.py
@@ -62,7 +62,7 @@ def present(name, value, config=None):
     if __opts__['test']:
         current = __salt__['sysctl.show']()
         configured = __salt__['sysctl.show'](config_file=config)
-        if not configured:
+        if configured is None:
             ret['result'] = None
             ret['comment'] = (
                 'Sysctl option {0} might be changed, we failed to check '

--- a/tests/unit/states/test_sysctl.py
+++ b/tests/unit/states/test_sysctl.py
@@ -46,6 +46,9 @@ class SysctlTestCase(TestCase, LoaderModuleMockMixin):
 
         ret = {'name': name, 'result': None, 'changes': {}, 'comment': comment}
 
+        comment_empty = ('Sysctl option {0} would be changed to {1}'
+                         ''.format(name, value))
+
         comment1 = ('Sysctl option {0} set to be changed to {1}'
                     .format(name, value))
 
@@ -91,8 +94,13 @@ class SysctlTestCase(TestCase, LoaderModuleMockMixin):
             return [name]
 
         with patch.dict(sysctl.__opts__, {'test': True}):
-            mock = MagicMock(return_value=False)
+            mock = MagicMock(return_value=None)
             with patch.dict(sysctl.__salt__, {'sysctl.show': mock}):
+                self.assertDictEqual(sysctl.present(name, value), ret)
+
+            mock = MagicMock(return_value=[])
+            with patch.dict(sysctl.__salt__, {'sysctl.show': mock}):
+                ret.update({'comment': comment_empty})
                 self.assertDictEqual(sysctl.present(name, value), ret)
 
             with patch.dict(sysctl.__salt__, {'sysctl.show': mock_current}):


### PR DESCRIPTION
### What does this PR do?
Adding a check to see if the config file exists, if not then return an empty list so we get the would be changes.  Adding a test for this functionality.

### What issues does this PR fix or reference?
#50292 

### Previous Behavior
When run with test=True, if the file did not exist then a log message would say that the file could not be opened.

### New Behavior
Updated the linux & freebsd sysctl modules to return an empty list when the file does not exist, then we get the would be changes.

### Tests written?
Yes

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
