### PR TITLE
Optionally use multiprocessing.Queue for MWorker to publisher

### DIFF
--- a/doc/ref/configuration/master.rst
+++ b/doc/ref/configuration/master.rst
@@ -1725,6 +1725,28 @@ The listen queue size of the ZeroMQ backlog.
 
 .. _master-module-management:
 
+``worker_use_queue``
+--------------------
+
+Default: ``False``
+
+Use a multiprocessing Queue instead of ZeroMQ PUSH/PULL for MWorker to publisher messaging.
+
+.. code-block:: yaml
+
+    worker_use_queue: True
+
+``worker_queue_size``
+---------------------
+
+Default: ``1000``
+
+Maximum queue size when ``worker_use_queue`` is enabled.
+
+.. code-block:: yaml
+
+    worker_queue_size: 2000
+
 Master Module Management
 ========================
 

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -95,6 +95,7 @@ def _gather_buffer_space():
     # Return the higher number between 5% of the system memory and 10MiB
     return max([total_mem * 0.05, 10 << 20])
 
+
 # For the time being this will be a fixed calculation
 # TODO: Allow user configuration
 _DFLT_IPC_WBUFFER = _gather_buffer_space() * .5

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -558,10 +558,10 @@ VALID_OPTS = {
     'worker_threads': int,
 
     # Use a multiprocessing Queue to send messages to the pub server process
-    'worker_use_queue' int,
+    'worker_use_queue': bool,
 
     # Pub server multiprocessing Queue size
-    'worker_queue_size', int
+    'worker_queue_size': int,
 
     # The port for the master to listen to returns on. The minion needs to connect to this port
     # to send returns.
@@ -1393,7 +1393,7 @@ DEFAULT_MASTER_OPTS = {
     'auth_mode': 1,
     'user': _MASTER_USER,
     'worker_threads': 5,
-    'worker_use_queue' False,
+    'worker_use_queue': False,
     'sock_dir': os.path.join(salt.syspaths.SOCK_DIR, 'master'),
     'sock_pool_size': 1,
     'ret_port': 4506,

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -557,6 +557,12 @@ VALID_OPTS = {
     # the number of connected minions increases.
     'worker_threads': int,
 
+    # Use a multiprocessing Queue to send messages to the pub server process
+    'worker_use_queue' int,
+
+    # Pub server multiprocessing Queue size
+    'worker_queue_size', int
+
     # The port for the master to listen to returns on. The minion needs to connect to this port
     # to send returns.
     'ret_port': int,
@@ -1387,6 +1393,7 @@ DEFAULT_MASTER_OPTS = {
     'auth_mode': 1,
     'user': _MASTER_USER,
     'worker_threads': 5,
+    'worker_use_queue' False,
     'sock_dir': os.path.join(salt.syspaths.SOCK_DIR, 'master'),
     'sock_pool_size': 1,
     'ret_port': 4506,

--- a/salt/master.py
+++ b/salt/master.py
@@ -530,7 +530,10 @@ class Master(SMaster):
             pub_channels = []
             log.info('Creating master publisher process')
             log_queue = salt.log.setup.get_multiprocessing_logging_queue()
-            msg_queue = multiprocessing.Queue(1000)
+            if self.opts['worker_use_queue']:
+                msg_queue = multiprocessing.Queue(self.opts.get('worker_queue_size', 1000))
+            else:
+                msg_queue = None
             for transport, opts in iter_transport_opts(self.opts):
                 chan = salt.transport.server.PubServerChannel.factory(opts)
                 chan.pre_fork(
@@ -689,7 +692,8 @@ class ReqServer(SignalHandlingMultiprocessingProcess):
     def __setstate__(self, state):
         self._is_child = True
         self.__init__(state['opts'], state['key'], state['mkey'],
-                      log_queue=state['log_queue'], msg_queue=state['msg_queue'], secrets=state['secrets'])
+                      log_queue=state['log_queue'], msg_queue=state['msg_queue'],
+                      secrets=state['secrets'])
 
     def __getstate__(self):
         return {'opts': self.opts,

--- a/salt/master.py
+++ b/salt/master.py
@@ -597,11 +597,10 @@ class Master(SMaster):
                 time.sleep(2)
 
             log.info('Creating master request server process')
-            kwargs = {}
+            kwargs = {'msg_queue': msg_queue}
             if salt.utils.is_windows():
                 kwargs['log_queue'] = log_queue
                 kwargs['secrets'] = SMaster.secrets
-                kwargs['msg_queue'] = msg_queue
 
             self.process_manager.add_process(
                 ReqServer,
@@ -740,10 +739,9 @@ class ReqServer(SignalHandlingMultiprocessingProcess):
             if transport != 'tcp':
                 tcp_only = False
 
-        kwargs = {}
+        kwargs = {'msg_queue': self.msg_queue}
         if salt.utils.is_windows():
             kwargs['log_queue'] = self.log_queue
-            kwargs['msg_queue'] = self.msg_queue
             # Use one worker thread if only the TCP transport is set up on
             # Windows and we are using Python 2. There is load balancer
             # support on Windows for the TCP transport when using Python 3.

--- a/salt/utils/process.py
+++ b/salt/utils/process.py
@@ -595,6 +595,7 @@ class MultiprocessingProcess(multiprocessing.Process, NewStyleClassMixIn):
             self._kwargs_for_getstate = copy.copy(kwargs)
 
         self.log_queue = kwargs.pop('log_queue', None)
+        self.msg_queue = kwargs.pop('msg_queue', None)
         if self.log_queue is None:
             self.log_queue = salt.log.setup.get_multiprocessing_logging_queue()
         else:
@@ -648,6 +649,8 @@ class MultiprocessingProcess(multiprocessing.Process, NewStyleClassMixIn):
         kwargs = self._kwargs_for_getstate
         if 'log_queue' not in kwargs:
             kwargs['log_queue'] = self.log_queue
+        if 'msg_queue' not in kwargs:
+            kwargs['msg_queue'] = self.msg_queue
         # Remove the version of these in the parent process since
         # they are no longer needed.
         del self._args_for_getstate

--- a/tests/integration/files/conf/master
+++ b/tests/integration/files/conf/master
@@ -5,6 +5,7 @@ interface: 127.0.0.1
 publish_port: 64505
 ret_port: 64506
 worker_threads: 3
+worker_use_queue: True
 pidfile: master.pid
 sock_dir: master_sock
 timeout: 12


### PR DESCRIPTION
### What does this PR do?

Adds an option to use a `multiprocessing.Queue` instead of ZeroMQ PUSH/PULL sockets for messages relayed from MWorkers to the publisher daemon process.

### What issues does this PR fix or reference?

#36469
#46553
#50393

### Previous Behavior

ZeroMQ's PUSH/PULL sockets are unreliable when dealing with large messages (size) or large number of messages sent quickly.

### New Behavior

Optionally a multiprocessing.Queue for messages moving from MWorkers to the publisher daemon. Messages will get published reliably.

### Tests written?

No - This patch has been tested on via jenkin's branch tests on a fork of 2017.7

### Commits signed with GPG?

Yes