### PR TITLE
Port json_query Jinja filter from Ansible

### DIFF
--- a/doc/topics/jinja/index.rst
+++ b/doc/topics/jinja/index.rst
@@ -1255,8 +1255,52 @@ Returns:
 
   'default'
 
+
+.. jinja_ref:: json_query
+
+``json_query``
+--------------
+
+.. versionadded:: Neon
+
+A port of Ansible ``json_query`` Jinja filter to make queries against JSON data using `JMESPath language`_.
+Could be used to filter ``pillar`` data, ``yaml`` maps, and together with :jinja_ref:`http_query`.
+Depends on the `jmespath`_ Python module.
+
+Examples:
+
+.. code-block:: jinja
+
+  Example 1: {{ [1, 2, 3, 4, [5, 6]] | json_query('[]') }}
+
+  Example 2: {{
+  {"machines": [
+    {"name": "a", "state": "running"},
+    {"name": "b", "state": "stopped"},
+    {"name": "b", "state": "running"}
+  ]} | json_query("machines[?state=='running'].name") }}
+
+  Example 3: {{
+  {"services": [
+    {"name": "http", "host": "1.2.3.4", "port": 80},
+    {"name": "smtp", "host": "1.2.3.5", "port": 25},
+    {"name": "ssh",  "host": "1.2.3.6", "port": 22},
+  ]} | json_query("services[].port") }}
+
+Returns:
+
+.. code-block:: text
+
+  Example 1: [1, 2, 3, 4, 5, 6]
+
+  Example 2: ['a', 'b']
+
+  Example 3: [80, 25, 22]
+
 .. _`builtin filters`: http://jinja.pocoo.org/docs/templates/#builtin-filters
 .. _`timelib`: https://github.com/pediapress/timelib/
+.. _`JMESPath language`: http://jmespath.org/
+.. _`jmespath`: https://github.com/jmespath/jmespath.py
 
 Networking Filters
 ------------------

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -40,3 +40,4 @@ kazoo
 ansible; sys.platform != 'win32' and sys.platform != 'darwin' and python_version >= '3.5'
 ansible; sys.platform != 'win32' and sys.platform != 'darwin' and python_version == '2.7'
 pylxd>=2.2.5; sys.platform != 'win32' and sys.platform != 'darwin'
+jmespath

--- a/salt/utils/data.py
+++ b/salt/utils/data.py
@@ -29,6 +29,11 @@ from salt.utils.decorators.jinja import jinja_filter
 from salt.ext import six
 from salt.ext.six.moves import range  # pylint: disable=redefined-builtin
 
+try:
+    import jmespath
+except ImportError:
+    jmespath = None
+
 log = logging.getLogger(__name__)
 
 
@@ -894,3 +899,13 @@ def stringify(data):
             item = six.text_type(item)
         ret.append(item)
     return ret
+
+
+@jinja_filter('json_query')
+def json_query(data, expr):
+    '''
+    Query data using JMESPath query language (http://jmespath.org).
+    '''
+    if jmespath is None:
+        raise RuntimeError('json_query filter requires jmespath library which is not installed')
+    return jmespath.search(expr, data)

--- a/salt/utils/data.py
+++ b/salt/utils/data.py
@@ -904,8 +904,10 @@ def stringify(data):
 @jinja_filter('json_query')
 def json_query(data, expr):
     '''
-    Query data using JMESPath query language (http://jmespath.org).
+    Query data using JMESPath language (http://jmespath.org).
     '''
     if jmespath is None:
-        raise RuntimeError('json_query filter requires jmespath library which is not installed')
+        err = 'json_query requires jmespath module installed'
+        log.error(err)
+        raise RuntimeError(err)
     return jmespath.search(expr, data)

--- a/tests/unit/utils/test_data.py
+++ b/tests/unit/utils/test_data.py
@@ -598,3 +598,24 @@ class DataTestCase(TestCase):
             salt.utils.data.stringify(['one', 'two', str('three'), 4, 5]),  # future lint: disable=blacklisted-function
             ['one', 'two', 'three', '4', '5']
         )
+
+    def test_json_query(self):
+        # Raises exception if jmespath module is not found
+        with patch('salt.utils.data.jmespath', None):
+            self.assertRaisesRegex(
+                RuntimeError, 'requires jmespath',
+                salt.utils.data.json_query, {}, '@'
+            )
+
+        # Test search
+        user_groups = {
+            'user1': {'groups': ['group1', 'group2', 'group3']},
+            'user2': {'groups': ['group1', 'group2']},
+            'user3': {'groups': ['group3']},
+        }
+        expression = '*.groups[0]'
+        primary_groups = ['group1', 'group1', 'group3']
+        self.assertEqual(
+            sorted(salt.utils.data.json_query(user_groups, expression)),
+            primary_groups
+        )

--- a/tests/unit/utils/test_jinja.py
+++ b/tests/unit/utils/test_jinja.py
@@ -1312,6 +1312,16 @@ class TestCustomExtensions(TestCase):
                                      dict(opts=self.local_opts, saltenv='test', salt=self.local_salt))
         self.assertEqual(rendered, 'random')
 
+    def test_json_query(self):
+        '''
+        Test the `json_query` Jinja filter.
+        '''
+        rendered = render_jinja_tmpl(
+            "{{ [1, 2, 3] | json_query('[1]')}}",
+            dict(opts=self.local_opts, saltenv='test', salt=self.local_salt)
+        )
+        self.assertEqual(rendered, '2')
+
     # def test_print(self):
     #     env = Environment(extensions=[SerializerExtension])
     #     source = '{% import_yaml "toto.foo" as docu %}'


### PR DESCRIPTION
### What does this PR do?

This is a port of Ansible `json_query` Jinja filter to make complex queries against json data structures. Query language http://jmespath.org/ parser depends on `jmespath` python library (optional).

It could be used to filter `pillar` data, `yaml` maps, and in combination with`http_query`. Can replace lots of ugly Jinja loops and in some cases help to avoid writing trivial custom modules https://docs.saltstack.com/en/latest/topics/tutorials/jinja_to_execution_module.html

Jinja template:

```
  Example 1: {{ [1, 2, 3, 4, [5, 6]] | json_query('[]') }}

  Example 2: {{
  {"machines": [
    {"name": "a", "state": "running"},
    {"name": "b", "state": "stopped"},
    {"name": "b", "state": "running"}
  ]} | json_query("machines[?state=='running'].name") }}

  Example 3: {{
  {"services": [
    {"name": "http", "host": "1.2.3.4", "port": 80},
    {"name": "smtp", "host": "1.2.3.5", "port": 25},
    {"name": "ssh",  "host": "1.2.3.6", "port": 22},
  ]} | json_query("services[].port") }}
```

Rendered output:

```
  Example 1: [1, 2, 3, 4, 5, 6]

  Example 2: ['a', 'b']

  Example 3: [80, 25, 22]
```

### Tests written?

Yes

### Commits signed with GPG?

No

P.S. The feature is not intrusive, how about including it into the Fluorine branch?