### PR TITLE
Update create disk fix

### DIFF
--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -1920,10 +1920,11 @@ def update(name,
 
     # Compute the XML to get the disks, interfaces and graphics
     hypervisor = desc.get('type')
+    all_disks = _disk_profile(disk_profile, hypervisor, disks, name, **kwargs)
     new_desc = ElementTree.fromstring(_gen_xml(name,
                                                cpu,
                                                mem,
-                                               _disk_profile(disk_profile, hypervisor, disks, name, **kwargs),
+                                               all_disks,
                                                _get_merged_nics(hypervisor, nic_profile, interfaces),
                                                hypervisor,
                                                domain.OSType(),
@@ -1966,6 +1967,12 @@ def update(name,
 
     # Set the new definition
     if need_update:
+        # Create missing disks if needed
+        if changes['disk']:
+            for idx, item in enumerate(changes['disk']['sorted']):
+                if item in new and not os.path.isfile(all_disks[idx]['source_file']):
+                    _qemu_image_create(all_disks[idx])
+
         try:
             conn.defineXML(ElementTree.tostring(desc))
             status['definition'] = True

--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -1034,7 +1034,8 @@ def _fill_disk_filename(vm_name, disk, hypervisor, **kwargs):
         else:
             if not base_dir.startswith('/'):
                 # The pool seems not to be a path, lookup for pool infos
-                pool = pool_info(base_dir, **kwargs)
+                infos = pool_info(base_dir, **kwargs)
+                pool = infos[base_dir] if base_dir in infos else None
                 if not pool or not pool['target_path'] or pool['target_path'].startswith('/dev'):
                     raise CommandExecutionError(
                                 'Unable to create new disk {0}, specified pool {1} does not exist '

--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -1519,9 +1519,9 @@ def init(name,
     .. _graphics element: https://libvirt.org/formatdomain.html#elementsGraphics
     '''
     caps = capabilities(**kwargs)
-    os_types = sorted(set([guest['os_type'] for guest in caps['guests']]))
-    arches = sorted(set([guest['arch']['name'] for guest in caps['guests']]))
-    hypervisors = sorted(set([x for y in [guest['arch']['domains'].keys() for guest in caps['guests']] for x in y]))
+    os_types = sorted({guest['os_type'] for guest in caps['guests']})
+    arches = sorted({guest['arch']['name'] for guest in caps['guests']})
+    hypervisors = sorted({x for y in [guest['arch']['domains'].keys() for guest in caps['guests']] for x in y})
     hypervisor = __salt__['config.get']('libvirt:hypervisor', hypervisor)
     if hypervisor is not None:
         salt.utils.versions.warn_until(
@@ -1791,7 +1791,7 @@ def _diff_disk_lists(old, new):
     :param old: list of ElementTree nodes representing the old disks
     :param new: list of ElementTree nodes representing the new disks
     '''
-    # Fix the target device to avoid duplicates before diffing: this may lead
+    # Change the target device to avoid duplicates before diffing: this may lead
     # to additional changes. Think of unchanged disk 'hda' and another disk listed
     # before it becoming 'hda' too... the unchanged need to turn into 'hdb'.
     targets = []
@@ -2646,7 +2646,7 @@ def get_profiles(hypervisor=None, **kwargs):
     ret = {}
 
     caps = capabilities(**kwargs)
-    hypervisors = sorted(set([x for y in [guest['arch']['domains'].keys() for guest in caps['guests']] for x in y]))
+    hypervisors = sorted({x for y in [guest['arch']['domains'].keys() for guest in caps['guests']] for x in y})
     default_hypervisor = 'kvm' if 'kvm' in hypervisors else hypervisors[0]
 
     if not hypervisor:

--- a/tests/unit/modules/test_virt.py
+++ b/tests/unit/modules/test_virt.py
@@ -2191,7 +2191,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
 
         caps = virt.all_capabilities()
         self.assertEqual('44454c4c-3400-105a-8033-b3c04f4b344a', caps['host']['host']['uuid'])
-        self.assertEqual(set(['qemu', 'kvm']), set([domainCaps['domain'] for domainCaps in caps['domains']]))
+        self.assertEqual(set(['qemu', 'kvm']), {domainCaps['domain'] for domainCaps in caps['domains']})
 
     def test_network_tag(self):
         '''

--- a/tests/unit/modules/test_virt.py
+++ b/tests/unit/modules/test_virt.py
@@ -1185,16 +1185,25 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         devdetach_mock = MagicMock(return_value=0)
         domain_mock.attachDevice = devattach_mock
         domain_mock.detachDevice = devdetach_mock
-        ret = virt.update('myvm', disk_profile='default', disks=[{'name': 'added', 'size': 2048}])
-        self.assertListEqual(
-            [os.path.join(root_dir, 'myvm_added.qcow2')],
-            [ET.fromstring(disk).find('source').get('file') for disk in ret['disk']['attached']])
+        mock_chmod = MagicMock()
+        mock_run = MagicMock()
+        with patch.dict(os.__dict__, {'chmod': mock_chmod}):  # pylint: disable=no-member
+            with patch.dict(virt.__salt__, {'cmd.run': mock_run}):  # pylint: disable=no-member
+                ret = virt.update('myvm', disk_profile='default', disks=[{'name': 'added', 'size': 2048}])
+                added_disk_path = os.path.join(
+                        virt.__salt__['config.get']('virt:images'), 'myvm_added.qcow2')  # pylint: disable=no-member
+                self.assertEqual(mock_run.call_args[0][0],
+                                 'qemu-img create -f qcow2 {0} 2048M'.format(added_disk_path))
+                self.assertEqual(mock_chmod.call_args[0][0], added_disk_path)
+                self.assertListEqual(
+                    [os.path.join(root_dir, 'myvm_added.qcow2')],
+                    [ET.fromstring(disk).find('source').get('file') for disk in ret['disk']['attached']])
 
-        self.assertListEqual(
-            [os.path.join(root_dir, 'myvm_data.qcow2')],
-            [ET.fromstring(disk).find('source').get('file') for disk in ret['disk']['detached']])
-        devattach_mock.assert_called_once()
-        devdetach_mock.assert_called_once()
+                self.assertListEqual(
+                    [os.path.join(root_dir, 'myvm_data.qcow2')],
+                    [ET.fromstring(disk).find('source').get('file') for disk in ret['disk']['detached']])
+                devattach_mock.assert_called_once()
+                devdetach_mock.assert_called_once()
 
         # Update nics case
         yaml_config = '''

--- a/tests/unit/modules/test_virt.py
+++ b/tests/unit/modules/test_virt.py
@@ -698,32 +698,32 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
             self.assertTrue(len(root.findall('.//interface')) == 2)
 
     @patch('salt.modules.virt.pool_info',
-           return_value={'target_path': os.path.join(salt.syspaths.ROOT_DIR,
-                                                     'pools',
-                                                     'default')})
+           return_value={'mypool': {'target_path': os.path.join(salt.syspaths.ROOT_DIR, 'pools', 'mypool')}})
     def test_disk_profile_kvm_disk_pool(self, mock_poolinfo):
         '''
         Test virt._gen_xml(), KVM case with pools defined.
         '''
         disks = {
             'noeffect': [
-                {'first': {'size': 8192, 'pool': 'default'}},
+                {'first': {'size': 8192, 'pool': 'mypool'}},
                 {'second': {'size': 4096}}
             ]
         }
+
+        # pylint: disable=no-member
         with patch.dict(virt.__salt__, {'config.get': MagicMock(side_effect=[
                 disks,
                 os.path.join(salt.syspaths.ROOT_DIR, 'default', 'path')])}):
+
             diskp = virt._disk_profile('noeffect', 'kvm', [], 'hello')
 
-            pools_path = os.path.join(
-                salt.syspaths.ROOT_DIR, 'pools', 'default') + os.sep
-            default_path = os.path.join(
-                salt.syspaths.ROOT_DIR, 'default', 'path') + os.sep
+            pools_path = os.path.join(salt.syspaths.ROOT_DIR, 'pools', 'mypool') + os.sep
+            default_path = os.path.join(salt.syspaths.ROOT_DIR, 'default', 'path') + os.sep
 
             self.assertEqual(len(diskp), 2)
             self.assertTrue(diskp[0]['source_file'].startswith(pools_path))
             self.assertTrue(diskp[1]['source_file'].startswith(default_path))
+        # pylint: enable=no-member
 
     def test_disk_profile_kvm_disk_external_image(self):
         '''


### PR DESCRIPTION
### What does this PR do?

This PR fixes several bugs in `virt.update` regarding disks.

* Adapts the use of virt.pool_info to the recently changed behavior. Without this the disk `pool` value doesn't affect the image location.
* Creates the new disk images in `virt.update`

### What issues does this PR fix or reference?

None

### Previous Behavior

`virt.update` with a new disk providing a value for the pool property always ended up computing a disk image path to `/srv/salt-images` and the disk image was not physically created.

### New Behavior

`virt.update` now uses the disk's pool property value and the disk is physically created.

### Tests written?

Yes

### Commits signed with GPG?

Yes