### PR TITLE
Update create disk fix

### DIFF
--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -928,7 +928,8 @@ def _fill_disk_filename(vm_name, disk, hypervisor, **kwargs):
         else:
             if not base_dir.startswith('/'):
                 # The pool seems not to be a path, lookup for pool infos
-                pool = pool_info(base_dir, **kwargs)
+                infos = pool_info(base_dir, **kwargs)
+                pool = infos[base_dir] if base_dir in infos else None
                 if not pool or not pool['target_path'] or pool['target_path'].startswith('/dev'):
                     raise CommandExecutionError(
                                 'Unable to create new disk {0}, specified pool {1} does not exist '

--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -1367,9 +1367,9 @@ def init(name,
     .. _graphics element: https://libvirt.org/formatdomain.html#elementsGraphics
     '''
     caps = capabilities(**kwargs)
-    os_types = sorted(set([guest['os_type'] for guest in caps['guests']]))
-    arches = sorted(set([guest['arch']['name'] for guest in caps['guests']]))
-    hypervisors = sorted(set([x for y in [guest['arch']['domains'].keys() for guest in caps['guests']] for x in y]))
+    os_types = sorted({guest['os_type'] for guest in caps['guests']})
+    arches = sorted({guest['arch']['name'] for guest in caps['guests']})
+    hypervisors = sorted({x for y in [guest['arch']['domains'].keys() for guest in caps['guests']] for x in y})
     hypervisor = __salt__['config.get']('libvirt:hypervisor', hypervisor)
     if hypervisor is not None:
         salt.utils.versions.warn_until(
@@ -1628,7 +1628,7 @@ def _diff_disk_lists(old, new):
     :param old: list of ElementTree nodes representing the old disks
     :param new: list of ElementTree nodes representing the new disks
     '''
-    # Fix the target device to avoid duplicates before diffing: this may lead
+    # Change the target device to avoid duplicates before diffing: this may lead
     # to additional changes. Think of unchanged disk 'hda' and another disk listed
     # before it becoming 'hda' too... the unchanged need to turn into 'hdb'.
     targets = []
@@ -2459,7 +2459,7 @@ def get_profiles(hypervisor=None, **kwargs):
     ret = {}
 
     caps = capabilities(**kwargs)
-    hypervisors = sorted(set([x for y in [guest['arch']['domains'].keys() for guest in caps['guests']] for x in y]))
+    hypervisors = sorted({x for y in [guest['arch']['domains'].keys() for guest in caps['guests']] for x in y})
     default_hypervisor = 'kvm' if 'kvm' in hypervisors else hypervisors[0]
 
     if not hypervisor:

--- a/tests/unit/modules/test_virt.py
+++ b/tests/unit/modules/test_virt.py
@@ -636,32 +636,32 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
             self.assertTrue(len(root.findall('.//interface')) == 2)
 
     @patch('salt.modules.virt.pool_info',
-           return_value={'target_path': os.path.join(salt.syspaths.ROOT_DIR,
-                                                     'pools',
-                                                     'default')})
+           return_value={'mypool': {'target_path': os.path.join(salt.syspaths.ROOT_DIR, 'pools', 'mypool')}})
     def test_disk_profile_kvm_disk_pool(self, mock_poolinfo):
         '''
         Test virt._gen_xml(), KVM case with pools defined.
         '''
         disks = {
             'noeffect': [
-                {'first': {'size': 8192, 'pool': 'default'}},
+                {'first': {'size': 8192, 'pool': 'mypool'}},
                 {'second': {'size': 4096}}
             ]
         }
+
+        # pylint: disable=no-member
         with patch.dict(virt.__salt__, {'config.get': MagicMock(side_effect=[
                 disks,
                 os.path.join(salt.syspaths.ROOT_DIR, 'default', 'path')])}):
+
             diskp = virt._disk_profile('noeffect', 'kvm', [], 'hello')
 
-            pools_path = os.path.join(
-                salt.syspaths.ROOT_DIR, 'pools', 'default') + os.sep
-            default_path = os.path.join(
-                salt.syspaths.ROOT_DIR, 'default', 'path') + os.sep
+            pools_path = os.path.join(salt.syspaths.ROOT_DIR, 'pools', 'mypool') + os.sep
+            default_path = os.path.join(salt.syspaths.ROOT_DIR, 'default', 'path') + os.sep
 
             self.assertEqual(len(diskp), 2)
             self.assertTrue(diskp[0]['source_file'].startswith(pools_path))
             self.assertTrue(diskp[1]['source_file'].startswith(default_path))
+        # pylint: enable=no-member
 
     def test_disk_profile_kvm_disk_external_image(self):
         '''


### PR DESCRIPTION
Backport of PR #50431 

### What does this PR do?

This PR fixes several bugs in `virt.update` regarding disks.

* Adapts the use of virt.pool_info to the recently changed behavior. Without this the disk `pool` value doesn't affect the image location.
* Creates the new disk images in `virt.update`

### What issues does this PR fix or reference?

None

### Previous Behavior

`virt.update` with a new disk providing a value for the pool property always ended up computing a disk image path to `/srv/salt-images` and the disk image was not physically created.

### New Behavior

`virt.update` now uses the disk's pool property value and the disk is physically created.

### Tests written?

Yes

### Commits signed with GPG?

Yes