### PR TITLE
Add attempts kwarg in flaky test decorator

### DIFF
--- a/tests/integration/modules/test_mac_system.py
+++ b/tests/integration/modules/test_mac_system.py
@@ -34,7 +34,7 @@ SET_SUBNET_NAME = __random_string()
 
 
 @skip_if_not_root
-@flaky
+@flaky(attempts=8)
 @skipIf(not salt.utils.platform.is_darwin(), 'Test only available on macOS')
 @skipIf(not salt.utils.path.which('systemsetup'), '\'systemsetup\' binary not found in $PATH')
 class MacSystemModuleTest(ModuleCase):

--- a/tests/support/helpers.py
+++ b/tests/support/helpers.py
@@ -164,7 +164,7 @@ def expensiveTest(caller):
     return wrap
 
 
-def flaky(caller=None, condition=True):
+def flaky(caller=None, condition=True, attempts=4):
     '''
     Mark a test as flaky. The test will attempt to run five times,
     looking for a successful run. After an immediate second try,
@@ -179,7 +179,7 @@ def flaky(caller=None, condition=True):
             pass
     '''
     if caller is None:
-        return functools.partial(flaky, condition=condition)
+        return functools.partial(flaky, condition=condition, attempts=attempts)
 
     if isinstance(condition, bool) and condition is False:
         # Don't even decorate
@@ -196,7 +196,7 @@ def flaky(caller=None, condition=True):
                 function = getattr(caller, attrname)
                 if not inspect.isfunction(function) and not inspect.ismethod(function):
                     continue
-                setattr(caller, attrname, flaky(caller=function, condition=condition))
+                setattr(caller, attrname, flaky(caller=function, condition=condition, attempts=attempts))
             except Exception as exc:
                 log.exception(exc)
                 continue
@@ -204,11 +204,11 @@ def flaky(caller=None, condition=True):
 
     @functools.wraps(caller)
     def wrap(cls):
-        for attempt in range(0, 4):
+        for attempt in range(0, attempts):
             try:
                 return caller(cls)
             except Exception as exc:
-                if attempt >= 3:
+                if attempt >= attempts -1:
                     raise exc
                 backoff_time = attempt ** 2
                 log.info('Found Exception. Waiting %s seconds to retry.', backoff_time)


### PR DESCRIPTION
### What does this PR do?
The flaky decorator was added to the the mac_system tests here https://github.com/saltstack/salt/pull/48583 with an explanation as to why its needed here. This PR adds the `attempts` kwarg to the flaky decorator so we can increase the attempts each test in mac_system is run  after a failure as there is still some flaky behavior occurring.