### PR TITLE
fix when checking for service Label on macOS

### DIFF
--- a/salt/utils/mac_utils.py
+++ b/salt/utils/mac_utils.py
@@ -354,7 +354,7 @@ def _available_services(refresh=False):
                 # Follow symbolic links of files in _launchd_paths
                 file_path = os.path.join(root, file_name)
                 true_path = os.path.realpath(file_path)
-
+                log.trace('Gathering service info for {}'.format(true_path))
                 # ignore broken symlinks
                 if not os.path.exists(true_path):
                     continue
@@ -397,10 +397,16 @@ def _available_services(refresh=False):
                         logging.warning(msg, true_path)
                         continue
 
-                _available_services[plist['Label'].lower()] = {
-                    'file_name': file_name,
-                    'file_path': true_path,
-                    'plist': plist}
+                try:
+                    # not all launchd plists contain a Label key
+                    _available_services[plist['Label'].lower()] = {
+                        'file_name': file_name,
+                        'file_path': true_path,
+                        'plist': plist}
+                except KeyError:
+                    log.debug('Service {} does not contain a'
+                              ' Label key. Skipping.'.format(true_path))
+                    continue
 
     # put this in __context__ as this is a time consuming function.
     # a fix for this issue. https://github.com/saltstack/salt/issues/48414


### PR DESCRIPTION
### What does this PR do?

Fixes an issue where the mac_utils module would try to process `/System/Library/LaunchDaemons/com.apple.jetsamproperties.Mac.plist` and fail when trying to access the `Label` Key that was introduced in #50228. This adds a try/except for it and logs accordingly. 
### What issues does this PR fix or reference?

Not currently in a public release.

### Tests written?

Yes

### Commits signed with GPG?

Yes

cc @sheagcraig (I got you bud 😉) 