### PR TITLE
Fix virtual disk creation in update

### DIFF
--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -1970,7 +1970,8 @@ def update(name,
         # Create missing disks if needed
         if changes['disk']:
             for idx, item in enumerate(changes['disk']['sorted']):
-                if item in new and not os.path.isfile(all_disks[idx]['source_file']):
+                source_file = all_disks[idx]['source_file']
+                if item in changes['disk']['new'] and source_file and not os.path.isfile(source_file):
                     _qemu_image_create(all_disks[idx])
 
         try:

--- a/tests/unit/modules/test_virt.py
+++ b/tests/unit/modules/test_virt.py
@@ -1189,20 +1189,23 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         mock_run = MagicMock()
         with patch.dict(os.__dict__, {'chmod': mock_chmod}):  # pylint: disable=no-member
             with patch.dict(virt.__salt__, {'cmd.run': mock_run}):  # pylint: disable=no-member
-                ret = virt.update('myvm', disk_profile='default', disks=[{'name': 'added', 'size': 2048}])
+                ret = virt.update('myvm', disk_profile='default', disks=[
+                    {'name': 'cddrive', 'device': 'cdrom', 'source_file': None, 'model': 'ide'},
+                    {'name': 'added', 'size': 2048}])
                 added_disk_path = os.path.join(
                         virt.__salt__['config.get']('virt:images'), 'myvm_added.qcow2')  # pylint: disable=no-member
                 self.assertEqual(mock_run.call_args[0][0],
                                  'qemu-img create -f qcow2 {0} 2048M'.format(added_disk_path))
                 self.assertEqual(mock_chmod.call_args[0][0], added_disk_path)
                 self.assertListEqual(
-                    [os.path.join(root_dir, 'myvm_added.qcow2')],
-                    [ET.fromstring(disk).find('source').get('file') for disk in ret['disk']['attached']])
+                    [None, os.path.join(root_dir, 'myvm_added.qcow2')],
+                    [ET.fromstring(disk).find('source').get('file') if str(disk).find('<source') > -1 else None
+                     for disk in ret['disk']['attached']])
 
                 self.assertListEqual(
                     [os.path.join(root_dir, 'myvm_data.qcow2')],
                     [ET.fromstring(disk).find('source').get('file') for disk in ret['disk']['detached']])
-                devattach_mock.assert_called_once()
+                self.assertEqual(devattach_mock.call_count, 2)
                 devdetach_mock.assert_called_once()
 
         # Update nics case


### PR DESCRIPTION
### What does this PR do?

Some disk devices like cdroms may have an empty source_file: handle it
or we will fail when testing for the file presence.

### What issues does this PR fix or reference?

None referenced

### Previous Behavior

Run virt.update with a new disk and a cdrom with no attached disk before it: virt.update will fail

### New Behavior

Run virt.update with a new disk and a cdrom with no attached disk before it: virt.update will skip the cdrom when checking for disks to be created.

### Tests written?

Yes

### Commits signed with GPG?

Yes
