### PR TITLE
Introduce a new way of specifying uri + attempt to use oratab

### DIFF
--- a/salt/modules/oracle.py
+++ b/salt/modules/oracle.py
@@ -28,7 +28,10 @@ Oracle DataBase connection module
             <db>:
               uri: connection credentials in format:
             user/password@host[:port]/sid[ servicename as {sysdba|sysoper}]
-              optional keyword servicename will determine whether it is a sid or service_name
+              or
+            sid[ as {sysdba|sysoper}]
+             (ORACLE_HOME is parsed from oratab)
+            optional keyword servicename will determine whether it is a sid or service_name
             <db>:
               uri: .....
 '''
@@ -37,6 +40,8 @@ from __future__ import absolute_import, print_function, unicode_literals
 import os
 import logging
 from salt.utils.decorators import depends
+from salt.utils.files import fopen
+from salt.exceptions import CommandExecutionError
 from salt.ext import six
 
 log = logging.getLogger(__name__)
@@ -85,11 +90,14 @@ def _unicode_output(cursor, name, default_type, size, precision, scale):
 
 def _connect(uri):
     '''
-    uri = user/password@host[:port]/sid[ as {sysdba|sysoper}]
+    uri = user/password@host[:port]/sid[servicename as {sysdba|sysoper}]
+     or
+    uri = sid[ as {sysdba|sysoper}]
+     (this syntax only makes sense on non-Windows minions, ORAHOME is taken from oratab)
 
     Return cx_Oracle.Connection instance
     '''
-    # cx_Oracle.Connection() not support 'as sysdba' syntax
+    # cx_Oracle.Connection() does not support 'as sysdba' syntax
     uri_l = uri.rsplit(' as ', 1)
     if len(uri_l) == 2:
         credentials, mode = uri_l
@@ -97,33 +105,64 @@ def _connect(uri):
     else:
         credentials = uri_l[0]
         mode = 0
-
-    serv_name = False
-    userpass, hostportsid = credentials.split('@')
-    user, password = userpass.split('/')
-    hostport, sid = hostportsid.split('/')
-    if 'servicename' in sid:
-        serv_name = True
-        sid = sid.split('servicename')[0].strip()
-    hostport_l = hostport.split(':')
-    if len(hostport_l) == 2:
-        host, port = hostport_l
-    else:
-        host = hostport_l[0]
-        port = 1521
-    log.debug('connect: %s', (user, password, host, port, sid, mode))
     # force UTF-8 client encoding
     os.environ['NLS_LANG'] = '.AL32UTF8'
-    if serv_name:
-        conn = cx_Oracle.connect(user, password,
-                             cx_Oracle.makedsn(host, port, service_name=sid),
-                             mode)
+    if '@' in uri:
+        serv_name = False
+        userpass, hostportsid = credentials.split('@')
+        user, password = userpass.split('/')
+        hostport, sid = hostportsid.split('/')
+        if 'servicename' in sid:
+            serv_name = True
+            sid = sid.split('servicename')[0].strip()
+        hostport_l = hostport.split(':')
+        if len(hostport_l) == 2:
+            host, port = hostport_l
+        else:
+            host = hostport_l[0]
+            port = 1521
+        log.debug('connect: {0}'.format((user, password, host, port, sid, mode)))
+        if serv_name:
+            conn = cx_Oracle.connect(user, password, cx_Oracle.makedsn(host, port, service_name=sid), mode)
+        else:
+            conn = cx_Oracle.connect(user, password, cx_Oracle.makedsn(host, port, sid), mode)
     else:
-        conn = cx_Oracle.connect(user, password,
-                             cx_Oracle.makedsn(host, port, sid),
-                             mode)
+        sid = uri.rsplit(' as ', 1)[0]
+        orahome = _parse_oratab(sid)
+        if orahome:
+            os.environ['ORACLE_HOME'] = orahome
+        else:
+            raise CommandExecutionError('No uri defined and SID {0} not found in oratab'.format(sid))
+        os.environ['ORACLE_SID'] = sid
+        log.debug('connect: {0}'.format((sid, mode)))
+        conn = cx_Oracle.connect(mode=MODE['sysdba'])
     conn.outputtypehandler = _unicode_output
     return conn
+
+
+def _parse_oratab(sid):
+    '''
+    Return ORACLE_HOME for a given SID found in oratab
+
+    Note: only works with Unix-like minions
+    '''
+    if __grains__.get('kernel') in ('Linux', 'AIX', 'FreeBSD', 'OpenBSD', 'NetBSD'):
+        ORATAB = '/etc/oratab'
+    elif __grains__.get('kernel') in 'SunOS':
+        ORATAB = '/var/opt/oracle/oratab'
+    else:
+        # Windows has no oratab file
+        raise CommandExecutionError('No uri defined for %s and oratab not available in this OS', sid)
+    with fopen(ORATAB, 'r') as f:
+        while True:
+            line = f.readline()
+            if not line:
+                break
+            if line.startswith('#'):
+                continue
+            if sid in line.split(':')[0]:
+                return line.split(':')[1]
+    return None
 
 
 @depends('cx_Oracle', fallback_function=_cx_oracle_req)
@@ -137,8 +176,13 @@ def run_query(db, query):
 
         salt '*' oracle.run_query my_db "select * from my_table"
     '''
-    log.debug('run query on %s: %s', db, query)
-    conn = _connect(show_dbs(db)[db]['uri'])
+    if db in [x.keys()[0] for x in show_dbs()]:
+        conn = _connect(show_dbs(db)[db]['uri'])
+    else:
+        log.debug('No uri found in pillars - will try to use oratab')
+        # if db does not have uri defined in pillars
+        # or it's not defined in pillars at all parse oratab file
+        conn = _connect(uri=db)
     return conn.cursor().execute(query).fetchall()
 
 
@@ -154,14 +198,14 @@ def show_dbs(*dbs):
         salt '*' oracle.show_dbs my_db
     '''
     if dbs:
-        log.debug('get dbs from pillar: %s', dbs)
+        log.debug('get db versions for: %s', dbs)
         result = {}
         for db in dbs:
             result[db] = __salt__['pillar.get']('oracle:dbs:' + db)
         return result
     else:
         pillar_dbs = __salt__['pillar.get']('oracle:dbs')
-        log.debug('get all (%s) dbs from pillar', len(pillar_dbs))
+        log.debug('get all (%s) dbs versions', len(pillar_dbs))
         return pillar_dbs
 
 
@@ -183,12 +227,12 @@ def version(*dbs):
         ]
     result = {}
     if dbs:
-        log.debug('get db versions for: %s', dbs)
+        log.debug('get db versions for: {0}'.format(dbs))
         for db in dbs:
             if db in pillar_dbs:
                 result[db] = get_version(db)
     else:
-        log.debug('get all (%s) dbs versions', len(dbs))
+        log.debug('get all({0}) dbs versions'.format(len(dbs)))
         for db in dbs:
             result[db] = get_version(db)
     return result


### PR DESCRIPTION
### What does this PR do?

Specifying uri for all databases may be cumbersome, same goes with
maintaining pillars where some might see security concerns having
passwords stored in a central location.

This PR introduces a new uri format spec in form:
 sid[ as {sysdba|sysoper}]

As a result ORACLE_HOME and ORACLE_SID env variables are set based on
the contents of oratab. Due to the fact that this file on exists on
unix-like minions, Windows minions do not support this syntax.

Another change is that presence of oracle:dbs pillar is no longer
required when executing a query. In this case SID is set to the name
of the database argument and /sysdba login is used to run the query.

### Tests written?

No

### Commits signed with GPG?

No
