### PR TITLE
Debian info_installed compatibility

### DIFF
--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -2771,15 +2771,15 @@ def info_installed(*names, **kwargs):
     '''
     kwargs = salt.utils.args.clean_kwargs(**kwargs)
     failhard = kwargs.pop('failhard', True)
-    kwargs.pop('errors', None)  # Only for compatibility with RPM
-    attr = kwargs.pop('attr', None)
+    kwargs.pop('errors', None)                # Only for compatibility with RPM
+    attr = kwargs.pop('attr', None)           # Package attributes to return
     all_versions = kwargs.pop('all_versions', False)
 
     if kwargs:
         salt.utils.args.invalid_kwargs(kwargs)
 
     ret = dict()
-    for pkg_name, pkg_nfo in __salt__['lowpkg.info'](*names, failhard=failhard).items():
+    for pkg_name, pkg_nfo in __salt__['lowpkg.info'](*names, failhard=failhard, attr=attr).items():
         t_nfo = dict()
         # Translate dpkg-specific keys to a common structure
         for key, value in pkg_nfo.items():

--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -2771,6 +2771,10 @@ def info_installed(*names, **kwargs):
     '''
     kwargs = salt.utils.args.clean_kwargs(**kwargs)
     failhard = kwargs.pop('failhard', True)
+    kwargs.pop('errors', None)  # Only for compatibility with RPM
+    attr = kwargs.pop('attr', None)
+    all_versions = kwargs.pop('all_versions', False)
+
     if kwargs:
         salt.utils.args.invalid_kwargs(kwargs)
 

--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -2761,6 +2761,15 @@ def info_installed(*names, **kwargs):
 
         .. versionadded:: 2016.11.3
 
+    attr
+        Comma-separated package attributes. If no 'attr' is specified, all available attributes returned.
+
+        Valid attributes are:
+            version, vendor, release, build_date, build_date_time_t, install_date, install_date_time_t,
+            build_host, group, source_rpm, arch, epoch, size, license, signature, packager, url, summary, description.
+
+        .. versionadded:: Neon
+
     CLI example:
 
     .. code-block:: bash

--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -2773,7 +2773,7 @@ def info_installed(*names, **kwargs):
     failhard = kwargs.pop('failhard', True)
     kwargs.pop('errors', None)                # Only for compatibility with RPM
     attr = kwargs.pop('attr', None)           # Package attributes to return
-    all_versions = kwargs.pop('all_versions', False)
+    all_versions = kwargs.pop('all_versions', False)  # This is for backward compatible structure only
 
     if kwargs:
         salt.utils.args.invalid_kwargs(kwargs)
@@ -2796,7 +2796,10 @@ def info_installed(*names, **kwargs):
             else:
                 t_nfo[key] = value
 
-        ret[pkg_name] = t_nfo
+        if all_versions:
+            ret.setdefault(pkg_name, []).append(t_nfo)
+        else:
+            ret[pkg_name] = t_nfo
 
     return ret
 

--- a/salt/modules/dpkg.py
+++ b/salt/modules/dpkg.py
@@ -447,6 +447,15 @@ def info(*packages, **kwargs):
 
         .. versionadded:: 2016.11.3
 
+    attr
+        Comma-separated package attributes. If no 'attr' is specified, all available attributes returned.
+
+        Valid attributes are:
+            version, vendor, release, build_date, build_date_time_t, install_date, install_date_time_t,
+            build_host, group, source_rpm, arch, epoch, size, license, signature, packager, url, summary, description.
+
+        .. versionadded:: 2018.11
+
     CLI example:
 
     .. code-block:: bash
@@ -461,6 +470,10 @@ def info(*packages, **kwargs):
 
     kwargs = salt.utils.args.clean_kwargs(**kwargs)
     failhard = kwargs.pop('failhard', True)
+    attr = kwargs.pop('attr', None) or None
+    if attr:
+        attr = attr.split(',')
+
     if kwargs:
         salt.utils.args.invalid_kwargs(kwargs)
 
@@ -480,6 +493,14 @@ def info(*packages, **kwargs):
         lic = _get_pkg_license(pkg['package'])
         if lic:
             pkg['license'] = lic
-        ret[pkg['package']] = pkg
+
+        # Remove keys that aren't in attrs
+        pkg_name = pkg['package']
+        if attr:
+            for k in list(pkg.keys())[:]:
+                if k not in attr:
+                    del pkg[k]
+
+        ret[pkg_name] = pkg
 
     return ret

--- a/salt/modules/dpkg.py
+++ b/salt/modules/dpkg.py
@@ -306,7 +306,7 @@ def _get_pkg_info(*packages, **kwargs):
     ret = []
     cmd = "dpkg-query -W -f='package:" + bin_var + "\\n" \
           "revision:${binary:Revision}\\n" \
-          "architecture:${Architecture}\\n" \
+          "arch:${Architecture}\\n" \
           "maintainer:${Maintainer}\\n" \
           "summary:${Summary}\\n" \
           "source:${source:Package}\\n" \

--- a/salt/modules/dpkg.py
+++ b/salt/modules/dpkg.py
@@ -341,7 +341,7 @@ def _get_pkg_install_time(pkg, arch=None):
 
     :return:
     '''
-    iso_time = None
+    iso_time = iso_time_t = None
     loc_root = '/var/lib/dpkg/info'
     if pkg is not None:
         locations = []
@@ -351,8 +351,8 @@ def _get_pkg_install_time(pkg, arch=None):
         locations.append(os.path.join(loc_root, '{0}.list'.format(pkg)))
         for location in locations:
             try:
-                iso_time = datetime.datetime.utcfromtimestamp(
-                            int(os.path.getmtime(location))).isoformat() + 'Z'
+                iso_time_t = int(os.path.getmtime(location))
+                iso_time = datetime.datetime.utcfromtimestamp(iso_time_t).isoformat() + 'Z'
                 break
             except OSError:
                 pass
@@ -360,7 +360,7 @@ def _get_pkg_install_time(pkg, arch=None):
         if iso_time is None:
             log.debug('Unable to get package installation time for package "%s".', pkg)
 
-    return iso_time
+    return iso_time, iso_time_t
 
 
 def _get_pkg_ds_avail():

--- a/salt/modules/dpkg.py
+++ b/salt/modules/dpkg.py
@@ -354,7 +354,7 @@ def _get_pkg_install_time(pkg, arch=None):
                 iso_time = datetime.datetime.utcfromtimestamp(
                             int(os.path.getmtime(location))).isoformat() + 'Z'
                 break
-            except OSError as err:
+            except OSError:
                 pass
 
         if iso_time is None:

--- a/salt/modules/dpkg.py
+++ b/salt/modules/dpkg.py
@@ -339,7 +339,7 @@ def _get_pkg_info(*packages, **kwargs):
             key, value = pkg_info_line.split(":", 1)
             if value:
                 pkg_data[key] = value
-        install_date, install_date_t = _get_pkg_install_time(pkg_data.get('package'), pkg_data.get('architecture'))
+        install_date, install_date_t = _get_pkg_install_time(pkg_data.get('package'), pkg_data.get('arch'))
         if install_date:
             pkg_data['install_date'] = install_date
             pkg_data['install_date_time_t'] = install_date_t  # Unix ticks

--- a/salt/modules/dpkg.py
+++ b/salt/modules/dpkg.py
@@ -454,7 +454,7 @@ def info(*packages, **kwargs):
             version, vendor, release, build_date, build_date_time_t, install_date, install_date_time_t,
             build_host, group, source_rpm, arch, epoch, size, license, signature, packager, url, summary, description.
 
-        .. versionadded:: 2018.11
+        .. versionadded:: Neon
 
     CLI example:
 

--- a/salt/modules/dpkg.py
+++ b/salt/modules/dpkg.py
@@ -307,9 +307,10 @@ def _get_pkg_info(*packages, **kwargs):
             key, value = pkg_info_line.split(":", 1)
             if value:
                 pkg_data[key] = value
-        install_date = _get_pkg_install_time(pkg_data.get('package'), pkg_data.get('architecture'))
+        install_date, install_date_t = _get_pkg_install_time(pkg_data.get('package'), pkg_data.get('architecture'))
         if install_date:
             pkg_data['install_date'] = install_date
+            pkg_data['install_date_t'] = install_date_t  # Unix ticks
         pkg_data['description'] = pkg_descr.split(":", 1)[-1]
         ret.append(pkg_data)
 

--- a/tests/unit/modules/test_aptpkg.py
+++ b/tests/unit/modules/test_aptpkg.py
@@ -275,6 +275,37 @@ class AptPkgTestCase(TestCase, LoaderModuleMockMixin):
         for k in wget_pkg:
             assert k in expected_pkg
             assert wget_pkg[k] == expected_pkg[k]
+
+    @patch('salt.modules.aptpkg.__salt__', {'lowpkg.info': MagicMock(return_value=LOWPKG_INFO)})
+    def test_info_installed_all_versions(self):
+        '''
+        Test info_installed 'all_versions'.
+        Since Debian won't return same name packages with the different names,
+        this should just return different structure, backward compatible with
+        the RPM equivalents.
+
+        :return:
+        '''
+        print()
+        ret = aptpkg.info_installed('emacs', all_versions=True)
+        assert isinstance(ret, dict)
+        assert 'wget' in ret
+        assert isinstance(ret['wget'], list)
+
+        pkgs = ret['wget']
+
+        assert len(pkgs) == 1
+        assert isinstance(pkgs[0], dict)
+
+        wget_pkg = pkgs[0]
+        expected_pkg = {'url': 'http://www.gnu.org/software/wget/',
+                        'packager': 'Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>', 'name': 'wget',
+                        'install_date': '2016-08-30T22:20:15Z', 'description': 'retrieves files from the web',
+                        'version': '1.15-1ubuntu1.14.04.2', 'architecture': 'amd64', 'group': 'web', 'source': 'wget'}
+        for k in wget_pkg:
+            assert k in expected_pkg
+            assert wget_pkg[k] == expected_pkg[k]
+
     def test_owner(self):
         '''
         Test - Return the name of the package that owns the file.

--- a/tests/unit/modules/test_aptpkg.py
+++ b/tests/unit/modules/test_aptpkg.py
@@ -253,6 +253,26 @@ class AptPkgTestCase(TestCase, LoaderModuleMockMixin):
         with patch.dict(aptpkg.__salt__, {'lowpkg.info': mock}):
             self.assertEqual(aptpkg.info_installed('wget'), installed)
 
+    @patch('salt.modules.aptpkg.__salt__', {'lowpkg.info': MagicMock(return_value=LOWPKG_INFO)})
+    def test_info_installed_attr(self):
+        '''
+        Test info_installed 'attr'.
+        This doesn't test 'attr' behaviour per se, since the underlying function in dpkg
+
+        :return:
+        '''
+        ret = aptpkg.info_installed('emacs', attr='foo,bar')
+        assert isinstance(ret, dict)
+        assert 'wget' in ret
+
+        wget_pkg = ret['wget']
+        expected_pkg = {'url': 'http://www.gnu.org/software/wget/',
+                        'packager': 'Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>', 'name': 'wget',
+                        'install_date': '2016-08-30T22:20:15Z', 'description': 'retrieves files from the web',
+                        'version': '1.15-1ubuntu1.14.04.2', 'architecture': 'amd64', 'group': 'web', 'source': 'wget'}
+        for k in wget_pkg:
+            assert k in expected_pkg
+            assert wget_pkg[k] == expected_pkg[k]
     def test_owner(self):
         '''
         Test - Return the name of the package that owns the file.

--- a/tests/unit/modules/test_aptpkg.py
+++ b/tests/unit/modules/test_aptpkg.py
@@ -257,7 +257,8 @@ class AptPkgTestCase(TestCase, LoaderModuleMockMixin):
     def test_info_installed_attr(self):
         '''
         Test info_installed 'attr'.
-        This doesn't test 'attr' behaviour per se, since the underlying function in dpkg
+        This doesn't test 'attr' behaviour per se, since the underlying function is in dpkg.
+        The test should simply not raise exceptions for invalid parameter.
 
         :return:
         '''

--- a/tests/unit/modules/test_aptpkg.py
+++ b/tests/unit/modules/test_aptpkg.py
@@ -265,6 +265,7 @@ class AptPkgTestCase(TestCase, LoaderModuleMockMixin):
         ret = aptpkg.info_installed('emacs', attr='foo,bar')
         assert isinstance(ret, dict)
         assert 'wget' in ret
+        assert isinstance(ret['wget'], dict)
 
         wget_pkg = ret['wget']
         expected_pkg = {'url': 'http://www.gnu.org/software/wget/',

--- a/tests/unit/modules/test_aptpkg.py
+++ b/tests/unit/modules/test_aptpkg.py
@@ -306,14 +306,12 @@ class AptPkgTestCase(TestCase, LoaderModuleMockMixin):
             assert k in expected_pkg
             assert wget_pkg[k] == expected_pkg[k]
 
+    @patch('salt.modules.aptpkg.__salt__', {'cmd.run_stdout': MagicMock(return_value='wget: /usr/bin/wget')})
     def test_owner(self):
         '''
         Test - Return the name of the package that owns the file.
         '''
-        paths = ['/usr/bin/wget']
-        mock = MagicMock(return_value='wget: /usr/bin/wget')
-        with patch.dict(aptpkg.__salt__, {'cmd.run_stdout': mock}):
-            self.assertEqual(aptpkg.owner(*paths), 'wget')
+        assert aptpkg.owner('/usr/bin/wget') == 'wget'
 
     def test_refresh_db(self):
         '''

--- a/tests/unit/modules/test_aptpkg.py
+++ b/tests/unit/modules/test_aptpkg.py
@@ -361,41 +361,29 @@ class AptPkgTestCase(TestCase, LoaderModuleMockMixin):
                 assert aptpkg.autoremove(list_only=True) == []
                 assert aptpkg.autoremove(list_only=True, purge=True) == []
 
+    @patch('salt.modules.aptpkg._uninstall', MagicMock(return_value=UNINSTALL))
     def test_remove(self):
         '''
         Test - Remove packages.
         '''
-        with patch('salt.modules.aptpkg._uninstall',
-                   MagicMock(return_value=UNINSTALL)):
-            self.assertEqual(aptpkg.remove(name='tmux'), UNINSTALL)
+        assert aptpkg.remove(name='tmux') == UNINSTALL
 
+    @patch('salt.modules.aptpkg._uninstall', MagicMock(return_value=UNINSTALL))
     def test_purge(self):
         '''
         Test - Remove packages along with all configuration files.
         '''
-        with patch('salt.modules.aptpkg._uninstall',
-                   MagicMock(return_value=UNINSTALL)):
-            self.assertEqual(aptpkg.purge(name='tmux'), UNINSTALL)
+        assert aptpkg.purge(name='tmux') == UNINSTALL
 
+    @patch('salt.utils.pkg.clear_rtag', MagicMock())
+    @patch('salt.modules.aptpkg.list_pkgs', MagicMock(return_value=UNINSTALL))
+    @patch.multiple(aptpkg, **{'__salt__': {'config.get': MagicMock(return_value=True),
+                                            'cmd.run_all': MagicMock(return_value={'retcode': 0, 'stdout': UPGRADE})}})
     def test_upgrade(self):
         '''
         Test - Upgrades all packages.
         '''
-        with patch('salt.utils.pkg.clear_rtag', MagicMock()):
-            with patch('salt.modules.aptpkg.list_pkgs',
-                       MagicMock(return_value=UNINSTALL)):
-                mock_cmd = MagicMock(return_value={
-                    'retcode': 0,
-                    'stdout': UPGRADE
-                })
-                patch_kwargs = {
-                    '__salt__': {
-                        'config.get': MagicMock(return_value=True),
-                        'cmd.run_all': mock_cmd
-                    }
-                }
-                with patch.multiple(aptpkg, **patch_kwargs):
-                    self.assertEqual(aptpkg.upgrade(), dict())
+        assert aptpkg.upgrade() == {}
 
     # TODO: has to be broken up
     def test_show(self):

--- a/tests/unit/modules/test_aptpkg.py
+++ b/tests/unit/modules/test_aptpkg.py
@@ -397,6 +397,7 @@ class AptPkgTestCase(TestCase, LoaderModuleMockMixin):
                 with patch.multiple(aptpkg, **patch_kwargs):
                     self.assertEqual(aptpkg.upgrade(), dict())
 
+    # TODO: has to be broken up
     def test_show(self):
         '''
         Test that the pkg.show function properly parses apt-cache show output.

--- a/tests/unit/modules/test_dpkg.py
+++ b/tests/unit/modules/test_dpkg.py
@@ -154,3 +154,21 @@ class DpkgTestCase(TestCase, LoaderModuleMockMixin):
         assert pkg_data['section'] == 'editors'
         assert pkg_data['maintainer'] == 'Simpsons Developers <simpsons-devel-discuss@lists.springfield.org>'
         assert pkg_data['license'] == 'BSD v3'
+
+    @patch('salt.modules.dpkg._get_pkg_ds_avail', MagicMock(return_value=dselect_pkg))
+    @patch('salt.modules.dpkg._get_pkg_info', MagicMock(return_value=pkgs_info))
+    @patch('salt.modules.dpkg._get_pkg_license', MagicMock(return_value='BSD v3'))
+    def test_info_attr(self):
+        '''
+        Test info with 'attr' parameter
+        :return:
+        '''
+        ret = dpkg.info('emacs', attr='arch,license,version')
+        assert isinstance(ret, dict)
+        assert 'emacs' in ret
+        for attr in ['arch', 'license', 'version']:
+            assert attr in ret['emacs']
+
+        assert ret['emacs']['arch'] == 'all'
+        assert ret['emacs']['license'] == 'BSD v3'
+        assert ret['emacs']['version'] == '46.1'

--- a/tests/unit/modules/test_dpkg.py
+++ b/tests/unit/modules/test_dpkg.py
@@ -49,7 +49,6 @@ class DpkgTestCase(TestCase, LoaderModuleMockMixin):
          'build_date_time_t': 1407430308, 'installed_size': '25', 'install_date': '2016-12-14T20:02:58Z'}
     ]
 
-
     def setup_loader_modules(self):
         return {dpkg: {}}
 

--- a/tests/unit/modules/test_dpkg.py
+++ b/tests/unit/modules/test_dpkg.py
@@ -25,6 +25,31 @@ class DpkgTestCase(TestCase, LoaderModuleMockMixin):
     '''
     Test cases for salt.modules.dpkg
     '''
+    dselect_pkg = {
+        'emacs': {'priority': 'optional', 'filename': 'pool/main/e/emacs-defaults/emacs_46.1_all.deb',
+                  'description': 'GNU Emacs editor (metapackage)', 'md5sum': '766eb2cee55ba0122dac64c4cea04445',
+                  'sha256': 'd172289b9a1608820eddad85c7ffc15f346a6e755c3120de0f64739c4bbc44ce',
+                  'description-md5': '21fb7da111336097a2378959f6d6e6a8',
+                  'bugs': 'https://bugs.launchpad.net/springfield/+filebug',
+                  'depends': 'emacs24 | emacs24-lucid | emacs24-nox', 'origin': 'Simpsons', 'version': '46.1',
+                  'task': 'ubuntu-usb, edubuntu-usb', 'original-maintainer': 'Homer Simpson <homer@springfield.org>',
+                  'package': 'emacs', 'architecture': 'all', 'size': '1692',
+                  'sha1': '9271bcec53c1f7373902b1e594d9fc0359616407', 'source': 'emacs-defaults',
+                  'maintainer': 'Simpsons Developers <simpsons-devel-discuss@lists.springfield.org>', 'supported': '9m',
+                  'section': 'editors', 'installed-size': '25'}
+    }
+
+    pkgs_info = [
+        {'version': '46.1', 'arch': 'all', 'build_date': '2014-08-07T16:51:48Z', 'install_date_time_t': 1481745778,
+         'section': 'editors', 'description': 'GNU Emacs editor (metapackage)\n GNU Emacs is the extensible '
+                                              'self-documenting text editor.\n This is a metapackage that will always '
+                                              'depend on the latest\n recommended Emacs release.\n',
+         'package': 'emacs', 'source': 'emacs-defaults',
+         'maintainer': 'Simpsons Developers <simpsons-devel-discuss@lists.springfield.org>',
+         'build_date_time_t': 1407430308, 'installed_size': '25', 'install_date': '2016-12-14T20:02:58Z'}
+    ]
+
+
     def setup_loader_modules(self):
         return {dpkg: {}}
 
@@ -102,3 +127,30 @@ class DpkgTestCase(TestCase, LoaderModuleMockMixin):
                                        'stdout': 'Salt'})
         with patch.dict(dpkg.__salt__, {'cmd.run_all': mock}):
             self.assertEqual(dpkg.file_dict('httpd'), 'Error:  error')
+
+    @patch('salt.modules.dpkg._get_pkg_ds_avail', MagicMock(return_value=dselect_pkg))
+    @patch('salt.modules.dpkg._get_pkg_info', MagicMock(return_value=pkgs_info))
+    @patch('salt.modules.dpkg._get_pkg_license', MagicMock(return_value='BSD v3'))
+    def test_info(self):
+        '''
+        Test info
+        :return:
+        '''
+        ret = dpkg.info('emacs')
+
+        assert isinstance(ret, dict)
+        assert len(ret.keys()) == 1
+        assert 'emacs' in ret
+
+        pkg_data = ret['emacs']
+
+        assert isinstance(pkg_data, dict)
+        for pkg_section in ['section', 'architecture', 'original-maintainer', 'maintainer', 'package', 'installed-size',
+                            'build_date_time_t', 'sha256', 'origin', 'build_date', 'size', 'source', 'version',
+                            'install_date_time_t', 'license', 'priority', 'description', 'md5sum', 'supported',
+                            'filename', 'sha1', 'install_date', 'arch']:
+            assert pkg_section in pkg_data
+
+        assert pkg_data['section'] == 'editors'
+        assert pkg_data['maintainer'] == 'Simpsons Developers <simpsons-devel-discuss@lists.springfield.org>'
+        assert pkg_data['license'] == 'BSD v3'


### PR DESCRIPTION
### What does this PR do?

Brings `info_installed` function compatible with the RPM equivalent

### Tests written?

Yes
