### PR TITLE
Adding the released version as the bootstrap minion.

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,6 +1,6 @@
 ---
 <% vagrant = system('gem list -i kitchen-vagrant 2>/dev/null >/dev/null') %>
-<% version = '2018.3.3' %>
+<% version = 'v2018.3.3' %>
 <% platformsfile = ENV['SALT_KITCHEN_PLATFORMS'] || '.kitchen/platforms.yml' %>
 <% driverfile = ENV['SALT_KITCHEN_DRIVER'] || '.kitchen/driver.yml' %>
 <% verifierfile = ENV['SALT_KITCHEN_VERIFIER'] || '.kitchen/verifier.yml' %>

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -30,7 +30,7 @@ provisioner:
   salt_install: bootstrap
   salt_version: latest
   salt_bootstrap_url: https://bootstrap.saltstack.com
-  salt_bootstrap_options: -X -p rsync <%= version %>
+  salt_bootstrap_options: -X -p rsync git <%= version %>
   log_level: info
   sudo: true
   require_chef: false

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -30,7 +30,7 @@ provisioner:
   salt_install: bootstrap
   salt_version: latest
   salt_bootstrap_url: https://bootstrap.saltstack.com
-  salt_bootstrap_options: -X -p rsync stable <%= version %>
+  salt_bootstrap_options: -X -p rsync <%= version %>
   log_level: info
   sudo: true
   require_chef: false


### PR DESCRIPTION
### What does this PR do?
Updates the kitchen salt file to bootstrap salt to version v2018.3.3 instead of 2018.3.3.

### What issues does this PR fix or reference?
No fixes, just updating configuration.

### Tests written?

No

### Commits signed with GPG?

Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
