### PR TITLE
Acceptance wait time

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1015,6 +1015,10 @@ class MinionManager(MinionBase):
         auth_wait = minion.opts['acceptance_wait_time']
         failed = False
         while True:
+            if failed:
+                if auth_wait < self.max_auth_wait:
+                    auth_wait += self.auth_wait
+                yield tornado.gen.sleep(auth_wait)  # TODO: log?
             try:
                 if minion.opts.get('beacons_before_connect', False):
                     minion.setup_beacons(before_connect=True)
@@ -1031,9 +1035,6 @@ class MinionManager(MinionBase):
                     'master at %s responding?', minion.opts['master']
                 )
                 last = time.time()
-                if auth_wait < self.max_auth_wait:
-                    auth_wait += self.auth_wait
-                yield tornado.gen.sleep(auth_wait)  # TODO: log?
             except SaltMasterUnresolvableError:
                 err = 'Master address: \'{0}\' could not be resolved. Invalid or unresolveable address. ' \
                       'Set \'master\' value in minion config.'.format(minion.opts['master'])
@@ -3029,6 +3030,10 @@ class SyndicManager(MinionBase):
         auth_wait = opts['acceptance_wait_time']
         failed = False
         while True:
+            if failed:
+                if auth_wait < self.max_auth_wait:
+                    auth_wait += self.auth_wait
+                yield tornado.gen.sleep(auth_wait)  # TODO: log?
             log.debug(
                 'Syndic attempting to connect to %s',
                 opts['master']
@@ -3058,9 +3063,6 @@ class SyndicManager(MinionBase):
                     'master at %s responding?', opts['master']
                 )
                 last = time.time()
-                if auth_wait < self.max_auth_wait:
-                    auth_wait += self.auth_wait
-                yield tornado.gen.sleep(auth_wait)  # TODO: log?
             except (KeyboardInterrupt, SystemExit):
                 raise
             except Exception:

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1017,6 +1017,12 @@ class MinionManager(MinionBase):
             if failed:
                 if auth_wait < self.max_auth_wait:
                     auth_wait += self.auth_wait
+                log.debug(
+                    "sleeping before reconnect attempt to %s [%d/%d]",
+                   minion.opts['master'],
+                    auth_wait,
+                    self.max_auth_wait,
+                )
                 yield tornado.gen.sleep(auth_wait)  # TODO: log?
             try:
                 if minion.opts.get('beacons_before_connect', False):
@@ -3030,6 +3036,12 @@ class SyndicManager(MinionBase):
             if failed:
                 if auth_wait < self.max_auth_wait:
                     auth_wait += self.auth_wait
+                log.debug(
+                    "sleeping before reconnect attempt to %s [%d/%d]",
+                    opts['master'],
+                    auth_wait,
+                    self.max_auth_wait,
+                )
                 yield tornado.gen.sleep(auth_wait)  # TODO: log?
             log.debug(
                 'Syndic attempting to connect to %s',

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1011,7 +1011,6 @@ class MinionManager(MinionBase):
         '''
         Create a minion, and asynchronously connect it to a master
         '''
-        last = 0  # never have we signed in
         auth_wait = minion.opts['acceptance_wait_time']
         failed = False
         while True:
@@ -1034,7 +1033,6 @@ class MinionManager(MinionBase):
                     'Error while bringing up minion for multi-master. Is '
                     'master at %s responding?', minion.opts['master']
                 )
-                last = time.time()
             except SaltMasterUnresolvableError:
                 err = 'Master address: \'{0}\' could not be resolved. Invalid or unresolveable address. ' \
                       'Set \'master\' value in minion config.'.format(minion.opts['master'])
@@ -3026,7 +3024,6 @@ class SyndicManager(MinionBase):
         '''
         Create a syndic, and asynchronously connect it to a master
         '''
-        last = 0  # never have we signed in
         auth_wait = opts['acceptance_wait_time']
         failed = False
         while True:
@@ -3062,7 +3059,6 @@ class SyndicManager(MinionBase):
                     'Error while bringing up syndic for multi-syndic. Is the '
                     'master at %s responding?', opts['master']
                 )
-                last = time.time()
             except (KeyboardInterrupt, SystemExit):
                 raise
             except Exception:


### PR DESCRIPTION
### What does this PR do?
Always enforce `acceptance_wait_time` if a retry is going to happen

### Previous Behavior
If the exception wasn't a `SaltClientError` it would spin indefinitely

### New Behavior
Wait the configured time