### PR TITLE
Add support to highstate_return.py for user authentication

### DIFF
--- a/salt/returners/highstate_return.py
+++ b/salt/returners/highstate_return.py
@@ -44,6 +44,10 @@ Here is an example of what the configuration might look like:
       smtp_success_subject: 'success minion {id} on host {host}'
       smtp_failure_subject: 'failure minion {id} on host {host}'
       smtp_server: smtp.example.com
+      smtp_port: 25
+      smtp_tls: False
+      smtp_username: username
+      smtp_password: password
       smtp_recipients: saltusers@example.com, devops@example.com
       smtp_sender: salt@example.com
 
@@ -123,7 +127,11 @@ def _get_options(ret):
         'smtp_recipients': 'smtp_recipients',
         'smtp_failure_subject': 'smtp_failure_subject',
         'smtp_success_subject': 'smtp_success_subject',
-        'smtp_server': 'smtp_server'
+        'smtp_server': 'smtp_server',
+        'smtp_port': 'smtp_port',
+        'smtp_tls': 'smtp_tls',
+        'smtp_username': 'smtp_username',
+        'smtp_password': 'smtp_password'
     }
 
     _options = salt.returners.get_returner_options(
@@ -448,6 +456,12 @@ def _produce_output(report, failed, setup):
         sender = setup.get('smtp_sender', '')
         recipients = setup.get('smtp_recipients', '')
 
+        host = setup.get('smtp_server', '')
+        port = int(setup.get('smtp_port', 0))
+        tls = setup.get('smtp_tls')
+        username = setup.get('smtp_username')
+        password = setup.get('smtp_password')
+
         if failed:
             subject = setup.get('smtp_failure_subject', 'Installation failure')
         else:
@@ -459,10 +473,25 @@ def _produce_output(report, failed, setup):
         msg['From'] = sender
         msg['To'] = recipients
 
-        smtp = smtplib.SMTP(host=setup.get('smtp_server', ''))
+        log.debug('highstate smtp port: %d', port)
+        smtp = smtplib.SMTP(host=host, port=port)
+
+        if tls is True:
+            smtp.starttls()
+            log.debug('highstate smtp tls enabled')
+        
+        if username and password:
+            smtp.login(username, password)
+            log.debug('highstate smtp authenticated')
+        
+        # Enable logging SMTP session after the login credentials were passed
+        smtp.set_debuglevel(1)
+
         smtp.sendmail(
             sender,
             [x.strip() for x in recipients.split(',')], msg.as_string())
+        log.debug('highstate message sent.')
+
         smtp.quit()
 
 

--- a/salt/returners/highstate_return.py
+++ b/salt/returners/highstate_return.py
@@ -143,6 +143,7 @@ def _get_options(ret):
 
     return _options
 
+
 #
 # Most email readers to not support <style> tag.
 # The following dict and a function provide a primitive styler
@@ -479,13 +480,10 @@ def _produce_output(report, failed, setup):
         if tls is True:
             smtp.starttls()
             log.debug('highstate smtp tls enabled')
-        
+
         if username and password:
             smtp.login(username, password)
             log.debug('highstate smtp authenticated')
-        
-        # Enable logging SMTP session after the login credentials were passed
-        smtp.set_debuglevel(1)
 
         smtp.sendmail(
             sender,

--- a/salt/returners/highstate_return.py
+++ b/salt/returners/highstate_return.py
@@ -458,7 +458,7 @@ def _produce_output(report, failed, setup):
         recipients = setup.get('smtp_recipients', '')
 
         host = setup.get('smtp_server', '')
-        port = int(setup.get('smtp_port', 0))
+        port = int(setup.get('smtp_port', 25))
         tls = setup.get('smtp_tls')
         username = setup.get('smtp_username')
         password = setup.get('smtp_password')


### PR DESCRIPTION
### What does this PR do?

This PR adds support for sending emails with `highstate` return out of the same mail server by providing user authentication:

- `smtp_username`: Empty by default
- `smtp_password`: Empty by default

Additionally, more parameters for server configuration have been added:

- `smtp_port`: Default to `0` (same as before)
- `smtp_tls`: Default to `False` (same as before)

### What issues does this PR fix or reference?

Previously this returner was unable to send messages outside the outgoing mail server.

### New Behavior

By providing user authentication parameters you can now send emails outside the outgoing mail server.

### Tests written?

No

### Commits signed with GPG?

Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.