### PR TITLE
Use patched version of test-kitchen until next upstream release

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,8 @@
 
 source 'https://rubygems.org'
 
-gem 'test-kitchen', '~>1.21'
+# Point this back at the test-kitchen package after 1.23.3 is relased
+gem 'test-kitchen', :git => 'https://github.com/dwoz/test-kitchen.git', :branch => 'winrm_opts'
 gem 'kitchen-salt', '~>0.2'
 gem 'kitchen-sync'
 gem 'git'


### PR DESCRIPTION
### What does this PR do?

Point `test-kitchen` at my bug fix branch until next `test-kitchen` release so we can configure the winrm `receive_timeout` option.

### What issues does this PR fix or reference?

We're seeing `[execution expired]` exceptions from test kitchen in our Windows test suites. Point `test-kitchen` at my bug fix branch for upstream issue [test-kitchen 1331](https://github.com/test-kitchen/test-kitchen/issues/1331).
