### PR TITLE
 [2018.3] Adding elementary override to grains/core.py

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1365,6 +1365,7 @@ _OS_FAMILY_MAP = {
     'GCEL': 'Debian',
     'Linaro': 'Debian',
     'elementary OS': 'Debian',
+    'elementary': 'Debian',
     'Univention': 'Debian',
     'ScientificLinux': 'RedHat',
     'Raspbian': 'Debian',


### PR DESCRIPTION
### What does this PR do?
On later versions of elementary, the os_family is being populated as elementary.  In order for the `aptpkg` module to function, we need to override is to be Debian.

### What issues does this PR fix or reference?
#50461 

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
