### PR TITLE
Allow to specify used trustmodel in `gpg.verify`

### DIFF
--- a/salt/modules/gpg.py
+++ b/salt/modules/gpg.py
@@ -1031,7 +1031,8 @@ def verify(text=None,
            user=None,
            filename=None,
            gnupghome=None,
-           signature=None):
+           signature=None,
+           trustmodel=None):
     '''
     Verify a message or file
 
@@ -1054,6 +1055,18 @@ def verify(text=None,
 
         .. versionadded:: 2018.3.0
 
+    trustmodel
+        Explicitly define the used trust model. One of:
+          - pgp
+          - classic
+          - tofu
+          - tofu+pgp
+          - direct
+          - always
+          - auto
+
+        .. versionadded:: fluorine
+
     CLI Example:
 
     .. code-block:: bash
@@ -1061,21 +1074,33 @@ def verify(text=None,
         salt '*' gpg.verify text='Hello there.  How are you?'
         salt '*' gpg.verify filename='/path/to/important.file'
         salt '*' gpg.verify filename='/path/to/important.file' use_passphrase=True
+        salt '*' gpg.verify filename='/path/to/important.file' trustmodel=direct
 
     '''
     gpg = _create_gpg(user)
+    trustmodels = ('pgp', 'classic', 'tofu', 'tofu+pgp', 'direct', 'always', 'auto')
+
+    if trustmodel and trustmodel not in trustmodels:
+        msg = 'Invalid trustmodel defined: {}. Use one of: {}'.format(trustmodel, ', '.join(trustmodels))
+        log.warn(msg)
+        return {'res': False, 'message': msg}
+
+    extra_args = []
+
+    if trustmodel:
+        extra_args.extend(['--trust-model', trustmodel])
 
     if text:
-        verified = gpg.verify(text)
+        verified = gpg.verify(text, extra_args=extra_args)
     elif filename:
         if signature:
             # need to call with fopen instead of flopen due to:
             # https://bitbucket.org/vinay.sajip/python-gnupg/issues/76/verify_file-closes-passed-file-handle
             with salt.utils.files.fopen(signature, 'rb') as _fp:
-                verified = gpg.verify_file(_fp, filename)
+                verified = gpg.verify_file(_fp, filename, extra_args=extra_args)
         else:
             with salt.utils.files.flopen(filename, 'rb') as _fp:
-                verified = gpg.verify_file(_fp)
+                verified = gpg.verify_file(_fp, extra_args=extra_args)
     else:
         raise SaltInvocationError('filename or text must be passed.')
 


### PR DESCRIPTION
### What does this PR do?
It allows to explicitly specify the trust model used by `gpg.verify`, such as `direct` or `tofu+pgp`

### What issues does this PR fix or reference?
None

### Previous Behavior
`gpg.verify` always used the trust model implicitly defined by python-gnupg/GnuPG

### New Behavior
The previous behaviour can be overridden by explicitly providing a trust model.

### Tests written?
No

### Commits signed with GPG?
Yes