### PR TITLE
Update digital ocean location for cloud tests

### DIFF
--- a/tests/integration/cloud/providers/test_digital_ocean.py
+++ b/tests/integration/cloud/providers/test_digital_ocean.py
@@ -95,7 +95,7 @@ class DigitalOceanTest(ShellCase):
         '''
         _list_locations = self.run_cloud('--list-locations {0}'.format(PROVIDER_NAME))
         self.assertIn(
-            'San Francisco 1',
+            'San Francisco 2',
             [i.strip() for i in _list_locations]
         )
 

--- a/tests/integration/cloud/providers/test_digital_ocean.py
+++ b/tests/integration/cloud/providers/test_digital_ocean.py
@@ -30,6 +30,7 @@ def __random_name(size=6):
         for x in range(size)
     )
 
+
 # Create the cloud instance name to be used throughout the tests
 INSTANCE_NAME = __random_name()
 PROVIDER_NAME = 'digital_ocean'


### PR DESCRIPTION
### What does this PR do?
Digital Ocean updated their location to San Francisco 2. The digital ocean cloud tests are currently failing and will require this PR and https://github.com/saltstack/salt-jenkins/pull/1202 to be merged
