### PR TITLE
Don't import obsolete Directive class from Sphinx

### DIFF
--- a/doc/_ext/saltdomain.py
+++ b/doc/_ext/saltdomain.py
@@ -7,7 +7,7 @@ from docutils.parsers.rst import Directive
 
 from docutils.statemachine import ViewList
 from sphinx import addnodes
-from sphinx.directives import ObjectDescription, Directive
+from sphinx.directives import ObjectDescription
 from sphinx.domains import Domain, ObjType
 from sphinx.domains.python import PyObject
 from sphinx.locale import l_, _


### PR DESCRIPTION
`Directive` was apparently removed from Sphinx and made part of docutils.  For some reason, in this saltdomain extension, we were importing both from docutils and sphinx. This worked well enough while `Directive` was still only deprecated, but it appears to recently have been removed, meaning that it now just causes an `ImportError`.

This commit removes the redundant import.