### PR TITLE
Back-port #50228 and #50443 to 2018.3

### DIFF
--- a/salt/utils/mac_utils.py
+++ b/salt/utils/mac_utils.py
@@ -11,6 +11,7 @@ import subprocess
 import os
 import plistlib
 import time
+import xml.parsers.expat
 
 # Import Salt Libs
 import salt.modules.cmdmod
@@ -306,6 +307,12 @@ def launchctl(sub_cmd, *args, **kwargs):
 def _available_services(refresh=False):
     '''
     This is a helper function for getting the available macOS services.
+
+    The strategy is to look through the known system locations for
+    launchd plist files, parse them, and use their information for
+    populating the list of services. Services can run without a plist
+    file present, but normally services which have an automated startup
+    will have a plist file, so this is a minor compromise.
     '''
     try:
         if __context__['available_services'] and not refresh:
@@ -339,39 +346,47 @@ def _available_services(refresh=False):
                     continue
 
                 try:
-                    # This assumes most of the plist files
-                    # will be already in XML format
-                    plist = plistlib.readPlist(true_path)
+                    if six.PY2:
+                        # py2 plistlib can't read binary plists, and
+                        # uses a different API than py3.
+                        plist = plistlib.readPlist(true_path)
+                    else:
+                        with salt.utils.files.fopen(true_path, 'rb') as handle:
+                            plist = plistlib.load(handle)
 
-                except Exception:
-                    # If plistlib is unable to read the file we'll need to use
-                    # the system provided plutil program to attempt conversion
-                    # from binary.
+                except plistlib.InvalidFileException:
+                    # Raised in python3 if the file is not XML.
+                    # There's nothing we can do; move on to the next one.
+                    msg = 'Unable to parse "%s" as it is invalid XML: InvalidFileException.'
+                    logging.warning(msg, true_path)
+                    continue
+
+                except xml.parsers.expat.ExpatError:
+                    # Raised by py2 for all errors.
+                    # Raised by py3 if the file is XML, but with errors.
+                    if six.PY3:
+                        # There's an error in the XML, so move on.
+                        msg = 'Unable to parse "%s" as it is invalid XML: xml.parsers.expat.ExpatError.'
+                        logging.warning(msg, true_path)
+                        continue
+
+                    # Use the system provided plutil program to attempt
+                    # conversion from binary.
                     cmd = '/usr/bin/plutil -convert xml1 -o - -- "{0}"'.format(
                         true_path)
                     try:
                         plist_xml = __salt__['cmd.run'](cmd)
-                        if six.PY2:
-                            plist = plistlib.readPlistFromString(plist_xml)
-                        else:
-                            plist = plistlib.loads(
-                                salt.utils.stringutils.to_bytes(plist_xml))
-                    except Exception:
-                        # If the file is actually just invalid XML, move on to
-                        # the next one.
+                        plist = plistlib.readPlistFromString(plist_xml)
+                    except xml.parsers.expat.ExpatError:
+                        # There's still an error in the XML, so move on.
+                        msg = 'Unable to parse "%s" as it is invalid XML: xml.parsers.expat.ExpatError.'
+                        logging.warning(msg, true_path)
                         continue
 
-                try:
-                    _available_services[plist.Label.lower()] = {
-                        'file_name': file_name,
-                        'file_path': true_path,
-                        'plist': plist}
-                except AttributeError:
-                    # Handle malformed plist files
-                    _available_services[os.path.basename(file_name).lower()] = {
-                        'file_name': file_name,
-                        'file_path': true_path,
-                        'plist': plist}
+                _available_services[plist['Label'].lower()] = {
+                    'file_name': file_name,
+                    'file_path': true_path,
+                    'plist': plist}
 
     # put this in __context__ as this is a time consuming function.
     # a fix for this issue. https://github.com/saltstack/salt/issues/48414

--- a/salt/utils/mac_utils.py
+++ b/salt/utils/mac_utils.py
@@ -349,7 +349,7 @@ def _available_services(refresh=False):
                 # Follow symbolic links of files in _launchd_paths
                 file_path = os.path.join(root, file_name)
                 true_path = os.path.realpath(file_path)
-                log.trace('Gathering service info for {}'.format(true_path))
+                log.trace('Gathering service info for %s', true_path)
                 # ignore broken symlinks
                 if not os.path.exists(true_path):
                     continue
@@ -399,8 +399,8 @@ def _available_services(refresh=False):
                         'file_path': true_path,
                         'plist': plist}
                 except KeyError:
-                    log.debug('Service {} does not contain a'
-                              ' Label key. Skipping.'.format(true_path))
+                    log.debug('Service %s does not contain a'
+                              ' Label key. Skipping.', true_path)
                     continue
 
     # put this in __context__ as this is a time consuming function.

--- a/salt/utils/mac_utils.py
+++ b/salt/utils/mac_utils.py
@@ -349,7 +349,7 @@ def _available_services(refresh=False):
                 # Follow symbolic links of files in _launchd_paths
                 file_path = os.path.join(root, file_name)
                 true_path = os.path.realpath(file_path)
-
+                log.trace('Gathering service info for {}'.format(true_path))
                 # ignore broken symlinks
                 if not os.path.exists(true_path):
                     continue
@@ -392,10 +392,16 @@ def _available_services(refresh=False):
                         logging.warning(msg, true_path)
                         continue
 
-                _available_services[plist['Label'].lower()] = {
-                    'file_name': file_name,
-                    'file_path': true_path,
-                    'plist': plist}
+                try:
+                    # not all launchd plists contain a Label key
+                    _available_services[plist['Label'].lower()] = {
+                        'file_name': file_name,
+                        'file_path': true_path,
+                        'plist': plist}
+                except KeyError:
+                    log.debug('Service {} does not contain a'
+                              ' Label key. Skipping.'.format(true_path))
+                    continue
 
     # put this in __context__ as this is a time consuming function.
     # a fix for this issue. https://github.com/saltstack/salt/issues/48414

--- a/salt/utils/mac_utils.py
+++ b/salt/utils/mac_utils.py
@@ -328,6 +328,15 @@ def _available_services(refresh=False):
         '/System/Library/LaunchAgents',
         '/System/Library/LaunchDaemons',
     ]
+
+    try:
+        for user in os.listdir('/Users/'):
+            agent_path = '/Users/{}/Library/LaunchAgents'.format(user)
+            if os.path.isdir(agent_path):
+                launchd_paths.append(agent_path)
+    except OSError:
+        pass
+
     _available_services = dict()
     for launch_dir in launchd_paths:
         for root, dirs, files in salt.utils.path.os_walk(launch_dir):

--- a/salt/utils/mac_utils.py
+++ b/salt/utils/mac_utils.py
@@ -40,6 +40,11 @@ __salt__ = {
     'cmd.run': salt.modules.cmdmod._run_quiet,
 }
 
+if six.PY2:
+    class InvalidFileException(Exception):
+        pass
+    plistlib.InvalidFileException = InvalidFileException
+
 
 def __virtual__():
     '''

--- a/salt/utils/mac_utils.py
+++ b/salt/utils/mac_utils.py
@@ -340,15 +340,21 @@ def _available_services(refresh=False):
 
                 except Exception:
                     # If plistlib is unable to read the file we'll need to use
-                    # the system provided plutil program to do the conversion
+                    # the system provided plutil program to attempt conversion
+                    # from binary.
                     cmd = '/usr/bin/plutil -convert xml1 -o - -- "{0}"'.format(
                         true_path)
-                    plist_xml = __salt__['cmd.run'](cmd)
-                    if six.PY2:
-                        plist = plistlib.readPlistFromString(plist_xml)
-                    else:
-                        plist = plistlib.loads(
-                            salt.utils.stringutils.to_bytes(plist_xml))
+                    try:
+                        plist_xml = __salt__['cmd.run'](cmd)
+                        if six.PY2:
+                            plist = plistlib.readPlistFromString(plist_xml)
+                        else:
+                            plist = plistlib.loads(
+                                salt.utils.stringutils.to_bytes(plist_xml))
+                    except Exception:
+                        # If the file is actually just invalid XML, move on to
+                        # the next one.
+                        continue
 
                 try:
                     _available_services[plist.Label.lower()] = {

--- a/tests/unit/utils/test_mac_utils.py
+++ b/tests/unit/utils/test_mac_utils.py
@@ -213,261 +213,85 @@ class MacUtilsTestCase(TestCase, LoaderModuleMockMixin):
             except CommandExecutionError as exc:
                 self.assertEqual(exc.message, error)
 
+    def _get_walk_side_effects(self, results):
+        '''
+        Data generation helper function for service tests.
+        '''
+        def walk_side_effect(*args, **kwargs):
+            return [(args[0], [], results.get(args[0], []))]
+        return walk_side_effect
+
+
     @patch('salt.utils.path.os_walk')
     @patch('os.path.exists')
-    @patch('plistlib.readPlist')
-    def test_available_services(self, mock_read_plist, mock_exists, mock_os_walk):
+    def test_available_services_result(self, mock_exists, mock_os_walk):
         '''
-        test available_services
+        test available_services results are properly formed dicts.
         '''
-        mock_os_walk.side_effect = [
-            [('/Library/LaunchAgents', [], ['com.apple.lla1.plist', 'com.apple.lla2.plist'])],
-            [('/Library/LaunchDaemons', [], ['com.apple.lld1.plist', 'com.apple.lld2.plist'])],
-            [('/System/Library/LaunchAgents', [], ['com.apple.slla1.plist', 'com.apple.slla2.plist'])],
-            [('/System/Library/LaunchDaemons', [], ['com.apple.slld1.plist', 'com.apple.slld2.plist'])],
-        ]
-
-        mock_read_plist.side_effect = [
-            MagicMock(Label='com.apple.lla1'),
-            MagicMock(Label='com.apple.lla2'),
-            MagicMock(Label='com.apple.lld1'),
-            MagicMock(Label='com.apple.lld2'),
-            MagicMock(Label='com.apple.slla1'),
-            MagicMock(Label='com.apple.slla2'),
-            MagicMock(Label='com.apple.slld1'),
-            MagicMock(Label='com.apple.slld2'),
-        ]
-
+        results = {'/Library/LaunchAgents': ['com.apple.lla1.plist']}
+        mock_os_walk.side_effect = self._get_walk_side_effects(results)
         mock_exists.return_value = True
-        ret = mac_utils._available_services()
 
-        # Make sure it's a dict with 8 items
+        mock_plist = {'Label': 'com.apple.lla1'}
+        if six.PY2:
+            mock_read_plist = MagicMock(return_value=mock_plist)
+            with patch('plistlib.readPlist', mock_read_plist):
+                ret = mac_utils._available_services()
+        else:
+            mock_load = MagicMock(return_value=mock_plist)
+            with patch('salt.utils.files.fopen', mock_open()), patch('plistlib.load', mock_load):
+                ret = mac_utils._available_services()
+
         self.assertTrue(isinstance(ret, dict))
-        self.assertEqual(len(ret), 8)
-
-        self.assertEqual(
-            ret['com.apple.lla1']['file_name'],
-            'com.apple.lla1.plist')
-
+        self.assertEqual(len(ret), 1)
+        self.assertEqual(ret['com.apple.lla1']['file_name'], 'com.apple.lla1.plist')
         self.assertEqual(
             ret['com.apple.lla1']['file_path'],
-            os.path.realpath(
-                os.path.join('/Library/LaunchAgents', 'com.apple.lla1.plist')))
-
-        self.assertEqual(
-            ret['com.apple.slld2']['file_name'],
-            'com.apple.slld2.plist')
-
-        self.assertEqual(
-            ret['com.apple.slld2']['file_path'],
-            os.path.realpath(
-                os.path.join('/System/Library/LaunchDaemons', 'com.apple.slld2.plist')))
+            os.path.realpath(os.path.join('/Library/LaunchAgents', 'com.apple.lla1.plist')))
 
     @patch('salt.utils.path.os_walk')
     @patch('os.path.exists')
-    @patch('plistlib.readPlist')
-    def test_available_services_broken_symlink(self, mock_read_plist, mock_exists, mock_os_walk):
+    @patch('os.listdir')
+    @patch('os.path.isdir')
+    def test_available_services_dirs(self,
+                                     mock_isdir,
+                                     mock_listdir,
+                                     mock_exists,
+                                     mock_os_walk):
         '''
-        test available_services
+        test available_services checks all of the expected dirs.
         '''
-        mock_os_walk.side_effect = [
-            [('/Library/LaunchAgents', [], ['com.apple.lla1.plist', 'com.apple.lla2.plist'])],
-            [('/Library/LaunchDaemons', [], ['com.apple.lld1.plist', 'com.apple.lld2.plist'])],
-            [('/System/Library/LaunchAgents', [], ['com.apple.slla1.plist', 'com.apple.slla2.plist'])],
-            [('/System/Library/LaunchDaemons', [], ['com.apple.slld1.plist', 'com.apple.slld2.plist'])],
-        ]
+        results = {
+            '/Library/LaunchAgents': ['com.apple.lla1.plist'],
+            '/Library/LaunchDaemons': ['com.apple.lld1.plist'],
+            '/System/Library/LaunchAgents': ['com.apple.slla1.plist'],
+            '/System/Library/LaunchDaemons': ['com.apple.slld1.plist'],
+            '/Users/saltymcsaltface/Library/LaunchAgents': [
+                'com.apple.uslla1.plist']}
 
-        mock_read_plist.side_effect = [
-            MagicMock(Label='com.apple.lla1'),
-            MagicMock(Label='com.apple.lla2'),
-            MagicMock(Label='com.apple.lld1'),
-            MagicMock(Label='com.apple.lld2'),
-            MagicMock(Label='com.apple.slld1'),
-            MagicMock(Label='com.apple.slld2'),
-        ]
-
-        mock_exists.side_effect = [True, True, True, True, False, False, True, True]
-        ret = mac_utils._available_services()
-
-        # Make sure it's a dict with 6 items
-        self.assertTrue(isinstance(ret, dict))
-        self.assertEqual(len(ret), 6)
-
-        self.assertEqual(
-            ret['com.apple.lla1']['file_name'],
-            'com.apple.lla1.plist')
-
-        self.assertEqual(
-            ret['com.apple.lla1']['file_path'],
-            os.path.realpath(
-                os.path.join('/Library/LaunchAgents', 'com.apple.lla1.plist')))
-
-        self.assertEqual(
-            ret['com.apple.slld2']['file_name'],
-            'com.apple.slld2.plist')
-
-        self.assertEqual(
-            ret['com.apple.slld2']['file_path'],
-            os.path.realpath(
-                os.path.join('/System/Library/LaunchDaemons', 'com.apple.slld2.plist')))
-
-    @patch('salt.utils.path.os_walk')
-    @patch('os.path.exists')
-    @patch('plistlib.readPlist')
-    @patch('salt.utils.mac_utils.__salt__')
-    @patch('plistlib.readPlistFromString' if six.PY2 else 'plistlib.loads')
-    def test_available_services_non_xml(self,
-                                        mock_read_plist_from_string,
-                                        mock_run,
-                                        mock_read_plist,
-                                        mock_exists,
-                                        mock_os_walk):
-        '''
-        test available_services
-        '''
-        mock_os_walk.side_effect = [
-            [('/Library/LaunchAgents', [], ['com.apple.lla1.plist', 'com.apple.lla2.plist'])],
-            [('/Library/LaunchDaemons', [], ['com.apple.lld1.plist', 'com.apple.lld2.plist'])],
-            [('/System/Library/LaunchAgents', [], ['com.apple.slla1.plist', 'com.apple.slla2.plist'])],
-            [('/System/Library/LaunchDaemons', [], ['com.apple.slld1.plist', 'com.apple.slld2.plist'])],
-        ]
-        attrs = {'cmd.run': MagicMock(return_value='<some xml>')}
-
-        def getitem(name):
-            return attrs[name]
-
-        mock_run.__getitem__.side_effect = getitem
-        mock_run.configure_mock(**attrs)
+        mock_os_walk.side_effect = self._get_walk_side_effects(results)
+        mock_listdir.return_value = ['saltymcsaltface']
+        mock_isdir.return_value = True
         mock_exists.return_value = True
-        mock_read_plist.side_effect = Exception()
-        mock_read_plist_from_string.side_effect = [
-            MagicMock(Label='com.apple.lla1'),
-            MagicMock(Label='com.apple.lla2'),
-            MagicMock(Label='com.apple.lld1'),
-            MagicMock(Label='com.apple.lld2'),
-            MagicMock(Label='com.apple.slla1'),
-            MagicMock(Label='com.apple.slla2'),
-            MagicMock(Label='com.apple.slld1'),
-            MagicMock(Label='com.apple.slld2'),
-        ]
 
-        ret = mac_utils._available_services()
+        plists = [
+            {'Label': 'com.apple.lla1'},
+            {'Label': 'com.apple.lld1'},
+            {'Label': 'com.apple.slla1'},
+            {'Label': 'com.apple.slld1'},
+            {'Label': 'com.apple.uslla1'}]
 
-        cmd = '/usr/bin/plutil -convert xml1 -o - -- "{0}"'
-        calls = [
-            call.cmd.run(cmd.format(os.path.realpath(os.path.join(
-                         '/Library/LaunchAgents', 'com.apple.lla1.plist'))),),
-            call.cmd.run(cmd.format(os.path.realpath(os.path.join(
-                         '/Library/LaunchAgents', 'com.apple.lla2.plist'))),),
-            call.cmd.run(cmd.format(os.path.realpath(os.path.join(
-                         '/Library/LaunchDaemons', 'com.apple.lld1.plist'))),),
-            call.cmd.run(cmd.format(os.path.realpath(os.path.join(
-                         '/Library/LaunchDaemons', 'com.apple.lld2.plist'))),),
-            call.cmd.run(cmd.format(os.path.realpath(os.path.join(
-                         '/System/Library/LaunchAgents', 'com.apple.slla1.plist'))),),
-            call.cmd.run(cmd.format(os.path.realpath(os.path.join(
-                         '/System/Library/LaunchAgents', 'com.apple.slla2.plist'))),),
-            call.cmd.run(cmd.format(os.path.realpath(os.path.join(
-                         '/System/Library/LaunchDaemons', 'com.apple.slld1.plist'))),),
-            call.cmd.run(cmd.format(os.path.realpath(os.path.join(
-                         '/System/Library/LaunchDaemons', 'com.apple.slld2.plist'))),),
-        ]
-        mock_run.assert_has_calls(calls, any_order=True)
+        if six.PY2:
+            mock_read_plist = MagicMock()
+            mock_read_plist.side_effect = plists
+            with patch('plistlib.readPlist', mock_read_plist):
+                ret = mac_utils._available_services()
+        else:
+            mock_load = MagicMock()
+            mock_load.side_effect = plists
+            with patch('salt.utils.files.fopen', mock_open()):
+                with patch('plistlib.load', mock_load):
+                    ret = mac_utils._available_services()
 
-        # Make sure it's a dict with 8 items
-        self.assertTrue(isinstance(ret, dict))
-        self.assertEqual(len(ret), 8)
+        self.assertEqual(len(ret), 5)
 
-        self.assertEqual(
-            ret['com.apple.lla1']['file_name'],
-            'com.apple.lla1.plist')
-
-        self.assertEqual(
-            ret['com.apple.lla1']['file_path'],
-            os.path.realpath(
-                os.path.join('/Library/LaunchAgents', 'com.apple.lla1.plist')))
-
-        self.assertEqual(
-            ret['com.apple.slld2']['file_name'],
-            'com.apple.slld2.plist')
-
-        self.assertEqual(
-            ret['com.apple.slld2']['file_path'],
-            os.path.realpath(
-                os.path.join('/System/Library/LaunchDaemons', 'com.apple.slld2.plist')))
-
-    @patch('salt.utils.path.os_walk')
-    @patch('os.path.exists')
-    @patch('plistlib.readPlist')
-    @patch('salt.utils.mac_utils.__salt__')
-    @patch('plistlib.readPlistFromString' if six.PY2 else 'plistlib.loads')
-    def test_available_services_non_xml_malformed_plist(self,
-                                                        mock_read_plist_from_string,
-                                                        mock_run,
-                                                        mock_read_plist,
-                                                        mock_exists,
-                                                        mock_os_walk):
-        '''
-        test available_services
-        '''
-        mock_os_walk.side_effect = [
-            [('/Library/LaunchAgents', [], ['com.apple.lla1.plist', 'com.apple.lla2.plist'])],
-            [('/Library/LaunchDaemons', [], ['com.apple.lld1.plist', 'com.apple.lld2.plist'])],
-            [('/System/Library/LaunchAgents', [], ['com.apple.slla1.plist', 'com.apple.slla2.plist'])],
-            [('/System/Library/LaunchDaemons', [], ['com.apple.slld1.plist', 'com.apple.slld2.plist'])],
-        ]
-        attrs = {'cmd.run': MagicMock(return_value='<some xml>')}
-
-        def getitem(name):
-            return attrs[name]
-
-        mock_run.__getitem__.side_effect = getitem
-        mock_run.configure_mock(**attrs)
-        mock_exists.return_value = True
-        mock_read_plist.side_effect = Exception()
-        mock_read_plist_from_string.return_value = Exception()
-
-        ret = mac_utils._available_services()
-
-        cmd = '/usr/bin/plutil -convert xml1 -o - -- "{0}"'
-        calls = [
-            call.cmd.run(cmd.format(os.path.realpath(os.path.join(
-                         '/Library/LaunchAgents', 'com.apple.lla1.plist'))),),
-            call.cmd.run(cmd.format(os.path.realpath(os.path.join(
-                         '/Library/LaunchAgents', 'com.apple.lla2.plist'))),),
-            call.cmd.run(cmd.format(os.path.realpath(os.path.join(
-                         '/Library/LaunchDaemons', 'com.apple.lld1.plist'))),),
-            call.cmd.run(cmd.format(os.path.realpath(os.path.join(
-                         '/Library/LaunchDaemons', 'com.apple.lld2.plist'))),),
-            call.cmd.run(cmd.format(os.path.realpath(os.path.join(
-                         '/System/Library/LaunchAgents', 'com.apple.slla1.plist'))),),
-            call.cmd.run(cmd.format(os.path.realpath(os.path.join(
-                         '/System/Library/LaunchAgents', 'com.apple.slla2.plist'))),),
-            call.cmd.run(cmd.format(os.path.realpath(os.path.join(
-                         '/System/Library/LaunchDaemons', 'com.apple.slld1.plist'))),),
-            call.cmd.run(cmd.format(os.path.realpath(os.path.join(
-                         '/System/Library/LaunchDaemons', 'com.apple.slld2.plist'))),),
-        ]
-        mock_run.assert_has_calls(calls, any_order=True)
-
-        # Make sure it's a dict with 8 items
-        self.assertTrue(isinstance(ret, dict))
-        self.assertEqual(len(ret), 8)
-
-        self.assertEqual(
-            ret['com.apple.lla1.plist']['file_name'],
-            'com.apple.lla1.plist')
-
-        self.assertEqual(
-            ret['com.apple.lla1.plist']['file_path'],
-            os.path.realpath(
-                os.path.join('/Library/LaunchAgents', 'com.apple.lla1.plist')))
-
-        self.assertEqual(
-            ret['com.apple.slld2.plist']['file_name'],
-            'com.apple.slld2.plist')
-
-        self.assertEqual(
-            ret['com.apple.slld2.plist']['file_path'],
-            os.path.realpath(
-                os.path.join('/System/Library/LaunchDaemons', 'com.apple.slld2.plist')))

--- a/tests/unit/utils/test_mac_utils.py
+++ b/tests/unit/utils/test_mac_utils.py
@@ -425,7 +425,7 @@ class MacUtilsTestCase(TestCase, LoaderModuleMockMixin):
         mock_run.configure_mock(**attrs)
         mock_exists.return_value = True
         mock_read_plist.side_effect = Exception()
-        mock_read_plist_from_string.return_value = 'malformedness'
+        mock_read_plist_from_string.return_value = Exception()
 
         ret = mac_utils._available_services()
 

--- a/tests/unit/utils/test_mac_utils.py
+++ b/tests/unit/utils/test_mac_utils.py
@@ -5,7 +5,8 @@ mac_utils tests
 
 # Import python libs
 from __future__ import absolute_import, unicode_literals
-import os
+import plistlib
+import xml.parsers.expat
 
 # Import Salt Testing Libs
 from tests.support.unit import TestCase, skipIf
@@ -339,7 +340,6 @@ class MacUtilsTestCase(TestCase, LoaderModuleMockMixin):
 
         if six.PY2:
             mock_run.assert_has_calls(calls, any_order=True)
-
 
     @patch('salt.utils.path.os_walk')
     @patch('os.path.exists')

--- a/tests/unit/utils/test_mac_utils.py
+++ b/tests/unit/utils/test_mac_utils.py
@@ -341,6 +341,77 @@ class MacUtilsTestCase(TestCase, LoaderModuleMockMixin):
             mock_run.assert_has_calls(calls, any_order=True)
 
 
+    @patch('salt.utils.path.os_walk')
+    @patch('os.path.exists')
+    def test_available_services_invalid_file(self, mock_exists, mock_os_walk):
+        '''
+        test available_services excludes invalid files.
+
+        The py3 plistlib raises an InvalidFileException when a plist
+        file cannot be parsed. This test only asserts things for py3.
+        '''
+        if six.PY3:
+            results = {'/Library/LaunchAgents': ['com.apple.lla1.plist']}
+            mock_os_walk.side_effect = _get_walk_side_effects(results)
+            mock_exists.return_value = True
+
+            plists = [{'Label': 'com.apple.lla1'}]
+
+            mock_load = MagicMock()
+            mock_load.side_effect = plistlib.InvalidFileException
+            with patch('salt.utils.files.fopen', mock_open()):
+                with patch('plistlib.load', mock_load):
+                    ret = mac_utils._available_services()
+
+            self.assertEqual(len(ret), 0)
+
+    @patch('salt.utils.mac_utils.__salt__')
+    @patch('plistlib.readPlist')
+    @patch('salt.utils.path.os_walk')
+    @patch('os.path.exists')
+    def test_available_services_expat_error(self,
+                                            mock_exists,
+                                            mock_os_walk,
+                                            mock_read_plist,
+                                            mock_run):
+        '''
+        test available_services excludes files with expat errors.
+
+        Poorly formed XML will raise an ExpatError on py2. It will
+        also be raised by some almost-correct XML on py3.
+        '''
+        results = {'/Library/LaunchAgents': ['com.apple.lla1.plist']}
+        mock_os_walk.side_effect = _get_walk_side_effects(results)
+        mock_exists.return_value = True
+
+        if six.PY3:
+            mock_load = MagicMock()
+            mock_load.side_effect = xml.parsers.expat.ExpatError
+            with patch('salt.utils.files.fopen', mock_open()):
+                with patch('plistlib.load', mock_load):
+                    ret = mac_utils._available_services()
+        else:
+            attrs = {'cmd.run': MagicMock()}
+
+            def getitem(name):
+                return attrs[name]
+
+            mock_run.__getitem__.side_effect = getitem
+            mock_run.configure_mock(**attrs)
+            cmd = '/usr/bin/plutil -convert xml1 -o - -- "{}"'.format(
+                '/Library/LaunchAgents/com.apple.lla1.plist')
+            calls = [call.cmd.run(cmd)]
+
+            mock_raise_expat_error = MagicMock(
+                side_effect=xml.parsers.expat.ExpatError)
+
+            with patch('plistlib.readPlist', mock_raise_expat_error):
+                with patch('plistlib.readPlistFromString', mock_raise_expat_error):
+                    ret = mac_utils._available_services()
+
+            mock_run.assert_has_calls(calls, any_order=True)
+
+        self.assertEqual(len(ret), 0)
 
 
 def _get_walk_side_effects(results):

--- a/tests/unit/utils/test_mac_utils.py
+++ b/tests/unit/utils/test_mac_utils.py
@@ -10,7 +10,14 @@ import xml.parsers.expat
 
 # Import Salt Testing Libs
 from tests.support.unit import TestCase, skipIf
-from tests.support.mock import MagicMock, patch, NO_MOCK, NO_MOCK_REASON, call
+from tests.support.mock import (
+    call,
+    MagicMock,
+    mock_open,
+    NO_MOCK,
+    NO_MOCK_REASON,
+    patch
+)
 from tests.support.mixins import LoaderModuleMockMixin
 
 # Import Salt libs


### PR DESCRIPTION
Back-port #50228 and #50443 to 2018.3