### PR TITLE
Set jenkins docs job to treat any warnings as errors

### DIFF
--- a/.ci/docs
+++ b/.ci/docs
@@ -29,7 +29,7 @@ pipeline {
         }
         stage('build') {
             steps {
-                sh 'eval "$(pyenv init -)"; make -C doc clean html'
+                sh 'eval "$(pyenv init -)"; make SPHINXOPTS="-W" -C doc clean html'
             }
         }
     }
@@ -48,8 +48,8 @@ pipeline {
                 description: 'The docs job has failed',
                 status: 'FAILURE',
                 context: "jenkins/pr/docs"
-            slackSend channel: "#jenkins-prod-pr", 
-                color: '#FF0000', 
+            slackSend channel: "#jenkins-prod-pr",
+                color: '#FF0000',
                 message: "FAILED: PR-Job: '${env.JOB_NAME} [${env.BUILD_NUMBER}]' (${env.BUILD_URL})"
         }
     }

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -302,7 +302,7 @@ extensions = [
     'sphinx.ext.intersphinx',
     'httpdomain',
     'youtube',
-    'saltautodoc', # Must be AFTER autodoc
+    #'saltautodoc', # Must be AFTER autodoc
     'shorturls',
 ]
 

--- a/salt/states/alternatives.py
+++ b/salt/states/alternatives.py
@@ -201,6 +201,12 @@ def set_(name, path):
     path
         is the location of one of the alternative target files.
         (e.g. /usr/bin/less)
+
+    .. code-block:: yaml
+
+        foo:
+          alternatives.set:
+            - path: /usr/bin/foo-2.0
     '''
     ret = {'name': name,
            'path': path,

--- a/salt/states/eselect.py
+++ b/salt/states/eselect.py
@@ -5,11 +5,6 @@ Management of Gentoo configuration using eselect
 
 A state module to manage Gentoo configuration via eselect
 
-.. code-block:: yaml
-
-    profile:
-        eselect.set:
-            target: hardened/linux/amd64
 '''
 
 # Import Python libs
@@ -44,6 +39,11 @@ def set_(name, target, module_parameter=None, action_parameter=None):
     action_parameter
         additional params passed to the defined action
 
+    .. code-block:: yaml
+
+        profile:
+          eselect.set:
+            - target: hardened/linux/amd64
     '''
     ret = {'changes': {},
            'comment': '',

--- a/salt/states/etcd_mod.py
+++ b/salt/states/etcd_mod.py
@@ -113,7 +113,6 @@ __virtualname__ = 'etcd'
 # Function aliases
 __func_alias__ = {
     'set_': 'set',
-    'rm_': 'rm'
 }
 
 # Import third party libs
@@ -134,12 +133,13 @@ def __virtual__():
 
 def set_(name, value, profile=None):
     '''
-    Set a key in etcd and can be called as ``set``.
+    Set a key in etcd
 
     name
         The etcd key name, for example: ``/foo/bar/baz``.
     value
         The value the key should contain.
+
     profile
         Optional, defaults to ``None``. Sets the etcd profile to use which has
         been defined in the Salt Master config.
@@ -194,14 +194,16 @@ def wait_set(name, value, profile=None):
     }
 
 
-def rm_(name, recurse=False, profile=None):
+def rm(name, recurse=False, profile=None):
     '''
-    Deletes a key from etcd. This function is also aliased as ``rm``.
+    Deletes a key from etcd
 
     name
         The etcd key name to remove, for example ``/foo/bar/baz``.
+
     recurse
         Optional, defaults to ``False``. If ``True`` performs a recursive delete.
+
     profile
         Optional, defaults to ``None``. Sets the etcd profile to use which has
         been defined in the Salt Master config.
@@ -272,7 +274,7 @@ def mod_watch(name, **kwargs):
 
     # Watch to rm etcd key
     if kwargs.get('sfun') in ['wait_rm_key', 'wait_rm']:
-        return rm_(
+        return rm(
             name,
             kwargs.get('profile'))
 

--- a/salt/states/logrotate.py
+++ b/salt/states/logrotate.py
@@ -60,20 +60,20 @@ def set_(name, key, value, setting=None, conf_file=_DEFAULT_CONF):
     .. code-block:: yaml
 
         logrotate-rotate:
-            logrotate.set:
-                - key: rotate
-                - value: 2
+          logrotate.set:
+            - key: rotate
+            - value: 2
 
     Example of usage specifying all available arguments:
 
     .. code-block:: yaml
 
         logrotate-wtmp-rotate:
-            logrotate.set:
-                - key: /var/log/wtmp
-                - value: rotate
-                - setting: 2
-                - conf_file: /etc/logrotate.conf
+          logrotate.set:
+            - key: /var/log/wtmp
+            - value: rotate
+            - setting: 2
+            - conf_file: /etc/logrotate.conf
     '''
     ret = {'name': name,
            'changes': dict(),

--- a/salt/states/zone.py
+++ b/salt/states/zone.py
@@ -127,7 +127,6 @@ log = logging.getLogger(__name__)
 
 __func_alias__ = {
     'import_': 'import',
-    'export_': 'export',
 }
 
 # Define the state's virtual name
@@ -623,7 +622,7 @@ def halted(name, graceful=True):
     return ret
 
 
-def export_(name, path, replace=False):
+def export(name, path, replace=False):
     '''
     Export a zones configuration
 
@@ -760,6 +759,11 @@ def import_(name, path, mode='import', nodataset=False, brand_opts=None):
         ``install``: will import and then try to install the zone
         ``attach``: will import and then try to attach of the zone
 
+    .. code-block:: yaml
+
+        omipkg1:
+          zone.import:
+            - path: /foo/bar/baz
     '''
     ret = {'name': name,
            'changes': {},


### PR DESCRIPTION
This allows us to make the PR docs job fail when the PR introduces invalid RST.