### PR TITLE
Add definition for RestrictRemoteSAM

### DIFF
--- a/salt/modules/win_lgpo.py
+++ b/salt/modules/win_lgpo.py
@@ -664,6 +664,20 @@ class _policy_info(object):
                         },
                         'Transform': self.enabled_one_disabled_zero_transform,
                     },
+                    'RestrictRemoteSAM': {
+                        'Policy': 'Network access: Restrict clients allowed to '
+                                  'make remote calls to SAM',
+                        'lgpo_section': self.security_options_gpedit_path,
+                        'Registry': {
+                            'Hive': 'HKEY_LOCAL_MACHINE',
+                            'Path': 'System\\CurrentControlSet\\Control\\Lsa',
+                            'Value': 'RestrictRemoteSAM',
+                            'Type': 'REG_SZ'
+                        },
+                        'Transform': {
+                            'Put': '_string_put_transform'
+                        }
+                    },
                     'RestrictAnonymous': {
                         'Policy': 'Network access: Do not allow anonymous '
                                   'enumeration of SAM accounts and shares',


### PR DESCRIPTION
### What does this PR do?
Adds support for the "Network access: Restrict clients allowed to make remote calls to SAM" group policy

### What issues does this PR fix or reference?
https://github.com/saltstack/lock/issues/506

### Tests written?
No

### Commits signed with GPG?
Yes