### PR TITLE
Fix comment in the swarm module

### DIFF
--- a/salt/modules/swarm.py
+++ b/salt/modules/swarm.py
@@ -413,7 +413,7 @@ def update_node(availability=str,
 
     .. code-block:: bash
 
-        salt '*' docker_util.update_node availability=drain node_name=minion2 \
+        salt '*' swarm.update_node availability=drain node_name=minion2 \
             role=worker node_id=3k9x7t8m4pel9c0nqr3iajnzp version=19
     '''
     client = docker.APIClient(base_url='unix://var/run/docker.sock')


### PR DESCRIPTION
### What does this PR do?
The help of the function update_node() reports the old name of this module ("docker_util").
Use the current one instead ("swarm").

### What issues does this PR fix or reference?
Fix the swarm module help for update_node().

### Tests written?
No

### Commits signed with GPG?
No
