### PR TITLE
Parse the command line from noaction operations and return the packag

### DIFF
--- a/salt/modules/opkg.py
+++ b/salt/modules/opkg.py
@@ -318,17 +318,17 @@ def _parse_reported_packages_from_install_output(output):
     or
         Upgrading <package> from <oldVersion> to <version> on root
     '''
-    reportedPkgs = {}
-    installPattern = re.compile(r'Installing\s(?P<package>.*?)\s\((?P<version>.*?)\)\son\s(?P<target>.*?)')
-    upgradePattern = re.compile(r'Upgrading\s(?P<package>.*?)\sfrom\s(?P<oldVersion>.*?)\sto\s(?P<version>.*?)\son\s(?P<target>.*?)')
+    reported_pkgs = {}
+    install_pattern = re.compile(r'Installing\s(?P<package>.*?)\s\((?P<version>.*?)\)\son\s(?P<target>.*?)')
+    upgrade_pattern = re.compile(r'Upgrading\s(?P<package>.*?)\sfrom\s(?P<oldVersion>.*?)\sto\s(?P<version>.*?)\son\s(?P<target>.*?)')
     for line in salt.utils.itertools.split(output, '\n'):
-        match = installPattern.match(line)
+        match = install_pattern.match(line)
         if match is None:
-            match = upgradePattern.match(line)
+            match = upgrade_pattern.match(line)
         if match:
-            reportedPkgs[match.group('package')] = match.group('version')
+            reported_pkgs[match.group('package')] = match.group('version')
 
-    return reportedPkgs
+    return reported_pkgs
 
 
 def _execute_install_commands(cmds, parse_output, errors, parsed_packages):
@@ -510,7 +510,7 @@ def install(name=None,
     errors = []
     is_testmode = _is_testmode(**kwargs)
     test_packages = {}
-    _execute_install_commands(cmds, is_test, errors, test_packages)
+    _execute_install_commands(cmds, is_testmode, errors, test_packages)
 
     __context__.pop('pkg.list_pkgs', None)
     new = list_pkgs()
@@ -566,14 +566,14 @@ def _parse_reported_packages_from_remove_output(output):
     We are looking for lines like
         Removing <package> (<version>) from <Target>...
     '''
-    reportedPkgs = {}
-    removePattern = re.compile(r'Removing\s(?P<package>.*?)\s\((?P<version>.*?)\)\sfrom\s(?P<target>.*?)...')
+    reported_pkgs = {}
+    remove_pattern = re.compile(r'Removing\s(?P<package>.*?)\s\((?P<version>.*?)\)\sfrom\s(?P<target>.*?)...')
     for line in salt.utils.itertools.split(output, '\n'):
-        match = removePattern.match(line)
+        match = remove_pattern.match(line)
         if match:
-            reportedPkgs[match.group('package')] = ''
+            reported_pkgs[match.group('package')] = ''
 
-    return reportedPkgs
+    return reported_pkgs
 
 
 def remove(name=None, pkgs=None, **kwargs):  # pylint: disable=unused-argument

--- a/salt/modules/opkg.py
+++ b/salt/modules/opkg.py
@@ -284,7 +284,31 @@ def _append_noaction_if_testmode(cmd, **kwargs):
         cmd.append('--noaction')
 
 
-def _parse_reported_packages_from_noaction_install_output(output):
+def _build_install_command_list(cmd_prefix, to_install, to_downgrade, to_reinstall):
+    '''
+    Builds a list of install commands to be executed in sequence in order to process
+    each of the to_install, to_downgrade, and to_reinstall lists.
+    '''
+    cmds = []
+    if to_install:
+        cmd = copy.deepcopy(cmd_prefix)
+        cmd.extend(to_install)
+        cmds.append(cmd)
+    if to_downgrade:
+        cmd = copy.deepcopy(cmd_prefix)
+        cmd.append('--force-downgrade')
+        cmd.extend(to_downgrade)
+        cmds.append(cmd)
+    if to_reinstall:
+        cmd = copy.deepcopy(cmd_prefix)
+        cmd.append('--force-reinstall')
+        cmd.extend(to_reinstall)
+        cmds.append(cmd)
+
+    return cmds
+
+
+def _parse_reported_packages_from_install_output(output):
     '''
     Parses the output of "opkg install" to determine what packages would have been
     installed by an operation run with the --noaction flag.
@@ -305,6 +329,27 @@ def _parse_reported_packages_from_noaction_install_output(output):
             reportedPkgs[match.group('package')] = match.group('version')
 
     return reportedPkgs
+
+
+def _execute_install_commands(cmds, parse_output, errors, parsed_packages):
+    '''
+    Executes a sequence of install commands.
+    If any command fails, the command output will be appended to the errors list.
+    If parse_output is true, updated packages will be appended to the parsed_packages dictionary.
+    '''
+    for cmd in cmds:
+        out = __salt__['cmd.run_all'](
+            cmd,
+            output_loglevel='trace',
+            python_shell=False
+        )
+        if out['retcode'] != 0:
+            if out['stderr']:
+                errors.append(out['stderr'])
+            else:
+                errors.append(out['stdout'])
+        elif parse_output:
+            parsed_packages.update(_parse_reported_packages_from_install_output(out['stdout']))
 
 
 def install(name=None,
@@ -454,24 +499,7 @@ def install(name=None,
                         # This should cause the command to fail.
                         to_install.append(pkgstr)
 
-    cmds = []
-
-    if to_install:
-        cmd = copy.deepcopy(cmd_prefix)
-        cmd.extend(to_install)
-        cmds.append(cmd)
-
-    if to_downgrade:
-        cmd = copy.deepcopy(cmd_prefix)
-        cmd.append('--force-downgrade')
-        cmd.extend(to_downgrade)
-        cmds.append(cmd)
-
-    if to_reinstall:
-        cmd = copy.deepcopy(cmd_prefix)
-        cmd.append('--force-reinstall')
-        cmd.extend(to_reinstall)
-        cmds.append(cmd)
+    cmds = _build_install_command_list(cmd_prefix, to_install, to_downgrade, to_reinstall)
 
     if not cmds:
         return {}
@@ -480,24 +508,15 @@ def install(name=None,
         refresh_db()
 
     errors = []
-    for cmd in cmds:
-        out = __salt__['cmd.run_all'](
-            cmd,
-            output_loglevel='trace',
-            python_shell=False
-        )
-        if out['retcode'] != 0:
-            if out['stderr']:
-                errors.append(out['stderr'])
-            else:
-                errors.append(out['stdout'])
+    is_testmode = _is_testmode(**kwargs)
+    test_packages = {}
+    _execute_install_commands(cmds, is_test, errors, test_packages)
 
     __context__.pop('pkg.list_pkgs', None)
     new = list_pkgs()
-    if _is_testmode(**kwargs):
-        reportedPkgs = _parse_reported_packages_from_noaction_install_output(out['stdout'])
+    if is_testmode:
         new = copy.deepcopy(new)
-        new.update(reportedPkgs)
+        new.update(test_packages)
 
     ret = salt.utils.data.compare_dicts(old, new)
 
@@ -539,7 +558,7 @@ def install(name=None,
     return ret
 
 
-def _parse_reported_packages_from_noaction_remove_output(output):
+def _parse_reported_packages_from_remove_output(output):
     '''
     Parses the output of "opkg remove" to determine what packages would have been
     removed by an operation run with the --noaction flag.
@@ -625,7 +644,7 @@ def remove(name=None, pkgs=None, **kwargs):  # pylint: disable=unused-argument
     __context__.pop('pkg.list_pkgs', None)
     new = list_pkgs()
     if _is_testmode(**kwargs):
-        reportedPkgs = _parse_reported_packages_from_noaction_remove_output(out['stdout'])
+        reportedPkgs = _parse_reported_packages_from_remove_output(out['stdout'])
         new = {k: v for k, v in new.items() if k not in reportedPkgs}
     ret = salt.utils.data.compare_dicts(old, new)
 

--- a/salt/modules/opkg.py
+++ b/salt/modules/opkg.py
@@ -331,25 +331,25 @@ def _parse_reported_packages_from_install_output(output):
     return reported_pkgs
 
 
-def _execute_install_commands(cmds, parse_output, errors, parsed_packages):
+def _execute_install_command(cmd, parse_output, errors, parsed_packages):
     '''
-    Executes a sequence of install commands.
-    If any command fails, the command output will be appended to the errors list.
-    If parse_output is true, updated packages will be appended to the parsed_packages dictionary.
+    Executes a command for the install operation.
+    If the command fails, its error output will be appended to the errors list.
+    If the command succeeds and parse_output is true, updated packages will be appended
+    to the parsed_packages dictionary.
     '''
-    for cmd in cmds:
-        out = __salt__['cmd.run_all'](
-            cmd,
-            output_loglevel='trace',
-            python_shell=False
-        )
-        if out['retcode'] != 0:
-            if out['stderr']:
-                errors.append(out['stderr'])
-            else:
-                errors.append(out['stdout'])
-        elif parse_output:
-            parsed_packages.update(_parse_reported_packages_from_install_output(out['stdout']))
+    out = __salt__['cmd.run_all'](
+        cmd,
+        output_loglevel='trace',
+        python_shell=False
+    )
+    if out['retcode'] != 0:
+        if out['stderr']:
+            errors.append(out['stderr'])
+        else:
+            errors.append(out['stdout'])
+    elif parse_output:
+        parsed_packages.update(_parse_reported_packages_from_install_output(out['stdout']))
 
 
 def install(name=None,
@@ -510,7 +510,8 @@ def install(name=None,
     errors = []
     is_testmode = _is_testmode(**kwargs)
     test_packages = {}
-    _execute_install_commands(cmds, is_testmode, errors, test_packages)
+    for cmd in cmds:
+        _execute_install_command(cmd, is_testmode, errors, test_packages)
 
     __context__.pop('pkg.list_pkgs', None)
     new = list_pkgs()

--- a/salt/modules/opkg.py
+++ b/salt/modules/opkg.py
@@ -269,12 +269,42 @@ def refresh_db(failhard=False, **kwargs):  # pylint: disable=unused-argument
     return ret
 
 
+def _is_testmode(**kwargs):
+    '''
+    Returns whether a test mode (noaction) operation was requested.
+    '''
+    return bool(kwargs.get('test') or __opts__.get('test'))
+
+
 def _append_noaction_if_testmode(cmd, **kwargs):
     '''
     Adds the --noaction flag to the command if it's running in the test mode.
     '''
-    if bool(kwargs.get('test') or __opts__.get('test')):
+    if _is_testmode(**kwargs):
         cmd.append('--noaction')
+
+
+def _parse_reported_packages_from_noaction_install_output(output):
+    '''
+    Parses the output of "opkg install" to determine what packages would have been
+    installed by an operation run with the --noaction flag.
+
+    We are looking for lines like:
+        Installing <package> (<version>) on <target>
+    or
+        Upgrading <package> from <oldVersion> to <version> on root
+    '''
+    reportedPkgs = {}
+    installPattern = re.compile(r'Installing\s(?P<package>.*?)\s\((?P<version>.*?)\)\son\s(?P<target>.*?)')
+    upgradePattern = re.compile(r'Upgrading\s(?P<package>.*?)\sfrom\s(?P<oldVersion>.*?)\sto\s(?P<version>.*?)\son\s(?P<target>.*?)')
+    for line in salt.utils.itertools.split(output, '\n'):
+        match = installPattern.match(line)
+        if match is None:
+            match = upgradePattern.match(line)
+        if match:
+            reportedPkgs[match.group('package')] = match.group('version')
+
+    return reportedPkgs
 
 
 def install(name=None,
@@ -464,6 +494,11 @@ def install(name=None,
 
     __context__.pop('pkg.list_pkgs', None)
     new = list_pkgs()
+    if _is_testmode(**kwargs):
+        reportedPkgs = _parse_reported_packages_from_noaction_install_output(out['stdout'])
+        new = copy.deepcopy(new)
+        new.update(reportedPkgs)
+
     ret = salt.utils.data.compare_dicts(old, new)
 
     if pkg_type == 'file' and reinstall:
@@ -502,6 +537,24 @@ def install(name=None,
     _process_restartcheck_result(rs_result)
 
     return ret
+
+
+def _parse_reported_packages_from_noaction_remove_output(output):
+    '''
+    Parses the output of "opkg remove" to determine what packages would have been
+    removed by an operation run with the --noaction flag.
+
+    We are looking for lines like
+        Removing <package> (<version>) from <Target>...
+    '''
+    reportedPkgs = {}
+    removePattern = re.compile(r'Removing\s(?P<package>.*?)\s\((?P<version>.*?)\)\sfrom\s(?P<target>.*?)...')
+    for line in salt.utils.itertools.split(output, '\n'):
+        match = removePattern.match(line)
+        if match:
+            reportedPkgs[match.group('package')] = ''
+
+    return reportedPkgs
 
 
 def remove(name=None, pkgs=None, **kwargs):  # pylint: disable=unused-argument
@@ -571,6 +624,9 @@ def remove(name=None, pkgs=None, **kwargs):  # pylint: disable=unused-argument
 
     __context__.pop('pkg.list_pkgs', None)
     new = list_pkgs()
+    if _is_testmode(**kwargs):
+        reportedPkgs = _parse_reported_packages_from_noaction_remove_output(out['stdout'])
+        new = {k: v for k, v in new.items() if k not in reportedPkgs}
     ret = salt.utils.data.compare_dicts(old, new)
 
     rs_result = _get_restartcheck_result(errors)

--- a/tests/unit/modules/test_opkg.py
+++ b/tests/unit/modules/test_opkg.py
@@ -147,8 +147,9 @@ class OpkgTestCase(TestCase, LoaderModuleMockMixin):
         '''
         Test - Install packages.
         '''
-        with patch('salt.modules.opkg.list_pkgs', MagicMock(return_value=({}))):
-            ret_value = {'retcode': 0}
+        with patch('salt.modules.opkg.list_pkgs', MagicMock(side_effect=({}, {}))):
+            std_out = 'Downloading http://feedserver/feeds/test/vim_7.4_arch.ipk.\n\nInstalling vim (7.4) on root\n'
+            ret_value = {'retcode': 0, 'stdout': std_out}
             mock = MagicMock(return_value=ret_value)
             patch_kwargs = {
                 '__salt__': {
@@ -158,7 +159,7 @@ class OpkgTestCase(TestCase, LoaderModuleMockMixin):
                 }
             }
             with patch.multiple(opkg, **patch_kwargs):
-                self.assertEqual(opkg.install('vim:7.4', test=True), {})
+                self.assertEqual(opkg.install('vim:7.4', test=True), INSTALLED)
 
     def test_remove(self):
         '''
@@ -181,8 +182,9 @@ class OpkgTestCase(TestCase, LoaderModuleMockMixin):
         '''
         Test - Remove packages.
         '''
-        with patch('salt.modules.opkg.list_pkgs', MagicMock(return_value=({}))):
-            ret_value = {'retcode': 0}
+        with patch('salt.modules.opkg.list_pkgs', MagicMock(side_effect=[PACKAGES, PACKAGES])):
+            std_out = '\nRemoving vim (7.4) from root...\n'
+            ret_value = {'retcode': 0, 'stdout': std_out}
             mock = MagicMock(return_value=ret_value)
             patch_kwargs = {
                 '__salt__': {
@@ -192,7 +194,7 @@ class OpkgTestCase(TestCase, LoaderModuleMockMixin):
                 }
             }
             with patch.multiple(opkg, **patch_kwargs):
-                self.assertEqual(opkg.remove('vim:7.4', test=True), {})
+                self.assertEqual(opkg.remove('vim:7.4', test=True), REMOVED)
 
     def test_info_installed(self):
         '''


### PR DESCRIPTION
…es which would be modified

Signed-off-by: JD Robertson <jd.robertson@ni.com>

Review cleanup

Signed-off-by: JD Robertson <jd.robertson@ni.com>

More refactoring from review & fix pylint issues.

Signed-off-by: JD Robertson <jd.robertson@ni.com>

Fix comment.

Signed-off-by: JD Robertson <jd.robertson@ni.com>

Cleanup based on feedback

Signed-off-by: JD Robertson <jd.robertson@ni.com>

### What does this PR do?

A previous commit added support for running the opkg "install" and "remove" commands with the "noaction" argument in order to test a configuration before committing it. As written, the test operations would only report success or failure, and would not report the set of packages that would be modified by the operation. This change addresses that gap by parsing the output of the noaction command for information about changed packages.

### Previous Behavior
Running install or remove with "test=1" would always return an empty dictionary.

### New Behavior
Running install or remove with "test=1" will return a dictionary containing the potential changes reported by opkg. 

### Tests written?

Yes

### Commits signed with GPG?

Yes
