### PR TITLE
[2018.3] Fix to virtual core grain

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -909,7 +909,7 @@ def _virtual(osdata):
                 # Tested on CentOS 5.4 / 2.6.18-164.15.1.el5xen
                 grains['virtual_subtype'] = 'Xen Dom0'
             else:
-                if grains.get('productname', '') == 'HVM domU':
+                if osdata.get('productname', '') == 'HVM domU':
                     # Requires dmidecode!
                     grains['virtual_subtype'] = 'Xen HVM DomU'
                 elif os.path.isfile('/proc/xen/capabilities') and \
@@ -926,9 +926,8 @@ def _virtual(osdata):
                 elif isdir('/sys/bus/xen'):
                     if 'xen:' in __salt__['cmd.run']('dmesg').lower():
                         grains['virtual_subtype'] = 'Xen PV DomU'
-                    elif os.listdir('/sys/bus/xen/drivers'):
-                        # An actual DomU will have several drivers
-                        # whereas a paravirt ops kernel will  not.
+                    elif os.path.isfile('/sys/bus/xen/drivers/xenconsole'):
+                        # An actual DomU will have the xenconsole driver
                         grains['virtual_subtype'] = 'Xen PV DomU'
             # If a Dom0 or DomU was detected, obviously this is xen
             if 'dom' in grains.get('virtual_subtype', '').lower():

--- a/tests/unit/grains/test_core.py
+++ b/tests/unit/grains/test_core.py
@@ -695,11 +695,11 @@ class CoreGrainsTestCase(TestCase, LoaderModuleMockMixin):
                 patch.object(os.path,
                              'isfile',
                              MagicMock(side_effect=lambda x: True if x == '/sys/bus/xen/drivers/xenconsole' else False)):
-                    log.debug('Testing Xen')
-                    self.assertEqual(
-                        core._virtual({'kernel': 'Linux'}).get('virtual_subtype'),
-                        'Xen PV DomU'
-                    )
+                log.debug('Testing Xen')
+                self.assertEqual(
+                    core._virtual({'kernel': 'Linux'}).get('virtual_subtype'),
+                    'Xen PV DomU'
+                )
 
     def _check_ipaddress(self, value, ip_v):
         '''

--- a/tests/unit/grains/test_core.py
+++ b/tests/unit/grains/test_core.py
@@ -685,6 +685,22 @@ class CoreGrainsTestCase(TestCase, LoaderModuleMockMixin):
                                 'Docker'
                             )
 
+    @skipIf(salt.utils.platform.is_windows(), 'System is Windows')
+    def test_xen_virtual(self):
+        '''
+        Test if OS grains are parsed correctly in Ubuntu Xenial Xerus
+        '''
+        with patch.object(os.path, 'isfile', MagicMock(return_value=False)):
+            with patch.dict(core.__salt__, {'cmd.run': MagicMock(return_value='')}), \
+                patch.object(os.path,
+                             'isfile',
+                             MagicMock(side_effect=lambda x: True if x == '/sys/bus/xen/drivers/xenconsole' else False)):
+                    log.debug('Testing Xen')
+                    self.assertEqual(
+                        core._virtual({'kernel': 'Linux'}).get('virtual_subtype'),
+                        'Xen PV DomU'
+                    )
+
     def _check_ipaddress(self, value, ip_v):
         '''
         check if ip address in a list is valid


### PR DESCRIPTION
### What does this PR do?
Fixing a typo in the _virtual function, should be checking for existing grains in osdata not grains.  Updating the detection to look for /sys/bus/xen/drivers/xenconsole instead of specifically looking for any files under /sys/bus/xen/drivers.  Some systems that are not running as Xen PV hosts include files under that location, particularly Oracle Linux.

### What issues does this PR fix or reference?
#50266 

### Tests written?
Yes

### Commits signed with GPG?

Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
