### PR TITLE
Test and fix disk creation in virt.init

### DIFF
--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -745,10 +745,8 @@ def _qemu_image_create(disk, create_overlay=False, saltenv='base'):
     log.debug('Image destination will be %s', img_dest)
     img_dir = os.path.dirname(img_dest)
     log.debug('Image destination directory is %s', img_dir)
-    try:
+    if not os.path.exists(img_dir):
         os.makedirs(img_dir)
-    except OSError:
-        pass
 
     if disk_image:
         log.debug('Create disk from specified image %s', disk_image)
@@ -1460,10 +1458,11 @@ def init(name,
             else:
                 create_overlay = _disk.get('overlay_image', False)
 
-            if _disk['source_file'] and os.path.exists(_disk['source_file']):
-                img_dest = _disk['source_file']
-            elif 'source_file' not in _disk:
-                img_dest = _qemu_image_create(_disk, create_overlay, saltenv)
+            if _disk['source_file']:
+                if os.path.exists(_disk['source_file']):
+                    img_dest = _disk['source_file']
+                else:
+                    img_dest = _qemu_image_create(_disk, create_overlay, saltenv)
             else:
                 img_dest = None
 

--- a/tests/unit/modules/test_virt.py
+++ b/tests/unit/modules/test_virt.py
@@ -900,9 +900,9 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         self.assertEqual([nic.find('mac').get('address') for nic in ret['deleted']],
                          ['52:54:00:39:02:b2', '52:54:00:39:02:b3'])
 
-    def test_init_no_nics_disks(self):
+    def test_init(self):
         '''
-        Ensure the init() function allows creating VM without NIC and disk
+        Test init() function
         '''
         xml = '''
 <capabilities>
@@ -1024,19 +1024,50 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
 </capabilities>
         '''
         self.mock_conn.getCapabilities.return_value = xml  # pylint: disable=no-member
+
+        root_dir = os.path.join(salt.syspaths.ROOT_DIR, 'srv', 'salt-images')
+
         defineMock = MagicMock(return_value=1)
         self.mock_conn.defineXML = defineMock
-        with patch.dict(virt.__salt__, {'cmd.run': MagicMock()}):  # pylint: disable=no-member
-            virt.init('testvm',
-                      2,
-                      1234,
-                      nic=None,
-                      disk=None,
-                      seed=False,
-                      start=False)
-            definition = defineMock.call_args_list[0][0][0]
-            self.assertFalse('<interface' in definition)
-            self.assertFalse('<disk' in definition)
+        mock_chmod = MagicMock()
+        mock_run = MagicMock()
+        with patch.dict(os.__dict__, {'chmod': mock_chmod, 'makedirs': MagicMock()}):  # pylint: disable=no-member
+            with patch.dict(virt.__salt__, {'cmd.run': mock_run}):  # pylint: disable=no-member
+
+                # Ensure the init() function allows creating VM without NIC and disk
+                virt.init('testvm',
+                          2,
+                          1234,
+                          nic=None,
+                          disk=None,
+                          seed=False,
+                          start=False)
+                definition = defineMock.call_args_list[0][0][0]
+                self.assertFalse('<interface' in definition)
+                self.assertFalse('<disk' in definition)
+
+                # Test case creating disks
+                defineMock.reset_mock()
+                mock_run.reset_mock()
+                virt.init('testvm',
+                          2,
+                          1234,
+                          nic=None,
+                          disk=None,
+                          disks=[
+                              {'name': 'system', 'size': 10240},
+                              {'name': 'cddrive', 'device': 'cdrom', 'source_file': None, 'model': 'ide'}
+                          ],
+                          seed=False,
+                          start=False)
+                definition = ET.fromstring(defineMock.call_args_list[0][0][0])
+                disk_sources = [disk.find('source').get('file') if disk.find('source') is not None else None
+                                for disk in definition.findall('./devices/disk')]
+                expected_disk_path = os.path.join(root_dir, 'testvm_system.qcow2')
+                self.assertEqual(disk_sources, [expected_disk_path, None])
+                self.assertEqual(mock_run.call_args[0][0],
+                                 'qemu-img create -f qcow2 {0} 10240M'.format(expected_disk_path))
+                self.assertEqual(mock_chmod.call_args[0][0], expected_disk_path)
 
     def test_update(self):
         '''
@@ -1136,7 +1167,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         domain_mock.detachDevice = devdetach_mock
         mock_chmod = MagicMock()
         mock_run = MagicMock()
-        with patch.dict(os.__dict__, {'chmod': mock_chmod}):  # pylint: disable=no-member
+        with patch.dict(os.__dict__, {'chmod': mock_chmod, 'makedirs': MagicMock()}):  # pylint: disable=no-member
             with patch.dict(virt.__salt__, {'cmd.run': mock_run}):  # pylint: disable=no-member
                 ret = virt.update('myvm', disk_profile='default', disks=[
                     {'name': 'cddrive', 'device': 'cdrom', 'source_file': None, 'model': 'ide'},


### PR DESCRIPTION
### What does this PR do?

Adding a test case in virt.init uncovered a few issues: a passed
exception that we really want to report to the user, and disks that
were not created.

### What issues does this PR fix or reference?

None

### Previous Behavior

* os.makedirs() errors where silenced during `virt.update` / `virt.init`
* Disk images were not created in `virt.init`

### New Behavior

These two problems are fixed

### Tests written?

Yes

### Commits signed with GPG?

Yes