### PR TITLE
Bugfix: OS arch fall-back when no RPM installed on inird image

### DIFF
--- a/salt/utils/pkg/rpm.py
+++ b/salt/utils/pkg/rpm.py
@@ -9,7 +9,9 @@ import collections
 import datetime
 import logging
 import subprocess
+import platform
 import salt.utils.stringutils
+import salt.utils.path
 
 # Import 3rd-party libs
 from salt.ext import six
@@ -45,12 +47,16 @@ def get_osarch():
     '''
     Get the os architecture using rpm --eval
     '''
-    ret = subprocess.Popen(
-        'rpm --eval "%{_host_cpu}"',
-        shell=True,
-        close_fds=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE).communicate()[0]
+    if salt.utils.path.which('rpm'):
+        ret = subprocess.Popen(
+            'rpm --eval "%{_host_cpu}"',
+            shell=True,
+            close_fds=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE).communicate()[0]
+    else:
+        ret = ''.join(list(filter(None, platform.uname()[-2:]))[-1:])
+
     return salt.utils.stringutils.to_str(ret).strip() or 'unknown'
 
 

--- a/salt/utils/pkg/rpm.py
+++ b/salt/utils/pkg/rpm.py
@@ -55,7 +55,7 @@ def get_osarch():
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE).communicate()[0]
     else:
-        ret = ''.join(list(filter(None, platform.uname()[-2:]))[-1:])
+        ret = ''.join([x for x in platform.uname()[-2:] if x][-1:])
 
     return salt.utils.stringutils.to_str(ret).strip() or 'unknown'
 

--- a/tests/unit/utils/test_pkg.py
+++ b/tests/unit/utils/test_pkg.py
@@ -3,7 +3,7 @@
 from __future__ import absolute_import, unicode_literals, print_function
 
 from tests.support.unit import TestCase, skipIf
-from tests.support.mock import Mock, MagicMock, patch, NO_MOCK, NO_MOCK_REASON
+from tests.support.mock import MagicMock, patch, NO_MOCK, NO_MOCK_REASON
 import salt.utils.pkg
 from salt.utils.pkg import rpm
 

--- a/tests/unit/utils/test_pkg.py
+++ b/tests/unit/utils/test_pkg.py
@@ -86,3 +86,14 @@ class PkgRPMTestCase(TestCase):
         :return:
         '''
         assert rpm.get_osarch() == 'Z80'
+
+    @patch('salt.utils.path.which', MagicMock(return_value=False))
+    @patch('salt.utils.pkg.rpm.subprocess', MagicMock(return_value=False))
+    @patch('salt.utils.pkg.rpm.platform.uname', MagicMock(
+        return_value=('Sinclair BASIC', 'motophone', '1982 Sinclair Research Ltd', '1.0', 'ZX81', '')))
+    def test_get_osarch_by_platform_no_cpu_arch(self):
+        '''
+        Get os_arch if RPM package is not installed (inird image, for example) but cpu arch cannot be determined.
+        :return:
+        '''
+        assert rpm.get_osarch() == 'ZX81'

--- a/tests/unit/utils/test_pkg.py
+++ b/tests/unit/utils/test_pkg.py
@@ -56,7 +56,7 @@ class PkgUtilsTestCase(TestCase):
 @skipIf(pytest is None, 'PyTest is missing')
 class PkgRPMTestCase(TestCase):
     '''
-    Test case.
+    Test case for pkg.rpm utils
     '''
 
     @patch('salt.utils.path.which', MagicMock(return_value=True))

--- a/tests/unit/utils/test_pkg.py
+++ b/tests/unit/utils/test_pkg.py
@@ -1,11 +1,16 @@
 # -*- coding: utf-8 -*-
 
-# Import Python libs
-from __future__ import absolute_import
-# Import Salt Libs
+from __future__ import absolute_import, unicode_literals, print_function
+
+from tests.support.unit import TestCase, skipIf
+from tests.support.mock import Mock, MagicMock, patch, NO_MOCK, NO_MOCK_REASON
 import salt.utils.pkg
-# Import Salt Testing Libs
-from tests.support.unit import TestCase
+from salt.utils.pkg import rpm
+
+try:
+    import pytest
+except ImportError:
+    pytest = None
 
 
 class PkgUtilsTestCase(TestCase):

--- a/tests/unit/utils/test_pkg.py
+++ b/tests/unit/utils/test_pkg.py
@@ -7,11 +7,6 @@ from tests.support.mock import MagicMock, patch, NO_MOCK, NO_MOCK_REASON
 import salt.utils.pkg
 from salt.utils.pkg import rpm
 
-try:
-    import pytest
-except ImportError:
-    pytest = None
-
 
 class PkgUtilsTestCase(TestCase):
     '''
@@ -53,7 +48,6 @@ class PkgUtilsTestCase(TestCase):
 
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
-@skipIf(pytest is None, 'PyTest is missing')
 class PkgRPMTestCase(TestCase):
     '''
     Test case for pkg.rpm utils

--- a/tests/unit/utils/test_pkg.py
+++ b/tests/unit/utils/test_pkg.py
@@ -97,3 +97,15 @@ class PkgRPMTestCase(TestCase):
         :return:
         '''
         assert rpm.get_osarch() == 'ZX81'
+
+    @patch('salt.utils.path.which', MagicMock(return_value=False))
+    @patch('salt.utils.pkg.rpm.subprocess', MagicMock(return_value=False))
+    @patch('salt.utils.pkg.rpm.platform.uname', MagicMock(
+        return_value=('Sinclair BASIC', 'motophone', '1982 Sinclair Research Ltd', '1.0', '', '')))
+    def test_get_osarch_by_platform_no_cpu_arch_no_machine(self):
+        '''
+        Get os_arch if RPM package is not installed (inird image, for example)
+        where both cpu arch and machine cannot be determined.
+        :return:
+        '''
+        assert rpm.get_osarch() == 'unknown'

--- a/tests/unit/utils/test_pkg.py
+++ b/tests/unit/utils/test_pkg.py
@@ -50,3 +50,34 @@ class PkgUtilsTestCase(TestCase):
             oper, verstr = salt.utils.pkg.split_comparison(test_parameter[0])
             self.assertEqual(test_parameter[1], oper)
             self.assertEqual(test_parameter[2], verstr)
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+@skipIf(pytest is None, 'PyTest is missing')
+class PkgRPMTestCase(TestCase):
+    '''
+    Test case.
+    '''
+
+    @patch('salt.utils.path.which', MagicMock(return_value=True))
+    def test_get_osarch_by_rpm(self):
+        '''
+        Get os_arch if RPM package is installed.
+        :return:
+        '''
+        subprocess_mock = MagicMock()
+        subprocess_mock.Popen = MagicMock()
+        subprocess_mock.Popen().communicate = MagicMock(return_value=['Z80'])
+        with patch('salt.utils.pkg.rpm.subprocess', subprocess_mock):
+            assert rpm.get_osarch() == 'Z80'
+        assert subprocess_mock.Popen.call_count == 2  # One within the mock
+        assert subprocess_mock.Popen.call_args[1]['close_fds']
+        assert subprocess_mock.Popen.call_args[1]['shell']
+        assert len(subprocess_mock.Popen.call_args_list) == 2
+        assert subprocess_mock.Popen.call_args[0][0] == 'rpm --eval "%{_host_cpu}"'
+
+    def test_get_osarch_by_platform(self):
+        '''
+        Get os_arch if RPM package is not installed (inird image, for example).
+        :return:
+        '''

--- a/tests/unit/utils/test_pkg.py
+++ b/tests/unit/utils/test_pkg.py
@@ -76,8 +76,13 @@ class PkgRPMTestCase(TestCase):
         assert len(subprocess_mock.Popen.call_args_list) == 2
         assert subprocess_mock.Popen.call_args[0][0] == 'rpm --eval "%{_host_cpu}"'
 
+    @patch('salt.utils.path.which', MagicMock(return_value=False))
+    @patch('salt.utils.pkg.rpm.subprocess', MagicMock(return_value=False))
+    @patch('salt.utils.pkg.rpm.platform.uname', MagicMock(
+        return_value=('Sinclair BASIC', 'motophone', '1982 Sinclair Research Ltd', '1.0', 'ZX81', 'Z80')))
     def test_get_osarch_by_platform(self):
         '''
         Get os_arch if RPM package is not installed (inird image, for example).
         :return:
         '''
+        assert rpm.get_osarch() == 'Z80'


### PR DESCRIPTION
### What does this PR do?

Bugfix.

### What issues does this PR fix or reference?

Salt is unable to determine OS architecture grain on `initrd` Linux images for RPM systems.

### Previous Behavior

OS architecture is not detected.

### New Behavior

OS architecture is detected.

### Tests written?

Yes
