### PR TITLE
Enable proxy/ssh daemons when filename mapping causes those tests to be run

### DIFF
--- a/tests/support/parser/__init__.py
+++ b/tests/support/parser/__init__.py
@@ -449,6 +449,14 @@ class SaltTestingParser(optparse.OptionParser):
                     ret.update(filename_map[path_expr])
                     break
 
+        if any(x.startswith('integration.proxy.') for x in ret):
+            # Ensure that the salt-proxy daemon is started for these tests.
+            self.options.proxy = True
+
+        if any(x.startswith('integration.ssh.') for x in ret):
+            # Ensure that an ssh daemon is started for these tests.
+            self.options.ssh = True
+
         return ret
 
     def parse_args(self, args=None, values=None):


### PR DESCRIPTION
The proxy and ssh tests won't run when the `--proxy` and `--ssh` CLI flags, respectively, aren't passed to runtests.py. This ensures that we start the daemons when the file mapping logic triggers them to be run.