### PR TITLE
Adding tag to ec2 cloud tests

### DIFF
--- a/tests/integration/files/conf/cloud.profiles.d/ec2.conf
+++ b/tests/integration/files/conf/cloud.profiles.d/ec2.conf
@@ -4,6 +4,7 @@ ec2-test:
   size: c5.large
   sh_username: centos
   script_args: '-P'
+  tag: {'created-by': 'cloud-tests'}
 ec2-win2012r2-test:
   provider: ec2-config
   size: c5.large
@@ -17,6 +18,7 @@ ec2-win2012r2-test:
   use_winrm: True
   winrm_verify_ssl: False
   deploy: True
+  tag: {'created-by': 'cloud-tests'}
 ec2-win2016-test:
   provider: ec2-config
   size: c5.large
@@ -30,3 +32,4 @@ ec2-win2016-test:
   use_winrm: True
   winrm_verify_ssl: False
   deploy: True
+  tag: {'created-by': 'cloud-tests'}


### PR DESCRIPTION
### What does this PR do?
This adds a tag to the EC2 instance that the cloud integration tests run. We use this tag for cleaning up the environment if something in the test suite fails or aborts.

### What issues does this PR fix or reference?
Enhancement to the current functionality

### Tests written?

No

### Commits signed with GPG?

Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
