### PR TITLE
Fix a bug with pkg.list_pkgs on Windows

### DIFF
--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -377,7 +377,7 @@ def list_pkgs(versions_as_list=False,
 
     Args:
 
-        version_as_list (bool):
+        versions_as_list (bool):
             Returns the versions as a list
 
         include_components (bool):

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -576,13 +576,19 @@ def _get_reg_software():
     search_key_userdata = 'Software\\Microsoft\\Windows\\CurrentVersion\\Installer\\UserData\\S-1-5-18\\Products'
     for reg_key in __utils__['reg.list_keys'](hive=search_hive, key=search_key):
         # Does the key exist in userdata
-        if __utils__['reg.key_exists'](
+        if not __utils__['reg.key_exists'](
                 hive=search_hive,
                 key='{0}\\{1}'.format(search_key_userdata, reg_key)):
             continue
-        if skip_component(hive=search_hive, key=search_key, reg_key=reg_key):
+        if skip_component(hive=search_hive,
+                          key=search_key,
+                          reg_key=reg_key,
+                          use_32bit=False):
             continue
-        add_software(hive=search_hive, key=search_key, reg_key=reg_key)
+        add_software(hive=search_hive,
+                     key=search_key,
+                     reg_key=reg_key,
+                     use_32bit=False)
 
     # This has a propensity to take a while on a machine where many users have
     # logged in. Untested in such a scenario

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -617,17 +617,12 @@ def _get_reg_software(include_components=True,
             use_32bit_registry=use_32bit)
 
         d_vers = 'Not Found'
-        if (not d_vers_regdata['success'] or
-                d_vers_regdata['vtype'] not in ['REG_SZ',
-                                                'REG_EXPAND_SZ',
-                                                'REG_DWORD'] or
-                d_name_regdata['vdata'] in ['(value not set)', None, False]):
-            d_vers = d_name
-
-        if isinstance(d_vers_regdata['vdata'], int):
-            d_vers = six.text_type(d_vers_regdata['vdata'])
-        elif d_vers_regdata['vdata'] and d_vers_regdata['vdata'] != '(value not set)':  # Check for blank values
-            d_vers = d_vers_regdata['vdata']
+        if (d_vers_regdata['success'] and
+                d_vers_regdata['vtype'] in ['REG_SZ', 'REG_EXPAND_SZ', 'REG_DWORD']):
+            if isinstance(d_vers_regdata['vdata'], int):
+                d_vers = six.text_type(d_vers_regdata['vdata'])
+            elif d_vers_regdata['vdata'] and d_vers_regdata['vdata'] != '(value not set)':  # Check for blank values
+                d_vers = d_vers_regdata['vdata']
 
         reg_software.setdefault(d_name, []).append(d_vers)
 

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -502,7 +502,7 @@ def _get_reg_software(include_components=True,
         'WindowsInstaller' must be either absent or present with a value of 0.
         If the value is set to 1, then the application is included in the list
         if and only if the corresponding compressed guid is also present in
-        HKLM:\Software\Classes\Installer\Products\
+        HKLM:\\Software\\Classes\\Installer\\Products
 
         Returns:
             bool: True if the package needs to be skipped, otherwise False

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -576,19 +576,13 @@ def _get_reg_software():
     search_key_userdata = 'Software\\Microsoft\\Windows\\CurrentVersion\\Installer\\UserData\\S-1-5-18\\Products'
     for reg_key in __utils__['reg.list_keys'](hive=search_hive, key=search_key):
         # Does the key exist in userdata
-        if not __utils__['reg.key_exists'](
+        if __utils__['reg.key_exists'](
                 hive=search_hive,
                 key='{0}\\{1}'.format(search_key_userdata, reg_key)):
             continue
-        if skip_component(hive=search_hive,
-                          key=search_key,
-                          reg_key=reg_key,
-                          use_32bit=False):
+        if skip_component(hive=search_hive, key=search_key, reg_key=reg_key):
             continue
-        add_software(hive=search_hive,
-                     key=search_key,
-                     reg_key=reg_key,
-                     use_32bit=False)
+        add_software(hive=search_hive, key=search_key, reg_key=reg_key)
 
     # This has a propensity to take a while on a machine where many users have
     # logged in. Untested in such a scenario

--- a/salt/utils/win_functions.py
+++ b/salt/utils/win_functions.py
@@ -10,6 +10,7 @@ import ctypes
 
 # Import Salt Libs
 from salt.exceptions import CommandExecutionError
+from salt.ext.six.moves import range
 
 # Import 3rd Party Libs
 try:

--- a/salt/utils/win_functions.py
+++ b/salt/utils/win_functions.py
@@ -305,3 +305,60 @@ def broadcast_setting_change(message='Environment'):
                                         broadcast_message, SMTO_ABORTIFHUNG,
                                         5000, 0)
     return result == 1
+
+
+def guid_to_squid(guid):
+    '''
+    Converts a GUID   to a compressed guid (SQUID)
+
+    Each Guid has 5 parts separated by '-'. For the first three each one will be
+    totally reversed, and for the remaining two each one will be reversed by
+    every other character. Then the final compressed Guid will be constructed by
+    concatenating all the reversed parts without '-'.
+
+    .. Example::
+
+        Input:                  2BE0FA87-5B36-43CF-95C8-C68D6673FB94
+        Reversed:               78AF0EB2-63B5-FC34-598C-6CD86637BF49
+        Final Compressed Guid:  78AF0EB263B5FC34598C6CD86637BF49
+
+    Args:
+
+        guid (str): A valid GUID
+
+    Returns:
+        str: A valid compressed GUID (SQUID)
+    '''
+    guid_pattern = re.compile(r'^\{(\w{8})-(\w{4})-(\w{4})-(\w\w)(\w\w)-(\w\w)(\w\w)(\w\w)(\w\w)(\w\w)(\w\w)\}$')
+    guid_match = guid_pattern.match(guid)
+    squid = ''
+    if guid_match is not None:
+        for index in range(1, 12):
+            squid += guid_match.group(index)[::-1]
+    return squid
+
+
+def squid_to_guid(squid):
+    '''
+    Converts a compressed GUID (SQUID) back into a GUID
+
+    Args:
+
+        squid (str): A valid compressed GUID
+
+    Returns:
+        str: A valid GUID
+    '''
+    squid_pattern = re.compile(r'^(\w{8})(\w{4})(\w{4})(\w\w)(\w\w)(\w\w)(\w\w)(\w\w)(\w\w)(\w\w)(\w\w)$')
+    squid_match = squid_pattern.match(squid)
+    guid = ''
+    if squid_match is not None:
+        guid = '{' + \
+               squid_match.group(1)[::-1]+'-' + \
+               squid_match.group(2)[::-1]+'-' + \
+               squid_match.group(3)[::-1]+'-' + \
+               squid_match.group(4)[::-1]+squid_match.group(5)[::-1] + '-'
+        for index in range(6, 12):
+            guid += squid_match.group(index)[::-1]
+        guid += '}'
+    return guid

--- a/salt/utils/win_reg.py
+++ b/salt/utils/win_reg.py
@@ -302,7 +302,7 @@ def list_keys(hive, key=None, use_32bit_registry=False):
 
                 - HKEY_LOCAL_MACHINE or HKLM
                 - HKEY_CURRENT_USER or HKCU
-                - HKEY_USER or HKU
+                - HKEY_USERS or HKU
                 - HKEY_CLASSES_ROOT or HKCR
                 - HKEY_CURRENT_CONFIG or HKCC
 

--- a/tests/whitelist.txt
+++ b/tests/whitelist.txt
@@ -36,7 +36,6 @@ integration.modules.test_localemod
 integration.modules.test_lxc
 integration.modules.test_mine
 integration.modules.test_mysql
-integration.modules.test_nacl
 integration.modules.test_network
 integration.modules.test_nilrt_ip
 integration.modules.test_pillar


### PR DESCRIPTION
### What does this PR do?
`pkg.list_pkgs` on Windows was returning many things that aren't in the Add/Remove Programs such as Windows Updates and Software Upgrades. Those items would be better listed in the wusa module.

It was also failing to show other packages installed on the system as well. Some packages were being dropped because they were missing a version. Others weren't being found in the registry.

This will display installed software as it is displayed by Add/Remove Programs

Also fixes a minor docs issue in the `win_reg` salt util.

### Tests written?
No

### Commits signed with GPG?
Yes