### PR TITLE
Fix zeromq stream.send exception message

### DIFF
--- a/salt/transport/zeromq.py
+++ b/salt/transport/zeromq.py
@@ -699,7 +699,7 @@ class ZeroMQReqServerChannel(salt.transport.mixins.auth.AESReqServerMixin,
             ret, req_opts = yield self.payload_handler(payload)
         except Exception as e:
             # always attempt to return an error to the minion
-            stream.send('Some exception handling minion payload')
+            stream.send(self.serial.dumps('Some exception handling minion payload'))
             log.error('Some exception handling a payload from minion', exc_info=True)
             raise tornado.gen.Return()
 
@@ -716,7 +716,7 @@ class ZeroMQReqServerChannel(salt.transport.mixins.auth.AESReqServerMixin,
         else:
             log.error('Unknown req_fun %s', req_fun)
             # always attempt to return an error to the minion
-            stream.send('Server-side exception handling payload')
+            stream.send(self.serial.dumps('Server-side exception handling payload'))
         raise tornado.gen.Return()
 
     def __setup_signals(self):


### PR DESCRIPTION
### What does this PR do?

Fixes failing exception message streaming.

### What issues does this PR fix or reference?

Inspiration was taken from this example: https://github.com/saltstack/salt/blob/9f2e58dfcc44a6b6300b52d1d59a2bc39e6536c8/salt/transport/zeromq.py#L669

### Tests written?

No

### Commits signed with GPG?

No