### PR TITLE
Async batch

### DIFF
--- a/salt/auth/__init__.py
+++ b/salt/auth/__init__.py
@@ -49,7 +49,9 @@ AUTH_INTERNAL_KEYWORDS = frozenset([
     'metadata',
     'print_event',
     'raw',
-    'yield_pub_data'
+    'yield_pub_data',
+    'batch',
+    'batch_delay'
 ])
 
 

--- a/salt/cli/batch.py
+++ b/salt/cli/batch.py
@@ -26,6 +26,79 @@ import logging
 log = logging.getLogger(__name__)
 
 
+def _get_bnum(opts, minions, quiet):
+    '''
+    Return the active number of minions to maintain
+    '''
+    partition = lambda x: float(x) / 100.0 * len(minions)
+    try:
+        if '%' in opts['batch']:
+            res = partition(float(opts['batch'].strip('%')))
+            if res < 1:
+                return int(math.ceil(res))
+            else:
+                return int(res)
+        else:
+            return int(opts['batch'])
+    except ValueError:
+        if not quiet:
+            salt.utils.stringutils.print_cli('Invalid batch data sent: {0}\nData must be in the '
+                      'form of %10, 10% or 3'.format(opts['batch']))
+
+
+def _batch_get_opts(
+        tgt,
+        fun,
+        batch,
+        parent_opts,
+        arg=(),
+        tgt_type='glob',
+        ret='',
+        kwarg=None,
+        **kwargs):
+    # We need to re-import salt.utils.args here
+    # even though it has already been imported.
+    # when cmd_batch is called via the NetAPI
+    # the module is unavailable.
+    import salt.utils.args
+
+    arg = salt.utils.args.condition_input(arg, kwarg)
+    opts = {'tgt': tgt,
+            'fun': fun,
+            'arg': arg,
+            'tgt_type': tgt_type,
+            'ret': ret,
+            'batch': batch,
+            'failhard': kwargs.get('failhard', False),
+            'raw': kwargs.get('raw', False)}
+
+    if 'timeout' in kwargs:
+        opts['timeout'] = kwargs['timeout']
+    if 'gather_job_timeout' in kwargs:
+        opts['gather_job_timeout'] = kwargs['gather_job_timeout']
+    if 'batch_wait' in kwargs:
+        opts['batch_wait'] = int(kwargs['batch_wait'])
+
+    for key, val in six.iteritems(parent_opts):
+        if key not in opts:
+            opts[key] = val
+
+    return opts
+
+
+def _batch_get_eauth(kwargs):
+    eauth = {}
+    if 'eauth' in kwargs:
+        eauth['eauth'] = kwargs.pop('eauth')
+    if 'username' in kwargs:
+        eauth['username'] = kwargs.pop('username')
+    if 'password' in kwargs:
+        eauth['password'] = kwargs.pop('password')
+    if 'token' in kwargs:
+        eauth['token'] = kwargs.pop('token')
+    return eauth
+
+
 class Batch(object):
     '''
     Manage the execution of batch runs
@@ -80,23 +153,7 @@ class Batch(object):
         return (list(fret), ping_gen, nret.difference(fret))
 
     def get_bnum(self):
-        '''
-        Return the active number of minions to maintain
-        '''
-        partition = lambda x: float(x) / 100.0 * len(self.minions)
-        try:
-            if '%' in self.opts['batch']:
-                res = partition(float(self.opts['batch'].strip('%')))
-                if res < 1:
-                    return int(math.ceil(res))
-                else:
-                    return int(res)
-            else:
-                return int(self.opts['batch'])
-        except ValueError:
-            if not self.quiet:
-                salt.utils.stringutils.print_cli('Invalid batch data sent: {0}\nData must be in the '
-                          'form of %10, 10% or 3'.format(self.opts['batch']))
+        return _get_bnum(self.opts, self.minions, self.quiet)
 
     def __update_wait(self, wait):
         now = datetime.now()

--- a/salt/cli/batch.py
+++ b/salt/cli/batch.py
@@ -26,7 +26,7 @@ import logging
 log = logging.getLogger(__name__)
 
 
-def _get_bnum(opts, minions, quiet):
+def get_bnum(opts, minions, quiet):
     '''
     Return the active number of minions to maintain
     '''
@@ -46,7 +46,7 @@ def _get_bnum(opts, minions, quiet):
                       'form of %10, 10% or 3'.format(opts['batch']))
 
 
-def _batch_get_opts(
+def batch_get_opts(
         tgt,
         fun,
         batch,
@@ -86,7 +86,7 @@ def _batch_get_opts(
     return opts
 
 
-def _batch_get_eauth(kwargs):
+def batch_get_eauth(kwargs):
     eauth = {}
     if 'eauth' in kwargs:
         eauth['eauth'] = kwargs.pop('eauth')
@@ -153,7 +153,7 @@ class Batch(object):
         return (list(fret), ping_gen, nret.difference(fret))
 
     def get_bnum(self):
-        return _get_bnum(self.opts, self.minions, self.quiet)
+        return get_bnum(self.opts, self.minions, self.quiet)
 
     def __update_wait(self, wait):
         now = datetime.now()

--- a/salt/cli/batch_async.py
+++ b/salt/cli/batch_async.py
@@ -194,6 +194,5 @@ class BatchAsync(object):
                 gather_job_timeout=self.opts['gather_job_timeout'],
                 jid=self.batch_jid,
                 **self.eauth)
-            # TODO add parameter for find_job - should use gather_job_timeout?
-            self.event.io_loop.call_later(10, self.find_job, set(next_batch))
+            self.event.io_loop.call_later(self.opts['timeout'], self.find_job, set(next_batch))
             self.active = self.active.union(next_batch)

--- a/salt/cli/batch_async.py
+++ b/salt/cli/batch_async.py
@@ -5,23 +5,11 @@ Execute batch runs
 
 # Import python libs
 from __future__ import absolute_import, print_function, unicode_literals
-import math
-import time
-import copy
 import tornado
-from datetime import datetime, timedelta
 
 # Import salt libs
-import salt.utils.stringutils
-import salt.utils.event
 import salt.client
-import salt.output
-import salt.exceptions
 
-# Import 3rd-party libs
-# pylint: disable=import-error,no-name-in-module,redefined-builtin
-from salt.ext import six
-from salt.ext.six.moves import range
 # pylint: enable=import-error,no-name-in-module,redefined-builtin
 import logging
 import fnmatch

--- a/salt/cli/batch_async.py
+++ b/salt/cli/batch_async.py
@@ -13,7 +13,6 @@ import salt.client
 # pylint: enable=import-error,no-name-in-module,redefined-builtin
 import logging
 import fnmatch
-from salt.ext.six.moves import range
 
 log = logging.getLogger(__name__)
 

--- a/salt/cli/batch_async.py
+++ b/salt/cli/batch_async.py
@@ -1,0 +1,142 @@
+# -*- coding: utf-8 -*-
+'''
+Execute batch runs
+'''
+
+# Import python libs
+from __future__ import absolute_import, print_function, unicode_literals
+import math
+import time
+import copy
+import tornado
+from datetime import datetime, timedelta
+
+# Import salt libs
+import salt.utils.stringutils
+import salt.utils.event
+import salt.client
+import salt.output
+import salt.exceptions
+
+# Import 3rd-party libs
+# pylint: disable=import-error,no-name-in-module,redefined-builtin
+from salt.ext import six
+from salt.ext.six.moves import range
+# pylint: enable=import-error,no-name-in-module,redefined-builtin
+import logging
+import fnmatch
+
+log = logging.getLogger(__name__)
+
+from salt.cli.batch import _get_bnum, _batch_get_opts, _batch_get_eauth
+
+
+class BatchAsync(object):
+    '''
+    Manage the execution of batch runs
+    '''
+    def __init__(self, parent_opts, jid_gen, clear_load):
+        ioloop = tornado.ioloop.IOLoop.current()
+        self.local = salt.client.get_local_client(parent_opts['conf_file'])
+        clear_load['gather_job_timeout'] = clear_load['kwargs'].pop('gather_job_timeout')
+        self.opts = _batch_get_opts(
+            clear_load.pop('tgt'),
+            clear_load.pop('fun'),
+            clear_load['kwargs'].pop('batch'),
+            self.local.opts,
+            **clear_load)
+        self.eauth = _batch_get_eauth(clear_load['kwargs'])
+        self.minions = set()
+        self.down_minions = set()
+        self.done = set()
+        self.active = []
+        self.initialized = False
+        self.ping_jid = jid_gen()
+        self.batch_jid = jid_gen()
+        self.event = salt.utils.event.get_event(
+            'master',
+            self.opts['sock_dir'],
+            self.opts['transport'],
+            opts=self.opts,
+            listen=True,
+            io_loop=ioloop,
+            keep_loop=True)
+        self.__set_event_handler()
+
+    def __set_event_handler(self):
+        ping_return_pattern = 'salt/job/{0}/ret/*'.format(self.ping_jid)
+        batch_return_pattern = 'salt/job/{0}/ret/*'.format(self.batch_jid)
+        self.event.subscribe(ping_return_pattern, match_type='glob')
+        self.event.subscribe(batch_return_pattern, match_type='glob')
+        self.event.patterns = {
+            (ping_return_pattern, 'ping_return'),
+            (batch_return_pattern, 'batch_run')
+        }
+        if not self.event.subscriber.connected():
+            self.event.set_event_handler(self.__event_handler)
+
+    def __event_handler(self, raw):
+        mtag, data = self.event.unpack(raw, self.event.serial)
+        for (pattern, op) in self.event.patterns:
+            if fnmatch.fnmatch(mtag, pattern):
+                minion = data['id']
+                if op == 'ping_return':
+                    self.minions.add(minion)
+                    self.down_minions.remove(minion)
+                    self.batch_size = _get_bnum(self.opts, self.minions, True)
+                    self.to_run = self.minions.difference(self.done).difference(self.active)
+                if not self.initialized:
+                    #start batching even if not all minions respond to ping
+                    self.event.io_loop.call_later(
+                        self.opts['gather_job_timeout'], self.next)
+                    self.initialized = True
+                elif op == 'batch_run':
+                    if minion in self.active:
+                        self.active.remove(minion)
+                        self.done.add(minion)
+                    if len(self.done) >= len(self.minions):
+                        self.event.close_pub()
+                    else:
+                        # call later so that we maybe gather more returns
+                        self.event.io_loop.call_later(1, self.next)
+
+    def _get_next(self):
+        next_batch_size = min(
+            len(self.to_run),                   # partial batch (all left)
+            self.batch_size - len(self.active)  # full batch
+        )
+        next_batch = []
+        for i in range(next_batch_size):
+            next_batch.append(self.to_run.pop())
+        return next_batch
+
+    @tornado.gen.coroutine
+    def start(self):
+        ping_return = yield self.local.run_job_async(
+            self.opts['tgt'],
+            'test.ping',
+            [],
+            self.opts.get(
+                'selected_target_option',
+                self.opts.get('tgt_type', 'glob')
+            ),
+            gather_job_timeout=self.opts['gather_job_timeout'],
+            jid=self.ping_jid,
+            **self.eauth)
+        self.down_minions = ping_return['minions']
+
+    @tornado.gen.coroutine
+    def next(self):
+        next_batch = self._get_next()
+        if next_batch:
+            yield self.local.run_job_async(
+                next_batch,
+                self.opts['fun'],
+                self.opts['arg'],
+                'list',
+                raw=self.opts.get('raw', False),
+                ret=self.opts.get('return', ''),
+                gather_job_timeout=self.opts['gather_job_timeout'],
+                jid=self.batch_jid,
+                **self.eauth)
+            self.active += next_batch

--- a/salt/cli/batch_async.py
+++ b/salt/cli/batch_async.py
@@ -27,7 +27,10 @@ class BatchAsync(object):
     def __init__(self, parent_opts, jid_gen, clear_load):
         ioloop = tornado.ioloop.IOLoop.current()
         self.local = salt.client.get_local_client(parent_opts['conf_file'])
-        clear_load['gather_job_timeout'] = clear_load['kwargs'].pop('gather_job_timeout')
+        if 'gather_job_timeout' in clear_load['kwargs']:
+            clear_load['gather_job_timeout'] = clear_load['kwargs'].pop('gather_job_timeout')
+        else:
+            clear_load['gather_job_timeout'] = self.local.opts['gather_job_timeout']
         self.batch_delay = clear_load['kwargs'].get('batch_delay', 1)
         self.opts = batch_get_opts(
             clear_load.pop('tgt'),

--- a/salt/cli/batch_async.py
+++ b/salt/cli/batch_async.py
@@ -68,7 +68,6 @@ class BatchAsync(object):
             (find_job_return_pattern, 'find_job_return')
         }
         if not self.event.subscriber.connected():
-            # TODO is there a way to subscribe to only some tags?
             self.event.set_event_handler(self.__event_handler)
 
     def __event_handler(self, raw):

--- a/salt/cli/batch_async.py
+++ b/salt/cli/batch_async.py
@@ -166,7 +166,7 @@ class BatchAsync(object):
                     "available_minions": self.minions,
                     "down_minions": self.down_minions
                 },
-                "salt/batch/%s/start" % self.batch_jid)
+                "salt/batch/{0}/start".format(self.batch_jid))
             yield self.next()
 
     def end_batch(self):
@@ -177,7 +177,7 @@ class BatchAsync(object):
                 "done_minions": self.done_minions,
                 "timedout_minions": self.timedout_minions
             },
-            "salt/batch/%s/done" % self.batch_jid)
+            "salt/batch/{0}/done".format(self.batch_jid))
         self.event.remove_event_handler(self.__event_handler)
 
     @tornado.gen.coroutine

--- a/salt/cli/batch_async.py
+++ b/salt/cli/batch_async.py
@@ -94,12 +94,10 @@ class BatchAsync(object):
                         self.opts['gather_job_timeout'], self.next)
                     self.initialized = True
 
-        from salt.master import mylogger
         if self.initialized and self.done_minions == self.minions.difference(self.timedout_minions):
             # TODO
             # if not all available minions finish the batch
             # the event handler connection is not closed
-            mylogger.info('Closing: %s %s %s', self.done_minions, self.timedout_minions, self.down_minions)
             self.event.close_pub()
 
     def _get_next(self):
@@ -114,10 +112,8 @@ class BatchAsync(object):
 
     @tornado.gen.coroutine
     def check_find_job(self, minions):
-        from salt.master import mylogger
         did_not_return = minions.difference(self.find_job_returned)
         if did_not_return:
-            mylogger.info('Not returned: %s', did_not_return)
             for minion in did_not_return:
                 if minion in self.find_job_returned:
                     self.find_job_returned.remove(minion)
@@ -130,7 +126,6 @@ class BatchAsync(object):
 
     @tornado.gen.coroutine
     def find_job(self, minions):
-        from salt.master import mylogger
         not_done = minions.difference(self.done_minions)
         ping_return = yield self.local.run_job_async(
             not_done,

--- a/salt/cli/batch_async.py
+++ b/salt/cli/batch_async.py
@@ -187,23 +187,29 @@ class BatchAsync(object):
         if not self.initialized:
             self.batch_size = get_bnum(self.opts, self.minions, True)
             self.initialized = True
-            self.event.fire_event(
+            data = {}
+            data.update(self.kwargs)
+            data.update(
                 {
                     "available_minions": self.minions,
                     "down_minions": self.down_minions
-                },
-                "salt/batch/{0}/start".format(self.batch_jid))
+                }
+            )
+            self.event.fire_event(data, "salt/batch/{0}/start".format(self.batch_jid))
             yield self.schedule_next()
 
     def end_batch(self):
-        self.event.fire_event(
+        data = {}
+        data.update(self.kwargs)
+        data.update(
             {
                 "available_minions": self.minions,
                 "down_minions": self.down_minions,
                 "done_minions": self.done_minions,
                 "timedout_minions": self.timedout_minions
-            },
-            "salt/batch/{0}/done".format(self.batch_jid))
+            }
+        )
+        self.event.fire_event(data, "salt/batch/{0}/done".format(self.batch_jid))
         self.event.remove_event_handler(self.__event_handler)
 
     @tornado.gen.coroutine

--- a/salt/cli/batch_async.py
+++ b/salt/cli/batch_async.py
@@ -17,7 +17,7 @@ from salt.ext.six.moves import range
 
 log = logging.getLogger(__name__)
 
-from salt.cli.batch import _get_bnum, _batch_get_opts, _batch_get_eauth
+from salt.cli.batch import get_bnum, batch_get_opts, batch_get_eauth
 
 
 class BatchAsync(object):
@@ -28,13 +28,13 @@ class BatchAsync(object):
         ioloop = tornado.ioloop.IOLoop.current()
         self.local = salt.client.get_local_client(parent_opts['conf_file'])
         clear_load['gather_job_timeout'] = clear_load['kwargs'].pop('gather_job_timeout')
-        self.opts = _batch_get_opts(
+        self.opts = batch_get_opts(
             clear_load.pop('tgt'),
             clear_load.pop('fun'),
             clear_load['kwargs'].pop('batch'),
             self.local.opts,
             **clear_load)
-        self.eauth = _batch_get_eauth(clear_load['kwargs'])
+        self.eauth = batch_get_eauth(clear_load['kwargs'])
         self.minions = set()
         self.down_minions = set()
         self.timedout_minions = set()
@@ -79,7 +79,7 @@ class BatchAsync(object):
                 if op == 'ping_return':
                     self.minions.add(minion)
                     self.down_minions.remove(minion)
-                    self.batch_size = _get_bnum(self.opts, self.minions, True)
+                    self.batch_size = get_bnum(self.opts, self.minions, True)
                     self.to_run = self.minions.difference(self.done_minions).difference(self.active)
                 elif op == 'find_job_return':
                     self.find_job_returned.add(minion)

--- a/salt/cli/batch_async.py
+++ b/salt/cli/batch_async.py
@@ -62,7 +62,8 @@ class BatchAsync(object):
             clear_load['kwargs'].pop('batch'),
             self.local.opts,
             **clear_load)
-        self.eauth = batch_get_eauth(clear_load['kwargs'])
+        self.kwargs = clear_load['kwargs']
+        self.kwargs.update(batch_get_eauth(clear_load['kwargs']))
         self.minions = set()
         self.down_minions = set()
         self.timedout_minions = set()
@@ -155,7 +156,7 @@ class BatchAsync(object):
             'list',
             gather_job_timeout=self.opts['gather_job_timeout'],
             jid=self.find_job_jid,
-            **self.eauth)
+            **self.kwargs)
         self.event.io_loop.call_later(
             self.opts['gather_job_timeout'],
             self.check_find_job,
@@ -177,7 +178,7 @@ class BatchAsync(object):
             ),
             gather_job_timeout=self.opts['gather_job_timeout'],
             jid=self.ping_jid,
-            **self.eauth)
+            **self.kwargs)
         self.down_minions = set(ping_return['minions'])
 
     @tornado.gen.coroutine
@@ -217,6 +218,6 @@ class BatchAsync(object):
                 ret=self.opts.get('return', ''),
                 gather_job_timeout=self.opts['gather_job_timeout'],
                 jid=self.batch_jid,
-                **self.eauth)
+                **self.kwargs)
             self.event.io_loop.call_later(self.opts['timeout'], self.find_job, set(next_batch))
             self.active = self.active.union(next_batch)

--- a/salt/cli/batch_async.py
+++ b/salt/cli/batch_async.py
@@ -91,7 +91,7 @@ class BatchAsync(object):
                         self.active.remove(minion)
                         self.done_minions.add(minion)
                         # call later so that we maybe gather more returns
-                        self.event.io_loop.call_later(self.batch_delay, self.next)
+                        self.event.io_loop.call_later(self.batch_delay, self.schedule_next)
 
         if self.initialized and self.done_minions == self.minions.difference(self.timedout_minions):
             self.end_batch()
@@ -167,7 +167,7 @@ class BatchAsync(object):
                     "down_minions": self.down_minions
                 },
                 "salt/batch/{0}/start".format(self.batch_jid))
-            yield self.next()
+            yield self.schedule_next()
 
     def end_batch(self):
         self.event.fire_event(
@@ -181,7 +181,7 @@ class BatchAsync(object):
         self.event.remove_event_handler(self.__event_handler)
 
     @tornado.gen.coroutine
-    def next(self):
+    def schedule_next(self):
         next_batch = self._get_next()
         if next_batch:
             yield self.local.run_job_async(

--- a/salt/cli/batch_async.py
+++ b/salt/cli/batch_async.py
@@ -95,9 +95,6 @@ class BatchAsync(object):
                     self.initialized = True
 
         if self.initialized and self.done_minions == self.minions.difference(self.timedout_minions):
-            # TODO
-            # if not all available minions finish the batch
-            # the event handler connection is not closed
             self.event.close_pub()
 
     def _get_next(self):

--- a/salt/cli/batch_async.py
+++ b/salt/cli/batch_async.py
@@ -63,7 +63,8 @@ class BatchAsync(object):
             self.local.opts,
             **clear_load)
         self.kwargs = clear_load['kwargs']
-        self.kwargs.update(batch_get_eauth(clear_load['kwargs']))
+        self.eauth = batch_get_eauth(clear_load['kwargs'])
+        self.kwargs.update(self.eauth)
         self.minions = set()
         self.down_minions = set()
         self.timedout_minions = set()
@@ -156,7 +157,7 @@ class BatchAsync(object):
             'list',
             gather_job_timeout=self.opts['gather_job_timeout'],
             jid=self.find_job_jid,
-            **self.kwargs)
+            **self.eauth)
         self.event.io_loop.call_later(
             self.opts['gather_job_timeout'],
             self.check_find_job,
@@ -178,7 +179,7 @@ class BatchAsync(object):
             ),
             gather_job_timeout=self.opts['gather_job_timeout'],
             jid=self.ping_jid,
-            **self.kwargs)
+            **self.eauth)
         self.down_minions = set(ping_return['minions'])
 
     @tornado.gen.coroutine

--- a/salt/cli/batch_async.py
+++ b/salt/cli/batch_async.py
@@ -13,6 +13,7 @@ import salt.client
 # pylint: enable=import-error,no-name-in-module,redefined-builtin
 import logging
 import fnmatch
+from salt.ext.six.moves import range
 
 log = logging.getLogger(__name__)
 

--- a/salt/cli/batch_async.py
+++ b/salt/cli/batch_async.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 '''
-Execute batch runs
+Execute a job on the targeted minions by using a moving window of fixed size `batch`.
 '''
 
 # Import python libs

--- a/salt/cli/batch_async.py
+++ b/salt/cli/batch_async.py
@@ -21,7 +21,32 @@ from salt.cli.batch import get_bnum, batch_get_opts, batch_get_eauth
 
 class BatchAsync(object):
     '''
-    Manage the execution of batch runs
+    Run a job on the targeted minions by using a moving window of fixed size `batch`.
+
+    ``BatchAsync`` is used to execute a job on the targeted minions by keeping
+    the number of concurrent running minions to the size of `batch` parameter.
+
+    The control parameters are:
+        - batch: number/percentage of concurrent running minions
+        - batch_delay: minimum wait time between batches
+        - gather_job_timeout: `find_job` timeout
+        - timeout: time to wait before firing a `find_job`
+
+    When the batch stars, a `start` event is fired:
+         - tag: salt/batch/<batch-jid>/start
+         - data: {
+             "available_minions": self.minions,
+             "down_minions": self.down_minions
+           }
+
+    When the batch ends, an `done` event is fired:
+        - tag: salt/batch/<batch-jid>/done
+        - data: {
+             "available_minions": self.minions,
+             "down_minions": self.down_minions,
+             "done_minions": self.done_minions,
+             "timedout_minions": self.timedout_minions
+         }
     '''
     def __init__(self, parent_opts, jid_gen, clear_load):
         ioloop = tornado.ioloop.IOLoop.current()

--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -530,11 +530,11 @@ class LocalClient(object):
         '''
         # Late import - not used anywhere else in this file
         import salt.cli.batch
-        opts = salt.cli.batch._batch_get_opts(
+        opts = salt.cli.batch.batch_get_opts(
             tgt, fun, batch, self.opts,
             arg=arg, tgt_type=tgt_type, ret=ret, kwarg=kwarg, **kwargs)
 
-        eauth = salt.cli.batch._batch_get_eauth(kwargs)
+        eauth = salt.cli.batch.batch_get_eauth(kwargs)
 
         batch = salt.cli.batch.Batch(opts, eauth=eauth, quiet=True)
         for ret in batch.run():

--- a/salt/master.py
+++ b/salt/master.py
@@ -96,12 +96,6 @@ from salt.utils.ctx import RequestContext
 
 log = logging.getLogger(__name__)
 
-fh = logging.FileHandler('/tmp/log.log')
-formatter = logging.Formatter('%(asctime)s - %(module)s.%(funcName)s - %(message)s')
-fh.setFormatter(formatter)
-mylogger = logging.getLogger('loglog')
-mylogger.addHandler(fh)
-
 
 class SMaster(object):
     '''
@@ -1608,7 +1602,6 @@ class AESFuncs(object):
 
         :param dict load: The minion payload
         '''
-        mylogger.debug("{jid} {id} {fun}".format(**load))
         if self.opts['require_minion_sign_messages'] and 'sig' not in load:
             log.critical(
                 '_return: Master is requiring minions to sign their '
@@ -2041,16 +2034,6 @@ class ClearFuncs(object):
             return False
         return self.loadauth.get_tok(clear_load['token'])
 
-    @tornado.gen.coroutine
-    def _timestamp(self, ioloop, lasttime, times, name):
-        if times >= 50:
-            raise tornado.gen.Return()
-        import random
-        # yield tornado.gen.sleep(random.randint(1, 50) / 100.0)
-        yield tornado.gen.sleep(0.1)
-        mylogger.info("%s %s", name, time.time() - lasttime)
-        ioloop.add_callback(self._timestamp, ioloop, time.time(), times + 1, name)
-
     def publish_batch(self, batch, clear_load):
         batch_load = {}
         batch_load.update(clear_load)
@@ -2063,9 +2046,6 @@ class ClearFuncs(object):
         )
         ioloop = tornado.ioloop.IOLoop.current()
         ioloop.add_callback(batch.start)
-        # ioloop.add_callback(self._timestamp, ioloop, time.time(), 0, ' 1     ')
-        # ioloop.add_callback(self._timestamp, ioloop, time.time(), 0, '   2   ')
-        # ioloop.add_callback(self._timestamp, ioloop, time.time(), 0, '     3 ')
 
         return {
             'enc': 'clear',
@@ -2176,7 +2156,6 @@ class ClearFuncs(object):
                 return {'enc': 'clear',
                         'load': {'error': 'Master failed to assign jid'}}
             payload = self._prep_pub(minions, jid, clear_load, extra, missing)
-            mylogger.debug("{jid} {fun} {tgt} {arg}".format(**payload))
 
             # Send it!
             self._send_ssh_pub(payload, ssh_minions=ssh_minions)

--- a/salt/master.py
+++ b/salt/master.py
@@ -31,6 +31,7 @@ import tornado.gen  # pylint: disable=F0401
 
 # Import salt libs
 import salt.crypt
+import salt.cli.batch_async
 import salt.client
 import salt.client.ssh.client
 import salt.exceptions
@@ -2034,10 +2035,9 @@ class ClearFuncs(object):
             return False
         return self.loadauth.get_tok(clear_load['token'])
 
-    def publish_batch(self, batch, clear_load):
+    def publish_batch(self, clear_load):
         batch_load = {}
         batch_load.update(clear_load)
-        batch_load['kwargs']['batch'] = batch
         import salt.cli.batch_async
         batch = salt.cli.batch_async.BatchAsync(
             self.local.opts,
@@ -2062,7 +2062,6 @@ class ClearFuncs(object):
         by the LocalClient.
         '''
         extra = clear_load.get('kwargs', {})
-        batch = extra.pop('batch', None)
 
         publisher_acl = salt.acl.PublisherACL(self.opts['publisher_acl_blacklist'])
 
@@ -2148,8 +2147,8 @@ class ClearFuncs(object):
                         'error': 'Master could not resolve minions for target {0}'.format(clear_load['tgt'])
                     }
                 }
-        if batch:
-            return self.publish_batch(batch, clear_load)
+        if extra.get('batch', None):
+            return self.publish_batch(clear_load)
         else:
             jid = self._prep_jid(clear_load, extra)
             if jid is None:

--- a/salt/master.py
+++ b/salt/master.py
@@ -2149,25 +2149,25 @@ class ClearFuncs(object):
                 }
         if extra.get('batch', None):
             return self.publish_batch(clear_load, minions, missing)
-        else:
-            jid = self._prep_jid(clear_load, extra)
-            if jid is None:
-                return {'enc': 'clear',
-                        'load': {'error': 'Master failed to assign jid'}}
-            payload = self._prep_pub(minions, jid, clear_load, extra, missing)
 
-            # Send it!
-            self._send_ssh_pub(payload, ssh_minions=ssh_minions)
-            self._send_pub(payload)
+        jid = self._prep_jid(clear_load, extra)
+        if jid is None:
+            return {'enc': 'clear',
+                    'load': {'error': 'Master failed to assign jid'}}
+        payload = self._prep_pub(minions, jid, clear_load, extra, missing)
 
-            return {
-                'enc': 'clear',
-                'load': {
-                    'jid': clear_load['jid'],
-                    'minions': minions,
-                    'missing': missing
-                }
+        # Send it!
+        self._send_ssh_pub(payload, ssh_minions=ssh_minions)
+        self._send_pub(payload)
+
+        return {
+            'enc': 'clear',
+            'load': {
+                'jid': clear_load['jid'],
+                'minions': minions,
+                'missing': missing
             }
+        }
 
     def _prep_auth_info(self, clear_load):
         sensitive_load_keys = []

--- a/salt/master.py
+++ b/salt/master.py
@@ -2035,7 +2035,7 @@ class ClearFuncs(object):
             return False
         return self.loadauth.get_tok(clear_load['token'])
 
-    def publish_batch(self, clear_load):
+    def publish_batch(self, clear_load, minions, missing):
         batch_load = {}
         batch_load.update(clear_load)
         import salt.cli.batch_async
@@ -2051,8 +2051,8 @@ class ClearFuncs(object):
             'enc': 'clear',
             'load': {
                 'jid': batch.batch_jid,
-                'minions': [],
-                'missing': []
+                'minions': minions,
+                'missing': missing
             }
         }
 
@@ -2148,7 +2148,7 @@ class ClearFuncs(object):
                     }
                 }
         if extra.get('batch', None):
-            return self.publish_batch(clear_load)
+            return self.publish_batch(clear_load, minions, missing)
         else:
             jid = self._prep_jid(clear_load, extra)
             if jid is None:

--- a/salt/netapi/__init__.py
+++ b/salt/netapi/__init__.py
@@ -88,7 +88,8 @@ class NetapiClient(object):
         :return: job ID
         '''
         local = salt.client.get_local_client(mopts=self.opts)
-        return local.run_job(*args, **kwargs)
+        ret = local.run_job(*args, **kwargs)
+        return ret
 
     def local(self, *args, **kwargs):
         '''

--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -873,6 +873,10 @@ class SaltEvent(object):
                     # Minion fired a bad retcode, fire an event
                     self._fire_ret_load_specific_fun(load)
 
+    def remove_event_handler(self, event_handler):
+        if event_handler in self.subscriber.callbacks:
+            self.subscriber.callbacks.remove(event_handler)
+
     def set_event_handler(self, event_handler):
         '''
         Invoke the event_handler callback each time an event arrives.
@@ -881,8 +885,11 @@ class SaltEvent(object):
 
         if not self.cpub:
             self.connect_pub()
-        # This will handle reconnects
-        return self.subscriber.read_async(event_handler)
+
+        self.subscriber.callbacks.add(event_handler)
+        if not self.subscriber.reading:
+            # This will handle reconnects
+            self.subscriber.read_async()
 
     def __del__(self):
         # skip exceptions in destroy-- since destroy() doesn't cover interpreter

--- a/tests/unit/cli/test_batch_async.py
+++ b/tests/unit/cli/test_batch_async.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 # Import Salt Libs
 from salt.cli.batch_async import BatchAsync
 
@@ -15,7 +17,6 @@ class AsyncBatchTestCase(AsyncTestCase, TestCase):
         opts = {'batch': '1',
                 'conf_file': {},
                 'tgt': '*',
-                'transport': '',
                 'timeout': 5,
                 'gather_job_timeout': 5,
                 'transport': None,

--- a/tests/unit/cli/test_batch_async.py
+++ b/tests/unit/cli/test_batch_async.py
@@ -128,7 +128,7 @@ class AsyncBatchTestCase(AsyncTestCase, TestCase):
         )
         self.assertEqual(
             self.batch.event.io_loop.call_later.call_args[0],
-            (10, self.batch.find_job, {'foo', 'bar'})
+            (self.batch.opts['timeout'], self.batch.find_job, {'foo', 'bar'})
         )
         self.assertEqual(self.batch.active, {'bar', 'foo'})
 

--- a/tests/unit/cli/test_batch_async.py
+++ b/tests/unit/cli/test_batch_async.py
@@ -1,0 +1,320 @@
+# Import Salt Libs
+from salt.cli.batch_async import BatchAsync
+
+import tornado
+from tornado.testing import AsyncTestCase
+from tests.support.unit import skipIf, TestCase
+from tests.support.mock import MagicMock, patch, NO_MOCK, NO_MOCK_REASON
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class AsyncBatchTestCase(AsyncTestCase, TestCase):
+
+    def setUp(self):
+        self.io_loop = self.get_new_ioloop()
+        opts = {'batch': '1',
+                'conf_file': {},
+                'tgt': '*',
+                'transport': '',
+                'timeout': 5,
+                'gather_job_timeout': 5,
+                'transport': None,
+                'sock_dir': ''}
+
+        with patch('salt.client.get_local_client', MagicMock(return_value=MagicMock())):
+            with patch('salt.cli.batch_async.batch_get_opts',
+                MagicMock(return_value=opts)
+            ):
+                self.batch = BatchAsync(opts, MagicMock(side_effect=['1234', '1235', '1236']), MagicMock())
+
+    def test_ping_jid(self):
+        self.assertEqual(self.batch.ping_jid, '1234')
+
+    def test_batch_jid(self):
+        self.assertEqual(self.batch.batch_jid, '1235')
+
+    def test_find_job_jid(self):
+        self.assertEqual(self.batch.find_job_jid, '1236')
+
+    def test_batch_size(self):
+        '''
+        Tests passing batch value as a number
+        '''
+        self.batch.opts = {'batch': '2', 'timeout': 5}
+        self.batch.minions = set(['foo', 'bar'])
+        self.batch.start_batch()
+        self.assertEqual(self.batch.batch_size, 2)
+
+    @tornado.testing.gen_test
+    def test_batch_start(self):
+        self.batch.event = MagicMock()
+        future = tornado.gen.Future()
+        future.set_result({'minions': ['foo', 'bar']})
+        self.batch.local.run_job_async.return_value = future
+        ret = self.batch.start()
+        # assert start_batch is called later with gather_job_timeout as param
+        self.assertEqual(
+            self.batch.event.io_loop.call_later.call_args[0],
+            (5, self.batch.start_batch))
+        # assert test.ping called
+        self.assertEqual(
+            self.batch.local.run_job_async.call_args[0],
+            ('*', 'test.ping', [], 'glob')
+        )
+        # assert down_minions == all minions matched by tgt
+        self.assertEqual(self.batch.down_minions, set(['foo', 'bar']))
+
+    def test_batch_fire_start_event(self):
+        self.batch.minions = set(['foo', 'bar'])
+        self.batch.opts = {'batch': '2', 'timeout': 5}
+        self.batch.event = MagicMock()
+        self.batch.start_batch()
+        self.assertEqual(
+            self.batch.event.fire_event.call_args[0],
+            (
+                {
+                    'available_minions': set(['foo', 'bar']),
+                    'down_minions': set()
+                },
+                "salt/batch/1235/start"
+            )
+        )
+
+    @tornado.testing.gen_test
+    def test_start_batch_calls_next(self):
+        self.batch.next = MagicMock(return_value=MagicMock())
+        self.batch.event = MagicMock()
+        future = tornado.gen.Future()
+        future.set_result(None)
+        self.batch.next = MagicMock(return_value=future)
+        self.batch.start_batch()
+        self.assertEqual(self.batch.initialized, True)
+        self.assertEqual(len(self.batch.next.mock_calls), 1)
+
+    def test_batch_fire_done_event(self):
+        self.batch.minions = set(['foo', 'bar'])
+        self.batch.event = MagicMock()
+        self.batch.end_batch()
+        self.assertEqual(
+            self.batch.event.fire_event.call_args[0],
+            (
+                {
+                    'available_minions': set(['foo', 'bar']),
+                    'done_minions': set(),
+                    'down_minions': set(),
+                    'timedout_minions': set()
+                },
+                "salt/batch/1235/done"
+            )
+        )
+        self.assertEqual(
+            len(self.batch.event.remove_event_handler.mock_calls), 1)
+
+    @tornado.testing.gen_test
+    def test_batch_next(self):
+        self.batch.event = MagicMock()
+        self.batch.opts['fun'] = 'my.fun'
+        self.batch.opts['arg'] = []
+        self.batch._get_next = MagicMock(return_value={'foo', 'bar'})
+        self.batch.batch_size = 2
+        future = tornado.gen.Future()
+        future.set_result({'minions': ['foo', 'bar']})
+        self.batch.local.run_job_async.return_value = future
+        ret = self.batch.next().result()
+        self.assertEqual(
+            self.batch.local.run_job_async.call_args[0],
+            ({'foo', 'bar'}, 'my.fun', [], 'list')
+        )
+        self.assertEqual(
+            self.batch.event.io_loop.call_later.call_args[0],
+            (10, self.batch.find_job, {'foo', 'bar'})
+        )
+        self.assertEqual(self.batch.active, {'bar', 'foo'})
+
+    def test_next_batch(self):
+        self.batch.minions = {'foo', 'bar'}
+        self.batch.batch_size = 2
+        self.assertEqual(self.batch._get_next(), {'foo', 'bar'})
+
+    def test_next_batch_one_done(self):
+        self.batch.minions = {'foo', 'bar'}
+        self.batch.done_minions = {'bar'}
+        self.batch.batch_size = 2
+        self.assertEqual(self.batch._get_next(), {'foo'})
+
+    def test_next_batch_one_done_one_active(self):
+        self.batch.minions = {'foo', 'bar', 'baz'}
+        self.batch.done_minions = {'bar'}
+        self.batch.active = {'baz'}
+        self.batch.batch_size = 2
+        self.assertEqual(self.batch._get_next(), {'foo'})
+
+    def test_next_batch_one_done_one_active_one_timedout(self):
+        self.batch.minions = {'foo', 'bar', 'baz', 'faz'}
+        self.batch.done_minions = {'bar'}
+        self.batch.active = {'baz'}
+        self.batch.timedout_minions = {'faz'}
+        self.batch.batch_size = 2
+        self.assertEqual(self.batch._get_next(), {'foo'})
+
+    def test_next_batch_bigger_size(self):
+        self.batch.minions = {'foo', 'bar'}
+        self.batch.batch_size = 3
+        self.assertEqual(self.batch._get_next(), {'foo', 'bar'})
+
+    def test_next_batch_all_done(self):
+        self.batch.minions = {'foo', 'bar'}
+        self.batch.done_minions = {'foo', 'bar'}
+        self.batch.batch_size = 2
+        self.assertEqual(self.batch._get_next(), set())
+
+    def test_next_batch_all_active(self):
+        self.batch.minions = {'foo', 'bar'}
+        self.batch.active = {'foo', 'bar'}
+        self.batch.batch_size = 2
+        self.assertEqual(self.batch._get_next(), set())
+
+    def test_next_batch_all_timedout(self):
+        self.batch.minions = {'foo', 'bar'}
+        self.batch.timedout_minions = {'foo', 'bar'}
+        self.batch.batch_size = 2
+        self.assertEqual(self.batch._get_next(), set())
+
+    def test_batch__event_handler_ping_return(self):
+        self.batch.down_minions = {'foo'}
+        self.batch.event = MagicMock(
+            unpack=MagicMock(return_value=('salt/job/1234/ret/foo', {'id': 'foo'})))
+        self.batch.start()
+        self.assertEqual(self.batch.minions, set())
+        self.batch._BatchAsync__event_handler(MagicMock())
+        self.assertEqual(self.batch.minions, {'foo'})
+        self.assertEqual(self.batch.done_minions, set())
+
+    def test_batch__event_handler_call_start_batch_when_all_pings_return(self):
+        self.batch.down_minions = {'foo'}
+        self.batch.event = MagicMock(
+            unpack=MagicMock(return_value=('salt/job/1234/ret/foo', {'id': 'foo'})))
+        self.batch.start()
+        self.batch._BatchAsync__event_handler(MagicMock())
+        self.assertEqual(
+            self.batch.event.io_loop.spawn_callback.call_args[0],
+            (self.batch.start_batch,))
+
+    def test_batch__event_handler_not_call_start_batch_when_not_all_pings_return(self):
+        self.batch.down_minions = {'foo', 'bar'}
+        self.batch.event = MagicMock(
+            unpack=MagicMock(return_value=('salt/job/1234/ret/foo', {'id': 'foo'})))
+        self.batch.start()
+        self.batch._BatchAsync__event_handler(MagicMock())
+        self.assertEqual(
+            len(self.batch.event.io_loop.spawn_callback.mock_calls), 0)
+
+    def test_batch__event_handler_batch_run_return(self):
+        self.batch.event = MagicMock(
+            unpack=MagicMock(return_value=('salt/job/1235/ret/foo', {'id': 'foo'})))
+        self.batch.start()
+        self.batch.active = {'foo'}
+        self.batch._BatchAsync__event_handler(MagicMock())
+        self.assertEqual(self.batch.active, set())
+        self.assertEqual(self.batch.done_minions, {'foo'})
+        self.assertEqual(
+            self.batch.event.io_loop.call_later.call_args[0],
+            (self.batch.batch_delay, self.batch.next))
+
+    def test_batch__event_handler_find_job_return(self):
+        self.batch.event = MagicMock(
+            unpack=MagicMock(return_value=('salt/job/1236/ret/foo', {'id': 'foo'})))
+        self.batch.start()
+        self.batch._BatchAsync__event_handler(MagicMock())
+        self.assertEqual(self.batch.find_job_returned, {'foo'})
+
+    @tornado.testing.gen_test
+    def test_batch__event_handler_end_batch(self):
+        self.batch.event = MagicMock(
+            unpack=MagicMock(return_value=('salt/job/not-my-jid/ret/foo', {'id': 'foo'})))
+        future = tornado.gen.Future()
+        future.set_result({'minions': ['foo', 'bar', 'baz']})
+        self.batch.local.run_job_async.return_value = future
+        self.batch.start()
+        self.batch.initialized = True
+        self.assertEqual(self.batch.down_minions, {'foo', 'bar', 'baz'})
+        self.batch.end_batch = MagicMock()
+        self.batch.minions = {'foo', 'bar', 'baz'}
+        self.batch.done_minions = {'foo', 'bar'}
+        self.batch.timedout_minions = {'baz'}
+        self.batch._BatchAsync__event_handler(MagicMock())
+        self.assertEqual(len(self.batch.end_batch.mock_calls), 1)
+
+    @tornado.testing.gen_test
+    def test_batch_find_job(self):
+        self.batch.event = MagicMock()
+        future = tornado.gen.Future()
+        future.set_result({})
+        self.batch.local.run_job_async.return_value = future
+        self.batch.find_job({'foo', 'bar'})
+        self.assertEqual(
+            self.batch.event.io_loop.call_later.call_args[0],
+            (self.batch.opts['gather_job_timeout'], self.batch.check_find_job, {'foo', 'bar'})
+        )
+
+    @tornado.testing.gen_test
+    def test_batch_find_job_with_done_minions(self):
+        self.batch.done_minions = {'bar'}
+        self.batch.event = MagicMock()
+        future = tornado.gen.Future()
+        future.set_result({})
+        self.batch.local.run_job_async.return_value = future
+        self.batch.find_job({'foo', 'bar'})
+        self.assertEqual(
+            self.batch.event.io_loop.call_later.call_args[0],
+            (self.batch.opts['gather_job_timeout'], self.batch.check_find_job, {'foo'})
+        )
+
+    def test_batch_check_find_job_did_not_return(self):
+        self.batch.event = MagicMock()
+        self.batch.active = {'foo'}
+        self.batch.find_job_returned = set()
+        self.batch.check_find_job({'foo'})
+        self.assertEqual(self.batch.find_job_returned, set())
+        self.assertEqual(self.batch.active, set())
+        self.assertEqual(len(self.batch.event.io_loop.add_callback.mock_calls), 0)
+
+    def test_batch_check_find_job_did_return(self):
+        self.batch.event = MagicMock()
+        self.batch.find_job_returned = {'foo'}
+        self.batch.check_find_job({'foo'})
+        self.assertEqual(
+            self.batch.event.io_loop.add_callback.call_args[0],
+            (self.batch.find_job, {'foo'})
+        )
+
+    def test_batch_check_find_job_multiple_states(self):
+        self.batch.event = MagicMock()
+        # currently running minions
+        self.batch.active = {'foo', 'bar'}
+
+        # minion is running and find_job returns
+        self.batch.find_job_returned = {'foo'}
+
+        # minion started running but find_job did not return
+        self.batch.timedout_minions = {'faz'}
+
+        # minion finished
+        self.batch.done_minions = {'baz'}
+
+        # both not yet done but only 'foo' responded to find_job
+        not_done = {'foo', 'bar'}
+
+        self.batch.check_find_job(not_done)
+
+        # assert 'bar' removed from active
+        self.assertEqual(self.batch.active, {'foo'})
+
+        # assert 'bar' added to timedout_minions
+        self.assertEqual(self.batch.timedout_minions, {'bar', 'faz'})
+
+        # assert 'find_job' schedueled again only for 'foo'
+        self.assertEqual(
+            self.batch.event.io_loop.add_callback.call_args[0],
+            (self.batch.find_job, {'foo'})
+        )

--- a/tests/unit/cli/test_batch_async.py
+++ b/tests/unit/cli/test_batch_async.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import absolute_import
+
 # Import Salt Libs
 from salt.cli.batch_async import BatchAsync
 

--- a/tests/unit/cli/test_batch_async.py
+++ b/tests/unit/cli/test_batch_async.py
@@ -85,14 +85,14 @@ class AsyncBatchTestCase(AsyncTestCase, TestCase):
 
     @tornado.testing.gen_test
     def test_start_batch_calls_next(self):
-        self.batch.next = MagicMock(return_value=MagicMock())
+        self.batch.schedule_next = MagicMock(return_value=MagicMock())
         self.batch.event = MagicMock()
         future = tornado.gen.Future()
         future.set_result(None)
-        self.batch.next = MagicMock(return_value=future)
+        self.batch.schedule_next = MagicMock(return_value=future)
         self.batch.start_batch()
         self.assertEqual(self.batch.initialized, True)
-        self.assertEqual(len(self.batch.next.mock_calls), 1)
+        self.assertEqual(len(self.batch.schedule_next.mock_calls), 1)
 
     def test_batch_fire_done_event(self):
         self.batch.minions = set(['foo', 'bar'])
@@ -123,7 +123,7 @@ class AsyncBatchTestCase(AsyncTestCase, TestCase):
         future = tornado.gen.Future()
         future.set_result({'minions': ['foo', 'bar']})
         self.batch.local.run_job_async.return_value = future
-        ret = self.batch.next().result()
+        ret = self.batch.schedule_next().result()
         self.assertEqual(
             self.batch.local.run_job_async.call_args[0],
             ({'foo', 'bar'}, 'my.fun', [], 'list')
@@ -222,7 +222,7 @@ class AsyncBatchTestCase(AsyncTestCase, TestCase):
         self.assertEqual(self.batch.done_minions, {'foo'})
         self.assertEqual(
             self.batch.event.io_loop.call_later.call_args[0],
-            (self.batch.batch_delay, self.batch.next))
+            (self.batch.batch_delay, self.batch.schedule_next))
 
     def test_batch__event_handler_find_job_return(self):
         self.batch.event = MagicMock(

--- a/tests/unit/cli/test_batch_async.py
+++ b/tests/unit/cli/test_batch_async.py
@@ -71,13 +71,15 @@ class AsyncBatchTestCase(AsyncTestCase, TestCase):
         self.batch.minions = set(['foo', 'bar'])
         self.batch.opts = {'batch': '2', 'timeout': 5}
         self.batch.event = MagicMock()
+        self.batch.metadata = {'mykey': 'myvalue'}
         self.batch.start_batch()
         self.assertEqual(
             self.batch.event.fire_event.call_args[0],
             (
                 {
                     'available_minions': set(['foo', 'bar']),
-                    'down_minions': set()
+                    'down_minions': set(),
+                    'metadata': self.batch.metadata
                 },
                 "salt/batch/1235/start"
             )
@@ -97,6 +99,7 @@ class AsyncBatchTestCase(AsyncTestCase, TestCase):
     def test_batch_fire_done_event(self):
         self.batch.minions = set(['foo', 'bar'])
         self.batch.event = MagicMock()
+        self.batch.metadata = {'mykey': 'myvalue'}
         self.batch.end_batch()
         self.assertEqual(
             self.batch.event.fire_event.call_args[0],
@@ -105,7 +108,8 @@ class AsyncBatchTestCase(AsyncTestCase, TestCase):
                     'available_minions': set(['foo', 'bar']),
                     'done_minions': set(),
                     'down_minions': set(),
-                    'timedout_minions': set()
+                    'timedout_minions': set(),
+                    'metadata': self.batch.metadata
                 },
                 "salt/batch/1235/done"
             )


### PR DESCRIPTION
### What does this PR do?

Implementation of [RFC#0002](https://github.com/saltstack/salt/blob/develop/rfcs/0002-netapi-async-batch.md)

### What issues does this PR fix or reference?

When doing a request to /run endpoint with the following payload:

```
{
    "client": "local_async",
    "eauth": "auto",
    "username": "admin",
    "password": "admin",
    "tgt": "*",
    "fun": "cmd.run",
    "arg": ["sleep $((RANDOM % 30)) && echo hello"],
    "timeout": 5,
    "gather_job_timeout": 5,
    "batch_delay": 1,
    "batch": "2"
}
```

A response is returned immediately. The response is empty (please ignore that for now) but it basically looks like this: https://github.com/saltstack/salt/blob/7f6e5d89a48bccf19cb45ed52a3a54f5cc53f400/salt/master.py#L2070-L2077

After returning the response, the batch executes a test.ping. Once the test.ping is done an event is published `salt/batch/<batch-jid>/start` with the following data: https://github.com/saltstack/salt/blob/7d4cae95f3fd54f10ad79544d4c9a2074ab11ed4/salt/cli/batch_async.py#L190-L194

When the batch finishes, it fires `salt/batch/<batch-jid>/done` event: https://github.com/saltstack/salt/blob/7d4cae95f3fd54f10ad79544d4c9a2074ab11ed4/salt/cli/batch_async.py#L199-L205

### Previous Behavior
The response is only returned after the batch job was executed.

### New Behavior
The response is returned immediately and the batch job continues to run as tornado coroutines.

### Tests written?

TODO
