### PR TITLE
[2018.3] Fixes to verify_login in mysql module

### DIFF
--- a/salt/modules/mysql.py
+++ b/salt/modules/mysql.py
@@ -1247,7 +1247,7 @@ def user_exists(user,
         args['password'] = password_hash
 
     if run_verify:
-        if not verify_login(user, host, password):
+        if not verify_login(user, password, **connection_args):
             return False
     try:
         _execute(cur, qry, args)
@@ -2235,7 +2235,7 @@ def showglobal(**connection_args):
     return rtnv
 
 
-def verify_login(user, host='localhost', password=None, **connection_args):
+def verify_login(user, password=None, **connection_args):
     '''
     Attempt to login using the provided credentials.
     If successful, return true.  Otherwise, return False.
@@ -2244,11 +2244,10 @@ def verify_login(user, host='localhost', password=None, **connection_args):
 
     .. code-block:: bash
 
-        salt '*' mysql.verify_login root localhost password
+        salt '*' mysql.verify_login root password
     '''
-    # Override the connection args
+    # Override the connection args for username and password
     connection_args['connection_user'] = user
-    connection_args['connection_host'] = host
     connection_args['connection_pass'] = password
 
     dbc = _connect(**connection_args)

--- a/tests/unit/modules/test_mysql.py
+++ b/tests/unit/modules/test_mysql.py
@@ -66,6 +66,19 @@ class MySQLTestCase(TestCase, LoaderModuleMockMixin):
                             password='BLUECOW'
             )
 
+        with patch.object(mysql, 'version', return_value='8.0.11'):
+            self._test_call(mysql.user_exists,
+                            {'sql': ('SELECT User,Host FROM mysql.user WHERE '
+                                     'User = %(user)s AND Host = %(host)s'),
+                             'sql_args': {'host': '%',
+                                          'user': 'mytestuser'
+                                         }
+                            },
+                            user='mytestuser',
+                            host='%',
+                            password='BLUECOW'
+            )
+
         # test_user_create_when_user_exists(self):
         # ensure we don't try to create a user when one already exists
         # mock the version of MySQL


### PR DESCRIPTION
### What does this PR do?
Ensure that verify_login is using the host from the connection_args and not the host associated with the user.  Adding a test to ensure user_exists when the passed host is the MySQL wildcard %.

### What issues does this PR fix or reference?
#50542 

### Previous Behavior
When `user_exists` was called with a wildcard hostname, `%`, then verify login would fail because it was trying to connect to that as a real hostname.

### New Behavior
We should ensure we're using the hostname from connection_args when verifying the login.

### Tests written?
Yes

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
