### PR TITLE
Fix inconsistency with `pkg.list_pkgs` when using `attr` on RHEL systems

### DIFF
--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -217,6 +217,23 @@ def _warn_software_properties(repo):
     log.warning('Best guess at ppa format: %s', repo)
 
 
+def normalize_name(name):
+    '''
+    Strips the architecture from the specified package name, if necessary.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' pkg.normalize_name zsh:amd64
+    '''
+    try:
+        name, arch = name.rsplit(':', 1)
+    except ValueError:
+        return name
+    return name
+
+
 def latest_version(*names, **kwargs):
     '''
     Return the latest version of the named package available for upgrade or

--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -76,6 +76,7 @@ except ImportError:
 # pylint: enable=import-error
 
 APT_LISTS_PATH = "/var/lib/apt/lists"
+PKG_ARCH_SEPARATOR = ':'
 
 # Source format for urllib fallback on PPA handling
 LP_SRC_FORMAT = 'deb http://ppa.launchpad.net/{0}/{1}/ubuntu {2} main'
@@ -232,6 +233,26 @@ def normalize_name(name):
     except ValueError:
         return name
     return name
+
+
+def parse_arch_from_name(name):
+    '''
+    Parse name and architecture from the specified package name.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' pkg.parse_arch_from_name zsh:amd64
+    '''
+    try:
+        _name, _arch = name.rsplit(PKG_ARCH_SEPARATOR, 1)
+    except ValueError:
+        _name, _arch = name, None
+    return {
+        'name': _name,
+        'arch': _arch
+    }
 
 
 def latest_version(*names, **kwargs):

--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -229,7 +229,7 @@ def normalize_name(name):
         salt '*' pkg.normalize_name zsh:amd64
     '''
     try:
-        name, arch = name.rsplit(':', 1)
+        name, arch = name.rsplit(PKG_ARCH_SEPARATOR, 1)
     except ValueError:
         return name
     return name

--- a/salt/modules/pkg_resource.py
+++ b/salt/modules/pkg_resource.py
@@ -319,22 +319,22 @@ def format_pkg_list(packages, versions_as_list, attr):
             requested_attr &= set(attr + ['version'] + ['arch'])
 
         for name in ret:
+            try:
+                _name, _arch = name.rsplit('.', 1)
+            except ValueError:
+                _name, _arch = None, None
+
             versions = []
-            pkgname = name
+            pkgname = None
             for all_attr in ret[name]:
                 filtered_attr = {}
                 for key in requested_attr:
-                    if all_attr[key]:
+                    if key in all_attr:
                         filtered_attr[key] = all_attr[key]
                 versions.append(filtered_attr)
-            try:
-                namepart, archpart = name.rsplit('.', 1)
-            except ValueError:
-                pass
-            else:
-                if archpart in [attrs['arch'] for attrs in versions]:
-                    pkgname = namepart
-            ret_attr.setdefault(pkgname, []).extend(versions)
+                if _name and filtered_attr.get('arch', None) == _arch:
+                    pkgname = _name
+            ret_attr.setdefault(pkgname or name, []).extend(versions)
         return ret_attr
 
     for name in ret:

--- a/salt/modules/pkg_resource.py
+++ b/salt/modules/pkg_resource.py
@@ -319,10 +319,10 @@ def format_pkg_list(packages, versions_as_list, attr):
             requested_attr &= set(attr + ['version'] + ['arch'])
 
         for name in ret:
-            try:
-                _name, _arch = name.rsplit('.', 1)
-            except ValueError:
-                _name, _arch = None, None
+            _parse_arch_from_name = __salt__.get('pkg.parse_arch_from_name', lambda pkgname: {'name': pkgname, 'arch': None})
+            name_arch_d = _parse_arch_from_name(name)
+            _name = name_arch_d['name']
+            _arch = name_arch_d['arch']
 
             versions = []
             pkgname = None

--- a/salt/modules/pkg_resource.py
+++ b/salt/modules/pkg_resource.py
@@ -311,22 +311,31 @@ def format_pkg_list(packages, versions_as_list, attr):
     '''
     ret = copy.deepcopy(packages)
     if attr:
+        ret_attr = {}
         requested_attr = set(['epoch', 'version', 'release', 'arch',
                               'install_date', 'install_date_time_t'])
 
         if attr != 'all':
-            requested_attr &= set(attr + ['version'])
+            requested_attr &= set(attr + ['version'] + ['arch'])
 
         for name in ret:
             versions = []
+            pkgname = name
             for all_attr in ret[name]:
                 filtered_attr = {}
                 for key in requested_attr:
                     if all_attr[key]:
                         filtered_attr[key] = all_attr[key]
                 versions.append(filtered_attr)
-            ret[name] = versions
-        return ret
+            try:
+                namepart, archpart = name.rsplit('.', 1)
+            except ValueError:
+                pass
+            else:
+                if archpart in [attrs['arch'] for attrs in versions]:
+                    pkgname = namepart
+            ret_attr.setdefault(pkgname, []).extend(versions)
+        return ret_attr
 
     for name in ret:
         ret[name] = [format_version(d['epoch'], d['version'], d['release'])

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -65,6 +65,8 @@ log = logging.getLogger(__name__)
 
 __HOLD_PATTERN = r'[\w+]+(?:[.-][^-]+)*'
 
+PKG_ARCH_SEPARATOR = '.'
+
 # Define the module's virtual name
 __virtualname__ = 'pkg'
 
@@ -407,6 +409,30 @@ def normalize_name(name):
             or salt.utils.pkg.rpm.check_32(arch, osarch=__grains__['osarch']):
         return name[:-(len(arch) + 1)]
     return name
+
+
+def parse_arch_from_name(name):
+    '''
+    Parse name and architecture from the specified package name.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' pkg.parse_arch_from_name zsh.x86_64
+    '''
+    _name, _arch = None, None
+    try:
+        _name, _arch = name.rsplit(PKG_ARCH_SEPARATOR, 1)
+    except ValueError:
+        pass
+    if _arch not in salt.utils.pkg.rpm.ARCHES + ('noarch',):
+        _name = name
+        _arch = None
+    return {
+        'name': _name,
+        'arch': _arch
+    }
 
 
 def latest_version(*names, **kwargs):

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -400,7 +400,7 @@ def normalize_name(name):
         salt '*' pkg.normalize_name zsh.x86_64
     '''
     try:
-        arch = name.rsplit('.', 1)[-1]
+        arch = name.rsplit(PKG_ARCH_SEPARATOR, 1)[-1]
         if arch not in salt.utils.pkg.rpm.ARCHES + ('noarch',):
             return name
     except ValueError:

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -38,6 +38,7 @@ import salt.utils.files
 import salt.utils.functools
 import salt.utils.path
 import salt.utils.pkg
+import salt.utils.pkg.rpm
 import salt.utils.stringutils
 import salt.utils.systemd
 from salt.utils.versions import LooseVersion
@@ -50,6 +51,7 @@ ZYPP_HOME = '/etc/zypp'
 LOCKS = '{0}/locks'.format(ZYPP_HOME)
 REPOS = '{0}/repos.d'.format(ZYPP_HOME)
 DEFAULT_PRIORITY = 99
+PKG_ARCH_SEPARATOR = '.'
 
 # Define the module's virtual name
 __virtualname__ = 'pkg'
@@ -575,6 +577,30 @@ def info_available(*names, **kwargs):
             nfo['installed'] = nfo.get('installed').lower() == 'yes' and True or False
 
     return ret
+
+
+def parse_arch_from_name(name):
+    '''
+    Parse name and architecture from the specified package name.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' pkg.parse_arch_from_name zsh.x86_64
+    '''
+    _name, _arch = None, None
+    try:
+        _name, _arch = name.rsplit(PKG_ARCH_SEPARATOR, 1)
+    except ValueError:
+        pass
+    if _arch not in salt.utils.pkg.rpm.ARCHES + ('noarch',):
+        _name = name
+        _arch = None
+    return {
+        'name': _name,
+        'arch': _arch
+    }
 
 
 def latest_version(*names, **kwargs):

--- a/tests/unit/modules/test_pkg_resource.py
+++ b/tests/unit/modules/test_pkg_resource.py
@@ -183,7 +183,6 @@ class PkgresTestCase(TestCase, LoaderModuleMockMixin):
                 'arch': None
             }
         }
-        parse_arch_lambda = lambda x: NAME_ARCH_MAPPING.get(x)
         packages = {
             'glibc': [{'version': '2.12', 'epoch': '', 'release': '1.212.el6', 'arch': 'x86_64'}],
             'glibc.i686': [{'version': '2.12', 'epoch': '', 'release': '1.212.el6', 'arch': 'i686'}],
@@ -240,7 +239,7 @@ class PkgresTestCase(TestCase, LoaderModuleMockMixin):
                 }
             ]
         }
-        with patch.dict(pkg_resource.__salt__, {'pkg.parse_arch_from_name': parse_arch_lambda}):
+        with patch.dict(pkg_resource.__salt__, {'pkg.parse_arch_from_name': NAME_ARCH_MAPPING.get}):
             if six.PY3:
                 self.assertCountEqual(pkg_resource.format_pkg_list(packages, False, attr=['epoch', 'release']), expected_pkg_list)
             else:

--- a/tests/unit/modules/test_pkg_resource.py
+++ b/tests/unit/modules/test_pkg_resource.py
@@ -150,7 +150,7 @@ class PkgresTestCase(TestCase, LoaderModuleMockMixin):
             'foobar.something': '3:1.1-23.1',
             'foobar.': '3:1.1-23.1',
         }
-        self.assertDictEqual(pkg_resource.format_pkg_list(packages, False, None), expected_pkg_list)
+        self.assertItemsEqual(pkg_resource.format_pkg_list(packages, False, None), expected_pkg_list)
 
     def test_format_pkg_list_with_attr(self):
         '''
@@ -214,7 +214,7 @@ class PkgresTestCase(TestCase, LoaderModuleMockMixin):
                 }
             ]
         }
-        self.assertDictEqual(pkg_resource.format_pkg_list(packages, False, attr=['epoch', 'release']), expected_pkg_list)
+        self.assertItemsEqual(pkg_resource.format_pkg_list(packages, False, attr=['epoch', 'release']), expected_pkg_list)
 
     def test_stringify(self):
         '''

--- a/tests/unit/modules/test_pkg_resource.py
+++ b/tests/unit/modules/test_pkg_resource.py
@@ -151,8 +151,8 @@ class PkgresTestCase(TestCase, LoaderModuleMockMixin):
     def test_format_pkg_list_with_attr(self):
         '''
             Test to output format of the package list with attr parameter.
-			In this case, any redundant "arch" reference will be removed from the package name since it's
-			include as part of the requested attr.
+            In this case, any redundant "arch" reference will be removed from the package name since it's
+            include as part of the requested attr.
         '''
         packages = {
             'glibc': [{'version': '2.12', 'epoch': '', 'release': '1.212.el6', 'arch': 'x86_64'}],

--- a/tests/unit/modules/test_pkg_resource.py
+++ b/tests/unit/modules/test_pkg_resource.py
@@ -129,6 +129,69 @@ class PkgresTestCase(TestCase, LoaderModuleMockMixin):
         '''
         self.assertIsNone(pkg_resource.sort_pkglist({}))
 
+    def test_format_pkg_list_no_attr(self):
+        '''
+            Test to output format of the package list with no attr parameter.
+        '''
+        packages = {
+            'glibc': [{'version': '2.12', 'epoch': '', 'release': '1.212.el6', 'arch': 'x86_64'}],
+            'glibc.i686': [{'version': '2.12', 'epoch': '', 'release': '1.212.el6', 'arch': 'i686'}],
+            'foobar': [
+                {'version': '1.2.0', 'epoch': '2', 'release': '7', 'arch': 'x86_64'},
+                {'version': '1.2.3', 'epoch': '2', 'release': '27', 'arch': 'x86_64'},
+            ]
+        }
+        expected_pkg_list = {
+            'glibc': '2.12-1.212.el6',
+            'glibc.i686': '2.12-1.212.el6',
+            'foobar': '2:1.2.0-7,2:1.2.3-27',
+        }
+        self.assertDictEqual(pkg_resource.format_pkg_list(packages, False, None), expected_pkg_list)
+
+    def test_format_pkg_list_with_attr(self):
+        '''
+            Test to output format of the package list with attr parameter.
+			In this case, any redundant "arch" reference will be removed from the package name since it's
+			include as part of the requested attr.
+        '''
+        packages = {
+            'glibc': [{'version': '2.12', 'epoch': '', 'release': '1.212.el6', 'arch': 'x86_64'}],
+            'glibc.i686': [{'version': '2.12', 'epoch': '', 'release': '1.212.el6', 'arch': 'i686'}],
+            'foobar': [
+                {'version': '1.2.0', 'epoch': '2', 'release': '7', 'arch': 'x86_64'},
+                {'version': '1.2.3', 'epoch': '2', 'release': '27', 'arch': 'x86_64'},
+            ]
+        }
+        expected_pkg_list = {
+            'glibc': [
+                {
+                    'arch': 'x86_64',
+                    'release': '1.212.el6',
+                    'version': '2.12'
+                },
+                {
+                    'arch': 'i686',
+                    'release': '1.212.el6',
+                    'version': '2.12'
+                }
+             ],
+            'foobar': [
+                {
+                    'arch': 'x86_64',
+                    'release': '7',
+                    'epoch': '2',
+                    'version': '1.2.0'
+                },
+                {
+                    'arch': 'x86_64',
+                    'release': '27',
+                    'epoch': '2',
+                    'version': '1.2.3'
+                }
+             ]
+        }
+        self.assertDictEqual(pkg_resource.format_pkg_list(packages, False, attr=['epoch', 'release']), expected_pkg_list)
+
     def test_stringify(self):
         '''
             Test to takes a dict of package name/version information

--- a/tests/unit/modules/test_pkg_resource.py
+++ b/tests/unit/modules/test_pkg_resource.py
@@ -139,12 +139,16 @@ class PkgresTestCase(TestCase, LoaderModuleMockMixin):
             'foobar': [
                 {'version': '1.2.0', 'epoch': '2', 'release': '7', 'arch': 'x86_64'},
                 {'version': '1.2.3', 'epoch': '2', 'release': '27', 'arch': 'x86_64'},
-            ]
+            ],
+            'foobar.something': [{'version': '1.1', 'epoch': '3', 'release': '23.1', 'arch': 'i686'}],
+            'foobar.': [{'version': '1.1', 'epoch': '3', 'release': '23.1', 'arch': 'i686'}]
         }
         expected_pkg_list = {
             'glibc': '2.12-1.212.el6',
             'glibc.i686': '2.12-1.212.el6',
             'foobar': '2:1.2.0-7,2:1.2.3-27',
+            'foobar.something': '3:1.1-23.1',
+            'foobar.': '3:1.1-23.1',
         }
         self.assertDictEqual(pkg_resource.format_pkg_list(packages, False, None), expected_pkg_list)
 
@@ -160,18 +164,22 @@ class PkgresTestCase(TestCase, LoaderModuleMockMixin):
             'foobar': [
                 {'version': '1.2.0', 'epoch': '2', 'release': '7', 'arch': 'x86_64'},
                 {'version': '1.2.3', 'epoch': '2', 'release': '27', 'arch': 'x86_64'},
-            ]
+            ],
+            'foobar.something': [{'version': '1.1', 'epoch': '3', 'release': '23.1', 'arch': 'i686'}],
+            'foobar.': [{'version': '1.1', 'epoch': '3', 'release': '23.1', 'arch': 'i686'}]
         }
         expected_pkg_list = {
             'glibc': [
                 {
                     'arch': 'x86_64',
                     'release': '1.212.el6',
+                    'epoch': '',
                     'version': '2.12'
                 },
                 {
                     'arch': 'i686',
                     'release': '1.212.el6',
+                    'epoch': '',
                     'version': '2.12'
                 }
              ],
@@ -188,7 +196,23 @@ class PkgresTestCase(TestCase, LoaderModuleMockMixin):
                     'epoch': '2',
                     'version': '1.2.3'
                 }
-             ]
+            ],
+            'foobar.': [
+                {
+                    'arch': 'i686',
+                    'release': '23.1',
+                    'epoch': '3',
+                    'version': '1.1'
+                }
+            ],
+            'foobar.something': [
+                {
+                    'arch': 'i686',
+                    'release': '23.1',
+                    'epoch': '3',
+                    'version': '1.1'
+                }
+            ]
         }
         self.assertDictEqual(pkg_resource.format_pkg_list(packages, False, attr=['epoch', 'release']), expected_pkg_list)
 

--- a/tests/unit/modules/test_pkg_resource.py
+++ b/tests/unit/modules/test_pkg_resource.py
@@ -150,7 +150,10 @@ class PkgresTestCase(TestCase, LoaderModuleMockMixin):
             'foobar.something': '3:1.1-23.1',
             'foobar.': '3:1.1-23.1',
         }
-        self.assertItemsEqual(pkg_resource.format_pkg_list(packages, False, None), expected_pkg_list)
+        if six.PY3:
+            self.assertCountEqual(pkg_resource.format_pkg_list(packages, False, None), expected_pkg_list)
+        else:
+            self.assertItemsEqual(pkg_resource.format_pkg_list(packages, False, None), expected_pkg_list)
 
     def test_format_pkg_list_with_attr(self):
         '''
@@ -214,7 +217,10 @@ class PkgresTestCase(TestCase, LoaderModuleMockMixin):
                 }
             ]
         }
-        self.assertItemsEqual(pkg_resource.format_pkg_list(packages, False, attr=['epoch', 'release']), expected_pkg_list)
+        if six.PY3:
+            self.assertCountEqual(pkg_resource.format_pkg_list(packages, False, attr=['epoch', 'release']), expected_pkg_list)
+        else:
+            self.assertItemsEqual(pkg_resource.format_pkg_list(packages, False, attr=['epoch', 'release']), expected_pkg_list)
 
     def test_stringify(self):
         '''

--- a/tests/unit/modules/test_yumpkg.py
+++ b/tests/unit/modules/test_yumpkg.py
@@ -156,54 +156,63 @@ class YumTestCase(TestCase, LoaderModuleMockMixin):
                     'release': '8.el7',
                     'arch': 'noarch',
                     'install_date_time_t': 1487838471,
+                    'epoch': ''
                 },
                 'alsa-lib': {
                     'version': '1.1.1',
                     'release': '1.el7',
                     'arch': 'x86_64',
                     'install_date_time_t': 1487838475,
+                    'epoch': ''
                 },
                 'gnupg2': {
                     'version': '2.0.22',
                     'release': '4.el7',
                     'arch': 'x86_64',
                     'install_date_time_t': 1487838477,
+                    'epoch': ''
                 },
                 'rpm-python': {
                     'version': '4.11.3',
                     'release': '21.el7',
                     'arch': 'x86_64',
                     'install_date_time_t': 1487838477,
+                    'epoch': ''
                 },
                 'pygpgme': {
                     'version': '0.3',
                     'release': '9.el7',
                     'arch': 'x86_64',
                     'install_date_time_t': 1487838478,
+                    'epoch': ''
                 },
                 'yum': {
                     'version': '3.4.3',
                     'release': '150.el7.centos',
                     'arch': 'noarch',
                     'install_date_time_t': 1487838479,
+                    'epoch': ''
                 },
                 'lzo': {
                     'version': '2.06',
                     'release': '8.el7',
                     'arch': 'x86_64',
                     'install_date_time_t': 1487838479,
+                    'epoch': ''
                 },
                 'qrencode-libs': {
                     'version': '3.4.1',
                     'release': '3.el7',
                     'arch': 'x86_64',
                     'install_date_time_t': 1487838480,
+                    'epoch': ''
                 },
                 'ustr': {
                     'version': '1.0.4',
                     'release': '16.el7',
                     'arch': 'x86_64',
                     'install_date_time_t': 1487838480,
+                    'epoch': ''
                 },
                 'shadow-utils': {
                     'epoch': '2',
@@ -217,18 +226,21 @@ class YumTestCase(TestCase, LoaderModuleMockMixin):
                     'release': '33.el7',
                     'arch': 'x86_64',
                     'install_date_time_t': 1487838484,
+                    'epoch': ''
                 },
                 'openssh': {
                     'version': '6.6.1p1',
                     'release': '33.el7_3',
                     'arch': 'x86_64',
                     'install_date_time_t': 1487838485,
+                    'epoch': ''
                 },
                 'virt-what': {
                     'version': '1.13',
                     'release': '8.el7',
                     'install_date_time_t': 1487838486,
                     'arch': 'x86_64',
+                    'epoch': ''
                 }}.items():
                 self.assertTrue(pkgs.get(pkg_name))
                 self.assertEqual(pkgs[pkg_name], [pkg_attr])

--- a/tests/unit/modules/test_yumpkg.py
+++ b/tests/unit/modules/test_yumpkg.py
@@ -61,6 +61,7 @@ class YumTestCase(TestCase, LoaderModuleMockMixin):
     Test cases for salt.modules.yumpkg
     '''
     def setup_loader_modules(self):
+        pkg_resource.__salt__ = {}
         return {
             yumpkg: {
                 '__context__': {
@@ -102,7 +103,8 @@ class YumTestCase(TestCase, LoaderModuleMockMixin):
              patch.dict(yumpkg.__salt__, {'cmd.run': MagicMock(return_value=os.linesep.join(rpm_out))}), \
              patch.dict(yumpkg.__salt__, {'pkg_resource.add_pkg': _add_data}), \
              patch.dict(yumpkg.__salt__, {'pkg_resource.format_pkg_list': pkg_resource.format_pkg_list}), \
-             patch.dict(yumpkg.__salt__, {'pkg_resource.stringify': MagicMock()}):
+             patch.dict(yumpkg.__salt__, {'pkg_resource.stringify': MagicMock()}), \
+             patch.dict(pkg_resource.__salt__, {'pkg.parse_arch_from_name': yumpkg.parse_arch_from_name}):
             pkgs = yumpkg.list_pkgs(versions_as_list=True)
             for pkg_name, pkg_version in {
                 'python-urlgrabber': '3.10-8.el7',
@@ -149,7 +151,8 @@ class YumTestCase(TestCase, LoaderModuleMockMixin):
              patch.dict(yumpkg.__salt__, {'cmd.run': MagicMock(return_value=os.linesep.join(rpm_out))}), \
              patch.dict(yumpkg.__salt__, {'pkg_resource.add_pkg': _add_data}), \
              patch.dict(yumpkg.__salt__, {'pkg_resource.format_pkg_list': pkg_resource.format_pkg_list}), \
-             patch.dict(yumpkg.__salt__, {'pkg_resource.stringify': MagicMock()}):
+             patch.dict(yumpkg.__salt__, {'pkg_resource.stringify': MagicMock()}), \
+             patch.dict(pkg_resource.__salt__, {'pkg.parse_arch_from_name': yumpkg.parse_arch_from_name}):
             pkgs = yumpkg.list_pkgs(attr=['epoch', 'release', 'arch', 'install_date_time_t'])
             for pkg_name, pkg_attr in {
                 'python-urlgrabber': {
@@ -266,7 +269,8 @@ class YumTestCase(TestCase, LoaderModuleMockMixin):
              patch.dict(yumpkg.__salt__, {'cmd.run': MagicMock(return_value=os.linesep.join(rpm_out))}), \
              patch.dict(yumpkg.__salt__, {'pkg_resource.add_pkg': _add_data}), \
              patch.dict(yumpkg.__salt__, {'pkg_resource.format_pkg_list': pkg_resource.format_pkg_list}), \
-             patch.dict(yumpkg.__salt__, {'pkg_resource.stringify': MagicMock()}):
+             patch.dict(yumpkg.__salt__, {'pkg_resource.stringify': MagicMock()}), \
+             patch.dict(pkg_resource.__salt__, {'pkg.parse_arch_from_name': yumpkg.parse_arch_from_name}):
             pkgs = yumpkg.list_pkgs(attr=['epoch', 'release', 'arch', 'install_date_time_t'])
             expected_pkg_list = {
                 'glibc': [

--- a/tests/unit/modules/test_yumpkg.py
+++ b/tests/unit/modules/test_yumpkg.py
@@ -302,7 +302,10 @@ class YumTestCase(TestCase, LoaderModuleMockMixin):
                 ]
             }
             for pkgname, pkginfo in pkgs.items():
-                self.assertItemsEqual(pkginfo, expected_pkg_list[pkgname])
+                if six.PY3:
+                    self.assertCountEqual(pkginfo, expected_pkg_list[pkgname])
+                else:
+                    self.assertItemsEqual(pkginfo, expected_pkg_list[pkgname])
 
     def test_latest_version_with_options(self):
         with patch.object(yumpkg, 'list_pkgs', MagicMock(return_value={})):

--- a/tests/unit/modules/test_yumpkg.py
+++ b/tests/unit/modules/test_yumpkg.py
@@ -16,6 +16,7 @@ from tests.support.mock import (
 )
 
 # Import Salt libs
+from salt.ext import six
 import salt.modules.rpm
 import salt.modules.yumpkg as yumpkg
 import salt.modules.pkg_resource as pkg_resource

--- a/tests/unit/modules/test_yumpkg.py
+++ b/tests/unit/modules/test_yumpkg.py
@@ -302,7 +302,7 @@ class YumTestCase(TestCase, LoaderModuleMockMixin):
                 ]
             }
             for pkgname, pkginfo in pkgs.items():
-                self.assertListEqual(pkginfo, expected_pkg_list[pkgname])
+                self.assertItemsEqual(pkginfo, expected_pkg_list[pkgname])
 
     def test_latest_version_with_options(self):
         with patch.object(yumpkg, 'list_pkgs', MagicMock(return_value={})):

--- a/tests/unit/modules/test_yumpkg.py
+++ b/tests/unit/modules/test_yumpkg.py
@@ -61,7 +61,6 @@ class YumTestCase(TestCase, LoaderModuleMockMixin):
     Test cases for salt.modules.yumpkg
     '''
     def setup_loader_modules(self):
-        pkg_resource.__salt__ = {}
         return {
             yumpkg: {
                 '__context__': {
@@ -72,7 +71,8 @@ class YumTestCase(TestCase, LoaderModuleMockMixin):
                     'os_family': 'RedHat',
                     'osmajorrelease': 7,
                 },
-            }
+            },
+            pkg_resource: {}
         }
 
     def test_list_pkgs(self):

--- a/tests/unit/modules/test_zypper.py
+++ b/tests/unit/modules/test_zypper.py
@@ -61,8 +61,7 @@ class ZypperTestCase(TestCase, LoaderModuleMockMixin):
     '''
 
     def setup_loader_modules(self):
-        pkg_resource.__salt__ = {}
-        return {zypper: {'rpm': None}}
+        return {zypper: {'rpm': None}, pkg_resource: {}}
 
     def setUp(self):
         self.new_repo_config = dict(

--- a/tests/unit/modules/test_zypper.py
+++ b/tests/unit/modules/test_zypper.py
@@ -541,36 +541,42 @@ Repository 'DUMMY' not found by its alias, number, or URI.
                     'release': '129.686',
                     'arch': 'noarch',
                     'install_date_time_t': 1498636511,
+                    'epoch': '',
                 },
                 'yast2-ftp-server': {
                     'version': '3.1.8',
                     'release': '8.1',
                     'arch': 'x86_64',
                     'install_date_time_t': 1499257798,
+                    'epoch': '',
                 },
                 'protobuf-java': {
                     'version': '2.6.1',
                     'release': '3.1.develHead',
                     'install_date_time_t': 1499257756,
                     'arch': 'noarch',
+                    'epoch': '',
                 },
                 'susemanager-build-keys-web': {
                     'version': '12.0',
                     'release': '5.1.develHead',
                     'arch': 'noarch',
                     'install_date_time_t': 1498636510,
+                    'epoch': '',
                 },
                 'apache-commons-cli': {
                     'version': '1.2',
                     'release': '1.233',
                     'arch': 'noarch',
                     'install_date_time_t': 1498636510,
+                    'epoch': '',
                 },
                 'jose4j': {
                     'arch': 'noarch',
                     'version': '0.4.4',
                     'release': '2.1.develHead',
                     'install_date_time_t': 1499257756,
+                    'epoch': '',
                 }}.items():
                 self.assertTrue(pkgs.get(pkg_name))
                 self.assertEqual(pkgs[pkg_name], [pkg_attr])

--- a/tests/unit/modules/test_zypper.py
+++ b/tests/unit/modules/test_zypper.py
@@ -636,7 +636,7 @@ Repository 'DUMMY' not found by its alias, number, or URI.
                 ]
             }
             for pkgname, pkginfo in pkgs.items():
-                self.assertListEqual(pkginfo, expected_pkg_list[pkgname])
+                self.assertItemsEqual(pkginfo, expected_pkg_list[pkgname])
 
     def test_list_patches(self):
         '''

--- a/tests/unit/modules/test_zypper.py
+++ b/tests/unit/modules/test_zypper.py
@@ -636,7 +636,10 @@ Repository 'DUMMY' not found by its alias, number, or URI.
                 ]
             }
             for pkgname, pkginfo in pkgs.items():
-                self.assertItemsEqual(pkginfo, expected_pkg_list[pkgname])
+                if six.PY3:
+                    self.assertCountEqual(pkginfo, expected_pkg_list[pkgname])
+                else:
+                    self.assertItemsEqual(pkginfo, expected_pkg_list[pkgname])
 
     def test_list_patches(self):
         '''

--- a/tests/unit/modules/test_zypper.py
+++ b/tests/unit/modules/test_zypper.py
@@ -61,6 +61,7 @@ class ZypperTestCase(TestCase, LoaderModuleMockMixin):
     '''
 
     def setup_loader_modules(self):
+        pkg_resource.__salt__ = {}
         return {zypper: {'rpm': None}}
 
     def setUp(self):
@@ -533,7 +534,8 @@ Repository 'DUMMY' not found by its alias, number, or URI.
         with patch.dict(zypper.__salt__, {'cmd.run': MagicMock(return_value=os.linesep.join(rpm_out))}), \
              patch.dict(zypper.__salt__, {'pkg_resource.add_pkg': _add_data}), \
              patch.dict(zypper.__salt__, {'pkg_resource.format_pkg_list': pkg_resource.format_pkg_list}), \
-             patch.dict(zypper.__salt__, {'pkg_resource.stringify': MagicMock()}):
+             patch.dict(zypper.__salt__, {'pkg_resource.stringify': MagicMock()}), \
+             patch.dict(pkg_resource.__salt__, {'pkg.parse_arch_from_name': zypper.parse_arch_from_name}):
             pkgs = zypper.list_pkgs(attr=['epoch', 'release', 'arch', 'install_date_time_t'])
             for pkg_name, pkg_attr in {
                 'jakarta-commons-discovery': {
@@ -596,10 +598,12 @@ Repository 'DUMMY' not found by its alias, number, or URI.
             'virt-what_|-1.13_|-8.el7_|-x86_64_|-_|-1487838486',
             'virt-what_|-1.10_|-2.el7_|-x86_64_|-_|-1387838486',
         ]
+
         with patch.dict(zypper.__salt__, {'cmd.run': MagicMock(return_value=os.linesep.join(rpm_out))}), \
              patch.dict(zypper.__salt__, {'pkg_resource.add_pkg': _add_data}), \
              patch.dict(zypper.__salt__, {'pkg_resource.format_pkg_list': pkg_resource.format_pkg_list}), \
-             patch.dict(zypper.__salt__, {'pkg_resource.stringify': MagicMock()}):
+             patch.dict(zypper.__salt__, {'pkg_resource.stringify': MagicMock()}), \
+             patch.dict(pkg_resource.__salt__, {'pkg.parse_arch_from_name': zypper.parse_arch_from_name}):
             pkgs = zypper.list_pkgs(attr=['epoch', 'release', 'arch', 'install_date_time_t'])
             expected_pkg_list = {
                 'glibc': [

--- a/tests/unit/modules/test_zypper.py
+++ b/tests/unit/modules/test_zypper.py
@@ -581,6 +581,63 @@ Repository 'DUMMY' not found by its alias, number, or URI.
                 self.assertTrue(pkgs.get(pkg_name))
                 self.assertEqual(pkgs[pkg_name], [pkg_attr])
 
+    def test_list_pkgs_with_attr_multiple_versions(self):
+        '''
+        Test packages listing with the attr parameter reporting multiple version installed
+
+        :return:
+        '''
+        def _add_data(data, key, value):
+            data.setdefault(key, []).append(value)
+
+        rpm_out = [
+            'glibc_|-2.12_|-1.212.el6_|-i686_|-_|-1542394210',
+            'glibc_|-2.12_|-1.212.el6_|-x86_64_|-_|-1542394204',
+            'virt-what_|-1.13_|-8.el7_|-x86_64_|-_|-1487838486',
+            'virt-what_|-1.10_|-2.el7_|-x86_64_|-_|-1387838486',
+        ]
+        with patch.dict(zypper.__salt__, {'cmd.run': MagicMock(return_value=os.linesep.join(rpm_out))}), \
+             patch.dict(zypper.__salt__, {'pkg_resource.add_pkg': _add_data}), \
+             patch.dict(zypper.__salt__, {'pkg_resource.format_pkg_list': pkg_resource.format_pkg_list}), \
+             patch.dict(zypper.__salt__, {'pkg_resource.stringify': MagicMock()}):
+            pkgs = zypper.list_pkgs(attr=['epoch', 'release', 'arch', 'install_date_time_t'])
+            expected_pkg_list = {
+                'glibc': [
+                    {
+                        'version': '2.12',
+                        'release': '1.212.el6',
+                        'install_date_time_t': 1542394210,
+                        'arch': 'i686',
+                        'epoch': ''
+                    },
+                    {
+                        'version': '2.12',
+                        'release': '1.212.el6',
+                        'install_date_time_t': 1542394204,
+                        'arch': 'x86_64',
+                        'epoch': ''
+                    }
+                ],
+                'virt-what': [
+                    {
+                        'version': '1.10',
+                        'release': '2.el7',
+                        'install_date_time_t': 1387838486,
+                        'arch': 'x86_64',
+                        'epoch': ''
+                    },
+                    {
+                        'version': '1.13',
+                        'release': '8.el7',
+                        'install_date_time_t': 1487838486,
+                        'arch': 'x86_64',
+                        'epoch': ''
+                    }
+                ]
+            }
+            for pkgname, pkginfo in pkgs.items():
+                self.assertListEqual(pkginfo, expected_pkg_list[pkgname])
+
     def test_list_patches(self):
         '''
         Test advisory patches listing.


### PR DESCRIPTION
### What does this PR do?
This PR fixes an issue on the `pkg.list_pkgs` method when using `attr` parameter on RHEL systems.

On past PRs we've introduced the use of `attr` on `pkg.list_pkgs` on the Zypper/Yum modules for collecting not only the package version string but instead getting the desired RPM attributes (like `epoch`, `install_date`, `release`, etc) in an unified and structured way.

So when using `attr` the output from `pkg.list_pkgs` will follow this specific format for `attr='release,arch'`):
```yaml
"package": [
  {
    "version": "value1",
    "release": "value2",
    "arch": "value3",
  },
  {
    "version": "value4",
    "release": "value5",
    "arch": "value6",
  }
]
```
As you can see, the format is meant to group all installed versions of the same package (with its RPM attributes) into a single key `package` which holds a list containing a dict with all attrs for each installed version.

### Previous Behavior

On SUSE systems there is no problem since packages with different architectures always have different names, like `glibc` and `glibc-32bit` :+1: 

But the problem is happening on RHEL systems, where the architecture is internally handled by Salt as part of the package name. This is leading into an inconsistent looking output from `pkg.list_pkgs` according with the proposed format when using `attr`:

```json
$ salt-call --local pkg.list_pkgs attr='arch,release' --output=json

...
        "glibc": [
            {
                "release": "1.212.el6", 
                "version": "2.12", 
                "arch": "x86_64"
            }
        ], 
        "glibc.i686": [
            {
                "release": "1.212.el6", 
                "version": "2.12", 
                "arch": "i686"
            }
        ],
...
```

### New Behavior

The expected output should consider `glibc` and `glibc.i686` as the same package and group them into the same dict key. The output should be:
```json
$ salt-call --local pkg.list_pkgs attr='arch,release' --output=json

...
        "glibc": [
            {
                "release": "1.212.el6", 
                "version": "2.12", 
                "arch": "i686"
            }, 
            {
                "release": "1.212.el6", 
                "version": "2.12", 
                "arch": "x86_64"
            }
        ], 
...
```

### Tests written?

Yes

### Commits signed with GPG?

Yes
