### PR TITLE
azurefs: gracefully handle AttributeError

### DIFF
--- a/salt/fileserver/azurefs.py
+++ b/salt/fileserver/azurefs.py
@@ -68,7 +68,7 @@ try:
     if LooseVersion(azure.storage.__version__) < LooseVersion('0.20.0'):
         raise ImportError('azure.storage.__version__ must be >= 0.20.0')
     HAS_AZURE = True
-except ImportError:
+except (ImportError, AttributeError):
     HAS_AZURE = False
 
 # Import third party libs


### PR DESCRIPTION
### What does this PR do?

It is possible that the azure.storage object has no __version__ defined.
In that case, prevent console spam with unhandled AttributeError
messages and instead consider that Azure support is not present.

Problem was encountered on openSUSE Tumbleweed.

### What issues does this PR fix or reference?

#50535

### Tests written?

No, I am not sure how to add that though.

### Commits signed with GPG?

Yes