### PR TITLE
[2018.3] Adding test=True to artifactory.download.

### DIFF
--- a/salt/states/artifactory.py
+++ b/salt/states/artifactory.py
@@ -84,7 +84,7 @@ def downloaded(name, artifact, target_dir='/tmp', target_file=None, use_literal_
            'changes': {},
            'comment': ''}
 
-    if 'test' in __opts__ and __opts__ ['test'] is True:
+    if 'test' in __opts__ and __opts__['test'] is True:
         fetch_result = {}
         fetch_result['status'] = True
         fetch_result['comment'] = 'Artifact would be downloaded from URL: {0}'.format(artifact['artifactory_url'])

--- a/salt/states/artifactory.py
+++ b/salt/states/artifactory.py
@@ -84,12 +84,18 @@ def downloaded(name, artifact, target_dir='/tmp', target_file=None, use_literal_
            'changes': {},
            'comment': ''}
 
-    try:
-        fetch_result = __fetch_from_artifactory(artifact, target_dir, target_file, use_literal_group_id)
-    except Exception as exc:
-        ret['result'] = False
-        ret['comment'] = six.text_type(exc)
-        return ret
+    if 'test' in __opts__ and __opts__ ['test'] is True:
+        fetch_result = {}
+        fetch_result['status'] = True
+        fetch_result['comment'] = 'Artifact would be downloaded from URL: {0}'.format(artifact['artifactory_url'])
+        fetch_result['changes'] = {}
+    else:
+        try:
+            fetch_result = __fetch_from_artifactory(artifact, target_dir, target_file, use_literal_group_id)
+        except Exception as exc:
+            ret['result'] = False
+            ret['comment'] = six.text_type(exc)
+            return ret
 
     log.debug('fetch_result = %s', fetch_result)
 

--- a/tests/unit/states/test_artifactory.py
+++ b/tests/unit/states/test_artifactory.py
@@ -55,3 +55,34 @@ class ArtifactoryTestCase(TestCase, LoaderModuleMockMixin):
             ret = artifactory.downloaded(name, artifact)
             self.assertEqual(ret['result'], False)
             self.assertEqual(ret['comment'], 'error')
+
+    # 'downloaded test=True' function tests: 1
+
+    def test_downloaded_test_true(self):
+        '''
+        Test to ensures that the artifact from artifactory exists at
+        given location.
+        '''
+        name = 'jboss'
+        arti_url = 'http://artifactory.intranet.example.com/artifactory'
+        artifact = {'artifactory_url': arti_url, 'artifact_id': 'module',
+                    'repository': 'libs-release-local', 'packaging': 'jar',
+                    'group_id': 'com.company.module', 'classifier': 'sources',
+                    'version': '1.0'}
+
+        ret = {'name': name,
+               'result': True,
+               'changes': {},
+               'comment': 'Artifact would be downloaded from URL: http://artifactory.intranet.example.com/artifactory'}
+
+        mck = MagicMock(return_value={'status': False, 'changes': {},
+                                      'comment': ''})
+        with patch.dict(artifactory.__salt__, {'artifactory.get_release': mck}):
+            with patch.dict(artifactory.__opts__, {'test': True}):
+                self.assertDictEqual(artifactory.downloaded(name, artifact), ret)
+
+        with patch.object(artifactory, '__fetch_from_artifactory',
+                          MagicMock(side_effect=Exception('error'))):
+            ret = artifactory.downloaded(name, artifact)
+            self.assertEqual(ret['result'], False)
+            self.assertEqual(ret['comment'], 'error')


### PR DESCRIPTION
### What does this PR do?
Adding test=True to artifactory.download.

### What issues does this PR fix or reference?
#50155 #50558

### Previous Behavior
test=True was previously ignored

### New Behavior
If test=True then we don't download the artifact but return a message of what would be downloaded.

### Tests written?
Yes

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
