### PR TITLE
CacheDisk enhancements and bugfixes

### DIFF
--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -339,8 +339,8 @@ class PillarCache(object):
             fresh_pillar = self.fetch_pillar()
             self.cache[self.minion_id] = {self.pillarenv: fresh_pillar}
             log.debug('Pillar cache miss for minion %s', self.minion_id)
-            log.debug('Current pillar cache: %s', self.cache._dict)  # FIXME hack!
             return fresh_pillar
+            log.debug('Current pillar cache: %s', self.cache[self.minion_id])
 
 
 class Pillar(object):

--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -331,6 +331,7 @@ class PillarCache(object):
                 # We found the minion but not the env. Store it.
                 fresh_pillar = self.fetch_pillar()
                 self.cache[self.minion_id][self.pillarenv] = fresh_pillar
+                self.cache.store()
                 log.debug('Pillar cache miss for pillarenv %s for minion %s', self.pillarenv, self.minion_id)
                 return fresh_pillar
         else:

--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -326,21 +326,21 @@ class PillarCache(object):
             if self.pillarenv in self.cache[self.minion_id]:
                 # We have a cache hit! Send it back.
                 log.debug('Pillar cache hit for minion %s and pillarenv %s', self.minion_id, self.pillarenv)
-                return self.cache[self.minion_id][self.pillarenv]
+                pillar_data = self.cache[self.minion_id][self.pillarenv]
             else:
                 # We found the minion but not the env. Store it.
-                fresh_pillar = self.fetch_pillar()
-                self.cache[self.minion_id][self.pillarenv] = fresh_pillar
+                pillar_data = self.fetch_pillar()
+                self.cache[self.minion_id][self.pillarenv] = pillar_data
                 self.cache.store()
                 log.debug('Pillar cache miss for pillarenv %s for minion %s', self.pillarenv, self.minion_id)
-                return fresh_pillar
         else:
             # We haven't seen this minion yet in the cache. Store it.
-            fresh_pillar = self.fetch_pillar()
-            self.cache[self.minion_id] = {self.pillarenv: fresh_pillar}
-            log.debug('Pillar cache miss for minion %s', self.minion_id)
-            return fresh_pillar
+            pillar_data = self.fetch_pillar()
+            self.cache[self.minion_id] = {self.pillarenv: pillar_data}
+            log.debug('Pillar cache has been added for minion %s', self.minion_id)
             log.debug('Current pillar cache: %s', self.cache[self.minion_id])
+
+        return pillar_data
 
 
 class Pillar(object):

--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -310,6 +310,13 @@ class PillarCache(object):
         return fresh_pillar.compile_pillar()
 
     def compile_pillar(self, *args, **kwargs):  # Will likely just be pillar_dirs
+        '''
+        Compile pillar and set it to the cache, if not found.
+
+        :param args:
+        :param kwargs:
+        :return:
+        '''
         log.debug('Scanning pillar cache for information about minion %s and pillarenv %s', self.minion_id, self.pillarenv)
         log.debug('Scanning cache: %s', self.cache._dict)
         # Check the cache!

--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -318,7 +318,8 @@ class PillarCache(object):
         :return:
         '''
         log.debug('Scanning pillar cache for information about minion %s and pillarenv %s', self.minion_id, self.pillarenv)
-        log.debug('Scanning cache: %s', self.cache._dict)
+        log.debug('Scanning cache for minion %s: %s', self.minion_id, self.cache[self.minion_id] or '*empty*')
+
         # Check the cache!
         if self.minion_id in self.cache:  # Keyed by minion_id
             # TODO Compare grains, etc?

--- a/salt/utils/cache.py
+++ b/salt/utils/cache.py
@@ -43,7 +43,15 @@ class CacheFactory(object):
             log.error('CacheFactory received unrecognized cache type')
 
 
-class CacheDict(dict):
+class CacheAPI(dict):
+    def store(self):
+        '''
+        Store data in the cache persistence.
+        :return:
+        '''
+
+
+class CacheDict(CacheAPI):
     '''
     Subclass of dict that will lazily delete items past ttl
     '''

--- a/salt/utils/cache.py
+++ b/salt/utils/cache.py
@@ -115,6 +115,13 @@ class CacheDisk(CacheDict):
         self._enforce_ttl_key(key)
         return self._dict.__contains__(key)
 
+    def __repr__(self):
+        '''
+        Represent CacheDisk.
+        :return:
+        '''
+        return '<{name} of {length} entries at {memaddr}>'.format(
+            name=self.__class__.__name__, length=len(self), memaddr=hex(id(self)))
     def __getitem__(self, key):
         '''
         Check if the key is ttld out, then do the get

--- a/salt/utils/cache.py
+++ b/salt/utils/cache.py
@@ -43,6 +43,9 @@ class CacheFactory(object):
 
 
 class CacheAPI(dict):
+    '''
+    Stub to export any cache implementation API
+    '''
     def store(self):
         '''
         Store data in the cache persistence.

--- a/salt/utils/cache.py
+++ b/salt/utils/cache.py
@@ -54,8 +54,8 @@ class CacheDict(CacheAPI):
     '''
     Subclass of dict that will lazily delete items past ttl
     '''
-    def __init__(self, ttl, *args, **kwargs):
-        dict.__init__(self, *args, **kwargs)
+    def __init__(self, ttl, *args, **kwargs):  # pylint: disable=W0231
+        dict.__init__(self, *args, **kwargs)   # pylint: disable=W0233
         self._ttl = ttl
         self._key_cache_time = {}
 

--- a/salt/utils/cache.py
+++ b/salt/utils/cache.py
@@ -122,6 +122,13 @@ class CacheDisk(CacheDict):
         '''
         return '<{name} of {length} entries at {memaddr}>'.format(
             name=self.__class__.__name__, length=len(self), memaddr=hex(id(self)))
+
+    def __str__(self):
+        '''
+        String version of this object.
+        :return:
+        '''
+        return self.__repr__()
     def __getitem__(self, key):
         '''
         Check if the key is ttld out, then do the get

--- a/salt/utils/cache.py
+++ b/salt/utils/cache.py
@@ -192,14 +192,16 @@ class CacheDisk(CacheDict):
         '''
         if not HAS_MSGPACK:
             return
-        # TODO Add check into preflight to ensure dir exists
         # TODO Dir hashing?
-        with salt.utils.files.fopen(self._path, 'wb+') as fp_:
-            cache = {
-                "CacheDisk_data": self._dict,
-                "CacheDisk_cachetime": self._key_cache_time
-            }
-            msgpack.dump(cache, fp_, use_bin_type=True)
+        try:
+            with salt.utils.files.fopen(self._path, 'wb+') as fp_:
+                cache = {
+                    "CacheDisk_data": self._dict,
+                    "CacheDisk_cachetime": self._key_cache_time
+                }
+                msgpack.dump(cache, fp_, use_bin_type=True)
+        except (IOError, OSError) as err:
+            log.error('Error storing cache data to the disk: %s', err)
 
 
 class CacheCli(object):

--- a/salt/utils/cache.py
+++ b/salt/utils/cache.py
@@ -121,7 +121,7 @@ class CacheDisk(CacheDict):
         self._key_cache_time[key] = time.time()
         self._dict.__setitem__(key, val)
         # Do the same as the parent but also persist
-        self._write()
+        self.store()
 
     def __delitem__(self, key):
         '''
@@ -130,7 +130,7 @@ class CacheDisk(CacheDict):
         del self._key_cache_time[key]
         self._dict.__delitem__(key)
         # Do the same as the parent but also persist
-        self._write()
+        self.store()
 
     def _read(self):
         '''
@@ -151,7 +151,7 @@ class CacheDisk(CacheDict):
         if log.isEnabledFor(logging.DEBUG):
             log.debug('Disk cache retrieved: %s', cache)
 
-    def _write(self):
+    def store(self):
         '''
         Write content of the entire cache to disk
         '''

--- a/salt/utils/cache.py
+++ b/salt/utils/cache.py
@@ -112,7 +112,11 @@ class CacheDisk(CacheDict):
         Check if the key is ttld out, then do the get
         '''
         self._enforce_ttl_key(key)
-        return self._dict.__getitem__(key)
+        item = None
+        if key in self._dict:
+            item = self._dict.__getitem__(key)
+
+        return item
 
     def __setitem__(self, key, val):
         '''

--- a/salt/utils/cache.py
+++ b/salt/utils/cache.py
@@ -153,7 +153,7 @@ class CacheDisk(CacheDict):
 
     def _write(self):
         '''
-        Write out to disk
+        Write content of the entire cache to disk
         '''
         if not HAS_MSGPACK:
             return

--- a/salt/utils/cache.py
+++ b/salt/utils/cache.py
@@ -129,6 +129,15 @@ class CacheDisk(CacheDict):
         :return:
         '''
         return self.__repr__()
+
+    def __len__(self):
+        '''
+        Length of the cache storage.
+
+        :return:
+        '''
+        return len(self._dict)
+
     def __getitem__(self, key):
         '''
         Check if the key is ttld out, then do the get

--- a/tests/unit/utils/test_cache.py
+++ b/tests/unit/utils/test_cache.py
@@ -406,12 +406,12 @@ class CacheDiskTestCase(TestCase):
             msg, arg = logger.error.call_args[0]
             assert msg % arg == 'Error storing cache data to the disk: Boredom in the kernel'
 
-    def test_everything(self):
+    def test_persistence_no_mocking(self):
         '''
         Make sure you can instantiate, add, update, remove, expire
         '''
+        tmpdir = tempfile.mkdtemp()
         try:
-            tmpdir = tempfile.mkdtemp()
             path = os.path.join(tmpdir, 'CacheDisk_test')
 
             # test instantiation
@@ -436,6 +436,5 @@ class CacheDiskTestCase(TestCase):
             time.sleep(0.2)
             self.assertNotIn('foo', cd)
             self.assertNotIn('foo', cd2)
-
         finally:
             shutil.rmtree(tmpdir, ignore_errors=True)

--- a/tests/unit/utils/test_cache.py
+++ b/tests/unit/utils/test_cache.py
@@ -306,6 +306,23 @@ class CacheDiskTestCase(TestCase):
             assert 'banana' in args
             assert msg % 'Redundant ACLs' == 'Disk cache retrieved: Redundant ACLs'
 
+    @patch('salt.utils.cache.msgpack', True)
+    @patch('salt.utils.files.fopen', MagicMock())
+    def test_store(self):
+        '''
+        Test storing is not happening if no msgpack installed.
+        :return:
+        '''
+        logger = MagicMock()
+        logger.isEnabledFor = MagicMock(return_value=True)
+        with patch('salt.utils.cache.log', logger):
+            c = cache.CacheDisk(0, '/dev/nowhere')
+            with patch('salt.utils.cache.msgpack', None):
+                c.store()
+                assert logger.error.call_count == 1
+                assert len(logger.error.call_args[0]) == 1
+                assert logger.error.call_args[0][0] == 'Cache cannot be stored on disk: msgpack is missing'
+
     def test_everything(self):
         '''
         Make sure you can instantiate, add, update, remove, expire

--- a/tests/unit/utils/test_cache.py
+++ b/tests/unit/utils/test_cache.py
@@ -236,6 +236,25 @@ class CacheDiskTestCase(TestCase):
         Test _read() support old format of the cache.
         :return:
         '''
+        logger = MagicMock()
+        with patch('salt.utils.cache.log', logger):
+            c = cache.CacheDisk(0, '/dev/nowhere')
+            assert 'banana' in c
+            assert 'status' in c['banana']
+            assert c['banana']['status'] == 'rotten'
+            assert c['banana'] == c._dict['banana']
+            assert 'banana' in c._key_cache_time
+            assert c._key_cache_time['banana'] == 42
+
+    @patch('os.path.exists', MagicMock(return_value=True))
+    @patch('os.path.getmtime', MagicMock(return_value=42))
+    @patch('salt.utils.files.fopen', MagicMock())
+    @patch('salt.utils.cache.msgpack', MagicMock())
+    @patch('salt.utils.data.decode', MagicMock(
+        return_value={'CacheDisk_cachetime': {'banana': 42}, 'CacheDisk_data': {'banana': {'status': 'rotten'}}}))
+    def test_read_new_format_support(self):
+        '''
+        Test _read() supports new format of the cache.
         :return:
         '''
         logger = MagicMock()

--- a/tests/unit/utils/test_cache.py
+++ b/tests/unit/utils/test_cache.py
@@ -210,6 +210,22 @@ class CacheDiskTestCase(TestCase):
             assert msg % (pth, exc) == ('Error while reading disk cache from /solar/interference: '
                                         'Radial telemetry infiltration')
 
+    @patch('os.path.exists', MagicMock(return_value=True))
+    @patch('salt.utils.files.fopen', MagicMock(side_effect=OSError("The keyboard isn't plugged in")))
+    def test_read_oserror_handling(self):
+        '''
+        Test _read() is handling OSError.
+        :return:
+        '''
+        logger = MagicMock()
+        with patch('salt.utils.cache.log', logger):
+            cache.CacheDisk(0, '/dev/nowhere')
+            assert logger.error.call_count == 1
+            assert len(logger.error.call_args[0]) == 3
+            msg, pth, exc = logger.error.call_args[0]
+            assert msg % (pth, exc) == ('Error while reading disk cache from /dev/nowhere: '
+                                        "The keyboard isn't plugged in")
+
     def test_everything(self):
         '''
         Make sure you can instantiate, add, update, remove, expire

--- a/tests/unit/utils/test_cache.py
+++ b/tests/unit/utils/test_cache.py
@@ -194,6 +194,22 @@ class CacheDiskTestCase(TestCase):
             msg, arg = logger.debug.call_args[0]
             assert msg % arg == 'Cache path does not exist for reading: /solar/interference'
 
+    @patch('os.path.exists', MagicMock(return_value=True))
+    @patch('salt.utils.files.fopen', MagicMock(side_effect=IOError('Radial telemetry infiltration')))
+    def test_read_ioerror_handling(self):
+        '''
+        Test _read() is handling IOError.
+        :return:
+        '''
+        logger = MagicMock()
+        with patch('salt.utils.cache.log', logger):
+            cache.CacheDisk(0, '/solar/interference')
+            assert logger.error.call_count == 1
+            assert len(logger.error.call_args[0]) == 3
+            msg, pth, exc = logger.error.call_args[0]
+            assert msg % (pth, exc) == ('Error while reading disk cache from /solar/interference: '
+                                        'Radial telemetry infiltration')
+
     def test_everything(self):
         '''
         Make sure you can instantiate, add, update, remove, expire

--- a/tests/unit/utils/test_cache.py
+++ b/tests/unit/utils/test_cache.py
@@ -322,6 +322,21 @@ class CacheDiskTestCase(TestCase):
                 assert len(logger.error.call_args[0]) == 1
                 assert logger.error.call_args[0][0] == 'Cache cannot be stored on disk: msgpack is missing'
 
+    @patch('salt.utils.files.fopen', MagicMock(side_effect=OSError('Your processor does not develop enough heat.')))
+    def test_store_target_is_not_writable(self):
+        '''
+        Test store() function cannot write target properly.
+        :return:
+        '''
+        logger = MagicMock()
+        with patch('salt.utils.cache.log', logger):
+            c = cache.CacheDisk(0, '/dev/nowhere')
+            c.store()
+            assert logger.error.call_count == 1
+            assert len(logger.error.call_args[0]) == 2
+            msg, args = logger.error.call_args[0]
+            assert msg % args == 'Error storing cache data to the disk: Your processor does not develop enough heat.'
+
     def test_everything(self):
         '''
         Make sure you can instantiate, add, update, remove, expire

--- a/tests/unit/utils/test_cache.py
+++ b/tests/unit/utils/test_cache.py
@@ -15,7 +15,7 @@ import shutil
 
 # Import Salt Testing libs
 from tests.support.unit import TestCase, skipIf
-from tests.support.mock import NO_MOCK, NO_MOCK_REASON
+from tests.support.mock import patch, MagicMock, NO_MOCK, NO_MOCK_REASON
 
 # Import salt libs
 import salt.config
@@ -164,6 +164,20 @@ class ContextCacheTest(TestCase):
 
 
 class CacheDiskTestCase(TestCase):
+    '''
+    DiskCache test case.
+    '''
+    @patch('salt.utils.cache.msgpack', None)
+    def test_no_msgpack(self):
+        '''
+        Test msgpack is not installed.
+        :return:
+        '''
+        logger = MagicMock()
+        with patch('salt.utils.cache.log', logger):
+            cache.CacheDisk(0, '/tmp')
+            assert logger.error.call_count == 1
+            assert logger.error.call_args[0][0] == 'Cache cannot be read from the disk: msgpack is missing'
 
     def test_everything(self):
         '''

--- a/tests/unit/utils/test_cache.py
+++ b/tests/unit/utils/test_cache.py
@@ -308,13 +308,12 @@ class CacheDiskTestCase(TestCase):
 
     @patch('salt.utils.cache.msgpack', True)
     @patch('salt.utils.files.fopen', MagicMock())
-    def test_store(self):
+    def test_store_msgpack_missing(self):
         '''
         Test storing is not happening if no msgpack installed.
         :return:
         '''
         logger = MagicMock()
-        logger.isEnabledFor = MagicMock(return_value=True)
         with patch('salt.utils.cache.log', logger):
             c = cache.CacheDisk(0, '/dev/nowhere')
             with patch('salt.utils.cache.msgpack', None):

--- a/tests/unit/utils/test_cache.py
+++ b/tests/unit/utils/test_cache.py
@@ -179,6 +179,21 @@ class CacheDiskTestCase(TestCase):
             assert logger.error.call_count == 1
             assert logger.error.call_args[0][0] == 'Cache cannot be read from the disk: msgpack is missing'
 
+    @patch('os.path.exists', MagicMock(return_value=False))
+    def test_read_no_path(self):
+        '''
+        Test _read() is bailing out if no path [yet] exists.
+        :return:
+        '''
+        logger = MagicMock()
+        with patch('salt.utils.cache.log', logger):
+            cache.CacheDisk(0, '/solar/interference')
+            assert logger.error.call_count == 0
+            assert logger.debug.call_count == 1
+            assert len(logger.debug.call_args[0]) == 2
+            msg, arg = logger.debug.call_args[0]
+            assert msg % arg == 'Cache path does not exist for reading: /solar/interference'
+
     def test_everything(self):
         '''
         Make sure you can instantiate, add, update, remove, expire

--- a/tests/unit/utils/test_cache.py
+++ b/tests/unit/utils/test_cache.py
@@ -227,6 +227,26 @@ class CacheDiskTestCase(TestCase):
                                         "The keyboard isn't plugged in")
 
     @patch('os.path.exists', MagicMock(return_value=True))
+    @patch('os.path.getmtime', MagicMock(return_value=42))
+    @patch('salt.utils.files.fopen', MagicMock())
+    @patch('salt.utils.cache.msgpack', MagicMock())
+    @patch('salt.utils.data.decode', MagicMock(return_value={'banana': {'status': 'rotten'}}))
+    def test_read_old_format_support(self):
+        '''
+        Test _read() is handling OSError.
+        :return:
+        '''
+        logger = MagicMock()
+        with patch('salt.utils.cache.log', logger):
+            c = cache.CacheDisk(0, '/dev/nowhere')
+            assert 'banana' in c
+            assert 'status' in c['banana']
+            assert c['banana']['status'] == 'rotten'
+            assert c['banana'] == c._dict['banana']
+            assert 'banana' in c._key_cache_time
+            assert c._key_cache_time['banana'] == 42
+
+    @patch('os.path.exists', MagicMock(return_value=True))
     @patch('salt.utils.files.fopen', MagicMock())
     @patch('salt.utils.cache.msgpack', MagicMock())
     @patch('salt.utils.cache.id', MagicMock(return_value=66))

--- a/tests/unit/utils/test_cache.py
+++ b/tests/unit/utils/test_cache.py
@@ -233,7 +233,9 @@ class CacheDiskTestCase(TestCase):
     @patch('salt.utils.data.decode', MagicMock(return_value={'banana': {'status': 'rotten'}}))
     def test_read_old_format_support(self):
         '''
-        Test _read() is handling OSError.
+        Test _read() support old format of the cache.
+        :return:
+        '''
         :return:
         '''
         logger = MagicMock()

--- a/tests/unit/utils/test_cache.py
+++ b/tests/unit/utils/test_cache.py
@@ -240,7 +240,7 @@ class CacheDiskTestCase(TestCase):
         with patch('salt.utils.cache.log', logger):
             c = cache.CacheDisk(0, '/dev/nowhere')
             assert 'banana' in c
-            assert 'status' in c['banana']
+            assert 'status' in c['banana']  # pylint: disable=E1135
             assert c['banana']['status'] == 'rotten'
             assert c['banana'] == c._dict['banana']
             assert 'banana' in c._key_cache_time
@@ -261,7 +261,7 @@ class CacheDiskTestCase(TestCase):
         with patch('salt.utils.cache.log', logger):
             c = cache.CacheDisk(0, '/dev/nowhere')
             assert 'banana' in c
-            assert 'status' in c['banana']
+            assert 'status' in c['banana']  # pylint: disable=E1135
             assert c['banana']['status'] == 'rotten'
             assert c['banana'] == c._dict['banana']
             assert 'banana' in c._key_cache_time

--- a/tests/unit/utils/test_cache.py
+++ b/tests/unit/utils/test_cache.py
@@ -359,6 +359,18 @@ class CacheDiskTestCase(TestCase):
             assert stored_data['CacheDisk_data']['banana']['status'] == 'rotten'
             assert stored_data['CacheDisk_cachetime']['banana'] == 42
 
+    @patch('salt.utils.cache.msgpack', None)  # Just turn off reading
+    def test_getitem_no_keyerror(self):
+        '''
+        Test get non-existing item raises no keyerror.
+        :return:
+        '''
+        c = cache.CacheDisk(0, '/dev/nowhere')
+        assert c['backup_destination'] is None
+        with patch.object(c, 'store', MagicMock()):
+            c['backup_destination'] = '/dev/null'
+            assert c['backup_destination'] == '/dev/null'
+
     def test_everything(self):
         '''
         Make sure you can instantiate, add, update, remove, expire

--- a/tests/unit/utils/test_cache.py
+++ b/tests/unit/utils/test_cache.py
@@ -371,6 +371,21 @@ class CacheDiskTestCase(TestCase):
             c['backup_destination'] = '/dev/null'
             assert c['backup_destination'] == '/dev/null'
 
+    @patch('salt.utils.cache.msgpack', None)  # Just turn off reading
+    def test_add_remove_operations(self):
+        '''
+        Test dict operations set/delete on the cache object.
+        :return:
+        '''
+        c = cache.CacheDisk(0, '/dev/nowhere')
+        assert 'backup_destination' not in c
+        assert c['backup_destination'] is None
+        c['backup_destination'] = '/dev/null'
+        assert c['backup_destination'] == '/dev/null'
+        del c['backup_destination']
+        assert 'backup_destination' not in c
+        assert c['backup_destination'] is None
+
     def test_everything(self):
         '''
         Make sure you can instantiate, add, update, remove, expire

--- a/tests/unit/utils/test_cache.py
+++ b/tests/unit/utils/test_cache.py
@@ -226,6 +226,22 @@ class CacheDiskTestCase(TestCase):
             assert msg % (pth, exc) == ('Error while reading disk cache from /dev/nowhere: '
                                         "The keyboard isn't plugged in")
 
+    @patch('os.path.exists', MagicMock(return_value=True))
+    @patch('salt.utils.files.fopen', MagicMock())
+    @patch('salt.utils.cache.msgpack', MagicMock())
+    @patch('salt.utils.cache.id', MagicMock(return_value=66))
+    @patch('salt.utils.data.decode', MagicMock(return_value={'banana': {'status': 'rotten'}}))
+    def test_str_repr(self):
+        '''
+        Test __str__ and __repr__ content
+        :return:
+        '''
+        logger = MagicMock()
+        with patch('salt.utils.cache.log', logger):
+            c = cache.CacheDisk(0, '/dev/nowhere')
+            assert str(repr(c)) == str(c)
+            assert str(c) == '<CacheDisk of 1 entries at 0x42>'
+
     def test_everything(self):
         '''
         Make sure you can instantiate, add, update, remove, expire


### PR DESCRIPTION
### What does this PR do?

- Enhances API for all caches (currently CacheDict and CacheDisk)
- Provides `store` function that will trigger persistence manually (in case implementation has one)
- Adds better logging
- "Todoes" TODO hacks
- Guards against IO/OS crashes
- other minor improvements

### What issues does this PR fix or reference?

This all started here as @rongzeng54 spotted a bug, where CacheDisk is not storing pillar data, when its _content_ is changed: https://github.com/saltstack/salt/pull/50179

### New Behavior

- Mentioned bug is fixed
- No crashes on e.g. different permissions (happens when master was previously run as `root`, then as `salt`).
- Everything else should work as before

### Tests written?

- Refactored existing
- Added new