### PR TITLE
Thorium len_eq is not checking the list length

### DIFF
--- a/salt/thorium/check.py
+++ b/salt/thorium/check.py
@@ -465,7 +465,7 @@ def len_eq(name, value):
         ret['result'] = False
         ret['comment'] = 'Value {0} not in register'.format(name)
         return ret
-    if __reg__[name]['val'] == value:
+    if len(__reg__[name]['val']) == value:
         ret['result'] = True
     return ret
 


### PR DESCRIPTION
### What does this PR do?
Thorium `check` module `len_eq` actually is not comparing list `len`

### What issues does this PR fix or reference?
Added (missing I guess) list length check

### Previous Behavior
```
something:
  reg.list:
    - add: "some_field"
    - match: 'salt/custom/event'
  check.len_eq:
    - value: 2
debug_thor:
  runner.cmd:
  - func: event.send
  - arg:
    - thor/works
  - require:
      - check: something
```

Then send from terminal:
```
> salt-run event.send 'salt/custom/event' '{"some_field": "a"}'
> salt-run event.send 'salt/custom/event' '{"some_field": "b"}'
```
(Observe e.g. in rawfile_json events), no `thor/works` event will be fired

### New Behavior
`thor/works` fired in aforementioned example

### Tests written?
No


