### PR TITLE
Disable unused shorturls plugin (backport to 2017.7)

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -303,7 +303,7 @@ extensions = [
     'httpdomain',
     'youtube',
     #'saltautodoc', # Must be AFTER autodoc
-    'shorturls',
+    #'shorturls',
 ]
 
 try:

--- a/salt/pillar/nodegroups.py
+++ b/salt/pillar/nodegroups.py
@@ -1,8 +1,5 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-
 '''
-=================
 Nodegroups Pillar
 =================
 


### PR DESCRIPTION
It was causing build errors when SPHINXOPTS=-W is used.

This also removes an overline from one of the pillar modules, as it causes a warning on newer sphinx releases.