### PR TITLE
Merge Sphinx fixes from 2017.7 to 2018.3

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -303,7 +303,7 @@ extensions = [
     'httpdomain',
     'youtube',
     #'saltautodoc', # Must be AFTER autodoc
-    'shorturls',
+    #'shorturls',
 ]
 
 try:

--- a/salt/pillar/nodegroups.py
+++ b/salt/pillar/nodegroups.py
@@ -1,8 +1,5 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-
 '''
-=================
 Nodegroups Pillar
 =================
 


### PR DESCRIPTION
This disables a custom plugin that we aren't actually using, which was causing failures when we made the docs job start using `SPHINXOPTS=-W`, and also gets rid of an overline that causes a Sphinx warning in newer Sphinx releases.