### PR TITLE
Remove no-longer-existant test module from whitelist.txt

### DIFF
--- a/tests/whitelist.txt
+++ b/tests/whitelist.txt
@@ -36,7 +36,6 @@ integration.modules.test_localemod
 integration.modules.test_lxc
 integration.modules.test_mine
 integration.modules.test_mysql
-integration.modules.test_nacl
 integration.modules.test_network
 integration.modules.test_nilrt_ip
 integration.modules.test_pillar


### PR DESCRIPTION
This was converted to unit tests in #50528. Since there are no unit tests in the whitelist.txt, I've removed it rather than renaming.

CC: @twangboy