### PR TITLE
Fixed the supervisord.dead state idempotency

### DIFF
--- a/salt/states/supervisord.py
+++ b/salt/states/supervisord.py
@@ -338,6 +338,7 @@ def dead(name,
         else:
             # process name doesn't exist
             ret['comment'] = "Service {0} doesn't exist".format(name)
+            return ret
 
         if is_stopped is True:
             ret['comment'] = "Service {0} is not running".format(name)


### PR DESCRIPTION
### What does this PR do?
Added quick return in supervisord.dead state to enforce idempotency is the supervisord service is not exists.

### What issues does this PR fix or reference?
Fixes #50601

### Previous Behavior
supervisord.dead state wasn't idempotent in case of non-existed service.

### New Behavior
supervisord.dead state is idempotent in case of non-existed service.

### Tests written?
No

### Commits signed with GPG?
Yes