### PR TITLE
Avoid overwriting ini file if no changes present

### DIFF
--- a/salt/modules/ini_manage.py
+++ b/salt/modules/ini_manage.py
@@ -83,7 +83,8 @@ def set_option(file_name, sections=None, separator='='):
     changes = {}
     inifile = _Ini.get_ini_file(file_name, separator=separator)
     changes = inifile.update(sections)
-    inifile.flush()
+    if changes:
+        inifile.flush()
     return changes
 
 
@@ -142,7 +143,8 @@ def remove_option(file_name, section, option, separator='='):
         value = inifile.get(section, {}).pop(option, None)
     else:
         value = inifile.pop(option, None)
-    inifile.flush()
+    if value:
+        inifile.flush()
     return value
 
 


### PR DESCRIPTION
### What does this PR do?
At the request of @Ch3LL I have looked into https://github.com/saltstack/salt/issues/50536 to prevent additional whitespace being added unnecessarily. That issue is really two issues in one (the other being pkgrepo-related), and this is a partial fix to the `ini_manage` part of the issue.

### What issues does this PR fix or reference?
Currently `ini_manage.set_option` and `ini_manage.remove_option` rewrite the ini file even if no changes were made. At minimum, this has the effect of adjusting file timestamps which might trigger false positives in intrusion detection software such as AIDE. This may also cause whitespace to be reformatted unnecessarily on first execution.

### Previous Behavior
`ini_manage.set_option` and `ini_manage.remove_option` would always replace the ini file in question (but strangely `ini_manage.remove_section` does not).

### New Behavior
Only replace the ini file in question if requested changes were generated.

### Note
Any change will still cause everything to be written, including changes to the whitespace formatting. Addressing this would probably require re-working the `gen_ini()` method of the `_Section()` class to iterate over lines in the config file and reuse those original line strings when the results are the same where unnecessary whitespace is not considered. It might also be possible and cleaner to use Python's built-in configparser library. I'm a little surprised this execution module wasn't already using it.

Having said all that, I personally do like (for the most part) the way `ini_manage` reformats the whitespace consistently upon a change and would like the option to keep that behaviour should a complete solution to that issue be implemented.

### Tests written?
No new tests, but all related existing tests pass on my box.

### Commits signed with GPG?
Yes
