### PR TITLE
Avoid leaving an empty first line on ini edits

### DIFF
--- a/salt/modules/ini_manage.py
+++ b/salt/modules/ini_manage.py
@@ -449,7 +449,11 @@ class _Ini(_Section):
             with salt.utils.files.fopen(self.name, 'wb') as outfile:
                 ini_gen = self.gen_ini()
                 next(ini_gen)
-                outfile.writelines(salt.utils.data.encode(list(ini_gen)))
+                ini_gen_list = list(ini_gen)
+                # Avoid writing an initial line separator.
+                if len(ini_gen_list):
+                    ini_gen_list[0] = ini_gen_list[0].lstrip(os.linesep)
+                outfile.writelines(salt.utils.data.encode(ini_gen_list))
         except (OSError, IOError) as exc:
             raise CommandExecutionError(
                 "Unable to write file '{0}'. "


### PR DESCRIPTION
### What does this PR do?
This change prevents Salt creating an empty new line to the start of an ini file whenever it first makes an edit.

### What issues does this PR fix or reference?
This is related to issue https://github.com/saltstack/salt/issues/50536 and discovered when writing PR https://github.com/saltstack/salt/pull/50613.

### Previous Behavior
Currently Salt's `ini_manage` execution module writes sections typically like this:
`\n[section name]\n`

Since ini files typically lead with a section, this would cause the file to look like this:
```
$ cat somefile.ini

[section name]
some_option: 1
$
```

### New Behavior
The new behaviour is to avoid writing an initial empty line. eg.
```
$ cat somefile.ini
[section name]
some_option: 1
$
```

### Tests written?
No. Existing tests pass for me.

### Commits signed with GPG?
Yes