### PR TITLE
Fixes icinga2 certs path for newer versions 2.8+

### DIFF
--- a/salt/modules/icinga2.py
+++ b/salt/modules/icinga2.py
@@ -10,11 +10,11 @@ Module to provide icinga2 compatibility to salt.
 # Import python libs
 from __future__ import absolute_import, print_function, unicode_literals
 import logging
-import subprocess
 
 # Import Salt libs
 import salt.utils.path
 import salt.utils.platform
+from salt.utils.icinga2 import get_certs_path, execute
 
 log = logging.getLogger(__name__)
 
@@ -32,18 +32,6 @@ def __virtual__():
     return (False, 'Icinga2 not installed.')
 
 
-def _execute(cmd, ret_code=False):
-    process = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
-    if ret_code:
-        return process.wait()
-    output, error = process.communicate()
-    if output:
-        log.debug(output)
-        return output
-    log.debug(error)
-    return error
-
-
 def generate_ticket(domain):
     '''
     Generate and save an icinga2 ticket.
@@ -58,7 +46,7 @@ def generate_ticket(domain):
         salt '*' icinga2.generate_ticket domain.tld
 
     '''
-    result = _execute(["icinga2", "pki", "ticket", "--cn", domain])
+    result = execute(["icinga2", "pki", "ticket", "--cn", domain])
     return result
 
 
@@ -76,7 +64,7 @@ def generate_cert(domain):
         salt '*' icinga2.generate_cert domain.tld
 
     '''
-    result = _execute(["icinga2", "pki", "new-cert", "--cn", domain, "--key", "/etc/icinga2/pki/{0}.key".format(domain), "--cert", "/etc/icinga2/pki/{0}.crt".format(domain)], ret_code=True)
+    result = execute(["icinga2", "pki", "new-cert", "--cn", domain, "--key", "{0}{1}.key".format(get_certs_path(), domain), "--cert", "{0}{1}.crt".format(get_certs_path(), domain)], ret_code=True)
     return result
 
 
@@ -94,8 +82,8 @@ def save_cert(domain, master):
         salt '*' icinga2.save_cert domain.tld master.domain.tld
 
     '''
-    result = _execute(["icinga2", "pki", "save-cert", "--key", "/etc/icinga2/pki/{0}.key".format(domain), "--cert", "/etc/icinga2/pki/{0}.cert".format(domain), "--trustedcert",
-                       "/etc/icinga2/pki/trusted-master.crt", "--host", master], ret_code=True)
+    result = execute(["icinga2", "pki", "save-cert", "--key", "{0}{1}.key".format(get_certs_path(), domain), "--cert", "{0}{1}.cert".format(get_certs_path(), domain), "--trustedcert",
+                       "{0}trusted-master.crt".format(get_certs_path()), "--host", master], ret_code=True)
     return result
 
 
@@ -114,8 +102,8 @@ def request_cert(domain, master, ticket, port):
         salt '*' icinga2.request_cert domain.tld master.domain.tld TICKET_ID
 
     '''
-    result = _execute(["icinga2", "pki", "request", "--host", master, "--port", port, "--ticket", ticket, "--key", "/etc/icinga2/pki/{0}.key".format(domain), "--cert",
-                       "/etc/icinga2/pki/{0}.crt".format(domain), "--trustedcert", "/etc/icinga2/pki/trusted-master.crt", "--ca", "/etc/icinga2/pki/ca.crt"], ret_code=True)
+    result = execute(["icinga2", "pki", "request", "--host", master, "--port", port, "--ticket", ticket, "--key", "{0}{1}.key".format(get_certs_path(), domain), "--cert",
+                       "{0}{1}.crt".format(get_certs_path(), domain), "--trustedcert", "{0}trusted-master.crt".format{get_certs_path()), "--ca", "{0}ca.crt".format(get_certs_path())], ret_code=True)
     return result
 
 
@@ -134,6 +122,6 @@ def node_setup(domain, master, ticket):
         salt '*' icinga2.node_setup domain.tld master.domain.tld TICKET_ID
 
     '''
-    result = _execute(["icinga2", "node", "setup", "--ticket", ticket, "--endpoint", master, "--zone", domain, "--master_host", master, "--trustedcert", "/etc/icinga2/pki/trusted-master.crt"],
+    result = execute(["icinga2", "node", "setup", "--ticket", ticket, "--endpoint", master, "--zone", domain, "--master_host", master, "--trustedcert", "{0}trusted-master.crt".format(get_certs_path())],
                        ret_code=True)
     return result

--- a/salt/modules/icinga2.py
+++ b/salt/modules/icinga2.py
@@ -14,7 +14,7 @@ import logging
 # Import Salt libs
 import salt.utils.path
 import salt.utils.platform
-from salt.utils.icinga2 import get_certs_path, execute
+from salt.utils.icinga2 import get_certs_path
 
 log = logging.getLogger(__name__)
 
@@ -46,7 +46,7 @@ def generate_ticket(domain):
         salt '*' icinga2.generate_ticket domain.tld
 
     '''
-    result = execute(["icinga2", "pki", "ticket", "--cn", domain])
+    result = __salt__['cmd.run_all'](["icinga2", "pki", "ticket", "--cn", domain], python_shell=False)
     return result
 
 
@@ -64,7 +64,7 @@ def generate_cert(domain):
         salt '*' icinga2.generate_cert domain.tld
 
     '''
-    result = execute(["icinga2", "pki", "new-cert", "--cn", domain, "--key", "{0}{1}.key".format(get_certs_path(), domain), "--cert", "{0}{1}.crt".format(get_certs_path(), domain)], ret_code=True)
+    result = __salt__['cmd.run_all'](["icinga2", "pki", "new-cert", "--cn", domain, "--key", "{0}{1}.key".format(get_certs_path(), domain), "--cert", "{0}{1}.crt".format(get_certs_path(), domain)], python_shell=False)
     return result
 
 
@@ -82,8 +82,8 @@ def save_cert(domain, master):
         salt '*' icinga2.save_cert domain.tld master.domain.tld
 
     '''
-    result = execute(["icinga2", "pki", "save-cert", "--key", "{0}{1}.key".format(get_certs_path(), domain), "--cert", "{0}{1}.cert".format(get_certs_path(), domain), "--trustedcert",
-                       "{0}trusted-master.crt".format(get_certs_path()), "--host", master], ret_code=True)
+    result = __salt__['cmd.run_all'](["icinga2", "pki", "save-cert", "--key", "{0}{1}.key".format(get_certs_path(), domain), "--cert", "{0}{1}.cert".format(get_certs_path(), domain), "--trustedcert",
+                                      "{0}trusted-master.crt".format(get_certs_path()), "--host", master], python_shell=False)
     return result
 
 
@@ -102,8 +102,8 @@ def request_cert(domain, master, ticket, port):
         salt '*' icinga2.request_cert domain.tld master.domain.tld TICKET_ID
 
     '''
-    result = execute(["icinga2", "pki", "request", "--host", master, "--port", port, "--ticket", ticket, "--key", "{0}{1}.key".format(get_certs_path(), domain), "--cert",
-                       "{0}{1}.crt".format(get_certs_path(), domain), "--trustedcert", "{0}trusted-master.crt".format{get_certs_path()), "--ca", "{0}ca.crt".format(get_certs_path())], ret_code=True)
+    result = __salt__['cmd.run_all'](["icinga2", "pki", "request", "--host", master, "--port", port, "--ticket", ticket, "--key", "{0}{1}.key".format(get_certs_path(), domain), "--cert",
+                                      "{0}{1}.crt".format(get_certs_path(), domain), "--trustedcert", "{0}trusted-master.crt".format(get_certs_path()), "--ca", "{0}ca.crt".format(get_certs_path())], python_shell=False)
     return result
 
 
@@ -122,6 +122,6 @@ def node_setup(domain, master, ticket):
         salt '*' icinga2.node_setup domain.tld master.domain.tld TICKET_ID
 
     '''
-    result = execute(["icinga2", "node", "setup", "--ticket", ticket, "--endpoint", master, "--zone", domain, "--master_host", master, "--trustedcert", "{0}trusted-master.crt".format(get_certs_path())],
-                       ret_code=True)
+    result = __salt__['cmd.run_all'](["icinga2", "node", "setup", "--ticket", ticket, "--endpoint", master, "--zone", domain, "--master_host", master, "--trustedcert", "{0}trusted-master.crt".format(get_certs_path())],
+                                       python_shell=False)
     return result

--- a/salt/states/icinga2.py
+++ b/salt/states/icinga2.py
@@ -27,6 +27,7 @@ import os.path
 from salt.ext import six
 import salt.utils.files
 import salt.utils.stringutils
+from salt.utils.icinga2 import get_certs_path
 
 
 def __virtual__():
@@ -140,8 +141,8 @@ def generate_cert(name):
            'changes': {},
            'result': True,
            'comment': ''}
-    cert = "/etc/icinga2/pki/{0}.crt".format(name)
-    key = "/etc/icinga2/pki/{0}.key".format(name)
+    cert = "{0}{1}.crt".format(get_certs_path(), name)
+    key = "{0}{1}.key".format(get_certs_path(), name)
 
     # Checking if execution is needed.
     if os.path.isfile(cert) and os.path.isfile(key):
@@ -175,7 +176,7 @@ def save_cert(name, master):
            'changes': {},
            'result': True,
            'comment': ''}
-    cert = "/etc/icinga2/pki/trusted-master.crt"
+    cert = "{0}trusted-master.crt".format(get_certs_path())
 
     # Checking if execution is needed.
     if os.path.isfile(cert):
@@ -214,7 +215,7 @@ def request_cert(name, master, ticket, port="5665"):
            'changes': {},
            'result': True,
            'comment': ''}
-    cert = "/etc/icinga2/pki/ca.crt"
+    cert = "{0}ca.crt".format(get_certs_path())
 
     # Checking if execution is needed.
     if os.path.isfile(cert):
@@ -254,8 +255,8 @@ def node_setup(name, master, ticket):
            'changes': {},
            'result': True,
            'comment': ''}
-    cert = "/etc/icinga2/pki/{0}.crt.orig".format(name)
-    key = "/etc/icinga2/pki/{0}.key.orig".format(name)
+    cert = "{0}{1}.crt.orig".format(get_certs_path(), name)
+    key = "{0}{1}.key.orig".format(get_certs_path(), name)
 
     # Checking if execution is needed.
     if os.path.isfile(cert) and os.path.isfile(cert):

--- a/salt/states/icinga2.py
+++ b/salt/states/icinga2.py
@@ -104,8 +104,9 @@ def generate_ticket(name, output=None, grain=None, key=None, overwrite=True):
         return ret
 
     # Executing the command.
-    ticket = __salt__['icinga2.generate_ticket'](name).strip()
-    if ticket:
+    ticket_res = __salt__['icinga2.generate_ticket'](name)
+    ticket = ticket_res['stdout']
+    if not ticket_res['retcode']:
         ret['comment'] = six.text_type(ticket)
 
     if output == 'grain':
@@ -155,7 +156,7 @@ def generate_cert(name):
 
     # Executing the command.
     cert_save = __salt__['icinga2.generate_cert'](name)
-    if not cert_save:
+    if not cert_save['retcode']:
         ret['comment'] = "Certificate and key generated"
         ret['changes']['cert'] = "Executed. Certificate saved: {0}".format(cert)
         ret['changes']['key'] = "Executed. Key saved: {0}".format(key)
@@ -189,7 +190,7 @@ def save_cert(name, master):
 
     # Executing the command.
     cert_save = __salt__['icinga2.save_cert'](name, master)
-    if not cert_save:
+    if not cert_save['retcode']:
         ret['comment'] = "Certificate for icinga2 master saved"
         ret['changes']['cert'] = "Executed. Certificate saved: {0}".format(cert)
     return ret
@@ -228,12 +229,12 @@ def request_cert(name, master, ticket, port="5665"):
 
     # Executing the command.
     cert_request = __salt__['icinga2.request_cert'](name, master, ticket, port)
-    if not cert_request:
+    if not cert_request['retcode']:
         ret['comment'] = "Certificate request from icinga2 master executed"
         ret['changes']['cert'] = "Executed. Certificate requested: {0}".format(cert)
         return ret
 
-    ret['comment'] = "FAILED. Certificate requested failed with exit code: {0}".format(cert_request)
+    ret['comment'] = "FAILED. Certificate requested failed with output: {0}".format(cert_request['stdout'])
     ret['result'] = False
     return ret
 
@@ -269,11 +270,11 @@ def node_setup(name, master, ticket):
 
     # Executing the command.
     node_setup = __salt__['icinga2.node_setup'](name, master, ticket)
-    if not node_setup:
+    if not node_setup['retcode']:
         ret['comment'] = "Node setup executed."
         ret['changes']['cert'] = "Node setup finished successfully."
         return ret
 
-    ret['comment'] = "FAILED. Node setup failed with exit code: {0}".format(node_setup)
+    ret['comment'] = "FAILED. Node setup failed with outpu: {0}".format(node_setup['stdout'])
     ret['result'] = False
     return ret

--- a/salt/utils/icinga2.py
+++ b/salt/utils/icinga2.py
@@ -7,8 +7,8 @@ This module provides common functionality for icinga2 module and state.
 
 .. versionadded:: 2018.8.3
 '''
-
 # Import python libs
+from __future__ import absolute_import, print_function, unicode_literals
 import logging
 import re
 
@@ -20,10 +20,9 @@ log = logging.getLogger(__name__)
 
 def get_certs_path():
     icinga2_output = __salt__['cmd.run_all']([salt.utils.path.which('icinga2'), "--version"], python_shell=False)
-    version = re.search('r\d+\.\d+', icinga2_output['stdout']).group(0)
+    version = re.search(r'r\d+\.\d+', icinga2_output['stdout']).group(0)
     # Return new certs path for icinga2 >= 2.8
     if int(version.split('.')[1]) >= 8:
         return '/var/lib/icinga2/certs/'
     # Keep backwords compatibility with older icinga2
     return '/etc/icinga2/pki/'
-

--- a/salt/utils/icinga2.py
+++ b/salt/utils/icinga2.py
@@ -10,7 +10,6 @@ This module provides common functionality for icinga2 module and state.
 
 # Import python libs
 import logging
-import subprocess
 import re
 
 # Import Salt libs
@@ -19,21 +18,9 @@ import salt.utils.path
 log = logging.getLogger(__name__)
 
 
-def execute(cmd, ret_code=False):
-    process = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
-    if ret_code:
-        return process.wait()
-    output, error = process.communicate()
-    if output:
-        log.debug(output)
-        return output
-    log.debug(error)
-    return error
-
-
 def get_certs_path():
-    icinga2_output = execute([salt.utils.path.which('icinga2'), "--version"])
-    version = re.search('r\d+\.\d+', icinga2_output).group(0)
+    icinga2_output = __salt__['cmd.run_all']([salt.utils.path.which('icinga2'), "--version"], python_shell=False)
+    version = re.search('r\d+\.\d+', icinga2_output['stdout']).group(0)
     # Return new certs path for icinga2 >= 2.8
     if int(version.split('.')[1]) >= 8:
         return '/var/lib/icinga2/certs/'

--- a/salt/utils/icinga2.py
+++ b/salt/utils/icinga2.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+'''
+Icinga2 Common Utils
+=================
+
+This module provides common functionality for icinga2 module and state.
+
+.. versionadded:: 2018.8.3
+'''
+
+# Import python libs
+import logging
+import subprocess
+import re
+
+# Import Salt libs
+import salt.utils.path
+
+log = logging.getLogger(__name__)
+
+
+def execute(cmd, ret_code=False):
+    process = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
+    if ret_code:
+        return process.wait()
+    output, error = process.communicate()
+    if output:
+        log.debug(output)
+        return output
+    log.debug(error)
+    return error
+
+
+def get_certs_path():
+    icinga2_output = execute([salt.utils.path.which('icinga2'), "--version"])
+    version = re.search('r\d+\.\d+', icinga2_output).group(0)
+    # Return new certs path for icinga2 >= 2.8
+    if int(version.split('.')[1]) >= 8:
+        return '/var/lib/icinga2/certs/'
+    # Keep backwords compatibility with older icinga2
+    return '/etc/icinga2/pki/'
+


### PR DESCRIPTION
### What does this PR do?

Bug fixing.

### What issues does this PR fix or reference?

#45867

### Previous Behavior

Icinga2 module and state worked only with versions prior to 2.8 for new deployments.
It also worked for versions newer than 2.8 but if upgraded from older versions without following the official documentation.

### Tests written?

No

### Commits signed with GPG?

No

### Notes

My issues so far:
1. Documentation refers to old certs path and now the path is selected based on icinga2 version. How should the docs be written?
2. If the server was deployed with icinga2 prior to 2.8 and upgraded without following the documentation, this change will break compatibility. This scenario is a bit messy. If configuration files are not updated, certs path is kept like before but new certs will be deployed in new path. So icinga2 will fail to register new clients. Again this will happen only if the upgrade was done without following the documentation;
3. I moved some common parts to salt/utils/icinga2.py so this is a new file. This is not a big change but since it is a bug fix I am not sure if all my changes are acceptable.
4. I created this pull request for branch 2018.3.3 since this should be a bug fix, is it ok?

Tomorrow I will fully test all this changes on an older server following upgrade documentation.
