### PR TITLE
git_pillar: Allow root and mountpoint parameters together

### DIFF
--- a/salt/pillar/git_pillar.py
+++ b/salt/pillar/git_pillar.py
@@ -327,6 +327,8 @@ mountpoint to ``web/`` (and restart the ``salt-master`` daemon).
       :conf_master:`git_pillar_includes` is not disabled.
     - Content from mounted git_pillar repos can only be referenced by a top
       file in the same pillar environment.
+    - Salt versions prior to 2018.3.4 ignore the ``root`` parameter when
+      ``mountpoint`` is set.
 '''
 from __future__ import absolute_import, print_function, unicode_literals
 

--- a/salt/utils/gitfs.py
+++ b/salt/utils/gitfs.py
@@ -2988,6 +2988,7 @@ class GitPillar(GitBase):
         points at the correct path
         '''
         lcachelink = salt.utils.path.join(repo.linkdir, repo._mountpoint)
+        lcachedest = salt.utils.path.join(repo.cachedir, repo.root()).rstrip(os.sep)
         wipe_linkdir = False
         create_link = False
         try:
@@ -3021,11 +3022,11 @@ class GitPillar(GitBase):
                             )
                             wipe_linkdir = True
                         else:
-                            if ldest != repo.cachedir:
+                            if ldest != lcachedest:
                                 log.debug(
                                     'Destination of %s (%s) does not match '
                                     'the expected value (%s)',
-                                    lcachelink, ldest, repo.cachedir
+                                    lcachelink, ldest, lcachedest
                                 )
                                 # Since we know that the parent dirs of the
                                 # link are set up properly, all we need to do
@@ -3070,16 +3071,16 @@ class GitPillar(GitBase):
 
                 if create_link:
                     try:
-                        os.symlink(repo.cachedir, lcachelink)
+                        os.symlink(lcachedest, lcachelink)
                         log.debug(
                             'Successfully linked %s to cachedir %s',
-                            lcachelink, repo.cachedir
+                            lcachelink, lcachedest
                         )
                         return True
                     except OSError as exc:
                         log.error(
                             'Failed to create symlink to %s at path %s: %s',
-                            repo.cachedir, lcachelink, exc.__str__()
+                            lcachedest, lcachelink, exc.__str__()
                         )
                         return False
         except GitLockError:

--- a/tests/integration/pillar/test_git_pillar.py
+++ b/tests/integration/pillar/test_git_pillar.py
@@ -436,6 +436,30 @@ class GitPythonMixin(object):
             ''')
         self.assertEqual(ret, expected)
 
+    def test_root_and_mountpoint_parameters(self):
+        '''
+        Test root and mountpoint parameters
+        '''
+        expected = {
+            'from_subdir': True
+        }
+
+        ret = self.get_pillar('''\
+            file_ignore_regex: []
+            file_ignore_glob: []
+            git_pillar_provider: gitpython
+            cachedir: {cachedir}
+            extension_modules: {extmods}
+            ext_pillar:
+              - git:
+                - master {url}:
+                  - mountpoint: mounted
+                  - root: subdir
+                - top_mounted {url}:
+                  - env: base
+            ''')
+        self.assertEqual(ret, expected)
+
 
 @destructiveTest
 @skipIf(NO_MOCK, NO_MOCK_REASON)
@@ -1493,6 +1517,102 @@ class TestPygit2SSH(GitPillarSSHTestBase):
             ''')
         self.assertEqual(ret, expected)
 
+    @requires_system_grains
+    def test_root_and_mountpoint_parameters(self, grains):
+        '''
+        Test root and mountpoint parameters
+        '''
+        expected = {
+            'from_subdir': True
+        }
+
+        # Test with passphraseless key and global credential options
+        ret = self.get_pillar('''\
+            file_ignore_regex: []
+            file_ignore_glob: []
+            git_pillar_provider: pygit2
+            git_pillar_pubkey: {pubkey_nopass}
+            git_pillar_privkey: {privkey_nopass}
+            cachedir: {cachedir}
+            extension_modules: {extmods}
+            ext_pillar:
+              - git:
+                - master {url}:
+                  - mountpoint: mounted
+                  - root: subdir
+                - top_mounted {url}:
+                  - env: base
+            ''')
+        self.assertEqual(ret, expected)
+
+        # Test with passphraseless key and per-repo credential options
+        ret = self.get_pillar('''\
+            file_ignore_regex: []
+            file_ignore_glob: []
+            git_pillar_provider: pygit2
+            cachedir: {cachedir}
+            extension_modules: {extmods}
+            ext_pillar:
+              - git:
+                - master {url}:
+                  - mountpoint: mounted
+                  - root: subdir
+                  - pubkey: {pubkey_nopass}
+                  - privkey: {privkey_nopass}
+                - top_mounted {url}:
+                  - pubkey: {pubkey_nopass}
+                  - privkey: {privkey_nopass}
+                  - env: base
+            ''')
+        self.assertEqual(ret, expected)
+
+        if grains['os_family'] == 'Debian':
+            # passphrase-protected currently does not work here
+            return
+
+        # Test with passphrase-protected key and global credential options
+        ret = self.get_pillar('''\
+            file_ignore_regex: []
+            file_ignore_glob: []
+            git_pillar_provider: pygit2
+            git_pillar_pubkey: {pubkey_withpass}
+            git_pillar_privkey: {privkey_withpass}
+            git_pillar_passphrase: {passphrase}
+            cachedir: {cachedir}
+            extension_modules: {extmods}
+            ext_pillar:
+              - git:
+                - master {url}:
+                  - mountpoint: mounted
+                  - root: subdir
+                - top_mounted {url}:
+                  - env: base
+            ''')
+        self.assertEqual(ret, expected)
+
+        # Test with passphrase-protected key and per-repo credential options
+        ret = self.get_pillar('''\
+            file_ignore_regex: []
+            file_ignore_glob: []
+            git_pillar_provider: pygit2
+            cachedir: {cachedir}
+            extension_modules: {extmods}
+            ext_pillar:
+              - git:
+                - master {url}:
+                  - mountpoint: mounted
+                  - root: subdir
+                  - pubkey: {pubkey_withpass}
+                  - privkey: {privkey_withpass}
+                  - passphrase: {passphrase}
+                - top_mounted {url}:
+                  - pubkey: {pubkey_withpass}
+                  - privkey: {privkey_withpass}
+                  - passphrase: {passphrase}
+                  - env: base
+            ''')
+        self.assertEqual(ret, expected)
+
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
 @skipIf(_windows_or_mac(), 'minion is windows or mac')
@@ -1813,6 +1933,30 @@ class TestPygit2HTTP(GitPillarHTTPTestBase):
               - git:
                 - master {url}:
                   - mountpoint: mounted
+                - top_mounted {url}:
+                  - env: base
+            ''')
+        self.assertEqual(ret, expected)
+
+    def test_root_and_mountpoint_parameters(self):
+        '''
+        Test root and mountpoint parameters
+        '''
+        expected = {
+            'from_subdir': True
+        }
+
+        ret = self.get_pillar('''\
+            file_ignore_regex: []
+            file_ignore_glob: []
+            git_pillar_provider: pygit2
+            cachedir: {cachedir}
+            extension_modules: {extmods}
+            ext_pillar:
+              - git:
+                - master {url}:
+                  - mountpoint: mounted
+                  - root: subdir
                 - top_mounted {url}:
                   - env: base
             ''')
@@ -2360,3 +2504,30 @@ class TestPygit2AuthenticatedHTTP(GitPillarHTTPTestBase):
                         'nested_list': ['master'],
                         'nested_dict': {'master': True}}}
         )
+
+    def test_root_and_mountpoint_parameters(self):
+        '''
+        Test root and mountpoint parameters
+        '''
+        expected = {
+            'from_subdir': True
+        }
+
+        ret = self.get_pillar('''\
+            file_ignore_regex: []
+            file_ignore_glob: []
+            git_pillar_provider: pygit2
+            git_pillar_user: {user}
+            git_pillar_password: {password}
+            git_pillar_insecure_auth: True
+            cachedir: {cachedir}
+            extension_modules: {extmods}
+            ext_pillar:
+              - git:
+                - master {url}:
+                  - mountpoint: mounted
+                  - root: subdir
+                - top_mounted {url}:
+                  - env: base
+            ''')
+        self.assertEqual(ret, expected)


### PR DESCRIPTION
### What does this PR do?
It allows to specify both `mountpoint` and `root` parameters.

### What issues does this PR fix or reference?
Fixes: #50364

### Previous Behavior
Consider the following master config:
```yaml
ext_pillar:
  - git:
    - master https://mydomain.tld/top.git:
      - root: pillar
      - mountpoint: ''
    - master https://mydomain.tld/myapp1.git:
      - root: pillar/myapp1
      - mountpoint: myapp1
    - master https://mydomain.tld/myapp2.git:
      - root: pillar/myapp2
      - mountpoint: myapp2
```
The `root` parameter is ignored.

### New Behavior
The `root` parameter is properly applied.

### Tests written?

Yes

### Commits signed with GPG?

Yes