### PR TITLE
Better handle errors in entry points

### DIFF
--- a/salt/loader.py
+++ b/salt/loader.py
@@ -139,11 +139,11 @@ def static_loader(
 
 
 def _format_entrypoint_target(ep):
-    """
+    '''
     Makes a string describing the target of an EntryPoint object.
 
     Base strongly on EntryPoint.__str__().
-    """
+    '''
     s = ep.module_name
     if ep.attrs:
         s += ':' + '.'.join(ep.attrs)

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -160,9 +160,12 @@ def _module_dirs(
             ext_type_types.extend(opts[ext_type_dirs])
         if HAS_PKG_RESOURCES and ext_type_dirs:
             for entry_point in pkg_resources.iter_entry_points('salt.loader', ext_type_dirs):
-                loaded_entry_point = entry_point.load()
-                for path in loaded_entry_point():
-                    ext_type_types.append(path)
+                try:
+                    loaded_entry_point = entry_point.load()
+                    for path in loaded_entry_point():
+                        ext_type_types.append(path)
+                except Exception:
+                    log.exception("Error running entry point %r", entry_point)
 
     cli_module_dirs = []
     # The dirs can be any module dir, or a in-tree _{ext_type} dir

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -138,6 +138,18 @@ def static_loader(
     return ret
 
 
+def _format_entrypoint_target(ep):
+    """
+    Makes a string describing the target of an EntryPoint object.
+
+    Base strongly on EntryPoint.__str__().
+    """
+    s = ep.module_name
+    if ep.attrs:
+        s += ':' + '.'.join(ep.attrs)
+    return s
+
+
 def _module_dirs(
         opts,
         ext_type,
@@ -164,8 +176,9 @@ def _module_dirs(
                     loaded_entry_point = entry_point.load()
                     for path in loaded_entry_point():
                         ext_type_types.append(path)
-                except Exception:
-                    log.exception("Error running entry point %r", entry_point)
+                except Exception as exc:
+                    log.error("Error getting module directories from %s: %s", _format_entrypoint_target(entry_point), exc)
+                    log.debug("Full backtrace for module directories error", exc_info=True)
 
     cli_module_dirs = []
     # The dirs can be any module dir, or a in-tree _{ext_type} dir


### PR DESCRIPTION
### What does this PR do?

Fixes entry point loading, so that if it fails, the exception is logged instead of propagated to the larger system. 

### What issues does this PR fix or reference?

None.

### Previous Behavior
The minion would fail to start if there was any kind of problem with entry point loading.

### New Behavior
The exception is logged instead.

### Tests written?

No, and I'm not sure how or where.

### Commits signed with GPG?

Yes.

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
