### PR TITLE
fix typo for default publish_port

### DIFF
--- a/salt/transport/zeromq.py
+++ b/salt/transport/zeromq.py
@@ -439,7 +439,7 @@ class AsyncZeroMQPubChannel(salt.transport.mixins.auth.AESPubClientMixin, salt.t
             yield self.auth.authenticate()
 
         # if this is changed from the default, we assume it was intentional
-        if int(self.opts.get('publish_port', 4506)) != 4506:
+        if int(self.opts.get('publish_port', 4505)) != 4505:
             self.publish_port = self.opts.get('publish_port')
         # else take the relayed publish_port master reports
         else:


### PR DESCRIPTION
### What does this PR do?
fix typo for default publish_port in `zeromq.py`
### What issues does this PR fix or reference?
not match default value publish_port in config https://github.com/saltstack/salt/blob/develop/salt/config/__init__.py#L1508

### Tests written?

No

### Commits signed with GPG?

Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
