### PR TITLE
Check file_mode in file.directory and _check_directory

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -677,6 +677,7 @@ def _check_directory(name,
                      group=None,
                      recurse=False,
                      mode=None,
+                     file_mode=None,
                      clean=False,
                      require=False,
                      exclude_pat=None,
@@ -712,6 +713,7 @@ def _check_directory(name,
             if check_files:
                 for fname in files:
                     fchange = {}
+                    mode = file_mode
                     path = os.path.join(root, fname)
                     stats = __salt__['file.stats'](
                         path, None, follow_symlinks
@@ -720,6 +722,8 @@ def _check_directory(name,
                         fchange['user'] = user
                     if group is not None and group != stats.get('group'):
                         fchange['group'] = group
+                    if mode is not None and mode != stats.get('mode'):
+                        fchange['mode'] = mode
                     if fchange:
                         changes[path] = fchange
             if check_dirs:
@@ -3119,8 +3123,8 @@ def directory(name,
             win_perms_reset=win_perms_reset)
     else:
         presult, pcomment, pchanges = _check_directory(
-            name, user, group, recurse or [], dir_mode, clean, require,
-            exclude_pat, max_depth, follow_symlinks)
+            name, user, group, recurse or [], dir_mode, file_mode, clean,
+            require, exclude_pat, max_depth, follow_symlinks)
 
     if pchanges:
         ret['pchanges'].update(pchanges)


### PR DESCRIPTION
### What does this PR do?

It fixes a bug in salt.states.file.directory that caused the function to return prematurely without evaluating the mode of files in a directory to be recursively evaluated. This PR adds a check for the file_mode parameter in the _check_directory function used by salt.states.file.directory

### What issues does this PR fix or reference?
file.directory recurse not always changing perms saltstack/salt#49393 

### Previous Behavior
_check_directory does not evaluate the mode of files, only the user and group.

### New Behavior
_check_directory evaluates the user, group, and mode of files.

### Tests written?

No

### Commits signed with GPG?

Yes


Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
