### PR TITLE
[2017.7] fixes to gem state when using greater than or less than versions

### DIFF
--- a/salt/states/gem.py
+++ b/salt/states/gem.py
@@ -16,6 +16,9 @@ you can specify what ruby version and gemset to target.
 '''
 from __future__ import absolute_import
 
+import salt.utils
+
+import re
 import logging
 log = logging.getLogger(__name__)
 
@@ -84,10 +87,29 @@ def installed(name,          # pylint: disable=C0103
             'Use of argument ruby found, but neither rvm or rbenv is installed'
         )
     gems = __salt__['gem.list'](name, ruby, gem_bin=gem_bin, runas=user)
-    if name in gems and version is not None and str(version) in gems[name]:
-        ret['result'] = True
-        ret['comment'] = 'Gem is already installed.'
-        return ret
+    if name in gems and version is not None:
+        match = re.match(r'(>=|>|<|<=)', version)
+        if match:
+            # Grab the comparison
+            cmpr = match.group()
+
+            # Clear out 'default:' and any whitespace
+            installed_version = re.sub('default: ', '', gems[name][0]).strip()
+
+            # Clear out comparison from version and whitespace
+            desired_version = re.sub(cmpr, '', version).strip()
+
+            if salt.utils.compare_versions(installed_version,
+                                           cmpr,
+                                           desired_version):
+                ret['result'] = True
+                ret['comment'] = 'Installed Gem meets version requirements.'
+                return ret
+        else:
+            if str(version) in gems[name]:
+                ret['result'] = True
+                ret['comment'] = 'Gem is already installed.'
+                return ret
     elif name in gems and version is None:
         ret['result'] = True
         ret['comment'] = 'Gem is already installed.'

--- a/tests/unit/states/test_gem.py
+++ b/tests/unit/states/test_gem.py
@@ -47,6 +47,19 @@ class TestGemState(TestCase, LoaderModuleMockMixin):
                     ri=False, gem_bin=None
                 )
 
+    def test_installed_version(self):
+        gems = {'foo': ['1.0'], 'bar': ['2.0']}
+        gem_list = MagicMock(return_value=gems)
+        gem_install_succeeds = MagicMock(return_value=True)
+
+        with patch.dict(gem.__salt__, {'gem.list': gem_list}):
+            with patch.dict(gem.__salt__,
+                            {'gem.install': gem_install_succeeds}):
+                ret = gem.installed('foo', version='>= 1.0')
+                self.assertEqual(True, ret['result'])
+                self.assertEqual('Installed Gem meets version requirements.',
+                                 ret['comment'])
+
     def test_removed(self):
         gems = ['foo', 'bar']
         gem_list = MagicMock(return_value=gems)


### PR DESCRIPTION
### What does this PR do?
When using the gem installed state, when passing a version that includes greater than or less than symbols, ensure that the installed versions meets that requirement.

### What issues does this PR fix or reference?
#49954

### Previous Behavior
Greater than, less than, etc. symbols are basically ignored and Salt state will continue attempting to install the gem.

### New Behavior
Ensure the installed version is greater than or less than desired version if appropriate symbols are provided.

### Tests written?
Yes

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
