### PR TITLE
 [2018.3] Fix to logic for configuring returners

### DIFF
--- a/salt/returners/__init__.py
+++ b/salt/returners/__init__.py
@@ -137,7 +137,10 @@ def _fetch_option(cfg, ret_config, virtualname, attr_name):
     if not ret_config:
         # Using the default configuration key
         if isinstance(cfg, dict):
-            return c_cfg.get(attr_name, cfg.get(default_cfg_key))
+            if default_cfg_key in cfg:
+                return cfg[default_cfg_key]
+            else:
+                return c_cfg.get(attr_name)
         else:
             return c_cfg.get(attr_name, cfg(default_cfg_key))
 


### PR DESCRIPTION
### What does this PR do?
When pulling values out of the available configuration for returnerswe should always default to using keys for those returners, eg. mongo.user for the username.  Otherwise in certain situations, eg. when using salt-ssh we will end up with the wrong value for the user.

### What issues does this PR fix or reference?
#50406 

### Tests written?
Not yet.

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
