### PR TITLE
Adds 'keyspace' option for returner to make returner available to specify Cassandra keyspace.

### DIFF
--- a/tests/unit/returners/test_cassandra_cql_return.py
+++ b/tests/unit/returners/test_cassandra_cql_return.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+'''
+Cassandra cql returner test cases
+'''
+
+# Import Python libs
+from __future__ import absolute_import
+
+# Import Salt Testing libs
+from tests.support.unit import TestCase, skipIf
+from tests.support.mock import patch, NO_MOCK, NO_MOCK_REASON
+from tests.support.mixins import LoaderModuleMockMixin
+
+
+# Import salt libs
+import salt.returners.cassandra_cql_return as cassandra_cql
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class CassandraCqlReturnerTestCase(TestCase, LoaderModuleMockMixin):
+    '''
+    Test Cassandra Cql Returner
+    '''
+    def setup_loader_modules(self):
+        return {cassandra_cql: {}}
+
+    def test_get_keyspace(self):
+        '''
+        Test edge cases of _get_keyspace
+        '''
+        # Empty __opts__
+        with patch.dict(cassandra_cql.__opts__, {}):
+            self.assertEqual(cassandra_cql._get_keyspace(), 'salt')
+
+        # Cassandra option without keyspace
+        with patch.dict(cassandra_cql.__opts__, {'cassandra': None}):
+            self.assertEqual(cassandra_cql._get_keyspace(), 'salt')
+        with patch.dict(cassandra_cql.__opts__, {'cassandra': {}}):
+            self.assertEqual(cassandra_cql._get_keyspace(), 'salt')
+
+        # Cassandra option with keyspace
+        with patch.dict(cassandra_cql.__opts__, {'cassandra': {'keyspace': 'abcd'}}):
+            self.assertEqual(cassandra_cql._get_keyspace(), 'abcd')


### PR DESCRIPTION
### What does this PR do?

Adds 'keyspace' option for returner to make returner available to specify Cassandra keyspace.

### What issues does this PR fix or reference?

N/A

### Previous Behavior

Cassandra returner cannot be specified the keyspace.

### New Behavior

Cassandra returner can be specified which keyspace to use.

### Tests written?

Yes

### Commits signed with GPG?

Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.