### PR TITLE
zypper: demote log from error to warning

### DIFF
--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -960,7 +960,7 @@ def _get_configured_repos(root=None):
     if os.path.exists(repos):
         repos_cfg.read([repos + '/' + fname for fname in os.listdir(repos) if fname.endswith(".repo")])
     else:
-        log.error('Repositories not found in {}'.format(repos))
+        log.warning('Repositories not found in {}'.format(repos))
 
     return repos_cfg
 


### PR DESCRIPTION
### What does this PR do?

In _get_configured_repos if the directory where the repositories
are stored is not found, an log error is emitted.

Most of the times this is indeed an indication of an error, but is
not always the case. For example, when we are creating a chroot
environment we do not need to create this directory, as is generated
by zypper when a new repository is added.

This patch demote the error to a warning, as this directory will
be present eventually is most situations after the first call to
zypper.
