### PR TITLE
[2017.7] fixes to file.replace with search_only

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -5655,6 +5655,7 @@ def list_backups(path, limit=None):
         [files[x] for x in sorted(files, reverse=True)[:limit]]
     )))
 
+
 list_backup = salt.utils.alias_function(list_backups, 'list_backup')
 
 
@@ -5826,6 +5827,7 @@ def delete_backup(path, backup_id):
         ret['comment'] = 'Successfully removed {0}'.format(backup['Location'])
 
     return ret
+
 
 remove_backup = salt.utils.alias_function(delete_backup, 'remove_backup')
 

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -2096,6 +2096,8 @@ def replace(path,
                 # Just search; bail as early as a match is found
                 if re.search(cpattern, r_data):
                     return True  # `with` block handles file closure
+                else:
+                    return False
             else:
                 result, nrepl = re.subn(cpattern,
                                         repl.replace('\\', '\\\\') if backslash_literal else repl,

--- a/tests/unit/modules/test_file.py
+++ b/tests/unit/modules/test_file.py
@@ -198,6 +198,22 @@ class FileReplaceTestCase(TestCase, LoaderModuleMockMixin):
         '''
         filemod.replace(self.tfile.name, r'Etiam', 123)
 
+    def test_search_only_return_true(self):
+        ret = filemod.replace(self.tfile.name,
+                              r'Etiam', 'Salticus',
+                              search_only=True)
+
+        self.assertIsInstance(ret, bool)
+        self.assertEqual(ret, True)
+
+    def test_search_only_return_false(self):
+        ret = filemod.replace(self.tfile.name,
+                              r'Etian', 'Salticus',
+                              search_only=True)
+
+        self.assertIsInstance(ret, bool)
+        self.assertEqual(ret, False)
+
 
 class FileBlockReplaceTestCase(TestCase, LoaderModuleMockMixin):
     def setup_loader_modules(self):


### PR DESCRIPTION
### What does this PR do?
When using file.replace, with the search_only option, if the pattern does not exist in the file then we should return False.

### What issues does this PR fix or reference?
#49691

### Tests written?
Yes

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
