### PR TITLE
Reactor: remove thread pool for runner/wheel

### DIFF
--- a/salt/runners/reactor.py
+++ b/salt/runners/reactor.py
@@ -51,7 +51,7 @@ def list_(saltenv='base', test=None):
             opts=__opts__,
             listen=True)
 
-    master_key = salt.utils.master.get_master_key('root', __opts__) + 'a'
+    master_key = salt.utils.master.get_master_key('root', __opts__)
     sevent.fire_event({'key': master_key}, 'salt/reactors/manage/list')
 
     results = sevent.get_event(wait=30, tag='salt/reactors/manage/list-results')

--- a/salt/runners/reactor.py
+++ b/salt/runners/reactor.py
@@ -18,10 +18,13 @@ from __future__ import absolute_import, print_function, unicode_literals
 import logging
 
 # Import salt libs
+import salt.config
+import salt.utils.master
 import salt.utils.reactor
 import salt.syspaths
 import salt.utils.event
 import salt.utils.process
+import salt.transport
 from salt.ext.six import string_types
 
 log = logging.getLogger(__name__)
@@ -48,9 +51,11 @@ def list_(saltenv='base', test=None):
             opts=__opts__,
             listen=True)
 
-    __jid_event__.fire_event({}, 'salt/reactors/manage/list')
+    master_key = salt.utils.master.get_master_key('root', __opts__) + 'a'
+    sevent.fire_event({'key': master_key}, 'salt/reactors/manage/list')
 
     results = sevent.get_event(wait=30, tag='salt/reactors/manage/list-results')
+
     reactors = results['reactors']
     return reactors
 
@@ -75,9 +80,11 @@ def add(event, reactors, saltenv='base', test=None):
             opts=__opts__,
             listen=True)
 
-    __jid_event__.fire_event({'event': event,
-                              'reactors': reactors},
-                             'salt/reactors/manage/add')
+    master_key = salt.utils.master.get_master_key('root', __opts__)
+    sevent.fire_master({'event': event,
+                        'reactors': reactors,
+                        'key': master_key},
+                        'salt/reactors/manage/add')
 
     res = sevent.get_event(wait=30, tag='salt/reactors/manage/add-complete')
     return res['result']
@@ -100,7 +107,8 @@ def delete(event, saltenv='base', test=None):
             opts=__opts__,
             listen=True)
 
-    __jid_event__.fire_event({'event': event}, 'salt/reactors/manage/delete')
+    master_key = salt.utils.master.get_master_key('root', __opts__)
+    sevent.fire_event({'event': event, 'key': master_key}, 'salt/reactors/manage/delete')
 
     res = sevent.get_event(wait=30, tag='salt/reactors/manage/delete-complete')
     return res['result']

--- a/salt/utils/reactor.py
+++ b/salt/utils/reactor.py
@@ -267,6 +267,13 @@ class Reactor(salt.utils.process.SignalHandlingMultiprocessingProcess, salt.stat
             if data['data'].get('user') == self.wrap.event_user:
                 continue
 
+            # NOTE: these events must contain the masters key in order to be accepted
+            # see salt.runners.reactor for the requesting interface
+            if 'salt/reactors/manage' in data['tag']:
+                master_key = salt.utils.master.get_master_key('root', self.opts)
+                if data['data'].get('key') != master_key:
+                    log.error('received salt/reactors/manage event without matching master_key. discarding')
+                    continue
             if data['tag'].endswith('salt/reactors/manage/add'):
                 _data = data['data']
                 res = self.add_reactor(_data['event'], _data['reactors'])

--- a/salt/utils/reactor.py
+++ b/salt/utils/reactor.py
@@ -38,9 +38,9 @@ log = logging.getLogger(__name__)
 REACTOR_INTERNAL_KEYWORDS = frozenset([
     '__id__',
     '__sls__',
-    'name',
     'order',
     'fun',
+    'key',
     'state',
 ])
 
@@ -436,13 +436,11 @@ class ReactWrap(object):
                                 low['__id__'], low['state'], low['fun']
                             )
                             return
-
                         react_call = salt.utils.args.format_call(
                             react_fun,
                             low,
                             expected_extra_kws=REACTOR_INTERNAL_KEYWORDS
                         )
-
                 if 'arg' not in kwargs:
                     kwargs['arg'] = react_call.get('args', ())
                 if 'kwarg' not in kwargs:

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -807,13 +807,32 @@ class TestDaemon(object):
                 RUNTIME_VARS.TMP_PRODENV_STATE_TREE
             ]
         }
-        master_opts.setdefault('reactor', []).append(
-            {
-                'salt/minion/*/start': [
-                    os.path.join(FILES, 'reactor-sync-minion.sls')
-                ],
-            }
-        )
+        master_opts.setdefault('reactor', []).append({
+            'salt/minion/*/start': [
+                os.path.join(FILES, 'reactor-sync-minion.sls')
+            ],
+        })
+        master_opts['reactor'].append({
+            'salt/test/reactor/local': [
+                os.path.join(FILES, 'reactor-test-local.sls')
+            ],
+        })
+        master_opts['reactor'].append({
+            'salt/test/reactor/runner': [
+                os.path.join(FILES, 'reactor-test-runner.sls')
+            ],
+        })
+        master_opts['reactor'].append({
+            'salt/test/reactor/wheel': [
+                os.path.join(FILES, 'reactor-test-wheel.sls')
+            ],
+        })
+        master_opts['reactor'].append({
+            'salt/test/reactor/legacy': [
+                os.path.join(FILES, 'reactor-test-legacy.sls')
+            ],
+        })
+
         for opts_dict in (master_opts, syndic_master_opts):
             if 'ext_pillar' not in opts_dict:
                 opts_dict['ext_pillar'] = []

--- a/tests/integration/files/reactor-test-legacy.sls
+++ b/tests/integration/files/reactor-test-legacy.sls
@@ -1,0 +1,7 @@
+reactor-test:
+  runner.event.send:
+    - arg:
+      - test_reaction
+    - kwarg:
+        data:
+          test_reaction: True

--- a/tests/integration/files/reactor-test-local.sls
+++ b/tests/integration/files/reactor-test-local.sls
@@ -1,0 +1,7 @@
+reactor-test:
+  local.event.fire_master:
+    - tgt: 'minion'
+    - args:
+      - tag: test_reaction
+      - data:
+          test_reaction: True

--- a/tests/integration/files/reactor-test-runner.sls
+++ b/tests/integration/files/reactor-test-runner.sls
@@ -1,0 +1,6 @@
+reactor-test:
+  runner.event.send:
+    - args:
+      - tag: test_reaction
+      - data:
+          test_reaction: True

--- a/tests/integration/files/reactor-test-wheel.sls
+++ b/tests/integration/files/reactor-test-wheel.sls
@@ -1,0 +1,12 @@
+reactor-test:
+  wheel.key.gen_accept:
+    - args:
+      - id_: foobar
+
+# we just use this to signal the previous state fired
+wheel-ran:
+  runner.event.send:
+    - args:
+      - tag: test_reaction
+      - data:
+          test_reaction: True

--- a/tests/integration/reactor/test_reactor.py
+++ b/tests/integration/reactor/test_reactor.py
@@ -61,7 +61,6 @@ class ReactorTest(ShellTestCase, SaltMinionEventAssertsMixin):
 
         self.assertMinionEventReceived({'a': 'b'})
 
-
     @skipIf(salt.utils.platform.is_windows(), 'no sigalarm on windows')
     def test_reactor_local_reaction(self):
         '''
@@ -86,7 +85,6 @@ class ReactorTest(ShellTestCase, SaltMinionEventAssertsMixin):
                     break
         finally:
             signal.alarm(0)
-
 
     @skipIf(salt.utils.platform.is_windows(), 'no sigalarm on windows')
     def test_reactor_runner_reaction(self):

--- a/tests/integration/reactor/test_reactor.py
+++ b/tests/integration/reactor/test_reactor.py
@@ -11,18 +11,42 @@
 from __future__ import absolute_import
 
 # Import Salt testing libs
-from tests.support.case import ModuleCase
-from tests.support.helpers import flaky
+from tests.support.case import ShellTestCase
 from tests.support.mixins import SaltMinionEventAssertsMixin
+from tests.support.unit import skipIf
+from tests.support.helpers import flaky
 
 # Import Salt libs
 import salt.utils.event
+import salt.utils.reactor
+import signal
 
 
-class ReactorTest(ModuleCase, SaltMinionEventAssertsMixin):
+class TimeoutException(Exception):
+    pass
+
+
+class ReactorTest(ShellTestCase, SaltMinionEventAssertsMixin):
     '''
     Test Salt's reactor system
     '''
+    def setUp(self):
+        self.timeout = 30
+
+    def get_event(self, class_type='master'):
+        return salt.utils.event.get_event(
+            class_type,
+            sock_dir=self.master_opts['sock_dir'],
+            transport=self.master_opts['transport'],
+            keep_loop=True,
+            opts=self.master_opts)
+
+    def fire_event(self, tag, data):
+        event = self.get_event()
+        event.fire_event(tag, data)
+
+    def alarm_handler(self, signal, frame):
+        raise TimeoutException('Timeout of {0} seconds reached'.format(self.timeout))
 
     @flaky
     def test_ping_reaction(self):
@@ -36,3 +60,108 @@ class ReactorTest(ModuleCase, SaltMinionEventAssertsMixin):
         e.fire_event({'a': 'b'}, '/test_event')
 
         self.assertMinionEventReceived({'a': 'b'})
+
+
+    @skipIf(salt.utils.platform.is_windows(), 'no sigalarm on windows')
+    def test_reactor_local_reaction(self):
+        '''
+        Fire an event on the master and ensure
+        The reactor event responds with localclient
+        '''
+        signal.signal(signal.SIGALRM, self.alarm_handler)
+        signal.alarm(self.timeout)
+
+        master_event = self.get_event()
+        master_event.fire_event({'id': 'minion'}, 'salt/test/reactor/local')
+
+        try:
+            while True:
+                event = master_event.get_event(full=True)
+
+                if event is None:
+                    continue
+
+                if event.get('tag') == 'test_reaction':
+                    self.assertTrue(event['data']['data']['test_reaction'])
+                    break
+        finally:
+            signal.alarm(0)
+
+
+    @skipIf(salt.utils.platform.is_windows(), 'no sigalarm on windows')
+    def test_reactor_runner_reaction(self):
+        '''
+        Fire an event on the master and ensure
+        The reactor event responds with a runner client
+        '''
+        signal.signal(signal.SIGALRM, self.alarm_handler)
+        signal.alarm(self.timeout)
+
+        master_event = self.get_event()
+        master_event.fire_event({'id': 'minion'}, 'salt/test/reactor/runner')
+
+        try:
+            while True:
+                event = master_event.get_event(full=True)
+
+                if event is None:
+                    continue
+
+                if event.get('tag') == 'test_reaction':
+                    self.assertTrue(event['data']['test_reaction'])
+                    break
+        finally:
+            signal.alarm(0)
+
+    @skipIf(salt.utils.platform.is_windows(), 'no sigalarm on windows')
+    def test_reactor_wheel_reaction(self):
+        '''
+        Fire an event on the master and ensure
+        The reactor event responds with a wheel client
+        '''
+        signal.signal(signal.SIGALRM, self.alarm_handler)
+        signal.alarm(self.timeout)
+
+        master_event = self.get_event()
+        master_event.fire_event({'id': 'minion'}, 'salt/test/reactor/wheel')
+
+        try:
+            while True:
+                event = master_event.get_event(full=True)
+
+                if event is None:
+                    continue
+
+                if event.get('tag') == 'test_reaction':
+                    self.assertTrue(event['data']['test_reaction'])
+                    self.assertTrue('foobar' in self.run_key('--list=accepted'))
+                    break
+
+        finally:
+            signal.alarm(0)
+
+    @skipIf(salt.utils.platform.is_windows(), 'no sigalarm on windows')
+    def test_reactor_legacy_reaction(self):
+        '''
+        Fire an event on the master and ensure
+        The reactor event responds with a wheel client
+        '''
+        signal.signal(signal.SIGALRM, self.alarm_handler)
+        signal.alarm(self.timeout)
+
+        master_event = self.get_event()
+        master_event.fire_event({'id': 'minion'}, 'salt/test/reactor/legacy')
+
+        try:
+            while True:
+                event = master_event.get_event(full=True)
+
+                if event is None:
+                    continue
+
+                if event.get('tag') == 'test_reaction':
+                    self.assertTrue(event['data']['test_reaction'])
+                    break
+
+        finally:
+            signal.alarm(0)


### PR DESCRIPTION
### What does this PR do?
rather than execute inline in a separate pool, we can push these off to the master to handle like other work, so lets do that instead. This deprecates/removes the REACTOR_WORKER_HWM and REACTOR_WORKER_THREADS settings.

also included:
add root_key identity check for interacting with the reactor
since actions through the reactor/manage interface can be potentially  destructive, we use the root_key as a identifier to assert it originated  only from the runner as the root user as opposed to any event coming through the bus.

### What issues does this PR fix or reference?
- performance bottleneck in the reactor engine.
- unauthenticated interaction with the reactor management interface

### Tests written?
Yes

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
