### PR TITLE
Fix python3 x509

### DIFF
--- a/salt/states/x509.py
+++ b/salt/states/x509.py
@@ -164,6 +164,7 @@ import copy
 # Import Salt Libs
 import salt.exceptions
 import salt.utils.stringutils
+from salt.utils.locales import sdecode
 
 # Import 3rd-party libs
 from salt.ext import six
@@ -557,8 +558,8 @@ def certificate_managed(name,
     if (current_comp == new_comp and
             current_days_remaining > days_remaining and
             __salt__['x509.verify_signature'](name, new_issuer_public_key)):
-        certificate = __salt__['x509.get_pem_entry'](
-            name, pem_type='CERTIFICATE')
+        certificate = sdecode(__salt__['x509.get_pem_entry'](
+            name, pem_type='CERTIFICATE'))
     else:
         if rotate_private_key and not new_private_key:
             new_private_key = True
@@ -566,7 +567,7 @@ def certificate_managed(name,
                 text=True, bits=private_key_args['bits'], verbose=private_key_args['verbose'])
             kwargs['public_key'] = private_key
         new_certificate = True
-        certificate = __salt__['x509.create_certificate'](text=True, **kwargs)
+        certificate = sdecode(__salt__['x509.create_certificate'](text=True, **kwargs))
 
     file_args['contents'] = ''
     private_ret = {}


### PR DESCRIPTION
### What does this PR do?
Fix x509 usage with Python 3, not sure if it's the right way but working for me

```     Comment: An exception occurred in this state: Traceback (most recent call last):
                File "/usr/lib/python3.4/site-packages/salt/state.py", line 1913, in call
                  **cdata['kwargs'])
                File "/usr/lib/python3.4/site-packages/salt/loader.py", line 1898, in wrapper
                  return f(*args, **kwargs)
                File "/usr/lib/python3.4/site-packages/salt/states/x509.py", line 554, in certificate_managed
                  file_args['contents'] += certificate
              TypeError: Can't convert 'bytes' object to str implicitly
```

### What issues does this PR fix or reference?

My comment in #39608

### Tests written?

No

### Commits signed with GPG?

No

