### PR TITLE
add asynchronous to states.saltmod

### DIFF
--- a/salt/states/saltmod.py
+++ b/salt/states/saltmod.py
@@ -225,6 +225,15 @@ def state(name,
 
         .. versionadded:: 2017.7.0
 
+    asynchronous
+        Run the salt command but don't wait for a reply.
+
+        NOTE: This flag conflicts with subset and batch flags and cannot be
+        used at the same time.
+
+        .. versionadded:: neon
+
+
     Examples:
 
     Run a list of sls files via :py:func:`state.sls <salt.state.sls>` on target
@@ -287,6 +296,7 @@ def state(name,
     cmd_kw['tgt_type'] = tgt_type
     cmd_kw['ssh'] = ssh
     cmd_kw['expect_minions'] = expect_minions
+    cmd_kw['asynchronous'] = kwargs.pop('asynchronous', False)
     if highstate:
         fun = 'state.highstate'
     elif top:
@@ -348,6 +358,17 @@ def state(name,
             'out': tmp_ret.get('out', 'highstate') if
                 isinstance(tmp_ret, dict) else 'highstate'
         }}
+
+    if cmd_kw['asynchronous']:
+        state_ret['__jid__'] = cmd_ret.get('jid')
+        state_ret['changes'] = cmd_ret
+        if int(cmd_ret.get('jid', 0)) > 0:
+            state_ret['result'] = True
+            state_ret['comment'] = 'State submitted successfully.'
+        else:
+            state_ret['result'] = False
+            state_ret['comment'] = 'State failed to run.'
+        return state_ret
 
     try:
         state_ret['__jid__'] = cmd_ret[next(iter(cmd_ret))]['jid']
@@ -494,6 +515,11 @@ def function(
 
         .. versionadded:: 2017.7.0
 
+    asynchronous
+        Run the salt command but don't wait for a reply.
+
+        .. versionadded:: neon
+
     '''
     func_ret = {'name': name,
                 'changes': {},
@@ -518,6 +544,7 @@ def function(
     cmd_kw['ssh'] = ssh
     cmd_kw['expect_minions'] = expect_minions
     cmd_kw['_cmd_meta'] = True
+    cmd_kw['asynchronous'] = kwargs.pop('asynchronous', False)
 
     if ret_config:
         cmd_kw['ret_config'] = ret_config
@@ -537,6 +564,17 @@ def function(
     except Exception as exc:
         func_ret['result'] = False
         func_ret['comment'] = six.text_type(exc)
+        return func_ret
+
+    if cmd_kw['asynchronous']:
+        func_ret['__jid__'] = cmd_ret.get('jid')
+        func_ret['changes'] = cmd_ret
+        if int(cmd_ret.get('jid', 0)) > 0:
+            func_ret['result'] = True
+            func_ret['comment'] = 'Function submitted successfully.'
+        else:
+            func_ret['result'] = False
+            func_ret['comment'] = 'Function failed to run.'
         return func_ret
 
     try:
@@ -716,8 +754,15 @@ def runner(name, **kwargs):
 
     name
         The name of the function to run
+
     kwargs
         Any keyword arguments to pass to the runner function
+
+    asynchronous
+        Run the salt command but don't wait for a reply.
+
+        .. versionadded:: neon
+
 
     .. code-block:: yaml
 
@@ -747,6 +792,10 @@ def runner(name, **kwargs):
                                       __env__=__env__,
                                       full_return=True,
                                       **kwargs)
+
+    if kwargs.get('asynchronous'):
+        out['return'] = out.copy()
+        out['success'] = 'jid' in out and 'tag' in out
 
     runner_return = out.get('return')
     if isinstance(runner_return, dict) and 'Error' in runner_return:
@@ -960,8 +1009,15 @@ def wheel(name, **kwargs):
 
     name
         The name of the function to run
+
     kwargs
         Any keyword arguments to pass to the wheel function
+
+    asynchronous
+        Run the salt command but don't wait for a reply.
+
+        .. versionadded:: neon
+
 
     .. code-block:: yaml
 
@@ -989,6 +1045,17 @@ def wheel(name, **kwargs):
                                      __orchestration_jid__=jid,
                                      __env__=__env__,
                                      **kwargs)
+
+    if kwargs.get('asynchronous'):
+        ret['__jid__'] = ret.get('jid')
+        ret['changes'] = out
+        if int(out.get('jid', 0)) > 0:
+            ret['result'] = True
+            ret['comment'] = 'wheel submitted successfully.'
+        else:
+            ret['result'] = False
+            ret['comment'] = 'wheel failed to run.'
+        return ret
 
     wheel_return = out.get('return')
     if isinstance(wheel_return, dict) and 'Error' in wheel_return:

--- a/tests/integration/files/file/base/orch/retcode_async.sls
+++ b/tests/integration/files/file/base/orch/retcode_async.sls
@@ -1,0 +1,21 @@
+test_runner_success:
+  salt.runner:
+    - name: runtests_helpers.success
+    - asynchronous: True
+
+test_wheel_sucess:
+  salt.wheel:
+    - name: runtests_helpers.success
+    - asynchronous: True
+
+test_function_sucess:
+  salt.function:
+    - tgt: minion
+    - name: runtests_helpers.success
+    - asynchronous: True
+
+test_state_sucess:
+  salt.state:
+    - tgt: minion
+    - sls: test
+    - asynchronous: True

--- a/tests/integration/runners/test_state.py
+++ b/tests/integration/runners/test_state.py
@@ -142,6 +142,7 @@ class StateRunnerTest(ShellCase):
                         'test_|-test fail with changes_|-test fail with changes_|-fail_with_changes': {
                             '__id__': 'test fail with changes',
                             '__run_num__': 0,
+                            '__saltfunc__': 'test.fail_with_changes',
                             '__sls__': 'orch.issue43204.fail_with_changes',
                             'changes': {
                                 'testing': {
@@ -228,7 +229,7 @@ class StateRunnerTest(ShellCase):
         self.assertIn('Succeeded: 4 (changed=4)\n', ret)
 
         # scrub ephemeral output
-        ret = re.sub('\d', 'x', ret)
+        ret = re.sub(r'\d', 'x', ret)
         ret = re.sub('Duration: .*', 'Duration: x', ret)
         ret = re.sub('Started: .*', 'Started: x', ret)
 

--- a/tests/integration/runners/test_state.py
+++ b/tests/integration/runners/test_state.py
@@ -8,6 +8,7 @@ from __future__ import absolute_import, print_function, unicode_literals
 import errno
 import logging
 import os
+import re
 import shutil
 import signal
 import tempfile
@@ -215,6 +216,82 @@ class StateRunnerTest(ShellCase):
                        '        Name: runtests_helpers.failure\n'
                        '      Result: False'):
             self.assertIn(result, ret)
+
+    def test_orchestrate_retcode_async(self):
+        '''
+        Test orchestration with nonzero retcode set in __context__ for async
+        '''
+        self.run_run('saltutil.sync_runners')
+        self.run_run('saltutil.sync_wheel')
+        ret = "\n".join(self.run_run('state.orchestrate orch.retcode_async'))
+
+        self.assertIn('Succeeded: 4 (changed=4)\n', ret)
+
+        # scrub ephemeral output
+        ret = re.sub('\d', 'x', ret)
+        ret = re.sub('Duration: .*', 'Duration: x', ret)
+        ret = re.sub('Started: .*', 'Started: x', ret)
+
+        result = textwrap.dedent('''
+                  ID: test_runner_success
+            Function: salt.runner
+                Name: runtests_helpers.success
+              Result: True
+             Comment: Runner function 'runtests_helpers.success' executed.
+             Started: x
+            Duration: x
+             Changes:   
+                      ----------
+                      return:
+                          ----------
+                          jid:
+                              xxxxxxxxxxxxxxxxxxxx
+                          tag:
+                              salt/run/xxxxxxxxxxxxxxxxxxxx
+        ----------
+                  ID: test_wheel_sucess
+            Function: salt.wheel
+                Name: runtests_helpers.success
+              Result: True
+             Comment: wheel submitted successfully.
+             Started: x
+            Duration: x
+             Changes:   
+                      ----------
+                      jid:
+                          xxxxxxxxxxxxxxxxxxxx
+                      tag:
+                          salt/wheel/xxxxxxxxxxxxxxxxxxxx
+        ----------
+                  ID: test_function_sucess
+            Function: salt.function
+                Name: runtests_helpers.success
+              Result: True
+             Comment: Function submitted successfully.
+             Started: x
+            Duration: x
+             Changes:   
+                      ----------
+                      jid:
+                          xxxxxxxxxxxxxxxxxxxx
+                      minions:
+                          - minion
+        ----------
+                  ID: test_state_sucess
+            Function: salt.state
+              Result: True
+             Comment: State submitted successfully.
+             Started: x
+            Duration: x
+             Changes:   
+                      ----------
+                      jid:
+                          xxxxxxxxxxxxxxxxxxxx
+                      minions:
+                          - minion
+        ''')
+
+        self.assertIn(result, ret)
 
     def test_orchestrate_target_doesnt_exist(self):
         '''


### PR DESCRIPTION
### What does this PR do?
this exposes the cmd_async functionality of each client that saltmod
wraps in the saltmod state. The idea of this being fire and forget,
wherein you can either store that runs jid for later processing, or do
nothing if you don't care. Without this, you must pay the round trip
penalty of waiting for the full job to complete.


### Tests written?
Yes

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
