### PR TITLE
Added JID lookup message in case minion times out.

### DIFF
--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -1580,7 +1580,12 @@ class LocalClient(object):
                                 id_: {
                                     'out': 'no_return',
                                     'ret': 'Minion did not return. [No response]',
-                                    'retcode': salt.defaults.exitcodes.EX_GENERIC
+                                    'retcode': salt.defaults.exitcodes.EX_GENERIC,'\n\n',
+                                    'The minions may not have all finished running and any '
+                                    'remaining minions will return upon completion. To look '
+                                    'up the return data for this job later, run the following '
+                                    'command:\n\n'
+                                    'salt-run jobs.lookup_jid {0}'.format(jid)
                                 }
                             }
                 else:


### PR DESCRIPTION
### What does this PR do?
In case a minion does not return before timeout, the job ID is printed on screen, exactly as after pressing ctrl+c (but without having to).

### What issues does this PR fix or reference?
This is not a bug fix, just a small usability enhancement. It gives the Master the option to wait for a job to be completed and an easy way to look up the return data in case the minion does not return in time.
