### PR TITLE
Added JID lookup message in case minion times out. 

### DIFF
--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -1580,7 +1580,12 @@ class LocalClient(object):
                                 id_: {
                                     'out': 'no_return',
                                     'ret': 'Minion did not return. [No response]',
-                                    'retcode': salt.defaults.exitcodes.EX_GENERIC
+                                    'retcode': salt.defaults.exitcodes.EX_GENERIC,'\n\n',
+                                    'The minions may not have all finished running and any '
+                                    'remaining minions will return upon completion. To look '
+                                    'up the return data for this job later, run the following '
+                                    'command:\n\n'
+                                    'salt-run jobs.lookup_jid {0}'.format(jid)
                                 }
                             }
                 else:

--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -1579,13 +1579,13 @@ class LocalClient(object):
                             yield {
                                 id_: {
                                     'out': 'no_return',
-                                    'ret': 'Minion did not return. [No response]',
-                                    'retcode': salt.defaults.exitcodes.EX_GENERIC,'\n\n',
-                                    'The minions may not have all finished running and any '
+                                    'ret': 'Minion did not return. [No response]'
+                                    '\nThe minions may not have all finished running and any '
                                     'remaining minions will return upon completion. To look '
                                     'up the return data for this job later, run the following '
                                     'command:\n\n'
-                                    'salt-run jobs.lookup_jid {0}'.format(jid)
+                                    'salt-run jobs.lookup_jid {0}'.format(jid),
+                                    'retcode': salt.defaults.exitcodes.EX_GENERIC
                                 }
                             }
                 else:

--- a/tests/integration/client/test_standard.py
+++ b/tests/integration/client/test_standard.py
@@ -125,7 +125,8 @@ class StdTest(ModuleCase):
         '''
         Test return/messaging on a disconnected minion
         '''
-        test_ret = {'ret': 'Minion did not return. [No response]', 'out': 'no_return'}
+        test_ret = 'Minion did not return. [No response]'
+        test_out = 'no_return'
 
         # Create a minion key, but do not start the "fake" minion. This mimics
         # a disconnected minion.
@@ -143,8 +144,8 @@ class StdTest(ModuleCase):
             num_ret = 0
             for ret in cmd_iter:
                 num_ret += 1
-                self.assertEqual(ret['disconnected']['ret'], test_ret['ret'])
-                self.assertEqual(ret['disconnected']['out'], test_ret['out'])
+                assert ret['disconnected']['ret'].startswith(test_ret), ret['disconnected']['ret']
+                assert ret['disconnected']['out'] == test_out, ret['disconnected']['out']
 
             # Ensure that we entered the loop above
             self.assertEqual(num_ret, 1)
@@ -161,11 +162,12 @@ class StdTest(ModuleCase):
                 'test.ping',
                 tgt_type='list'
                 )
-        self.assertIn('minion', ret)
-        self.assertIn('ghostminion', ret)
-        self.assertEqual(True, ret['minion'])
-        self.assertEqual(u'Minion did not return. [No response]',
-                         ret['ghostminion'])
+        assert 'minion' in ret
+        assert 'ghostminion' in ret
+        assert ret['minion'] is True
+        assert ret['ghostminion'].startswith(
+            'Minion did not return. [No response]'
+        ), ret['ghostminion']
 
     def test_missing_minion_nodegroup(self):
         '''
@@ -176,8 +178,9 @@ class StdTest(ModuleCase):
                 'test.ping',
                 tgt_type='nodegroup'
                 )
-        self.assertIn('minion', ret)
-        self.assertIn('ghostminion', ret)
-        self.assertEqual(True, ret['minion'])
-        self.assertEqual(u'Minion did not return. [No response]',
-                         ret['ghostminion'])
+        assert 'minion' in ret
+        assert 'ghostminion' in ret
+        assert ret['minion'] is True
+        assert ret['ghostminion'].startswith(
+            'Minion did not return. [No response]'
+        ), ret['ghostminion']


### PR DESCRIPTION
### What does this PR do?
In case a minion does not return before timeout, the job ID is printed on screen, exactly as after pressing ctrl+c (but without having to).

### What issues does this PR fix or reference?
This is not a bug fix, just a small usability enhancement. It gives the Master the option to wait for a job to be completed and an easy way to look up the return data in case the minion does not return in time.

