### PR TITLE
Fix failing jinja filter test

### DIFF
--- a/salt/utils/json.py
+++ b/salt/utils/json.py
@@ -93,7 +93,7 @@ def loads(s, **kwargs):
     except TypeError as exc:
         # json.loads cannot load bytestrings in Python < 3.6
         if six.PY3 and isinstance(s, bytes):
-            return json_module.loads(s.decode(__salt_system_encoding__), **kwargs)
+            return json_module.loads(salt.utils.stringutils.to_unicode(s), **kwargs)
         else:
             raise exc
 

--- a/tests/integration/states/test_file.py
+++ b/tests/integration/states/test_file.py
@@ -701,7 +701,7 @@ class FileTest(ModuleCase, SaltReturnAssertsMixin):
             pillar={'tojson-file': test_file})
         ret = ret[next(iter(ret))]
         assert ret['result'], ret
-        with salt.utils.files.fopen(test_file) as fp_:
+        with salt.utils.files.fopen(test_file, mode='rb') as fp_:
             managed = salt.utils.stringutils.to_unicode(fp_.read())
         expected = dedent('''\
             Die Webseite ist https://saltstack.com.
@@ -4548,6 +4548,7 @@ class PatchTest(ModuleCase, SaltReturnAssertsMixin):
         ret = ret[next(iter(ret))]
         self.assertIn('Patch would not apply cleanly', ret['comment'])
         self.assertEqual(ret['changes'], {})
+
 
 WIN_TEST_FILE = 'c:/testfile'
 


### PR DESCRIPTION
### What does this PR do?

Fix `integration.states.test_file.FileTest.test_managed_unicode_jinja_with_tojson_filter` on Windows builds.

This is cherry-picked from PR #50654 to `develop`


### Tests written?

No - Fixing test

### Commits signed with GPG?

Yes

