### PR TITLE
_disbatch_local: break when TimeoutException occurs, not pass

### DIFF
--- a/salt/netapi/rest_tornado/saltnado.py
+++ b/salt/netapi/rest_tornado/saltnado.py
@@ -934,8 +934,9 @@ class SaltAPIHandler(BaseSaltAPIHandler):  # pylint: disable=W0223
                 ret.append('Unexpected exception while handling request: {0}'.format(ex))
                 log.error('Unexpected exception while handling request:', exc_info=True)
 
-        self.write(self.serialize({'return': ret}))
-        self.finish()
+        if not self._finished:
+            self.write(self.serialize({'return': ret}))
+            self.finish()
 
     @tornado.gen.coroutine
     def _disbatch_local(self, chunk):

--- a/salt/netapi/rest_tornado/saltnado.py
+++ b/salt/netapi/rest_tornado/saltnado.py
@@ -1037,7 +1037,7 @@ class SaltAPIHandler(BaseSaltAPIHandler):  # pylint: disable=W0223
                         raise tornado.gen.Return(chunk_ret)
 
             except TimeoutException:
-                pass
+                break
 
             if f == events[0]:
                 events[0] = self.application.event_listener.get_event(self, tag='salt/job/'+chunk['jid'])


### PR DESCRIPTION
### What does this PR do?
addresses an infinite loop when connections close prematurely. also guard against writing on already closed requests in the same scenario.

### What issues does this PR fix or reference?
n/a

### Previous Behavior
api crashes on premature connection close

### New Behavior
request handled gracefully

### Tests written?
No

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
