### PR TITLE
Skip Xen test when not linux

### DIFF
--- a/tests/unit/grains/test_core.py
+++ b/tests/unit/grains/test_core.py
@@ -709,7 +709,7 @@ class CoreGrainsTestCase(TestCase, LoaderModuleMockMixin):
                                 'Docker'
                             )
 
-    @skipIf(salt.utils.platform.is_windows(), 'System is Windows')
+    @skipIf(not salt.utils.platform.is_linux(), 'System is not Linux')
     def test_xen_virtual(self):
         '''
         Test if OS grains are parsed correctly in Ubuntu Xenial Xerus


### PR DESCRIPTION
### What does this PR do?

Skip Xen test when not linux. This test was failing on MacOS tests, I think Xen is for linux only.

### Tests written?

No - Skip existing test

### Commits signed with GPG?

Yes