### PR TITLE
Honor run_run timeout for shell tests

### DIFF
--- a/tests/support/case.py
+++ b/tests/support/case.py
@@ -502,7 +502,7 @@ class ShellCase(ShellTestCase, AdaptedConfigurationTestCaseMixin, ScriptPathMixi
                                arg_str,
                                with_retcode=with_retcode,
                                catch_stderr=catch_stderr,
-                               timeout=60)
+                               timeout=timeout + 10)
 
     def run_run_plus(self, fun, *arg, **kwargs):
         '''


### PR DESCRIPTION
### What does this PR do?

Make sure we honor the timeout passed to ShellCase.run_run from tests.

### Tests written?

No - Making tests less flaky

### Commits signed with GPG?

Yes