### PR TITLE
Increase timeout on orchestrate subset test

### DIFF
--- a/tests/integration/runners/test_state.py
+++ b/tests/integration/runners/test_state.py
@@ -266,7 +266,7 @@ class StateRunnerTest(ShellCase):
         '''
         test orchestration state using subset
         '''
-        ret = self.run_run('state.orchestrate orch.subset')
+        ret = self.run_run('state.orchestrate orch.subset', timeout=500)
 
         def count(thing, listobj):
             return sum([obj.strip() == thing for obj in listobj])

--- a/tests/support/case.py
+++ b/tests/support/case.py
@@ -545,10 +545,10 @@ class ShellCase(ShellTestCase, AdaptedConfigurationTestCaseMixin, ScriptPathMixi
                                                                timeout=timeout,
                                                                async_flag=' --async' if asynchronous else '')
         ret = self.run_script('salt-run',
-                              arg_str,
-                              with_retcode=with_retcode,
-                              catch_stderr=catch_stderr,
-                              timeout=60)
+                               arg_str,
+                               with_retcode=with_retcode,
+                               catch_stderr=catch_stderr,
+                               timeout=timeout + 10)
         log.debug('Result of run_run for command \'%s\': %s', arg_str, ret)
         return ret
 

--- a/tests/support/case.py
+++ b/tests/support/case.py
@@ -545,10 +545,10 @@ class ShellCase(ShellTestCase, AdaptedConfigurationTestCaseMixin, ScriptPathMixi
                                                                timeout=timeout,
                                                                async_flag=' --async' if asynchronous else '')
         ret = self.run_script('salt-run',
-                               arg_str,
-                               with_retcode=with_retcode,
-                               catch_stderr=catch_stderr,
-                               timeout=timeout + 10)
+                              arg_str,
+                              with_retcode=with_retcode,
+                              catch_stderr=catch_stderr,
+                              timeout=timeout + 10)
         log.debug('Result of run_run for command \'%s\': %s', arg_str, ret)
         return ret
 


### PR DESCRIPTION
### What does this PR do?

Fixes [integration.runners.test_state.StateRunnerTest.test_orchestrate_subset](https://jenkinsci.saltstack.com/job/fluorine/view/Python3/job/salt-mac-highsierra-py3/63/) test on MacOS.

- cherry pick timeout fix from #50718
- increase `test_orchestrate_subset` salt-run timeout

### Tests written?

No - Fixing test

### Commits signed with GPG?

Yes