### PR TITLE
Report salt-call exit code from ssh_py_shim.py

### DIFF
--- a/salt/client/ssh/ssh_py_shim.py
+++ b/salt/client/ssh/ssh_py_shim.py
@@ -222,18 +222,21 @@ def main(argv):  # pylint: disable=W0613
     if OPTIONS.cmd_umask is not None:
         old_umask = os.umask(OPTIONS.cmd_umask)
     if OPTIONS.tty:
-        stdout, _ = subprocess.Popen(salt_argv, stdout=subprocess.PIPE, stderr=subprocess.PIPE).communicate()
+        proc = subprocess.Popen(salt_argv, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        stdout, _ = proc.communicate()
         sys.stdout.write(stdout)
         sys.stdout.flush()
+        retcode = proc.returncode
         if OPTIONS.wipe:
             shutil.rmtree(OPTIONS.saltdir)
     elif OPTIONS.wipe:
-        subprocess.call(salt_argv)
+        retcode = subprocess.call(salt_argv)
         shutil.rmtree(OPTIONS.saltdir)
     else:
-        subprocess.call(salt_argv)
+        retcode = subprocess.call(salt_argv)
     if OPTIONS.cmd_umask is not None:
         os.umask(old_umask)
+    return retcode
 
 if __name__ == '__main__':
     sys.exit(main(sys.argv))


### PR DESCRIPTION
### What does this PR do?

Fix error reporting if salt-call called from ssh_py_shim.py fails to run.

### What issues does this PR fix or reference?

Fixes #50727

### Previous Behavior

salt-call exit code ignored by ssh_py_shim.py, always 0 returned.

### New Behavior

ssh_py_shim.py exits with salt-call exit code.

### Tests written?

No

### Commits signed with GPG?

Yes (but with Github's key...)

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
