### PR TITLE
Ignoring ACL check for empty ACL in zookeeper.present

### DIFF
--- a/salt/states/zookeeper.py
+++ b/salt/states/zookeeper.py
@@ -133,19 +133,19 @@ def present(name, value, acls=None, ephemeral=False, sequence=False, makepath=Fa
     if __salt__['zookeeper.exists'](name, **connkwargs):
         cur_value = __salt__['zookeeper.get'](name, **connkwargs)
         cur_acls = __salt__['zookeeper.get_acls'](name, **connkwargs)
-        if cur_value == value and _check_acls(cur_acls, chk_acls):
+        if cur_value == value and (not chk_acls or _check_acls(cur_acls, chk_acls)):
             ret['result'] = True
             ret['comment'] = 'Znode {0} is already set to the correct value with the correct acls'.format(name)
             return ret
         elif __opts__['test'] is True:
             ret['result'] = None
-            ret['comment'] = 'Znode {0} is will be updated'.format(name)
+            ret['comment'] = 'Znode {0} will be updated'.format(name)
             ret['changes']['old'] = {}
             ret['changes']['new'] = {}
             if value != cur_value:
                 ret['changes']['old']['value'] = cur_value
                 ret['changes']['new']['value'] = value
-            if not _check_acls(chk_acls, cur_acls):
+            if chk_acls and not _check_acls(chk_acls, cur_acls):
                 ret['changes']['old']['acls'] = cur_acls
                 ret['changes']['new']['acls'] = chk_acls
             return ret


### PR DESCRIPTION
### What does this PR do?
Ignores the ACL differences, if no ACL is specified in the zookeeper.present state, Just values are compared.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/50731

### Previous Behavior
If zookeeper.present ACL setting is None and znode values are the same, running a state with Test=True always shows ACL changes will be made, while actually running the state would result in the incorrect message "successfully updated", even though the values are the same and no ACL changes would be done as well.

### New Behavior
If zookeeper.present ACL setting is None and znode values are the same, running a state would not show and/or make any changes and respond with the message "is already set to the correct value with the correct acls"
