### PR TITLE
Catch UnicodeDecodeErrors in id verification

### DIFF
--- a/salt/utils/verify.py
+++ b/salt/utils/verify.py
@@ -500,7 +500,7 @@ def valid_id(opts, id_):
         if any(x in id_ for x in ('/', '\\', str('\0'))):
             return False
         return bool(clean_path(opts['pki_dir'], id_))
-    except (AttributeError, KeyError, TypeError):
+    except (AttributeError, KeyError, TypeError, UnicodeDecodeError):
         return False
 
 


### PR DESCRIPTION
Do not crash if the id cannot be decoded. An invalid id provided by an untrusted client can DOS the master.

### What does this PR do?
Makes the valid_id function return false in case the provided minion id cannot be decoded to a unicode string.
Without this a malformed id from an unaccepted (and so untrusted) minion can bring down the master causing a DOS. I was even tempted to catch any exception since any error in this validation function can bring down the master and the function takes its input from untrusted sources.

### Previous Behavior
A malformed minion id causes the master to crash with the following traceback
```
[tornado.application:140 ][ERROR   ][23437] Future exception was never retrieved: Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/tornado/gen.py", line 326, in wrapper
    yielded = next(result)
  File "/usr/lib/python2.7/site-packages/salt/transport/zeromq.py", line 680, in handle_message
    stream.send(self.serial.dumps(self._auth(payload['load'])))
  File "/usr/lib/python2.7/site-packages/salt/transport/mixins/auth.py", line 180, in _auth
    if not salt.utils.verify.valid_id(self.opts, load['id']):
  File "/usr/lib/python2.7/site-packages/salt/utils/verify.py", line 500, in valid_id
    if any(x in id_ for x in ('/', '\\', str('\0'))):
  File "/usr/lib/python2.7/site-packages/salt/utils/verify.py", line 500, in <genexpr>
    if any(x in id_ for x in ('/', '\\', str('\0'))):
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc2 in position 11: ordinal not in range(128)
```

### New Behavior
valid_id returns False and discards the minion