### PR TITLE
Older MacOS versions won't have TMPDIR environment

### DIFF
--- a/tests/unit/modules/test_kubernetes.py
+++ b/tests/unit/modules/test_kubernetes.py
@@ -181,7 +181,7 @@ class KubernetesTestCase(TestCase, LoaderModuleMockMixin):
                 if salt.utils.platform.is_windows():
                     check_path = os.path.join(os.environ.get('TMP'), 'salt-kubeconfig-')
                 elif salt.utils.platform.is_darwin():
-                    check_path = os.path.join(os.environ.get('TMPDIR'), 'salt-kubeconfig-')
+                    check_path = os.path.join(os.environ.get('TMPDIR', '/tmp'), 'salt-kubeconfig-')
                 self.assertTrue(config['kubeconfig'].lower().startswith(check_path.lower()))
                 self.assertTrue(os.path.exists(config['kubeconfig']))
                 with salt.utils.files.fopen(config['kubeconfig'], 'r') as kcfg:


### PR DESCRIPTION
### What does this PR do?

My fix for [salt-jenkins#1211](https://github.com/saltstack/salt-jenkins/issues/1221) only worked on newer MacOS versions, old versions still use `/tmp`

### Tests written?

No

### Commits signed with GPG?

Yes
