### PR TITLE
Fix grafana dashboard updating when nothing has changed

### DIFF
--- a/salt/states/grafana4_dashboard.py
+++ b/salt/states/grafana4_dashboard.py
@@ -247,6 +247,7 @@ def absent(name, orgname=None, profile='grafana'):
 
 _IGNORED_DASHBOARD_FIELDS = [
     'id',
+    'uid',
     'originalTitle',
     'version',
 ]


### PR DESCRIPTION
### What does this PR do?
Fix grafana dashboard update

### What issues does this PR fix or reference?
No existing issue in bug tracker.

### Previous Behavior
`grafana4_dashboard.present` state would always report a dashboard update even if nothing has changed.

### New Behavior
`grafana4_dashboard.present` state now report a dashboard update only if something has actually changed.

### Tests written?

No

### Commits signed with GPG?

No
