### PR TITLE
Fix exit status tests on osx

### DIFF
--- a/tests/integration/utils/testprogram.py
+++ b/tests/integration/utils/testprogram.py
@@ -820,6 +820,9 @@ class TestDaemon(TestProgram):
                     # Process exited between when process_iter was invoked and
                     # when we tried to invoke this instance's cmdline() func.
                     continue
+                except psutils.AccessDenied:
+                    # We might get access denied if not running as root
+                    continue
                 if any((cmdline == proc_cmdline[n:n + cmd_len])
                         for n in range(len(proc_cmdline) - cmd_len + 1)):
                     ret.append(proc)


### PR DESCRIPTION
### What does this PR do?

Fix `integration.shell.test_syndic.SyndicTest.test_exit_status_correct_usage` when running as not root like in the MacOS test suite.

https://jenkinsci.saltstack.com/job/fluorine/job/salt-mac-sierra-py2/67/testReport/junit/integration.shell.test_syndic/SyndicTest/test_exit_status_correct_usage/


### Tests written?

No

### Commits signed with GPG?

Yes