### PR TITLE
Fix last key detection in pillar.pepa`key_value_to_tree`

### DIFF
--- a/salt/pillar/pepa.py
+++ b/salt/pillar/pepa.py
@@ -365,8 +365,8 @@ def key_value_to_tree(data):
     for flatkey, value in six.iteritems(data):
         t = tree
         keys = flatkey.split(__opts__['pepa_delimiter'])
-        for key in keys:
-            if key == keys[-1]:
+        for i, key in enumerate(keys, 1):
+            if i == len(keys):
                 t[key] = value
             else:
                 t = t.setdefault(key, {})

--- a/tests/unit/pillar/test_pepa.py
+++ b/tests/unit/pillar/test_pepa.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+
+# Import python libs
+from __future__ import absolute_import, print_function, unicode_literals
+from collections import OrderedDict
+
+# Import Salt Testing libs
+from tests.support.unit import TestCase
+
+# Import Salt Libs
+import salt.pillar.pepa as pepa
+
+
+class PepaPillarTestCase(TestCase):
+    def test_repeated_keys(self):
+        expected_result = {
+            "foo": {
+                "bar": {
+                    "foo": True,
+                    "baz": True,
+                },
+            },
+        }
+        data = OrderedDict([
+            ('foo..bar..foo', True),
+            ('foo..bar..baz', True),
+        ])
+        result = pepa.key_value_to_tree(data)
+        self.assertDictEqual(result, expected_result)


### PR DESCRIPTION
`salt.pillar.pepa.key_value_to_tree()` only checks the name of the key when attempting
to identify the last key in a flattened key.  This can lead to strange
behavior when the final key name also occurs earlier in the flatkey.

This change explicitly checks that we are the final key in flatkey
prior to setting value.  Test included.

Also see mickep76/pepa#11 and mickep76/pepa#12

### What does this PR do?
Fix an issue with key processing in the pepa pillar module

### What issues does this PR fix or reference?
mickep76/pepa#11 and mickep76/pepa#12

### Previous Behavior
```python
In [1]: import collections

In [2]: import salt.pillar.pepa as pepa

In [3]: data = collections.OrderedDict([('foo..bar..foo', True), ('foo..bar..baz', True)])

In [4]: pepa.key_value_to_tree(data)
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-4-f64c7011dc9a> in <module>()
----> 1 pepa.key_value_to_tree(data)

/mnt/c/Users/bewing/PycharmProjects/salt/salt/pillar/pepa/__init__.pyc in key_value_to_tree(data, delimiter)
     28                 t[key] = value
     29             else:
---> 30                 t = t.setdefault(key, {})
     31     return tree
     32

AttributeError: 'bool' object has no attribute 'setdefault'
```
### New Behavior
```python
In [1]: import collections

In [2]: import salt.pillar.pepa as pepa

In [3]: data = collections.OrderedDict([('foo..bar..foo', True), ('foo..bar..baz', True)])

In [4]: pepa.key_value_to_tree(data)
Out[4]: {'foo': {'bar': {'baz': True, 'foo': True}}}

```
### Tests written?
Yes

### Commits signed with GPG?
Yes
