### PR TITLE
Fixes a memory leak which is caused by un-cleared stream connections.

### DIFF
--- a/salt/netapi/rest_tornado/saltnado.py
+++ b/salt/netapi/rest_tornado/saltnado.py
@@ -494,6 +494,8 @@ class BaseSaltAPIHandler(tornado.web.RequestHandler):  # pylint: disable=W0223
         '''
         # timeout all the futures
         self.timeout_futures()
+        # clear local_client objects to disconnect event publisher's IOStream connections
+        del self.saltclients
 
     def on_connection_close(self):
         '''


### PR DESCRIPTION
### What does this PR do?

Compliment memory leak fixes of #46094.

Previous versions of tornado (4.4.x) do gc frequently for asynchronous request handlers' variables, but the current version of tornado (5.x) don't do gc well for the variables.

The reason that gc should be run appropriately is that the `saltclients` variable maintains connections between the publish channel of `EventPublisher`. if the connections do not be cleaned as soon as possible, those will occupy un-necessary memory.


### What issues does this PR fix or reference?

#46094

### Previous Behavior

(Logging by following code at [`translate/ipc.py`](https://github.com/kstreee/salt/blob/fix-memory-leak/salt/transport/ipc.py#L540))
```
log.info('stream size is : {}'.format(len(self.streams)))
def buf_log(stream):
    if stream:
        return 'r{}-w{}'.format(stream._read_buffer.__len__(), stream._write_buffer._size)
log.info(' '.join('{}: {}, '.format(idx, buf_log(s)) for idx, s in enumerate(self.streams)))
```

```
2018-12-05 14:33:48,272 [salt.transport.ipc:541            ][INFO    ] stream size is : 14
2018-12-05 14:33:48,272 [salt.transport.ipc:545            ][INFO    ] 0: r0-w0,  1: r0-w0,  2: r0-w0,  3: r0-w0,  4: r0-w0,  5: r0-w0,  6: r0-w0,  7: r0-w0,  8: r0-w0,  9: r0-w0,  10: r0-w0,  11: r0-w0,  12: r0-w0,  13: r0-w0,
...
2018-12-05 14:34:10,359 [salt.transport.ipc:541            ][INFO    ] stream size is : 18
2018-12-05 14:34:10,360 [salt.transport.ipc:545            ][INFO    ] 0: r0-w0,  1: r0-w0,  2: r0-w0,  3: r0-w0,  4: r0-w0,  5: r0-w0,  6: r0-w0,  7: r0-w0,  8: r0-w14003,  9: r0-w29063,  10: r0-w0,  11: r0-w0,  12: r0-w4735,  13: r0-w16017,  14: r0-w0,  15: r0-w0,  16: r0-w18198,  17: r0-w0,
...
2018-12-05 14:34:39,278 [salt.transport.ipc:541            ][INFO    ] stream size is : 24
2018-12-05 14:34:39,278 [salt.transport.ipc:545            ][INFO    ] 0: r0-w0,  1: r0-w8986,  2: r0-w0,  3: r0-w0,  4: r0-w0,  5: r0-w0,  6: r0-w11021,  7: r0-w0,  8: r0-w30536,  9: r0-w32717,  10: r0-w43582,  11: r0-w0,  12: r0-w0, 13: r0-w0,  14: r0-w28522,  15: r0-w0,  16: r0-w0,  17: r0-w0,  18: r0-w0,  19: r0-w0,  20: r0-w14026,  21: r0-w19254,  22: r0-w0,  23: r0-w0,
...
2018-12-05 14:34:44,984 [salt.transport.ipc:541            ][INFO    ] stream size is : 40
2018-12-05 14:34:44,984 [salt.transport.ipc:545            ][INFO    ] 0: r0-w0,  1: r0-w56690,  2: r0-w0,  3: r0-w0,  4: r0-w4318,  5: r0-w9625,  6: r0-w58725,  7: r0-w5953,  8: r0-w0,  9: r0-w0,  10: r0-w0,  11: r0-w78240,  12: r0-w80421,  13: r0-w0,  14: r0-w0,  15: r0-w91286,  16: r0-w0,  17: r0-w0,  18: r0-w0,  19: r0-w0,  20: r0-w0,  21: r0-w76226,  22: r0-w2000,  23: r0-w0,  24: r0-w0,  25: r0-w0,  26: r0-w0,  27: r0-w0,  28: r0-w0,  29: r0-w61730,  30: r0-w0, 31: r0-w0,  32: r0-w0,  33: r0-w0,  34: r0-w0,  35: r0-w0,  36: r0-w66958,  37: r0-w0,  38: r0-w0,  39: r0-w0,
...
```

### New Behavior

Maintains the stream size and the read-write buffer size.

```
2018-12-05 14:42:00,618 [salt.transport.ipc:541            ][INFO    ] stream size is : 6
2018-12-05 14:42:00,618 [salt.transport.ipc:545            ][INFO    ] 0: r0-w0,  1: r0-w0,  2: r0-w0,  3: r0-w0,  4: r0-w0,  5: r0-w0,
...
2018-12-05 14:46:02,033 [salt.transport.ipc:541            ][INFO    ] stream size is : 6
2018-12-05 14:46:02,034 [salt.transport.ipc:545            ][INFO    ] 0: r0-w0,  1: r0-w0,  2: r0-w0,  3: r0-w0,  4: r0-w0,  5: r0-w0,
...
2018-12-05 14:50:40,155 [salt.transport.ipc:541            ][INFO    ] stream size is : 6
2018-12-05 14:50:40,155 [salt.transport.ipc:545            ][INFO    ] 0: r0-w0,  1: r0-w0,  2: r0-w0,  3: r0-w0,  4: r0-w0,  5: r0-w0,
```

### Tests written?

No

### Commits signed with GPG?

Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.