### PR TITLE
Use a process pool to instantiate and start processes

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1150,7 +1150,7 @@ class Minion(MinionBase):
 
         # We want the process pool on our main process
         # Check if there is a max process count,
-        # if not we will use the same way to create a process as before, Process() 
+        # if not we will use the same way to create a process as before, Process()
         self.pool = None
         process_count_max = self.opts.get('process_count_max')
         if not hasattr(self, '_is_child') and pool and process_count_max > 0:
@@ -1590,7 +1590,6 @@ class Minion(MinionBase):
                 args=(instance, self.opts, data, self.connected),
                 name=data['jid']
             )
-
 
         # Reset current signals before starting the process in
         # order not to inherit the current signal handlers

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -129,8 +129,8 @@ log = logging.getLogger(__name__)
 
 def child_minion_process(minion_instance, opts, data, connected):
     '''
-    On a process pool, we cann not use a member function
-    We need to instanciate the minion in a function
+    On a process pool, we can not use a member function
+    We need to instantiate the minion in a function
     '''
     if not minion_instance:
         minion_instance = Minion(opts, pool=False)


### PR DESCRIPTION
On windows, to instantiate new minion on a new process, for a simple command like `test.ping` it took more than 3 seconds. I tried to find a way to avoid this overload.

### What does this PR do?
Instead of using multiprocessing.Process() to instantiate new minion and run salt command. We use a process pool.

### Previous Behavior
On windows, at every command on the minion, we launch a new process, instantiate the minion, and execute this command.

### New Behavior
At the beginning of salt-minion, we create a process pool sized by `process_count_max`. When a new command has to be run, we just use a process that already exists. If `process_count_max` does not exist, we use the previous behavior.

### Tests written?

No

### Commits signed with GPG?

No

