### PR TITLE
restartcheck: fix python 3 bytestring breakage

### DIFF
--- a/salt/modules/restartcheck.py
+++ b/salt/modules/restartcheck.py
@@ -552,7 +552,7 @@ def restartcheck(ignorelist=None, blacklist=None, excludepid=None, **kwargs):
 
         while True:
             _check_timeout(start_time, timeout)
-            line = paths.stdout.readline()
+            line = salt.utils.stringutils.to_unicode(paths.stdout.readline())
             if not line:
                 break
             pth = line[:-1]


### PR DESCRIPTION
In python 2, bytes is an alias for str and b'foo' == 'foo' so this code
used to work, but in python 3 bytes is a separate type, b'foo' != 'foo'
so pth.startswith() errors because of the type mismatch:

"Passed invalid arguments: startswith first arg must be bytes or a
tuple of bytes, not str."

Fix this by converting bytes to an unicode string so the code works in
both v2 and v3.

Signed-off-by: Ioan-Adrian Ratiu <adrian.ratiu@ni.com>

### What does this PR do?

See above.

### What issues does this PR fix or reference?

No github issue: it was found during downstream NILinuxRT testing.

### Previous Behavior

Function restartcheck was run only on python 2.

### New Behavior
Updated to python 3 and restartcheck broke because of the str/bytes type difference.

### Tests written?

No

### Commits signed with GPG?

No

