### PR TITLE
qemu-img output may not have cluster-size

### DIFF
--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -292,7 +292,7 @@ def _parse_qemu_img_info(info):
                    'file format': disk_infos['format'],
                    'disk size': disk_infos['actual-size'],
                    'virtual size': disk_infos['virtual-size'],
-                   'cluster size': disk_infos['cluster-size']
+                   'cluster size': disk_infos['cluster-size'] if 'cluster-size' in disk_infos else None,
                }
 
         if 'full-backing-filename' in disk_infos.keys():


### PR DESCRIPTION
### What does this PR do?

Older versions of qemu-img may not output the cluster-size, in which
case we replace it with None to avoid a failure.

### What issues does this PR fix or reference?

None referenced.

### Previous Behavior

Getting disks of a VM could raise an exception on old qemu-img versions (reproduced with 2.9.1)

### New Behavior

Don't raise an exception and replace cluster-size value by None.

### Tests written?

No

### Commits signed with GPG?

Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
