### PR TITLE
salt.runners.pillar: fix special case for masters pillar

### DIFF
--- a/salt/runners/pillar.py
+++ b/salt/runners/pillar.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import, print_function, unicode_literals
 
 # Import salt libs
 import salt.pillar
+import salt.loader
 import salt.utils.minions
 
 
@@ -21,6 +22,8 @@ def show_top(minion=None, saltenv='base'):
         salt-run pillar.show_top
     '''
     id_, grains, _ = salt.utils.minions.get_minion_data(minion, __opts__)
+    if not grains and minion == __opts__['id']:
+        grains = salt.loader.grains(__opts__)
     pillar = salt.pillar.Pillar(
         __opts__,
         grains,
@@ -89,6 +92,8 @@ def show_pillar(minion='*', **kwargs):
     pillarenv = None
     saltenv = 'base'
     id_, grains, _ = salt.utils.minions.get_minion_data(minion, __opts__)
+    if not grains and minion == __opts__['id']:
+        grains = salt.loader.grains(__opts__)
     if grains is None:
         grains = {'fqdn': minion}
 


### PR DESCRIPTION
### What does this PR do?
when asking for the pillar of the running minion in master context it
talks on a '_master' to the minion_id, which will be a cache miss for
grains. if this is asked for, just generate it via salt.loader.grains

### What issues does this PR fix or reference?
salt-run pillar.show_pillar foo_master didnt work

### Tests written?
No

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
