### PR TITLE
Load user profile using original token (before elevation)

### DIFF
--- a/salt/utils/win_runas.py
+++ b/salt/utils/win_runas.py
@@ -127,6 +127,9 @@ def runas(cmdLine, username, password=None, cwd=None):
         # Login without a password. This always returns an elevated token.
         user_token = salt.platform.win.logon_msv1_s4u(username).Token
 
+    # Make sure the user's profile is loaded.
+    handle_reg = win32profile.LoadUserProfile(user_token, {'UserName': username})
+
     # Get a linked user token to elevate if needed
     elevation_type = win32security.GetTokenInformation(
         user_token, win32security.TokenElevationType
@@ -139,9 +142,6 @@ def runas(cmdLine, username, password=None, cwd=None):
 
     # Elevate the user token
     salt.platform.win.elevate_token(user_token)
-
-    # Make sure the user's profile is loaded.
-    handle_reg = win32profile.LoadUserProfile(user_token, {'UserName': username})
 
     # Make sure the user's token has access to a windows station and desktop
     salt.platform.win.grant_winsta_and_desktop(user_token)


### PR DESCRIPTION
### What does this PR do?

Use the logon token to load the user's profile before doing token elevation.

This fixes:

[`integration.states.test_pip_state.PipStateTest.test_issue_6912_wrong_owner`](https://jenkinsci.saltstack.com/job/fluorine/job/salt-windows-2016-py2/43/)


### Tests written?

No - Fixing test

### Commits signed with GPG?

Yes