### PR TITLE
Non-root building and signing of packages on Debian family

### DIFF
--- a/salt/modules/debbuild.py
+++ b/salt/modules/debbuild.py
@@ -877,11 +877,7 @@ def make_repo(repodir,
                     number_retries = timeout / interval
                     times_looped = 0
                     error_msg = 'Failed to debsign file {0}'.format(abs_file)
-                    if __grains__['os'] in ['Debian'] or (__grains__['os'] in ['Ubuntu'] and __grains__['osmajorrelease'] >= 18):
-                        cmd = 'debsign --re-sign -k {0} {1}'.format(local_key_fingerprint, abs_file)
-                        log.debug("DGM make_repo debian gpg2 debsign cmd \'{0}\'".format(cmd))
-                        retrc |= __salt__['cmd.retcode'](cmd, runas=runas, cwd=repodir, use_vt=True, env=env)
-                    else:
+                    if __grains__['os'] in ['Ubuntu'] and __grains__['osmajorrelease'] < 18:
                         cmd = 'debsign --re-sign -k {0} {1}'.format(keyid, abs_file)
                         log.debug("DGM make_repo ubuntu gpg2 debsign cmd \'{0}\'".format(cmd))
                         ##DGM retrc |= __salt__['cmd.retcode'](cmd, runas=runas, cwd=repodir, use_vt=True, env=env)
@@ -925,6 +921,10 @@ def make_repo(repodir,
                                     'stderr': trace}
                         finally:
                             proc.close(terminate=True, kill=True)
+                    else:
+                        cmd = 'debsign --re-sign -k {0} {1}'.format(local_key_fingerprint, abs_file)
+                        log.debug("DGM make_repo debian gpg2 debsign cmd \'{0}\'".format(cmd))
+                        retrc |= __salt__['cmd.retcode'](cmd, runas=runas, cwd=repodir, use_vt=True, env=env)
 
                 number_retries = timeout / interval
                 times_looped = 0
@@ -932,10 +932,7 @@ def make_repo(repodir,
                 cmd = 'reprepro --ignore=wrongdistribution --component=main -Vb . includedsc {0} {1}'.format(
                         codename,
                         abs_file)
-                if __grains__['os'] in ['Debian'] or (__grains__['os'] in ['Ubuntu'] and __grains__['osmajorrelease'] >= 18):
-                    log.debug("DGM make_repo debian gpg2 reprepro cmd \'{0}\'".format(cmd))
-                    retrc |= __salt__['cmd.retcode'](cmd, runas=runas, cwd=repodir, use_vt=True, env=env)
-                else:
+                if __grains__['os'] in ['Ubuntu'] and __grains__['osmajorrelease'] < 18:
                     log.debug("DGM make_repo ubuntu gpg2 reprepro cmd \'{0}\'".format(cmd))
                     try:
                         proc = salt.utils.vt.Terminal(
@@ -979,6 +976,9 @@ def make_repo(repodir,
                                 }
                     finally:
                         proc.close(terminate=True, kill=True)
+                else:
+                    log.debug("DGM make_repo debian gpg2 reprepro cmd \'{0}\'".format(cmd))
+                    retrc |= __salt__['cmd.retcode'](cmd, runas=runas, cwd=repodir, use_vt=True, env=env)
 
         if retrc != 0:
             raise SaltInvocationError(


### PR DESCRIPTION
### What does this PR do?
Allows for building and signing Debian (and Raspbian and latest Ubuntu 18.04) packages on AWS and VirtualBox, which were failing as root user due to changes in latest versions of gpg-agent.  Ubuntu 14.04 and Ubuntu 16.04 are still built as root, due to gpg-agent version supported in those versions.

### What issues does this PR fix or reference?
With recent Debian 9 (9.5 on VirtualBox, from 9.0 on AWS) the gpg-agent does not start correctly if launched by root user, hence the need to build and sign as a non-root user.  This is due to changes in gpg-agent utilizing systemd and the associated Unix standard sockets failing to start correctly if root.  This results in failing to store the passphrase and hence signing failures.  Also with recent changes the key fingerprint is now used in re-signing with debsign.

### Previous Behavior
Signing packages Debian 9.0 and above would fail on AWS, 9.5 would fail on VirtualBox.  Debian 9.2 on OpenNebula and VirtualBox would succeed.

### New Behavior
Signing Debian 9 packages now succeed on AWS when signing as a non-root user.

### Tests written?
No, use of salt-pack, salt-pack-py3 and salt-auto-pack si sufficient testing

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
