### PR TITLE
state.win_firewall: Add a delete_rule function to reflect execution module

### DIFF
--- a/salt/states/win_firewall.py
+++ b/salt/states/win_firewall.py
@@ -210,8 +210,6 @@ def delete_rule(name,
 
         remoteip (Optional[str]): The remote IP of the rule.
 
-        .. versionadded:: Neon
-
     Example:
 
     .. code-block:: yaml

--- a/salt/states/win_firewall.py
+++ b/salt/states/win_firewall.py
@@ -184,6 +184,70 @@ def add_rule(name,
     return ret
 
 
+def delete_rule(name,
+             localport=None,
+             protocol=None,
+             dir=None,
+             remoteip=None):
+    '''
+    Delete an existing firewall rule identified by name and optionally by ports,
+    protocols, direction, and remote IP.
+
+    .. versionadded:: Neon
+
+    Args:
+
+        name (str): The name of the rule to delete. If the name ``all`` is used
+            you must specify additional parameters.
+
+        localport (Optional[str]): The port of the rule. If protocol is not
+            specified, protocol will be set to ``tcp``
+
+        protocol (Optional[str]): The protocol of the rule. Default is ``tcp``
+            when ``localport`` is specified
+
+        dir (Optional[str]): The direction of the rule.
+
+        remoteip (Optional[str]): The remote IP of the rule.
+
+        .. versionadded:: Neon
+
+    Example:
+
+    .. code-block:: yaml
+
+        delete_smb_port_rule:
+          win_firewall.delete_rule:
+            - name: SMB (445)
+    '''
+    ret = {'name': name,
+           'result': True,
+           'changes': {},
+           'comment': ''}
+
+    # Check if rule exists
+    if __salt__['firewall.rule_exists'](name):
+        ret['changes'] = {'delete rule': name}
+    else:
+        ret['comment'] = 'A rule with that name does not exist'
+        return ret
+
+    if __opts__['test']:
+        ret['result'] = not ret['changes'] or None
+        ret['comment'] = ret['changes']
+        ret['changes'] = {}
+        return ret
+
+    # Delete rule
+    try:
+        __salt__['firewall.delete_rule'](
+            name, localport, protocol, dir, remoteip)
+    except CommandExecutionError:
+        ret['comment'] = 'Could not delete rule'
+
+    return ret
+
+
 def enabled(name='allprofiles'):
     '''
     Enable all the firewall profiles (Windows only)


### PR DESCRIPTION
### What does this PR do?
Adds the opposite function of ``win_firewall.add_rule`` to the win_firewall state module. 

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/50658

### Previous Behavior
Report on the non-existence of ``win_firewall.delete_rule``.

### New Behavior
Either remove the rule if it exists, or report on it not existing if it doesn't.

### Tests written?

No, lacking existing tests for this state module and a windows development environment. I have however tested it on a windows 2016 server minion.

```
bash-4.4# salt win\* state.sls close_win_firewall
windows2016:
----------
          ID: close_smb_port
    Function: win_firewall.delete_rule
        Name: SMB (445)
      Result: True
     Comment: 
     Started: 20:15:19.568672
    Duration: 124.563 ms
     Changes:   
              ----------
              delete rule:
                  SMB (445)

Summary for windows2016
------------
Succeeded: 1 (changed=1)
Failed:    0
------------
Total states run:     1
Total run time: 124.563 ms
bash-4.4# salt win\* state.sls close_win_firewall
windows2016:
----------
          ID: close_smb_port
    Function: win_firewall.delete_rule
        Name: SMB (445)
      Result: True
     Comment: A rule with that name does not exist
     Started: 20:27:35.870760
    Duration: 155.819 ms
     Changes:   

Summary for windows2016
------------
Succeeded: 1
Failed:    0
------------
Total states run:     1
Total run time: 155.819 ms
```

### Commits signed with GPG?

Yes