### PR TITLE
Make sure ldap passwords are honored

### DIFF
--- a/salt/auth/ldap.py
+++ b/salt/auth/ldap.py
@@ -283,12 +283,14 @@ def auth(username, password):
         log.error('LDAP authentication requires python-ldap module')
         return False
 
+    bind = None
+
     # If bind credentials are configured, verify that we receive a valid bind
     if _config('binddn', mandatory=False) and _config('bindpw', mandatory=False):
-        bind = _bind_for_search(anonymous=_config('anonymous', mandatory=False))
+        search_bind = _bind_for_search(anonymous=_config('anonymous', mandatory=False))
 
         # If username & password are not None, attempt to verify they are valid
-        if bind and username and password:
+        if search_bind and username and password:
             bind = _bind(username, password,
                          anonymous=_config('auth_by_group_membership_only', mandatory=False)
                          and _config('anonymous', mandatory=False))

--- a/tests/unit/auth/test_ldap.py
+++ b/tests/unit/auth/test_ldap.py
@@ -10,6 +10,8 @@ import salt.auth.ldap
 from tests.support.mock import patch, NO_MOCK, NO_MOCK_REASON
 from tests.support.unit import skipIf, TestCase
 
+from unittest import TestCase
+
 salt.auth.ldap.__opts__ = {}
 
 
@@ -86,3 +88,8 @@ class LDAPAuthTestCase(TestCase):
         with patch.dict(salt.auth.ldap.__opts__, self.opts):
             with patch('salt.auth.ldap.auth', return_value=Bind):
                 self.assertIn('saltusers', salt.auth.ldap.groups('saltuser', password='password'))
+
+    def test_auth_nopass(self):
+        with patch.dict(salt.auth.ldap.__opts__, self.opts):
+            with patch('salt.auth.ldap._bind_for_search', return_value=Bind):
+                assert salt.auth.ldap.auth('foo', None) == False

--- a/tests/unit/auth/test_ldap.py
+++ b/tests/unit/auth/test_ldap.py
@@ -90,6 +90,22 @@ class LDAPAuthTestCase(TestCase):
                 self.assertIn('saltusers', salt.auth.ldap.groups('saltuser', password='password'))
 
     def test_auth_nopass(self):
-        with patch.dict(salt.auth.ldap.__opts__, self.opts):
+        opts = self.opts.copy()
+        opts['auth.ldap.bindpw'] = 'p@ssw0rd!'
+        with patch.dict(salt.auth.ldap.__opts__, opts):
             with patch('salt.auth.ldap._bind_for_search', return_value=Bind):
                 assert salt.auth.ldap.auth('foo', None) == False
+
+    def test_auth_nouser(self):
+        opts = self.opts.copy()
+        opts['auth.ldap.bindpw'] = 'p@ssw0rd!'
+        with patch.dict(salt.auth.ldap.__opts__, opts):
+            with patch('salt.auth.ldap._bind_for_search', return_value=Bind):
+                assert salt.auth.ldap.auth(None, 'foo') == False
+
+    def test_auth_nouserandpass(self):
+        opts = self.opts.copy()
+        opts['auth.ldap.bindpw'] = 'p@ssw0rd!'
+        with patch.dict(salt.auth.ldap.__opts__, opts):
+            with patch('salt.auth.ldap._bind_for_search', return_value=Bind):
+                assert salt.auth.ldap.auth(None, None) == False

--- a/tests/unit/auth/test_ldap.py
+++ b/tests/unit/auth/test_ldap.py
@@ -92,18 +92,18 @@ class LDAPAuthTestCase(TestCase):
         opts['auth.ldap.bindpw'] = 'p@ssw0rd!'
         with patch.dict(salt.auth.ldap.__opts__, opts):
             with patch('salt.auth.ldap._bind_for_search', return_value=Bind):
-                assert salt.auth.ldap.auth('foo', None) == False
+                self.assertFalse(salt.auth.ldap.auth('foo', None))
 
     def test_auth_nouser(self):
         opts = self.opts.copy()
         opts['auth.ldap.bindpw'] = 'p@ssw0rd!'
         with patch.dict(salt.auth.ldap.__opts__, opts):
             with patch('salt.auth.ldap._bind_for_search', return_value=Bind):
-                assert salt.auth.ldap.auth(None, 'foo') == False
+                self.assertFalse(salt.auth.ldap.auth(None, 'foo'))
 
     def test_auth_nouserandpass(self):
         opts = self.opts.copy()
         opts['auth.ldap.bindpw'] = 'p@ssw0rd!'
         with patch.dict(salt.auth.ldap.__opts__, opts):
             with patch('salt.auth.ldap._bind_for_search', return_value=Bind):
-                assert salt.auth.ldap.auth(None, None) == False
+                self.assertFalse(salt.auth.ldap.auth(None, None))

--- a/tests/unit/auth/test_ldap.py
+++ b/tests/unit/auth/test_ldap.py
@@ -10,8 +10,6 @@ import salt.auth.ldap
 from tests.support.mock import patch, NO_MOCK, NO_MOCK_REASON
 from tests.support.unit import skipIf, TestCase
 
-from unittest import TestCase
-
 salt.auth.ldap.__opts__ = {}
 
 


### PR DESCRIPTION
### What does this PR do?

Only return a bind from an actual auth attempt.

### What issues does this PR fix or reference?

ZD-2993

### Previous Behavior

A successful search bind would result in a successful authentication if no username and/or password is provided.

### New Behavior

Keep search bind separate and only return bind from an authentication request.

### Tests written?

Yes

### Commits signed with GPG?

Yes