### PR TITLE
git_pillar: Add support for all_saltenvs parameter

### DIFF
--- a/salt/pillar/git_pillar.py
+++ b/salt/pillar/git_pillar.py
@@ -329,6 +329,27 @@ mountpoint to ``web/`` (and restart the ``salt-master`` daemon).
       file in the same pillar environment.
     - Salt versions prior to 2018.3.4 ignore the ``root`` parameter when
       ``mountpoint`` is set.
+
+.. _git-pillar-all_saltenvs:
+
+all_saltenvs
+~~~~~~~~~~~~
+
+.. versionadded:: 2018.3.4
+
+When ``__env__`` is specified as the branch name, ``all_saltenvs`` per-remote configuration parameter overrides the logic Salt uses to map branches/tags to pillar environments (i.e. pillarenvs). This allows a single branch/tag to appear in all saltenvs. Example:
+
+.. code-block:: yaml
+
+    ext_pillar:
+      - git:
+        - __env__ https://mydomain.tld/top.git
+          - all_saltenvs: master
+        - __env__ https://mydomain.tld/pillar-nginx.git:
+          - mountpoint: web/server/
+        - __env__ https://mydomain.tld/pillar-appdata.git:
+          - mountpoint: web/server/
+
 '''
 from __future__ import absolute_import, print_function, unicode_literals
 
@@ -348,7 +369,7 @@ from salt.pillar import Pillar
 from salt.ext import six
 
 PER_REMOTE_OVERRIDES = ('env', 'root', 'ssl_verify', 'refspecs')
-PER_REMOTE_ONLY = ('name', 'mountpoint')
+PER_REMOTE_ONLY = ('name', 'mountpoint', 'all_saltenvs')
 GLOBAL_ONLY = ('base', 'branch')
 
 # Set up logging

--- a/salt/utils/gitfs.py
+++ b/salt/utils/gitfs.py
@@ -984,6 +984,11 @@ class GitProvider(object):
         Resolve dynamically-set branch
         '''
         if self.role == 'git_pillar' and self.branch == '__env__':
+            try:
+                return self.all_saltenvs
+            except AttributeError:
+                # all_saltenvs not configured for this remote
+                pass
             target = self.opts.get('pillarenv') \
                 or self.opts.get('saltenv') \
                 or 'base'
@@ -2971,7 +2976,11 @@ class GitPillar(GitBase):
             cachedir = self.do_checkout(repo)
             if cachedir is not None:
                 # Figure out which environment this remote should be assigned
-                if repo.env:
+                if repo.branch == '__env__' and hasattr(repo, 'all_saltenvs'):
+                    env = self.opts.get('pillarenv') \
+                        or self.opts.get('saltenv') \
+                        or self.opts.get('git_pillar_base')
+                elif repo.env:
                     env = repo.env
                 else:
                     env = 'base' if repo.branch == repo.base else repo.get_checkout_target()

--- a/tests/integration/pillar/test_git_pillar.py
+++ b/tests/integration/pillar/test_git_pillar.py
@@ -460,6 +460,34 @@ class GitPythonMixin(object):
             ''')
         self.assertEqual(ret, expected)
 
+    def test_all_saltenvs(self):
+        '''
+        Test all_saltenvs parameter.
+        '''
+        ret = self.get_pillar('''\
+            file_ignore_regex: []
+            file_ignore_glob: []
+            git_pillar_provider: gitpython
+            cachedir: {cachedir}
+            extension_modules: {extmods}
+            pillarenv: dev
+            ext_pillar:
+              - git:
+                - __env__ {url_extra_repo}:
+                  - all_saltenvs: master
+                - __env__ {url}:
+                  - mountpoint: nowhere
+            ''')
+        self.assertEqual(
+            ret,
+            {'branch': 'dev',
+             'motd': 'The force will be with you. Always.',
+             'mylist': ['dev'],
+             'mydict': {'dev': True,
+                        'nested_list': ['dev'],
+                        'nested_dict': {'dev': True}}}
+        )
+
 
 @destructiveTest
 @skipIf(NO_MOCK, NO_MOCK_REASON)
@@ -1613,6 +1641,107 @@ class TestPygit2SSH(GitPillarSSHTestBase):
             ''')
         self.assertEqual(ret, expected)
 
+    @requires_system_grains
+    def test_all_saltenvs(self, grains):
+        '''
+        Test all_saltenvs parameter.
+        '''
+        expected = {'branch': 'dev',
+             'motd': 'The force will be with you. Always.',
+             'mylist': ['dev'],
+             'mydict': {'dev': True,
+                        'nested_list': ['dev'],
+                        'nested_dict': {'dev': True}
+                       }
+        }
+
+        # Test with passphraseless key and global credential options
+        ret = self.get_pillar('''\
+            file_ignore_regex: []
+            file_ignore_glob: []
+            git_pillar_provider: pygit2
+            git_pillar_pubkey: {pubkey_nopass}
+            git_pillar_privkey: {privkey_nopass}
+            cachedir: {cachedir}
+            extension_modules: {extmods}
+            pillarenv: dev
+            ext_pillar:
+              - git:
+                - __env__ {url_extra_repo}:
+                  - all_saltenvs: master
+                - __env__ {url}:
+                  - mountpoint: nowhere
+            ''')
+        self.assertEqual(ret, expected)
+
+        # Test with passphraseless key and per-repo credential options
+        ret = self.get_pillar('''\
+            file_ignore_regex: []
+            file_ignore_glob: []
+            git_pillar_provider: pygit2
+            cachedir: {cachedir}
+            extension_modules: {extmods}
+            pillarenv: dev
+            ext_pillar:
+              - git:
+                - __env__ {url_extra_repo}:
+                  - all_saltenvs: master
+                  - pubkey: {pubkey_nopass}
+                  - privkey: {privkey_nopass}
+                - __env__ {url}:
+                  - mountpoint: nowhere
+                  - pubkey: {pubkey_nopass}
+                  - privkey: {privkey_nopass}
+            ''')
+        self.assertEqual(ret, expected)
+
+        if grains['os_family'] == 'Debian':
+            # passphrase-protected currently does not work here
+            return
+
+        # Test with passphrase-protected key and global credential options
+        ret = self.get_pillar('''\
+            file_ignore_regex: []
+            file_ignore_glob: []
+            git_pillar_provider: pygit2
+            git_pillar_pubkey: {pubkey_withpass}
+            git_pillar_privkey: {privkey_withpass}
+            git_pillar_passphrase: {passphrase}
+            cachedir: {cachedir}
+            extension_modules: {extmods}
+            pillarenv: dev
+            ext_pillar:
+              - git:
+                - __env__ {url_extra_repo}:
+                  - all_saltenvs: master
+                - __env__ {url}:
+                  - mountpoint: nowhere
+            ''')
+        self.assertEqual(ret, expected)
+
+        # Test with passphrase-protected key and per-repo credential options
+        ret = self.get_pillar('''\
+            file_ignore_regex: []
+            file_ignore_glob: []
+            git_pillar_provider: pygit2
+            cachedir: {cachedir}
+            extension_modules: {extmods}
+            pillarenv: dev
+            ext_pillar:
+              - git:
+                - __env__ {url_extra_repo}:
+                  - all_saltenvs: master
+                  - pubkey: {pubkey_nopass}
+                  - privkey: {privkey_nopass}
+                  - passphrase: {passphrase}
+                - __env__ {url}:
+                  - mountpoint: nowhere
+                  - pubkey: {pubkey_nopass}
+                  - privkey: {privkey_nopass}
+                  - passphrase: {passphrase}
+            ''')
+        self.assertEqual(ret, expected)
+
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
 @skipIf(_windows_or_mac(), 'minion is windows or mac')
@@ -1961,6 +2090,34 @@ class TestPygit2HTTP(GitPillarHTTPTestBase):
                   - env: base
             ''')
         self.assertEqual(ret, expected)
+
+    def test_all_saltenvs(self):
+        '''
+        Test all_saltenvs parameter.
+        '''
+        ret = self.get_pillar('''\
+            file_ignore_regex: []
+            file_ignore_glob: []
+            git_pillar_provider: pygit2
+            cachedir: {cachedir}
+            extension_modules: {extmods}
+            pillarenv: dev
+            ext_pillar:
+              - git:
+                - __env__ {url_extra_repo}:
+                  - all_saltenvs: master
+                - __env__ {url}:
+                  - mountpoint: nowhere
+            ''')
+        self.assertEqual(
+            ret,
+            {'branch': 'dev',
+             'motd': 'The force will be with you. Always.',
+             'mylist': ['dev'],
+             'mydict': {'dev': True,
+                        'nested_list': ['dev'],
+                        'nested_dict': {'dev': True}}}
+        )
 
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
@@ -2531,3 +2688,34 @@ class TestPygit2AuthenticatedHTTP(GitPillarHTTPTestBase):
                   - env: base
             ''')
         self.assertEqual(ret, expected)
+
+    def test_all_saltenvs(self):
+        '''
+        Test all_saltenvs parameter.
+        '''
+        ret = self.get_pillar('''\
+            file_ignore_regex: []
+            file_ignore_glob: []
+            git_pillar_provider: pygit2
+            git_pillar_user: {user}
+            git_pillar_password: {password}
+            git_pillar_insecure_auth: True
+            cachedir: {cachedir}
+            extension_modules: {extmods}
+            pillarenv: dev
+            ext_pillar:
+              - git:
+                - __env__ {url_extra_repo}:
+                  - all_saltenvs: master
+                - __env__ {url}:
+                  - mountpoint: nowhere
+            ''')
+        self.assertEqual(
+            ret,
+            {'branch': 'dev',
+             'motd': 'The force will be with you. Always.',
+             'mylist': ['dev'],
+             'mydict': {'dev': True,
+                        'nested_list': ['dev'],
+                        'nested_dict': {'dev': True}}}
+        )


### PR DESCRIPTION
### What does this PR do?

On the road to support more options a-la-gitfs (#32245), this PR implements the `all_saltenvs` parameter.

### What issues does this PR fix or reference?

Part of #32245.

### Previous Behavior
Unable to map a git_pillar remote to all pillarenvs.

### New Behavior
With `all_saltenvs` this is now possible

### Tests written?

Yes

### Commits signed with GPG?

Yes