### PR TITLE
Fix failing `integration.cli.test_grains.GrainsTargetingTest.test_grains_targeting_disconnected`

### DIFF
--- a/tests/integration/cli/test_grains.py
+++ b/tests/integration/cli/test_grains.py
@@ -15,6 +15,7 @@
 # Import Python libs
 from __future__ import absolute_import, print_function, unicode_literals
 import os
+import logging
 
 # Import Salt Libs
 import salt.utils.files
@@ -22,6 +23,8 @@ import salt.utils.files
 # Import Salt Testing Libs
 from tests.support.case import ShellCase, SSHCase
 from tests.support.helpers import flaky
+
+log = logging.getLogger(__name__)
 
 
 class GrainsTargetingTest(ShellCase):
@@ -66,18 +69,13 @@ class GrainsTargetingTest(ShellCase):
         with salt.utils.files.fopen(key_file, 'a'):
             pass
 
-        import logging
-        log = logging.getLogger(__name__)
         # ping disconnected minion and ensure it times out and returns with correct message
         try:
-            if salt.utils.platform.is_windows():
-                cmd_str = '-t 1 -G "id:disconnected" test.ping'
-            else:
-                cmd_str = '-t 1 -G \'id:disconnected\' test.ping'
             ret = ''
             for item in self.run_salt('-t 1 -G "id:disconnected" test.ping', timeout=40):
                 if item != 'disconnected:':
                     ret = item.strip()
+                    break
             assert ret == test_ret
         finally:
             os.unlink(key_file)

--- a/tests/integration/states/test_file.py
+++ b/tests/integration/states/test_file.py
@@ -2771,7 +2771,7 @@ class FileTest(ModuleCase, SaltReturnAssertsMixin):
         self.assertSaltTrueReturn(ret)
 
         ret = self.run_state('file.keyvalue',
-                name=name, key_values={'logingracetime':'1m'}, separator=" ", uncomment=" #", key_ignore_case=True)
+                name=name, key_values={'logingracetime': '1m'}, separator=" ", uncomment=" #", key_ignore_case=True)
 
         with salt.utils.files.fopen(name, 'r') as fp_:
             file_contents = fp_.read()


### PR DESCRIPTION
On the develop branch the last line is not what's being asserted against:
```
['disconnected:',
 '    Minion did not return. [No response]',
 '    The minions may not have all finished running and any remaining minions will return upon completion. To look up the return data for this job later, run the following command:',
 '    ',
 '    salt-run jobs.lookup_jid 20181206232209819226']
```
As opposed to what was expected on 2018.3.x:
```
['disconnected:',
 '    Minion did not return. [No response]']
```

### What does this PR do?
Fix a failing test.

### Tests written?

No. Fixed.

### Commits signed with GPG?

Yes