### PR TITLE
Use newest upstream test-kitchen

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,7 @@
 
 source 'https://rubygems.org'
 
-# Point this back at the test-kitchen package after 1.23.3 is relased
-gem 'test-kitchen', :git => 'https://github.com/dwoz/test-kitchen.git', :branch => 'winrm_opts'
+gem 'test-kitchen', '~>1.23.3'
 gem 'kitchen-salt', '~>0.2'
 gem 'kitchen-sync'
 gem 'git'


### PR DESCRIPTION
### What does this PR do?

Point Gemfile at newest test-kitchen release which supports winrm timeout config.

### Tests written?

No

### Commits signed with GPG?

Yes