### PR TITLE
gitfs/git_pillar: Fix UnicodeDecodeError while cleaning stale refs

### DIFF
--- a/salt/utils/gitfs.py
+++ b/salt/utils/gitfs.py
@@ -584,10 +584,20 @@ class GitProvider(object):
         '''
         cleaned = []
         cmd_str = 'git remote prune origin'
+
+        # Attempt to force all output to plain ascii english, which is what some parsing code
+        # may expect.
+        # According to stackoverflow (http://goo.gl/l74GC8), we are setting LANGUAGE as well
+        # just to be sure.
+        env = os.environ.copy()
+        env["LANGUAGE"] = "C"
+        env["LC_ALL"] = "C"
+
         cmd = subprocess.Popen(
             shlex.split(cmd_str),
             close_fds=not salt.utils.platform.is_windows(),
             cwd=os.path.dirname(self.gitdir),
+            env=env,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT)
         output = cmd.communicate()[0]


### PR DESCRIPTION
### What does this PR do?
It fixes:
```
[salt.utils.gitfs :2341][ERROR   ][866] Exception caught while fetching gitfs remote '__env__ https://git.example.org/somerepo.git': 'ascii' codec can't decode byte 0xc3 in position 0: ordinal not in range(128)
```

The environement variables are not sanitized, and as we use `LANG=fr_FR.utf8`. Calling the same command prints non-ascii:
```
root@salt-master:/var/cache/salt/master/git_pillar/51958f355141ebce331e186a5230c20f2d0264025054eeb2fc2c5b3b81ab53a0# git remote prune origin
Élimination de origin
URL : https://git.example.org/somerepo.git
* [éliminé] origin/toto
```

Inspired by https://github.com/gitpython-developers/GitPython/blob/a8591a094a768d73e6efb5a698f74d354c989291/git/cmd.py#L694

### What issues does this PR fix or reference?
None

### Previous Behavior
An exception is raised (and the flow is stopped, but will be successful on the next try as the remote is now pruned):
```
2018-12-06 11:57:11,495 [salt.utils.gitfs :2341][ERROR   ][866] Exception caught while fetching gitfs remote '__env__ https://git.example.org/somerepo.git': 'ascii' codec can't decode byte 0xc3 in position 0: ordinal not in range(128)
Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/salt/utils/gitfs.py", line 2329, in fetch_remotes
    if repo.fetch():
  File "/usr/lib/python2.7/dist-packages/salt/utils/gitfs.py", line 757, in fetch
    return self._fetch()
  File "/usr/lib/python2.7/dist-packages/salt/utils/gitfs.py", line 1271, in _fetch
    cleaned = self.clean_stale_refs()
  File "/usr/lib/python2.7/dist-packages/salt/utils/gitfs.py", line 605, in clean_stale_refs
    if line.startswith(marker):
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 0: ordinal not in range(128)
```

### New Behavior
No more exception. And the fetch succesfuly terminates.

### Tests written?

No

### Commits signed with GPG?

Yes