### PR TITLE
fix default ipc_write_buffer always is 0 if not set ipc_write_buffer …

### DIFF
--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -3812,8 +3812,6 @@ def apply_minion_config(overrides=None,
 
     if overrides.get('ipc_write_buffer', '') == 'dynamic':
         opts['ipc_write_buffer'] = _DFLT_IPC_WBUFFER
-    if 'ipc_write_buffer' not in overrides:
-        opts['ipc_write_buffer'] = 0
 
     # Make sure hash_type is lowercase
     opts['hash_type'] = opts['hash_type'].lower()
@@ -3963,8 +3961,7 @@ def apply_master_config(overrides=None, defaults=None):
 
     if overrides.get('ipc_write_buffer', '') == 'dynamic':
         opts['ipc_write_buffer'] = _DFLT_IPC_WBUFFER
-    if 'ipc_write_buffer' not in overrides:
-        opts['ipc_write_buffer'] = 0
+
     using_ip_for_id = False
     append_master = False
     if not opts.get('id'):


### PR DESCRIPTION
### What does this PR do?
The ipc_write_buffer always is 0 if not set ipc_write_buffer in config file

In my case, the memory of IPCMessagePublisher process use a lot of memory and has been growing
After I review the code, I found that it was caused by not setting the limit of write buffer

### What issues does this PR fix or reference?


### Tests written?
No

### Commits signed with GPG?

Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.