### PR TITLE
Mark integration.modules.test_cp.CPModuleTest.test_get_file_str_https as flaky

### DIFF
--- a/tests/integration/modules/test_cp.py
+++ b/tests/integration/modules/test_cp.py
@@ -15,6 +15,7 @@ import textwrap
 # Import Salt Testing libs
 from tests.support.case import ModuleCase
 from tests.support.helpers import (
+    flaky,
     get_unused_localhost_port,
     skip_if_not_root,
     with_tempfile)
@@ -385,6 +386,7 @@ class CPModuleTest(ModuleCase):
             ])
         self.assertEqual(ret, False)
 
+    @flaky
     def test_get_file_str_https(self):
         '''
         cp.get_file_str with https:// source given


### PR DESCRIPTION
There appears to be something weird with the DNS resolution on the AWS Arch boxes. This test fails because it fails to resolve repo.saltstack.com, and I can reproduce this using an AWS instance via TestKitchen, but if I run the test again it works.

By marking this test as flaky we can make it reattempt (when necessary) and get it to pass.

Resolves https://github.com/saltstack/salt-jenkins/issues/1225 (hopefully)