### PR TITLE
The user profile is loaded the logon methods

### DIFF
--- a/salt/utils/win_runas.py
+++ b/salt/utils/win_runas.py
@@ -127,9 +127,6 @@ def runas(cmdLine, username, password=None, cwd=None):
         # Login without a password. This always returns an elevated token.
         user_token = salt.platform.win.logon_msv1_s4u(username).Token
 
-    # Make sure the user's profile is loaded.
-    handle_reg = win32profile.LoadUserProfile(user_token, {'UserName': username})
-
     # Get a linked user token to elevate if needed
     elevation_type = win32security.GetTokenInformation(
         user_token, win32security.TokenElevationType
@@ -217,8 +214,6 @@ def runas(cmdLine, username, password=None, cwd=None):
     with os.fdopen(fd_err, 'r') as f_err:
         stderr = f_err.read()
         ret['stderr'] = stderr
-
-    win32profile.UnloadUserProfile(user_token, handle_reg)
 
     salt.platform.win.kernel32.CloseHandle(hProcess)
     win32api.CloseHandle(user_token)


### PR DESCRIPTION
### What does this PR do?

Fix for `integration.states.test_pip_state.PipStateTest.test_issue_6912_wrong_owner` failure. Do not call load user profile since it will already be loaded from the logon methods.


### Tests written?

No - Fixing tests

### Commits signed with GPG?

Yes