### PR TITLE
support cachedir, pki_dir for salt-ssh

### DIFF
--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -2925,6 +2925,7 @@ class SaltSSHOptionParser(six.with_metaclass(OptionParserMeta,
                                              OutputOptionsMixIn,
                                              SaltfileMixIn,
                                              HardCrashMixin,
+                                             CacheDirMixIn,
                                              NoParseMixin)):
 
     usage = '%prog [options] \'<target>\' <function> [arguments]'

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -3156,6 +3156,11 @@ class SaltSSHOptionParser(six.with_metaclass(OptionParserMeta,
             help='If hostname is not found in the roster, store the information'
                  'into the default roster file (flat).'
         )
+        auth_group.add_option(
+            '--pki-dir',
+            dest="pki_dir",
+            help=("Set the directory to load the pki keys.")
+        )
         self.add_option_group(auth_group)
 
         scan_group = optparse.OptionGroup(


### PR DESCRIPTION
### What does this PR do?
salt-ssh doesn't support `cachedir` option for now. And this option is important for __none root user__(as mentioned at document: [RUNNING SALT SSH AS NON-ROOT USER](https://docs.saltstack.com/en/latest/topics/ssh/#running-salt-ssh-as-non-root-user)). So this PR is to fix it

### What issues does this PR fix or reference?
#44073 
#38336

### Previous Behavior
Not support `--cachedir` option

### New Behavior
You can now specify `--cachedir` option now.

### Tests written?

No

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
