### PR TITLE
Back-port #49355 to 2018.3

### DIFF
--- a/salt/modules/debian_ip.py
+++ b/salt/modules/debian_ip.py
@@ -393,7 +393,7 @@ def __within(within=None, errmsg=None, dtype=None):
 
 def __space_delimited_list(value):
     '''validate that a value contains one or more space-delimited values'''
-    if isinstance(value, str):
+    if isinstance(value, six.string_types):
         value = value.strip().split()
 
     if hasattr(value, '__iter__') and value != []:

--- a/salt/modules/debian_ip.py
+++ b/salt/modules/debian_ip.py
@@ -1707,6 +1707,11 @@ def build_interface(iface, iface_type, enabled, **settings):
     if 'proto' not in settings:
         settings['proto'] = 'static'
 
+    if 'ipv6ipaddr' not in settings and 'ipv6ipaddrs' in settings:
+        settings['ipv6addr'] = settings['ipv6ipaddrs'].pop(0)
+    if 'ipaddr' not in settings and 'ipaddrs' in settings:
+        settings['ipaddr'] = settings['ipaddrs'].pop(0)
+
     if iface_type == 'slave':
         settings['slave'] = 'yes'
         if 'master' not in settings:

--- a/salt/modules/debian_ip.py
+++ b/salt/modules/debian_ip.py
@@ -629,7 +629,12 @@ def _parse_interfaces(interface_files=None):
                             attrname = attr
                         (valid, value, errmsg) = _validate_interface_option(
                             attr, valuestr, addrfam)
-                        iface_dict[attrname] = value
+                        if attrname == 'address' and 'address' in iface_dict:
+                            if 'addresses' not in iface_dict:
+                                iface_dict['addresses'] = []
+                            iface_dict['addresses'].append(value)
+                        else:
+                            iface_dict[attrname] = value
 
                     elif attr in _REV_ETHTOOL_CONFIG_OPTS:
                         if 'ethtool' not in iface_dict:
@@ -1709,11 +1714,6 @@ def build_interface(iface, iface_type, enabled, **settings):
 
     if 'proto' not in settings:
         settings['proto'] = 'static'
-
-    if 'ipv6ipaddr' not in settings and 'ipv6ipaddrs' in settings:
-        settings['ipv6ipaddr'] = settings['ipv6ipaddrs'].pop(0)
-    if 'ipaddr' not in settings and 'ipaddrs' in settings:
-        settings['ipaddr'] = settings['ipaddrs'].pop(0)
 
     if iface_type == 'slave':
         settings['slave'] = 'yes'

--- a/salt/modules/debian_ip.py
+++ b/salt/modules/debian_ip.py
@@ -420,7 +420,7 @@ DEBIAN_ATTR_TO_SALT_ATTR_MAP['hwaddress'] = 'hwaddress'
 
 IPV4_VALID_PROTO = ['bootp', 'dhcp', 'static', 'manual', 'loopback', 'ppp']
 
-IPV6_ATTR_MAP = {
+IPV4_ATTR_MAP = {
     'proto': __within(IPV4_VALID_PROTO, dtype=six.text_type),
     # ipv4 static & manual
     'address': __ipv4_quad,

--- a/salt/modules/debian_ip.py
+++ b/salt/modules/debian_ip.py
@@ -1708,7 +1708,7 @@ def build_interface(iface, iface_type, enabled, **settings):
         settings['proto'] = 'static'
 
     if 'ipv6ipaddr' not in settings and 'ipv6ipaddrs' in settings:
-        settings['ipv6addr'] = settings['ipv6ipaddrs'].pop(0)
+        settings['ipv6ipaddr'] = settings['ipv6ipaddrs'].pop(0)
     if 'ipaddr' not in settings and 'ipaddrs' in settings:
         settings['ipaddr'] = settings['ipaddrs'].pop(0)
 

--- a/salt/modules/debian_ip.py
+++ b/salt/modules/debian_ip.py
@@ -407,6 +407,7 @@ SALT_ATTR_TO_DEBIAN_ATTR_MAP = {
     'search': 'dns-search',
     'hwaddr': 'hwaddress',  # TODO: this limits bootp functionality
     'ipaddr': 'address',
+    'ipaddrs': 'addresses',
 }
 
 
@@ -419,10 +420,11 @@ DEBIAN_ATTR_TO_SALT_ATTR_MAP['hwaddress'] = 'hwaddress'
 
 IPV4_VALID_PROTO = ['bootp', 'dhcp', 'static', 'manual', 'loopback', 'ppp']
 
-IPV4_ATTR_MAP = {
+IPV6_ATTR_MAP = {
     'proto': __within(IPV4_VALID_PROTO, dtype=six.text_type),
     # ipv4 static & manual
     'address': __ipv4_quad,
+    'addresses': __anything,
     'netmask': __ipv4_netmask,
     'broadcast': __ipv4_quad,
     'metric':  __int,
@@ -473,6 +475,7 @@ IPV6_ATTR_MAP = {
     'proto': __within(IPV6_VALID_PROTO),
     # ipv6 static & manual
     'address': __ipv6,
+    'addresses': __anything,
     'netmask': __ipv6_netmask,
     'broadcast': __ipv6,
     'gateway': __ipv6,  # supports a colon-delimited list

--- a/salt/states/network.py
+++ b/salt/states/network.py
@@ -18,6 +18,21 @@ all interfaces are ignored unless specified.
 
     Other platforms are not yet supported.
 
+.. note::
+
+    On Debian-based systems, networking configuration can be specified
+    in `/etc/network/interfaces` or via included files such as (by default)
+    `/etc/network/interfaces.d/*`. This can be problematic for configuration
+    management. It is recommended to use either `file.managed` *or*
+    `network.managed`.
+
+    If using `network.managed`, it can be useful to ensure `interfaces.d/`
+    is empty. This can be done using:
+
+        /etc/network/interfaces.d:
+          file.directory:
+            - clean: True
+
 .. code-block:: yaml
 
     system:

--- a/salt/states/network.py
+++ b/salt/states/network.py
@@ -217,6 +217,7 @@ all interfaces are ignored unless specified.
       network.managed:
         - name: lo
         - type: eth
+        - proto: loopback
         - onboot: yes
         - userctl: no
         - ipv6_autoconf: no

--- a/salt/states/network.py
+++ b/salt/states/network.py
@@ -9,9 +9,12 @@ all interfaces are ignored unless specified.
 
 .. note::
 
-    Prior to version 2014.1.0, only RedHat-based systems (RHEL,
-    CentOS, Scientific Linux, etc.) are supported. Support for Debian/Ubuntu is
-    new in 2014.1.0 and should be considered experimental.
+    RedHat-based systems (RHEL, CentOS, Scientific, etc.)
+    have been supported since version 2014.1.0.
+
+    Debian-based systems (Debian, Ubuntu, etc.) have been
+    supported since version 2017.7.0. The following options
+    are not supported: ipaddr_start, and ipaddr_end.
 
     Other platforms are not yet supported.
 
@@ -31,9 +34,17 @@ all interfaces are ignored unless specified.
       network.managed:
         - enabled: True
         - type: eth
-        - proto: none
-        - ipaddr: 10.1.0.1
+        - proto: static
+        - ipaddr: 10.1.0.7
         - netmask: 255.255.255.0
+        - gateway: 10.1.0.1
+        - enable_ipv6: true
+        - ipv6proto: static
+        - ipv6ipaddrs:
+          - 2001:db8:dead:beef::3/64
+          - 2001:db8:dead:beef::7/64
+        - ipv6gateway: 2001:db8:dead:beef::1
+        - ipv6netmask: 64
         - dns:
           - 8.8.8.8
           - 8.8.4.4
@@ -121,12 +132,11 @@ all interfaces are ignored unless specified.
         - type: bond
         - ipaddr: 10.1.0.1
         - netmask: 255.255.255.0
-        - mode: active-backup
+        - mode: gre
         - proto: static
         - dns:
           - 8.8.8.8
           - 8.8.4.4
-        - ipv6:
         - enabled: False
         - slaves: eth2 eth3
         - require:
@@ -202,6 +212,62 @@ all interfaces are ignored unless specified.
         - require:
           - network: eth4
 
+    eth6:
+      network.managed:
+        - type: eth
+        - noifupdown: True
+
+        # IPv4
+        - proto: static
+        - ipaddr: 192.168.4.9
+        - netmask: 255.255.255.0
+        - gateway: 192.168.4.1
+        - enable_ipv6: True
+
+        # IPv6
+        - ipv6proto: static
+        - ipv6ipaddr: 2001:db8:dead:c0::3
+        - ipv6netmask: 64
+        - ipv6gateway: 2001:db8:dead:c0::1
+        # override shared; makes those options v4-only
+        - ipv6ttl: 15
+
+        # Shared
+        - mtu: 1480
+        - ttl: 18
+        - dns:
+          - 8.8.8.8
+          - 8.8.4.4
+
+    eth7:
+        - type: eth
+        - proto: static
+        - ipaddr: 10.1.0.7
+        - netmask: 255.255.255.0
+        - gateway: 10.1.0.1
+        - enable_ipv6: True
+        - ipv6proto: static
+        - ipv6ipaddr: 2001:db8:dead:beef::3
+        - ipv6netmask: 64
+        - ipv6gateway: 2001:db8:dead:beef::1
+        - noifupdown: True
+
+    eth8:
+      network.managed:
+        - enabled: True
+        - type: eth
+        - proto: static
+        - enable_ipv6: true
+        - ipv6proto: static
+        - ipv6ipaddrs:
+          - 2001:db8:dead:beef::3/64
+          - 2001:db8:dead:beef::7/64
+        - ipv6gateway: 2001:db8:dead:beef::1
+        - ipv6netmask: 64
+        - dns:
+          - 8.8.8.8
+          - 8.8.4.4
+
     system:
       network.system:
         - enabled: True
@@ -222,13 +288,6 @@ all interfaces are ignored unless specified.
         - userctl: no
         - ipv6_autoconf: no
         - enable_ipv6: true
-        - ipaddrs:
-          - 127.0.0.1/8
-          - 10.1.0.4/32
-          - 10.1.0.12/32
-        - ipv6addrs:
-          - fc00::1/128
-          - fc00::100/128
 
     .. note::
         Apply changes to hostname immediately.

--- a/salt/templates/debian_ip/debian_eth.jinja
+++ b/salt/templates/debian_ip/debian_eth.jinja
@@ -30,8 +30,12 @@
 {%endif%}{% if interface.unit               %}    unit {{interface.unit}}
 {%endif%}{% if interface.options            %}    options {{interface.options}}
 {%endif%}{% if interface.master             %}    bond-master {{interface.master}}
-{%endif%}{% if interface.dns_nameservers    %}    dns-nameservers {%for item in interface.dns_nameservers %}{{item}} {%endfor%}
-{%endif%}{% if interface.dns_search         %}    dns-search {% for item in interface.dns_search %}{{item}} {%endfor%}
+{%endif%}{% if interface.dns_nameservers    %}    dns-nameservers {%
+    if interface.dns_nameservers is string %}{{ interface.dns_nameservers }}{%
+    else %}{{ interface.dns_nameservers|join(" ") }}{% endif %}
+{%endif%}{% if interface.dns_search         %}    dns-search {%
+    if interface.dns_search is string %}{{interface.dns_search }}{%
+    else %}{{ interface.dns_search|join(" ") }}{% endif %}
 {%endif%}{% if interface.ethtool            %}{%for item in interface.ethtool_keys %}    {{item}} {{interface.ethtool[item]}}
 {%endfor%}{%endif%}{% if interface.bonding  %}{%for item in interface.bonding_keys %}    bond-{{item}} {{interface.bonding[item]}}
 {%endfor%}{%endif%}{% if interface.bridging %}{%for item in interface.bridging_keys %}    bridge_{{item}} {{interface.bridging[item]}}
@@ -94,8 +98,12 @@
 {%endif%}{% if interface.unit               %}    unit {{interface.unit}}
 {%endif%}{% if interface.options            %}    options {{interface.options}}
 {%endif%}{% if interface.master             %}    bond-master {{interface.master}}
-{%endif%}{% if interface.dns_nameservers    %}    dns-nameservers {%for item in interface.dns_nameservers %}{{item}} {%endfor%}
-{%endif%}{% if interface.dns_search         %}    dns-search {% for item in interface.dns_search %}{{item}} {%endfor%}
+{%endif%}{% if interface.dns_nameservers    %}    dns-nameservers {%
+    if interface.dns_nameservers is string %}{{ interface.dns_nameservers }}{%
+    else %}{{ interface.dns_nameservers|join(" ") }}{% endif %}
+{%endif%}{% if interface.dns_search         %}    dns-search {%
+    if interface.dns_search is string %}{{interface.dns_search }}{%
+    else %}{{ interface.dns_search|join(" ") }}{% endif %}
 {%endif%}{% if interface.ethtool            %}{%for item in interface.ethtool_keys %}    {{item}} {{interface.ethtool[item]}}
 {%endfor%}{%endif%}{% if interface.bonding  %}{%for item in interface.bonding_keys %}    bond-{{item}} {{interface.bonding[item]}}
 {%endfor%}{%endif%}{% if interface.bridging %}{%for item in interface.bridging_keys %}    bridge_{{item}} {{interface.bridging[item]}}

--- a/salt/templates/debian_ip/debian_eth.jinja
+++ b/salt/templates/debian_ip/debian_eth.jinja
@@ -5,7 +5,8 @@
 {% if interface.hwaddress                   %}    hwaddress {{interface.hwaddress}}
 {%endif%}{% if interface.vlan_raw_device    %}    vlan-raw-device {{interface.vlan_raw_device}}
 {%endif%}{% if interface.address            %}    address {{interface.address}}
-{%endif%}{% if interface.netmask            %}    netmask {{interface.netmask}}
+{%endif%}{% if interface.addresses          %}{%for addr in interface.addresses %}    address {{addr}}
+{%endfor%}{%endif%}{% if interface.netmask  %}    netmask {{interface.netmask}}
 {%endif%}{% if interface.broadcast          %}    broadcast {{interface.broadcast}}
 {%endif%}{% if interface.metric             %}    metric {{interface.metric}}
 {%endif%}{% if interface.gateway            %}    gateway {{interface.gateway}}
@@ -73,7 +74,8 @@
 {%endif%}{% if interface.dhcp               %}    dhcp {{interface.dhcp}}{# END V6ONLOPTS #}
 {%endif%}{% if interface.vlan_raw_device    %}    vlan-raw-device {{interface.vlan_raw_device}}
 {%endif%}{% if interface.address            %}    address {{interface.address}}
-{%endif%}{% if interface.netmask            %}    netmask {{interface.netmask}}
+{%endif%}{% if interface.addresses          %}{% for addr in interface.addresses %}    address {{addr}}
+{%endfor%}{%endif%}{% if interface.netmask  %}    netmask {{interface.netmask}}
 {%endif%}{% if interface.broadcast          %}    broadcast {{interface.broadcast}}
 {%endif%}{% if interface.metric             %}    metric {{interface.metric}}
 {%endif%}{% if interface.gateway            %}    gateway {{interface.gateway}}

--- a/tests/unit/modules/test_debian_ip.py
+++ b/tests/unit/modules/test_debian_ip.py
@@ -174,6 +174,284 @@ class DebianIpTestCase(TestCase, LoaderModuleMockMixin):
             with patch.object(jinja2.Environment, 'get_template', mock):
                 self.assertEqual(debian_ip.get_interface('lo'), '')
 
+    # 'build_interface' function tests: 12
+
+    def test_build_interface(self):
+        '''
+        Test if salt correctly builds interfaces.
+        '''
+        interfaces = [
+                # IPv4-only interface; single address
+                {'iface_name': 'eth1', 'iface_type': 'eth', 'enabled': True,
+                    'settings': {
+                        'proto': 'static',
+                        'ipaddr': '192.168.4.9',
+                        'netmask': '255.255.255.0',
+                        'gateway': '192.168.4.1',
+                        'enable_ipv6': False,
+                        'noifupdown': True,
+                        },
+                    'return': [
+                        'auto eth1\n',
+                        'iface eth1 inet static\n',
+                        '    address 192.168.4.9\n',
+                        '    netmask 255.255.255.0\n',
+                        '    gateway 192.168.4.1\n',
+                        '\n']},
+                # IPv6-only; single address
+                {'iface_name': 'eth2', 'iface_type': 'eth', 'enabled': True,
+                    'settings': {
+                        'proto': 'static',
+                        'ipv6proto': 'static',
+                        'ipv6ipaddr': '2001:db8:dead:beef::3',
+                        'ipv6netmask': '64',
+                        'ipv6gateway': '2001:db8:dead:beef::1',
+                        'enable_ipv6': True,
+                        'noifupdown': True,
+                        },
+                    'return': [
+                        'auto eth2\n',
+                        'iface eth2 inet6 static\n',
+                        '    address 2001:db8:dead:beef::3\n',
+                        '    netmask 64\n',
+                        '    gateway 2001:db8:dead:beef::1\n',
+                        '\n']},
+                # IPv4 and IPv6; shared/overridden settings
+                {'iface_name': 'eth3', 'iface_type': 'eth', 'enabled': True,
+                    'settings': {
+                        'proto': 'static',
+                        'ipaddr': '192.168.4.9',
+                        'netmask': '255.255.255.0',
+                        'gateway': '192.168.4.1',
+                        'ipv6proto': 'static',
+                        'ipv6ipaddr': '2001:db8:dead:beef::3',
+                        'ipv6netmask': '64',
+                        'ipv6gateway': '2001:db8:dead:beef::1',
+                        'ttl': '18', # shared
+                        'ipv6ttl': '15', # overriden for v6
+                        'mtu': '1480', # shared
+                        'enable_ipv6': True,
+                        'noifupdown': True,
+                        },
+                    'return': [
+                        'auto eth3\n',
+                        'iface eth3 inet static\n',
+                        '    address 192.168.4.9\n',
+                        '    netmask 255.255.255.0\n',
+                        '    gateway 192.168.4.1\n',
+                        '    ttl 18\n',
+                        '    mtu 1480\n',
+                        'iface eth3 inet6 static\n',
+                        '    address 2001:db8:dead:beef::3\n',
+                        '    netmask 64\n',
+                        '    gateway 2001:db8:dead:beef::1\n',
+                        '    ttl 15\n',
+                        '    mtu 1480\n',
+                        '\n']},
+                # Slave iface
+                {'iface_name': 'eth4', 'iface_type': 'slave', 'enabled': True,
+                    'settings': {
+                        'master': 'bond0',
+                        'noifupdown': True,
+                        },
+                    'return': [
+                        'auto eth4\n',
+                        'iface eth4 inet manual\n',
+                        '    bond-master bond0\n',
+                        '\n']},
+                # Bond; with address IPv4 and IPv6 address; slaves as string
+                {'iface_name': 'bond5', 'iface_type': 'bond', 'enabled': True,
+                    'settings': {
+                        'proto': 'static',
+                        'ipaddr': '10.1.0.14',
+                        'netmask': '255.255.255.0',
+                        'gateway': '10.1.0.1',
+                        'ipv6proto': 'static',
+                        'ipv6ipaddr': '2001:db8:dead:c0::3',
+                        'ipv6netmask': '64',
+                        'ipv6gateway': '2001:db8:dead:c0::1',
+                        'mode': '802.3ad',
+                        'slaves': 'eth4 eth5',
+                        'enable_ipv6': True,
+                        'noifupdown': True,
+                        },
+                    'return': [
+                        'auto bond5\n',
+                        'iface bond5 inet static\n',
+                        '    address 10.1.0.14\n',
+                        '    netmask 255.255.255.0\n',
+                        '    gateway 10.1.0.1\n',
+                        '    bond-ad_select 0\n',
+                        '    bond-downdelay 200\n',
+                        '    bond-lacp_rate 0\n',
+                        '    bond-miimon 100\n',
+                        '    bond-mode 4\n',
+                        '    bond-slaves eth4 eth5\n',
+                        '    bond-updelay 0\n',
+                        '    bond-use_carrier on\n',
+                        'iface bond5 inet6 static\n',
+                        '    address 2001:db8:dead:c0::3\n',
+                        '    netmask 64\n',
+                        '    gateway 2001:db8:dead:c0::1\n',
+                             # TODO: I suspect there should be more here.
+                        '\n']},
+                # Bond; with address IPv4 and IPv6 address; slaves as list
+                {'iface_name': 'bond6', 'iface_type': 'bond', 'enabled': True,
+                    'settings': {
+                        'proto': 'static',
+                        'ipaddr': '10.1.0.14',
+                        'netmask': '255.255.255.0',
+                        'gateway': '10.1.0.1',
+                        'ipv6proto': 'static',
+                        'ipv6ipaddr': '2001:db8:dead:c0::3',
+                        'ipv6netmask': '64',
+                        'ipv6gateway': '2001:db8:dead:c0::1',
+                        'mode': '802.3ad',
+                        # TODO: Need to add this support
+                        #'slaves': ['eth4', 'eth5'],
+                        'slaves': 'eth4 eth5',
+                        'enable_ipv6': True,
+                        'noifupdown': True,
+                        },
+                    'return': [
+                        'auto bond6\n',
+                        'iface bond6 inet static\n',
+                        '    address 10.1.0.14\n',
+                        '    netmask 255.255.255.0\n',
+                        '    gateway 10.1.0.1\n',
+                        '    bond-ad_select 0\n',
+                        '    bond-downdelay 200\n',
+                        '    bond-lacp_rate 0\n',
+                        '    bond-miimon 100\n',
+                        '    bond-mode 4\n',
+                        '    bond-slaves eth4 eth5\n',
+                        '    bond-updelay 0\n',
+                        '    bond-use_carrier on\n',
+                        'iface bond6 inet6 static\n',
+                        '    address 2001:db8:dead:c0::3\n',
+                        '    netmask 64\n',
+                        '    gateway 2001:db8:dead:c0::1\n',
+                             # TODO: I suspect there should be more here.
+                        '\n']},
+                # Bond VLAN; with IPv4 address
+                {'iface_name': 'bond1.7', 'iface_type': 'vlan', 'enabled': True,
+                    'settings': {
+                        'proto': 'static',
+                        'ipaddr': '10.7.0.8',
+                        'netmask': '255.255.255.0',
+                        'gateway': '10.7.0.1',
+                        'slaves': 'eth6 eth7',
+                        'mode': '802.3ad',
+                        'enable_ipv6': False,
+                        'noifupdown': True,
+                        },
+                    'return': [
+                        'auto bond1.7\n',
+                        'iface bond1.7 inet static\n',
+                        '    vlan-raw-device bond1\n',
+                        '    address 10.7.0.8\n',
+                        '    netmask 255.255.255.0\n',
+                        '    gateway 10.7.0.1\n',
+                        '    mode 802.3ad\n',
+                        '\n']},
+                # Bond; without address
+                {'iface_name': 'bond1.8', 'iface_type': 'vlan', 'enabled': True,
+                    'settings': {
+                        'proto': 'static',
+                        'slaves': 'eth6 eth7',
+                        'mode': '802.3ad',
+                        'enable_ipv6': False,
+                        'noifupdown': True,
+                        },
+                    'return': [
+                        'auto bond1.8\n',
+                        'iface bond1.8 inet static\n',
+                        '    vlan-raw-device bond1\n',
+                        '    mode 802.3ad\n',
+                        '\n']},
+                # DNS NS as list
+                {'iface_name': 'eth9', 'iface_type': 'eth', 'enabled': True,
+                    'settings': {
+                        'proto': 'static',
+                        'ipaddr': '192.168.4.9',
+                        'netmask': '255.255.255.0',
+                        'gateway': '192.168.4.1',
+                        'enable_ipv6': False,
+                        'noifupdown': True,
+                        'dns': ['8.8.8.8', '8.8.4.4'],
+                        },
+                    'return': [
+                        'auto eth9\n',
+                        'iface eth9 inet static\n',
+                        '    address 192.168.4.9\n',
+                        '    netmask 255.255.255.0\n',
+                        '    gateway 192.168.4.1\n',
+                        '    dns-nameservers 8.8.8.8 8.8.4.4\n',
+                        '\n']},
+                # DNS NS as string
+                {'iface_name': 'eth10', 'iface_type': 'eth', 'enabled': True,
+                    'settings': {
+                        'proto': 'static',
+                        'ipaddr': '192.168.4.9',
+                        'netmask': '255.255.255.0',
+                        'gateway': '192.168.4.1',
+                        'enable_ipv6': False,
+                        'noifupdown': True,
+                        'dns': '8.8.8.8 8.8.4.4',
+                        },
+                    'return': [
+                        'auto eth10\n',
+                        'iface eth10 inet static\n',
+                        '    address 192.168.4.9\n',
+                        '    netmask 255.255.255.0\n',
+                        '    gateway 192.168.4.1\n',
+                        '    dns-nameservers 8.8.8.8 8.8.4.4\n',
+                        '\n']},
+                # Loopback; with IPv4 and IPv6 address
+                {'iface_name': 'lo11', 'iface_type': 'loopback', 'enabled': True,
+                    'settings': {
+                        'proto': 'loopback',
+                        'ipaddr': '192.168.4.9',
+                        'netmask': '255.255.255.0',
+                        'gateway': '192.168.4.1',
+                        'ipv6ipaddr': 'fc00::1',
+                        'ipv6netmask': '128',
+                        'ipv6_autoconf': False,
+                        'enable_ipv6': True,
+                        'noifupdown': True,
+                        },
+                    'return': [
+                        'auto lo11\n',
+                        'iface lo11 inet loopback\n',
+                        '    address 192.168.4.9\n',
+                        '    netmask 255.255.255.0\n',
+                        '    gateway 192.168.4.1\n',
+                        'iface lo11 inet6 loopback\n',
+                        '    address fc00::1\n',
+                        '    netmask 128\n',
+                        '\n']},
+                # Loopback; without address
+                {'iface_name': 'lo12', 'iface_type': 'loopback', 'enabled': True,
+                    'settings': {
+                        'enable_ipv6': False,
+                        'noifupdown': True,
+                        },
+                    'return': [
+                        'auto lo12\n',
+                        'iface lo12 inet loopback\n',
+                        '\n']},
+                ]
+
+        for iface in interfaces:
+            # Skip tests that require __salt__['pkg.install']()
+            if iface['iface_type'] not in ['bridge', 'pppoe', 'vlan']:
+                self.assertListEqual(debian_ip.build_interface(
+                                            iface = iface['iface_name'],
+                                            iface_type = iface['iface_type'],
+                                            enabled = iface['enabled'],
+                                            **iface['settings']),
+                                     iface['return'])
+
     # 'up' function tests: 1
 
     def test_up(self):

--- a/tests/unit/modules/test_debian_ip.py
+++ b/tests/unit/modules/test_debian_ip.py
@@ -76,34 +76,6 @@ class DebianIpTestCase(TestCase, LoaderModuleMockMixin):
             with patch.dict(debian_ip.__grains__, {'osrelease': mock}):
                 self.assertTrue(debian_ip.build_bond('bond0', test='True'))
 
-    # 'build_interface' function tests: 1
-
-    def test_build_interface(self):
-        '''
-        Test if it builds an interface script for a network interface.
-        '''
-        with patch('salt.modules.debian_ip._write_file_ifaces',
-                   MagicMock(return_value='salt')):
-            self.assertEqual(debian_ip.build_interface('eth0', 'eth', 'enabled'),
-                             ['s\n', 'a\n', 'l\n', 't\n'])
-
-            self.assertTrue(debian_ip.build_interface('eth0', 'eth', 'enabled',
-                                                      test='True'))
-
-            with patch.object(debian_ip, '_parse_settings_eth',
-                              MagicMock(return_value={'routes': []})):
-                self.assertRaises(AttributeError, debian_ip.build_interface,
-                                  'eth0', 'bridge', 'enabled')
-
-                self.assertRaises(AttributeError, debian_ip.build_interface,
-                                  'eth0', 'slave', 'enabled')
-
-                self.assertRaises(AttributeError, debian_ip.build_interface,
-                                  'eth0', 'bond', 'enabled')
-
-            self.assertTrue(debian_ip.build_interface('eth0', 'eth', 'enabled',
-                                                      test='True'))
-
     # 'build_routes' function tests: 2
 
     def test_build_routes(self):
@@ -174,12 +146,34 @@ class DebianIpTestCase(TestCase, LoaderModuleMockMixin):
             with patch.object(jinja2.Environment, 'get_template', mock):
                 self.assertEqual(debian_ip.get_interface('lo'), '')
 
-    # 'build_interface' function tests: 12
+    # 'build_interface' function tests: 1
 
     def test_build_interface(self):
         '''
-        Test if salt correctly builds interfaces.
+        Test if it builds an interface script for a network interface.
         '''
+        with patch('salt.modules.debian_ip._write_file_ifaces',
+                   MagicMock(return_value='salt')):
+            self.assertEqual(debian_ip.build_interface('eth0', 'eth', 'enabled'),
+                             ['s\n', 'a\n', 'l\n', 't\n'])
+
+            self.assertTrue(debian_ip.build_interface('eth0', 'eth', 'enabled',
+                                                      test='True'))
+
+            with patch.object(debian_ip, '_parse_settings_eth',
+                              MagicMock(return_value={'routes': []})):
+                self.assertRaises(AttributeError, debian_ip.build_interface,
+                                  'eth0', 'bridge', 'enabled')
+
+                self.assertRaises(AttributeError, debian_ip.build_interface,
+                                  'eth0', 'slave', 'enabled')
+
+                self.assertRaises(AttributeError, debian_ip.build_interface,
+                                  'eth0', 'bond', 'enabled')
+
+            self.assertTrue(debian_ip.build_interface('eth0', 'eth', 'enabled',
+                                                      test='True'))
+
         interfaces = [
                 # IPv4-only interface; single address
                 {'iface_name': 'eth1', 'iface_type': 'eth', 'enabled': True,
@@ -408,7 +402,7 @@ class DebianIpTestCase(TestCase, LoaderModuleMockMixin):
                         '    dns-nameservers 8.8.8.8 8.8.4.4\n',
                         '\n']},
                 # Loopback; with IPv4 and IPv6 address
-                {'iface_name': 'lo11', 'iface_type': 'loopback', 'enabled': True,
+                {'iface_name': 'lo11', 'iface_type': 'eth', 'enabled': True,
                     'settings': {
                         'proto': 'loopback',
                         'ipaddr': '192.168.4.9',
@@ -431,8 +425,9 @@ class DebianIpTestCase(TestCase, LoaderModuleMockMixin):
                         '    netmask 128\n',
                         '\n']},
                 # Loopback; without address
-                {'iface_name': 'lo12', 'iface_type': 'loopback', 'enabled': True,
+                {'iface_name': 'lo12', 'iface_type': 'eth', 'enabled': True,
                     'settings': {
+                        'proto': 'loopback',
                         'enable_ipv6': False,
                         'noifupdown': True,
                         },

--- a/tests/unit/modules/test_debian_ip.py
+++ b/tests/unit/modules/test_debian_ip.py
@@ -221,9 +221,9 @@ class DebianIpTestCase(TestCase, LoaderModuleMockMixin):
                         'ipv6ipaddr': '2001:db8:dead:beef::3',
                         'ipv6netmask': '64',
                         'ipv6gateway': '2001:db8:dead:beef::1',
-                        'ttl': '18', # shared
-                        'ipv6ttl': '15', # overriden for v6
-                        'mtu': '1480', # shared
+                        'ttl': '18',  # shared
+                        'ipv6ttl': '15',  # overriden for v6
+                        'mtu': '1480',  # shared
                         'enable_ipv6': True,
                         'noifupdown': True,
                         },
@@ -441,9 +441,9 @@ class DebianIpTestCase(TestCase, LoaderModuleMockMixin):
             # Skip tests that require __salt__['pkg.install']()
             if iface['iface_type'] not in ['bridge', 'pppoe', 'vlan']:
                 self.assertListEqual(debian_ip.build_interface(
-                                            iface = iface['iface_name'],
-                                            iface_type = iface['iface_type'],
-                                            enabled = iface['enabled'],
+                                            iface=iface['iface_name'],
+                                            iface_type=iface['iface_type'],
+                                            enabled=iface['enabled'],
                                             **iface['settings']),
                                      iface['return'])
 


### PR DESCRIPTION
Backport https://github.com/saltstack/salt/pull/49355

Conflict:
  - salt/templates/debian_ip/debian_eth.jinja