### PR TITLE
Don't try to decrypt values without PGP header line

### DIFF
--- a/salt/renderers/gpg.py
+++ b/salt/renderers/gpg.py
@@ -372,7 +372,6 @@ def _decrypt_ciphertexts(cipher, translate_newlines=False):
         # it will conain unexpected trailing newline.
         return ret.rstrip('\n')
     else:
-        # Possibly just encrypted data without begin/end marks
         return cipher
 
 

--- a/salt/renderers/gpg.py
+++ b/salt/renderers/gpg.py
@@ -373,7 +373,7 @@ def _decrypt_ciphertexts(cipher, translate_newlines=False):
         return ret.rstrip('\n')
     else:
         # Possibly just encrypted data without begin/end marks
-        return _decrypt_ciphertext(cipher)
+        return cipher
 
 
 def _decrypt_object(obj, translate_newlines=False):

--- a/tests/unit/renderers/test_gpg.py
+++ b/tests/unit/renderers/test_gpg.py
@@ -44,11 +44,10 @@ class GPGTestCase(TestCase, LoaderModuleMockMixin):
         '''
         key_dir = '/etc/salt/gpgkeys'
         secret = 'Use more salt.'
-        crypted_long = '-----BEGIN PGP MESSAGE-----!@#$%^&*()_+-----END PGP MESSAGE-----'
-        crypted_short = '!@#$%^&*()_+'
+        crypted = '-----BEGIN PGP MESSAGE-----!@#$%^&*()_+-----END PGP MESSAGE-----'
 
         multisecret = 'password is {0} and salt is {0}'.format(secret)
-        multicrypted = 'password is {0} and salt is {0}'.format(crypted_long)
+        multicrypted = 'password is {0} and salt is {0}'.format(crypted)
 
         class GPGDecrypt(object):
             def communicate(self, *args, **kwargs):
@@ -61,13 +60,11 @@ class GPGTestCase(TestCase, LoaderModuleMockMixin):
         with patch('salt.renderers.gpg._get_key_dir', MagicMock(return_value=key_dir)), \
                 patch('salt.utils.path.which', MagicMock()):
             with patch('salt.renderers.gpg.Popen', MagicMock(return_value=GPGDecrypt())):
-                self.assertEqual(gpg._decrypt_ciphertexts(crypted_short), secret)
-                self.assertEqual(gpg._decrypt_ciphertexts(crypted_long), secret)
+                self.assertEqual(gpg._decrypt_ciphertexts(crypted), secret)
                 self.assertEqual(
                     gpg._decrypt_ciphertexts(multicrypted), multisecret)
             with patch('salt.renderers.gpg.Popen', MagicMock(return_value=GPGNotDecrypt())):
-                self.assertEqual(gpg._decrypt_ciphertexts(crypted_short), crypted_short)
-                self.assertEqual(gpg._decrypt_ciphertexts(crypted_long), crypted_long)
+                self.assertEqual(gpg._decrypt_ciphertexts(crypted), crypted)
                 self.assertEqual(
                     gpg._decrypt_ciphertexts(multicrypted), multicrypted)
 


### PR DESCRIPTION
### What does this PR do?
Partially revert logic accidentally introduced in #46542.

### What issues does this PR fix or reference?
Fixes #50809 

### Previous Behavior
I've added the logic that tries to decrypt values having no `-----BEGIN/END PGP MESSAGE-----` header/footer lines in #46542.

### New Behavior
Return the text without marks as is.

### Tests written?
Updated

### Commits signed with GPG?
Yes
