### PR TITLE
Adding git 'v' to the bootstrap options

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -30,7 +30,7 @@ provisioner:
   salt_install: bootstrap
   salt_version: latest
   salt_bootstrap_url: https://bootstrap.saltstack.com
-  salt_bootstrap_options: -X -p rsync git <%= version %>
+  salt_bootstrap_options: -X -p rsync git v<%= version %>
   log_level: info
   sudo: true
   require_chef: false


### PR DESCRIPTION
### What does this PR do?
Fixes the missing `v` in the bootstrap options in .kitchen.yml.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/50813

### Tests written?

No

### Commits signed with GPG?

Yes
