### PR TITLE
salt/modules/opkg: add restart_services kwargs option

### DIFF
--- a/salt/modules/opkg.py
+++ b/salt/modules/opkg.py
@@ -101,14 +101,18 @@ def _process_restartcheck_result(rs_result):
     '''
     if 'No packages seem to need to be restarted' in rs_result:
         return
+    reboot_required = False
     for rstr in rs_result:
         if 'System restart required' in rstr:
             _update_nilrt_restart_state()
             __salt__['system.set_reboot_required_witnessed']()
-        else:
-            service = os.path.join('/etc/init.d', rstr)
-            if os.path.exists(service):
-                __salt__['cmd.run']([service, 'restart'])
+            reboot_required = True
+    if kwargs.get('restart_services', True) or not reboot_required:
+        for rstr in rs_result:
+            if 'System restart required' not in rstr:
+                service = os.path.join('/etc/init.d', rstr)
+                if os.path.exists(service):
+                    __salt__['cmd.run']([service, 'restart'])
 
 
 def __virtual__():
@@ -429,7 +433,10 @@ def install(name=None,
 
         .. versionadded:: 2017.7.0
 
-    Returns a dict containing the new package names and versions::
+    restart_services
+        Whether to restart services even if a reboot is required. Default is True.
+
+		Returns a dict containing the new package names and versions::
 
         {'<package>': {'old': '<old-version>',
                        'new': '<new-version>'}}
@@ -554,7 +561,7 @@ def install(name=None,
             info={'errors': errors, 'changes': ret}
         )
 
-    _process_restartcheck_result(rs_result)
+    _process_restartcheck_result(rs_result, **kwargs)
 
     return ret
 
@@ -657,7 +664,7 @@ def remove(name=None, pkgs=None, **kwargs):  # pylint: disable=unused-argument
             info={'errors': errors, 'changes': ret}
         )
 
-    _process_restartcheck_result(rs_result)
+    _process_restartcheck_result(rs_result, **kwargs)
 
     return ret
 
@@ -740,7 +747,7 @@ def upgrade(refresh=True, **kwargs):  # pylint: disable=unused-argument
             info={'errors': errors, 'changes': ret}
         )
 
-    _process_restartcheck_result(rs_result)
+    _process_restartcheck_result(rs_result, **kwargs)
 
     return ret
 

--- a/salt/modules/opkg.py
+++ b/salt/modules/opkg.py
@@ -107,7 +107,7 @@ def _process_restartcheck_result(rs_result, **kwargs):
             _update_nilrt_restart_state()
             __salt__['system.set_reboot_required_witnessed']()
             reboot_required = True
-    if kwargs.get('restart_services', True) or not reboot_required:
+    if kwargs.get('always_restart_services', True) or not reboot_required:
         for rstr in rs_result:
             if 'System restart required' not in rstr:
                 service = os.path.join('/etc/init.d', rstr)
@@ -433,7 +433,7 @@ def install(name=None,
 
         .. versionadded:: 2017.7.0
 
-    restart_services
+    always_restart_services
         Whether to restart services even if a reboot is required. Default is True.
 
     Returns a dict containing the new package names and versions::

--- a/salt/modules/opkg.py
+++ b/salt/modules/opkg.py
@@ -94,7 +94,7 @@ def _get_restartcheck_result(errors):
     return rs_result
 
 
-def _process_restartcheck_result(rs_result):
+def _process_restartcheck_result(rs_result, **kwargs):
     '''
     Check restartcheck output to see if system/service restarts were requested
     and take appropriate action.
@@ -436,7 +436,7 @@ def install(name=None,
     restart_services
         Whether to restart services even if a reboot is required. Default is True.
 
-		Returns a dict containing the new package names and versions::
+    Returns a dict containing the new package names and versions::
 
         {'<package>': {'old': '<old-version>',
                        'new': '<new-version>'}}


### PR DESCRIPTION
The commands to install and upgrade (and remove) all support the option, which
is useful for clients that will query the restartcheck module and initiate a
system reboot if needed. This omits unnecessary work and makes install faster.

Signed-off-by: Dan Mondrik <dan.mondrik@ni.com>

### What does this PR do?
Some clients will perform a restartcheck after an install, and reboot the system if needed.
For these clients, the service auto-restart during the install operation is unnecessary.

### What issues does this PR fix or reference?

### Previous Behavior
Services using upgraded files would always be restarted, even if a reboot was needed.

### New Behavior
If the user passes --restart_services=False then services will not be restarted.

### Tests written?
N/A

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
