### PR TITLE
Fix issues with lgpo state and util

### DIFF
--- a/salt/states/win_lgpo.py
+++ b/salt/states/win_lgpo.py
@@ -114,6 +114,7 @@ import salt.utils.json
 
 # Import 3rd party libs
 from salt.ext import six
+from requests.structures import CaseInsensitiveDict
 
 log = logging.getLogger(__name__)
 __virtualname__ = 'lgpo'
@@ -250,6 +251,9 @@ def set_(name,
     for policy_section, policy_data in six.iteritems(pol_data):
         pol_id = None
         if policy_data and policy_data['output_section'] in current_policy:
+            # Make the subdict keys case insensitive
+            current_policy[policy_data['output_section']] = CaseInsensitiveDict(
+                current_policy[policy_data['output_section']])
             for policy_name, policy_setting in six.iteritems(policy_data['requested_policy']):
                 currently_set = False
                 if policy_name in current_policy[policy_data['output_section']]:

--- a/salt/utils/win_lgpo_netsh.py
+++ b/salt/utils/win_lgpo_netsh.py
@@ -77,7 +77,7 @@ import tempfile
 
 import salt.modules.cmdmod
 from salt.exceptions import CommandExecutionError
-from salt.ext.six.moves import map
+from salt.ext.six.moves import zip
 
 log = logging.getLogger(__name__)
 __hostname__ = socket.gethostname()
@@ -196,7 +196,7 @@ def get_settings(profile, section, store='local'):
     ret = {}
     # Skip the first 2 lines. Add everything else to a dictionary
     for line in results[3:]:
-        ret.update(dict(zip(*[iter(re.split(r"\s{2,}", line))]*2)))
+        ret.update(dict(list(zip(*[iter(re.split(r"\s{2,}", line))]*2))))
 
     # Remove spaces from the values so that `Not Configured` is detected
     # correctly

--- a/salt/utils/win_lgpo_netsh.py
+++ b/salt/utils/win_lgpo_netsh.py
@@ -196,7 +196,7 @@ def get_settings(profile, section, store='local'):
     ret = {}
     # Skip the first 2 lines. Add everything else to a dictionary
     for line in results[3:]:
-        ret.update(dict(map(None, *[iter(re.split(r"\s{2,}", line))]*2)))  # pylint: disable=incompatible-py3-code
+        ret.update(dict(zip(*[iter(re.split(r"\s{2,}", line))]*2)))
 
     # Remove spaces from the values so that `Not Configured` is detected
     # correctly


### PR DESCRIPTION
### What does this PR do?
Fix a py3 issue in the win_lgpo_netsh salt util. It didn't work at all on Py3
Make the state case insensitive for policy lookups. You can set them case-insensitive, but the state was case sensitive, causing `test=True` to report changes erroneously

### Tests written?
No

### Commits signed with GPG?
Yes/No