### PR TITLE
Updated to allow for Debian 8 signing packages

### DIFF
--- a/salt/modules/debbuild.py
+++ b/salt/modules/debbuild.py
@@ -832,7 +832,8 @@ def make_repo(repodir,
                     number_retries = timeout / interval
                     times_looped = 0
                     error_msg = 'Failed to debsign file {0}'.format(abs_file)
-                    if __grains__['os'] in ['Ubuntu'] and __grains__['osmajorrelease'] < 18:
+                    if ((__grains__['os'] in ['Ubuntu'] and __grains__['osmajorrelease'] < 18)
+                         or (__grains__['os'] in ['Debian'] and __grains__['osmajorrelease'] <= 8)):
                         cmd = 'debsign --re-sign -k {0} {1}'.format(keyid, abs_file)
                         try:
                             proc = salt.utils.vt.Terminal(
@@ -884,7 +885,8 @@ def make_repo(repodir,
                 cmd = 'reprepro --ignore=wrongdistribution --component=main -Vb . includedsc {0} {1}'.format(
                         codename,
                         abs_file)
-                if __grains__['os'] in ['Ubuntu'] and __grains__['osmajorrelease'] < 18:
+                if ((__grains__['os'] in ['Ubuntu'] and __grains__['osmajorrelease'] < 18)
+                    or (__grains__['os'] in ['Debian'] and __grains__['osmajorrelease'] <= 8)):
                     try:
                         proc = salt.utils.vt.Terminal(
                                 cmd,


### PR DESCRIPTION
### What does this PR do?
Reverts Debian 8 to using SaltStack VT terminal to sign packages

### What issues does this PR fix or reference?
Debian 8 was failing to sign packages with recent changes for Debian 9 running on AWS.

### Tests written?
No, automated builds on AWS test it sufficiently

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
