### PR TITLE
PillarCache: fix handling of pillar_override

### DIFF
--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -305,7 +305,6 @@ class PillarCache(object):
                               self.saltenv,
                               ext=self.ext,
                               functions=self.functions,
-                              pillar_override=self.pillar_override,
                               pillarenv=self.pillarenv)
         return fresh_pillar.compile_pillar()
 
@@ -339,6 +338,16 @@ class PillarCache(object):
             self.cache[self.minion_id] = {self.pillarenv: pillar_data}
             log.debug('Pillar cache has been added for minion %s', self.minion_id)
             log.debug('Current pillar cache: %s', self.cache[self.minion_id])
+
+        # we dont want the pillar_override baked into the cached fetch_pillar from above
+        if self.pillar_override:
+            pillar_data = merge(
+                pillar_data,
+                self.pillar_override,
+                self.opts.get('pillar_source_merging_strategy', 'smart'),
+                self.opts.get('renderer', 'yaml'),
+                self.opts.get('pillar_merge_lists', False))
+            pillar_data.update(self.pillar_override)
 
         return pillar_data
 


### PR DESCRIPTION
### What does this PR do?
pillar ovverrides (ie via cli) were being ignored for cached results.
this accounts for that by applying the requested override/merge similar
to what is done in base pillar. Also removed the pillar_override from
the fetch call to avoid baking that into the cached results.

@isbm just pinging as you are the main pillarcache guy I think

### What issues does this PR fix or reference?
described above

### Previous Behavior
salt 'minion' state.apply pillar='{foo}' was ignored

### New Behavior
it works

### Tests written?
no

### Commits signed with GPG?
no

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
