### PR TITLE
[develop] Schedule when cleanup

### DIFF
--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -950,117 +950,60 @@ class Schedule(object):
                 _when_data = [data['when']]
             else:
                 _when_data = data['when']
-        
-            if isinstance(_when_data, list):
-                _when = []
-                for i in _when_data:
-                    if ('pillar' in self.opts and 'whens' in self.opts['pillar'] and
-                            i in self.opts['pillar']['whens']):
-                        if not isinstance(self.opts['pillar']['whens'],
-                                          dict):
-                            data['_error'] = ('Pillar item "whens" '
-                                              'must be a dict. '
-                                              'Ignoring job {0}.'.format(data['name']))
-                            log.error(data['_error'])
-                            return
-                        when_ = self.opts['pillar']['whens'][i]
-                    elif ('whens' in self.opts['grains'] and
-                          i in self.opts['grains']['whens']):
-                        if not isinstance(self.opts['grains']['whens'],
-                                          dict):
-                            data['_error'] = ('Grain "whens" must be a dict. '
-                                              'Ignoring job {0}.'.format(data['name']))
-                            log.error(data['_error'])
-                            return
-                        when_ = self.opts['grains']['whens'][i]
-                    else:
-                        when_ = i
 
-                    if not isinstance(when_, datetime.datetime):
-                        try:
-                            when_ = dateutil_parser.parse(when_)
-                        except ValueError:
-                            data['_error'] = ('Invalid date string {0}. '
-                                              'Ignoring job {1}.'.format(i, data['name']))
-                            log.error(data['_error'])
-                            return
-
-                    _when.append(when_)
-
-                if data['_splay']:
-                    _when.append(data['_splay'])
-
-                # Sort the list of "whens" from earlier to later schedules
-                _when.sort()
-
-                # Copy the list so we can loop through it
-                for i in copy.deepcopy(_when):
-                    if len(_when) > 1:
-                        if i < now - loop_interval:
-                            # Remove all missed schedules except the latest one.
-                            # We need it to detect if it was triggered previously.
-                            _when.remove(i)
-
-                if _when:
-                    # Grab the first element, which is the next run time or
-                    # last scheduled time in the past.
-                    when = _when[0]
-
-                    if when < now - loop_interval and \
-                            not data.get('_run', False) and \
-                            not data.get('run', False) and \
-                            not data['_splay']:
-                        data['_next_fire_time'] = None
-                        data['_continue'] = True
-                        return
-
-                    if '_run' not in data:
-                        # Prevent run of jobs from the past
-                        data['_run'] = bool(when >= now - loop_interval)
-
-                    if not data['_next_fire_time']:
-                        data['_next_fire_time'] = when
-
-                    data['_next_scheduled_fire_time'] = when
-
-                    if data['_next_fire_time'] < when and \
-                            not run and \
-                            not data['_run']:
-                        data['_next_fire_time'] = when
-                        data['_run'] = True
-
-                elif not data.get('_run', False):
-                    data['_next_fire_time'] = None
-                    data['_continue'] = True
-
-            else:
+            _when = []
+            for i in _when_data:
                 if ('pillar' in self.opts and 'whens' in self.opts['pillar'] and
-                        data['when'] in self.opts['pillar']['whens']):
-                    if not isinstance(self.opts['pillar']['whens'], dict):
-                        data['_error'] = ('Pillar item "whens" must be dict.'
+                        i in self.opts['pillar']['whens']):
+                    if not isinstance(self.opts['pillar']['whens'],
+                                      dict):
+                        data['_error'] = ('Pillar item "whens" '
+                                          'must be a dict. '
                                           'Ignoring job {0}.'.format(data['name']))
                         log.error(data['_error'])
                         return
-                    when = self.opts['pillar']['whens'][data['when']]
+                    when_ = self.opts['pillar']['whens'][i]
                 elif ('whens' in self.opts['grains'] and
-                      data['when'] in self.opts['grains']['whens']):
-                    if not isinstance(self.opts['grains']['whens'], dict):
+                      i in self.opts['grains']['whens']):
+                    if not isinstance(self.opts['grains']['whens'],
+                                      dict):
                         data['_error'] = ('Grain "whens" must be a dict. '
                                           'Ignoring job {0}.'.format(data['name']))
                         log.error(data['_error'])
                         return
-                    when = self.opts['grains']['whens'][data['when']]
+                    when_ = self.opts['grains']['whens'][i]
                 else:
-                    when = data['when']
+                    when_ = i
 
-                if not isinstance(when, datetime.datetime):
+                if not isinstance(when_, datetime.datetime):
                     try:
-                        when = dateutil_parser.parse(when)
+                        when_ = dateutil_parser.parse(when_)
                     except ValueError:
-                        data['_error'] = ('Invalid date string. '
-                                          'Ignoring job {0}.'.format(data['name']))
+                        data['_error'] = ('Invalid date string {0}. '
+                                          'Ignoring job {1}.'.format(i, data['name']))
                         log.error(data['_error'])
                         return
+
+                _when.append(when_)
+
+            if data['_splay']:
+                _when.append(data['_splay'])
+
+            # Sort the list of "whens" from earlier to later schedules
+            _when.sort()
+
+            # Copy the list so we can loop through it
+            for i in copy.deepcopy(_when):
+                if len(_when) > 1:
+                    if i < now - loop_interval:
+                        # Remove all missed schedules except the latest one.
+                        # We need it to detect if it was triggered previously.
+                        _when.remove(i)
+
+            if _when:
+                # Grab the first element, which is the next run time or
+                # last scheduled time in the past.
+                when = _when[0]
 
                 if when < now - loop_interval and \
                         not data.get('_run', False) and \
@@ -1071,7 +1014,8 @@ class Schedule(object):
                     return
 
                 if '_run' not in data:
-                    data['_run'] = True
+                    # Prevent run of jobs from the past
+                    data['_run'] = bool(when >= now - loop_interval)
 
                 if not data['_next_fire_time']:
                     data['_next_fire_time'] = when
@@ -1079,9 +1023,14 @@ class Schedule(object):
                 data['_next_scheduled_fire_time'] = when
 
                 if data['_next_fire_time'] < when and \
+                        not run and \
                         not data['_run']:
                     data['_next_fire_time'] = when
                     data['_run'] = True
+
+            elif not data.get('_run', False):
+                data['_next_fire_time'] = None
+                data['_continue'] = True
 
         def _handle_cron(data, loop_interval):
             '''

--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -946,9 +946,14 @@ class Schedule(object):
                 log.error(data['_error'])
                 return
 
-            if isinstance(data['when'], list):
+            if not isinstance(data['when'], list):
+                _when_data = [data['when']]
+            else:
+                _when_data = data['when']
+        
+            if isinstance(_when_data, list):
                 _when = []
-                for i in data['when']:
+                for i in _when_data:
                     if ('pillar' in self.opts and 'whens' in self.opts['pillar'] and
                             i in self.opts['pillar']['whens']):
                         if not isinstance(self.opts['pillar']['whens'],
@@ -963,7 +968,7 @@ class Schedule(object):
                           i in self.opts['grains']['whens']):
                         if not isinstance(self.opts['grains']['whens'],
                                           dict):
-                            data['_error'] = ('Grain "whens" must be a dict.'
+                            data['_error'] = ('Grain "whens" must be a dict. '
                                               'Ignoring job {0}.'.format(data['name']))
                             log.error(data['_error'])
                             return

--- a/tests/integration/scheduler/test_error.py
+++ b/tests/integration/scheduler/test_error.py
@@ -103,7 +103,7 @@ class SchedulerErrorTest(ModuleCase, SaltReturnAssertsMixin):
         self.schedule.eval(now=run_time)
         ret = self.schedule.job_status('job1')
         self.assertEqual(ret['_error'],
-                         'Invalid date string. Ignoring job job1.')
+                         'Invalid date string 13/29/2017 1:00pm. Ignoring job job1.')
 
     def test_eval_whens_grain_not_dict(self):
         '''


### PR DESCRIPTION
### What does this PR do?
Some cleanup in the `_handle_when`, removing some redundant code when the provided schedule data was either a list or not a list.  Now we just convert to a list if the provided data is not a list, then we can handle both scenarios the same.
 
### What issues does this PR fix or reference?
N/A

### Tests written?
Yes.  Tests exist that test as both a list and non-list.

### Commits signed with GPG?

Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
