### PR TITLE
Fix RemoveCapacityFromDiskgroupTestCase require pyvmomi

### DIFF
--- a/tests/unit/modules/test_vsphere.py
+++ b/tests/unit/modules/test_vsphere.py
@@ -1478,6 +1478,7 @@ class RemoveDiskgroupTestCase(TestCase, LoaderModuleMockMixin):
 
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
+@skipIf(not HAS_PYVMOMI, 'The \'pyvmomi\' library is missing')
 @skipIf(not vsphere.HAS_JSONSCHEMA, 'The \'jsonschema\' library is missing')
 class RemoveCapacityFromDiskgroupTestCase(TestCase, LoaderModuleMockMixin):
     '''


### PR DESCRIPTION
If the `pyvmomi` library is missing, all tests from the tests.unit.modules.RemoveCapacityFromDiskgroupTestCase will fail:

```
ERROR: test__get_proxy_target_call
(unit.modules.test_vsphere.RemoveCapacityFromDiskgroupTestCase)
[CPU:0.0%|MEM:35.1%]
----------------------------------------------------------------------
Traceback (most recent call last):
  File "salt/utils/vmware.py", line 485, in disconnect
    Disconnect(service_instance)
NameError: name 'Disconnect' is not defined

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "salt/modules/vsphere.py", line 381, in _gets_service_instance_via_proxy
    salt.utils.vmware.disconnect(local_service_instance)
  File "salt/utils/vmware.py", line 486, in disconnect
    except vim.fault.NoPermission as exc:
NameError: name 'vim' is not defined

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "salt/utils/vmware.py", line 485, in disconnect
    Disconnect(service_instance)
NameError: name 'Disconnect' is not defined

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "tests/unit/modules/test_vsphere.py", line 1568, in test__get_proxy_target_call
    capacity_disk_ids=['fake_disk1', 'fake_disk2'])
  File "salt/modules/vsphere.py", line 295, in __supports_proxies
    return fn(*args, **salt.utils.args.clean_kwargs(**kwargs))
  File "salt/modules/vsphere.py", line 386, in _gets_service_instance_via_proxy
    salt.utils.vmware.disconnect(local_service_instance)
  File "/home/bdrung/projects/salt/debian/salt/utils/vmware.py", line 486, in disconnect
    except vim.fault.NoPermission as exc:
NameError: name 'vim' is not defined
```