### PR TITLE
Fix grains for future windows releases

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1089,6 +1089,7 @@ def id_():
     '''
     return {'id': __opts__.get('id', '')}
 
+
 _REPLACE_LINUX_RE = re.compile(r'\W(?:gnu/)?linux', re.IGNORECASE)
 
 # This maps (at most) the first ten characters (no spaces, lowercased) of

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -982,26 +982,34 @@ def _windows_platform_data():
         except IndexError:
             log.debug('Motherboard info not available on this system')
 
-        os_release = platform.release()
         info = salt.utils.win_osinfo.get_os_version_info()
-        server = {'Vista': '2008Server',
-                  '7': '2008ServerR2',
-                  '8': '2012Server',
-                  '8.1': '2012ServerR2',
-                  '10': '2016Server'}
-
-        # Starting with Python 2.7.12 and 3.5.2 the `platform.uname()` function
-        # started reporting the Desktop version instead of the Server version on
-        # Server versions of Windows, so we need to look those up
-        # So, if you find a Server Platform that's a key in the server
-        # dictionary, then lookup the actual Server Release.
-        # (Product Type 1 is Desktop, Everything else is Server)
-        if info['ProductType'] > 1 and os_release in server:
-            os_release = server[os_release]
 
         service_pack = None
         if info['ServicePackMajor'] > 0:
             service_pack = ''.join(['SP', str(info['ServicePackMajor'])])
+
+        # This creates the osrelease grain based on the Windows Operating
+        # System Product Name. As long as Microsoft maintains a similar format
+        # this should be future proof
+        version = 'Unknown'
+        release = ''
+        if 'Server' in osinfo.Caption:
+            for item in osinfo.Caption.split(' '):
+                # If it's all digits, then it's version
+                if re.match(r'\d+', item):
+                    version = item
+                # If it starts with R and then numbers, it's the release
+                # ie: R2
+                if re.match(r'^R\d+$', item):
+                    release = item
+            os_release = '{0}Server{1}'.format(version, release)
+        else:
+            for item in osinfo.Caption.split(' '):
+                # If it's a number, decimal number, Thin or Vista, then it's the
+                # version
+                if re.match(r'^(\d+(\.\d+)?)|Thin|Vista$', item):
+                    version = item
+            os_release = version
 
         grains = {
             'kernelrelease': _clean_value('kernelrelease', osinfo.Version),

--- a/salt/version.py
+++ b/salt/version.py
@@ -766,6 +766,7 @@ def msi_conformant_version():
     commi = __saltstack_version__.noc
     return '{0}.{1}.{2}.{3}'.format(year2, month, minor, commi)
 
+
 if __name__ == '__main__':
     if len(sys.argv) == 2 and sys.argv[1] == 'msi':
         # Building the msi requires an msi-conformant version

--- a/salt/version.py
+++ b/salt/version.py
@@ -653,26 +653,47 @@ def system_information():
         else:
             return ''
 
-    version = system_version()
-    release = platform.release()
     if platform.win32_ver()[0]:
+        # Get the version and release info based on the Windows Operating
+        # System Product Name. As long as Microsoft maintains a similar format
+        # this should be future proof
         import win32api  # pylint: disable=3rd-party-module-not-gated
-        server = {'Vista': '2008Server',
-                  '7': '2008ServerR2',
-                  '8': '2012Server',
-                  '8.1': '2012ServerR2',
-                  '10': '2016Server'}
-        # Starting with Python 2.7.12 and 3.5.2 the `platform.uname()` function
-        # started reporting the Desktop version instead of the Server version on
-        # Server versions of Windows, so we need to look those up
-        # So, if you find a Server Platform that's a key in the server
-        # dictionary, then lookup the actual Server Release.
-        # If this is a Server Platform then `GetVersionEx` will return a number
-        # greater than 1.
-        if win32api.GetVersionEx(1)[8] > 1 and release in server:
-            release = server[release]
+        import win32con  # pylint: disable=3rd-party-module-not-gated
+
+        # Get the product name from the registry
+        hkey = win32con.HKEY_LOCAL_MACHINE
+        key = 'SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion'
+        value_name = 'ProductName'
+        reg_handle = win32api.RegOpenKey(hkey, key)
+
+        # Returns a tuple of (product_name, value_type)
+        product_name, _ = win32api.RegQueryValueEx(reg_handle, value_name)
+
+        version = 'Unknown'
+        release = ''
+        if 'Server' in product_name:
+            for item in product_name.split(' '):
+                # If it's all digits, then it's version
+                if re.match(r'\d+', item):
+                    version = item
+                # If it starts with R and then numbers, it's the release
+                # ie: R2
+                if re.match(r'^R\d+$', item):
+                    release = item
+            release = '{0}Server{1}'.format(version, release)
+        else:
+            for item in product_name.split(' '):
+                # If it's a number, decimal number, Thin or Vista, then it's the
+                # version
+                if re.match(r'^(\d+(\.\d+)?)|Thin|Vista$', item):
+                    version = item
+            release = version
+
         _, ver, sp, extra = platform.win32_ver()
         version = ' '.join([release, ver, sp, extra])
+    else:
+        version = system_version()
+        release = platform.release()
 
     system = [
         ('system', platform.system()),


### PR DESCRIPTION
### What does this PR do?
This PR tries to future proof the release and version information displayed in the grains and in the version information for Salt. 

Python reports os versions relative to the desktop release. To get the Server version we created a dictionary that correlated the desktop release to the server release. If we detected a server installation then we would use the dictionary to look up the associated server release. Since Microsoft has moved to a rolling release for Windows 10 desktop new server releases no longer have a corresponding desktop release. Windows just released Windows Server 2019 and Salt was still reporting 2016 as the server version.

This PR will base the release and version on the full platform name. Tested against the following data set:
```
versions = ['Windows 10 Home',
            'Windows 10 Pro',
            'Windows 10 Pro for Workstations',
            'Windows 10 Pro Education',
            'Windows 10 Enterprise',
            'Windows 10 Enterprise LTSB',
            'Windows 10 Education',
            'Windows 10 IoT Core',
            'Windows 10 IoT Enterprise',
            'Windows 10 S',
            'Windows 8.1',
            'Windows 8.1 Pro',
            'Windows 8.1 Enterprise',
            'Windows 8.1 OEM',
            'Windows 8.1 with Bing',
            'Windows 8',
            'Windows 8 Pro',
            'Windows 8 Enterprise',
            'Windows 8 OEM',
            'Windows 7 Starter',
            'Windows 7 Home Basic',
            'Windows 7 Home Premium',
            'Windows 7 Professional',
            'Windows 7 Enterprise',
            'Windows 7 Ultimate',
            'Windows Thin PC',
            'Windows Vista Starter',
            'Windows Vista Home Basic',
            'Windows Vista Home Premium',
            'Windows Vista Business',
            'Windows Vista Enterprise',
            'Windows Vista Ultimate',
            'Windows Server 2019 Essentials',
            'Windows Server 2019 Standard',
            'Windows Server 2019 Datacenter',
            'Windows Server 2016 Essentials',
            'Windows Server 2016 Standard',
            'Windows Server 2016 Datacenter',
            'Windows Server 2012 R2 Foundation',
            'Windows Server 2012 R2 Essentials',
            'Windows Server 2012 R2 Standard',
            'Windows Server 2012 R2 Datacenter',
            'Windows Server 2012 Foundation',
            'Windows Server 2012 Essentials',
            'Windows Server 2012 Standard',
            'Windows Server 2012 Datacenter',
            'Windows MultiPoint Server 2012',
            'Windows Server 2008 R2 Foundation',
            'Windows Server 2008 R2 Standard',
            'Windows Server 2008 R2 Enterprise',
            'Windows Server 2008 R2 Datacenter',
            'Windows Server 2008 R2 for Itanium-based Systems',
            'Windows Web Server 2008 R2',
            'Windows Storage Server 2008 R2',
            'Windows HPC Server 2008 R2',
            'Windows Small Business Server 2011',
            'Windows MultiPoint Server 2011',
            'Windows Home Server 2011',
            'Windows MultiPoint Server 2010',
            'Windows Server 2008 Standard',
            'Windows Server 2008 Enterprise',
            'Windows Server 2008 Datacenter',
            'Windows Server 2008 for Itanium-based Systems',
            'Windows Server Foundation 2008',
            'Windows Essential Business Server 2008',
            'Windows HPC Server 2008',
            'Windows Small Business Server 2008',
            'Windows Storage Server 2008',
            'Windows Web Server 2008']
```
They are detected as follows (osrelease, osfullname):
```
10      Windows 10 Home
10      Windows 10 Pro
10      Windows 10 Pro for Workstations
10      Windows 10 Pro Education
10      Windows 10 Enterprise
10      Windows 10 Enterprise LTSB
10      Windows 10 Education
10      Windows 10 IoT Core
10      Windows 10 IoT Enterprise
10      Windows 10 S
8.1     Windows 8.1
8.1     Windows 8.1 Pro
8.1     Windows 8.1 Enterprise
8.1     Windows 8.1 OEM
8.1     Windows 8.1 with Bing
8       Windows 8
8       Windows 8 Pro
8       Windows 8 Enterprise
8       Windows 8 OEM
7       Windows 7 Starter
7       Windows 7 Home Basic
7       Windows 7 Home Premium
7       Windows 7 Professional
7       Windows 7 Enterprise
7       Windows 7 Ultimate
Thin    Windows Thin PC
Vista   Windows Vista Starter
Vista   Windows Vista Home Basic
Vista   Windows Vista Home Premium
Vista   Windows Vista Business
Vista   Windows Vista Enterprise
Vista   Windows Vista Ultimate
2019Server      Windows Server 2019 Essentials
2019Server      Windows Server 2019 Standard
2019Server      Windows Server 2019 Datacenter
2016Server      Windows Server 2016 Essentials
2016Server      Windows Server 2016 Standard
2016Server      Windows Server 2016 Datacenter
2012ServerR2    Windows Server 2012 R2 Foundation
2012ServerR2    Windows Server 2012 R2 Essentials
2012ServerR2    Windows Server 2012 R2 Standard
2012ServerR2    Windows Server 2012 R2 Datacenter
2012Server      Windows Server 2012 Foundation
2012Server      Windows Server 2012 Essentials
2012Server      Windows Server 2012 Standard
2012Server      Windows Server 2012 Datacenter
2012Server      Windows MultiPoint Server 2012
2008ServerR2    Windows Server 2008 R2 Foundation
2008ServerR2    Windows Server 2008 R2 Standard
2008ServerR2    Windows Server 2008 R2 Enterprise
2008ServerR2    Windows Server 2008 R2 Datacenter
2008ServerR2    Windows Server 2008 R2 for Itanium-based Systems
2008ServerR2    Windows Web Server 2008 R2
2008ServerR2    Windows Storage Server 2008 R2
2008ServerR2    Windows HPC Server 2008 R2
2011Server      Windows Small Business Server 2011
2011Server      Windows MultiPoint Server 2011
2011Server      Windows Home Server 2011
2010Server      Windows MultiPoint Server 2010
2008Server      Windows Server 2008 Standard
2008Server      Windows Server 2008 Enterprise
2008Server      Windows Server 2008 Datacenter
2008Server      Windows Server 2008 for Itanium-based Systems
2008Server      Windows Server Foundation 2008
2008Server      Windows Essential Business Server 2008
2008Server      Windows HPC Server 2008
2008Server      Windows Small Business Server 2008
2008Server      Windows Storage Server 2008
2008Server      Windows Web Server 2008
```

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/50758

### Tests written?
No

### Commits signed with GPG?
No