### PR TITLE
get searchdomain in Ubuntu 12+ (2018.3)

### DIFF
--- a/salt/modules/debian_ip.py
+++ b/salt/modules/debian_ip.py
@@ -1913,9 +1913,11 @@ def get_network_settings():
 
         hostname = _parse_hostname()
         domainname = _parse_domainname()
+        searchdomain = _parse_searchdomain()
 
         settings['hostname'] = hostname
         settings['domainname'] = domainname
+        settings['searchdomain'] = searchdomain
 
     else:
         settings = _parse_current_network_settings()

--- a/tests/unit/modules/test_debian_ip.py
+++ b/tests/unit/modules/test_debian_ip.py
@@ -474,14 +474,17 @@ class DebianIpTestCase(TestCase, LoaderModuleMockMixin):
                 patch('salt.modules.debian_ip._parse_hostname',
                       MagicMock(return_value='SaltStack')), \
                         patch('salt.modules.debian_ip._parse_domainname',
-                              MagicMock(return_value='saltstack.com')):
+                              MagicMock(return_value='saltstack.com')), \
+                                    patch('salt.modules.debian_ip._parse_searchdomain',
+                                          MagicMock(return_value='test.saltstack.com')):
             mock_avai = MagicMock(return_value=True)
             with patch.dict(debian_ip.__salt__, {'service.available': mock_avai,
                                                  'service.status': mock_avai}):
                 self.assertEqual(debian_ip.get_network_settings(),
                                  ['NETWORKING=yes\n',
                                   'HOSTNAME=SaltStack\n',
-                                  'DOMAIN=saltstack.com\n'])
+                                  'DOMAIN=saltstack.com\n',
+                                  'SEARCH=test.saltstack.com\n'])
 
                 mock = MagicMock(side_effect=jinja2.exceptions.TemplateNotFound
                                  ('error'))


### PR DESCRIPTION
resolves #39151

### What does this PR do?

The `get_networking_settings` function checks whether the `osrelease` is Ubuntu 12+ in order to skip checking `/etc/default/networking`, but `_parse_networking_settings` doesn't. Because `get_networking_settings` was not parsing resolv.conf for `search`, Ubuntu 12+ systems would result in re-applying network settings every highstate.

### What issues does this PR fix or reference?

#39151

### Previous Behavior

Every highstate produced the following and restarted networking.service:

```
----------
          ID: network-system
    Function: network.system
      Result: True
     Comment: Global network settings are up to date.
     Started: 19:21:58.926859
    Duration: 4126.608 ms
     Changes:
              ----------
              network_settings:
                  ---
                  +++
                  @@ -1,2 +1,3 @@
                   NETWORKING=yes

                   HOSTNAME=hostname

                  +SEARCH=domain.tld
```

### New Behavior

No changes during highstate
