### PR TITLE
Clean up IPC Singletons - Stage 2

### DIFF
--- a/salt/payload.py
+++ b/salt/payload.py
@@ -11,6 +11,7 @@ from __future__ import absolute_import, print_function, unicode_literals
 import logging
 import gc
 import datetime
+import weakref
 
 # Import salt libs
 import salt.log
@@ -266,6 +267,11 @@ class SREQ(object):
     Create a generic interface to wrap salt zeromq req calls.
     '''
     def __init__(self, master, id_='', serial='msgpack', linger=0, opts=None):
+        try:
+            weakref.finalize(self, self.destroy)
+        except AttributeError:
+            # FIXME when we go Py3 only
+            pass
         self.master = master
         self.id_ = id_
         self.serial = Serial(serial)
@@ -391,5 +397,6 @@ class SREQ(object):
         if self.context.closed is False:
             self.context.term()
 
-    def __del__(self):
-        self.destroy()
+    if six.PY2:
+        def __del__(self):
+            self.destroy()

--- a/salt/transport/ipc.py
+++ b/salt/transport/ipc.py
@@ -353,16 +353,13 @@ class IPCClient(object):
                 yield tornado.gen.sleep(1)
 
     def __del__(self):
-        self._close()
+        self.close()
 
-    def _close(self):
+    def close(self):
         '''
         Routines to handle any cleanup before the instance shuts down.
         Sockets and filehandles should be closed explicitly, to prevent
         leaks.
-
-        This class is a singleton so close have to be called only once during
-        garbage collection when nobody uses this instance.
         '''
         if self._closing:
             return
@@ -740,17 +737,14 @@ class IPCMessageSubscriber(IPCClient):
                 yield tornado.gen.sleep(1)
         yield self._read_async(callback)
 
-    def _close(self):
+    def close(self):
         '''
         Routines to handle any cleanup before the instance shuts down.
         Sockets and filehandles should be closed explicitly, to prevent
         leaks.
-
-        This class is a singleton so close have to be called only once during
-        garbage collection when nobody uses this instance.
         '''
         if not self._closing:
-            IPCClient._close(self)
+            IPCClient.close(self)
             # This will prevent this message from showing up:
             # '[ERROR   ] Future exception was never retrieved:
             # StreamClosedError'
@@ -761,4 +755,4 @@ class IPCMessageSubscriber(IPCClient):
 
     def __del__(self):
         if IPCMessageSubscriber in globals():
-            self._close()
+            self.close()

--- a/salt/transport/tcp.py
+++ b/salt/transport/tcp.py
@@ -147,6 +147,11 @@ if USE_LOAD_BALANCER:
 
         def __init__(self, opts, socket_queue, **kwargs):
             super(LoadBalancerServer, self).__init__(**kwargs)
+            try:
+                weakref.finalize(self, self.close)
+            except AttributeError:
+                # FIXME when we go Py3 only
+                pass
             self.opts = opts
             self.socket_queue = socket_queue
             self._socket = None
@@ -178,8 +183,9 @@ if USE_LOAD_BALANCER:
                 self._socket.close()
                 self._socket = None
 
-        def __del__(self):
-            self.close()
+        if six.PY2:
+            def __del__(self):
+                self.close()
 
         def run(self):
             '''
@@ -261,6 +267,11 @@ class AsyncTCPReqChannel(salt.transport.client.ReqChannel):
 
     # an init for the singleton instance to call
     def __singleton_init__(self, opts, **kwargs):
+        try:
+            weakref.finalize(self, self.close)
+        except AttributeError:
+            # FIXME when we go Py3 only
+            pass
         self.opts = dict(opts)
 
         self.serial = salt.payload.Serial(self.opts)
@@ -291,8 +302,9 @@ class AsyncTCPReqChannel(salt.transport.client.ReqChannel):
         self._closing = True
         self.message_client.close()
 
-    def __del__(self):
-        self.close()
+    if six.PY2:
+        def __del__(self):
+            self.close()
 
     def _package_load(self, load):
         return {
@@ -376,6 +388,11 @@ class AsyncTCPPubChannel(salt.transport.mixins.auth.AESPubClientMixin, salt.tran
     def __init__(self,
                  opts,
                  **kwargs):
+        try:
+            weakref.finalize(self, self.close)
+        except AttributeError:
+            # FIXME when we go Py3 only
+            pass
         self.opts = opts
 
         self.serial = salt.payload.Serial(self.opts)
@@ -398,8 +415,9 @@ class AsyncTCPPubChannel(salt.transport.mixins.auth.AESPubClientMixin, salt.tran
         if hasattr(self, 'message_client'):
             self.message_client.close()
 
-    def __del__(self):
-        self.close()
+    if six.PY2:
+        def __del__(self):
+            self.close()
 
     def _package_load(self, load):
         return {
@@ -559,6 +577,11 @@ class TCPReqServerChannel(salt.transport.mixins.auth.AESReqServerMixin, salt.tra
 
     def __init__(self, opts):
         salt.transport.server.ReqServerChannel.__init__(self, opts)
+        try:
+            weakref.finalize(self, self.close)
+        except AttributeError:
+            # FIXME when we go Py3 only
+            pass
         self._socket = None
 
     @property
@@ -584,8 +607,9 @@ class TCPReqServerChannel(salt.transport.mixins.auth.AESReqServerMixin, salt.tra
             except Exception as exc:
                 log.exception('TCPReqServerChannel close generated an exception: %s', str(exc))
 
-    def __del__(self):
-        self.close()
+    if six.PY2:
+        def __del__(self):
+            self.close()
 
     def pre_fork(self, process_manager):
         '''
@@ -829,9 +853,15 @@ class SaltMessageClientPool(salt.transport.MessageClientPool):
     '''
     def __init__(self, opts, args=None, kwargs=None):
         super(SaltMessageClientPool, self).__init__(SaltMessageClient, opts, args=args, kwargs=kwargs)
+        try:
+            weakref.finalize(self, self.close)
+        except AttributeError:
+            # FIXME when we go Py3 only
+            pass
 
-    def __del__(self):
-        self.close()
+    if six.PY2:
+        def __del__(self):
+            self.close()
 
     def close(self):
         for message_client in self.message_clients:
@@ -870,6 +900,11 @@ class SaltMessageClient(object):
     def __init__(self, opts, host, port, io_loop=None, resolver=None,
                  connect_callback=None, disconnect_callback=None,
                  source_ip=None, source_port=None):
+        try:
+            weakref.finalize(self, self.close)
+        except AttributeError:
+            # FIXME when we go Py3 only
+            pass
         self.opts = opts
         self.host = host
         self.port = port
@@ -936,8 +971,9 @@ class SaltMessageClient(object):
         self.connect_callback = None
         self.disconnect_callback = None
 
-    def __del__(self):
-        self.close()
+    if six.PY2:
+        def __del__(self):
+            self.close()
 
     def connect(self):
         '''
@@ -1156,6 +1192,11 @@ class Subscriber(object):
     Client object for use with the TCP publisher server
     '''
     def __init__(self, stream, address):
+        try:
+            weakref.finalize(self, self.close)
+        except AttributeError:
+            # FIXME when we go Py3 only
+            pass
         self.stream = stream
         self.address = address
         self._closing = False
@@ -1177,8 +1218,9 @@ class Subscriber(object):
                 # 'StreamClosedError' when the stream is closed.
                 self._read_until_future.exception()
 
-    def __del__(self):
-        self.close()
+    if six.PY2:
+        def __del__(self):
+            self.close()
 
 
 class PubServer(tornado.tcpserver.TCPServer, object):
@@ -1187,6 +1229,11 @@ class PubServer(tornado.tcpserver.TCPServer, object):
     '''
     def __init__(self, opts, io_loop=None):
         super(PubServer, self).__init__(ssl_options=opts.get('ssl'))
+        try:
+            weakref.finalize(self, self.close)
+        except AttributeError:
+            # FIXME when we go Py3 only
+            pass
         self.io_loop = io_loop
         self.opts = opts
         self._closing = False
@@ -1217,8 +1264,9 @@ class PubServer(tornado.tcpserver.TCPServer, object):
             return
         self._closing = True
 
-    def __del__(self):
-        self.close()
+    if six.PY2:
+        def __del__(self):
+            self.close()
 
     def _add_client_present(self, client):
         id_ = client.id_

--- a/salt/transport/tcp.py
+++ b/salt/transport/tcp.py
@@ -172,18 +172,14 @@ if USE_LOAD_BALANCER:
                 'log_queue_level': self.log_queue_level
             }
 
-        def _close(self):
-            '''
-            This class is a singleton so close have to be called only once during
-            garbage collection when nobody uses this instance.
-            '''
+        def close(self):
             if self._socket is not None:
                 self._socket.shutdown(socket.SHUT_RDWR)
                 self._socket.close()
                 self._socket = None
 
         def __del__(self):
-            self._close()
+            self.close()
 
         def run(self):
             '''

--- a/salt/transport/tcp.py
+++ b/salt/transport/tcp.py
@@ -44,6 +44,7 @@ import tornado.gen
 import tornado.concurrent
 import tornado.tcpclient
 import tornado.netutil
+from tornado import iostream
 
 # pylint: disable=import-error,no-name-in-module
 if six.PY2:
@@ -304,6 +305,12 @@ class AsyncTCPReqChannel(salt.transport.client.ReqChannel):
                                                             'source_ip': self.opts.get('source_ip'),
                                                             'source_port': self.opts.get('source_ret_port')})
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        self.close()
+
     def close(self):
         if self._closing:
             return
@@ -403,7 +410,12 @@ class AsyncTCPReqChannel(salt.transport.client.ReqChannel):
         raise tornado.gen.Return(ret)
 
     @tornado.gen.coroutine
-    def send(self, load, tries=3, timeout=60, raw=False):
+    def send(self,  # pylint: disable=arguments-differ
+             load,
+             tries=3,
+             timeout=60,
+             raw=False,
+             StreamClosedError=iostream.StreamClosedError):
         '''
         Send a request, return a future which will complete when we send the message
         '''
@@ -412,7 +424,7 @@ class AsyncTCPReqChannel(salt.transport.client.ReqChannel):
                 ret = yield self._uncrypted_transfer(load, tries=tries, timeout=timeout)
             else:
                 ret = yield self._crypted_transfer(load, tries=tries, timeout=timeout)
-        except tornado.iostream.StreamClosedError:
+        except StreamClosedError:
             # Convert to 'SaltClientError' so that clients can handle this
             # exception more appropriately.
             raise SaltClientError('Connection to master lost')
@@ -692,7 +704,7 @@ class TCPReqServerChannel(salt.transport.mixins.auth.AESReqServerMixin, salt.tra
         salt.transport.mixins.auth.AESReqServerMixin.post_fork(self, payload_handler, io_loop)
 
     @tornado.gen.coroutine
-    def handle_message(self, stream, header, payload):
+    def handle_message(self, stream, header, payload, StreamClosedError=iostream.StreamClosedError):
         '''
         Handle incoming messages from underylying tcp streams
         '''
@@ -754,7 +766,7 @@ class TCPReqServerChannel(salt.transport.mixins.auth.AESReqServerMixin, salt.tra
                 stream.close()
         except tornado.gen.Return:
             raise
-        except tornado.iostream.StreamClosedError:
+        except StreamClosedError:
             # Stream was closed. This could happen if the remote side
             # closed the connection on its end (eg in a timeout or shutdown
             # situation).
@@ -779,7 +791,8 @@ class SaltMessageServer(tornado.tcpserver.TCPServer, object):
         self.message_handler = message_handler
 
     @tornado.gen.coroutine
-    def handle_stream(self, stream, address):
+    def handle_stream(self, stream, address,  # pylint: disable=arguments-differ
+                      StreamClosedError=iostream.StreamClosedError):
         '''
         Handle incoming streams and add messages to the incoming queue
         '''
@@ -798,7 +811,7 @@ class SaltMessageServer(tornado.tcpserver.TCPServer, object):
                     header = framed_msg['head']
                     self.io_loop.spawn_callback(self.message_handler, stream, header, framed_msg['body'])
 
-        except tornado.iostream.StreamClosedError:
+        except StreamClosedError:
             log.trace('req client disconnected %s', address)
             self.clients.remove((stream, address))
         except Exception as e:
@@ -874,7 +887,7 @@ class TCPClientKeepAlive(tornado.tcpclient.TCPClient):
         # after one connection has completed.
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         _set_tcp_keepalive(sock, self.opts)
-        stream = tornado.iostream.IOStream(
+        stream = iostream.IOStream(
             sock,
             max_buffer_size=max_buffer_size)
         if tornado.version_info < (5,):
@@ -1062,7 +1075,7 @@ class SaltMessageClient(object):
                 #self._connecting_future.set_exception(e)
 
     @tornado.gen.coroutine
-    def _stream_return(self):
+    def _stream_return(self, StreamClosedError=iostream.StreamClosedError):
         try:
             while not self._closing and (
                     not self._connecting_future.done() or
@@ -1091,7 +1104,7 @@ class SaltMessageClient(object):
                                 self.io_loop.spawn_callback(self._on_recv, header, body)
                             else:
                                 log.error('Got response for message_id %s that we are not tracking', message_id)
-                except tornado.iostream.StreamClosedError as e:
+                except StreamClosedError as e:
                     log.debug('tcp stream to %s:%s closed, unable to recv', self.host, self.port)
                     for future in six.itervalues(self.send_future_map):
                         future.set_exception(e)
@@ -1128,7 +1141,7 @@ class SaltMessageClient(object):
             self._stream_return_future.set_result(True)
 
     @tornado.gen.coroutine
-    def _stream_send(self):
+    def _stream_send(self, StreamClosedError=iostream.StreamClosedError):
         while not self._connecting_future.done() or self._connecting_future.result() is not True:
             yield self._connecting_future
         while len(self.send_queue) > 0:
@@ -1138,7 +1151,7 @@ class SaltMessageClient(object):
                 del self.send_queue[0]
             # if the connection is dead, lets fail this send, and make sure we
             # attempt to reconnect
-            except tornado.iostream.StreamClosedError as e:
+            except StreamClosedError as e:
                 if message_id in self.send_future_map:
                     self.send_future_map.pop(message_id).set_exception(e)
                 self.remove_message_timeout(message_id)
@@ -1355,7 +1368,7 @@ class PubServer(tornado.tcpserver.TCPServer, object):
                 )
 
     @tornado.gen.coroutine
-    def _stream_read(self, client):
+    def _stream_read(self, client, StreamClosedError=iostream.StreamClosedError):
         unpacker = msgpack.Unpacker()
         while not self._closing:
             try:
@@ -1379,7 +1392,7 @@ class PubServer(tornado.tcpserver.TCPServer, object):
                         continue
                     client.id_ = load['id']
                     self._add_client_present(client)
-            except tornado.iostream.StreamClosedError as e:
+            except StreamClosedError as e:
                 log.debug('tcp stream to %s closed, unable to recv', client.address)
                 client.close()
                 self._remove_client_present(client)
@@ -1397,7 +1410,7 @@ class PubServer(tornado.tcpserver.TCPServer, object):
 
     # TODO: ACK the publish through IPC
     @tornado.gen.coroutine
-    def publish_payload(self, package, _):
+    def publish_payload(self, package, _, StreamClosedError=iostream.StreamClosedError):
         log.debug('TCP PubServer sending payload: %s', package)
         payload = salt.transport.frame.frame_msg(package['payload'])
 
@@ -1416,7 +1429,7 @@ class PubServer(tornado.tcpserver.TCPServer, object):
                             # Write the packed str
                             f = client.stream.write(payload)
                             self.io_loop.add_future(f, lambda f: True)
-                        except tornado.iostream.StreamClosedError:
+                        except StreamClosedError:
                             to_remove.append(client)
                 else:
                     log.debug('Publish target %s not connected', topic)
@@ -1426,7 +1439,7 @@ class PubServer(tornado.tcpserver.TCPServer, object):
                     # Write the packed str
                     f = client.stream.write(payload)
                     self.io_loop.add_future(f, lambda f: True)
-                except tornado.iostream.StreamClosedError:
+                except StreamClosedError:
                     to_remove.append(client)
         for client in to_remove:
             log.debug('Subscriber at %s has disconnected from publisher', client.address)

--- a/salt/utils/asynchronous.py
+++ b/salt/utils/asynchronous.py
@@ -84,6 +84,12 @@ class SyncWrapper(object):
         self.io_loop.start()
         return future.result()
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        self.close()
+
     def close(self):
         '''
         On deletion of the asynchronous wrapper, make sure to clean up the asynchronous stuff

--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -411,6 +411,7 @@ class SaltEvent(object):
         if not self.cpub:
             return
 
+        self.subscriber.close()
         self.subscriber = None
         self.pending_events = []
         self.cpub = False
@@ -784,9 +785,10 @@ class SaltEvent(object):
         return self.fire_event(msg, "fire_master", timeout)
 
     def destroy(self):
-        # Do not directly close singleton instances, just set to None
-        self.subscriber = None
-        self.pusher = None
+        if self.subscriber is not None:
+            self.subscriber.close()
+        if self.pusher is not None:
+            self.pusher.close()
         if self._run_io_loop_sync and not self.keep_loop:
             self.io_loop.close()
 
@@ -1061,7 +1063,7 @@ class AsyncEventPublisher(object):
             return
         self._closing = True
         if hasattr(self, 'publisher'):
-            self.publisher = None
+            self.publisher.close()
         if hasattr(self, 'puller'):
             self.puller.close()
 

--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -971,6 +971,11 @@ class AsyncEventPublisher(object):
     TODO: remove references to "minion_event" whenever we need to use this for other things
     '''
     def __init__(self, opts, io_loop=None):
+        try:
+            weakref.finalize(self, self.close)
+        except AttributeError:
+            # FIXME when we go Py3 only
+            pass
         self.opts = salt.config.DEFAULT_MINION_OPTS.copy()
         default_minion_sock_dir = self.opts['sock_dir']
         self.opts.update(opts)
@@ -1074,8 +1079,9 @@ class AsyncEventPublisher(object):
         if hasattr(self, 'puller'):
             self.puller.close()
 
-    def __del__(self):
-        self.close()
+    if six.PY2:
+        def __del__(self):
+            self.close()
 
 
 class EventPublisher(salt.utils.process.SignalHandlingMultiprocessingProcess):
@@ -1085,6 +1091,11 @@ class EventPublisher(salt.utils.process.SignalHandlingMultiprocessingProcess):
     '''
     def __init__(self, opts, **kwargs):
         super(EventPublisher, self).__init__(**kwargs)
+        try:
+            weakref.finalize(self, self.close)
+        except AttributeError:
+            # FIXME when we go Py3 only
+            pass
         self.opts = salt.config.DEFAULT_MASTER_OPTS.copy()
         self.opts.update(opts)
         self._closing = False
@@ -1183,8 +1194,9 @@ class EventPublisher(salt.utils.process.SignalHandlingMultiprocessingProcess):
         self.close()
         super(EventPublisher, self)._handle_signals(signum, sigframe)
 
-    def __del__(self):
-        self.close()
+    if six.PY2:
+        def __del__(self):
+            self.close()
 
 
 class EventReturn(salt.utils.process.SignalHandlingMultiprocessingProcess):


### PR DESCRIPTION
### What does this PR do?
Continuation of #50856. Merge #50856 before this one.

* Reverts #50798 
* Keep track and close IPC singleton instances
* Replaces `__del__` with [`weakref.finalize`](https://docs.python.org/3.5/library/weakref.html?highlight=weakref#weakref.finalize) under Py3.
* Also cleanup TCP and ZeroMQ singletons.

### Tests written?

No

### Commits signed with GPG?

Yes