### PR TITLE
fix typo in file.managed documentation

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -2201,7 +2201,7 @@ def managed(name,
 
     contents_pillar
         .. versionadded:: 0.17.0
-        .. versionchanged: 2016.11.0
+        .. versionchanged:: 2016.11.0
             contents_pillar can also be a list, and the pillars will be
             concatinated together to form one file.
 


### PR DESCRIPTION
Hello,

just a little typo that hide a wonderful feature in the documentation :)

(if that can be backport to 2016/2017/2018 documentation, that would be great)