### PR TITLE
fix error when exception message is not ascii

### DIFF
--- a/salt/log/setup.py
+++ b/salt/log/setup.py
@@ -785,7 +785,7 @@ def __process_multiprocessing_logging_queue(opts, queue):
         except Exception as exc:  # pylint: disable=broad-except
             logging.getLogger(__name__).warning(
                 'An exception occurred in the multiprocessing logging '
-                'queue thread: %s', exc, exc_info_on_loglevel=logging.DEBUG
+                'queue thread: %r', exc, exc_info_on_loglevel=logging.DEBUG
             )
 
 


### PR DESCRIPTION
### What does this PR do?

Pass the exception string instead of the object when an error occured in multiprocessing logging.

### Previous Behavior

Sometimes, my minion gets an error like below. I discovered that was due to an errno message that contains utf-8 characters.

`Process Process-1:
Traceback (most recent call last):
  File "C:\salt\bin\lib\multiprocessing\process.py", line 267, in _bootstrap
    self.run()
  File "C:\salt\bin\lib\multiprocessing\process.py", line 114, in run
    self._target(*self._args, **self._kwargs)
  File "C:\salt\bin\lib\site-packages\salt\log\setup.py", line 1076, in __process_multiprocessing_logging_queue
    'queue thread: %s', exc, exc_info_on_loglevel=logging.DEBUG
  File "C:\salt\bin\lib\logging\__init__.py", line 1179, in warning
    self._log(WARNING, msg, args, **kwargs)
  File "C:\salt\bin\lib\site-packages\salt\log\setup.py", line 328, in _log
    self, level, msg, args, exc_info=exc_info, extra=extra
  File "C:\salt\bin\lib\logging\__init__.py", line 1285, in _log
    record = self.makeRecord(self.name, level, fn, lno, msg, args, exc_info, func, extra)
  File "C:\salt\bin\lib\site-packages\salt\log\setup.py", line 375, in makeRecord
    exc_info, func)
  File "C:\salt\bin\lib\site-packages\salt\log\setup.py", line 209, in __init__
    self.colormsg = '%s%s%s' % (cmsg, self.getMessage(), reset)
  File "C:\salt\bin\lib\logging\__init__.py", line 329, in getMessage
    msg = msg % self.args
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe9 in position 24: ordinal
 not in range(128) `

I do not really know why, but the memory increased exponentially like below.
![image](https://user-images.githubusercontent.com/7715984/50010357-7f9f9e80-ffb9-11e8-82f4-fb1b1b3c54dd.png)

### New Behavior

Now the error message is well displayed like below.
> [WARNING ] An exception occurred in the multiprocessing logging queue thread: [Errno 234] Plus de données sont disponibes

### Tests written?

No

### Commits signed with GPG?

No