### PR TITLE
Fix compound matching in eauth

### DIFF
--- a/salt/utils/minions.py
+++ b/salt/utils/minions.py
@@ -661,26 +661,6 @@ class CkMinions(object):
             minions = []
         return minions
 
-    def _expand_matching(self, auth_entry):
-        ref = {'G': 'grain',
-               'P': 'grain_pcre',
-               'I': 'pillar',
-               'J': 'pillar_pcre',
-               'L': 'list',
-               'S': 'ipcidr',
-               'E': 'pcre',
-               'N': 'node',
-               None: 'compound'}
-
-        target_info = parse_target(auth_entry)
-        if not target_info:
-            log.error('Failed to parse valid target "{0}"'.format(auth_entry))
-
-        v_matcher = ref.get(target_info['engine'])
-        v_expr = target_info['pattern']
-
-        return set(self.check_minions(v_expr, v_matcher))
-
     def validate_tgt(self, valid, expr, tgt_type, minions=None, expr_form=None):
         '''
         Return a Bool. This function returns if the expression sent in is
@@ -697,7 +677,7 @@ class CkMinions(object):
             )
             tgt_type = expr_form
 
-        v_minions = self._expand_matching(valid)
+        v_minions = set(self.check_minions(valid, 'compound'))
         if minions is None:
             minions = set(self.check_minions(expr, tgt_type))
         else:
@@ -824,7 +804,7 @@ class CkMinions(object):
                     continue
             allowed_minions.update(set(auth_list_entry.keys()))
             for key in auth_list_entry:
-                for match in self._expand_matching(key):
+                for match in set(self.check_minions(key, 'compound')):
                     if match in auth_dictionary:
                         auth_dictionary[match].extend(auth_list_entry[key])
                     else:
@@ -832,7 +812,7 @@ class CkMinions(object):
 
         allowed_minions_from_auth_list = set()
         for next_entry in allowed_minions:
-            allowed_minions_from_auth_list.update(self._expand_matching(next_entry))
+            allowed_minions_from_auth_list.update(set(self.check_minions(next_entry, 'compound')))
         # 'minions' here are all the names of minions matched by the target
         # if we take out all the allowed minions, and there are any left, then
         # the target includes minions that are not allowed by eauth


### PR DESCRIPTION
The auth validation functions were using flawed logic to validate the expressions configured for a given eauth plugin. To "expand" the expression, it would use `salt.utils.minions.parse_target()` to analyze the expression. However, this function was intended to be used on individual words in a compound expression, not on a compound expression as a whole. This means that any multi-word compound expression would fail to validate. By assuming that the euth expression is compound and using `check_minions()` to get the list of minions that match the expression, we ensure that it is properly validated.

Fixes #50153.

CC: @thatch45