### PR TITLE
Fix profile outputter docs

### DIFF
--- a/doc/ref/cli/_includes/output-options.rst
+++ b/doc/ref/cli/_includes/output-options.rst
@@ -6,12 +6,9 @@ Output Options
     Pass in an alternative outputter to display the return of data. This
     outputter can be any of the available outputters:
 
-        ``grains``, ``highstate``, ``json``, ``key``, ``overstatestage``, ``pprint``, ``raw``, ``txt``, ``yaml``
+        ``highstate``, ``json``, ``key``, ``overstatestage``, ``pprint``, ``raw``, ``txt``, ``yaml``, and :ref:`many others <all-salt.output>`.
 
-    Some outputters are formatted only for data returned from specific
-    functions; for instance, the ``grains`` outputter will not work for non-grains
-    data.
-
+    Some outputters are formatted only for data returned from specific functions.
     If an outputter is used that does not support the data passed into it, then
     Salt will fall back on the ``pprint`` outputter and display the return data
     using the Python ``pprint`` standard library module.

--- a/doc/ref/output/all/index.rst
+++ b/doc/ref/output/all/index.rst
@@ -22,6 +22,7 @@ Follow one of the below links for further information and examples
     overstatestage
     pony
     pprint_out
+    profile
     progress
     raw
     table_out

--- a/doc/ref/output/all/salt.output.profile.rst
+++ b/doc/ref/output/all/salt.output.profile.rst
@@ -1,0 +1,6 @@
+===================
+salt.output.profile
+===================
+
+.. automodule:: salt.output.profile
+    :members:

--- a/doc/topics/troubleshooting/master.rst
+++ b/doc/topics/troubleshooting/master.rst
@@ -219,6 +219,10 @@ configuration file: ``/etc/salt/master`` and setting the ``timeout`` value to
 change the default timeout for all commands, and then restarting the
 salt-master service.
 
+If a ``state.apply`` run takes too long, you can find a bottleneck by adding the
+:py:mod:`--out=profile <salt.output.profile>` option.
+
+
 Salt Master Auth Flooding
 =========================
 

--- a/doc/topics/troubleshooting/minion.rst
+++ b/doc/topics/troubleshooting/minion.rst
@@ -152,3 +152,6 @@ salt-minion service.
     Modifying the minion timeout value is not required when running commands
     from a Salt Master. It is only required when running commands locally on
     the minion.
+
+If a ``state.apply`` run takes too long, you can find a bottleneck by adding the
+:py:mod:`--out=profile <salt.output.profile>` option.

--- a/salt/output/profile.py
+++ b/salt/output/profile.py
@@ -1,4 +1,31 @@
 # -*- coding: utf-8 -*-
+'''
+Display profiling data in a table format
+========================================
+
+Show profile data for returners that would normally show a highstate output.
+
+    salt MINION state.apply something --out=profile
+
+Attempt to output the returns of state.sls and state.highstate as a table of
+names, modules and durations that looks somewhat like the following::
+
+    name                mod.fun                duration (ms)
+    --------------------------------------------------------
+    I-fail-unless-stmt  other.function               -1.0000
+    old-minion-config   grains.list_present           1.1200
+    salt-data           group.present                48.3800
+    /etc/salt/minion    file.managed                 63.1450
+
+
+To get the above appearance, use settings something like these::
+
+    out.table.separate_rows: False
+    out.table.justify: left
+    out.table.delim: '  '
+    out.table.prefix: ''
+    out.table.suffix: ''
+'''
 from __future__ import absolute_import, print_function, unicode_literals
 import salt.output.table_out as table_out
 
@@ -39,28 +66,7 @@ def _find_durations(data, name_max=60):
 
 def output(data, **kwargs):
     '''
-
-    Show profile data for returners that would normally show a highstate output.
-
-        salt globhere state.sls something --out=profile
-
-    Attempt to output the returns of state.sls and state.highstate as a table of
-    names, modules and durations that looks somewhat like the following:
-
-        name                mod.fun                duration (ms)
-        --------------------------------------------------------
-        I-fail-unless-stmt  other.function               -1.0000
-        old-minion-config   grains.list_present           1.1200
-        salt-data           group.present                48.3800
-        /etc/salt/minion    file.managed                 63.1450
-
-
-    To get the above appearance, use settings something like these:
-      out.table.separate_rows: False
-      out.table.justify: left
-      out.table.delim: '  '
-      out.table.prefix: ''
-      out.table.suffix: ''
+    Display the profiling data in a table format.
     '''
 
     rows = _find_durations(data)


### PR DESCRIPTION
### What does this PR do?

Add the `profile` outputter docs, plus remove the mention of obsolete `grains` output format.

### Tests written?

No

### Commits signed with GPG?

No
