### PR TITLE
Allow shorthand syntax in Pillar top.sls files

### DIFF
--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -600,6 +600,9 @@ class Pillar(object):
                         states = OrderedDict()
                         orders[saltenv][tgt] = 0
                         ignore_missing = False
+                        # handle a pillar sls target written in shorthand form
+                        if isinstance(ctop[saltenv][tgt], six.string_types):
+                            ctop[saltenv][tgt] = [ctop[saltenv][tgt]]
                         for comp in ctop[saltenv][tgt]:
                             if isinstance(comp, dict):
                                 if 'match' in comp:


### PR DESCRIPTION
Allow correct parsing of shorthand sls targets in a pillar top.sls file
as described in
https://docs.saltstack.com/en/latest/ref/states/top.html#shorthand

Fixes #48007

### What does this PR do?
See description at the top.

### What issues does this PR fix or reference?
#48007

### Previous Behavior
Rendering errors as described in #48007 

### New Behavior
Pillar values are correctly referenced when a shorthand sls syntax is used in
a pillar top.sls file.

### Tests written?
No

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
