### PR TITLE
fix a del in cloud vmware that crash when the key isn't there

### DIFF
--- a/salt/cloud/clouds/vmware.py
+++ b/salt/cloud/clouds/vmware.py
@@ -2889,7 +2889,8 @@ def create(vm_):
         log.debug('config_spec set to:\n%s', pprint.pformat(config_spec))
 
     event_kwargs = vm_.copy()
-    del event_kwargs['password']
+    if event_kwargs.get('password'):
+        del event_kwargs['password']
 
     try:
         __utils__['cloud.fire_event'](


### PR DESCRIPTION
so I don't really understand what I've patch but this line always throw a KeyError when i try to deploy a machine on vcenter

(if that can be backport to 2017/2018 that would be great )