### PR TITLE
salt.modules.event tweaks

### DIFF
--- a/salt/modules/event.py
+++ b/salt/modules/event.py
@@ -31,7 +31,7 @@ def _dict_subset(keys, master_dict):
     return dict([(k, v) for k, v in six.iteritems(master_dict) if k in keys])
 
 
-def fire_master(data, tag, preload=None):
+def fire_master(data, tag, preload=None, timeout=60):
     '''
     Fire an event off up to the master server
 
@@ -74,7 +74,7 @@ def fire_master(data, tag, preload=None):
         for master in masters:
             channel = salt.transport.client.ReqChannel.factory(__opts__, master_uri=master)
             try:
-                channel.send(load)
+                channel.send(load, timeout=timeout)
                 # channel.send was successful.
                 # Ensure ret is True.
                 ret = True
@@ -98,7 +98,7 @@ def fire_master(data, tag, preload=None):
             return False
 
 
-def fire(data, tag):
+def fire(data, tag, timeout=None):
     '''
     Fire an event on the local minion event bus. Data must be formed as a dict.
 
@@ -108,14 +108,19 @@ def fire(data, tag):
 
         salt '*' event.fire '{"data":"my event data"}' 'tag'
     '''
+    if timeout is None:
+        timeout = 60000
+    else:
+        timeout = timeout * 1000
     try:
-        event = salt.utils.event.get_event(__opts__['__role'],
+        event = salt.utils.event.get_event(__opts__.get('__role', 'minion'),
                                            sock_dir=__opts__['sock_dir'],
                                            transport=__opts__['transport'],
                                            opts=__opts__,
+                                           keep_loop=True,
                                            listen=False)
 
-        return event.fire_event(data, tag)
+        return event.fire_event(data, tag, timeout=timeout)
     except Exception:
         exc_type, exc_value, exc_traceback = sys.exc_info()
         lines = traceback.format_exception(exc_type, exc_value, exc_traceback)
@@ -130,6 +135,7 @@ def send(tag,
         with_grains=False,
         with_pillar=False,
         with_env_opts=False,
+        timeout=60,
         **kwargs):
     '''
     Send an event to the Salt Master
@@ -173,6 +179,9 @@ def send(tag,
     :type with_env_opts: Specify ``True`` to include ``saltenv`` and
         ``pillarenv`` values or ``False`` to omit them.
 
+    :param timeout: maximum duration to wait to connect to Salt's
+        IPCMessageServer in seconds. Defaults to 60s
+
     :param kwargs: Any additional keyword arguments passed to this function
         will be interpreted as key-value pairs and included in the event data.
         This provides a convenient alternative to YAML for simple values.
@@ -198,7 +207,7 @@ def send(tag,
 
     .. code-block:: bash
 
-        sudo -E salt-call event.send myco/jenkins/build/success with_env=[BUILD_ID, BUILD_URL, GIT_BRANCH, GIT_COMMIT]
+        sudo -E salt-call event.send myco/jenkins/build/success with_env='[BUILD_ID, BUILD_URL, GIT_BRANCH, GIT_COMMIT]'
 
     '''
     data_dict = {}
@@ -233,6 +242,6 @@ def send(tag,
         data_dict.update(data)
 
     if __opts__.get('local') or __opts__.get('file_client') == 'local' or __opts__.get('master_type') == 'disable':
-        return fire(data_dict, tag)
+        return fire(data_dict, tag, timeout=timeout)
     else:
-        return fire_master(data_dict, tag, preload=preload)
+        return fire_master(data_dict, tag, preload=preload, timeout=timeout)

--- a/salt/modules/event.py
+++ b/salt/modules/event.py
@@ -109,7 +109,7 @@ def fire(data, tag):
         salt '*' event.fire '{"data":"my event data"}' 'tag'
     '''
     try:
-        event = salt.utils.event.get_event('minion',  # was __opts__['id']
+        event = salt.utils.event.get_event(__opts__['__role'],
                                            sock_dir=__opts__['sock_dir'],
                                            transport=__opts__['transport'],
                                            opts=__opts__,

--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -145,13 +145,13 @@ def get_event(
                      raise_errors=raise_errors)
 
 
-def get_master_event(opts, sock_dir, listen=True, io_loop=None, raise_errors=False):
+def get_master_event(opts, sock_dir, listen=True, io_loop=None, raise_errors=False, keep_loop=False):
     '''
     Return an event object suitable for the named transport
     '''
     # TODO: AIO core is separate from transport
     if opts['transport'] in ('zeromq', 'tcp', 'detect'):
-        return MasterEvent(sock_dir, opts, listen=listen, io_loop=io_loop, raise_errors=raise_errors)
+        return MasterEvent(sock_dir, opts, listen=listen, io_loop=io_loop, raise_errors=raise_errors, keep_loop=keep_loop)
 
 
 def fire_args(opts, jid, tag_data, prefix=''):


### PR DESCRIPTION
### What does this PR do?
- use  __opts__['__role'] with salt.utils.event.get_event, so that in master/orch it does the right thing
- expose a timeout kwarg when longer than default is needed
- use keep_loop=True to not close ioloop when done

### What issues does this PR fix or reference?
n/a

## Tests written?
No

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
