### PR TITLE
Misc virt fixes

### DIFF
--- a/salt/engines/libvirt_events.py
+++ b/salt/engines/libvirt_events.py
@@ -165,7 +165,7 @@ def _get_libvirt_enum_string(prefix, value):
     # Filter out the values starting with a common base as they match another enum
     prefixes = [_compute_subprefix(p) for p in attributes]
     counts = {p: prefixes.count(p) for p in prefixes}
-    sub_prefixes = [p for p, count in counts.items() if count > 1]
+    sub_prefixes = [p for p, count in counts.items() if count > 1 or (p.endswith('_') and p[:-1] in prefixes)]
     filtered = [attr for attr in attributes if _compute_subprefix(attr) not in sub_prefixes]
 
     for candidate in filtered:

--- a/salt/engines/libvirt_events.py
+++ b/salt/engines/libvirt_events.py
@@ -313,10 +313,9 @@ def _domain_event_graphics_cb(conn, domain, phase, local, remote, auth, subject,
         '''
         transform address structure into event data piece
         '''
-        data = {'family': _get_libvirt_enum_string('{0}_ADDRESS_'.format(prefix), addr['family']),
+        return {'family': _get_libvirt_enum_string('{0}_ADDRESS_'.format(prefix), addr['family']),
                 'node': addr['node'],
                 'service': addr['service']}
-        return addr
 
     _salt_send_domain_event(opaque, conn, domain, opaque['event'], {
         'phase': _get_libvirt_enum_string(prefix, phase),

--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -1786,11 +1786,12 @@ def update(name,
         need_update = True
 
     # Update the memory, note that libvirt outputs all memory sizes in KiB
-    mem_node = desc.find('memory')
-    if mem and int(mem_node.text) != mem * 1024:
-        mem_node.text = six.text_type(mem)
-        mem_node.set('unit', 'MiB')
-        need_update = True
+    for mem_node_name in ['memory', 'currentMemory']:
+        mem_node = desc.find(mem_node_name)
+        if mem and int(mem_node.text) != mem * 1024:
+            mem_node.text = six.text_type(mem)
+            mem_node.set('unit', 'MiB')
+            need_update = True
 
     # Update the XML definition with the new disks and diff changes
     devices_node = desc.find('devices')

--- a/salt/templates/virt/libvirt_domain.jinja
+++ b/salt/templates/virt/libvirt_domain.jinja
@@ -2,6 +2,7 @@
         <name>{{ name }}</name>
         <vcpu>{{ cpu }}</vcpu>
         <memory unit='KiB'>{{ mem }}</memory>
+        <currentMemory unit='KiB'>{{ mem }}</currentMemory>
         <os>
                 <type arch='{{ arch }}'>{{ os_type }}</type>
                 {% if kernel %}<kernel>{{ kernel }}</kernel>{% endif %}

--- a/tests/unit/engines/test_libvirt_events.py
+++ b/tests/unit/engines/test_libvirt_events.py
@@ -56,18 +56,19 @@ class EngineLibvirtEventTestCase(TestCase, LoaderModuleMockMixin):
 
     @patch('salt.engines.libvirt_events.libvirt',
            VIR_PREFIX_FOO=0,
-           VIR_PREFIX_FOO_BAR=1,
-           VIR_PREFIX_BAR_FOO=2)
+           VIR_PREFIX_BAR_FOO=1)
     def test_get_libvirt_enum_string_underscores(self, libvirt_mock):
         '''
         Make sure the libvirt enum value to string works reliably and items
         with an underscore aren't confused with sub prefixes.
         '''
-        assert libvirt_events._get_libvirt_enum_string('VIR_PREFIX_', 1) == 'foo bar'
+        assert libvirt_events._get_libvirt_enum_string('VIR_PREFIX_', 1) == 'bar foo'
 
     @patch('salt.engines.libvirt_events.libvirt',
+           VIR_DOMAIN_EVENT_CRASHED_PANICKED=0,
            VIR_DOMAIN_EVENT_DEFINED=0,
            VIR_DOMAIN_EVENT_UNDEFINED=1,
+           VIR_DOMAIN_EVENT_CRASHED=2,
            VIR_DOMAIN_EVENT_DEFINED_ADDED=0,
            VIR_DOMAIN_EVENT_DEFINED_UPDATED=1)
     def test_get_domain_event_detail(self, mock_libvirt):


### PR DESCRIPTION
### What does this PR do?

Fixes two unrelated bugs:

* libvirt-events engine didn't map the defined/updated domain lifecycle events properly (only with the real libvirt, our unit test had a flaw)
* set/update the current memory as well as the max one on VMs.

### What issues does this PR fix or reference?

None

### Tests written?

Yes

### Commits signed with GPG?

Yes