### PR TITLE
Increase and standardize ShellCase timeouts

### DIFF
--- a/tests/support/case.py
+++ b/tests/support/case.py
@@ -488,8 +488,8 @@ class ShellCase(ShellTestCase, AdaptedConfigurationTestCaseMixin, ScriptPathMixi
         except OSError:
             os.chdir(INTEGRATION_TEST_DIR)
 
-    def run_salt(self, arg_str, with_retcode=False, catch_stderr=False,
-            timeout=RUN_TIMEOUT, popen_kwargs=None):  # pylint: disable=W0221
+    def run_salt(self, arg_str, with_retcode=False, catch_stderr=False,  # pylint: disable=W0221
+            timeout=RUN_TIMEOUT, popen_kwargs=None):
         '''
         Execute salt
         '''
@@ -594,7 +594,8 @@ class ShellCase(ShellTestCase, AdaptedConfigurationTestCaseMixin, ScriptPathMixi
                   fun, opts_arg, ret)
         return ret
 
-    def run_key(self, arg_str, catch_stderr=False, with_retcode=False, timeout=RUN_TIMEOUT):
+    def run_key(self, arg_str, catch_stderr=False, with_retcode=False,  # pylint: disable=W0221
+            timeout=RUN_TIMEOUT):
         '''
         Execute salt-key
         '''
@@ -607,7 +608,8 @@ class ShellCase(ShellTestCase, AdaptedConfigurationTestCaseMixin, ScriptPathMixi
         log.debug('Result of run_key for command \'%s\': %s', arg_str, ret)
         return ret
 
-    def run_cp(self, arg_str, with_retcode=False, catch_stderr=False, timeout=RUN_TIMEOUT):
+    def run_cp(self, arg_str, with_retcode=False, catch_stderr=False,  # pylint: disable=W0221
+            timeout=RUN_TIMEOUT):
         '''
         Execute salt-cp
         '''
@@ -620,7 +622,8 @@ class ShellCase(ShellTestCase, AdaptedConfigurationTestCaseMixin, ScriptPathMixi
                                catch_stderr=catch_stderr,
                                timeout=timeout)
 
-    def run_call(self, arg_str, with_retcode=False, catch_stderr=False, local=False, timeout=RUN_TIMEOUT):
+    def run_call(self, arg_str, with_retcode=False, catch_stderr=False,  # pylint: disable=W0221
+            local=False, timeout=RUN_TIMEOUT):
         '''
         Execute salt-call.
         '''

--- a/tests/support/case.py
+++ b/tests/support/case.py
@@ -480,6 +480,7 @@ class ShellCase(ShellTestCase, AdaptedConfigurationTestCaseMixin, ScriptPathMixi
     _code_dir_ = CODE_DIR
     _script_dir_ = SCRIPT_DIR
     _python_executable_ = PYEXEC
+    RUN_TIMEOUT = 500
 
     def chdir(self, dirname):
         try:
@@ -487,7 +488,8 @@ class ShellCase(ShellTestCase, AdaptedConfigurationTestCaseMixin, ScriptPathMixi
         except OSError:
             os.chdir(INTEGRATION_TEST_DIR)
 
-    def run_salt(self, arg_str, with_retcode=False, catch_stderr=False, timeout=90, popen_kwargs=None):  # pylint: disable=W0221
+    def run_salt(self, arg_str, with_retcode=False, catch_stderr=False,
+            timeout=RUN_TIMEOUT, popen_kwargs=None):  # pylint: disable=W0221
         '''
         Execute salt
         '''
@@ -501,7 +503,7 @@ class ShellCase(ShellTestCase, AdaptedConfigurationTestCaseMixin, ScriptPathMixi
         log.debug('Result of run_salt for command \'%s\': %s', arg_str, ret)
         return ret
 
-    def run_spm(self, arg_str, with_retcode=False, catch_stderr=False, timeout=60):  # pylint: disable=W0221
+    def run_spm(self, arg_str, with_retcode=False, catch_stderr=False, timeout=RUN_TIMEOUT):  # pylint: disable=W0221
         '''
         Execute spm
         '''
@@ -514,7 +516,7 @@ class ShellCase(ShellTestCase, AdaptedConfigurationTestCaseMixin, ScriptPathMixi
         return ret
 
     def run_ssh(self, arg_str, with_retcode=False, catch_stderr=False,  # pylint: disable=W0221
-                timeout=60, wipe=True, raw=False):
+                timeout=RUN_TIMEOUT, wipe=True, raw=False):
         '''
         Execute salt-ssh
         '''
@@ -535,7 +537,7 @@ class ShellCase(ShellTestCase, AdaptedConfigurationTestCaseMixin, ScriptPathMixi
         return ret
 
     def run_run(self, arg_str, with_retcode=False, catch_stderr=False,
-                asynchronous=False, timeout=180, config_dir=None, **kwargs):
+            asynchronous=False, timeout=RUN_TIMEOUT, config_dir=None, **kwargs):
         '''
         Execute salt-run
         '''
@@ -592,7 +594,7 @@ class ShellCase(ShellTestCase, AdaptedConfigurationTestCaseMixin, ScriptPathMixi
                   fun, opts_arg, ret)
         return ret
 
-    def run_key(self, arg_str, catch_stderr=False, with_retcode=False):
+    def run_key(self, arg_str, catch_stderr=False, with_retcode=False, timeout=RUN_TIMEOUT):
         '''
         Execute salt-key
         '''
@@ -601,11 +603,11 @@ class ShellCase(ShellTestCase, AdaptedConfigurationTestCaseMixin, ScriptPathMixi
                               arg_str,
                               catch_stderr=catch_stderr,
                               with_retcode=with_retcode,
-                              timeout=60)
+                              timeout=timeout)
         log.debug('Result of run_key for command \'%s\': %s', arg_str, ret)
         return ret
 
-    def run_cp(self, arg_str, with_retcode=False, catch_stderr=False):
+    def run_cp(self, arg_str, with_retcode=False, catch_stderr=False, timeout=RUN_TIMEOUT):
         '''
         Execute salt-cp
         '''
@@ -616,9 +618,9 @@ class ShellCase(ShellTestCase, AdaptedConfigurationTestCaseMixin, ScriptPathMixi
                                arg_str,
                                with_retcode=with_retcode,
                                catch_stderr=catch_stderr,
-                               timeout=60)
+                               timeout=timeout)
 
-    def run_call(self, arg_str, with_retcode=False, catch_stderr=False, local=False):
+    def run_call(self, arg_str, with_retcode=False, catch_stderr=False, local=False, timeout=RUN_TIMEOUT):
         '''
         Execute salt-call.
         '''
@@ -628,11 +630,11 @@ class ShellCase(ShellTestCase, AdaptedConfigurationTestCaseMixin, ScriptPathMixi
                               arg_str,
                               with_retcode=with_retcode,
                               catch_stderr=catch_stderr,
-                              timeout=60)
+                              timeout=timeout)
         log.debug('Result of run_call for command \'%s\': %s', arg_str, ret)
         return ret
 
-    def run_cloud(self, arg_str, catch_stderr=False, timeout=30):
+    def run_cloud(self, arg_str, catch_stderr=False, timeout=RUN_TIMEOUT):
         '''
         Execute salt-cloud
         '''


### PR DESCRIPTION
### What does this PR do?

Reduce test flakiness by increasing the ShellCase default timeouts.

### What issues does this PR fix or reference?

Fixing multiple failures in:

integration.shell.test_matcher
integration.proxy

When running tests on our Jenkins infrastructure we see lots of tests failing from timeouts intermittently. Increase the timeout so we can get valid test results on overloaded boxes.