### PR TITLE
Document {% include %}

### DIFF
--- a/doc/topics/jinja/index.rst
+++ b/doc/topics/jinja/index.rst
@@ -87,6 +87,13 @@ the context into the included file is required:
 .. code-block:: jinja
 
     {% from 'lib.sls' import test with context %}
+    
+Includes must use full paths, like so:
+
+.. code-block:: jinja
+   :caption: spam/eggs.jinja
+
+    {% include 'spam/foobar.jinja' %}
 
 Including Context During Include/Import
 ---------------------------------------


### PR DESCRIPTION
### What does this PR do?

Mention that jinja includes need to use the full path and cannot use relative paths.

This is a docs-only change.

### What issues does this PR fix or reference?

None, that I'm aware of.