### PR TITLE
Change log level for backend warning

### DIFF
--- a/salt/auth/__init__.py
+++ b/salt/auth/__init__.py
@@ -287,7 +287,7 @@ class LoadAuth(object):
             return False
 
         if load['eauth'] not in self.opts['external_auth']:
-            log.debug('The eauth system "%s" is not enabled', load['eauth'])
+            log.warning('The eauth system "%s" is not enabled', load['eauth'])
             log.warning('Authentication failure of type "eauth" occurred.')
             return False
 


### PR DESCRIPTION
Given that we have other warnings which do expose the auth backend that
is configured, it makes no sense to have this one hidden and it makes
troubleshooting failed logins kind of infuriating otherwise. ;)

