### PR TITLE
Fix twilio version checking

### DIFF
--- a/salt/modules/twilio_notify.py
+++ b/salt/modules/twilio_notify.py
@@ -25,7 +25,9 @@ from salt.ext import six
 HAS_LIBS = False
 try:
     import twilio
-    if twilio.__version__ > 5:
+    # Grab version, ensure elements are ints
+    twilio_version = tuple([int(x) for x in twilio.__version_info__])
+    if twilio_version > (5, ):
         TWILIO_5 = False
         from twilio.rest import Client as TwilioRestClient
         from twilio.rest import TwilioException as TwilioRestException

--- a/tests/unit/modules/test_twilio_notify.py
+++ b/tests/unit/modules/test_twilio_notify.py
@@ -22,7 +22,9 @@ import salt.modules.twilio_notify as twilio_notify
 HAS_LIBS = False
 try:
     import twilio
-    if twilio.__version__ > 5:
+    # Grab version, ensure elements are ints
+    twilio_version = tuple([int(x) for x in twilio.__version_info__])
+    if twilio_version > (5, ):
         TWILIO_5 = False
     else:
         TWILIO_5 = True


### PR DESCRIPTION
`twilio.__version__` is a string and `twilio.__version_info__` is a tuple of strings containing integers [e.g. `('6', '8', '2')`]. The test_twilio_notify unittest fails:

```
ERROR: unit.modules.test_twilio_notify (unittest.loader._FailedTest)
----------------------------------------------------------------------
ImportError: Failed to import test module: unit.modules.test_twilio_notify
Traceback (most recent call last):
  File "/usr/lib/python3.7/unittest/loader.py", line 434, in _find_test_path
    module = self._get_module_from_name(name)
  File "/usr/lib/python3.7/unittest/loader.py", line 375, in _get_module_from_name
    __import__(name)
  File "tests/unit/modules/test_twilio_notify.py", line 20, in <module>
    import salt.modules.twilio_notify as twilio_notify
  File "salt/modules/twilio_notify.py", line 28, in <module>
    if twilio.__version__ > 5:
TypeError: '>' not supported between instances of 'str' and 'int'
```

Fix the twilio version check to use `__version_info__` and converting its elements to int.