### PR TITLE
Fix error message (missing space) in the module ssh

### DIFF
--- a/salt/modules/ssh.py
+++ b/salt/modules/ssh.py
@@ -1136,7 +1136,7 @@ def set_known_host(user=None,
 
         if fingerprint and fingerprint not in known_fingerprints:
             return {'status': 'error',
-                    'error': ('Remote host public keys found but none of their'
+                    'error': ('Remote host public keys found but none of their '
                               'fingerprints match the one you have provided')}
 
         if check_required:


### PR DESCRIPTION
### What does this PR do?
Fix an error message (a space is missing).

### Previous Behavior
Message: 'Remote host public keys found but none of theirfingerprints match the one you have provided'

### New Behavior
Message: 'Remote host public keys found but none of their fingerprints match the one you have provided'

### Tests written?
No

### Commits signed with GPG?
No
