### PR TITLE
Prevent valid return from virt-what creating unhandled exceptions

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -794,7 +794,10 @@ def _virtual(osdata):
                 grains['virtual'] = 'LXC'
                 break
         elif command == 'virt-what':
-            output = output.splitlines()[-1]
+            try:
+                output = output.splitlines()[-1]
+            except IndexError:
+                pass
             if output in ('kvm', 'qemu', 'uml', 'xen', 'lxc'):
                 grains['virtual'] = output
                 break


### PR DESCRIPTION
### What does this PR do?

Fix Issue #50999 by handling zero output (which is valid) from virt-what.

### Previous Behavior

Unhandled exception when output of virt-what is blank.

### New Behavior
No unhandled exception when output of virt-what is blank.

### Tests written?

No

### Commits signed with GPG?

No
