### PR TITLE
Allow clone_from setting in proxmox salt-cloud to be an integer as pe…

### DIFF
--- a/salt/cloud/clouds/proxmox.py
+++ b/salt/cloud/clouds/proxmox.py
@@ -1008,9 +1008,12 @@ def create_node(vm_, newid):
         if 'host' in vm_:
             postParams['target'] = vm_['host']
 
-        if ':' in vm_['clone_from']:
-            vmhost = vm_['clone_from'].split(':')[0]
-            vm_['clone_from'] = vm_['clone_from'].split(':')[1]
+        try:
+            int(vm_['clone_from'])
+        except ValueError:
+            if ':' in vm_['clone_from']:
+                vmhost = vm_['clone_from'].split(':')[0]
+                vm_['clone_from'] = vm_['clone_from'].split(':')[1]
 
         node = query('post', 'nodes/{0}/qemu/{1}/clone'.format(
             vmhost, vm_['clone_from']), postParams)


### PR DESCRIPTION
### What does this PR do?

Allows clone_from option to be an integer in salt-cloud for proxmox as per the documentation.

### What issues does this PR fix or reference?

Fixes #51001

### Previous Behavior
ValueError exception when clone_from is an integer

### New Behavior
Machine is cloned correctly using the clone_from integer on the same host as the new machine (as per previous behaviour)

### Tests written?

No

### Commits signed with GPG?

No

