### PR TITLE
Add a merge option to match.filter_by

### DIFF
--- a/salt/modules/match.py
+++ b/salt/modules/match.py
@@ -320,6 +320,7 @@ def filter_by(lookup,
               tgt_type='compound',
               minion_id=None,
               merge=None,
+              merge_lists=False,
               default='default'):
     '''
     Return the first match in a dictionary of target patterns
@@ -359,7 +360,7 @@ def filter_by(lookup,
                 if lookup[key] is None:
                     return merge
                 else:
-                    salt.utils.dictupdate.update(lookup[key], copy.deepcopy(merge))
+                    salt.utils.dictupdate.update(lookup[key], copy.deepcopy(merge), merge_lists=merge_lists)
 
             return lookup[key]
 

--- a/salt/modules/match.py
+++ b/salt/modules/match.py
@@ -8,6 +8,7 @@ from __future__ import absolute_import, print_function, unicode_literals
 import inspect
 import logging
 import sys
+import collections
 import copy
 
 # Import salt libs
@@ -15,6 +16,7 @@ import salt.minion
 import salt.loader
 from salt.defaults import DEFAULT_TARGET_DELIM
 from salt.ext import six
+from salt.exceptions import SaltException
 
 __func_alias__ = {
     'list_': 'list'
@@ -317,6 +319,7 @@ def glob(tgt, minion_id=None):
 def filter_by(lookup,
               tgt_type='compound',
               minion_id=None,
+              merge=None,
               default='default'):
     '''
     Return the first match in a dictionary of target patterns
@@ -348,6 +351,16 @@ def filter_by(lookup,
     for key in lookup:
         params = (key, minion_id) if minion_id else (key, )
         if expr_funcs[tgt_type](*params):
+            if merge:
+                if not isinstance(merge, collections.Mapping):
+                    raise SaltException(
+                        'filter_by merge argument must be a dictionary.')
+
+                if lookup[key] is None:
+                    return merge
+                else:
+                    salt.utils.dictupdate.update(lookup[key], copy.deepcopy(merge))
+
             return lookup[key]
 
     return lookup.get(default, None)

--- a/tests/unit/modules/test_match.py
+++ b/tests/unit/modules/test_match.py
@@ -1,0 +1,124 @@
+# -*- coding: utf-8 -*-
+'''
+    :codeauthor: Oleg Lipovchenko <oleg.lipovchenko@gmail.com>
+'''
+
+# Import python libs
+from __future__ import absolute_import, print_function, unicode_literals
+
+
+# Import Salt Testing libs
+from tests.support.mixins import LoaderModuleMockMixin
+from tests.support.unit import TestCase, skipIf
+from tests.support.mock import (
+    MagicMock,
+    patch,
+    NO_MOCK,
+    NO_MOCK_REASON,
+)
+
+# Import Salt Libs
+from salt.exceptions import SaltException
+import salt.modules.match as match
+import salt.matchers.compound_match as compound_match
+import salt.matchers.glob_match as glob_match
+
+MATCHERS_DICT = {
+    'compound_match.match': compound_match.match,
+    'glob_match.match': glob_match.match
+    }
+
+# the name of the minion to be used for tests
+MINION_ID = 'bar03'
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+@patch('salt.loader.matchers', MagicMock(return_value=MATCHERS_DICT))
+class MatchTestCase(TestCase, LoaderModuleMockMixin):
+    '''
+    This class contains a set of functions that test salt.modules.match.
+    '''
+
+    def setup_loader_modules(self):
+        return {
+            match: {
+                '__opts__': {
+                    'extension_modules': '',
+                    'id': MINION_ID
+                }
+            },
+            glob_match: {
+                '__opts__': {'id': MINION_ID}
+            }
+        }
+
+    def test_filter_by(self):
+        '''
+        Tests if filter_by returns the correct dictionary.
+        '''
+        lookup = {
+            'foo*': {
+                'key1': 'fooval1', 'key2': 'fooval2'
+            },
+            'bar*': {
+                'key1': 'barval1', 'key2': 'barval2'
+            }
+        }
+        result = {'key1': 'barval1', 'key2': 'barval2'}
+
+        self.assertDictEqual(match.filter_by(lookup), result)
+
+    def test_filter_by_merge(self):
+        '''
+        Tests if filter_by returns a dictionary merged with another dictionary.
+        '''
+        lookup = {
+            'foo*': {
+                'key1': 'fooval1', 'key2': 'fooval2'
+            },
+            'bar*': {
+                'key1': 'barval1', 'key2': 'barval2'
+            }
+        }
+        mdict = {'key1': 'mergeval1'}
+        result = {'key1': 'mergeval1', 'key2': 'barval2'}
+
+        self.assertDictEqual(match.filter_by(lookup, merge=mdict), result)
+
+    def test_filter_by_merge_with_none(self):
+        '''
+        Tests if filter_by merges a None object with a merge dictionary.
+        '''
+        lookup = {
+            'foo*': {
+                'key1': 'fooval1', 'key2': 'fooval2'
+            },
+            'bar*': None
+        }
+
+        # mdict should also be the returned dictionary
+        # since a merge is done with None
+        mdict = {'key1': 'mergeval1'}
+
+        self.assertDictEqual(match.filter_by(lookup, merge=mdict), mdict)
+
+    def test_filter_by_merge_fail(self):
+        '''
+        Tests for an exception if a merge is done without a dictionary.
+        '''
+        lookup = {
+            'foo*': {
+                'key1': 'fooval1', 'key2': 'fooval2'
+            },
+            'bar*': {
+                'key1': 'barval1', 'key2': 'barval2'
+            }
+        }
+        mdict = 'notadict'
+
+        self.assertRaises(
+            SaltException,
+            match.filter_by,
+            lookup,
+            merge=mdict
+        )

--- a/tests/unit/modules/test_match.py
+++ b/tests/unit/modules/test_match.py
@@ -85,6 +85,75 @@ class MatchTestCase(TestCase, LoaderModuleMockMixin):
 
         self.assertDictEqual(match.filter_by(lookup, merge=mdict), result)
 
+    def test_filter_by_merge_lists_rep(self):
+        '''
+        Tests if filter_by merges list values by replacing the original list
+        values with the merged list values.
+        '''
+        lookup = {
+            'foo*': {
+                'list_key': []
+             },
+            'bar*': {
+                'list_key': [
+                    'val1',
+                    'val2'
+                ]
+            }
+        }
+
+        mdict = {
+            'list_key': [
+                'val3',
+                'val4'
+            ]
+        }
+
+        # list replacement specified by the merge_lists=False option
+        result = {
+            'list_key': [
+                'val3',
+                'val4'
+            ]
+        }
+
+        self.assertDictEqual(match.filter_by(lookup, merge=mdict, merge_lists=False), result)
+
+    def test_filter_by_merge_lists_agg(self):
+        '''
+        Tests if filter_by merges list values by aggregating them.
+        '''
+        lookup = {
+            'foo*': {
+                'list_key': []
+             },
+            'bar*': {
+                'list_key': [
+                    'val1',
+                    'val2'
+                ]
+            }
+        }
+
+        mdict = {
+            'list_key': [
+                'val3',
+                'val4'
+            ]
+        }
+
+        # list aggregation specified by the merge_lists=True option
+        result = {
+            'list_key': [
+                'val1',
+                'val2',
+                'val3',
+                'val4'
+            ]
+        }
+
+        self.assertDictEqual(match.filter_by(lookup, merge=mdict, merge_lists=True), result)
+
     def test_filter_by_merge_with_none(self):
         '''
         Tests if filter_by merges a None object with a merge dictionary.


### PR DESCRIPTION
### What does this PR do?
Adds a merge option to match.filter_by for merging a dictionary specified by the **merge** argument with the dictionary specified by the **lookup** argument.

### What issues does this PR fix or reference?
#49845

### Previous Behavior
No merge option existed in match.filter_by.

### New Behavior
Allows merging of dictionaries in match.filter_by.

### Tests written?

Yes; Unit tests created in test_match.py.

### Commits signed with GPG?

Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
