### PR TITLE
Fix cmd.run with cwd and runas on macOS

### DIFF
--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -413,7 +413,7 @@ def _run(cmd,
         if isinstance(cmd, (list, tuple)):
             cmd = ' '.join(map(_cmd_quote, cmd))
 
-        cmd = 'su -l {0} -c "{1}"'.format(runas, cmd)
+        cmd = 'su -l {0} -c "cd {1}; {2}"'.format(runas, cwd, cmd)
         # set runas to None, because if you try to run `su -l` as well as
         # simulate the environment macOS will prompt for the password of the
         # user and will cause salt to hang.

--- a/tests/unit/modules/test_cmdmod.py
+++ b/tests/unit/modules/test_cmdmod.py
@@ -353,7 +353,8 @@ class CMDMODTestCase(TestCase, LoaderModuleMockMixin):
         cwd = '/tmp'
         runas = 'foobar'
 
-        with patch('pwd.getpwnam') as getpwnam_mock:
+        with patch('pwd.getpwnam') as getpwnam_mock, \
+                patch.dict(cmdmod.__grains__, {'os': 'Darwin', 'os_family': 'Solaris'}):
             stdout = cmdmod._run(cmd, cwd=cwd, runas=runas).get('stdout')
         self.assertEqual(stdout, cwd)
 

--- a/tests/unit/modules/test_cmdmod.py
+++ b/tests/unit/modules/test_cmdmod.py
@@ -344,6 +344,18 @@ class CMDMODTestCase(TestCase, LoaderModuleMockMixin):
         else:
             raise RuntimeError
 
+    def test_run_cwd_in_combination_with_runas(self):
+        '''
+        cmd.run executes command in the cwd directory
+        when the runas parameter is specified
+        '''
+        cmd = 'pwd'
+        cwd = '/tmp'
+        runas = 'foobar'
+
+        stdout = cmdmod._run(cmd, cwd=cwd, runas=runas).get('stdout')
+        self.assertEqual(stdout, cwd)
+
     def test_run_all_binary_replace(self):
         '''
         Test for failed decoding of binary data, for instance when doing

--- a/tests/unit/modules/test_cmdmod.py
+++ b/tests/unit/modules/test_cmdmod.py
@@ -353,7 +353,8 @@ class CMDMODTestCase(TestCase, LoaderModuleMockMixin):
         cwd = '/tmp'
         runas = 'foobar'
 
-        stdout = cmdmod._run(cmd, cwd=cwd, runas=runas).get('stdout')
+        with patch('pwd.getpwnam') as getpwnam_mock:
+            stdout = cmdmod._run(cmd, cwd=cwd, runas=runas).get('stdout')
         self.assertEqual(stdout, cwd)
 
     def test_run_all_binary_replace(self):


### PR DESCRIPTION
### What does this PR do?

When calling `cmd.run` with `cwd` in combination with `runas` the working directory was not set on macOS

#### SLS test recipe

```yaml
test 1 - cmd.run as root:
  cmd.run:
    - name: pwd | grep '/Users/Carlos/Desktop'
    - cwd: /Users/Carlos/Desktop

test 2 - cmd.run as user:
  cmd.run:
    - name: pwd | grep '/Users/Carlos/Desktop'
    - cwd: /Users/Carlos/Desktop
    - runas: Carlos

test 3 - git.cloned (uses cmd.run):
  git.cloned:
    - name: https://github.com/robbyrussell/oh-my-zsh.git
    - target: /Users/Carlos/.oh-my-zsh
    - user: Carlos

test 4 - git.latest (uses cmd.run):
  git.latest:
    - name: https://github.com/bhilburn/powerlevel9k.git
    - target: /Users/Carlos/.oh-my-zsh/custom/themes/powerlevel9k
    - user: Carlos
```

### What issues does this PR fix or reference?

#51008

### Previous Behavior

```
local:
----------
          ID: test 1 - cmd.run as root
    Function: cmd.run
        Name: pwd | grep '/Users/Carlos/Desktop'
      Result: True
     Comment: Command "pwd | grep '/Users/Carlos/Desktop'" run
     Started: 14:25:37.286952
    Duration: 13.423 ms
     Changes:
              ----------
              pid:
                  21164
              retcode:
                  0
              stderr:
              stdout:
                  /Users/Carlos/Desktop
----------
          ID: test 2 - cmd.run as user
    Function: cmd.run
        Name: pwd | grep '/Users/Carlos/Desktop'
      Result: False
     Comment: Command "pwd | grep '/Users/Carlos/Desktop'" run
     Started: 14:25:37.300748
    Duration: 58.866 ms
     Changes:
              ----------
              pid:
                  21167
              retcode:
                  1
              stderr:
              stdout:
----------
          ID: test 3 - git.cloned (uses cmd.run)
    Function: git.cloned
        Name: https://github.com/robbyrussell/oh-my-zsh.git
      Result: False
     Comment: Command 'git status -z --porcelain' failed: fatal: not a git repository (or any of the parent directories): .git
     Started: 14:25:37.374095
    Duration: 59.353 ms
     Changes:
----------
          ID: test 4 - git.latest (uses cmd.run)
    Function: git.latest
        Name: https://github.com/bhilburn/powerlevel9k.git
      Result: False
     Comment: fatal: not a git repository (or any of the parent directories): .git
     Started: 14:25:37.433847
    Duration: 1953.688 ms
     Changes:

Summary for local
------------
Succeeded: 1 (changed=2)
Failed:    3
------------
Total states run:     4
Total run time:   2.085 s
```

### New Behavior

```
local:
----------
          ID: test 1 - cmd.run as root
    Function: cmd.run
        Name: pwd | grep '/Users/Carlos/Desktop'
      Result: True
     Comment: Command "pwd | grep '/Users/Carlos/Desktop'" run
     Started: 14:27:03.927846
    Duration: 26.604 ms
     Changes:
              ----------
              pid:
                  21433
              retcode:
                  0
              stderr:
              stdout:
                  /Users/Carlos/Desktop
----------
          ID: test 2 - cmd.run as user
    Function: cmd.run
        Name: pwd | grep '/Users/Carlos/Desktop'
      Result: True
     Comment: Command "pwd | grep '/Users/Carlos/Desktop'" run
     Started: 14:27:03.954871
    Duration: 58.845 ms
     Changes:
              ----------
              pid:
                  21436
              retcode:
                  0
              stderr:
              stdout:
                  /Users/Carlos/Desktop
----------
          ID: test 3 - git.cloned (uses cmd.run)
    Function: git.cloned
        Name: https://github.com/robbyrussell/oh-my-zsh.git
      Result: True
     Comment: Repository already exists at /Users/Carlos/.oh-my-zsh
     Started: 14:27:04.028293
    Duration: 106.831 ms
     Changes:
----------
          ID: test 4 - git.latest (uses cmd.run)
    Function: git.latest
        Name: https://github.com/bhilburn/powerlevel9k.git
      Result: True
     Comment: Repository /Users/Carlos/.oh-my-zsh/custom/themes/powerlevel9k is up-to-date
     Started: 14:27:04.135623
    Duration: 4391.238 ms
     Changes:

Summary for local
------------
Succeeded: 4 (changed=2)
Failed:    0
------------
Total states run:     4
Total run time:   4.584 s
```

### Tests written?

Yes

### Commits signed with GPG?

Yes