### PR TITLE
Add multiple retries and timeout for getting vm resources in proxmox …

### DIFF
--- a/salt/cloud/clouds/proxmox.py
+++ b/salt/cloud/clouds/proxmox.py
@@ -326,22 +326,42 @@ def get_resources_vms(call=None, resFilter=None, includeConfig=True):
 
         salt-cloud -f get_resources_vms my-proxmox-config
     '''
-    log.debug('Getting resource: vms.. (filter: %s)', resFilter)
-    resources = query('get', 'cluster/resources')
 
-    ret = {}
-    for resource in resources:
-        if 'type' in resource and resource['type'] in ['openvz', 'qemu', 'lxc']:
-            name = resource['name']
-            ret[name] = resource
+    timeoutTime = time.time() + 60
+    while True:
+        log.debug('Getting resource: vms.. (filter: %s)', resFilter)
+        resources = query('get', 'cluster/resources')
+        ret = {}
+        badResource = False
+        for resource in resources:
+            if 'type' in resource and resource['type'] in ['openvz', 'qemu',
+                                                           'lxc']:
+                try:
+                    name = resource['name']
+                except KeyError:
+                    badResource = True
+                    log.debug('No name in VM resource %s', repr(resource))
+                    break
 
-            if includeConfig:
-                # Requested to include the detailed configuration of a VM
-                ret[name]['config'] = get_vmconfig(
-                    ret[name]['vmid'],
-                    ret[name]['node'],
-                    ret[name]['type']
-                )
+                ret[name] = resource
+
+                if includeConfig:
+                    # Requested to include the detailed configuration of a VM
+                    ret[name]['config'] = get_vmconfig(
+                        ret[name]['vmid'],
+                        ret[name]['node'],
+                        ret[name]['type']
+                    )
+
+        if time.time() > timeoutTime:
+            raise SaltCloudExecutionTimeout('FAILED to get the proxmox '
+                                            'resources vms')
+
+        # Carry on if there wasn't a bad resource return from Proxmox
+        if not badResource:
+            break
+
+        time.sleep(0.5)
 
     if resFilter is not None:
         log.debug('Filter given: %s, returning requested '


### PR DESCRIPTION
…cloud. Fixes #49485

### What does this PR do?

Introduces more resilient querying of VMs through the proxmox driver when trying to get the VM resources from proxmox.

### What issues does this PR fix or reference?

Fixes issue #49485

### Previous Behavior

After creating a VM via the proxmox API, the machine is un-named. If salt-cloud's proxmox driver queries fast enough after the creation of the VM, the resource will be returned without a name key. This causes the proxmox driver to fail (Raise an unhandled KeyError exception).

### New Behavior

The API request is attempted multiple times for a certain period of time and if the proxmox API query continually fails we raise a saltcloud timeout exception instead.

### Tests written?

No

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
