### PR TITLE
[develop] cmdmod OS X fix

### DIFF
--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -413,7 +413,7 @@ def _run(cmd,
         if isinstance(cmd, (list, tuple)):
             cmd = ' '.join(map(_cmd_quote, cmd))
 
-        cmd = 'su -l {0} -c "cd {1}; {2}"'.format(runas, cwd, cmd)
+        cmd = 'su {0} -c "{2}"'.format(runas, cmd)
         # set runas to None, because if you try to run `su -l` as well as
         # simulate the environment macOS will prompt for the password of the
         # user and will cause salt to hang.


### PR DESCRIPTION
### What does this PR do?
Updating cmdmod when run on Darwin (OS X), removing the -l from the call to su so that the session does not immediately change into the user's home directory, when run with runas.

### What issues does this PR fix or reference?
N/A

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
