### PR TITLE
Move all of PyTest requirements to its own requiremnts file

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -2,8 +2,6 @@
 
 mock>=2.0.0
 SaltPyLint>=v2017.3.6
-pytest>=3.5.0
-pytest-salt>=2018.12.8
 testinfra>=1.7.0,!=1.17.0
 
 # httpretty Needs to be here for now even though it's a dependency of boto.

--- a/requirements/pytest.txt
+++ b/requirements/pytest.txt
@@ -1,5 +1,6 @@
+# PyTest
 pytest >= 4.0.1
-pytest-salt >= 2018.12.7
+pytest-salt >= 2018.12.8
 pytest-timeout >= 1.3.3
 pytest-tempdir >= 2018.8.11
 pytest-helpers-namespace >= 2017.11.11


### PR DESCRIPTION
```
❯ pip install -r requirements/tests.txt
Ignoring tornado: markers 'python_version < "3"' don't match your environment
Ignoring futures: markers 'python_version < "3.0"' don't match your environment
Ignoring pyzmq: markers 'python_version == "3.4"' don't match your environment
Ignoring tornado: markers 'python_version < "3"' don't match your environment
Ignoring futures: markers 'python_version < "3.0"' don't match your environment
Double requirement given: pytest>=4.0.1 (from -r requirements/pytest.txt (line 1)) (already in pytest>=3.5.0 (from -r requirements/dev.txt (line 5)), name='pytest')
```
### Tests written?

No

### Commits signed with GPG?

Yes