### PR TITLE
docs: add VIRTUALENV_ALWAYS_COPY option example

### DIFF
--- a/salt/modules/virtualenv_mod.py
+++ b/salt/modules/virtualenv_mod.py
@@ -134,6 +134,14 @@ def create(path,
     .. code-block:: bash
 
         salt '*' virtualenv.create /path/to/new/virtualenv
+     
+     Example of using --always-copy environment variable (in case your fs doesn't support symlinks).
+     This will copy files into the virtualenv instead of symlinking them.
+     
+     .. code-block:: bash
+        
+         - env:
+           - VIRTUALENV_ALWAYS_COPY: 1
     '''
     if venv_bin is None:
         venv_bin = __opts__.get('venv_bin') or __pillar__.get('venv_bin')


### PR DESCRIPTION
Show how a user can specify VIRTUALENV_ALWAYS_COPY to copy files instead of using symlinks

This is necessary for some filesystems (particularly vboxfs mounted in a linux VM from a windows host) where trying to create symlinks results in a 'protocol error'.

See https://github.com/pypa/pipenv/issues/2084 for discussion

In the future, it might be good to explicitly support the --always-copy switch on the virtualenv command so we don't have to use environment vars this way in Salt.

Open for other suggestions on how to document this, or how to handle this situation in Salt.

I didn't have a way to test the doc generation here, will make a fix if it's needed

### What does this PR do?

### What issues does this PR fix or reference?

### Previous Behavior
Remove this section if not relevant

### New Behavior
Remove this section if not relevant

### Tests written?

Yes/No

### Commits signed with GPG?

Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
