### PR TITLE
AIX lsattr fix for file module.

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -522,6 +522,10 @@ def _cmp_attrs(path, attrs):
     '''
     diff = [None, None]
 
+    # lsattr for AIX is not the same thing as lsattr for linux.
+    if salt.utils.platform.is_aix():
+        return None
+
     try:
         lattrs = lsattr(path).get(path, '')
     except AttributeError:
@@ -544,6 +548,9 @@ def lsattr(path):
     .. versionadded:: 2018.3.0
     .. versionchanged:: 2018.3.1
         If ``lsattr`` is not installed on the system, ``None`` is returned.
+    .. versionchanged:: 2018.3.4
+        If on ``AIX``, ``None`` is returned even if in filesystem as lsattr on ``AIX``
+        is not the same thing as the linux version.
 
     Obtain the modifiable attributes of the given file. If path
     is to a directory, an empty list is returned.
@@ -557,7 +564,7 @@ def lsattr(path):
 
         salt '*' file.lsattr foo1.txt
     '''
-    if not salt.utils.path.which('lsattr'):
+    if not salt.utils.path.which('lsattr') or salt.utils.platform.is_aix():
         return None
 
     if not os.path.exists(path):


### PR DESCRIPTION
Set lsattr functions to return None if `salt.utils.platform.is_aix`

returns true.

This should fix https://github.com/saltstack/salt/issues/49089

### What does this PR do?

Fix https://github.com/saltstack/salt/issues/49089

### What issues does this PR fix or reference?

https://github.com/saltstack/salt/issues/49089

### Previous Behavior
lsattr functions for salt.modules.file would try functioning on AIX when AIX uses a different lsattr

### New Behavior

Return None for functions that let salt.modules.file know if lsattr on AIX

### Tests written?

No

### Commits signed with GPG?

No
