### PR TITLE
Set long_description

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -125,6 +125,7 @@ SALT_SYSPATHS_HARDCODED = os.path.join(os.path.abspath(SETUP_DIRNAME), 'salt', '
 SALT_REQS = os.path.join(os.path.abspath(SETUP_DIRNAME), 'requirements', 'base.txt')
 SALT_ZEROMQ_REQS = os.path.join(os.path.abspath(SETUP_DIRNAME), 'requirements', 'zeromq.txt')
 SALT_WINDOWS_REQS = os.path.join(os.path.abspath(SETUP_DIRNAME), 'pkg', 'windows', 'req.txt')
+SALT_LONG_DESCRIPTION_FILE = os.path.join(os.path.abspath(SETUP_DIRNAME), 'README.rst')
 
 # Salt SSH Packaging Detection
 PACKAGED_FOR_SALT_SSH_FILE = os.path.join(os.path.abspath(SETUP_DIRNAME), '.salt-ssh-package')
@@ -854,6 +855,9 @@ class SaltDistribution(distutils.dist.Distribution):
         self.name = 'salt-ssh' if PACKAGED_FOR_SALT_SSH else 'salt'
         self.salt_version = __version__  # pylint: disable=undefined-variable
         self.description = 'Portable, distributed, remote execution and configuration management system'
+        with open(SALT_LONG_DESCRIPTION_FILE) as f:
+            self.long_description = f.read()
+        self.long_description_content_type = 'text/x-rst'
         self.author = 'Thomas S Hatch'
         self.author_email = 'thatch45@gmail.com'
         self.url = 'http://saltstack.org'


### PR DESCRIPTION
Closes #50964 by setting the `long_description`.

It's good to have information on PyPI if people are looking there, and this does that.

### Previous Behavior
The [salt package on pypi](https://pypi.org/project/salt/) has no project description

<img width="1119" alt="screen shot 2019-01-02 at 4 07 21 pm" src="https://user-images.githubusercontent.com/189750/50615039-90507f80-0ea8-11e9-8e36-ebe9eea16b11.png">


### New Behavior
Now uploading to pypi should also provide a description. It did on test pypi 😄 :
<img width="1119" alt="screen shot 2019-01-02 at 4 08 48 pm" src="https://user-images.githubusercontent.com/189750/50615104-ca218600-0ea8-11e9-9903-f191d2fbb32b.png">

I believe this should also update the description for the `salt-ssh` package.

### Tests written?

No(t relevant?)

### Commits signed with GPG?

Yes
