### PR TITLE
doc: remote_execution: Replace 'saltenv' with 'env' for cmd state module

### DIFF
--- a/doc/topics/execution/remote_execution.rst
+++ b/doc/topics/execution/remote_execution.rst
@@ -81,9 +81,9 @@ Arguments are formatted as YAML:
 
 .. code-block:: bash
 
-    salt '*' cmd.run 'echo "Hello: $FIRST_NAME"' saltenv='{FIRST_NAME: "Joe"}'
+    salt '*' cmd.run 'echo "Hello: $FIRST_NAME"' env='{FIRST_NAME: "Joe"}'
 
-Note: dictionaries must have curly braces around them (like the ``saltenv``
+Note: dictionaries must have curly braces around them (like the ``env``
 keyword argument above).  This was changed in 0.15.1: in the above example,
 the first argument used to be parsed as the dictionary
 ``{'echo "Hello': '$FIRST_NAME"'}``. This was generally not the expected
@@ -94,7 +94,7 @@ If you want to test what parameters are actually passed to a module, use the
 
 .. code-block:: bash
 
-    salt '*' test.arg_repr 'echo "Hello: $FIRST_NAME"' saltenv='{FIRST_NAME: "Joe"}'
+    salt '*' test.arg_repr 'echo "Hello: $FIRST_NAME"' env='{FIRST_NAME: "Joe"}'
 
 Finding available minion functions
 ``````````````````````````````````


### PR DESCRIPTION
The 'cmd' state module accepts an 'env' parameter when we want to define
env variables for the command we are executing. The 'saltenv' is only
used to define which state hierarchy is going to be used by Salt.

### What does this PR do?

Fixes a documentation issue

### Tests written?

No

### Commits signed with GPG?

No