### PR TITLE
[fluorine] fix to salt.utils.vt.Terminal

### DIFF
--- a/salt/utils/vt.py
+++ b/salt/utils/vt.py
@@ -686,7 +686,7 @@ class Terminal(object):
                         stdout = None
                     else:
                         if self.stream_stdout:
-                            self.stream_stdout.write(salt.utils.data.encode(stdout))
+                            self.stream_stdout.write(salt.utils.stringutils.to_str(stdout))
                             self.stream_stdout.flush()
 
                         if self.stdout_logger:


### PR DESCRIPTION
### What does this PR do?
When writing output to stdout we want to ensure that the data is a st…ring not bytes.  Under py2 the salt.utils.data.encode function results in a string but under py3 the result is a bytestring.  Swapping out salt.utils.data.encode for salt.utils.stringutils.to_str.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt-jenkins/issues/1232

### Previous Behavior
salt-cloud under Python3 wasn't working and would endless attempt to perform the initial login for deployment.

### New Behavior
salt-cloud works again under Python3.

### Tests written?
Tests exist.

### Commits signed with GPG?

Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
