### PR TITLE
ss command replace netstat command

### DIFF
--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -1403,7 +1403,6 @@ def _remotes_on(port, which_end):
     if ret is not None and len(ret) > 0:    # ss tools may not be valid
         return ret
     ret = set()
-
     proc_available = False
     for statf in ['/proc/net/tcp', '/proc/net/tcp6']:
         if os.path.isfile(statf):

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -1496,9 +1496,9 @@ def _netlink_tool_remote_on(port, which_end):
         if which_end == 'local_port' and int(local_port) != port:
             continue
         remotes.add(remote_host)
-    else:
-        if valid is False:
-            remotes = None
+
+    if valid is False:
+        remotes = None
     return remotes
 
 

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -1454,6 +1454,7 @@ def _parse_tcp_line(line):
     ret[sl]['state'] = int(comps[3], 16)
     return ret
 
+
 def _netlink_tool_remote_on(port, which_end):
     '''
     Returns set of ipv4 host addresses of remote established connections
@@ -1490,6 +1491,7 @@ def _netlink_tool_remote_on(port, which_end):
             continue
         remotes.add(remote_host)
     return remotes
+
 
 def _sunos_remotes_on(port, which_end):
     '''

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -1399,6 +1399,9 @@ def _remotes_on(port, which_end):
     Return a set of ip addrs active tcp connections
     '''
     port = int(port)
+    ret = _netlink_tool_remote_on(port, which_end)
+    if ret is not None and len(ret) > 0:    # ss tools may not be valid
+        return ret
     ret = set()
 
     proc_available = False
@@ -1451,6 +1454,42 @@ def _parse_tcp_line(line):
     ret[sl]['state'] = int(comps[3], 16)
     return ret
 
+def _netlink_tool_remote_on(port, which_end):
+    '''
+    Returns set of ipv4 host addresses of remote established connections
+    on local or remote tcp port.
+
+    Parses output of shell 'ss' to get connections
+
+    [root@salt-master ~]# ss -ant
+    State      Recv-Q Send-Q               Local Address:Port                 Peer Address:Port
+    LISTEN     0      511                              *:80                              *:*
+    LISTEN     0      128                              *:22                              *:*
+    ESTAB      0      0                      127.0.0.1:56726                  127.0.0.1:4505
+    '''
+    remotes = set()
+    try:
+        data = subprocess.check_output(['ss', '-ant'])  # pylint: disable=minimum-python-version
+    except subprocess.CalledProcessError:
+        log.error('Failed ss')
+        raise
+    except OSError:     # not command "No such file or directory"
+        return None
+
+    lines = salt.utils.to_str(data).split('\n')
+    for line in lines:
+        if 'ESTAB' not in line:
+            continue
+        chunks = line.split()
+        local_host, local_port = chunks[3].split(':')
+        remote_host, remote_port = chunks[4].split(':')
+
+        if which_end == 'remote_port' and int(remote_port) != port:
+            continue
+        if which_end == 'local_port' and int(local_port) != port:
+            continue
+        remotes.add(remote_host)
+    return remotes
 
 def _sunos_remotes_on(port, which_end):
     '''


### PR DESCRIPTION
Reading the /proc/net/tcp file for a machine with a large network connection will consume CPU. So we changed to use the ss command instead of the netstat command to get the network connection first. The ss uses the tcp_diag in the TCP protocol stack so it will be faster than Netstat command is much faster

In fact currently socket.py module does not support the NETLINK_INET_DIAG protocol, so it can only be replaced with the ss tool. When the socket.py module supports more NETLINK protocols, you can using socket.py module to implement

#51070