### PR TITLE
disk: support setting FAT size for format_

### DIFF
--- a/salt/modules/disk.py
+++ b/salt/modules/disk.py
@@ -432,6 +432,7 @@ def format_(device,
             fs_type='ext4',
             inode_size=None,
             lazy_itable_init=None,
+            fat=None,
             force=False):
     '''
     Format a filesystem onto a device
@@ -459,6 +460,10 @@ def format_(device,
 
         This option is only enabled for ext filesystems
 
+    fat
+        FAT size option. Can be 12, 16 or 32, and can only be used on
+        fat or vfat filesystems.
+
     force
         Force mke2fs to create a filesystem, even if the specified device is
         not a partition on a block special device. This option is only enabled
@@ -481,6 +486,9 @@ def format_(device,
     if lazy_itable_init is not None:
         if fs_type[:3] == 'ext':
             cmd.extend(['-E', 'lazy_itable_init={0}'.format(lazy_itable_init)])
+    if fat is not None and fat in (12, 16, 32):
+        if fs_type[-3:] == 'fat':
+            cmd.extend(['-F', fat])
     if force:
         if fs_type[:3] == 'ext':
             cmd.append('-F')


### PR DESCRIPTION
### What does this PR do?

Add new optional parameter `fat` in disk.format_ to specify the FAT size (12, 16 or 32).

### Tests written?

No, current one should be OK