### PR TITLE
Fix shadow.set_date/shadow.set_expire on F28

### DIFF
--- a/salt/modules/shadow.py
+++ b/salt/modules/shadow.py
@@ -349,8 +349,8 @@ def set_date(name, date):
 
         salt '*' shadow.set_date username 0
     '''
-    cmd = 'chage -d {0} {1}'.format(date, name)
-    return not __salt__['cmd.run'](cmd, python_shell=False)
+    cmd = ['chage', '-d', date, name]
+    return __salt__['cmd.retcode'](cmd, python_shell=False) == 0
 
 
 def set_expire(name, expire):
@@ -367,8 +367,8 @@ def set_expire(name, expire):
 
         salt '*' shadow.set_expire username -1
     '''
-    cmd = 'chage -E {0} {1}'.format(expire, name)
-    return not __salt__['cmd.run'](cmd, python_shell=False)
+    cmd = ['chage', '-E', expire, name]
+    return __salt__['cmd.retcode'](cmd, python_shell=False) == 0
 
 
 def list_users():


### PR DESCRIPTION
When there are problems with SSSD, warnings are written to stderr but as long as chage succeeds, the command will exit with a zero exit code.

These two functions were returning True only when there is no CLI output, instead of checking the retcode as they should have.

This commit fixes this, allowing F28 (and any other distros which use SSSD) to properly report success/failure when there are SSSD warnings in the output from chage.

Refs https://github.com/saltstack/salt-jenkins/issues/1238