### PR TITLE
Set encoding when reading the README.rst

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -855,7 +855,7 @@ class SaltDistribution(distutils.dist.Distribution):
         self.name = 'salt-ssh' if PACKAGED_FOR_SALT_SSH else 'salt'
         self.salt_version = __version__  # pylint: disable=undefined-variable
         self.description = 'Portable, distributed, remote execution and configuration management system'
-        with open(SALT_LONG_DESCRIPTION_FILE) as f:
+        with open(SALT_LONG_DESCRIPTION_FILE, encoding='utf-8') as f:
             self.long_description = f.read()
         self.long_description_content_type = 'text/x-rst'
         self.author = 'Thomas S Hatch'


### PR DESCRIPTION
### What does this PR do?

What it says on the tin

### What issues does this PR fix or reference?

Apparently there are some unicode sequences in the setup.py that cause
issues for some people - see https://github.com/saltstack/salt/issues/50964#issuecomment-451856830

### Previous Behavior

Uses some default encodings based on environment, compile flags, etc.

### New Behavior

Forces utf-8 encoding

### Tests written?

No - besides simply doing `open(..., encoding='ascii')`, I couldn't actually get this to fail locally. But running `open('README.rst', encoding='ascii')` does fail. `encoding='utf-8'` succeeds.

If someone has a specific idea for how I could write a test for this, I would be glad to implement it!

### Commits signed with GPG?

Yes