### PR TITLE
Update purefa module to support NVMeF NQN for host connectivity

### DIFF
--- a/salt/modules/purefa.py
+++ b/salt/modules/purefa.py
@@ -615,7 +615,7 @@ def volume_detach(name, host):
             return False
 
 
-def host_create(name, iqn=None, wwn=None):
+def host_create(name, iqn=None, wwn=None, nqn=None):
     '''
 
     Add a host on a Pure Storage FlashArray.
@@ -630,6 +630,8 @@ def host_create(name, iqn=None, wwn=None):
         name of host (truncated to 63 characters)
     iqn : string
         iSCSI IQN of host
+    nqn : string
+        NVMeF NQN of host
     wwn : string
         Fibre Channel WWN of host
 
@@ -637,7 +639,7 @@ def host_create(name, iqn=None, wwn=None):
 
     .. code-block:: bash
 
-        salt '*' purefa.host_create foo iqn='<Valid iSCSI IQN>' wwn='<Valid WWN>'
+        salt '*' purefa.host_create foo iqn='<Valid iSCSI IQN>' wwn='<Valid WWN>' nqn='<Valid NQN>'
 
     '''
     array = _get_system()
@@ -648,6 +650,12 @@ def host_create(name, iqn=None, wwn=None):
             array.create_host(name)
         except purestorage.PureError:
             return False
+        if nqn is not None:
+            try:
+                array.set_host(name, addnqnlist=[nqn])
+            except purestorage.PureError:
+                array.delete_host(name)
+                return False
         if iqn is not None:
             try:
                 array.set_host(name, addiqnlist=[iqn])
@@ -666,7 +674,7 @@ def host_create(name, iqn=None, wwn=None):
     return True
 
 
-def host_update(name, iqn=None, wwn=None):
+def host_update(name, iqn=None, wwn=None, nqn=None):
     '''
 
     Update a hosts port definitions on a Pure Storage FlashArray.
@@ -679,6 +687,8 @@ def host_update(name, iqn=None, wwn=None):
 
     name : string
         name of host
+    nqn : string
+        Additional NVMeF NQN of host
     iqn : string
         Additional iSCSI IQN of host
     wwn : string
@@ -688,11 +698,16 @@ def host_update(name, iqn=None, wwn=None):
 
     .. code-block:: bash
 
-        salt '*' purefa.host_update foo iqn='<Valid iSCSI IQN>' wwn='<Valid WWN>'
+        salt '*' purefa.host_update foo iqn='<Valid iSCSI IQN>' wwn='<Valid WWN>' nqn='<Valid NQN>'
 
     '''
     array = _get_system()
     if _get_host(name, array) is not None:
+        if nqn is not None:
+            try:
+                array.set_host(name, addnqnlist=[nqn])
+            except purestorage.PureError:
+                return False
         if iqn is not None:
             try:
                 array.set_host(name, addiqnlist=[iqn])


### PR DESCRIPTION
### What does this PR do?
Add support for NVMeF as a transport protocol for hosts in a Pure Storage FlashArray.
NQN parameter added to host_create and host_update. 
With the merge of #50953 this will allow grains to populate this new parameter

### Tests written?

No

### Commits signed with GPG?

No