### PR TITLE
Updates to salt-junos modules

### DIFF
--- a/salt/modules/junos.py
+++ b/salt/modules/junos.py
@@ -1051,26 +1051,6 @@ def install_os(path=None, **kwargs):
     ret = {}
     ret['out'] = True
 
-    if path is None:
-        ret['message'] = \
-            'Please provide the salt path where the junos image is present.'
-        ret['out'] = False
-        return ret
-
-    image_cached_path = salt.utils.files.mkstemp()
-    __salt__['cp.get_file'](path, image_cached_path)
-
-    if not os.path.isfile(image_cached_path):
-        ret['message'] = 'Invalid image path.'
-        ret['out'] = False
-        return ret
-
-    if os.path.getsize(image_cached_path) == 0:
-        ret['message'] = 'Failed to copy image'
-        ret['out'] = False
-        return ret
-    path = image_cached_path
-
     op = {}
     if '__pub_arg' in kwargs:
         if kwargs['__pub_arg']:
@@ -1078,6 +1058,29 @@ def install_os(path=None, **kwargs):
                 op.update(kwargs['__pub_arg'][-1])
     else:
         op.update(kwargs)
+
+    no_copy_ = op.get('no_copy', False)
+
+    if path is None:
+        ret['message'] = \
+            'Please provide the salt path where the junos image is present.'
+        ret['out'] = False
+        return ret
+
+    if not no_copy_:
+        image_cached_path = salt.utils.files.mkstemp()
+        __salt__['cp.get_file'](path, image_cached_path)
+
+        if not os.path.isfile(image_cached_path):
+            ret['message'] = 'Invalid image path.'
+            ret['out'] = False
+            return ret
+
+        if os.path.getsize(image_cached_path) == 0:
+            ret['message'] = 'Failed to copy image'
+            ret['out'] = False
+            return ret
+        path = image_cached_path
 
     try:
         conn.sw.install(path, progress=True, **op)
@@ -1087,7 +1090,8 @@ def install_os(path=None, **kwargs):
         ret['out'] = False
         return ret
     finally:
-        salt.utils.files.safe_rm(image_cached_path)
+        if not no_copy_:
+            salt.utils.files.safe_rm(image_cached_path)
 
     if 'reboot' in op and op['reboot'] is True:
         try:

--- a/salt/modules/junos.py
+++ b/salt/modules/junos.py
@@ -958,6 +958,10 @@ def install_config(path=None, **kwargs):
             ret['message'] = 'Loaded configuration but commit check failed.'
             ret['out'] = False
             cu.rollback()
+        else:
+            ret['message'] = 'Commit check passed, but skipping commit for dry-run.'
+            ret['out'] = True
+            cu.rollback()
 
         try:
             if write_diff and config_diff is not None:

--- a/salt/modules/junos.py
+++ b/salt/modules/junos.py
@@ -18,7 +18,6 @@ Refer to :mod:`junos <salt.proxy.junos>` for information on connecting to junos 
 from __future__ import absolute_import, print_function, unicode_literals
 import logging
 import os
-from functools import wraps
 
 try:
     from lxml import etree

--- a/salt/modules/junos.py
+++ b/salt/modules/junos.py
@@ -70,16 +70,6 @@ def __virtual__():
                        'junos-eznc or jxmlease or proxy could not be loaded.')
 
 
-def resultdecorator(function):
-    @wraps(function)
-    def wrapper(*args, **kwargs):
-        ret = function(*args, **kwargs)
-        ret['result'] = ret['out']
-        return ret
-
-    return wrapper
-
-@resultdecorator
 def facts_refresh():
     '''
     Reload the facts dictionary from the device. Usually only needed if,
@@ -112,7 +102,7 @@ def facts_refresh():
         log.error('Grains could not be updated due to "%s"', exception)
     return ret
 
-@resultdecorator
+
 def facts():
     '''
     Displays the facts gathered during the connection.
@@ -134,7 +124,7 @@ def facts():
         ret['out'] = False
     return ret
 
-@resultdecorator
+# 
 def rpc(cmd=None, dest=None, **kwargs):
     '''
     This function executes the RPC provided as arguments on the junos device.
@@ -254,7 +244,7 @@ def rpc(cmd=None, dest=None, **kwargs):
             fp.write(salt.utils.stringutils.to_str(write_response))
     return ret
 
-@resultdecorator
+
 def set_hostname(hostname=None, **kwargs):
     '''
     Set the device's hostname
@@ -330,7 +320,7 @@ def set_hostname(hostname=None, **kwargs):
         conn.cu.rollback()
     return ret
 
-@resultdecorator
+
 def commit(**kwargs):
     '''
     To commit the changes loaded in the candidate configuration.
@@ -424,7 +414,7 @@ def commit(**kwargs):
 
     return ret
 
-@resultdecorator
+
 def rollback(**kwargs):
     '''
     Roll back the last committed configuration changes and commit
@@ -511,7 +501,7 @@ def rollback(**kwargs):
         ret['out'] = False
     return ret
 
-@resultdecorator
+
 def diff(**kwargs):
     '''
     Returns the difference between the candidate and the current configuration
@@ -542,7 +532,7 @@ def diff(**kwargs):
 
     return ret
 
-@resultdecorator
+
 def ping(dest_ip=None, **kwargs):
     '''
     Send a ping RPC to a device
@@ -604,7 +594,7 @@ def ping(dest_ip=None, **kwargs):
         ret['out'] = False
     return ret
 
-@resultdecorator
+
 def cli(command=None, **kwargs):
     '''
     Executes the CLI commands and returns the output in specified format. \
@@ -668,7 +658,7 @@ def cli(command=None, **kwargs):
     ret['out'] = True
     return ret
 
-@resultdecorator
+
 def shutdown(**kwargs):
     '''
     Shut down (power off) or reboot a device running Junos OS. This includes
@@ -743,7 +733,7 @@ def shutdown(**kwargs):
         ret['out'] = False
     return ret
 
-@resultdecorator
+
 def install_config(path=None, **kwargs):
     '''
     Installs the given configuration file into the candidate configuration.
@@ -953,7 +943,7 @@ def install_config(path=None, **kwargs):
 
     return ret
 
-@resultdecorator
+
 def zeroize():
     '''
     Resets the device to default factory settings
@@ -976,7 +966,7 @@ def zeroize():
 
     return ret
 
-@resultdecorator
+
 def install_os(path=None, **kwargs):
     '''
     Installs the given image on the device. After the installation is complete\
@@ -1064,7 +1054,7 @@ def install_os(path=None, **kwargs):
         ret['message'] = 'Successfully installed and rebooted!'
     return ret
 
-@resultdecorator
+
 def file_copy(src=None, dest=None):
     '''
     Copies the file from the local device to the junos device
@@ -1111,7 +1101,7 @@ def file_copy(src=None, dest=None):
         ret['out'] = False
     return ret
 
-@resultdecorator
+
 def lock():
     '''
     Attempts an exclusive lock on the candidate configuration. This
@@ -1141,7 +1131,7 @@ def lock():
 
     return ret
 
-@resultdecorator
+
 def unlock():
     '''
     Unlocks the candidate configuration.
@@ -1165,7 +1155,7 @@ def unlock():
 
     return ret
 
-@resultdecorator
+
 def load(path=None, **kwargs):
     '''
     Loads the configuration from the file provided onto the device.
@@ -1292,7 +1282,7 @@ def load(path=None, **kwargs):
 
     return ret
 
-@resultdecorator
+
 def commit_check():
     '''
     Perform a commit check on the configuration

--- a/salt/modules/junos.py
+++ b/salt/modules/junos.py
@@ -85,11 +85,13 @@ def facts_refresh():
     conn = __proxy__['junos.conn']()
     ret = dict()
     ret['out'] = True
+    ret['result'] = False
     try:
         conn.facts_refresh()
     except Exception as exception:
         ret['message'] = 'Execution failed due to "{0}"'.format(exception)
         ret['out'] = False
+        ret['result'] = False
         return ret
 
     ret['facts'] = __proxy__['junos.get_serialized_facts']()
@@ -122,7 +124,7 @@ def facts():
         ret['out'] = False
     return ret
 
-
+# 
 def rpc(cmd=None, dest=None, **kwargs):
     '''
     This function executes the RPC provided as arguments on the junos device.
@@ -912,7 +914,7 @@ def install_config(path=None, **kwargs):
             ret['out'] = False
             return ret
 
-        if check and not test:
+        if check:
             try:
                 cu.commit(**commit_params)
                 ret['message'] = 'Successfully loaded and committed!'
@@ -922,8 +924,8 @@ def install_config(path=None, **kwargs):
                     .format(exception)
                 ret['out'] = False
                 return ret
-        elif not check:
-            ret['message'] = 'Setting it here'
+        else:
+            ret['message'] = 'Loaded configuration but commit check failed.'
             ret['out'] = False
             cu.rollback()
 

--- a/salt/modules/junos.py
+++ b/salt/modules/junos.py
@@ -445,7 +445,7 @@ def rollback(**kwargs):
     '''
     Roll back the last committed configuration changes and commit
 
-    r_id : 0
+    id : 0
         The rollback ID value (0-49)
 
     dev_timeout : 30
@@ -471,7 +471,7 @@ def rollback(**kwargs):
 
         salt 'device_name' junos.rollback 10
     '''
-    id_ = kwargs.pop('r_id', 0)
+    id_ = kwargs.pop('id', 0)
 
     ret = {}
     conn = __proxy__['junos.conn']()

--- a/salt/modules/junos.py
+++ b/salt/modules/junos.py
@@ -955,13 +955,13 @@ def install_config(path=None, **kwargs):
                 ret['out'] = False
                 return ret
         elif not check:
-            ret['message'] = 'Loaded configuration but commit check failed.'
+            cu.rollback()
+            ret['message'] = 'Loaded configuration but commit check failed, hence rolling back configuration.'
             ret['out'] = False
-            cu.rollback()
         else:
-            ret['message'] = 'Commit check passed, but skipping commit for dry-run.'
-            ret['out'] = True
             cu.rollback()
+            ret['message'] = 'Commit check passed, but skipping commit for dry-run and rolling back configuration.'
+            ret['out'] = True
 
         try:
             if write_diff and config_diff is not None:

--- a/salt/modules/junos.py
+++ b/salt/modules/junos.py
@@ -1384,7 +1384,7 @@ def get_table(table, table_file, path=None, target=None, key=None, key_items=Non
             file_name = file_loc[0]
         elif len(file_loc) > 1:
             ret['message'] = 'Given table file %s is located at multiple location'\
-                % file
+                % table_file
             ret['out'] = False
             return ret
         elif len(file_loc) == 0:

--- a/salt/modules/junos.py
+++ b/salt/modules/junos.py
@@ -1378,15 +1378,12 @@ def get_table(table, table_file, path=None, target=None, key=None, key_items=Non
         get_kvargs['args'] = args
     pyez_tables_path = os.path.dirname(os.path.abspath(tables_dir.__file__))
     try:
-        file_loc = glob.glob(os.path.join(path, '{}'.format(table_file))) or \
-                   glob.glob(os.path.join(pyez_tables_path, '{}'.format(table_file)))
+        if path is not None:
+            file_loc = glob.glob(os.path.join(path, '{}'.format(table_file)))
+        else:
+            file_loc = glob.glob(os.path.join(pyez_tables_path, '{}'.format(table_file)))
         if len(file_loc) == 1:
             file_name = file_loc[0]
-        elif len(file_loc) > 1:
-            ret['message'] = 'Given table file %s is located at multiple location'\
-                % table_file
-            ret['out'] = False
-            return ret
         else:
             ret['message'] = 'Given table file %s cannot be located' % table_file
             ret['out'] = False

--- a/salt/modules/junos.py
+++ b/salt/modules/junos.py
@@ -116,7 +116,7 @@ def facts_refresh():
         salt 'device_name' junos.facts_refresh
     '''
     conn = __proxy__['junos.conn']()
-    ret = dict()
+    ret = {}
     ret['out'] = True
     try:
         conn.facts_refresh()
@@ -145,7 +145,7 @@ def facts():
 
         salt 'device_name' junos.facts
     '''
-    ret = dict()
+    ret = {}
     try:
         ret['facts'] = __proxy__['junos.get_serialized_facts']()
         ret['out'] = True
@@ -195,7 +195,7 @@ def rpc(cmd=None, dest=None, **kwargs):
     '''
 
     conn = __proxy__['junos.conn']()
-    ret = dict()
+    ret = {}
     ret['out'] = True
 
     if cmd is None:
@@ -301,7 +301,7 @@ def set_hostname(hostname=None, **kwargs):
         salt 'device_name' junos.set_hostname salt-device
     '''
     conn = __proxy__['junos.conn']()
-    ret = dict()
+    ret = {}
     if hostname is None:
         ret['message'] = 'Please provide the hostname.'
         ret['out'] = False
@@ -473,7 +473,7 @@ def rollback(**kwargs):
     '''
     id_ = kwargs.pop('id', 0)
 
-    ret = dict()
+    ret = {}
     conn = __proxy__['junos.conn']()
 
     op = dict()
@@ -550,7 +550,7 @@ def diff(**kwargs):
         salt.utils.args.invalid_kwargs(kwargs)
 
     conn = __proxy__['junos.conn']()
-    ret = dict()
+    ret = {}
     ret['out'] = True
     try:
         ret['message'] = conn.cu.diff(rb_id=id_)
@@ -597,7 +597,7 @@ def ping(dest_ip=None, **kwargs):
         salt 'device_name' junos.ping '8.8.8.8' ttl=1 rapid=True
     '''
     conn = __proxy__['junos.conn']()
-    ret = dict()
+    ret = {}
 
     if dest_ip is None:
         ret['message'] = 'Please specify the destination ip to ping.'
@@ -658,7 +658,7 @@ def cli(command=None, **kwargs):
     if not format_:
         format_ = 'text'
 
-    ret = dict()
+    ret = {}
     if command is None:
         ret['message'] = 'Please provide the CLI command to be executed.'
         ret['out'] = False
@@ -727,10 +727,10 @@ def shutdown(**kwargs):
         salt 'device_name' junos.shutdown shutdown=True
     '''
     conn = __proxy__['junos.conn']()
-    ret = dict()
+    ret = {}
     sw = SW(conn)
 
-    op = dict()
+    op = {}
     if '__pub_arg' in kwargs:
         if kwargs['__pub_arg']:
             if isinstance(kwargs['__pub_arg'][-1], dict):
@@ -843,7 +843,7 @@ def install_config(path=None, **kwargs):
         salt 'device_name' junos.install_config 'salt://syslog_template.conf' template_vars='{"syslog_host": "10.180.222.7"}'
     '''
     conn = __proxy__['junos.conn']()
-    ret = dict()
+    ret = {}
     ret['out'] = True
 
     if path is None:
@@ -852,7 +852,7 @@ def install_config(path=None, **kwargs):
         ret['out'] = False
         return ret
 
-    op = dict()
+    op = {}
     if '__pub_arg' in kwargs:
         if kwargs['__pub_arg']:
             if isinstance(kwargs['__pub_arg'][-1], dict):
@@ -860,7 +860,7 @@ def install_config(path=None, **kwargs):
     else:
         op.update(kwargs)
 
-    template_vars = dict()
+    template_vars = {}
     if "template_vars" in op:
         template_vars = op["template_vars"]
 
@@ -981,7 +981,7 @@ def zeroize():
         salt 'device_name' junos.zeroize
     '''
     conn = __proxy__['junos.conn']()
-    ret = dict()
+    ret = {}
     ret['out'] = True
     try:
         conn.cli('request system zeroize')
@@ -1024,7 +1024,7 @@ def install_os(path=None, **kwargs):
         salt 'device_name' junos.install_os 'salt://junos_16_1.tgz' dev_timeout=300
     '''
     conn = __proxy__['junos.conn']()
-    ret = dict()
+    ret = {}
     ret['out'] = True
 
     if path is None:
@@ -1047,7 +1047,7 @@ def install_os(path=None, **kwargs):
         return ret
     path = image_cached_path
 
-    op = dict()
+    op = {}
     if '__pub_arg' in kwargs:
         if kwargs['__pub_arg']:
             if isinstance(kwargs['__pub_arg'][-1], dict):
@@ -1096,7 +1096,7 @@ def file_copy(src=None, dest=None):
         salt 'device_name' junos.file_copy /home/m2/info.txt info_copy.txt
     '''
     conn = __proxy__['junos.conn']()
-    ret = dict()
+    ret = {}
     ret['out'] = True
 
     if src is None:
@@ -1145,7 +1145,7 @@ def lock():
         salt 'device_name' junos.lock
     '''
     conn = __proxy__['junos.conn']()
-    ret = dict()
+    ret = {}
     ret['out'] = True
     try:
         conn.cu.lock()
@@ -1168,7 +1168,7 @@ def unlock():
         salt 'device_name' junos.unlock
     '''
     conn = __proxy__['junos.conn']()
-    ret = dict()
+    ret = {}
     ret['out'] = True
     try:
         conn.cu.unlock()
@@ -1235,7 +1235,7 @@ def load(path=None, **kwargs):
         salt 'device_name' junos.load 'salt://syslog_template.conf' template_vars='{"syslog_host": "10.180.222.7"}'
     '''
     conn = __proxy__['junos.conn']()
-    ret = dict()
+    ret = {}
     ret['out'] = True
 
     if path is None:
@@ -1244,7 +1244,7 @@ def load(path=None, **kwargs):
         ret['out'] = False
         return ret
 
-    op = dict()
+    op = {}
     if '__pub_arg' in kwargs:
         if kwargs['__pub_arg']:
             if isinstance(kwargs['__pub_arg'][-1], dict):
@@ -1252,7 +1252,7 @@ def load(path=None, **kwargs):
     else:
         op.update(kwargs)
 
-    template_vars = dict()
+    template_vars = {}
     if "template_vars" in op:
         template_vars = op["template_vars"]
 
@@ -1319,7 +1319,7 @@ def commit_check():
         salt 'device_name' junos.commit_check
     '''
     conn = __proxy__['junos.conn']()
-    ret = dict()
+    ret = {}
     ret['out'] = True
     try:
         conn.cu.commit_check()
@@ -1333,7 +1333,7 @@ def commit_check():
 
 def get_table(table, table_file, path=None, target=None, key=None, key_items=None,
               filters=None, args=None):
-    """
+    '''
     Retrieve data from a Junos device using Tables/Views
     Usage:
     .. code-block:: bash
@@ -1358,10 +1358,10 @@ def get_table(table, table_file, path=None, target=None, key=None, key_items=Non
           To select only filter for the dictionary from columns
         * args:
           key/value pair which should render Jinja template command
-    """
+    '''
 
     conn = __proxy__['junos.conn']()
-    ret = dict()
+    ret = {}
     ret['out'] = True
     ret['hostname'] = conn._hostname
     ret['tablename'] = table

--- a/salt/modules/junos.py
+++ b/salt/modules/junos.py
@@ -1387,8 +1387,8 @@ def get_table(table, table_file, path=None, target=None, key=None, key_items=Non
                 % table_file
             ret['out'] = False
             return ret
-        elif len(file_loc) == 0:
-            ret['message'] = 'Given table file %s cannot be located' % file
+        else:
+            ret['message'] = 'Given table file %s cannot be located' % table_file
             ret['out'] = False
             return ret
         try:
@@ -1398,7 +1398,7 @@ def get_table(table, table_file, path=None, target=None, key=None, key_items=Non
                 globals().update(FactoryLoader().load(ret['table']))
         except IOError as err:
             ret['message'] = 'Uncaught exception during YAML Load - please ' \
-                             'report: {0}'.format(str(err))
+                             'report: {0}'.format(six.text_type(err))
             ret['out'] = False
             return ret
         try:
@@ -1406,7 +1406,7 @@ def get_table(table, table_file, path=None, target=None, key=None, key_items=Non
             data.get(**get_kvargs)
         except KeyError as err:
             ret['message'] = 'Uncaught exception during get API call - please ' \
-                             'report: {0}'.format(str(err))
+                             'report: {0}'.format(six.text_type(err))
             ret['out'] = False
             return ret
         ret['reply'] = json.loads(data.to_json())

--- a/salt/modules/junos.py
+++ b/salt/modules/junos.py
@@ -85,13 +85,11 @@ def facts_refresh():
     conn = __proxy__['junos.conn']()
     ret = dict()
     ret['out'] = True
-    ret['result'] = False
     try:
         conn.facts_refresh()
     except Exception as exception:
         ret['message'] = 'Execution failed due to "{0}"'.format(exception)
         ret['out'] = False
-        ret['result'] = False
         return ret
 
     ret['facts'] = __proxy__['junos.get_serialized_facts']()
@@ -124,7 +122,7 @@ def facts():
         ret['out'] = False
     return ret
 
-# 
+
 def rpc(cmd=None, dest=None, **kwargs):
     '''
     This function executes the RPC provided as arguments on the junos device.
@@ -914,7 +912,7 @@ def install_config(path=None, **kwargs):
             ret['out'] = False
             return ret
 
-        if check:
+        if check and not test:
             try:
                 cu.commit(**commit_params)
                 ret['message'] = 'Successfully loaded and committed!'
@@ -924,8 +922,8 @@ def install_config(path=None, **kwargs):
                     .format(exception)
                 ret['out'] = False
                 return ret
-        else:
-            ret['message'] = 'Loaded configuration but commit check failed.'
+        elif not check:
+            ret['message'] = 'Setting it here'
             ret['out'] = False
             cu.rollback()
 

--- a/salt/modules/junos.py
+++ b/salt/modules/junos.py
@@ -19,6 +19,10 @@ from __future__ import absolute_import, print_function, unicode_literals
 import logging
 import os
 from functools import wraps
+import traceback
+import json
+import glob
+import yaml
 
 try:
     from lxml import etree
@@ -43,6 +47,11 @@ try:
     import jnpr.junos.utils
     import jnpr.junos.cfg
     import jxmlease
+    from jnpr.junos.factory.optable import OpTable
+    import jnpr.junos.op as tables_dir
+    from jnpr.junos.factory.factory_loader import FactoryLoader
+    import yamlordereddictloader
+    from jnpr.junos.exception import ConnectClosedError
     # pylint: enable=W0611
     HAS_JUNOS = True
 except ImportError:
@@ -66,8 +75,9 @@ def __virtual__():
     if HAS_JUNOS and 'proxy' in __opts__:
         return __virtualname__
     else:
-        return (False, 'The junos module could not be loaded: '
-                       'junos-eznc or jxmlease or proxy could not be loaded.')
+        return (False, 'The junos or dependent module could not be loaded: '
+                       'junos-eznc or jxmlease or or yamlordereddictloader or '
+                       'proxy could not be loaded.')
 
 
 def timeoutDecorator(function):
@@ -1318,4 +1328,114 @@ def commit_check():
         ret['message'] = 'Commit check failed with {0}'.format(exception)
         ret['out'] = False
 
+    return ret
+
+
+def get_table(table, table_file, path=None, target=None, key=None, key_items=None,
+              filters=None, args=None):
+    """
+    Retrieve data from a Junos device using Tables/Views
+    Usage:
+    .. code-block:: bash
+        salt 'device_name' junos.get_table
+    Parameters:
+      Required
+        * table:
+          Name of PyEZ Table
+        * table_file:
+          YAML file that has the table specified in table parameter
+      Optional
+        * path:
+          Path of location of the YAML file.
+          defaults to op directory in jnpr.junos.op
+        * target:
+          if command need to run on FPC, can specify fpc target
+        * key:
+          To overwrite key provided in YAML
+        * key_items:
+          To select only given key items
+        * filters:
+          To select only filter for the dictionary from columns
+        * args:
+          key/value pair which should render Jinja template command
+    """
+
+    conn = __proxy__['junos.conn']()
+    ret = dict()
+    ret['out'] = True
+    ret['hostname'] = conn._hostname
+    ret['tablename'] = table
+    get_kvargs = {}
+    if target is not None:
+        get_kvargs['target'] = target
+    if key is not None:
+        get_kvargs['key'] = key
+    if key_items is not None:
+        get_kvargs['key_items'] = key_items
+    if filters is not None:
+        get_kvargs['filters'] = filters
+    if args is not None and isinstance(args, dict):
+        get_kvargs['args'] = args
+    pyez_tables_path = os.path.dirname(os.path.abspath(tables_dir.__file__))
+    try:
+        file_loc = glob.glob(os.path.join(path, '{}'.format(table_file))) or \
+                   glob.glob(os.path.join(pyez_tables_path, '{}'.format(table_file)))
+        if len(file_loc) == 1:
+            file_name = file_loc[0]
+        elif len(file_loc) > 1:
+            ret['message'] = 'Given table file %s is located at multiple location'\
+                % file
+            ret['out'] = False
+            return ret
+        elif len(file_loc) == 0:
+            ret['message'] = 'Given table file %s cannot be located' % file
+            ret['out'] = False
+            return ret
+        try:
+            with salt.utils.fopen(file_name) as fp:
+                ret['table'] = yaml.load(fp.read(),
+                                         Loader=yamlordereddictloader.Loader)
+                globals().update(FactoryLoader().load(ret['table']))
+        except IOError as err:
+            ret['message'] = 'Uncaught exception during YAML Load - please ' \
+                             'report: {0}'.format(str(err))
+            ret['out'] = False
+            return ret
+        try:
+            data = globals()[table](conn)
+            data.get(**get_kvargs)
+        except KeyError as err:
+            ret['message'] = 'Uncaught exception during get API call - please ' \
+                             'report: {0}'.format(str(err))
+            ret['out'] = False
+            return ret
+        ret['reply'] = json.loads(data.to_json())
+        if data.__class__.__bases__[0] == OpTable:
+            # Sets key value if not present in YAML. To be used by returner
+            if ret['table'][table].get('key') is None:
+                ret['table'][table]['key'] = data.ITEM_NAME_XPATH
+            # If key is provided from salt state file.
+            if key is not None:
+                ret['table'][table]['key'] = data.KEY
+        else:
+            if target is not None:
+                ret['table'][table]['target'] = data.TARGET
+            if key is not None:
+                ret['table'][table]['key'] = data.KEY
+            if key_items is not None:
+                ret['table'][table]['key_items'] = data.KEY_ITEMS
+            if args is not None:
+                ret['table'][table]['args'] = data.CMD_ARGS
+                ret['table'][table]['command'] = data.GET_CMD
+    except ConnectClosedError:
+        ret['message'] = 'Got ConnectClosedError exception. Connection lost ' \
+                         'with %s' % conn
+        ret['out'] = False
+        return ret
+    except Exception as err:
+        ret['message'] = 'Uncaught exception - please report: {0}'.format(
+            str(err))
+        traceback.print_exc()
+        ret['out'] = False
+        return ret
     return ret

--- a/salt/modules/junos.py
+++ b/salt/modules/junos.py
@@ -85,13 +85,11 @@ def facts_refresh():
     conn = __proxy__['junos.conn']()
     ret = dict()
     ret['out'] = True
-    ret['result'] = False
     try:
         conn.facts_refresh()
     except Exception as exception:
         ret['message'] = 'Execution failed due to "{0}"'.format(exception)
         ret['out'] = False
-        ret['result'] = False
         return ret
 
     ret['facts'] = __proxy__['junos.get_serialized_facts']()
@@ -124,7 +122,7 @@ def facts():
         ret['out'] = False
     return ret
 
-# 
+
 def rpc(cmd=None, dest=None, **kwargs):
     '''
     This function executes the RPC provided as arguments on the junos device.

--- a/salt/modules/junos.py
+++ b/salt/modules/junos.py
@@ -1003,6 +1003,13 @@ def install_os(path=None, **kwargs):
     path (required)
         Path where the image file is present on the proxy minion
 
+    remote_path :
+        If the value of path  is a file path on the local
+        (Salt host's) filesystem, then the image is copied from the local
+        filesystem to the :remote_path: directory on the target Junos
+        device. The default is ``/var/tmp``. If the value of :path: or
+        is a URL, then the value of :remote_path: is unused.
+
     dev_timeout : 30
         The NETCONF RPC timeout (in seconds). This argument was added since most of
         the time the "package add" RPC takes a significant amount of time.  The default
@@ -1015,6 +1022,23 @@ def install_os(path=None, **kwargs):
 
     no_copy : False
         If ``True`` the software package will not be SCP’d to the device
+
+    bool validate:
+        When ``True`` this method will perform a config validation against
+        the new image
+
+    bool issu:
+        When ``True`` allows unified in-service software upgrade
+        (ISSU) feature enables you to upgrade between two different Junos OS
+        releases with no disruption on the control plane and with minimal
+        disruption of traffic.
+
+    bool nssu:
+        When ``True`` allows nonstop software upgrade (NSSU)
+        enables you to upgrade the software running on a Juniper Networks
+        EX Series Virtual Chassis or a Juniper Networks EX Series Ethernet
+        Switch with redundant Routing Engines with a single command and
+        minimal disruption to network traffic.
 
     CLI Examples:
 
@@ -1056,7 +1080,7 @@ def install_os(path=None, **kwargs):
         op.update(kwargs)
 
     try:
-        conn.sw.install(path, progress=True)
+        conn.sw.install(path, progress=True, **op)
         ret['message'] = 'Installed the os.'
     except Exception as exception:
         ret['message'] = 'Installation failed due to: "{0}"'.format(exception)

--- a/salt/modules/junos.py
+++ b/salt/modules/junos.py
@@ -445,7 +445,7 @@ def rollback(**kwargs):
     '''
     Roll back the last committed configuration changes and commit
 
-    id : 0
+    r_id : 0
         The rollback ID value (0-49)
 
     dev_timeout : 30
@@ -471,7 +471,7 @@ def rollback(**kwargs):
 
         salt 'device_name' junos.rollback 10
     '''
-    id_ = kwargs.pop('id', 0)
+    id_ = kwargs.pop('r_id', 0)
 
     ret = {}
     conn = __proxy__['junos.conn']()

--- a/salt/modules/junos.py
+++ b/salt/modules/junos.py
@@ -110,7 +110,7 @@ def facts_refresh():
         __salt__['saltutil.sync_grains']()
     except Exception as exception:
         log.error('Grains could not be updated due to "%s"', exception)
-    return ret.transform()
+    return ret
 
 @resultdecorator
 def facts():

--- a/salt/proxy/junos.py
+++ b/salt/proxy/junos.py
@@ -46,8 +46,9 @@ try:
     import jnpr.junos.utils
     import jnpr.junos.utils.config
     import jnpr.junos.utils.sw
-    from jnpr.junos.exception import RpcTimeoutError, ConnectClosedError, RpcError, ConnectError, \
-        ProbeError, ConnectAuthError, ConnectRefusedError, ConnectTimeoutError
+    from jnpr.junos.exception import RpcTimeoutError, ConnectClosedError,\
+        RpcError, ConnectError, ProbeError, ConnectAuthError,\
+        ConnectRefusedError, ConnectTimeoutError
     from ncclient.operations.errors import TimeoutExpiredError
 except ImportError:
     HAS_JUNOS = False
@@ -106,7 +107,8 @@ def init(opts):
     thisproxy['conn'] = jnpr.junos.Device(**args)
     try:
         thisproxy['conn'].open()
-    except (ProbeError, ConnectAuthError, ConnectRefusedError, ConnectTimeoutError, ConnectError) as ex:
+    except (ProbeError, ConnectAuthError, ConnectRefusedError, ConnectTimeoutError,
+            ConnectError) as ex:
         log.error("%s : not able to initiate connection to the device" % ex)
         thisproxy['initialized'] = False
         return

--- a/salt/proxy/junos.py
+++ b/salt/proxy/junos.py
@@ -46,10 +46,8 @@ try:
     import jnpr.junos.utils
     import jnpr.junos.utils.config
     import jnpr.junos.utils.sw
-    from jnpr.junos.exception import RpcTimeoutError
-    from jnpr.junos.exception import ConnectClosedError
-    from jnpr.junos.exception import RpcError
-    from jnpr.junos.exception import ConnectError
+    from jnpr.junos.exception import RpcTimeoutError, ConnectClosedError, RpcError, ConnectError, \
+        ProbeError, ConnectAuthError, ConnectRefusedError, ConnectTimeoutError
     from ncclient.operations.errors import TimeoutExpiredError
 except ImportError:
     HAS_JUNOS = False
@@ -106,9 +104,22 @@ def init(opts):
             args[arg] = opts['proxy'][arg]
 
     thisproxy['conn'] = jnpr.junos.Device(**args)
-    thisproxy['conn'].open()
-    thisproxy['conn'].bind(cu=jnpr.junos.utils.config.Config)
-    thisproxy['conn'].bind(sw=jnpr.junos.utils.sw.SW)
+    try:
+        thisproxy['conn'].open()
+    except (ProbeError, ConnectAuthError, ConnectRefusedError, ConnectTimeoutError, ConnectError) as ex:
+        log.error("%s : not able to initiate connection to the device" % ex)
+        thisproxy['initialized'] = False
+        return
+
+    try:
+        thisproxy['conn'].bind(cu=jnpr.junos.utils.config.Config)
+    except Exception as ex:
+        log.error('Bind failed with Config class due to: %s' % ex)
+
+    try:
+        thisproxy['conn'].bind(sw=jnpr.junos.utils.sw.SW)
+    except Exception as ex:
+        log.error('Bind failed with SW class due to: %s' % ex)
     thisproxy['initialized'] = True
 
 

--- a/salt/proxy/junos.py
+++ b/salt/proxy/junos.py
@@ -189,6 +189,20 @@ def proxytype():
     return 'junos'
 
 
+def get_serialized_facts():
+    facts = dict(thisproxy['conn'].facts)
+    if 'version_info' in facts:
+        facts['version_info'] = \
+            dict(facts['version_info'])
+    # For backward compatibility. 'junos_info' is present
+    # only of in newer versions of facts.
+    if 'junos_info' in facts:
+        for re in facts['junos_info']:
+            facts['junos_info'][re]['object'] = \
+                dict(facts['junos_info'][re]['object'])
+    return facts
+
+
 def shutdown(opts):
     '''
     This is called when the proxy-minion is exiting to make sure the

--- a/salt/states/junos.py
+++ b/salt/states/junos.py
@@ -542,3 +542,40 @@ def commit_check(name):
     ret = {'name': name, 'changes': {}, 'result': True, 'comment': ''}
     ret['changes'] = __salt__['junos.commit_check']()
     return ret
+
+@resultdecorator
+def get_table(name, table, table_file, **kwargs):
+    '''
+    Retrieve data from a Junos device using Tables/Views
+    .. code-block:: yaml
+        get route details:
+            junos:
+              - get_table
+              - table: RouteTable
+              - file: routes.yml
+    Parameters:
+      Required
+        * name:
+          task definition
+        * table:
+          Name of PyEZ Table
+        * file:
+          YAML file that has the table specified in table parameter
+      Optional
+        * path:
+          Path of location of the YAML file.
+          defaults to op directory in jnpr.junos.op
+        * target:
+          if command need to run on FPC, can specify fpc target
+        * key:
+          To overwrite key provided in YAML
+        * key_items:
+          To select only given key items
+        * filters:
+          To select only filter for the dictionary from columns
+        * args:
+          key/value pair which should render Jinja template command
+    '''
+    ret = {'name': name, 'changes': {}, 'result': True, 'comment': ''}
+    ret['changes'] = __salt__['junos.get_table'](table, table_file, **kwargs)
+    return ret

--- a/salt/states/junos.py
+++ b/salt/states/junos.py
@@ -79,7 +79,7 @@ def rpc(name, dest=None, format='xml', args=None, **kwargs):
             *args,
             **kwargs)
     else:
-        ret['changes'] = __salt__['junos.rpc'](name, dest, format, **kwargs)
+        ret['changes'] = __salt__['junos.rpc'](name, dest, **kwargs)
     return ret
 
 
@@ -162,7 +162,7 @@ def commit(name, **kwargs):
 
 
 @resultdecorator
-def rollback(name, id, **kwargs):
+def rollback(name, **kwargs):
     '''
     Rollbacks the committed changes.
 
@@ -192,12 +192,12 @@ def rollback(name, id, **kwargs):
 
     '''
     ret = {'name': name, 'changes': {}, 'result': True, 'comment': ''}
-    ret['changes'] = __salt__['junos.rollback'](id, **kwargs)
+    ret['changes'] = __salt__['junos.rollback'](**kwargs)
     return ret
 
 
 @resultdecorator
-def diff(name, d_id):
+def diff(name, **kwargs):
     '''
     Gets the difference between the candidate and the current configuration.
 
@@ -214,7 +214,7 @@ def diff(name, d_id):
           The rollback id value [0-49]. (default = 0)
     '''
     ret = {'name': name, 'changes': {}, 'result': True, 'comment': ''}
-    ret['changes'] = __salt__['junos.diff'](d_id)
+    ret['changes'] = __salt__['junos.diff'](**kwargs)
     return ret
 
 

--- a/salt/states/junos.py
+++ b/salt/states/junos.py
@@ -32,7 +32,7 @@ def resultdecorator(function):
 
 
 @resultdecorator
-def rpc(name, dest=None, format='xml', args=None, **kwargs):
+def rpc(name, dest=None, **kwargs):
     '''
     Executes the given rpc. The returned data can be stored in a file
     by specifying the destination path with dest as an argument
@@ -71,15 +71,7 @@ def rpc(name, dest=None, format='xml', args=None, **kwargs):
               Name of the interface whose information you want.
     '''
     ret = {'name': name, 'changes': {}, 'result': True, 'comment': ''}
-    if args is not None:
-        ret['changes'] = __salt__['junos.rpc'](
-            name,
-            dest,
-            format,
-            *args,
-            **kwargs)
-    else:
-        ret['changes'] = __salt__['junos.rpc'](name, dest, **kwargs)
+    ret['changes'] = __salt__['junos.rpc'](name, dest, **kwargs)
     return ret
 
 

--- a/salt/states/junos.py
+++ b/salt/states/junos.py
@@ -16,10 +16,22 @@ Refer to :mod:`junos <salt.proxy.junos>` for information on connecting to junos 
 # Import Python libs
 from __future__ import absolute_import, print_function, unicode_literals
 import logging
+from functools import wraps
 
 log = logging.getLogger()
 
 
+def resultdecorator(function):
+    @wraps(function)
+    def wrapper(*args, **kwargs):
+        ret = function(*args, **kwargs)
+        ret['result'] = ret['changes']['out']
+        return ret
+
+    return wrapper
+
+
+@resultdecorator
 def rpc(name, dest=None, format='xml', args=None, **kwargs):
     '''
     Executes the given rpc. The returned data can be stored in a file
@@ -71,6 +83,7 @@ def rpc(name, dest=None, format='xml', args=None, **kwargs):
     return ret
 
 
+@resultdecorator
 def set_hostname(name, **kwargs):
     '''
     Changes the hostname of the device.
@@ -104,6 +117,7 @@ def set_hostname(name, **kwargs):
     return ret
 
 
+@resultdecorator
 def commit(name, **kwargs):
     '''
     Commits the changes loaded into the candidate configuration.
@@ -147,6 +161,7 @@ def commit(name, **kwargs):
     return ret
 
 
+@resultdecorator
 def rollback(name, id, **kwargs):
     '''
     Rollbacks the committed changes.
@@ -181,6 +196,7 @@ def rollback(name, id, **kwargs):
     return ret
 
 
+@resultdecorator
 def diff(name, d_id):
     '''
     Gets the difference between the candidate and the current configuration.
@@ -202,6 +218,7 @@ def diff(name, d_id):
     return ret
 
 
+@resultdecorator
 def cli(name, format='text', **kwargs):
     '''
     Executes the CLI commands and reuturns the text output.
@@ -234,6 +251,7 @@ def cli(name, format='text', **kwargs):
     return ret
 
 
+@resultdecorator
 def shutdown(name, **kwargs):
     '''
     Shuts down the device.
@@ -260,6 +278,7 @@ def shutdown(name, **kwargs):
     return ret
 
 
+@resultdecorator
 def install_config(name, **kwargs):
     '''
     Loads and commits the configuration provided.
@@ -331,6 +350,7 @@ def install_config(name, **kwargs):
     return ret
 
 
+@resultdecorator
 def zeroize(name):
     '''
     Resets the device to default factory settings.
@@ -347,6 +367,7 @@ def zeroize(name):
     return ret
 
 
+@resultdecorator
 def install_os(name, **kwargs):
     '''
     Installs the given image on the device. After the installation is complete
@@ -382,6 +403,7 @@ def install_os(name, **kwargs):
     return ret
 
 
+@resultdecorator
 def file_copy(name, dest=None, **kwargs):
     '''
     Copies the file from the local device to the junos device.
@@ -405,6 +427,7 @@ def file_copy(name, dest=None, **kwargs):
     return ret
 
 
+@resultdecorator
 def lock(name):
     '''
     Attempts an exclusive lock on the candidate configuration. This
@@ -426,6 +449,7 @@ def lock(name):
     return ret
 
 
+@resultdecorator
 def unlock(name):
     '''
     Unlocks the candidate configuration.
@@ -441,6 +465,7 @@ def unlock(name):
     return ret
 
 
+@resultdecorator
 def load(name, **kwargs):
     '''
     Loads the configuration provided onto the junos device.
@@ -502,6 +527,7 @@ def load(name, **kwargs):
     return ret
 
 
+@resultdecorator
 def commit_check(name):
     '''
 

--- a/tests/unit/modules/test_junos.py
+++ b/tests/unit/modules/test_junos.py
@@ -1712,7 +1712,7 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
         ret_exp = {'out': False, 'hostname': '1.1.1.1',
                    'tablename': 'ModuleTable',
                    'message': 'Got ConnectClosedError exception. Connection lost with Device(1.1.1.1)'}
-        with patch('jnpr.junos.factory.FactoryLoader.load') as mock_load:
+        with patch('jnpr.junos.factory.optable.OpTable.get') as mock_load:
             dev = Device(host='1.1.1.1', user='rick')
             mock_load.side_effect = ConnectClosedError(dev)
             ret = junos.get_table(table, file)

--- a/tests/unit/modules/test_junos.py
+++ b/tests/unit/modules/test_junos.py
@@ -4,6 +4,7 @@
 '''
 # Import python libs
 from __future__ import absolute_import, print_function, unicode_literals
+import os
 
 # Import test libs
 from tests.support.mixins import LoaderModuleMockMixin, XMLEqualityMixin
@@ -21,6 +22,9 @@ try:
     from jnpr.junos.utils.sw import SW
     from jnpr.junos.device import Device
     import jxmlease  # pylint: disable=unused-import
+    import jnpr.junos.op as tables_dir
+    from jnpr.junos.exception import ConnectClosedError, LockError, RpcError, \
+        UnlockError
     HAS_JUNOS = True
 except ImportError:
     HAS_JUNOS = False
@@ -1370,8 +1374,9 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
 
     def test_virtual_proxy_unavailable(self):
         with patch.dict(junos.__opts__, {}):
-            res = (False, 'The junos module could not be '
-                          'loaded: junos-eznc or jxmlease or proxy could not be loaded.')
+            res = (False, 'The junos or dependent module could not be loaded: '
+                          'junos-eznc or jxmlease or or yamlordereddictloader or '
+                          'proxy could not be loaded.')
             self.assertEqual(junos.__virtual__(), res)
 
     def test_virtual_all_true(self):
@@ -1486,3 +1491,243 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
                 junos.rpc('get-chassis-inventory', '/path/to/file')
                 writes = m_open.write_calls()
                 assert writes == ['xml rpc reply'], writes
+
+    def test_lock_success(self):
+        ret_exp = {'out': True, 'message': 'Successfully locked the configuration.'}
+        ret = junos.lock()
+        self.assertEqual(ret, ret_exp)
+
+    def test_lock_error(self):
+        ret_exp = {'out': False, 'message': 'Could not gain lock due to : "LockError"'}
+        with patch('jnpr.junos.utils.config.Config.lock') as mock_lock:
+            mock_lock.side_effect = LockError(None)
+            ret = junos.lock()
+            self.assertEqual(ret, ret_exp)
+
+    def test_unlock_success(self):
+        ret_exp = {'out': True, 'message': 'Successfully unlocked the configuration.'}
+        ret = junos.unlock()
+        self.assertEqual(ret, ret_exp)
+
+    def test_unlock_error(self):
+        ret_exp = {'out': False, 'message': 'Could not unlock configuration due to : "UnlockError"'}
+        with patch('jnpr.junos.utils.config.Config.unlock') as mock_unlock:
+            mock_unlock.side_effect = UnlockError(None)
+            ret = junos.unlock()
+            self.assertEqual(ret, ret_exp)
+
+    def test_load_none_path(self):
+        ret_exp = {'out': False,
+                   'message': 'Please provide the salt path where the configuration is present'}
+        ret = junos.load()
+        self.assertEqual(ret, ret_exp)
+
+    def test_load_wrong_tmp_file(self):
+        ret_exp = {'out': False, 'message': 'Invalid file path.'}
+        with patch('salt.utils.files.mkstemp') as mock_mkstemp:
+            mock_mkstemp.return_value = '/pat/to/tmp/file'
+            ret = junos.load('/path/to/file')
+            self.assertEqual(ret, ret_exp)
+
+    def test_load_invalid_path(self):
+        ret_exp = {'out': False, 'message': 'Template failed to render'}
+        ret = junos.load('/path/to/file')
+        self.assertEqual(ret, ret_exp)
+
+    def test_load_no_extension(self):
+        ret_exp = {'out': True, 'message': 'Successfully loaded the configuration.'}
+        with patch('os.path.getsize') as mock_getsize, \
+                patch('jnpr.junos.utils.config.Config.load') as mock_load, \
+                patch('salt.utils.files.mkstemp') as mock_mkstmp, \
+                patch('os.path.isfile') as mock_isfile:
+            mock_getsize.return_value = 1000
+            mock_mkstmp.return_value = '/path/to/file'
+            mock_isfile.return_value = True
+            ret = junos.load('/path/to/file')
+            mock_load.assert_called_with(format='text', path='/path/to/file')
+            self.assertEqual(ret, ret_exp)
+
+    def test_load_xml_extension(self):
+        ret_exp = {'out': True, 'message': 'Successfully loaded the configuration.'}
+        with patch('os.path.getsize') as mock_getsize, \
+                patch('jnpr.junos.utils.config.Config.load') as mock_load, \
+                patch('salt.utils.files.mkstemp') as mock_mkstmp, \
+                patch('os.path.isfile') as mock_isfile:
+            mock_getsize.return_value = 1000
+            mock_mkstmp.return_value = '/path/to/file'
+            mock_isfile.return_value = True
+            ret = junos.load('/path/to/file.xml')
+            mock_load.assert_called_with(format='xml', path='/path/to/file')
+            self.assertEqual(ret, ret_exp)
+
+    def test_load_set_extension(self):
+        ret_exp = {'out': True, 'message': 'Successfully loaded the configuration.'}
+        with patch('os.path.getsize') as mock_getsize, \
+                patch('jnpr.junos.utils.config.Config.load') as mock_load, \
+                patch('salt.utils.files.mkstemp') as mock_mkstmp, \
+                patch('os.path.isfile') as mock_isfile:
+            mock_getsize.return_value = 1000
+            mock_mkstmp.return_value = '/path/to/file'
+            mock_isfile.return_value = True
+            ret = junos.load('/path/to/file.set')
+            mock_load.assert_called_with(format='set', path='/path/to/file')
+            self.assertEqual(ret, ret_exp)
+
+    def test_load_replace_true(self):
+        ret_exp = {'out': True, 'message': 'Successfully loaded the configuration.'}
+        with patch('os.path.getsize') as mock_getsize, \
+                patch('jnpr.junos.utils.config.Config.load') as mock_load, \
+                patch('salt.utils.files.mkstemp') as mock_mkstmp, \
+                patch('os.path.isfile') as mock_isfile:
+            mock_getsize.return_value = 1000
+            mock_mkstmp.return_value = '/path/to/file'
+            mock_isfile.return_value = True
+            ret = junos.load('/path/to/file', replace=True)
+            mock_load.assert_called_with(format='text', merge=False, path='/path/to/file')
+            self.assertEqual(ret, ret_exp)
+
+    def test_load_replace_false(self):
+        ret_exp = {'out': True, 'message': 'Successfully loaded the configuration.'}
+        with patch('os.path.getsize') as mock_getsize, \
+                patch('jnpr.junos.utils.config.Config.load') as mock_load, \
+                patch('salt.utils.files.mkstemp') as mock_mkstmp, \
+                patch('os.path.isfile') as mock_isfile:
+            mock_getsize.return_value = 1000
+            mock_mkstmp.return_value = '/path/to/file'
+            mock_isfile.return_value = True
+            ret = junos.load('/path/to/file', replace=False)
+            mock_load.assert_called_with(format='text', replace=False, path='/path/to/file')
+            self.assertEqual(ret, ret_exp)
+
+    def test_load_overwrite_true(self):
+        ret_exp = {'out': True, 'message': 'Successfully loaded the configuration.'}
+        with patch('os.path.getsize') as mock_getsize, \
+                patch('jnpr.junos.utils.config.Config.load') as mock_load, \
+                patch('salt.utils.files.mkstemp') as mock_mkstmp, \
+                patch('os.path.isfile') as mock_isfile:
+            mock_getsize.return_value = 1000
+            mock_mkstmp.return_value = '/path/to/file'
+            mock_isfile.return_value = True
+            ret = junos.load('/path/to/file', overwrite=True)
+            mock_load.assert_called_with(format='text', overwrite=True, path='/path/to/file')
+            self.assertEqual(ret, ret_exp)
+
+    def test_load_overwrite_false(self):
+        ret_exp = {'out': True, 'message': 'Successfully loaded the configuration.'}
+        with patch('os.path.getsize') as mock_getsize, \
+                patch('jnpr.junos.utils.config.Config.load') as mock_load, \
+                patch('salt.utils.files.mkstemp') as mock_mkstmp, \
+                patch('os.path.isfile') as mock_isfile:
+            mock_getsize.return_value = 1000
+            mock_mkstmp.return_value = '/path/to/file'
+            mock_isfile.return_value = True
+            ret = junos.load('/path/to/file', overwrite=False)
+            mock_load.assert_called_with(format='text', merge=True, path='/path/to/file')
+            self.assertEqual(ret, ret_exp)
+
+    def test_load_error(self):
+        ret_exp = {'out': False,
+                   'format': 'text',
+                   'message': 'Could not load configuration due to : "Test Error"'}
+        with patch('os.path.getsize') as mock_getsize, \
+                patch('jnpr.junos.utils.config.Config.load') as mock_load, \
+                patch('salt.utils.files.mkstemp') as mock_mkstmp, \
+                patch('os.path.isfile') as mock_isfile:
+            mock_getsize.return_value = 1000
+            mock_mkstmp.return_value = '/path/to/file'
+            mock_isfile.return_value = True
+            mock_load.side_effect = Exception('Test Error')
+            ret = junos.load('/path/to/file')
+            self.assertEqual(ret, ret_exp)
+
+    def test_commit_check_success(self):
+        ret_exp = {'out': True, 'message': 'Commit check succeeded.'}
+        ret = junos.commit_check()
+        self.assertEqual(ret, ret_exp)
+
+    def test_commit_check_error(self):
+        ret_exp = {'out': False, 'message': 'Commit check failed with '}
+        with patch('jnpr.junos.utils.config.Config.commit_check') as mock_check:
+            mock_check.side_effect = Exception
+            ret = junos.commit_check()
+            self.assertEqual(ret, ret_exp)
+
+    def test_get_table_wrong_path(self):
+        table = 'ModuleTable'
+        file = 'sample.yml'
+        path = '/path/to/file'
+        ret_exp = {'out': False, 'hostname': '1.1.1.1',
+                   'tablename': 'ModuleTable',
+                   'message': 'Given table file %s cannot be located' % file}
+        with patch('jnpr.junos.factory.FactoryLoader.load') as mock_load:
+            ret = junos.get_table(table, file, path)
+            self.assertEqual(ret, ret_exp)
+            mock_load.assert_not_called()
+
+    def test_get_table_multiple_paths(self):
+        table = 'ModuleTable'
+        file = 'inventory.yml'
+        path = '/path/to/file'
+        ret_exp = {'out': False, 'hostname': '1.1.1.1',
+                   'tablename': 'ModuleTable',
+                   'message': 'Given table file %s is located at multiple location' % file}
+        pyez_tables_path = os.path.dirname(os.path.abspath(tables_dir.__file__))
+        with patch('jnpr.junos.factory.FactoryLoader.load') as mock_load, \
+                patch('glob.glob') as mock_fopen:
+            mock_fopen.return_value = pyez_tables_path
+            ret = junos.get_table(table, file, path)
+            self.assertEqual(ret, ret_exp)
+            mock_load.assert_not_called()
+
+    def test_get_table_yaml_load_error(self):
+        table = 'ModuleTable'
+        file = 'inventory.yml'
+        path = '/path/to/file'
+        message = 'File not located test'
+        ret_exp = {'out': False, 'hostname': '1.1.1.1',
+                   'tablename': 'ModuleTable',
+                   'message': 'Uncaught exception during YAML Load - please report: %s'
+                              % message}
+        with patch('salt.utils.fopen', mock_open(IOError(message))) as mock_file:
+            ret = junos.get_table(table, file, path)
+            self.assertEqual(ret, ret_exp)
+
+    def test_get_table_api_error(self):
+        table = 'sample'
+        file = 'inventory.yml'
+        path = '/path/to/file'
+        ret_exp = {'out': False, 'hostname': '1.1.1.1',
+                   'tablename': 'sample',
+                   'message': 'Uncaught exception during get API call - please report:'
+                              ' u\'{0}\''.format(table)}
+        with patch('jnpr.junos.device.Device.execute') as mock_execute:
+            ret = junos.get_table(table, file, path)
+            self.assertEqual(ret['out'], ret_exp['out'])
+            self.assertEqual(ret['tablename'], ret_exp['tablename'])
+            self.assertEqual(ret['message'], ret_exp['message'])
+
+    def test_get_table_connect_closed_error(self):
+        table = 'ModuleTable'
+        file = 'inventory.yml'
+        path = '/path/to/file'
+        ret_exp = {'out': False, 'hostname': '1.1.1.1',
+                   'tablename': 'ModuleTable',
+                   'message': 'Got ConnectClosedError exception. Connection lost with Device(1.1.1.1)'}
+        with patch('jnpr.junos.factory.FactoryLoader.load') as mock_load:
+            dev = Device(host='1.1.1.1', user='rick')
+            mock_load.side_effect = ConnectClosedError(dev)
+            ret = junos.get_table(table, file, path)
+            self.assertEqual(ret['out'], ret_exp['out'])
+            self.assertEqual(ret['tablename'], ret_exp['tablename'])
+            self.assertEqual(ret['message'], ret_exp['message'])
+
+    def test_get_table_inventory(self):
+        table = 'ModuleTable'
+        file = 'inventory.yml'
+        path = '/path/to/file'
+        with patch('jnpr.junos.device.Device.execute') as mock_execute, \
+                patch('salt.utils.json.dumps') as mock_dumps:
+            mock_dumps.return_value = 'json rpc reply'
+            m = mock_open()
+            ret = junos.get_table(table, file, path)
+            self.assertEqual(ret['out'], True)

--- a/tests/unit/modules/test_junos.py
+++ b/tests/unit/modules/test_junos.py
@@ -1183,7 +1183,7 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
             mock_commit_check.return_value = False
 
             ret = dict()
-            ret['message'] = 'Loaded configuration but commit check failed.'
+            ret['message'] = 'Loaded configuration but commit check failed, hence rolling back configuration.'
             ret['out'] = False
             self.assertEqual(junos.install_config('actual/path/config.xml'), ret)
 

--- a/tests/unit/modules/test_junos.py
+++ b/tests/unit/modules/test_junos.py
@@ -8,7 +8,7 @@ import os
 
 # Import test libs
 from tests.support.mixins import LoaderModuleMockMixin, XMLEqualityMixin
-from tests.support.mock import patch, mock_open, PropertyMock, call
+from tests.support.mock import patch, mock_open, PropertyMock, call, ANY
 from tests.support.unit import skipIf, TestCase
 
 # Import 3rd-party libs
@@ -1316,6 +1316,51 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
                 'Installation successful but reboot failed due to : "Test exception"'
             ret['out'] = False
             self.assertEqual(junos.install_os('path', **args), ret)
+
+    def test_install_os_no_copy(self):
+        with patch('jnpr.junos.utils.sw.SW.install') as mock_install, \
+                patch('salt.utils.files.safe_rm') as mock_safe_rm, \
+                patch('salt.utils.files.mkstemp') as mock_mkstemp, \
+                patch('os.path.isfile') as mock_isfile, \
+                patch('os.path.getsize') as mock_getsize:
+            mock_getsize.return_value = 10
+            mock_isfile.return_value = True
+            ret = dict()
+            ret['out'] = True
+            ret['message'] = 'Installed the os.'
+            self.assertEqual(junos.install_os('path', no_copy=True), ret)
+            mock_install.assert_called_with(u'path', no_copy=True, progress=True)
+            mock_mkstemp.assert_not_called()
+            mock_safe_rm.assert_not_called()
+
+    def test_install_os_issu(self):
+        with patch('jnpr.junos.utils.sw.SW.install') as mock_install, \
+                patch('salt.utils.files.safe_rm') as mock_safe_rm, \
+                patch('salt.utils.files.mkstemp') as mock_mkstemp, \
+                patch('os.path.isfile') as mock_isfile, \
+                patch('os.path.getsize') as mock_getsize:
+            mock_getsize.return_value = 10
+            mock_isfile.return_value = True
+            ret = dict()
+            ret['out'] = True
+            ret['message'] = 'Installed the os.'
+            self.assertEqual(junos.install_os('path', issu=True), ret)
+            mock_install.assert_called_with(ANY, issu=True, progress=True)
+
+    def test_install_os_add_params(self):
+        with patch('jnpr.junos.utils.sw.SW.install') as mock_install, \
+                patch('salt.utils.files.safe_rm') as mock_safe_rm, \
+                patch('salt.utils.files.mkstemp') as mock_mkstemp, \
+                patch('os.path.isfile') as mock_isfile, \
+                patch('os.path.getsize') as mock_getsize:
+            mock_getsize.return_value = 10
+            mock_isfile.return_value = True
+            ret = dict()
+            ret['out'] = True
+            ret['message'] = 'Installed the os.'
+            remote_path = '/path/to/file'
+            self.assertEqual(junos.install_os('path', remote_path=remote_path, nssu=True, validate=True), ret)
+            mock_install.assert_called_with(ANY, nssu=True, remote_path=remote_path, progress=True, validate=True)
 
     def test_file_copy_without_args(self):
         ret = dict()

--- a/tests/unit/modules/test_junos.py
+++ b/tests/unit/modules/test_junos.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import, print_function, unicode_literals
 
 # Import test libs
 from tests.support.mixins import LoaderModuleMockMixin, XMLEqualityMixin
-from tests.support.mock import patch, mock_open, ANY
+from tests.support.mock import patch, mock_open, PropertyMock, call
 from tests.support.unit import skipIf, TestCase
 
 # Import 3rd-party libs
@@ -20,7 +20,6 @@ try:
     from jnpr.junos.utils.config import Config
     from jnpr.junos.utils.sw import SW
     from jnpr.junos.device import Device
-    from jnpr.junos.exception import RpcTimeoutError
     import jxmlease  # pylint: disable=unused-import
     HAS_JUNOS = True
 except ImportError:
@@ -50,7 +49,7 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
 
     def make_connect(self):
         with patch('ncclient.manager.connect') as mock_connect:
-            self.dev = self.dev = Device(
+            self.dev = Device(
                 host='1.1.1.1',
                 user='test',
                 password='test123',
@@ -130,12 +129,17 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
                  'virtual': True}
         return facts
 
-    def raise_timeout_exception(self):
-        dev = Device(host='1.1.1.1',
-                     user='test',
-                     password='test123')
-        ex = RpcTimeoutError(dev, "TestRPC", 30)
-        return ex
+    def test_timeout_decorator(self):
+        with patch('jnpr.junos.Device.timeout',
+                   new_callable=PropertyMock) as mock_timeout:
+            mock_timeout.return_value = 30
+
+            def function(x):
+                return x
+            decorator = junos.timeoutDecorator(function)
+            decorator("Test Mock", dev_timeout=10)
+            calls = [call(), call(10), call(30)]
+            mock_timeout.assert_has_calls(calls)
 
     def test_facts_refresh(self):
         with patch('salt.modules.saltutil.sync_grains') as mock_sync_grains:
@@ -373,16 +377,6 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
             ret['out'] = False
             self.assertEqual(junos.set_hostname('test-name'), ret)
 
-    def test_set_hostname_raise_timeout_exception_for_commit(self):
-        with patch('jnpr.junos.utils.config.Config.commit') as mock_commit:
-            mock_commit.side_effect = self.raise_timeout_exception()
-            ret = dict()
-            ret['message'] = 'Successfully loaded host-name but commit failed with ' \
-                             '"RpcTimeoutError(host: 1.1.1.1, cmd: TestRPC, timeout: 30)"'
-            ret['out'] = False
-            self.assertEqual(junos.set_hostname('test-name', dev_timeout=30), ret)
-            mock_commit.assert_called_with(dev_timeout=30)
-
     def test_set_hostname_fail_commit_check(self):
         with patch('jnpr.junos.utils.config.Config.commit_check') as mock_commit_check, \
                 patch('salt.modules.junos.rollback') as mock_rollback:
@@ -420,19 +414,6 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
             ret['message'] = \
                 'Commit check succeeded but actual commit failed with "Test exception"'
             self.assertEqual(junos.commit(), ret)
-
-    def test_commit_raise_commit_timeout_exception(self):
-        with patch('jnpr.junos.utils.config.Config.commit_check') as mock_commit_check, \
-                patch('jnpr.junos.utils.config.Config.commit') as mock_commit:
-            mock_commit_check.return_value = True
-            mock_commit.side_effect = self.raise_timeout_exception()
-            ret = dict()
-            ret['out'] = False
-            ret['message'] = \
-                'Commit check succeeded but actual commit failed with' \
-                ' "RpcTimeoutError(host: 1.1.1.1, cmd: TestRPC, timeout: 30)"'
-            self.assertEqual(junos.commit(dev_timeout=30), ret)
-            mock_commit.assert_called_with(detail=False, dev_timeout=30)
 
     def test_commit_with_single_argument(self):
         with patch('jnpr.junos.utils.config.Config.commit_check') as mock_commit_check, \
@@ -544,10 +525,9 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
             mock_commit_check.return_value = True
             args = {'comment': 'Comitted via salt',
                     '__pub_user': 'root',
-                    'dev_timeout': 40,
                     '__pub_arg': [2,
                                   {'comment': 'Comitted via salt',
-                                   'timeout': 40,
+                                   'dev_timeout': 40,
                                    'confirm': 1}],
                     'confirm': 1,
                     '__pub_fun': 'junos.rollback',
@@ -558,7 +538,7 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
             junos.rollback(id=2, **args)
             mock_rollback.assert_called_with(2)
             mock_commit.assert_called_with(
-                comment='Comitted via salt', confirm=1, timeout=40)
+                comment='Comitted via salt', confirm=1, dev_timeout=40)
 
     def test_rollback_with_only_single_arg(self):
         with patch('jnpr.junos.utils.config.Config.commit_check') as mock_commit_check, \
@@ -725,15 +705,6 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
             ret['message'] = 'Execution failed due to "Test exception"'
             ret['out'] = False
             self.assertEqual(junos.ping('1.1.1.1'), ret)
-
-    def test_ping_timeout_exception(self):
-        with patch('jnpr.junos.device.Device.execute') as mock_execute:
-            mock_execute.side_effect = self.raise_timeout_exception()
-            ret = dict()
-            ret['message'] = 'Execution failed due to "RpcTimeoutError(host: 1.1.1.1, cmd: TestRPC, timeout: 30)"'
-            ret['out'] = False
-            self.assertEqual(junos.ping('1.1.1.1', dev_timeout=30), ret)
-            mock_execute.assert_called_with(ANY, dev_timeout=30)
 
     def test_cli_without_args(self):
         ret = dict()
@@ -1193,25 +1164,6 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
                 ret)
             mock_commit.assert_called_with(comment='comitted via salt', confirm=3)
 
-    def test_install_config_commit_check_exception(self):
-        with patch('jnpr.junos.utils.config.Config.commit_check') as mock_commit_check, \
-                patch('jnpr.junos.utils.config.Config.diff') as mock_diff, \
-                patch('jnpr.junos.utils.config.Config.load') as mock_load, \
-                patch('salt.utils.files.safe_rm') as mock_safe_rm, \
-                patch('salt.utils.files.mkstemp') as mock_mkstemp, \
-                patch('os.path.isfile') as mock_isfile, \
-                patch('os.path.getsize') as mock_getsize:
-            mock_isfile.return_value = True
-            mock_getsize.return_value = 10
-            mock_mkstemp.return_value = 'test/path/config'
-            mock_diff.return_value = 'diff'
-            mock_commit_check.side_effect = self.raise_exception
-
-            ret = dict()
-            ret['message'] = 'Commit check threw the following exception: "Test exception"'
-            ret['out'] = False
-            self.assertEqual(junos.install_config('actual/path/config.xml'), ret)
-
     def test_install_config_commit_check_fails(self):
         with patch('jnpr.junos.utils.config.Config.commit_check') as mock_commit_check, \
                 patch('jnpr.junos.utils.config.Config.diff') as mock_diff, \
@@ -1251,28 +1203,6 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
                 'Commit check successful but commit failed with "Test exception"'
             ret['out'] = False
             self.assertEqual(junos.install_config('actual/path/config'), ret)
-
-    def test_install_config_commit_timeout_exception(self):
-        with patch('jnpr.junos.utils.config.Config.commit') as mock_commit, \
-                patch('jnpr.junos.utils.config.Config.commit_check') as mock_commit_check, \
-                patch('jnpr.junos.utils.config.Config.diff') as mock_diff, \
-                patch('jnpr.junos.utils.config.Config.load') as mock_load, \
-                patch('salt.utils.files.safe_rm') as mock_safe_rm, \
-                patch('salt.utils.files.mkstemp') as mock_mkstemp, \
-                patch('os.path.isfile') as mock_isfile, \
-                patch('os.path.getsize') as mock_getsize:
-            mock_isfile.return_value = True
-            mock_getsize.return_value = 10
-            mock_mkstemp.return_value = 'test/path/config'
-            mock_diff.return_value = 'diff'
-            mock_commit_check.return_value = True
-            mock_commit.side_effect = self.raise_timeout_exception()
-            ret = dict()
-            ret['message'] = \
-                'Commit check successful but commit failed with ' \
-                '"RpcTimeoutError(host: 1.1.1.1, cmd: TestRPC, timeout: 30)"'
-            ret['out'] = False
-            self.assertEqual(junos.install_config('actual/path/config', dev_timeout=30), ret)
 
     def test_zeroize(self):
         with patch('jnpr.junos.device.Device.cli') as mock_cli:
@@ -1362,20 +1292,6 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
             ret['message'] = 'Installation failed due to: "Test exception"'
             ret['out'] = False
             self.assertEqual(junos.install_os('path'), ret)
-
-    def test_install_os_pyez_install_timeout_exception(self):
-        with patch('jnpr.junos.utils.sw.SW.install') as mock_install, \
-                patch('salt.utils.files.safe_rm') as mock_safe_rm, \
-                patch('salt.utils.files.mkstemp') as mock_mkstemp, \
-                patch('os.path.isfile') as mock_isfile, \
-                patch('os.path.getsize') as mock_getsize:
-            mock_getsize.return_value = 10
-            mock_isfile.return_value = True
-            mock_install.side_effect = self.raise_timeout_exception()
-            ret = dict()
-            ret['message'] = 'Installation failed due to: "RpcTimeoutError(host: 1.1.1.1, cmd: TestRPC, timeout: 30)"'
-            ret['out'] = False
-            self.assertEqual(junos.install_os('path', dev_timeout=30), ret)
 
     def test_install_os_with_reboot_raises_exception(self):
         with patch('jnpr.junos.utils.sw.SW.install') as mock_install, \
@@ -1500,7 +1416,6 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
             args = mock_execute.call_args
             expected_rpc = '<get-interface-information format="json"/>'
             self.assertEqualXML(args[0][0], expected_rpc)
-            self.assertEqual(args[1], {'dev_timeout': 30})
 
     def test_rpc_get_interface_information_with_kwargs(self):
         with patch('jnpr.junos.device.Device.execute') as mock_execute:
@@ -1571,12 +1486,3 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
                 junos.rpc('get-chassis-inventory', '/path/to/file')
                 writes = m_open.write_calls()
                 assert writes == ['xml rpc reply'], writes
-
-    def test_rpc_get_interface_information_timeout_exception(self):
-        with patch('jnpr.junos.device.Device.execute') as mock_execute:
-            mock_execute.side_effect = self.raise_timeout_exception()
-            ret = dict()
-            ret['message'] = 'RPC execution failed due to "RpcTimeoutError(host: 1.1.1.1, cmd: TestRPC, timeout: 30)"'
-            ret['out'] = False
-            self.assertEqual(junos.rpc('get_interface_information', dev_timout='30'), ret)
-            mock_execute.assert_called_with(ANY, dev_timeout=30)


### PR DESCRIPTION
### What does this PR do?
The PR contains new features and bug fixes for Junos modules and proxy. 

#### New features:
- Add new API get_table under junos module and state. For example,
```
# salt 'proxy01' junos.get_table FPCtable fpc_pic.yml /xxx/salt/_tables/
proxy01:
    ----------
    hostname:
        teakwood
    out:
        True
    reply:
        ----------
        1:
            ----------
            desc:
                MPCE Type 3 3D
            pic_status:
                ----------
                0:
                    ----------
                    desc:
                        10x 1GE(LAN) -E SFP
                    state:
                        Present
                1:
                    ----------
                    desc:
                        10x 1GE(LAN) -E SFP
                    state:
                        Present
```
- Added new options to `install_os` module. Options:`remote_path`, `validate`, `issu`, `nssu` 

#### Bug fixes
- Timeout issue not respected issue resolved.
- State module doesn't return success in `result` key.

### What issues does this PR fix or reference?
- https://github.com/Juniper/salt/issues/56
- https://github.com/Juniper/salt/issues/77
- https://github.com/Juniper/salt/issues/44
- https://github.com/Juniper/salt/issues/38
- https://github.com/Juniper/salt/issues/74
- https://github.com/Juniper/salt/issues/69

### Tests written?

Yes