### PR TITLE
Fixed typo in memcached SDB module documentation.

### DIFF
--- a/salt/sdb/memcached.py
+++ b/salt/sdb/memcached.py
@@ -18,8 +18,8 @@ requires very little. In the example:
 
     mymemcache:
       driver: memcached
-      host: localhost
-      port: 11211
+      memcached.host: localhost
+      memcached.port: 11211
 
 The ``driver`` refers to the memcached module, ``host`` and ``port`` the
 memcached server to connect to (defaults to ``localhost`` and ``11211``,


### PR DESCRIPTION
### What does this PR do?

As written, host/port were ignored (default host=127.0.0.1 was being used).

### What issues does this PR fix or reference?

### Tests written?

N/A

### Commits signed with GPG?

N/A