### PR TITLE
fix flakiness in create wake on lan test (2019.2)

### DIFF
--- a/tests/unit/cloud/clouds/test_saltify.py
+++ b/tests/unit/cloud/clouds/test_saltify.py
@@ -112,7 +112,9 @@ class SaltifyTestCase(TestCase, LoaderModuleMockMixin):
                     result = saltify.create(vm_)
                     mock_cmd.assert_called_once_with(vm_, ANY)
                     mm_cmd.assert_called_with('friend1', 'network.wol', ['aa-bb-cc-dd-ee-ff'])
-                    mock_sleep.assert_called_with(0.01)
+                    # The test suite might call time.sleep, look for any call
+                    # that has the expected wait time.
+                    mock_sleep.assert_any_call(0.01)
                     self.assertTrue(result)
 
     def test_avail_locations(self):


### PR DESCRIPTION
### What does this PR do?

Fix flakiness in mac tests:

https://jenkinsci.saltstack.com/job/2019.2/job/salt-mac-highsierra-py2/2/testReport/junit/unit.cloud.clouds.test_saltify/SaltifyTestCase/test_create_wake_on_lan/

### Tests written?

No - Fixing flaky test

### Commits signed with GPG?

Yes