### PR TITLE
Handle encoding when opening file for both py2/py3

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 What is SaltStack?
 ==================
 
-SaltStack makes software for complex systems management at scale.
+SaltStack makes software for complex systems management at scale.
 SaltStack is the company that created and maintains the Salt Open
 project and develops and sells SaltStack Enterprise software, services
 and support. Easy enough to get running in minutes, scalable enough to

--- a/setup.py
+++ b/setup.py
@@ -855,7 +855,10 @@ class SaltDistribution(distutils.dist.Distribution):
         self.name = 'salt-ssh' if PACKAGED_FOR_SALT_SSH else 'salt'
         self.salt_version = __version__  # pylint: disable=undefined-variable
         self.description = 'Portable, distributed, remote execution and configuration management system'
-        with open(SALT_LONG_DESCRIPTION_FILE, encoding='utf-8') as f:
+        kwargs = {}
+        if IS_PY3:
+            kwargs['encoding'] = 'utf-8'
+        with open(SALT_LONG_DESCRIPTION_FILE, **kwargs) as f:
             self.long_description = f.read()
         self.long_description_content_type = 'text/x-rst'
         self.author = 'Thomas S Hatch'


### PR DESCRIPTION
This handles opening the README file for both py2 and py3. When using python3 we need to make sure we set utf-8 encoding. 

This PR also removes the character that was causing the initial ascii error.

Follow up to https://github.com/saltstack/salt/pull/51122