### PR TITLE
Add `utc_jid` option for generating jids based on utc

### DIFF
--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -459,6 +459,9 @@ VALID_OPTS = {
     # Tell the client to display the jid when a job is published
     'show_jid': bool,
 
+    # Generate jids based on UTC time instead of local time
+    'utc_jid': bool,
+
     # Ensure that a generated jid is always unique. If this is set, the jid
     # format is different due to an underscore and process id being appended
     # to the jid. WARNING: A change to the jid format may break external

--- a/salt/utils/jid.py
+++ b/salt/utils/jid.py
@@ -27,9 +27,12 @@ def gen_jid(opts=None):
         opts = {}
     global LAST_JID_DATETIME  # pylint: disable=global-statement
 
+    if opts.get('utc_jid', False):
+        jid_dt = datetime.datetime.utcnow()
+    else:
+        jid_dt = datetime.datetime.now()
     if not opts.get('unique_jid', False):
-        return '{0:%Y%m%d%H%M%S%f}'.format(datetime.datetime.now())
-    jid_dt = datetime.datetime.now()
+        return '{0:%Y%m%d%H%M%S%f}'.format(jid_dt)
     if LAST_JID_DATETIME and LAST_JID_DATETIME >= jid_dt:
         jid_dt = LAST_JID_DATETIME + datetime.timedelta(microseconds=1)
     LAST_JID_DATETIME = jid_dt

--- a/tests/unit/utils/test_jid.py
+++ b/tests/unit/utils/test_jid.py
@@ -35,13 +35,21 @@ class JidTestCase(TestCase):
 
     @skipIf(NO_MOCK, NO_MOCK_REASON)
     def test_gen_jid(self):
-        now = datetime.datetime(2002, 12, 25, 12, 00, 00, 00)
+        now = datetime.datetime(2002, 12, 25, 12, 0, 0, 0)
+        utcnow = datetime.datetime(2002, 12, 25, 12, 7, 0, 0)
         with patch('datetime.datetime'):
             datetime.datetime.now.return_value = now
+            datetime.datetime.utcnow.return_value = utcnow
             ret = salt.utils.jid.gen_jid({})
             self.assertEqual(ret, '20021225120000000000')
+            ret = salt.utils.jid.gen_jid({'utc_jid': True})
+            self.assertEqual(ret, '20021225120700000000')
             salt.utils.jid.LAST_JID_DATETIME = None
             ret = salt.utils.jid.gen_jid({'unique_jid': True})
             self.assertEqual(ret, '20021225120000000000_{0}'.format(os.getpid()))
             ret = salt.utils.jid.gen_jid({'unique_jid': True})
             self.assertEqual(ret, '20021225120000000001_{0}'.format(os.getpid()))
+            ret = salt.utils.jid.gen_jid({'utc_jid': True, 'unique_jid': True})
+            self.assertEqual(ret, '20021225120700000000_{0}'.format(os.getpid()))
+            ret = salt.utils.jid.gen_jid({'utc_jid': True, 'unique_jid': True})
+            self.assertEqual(ret, '20021225120700000001_{0}'.format(os.getpid()))

--- a/tests/unit/utils/test_jid.py
+++ b/tests/unit/utils/test_jid.py
@@ -36,19 +36,36 @@ class JidTestCase(TestCase):
     @skipIf(NO_MOCK, NO_MOCK_REASON)
     def test_gen_jid(self):
         now = datetime.datetime(2002, 12, 25, 12, 0, 0, 0)
-        utcnow = datetime.datetime(2002, 12, 25, 12, 7, 0, 0)
         with patch('datetime.datetime'):
             datetime.datetime.now.return_value = now
-            datetime.datetime.utcnow.return_value = utcnow
             ret = salt.utils.jid.gen_jid({})
             self.assertEqual(ret, '20021225120000000000')
-            ret = salt.utils.jid.gen_jid({'utc_jid': True})
-            self.assertEqual(ret, '20021225120700000000')
+
+    @skipIf(NO_MOCK, NO_MOCK_REASON)
+    def test_gen_jid_unique(self):
+        now = datetime.datetime(2002, 12, 25, 12, 0, 0, 0)
+        with patch('datetime.datetime'):
+            datetime.datetime.now.return_value = now
             salt.utils.jid.LAST_JID_DATETIME = None
             ret = salt.utils.jid.gen_jid({'unique_jid': True})
             self.assertEqual(ret, '20021225120000000000_{0}'.format(os.getpid()))
             ret = salt.utils.jid.gen_jid({'unique_jid': True})
             self.assertEqual(ret, '20021225120000000001_{0}'.format(os.getpid()))
+
+    @skipIf(NO_MOCK, NO_MOCK_REASON)
+    def test_gen_jid_utc(self):
+        utcnow = datetime.datetime(2002, 12, 25, 12, 7, 0, 0)
+        with patch('datetime.datetime'):
+            datetime.datetime.utcnow.return_value = utcnow
+            ret = salt.utils.jid.gen_jid({'utc_jid': True})
+            self.assertEqual(ret, '20021225120700000000')
+
+    @skipIf(NO_MOCK, NO_MOCK_REASON)
+    def test_gen_jid_utc_unique(self):
+        utcnow = datetime.datetime(2002, 12, 25, 12, 7, 0, 0)
+        with patch('datetime.datetime'):
+            datetime.datetime.utcnow.return_value = utcnow
+            salt.utils.jid.LAST_JID_DATETIME = None
             ret = salt.utils.jid.gen_jid({'utc_jid': True, 'unique_jid': True})
             self.assertEqual(ret, '20021225120700000000_{0}'.format(os.getpid()))
             ret = salt.utils.jid.gen_jid({'utc_jid': True, 'unique_jid': True})


### PR DESCRIPTION
### What does this PR do?

Add the `utc_jid` config option (boolean) for generating jids based on UTC instead of local time.

This is useful in SSE deployments where masters are in different timezones, so that jobs across the infrastructure can easily be sorted chronologically. The workaround is to set each master's clock to UTC.

### What issues does this PR fix or reference?

#33309

### Previous Behavior

Previous behavior is still available and enabled by default.

### New Behavior

If `utc_jid` is `True`, generate jids based on UTC instead of local time.

### Tests written?

Yes

### Commits signed with GPG?

Yes
