### PR TITLE
file.symlink: add ability to copy target user/group

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -1319,6 +1319,7 @@ def symlink(
         makedirs=False,
         user=None,
         group=None,
+        copy_target_user=False,
         mode=None,
         win_owner=None,
         win_perms=None,
@@ -1410,6 +1411,17 @@ def symlink(
            'comment': ''}
     if not name:
         return _error(ret, 'Must provide name to file.symlink')
+
+    if copy_target_user:
+        if user:
+            log.warning('`copy_target_user` and `user` are mutually exclusive. Using `user`.')
+        else:
+            try:
+                user = __salt__['file.get_user'](target)
+            except CommandExecutionError:
+                ret['result'] = False
+                ret['comment'] = '`copy_target_user` is set, but target `{0}` does not exist.'.format(target)
+                return ret
 
     if user is None:
         user = __opts__['user']

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -1320,6 +1320,7 @@ def symlink(
         user=None,
         group=None,
         copy_target_user=False,
+        copy_target_group=False,
         mode=None,
         win_owner=None,
         win_perms=None,
@@ -1421,6 +1422,17 @@ def symlink(
             except CommandExecutionError:
                 ret['result'] = False
                 ret['comment'] = '`copy_target_user` is set, but target `{0}` does not exist.'.format(target)
+                return ret
+
+    if copy_target_group:
+        if group:
+            log.warning('`copy_target_group` and `group` are mutually exclusive. Using `group`.')
+        else:
+            try:
+                group = __salt__['file.get_group'](target)
+            except CommandExecutionError:
+                ret['result'] = False
+                ret['comment'] = '`copy_target_group` is set, but target `{0}` does not exist.'.format(target)
                 return ret
 
     if user is None:

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -1434,17 +1434,6 @@ def symlink(
                 ret['comment'] = '`copy_target_user` is set, but target `{0}` does not exist.'.format(target)
                 return ret
 
-    if copy_target_group:
-        if group:
-            log.warning('`copy_target_group` and `group` are mutually exclusive. Using `group`.')
-        else:
-            try:
-                group = __salt__['file.get_group'](target)
-            except CommandExecutionError:
-                ret['result'] = False
-                ret['comment'] = '`copy_target_group` is set, but target `{0}` does not exist.'.format(target)
-                return ret
-
     if user is None:
         user = __opts__['user']
 
@@ -1470,7 +1459,26 @@ def symlink(
                 'is a Windows system. Please use the `win_*` parameters to set '
                 'permissions in Windows.'.format(name)
             )
+
+        if copy_target_group is not None:
+            log.warning(
+                'The copy_target_group argument for {0} has been ignored as this '
+                'is a Windows system. Please use the `win_*` parameters to set '
+                'permissions in Windows.'.format(name)
+            )
+
         group = user
+
+    if copy_target_group:
+        if group:
+            log.warning('`copy_target_group` and `group` are mutually exclusive. Using `group`.')
+        else:
+            try:
+                group = __salt__['file.get_group'](target)
+            except CommandExecutionError:
+                ret['result'] = False
+                ret['comment'] = '`copy_target_group` is set, but target `{0}` does not exist.'.format(target)
+                return ret
 
     if group is None:
         group = __salt__['file.gid_to_group'](

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -1376,10 +1376,14 @@ def symlink(
         also passed, it will be used instead. This option requires the target
         to exist.
 
+        .. versionadded:: 2019.2.0
+
     copy_target_group : False
         If True, set the symlink's group to that of the target. If ``group`` is
         also passed, it will be used instead. This option requires the target
         to exist.
+
+        .. versionadded:: 2019.2.0
 
     mode
         The permissions to set on this file, aka 644, 0775, 4664. Not supported

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -1371,6 +1371,16 @@ def symlink(
         The group ownership set for the file, this defaults to the group salt
         is running as on the minion. On Windows, this is ignored
 
+    copy_target_user : False
+        If True, set the symlink's owner to that of the target. If ``user`` is
+        also passed, it will be used instead. This option requires the target
+        to exist.
+
+    copy_target_group : False
+        If True, set the symlink's group to that of the target. If ``group`` is
+        also passed, it will be used instead. This option requires the target
+        to exist.
+
     mode
         The permissions to set on this file, aka 644, 0775, 4664. Not supported
         on Windows.


### PR DESCRIPTION
### What does this PR do?
Adds the boolean options 'copy_target_user' and 'copy_target_group' to file.symlink. When set to True, the user and/or group of the symlink will be copied from the target.

### What issues does this PR fix or reference?
I am not aware of an open issue for this. The feature was requested by a coworker for use on Apache webservers.

### Tests written?
No

### Commits signed with GPG?
No

I did not test it on a Windows minion, as I do not have a Windows machine handy, but it uses the existing code for handling 'group' on Windows.