### PR TITLE
mount: cache blkid information

### DIFF
--- a/salt/modules/mount.py
+++ b/salt/modules/mount.py
@@ -63,7 +63,9 @@ def _active_mountinfo(ret):
         msg = 'File not readable {0}'
         raise CommandExecutionError(msg.format(filename))
 
-    blkid_info = __salt__['disk.blkid']()
+    if 'disk.blkid' not in __context__:
+        __context__['disk.blkid'] = __salt__['disk.blkid']()
+    blkid_info = __context__['disk.blkid']
 
     with salt.utils.files.fopen(filename) as ifile:
         for line in ifile:


### PR DESCRIPTION
### What does this PR do?

During the mount of a device a call to blkid is done, to get
information of the current devices.

blkid is a slow operation, to avoid that use an internal cache,
that is specified in /etc/blkid configuration file, but a single
blkid can still redo this cache file, making the second call
equally slow.

This patch cache the blkid information for _active_mountinfo in
the __context__ dict, making the next mount action a fast
operation.

### Tests written?

No, as this patch do not change the mount behavior, only makes
the second call faster.
