### PR TITLE
Prevent crash by testing for 'manufacturer' in osdata on OpenBSD

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1003,10 +1003,11 @@ def _virtual(osdata):
             if 'QEMU Virtual CPU' in model:
                 grains['virtual'] = 'kvm'
     elif osdata['kernel'] == 'OpenBSD':
-        if osdata['manufacturer'] in ['QEMU', 'Red Hat']:
-            grains['virtual'] = 'kvm'
-        if osdata['manufacturer'] == 'OpenBSD':
-            grains['virtual'] = 'vmm'
+        if 'manufacturer' in osdata:
+            if osdata['manufacturer'] in ['QEMU', 'Red Hat', 'Joyent']:
+                grains['virtual'] = 'kvm'
+            if osdata['manufacturer'] == 'OpenBSD':
+                grains['virtual'] = 'vmm'
     elif osdata['kernel'] == 'SunOS':
         if grains['virtual'] == 'LDOM':
             roles = []


### PR DESCRIPTION
### What does this PR do?

Two things, on OpenBSD systems:
1. check for existence of `manufacturer` key in `osdata`
2. recognize SmartOS KVM in `_virtual()`

### What issues does this PR fix or reference?

Issue #51067 

### Previous Behavior

On my Raspberry Pi 3B:
```bash
# salt-call --local grains.items | egrep -A1 'kernel|productname|virtual|manufacturer'
[ERROR   ] An un-handled exception was caught by salt's global exception handler:
KeyError: u'manufacturer'
Traceback (most recent call last):
  File "/usr/local/bin/salt-call", line 11, in <module>
    salt_call()
  File "/usr/local/lib/python2.7/site-packages/salt/scripts.py", line 400, in salt_call
    client.run()
  File "/usr/local/lib/python2.7/site-packages/salt/cli/call.py", line 47, in run
    caller = salt.cli.caller.Caller.factory(self.config)
  File "/usr/local/lib/python2.7/site-packages/salt/cli/caller.py", line 79, in factory
    return ZeroMQCaller(opts, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/salt/cli/caller.py", line 291, in __init__
    super(ZeroMQCaller, self).__init__(opts)
  File "/usr/local/lib/python2.7/site-packages/salt/cli/caller.py", line 102, in __init__
    self.minion = salt.minion.SMinion(opts)
  File "/usr/local/lib/python2.7/site-packages/salt/minion.py", line 784, in __init__
    opts['grains'] = salt.loader.grains(opts)
  File "/usr/local/lib/python2.7/site-packages/salt/loader.py", line 734, in grains
    ret = funcs[key]()
  File "/usr/local/lib/python2.7/site-packages/salt/grains/core.py", line 1792, in os_data
    grains.update(_virtual(grains))
  File "/usr/local/lib/python2.7/site-packages/salt/grains/core.py", line 925, in _virtual
    if osdata['manufacturer'] in ['QEMU', 'Red Hat']:
KeyError: u'manufacturer'
Traceback (most recent call last):
  File "/usr/local/bin/salt-call", line 11, in <module>
    salt_call()
  File "/usr/local/lib/python2.7/site-packages/salt/scripts.py", line 400, in salt_call
    client.run()
  File "/usr/local/lib/python2.7/site-packages/salt/cli/call.py", line 47, in run
    caller = salt.cli.caller.Caller.factory(self.config)
  File "/usr/local/lib/python2.7/site-packages/salt/cli/caller.py", line 79, in factory
    return ZeroMQCaller(opts, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/salt/cli/caller.py", line 291, in __init__
    super(ZeroMQCaller, self).__init__(opts)
  File "/usr/local/lib/python2.7/site-packages/salt/cli/caller.py", line 102, in __init__
    self.minion = salt.minion.SMinion(opts)
  File "/usr/local/lib/python2.7/site-packages/salt/minion.py", line 784, in __init__
    opts['grains'] = salt.loader.grains(opts)
  File "/usr/local/lib/python2.7/site-packages/salt/loader.py", line 734, in grains
    ret = funcs[key]()
  File "/usr/local/lib/python2.7/site-packages/salt/grains/core.py", line 1792, in os_data
    grains.update(_virtual(grains))
  File "/usr/local/lib/python2.7/site-packages/salt/grains/core.py", line 925, in _virtual
    if osdata['manufacturer'] in ['QEMU', 'Red Hat']:
```

On my SmartOS HVM:
```bash
# salt-call --local grains.items | egrep -A1 'kernel|productname|virtual|manufacturer'
    kernel:
        OpenBSD
    kernelrelease:
        6.4
    kernelversion:
        GENERIC#3
    manufacturer:
        Joyent
    productname:
        SmartDC HVM
    virtual:
        physical
```


### New Behavior

On my Raspberry Pi 3B:
```bash
# salt-call --local grains.items | egrep -A1 'kernel|productname|virtual|manufacturer'
    kernel:
        OpenBSD
    kernelrelease:
        6.4
    kernelversion:
        GENERIC.MP#3
    productname:
        Raspberry Pi 3 Model B Rev 1.2
    virtual:
        physical
```


On my SmartOS HVM:
```bash
# salt-call --local grains.items | egrep -A1 'kernel|productname|virtual|manufacturer'
    kernel:
        OpenBSD
    kernelrelease:
        6.4
    kernelversion:
        GENERIC#3
    manufacturer:
        Joyent
    productname:
        SmartDC HVM
    virtual:
        kvm
```


### Tests written?

No

### Commits signed with GPG?

No
