### PR TITLE
Ignore exceptions when generating the minion ID

### DIFF
--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -137,7 +137,23 @@ def _generate_minion_id():
         def first(self):
             return self and self[0] or None
 
-    hosts = DistinctList().append(socket.getfqdn()).append(platform.node()).append(socket.gethostname())
+    hosts = DistinctList([])
+
+    try:
+        hosts.append(socket.getfqdn())
+    except ValueError:
+        pass
+
+    try:
+        hosts.append(platform.node())
+    except ValueError:
+        pass
+
+    try:
+        hosts.append(socket.gethostname())
+    except ValueError:
+        pass
+
     if not hosts:
         try:
             for a_nfo in socket.getaddrinfo(hosts.first() or 'localhost', None, socket.AF_INET,

--- a/tests/unit/utils/test_network.py
+++ b/tests/unit/utils/test_network.py
@@ -181,6 +181,15 @@ class NetworkTestCase(TestCase):
         with patch('salt.utils.files.fopen', fopen_mock):
             assert 'thisismyhostname' in network._generate_minion_id()
 
+    def test_generate_minion_id_with_long_hostname(self):
+        '''
+        Test that hostnames longer than 63 characters do not raise
+        an exception when generating the minion ID
+        '''
+        with patch('socket.gethostbyaddr') as mock_gethostbyname:
+            mock_gethostbyname.side_effect = UnicodeError('encoding with \'idna\' codec failed')
+            self.assertTrue(network.generate_minion_id())
+
     def test_is_ip(self):
         self.assertTrue(network.is_ip('10.10.0.3'))
         self.assertFalse(network.is_ip('0.9.800.1000'))


### PR DESCRIPTION
### What does this PR do?
Hostnames longer than 63 characters cause the `network.generate_minion_id()` function
to fail under Python 3. This change ignores those exceptions so the function can fall through
to other ways to generate the minion ID

### What issues does this PR fix or reference?
#51160 

### Tests written?
Yes

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
