### PR TITLE
More descriptive error when missing GitPython or PyGit2

### DIFF
--- a/salt/states/git.py
+++ b/salt/states/git.py
@@ -749,6 +749,12 @@ def latest(name,
             ret,
             'Failed to check remote refs: {0}'.format(_strip_exc(exc))
         )
+    except NameError as exc:
+        if 'global name' in exc.message:
+            raise CommandExecutionError(
+                'Failed to check remote refs: You may need to install '
+                'GitPython or PyGit2')
+        raise
 
     if 'HEAD' in all_remote_refs:
         head_rev = all_remote_refs['HEAD']


### PR DESCRIPTION
### What does this PR do?
Gives more descriptive error when pygit2 or git python are not intstalled when running winrepo.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/36127

### Tests written?
No

### Commits signed with GPG?
No