### PR TITLE
Add random sleep time to avoid overloading Windows

### DIFF
--- a/salt/crypt.py
+++ b/salt/crypt.py
@@ -9,6 +9,7 @@ authenticating peers
 # the Array class, which has incompatibilities with it.
 from __future__ import absolute_import, print_function
 import os
+import random
 import sys
 import copy
 import time
@@ -727,6 +728,10 @@ class AsyncAuth(object):
                             'minion.\nOr restart the Salt Master in open mode to '
                             'clean out the keys. The Salt Minion will now exit.'
                         )
+                        # Add a random sleep here for systems that are using a
+                        # a service manager to immediately restart the service
+                        # to avoid overloading the system
+                        time.sleep(random.randint(10, 20))
                         sys.exit(salt.defaults.exitcodes.EX_NOPERM)
                 # has the master returned that its maxed out with minions?
                 elif payload['load']['ret'] == 'full':


### PR DESCRIPTION
### What does this PR do?
Fixes an issue on Windows where the salt-minion restarts over and over when the key has been denied on the master. This adds a random delay between 10 and 20 seconds before the minion exits.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/51138

### Tests written?
No

### Commits signed with GPG?
Yes