### PR TITLE
Avoid exceptions by passing bytes to idna

### DIFF
--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -137,7 +137,12 @@ def _generate_minion_id():
         def first(self):
             return self and self[0] or None
 
-    hosts = DistinctList().append(socket.getfqdn()).append(platform.node()).append(socket.gethostname())
+    hostname = socket.gethostname()
+
+    hosts = DistinctList().append(
+        salt.utils.stringutils.to_unicode(socket.getfqdn(salt.utils.stringutils.to_bytes(hostname)))
+    )
+    hosts.append(platform.node()).append(hostname)
     if not hosts:
         try:
             for a_nfo in socket.getaddrinfo(hosts.first() or 'localhost', None, socket.AF_INET,

--- a/tests/unit/utils/test_network.py
+++ b/tests/unit/utils/test_network.py
@@ -181,15 +181,6 @@ class NetworkTestCase(TestCase):
         with patch('salt.utils.files.fopen', fopen_mock):
             assert 'thisismyhostname' in network._generate_minion_id()
 
-    def test_generate_minion_id_with_long_hostname(self):
-        '''
-        Test that hostnames longer than 63 characters do not raise
-        an exception when generating the minion ID
-        '''
-        with patch('socket.gethostbyaddr') as mock_gethostbyname:
-            mock_gethostbyname.side_effect = UnicodeError('encoding with \'idna\' codec failed')
-            self.assertTrue(network.generate_minion_id())
-
     def test_is_ip(self):
         self.assertTrue(network.is_ip('10.10.0.3'))
         self.assertFalse(network.is_ip('0.9.800.1000'))
@@ -552,7 +543,6 @@ class NetworkTestCase(TestCase):
         '''
         long_name = 'localhost-abcdefghijklmnopqrstuvwxyz-abcdefghijklmnopqrstuvwxyz'
         with patch('socket.gethostname', MagicMock(return_value=long_name)):
-            # An exception is raised if unicode is passed to socket.getfqdn 
+            # An exception is raised if unicode is passed to socket.getfqdn
             minion_id = network.generate_minion_id()
         assert minion_id != '', minion_id
-

--- a/tests/unit/utils/test_network.py
+++ b/tests/unit/utils/test_network.py
@@ -534,3 +534,16 @@ class NetworkTestCase(TestCase):
         self.assertRaises(ValueError, network.mac_str_to_bytes, 'a0:b0:c0:d0:e0:fg')
         self.assertEqual(b'\x10\x08\x06\x04\x02\x00', network.mac_str_to_bytes('100806040200'))
         self.assertEqual(b'\xf8\xe7\xd6\xc5\xb4\xa3', network.mac_str_to_bytes('f8e7d6c5b4a3'))
+
+    def test_generate_minion_id_with_long_hostname(self):
+        '''
+        Validate the fix for:
+
+        https://github.com/saltstack/salt/issues/51160
+        '''
+        long_name = 'localhost-abcdefghijklmnopqrstuvwxyz-abcdefghijklmnopqrstuvwxyz'
+        with patch('socket.gethostname', MagicMock(return_value=long_name)):
+            # An exception is raised if unicode is passed to socket.getfqdn 
+            minion_id = network.generate_minion_id()
+        assert minion_id != '', minion_id
+


### PR DESCRIPTION
### What does this PR do?

Avoid exceptions by passing bytes to idna (which patches socket). This also reverts PR #51161 in favor of a proper fix with regression test.

### What issues does this PR fix or reference?

#51160

### Tests written?

Yes

### Commits signed with GPG?

Yes