### PR TITLE
Update OpsGenie to use their V2 API (2018.3)

### DIFF
--- a/salt/states/opsgenie.py
+++ b/salt/states/opsgenie.py
@@ -86,7 +86,7 @@ def create_alert(name=None, api_key=None, reason=None, action_type="Create"):
     if __opts__['test'] is True:
         ret[
             'comment'] = 'Test: {0} alert request will be processed ' \
-                         'using the API Key="{1}".'.format(api_key)
+                         'using the API Key="{1}".'.format(action_type, api_key)
 
         # Return ``None`` when running with ``test=true``.
         ret['result'] = None

--- a/salt/states/opsgenie.py
+++ b/salt/states/opsgenie.py
@@ -86,9 +86,7 @@ def create_alert(name=None, api_key=None, reason=None, action_type="Create"):
     if __opts__['test'] is True:
         ret[
             'comment'] = 'Test: {0} alert request will be processed ' \
-                         'using the API Key="{1}".'.format(
-            action_type,
-            api_key)
+                         'using the API Key="{1}".'.format(api_key)
 
         # Return ``None`` when running with ``test=true``.
         ret['result'] = None
@@ -101,7 +99,7 @@ def create_alert(name=None, api_key=None, reason=None, action_type="Create"):
         reason=reason,
         action_type=action_type
     )
-
+	
     if 200 <= response_status_code < 300:
         log.info(
             "POST Request has succeeded with message: %s status code: %s",

--- a/salt/states/opsgenie.py
+++ b/salt/states/opsgenie.py
@@ -99,7 +99,7 @@ def create_alert(name=None, api_key=None, reason=None, action_type="Create"):
         reason=reason,
         action_type=action_type
     )
-	
+
     if 200 <= response_status_code < 300:
         log.info(
             "POST Request has succeeded with message: %s status code: %s",


### PR DESCRIPTION
### What does this PR do?
Updates OpsGenie to use their V2 API.

### What issues does this PR fix or reference?
OpsGenie's V1 API was deprecated in June 2018

### Previous Behavior
Completely broken.

### New Behavior
Able to create an alert "onfail", and close the alert when not.

### Tests written?
No

### Commits signed with GPG?
No

### Example pillar
```
used_space:
  disk.status:
    - name: 'C:\'
    - maximum: 79%
    - minimum: 10%
   
opsgenie_create_action_sender:
  opsgenie.create_alert:
    - api_key: '{{ pillar['opsgenie_sysadmin_apitoken'] }}'
    - reason: 'Disk capacity is out of designated range for {{ grains['id'] }}.'
    - name: '{{ grains['id'] }}_disk.status'
    - onfail:
      - disk: used_space
 
opsgenie_close_action_sender:
  opsgenie.close_alert:
    - api_key: '{{ pillar['opsgenie_sysadmin_apitoken'] }}'
    - name: '{{ grains['id'] }}_disk.status'
    - require:
      - disk: used_space
```