### PR TITLE
Fix possible oversight in nodegroup modifications

### DIFF
--- a/salt/utils/minions.py
+++ b/salt/utils/minions.py
@@ -149,7 +149,7 @@ def nodegroup_comp(nodegroup, nodegroups, skip=None, first_call=True):
             # No compound operators found in nodegroup definition. Check for
             # group type specifiers
             group_type_re = re.compile('^[A-Z]@')
-            regex_chars = ['(', '[', '{', '\\', '?''}])']
+            regex_chars = ['(', '[', '{', '\\', '?', '}', ']', ')']
             if not [x for x in ret if '*' in x or group_type_re.match(x)]:
                 # No group type specifiers and no wildcards.
                 # Treat this as an expression.


### PR DESCRIPTION
b3e2f38 enhanced nodegroup matching to allow sequences. However, the list of regex special characters appears to have been improperly formatted.

We'll have to see what the test results say.