### PR TITLE
Fix service name in minion plist

### DIFF
--- a/pkg/darwin/com.saltstack.salt.minion.plist
+++ b/pkg/darwin/com.saltstack.salt.minion.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
   <dict>
     <key>Label</key>
-    <string>salt-minion</string>
+    <string>com.saltstack.salt.minion</string>
     <key>RunAtLoad</key>
     <true/>
     <key>KeepAlive</key>


### PR DESCRIPTION
### What does this PR do?
Fixes the service name to match Apple's conventions. Homebrew uses the paths in this plist. This is the same service name fix from twangboy@23d47722b730443976a6ebd64cb7258f8c5b426f. The pkg built from pkg/macos use a different install path.

### What issues does this PR fix or reference?

### Previous Behavior
The minion service was named "salt-minion" and failed to be targeted by service.enable in 2018.3.3. While service.enable worked in previous versions, the oldest supported version that didn't follow the convention is 2017.7

### New Behavior
The minion service is named "com.saltstack.salt.minion", matching the plist naming, which uses Apple's naming convention. The service can be properly targeted by service.enable.

### Tests written?

No

### Commits signed with GPG?

No
