### PR TITLE
Fix win_lgpo_auditpol salt util on Windows

### DIFF
--- a/salt/utils/win_lgpo_auditpol.py
+++ b/salt/utils/win_lgpo_auditpol.py
@@ -66,6 +66,7 @@ import re
 import tempfile
 
 # Import Salt libs
+import salt.modules.cmdmod
 import salt.utils.files
 import salt.utils.platform
 from salt.exceptions import CommandExecutionError
@@ -117,8 +118,8 @@ def _auditpol_cmd(cmd):
     Raises:
         CommandExecutionError: If the command encounters an error
     '''
-    ret = __salt__['cmd.run_all'](cmd='auditpol {0}'.format(cmd),
-                                  python_shell=True)
+    ret = salt.modules.cmdmod.run_all(cmd='auditpol {0}'.format(cmd),
+                                      python_shell=True)
     if ret['retcode'] == 0:
         return ret['stdout'].splitlines()
 

--- a/tests/unit/utils/test_win_lgpo_auditpol.py
+++ b/tests/unit/utils/test_win_lgpo_auditpol.py
@@ -55,7 +55,7 @@ class WinLgpoAuditpolTestCase(TestCase, LoaderModuleMockMixin):
     def test_set_setting(self):
         names = ['Credential Validation', 'IPsec Driver', 'File System', 'SAM']
         mock_set = MagicMock(return_value={'retcode': 0, 'stdout': 'Success'})
-        with patch.dict(win_lgpo_auditpol.__salt__, {'cmd.run_all': mock_set}):
+        with patch.object(salt.modules.cmdmod, 'run_all', mock_set):
             with patch.object(win_lgpo_auditpol, '_get_valid_names',
                               return_value=[k.lower() for k in names]):
                 for name in names:


### PR DESCRIPTION
### What does this PR do?
Calls `cmd.run_all` directly instead of calling it via `__salt__`. Apparently, you can't always use `__salt__` in a util.

### What issues does this PR fix or reference?
https://github.com/saltstack/lock/issues/777#issuecomment-454407399

### Tests written?
Yes

### Commits signed with GPG?
Yes