### PR TITLE
Fix Python 3 incompatibility in EC2 salt-cloud driver

### DIFF
--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -97,6 +97,7 @@ import decimal
 
 # Import Salt Libs
 import salt.utils.cloud
+import salt.utils.compat
 import salt.utils.files
 import salt.utils.hashutils
 import salt.utils.json
@@ -1225,7 +1226,7 @@ def get_imageid(vm_):
     _t = lambda x: datetime.datetime.strptime(x['creationDate'], '%Y-%m-%dT%H:%M:%S.%fZ')
     image_id = sorted(aws.query(params, location=get_location(),
                                  provider=get_provider(), opts=__opts__, sigver='4'),
-                      lambda i, j: cmp(_t(i), _t(j))
+                      lambda i, j: salt.utils.compat.cmp(_t(i), _t(j))
                       )[-1]['imageId']
     get_imageid.images[image] = image_id
     return image_id


### PR DESCRIPTION
cmp does not exist in Python 3