### PR TITLE
Lint: Fix str-format-in-logging, len-as-condition, etc. (5)

### DIFF
--- a/salt/netapi/rest_cherrypy/app.py
+++ b/salt/netapi/rest_cherrypy/app.py
@@ -720,11 +720,11 @@ def salt_api_acl_tool(username, request):
     :type request: cherrypy.request
     '''
     failure_str = ("[api_acl] Authentication failed for "
-                   "user {0} from IP {1}")
+                   "user %s from IP %s")
     success_str = ("[api_acl] Authentication sucessful for "
-                   "user {0} from IP {1}")
+                   "user %s from IP %s")
     pass_str = ("[api_acl] Authentication not checked for "
-                "user {0} from IP {1}")
+                "user %s from IP %s")
 
     acl = None
     # Salt Configuration
@@ -742,23 +742,23 @@ def salt_api_acl_tool(username, request):
         if users:
             if username in users:
                 if ip in users[username] or '*' in users[username]:
-                    logger.info(success_str.format(username, ip))
+                    logger.info(success_str, username, ip)
                     return True
                 else:
-                    logger.info(failure_str.format(username, ip))
+                    logger.info(failure_str, username, ip)
                     return False
             elif username not in users and '*' in users:
                 if ip in users['*'] or '*' in users['*']:
-                    logger.info(success_str.format(username, ip))
+                    logger.info(success_str, username, ip)
                     return True
                 else:
-                    logger.info(failure_str.format(username, ip))
+                    logger.info(failure_str, username, ip)
                     return False
             else:
-                logger.info(failure_str.format(username, ip))
+                logger.info(failure_str, username, ip)
                 return False
     else:
-        logger.info(pass_str.format(username, ip))
+        logger.info(pass_str, username, ip)
         return True
 
 
@@ -775,11 +775,11 @@ def salt_ip_verify_tool():
         if cherrypy_conf:
             auth_ip_list = cherrypy_conf.get('authorized_ips', None)
             if auth_ip_list:
-                logger.debug("Found IP list: {0}".format(auth_ip_list))
+                logger.debug('Found IP list: %s', auth_ip_list)
                 rem_ip = cherrypy.request.headers.get('Remote-Addr', None)
-                logger.debug("Request from IP: {0}".format(rem_ip))
+                logger.debug('Request from IP: %s', rem_ip)
                 if rem_ip not in auth_ip_list:
-                    logger.error("Blocked IP: {0}".format(rem_ip))
+                    logger.error('Blocked IP: %s', rem_ip)
                     raise cherrypy.HTTPError(403, 'Bad IP')
 
 
@@ -1239,7 +1239,7 @@ class LowDataAdapter(object):
             HTTP/1.1 200 OK
             Content-Type: application/json
         '''
-        import inspect
+        import inspect  # pylint: disable=unused-import
 
         return {
             'return': "Welcome",
@@ -1915,9 +1915,11 @@ class Login(LowDataAdapter):
             if not perms:
                 logger.debug("Eauth permission list not found.")
         except Exception:
-            logger.debug("Configuration for external_auth malformed for "
-                "eauth '{0}', and user '{1}'."
-                .format(token.get('eauth'), token.get('name')), exc_info=True)
+            logger.debug(
+                "Configuration for external_auth malformed for eauth '%s', "
+                "and user '%s'.", token.get('eauth'), token.get('name'),
+                exc_info=True
+            )
             perms = None
 
         return {'return': [{
@@ -2560,8 +2562,7 @@ class WebsocketEndpoint(object):
                             )
                     except UnicodeDecodeError:
                         logger.error(
-                                "Error: Salt event has non UTF-8 data:\n{0}"
-                                .format(data))
+                            "Error: Salt event has non UTF-8 data:\n%s", data)
 
         parent_pipe, child_pipe = Pipe()
         handler.pipe = parent_pipe

--- a/salt/netapi/rest_tornado/saltnado.py
+++ b/salt/netapi/rest_tornado/saltnado.py
@@ -368,7 +368,7 @@ class EventListener(object):
         if not future.done():
             future.set_exception(TimeoutException())
             self.tag_map[(tag, matcher)].remove(future)
-        if len(self.tag_map[(tag, matcher)]) == 0:
+        if not self.tag_map[(tag, matcher)]:
             del self.tag_map[(tag, matcher)]
 
     def _handle_event_socket_recv(self, raw):

--- a/salt/output/__init__.py
+++ b/salt/output/__init__.py
@@ -96,7 +96,7 @@ def display_output(data, out=None, opts=None, **kwargs):
     display_data = try_printout(data, out, opts, **kwargs)
 
     output_filename = opts.get('output_file', None)
-    log.trace('data = {0}'.format(data))
+    log.trace('data = %s', data)
     try:
         # output filename can be either '' or None
         if output_filename:
@@ -193,7 +193,7 @@ def get_printout(out, opts=None, **kwargs):
         # Since the grains outputter was removed we don't need to fire this
         # error when old minions are asking for it
         if out != 'grains':
-            log.error('Invalid outputter {0} specified, fall back to nested'.format(out))
+            log.error('Invalid outputter %s specified, falling back to nested', out)
         return outputters['nested']
     return outputters[out]
 

--- a/salt/pillar/ec2_pillar.py
+++ b/salt/pillar/ec2_pillar.py
@@ -177,7 +177,7 @@ def ext_pillar(minion_id,
         return {}
 
     myself = boto.utils.get_instance_metadata(timeout=0.1, num_retries=1)
-    if len(myself.keys()) < 1:
+    if not myself:
         log.info("%s: salt master not an EC2 instance, skipping", __name__)
         return {}
 

--- a/salt/pillar/file_tree.py
+++ b/salt/pillar/file_tree.py
@@ -479,10 +479,10 @@ def _ext_pillar(minion_id,
 
     ngroup_pillar = {}
     nodegroups_dir = os.path.join(root_dir, 'nodegroups')
-    if os.path.exists(nodegroups_dir) and len(__opts__.get('nodegroups', ())) > 0:
+    if os.path.exists(nodegroups_dir) and __opts__.get('nodegroups'):
         master_ngroups = __opts__['nodegroups']
         ext_pillar_dirs = os.listdir(nodegroups_dir)
-        if len(ext_pillar_dirs) > 0:
+        if ext_pillar_dirs:
             for nodegroup in ext_pillar_dirs:
                 if (os.path.isdir(nodegroups_dir) and
                         nodegroup in master_ngroups):

--- a/salt/pillar/makostack.py
+++ b/salt/pillar/makostack.py
@@ -452,7 +452,7 @@ def ext_pillar(minion_id, pillar, *args, **kwargs):
         else:
             namespace = None
         if not os.path.isfile(cfg):
-            log.warning('Ignoring MakoStack cfg `{}`: file not found'.format(cfg))
+            log.warning('Ignoring MakoStack cfg `%s`: file not found', cfg)
             continue
         stack = _process_stack_cfg(cfg, stack, minion_id, pillar, namespace, config)
     return stack
@@ -479,13 +479,13 @@ def _process_stack_cfg(cfg, stack, minion_id, pillar, namespace, config):
                 for sub in namespace.split(':')[::-1]:
                     obj = {sub: obj}
             stack = _merge_dict(stack, obj)
-            log.debug('MakoStack template `{}` parsed'.format(line))
+            log.debug('MakoStack template `%s` parsed', line)
         except exceptions.TopLevelLookupException as err:
             if config.get('fail_on_missing_file'):
                 msg = 'MakoStack template `{}` not found - aborting compilation.'.format(line)
                 log.error(msg)
                 raise CommandExecutionError(msg)
-            log.info('MakoStack template `{}` not found.'.format(line))
+            log.info('MakoStack template `%s` not found.', line)
             continue
         except Exception as err:
             # Catches the above KeyError, and any other parsing errors...
@@ -531,7 +531,7 @@ def _merge_dict(stack, obj):
                     stack[k] = _cleanup(v)
                     v = stack_k
                 if type(stack[k]) != type(v):
-                    log.debug('Force overwrite, types differ: `{}` != `{}`'.format(stack[k], v))
+                    log.debug('Force overwrite, types differ: `%s` != `%s`', stack[k], v)
                     stack[k] = _cleanup(v)
                 elif isinstance(v, dict):
                     stack[k] = _merge_dict(stack[k], v)
@@ -568,9 +568,9 @@ def _parse_top_cfg(content, filename):
     try:
         obj = salt.utils.yaml.safe_load(content)
         if isinstance(obj, list):
-            log.debug('MakoStack cfg `{}` parsed as YAML'.format(filename))
+            log.debug('MakoStack cfg `%s` parsed as YAML', filename)
             return obj
     except Exception as err:
         pass
-    log.debug('MakoStack cfg `{}` parsed as plain text'.format(filename))
+    log.debug('MakoStack cfg `%s` parsed as plain text', filename)
     return content.splitlines()

--- a/salt/pillar/pillar_ldap.py
+++ b/salt/pillar/pillar_ldap.py
@@ -329,11 +329,13 @@ def ext_pillar(minion_id,  # pylint: disable=W0613
         opts['conf_file'] = config_file
     except Exception as err:
         import salt.log
-        msg = 'pillar_ldap: error parsing configuration file: {0} - {1}'
+        msg = 'pillar_ldap: error parsing configuration file: {0} - {1}'.format(
+            config_file, err
+        )
         if salt.log.is_console_configured():
-            log.warning(msg.format(config_file, err))
+            log.warning(msg)
         else:
-            print(msg.format(config_file, err))
+            print(msg)
         return {}
     else:
         if not isinstance(opts, dict):

--- a/salt/pillar/reclass_adapter.py
+++ b/salt/pillar/reclass_adapter.py
@@ -71,7 +71,7 @@ __virtualname__ = 'reclass'
 
 def __virtual__(retry=False):
     try:
-        import reclass
+        import reclass  # pylint: disable=unused-import
         return __virtualname__
 
     except ImportError as e:

--- a/salt/proxy/bluecoat_sslv.py
+++ b/salt/proxy/bluecoat_sslv.py
@@ -102,7 +102,7 @@ def __virtual__():
 def _validate_response_code(response_code_to_check):
     formatted_response_code = response_code_to_check
     if formatted_response_code not in [200, 201, 202, 204]:
-        log.error("Received error HTTP status code: {0}" .format(formatted_response_code))
+        log.error("Received error HTTP status code: %s", formatted_response_code)
         raise salt.exceptions.CommandExecutionError(
             "Did not receive a valid response from host.")
 
@@ -181,8 +181,8 @@ def logon():
     logon_response = session.post(DETAILS['url'], data=json.dumps(payload), verify=False)
 
     if logon_response.status_code != 200:
-        log.error("Error logging into proxy. HTTP Error code: {0}" .format(
-            logon_response.status_code))
+        log.error("Error logging into proxy. HTTP Error code: %s",
+                  logon_response.status_code)
         raise salt.exceptions.CommandExecutionError(
             "Did not receive a valid response from host.")
 

--- a/salt/proxy/cimc.py
+++ b/salt/proxy/cimc.py
@@ -102,7 +102,7 @@ def _validate_response_code(response_code_to_check, cookie_to_logout=None):
     if formatted_response_code not in ['200', '201', '202', '204']:
         if cookie_to_logout:
             logout(cookie_to_logout)
-        log.error("Received error HTTP status code: {0}" .format(formatted_response_code))
+        log.error("Received error HTTP status code: %s", formatted_response_code)
         raise salt.exceptions.CommandExecutionError(
             "Did not receive a valid response from host.")
 

--- a/salt/proxy/esxi.py
+++ b/salt/proxy/esxi.py
@@ -377,9 +377,7 @@ def init(opts):
                 log.critical('No \'username\' key found in pillar for this '
                              'proxy.')
                 return False
-            if 'passwords' not in proxy_conf and \
-                len(proxy_conf['passwords']) > 0:
-
+            if 'passwords' not in proxy_conf and proxy_conf['passwords']:
                 log.critical('Mechanism is set to \'userpass\' , but no '
                              '\'passwords\' key found in pillar for this '
                              'proxy.')

--- a/salt/proxy/nxos.py
+++ b/salt/proxy/nxos.py
@@ -223,7 +223,7 @@ def init(opts=None):
         log.info('NXOS PROXY: Initialize nxapi proxy connection')
         return _init_nxapi(opts)
     else:
-        log.error('Unknown Connection Type: {0}'.format(CONNECTION))
+        log.error('Unknown Connection Type: %s', CONNECTION)
         return False
 
 
@@ -261,7 +261,7 @@ def grains(**kwargs):
 
         salt '*' nxos.cmd grains
     '''
-    import __main__ as main
+    import __main__ as main  # pylint: disable=unused-import
     if not DEVICE_DETAILS['grains_cache']:
         data = sendline('show version')
         if CONNECTION == 'nxapi':
@@ -403,7 +403,7 @@ def _init_ssh(opts):
             ssh_args=opts['proxy'].get('ssh_args', ''),
             prompt=this_prompt)
         out, err = DEVICE_DETAILS[_worker_name()].sendline('terminal length 0')
-        log.info('SSH session establised for process {}'.format(_worker_name()))
+        log.info('SSH session establised for process %s', _worker_name())
     except Exception as ex:
         log.error('Unable to connect to %s', opts['proxy']['host'])
         log.error('Please check the following:\n')
@@ -502,7 +502,7 @@ def _init_nxapi(opts):
         log.error('-- Verify that nxapi settings on the NX-OS device and proxy minion config file match')
         log.error('-- Exception Generated: %s', ex)
         exit()
-    log.info('nxapi DEVICE_DETAILS info: {}'.format(DEVICE_DETAILS))
+    log.info('nxapi DEVICE_DETAILS info: %s', DEVICE_DETAILS)
     return True
 
 

--- a/salt/queues/pgjsonb_queue.py
+++ b/salt/queues/pgjsonb_queue.py
@@ -246,7 +246,7 @@ def pop(queue, quantity=1, is_runner=False):
     with _conn(commit=True) as cur:
         cur.execute(cmd)
         result = cur.fetchall()
-        if len(result) > 0:
+        if result:
             ids = [six.text_type(item[0]) for item in result]
             items = [item[1] for item in result]
             idlist = "','".join(ids)

--- a/salt/queues/sqlite_queue.py
+++ b/salt/queues/sqlite_queue.py
@@ -227,7 +227,7 @@ def pop(queue, quantity=1, is_runner=False):
     with con:
         cur = con.cursor()
         result = cur.execute(cmd).fetchall()
-        if len(result) > 0:
+        if result:
             items = [item[0] for item in result]
             itemlist = '","'.join(items)
             _quote_escape(itemlist)

--- a/salt/renderers/hjson.py
+++ b/salt/renderers/hjson.py
@@ -11,7 +11,7 @@ from __future__ import absolute_import, print_function, unicode_literals
 
 # Import 3rd party libs
 try:
-    import hjson as hjson
+    import hjson
     HAS_LIBS = True
 except ImportError:
     HAS_LIBS = False

--- a/salt/renderers/stateconf.py
+++ b/salt/renderers/stateconf.py
@@ -79,7 +79,7 @@ def __init__(opts):
 MOD_BASENAME = os.path.basename(__file__)
 INVALID_USAGE_ERROR = SaltRenderError(
     'Invalid use of {0} renderer!\n'
-    '''Usage: #!{1} [-GoSp] [<data_renderer> [options] . <template_renderer> [options]]
+    '''Usage: #!{0} [-GoSp] [<data_renderer> [options] . <template_renderer> [options]]
 
 where an example <data_renderer> would be yaml and a <template_renderer> might
 be jinja. Each renderer can be passed its renderer specific options.
@@ -99,7 +99,7 @@ Options(for this renderer):
        in the sls will have no effect, but other features of the renderer still
        apply.
 
-  '''.format(MOD_BASENAME, MOD_BASENAME)
+  '''.format(MOD_BASENAME)
 )
 
 

--- a/salt/renderers/yaml.py
+++ b/salt/renderers/yaml.py
@@ -57,7 +57,7 @@ def render(yaml_data, saltenv='base', sls='', argline='', **kws):
             raise SaltRenderError(err_type, line_num, exc.problem_mark.buffer)
         except (ParserError, ConstructorError) as exc:
             raise SaltRenderError(exc)
-        if len(warn_list) > 0:
+        if warn_list:
             for item in warn_list:
                 log.warning(
                     '%s found in %s saltenv=%s',

--- a/salt/returners/appoptics_return.py
+++ b/salt/returners/appoptics_return.py
@@ -119,7 +119,7 @@ def _get_options(ret=None):
         'host_hostname_alias': __salt__['grains.get']('id')
     })
 
-    log.debug('Retrieved appoptics options: {}'.format(_options))
+    log.debug('Retrieved appoptics options: %s', _options)
     return _options
 
 
@@ -153,31 +153,30 @@ def _calculate_runtimes(states):
             # Count durations
             results['runtime'] += resultset['duration']
 
-    log.debug('Parsed state metrics: {}'.format(results))
+    log.debug('Parsed state metrics: %s', results)
     return results
 
 
 def _state_metrics(ret, options, tags):
     # Calculate the runtimes and number of failed states.
     stats = _calculate_runtimes(ret['return'])
-    log.debug('Batching Metric retcode with {}'.format(ret['retcode']))
+    log.debug('Batching Metric retcode with %s', ret['retcode'])
     appoptics_conn = _get_appoptics(options)
     q = appoptics_conn.new_queue(tags=tags)
 
     q.add('saltstack.retcode', ret['retcode'])
-    log.debug('Batching Metric num_failed_jobs with {}'.format(
-        stats['num_failed_states']))
+    log.debug('Batching Metric num_failed_jobs with %s', stats['num_failed_states'])
     q.add('saltstack.failed', stats['num_failed_states'])
 
-    log.debug('Batching Metric num_passed_states with {}'.format(
-        stats['num_passed_states']))
+    log.debug('Batching Metric num_passed_states with %s',
+              stats['num_passed_states'])
     q.add('saltstack.passed', stats['num_passed_states'])
 
-    log.debug('Batching Metric runtime with {}'.format(stats['runtime']))
+    log.debug('Batching Metric runtime with %s', stats['runtime'])
     q.add('saltstack.runtime', stats['runtime'])
 
-    log.debug('Batching with  Metric total states {}'.format(
-              (stats['num_failed_states'] + stats['num_passed_states'])))
+    log.debug('Batching with  Metric total states %s',
+              (stats['num_failed_states'] + stats['num_passed_states']))
     q.add('saltstack.highstate.total_states',
           (stats['num_failed_states'] + stats['num_passed_states']))
     log.info('Sending metrics to appoptics.')
@@ -199,12 +198,12 @@ def returner(ret):
     if ret['fun'] in states_to_report:
         tags = options.get('tags', {}).copy()
         tags['state_type'] = ret['fun']
-        log.info("Tags for this run are {}".format(str(tags)))
+        log.info("Tags for this run are %s", tags)
         matched_states = set(ret['fun_args']).intersection(
             set(options.get('sls_states', [])))
         # What can I do if a run has multiple states that match?
         # In the mean time, find one matching state name and use it.
         if matched_states:
             tags['state_name'] = sorted(matched_states)[0]
-            log.debug('Found returned data from {}.'.format(tags['state_name']))
+            log.debug('Found returned data from %s.', tags['state_name'])
         _state_metrics(ret, options, tags)

--- a/salt/returners/couchdb_return.py
+++ b/salt/returners/couchdb_return.py
@@ -234,10 +234,10 @@ def returner(ret):
 
         # Confirm that the response back was simple 'ok': true.
         if 'ok' not in _response or _response['ok'] is not True:
-            log.error('Nothing logged! Lost data. Unable to create database "{0}"'.format(options['db']))
-            log.debug('_response object is: {0}'.format(_response))
+            log.error('Nothing logged! Lost data. Unable to create database "%s"', options['db'])
+            log.debug('_response object is: %s', _response)
             return
-        log.info('Created database "{0}"'.format(options['db']))
+        log.info('Created database "%s"', options['db'])
 
     if boltons_lib:
         # redact all passwords if options['redact_pws'] is True
@@ -266,7 +266,7 @@ def returner(ret):
 
     # Sanity check regarding the response..
     if 'ok' not in _response or _response['ok'] is not True:
-        log.error('Nothing logged! Lost data. Unable to create document: "{0}"'.format(_response))
+        log.error('Nothing logged! Lost data. Unable to create document: "%s"', _response)
 
 
 def event_return(events):
@@ -281,7 +281,7 @@ def event_return(events):
       - couchdb
 
     '''
-    log.debug('events data is: {}'.format(events))
+    log.debug('events data is: %s', events)
 
     options = _get_options()
 
@@ -291,7 +291,7 @@ def event_return(events):
     if event_db not in _response:
 
         # Make a PUT request to create the database.
-        log.info('Creating database "{0}"'.format(event_db))
+        log.info('Creating database "%s"', event_db)
         _response = _request("PUT",
                              options['url'] + event_db,
                              user=options['user'],
@@ -299,13 +299,13 @@ def event_return(events):
 
         # Confirm that the response back was simple 'ok': true.
         if 'ok' not in _response or _response['ok'] is not True:
-            log.error('Nothing logged! Lost data. Unable to create database "{0}"'.format(event_db))
+            log.error('Nothing logged! Lost data. Unable to create database "%s"', event_db)
             return
-        log.info('Created database "{0}"'.format(event_db))
+        log.info('Created database "%s"', event_db)
 
     for event in events:
         # Call _generate_doc to get a dict object of the document we're going to shove into the database.
-        log.debug('event data is: {}'.format(event))
+        log.debug('event data is: %s', event)
         doc = _generate_event_doc(event)
 
         # Make the actual HTTP PUT request to create the doc.
@@ -315,7 +315,7 @@ def event_return(events):
                              salt.utils.json.dumps(doc))
         # Sanity check regarding the response..
         if 'ok' not in _response or _response['ok'] is not True:
-            log.error('Nothing logged! Lost data. Unable to create document: "{0}"'.format(_response))
+            log.error('Nothing logged! Lost data. Unable to create document: "%s"', _response)
 
 
 def get_jid(jid):
@@ -325,7 +325,7 @@ def get_jid(jid):
     options = _get_options(ret=None)
     _response = _request("GET", options['url'] + options['db'] + '/' + jid)
     if 'error' in _response:
-        log.error('Unable to get JID "{0}" : "{1}"'.format(jid, _response))
+        log.error('Unable to get JID "%s" : "%s"', jid, _response)
         return {}
     return {_response['id']: _response}
 
@@ -339,7 +339,7 @@ def get_jids():
 
     # Make sure the 'total_rows' is returned.. if not error out.
     if 'total_rows' not in _response:
-        log.error('Didn\'t get valid response from requesting all docs: {0}'.format(_response))
+        log.error('Didn\'t get valid response from requesting all docs: %s', _response)
         return {}
 
     # Return the rows.
@@ -384,13 +384,13 @@ def get_fun(fun):
                                                         fun))
         # Skip the minion if we got an error..
         if 'error' in _response:
-            log.warning('''Got an error when querying for last command
-                         by a minion: {0}'''.format(_response['error']))
+            log.warning('Got an error when querying for last command '
+                        'by a minion: %s', _response['error'])
             continue
 
         # Skip the minion if we didn't get any rows back. ( IE function that
         # they're looking for has a typo in it or some such ).
-        if len(_response['rows']) < 1:
+        if not _response['rows']:
             continue
 
         # Set the respnse ..
@@ -417,7 +417,7 @@ def get_minions():
 
     # Verify that we got a response back.
     if 'rows' not in _response:
-        log.error('Unable to get available minions: {0}'.format(_response))
+        log.error('Unable to get available minions: %s', _response)
         return []
 
     # Iterate over the rows to build up a list return it.
@@ -492,7 +492,7 @@ def set_salt_view():
                          options['url'] + options['db'] + "/_design/salt",
                          "application/json", salt.utils.json.dumps(new_doc))
     if 'error' in _response:
-        log.warning('Unable to set the salt design document: {0}'.format(_response['error']))
+        log.warning('Unable to set the salt design document: %s', _response['error'])
         return False
     return True
 
@@ -525,6 +525,6 @@ def get_load(jid):
     options = _get_options(ret=None)
     _response = _request("GET", options['url'] + options['db'] + '/' + jid)
     if 'error' in _response:
-        log.error('Unable to get JID "{0}" : "{1}"'.format(jid, _response))
+        log.error('Unable to get JID "%s" : "%s"', jid, _response)
         return {}
     return {_response['id']: _response}

--- a/salt/returners/etcd_return.py
+++ b/salt/returners/etcd_return.py
@@ -138,7 +138,7 @@ def save_load(jid, load, minions=None):
     '''
     Save the load to the specified jid
     '''
-    log.debug('sdstack_etcd returner <save_load> called jid: {0}'.format(jid))
+    log.debug('sdstack_etcd returner <save_load> called jid: %s', jid)
     write_profile = __opts__.get('etcd.returner_write_profile')
     client, path = _get_conn(__opts__, write_profile)
     if write_profile:
@@ -170,7 +170,7 @@ def get_load(jid):
     '''
     Return the load data that marks a specified jid
     '''
-    log.debug('sdstack_etcd returner <get_load> called jid: {0}'.format(jid))
+    log.debug('sdstack_etcd returner <get_load> called jid: %s', jid)
     read_profile = __opts__.get('etcd.returner_read_profile')
     client, path = _get_conn(__opts__, read_profile)
     return salt.utils.json.loads(client.get('/'.join((path, 'jobs', jid, '.load.p'))).value)
@@ -180,7 +180,7 @@ def get_jid(jid):
     '''
     Return the information returned when the specified job id was executed
     '''
-    log.debug('sdstack_etcd returner <get_jid> called jid: {0}'.format(jid))
+    log.debug('sdstack_etcd returner <get_jid> called jid: %s', jid)
     ret = {}
     client, path = _get_conn(__opts__)
     items = client.get('/'.join((path, 'jobs', jid)))
@@ -197,7 +197,7 @@ def get_fun(fun):
     '''
     Return a dict of the last function called for all minions
     '''
-    log.debug('sdstack_etcd returner <get_fun> called fun: {0}'.format(fun))
+    log.debug('sdstack_etcd returner <get_fun> called fun: %s', fun)
     ret = {}
     client, path = _get_conn(__opts__)
     items = client.get('/'.join((path, 'minions')))

--- a/salt/returners/rawfile_json.py
+++ b/salt/returners/rawfile_json.py
@@ -69,7 +69,7 @@ def event_return(events):
     '''
     Write event data (return data and non-return data) to file on the master.
     '''
-    if len(events) == 0:
+    if not events:
         # events is an empty list.
         # Don't open the logfile in vain.
         return

--- a/salt/returners/redis_return.py
+++ b/salt/returners/redis_return.py
@@ -314,7 +314,7 @@ def clean_old_jobs():
         load_key = ret_key.replace('ret:', 'load:', 1)
         if load_key not in living_jids:
             to_remove.append(ret_key)
-    if len(to_remove) != 0:
+    if to_remove:
         serv.delete(*to_remove)
         log.debug('clean old jobs: %s', to_remove)
 

--- a/salt/returners/sentry_return.py
+++ b/salt/returners/sentry_return.py
@@ -110,7 +110,7 @@ def _get_message(ret):
         return 'salt func: {}'.format(ret['fun'])
     arg_string = ' '.join([arg for arg in ret['fun_args'] if isinstance(arg, six.string_types)])
     kwarg_string = ''
-    if isinstance(ret['fun_args'], list) and len(ret['fun_args']) > 0:
+    if ret['fun_args'] and isinstance(ret['fun_args'], list):
         kwargs = ret['fun_args'][-1]
         if isinstance(kwargs, dict):
             kwarg_string = ' '.join(sorted(['{}={}'.format(k, v) for k, v in kwargs.items() if not k.startswith('_')]))

--- a/salt/returners/slack_webhook_return.py
+++ b/salt/returners/slack_webhook_return.py
@@ -162,7 +162,7 @@ def _generate_payload(author_icon, title, report):
         'title': 'Changed: {changed}'.format(changed=report['changed'].get('counter', None))
     }
 
-    if len(report['changed'].get('tasks', [])) > 0:
+    if report['changed'].get('tasks'):
         changed['fields'] = list(
             map(_format_task, report['changed'].get('tasks')))
 
@@ -171,12 +171,12 @@ def _generate_payload(author_icon, title, report):
         'title': 'Failed: {failed}'.format(failed=report['failed'].get('counter', None))
     }
 
-    if len(report['failed'].get('tasks', [])) > 0:
+    if report['failed'].get('tasks'):
         failed['fields'] = list(
             map(_format_task, report['failed'].get('tasks')))
 
     text = 'Function: {function}\n'.format(function=report.get('function'))
-    if len(report.get('arguments', [])) > 0:
+    if report.get('arguments'):
         text += 'Function Args: {arguments}\n'.format(
             arguments=str(list(map(str, report.get('arguments')))))
 

--- a/salt/returners/splunk.py
+++ b/salt/returners/splunk.py
@@ -201,7 +201,7 @@ class http_event_collector(object):
     def flushBatch(self):
         # Method to flush the batch list of events
 
-        if len(self.batchEvents) > 0:
+        if self.batchEvents:
             headers = {'Authorization': 'Splunk '+self.token}
             r = requests.post(self.server_uri, data=" ".join(self.batchEvents), headers=headers, verify=http_event_collector_SSL_verify)
             self.batchEvents = []

--- a/salt/runners/smartos_vmadm.py
+++ b/salt/runners/smartos_vmadm.py
@@ -65,7 +65,7 @@ def _action(action='get', search=None, one=True, force=False):
         pass
 
     ## check if we have vms
-    if len(vms) == 0:
+    if not vms:
         return {'Error': 'No vms found.'}
 
     ## simple search
@@ -89,7 +89,7 @@ def _action(action='get', search=None, one=True, force=False):
                     matched_vms.append(vm)
 
             ## exit on match(es) or try again
-            if len(matched_vms) > 0:
+            if matched_vms:
                 break
             else:
                 loop_pass += 1
@@ -98,7 +98,7 @@ def _action(action='get', search=None, one=True, force=False):
             matched_vms.append(vm)
 
     ## check if we have vms
-    if len(matched_vms) == 0:
+    if not matched_vms:
         return {'Error': 'No vms matched.'}
 
     ## multiple allowed?

--- a/salt/serializers/yamlex.py
+++ b/salt/serializers/yamlex.py
@@ -403,7 +403,7 @@ Dumper.add_multi_representer(type(None), Dumper.represent_none)
 if six.PY2:
     Dumper.add_multi_representer(six.binary_type, Dumper.represent_str)
     Dumper.add_multi_representer(six.text_type, Dumper.represent_unicode)
-    Dumper.add_multi_representer(long, Dumper.represent_long)  # pylint: disable=incompatible-py3-code
+    Dumper.add_multi_representer(long, Dumper.represent_long)  # pylint: disable=incompatible-py3-code,undefined-variable
 else:
     Dumper.add_multi_representer(six.binary_type, Dumper.represent_binary)
     Dumper.add_multi_representer(six.text_type, Dumper.represent_str)

--- a/salt/spm/__init__.py
+++ b/salt/spm/__init__.py
@@ -428,7 +428,7 @@ class SPMClient(object):
 
             needs, unavail, optional, recommended = self._resolve_deps(formula_def)
 
-            if len(unavail) > 0:
+            if unavail:
                 raise SPMPackageError(
                     'Cannot install {0}, the following dependencies are needed:\n\n{1}'.format(
                         formula_def['name'], '\n'.join(unavail))
@@ -596,7 +596,7 @@ class SPMClient(object):
 
         inspected = []
         to_inspect = can_has.copy()
-        while len(to_inspect) > 0:
+        while to_inspect:
             dep = next(six.iterkeys(to_inspect))
             del to_inspect[dep]
 

--- a/salt/utils/thread_local_proxy.py
+++ b/salt/utils/thread_local_proxy.py
@@ -3,7 +3,7 @@
 Proxy object that can reference different values depending on the current
 thread of execution.
 
-..versionadded:: 2018.3.4
+..versionadded:: Neon
 
 '''
 

--- a/tests/buildpackage.py
+++ b/tests/buildpackage.py
@@ -177,16 +177,16 @@ def _move(src, dst):
 
 
 def _run_command(args):
-    log.info('Running command: {0}'.format(args))
+    log.info('Running command: %s', args)
     proc = subprocess.Popen(args,
                             stdout=subprocess.PIPE,
                             stderr=subprocess.PIPE)
     stdout, stderr = proc.communicate()
     if stdout:
-        log.debug('Command output: \n{0}'.format(stdout))
+        log.debug('Command output: \n%s', stdout)
     if stderr:
         log.error(stderr)
-    log.info('Return code: {0}'.format(proc.returncode))
+    log.info('Return code: %s', proc.returncode)
     return stdout, stderr, proc.returncode
 
 
@@ -199,7 +199,7 @@ def _make_sdist(opts, python_bin='python'):
             glob.iglob(os.path.join(opts.source_dir, 'dist', 'salt-*.tar.gz')),
             key=os.path.getctime
         )
-        log.info('sdist is located at {0}'.format(sdist_path))
+        log.info('sdist is located at %s', sdist_path)
         return sdist_path
     else:
         _abort('Failed to create sdist')
@@ -224,7 +224,7 @@ def build_centos(opts):
     except IOError as exc:
         _abort('{0}'.format(exc))
 
-    log.info('major_release: {0}'.format(major_release))
+    log.info('major_release: %s', major_release)
 
     define_opts = [
         '--define',
@@ -269,8 +269,8 @@ def build_centos(opts):
         salt_pkgver = '.'.join((base, offset, oid))
         salt_srcver = '-'.join((base, offset, oid))
 
-    log.info('salt_pkgver: {0}'.format(salt_pkgver))
-    log.info('salt_srcver: {0}'.format(salt_srcver))
+    log.info('salt_pkgver: %s', salt_pkgver)
+    log.info('salt_srcver: %s', salt_srcver)
 
     # Setup build environment
     for build_dir in 'BUILD BUILDROOT RPMS SOURCES SPECS SRPMS'.split():
@@ -352,8 +352,8 @@ if __name__ == '__main__':
                         datefmt=log_datefmt,
                         level=LOG_LEVELS[opts.log_level])
     if opts.log_level not in LOG_LEVELS:
-        log.error('Invalid log level \'{0}\', falling back to \'warning\''
-                  .format(opts.log_level))
+        log.error('Invalid log level \'%s\', falling back to \'warning\'',
+                  opts.log_level)
 
     # Build for the specified platform
     if not opts.platform:
@@ -369,5 +369,5 @@ if __name__ == '__main__':
     print(msg)  # pylint: disable=C0325
     for artifact in artifacts:
         shutil.copy(artifact, opts.artifact_dir)
-        log.info('Copied {0} to artifact directory'.format(artifact))
+        log.info('Copied %s to artifact directory', artifact)
     log.info('Done!')

--- a/tests/committer_parser.py
+++ b/tests/committer_parser.py
@@ -138,7 +138,7 @@ def main(argv=None):
     try:
         try:
             opts, args = getopt.getopt(argv[1:], 'hc', ['help', 'contributor-detail'])
-            if len(args) < 1:
+            if not args:
                 raise Usage('committer_parser.py needs a filename or \'-\' to read from stdin')
         except getopt.error as msg:
             raise Usage(msg)
@@ -146,13 +146,13 @@ def main(argv=None):
         print(err.msg, file=sys.stderr)
         return 2
 
-    if len(opts) > 0:
+    if opts:
         if '-h' in opts[0] or '--help' in opts[0]:
             return 0
 
     data, counts, commits_by_contributor = parse_gitlog(filename=args[0])
 
-    if len(opts) > 0:
+    if opts:
         if '-c' or '--contributor-detail':
             print(counts_by_contributor(commits_by_contributor, data))
     else:

--- a/tests/integration/cloud/helpers/virtualbox.py
+++ b/tests/integration/cloud/helpers/virtualbox.py
@@ -70,7 +70,7 @@ class VirtualboxCloudTestCase(ShellCase):
         # Attempt to clean json output before fix of https://github.com/saltstack/salt/issues/27629
         valid_initial_chars = ['{', '[', '"']
         for line in output[:]:
-            if len(line) == 0 or (line[0] not in valid_initial_chars):
+            if not line or (line[0] not in valid_initial_chars):
                 output.pop(0)
             else:
                 break

--- a/tests/integration/modules/test_mac_brew.py
+++ b/tests/integration/modules/test_mac_brew.py
@@ -142,7 +142,7 @@ class BrewModuleTest(ModuleCase):
             upgrades = self.run_function('pkg.list_upgrades')
             try:
                 self.assertTrue(isinstance(upgrades, dict))
-                if len(upgrades):
+                if upgrades:
                     for name in upgrades:
                         self.assertTrue(isinstance(name, six.string_types))
                         self.assertTrue(isinstance(upgrades[name], six.string_types))

--- a/tests/integration/netapi/rest_tornado/test_app.py
+++ b/tests/integration/netapi/rest_tornado/test_app.py
@@ -100,6 +100,11 @@ class TestSaltAPIHandler(_SaltnadoIntegrationTestCase):
                               )
         response_obj = salt.utils.json.loads(response.body)
         self.assertEqual(len(response_obj['return']), 1)
+        # If --proxy is set, it will cause an extra minion_id to be in the
+        # response. Since there's not a great way to know if the test
+        # runner's proxy minion is running, and we're not testing proxy
+        # minions here anyway, just remove it from the response.
+        response_obj['return'][0].pop('proxytest', None)
         self.assertEqual(response_obj['return'][0], {'minion': True, 'sub_minion': True})
 
     def test_simple_local_post_no_tgt(self):
@@ -142,6 +147,11 @@ class TestSaltAPIHandler(_SaltnadoIntegrationTestCase):
                               )
         response_obj = salt.utils.json.loads(response.body)
         self.assertEqual(len(response_obj['return']), 1)
+        # If --proxy is set, it will cause an extra minion_id to be in the
+        # response. Since there's not a great way to know if the test
+        # runner's proxy minion is running, and we're not testing proxy
+        # minions here anyway, just remove it from the response.
+        response_obj['return'][0].pop('proxytest', None)
         self.assertEqual(response_obj['return'][0], {'minion': True, 'sub_minion': True})
 
     def test_simple_local_post_invalid_request(self):
@@ -175,6 +185,14 @@ class TestSaltAPIHandler(_SaltnadoIntegrationTestCase):
         response_obj = salt.utils.json.loads(response.body)
         ret = response_obj['return']
         ret[0]['minions'] = sorted(ret[0]['minions'])
+        try:
+            # If --proxy is set, it will cause an extra minion_id to be in the
+            # response. Since there's not a great way to know if the test
+            # runner's proxy minion is running, and we're not testing proxy
+            # minions here anyway, just remove it from the response.
+            ret[0]['minions'].remove('proxytest')
+        except ValueError:
+            pass
 
         # TODO: verify pub function? Maybe look at how we test the publisher
         self.assertEqual(len(ret), 1)
@@ -201,6 +219,15 @@ class TestSaltAPIHandler(_SaltnadoIntegrationTestCase):
         ret = response_obj['return']
         ret[0]['minions'] = sorted(ret[0]['minions'])
         ret[1]['minions'] = sorted(ret[1]['minions'])
+        try:
+            # If --proxy is set, it will cause an extra minion_id to be in the
+            # response. Since there's not a great way to know if the test
+            # runner's proxy minion is running, and we're not testing proxy
+            # minions here anyway, just remove it from the response.
+            ret[0]['minions'].remove('proxytest')
+            ret[1]['minions'].remove('proxytest')
+        except ValueError:
+            pass
 
         self.assertEqual(len(ret), 2)
         self.assertIn('jid', ret[0])
@@ -235,6 +262,15 @@ class TestSaltAPIHandler(_SaltnadoIntegrationTestCase):
         ret = response_obj['return']
         ret[0]['minions'] = sorted(ret[0]['minions'])
         ret[1]['minions'] = sorted(ret[1]['minions'])
+        try:
+            # If --proxy is set, it will cause an extra minion_id to be in the
+            # response. Since there's not a great way to know if the test
+            # runner's proxy minion is running, and we're not testing proxy
+            # minions here anyway, just remove it from the response.
+            ret[0]['minions'].remove('proxytest')
+            ret[1]['minions'].remove('proxytest')
+        except ValueError:
+            pass
 
         self.assertEqual(len(ret), 3)  # make sure we got 3 responses
         self.assertIn('jid', ret[0])  # the first 2 are regular returns
@@ -279,6 +315,11 @@ class TestSaltAPIHandler(_SaltnadoIntegrationTestCase):
                               request_timeout=30,
                               )
         response_obj = salt.utils.json.loads(response.body)
+        # If --proxy is set, it will cause an extra minion_id to be in the
+        # response. Since there's not a great way to know if the test runner's
+        # proxy minion is running, and we're not testing proxy minions here
+        # anyway, just remove it from the response.
+        response_obj[0]['return'].pop('proxytest', None)
         self.assertEqual(response_obj['return'], [{'minion': True, 'sub_minion': True}])
 
     # runner tests
@@ -296,6 +337,14 @@ class TestSaltAPIHandler(_SaltnadoIntegrationTestCase):
                               )
         response_obj = salt.utils.json.loads(response.body)
         self.assertEqual(len(response_obj['return']), 1)
+        try:
+            # If --proxy is set, it will cause an extra minion_id to be in the
+            # response. Since there's not a great way to know if the test
+            # runner's proxy minion is running, and we're not testing proxy
+            # minions here anyway, just remove it from the response.
+            response_obj['return'][0].remove('proxytest')
+        except ValueError:
+            pass
         self.assertEqual(sorted(response_obj['return'][0]), sorted(['minion', 'sub_minion']))
 
     # runner_async tests

--- a/tests/integration/netapi/test_client.py
+++ b/tests/integration/netapi/test_client.py
@@ -36,6 +36,11 @@ class NetapiClientTest(TestCase):
         low.update(self.eauth_creds)
 
         ret = self.netapi.run(low)
+        # If --proxy is set, it will cause an extra minion_id to be in the
+        # response. Since there's not a great way to know if the test
+        # runner's proxy minion is running, and we're not testing proxy
+        # minions here anyway, just remove it from the response.
+        ret.pop('proxytest', None)
         self.assertEqual(ret, {'minion': True, 'sub_minion': True})
 
     def test_local_batch(self):
@@ -59,6 +64,14 @@ class NetapiClientTest(TestCase):
         self.assertIn('jid', ret)
         ret.pop('jid', None)
         ret['minions'] = sorted(ret['minions'])
+        try:
+            # If --proxy is set, it will cause an extra minion_id to be in the
+            # response. Since there's not a great way to know if the test
+            # runner's proxy minion is running, and we're not testing proxy
+            # minions here anyway, just remove it from the response.
+            ret['minions'].remove('proxytest')
+        except ValueError:
+            pass
         self.assertEqual(ret, {'minions': sorted(['minion', 'sub_minion'])})
 
     def test_wheel(self):

--- a/tests/integration/scheduler/test_error.py
+++ b/tests/integration/scheduler/test_error.py
@@ -20,7 +20,7 @@ import tests.integration as integration
 # Import Salt libs
 import salt.utils.schedule
 
-from salt.modules.test import ping as ping
+from salt.modules.test import ping
 
 try:
     import croniter  # pylint: disable=W0611

--- a/tests/integration/scheduler/test_eval.py
+++ b/tests/integration/scheduler/test_eval.py
@@ -25,7 +25,7 @@ import tests.integration as integration
 import salt.utils.schedule
 import salt.utils.platform
 
-from salt.modules.test import ping as ping
+from salt.modules.test import ping
 
 try:
     import croniter  # pylint: disable=W0611

--- a/tests/integration/scheduler/test_maxrunning.py
+++ b/tests/integration/scheduler/test_maxrunning.py
@@ -19,7 +19,7 @@ import tests.integration as integration
 # Import Salt libs
 import salt.utils.schedule
 
-from salt.modules.test import ping as ping
+from salt.modules.test import ping
 
 try:
     import croniter  # pylint: disable=W0611

--- a/tests/integration/scheduler/test_postpone.py
+++ b/tests/integration/scheduler/test_postpone.py
@@ -20,7 +20,7 @@ import tests.integration as integration
 # Import Salt libs
 import salt.utils.schedule
 
-from salt.modules.test import ping as ping
+from salt.modules.test import ping
 
 log = logging.getLogger(__name__)
 ROOT_DIR = os.path.join(integration.TMP, 'schedule-unit-tests')

--- a/tests/integration/scheduler/test_skip.py
+++ b/tests/integration/scheduler/test_skip.py
@@ -19,7 +19,7 @@ import tests.integration as integration
 # Import Salt libs
 import salt.utils.schedule
 
-from salt.modules.test import ping as ping
+from salt.modules.test import ping
 
 log = logging.getLogger(__name__)
 ROOT_DIR = os.path.join(integration.TMP, 'schedule-unit-tests')

--- a/tests/integration/shell/test_minion.py
+++ b/tests/integration/shell/test_minion.py
@@ -118,10 +118,10 @@ class MinionTest(ShellCase, testprogram.TestProgramCase, ShellCaseCommonTestsMix
         )
 
         for line in ret[0]:
-            log.debug('script: salt-minion: stdout: {0}'.format(line))
+            log.debug('script: salt-minion: stdout: %s', line)
         for line in ret[1]:
-            log.debug('script: salt-minion: stderr: {0}'.format(line))
-        log.debug('exit status: {0}'.format(ret[2]))
+            log.debug('script: salt-minion: stderr: %s', line)
+        log.debug('exit status: %s', ret[2])
 
         if six.PY3:
             std_out = b'\nSTDOUT:'.join(ret[0])

--- a/tests/integration/states/test_pkg.py
+++ b/tests/integration/states/test_pkg.py
@@ -109,7 +109,7 @@ def pkgmgr_avail(run_function, grains):
         # Try lsof if it's available
         if salt.utils.path.which('lsof'):
             lock = run_function('cmd.run', ['lsof {0}'.format(path)])
-            return True if len(lock) else False
+            return True if lock else False
 
         # Try to find any locks on path from /proc/locks
         elif grains.get('kernel') == 'Linux':
@@ -807,7 +807,7 @@ class PkgTest(ModuleCase, SaltReturnAssertsMixin):
 
         os_family = grains.get('os_family', '')
         pkg_cap_targets = _PKG_CAP_TARGETS.get(os_family, [])
-        if not len(pkg_cap_targets) > 0:
+        if not pkg_cap_targets:
             self.skipTest('Capability not provided')
 
         target, realpkg = pkg_cap_targets[0]
@@ -841,7 +841,7 @@ class PkgTest(ModuleCase, SaltReturnAssertsMixin):
 
         os_family = grains.get('os_family', '')
         pkg_cap_targets = _PKG_CAP_TARGETS.get(os_family, [])
-        if not len(pkg_cap_targets) > 0:
+        if not pkg_cap_targets:
             self.skipTest('Capability not provided')
 
         target, realpkg = pkg_cap_targets[0]
@@ -883,7 +883,7 @@ class PkgTest(ModuleCase, SaltReturnAssertsMixin):
 
         os_family = grains.get('os_family', '')
         pkg_cap_targets = _PKG_CAP_TARGETS.get(os_family, [])
-        if not len(pkg_cap_targets) > 0:
+        if not pkg_cap_targets:
             self.skipTest('Capability not provided')
         pkg_targets = _PKG_TARGETS.get(os_family, [])
 
@@ -958,7 +958,7 @@ class PkgTest(ModuleCase, SaltReturnAssertsMixin):
 
         os_family = grains.get('os_family', '')
         pkg_cap_targets = _PKG_CAP_TARGETS.get(os_family, [])
-        if not len(pkg_cap_targets) > 0:
+        if not pkg_cap_targets:
             self.skipTest('Capability not provided')
 
         target, realpkg = pkg_cap_targets[0]
@@ -996,7 +996,7 @@ class PkgTest(ModuleCase, SaltReturnAssertsMixin):
 
         os_family = grains.get('os_family', '')
         pkg_cap_targets = _PKG_CAP_TARGETS.get(os_family, [])
-        if not len(pkg_cap_targets) > 0:
+        if not pkg_cap_targets:
             self.skipTest('Capability not provided')
 
         target, realpkg = pkg_cap_targets[0]
@@ -1030,7 +1030,7 @@ class PkgTest(ModuleCase, SaltReturnAssertsMixin):
 
         os_family = grains.get('os_family', '')
         pkg_cap_targets = _PKG_CAP_TARGETS.get(os_family, [])
-        if not len(pkg_cap_targets) > 0:
+        if not pkg_cap_targets:
             self.skipTest('Capability not provided')
 
         target, realpkg = pkg_cap_targets[0]

--- a/tests/integration/states/test_pkgrepo.py
+++ b/tests/integration/states/test_pkgrepo.py
@@ -43,7 +43,7 @@ class PkgrepoTest(ModuleCase, SaltReturnAssertsMixin):
 
         if grains['os_family'] == 'Debian':
             try:
-                from aptsources import sourceslist
+                from aptsources import sourceslist  # pylint: disable=unused-import
             except ImportError:
                 self.skipTest(
                     'aptsources.sourceslist python module not found'

--- a/tests/integration/utils/testprogram.py
+++ b/tests/integration/utils/testprogram.py
@@ -214,7 +214,7 @@ class TestProgram(six.with_metaclass(TestProgramMeta, object)):
         cpath = self.abs_path(self.config_file_get(config))
         with salt.utils.files.fopen(cpath, 'w') as cfo:
             cfg = self.config_stringify(config)
-            log.debug('Writing configuration for {0} to {1}:\n{2}'.format(self.name, cpath, cfg))
+            log.debug('Writing configuration for %s to %s:\n%s', self.name, cpath, cfg)
             cfo.write(cfg)
             cfo.flush()
 
@@ -264,14 +264,14 @@ class TestProgram(six.with_metaclass(TestProgramMeta, object)):
         '''Create directory structure.'''
         subdirs = []
         for branch in self.dirtree:
-            log.debug('checking dirtree: {0}'.format(branch))
+            log.debug('checking dirtree: %s', branch)
             if not branch:
                 continue
             if isinstance(branch, six.string_types) and branch[0] == '&':
-                log.debug('Looking up dirtree branch "{0}"'.format(branch))
+                log.debug('Looking up dirtree branch "%s"', branch)
                 try:
                     dirattr = getattr(self, branch[1:], None)
-                    log.debug('dirtree "{0}" => "{1}"'.format(branch, dirattr))
+                    log.debug('dirtree "%s" => "%s"', branch, dirattr)
                 except AttributeError:
                     raise ValueError(
                         'Unable to find dirtree attribute "{0}" on object "{1}.name = {2}: {3}"'.format(
@@ -296,7 +296,7 @@ class TestProgram(six.with_metaclass(TestProgramMeta, object)):
         for subdir in subdirs:
             path = self.abs_path(subdir)
             if not os.path.exists(path):
-                log.debug('make_dirtree: {0}'.format(path))
+                log.debug('make_dirtree: %s', path)
                 os.makedirs(path)
 
     def setup(self, *args, **kwargs):
@@ -668,7 +668,7 @@ class TestSaltProgram(six.with_metaclass(TestSaltProgramMeta, TestProgram)):
                         continue
                 cfg[key] = _val
             cfg = self.config_merge(cfg_base, cfg)
-        log.debug('Generated config => {0}'.format(cfg))
+        log.debug('Generated config => %s', cfg)
         return cfg
 
     def config_stringify(self, config):
@@ -697,7 +697,7 @@ class TestSaltProgram(six.with_metaclass(TestSaltProgramMeta, TestProgram)):
         lines.insert(0, '#!{0}\n'.format(sys.executable))
 
         script_path = self.abs_path(os.path.join(self.script_dir, self.script))
-        log.debug('Installing "{0}" to "{1}"'.format(script_source, script_path))
+        log.debug('Installing "%s" to "%s"', script_source, script_path)
         with salt.utils.files.fopen(script_path, 'w') as sdo:
             sdo.write(''.join(lines))
             sdo.flush()

--- a/tests/kitchen/tests/wordpress/tests/salt/test_salt.py
+++ b/tests/kitchen/tests/wordpress/tests/salt/test_salt.py
@@ -1,9 +1,13 @@
+# -*- coding: utf-8 -*-
+
+
 def test_formula(salt):
     '''
     Test that the states are synced to minion
     '''
     dirs = salt('cp.list_master_dirs')
     assert 'states' in dirs
+
 
 def test_wordpress_module(salt):
     '''

--- a/tests/minionswarm.py
+++ b/tests/minionswarm.py
@@ -272,9 +272,6 @@ class MinionSwarm(Swarm):
     '''
     Create minions
     '''
-    def __init__(self, opts):
-        super(MinionSwarm, self).__init__(opts)
-
     def start_minions(self):
         '''
         Iterate over the config files and start up the minions

--- a/tests/support/helpers.py
+++ b/tests/support/helpers.py
@@ -435,7 +435,7 @@ class ForceImportErrorOn(object):
     Traceback (most recent call last):
       File "<stdin>", line 2, in <module>
       File "salttesting/helpers.py", line 263, in __import__
-        'Forced ImportError raised for {0!r}'.format(name)
+        'Forced ImportError raised for \'{0}\''.format(name)
     ImportError: Forced ImportError raised for 'os.path'
     >>>
 
@@ -462,7 +462,7 @@ class ForceImportErrorOn(object):
     Traceback (most recent call last):
       File "<stdin>", line 2, in <module>
       File "salttesting/helpers.py", line 281, in __fake_import__
-        'Forced ImportError raised for {0!r}'.format(name)
+        'Forced ImportError raised for \'{0}\''.format(name)
     ImportError: Forced ImportError raised for 'os.path'
     >>>
     '''
@@ -493,12 +493,12 @@ class ForceImportErrorOn(object):
             importerror_fromlist = self.__module_names.get(name)
             if importerror_fromlist is None:
                 raise ImportError(
-                    'Forced ImportError raised for {0!r}'.format(name)
+                    'Forced ImportError raised for \'{0}\''.format(name)
                 )
 
             if importerror_fromlist.intersection(set(fromlist)):
                 raise ImportError(
-                    'Forced ImportError raised for {0!r}'.format(
+                    'Forced ImportError raised for \'{0}\''.format(
                         'from {0} import {1}'.format(
                             name, ', '.join(fromlist)
                         )
@@ -660,7 +660,7 @@ def with_system_user(username, on_existing='delete', delete=True, password=None,
         def wrap(cls):
 
             # Let's add the user to the system.
-            log.debug('Creating system user {0!r}'.format(username))
+            log.debug('Creating system user \'%s\'', username)
             kwargs = {'timeout': 60, 'groups': groups}
             if salt.utils.platform.is_windows():
                 kwargs.update({'password': password})
@@ -670,35 +670,27 @@ def with_system_user(username, on_existing='delete', delete=True, password=None,
                 # The user was not created
                 if on_existing == 'skip':
                     cls.skipTest(
-                        'Failed to create system user {0!r}'.format(
+                        'Failed to create system user \'{0}\''.format(
                             username
                         )
                     )
 
                 if on_existing == 'delete':
-                    log.debug(
-                        'Deleting the system user {0!r}'.format(
-                            username
-                        )
-                    )
+                    log.debug('Deleting the system user \'%s\'', username)
                     delete_user = cls.run_function(
                         'user.delete', [username, True, True]
                     )
                     if not delete_user:
                         cls.skipTest(
-                            'A user named {0!r} already existed on the '
+                            'A user named \'{0}\' already existed on the '
                             'system and re-creating it was not possible'
                             .format(username)
                         )
-                    log.debug(
-                        'Second time creating system user {0!r}'.format(
-                            username
-                        )
-                    )
+                    log.debug('Second time creating system user \'%s\'', username)
                     create_user = cls.run_function('user.add', [username], **kwargs)
                     if not create_user:
                         cls.skipTest(
-                            'A user named {0!r} already existed, was deleted '
+                            'A user named \'{0}\' already existed, was deleted '
                             'as requested, but re-creating it was not possible'
                             .format(username)
                         )
@@ -707,13 +699,8 @@ def with_system_user(username, on_existing='delete', delete=True, password=None,
             try:
                 try:
                     return func(cls, username)
-                except Exception as exc:  # pylint: disable=W0703
-                    log.error(
-                        'Running {0!r} raised an exception: {1}'.format(
-                            func, exc
-                        ),
-                        exc_info=True
-                    )
+                except Exception:
+                    log.exception('Running %s raised an exception', func)
                     # Store the original exception details which will be raised
                     # a little further down the code
                     failure = sys.exc_info()
@@ -726,13 +713,13 @@ def with_system_user(username, on_existing='delete', delete=True, password=None,
                         if failure is None:
                             log.warning(
                                 'Although the actual test-case did not fail, '
-                                'deleting the created system user {0!r} '
-                                'afterwards did.'.format(username)
+                                'deleting the created system user \'%s\' '
+                                'afterwards did.', username
                             )
                         else:
                             log.warning(
                                 'The test-case failed and also did the removal'
-                                ' of the system user {0!r}'.format(username)
+                                ' of the system user \'%s\'', username
                             )
                 if failure is not None:
                     # If an exception was thrown, raise it
@@ -773,36 +760,30 @@ def with_system_group(group, on_existing='delete', delete=True):
         def wrap(cls):
 
             # Let's add the user to the system.
-            log.debug('Creating system group {0!r}'.format(group))
+            log.debug('Creating system group \'%s\'', group)
             create_group = cls.run_function('group.add', [group])
             if not create_group:
                 log.debug('Failed to create system group')
                 # The group was not created
                 if on_existing == 'skip':
                     cls.skipTest(
-                        'Failed to create system group {0!r}'.format(group)
+                        'Failed to create system group \'{0}\''.format(group)
                     )
 
                 if on_existing == 'delete':
-                    log.debug(
-                        'Deleting the system group {0!r}'.format(group)
-                    )
+                    log.debug('Deleting the system group \'%s\'', group)
                     delete_group = cls.run_function('group.delete', [group])
                     if not delete_group:
                         cls.skipTest(
-                            'A group named {0!r} already existed on the '
+                            'A group named \'{0}\' already existed on the '
                             'system and re-creating it was not possible'
                             .format(group)
                         )
-                    log.debug(
-                        'Second time creating system group {0!r}'.format(
-                            group
-                        )
-                    )
+                    log.debug('Second time creating system group \'%s\'', group)
                     create_group = cls.run_function('group.add', [group])
                     if not create_group:
                         cls.skipTest(
-                            'A group named {0!r} already existed, was deleted '
+                            'A group named \'{0}\' already existed, was deleted '
                             'as requested, but re-creating it was not possible'
                             .format(group)
                         )
@@ -811,13 +792,8 @@ def with_system_group(group, on_existing='delete', delete=True):
             try:
                 try:
                     return func(cls, group)
-                except Exception as exc:  # pylint: disable=W0703
-                    log.error(
-                        'Running {0!r} raised an exception: {1}'.format(
-                            func, exc
-                        ),
-                        exc_info=True
-                    )
+                except Exception:
+                    log.exception('Running %s raised an exception', func)
                     # Store the original exception details which will be raised
                     # a little further down the code
                     failure = sys.exc_info()
@@ -828,13 +804,13 @@ def with_system_group(group, on_existing='delete', delete=True):
                         if failure is None:
                             log.warning(
                                 'Although the actual test-case did not fail, '
-                                'deleting the created system group {0!r} '
-                                'afterwards did.'.format(group)
+                                'deleting the created system group \'%s\' '
+                                'afterwards did.', group
                             )
                         else:
                             log.warning(
                                 'The test-case failed and also did the removal'
-                                ' of the system group {0!r}'.format(group)
+                                ' of the system group \'%s\'', group
                             )
                 if failure is not None:
                     # If an exception was thrown, raise it
@@ -879,44 +855,36 @@ def with_system_user_and_group(username, group,
         def wrap(cls):
 
             # Let's add the user to the system.
-            log.debug('Creating system user {0!r}'.format(username))
+            log.debug('Creating system user %s', username)
             create_user = cls.run_function('user.add', [username])
-            log.debug('Creating system group {0!r}'.format(group))
+            log.debug('Creating system group %s', group)
             create_group = cls.run_function('group.add', [group])
             if not create_user:
                 log.debug('Failed to create system user')
                 # The user was not created
                 if on_existing == 'skip':
                     cls.skipTest(
-                        'Failed to create system user {0!r}'.format(
+                        'Failed to create system user \'{0}\''.format(
                             username
                         )
                     )
 
                 if on_existing == 'delete':
-                    log.debug(
-                        'Deleting the system user {0!r}'.format(
-                            username
-                        )
-                    )
+                    log.debug('Deleting the system user \'%s\'', username)
                     delete_user = cls.run_function(
                         'user.delete', [username, True, True]
                     )
                     if not delete_user:
                         cls.skipTest(
-                            'A user named {0!r} already existed on the '
+                            'A user named \'{0}\' already existed on the '
                             'system and re-creating it was not possible'
                             .format(username)
                         )
-                    log.debug(
-                        'Second time creating system user {0!r}'.format(
-                            username
-                        )
-                    )
+                    log.debug('Second time creating system user \'%s\'', username)
                     create_user = cls.run_function('user.add', [username])
                     if not create_user:
                         cls.skipTest(
-                            'A user named {0!r} already existed, was deleted '
+                            'A user named \'{0}\' already existed, was deleted '
                             'as requested, but re-creating it was not possible'
                             .format(username)
                         )
@@ -925,29 +893,23 @@ def with_system_user_and_group(username, group,
                 # The group was not created
                 if on_existing == 'skip':
                     cls.skipTest(
-                        'Failed to create system group {0!r}'.format(group)
+                        'Failed to create system group \'{0}\''.format(group)
                     )
 
                 if on_existing == 'delete':
-                    log.debug(
-                        'Deleting the system group {0!r}'.format(group)
-                    )
+                    log.debug('Deleting the system group %s', group)
                     delete_group = cls.run_function('group.delete', [group])
                     if not delete_group:
                         cls.skipTest(
-                            'A group named {0!r} already existed on the '
+                            'A group named \'{0}\' already existed on the '
                             'system and re-creating it was not possible'
                             .format(group)
                         )
-                    log.debug(
-                        'Second time creating system group {0!r}'.format(
-                            group
-                        )
-                    )
+                    log.debug('Second time creating system group %s', group)
                     create_group = cls.run_function('group.add', [group])
                     if not create_group:
                         cls.skipTest(
-                            'A group named {0!r} already existed, was deleted '
+                            'A group named \'{0}\' already existed, was deleted '
                             'as requested, but re-creating it was not possible'
                             .format(group)
                         )
@@ -956,13 +918,8 @@ def with_system_user_and_group(username, group,
             try:
                 try:
                     return func(cls, username, group)
-                except Exception as exc:  # pylint: disable=W0703
-                    log.error(
-                        'Running {0!r} raised an exception: {1}'.format(
-                            func, exc
-                        ),
-                        exc_info=True
-                    )
+                except Exception:
+                    log.exception('Running %s raised an exception', func)
                     # Store the original exception details which will be raised
                     # a little further down the code
                     failure = sys.exc_info()
@@ -976,25 +933,25 @@ def with_system_user_and_group(username, group,
                         if failure is None:
                             log.warning(
                                 'Although the actual test-case did not fail, '
-                                'deleting the created system user {0!r} '
-                                'afterwards did.'.format(username)
+                                'deleting the created system user \'%s\' '
+                                'afterwards did.', username
                             )
                         else:
                             log.warning(
                                 'The test-case failed and also did the removal'
-                                ' of the system user {0!r}'.format(username)
+                                ' of the system user \'%s\'', username
                             )
                     if not delete_group:
                         if failure is None:
                             log.warning(
                                 'Although the actual test-case did not fail, '
-                                'deleting the created system group {0!r} '
-                                'afterwards did.'.format(group)
+                                'deleting the created system group \'%s\' '
+                                'afterwards did.', group
                             )
                         else:
                             log.warning(
                                 'The test-case failed and also did the removal'
-                                ' of the system group {0!r}'.format(group)
+                                ' of the system group \'%s\'', group
                             )
                 if failure is not None:
                     # If an exception was thrown, raise it
@@ -1105,8 +1062,8 @@ def requires_salt_modules(*names):
                 not_found_modules = self.run_function('runtests_helpers.modules_available', names)
                 if not_found_modules:
                     if len(not_found_modules) == 1:
-                        self.skipTest('Salt module {0!r} is not available'.format(not_found_modules[0]))
-                    self.skipTest('Salt modules not available: {0!r}'.format(not_found_modules))
+                        self.skipTest('Salt module \'{0}\' is not available'.format(not_found_modules[0]))
+                    self.skipTest('Salt modules not available: \'{0}\''.format(not_found_modules))
             caller.setUp = setUp
             return caller
 
@@ -1125,7 +1082,7 @@ def requires_salt_modules(*names):
             for name in names:
                 if name not in cls.run_function('sys.doc', [name]):
                     cls.skipTest(
-                        'Salt module {0!r} is not available'.format(name)
+                        'Salt module \'{0}\' is not available'.format(name)
                     )
                     break
 
@@ -1152,7 +1109,7 @@ def skip_if_binaries_missing(*binaries, **kwargs):
         for binary in binaries:
             if salt.utils.path.which(binary) is None:
                 return skip(
-                    '{0}The {1!r} binary was not found'.format(
+                    '{0}The \'{1}\' binary was not found'.format(
                         message and '{0}. '.format(message) or '',
                         binary
                     )

--- a/tests/support/mixins.py
+++ b/tests/support/mixins.py
@@ -564,7 +564,7 @@ class SaltReturnAssertsMixin(object):
             for saltret in self.__getWithinSaltReturn(ret, 'result'):
                 self.assertTrue(saltret)
         except AssertionError:
-            log.info('Salt Full Return:\n{0}'.format(pprint.pformat(ret)))
+            log.info('Salt Full Return:\n%s', pprint.pformat(ret))
             try:
                 raise AssertionError(
                     '{result} is not True. Salt Comment:\n{comment}'.format(
@@ -583,7 +583,7 @@ class SaltReturnAssertsMixin(object):
             for saltret in self.__getWithinSaltReturn(ret, 'result'):
                 self.assertFalse(saltret)
         except AssertionError:
-            log.info('Salt Full Return:\n{0}'.format(pprint.pformat(ret)))
+            log.info('Salt Full Return:\n%s', pprint.pformat(ret))
             try:
                 raise AssertionError(
                     '{result} is not False. Salt Comment:\n{comment}'.format(
@@ -600,7 +600,7 @@ class SaltReturnAssertsMixin(object):
             for saltret in self.__getWithinSaltReturn(ret, 'result'):
                 self.assertIsNone(saltret)
         except AssertionError:
-            log.info('Salt Full Return:\n{0}'.format(pprint.pformat(ret)))
+            log.info('Salt Full Return:\n%s', pprint.pformat(ret))
             try:
                 raise AssertionError(
                     '{result} is not None. Salt Comment:\n{comment}'.format(

--- a/tests/support/runtests.py
+++ b/tests/support/runtests.py
@@ -132,20 +132,20 @@ def recursive_copytree(source, destination, overwrite=False):
             src_path = os.path.join(root, item)
             dst_path = os.path.join(destination, src_path.replace(source, '').lstrip(os.sep))
             if not os.path.exists(dst_path):
-                log.debug('Creating directory: {0}'.format(dst_path))
+                log.debug('Creating directory: %s', dst_path)
                 os.makedirs(dst_path)
         for item in files:
             src_path = os.path.join(root, item)
             dst_path = os.path.join(destination, src_path.replace(source, '').lstrip(os.sep))
             if os.path.exists(dst_path) and not overwrite:
                 if os.stat(src_path).st_mtime > os.stat(dst_path).st_mtime:
-                    log.debug('Copying {0} to {1}'.format(src_path, dst_path))
+                    log.debug('Copying %s to %s', src_path, dst_path)
                     shutil.copy2(src_path, dst_path)
             else:
                 if not os.path.isdir(os.path.dirname(dst_path)):
-                    log.debug('Creating directory: {0}'.format(os.path.dirname(dst_path)))
+                    log.debug('Creating directory: %s', os.path.dirname(dst_path))
                     os.makedirs(os.path.dirname(dst_path))
-                log.debug('Copying {0} to {1}'.format(src_path, dst_path))
+                log.debug('Copying %s to %s', src_path, dst_path)
                 shutil.copy2(src_path, dst_path)
 
 

--- a/tests/support/unit.py
+++ b/tests/support/unit.py
@@ -365,11 +365,11 @@ class TextTestResult(_TextTestResult):
     '''
 
     def startTest(self, test):
-        log.debug('>>>>> START >>>>> {0}'.format(test.id()))
+        log.debug('>>>>> START >>>>> %s', test.id())
         return super(TextTestResult, self).startTest(test)
 
     def stopTest(self, test):
-        log.debug('<<<<< END <<<<<<< {0}'.format(test.id()))
+        log.debug('<<<<< END <<<<<<< %s', test.id())
         return super(TextTestResult, self).stopTest(test)
 
 

--- a/tests/support/xmlunit.py
+++ b/tests/support/xmlunit.py
@@ -56,7 +56,7 @@ try:
 
     class _XMLTestResult(xmlrunner.result._XMLTestResult):
         def startTest(self, test):
-            log.debug('>>>>> START >>>>> {0}'.format(test.id()))
+            log.debug('>>>>> START >>>>> %s', test.id())
             # xmlrunner classes are NOT new-style classes
             xmlrunner.result._XMLTestResult.startTest(self, test)
             if self.buffer:
@@ -68,7 +68,7 @@ try:
                 sys.stdout = self._stdout_buffer
 
         def stopTest(self, test):
-            log.debug('<<<<< END <<<<<<< {0}'.format(test.id()))
+            log.debug('<<<<< END <<<<<<< %s', test.id())
             # xmlrunner classes are NOT new-style classes
             return xmlrunner.result._XMLTestResult.stopTest(self, test)
 

--- a/tests/unit/beacons/test_telegram_bot_msg.py
+++ b/tests/unit/beacons/test_telegram_bot_msg.py
@@ -97,7 +97,7 @@ class TelegramBotMsgBeaconTestCase(TestCase, LoaderModuleMockMixin):
             inst = MagicMock(name='telegram.Bot()')
             telegram_api.Bot = MagicMock(name='telegram', return_value=inst)
 
-            log.debug('telegram {}'.format(telegram))
+            log.debug('telegram %s', telegram)
             username = 'different_user'
             user = telegram.user.User(id=1, first_name='', username=username)
             chat = telegram.chat.Chat(1, 'private', username=username)

--- a/tests/unit/beacons/test_wtmp.py
+++ b/tests/unit/beacons/test_wtmp.py
@@ -129,7 +129,7 @@ class WTMPBeaconTestCase(TestCase, LoaderModuleMockMixin):
                               'user': 'gareth'}]
 
                 ret = wtmp.beacon(config)
-                log.debug('{}'.format(ret))
+                log.debug('%s', ret)
                 self.assertEqual(ret, _expected)
 
     @skipIf(not _TIME_SUPPORTED, 'dateutil.parser is missing.')

--- a/tests/unit/modules/test_git.py
+++ b/tests/unit/modules/test_git.py
@@ -68,7 +68,7 @@ def _git_version():
     if not git_version:
         log.error('Git not installed')
         return False
-    log.debug('Detected git version ' + git_version)
+    log.debug('Detected git version %s', git_version)
     return LooseVersion(git_version.split()[-1])
 
 

--- a/tests/unit/modules/test_jboss7_cli.py
+++ b/tests/unit/modules/test_jboss7_cli.py
@@ -45,13 +45,13 @@ class CmdMock(object):
         return None
 
     def get_last_command(self):
-        if len(self.commands) > 0:
+        if self.commands:
             return self.commands[-1]
         else:
             return None
 
     def get_last_cli_command(self):
-        if len(self.cli_commands) > 0:
+        if self.cli_commands:
             return self.cli_commands[-1]
         else:
             return None

--- a/tests/unit/modules/test_portage_config.py
+++ b/tests/unit/modules/test_portage_config.py
@@ -48,7 +48,7 @@ class PortageConfigTestCase(TestCase, LoaderModuleMockMixin):
 
     def setup_loader_modules(self):
         try:
-            import portage
+            import portage  # pylint: disable=unused-import
             return {}
         except ImportError:
             dummy_atom = self.DummyAtom()

--- a/tests/unit/modules/test_tls.py
+++ b/tests/unit/modules/test_tls.py
@@ -203,9 +203,8 @@ class TLSAddTestCase(TestCase, LoaderModuleMockMixin):
         '''
         ca_path = '/tmp/test_tls'
         ca_name = 'test_ca'
-        certp = '{0}/{1}/{2}_ca_cert.crt'.format(
+        certp = '{0}/{1}/{1}_ca_cert.crt'.format(
             ca_path,
-            ca_name,
             ca_name)
         mock_opt = MagicMock(return_value=ca_path)
         with patch.dict(tls.__salt__, {'config.option': mock_opt}), \
@@ -224,9 +223,8 @@ class TLSAddTestCase(TestCase, LoaderModuleMockMixin):
                       MagicMock(return_value=True)):
             ca_path = '/tmp/test_tls'
             ca_name = 'test_ca'
-            certp = '{0}/{1}/{2}_ca_cert.crt'.format(
+            certp = '{0}/{1}/{1}_ca_cert.crt'.format(
                 ca_path,
-                ca_name,
                 ca_name)
             ret = {
                 'not_after': 1462379961,
@@ -312,13 +310,11 @@ class TLSAddTestCase(TestCase, LoaderModuleMockMixin):
         Test creating CA cert
         '''
         ca_name = 'test_ca'
-        certp = '{0}/{1}/{2}_ca_cert.crt'.format(
+        certp = '{0}/{1}/{1}_ca_cert.crt'.format(
             ca_path,
-            ca_name,
             ca_name)
-        certk = '{0}/{1}/{2}_ca_cert.key'.format(
+        certk = '{0}/{1}/{1}_ca_cert.key'.format(
             ca_path,
-            ca_name,
             ca_name)
         ret = 'Created Private Key: "{0}." Created CA "{1}": "{2}."'.format(
             certk, ca_name, certp)
@@ -342,13 +338,11 @@ class TLSAddTestCase(TestCase, LoaderModuleMockMixin):
         Test creating CA cert when one already exists
         '''
         ca_name = 'test_ca'
-        certp = '{0}/{1}/{2}_ca_cert.crt'.format(
+        certp = '{0}/{1}/{1}_ca_cert.crt'.format(
             ca_path,
-            ca_name,
             ca_name)
-        certk = '{0}/{1}/{2}_ca_cert.key'.format(
+        certk = '{0}/{1}/{1}_ca_cert.key'.format(
             ca_path,
-            ca_name,
             ca_name)
         ret = 'Created Private Key: "{0}." Created CA "{1}": "{2}."'.format(
             certk, ca_name, certp)
@@ -666,13 +660,11 @@ class TLSAddTestCase(TestCase, LoaderModuleMockMixin):
         pillarval = {'csr': {'extendedKeyUsage': 'serverAuth'}}
         mock_pgt = MagicMock(return_value=pillarval)
         ca_name = 'test_ca'
-        certp = '{0}/{1}/{2}_ca_cert.crt'.format(
+        certp = '{0}/{1}/{1}_ca_cert.crt'.format(
             ca_path,
-            ca_name,
             ca_name)
-        certk = '{0}/{1}/{2}_ca_cert.key'.format(
+        certk = '{0}/{1}/{1}_ca_cert.key'.format(
             ca_path,
-            ca_name,
             ca_name)
         ret = 'Created Private Key: "{0}." Created CA "{1}": "{2}."'.format(
             certk, ca_name, certp)

--- a/tests/unit/roster/test_clustershell.py
+++ b/tests/unit/roster/test_clustershell.py
@@ -37,8 +37,10 @@ class ClusterShellTestCase(TestCase):
             with patch.dict(salt.roster.clustershell.__opts__, {'ssh_scan_ports': [1, 2, 3],
                 'ssh_scan_timeout': 30}):
                 # Reimports are necessary to re-init the namespace.
+                # pylint: disable=unused-import
                 import socket
                 from ClusterShell.NodeSet import NodeSet
+                # pylint: enable=unused-import
                 ret = salt.roster.clustershell.targets('foo')
                 mock_socket.gethostbyname.assert_any_call('foo')
                 self.assertTrue('foo' in ret)

--- a/tests/unit/states/test_saltutil.py
+++ b/tests/unit/states/test_saltutil.py
@@ -43,7 +43,7 @@ class Saltutil(TestCase, LoaderModuleMockMixin):
             'sdb': [],
             'proxymodules': [],
             'output': [],
-            'pillar': []
+            'pillar': [],
         }
         state_id = 'somename'
         state_result = {'changes': {},
@@ -73,7 +73,7 @@ class Saltutil(TestCase, LoaderModuleMockMixin):
             'sdb': [],
             'proxymodules': [],
             'output': [],
-            'pillar': []
+            'pillar': [],
         }
         state_id = 'somename'
         state_result = {'changes': {},
@@ -104,7 +104,7 @@ class Saltutil(TestCase, LoaderModuleMockMixin):
             'sdb': [],
             'proxymodules': [],
             'output': [],
-            'pillar': []
+            'pillar': [],
         }
         state_id = 'somename'
         state_result = {'changes': {'modules': ['modules.file'],

--- a/tests/unit/test_spm.py
+++ b/tests/unit/test_spm.py
@@ -138,14 +138,14 @@ class SPMTest(TestCase, AdaptedConfigurationTestCaseMixin):
         with patch('salt.client.Caller', MagicMock(return_value=self.minion_opts)):
             with patch('salt.client.get_local_client', MagicMock(return_value=self.minion_opts['conf_file'])):
                 self.client.run(['local', 'install', pkgpath])
-        assert len(self.ui._error) > 0
+        assert self.ui._error
         # Reinstall with force=True, should succeed
         with patch.dict(self.minion_config, {'force': True}):
             self.ui._error = []
             with patch('salt.client.Caller', MagicMock(return_value=self.minion_opts)):
                 with patch('salt.client.get_local_client', MagicMock(return_value=self.minion_opts['conf_file'])):
                     self.client.run(['local', 'install', pkgpath])
-            assert len(self.ui._error) == 0
+            assert not self.ui._error
 
     def test_failure_paths(self):
         fail_args = (
@@ -179,4 +179,4 @@ class SPMTest(TestCase, AdaptedConfigurationTestCaseMixin):
             with patch('salt.client.Caller', MagicMock(return_value=self.minion_opts)):
                 with patch('salt.client.get_local_client', MagicMock(return_value=self.minion_opts['conf_file'])):
                     self.client.run(args)
-            assert len(self.ui._error) > 0
+            assert self.ui._error

--- a/tests/unit/transport/test_tcp.py
+++ b/tests/unit/transport/test_tcp.py
@@ -228,7 +228,7 @@ class BaseTCPPubCase(AsyncTestCase, AdaptedConfigurationTestCaseMixin):
         for k, v in six.iteritems(self.io_loop._handlers):
             if self._start_handlers.get(k) != v:
                 failures.append((k, v))
-        if len(failures) > 0:
+        if failures:
             raise Exception('FDs still attached to the IOLoop: {0}'.format(failures))
         del self.channel
         del self._start_handlers

--- a/tests/unit/transport/test_zeromq.py
+++ b/tests/unit/transport/test_zeromq.py
@@ -268,7 +268,7 @@ class BaseZMQPubCase(AsyncTestCase, AdaptedConfigurationTestCaseMixin):
             if self._start_handlers.get(k) != v:
                 failures.append((k, v))
         del self._start_handlers
-        if len(failures) > 0:
+        if failures:
             raise Exception('FDs still attached to the IOLoop: {0}'.format(failures))
 
 

--- a/tests/unit/utils/test_jinja.py
+++ b/tests/unit/utils/test_jinja.py
@@ -151,7 +151,7 @@ class TestSaltCacheLoader(TestCase):
         tmpl_dir = os.path.join(self.template_dir, 'hello_simple')
         self.assertEqual(res[1], tmpl_dir)
         assert res[2](), 'Template up to date?'
-        assert len(loader._file_client.requests)
+        assert loader._file_client.requests
         self.assertEqual(loader._file_client.requests[0]['path'], 'salt://hello_simple')
 
     def get_loader(self, opts=None, saltenv='base'):

--- a/tests/unit/utils/test_path.py
+++ b/tests/unit/utils/test_path.py
@@ -17,6 +17,7 @@ from tests.support.unit import TestCase, skipIf
 from tests.support.mock import patch, NO_MOCK, NO_MOCK_REASON
 
 # Import Salt libs
+import salt.utils.compat
 import salt.utils.path
 import salt.utils.platform
 from salt.exceptions import CommandNotFoundError
@@ -125,7 +126,7 @@ class PathJoinTestCase(TestCase):
         platform.system = lambda: "windows"
 
         for module in (ntpath, os, os.path, tempfile):
-            reload(module)
+            salt.utils.compat.reload(module)
 
     def __unpatch_path(self):
         del sys.modules['nt']
@@ -133,7 +134,7 @@ class PathJoinTestCase(TestCase):
         platform.system = self.PLATFORM_FUNC
 
         for module in (posixpath, os, os.path, tempfile, platform):
-            reload(module)
+            salt.utils.compat.reload(module)
 
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)

--- a/tests/unit/utils/test_vt.py
+++ b/tests/unit/utils/test_vt.py
@@ -26,6 +26,7 @@ import salt.utils.platform
 import salt.utils.vt
 
 # Import 3rd-party libs
+from salt.ext import six
 from salt.ext.six.moves import range  # pylint: disable=import-error,redefined-builtin
 
 
@@ -96,7 +97,7 @@ class VTTestCase(TestCase):
                 except (ValueError, OSError, IOError):
                     self.fail('Unable to find out how many PTY\'s are open')
             except Exception as exc:
-                if 'out of pty devices' in exc:
+                if 'out of pty devices' in six.text_type(exc):
                     # We're not cleaning up
                     raise
                 # We're pushing the system resources, let's keep going


### PR DESCRIPTION
This fixes violations found in the following locations:

- salt/netapi/
- salt/output/
- salt/pillar/
- salt/proxy/
- salt/queues/
- salt/renderers/
- salt/returners/
- salt/runners/
- salt/sdb/
- salt/serializers/
- salt/spm/
- tests/