### PR TITLE
Fix usage of reload for PY3 compatibility

### DIFF
--- a/salt/modules/ebuild.py
+++ b/salt/modules/ebuild.py
@@ -22,6 +22,7 @@ import re
 
 # Import salt libs
 import salt.utils.args
+import salt.utils.compat
 import salt.utils.data
 import salt.utils.functools
 import salt.utils.path
@@ -31,9 +32,6 @@ import salt.utils.versions
 from salt.exceptions import CommandExecutionError, MinionError
 from salt.ext import six
 
-# Workaround for 'reload' builtin of py2.7
-if six.PY3:
-    from importlib import reload  # pylint: disable=no-name-in-module
 
 # Import third party libs
 HAS_PORTAGE = False
@@ -69,13 +67,13 @@ def __virtual__():
 
 def _vartree():
     import portage  # pylint: disable=3rd-party-module-not-gated
-    portage = reload(portage)
+    portage = salt.utils.compat.reload(portage)
     return portage.db[portage.root]['vartree']
 
 
 def _porttree():
     import portage  # pylint: disable=3rd-party-module-not-gated
-    portage = reload(portage)
+    portage = salt.utils.compat.reload(portage)
     return portage.db[portage.root]['porttree']
 
 

--- a/salt/modules/portage_config.py
+++ b/salt/modules/portage_config.py
@@ -10,6 +10,7 @@ import os
 import shutil
 
 # Import salt libs
+import salt.utils.compat
 import salt.utils.data
 import salt.utils.files
 import salt.utils.path
@@ -57,7 +58,7 @@ def _get_portage():
     portage module must be reloaded or it can't catch the changes
     in portage.* which had been added after when the module was loaded
     '''
-    return reload(portage)
+    return salt.utils.compat.reload(portage)
 
 
 def _porttree():

--- a/salt/utils/compat.py
+++ b/salt/utils/compat.py
@@ -8,6 +8,7 @@ from __future__ import absolute_import, print_function, unicode_literals
 import sys
 import copy
 import types
+import importlib
 
 # Import salt libs
 import salt.loader

--- a/salt/utils/compat.py
+++ b/salt/utils/compat.py
@@ -58,3 +58,13 @@ def cmp(x, y):
     Return negative if x<y, zero if x==y, positive if x>y.
     '''
     return (x > y) - (x < y)
+
+
+def reload(mod):
+    '''
+    Compatibility helper function to replace the ``reload`` builtin from Python 2.
+    '''
+    try:
+        return importlib.reload(mod)
+    except AttributeError:
+        return reload(mod)

--- a/salt/utils/virtualbox.py
+++ b/salt/utils/virtualbox.py
@@ -14,13 +14,11 @@ import re
 import time
 
 # Import salt libs
+import salt.utils.compat
 import salt.utils.data
 from salt.utils.timeout import wait_for
 import salt.ext.six as six
 
-# Workaround for 'reload' builtin of py2.7
-if six.PY3:
-    from importlib import reload  # pylint: disable=no-name-in-module
 
 log = logging.getLogger(__name__)
 
@@ -140,7 +138,7 @@ def vb_get_manager():
     '''
     global _virtualboxManager
     if _virtualboxManager is None and HAS_LIBS:
-        reload(vboxapi)
+        salt.utils.compat.reload(vboxapi)
         _virtualboxManager = vboxapi.VirtualBoxManager(None, None)
 
     return _virtualboxManager

--- a/tests/unit/utils/test_path.py
+++ b/tests/unit/utils/test_path.py
@@ -17,6 +17,7 @@ from tests.support.unit import TestCase, skipIf
 from tests.support.mock import patch, NO_MOCK, NO_MOCK_REASON
 
 # Import Salt libs
+import salt.utils.compat
 import salt.utils.path
 import salt.utils.platform
 from salt.exceptions import CommandNotFoundError
@@ -125,7 +126,7 @@ class PathJoinTestCase(TestCase):
         platform.system = lambda: "windows"
 
         for module in (ntpath, os, os.path, tempfile):
-            reload(module)
+            salt.utils.compat.reload(module)
 
     def __unpatch_path(self):
         del sys.modules['nt']
@@ -133,7 +134,7 @@ class PathJoinTestCase(TestCase):
         platform.system = self.PLATFORM_FUNC
 
         for module in (posixpath, os, os.path, tempfile, platform):
-            reload(module)
+            salt.utils.compat.reload(module)
 
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)


### PR DESCRIPTION
This also normalizes some hacks that were in place to import reload from
importlib, so that these instances also use the compatibility function.