### PR TITLE
Allow slashes in file_roots envs.

### DIFF
--- a/salt/fileserver/roots.py
+++ b/salt/fileserver/roots.py
@@ -303,8 +303,8 @@ def _file_lists(load, form):
         except os.error:
             log.critical('Unable to make cachedir %s', list_cachedir)
             return []
-    list_cache = os.path.join(list_cachedir, '{0}.p'.format(load['saltenv']))
-    w_lock = os.path.join(list_cachedir, '.{0}.w'.format(load['saltenv']))
+    list_cache = os.path.join(list_cachedir, '{0}.p'.format(salt.utils.files.safe_filename_leaf(load['saltenv'])))
+    w_lock = os.path.join(list_cachedir, '.{0}.w'.format(salt.utils.files.safe_filename_leaf(load['saltenv'])))
     cache_match, refresh_cache, save_cache = \
         salt.fileserver.check_file_list_cache(
             __opts__, form, list_cache, w_lock

--- a/tests/unit/fileserver/test_roots.py
+++ b/tests/unit/fileserver/test_roots.py
@@ -153,6 +153,17 @@ class RootsTest(TestCase, AdaptedConfigurationTestCaseMixin, LoaderModuleMockMix
         ret = roots.file_list_emptydirs({'saltenv': 'base'})
         self.assertIn('empty_dir', ret)
 
+    def test_file_list_with_slash(self):
+        opts = {'file_roots': copy.copy(self.opts['file_roots'])}
+        opts['file_roots']['foo/bar'] = opts['file_roots']['base']
+        load = {
+                'saltenv': 'foo/bar',
+                }
+        with patch.dict(roots.__opts__, opts):
+            ret = roots.file_list(load)
+        self.assertIn('testfile', ret)
+        self.assertIn(UNICODE_FILENAME, ret)
+
     def test_dir_list(self):
         ret = roots.dir_list({'saltenv': 'base'})
         self.assertIn('empty_dir', ret)


### PR DESCRIPTION
### What does this PR do?

Allow slashes in `file_roots` envs.

### What issues does this PR fix or reference?

Fixes #51211.

### Previous Behavior
Using this master config (to workaround #48132):
```yaml
file_roots:
  base:
    - /srv/salt
  feature/2:
    - /srv/salt
```
Salt works incorrectly and logs:
```log
2019-01-08 09:57:23,653 [salt.master      :1795][ERROR   ][28091] Error in function _file_list:
Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/salt/master.py", line 1788, in run_func
    ret = getattr(self, func)(load)
  File "/usr/lib/python2.7/dist-packages/salt/utils/decorators/__init__.py", line 594, in wrapped
    **salt.utils.data.decode_dict(kwargs)
  File "/usr/lib/python2.7/dist-packages/salt/fileserver/__init__.py", line 752, in file_list
    ret.update(self.servers[fstr](load))
  File "/usr/lib/python2.7/dist-packages/salt/fileserver/roots.py", line 422, in file_list
    return _file_lists(load, 'files')
  File "/usr/lib/python2.7/dist-packages/salt/fileserver/roots.py", line 310, in _file_lists
    __opts__, form, list_cache, w_lock
  File "/usr/lib/python2.7/dist-packages/salt/fileserver/__init__.py", line 116, in check_file_list_cache
    if not os.path.isfile(list_cache) and _lock_cache(w_lock):
  File "/usr/lib/python2.7/dist-packages/salt/fileserver/__init__.py", line 50, in _lock_cache
    os.mkdir(w_lock)
OSError: [Errno 2] No such file or directory: '/var/cache/salt/master/file_lists/roots/.feature/2.w'
```

### New Behavior
Slashes in `file_roots` envs are allowed.

### Tests written?

Yes

### Commits signed with GPG?

Yes
