### PR TITLE
Fix broken lookup in salt/utils/dns.py

### DIFF
--- a/salt/utils/dns.py
+++ b/salt/utils/dns.py
@@ -382,7 +382,8 @@ def _lookup_host(name, rdtype, timeout=None, server=None):
         return []
 
     res = []
-    for line in cmd['stdout'].splitlines():
+    _stdout = cmd['stdout'] if server is None else cmd['stdout'].split('\n\n')[-1]
+    for line in _stdout.splitlines():
         if rdtype != 'CNAME' and 'is an alias' in line:
             continue
         line = line.split(' ', 3)[-1]

--- a/salt/utils/dns.py
+++ b/salt/utils/dns.py
@@ -365,12 +365,13 @@ def _lookup_host(name, rdtype, timeout=None, server=None):
     '''
     cmd = 'host -t {0} '.format(rdtype)
 
-    if server is not None:
-        cmd += '@{0} '.format(server)
     if timeout:
         cmd += '-W {0} '.format(int(timeout))
+    cmd += name
+    if server is not None:
+        cmd += ' {0}'.format(server)
 
-    cmd = __salt__['cmd.run_all'](cmd + name, python_shell=False, output_loglevel='quiet')
+    cmd = __salt__['cmd.run_all'](cmd, python_shell=False, output_loglevel='quiet')
 
     if 'invalid type' in cmd['stderr']:
         raise ValueError('Invalid DNS type {}'.format(rdtype))

--- a/tests/unit/utils/test_dns.py
+++ b/tests/unit/utils/test_dns.py
@@ -442,7 +442,7 @@ class DNSlookupsCase(TestCase):
 
         empty = {'stdout': 'www.example.com has no MX record'}
 
-        # example returns for dig
+        # example returns for host
         rights = {
             'A':     [
                 'mocksrvr.example.com has address 10.1.1.1',

--- a/tests/unit/utils/test_dns.py
+++ b/tests/unit/utils/test_dns.py
@@ -446,9 +446,9 @@ class DNSlookupsCase(TestCase):
         rights = {
             'A':     [
                 'mocksrvr.example.com has address 10.1.1.1',
-                'web.example.com  has address 10.1.1.1\n'
-                'web.example.com  has address 10.2.2.2\n'
-                'web.example.com  has address 10.3.3.3'
+                'web.example.com has address 10.1.1.1\n'
+                'web.example.com has address 10.2.2.2\n'
+                'web.example.com has address 10.3.3.3'
 
             ],
             'AAAA':  [

--- a/tests/unit/utils/test_dns.py
+++ b/tests/unit/utils/test_dns.py
@@ -14,6 +14,7 @@ from salt.utils.odict import OrderedDict
 import salt.utils.dns
 from salt.utils.dns import _to_port, _tree, _weighted_order, _data2rec, _data2rec_group
 from salt.utils.dns import _lookup_gai, _lookup_dig, _lookup_drill, _lookup_host, _lookup_nslookup
+from salt.utils.dns import lookup
 
 # Testing
 from tests.support.unit import skipIf, TestCase
@@ -275,6 +276,46 @@ class DNSlookupsCase(TestCase):
                     self.assertEqual(
                         lookup_cb('mocksrvr.example.com', rec_t, secure=True), test_res,
                         msg='Error parsing DNSSEC\'d {0} returns'.format(rec_t)
+                    )
+
+    def test_lookup_with_servers(self):
+        rights = {
+            'A': [
+                'Name:\tmocksrvr.example.com\nAddress: 10.1.1.1',
+                'Name:\tmocksrvr.example.com\nAddress: 10.1.1.1\n'
+                'Name:\tweb.example.com\nAddress: 10.2.2.2\n'
+                'Name:\tweb.example.com\nAddress: 10.3.3.3'
+            ],
+            'AAAA': [
+                'mocksrvr.example.com\thas AAAA address 2a00:a00:b01:c02:d03:e04:f05:111',
+                'mocksrvr.example.com\tcanonical name = web.example.com.\n'
+                'web.example.com\thas AAAA address 2a00:a00:b01:c02:d03:e04:f05:111\n'
+                'web.example.com\thas AAAA address 2a00:a00:b01:c02:d03:e04:f05:222\n'
+                'web.example.com\thas AAAA address 2a00:a00:b01:c02:d03:e04:f05:333'
+            ],
+            'CNAME': [
+                'mocksrvr.example.com\tcanonical name = web.example.com.'
+            ],
+            'MX':    [
+                'example.com\tmail exchanger = 10 mx1.example.com.',
+                'example.com\tmail exchanger = 10 mx1.example.com.\n'
+                'example.com\tmail exchanger = 20 mx2.example.eu.\n'
+                'example.com\tmail exchanger = 30 mx3.example.nl.'
+            ],
+            'TXT':   [
+                'example.com\ttext = "v=spf1 a include:_spf4.example.com include:mail.example.eu ip4:10.0.0.0/8 ip6:2a00:a00:b01::/48 ~all"'
+            ]
+        }
+
+        for rec_t, tests in rights.items():
+            with self._mock_cmd_ret([dict([('stdout', dres)]) for dres in tests]):
+                for test_res in self.RESULTS[rec_t]:
+                    if rec_t in ('A', 'AAAA', 'CNAME'):
+                        rec = 'mocksrvr.example.com'
+                    else:
+                        rec = 'example.com'
+                    self.assertEqual(
+                        lookup(rec, rec_t, method='nslookup', servers='8.8.8.8'), test_res,
                     )
 
     def test_dig(self):


### PR DESCRIPTION
### What does this PR do?
Fix _lookup_ function in salt/utils/dns.py.

### What issues does this PR fix or reference?
#51249

### Previous Behavior
1. the __multi_srvr_ recursively called since _resolver_ in the function points to __multi_srvr_ and causes the following error.
`Passed invalid arguments: _multi_srvr() got multiple values for keyword argument 'server'.`
2. method _host_ fails to query the resolver when the _servers_ argument specified.

### New Behavior
1. instead of pointing the _resolver_ to _multi_srvr, it now generates wrapper functions and assign that to _resolver_.
2. _host_ properly specifies the resolver to query.

### Tests written?
Work in progress.

### Commits signed with GPG?
Yes.

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
