### PR TITLE
Fix 'Path not found' error in file.directory

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -3155,7 +3155,7 @@ def directory(name,
                             ret, _ = __salt__['file.check_perms'](
                                 full, ret, user, group, file_mode, follow_symlinks)
                     except CommandExecutionError as exc:
-                        if not exc.strerror.endswith('does not exist'):
+                        if not exc.strerror.startswith('Path not found'):
                             errors.append(exc.strerror)
 
             if check_dirs:


### PR DESCRIPTION
### What does this PR do?

`file.check_perms` raises `CommandExecutionError` with message that starts with `'Path not found'` when file or directory was deleted between `_depth_limited_walk` and actual permissions check. This error was correctly ignored for directories, but not for files. This PR fixes error message check for files.

### What issues does this PR fix or reference?

Previous race condition bug: #36831, and PR with fix: #36928

### Tests written?

No

### Commits signed with GPG?

No
