### PR TITLE
Warn about proper validation option

### DIFF
--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -1938,15 +1938,10 @@ PROVIDER_CONFIG_DEFAULTS = {
 # <---- Salt Cloud Configuration Defaults ------------------------------------
 
 
-def _validate_file_roots(file_roots):
+def _normalize_roots(file_roots):
     '''
-    If the file_roots option has a key that is None then we will error out,
-    just replace it with an empty list
+    Normalize file or pillar roots.
     '''
-    if not isinstance(file_roots, dict):
-        log.warning('The file_roots parameter is not properly formatted,'
-                    ' using defaults')
-        return {'base': _expand_glob_path([salt.syspaths.BASE_FILE_ROOTS_DIR])}
     for saltenv, dirs in six.iteritems(file_roots):
         normalized_saltenv = six.text_type(saltenv)
         if normalized_saltenv != saltenv:
@@ -1956,6 +1951,30 @@ def _validate_file_roots(file_roots):
         file_roots[normalized_saltenv] = \
                 _expand_glob_path(file_roots[normalized_saltenv])
     return file_roots
+
+
+def _validate_pillar_roots(pillar_roots):
+    '''
+    If the pillar_roots option has a key that is None then we will error out,
+    just replace it with an empty list
+    '''
+    if not isinstance(pillar_roots, dict):
+        log.warning('The pillar_roots parameter is not properly formatted,'
+                    ' using defaults')
+        return {'base': _expand_glob_path([salt.syspaths.BASE_PILLAR_ROOTS_DIR])}
+    return _normalize_roots(pillar_roots)
+
+
+def _validate_file_roots(file_roots):
+    '''
+    If the file_roots option has a key that is None then we will error out,
+    just replace it with an empty list
+    '''
+    if not isinstance(file_roots, dict):
+        log.warning('The file_roots parameter is not properly formatted,'
+                    ' using defaults')
+        return {'base': _expand_glob_path([salt.syspaths.BASE_FILE_ROOTS_DIR])}
+    return _normalize_roots(file_roots)
 
 
 def _expand_glob_path(file_roots):

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -3786,7 +3786,7 @@ def apply_minion_config(overrides=None,
     # nothing else!
     opts['open_mode'] = opts['open_mode'] is True
     opts['file_roots'] = _validate_file_roots(opts['file_roots'])
-    opts['pillar_roots'] = _validate_file_roots(opts['pillar_roots'])
+    opts['pillar_roots'] = _validate_pillar_roots(opts['pillar_roots'])
     # Make sure ext_mods gets set if it is an untrue value
     # (here to catch older bad configs)
     opts['extension_modules'] = (

--- a/tests/unit/config/__init__.py
+++ b/tests/unit/config/__init__.py
@@ -1,1 +1,31 @@
 # -*- coding: utf-8 -*-
+
+# Import python libs
+from __future__ import absolute_import, print_function, unicode_literals
+
+# Import Salt Testing Libs
+from tests.support.unit import TestCase, skipIf
+import mock
+
+import salt.config
+import salt.syspaths
+
+class ConfigTest(TestCase):
+
+    def test_validate_bad_pillar_roots(self):
+        expected = salt.config._expand_glob_path(
+            [salt.syspaths.BASE_PILLAR_ROOTS_DIR]
+        )
+        with mock.patch('salt.config._normalize_roots') as mk:
+            ret = salt.config._validate_pillar_roots(None)
+            assert not mk.called
+        assert ret == {'base': expected}
+
+    def test_validate_bad_file_roots(self):
+        expected = salt.config._expand_glob_path(
+            [salt.syspaths.BASE_FILE_ROOTS_DIR]
+        )
+        with mock.patch('salt.config._normalize_roots') as mk:
+            ret = salt.config._validate_file_roots(None)
+            assert not mk.called
+        assert ret == {'base': expected}

--- a/tests/unit/config/__init__.py
+++ b/tests/unit/config/__init__.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import, print_function, unicode_literals
 
 # Import Salt Testing Libs
 from tests.support.unit import TestCase, skipIf
-from tests.support.mock import  mock
+import tests.support.mock as mock
 
 import salt.config
 import salt.syspaths

--- a/tests/unit/config/__init__.py
+++ b/tests/unit/config/__init__.py
@@ -5,10 +5,11 @@ from __future__ import absolute_import, print_function, unicode_literals
 
 # Import Salt Testing Libs
 from tests.support.unit import TestCase, skipIf
-import mock
+from tests.support.mock import  mock
 
 import salt.config
 import salt.syspaths
+
 
 class ConfigTest(TestCase):
 


### PR DESCRIPTION
### What does this PR do?

When normalizing `pillar_roots` if the option is not a dictionary, warn about `pillar_roots` and fallback to its default.

### What issues does this PR fix or reference?

#51248 

### Previous Behavior

When validating `pillar_roots` we warned about `file_roots` and used the `file_roots` fallback.

### New Behavior

Warn about the proper option and use proper fallback for `pillar_roots`

### Tests written?

Yes

### Commits signed with GPG?

Yes
