### PR TITLE
Skip test_get_file_templated_paths on Windows/Py3

### DIFF
--- a/tests/integration/modules/test_cp.py
+++ b/tests/integration/modules/test_cp.py
@@ -22,6 +22,9 @@ from tests.support.helpers import (
 from tests.support.unit import skipIf
 import tests.support.paths as paths
 
+# Import 3rd party libs
+import salt.ext.six as six
+
 # Import salt libs
 import salt.utils.files
 import salt.utils.path
@@ -78,6 +81,7 @@ class CPModuleTest(ModuleCase):
         self.assertNotIn('bacon', data)
 
     @with_tempfile()
+    @skipIf(salt.utils.platform.is_windows() and six.PY3, 'This test hangs on Windows on Py3')
     def test_get_file_templated_paths(self, tgt):
         '''
         cp.get_file


### PR DESCRIPTION
### What does this PR do?
Skips `test_get_file_templated_paths` on Windows on Py3

https://github.com/saltstack/salt-jenkins/issues/1252

### Tests written?
No

### Commits signed with GPG?
Yes