### PR TITLE
[2018.3] Fixes to dns_check in salt.utils.network

### DIFF
--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -1855,6 +1855,9 @@ def dns_check(addr, port, safe=False, ipv6=None):
     seen_ipv6 = False
     try:
         refresh_dns()
+        if isinstance(addr, salt.ext.ipaddress.IPv4Address) or \
+           isinstance(addr, salt.ext.ipaddress.IPv6Address):
+            return addr.exploded
         hostnames = socket.getaddrinfo(
             addr, None, socket.AF_UNSPEC, socket.SOCK_STREAM
         )

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -1854,6 +1854,7 @@ def dns_check(addr, port, safe=False, ipv6=None):
     lookup = addr
     seen_ipv6 = False
     try:
+        log.debug('=== %s ===', socket.getaddrinfo)
         refresh_dns()
         if isinstance(addr, salt.ext.ipaddress.IPv4Address) or \
            isinstance(addr, salt.ext.ipaddress.IPv6Address):
@@ -1861,6 +1862,7 @@ def dns_check(addr, port, safe=False, ipv6=None):
         hostnames = socket.getaddrinfo(
             addr, None, socket.AF_UNSPEC, socket.SOCK_STREAM
         )
+        log.debug('=== hostnames %s ===', hostnames)
         if not hostnames:
             error = True
         else:
@@ -1885,6 +1887,7 @@ def dns_check(addr, port, safe=False, ipv6=None):
                 try:
                     s = socket.socket(h[0], socket.SOCK_STREAM)
                     s.connect((candidate_addr, port))
+                    log.debug('=== h %s ===', h)
                     s.close()
 
                     resolved = candidate_addr


### PR DESCRIPTION
### What does this PR do?
Inside the dns_check function if the master address is either an salt.ext.ipaddress.IPv4Address or an salt.ext.ipaddress.IPv6Address object, just return the exploded IP address.

### What issues does this PR fix or reference?
#51289 

### Previous Behavior
Specifying an IP address as the Salt master would result in the Salt minion being unable to start.

### New Behavior
Salt minion starts.

### Tests written?
Yes

### Commits signed with GPG?

Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
