### PR TITLE
Fix edge case when minion ID is a 16-character string

### DIFF
--- a/salt/_compat.py
+++ b/salt/_compat.py
@@ -144,13 +144,6 @@ class IPv6AddressScoped(ipaddress.IPv6Address):
 
         :param address:
         '''
-        # pylint: disable-all
-        if not hasattr(self, '_is_packed_binary'):
-            # This method (below) won't be around for some Python 3 versions
-            # and we need check this differently anyway
-            self._is_packed_binary = lambda p: isinstance(p, bytes)
-        # pylint: enable-all
-
         if isinstance(address, string_types) and '%' in address:
             buff = address.split('%')
             if len(buff) != 2:
@@ -189,7 +182,7 @@ class IPv6AddressScoped(ipaddress.IPv6Address):
         :return:
         '''
         packed = False
-        if len(data) == 16 and ':' not in data:
+        if isinstance(data, bytes) and len(data) == 16 and b':' not in data:
             try:
                 packed = bool(int(str(bytearray(data)).encode('hex'), 16))
             except ValueError:

--- a/tests/unit/utils/test_network.py
+++ b/tests/unit/utils/test_network.py
@@ -184,11 +184,17 @@ class NetworkTestCase(TestCase):
     def test_is_ip(self):
         self.assertTrue(network.is_ip('10.10.0.3'))
         self.assertFalse(network.is_ip('0.9.800.1000'))
+        # Check 16-char-long unicode string
+        # https://github.com/saltstack/salt/issues/51258
+        self.assertFalse(network.is_ipv6('sixteen-char-str'))
 
     def test_is_ipv4(self):
         self.assertTrue(network.is_ipv4('10.10.0.3'))
         self.assertFalse(network.is_ipv4('10.100.1'))
         self.assertFalse(network.is_ipv4('2001:db8:0:1:1:1:1:1'))
+        # Check 16-char-long unicode string
+        # https://github.com/saltstack/salt/issues/51258
+        self.assertFalse(network.is_ipv4('sixteen-char-str'))
 
     def test_is_ipv6(self):
         self.assertTrue(network.is_ipv6('2001:db8:0:1:1:1:1:1'))
@@ -201,6 +207,9 @@ class NetworkTestCase(TestCase):
         self.assertFalse(network.is_ipv6('2001:0db8:::0370:7334'))
         self.assertFalse(network.is_ipv6('10.0.1.2'))
         self.assertFalse(network.is_ipv6('2001.0db8.85a3.0000.0000.8a2e.0370.7334'))
+        # Check 16-char-long unicode string
+        # https://github.com/saltstack/salt/issues/51258
+        self.assertFalse(network.is_ipv6('sixteen-char-str'))
 
     def test_is_subnet(self):
         for subnet_data in (IPV4_SUBNETS, IPV6_SUBNETS):


### PR DESCRIPTION
Some code in `salt._compat` which checks if the value is a packed binary representation of an IPv6 address fails if the value passed is not a bytestring (i.e. a `unicode` type on PY2 or `str` type on PY3). This fixes that code when the minion ID is a 16-character string (not a bytestring). Note that the minion ID will never be a bytestring as of 2018.3.0, so this affects any 16-character minion ID when the minion ID is checked to see if it is really an IP address.

Resolves #51258.