### PR TITLE
Fix failing test `unit.states.test_file.TestFileState.test_managed` on Windows

### DIFF
--- a/tests/unit/states/test_file.py
+++ b/tests/unit/states/test_file.py
@@ -775,10 +775,15 @@ class TestFileState(TestCase, LoaderModuleMockMixin):
                             with patch.object(os.path, 'exists', mock_t):
                                 with patch.dict(filestate.__opts__, {'test': True}):
                                     ret.update({'comment': comt})
-                                    self.assertDictEqual(filestate.managed
-                                                         (name, user=user,
-                                                          group=group,
-                                                          mode=400), ret)
+                                    if salt.utils.is_windows():
+                                        self.assertDictEqual(filestate.managed
+                                                             (name, user=user,
+                                                              group=group), ret)
+                                    else:
+                                        self.assertDictEqual(filestate.managed
+                                                             (name, user=user,
+                                                              group=group,
+                                                              mode=400), ret)
 
     # 'directory' function tests: 1
 


### PR DESCRIPTION
### What does this PR do?
Fixes failing test `unit.states.test_file.TestFileState.test_managed` on Windows. A new test was added that was passing the `mode` parameter to `file.managed`. This returns an error message on Windows. Removing the `mode` parameter on Window allows the test to continue.

### What issues does this PR fix or reference?
https://jenkinsci.saltstack.com/job/2018.3.4/job/salt-windows-2016-py2/3/testReport/junit/unit.states.test_file/TestFileState/test_managed/

### Tests written?
Yes

### Commits signed with GPG?
Yes