### PR TITLE
Fix regression in dynamic pillarenv

### DIFF
--- a/salt/utils/gitfs.py
+++ b/salt/utils/gitfs.py
@@ -2993,7 +2993,11 @@ class GitPillar(GitBase):
                 elif repo.env:
                     env = repo.env
                 else:
-                    env = 'base' if repo.branch == repo.base else repo.get_checkout_target()
+                    if repo.branch == repo.base:
+                        env = 'base'
+                    else:
+                        tgt = repo.get_checkout_target()
+                        env = 'base' if tgt == repo.base else tgt
                 if repo._mountpoint:
                     if self.link_mountpoint(repo):
                         self.pillar_dirs[repo.linkdir] = env


### PR DESCRIPTION
https://github.com/saltstack/salt/pull/50417 caused a regression in which the env name is not properly detected as `base` when `get_checkout_target()` returns the branch name corresponding to that repo's `base` config option. This corrects that regression.