### PR TITLE
[2019.2.0rc1] Fix to __auth_call

### DIFF
--- a/salt/auth/__init__.py
+++ b/salt/auth/__init__.py
@@ -93,9 +93,14 @@ class LoadAuth(object):
         fstr = '{0}.auth'.format(load['eauth'])
         if fstr not in self.auth:
             return False
+        # When making auth calls, only username, password, auth, and token
+        # are valid, so we strip anything else out.
+        _valid = ['username', 'password', 'eauth', 'token']
+        _load = {key: value for (key, value) in load.items() if key in _valid}
+
         fcall = salt.utils.args.format_call(
             self.auth[fstr],
-            load,
+            _load,
             expected_extra_kws=AUTH_INTERNAL_KEYWORDS)
         try:
             if 'kwargs' in fcall:

--- a/tests/integration/netapi/rest_cherrypy/test_app.py
+++ b/tests/integration/netapi/rest_cherrypy/test_app.py
@@ -191,6 +191,20 @@ class TestRun(cptc.BaseRestCherryPyTest):
         })
         assert response.status == '401 Unauthorized'
 
+    def test_run_extra_parameters(self):
+        '''
+        Test the run URL with good auth credentials
+        '''
+        cmd = dict(self.low, **dict(self.auth_creds))
+        cmd['id_'] = 'someminionname'
+        body = urlencode(cmd)
+
+        request, response = self.request('/run', method='POST', body=body,
+            headers={
+                'content-type': 'application/x-www-form-urlencoded'
+        })
+        self.assertEqual(response.status, '200 OK')
+
 
 class TestWebhookDisableAuth(cptc.BaseRestCherryPyTest):
 


### PR DESCRIPTION
### What does this PR do?
When making auth calls, only username, password, auth, and token are valid, so we strip anything else out.

### What issues does this PR fix or reference?
#51273 

### Tests written?
Yes

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
