### PR TITLE
Fix 500 error when using wheel_async

### DIFF
--- a/salt/utils/process.py
+++ b/salt/utils/process.py
@@ -806,7 +806,7 @@ def default_signals(*signals):
     old_signals = {}
     for signum in signals:
         try:
-            old_signals[signum] = signal.getsignal(signum)
+            saved_signal = signal.getsignal(signum)
             signal.signal(signum, signal.SIG_DFL)
         except ValueError as exc:
             # This happens when a netapi module attempts to run a function
@@ -816,6 +816,8 @@ def default_signals(*signals):
                 'Failed to register signal for signum %d: %s',
                 signum, exc
             )
+        else:
+            old_signals[signum] = saved_signal
 
     # Do whatever is needed with the reset signals
     yield


### PR DESCRIPTION
When `wheel_async` is used, the job completes, but for the same reason we couldn't replace the signal in the first place, we fail to restore it after control is returned to the context manager.

This fixes this by only adding the signal data to the `old_signals` dict when we successfully override the signal handling, so that we don't incorrectly attempt to "restore" the signal later.

Resolves #51256.