### PR TITLE
Catch recursive objects during msgpack serialize

### DIFF
--- a/salt/payload.py
+++ b/salt/payload.py
@@ -237,15 +237,21 @@ class Serial(object):
         except (OverflowError, msgpack.exceptions.PackValueError):
             # msgpack<=0.4.6 don't call ext encoder on very long integers raising the error instead.
             # Convert any very long longs to strings and call dumps again.
-            def verylong_encoder(obj):
+            def verylong_encoder(obj, context):
+                # Make sure we catch recursion here.
+                objid = id(obj)
+                if objid in context:
+                    return '<Recursion on {} with id={}>'.format(type(obj).__name__, id(obj))
+                context.add(objid)
+
                 if isinstance(obj, dict):
                     for key, value in six.iteritems(obj.copy()):
-                        obj[key] = verylong_encoder(value)
+                        obj[key] = verylong_encoder(value, context)
                     return dict(obj)
                 elif isinstance(obj, (list, tuple)):
                     obj = list(obj)
                     for idx, entry in enumerate(obj):
-                        obj[idx] = verylong_encoder(entry)
+                        obj[idx] = verylong_encoder(entry, context)
                     return obj
                 # A value of an Integer object is limited from -(2^63) upto (2^64)-1 by MessagePack
                 # spec. Here we care only of JIDs that are positive integers.
@@ -254,7 +260,7 @@ class Serial(object):
                 else:
                     return obj
 
-            msg = verylong_encoder(msg)
+            msg = verylong_encoder(msg, set())
             if msgpack.version >= (0, 4, 0):
                 return salt.utils.msgpack.dumps(msg, default=ext_type_encoder,
                                                 use_bin_type=use_bin_type,

--- a/tests/unit/test_payload.py
+++ b/tests/unit/test_payload.py
@@ -153,6 +153,17 @@ class PayloadTestCase(TestCase):
         odata = payload.loads(sdata)
         self.assertEqual(edata, odata)
 
+    def test_recursive_dump_load(self):
+        '''
+        Test recursive payloads are (mostly) serialized
+        '''
+        payload = salt.payload.Serial('msgpack')
+        data = {'name': 'roscivs'}
+        data['data'] = data  # Data all the things!
+        sdata = payload.dumps(data)
+        odata = payload.loads(sdata)
+        self.assertTrue('recursion' in odata['data'].lower())
+
 
 class SREQTestCase(TestCase):
     port = 8845  # TODO: dynamically assign a port?


### PR DESCRIPTION
### What does this PR do?

What it says on the tin - catches recursion during payload/msgpack serialization.

### What issues does this PR fix or reference?

#37646 

### Previous Behavior

A return response from a state containing a recursive or cyclical reference, e.g.

```
bad = {}
bad['news'] = bad
```

Anywhere in a state response would fail trying to serialize it.

### New Behavior

Now the message is serialized, with a `<Recursion on ... with id=...>` placeholder.

I don't know if there's a better way to do that - repr offers `[...]` or some such. This follows [pprint's style](https://github.com/python/cpython/blob/8db5b54463118e5eb60cb3582e3108623f01f5df/Lib/pprint.py#L561), which is slightly more verbose, so at least when you get the message you might have an idea about what's going on.

### Tests written?

Yes

### Commits signed with GPG?

Yes