### PR TITLE
6922 fix network error errors

### DIFF
--- a/salt/modules/debian_ip.py
+++ b/salt/modules/debian_ip.py
@@ -158,7 +158,7 @@ def _error_msg_iface(iface, option, expected):
     a list of expected values.
     '''
     msg = 'Invalid option -- Interface: {0}, Option: {1}, Expected: [{2}]'
-    return msg.format(iface, option, '|'.join(expected))
+    return msg.format(iface, option, '|'.join(str(e) for e in expected))
 
 
 def _error_msg_routes(iface, option, expected):
@@ -181,7 +181,7 @@ def _error_msg_network(option, expected):
     a list of expected values.
     '''
     msg = 'Invalid network setting -- Setting: {0}, Expected: [{1}]'
-    return msg.format(option, '|'.join(expected))
+    return msg.format(option, '|'.join(str(e) for e in expected))
 
 
 def _log_default_network(opt, value):

--- a/salt/modules/rh_ip.py
+++ b/salt/modules/rh_ip.py
@@ -81,7 +81,7 @@ def _error_msg_iface(iface, option, expected):
     a list of expected values.
     '''
     msg = 'Invalid option -- Interface: {0}, Option: {1}, Expected: [{2}]'
-    return msg.format(iface, option, '|'.join(expected))
+    return msg.format(iface, option, '|'.join(str(e) for e in expected))
 
 
 def _error_msg_routes(iface, option, expected):
@@ -104,7 +104,7 @@ def _error_msg_network(option, expected):
     a list of expected values.
     '''
     msg = 'Invalid network setting -- Setting: {0}, Expected: [{1}]'
-    return msg.format(option, '|'.join(expected))
+    return msg.format(option, '|'.join(str(e) for e in expected))
 
 
 def _log_default_network(opt, value):

--- a/tests/unit/modules/test_debian_ip.py
+++ b/tests/unit/modules/test_debian_ip.py
@@ -814,6 +814,18 @@ class DebianIpTestCase(TestCase, LoaderModuleMockMixin):
                                                      'pkg.install': mock}):
                     self.assertEqual(debian_ip.build_bond('bond0'), '')
 
+    def test_error_message_iface_should_process_non_str_expected(self):
+        values = [1, True, False, 'no-kaboom']
+        iface = 'ethtest'
+        option = 'test'
+        msg = debian_ip._error_msg_iface(iface, option, values)
+        self.assertTrue(msg.endswith('[1|True|False|no-kaboom]'), msg)
+
+    def test_error_message_network_should_process_non_str_expected(self):
+        values = [1, True, False, 'no-kaboom']
+        msg = debian_ip._error_msg_network('fnord', values)
+        self.assertTrue(msg.endswith('[1|True|False|no-kaboom]'), msg)
+
     def test_build_bond_exception(self):
         '''
         Test if it create a bond script in /etc/modprobe.d with the passed

--- a/tests/unit/modules/test_rh_ip.py
+++ b/tests/unit/modules/test_rh_ip.py
@@ -32,6 +32,18 @@ class RhipTestCase(TestCase, LoaderModuleMockMixin):
     def setup_loader_modules(self):
         return {rh_ip: {}}
 
+    def test_error_message_iface_should_process_non_str_expected(self):
+        values = [1, True, False, 'no-kaboom']
+        iface = 'ethtest'
+        option = 'test'
+        msg = rh_ip._error_msg_iface(iface, option, values)
+        self.assertTrue(msg.endswith('[1|True|False|no-kaboom]'), msg)
+
+    def test_error_message_network_should_process_non_str_expected(self):
+        values = [1, True, False, 'no-kaboom']
+        msg = rh_ip._error_msg_network('fnord', values)
+        self.assertTrue(msg.endswith('[1|True|False|no-kaboom]'), msg)
+
     def test_build_bond(self):
         '''
         Test to create a bond script in /etc/modprobe.d with the passed


### PR DESCRIPTION
### What does this PR do?

Changes the error message producing code to actually produce the expected behavior (i.e. provide a useful error message).

It would be nice to refactor the debian_ip and rh_ip states, they have a lot of shared code, but I think it's probably fine for now to just make this fix. If I have to touch these modules again, though, I'll probably take the time to refactor out all the shared code 😛 

### What issues does this PR fix or reference?

#6922

### Previous Behavior

Bad options produced a stack trace, whoops.

### New Behavior

Bad options provide a nice helpful comment, e.g.:

```
  Comment: Invalid network setting -- Setting: networking, Expected: [yes|on|true|1|True|no|off|false|0|False]
```
### Tests written?

Yes

### Commits signed with GPG?

Yes