### PR TITLE
Fix salt-cloud sync_after_install functionality

### DIFF
--- a/salt/cloud/__init__.py
+++ b/salt/cloud/__init__.py
@@ -1288,16 +1288,16 @@ class Cloud(object):
                 start = int(time.time())
                 while int(time.time()) < start + 60:
                     # We'll try every <timeout> seconds, up to a minute
-                    mopts_ = salt.config.DEFAULT_MINION_OPTS
+                    mopts_ = salt.config.DEFAULT_MASTER_OPTS
                     conf_path = '/'.join(self.opts['conf_file'].split('/')[:-1])
                     mopts_.update(
-                        salt.config.minion_config(
+                        salt.config.master_config(
                             os.path.join(conf_path,
-                                         'minion')
+                                         'master')
                         )
                     )
 
-                    client = salt.client.get_local_client(mopts=self.opts)
+                    client = salt.client.get_local_client(mopts=mopts_)
 
                     ret = client.cmd(
                         vm_['name'],


### PR DESCRIPTION
Configure the Salt local client to use the master configuration for
syncing to the salt-cloud instance(s).

Fixes #40695

### What does this PR do?
Allows a local salt client to perform syncs to salt-cloud instances.

### What issues does this PR fix or reference?
#40695

### Previous Behavior
Syncing fails with an authentication error as described in #40695.

### New Behavior
sync_after_install tasks are run without error.

### Tests written?

No

### Commits signed with GPG?

Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
