### PR TITLE
Add Python2 depreciation warning

### DIFF
--- a/salt/__init__.py
+++ b/salt/__init__.py
@@ -95,17 +95,3 @@ __define_global_system_encoding_variable__()
 
 # This is now garbage collectable
 del __define_global_system_encoding_variable__
-
-
-# REMOVEME after Python 2.7 support is dropped
-import salt.ext.six as six
-
-if six.PY2:
-    from salt.utils.versions import warn_until
-    # Message borrowed from pip's deprecation warning
-    warn_until('Sodium',
-               'Python 2.7 will reach the end of its life on January 1st, 2020.'
-               ' Please upgrade your Python as Python 2.7 won\'t be maintained'
-               ' after that date.  Salt will drop support for Python 2.7 in the'
-               ' Sodium release.')
-# END REMOVEME

--- a/salt/__init__.py
+++ b/salt/__init__.py
@@ -29,6 +29,7 @@ warnings.filterwarnings(
     UserWarning
 )
 
+
 def __define_global_system_encoding_variable__():
     import sys
     # This is the most trustworthy source of the system encoding, though, if
@@ -97,7 +98,7 @@ del __define_global_system_encoding_variable__
 
 
 # REMOVEME after Python 2.7 support is dropped
-import six
+import salt.ext.six as six
 
 if six.PY2:
     from salt.utils.versions import warn_until

--- a/salt/__init__.py
+++ b/salt/__init__.py
@@ -29,7 +29,6 @@ warnings.filterwarnings(
     UserWarning
 )
 
-
 def __define_global_system_encoding_variable__():
     import sys
     # This is the most trustworthy source of the system encoding, though, if
@@ -95,3 +94,17 @@ __define_global_system_encoding_variable__()
 
 # This is now garbage collectable
 del __define_global_system_encoding_variable__
+
+
+# REMOVEME after Python 2.7 support is dropped
+import six
+
+if six.PY2:
+    from salt.utils.versions import warn_until
+    # Message borrowed from pip's deprecation warning
+    warn_until('Sodium',
+               'Python 2.7 will reach the end of its life on January 1st, 2020.'
+               ' Please upgrade your Python as Python 2.7 won\'t be maintained'
+               ' after that date.  Salt will drop support for Python 2.7 in the'
+               ' Sodium release.')
+# END REMOVEME

--- a/scripts/salt-master
+++ b/scripts/salt-master
@@ -3,8 +3,11 @@
 Start the salt-master
 '''
 
+import salt.ext.six as six
 import salt.utils.platform
 from salt.scripts import salt_master
+
+
 
 
 if __name__ == '__main__':
@@ -19,4 +22,14 @@ if __name__ == '__main__':
         cfile = os.path.splitext(__file__)[0] + '.pyc'
         if not os.path.exists(cfile):
             py_compile.compile(__file__, cfile)
+# REMOVEME after Python 2.7 support is dropped (also the six import)
+    elif six.PY2:
+        from salt.utils.versions import warn_until
+        # Message borrowed from pip's deprecation warning
+        warn_until('Sodium',
+                   'Python 2.7 will reach the end of its life on January 1st,'
+                   ' 2020. Please upgrade your Python as Python 2.7 won\'t be'
+                   ' maintained after that date.  Salt will drop support for'
+                   ' Python 2.7 in the Sodium release or later.')
+# END REMOVEME
     salt_master()

--- a/scripts/salt-minion
+++ b/scripts/salt-minion
@@ -3,6 +3,7 @@
 This script is used to kick off a salt minion daemon
 '''
 
+import salt.ext.six as six
 import salt.utils.platform
 from salt.scripts import salt_minion
 from multiprocessing import freeze_support
@@ -20,6 +21,16 @@ if __name__ == '__main__':
         cfile = os.path.splitext(__file__)[0] + '.pyc'
         if not os.path.exists(cfile):
             py_compile.compile(__file__, cfile)
+# REMOVEME after Python 2.7 support is dropped (also the six import)
+    elif six.PY2:
+        from salt.utils.versions import warn_until
+        # Message borrowed from pip's deprecation warning
+        warn_until('Sodium',
+                   'Python 2.7 will reach the end of its life on January 1st,'
+                   ' 2020. Please upgrade your Python as Python 2.7 won\'t be'
+                   ' maintained after that date.  Salt will drop support for'
+                   ' Python 2.7 in the Sodium release or later.')
+# END REMOVEME
     # This handles the bootstrapping code that is included with frozen
     # scripts. It is a no-op on unfrozen code.
     freeze_support()


### PR DESCRIPTION
### What does this PR do?

Adds a depreciation warning when anything `salt` runs. I'm not sure if it's better to add it here, or somewhere else. The warning comes out like this:

```
 DeprecationWarning: Python 2.7 will reach the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 won't be maintained after that date.  Salt will drop support for Python 2.7 in the Sodium release.
```

### Commits signed with GPG?

Yes