### PR TITLE
Fix issue when directory doesn't exist in LGPO module (2018.3.4)

### DIFF
--- a/salt/modules/win_lgpo.py
+++ b/salt/modules/win_lgpo.py
@@ -5083,8 +5083,8 @@ def _findOptionValueAdvAudit(option):
                 field_names = _get_audit_defaults('fieldnames')
                 # If the file doesn't exist anywhere, create it with default
                 # fieldnames
-                __salt__['file.touch'](f_audit)
-                __salt__['file.append'](f_audit, ','.join(field_names))
+                __salt__['file.mkdir'](os.path.dirname(f_audit))
+                __salt__['file.write'](f_audit, ','.join(field_names))
 
         audit_settings = {}
         with salt.utils.files.fopen(f_audit, mode='r') as csv_file:
@@ -5187,6 +5187,7 @@ def _set_audit_file_data(option, value):
             # Copy the temporary csv file over the existing audit.csv in both
             # locations if a value was written
             __salt__['file.copy'](f_temp.name, f_audit, remove_existing=True)
+            __salt__['file.mkdir'](os.path.dirname(f_audit_gpo))
             __salt__['file.copy'](f_temp.name, f_audit_gpo, remove_existing=True)
     finally:
         f_temp.close()


### PR DESCRIPTION
### What does this PR do?
Fixes an issue with the auditpol mechanism in the LGPO module where it would crash if the directory structure containing the `audit.csv` file didn't exist.

### What issues does this PR fix or reference?
https://github.com/saltstack/lock/issues/835

### Tests written?
No

### Commits signed with GPG?
Yes