### PR TITLE
Added an implementation of .set_domain_workgroup() that corresponds with .get_domain_workgroup()

### DIFF
--- a/salt/modules/win_system.py
+++ b/salt/modules/win_system.py
@@ -1004,9 +1004,6 @@ def set_domain_workgroup(workgroup):
     conn = wmi.WMI()
     comp = conn.Win32_ComputerSystem()[0]
 
-    # Grab the current workgroup/domain value
-    current = comp.Domain if comp.PartOfDomain else comp.Workgroup
-
     # Now we can join the new workgroup
     res = comp.JoinDomainOrWorkgroup(Name=workgroup.upper())
     return True if not res[0] else False

--- a/salt/modules/win_system.py
+++ b/salt/modules/win_system.py
@@ -976,7 +976,7 @@ def get_domain_workgroup():
         if computer.PartOfDomain:
             return {'Domain': computer.Domain}
         else:
-            return {'Workgroup': computer.Domain}
+            return {'Workgroup': computer.Workgroup}
 
 
 def set_domain_workgroup(workgroup):

--- a/salt/modules/win_system.py
+++ b/salt/modules/win_system.py
@@ -994,10 +994,22 @@ def set_domain_workgroup(workgroup):
 
         salt 'minion-id' system.set_domain_workgroup LOCAL
     '''
+    if six.PY2:
+        workgroup = _to_unicode(workgroup)
+
+    # Initialize COM
     pythoncom.CoInitialize()
+
+    # Grab the first Win32_ComputerSystem object from wmi
     conn = wmi.WMI()
     comp = conn.Win32_ComputerSystem()[0]
-    return comp.JoinDomainOrWorkgroup(Name=workgroup)
+
+    # Grab the current workgroup/domain value
+    current = comp.Domain if comp.PartOfDomain else comp.Workgroup
+
+    # Now we can join the new workgroup
+    res = comp.JoinDomainOrWorkgroup(Name=workgroup.upper())
+    return True if not res[0] else False
 
 
 def _try_parse_datetime(time_str, fmts):

--- a/salt/modules/win_system.py
+++ b/salt/modules/win_system.py
@@ -972,13 +972,13 @@ def get_domain_workgroup():
 
         salt 'minion-id' system.get_domain_workgroup
     '''
-    pythoncom.CoInitialize()
-    conn = wmi.WMI()
-    for computer in conn.Win32_ComputerSystem():
-        if computer.PartOfDomain:
-            return {'Domain': computer.Domain}
-        else:
-            return {'Workgroup': computer.Workgroup}
+    with salt.utils.winapi.Com():
+        conn = wmi.WMI()
+        for computer in conn.Win32_ComputerSystem():
+            if computer.PartOfDomain:
+                return {'Domain': computer.Domain}
+            else:
+                return {'Workgroup': computer.Workgroup}
 
 
 def set_domain_workgroup(workgroup):
@@ -1000,14 +1000,14 @@ def set_domain_workgroup(workgroup):
         workgroup = _to_unicode(workgroup)
 
     # Initialize COM
-    pythoncom.CoInitialize()
+    with salt.utils.winapi.Com():
+        # Grab the first Win32_ComputerSystem object from wmi
+        conn = wmi.WMI()
+        comp = conn.Win32_ComputerSystem()[0]
 
-    # Grab the first Win32_ComputerSystem object from wmi
-    conn = wmi.WMI()
-    comp = conn.Win32_ComputerSystem()[0]
+        # Now we can join the new workgroup
+        res = comp.JoinDomainOrWorkgroup(Name=workgroup.upper())
 
-    # Now we can join the new workgroup
-    res = comp.JoinDomainOrWorkgroup(Name=workgroup.upper())
     return True if not res[0] else False
 
 

--- a/salt/modules/win_system.py
+++ b/salt/modules/win_system.py
@@ -980,6 +980,28 @@ def get_domain_workgroup():
             return {'Workgroup': computer.Domain}
 
 
+def set_domain_workgroup(workgroup):
+    '''
+    Set the domain or workgroup the computer belongs to.
+
+    .. versionadded:: 2019.2.0
+
+    Returns:
+        bool: ``True`` if successful, otherwise ``False``
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt 'minion-id' system.set_domain_workgroup LOCAL
+    '''
+    curr_hostname = get_hostname()
+    cmd = "wmic computersystem where name='{0}' call JoinDomainOrWorkgroup name='{1}'".format(curr_hostname, workgroup)
+    ret = __salt__['cmd.run'](cmd=cmd)
+
+    return "successful" in ret
+
+
 def _try_parse_datetime(time_str, fmts):
     '''
     A helper function that attempts to parse the input time_str as a date.

--- a/salt/modules/win_system.py
+++ b/salt/modules/win_system.py
@@ -692,11 +692,10 @@ def set_hostname(hostname):
 
         salt 'minion-id' system.set_hostname newhostname
     '''
-    curr_hostname = get_hostname()
-    cmd = "wmic computersystem where name='{0}' call rename name='{1}'".format(curr_hostname, hostname)
-    ret = __salt__['cmd.run'](cmd=cmd)
-
-    return "successful" in ret
+    pythoncom.CoInitialize()
+    conn = wmi.WMI()
+    comp = conn.Win32_ComputerSystem()[0]
+    return comp.Rename(Name=hostname)
 
 
 def join_domain(domain,
@@ -995,11 +994,10 @@ def set_domain_workgroup(workgroup):
 
         salt 'minion-id' system.set_domain_workgroup LOCAL
     '''
-    curr_hostname = get_hostname()
-    cmd = "wmic computersystem where name='{0}' call JoinDomainOrWorkgroup name='{1}'".format(curr_hostname, workgroup)
-    ret = __salt__['cmd.run'](cmd=cmd)
-
-    return "successful" in ret
+    pythoncom.CoInitialize()
+    conn = wmi.WMI()
+    comp = conn.Win32_ComputerSystem()[0]
+    return comp.JoinDomainOrWorkgroup(Name=workgroup)
 
 
 def _try_parse_datetime(time_str, fmts):

--- a/salt/states/win_system.py
+++ b/salt/states/win_system.py
@@ -175,6 +175,14 @@ def workgroup(name):
 
     name
         The workgroup to set
+
+    Example:
+
+    .. code-block:: yaml
+
+        set workgroup:
+          system.workgroup:
+            - name: local
     '''
     ret = {
         'name': name.upper(),

--- a/salt/states/win_system.py
+++ b/salt/states/win_system.py
@@ -183,7 +183,8 @@ def workgroup(name):
         'comment': ''
     }
 
-    current_workgroup = __salt__['system.get_domain_workgroup']()
+    res = __salt__['system.get_domain_workgroup']()
+    current_workgroup = res['Domain'] if 'Domain' in res else res['Workgroup'] if 'Workgroup' in res else ''
 
     if current_workgroup.upper() == name.upper():
         ret['comment'] = "Workgroup is already set to '{0}'".format(name.upper())

--- a/salt/states/win_system.py
+++ b/salt/states/win_system.py
@@ -184,33 +184,43 @@ def workgroup(name):
           system.workgroup:
             - name: local
     '''
-    ret = {
-        'name': name.upper(),
-        'changes': {},
-        'result': True,
-        'comment': ''
-    }
+    ret = {'name': name.upper(), 'result': False, 'changes': {}, 'comment': ''}
 
-    res = __salt__['system.get_domain_workgroup']()
-    current_workgroup = res['Domain'] if 'Domain' in res else res['Workgroup'] if 'Workgroup' in res else ''
+    # Grab the current domain/workgroup
+    out = __salt__['system.get_domain_workgroup']()
+    current_workgroup = out['Domain'] if 'Domain' in out else out['Workgroup'] if 'Workgroup' in out else ''
 
-    if __opts__['test']:
-        ret['result'] = None
-        ret['comment'] = 'Computer will be joined to workgroup \'{0}\''.format(name)
-        return ret
-
+    # Notify the user if the requested workgroup is the same
     if current_workgroup.upper() == name.upper():
+        ret['result'] = True
         ret['comment'] = "Workgroup is already set to '{0}'".format(name.upper())
         return ret
 
-    out = __salt__['system.set_domain_workgroup'](name.upper())
+    # If being run in test-mode, inform the user what is supposed to happen
+    if __opts__['test']:
+        ret['result'] = None
+        ret['changes'] = {}
+        ret['comment'] = 'Computer will be joined to workgroup \'{0}\''.format(name)
+        return ret
 
-    if out:
-        ret['comment'] = "The workgroup has been changed from '{0}' to '{1}".format(current_workgroup.upper(), name.upper())
-        ret['changes'] = {'workgroup': name.upper()}
+    # Set our new workgroup, and then immediately ask the machine what it
+    # is again to validate the change
+    res = __salt__['system.set_domain_workgroup'](name.upper())
+    out = __salt__['system.get_domain_workgroup']()
+    changed_workgroup = out['Domain'] if 'Domain' in out else out['Workgroup'] if 'Workgroup' in out else ''
+
+    # Return our results based on the changes
+    ret = {}
+    if res and current_workgroup.upper() == changed_workgroup.upper():
+        ret['result'] = True
+        ret['comment'] = "The new workgroup '{0}' is the same as '{1}'".format(current_workgroup.upper(), changed_workgroup.upper())
+    elif res:
+        ret['result'] = True
+        ret['comment'] = "The workgroup has been changed from '{0}' to '{1}'".format(current_workgroup.upper(), changed_workgroup.upper())
+        ret['changes'] = {'old', current_workgroup.upper(), 'new': changed_workgroup.upper()}
     else:
         ret['result'] = False
-        ret['comment'] = 'Unable to set the workgroup'
+        ret['comment'] = "Unable to join the requested workgroup '{0}'".format(changed_workgroup.upper())
 
     return ret
 

--- a/salt/states/win_system.py
+++ b/salt/states/win_system.py
@@ -217,7 +217,7 @@ def workgroup(name):
     elif res:
         ret['result'] = True
         ret['comment'] = "The workgroup has been changed from '{0}' to '{1}'".format(current_workgroup.upper(), changed_workgroup.upper())
-        ret['changes'] = {'old', current_workgroup.upper(), 'new': changed_workgroup.upper()}
+        ret['changes'] = {'old': current_workgroup.upper(), 'new': changed_workgroup.upper()}
     else:
         ret['result'] = False
         ret['comment'] = "Unable to join the requested workgroup '{0}'".format(changed_workgroup.upper())

--- a/salt/states/win_system.py
+++ b/salt/states/win_system.py
@@ -167,6 +167,40 @@ def hostname(name):
     return ret
 
 
+def workgroup(name):
+    '''
+    .. versionadded:: 2019.2.0
+
+    Manage the workgroup of the computer
+
+    name
+        The workgroup to set
+    '''
+    ret = {
+        'name': name.upper(),
+        'changes': {},
+        'result': True,
+        'comment': ''
+    }
+
+    current_workgroup = __salt__['system.get_domain_workgroup']()
+
+    if current_workgroup.upper() == name.upper():
+        ret['comment'] = "Workgroup is already set to '{0}'".format(name.upper())
+        return ret
+
+    out = __salt__['system.set_domain_workgroup'](name.upper())
+
+    if out:
+        ret['comment'] = "The workgroup has been changed from '{0}' to '{1}".format(current_workgroup.upper(), name.upper())
+        ret['changes'] = {'workgroup': name.upper()}
+    else:
+        ret['result'] = False
+        ret['comment'] = 'Unable to set the workgroup'
+
+    return ret
+
+
 def join_domain(name,
                 username=None,
                 password=None,

--- a/salt/states/win_system.py
+++ b/salt/states/win_system.py
@@ -194,6 +194,11 @@ def workgroup(name):
     res = __salt__['system.get_domain_workgroup']()
     current_workgroup = res['Domain'] if 'Domain' in res else res['Workgroup'] if 'Workgroup' in res else ''
 
+    if __opts__['test']:
+        ret['result'] = None
+        ret['comment'] = 'Computer will be joined to workgroup \'{0}\''.format(name)
+        return ret
+
     if current_workgroup.upper() == name.upper():
         ret['comment'] = "Workgroup is already set to '{0}'".format(name.upper())
         return ret

--- a/tests/unit/modules/test_win_system.py
+++ b/tests/unit/modules/test_win_system.py
@@ -60,6 +60,10 @@ class MockWMI_ComputerSystem(object):
     def Rename(Name):
         return Name == Name
 
+    @staticmethod
+    def JoinDomainOrWorkgroup(Name):
+        return [0]
+
 
 class MockWMI_OperatingSystem(object):
     '''
@@ -411,9 +415,32 @@ class WinSystemTestCase(TestCase, LoaderModuleMockMixin):
                 patch.object(wmi, 'WMI', Mock(return_value=self.WMI)):
             self.assertTrue(win_system.set_hostname("NEW"))
 
+    def test_get_domain_workgroup(self):
+        '''
+        Test get_domain_workgroup
+        '''
+        with patch('salt.utils', Mockwinapi), \
+                patch.object(wmi, 'WMI', Mock(return_value=self.WMI)), \
+                patch('salt.utils.winapi.Com', MagicMock()), \
+                patch.object(self.WMI, 'Win32_ComputerSystem',
+                             return_value=[MockWMI_ComputerSystem()]):
+            self.assertDictEqual(win_system.get_domain_workgroup(),
+                                 {'Workgroup': 'WORKGROUP'})
+
+    def test_set_domain_workgroup(self):
+        '''
+        Test set_domain_workgroup
+        '''
+        with patch('salt.utils', Mockwinapi), \
+                patch.object(wmi, 'WMI', Mock(return_value=self.WMI)), \
+                patch('salt.utils.winapi.Com', MagicMock()), \
+                patch.object(self.WMI, 'Win32_ComputerSystem',
+                          return_value=[MockWMI_ComputerSystem()]):
+            self.assertTrue(win_system.set_domain_workgroup('test'))
+
     def test_get_hostname(self):
         '''
-            Test setting a new hostname
+            Test getting a new hostname
         '''
         cmd_run_mock = MagicMock(return_value="MINION")
         with patch.dict(win_system.__salt__, {'cmd.run': cmd_run_mock}):

--- a/tests/unit/modules/test_win_system.py
+++ b/tests/unit/modules/test_win_system.py
@@ -14,21 +14,148 @@ from tests.support.unit import TestCase, skipIf
 from tests.support.mock import (
     MagicMock,
     patch,
+    Mock,
     NO_MOCK,
     NO_MOCK_REASON
 )
 
 # Import Salt Libs
 import salt.modules.win_system as win_system
+import salt.utils.stringutils
+
+try:
+    import wmi
+    HAS_WMI = True
+except ImportError:
+    HAS_WMI = False
+
+
+class MockWMI_ComputerSystem(object):
+    '''
+    Mock WMI Win32_ComputerSystem Class
+    '''
+    BootupState = 'Normal boot'
+    Caption = 'SALT SERVER'
+    ChassisBootupState = 3
+    ChassisSKUNumber = '3.14159'
+    DNSHostname = 'SALT SERVER'
+    Domain = 'WORKGROUP'
+    DomainRole = 2
+    Manufacturer = 'Dell Inc.'
+    Model = 'Dell 2980'
+    NetworkServerModeEnabled = True
+    PartOfDomain = False
+    PCSystemType = 4
+    PowerState = 0
+    Status = 'OK'
+    SystemType = 'x64-based PC'
+    TotalPhysicalMemory = 17078214656
+    ThermalState = 3
+    Workgroup = 'WORKGROUP'
+
+    def __init__(self):
+        pass
+
+    @staticmethod
+    def Rename(Name):
+        return Name == Name
+
+
+class MockWMI_OperatingSystem(object):
+    '''
+    Mock WMI Win32_OperatingSystem Class
+    '''
+    Description = 'Because salt goes EVERYWHERE'
+    InstallDate = '20110211131800'
+    LastBootUpTime = '19620612120000'
+    Manufacturer = 'Python'
+    Caption = 'Salty'
+    NumberOfUsers = 7530000000
+    Organization = 'SaltStack'
+    OSArchitecture = 'Windows'
+    Primary = True
+    ProductType = 3
+    RegisteredUser = 'thatch@saltstack.com'
+    SystemDirectory = 'C:\\Windows\\System32'
+    SystemDrive = 'C:\\'
+    Version = '10.0.17763'
+    WindowsDirectory = 'C:\\Windows'
+
+    def __init__(self):
+        pass
+
+
+class MockWMI_Processor(object):
+    '''
+    Mock WMI Win32_Processor Class
+    '''
+    Manufacturer = 'Intel'
+    MaxClockSpeed = 2301
+    NumberOfLogicalProcessors = 8
+    NumberOfCores = 4
+    NumberOfEnabledCore = 4
+
+    def __init__(self):
+        pass
+
+
+class MockWMI_BIOS(object):
+    '''
+    Mock WMI Win32_BIOS Class
+    '''
+    SerialNumber = 'SALTY2011'
+    Manufacturer = 'Dell Inc.'
+    Version = 'DELL - 10283849'
+    Caption = 'A12'
+    BIOSVersion = [Version, Caption, 'ASUS - 3948D']
+    Description = Caption
+
+    def __init__(self):
+        pass
+
+
+class Mockwinapi(object):
+    '''
+    Mock winapi class
+    '''
+    def __init__(self):
+        pass
+
+    class winapi(object):
+        '''
+        Mock winapi class
+        '''
+        def __init__(self):
+            pass
+
+        @staticmethod
+        def Com():
+            '''
+            Mock Com method
+            '''
+            return True
 
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
+@skipIf(not HAS_WMI, 'WMI only available on Windows')
 class WinSystemTestCase(TestCase, LoaderModuleMockMixin):
     '''
         Test cases for salt.modules.win_system
     '''
     def setup_loader_modules(self):
         modules_globals = {}
+        # wmi and pythoncom modules are platform specific...
+        mock_pythoncom = types.ModuleType(
+            salt.utils.stringutils.to_str('pythoncom')
+        )
+        sys_modules_patcher = patch.dict('sys.modules',
+                                         {'pythoncom': mock_pythoncom})
+        sys_modules_patcher.start()
+        self.addCleanup(sys_modules_patcher.stop)
+        self.WMI = Mock()
+        self.addCleanup(delattr, self, 'WMI')
+        modules_globals['wmi'] = wmi
+
         if win_system.HAS_WIN32NET_MODS is False:
             win32api = types.ModuleType(
                 str('win32api')  # future lint: disable=blacklisted-function
@@ -38,6 +165,7 @@ class WinSystemTestCase(TestCase, LoaderModuleMockMixin):
                                                             now.day, now.hour, now.minute,
                                                             now.second, now.microsecond])
             modules_globals['win32api'] = win32api
+
         return {win_system: modules_globals}
 
     def test_halt(self):
@@ -181,10 +309,9 @@ class WinSystemTestCase(TestCase, LoaderModuleMockMixin):
         with patch.dict(win_system.__salt__, {'cmd.run': mock}):
             mock = MagicMock(return_value="Salt's comp")
             with patch.object(win_system, 'get_computer_desc', mock):
-                self.assertDictEqual(win_system.set_computer_desc(
-                                                                  "Salt's comp"
-                                                                  ),
-                                     {'Computer Description': "Salt's comp"})
+                self.assertDictEqual(
+                    win_system.set_computer_desc("Salt's comp"),
+                    {'Computer Description': "Salt's comp"})
 
     @skipIf(not win_system.HAS_WIN32NET_MODS, 'Missing win32 libraries')
     def test_get_computer_desc(self):
@@ -277,13 +404,12 @@ class WinSystemTestCase(TestCase, LoaderModuleMockMixin):
         '''
             Test setting a new hostname
         '''
-        cmd_run_mock = MagicMock(return_value="Method execution successful.")
-        get_hostname = MagicMock(return_value="MINION")
-        with patch.dict(win_system.__salt__, {'cmd.run': cmd_run_mock}):
-            with patch.object(win_system, 'get_hostname', get_hostname):
-                win_system.set_hostname("NEW")
-
-        cmd_run_mock.assert_called_once_with(cmd="wmic computersystem where name='MINION' call rename name='NEW'")
+        with patch('salt.utils', Mockwinapi), \
+                patch('salt.utils.winapi.Com', MagicMock()), \
+                patch.object(self.WMI, 'Win32_ComputerSystem',
+                             return_value=[MockWMI_ComputerSystem()]), \
+                patch.object(wmi, 'WMI', Mock(return_value=self.WMI)):
+            self.assertTrue(win_system.set_hostname("NEW"))
 
     def test_get_hostname(self):
         '''
@@ -314,7 +440,19 @@ class WinSystemTestCase(TestCase, LoaderModuleMockMixin):
                   'thermal_state', 'total_physical_memory',
                   'total_physical_memory_raw', 'users', 'windows_directory',
                   'workgroup']
-        ret = win_system.get_system_info()
+        with patch('salt.utils', Mockwinapi), \
+                patch('salt.utils.winapi.Com', MagicMock()), \
+                patch.object(self.WMI, 'Win32_OperatingSystem',
+                             return_value=[MockWMI_OperatingSystem()]), \
+                patch.object(self.WMI, 'Win32_ComputerSystem',
+                             return_value=[MockWMI_ComputerSystem()]), \
+                patch.object(self.WMI, 'Win32_Processor',
+                             return_value=[MockWMI_Processor(),
+                                           MockWMI_Processor()]), \
+                patch.object(self.WMI, 'Win32_BIOS',
+                             return_value=[MockWMI_BIOS()]), \
+                patch.object(wmi, 'WMI', Mock(return_value=self.WMI)):
+            ret = win_system.get_system_info()
         # Make sure all the fields are in the return
         for field in fields:
             self.assertIn(field, ret)


### PR DESCRIPTION
### What does this PR do?
This adds an implementation of `set_domain_workgroup()` to `salt.modules.win_system`. The `salt.modules.win_system` module includes an implementation of `get_domain_workgroup()`, but nothing in the form of actually setting it (other than joining an AD domain which has differing semantics). This was done using the COM api for WMI similar to other functions defined within the module.

The `set_hostname()` function was also updated to use the COM api as before it was using salt.cmd to execute `wmic` to set the name. On top of these additions, a new state function was added to `salt.states.win_system`  as `workgroup()` which allows one to manage the workgroup of a windows machine in the same way as the "hostname" and "computer_name".

### Previous Behavior
There was no way to set the workgroup for a windows machine.

### New Behavior
Now it's possible to set the workgroup for a windows machine via the module, or using the state to manage the workgroup. This adds to `salt.states.win_system` and `salt.modules.win_system`.