### PR TITLE
imgadm module should deal with invalid images better

### DIFF
--- a/salt/modules/smartos_imgadm.py
+++ b/salt/modules/smartos_imgadm.py
@@ -56,7 +56,7 @@ def _parse_image_meta(image=None, detail=False):
 
     if image and 'Error' in image:
         ret = image
-    elif image:
+    elif image and 'manifest' in image:
         name = image['manifest']['name']
         version = image['manifest']['version']
         os = image['manifest']['os']
@@ -164,6 +164,8 @@ def docker_to_uuid(uuid):
     if _is_docker_uuid(uuid):
         images = list_installed(verbose=True)
         for image_uuid in images:
+            if 'name' not in images[image_uuid]:
+                continue
             if images[image_uuid]['name'] == uuid:
                 return image_uuid
     return None


### PR DESCRIPTION
### What does this PR do?
images should always have a manifest and name tag, but it looks like it is possible to encouter some in the wild that do not have those fields. This PR ensure we do not simple hard fail on those and throw and Exception.

### What issues does this PR fix or reference?
#51351
#51503 (works for me with this applied)

### Previous Behavior
Exception was thrown

### New Behavior
We return `None` ... well technically
{uuid-here: None}

### Tests written?
No

### Commits signed with GPG?
No