### PR TITLE
Make binary data output possible

### DIFF
--- a/salt/output/nested.py
+++ b/salt/output/nested.py
@@ -125,9 +125,19 @@ class NestDisplay(object):
         elif isinstance(ret, six.string_types):
             first_line = True
             for line in ret.splitlines():
+                line_prefix = ' ' * len(prefix) if not first_line else prefix
+                if isinstance(line, bytes):
+                    out.append(
+                        self.ustring(
+                            indent,
+                            self.YELLOW,
+                            'Not string data',
+                            prefix=line_prefix
+                        )
+                    )
+                    break
                 if self.strip_colors:
                     line = salt.output.strip_esc_sequence(line)
-                line_prefix = ' ' * len(prefix) if not first_line else prefix
                 out.append(
                     self.ustring(
                         indent,


### PR DESCRIPTION
If for example a pillar contains binary data it's possible that it won't
be possible to print it when doing e.g pillar.items:

`File "/usr/lib/python3/dist-packages/salt/output/__init__.py", line 232, in strip_esc_sequence
    return txt.replace('\033', '?')
TypeError: a bytes-like object is required, not 'str'`

Replace non-printable data during output with a message instead.

### What does this PR do?

We noticed that when we had binary data in our pillars, certain functions could not print the output. Also it wouldn't look very good printing big binary files that you have in your pillars. We haven't found any other way of doing this differently so here is a PR that solves this problem. Instead of trying to print the binary data, it will print a message instead.

When looking at the code you would think that in this passage it would be a string, because we are checking against "six.string_types". But this variable is set from type "Str" to a Tuple of the form: "(<class 'str'>, <class 'bytes'>)". I was not able to follow the runtime code fully, but it looks like the six.string_types is changed somewhere in the salt cli code. I'm very new to Saltstack so maybe all this is known things and intended behaviour.

### What issues does this PR fix or reference?

None that I've seen.

### Previous Behavior
Pillars containing binary data would make the pillar.items or other Salt output call to fail.

### New Behavior
Output with binary data would be replaced with a message.

### Tests written?

No

### Commits signed with GPG?

No