### PR TITLE
Backport proxy fixes to 2018.3

### DIFF
--- a/tests/integration/netapi/rest_tornado/test_app.py
+++ b/tests/integration/netapi/rest_tornado/test_app.py
@@ -100,6 +100,11 @@ class TestSaltAPIHandler(_SaltnadoIntegrationTestCase):
                               )
         response_obj = salt.utils.json.loads(response.body)
         self.assertEqual(len(response_obj['return']), 1)
+        # If --proxy is set, it will cause an extra minion_id to be in the
+        # response. Since there's not a great way to know if the test
+        # runner's proxy minion is running, and we're not testing proxy
+        # minions here anyway, just remove it from the response.
+        response_obj['return'][0].pop('proxytest', None)
         self.assertEqual(response_obj['return'][0], {'minion': True, 'sub_minion': True})
 
     def test_simple_local_post_no_tgt(self):
@@ -142,6 +147,11 @@ class TestSaltAPIHandler(_SaltnadoIntegrationTestCase):
                               )
         response_obj = salt.utils.json.loads(response.body)
         self.assertEqual(len(response_obj['return']), 1)
+        # If --proxy is set, it will cause an extra minion_id to be in the
+        # response. Since there's not a great way to know if the test
+        # runner's proxy minion is running, and we're not testing proxy
+        # minions here anyway, just remove it from the response.
+        response_obj['return'][0].pop('proxytest', None)
         self.assertEqual(response_obj['return'][0], {'minion': True, 'sub_minion': True})
 
     def test_simple_local_post_invalid_request(self):
@@ -175,6 +185,14 @@ class TestSaltAPIHandler(_SaltnadoIntegrationTestCase):
         response_obj = salt.utils.json.loads(response.body)
         ret = response_obj['return']
         ret[0]['minions'] = sorted(ret[0]['minions'])
+        try:
+            # If --proxy is set, it will cause an extra minion_id to be in the
+            # response. Since there's not a great way to know if the test
+            # runner's proxy minion is running, and we're not testing proxy
+            # minions here anyway, just remove it from the response.
+            ret[0]['minions'].remove('proxytest')
+        except ValueError:
+            pass
 
         # TODO: verify pub function? Maybe look at how we test the publisher
         self.assertEqual(len(ret), 1)
@@ -201,6 +219,15 @@ class TestSaltAPIHandler(_SaltnadoIntegrationTestCase):
         ret = response_obj['return']
         ret[0]['minions'] = sorted(ret[0]['minions'])
         ret[1]['minions'] = sorted(ret[1]['minions'])
+        try:
+            # If --proxy is set, it will cause an extra minion_id to be in the
+            # response. Since there's not a great way to know if the test
+            # runner's proxy minion is running, and we're not testing proxy
+            # minions here anyway, just remove it from the response.
+            ret[0]['minions'].remove('proxytest')
+            ret[1]['minions'].remove('proxytest')
+        except ValueError:
+            pass
 
         self.assertEqual(len(ret), 2)
         self.assertIn('jid', ret[0])
@@ -235,6 +262,15 @@ class TestSaltAPIHandler(_SaltnadoIntegrationTestCase):
         ret = response_obj['return']
         ret[0]['minions'] = sorted(ret[0]['minions'])
         ret[1]['minions'] = sorted(ret[1]['minions'])
+        try:
+            # If --proxy is set, it will cause an extra minion_id to be in the
+            # response. Since there's not a great way to know if the test
+            # runner's proxy minion is running, and we're not testing proxy
+            # minions here anyway, just remove it from the response.
+            ret[0]['minions'].remove('proxytest')
+            ret[1]['minions'].remove('proxytest')
+        except ValueError:
+            pass
 
         self.assertEqual(len(ret), 3)  # make sure we got 3 responses
         self.assertIn('jid', ret[0])  # the first 2 are regular returns
@@ -279,9 +315,13 @@ class TestSaltAPIHandler(_SaltnadoIntegrationTestCase):
                               request_timeout=30,
                               )
         response_obj = salt.utils.json.loads(response.body)
-
         self.application.opts['order_masters'] = []
         self.application.opts['syndic_wait'] = 5
+        # If --proxy is set, it will cause an extra minion_id to be in the
+        # response. Since there's not a great way to know if the test runner's
+        # proxy minion is running, and we're not testing proxy minions here
+        # anyway, just remove it from the response.
+        response_obj[0]['return'].pop('proxytest', None)
         self.assertEqual(response_obj['return'], [{'minion': True, 'sub_minion': True}])
 
     # runner tests
@@ -299,7 +339,15 @@ class TestSaltAPIHandler(_SaltnadoIntegrationTestCase):
                               )
         response_obj = salt.utils.json.loads(response.body)
         self.assertEqual(len(response_obj['return']), 1)
-        self.assertEqual(set(response_obj['return'][0]), set(['minion', 'sub_minion']))
+        try:
+            # If --proxy is set, it will cause an extra minion_id to be in the
+            # response. Since there's not a great way to know if the test
+            # runner's proxy minion is running, and we're not testing proxy
+            # minions here anyway, just remove it from the response.
+            response_obj['return'][0].remove('proxytest')
+        except ValueError:
+            pass
+        self.assertEqual(sorted(response_obj['return'][0]), sorted(['minion', 'sub_minion']))
 
     # runner_async tests
     def test_simple_local_runner_async_post(self):

--- a/tests/integration/netapi/test_client.py
+++ b/tests/integration/netapi/test_client.py
@@ -36,6 +36,11 @@ class NetapiClientTest(TestCase):
         low.update(self.eauth_creds)
 
         ret = self.netapi.run(low)
+        # If --proxy is set, it will cause an extra minion_id to be in the
+        # response. Since there's not a great way to know if the test
+        # runner's proxy minion is running, and we're not testing proxy
+        # minions here anyway, just remove it from the response.
+        ret.pop('proxytest', None)
         self.assertEqual(ret, {'minion': True, 'sub_minion': True})
 
     def test_local_batch(self):
@@ -59,6 +64,14 @@ class NetapiClientTest(TestCase):
         self.assertIn('jid', ret)
         ret.pop('jid', None)
         ret['minions'] = sorted(ret['minions'])
+        try:
+            # If --proxy is set, it will cause an extra minion_id to be in the
+            # response. Since there's not a great way to know if the test
+            # runner's proxy minion is running, and we're not testing proxy
+            # minions here anyway, just remove it from the response.
+            ret['minions'].remove('proxytest')
+        except ValueError:
+            pass
         self.assertEqual(ret, {'minions': sorted(['minion', 'sub_minion'])})
 
     def test_wheel(self):


### PR DESCRIPTION
These issues were discovered while working on PR #51204, and would affect either Salt, the test suite, or both, when the proxy service is running.