### PR TITLE
Move deprecation warning after logging starts up

### DIFF
--- a/salt/scripts.py
+++ b/salt/scripts.py
@@ -20,6 +20,7 @@ from random import randint
 # Import salt libs
 from salt.exceptions import SaltSystemExit, SaltClientError, SaltReqTimeoutError
 import salt.defaults.exitcodes  # pylint: disable=unused-import
+import salt.ext.six as six
 
 log = logging.getLogger(__name__)
 
@@ -93,6 +94,16 @@ def salt_master():
     Start the salt master.
     '''
     import salt.cli.daemons
+# REMOVEME after Python 2.7 support is dropped (also the six import)
+    if six.PY2:
+        from salt.utils.versions import warn_until
+        # Message borrowed from pip's deprecation warning
+        warn_until('Sodium',
+                   'Python 2.7 will reach the end of its life on January 1st,'
+                   ' 2020. Please upgrade your Python as Python 2.7 won\'t be'
+                   ' maintained after that date.  Salt will drop support for'
+                   ' Python 2.7 in the Sodium release or later.')
+# END REMOVEME
     master = salt.cli.daemons.Master()
     master.start()
 
@@ -179,6 +190,16 @@ def salt_minion():
         minion = salt.cli.daemons.Minion()
         minion.start()
         return
+# REMOVEME after Python 2.7 support is dropped (also the six import)
+    elif six.PY2:
+        from salt.utils.versions import warn_until
+        # Message borrowed from pip's deprecation warning
+        warn_until('Sodium',
+                   'Python 2.7 will reach the end of its life on January 1st,'
+                   ' 2020. Please upgrade your Python as Python 2.7 won\'t be'
+                   ' maintained after that date.  Salt will drop support for'
+                   ' Python 2.7 in the Sodium release or later.')
+# END REMOVEME
 
     if '--disable-keepalive' in sys.argv:
         sys.argv.remove('--disable-keepalive')

--- a/scripts/salt-master
+++ b/scripts/salt-master
@@ -3,11 +3,8 @@
 Start the salt-master
 '''
 
-import salt.ext.six as six
 import salt.utils.platform
 from salt.scripts import salt_master
-
-
 
 
 if __name__ == '__main__':
@@ -22,14 +19,4 @@ if __name__ == '__main__':
         cfile = os.path.splitext(__file__)[0] + '.pyc'
         if not os.path.exists(cfile):
             py_compile.compile(__file__, cfile)
-# REMOVEME after Python 2.7 support is dropped (also the six import)
-    elif six.PY2:
-        from salt.utils.versions import warn_until
-        # Message borrowed from pip's deprecation warning
-        warn_until('Sodium',
-                   'Python 2.7 will reach the end of its life on January 1st,'
-                   ' 2020. Please upgrade your Python as Python 2.7 won\'t be'
-                   ' maintained after that date.  Salt will drop support for'
-                   ' Python 2.7 in the Sodium release or later.')
-# END REMOVEME
     salt_master()

--- a/scripts/salt-minion
+++ b/scripts/salt-minion
@@ -3,7 +3,6 @@
 This script is used to kick off a salt minion daemon
 '''
 
-import salt.ext.six as six
 import salt.utils.platform
 from salt.scripts import salt_minion
 from multiprocessing import freeze_support
@@ -21,16 +20,6 @@ if __name__ == '__main__':
         cfile = os.path.splitext(__file__)[0] + '.pyc'
         if not os.path.exists(cfile):
             py_compile.compile(__file__, cfile)
-# REMOVEME after Python 2.7 support is dropped (also the six import)
-    elif six.PY2:
-        from salt.utils.versions import warn_until
-        # Message borrowed from pip's deprecation warning
-        warn_until('Sodium',
-                   'Python 2.7 will reach the end of its life on January 1st,'
-                   ' 2020. Please upgrade your Python as Python 2.7 won\'t be'
-                   ' maintained after that date.  Salt will drop support for'
-                   ' Python 2.7 in the Sodium release or later.')
-# END REMOVEME
     # This handles the bootstrapping code that is included with frozen
     # scripts. It is a no-op on unfrozen code.
     freeze_support()


### PR DESCRIPTION
### What does this PR do?

*actually* displays the warning on the command line 😝 

### Previous Behavior

Warn was called, just was apparently in the wrong place to print out, so it didn't print the warning

### New Behavior

On `salt-minion` and `salt-master` the warning gets printed

### Tests written?

No - checked manually

### Commits signed with GPG?

Yes