### PR TITLE
Use gems.github.com no longer exists, use gemcutter.org

### DIFF
--- a/tests/integration/modules/test_gem.py
+++ b/tests/integration/modules/test_gem.py
@@ -110,7 +110,7 @@ class GemModuleTest(ModuleCase):
         gem.sources_add
         gem.sources_remove
         '''
-        source = 'http://gems.github.com'
+        source = 'http://gemcutter.org/'
 
         self.run_function('gem.sources_add', [source])
         sources_list = self.run_function('gem.sources_list')


### PR DESCRIPTION
### What does this PR do?

Switch test from `gems.github.com` to `gemcutter.org` because `gems.github.com` returns a 404.

### What issues does this PR fix or reference?

https://github.com/saltstack/salt-jenkins/issues/1266

### Tests written?

No - Fixing test

### Commits signed with GPG?

Yes