### PR TITLE
Add testing path to run_script commands [2018.3]

### DIFF
--- a/tests/support/case.py
+++ b/tests/support/case.py
@@ -267,9 +267,15 @@ class ShellTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
         script_path = self.get_script_path(script)
         if not os.path.isfile(script_path):
             return False
+        popen_kwargs = popen_kwargs or {}
 
         if salt.utils.platform.is_windows():
             cmd = 'python '
+            if 'cwd' not in popen_kwargs:
+                popen_kwargs['cwd'] = os.getcwd()
+            if 'env' not in popen_kwargs:
+                popen_kwargs['env'] = os.environ.copy()
+                popen_kwargs['env'][b'PYTHONPATH'] = os.getcwd().encode()
         else:
             cmd = 'PYTHONPATH='
             python_path = os.environ.get('PYTHONPATH', None)
@@ -286,7 +292,6 @@ class ShellTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
 
         tmp_file = tempfile.SpooledTemporaryFile()
 
-        popen_kwargs = popen_kwargs or {}
         popen_kwargs = dict({
             'shell': True,
             'stdout': tmp_file,


### PR DESCRIPTION
### What does this PR do?

Fix failing Windows tests that use `ShellCase.run_script`.

https://jenkinsci.saltstack.com/job/pr-kitchen-windows2016-py3/job/PR-51366/2/testReport/junit/integration.shell.test_cloud/SaltCloudCliTest/test_function_arguments/

### Tests written?

No - Fixing existing tests

### Commits signed with GPG?

Yes