### PR TITLE
Add testing path to run_script commands

### DIFF
--- a/tests/support/case.py
+++ b/tests/support/case.py
@@ -243,9 +243,15 @@ class ShellTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
         script_path = self.get_script_path(script)
         if not os.path.isfile(script_path):
             return False
+        popen_kwargs = popen_kwargs or {}
 
         if salt.utils.is_windows():
             cmd = 'python '
+            if 'cwd' not in popen_kwargs:
+                popen_kwargs['cwd'] = os.getcwd()
+            if 'env' not in popen_kwargs:
+                popen_kwargs['env'] = os.environ.copy()
+                popen_kwargs['env'][b'PYTHONPATH'] = os.getcwd().encode()
         else:
             cmd = 'PYTHONPATH='
             python_path = os.environ.get('PYTHONPATH', None)
@@ -262,7 +268,6 @@ class ShellTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
 
         tmp_file = tempfile.SpooledTemporaryFile()
 
-        popen_kwargs = popen_kwargs or {}
         popen_kwargs = dict({
             'shell': True,
             'stdout': tmp_file,


### PR DESCRIPTION
### What does this PR do?

Cherry-pick run_script test fix.

Fixes https://github.com/saltstack/salt-jenkins/issues/1271

https://jenkinsci.saltstack.com/job/pr-kitchen-windows2016-py2/job/PR-51397/1/testReport/junit/integration.cli.test_batch/BatchTest/test_batch_exit_code/

### Tests written?

No - Fixing existing tests

### Commits signed with GPG?

Yes