### PR TITLE
parted: fix _validate_partition_boundary

### DIFF
--- a/salt/modules/parted.py
+++ b/salt/modules/parted.py
@@ -19,6 +19,7 @@ from __future__ import absolute_import, unicode_literals, print_function
 
 # Import python libs
 import os
+import re
 import stat
 import string
 import logging
@@ -91,15 +92,15 @@ def _validate_partition_boundary(boundary):
     '''
     Ensure valid partition boundaries are supplied.
     '''
-    try:
-        for unit in VALID_UNITS:
-            if six.text_type(boundary).endswith(unit):
-                return
-        int(boundary)
-    except Exception:
-        raise CommandExecutionError(
-            'Invalid partition boundary passed: "{0}"'.format(boundary)
-        )
+    boundary = six.text_type(boundary)
+    match = re.search(r'^([\d.]+)(\D*)$', boundary)
+    if match:
+        unit = match.group(2)
+        if not unit or unit in VALID_UNITS:
+            return
+    raise CommandExecutionError(
+        'Invalid partition boundary passed: "{0}"'.format(boundary)
+    )
 
 
 def probe(*devices):


### PR DESCRIPTION
The current partition boundary validator checks that one of the
valid units is a suffix of the boundary, and if so consider it
a valid one. This validation have two problems:

* We can miss the numerical part of the boundary

  e.g: 's' or 'MB' will be valid units

* The unit provided can be invalid

  e.g: '10as', '1okB'

The current validator make sure that there is a valid number
and a valid unit in the boundary.

(cherry picked from commit 9e5a0fe67688d83c38a7d5e7be32888ef4504313)

