### PR TITLE
service: SUSE is not based on sysvinit anymore

### DIFF
--- a/salt/modules/service.py
+++ b/salt/modules/service.py
@@ -41,6 +41,7 @@ def __virtual__():
         'elementary OS',
         'McAfee  OS Server',
         'Raspbian',
+        'SUSE',
     ))
     if __grains__.get('os') in disable:
         return (False, 'Your OS is on the disabled list')


### PR DESCRIPTION
openSUSE and SLE are systemd based distributions

(cherry picked from commit dd1ec387bb34c72db9a3241c4c345743a75439ef)

