### PR TITLE
file: update attributes for lsattr and chattr

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -577,7 +577,7 @@ def lsattr(path):
     for line in result.splitlines():
         if not line.startswith('lsattr: '):
             vals = line.split(None, 1)
-            results[vals[1]] = re.findall(r"[acdijstuADST]", vals[0])
+            results[vals[1]] = re.findall(r"[aAcCdDeijPsStTu]", vals[0])
 
     return results
 
@@ -594,8 +594,8 @@ def chattr(*files, **kwargs):
         should be added or removed from files
 
     attributes
-        One or more of the following characters: ``acdijstuADST``, representing
-        attributes to add to/remove from files
+        One or more of the following characters: ``aAcCdDeijPsStTu``,
+        representing attributes to add to/remove from files
 
     version
         a version number to assign to the file(s)
@@ -620,7 +620,7 @@ def chattr(*files, **kwargs):
         raise SaltInvocationError(
             "Need an operator: 'add' or 'remove' to modify attributes.")
     if attributes is None:
-        raise SaltInvocationError("Need attributes: [AacDdijsTtSu]")
+        raise SaltInvocationError("Need attributes: [aAcCdDeijPsStTu]")
 
     cmd = ['chattr']
 

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -2116,7 +2116,7 @@ def managed(name,
     attrs
         The attributes to have on this file, e.g. ``a``, ``i``. The attributes
         can be any or a combination of the following characters:
-        ``acdijstuADST``.
+        ``aAcCdDeijPsStTu``.
 
         .. note::
             This option is **not** supported on Windows.

--- a/salt/states/netconfig.py
+++ b/salt/states/netconfig.py
@@ -303,7 +303,7 @@ def saved(name,
     attrs
         The attributes to have on this file, e.g. ``a``, ``i``. The attributes
         can be any or a combination of the following characters:
-        ``acdijstuADST``.
+        ``aAcCdDeijPsStTu``.
 
         .. note::
             This option is **not** supported on Windows.


### PR DESCRIPTION
### What does this PR do?

Update the different attributes that chattr and lsattr can understand. This include new attributes like C, that can disable the copy on write for btrfs subvolumes.

### Tests written?

No, the current ones cover the same case.

(cherry picked from commit 1be76ec2915a18f82a17198da3852fe5d6a66ced)

