### PR TITLE
Add disk_set and disk_toggle functions, and update valid partition flags

### DIFF
--- a/salt/modules/parted.py
+++ b/salt/modules/parted.py
@@ -43,6 +43,9 @@ __func_alias__ = {
 VALID_UNITS = set(['s', 'B', 'kB', 'MB', 'MiB', 'GB', 'GiB', 'TB', 'TiB', '%',
                    'cyl', 'chs', 'compact'])
 
+VALID_DISK_FLAGS = set(['cylinder_alignment', 'pmbr_boot',
+                        'implicit_partition_table'])
+
 
 def __virtual__():
     '''
@@ -684,6 +687,60 @@ def toggle(device, partition, flag):
         raise CommandExecutionError('Invalid flag passed to partition.toggle')
 
     cmd = 'parted -m -s {0} toggle {1} {2}'.format(device, partition, flag)
+    out = __salt__['cmd.run'](cmd).splitlines()
+    return out
+
+
+def disk_set(device, flag, state):
+    '''
+    Changes a flag on selected device.
+
+    A flag can be either "on" or "off" (make sure to use proper
+    quoting, see :ref:`YAML Idiosyncrasies
+    <yaml-idiosyncrasies>`). Some or all of these flags will be
+    available, depending on what disk label you are using.
+
+    Valid flags are:
+      * cylinder_alignment
+      * pmbr_boot
+      * implicit_partition_table
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' partition.disk_set /dev/sda pmbr_boot '"on"'
+    '''
+    _validate_device(device)
+
+    if flag not in VALID_DISK_FLAGS:
+        raise CommandExecutionError('Invalid flag passed to partition.disk_set')
+
+    if state not in set(['on', 'off']):
+        raise CommandExecutionError('Invalid state passed to partition.disk_set')
+
+    cmd = ['parted', '-m', '-s', device, 'disk_set', flag, state]
+    out = __salt__['cmd.run'](cmd).splitlines()
+    return out
+
+
+def disk_toggle(device, flag):
+    '''
+    Toggle the state of <flag> on <device>. Valid flags are the same
+    as the disk_set command.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' partition.disk_toggle /dev/sda pmbr_boot
+    '''
+    _validate_device(device)
+
+    if flag not in VALID_DISK_FLAGS:
+        raise CommandExecutionError('Invalid flag passed to partition.disk_toggle')
+
+    cmd = ['parted', '-m', '-s', device, 'disk_toggle', flag]
     out = __salt__['cmd.run'](cmd).splitlines()
     return out
 

--- a/salt/modules/parted.py
+++ b/salt/modules/parted.py
@@ -46,6 +46,12 @@ VALID_UNITS = set(['s', 'B', 'kB', 'MB', 'MiB', 'GB', 'GiB', 'TB', 'TiB', '%',
 VALID_DISK_FLAGS = set(['cylinder_alignment', 'pmbr_boot',
                         'implicit_partition_table'])
 
+VALID_PARTITION_FLAGS = set(['boot', 'root', 'swap', 'hidden', 'raid',
+                             'lvm', 'lba', 'hp-service', 'palo',
+                             'prep', 'msftres', 'bios_grub', 'atvrecv',
+                             'diag', 'legacy_boot', 'msftdata', 'irst',
+                             'esp', 'type'])
+
 
 def __virtual__():
     '''
@@ -632,8 +638,25 @@ def set_(device, minor, flag, state):
     :ref:`YAML Idiosyncrasies <yaml-idiosyncrasies>`). Some or all of these
     flags will be available, depending on what disk label you are using.
 
-    Valid flags are: bios_grub, legacy_boot, boot, lba, root, swap, hidden, raid,
-        LVM, PALO, PREP, DIAG
+    Valid flags are:
+      * boot
+      * root
+      * swap
+      * hidden
+      * raid
+      * lvm
+      * lba
+      * hp-service
+      * palo
+      * prep
+      * msftres
+      * bios_grub
+      * atvrecv
+      * diag
+      * legacy_boot
+      * msftdata
+      * irst
+      * esp type
 
     CLI Example:
 
@@ -650,8 +673,7 @@ def set_(device, minor, flag, state):
             'Invalid minor number passed to partition.set'
         )
 
-    if flag not in set(['bios_grub', 'legacy_boot', 'boot', 'lba', 'root',
-                        'swap', 'hidden', 'raid', 'LVM', 'PALO', 'PREP', 'DIAG']):
+    if flag not in VALID_PARTITION_FLAGS:
         raise CommandExecutionError('Invalid flag passed to partition.set')
 
     if state not in set(['on', 'off']):
@@ -682,8 +704,7 @@ def toggle(device, partition, flag):
             'Invalid partition number passed to partition.toggle'
         )
 
-    if flag not in set(['bios_grub', 'legacy_boot', 'boot', 'lba', 'root',
-                        'swap', 'hidden', 'raid', 'LVM', 'PALO', 'PREP', 'DIAG']):
+    if flag not in VALID_PARTITION_FLAGS:
         raise CommandExecutionError('Invalid flag passed to partition.toggle')
 
     cmd = 'parted -m -s {0} toggle {1} {2}'.format(device, partition, flag)

--- a/tests/unit/modules/test_parted.py
+++ b/tests/unit/modules/test_parted.py
@@ -335,3 +335,20 @@ class PartedTestCase(TestCase, LoaderModuleMockMixin):
                 }
             }
             self.assertEqual(output, expected)
+
+    def test_disk_set(self):
+        with patch('salt.modules.parted._validate_device', MagicMock()):
+            self.cmdrun.return_value = ''
+            output = parted.disk_set('/dev/sda', 'pmbr_boot', 'on')
+            self.cmdrun.assert_called_once_with(
+                ['parted', '-m', '-s', '/dev/sda', 'disk_set',
+                 'pmbr_boot', 'on'])
+            assert output == []
+
+    def test_disk_toggle(self):
+        with patch('salt.modules.parted._validate_device', MagicMock()):
+            self.cmdrun.return_value = ''
+            output = parted.disk_toggle('/dev/sda', 'pmbr_boot')
+            self.cmdrun.assert_called_once_with(
+                ['parted', '-m', '-s', '/dev/sda', 'disk_toggle', 'pmbr_boot'])
+            assert output == []


### PR DESCRIPTION
### What does this PR do?

* Add disk_set and disk_toggle parted functions
* Update the list of valid flags for partitions, based on parted 3.2

### Tests written?

Yes, for the new code

(backported from #50834)