### PR TITLE
cmdmod: add sysfs into the chroot

### DIFF
--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -3035,12 +3035,16 @@ def run_chroot(root,
     '''
     __salt__['mount.mount'](
         os.path.join(root, 'dev'),
-        'udev',
+        'devtmpfs',
         fstype='devtmpfs')
     __salt__['mount.mount'](
         os.path.join(root, 'proc'),
         'proc',
         fstype='proc')
+    __salt__['mount.mount'](
+        os.path.join(root, 'sys'),
+        'sysfs',
+        fstype='sysfs')
 
     # Execute chroot routine
     sh_ = '/bin/sh'
@@ -3092,6 +3096,7 @@ def run_chroot(root,
         log.error('Processes running in chroot could not be killed, '
                   'filesystem will remain mounted')
 
+    __salt__['mount.umount'](os.path.join(root, 'sys'))
     __salt__['mount.umount'](os.path.join(root, 'proc'))
     __salt__['mount.umount'](os.path.join(root, 'dev'))
     if hide_output:


### PR DESCRIPTION
Some commands executed inside the chroot require access to the /sys
information. For example, /sys/firmware is used to get to information
from UEFI systems.

This patch mount a sysfs file system inside the chroot.

Also normalize the name for devtmpfs, replacing the old udev one.

(cherry picked from commit 2b5d45ac9901881945d3ff552b32e78b1664662e)

