### PR TITLE
Allow loading executor modules from the fileserver

### DIFF
--- a/doc/topics/development/modules/index.rst
+++ b/doc/topics/development/modules/index.rst
@@ -73,7 +73,7 @@ Sync Via the saltutil Module
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The saltutil module has a number of functions that can be used to sync all
-or specific dynamic modules. The ``saltutil.sync_*`` 
+or specific dynamic modules. The ``saltutil.sync_*``
 :py:mod:`execution functions <salt.modules.saltutil>` and
 :py:mod:`runner functions <salt.runners.saltutil>` can be used to sync modules
 to minions and the master, respectively.
@@ -110,7 +110,7 @@ This is done via setuptools entry points:
     )
 
 Note that these are not synced from the Salt Master to the Minions. They must be
-installed indepdendently on each Minion.
+installed independently on each Minion.
 
 Module Types
 ============
@@ -129,7 +129,7 @@ Cache        ``salt.cache`` (:ref:`index <all-salt.cache>`)                   ``
 Cloud        ``salt.cloud.clouds`` (:ref:`index <all-salt.clouds>`)           ``clouds``                ``cloud_dirs``
 Engine       ``salt.engines`` (:ref:`index <engines>`)                        ``engines``               ``engines_dirs``
 Execution    ``salt.modules`` (:ref:`index <all-salt.modules>`)               ``modules``               ``module_dirs``
-Executor     ``salt.executors`` (:ref:`index <all-salt.executors>`)           ``executors`` [#no-fs]_   ``executor_dirs``
+Executor     ``salt.executors`` (:ref:`index <all-salt.executors>`)           ``executors``             ``executor_dirs``
 File Server  ``salt.fileserver`` (:ref:`index <file-server>`)                 ``fileserver``            ``fileserver_dirs``
 Grain        ``salt.grains`` (:ref:`index <all-salt.grains>`)                 ``grains``                ``grains_dirs``
 Log Handler  ``salt.log.handlers`` (:ref:`index <external-logging-handlers>`) ``log_handlers``          ``log_handlers_dirs``
@@ -395,7 +395,7 @@ the state system.
 Util
 ----
 
-Just utility modules to use with other modules via ``__utils__`` (see 
+Just utility modules to use with other modules via ``__utils__`` (see
 :ref:`Dunder Dictionaries <dunder-dictionaries>`).
 
 Wheel

--- a/salt/modules/saltutil.py
+++ b/salt/modules/saltutil.py
@@ -817,6 +817,45 @@ def sync_serializers(saltenv=None, refresh=True, extmod_whitelist=None, extmod_b
     return ret
 
 
+def sync_executors(saltenv=None, refresh=True, extmod_whitelist=None, extmod_blacklist=None):
+    '''
+    .. versionadded:: Neon
+
+    Sync executors from ``salt://_executors`` to the minion
+
+    saltenv
+        The fileserver environment from which to sync. To sync from more than
+        one environment, pass a comma-separated list.
+
+        If not passed, then all environments configured in the :ref:`top files
+        <states-top>` will be checked for executor modules to sync. If no top
+        files are found, then the ``base`` environment will be synced.
+
+    refresh : True
+        If ``True``, refresh the available execution modules on the minion.
+        This refresh will be performed even if no new serializer modules are
+        synced. Set to ``False`` to prevent this refresh.
+
+    extmod_whitelist : None
+        comma-seperated list of modules to sync
+
+    extmod_blacklist : None
+        comma-seperated list of modules to blacklist based on type
+
+    CLI Examples:
+
+    .. code-block:: bash
+
+        salt '*' saltutil.sync_executors
+        salt '*' saltutil.sync_executors saltenv=dev
+        salt '*' saltutil.sync_executors saltenv=base,dev
+    '''
+    ret = _sync('executors', saltenv, extmod_whitelist, extmod_blacklist)
+    if refresh:
+        refresh_modules()
+    return ret
+
+
 def list_extmods():
     '''
     .. versionadded:: 2017.7.0
@@ -986,6 +1025,7 @@ def sync_all(saltenv=None, refresh=True, extmod_whitelist=None, extmod_blacklist
     ret['thorium'] = sync_thorium(saltenv, False, extmod_whitelist, extmod_blacklist)
     ret['serializers'] = sync_serializers(saltenv, False, extmod_whitelist, extmod_blacklist)
     ret['matchers'] = sync_matchers(saltenv, False, extmod_whitelist, extmod_blacklist)
+    ret['executors'] = sync_executors(saltenv, False, extmod_whitelist, extmod_blacklist)
     if __opts__['file_client'] == 'local':
         ret['pillar'] = sync_pillar(saltenv, False, extmod_whitelist, extmod_blacklist)
     if refresh:

--- a/salt/states/saltutil.py
+++ b/salt/states/saltutil.py
@@ -129,6 +129,20 @@ def sync_engines(name, **kwargs):
     return _sync_single(name, "engines", **kwargs)
 
 
+def sync_executors(name, **kwargs):
+    '''
+    Performs the same task as saltutil.sync_executors module
+    See :mod:`saltutil module for full list of options <salt.modules.saltutil>`
+
+    .. code-block:: yaml
+
+        sync_everything:
+          saltutil.sync_executors:
+            - refresh: True
+    '''
+    return _sync_single(name, "executors", **kwargs)
+
+
 def sync_grains(name, **kwargs):
     '''
     Performs the same task as saltutil.sync_grains module

--- a/tests/integration/modules/test_saltutil.py
+++ b/tests/integration/modules/test_saltutil.py
@@ -107,7 +107,8 @@ class SaltUtilSyncModuleTest(ModuleCase):
                            'proxymodules': [],
                            'output': [],
                            'thorium': [],
-                           'serializers': []}
+                           'serializers': [],
+                           'executors': []}
         ret = self.run_function('saltutil.sync_all')
         self.assertEqual(ret, expected_return)
 
@@ -130,7 +131,8 @@ class SaltUtilSyncModuleTest(ModuleCase):
                            'proxymodules': [],
                            'output': [],
                            'thorium': [],
-                           'serializers': []}
+                           'serializers': [],
+                           'executors': []}
         ret = self.run_function('saltutil.sync_all', extmod_whitelist={'modules': ['salttest']})
         self.assertEqual(ret, expected_return)
 
@@ -156,7 +158,8 @@ class SaltUtilSyncModuleTest(ModuleCase):
                            'proxymodules': [],
                            'output': [],
                            'thorium': [],
-                           'serializers': []}
+                           'serializers': [],
+                           'executors': []}
         ret = self.run_function('saltutil.sync_all', extmod_blacklist={'modules': ['runtests_decorators']})
         self.assertEqual(ret, expected_return)
 
@@ -179,7 +182,8 @@ class SaltUtilSyncModuleTest(ModuleCase):
                            'proxymodules': [],
                            'output': [],
                            'thorium': [],
-                           'serializers': []}
+                           'serializers': [],
+                           'executors': []}
         ret = self.run_function('saltutil.sync_all', extmod_whitelist={'modules': ['runtests_decorators']},
                                 extmod_blacklist={'modules': ['runtests_decorators']})
         self.assertEqual(ret, expected_return)

--- a/tests/unit/states/test_saltutil.py
+++ b/tests/unit/states/test_saltutil.py
@@ -31,6 +31,7 @@ class Saltutil(TestCase, LoaderModuleMockMixin):
         sync_output = {
             'clouds': [],
             'engines': [],
+            'executors': [],
             'grains': [],
             'beacons': [],
             'utils': [],
@@ -61,6 +62,7 @@ class Saltutil(TestCase, LoaderModuleMockMixin):
         sync_output = {
             'clouds': [],
             'engines': [],
+            'executors': [],
             'grains': [],
             'beacons': [],
             'utils': [],
@@ -92,6 +94,7 @@ class Saltutil(TestCase, LoaderModuleMockMixin):
         sync_output = {
             'clouds': [],
             'engines': [],
+            'executors': [],
             'grains': [],
             'beacons': [],
             'utils': [],


### PR DESCRIPTION
### What does this PR do?

Allow loading executor modules from the `_executors` fileserver directory.  This allows overloading standard executors and also adding new ones to wrap state execution calls globally.

### Tests written?

Yes

### Commits signed with GPG?

No
