### PR TITLE
The +nocl is supported much wider than +noclass

### DIFF
--- a/salt/utils/dns.py
+++ b/salt/utils/dns.py
@@ -45,7 +45,7 @@ try:
 except ImportError:
     HAS_DNSPYTHON = False
 HAS_DIG = salt.utils.path.which('dig') is not None
-DIG_OPTIONS = '+search +fail +noall +answer +noclass +nottl'
+DIG_OPTIONS = '+search +fail +noall +answer +nocl +nottl'
 HAS_DRILL = salt.utils.path.which('drill') is not None
 HAS_HOST = salt.utils.path.which('host') is not None
 HAS_NSLOOKUP = salt.utils.path.which('nslookup') is not None

--- a/salt/utils/dns.py
+++ b/salt/utils/dns.py
@@ -45,6 +45,7 @@ try:
 except ImportError:
     HAS_DNSPYTHON = False
 HAS_DIG = salt.utils.path.which('dig') is not None
+DIG_OPTIONS = '+search +fail +noall +answer +noclass +nottl'
 HAS_DRILL = salt.utils.path.which('drill') is not None
 HAS_HOST = salt.utils.path.which('host') is not None
 HAS_NSLOOKUP = salt.utils.path.which('nslookup') is not None
@@ -229,7 +230,7 @@ def _lookup_dig(name, rdtype, timeout=None, servers=None, secure=None):
     :param servers: [] of servers to use
     :return: [] of records or False if error
     '''
-    cmd = 'dig +search +fail +noall +answer +noclass +nottl -t {0} '.format(rdtype)
+    cmd = 'dig {0} -t {1} '.format(DIG_OPTIONS, rdtype)
     if servers:
         cmd += ''.join(['@{0} '.format(srv) for srv in servers])
     if timeout is not None:

--- a/tests/unit/utils/test_dns.py
+++ b/tests/unit/utils/test_dns.py
@@ -14,6 +14,7 @@ from salt.utils.odict import OrderedDict
 import salt.utils.dns
 from salt.utils.dns import _to_port, _tree, _weighted_order, _data2rec, _data2rec_group
 from salt.utils.dns import _lookup_gai, _lookup_dig, _lookup_drill, _lookup_host, _lookup_nslookup
+import salt.modules.cmdmod
 
 # Testing
 from tests.support.unit import skipIf, TestCase
@@ -276,6 +277,12 @@ class DNSlookupsCase(TestCase):
                         lookup_cb('mocksrvr.example.com', rec_t, secure=True), test_res,
                         msg='Error parsing DNSSEC\'d {0} returns'.format(rec_t)
                     )
+
+    @skipIf(not salt.utils.dns.HAS_DIG, 'dig is not available')
+    def test_dig_options(self):
+        cmd = 'dig {0}'.format(salt.utils.dns.DIG_OPTIONS)
+        cmd = salt.modules.cmdmod.retcode(cmd, python_shell=False, output_loglevel='quiet')
+        self.assertEqual(cmd, 0)
 
     def test_dig(self):
         wrong_type = {'retcode': 0, 'stderr':  ';; Warning, ignoring invalid type ABC'}

--- a/tests/unit/utils/test_dns.py
+++ b/tests/unit/utils/test_dns.py
@@ -280,7 +280,7 @@ class DNSlookupsCase(TestCase):
 
     @skipIf(not salt.utils.dns.HAS_DIG, 'dig is not available')
     def test_dig_options(self):
-        cmd = 'dig {0}'.format(salt.utils.dns.DIG_OPTIONS)
+        cmd = 'dig {0} -v'.format(salt.utils.dns.DIG_OPTIONS)
         cmd = salt.modules.cmdmod.retcode(cmd, python_shell=False, output_loglevel='quiet')
         self.assertEqual(cmd, 0)
 


### PR DESCRIPTION
They are same options.
```
in bin/dig/dig.c
...
case 'l': /* class */
    /* keep +cl for backwards compatibility */
    FULLCHECK2("cl", "class");
    lookup->noclass = !state;
    break;
```

Seems the +nocl is introduced with tag v9_0_1 while +noclass is with tag v9_11_0.
(the tag could be different with distribution's version)

```
$ cat /etc/redhat-release 
Red Hat Enterprise Linux Server release 7.6 (Maipo)

$ dig -v
DiG 9.9.4-RedHat-9.9.4-73.el7_6

$ dig +nocl +short -t soa saltstack.com
ns-39.awsdns-04.com. operations.saltstack.com. 1 7200 900 1209600 500

$ dig +noclass +short -t soa saltstack.com
Invalid option: +noclass
...
```

### What does this PR do?
This PR will replace +noclass option for dig with +nocl in order to support more OS without compromising anything.

### What issues does this PR fix or reference?
#51428 

### Previous Behavior
```
$ cat lookup.py 
import salt.utils

def run():
    dig = salt.utils.dns.lookup('google.com', 'soa', method='dig')
    host = salt.utils.dns.lookup('google.com', 'soa', method='host')
    return { "dig": dig, "host": host }
$ 
$ sudo salt-call lookup.run                                                                                                                                   
[WARNING ] dig returned (1): Invalid option: +noclass
Usage:  dig [@global-server] [domain] [q-type] [q-class] {q-opt}
            {global-d-opt} host [@local-server] {local-d-opt}
            [ host [@local-server] {local-d-opt} [...]]

Use "dig -h" (or "dig -h | more") for complete list of options
local:
    ----------
    dig:
        None
    host:
        - ns1.google.com. dns-admin.google.com. 231793091 900 900 1800 60
```

### New Behavior
```
$ sudo salt-call lookup.run 
local:
    ----------
    dig:
        - ns1.google.com. dns-admin.google.com. 231793091 900 900 1800 60
    host:
        - ns1.google.com. dns-admin.google.com. 231793091 900 900 1800 60
```

### Tests written?
No

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
