### PR TITLE
Implement cache clear threshold (in days)

### DIFF
--- a/tests/integration/modules/test_saltutil.py
+++ b/tests/integration/modules/test_saltutil.py
@@ -9,6 +9,8 @@ import os
 import time
 import textwrap
 import threading
+import shutil
+import datetime
 
 # Import Salt Testing libs
 from tests.support.runtests import RUNTIME_VARS
@@ -22,6 +24,7 @@ import salt.defaults.events
 import salt.utils.event
 import salt.utils.files
 import salt.utils.stringutils
+import salt.utils.files
 
 
 class SaltUtilModuleTest(ModuleCase):
@@ -295,3 +298,34 @@ class SaltUtilSyncPillarTest(ModuleCase):
     def tearDown(self):
         for filename in os.listdir(RUNTIME_VARS.TMP_PILLAR_TREE):
             os.remove(os.path.join(RUNTIME_VARS.TMP_PILLAR_TREE, filename))
+
+
+class SaltUtilClearCacheTest(ModuleCase):
+    '''
+    Testcase for the saltutil clear cache module
+    '''
+    def setUp(self):
+        '''
+        Creates a temporary directory for this test class
+        '''
+        self.tmp_dir = os.path.join(self.master_opts['cachedir'], 'SaltUtilClearCacheTest')
+        os.makedirs(self.tmp_dir)
+
+    def tearDown(self):
+        '''
+        Recursively deletes the temporary directory created for this test scenario
+        '''
+        shutil.rmtree(self.tmp_dir)
+
+    def createDummyCachedFile(self, filename, mtime=time.time()):
+        target_file = os.path.join(self.tmp_dir, filename)
+        with salt.utils.files.fopen(target_file, 'a'):
+            os.utime(target_file, (int(mtime), int(mtime)))
+        return target_file
+
+    def test_clear_cache_files_older_than_seven_days(self):
+        old_file = self.createDummyCachedFile('old', time.time() - datetime.timedelta(days=10).total_seconds())
+        new_file = self.createDummyCachedFile('new')
+        self.run_function('saltutil.clear_cache', days=7)
+        self.assertFalse(os.path.exists(old_file))
+        self.assertTrue(os.path.exists(new_file))


### PR DESCRIPTION
### What does this PR do?

- Allow for clearing all files in cache directory older than a certain threshold date (specified in days relative to the current datetime).
- Implemented similar to `saltutil.clear_job_cache` .
- Add integration test for the new functionality.

example call: `salt '*' saltutil.clear_cache days=7`

### What issues does this PR fix or reference?

At some of our development systems, the salt minions kept filling up the filesystem with nightly build artifacts.
This pull request modifies the `saltutil.clear_cache` function to accept an optional threshold time when clearing files from the cache directory.

### Previous Behavior
All files in the cache folder were deleted.

### New Behavior
Only cached files older than the (optional) threshold are deleted.
Specifying no explicit threshold defaults to the old behaviour.

### Tests written?

Yes

### Commits signed with GPG?

Yes