### PR TITLE
Remove custom grains module from 2018.3 branch

### DIFF
--- a/tests/integration/files/file/base/_grains/custom_grains.py
+++ b/tests/integration/files/file/base/_grains/custom_grains.py
@@ -1,5 +1,0 @@
-# -*- coding: utf-8 -*-
-
-
-def test(grains):
-    return {'custom_grain_test': 'itworked' if 'os' in grains else 'itdidntwork'}


### PR DESCRIPTION
Support for passing the grains data to custom grains modules wasn't added until the `2019.2` release cycle. It seems like this file was included when something else was backported to `2018.3`. This results in the following harmless traceback in the test suite:

```pytb
Traceback (most recent call last):
  File "/tmp/kitchen/testing/salt/loader.py", line 778, in grains
    ret = funcs[key](proxy)
  File "/tmp/salt-tests-tmpdir/rootdir/var/cache/salt/minion/extmods/grains/custom_grains.py", line 5, in test
    return {'custom_grain_test': 'itworked' if 'os' in grains else 'itdidntwork'}
TypeError: argument of type 'NoneType' is not iterable
```

(It's harmless because nothing actually tests this grain until `2019.2`)

@garethgreenaway @Ch3LL Please note that this will cause the following test to fail upon being merged into `2019.2`:

```
integration.grains.test_custom.TestGrainsCore.test_grains_passed_to_custom_grain
```

So, when doing a merge-forward, you'll want to do a `git revert <commit_id>`, where `<commit_id>` is the commit ID for this change, and add it to the pull request for the merge from `2018.3` to `2019.2`.