### PR TITLE
Fix deprecation warning in nested outputter

### DIFF
--- a/salt/output/nested.py
+++ b/salt/output/nested.py
@@ -33,7 +33,11 @@ import salt.utils.color
 import salt.utils.odict
 import salt.utils.stringutils
 from salt.ext import six
-from collections import Mapping
+
+try:
+    from collections.abc import Mapping
+except ImportError:
+    from collections import Mapping
 
 
 class NestDisplay(object):


### PR DESCRIPTION
Pull request #50963 introduces a deprecation warning on later Python 3 releases, as the abstract base classes now live in `collections.abc`. This fixes that deprecation warning.