### PR TITLE
Add Py2 Warning for Py2 Installer

### DIFF
--- a/pkg/windows/installer/Salt-Minion-Setup.nsi
+++ b/pkg/windows/installer/Salt-Minion-Setup.nsi
@@ -70,6 +70,22 @@ ${StrStrAdv}
 !define MUI_ICON "salt.ico"
 !define MUI_UNICON "salt.ico"
 !define MUI_WELCOMEFINISHPAGE_BITMAP "panel.bmp"
+!define MUI_UNWELCOMEFINISHPAGE_BITMAP "panel.bmp"
+
+# This entire if block can be removed for the Sodium release... including the !define MUI_WELCOMEPAGE_TEXT
+# NSIS will just use the default like it does for Python 3, which should be the same test
+!if "${PYTHON_VERSION}" == "2"
+    !define MUI_WELCOMEPAGE_TEXT "\
+        WARNING: Python 2 Support will be discontinued in Sodium. Salt will only ship Python 3 \
+        installers starting with the Sodium release.$\r$\n\
+        $\r$\n\
+        Setup will guide you through the installation of ${PRODUCT_NAME} ${PRODUCT_VERSION}.$\r$\n\
+        $\r$\n\
+        It is recommended that you close all other applications before starting Setup. This will make it possible to \
+        update relevant system files without having to reboot your computer.$\r$\n\
+        $\r$\n\
+        Click Next to continue."
+!endif
 
 # Welcome page
 !insertmacro MUI_PAGE_WELCOME


### PR DESCRIPTION
### What does this PR do?
Adds a warning to the Python 2 installer that Salt will drop support for Python 2 with the release of Sodium.

### Tests written?
NA

### Commits signed with GPG?
Yes