### PR TITLE
Update installer mac 2018.3.4

### DIFF
--- a/pkg/osx/build_pkg.sh
+++ b/pkg/osx/build_pkg.sh
@@ -158,13 +158,20 @@ echo -n -e "\033]0;Build_Pkg: Add Version to .xml\007"
 if [ "$PYVER" == "2" ]; then
     TITLE="Salt $VERSION"
     DESC="Salt $VERSION with Python 2"
+    SEDSTR="s/@PY2@/_py2/g"
 else
     TITLE="Salt $VERSION (Python 3)"
     DESC="Salt $VERSION with Python 3"
+    SEDSTR="s/@PY2@//g"
 fi
 
 cd $PKGRESOURCES
 cp distribution.xml.dist distribution.xml
+
+# Select the appropriate welcome text
+# This is only necessary until Sodium, then this can be removed
+sed -E -i '' "$SEDSTR" distribution.xml
+
 SEDSTR="s/@TITLE@/$TITLE/g"
 sed -E -i '' "$SEDSTR" distribution.xml
 

--- a/pkg/osx/distribution.xml.dist
+++ b/pkg/osx/distribution.xml.dist
@@ -12,11 +12,12 @@
              hostArchitectures="@CPUARCH@" />
     <domains enable_localSystem="true" />
     <!-- Define background image -->
-    <background file="saltstack.png"
+    <background file="logo.png"
                 mime-type="image/png"
-                scaling="proportional" />
+                scaling="proportional"
+                alignment="bottomleft" />
     <!-- Define documents displayed at various steps -->
-    <welcome file="welcome.rtf"
+    <welcome file="welcome@PY2@.rtf"
              mime-type="text/rtf" />
     <license file="license.rtf"
              mime-type="text/rtf" />

--- a/pkg/osx/distribution.xml.dist
+++ b/pkg/osx/distribution.xml.dist
@@ -12,10 +12,9 @@
              hostArchitectures="@CPUARCH@" />
     <domains enable_localSystem="true" />
     <!-- Define background image -->
-    <background file="logo.png"
+    <background file="saltstack.png"
                 mime-type="image/png"
-                scaling="proportional"
-                alignment="bottomleft" />
+                scaling="proportional" />
     <!-- Define documents displayed at various steps -->
     <welcome file="welcome@PY2@.rtf"
              mime-type="text/rtf" />

--- a/pkg/osx/pkg-resources/welcome_py2.rtf
+++ b/pkg/osx/pkg-resources/welcome_py2.rtf
@@ -1,0 +1,32 @@
+{\rtf1\ansi\ansicpg1252\cocoartf1404\cocoasubrtf340
+{\fonttbl\f0\fswiss\fcharset0 Helvetica;\f1\froman\fcharset0 Times-Roman;\f2\fnil\fcharset0 PTMono-Regular;
+}
+{\colortbl;\red255\green255\blue255;\red0\green0\blue233;}
+\vieww28300\viewh14680\viewkind0
+\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\pardirnatural\partightenfactor0
+
+\f0\fs24 \cf0 WARNING: Python 2 Support will be discontinued in Sodium. Salt will only ship Python 3 installers starting with the Sodium release.\
+\
+\pard\pardeftab720\sl280\sa240\partightenfactor0
+{\field{\*\fldinst{HYPERLINK "http://saltstack.com/"}}{\fldrslt 
+\f1 \cf2 \expnd0\expndtw0\kerning0
+\ul \ulc2 SaltStack}}
+\f1 \expnd0\expndtw0\kerning0
+ is extremely fast and scalable systems and configuration management software for predictive orchestration, cloud and data center automation, server provisioning, application deployment and more. \
+Documentation for Salt is available at {\field{\*\fldinst{HYPERLINK "http://docs.saltstack.com/"}}{\fldrslt \cf2 \ul \ulc2 http://docs.saltstack.com}} \
+This package will install Salt on your Mac. Salt installs into 
+\f2\fs22 /opt/salt
+\f1\fs24 .\
+Sample configuration files (
+\f2\fs22 master.dist
+\f1\fs24  and 
+\f2\fs22 minion.dist
+\f1\fs24 ) will be installed to 
+\f2\fs22 /etc/salt
+\f1\fs24 . Create copies of them without the '
+\f2\fs22 .dist
+\f1\fs24 ' in the filename and edit as you see fit.\
+This Salt package uses a custom-built Python. To install additional Python modules for Salt, use the associated 'pip' binary. For example, if you need LDAP support in Salt you will need the 'python-ldap' module. Install it with 
+\f2\fs22 /opt/salt/bin/pip install python-ldap
+\f1\fs24 \
+Note that some Python modules need a compiler available. Installing Apple's Xcode Command Line Tools should provide the necessary utilities. Alternatively, {\field{\*\fldinst{HYPERLINK "http://macports.org/"}}{\fldrslt \cf2 \ul \ulc2 MacPorts}}, {\field{\*\fldinst{HYPERLINK "http://finkproject.org/"}}{\fldrslt \cf2 \ul \ulc2 Fink}}, or {\field{\*\fldinst{HYPERLINK "http://brew.sh/"}}{\fldrslt \cf2 \ul \ulc2 Homebrew}} may provide what you need.}


### PR DESCRIPTION
### What does this PR do?
Adds a warning to the Python 2 installer that Salt will drop support for Python 2 with the release of Sodium.

### Tests written?
NA

### Commits signed with GPG?
Yes