### PR TITLE
`modules.tls.validate` is now a thing

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,13 +1,21 @@
-languages:
-  Ruby: false
-  JavaScript: false
-  Python: true
-  PHP: false
+version: "2"
 
-engines:
+exclude_patterns:
+  - "*.js"
+  - "*.rb"
+  - "*.php"
+
+plugins:
   radon:
     enabled: true
-    exclude_paths:
+    exclude_patterns:
       - "templates/"
     config:
       threshold: "D"
+
+checks:
+  argument-count:
+    enabled: false
+  similar-code:
+    config:
+      threshold: 40

--- a/salt/modules/tls.py
+++ b/salt/modules/tls.py
@@ -563,6 +563,52 @@ def _read_cert(cert):
             return cert
 
 
+def validate(cert, ca_name, crl_file):
+    '''
+    .. versionadded:: Neon
+
+    Validate a certificate against a given CA/CRL.
+
+    cert
+        path to the certifiate PEM file or string
+
+    ca_name
+        name of the CA
+
+    crl_file
+        full path to the CRL file
+    '''
+    store = OpenSSL.crypto.X509Store()
+    cert_obj = _read_cert(cert)
+    if cert_obj is None:
+        raise CommandExecutionError(
+            'Failed to read cert from {0}, see log for details'.format(cert)
+        )
+    ca_dir = '{0}/{1}'.format(cert_base_path(), ca_name)
+    ca_cert = _read_cert('{0}/{1}_ca_cert.crt'.format(ca_dir, ca_name))
+    store.add_cert(ca_cert)
+    # These flags tell OpenSSL to check the leaf as well as the
+    # entire cert chain.
+    X509StoreFlags = OpenSSL.crypto.X509StoreFlags
+    store.set_flags(X509StoreFlags.CRL_CHECK | X509StoreFlags.CRL_CHECK_ALL)
+    if crl_file is None:
+        crl = OpenSSL.crypto.CRL()
+    else:
+        with salt.utils.files.fopen(crl_file) as fhr:
+            crl = OpenSSL.crypto.load_crl(OpenSSL.crypto.FILETYPE_PEM, fhr.read())
+    store.add_crl(crl)
+    context = OpenSSL.crypto.X509StoreContext(store, cert_obj)
+    ret = {}
+    try:
+        context.verify_certificate()
+        ret['valid'] = True
+    except OpenSSL.crypto.X509StoreContextError as e:
+        ret['error'] = str(e)
+        ret['error_cert'] = e.certificate
+        ret['valid'] = False
+    return ret
+
+
 def _get_expiration_date(cert):
     '''
     Returns a datetime.datetime object

--- a/tests/integration/modules/test_tls.py
+++ b/tests/integration/modules/test_tls.py
@@ -1,0 +1,171 @@
+# -*- coding: utf-8 -*-
+'''
+    :codeauthor: Wayne Werner <wwerner@saltstack.com>
+'''
+
+# Import the future
+from __future__ import absolute_import, unicode_literals, print_function
+
+import os
+import shutil
+import tempfile
+
+# Testing libs
+from tests.support.case import ModuleCase
+from tests.support.mixins import LoaderModuleMockMixin
+from tests.support.mock import (
+    MagicMock,
+    NO_MOCK,
+    NO_MOCK_REASON,
+    patch
+)
+from tests.support.runtests import RUNTIME_VARS
+from tests.support.unit import skipIf
+
+# Salt Libs
+import salt.modules.cmdmod as cmd
+import salt.modules.file as file
+import salt.modules.tls as tls
+import salt.utils.files as files
+import salt.utils.stringutils as stringutils
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class TLSModuleTest(ModuleCase, LoaderModuleMockMixin):
+    '''
+    Tests for salt.modules.tls
+    '''
+
+    def setup_loader_modules(self):
+        opts = {
+            'cachedir': os.path.join(RUNTIME_VARS.TMP, 'cache'),
+            'test': True,
+        }
+        return {
+            tls: {
+                '__salt__': {
+                    'config.option': MagicMock(return_value=self.tempdir),
+                    'cmd.retcode': cmd.retcode,
+                    'pillar.get': MagicMock(return_value=False),
+                    'file.replace': file.replace,
+                },
+                '__opts__': opts,
+            },
+            file: {
+                '__utils__': {
+                    'files.is_text': files.is_text,
+                    'stringutils.get_diff': stringutils.get_diff,
+                },
+                '__opts__': opts,
+            },
+        }
+
+    @classmethod
+    def setUpClass(self):
+        self.ca_name = 'roscivs'
+        self.tempdir = tempfile.mkdtemp(dir=RUNTIME_VARS.TMP)
+
+    def test_ca_exists_should_be_False_before_ca_is_created(self):
+        self.assertFalse(tls.ca_exists(self.ca_name))
+
+    def test_ca_exists_should_be_True_after_ca_is_created(self):
+        tls.create_ca(self.ca_name)
+        self.assertTrue(tls.ca_exists(self.ca_name))
+
+    def test_creating_csr_should_fail_with_no_ca(self):
+        expected_message = (
+            'Certificate for CA named "bad_ca" does not exist,'
+            ' please create it first.'
+        )
+        self.assertEqual(tls.create_csr(ca_name='bad_ca'), expected_message)
+
+    def test_with_existing_ca_signing_csr_should_produce_valid_cert(self):
+        print('Revoked should not be here')
+        empty_crl_filename = os.path.join(self.tempdir, 'empty.crl')
+        tls.create_ca(self.ca_name)
+        tls.create_csr(
+            ca_name=self.ca_name,
+            CN='testing.localhost',
+        )
+        tls.create_ca_signed_cert(
+            ca_name=self.ca_name,
+            CN='testing.localhost',
+        )
+        tls.create_empty_crl(
+            ca_name=self.ca_name,
+            crl_file=empty_crl_filename,
+        )
+        ret = tls.validate(
+            cert=os.path.join(
+                self.tempdir,
+                self.ca_name,
+                'certs',
+                'testing.localhost.crt',
+            ),
+            ca_name=self.ca_name,
+            crl_file=empty_crl_filename,
+        )
+        print('not there')
+        self.assertTrue(ret['valid'], ret.get('error'))
+
+    def test_revoked_cert_should_return_False_from_validate(self):
+        revoked_crl_filename = os.path.join(self.tempdir, 'revoked.crl')
+        tls.create_ca(self.ca_name)
+        tls.create_csr(
+            ca_name=self.ca_name,
+            CN='testing.bad.localhost',
+        )
+        tls.create_ca_signed_cert(
+            ca_name=self.ca_name,
+            CN='testing.bad.localhost',
+        )
+        tls.create_empty_crl(
+            ca_name=self.ca_name,
+            crl_file=revoked_crl_filename,
+        )
+        tls.revoke_cert(
+            ca_name=self.ca_name,
+            CN='testing.bad.localhost',
+            crl_file=revoked_crl_filename,
+        )
+        self.assertFalse(tls.validate(
+            cert=os.path.join(
+                self.tempdir,
+                self.ca_name,
+                'certs',
+                'testing.bad.localhost.crt',
+            ),
+            ca_name=self.ca_name,
+            crl_file=revoked_crl_filename,
+        )['valid'])
+
+    def test_validating_revoked_cert_with_no_crl_file_should_return_False(self):
+        revoked_crl_filename = None
+        tls.create_ca(self.ca_name)
+        tls.create_csr(
+            ca_name=self.ca_name,
+            CN='testing.bad.localhost',
+        )
+        tls.create_ca_signed_cert(
+            ca_name=self.ca_name,
+            CN='testing.bad.localhost',
+        )
+        tls.create_empty_crl(
+            ca_name=self.ca_name,
+            crl_file=revoked_crl_filename,
+        )
+        tls.revoke_cert(
+            ca_name=self.ca_name,
+            CN='testing.bad.localhost',
+            crl_file=revoked_crl_filename,
+        )
+        self.assertFalse(tls.validate(
+            cert=os.path.join(
+                self.tempdir,
+                self.ca_name,
+                'certs',
+                'testing.bad.localhost.crt',
+            ),
+            ca_name=self.ca_name,
+            crl_file=revoked_crl_filename,
+        )['valid'])

--- a/tests/integration/modules/test_tls.py
+++ b/tests/integration/modules/test_tls.py
@@ -7,7 +7,6 @@
 from __future__ import absolute_import, unicode_literals, print_function
 
 import os
-import shutil
 import tempfile
 
 # Testing libs
@@ -17,7 +16,6 @@ from tests.support.mock import (
     MagicMock,
     NO_MOCK,
     NO_MOCK_REASON,
-    patch
 )
 from tests.support.runtests import RUNTIME_VARS
 from tests.support.unit import skipIf
@@ -61,9 +59,9 @@ class TLSModuleTest(ModuleCase, LoaderModuleMockMixin):
         }
 
     @classmethod
-    def setUpClass(self):
-        self.ca_name = 'roscivs'
-        self.tempdir = tempfile.mkdtemp(dir=RUNTIME_VARS.TMP)
+    def setUpClass(cls):
+        cls.ca_name = 'roscivs'
+        cls.tempdir = tempfile.mkdtemp(dir=RUNTIME_VARS.TMP)
 
     def test_ca_exists_should_be_False_before_ca_is_created(self):
         self.assertFalse(tls.ca_exists(self.ca_name))

--- a/tests/support/mixins.py
+++ b/tests/support/mixins.py
@@ -344,8 +344,6 @@ class _FixLoaderModuleMockMixinMroOrder(type):
 class LoaderModuleMockMixin(six.with_metaclass(_FixLoaderModuleMockMixinMroOrder, object)):
     '''
     This class will setup salt loader dunders.
-
-    Please check `set_up_loader_mocks` above
     '''
 
     # Define our setUp function decorator


### PR DESCRIPTION
### What does this PR do?

Add 'validate' to the TLS module, and fixes a couple of bugs

### What issues does this PR fix or reference?

#7424

### Previous Behavior

I still need to double check to see how far back it was, but at some point the `digest` argument was required for a couple of features, but we weren't providing it. I've added those. There were also some encoding (text/unicode vs bytes) problems that popped up when I was running it under Python3, whoops. Running those functions would fail.

### New Behavior

Failing functions no longer fail.

`validate` now exists - one can pass a cert, a CA, and a CRL to confirm that a certificate is valid.

### Tests written?

Yes - including some integration tests to check that we're using pyOpenSSL properly.

### Commits signed with GPG?

Yes

### Things to confirm

Before merging this I do need to check when pyOpenSSL introduced the behavior that has our module broken - I don't want my changes to break anything if that was a reasonably new (<1 year?) change.

Also if there's any code style changes that I should make, please point that out.

Oh, also had a couple of ❓ 
```
# TODO: Should we skip on Windows? Or skip if PyOpenSSL is not installed? -W. Werner, 2019-01-30
# TODO: Should any of these tests be marked destructive? -W. Werner, 2019-01-30
```
I wasn't sure what kind of changes were considered `destructive` - these aren't adding or removing users or anything, but it *is* creating and mucking with a CA. I'm guessing that it's entirely fine though?