### PR TITLE
Allow to override git_pillar_base per-remote

### DIFF
--- a/salt/pillar/git_pillar.py
+++ b/salt/pillar/git_pillar.py
@@ -368,9 +368,9 @@ from salt.pillar import Pillar
 # Import third party libs
 from salt.ext import six
 
-PER_REMOTE_OVERRIDES = ('env', 'root', 'ssl_verify', 'refspecs')
+PER_REMOTE_OVERRIDES = ('base', 'env', 'root', 'ssl_verify', 'refspecs')
 PER_REMOTE_ONLY = ('name', 'mountpoint', 'all_saltenvs')
-GLOBAL_ONLY = ('base', 'branch')
+GLOBAL_ONLY = ('branch',)
 
 # Set up logging
 log = logging.getLogger(__name__)


### PR DESCRIPTION
### What does this PR do?

Allow to override git_pillar_base per-remote

### What issues does this PR fix or reference?
None.

### New Behavior
Example:
```yaml

git_pillar_base: develop

ext_pillar:
  - git:
    - __env__ https://gitserver/git-pillar.git
    - __env__ https://gitserver/git-pillar2.git:
      - base: master
```

### Tests written?

No

### Commits signed with GPG?

Not yet
