### PR TITLE
Don't prevent `get_locale` from working when running under Suse docker containers

### DIFF
--- a/salt/modules/localemod.py
+++ b/salt/modules/localemod.py
@@ -139,7 +139,7 @@ def get_locale():
     if lc_ctl and not (__grains__['os_family'] in ['Suse'] and __grains__['osmajorrelease'] in [12]):
         ret = (_parse_dbus_locale() if dbus is not None else _localectl_status()['system_locale']).get('LANG', '')
     else:
-        if 'Suse' in __grains__['os_family'] and __grains__['osmajorrelease'] == 12:
+        if 'Suse' in __grains__['os_family']:
             cmd = 'grep "^RC_LANG" /etc/sysconfig/language'
         elif 'RedHat' in __grains__['os_family']:
             cmd = 'grep "^LANG=" /etc/sysconfig/i18n'


### PR DESCRIPTION
### What does this PR do?
Don't prevent `get_locale` from working when running under Suse docker containers

### What issues does this PR fix or reference?
None?

### Previous Behavior
When running under docker, even though the system has the required information, salt was prevented from getting it.

### New Behavior
Now also works under Docker containers

### Tests written?

No

### Commits signed with GPG?

Yes