### PR TITLE
Do not treat MSI auth support as hard dependency

### DIFF
--- a/salt/cloud/__init__.py
+++ b/salt/cloud/__init__.py
@@ -71,10 +71,16 @@ def communicator(func):
             queue.put('KEYBOARDINT')
             queue.put('Keyboard interrupt')
             queue.put('{0}\n{1}\n'.format(ex, trace))
-        except BaseException as ex:
+        except Exception as ex:
             trace = traceback.format_exc()
             queue.put('ERROR')
             queue.put('Exception')
+            queue.put('{0}\n{1}\n'.format(ex, trace))
+        except SystemExit as ex:
+            print("Communicatior: caught exception")
+            trace = traceback.format_exc()
+            queue.put('ERROR')
+            queue.put('System exit')
             queue.put('{0}\n{1}\n'.format(ex, trace))
         return ret
     return _call

--- a/salt/cloud/__init__.py
+++ b/salt/cloud/__init__.py
@@ -71,7 +71,7 @@ def communicator(func):
             queue.put('KEYBOARDINT')
             queue.put('Keyboard interrupt')
             queue.put('{0}\n{1}\n'.format(ex, trace))
-        except Exception as ex:
+        except BaseException as ex:
             trace = traceback.format_exc()
             queue.put('ERROR')
             queue.put('Exception')

--- a/salt/cloud/__init__.py
+++ b/salt/cloud/__init__.py
@@ -77,7 +77,6 @@ def communicator(func):
             queue.put('Exception')
             queue.put('{0}\n{1}\n'.format(ex, trace))
         except SystemExit as ex:
-            print("Communicatior: caught exception")
             trace = traceback.format_exc()
             queue.put('ERROR')
             queue.put('System exit')

--- a/salt/utils/azurearm.py
+++ b/salt/utils/azurearm.py
@@ -47,9 +47,6 @@ try:
         UserPassCredentials,
         ServicePrincipalCredentials,
     )
-    from msrestazure.azure_active_directory import (
-        MSIAuthentication
-    )
     from msrestazure.azure_cloud import (
         MetadataEndpointError,
         get_cloud_from_metadata_endpoint,
@@ -114,7 +111,13 @@ def _determine_auth(**kwargs):
                                               kwargs['password'],
                                               cloud_environment=cloud_env)
     elif 'subscription_id' in kwargs:
-        credentials = MSIAuthentication(cloud_environment=cloud_env)
+        try:
+            from msrestazure.azure_active_directory import (
+                MSIAuthentication
+            )
+            credentials = MSIAuthentication(cloud_environment=cloud_env)
+        except ImportError:
+            raise SaltSystemExit(msg='MSI authentication support not availabe (requires msrestazure >= 0.4.14)')
 
     else:
         raise SaltInvocationError(
@@ -152,7 +155,7 @@ def get_client(client_type, **kwargs):
 
     if client_type not in client_map:
         raise SaltSystemExit(
-            'The Azure ARM client_type {0} specified can not be found.'.format(
+            msg='The Azure ARM client_type {0} specified can not be found.'.format(
                 client_type)
         )
 


### PR DESCRIPTION
### What does this PR do?
On systems that lack MSI authentication support, only fail if MSI is actually used.

### What issues does this PR fix or reference?
It allows users who are on an older version of msrestazure (i.e. < 0.4.14) to use the azurearm back-end, as long as they do not use MSI authentication.

### Commits signed with GPG?

Yes

### Notes
I had to change the `_call` function of the `communicator` class to catch `BaseException` instead of just `Exception` for this to work. This is because if a `SaltSystemExit` exception is thrown in a worker thread, the `pool.map` call hangs. The other `SaltSystemExit` exception in `get_client` was potentially affected too, but AFAICS that code path could really only be triggered by a bug.