### PR TITLE
Fix the failing dns test on Windows

### DIFF
--- a/tests/integration/modules/test_win_dns_client.py
+++ b/tests/integration/modules/test_win_dns_client.py
@@ -22,8 +22,12 @@ class WinDNSTest(ModuleCase):
         '''
         Test add and removing a dns server
         '''
+        # Get a list of interfaces on the system
+        interfaces = self.run_function('network.interfaces_names')
+        skipIf(interfaces.count == 0, 'This test requires a network interface')
+
+        interface = interfaces[0]
         dns = '8.8.8.8'
-        interface = 'Ethernet'
         # add dns server
         self.assertTrue(self.run_function('win_dns_client.add_dns', [dns, interface], index=42))
 


### PR DESCRIPTION
### What does this PR do?
Gets the name of the first interface on the system. Windows network interfaces don't have the same name across Window systems. You can even go as far as naming them whatever you want. The test was failing because the interface name was hard-coded as 'Ethernet'.

### What issues does this PR fix or reference?
found in jenkins

### Tests written?
Yes

### Commits signed with GPG?
Yes