### PR TITLE
Don't log shell warning if output_loglevel is quiet

### DIFF
--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -280,7 +280,7 @@ def _run(cmd,
     '''
     if 'pillar' in kwargs and not pillar_override:
         pillar_override = kwargs['pillar']
-    if _is_valid_shell(shell) is False:
+    if output_loglevel != 'quiet' and _is_valid_shell(shell) is False:
         log.warning(
             'Attempt to run a shell command with what may be an invalid shell! '
             'Check to ensure that the shell <%s> is valid for this user.',


### PR DESCRIPTION
This will prevent grains generation from logging a bunch of these sort of warnings when Salt is being run using sudo as a user with an invalid shell.