### PR TITLE
address circular reference in LazyLoader with ThreadLocalProxy

### DIFF
--- a/tests/integration/files/file/base/issue-51499.sls
+++ b/tests/integration/files/file/base/issue-51499.sls
@@ -1,0 +1,6 @@
+{% if 'nonexistent_module.function' in salt %}
+{% do salt.log.warning("Module is available") %}
+{% endif %}
+always-passes:
+  test.succeed_without_changes:
+    - name: foo

--- a/tests/integration/modules/test_state.py
+++ b/tests/integration/modules/test_state.py
@@ -2171,3 +2171,16 @@ class StateModuleTest(ModuleCase, SaltReturnAssertsMixin):
         self.assertEqual(state_run[state_id]['comment'],
                          'Success!')
         self.assertTrue(state_run[state_id]['result'])
+
+    def test_state_sls_lazyloader_allows_recursion(self):
+        '''
+        This tests that referencing dunders like __salt__ work
+        context: https://github.com/saltstack/salt/pull/51499
+        '''
+        state_run = self.run_function('state.sls', mods='issue-51499')
+
+        state_id = 'test_|-always-passes_|-foo_|-succeed_without_changes'
+        self.assertIn(state_id, state_run)
+        self.assertEqual(state_run[state_id]['comment'],
+                         'Success!')
+        self.assertTrue(state_run[state_id]['result'])


### PR DESCRIPTION
### What does this PR do?
when lazyLoader was getting instantiated from inside already lazyloaded
modules (ie state), pillar/grain (and probably other) globals were
already populated. In this case they weren't getting dereferenced
properly when wrapped via the NamespacedDict wrapper, causing an
infinite loop. This should fix that scenario.


### What issues does this PR fix or reference?
https://github.com/saltstack/salt/pull/50655#issuecomment-460050683

pushing this to see what jenkins has to say



### Previous Behavior
Remove this section if not relevant

### New Behavior
Remove this section if not relevant

### Tests written?

Yes/No

### Commits signed with GPG?

Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
