### PR TITLE
Fix invocation of user.list_users in test suite

### DIFF
--- a/tests/integration/states/test_file.py
+++ b/tests/integration/states/test_file.py
@@ -148,7 +148,7 @@ class FileTest(ModuleCase, SaltReturnAssertsMixin):
         remove files created in previous tests
         '''
         user = 'salt'
-        if user in str(self.run_function('user.list_users', [user])):
+        if user in str(self.run_function('user.list_users')):
             self.run_function('user.delete', [user])
 
         for path in (FILEPILLAR, FILEPILLARDEF, FILEPILLARGIT):


### PR DESCRIPTION
This function does not take an argument, so this causes a traceback in the tearDown.