### PR TITLE
Correctly identify TurnKey Linux as a Debian derivative (grains)

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1464,6 +1464,7 @@ _OS_FAMILY_MAP = {
     'IDMS': 'Debian',
     'Funtoo': 'Gentoo',
     'AIX': 'AIX',
+    'TurnKey': 'Debian',
 }
 
 # Matches any possible format:


### PR DESCRIPTION
### What does this PR do?
Amends the core grains to correctly identify TurnKey Linux as a Debian derivative (os_family: Debian). 

### What issues does this PR fix or reference?
NA
### Previous Behavior
Pkg module doesn't work. e.g.
```
$ salt-call -l debug pkg.install certbot
...
[DEBUG   ] Could not LazyLoad pkg.install: 'pkg.install' is not available.
'pkg.install' is not available.
```

### New Behavior
Pkg module works.

### Tests written?

No

### Commits signed with GPG?

Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
