### PR TITLE
fix grains: ip6_interfaces returns secondary v4 addresses

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -2290,8 +2290,12 @@ def ip4_interfaces():
             if 'address' in inet:
                 iface_ips.append(inet['address'])
         for secondary in ifaces[face].get('secondary', []):
-            if 'address' in secondary:
-                iface_ips.append(secondary['address'])
+            try:
+                socket.inet_pton(socket.AF_INET6, secondary['address'])
+                if 'address' in secondary:
+                    iface_ips.append(secondary['address'])
+            except:
+                pass
         ret[face] = iface_ips
     return {'ip4_interfaces': ret}
 


### PR DESCRIPTION
…1481


### What does this PR do?
Fix ipv6 grains returning ipv4 secondary addresses

### What issues does this PR fix or reference?
#51481 

### Previous Behavior
IPv6 grains returned secondary ipv4 addresses, as the call to the network functions did not specify ipv6

### New Behavior
Filter return list to exclude ipv4

### Tests written?

No

### Commits signed with GPG?

No
