### PR TITLE
Bugfixes in solarisips

### DIFF
--- a/salt/modules/solarisips.py
+++ b/salt/modules/solarisips.py
@@ -46,6 +46,7 @@ import salt.utils.data
 import salt.utils.functools
 import salt.utils.path
 import salt.utils.pkg
+from salt.ext.six import string_types
 from salt.exceptions import CommandExecutionError
 
 # Define the module's virtual name
@@ -332,7 +333,6 @@ def latest_version(name, **kwargs):
         return ret
     return ''
 
-
 # available_version is being deprecated
 available_version = salt.utils.functools.alias_function(latest_version, 'available_version')
 
@@ -474,12 +474,16 @@ def install(name=None, refresh=False, pkgs=None, version=None, test=False, **kwa
 
     pkg2inst = ''
     if pkgs:    # multiple packages specified
+        pkg2inst = []
         for pkg in pkgs:
-            if list(pkg.items())[0][1]:   # version specified
-                pkg2inst += '{0}@{1} '.format(list(pkg.items())[0][0],
-                                              list(pkg.items())[0][1])
+            if getattr(pkg, 'items', False):
+                if list(pkg.items())[0][1]:   # version specified
+                    pkg2inst.append('{0}@{1}'.format(list(pkg.items())[0][0],
+                                                     list(pkg.items())[0][1]))
+                else:
+                    pkg2inst.append(list(pkg.items())[0][0])
             else:
-                pkg2inst += '{0} '.format(list(pkg.items())[0][0])
+                pkg2inst.append("{0}".format(pkg))
         log.debug('Installing these packages instead of %s: %s',
                   name, pkg2inst)
 
@@ -499,7 +503,10 @@ def install(name=None, refresh=False, pkgs=None, version=None, test=False, **kwa
 
     # Install or upgrade the package
     # If package is already installed
-    cmd.append(pkg2inst)
+    if isinstance(pkg2inst, string_types):
+        cmd.append(pkg2inst)
+    elif isinstance(pkg2inst, list):
+        cmd = cmd + pkg2inst
 
     out = __salt__['cmd.run_all'](cmd, output_loglevel='trace')
 

--- a/salt/modules/solarisips.py
+++ b/salt/modules/solarisips.py
@@ -333,6 +333,7 @@ def latest_version(name, **kwargs):
         return ret
     return ''
 
+
 # available_version is being deprecated
 available_version = salt.utils.functools.alias_function(latest_version, 'available_version')
 

--- a/tests/unit/modules/test_solarisips.py
+++ b/tests/unit/modules/test_solarisips.py
@@ -175,3 +175,124 @@ class IpsTestCase(TestCase, LoaderModuleMockMixin):
         with patch.object(solarisips, 'is_installed', return_value=True):
             result = solarisips.install(name='less')
         self.assertEqual(result, expected_result)
+
+    def test_install_dict_pkgs_with_version_validate_cmd(self):
+        '''
+        Test installing a list of packages
+        '''
+        def check_param(arg, **kwargs):
+            self.assertEqual(arg, [
+                'pkg',
+                'install',
+                '-v',
+                '--accept',
+                'less@458,5.11-0.175.3.0.0.30.0:20150821T172730Z',
+                'libsasl@0.5.11,5.11-0.175.3.32.0.1.0:20180406T191209Z'
+            ])
+            return {
+                'pid': 1234,
+                'retcode': 0,
+                'stderr': '',
+                'stdout': '',
+            }
+
+        pkg_list_pre = {
+            'pkg://solaris/compress/bzip2': '1.0.6,5.11-0.175.3.10.0.4.0:20160630T215500Z',
+            'pkg://solaris/compress/gzip': '1.5,5.11-0.175.3.0.0.30.0:20150821T161446Z',
+            'pkg://solaris/compress/p7zip': '16.2.3,5.11-0.175.3.34.0.2.0:20180614T204908Z',
+        }
+        pkg_list_post = {
+            'pkg://solaris/compress/bzip2': '1.0.6,5.11-0.175.3.10.0.4.0:20160630T215500Z',
+            'pkg://solaris/compress/gzip': '1.5,5.11-0.175.3.0.0.30.0:20150821T161446Z',
+            'pkg://solaris/compress/p7zip': '16.2.3,5.11-0.175.3.34.0.2.0:20180614T204908Z',
+            'pkg://solaris/text/less': '458,5.11-0.175.3.0.0.30.0:20150821T172730Z',
+            'pkg://solaris/system/library/security/libsasl': '0.5.11,5.11-0.175.3.32.0.1.0:20180406T191209Z',
+        }
+        mock_install_cmd = MagicMock(side_effect=check_param)
+        list_pkgs_responses = [pkg_list_pre, pkg_list_post]
+        with patch.object(solarisips, 'is_installed', return_value=False), \
+                patch.object(solarisips, 'list_pkgs', side_effect=list_pkgs_responses):
+            with patch.dict(solarisips.__salt__, {'cmd.run_all': mock_install_cmd}):
+                result = solarisips.install(pkgs=[
+                        {'less': '458,5.11-0.175.3.0.0.30.0:20150821T172730Z'},
+                        {'libsasl': '0.5.11,5.11-0.175.3.32.0.1.0:20180406T191209Z'}], refresh=False)
+
+    def test_install_dict_pkgs_no_version_validate_cmd(self):
+        '''
+        Test installing a list of packages
+        '''
+        def check_param(arg, **kwargs):
+            self.assertEqual(arg, [
+                'pkg',
+                'install',
+                '-v',
+                '--accept',
+                'less',
+                'libsasl'
+            ])
+            return {
+                'pid': 1234,
+                'retcode': 0,
+                'stderr': '',
+                'stdout': '',
+            }
+
+        pkg_list_pre = {
+            'pkg://solaris/compress/bzip2': '1.0.6,5.11-0.175.3.10.0.4.0:20160630T215500Z',
+            'pkg://solaris/compress/gzip': '1.5,5.11-0.175.3.0.0.30.0:20150821T161446Z',
+            'pkg://solaris/compress/p7zip': '16.2.3,5.11-0.175.3.34.0.2.0:20180614T204908Z',
+        }
+        pkg_list_post = {
+            'pkg://solaris/compress/bzip2': '1.0.6,5.11-0.175.3.10.0.4.0:20160630T215500Z',
+            'pkg://solaris/compress/gzip': '1.5,5.11-0.175.3.0.0.30.0:20150821T161446Z',
+            'pkg://solaris/compress/p7zip': '16.2.3,5.11-0.175.3.34.0.2.0:20180614T204908Z',
+            'pkg://solaris/text/less': '458,5.11-0.175.3.0.0.30.0:20150821T172730Z',
+            'pkg://solaris/system/library/security/libsasl': '0.5.11,5.11-0.175.3.32.0.1.0:20180406T191209Z',
+        }
+        mock_install_cmd = MagicMock(side_effect=check_param)
+        list_pkgs_responses = [pkg_list_pre, pkg_list_post]
+        with patch.object(solarisips, 'is_installed', return_value=False), \
+                patch.object(solarisips, 'list_pkgs', side_effect=list_pkgs_responses):
+            with patch.dict(solarisips.__salt__, {'cmd.run_all': mock_install_cmd}):
+                result = solarisips.install(pkgs=[
+                        {'less': ''},
+                        {'libsasl': ''}], refresh=False)
+
+    def test_install_list_pkgs_validate_cmd(self):
+        '''
+        Test installing a list of packages
+        '''
+        def check_param(arg, **kwargs):
+            self.assertEqual(arg, [
+                'pkg',
+                'install',
+                '-v',
+                '--accept',
+                'less',
+                'libsasl'
+            ])
+            return {
+                'pid': 1234,
+                'retcode': 0,
+                'stderr': '',
+                'stdout': '',
+            }
+
+        pkg_list_pre = {
+            'pkg://solaris/compress/bzip2': '1.0.6,5.11-0.175.3.10.0.4.0:20160630T215500Z',
+            'pkg://solaris/compress/gzip': '1.5,5.11-0.175.3.0.0.30.0:20150821T161446Z',
+            'pkg://solaris/compress/p7zip': '16.2.3,5.11-0.175.3.34.0.2.0:20180614T204908Z',
+        }
+        pkg_list_post = {
+            'pkg://solaris/compress/bzip2': '1.0.6,5.11-0.175.3.10.0.4.0:20160630T215500Z',
+            'pkg://solaris/compress/gzip': '1.5,5.11-0.175.3.0.0.30.0:20150821T161446Z',
+            'pkg://solaris/compress/p7zip': '16.2.3,5.11-0.175.3.34.0.2.0:20180614T204908Z',
+            'pkg://solaris/text/less': '458,5.11-0.175.3.0.0.30.0:20150821T172730Z',
+            'pkg://solaris/system/library/security/libsasl': '0.5.11,5.11-0.175.3.32.0.1.0:20180406T191209Z',
+        }
+        mock_install_cmd = MagicMock(side_effect=check_param)
+        list_pkgs_responses = [pkg_list_pre, pkg_list_post]
+        with patch.object(solarisips, 'is_installed', return_value=False), \
+                patch.object(solarisips, 'list_pkgs', side_effect=list_pkgs_responses):
+            with patch.dict(solarisips.__salt__, {'cmd.run_all': mock_install_cmd}):
+                result = solarisips.install(pkgs=['less', 'libsasl'], refresh=False)

--- a/tests/unit/modules/test_solarisips.py
+++ b/tests/unit/modules/test_solarisips.py
@@ -1,0 +1,177 @@
+# -*- coding: utf-8 -*-
+
+# Import Python Libs
+from __future__ import absolute_import
+import os
+
+# Import Salt Testing Libs
+from tests.support.mixins import LoaderModuleMockMixin
+from tests.support.unit import TestCase, skipIf
+from tests.support.mock import (
+    Mock,
+    MagicMock,
+    patch,
+    NO_MOCK,
+    NO_MOCK_REASON
+)
+
+# Import Salt libs
+import salt.modules.solarisips as solarisips
+import salt.modules.pkg_resource as pkg_resource
+import salt.utils.data
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class IpsTestCase(TestCase, LoaderModuleMockMixin):
+    '''
+    Test cases for salt.modules.solarisips
+    '''
+    def setup_loader_modules(self):
+        self.opts = opts = salt.config.DEFAULT_MINION_OPTS
+        utils = salt.loader.utils(
+            opts,
+            whitelist=['pkg', 'path', 'platform'])
+        return {
+            pkg_resource: {
+                '__grains__': {
+                    'osarch': 'sparcv9',
+                    'os_family': 'Solaris',
+                    'osmajorrelease': 11,
+                    'kernelrelease': 5.11,
+                },
+            },
+            solarisips: {
+                '__opts__': opts,
+                '__utils__': utils,
+            }
+        }
+
+    def test_install_single_package(self):
+        '''
+        Test installing a single package
+        '''
+        pkg_list_pre = {
+            'pkg://solaris/compress/bzip2': '1.0.6,5.11-0.175.3.10.0.4.0:20160630T215500Z',
+            'pkg://solaris/compress/gzip': '1.5,5.11-0.175.3.0.0.30.0:20150821T161446Z',
+            'pkg://solaris/compress/p7zip': '16.2.3,5.11-0.175.3.34.0.2.0:20180614T204908Z',
+        }
+        pkg_list_post = {
+            'pkg://solaris/compress/bzip2': '1.0.6,5.11-0.175.3.10.0.4.0:20160630T215500Z',
+            'pkg://solaris/compress/gzip': '1.5,5.11-0.175.3.0.0.30.0:20150821T161446Z',
+            'pkg://solaris/compress/p7zip': '16.2.3,5.11-0.175.3.34.0.2.0:20180614T204908Z',
+            'pkg://solaris/text/less': '458,5.11-0.175.3.0.0.30.0:20150821T172730Z',
+        }
+        install_cmd = {
+            'pid': 1234,
+            'retcode': 0,
+            'stderr': '',
+            'stdout': '',
+        }
+        mock_install_cmd = MagicMock(return_value=install_cmd)
+        list_pkgs_responses = [pkg_list_pre, pkg_list_post]
+        with patch.object(solarisips, 'is_installed', return_value=False), \
+                patch.object(solarisips, 'list_pkgs', side_effect=list_pkgs_responses), \
+                patch.dict(solarisips.__salt__, {'cmd.run_all': mock_install_cmd}):
+            result = solarisips.install(name='less', refresh=False)
+            self.assertEqual(result, salt.utils.data.compare_dicts(pkg_list_pre, pkg_list_post))
+
+    def test_install_list_pkgs(self):
+        '''
+        Test installing a list of packages
+        '''
+        pkg_list_pre = {
+            'pkg://solaris/compress/bzip2': '1.0.6,5.11-0.175.3.10.0.4.0:20160630T215500Z',
+            'pkg://solaris/compress/gzip': '1.5,5.11-0.175.3.0.0.30.0:20150821T161446Z',
+            'pkg://solaris/compress/p7zip': '16.2.3,5.11-0.175.3.34.0.2.0:20180614T204908Z',
+        }
+        pkg_list_post = {
+            'pkg://solaris/compress/bzip2': '1.0.6,5.11-0.175.3.10.0.4.0:20160630T215500Z',
+            'pkg://solaris/compress/gzip': '1.5,5.11-0.175.3.0.0.30.0:20150821T161446Z',
+            'pkg://solaris/compress/p7zip': '16.2.3,5.11-0.175.3.34.0.2.0:20180614T204908Z',
+            'pkg://solaris/text/less': '458,5.11-0.175.3.0.0.30.0:20150821T172730Z',
+            'pkg://solaris/system/library/security/libsasl': '0.5.11,5.11-0.175.3.32.0.1.0:20180406T191209Z',
+        }
+        install_cmd = {
+            'pid': 1234,
+            'retcode': 0,
+            'stderr': '',
+            'stdout': '',
+        }
+        mock_install_cmd = MagicMock(return_value=install_cmd)
+        list_pkgs_responses = [pkg_list_pre, pkg_list_post]
+        with patch.object(solarisips, 'is_installed', return_value=False), \
+                patch.object(solarisips, 'list_pkgs', side_effect=list_pkgs_responses), \
+                patch.dict(solarisips.__salt__, {'cmd.run_all': mock_install_cmd}):
+            result = solarisips.install(pkgs=['less', 'libsasl'], refresh=False)
+            self.assertEqual(result, salt.utils.data.compare_dicts(pkg_list_pre, pkg_list_post))
+
+    def test_install_dict_pkgs_no_version(self):
+        '''
+        Test installing a list of packages
+        '''
+        pkg_list_pre = {
+            'pkg://solaris/compress/bzip2': '1.0.6,5.11-0.175.3.10.0.4.0:20160630T215500Z',
+            'pkg://solaris/compress/gzip': '1.5,5.11-0.175.3.0.0.30.0:20150821T161446Z',
+            'pkg://solaris/compress/p7zip': '16.2.3,5.11-0.175.3.34.0.2.0:20180614T204908Z',
+        }
+        pkg_list_post = {
+            'pkg://solaris/compress/bzip2': '1.0.6,5.11-0.175.3.10.0.4.0:20160630T215500Z',
+            'pkg://solaris/compress/gzip': '1.5,5.11-0.175.3.0.0.30.0:20150821T161446Z',
+            'pkg://solaris/compress/p7zip': '16.2.3,5.11-0.175.3.34.0.2.0:20180614T204908Z',
+            'pkg://solaris/text/less': '458,5.11-0.175.3.0.0.30.0:20150821T172730Z',
+            'pkg://solaris/system/library/security/libsasl': '0.5.11,5.11-0.175.3.32.0.1.0:20180406T191209Z',
+        }
+        install_cmd = {
+            'pid': 1234,
+            'retcode': 0,
+            'stderr': '',
+            'stdout': '',
+        }
+        mock_install_cmd = MagicMock(return_value=install_cmd)
+        list_pkgs_responses = [pkg_list_pre, pkg_list_post]
+        with patch.object(solarisips, 'is_installed', return_value=False), \
+                patch.object(solarisips, 'list_pkgs', side_effect=list_pkgs_responses), \
+                patch.dict(solarisips.__salt__, {'cmd.run_all': mock_install_cmd}):
+            result = solarisips.install(pkgs=[{'less': ''}, {'libsasl': ''}], refresh=False)
+            self.assertEqual(result, salt.utils.data.compare_dicts(pkg_list_pre, pkg_list_post))
+
+    def test_install_dict_pkgs_with_version(self):
+        '''
+        Test installing a list of packages
+        '''
+        pkg_list_pre = {
+            'pkg://solaris/compress/bzip2': '1.0.6,5.11-0.175.3.10.0.4.0:20160630T215500Z',
+            'pkg://solaris/compress/gzip': '1.5,5.11-0.175.3.0.0.30.0:20150821T161446Z',
+            'pkg://solaris/compress/p7zip': '16.2.3,5.11-0.175.3.34.0.2.0:20180614T204908Z',
+        }
+        pkg_list_post = {
+            'pkg://solaris/compress/bzip2': '1.0.6,5.11-0.175.3.10.0.4.0:20160630T215500Z',
+            'pkg://solaris/compress/gzip': '1.5,5.11-0.175.3.0.0.30.0:20150821T161446Z',
+            'pkg://solaris/compress/p7zip': '16.2.3,5.11-0.175.3.34.0.2.0:20180614T204908Z',
+            'pkg://solaris/text/less': '458,5.11-0.175.3.0.0.30.0:20150821T172730Z',
+            'pkg://solaris/system/library/security/libsasl': '0.5.11,5.11-0.175.3.32.0.1.0:20180406T191209Z',
+        }
+        install_cmd = {
+            'pid': 1234,
+            'retcode': 0,
+            'stderr': '',
+            'stdout': '',
+        }
+        mock_install_cmd = MagicMock(return_value=install_cmd)
+        list_pkgs_responses = [pkg_list_pre, pkg_list_post]
+        with patch.object(solarisips, 'is_installed', return_value=False), \
+                patch.object(solarisips, 'list_pkgs', side_effect=list_pkgs_responses), \
+                patch.dict(solarisips.__salt__, {'cmd.run_all': mock_install_cmd}):
+            result = solarisips.install(pkgs=[
+                    {'less': '458,5.11-0.175.3.0.0.30.0:20150821T172730Z'},
+                    {'libsasl': '0.5.11,5.11-0.175.3.32.0.1.0:20180406T191209Z'}], refresh=False)
+            self.assertEqual(result, salt.utils.data.compare_dicts(pkg_list_pre, pkg_list_post))
+
+    def test_install_already_installed_single_pkg(self):
+        '''
+        Test installing a package that is already installed
+        '''
+        result = None
+        expected_result = 'Package already installed.'
+        with patch.object(solarisips, 'is_installed', return_value=True):
+            result = solarisips.install(name='less')
+        self.assertEqual(result, expected_result)

--- a/tests/unit/modules/test_solarisips.py
+++ b/tests/unit/modules/test_solarisips.py
@@ -2,13 +2,11 @@
 
 # Import Python Libs
 from __future__ import absolute_import
-import os
 
 # Import Salt Testing Libs
 from tests.support.mixins import LoaderModuleMockMixin
 from tests.support.unit import TestCase, skipIf
 from tests.support.mock import (
-    Mock,
     MagicMock,
     patch,
     NO_MOCK,
@@ -19,6 +17,7 @@ from tests.support.mock import (
 import salt.modules.solarisips as solarisips
 import salt.modules.pkg_resource as pkg_resource
 import salt.utils.data
+
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
 class IpsTestCase(TestCase, LoaderModuleMockMixin):


### PR DESCRIPTION
### What does this PR do?
Corrects two bugs in the solarisips module:

1) #50874 - where pkg.install would not accept a list of packages
2) Unreported bug where multiple package names were improperly quoted (i.e. "package1 package2" instead of "package1" "pacakge2") when being passed to the pkg command, which would cause the install to fail

### What issues does this PR fix or reference?
#50874

### Previous Behavior
Unable to use pkg.install to install a list of packages or a dict of packages

### New Behavior
pkg.install allows passing "pkgs" as a list or a dict of names/versions and properly passes the package names to the `pkg install` command

### Tests written?
Yes

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
