### PR TITLE
Convert data to string using salt util

### DIFF
--- a/salt/utils/filebuffer.py
+++ b/salt/utils/filebuffer.py
@@ -11,8 +11,8 @@
 from __future__ import absolute_import, unicode_literals, print_function
 
 # Import salt libs
-from salt.ext import six
 import salt.utils.files
+import salt.utils.stringutils
 from salt.exceptions import SaltException
 
 
@@ -85,14 +85,11 @@ class BufferedReader(object):
             multiplier = 1
             self.__buffered = self.__buffered[self.__chunk_size:]
 
-        if six.PY3:
-            # Data is a byte object in Python 3
-            # Decode it in order to append to self.__buffered str later
-            data = self.__file.read(self.__chunk_size * multiplier).decode(
-                __salt_system_encoding__
-            )
-        else:
-            data = self.__file.read(self.__chunk_size * multiplier)
+        data = self.__file.read(self.__chunk_size * multiplier)
+        # Data is a byte object in Python 3
+        # Decode it in order to append to self.__buffered str later
+        # Use the salt util in case it's already a string (Windows)
+        data = salt.utils.stringutils.to_str(data)
 
         if not data:
             self.__file.close()


### PR DESCRIPTION
### What does this PR do?
Fixes issue in Py3 on Windows where the filebuffer is trying to decode something that's already a string.

This PR will use the salt util to convert to string which handles those cases nicely.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/51309

An optional fix is to open the filebuffer using `'rb'` mode. I went with this approach...

### Tests written?
No

### Commits signed with GPG?
Yes