### PR TITLE
Fixes salt.utils.EtcdClient.write so it distinguishes between the different python-etcd logic for files/directories

### DIFF
--- a/salt/utils/etcd_util.py
+++ b/salt/utils/etcd_util.py
@@ -275,6 +275,8 @@ class EtcdClient(object):
         try:
             result = self.client.write(key, value, ttl=ttl, dir=False)
         except (etcd.EtcdNotFile, etcd.EtcdRootReadOnly, ValueError) as err:
+            # If EtcdNotFile is raised, then this key is a directory and
+            # really this is a name collision.
             log.error('etcd: %s', err)
             return None
         except MaxRetryError as err:
@@ -298,6 +300,8 @@ class EtcdClient(object):
             log.info('etcd: directory already exists: %s', key)
             return True
         except (etcd.EtcdNotDir, etcd.EtcdRootReadOnly, ValueError) as err:
+            # If EtcdNotDir is raised, then the specified path is a file and
+            # thus this is an error.
             log.error('etcd: %s', err)
             return None
         except MaxRetryError as err:

--- a/salt/utils/etcd_util.py
+++ b/salt/utils/etcd_util.py
@@ -274,7 +274,7 @@ class EtcdClient(object):
     def write_file(self, key, value, ttl=None):
         try:
             result = self.client.write(key, value, ttl=ttl, dir=False)
-        except (etcd.EtcdNotDir, etcd.EtcdRootReadOnly, ValueError) as err:
+        except (etcd.EtcdNotFile, etcd.EtcdRootReadOnly, ValueError) as err:
             log.error('etcd: %s', err)
             return None
         except MaxRetryError as err:
@@ -292,7 +292,12 @@ class EtcdClient(object):
         try:
             # directories can't have values, but have to have it passed
             result = self.client.write(key, None, ttl=ttl, dir=True)
-        except (etcd.EtcdNotFile, etcd.EtcdRootReadOnly, ValueError) as err:
+        except etcd.EtcdNotFile:
+            # When a directory already exists, python-etcd raises an EtcdNotFile
+            # exception. In this case, we just catch and return True for success.
+            log.info('etcd: directory already exists: %s', key)
+            return True
+        except (etcd.EtcdNotDir, etcd.EtcdRootReadOnly, ValueError) as err:
             log.error('etcd: %s', err)
             return None
         except MaxRetryError as err:

--- a/tests/unit/utils/test_etcd_util.py
+++ b/tests/unit/utils/test_etcd_util.py
@@ -174,17 +174,33 @@ class EtcdUtilTestCase(TestCase):
             self.assertEqual(client.write('/some-dir', 'salt', ttl=0, directory=True), True)
             etcd_client.write.assert_called_with('/some-dir', None, ttl=0, dir=True)
 
+            # Check when a file is attempted to be written to a read-only root
             etcd_client.write.side_effect = etcd.EtcdRootReadOnly()
-            self.assertEqual(client.write('/', 'some-val'), None)
+            self.assertEqual(client.write('/', 'some-val', directory=False), None)
 
-            etcd_client.write.side_effect = etcd.EtcdNotFile()
-            self.assertEqual(client.write('/some-key', 'some-val'), None)
+            # Check when a directory is attempted to be written to a read-only root
+            etcd_client.write.side_effect = etcd.EtcdRootReadOnly()
+            self.assertEqual(client.write('/', None, directory=True), None)
 
-            etcd_client.write.side_effect = etcd.EtcdNotDir()
-            self.assertEqual(client.write('/some-dir', 'some-val'), None)
-
+            # Check when a file is attempted to be written when unable to connect to the service
             etcd_client.write.side_effect = MaxRetryError(None, None)
-            self.assertEqual(client.write('/some-key', 'some-val'), None)
+            self.assertEqual(client.write('/some-key', 'some-val', directory=False), None)
+
+            # Check when a directory is attempted to be written when unable to connect to the service
+            etcd_client.write.side_effect = MaxRetryError(None, None)
+            self.assertEqual(client.write('/some-dir', None, directory=True), None)
+
+            # Check when a file is attempted to be written to a directory that already exists (name-collision)
+            etcd_client.write.side_effect = etcd.EtcdNotFile()
+            self.assertEqual(client.write('/some-dir', 'some-val', directory=False), None)
+
+            # Check when a directory is attempted to be written to a file that already exists (name-collision)
+            etcd_client.write.side_effect = etcd.EtcdNotDir()
+            self.assertEqual(client.write('/some-key', None, directory=True), None)
+
+            # Check when a directory is attempted to be written to a directory that already exists (update-ttl)
+            etcd_client.write.side_effect = etcd.EtcdNotFile()
+            self.assertEqual(client.write('/some-dir', None, directory=True), True)
 
             etcd_client.write.side_effect = ValueError
             self.assertEqual(client.write('/some-key', 'some-val'), None)


### PR DESCRIPTION
### What does this PR do?
Fixes some oversights in the salt.utils.etcd_util module when creating directories vs files.

### What issues does this PR fix or reference?
Closes issue #51537

### Previous Behavior
When creating a directory an error message is logged saying the path is not a file.

### New Behavior
Fixes the prior mentioned behaviour.

### Tests written?
I'm tired.

### Commits signed with GPG?
No.