### PR TITLE
Silence linux_distribution deprecation warning

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -22,6 +22,7 @@ import locale
 import uuid
 from errno import EACCES, EPERM
 import datetime
+import warnings
 
 __proxyenabled__ = ['*']
 __FQDN__ = None
@@ -34,7 +35,12 @@ _supported_dists += ('arch', 'mageia', 'meego', 'vmware', 'bluewhite64',
 
 # linux_distribution deprecated in py3.7
 try:
-    from platform import linux_distribution
+    from platform import linux_distribution as _deprecated_linux_distribution
+
+    def linux_distribution(**kwargs):
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            return _deprecated_linux_distribution(**kwargs)
 except ImportError:
     from distro import linux_distribution
 

--- a/salt/version.py
+++ b/salt/version.py
@@ -8,10 +8,16 @@ from __future__ import absolute_import, print_function, unicode_literals
 import re
 import sys
 import platform
+import warnings
 
 # linux_distribution deprecated in py3.7
 try:
-    from platform import linux_distribution
+    from platform import linux_distribution as _deprecated_linux_distribution
+
+    def linux_distribution(**kwargs):
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            return _deprecated_linux_distribution(**kwargs)
 except ImportError:
     from distro import linux_distribution
 


### PR DESCRIPTION
The salt master log is flooded with deprecation warnings:

```
Feb 07 10:45:34 debian salt-master[1657]: [WARNING ]
/usr/lib/python3/dist-packages/salt/grains/core.py:1759:
DeprecationWarning: dist() and linux_distribution() functions are deprecated in Python 3.5
Feb 07 10:45:34 debian salt-master[1657]:
linux_distribution(supported_dists=_supported_dists)]
Feb 07 10:45:34 debian salt-master[1657]: [WARNING ]
/usr/lib/python3/dist-packages/salt/grains/core.py:1759:
DeprecationWarning: dist() and linux_distribution() functions are deprecated in Python 3.5
```

Since the import statement already falls back to use distro.linux_distribution, silence the deprecation warning.

Bug-Debian: https://bugs.debian.org/921630