### PR TITLE
Let dpkg.info expose package status

### DIFF
--- a/salt/modules/dpkg.py
+++ b/salt/modules/dpkg.py
@@ -319,6 +319,7 @@ def _get_pkg_info(*packages, **kwargs):
           "SHA256:${SHA256}\\n" \
           "origin:${Origin}\\n" \
           "homepage:${Homepage}\\n" \
+          "status:${db:Status-Abbrev}\\n" \
           "======\\n" \
           "description:${Description}\\n" \
           "------\\n'"

--- a/tests/unit/modules/test_dpkg.py
+++ b/tests/unit/modules/test_dpkg.py
@@ -46,7 +46,8 @@ class DpkgTestCase(TestCase, LoaderModuleMockMixin):
                                               'depend on the latest\n recommended Emacs release.\n',
          'package': 'emacs', 'source': 'emacs-defaults',
          'maintainer': 'Simpsons Developers <simpsons-devel-discuss@lists.springfield.org>',
-         'build_date_time_t': 1407430308, 'installed_size': '25', 'install_date': '2016-12-14T20:02:58Z'}
+         'build_date_time_t': 1407430308, 'installed_size': '25', 'install_date': '2016-12-14T20:02:58Z',
+         'status': 'ii'}
     ]
 
     def setup_loader_modules(self):
@@ -147,12 +148,13 @@ class DpkgTestCase(TestCase, LoaderModuleMockMixin):
         for pkg_section in ['section', 'architecture', 'original-maintainer', 'maintainer', 'package', 'installed-size',
                             'build_date_time_t', 'sha256', 'origin', 'build_date', 'size', 'source', 'version',
                             'install_date_time_t', 'license', 'priority', 'description', 'md5sum', 'supported',
-                            'filename', 'sha1', 'install_date', 'arch']:
+                            'filename', 'sha1', 'install_date', 'arch', "status"]:
             assert pkg_section in pkg_data
 
         assert pkg_data['section'] == 'editors'
         assert pkg_data['maintainer'] == 'Simpsons Developers <simpsons-devel-discuss@lists.springfield.org>'
         assert pkg_data['license'] == 'BSD v3'
+        assert pkg_data['status'] == 'ii'
 
     @patch('salt.modules.dpkg._get_pkg_ds_avail', MagicMock(return_value=dselect_pkg))
     @patch('salt.modules.dpkg._get_pkg_info', MagicMock(return_value=pkgs_info))


### PR DESCRIPTION
### What does this PR do?

`dpkg.info` calls `dpkg-query -W ...` under the hood. This reports also packages that are not completely removed (status `rc`) or packages that are purged (status `pn`). See more [here](https://linuxprograms.wordpress.com/2010/05/11/status-dpkg-list/) and [here.](https://linuxprograms.wordpress.com/2010/05/12/pn-dpkg-list/).

This PR exposes the package `status` in the data returned by `dpkg.info`. 

### What issues does this PR fix or reference?

None.

### Previous Behavior
Package status no exposed.

### New Behavior
Package status is exposed.

### Tests written?

Yes

### Commits signed with GPG?

No

