### PR TITLE
Fix test_windows_platform_data grains test for Windows Server 2019

### DIFF
--- a/tests/unit/grains/test_core.py
+++ b/tests/unit/grains/test_core.py
@@ -601,7 +601,7 @@ class CoreGrainsTestCase(TestCase, LoaderModuleMockMixin):
         self.assertIn(returned_grains['windowsdomaintype'], valid_types)
         valid_releases = ['Vista', '7', '8', '8.1', '10', '2008Server',
                           '2008ServerR2', '2012Server', '2012ServerR2',
-                          '2016Server']
+                          '2016Server', '2019Server']
         self.assertIn(returned_grains['osrelease'], valid_releases)
 
     @skipIf(not salt.utils.platform.is_linux(), 'System is not Linux')


### PR DESCRIPTION
### What does this PR do?
Adds support for Windows Server 2019 to the Windows Platform grain tests.

### What issues does this PR fix or reference?
https://jenkinsci.saltstack.com/job/2019.2.0.rc1/job/salt-windows-2019-py2/1/testReport/junit/unit.grains.test_core/CoreGrainsTestCase/test_windows_platform_data/

### Tests written?
Yes

### Commits signed with GPG?
Yes