### PR TITLE
Update url to libsodium for mac builds

### DIFF
--- a/pkg/osx/build_env.sh
+++ b/pkg/osx/build_env.sh
@@ -177,7 +177,7 @@ $MAKE install
 ############################################################################
 echo -n -e "\033]0;Build_Env: libsodium: download\007"
 
-PKGURL="https://download.libsodium.org/libsodium/releases/libsodium-1.0.15.tar.gz"
+PKGURL="https://download.libsodium.org/libsodium/releases/old/libsodium-1.0.15.tar.gz"
 PKGDIR="libsodium-1.0.15"
 
 download $PKGURL


### PR DESCRIPTION
### What does this PR do?
Updates the URL to libsodium. Libsodium moves older builds into an `old` directory. This version has been moved since the last build.

### Tests written?
NA

### Commits signed with GPG?
Yes