### PR TITLE
Do not load zyppnotify file on module import

### DIFF
--- a/tests/unit/test_zypp_plugins.py
+++ b/tests/unit/test_zypp_plugins.py
@@ -25,8 +25,10 @@ if sys.version_info >= (3,):
 else:
     BUILTINS_OPEN = '__builtin__.open'
 
-zyppnotify = imp.load_source('zyppnotify', os.path.sep.join(os.path.dirname(__file__).split(
-    os.path.sep)[:-2] + ['scripts', 'suse', 'zypper', 'plugins', 'commit', 'zyppnotify']))
+ZYPPNOTIFY_FILE = os.path.sep.join(
+    os.path.dirname(__file__).split(os.path.sep)[:-2] +
+    ['scripts', 'suse', 'zypper', 'plugins', 'commit', 'zyppnotify']
+)
 
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
@@ -40,6 +42,7 @@ class ZyppPluginsTestCase(TestCase):
         Returns:
 
         '''
+        zyppnotify = imp.load_source('zyppnotify', ZYPPNOTIFY_FILE)
         drift = zyppnotify.DriftDetector()
         drift._get_mtime = MagicMock(return_value=123)
         drift._get_checksum = MagicMock(return_value='deadbeef')


### PR DESCRIPTION
The call `imp.load_source()` could fail (i.e. when the specified zyppnotify does not exist). To prevent an import failure in that case, move the loading of the zyppnotify file into the test case.