### PR TITLE
test_argspec_report: Fix expected argspec_report result

### DIFF
--- a/tests/unit/utils/test_args.py
+++ b/tests/unit/utils/test_args.py
@@ -130,8 +130,9 @@ class ArgsTestCase(TestCase):
         sys_mock = create_autospec(_test_spec)
         test_functions = {'test_module.test_spec': sys_mock}
         ret = salt.utils.args.argspec_report(test_functions, 'test_module.test_spec')
-        self.assertDictEqual(ret, {'test_module.test_spec':
-                                       {'kwargs': True, 'args': None, 'defaults': None, 'varargs': True}})
+        self.assertDictEqual(ret, {'test_module.test_spec': {
+            'args': ['arg1', 'arg2', 'kwarg1'], 'defaults': (None,),
+            'kwargs': None, 'varargs': None}})
 
     def test_test_mode(self):
         self.assertTrue(salt.utils.args.test_mode(test=True))


### PR DESCRIPTION
The test_argspec_report test fails on Debian testing/unstable (as described in #51555):

```
======================================================================
FAIL: test_argspec_report (unit.utils.test_args.ArgsTestCase)
[CPU:100.0%|MEM:21.2%]
----------------------------------------------------------------------
Traceback (most recent call last):
  File "tests/unit/utils/test_args.py", line 134, in test_argspec_report
    {'kwargs': True, 'args': None, 'defaults': None, 'varargs': True}})
AssertionError: {'tes[18 chars]': {'args': ['arg1', 'arg2', 'kwarg1'],
'defau[43 chars]one}} != {'tes[18 chars]': {'kwargs': True, 'args':
None, 'defaults': [18 chars]rue}}
- {'test_module.test_spec': {'args': ['arg1', 'arg2', 'kwarg1'],
+ {'test_module.test_spec': {'args': None,
-                            'defaults': (None,),
?                                        -     --

+                            'defaults': None,
-                            'kwargs': None,
?                                      ^^^

+                            'kwargs': True,
?                                      ^^^

-                            'varargs': None}}
?                                       ^^^

+                            'varargs': True}}
?                                       ^^^
```

Adjust the expected result of argspec_report() to the argument specification of the _test_spec() function.
