### PR TITLE
Bugfix : Fix RabbitMQ policy definition change check

### DIFF
--- a/salt/states/rabbitmq_policy.py
+++ b/salt/states/rabbitmq_policy.py
@@ -21,6 +21,7 @@ from __future__ import absolute_import
 
 # Import python libs
 import logging
+import json
 import salt.utils
 
 log = logging.getLogger(__name__)
@@ -66,7 +67,10 @@ def present(name,
     if policy:
         if policy.get('pattern') != pattern:
             updates.append('Pattern')
-        if policy.get('definition') != definition:
+        current_definition = policy.get('definition')
+        current_definition = json.loads(current_definition) if current_definition else ''
+        new_definition = json.loads(definition) if definition else ''
+        if current_definition != new_definition:
             updates.append('Definition')
         if int(policy.get('priority')) != priority:
             updates.append('Priority')


### PR DESCRIPTION
### What does this PR do?
Fix the way the rabbitmq_policy.present state compares the existing policy definition to the given policy definition to define the changes to apply.

As this field is a json field, compare the dict objects generated by `json.loads` instead of doing a string comparison.

### What issues does this PR fix or reference?

Could not find any related issue.

### Previous Behavior
An example state is defined like the following :
```
rabbit_policy:
  rabbitmq_policy.present:
    - name: HA
    - pattern: '.*'
    - definition: '{"ha-mode": "all"}'
```

Now, `salt "*saltmaster*" rabbitmq.list_policies` returns the policies for the vhost /, with the previous policy defined it returns for the policy definition :
``` 
definition:
                {"ha-mode":"all"}
```

So, in the current state of the code, the definition from the state and the definition returned by `list_policies` are compared as string, and due to the space that is removed between the property name and its value, the state acts like there was indeed a change in the definition.

### New Behavior
Policy definitions are compared as dictionnaries and not as strings, avoiding uneeded re-application of existing policy.

### Tests written?

No

### Commits signed with GPG?

No