### PR TITLE
Imgadm docker

### DIFF
--- a/salt/modules/smartos_imgadm.py
+++ b/salt/modules/smartos_imgadm.py
@@ -110,8 +110,7 @@ def _split_docker_uuid(uuid):
         if len(uuid) == 2:
             tag = uuid[1]
             repo = uuid[0]
-            if len(repo.split('/')) == 2:
-                return repo, tag
+            return repo, tag
     return None, None
 
 

--- a/salt/states/smartos.py
+++ b/salt/states/smartos.py
@@ -157,8 +157,7 @@ def _split_docker_uuid(uuid):
         if len(uuid) == 2:
             tag = uuid[1]
             repo = uuid[0]
-            if len(repo.split('/')) == 2:
-                return repo, tag
+            return repo, tag
     return None, None
 
 

--- a/salt/states/smartos.py
+++ b/salt/states/smartos.py
@@ -809,6 +809,19 @@ def vm_present(name, vmconfig, config=None):
                 ret['result'] = False
                 ret['comment'] = 'image {0} not installed'.format(vmconfig['image_uuid'])
 
+    # prepare disk.*.image_uuid
+    for disk in vmconfig['disks'] if 'disks' in vmconfig else []:
+        if 'image_uuid' in disk and disk['image_uuid'] not in __salt__['imgadm.list']():
+            if config['auto_import']:
+                if not __opts__['test']:
+                    res = __salt__['imgadm.import'](disk['image_uuid'])
+                    if disk['image_uuid'] not in res:
+                        ret['result'] = False
+                        ret['comment'] = 'failed to import image {0}'.format(disk['image_uuid'])
+            else:
+                ret['result'] = False
+                ret['comment'] = 'image {0} not installed'.format(disk['image_uuid'])
+
     # docker json-array handling
     if 'internal_metadata' in vmconfig:
         for var in vmconfig_docker_array:


### PR DESCRIPTION
### What does this PR do?
After the recent issues reported with imgadm module/state on SmartOS I did a few more tests and two small improvement should be made.

1. Up until now imgadm module assumed that docker images were always called `account/image:tag`, but this is not always the case, e.g. `fedora:latest` is a valid docker image too.

2. auto_import would not import image for disks, this resulted in confusing errors about image_size.

### What issues does this PR fix or reference?
N/a

### Previous Behavior
Docker images like `fedora:latest` could not be imported. 
Unhelpful error when disk images were missing, even with auto_import set to true.

### New Behavior
Docker images like `fedora:latest` can now be imported. They might still not run properly, but at least now they can be imported.

With auto_import set to true we now also import disks images, this confusing error is still present with auto_import set to false, but we pass it directly from upstream (vmadm). So not much we can do about it in salt.

### Tests written?
No

### Commits signed with GPG?
No