### PR TITLE
git_pillar: Fix all_saltenvs on base env

### DIFF
--- a/salt/utils/gitfs.py
+++ b/salt/utils/gitfs.py
@@ -2989,7 +2989,7 @@ class GitPillar(GitBase):
                 if repo.branch == '__env__' and hasattr(repo, 'all_saltenvs'):
                     env = self.opts.get('pillarenv') \
                         or self.opts.get('saltenv') \
-                        or self.opts.get('git_pillar_base')
+                        or 'base'
                 elif repo.env:
                     env = repo.env
                 else:


### PR DESCRIPTION
### What does this PR do?

Fixes #50768.

### What issues does this PR fix or reference?

PR #50768.

### Previous Behavior
```
minion:
    Data failed to compile:
----------
    Pillar failed to render with the following messages:
----------
    Specified SLS 'projects.gitlab' in environment 'prod' is not available on the salt master
```


### New Behavior

State applies succesfully.

### Tests written?

No

### Commits signed with GPG?

Yes