### PR TITLE
Backport #51510 to 2018.3 branch

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1389,7 +1389,9 @@ _OS_FAMILY_MAP = {
     'KDE neon': 'Debian',
     'Void': 'Void',
     'IDMS': 'Debian',
-    'AIX': 'AIX'
+    'Funtoo': 'Gentoo',
+    'AIX': 'AIX',
+    'TurnKey': 'Debian',
 }
 
 # Matches any possible format:


### PR DESCRIPTION
Note that this also includes a recently-added grain from 5675166, as it also should have been backported.