### PR TITLE
Handle explicit lists properly

### DIFF
--- a/salt/modules/win_lgpo.py
+++ b/salt/modules/win_lgpo.py
@@ -5605,7 +5605,7 @@ def _getDataFromRegPolData(search_string, policy_data, return_value_name=False):
                                                        )
                                         ].split(encoded_semicolon)
                 if len(pol_entry) >= 2:
-                    valueName = pol_entry[1]
+                    valueName = pol_entry[1].decode('utf-16-le').rstrip(chr(0))
                 if len(pol_entry) >= 5:
                     value = pol_entry[4]
                     if vtype == 'REG_DWORD' or vtype == 'REG_QWORD':
@@ -5923,18 +5923,18 @@ def _processValueItem(element, reg_key, reg_valuename, policy, parent_element,
                                          ']'.encode('utf-16-le')])
             if 'expandable' in element.attrib:
                 this_vtype = 'REG_EXPAND_SZ'
-            if 'explicitValue' in element.attrib and element.attrib['explicitValue'].lower() == 'true':
+            if element.attrib.get('explicitValue', 'false').lower() == 'true':
                 if this_element_value is not None:
-                    element_valuenames = this_element_value.keys()
-                    element_values = this_element_value.values()
-            if 'valuePrefix' in element.attrib:
+                    element_valuenames = [str(k) for k in this_element_value.keys()]
+                    element_values = [str(v) for v in this_element_value.values()]
+            elif 'valuePrefix' in element.attrib:
                 # if the valuePrefix attribute exists, the valuenames are <prefix><number>
                 # most prefixes attributes are empty in the admx files, so the valuenames
                 # end up being just numbers
                 if element.attrib['valuePrefix'] != '':
                     if this_element_value is not None:
-                        element_valuenames = ['{0}{1}'.format(element.attrib['valuePrefix'],
-                                                              k) for k in element_valuenames]
+                        element_valuenames = ['{0}{1}'.format(
+                            element.attrib['valuePrefix'], k) for k in element_valuenames]
             else:
                 # if there is no valuePrefix attribute, the valuename is the value
                 if element_values is not None:


### PR DESCRIPTION
### What does this PR do?
Merges forward https://github.com/saltstack/salt/pull/51613

Handles explicit lists properly.
- Properly decodes the key names when getting existing policies with explicit lists
- Does not make value names the same as the values on explicit lists
- Converts the ordered dicts lists to regular lists for PY3

Handles both of these states properly:
unc_paths.sls
```
Hardened UNC Paths:
  lgpo.set:
    - computer_policy:
        'Network\Network Provider\Hardened UNC Paths':
          'Hardened UNC Paths':
            '\\*\NETLOGON':
              RequireMutualAuthentication=1, RequireIntegrity=1
            '\\*\SYSVOL':
              RequireMutualAuthentication=1, RequireIntegrity=1
```
remote_assistance.sls
```
remote_assistance:
  lgpo.set:
    - computer_policy:
        'System\Remote Assistance\Configure Offer Remote Assistance':
          'Permit remote control of this computer':
            'Allow helpers to remotely control the computer'
          'Helpers':
            - Users
            - Administrators
            - Backup Operators
```

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/51566

### Tests written?
Yes

### Commits signed with GPG?
Yes