### PR TITLE
Prevents crash when there is no job entry

### DIFF
--- a/salt/returners/local_cache.py
+++ b/salt/returners/local_cache.py
@@ -77,6 +77,9 @@ def _walk_through(job_dir):
                 except Exception:
                     log.exception('Failed to deserialize %s', load_path)
                     continue
+                if not job:
+                    log.error('Deserialization of job succeded but there is no data in %s', load_path)
+                    continue
                 jid = job['jid']
                 yield jid, job, t_path, final
 


### PR DESCRIPTION
### What does this PR do?

Seems like in rare race conditions it might happen that there is no job entry. This prevents Salt from crashing at that point.

In rare cases we could see this while bootstrapping a minion:

```
Exception occurred in runner jobs.list_jobs: Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/salt/client/mixins.py", line 387, in _low
    data['return'] = self.functions[fun](*args, **kwargs)
  File "/usr/lib/python2.7/site-packages/salt/runners/jobs.py", line 306, in list_jobs
    ret = mminion.returners['{0}.get_jids'.format(returner)]()
  File "/usr/lib/python2.7/site-packages/salt/returners/local_cache.py", line 376, in get_jids
    for jid, job, _, _ in _walk_through(_job_dir()):
  File "/usr/lib/python2.7/site-packages/salt/returners/local_cache.py", line 80, in _walk_through
    jid = job['jid']
TypeError: 'NoneType' object has no attribute '__getitem__'
```

I'm sure that the cause of this can be found somewhere else. But in the meantime it would be nice if Salt wouldn't crash at that point of time.

### Previous Behavior

Salt threw a `TypeError` like above.

### New Behavior

Salt logs an error instead.

### Tests written?

No

### Commits signed with GPG?

Yes