### PR TITLE
Properly create the value for a "True" boolean element item

### DIFF
--- a/salt/modules/win_lgpo.py
+++ b/salt/modules/win_lgpo.py
@@ -5857,7 +5857,7 @@ def _processValueItem(element, reg_key, reg_valuename, policy, parent_element,
                 check_deleted = True
             if not check_deleted:
                 this_vtype = 'REG_DWORD'
-            this_element_value = chr(1).encode('utf-16-le')
+            this_element_value = struct.pack('I', 1)
             standard_element_expected_string = False
         elif etree.QName(element).localname == 'decimal':
             # https://msdn.microsoft.com/en-us/library/dn605987(v=vs.85).aspx

--- a/tests/integration/modules/test_win_lgpo.py
+++ b/tests/integration/modules/test_win_lgpo.py
@@ -260,6 +260,63 @@ class WinLgpoTest(ModuleCase):
         '''
         Test setting/unsetting/changing WindowsUpdate policy
         '''
+        the_policy = {
+            'Configure automatic updating': '4 - Auto download and schedule the install',
+            'Install during automatic maintenance': False,
+            'Scheduled install day': '7 - Every Saturday',
+            'Scheduled install time': '17:00',
+            'Install updates for other Microsoft products': True
+        }
+        the_policy_check = [
+            r'Computer[\s]*Software\\Policies\\Microsoft\\Windows\\WindowsUpdate\\AU[\s]*NoAutoUpdate[\s]*DWORD:0',
+            r'Computer[\s]*Software\\Policies\\Microsoft\\Windows\\WindowsUpdate\\AU[\s]*AUOptions[\s]*DWORD:4',
+            r'Computer[\s]*Software\\Policies\\Microsoft\\Windows\\WindowsUpdate\\AU[\s]*AutomaticMaintenanceEnabled[\s]*DELETE',
+            r'Computer[\s]*Software\\Policies\\Microsoft\\Windows\\WindowsUpdate\\AU[\s]*ScheduledInstallDay[\s]*DWORD:7',
+            r'Computer[\s]*Software\\Policies\\Microsoft\\Windows\\WindowsUpdate\\AU[\s]*ScheduledInstallTime[\s]*DWORD:17',
+            r'Computer[\s]*Software\\Policies\\Microsoft\\Windows\\WindowsUpdate\\AU[\s]*AllowMUUpdateService[\s]*DWORD:1\s*'
+        ]
+
+        # Configure Automatic Updates has different options in 2016 than in 2012
+        # and has only one boolean item, so we'll test it "False" in this block
+        # and then "True" in next block
+        if self.osrelease in ['2012Server', '2012ServerR2']:
+            the_policy = {
+                'Configure automatic updating': '4 - Auto download and schedule the install',
+                'Install during automatic maintenance': False,
+                'Schedule install day': '7 - Every Saturday',
+                'Schedule install time': '17:00',
+            }
+            the_policy_check = [
+                r'Computer[\s]*Software\\Policies\\Microsoft\\Windows\\WindowsUpdate\\AU[\s]*NoAutoUpdate[\s]*DWORD:0',
+                r'Computer[\s]*Software\\Policies\\Microsoft\\Windows\\WindowsUpdate\\AU[\s]*AUOptions[\s]*DWORD:4',
+                r'Computer[\s]*Software\\Policies\\Microsoft\\Windows\\WindowsUpdate\\AU[\s]*AutomaticMaintenanceEnabled[\s]*DELETE',
+                r'Computer[\s]*Software\\Policies\\Microsoft\\Windows\\WindowsUpdate\\AU[\s]*ScheduledInstallDay[\s]*DWORD:7',
+                r'Computer[\s]*Software\\Policies\\Microsoft\\Windows\\WindowsUpdate\\AU[\s]*ScheduledInstallTime[\s]*DWORD:17',
+            ]
+            # test as False
+            self._testComputerAdmxPolicy(r'Windows Components\Windows Update\Configure Automatic Updates',
+                                         the_policy,
+                                         the_policy_check)
+            # configure as True for "enable Automatic Updates" test below
+            the_policy = {
+                'Configure automatic updating': '4 - Auto download and schedule the install',
+                'Install during automatic maintenance': True,
+                'Schedule install day': '7 - Every Saturday',
+                'Schedule install time': '17:00',
+            }
+            the_policy_check = [
+                r'Computer[\s]*Software\\Policies\\Microsoft\\Windows\\WindowsUpdate\\AU[\s]*NoAutoUpdate[\s]*DWORD:0',
+                r'Computer[\s]*Software\\Policies\\Microsoft\\Windows\\WindowsUpdate\\AU[\s]*AUOptions[\s]*DWORD:4',
+                r'Computer[\s]*Software\\Policies\\Microsoft\\Windows\\WindowsUpdate\\AU[\s]*AutomaticMaintenanceEnabled[\s]*DWORD:1\s*',
+                r'Computer[\s]*Software\\Policies\\Microsoft\\Windows\\WindowsUpdate\\AU[\s]*ScheduledInstallDay[\s]*DWORD:7',
+                r'Computer[\s]*Software\\Policies\\Microsoft\\Windows\\WindowsUpdate\\AU[\s]*ScheduledInstallTime[\s]*DWORD:17',
+            ]
+
+        # enable Automatic Updates
+        self._testComputerAdmxPolicy(r'Windows Components\Windows Update\Configure Automatic Updates',
+                                     the_policy,
+                                     the_policy_check)
+
         # disable Configure Automatic Updates
         self._testComputerAdmxPolicy(r'Windows Components\Windows Update\Configure Automatic Updates',
                                      'Disabled',


### PR DESCRIPTION
### What does this PR do?
Properly creates the 'True' value for boolean admx element item

### What issues does this PR fix or reference?
#51634 

### Previous Behavior
True values for a boolean element type were not created properly in the Registry.pol file

### New Behavior
True values are created properly

### Tests written?
Yes

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
