### PR TITLE
[2017.7]  Increase minion wait for slow boxes

### DIFF
--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -181,7 +181,7 @@ class TestDaemon(object):
     '''
     Set up the master and minion daemons, and run related cases
     '''
-    MINIONS_CONNECT_TIMEOUT = MINIONS_SYNC_TIMEOUT = 300
+    MINIONS_CONNECT_TIMEOUT = MINIONS_SYNC_TIMEOUT = 500
 
     def __init__(self, parser):
         self.parser = parser


### PR DESCRIPTION
### What does this PR do?

We are still seeing a few cases of failed windows py3 builds, increasing minion wait time.

### Tests written?

No

### Commits signed with GPG?

Yes
