### PR TITLE
Strip trailing "/" from repo.uri when comparing repos in apktpkg.mod_repo

### DIFF
--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -2304,7 +2304,7 @@ def mod_repo(repo, saltenv='base', **kwargs):
         # and the resulting source line.  The idea here is to ensure
         # we are not returning bogus data because the source line
         # has already been modified on a previous run.
-        repo_matches = source.type == repo_type and source.uri == repo_uri and source.dist == repo_dist
+        repo_matches = source.type == repo_type and source.uri.rstrip('/') == repo_uri.rstrip('/') and source.dist == repo_dist
         kw_matches = source.dist == kw_dist and source.type == kw_type
 
         if repo_matches or kw_matches:


### PR DESCRIPTION
### What does this PR do?

Strip trailing `/` from repo URI when comparing repos in `apktpkg.mod_repo`.

### What issues does this PR fix or reference?

None

### Previous Behavior
`salt-call --local pkg.mod_repo repo="deb http://es.archive.ubuntu.com/ubuntu xenial main restricted" ...`

did not find the target repo if it had a trailing `/` in the URI because repo URIs were compared 
verbatim.
E.g. from `/etc/apt/sorces.list` on Ubuntu 16.04:
```
deb http://es.archive.ubuntu.com/ubuntu/ xenial restricted main
```

### New Behavior
To be consistent with the rest of functions from `aptpkg` the trailing `/` are removed when comparing repos URIs in `mod_repo`.

### Tests written?

No

### Commits signed with GPG?

No


