### PR TITLE
[2017.7] Removing unused salt.crypt imports

### DIFF
--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -3572,7 +3572,6 @@ def apply_master_config(overrides=None, defaults=None):
     '''
     Returns master configurations dict.
     '''
-    import salt.crypt
     if defaults is None:
         defaults = DEFAULT_MASTER_OPTS
 

--- a/salt/payload.py
+++ b/salt/payload.py
@@ -14,7 +14,6 @@ import datetime
 
 # Import salt libs
 import salt.log
-import salt.crypt
 import salt.transport.frame
 from salt.exceptions import SaltReqTimeoutError
 from salt.utils import immutabletypes

--- a/salt/utils/rsax931.py
+++ b/salt/utils/rsax931.py
@@ -70,9 +70,7 @@ def _init_libcrypto():
     libcrypto.RSA_public_decrypt.argtypes = (c_int, c_char_p, c_char_p, c_void_p, c_int)
 
     try:
-        libcrypto.OPENSSL_init_crypto(OPENSSL_INIT_NO_LOAD_CONFIG |
-                                      OPENSSL_INIT_ADD_ALL_CIPHERS |
-                                      OPENSSL_INIT_ADD_ALL_DIGESTS, None)
+        libcrypto.OPENSSL_init_crypto()
     except AttributeError:
         # Support for OpenSSL < 1.1 (OPENSSL_API_COMPAT < 0x10100000L)
         libcrypto.OPENSSL_no_config()


### PR DESCRIPTION
### What does this PR do?
Removing unused salt.crypt imports which are causing salt-master to not start and salt-key to now work when using openssl 1.1.1-1 and tornado >= 5.0.

### What issues does this PR fix or reference?
#49661 

### Previous Behavior
salt-master wouldn't start up if openssl 1.1.1-1 was installed and tornado >= 5.0.
salt-key would produce a crypt SSL error.

### New Behavior
salt-master starts as expected and salt-key works as expected.

### Tests written?
No

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
