### PR TITLE
Iis webconfiguration location parameter

### DIFF
--- a/salt/modules/win_iis.py
+++ b/salt/modules/win_iis.py
@@ -2042,13 +2042,14 @@ def set_webapp_settings(name, site, settings):
     return True
 
 
-def get_webconfiguration_settings(name, settings):
+def get_webconfiguration_settings(name, settings, location=''):
     r'''
     Get the webconfiguration settings for the IIS PSPath.
 
     Args:
         name (str): The PSPath of the IIS webconfiguration settings.
         settings (list): A list of dictionaries containing setting name and filter.
+        location (str): The location of the settings (optional)
 
     Returns:
         dict: A list of dictionaries containing setting name, filter and value.
@@ -2078,27 +2079,28 @@ def get_webconfiguration_settings(name, settings):
                                 '-PSPath', "'{0}'".format(name),
                                 '-Filter', "'{0}'".format(setting['filter']),
                                 '-Name', "'{0}'".format(setting['name']),
+                                '-Location', "'{0}'".format(location),
                                 '-ErrorAction', 'Stop',
                                 '|', 'Out-Null;'])
 
         # Some ItemProperties are Strings and others are ConfigurationAttributes.
         # Since the former doesn't have a Value property, we need to account
-        # for this.
+        # for this.é"
         ps_cmd.append("$Property = Get-WebConfigurationProperty -PSPath '{0}'".format(name))
-        ps_cmd.append("-Name '{0}' -Filter '{1}' -ErrorAction Stop;".format(setting['name'], setting['filter']))
+        ps_cmd.append("-Name '{0}' -Filter '{1}' -Location '{2}' -ErrorAction Stop;".format(setting['name'], setting['filter'], location))
         if setting['name'].split('.')[-1] == 'Collection':
             if 'value' in setting:
                 ps_cmd.append("$Property = $Property | select -Property {0} ;"
                               .format(",".join(list(setting['value'][0].keys()))))
-            ps_cmd.append("$Settings.add(@{{filter='{0}';name='{1}';value=[System.Collections.ArrayList] @($Property)}})| Out-Null;"
-                          .format(setting['filter'], setting['name']))
+            ps_cmd.append("$Settings.add(@{{filter='{0}';name='{1}';location='{2}';value=[System.Collections.ArrayList] @($Property)}})| Out-Null;"
+                          .format(setting['filter'], setting['name'], location))
         else:
             ps_cmd.append(r'if (([String]::IsNullOrEmpty($Property) -eq $False) -and')
             ps_cmd.append(r"($Property.GetType()).Name -eq 'ConfigurationAttribute') {")
             ps_cmd.append(r'$Property = $Property | Select-Object')
             ps_cmd.append(r'-ExpandProperty Value };')
-            ps_cmd.append("$Settings.add(@{{filter='{0}';name='{1}';value=[String] $Property}})| Out-Null;"
-                          .format(setting['filter'], setting['name']))
+            ps_cmd.append("$Settings.add(@{{filter='{0}';name='{1}';location='{2}';value=[String] $Property}})| Out-Null;"
+                          .format(setting['filter'], setting['name'], location))
         ps_cmd.append(r'$Property = $Null;')
 
     # Validate the setting names that were passed in.
@@ -2120,13 +2122,14 @@ def get_webconfiguration_settings(name, settings):
     return ret
 
 
-def set_webconfiguration_settings(name, settings):
+def set_webconfiguration_settings(name, settings, location=''):
     r'''
     Set the value of the setting for an IIS container.
 
     Args:
         name (str): The PSPath of the IIS webconfiguration settings.
         settings (list): A list of dictionaries containing setting name, filter and value.
+        location (str): The location of the settings (optional)
 
     Returns:
         bool: True if successful, otherwise False
@@ -2152,7 +2155,7 @@ def set_webconfiguration_settings(name, settings):
             settings[idx]['value'] = six.text_type(setting['value'])
 
     current_settings = get_webconfiguration_settings(
-        name=name, settings=settings)
+        name=name, settings=settings, location=location)
 
     if settings == current_settings:
         log.debug('Settings already contain the provided values.')
@@ -2179,6 +2182,7 @@ def set_webconfiguration_settings(name, settings):
                        '-PSPath', "'{0}'".format(name),
                        '-Filter', "'{0}'".format(setting['filter']),
                        '-Name', "'{0}'".format(setting['name']),
+                       '-Location', "'{0}'".format(location),
                        '-Value', '{0};'.format(value)])
 
     cmd_ret = _srvmgr(ps_cmd)
@@ -2190,7 +2194,7 @@ def set_webconfiguration_settings(name, settings):
     # Get the fields post-change so that we can verify tht all values
     # were modified successfully. Track the ones that weren't.
     new_settings = get_webconfiguration_settings(
-        name=name, settings=settings)
+        name=name, settings=settings, location=location)
 
     failed_settings = []
 

--- a/salt/modules/win_iis.py
+++ b/salt/modules/win_iis.py
@@ -2085,7 +2085,7 @@ def get_webconfiguration_settings(name, settings, location=''):
 
         # Some ItemProperties are Strings and others are ConfigurationAttributes.
         # Since the former doesn't have a Value property, we need to account
-        # for this.é"
+        # for this.
         ps_cmd.append("$Property = Get-WebConfigurationProperty -PSPath '{0}'".format(name))
         ps_cmd.append("-Name '{0}' -Filter '{1}' -Location '{2}' -ErrorAction Stop;".format(setting['name'], setting['filter'], location))
         if setting['name'].split('.')[-1] == 'Collection':

--- a/salt/states/win_iis.py
+++ b/salt/states/win_iis.py
@@ -871,13 +871,14 @@ def set_app(name, site, settings=None):
     return ret
 
 
-def webconfiguration_settings(name, settings=None):
+def webconfiguration_settings(name, location='', settings=None):
     r'''
     Set the value of webconfiguration settings.
 
     :param str name: The name of the IIS PSPath containing the settings.
         Possible PSPaths are :
         MACHINE, MACHINE/WEBROOT, IIS:\, IIS:\Sites\sitename, ...
+    :param str location: The location of the settings.
     :param dict settings: Dictionaries of dictionaries.
         You can match a specific item in a collection with this syntax inside a key:
         'Collection[{name: site0}].logFile.directory'
@@ -925,6 +926,18 @@ def webconfiguration_settings(name, settings=None):
                 system.applicationHost/sites:
                   'Collection[{name: site0}].logFile.directory': 'C:\logs\iis\site0'
 
+    Example of usage with a location:
+
+    .. code-block:: yaml
+
+        site0-IIS-location-level-security:
+          win_iis.webconfiguration_settings:
+            - name: 'IIS:/'
+            - location: 'site0'
+            - settings:
+              system.webServer/security/authentication/basicAuthentication:
+                enabled: True
+
     '''
 
     ret = {'name': name,
@@ -949,7 +962,7 @@ def webconfiguration_settings(name, settings=None):
             settings_list.append({'filter': filter, 'name': setting_name, 'value': value})
 
     current_settings_list = __salt__['win_iis.get_webconfiguration_settings'](name=name,
-                                                                                  settings=settings_list)
+                                                                                  settings=settings_list, location=location)
     for idx, setting in enumerate(settings_list):
 
         is_collection = setting['name'].split('.')[-1] == 'Collection'
@@ -967,10 +980,10 @@ def webconfiguration_settings(name, settings=None):
         ret['changes'] = ret_settings
         return ret
 
-    __salt__['win_iis.set_webconfiguration_settings'](name=name, settings=settings_list)
+    __salt__['win_iis.set_webconfiguration_settings'](name=name, settings=settings_list, location=location)
 
     new_settings_list = __salt__['win_iis.get_webconfiguration_settings'](name=name,
-                                                                              settings=settings_list)
+                                                                              settings=settings_list, location=location)
     for idx, setting in enumerate(settings_list):
 
         is_collection = setting['name'].split('.')[-1] == 'Collection'


### PR DESCRIPTION
### What does this PR do?
Add an optional "location" parameter to webconfigurations functions in win_iis execution module and win_iis state module.
This parameter is needed for some very specific configurations, like the one given in example in the state module.
This code does not modify the current behaviour if you already use webconfiguration functions, it's entirely optional.

### What issues does this PR fix or reference?

### Tests written?
No

### Commits signed with GPG?
No
