### PR TITLE
2 enhancements to config.option

### DIFF
--- a/doc/topics/releases/neon.rst
+++ b/doc/topics/releases/neon.rst
@@ -372,9 +372,19 @@ Module Changes
 - Added new :py:func:`boto_ssm <salt.modules.boto_ssm>` module to set and query
   secrets in AWS SSM parameters.
 
-- The :py:func:`file.set_selinux_context <salt.modules.file.set_selinux_context>`
-  module now supports perstant changes with ``persist=True`` by calling the
-  :py:func:`selinux.fcontext_add_policy <salt.modules.selinux.fcontext_add_policy>` module.
+- The :py:func:`file.set_selinux_context
+  <salt.modules.file.set_selinux_context>` module now supports perstant changes
+  with ``persist=True`` by calling the :py:func:`selinux.fcontext_add_policy
+  <salt.modules.selinux.fcontext_add_policy>` module.
+
+- The :py:func:`config.option <salt.modules.config.option>` now also returns
+  matches from the grains, making it align better with :py:func:`config.get
+  <salt.modules.config.get>`.
+
+- Configuration for Docker registries is no longer restricted only to pillar
+  data, and is now loaded using :py:func:`config.option
+  <salt.modules.config.option>`. More information on registry authentication
+  can be found :ref:`here <docker-authentication>`.
 
 - The :py:func:`yumpkg <salt.modules.yumpkg>` module has been updated to support
   VMWare's Photon OS, which uses tdnf (a C implementation of dnf).

--- a/doc/topics/releases/neon.rst
+++ b/doc/topics/releases/neon.rst
@@ -373,8 +373,9 @@ Module Changes
   secrets in AWS SSM parameters.
 
 - The :py:func:`file.set_selinux_context
-  <salt.modules.file.set_selinux_context>` module now supports perstant changes
-  with ``persist=True`` by calling the :py:func:`selinux.fcontext_add_policy
+  <salt.modules.file.set_selinux_context>` module now supports persistant
+  changes with ``persist=True`` by calling the
+  :py:func:`selinux.fcontext_add_policy
   <salt.modules.selinux.fcontext_add_policy>` module.
 
 - The :py:func:`config.option <salt.modules.config.option>` now also returns

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -1183,9 +1183,6 @@ VALID_OPTS = immutabletypes.freeze({
     # Subconfig entries can be specified by using the ':' notation (e.g. key:subkey)
     'pass_to_ext_pillars': (six.string_types, list),
 
-    # Used by salt.modules.dockermod.compare_container_networks to specify which keys are compared
-    'docker.compare_container_networks': dict,
-
     # SSDP discovery publisher description.
     # Contains publisher configuration and minion mapping.
     # Setting it to False disables discovery
@@ -1508,11 +1505,6 @@ DEFAULT_MINION_OPTS = immutabletypes.freeze({
     'extmod_whitelist': {},
     'extmod_blacklist': {},
     'minion_sign_messages': False,
-    'docker.compare_container_networks': {
-        'static': ['Aliases', 'Links', 'IPAMConfig'],
-        'automatic': ['IPAddress', 'Gateway',
-                      'GlobalIPv6Address', 'IPv6Gateway'],
-    },
     'discovery': False,
     'schedule': {},
     'ssh_merge_pillar': True,

--- a/salt/modules/config.py
+++ b/salt/modules/config.py
@@ -242,7 +242,6 @@ def option(
         return ret or default
 
 
-
 def merge(value,
           default='',
           omit_opts=False,

--- a/salt/modules/config.py
+++ b/salt/modules/config.py
@@ -79,6 +79,7 @@ DEFAULTS = {'mongo.db': 'salt',
             'virt': {'tunnel': False,
                      'images': os.path.join(syspaths.SRV_ROOT_DIR, 'salt-images')},
 
+            'docker.exec_driver': 'docker-exec',
             'docker.compare_container_networks': {
                 'static': ['Aliases', 'Links', 'IPAMConfig'],
                 'automatic': ['IPAddress', 'Gateway',

--- a/salt/modules/config.py
+++ b/salt/modules/config.py
@@ -141,14 +141,42 @@ def option(
         omit_grains=False,
         omit_pillar=False,
         omit_master=False,
+        omit_all=False,
         wildcard=False):
     '''
-    Pass in a generic option and receive the value that will be assigned
+    Returns the setting for the specified config value. The priority for
+    matches is the same as in :py:func:`config.get <salt.modules.config.get>`,
+    only this function does not recurse into nested data structures. Another
+    difference between this function and :py:func:`config.get
+    <salt.modules.config.get>` is that it comes with a set of "sane defaults".
+    To view these, you can run the following command:
+
+    .. code-block:: bash
+
+        salt '*' config.option '*' omit_all=True wildcard=True
 
     default
         The default value if no match is found. If not specified, then the
         fallback default will be an empty string, unless ``wildcard=True``, in
         which case the return will be an empty dictionary.
+
+    omit_opts : False
+        Pass as ``True`` to exclude matches from the minion configuration file
+
+    omit_grains : False
+        Pass as ``True`` to exclude matches from the grains
+
+    omit_pillar : False
+        Pass as ``True`` to exclude matches from the pillar data
+
+    omit_master : False
+        Pass as ``True`` to exclude matches from the master configuration file
+
+    omit_all : True
+        Shorthand to omit all of the above and return matches only from the
+        "sane defaults".
+
+        .. versionadded:: Neon
 
     wildcard : False
         If used, this will perform pattern matching on keys. Note that this
@@ -169,6 +197,9 @@ def option(
 
         salt '*' config.option redis.host
     '''
+    if omit_all:
+        omit_opts = omit_grains = omit_pillar = omit_master = True
+
     if default is None:
         default = '' if not wildcard else {}
 

--- a/salt/modules/dockermod.py
+++ b/salt/modules/dockermod.py
@@ -1062,6 +1062,11 @@ def compare_container_networks(first, second):
     than waiting for a new Salt release one can just set
     :conf_minion:`docker.compare_container_networks`.
 
+    .. versionchanged:: Neon
+        This config option can now also be set in pillar data and grains.
+        Additionally, it can be set in the master config file, provided that
+        :conf_minion:`pillar_opts` is enabled on the minion.
+
     .. note::
         The checks for automatic IP configuration described above only apply if
         ``IPAMConfig`` is among the keys set for static IP checks in

--- a/salt/states/docker_container.py
+++ b/salt/states/docker_container.py
@@ -2062,7 +2062,8 @@ def running(name,
                 __context__[contextkey] = new_container_info.get(
                     'NetworkSettings', {}).get('Networks', {})
             return __context__[contextkey]
-        autoip_keys = __opts__['docker.compare_container_networks'].get('automatic', [])
+        autoip_keys = __salt__['config.option'](
+            'docker.compare_container_networks').get('automatic', [])
         for net_name, net_changes in six.iteritems(
                 ret['changes'].get('container', {}).get('Networks', {})):
             if 'IPConfiguration' in net_changes \

--- a/tests/integration/states/test_docker_container.py
+++ b/tests/integration/states/test_docker_container.py
@@ -1156,10 +1156,11 @@ class DockerContainerTestCase(ModuleCase, SaltReturnAssertsMixin):
             'docker_container.run',
             name=name,
             image=self.image,
-            command=RUNTIME_VARS.SHELL_FALSE_PATH,
+            command='/bin/false',
             failhard=True)
         self.assertSaltFalseReturn(ret)
         ret = ret[next(iter(ret))]
+        log.critical('ret = %s', ret)
         self.assertEqual(ret['changes']['Logs'], '')
         self.assertTrue(
             ret['comment'].startswith(
@@ -1172,7 +1173,7 @@ class DockerContainerTestCase(ModuleCase, SaltReturnAssertsMixin):
             'docker_container.run',
             name=name,
             image=self.image,
-            command=RUNTIME_VARS.SHELL_FALSE_PATH,
+            command='/bin/false',
             failhard=False)
         self.assertSaltTrueReturn(ret)
         ret = ret[next(iter(ret))]

--- a/tests/integration/states/test_docker_container.py
+++ b/tests/integration/states/test_docker_container.py
@@ -1151,6 +1151,12 @@ class DockerContainerTestCase(ModuleCase, SaltReturnAssertsMixin):
         Test to make sure that we fail a state when the container exits with
         nonzero status if failhard is set to True, and that we don't when it is
         set to False.
+
+        NOTE: We can't use RUNTIME_VARS.SHELL_FALSE_PATH here because the image
+        we build on-the-fly here is based on busybox and does not include
+        /usr/bin/false. Therefore, when the host machine running the tests
+        has /usr/bin/false, it will not exist in the container and the Docker
+        Engine API will cause an exception to be raised.
         '''
         ret = self.run_state(
             'docker_container.run',
@@ -1160,7 +1166,6 @@ class DockerContainerTestCase(ModuleCase, SaltReturnAssertsMixin):
             failhard=True)
         self.assertSaltFalseReturn(ret)
         ret = ret[next(iter(ret))]
-        log.critical('ret = %s', ret)
         self.assertEqual(ret['changes']['Logs'], '')
         self.assertTrue(
             ret['comment'].startswith(

--- a/tests/integration/states/test_docker_container.py
+++ b/tests/integration/states/test_docker_container.py
@@ -26,6 +26,7 @@ import salt.utils.files
 import salt.utils.network
 import salt.utils.path
 from salt.exceptions import CommandExecutionError
+from salt.modules.config import DEFAULTS as _config_defaults
 
 # Import 3rd-party libs
 from salt.ext import six
@@ -772,7 +773,7 @@ class DockerContainerTestCase(ModuleCase, SaltReturnAssertsMixin):
         container_netinfo = self.run_function(
             'docker.inspect_container',
             [container_name]).get('NetworkSettings', {}).get('Networks', {})[nets[-1].name]
-        autoip_keys = self.minion_opts['docker.compare_container_networks']['automatic']
+        autoip_keys = _config_defaults['docker.compare_container_networks']['automatic']
         autoip_config = {
             x: y for x, y in six.iteritems(container_netinfo)
             if x in autoip_keys and y

--- a/tests/unit/modules/test_config.py
+++ b/tests/unit/modules/test_config.py
@@ -84,7 +84,6 @@ class TestModulesConfig(TestCase, LoaderModuleMockMixin):
             ret = config.option(self.wildcard_opt_name)
             assert ret == '', ret
 
-
     def test_omits(self):
         with patch.dict(config.DEFAULTS, DEFAULTS):
 

--- a/tests/unit/modules/test_config.py
+++ b/tests/unit/modules/test_config.py
@@ -2,6 +2,7 @@
 
 # Import Python libs
 from __future__ import absolute_import, print_function, unicode_literals
+import fnmatch
 
 # Import Salt Testing libs
 from tests.support.mixins import LoaderModuleMockMixin
@@ -12,28 +13,48 @@ from tests.support.mock import NO_MOCK, NO_MOCK_REASON, patch
 import salt.modules.config as config
 
 DEFAULTS = {
-    'test.option.all': 'value of test.option.all in DEFAULTS',
-    'test.option': 'value of test.option in DEFAULTS'
+    'test.option.foo': 'value of test.option.foo in DEFAULTS',
+    'test.option.bar': 'value of test.option.bar in DEFAULTS',
+    'test.option.baz': 'value of test.option.baz in DEFAULTS',
+    'test.option': 'value of test.option in DEFAULTS',
 }
 
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
 class TestModulesConfig(TestCase, LoaderModuleMockMixin):
 
+    no_match = 'test.option.nope'
+    opt_name = 'test.option.foo'
+    wildcard_opt_name = 'test.option.b*'
+
     def setup_loader_modules(self):
         return {
             config: {
                 '__opts__': {
-                    'test.option.all': 'value of test.option.all in __opts__'
+                    'test.option.foo': 'value of test.option.foo in __opts__',
+                    'test.option.bar': 'value of test.option.bar in __opts__',
+                    'test.option.baz': 'value of test.option.baz in __opts__',
                 },
                 '__pillar__': {
-                    'test.option.all': 'value of test.option.all in __pillar__',
+                    'test.option.foo': 'value of test.option.foo in __pillar__',
+                    'test.option.bar': 'value of test.option.bar in __pillar__',
+                    'test.option.baz': 'value of test.option.baz in __pillar__',
                     'master': {
-                        'test.option.all': 'value of test.option.all in master'
+                        'test.option.foo': 'value of test.option.foo in master',
+                        'test.option.bar': 'value of test.option.bar in master',
+                        'test.option.baz': 'value of test.option.baz in master',
                     }
+                },
+                '__grains__': {
+                    'test.option.foo': 'value of test.option.foo in __grains__',
+                    'test.option.bar': 'value of test.option.bar in __grains__',
+                    'test.option.baz': 'value of test.option.baz in __grains__',
                 }
             }
         }
+
+    def _wildcard_match(self, data):
+        return {x: data[x] for x in fnmatch.filter(data, self.wildcard_opt_name)}
 
     def test_defaults_only_name(self):
         with patch.dict(config.DEFAULTS, DEFAULTS):
@@ -41,26 +62,103 @@ class TestModulesConfig(TestCase, LoaderModuleMockMixin):
             opt = config.option(opt_name)
             self.assertEqual(opt, config.DEFAULTS[opt_name])
 
+    def test_no_match(self):
+        '''
+        Make sure that the defa
+        '''
+        with patch.dict(config.DEFAULTS, DEFAULTS):
+            ret = config.option(self.no_match)
+            assert ret == '', ret
+
+            default = 'wat'
+            ret = config.option(self.no_match, default=default)
+            assert ret == default, ret
+
+            ret = config.option(self.no_match, wildcard=True)
+            assert ret == {}, ret
+
+            default = {'foo': 'bar'}
+            ret = config.option(self.no_match, default=default, wildcard=True)
+            assert ret == default, ret
+
+            # Should be no match since wildcard=False
+            ret = config.option(self.wildcard_opt_name)
+            assert ret == '', ret
+
+
     def test_omits(self):
         with patch.dict(config.DEFAULTS, DEFAULTS):
-            opt_name = 'test.option.all'
-            opt = config.option(opt_name,
-                                omit_opts=False,
-                                omit_master=True,
-                                omit_pillar=True)
 
-            self.assertEqual(opt, config.__opts__[opt_name])
+            # ********** OMIT NOTHING **********
 
-            opt = config.option(opt_name,
+            # Match should be in __opts__ dict
+            ret = config.option(self.opt_name)
+            assert ret == config.__opts__[self.opt_name], ret
+
+            # Wildcard match
+            ret = config.option(self.wildcard_opt_name, wildcard=True)
+            assert ret == self._wildcard_match(config.__opts__), ret
+
+            # ********** OMIT __opts__ **********
+
+            # Match should be in __grains__ dict
+            ret = config.option(self.opt_name,
+                                omit_opts=True)
+            assert ret == config.__grains__[self.opt_name], ret
+
+            # Wildcard match
+            ret = config.option(self.wildcard_opt_name,
                                 omit_opts=True,
-                                omit_master=True,
-                                omit_pillar=False)
+                                wildcard=True)
+            assert ret == self._wildcard_match(config.__grains__), ret
 
-            self.assertEqual(opt, config.__pillar__[opt_name])
-            opt = config.option(opt_name,
+            # ********** OMIT __opts__, __grains__ **********
+
+            # Match should be in __pillar__ dict
+            ret = config.option(self.opt_name,
                                 omit_opts=True,
-                                omit_master=False,
-                                omit_pillar=True)
+                                omit_grains=True)
+            assert ret == config.__pillar__[self.opt_name], ret
 
-            self.assertEqual(
-                opt, config.__pillar__['master'][opt_name])
+            # Wildcard match
+            ret = config.option(self.wildcard_opt_name,
+                                omit_opts=True,
+                                omit_grains=True,
+                                wildcard=True)
+            assert ret == self._wildcard_match(config.__pillar__), ret
+
+            # ********** OMIT __opts__, __grains__, __pillar__ **********
+
+            # Match should be in master opts
+            ret = config.option(self.opt_name,
+                                omit_opts=True,
+                                omit_grains=True,
+                                omit_pillar=True)
+            assert ret == config.__pillar__['master'][self.opt_name], ret
+
+            # Wildcard match
+            ret = config.option(self.wildcard_opt_name,
+                                omit_opts=True,
+                                omit_grains=True,
+                                omit_pillar=True,
+                                wildcard=True)
+            assert ret == self._wildcard_match(config.__pillar__['master']), ret
+
+            # ********** OMIT ALL THE THINGS **********
+
+            # Match should be in master opts
+            ret = config.option(self.opt_name,
+                                omit_opts=True,
+                                omit_grains=True,
+                                omit_pillar=True,
+                                omit_master=True)
+            assert ret == config.DEFAULTS[self.opt_name], ret
+
+            # Wildcard match
+            ret = config.option(self.wildcard_opt_name,
+                                omit_opts=True,
+                                omit_grains=True,
+                                omit_pillar=True,
+                                omit_master=True,
+                                wildcard=True)
+            assert ret == self._wildcard_match(config.DEFAULTS), ret

--- a/tests/unit/modules/test_config.py
+++ b/tests/unit/modules/test_config.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-
 # Import Python libs
 from __future__ import absolute_import, print_function, unicode_literals
 import fnmatch
@@ -160,5 +159,16 @@ class TestModulesConfig(TestCase, LoaderModuleMockMixin):
                                 omit_grains=True,
                                 omit_pillar=True,
                                 omit_master=True,
+                                wildcard=True)
+            assert ret == self._wildcard_match(config.DEFAULTS), ret
+
+            # Match should be in master opts
+            ret = config.option(self.opt_name,
+                                omit_all=True)
+            assert ret == config.DEFAULTS[self.opt_name], ret
+
+            # Wildcard match
+            ret = config.option(self.wildcard_opt_name,
+                                omit_all=True,
                                 wildcard=True)
             assert ret == self._wildcard_match(config.DEFAULTS), ret


### PR DESCRIPTION
This makes the following two changes to `config.option`:

1. Matches are now returned from grains
2. Wildcard matches are now supported

For backward compatibility, wildcard matches are only attempted when `wildcard=True` is passed.

Additionally, the Docker registry configuration now uses `config.option`, meaning that registry auth can be configured elsewhere than the pillar data.

Resolves #51531.