### PR TITLE
Jinja regex_match can return named subgroups dict with as_dict arg

### DIFF
--- a/salt/utils/jinja.py
+++ b/salt/utils/jinja.py
@@ -381,7 +381,7 @@ def regex_search(txt, rgx, ignorecase=False, multiline=False):
 
 
 @jinja_filter('regex_match')
-def regex_match(txt, rgx, ignorecase=False, multiline=False):
+def regex_match(txt, rgx, ignorecase=False, multiline=False, as_dict=False):
     '''
     Searches for a pattern in the text.
 
@@ -404,6 +404,8 @@ def regex_match(txt, rgx, ignorecase=False, multiline=False):
     obj = re.match(rgx, txt, flag)
     if not obj:
         return
+    if as_dict:
+        return obj.groupdict()
     return obj.groups()
 
 


### PR DESCRIPTION
Signed-off-by: Anthony ARNAUD <github@anthony-arnaud.fr>

### What does this PR do?
Enable dict return for jinja `regex_match` with `as_dict` argument


### Tests written?
No

### Commits signed with GPG?
Yes
