### PR TITLE
Modified the check_remote conditional in salt.modules.chocolatey.version to not assume that a package exists in the packages returned from salt.modules.chocolatey.list_.

### DIFF
--- a/salt/modules/chocolatey.py
+++ b/salt/modules/chocolatey.py
@@ -933,8 +933,14 @@ def version(name, check_remote=False, source=None, pre_versions=False):
         available = {k.lower(): v for k, v in available.items()}
 
         for pkg in packages:
-            packages[pkg] = {'installed': installed[pkg],
-                             'available': available[pkg]}
+            # Grab the current version from the package that was installed
+            packages[pkg] = {'installed': installed[pkg]}
+
+            # If there's a remote package available, then also include that
+            # in the dictionary that we return.
+            if pkg in available:
+                packages[pkg]['available'] = available[pkg]
+            continue
 
     return packages
 


### PR DESCRIPTION
### What does this PR do?
This fixes issue #51700 so that when `salt.utils.chocolatey.version` is called with `check_remote` set to true, it doesn't raise an uncaught exception when the remote repository does not contain said package.

The `salt.states.chocolatey.installed` state uses this to check the remote version, and if there's an issue with the package in the remote repository (`choco list $pkg` is unable to list it), then `chocolatey.installed` will terminate with an uncaught exception when trying to check against the remote version.

### What issues does this PR fix or reference?
As prior mentioned, this will close issue #51700.

### Previous Behavior
Previously, `salt.modules.chocolatey.version` assumes that the specified package name will always exist in the available packages. This is likely an unfair assumption as an installed chocolatey package is not always guaranteed to exist such as if a chocolatey package maintainer removes their package from the repository, or if the chocolatey repository is corrupted in some way (when `choco list $pkg` doesn't work).

### New Behavior
This checks that the dictioanry key exists before attempting to fetch the package from the `available` dictionary.

### Tests written?
No.