### PR TITLE
fixed itertools

### DIFF
--- a/salt/modules/upstart.py
+++ b/salt/modules/upstart.py
@@ -50,7 +50,6 @@ from __future__ import absolute_import, unicode_literals, print_function
 import glob
 import os
 import re
-import itertools
 import fnmatch
 
 # Import salt libs
@@ -58,6 +57,7 @@ import salt.modules.cmdmod
 import salt.utils.files
 import salt.utils.path
 import salt.utils.systemd
+from salt.ext.six.moves import filter
 
 __func_alias__ = {
     'reload_': 'reload'
@@ -190,7 +190,7 @@ def _upstart_is_disabled(name):
     in /etc/init/[name].conf.
     '''
     files = ['/etc/init/{0}.conf'.format(name), '/etc/init/{0}.override'.format(name)]
-    for file_name in itertools.ifilter(os.path.isfile, files):
+    for file_name in filter(os.path.isfile, files):
         with salt.utils.files.fopen(file_name) as fp_:
             if re.search(r'^\s*manual',
                          salt.utils.stringutils.to_unicode(fp_.read()),
@@ -516,7 +516,7 @@ def _upstart_enable(name):
         return _upstart_is_enabled(name)
     override = '/etc/init/{0}.override'.format(name)
     files = ['/etc/init/{0}.conf'.format(name), override]
-    for file_name in itertools.ifilter(os.path.isfile, files):
+    for file_name in filter(os.path.isfile, files):
         with salt.utils.files.fopen(file_name, 'r+') as fp_:
             new_text = re.sub(r'^\s*manual\n?',
                               '',


### PR DESCRIPTION
### What does this PR do?
It fixes a failure to execute `service.running` function when python 3 is used.

### What issues does this PR fix or reference?
----------
          ID: nginx_backend
    Function: service.running
        Name: nginx
      Result: False
     Comment: An exception occurred in this state: Traceback (most recent call last):
                File "/var/tmp/.ubuntu_97613f_salt/pyall/salt/state.py", line 1951, in call
                  ret = self.states[cdata['full']](*cdata['args'], **cdata['kwargs'])
                File "/var/tmp/.ubuntu_97613f_salt/pyall/salt/loader.py", line 2047, in wrapper
                  return f(*args, **kwargs)
                File "/var/tmp/.ubuntu_97613f_salt/pyall/salt/states/service.py", line 410, in running
                  if not _available(name, ret):
                File "/var/tmp/.ubuntu_97613f_salt/pyall/salt/states/service.py", line 329, in _available
                  avail = __salt__['service.available'](name)
                File "/var/tmp/.ubuntu_97613f_salt/pyall/salt/modules/upstart.py", line 323, in available
                  return name in get_all()
                File "/var/tmp/.ubuntu_97613f_salt/pyall/salt/modules/upstart.py", line 351, in get_all
                  return sorted(get_enabled() + get_disabled())
                File "/var/tmp/.ubuntu_97613f_salt/pyall/salt/modules/upstart.py", line 281, in get_enabled
                  if _upstart_is_enabled(name):
                File "/var/tmp/.ubuntu_97613f_salt/pyall/salt/modules/upstart.py", line 207, in _upstart_is_enabled
                  return not _upstart_is_disabled(name)
                File "/var/tmp/.ubuntu_97613f_salt/pyall/salt/modules/upstart.py", line 193, in _upstart_is_disabled
                  for file_name in itertools.ifilter(os.path.isfile, files):
              AttributeError: 'module' object has no attribute 'ifilter'
     Started: 01:43:36.776517
    Duration: 9.999997913837433 ms
     Changes:   


### Tests written?

No

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
