### PR TITLE
Bugfix: pillar refresh

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -2210,6 +2210,8 @@ class Minion(MinionBase):
             finally:
                 async_pillar.destroy()
         self.module_refresh(force_refresh)
+        self.matchers_refresh()
+        self.beacons_refresh()
 
     def manage_schedule(self, tag, data):
         '''


### PR DESCRIPTION
### What does this PR do?

Bugfix

### What issues does this PR fix or reference?

Pillars are not fully refreshed.

### Previous Behavior

Reproducer:

1. Start master.
2. Start minion.
3. Add some pillar keypair, say `name: toto`.
4. Verify that the new pillar is ready: `salt <yourminion> pillar.items`
5. Refresh it: `salt <yourminion> saltutil.refresh_pillar`
6. Try target your minion by this pillar: `salt -I 'name:toto' test.ping` and it won't work.
7. The targeting above fully works the whole cycle only if you restart the minion (so it refreshes all the instances of the pillar)

While _targeting_ by itself works, the minion won't return the results back and the master is trying to find a running job. The reason is because the minion is verifying itself if it is properly targeted against the _old_ data. This is happening because `opts` instance of the Minion is newer than the copy of it as `__opts__` in the matchers.

For the same reasons beacons do not fully tolerate pillar refresh.

### New Behavior

Targeting and module orchestration calls is working after the `saltutil.refresh_pillar` is issued.

### Tests written?

Existing should apply.
