### PR TITLE
[2017.7] Fix ruby gems tests, again

### DIFF
--- a/tests/integration/modules/test_gem.py
+++ b/tests/integration/modules/test_gem.py
@@ -110,7 +110,7 @@ class GemModuleTest(ModuleCase):
         gem.sources_add
         gem.sources_remove
         '''
-        source = 'http://gemcutter.org/'
+        source = 'http://production.cf.rubygems.org'
 
         self.run_function('gem.sources_add', [source])
         sources_list = self.run_function('gem.sources_list')


### PR DESCRIPTION
### What does this PR do?

Fixing `integration.modules.test_gem.GemModuleTest.test_sources_add_remove` again.

### What issues does this PR fix or reference?

### Previous Behavior
Remove this section if not relevant

### New Behavior
Remove this section if not relevant

### Tests written?

No - Fixing test

### Commits signed with GPG?

Yes