### PR TITLE
This fixes mount function when run on Solaris. Currently -t is passed…

### DIFF
--- a/salt/modules/mount.py
+++ b/salt/modules/mount.py
@@ -1217,6 +1217,9 @@ def mount(name, device, mkmnt=False, fstype='', opts='defaults', user=None, util
     if 'AIX' in __grains__['os']:
         if fstype:
             args += ' -v {0}'.format(fstype)
+    elif 'solaris' in __grains__['os'].lower():
+        if fstype:
+            args += ' -F {0}'.format(fstype)
     else:
         args += ' -t {0}'.format(fstype)
     cmd = 'mount {0} {1} {2} '.format(args, device, name)


### PR DESCRIPTION
… as argument to the mount command. This is an invalid argument to the mount command on solaris.

### What does this PR do?
Currently on Solaris  when calling mount.mount this is not working as -t is passed as an argument to 
the mount command. This is an invalid argument.  The following error is seen:

----------
     Comment: mount: illegal option -- t
              Usage:
              mount [-v | -p]
              mount [-F FSType] [-V] [current_options] [-o specific_options]
                {special | mount_point}
              mount [-F FSType] [-V] [current_options] [-o specific_options]
                special mount_point
              mount -a [-F FSType ] [-V] [current_options] [-o specific_options]
                [mount_point ...]
     Started: 06:21:25.056284
    Duration: 44.788 ms
     Changes:

The update I have done here will pass -F to mount command if OS is Solaris.

### What issues does this PR fix or reference?

### Previous Behavior
Remove this section if not relevant

### New Behavior
Remove this section if not relevant

### Tests written?

Yes/No

### Commits signed with GPG?

Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
