### PR TITLE
Replaced a dead link for github issue tracker with another github

### DIFF
--- a/doc/topics/development/contributing.rst
+++ b/doc/topics/development/contributing.rst
@@ -100,7 +100,8 @@ Fork a Repo Guide_>`_ and is well worth reading.
     .. note::
 
         If your change fixes a bug or implements a feature already filed in the
-        `issue tracker <GitHub issue tracker>`_, be sure to reference the issue
+        `issue tracker <https://guides.github.com/features/issues/>`_, be sure to
+	`reference the issue <https://help.github.com/en/articles/closing-issues-using-keywords>`_
         number in the commit message body.
 
     .. code-block:: bash


### PR DESCRIPTION
### What does this PR do?
Replaced a dead link for github issue tracker with another github link for the issue tracker and added a link to show more options for closing issues in commit messages.

### What issues does this PR fix or reference?
Didn't bother to make an issue for the deadlink

### Commits signed with GPG?
Yes