### PR TITLE
Make recurse and directory case sensitive (2017.7)

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -633,6 +633,7 @@ def _clean_dir(root, keep, exclude_pat):
     Clean out all of the files and directories in a directory (root) while
     preserving the files in a list (keep) and part of exclude_pat
     '''
+    root = os.path.normcase(root)
     real_keep = _find_keep_files(root, keep)
     removed = set()
 

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -609,6 +609,7 @@ def _check_file(name):
 def _find_keep_files(root, keep):
     '''
     Compile a list of valid keep files (and directories).
+    Used by _clean_dir()
     '''
     real_keep = set()
     real_keep.add(root)
@@ -2933,7 +2934,7 @@ def directory(name,
                   perms: full_control
             - win_inheritance: False
     '''
-    name = os.path.normcase(os.path.expanduser(name))
+    name = os.path.expanduser(name)
     ret = {'name': name,
            'changes': {},
            'pchanges': {},
@@ -3419,7 +3420,7 @@ def recurse(name,
             )
         kwargs.pop('env')
 
-    name = os.path.normcase(os.path.expanduser(sdecode(name)))
+    name = os.path.expanduser(sdecode(name))
 
     user = _test_owner(kwargs, user=user)
     if salt.utils.is_windows():

--- a/tests/unit/states/test_file.py
+++ b/tests/unit/states/test_file.py
@@ -1930,15 +1930,20 @@ class TestFindKeepFiles(TestCase):
 
     @skipIf(not salt.utils.is_windows(), 'Only run on Windows')
     def test__find_keep_files_win32(self):
+        '''
+        Test _find_keep_files. The `_find_keep_files` function is only called by
+        _clean_dir, so case doesn't matter. Should return all lower case.
+        '''
         keep = filestate._find_keep_files(
             'c:\\test\\parent_folder',
-            ['C:\\test\\parent_folder\\meh-2.txt']
+            ['C:\\test\\parent_folder\\meh-1.txt',
+             'C:\\Test\\Parent_folder\\Meh-2.txt']
         )
         expected = [
             'c:\\',
             'c:\\test',
             'c:\\test\\parent_folder',
-            'c:\\test\\parent_folder\\meh-2.txt'
-        ]
+            'c:\\test\\parent_folder\\meh-1.txt',
+            'c:\\test\\parent_folder\\meh-2.txt']
         actual = sorted(list(keep))
-        assert actual == expected, actual
+        self.assertListEqual(actual, expected)


### PR DESCRIPTION
### What does this PR do?
Brings back case sensitive filenames to `file.directory` and `file.recurse`

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/51486

### Tests written?
Yes, but not related to case sensitivity

### Commits signed with GPG?
Yes