### PR TITLE
Revert "Remove custom grains module from 2018.3 branch"

### DIFF
--- a/tests/integration/files/file/base/_grains/custom_grains.py
+++ b/tests/integration/files/file/base/_grains/custom_grains.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+
+
+def test(grains):
+    return {'custom_grain_test': 'itworked' if 'os' in grains else 'itdidntwork'}


### PR DESCRIPTION
This reverts commit 191235d8d31817991035107fb320cc698d9f9bcf.
This fixes the custom grains test.

### Tests written?

No - Fixing broken test

### Commits signed with GPG?

Yes
