### PR TITLE
bug: status might be a string, coerce it

### DIFF
--- a/salt/states/http.py
+++ b/salt/states/http.py
@@ -123,7 +123,7 @@ def query(name, match=None, match_type='string', status=None, status_type='strin
 
     if status is not None:
         if status_type == 'string':
-            if data.get('status', '') == str(status):
+            if str(data.get('status', '')) == str(status):
                 ret['comment'] += ' Status {0} was found.'.format(status)
                 if ret['result'] is None:
                     ret['result'] = True


### PR DESCRIPTION
some backends (requests) return status code as an int, make sure its
coerced as string before doing a comparison.

### What does this PR do?
fix status match when using requests backend. 

### What issues does this PR fix or reference?
n/a

### Tests written?
No

### Commits signed with GPG?

Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
