### PR TITLE
Fix typo in the description of the netyang state

### DIFF
--- a/salt/states/netyang.py
+++ b/salt/states/netyang.py
@@ -12,7 +12,7 @@ Dependencies
 ------------
 
 - napalm-yang
-- pyangbing > 0.5.11
+- pyangbind > 0.5.11
 
 To be able to load configuration on network devices,
 it requires NAPALM_ library to be installed:  ``pip install napalm``.
@@ -206,7 +206,7 @@ def configured(name,
                data,
                **kwargs):
     '''
-    Configure the network device, given the input data strucuted
+    Configure the network device, given the input data structured
     according to the YANG models.
 
     .. note::

--- a/salt/states/netyang.py
+++ b/salt/states/netyang.py
@@ -12,7 +12,7 @@ Dependencies
 ------------
 
 - napalm-yang
-- pyangbing > 0.5.11
+- pyangbind > 0.5.11
 
 To be able to load configuration on network devices,
 it requires NAPALM_ library to be installed:  ``pip install napalm``.


### PR DESCRIPTION
### What does this PR do?
Fix a typo in the documentation of the netyang state. This typo is very prominent and quite annoying.

### What issues does this PR fix or reference?
No issue. Just typo.

### Tests written?

No

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
