### PR TITLE
Fix diskusage beacon on Windows

### DIFF
--- a/salt/beacons/diskusage.py
+++ b/salt/beacons/diskusage.py
@@ -97,7 +97,11 @@ def beacon(config):
             mount_re = '{0}$'.format(mount)
 
         if salt.utils.platform.is_windows():
-            mount_re = re.sub('\\$', '\\\\', mount_re)
+            # mount_re comes in formatted with a $ at the end
+            # can be `C:\\$` or `C:\\\\$`
+            # re string must be like `C:\\\\` regardless of \\ or \\\\
+            mount_re = re.sub(r':\\\$', r':\\\\', mount_re)
+            mount_re = re.sub(r':\\\\\$', r':\\\\', mount_re)
 
         for part in parts:
             if re.match(mount_re, part.mountpoint):

--- a/salt/beacons/diskusage.py
+++ b/salt/beacons/diskusage.py
@@ -100,8 +100,10 @@ def beacon(config):
             # mount_re comes in formatted with a $ at the end
             # can be `C:\\$` or `C:\\\\$`
             # re string must be like `C:\\\\` regardless of \\ or \\\\
+            # also, psutil returns uppercase
             mount_re = re.sub(r':\\\$', r':\\\\', mount_re)
             mount_re = re.sub(r':\\\\\$', r':\\\\', mount_re)
+            mount_re = mount_re.upper()
 
         for part in parts:
             if re.match(mount_re, part.mountpoint):

--- a/tests/unit/beacons/test_diskusage.py
+++ b/tests/unit/beacons/test_diskusage.py
@@ -158,6 +158,25 @@ class DiskUsageBeaconTestCase(TestCase, LoaderModuleMockMixin):
                 ret = diskusage.beacon(config)
                 self.assertEqual(ret, [{'diskusage': 50, 'mount': 'C:\\'}])
 
+    def test_diskusage_windows_lowercase(self):
+        '''
+        This tests lowercase drive letter (c:\)
+        '''
+        disk_usage_mock = Mock(return_value=WINDOWS_STUB_DISK_USAGE)
+        with patch('salt.utils.platform.is_windows',
+                   MagicMock(return_value=True)):
+            with patch('psutil.disk_partitions',
+                       MagicMock(return_value=WINDOWS_STUB_DISK_PARTITION)), \
+                 patch('psutil.disk_usage', disk_usage_mock):
+                config = [{'c:\\': '50%'}]
+
+                ret = diskusage.validate(config)
+
+                self.assertEqual(ret, (True, 'Valid beacon configuration'))
+
+                ret = diskusage.beacon(config)
+                self.assertEqual(ret, [{'diskusage': 50, 'mount': 'C:\\'}])
+
     def test_diskusage_windows_match_regex(self):
         disk_usage_mock = Mock(return_value=WINDOWS_STUB_DISK_USAGE)
         with patch('salt.utils.platform.is_windows',

--- a/tests/unit/beacons/test_diskusage.py
+++ b/tests/unit/beacons/test_diskusage.py
@@ -120,7 +120,10 @@ class DiskUsageBeaconTestCase(TestCase, LoaderModuleMockMixin):
             ret = diskusage.beacon(config)
             self.assertEqual(ret, [{'diskusage': 50, 'mount': '/'}])
 
-    def test_diskusage_windows(self):
+    def test_diskusage_windows_single_slash(self):
+        '''
+        This tests new behavior (C:\)
+        '''
         disk_usage_mock = Mock(return_value=WINDOWS_STUB_DISK_USAGE)
         with patch('salt.utils.platform.is_windows',
                    MagicMock(return_value=True)):
@@ -128,6 +131,25 @@ class DiskUsageBeaconTestCase(TestCase, LoaderModuleMockMixin):
                        MagicMock(return_value=WINDOWS_STUB_DISK_PARTITION)), \
                     patch('psutil.disk_usage', disk_usage_mock):
                 config = [{'C:\\': '50%'}]
+
+                ret = diskusage.validate(config)
+
+                self.assertEqual(ret, (True, 'Valid beacon configuration'))
+
+                ret = diskusage.beacon(config)
+                self.assertEqual(ret, [{'diskusage': 50, 'mount': 'C:\\'}])
+
+    def test_diskusage_windows_double_slash(self):
+        '''
+        This tests original behavior (C:\\)
+        '''
+        disk_usage_mock = Mock(return_value=WINDOWS_STUB_DISK_USAGE)
+        with patch('salt.utils.platform.is_windows',
+                   MagicMock(return_value=True)):
+            with patch('psutil.disk_partitions',
+                       MagicMock(return_value=WINDOWS_STUB_DISK_PARTITION)), \
+                    patch('psutil.disk_usage', disk_usage_mock):
+                config = [{'C:\\\\': '50%'}]
 
                 ret = diskusage.validate(config)
 

--- a/tests/unit/beacons/test_diskusage.py
+++ b/tests/unit/beacons/test_diskusage.py
@@ -121,7 +121,7 @@ class DiskUsageBeaconTestCase(TestCase, LoaderModuleMockMixin):
             self.assertEqual(ret, [{'diskusage': 50, 'mount': '/'}])
 
     def test_diskusage_windows_single_slash(self):
-        '''
+        r'''
         This tests new behavior (C:\)
         '''
         disk_usage_mock = Mock(return_value=WINDOWS_STUB_DISK_USAGE)
@@ -159,7 +159,7 @@ class DiskUsageBeaconTestCase(TestCase, LoaderModuleMockMixin):
                 self.assertEqual(ret, [{'diskusage': 50, 'mount': 'C:\\'}])
 
     def test_diskusage_windows_lowercase(self):
-        '''
+        r'''
         This tests lowercase drive letter (c:\)
         '''
         disk_usage_mock = Mock(return_value=WINDOWS_STUB_DISK_USAGE)


### PR DESCRIPTION
### What does this PR do?
As documented the drive should be designated as `C:\\`. A recent PR #50188 changed the behavior to work with `C:\`, which was causing the documented syntax to fail.

This change allows either syntax `C:\` or `C:\\`. Additionally, this change will make sure the driveletter is capitalized.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/51792

### Tests written?
Yes

### Commits signed with GPG?
Yes