### PR TITLE
Fixed the salt.modules.npm module to check the npm version correctly on the Windows platform

### DIFF
--- a/salt/modules/npm.py
+++ b/salt/modules/npm.py
@@ -49,10 +49,13 @@ def _check_valid_version():
     Check the version of npm to ensure this module will work. Currently
     npm must be at least version 1.2.
     '''
+
+    # Locate the full path to npm
+    npm_path = salt.utils.path.which('npm')
+
     # pylint: disable=no-member
-    npm_version = _LooseVersion(
-        salt.modules.cmdmod.run('npm --version', output_loglevel='quiet'))
-    valid_version = _LooseVersion('1.2')
+    res = salt.modules.cmdmod.run('{npm} --version'.format(npm=npm_path), output_loglevel='quiet')
+    npm_version, valid_version = _LooseVersion(res), _LooseVersion('1.2')
     # pylint: enable=no-member
     if npm_version < valid_version:
         raise CommandExecutionError(

--- a/salt/states/npm.py
+++ b/salt/states/npm.py
@@ -32,7 +32,7 @@ def __virtual__():
     '''
     Only load if the npm module is available in __salt__
     '''
-    return 'npm' if 'npm.install' in __salt__ else False, 'Failure trying to load \'npm\' module'
+    return 'npm' if 'npm.list' in __salt__ else False, '\'npm\' binary not found on system'
 
 
 def installed(name,

--- a/salt/states/npm.py
+++ b/salt/states/npm.py
@@ -32,7 +32,7 @@ def __virtual__():
     '''
     Only load if the npm module is available in __salt__
     '''
-    return 'npm' if 'npm.list' in __salt__ else False, '\'npm\' binary not found on system'
+    return 'npm' if 'npm.install' in __salt__ else False, 'Failure trying to load \'npm\' module'
 
 
 def installed(name,


### PR DESCRIPTION
### What does this PR do?
The `salt.states.npm` module verifying that `npm` support is available in the wrong way. It is checking for a function (`salt.modules.npm.list()`) that does not exist. Halfway through 2017, this function was renamed to `list_()` but for some reason this module was not updated.

Instead of fixing this issue by renaming the check to `list_`, we opt to use `install` as due to it being a not-so-generic name it's unlikely to change during another refactor. The error message that is emitted is also rephrased in order to be more clear that it's not that the `npm` binary is missing, but that it's unable to load the `salt.modules.npm` module.

### What issues does this PR fix or reference?
This closes issues #51811.

### Previous Behavior
Prior to this fix, the `salt.states.npm` module could never work (since 2017-06-04.

### New Behavior
Now that it's checking for a function that exists, it should behave correctly and all the states/functions in `salt.states.npm` should work. By checking for `install` instead of `list`, this will hopefully survive a refactor as renaming `install` appears to be a more serious issue than renaming something as general as `list`.

There needs to be a better/safer to check for a successful vs failed module load to avoid these issues in the future, but for now we'll just hope that nobody renames `install` to something else...

### Tests written?
No, but if someone else had actually written tests here and verified them before commit 384570384e then that would've blocked that commit until things like this worked.

### Commits signed with GPG?
No