### PR TITLE
Fixed the salt.modules.npm module to check the npm version correctly on the Windows platform

### DIFF
--- a/salt/modules/npm.py
+++ b/salt/modules/npm.py
@@ -49,10 +49,13 @@ def _check_valid_version():
     Check the version of npm to ensure this module will work. Currently
     npm must be at least version 1.2.
     '''
+
+    # Locate the full path to npm
+    npm_path = salt.utils.path.which('npm')
+
     # pylint: disable=no-member
-    npm_version = _LooseVersion(
-        salt.modules.cmdmod.run('npm --version', output_loglevel='quiet'))
-    valid_version = _LooseVersion('1.2')
+    res = salt.modules.cmdmod.run('{npm} --version'.format(npm=npm_path), output_loglevel='quiet')
+    npm_version, valid_version = _LooseVersion(res), _LooseVersion('1.2')
     # pylint: enable=no-member
     if npm_version < valid_version:
         raise CommandExecutionError(

--- a/salt/states/npm.py
+++ b/salt/states/npm.py
@@ -32,7 +32,7 @@ def __virtual__():
     '''
     Only load if the npm module is available in __salt__
     '''
-    return 'npm' if 'npm.install' in __salt__ else False, 'Failure trying to load \'npm\' module'
+    return 'npm' if 'npm.list' in __salt__ else False, '\'npm\' binary not found on system'
 
 
 def installed(name,

--- a/salt/states/npm.py
+++ b/salt/states/npm.py
@@ -32,7 +32,7 @@ def __virtual__():
     '''
     Only load if the npm module is available in __salt__
     '''
-    return 'npm' if 'npm.list' in __salt__ else False, '\'npm\' binary not found on system'
+    return 'npm' if 'npm.install' in __salt__ else False, 'Failure trying to load \'npm\' module'
 
 
 def installed(name,


### PR DESCRIPTION
### What does this PR do?
On the Windows platform, the `salt.modules.npm` module does not check the npm version correctly. This is likely because the `npm` script that is installed is actually `npm.CMD`. When checking the version, the `salt.modules.npm` module attempts to call just `npm`.

This PR locates `npm` by using `salt.utils.path.which()` to detect the path before checking the version. The version check uses `salt.modules.cmdmod.run` whereas the rest of the module uses `salt.modules.cmdmod.run_all`. It was not determined why `salt.modules.cmdmod.run` acts different from `salt.modules.cmdmod.run_all` when running a cmd-script on the Windows platform.

### What issues does this PR fix or reference?
This closes issue #51811.

### Previous Behavior
When performing the version check, the module is unable to locate the npm binary (or script, really) and thus the version check fails.

### New Behavior
Due to checking for the full path of `npm.cmd`, the version is correctly detected and the rest of the module works. (`npm.install`, `npm.uninstall`, and `npm.list` was checked).

### Tests written?
No

### Commits signed with GPG?
No