### PR TITLE
[2018.3] Fix to inotify beacon when multiple file paths with excludes are used

### DIFF
--- a/salt/beacons/inotify.py
+++ b/salt/beacons/inotify.py
@@ -243,15 +243,16 @@ def beacon(config):
             if excludes and isinstance(excludes, list):
                 for exclude in excludes:
                     if isinstance(exclude, dict):
-                        if exclude.values()[0].get('regex', False):
+                        _exclude = next(iter(exclude))
+                        if exclude[_exclude].get('regex', False):
                             try:
-                                if re.search(list(exclude)[0], event.pathname):
+                                if re.search(_exclude, event.pathname):
                                     _append = False
                             except Exception:
                                 log.warning('Failed to compile regex: %s',
-                                            list(exclude)[0])
+                                            _exclude)
                         else:
-                            exclude = list(exclude)[0]
+                            exclude = _exclude
                     elif '*' in exclude:
                         if fnmatch.fnmatch(event.pathname, exclude):
                             _append = False
@@ -311,7 +312,7 @@ def beacon(config):
                 excl = []
                 for exclude in excludes:
                     if isinstance(exclude, dict):
-                        excl.append(exclude.keys()[0])
+                        excl.append(list(exclude)[0])
                     else:
                         excl.append(exclude)
                 excl = pyinotify.ExcludeFilter(excl)

--- a/salt/beacons/inotify.py
+++ b/salt/beacons/inotify.py
@@ -238,8 +238,7 @@ def beacon(config):
                     break
                 path = os.path.dirname(path)
 
-            for path in _config.get('files', {}):
-                excludes = _config['files'][path].get('exclude', '')
+            excludes = _config['files'][path].get('exclude', '')
 
             if excludes and isinstance(excludes, list):
                 for exclude in excludes:


### PR DESCRIPTION
### What does this PR do?
Fixing a bug that caused excludes to not work as expected when multiple file options were in place, the excludes of the last file section were being used over any previous ones.  Including a test to ensure excludes work as expected when multiple file sections are in place.

### What issues does this PR fix or reference?
#51673 

### Tests written?
Yes

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
