### PR TITLE
Fix name of Python 2.7 development requirements file

### DIFF
--- a/HACKING.rst
+++ b/HACKING.rst
@@ -250,9 +250,9 @@ If it is less than 2047, you should increase it with::
 Running the tests
 ~~~~~~~~~~~~~~~~~
 
-For running tests, you'll also need to install ``requirements/dev_python2x.txt``::
+For running tests, you'll also need to install ``requirements/dev_python27.txt``::
 
-    pip install -r requirements/dev_python2x.txt
+    pip install -r requirements/dev_python27.txt
 
 Finally you use setup.py to run the tests with the following command::
 


### PR DESCRIPTION
The file for Python 2.7 file is the only left for 2.x as the one for
2.6 was removed back in March 2017.

### Commits signed with GPG?

Yes