### PR TITLE
[2019.2] Fix to schedule.list function to filter out attributes that are None

### DIFF
--- a/salt/modules/schedule.py
+++ b/salt/modules/schedule.py
@@ -132,6 +132,9 @@ def list_(show_all=False,
             if item not in SCHEDULE_CONF:
                 del schedule[job][item]
                 continue
+            if schedule[job][item] is None:
+                del schedule[job][item]
+                continue
             if schedule[job][item] == 'true':
                 schedule[job][item] = True
             if schedule[job][item] == 'false':


### PR DESCRIPTION
### What does this PR do?
Splay defaulting to None internally, broke schedule.present causing it to always report differences when a state is run.  Updating the schedule.list function to check if an attribute is None and remove it.

### What issues does this PR fix or reference?
#51824 #51647

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
 