### PR TITLE
Fix typo in 2019.2.0 release notes

### DIFF
--- a/doc/topics/releases/2019.2.0.rst
+++ b/doc/topics/releases/2019.2.0.rst
@@ -280,7 +280,7 @@ a BGP policy referenced in many places, you can do so by running:
 
 .. code-block:: bash
 
-    salt '*' net.replae_pattern OLD-POLICY-CONFIG new-policy-config
+    salt '*' net.replace_pattern OLD-POLICY-CONFIG new-policy-config
 
 Similarly, you can also replace entire configuration blocks using the
 :mod:`net.blockreplace <salt.modules.napalm_network.blockreplace>` function.


### PR DESCRIPTION
### What does this PR do?

Fix typo in 2019.2.0 release notes.

### What issues does this PR fix or reference?

Typo in example - net.replae_pattern corrected to net.replace_pattern