### PR TITLE
Add separate batch presence_ping timeout

### DIFF
--- a/salt/cli/batch_async.py
+++ b/salt/cli/batch_async.py
@@ -29,6 +29,7 @@ class BatchAsync(object):
     The control parameters are:
         - batch: number/percentage of concurrent running minions
         - batch_delay: minimum wait time between batches
+        - batch_presence_ping_timeout: time to wait for presence pings before starting the batch
         - gather_job_timeout: `find_job` timeout
         - timeout: time to wait before firing a `find_job`
 
@@ -55,6 +56,7 @@ class BatchAsync(object):
             clear_load['gather_job_timeout'] = clear_load['kwargs'].pop('gather_job_timeout')
         else:
             clear_load['gather_job_timeout'] = self.local.opts['gather_job_timeout']
+        self.batch_presence_ping_timeout = clear_load['kwargs'].get('batch_presence_ping_timeout', None)
         self.batch_delay = clear_load['kwargs'].get('batch_delay', 1)
         self.opts = batch_get_opts(
             clear_load.pop('tgt'),
@@ -167,7 +169,8 @@ class BatchAsync(object):
         self.__set_event_handler()
         #start batching even if not all minions respond to ping
         self.event.io_loop.call_later(
-            self.opts['gather_job_timeout'], self.start_batch)
+            self.batch_presence_ping_timeout or self.opts['gather_job_timeout'],
+            self.start_batch)
         ping_return = yield self.local.run_job_async(
             self.opts['tgt'],
             'test.ping',

--- a/tests/unit/cli/test_batch_async.py
+++ b/tests/unit/cli/test_batch_async.py
@@ -21,6 +21,7 @@ class AsyncBatchTestCase(AsyncTestCase, TestCase):
                 'tgt': '*',
                 'timeout': 5,
                 'gather_job_timeout': 5,
+                'batch_presence_ping_timeout': 1,
                 'transport': None,
                 'sock_dir': ''}
 
@@ -28,7 +29,17 @@ class AsyncBatchTestCase(AsyncTestCase, TestCase):
             with patch('salt.cli.batch_async.batch_get_opts',
                 MagicMock(return_value=opts)
             ):
-                self.batch = BatchAsync(opts, MagicMock(side_effect=['1234', '1235', '1236']), MagicMock())
+                self.batch = BatchAsync(
+                    opts,
+                    MagicMock(side_effect=['1234', '1235', '1236']),
+                    {
+                        'tgt': '',
+                        'fun': '',
+                        'kwargs': {
+                            'batch': '',
+                            'batch_presence_ping_timeout': 1
+                        }
+                    })
 
     def test_ping_jid(self):
         self.assertEqual(self.batch.ping_jid, '1234')
@@ -49,16 +60,16 @@ class AsyncBatchTestCase(AsyncTestCase, TestCase):
         self.assertEqual(self.batch.batch_size, 2)
 
     @tornado.testing.gen_test
-    def test_batch_start(self):
+    def test_batch_start_on_batch_presence_ping_timeout(self):
         self.batch.event = MagicMock()
         future = tornado.gen.Future()
         future.set_result({'minions': ['foo', 'bar']})
         self.batch.local.run_job_async.return_value = future
         ret = self.batch.start()
-        # assert start_batch is called later with gather_job_timeout as param
+        # assert start_batch is called later with batch_presence_ping_timeout as param
         self.assertEqual(
             self.batch.event.io_loop.call_later.call_args[0],
-            (5, self.batch.start_batch))
+            (self.batch.batch_presence_ping_timeout, self.batch.start_batch))
         # assert test.ping called
         self.assertEqual(
             self.batch.local.run_job_async.call_args[0],
@@ -66,6 +77,19 @@ class AsyncBatchTestCase(AsyncTestCase, TestCase):
         )
         # assert down_minions == all minions matched by tgt
         self.assertEqual(self.batch.down_minions, set(['foo', 'bar']))
+
+    @tornado.testing.gen_test
+    def test_batch_start_on_gather_job_timeout(self):
+        self.batch.event = MagicMock()
+        future = tornado.gen.Future()
+        future.set_result({'minions': ['foo', 'bar']})
+        self.batch.local.run_job_async.return_value = future
+        self.batch.batch_presence_ping_timeout = None
+        ret = self.batch.start()
+        # assert start_batch is called later with gather_job_timeout as param
+        self.assertEqual(
+            self.batch.event.io_loop.call_later.call_args[0],
+            (self.batch.opts['gather_job_timeout'], self.batch.start_batch))
 
     def test_batch_fire_start_event(self):
         self.batch.minions = set(['foo', 'bar'])


### PR DESCRIPTION
### What does this PR do?
Adds a separate parameter to control the async batch presence ping timeout

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/pull/50546

### Previous Behavior
gather_job_timeout was used before

### New Behavior
send `batch_presence_ping_timeout` in the request and this would be used as a timeout for starting the async batch.
The default would be to use `gather_job_timeout`

### Tests written?

Yes