### PR TITLE
Decode mysql_version for python3 compatibility

### DIFF
--- a/salt/modules/mysql.py
+++ b/salt/modules/mysql.py
@@ -1265,7 +1265,7 @@ def user_exists(user,
         salt '*' mysql.user_exists 'username' password_column='authentication_string'
     '''
     run_verify = False
-    server_version = version(**connection_args)
+    server_version = salt.utils.data.decode(version(**connection_args))
     compare_version = '10.2.0' if 'MariaDB' in server_version else '8.0.11'
     dbc = _connect(**connection_args)
     # Did we fail to connect with the user we are checking
@@ -1404,7 +1404,7 @@ def user_create(user,
         salt '*' mysql.user_create 'username' 'hostname' password_hash='hash'
         salt '*' mysql.user_create 'username' 'hostname' allow_passwordless=True
     '''
-    server_version = version(**connection_args)
+    server_version = salt.utils.data.decode(version(**connection_args))
     compare_version = '10.2.0' if 'MariaDB' in server_version else '8.0.11'
     if user_exists(user, host, **connection_args):
         log.info('User \'%s\'@\'%s\' already exists', user, host)
@@ -1509,7 +1509,7 @@ def user_chpass(user,
         salt '*' mysql.user_chpass frank localhost password_hash='hash'
         salt '*' mysql.user_chpass frank localhost allow_passwordless=True
     '''
-    server_version = version(**connection_args)
+    server_version = salt.utils.data.decode(version(**connection_args))
     compare_version = '10.2.0' if 'MariaDB' in server_version else '8.0.11'
     args = {}
     if password is not None:
@@ -1865,7 +1865,7 @@ def grant_exists(grant,
              'SELECT,INSERT,UPDATE,...' 'database.*' 'frank' 'localhost'
     '''
 
-    server_version = version(**connection_args)
+    server_version = salt.utils.data.decode(version(**connection_args))
     if 'ALL' in grant:
         if salt.utils.versions.version_cmp(server_version, '8.0') >= 0 and \
            'MariaDB' not in server_version:

--- a/salt/modules/mysql.py
+++ b/salt/modules/mysql.py
@@ -1266,6 +1266,11 @@ def user_exists(user,
     '''
     run_verify = False
     server_version = salt.utils.data.decode(version(**connection_args))
+    if not server_version:
+        lasr_err = __context__['mysql.error']
+        err = 'MySQL Error: Unable to fetch current server version. Last error was: "{}"'.format(lasr_err)
+        log.error(err)
+        return False
     compare_version = '10.2.0' if 'MariaDB' in server_version else '8.0.11'
     dbc = _connect(**connection_args)
     # Did we fail to connect with the user we are checking
@@ -1405,6 +1410,11 @@ def user_create(user,
         salt '*' mysql.user_create 'username' 'hostname' allow_passwordless=True
     '''
     server_version = salt.utils.data.decode(version(**connection_args))
+    if not server_version:
+        lasr_err = __context__['mysql.error']
+        err = 'MySQL Error: Unable to fetch current server version. Last error was: "{}"'.format(lasr_err)
+        log.error(err)
+        return False
     compare_version = '10.2.0' if 'MariaDB' in server_version else '8.0.11'
     if user_exists(user, host, **connection_args):
         log.info('User \'%s\'@\'%s\' already exists', user, host)
@@ -1510,6 +1520,11 @@ def user_chpass(user,
         salt '*' mysql.user_chpass frank localhost allow_passwordless=True
     '''
     server_version = salt.utils.data.decode(version(**connection_args))
+    if not server_version:
+        lasr_err = __context__['mysql.error']
+        err = 'MySQL Error: Unable to fetch current server version. Last error was: "{}"'.format(lasr_err)
+        log.error(err)
+        return False
     compare_version = '10.2.0' if 'MariaDB' in server_version else '8.0.11'
     args = {}
     if password is not None:
@@ -1866,6 +1881,11 @@ def grant_exists(grant,
     '''
 
     server_version = salt.utils.data.decode(version(**connection_args))
+    if not server_version:
+        lasr_err = __context__['mysql.error']
+        err = 'MySQL Error: Unable to fetch current server version. Last error was: "{}"'.format(lasr_err)
+        log.error(err)
+        return False
     if 'ALL' in grant:
         if salt.utils.versions.version_cmp(server_version, '8.0') >= 0 and \
            'MariaDB' not in server_version:

--- a/salt/modules/mysql.py
+++ b/salt/modules/mysql.py
@@ -1267,8 +1267,8 @@ def user_exists(user,
     run_verify = False
     server_version = salt.utils.data.decode(version(**connection_args))
     if not server_version:
-        lasr_err = __context__['mysql.error']
-        err = 'MySQL Error: Unable to fetch current server version. Last error was: "{}"'.format(lasr_err)
+        last_err = __context__['mysql.error']
+        err = 'MySQL Error: Unable to fetch current server version. Last error was: "{}"'.format(last_err)
         log.error(err)
         return False
     compare_version = '10.2.0' if 'MariaDB' in server_version else '8.0.11'
@@ -1411,8 +1411,8 @@ def user_create(user,
     '''
     server_version = salt.utils.data.decode(version(**connection_args))
     if not server_version:
-        lasr_err = __context__['mysql.error']
-        err = 'MySQL Error: Unable to fetch current server version. Last error was: "{}"'.format(lasr_err)
+        last_err = __context__['mysql.error']
+        err = 'MySQL Error: Unable to fetch current server version. Last error was: "{}"'.format(last_err)
         log.error(err)
         return False
     compare_version = '10.2.0' if 'MariaDB' in server_version else '8.0.11'
@@ -1521,8 +1521,8 @@ def user_chpass(user,
     '''
     server_version = salt.utils.data.decode(version(**connection_args))
     if not server_version:
-        lasr_err = __context__['mysql.error']
-        err = 'MySQL Error: Unable to fetch current server version. Last error was: "{}"'.format(lasr_err)
+        last_err = __context__['mysql.error']
+        err = 'MySQL Error: Unable to fetch current server version. Last error was: "{}"'.format(last_err)
         log.error(err)
         return False
     compare_version = '10.2.0' if 'MariaDB' in server_version else '8.0.11'
@@ -1882,8 +1882,8 @@ def grant_exists(grant,
 
     server_version = salt.utils.data.decode(version(**connection_args))
     if not server_version:
-        lasr_err = __context__['mysql.error']
-        err = 'MySQL Error: Unable to fetch current server version. Last error was: "{}"'.format(lasr_err)
+        last_err = __context__['mysql.error']
+        err = 'MySQL Error: Unable to fetch current server version. Last error was: "{}"'.format(last_err)
         log.error(err)
         return False
     if 'ALL' in grant:


### PR DESCRIPTION
### What does this PR do?
Adds decode to the mysql version fetch so it should work with both Py2 and py3. 

### What issues does this PR fix or reference?
Fixes https://github.com/saltstack/salt/issues/51866

### Previous Behavior
```
TypeError: a bytes-like object is required, not 'str'
```

Exception with Python 3

### New Behavior
The module works with both python3 and python2.

### Tests written?

No

### Commits signed with GPG?

Yes
