### PR TITLE
Revert "Removing options from libcrypto.OPENSSL_init_crypto..."

### DIFF
--- a/salt/utils/rsax931.py
+++ b/salt/utils/rsax931.py
@@ -70,7 +70,9 @@ def _init_libcrypto():
     libcrypto.RSA_public_decrypt.argtypes = (c_int, c_char_p, c_char_p, c_void_p, c_int)
 
     try:
-        libcrypto.OPENSSL_init_crypto()
+        libcrypto.OPENSSL_init_crypto(OPENSSL_INIT_NO_LOAD_CONFIG |
+                                      OPENSSL_INIT_ADD_ALL_CIPHERS |
+                                      OPENSSL_INIT_ADD_ALL_DIGESTS, None)
     except AttributeError:
         # Support for OpenSSL < 1.1 (OPENSSL_API_COMPAT < 0x10100000L)
         libcrypto.OPENSSL_no_config()


### PR DESCRIPTION
Revert "Removing options from libcrypto.OPENSSL_init_crypto so it will simply use the defaults."

This reverts commit 1831e645fa104a2ec59b16c2a309981f7be14cad.

This change throws core dumps on at least Ubuntu 18.04.