### PR TITLE
Avoid race condition when initializing OpenSSL

### DIFF
--- a/salt/utils/rsax931.py
+++ b/salt/utils/rsax931.py
@@ -55,6 +55,13 @@ def _init_libcrypto():
     '''
     libcrypto = _load_libcrypto()
 
+    try:
+        libcrypto.OPENSSL_init_crypto()
+    except AttributeError:
+        # Support for OpenSSL < 1.1 (OPENSSL_API_COMPAT < 0x10100000L)
+        libcrypto.OPENSSL_no_config()
+        libcrypto.OPENSSL_add_all_algorithms_noconf()
+
     libcrypto.RSA_new.argtypes = ()
     libcrypto.RSA_new.restype = c_void_p
     libcrypto.RSA_free.argtypes = (c_void_p, )
@@ -68,13 +75,6 @@ def _init_libcrypto():
     libcrypto.PEM_read_bio_RSA_PUBKEY.restype = c_void_p
     libcrypto.RSA_private_encrypt.argtypes = (c_int, c_char_p, c_char_p, c_void_p, c_int)
     libcrypto.RSA_public_decrypt.argtypes = (c_int, c_char_p, c_char_p, c_void_p, c_int)
-
-    try:
-        libcrypto.OPENSSL_init_crypto()
-    except AttributeError:
-        # Support for OpenSSL < 1.1 (OPENSSL_API_COMPAT < 0x10100000L)
-        libcrypto.OPENSSL_no_config()
-        libcrypto.OPENSSL_add_all_algorithms_noconf()
 
     return libcrypto
 


### PR DESCRIPTION
### What does this PR do?

Avoid race condition when initializing OpenSSL by initializing before setting up ctypes functions.

### Tests written?

No - Fixing issue seen in the test suite on Ubuntu 18.04

### Commits signed with GPG?

Yes