### PR TITLE
mount: fix extra -t parameter

### DIFF
--- a/salt/modules/mount.py
+++ b/salt/modules/mount.py
@@ -1208,13 +1208,15 @@ def mount(name, device, mkmnt=False, fstype='', opts='defaults', user=None, util
         lopts = ','.join(opts)
         args = '-o {0}'.format(lopts)
 
-    # use of fstype on AIX differs from typical Linux use of -t functionality
-    # AIX uses -v vfsname, -t fstype mounts all with fstype in /etc/filesystems
-    if 'AIX' in __grains__['os']:
-        if fstype:
+    if fstype:
+        # use of fstype on AIX differs from typical Linux use of -t
+        # functionality AIX uses -v vfsname, -t fstype mounts all with
+        # fstype in /etc/filesystems
+        if 'AIX' in __grains__['os']:
             args += ' -v {0}'.format(fstype)
-    else:
-        args += ' -t {0}'.format(fstype)
+        else:
+            args += ' -t {0}'.format(fstype)
+
     cmd = 'mount {0} {1} {2} '.format(args, device, name)
     out = __salt__['cmd.run_all'](cmd, runas=user, python_shell=False)
     if out['retcode']:

--- a/tests/unit/modules/test_mount.py
+++ b/tests/unit/modules/test_mount.py
@@ -297,6 +297,13 @@ class MountTestCase(TestCase, LoaderModuleMockMixin):
                                                    'stderr': True})
                     with patch.dict(mount.__salt__, {'cmd.run_all': mock}):
                         self.assertTrue(mount.mount('name', 'device'))
+                        mock.assert_called_with('mount  device name ',
+                                                python_shell=False, runas=None)
+
+                    with patch.dict(mount.__salt__, {'cmd.run_all': mock}):
+                        self.assertTrue(mount.mount('name', 'device', fstype='fstype'))
+                        mock.assert_called_with('mount  -t fstype device name ',
+                                                python_shell=False, runas=None)
 
                     mock = MagicMock(return_value={'retcode': False,
                                                    'stderr': False})
@@ -312,6 +319,35 @@ class MountTestCase(TestCase, LoaderModuleMockMixin):
                                                    'stderr': True})
                     with patch.dict(mount.__salt__, {'cmd.run_all': mock}):
                         self.assertTrue(mount.mount('name', 'device'))
+                        mock.assert_called_with('mount  device name ',
+                                                python_shell=False, runas=None)
+
+                    with patch.dict(mount.__salt__, {'cmd.run_all': mock}):
+                        self.assertTrue(mount.mount('name', 'device', fstype='fstype'))
+                        mock.assert_called_with('mount  -v fstype device name ',
+                                                python_shell=False, runas=None)
+
+                    mock = MagicMock(return_value={'retcode': False,
+                                                   'stderr': False})
+                    with patch.dict(mount.__salt__, {'cmd.run_all': mock}):
+                        self.assertTrue(mount.mount('name', 'device'))
+
+        with patch.dict(mount.__grains__, {'os': 'Linux'}):
+            mock = MagicMock(return_value=True)
+            with patch.object(os.path, 'exists', mock):
+                mock = MagicMock(return_value=None)
+                with patch.dict(mount.__salt__, {'file.mkdir': None}):
+                    mock = MagicMock(return_value={'retcode': True,
+                                                   'stderr': True})
+                    with patch.dict(mount.__salt__, {'cmd.run_all': mock}):
+                        self.assertTrue(mount.mount('name', 'device'))
+                        mock.assert_called_with('mount -o defaults device name ',
+                                                python_shell=False, runas=None)
+
+                    with patch.dict(mount.__salt__, {'cmd.run_all': mock}):
+                        self.assertTrue(mount.mount('name', 'device', fstype='fstype'))
+                        mock.assert_called_with('mount -o defaults -t fstype device name ',
+                                                python_shell=False, runas=None)
 
                     mock = MagicMock(return_value={'retcode': False,
                                                    'stderr': False})


### PR DESCRIPTION
If 'fstype' parameter is not set in Linux environments, salt will
build a mount command with an empty -t value, making the command
fail.

Note that this code needs to be backported to 2019.2, as this bug is also present there.