### PR TITLE
Minor improvements in module docs

### DIFF
--- a/doc/topics/development/modules/index.rst
+++ b/doc/topics/development/modules/index.rst
@@ -133,6 +133,8 @@ Executor     ``salt.executors`` (:ref:`index <all-salt.executors>`)           ``
 File Server  ``salt.fileserver`` (:ref:`index <file-server>`)                 ``fileserver``            ``fileserver_dirs``
 Grain        ``salt.grains`` (:ref:`index <all-salt.grains>`)                 ``grains``                ``grains_dirs``
 Log Handler  ``salt.log.handlers`` (:ref:`index <external-logging-handlers>`) ``log_handlers``          ``log_handlers_dirs``
+Matcher      ``salt.matchers``                                                ``matchers``              ``matchers_dirs``
+Metaproxy    ``salt.metaproxy``                                               ``metaproxy`` [#no-fs]_   ``metaproxy_dirs``
 Net API      ``salt.netapi`` (:ref:`index <all-netapi-modules>`)              ``netapi`` [#no-fs]_      ``netapi_dirs``
 Outputter    ``salt.output`` (:ref:`index <all-salt.output>`)                 ``output``                ``outputter_dirs``
 Pillar       ``salt.pillar`` (:ref:`index <all-salt.pillars>`)                ``pillar``                ``pillar_dirs``
@@ -179,7 +181,7 @@ Beacon
 
 * :ref:`Writing Beacons <writing-beacons>`
 
-Beacons are polled by the Salt event loop to monitor non-salt processes. See 
+Beacons are polled by the Salt event loop to monitor non-salt processes. See
 :ref:`Beacons <beacons>` for more information about the beacon system.
 
 Cache
@@ -257,6 +259,19 @@ Log Handler
 
 Log handlers allows the logs from salt (master or minion) to be sent to log
 aggregation systems.
+
+Matcher
+-------
+
+Matcher modules are used to define the :ref:`minion targeting expressions <targeting>`.
+For now, it is only possible to override the :ref:`existing matchers <matchers>`
+(the required CLI plumbing for custom matchers is not implemented yet).
+
+Metaproxy
+---------
+
+Metaproxy is an abstraction layer above the existing proxy minion. It enables
+adding different types of proxy minions that can still load existing proxymodules.
 
 Net API
 -------

--- a/doc/topics/development/modules/index.rst
+++ b/doc/topics/development/modules/index.rst
@@ -55,7 +55,7 @@ prepended by underscore, such as:
 Modules must be synced before they can be used. This can happen a few ways,
 discussed below.
 
-.. note:
+.. note::
     Using saltenvs besides ``base`` may not work in all contexts.
 
 Sync Via States
@@ -159,7 +159,7 @@ Wheel        ``salt.wheels`` (:ref:`index <all-salt.wheel>`)                  ``
 
 .. [#no-fs] These modules cannot be loaded from the Salt File Server.
 
-.. note:
+.. note::
     While it is possible to import modules directly with the import statement,
     it is strongly recommended that the appropriate
     :ref:`dunder dictionary <dunder-dictionaries>` is used to access them
@@ -397,7 +397,7 @@ Tokens
 Token stores for :ref:`External Authentication <acl-eauth>`. See the
 :py:mod:`salt.tokens` docstring for details.
 
-.. note:
+.. note::
     The runner to load tokens modules is
     :py:func:`saltutil.sync_eauth_tokens <salt.runners.saltutil.sync_eauth_tokens>`.
 

--- a/doc/topics/tutorials/jinja_to_execution_module.rst
+++ b/doc/topics/tutorials/jinja_to_execution_module.rst
@@ -6,8 +6,7 @@ How to Convert Jinja Logic to an Execution Module
 
 .. versionadded: 2016.???
 
-.. note:
-
+.. note::
     This tutorial assumes a basic knowledge of Salt states and specifically
     experience using the `maps.jinja` idiom.
 


### PR DESCRIPTION
### What does this PR do?

* Mention `matcher` and `metaproxy` loadable module types
* Add missing colon to a couple of notes (otherwise they aren't rendered)

### Commits signed with GPG?

No