### PR TITLE
Fix #51902 #51903

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -708,6 +708,8 @@ def _check_directory(name,
         for i in walk_l:
             walk_d[i[0]] = (i[1], i[2])
 
+    # Preserve rootdir_mode before going into recurse
+    rootdir_mode = mode
     if recurse:
         try:
             recurse_set = _get_recurse_set(recurse)
@@ -725,7 +727,7 @@ def _check_directory(name,
             if check_files:
                 for fname in files:
                     fchange = {}
-                    mode = file_mode
+                    mode = file_mode if mode is not None else None
                     path = os.path.join(root, fname)
                     stats = __salt__['file.stats'](
                         path, None, follow_symlinks
@@ -747,7 +749,7 @@ def _check_directory(name,
 
     # Recurse skips root (we always do dirs, not root), so always check root:
     if not children_only:
-        fchange = _check_dir_meta(name, user, group, mode, follow_symlinks)
+        fchange = _check_dir_meta(name, user, group, rootdir_mode, follow_symlinks)
         if fchange:
             changes[name] = fchange
 


### PR DESCRIPTION
### What does this PR do?
Fix the following issues
- #51902: [Fluorine] State file.directory recurse: file mode is applied without mode specified in recurse parameter
- #51903: [Fluorine] State file.directory recurse: When both file_mode and dir_mode are supplied, file_mode overrides dir_mode for the directory itself

### What issues does this PR fix or reference?
#51902 and #51903

### Previous Behavior
- In State file.directory recurse, file mode is applied without mode specified in recurse parameter
- In State file.directory recurse, when both file_mode and dir_mode are supplied, file_mode overrides dir_mode for the root directory itself

### New Behavior
- When mode is not specified in recurse parameter, sub dir file and folder permission is ignored
- When both file_mode and dir_mode are supplied, they are applied correctly for both root dir and sub directories

### Tests written?
No, manually tested

For #51902
```
[root@localhost salttest]# tree -up .
.
├── [drwxr-xr-x root    ]  dir_one
│   └── [drwxr-xr-x root    ]  dir_two
│       └── [-rwxrwx--- root    ]  testfile.txt  <=====
├── [-rw-r--r-- root    ]  file_perm.sls
└── [-rw-r--r-- root    ]  top.sls

2 directories, 3 files

[root@localhost salttest]# cat file_perm.sls
/tmp/salttest/dir_one:
  file.directory:
    - user: root
    - group: root
    - dir_mode: 755
    - file_mode: 644
    - recurse:  <===================
      - user
      - group

/tmp/salttest/dir_one/dir_two:
  file.directory:
    - user: root
    - group: root
    - dir_mode: 755
    - makedirs: True

[root@localhost salttest]# salt-call --local --file-root=/tmp/salttest/ state.apply test=True file_perm
local:
----------
          ID: /tmp/salttest/dir_one
    Function: file.directory
      Result: True
     Comment: The directory /tmp/salttest/dir_one is in the correct state
     Started: 16:33:39.986666
    Duration: 6.086 ms
     Changes:
----------
          ID: /tmp/salttest/dir_one/dir_two
    Function: file.directory
      Result: True
     Comment: The directory /tmp/salttest/dir_one/dir_two is in the correct state
     Started: 16:33:39.992922
    Duration: 0.742 ms
     Changes:

Summary for local
------------
Succeeded: 2
Failed:    0
------------
Total states run:     2
Total run time:   6.828 ms

============================================================

[root@localhost salttest]# cat file_perm.sls
/tmp/salttest/dir_one:
  file.directory:
    - user: root
    - group: root
    - dir_mode: 755
    - file_mode: 644
    - recurse:
      - user
      - group
      - mode  <=================

/tmp/salttest/dir_one/dir_two:
  file.directory:
    - user: root
    - group: root
    - dir_mode: 755
    - makedirs: True



[root@localhost salttest]# salt-call --local --file-root=/tmp/salttest/ state.apply test=True file_perm
local:
----------
          ID: /tmp/salttest/dir_one
    Function: file.directory
      Result: None
     Comment: The following files will be changed:
              /tmp/salttest/dir_one/dir_two/testfile.txt: mode - 0644
     Started: 16:34:55.357595
    Duration: 6.249 ms
     Changes:
              ----------
              /tmp/salttest/dir_one/dir_two/testfile.txt:
                  ----------
                  mode:
                      0644
----------
          ID: /tmp/salttest/dir_one/dir_two
    Function: file.directory
      Result: True
     Comment: The directory /tmp/salttest/dir_one/dir_two is in the correct state
     Started: 16:34:55.364020
    Duration: 0.749 ms
     Changes:

Summary for local
------------
Succeeded: 2 (unchanged=1, changed=1)
Failed:    0
------------
Total states run:     2
Total run time:   6.998 ms

```

For #51903 
```
[root@localhost salttest]# tree -up .
.
├── [drwxr-xr-x root    ]  dir_one  <========
│   └── [drwxr-xr-x root    ]  dir_two
│       └── [-rw-r--r-- root    ]  testfile.txt
├── [-rw-r--r-- root    ]  file_perm.sls
└── [-rw-r--r-- root    ]  top.sls

2 directories, 3 files


[root@localhost salttest]# cat file_perm.sls
/tmp/salttest/dir_one:
  file.directory:
    - user: root
    - group: root
    - dir_mode: 755 <===========
    - file_mode: 644 <============
    - recurse:
      - user
      - group
      - mode

/tmp/salttest/dir_one/dir_two:
  file.directory:
    - user: root
    - group: root
    - dir_mode: 755
    - makedirs: True


[root@localhost salttest]# salt-call --local --file-root=/tmp/salttest/ state.apply test=True file_perm
local:
----------
          ID: /tmp/salttest/dir_one
    Function: file.directory
      Result: True
     Comment: The directory /tmp/salttest/dir_one is in the correct state
     Started: 16:38:45.964966
    Duration: 6.378 ms
     Changes:
----------
          ID: /tmp/salttest/dir_one/dir_two
    Function: file.directory
      Result: True
     Comment: The directory /tmp/salttest/dir_one/dir_two is in the correct state
     Started: 16:38:45.971525
    Duration: 0.764 ms
     Changes:

Summary for local
------------
Succeeded: 2
Failed:    0
------------
Total states run:     2
Total run time:   7.142 ms

```


### Commits signed with GPG?

Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
