### PR TITLE
Add VMWare Photon OS support to yumpkg

### DIFF
--- a/doc/topics/releases/neon.rst
+++ b/doc/topics/releases/neon.rst
@@ -269,6 +269,9 @@ Module Changes
   module now supports perstant changes with ``persist=True`` by calling the
   :py:func:`selinux.fcontext_add_policy <salt.modules.selinux.fcontext_add_policy>` module.
 
+- The :py:func:`yumpkg <salt.modules.yumpkg>` module has been updated to support
+  VMWare's Photon OS, which uses tdnf (a C implementation of dnf).
+
 Enhancements to Engines
 =======================
 

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -83,7 +83,7 @@ def __virtual__():
     except Exception:
         return (False, "Module yumpkg: no yum based system detected")
 
-    enabled = ('amazon', 'xcp', 'xenserver', 'virtuozzolinux', 'virtuozzo')
+    enabled = ('amazon', 'xcp', 'xenserver', 'virtuozzolinux', 'virtuozzo', 'vmware photon')
 
     if os_family == 'redhat' or os_grain in enabled:
         return __virtualname__
@@ -146,6 +146,8 @@ def _yum():
         if ('fedora' in __grains__['os'].lower()
            and int(__grains__['osrelease']) >= 22):
             __context__[contextkey] = 'dnf'
+        elif 'photon' in __grains__['os'].lower():
+            __context__[contextkey] = 'tdnf'
         else:
             __context__[contextkey] = 'yum'
     return __context__[contextkey]
@@ -343,7 +345,7 @@ def _get_yum_config():
         # fall back to parsing the config ourselves
         # Look for the config the same order yum does
         fn = None
-        paths = ('/etc/yum/yum.conf', '/etc/yum.conf', '/etc/dnf/dnf.conf')
+        paths = ('/etc/yum/yum.conf', '/etc/yum.conf', '/etc/dnf/dnf.conf', '/etc/tdnf/tdnf.conf')
         for path in paths:
             if os.path.exists(path):
                 fn = path


### PR DESCRIPTION
### What does this PR do?
Allows VMWare's Photon OS (which uses tdnf) to use yumpkg

### What issues does this PR fix or reference?
None

### Previous Behavior
pkg.XXXXX modules/states did not function on Photon OS

### New Behavior
pkg.XXXXX function on Photon OS

### Tests written?
No

### Commits signed with GPG?
No