### PR TITLE
Remove nulls to prevent Zabbix API errors

### DIFF
--- a/salt/states/zabbix_host.py
+++ b/salt/states/zabbix_host.py
@@ -122,8 +122,8 @@ def present(host, groups, interfaces, **kwargs):
             interface_type = interface_ports[value['type'].lower()][0]
             main = '1' if six.text_type(value.get('main', 'true')).lower() == 'true' else '0'
             useip = '1' if six.text_type(value.get('useip', 'true')).lower() == 'true' else '0'
-            interface_ip = value.get('ip')
-            dns = value.get('dns', key)
+            interface_ip = value.get('ip') or ""
+            dns = value.get('dns', key) or ""
             port = six.text_type(value.get('port', interface_ports[value['type'].lower()][1]))
 
             interfaces_list.append({'type': interface_type,

--- a/salt/states/zabbix_host.py
+++ b/salt/states/zabbix_host.py
@@ -122,8 +122,8 @@ def present(host, groups, interfaces, **kwargs):
             interface_type = interface_ports[value['type'].lower()][0]
             main = '1' if six.text_type(value.get('main', 'true')).lower() == 'true' else '0'
             useip = '1' if six.text_type(value.get('useip', 'true')).lower() == 'true' else '0'
-            interface_ip = value.get('ip') or ""
-            dns = value.get('dns', key) or ""
+            interface_ip = value.get('ip', '')
+            dns = value.get('dns', key)
             port = six.text_type(value.get('port', interface_ports[value['type'].lower()][1]))
 
             interfaces_list.append({'type': interface_type,


### PR DESCRIPTION
If IP or DNS are null, Zabbix API returns an error. Prefer empty string over null.

### What does this PR do?
Replaces nulls with empty strings in "ip" and "dns" params
### What issues does this PR fix or reference?
N/A
### Previous Behavior
Null ip or dns params if empty

### New Behavior
Empty string ip or dns params if empty

### Tests written?
No

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
