### PR TITLE
lvm: be quiet when a pv, lv or vg is not expected

### DIFF
--- a/salt/modules/linux_lvm.py
+++ b/salt/modules/linux_lvm.py
@@ -64,16 +64,20 @@ def fullversion():
     return ret
 
 
-def pvdisplay(pvname='', real=False):
+def pvdisplay(pvname='', real=False, quiet=False):
     '''
     Return information about the physical volume(s)
 
     pvname
         physical device name
+
     real
         dereference any symlinks and report the real device
 
         .. versionadded:: 2015.8.7
+
+    quiet
+        if the physical volume is not present, do not show any error
 
 
     CLI Examples:
@@ -87,7 +91,8 @@ def pvdisplay(pvname='', real=False):
     cmd = ['pvdisplay', '-c']
     if pvname:
         cmd.append(pvname)
-    cmd_ret = __salt__['cmd.run_all'](cmd, python_shell=False)
+    cmd_ret = __salt__['cmd.run_all'](cmd, python_shell=False,
+                                      ignore_retcode=quiet)
 
     if cmd_ret['retcode'] != 0:
         return {}
@@ -118,9 +123,15 @@ def pvdisplay(pvname='', real=False):
     return ret
 
 
-def vgdisplay(vgname=''):
+def vgdisplay(vgname='', quiet=False):
     '''
     Return information about the volume group(s)
+
+    vgname
+        volume group name
+
+    quiet
+        if the volume group is not present, do not show any error
 
     CLI Examples:
 
@@ -133,7 +144,8 @@ def vgdisplay(vgname=''):
     cmd = ['vgdisplay', '-c']
     if vgname:
         cmd.append(vgname)
-    cmd_ret = __salt__['cmd.run_all'](cmd, python_shell=False)
+    cmd_ret = __salt__['cmd.run_all'](cmd, python_shell=False,
+                                      ignore_retcode=quiet)
 
     if cmd_ret['retcode'] != 0:
         return {}
@@ -167,6 +179,12 @@ def lvdisplay(lvname='', quiet=False):
     '''
     Return information about the logical volume(s)
 
+    lvname
+        logical device name
+
+    quiet
+        if the logical volume is not present, do not show any error
+
     CLI Examples:
 
     .. code-block:: bash
@@ -178,10 +196,8 @@ def lvdisplay(lvname='', quiet=False):
     cmd = ['lvdisplay', '-c']
     if lvname:
         cmd.append(lvname)
-    if quiet:
-        cmd_ret = __salt__['cmd.run_all'](cmd, python_shell=False, output_loglevel='quiet')
-    else:
-        cmd_ret = __salt__['cmd.run_all'](cmd, python_shell=False)
+    cmd_ret = __salt__['cmd.run_all'](cmd, python_shell=False,
+                                      ignore_retcode=quiet)
 
     if cmd_ret['retcode'] != 0:
         return {}

--- a/salt/states/lvm.py
+++ b/salt/states/lvm.py
@@ -56,7 +56,7 @@ def pv_present(name, **kwargs):
            'name': name,
            'result': True}
 
-    if __salt__['lvm.pvdisplay'](name):
+    if __salt__['lvm.pvdisplay'](name, quiet=True):
         ret['comment'] = 'Physical Volume {0} already present'.format(name)
     elif __opts__['test']:
         ret['comment'] = 'Physical Volume {0} is set to be created'.format(name)
@@ -86,7 +86,7 @@ def pv_absent(name):
            'name': name,
            'result': True}
 
-    if not __salt__['lvm.pvdisplay'](name):
+    if not __salt__['lvm.pvdisplay'](name, quiet=True):
         ret['comment'] = 'Physical Volume {0} does not exist'.format(name)
     elif __opts__['test']:
         ret['comment'] = 'Physical Volume {0} is set to be removed'.format(name)
@@ -95,7 +95,7 @@ def pv_absent(name):
     else:
         changes = __salt__['lvm.pvremove'](name)
 
-        if __salt__['lvm.pvdisplay'](name):
+        if __salt__['lvm.pvdisplay'](name, quiet=True):
             ret['comment'] = 'Failed to remove Physical Volume {0}'.format(name)
             ret['result'] = False
         else:
@@ -125,7 +125,7 @@ def vg_present(name, devices=None, **kwargs):
     if isinstance(devices, six.string_types):
         devices = devices.split(',')
 
-    if __salt__['lvm.vgdisplay'](name):
+    if __salt__['lvm.vgdisplay'](name, quiet=True):
         ret['comment'] = 'Volume Group {0} already present'.format(name)
         for device in devices:
             realdev = os.path.realpath(device)
@@ -185,7 +185,7 @@ def vg_absent(name):
            'name': name,
            'result': True}
 
-    if not __salt__['lvm.vgdisplay'](name):
+    if not __salt__['lvm.vgdisplay'](name, quiet=True):
         ret['comment'] = 'Volume Group {0} already absent'.format(name)
     elif __opts__['test']:
         ret['comment'] = 'Volume Group {0} is set to be removed'.format(name)
@@ -194,7 +194,7 @@ def vg_absent(name):
     else:
         changes = __salt__['lvm.vgremove'](name)
 
-        if not __salt__['lvm.vgdisplay'](name):
+        if not __salt__['lvm.vgdisplay'](name, quiet=True):
             ret['comment'] = 'Removed Volume Group {0}'.format(name)
             ret['changes']['removed'] = changes
         else:
@@ -311,7 +311,7 @@ def lv_absent(name, vgname=None):
            'result': True}
 
     lvpath = '/dev/{0}/{1}'.format(vgname, name)
-    if not __salt__['lvm.lvdisplay'](lvpath):
+    if not __salt__['lvm.lvdisplay'](lvpath, quiet=True):
         ret['comment'] = 'Logical Volume {0} already absent'.format(name)
     elif __opts__['test']:
         ret['comment'] = 'Logical Volume {0} is set to be removed'.format(name)
@@ -320,7 +320,7 @@ def lv_absent(name, vgname=None):
     else:
         changes = __salt__['lvm.lvremove'](name, vgname)
 
-        if not __salt__['lvm.lvdisplay'](lvpath):
+        if not __salt__['lvm.lvdisplay'](lvpath, quiet=True):
             ret['comment'] = 'Removed Logical Volume {0}'.format(name)
             ret['changes']['removed'] = changes
         else:


### PR DESCRIPTION
### What does this PR do?

When we try to create a new pv, lv or vg, there is a chance that
is not present in the system. Also when we want to remove it, we
expect that is absent and the end of the operation.

This patch hide the error messages from pvdisplay, lvdisplay and
vgdisplay commands in those cases.
