### PR TITLE
linux_lvm: clean error in pvcreate and pvremove

### DIFF
--- a/salt/modules/linux_lvm.py
+++ b/salt/modules/linux_lvm.py
@@ -246,7 +246,7 @@ def pvcreate(devices, override=True, **kwargs):
     for device in devices:
         if not os.path.exists(device):
             raise CommandExecutionError('{0} does not exist'.format(device))
-        if not pvdisplay(device):
+        if not pvdisplay(device, quiet=True):
             cmd.append(device)
         elif not override:
             raise CommandExecutionError('Device "{0}" is already an LVM physical volume.'.format(device))
@@ -311,7 +311,7 @@ def pvremove(devices, override=True):
 
     # Verify pvcremove was successful
     for device in devices:
-        if pvdisplay(device):
+        if pvdisplay(device, quiet=True):
             raise CommandExecutionError('Device "{0}" was not affected.'.format(device))
 
     return True


### PR DESCRIPTION
### What does this PR do?

The LVM module behaves like a state when doing a pvcreate and a
pvremove, checking the previous and last state.  We do not expect
to have a physical volume before creating it, or after removing it.

This patch pass the 'quiet' parameter into pvdisplay to hide the
expected error in those cases.

A continuation of: https://github.com/saltstack/salt/pull/51929