### PR TITLE
blockdev: hide blkid errors when are expected

### DIFF
--- a/salt/states/blockdev.py
+++ b/salt/states/blockdev.py
@@ -193,5 +193,6 @@ def _checkblk(name):
     Check if the blk exists and return its fstype if ok
     '''
 
-    blk = __salt__['cmd.run']('blkid -o value -s TYPE {0}'.format(name))
+    blk = __salt__['cmd.run']('blkid -o value -s TYPE {0}'.format(name),
+                              ignore_retcode=True)
     return '' if not blk else blk


### PR DESCRIPTION
### What does this PR do?

The function _checkblk is called to detect if the device is already
formatted. The first time that we call blkid -o value -s TYPE will
will fail, as the device is still not formatted.

This patch hide this error from the logs (only the ERROR status,
not the stderr output and the retcode), as is an expected error.
