### PR TITLE
saltnado: account for full_return in local sync calls

### DIFF
--- a/salt/netapi/rest_tornado/saltnado.py
+++ b/salt/netapi/rest_tornado/saltnado.py
@@ -951,6 +951,7 @@ class SaltAPIHandler(BaseSaltAPIHandler):  # pylint: disable=W0223
         Dispatch local client commands
         '''
         # Generate jid and find all minions before triggering a job to subscribe all returns from minions
+        full_return = chunk.pop('full_return', False)
         chunk['jid'] = salt.utils.jid.gen_jid(self.application.opts) if not chunk.get('jid', None) else chunk['jid']
         minions = set(self.ckminions.check_minions(chunk['tgt'], chunk.get('tgt_type', 'glob')))
 
@@ -1057,7 +1058,7 @@ class SaltAPIHandler(BaseSaltAPIHandler):  # pylint: disable=W0223
                         if minion_id not in minions:
                             minions[minion_id] = False
                 else:
-                    chunk_ret[f_result['data']['id']] = f_result['data']['return']
+                    chunk_ret[f_result['data']['id']] = f_result if full_return else f_result['data']['return']
                     # clear finished event future
                     minions[f_result['data']['id']] = True
                     # if there are no more minions to wait for, then we are done


### PR DESCRIPTION
### What does this PR do?
full_return should be respected if asked for in low data.

### Tests written?
No

### Commits signed with GPG?

Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
