### PR TITLE
partially unify public functions signature for pkg and lowpkg

### DIFF
--- a/salt/modules/aixpkg.py
+++ b/salt/modules/aixpkg.py
@@ -398,7 +398,7 @@ def latest_version(*names, **kwargs):
 available_version = salt.utils.functools.alias_function(latest_version, 'available_version')
 
 
-def upgrade_available(name):
+def upgrade_available(name, **kwargs):
     '''
     Check whether or not an upgrade is available for a given package
 

--- a/salt/modules/apkpkg.py
+++ b/salt/modules/apkpkg.py
@@ -83,7 +83,7 @@ def version(*names, **kwargs):
     return __salt__['pkg_resource.version'](*names, **kwargs)
 
 
-def refresh_db():
+def refresh_db(**kwargs):
     '''
     Updates the package list
 
@@ -425,7 +425,7 @@ def remove(name=None, pkgs=None, purge=False, **kwargs):  # pylint: disable=unus
     return ret
 
 
-def upgrade(name=None, pkgs=None, refresh=True):
+def upgrade(name=None, pkgs=None, refresh=True, **kwargs):
     '''
     Upgrades all packages via ``apk upgrade`` or a specific package if name or
     pkgs is specified. Name is ignored if pkgs is specified
@@ -485,7 +485,7 @@ def upgrade(name=None, pkgs=None, refresh=True):
     return ret
 
 
-def list_upgrades(refresh=True):
+def list_upgrades(refresh=True, **kwargs):
     '''
     List all available package upgrades.
 
@@ -524,7 +524,7 @@ def list_upgrades(refresh=True):
     return ret
 
 
-def file_list(*packages):
+def file_list(*packages, **kwargs):
     '''
     List the files that belong to a package. Not specifying any packages will
     return a list of _every_ file on the system's package database (not
@@ -541,7 +541,7 @@ def file_list(*packages):
     return file_dict(*packages)
 
 
-def file_dict(*packages):
+def file_dict(*packages, **kwargs):
     '''
     List the files that belong to a package, grouped by package. Not
     specifying any packages will return a list of _every_ file on the system's
@@ -580,7 +580,7 @@ def file_dict(*packages):
     return {'errors': errors, 'packages': ret}
 
 
-def owner(*paths):
+def owner(*paths, **kwargs):
     '''
     Return the name of the package that owns the file. Multiple file paths can
     be passed. Like :mod:`pkg.version <salt.modules.apk.version`, if a single

--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -294,7 +294,7 @@ def version(*names, **kwargs):
     return __salt__['pkg_resource.version'](*names, **kwargs)
 
 
-def refresh_db(cache_valid_time=0, failhard=False):
+def refresh_db(cache_valid_time=0, failhard=False, **kwargs):
     '''
     Updates the APT database to latest packages based upon repositories
 
@@ -1392,7 +1392,7 @@ def list_upgrades(refresh=True, dist_upgrade=True, **kwargs):
     return _get_upgradable(dist_upgrade, **kwargs)
 
 
-def upgrade_available(name):
+def upgrade_available(name, **kwargs):
     '''
     Check whether or not an upgrade is available for a given package
 
@@ -1405,7 +1405,7 @@ def upgrade_available(name):
     return latest_version(name) != ''
 
 
-def version_cmp(pkg1, pkg2, ignore_epoch=False):
+def version_cmp(pkg1, pkg2, ignore_epoch=False, **kwargs):
     '''
     Do a cmp-style comparison on two packages. Return -1 if pkg1 < pkg2, 0 if
     pkg1 == pkg2, and 1 if pkg1 > pkg2. Return None if there was a problem
@@ -1595,7 +1595,7 @@ def _skip_source(source):
     return False
 
 
-def list_repos():
+def list_repos(**kwargs):
     '''
     Lists all repos in the sources.list (and sources.lists.d) files
 
@@ -2362,7 +2362,7 @@ def mod_repo(repo, saltenv='base', **kwargs):
     }
 
 
-def file_list(*packages):
+def file_list(*packages, **kwargs):
     '''
     List the files that belong to a package. Not specifying any packages will
     return a list of _every_ file on the system's package database (not
@@ -2379,7 +2379,7 @@ def file_list(*packages):
     return __salt__['lowpkg.file_list'](*packages)
 
 
-def file_dict(*packages):
+def file_dict(*packages, **kwargs):
     '''
     List the files that belong to a package, grouped by package. Not
     specifying any packages will return a list of _every_ file on the system's
@@ -2663,7 +2663,7 @@ def _resolve_deps(name, pkgs, **kwargs):
     return
 
 
-def owner(*paths):
+def owner(*paths, **kwargs):
     '''
     .. versionadded:: 2014.7.0
 

--- a/salt/modules/dpkg_lowpkg.py
+++ b/salt/modules/dpkg_lowpkg.py
@@ -135,7 +135,7 @@ def unpurge(*packages):
     return salt.utils.data.compare_dicts(old, new)
 
 
-def list_pkgs(*packages):
+def list_pkgs(*packages, **kwargs):
     '''
     List the packages currently installed in a dict::
 
@@ -169,7 +169,7 @@ def list_pkgs(*packages):
     return pkgs
 
 
-def file_list(*packages):
+def file_list(*packages, **kwargs):
     '''
     List the files that belong to a package. Not specifying any packages will
     return a list of _every_ file on the system's package database (not
@@ -211,7 +211,7 @@ def file_list(*packages):
     return {'errors': errors, 'files': list(ret)}
 
 
-def file_dict(*packages):
+def file_dict(*packages, **kwargs):
     '''
     List the files that belong to a package, grouped by package. Not
     specifying any packages will return a list of _every_ file on the system's

--- a/salt/modules/ebuildpkg.py
+++ b/salt/modules/ebuildpkg.py
@@ -360,7 +360,7 @@ def list_upgrades(refresh=True, backtrack=3, **kwargs):  # pylint: disable=W0613
     return _get_upgradable(backtrack)
 
 
-def upgrade_available(name):
+def upgrade_available(name, **kwargs):
     '''
     Check whether or not an upgrade is available for a given package
 
@@ -442,7 +442,7 @@ def list_pkgs(versions_as_list=False, **kwargs):
     return ret
 
 
-def refresh_db():
+def refresh_db(**kwargs):
     '''
     Update the portage tree using the first available method from the following
     list:
@@ -767,7 +767,7 @@ def install(name=None,
     return changes
 
 
-def update(pkg, slot=None, fromrepo=None, refresh=False, binhost=None):
+def update(pkg, slot=None, fromrepo=None, refresh=False, binhost=None, **kwargs):
     '''
     .. versionchanged:: 2015.8.12,2016.3.3,2016.11.0
         On minions running systemd>=205, `systemd-run(1)`_ is now used to
@@ -860,7 +860,7 @@ def update(pkg, slot=None, fromrepo=None, refresh=False, binhost=None):
     return ret
 
 
-def upgrade(refresh=True, binhost=None, backtrack=3):
+def upgrade(refresh=True, binhost=None, backtrack=3, **kwargs):
     '''
     .. versionchanged:: 2015.8.12,2016.3.3,2016.11.0
         On minions running systemd>=205, `systemd-run(1)`_ is now used to

--- a/salt/modules/freebsdpkg.py
+++ b/salt/modules/freebsdpkg.py
@@ -238,7 +238,7 @@ def version(*names, **kwargs):
     ])
 
 
-def refresh_db():
+def refresh_db(**kwargs):
     '''
     ``pkg_add(1)`` does not use a local database of available packages, so this
     function simply returns ``True``. it exists merely for API compatibility.
@@ -503,7 +503,7 @@ def _rehash():
         __salt__['cmd.shell']('rehash', output_loglevel='trace')
 
 
-def file_list(*packages):
+def file_list(*packages, **kwargs):
     '''
     List the files that belong to a package. Not specifying any packages will
     return a list of _every_ file on the system's package database (not
@@ -525,7 +525,7 @@ def file_list(*packages):
     return ret
 
 
-def file_dict(*packages):
+def file_dict(*packages, **kwargs):
     '''
     List the files that belong to a package, grouped by package. Not
     specifying any packages will return a list of _every_ file on the

--- a/salt/modules/mac_brew_pkg.py
+++ b/salt/modules/mac_brew_pkg.py
@@ -276,7 +276,7 @@ def remove(name=None, pkgs=None, **kwargs):
     return ret
 
 
-def refresh_db():
+def refresh_db(**kwargs):
     '''
     Update the homebrew package repository.
 
@@ -459,7 +459,7 @@ def list_upgrades(refresh=True, **kwargs):  # pylint: disable=W0613
     return ret
 
 
-def upgrade_available(pkg):
+def upgrade_available(pkg, **kwargs):
     '''
     Check whether or not an upgrade is available for a given package
 
@@ -472,7 +472,7 @@ def upgrade_available(pkg):
     return pkg in list_upgrades()
 
 
-def upgrade(refresh=True):
+def upgrade(refresh=True, **kwargs):
     '''
     Upgrade outdated, unpinned brews.
 
@@ -517,7 +517,7 @@ def upgrade(refresh=True):
     return ret
 
 
-def info_installed(*names):
+def info_installed(*names, **kwargs):
     '''
     Return the information of the named package(s) installed on the system.
 

--- a/salt/modules/mac_portspkg.py
+++ b/salt/modules/mac_portspkg.py
@@ -376,7 +376,7 @@ def list_upgrades(refresh=True, **kwargs):  # pylint: disable=W0613
     return _list('outdated')
 
 
-def upgrade_available(pkg, refresh=True):
+def upgrade_available(pkg, refresh=True, **kwargs):
     '''
     Check whether or not an upgrade is available for a given package
 
@@ -389,7 +389,7 @@ def upgrade_available(pkg, refresh=True):
     return pkg in list_upgrades(refresh=refresh)
 
 
-def refresh_db():
+def refresh_db(**kwargs):
     '''
     Update ports with ``port selfupdate``
 
@@ -405,7 +405,7 @@ def refresh_db():
     return salt.utils.mac_utils.execute_return_success(cmd)
 
 
-def upgrade(refresh=True):  # pylint: disable=W0613
+def upgrade(refresh=True, **kwargs):  # pylint: disable=W0613
     '''
     Run a full upgrade using MacPorts 'port upgrade outdated'
 

--- a/salt/modules/openbsdpkg.py
+++ b/salt/modules/openbsdpkg.py
@@ -344,7 +344,7 @@ def purge(name=None, pkgs=None, **kwargs):
     return remove(name=name, pkgs=pkgs, purge=True)
 
 
-def upgrade_available(name):
+def upgrade_available(name, **kwargs):
     '''
     Check whether or not an upgrade is available for a given package
 

--- a/salt/modules/pacmanpkg.py
+++ b/salt/modules/pacmanpkg.py
@@ -111,7 +111,7 @@ def latest_version(*names, **kwargs):
 available_version = salt.utils.functools.alias_function(latest_version, 'available_version')
 
 
-def upgrade_available(name):
+def upgrade_available(name, **kwargs):
     '''
     Check whether or not an upgrade is available for a given package
 
@@ -393,7 +393,7 @@ def group_diff(name):
     return ret
 
 
-def refresh_db(root=None):
+def refresh_db(root=None, **kwargs):
     '''
     Just run a ``pacman -Sy``, return a dict::
 
@@ -843,7 +843,7 @@ def purge(name=None, pkgs=None, **kwargs):
     return _uninstall(action='purge', name=name, pkgs=pkgs)
 
 
-def file_list(*packages):
+def file_list(*packages, **kwargs):
     '''
     List the files that belong to a package. Not specifying any packages will
     return a list of _every_ file on the system's package database (not
@@ -877,7 +877,7 @@ def file_list(*packages):
     return {'errors': errors, 'files': ret}
 
 
-def file_dict(*packages):
+def file_dict(*packages, **kwargs):
     '''
     List the files that belong to a package, grouped by package. Not
     specifying any packages will return a list of _every_ file on the system's
@@ -913,7 +913,7 @@ def file_dict(*packages):
     return {'errors': errors, 'packages': ret}
 
 
-def owner(*paths):
+def owner(*paths, **kwargs):
     '''
     .. versionadded:: 2014.7.0
 

--- a/salt/modules/pkgin.py
+++ b/salt/modules/pkgin.py
@@ -117,7 +117,7 @@ def _splitpkg(name):
         return name.split(';', 1)[0].rsplit('-', 1)
 
 
-def search(pkg_name):
+def search(pkg_name, **kwargs):
     '''
     Searches for an exact match using pkgin ^package$
 
@@ -230,7 +230,7 @@ def version(*names, **kwargs):
     return __salt__['pkg_resource.version'](*names, **kwargs)
 
 
-def refresh_db(force=False):
+def refresh_db(force=False, **kwargs):
     '''
     Use pkg update to get latest pkg_summary
 
@@ -642,7 +642,7 @@ def _rehash():
         __salt__['cmd.run']('rehash', output_loglevel='trace')
 
 
-def file_list(package):
+def file_list(package, **kwargs):
     '''
     List the files that belong to a package.
 
@@ -660,7 +660,7 @@ def file_list(package):
     return ret
 
 
-def file_dict(*packages):
+def file_dict(*packages, **kwargs):
     '''
     .. versionchanged: 2016.3.0
 

--- a/salt/modules/pkgng.py
+++ b/salt/modules/pkgng.py
@@ -224,7 +224,7 @@ def version(*names, **kwargs):
 info = salt.utils.functools.alias_function(version, 'info')
 
 
-def refresh_db(jail=None, chroot=None, root=None, force=False):
+def refresh_db(jail=None, chroot=None, root=None, force=False, **kwargs):
     '''
     Refresh PACKAGESITE contents
 
@@ -2441,7 +2441,7 @@ def _parse_upgrade(stdout):
     return result
 
 
-def version_cmp(pkg1, pkg2, ignore_epoch=False):
+def version_cmp(pkg1, pkg2, ignore_epoch=False, **kwargs):
     '''
     Do a cmp-style comparison on two packages. Return -1 if pkg1 < pkg2, 0 if
     pkg1 == pkg2, and 1 if pkg1 > pkg2. Return None if there was a problem

--- a/salt/modules/solarisipspkg.py
+++ b/salt/modules/solarisipspkg.py
@@ -109,7 +109,7 @@ def _ips_get_pkgversion(line):
     return line.split()[0].split('@')[1].strip()
 
 
-def refresh_db(full=False):
+def refresh_db(full=False, **kwargs):
     '''
     Updates the remote repos database.
 
@@ -133,7 +133,7 @@ def refresh_db(full=False):
         return __salt__['cmd.retcode']('/bin/pkg refresh') == 0
 
 
-def upgrade_available(name):
+def upgrade_available(name, **kwargs):
     '''
     Check if there is an upgrade available for a certain package
     Accepts full or partial FMRI. Returns all matches found.

--- a/salt/modules/solarispkg.py
+++ b/salt/modules/solarispkg.py
@@ -169,7 +169,7 @@ def latest_version(*names, **kwargs):
 available_version = salt.utils.functools.alias_function(latest_version, 'available_version')
 
 
-def upgrade_available(name):
+def upgrade_available(name, **kwargs):
     '''
     Check whether or not an upgrade is available for a given package
 

--- a/salt/modules/xbpspkg.py
+++ b/salt/modules/xbpspkg.py
@@ -121,7 +121,7 @@ def list_pkgs(versions_as_list=False, **kwargs):
     return ret
 
 
-def list_upgrades(refresh=True):
+def list_upgrades(refresh=True, **kwargs):
     '''
     Check whether or not an upgrade is available for all packages
 
@@ -247,7 +247,7 @@ def latest_version(*names, **kwargs):
 available_version = latest_version
 
 
-def upgrade_available(name):
+def upgrade_available(name, **kwargs):
     '''
     Check whether or not an upgrade is available for a given package
 
@@ -260,7 +260,7 @@ def upgrade_available(name):
     return latest_version(name) != ''
 
 
-def refresh_db():
+def refresh_db(**kwargs):
     '''
     Update list of available packages from installed repos
 
@@ -300,7 +300,7 @@ def version(*names, **kwargs):
     return __salt__['pkg_resource.version'](*names, **kwargs)
 
 
-def upgrade(refresh=True):
+def upgrade(refresh=True, **kwargs):
     '''
     Run a full system upgrade
 
@@ -484,7 +484,7 @@ def remove(name=None, pkgs=None, recursive=True, **kwargs):
     return salt.utils.data.compare_dicts(old, new)
 
 
-def list_repos():
+def list_repos(**kwargs):
     '''
     List all repos known by XBPS
 
@@ -607,7 +607,7 @@ def add_repo(repo, conffile='/usr/share/xbps.d/15-saltstack.conf'):
     return True
 
 
-def del_repo(repo):
+def del_repo(repo, **kwargs):
     '''
     Remove an XBPS repository from the system.
 

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -596,7 +596,7 @@ def version(*names, **kwargs):
     return __salt__['pkg_resource.version'](*names, **kwargs)
 
 
-def version_cmp(pkg1, pkg2, ignore_epoch=False):
+def version_cmp(pkg1, pkg2, ignore_epoch=False, **kwargs):
     '''
     .. versionadded:: 2015.5.4
 
@@ -988,7 +988,7 @@ def list_upgrades(refresh=True, **kwargs):
 list_updates = salt.utils.functools.alias_function(list_upgrades, 'list_updates')
 
 
-def list_downloaded():
+def list_downloaded(**kwargs):
     '''
     .. versionadded:: 2017.7.0
 
@@ -1924,13 +1924,13 @@ def upgrade(name=None,
 
 
 def update(name=None,
-            pkgs=None,
-            refresh=True,
-            skip_verify=False,
-            normalize=True,
-            minimal=False,
-            obsoletes=False,
-            **kwargs):
+           pkgs=None,
+           refresh=True,
+           skip_verify=False,
+           normalize=True,
+           minimal=False,
+           obsoletes=False,
+           **kwargs):
     '''
     .. versionadded:: 2019.2.0
 
@@ -2620,7 +2620,7 @@ def group_install(name,
 groupinstall = salt.utils.functools.alias_function(group_install, 'groupinstall')
 
 
-def list_repos(basedir=None):
+def list_repos(basedir=None, **kwargs):
     '''
     Lists all repos in <basedir> (default: all dirs in `reposdir` yum option).
 
@@ -2952,7 +2952,7 @@ def _parse_repo_file(filename):
     return (headers, salt.utils.data.decode(config))
 
 
-def file_list(*packages):
+def file_list(*packages, **kwargs):
     '''
     .. versionadded:: 2014.1.0
 
@@ -2971,7 +2971,7 @@ def file_list(*packages):
     return __salt__['lowpkg.file_list'](*packages)
 
 
-def file_dict(*packages):
+def file_dict(*packages, **kwargs):
     '''
     .. versionadded:: 2014.1.0
 
@@ -2990,7 +2990,7 @@ def file_dict(*packages):
     return __salt__['lowpkg.file_dict'](*packages)
 
 
-def owner(*paths):
+def owner(*paths, **kwargs):
     '''
     .. versionadded:: 2014.7.0
 
@@ -3078,7 +3078,7 @@ def modified(*packages, **flags):
 
 
 @salt.utils.decorators.path.which('yumdownloader')
-def download(*packages):
+def download(*packages, **kwargs):
     '''
     .. versionadded:: 2015.5.0
 
@@ -3150,7 +3150,7 @@ def download(*packages):
     return ret
 
 
-def diff(*paths):
+def diff(*paths, **kwargs):
     '''
     Return a formatted diff between current files and original in a package.
     NOTE: this function includes all files (configuration and not), but does
@@ -3210,7 +3210,7 @@ def _get_patches(installed_only=False):
     return patches
 
 
-def list_patches(refresh=False):
+def list_patches(refresh=False, **kwargs):
     '''
     .. versionadded:: 2017.7.0
 
@@ -3233,7 +3233,7 @@ def list_patches(refresh=False):
     return _get_patches()
 
 
-def list_installed_patches():
+def list_installed_patches(**kwargs):
     '''
     .. versionadded:: 2017.7.0
 

--- a/salt/modules/zypperpkg.py
+++ b/salt/modules/zypperpkg.py
@@ -704,7 +704,7 @@ def version(*names, **kwargs):
     return __salt__['pkg_resource.version'](*names, **kwargs) or {}
 
 
-def version_cmp(ver1, ver2, ignore_epoch=False):
+def version_cmp(ver1, ver2, ignore_epoch=False, **kwargs):
     '''
     .. versionadded:: 2015.5.4
 
@@ -999,7 +999,7 @@ def get_repo(repo, root=None, **kwargs):  # pylint: disable=unused-argument
     return _get_repo_info(repo, root=root)
 
 
-def list_repos(root=None):
+def list_repos(root=None, **kwargs):
     '''
     Lists all repos.
 
@@ -2534,7 +2534,7 @@ def _get_patches(installed_only=False, root=None):
     return patches
 
 
-def list_patches(refresh=False, root=None):
+def list_patches(refresh=False, root=None, **kwargs):
     '''
     .. versionadded:: 2017.7.0
 
@@ -2560,7 +2560,7 @@ def list_patches(refresh=False, root=None):
     return _get_patches(root=root)
 
 
-def list_installed_patches(root=None):
+def list_installed_patches(root=None, **kwargs):
     '''
     .. versionadded:: 2017.7.0
 


### PR DESCRIPTION
### What does this PR do?
 
The virtual module 'pkg' is heavily used by other states, like the
'pkg' state, so differences in the signature of public functions
can generate errors like:

  TypeError: xxx() got an unexpected keyword argument 'yyy'

The fix is to add the parameter 'yyy' into all versions of the
function 'xxx()' in all the 'pkg' virtual modules, but this
approach is cumbersome and not very resilient, as any refactoring
on the public interface or in the pkg state module will break
again the already agreed contract.

This patch append **kwarg in most of the public methods on virtual
module pkg where it is missing, fixing the described issue and
making more easy the refactoring of the code.

Also do the same for 'lowpkg'