### PR TITLE
saltnado: backcompat fixes for pepper functionality

### DIFF
--- a/salt/netapi/rest_tornado/__init__.py
+++ b/salt/netapi/rest_tornado/__init__.py
@@ -49,6 +49,7 @@ def get_application(opts):
     paths = [
         (r"/", saltnado.SaltAPIHandler),
         (r"/login", saltnado.SaltAuthHandler),
+        (r"/token", saltnado.SaltAuthHandler),
         (r"/minions/(.*)", saltnado.MinionSaltAPIHandler),
         (r"/minions", saltnado.MinionSaltAPIHandler),
         (r"/jobs/(.*)", saltnado.JobsSaltAPIHandler),

--- a/salt/netapi/rest_tornado/saltnado.py
+++ b/salt/netapi/rest_tornado/saltnado.py
@@ -956,6 +956,8 @@ class SaltAPIHandler(BaseSaltAPIHandler):  # pylint: disable=W0223
         '''
         # Generate jid and find all minions before triggering a job to subscribe all returns from minions
         full_return = chunk.pop('full_return', False)
+        timeout_length = chunk.get('timeout', self.application.opts['gather_job_timeout'])
+
         chunk['jid'] = salt.utils.jid.gen_jid(self.application.opts) if not chunk.get('jid', None) else chunk['jid']
         minions = set(self.ckminions.check_minions(chunk['tgt'], chunk.get('tgt_type', 'glob')))
 
@@ -1010,7 +1012,7 @@ class SaltAPIHandler(BaseSaltAPIHandler):  # pylint: disable=W0223
             min_wait_time = tornado.gen.sleep(self.application.opts['syndic_wait'])
 
         # To ensure job_not_running and all_return are terminated by each other, communicate using a future
-        is_timed_out = tornado.gen.sleep(self.application.opts['gather_job_timeout'])
+        is_timed_out = tornado.gen.sleep(timeout_length)
         is_finished = Future()
 
         # ping until the job is not running, while doing so, if we see new minions returning

--- a/salt/netapi/rest_tornado/saltnado.py
+++ b/salt/netapi/rest_tornado/saltnado.py
@@ -1081,40 +1081,38 @@ class SaltAPIHandler(BaseSaltAPIHandler):  # pylint: disable=W0223
         Return a future which will complete once jid (passed in) is no longer
         running on tgt
         '''
-        ping_pub_data = yield self.saltclients['local'](tgt,
-                                                        'saltutil.find_job',
-                                                        [jid],
-                                                        tgt_type=tgt_type)
-        ping_tag = tagify([ping_pub_data['jid'], 'ret'], 'job')
-
-        minion_running = False
         while True:
             try:
+                # we can't do anything if the client cxn is already terminated
+                if self._finished:
+                    return
+
+                ping_pub_data = yield self.saltclients['local'](tgt,
+                                                                'saltutil.find_job',
+                                                                [jid],
+                                                                tgt_type=tgt_type)
+                ping_tag = tagify([ping_pub_data['jid'], 'ret'], 'job')
+
+                minion_running = False
+
                 event = self.application.event_listener.get_event(self,
                                                                   tag=ping_tag,
                                                                   timeout=self.application.opts['gather_job_timeout'])
                 event = yield event
+
+                # Minions can return, we want to see if the job is running...
+                if event['data'].get('return', {}) == {}:
+                    continue
+                if event['data']['id'] not in minions:
+                    minions[event['data']['id']] = False
+                minion_running = True
             except TimeoutException:
                 if not event.done():
                     event.set_result(None)
 
                 if not minion_running or is_finished.done():
                     raise tornado.gen.Return(True)
-                else:
-                    ping_pub_data = yield self.saltclients['local'](tgt,
-                                                                    'saltutil.find_job',
-                                                                    [jid],
-                                                                    tgt_type=tgt_type)
-                    ping_tag = tagify([ping_pub_data['jid'], 'ret'], 'job')
-                    minion_running = False
-                    continue
 
-            # Minions can return, we want to see if the job is running...
-            if event['data'].get('return', {}) == {}:
-                continue
-            if event['data']['id'] not in minions:
-                minions[event['data']['id']] = False
-            minion_running = True
 
     @tornado.gen.coroutine
     def _disbatch_local_async(self, chunk):

--- a/salt/netapi/rest_tornado/saltnado.py
+++ b/salt/netapi/rest_tornado/saltnado.py
@@ -1058,7 +1058,7 @@ class SaltAPIHandler(BaseSaltAPIHandler):  # pylint: disable=W0223
                         if minion_id not in minions:
                             minions[minion_id] = False
                 else:
-                    chunk_ret[f_result['data']['id']] = f_result if full_return else f_result['data']['return']
+                    chunk_ret[f_result['data']['id']] = f_result['data'] if full_return else f_result['data']['return']
                     # clear finished event future
                     minions[f_result['data']['id']] = True
                     # if there are no more minions to wait for, then we are done

--- a/salt/netapi/rest_tornado/saltnado.py
+++ b/salt/netapi/rest_tornado/saltnado.py
@@ -785,6 +785,10 @@ class SaltAuthHandler(BaseSaltAPIHandler):  # pylint: disable=W0223
             'perms': perms,
             }]}
 
+        # to provide cherrypy backcompat, the /token return is slightly different
+        if self.request.path == '/token':
+            ret = ret['return']
+
         self.write(self.serialize(ret))
 
 

--- a/salt/runner.py
+++ b/salt/runner.py
@@ -78,7 +78,7 @@ class RunnerClient(mixins.SyncClientMixin, mixins.AsyncClientMixin, object):
         verify_fun(self.functions, fun)
 
         eauth_creds = dict([(i, low.pop(i)) for i in [
-            'username', 'password', 'eauth', 'token', 'client', 'user', 'key',
+            'username', 'password', 'eauth', 'token', 'client', 'user', 'key', 'timeout',
         ] if i in low])
 
         # Run name=value args through parse_input. We don't need to run kwargs


### PR DESCRIPTION
### What does this PR do?
- saltnado: timeout handling as low parameter
- saltnado: add /token route for backcompat with cherrypy
- saltnado: don't include data root key
- saltnado: account for full_return in local sync calls

sorry I missed this yesterday @dwoz 


### What issues does this PR fix or reference?

### Previous Behavior
Remove this section if not relevant

### New Behavior
Remove this section if not relevant

### Tests written?
No

### Commits signed with GPG?

Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
