### PR TITLE
extmods: add utils directories in sys.path

### DIFF
--- a/salt/utils/extmods.py
+++ b/salt/utils/extmods.py
@@ -8,6 +8,7 @@ from __future__ import absolute_import, unicode_literals, print_function
 import logging
 import os
 import shutil
+import sys
 
 # Import salt libs
 import salt.fileclient
@@ -130,6 +131,12 @@ def sync(opts,
                             os.makedirs(dest_dir)
                         shutil.copyfile(fn_, dest)
                         ret.append('{0}.{1}'.format(form, relname))
+
+                    # If the synchronized module is an utils
+                    # directory, we add it to sys.path
+                    for util_dir in opts['utils_dirs']:
+                        if mod_dir.endswith(util_dir) and mod_dir not in sys.path:
+                            sys.path.append(mod_dir)
 
             touched = bool(ret)
             if opts['clean_dynamic_modules'] is True:


### PR DESCRIPTION
### What does this PR do?

When the minion start clean and there are not utils directory in
the extmods cache, any import from a module to any code inside the
utils directory will fail. A second run of the highstate will fix
this issue, as the utils directories are added into sys.path inside
config/__init__.py, as part of the master and minion startup.

This commit add the utils directories during the synchronization of
the custom modules.

Fixes #51958
