### PR TITLE
Fixed comparison of `None` with constants

### DIFF
--- a/salt/cloud/clouds/gce.py
+++ b/salt/cloud/clouds/gce.py
@@ -1828,7 +1828,7 @@ def create_disk(kwargs=None, call=None):
         )
         return False
 
-    if 'size' is None and 'image' is None and 'snapshot' is None:
+    if size is None and image is None and snapshot is None:
         log.error(
             'Must specify image, snapshot, or size.'
         )

--- a/salt/modules/github.py
+++ b/salt/modules/github.py
@@ -1256,9 +1256,9 @@ def edit_team(name,
         parameters = {}
         if name is not None:
             parameters['name'] = name
-        if 'description' is not None:
+        if description is not None:
             parameters['description'] = description
-        if 'privacy' is not None:
+        if privacy is not None:
             parameters['privacy'] = privacy
         if permission is not None:
             parameters['permission'] = permission


### PR DESCRIPTION
### What does this PR do?
There are comparisons of `None` with constant values (e.g. `'size' is None`) resulting in the comparison always being `True` or `False`.
I replaced the constant values with variable names that seemed appropriate.

I work for Semmle and I noticed these issues with out LGTM code analyzer
https://lgtm.com/projects/g/saltstack/salt/alerts/?mode=tree&ruleFocus=3980086

### Previous Behavior
The comparison of `None` with constant will always result in `True` or `False`.
For example `'size' is None` is always `True` and `'size' is not None` is always `False`
I don't believe this is the desired behavior. If it is perhaps the comparison can be replaced with the appropriate Boolean.

### Tests written?
No

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
