### PR TITLE
Allow minions to request the master to clear its pillar cache

### DIFF
--- a/salt/daemons/masterapi.py
+++ b/salt/daemons/masterapi.py
@@ -1034,6 +1034,31 @@ class RemoteFuncs(object):
                                                          False))
         return True
 
+    def clear_pillarcache(self, load):
+        '''
+        Allow a minion to clear its master pillar cache
+        '''
+        if not all(k in load for k in ('id', 'grains', 'saltenv', 'pillarenv')):
+            return False
+        if self.opts.get('pillar_cache', False):
+            try:
+                pillar_cache = salt.pillar.PillarCache(
+                    self.opts,
+                    load['grains'],
+                    load['id'],
+                    saltenv=load['saltenv'],
+                    functions=self.mminion.functions,
+                    pillarenv=load['pillarenv']).cache
+                if load['id'] in pillar_cache:
+                    del pillar_cache[load['id']]
+            except Exception as exc:
+                log.error(
+                    'Exception %s occurred in clear pillarcache for minion %s',
+                    exc, load['id'], exc_info_on_loglevel=logging.DEBUG
+                )
+                return False
+        return True
+
 
 class LocalFuncs(object):
     '''

--- a/salt/master.py
+++ b/salt/master.py
@@ -1857,6 +1857,32 @@ class AESFuncs(object):
         # Encrypt the return
         return ret, {'fun': 'send'}
 
+    def clear_pillarcache(self, load):
+        '''
+        Allow a minion to clear its master pillar cache
+
+        :param dict load: The minion payload
+
+        :rtype: dict
+        :return: If the load is invalid, it may be returned. No operation is performed.
+
+        :rtype: bool
+        :return: True if cache was cleared, False if not
+        '''
+        load = self.__verify_load(load, ('id', 'tok'))
+
+        if not self.opts.get('allow_minion_pillar_flush', False):
+            log.warning(
+                'Minion %s requests pillar cache flush, but allow_minion_pillar_flush '
+                'is set to False', load['id']
+            )
+            return load
+
+        if load is False:
+            return load
+        else:
+            return self.masterapi.clear_pillarcache(load)
+
 
 class ClearFuncs(object):
     '''


### PR DESCRIPTION
Adds a function clear_masterpillar to the saltutil module to allow the minion to send a request to the master to have its pillar cache cleared. Functionality must be enabled in the salt-master conf.

### Tests written?
No

### Commits signed with GPG?
No