### PR TITLE
Allow `/` in pillar includes

### DIFF
--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -776,7 +776,7 @@ class Pillar(object):
                             try:
                                 matched_pstates.extend(fnmatch.filter(
                                     self.avail[saltenv],
-                                    sub_sls.replace('/', '.'),
+                                    sub_sls.lstrip('.').replace('/', '.'),
                                 ))
                             except KeyError:
                                 errors.extend(

--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -257,7 +257,7 @@ class RemotePillar(RemotePillarMixin):
         return ret_pillar
 
     def destroy(self):
-        if self._closing:
+        if hasattr(self, '_closing') and self._closing:
             return
 
         self._closing = True

--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -774,7 +774,10 @@ class Pillar(object):
                                 key = None
 
                             try:
-                                matched_pstates += fnmatch.filter(self.avail[saltenv], sub_sls)
+                                matched_pstates.extend(fnmatch.filter(
+                                    self.avail[saltenv],
+                                    sub_sls.replace('/', '.'),
+                                ))
                             except KeyError:
                                 errors.extend(
                                     ['No matching pillar environment for environment '


### PR DESCRIPTION
### What does this PR do?

Re-allows / in pillar includes

### What issues does this PR fix or reference?

#51832 

### Previous Behavior

Using `fnmatch` stopped us from allowing `/` in our pillar includes.

### New Behavior

re-allow `/`

### Tests written?

No(t yet)

### Commits signed with GPG?

Yes

---

This works but I'm not certain if this works too broadly. For instance, if you wrote:

```
  include: foo/bar.bang/thing
```

It would look for `foo.bar.bang.thing`. Is that reasonable, or should I throw in a check to make sure that there is no `.` in the `sub_sls` before I do the replacement?