### PR TITLE
Fix incorrect changes dict format in file.managed (test mode)

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -4999,7 +4999,7 @@ def check_managed_changes(
 
         if comments:
             __clean_tmp(sfn)
-            return False, comments
+            raise CommandExecutionError(comments)
         if sfn and source and keep_mode:
             if _urlparse(source).scheme in ('salt', 'file') \
                     or source.startswith('/'):

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -2811,7 +2811,7 @@ def managed(name,
 
     try:
         if __opts__['test']:
-            if 'file.check_managed_changes' in __salt__:
+            try:
                 ret['changes'] = __salt__['file.check_managed_changes'](
                     name,
                     source,
@@ -2834,20 +2834,24 @@ def managed(name,
                     serange=serange,
                     **kwargs
                 )
+            except CommandExecutionError as exc:
+                ret['result'] = False
+                ret['comment'] = six.text_type(exc)
+                return ret
 
-                if salt.utils.platform.is_windows():
-                    try:
-                        ret = __salt__['file.check_perms'](
-                            path=name,
-                            ret=ret,
-                            owner=win_owner,
-                            grant_perms=win_perms,
-                            deny_perms=win_deny_perms,
-                            inheritance=win_inheritance,
-                            reset=win_perms_reset)
-                    except CommandExecutionError as exc:
-                        if exc.strerror.startswith('Path not found'):
-                            ret['comment'] = '{0} will be created'.format(name)
+            if salt.utils.platform.is_windows():
+                try:
+                    ret = __salt__['file.check_perms'](
+                        path=name,
+                        ret=ret,
+                        owner=win_owner,
+                        grant_perms=win_perms,
+                        deny_perms=win_deny_perms,
+                        inheritance=win_inheritance,
+                        reset=win_perms_reset)
+                except CommandExecutionError as exc:
+                    if exc.strerror.startswith('Path not found'):
+                        ret['comment'] = '{0} will be created'.format(name)
 
             if isinstance(ret['changes'], tuple):
                 ret['result'], ret['comment'] = ret['changes']
@@ -7350,23 +7354,28 @@ def serialize(name,
     mode = salt.utils.files.normalize_mode(mode)
 
     if __opts__['test']:
-        ret['changes'] = __salt__['file.check_managed_changes'](
-            name=name,
-            source=None,
-            source_hash={},
-            source_hash_name=None,
-            user=user,
-            group=group,
-            mode=mode,
-            attrs=None,
-            template=None,
-            context=None,
-            defaults=None,
-            saltenv=__env__,
-            contents=contents,
-            skip_verify=False,
-            **kwargs
-        )
+        try:
+            ret['changes'] = __salt__['file.check_managed_changes'](
+                name=name,
+                source=None,
+                source_hash={},
+                source_hash_name=None,
+                user=user,
+                group=group,
+                mode=mode,
+                attrs=None,
+                template=None,
+                context=None,
+                defaults=None,
+                saltenv=__env__,
+                contents=contents,
+                skip_verify=False,
+                **kwargs
+            )
+        except CommandExecutionError as exc:
+            ret['result'] = False
+            ret['comment'] = six.text_type(exc)
+            return ret
 
         if ret['changes']:
             ret['result'] = None


### PR DESCRIPTION
The `file.check_managed_changes` function was incorrectly designed, but
this bad design was hidden by the fact that the output of this function
was only going to the unused "pchanges" key in the state return dict.
The fact that pchanges no longer exists in develop, combined with the
fact that we now have the OutputUnifier decorator checking state
returns, means that you don't get the proper comment for file.managed
states when test=True is used and the file doesn't exist. This fixes the
`file.check_managed_changes` function so that it raises an exception
when the file is not found, and then handles that exception in places
where we invoke the function.