### PR TITLE
Don't log debug messages during close

### DIFF
--- a/salt/transport/zeromq.py
+++ b/salt/transport/zeromq.py
@@ -234,8 +234,6 @@ class AsyncZeroMQReqChannel(salt.transport.client.ReqChannel):
         self._closing = True
         if hasattr(self, 'message_client'):
             self.message_client.close()
-        else:
-            log.debug('No message_client attr for AsyncZeroMQReqChannel found. Not destroying sockets.')
 
         # Remove the entry from the instance map so that a closed entry may not
         # be reused.


### PR DESCRIPTION
This can hit race conditions where we might not have a fully functional logger.

Prevents a stacktrace that looks like:

```
Exception ignored in: <bound method RemoteClient.__del__ of <salt.fileclient.RemoteClient object at 0x7f5e98add2b0>>
Traceback (most recent call last):
  File "/opt/behavox/.local/lib/python3.6/site-packages/salt/fileclient.py", line 1026, in __del__
  File "/opt/behavox/.local/lib/python3.6/site-packages/salt/fileclient.py", line 1033, in destroy
  File "/opt/behavox/.local/lib/python3.6/site-packages/salt/utils/asynchronous.py", line 62, in wrap
  File "/opt/behavox/.local/lib/python3.6/site-packages/salt/transport/zeromq.py", line 227, in close
  File "/usr/lib64/python3.6/logging/__init__.py", line 1295, in debug
  File "/opt/behavox/.local/lib/python3.6/site-packages/salt/log/setup.py", line 343, in _log
  File "/usr/lib64/python3.6/logging/__init__.py", line 1442, in _log
  File "/opt/behavox/.local/lib/python3.6/site-packages/salt/log/setup.py", line 363, in makeRecord
NameError: name '__salt_system_encoding__' is not defined
```

Credit to @Oloremo for finding this. :) 