### PR TITLE
Use __utils__ for registry commands

### DIFF
--- a/salt/modules/environ.py
+++ b/salt/modules/environ.py
@@ -75,7 +75,7 @@ def setval(key, val, false_unsets=False, permanent=False):
             try:
                 os.environ.pop(key, None)
                 if permanent and is_windows:
-                    __salt__['reg.delete_value'](permanent_hive, permanent_key, key)
+                    __utils__['reg.delete_value'](permanent_hive, permanent_key, key)
                 return None
             except Exception as exc:
                 log.error(
@@ -89,7 +89,7 @@ def setval(key, val, false_unsets=False, permanent=False):
         try:
             os.environ[key] = val
             if permanent and is_windows:
-                __salt__['reg.set_value'](permanent_hive, permanent_key, key, val)
+                __utils__['reg.set_value'](permanent_hive, permanent_key, key, val)
             return os.environ[key]
         except Exception as exc:
             log.error(

--- a/salt/modules/proxy.py
+++ b/salt/modules/proxy.py
@@ -53,7 +53,7 @@ def _set_proxy_osx(cmd_function, server, port, user, password, network_service):
 
 
 def _get_proxy_windows(types=None):
-    ret = {}
+    proxies = {}
 
     if types is None:
         types = ['http', 'https', 'ftp']
@@ -76,12 +76,17 @@ def _get_proxy_windows(types=None):
                 port = None
 
             proxy_type, server = server_type.split("=")
-            ret[proxy_type] = {"server": server, "port": port}
+            proxies[proxy_type] = {"server": server, "port": port}
 
-    # Filter out types
-    for key in ret:
-        if key not in types:
-            del ret[key]
+    ret = {}
+    if proxies:
+        if len(types) == 1:
+            return proxies[types[0]]
+        else:
+            # Filter out types
+            for proxy in proxies:
+                if proxy in types:
+                    ret[proxy] = proxies[proxy]
 
     # Return enabled info
     ret['enabled'] = __utils__['reg.read_value'](

--- a/salt/modules/proxy.py
+++ b/salt/modules/proxy.py
@@ -58,7 +58,7 @@ def _get_proxy_windows(types=None):
     if types is None:
         types = ['http', 'https', 'ftp']
 
-    servers = __salt__['reg.read_value'](
+    servers = __utils__['reg.read_value'](
         hive='HKEY_CURRENT_USER',
         key=r'SOFTWARE\Microsoft\Windows\CurrentVersion\Internet Settings',
         vname='ProxyServer')['vdata']
@@ -79,15 +79,12 @@ def _get_proxy_windows(types=None):
             ret[proxy_type] = {"server": server, "port": port}
 
     # Filter out types
-    if len(types) == 1:
-        return ret[types[0]]
-    else:
-        for key in ret:
-            if key not in types:
-                del ret[key]
+    for key in ret:
+        if key not in types:
+            del ret[key]
 
     # Return enabled info
-    ret['enabled'] = __salt__['reg.read_value'](
+    ret['enabled'] = __utils__['reg.read_value'](
         hive='HKEY_CURRENT_USER',
         key=r'SOFTWARE\Microsoft\Windows\CurrentVersion\Internet Settings',
         vname='ProxyEnable')['vdata'] == 1
@@ -107,13 +104,13 @@ def _set_proxy_windows(server,
     for t in types:
         server_str += '{0}={1}:{2};'.format(t, server, port)
 
-    __salt__['reg.set_value'](
+    __utils__['reg.set_value'](
         hive='HKEY_CURRENT_USER',
         key=r'SOFTWARE\Microsoft\Windows\CurrentVersion\Internet Settings',
         vname='ProxyServer',
         vdata=server_str)
 
-    __salt__['reg.set_value'](
+    __utils__['reg.set_value'](
         hive='HKEY_CURRENT_USER',
         key=r'SOFTWARE\Microsoft\Windows\CurrentVersion\Internet Settings',
         vname='ProxyEnable',
@@ -123,7 +120,7 @@ def _set_proxy_windows(server,
     if bypass_hosts is not None:
         bypass_hosts_str = '<local>;{0}'.format(';'.join(bypass_hosts))
 
-        __salt__['reg.set_value'](
+        __utils__['reg.set_value'](
             hive='HKEY_CURRENT_USER',
             key=r'SOFTWARE\Microsoft\Windows\CurrentVersion\Internet Settings',
             vname='ProxyOverride',
@@ -366,7 +363,7 @@ def get_proxy_bypass(network_service="Ethernet"):
 
     '''
     if __grains__['os'] == 'Windows':
-        reg_val = __salt__['reg.read_value'](
+        reg_val = __utils__['reg.read_value'](
             hive='HKEY_CURRENT_USER',
             key=r'SOFTWARE\Microsoft\Windows\CurrentVersion\Internet Settings',
             vname='ProxyOverride')['vdata']

--- a/salt/modules/win_lgpo.py
+++ b/salt/modules/win_lgpo.py
@@ -7665,7 +7665,7 @@ def get(policy_class=None, return_full_policy_names=True,
                 vals_key_name = policy_name
                 if 'Registry' in _pol:
                     # get value from registry
-                    class_vals[policy_name] = __salt__['reg.read_value'](
+                    class_vals[policy_name] = __utils__['reg.read_value'](
                         _pol['Registry']['Hive'],
                         _pol['Registry']['Path'],
                         _pol['Registry']['Value'])['vdata']
@@ -8099,19 +8099,19 @@ def set_(computer_policy=None,
                         log.debug('%s is a Registry policy', regedit)
                         # if the value setting is None or "(value not set)", we will delete the value from the registry
                         if _regedits[regedit]['value'] is not None and _regedits[regedit]['value'] != '(value not set)':
-                            _ret = __salt__['reg.set_value'](
+                            _ret = __utils__['reg.set_value'](
                                     _regedits[regedit]['policy']['Registry']['Hive'],
                                     _regedits[regedit]['policy']['Registry']['Path'],
                                     _regedits[regedit]['policy']['Registry']['Value'],
                                     _regedits[regedit]['value'],
                                     _regedits[regedit]['policy']['Registry']['Type'])
                         else:
-                            _ret = __salt__['reg.read_value'](
+                            _ret = __utils__['reg.read_value'](
                                     _regedits[regedit]['policy']['Registry']['Hive'],
                                     _regedits[regedit]['policy']['Registry']['Path'],
                                     _regedits[regedit]['policy']['Registry']['Value'])
                             if _ret['success'] and _ret['vdata'] != '(value not set)':
-                                _ret = __salt__['reg.delete_value'](
+                                _ret = __utils__['reg.delete_value'](
                                         _regedits[regedit]['policy']['Registry']['Hive'],
                                         _regedits[regedit]['policy']['Registry']['Path'],
                                         _regedits[regedit]['policy']['Registry']['Value'])

--- a/salt/modules/win_path.py
+++ b/salt/modules/win_path.py
@@ -84,7 +84,7 @@ def get_path():
         salt '*' win_path.get_path
     '''
     ret = salt.utils.stringutils.to_unicode(
-        __salt__['reg.read_value'](
+        __utils__['reg.read_value'](
             'HKEY_LOCAL_MACHINE',
             'SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Environment',
             'PATH')['vdata']
@@ -270,7 +270,7 @@ def add(path, index=None, **kwargs):
         return True
 
     # Move forward with registry update
-    result = __salt__['reg.set_value'](
+    result = __utils__['reg.set_value'](
         HIVE,
         KEY,
         VNAME,
@@ -346,7 +346,7 @@ def remove(path, **kwargs):
         # No changes necessary
         return True
 
-    result = __salt__['reg.set_value'](
+    result = __utils__['reg.set_value'](
         HIVE,
         KEY,
         VNAME,

--- a/salt/modules/win_system.py
+++ b/salt/modules/win_system.py
@@ -427,7 +427,7 @@ def get_pending_computer_name():
         salt 'minion-id' system.get_pending_computer_name
     '''
     current = get_computer_name()
-    pending = __salt__['reg.read_value'](
+    pending = __utils__['reg.read_value'](
                 'HKLM',
                 r'SYSTEM\CurrentControlSet\Services\Tcpip\Parameters',
                 'NV Hostname')['vdata']
@@ -1358,7 +1358,7 @@ def get_pending_file_rename():
     # then a reboot is pending.
 
     for vname in vnames:
-        reg_ret = __salt__['reg.read_value']('HKLM', key, vname)
+        reg_ret = __utils__['reg.read_value']('HKLM', key, vname)
 
         if reg_ret['success']:
             log.debug('Found key: %s', key)
@@ -1394,7 +1394,7 @@ def get_pending_servermanager():
     # the value data, and since an actual reboot won't be pending in that
     # instance, just catch instances where we try unsuccessfully to cast as int.
 
-    reg_ret = __salt__['reg.read_value']('HKLM', key, vname)
+    reg_ret = __utils__['reg.read_value']('HKLM', key, vname)
 
     if reg_ret['success']:
         log.debug('Found key: %s', key)
@@ -1469,12 +1469,13 @@ def set_reboot_required_witnessed():
 
         salt '*' system.set_reboot_required_witnessed
     '''
-    return __salt__['reg.set_value'](hive='HKLM',
-                                     key=MINION_VOLATILE_KEY,
-                                     volatile=True,
-                                     vname=REBOOT_REQUIRED_NAME,
-                                     vdata=1,
-                                     vtype='REG_DWORD')
+    return __utils__['reg.set_value'](
+        hive='HKLM',
+        key=MINION_VOLATILE_KEY,
+        volatile=True,
+        vname=REBOOT_REQUIRED_NAME,
+        vdata=1,
+        vtype='REG_DWORD')
 
 
 def get_reboot_required_witnessed():
@@ -1499,9 +1500,10 @@ def get_reboot_required_witnessed():
         salt '*' system.get_reboot_required_witnessed
 
     '''
-    value_dict = __salt__['reg.read_value'](hive='HKLM',
-                                            key=MINION_VOLATILE_KEY,
-                                            vname=REBOOT_REQUIRED_NAME)
+    value_dict = __utils__['reg.read_value'](
+        hive='HKLM',
+        key=MINION_VOLATILE_KEY,
+        vname=REBOOT_REQUIRED_NAME)
     return value_dict['vdata'] == 1
 
 

--- a/salt/modules/win_useradd.py
+++ b/salt/modules/win_useradd.py
@@ -839,11 +839,11 @@ def _get_userprofile_from_registry(user, sid):
     Returns:
         str: Profile directory
     '''
-    profile_dir = __salt__['reg.read_value'](
+    profile_dir = __utils__['reg.read_value'](
         'HKEY_LOCAL_MACHINE',
         'SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\ProfileList\\{0}'.format(sid),
         'ProfileImagePath'
-    )['vdata']
+    )['vdata'].rstrip('\0')
     log.debug(
         'user %s with sid=%s profile is located at "%s"',
         user, sid, profile_dir

--- a/salt/modules/win_useradd.py
+++ b/salt/modules/win_useradd.py
@@ -843,7 +843,7 @@ def _get_userprofile_from_registry(user, sid):
         'HKEY_LOCAL_MACHINE',
         'SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\ProfileList\\{0}'.format(sid),
         'ProfileImagePath'
-    )['vdata'].rstrip('\0')
+    )['vdata']
     log.debug(
         'user %s with sid=%s profile is located at "%s"',
         user, sid, profile_dir

--- a/salt/states/environ.py
+++ b/salt/states/environ.py
@@ -135,7 +135,7 @@ def setenv(name,
                         permanent_hive = 'HKLM'
                         permanent_key = r'SYSTEM\CurrentControlSet\Control\Session Manager\Environment'
 
-                    out = __salt__['reg.read_value'](permanent_hive, permanent_key, _norm_key(key))
+                    out = __utils__['reg.read_value'](permanent_hive, permanent_key, _norm_key(key))
                     return out['success'] is True
                 else:
                     return False

--- a/salt/states/win_dns_client.py
+++ b/salt/states/win_dns_client.py
@@ -189,12 +189,12 @@ def primary_suffix(name,
             }
     }
 
-    reg_data['suffix']['old'] = __salt__['reg.read_value'](
+    reg_data['suffix']['old'] = __utils__['reg.read_value'](
             reg_data['suffix']['hive'],
             reg_data['suffix']['key'],
             reg_data['suffix']['vname'],)['vdata']
 
-    reg_data['updates']['old'] = bool(__salt__['reg.read_value'](
+    reg_data['updates']['old'] = bool(__utils__['reg.read_value'](
             reg_data['updates']['hive'],
             reg_data['updates']['key'],
             reg_data['updates']['vname'],)['vdata'])
@@ -235,14 +235,14 @@ def primary_suffix(name,
                     'new': {
                         'suffix': reg_data['suffix']['new']}}
 
-    suffix_result = __salt__['reg.set_value'](
+    suffix_result = __utils__['reg.set_value'](
             reg_data['suffix']['hive'],
             reg_data['suffix']['key'],
             reg_data['suffix']['vname'],
             reg_data['suffix']['new'],
             reg_data['suffix']['vtype'])
 
-    updates_result = __salt__['reg.set_value'](
+    updates_result = __utils__['reg.set_value'](
             reg_data['updates']['hive'],
             reg_data['updates']['key'],
             reg_data['updates']['vname'],

--- a/salt/utils/win_reg.py
+++ b/salt/utils/win_reg.py
@@ -179,8 +179,8 @@ def key_exists(hive, key, use_32bit_registry=False):
 
         .. code-block:: python
 
-            import salt.utils.win_reg
-            winreg.key_exists(hive='HKLM', key='SOFTWARE\\Microsoft')
+            import salt.utils.win_reg as reg
+            reg.key_exists(hive='HKLM', key='SOFTWARE\\Microsoft')
     '''
     local_hive = _to_unicode(hive)
     local_key = _to_unicode(key)
@@ -228,8 +228,8 @@ def value_exists(hive, key, vname, use_32bit_registry=False):
 
         .. code-block:: python
 
-            import salt.utils.win_reg
-            winreg.key_exists(hive='HKLM', key='SOFTWARE\\Microsoft')
+            import salt.utils.win_reg as reg
+            reg.key_exists(hive='HKLM', key='SOFTWARE\\Microsoft')
     '''
     local_hive = _to_unicode(hive)
     local_key = _to_unicode(key)
@@ -412,7 +412,9 @@ def list_values(hive, key=None, use_32bit_registry=False, include_default=True):
             vname, vdata, vtype = win32api.RegEnumValue(handle, i)
 
             if not vname:
-                vname = "(Default)"
+                if not include_default:
+                    continue
+                vname = '(Default)'
 
             value = {'hive':   local_hive,
                      'key':    local_key,
@@ -423,7 +425,7 @@ def list_values(hive, key=None, use_32bit_registry=False, include_default=True):
             if vtype == win32con.REG_MULTI_SZ:
                 value['vdata'] = [_to_mbcs(i) for i in vdata]
             elif vtype in [win32con.REG_SZ, win32con.REG_EXPAND_SZ]:
-                value['vdata'] = _to_mbcs(vdata).rstrip('\0')
+                value['vdata'] = _to_mbcs(vdata)
             else:
                 value['vdata'] = vdata
             values.append(value)
@@ -480,8 +482,8 @@ def read_value(hive, key, vname=None, use_32bit_registry=False):
 
         .. code-block:: python
 
-            import salt.utils.win_reg
-            winreg.read_value(hive='HKLM', key='SOFTWARE\\Salt', vname='version')
+            import salt.utils.win_reg as reg
+            reg.read_value(hive='HKLM', key='SOFTWARE\\Salt', vname='version')
 
     Usage:
 
@@ -490,8 +492,8 @@ def read_value(hive, key, vname=None, use_32bit_registry=False):
 
         .. code-block:: python
 
-            import salt.utils.win_reg
-            winreg.read_value(hive='HKLM', key='SOFTWARE\\Salt')
+            import salt.utils.win_reg as reg
+            reg.read_value(hive='HKLM', key='SOFTWARE\\Salt')
     '''
     # If no name is passed, the default value of the key will be returned
     # The value name is Default
@@ -528,7 +530,7 @@ def read_value(hive, key, vname=None, use_32bit_registry=False):
                 if vtype == win32con.REG_MULTI_SZ:
                     ret['vdata'] = [_to_mbcs(i) for i in vdata]
                 elif vtype in [win32con.REG_SZ, win32con.REG_EXPAND_SZ]:
-                    ret['vdata'] = _to_mbcs(vdata).rstrip('\0')
+                    ret['vdata'] = _to_mbcs(vdata)
                 else:
                     ret['vdata'] = vdata
             else:

--- a/tests/unit/modules/test_environ.py
+++ b/tests/unit/modules/test_environ.py
@@ -50,20 +50,20 @@ class EnvironTestCase(TestCase, LoaderModuleMockMixin):
 
     def test_set_val_permanent(self):
         with patch.dict(os.environ, {}), \
-                patch.dict(environ.__salt__, {'reg.set_value': MagicMock(),
-                                              'reg.delete_value': MagicMock()}), \
+                patch.dict(environ.__utils__, {'reg.set_value': MagicMock(),
+                                               'reg.delete_value': MagicMock()}), \
                     patch('salt.utils.platform.is_windows', MagicMock(return_value=True)):
 
             environ.setval('key', 'Test', permanent=True)
-            environ.__salt__['reg.set_value'].assert_called_with('HKCU', 'Environment', 'key', 'Test')
+            environ.__utils__['reg.set_value'].assert_called_with('HKCU', 'Environment', 'key', 'Test')
 
             environ.setval('key', False, false_unsets=True, permanent=True)
-            environ.__salt__['reg.set_value'].asset_not_called()
-            environ.__salt__['reg.delete_value'].assert_called_with('HKCU', 'Environment', 'key')
+            environ.__utils__['reg.set_value'].asset_not_called()
+            environ.__utils__['reg.delete_value'].assert_called_with('HKCU', 'Environment', 'key')
 
             key = r'SYSTEM\CurrentControlSet\Control\Session Manager\Environment'
             environ.setval('key', 'Test', permanent='HKLM')
-            environ.__salt__['reg.set_value'].assert_called_with('HKLM', key, 'key', 'Test')
+            environ.__utils__['reg.set_value'].assert_called_with('HKLM', key, 'key', 'Test')
 
     def test_setenv(self):
         '''

--- a/tests/unit/modules/test_win_path.py
+++ b/tests/unit/modules/test_win_path.py
@@ -54,7 +54,7 @@ class WinPathTestCase(TestCase, LoaderModuleMockMixin):
         Test to Returns the system path
         '''
         mock = MagicMock(return_value={'vdata': 'C:\\Salt'})
-        with patch.dict(win_path.__salt__, {'reg.read_value': mock}):
+        with patch.dict(win_path.__utils__, {'reg.read_value': mock}):
             self.assertListEqual(win_path.get_path(), ['C:\\Salt'])
 
     def test_exists(self):
@@ -90,7 +90,7 @@ class WinPathTestCase(TestCase, LoaderModuleMockMixin):
             with patch.object(win_path, 'PATHSEP', self.pathsep), \
                     patch.object(win_path, 'get_path', mock_get), \
                     patch.object(os, 'environ', env), \
-                    patch.dict(win_path.__salt__, {'reg.set_value': mock_set}), \
+                    patch.dict(win_path.__utils__, {'reg.set_value': mock_set}), \
                     patch.object(win_path, 'rehash', MagicMock(return_value=True)):
                 return win_path.add(name, index), env, mock_set
 
@@ -210,7 +210,7 @@ class WinPathTestCase(TestCase, LoaderModuleMockMixin):
             with patch.object(win_path, 'PATHSEP', self.pathsep), \
                     patch.object(win_path, 'get_path', mock_get), \
                     patch.object(os, 'environ', env), \
-                    patch.dict(win_path.__salt__, {'reg.set_value': mock_set}), \
+                    patch.dict(win_path.__utils__, {'reg.set_value': mock_set}), \
                     patch.object(win_path, 'rehash', MagicMock(return_value=True)):
                 return win_path.remove(name), env, mock_set
 

--- a/tests/unit/modules/test_win_snmp.py
+++ b/tests/unit/modules/test_win_snmp.py
@@ -38,22 +38,20 @@ class WinSnmpTestCase(TestCase, LoaderModuleMockMixin):
         '''
         Test - Get the sysServices types that can be configured.
         '''
-        with patch.dict(win_snmp.__salt__):
-            self.assertIsInstance(win_snmp.get_agent_service_types(), list)
+        self.assertIsInstance(win_snmp.get_agent_service_types(), list)
 
     def test_get_permission_types(self):
         '''
         Test - Get the permission types that can be configured for communities.
         '''
-        with patch.dict(win_snmp.__salt__):
-            self.assertIsInstance(win_snmp.get_permission_types(), list)
+        self.assertIsInstance(win_snmp.get_permission_types(), list)
 
     def test_get_auth_traps_enabled(self):
         '''
         Test - Determine whether the host is configured to send authentication traps.
         '''
         mock_value = MagicMock(return_value={'vdata': 1})
-        with patch.dict(win_snmp.__salt__, {'reg.read_value': mock_value}):
+        with patch.dict(win_snmp.__utils__, {'reg.read_value': mock_value}):
             self.assertTrue(win_snmp.get_auth_traps_enabled())
 
     def test_set_auth_traps_enabled(self):
@@ -62,7 +60,7 @@ class WinSnmpTestCase(TestCase, LoaderModuleMockMixin):
         '''
         mock_value = MagicMock(return_value=True)
         kwargs = {'status': True}
-        with patch.dict(win_snmp.__salt__, {'reg.set_value': mock_value}), \
+        with patch.dict(win_snmp.__utils__, {'reg.set_value': mock_value}), \
                 patch('salt.modules.win_snmp.get_auth_traps_enabled',
                       MagicMock(return_value=True)):
             self.assertTrue(win_snmp.set_auth_traps_enabled(**kwargs))
@@ -74,8 +72,8 @@ class WinSnmpTestCase(TestCase, LoaderModuleMockMixin):
         mock_ret = MagicMock(return_value=[{'vdata': 16,
                                             'vname': 'TestCommunity'}])
         mock_false = MagicMock(return_value=False)
-        with patch.dict(win_snmp.__salt__, {'reg.list_values': mock_ret,
-                                            'reg.key_exists': mock_false}):
+        with patch.dict(win_snmp.__utils__, {'reg.list_values': mock_ret,
+                                             'reg.key_exists': mock_false}):
             self.assertEqual(win_snmp.get_community_names(),
                              COMMUNITY_NAMES)
 
@@ -86,8 +84,8 @@ class WinSnmpTestCase(TestCase, LoaderModuleMockMixin):
         mock_ret = MagicMock(return_value=[{'vdata': 'TestCommunity',
                                             'vname': 1}])
         mock_false = MagicMock(return_value=True)
-        with patch.dict(win_snmp.__salt__, {'reg.list_values': mock_ret,
-                                            'reg.key_exists': mock_false}):
+        with patch.dict(win_snmp.__utils__, {'reg.list_values': mock_ret,
+                                             'reg.key_exists': mock_false}):
             self.assertEqual(win_snmp.get_community_names(),
                              {'TestCommunity': 'Managed by GPO'})
 
@@ -98,8 +96,8 @@ class WinSnmpTestCase(TestCase, LoaderModuleMockMixin):
         mock_true = MagicMock(return_value=True)
         kwargs = {'communities': COMMUNITY_NAMES}
         mock_false = MagicMock(return_value=False)
-        with patch.dict(win_snmp.__salt__, {'reg.set_value': mock_true,
-                                            'reg.key_exists': mock_false}), \
+        with patch.dict(win_snmp.__utils__, {'reg.set_value': mock_true,
+                                             'reg.key_exists': mock_false}), \
                 patch('salt.modules.win_snmp.get_community_names',
                       MagicMock(return_value=COMMUNITY_NAMES)):
             self.assertTrue(win_snmp.set_community_names(**kwargs))
@@ -110,8 +108,8 @@ class WinSnmpTestCase(TestCase, LoaderModuleMockMixin):
         '''
         mock_true = MagicMock(return_value=True)
         kwargs = {'communities': COMMUNITY_NAMES}
-        with patch.dict(win_snmp.__salt__, {'reg.set_value': mock_true,
-                                            'reg.key_exists': mock_true}), \
+        with patch.dict(win_snmp.__utils__, {'reg.set_value': mock_true,
+                                             'reg.key_exists': mock_true}), \
              patch('salt.modules.win_snmp.get_community_names',
                    MagicMock(return_value=COMMUNITY_NAMES)):
             self.assertRaises(CommandExecutionError, win_snmp.set_community_names, **kwargs)

--- a/tests/unit/states/test_environ.py
+++ b/tests/unit/states/test_environ.py
@@ -24,10 +24,8 @@ class TestEnvironState(TestCase, LoaderModuleMockMixin):
         loader_globals = {
             '__env__': 'base',
             '__opts__': {'test': False},
-            '__salt__': {
-                'environ.setenv': envmodule.setenv,
-                'reg.read_value': salt.modules.reg.read_value,
-            }
+            '__salt__': {'environ.setenv': envmodule.setenv},
+            '__utils__': {'reg.read_value': salt.modules.reg.read_value}
         }
         return {envstate: loader_globals, envmodule: loader_globals}
 
@@ -59,14 +57,14 @@ class TestEnvironState(TestCase, LoaderModuleMockMixin):
         '''
         test that we can set perminent environment variables (requires pywin32)
         '''
-        with patch.dict(envmodule.__salt__, {'reg.set_value': MagicMock(), 'reg.delete_value': MagicMock()}):
+        with patch.dict(envmodule.__utils__, {'reg.set_value': MagicMock(), 'reg.delete_value': MagicMock()}):
             ret = envstate.setenv('test', 'value', permanent=True)
             self.assertEqual(ret['changes'], {'test': 'value'})
-            envmodule.__salt__['reg.set_value'].assert_called_with("HKCU", "Environment", 'test', 'value')
+            envmodule.__utils__['reg.set_value'].assert_called_with("HKCU", "Environment", 'test', 'value')
 
             ret = envstate.setenv('test', False, false_unsets=True, permanent=True)
             self.assertEqual(ret['changes'], {'test': None})
-            envmodule.__salt__['reg.delete_value'].assert_called_with("HKCU", "Environment", 'test')
+            envmodule.__utils__['reg.delete_value'].assert_called_with("HKCU", "Environment", 'test')
 
     def test_setenv_dict(self):
         '''
@@ -124,7 +122,7 @@ class TestEnvironState(TestCase, LoaderModuleMockMixin):
         ret = envstate.setenv('notimportant', {'foo': 'bar'})
         self.assertEqual(ret['changes'], {'foo': 'bar'})
 
-        with patch.dict(envstate.__salt__, {'reg.read_value': MagicMock()}):
+        with patch.dict(envstate.__utils__, {'reg.read_value': MagicMock()}):
             ret = envstate.setenv(
                 'notimportant', {'test': False, 'foo': 'baz'}, false_unsets=True)
         self.assertEqual(ret['changes'], {'test': None, 'foo': 'baz'})
@@ -133,7 +131,7 @@ class TestEnvironState(TestCase, LoaderModuleMockMixin):
         else:
             self.assertEqual(envstate.os.environ, {'INITIAL': 'initial', 'foo': 'baz'})
 
-        with patch.dict(envstate.__salt__, {'reg.read_value': MagicMock()}):
+        with patch.dict(envstate.__utils__, {'reg.read_value': MagicMock()}):
             ret = envstate.setenv('notimportant', {'test': False, 'foo': 'bax'})
         self.assertEqual(ret['changes'], {'test': '', 'foo': 'bax'})
         if salt.utils.platform.is_windows():

--- a/tests/unit/states/test_win_dns_client.py
+++ b/tests/unit/states/test_win_dns_client.py
@@ -120,13 +120,13 @@ class WinDnsClientTestCase(TestCase, LoaderModuleMockMixin):
                                                            ), ret)
 
         mock = MagicMock(side_effect=[{'vdata': 'a'}, {'vdata': False}, {'vdata': 'b'}, {'vdata': False}])
-        with patch.dict(win_dns_client.__salt__, {'reg.read_value': mock}):
+        with patch.dict(win_dns_client.__utils__, {'reg.read_value': mock}):
             ret.update({'comment': 'No changes needed', 'result': True})
             self.assertDictEqual(win_dns_client.primary_suffix('salt', 'a'),
                                  ret)
 
             mock = MagicMock(return_value=True)
-            with patch.dict(win_dns_client.__salt__, {'reg.set_value': mock}):
+            with patch.dict(win_dns_client.__utils__, {'reg.set_value': mock}):
                 ret.update({'changes': {'new': {'suffix': 'a'},
                                         'old': {'suffix': 'b'}},
                             'comment': 'Updated primary DNS suffix (a)'})


### PR DESCRIPTION
### What does this PR do?
Uses `__utils__` instead of `__salt__` for code that requires access to the registry.
Fixes proxy module for Windows when proxy is not configured.
Fixes some documentation issues in the `win_reg` salt util
Strips trailing null characters from user profile path in `win_useradd`
Reverts PR #51941

### Tests written?
Yes

### Commits signed with GPG?
Yes