### PR TITLE
fix some python3 type issue on x509

### DIFF
--- a/salt/modules/x509.py
+++ b/salt/modules/x509.py
@@ -726,7 +726,7 @@ def get_public_key(key, passphrase=None, asObj=False):
         return evppubkey
 
     rsa.save_pub_key_bio(bio)
-    return bio.read_all()
+    return bio.read_all().decode()
 
 
 def get_private_key_size(private_key, passphrase=None):

--- a/salt/modules/x509.py
+++ b/salt/modules/x509.py
@@ -726,7 +726,7 @@ def get_public_key(key, passphrase=None, asObj=False):
         return evppubkey
 
     rsa.save_pub_key_bio(bio)
-    return bio.read_all().decode()
+    return bio.read_all().decode('ascii')
 
 
 def get_private_key_size(private_key, passphrase=None):

--- a/salt/states/x509.py
+++ b/salt/states/x509.py
@@ -456,7 +456,7 @@ def certificate_managed(name,
                               new=private_key_args['new'],
                               overwrite=private_key_args['overwrite']):
             private_key = __salt__['x509.get_pem_entry'](
-                private_key_args['name'], pem_type='RSA PRIVATE KEY')
+                private_key_args['name'], pem_type='RSA PRIVATE KEY').decode()
         else:
             new_private_key = True
             private_key = __salt__['x509.create_private_key'](text=True, bits=private_key_args['bits'], passphrase=private_key_args[

--- a/salt/states/x509.py
+++ b/salt/states/x509.py
@@ -456,7 +456,7 @@ def certificate_managed(name,
                               new=private_key_args['new'],
                               overwrite=private_key_args['overwrite']):
             private_key = __salt__['x509.get_pem_entry'](
-                private_key_args['name'], pem_type='RSA PRIVATE KEY').decode()
+                private_key_args['name'], pem_type='RSA PRIVATE KEY').decode('ascii')
         else:
             new_private_key = True
             private_key = __salt__['x509.create_private_key'](text=True, bits=private_key_args['bits'], passphrase=private_key_args[

--- a/tests/integration/files/file/base/test_cert.sls
+++ b/tests/integration/files/file/base/test_cert.sls
@@ -56,10 +56,22 @@ test_crt:
     - CN: minion
     - days_remaining: 30
     - backup: True
+    - require:
+        - {{ tmp_dir  }}/pki/ca.crt
+        - {{ tmp_dir  }}/pki/test.key
+
+test_pem_cert:
+  x509.certificate_managed:
+    - name: {{ tmp_dir  }}/pki/test.pem
+    - ca_server: minion
+    - signing_policy: ca_policy
+    - public_key: {{ tmp_dir  }}/pki/test.key
+    - CN: minion
+    - days_remaining: 30
+    - backup: True
     - managed_private_key:
-        name: {{ tmp_dir  }}/pki/test.key
+        name: {{ tmp_dir  }}/pki/test.pem
         bits: 4096
         backup: True
     - require:
         - {{ tmp_dir  }}/pki/ca.crt
-        - {{ tmp_dir  }}/pki/test.key

--- a/tests/integration/states/test_x509.py
+++ b/tests/integration/states/test_x509.py
@@ -97,9 +97,49 @@ class x509Test(ModuleCase, SaltReturnAssertsMixin):
         assert os.path.exists(crtfile)
 
     def test_cert_signing(self):
+        '''
+        Test certificate signing, private key and cert in separate files
+        '''
         ret = self.run_function('state.apply', ['test_cert'], pillar={'tmp_dir': TMP})
         key = 'x509_|-test_crt_|-{}/pki/test.crt_|-certificate_managed'.format(TMP)
         assert key in ret
         assert 'changes' in ret[key]
         assert 'Certificate' in ret[key]['changes']
         assert 'New' in ret[key]['changes']['Certificate']
+
+    def test_cert_signing_no_change(self):
+        '''
+        Test private key and cert in separate files with no changes
+        '''
+        ret = self.run_function('state.apply', ['test_cert'], pillar={'tmp_dir': TMP})
+        key = 'x509_|-test_crt_|-{}/pki/test.crt_|-certificate_managed'.format(TMP)
+        assert key in ret
+        assert 'changes' in ret[key]
+        assert 'Certificate' in ret[key]['changes']
+        assert 'New' in ret[key]['changes']['Certificate']
+        ret = self.run_function('state.apply', ['test_cert'], pillar={'tmp_dir': TMP})
+        assert ret[key]['result'] == True
+        assert ret[key]['changes'] == {}
+
+    def test_cert_pem_format(self):
+        '''
+        Test private key and cert saved in single pem file
+        '''
+        ret = self.run_function('state.apply', ['test_cert'], pillar={'tmp_dir': TMP})
+        key = 'x509_|-test_pem_cert_|-{}/pki/test.pem_|-certificate_managed'.format(TMP)
+        assert key in ret
+        assert ret[key]['result'] == True
+        assert 'Certificate' in ret[key]['changes']
+
+    def test_cert_pem_format_no_change(self):
+        '''
+        Test private key in pem with no changes
+        '''
+        ret = self.run_function('state.apply', ['test_cert'], pillar={'tmp_dir': TMP})
+        key = 'x509_|-test_pem_cert_|-{}/pki/test.pem_|-certificate_managed'.format(TMP)
+        assert key in ret
+        assert ret[key]['result'] == True
+        assert 'Certificate' in ret[key]['changes']
+        ret = self.run_function('state.apply', ['test_cert'], pillar={'tmp_dir': TMP})
+        assert ret[key]['result'] == True
+        assert ret[key]['changes'] == {}


### PR DESCRIPTION
    fix some python3 type issue on x509
    
    [salt/states/x509.py]
    Behavior:
    When you store the private key and a certificate in a same file, both have to be in the same format.
    But in python3, when the private key is already existing and get using "get_pem_entry", it will return a bytes. A new generated one will be in str. That mean that at the second execution, your state will fail. We have to convert the get_pem_entry return in a str using .decode().
    
    [salt/modules/x509.py]
    Behavior:
    At each state execution, salt is making a comparison of the current key a new generated one.
    If one element (Subject, public key of the issuer...) differ, the key is replaced.
    In python3, the local key is in bytes while the remote key is provided in str. The compraison then fail $
    Fix:
    - use .decode() on the return of get_public_key to be sure that the result will not be a bytes
