### PR TITLE
Add fat as a valid fs_type in parted module

### DIFF
--- a/salt/modules/parted.py
+++ b/salt/modules/parted.py
@@ -390,8 +390,8 @@ def _is_fstype(fs_type):
     :param fs_type: file system type
     :return: True if fs_type is supported in this module, False otherwise
     '''
-    return fs_type in set(['ext2', 'ext3', 'ext4', 'fat32', 'fat16', 'linux-swap', 'reiserfs',
-                           'hfs', 'hfs+', 'hfsx', 'NTFS', 'ntfs', 'ufs'])
+    return fs_type in set(['ext2', 'ext3', 'ext4', 'fat32', 'fat16', 'fat', 'linux-swap',
+                           'reiserfs', 'hfs', 'hfs+', 'hfsx', 'NTFS', 'ntfs', 'ufs'])
 
 
 def mkfs(device, fs_type):


### PR DESCRIPTION
Fedora and RHEL do not have a mkfs.fat32 (or mkfs.fat16) binary available. There is only mkfs.fat and mkfs.vfat (same binary) provided by the dosfstools package.

### Previous Behavior
when specifying fs_type: fat --> CommandExecutionError: Invalid fs_type passed to partition.mkfs
when specifying fs_type: fat32 --> Error: mkfs.fat32 is unavailable

### Tests written?

No

### Commits signed with GPG?

No