### PR TITLE
always encode printed data and write it to the raw fd

### DIFF
--- a/salt/output/__init__.py
+++ b/salt/output/__init__.py
@@ -125,7 +125,12 @@ def display_output(data, out=None, opts=None, **kwargs):
                     ofh.close()
             return
         if display_data:
-            salt.utils.stringutils.print_cli(display_data)
+            if six.PY2:
+                salt.utils.stringutils.print_cli(display_data)
+            else:
+                encoded_data = display_data.encode('utf-8')
+                sys.stdout.buffer.write(encoded_data)
+                sys.stdout.buffer.write(b"\n")
     except IOError as exc:
         # Only raise if it's NOT a broken pipe
         if exc.errno != errno.EPIPE:


### PR DESCRIPTION
When using salt-ssh on a minion with a non-utf8 locale,
the `print_cli` function "automatically" encodes the data if `print`
fails:

``` python
try:
    print(msg)
except UnicodeEncodeError:
    print(msg.encode('utf-8'))
```

Because `json` is transported here, printing a `bytes` object will
lead to an unparsable `b'{"some": "json"}'` because of the starting `b'`.

This patch fixes the issue by always encoding the data as `utf-8` and
printing it to the raw file descriptor of `stdout`, thus bypassing
possible encoding errors because of some incompatible `sys.stdout.encoding`.



### What does this PR do?
Fix a bug where returned json-value of `salt-ssh` is not readable because the output was automatically encoded and then printed because printing it directly fails because of an incompatible `sys.stdout.encoding`.

### What issues does this PR fix or reference?
Fixes #51933

### Previous Behavior
returned json output looked like `b'{"funny": "json"}'` which is unparsable because of the `b'`

### New Behavior
the returned json will look like `{"funny": "json"}`

### Tests written?

No

### Commits signed with GPG?

No
