### PR TITLE
Update schedule.py

### DIFF
--- a/salt/states/schedule.py
+++ b/salt/states/schedule.py
@@ -136,9 +136,9 @@ def present(name,
         Requires python-croniter.
 
     run_on_start
-        Whether the job will perform the first run when Salt minion starts,
-        or the job will skip it and wait until the next scheduled run.  Value
-        should be a boolean.
+        Whether the job will run when Salt minion starts, or the job will be
+        skipped **once** and run at the next scheduled run.  Value should be a
+        boolean.
 
     function
         The function that should be executed by the scheduled job.

--- a/salt/states/schedule.py
+++ b/salt/states/schedule.py
@@ -136,8 +136,9 @@ def present(name,
         Requires python-croniter.
 
     run_on_start
-        Whether the job will run when Salt minion start.  Value should be
-        a boolean.
+        Whether the job will perform the first run when Salt minion starts,
+        or the job will skip it and wait until the next scheduled run.  Value
+        should be a boolean.
 
     function
         The function that should be executed by the scheduled job.


### PR DESCRIPTION
The documentation is incongruent with the module documentation. In the module the behaviour is stated as the fix  (https://docs.saltstack.com/en/latest/topics/jobs/#run-on-start), while the current doc suggest the schedule will not run at all if the value is set to False (which is wrong)

### What does this PR do?

### What issues does this PR fix or reference?

### Previous Behavior
Remove this section if not relevant

### New Behavior
Remove this section if not relevant

### Tests written?

Yes/No

### Commits signed with GPG?

Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
