### PR TITLE
Volume infos fix

### DIFF
--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -5298,14 +5298,14 @@ def _get_all_volumes_paths(conn):
             for vol in volumes if _is_valid_volume(vol)}
 
 
-def volume_infos(pool, volume, **kwargs):
+def volume_infos(pool=None, volume=None, **kwargs):
     '''
     Provide details on a storage volume. If no volume name is provided, the infos
     all the volumes contained in the pool are provided. If no pool is provided,
     the infos of the volumes of all pools are output.
 
-    :param pool: libvirt storage pool name
-    :param volume: name of the volume to get infos from
+    :param pool: libvirt storage pool name (default: ``None``)
+    :param volume: name of the volume to get infos from (default: ``None``)
     :param connection: libvirt connection URI, overriding defaults
     :param username: username to connect with, overriding defaults
     :param password: password to connect with, overriding defaults

--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -5274,6 +5274,19 @@ def _get_storage_vol(conn, pool, vol):
     return pool_obj.storageVolLookupByName(vol)
 
 
+def _is_valid_volume(vol):
+    '''
+    Checks whether a volume is valid for further use since those may have disappeared since
+    the last pool refresh.
+    '''
+    try:
+        # Getting info on an invalid volume raises error
+        vol.info()
+        return True
+    except libvirt.libvirtError as err:
+        return False
+
+
 def _get_all_volumes_paths(conn):
     '''
     Extract the path and backing stores path of all volumes.
@@ -5282,7 +5295,7 @@ def _get_all_volumes_paths(conn):
     '''
     volumes = [vol for l in [obj.listAllVolumes() for obj in conn.listAllStoragePools()] for vol in l]
     return {vol.path(): [path.text for path in ElementTree.fromstring(vol.XMLDesc()).findall('.//backingStore/path')]
-            for vol in volumes}
+            for vol in volumes if _is_valid_volume(vol)}
 
 
 def volume_infos(pool, volume, **kwargs):
@@ -5342,7 +5355,7 @@ def volume_infos(pool, volume, **kwargs):
         pools = [obj for obj in conn.listAllStoragePools() if pool is None or obj.name() == pool]
         vols = {pool_obj.name(): {vol.name(): _volume_extract_infos(vol)
                                   for vol in pool_obj.listAllVolumes()
-                                  if volume is None or vol.name() == volume}
+                                  if (volume is None or vol.name() == volume) and _is_valid_volume(vol)}
                 for pool_obj in pools}
         return {pool_name: volumes for (pool_name, volumes) in vols.items() if volumes}
     except libvirt.libvirtError as err:

--- a/tests/unit/modules/test_virt.py
+++ b/tests/unit/modules/test_virt.py
@@ -2836,6 +2836,13 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
                 'name': 'pool1',
                 'volumes': [
                     {
+                        'key': '/key/of/vol0bad',
+                        'name': 'vol0bad',
+                        'path': '/path/to/vol0bad.qcow2',
+                        'info': None,
+                        'backingStore': None
+                    },
+                    {
                         'key': '/key/of/vol1',
                         'name': 'vol1',
                         'path': '/path/to/vol1.qcow2',
@@ -2863,23 +2870,27 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
                 mock_volume.name.return_value = vol_data['name']
                 mock_volume.key.return_value = vol_data['key']
                 mock_volume.path.return_value = '/path/to/{0}.qcow2'.format(vol_data['name'])
-                mock_volume.info.return_value = vol_data['info']
-                backing_store = '''
-                    <backingStore>
-                      <format>qcow2</format>
-                      <path>{0}</path>
-                    </backingStore>
-                '''.format(vol_data['backingStore']) if vol_data['backingStore'] else '<backingStore/>'
-                mock_volume.XMLDesc.return_value = '''
-                    <volume type='file'>
-                      <name>{0}</name>
-                      <target>
-                        <format>qcow2</format>
-                        <path>/path/to/{0}.qcow2</path>
-                      </target>
-                      {1}
-                    </volume>
-                '''.format(vol_data['name'], backing_store)
+                if vol_data['info']:
+                    mock_volume.info.return_value = vol_data['info']
+                    backing_store = '''
+                        <backingStore>
+                          <format>qcow2</format>
+                          <path>{0}</path>
+                        </backingStore>
+                    '''.format(vol_data['backingStore']) if vol_data['backingStore'] else '<backingStore/>'
+                    mock_volume.XMLDesc.return_value = '''
+                        <volume type='file'>
+                          <name>{0}</name>
+                          <target>
+                            <format>qcow2</format>
+                            <path>/path/to/{0}.qcow2</path>
+                          </target>
+                          {1}
+                        </volume>
+                    '''.format(vol_data['name'], backing_store)
+                else:
+                    mock_volume.info.side_effect = self.mock_libvirt.libvirtError('No such volume')
+                    mock_volume.XMLDesc.side_effect = self.mock_libvirt.libvirtError('No such volume')
                 mock_volumes.append(mock_volume)
                 # pylint: enable=no-member
             mock_pool.listAllVolumes.return_value = mock_volumes  # pylint: disable=no-member


### PR DESCRIPTION
### What does this PR do?

Fixes some bugs in recently introduced `virt.volume_infos()`

* Add default value for parameters
* Handle volumes that disappeared since the last refresh

### What issues does this PR fix or reference?

None

### Previous Behavior

* Refresh a libvirt pool
* Remove a volume in that pool
* call virt.volume_infos()

The infos of the volumes after the failing one are not returned

### New Behavior

The invalid volume is simply skipped.

### Tests written?

Yes

### Commits signed with GPG?

Yes