### PR TITLE
fileclient: Fix traceback when template file cannot be cached

### DIFF
--- a/salt/fileclient.py
+++ b/salt/fileclient.py
@@ -735,7 +735,7 @@ class Client(object):
         kwargs['saltenv'] = saltenv
         url_data = urlparse(url)
         sfn = self.cache_file(url, saltenv, cachedir=cachedir)
-        if not os.path.exists(sfn):
+        if not sfn or not os.path.exists(sfn):
             return ''
         if template in salt.utils.templates.TEMPLATE_REGISTRY:
             data = salt.utils.templates.TEMPLATE_REGISTRY[template](


### PR DESCRIPTION
When `cache_file` fails, `sfn` is `False`, which causes a traceback when checking for the cached path's existence. This fixes that traceback.