### PR TITLE
Minor documentation tweak for file.replace state

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -4189,7 +4189,7 @@ def replace(name,
 
     pattern
         A regular expression, to be matched using Python's
-        :py:func:`~re.search`.
+        :py:func:`re.search`.
 
         .. note::
 


### PR DESCRIPTION
Using a tilde with `:py:func:` causes it to display only the function
name and not the entire `modulepath.funcname` as the link text. This
means that it says `search()` instead of `re.search()`. While this is
still a hyperlink that goes directly to the upstream Python
documentation, using the full name as the link text should help
alleviate confusion.