### PR TITLE
Add an execution module that does primitive parsing on state and execution module fns.

### DIFF
--- a/salt/modules/baredoc.py
+++ b/salt/modules/baredoc.py
@@ -1,0 +1,183 @@
+# -*- coding: utf-8 -*-
+'''
+Baredoc walks the installed module and state directories and generates
+dictionaries and lists of the function names and their arguments.
+
+.. versionadded:: Neon
+
+'''
+from __future__ import absolute_import, unicode_literals, print_function
+
+# Import python libs
+import json
+import logging
+import os
+import re
+
+
+# Import salt libs
+import salt.loader
+import salt.runner
+import salt.state
+import salt.utils.files
+import salt.utils.args
+import salt.utils.schema
+
+# Import 3rd-party libs
+from salt.ext import six
+from salt.utils.odict import OrderedDict
+
+log = logging.getLogger(__name__)
+
+def _parse_function_definition(fn_def, modulename, ret):
+    args = []
+    match = re.match(r'def\s+(.*?)\((.*)\):$', fn_def)
+    if match is None:
+        return
+    fn_name = match.group(1)
+    if fn_name.startswith('_'):
+        return
+    if fn_name.endswith('_'):
+        fn_name = fn_name[0:-1]
+    fn_name = fn_name.strip('"')
+    fn_name = fn_name.strip("'")
+    try:
+        raw_args = match.group(2)
+        raw_args = re.sub(r'(.*)\(.*\)(.*)', r'\1\2', raw_args)
+        raw_args = re.sub(r'(.*)\'.*\'(.*)', r'\1\2', raw_args)
+        individual_args = raw_args.split(',')
+        for a in individual_args:
+            if '*' in a:
+                continue
+            args.append(a.split('=')[0].strip())
+    except AttributeError:
+        pass
+    key = '{}.{}'.format(modulename, fn_name)
+    if key in ret:
+        ret[key].extend(args)
+    else:
+        ret[key] = args
+    ret[key] = list(set(ret[key]))
+
+def _mods_with_args(dirs):
+    ret = {}
+    for d in dirs:
+        for m in os.listdir(d):
+            if m.endswith('.py'):
+                with salt.utils.files.fopen(os.path.join(d, m), 'r') as f:
+                    in_def = False
+                    fn_def = u''
+                    modulename = m.split('.')[0]
+                    virtualname = None
+
+                    for l in f:
+                        l = l.decode('utf-8').rstrip()
+                        l = re.sub(r'(.*)#(.*)', r'\1', l)
+                        if '__virtualname__ =' in l and not virtualname:
+                            virtualname = l.split()[2].strip("'").strip('"')
+                            continue
+                        if l.startswith(u'def '):
+                            in_def = True
+                            fn_def = l
+                        if ':' in l:
+                            if in_def:
+                                if not l.startswith(u'def '):
+                                    fn_def = fn_def + l
+                                _parse_function_definition(fn_def, virtualname or modulename, ret)
+                                fn_def = u''
+                                in_def = False
+                                continue
+                        if in_def and not l.startswith(u'def '):
+                            fn_def = fn_def + l
+    return ret
+
+
+def modules_and_args(modules=True, states=False, names_only=False):
+    '''
+    Walk the Salt install tree and return a dictionary or a list
+    of the functions therein as well as their arguments.
+
+    :param modules: Walk the modules directory if True
+    :param states: Walk the states directory if True
+    :param names_only: Return only a list of the callable functions instead of a dictionary with arguments
+    :return: An OrderedDict with callable function names as keys and lists of arguments as
+             values (if ``names_only``==False) or simply an ordered list of callable
+             function nanes (if ``names_only``==True).
+
+    CLI Example:
+    (example truncated for brevity)
+
+    .. code-block:: bash
+
+        salt myminion baredoc.modules_and_args
+
+        myminion:
+            ----------
+        [...]
+            at.atrm:
+            at.jobcheck:
+            at.mod_watch:
+                - name
+            at.present:
+                - unique_tag
+                - name
+                - timespec
+                - job
+                - tag
+                - user
+            at.watch:
+                - unique_tag
+                - name
+                - timespec
+                - job
+                - tag
+                - user
+        [...]
+    '''
+    dirs = []
+    module_dir = os.path.dirname(os.path.realpath(__file__))
+    state_dir = os.path.join(os.path.dirname(module_dir), 'states')
+
+    if modules:
+        dirs.append(module_dir)
+    if states:
+        dirs.append(state_dir)
+
+    ret = _mods_with_args(dirs)
+    if names_only:
+        return sorted(ret.keys())
+    else:
+        return OrderedDict(sorted(ret.items()))
+
+
+def modules_with_test():
+    '''
+    Return a list of callable functions that have a ``test=`` flag.
+
+    CLI Example:
+
+    (results trimmed for brevity)
+
+    .. code-block:: bash
+
+        salt myminion baredoc.modules_with_test
+
+        myminion:
+            ----------
+            - boto_elb.set_instances
+            - netconfig.managed
+            - netconfig.replace_pattern
+            - pkg.install
+            - salt.state
+            - state.high
+            - state.highstate
+
+    '''
+    mods = modules_and_args()
+    testmods = []
+    for module_name, module_args in six.iteritems(mods):
+        if 'test' in module_args:
+            testmods.append(module_name)
+
+    return sorted(testmods)
+

--- a/salt/modules/baredoc.py
+++ b/salt/modules/baredoc.py
@@ -17,6 +17,7 @@ import re
 import salt.loader
 import salt.runner
 import salt.state
+import salt.utils.data
 import salt.utils.files
 import salt.utils.args
 import salt.utils.schema
@@ -71,7 +72,7 @@ def _mods_with_args(dirs):
                     virtualname = None
 
                     for l in f:
-                        l = l.decode('utf-8').rstrip()
+                        l = salt.utils.data.decode(l).rstrip()
                         l = re.sub(r'(.*)#(.*)', r'\1', l)
                         if '__virtualname__ =' in l and not virtualname:
                             virtualname = l.split()[2].strip("'").strip('"')

--- a/salt/modules/baredoc.py
+++ b/salt/modules/baredoc.py
@@ -29,6 +29,7 @@ from salt.utils.odict import OrderedDict
 
 log = logging.getLogger(__name__)
 
+
 def _parse_function_definition(fn_def, modulename, ret):
     args = []
     match = re.match(r'def\s+(.*?)\((.*)\):$', fn_def)
@@ -58,6 +59,7 @@ def _parse_function_definition(fn_def, modulename, ret):
     else:
         ret[key] = args
     ret[key] = list(set(ret[key]))
+
 
 def _mods_with_args(dirs):
     ret = {}
@@ -180,4 +182,3 @@ def modules_with_test():
             testmods.append(module_name)
 
     return sorted(testmods)
-

--- a/salt/modules/baredoc.py
+++ b/salt/modules/baredoc.py
@@ -13,7 +13,6 @@ import logging
 import os
 import re
 
-
 # Import salt libs
 import salt.loader
 import salt.runner
@@ -27,7 +26,6 @@ from salt.ext import six
 from salt.utils.odict import OrderedDict
 
 log = logging.getLogger(__name__)
-
 
 def _parse_function_definition(fn_def, modulename, ret):
     args = []

--- a/salt/modules/baredoc.py
+++ b/salt/modules/baredoc.py
@@ -27,6 +27,7 @@ from salt.utils.odict import OrderedDict
 
 log = logging.getLogger(__name__)
 
+
 def _parse_function_definition(fn_def, modulename, ret):
     args = []
     match = re.match(r'def\s+(.*?)\((.*)\):$', fn_def)

--- a/salt/modules/baredoc.py
+++ b/salt/modules/baredoc.py
@@ -9,7 +9,6 @@ dictionaries and lists of the function names and their arguments.
 from __future__ import absolute_import, unicode_literals, print_function
 
 # Import python libs
-import json
 import logging
 import os
 import re

--- a/salt/modules/baredoc.py
+++ b/salt/modules/baredoc.py
@@ -72,7 +72,7 @@ def _mods_with_args(dirs):
                     virtualname = None
 
                     for l in f:
-                        l = salt.utils.data.decode(l).rstrip()
+                        l = salt.utils.data.decode(l, encoding='utf-8').rstrip()
                         l = re.sub(r'(.*)#(.*)', r'\1', l)
                         if '__virtualname__ =' in l and not virtualname:
                             virtualname = l.split()[2].strip("'").strip('"')

--- a/tests/integration/modules/test_baredoc.py
+++ b/tests/integration/modules/test_baredoc.py
@@ -5,11 +5,6 @@ from __future__ import absolute_import
 
 # Import Salt Testing libs
 from tests.support.case import ModuleCase
-from tests.support.unit import skipIf
-
-# Import Salt Libs
-import salt.utils.path
-import salt.utils.platform
 
 
 class BaredocTest(ModuleCase):

--- a/tests/integration/modules/test_baredoc.py
+++ b/tests/integration/modules/test_baredoc.py
@@ -20,7 +20,6 @@ class BaredocTest(ModuleCase):
         self.assertIn('xml.value_present', ret)
         self.assertIn('xpath', ret['xml.value_present'])
 
-
     def test_baredoc_modules_with_test(self):
         '''
         baredoc.modules_and_args

--- a/tests/integration/modules/test_baredoc.py
+++ b/tests/integration/modules/test_baredoc.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+
+# Import Python libs
+from __future__ import absolute_import
+
+# Import Salt Testing libs
+from tests.support.case import ModuleCase
+from tests.support.unit import skipIf
+
+# Import Salt Libs
+import salt.utils.path
+import salt.utils.platform
+
+
+class BaredocTest(ModuleCase):
+    '''
+    Validate baredoc module
+    '''
+    def test_baredoc_module_and_args(self):
+        '''
+        baredoc.modules_and_args
+        '''
+        ret = self.run_function('baredoc.modules_and_args', states=True)
+        self.assertIn('state.highstate', ret)
+        self.assertIn('xml.value_present', ret)
+        self.assertIn('xpath', ret['xml.value_present'])
+
+
+    def test_baredoc_modules_with_test(self):
+        '''
+        baredoc.modules_and_args
+        '''
+        ret = self.run_function('baredoc.modules_with_test')
+        self.assertIn('pkg.install', ret)


### PR DESCRIPTION
### What does this PR do?

It is sometimes helpful to know all the execution and state module functions that exist.  The Salt loader and `sys.doc` go a long way to providing that, but are unable to return modules and functions that do not have current dependencies installed.  This execution module does some primitive parsing on all the .py files in the `modules` and `states` directories and returns a dictionary keyed by module and function name.  Each dictionary entry contains a list of arguments that the function can take.

This module also contains a second function that returns a list of all functions that take the `test` argument (for dry runs, aka `test=True`)
