### PR TITLE
Add DigitalOcean DNS-01 verification to module.acme

### DIFF
--- a/salt/modules/acme.py
+++ b/salt/modules/acme.py
@@ -122,7 +122,8 @@ def cert(name,
          http_01_port=None,
          http_01_address=None,
          dns_plugin=None,
-         dns_plugin_credentials=None):
+         dns_plugin_credentials=None,
+         dns_plugin_propagate_seconds=10):
     '''
     Obtain/renew a certificate from an ACME CA, probably Let's Encrypt.
 
@@ -150,8 +151,10 @@ def cert(name,
                          the port Certbot listens on. A conforming ACME server
                          will still attempt to connect on port 80.
     :param https_01_address: The address the server listens to during http-01 challenge.
-    :param dns_plugin: Name of a DNS plugin to use (currently only 'cloudflare')
+    :param dns_plugin: Name of a DNS plugin to use (currently only 'cloudflare' or 'digitalocean')
     :param dns_plugin_credentials: Path to the credentials file if required by the specified DNS plugin
+    :param dns_plugin_propagate_seconds: Number of seconds to wait for DNS propogations before
+                                asking ACME servers to verify the DNS record. (default 10)
     :return: dict with 'result' True/False/None, 'comment' and certificate's expiry date ('not_after')
 
     CLI example:
@@ -163,7 +166,7 @@ def cert(name,
 
     cmd = [LEA, 'certonly', '--non-interactive', '--agree-tos']
 
-    supported_dns_plugins = ['cloudflare']
+    supported_dns_plugins = ['cloudflare', 'digitalocean']
 
     cert_file = _cert_file(name, 'cert')
     if not __salt__['file.file_exists'](cert_file):
@@ -192,6 +195,11 @@ def cert(name,
         if dns_plugin == 'cloudflare':
             cmd.append('--dns-cloudflare')
             cmd.append('--dns-cloudflare-credentials {0}'.format(dns_plugin_credentials))
+            cmd.append('--dns-cloudflare-propagation-seconds {0}'.format(dns_plugin_propagate_seconds))
+        elif dns_plugin == 'digitalocean':
+            cmd.append('--dns-digitalocean')
+            cmd.append('--dns-digitalocean-credentials {0}'.format(dns_plugin_credentials))
+            cmd.append('--dns-digitalocean-propagation-seconds {0}'.format(dns_plugin_propagate_seconds))
         else:
             return {'result': False, 'comment': 'DNS plugin \'{0}\' is not supported'.format(dns_plugin)}
     else:


### PR DESCRIPTION
### What does this PR do?

Adds access to the DigitalOcean `certbot` plugin for DNS-01 verification.

### What issues does this PR fix or reference?

#52114

### New Behavior

Adds `dns_plugin` `digitalocean` option. Also add new kwarg `dns_plugin_propagation_seconds` to both `digitalocean` and existing `cloudflare` plugins.

### Tests written?

No

### Commits signed with GPG?

Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
