### PR TITLE
Fixed issue when raid.destroy is called but zero-superblock is not ex…

### DIFF
--- a/salt/modules/mdadm_raid.py
+++ b/salt/modules/mdadm_raid.py
@@ -131,7 +131,7 @@ def destroy(device):
     stop_cmd = ['mdadm', '--stop', device]
     zero_cmd = ['mdadm', '--zero-superblock']
 
-    if __salt__['cmd.retcode'](stop_cmd, python_shell=False):
+    if __salt__['cmd.retcode'](stop_cmd, python_shell=False) == 0:
         for number in details['members']:
             zero_cmd.append(details['members'][number]['device'])
         __salt__['cmd.retcode'](zero_cmd, python_shell=False)


### PR DESCRIPTION
…ecuted.

Test is expecting boolean response but 'cmd.retcode' is returning a 0 or 1.

### What does this PR do?

Fixes an issue when 'raid.destroy' is executed but code to zero-superblock is not executed.

### What issues does this PR fix or reference?

See previous comment.

### Previous Behavior
Remove this section if not relevant

Stop_cmd is returning a retcode of '0' or '1' but the test is expecting a boolean response. This has the effect of never executing the zero-superblock code.  

    if __salt__['cmd.retcode'](stop_cmd, python_shell=False):
        for number in details['members']:
            zero_cmd.append(details['members'][number]['device'])
        zero_results = __salt__['cmd.retcode'](zero_cmd, python_shell=False)

### New Behavior
Remove this section if not relevant

By altering the test slightly to check if retcode is '0', this validates the result of the test correctly and if successful, then executes the zero-superblock code. 

### Tests written?

No

### Commits signed with GPG?

Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
