### PR TITLE
Add --user flag to pip.installed state

### DIFF
--- a/salt/modules/pip.py
+++ b/salt/modules/pip.py
@@ -1289,23 +1289,24 @@ def list_json(bin_env=None,
     '''
     cmd = _get_pip_bin(bin_env)
     cmd.append('list')
+
+    if user_install:
+        cmd.append('--user')
+
     cmd.extend(['--format', 'json'])
 
     # Include pip, setuptools, distribute, wheel
-    min_version = '8.0.3'
+    min_version = '10'
     cur_version = version(bin_env)
     if salt.utils.versions.compare(ver1=cur_version, oper='<', ver2=min_version):
         logger.warning(
             'The version of pip installed is %s, which is older than %s. '
-            'The packages pip, wheel, setuptools, and distribute will not be '
-            'included in the output of pip.freeze', cur_version, min_version
+            'The location of the packages will not be displayed in the verbose output'
+            'as this feature was added to pip 10 milestone', cur_version, min_version
         )
-
-    if verbose:
-        cmd.append('--verbose')
-
-    if user_install:
-        cmd.append('--user')
+    else:
+        if verbose:
+            cmd.append('--verbose')
 
     cmd_kwargs = dict(runas=user, cwd=cwd, python_shell=False)
     if kwargs:

--- a/salt/modules/pip.py
+++ b/salt/modules/pip.py
@@ -961,7 +961,8 @@ def install(pkgs=None,  # pylint: disable=R0912,R0913,R0914
             cmd, cmd_kwargs
         )
 
-        return __salt__['cmd.run_all'](cmd, python_shell=False, **cmd_kwargs)
+        res = __salt__['cmd.run_all'](cmd, python_shell=False, **cmd_kwargs)
+        return res
     finally:
         _clear_context(bin_env)
         for tempdir in [cr for cr in cleanup_requirements if cr is not None]:
@@ -1100,6 +1101,7 @@ def freeze(bin_env=None,
            use_vt=False,
            env_vars=None,
            user_install=False,
+           verbose=False,
            **kwargs):
     '''
     Return a list of installed packages either globally or in the specified
@@ -1171,6 +1173,7 @@ def list_(prefix=None,
           cwd=None,
           env_vars=None,
           user_install=False,
+          verbose=False,
           **kwargs):
     '''
     Filter list of installed apps from ``freeze`` and check to see if
@@ -1205,6 +1208,7 @@ def list_(prefix=None,
                        cwd=cwd,
                        env_vars=env_vars,
                        user_install=user_install,
+                       verbose=verbose,
                        **kwargs):
         if line.startswith('-f') or line.startswith('#'):
             # ignore -f line as it contains --find-links directory
@@ -1241,6 +1245,32 @@ def list_(prefix=None,
             packages[name] = version_
 
     return packages
+
+
+def list_json(prefix=None,
+              bin_env=None,
+              user=None,
+              cwd=None,
+              env_vars=None,
+              user_install=False,
+              verbose=False,
+              **kwargs):
+    '''
+    New in Sodium
+    TODO flesh this out. - Some docs, some checking and usage of arguments, etc.
+    ...
+    '''
+    cmd = _get_pip_bin(bin_env)
+    cmd.append('list')
+    cmd.extend(['--verbose', '--format', 'json'])
+    if user_install:
+        cmd.append('--user')
+    result = __salt__['cmd.run_all'](cmd)
+
+    if result['retcode']:
+        raise CommandExecutionError(result['stderr'], info=result)
+
+    return salt.utils.json.loads(result['stdout'], strict=False)
 
 
 def version(bin_env=None):

--- a/salt/modules/pip.py
+++ b/salt/modules/pip.py
@@ -442,6 +442,7 @@ def install(pkgs=None,  # pylint: disable=R0912,R0913,R0914
             no_cache_dir=False,
             cache_dir=None,
             no_binary=None,
+            user_install=False,
             extra_args=None,
             **kwargs):
     '''
@@ -613,6 +614,10 @@ def install(pkgs=None,  # pylint: disable=R0912,R0913,R0914
 
     no_cache_dir
         Disable the cache.
+
+    user_install
+        Enable install to occur inside the user base's (site.USER_BASE) binary directory,
+        typically ~/.local/, or %APPDATA%\Python on Windows.
 
     extra_args
         pip keyword and positional arguments not yet implemented in salt
@@ -800,6 +805,9 @@ def install(pkgs=None,  # pylint: disable=R0912,R0913,R0914
 
     if source:
         cmd.extend(['--source', source])
+
+    if user_install:
+        cmd.append('--user')
 
     if upgrade:
         cmd.append('--upgrade')

--- a/salt/modules/pip.py
+++ b/salt/modules/pip.py
@@ -1099,6 +1099,7 @@ def freeze(bin_env=None,
            cwd=None,
            use_vt=False,
            env_vars=None,
+           user_install=False,
            **kwargs):
     '''
     Return a list of installed packages either globally or in the specified
@@ -1115,6 +1116,10 @@ def freeze(bin_env=None,
 
     cwd
         Directory from which to run pip
+
+    user_install
+        Enable output to show inside the user base's (site.USER_BASE) binary directory,
+        typically ~/.local/, or %APPDATA%\Python on Windows
 
     .. note::
         If the version of pip available is older than 8.0.3, the list will not
@@ -1142,6 +1147,9 @@ def freeze(bin_env=None,
     else:
         cmd.append('--all')
 
+    if user_install:
+        cmd.append('--user')
+
     cmd_kwargs = dict(runas=user, cwd=cwd, use_vt=use_vt, python_shell=False)
     if kwargs:
         cmd_kwargs.update(**kwargs)
@@ -1162,6 +1170,7 @@ def list_(prefix=None,
           user=None,
           cwd=None,
           env_vars=None,
+          user_install=False,
           **kwargs):
     '''
     Filter list of installed apps from ``freeze`` and check to see if
@@ -1174,6 +1183,11 @@ def list_(prefix=None,
         this function even if they are installed. Unlike :py:func:`pip.freeze
         <salt.modules.pip.freeze>`, this function always reports the version of
         pip which is installed.
+
+
+    user_install
+        Enable output to show inside the user base's (site.USER_BASE) binary directory,
+        typically ~/.local/, or %APPDATA%\Python on Windows
 
     CLI Example:
 
@@ -1190,6 +1204,7 @@ def list_(prefix=None,
                        user=user,
                        cwd=cwd,
                        env_vars=env_vars,
+                       user_install=user_install,
                        **kwargs):
         if line.startswith('-f') or line.startswith('#'):
             # ignore -f line as it contains --find-links directory

--- a/salt/modules/pip.py
+++ b/salt/modules/pip.py
@@ -445,7 +445,7 @@ def install(pkgs=None,  # pylint: disable=R0912,R0913,R0914
             user_install=False,
             extra_args=None,
             **kwargs):
-    '''
+    r'''
     Install packages with pip
 
     Install packages individually or from a pip requirements file. Install
@@ -1101,7 +1101,7 @@ def freeze(bin_env=None,
            env_vars=None,
            user_install=False,
            **kwargs):
-    '''
+    r'''
     Return a list of installed packages either globally or in the specified
     virtualenv
 
@@ -1172,7 +1172,7 @@ def list_(prefix=None,
           env_vars=None,
           user_install=False,
           **kwargs):
-    '''
+    r'''
     Filter list of installed apps from ``freeze`` and check to see if
     ``prefix`` exists in the list of packages installed.
 

--- a/salt/modules/pip.py
+++ b/salt/modules/pip.py
@@ -617,7 +617,7 @@ def install(pkgs=None,  # pylint: disable=R0912,R0913,R0914
 
     user_install
         Enable install to occur inside the user base's (site.USER_BASE) binary directory,
-        typically ~/.local/, or %APPDATA%\Python on Windows.
+        typically ~/.local/, or %APPDATA%\Python on Windows
 
     extra_args
         pip keyword and positional arguments not yet implemented in salt

--- a/salt/states/pip_state.py
+++ b/salt/states/pip_state.py
@@ -367,7 +367,7 @@ def installed(name,
               extra_args=None,
               user_install=False,
               **kwargs):
-    '''
+    r'''
     Make sure the package is installed
 
     name

--- a/salt/states/pip_state.py
+++ b/salt/states/pip_state.py
@@ -365,6 +365,7 @@ def installed(name,
               cache_dir=None,
               no_binary=None,
               extra_args=None,
+              user_install=False,
               **kwargs):
     '''
     Make sure the package is installed
@@ -404,6 +405,10 @@ def installed(name,
         Force to not use binary packages (requires pip >= 7.0.0)
         Accepts either :all: to disable all binary packages, :none: to empty the set,
         or a list of one or more packages
+
+    user_install
+        Enable install to occur inside the user base's (site.USER_BASE) binary directory,
+        typically ~/.local/, or %APPDATA%\Python on Windows.
 
     Example:
 
@@ -865,6 +870,7 @@ def installed(name,
         use_vt=use_vt,
         trusted_host=trusted_host,
         no_cache_dir=no_cache_dir,
+        user_install=user_install,
         extra_args=extra_args,
         **kwargs
     )

--- a/salt/states/pip_state.py
+++ b/salt/states/pip_state.py
@@ -408,7 +408,7 @@ def installed(name,
 
     user_install
         Enable install to occur inside the user base's (site.USER_BASE) binary directory,
-        typically ~/.local/, or %APPDATA%\Python on Windows.
+        typically ~/.local/, or %APPDATA%\Python on Windows
 
     Example:
 

--- a/tests/integration/states/test_pip_state.py
+++ b/tests/integration/states/test_pip_state.py
@@ -120,6 +120,22 @@ class PipStateTest(ModuleCase, SaltReturnAssertsMixin):
             ret = self.run_state('pip.removed', name=name, bin_env=venv_dir)
             self.assertSaltTrueReturn(ret)
 
+    def test_pip_installed_user_install_true(self):
+        venv_dir = os.path.join(
+            RUNTIME_VARS.TMP, 'pip_install_user_install'
+        )
+        with VirtualEnv(self, venv_dir):
+            pkg = 'pycurl'
+            self.run_state('pip.installed', user_install=True, name=pkg)
+            user_packages = self.run_function('pip.list', user_install=True)
+            system_packages = self.run_function('pip.list', user_install=False)
+
+            print(user_packages, system_packages)
+
+            self.assertTrue(pkg in user_packages and pkg not in system_packages)
+
+
+
     def test_pip_installed_errors(self):
         venv_dir = os.path.join(
             RUNTIME_VARS.TMP, 'pip-installed-errors'


### PR DESCRIPTION
### What does this PR do?
Adds feature for pip.installed to support --user argument.

### What issues does this PR fix or reference?
 #51847 

### Previous Behavior
Currently, pip.installed state doesn't support it in any release.

### New Behavior
Now, pip.installed state does support this behavior.

### Tests written?

No (marked as WIP as setting environment up to tests to run)

### Commits signed with GPG?

Yes