### PR TITLE
Skip test requiring pwd on Windows

### DIFF
--- a/tests/unit/modules/test_cmdmod.py
+++ b/tests/unit/modules/test_cmdmod.py
@@ -344,6 +344,7 @@ class CMDMODTestCase(TestCase, LoaderModuleMockMixin):
         else:
             raise RuntimeError
 
+    @skipIf(salt.utils.platform.is_windows(), 'Do not run on Windows')
     def test_run_cwd_in_combination_with_runas(self):
         '''
         cmd.run executes command in the cwd directory


### PR DESCRIPTION
### What does this PR do?
Skips the `unit.modules.test_cmdmod.CMDMODTestCase.test_run_cwd_in_combination_with_runas` test on Windows

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/52106

### Tests written?
No

### Commits signed with GPG?
Yes