### PR TITLE
Fix failing symlink test

### DIFF
--- a/tests/unit/modules/test_win_file.py
+++ b/tests/unit/modules/test_win_file.py
@@ -7,8 +7,10 @@ from __future__ import absolute_import, unicode_literals, print_function
 import os
 
 # Import Salt Testing Libs
-from tests.support.unit import TestCase, skipIf
+from tests.support.helpers import destructiveTest
+from tests.support.mixins import LoaderModuleMockMixin
 from tests.support.mock import patch, NO_MOCK, NO_MOCK_REASON
+from tests.support.unit import TestCase, skipIf
 
 # Import Salt Libs
 import salt.modules.win_file as win_file
@@ -19,7 +21,7 @@ import salt.utils.win_dacl
 
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
-class WinFileTestCase(TestCase):
+class WinFileTestCase(TestCase, LoaderModuleMockMixin):
     '''
         Test cases for salt.modules.win_file
     '''
@@ -28,6 +30,13 @@ class WinFileTestCase(TestCase):
         FAKE_PATH = os.sep.join(['C:', 'path', 'does', 'not', 'exist'])
     else:
         FAKE_PATH = os.sep.join(['path', 'does', 'not', 'exist'])
+
+    def setup_loader_modules(self):
+        return {win_file: {
+            '__utils__': {
+                'dacl.set_perms': salt.utils.win_dacl.set_perms
+            }
+        }}
 
     def test_issue_43328_stats(self):
         '''
@@ -48,19 +57,27 @@ class WinFileTestCase(TestCase):
             self.assertRaises(
                 CommandExecutionError, win_file.check_perms, self.FAKE_PATH)
 
+    @destructiveTest
     @skipIf(not salt.utils.platform.is_windows(), 'Skip on Non-Windows systems')
     def test_issue_52002_check_file_remove_symlink(self):
         '''
         Make sure that directories including symlinks or symlinks can be removed
         '''
-        base = temp.dir(prefix='base')
-        target = os.path.join(base, 'child 1', 'target/')
+        base = temp.dir(prefix='base-')
+        target = os.path.join(base, 'child 1', 'target\\')
         symlink = os.path.join(base, 'child 2', 'link')
-        self.assertFalse(win_file.directory_exists(target))
-        self.assertFalse(win_file.directory_exists(symlink))
-        self.assertTrue(win_file.makedirs_(target))
-        self.assertTrue(win_file.directory_exists(symlink))
-        self.assertTrue(win_file.symlink(target, symlink))
-        self.assertTrue(win_file.is_link(symlink))
-        self.assertTrue(win_file.remove(base))
-        self.assertFalse(win_file.directory_exists(base))
+        try:
+            # Create environment
+            self.assertFalse(win_file.directory_exists(target))
+            self.assertFalse(win_file.directory_exists(symlink))
+            self.assertTrue(win_file.makedirs_(target))
+            self.assertTrue(win_file.makedirs_(symlink))
+            self.assertTrue(win_file.symlink(target, symlink))
+            self.assertTrue(win_file.directory_exists(symlink))
+            self.assertTrue(win_file.is_link(symlink))
+            # Test removal of directory containing symlink
+            self.assertTrue(win_file.remove(base))
+            self.assertFalse(win_file.directory_exists(base))
+        finally:
+            if os.path.exists(base):
+                win_file.remove(base)


### PR DESCRIPTION
### What does this PR do?
Fixes failing test `unit.modules.test_win_file.WinFileTestCase.test_issue_52002_check_file_remove_symlink`
on Windows
Fixes the test so it cleans up after itself if it fails before the `win_file.remove`

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/52103

### Tests written?
Yes

### Commits signed with GPG?
Yes