### PR TITLE
mdadm_raid: Optionally ignore errors on examine.

### DIFF
--- a/salt/modules/mdadm_raid.py
+++ b/salt/modules/mdadm_raid.py
@@ -360,9 +360,15 @@ def assemble(name,
         return __salt__['cmd.run'](cmd, python_shell=False)
 
 
-def examine(device):
+def examine(device, quiet=False):
     '''
     Show detail for a specified RAID component device
+
+    device
+        Device to examine, that is part of the RAID
+
+    quiet
+        If the device is not part of the RAID, do not show any error
 
     CLI Example:
 
@@ -370,7 +376,9 @@ def examine(device):
 
         salt '*' raid.examine '/dev/sda1'
     '''
-    res = __salt__['cmd.run_stdout']('mdadm -Y -E {0}'.format(device), output_loglevel='trace', python_shell=False)
+    res = __salt__['cmd.run_stdout']('mdadm -Y -E {0}'.format(device),
+                                     python_shell=False,
+                                     ignore_retcode=quiet)
     ret = {}
 
     for line in res.splitlines():

--- a/salt/states/mdadm_raid.py
+++ b/salt/states/mdadm_raid.py
@@ -98,7 +98,7 @@ def present(name,
         if dev == 'missing' or not __salt__['file.access'](dev, 'f'):
             missing.append(dev)
             continue
-        superblock = __salt__['raid.examine'](dev)
+        superblock = __salt__['raid.examine'](dev, quiet=True)
 
         if 'MD_UUID' in superblock:
             uuid = superblock['MD_UUID']


### PR DESCRIPTION
### What does this PR do?

During the RAID creation, the code examine each device to decide
if belongs to an already present array or not. The first time that
the RAID is created, is expected that examine will fail.

This patch add an optional parameter to examine, to ignore the fail
in the logs. Also calls examine with this parameter during the RAID
creation.

