### PR TITLE
mdadm_raid: convert metadata to text

### DIFF
--- a/salt/modules/mdadm_raid.py
+++ b/salt/modules/mdadm_raid.py
@@ -247,7 +247,7 @@ def create(name,
            '-v',
            '-l', six.text_type(level),
            ] + opts + [
-           '-e', metadata,
+           '-e', six.text_type(metadata),
            '-n', six.text_type(raid_devices),
            ] + devices
 


### PR DESCRIPTION
### What does this PR do?

Convert the metadata parameter to text, as can be represented as a float in the pillar (0.9, 1.0, 1.2, etc)
