### PR TITLE
Rename obsolete beacon validation function

### DIFF
--- a/doc/topics/beacons/index.rst
+++ b/doc/topics/beacons/index.rst
@@ -305,7 +305,7 @@ the minion. The ``beacon`` function therefore cannot block and should be as
 lightweight as possible. The ``beacon`` also must return a list of dicts, each
 dict in the list will be translated into an event on the master.
 
-Beacons may also choose to implement a ``__validate__`` function which
+Beacons may also choose to implement a ``validate`` function which
 takes the beacon configuration as an argument and ensures that it
 is valid prior to continuing. This function is called automatically
 by the Salt loader when a beacon is loaded.

--- a/salt/beacons/aix_account.py
+++ b/salt/beacons/aix_account.py
@@ -27,7 +27,7 @@ def __virtual__():
                    'only available on AIX systems.')
 
 
-def __validate__(config):
+def validate(config):
     '''
     Validate the beacon configuration
     '''


### PR DESCRIPTION
### What does this PR do?

Small follow-up bugfix for #42317 to rename two remaining instances of beacon validation function from `__validate__` to `validate`:

* Use proper function name in the docs
* Rename validation function in the `aix_account` beacon (all other beacons are ok)

### Previous Behavior

`aix_account` beacon validator was ignored

### New Behavior

`aix_account` beacon validator should be called. 

### Tests written?

No. I don't have any AIX machine at hand :)
