### PR TITLE
Normalize file mode for Python 3 compatibility

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -3632,7 +3632,7 @@ def stats(path, hash_type=None, follow_symlinks=True):
     ret['mtime'] = pstat.st_mtime
     ret['ctime'] = pstat.st_ctime
     ret['size'] = pstat.st_size
-    ret['mode'] = six.text_type(oct(stat.S_IMODE(pstat.st_mode)))
+    ret['mode'] = salt.utils.files.normalize_mode(oct(stat.S_IMODE(pstat.st_mode)))
     if hash_type:
         ret['sum'] = get_hash(path, hash_type)
     ret['type'] = 'file'

--- a/salt/modules/win_file.py
+++ b/salt/modules/win_file.py
@@ -853,7 +853,7 @@ def stats(path, hash_type='sha256', follow_symlinks=True):
     ret['mtime'] = pstat.st_mtime
     ret['ctime'] = pstat.st_ctime
     ret['size'] = pstat.st_size
-    ret['mode'] = six.text_type(oct(stat.S_IMODE(pstat.st_mode)))
+    ret['mode'] = salt.utils.files.normalize_mode(oct(stat.S_IMODE(pstat.st_mode)))
     if hash_type:
         ret['sum'] = get_sum(path, hash_type)
     ret['type'] = 'file'

--- a/tests/unit/modules/test_file.py
+++ b/tests/unit/modules/test_file.py
@@ -42,7 +42,16 @@ here
 
 
 class DummyStat(object):
-    st_size = 123
+    st_mode = 33188
+    st_ino = 115331251
+    st_dev = 44
+    st_nlink = 1
+    st_uid = 99200001
+    st_gid = 99200001
+    st_size = 41743
+    st_atime = 1552661253
+    st_mtime = 1552661253
+    st_ctime = 1552661253
 
 
 class FileReplaceTestCase(TestCase, LoaderModuleMockMixin):
@@ -1108,6 +1117,14 @@ class FileModuleTestCase(TestCase, LoaderModuleMockMixin):
 
                 ret = filemod.get_diff('binary1', 'text1')
                 self.assertEqual(ret, 'Replace binary file with text file')
+
+    def test_stats(self):
+        with patch('os.path.expanduser', MagicMock(side_effect=lambda path: path)), \
+                patch('os.path.exists', MagicMock(return_value=True)), \
+                patch('os.stat', MagicMock(return_value=DummyStat())):
+            ret = filemod.stats('dummy', None, True)
+            self.assertEqual(ret['mode'], '0644')
+            self.assertEqual(ret['type'], 'file')
 
 
 @skipIf(pytest is None, 'PyTest required for this set of tests')


### PR DESCRIPTION
### What does this PR do?
The modules.file.stats() and modules.win_file.stats() functions
return a dictionary containing an octal representation of a file mode.
Due to a change in the built-in oct() function, that mode string was
formatted differently under Python 3. This change calls
salt.utils.files.normalize_mode() to normalize the string before
assigning it to the dictionary.

### What issues does this PR fix or reference?
#52174

### Previous Behavior
`file.stats` would return a dictionary with a `mode` element like `0644`. Under Python 3 that `mode` element would be `0o644`, which caused some calling functions to misbehave, including `states.file.directory`

### New Behavior
The `mode` element is normalized to the all-numeric format (e.g. `0644`)

### Tests written?
Yes

### Commits signed with GPG?
Yes
