### PR TITLE
Fix 49329

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -5724,19 +5724,23 @@ def append(name,
 
     if makedirs is True:
         dirname = os.path.dirname(name)
-        if not __salt__['file.directory_exists'](dirname):
-            try:
-                _makedirs(name=name)
-            except CommandExecutionError as exc:
-                return _error(ret, 'Drive {0} is not mapped'.format(exc.message))
+        if __opts__['test']:
+            ret['comment'] = 'Directory {0} is set to be updated'.format(dirname)
+            ret['result'] = None
+        else:
+            if not __salt__['file.directory_exists'](dirname):
+                try:
+                    _makedirs(name=name)
+                except CommandExecutionError as exc:
+                    return _error(ret, 'Drive {0} is not mapped'.format(exc.message))
 
-            check_res, check_msg, check_changes = _check_directory_win(dirname) \
-                if salt.utils.platform.is_windows() \
-                else _check_directory(dirname)
+                check_res, check_msg, check_changes = _check_directory_win(dirname) \
+                    if salt.utils.platform.is_windows() \
+                    else _check_directory(dirname)
 
-            if not check_res:
-                ret['changes'] = check_changes
-                return _error(ret, check_msg)
+                if not check_res:
+                    ret['changes'] = check_changes
+                    return _error(ret, check_msg)
 
     check_res, check_msg = _check_file(name)
     if not check_res:


### PR DESCRIPTION
### What does this PR do?
Wraps mkdir operation in test check

### What issues does this PR fix or reference?
#49329

### Previous Behavior
```
# salt-call state.single file.append /tmp/foo/bar text="bar" makedirs=True test=True
[ERROR   ] /tmp/foo/bar: file not found
local:
----------
          ID: /tmp/foo/bar
    Function: file.append
      Result: False
     Comment: /tmp/foo/bar: file not found
     Started: 22:11:50.803036
    Duration: 7.558 ms
     Changes:

Summary for local
------------
Succeeded: 0
Failed:    1
------------
Total states run:     1
Total run time:   7.558 ms
```
Created /tmp/foo directory


### New Behavior
```
# salt-call state.single file.append /tmp/foo/bar text="bar" makedirs=True test=True
local:
----------
          ID: /tmp/foo/bar
    Function: file.append
      Result: None
     Comment: File /tmp/foo/bar is set to be created
     Started: 22:25:49.798269
    Duration: 0.72 ms
     Changes:

Summary for local
------------
Succeeded: 1 (unchanged=1)
Failed:    0
------------
Total states run:     1
Total run time:   0.720 ms
```

### Tests written?
No

### Commits signed with GPG?
No