### PR TITLE
[2017.7.9] Avoid a traceback on tornado.testing test classes

### DIFF
--- a/tests/support/xmlunit.py
+++ b/tests/support/xmlunit.py
@@ -16,6 +16,8 @@
 from __future__ import absolute_import
 import io
 import sys
+import time
+import inspect
 import logging
 
 # Import 3rd-party libs
@@ -27,6 +29,7 @@ log = logging.getLogger(__name__)
 try:
     import xmlrunner.runner
     import xmlrunner.result
+    import xmlrunner.unittest
     HAS_XMLRUNNER = True
 
     class _DelegateIO(object):
@@ -56,9 +59,48 @@ try:
 
     class _XMLTestResult(xmlrunner.result._XMLTestResult):
         def startTest(self, test):
-            log.debug('>>>>> START >>>>> {0}'.format(test.id()))
+            log.debug('>>>>> START >>>>> %s', test.id())
             # xmlrunner classes are NOT new-style classes
-            xmlrunner.result._XMLTestResult.startTest(self, test)
+            # xmlrunner.result._XMLTestResult.startTest(self, test)
+
+            # ----- Re-Implement startTest -------------------------------------------------------------------------->
+            # The reason being that _XMLTestResult does not like tornado testing wrapping it's test class
+            #   https://gist.github.com/s0undt3ch/9298a69a3492404d89a832de9efb1e68
+            self.start_time = time.time()
+            xmlrunner.unittest.TestResult.startTest(self, test)
+
+            try:
+                if getattr(test, '_dt_test', None) is not None:
+                    # doctest.DocTestCase
+                    self.filename = test._dt_test.filename
+                    self.lineno = test._dt_test.lineno
+                else:
+                    # regular unittest.TestCase?
+                    test_method = getattr(test, test._testMethodName)
+                    test_class = type(test)
+                    # Note: inspect can get confused with decorators, so use class.
+                    self.filename = inspect.getsourcefile(test_class)
+                    # Handle partial and partialmethod objects.
+                    test_method = getattr(test_method, 'func', test_method)
+
+                    # ----- Code which avoids the inspect tracebacks ------------------------------------------------>
+                    try:
+                        from tornado.testing import _TestMethodWrapper
+                        if isinstance(test_method, _TestMethodWrapper):
+                            test_method = test_method.orig_method
+                    except (ImportError, AttributeError):
+                        pass
+                    # <---- Code which avoids the inspect tracebacks -------------------------------------------------
+                    _, self.lineno = inspect.getsourcelines(test_method)
+            finally:
+                pass
+
+            if self.showAll:
+                self.stream.write('  ' + self.getDescription(test))
+                self.stream.write(" ... ")
+                self.stream.flush()
+            # <---- Re-Implement startTest ---------------------------------------------------------------------------
+
             if self.buffer:
                 # Let's override the values of self._stdXXX_buffer
                 # We want a similar sys.stdXXX file like behaviour
@@ -68,7 +110,7 @@ try:
                 sys.stdout = self._stdout_buffer
 
         def stopTest(self, test):
-            log.debug('<<<<< END <<<<<<< {0}'.format(test.id()))
+            log.debug('<<<<< END <<<<<<< %s', test.id())
             # xmlrunner classes are NOT new-style classes
             return xmlrunner.result._XMLTestResult.stopTest(self, test)
 


### PR DESCRIPTION
### What does this PR do?
See title.

https://gist.github.com/s0undt3ch/9298a69a3492404d89a832de9efb1e68

This only happens when XML reporting is enabled.
Why only now, I have no clue.

### Tests written?

No

### Commits signed with GPG?

Yes