### PR TITLE
Fix win_proc threads leaked on linux

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1575,7 +1575,7 @@ class Minion(MinionBase):
         if multiprocessing_enabled and not salt.utils.platform.is_windows():
             # we only want to join() immediately if we are daemonizing a process
             process.join()
-        else:
+        elif salt.utils.platform.is_windows():
             self.win_proc.append(process)
 
     def ctx(self):


### PR DESCRIPTION
### What does this PR do?
Minion win_proc threads were leaked on linux. This happened because processes were added to win_proc on both Linux and Windows, but they were cleaned up only on Windows (see https://github.com/saltstack/salt/blob/develop/salt/minion.py#L2689). Since the win_proc collection was supposed to keep windows threads, the fix was to not add processes to it unless the minion runs on windows. 

### Previous Behavior
linux threads added to win_proc were leaked

### New Behavior
linuxs threads are not added to win_proc anymore

### Tests written?
No

### Commits signed with GPG?
No
