### PR TITLE
Use windows state to bootstrap windows builds

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -54,7 +54,7 @@ provisioner:
     base:
       "os:Windows":
         - match: grain
-        - prep_windows
+        - windows
       "*":
         - <%= ENV['KITCHEN_STATE'] || 'git.salt' %>
   pillars:


### PR DESCRIPTION
This is also removing the use of dev_*.ps1 scripts in the windows builds

### Tests written?

No

### Commits signed with GPG?

Yes
