### PR TITLE
Add git_pillar interval timer to control how often git remotes are checked

### DIFF
--- a/salt/master.py
+++ b/salt/master.py
@@ -226,7 +226,9 @@ class Maintenance(salt.utils.process.SignalHandlingMultiprocessingProcess):
 
         # Make Start Times
         last = int(time.time())
+        last_git_pillar = last
 
+        git_pillar_interval = self.opts.get('git_pillar_interval', 0)
         old_present = set()
         while True:
             now = int(time.time())
@@ -235,7 +237,9 @@ class Maintenance(salt.utils.process.SignalHandlingMultiprocessingProcess):
                 salt.daemons.masterapi.clean_expired_tokens(self.opts)
                 salt.daemons.masterapi.clean_pub_auth(self.opts)
                 salt.daemons.masterapi.clean_proc_dir(self.opts)
-            self.handle_git_pillar()
+            if (now - last_git_pillar) >= git_pillar_interval:
+                last_git_pillar = now
+                self.handle_git_pillar()
             self.handle_schedule()
             self.handle_key_cache()
             self.handle_presence(old_present)


### PR DESCRIPTION
### What does this PR do?
Add support for new config option ```git_pillar_interval``` so git_pillar data can be collected less frequently than the main ```loop_interval``` timer allows

### What issues does this PR fix or reference?
N/A

### Previous Behavior
Git pillar remotes would be checked using the ```loop_interval``` timer value (e.g. every 60 seconds).

### New Behavior
Git pillar remotes can be checked using a different interval to the ```loop_interval```. For example, if the git pillar data is not likely to change very often then a higher value such as 300 seconds could be used which would reduce the load on the git repo server by a factor of five.

### Tests written?
No

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
