### PR TITLE
[develop] Update to virtualenv module removing pyvenv if Python greater than 3.6

### DIFF
--- a/salt/modules/virtualenv_mod.py
+++ b/salt/modules/virtualenv_mod.py
@@ -22,6 +22,7 @@ from salt.exceptions import CommandExecutionError, SaltInvocationError
 from salt.ext.six import string_types
 
 KNOWN_BINARY_NAMES = frozenset([
+    'pyvenv-{0}.{1}'.format(*sys.version_info[:2]),
     'virtualenv-{0}.{1}'.format(*sys.version_info[:2]),
     'pyvenv{0}'.format(sys.version_info[0]),
     'virtualenv{0}'.format(sys.version_info[0]),

--- a/salt/modules/virtualenv_mod.py
+++ b/salt/modules/virtualenv_mod.py
@@ -141,7 +141,7 @@ def create(path,
     if venv_bin is None:
         # Beginning in 3.6, pyenv has been deprecated
         # in favor of "python3 -m venv"
-        if sys.version_info >= (3,6):
+        if sys.version_info >= (3, 6):
             venv_bin = ['python3', '-m', 'venv']
         else:
             venv_bin = __pillar__.get('venv_bin') or __opts__.get('venv_bin')

--- a/salt/modules/virtualenv_mod.py
+++ b/salt/modules/virtualenv_mod.py
@@ -21,14 +21,22 @@ import salt.utils.verify
 from salt.exceptions import CommandExecutionError, SaltInvocationError
 from salt.ext.six import string_types
 
-KNOWN_BINARY_NAMES = frozenset([
-    'pyvenv-{0}.{1}'.format(*sys.version_info[:2]),
-    'virtualenv-{0}.{1}'.format(*sys.version_info[:2]),
-    'pyvenv{0}'.format(sys.version_info[0]),
-    'virtualenv{0}'.format(sys.version_info[0]),
-    'pyvenv',
-    'virtualenv',
-])
+# Beginning in 3.6, pyenv has been deprecated
+if sys.version_info >= (3,6):
+    KNOWN_BINARY_NAMES = frozenset([
+        'virtualenv-{0}.{1}'.format(*sys.version_info[:2]),
+        'virtualenv{0}'.format(sys.version_info[0]),
+        'virtualenv',
+    ])
+else:
+    KNOWN_BINARY_NAMES = frozenset([
+        'pyvenv-{0}.{1}'.format(*sys.version_info[:2]),
+        'virtualenv-{0}.{1}'.format(*sys.version_info[:2]),
+        'pyvenv{0}'.format(sys.version_info[0]),
+        'virtualenv{0}'.format(sys.version_info[0]),
+        'pyvenv',
+        'virtualenv',
+    ])
 
 log = logging.getLogger(__name__)
 

--- a/salt/modules/virtualenv_mod.py
+++ b/salt/modules/virtualenv_mod.py
@@ -139,7 +139,7 @@ def create(path,
         salt '*' virtualenv.create /path/to/new/virtualenv
     '''
     if venv_bin is None:
-        # Beginning in 3.6, pyenv has been deprecated
+        # Beginning in 3.6, pyvenv has been deprecated
         # in favor of "python3 -m venv"
         if sys.version_info >= (3, 6):
             venv_bin = ['python3', '-m', 'venv']

--- a/salt/modules/virtualenv_mod.py
+++ b/salt/modules/virtualenv_mod.py
@@ -21,22 +21,13 @@ import salt.utils.verify
 from salt.exceptions import CommandExecutionError, SaltInvocationError
 from salt.ext.six import string_types
 
-# Beginning in 3.6, pyenv has been deprecated
-if sys.version_info >= (3,6):
-    KNOWN_BINARY_NAMES = frozenset([
-        'virtualenv-{0}.{1}'.format(*sys.version_info[:2]),
-        'virtualenv{0}'.format(sys.version_info[0]),
-        'virtualenv',
-    ])
-else:
-    KNOWN_BINARY_NAMES = frozenset([
-        'pyvenv-{0}.{1}'.format(*sys.version_info[:2]),
-        'virtualenv-{0}.{1}'.format(*sys.version_info[:2]),
-        'pyvenv{0}'.format(sys.version_info[0]),
-        'virtualenv{0}'.format(sys.version_info[0]),
-        'pyvenv',
-        'virtualenv',
-    ])
+KNOWN_BINARY_NAMES = frozenset([
+    'virtualenv-{0}.{1}'.format(*sys.version_info[:2]),
+    'pyvenv{0}'.format(sys.version_info[0]),
+    'virtualenv{0}'.format(sys.version_info[0]),
+    'pyvenv',
+    'virtualenv',
+])
 
 log = logging.getLogger(__name__)
 
@@ -147,9 +138,17 @@ def create(path,
         salt '*' virtualenv.create /path/to/new/virtualenv
     '''
     if venv_bin is None:
-        venv_bin = __pillar__.get('venv_bin') or __opts__.get('venv_bin')
+        # Beginning in 3.6, pyenv has been deprecated
+        # in favor of "python3 -m venv"
+        if sys.version_info >= (3,6):
+            venv_bin = ['python3', '-m', 'venv']
+        else:
+            venv_bin = __pillar__.get('venv_bin') or __opts__.get('venv_bin')
 
-    cmd = [venv_bin]
+    if not isinstance(venv_bin, list):
+        cmd = [venv_bin]
+    else:
+        cmd = venv_bin
 
     if 'pyvenv' not in venv_bin:
         # ----- Stop the user if pyvenv only options are used --------------->

--- a/tests/integration/states/test_pip_state.py
+++ b/tests/integration/states/test_pip_state.py
@@ -369,10 +369,6 @@ class PipStateTest(ModuleCase, SaltReturnAssertsMixin):
         try:
             try:
                 self.assertEqual(ret['retcode'], 0)
-                self.assertIn(
-                    'New python executable',
-                    ret['stdout']
-                )
             except AssertionError:
                 import pprint
                 pprint.pprint(ret)


### PR DESCRIPTION
### What does this PR do?
Beginning in Python 3.6, pyvenv has been deprecated in favor of using venv, so remove it from the list if we are using 3.6 or higher.

### What issues does this PR fix or reference?
N/A

### Tests written?
No.  Tests exist.

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
