### PR TITLE
Update to allow for malformed CPE_NAME from some OS's

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1495,6 +1495,10 @@ def _parse_cpe_name(cpe):
 
     Info: https://csrc.nist.gov/projects/security-content-automation-protocol/scap-specifications/cpe
 
+    Note: cpe:2.3:part:vendor:product:version:update:edition:lang:sw_edition:target_sw:target_hw:other
+          however some OS's do not have the full 13 elements, for example:
+                CPE_NAME="cpe:2.3:o:amazon:amazon_linux:2"
+
     :param cpe:
     :return:
     '''
@@ -1510,7 +1514,11 @@ def _parse_cpe_name(cpe):
             ret['vendor'], ret['product'], ret['version'] = cpe[2:5]
             ret['phase'] = cpe[5] if len(cpe) > 5 else None
             ret['part'] = part.get(cpe[1][1:])
-        elif len(cpe) == 13 and cpe[1] == '2.3':  # WFN to a string
+        elif len(cpe) == 6 and cpe[1] == '2.3':  # WFN to a string
+            ret['vendor'], ret['product'], ret['version'] = [x if x != '*' else None for x in cpe[3:6]]
+            ret['phase'] = None
+            ret['part'] = part.get(cpe[2])
+        elif len(cpe) > 7 and len(cpe) <= 13 and cpe[1] == '2.3':  # WFN to a string
             ret['vendor'], ret['product'], ret['version'], ret['phase'] = [x if x != '*' else None for x in cpe[3:7]]
             ret['part'] = part.get(cpe[2])
 


### PR DESCRIPTION
### What does this PR do?
Allows for malformed CPE_NAME in /etc/os-release on Amazon Linux 2.
CPE_NAME if element 1 is '2.3' should contain 13 elements

cpe:2.3:part:vendor:product:version:update:edition:lang:sw_edition:target_sw:target_hw:other

However on Amazon Linux 2 only 6 elements are provided, this change compensates for this and is more flexible in retrieving other elements if an OS insufficiently provides CPE_NAME. 

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/52281

### Previous Behavior
An ERROR was output stating the CPE_NAME was broken, for example:
143 2019-03-21 19:55:08,228 [salt.loaded.int.grains.core:1773][ERROR ][4113] Broken CPE_NAME format in /etc/os-release!

### New Behavior
CPE_NAME is correctly parsed on Amazon Linux 2

### Tests written?
No, tested by hand

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
