### PR TITLE
Allow byte data to be encoded to base64 if UnicodeDecodeError

### DIFF
--- a/salt/netapi/rest_cherrypy/app.py
+++ b/salt/netapi/rest_cherrypy/app.py
@@ -612,6 +612,7 @@ except ImportError:
 import salt
 import salt.auth
 import salt.exceptions
+import salt.utils.data
 import salt.utils.event
 import salt.utils.json
 import salt.utils.stringutils
@@ -898,6 +899,8 @@ def hypermedia_handler(*args, **kwargs):
     # Transform the output from the handler into the requested output format
     cherrypy.response.headers['Content-Type'] = best
     out = cherrypy.response.processors[best]
+    if isinstance(ret, dict):
+        ret = salt.utils.data.decode_dict(ret, encode_bytes=True)
     try:
         response = out(ret)
         if six.PY3:

--- a/salt/utils/data.py
+++ b/salt/utils/data.py
@@ -155,7 +155,7 @@ def compare_lists(old=None, new=None):
 
 def decode(data, encoding=None, errors='strict', keep=False,
            normalize=False, preserve_dict_class=False, preserve_tuples=False,
-           to_str=False):
+           to_str=False, encode_bytes=False):
     '''
     Generic function which will decode whichever type is passed, if necessary.
     Optionally use to_str=True to ensure strings are str types and not unicode
@@ -182,25 +182,30 @@ def decode(data, encoding=None, errors='strict', keep=False,
     two strings above, in which "й" is represented as two code points (i.e. one
     for the base character, and one for the breve mark). Normalizing allows for
     a more reliable test case.
+    :param encode_bytes: base64 encode bytes if it cannot be decoded
     '''
     _decode_func = salt.utils.stringutils.to_unicode \
         if not to_str \
         else salt.utils.stringutils.to_str
     if isinstance(data, Mapping):
         return decode_dict(data, encoding, errors, keep, normalize,
-                           preserve_dict_class, preserve_tuples, to_str)
+                           preserve_dict_class, preserve_tuples, to_str,
+                           encode_bytes=encode_bytes)
     elif isinstance(data, list):
         return decode_list(data, encoding, errors, keep, normalize,
-                           preserve_dict_class, preserve_tuples, to_str)
+                           preserve_dict_class, preserve_tuples, to_str,
+                           encode_bytes=encode_bytes)
     elif isinstance(data, tuple):
         return decode_tuple(data, encoding, errors, keep, normalize,
-                            preserve_dict_class, to_str) \
+                            preserve_dict_class, to_str, encode_bytes=encode_bytes) \
             if preserve_tuples \
             else decode_list(data, encoding, errors, keep, normalize,
-                             preserve_dict_class, preserve_tuples, to_str)
+                             preserve_dict_class, preserve_tuples, to_str,
+                             encode_bytes=encode_bytes)
     else:
         try:
-            data = _decode_func(data, encoding, errors, normalize)
+            data = _decode_func(data, encoding, errors, normalize,
+                                encode_bytes=encode_bytes)
         except TypeError:
             # to_unicode raises a TypeError when input is not a
             # string/bytestring/bytearray. This is expected and simply means we
@@ -214,10 +219,11 @@ def decode(data, encoding=None, errors='strict', keep=False,
 
 def decode_dict(data, encoding=None, errors='strict', keep=False,
                 normalize=False, preserve_dict_class=False,
-                preserve_tuples=False, to_str=False):
+                preserve_tuples=False, to_str=False, encode_bytes=False):
     '''
     Decode all string values to Unicode. Optionally use to_str=True to ensure
     strings are str types and not unicode on Python 2.
+    :param encode_bytes: base64 encode bytes if it cannot be decoded
     '''
     _decode_func = salt.utils.stringutils.to_unicode \
         if not to_str \
@@ -227,13 +233,15 @@ def decode_dict(data, encoding=None, errors='strict', keep=False,
     for key, value in six.iteritems(data):
         if isinstance(key, tuple):
             key = decode_tuple(key, encoding, errors, keep, normalize,
-                               preserve_dict_class, to_str) \
+                               preserve_dict_class, to_str, encode_bytes=encode_bytes) \
                 if preserve_tuples \
                 else decode_list(key, encoding, errors, keep, normalize,
-                                 preserve_dict_class, preserve_tuples, to_str)
+                                 preserve_dict_class, preserve_tuples, to_str,
+                                 encode_bytes=encode_bytes)
         else:
             try:
-                key = _decode_func(key, encoding, errors, normalize)
+                key = _decode_func(key, encoding, errors, normalize,
+                                   encode_bytes=encode_bytes)
             except TypeError:
                 # to_unicode raises a TypeError when input is not a
                 # string/bytestring/bytearray. This is expected and simply
@@ -245,19 +253,23 @@ def decode_dict(data, encoding=None, errors='strict', keep=False,
 
         if isinstance(value, list):
             value = decode_list(value, encoding, errors, keep, normalize,
-                                preserve_dict_class, preserve_tuples, to_str)
+                                preserve_dict_class, preserve_tuples, to_str,
+                                encode_bytes=encode_bytes)
         elif isinstance(value, tuple):
             value = decode_tuple(value, encoding, errors, keep, normalize,
-                                 preserve_dict_class, to_str) \
+                                 preserve_dict_class, to_str, encode_bytes=encode_bytes) \
                 if preserve_tuples \
                 else decode_list(value, encoding, errors, keep, normalize,
-                                 preserve_dict_class, preserve_tuples, to_str)
+                                 preserve_dict_class, preserve_tuples, to_str,
+                                 encode_bytes=encode_bytes)
         elif isinstance(value, Mapping):
             value = decode_dict(value, encoding, errors, keep, normalize,
-                                preserve_dict_class, preserve_tuples, to_str)
+                                preserve_dict_class, preserve_tuples, to_str,
+                                encode_bytes=encode_bytes)
         else:
             try:
-                value = _decode_func(value, encoding, errors, normalize)
+                value = _decode_func(value, encoding, errors, normalize,
+                                     encode_bytes=encode_bytes)
             except TypeError:
                 # to_unicode raises a TypeError when input is not a
                 # string/bytestring/bytearray. This is expected and simply
@@ -273,10 +285,11 @@ def decode_dict(data, encoding=None, errors='strict', keep=False,
 
 def decode_list(data, encoding=None, errors='strict', keep=False,
                 normalize=False, preserve_dict_class=False,
-                preserve_tuples=False, to_str=False):
+                preserve_tuples=False, to_str=False, encode_bytes=False):
     '''
     Decode all string values to Unicode. Optionally use to_str=True to ensure
     strings are str types and not unicode on Python 2.
+    :param encode_bytes: base64 encode bytes if it cannot be decoded
     '''
     _decode_func = salt.utils.stringutils.to_unicode \
         if not to_str \
@@ -285,19 +298,23 @@ def decode_list(data, encoding=None, errors='strict', keep=False,
     for item in data:
         if isinstance(item, list):
             item = decode_list(item, encoding, errors, keep, normalize,
-                               preserve_dict_class, preserve_tuples, to_str)
+                               preserve_dict_class, preserve_tuples, to_str,
+                               encode_bytes=encode_bytes)
         elif isinstance(item, tuple):
             item = decode_tuple(item, encoding, errors, keep, normalize,
-                                preserve_dict_class, to_str) \
+                                preserve_dict_class, to_str, encode_bytes=encode_bytes) \
                 if preserve_tuples \
                 else decode_list(item, encoding, errors, keep, normalize,
-                                 preserve_dict_class, preserve_tuples, to_str)
+                                 preserve_dict_class, preserve_tuples, to_str,
+                                 encode_bytes=encode_bytes)
         elif isinstance(item, Mapping):
             item = decode_dict(item, encoding, errors, keep, normalize,
-                               preserve_dict_class, preserve_tuples, to_str)
+                               preserve_dict_class, preserve_tuples, to_str,
+                               encode_bytes=encode_bytes)
         else:
             try:
-                item = _decode_func(item, encoding, errors, normalize)
+                item = _decode_func(item, encoding, errors, normalize,
+                                    encode_bytes=encode_bytes)
             except TypeError:
                 # to_unicode raises a TypeError when input is not a
                 # string/bytestring/bytearray. This is expected and simply
@@ -312,14 +329,16 @@ def decode_list(data, encoding=None, errors='strict', keep=False,
 
 
 def decode_tuple(data, encoding=None, errors='strict', keep=False,
-                 normalize=False, preserve_dict_class=False, to_str=False):
+                 normalize=False, preserve_dict_class=False, to_str=False,
+                 encode_bytes=False):
     '''
     Decode all string values to Unicode. Optionally use to_str=True to ensure
     strings are str types and not unicode on Python 2.
+    :param encode_bytes: base64 encode bytes if it cannot be decoded
     '''
     return tuple(
         decode_list(data, encoding, errors, keep, normalize,
-                    preserve_dict_class, True, to_str)
+                    preserve_dict_class, True, to_str, encode_bytes=encode_bytes)
     )
 
 

--- a/salt/utils/stringutils.py
+++ b/salt/utils/stringutils.py
@@ -98,7 +98,10 @@ def to_str(s, encoding=None, errors='strict', normalize=False,
                 except UnicodeDecodeError as err:
                     if encode_bytes:
                         return to_str(base64.b64encode(s),
-                                          encode_bytes=False)
+                                      encoding=encoding,
+                                      errors=errors,
+                                      normalize=normalize,
+                                      encode_bytes=False)
                     exc = err
                     continue
             # The only way we get this far is if a UnicodeDecodeError was
@@ -151,6 +154,9 @@ def to_unicode(s, encoding=None, errors='strict', normalize=False,
             except UnicodeDecodeError as err:
                 if encode_bytes:
                     return to_unicode(base64.b64encode(s),
+                                      encoding=encoding,
+                                      errors=errors,
+                                      normalize=normalize,
                                       encode_bytes=False)
                 raise err
 
@@ -168,6 +174,9 @@ def to_unicode(s, encoding=None, errors='strict', normalize=False,
                 except UnicodeDecodeError as err:
                     if encode_bytes:
                         return to_unicode(base64.b64encode(s),
+                                          encoding=encoding,
+                                          errors=errors,
+                                          normalize=normalize,
                                           encode_bytes=False)
                     exc = err
                     continue

--- a/salt/utils/stringutils.py
+++ b/salt/utils/stringutils.py
@@ -97,7 +97,7 @@ def to_str(s, encoding=None, errors='strict', normalize=False,
                     return _normalize(s.decode(enc, errors))
                 except UnicodeDecodeError as err:
                     if encode_bytes:
-                        return to_unicode(base64.b64encode(s),
+                        return to_str(base64.b64encode(s),
                                           encode_bytes=False)
                     exc = err
                     continue

--- a/tests/unit/utils/test_data.py
+++ b/tests/unit/utils/test_data.py
@@ -598,3 +598,175 @@ class DataTestCase(TestCase):
             salt.utils.data.stringify(['one', 'two', str('three'), 4, 5]),  # future lint: disable=blacklisted-function
             ['one', 'two', 'three', '4', '5']
         )
+
+    def test_decode_dict_encode_byte(self):
+        '''
+        test salt.utils.data.decode_dict when encode_bytes
+        is set and not set and there is data that cannot
+        be decoded
+        '''
+        #encode_bytes=True
+        test_dict = {'test': b'\x80',
+                     'test2': [b'\x81', 'blah1', 'blah2'],
+                     'test3': (b'\x82', 'tt2', 'tt3')}
+        exp_dict = {'test': 'gA==',
+                     'test2': ['gQ==', 'blah1', 'blah2'],
+                     'test3': ('gg==', 'tt2', 'tt3')}
+
+        ret = salt.utils.data.decode_dict(test_dict, encode_bytes=True,
+                                          preserve_tuples=True)
+        assert ret == exp_dict
+
+        #now test when encode bytes is not set
+        try:
+            ret = salt.utils.data.decode_dict(test_dict)
+            assert False
+        except UnicodeDecodeError:
+            assert True
+
+    def test_decode_encode_byte(self):
+        '''
+        test salt.utils.data.decode when encode_bytes
+        is set and not set and there is data that cannot
+        be decoded
+        '''
+        #encode_bytes=True
+        test_byte = b'\x80'
+
+        ret = salt.utils.data.decode(test_byte, encode_bytes=True,
+                                          preserve_tuples=True)
+        assert ret == 'gA=='
+
+        #now test when encode bytes is not set
+        try:
+            ret = salt.utils.data.decode(test_byte)
+            assert False
+        except UnicodeDecodeError:
+            assert True
+
+    def test_decode_list_encode_byte(self):
+        '''
+        test salt.utils.data.decode_list when encode_bytes
+        is set and not set and there is data that cannot
+        be decoded
+        '''
+        #encode_bytes=True
+        test_list = ['test', b'\x80',
+                     'test2', [b'\x81', 'blah1', 'blah2'],
+                     'test3', (b'\x82', 'tt2', 'tt3')]
+        exp_list = ['test', 'gA==',
+                    'test2', ['gQ==', 'blah1', 'blah2'],
+                    'test3', ('gg==', 'tt2', 'tt3')]
+
+        ret = salt.utils.data.decode_list(test_list, encode_bytes=True,
+                                          preserve_tuples=True)
+        assert ret == exp_list
+
+        #now test when encode bytes is not set
+        try:
+            ret = salt.utils.data.decode_list(test_list)
+            assert False
+        except UnicodeDecodeError:
+            assert True
+
+    def test_decode_tuple_encode_byte(self):
+        '''
+        test salt.utils.data.decode_tuple when encode_bytes
+        is set and not set and there is data that cannot
+        be decoded
+        '''
+        #encode_bytes=True
+        test_tuple = ('test', b'\x80',
+                     'test2', [b'\x81', 'blah1', 'blah2'],
+                     'test3', (b'\x82', 'tt2', 'tt3'))
+        exp_tuple = ('test', 'gA==',
+                    'test2', ['gQ==', 'blah1', 'blah2'],
+                    'test3', ('gg==', 'tt2', 'tt3'))
+
+        ret = salt.utils.data.decode_tuple(test_tuple, encode_bytes=True)
+        assert ret == exp_tuple
+
+        #now test when encode bytes is not set
+        try:
+            ret = salt.utils.data.decode_tuple(test_tuple)
+            assert False
+        except UnicodeDecodeError:
+            assert True
+
+    def test_decode_dict_encode_byte_utf8(self):
+        '''
+        test salt.utils.data.decode_dict when encode_bytes
+        is set and not set and there is utf-8 compliant data
+        '''
+        #encode_bytes=True
+        test_dict = {'test': '\x77',
+                     'test2': [b'\x78', 'blah1', 'blah2'],
+                     'test3': (b'\x79', 'tt2', 'tt3')}
+        exp_dict = {'test': 'w',
+                     'test2': ['x', 'blah1', 'blah2'],
+                     'test3': ('y', 'tt2', 'tt3')}
+
+        ret = salt.utils.data.decode_dict(test_dict, encode_bytes=True,
+                                          preserve_tuples=True)
+        assert ret == exp_dict
+
+        #now test when encode bytes is not set
+        ret = salt.utils.data.decode_dict(test_dict, preserve_tuples=True)
+        assert ret == exp_dict
+
+    def test_decode_encode_byte_utf8(self):
+        '''
+        test salt.utils.data.decode when encode_bytes
+        is set and not set and there is utf8 compiant data
+        '''
+        #encode_bytes=True
+        test_byte = b'\x79'
+
+        ret = salt.utils.data.decode(test_byte, encode_bytes=True,
+                                     preserve_tuples=True)
+        assert ret == 'y'
+
+        #now test when encode bytes is not set
+        ret = salt.utils.data.decode(test_byte)
+        assert ret == 'y'
+
+    def test_decode_list_encode_byte_utf8(self):
+        '''
+        test salt.utils.data.decode_list when encode_bytes
+        is set and not set and there is utf8 compliant data
+        '''
+        #encode_bytes=True
+        test_list = ['test', b'\x77',
+                     'test2', [b'\x78', 'blah1', 'blah2'],
+                     'test3', (b'\x79', 'tt2', 'tt3')]
+        exp_list = ['test', 'w',
+                    'test2', ['x', 'blah1', 'blah2'],
+                    'test3', ('y', 'tt2', 'tt3')]
+
+        ret = salt.utils.data.decode_list(test_list, encode_bytes=True,
+                                          preserve_tuples=True)
+        assert ret == exp_list
+
+        #now test when encode bytes is not set
+        ret = salt.utils.data.decode_list(test_list, preserve_tuples=True)
+        assert ret == exp_list
+
+    def test_decode_tuple_encode_byte_utf8(self):
+        '''
+        test salt.utils.data.decode_tuple when encode_bytes
+        is set and not set and there is utf8 compliant data
+        '''
+        #encode_bytes=True
+        test_tuple = ('test', b'\x77',
+                     'test2', [b'\x78', 'blah1', 'blah2'],
+                     'test3', (b'\x79', 'tt2', 'tt3'))
+        exp_tuple = ('test', 'w',
+                    'test2', ['x', 'blah1', 'blah2'],
+                    'test3', ('y', 'tt2', 'tt3'))
+
+        ret = salt.utils.data.decode_tuple(test_tuple, encode_bytes=True)
+        assert ret == exp_tuple
+
+        #now test when encode bytes is not set
+        ret = salt.utils.data.decode_tuple(test_tuple)
+        assert ret == exp_tuple

--- a/tests/unit/utils/test_stringutils.py
+++ b/tests/unit/utils/test_stringutils.py
@@ -277,7 +277,6 @@ class StringutilsTestCase(TestCase):
         except UnicodeDecodeError:
             assert True
 
-
     def test_to_unicode_bytearray_unicode_error(self):
         '''
         test when to_unicode can not properly decode

--- a/tests/unit/utils/test_stringutils.py
+++ b/tests/unit/utils/test_stringutils.py
@@ -255,6 +255,107 @@ class StringutilsTestCase(TestCase):
         result = salt.utils.stringutils.to_unicode(LATIN1_BYTES, encoding=('utf-8', 'latin1'))
         assert result == LATIN1_UNICODE
 
+    def test_to_unicode_bytes_unicode_error(self):
+        '''
+        test when to_unicode can not properly decode
+        a byte and returns a base64 type when
+        encode_byte is set.
+        '''
+        ret = salt.utils.stringutils.to_unicode(b'\x80', encoding=('utf-8'),
+                                                  encode_bytes=True)
+        assert ret == 'gA=='
+
+    def test_to_unicode_bytes_unicode_error_failure(self):
+        '''
+        test when to_unicode can not properly decode
+        a byte and returns a base64 type when
+        encode_byte is not set.
+        '''
+        try:
+            ret = salt.utils.stringutils.to_unicode(b'\x80', encoding=('utf-8'))
+            assert False
+        except UnicodeDecodeError:
+            assert True
+
+
+    def test_to_unicode_bytearray_unicode_error(self):
+        '''
+        test when to_unicode can not properly decode
+        a binaryarray type and returns a base64 type when
+        encode_byte is set.
+        '''
+        ret = salt.utils.stringutils.to_unicode(bytearray(b'\x80'),
+                                                encoding=('utf-8'),
+                                                encode_bytes=True)
+        assert ret == 'gA=='
+
+    def test_to_unicode_bytearray_unicode_error_failure(self):
+        '''
+        test when to_unicode can not properly decode
+        a binaryarray type and returns a base64 type when
+        encode_byte is not set.
+        '''
+        try:
+            ret = salt.utils.stringutils.to_unicode(bytearray(b'\x80'), encoding=('utf-8'))
+            assert False
+        except UnicodeDecodeError:
+            assert True
+
+    def test_to_str_bytes_str_error(self):
+        '''
+        test when to_str can not properly decode
+        a byte and returns a base64 type when
+        encode_byte is set.
+        '''
+        ret = salt.utils.stringutils.to_str(b'\x80', encoding=('utf-8'),
+                                                     encode_bytes=True)
+        if sys.version_info > (3, 0):
+            assert ret == 'gA=='
+        else:
+            assert ret == b'\x80'
+
+    def test_to_str_bytes_str_error_failure(self):
+        '''
+        test when to_str can not properly decode
+        a byte and returns a base64 type when
+        encode_byte is not set.
+        '''
+        try:
+            ret = salt.utils.stringutils.to_str(b'\x80', encoding=('utf-8'))
+            if sys.version_info > (3, 0):
+                assert False
+            assert ret == b'\x80'
+        except UnicodeDecodeError:
+            assert True
+
+    def test_to_str_bytearray_str_error(self):
+        '''
+        test when to_str can not properly decode
+        a binaryarray type and returns a base64 type when
+        encode_byte is set.
+        '''
+        ret = salt.utils.stringutils.to_str(bytearray(b'\x80'),
+                                                encoding=('utf-8'),
+                                                encode_bytes=True)
+        if sys.version_info > (3, 0):
+            assert ret == 'gA=='
+        else:
+            assert ret == b'\x80'
+
+    def test_to_str_bytearray_str_error_failure(self):
+        '''
+        test when to_str can not properly decode
+        a binaryarray type and returns a base64 type when
+        encode_byte is not set.
+        '''
+        try:
+            ret = salt.utils.stringutils.to_str(bytearray(b'\x80'), encoding=('utf-8'))
+            if sys.version_info > (3, 0):
+                assert False
+            assert ret == b'\x80'
+        except UnicodeDecodeError:
+            assert True
+
     def test_build_whitespace_split_regex(self):
         # With 3.7+,  re.escape only escapes special characters, no longer
         # escaping all characters other than ASCII letters, numbers and


### PR DESCRIPTION
### What does this PR do?
Currently the tests in this merge forward are failing: https://github.com/saltstack/salt/pull/52190

The reason they are failing is because when you run the two tests:

`python3 tests/runtests.py -n integration.states.test_file.FileTest.test_binary_contents -n integration.netapi.rest_cherrypy.test_app.TestJobs.test_all_jobs`

particularly when you run `test_binary_contents` before `test_all_jobs` the following gets added to the job return info: `b'GIF89a\x01\x00\x01\x00\x80\x00\x00\x05\x04\x04\x00\x00\x00,\x00\x00\x00\x00\x01\x00\x01\x00\x00\x02\x02D\x01\x00;'`
So when we go to run the `test_all_jobs` salt-api is not able to `json.dump` this because json does not work with bytes.

We also cant just decode it, because '\x80' is not a utf-8 unicode code point and results in a `UnicodeDecodeError`. We could possibly just pass `errors='replace'` when decoding, but then the user is no longer able to work with this data. This PR will encode bytes via base64 if its not able to decode it. This way the user will still be able to decode the base64 if they need the data, because a lot of times users that are using the salt-api are trying to consume this information programatically.

If reviewers are against this approach, I see the only other best scenario is just decoding with `errors='replace'`

### What issues does this PR fix or reference?
Fixes failing tests in this PR: https://github.com/saltstack/salt/pull/52190

### Previous Behavior
failing tests

### New Behavior
The tests `integration.states.test_file.FileTest.test_binary_contents` and `integration.netapi.rest_cherrypy.test_app.TestJobs.test_all_jobs` both pass

### Tests written?

Yes

### Commits signed with GPG?

Yes