### PR TITLE
utils/path.py: fix a DeprecationWarning

### DIFF
--- a/salt/utils/path.py
+++ b/salt/utils/path.py
@@ -6,7 +6,10 @@ lack of support for reading NTFS links.
 
 # Import python libs
 from __future__ import absolute_import, print_function, unicode_literals
-import collections
+try:
+    from collections.abc import Iterable
+except ImportError:
+    from collections import Iterable
 import errno
 import logging
 import os
@@ -301,7 +304,7 @@ def which_bin(exes):
     '''
     Scan over some possible executables and return the first one that is found
     '''
-    if not isinstance(exes, collections.Iterable):
+    if not isinstance(exes, Iterable):
         return None
     for exe in exes:
         path = which(exe)


### PR DESCRIPTION
### What does this PR do?

Fix a deprecation warning:

[WARNING ] /usr/lib/python3.7/site-packages/salt/utils/path.py:265:
  DeprecationWarning: Using or importing the ABCs from 'collections'
  instead of from 'collections.abc' is deprecated, and in 3.8 it will
  stop working
 if not isinstance(exes, collection.Iterable):