### PR TITLE
fileclient: Add function to return the expected cache location

### DIFF
--- a/salt/fileclient.py
+++ b/salt/fileclient.py
@@ -341,6 +341,29 @@ class Client(object):
 
         return ''
 
+    def cache_dest(self, url, saltenv='base', cachedir=None):
+        '''
+        Return the expected cache location for the specified URL and
+        environment.
+        '''
+        proto = urlparse(url).scheme
+
+        if proto == '':
+            # Local file path
+            return url
+
+        if proto == 'salt':
+            url, senv = salt.utils.url.parse(url)
+            if senv:
+                saltenv = senv
+            return salt.utils.path.join(
+                self.opts['cachedir'],
+                'files',
+                saltenv,
+                url.lstrip('|/'))
+
+        return self._extrn_path(url, saltenv, cachedir=cachedir)
+
     def list_states(self, saltenv):
         '''
         Return a list of all available sls modules on the master for a given

--- a/salt/modules/cp.py
+++ b/salt/modules/cp.py
@@ -525,6 +525,29 @@ def cache_file(path, saltenv='base', source_hash=None):
     return result
 
 
+def cache_dest(url, saltenv='base'):
+    '''
+    .. versionadded:: Neon
+
+    Returns the expected cache path for the file, if cached using
+    :py:func:`cp.cache_file <salt.modules.cp.cache_file>`.
+
+    .. note::
+        This only returns the _expected_ path, it does not tell you if the URL
+        is really cached. To check if the URL is cached, use
+        :py:func:`cp.is_cached <salt.modules.cp.is_cached>` instead.
+
+    CLI Examples:
+
+    .. code-block:: bash
+
+        salt '*' cp.cache_dest https://foo.com/bar.rpm
+        salt '*' cp.cache_dest salt://my/file
+        salt '*' cp.cache_dest salt://my/file saltenv=dev
+    '''
+    return _client().cache_dest(url, saltenv)
+
+
 def cache_files(paths, saltenv='base'):
     '''
     Used to gather many files from the Master, the gathered files will be


### PR DESCRIPTION
For use cases in which a file must be cached (using the `file.cached`
state) and then acted on in the same salt run, using `cp.is_cached` to
get the cache location of the file won't work since jinja is evaluated
before the states are are run. This commit adds a function to the
fileclient, as well as an interface to that function in the `cp` module,
which can be used in jinja to stand in for the location of the cached
file.