### PR TITLE
Fix x509 inconsistent file name in state example

### DIFF
--- a/salt/states/x509.py
+++ b/salt/states/x509.py
@@ -292,7 +292,7 @@ def private_key_managed(name,
           x509.private_key_managed:
             - bits: 4096
             - new: True
-            {% if salt['file.file_exists']('/etc/pki/ca.key') -%}
+            {% if salt['file.file_exists']('/etc/pki/www.key') -%}
             - prereq:
               - x509: /etc/pki/www.crt
             {%- endif %}


### PR DESCRIPTION
### What does this PR do?
Doc fix for x509 state example -- make the file name from the state match the actual file that is being managed

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/52166

### Tests written?

N/A

### Commits signed with GPG?

Yes

