### PR TITLE
[develop] Fixes to manage_schedule in minion.py

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -2278,11 +2278,11 @@ class Minion(MinionBase):
                  'disable_job': ('disable_job', (name, persist)),
                  'postpone_job': ('postpone_job', (name, data)),
                  'skip_job': ('skip_job', (name, data)),
-                 'reload': ('reload', (schedule)),
-                 'list': ('list', (where)),
+                 'reload': ('reload', (schedule,)),
+                 'list': ('list', (where,)),
                  'save_schedule': ('save_schedule', ()),
                  'get_next_fire_time': ('get_next_fire_time',
-                                        (name))}
+                                        (name,))}
 
         # Call the appropriate schedule function
         try:

--- a/tests/integration/modules/test_schedule.py
+++ b/tests/integration/modules/test_schedule.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+
+# Import Python libs
+from __future__ import absolute_import, print_function, unicode_literals
+import random
+
+# Import Salt Testing libs
+from tests.support.case import ModuleCase
+from tests.support.helpers import flaky
+from tests.support.unit import skipIf
+
+# Import Salt libs
+from salt.ext import six
+import salt.utils.platform
+
+import logging
+log = logging.getLogger(__name__)
+
+
+class ScheduleModuleTest(ModuleCase):
+    '''
+    Test the schedule module
+    '''
+    def test_schedule_list(self):
+        '''
+        schedule.list
+        '''
+        expected = {'schedule': {}}
+        ret = self.run_function('schedule.list')
+        self.assertEqual(ret, expected)
+
+    def test_schedule_reload(self):
+        '''
+        schedule.list
+        '''
+        expected = {'comment': [], 'result': True}
+        ret = self.run_function('schedule.reload')
+        self.assertEqual(ret, expected)

--- a/tests/integration/modules/test_schedule.py
+++ b/tests/integration/modules/test_schedule.py
@@ -2,16 +2,9 @@
 
 # Import Python libs
 from __future__ import absolute_import, print_function, unicode_literals
-import random
 
 # Import Salt Testing libs
 from tests.support.case import ModuleCase
-from tests.support.helpers import flaky
-from tests.support.unit import skipIf
-
-# Import Salt libs
-from salt.ext import six
-import salt.utils.platform
 
 import logging
 log = logging.getLogger(__name__)


### PR DESCRIPTION
### What does this PR do?
A couple fixes to the manage_schedule function inside minion.py, swapping values that should be tuples but had been set as strings. Initial addition for an integration test for schedule module.

### What issues does this PR fix or reference?
N/A

### Tests written?
Yes

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
