### PR TITLE
fix net.load_template bug

### DIFF
--- a/salt/modules/napalm_network.py
+++ b/salt/modules/napalm_network.py
@@ -1914,7 +1914,7 @@ def load_template(template_name=None,
     salt_render_prefixes = ('salt://', 'http://', 'https://', 'ftp://')
     salt_render = False
     file_exists = False
-    if not isinstance(template_name, (tuple, list)):
+    if template_name and not isinstance(template_name, (tuple, list)):
         for salt_render_prefix in salt_render_prefixes:
             if not salt_render:
                 salt_render = salt_render or template_name.startswith(salt_render_prefix)


### PR DESCRIPTION
### What does this PR do?

This fixes a bug in the napalm_network module that prevents users from only specifying an inline template with the `template_source` kwarg. 

The `template_name` variable defaults to `None` in this function, so when a user calls `net.load_template` without the `template_name` var defined (for example, if they want to specify an inline template with the `template_source` kwarg), this errors out due to the following:

```
if not isinstance(template_name, (tuple, list)): # this will run since template_name is a NoneType
        for salt_render_prefix in salt_render_prefixes:
            if not salt_render:
                salt_render = salt_render or template_name.startswith(salt_render_prefix) # <-- the bug is here - NoneType has no attribute 'startswith'
```

This currently produces the following traceback:

```
   The minion function caused an exception: Traceback (most recent call last):
      File "/usr/lib/python2.7/dist-packages/salt/minion.py", line 1607, in _thread_return
        return_data = minion_instance.executors[fname](opts, data, func, args, kwargs)
      File "/usr/lib/python2.7/dist-packages/salt/executors/direct_call.py", line 12, in execute
        return func(*args, **kwargs)
      File "/usr/lib/python2.7/dist-packages/salt/utils/napalm.py", line 430, in func_wrapper
        return func(*args, **kwargs)
      File "/var/cache/salt/proxy/extmods/junos/modules/napalm_network.py", line 1920, in load_template
        salt_render = salt_render or template_name.startswith(salt_render_prefix)
    AttributeError: 'NoneType' object has no attribute 'startswith'
```

pinging @mirceaulinic as well!