### PR TITLE
[2018.3] removing use of comments from incron modules

### DIFF
--- a/salt/modules/incron.py
+++ b/salt/modules/incron.py
@@ -53,11 +53,10 @@ def _render_tab(lst):
     for pre in lst['pre']:
         ret.append('{0}\n'.format(pre))
     for cron in lst['crons']:
-        ret.append('{0} {1} {2} {3}\n'.format(cron['path'],
-                                                      cron['mask'],
-                                                      cron['cmd'],
-                                                      TAG
-                                                      )
+        ret.append('{0} {1} {2}\n'.format(cron['path'],
+                                          cron['mask'],
+                                          cron['cmd'],
+                                          )
                    )
     return ret
 
@@ -191,23 +190,18 @@ def list_tab(user):
            'pre': []
            }
     flag = False
-    comment = None
-    tag = '# Line managed by Salt, do not edit'
     for line in data.splitlines():
-        if line.endswith(tag):
-            if len(line.split()) > 3:
-                # Appears to be a standard incron line
-                comps = line.split()
-                path = comps[0]
-                mask = comps[1]
-                (cmd, comment) = ' '.join(comps[2:]).split(' # ')
+        if len(line.split()) > 3:
+            # Appears to be a standard incron line
+            comps = line.split()
+            path = comps[0]
+            mask = comps[1]
+            cmd = ' '.join(comps[2:])
 
-                dat = {'path': path,
-                       'mask': mask,
-                       'cmd': cmd,
-                       'comment': comment}
-                ret['crons'].append(dat)
-                comment = None
+            dat = {'path': path,
+                   'mask': mask,
+                   'cmd': cmd}
+            ret['crons'].append(dat)
         else:
             ret['pre'].append(line)
     return ret

--- a/salt/states/incron.py
+++ b/salt/states/incron.py
@@ -44,6 +44,9 @@ then a new cron job will be added to the user's crontab.
 # Import Python libs
 from __future__ import absolute_import, print_function, unicode_literals
 
+import logging
+log = logging.getLogger(__name__)
+
 
 def _check_cron(user,
                 path,
@@ -56,6 +59,8 @@ def _check_cron(user,
     arg_mask.sort()
 
     lst = __salt__['incron.list_tab'](user)
+    if cmd.endswith('\n'):
+        cmd = cmd[:-1]
     for cron in lst['crons']:
         if path == cron['path'] and cron['cmd'] == cmd:
             cron_mask = cron['mask'].split(',')

--- a/tests/unit/modules/test_incron.py
+++ b/tests/unit/modules/test_incron.py
@@ -102,7 +102,7 @@ class IncronTestCase(TestCase, LoaderModuleMockMixin):
 
         val = {'pre': [], 'crons': [{'path': '/home/cybage',
                                      'mask': 'IN_MODIFY',
-                                     'cmd': 'echo "SALT"', 'comment': ''}]}
+                                     'cmd': 'echo "SALT"'}]}
         with patch.object(incron, 'list_tab',
                           MagicMock(return_value=val)):
             self.assertEqual(incron.set_job('cybage', '/home/cybage',
@@ -135,7 +135,7 @@ class IncronTestCase(TestCase, LoaderModuleMockMixin):
 
         val = {'pre': [], 'crons': [{'path': '/home/cybage',
                                      'mask': 'IN_MODIFY,IN_DELETE',
-                                     'cmd': 'echo "SALT"', 'comment': ''}]}
+                                     'cmd': 'echo "SALT"'}]}
         with patch.object(incron, 'list_tab',
                           MagicMock(return_value=val)):
             mock = MagicMock(return_value='incrontab')


### PR DESCRIPTION
### What does this PR do?
Updating the incron module, state module and tests to remove use of comments.

### What issues does this PR fix or reference?
#52197

### Previous Behavior
incron does not support comments and results in error logs when used.

### New Behavior
Removing the use of comments in the incrontab.

### Tests written?
Yes.  Existing tests.

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
