### PR TITLE
Draft: support slot parsing inside dict and lists of dict or strings

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -2134,9 +2134,10 @@ class State(object):
                 if isinstance(arg, dict):
                     # Search dictionary values for __slot__:
                     for key, value in arg.items():
-                        if value.startswith(SLOT_TEXT):
-                            log.debug("Slot processsing dict value %s", value)
-                            cdata[atype][ind][key] = self.__eval_slot(value)
+                        if isinstance(value, six.text_type):
+                            if value.startswith(SLOT_TEXT):
+                                log.debug("Slot processsing dict value %s", value)
+                                cdata[atype][ind][key] = self.__eval_slot(value)
                 elif isinstance(arg, list):
                     for idx, listvalue in enumerate(arg):
                         log.debug("Slot processing list value: %s", listvalue)

--- a/salt/state.py
+++ b/salt/state.py
@@ -2134,19 +2134,26 @@ class State(object):
                 if isinstance(arg, dict):
                     # Search dictionary values for __slot__:
                     for key, value in arg.items():
-                        if isinstance(value, six.text_type):
+                        try:
                             if value.startswith(SLOT_TEXT):
                                 log.debug("Slot processsing dict value %s", value)
                                 cdata[atype][ind][key] = self.__eval_slot(value)
+                        except AttributeError:
+                            # Not a string/slot
+                            continue
                 elif isinstance(arg, list):
                     for idx, listvalue in enumerate(arg):
                         log.debug("Slot processing list value: %s", listvalue)
                         if isinstance(listvalue, dict):
                             # Search dict values in list for __slot__:
                             for key, value in listvalue.items():
-                                if value.startswith(SLOT_TEXT):
-                                    log.debug("Slot processsing nested dict value %s", value)
-                                    cdata[atype][ind][idx][key] = self.__eval_slot(value)
+                                try:
+                                    if value.startswith(SLOT_TEXT):
+                                        log.debug("Slot processsing nested dict value %s", value)
+                                        cdata[atype][ind][idx][key] = self.__eval_slot(value)
+                                except AttributeError:
+                                    # Not a string/slot
+                                    continue
                         if isinstance(listvalue, six.text_type):
                             # Search strings in a list for __slot__:
                             if listvalue.startswith(SLOT_TEXT):

--- a/salt/state.py
+++ b/salt/state.py
@@ -2120,18 +2120,45 @@ class State(object):
         '''
         Read in the arguments from the low level slot syntax to make a last
         minute runtime call to gather relevant data for the specific routine
+
+        Will parse strings, first level of dictionary values, and strings and
+        first level dict values inside of lists
         '''
         # __slot__:salt.cmd.run(foo, bar, baz=qux)
+        SLOT_TEXT = '__slot__:'
         ctx = (('args', enumerate(cdata['args'])),
                ('kwargs', cdata['kwargs'].items()))
         for atype, avalues in ctx:
             for ind, arg in avalues:
                 arg = salt.utils.data.decode(arg, keep=True)
-                if not isinstance(arg, six.text_type) \
-                        or not arg.startswith('__slot__:'):
+                if isinstance(arg, dict):
+                    # Search dictionary values for __slot__:
+                    for key, value in arg.items():
+                        if value.startswith(SLOT_TEXT):
+                            log.debug("Slot processsing dict value %s", value)
+                            cdata[atype][ind][key] = self.__eval_slot(value)
+                elif isinstance(arg, list):
+                    for idx, listvalue in enumerate(arg):
+                        log.debug("Slot processing list value: %s", listvalue)
+                        if isinstance(listvalue, dict):
+                            # Search dict values in list for __slot__:
+                            for key, value in listvalue.items():
+                                if value.startswith(SLOT_TEXT):
+                                    log.debug("Slot processsing nested dict value %s", value)
+                                    cdata[atype][ind][idx][key] = self.__eval_slot(value)
+                        if isinstance(listvalue, six.text_type):
+                            # Search strings in a list for __slot__:
+                            if listvalue.startswith(SLOT_TEXT):
+                                log.debug("Slot processsing nested string %s", listvalue)
+                                cdata[atype][ind][idx] = self.__eval_slot(listvalue)
+                elif isinstance(arg, six.text_type) \
+                        and arg.startswith(SLOT_TEXT):
+                    # Search strings for __slot__:
+                    log.debug("Slot processsing %s", arg)
+                    cdata[atype][ind] = self.__eval_slot(arg)
+                else:
                     # Not a slot, skip it
                     continue
-                cdata[atype][ind] = self.__eval_slot(arg)
 
     def verify_retry_data(self, retry_data):
         '''

--- a/salt/state.py
+++ b/salt/state.py
@@ -2136,20 +2136,20 @@ class State(object):
                     for key, value in arg.items():
                         try:
                             if value.startswith(SLOT_TEXT):
-                                log.debug("Slot processsing dict value %s", value)
+                                log.trace("Slot processsing dict value %s", value)
                                 cdata[atype][ind][key] = self.__eval_slot(value)
                         except AttributeError:
                             # Not a string/slot
                             continue
                 elif isinstance(arg, list):
                     for idx, listvalue in enumerate(arg):
-                        log.debug("Slot processing list value: %s", listvalue)
+                        log.trace("Slot processing list value: %s", listvalue)
                         if isinstance(listvalue, dict):
                             # Search dict values in list for __slot__:
                             for key, value in listvalue.items():
                                 try:
                                     if value.startswith(SLOT_TEXT):
-                                        log.debug("Slot processsing nested dict value %s", value)
+                                        log.trace("Slot processsing nested dict value %s", value)
                                         cdata[atype][ind][idx][key] = self.__eval_slot(value)
                                 except AttributeError:
                                     # Not a string/slot
@@ -2157,12 +2157,12 @@ class State(object):
                         if isinstance(listvalue, six.text_type):
                             # Search strings in a list for __slot__:
                             if listvalue.startswith(SLOT_TEXT):
-                                log.debug("Slot processsing nested string %s", listvalue)
+                                log.trace("Slot processsing nested string %s", listvalue)
                                 cdata[atype][ind][idx] = self.__eval_slot(listvalue)
                 elif isinstance(arg, six.text_type) \
                         and arg.startswith(SLOT_TEXT):
                     # Search strings for __slot__:
-                    log.debug("Slot processsing %s", arg)
+                    log.trace("Slot processsing %s", arg)
                     cdata[atype][ind] = self.__eval_slot(arg)
                 else:
                     # Not a slot, skip it

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -337,6 +337,60 @@ class StateFormatSlotsTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
         mock.assert_called_once_with('fun_arg', fun_key='fun_val')
         self.assertEqual(cdata, {'args': ['fun_return'], 'kwargs': {'key': 'val'}})
 
+    def test_format_slots_dict_arg(self):
+        '''
+        Test the format slots is calling a slot specified in dict arg.
+        '''
+        cdata = {
+                'args': [
+                    {'subarg': '__slot__:salt:mod.fun(fun_arg, fun_key=fun_val)'},
+                ],
+                'kwargs': {
+                    'key': 'val',
+                }
+        }
+        mock = MagicMock(return_value='fun_return')
+        with patch.dict(self.state_obj.functions, {'mod.fun': mock}):
+            self.state_obj.format_slots(cdata)
+        mock.assert_called_once_with('fun_arg', fun_key='fun_val')
+        self.assertEqual(cdata, {'args': [{'subarg': 'fun_return'}], 'kwargs': {'key': 'val'}})
+
+    def test_format_slots_listdict_arg(self):
+        '''
+        Test the format slots is calling a slot specified in list containing a dict.
+        '''
+        cdata = {
+                'args': [[
+                    {'subarg': '__slot__:salt:mod.fun(fun_arg, fun_key=fun_val)'},
+                ]],
+                'kwargs': {
+                    'key': 'val',
+                }
+        }
+        mock = MagicMock(return_value='fun_return')
+        with patch.dict(self.state_obj.functions, {'mod.fun': mock}):
+            self.state_obj.format_slots(cdata)
+        mock.assert_called_once_with('fun_arg', fun_key='fun_val')
+        self.assertEqual(cdata, {'args': [[{'subarg': 'fun_return'}]], 'kwargs': {'key': 'val'}})
+
+    def test_format_slots_liststr_arg(self):
+        '''
+        Test the format slots is calling a slot specified in list containing a dict.
+        '''
+        cdata = {
+                'args': [[
+                    '__slot__:salt:mod.fun(fun_arg, fun_key=fun_val)',
+                ]],
+                'kwargs': {
+                    'key': 'val',
+                }
+        }
+        mock = MagicMock(return_value='fun_return')
+        with patch.dict(self.state_obj.functions, {'mod.fun': mock}):
+            self.state_obj.format_slots(cdata)
+        mock.assert_called_once_with('fun_arg', fun_key='fun_val')
+        self.assertEqual(cdata, {'args': [['fun_return']], 'kwargs': {'key': 'val'}})
+
     def test_format_slots_kwarg(self):
         '''
         Test the format slots is calling a slot specified in kwargs with corresponding arguments.


### PR DESCRIPTION
### What does this PR do?
Adds support for parsing slots inside of dictionaries and dicts and strings inside of lists.
This enables slot support for subkeys

### What issues does this PR fix or reference?
#51798
#50596

### Previous Behavior
As mentioned in linked issues, slots were not parsed in subkeys of state files

The following states displays the slot text itself
```
slot test:
  file.managed:
    - name: /tmp/thing
    - source: salt://slot.jinja
    - template: jinja
    - context:
        custom_var: __slot__:salt:cmd.run('echo password')

test module stuff:
  module.run:
    - test.arg:
      - message: __slot__:salt:cmd.run('echo blah')

scheduled_slot:
  schedule.present:
    - function: test.arg
    - job_args:
        - __slot__:salt:cmd.run('echo "blah"')
    - cron: '* * * * *'

scheduled_slot2:
  schedule.present:
    - function: test.arg
    - job_kwargs:
        - message: __slot__:salt:cmd.run('echo "blah"')
    - cron: '* * * * *'
```
### New Behavior
Previously mentioned state examples now show slot results

### Tests written?
Yes

### Commits signed with GPG?
No

@DmitryKuzmenko