### PR TITLE
fix 45195 - add ignore to sysctl state and module

### DIFF
--- a/salt/modules/linux_sysctl.py
+++ b/salt/modules/linux_sysctl.py
@@ -60,8 +60,8 @@ def show(config_file=False):
     '''
     Return a list of sysctl parameters for this minion
 
-    config: Pull the data from the system configuration file
-        instead of the live data.
+    :param config_file: Pull data from the system configuration file
+                        instead of the live kernel.
 
     CLI Example:
 
@@ -106,6 +106,9 @@ def get(name, ignore=False):
     '''
     Return a single sysctl parameter for this minion
 
+    :param name: Name of sysctl setting
+    :param ignore: Optional boolean to pass --ignore to sysctl (Default: False)
+
     CLI Example:
 
     .. code-block:: bash
@@ -122,6 +125,10 @@ def get(name, ignore=False):
 def assign(name, value, ignore=False):
     '''
     Assign a single sysctl parameter for this minion
+
+    :param name: Name of sysctl setting
+    :param value: Desired value of sysctl setting
+    :param ignore: Optional boolean to pass --ignore to sysctl (Default: False)
 
     CLI Example:
 
@@ -176,6 +183,11 @@ def persist(name, value, config=None, ignore=False):
     Assign and persist a simple sysctl parameter for this minion. If ``config``
     is not specified, a sensible default will be chosen using
     :mod:`sysctl.default_config <salt.modules.linux_sysctl.default_config>`.
+
+    :param name: Name of sysctl setting
+    :param value: Desired value of sysctl setting
+    :param config: Optional path to sysctl.conf
+    :param ignore: Optional boolean to pass --ignore to sysctl (Default: False)
 
     CLI Example:
 

--- a/salt/states/sysctl.py
+++ b/salt/states/sysctl.py
@@ -30,7 +30,7 @@ def __virtual__():
     return 'sysctl.show' in __salt__
 
 
-def present(name, value, config=None):
+def present(name, value, config=None, ignore=False):
     '''
     Ensure that the named sysctl value is set in memory and persisted to the
     named configuration file. The default sysctl configuration file is
@@ -111,7 +111,7 @@ def present(name, value, config=None):
         return ret
 
     try:
-        update = __salt__['sysctl.persist'](name, value, config)
+        update = __salt__['sysctl.persist'](name, value, config, ignore)
     except CommandExecutionError as exc:
         ret['result'] = False
         ret['comment'] = (
@@ -125,6 +125,11 @@ def present(name, value, config=None):
     elif update == 'Already set':
         ret['comment'] = (
             'Sysctl value {0} = {1} is already set'
+            .format(name, value)
+        )
+    elif update == 'Ignored':
+        ret['comment'] = (
+            'Sysctl value {0} = {1} was ignored'
             .format(name, value)
         )
 

--- a/salt/states/sysctl.py
+++ b/salt/states/sysctl.py
@@ -45,6 +45,13 @@ def present(name, value, config=None, ignore=False):
     config
         The location of the sysctl configuration file. If not specified, the
         proper location will be detected based on platform.
+
+    ignore
+        ..versionadded:: neon
+
+        Adds --ignore to sysctl commands. This suppresses errors in environments
+        where sysctl settings may have been disabled in kernel boot configuration.
+        Defaults to False
     '''
     ret = {'name': name,
            'result': True,

--- a/tests/unit/modules/test_linux_sysctl.py
+++ b/tests/unit/modules/test_linux_sysctl.py
@@ -40,6 +40,14 @@ class LinuxSysctlTestCase(TestCase, LoaderModuleMockMixin):
         with patch.dict(linux_sysctl.__salt__, {'cmd.run': mock_cmd}):
             self.assertEqual(linux_sysctl.get('net.ipv4.ip_forward'), 1)
 
+    def test_get_ignore(self):
+        '''
+        Tests the return of get function with ignore
+        '''
+        mock_cmd = MagicMock(return_value='')
+        with patch.dict(linux_sysctl.__salt__, {'cmd.run': mock_cmd}):
+            self.assertEqual(linux_sysctl.get('net.ipv4.ip_forward', ignore=True), '')
+
     def test_assign_proc_sys_failed(self):
         '''
         Tests if /proc/sys/<kernel-subsystem> exists or not
@@ -79,6 +87,19 @@ class LinuxSysctlTestCase(TestCase, LoaderModuleMockMixin):
             with patch.dict(linux_sysctl.__salt__, {'cmd.run_all': mock_cmd}):
                 self.assertEqual(linux_sysctl.assign(
                     'net.ipv4.ip_forward', 1), ret)
+
+    def test_assign_ignore(self):
+        '''
+        Tests the ignore assign function
+        '''
+        with patch('os.path.exists', MagicMock(return_value=True)):
+            cmd = {'pid': 1337, 'retcode': 0, 'stderr': '',
+                   'stdout': ''}
+            ret = {'net.ipv4.ip_forward': 'ignored'}
+            mock_cmd = MagicMock(return_value=cmd)
+            with patch.dict(linux_sysctl.__salt__, {'cmd.run_all': mock_cmd}):
+                self.assertEqual(linux_sysctl.assign(
+                    'net.ipv4.ip_forward', 1, ignore=True), ret)
 
     def test_persist_no_conf_failure(self):
         '''

--- a/tests/unit/states/test_sysctl.py
+++ b/tests/unit/states/test_sysctl.py
@@ -69,6 +69,8 @@ class SysctlTestCase(TestCase, LoaderModuleMockMixin):
 
         comt7 = ('Sysctl value {0} = {1} is already set'.format(name, value))
 
+        comt8 = ('Sysctl value {0} = {1} was ignored'.format(name, value))
+
         def mock_current(config_file=None):
             '''
             Mock return value for __salt__.
@@ -134,4 +136,9 @@ class SysctlTestCase(TestCase, LoaderModuleMockMixin):
             mock = MagicMock(return_value='Already set')
             with patch.dict(sysctl.__salt__, {'sysctl.persist': mock}):
                 ret.update({'comment': comt7, 'result': True})
+                self.assertDictEqual(sysctl.present(name, value), ret)
+
+            mock = MagicMock(return_value='Ignored')
+            with patch.dict(sysctl.__salt__, {'sysctl.persist': mock}):
+                ret.update({'comment': comt8, 'result': True})
                 self.assertDictEqual(sysctl.present(name, value), ret)


### PR DESCRIPTION
### What does this PR do?
Add ignore support for sysctl module and state

### What issues does this PR fix or reference?
#45195

### Previous Behavior
If kernel settings were adjusted via grub, sysctl state would throw errors. 


sysctl.get
```
# salt-call sysctl.get net.ipv6.conf.default.disable_ipv6
[ERROR   ] Command '[u'sysctl', u'-n', u'net.ipv6.conf.default.disable_ipv6']' failed with return code: 255
[ERROR   ] stdout: sysctl: cannot stat /proc/sys/net/ipv6/conf/default/disable_ipv6: No such file or directory
[ERROR   ] retcode: 255
[ERROR   ] Command 'sysctl -n net.ipv6.conf.default.disable_ipv6' failed with return code: 255
[ERROR   ] output: sysctl: cannot stat /proc/sys/net/ipv6/conf/default/disable_ipv6: No such file or directory
local:
    sysctl: cannot stat /proc/sys/net/ipv6/conf/default/disable_ipv6: No such file or directory
```

sysctl.assign
```
# salt-call sysctl.assign net.ipv6.conf.default.disable_ipv6 1 ignore=False
Error running 'sysctl.assign': sysctl net.ipv6.conf.default.disable_ipv6 does not exist
```

state sysctl.present
```
net.ipv6.conf.default.disable_ipv6:
  sysctl.present:
    - value: 1

# salt-call state.sls sysctl
[ERROR   ] Command '[u'sysctl', u'-n', u'net.ipv6.conf.default.disable_ipv6']' failed with return code: 255
[ERROR   ] stdout: sysctl: cannot stat /proc/sys/net/ipv6/conf/default/disable_ipv6: No such file or directory
[ERROR   ] retcode: 255
[ERROR   ] Command 'sysctl -n net.ipv6.conf.default.disable_ipv6' failed with return code: 255
[ERROR   ] output: sysctl: cannot stat /proc/sys/net/ipv6/conf/default/disable_ipv6: No such file or directory
[ERROR   ] Failed to set net.ipv6.conf.default.disable_ipv6 to 1: sysctl net.ipv6.conf.default.disable_ipv6 does not exist
local:
----------
          ID: net.ipv6.conf.default.disable_ipv6
    Function: sysctl.present
      Result: False
     Comment: Failed to set net.ipv6.conf.default.disable_ipv6 to 1: sysctl net.ipv6.conf.default.disable_ipv6 does not exist
     Started: 06:52:51.018918
    Duration: 22.922 ms
     Changes:

Summary for local
------------
Succeeded: 0
Failed:    1
------------
Total states run:     1
Total run time:  22.922 ms
```

### New Behavior
Support `ignore=True` in order to suppress sysctl errors on disabled settings

sysctl.get
```
# salt-call sysctl.get net.ipv6.conf.default.disable_ipv6 ignore=True
local:
```

sysctl.assign
```
# salt-call sysctl.assign net.ipv6.conf.default.disable_ipv6 1 ignore=True
local:
    ----------
    net.ipv6.conf.default.disable_ipv6:
        ignored
```

state sysctl.present
```
net.ipv6.conf.default.disable_ipv6:
  sysctl.present:
    - value: 1
    - ignore: True


# salt-call state.sls sysctl
local:
----------
          ID: net.ipv6.conf.default.disable_ipv6
    Function: sysctl.present
      Result: True
     Comment: Sysctl value net.ipv6.conf.default.disable_ipv6 = 1 was ignored
     Started: 06:54:07.576832
    Duration: 12.76 ms
     Changes:

Summary for local
------------
Succeeded: 1
Failed:    0
------------
Total states run:     1
Total run time:  12.760 ms
```

### Tests written?
Yes

### Commits signed with GPG?
No