### PR TITLE
Fix network.traceroute exec module function

### DIFF
--- a/salt/modules/network.py
+++ b/salt/modules/network.py
@@ -823,6 +823,7 @@ def active_tcp():
         return {}
 
 
+@salt.utils.decorators.path.which('traceroute')
 def traceroute(host):
     '''
     Performs a traceroute to a 3rd party host
@@ -840,12 +841,7 @@ def traceroute(host):
         salt '*' network.traceroute archlinux.org
     '''
     ret = []
-    if not salt.utils.path.which('traceroute'):
-        log.info('This minion does not have traceroute installed')
-        return ret
-
     cmd = 'traceroute {0}'.format(salt.utils.network.sanitize_host(host))
-
     out = __salt__['cmd.run'](cmd)
 
     # Parse version of traceroute

--- a/salt/modules/network.py
+++ b/salt/modules/network.py
@@ -848,17 +848,16 @@ def traceroute(host):
     if salt.utils.platform.is_sunos() or salt.utils.platform.is_aix():
         traceroute_version = [0, 0, 0]
     else:
-        cmd2 = 'traceroute --version'
-        out2 = __salt__['cmd.run'](cmd2)
+        version_out = __salt__['cmd.run']('traceroute --version')
         try:
             # Linux traceroute version looks like:
             #   Modern traceroute for Linux, version 2.0.19, Dec 10 2012
             # Darwin and FreeBSD traceroute version looks like: Version 1.4a12+[FreeBSD|Darwin]
 
-            traceroute_version_raw = re.findall(r'.*[Vv]ersion (\d+)\.([\w\+]+)\.*(\w*)', out2)[0]
-            log.debug('traceroute_version_raw: %s', traceroute_version_raw)
+            version_raw = re.findall(r'.*[Vv]ersion (\d+)\.([\w\+]+)\.*(\w*)', version_out)[0]
+            log.debug('traceroute_version_raw: %s', version_raw)
             traceroute_version = []
-            for t in traceroute_version_raw:
+            for t in version_raw:
                 try:
                     traceroute_version.append(int(t))
                 except ValueError:
@@ -873,26 +872,28 @@ def traceroute(host):
             traceroute_version = [0, 0, 0]
 
     for line in out.splitlines():
+        # Pre requirements for line parsing
+        skip_line = False
         if ' ' not in line:
-            continue
+            skip_line = True
         if line.startswith('traceroute'):
-            continue
-
+            skip_line = True
         if salt.utils.platform.is_aix():
             if line.startswith('trying to get source for'):
-                continue
-
+                skip_line = True
             if line.startswith('source should be'):
-                continue
-
+                skip_line = True
             if line.startswith('outgoing MTU'):
-                continue
-
+                skip_line = True
             if line.startswith('fragmentation required'):
-                continue
+                skip_line = True
+        if skip_line:
+            log.debug('Skipping traceroute output line: %s', line)
+            continue
 
+        # Parse output from unix variants
         if 'Darwin' in six.text_type(traceroute_version[1]) or \
-            'FreeBSD' in six.text_type(traceroute_version[1]) or \
+                'FreeBSD' in six.text_type(traceroute_version[1]) or \
                 __grains__['kernel'] in ('SunOS', 'AIX'):
             try:
                 traceline = re.findall(r'\s*(\d*)\s+(.*)\s+\((.*)\)\s+(.*)$', line)[0]
@@ -919,14 +920,15 @@ def traceroute(host):
             except IndexError:
                 result = {}
 
+        # Parse output from specific version ranges
         elif (traceroute_version[0] >= 2 and traceroute_version[2] >= 14
                 or traceroute_version[0] >= 2 and traceroute_version[1] > 0):
             comps = line.split('  ')
-            if comps[1] == '* * *':
+            if len(comps) >= 2 and comps[1] == '* * *':
                 result = {
                     'count': int(comps[0]),
                     'hostname': '*'}
-            else:
+            elif len(comps) >= 5:
                 result = {
                     'count': int(comps[0]),
                     'hostname': comps[1].split()[0],
@@ -934,21 +936,29 @@ def traceroute(host):
                     'ms1': float(comps[2].split()[0]),
                     'ms2': float(comps[3].split()[0]),
                     'ms3': float(comps[4].split()[0])}
+            else:
+                result = {}
+
+        # Parse anything else
         else:
             comps = line.split()
-            result = {
-                'count': comps[0],
-                'hostname': comps[1],
-                'ip': comps[2],
-                'ms1': comps[4],
-                'ms2': comps[6],
-                'ms3': comps[8],
-                'ping1': comps[3],
-                'ping2': comps[5],
-                'ping3': comps[7]}
+            if len(comps) >= 8:
+                result = {
+                    'count': comps[0],
+                    'hostname': comps[1],
+                    'ip': comps[2],
+                    'ms1': comps[4],
+                    'ms2': comps[6],
+                    'ms3': comps[8],
+                    'ping1': comps[3],
+                    'ping2': comps[5],
+                    'ping3': comps[7]}
+            else:
+                result = {}
 
         ret.append(result)
-
+        if not result:
+            log.warn('Cannot parse traceroute output line: %s', line)
     return ret
 
 

--- a/tests/unit/modules/test_network.py
+++ b/tests/unit/modules/test_network.py
@@ -113,14 +113,15 @@ class NetworkTestCase(TestCase, LoaderModuleMockMixin):
         '''
         Test for Performs a traceroute to a 3rd party host
         '''
-        with patch.object(salt.utils.path, 'which', side_effect=[False, True]):
-            self.assertListEqual(network.traceroute('host'), [])
+        with patch('salt.utils.path.which', MagicMock(return_value='traceroute')):
+            with patch.dict(network.__salt__, {'cmd.run': MagicMock(return_value='')}):
+                self.assertListEqual(network.traceroute('gentoo.org'), [])
 
             with patch.object(salt.utils.network, 'sanitize_host',
-                              return_value='A'):
+                              return_value='gentoo.org'):
                 with patch.dict(network.__salt__, {'cmd.run':
-                                                   MagicMock(return_value="")}):
-                    self.assertListEqual(network.traceroute('host'), [])
+                                                   MagicMock(return_value='')}):
+                    self.assertListEqual(network.traceroute('gentoo.org'), [])
 
     def test_dig(self):
         '''


### PR DESCRIPTION
### What does this PR do?
Armoring the unprotected list dereferences and redirecting the problematic lines to the log seemed like the best solution to this optimistically quixotic function.  Perhaps a future enterprising adventurer can dig into the source code of the many variants of traceroute and with unit tests provide a more orthogonal result.

### Previous Behavior
```py
# salt-call --local -l warning network.traceroute gentoo.org
[ERROR   ] An un-handled exception was caught by salt's global exception handler:
IndexError: list index out of range
Traceback (most recent call last):
  File "/usr/lib/python-exec/python2.7/salt-call", line 11, in <module>
    salt_call()
  File "/usr/lib/python2.7/site-packages/salt/scripts.py", line 431, in salt_call
    client.run()
  File "/usr/lib/python2.7/site-packages/salt/cli/call.py", line 57, in run
    caller.run()
  File "/usr/lib/python2.7/site-packages/salt/cli/caller.py", line 138, in run
    ret = self.call()
  File "/usr/lib/python2.7/site-packages/salt/cli/caller.py", line 237, in call
    ret['return'] = self.minion.executors[fname](self.opts, data, func, args, kwargs)
  File "/usr/lib/python2.7/site-packages/salt/executors/direct_call.py", line 12, in execute
    return func(*args, **kwargs)
  File "/usr/lib/python2.7/site-packages/salt/modules/network.py", line 941, in traceroute
    'ms3': float(comps[4].split()[0])}
IndexError: list index out of range
```
### New Behavior
```yaml
# salt-call --local -l warning network.traceroute gentoo.org
[WARNING ] Cannot parse traceroute output line:  8  be3037.ccr21.den01.atlas.cogentco.com (154.54.41.146)  49.349 ms be3038.ccr22.den01.atlas.cogentco.com (154.54.42.98)  50.383 ms *
[WARNING ] Cannot parse traceroute output line: 15  be3579.rcr51.lba01.atlas.cogentco.com (154.54.57.250)  162.295 ms *  162.492 ms
local:
    [...]
    |_
      ----------
      count:
          19
      hostname:
          www.gentoo.org
      ip: 
          89.16.167.134
      ms1:
          168.193
      ms2:
          163.027
      ms3:
          163.405
```
### What issues does this PR fix or reference?
#21927

### Tests written?
No

### Commits signed with GPG?
Yes