### PR TITLE
correctly reraise exceptions in states.http

### DIFF
--- a/salt/states/http.py
+++ b/salt/states/http.py
@@ -12,6 +12,10 @@ from __future__ import absolute_import, print_function, unicode_literals
 import logging
 import re
 import time
+import sys
+
+from salt.ext import six
+
 
 __monitor__ = [
         'query',
@@ -149,18 +153,19 @@ def wait_for_successful_query(name, wait_for=300, **kwargs):
 
     while True:
         caught_exception = None
+        exception_type = None
+        stacktrace = None
         ret = None
         try:
             ret = query(name, **kwargs)
             if ret['result']:
                 return ret
         except Exception as exc:
-            caught_exception = exc
+            exception_type, caught_exception, stacktrace = sys.exc_info()
 
         if time.time() > starttime + wait_for:
             if not ret and caught_exception:
-                # workaround pylint bug https://www.logilab.org/ticket/3207
-                raise caught_exception  # pylint: disable=E0702
+                six.reraise(exception_type, caught_exception, stacktrace)
             return ret
         else:
             # Space requests out by delaying for an interval


### PR DESCRIPTION
### What does this PR do?
It improves error reporting for unexpected circumstances in `salt.states.http`. I stumbled over this while investigating saltstack/salt#51180.

As per the contribution guidelines I'm filing this bugfix PR against the lowest supported release, which I believe to be 2018.3.

### Previous Behavior
When the http state returned `None` as the value of the body, the previous code would raise a meaningless stacktrace giving no information about where the actual problem occurred. 

### New Behavior
This PR uses six to reraise the exception correctly in Python 2 and 3 by saving the stack trace first and ensuring that the correct stack trace is then raised.

### Tests written?
No. The behavior has not changed only the exceptions content.

### Commits signed with GPG?
Yes
