### PR TITLE
Added virtual-machines to ext_pillars

### DIFF
--- a/salt/pillar/netbox.py
+++ b/salt/pillar/netbox.py
@@ -87,7 +87,16 @@ def ext_pillar(minion_id, pillar, *args, **kwargs):
                                            params={'name': minion_id},
                                            header_dict=headers,
                                            decode=True)
-   # Check status code for API call
+    # Check if devices are empty and try virtual-machines
+    if len(device_results['dict']['results']) == 0:
+        device_url = '{api_url}/{app}/{endpoint}'.format(api_url=api_url,
+                                                     app='virtualization',
+                                                     endpoint='virtual-machines')
+        device_results = salt.utils.http.query(device_url,
+                                           params={'name': minion_id},
+                                           header_dict=headers,
+                                           decode=True)
+    # Check status code for API call
     if 'error' in device_results:
         log.error('API query failed for "%s", status code: %d',
                   minion_id, device_results['status'])


### PR DESCRIPTION
### What does this PR do?
Adds virtual-machines to ext_pillars netbox otherwise nothing will be returned for those hosts

### What issues does this PR fix or reference?

### Previous Behavior
Only devices in dcim/devices returned pillar information from netbox

### New Behavior
Virtual-machines also return pillar information from netbox

### Tests written?

No

### Commits signed with GPG?

No

