### PR TITLE
new feature: dynamic file roots

### DIFF
--- a/doc/ref/file_server/file_roots.rst
+++ b/doc/ref/file_server/file_roots.rst
@@ -83,3 +83,15 @@ interface, copy the file server data to the minion and set the file_roots
 option on the minion to point to the directories copied from the master.
 Once the minion ``file_roots`` option has been set, change the ``file_client``
 option to local to make sure that the local file server interface is used.
+
+Dynamic File Roots
+=================
+
+.. versionadded::  Neon
+
+If you need more flexibility in defining file roots offered by a given
+environment at runtime, you can add a ``file_roots.roots`` and  ``file_roots.all_roots``
+definition via the utils/ LazyLoader mechanism. If a utils module with these functions
+are found in your environment, you can define at runtime what roots a given
+environment should map to. The return values should be equivalent in structure
+to what you would place in your configuration.

--- a/doc/topics/releases/neon.rst
+++ b/doc/topics/releases/neon.rst
@@ -318,7 +318,7 @@ Module Changes
   secrets in AWS SSM parameters.
 
 - The :py:func:`file.set_selinux_context <salt.modules.file.set_selinux_context>`
-  module now supports perstant changes with ``persist=True`` by calling the
+  module now supports persistent changes with ``persist=True`` by calling the
   :py:func:`selinux.fcontext_add_policy <salt.modules.selinux.fcontext_add_policy>` module.
 
 - The :py:func:`yumpkg <salt.modules.yumpkg>` module has been updated to support
@@ -330,6 +330,21 @@ Runner Changes
 - The :py:func:`saltutil.sync_auth <salt.runners.saltutil.sync_auth>` function
   has been added to sync loadable auth modules. :py:func:`saltutil.sync_all <salt.runners.saltutil.sync_all>`
   will also include these modules.
+
+FileServer Enhancements
+==================
+- When using the file_roots file server, you can now optionally define your
+  roots on the fly by enabling ``dynamic_file_roots: true`` in master config.
+  When this mode is on, the file_roots server attempts to dictupdate.merge what
+  ``file_roots.roots`` and ``file_roots.all_roots`` _utils/ module functions
+  returns with what is defined in the normal file_roots configuration. Adding
+  these functions allows you to dynamically define what roots are associated
+  with an environment at runtime.
+
+.. note::
+  Due to the chicken-egg situation of using the FileServer to sync _utils
+  modules, make sure to sync your util module before turning this feature on,
+  or ensure it is available via the extension_modules or utils_dirs parameters.
 
 Enhancements to Engines
 =======================

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -286,6 +286,9 @@ VALID_OPTS = immutabletypes.freeze({
     # a master for remote execution.
     'use_master_when_local': bool,
 
+    # enable optional file_root functionality
+    'dynamic_file_roots': bool,
+
     # A map of saltenvs and fileserver backend locations
     'file_roots': dict,
 
@@ -1288,6 +1291,7 @@ DEFAULT_MINION_OPTS = immutabletypes.freeze({
     'file_client': 'remote',
     'local': False,
     'use_master_when_local': False,
+    'dynamic_file_roots': False,
     'file_roots': {
         'base': [salt.syspaths.BASE_FILE_ROOTS_DIR,
                  salt.syspaths.SPM_FORMULA_PATH]
@@ -1538,6 +1542,7 @@ DEFAULT_MASTER_OPTS = immutabletypes.freeze({
     'pki_dir': os.path.join(salt.syspaths.CONFIG_DIR, 'pki', 'master'),
     'key_cache': '',
     'cachedir': os.path.join(salt.syspaths.CACHE_DIR, 'master'),
+    'dynamic_file_roots': False,
     'file_roots': {
         'base': [salt.syspaths.BASE_FILE_ROOTS_DIR,
                  salt.syspaths.SPM_FORMULA_PATH]

--- a/tests/unit/fileserver/test_roots.py
+++ b/tests/unit/fileserver/test_roots.py
@@ -179,7 +179,7 @@ class RootsTest(TestCase, AdaptedConfigurationTestCaseMixin, LoaderModuleMockMix
             if self.test_symlink_list_file_roots:
                 self.opts['file_roots'] = orig_file_roots
 
-    def test_dynamic_file_roots(self):
+    def test_fallback_file_root(self):
         dyn_root_dir = tempfile.mkdtemp(dir=TMP)
         top_sls = os.path.join(dyn_root_dir, 'top.sls')
         with salt.utils.files.fopen(top_sls, 'w') as fp_:
@@ -195,3 +195,66 @@ class RootsTest(TestCase, AdaptedConfigurationTestCaseMixin, LoaderModuleMockMix
         self.assertEqual('dynamo.sls', ret1['rel'])
         self.assertIn('top.sls', ret2)
         self.assertIn('dynamo.sls', ret2)
+
+    def test_dynamic_file_roots(self):
+        root_a = tempfile.mkdtemp(dir=TMP)
+        root_b = tempfile.mkdtemp(dir=TMP)
+        root_c = tempfile.mkdtemp(dir=TMP)
+
+        top_sls = os.path.join(root_a, 'top.sls')
+
+        with salt.utils.files.fopen(top_sls, 'w') as fp_:
+            fp_.write("{{saltenv}}:\n  '*':\n    - dynamo\n")
+
+        root_a_sls = os.path.join(root_a, 'from_root_a.sls')
+        root_b_sls = os.path.join(root_b, 'from_root_b.sls')
+        root_c_sls = os.path.join(root_c, 'from_root_c.sls')
+        with salt.utils.files.fopen(root_a_sls, 'w') as fp_:
+            fp_.write("foo:\n  test.nop\n")
+        with salt.utils.files.fopen(root_b_sls, 'w') as fp_:
+            fp_.write("foo:\n  test.nop\n")
+        with salt.utils.files.fopen(root_c_sls, 'w') as fp_:
+            fp_.write("foo:\n  test.nop\n")
+
+        opts = {'file_roots': copy.copy(self.opts['file_roots']), 'dynamic_file_roots': True}
+
+        print(opts['file_roots'])
+
+        def _all_roots():
+            return {
+                'base': [root_a],
+                'root_b': [root_b],
+                'root_c': [root_b, root_c],
+            }
+
+        def _roots(env):
+            if env == 'base':
+                return [root_a]
+
+            if env == 'root_b':
+                return [root_b]
+
+            if env == 'root_c':
+                return [root_b, root_c]
+
+        with patch.object(roots, '__utils__', {'file_roots.all_roots': _all_roots, 'file_roots.roots': _roots}, create=True):
+            with patch.dict(roots.__opts__, opts):
+                # assert that the dynamic roots are additive to the config
+                ret = roots.find_file('from_root_a.sls', 'base')
+                self.assertEqual('from_root_a.sls', ret['rel'])
+
+                ret = roots.find_file('core.sls', 'base')
+                self.assertEqual('core.sls', ret['rel'])
+
+                # assert that roots are separate, root_a is not root_b
+                ret = roots.find_file('from_root_a.sls', 'root_b')
+                self.assertEqual('', ret['rel'])
+                self.assertEqual('', ret['path'])
+
+                # assert root_b only contains the tmpfile we created
+                ret = roots.file_list({'saltenv': 'root_b'})
+                self.assertEqual(['from_root_b.sls'], ret)
+
+                # assert root_c contains both root_b and root_c
+                ret = roots.file_list({'saltenv': 'root_c'})
+                self.assertEqual(['from_root_b.sls', 'from_root_c.sls'], ret)


### PR DESCRIPTION
### What does this PR do?
when reaching a certain level of complexity in defining what file roots
are available to a given environment, being able to define these on the
fly without a master restart tied to a master configuration update is
desirable. This feature lets drop in a util to control the generation
and mapping of these roots to environments.

### What issues does this PR fix or reference?
n/a

### Tests written?
Yes

### Commits signed with GPG?

Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
