### PR TITLE
new feature: dynamic file roots

### DIFF
--- a/doc/ref/file_server/file_roots.rst
+++ b/doc/ref/file_server/file_roots.rst
@@ -83,3 +83,15 @@ interface, copy the file server data to the minion and set the file_roots
 option on the minion to point to the directories copied from the master.
 Once the minion ``file_roots`` option has been set, change the ``file_client``
 option to local to make sure that the local file server interface is used.
+
+Dynamic File Roots
+=================
+
+.. versionadded::  Neon
+
+If you need more flexibility in defining file roots offered by a given
+environment at runtime, you can add a ``file_roots.roots`` and  ``file_roots.all_roots``
+definition via the utils/ LazyLoader mechanism. If a utils module with these functions
+are found in your environment, you can define at runtime what roots a given
+environment should map to. The return values should be equivalent in structure
+to what you would place in your configuration.

--- a/doc/ref/file_server/file_roots.rst
+++ b/doc/ref/file_server/file_roots.rst
@@ -85,7 +85,7 @@ Once the minion ``file_roots`` option has been set, change the ``file_client``
 option to local to make sure that the local file server interface is used.
 
 Dynamic File Roots
-=================
+==================
 
 .. versionadded::  Neon
 

--- a/doc/topics/releases/neon.rst
+++ b/doc/topics/releases/neon.rst
@@ -318,7 +318,7 @@ Module Changes
   secrets in AWS SSM parameters.
 
 - The :py:func:`file.set_selinux_context <salt.modules.file.set_selinux_context>`
-  module now supports perstant changes with ``persist=True`` by calling the
+  module now supports persistent changes with ``persist=True`` by calling the
   :py:func:`selinux.fcontext_add_policy <salt.modules.selinux.fcontext_add_policy>` module.
 
 - The :py:func:`yumpkg <salt.modules.yumpkg>` module has been updated to support
@@ -330,6 +330,21 @@ Runner Changes
 - The :py:func:`saltutil.sync_auth <salt.runners.saltutil.sync_auth>` function
   has been added to sync loadable auth modules. :py:func:`saltutil.sync_all <salt.runners.saltutil.sync_all>`
   will also include these modules.
+
+FileServer Enhancements
+==================
+- When using the file_roots file server, you can now optionally define your
+  roots on the fly by enabling ``dynamic_file_roots: true`` in master config.
+  When this mode is on, the file_roots server attempts to dictupdate.merge what
+  ``file_roots.roots`` and ``file_roots.all_roots`` _utils/ module functions
+  returns with what is defined in the normal file_roots configuration. Adding
+  these functions allows you to dynamically define what roots are associated
+  with an environment at runtime.
+
+.. note::
+  Due to the chicken-egg situation of using the FileServer to sync _utils
+  modules, make sure to sync your util module before turning this feature on,
+  or ensure it is available via the extension_modules or utils_dirs parameters.
 
 Enhancements to Engines
 =======================

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -286,6 +286,9 @@ VALID_OPTS = immutabletypes.freeze({
     # a master for remote execution.
     'use_master_when_local': bool,
 
+    # enable optional file_root functionality
+    'dynamic_file_roots': bool,
+
     # A map of saltenvs and fileserver backend locations
     'file_roots': dict,
 
@@ -1288,6 +1291,7 @@ DEFAULT_MINION_OPTS = immutabletypes.freeze({
     'file_client': 'remote',
     'local': False,
     'use_master_when_local': False,
+    'dynamic_file_roots': False,
     'file_roots': {
         'base': [salt.syspaths.BASE_FILE_ROOTS_DIR,
                  salt.syspaths.SPM_FORMULA_PATH]
@@ -1538,6 +1542,7 @@ DEFAULT_MASTER_OPTS = immutabletypes.freeze({
     'pki_dir': os.path.join(salt.syspaths.CONFIG_DIR, 'pki', 'master'),
     'key_cache': '',
     'cachedir': os.path.join(salt.syspaths.CACHE_DIR, 'master'),
+    'dynamic_file_roots': False,
     'file_roots': {
         'base': [salt.syspaths.BASE_FILE_ROOTS_DIR,
                  salt.syspaths.SPM_FORMULA_PATH]

--- a/salt/fileserver/roots.py
+++ b/salt/fileserver/roots.py
@@ -34,7 +34,6 @@ import salt.utils.platform
 import salt.utils.stringutils
 import salt.utils.versions
 from salt.ext import six
-from salt.exceptions import FileserverConfigError
 
 log = logging.getLogger(__name__)
 
@@ -46,7 +45,7 @@ def _file_roots():
     roots = __opts__['file_roots']
 
     if __opts__['dynamic_file_roots']:
-        if not 'file_roots.all_roots' in __utils__:
+        if 'file_roots.all_roots' not in __utils__:
             log.error('missing _utils/file_roots.py:all_roots() for dynamic_file_roots. Did you forget to saltutil.sync_utils?')
         else:
             dynamic_roots = __utils__['file_roots.all_roots']()
@@ -62,7 +61,7 @@ def _file_roots_for(saltenv):
     roots = __opts__['file_roots'][saltenv]
 
     if __opts__['dynamic_file_roots']:
-        if not 'file_roots.roots' in __utils__:
+        if 'file_roots.roots' not in __utils__:
             log.error('missing _utils/file_roots.py:roots() for dynamic_file_roots. Did you forget to saltutil.sync_utils?')
         else:
             dynamic_roots = __utils__['file_roots.roots'](saltenv)


### PR DESCRIPTION
### What does this PR do?
when reaching a certain level of complexity in defining what file roots
are available to a given environment, being able to define these on the
fly without a master restart tied to a master configuration update is
desirable. This feature lets drop in a util to control the generation
and mapping of these roots to environments.


### Tests written?
Yes

### Commits signed with GPG?

Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
