### PR TITLE
Altered code to support salt-ssh on AIX

### DIFF
--- a/salt/client/ssh/ssh_py_shim.py
+++ b/salt/client/ssh/ssh_py_shim.py
@@ -118,7 +118,8 @@ def need_deployment():
         if dstat.st_uid != euid:
             # Attack detected, try again
             need_deployment()
-        if dstat.st_mode != 16832:
+        # AIX has non-POSIX bit 0o240700, isolate to 0o40700
+        if dstat.st_mode & ~65536 != 16832:
             # Attack detected
             need_deployment()
         # If SUDOing then also give the super user group write permissions

--- a/salt/utils/rsax931.py
+++ b/salt/utils/rsax931.py
@@ -46,7 +46,7 @@ def _load_libcrypto():
             lib = glob.glob('/opt/local/lib/libcrypto.so*') + glob.glob('/opt/tools/lib/libcrypto.so*')
             lib = lib[0] if len(lib) > 0 else None
         if not lib and salt.utils.platform.is_aix():
-            if os.ospath.isdir('/opt/salt/lib'):
+            if os.path.isdir('/opt/salt/lib'):
                 # preference for Salt installed fileset
                 lib = glob.glob('/opt/salt/lib/libcrypto.so*')
                 lib = lib[0] if len(lib) > 0 else None

--- a/salt/utils/rsax931.py
+++ b/salt/utils/rsax931.py
@@ -45,6 +45,14 @@ def _load_libcrypto():
             # two checks below
             lib = glob.glob('/opt/local/lib/libcrypto.so*') + glob.glob('/opt/tools/lib/libcrypto.so*')
             lib = lib[0] if len(lib) > 0 else None
+        if not lib and salt.utils.platform.is_aix():
+            if os.ospath.isdir('/opt/salt/lib'):
+                # preference for Salt installed fileset
+                lib = glob.glob('/opt/salt/lib/libcrypto.so*')
+                lib = lib[0] if len(lib) > 0 else None
+            else:
+                lib = glob.glob('/opt/freeware/lib/libcrypto.so*')
+                lib = lib[0] if len(lib) > 0 else None
         if lib:
             return cdll.LoadLibrary(lib)
         raise OSError('Cannot locate OpenSSL libcrypto')


### PR DESCRIPTION
### What does this PR do?
Allows salt-ssh to function correctly on AIX

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/27482

### Previous Behavior
Would fail and throw a tracback

### New Behavior
salt-ssh now functions and returns results

### Tests written?
No, hand tested on the CLI,
salt-ssh -v --askpass aixt2 test.versions
salt-ssh -v --askpass aixt1 test.versions
salt-ssh -v aixt2 test.versions

with roster /etc/salt/roster
aixt1:
    host: 172.29.157.155
    user: root
    passwd: ainu0hop

aixt2:
    host: 172.29.157.154
    user: root
    passwd: ausx5jbt

Note, AIX had python already installed, and /etc/ssh/sshd_config modified to allow root login.
By default there is no sudo support on AIX

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
