### PR TITLE
Bring host.present in line with Salt's test conventions

### DIFF
--- a/salt/states/host.py
+++ b/salt/states/host.py
@@ -86,7 +86,7 @@ def present(name, ip, clean=False):  # pylint: disable=C0103
     '''
     ret = {'name': name,
            'changes': {},
-           'result': None if __opts__['test'] else True,
+           'result': True,
            'comment': ''}
 
     if not isinstance(ip, list):
@@ -135,6 +135,7 @@ def present(name, ip, clean=False):  # pylint: disable=C0103
 
     for addr, name in to_add:
         if __opts__['test']:
+            ret['result'] = None
             comments.append(
                 'Host {0} ({1}) would be added'.format(name, addr)
             )
@@ -149,6 +150,7 @@ def present(name, ip, clean=False):  # pylint: disable=C0103
 
     for addr, name in to_remove:
         if __opts__['test']:
+            ret['result'] = None
             comments.append(
                 'Host {0} ({1}) would be removed'.format(name, addr)
             )

--- a/tests/unit/states/test_host.py
+++ b/tests/unit/states/test_host.py
@@ -294,7 +294,6 @@ class HostTestCase(TestCase, LoaderModuleMockMixin):
             assert add_host.mock_calls == [], add_host.mock_calls
             assert rm_host.mock_calls == [], rm_host.mock_calls
 
-
     def test_host_present_should_return_True_if_test_and_no_changes(self):
         expected = {
             'comment': 'Host {} ({}) already present'.format(

--- a/tests/unit/states/test_host.py
+++ b/tests/unit/states/test_host.py
@@ -25,6 +25,19 @@ class HostTestCase(TestCase, LoaderModuleMockMixin):
     '''
     Validate the host state
     '''
+    hostname = 'salt'
+    localhost_ip = '127.0.0.1'
+    ip_list = ['203.0.113.113', '203.0.113.14']
+    default_hosts = {
+        ip_list[0]: [hostname],
+        ip_list[1]: [hostname],
+    }
+
+    def setUp(self):
+        self.add_host_mock = MagicMock(return_value=True)
+        self.rm_host_mock = MagicMock(return_value=True)
+        self.list_hosts_mock = MagicMock(return_value=self.default_hosts)
+
     def setup_loader_modules(self):
         return {
             host: {
@@ -280,6 +293,78 @@ class HostTestCase(TestCase, LoaderModuleMockMixin):
             assert ret['changes'] == {}, ret['changes']
             assert add_host.mock_calls == [], add_host.mock_calls
             assert rm_host.mock_calls == [], rm_host.mock_calls
+
+
+    def test_host_present_should_return_True_if_test_and_no_changes(self):
+        expected = {
+            'comment': 'Host {} ({}) already present'.format(
+                self.hostname,
+                self.ip_list[0],
+            ),
+            'changes': {},
+            'name': self.hostname,
+            'result': True,
+        }
+        list_hosts = MagicMock(
+            return_value={self.ip_list[0]: [self.hostname]},
+        )
+        with patch.dict(host.__salt__,
+                        {'hosts.list_hosts': list_hosts,
+                         'hosts.add_host': self.add_host_mock,
+                         'hosts.rm_host': self.rm_host_mock}):
+            with patch.dict(host.__opts__, {'test': True}):
+                ret = host.present(self.hostname, self.ip_list[:1])
+
+                self.assertDictEqual(ret, expected)
+
+    def test_host_present_should_return_None_if_test_and_adding(self):
+        expected = {
+            'comment': '\n'.join([
+                'Host {} ({}) already present',
+                'Host {} ({}) would be added',
+            ]).format(
+                self.hostname,
+                self.ip_list[0],
+                self.hostname,
+                self.ip_list[1],
+            ),
+            'changes': {'added': {self.ip_list[1]: [self.hostname]}},
+            'name': self.hostname,
+            'result': None,
+        }
+        list_hosts = MagicMock(
+            return_value={self.ip_list[0]: [self.hostname]},
+        )
+        with patch.dict(host.__salt__,
+                        {'hosts.list_hosts': list_hosts,
+                         'hosts.add_host': self.add_host_mock,
+                         'hosts.rm_host': self.rm_host_mock}):
+            with patch.dict(host.__opts__, {'test': True}):
+                ret = host.present(self.hostname, self.ip_list)
+                self.assertDictEqual(ret, expected)
+
+    def test_host_present_should_return_None_if_test_and_removing(self):
+        expected = {
+            'comment': '\n'.join([
+                'Host {} ({}) already present',
+                'Host {} ({}) would be removed',
+            ]).format(
+                self.hostname,
+                self.ip_list[0],
+                self.hostname,
+                self.ip_list[1],
+            ),
+            'changes': {'removed': {self.ip_list[1]: [self.hostname]}},
+            'name': self.hostname,
+            'result': None,
+        }
+        with patch.dict(host.__salt__,
+                        {'hosts.list_hosts': self.list_hosts_mock,
+                         'hosts.add_host': self.add_host_mock,
+                         'hosts.rm_host': self.rm_host_mock}):
+            with patch.dict(host.__opts__, {'test': True}):
+                ret = host.present(self.hostname, self.ip_list[:1], clean=True)
+                self.assertDictEqual(ret, expected)
 
     def test_absent(self):
         '''


### PR DESCRIPTION
Previously, when using `test=True`, `host.present` would return
`None` always. In Salt we return `True` when there are (or would be)
changes, `False` when there are no changes, and `None` when there
*would* have been changes.

This brings `host.present` in-line with that convention.

### What does this PR do?

Brings `host.present` in line with Salt's test convention, which fixes #52116.

### What issues does this PR fix or reference?

#52116 

### Previous Behavior

Previously, on `test=True`, the `hosts.present` state would *always* return `None`. [Salt's convention](https://docs.saltstack.com/en/latest/ref/states/testing.html) is to return `None` **instead** of making changes. We were returning `None` even when we had no changes to make, which would be confusing.

**User**: Okay salt, apply my hosts changes - but just test them!!
**Salt**: Okay! I would have made three changes!
**User**: Okay, cool. Go ahead and make those changes.
**Salt**: Uh... what changes?
**User**: Uhhhh... wat?

### New Behavior

Now we only return `None` if we *would* have made a change. Otherwise, it's True/False 🎉 

### Tests written?

Yes

### Commits signed with GPG?

Yes