### PR TITLE
Fix test conditions

### DIFF
--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -197,9 +197,12 @@ class SampleConfTest(TestCase):
         commented out. This test loops through all of the files in that directory to check
         for any lines that are not commented or blank.
         '''
-        cloud_sample_files = os.listdir(SAMPLE_CONF_DIR + 'cloud.profiles.d/')
+        cloud_sample_dir = SAMPLE_CONF_DIR + 'cloud.profiles.d/'
+        if not os.path.exists(cloud_sample_dir):
+            self.skipTest("Sample config directory '{}' is missing.".format(cloud_sample_dir))
+        cloud_sample_files = os.listdir(cloud_sample_dir)
         for conf_file in cloud_sample_files:
-            profile_conf = SAMPLE_CONF_DIR + 'cloud.profiles.d/' + conf_file
+            profile_conf = cloud_sample_dir + conf_file
             ret = salt.config._read_conf_file(profile_conf)
             self.assertEqual(
                 ret,
@@ -215,9 +218,12 @@ class SampleConfTest(TestCase):
         commented out. This test loops through all of the files in that directory to check
         for any lines that are not commented or blank.
         '''
-        cloud_sample_files = os.listdir(SAMPLE_CONF_DIR + 'cloud.providers.d/')
+        cloud_sample_dir = SAMPLE_CONF_DIR + 'cloud.providers.d/'
+        if not os.path.exists(cloud_sample_dir):
+            self.skipTest("Sample config directory '{}' is missing.".format(cloud_sample_dir))
+        cloud_sample_files = os.listdir(cloud_sample_dir)
         for conf_file in cloud_sample_files:
-            provider_conf = SAMPLE_CONF_DIR + 'cloud.providers.d/' + conf_file
+            provider_conf = cloud_sample_dir + conf_file
             ret = salt.config._read_conf_file(provider_conf)
             self.assertEqual(
                 ret,
@@ -233,9 +239,12 @@ class SampleConfTest(TestCase):
         commented out. This test loops through all of the files in that directory to check
         for any lines that are not commented or blank.
         '''
-        cloud_sample_files = os.listdir(SAMPLE_CONF_DIR + 'cloud.maps.d/')
+        cloud_sample_dir = SAMPLE_CONF_DIR + 'cloud.maps.d/'
+        if not os.path.exists(cloud_sample_dir):
+            self.skipTest("Sample config directory '{}' is missing.".format(cloud_sample_dir))
+        cloud_sample_files = os.listdir(cloud_sample_dir)
         for conf_file in cloud_sample_files:
-            map_conf = SAMPLE_CONF_DIR + 'cloud.maps.d/' + conf_file
+            map_conf = cloud_sample_dir + conf_file
             ret = salt.config._read_conf_file(map_conf)
             self.assertEqual(
                 ret,

--- a/tests/unit/utils/test_extend.py
+++ b/tests/unit/utils/test_extend.py
@@ -14,7 +14,7 @@ import shutil
 from datetime import date
 
 # Import Salt Testing libs
-from tests.support.unit import TestCase
+from tests.support.unit import TestCase, skipIf
 from tests.support.mock import MagicMock, patch
 
 # Import salt libs
@@ -35,6 +35,8 @@ class ExtendTestCase(TestCase):
                 shutil.rmtree(self.out, True)
         os.chdir(self.starting_dir)
 
+    @skipIf(not os.path.exists(os.path.join(integration.CODE_DIR, 'templates')),
+            "Test template directory 'templates/' missing.")
     def test_run(self):
         with patch('sys.exit', MagicMock):
             out = salt.utils.extend.run('test', 'test', 'this description', integration.CODE_DIR, False)


### PR DESCRIPTION
The release tarball does not contain `conf/cloud.profiles.d`, `conf/cloud.providers.d`, `conf/cloud.maps.d`, and the `templates` directory. Therefore the test cases will fail:

```
======================================================================
ERROR: test_conf_cloud_maps_d_files_are_commented (unit.test_config.SampleConfTest)
[CPU:0.0%|MEM:53.9%]
----------------------------------------------------------------------
Traceback (most recent call last):
  File "tests/unit/test_config.py", line 236, in test_conf_cloud_maps_d_files_are_commented
    cloud_sample_files = os.listdir(SAMPLE_CONF_DIR + 'cloud.maps.d/')
FileNotFoundError: [Errno 2] No such file or directory: 'conf/cloud.maps.d/'

======================================================================
ERROR: test_conf_cloud_profiles_d_files_are_commented (unit.test_config.SampleConfTest)
[CPU:0.0%|MEM:53.9%]
----------------------------------------------------------------------
Traceback (most recent call last):
  File "tests/unit/test_config.py", line 200, in test_conf_cloud_profiles_d_files_are_commented
    cloud_sample_files = os.listdir(SAMPLE_CONF_DIR + 'cloud.profiles.d/')
FileNotFoundError: [Errno 2] No such file or directory: 'conf/cloud.profiles.d/'

======================================================================
ERROR: test_conf_cloud_providers_d_files_are_commented (unit.test_config.SampleConfTest)
[CPU:0.0%|MEM:53.9%]
----------------------------------------------------------------------
Traceback (most recent call last):
  File "tests/unit/test_config.py", line 218, in test_conf_cloud_providers_d_files_are_commented
    cloud_sample_files = os.listdir(SAMPLE_CONF_DIR + 'cloud.providers.d/')
FileNotFoundError: [Errno 2] No such file or directory: 'conf/cloud.providers.d/'

======================================================================
ERROR: test_run (unit.utils.test_extend.ExtendTestCase)
[CPU:0.0%|MEM:53.9%]
----------------------------------------------------------------------
Traceback (most recent call last):
  File "tests/unit/utils/test_extend.py", line 40, in test_run
    out = salt.utils.extend.run('test', 'test', 'this description', integration.CODE_DIR, False)
  File "salt/utils/extend.py", line 242, in run
    MODULE_OPTIONS = _fetch_templates(os.path.join(salt_dir, 'templates'))
  File "salt/utils/extend.py", line 76, in _fetch_templates
    for item in os.listdir(src):
FileNotFoundError: [Errno 2] No such file or directory: ' templates'
```