### PR TITLE
zypperpkg: install and update knows about patterns

### DIFF
--- a/salt/modules/zypperpkg.py
+++ b/salt/modules/zypperpkg.py
@@ -726,7 +726,7 @@ def version_cmp(ver1, ver2, ignore_epoch=False):
     return __salt__['lowpkg.version_cmp'](ver1, ver2, ignore_epoch=ignore_epoch)
 
 
-def list_pkgs(versions_as_list=False, root=None, **kwargs):
+def list_pkgs(versions_as_list=False, root=None, includes=None, **kwargs):
     '''
     List the packages currently installed as a dict. By default, the dict
     contains versions as a comma separated string::
@@ -740,6 +740,10 @@ def list_pkgs(versions_as_list=False, root=None, **kwargs):
 
     root:
         operate on a different root directory.
+
+    includes:
+        List of types of packages to include (package, patch, pattern, product)
+        By default packages are always included
 
     attr:
         If a list of package attributes is specified, returned value will
@@ -777,6 +781,8 @@ def list_pkgs(versions_as_list=False, root=None, **kwargs):
     attr = kwargs.get('attr')
     if attr is not None:
         attr = salt.utils.args.split_input(attr)
+
+    includes = includes if includes else []
 
     contextkey = 'pkg.list_pkgs'
 
@@ -821,6 +827,28 @@ def list_pkgs(versions_as_list=False, root=None, **kwargs):
             if pkgname.startswith('gpg-pubkey'):
                 continue
             _ret[pkgname] = sorted(ret[pkgname], key=lambda d: d['version'])
+
+        for include in includes:
+            if include in ('pattern', 'patch'):
+                if include == 'pattern':
+                    pkgs = list_installed_patterns(root=root)
+                elif include == 'patch':
+                    pkgs = list_installed_patches(root=root)
+                else:
+                    pkgs = []
+                for pkg in pkgs:
+                    pkg_extended_name = '{}:{}'.format(include, pkg)
+                    info = info_available(pkg_extended_name,
+                                          refresh=False,
+                                          root=root)
+                    _ret[pkg_extended_name] = [{
+                        'epoch': None,
+                        'version': info[pkg]['version'],
+                        'release': None,
+                        'arch': info[pkg]['arch'],
+                        'install_date': None,
+                        'install_date_time_t': None,
+                    }]
 
         __context__[contextkey] = _ret
 
@@ -1242,6 +1270,12 @@ def refresh_db(root=None):
     return ret
 
 
+def _find_types(pkgs):
+    '''Form a package names list, find prefixes of packages types.'''
+    return sorted({pkg.split(':', 1)[0] for pkg in pkgs
+                   if len(pkg.split(':', 1)) == 2})
+
+
 def install(name=None,
             refresh=False,
             fromrepo=None,
@@ -1426,12 +1460,15 @@ def install(name=None,
             if advisory_id not in cur_patches:
                 raise CommandExecutionError('Advisory id "{0}" not found'.format(advisory_id))
             else:
-                targets.append(advisory_id)
+                targets.append('patch:{}'.format(advisory_id))
     else:
         targets = pkg_params
 
     diff_attr = kwargs.get("diff_attr")
-    old = list_pkgs(attr=diff_attr, root=root) if not downloadonly else list_downloaded(root)
+
+    includes = _find_types(targets)
+    old = list_pkgs(attr=diff_attr, root=root, includes=includes) if not downloadonly else list_downloaded(root)
+
     downgrades = []
     if fromrepo:
         fromrepoopt = ['--force', '--force-resolution', '--from', fromrepo]
@@ -1454,8 +1491,6 @@ def install(name=None,
         cmd_install.append('--no-recommends')
 
     errors = []
-    if pkg_type == 'advisory':
-        targets = ["patch:{0}".format(t) for t in targets]
 
     # Split the targets into batches of 500 packages each, so that
     # the maximal length of the command line is not broken
@@ -1474,8 +1509,13 @@ def install(name=None,
         __zypper__(no_repo_failure=ignore_repo_failure, root=root).call(*cmd)
 
     _clean_cache()
-    new = list_pkgs(attr=diff_attr, root=root) if not downloadonly else list_downloaded(root)
+    new = list_pkgs(attr=diff_attr, root=root, includes=includes) if not downloadonly else list_downloaded(root)
     ret = salt.utils.data.compare_dicts(old, new)
+
+    # If something else from packages are included in the search,
+    # better clean the cache.
+    if includes:
+        _clean_cache()
 
     if errors:
         raise CommandExecutionError(
@@ -1626,7 +1666,8 @@ def _uninstall(name=None, pkgs=None, root=None):
     except MinionError as exc:
         raise CommandExecutionError(exc)
 
-    old = list_pkgs(root=root)
+    includes = _find_types(pkg_params.keys())
+    old = list_pkgs(root=root, includes=includes)
     targets = []
     for target in pkg_params:
         # Check if package version set to be removed is actually installed:
@@ -1646,7 +1687,8 @@ def _uninstall(name=None, pkgs=None, root=None):
         targets = targets[500:]
 
     _clean_cache()
-    ret = salt.utils.data.compare_dicts(old, list_pkgs(root=root))
+    new = list_pkgs(root=root, includes=includes)
+    ret = salt.utils.data.compare_dicts(old, new)
 
     if errors:
         raise CommandExecutionError(

--- a/tests/unit/modules/test_zypperpkg.py
+++ b/tests/unit/modules/test_zypperpkg.py
@@ -855,7 +855,7 @@ Repository 'DUMMY' not found by its alias, number, or URI.
                     'pico': '0.1.1',
                 }
 
-            def __call__(self, root=None):
+            def __call__(self, root=None, includes=None):
                 pkgs = self._pkgs.copy()
                 for target in self._packages:
                     if self._pkgs.get(target):


### PR DESCRIPTION
In the openSUSE family we have several kind of packages, like
patterns, patches and products. Currently we can use the `pkg`
state and the `pkg` module to install them, but as they are not
listed under any `rpm` command, the module and the state will
report a Fail.

This patch updates the zypperpkg `list_pkgs` to explicitly include
this kind of objects under the list, so the rest of the commands
from the same execution module (install, update, etc) will report
the correct restul at the end.

Because the way that the `installed` state from `pkg` is designed,
we cannot be implicit about the kind of objects that we are
installing, so we need to indicate in the SLS that at least one
object is a pattern or a patch:

```yaml
  example:
    pkg.installed:
      - name: pattern:SUSE-MicroOS
      - includes: [pattern]
```

The `includes` parameter will be passed to the `list_pkgs` from
the zypper execution module, that will return the package list
using RPM (for packages) and zypper (for patterns). This more
complete report will be used in `pkg.installed` to identify the
correct installation of the new object.

Closes #52402
