### PR TITLE
virt.volume_infos fix for single VM

### DIFF
--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -5322,10 +5322,12 @@ def volume_infos(pool=None, volume=None, **kwargs):
     conn = __get_conn(**kwargs)
     try:
         backing_stores = _get_all_volumes_paths(conn)
+        domains = _get_domain(conn)
+        domains_list = domains if isinstance(domains, list) else [domains]
         disks = {domain.name():
                  {node.get('file') for node
                   in ElementTree.fromstring(domain.XMLDesc(0)).findall('.//disk/source/[@file]')}
-                 for domain in _get_domain(conn)}
+                 for domain in domains_list}
 
         def _volume_extract_infos(vol):
             '''

--- a/tests/unit/modules/test_virt.py
+++ b/tests/unit/modules/test_virt.py
@@ -2943,6 +2943,52 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
                 }
             })
 
+        # Single VM test
+        with patch('salt.modules.virt._get_domain', MagicMock(return_value=mock_vms[0])):
+            actual = virt.volume_infos('pool0', 'vol0')
+            self.assertEqual(1, len(actual.keys()))
+            self.assertEqual(1, len(actual['pool0'].keys()))
+            self.assertEqual(['vm0'], sorted(actual['pool0']['vol0']['used_by']))
+            self.assertEqual('/path/to/vol0.qcow2', actual['pool0']['vol0']['path'])
+            self.assertEqual('file', actual['pool0']['vol0']['type'])
+            self.assertEqual('/key/of/vol0', actual['pool0']['vol0']['key'])
+            self.assertEqual(123456789, actual['pool0']['vol0']['capacity'])
+            self.assertEqual(123456, actual['pool0']['vol0']['allocation'])
+
+            self.assertEqual(virt.volume_infos('pool1', None), {
+                'pool1': {
+                    'vol1': {
+                        'type': 'file',
+                        'key': '/key/of/vol1',
+                        'path': '/path/to/vol1.qcow2',
+                        'capacity': 12345,
+                        'allocation': 1234,
+                        'used_by': [],
+                    },
+                    'vol2': {
+                        'type': 'file',
+                        'key': '/key/of/vol2',
+                        'path': '/path/to/vol2.qcow2',
+                        'capacity': 12345,
+                        'allocation': 1234,
+                        'used_by': [],
+                    }
+                }
+            })
+
+            self.assertEqual(virt.volume_infos(None, 'vol2'), {
+                'pool1': {
+                    'vol2': {
+                        'type': 'file',
+                        'key': '/key/of/vol2',
+                        'path': '/path/to/vol2.qcow2',
+                        'capacity': 12345,
+                        'allocation': 1234,
+                        'used_by': [],
+                    }
+                }
+            })
+
     def test_volume_delete(self):
         '''
         Test virt.volume_delete


### PR DESCRIPTION
### What does this PR do?

_get_domain returns a domain object when only one VM has been found.
virt.volume_infos needs to take care of it or it will fail to list the
volumes informations if the host in such a case.

### What issues does this PR fix or reference?

None

### Previous Behavior

Call `virt.volume_infos` on a virtual host with only one VM defined. The call fails.

### New Behavior

Call `virt.volume_infos` on a virtual host with only one VM defined. The volumes info are listed.

### Tests written?

Yes

### Commits signed with GPG?

Yes