### PR TITLE
Update state.module docs

### DIFF
--- a/salt/states/module.py
+++ b/salt/states/module.py
@@ -13,6 +13,11 @@ Execution of Salt modules from within states
         use_superseded:
           - module.run
 
+.. note::
+
+    The old style of ``module.run`` will no longer be available in the Sodium
+    release.
+
 With `module.run` these states allow individual execution module calls to be
 made via states. To call a single module function use a
 :mod:`module.run <salt.states.module.run>` state:


### PR DESCRIPTION
I'm not sure if this should just go against develop, or if I should rebase and direct towards 2018.3.

### What does this PR do?

(Attempts) to clarify the module state docs. It wasn't immediately obvious from the docs that there was an old and new style, and the note about manually enabling them was all the way at the bottom.

### What issues does this PR fix or reference?

fixes #44882
fixes #51349
Maybe some others?

### Tests written?

No - doc only (but new examples were tested manually)

### Commits signed with GPG?

Yes