### PR TITLE
Remove unused salt.crypt import

### DIFF
--- a/salt/fileclient.py
+++ b/salt/fileclient.py
@@ -20,7 +20,6 @@ from salt.exceptions import (
     CommandExecutionError, MinionError
 )
 import salt.client
-import salt.crypt
 import salt.loader
 import salt.payload
 import salt.transport.client

--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -19,7 +19,6 @@ import inspect
 import salt.loader
 import salt.fileclient
 import salt.minion
-import salt.crypt
 import salt.transport.client
 import salt.utils.args
 import salt.utils.cache


### PR DESCRIPTION


### What does this PR do?

It removes unused salt.crypt import.

### Previous Behavior

This causes pepper to fail on windows because of missing libcrypto.

### New Behavior

Pepper does not fail anymore

### Tests written?

No

### Commits signed with GPG?

No


See also #51655 for similar salt.crypt removals
