### PR TITLE
beacons/network_settings.py: Wrong uses of variables

### DIFF
--- a/salt/beacons/network_settings.py
+++ b/salt/beacons/network_settings.py
@@ -163,17 +163,14 @@ def beacon(config):
         else:
             # No direct match, try with * wildcard regexp
             interface_regexp = interface.replace('*', '[0-9]+')
-            for interface in _stats:
-                match = re.search(interface_regexp, interface)
+            for _interface in _stats:
+                match = re.search(interface_regexp, _interface)
                 if match:
                     interfaces.append(match.group())
-                    expanded_config[match.group()] = config['interfaces'][interface]
+                    expanded_config[match.group()] = _config['interfaces'][interface]
 
     if expanded_config:
-        config.update(expanded_config)
-
-        # config updated so update _config
-        list(map(_config.update, config))
+        _config['interfaces'].update(expanded_config)
 
     log.debug('interfaces %s', interfaces)
     for interface in interfaces:


### PR DESCRIPTION
Variable 'interface' was used twice in same context with different
scopes and _config['interfaces'] should be updated, instead of _config,
with matched interfaces from expanded_config.

Signed-off-by: Alexandru Vasiu <alexandru.vasiu@ni.com>

### What does this PR do?
Fix network settings beacon.

### Previous Behavior
Beacon didn't work and didn't send any notification when some network settings were changed.

### New Behavior
Now the beacon works correctly. 

### Tests written?
No

### Commits signed with GPG?
No