### PR TITLE
fix spm local client failing to install modules

### DIFF
--- a/salt/spm/pkgfiles/local.py
+++ b/salt/spm/pkgfiles/local.py
@@ -136,7 +136,7 @@ def install_file(package, formula_tar, member, formula_def, conn=None):
     if member.name.startswith('{0}/_'.format(package)):
         if node_type in ('master', 'minion'):
             # Module files are distributed via extmods directory
-            member.name = new_name.name.replace('{0}/_'.format(package), '')
+            member.name = new_name.replace('{0}/_'.format(package), '')
             out_path = os.path.join(
                 salt.syspaths.CACHE_DIR,
                 node_type,
@@ -144,7 +144,7 @@ def install_file(package, formula_tar, member, formula_def, conn=None):
             )
         else:
             # Module files are distributed via _modules, _states, etc
-            member.name = new_name.name.replace('{0}/'.format(package), '')
+            member.name = new_name.replace('{0}/'.format(package), '')
     elif member.name == '{0}/pillar.example'.format(package):
         # Pillars are automatically put in the pillar_path
         member.name = '{0}.sls.orig'.format(package)


### PR DESCRIPTION
### What does this PR do?
fixes crash during handling of module installation during `spm local install` 

### What issues does this PR fix or reference?

### Previous Behavior
```
root@6361cc77debd:/data/spm/kubevault-sdb-formula# tar -tf /srv/spm_build/kubevault_sdb-20190406-1.spm
kubevault_sdb
kubevault_sdb/
kubevault_sdb/_sdb/
kubevault_sdb/_sdb/kubevault.py
kubevault_sdb/FORMULA

root@6361cc77debd:/data/spm/kubevault-sdb-formula# spm local install /srv/spm_build/kubevault_sdb-20190406-1.spm
Installing packages:
        kubevault_sdb

Proceed? [N/y] y
... installing kubevault_sdb
[ERROR   ] An un-handled exception was caught by salt's global exception handler:
AttributeError: 'str' object has no attribute 'name'
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/salt/spm/__init__.py", line 159, in _pkgfiles_fun
    return getattr(getattr(self.pkgfiles, self.files_prov), func)(*args, **kwargs)
  File "/usr/lib/python3/dist-packages/salt/spm/pkgfiles/local.py", line 147, in install_file
    member.name = new_name.name.replace('{0}/'.format(package), '')
AttributeError: 'str' object has no attribute 'name'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/bin/spm", line 12, in <module>
    salt_spm()
  File "/usr/lib/python3/dist-packages/salt/scripts.py", line 527, in salt_spm
    spm.run()
  File "/usr/lib/python3/dist-packages/salt/cli/spm.py", line 41, in run
    client.run(self.args)
  File "/usr/lib/python3/dist-packages/salt/spm/__init__.py", line 127, in run
    self._local(args)
  File "/usr/lib/python3/dist-packages/salt/spm/__init__.py", line 185, in _local
    self._local_install(args)
  File "/usr/lib/python3/dist-packages/salt/spm/__init__.py", line 389, in _local_install
    self._install(args)
  File "/usr/lib/python3/dist-packages/salt/spm/__init__.py", line 308, in _install
    self._install_indv_pkg(package, file_map[package])
  File "/usr/lib/python3/dist-packages/salt/spm/__init__.py", line 532, in _install_indv_pkg
    self.files_conn)
  File "/usr/lib/python3/dist-packages/salt/spm/__init__.py", line 161, in _pkgfiles_fun
    return self.pkgfiles['{0}.{1}'.format(self.files_prov, func)](*args, **kwargs)
  File "/usr/lib/python3/dist-packages/salt/spm/pkgfiles/local.py", line 147, in install_file
    member.name = new_name.name.replace('{0}/'.format(package), '')
AttributeError: 'str' object has no attribute 'name'
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/salt/spm/__init__.py", line 159, in _pkgfiles_fun
    return getattr(getattr(self.pkgfiles, self.files_prov), func)(*args, **kwargs)
  File "/usr/lib/python3/dist-packages/salt/spm/pkgfiles/local.py", line 147, in install_file
    member.name = new_name.name.replace('{0}/'.format(package), '')
AttributeError: 'str' object has no attribute 'name'
```

### New Behavior
`spm local install` completes successfully even when modules are included

### Tests written?

No

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
