### PR TITLE
Add lost fs suffix for hgfs virtualname

### DIFF
--- a/salt/fileserver/hgfs.py
+++ b/salt/fileserver/hgfs.py
@@ -76,7 +76,7 @@ from salt.utils.event import tagify
 log = logging.getLogger(__name__)
 
 # Define the module's virtual name
-__virtualname__ = 'hg'
+__virtualname__ = 'hgfs'
 
 
 def __virtual__():


### PR DESCRIPTION
Commit 2d6760ee408d ("Add update_interval to gitfs, "fs" to several virtual names")
says that it adds "fs" to all of the fileserver virtualnames which did not already have them.
However, hgfs still has not "fs" in its virtualname

### What does this PR do?

This PR fixes 2d6760ee408dead28476a6baf1bd6cb6fb1cac9c

### What issues does this PR fix or reference?

### Tests written?

No

### Commits signed with GPG?

Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
