### PR TITLE
convert get to traverse_dict_and_list

### DIFF
--- a/salt/modules/saltcheck.py
+++ b/salt/modules/saltcheck.py
@@ -201,6 +201,7 @@ from salt.utils.json import loads, dumps
 import salt.utils.files
 import salt.utils.path
 import salt.utils.yaml
+import salt.utils.data
 import salt.client
 import salt.exceptions
 from salt.utils.odict import OrderedDict
@@ -540,7 +541,9 @@ class SaltCheck(object):
         except Exception:
             raise
         if isinstance(value, dict) and assertion_section:
-            return value.get(assertion_section, False)
+            return salt.utils.data.traverse_dict_and_list(value,
+                                                          assertion_section,
+                                                          default=False)
         else:
             return value
 


### PR DESCRIPTION
### What does this PR do?
Replaces value.get with call to traverse_dict_and_list to support list and deeper getting
Also only copy tst files from saltmaster, rather than run `cp.cache_master` on each invocation

### Previous Behavior
saltcheck was only able to process a single depth dict in assertion_section 
`cp.cache_master` always run

### New Behavior
saltcheck's assertion_section can now traverse dicts and lists
`cp.cache_files` run for all *.tst files

### Tests written?
No

### Commits signed with GPG?
No