### PR TITLE
Fix binary file.managed with binary data from contents_pillar

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -2700,7 +2700,7 @@ def managed(name,
                 'to True to allow the managed file to be empty.'
                 .format(contents_id)
             )
-        if isinstance(use_contents, six.binary_type) and b'\0' in use_contents:
+        if isinstance(use_contents, six.binary_type) in use_contents:
             contents = use_contents
         elif isinstance(use_contents, six.text_type) and str('\0') in use_contents:
             contents = use_contents


### PR DESCRIPTION
### What does this PR do?

This PR ensures that binary data retrieved from a `contents_pillar` (or `contents_grain` for this matter) is used as-is, instead of trying to convert it to a string.

For example, take a pillar file with the following contents:

```
mytest: !!binary |
          tJePBLCw2Wimhc3uk+fnM/ROjRxrH5+gClDTJbes0J0=
```

This data can be references from `file.managed` like this:

```
/my/test/file:
  file.managed:
    - contents_pillar: mytest
```

With this change, the data will be treated as binary, even though it does not contain a null-byte.

Before making this change, I did some research: Before 5741d287b5da5c0eb5debb43079d48cb5f8d0ebe, the code used `salt.utils.stringutils.is_binary`, which used a heuristic to determine whether the data was binary (it was considered binary if it contained a null byte or at least 30% of its bytes represented bytes that are not printable ASCII characters).  5741d287b5da5c0eb5debb43079d48cb5f8d0ebe changes this to only check for a null-byte, but this change did not correctly deal with the case when the data was not a Python string, but a binary Python object. This was further improved with e4182715be8cbe7952ec83be47a52cc3f35936bd and 2a521586db1ab6395c74327d92cdae2d9e09bf08 which added special handling for the case where the Python object is not a string.

However, I think that in these cases, it does not even make sense to check for the null-byte: If someone uses a binary type inside the pillar tree, this is usually done for a good reason. In my case, for example, I use it for a binary, cryptographic key which - for obvious reasons - must be copied verbatim, without doing any conversions which might modify even a single byte. In most other cases, one will use a string type in pillar and thus the regular null-byte check will apply.

### Previous Behavior

Binary data would only be treated as binary if it contained a null-byte.

### New Behavior

Binary data is always treated as binary, regardless of whether it contains a null byte.

### Tests written?

No

### Commits signed with GPG?

No

