### PR TITLE
Introduce presence ping timeout parameters for sync batch

### DIFF
--- a/salt/cli/batch.py
+++ b/salt/cli/batch.py
@@ -83,6 +83,9 @@ def batch_get_opts(
         if key not in opts:
             opts[key] = val
 
+    opts['batch_presence_ping_timeout'] = kwargs.get('batch_presence_ping_timeout', opts['timeout'])
+    opts['batch_presence_ping_gather_job_timeout'] = kwargs.get('batch_presence_ping_gather_job_timeout', opts['gather_job_timeout'])
+
     return opts
 
 
@@ -119,7 +122,7 @@ class Batch(object):
         args = [self.opts['tgt'],
                 'test.ping',
                 [],
-                self.opts['timeout'],
+                self.opts.get('batch_presence_ping_timeout', self.opts['timeout']),
                 ]
 
         selected_target_option = self.opts.get('selected_target_option', None)
@@ -130,7 +133,7 @@ class Batch(object):
 
         self.pub_kwargs['yield_pub_data'] = True
         ping_gen = self.local.cmd_iter(*args,
-                                       gather_job_timeout=self.opts['gather_job_timeout'],
+                                       gather_job_timeout=self.opts.get('batch_presence_ping_gather_job_timeout', self.opts['gather_job_timeout']),
                                        **self.pub_kwargs)
 
         # Broadcast to targets

--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -536,37 +536,6 @@ class LocalClient(object):
 
         eauth = salt.cli.batch.batch_get_eauth(kwargs)
 
-        arg = salt.utils.args.parse_input(arg, kwargs=kwarg)
-        opts = {'tgt': tgt,
-                'fun': fun,
-                'arg': arg,
-                'tgt_type': tgt_type,
-                'ret': ret,
-                'batch': batch,
-                'failhard': kwargs.get('failhard', False),
-                'raw': kwargs.get('raw', False)}
-
-        if 'timeout' in kwargs:
-            opts['timeout'] = kwargs['timeout']
-        if 'gather_job_timeout' in kwargs:
-            opts['gather_job_timeout'] = kwargs['gather_job_timeout']
-        if 'batch_wait' in kwargs:
-            opts['batch_wait'] = int(kwargs['batch_wait'])
-
-        eauth = {}
-        if 'eauth' in kwargs:
-            eauth['eauth'] = kwargs.pop('eauth')
-        if 'username' in kwargs:
-            eauth['username'] = kwargs.pop('username')
-        if 'password' in kwargs:
-            eauth['password'] = kwargs.pop('password')
-        if 'token' in kwargs:
-            eauth['token'] = kwargs.pop('token')
-
-        for key, val in six.iteritems(self.opts):
-            if key not in opts:
-                opts[key] = val
-
         batch = salt.cli.batch.Batch(opts, eauth=eauth, quiet=True)
         for ret in batch.run():
             yield ret


### PR DESCRIPTION
### What does this PR do?
- Introduce "batch_presence_ping_timeout" and "batch_presence_ping_gather_job_timeout" parameters for synchronous batching mode.
If this parameters are not sent, the "timeout" and "gather_job_timeout" are used as default instead.
- Remove duplicate code for initializing opts values

### What issues does this PR fix or reference?

### Previous Behavior
Before, "timeout" and "gather_job_tmeout" parameters were used for the presence ping in synchronous batching mode.

### New Behavior
presence ping in synchronous batching mode uses "timeout" and "gather_job_tmeout" parameters as default values, but can be overridden in the request with  "batch_presence_ping_timeout" and "batch_presence_ping_gather_job_timeout".

### Tests written?
No 

### Commits signed with GPG?

Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
