### PR TITLE
Simplify IPCClient and prevent corrupt messages

### DIFF
--- a/salt/transport/ipc.py
+++ b/salt/transport/ipc.py
@@ -9,6 +9,7 @@ import logging
 import socket
 import weakref
 import time
+import sys
 
 # Import 3rd-party libs
 import msgpack
@@ -81,6 +82,11 @@ class FutureWithTimeout(tornado.concurrent.Future):
             self.set_result(future.result())
         except Exception as exc:
             self.set_exception(exc)
+
+
+class IPCExceptionProxy(object):
+    def __init__(self, orig_info):
+        self.orig_info = orig_info
 
 
 class IPCServer(object):
@@ -648,6 +654,7 @@ class IPCMessageSubscriberService(IPCClient):
                 break
             except Exception as exc:
                 log.error('Exception occurred in Subscriber while handling stream: %s', exc)
+                exc = IPCExceptionProxy(sys.exc_info())
                 self._feed_subscribers([exc])
                 break
 
@@ -755,12 +762,18 @@ class IPCMessageSubscriber(object):
                 raise tornado.gen.Return(None)
             if data is None:
                 break
-            elif isinstance(data, Exception):
-                raise data
+            elif isinstance(data, IPCExceptionProxy):
+                self.reraise(data.orig_info)
             elif callback:
                 self.service.io_loop.spawn_callback(callback, data)
             else:
                 raise tornado.gen.Return(data)
+
+    def reraise(self, exc_info):
+        if six.PY2:
+            raise exc_info[0], exc_info[1], exc_info[2]
+        else:
+            raise exc_info[0].with_traceback(exc_info[1], exc_info[2])
 
     def read_sync(self, timeout=None):
         '''

--- a/salt/transport/ipc.py
+++ b/salt/transport/ipc.py
@@ -5,6 +5,7 @@ IPC transport classes
 
 # Import Python libs
 from __future__ import absolute_import, print_function, unicode_literals
+import errno
 import logging
 import socket
 import weakref
@@ -742,7 +743,7 @@ class IPCMessageSubscriber(object):
 
     def reraise(self, exc_info):
         if six.PY2:
-            raise exc_info[0], exc_info[1], exc_info[2]
+            raise exc_info[0], exc_info[1], exc_info[2]  # pylint: disable=W1699
         else:
             raise exc_info[0].with_traceback(exc_info[1], exc_info[2])
 

--- a/salt/transport/ipc.py
+++ b/salt/transport/ipc.py
@@ -733,17 +733,11 @@ class IPCMessageSubscriber(object):
             if data is None:
                 break
             elif isinstance(data, IPCExceptionProxy):
-                self.reraise(data.orig_info)
+                six.reraise(*data.orig_info)
             elif callback:
                 self.service.io_loop.spawn_callback(callback, data)
             else:
                 raise tornado.gen.Return(data)
-
-    def reraise(self, exc_info):
-        if six.PY2:
-            raise exc_info[0], exc_info[1], exc_info[2]  # pylint: disable=W1699
-        else:
-            raise exc_info[0].with_traceback(exc_info[1], exc_info[2])
 
     def read_sync(self, timeout=None):
         '''

--- a/salt/transport/ipc.py
+++ b/salt/transport/ipc.py
@@ -311,9 +311,8 @@ class IPCClient(object):
             if self.stream is None:
                 with salt.utils.asynchronous.current_ioloop(self.io_loop):
                     self.stream = IOStream(
-                        socket.socket(sock_type, socket.SOCK_STREAM),
+                        socket.socket(sock_type, socket.SOCK_STREAM)
                     )
-
             try:
                 log.trace('IPCClient: Connecting to socket: %s', self.socket_path)
                 yield self.stream.connect(sock_addr)
@@ -659,8 +658,7 @@ class IPCMessageSubscriberService(IPCClient):
         Sockets and filehandles should be closed explicitly, to prevent
         leaks.
         '''
-        if not self._closing:
-            super(IPCMessageSubscriberService, self).close()
+        super(IPCMessageSubscriberService, self).close()
 
     def __del__(self):
         if IPCMessageSubscriberService in globals():
@@ -760,6 +758,7 @@ class IPCMessageSubscriber(object):
 
     def close(self):
         self.service.unsubscribe(self)
+        self.service.close()
 
     def __del__(self):
         self.close()

--- a/tests/unit/transport/test_ipc.py
+++ b/tests/unit/transport/test_ipc.py
@@ -86,13 +86,14 @@ class IPCMessageClient(BaseIPCReqCase):
     '''
 
     def _get_channel(self):
-        channel = salt.transport.ipc.IPCMessageClient(
-            socket_path=self.socket_path,
-            io_loop=self.io_loop,
-        )
-        channel.connect(callback=self.stop)
-        self.wait()
-        return channel
+        if not hasattr(self, 'channel') or self.channel is None:
+            self.channel = salt.transport.ipc.IPCMessageClient(
+                socket_path=self.socket_path,
+                io_loop=self.io_loop,
+            )
+            self.channel.connect(callback=self.stop)
+            self.wait()
+        return self.channel
 
     def setUp(self):
         super(IPCMessageClient, self).setUp()
@@ -106,6 +107,8 @@ class IPCMessageClient(BaseIPCReqCase):
             if exc.errno != errno.EBADF:
                 # If its not a bad file descriptor error, raise
                 raise
+        finally:
+            self.channel = None
 
     def test_basic_send(self):
         msg = {'foo': 'bar', 'stop': True}


### PR DESCRIPTION
### What does this PR do?

- Re-raise queued exceptions with their original traceback
- Removes singleton from IPCClient and prevents corrupt message passing

### What issues does this PR fix or reference?

- Fixes many failing and flaky tests

### Previous Behavior

We tried to share a single IPCClient across the entire codebase resulting in send calls stomping on each other and creating corrupted messages.

### New Behavior

Allow IPCClient to be regular instances

### Tests written?

No - Fixing existing tests

[Full py2 test suite](https://jenkinsci.saltstack.com/job/salt-centos-7-py2-dwoz/)
[Full py3 test suite](https://jenkinsci.saltstack.com/job/salt-centos-7-py3-dwoz/)

### Commits signed with GPG?

Yes

