### PR TITLE
Restore pchanges in highstate outputter

### DIFF
--- a/salt/output/highstate.py
+++ b/salt/output/highstate.py
@@ -259,6 +259,8 @@ def _format_host(host, data, indent_level=1):
                 nchanges += 1
             else:
                 schanged, ctext = _format_changes(ret['changes'])
+                if not ctext and 'pchanges' in ret:
+                    schanged, ctext = _format_changes(ret['pchanges'])
                 nchanges += 1 if schanged else 0
 
             # Skip this state if it was successful & diff output was requested


### PR DESCRIPTION
This was added as part of #44353,
but seems to have mistakenly been removed in #46022.
Restoring this fixes showing file diffs in `test=True` mode,
as well as other states that use pchanges correctly in test=True mode.

Fixes #51932.

### What does this PR do?

(Re)fixes showing diffs in test=True mode by including pchanges in the highstate ouputter.

### What issues does this PR fix or reference?

See above.

### Previous Behavior

In test=True mode, `Changes: `  would always be empty.

### New Behavior

`Changes:` shows pchanges now.

### Tests written?

No

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
