### PR TITLE
Add noop feature to chocolatey upgrade exec and state modules

### DIFF
--- a/salt/modules/chocolatey.py
+++ b/salt/modules/chocolatey.py
@@ -752,7 +752,8 @@ def upgrade(name,
             install_args=None,
             override_args=False,
             force_x86=False,
-            package_args=None):
+            package_args=None,
+            noop=False):
     '''
     .. versionadded:: 2016.3.4
 
@@ -799,6 +800,10 @@ def upgrade(name,
         package_args
             A list of arguments you want to pass to the package
 
+        noop (bool)
+            Report if the package would be upgraded by chocolatey without
+            actually upgrading it
+
     Returns:
         str: Results of the ``chocolatey`` command
 
@@ -828,6 +833,8 @@ def upgrade(name,
         cmd.append('--forcex86')
     if package_args:
         cmd.extend(['--packageparameters', package_args])
+    if noop:
+        cmd.append('--noop')
 
     # Salt doesn't need to see the progress
     cmd.extend(_no_progress(__context__))

--- a/salt/modules/chocolatey.py
+++ b/salt/modules/chocolatey.py
@@ -756,8 +756,12 @@ def upgrade(name,
     '''
     .. versionadded:: 2016.3.4
 
-    Instructs Chocolatey to upgrade packages on the system. (update is being
-    deprecated). This command will install the package if not installed.
+    Instructs Chocolatey to upgrade packages on the system.  This command will
+    install the package if not installed.
+
+    .. note::
+        The ``update`` command is being deprecated by chocolatey in favor of
+        ``upgrade``.
 
     Args:
 
@@ -842,6 +846,10 @@ def upgrade(name,
 def update(name, source=None, pre_versions=False):
     '''
     Instructs Chocolatey to update packages on the system.
+
+    .. warning::
+        The ``update`` command is being deprecated by chocolatey in favor of
+        ``upgrade``.
 
     name
         The name of the package to update, or "all" to update everything

--- a/salt/states/chocolatey.py
+++ b/salt/states/chocolatey.py
@@ -412,9 +412,21 @@ def upgraded(name,
     if not ret['changes']:
         return ret
 
-    # Return if running in test mode
+    # Return comment if changes can be made
     if __opts__['test']:
         ret['result'] = None
+        result = __salt__['chocolatey.upgrade'](name=name,
+                                                version=version,
+                                                source=source,
+                                                force=force,
+                                                pre_versions=pre_versions,
+                                                install_args=install_args,
+                                                override_args=override_args,
+                                                force_x86=force_x86,
+                                                package_args=package_args,
+                                                noop=True)
+        if 'can upgrade:' in result.lower():
+            ret['comment'] = 'Package {0} is set to be upgraded'.format(name)
         return ret
 
     # Install the package


### PR DESCRIPTION
### What does this PR do?

Add `--noop` option to chocolatey upgrade commands through salt.

### What issues does this PR fix or reference?

`None`

### Tests written?

No

### Commits signed with GPG?

No