### PR TITLE
Backport #49437 into 2018.3

### DIFF
--- a/salt/modules/opkg.py
+++ b/salt/modules/opkg.py
@@ -1154,6 +1154,7 @@ def del_repo(alias, **kwargs):  # pylint: disable=unused-argument
 
         salt '*' pkg.del_repo alias
     '''
+    refresh = salt.utils.data.is_true(kwargs.get('refresh', True))
     repos = list_repos()
     if repos:
         deleted_from = dict()
@@ -1179,8 +1180,8 @@ def del_repo(alias, **kwargs):  # pylint: disable=unused-argument
                     except OSError:
                         pass
                 ret += msg.format(alias, repo_file)
-            # explicit refresh after a repo is deleted
-            refresh_db()
+            if refresh:
+                refresh_db()
             return ret
 
     return "Repo {0} doesn't exist in the opkg repo lists".format(alias)

--- a/salt/modules/opkg.py
+++ b/salt/modules/opkg.py
@@ -1179,7 +1179,7 @@ def del_repo(repo, **kwargs):  # pylint: disable=unused-argument
                         os.remove(repo_file)
                     except OSError:
                         pass
-                ret += msg.format(alias, repo_file)
+                ret += msg.format(repo, repo_file)
             if refresh:
                 refresh_db()
             return ret


### PR DESCRIPTION
Backport #49437 into 2018.3