### PR TITLE
encoding is deprecated; fixes #51741

### DIFF
--- a/salt/payload.py
+++ b/salt/payload.py
@@ -146,7 +146,7 @@ class Serial(object):
                 # that under Python 2 we can still work with older versions
                 # of msgpack.
                 try:
-                    ret = msgpack.loads(msg, use_list=True, ext_hook=ext_type_decoder, encoding=encoding)
+                    ret = msgpack.loads(msg, use_list=True, ext_hook=ext_type_decoder, raw=False)
                 except UnicodeDecodeError:
                     # msg contains binary data
                     ret = msgpack.loads(msg, use_list=True, ext_hook=ext_type_decoder)

--- a/salt/transport/ipc.py
+++ b/salt/transport/ipc.py
@@ -167,11 +167,7 @@ class IPCServer(object):
                 return return_message
             else:
                 return _null
-        if six.PY2:
-            encoding = None
-        else:
-            encoding = 'utf-8'
-        unpacker = msgpack.Unpacker(encoding=encoding)
+        unpacker = msgpack.Unpacker(raw=False)
         while not stream.closed():
             try:
                 wire_bytes = yield stream.read_bytes(4096, partial=True)
@@ -286,11 +282,7 @@ class IPCClient(object):
         self.socket_path = socket_path
         self._closing = False
         self.stream = None
-        if six.PY2:
-            encoding = None
-        else:
-            encoding = 'utf-8'
-        self.unpacker = msgpack.Unpacker(encoding=encoding)
+        self.unpacker = msgpack.Unpacker(raw=False)
 
     def __init__(self, socket_path, io_loop=None):
         # Handled by singleton __new__


### PR DESCRIPTION
### What does this PR do?

It replaces `encoding=encoding` with `raw=False` when using msgpack.

### What issues does this PR fix or reference?

It fixes the deprecation warning discussed in #51741.

### Previous Behavior

```
% salt 'example.test' test.ping                                 
[WARNING ] /usr/local/lib/python3.6/site-packages/salt/transport/ipc.py:292: DeprecationWarning: encoding is deprecated, Use raw=False instead.
  self.unpacker = msgpack.Unpacker(encoding=encoding)

[WARNING ] /usr/local/lib/python3.6/site-packages/salt/payload.py:149: DeprecationWarning: encoding is deprecated, Use raw=False instead.
  ret = msgpack.loads(msg, use_list=True, ext_hook=ext_type_decoder, encoding=encoding)

example.test:
    True
```

### New Behavior

```
% salt 'example.test' test.ping                                 
example.test:
    True
```


### Tests written?

No (Tried to run the tests, but failed.)

### Commits signed with GPG?

No