### PR TITLE
Update CodeClimate settings

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,13 +1,21 @@
-languages:
-  Ruby: false
-  JavaScript: false
-  Python: true
-  PHP: false
+version: "2"
 
-engines:
+exclude_patterns:
+  - "*.js"
+  - "*.rb"
+  - "*.php"
+
+plugins:
   radon:
     enabled: true
-    exclude_paths:
+    exclude_patterns:
       - "templates/"
     config:
       threshold: "D"
+
+checks:
+  argument-count:
+    enabled: false
+  similar-code:
+    config:
+      threshold: 40

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -16,6 +16,8 @@ plugins:
 checks:
   argument-count:
     enabled: false
+  file-lines:
+    enabled: false
   similar-code:
     config:
       threshold: 40


### PR DESCRIPTION
I'm pretty sure this is the right place to merge this to - it should go to 2019.2 and develop as well.

This tweaks the settings for code climate.
https://codeclimate.com/github/saltstack/salt/pull/51461 had a matching
block with mass of 38. Apparently that's too low because that code was
not even the same at all. Bumping it up a bit to avoid false positives.

Also disable argument count checks.