### PR TITLE
Data filter falsey

### DIFF
--- a/salt/utils/data.py
+++ b/salt/utils/data.py
@@ -1008,6 +1008,8 @@ def filter_falsey(data, recurse_depth=None, ignore_types=None):
         be filtered. Default: Only booleans are not filtered.
 
     :return type(data)
+
+    .. version-added:: Neon
     '''
     if ignore_types is None:
         ignore_types = []

--- a/salt/utils/data.py
+++ b/salt/utils/data.py
@@ -1039,7 +1039,7 @@ def filter_falsey(data, recurse_depth=None, ignore_types=()):
             for key, value in processed_elements
             if _is_not_considered_falsey(value, ignore_types=ignore_types)
         ])
-    elif hasattr(data, '__iter__'):
+    elif hasattr(data, '__iter__') and not isinstance(data, six.string_types):
         processed_elements = (filter_element(value) for value in data)
         return type(data)([
             value for value in processed_elements


### PR DESCRIPTION
### What does this PR do?
This adds a function `filter_falsey` to `salt.utils.data`. The function can be used to filter values from a list or dict that evaluate to false (but are not `bool(False)`). Optionally, a level of recursion can be set to process nested dicts/lists. Also optionally, a list of types to not filter can be passed in `ignore_types`.

### What issues does this PR fix or reference?
None that I know of.

### Previous Behavior
The functionality does not exist.

### New Behavior
We are now able to filter falsey values from dicts or lists.
This is especially handy when having to process a lot of kwargs that are explicitly specified in the function argument list, which default to `None`, but need not be passed on if they are None.
For example:
```
def some_function(foo=None, bar=None, baz=None):
    new_kwargs = {}
    if foo is not None:
        new_kwargs.update('Foo': foo)
    if bar is not None:
        new_kwargs.update('Bar': bar)
    if baz is not None:
        new_kwargs.update('Baz': baz)
    some_other_function(**new_kwargs)
```
will become
```
def some_function(foo=None, bar=None, baz=None):
    new_kwargs = salt.utils.data.filter_falsey({
        'Foo': foo,
        'Bar': bar,
        'Baz': baz,
    })
    some_other_function(**new_kwargs)
```
Which is a typical use-case for most Boto calls.

### Tests written?
Yes

### Commits signed with GPG?
Yes