### PR TITLE
Fix traceback when invalid source passed to archive.extracted

### DIFF
--- a/salt/states/archive.py
+++ b/salt/states/archive.py
@@ -777,6 +777,11 @@ def extracted(name,
         ret['comment'] = exc.strerror
         return ret
 
+    if not source_match:
+        ret['result'] = False
+        ret['comment'] = 'Invalid source "{0}"'.format(source)
+        return ret
+
     urlparsed_source = _urlparse(source_match)
     urlparsed_scheme = urlparsed_source.scheme
     urlparsed_path = os.path.join(


### PR DESCRIPTION
When the source is procedurally generated (e.g. from the result of a
remote execution function call), and that source ends up being an empty
string or some other invalid value, the call to `file.source_list` will
return a path of `None` which will cause a `TypeError` later on when we
try to run a urlparse on it.