### PR TITLE
2019.2: transport.zmq: fix bug introduced by b7df7e75cf2

### DIFF
--- a/tests/unit/transport/test_zeromq.py
+++ b/tests/unit/transport/test_zeromq.py
@@ -145,6 +145,17 @@ class ClearReqTestCases(BaseZMQReqCase, ReqChannelMixin):
         '''
         raise tornado.gen.Return((payload, {'fun': 'send_clear'}))
 
+    def test_master_uri_override(self):
+        '''
+        ensure master_uri kwarg is respected
+        '''
+        # minion_config should be 127.0.0.1, we want a different uri that still connects
+        uri = 'tcp://{master_ip}:{master_port}'.format(master_ip='localhost', master_port=self.minion_config['master_port'])
+
+        channel = salt.transport.Channel.factory(self.minion_config, master_uri=uri)
+        self.assertIn('localhost', channel.master_uri)
+        del channel
+
 
 @flaky
 @skipIf(ON_SUSE, 'Skipping until https://github.com/saltstack/salt/issues/32902 gets fixed')


### PR DESCRIPTION
What does this PR do?
this change was introduced to address evidently another bug where
somehow self.opts has no master_uri - but in the process it prioritized
using master_ip over master_uri even when master_uri is there.
providing master_uri as a way of specifiying which msater you would like
to create a channel for is documented used elsewhere in the codebase in
multi-master scenarios (ie, event.send, saltutil.revoke_auth)

Previous Behavior
event.send/saltutil.revoke_auth, anywhere else relying on master_uri doing the right thing are broken on 2018 on

New Behavior
master_uri kwarg respected again

Tests written?
yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
