### PR TITLE
[2017.7.9] Fix supervisord

### DIFF
--- a/salt/modules/supervisord.py
+++ b/salt/modules/supervisord.py
@@ -63,10 +63,12 @@ def _ctl_cmd(cmd, name, conf_file, bin_env):
 
 
 def _get_return(ret):
-    if ret['retcode'] == 0:
-        return ret['stdout']
-    else:
-        return ''
+    retmsg = ret['stdout']
+    if ret['retcode'] != 0:
+        # This is a non 0 exit code
+        if 'ERROR' not in retmsg:
+            retmsg = 'ERROR: {}'.format(retmsg)
+    return retmsg
 
 
 def start(name='all', user=None, conf_file=None, bin_env=None):


### PR DESCRIPTION
### What does this PR do?
Prefix any output with ERROR on non 0 exit code because that's what the supervisord state checks for.

### What issues does this PR fix or reference?
#52462

### Previous Behavior
Exit code wasn't checked and no output returned on failure making the state return assume it was all good.

### New Behavior
Provide the output and prefix it with `ERROR` in case of non 0 exit code

### Tests written?

No - They already exist

### Commits signed with GPG?

Yes