### PR TITLE
[2018.3] Fix supervisord

### DIFF
--- a/salt/modules/supervisord.py
+++ b/salt/modules/supervisord.py
@@ -63,10 +63,12 @@ def _ctl_cmd(cmd, name, conf_file, bin_env):
 
 
 def _get_return(ret):
-    if ret['retcode'] == 0:
-        return ret['stdout']
-    else:
-        return ''
+    retmsg = ret['stdout']
+    if ret['retcode'] != 0:
+        # This is a non 0 exit code
+        if 'ERROR' not in retmsg:
+            retmsg = 'ERROR: {}'.format(retmsg)
+    return retmsg
 
 
 def start(name='all', user=None, conf_file=None, bin_env=None):


### PR DESCRIPTION
Prefix any output with ERROR on non 0 exit code because that's what the
supervisord state checks for.

### What does this PR do?

Cherry-pick supervisord test fix from 2017.7

#52462

### Tests written?

No - Fixing existing tests

### Commits signed with GPG?

Yes