### PR TITLE
Add missing bits to batch async jobs

### DIFF
--- a/salt/cli/batch_async.py
+++ b/salt/cli/batch_async.py
@@ -222,6 +222,7 @@ class BatchAsync(object):
                 ret=self.opts.get('return', ''),
                 gather_job_timeout=self.opts['gather_job_timeout'],
                 jid=self.batch_jid,
-                metadata=self.metadata)
+                metadata=self.metadata,
+                **self.eauth)
             self.event.io_loop.call_later(self.opts['timeout'], self.find_job, set(next_batch))
             self.active = self.active.union(next_batch)

--- a/salt/master.py
+++ b/salt/master.py
@@ -2036,7 +2036,7 @@ class ClearFuncs(object):
             return False
         return self.loadauth.get_tok(clear_load['token'])
 
-    def publish_batch(self, clear_load, minions, missing):
+    def publish_batch(self, clear_load, extra, minions, missing):
         batch_load = {}
         batch_load.update(clear_load)
         import salt.cli.batch_async
@@ -2046,6 +2046,9 @@ class ClearFuncs(object):
             batch_load
         )
         ioloop = tornado.ioloop.IOLoop.current()
+
+        self._prep_pub(minions, batch.batch_jid, clear_load, extra, missing)
+
         ioloop.add_callback(batch.start)
 
         return {
@@ -2149,7 +2152,7 @@ class ClearFuncs(object):
                     }
                 }
         if extra.get('batch', None):
-            return self.publish_batch(clear_load, minions, missing)
+            return self.publish_batch(clear_load, extra, minions, missing)
 
         jid = self._prep_jid(clear_load, extra)
         if jid is None:

--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -889,7 +889,7 @@ class SaltEvent(object):
         self.subscriber.callbacks.add(event_handler)
         if not self.subscriber.reading:
             # This will handle reconnects
-            self.subscriber.read_async()
+            return self.subscriber.read_async()
 
     def __del__(self):
         # skip exceptions in destroy-- since destroy() doesn't cover interpreter

--- a/tests/unit/cli/test_batch_async.py
+++ b/tests/unit/cli/test_batch_async.py
@@ -151,6 +151,8 @@ class AsyncBatchTestCase(AsyncTestCase, TestCase):
         future = tornado.gen.Future()
         future.set_result({'minions': ['foo', 'bar']})
         self.batch.local.run_job_async.return_value = future
+        self.batch.eauth = {'username': 'user#1', 'password': 'pass'}
+        self.batch.metadata = {'mykey': 'myvalue'}
         ret = self.batch.schedule_next().result()
         self.assertEqual(
             self.batch.local.run_job_async.call_args[0],
@@ -159,6 +161,18 @@ class AsyncBatchTestCase(AsyncTestCase, TestCase):
         self.assertEqual(
             self.batch.event.io_loop.call_later.call_args[0],
             (self.batch.opts['timeout'], self.batch.find_job, {'foo', 'bar'})
+        )
+        self.assertEqual(
+            self.batch.local.run_job_async.call_args[1],
+            {
+                'username': 'user#1',
+                'password': 'pass',
+                'jid': self.batch.batch_jid,
+                'ret': u'',
+                'gather_job_timeout': self.batch.opts['gather_job_timeout'],
+                'raw': False,
+                'metadata': {'mykey': 'myvalue'}
+            }
         )
         self.assertEqual(self.batch.active, {'bar', 'foo'})
 


### PR DESCRIPTION
### What does this PR do?

Adds preparation steps performed for normal jobs.
Passes `eauth` parameters to `run_job_async`

### Tests written?

Yes
