### PR TITLE
VMWare cloud driver updates

### DIFF
--- a/doc/topics/cloud/vmware.rst
+++ b/doc/topics/cloud/vmware.rst
@@ -227,6 +227,13 @@ Set up an initial profile at ``/etc/salt/cloud.profiles`` or
     Enter the name of the VM/template to clone from. If not specified, the VM will be created
     without cloning.
 
+``clonefrom_datacenter``
+    If the VM/template to clone exists in a different datacenter than the destination
+    datacenter, supply the source VM/template's datacenter here.
+    This defaults to the same value as ``datacenter``.
+
+    .. versionadded:: neon
+
 ``num_cpus``
     Enter the number of vCPUS that you want the VM/template to have. If not specified,
     the current VM/template\'s vCPU count is used.
@@ -525,7 +532,7 @@ Set up an initial profile at ``/etc/salt/cloud.profiles`` or
 
     .. note::
 
-    	Windows template should have "administrator" account.
+        Windows template should have "administrator" account.
 
 ``win_password``
     Specify windows vm administrator account password.
@@ -547,10 +554,10 @@ Set up an initial profile at ``/etc/salt/cloud.profiles`` or
     https://www.vmware.com/support/developer/vc-sdk/visdk25pubs/ReferenceGuide/vim.vm.customization.UserData.html
 
 ``plain_text``
-	Flag to specify whether or not the password is in plain text, rather than encrypted.
-	VMware vSphere documentation:
+    Flag to specify whether or not the password is in plain text, rather than encrypted.
+    VMware vSphere documentation:
 
-	https://www.vmware.com/support/developer/vc-sdk/visdk25pubs/ReferenceGuide/vim.vm.customization.Password.html
+    https://www.vmware.com/support/developer/vc-sdk/visdk25pubs/ReferenceGuide/vim.vm.customization.Password.html
 
 ``win_installer``
     Specify windows minion client installer path
@@ -559,6 +566,54 @@ Set up an initial profile at ``/etc/salt/cloud.profiles`` or
     Specify a list of commands to run on first login to a windows minion
 
     https://www.vmware.com/support/developer/vc-sdk/visdk25pubs/ReferenceGuide/vim.vm.customization.GuiRunOnce.html
+
+``win_ad_domain``
+    Specify the AD domain to join during customization.  ``win_ad_user`` and ``win_ad_password``
+    must also be specified.
+
+    Default is not set.
+
+    .. versionadded:: neon
+
+``win_ad_user``
+    Specify the user from ``win_ad_domain`` that will be used to join the computer to the domain
+    during customization.
+
+    Default is not set.
+
+    .. versionadded:: neon
+
+``win_ad_password``
+    Specify the password for the ``win_ad_user``.
+
+    Default is not set.
+
+    .. versionadded:: neon
+
+``win_autologon``
+    Specify if the local "Administrator" account should be logged in to the Windows machine
+    after the cloning process.
+
+    Defaults to 'True', must be 'True' for ``win_run_once`` to be executed.
+
+    .. versionadded:: neon
+
+``timezone``
+    Specify the timezone to apply to the VM during customization.
+
+    See https://www.vmware.com/support/developer/vc-sdk/visdk400pubs/ReferenceGuide/vim.vm.customization.LinuxPrep.html for Linux timezone information.
+    See https://www.vmware.com/support/developer/vc-sdk/visdk400pubs/ReferenceGuide/vim.vm.customization.GuiUnattended.html for Windows timezone information.
+
+    Default is not set.
+
+    .. versionadded:: neon
+
+``hw_clock_utc``
+    Specify whether the hardware clock is in UTC or local time.
+
+    Default is not set.
+
+    .. versionadded:: neon
 
 Cloning a VM
 ============

--- a/doc/topics/releases/neon.rst
+++ b/doc/topics/releases/neon.rst
@@ -396,12 +396,29 @@ the ``beacon_module`` parameter in the beacon configuration.
 Salt Cloud Features
 ===================
 
+General
+-------
+
+The salt-cloud WinRM util has been extended to allow for an Administrator
+account rename during deployment (for example, the Administator account
+being renamed by an Active Directory group policy).
+
 GCE Driver
 ----------
 
 The GCE salt cloud driver can now be used with GCE instance credentials by
 setting the configuration paramaters ``service_account_private_key`` and
 ``service_account_private_email`` to an empty string.
+
+VMWware Driver
+--------------
+
+The VMWare driver has been updated to:
+    Allow specifying a Windows domain to join during customization.
+    Allow specifying timezone for the system during customization.
+    Allow disabling the Windows autologon after deployment.
+    Allow specifying the source template/VM's datacenter (to allow
+        cloning between datacenters).
 
 Salt Api
 ========

--- a/doc/topics/releases/neon.rst
+++ b/doc/topics/releases/neon.rst
@@ -417,8 +417,7 @@ The VMWare driver has been updated to:
     Allow specifying a Windows domain to join during customization.
     Allow specifying timezone for the system during customization.
     Allow disabling the Windows autologon after deployment.
-    Allow specifying the source template/VM's datacenter (to allow
-        cloning between datacenters).
+    Allow specifying the source template/VM's datacenter (to allow cloning between datacenters).
 
 Salt Api
 ========

--- a/salt/cloud/clouds/vmware.py
+++ b/salt/cloud/clouds/vmware.py
@@ -2633,11 +2633,33 @@ def create(vm_):
     win_run_once = config.get_cloud_config_value(
         'win_run_once', vm_, __opts__, search_global=False, default=None
     )
+    win_ad_domain = config.get_cloud_config_value(
+        'win_ad_domain', vm_, __opts__, search_global=False, default=''
+    )
+    win_ad_user = config.get_cloud_config_value(
+        'win_ad_user', vm_, __opts__, search_global=False, default=''
+    )
+    win_ad_password = config.get_cloud_config_value(
+        'win_ad_password', vm_, __opts__, search_global=False, default=''
+    )
+    win_autologon = config.get_cloud_config_value(
+        'win_autologon', vm_, __opts__, search_global=False, default=True
+    )
+    timezone = config.get_cloud_config_value(
+        'timezone', vm_, __opts__, search_global=False, default=''
+    )
+    hw_clock_utc = config.get_cloud_config_value(
+        'hw_clock_utc', vm_, __opts__, search_global=False, default=''
+    )
+    clonefrom_datacenter = config.get_cloud_config_value(
+        'clonefrom_datacenter', vm_, __opts__, search_global=False, default=datacenter
+    )
 
     # Get service instance object
     si = _get_si()
 
     container_ref = None
+    clonefrom_datacenter_ref = None
 
     # If datacenter is specified, set the container reference to start search from it instead
     if datacenter:
@@ -2653,13 +2675,22 @@ def create(vm_):
                                  datacenter
                              )
             container_ref = datacenter_ref if datacenter_ref else None
+            clonefrom_container_ref = datacenter_ref if datacenter_ref else None
+        # allow specifying a different datacenter that the template lives in
+        if clonefrom_datacenter:
+            clonefrom_datacenter_ref = salt.utils.vmware.get_mor_by_property(
+                                           si,
+                                           vim.Datacenter,
+                                           clonefrom_datacenter
+                                       )
+            clonefrom_container_ref = clonefrom_datacenter_ref if clonefrom_datacenter_ref else None
 
         # Clone VM/template from specified VM/template
         object_ref = salt.utils.vmware.get_mor_by_property(
                          si,
                          vim.VirtualMachine,
                          vm_['clonefrom'],
-                         container_ref=container_ref
+                         container_ref=clonefrom_container_ref
                      )
         if object_ref:
             clone_type = "template" if object_ref.config.template else "vm"
@@ -2897,14 +2928,23 @@ def create(vm_):
                 identity = vim.vm.customization.LinuxPrep()
                 identity.hostName = vim.vm.customization.FixedName(name=host_name)
                 identity.domain = domain_name
+                if timezone:
+                    identity.timeZone = timezone
+                if isinstance(hw_clock_utc, bool):
+                    identity.hwClockUTC = hw_clock_utc
             else:
                 identity = vim.vm.customization.Sysprep()
                 identity.guiUnattended = vim.vm.customization.GuiUnattended()
-                identity.guiUnattended.autoLogon = True
-                identity.guiUnattended.autoLogonCount = 1
+                identity.guiUnattended.autoLogon = win_autologon
+                if win_autologon:
+                    identity.guiUnattended.autoLogonCount = 1
+                else:
+                    identity.guiUnattended.autoLogonCount = 0
                 identity.guiUnattended.password = vim.vm.customization.Password()
                 identity.guiUnattended.password.value = win_password
                 identity.guiUnattended.password.plainText = plain_text
+                if timezone:
+                    identity.guiUnattended.timeZone = timezone
                 if win_run_once:
                     identity.guiRunOnce = vim.vm.customization.GuiRunOnce()
                     identity.guiRunOnce.commandList = win_run_once
@@ -2914,6 +2954,12 @@ def create(vm_):
                 identity.userData.computerName = vim.vm.customization.FixedName()
                 identity.userData.computerName.name = host_name
                 identity.identification = vim.vm.customization.Identification()
+                if win_ad_domain and win_ad_user and win_ad_password:
+                    identity.identification.joinDomain = win_ad_domain
+                    identity.identification.domainAdmin = win_ad_user
+                    identity.identification.domainAdminPassword = vim.vm.customization.Password()
+                    identity.identification.domainAdminPassword.value = win_ad_password
+                    identity.identification.domainAdminPassword.plainText = plain_text
             custom_spec = vim.vm.customization.Specification(
                 globalIPSettings=global_ip,
                 identity=identity,


### PR DESCRIPTION
### What does this PR do?
Update VMWare driver to allow joining domain and setting timezone during customization.
Update VMWare driver to allow specifying a template in a different datacenter than the destination datacenter.
Update VMWare driver to allow disabling autologon after deployment.

Update salt-cloud WinRM util to handle an administrator account rename
(i.e. by a group policy) during deployment.

Add documentation/release notes

### What issues does this PR fix or reference?


### Previous Behavior
When using a customization spec during a VM deployment, a Windows machine could not be configured to join an AD domain during the customization.

Timezone could not be set during customziation

Autologon could not be configured (thus the administrator account always being autologged on, which may not be desirable in all cases)

WinRM could not handle the administrator account being renamed during the deployment (i.e. by a GPO) and would automatically fail due to invalid credentials.

The source VM for a cone task had to reside in the same datacenter as the destination cluster.

### New Behavior
See above

### Tests written?
No
### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
