### PR TITLE
Fix use of deserializer_opts in file.serialize

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -6846,7 +6846,7 @@ def serialize(name,
                 try:
                     existing_data = __serializers__[deserializer_name](
                         fhr,
-                        **deserializer_options.get(serializer_name, {})
+                        **deserializer_options.get(deserializer_name, {})
                     )
                 except (TypeError, DeserializationError) as exc:
                     ret['result'] = False


### PR DESCRIPTION
### What does this PR do?
Corrects code attempting to pull deserialize_opts using the serializer_name instead of deserializer_name

### What issues does this PR fix or reference?
#52525

### Previous Behavior
deserializer_opts are packed into the deserializer_options dict using the deserialzier_name as the key.  However, when retrieved to pass to the deserializer, the serializer_name is used.

### New Behavior
deserializer_name is used to retrieve the options

### Tests written?
No

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
