### PR TITLE
Add TLS support up to version 1.2

### DIFF
--- a/pkg/windows/modules/download-module.psm1
+++ b/pkg/windows/modules/download-module.psm1
@@ -1,3 +1,6 @@
+# Powershell supports only TLS 1.0 by default. Add support up to TLS 1.2
+[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]'Tls,Tls11,Tls12'
+
 Function DownloadFileWithProgress {
 
     # Code for this function borrowed from http://poshcode.org/2461


### PR DESCRIPTION
### What does this PR do?
Adds support for TLS up to version 1.2. By default Powershell only supports TLS 1.0... lame

### What issues does this PR fix or reference?
https://github.com/saltstack/salt-bootstrap/issues/1338

### Tests written?
NA

### Commits signed with GPG?
Yes