### PR TITLE
Configparser item case preservation

### DIFF
--- a/doc/topics/releases/neon.rst
+++ b/doc/topics/releases/neon.rst
@@ -410,8 +410,9 @@ Serializer Changes
 - The configparser serializer and deserializer functions can now be made to preserve
   case of item names by passing 'preserve_case=True' in the options parameter of the function.
 
-  .. note:: This is a parameter consumed only by the salt.serializer.configparser serialize and
-  deserialize functions and not the low-level configparser python object.
+  .. note::
+      This is a parameter consumed only by the salt.serializer.configparser serialize and
+      deserialize functions and not the low-level configparser python object.
 
   For example, in a file.serialze state:
 

--- a/doc/topics/releases/neon.rst
+++ b/doc/topics/releases/neon.rst
@@ -410,6 +410,9 @@ Serializer Changes
 - The configparser serializer and deserializer functions can now be made to preserve
   case of item names by passing 'preserve_case=True' in the options parameter of the function.
 
+  .. note:: This is a parameter consumed only by the salt.serializer.configparser serialize and
+  deserialize functions and not the low-level configparser python object.
+
   For example, in a file.serialze state:
 
   .. code-block:: yaml

--- a/doc/topics/releases/neon.rst
+++ b/doc/topics/releases/neon.rst
@@ -404,6 +404,25 @@ Util Changes
     - :py:func:`versions_details <salt.utils.win_dotnet.versions_details>`
     - :py:func:`version_at_least <salt.utils.win_dotnet.version_at_least>`
 
+Serializer Changes
+==================
+
+- The configparser serializer and deserializer functions can now be made to preserve
+  case of item names by passing 'preserve_case=True' in the options parameter of the function.
+
+  For example, in a file.serialze state:
+
+  .. code-block:: yaml
+
+    some.ini:
+      - file.serialize:
+         - formatter: configparser
+         - merge_if_exists: True
+         - deserializer_opts:
+           - preserve_case: True
+         - serializer_opts:
+           - preserve_case: True
+
 Enhancements to Engines
 =======================
 

--- a/salt/serializers/configparser.py
+++ b/salt/serializers/configparser.py
@@ -20,7 +20,7 @@ __all__ = ['deserialize', 'serialize', 'available']
 
 available = True
 
-def _check_preservecase_option(**options)
+def _check_preservecase_option(**options):
     '''
     Checks options passed to the serialize/deserialze function
     for the 'casesensitive' argument.  If passed as True,

--- a/salt/serializers/configparser.py
+++ b/salt/serializers/configparser.py
@@ -20,6 +20,7 @@ __all__ = ['deserialize', 'serialize', 'available']
 
 available = True
 
+
 def _check_preservecase_option(**options):
     '''
     Checks options passed to the serialize/deserialze function
@@ -33,6 +34,7 @@ def _check_preservecase_option(**options):
         options.pop('preserve_case')
     return options, preserve_case
 
+    
 def deserialize(stream_or_string, **options):
     '''
     Deserialize any string or stream like object into a Python data structure.

--- a/salt/serializers/configparser.py
+++ b/salt/serializers/configparser.py
@@ -42,16 +42,7 @@ def deserialize(stream_or_string, **options):
     :param stream_or_string: stream or string to deserialize.
     :param options: options given to lower configparser module.
     '''
-    options, PRESERVE_CASE = _check_preservecase_option(**options)
-
-    if six.PY3:
-        cp = configparser.ConfigParser(**options)
-        if PRESERVE_CASE:
-            cp.optionxform = str
-    else:
-        cp = configparser.SafeConfigParser(**options)
-        if PRESERVE_CASE:
-            cp.optionxform = str
+    cp = _create_cp_object(**options)
 
     try:
         if not isinstance(stream_or_string, (bytes, six.string_types)):
@@ -84,20 +75,11 @@ def serialize(obj, **options):
     :param options: options given to lower configparser module.
     '''
 
-    options, PRESERVE_CASE = _check_preservecase_option(**options)
-
     try:
         if not isinstance(obj, dict):
             raise TypeError("configparser can only serialize dictionaries, not {0}".format(type(obj)))
         fp = options.pop('fp', None)
-        if six.PY3:
-            cp = configparser.ConfigParser(**options)
-            if PRESERVE_CASE:
-                cp.optionxform = str
-        else:
-            cp = configparser.SafeConfigParser(**options)
-            if PRESERVE_CASE:
-                cp.optionxform = str
+        cp = _create_cp_object(**options)
         _read_dict(cp, obj)
 
         if fp:
@@ -135,3 +117,19 @@ def _read_dict(cp, dictionary):
             if value is not None:
                 value = six.text_type(value)
             cp.set(section, key, value)
+
+
+def _create_cp_object(**options):
+    '''
+    build the configparser object
+    '''
+    options, preserve_case = _check_preservecase_option(**options)
+
+    if six.PY3:
+        cp = configparser.ConfigParser(**options)
+        if preserve_case:
+            cp.optionxform = str
+    else:
+        cp = configparser.SafeConfigParser(**options)
+        if preserve_case:
+            cp.optionxform = str

--- a/salt/serializers/configparser.py
+++ b/salt/serializers/configparser.py
@@ -34,7 +34,7 @@ def _check_preservecase_option(**options):
         options.pop('preserve_case')
     return options, preserve_case
 
-    
+
 def deserialize(stream_or_string, **options):
     '''
     Deserialize any string or stream like object into a Python data structure.

--- a/salt/serializers/configparser.py
+++ b/salt/serializers/configparser.py
@@ -133,3 +133,4 @@ def _create_cp_object(**options):
         cp = configparser.SafeConfigParser(**options)
         if preserve_case:
             cp.optionxform = str
+    return cp

--- a/salt/serializers/configparser.py
+++ b/salt/serializers/configparser.py
@@ -20,6 +20,18 @@ __all__ = ['deserialize', 'serialize', 'available']
 
 available = True
 
+def _check_preservecase_option(**options)
+    '''
+    Checks options passed to the serialize/deserialze function
+    for the 'casesensitive' argument.  If passed as True,
+    the configparser object will preserve case in items
+    '''
+    preserve_case = False
+    if 'preserve_case' in options:
+        if options['preserve_case']:
+            preserve_case = True
+        options.pop('preserve_case')
+    return options, preserve_case
 
 def deserialize(stream_or_string, **options):
     '''
@@ -28,11 +40,16 @@ def deserialize(stream_or_string, **options):
     :param stream_or_string: stream or string to deserialize.
     :param options: options given to lower configparser module.
     '''
+    options, PRESERVE_CASE = _check_preservecase_option(**options)
 
     if six.PY3:
         cp = configparser.ConfigParser(**options)
+        if PRESERVE_CASE:
+            cp.optionxform = str
     else:
         cp = configparser.SafeConfigParser(**options)
+        if PRESERVE_CASE:
+            cp.optionxform = str
 
     try:
         if not isinstance(stream_or_string, (bytes, six.string_types)):
@@ -65,14 +82,20 @@ def serialize(obj, **options):
     :param options: options given to lower configparser module.
     '''
 
+    options, PRESERVE_CASE = _check_preservecase_option(**options)
+
     try:
         if not isinstance(obj, dict):
             raise TypeError("configparser can only serialize dictionaries, not {0}".format(type(obj)))
         fp = options.pop('fp', None)
         if six.PY3:
             cp = configparser.ConfigParser(**options)
+            if PRESERVE_CASE:
+                cp.optionxform = str
         else:
             cp = configparser.SafeConfigParser(**options)
+            if PRESERVE_CASE:
+                cp.optionxform = str
         _read_dict(cp, obj)
 
         if fp:

--- a/salt/serializers/configparser.py
+++ b/salt/serializers/configparser.py
@@ -21,20 +21,6 @@ __all__ = ['deserialize', 'serialize', 'available']
 available = True
 
 
-def _check_preservecase_option(**options):
-    '''
-    Checks options passed to the serialize/deserialze function
-    for the 'casesensitive' argument.  If passed as True,
-    the configparser object will preserve case in items
-    '''
-    preserve_case = False
-    if 'preserve_case' in options:
-        if options['preserve_case']:
-            preserve_case = True
-        options.pop('preserve_case')
-    return options, preserve_case
-
-
 def deserialize(stream_or_string, **options):
     '''
     Deserialize any string or stream like object into a Python data structure.
@@ -123,7 +109,7 @@ def _create_cp_object(**options):
     '''
     build the configparser object
     '''
-    options, preserve_case = _check_preservecase_option(**options)
+    preserve_case = options.pop('preserve_case', False)
 
     if six.PY3:
         cp = configparser.ConfigParser(**options)

--- a/tests/unit/serializers/test_serializers.py
+++ b/tests/unit/serializers/test_serializers.py
@@ -358,6 +358,20 @@ class TestSerializers(TestCase):
         deserialized = configparser.deserialize(serialized)
         assert deserialized == data, deserialized
 
+    @skipIf(not configparser.available, SKIP_MESSAGE % 'configparser')
+    def test_configparser_preserve_case(self):
+        '''
+        Validate that items with case are preserved through serialization/deserialization
+        if the preserve_case=True option is passed
+        '''
+        data = {'foo': {'someItemWithCase': 'data'}}
+        # configparser appends empty lines
+        serialized = configparser.serialize(data, options={'preserve_case': True}).strip()
+        assert serialized == "[foo]\nsomeItemWithCase = data", serialized
+
+        deserialized = configparser.deserialize(serialized, options={'preserve_case': True})
+        assert deserialized == data, deserialized
+
     @skipIf(not toml.available, SKIP_MESSAGE % 'toml')
     def test_serialize_toml(self):
         data = {

--- a/tests/unit/serializers/test_serializers.py
+++ b/tests/unit/serializers/test_serializers.py
@@ -366,11 +366,25 @@ class TestSerializers(TestCase):
         '''
         data = {'foo': {'someItemWithCase': 'data'}}
         # configparser appends empty lines
-        serialized = configparser.serialize(data, options={'preserve_case': True}).strip()
+        serialized = configparser.serialize(data, **{'preserve_case': True}).strip()
         assert serialized == "[foo]\nsomeItemWithCase = data", serialized
 
-        deserialized = configparser.deserialize(serialized, options={'preserve_case': True})
+        deserialized = configparser.deserialize(serialized, **{'preserve_case': True})
         assert deserialized == data, deserialized
+
+    @skipIf(not configparser.available, SKIP_MESSAGE % 'configparser')
+    def test_configparser_case_not_preserved(self):
+        '''
+        Validate that items with case are *not* preserved through serialization/deserialization
+        if the preserve_case=True option is not passed
+        '''
+        data = {'foo': {'someItemWithCase': 'data'}}
+        # configparser appends empty lines
+        serialized = configparser.serialize(data).strip()
+        assert serialized == "[foo]\nsomeitemwithcase = data", serialized
+
+        deserialized = configparser.deserialize(serialized)
+        assert deserialized != data, deserialized
 
     @skipIf(not toml.available, SKIP_MESSAGE % 'toml')
     def test_serialize_toml(self):


### PR DESCRIPTION
### What does this PR do?
Allows passing options to the configparser serializer/deserializer functions to perserve case of item names (section names and item value case is preserved).

### What issues does this PR fix or reference?

### Previous Behavior
configparser converts all item names to lower case by default

For example, if the following were derserialized
```
[section]
item = value
itemTwo = value
```
it would return the dict
```
{'section': {'item': 'value', 'itemtwo': 'value'}}
```

Conversely, if the following dict were passed through the serialize function
```
{'section':{'item': 'value', 'itemTwo': 'value'}}
```
the following would be returned
```
[section]
item = value
itemtwo = value
```
### New Behavior
Case of item names can be preserved by passing "preserve_case=True" in the options of the functions

```
import salt.serializers.configparser as configparser
data = {'foo': {'someItemWithCase': 'data'}}
serialized = configparser.serialize(data, **{'preserve_case': True})
```

i.e. the following dict
```
{'section':{'item': 'value', 'itemTwo': 'value'}}
```
would return:
```
[section]
item = value
itemTwo = value
```

or more usefully, via the file.serialize state:
```
some/file:
  - file.serialze:
      - formatter: configparser
      - dataset:
          section:
              someValue: someData
              someValue2: someData2
  - merge_if_exists: True
  - deserializer_opts:
      - preserve_case: True
  - serializer_opts:
      - preserve_case: True
```
### Tests written?
Yes

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
