### PR TITLE
Fix failing cert_siging test

### DIFF
--- a/tests/integration/files/file/base/test_cert.sls
+++ b/tests/integration/files/file/base/test_cert.sls
@@ -1,5 +1,11 @@
 {% set tmp_dir = pillar['tmp_dir'] %}
 
+salt-minion:
+  service.running:
+    - enable: True
+    - listen:
+      - file: {{ tmp_dir}}/config/minion.d/signing_policies.conf
+
 {{ tmp_dir }}/pki:
   file.directory
 


### PR DESCRIPTION
### What does this PR do?

The test `integration.states.test_x509.x509Test.test_cert_signing` it is failing in a few PRs on centos-7. This change will resolve that failure.

### Tests written?

No - Fixing test

### Commits signed with GPG?

Yes
