### PR TITLE
Fix windows platform grains

### DIFF
--- a/tests/unit/grains/test_core.py
+++ b/tests/unit/grains/test_core.py
@@ -138,7 +138,6 @@ class CoreGrainsTestCase(TestCase, LoaderModuleMockMixin):
         grains = core._windows_platform_data()
         keys = ['biosversion',
                 'osrelease',
-                'domain',
                 'kernelrelease',
                 'motherboard',
                 'serialnumber',


### PR DESCRIPTION
Fix `unit.grains.test_core.CoreGrainsTestCase.test__windows_platform_data`
by removing the 'domain' grain since it is not included on any branch

### Tests written?

No - fixing unit.grains.test_core.CoreGrainsTestCase.test__windows_platform_data

### Commits signed with GPG?

Yes
