### PR TITLE
Fix race condition in event assertion

### DIFF
--- a/salt/modules/vsphere.py
+++ b/salt/modules/vsphere.py
@@ -6936,45 +6936,47 @@ def add_host_to_dvs(host, username, password, vmknic_name, vmnic_name,
     to sniff the SOAP stream from Powershell to our vSphere server and got
     this snippet out:
 
-    <UpdateNetworkConfig xmlns="urn:vim25">
-      <_this type="HostNetworkSystem">networkSystem-187</_this>
-      <config>
-        <vswitch>
-          <changeOperation>edit</changeOperation>
-          <name>vSwitch0</name>
-          <spec>
-            <numPorts>7812</numPorts>
-          </spec>
-        </vswitch>
-        <proxySwitch>
-            <changeOperation>edit</changeOperation>
-            <uuid>73 a4 05 50 b0 d2 7e b9-38 80 5d 24 65 8f da 70</uuid>
-            <spec>
-            <backing xsi:type="DistributedVirtualSwitchHostMemberPnicBacking">
-                <pnicSpec><pnicDevice>vmnic0</pnicDevice></pnicSpec>
-            </backing>
-            </spec>
-        </proxySwitch>
-        <portgroup>
-          <changeOperation>remove</changeOperation>
-          <spec>
-            <name>Management Network</name><vlanId>-1</vlanId><vswitchName /><policy />
-          </spec>
-        </portgroup>
-        <vnic>
-          <changeOperation>edit</changeOperation>
-          <device>vmk0</device>
-          <portgroup />
-          <spec>
-            <distributedVirtualPort>
-              <switchUuid>73 a4 05 50 b0 d2 7e b9-38 80 5d 24 65 8f da 70</switchUuid>
-              <portgroupKey>dvportgroup-191</portgroupKey>
-            </distributedVirtualPort>
-          </spec>
-        </vnic>
-      </config>
-      <changeMode>modify</changeMode>
-    </UpdateNetworkConfig>
+    .. code-block:: xml
+
+        <UpdateNetworkConfig xmlns="urn:vim25">
+          <_this type="HostNetworkSystem">networkSystem-187</_this>
+          <config>
+            <vswitch>
+              <changeOperation>edit</changeOperation>
+              <name>vSwitch0</name>
+              <spec>
+                <numPorts>7812</numPorts>
+              </spec>
+            </vswitch>
+            <proxySwitch>
+                <changeOperation>edit</changeOperation>
+                <uuid>73 a4 05 50 b0 d2 7e b9-38 80 5d 24 65 8f da 70</uuid>
+                <spec>
+                <backing xsi:type="DistributedVirtualSwitchHostMemberPnicBacking">
+                    <pnicSpec><pnicDevice>vmnic0</pnicDevice></pnicSpec>
+                </backing>
+                </spec>
+            </proxySwitch>
+            <portgroup>
+              <changeOperation>remove</changeOperation>
+              <spec>
+                <name>Management Network</name><vlanId>-1</vlanId><vswitchName /><policy />
+              </spec>
+            </portgroup>
+            <vnic>
+              <changeOperation>edit</changeOperation>
+              <device>vmk0</device>
+              <portgroup />
+              <spec>
+                <distributedVirtualPort>
+                  <switchUuid>73 a4 05 50 b0 d2 7e b9-38 80 5d 24 65 8f da 70</switchUuid>
+                  <portgroupKey>dvportgroup-191</portgroupKey>
+                </distributedVirtualPort>
+              </spec>
+            </vnic>
+          </config>
+          <changeMode>modify</changeMode>
+        </UpdateNetworkConfig>
 
     The SOAP API maps closely to PyVmomi, so from there it was (relatively)
     easy to figure out what Python to write.

--- a/tests/integration/reactor/test_reactor.py
+++ b/tests/integration/reactor/test_reactor.py
@@ -35,4 +35,4 @@ class ReactorTest(ModuleCase, SaltMinionEventAssertsMixin):
 
         e.fire_event({'a': 'b'}, '/test_event')
 
-        self.assertMinionEventReceived({'a': 'b'})
+        self.assertMinionEventReceived({'a': 'b'}, timeout=30)

--- a/tests/support/mixins.py
+++ b/tests/support/mixins.py
@@ -695,6 +695,8 @@ class SaltMinionEventAssertsMixin(object):
                 event = self.q.get(False)
             except Empty:
                 time.sleep(sleep_time)
+                if start - time.time() >= timeout:
+                    break
                 continue
             if isinstance(event, dict):
                 event.pop('_stamp')

--- a/tests/support/mixins.py
+++ b/tests/support/mixins.py
@@ -687,10 +687,10 @@ class SaltMinionEventAssertsMixin(object):
         #TODO
         raise salt.exceptions.NotImplemented('assertMinionEventFired() not implemented')
 
-    def assertMinionEventReceived(self, desired_event):
-        queue_wait = 5  # 2.5s
+    def assertMinionEventReceived(self, desired_event, timeout=5, sleep_time=0.5):
+        queue_wait = timeout / sleep_time
         while self.q.empty():
-            time.sleep(0.5)  # Wait for events to be pushed into the queue
+            time.sleep(sleep_time)  # Wait for events to be pushed into the queue
             queue_wait -= 1
             if queue_wait <= 0:
                 raise AssertionError('Queue wait timer expired')

--- a/tests/support/mixins.py
+++ b/tests/support/mixins.py
@@ -693,8 +693,9 @@ class SaltMinionEventAssertsMixin(object):
         while True:
             try:
                 event = self.q.get(False)
-            except Emtpy:
+            except Empty:
                 time.sleep(sleep_time)
+                continue
             if isinstance(event, dict):
                 event.pop('_stamp')
             if desired_event == event:

--- a/tests/support/mixins.py
+++ b/tests/support/mixins.py
@@ -47,7 +47,7 @@ from salt._compat import ElementTree as etree
 # Import 3rd-party libs
 from salt.ext import six
 from salt.ext.six.moves import zip  # pylint: disable=import-error,redefined-builtin
-from salt.ext.six.moves.queue import Empty
+from salt.ext.six.moves.queue import Empty # pylint: disable=import-error,no-name-in-module
 
 log = logging.getLogger(__name__)
 

--- a/tests/support/mixins.py
+++ b/tests/support/mixins.py
@@ -651,12 +651,8 @@ def _fetch_events(q):
             queue_item.task_done()
 
     atexit.register(_clean_queue)
-    a_config = AdaptedConfigurationTestCaseMixin()
-    event = salt.utils.event.get_event(
-        'minion',
-        sock_dir=a_config.get_config('minion')['sock_dir'],
-        opts=a_config.get_config('minion'),
-    )
+    opts = RUNTIME_VARS.RUNTIME_CONFIGS['minion']
+    event = salt.utils.event.get_event('minion', sock_dir=opts['sock_dir'], opts=opts)
     while True:
         try:
             events = event.get_event(full=False)

--- a/tests/support/mixins.py
+++ b/tests/support/mixins.py
@@ -47,7 +47,7 @@ from salt._compat import ElementTree as etree
 # Import 3rd-party libs
 from salt.ext import six
 from salt.ext.six.moves import zip  # pylint: disable=import-error,redefined-builtin
-from salt.ext.six.moves.queue import Empty # pylint: disable=import-error,no-name-in-module
+from salt.ext.six.moves.queue import Empty  # pylint: disable=import-error,no-name-in-module
 
 log = logging.getLogger(__name__)
 

--- a/tests/support/mixins.py
+++ b/tests/support/mixins.py
@@ -653,6 +653,14 @@ def _fetch_events(q):
     atexit.register(_clean_queue)
     opts = RUNTIME_VARS.RUNTIME_CONFIGS['minion']
     event = salt.utils.event.get_event('minion', sock_dir=opts['sock_dir'], opts=opts)
+
+    # Wait for event bus to be connected
+    while not event.connect_pull(30):
+        time.sleep(1)
+
+    # Notify parent process that the event bus is connected
+    q.put('CONNECTED')
+
     while True:
         try:
             events = event.get_event(full=False)
@@ -675,6 +683,11 @@ class SaltMinionEventAssertsMixin(object):
             target=_fetch_events, args=(cls.q,)
         )
         cls.fetch_proc.start()
+        # Wait for the event bus to be connected
+        msg = cls.q.get(block=True)
+        if msg != 'CONNECTED':
+            # Just in case something very bad happens
+            raise RuntimeError('Unexpected message in test\'s event queue')
         return object.__new__(cls)
 
     def __exit__(self, *args, **kwargs):

--- a/tests/support/mixins.py
+++ b/tests/support/mixins.py
@@ -651,8 +651,12 @@ def _fetch_events(q):
             queue_item.task_done()
 
     atexit.register(_clean_queue)
-    opts = RUNTIME_VARS.RUNTIME_CONFIGS['minion']
-    event = salt.utils.event.get_event('minion', sock_dir=opts['sock_dir'], opts=opts)
+    a_config = AdaptedConfigurationTestCaseMixin()
+    event = salt.utils.event.get_event(
+        'minion',
+        sock_dir=a_config.get_config('minion')['sock_dir'],
+        opts=a_config.get_config('minion'),
+    )
 
     # Wait for event bus to be connected
     while not event.connect_pull(30):

--- a/tests/support/mixins.py
+++ b/tests/support/mixins.py
@@ -695,7 +695,7 @@ class SaltMinionEventAssertsMixin(object):
                 event = self.q.get(False)
             except Empty:
                 time.sleep(sleep_time)
-                if start - time.time() >= timeout:
+                if time.time() - start >= timeout:
                     break
                 continue
             if isinstance(event, dict):
@@ -703,7 +703,7 @@ class SaltMinionEventAssertsMixin(object):
             if desired_event == event:
                 self.fetch_proc.terminate()
                 return True
-            if start - time.time() >= timeout:
+            if time.time() - start >= timeout:
                 break
         self.fetch_proc.terminate()
         raise AssertionError('Event {0} was not received by minion'.format(desired_event))


### PR DESCRIPTION
Fix race condition in event assertion.

The `integration.reactor.test_reactor.ReactorTest.test_ping_reaction` is passing in most places but failing every once in a while. Like here: https://jenkinsci.saltstack.com/job/2018.3/job/salt-centos-6-py2/166/

### Tests written?

No - Fixing flaky test `integration.reactor.test_reactor.ReactorTest.test_ping_reaction`

### Commits signed with GPG?

Yes
