### PR TITLE
Saltcheck salt-ssh support

### DIFF
--- a/doc/topics/releases/neon.rst
+++ b/doc/topics/releases/neon.rst
@@ -27,6 +27,7 @@ has been enhanced to:
 * Adds assertion_section keyword
 * Use saltcheck.state_apply to run state.apply for test setup or teardown
 * Changes output to display test time
+* Work over salt-ssh
 
 Saltcheck provides unittest like functionality requiring only the knowledge of
 salt module execution and yaml. Saltcheck uses salt modules to return data, then

--- a/salt/client/ssh/wrapper/saltcheck.py
+++ b/salt/client/ssh/wrapper/saltcheck.py
@@ -1,0 +1,121 @@
+# -*- coding: utf-8 -*-
+'''
+Wrap the saltcheck module to copy files to ssh minion before running tests
+'''
+# Import Python libs
+from __future__ import absolute_import, print_function
+import logging
+import tempfile
+import os
+import shutil
+import tarfile
+from contextlib import closing
+
+
+# Import salt libs
+import salt.utils.url
+import salt.utils.files
+
+log = logging.getLogger(__name__)
+
+def update_master_cache(states, saltenv='base'):
+    '''
+    Replace standard saltcheck version with similar logic but replacing cp.cache_dir with
+        generating files, tar'ing them up, copying tarball to remote host, extracting tar
+        to state cache directory, and cleanup of files
+    '''
+    cache = __opts__['cachedir']
+
+    # Setup for copying states to gendir
+    gendir = tempfile.mkdtemp()
+    trans_tar = salt.utils.files.mkstemp()
+    if 'cp.fileclient_{0}'.format(id(__opts__)) not in __context__:
+        __context__['cp.fileclient_{0}'.format(id(__opts__))] = \
+            salt.fileclient.get_file_client(__opts__)
+
+    # cp state directories to gendir
+    already_processed = []
+    sls_list = salt.utils.args.split_input(states)
+    for state_name in sls_list:
+        state_name = state_name.replace(".", os.sep)
+        if state_name in already_processed:
+            log.debug("Already cached state for %s", state_name)
+        else:
+            log.debug('copying %s to %s', state_name, gendir)
+            qualified_name = salt.utils.url.create(state_name, saltenv)
+            # Duplicate cp.get_dir to gendir
+            copy_result = __context__['cp.fileclient_{0}'.format(id(__opts__))].get_dir(
+                qualified_name, gendir, saltenv)
+            if copy_result:
+                already_processed.append(state_name)
+            else:
+                # If files were not copied, assume state.file.sls was given and just copy state
+                state_name = os.path.dirname(state_name)
+                if state_name in already_processed:
+                    log.debug('Already cached state for %s', state_name)
+                else:
+                    qualified_name = salt.utils.url.create(state_name, saltenv)
+                    copy_result = __context__['cp.fileclient_{0}'.format(id(__opts__))].get_dir(
+                        qualified_name, gendir, saltenv)
+                    if copy_result:
+                        already_processed.append(state_name)
+
+    # turn gendir into tarball and remove gendir
+    try:
+        # cwd may not exist if it was removed but salt was run from it
+        cwd = os.getcwd()
+    except OSError:
+        cwd = None
+    os.chdir(gendir)
+    with closing(tarfile.open(trans_tar, 'w:gz')) as tfp:
+        for root, dirs, files in salt.utils.path.os_walk(gendir):
+            for name in files:
+                full = os.path.join(root, name)
+                tfp.add(full[len(gendir):].lstrip(os.sep))
+    if cwd:
+        os.chdir(cwd)
+    shutil.rmtree(gendir)
+
+    # Copy tarfile to ssh host
+    single = salt.client.ssh.Single(
+            __opts__,
+            '',
+            **__salt__.kwargs)
+    thin_dir = __opts__['thin_dir']
+    ret = single.shell.send(trans_tar, thin_dir)
+
+    # Clean up local tar
+    try:
+        os.remove(trans_tar)
+    except (OSError, IOError):
+        pass
+
+    tar_path = os.path.join(thin_dir, os.path.basename(trans_tar))
+    state_cache = os.path.join(cache, 'files', saltenv)
+    # Extract remote tarball to cache directory and remove tar file
+    # TODO this could be better handled by a single state/connection due to ssh overhead
+    ret = __salt__['file.mkdir'](state_cache)
+    ret = __salt__['archive.tar']('xf', tar_path, dest=state_cache)
+    ret = __salt__['file.remove'](tar_path)
+
+    return ret
+
+
+def run_state_tests(states, saltenv='base', check_all=False):
+    '''
+    Define common functions to activite this wrapping module and tar copy.
+    After file copies are finished, run the usual local saltcheck function
+    '''
+    ret = update_master_cache(states, saltenv)
+    ret = __salt__['saltcheck.run_state_tests_ssh'](states, saltenv=saltenv, check_all=check_all)
+    return ret
+
+
+def run_highstate_tests(saltenv='base'):
+    '''
+    Lookup top files for minion, pass results to wrapped run_state_tests for copy and run
+    '''
+    top_states = __salt__['state.show_top']().get(saltenv)
+    state_string = ','.join(top_states)
+    ret = run_state_tests(state_string, saltenv)
+    return ret

--- a/salt/modules/saltcheck.py
+++ b/salt/modules/saltcheck.py
@@ -301,6 +301,8 @@ def state_apply(state_name, **kwargs):
     #   client is hardcoded to local
     # If the minion is running with a master, a potentially non-local client is needed to lookup states
     local_opts = salt.config.minion_config(__opts__['conf_file'])
+    if '_salt/running_data/var/run/salt-minion.pid' in __opts__.get('pidfile', False):
+        local_opts['file_client'] = 'local'
     caller = salt.client.Caller(mopts=local_opts)
     if kwargs:
         return caller.cmd('state.apply', state_name, **kwargs)

--- a/salt/modules/saltcheck.py
+++ b/salt/modules/saltcheck.py
@@ -201,6 +201,7 @@ from salt.utils.json import loads, dumps
 import salt.utils.files
 import salt.utils.path
 import salt.utils.yaml
+import salt.utils.data
 import salt.client
 import salt.exceptions
 from salt.utils.odict import OrderedDict
@@ -540,7 +541,9 @@ class SaltCheck(object):
         except Exception:
             raise
         if isinstance(value, dict) and assertion_section:
-            return value.get(assertion_section, False)
+            return salt.utils.data.traverse_dict_and_list(value,
+                                                          assertion_section,
+                                                          default=False)
         else:
             return value
 


### PR DESCRIPTION
### What does this PR do?
supersedes #52434

- Optimize test copying (replace `cp.cache_master` with logic to `cp.cache_dir` on used salt states)
- Tidy "salt://" handling by using url util
- Create saltcheck wrapper for use in salt-ssh. Handles cp.cache_dir functionality by creating a tarball, copying, and extracting on ssh minion. Then calls the regular saltcheck functions.


### Previous Behavior
1. saltcheck, being unable to run `cp.cache_*` from a salt-ssh minion, was not able to locate test files and did not function.
2. saltcheck was only able to parse an `assertion_section` of a single depth
3. `cp.cache_master` takes more time and I/O than necessary

### New Behavior
1. Wrapper written to gather needed state directories, tarball them, copy tar to salt-ssh minion, extract to local cache directory, and cleanup. Then hands over saltcheck running to the local saltcheck module. 
2. `assertion_section` can now be nested dicts or lists
3. Now uses `cp.cache_dir` on needed state directories

### Tests written?
No

### Commits signed with GPG?
No