### PR TITLE
Async ping_all_connected_minions

### DIFF
--- a/salt/utils/master.py
+++ b/salt/utils/master.py
@@ -775,7 +775,7 @@ def ping_all_connected_minions(opts):
     else:
         tgt = '*'
         form = 'glob'
-    client.cmd(tgt, 'test.ping', tgt_type=form)
+    client.cmd_async(tgt, 'test.ping', tgt_type=form)
 
 
 def get_master_key(key_user, opts, skip_perm_errors=False):


### PR DESCRIPTION
### What does this PR do?

Async ping_all_connected_minions function

### Previous Behavior

`ping_all_connected_minions` will block master `Maintenance` process for waiting `client.cmd`  finished when master key rotate and `ping_on_rotate` option set
### New Behavior

`ping_all_connected_minions` will be asynchronous  by `cmd_async`

### Tests written?

No

### Commits signed with GPG?

No