### PR TITLE
Virt purge fix

### DIFF
--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -3189,7 +3189,10 @@ def purge(vm_, dirs=False, removables=None, **kwargs):
             shutil.rmtree(dir_)
     if getattr(libvirt, 'VIR_DOMAIN_UNDEFINE_NVRAM', False):
         # This one is only in 1.2.8+
-        dom.undefineFlags(libvirt.VIR_DOMAIN_UNDEFINE_NVRAM)
+        try:
+            dom.undefineFlags(libvirt.VIR_DOMAIN_UNDEFINE_NVRAM)
+        except Exception:
+            dom.undefine()
     else:
         dom.undefine()
     conn.close()


### PR DESCRIPTION
### What does this PR do?

Fixes `Exception: unsupported flags (0x4) in function libxlDomainUndefineFlags` thrown when running `virt.purge` on non-QEMU hypervisor.

### What issues does this PR fix or reference?

Fixes issue #52547

### Previous Behavior

Running `virt.purge test-vm` on a Xen hypervisor raised an exception due to unhandled flag

### New Behavior

Running `virt.purge test-vm` on a Xen hypervisor just works

### Tests written?

No: catching up such errors would require integration tests with real libvirt on various hypervisors.

### Commits signed with GPG?

Yes