### PR TITLE
virt.vm_info and other functions in virt module

### DIFF
--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -326,7 +326,7 @@ def _get_uuid(dom):
     '''
     Get uuid from a libvirt domain object.
     '''
-    uuid = ElementTree.fromstring(dom.XMLDesc(0)).find('uuid')
+    uuid = ElementTree.fromstring(dom.XMLDesc(0)).find('uuid').text
 
     return uuid
 

--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -2626,6 +2626,26 @@ def setvcpus(vm_, vcpus, config=False, **kwargs):
     return ret1 == ret2 == 0
 
 
+def get_xml(vm_, **kwargs):
+    '''
+    Returns the XML for a given vm
+    :param vm_: domain name
+    :param connection: libvirt connection URI, overriding defaults
+        .. versionadded:: 2019.2.0
+    :param username: username to connect with, overriding defaults
+        .. versionadded:: 2019.2.0
+    :param password: password to connect with, overriding defaults
+        .. versionadded:: 2019.2.0
+    CLI Example:
+    .. code-block:: bash
+        salt '*' virt.get_xml <domain>
+    '''
+    conn = __get_conn(**kwargs)
+    xml_desc = _get_domain(conn, vm_).XMLDesc(0)
+    conn.close()
+    return xml_desc
+
+
 def _freemem(conn):
     '''
     Internal variant of freemem taking a libvirt connection as parameter

--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -2629,15 +2629,22 @@ def setvcpus(vm_, vcpus, config=False, **kwargs):
 def get_xml(vm_, **kwargs):
     '''
     Returns the XML for a given vm
+
     :param vm_: domain name
     :param connection: libvirt connection URI, overriding defaults
+
         .. versionadded:: 2019.2.0
     :param username: username to connect with, overriding defaults
+
         .. versionadded:: 2019.2.0
     :param password: password to connect with, overriding defaults
+
         .. versionadded:: 2019.2.0
+
     CLI Example:
+
     .. code-block:: bash
+
         salt '*' virt.get_xml <domain>
     '''
     conn = __get_conn(**kwargs)

--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -324,57 +324,52 @@ def _parse_qemu_img_info(info):
 
 def _get_uuid(dom):
     '''
-    Return a uuid from the named vm
-
-    CLI Example:
-
-    .. code-block:: bash
-
-        salt '*' virt.get_uuid <domain>
+    Get uuid from a libvirt domain object.
     '''
-    return ElementTree.fromstring(get_xml(dom)).find('uuid').text
+    uuid = ElementTree.fromstring(dom.XMLDesc(0)).find('uuid')
+
+    return uuid
 
 
 def _get_on_poweroff(dom):
     '''
-    Return `on_poweroff` setting from the named vm
-
-    CLI Example:
-
-    .. code-block:: bash
-
-        salt '*' virt.get_on_restart <domain>
+    Get on_poweroff from a libvirt domain object.
     '''
-    node = ElementTree.fromstring(get_xml(dom)).find('on_poweroff')
+    node = ElementTree.fromstring(dom.XMLDesc(0)).find('on_poweroff')
+
     return node.text if node is not None else ''
 
 
 def _get_on_reboot(dom):
     '''
-    Return `on_reboot` setting from the named vm
-
-    CLI Example:
-
-    .. code-block:: bash
-
-        salt '*' virt.get_on_reboot <domain>
+    Get on_reboot from a libvirt domain object.
     '''
-    node = ElementTree.fromstring(get_xml(dom)).find('on_reboot')
+    node = ElementTree.fromstring(dom.XMLDesc(0)).find('on_reboot')
+
     return node.text if node is not None else ''
 
 
 def _get_on_crash(dom):
     '''
-    Return `on_crash` setting from the named vm
-
-    CLI Example:
-
-    .. code-block:: bash
-
-        salt '*' virt.get_on_crash <domain>
+    Get on_crash from a libvirt domain object.
     '''
-    node = ElementTree.fromstring(get_xml(dom)).find('on_crash')
+    node = ElementTree.fromstring(dom.XMLDesc(0)).find('on_crash')
+
     return node.text if node is not None else ''
+
+
+def _get_macs(dom):
+    '''
+    Get mac addresses (macs) from a libvirt domain object.
+    '''
+    return [node.get('address') for node in dom.XMLDesc(0).findall('devices/interface/mac')]
+
+
+def _get_disk_devs(dom):
+    '''
+    Get the disk devices names from a libvirt domain object.
+    '''
+    return [target.get('dev') for target in dom.XMLDesc(0).findall('devices/disk/target')]
 
 
 def _get_nics(dom):
@@ -2345,8 +2340,9 @@ def get_macs(vm_, **kwargs):
 
         salt '*' virt.get_macs <domain>
     '''
-    doc = ElementTree.fromstring(get_xml(vm_, **kwargs))
-    return [node.get('address') for node in doc.findall('devices/interface/mac')]
+    macs = _get_macs(_get_domain(conn, vm_))
+
+    return macs
 
 
 def get_graphics(vm_, **kwargs):
@@ -2424,6 +2420,114 @@ def get_disks(vm_, **kwargs):
     disks = _get_disks(_get_domain(conn, vm_))
     conn.close()
     return disks
+
+def get_uuid(vm_, **kwargs):
+    '''
+    Return a uuid from the named vm
+
+    :param vm_: name of the domain
+    :param connection: libvirt connection URI, overriding defaults
+
+        .. versionadded:: 2019.2.0
+    :param username: username to connect with, overriding defaults
+
+        .. versionadded:: 2019.2.0
+    :param password: password to connect with, overriding defaults
+
+        .. versionadded:: 2019.2.0
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' virt.get_uuid <domain>
+    '''
+    conn = __get_conn(**kwargs)
+    uuid = _get_uuid(_get_domain(conn, vm_))
+
+    return uuid
+
+
+def get_on_poweroff(vm_, **kwargs):
+    '''
+    Return a on_poweroff from the named vm
+
+    :param vm_: name of the domain
+    :param connection: libvirt connection URI, overriding defaults
+
+        .. versionadded:: 2019.2.0
+    :param username: username to connect with, overriding defaults
+
+        .. versionadded:: 2019.2.0
+    :param password: password to connect with, overriding defaults
+
+        .. versionadded:: 2019.2.0
+
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' virt.get_on_poweroff <domain>
+    '''
+    conn = __get_conn(**kwargs)
+    on_poweroff = _get_on_poweroff(_get_domain(conn, vm_))
+
+    return on_poweroff
+
+
+def get_on_reboot(vm_, **kwargs):
+    '''
+    Return a on_reboot from the named vm
+
+    :param vm_: name of the domain
+    :param connection: libvirt connection URI, overriding defaults
+
+        .. versionadded:: 2019.2.0
+    :param username: username to connect with, overriding defaults
+
+        .. versionadded:: 2019.2.0
+    :param password: password to connect with, overriding defaults
+
+        .. versionadded:: 2019.2.0
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' virt.get_on_reboot <domain>
+    '''
+    conn = __get_conn(**kwargs)
+    on_reboot = _get_on_reboot(_get_domain(conn, vm_))
+
+    return on_reboot
+
+
+def get_on_crash(vm_, **kwargs):
+    '''
+    Return a on_crash from the named vm
+
+    :param vm_: name of the domain
+    :param connection: libvirt connection URI, overriding defaults
+
+        .. versionadded:: 2019.2.0
+    :param username: username to connect with, overriding defaults
+
+        .. versionadded:: 2019.2.0
+    :param password: password to connect with, overriding defaults
+
+        .. versionadded:: 2019.2.0
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' virt.get_on_crash <domain>
+    '''
+    conn = __get_conn(**kwargs)
+    on_crash = _get_on_crash(_get_domain(conn, vm_))
+
+    return on_crash
 
 
 def setmem(vm_, memory, config=False, **kwargs):
@@ -2624,33 +2728,6 @@ def full_info(**kwargs):
             'vm_info': vm_info()}
     conn.close()
     return info
-
-
-def get_xml(vm_, **kwargs):
-    '''
-    Returns the XML for a given vm
-
-    :param vm_: domain name
-    :param connection: libvirt connection URI, overriding defaults
-
-        .. versionadded:: 2019.2.0
-    :param username: username to connect with, overriding defaults
-
-        .. versionadded:: 2019.2.0
-    :param password: password to connect with, overriding defaults
-
-        .. versionadded:: 2019.2.0
-
-    CLI Example:
-
-    .. code-block:: bash
-
-        salt '*' virt.get_xml <domain>
-    '''
-    conn = __get_conn(**kwargs)
-    xml_desc = _get_domain(conn, vm_).XMLDesc(0)
-    conn.close()
-    return xml_desc
 
 
 def get_profiles(hypervisor=None, **kwargs):
@@ -3747,12 +3824,6 @@ def vm_diskstats(vm_=None, **kwargs):
 
         salt '*' virt.vm_blockstats
     '''
-    def get_disk_devs(dom):
-        '''
-        Extract the disk devices names from the domain XML definition
-        '''
-        doc = ElementTree.fromstring(get_xml(dom, **kwargs))
-        return [target.get('dev') for target in doc.findall('devices/disk/target')]
 
     def _info(dom):
         '''
@@ -3760,7 +3831,7 @@ def vm_diskstats(vm_=None, **kwargs):
         '''
         # Do not use get_disks, since it uses qemu-img and is very slow
         # and unsuitable for any sort of real time statistics
-        disks = get_disk_devs(dom)
+        disks = _get_disk_devs(dom)
         ret = {'rd_req': 0,
                'rd_bytes': 0,
                'wr_req': 0,

--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -2629,14 +2629,20 @@ def setvcpus(vm_, vcpus, config=False, **kwargs):
 def get_xml(vm_, **kwargs):
     '''
     Returns the XML for a given vm
+
     :param vm_: domain name
     :param connection: libvirt connection URI, overriding defaults
+
         .. versionadded:: 2019.2.0
     :param username: username to connect with, overriding defaults
+
         .. versionadded:: 2019.2.0
     :param password: password to connect with, overriding defaults
+
         .. versionadded:: 2019.2.0
+
     CLI Example:
+
     .. code-block:: bash
         salt '*' virt.get_xml <domain>
     '''

--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -2340,7 +2340,9 @@ def get_macs(vm_, **kwargs):
 
         salt '*' virt.get_macs <domain>
     '''
+    conn = __get_conn(**kwargs)
     macs = _get_macs(_get_domain(conn, vm_))
+    conn.close()
 
     return macs
 
@@ -2420,6 +2422,7 @@ def get_disks(vm_, **kwargs):
     disks = _get_disks(_get_domain(conn, vm_))
     conn.close()
     return disks
+
 
 def get_uuid(vm_, **kwargs):
     '''


### PR DESCRIPTION
### What does this PR do?

- It fixes few bugs with the current module and sticks to the standard way of implementing virt module functions, there were inconsistencies in the implementation of few functions like get_on_poweroff, get_on_crash, get_on_reboot, get_uuid and get_profiles. 

- removed function get_xml as it does not belong here

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/52431

### Previous Behavior
`salt '*' virt.vm_info`
The VM "<libvirt.virDomain object at 0x7f24e9e73198>" is not present
### New Behavior
`salt '*' virt.vm_info`
```
minion:
    ----------
    minion-1:
        ----------
        cpu:
            1
        cputime:
            0
        disks:
            ----------
            vda:
                ----------
                cluster size:
                    65536
                disk size:
                    3065716736
                file:
                    /var/lib/libvirt/images/ubuntu16.04.qcow2
                file format:
                    qcow2
                type:
                    disk
                virtual size:
                    10737418240
        graphics:
            ----------
            autoport:
                yes
            keymap:
                None
            listen:
                None
            port:
                None
            type:
                spice
        loader:
            ----------
            path:
                None
        maxMem:
            819200
        mem:
            819200
        nics:
            ----------
            52:54:00:70:b7:63:
                ----------
                address:
                    ----------
                    bus:
                        0x00
                    domain:
                        0x0000
                    function:
                        0x0
                    slot:
                        0x03
                    type:
                        pci
                mac:
                    52:54:00:70:b7:63
                model:
                    virtio
                source:
                    ----------
                    network:
                        default
                type:
                    network
        on_crash:
            destroy
        on_poweroff:
            destroy
        on_reboot:
            restart
        state:
            shutdown
        uuid:
            e6e3f990-8997-4a5e-8cb7-ea835eae4bbe
```
### Tests written?

No (but tested)

### Commits signed with GPG?

Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
