### PR TITLE
Initial support for running tests on AIX

### DIFF
--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -104,15 +104,16 @@ def get_unused_localhost_port():
 
     DARWIN = True if sys.platform.startswith('darwin') else False
     BSD = True if 'bsd' in sys.platform else False
+    AIX = True if sys.platform.startswith('aix') else False
 
-    if DARWIN and port in _RUNTESTS_PORTS:
+    if (AIX or DARWIN) and port in _RUNTESTS_PORTS:
         port = get_unused_localhost_port()
         usock.close()
         return port
 
     _RUNTESTS_PORTS[port] = usock
 
-    if DARWIN or BSD:
+    if DARWIN or BSD or AIX:
         usock.close()
 
     return port

--- a/tests/integration/doc/test_man.py
+++ b/tests/integration/doc/test_man.py
@@ -17,6 +17,7 @@ from tests.support.unit import skipIf
 
 
 @skipIf(salt.utils.platform.is_windows(), 'minion is windows')
+@skipIf(salt.utils.platform.is_aix(), 'minion is AIX')
 class ManTest(ModuleCase):
     rootdir = os.path.join(TMP, 'mantest')
     # Map filenames to search strings which should be in the manpage

--- a/tests/integration/ssh/test_grains.py
+++ b/tests/integration/ssh/test_grains.py
@@ -24,5 +24,7 @@ class SSHGrainsTest(SSHCase):
         grain = 'Linux'
         if salt.utils.platform.is_darwin():
             grain = 'Darwin'
+        if salt.utils.platform.is_aix():
+            grain = 'AIX'
         self.assertEqual(ret['kernel'], grain)
         self.assertTrue(isinstance(ret, dict))


### PR DESCRIPTION
### What does this PR do?
Adds support for running tests on AIX

### What issues does this PR fix or reference?
None, desire to get tests/runtests.py working on AIX to allow for ssh testing

### Previous Behavior
python tests/runtests.py would fail due to inability to open a port on the localhost

### New Behavior
tests/runtests.py can now run tests on AIX.
Note UTF-8 has to be installed on the AIX system, for example:
installp -acXYg -d /stage/middleware/AIX/bos/bos.loc.utf.EN_US.7.1.0.0.I all
and /etc/environment updated with LC_ALL=EN_US and the machine rebooted

### Tests written?
No, now able to run python tests/runtests.py --help and other unit tests
python test/runtests.py -v -n unit/client/test_ssh.py

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
