### PR TITLE
Address inconsistent usage of `get_xml` function in `virt` execution module.

### DIFF
--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -2435,7 +2435,9 @@ def get_xml(vm_, **kwargs):
         salt '*' virt.get_xml <domain>
     '''
     conn = __get_conn(**kwargs)
-    xml_desc = _get_domain(conn, vm_).XMLDesc(0)
+    xml_desc = vm_.XMLDesc(0) if isinstance(
+        vm_, libvirt.virDomain
+    ) else _get_domain(conn, vm_).XMLDesc(0)
     conn.close()
     return xml_desc
 

--- a/tests/unit/modules/test_virt.py
+++ b/tests/unit/modules/test_virt.py
@@ -38,6 +38,10 @@ class LibvirtMock(MagicMock):  # pylint: disable=too-many-ancestors
     '''
     Libvirt library mock
     '''
+    class virDomain(MagicMock):
+        '''
+        virDomain mock
+        '''
 
     class libvirtError(Exception):
         '''
@@ -76,7 +80,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         Define VM to use in tests
         '''
         self.mock_conn.listDefinedDomains.return_value = [name]  # pylint: disable=no-member
-        mock_domain = MagicMock()
+        mock_domain = self.mock_libvirt.virDomain()
         self.mock_conn.lookupByName.return_value = mock_domain  # pylint: disable=no-member
         mock_domain.XMLDesc.return_value = xml  # pylint: disable=no-member
 
@@ -1436,6 +1440,23 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         nic = nics[list(nics)[0]]
         self.assertEqual('bridge', nic['type'])
         self.assertEqual('ac:de:48:b6:8b:59', nic['mac'])
+
+    def test_get_xml(self):
+        '''
+        Test virt.get_xml()
+        '''
+        xml = '''<domain type='kvm' id='7'>
+              <name>test-vm</name>
+              <devices>
+                <graphics type='vnc' port='5900' autoport='yes' listen='0.0.0.0'>
+                  <listen type='address' address='0.0.0.0'/>
+                </graphics>
+              </devices>
+            </domain>
+        '''
+        domain = self.set_mock_vm("test-vm", xml)
+        self.assertEqual(xml, virt.get_xml('test-vm'))
+        self.assertEqual(xml, virt.get_xml(domain))
 
     def test_parse_qemu_img_info(self):
         '''


### PR DESCRIPTION
### What does this PR do?

Attempts to fix inconsistent usage of `get_xml()` in the `virt` execution module, introduced with commit `0f5184c45cc962a1961166d9d6ee8c9522cf431b` as part of PR #48736

### What issues does this PR fix or reference?

Fixes #52431

### Tests written?

No

### Commits signed with GPG?

No
