### PR TITLE
Fix test_xen_virtual on kernels with no Xen support

### DIFF
--- a/tests/unit/grains/test_core.py
+++ b/tests/unit/grains/test_core.py
@@ -820,11 +820,10 @@ class CoreGrainsTestCase(TestCase, LoaderModuleMockMixin):
         '''
         Test if OS grains are parsed correctly in Ubuntu Xenial Xerus
         '''
-        with patch.object(os.path, 'isfile', MagicMock(return_value=False)):
-            with patch.dict(core.__salt__, {'cmd.run': MagicMock(return_value='')}), \
-                patch.object(os.path,
-                             'isfile',
-                             MagicMock(side_effect=lambda x: True if x == '/sys/bus/xen/drivers/xenconsole' else False)):
+        with patch.multiple(os.path, isdir=MagicMock(side_effect=lambda x: x == '/sys/bus/xen'),
+                            isfile=MagicMock(side_effect=lambda x:
+                                             x == '/sys/bus/xen/drivers/xenconsole')):
+            with patch.dict(core.__salt__, {'cmd.run': MagicMock(return_value='')}):
                 log.debug('Testing Xen')
                 self.assertEqual(
                     core._virtual({'kernel': 'Linux'}).get('virtual_subtype'),


### PR DESCRIPTION
The latest version of salt is failing its autopkgtests on ppc64el and s390x architectures in Ubuntu:

```
[...]
FAIL: test_xen_virtual (unit.grains.test_core.CoreGrainsTestCase)
[CPU:0.0%|MEM:53.3%]
----------------------------------------------------------------------
Traceback (most recent call last):
  File "tests/unit/grains/test_core.py", line 701, in test_xen_virtual
    'Xen PV DomU'
AssertionError: None != 'Xen PV DomU'

----------------------------------------------------------------------
Ran 7575 tests in 3249.235s
[...]
```

  (http://autopkgtest.ubuntu.com/packages/s/salt/disco/ppc64el)

The cause of this failure is an improper test which mocks up an isfile check for /sys/bus/xen/drivers/xenconsole, but which doesn't also mock up the check for the /sys/bus/xen directory; so if run on a kernel with no Xen support at all, the test will fail.

The test happens to pass on the other architectures on which Ubuntu runs autopkgtests, because these happen to be architectures which have Xen support and Xen happens to be enabled in the kernels on these architectures. But it's a bad test that depends on the kernel instead of actually unit
testing the code.

Therefore also mock `os.path.isdir` to return `True` for the path `/sys/bus/xen`.

Bug-Debian: https://bugs.debian.org/922352