### PR TITLE
Ignore retcode when checking FS type

### DIFF
--- a/salt/states/blockdev.py
+++ b/salt/states/blockdev.py
@@ -193,5 +193,7 @@ def _checkblk(name):
     Check if the blk exists and return its fstype if ok
     '''
 
-    blk = __salt__['cmd.run']('blkid -o value -s TYPE {0}'.format(name))
+    blk = __salt__['cmd.run'](
+        ['blkid', '-o', 'value', '-s', 'TYPE', name],
+        ignore_retcode=True)
     return '' if not blk else blk

--- a/tests/unit/states/test_blockdev.py
+++ b/tests/unit/states/test_blockdev.py
@@ -12,6 +12,7 @@ from tests.support.unit import skipIf, TestCase
 from tests.support.mock import (
     NO_MOCK,
     NO_MOCK_REASON,
+    Mock,
     MagicMock,
     patch)
 
@@ -107,3 +108,16 @@ class BlockdevTestCase(TestCase, LoaderModuleMockMixin):
                                   MagicMock(return_value=True)):
                     with patch.dict(blockdev.__opts__, {'test': False}):
                         self.assertDictEqual(blockdev.formatted(name), ret)
+
+
+    def test__checkblk(self):
+        '''
+        Confirm that we call cmd.run with ignore_retcode=True
+        '''
+        cmd_mock = Mock()
+        with patch.dict(blockdev.__salt__, {'cmd.run': cmd_mock}):
+            blockdev._checkblk('/dev/foo')
+
+        cmd_mock.assert_called_once_with(
+            ['blkid', '-o', 'value', '-s', 'TYPE', '/dev/foo'],
+            ignore_retcode=True)

--- a/tests/unit/states/test_blockdev.py
+++ b/tests/unit/states/test_blockdev.py
@@ -109,7 +109,6 @@ class BlockdevTestCase(TestCase, LoaderModuleMockMixin):
                     with patch.dict(blockdev.__opts__, {'test': False}):
                         self.assertDictEqual(blockdev.formatted(name), ret)
 
-
     def test__checkblk(self):
         '''
         Confirm that we call cmd.run with ignore_retcode=True


### PR DESCRIPTION
This is used in part to check if the block device being checked actually exists. In these cases, a nonzero exit code is not an error condition, and thus should not have its results logged at the ERROR loglevel.