### PR TITLE
[develop] Support for running kitchen-salt on OS X, disabling a test on OS X

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,3 +25,9 @@ group :vagrant do
   gem 'vagrant-wrapper'
   gem 'kitchen-vagrant'
 end
+
+group :macos do
+  gem 'rbnacl', '< 5.0', :require => false
+  gem 'rbnacl-libsodium', :require => false
+  gem 'bcrypt_pbkdf', '< 2.0', :require => false
+end

--- a/tests/unit/modules/test_cmdmod.py
+++ b/tests/unit/modules/test_cmdmod.py
@@ -345,6 +345,7 @@ class CMDMODTestCase(TestCase, LoaderModuleMockMixin):
             raise RuntimeError
 
     @skipIf(salt.utils.platform.is_windows(), 'Do not run on Windows')
+    @skipIf(salt.utils.platform.is_darwin(), 'Do not run on MacOS')
     def test_run_cwd_in_combination_with_runas(self):
         '''
         cmd.run executes command in the cwd directory


### PR DESCRIPTION
### What does this PR do?
Adding gems needed to run kitchen-salt on OS X.  Disabling a unit test that does not currently run successfully on OS X.

### What issues does this PR fix or reference?
N/A

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
