### PR TITLE
Try to resolve user local groups without LG_INCLUDE_INDIRECT flag

### DIFF
--- a/salt/utils/win_functions.py
+++ b/salt/utils/win_functions.py
@@ -83,7 +83,12 @@ def get_user_groups(name, sid=False):
         # 'win32net.NetUserGetLocalGroups' will fail if you pass in 'SYSTEM'.
         groups = [name]
     else:
-        groups = win32net.NetUserGetLocalGroups(None, name)
+        try:
+            groups = win32net.NetUserGetLocalGroups(None, name)
+        except pywintypes.error as exc:
+            # Try without LG_INCLUDE_INDIRECT flag, because the user might not have
+            # permissions for it
+            groups = win32net.NetUserGetLocalGroups(None, name, 0)
 
     if not sid:
         return groups


### PR DESCRIPTION
### What does this PR do?
Try to resolve user groups without the LG_INCLUDE_INDIRECT flag when it fails for the first time with the flag set

### What issues does this PR fix or reference?
Fix #52577

### Previous Behavior
Salt-minion startup fails with `Access is denied.` message.

![image001](https://user-images.githubusercontent.com/1144837/56286819-f7720700-611a-11e9-8428-2dd4838b831f.png)


### New Behavior
Salt-minion starts up and works.

### Tests written?

No

### Commits signed with GPG?

Yes
