### PR TITLE
Use functools.wraps with decorators

### DIFF
--- a/salt/utils/decorators/__init__.py
+++ b/salt/utils/decorators/__init__.py
@@ -344,6 +344,7 @@ class _IsDeprecated(_DeprecationDecorator):
         '''
         _DeprecationDecorator.__call__(self, function)
 
+        @wraps(function)
         def _decorate(*args, **kwargs):
             '''
             Decorator function.
@@ -518,6 +519,7 @@ class _WithDeprecated(_DeprecationDecorator):
         '''
         _DeprecationDecorator.__call__(self, function)
 
+        @wraps(function)
         def _decorate(*args, **kwargs):
             '''
             Decorator function.

--- a/salt/utils/decorators/__init__.py
+++ b/salt/utils/decorators/__init__.py
@@ -574,6 +574,7 @@ def ignores_kwargs(*kwarg_names):
         List of argument names to ignore
     '''
     def _ignores_kwargs(fn):
+        @wraps(fn)
         def __ignores_kwargs(*args, **kwargs):
             kwargs_filtered = kwargs.copy()
             for name in kwarg_names:

--- a/tests/unit/utils/test_decorators.py
+++ b/tests/unit/utils/test_decorators.py
@@ -354,37 +354,25 @@ class DecoratorsTest(TestCase):
             assert depr(self.new_function)() == self.new_function()
 
     def test_with_depreciated_should_wrap_function(self):
-        def func(): pass
-
-        wrapped = decorators.with_deprecated({}, "Beryllium")(func)
-        assert wrapped.__module__ == func.__module__
+        wrapped = decorators.with_deprecated({}, "Beryllium")(self.old_function)
+        assert wrapped.__module__ == self.old_function.__module__
 
     def test_is_deprecated_should_wrap_function(self):
-        def func(): pass
-
-        wrapped = decorators.is_deprecated({}, "Beryllium")(func)
-        assert wrapped.__module__ == func.__module__
+        wrapped = decorators.is_deprecated({}, "Beryllium")(self.old_function)
+        assert wrapped.__module__ == self.old_function.__module__
 
     def test_ensure_unicode_args_should_wrap_function(self):
-        def func(): pass
-
-        wrapped = decorators.ensure_unicode_args(func)
-        assert wrapped.__module__ == func.__module__
+        wrapped = decorators.ensure_unicode_args(self.old_function)
+        assert wrapped.__module__ == self.old_function.__module__
 
     def test_ignores_kwargs_should_wrap_function(self):
-        def func(): pass
-
-        wrapped = decorators.ignores_kwargs('foo', 'bar')(func)
-        assert wrapped.__module__ == func.__module__
+        wrapped = decorators.ignores_kwargs('foo', 'bar')(self.old_function)
+        assert wrapped.__module__ == self.old_function.__module__
 
     def test_memoize_should_wrap_function(self):
-        def func(): pass
-
-        wrapped = decorators.memoize(func)
-        assert wrapped.__module__ == func.__module__
+        wrapped = decorators.memoize(self.old_function)
+        assert wrapped.__module__ == self.old_function.__module__
 
     def timing_should_wrap_function(self):
-        def func(): pass
-            
-        wrapped = decorators.timing(func)
-        assert wrapped.__module__ == func.__module__
+        wrapped = decorators.timing(self.old_function)
+        assert wrapped.__module__ == self.old_function.__module__

--- a/tests/unit/utils/test_decorators.py
+++ b/tests/unit/utils/test_decorators.py
@@ -352,3 +352,39 @@ class DecoratorsTest(TestCase):
         depr._curr_version = self._mk_version("Helium")[1]
         with self.assertRaises(SaltConfigurationError):
             assert depr(self.new_function)() == self.new_function()
+
+    def test_with_depreciated_should_wrap_function(self):
+        def func(): pass
+
+        wrapped = decorators.with_deprecated({}, "Beryllium")(func)
+        assert wrapped.__module__ == func.__module__
+
+    def test_is_deprecated_should_wrap_function(self):
+        def func(): pass
+
+        wrapped = decorators.is_deprecated({}, "Beryllium")(func)
+        assert wrapped.__module__ == func.__module__
+
+    def test_ensure_unicode_args_should_wrap_function(self):
+        def func(): pass
+
+        wrapped = decorators.ensure_unicode_args(func)
+        assert wrapped.__module__ == func.__module__
+
+    def test_ignores_kwargs_should_wrap_function(self):
+        def func(): pass
+
+        wrapped = decorators.ignores_kwargs('foo', 'bar')(func)
+        assert wrapped.__module__ == func.__module__
+
+    def test_memoize_should_wrap_function(self):
+        def func(): pass
+
+        wrapped = decorators.memoize(func)
+        assert wrapped.__module__ == func.__module__
+
+    def timing_should_wrap_function(self):
+        def func(): pass
+            
+        wrapped = decorators.timing(func)
+        assert wrapped.__module__ == func.__module__


### PR DESCRIPTION
### What does this PR do?

Otherwise, we're not fully wrapping the function so expected attributes
(at least __opts__ anyway) go missing.

### What issues does this PR fix or reference?

Fixes #44639

### Previous Behavior

See #44639, but basically, any function that was `_decorated` with `with_deprecated` or `is_deprecated` will 🔥 💥 when set as a prereq, because we're introspecting the function to get `__opts__`, but because we're hitting the decorator instead of the original function it goes down like a lead zeppelin.

### New Behavior

Now that the `_decorated` function uses `functools.wraps`, proper introspection is proper and leads to the original function instead of `_decorated` 🙌 

### Tests written?

No(t yet?) - I'm not exactly sure what (if any) the best test would be here :suspect: 

### Commits signed with GPG?

Yes