### PR TITLE
Add missing files to release tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -17,7 +17,7 @@ include tests/integration/files/*
 include tests/unit/templates/files/*
 recursive-include doc *
 recursive-include scripts *
-include conf/*
+recursive-include conf *
 recursive-include pkg *
 recursive-include salt *.jinja
 recursive-include salt *.flo

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,11 +1,15 @@
 include AUTHORS
+include CODE_OF_CONDUCT.md
+include CONTRIBUTING.rst
 include HACKING.rst
 include LICENSE
+include NOTICE
 include README.rst
 include requirements/base.txt
 include requirements/raet.txt
 include requirements/cloud.txt
 include requirements/zeromq.txt
+include SUPPORT.rst
 include tests/*.py
 recursive-include tests *
 include tests/integration/modules/files/*

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -21,5 +21,6 @@ recursive-include conf *
 recursive-include pkg *
 recursive-include salt *.jinja
 recursive-include salt *.flo
+recursive-include templates *
 include salt/templates/git/*
 include salt/templates/lxc/*


### PR DESCRIPTION
The release tarball misses several relevent files for documentation or the unit tests. This set of commits add them.

Add CODE_OF_CONDUCT.md, CONTRIBUTING.rst, NOTICE, and SUPPORT.rst into the release tarball, because these files are also useful there.

The unit tests in `unit.test_config.SampleConfTest` require the directories `conf/cloud.profiles.d`, `conf/cloud.providers.d`, and `conf/cloud.maps.d` to be present and to contain the relevant files.
The unit test `unit.utils.test_extend.ExtendTestCase` needs to access the files in the `templates` directory.

The test case `tests.unit.test_module.names.ZyppPluginsTestCase` requires `scripts/suse/zypper/plugins/commit/zyppnotify`.