### PR TITLE
Improve dpkg_lowpkg

### DIFF
--- a/salt/modules/dpkg_lowpkg.py
+++ b/salt/modules/dpkg_lowpkg.py
@@ -150,7 +150,8 @@ def list_pkgs(*packages):
     .. code-block:: bash
 
         salt '*' lowpkg.list_pkgs
-        salt '*' lowpkg.list_pkgs httpd
+        salt '*' lowpkg.list_pkgs hostname
+        salt '*' lowpkg.list_pkgs hostname mount
     """
     cmd = [
         "dpkg-query",
@@ -179,8 +180,8 @@ def file_list(*packages):
 
     .. code-block:: bash
 
-        salt '*' lowpkg.file_list httpd
-        salt '*' lowpkg.file_list httpd postfix
+        salt '*' lowpkg.file_list hostname
+        salt '*' lowpkg.file_list hostname mount
         salt '*' lowpkg.file_list
     """
     errors = []
@@ -214,8 +215,8 @@ def file_dict(*packages):
 
     .. code-block:: bash
 
-        salt '*' lowpkg.file_dict httpd
-        salt '*' lowpkg.file_dict httpd postfix
+        salt '*' lowpkg.file_dict hostname
+        salt '*' lowpkg.file_dict hostname mount
         salt '*' lowpkg.file_dict
     """
     errors = []

--- a/salt/modules/dpkg_lowpkg.py
+++ b/salt/modules/dpkg_lowpkg.py
@@ -200,11 +200,8 @@ def file_list(*packages):
         if "No packages found" in line:
             errors.append(line)
     for pkg in pkgs:
-        files = []
-        cmd = "dpkg -L {0}".format(pkg)
-        for line in __salt__["cmd.run"](cmd, python_shell=False).splitlines():
-            files.append(line)
-        fileset = set(files)
+        output = __salt__["cmd.run"](["dpkg", "-L", pkg], python_shell=False)
+        fileset = set(output.splitlines())
         ret = ret.union(fileset)
     return {"errors": errors, "files": list(ret)}
 
@@ -241,11 +238,8 @@ def file_dict(*packages):
         if "No packages found" in line:
             errors.append(line)
     for pkg in pkgs:
-        files = []
-        cmd = "dpkg -L {0}".format(pkg)
-        for line in __salt__["cmd.run"](cmd, python_shell=False).splitlines():
-            files.append(line)
-        ret[pkg] = files
+        cmd = ["dpkg", "-L", pkg]
+        ret[pkg] = __salt__["cmd.run"](cmd, python_shell=False).splitlines()
     return {"errors": errors, "packages": ret}
 
 

--- a/salt/modules/dpkg_lowpkg.py
+++ b/salt/modules/dpkg_lowpkg.py
@@ -214,9 +214,9 @@ def file_dict(*packages):
 
     .. code-block:: bash
 
-        salt '*' lowpkg.file_list httpd
-        salt '*' lowpkg.file_list httpd postfix
-        salt '*' lowpkg.file_list
+        salt '*' lowpkg.file_dict httpd
+        salt '*' lowpkg.file_dict httpd postfix
+        salt '*' lowpkg.file_dict
     """
     errors = []
     ret = {}

--- a/salt/modules/dpkg_lowpkg.py
+++ b/salt/modules/dpkg_lowpkg.py
@@ -203,7 +203,7 @@ def file_list(*packages):
         output = __salt__["cmd.run"](["dpkg", "-L", pkg], python_shell=False)
         fileset = set(output.splitlines())
         ret = ret.union(fileset)
-    return {"errors": errors, "files": list(ret)}
+    return {"errors": errors, "files": sorted(ret)}
 
 
 def file_dict(*packages):


### PR DESCRIPTION
While trying to work on fixing #52605, I stumbled over some code in `dpkg_lowpkg` that could be improved. This pull requests changes the code to use `dpkg-query` for listing packages instead of `dpkg -L`, because the output is easier to parse. Also remove some useless loop iterations and improve the documentation. Please have a look at the individual commits for details.