### PR TITLE
Add win function tests

### DIFF
--- a/tests/unit/utils/test_win_functions.py
+++ b/tests/unit/utils/test_win_functions.py
@@ -5,14 +5,22 @@ from __future__ import absolute_import, unicode_literals, print_function
 
 # Import Salt Testing Libs
 from tests.support.unit import TestCase, skipIf
-from tests.support.mock import (
-    NO_MOCK,
-    NO_MOCK_REASON
-)
+from tests.support.mock import patch, NO_MOCK, NO_MOCK_REASON
 
 # Import Salt Libs
 import salt.utils.platform
 import salt.utils.win_functions as win_functions
+
+# Import 3rd Party Libs
+try:
+    import win32net
+    HAS_WIN32 = True
+
+    class WinError(win32net.error):
+        winerror = 0
+
+except ImportError:
+    HAS_WIN32 = False
 
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
@@ -53,9 +61,47 @@ class WinFunctionsTestCase(TestCase):
 
         self.assertEqual(encoded, '^"C:\\Some Path\\With Spaces^"')
 
-    @skipIf(not salt.utils.platform.is_windows(), 'WinDLL only available on Windows')
+    @skipIf(not salt.utils.platform.is_windows(),
+            'WinDLL only available on Windows')
     def test_broadcast_setting_change(self):
         '''
             Test to rehash the Environment variables
         '''
         self.assertTrue(win_functions.broadcast_setting_change())
+
+    @skipIf(not salt.utils.platform.is_windows(),
+            'WinDLL only available on Windows')
+    def test_get_user_groups(self):
+        groups = ['Administrators', 'Users']
+        with patch('win32net.NetUserGetLocalGroups', return_value=groups):
+            ret = win_functions.get_user_groups('Administrator')
+            self.assertListEqual(groups, ret)
+
+    @skipIf(not salt.utils.platform.is_windows(),
+            'WinDLL only available on Windows')
+    def test_get_user_groups_sid(self):
+        groups = ['Administrators', 'Users']
+        expected = ['S-1-5-32-544', 'S-1-5-32-545']
+        with patch('win32net.NetUserGetLocalGroups', return_value=groups):
+            ret = win_functions.get_user_groups('Administrator', sid=True)
+            self.assertListEqual(expected, ret)
+
+    @skipIf(not salt.utils.platform.is_windows(),
+            'WinDLL only available on Windows')
+    def test_get_user_groups_system(self):
+        groups = ['SYSTEM']
+        with patch('win32net.NetUserGetLocalGroups', return_value=groups):
+            ret = win_functions.get_user_groups('SYSTEM')
+            self.assertListEqual(groups, ret)
+
+    @skipIf(not salt.utils.platform.is_windows(),
+            'WinDLL only available on Windows')
+    @skipIf(not HAS_WIN32, 'Requires pywin32 libraries')
+    def test_get_user_groups_missing_permission(self):
+        groups = ['Administrators', 'Users']
+        win_error = WinError()
+        win_error.winerror = 5
+        effect = [win_error, groups]
+        with patch('win32net.NetUserGetLocalGroups', side_effect=effect):
+            ret = win_functions.get_user_groups('Administrator')
+            self.assertListEqual(groups, ret)

--- a/tests/unit/utils/test_win_functions.py
+++ b/tests/unit/utils/test_win_functions.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import, unicode_literals, print_function
 
 # Import Salt Testing Libs
 from tests.support.unit import TestCase, skipIf
-from tests.support.mock import patch, NO_MOCK, NO_MOCK_REASON
+from tests.support.mock import patch, MagicMock, NO_MOCK, NO_MOCK_REASON
 
 # Import Salt Libs
 import salt.utils.platform
@@ -105,3 +105,14 @@ class WinFunctionsTestCase(TestCase):
         with patch('win32net.NetUserGetLocalGroups', side_effect=effect):
             ret = win_functions.get_user_groups('Administrator')
             self.assertListEqual(groups, ret)
+
+    @skipIf(not salt.utils.platform.is_windows(),
+            'WinDLL only available on Windows')
+    @skipIf(not HAS_WIN32, 'Requires pywin32 libraries')
+    def test_get_user_groups_missing_permission(self):
+        win_error = WinError()
+        win_error.winerror = 1927
+        mock_error = MagicMock(side_effect=win_error)
+        with patch('win32net.NetUserGetLocalGroups', side_effect=mock_error):
+            with self.assertRaises(WinError):
+                win_functions.get_user_groups('Administrator')

--- a/tests/unit/utils/test_win_functions.py
+++ b/tests/unit/utils/test_win_functions.py
@@ -109,7 +109,7 @@ class WinFunctionsTestCase(TestCase):
     @skipIf(not salt.utils.platform.is_windows(),
             'WinDLL only available on Windows')
     @skipIf(not HAS_WIN32, 'Requires pywin32 libraries')
-    def test_get_user_groups_missing_permission(self):
+    def test_get_user_groups_error(self):
         win_error = WinError()
         win_error.winerror = 1927
         mock_error = MagicMock(side_effect=win_error)


### PR DESCRIPTION
### What does this PR do?
Fixes some minor issues with the `get_user_groups` function.
- It was returning inconsistent types. A list if `sid=False` and a set if `sid=True`.
- Checks for specific error (`5`). Raises if it's not that one

Adds tests for the `get_user_groups` function, including a test to address https://github.com/saltstack/salt/pull/52596

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/pull/52596

### Tests written?
Yes

### Commits signed with GPG?
Yes