### PR TITLE
[2019.2] Fix to beacons.reset

### DIFF
--- a/salt/beacons/__init__.py
+++ b/salt/beacons/__init__.py
@@ -434,3 +434,14 @@ class Beacon(object):
         Reset the beacons to defaults
         '''
         self.opts['beacons'] = {}
+
+        comment = 'Beacon Reset'
+        complete = True
+
+        # Fire the complete event back along with updated list of beacons
+        evt = salt.utils.event.get_event('minion', opts=self.opts)
+        evt.fire_event({'complete': complete, 'comment': comment,
+                        'beacons': self.opts['beacons']},
+                       tag='/salt/minion/minion_beacon_reset_complete')
+
+        return True

--- a/salt/modules/beacons.py
+++ b/salt/modules/beacons.py
@@ -613,7 +613,7 @@ def reset(**kwargs):
     ret = {'comment': [],
            'result': True}
 
-    if 'test' in kwargs and kwargs['test']:
+    if kwargs.get('test'):
         ret['comment'] = 'Beacons would be reset.'
     else:
         try:
@@ -628,7 +628,7 @@ def reset(**kwargs):
                     ret['comment'] = 'Beacon configuration reset.'
                 else:
                     ret['result'] = False
-                    ret['comment'] = event_ret['comment']
+                    ret['comment'] = 'Something went wrong.'
                 return ret
         except KeyError:
             # Effectively a no-op, since we can't really return without an event system


### PR DESCRIPTION
### What does this PR do?
Fixing the beacons.reset function.  Once the reset has taken place in beacons/__init__.py we need to fire an event back to complete the loop and ensure that everything worked as expected.

### What issues does this PR fix or reference?
N/A

### Tests written?
Yes.  Tests exist.

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
