### PR TITLE
fix TypeError: argument of type int is not iterable

### DIFF
--- a/salt/cli/batch.py
+++ b/salt/cli/batch.py
@@ -85,7 +85,8 @@ class Batch(object):
         '''
         partition = lambda x: float(x) / 100.0 * len(self.minions)
         try:
-            if isinstance(self.opts['batch'], str) and '%' in self.opts['batch']:
+            if (isinstance(self.opts['batch'], str) or isinstance(self.opts['batch'], unicode)) \
+                    and '%' in self.opts['batch']:
                 res = partition(float(self.opts['batch'].strip('%')))
                 if res < 1:
                     return int(math.ceil(res))

--- a/salt/cli/batch.py
+++ b/salt/cli/batch.py
@@ -8,6 +8,7 @@ from __future__ import absolute_import, print_function, unicode_literals
 import math
 import time
 import copy
+import sys
 from datetime import datetime, timedelta
 
 # Import salt libs
@@ -85,8 +86,11 @@ class Batch(object):
         '''
         partition = lambda x: float(x) / 100.0 * len(self.minions)
         try:
-            if (isinstance(self.opts['batch'], str) or isinstance(self.opts['batch'], unicode)) \
-                    and '%' in self.opts['batch']:
+            if sys.version_info.major == 3:
+                batch_is_str = isinstance(self.opts['batch'], str)
+            else:
+                batch_is_str = isinstance(self.opts['batch'], str) or isinstance(self.opts['batch'], unicode)
+            if batch_is_str and '%' in self.opts['batch']:
                 res = partition(float(self.opts['batch'].strip('%')))
                 if res < 1:
                     return int(math.ceil(res))

--- a/salt/cli/batch.py
+++ b/salt/cli/batch.py
@@ -8,7 +8,6 @@ from __future__ import absolute_import, print_function, unicode_literals
 import math
 import time
 import copy
-import sys
 from datetime import datetime, timedelta
 
 # Import salt libs
@@ -86,11 +85,7 @@ class Batch(object):
         '''
         partition = lambda x: float(x) / 100.0 * len(self.minions)
         try:
-            if sys.version_info.major == 3:
-                batch_is_str = isinstance(self.opts['batch'], str)
-            else:
-                batch_is_str = isinstance(self.opts['batch'], str) or isinstance(self.opts['batch'], unicode)
-            if batch_is_str and '%' in self.opts['batch']:
+            if isinstance(self.opts['batch'], six.string_types) and '%' in self.opts['batch']:
                 res = partition(float(self.opts['batch'].strip('%')))
                 if res < 1:
                     return int(math.ceil(res))

--- a/salt/cli/batch.py
+++ b/salt/cli/batch.py
@@ -85,7 +85,7 @@ class Batch(object):
         '''
         partition = lambda x: float(x) / 100.0 * len(self.minions)
         try:
-            if '%' in self.opts['batch']:
+            if isinstance(self.opts['batch'], str) and '%' in self.opts['batch']:
                 res = partition(float(self.opts['batch'].strip('%')))
                 if res < 1:
                     return int(math.ceil(res))

--- a/tests/unit/cli/test_batch.py
+++ b/tests/unit/cli/test_batch.py
@@ -35,11 +35,19 @@ class BatchTestCase(TestCase):
 
     # get_bnum tests
 
-    def test_get_bnum(self):
+    def test_get_bnum_str(self):
         '''
-        Tests passing batch value as a number
+        Tests passing batch value as a number(str)
         '''
         self.batch.opts = {'batch': '2', 'timeout': 5}
+        self.batch.minions = ['foo', 'bar']
+        self.assertEqual(Batch.get_bnum(self.batch), 2)
+
+    def test_get_bnum_int(self):
+        '''
+        Tests passing batch value as a number(int)
+        '''
+        self.batch.opts = {'batch': 2, 'timeout': 5}
         self.batch.minions = ['foo', 'bar']
         self.assertEqual(Batch.get_bnum(self.batch), 2)
 


### PR DESCRIPTION
### What does this PR do?
fix a batch run bug, when batch_safe_size is set to a integer or percentage,  will resulting in "TypeError: argument of type 'int' is not iterable"

### Tests written?

Yes

### Commits signed with GPG?

Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
