### PR TITLE
Update test_schema to mirror the new ValidationErrors in 3.0.0

### DIFF
--- a/tests/unit/utils/test_schema.py
+++ b/tests/unit/utils/test_schema.py
@@ -509,7 +509,10 @@ class ConfigTestCase(TestCase):
                 {'personal_access_token': 'foo'},
                 Requirements.serialize()
             )
-        self.assertIn('is not valid under any of the given schemas', excinfo.exception.message)
+        if JSONSCHEMA_VERSION >= _LooseVersion('3.0.0'):
+            self.assertIn('\'ssh_key_file\' is a required property', excinfo.exception.message)
+        else:
+            self.assertIn('is not valid under any of the given schemas', excinfo.exception.message)
 
     def test_boolean_config(self):
         item = schema.BooleanItem(title='Hungry', description='Are you hungry?')
@@ -1731,7 +1734,10 @@ class ConfigTestCase(TestCase):
 
         with self.assertRaises(jsonschema.exceptions.ValidationError) as excinfo:
             jsonschema.validate({'item': {'sides': '4', 'color': 'blue'}}, TestConf.serialize())
-        self.assertIn('is not valid under any of the given schemas', excinfo.exception.message)
+        if JSONSCHEMA_VERSION >= _LooseVersion('3.0.0'):
+            self.assertIn('\'4\' is not of type \'boolean\'', excinfo.exception.message)
+        else:
+            self.assertIn('is not valid under any of the given schemas', excinfo.exception.message)
 
         class TestConf(schema.Schema):
             item = schema.DictItem(
@@ -1834,7 +1840,10 @@ class ConfigTestCase(TestCase):
 
         with self.assertRaises(jsonschema.exceptions.ValidationError) as excinfo:
             jsonschema.validate({'item': ['maybe']}, TestConf.serialize())
-        self.assertIn('is not valid under any of the given schemas', excinfo.exception.message)
+        if JSONSCHEMA_VERSION >= _LooseVersion('3.0.0'):
+            self.assertIn('\'maybe\' is not one of [\'yes\']', excinfo.exception.message)
+        else:
+            self.assertIn('is not valid under any of the given schemas', excinfo.exception.message)
 
         with self.assertRaises(jsonschema.exceptions.ValidationError) as excinfo:
             jsonschema.validate({'item': 2}, TestConf.serialize())
@@ -1886,7 +1895,10 @@ class ConfigTestCase(TestCase):
 
         with self.assertRaises(jsonschema.exceptions.ValidationError) as excinfo:
             jsonschema.validate({'item': ['maybe']}, TestConf.serialize())
-        self.assertIn('is not valid under any of the given schemas', excinfo.exception.message)
+        if JSONSCHEMA_VERSION >= _LooseVersion('3.0.0'):
+            self.assertIn('\'maybe\' is not one of [\'yes\']', excinfo.exception.message)
+        else:
+            self.assertIn('is not valid under any of the given schemas', excinfo.exception.message)
 
         with self.assertRaises(jsonschema.exceptions.ValidationError) as excinfo:
             jsonschema.validate({'item': 2}, TestConf.serialize())


### PR DESCRIPTION
### What does this PR do?
Fixes the failing tests: `unit.utils.test_schema`

In jsonschema version 3.0.0 the validation errors were updated to grab the best match, instead of the default `is not valid under any of the given schemas` in this commit: https://github.com/Julian/jsonschema/commit/17fb9cb006402f68b9fbf3b6877a778135f0aecc

to fix this issue: https://github.com/Julian/jsonschema/issues/498

This updates the tests to check for the error's with more detail when testing with >= 3.0.0 

### What issues does this PR fix or reference?
Fixes https://github.com/saltstack/salt/issues/52085

### Tests written?

No- Fixes current tests failing on osx

### Commits signed with GPG?

Yes