### PR TITLE
Fixes: #51797

### DIFF
--- a/salt/modules/netbox.py
+++ b/salt/modules/netbox.py
@@ -164,7 +164,7 @@ def filter_(app, endpoint, **kwargs):
     )
     if nb_query:
         ret = [_strip_url_field(dict(i)) for i in nb_query]
-    return sorted(ret)
+    return ret
 
 
 def get_(app, endpoint, id=None, **kwargs):


### PR DESCRIPTION
### What does this PR do?
Fixes issuing in py3 of sorting dicts by returning results from
`filter_()` unsorted.

### What issues does this PR fix or reference?
#51797 

### Previous Behavior
Sorted return from `filter_()`.

### New Behavior
Does not sort return from `filter_()`.

### Tests written?

No

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
