### PR TITLE
Fix salt.modules.publish and salt.states.x509 tests

### DIFF
--- a/salt/modules/x509.py
+++ b/salt/modules/x509.py
@@ -1391,10 +1391,13 @@ def create_certificate(
         for ignore in list(_STATE_INTERNAL_KEYWORDS) + \
                 ['listen_in', 'preqrequired', '__prerequired__']:
             kwargs.pop(ignore, None)
+        # TODO: Make timeout configurable in Neon
         certs = __salt__['publish.publish'](
             tgt=ca_server,
             fun='x509.sign_remote_certificate',
-            arg=salt.utils.data.decode_dict(kwargs, to_str=True))
+            arg=salt.utils.data.decode_dict(kwargs, to_str=True),
+            timeout=30
+        )
 
         if not any(certs):
             raise salt.exceptions.SaltInvocationError(

--- a/tests/integration/files/conf/master
+++ b/tests/integration/files/conf/master
@@ -28,7 +28,8 @@ tcp_master_workers: 64515
 
 peer:
   '.*':
-    - 'test.*'
+    - '(x509|test).*'
+    #- 'x509.sign_remote_certificate'
 
 ext_pillar:
   - ext_pillar_opts:

--- a/tests/integration/files/conf/master
+++ b/tests/integration/files/conf/master
@@ -29,7 +29,6 @@ tcp_master_workers: 64515
 peer:
   '.*':
     - '(x509|test).*'
-    #- 'x509.sign_remote_certificate'
 
 ext_pillar:
   - ext_pillar_opts:

--- a/tests/integration/files/conf/master.d/peers.conf
+++ b/tests/integration/files/conf/master.d/peers.conf
@@ -1,3 +1,0 @@
-peer:
-  .*:
-    - x509.sign_remote_certificate

--- a/tests/integration/states/test_x509.py
+++ b/tests/integration/states/test_x509.py
@@ -60,6 +60,9 @@ class x509Test(ModuleCase, SaltReturnAssertsMixin):
     def tearDown(self):
         os.remove(os.path.join(TMP_PILLAR_TREE, 'signing_policies.sls'))
         os.remove(os.path.join(TMP_PILLAR_TREE, 'top.sls'))
+        certs_path = os.path.join(TMP, 'pki')
+        if os.path.exists(certs_path):
+            salt.utils.files.rm_rf(certs_path)
         self.run_function('saltutil.refresh_pillar')
 
     def run_function(self, *args, **kwargs):


### PR DESCRIPTION
The peers.conf addition for the x509 state tests broke the
salt.modules.publish tests. Move the configuration to the test master's
config. Also increase the publish call timeout in the x509 module to
make the x509 state tests reliable on all platforms.

This PR fixes the following tests:
```
integration.modules.test_publish.PublishModuleTest.test_full_data
integration.modules.test_publish.PublishModuleTest.test_publish
integration.modules.test_publish.PublishModuleTest.test_publish_yaml_args
integration.modules.test_publish.PublishModuleTest.test_kwarg
```

And makes the following tests more reliable:
```
tests.integration.states.test_x509.x509Test.test_cert_signing
```

Fixes: #52508
### Tests written?

No - Fixing tests

### Commits signed with GPG?

Yes