### PR TITLE
Parse chattr version and fix test case

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -174,7 +174,7 @@ def _parse_chattr_man(man):
     '''
     match = re.search(
         r'E2fsprogs version [0-9\.]+',
-        salt.utils.string_utils.to_str(man),
+        salt.utils.stringutils.to_str(man),
     )
     if match:
         version = match.group().strip('E2fsprogs version ')

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -172,7 +172,7 @@ def _parse_chattr_man(man):
     '''
     Parse the contents of a chattr man page to find the E2fsprogs version
     '''
-    match = re.search('E2fsprogs version [0-9\.]+', man)
+    match = re.search(r'E2fsprogs version [0-9\.]+', man)
     if match:
         version = match.group().strip('E2fsprogs version ')
     else:
@@ -608,7 +608,7 @@ def lsattr(path):
             needed_version = salt.utils.versions.LooseVersion('1.41.12')
             chattr_version = salt.utils.versions.LooseVersion(_chattr_version())
             # The version of chattr on Centos 6 does not support extended
-            # attributes. 
+            # attributes.
             if chattr_version > needed_version:
                 results[vals[1]] = re.findall(r"[aAcCdDeijPsStTu]", vals[0])
             else:

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -23,6 +23,7 @@ import re
 import shutil
 import stat
 import string
+import subprocess
 import sys
 import tempfile
 import time
@@ -61,6 +62,7 @@ import salt.utils.templates
 import salt.utils.url
 import salt.utils.user
 import salt.utils.data
+import salt.utils.versions
 from salt.exceptions import CommandExecutionError, MinionError, SaltInvocationError, get_error_message as _get_error_message
 from salt.utils.files import HASHES, HASHES_REVMAP
 
@@ -157,6 +159,32 @@ def _splitlines_preserving_trailing_newline(str):
     if str.endswith('\n') or str.endswith('\r'):
         lines.append('')
     return lines
+
+
+def _get_chattr_man():
+    '''
+    Get the contents of the chattr man page
+    '''
+    return subprocess.check_output(['man', 'chattr'])
+
+
+def _parse_chattr_man(man):
+    '''
+    Parse the contents of a chattr man page to find the E2fsprogs version
+    '''
+    match = re.search('E2fsprogs version [0-9\.]+', man)
+    if match:
+        version = match.group().strip('E2fsprogs version ')
+    else:
+        version = None
+    return version
+
+
+def _chattr_version():
+    '''
+    Return the version of chattr installed
+    '''
+    return _parse_chattr_man(_get_chattr_man())
 
 
 def gid_to_group(gid):
@@ -577,7 +605,14 @@ def lsattr(path):
     for line in result.splitlines():
         if not line.startswith('lsattr: '):
             vals = line.split(None, 1)
-            results[vals[1]] = re.findall(r"[aAcCdDeijPsStTu]", vals[0])
+            needed_version = salt.utils.versions.LooseVersion('1.41.12')
+            chattr_version = salt.utils.versions.LooseVersion(_chattr_version())
+            # The version of chattr on Centos 6 does not support extended
+            # attributes. 
+            if chattr_version > needed_version:
+                results[vals[1]] = re.findall(r"[aAcCdDeijPsStTu]", vals[0])
+            else:
+                results[vals[1]] = re.findall(r"[acdijstuADST]", vals[0])
 
     return results
 

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -172,7 +172,10 @@ def _parse_chattr_man(man):
     '''
     Parse the contents of a chattr man page to find the E2fsprogs version
     '''
-    match = re.search(r'E2fsprogs version [0-9\.]+', man)
+    match = re.search(
+        r'E2fsprogs version [0-9\.]+',
+        salt.utils.string_utils.to_str(man),
+    )
     if match:
         version = match.group().strip('E2fsprogs version ')
     else:

--- a/tests/filename_map.yml
+++ b/tests/filename_map.yml
@@ -43,6 +43,9 @@ salt/modules/dockermod.py:
   - integration.states.test_docker_container
   - integration.states.test_docker_network
 
+salt/modules/file.py:
+  - integration.states.test_cron
+
 salt/modules/influxdb08mod.py:
   - unit.states.test_influxdb08_database
   - unit.states.test_influxdb08_user

--- a/tests/unit/modules/test_file.py
+++ b/tests/unit/modules/test_file.py
@@ -8,7 +8,7 @@ import tempfile
 import textwrap
 
 # Import Salt Testing libs
-from tests.support.helpers import with_tempfile
+from tests.support.helpers import with_tempfile, dedent
 from tests.support.mixins import LoaderModuleMockMixin
 from tests.support.paths import TMP
 from tests.support.unit import TestCase, skipIf
@@ -2045,3 +2045,28 @@ class FileBasicsTestCase(TestCase, LoaderModuleMockMixin):
             ret = filemod.source_list(
                 [{'file://' + self.myfile: ''}], 'filehash', 'base')
             self.assertEqual(list(ret), ['file://' + self.myfile, 'filehash'])
+
+
+class ChattrVersionTests(TestCase):
+    CHATTR_MAN = (
+         'AVAILABILITY\n'
+         'chattr is part of the e2fsprogs package and is available '
+         'from http://e2fsprogs.sourceforge.net.\n'
+         'SEE ALSO\n'
+         '   lsattr(1), btrfs(5), ext4(5), xfs(5).\n\n'
+         'E2fsprogs version 1.43.4                                        '
+         '                                          '
+         'January 2017                              '
+         '                                          '
+         '                          CHATTR(1)'
+    )
+
+    def test_chattr_version(self):
+        man_out = dedent(self.CHATTR_MAN)
+        parsed_version = filemod._parse_chattr_man(man_out)
+        assert parsed_version == '1.43.4', parsed_version
+
+    def test_chattr_version(self):
+        with patch('subprocess.check_output', return_value=self.CHATTR_MAN):
+            parsed_version = filemod._chattr_version()
+        assert parsed_version == '1.43.4', parsed_version

--- a/tests/unit/modules/test_file.py
+++ b/tests/unit/modules/test_file.py
@@ -2048,7 +2048,7 @@ class FileBasicsTestCase(TestCase, LoaderModuleMockMixin):
 
 
 class ChattrVersionTests(TestCase):
-    CHATTR_MAN = (
+    CHATTR_MAN = salt.utils.stringutils.to_bytes((
          'AVAILABILITY\n'
          'chattr is part of the e2fsprogs package and is available '
          'from http://e2fsprogs.sourceforge.net.\n'
@@ -2059,7 +2059,7 @@ class ChattrVersionTests(TestCase):
          'January 2017                              '
          '                                          '
          '                          CHATTR(1)'
-    )
+    ))
 
     def test__parse_chattr_version(self):
         '''

--- a/tests/unit/modules/test_file.py
+++ b/tests/unit/modules/test_file.py
@@ -2061,12 +2061,18 @@ class ChattrVersionTests(TestCase):
          '                          CHATTR(1)'
     )
 
-    def test_chattr_version(self):
+    def test__parse_chattr_version(self):
+        '''
+        Validate we can parse the E2fsprogs version from the chattr man page
+        '''
         man_out = dedent(self.CHATTR_MAN)
         parsed_version = filemod._parse_chattr_man(man_out)
         assert parsed_version == '1.43.4', parsed_version
 
-    def test_chattr_version(self):
+    def test__chattr_version(self):
+        '''
+        The _chattr_version method works
+        '''
         with patch('subprocess.check_output', return_value=self.CHATTR_MAN):
             parsed_version = filemod._chattr_version()
         assert parsed_version == '1.43.4', parsed_version


### PR DESCRIPTION
- Parse the system's chattr version from the chattr man page
- Fix integration.states.test_cron on centos 6: https://jenkinsci.saltstack.com/job/2019.2.1/job/salt-centos-6-py2/3/
- Run cron state tests when file module has changed

### Tests written?

Yes

### Commits signed with GPG?

Yes