### PR TITLE
Fix issues with the win_file tests

### DIFF
--- a/tests/unit/modules/test_win_file.py
+++ b/tests/unit/modules/test_win_file.py
@@ -15,10 +15,10 @@ from tests.support.unit import TestCase, skipIf
 
 # Import Salt Libs
 import salt.modules.win_file as win_file
+import salt.utils.win_dacl as win_dacl
 import salt.modules.temp as temp
-from salt.exceptions import CommandExecutionError
 import salt.utils.platform
-import salt.utils.win_dacl
+from salt.exceptions import CommandExecutionError
 
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
@@ -33,11 +33,11 @@ class WinFileTestCase(TestCase, LoaderModuleMockMixin):
         FAKE_PATH = os.sep.join(['path', 'does', 'not', 'exist'])
 
     def setup_loader_modules(self):
-        return {win_file: {
-            '__utils__': {
-                'dacl.set_perms': salt.utils.win_dacl.set_perms
+        return {
+            win_file: {
+                '__utils__': {'dacl.set_perms': win_dacl.set_perms}
             }
-        }}
+        }
 
     def test_issue_43328_stats(self):
         '''
@@ -98,8 +98,12 @@ class WinFileCheckPermsTestCase(TestCase, LoaderModuleMockMixin):
         self.current_user = salt.utils.win_functions.get_current_user(False)
         return {
             win_file: {
-                '__opts__': {
-                    'test': False}}}
+                '__utils__': {'dacl.check_perms': win_dacl.check_perms}
+            },
+            win_dacl: {
+                '__opts__': {'test': False},
+            }
+        }
 
     def setUp(self):
         self.temp_file = tempfile.NamedTemporaryFile(delete=False)
@@ -119,12 +123,11 @@ class WinFileCheckPermsTestCase(TestCase, LoaderModuleMockMixin):
         '''
         Test setting the owner of a file with test=True
         '''
-        with patch.dict(win_file.__opts__, {'test': True}):
-            expected = {'comment': '',
-                        'changes': {},
-                        'pchanges': {'owner': 'Administrators'},
-                        'name': self.temp_file.name,
-                        'result': None}
+        expected = {'comment': '',
+                    'changes': {'owner': 'Administrators'},
+                    'name': self.temp_file.name,
+                    'result': None}
+        with patch.dict(win_dacl.__opts__, {'test': True}):
             ret = win_file.check_perms(path=self.temp_file.name,
                                        owner='Administrators',
                                        inheritance=None)
@@ -135,7 +138,6 @@ class WinFileCheckPermsTestCase(TestCase, LoaderModuleMockMixin):
         Test setting the owner of a file
         '''
         expected = {'comment': '',
-                    'pchanges': {},
                     'changes': {'owner': 'Administrators'},
                     'name': self.temp_file.name,
                     'result': True}
@@ -148,19 +150,14 @@ class WinFileCheckPermsTestCase(TestCase, LoaderModuleMockMixin):
         '''
         Test setting deny perms on a file with test=True
         '''
-        with patch.dict(win_file.__opts__, {'test': True}):
-            expected = {'comment': '',
-                        'pchanges': {
-                            'deny_perms': {
-                                'Users': {'perms': 'read_execute'}}},
-                        'changes': {'deny_perms': {}},
-                        'name': self.temp_file.name,
-                        'result': None}
+        expected = {'comment': '',
+                    'changes': {'perms': {'Users': {'deny': 'read_execute'}}},
+                    'name': self.temp_file.name,
+                    'result': None}
+        with patch.dict(win_dacl.__opts__, {'test': True}):
             ret = win_file.check_perms(
                 path=self.temp_file.name,
-                deny_perms={
-                    'Users': {
-                        'perms': 'read_execute'}},
+                deny_perms={'Users': {'perms': 'read_execute'}},
                 inheritance=None)
             self.assertDictEqual(expected, ret)
 
@@ -169,36 +166,27 @@ class WinFileCheckPermsTestCase(TestCase, LoaderModuleMockMixin):
         Test setting deny perms on a file
         '''
         expected = {'comment': '',
-                    'pchanges': {'deny_perms': {}},
-                    'changes': {
-                        'deny_perms': {
-                            'Users': {'perms': 'read_execute'}}},
+                    'changes': {'perms': {'Users': {'deny': 'read_execute'}}},
                     'name': self.temp_file.name,
                     'result': True}
-        ret = win_file.check_perms(path=self.temp_file.name,
-                                   deny_perms={
-                                       'Users': {
-                                           'perms': 'read_execute'}},
-                                   inheritance=None)
+        ret = win_file.check_perms(
+            path=self.temp_file.name,
+            deny_perms={'Users': {'perms': 'read_execute'}},
+            inheritance=None)
         self.assertDictEqual(expected, ret)
 
     def test_check_perms_grant_test_true(self):
         '''
         Test setting grant perms on a file with test=True
         '''
-        with patch.dict(win_file.__opts__, {'test': True}):
-            expected = {'comment': '',
-                        'pchanges': {
-                            'grant_perms': {
-                                'Users': {'perms': 'read_execute'}}},
-                        'changes': {'grant_perms': {}},
-                        'name': self.temp_file.name,
-                        'result': None}
+        expected = {'comment': '',
+                    'changes': {'perms': {'Users': {'grant': 'read_execute'}}},
+                    'name': self.temp_file.name,
+                    'result': None}
+        with patch.dict(win_dacl.__opts__, {'test': True}):
             ret = win_file.check_perms(
                 path=self.temp_file.name,
-                grant_perms={
-                    'Users': {
-                        'perms': 'read_execute'}},
+                grant_perms={'Users': {'perms': 'read_execute'}},
                 inheritance=None)
             self.assertDictEqual(expected, ret)
 
@@ -207,29 +195,24 @@ class WinFileCheckPermsTestCase(TestCase, LoaderModuleMockMixin):
         Test setting grant perms on a file
         '''
         expected = {'comment': '',
-                    'pchanges': {'grant_perms': {}},
-                    'changes': {
-                        'grant_perms': {
-                            'Users': {'perms': 'read_execute'}}},
+                    'changes': {'perms': {'Users': {'grant': 'read_execute'}}},
                     'name': self.temp_file.name,
                     'result': True}
-        ret = win_file.check_perms(path=self.temp_file.name,
-                                   grant_perms={
-                                       'Users': {
-                                           'perms': 'read_execute'}},
-                                   inheritance=None)
+        ret = win_file.check_perms(
+            path=self.temp_file.name,
+            grant_perms={'Users': {'perms': 'read_execute'}},
+            inheritance=None)
         self.assertDictEqual(expected, ret)
 
     def test_check_perms_inheritance_false_test_true(self):
         '''
         Test setting inheritance to False with test=True
         '''
-        with patch.dict(win_file.__opts__, {'test': True}):
-            expected = {'comment': '',
-                        'pchanges': {'inheritance': False},
-                        'changes': {},
-                        'name': self.temp_file.name,
-                        'result': None}
+        expected = {'comment': '',
+                    'changes': {'inheritance': False},
+                    'name': self.temp_file.name,
+                    'result': None}
+        with patch.dict(win_dacl.__opts__, {'test': True}):
             ret = win_file.check_perms(path=self.temp_file.name,
                                        inheritance=False)
             self.assertDictEqual(expected, ret)
@@ -239,7 +222,6 @@ class WinFileCheckPermsTestCase(TestCase, LoaderModuleMockMixin):
         Test setting inheritance to False
         '''
         expected = {'comment': '',
-                    'pchanges': {},
                     'changes': {'inheritance': False},
                     'name': self.temp_file.name,
                     'result': True}
@@ -252,7 +234,6 @@ class WinFileCheckPermsTestCase(TestCase, LoaderModuleMockMixin):
         Test setting inheritance to true when it's already true (default)
         '''
         expected = {'comment': '',
-                    'pchanges': {},
                     'changes': {},
                     'name': self.temp_file.name,
                     'result': True}
@@ -272,31 +253,24 @@ class WinFileCheckPermsTestCase(TestCase, LoaderModuleMockMixin):
         salt.utils.win_dacl.set_permissions(obj_name=self.temp_file.name,
                                             principal='Administrator',
                                             permissions='full_control')
-
-        with patch.dict(win_file.__opts__, {'test': True}):
-            expected = {
-                'comment': '',
-                'pchanges': {
-                    'remove_perms': {
-                        'Administrator': {
-                            'grant': {
-                                'applies to': 'Not Inherited (file)',
-                                'permissions': ['Full control'],
-                                'inherited': False}}},
-                    'grant_perms': {
-                        'Administrators': {'perms': 'full_control'},
-                        'Users': {'perms': 'read_execute'}}},
-                'changes': {'grant_perms': {}},
-                'name': self.temp_file.name,
-                'result': None}
-            ret = win_file.check_perms(path=self.temp_file.name,
-                                       grant_perms={
-                                           'Users': {
-                                               'perms': 'read_execute'},
-                                           'Administrators': {
-                                               'perms': 'full_control'}},
-                                       inheritance=False,
-                                       reset=True)
+        expected = {'comment': '',
+                    'changes': {
+                        'perms': {
+                            'Administrators': {'grant': 'full_control'},
+                            'Users': {'grant': 'read_execute'}},
+                        'remove_perms': {
+                            'Administrator': {
+                                'grant': {'applies to': 'Not Inherited (file)',
+                                          'permissions': 'Full control'}}}},
+                    'name': self.temp_file.name,
+                    'result': None}
+        with patch.dict(win_dacl.__opts__, {'test': True}):
+            ret = win_file.check_perms(
+                path=self.temp_file.name,
+                grant_perms={'Users': {'perms': 'read_execute'},
+                             'Administrators': {'perms': 'full_control'}},
+                inheritance=False,
+                reset=True)
             self.assertDictEqual(expected, ret)
 
     def test_check_perms_reset(self):
@@ -311,50 +285,21 @@ class WinFileCheckPermsTestCase(TestCase, LoaderModuleMockMixin):
         salt.utils.win_dacl.set_permissions(obj_name=self.temp_file.name,
                                             principal='Administrator',
                                             permissions='full_control')
-        expected = {
-            'comment': '',
-            'pchanges': {'grant_perms': {}},
-            'changes': {
-                'remove_perms': {
-                    'Administrator': {
-                        'grant': {
-                            'applies to': 'Not Inherited (file)',
-                            'permissions': ['Full control'],
-                            'inherited': False}}},
-                'grant_perms': {
-                    'Administrators': {'perms': 'full_control'},
-                    'Users': {'perms': 'read_execute'}}},
-            'name': self.temp_file.name,
-            'result': True}
-        ret = win_file.check_perms(path=self.temp_file.name,
-                                   grant_perms={
-                                       'Users': {
-                                           'perms': 'read_execute'},
-                                       'Administrators': {
-                                           'perms': 'full_control'}},
-                                   inheritance=False,
-                                   reset=True)
+        expected = {'comment': '',
+                    'changes': {
+                        'perms': {
+                            'Administrators': {'grant': 'full_control'},
+                            'Users': {'grant': 'read_execute'}},
+                        'remove_perms': {
+                            'Administrator': {
+                                'grant': {'applies to': 'Not Inherited (file)',
+                                          'permissions': 'Full control'}}}},
+                    'name': self.temp_file.name,
+                    'result': True}
+        ret = win_file.check_perms(
+            path=self.temp_file.name,
+            grant_perms={'Users': {'perms': 'read_execute'},
+                         'Administrators': {'perms': 'full_control'}},
+            inheritance=False,
+            reset=True)
         self.assertDictEqual(expected, ret)
-
-    def test_issue_52002_check_file_remove_symlink(self):
-        '''
-        Make sure that directories including symlinks or symlinks can be removed
-        '''
-        base = temp.dir(prefix='base-')
-        target = os.path.join(base, 'child 1', 'target\\')
-        symlink = os.path.join(base, 'child 2', 'link')
-        try:
-            # Create environment
-            self.assertFalse(win_file.directory_exists(target))
-            self.assertFalse(win_file.directory_exists(symlink))
-            self.assertTrue(win_file.makedirs_(target))
-            self.assertTrue(win_file.makedirs_(symlink))
-            self.assertTrue(win_file.symlink(target, symlink))
-            self.assertTrue(win_file.directory_exists(symlink))
-            self.assertTrue(win_file.is_link(symlink))
-            # Test removal of directory containing symlink
-            self.assertTrue(win_file.remove(base))
-            self.assertFalse(win_file.directory_exists(base))
-        finally:
-            if os.path.exists(base):
-                win_file.remove(base)


### PR DESCRIPTION
### What does this PR do?
Fixes the failing branch tests https://jenkinsci.saltstack.com/job/pr-kitchen-windows2016-py2/job/PR-52633/1/#showFailuresLink

Removes pchanges
Mocks `__utils__['dacl.*']` instead of `win_file.check_perms`

### Tests written?
Yes

### Commits signed with GPG?
Yes