### PR TITLE
Virt module tests

### DIFF
--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -446,7 +446,7 @@ def _get_disks(dom):
             if driver is not None and driver.get('type') == 'qcow2':
                 try:
                     stdout = subprocess.Popen(
-                                ['qemu-img', 'info', '--output', 'json', '--backing-chain', disk['file']],
+                                ['qemu-img', 'info', '--force-share', '--output', 'json', '--backing-chain', disk['file']],
                                 shell=False,
                                 stdout=subprocess.PIPE).communicate()[0]
                     qemu_output = salt.utils.stringutils.to_str(stdout)

--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -2403,6 +2403,7 @@ def full_info(**kwargs):
     conn.close()
     return info
 
+
 def get_uuid(vm_, **kwargs):
     '''
     Return a uuid from the named vm

--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -323,57 +323,45 @@ def _parse_qemu_img_info(info):
 
 def _get_uuid(dom):
     '''
-    Return a uuid from the named vm
-
-    CLI Example:
-
-    .. code-block:: bash
-
-        salt '*' virt.get_uuid <domain>
+    Get uuid from a libvirt domain object.
     '''
-    return ElementTree.fromstring(get_xml(dom)).find('uuid').text
+    uuid = ElementTree.fromstring(dom.XMLDesc(0)).find('uuid').text
+
+    return uuid
 
 
 def _get_on_poweroff(dom):
     '''
-    Return `on_poweroff` setting from the named vm
-
-    CLI Example:
-
-    .. code-block:: bash
-
-        salt '*' virt.get_on_restart <domain>
+    Get on_poweroff from a libvirt domain object.
     '''
-    node = ElementTree.fromstring(get_xml(dom)).find('on_poweroff')
+    node = ElementTree.fromstring(dom.XMLDesc(0)).find('on_poweroff')
+
     return node.text if node is not None else ''
 
 
 def _get_on_reboot(dom):
     '''
-    Return `on_reboot` setting from the named vm
-
-    CLI Example:
-
-    .. code-block:: bash
-
-        salt '*' virt.get_on_reboot <domain>
+    Get on_reboot from a libvirt domain object.
     '''
-    node = ElementTree.fromstring(get_xml(dom)).find('on_reboot')
+    node = ElementTree.fromstring(dom.XMLDesc(0)).find('on_reboot')
+
     return node.text if node is not None else ''
 
 
 def _get_on_crash(dom):
     '''
-    Return `on_crash` setting from the named vm
-
-    CLI Example:
-
-    .. code-block:: bash
-
-        salt '*' virt.get_on_crash <domain>
+    Get on_crash from a libvirt domain object.
     '''
-    node = ElementTree.fromstring(get_xml(dom)).find('on_crash')
+    node = ElementTree.fromstring(dom.XMLDesc(0)).find('on_crash')
+
     return node.text if node is not None else ''
+
+
+def _get_macs(dom):
+    '''
+    Get mac addresses (macs) from a libvirt domain object.
+    '''
+    return [node.get('address') for node in dom.XMLDesc(0).findall('devices/interface/mac')]
 
 
 def _get_nics(dom):
@@ -2155,8 +2143,11 @@ def get_macs(vm_, **kwargs):
 
         salt '*' virt.get_macs <domain>
     '''
-    doc = ElementTree.fromstring(get_xml(vm_, **kwargs))
-    return [node.get('address') for node in doc.findall('devices/interface/mac')]
+    conn = __get_conn(**kwargs)
+    macs = _get_macs(_get_domain(conn, vm_))
+    conn.close()
+
+    return macs
 
 
 def get_graphics(vm_, **kwargs):
@@ -2411,6 +2402,114 @@ def full_info(**kwargs):
             'vm_info': vm_info()}
     conn.close()
     return info
+
+def get_uuid(vm_, **kwargs):
+    '''
+    Return a uuid from the named vm
+
+    :param vm_: name of the domain
+    :param connection: libvirt connection URI, overriding defaults
+
+        .. versionadded:: 2019.2.0
+    :param username: username to connect with, overriding defaults
+
+        .. versionadded:: 2019.2.0
+    :param password: password to connect with, overriding defaults
+
+        .. versionadded:: 2019.2.0
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' virt.get_uuid <domain>
+    '''
+    conn = __get_conn(**kwargs)
+    uuid = _get_uuid(_get_domain(conn, vm_))
+
+    return uuid
+
+
+def get_on_poweroff(vm_, **kwargs):
+    '''
+    Return a on_poweroff from the named vm
+
+    :param vm_: name of the domain
+    :param connection: libvirt connection URI, overriding defaults
+
+        .. versionadded:: 2019.2.0
+    :param username: username to connect with, overriding defaults
+
+        .. versionadded:: 2019.2.0
+    :param password: password to connect with, overriding defaults
+
+        .. versionadded:: 2019.2.0
+
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' virt.get_on_poweroff <domain>
+    '''
+    conn = __get_conn(**kwargs)
+    on_poweroff = _get_on_poweroff(_get_domain(conn, vm_))
+
+    return on_poweroff
+
+
+def get_on_reboot(vm_, **kwargs):
+    '''
+    Return a on_reboot from the named vm
+
+    :param vm_: name of the domain
+    :param connection: libvirt connection URI, overriding defaults
+
+        .. versionadded:: 2019.2.0
+    :param username: username to connect with, overriding defaults
+
+        .. versionadded:: 2019.2.0
+    :param password: password to connect with, overriding defaults
+
+        .. versionadded:: 2019.2.0
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' virt.get_on_reboot <domain>
+    '''
+    conn = __get_conn(**kwargs)
+    on_reboot = _get_on_reboot(_get_domain(conn, vm_))
+
+    return on_reboot
+
+
+def get_on_crash(vm_, **kwargs):
+    '''
+    Return a on_crash from the named vm
+
+    :param vm_: name of the domain
+    :param connection: libvirt connection URI, overriding defaults
+
+        .. versionadded:: 2019.2.0
+    :param username: username to connect with, overriding defaults
+
+        .. versionadded:: 2019.2.0
+    :param password: password to connect with, overriding defaults
+
+        .. versionadded:: 2019.2.0
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' virt.get_on_crash <domain>
+    '''
+    conn = __get_conn(**kwargs)
+    on_crash = _get_on_crash(_get_domain(conn, vm_))
+
+    return on_crash
 
 
 def get_xml(vm_, **kwargs):
@@ -3505,14 +3604,14 @@ def vm_diskstats(vm_=None, **kwargs):
 
     .. code-block:: bash
 
-        salt '*' virt.vm_blockstats
+        salt '*' virt.vm_diskstats
     '''
-    def get_disk_devs(dom):
+    def _get_disk_devs(dom):
         '''
-        Extract the disk devices names from the domain XML definition
+        Get the disk devices names from a libvirt domain object.
         '''
-        doc = ElementTree.fromstring(get_xml(dom, **kwargs))
-        return [target.get('dev') for target in doc.findall('devices/disk/target')]
+        return [target.get('dev') for target in dom.XMLDesc(0).findall('devices/disk/target')]
+
 
     def _info(dom):
         '''
@@ -3520,7 +3619,7 @@ def vm_diskstats(vm_=None, **kwargs):
         '''
         # Do not use get_disks, since it uses qemu-img and is very slow
         # and unsuitable for any sort of real time statistics
-        disks = get_disk_devs(dom)
+        disks = _get_disk_devs(dom)
         ret = {'rd_req': 0,
                'rd_bytes': 0,
                'wr_req': 0,

--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -3613,7 +3613,6 @@ def vm_diskstats(vm_=None, **kwargs):
         '''
         return [target.get('dev') for target in dom.XMLDesc(0).findall('devices/disk/target')]
 
-
     def _info(dom):
         '''
         Compute the disk stats of a domain

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -1040,7 +1040,10 @@ class TestDaemon(object):
         '''
         Kill the minion and master processes
         '''
-        self.sub_minion_process.terminate()
+        try:
+            self.sub_minion_process.terminate()
+        except AttributeError:
+            pass
         self.minion_process.terminate()
         if hasattr(self, 'proxy_process'):
             self.proxy_process.terminate()

--- a/tests/unit/modules/test_virt.py
+++ b/tests/unit/modules/test_virt.py
@@ -85,7 +85,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         mock_domain.XMLDesc.return_value = xml  # pylint: disable=no-member
 
         # Return state as shutdown
-        mock_domain.info.return_value = [4, 0, 0, 0]  # pylint: disable=no-member
+        mock_domain.info.return_value = [4, 0, 0, 0, 0]  # pylint: disable=no-member
         return mock_domain
 
     def test_disk_profile_merge(self):
@@ -1439,7 +1439,6 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         '''
         domain = self.set_mock_vm("test-vm-info", xml)
         vm_info = virt.vm_info('test-vm-info')['test-vm-info']
-
         self.assertEqual('e6e3f990-8997-4a5e-8cb7-ea835eae4bbe', vm_info['uuid'])
         self.assertEqual('destroy', vm_info['on_poweroff'])
 

--- a/tests/unit/modules/test_virt.py
+++ b/tests/unit/modules/test_virt.py
@@ -2774,4 +2774,3 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         # pylint: enable=no-member
         self.assertEqual(names, virt.pool_list_volumes('default'))
 
-

--- a/tests/unit/modules/test_virt.py
+++ b/tests/unit/modules/test_virt.py
@@ -1441,7 +1441,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         vm_info = virt.vm_info('test-vm-info')['test-vm-info']
 
         self.assertEqual('e6e3f990-8997-4a5e-8cb7-ea835eae4bbe', vm_info['uuid'])
-        self.assertEqual("destroy", vm_info['on_poweroff'])
+        self.assertEqual('destroy', vm_info['on_poweroff'])
 
     def test_get_uuid(self):
         '''
@@ -1454,8 +1454,8 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
             </domain>
         '''
 
-        domain = self.set_mock_vm("test-vm-info", xml)
-        self.assertEqual("e6e3f990-8997-4a5e-8cb7-ea835eae4bbe", virt.get_uuid('test-vm-info'))
+        domain = self.set_mock_vm('test-vm-info', xml)
+        self.assertEqual('e6e3f990-8997-4a5e-8cb7-ea835eae4bbe', virt.get_uuid('test-vm-info'))
 
     def test_get_on_poweroff(self):
         '''
@@ -1471,8 +1471,8 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
             </domain>
         '''
 
-        domain = self.set_mock_vm("test-vm-info", xml)
-        self.assertEqual("destroy", virt.get_on_poweroff('test-vm-info'))
+        domain = self.set_mock_vm('test-vm-info', xml)
+        self.assertEqual('destroy', virt.get_on_poweroff('test-vm-info'))
 
     def test_get_on_reboot(self):
         '''
@@ -1488,8 +1488,8 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
             </domain>
         '''
 
-        domain = self.set_mock_vm("test-vm-info", xml)
-        self.assertEqual("restart", virt.get_on_reboot('test-vm-info'))
+        domain = self.set_mock_vm('test-vm-info', xml)
+        self.assertEqual('restart', virt.get_on_reboot('test-vm-info'))
 
     def test_get_on_crash(self):
         '''
@@ -1505,8 +1505,8 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
             </domain>
         '''
 
-        domain = self.set_mock_vm("test-vm-info", xml)
-        self.assertEqual("destroy", virt.get_on_crash('test-vm-info'))
+        domain = self.set_mock_vm('test-vm-info', xml)
+        self.assertEqual('destroy', virt.get_on_crash('test-vm-info'))
 
     def test_get_graphics(self):
         '''

--- a/tests/unit/modules/test_virt.py
+++ b/tests/unit/modules/test_virt.py
@@ -1398,6 +1398,188 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
                     re.match('^([0-9A-F]{2}[:-]){5}([0-9A-F]{2})$',
                              interface_attrs['mac'], re.I))
 
+    def test_vm_info(self):
+        '''
+        Test virt.vm_info(vm_name)
+        '''
+        xml = '''
+            <domain type='qemu'>
+              <name>minion-1</name>
+              <uuid>e6e3f990-8997-4a5e-8cb7-ea835eae4bbe</uuid>
+              <metadata>
+                <libosinfo:libosinfo xmlns:libosinfo="http://libosinfo.org/xmlns/libvirt/domain/1.0">
+                  <libosinfo:os id="http://ubuntu.com/ubuntu/16.04"/>
+                </libosinfo:libosinfo>
+              </metadata>
+              <memory unit='KiB'>819200</memory>
+              <currentMemory unit='KiB'>819200</currentMemory>
+              <vcpu placement='static'>1</vcpu>
+              <os>
+                <type arch='x86_64' machine='pc-i440fx-bionic'>hvm</type>
+                <boot dev='hd'/>
+              </os>
+              <features>
+                <acpi/>
+                <apic/>
+                <vmport state='off'/>
+              </features>
+              <clock offset='utc'>
+                <timer name='rtc' tickpolicy='catchup'/>
+                <timer name='pit' tickpolicy='delay'/>
+                <timer name='hpet' present='no'/>
+              </clock>
+              <on_poweroff>destroy</on_poweroff>
+              <on_reboot>restart</on_reboot>
+              <on_crash>destroy</on_crash>
+              <pm>
+                <suspend-to-mem enabled='no'/>
+                <suspend-to-disk enabled='no'/>
+              </pm>
+              <devices>
+                <emulator>/usr/bin/qemu-system-x86_64</emulator>
+                <disk type='file' device='disk'>
+                  <driver name='qemu' type='qcow2'/>
+                  <source file='/var/lib/libvirt/images/ubuntu16.04.qcow2'/>
+                  <target dev='vda' bus='virtio'/>
+                  <address type='pci' domain='0x0000' bus='0x00' slot='0x06' function='0x0'/>
+                </disk>
+                <disk type='file' device='cdrom'>
+                  <driver name='qemu' type='raw'/>
+                  <target dev='hda' bus='ide'/>
+                  <readonly/>
+                  <address type='drive' controller='0' bus='0' target='0' unit='0'/>
+                </disk>
+                <controller type='usb' index='0' model='ich9-ehci1'>
+                  <address type='pci' domain='0x0000' bus='0x00' slot='0x05' function='0x7'/>
+                </controller>
+                <controller type='usb' index='0' model='ich9-uhci1'>
+                  <master startport='0'/>
+                  <address type='pci' domain='0x0000' bus='0x00' slot='0x05' function='0x0' multifunction='on'/>
+                </controller>
+                <controller type='usb' index='0' model='ich9-uhci2'>
+                  <master startport='2'/>
+                  <address type='pci' domain='0x0000' bus='0x00' slot='0x05' function='0x1'/>
+                </controller>
+                <controller type='usb' index='0' model='ich9-uhci3'>
+                  <master startport='4'/>
+                  <address type='pci' domain='0x0000' bus='0x00' slot='0x05' function='0x2'/>
+                </controller>
+                <controller type='pci' index='0' model='pci-root'/>
+                <controller type='ide' index='0'>
+                  <address type='pci' domain='0x0000' bus='0x00' slot='0x01' function='0x1'/>
+                </controller>
+                <interface type='network'>
+                  <mac address='52:54:00:70:b7:63'/>
+                  <source network='default'/>
+                  <model type='virtio'/>
+                  <address type='pci' domain='0x0000' bus='0x00' slot='0x03' function='0x0'/>
+                </interface>
+                <serial type='pty'>
+                  <target type='isa-serial' port='0'>
+                    <model name='isa-serial'/>
+                  </target>
+                </serial>
+                <console type='pty'>
+                  <target type='serial' port='0'/>
+                </console>
+                <input type='tablet' bus='usb'>
+                  <address type='usb' bus='0' port='1'/>
+                </input>
+                <input type='mouse' bus='ps2'/>
+                <input type='keyboard' bus='ps2'/>
+                <graphics type='spice' autoport='yes'>
+                  <listen type='address'/>
+                </graphics>
+                <sound model='ich6'>
+                  <address type='pci' domain='0x0000' bus='0x00' slot='0x04' function='0x0'/>
+                </sound>
+                <video>
+                  <model type='qxl' ram='65536' vram='65536' vgamem='16384' heads='1' primary='yes'/>
+                  <address type='pci' domain='0x0000' bus='0x00' slot='0x02' function='0x0'/>
+                </video>
+                <redirdev bus='usb' type='spicevmc'>
+                  <address type='usb' bus='0' port='2'/>
+                </redirdev>
+                <redirdev bus='usb' type='spicevmc'>
+                  <address type='usb' bus='0' port='3'/>
+                </redirdev>
+                <memballoon model='virtio'>
+                  <address type='pci' domain='0x0000' bus='0x00' slot='0x07' function='0x0'/>
+                </memballoon>
+              </devices>
+            </domain>
+        '''
+        domain = self.set_mock_vm("test-vm-info", xml)
+        vm_info = virt.vm_info('test-vm-info')[0]
+        self.assertEqual('1', vm_info['cpu'])
+        self.assertEqual('e6e3f990-8997-4a5e-8cb7-ea835eae4bbe', vm_info['uuid'])
+        self.assertEqual("destroy", vm_info['on_poweroff'])
+
+    def test_get_uuid(self):
+        '''
+        Test virt.get_uuid(vm_name)
+        '''
+        xml = '''
+            <domain type='qemu'>
+              <name>minion-1</name>
+              <uuid>e6e3f990-8997-4a5e-8cb7-ea835eae4bbe</uuid>
+            </domain>
+        '''
+
+        domain = self.set_mock_vm("test-vm-info", xml)
+        self.assertEqual("e6e3f990-8997-4a5e-8cb7-ea835eae4bbe", virt.get_uuid('test-vm-info'))
+
+    def test_get_on_poweroff(self):
+        '''
+        Test virt.get_on_poweroff(vm_name)
+        '''
+        xml = '''
+            <domain type='qemu'>
+              <name>minion-1</name>
+              <uuid>e6e3f990-8997-4a5e-8cb7-ea835eae4bbe</uuid>
+              <on_poweroff>destroy</on_poweroff>
+              <on_reboot>restart</on_reboot>
+              <on_crash>destroy</on_crash>
+            </domain>
+        '''
+
+        domain = self.set_mock_vm("test-vm-info", xml)
+        self.assertEqual("destroy", virt.get_on_poweroff('test-vm-info'))
+
+    def test_get_on_reboot(self):
+        '''
+        Test virt.get_on_poweroff(vm_name)
+        '''
+        xml = '''
+            <domain type='qemu'>
+              <name>minion-1</name>
+              <uuid>e6e3f990-8997-4a5e-8cb7-ea835eae4bbe</uuid>
+              <on_poweroff>destroy</on_poweroff>
+              <on_reboot>restart</on_reboot>
+              <on_crash>destroy</on_crash>
+            </domain>
+        '''
+
+        domain = self.set_mock_vm("test-vm-info", xml)
+        self.assertEqual("restart", virt.get_on_reboot('test-vm-info'))
+
+    def test_get_on_crash(self):
+        '''
+        Test virt.get_uuid(vm_name)
+        '''
+        xml = '''
+            <domain type='qemu'>
+              <name>minion-1</name>
+              <uuid>e6e3f990-8997-4a5e-8cb7-ea835eae4bbe</uuid>
+              <on_poweroff>destroy</on_poweroff>
+              <on_reboot>restart</on_reboot>
+              <on_crash>destroy</on_crash>
+            </domain>
+        '''
+
+        domain = self.set_mock_vm("test-vm-info", xml)
+        self.assertEqual("destroy", virt.get_on_crash('test-vm-info'))
+
     def test_get_graphics(self):
         '''
         Test virt.get_graphics()
@@ -2664,18 +2846,4 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         # pylint: enable=no-member
         self.assertEqual(names, virt.pool_list_volumes('default'))
 
-    def test_get_uuid(self):
-        '''
-        Test virt.get_uuid()
-        '''
-        root_dir = os.path.join(salt.syspaths.ROOT_DIR, 'srv', 'salt-images')
-        xml = '''
-            <domain type='qemu'>
-              <name>minion-1</name>
-              <uuid>e6e3f990-8997-4a5e-8cb7-ea835eae4bbe</uuid>
-            </domain>
-        '''
-
-        domain = self.set_mock_vm("test-vm-info", xml)
-        self.assertEqual("e6e3f990-8997-4a5e-8cb7-ea835eae4bbe", virt.get_uuid('test-vm-info'))
 

--- a/tests/unit/modules/test_virt.py
+++ b/tests/unit/modules/test_virt.py
@@ -2663,3 +2663,15 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         self.mock_conn.storagePoolLookupByName.return_value = mock_pool
         # pylint: enable=no-member
         self.assertEqual(names, virt.pool_list_volumes('default'))
+
+    def test_get_uuid(self):
+        '''
+        Test virt.get_uuid()
+        '''
+        mock = MagicMock(return_value={})
+        with patch.dict(virt.__salt__, {'config.get': mock}):  # pylint: disable=no-member
+            ret = virt.get_uuid()
+            self.assertTrue(len(ret) == 1)
+            uuid = ret[0]
+            print uuid
+

--- a/tests/unit/modules/test_virt.py
+++ b/tests/unit/modules/test_virt.py
@@ -1435,83 +1435,11 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
                 <suspend-to-mem enabled='no'/>
                 <suspend-to-disk enabled='no'/>
               </pm>
-              <devices>
-                <emulator>/usr/bin/qemu-system-x86_64</emulator>
-                <disk type='file' device='disk'>
-                  <driver name='qemu' type='qcow2'/>
-                  <source file='/var/lib/libvirt/images/ubuntu16.04.qcow2'/>
-                  <target dev='vda' bus='virtio'/>
-                  <address type='pci' domain='0x0000' bus='0x00' slot='0x06' function='0x0'/>
-                </disk>
-                <disk type='file' device='cdrom'>
-                  <driver name='qemu' type='raw'/>
-                  <target dev='hda' bus='ide'/>
-                  <readonly/>
-                  <address type='drive' controller='0' bus='0' target='0' unit='0'/>
-                </disk>
-                <controller type='usb' index='0' model='ich9-ehci1'>
-                  <address type='pci' domain='0x0000' bus='0x00' slot='0x05' function='0x7'/>
-                </controller>
-                <controller type='usb' index='0' model='ich9-uhci1'>
-                  <master startport='0'/>
-                  <address type='pci' domain='0x0000' bus='0x00' slot='0x05' function='0x0' multifunction='on'/>
-                </controller>
-                <controller type='usb' index='0' model='ich9-uhci2'>
-                  <master startport='2'/>
-                  <address type='pci' domain='0x0000' bus='0x00' slot='0x05' function='0x1'/>
-                </controller>
-                <controller type='usb' index='0' model='ich9-uhci3'>
-                  <master startport='4'/>
-                  <address type='pci' domain='0x0000' bus='0x00' slot='0x05' function='0x2'/>
-                </controller>
-                <controller type='pci' index='0' model='pci-root'/>
-                <controller type='ide' index='0'>
-                  <address type='pci' domain='0x0000' bus='0x00' slot='0x01' function='0x1'/>
-                </controller>
-                <interface type='network'>
-                  <mac address='52:54:00:70:b7:63'/>
-                  <source network='default'/>
-                  <model type='virtio'/>
-                  <address type='pci' domain='0x0000' bus='0x00' slot='0x03' function='0x0'/>
-                </interface>
-                <serial type='pty'>
-                  <target type='isa-serial' port='0'>
-                    <model name='isa-serial'/>
-                  </target>
-                </serial>
-                <console type='pty'>
-                  <target type='serial' port='0'/>
-                </console>
-                <input type='tablet' bus='usb'>
-                  <address type='usb' bus='0' port='1'/>
-                </input>
-                <input type='mouse' bus='ps2'/>
-                <input type='keyboard' bus='ps2'/>
-                <graphics type='spice' autoport='yes'>
-                  <listen type='address'/>
-                </graphics>
-                <sound model='ich6'>
-                  <address type='pci' domain='0x0000' bus='0x00' slot='0x04' function='0x0'/>
-                </sound>
-                <video>
-                  <model type='qxl' ram='65536' vram='65536' vgamem='16384' heads='1' primary='yes'/>
-                  <address type='pci' domain='0x0000' bus='0x00' slot='0x02' function='0x0'/>
-                </video>
-                <redirdev bus='usb' type='spicevmc'>
-                  <address type='usb' bus='0' port='2'/>
-                </redirdev>
-                <redirdev bus='usb' type='spicevmc'>
-                  <address type='usb' bus='0' port='3'/>
-                </redirdev>
-                <memballoon model='virtio'>
-                  <address type='pci' domain='0x0000' bus='0x00' slot='0x07' function='0x0'/>
-                </memballoon>
-              </devices>
             </domain>
         '''
         domain = self.set_mock_vm("test-vm-info", xml)
-        vm_info = virt.vm_info('test-vm-info')[0]
-        self.assertEqual('1', vm_info['cpu'])
+        vm_info = virt.vm_info('test-vm-info')['test-vm-info']
+
         self.assertEqual('e6e3f990-8997-4a5e-8cb7-ea835eae4bbe', vm_info['uuid'])
         self.assertEqual("destroy", vm_info['on_poweroff'])
 

--- a/tests/unit/modules/test_virt.py
+++ b/tests/unit/modules/test_virt.py
@@ -2668,10 +2668,14 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         '''
         Test virt.get_uuid()
         '''
-        mock = MagicMock(return_value={})
-        with patch.dict(virt.__salt__, {'config.get': mock}):  # pylint: disable=no-member
-            ret = virt.get_uuid()
-            self.assertTrue(len(ret) == 1)
-            uuid = ret[0]
-            print uuid
+        root_dir = os.path.join(salt.syspaths.ROOT_DIR, 'srv', 'salt-images')
+        xml = '''
+            <domain type='qemu'>
+              <name>minion-1</name>
+              <uuid>e6e3f990-8997-4a5e-8cb7-ea835eae4bbe</uuid>
+            </domain>
+        '''
+
+        domain = self.set_mock_vm("test-vm-info", xml)
+        self.assertEqual("e6e3f990-8997-4a5e-8cb7-ea835eae4bbe", virt.get_uuid('test-vm-info'))
 

--- a/tests/unit/modules/test_virt.py
+++ b/tests/unit/modules/test_virt.py
@@ -2773,4 +2773,3 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         self.mock_conn.storagePoolLookupByName.return_value = mock_pool
         # pylint: enable=no-member
         self.assertEqual(names, virt.pool_list_volumes('default'))
-


### PR DESCRIPTION
### What does this PR do?

- It fixes few bugs with the current module and sticks to the standard way of implementing virt module functions, there were inconsistencies in the implementation of few functions like get_on_poweroff, get_on_crash, get_on_reboot, get_uuid and get_profiles and in their documentation too.
- Add tests for virt.vm_info virt.get_on_poweroff and the rest of the chain.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/52431
https://github.com/saltstack/salt/issues/52676

### Previous Behavior
`salt '*' virt.vm_info`
The VM "<libvirt.virDomain object at 0x7f24e9e73198>" is not present
### New Behavior
`salt '*' virt.vm_info`
```
minion:
    ----------
    minion-1:
        ----------
        cpu:
            1
        cputime:
            0
        disks:
            ----------
            vda:
                ----------
                cluster size:
                    65536
                disk size:
                    3065716736
                file:
                    /var/lib/libvirt/images/ubuntu16.04.qcow2
                file format:
                    qcow2
                type:
                    disk
                virtual size:
                    10737418240
        graphics:
            ----------
            autoport:
                yes
            keymap:
                None
            listen:
                None
            port:
                None
            type:
                spice
        loader:
            ----------
            path:
                None
        maxMem:
            819200
        mem:
            819200
        nics:
            ----------
            52:54:00:70:b7:63:
                ----------
                address:
                    ----------
                    bus:
                        0x00
                    domain:
                        0x0000
                    function:
                        0x0
                    slot:
                        0x03
                    type:
                        pci
                mac:
                    52:54:00:70:b7:63
                model:
                    virtio
                source:
                    ----------
                    network:
                        default
                type:
                    network
        on_crash:
            destroy
        on_poweroff:
            destroy
        on_reboot:
            restart
        state:
            shutdown
        uuid:
            e6e3f990-8997-4a5e-8cb7-ea835eae4bbe
```
### Tests written?

Yes

### Commits signed with GPG?

Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.