### PR TITLE
Tidy "Changes made" output in git states

### DIFF
--- a/salt/states/git.py
+++ b/salt/states/git.py
@@ -163,7 +163,7 @@ def _uptodate(ret, target, comments=None, local_changes=False):
         # report on them so we are alerted to potential problems with our
         # logic.
         ret["comment"] += "\n\nChanges {0}made: {1}".format(
-            "that would be " if __opts__["test"] else "", _format_comments(comments)
+            "that would be " if __opts__["test"] else "", comments
         )
     return ret
 

--- a/salt/states/git.py
+++ b/salt/states/git.py
@@ -152,6 +152,8 @@ def _strip_exc(exc):
 
 
 def _uptodate(ret, target, comments=None, local_changes=False):
+    assert comments is None or isinstance(comments, six.string_types)
+
     ret["comment"] = "Repository {0} is up-to-date".format(target)
     if local_changes:
         ret["comment"] += (

--- a/tests/unit/states/test_git.py
+++ b/tests/unit/states/test_git.py
@@ -73,3 +73,86 @@ class GitTestCase(TestCase, LoaderModuleMockMixin):
             )
             assert result["result"] is True, result
             git_diff.assert_not_called()
+
+    def test_uptodate_message_format_gen(self):
+        fetch_url = "https://xyz.invalid/salt/unit/test/repo.git"
+        local_path = "/local/salt/unit/test/repo.git"
+        branch = "master"
+        head_rev = "cafe0000cafe0000cafe0000cafe0000cafe0000"
+        remote_name = "salt_test_remote"
+
+        tags = []
+        remote_refs = {
+            "HEAD": head_rev,
+            "refs/heads/" + branch: head_rev
+        }
+
+        def rev_parse(cwd, rev, *args, **kwargs):
+            assert cwd == local_path
+
+            if "--abbrev-ref" in kwargs.get("opts", []) and rev.endswith("@{upstream}"):
+                return remote_name + "/" + rev.split("@")[0]
+
+            rev = rev.split("^")[0]
+            return remote_refs.get(rev) \
+                or remote_refs.get("refs/heads/" + rev) \
+                or rev
+
+        def ls_remote(cwd, remote, opts, *args, **kwargs):
+            assert cwd == local_path
+            assert remote in [remote_name, fetch_url]
+
+            if opts == "--tags":
+                return tags
+            raise NotImplementedError()
+
+        def merge_base(cwd, refs, is_ancestor=False, **kwargs):
+            assert cwd == local_path
+            assert is_ancestor
+
+            return all(ref == refs[0] for ref in refs)
+
+        dunder_salt = {
+            "git.config_get_regexp": MagicMock(return_value={}),
+            "git.remote_refs": MagicMock(return_value=remote_refs),
+            "git.version": MagicMock(return_value="1.8.3.1"),
+            "git.list_branches": MagicMock(return_value=[branch]),
+            "git.list_tags": MagicMock(return_value=tags),
+            "git.revision": MagicMock(return_value=head_rev),
+            "git.current_branch": MagicMock(return_value=branch),
+            "git.remotes": MagicMock(return_value={
+                remote_name: {
+                    "fetch": fetch_url,
+                },
+            }),
+            "git.diff": MagicMock(return_value=""),
+            "git.rev_parse": MagicMock(side_effect=rev_parse),
+            "git.ls_remote": MagicMock(side_effect=ls_remote),
+            "git.fetch": MagicMock(return_value=True),
+            "git.merge_base": MagicMock(side_effect=merge_base),
+        }
+
+        # Things that would interact with FS on test host
+        isfile_mock = MagicMock(return_value=False)
+        # expanduser reads home directory from system
+        expanduser_mock = MagicMock(side_effect=NotImplementedError)
+        isdir_mock = MagicMock(return_value=True)
+
+        with patch.dict(git_state.__salt__, dunder_salt), \
+                patch("os.path.isfile", isfile_mock), \
+                patch("os.path.expanduser", expanduser_mock), \
+                patch("os.path.isdir", isdir_mock):
+            result = git_state.latest(
+                fetch_url, rev=branch, remote=remote_name, target=local_path
+            )
+            assert result["result"] is True, result
+            # Ensure the comment is formatted correctly. Namely that the repo
+            # path is not mangled.
+            self.assertIn(
+                "Repository {repo} is up-to-date".format(repo=local_path),
+                result["comment"],
+            )
+            self.assertIn(
+                "{repo} was fetched, resulting in updated refs".format(repo=fetch_url),
+                result["comment"],
+            )


### PR DESCRIPTION
### What does this PR do?

Fixes a cosmetic issue in comment output of git-related states.

### What issues does this PR fix or reference?

None as far as a cursory search shows

### Previous Behavior

Sample excerpt from `git.latest` output:
`Changes made: /. h. o. m. e. /. g. i. t. /. r. e. p. o. s. i. t. o. r. i. e. s. /. s. a. l. t. -. c. o. n. f. i. g. .. g. i. t.  . w. a. s.  . f. e. t. c. h. e. d. ,.  . r. e. s. u. l. t. i. n. g.  . i. n.  . u. p. d. a. t. e. d.  . r. e. f. s.`

### New Behavior

`Changes made: /home/git/repositories/salt-config.git was fetched, resulting in updated refs`

### Tests written?

No

Not sure how to test for this either

### Commits signed with GPG?

No