### PR TITLE
[2019.2] Fixes to run_job in scheduler

### DIFF
--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -210,7 +210,7 @@ class Schedule(object):
         # dict we treat it like it was there and is True
 
         # Check if we're able to run
-        if not data['run']:
+        if not data.get('run', True):
             return data
         if 'jid_include' not in data or data['jid_include']:
             jobcount = 0
@@ -461,16 +461,18 @@ class Schedule(object):
             data['name'] = name
         log.info('Running Job: %s', name)
 
+        now = datetime.datetime.now()
         if not self.standalone:
             data = self._check_max_running(func,
                                            data,
                                            self.opts,
-                                           datetime.datetime.now())
+                                           now)
 
         # Grab run, assume True
         run = data.get('run', True)
         if run:
             self._run_job(func, data)
+            data['_last_run'] = now
 
     def enable_schedule(self):
         '''

--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -211,7 +211,8 @@ class Schedule(object):
 
         # Check if we're able to run, default to False
         # in case the `run` value is not present.
-        if not data.get('run'):
+        log.info('==== run %s ===', data['run'])
+        if not data['run']:
             return data
         if 'jid_include' not in data or data['jid_include']:
             jobcount = 0

--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -476,7 +476,6 @@ class Schedule(object):
         run = data.get('run', True)
         if run:
             self._run_job(func, data)
-            data['_last_run'] = now
 
     def enable_schedule(self):
         '''

--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -209,8 +209,9 @@ class Schedule(object):
         # NOTE--jid_include defaults to True, thus if it is missing from the data
         # dict we treat it like it was there and is True
 
-        # Check if we're able to run
-        if not data['run']:
+        # Check if we're able to run, default to False
+        # in case the `run` value is not present.
+        if not data.get('run'):
             return data
         if 'jid_include' not in data or data['jid_include']:
             jobcount = 0

--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -210,7 +210,7 @@ class Schedule(object):
         # dict we treat it like it was there and is True
 
         # Check if we're able to run
-        if not data.get('run', True):
+        if not data['run']:
             return data
         if 'jid_include' not in data or data['jid_include']:
             jobcount = 0
@@ -459,6 +459,8 @@ class Schedule(object):
 
         if 'name' not in data:
             data['name'] = name
+        if 'run' not in data:
+            data['run'] = True
         log.info('Running Job: %s', name)
 
         now = datetime.datetime.now()

--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -476,6 +476,7 @@ class Schedule(object):
         run = data.get('run', True)
         if run:
             self._run_job(func, data)
+            data['_last_run'] = now
 
     def enable_schedule(self):
         '''

--- a/tests/integration/scheduler/test_error.py
+++ b/tests/integration/scheduler/test_error.py
@@ -5,7 +5,6 @@ from __future__ import absolute_import
 import copy
 import logging
 import os
-import time
 
 import dateutil.parser as dateutil_parser
 

--- a/tests/integration/scheduler/test_error.py
+++ b/tests/integration/scheduler/test_error.py
@@ -5,6 +5,7 @@ from __future__ import absolute_import
 import copy
 import logging
 import os
+import time
 
 import dateutil.parser as dateutil_parser
 
@@ -49,11 +50,14 @@ class SchedulerErrorTest(ModuleCase, SaltReturnAssertsMixin):
             functions = {'test.ping': ping}
             self.schedule = salt.utils.schedule.Schedule(copy.deepcopy(DEFAULT_CONFIG), functions, returners={})
         self.schedule.opts['loop_interval'] = 1
+        self.schedule.opts['run_schedule_jobs_in_background'] = False
 
         self.schedule.opts['grains']['whens'] = {'tea time': '11/29/2017 12:00pm'}
 
     def tearDown(self):
         self.schedule.reset()
+
+        del self.schedule
 
     @skipIf(not HAS_CRONITER, 'Cannot find croniter python module')
     def test_eval_cron_invalid(self):

--- a/tests/integration/scheduler/test_error.py
+++ b/tests/integration/scheduler/test_error.py
@@ -56,8 +56,6 @@ class SchedulerErrorTest(ModuleCase, SaltReturnAssertsMixin):
     def tearDown(self):
         self.schedule.reset()
 
-        del self.schedule
-
     @skipIf(not HAS_CRONITER, 'Cannot find croniter python module')
     def test_eval_cron_invalid(self):
         '''

--- a/tests/integration/scheduler/test_eval.py
+++ b/tests/integration/scheduler/test_eval.py
@@ -47,7 +47,7 @@ DEFAULT_CONFIG['cachedir'] = os.path.join(ROOT_DIR, 'cache')
 
 class SchedulerEvalTest(ModuleCase, SaltReturnAssertsMixin):
     '''
-    Validate the pkg module
+    Validate the scheduler
     '''
     def setUp(self):
         with patch('salt.utils.schedule.clean_proc_dir', MagicMock(return_value=None)):

--- a/tests/integration/scheduler/test_eval.py
+++ b/tests/integration/scheduler/test_eval.py
@@ -46,6 +46,7 @@ DEFAULT_CONFIG['cachedir'] = os.path.join(ROOT_DIR, 'cache')
 
 JOB_FUNCTION = 'test.ping'
 
+
 class SchedulerEvalTest(ModuleCase, SaltReturnAssertsMixin):
     '''
     Validate the scheduler
@@ -123,8 +124,8 @@ class SchedulerEvalTest(ModuleCase, SaltReturnAssertsMixin):
         self.assertEqual(ret['_last_run'], run_time1)
 
         # Give the job a chance to finish
-	while self.schedule.job_running(ret):
-          time.sleep(1)
+        while self.schedule.job_running(ret):
+            time.sleep(1)
 
         # Evaluate run time2
         self.schedule.eval(now=run_time2)
@@ -217,8 +218,8 @@ class SchedulerEvalTest(ModuleCase, SaltReturnAssertsMixin):
         self.assertEqual(ret['_last_run'], run_time1)
 
         # Give the job a chance to finish
-	while self.schedule.job_running(ret):
-          time.sleep(1)
+        while self.schedule.job_running(ret):
+            time.sleep(1)
 
         # Evaluate 1 second at the run time
         self.schedule.eval(now=run_time2)
@@ -365,8 +366,8 @@ class SchedulerEvalTest(ModuleCase, SaltReturnAssertsMixin):
         self.assertEqual(ret['_last_run'], run_time)
 
         # Give the job a chance to finish
-	while self.schedule.job_running(ret):
-          time.sleep(1)
+        while self.schedule.job_running(ret):
+            time.sleep(1)
 
         # eval at 4:00pm, will run.
         run_time = dateutil_parser.parse('11/29/2017 4:00pm')
@@ -375,8 +376,8 @@ class SchedulerEvalTest(ModuleCase, SaltReturnAssertsMixin):
         self.assertEqual(ret['_last_run'], run_time)
 
         # Give the job a chance to finish
-	while self.schedule.job_running(ret):
-          time.sleep(1)
+        while self.schedule.job_running(ret):
+            time.sleep(1)
 
         # eval at 5:00pm, will not run
         run_time = dateutil_parser.parse('11/29/2017 5:00pm')
@@ -705,8 +706,8 @@ class SchedulerEvalTest(ModuleCase, SaltReturnAssertsMixin):
         self.assertEqual(ret['_next_fire_time'], next_run_time)
 
         # Give the job a chance to finish
-	while self.schedule.job_running(ret):
-          time.sleep(1)
+        while self.schedule.job_running(ret):
+            time.sleep(1)
 
         # eval at 2:01:00pm, will run.
         run_time = dateutil_parser.parse('11/29/2017 2:01:00pm')
@@ -717,8 +718,8 @@ class SchedulerEvalTest(ModuleCase, SaltReturnAssertsMixin):
         self.assertEqual(ret['_next_fire_time'], next_run_time)
 
         # Give the job a chance to finish
-	while self.schedule.job_running(ret):
-          time.sleep(1)
+        while self.schedule.job_running(ret):
+            time.sleep(1)
 
         # eval at 2:01:30pm, will run.
         run_time = dateutil_parser.parse('11/29/2017 2:01:30pm')
@@ -769,8 +770,8 @@ class SchedulerEvalTest(ModuleCase, SaltReturnAssertsMixin):
         self.assertEqual(ret['_last_run'], run_time)
 
         # Give the job a chance to finish
-	while self.schedule.job_running(ret):
-          time.sleep(1)
+        while self.schedule.job_running(ret):
+            time.sleep(1)
 
         # eval at 3:00:00pm, will run.
         run_time = dateutil_parser.parse('11/29/2017 3:00:00pm')
@@ -779,8 +780,8 @@ class SchedulerEvalTest(ModuleCase, SaltReturnAssertsMixin):
         self.assertEqual(ret['_last_run'], run_time)
 
         # Give the job a chance to finish
-	while self.schedule.job_running(ret):
-          time.sleep(1)
+        while self.schedule.job_running(ret):
+            time.sleep(1)
 
         # eval at 3:30:00pm, will run.
         run_time = dateutil_parser.parse('11/29/2017 3:30:00pm')
@@ -829,8 +830,8 @@ class SchedulerEvalTest(ModuleCase, SaltReturnAssertsMixin):
         self.assertEqual(ret['_last_run'], run_time)
 
         # Give the job a chance to finish
-	while self.schedule.job_running(ret):
-          time.sleep(1)
+        while self.schedule.job_running(ret):
+            time.sleep(1)
 
         # eval at 6:00:00pm, will run.
         run_time = dateutil_parser.parse('11/29/2017 6:00:00pm')
@@ -839,8 +840,8 @@ class SchedulerEvalTest(ModuleCase, SaltReturnAssertsMixin):
         self.assertEqual(ret['_last_run'], run_time)
 
         # Give the job a chance to finish
-	while self.schedule.job_running(ret):
-          time.sleep(1)
+        while self.schedule.job_running(ret):
+            time.sleep(1)
 
         # eval at 8:00:00pm, will run.
         run_time = dateutil_parser.parse('11/29/2017 8:00:00pm')
@@ -893,8 +894,8 @@ class SchedulerEvalTest(ModuleCase, SaltReturnAssertsMixin):
         self.assertEqual(ret['_next_fire_time'], next_run_time)
 
         # Give the job a chance to finish
-	while self.schedule.job_running(ret):
-          time.sleep(1)
+        while self.schedule.job_running(ret):
+            time.sleep(1)
 
         # eval at 11/27/2017 2:00:00pm, will run.
         run_time = dateutil_parser.parse('11/27/2017 2:00:00pm')
@@ -905,8 +906,8 @@ class SchedulerEvalTest(ModuleCase, SaltReturnAssertsMixin):
         self.assertEqual(ret['_next_fire_time'], next_run_time)
 
         # Give the job a chance to finish
-	while self.schedule.job_running(ret):
-          time.sleep(1)
+        while self.schedule.job_running(ret):
+            time.sleep(1)
 
         # eval at 11/28/2017 2:00:00pm, will not run.
         run_time = dateutil_parser.parse('11/28/2017 2:00:00pm')
@@ -917,8 +918,8 @@ class SchedulerEvalTest(ModuleCase, SaltReturnAssertsMixin):
         self.assertEqual(ret['_next_fire_time'], next_run_time)
 
         # Give the job a chance to finish
-	while self.schedule.job_running(ret):
-          time.sleep(1)
+        while self.schedule.job_running(ret):
+            time.sleep(1)
 
         # eval at 11/29/2017 2:00:00pm, will run.
         run_time = dateutil_parser.parse('11/29/2017 2:00:00pm')

--- a/tests/integration/scheduler/test_eval.py
+++ b/tests/integration/scheduler/test_eval.py
@@ -7,7 +7,6 @@ import datetime
 import logging
 import os
 import random
-import time
 
 import dateutil.parser as dateutil_parser
 import datetime
@@ -123,10 +122,6 @@ class SchedulerEvalTest(ModuleCase, SaltReturnAssertsMixin):
         ret = self.schedule.job_status(job_name)
         self.assertEqual(ret['_last_run'], run_time1)
 
-        # Give the job a chance to finish
-        while self.schedule.job_running(ret):
-            time.sleep(1)
-
         # Evaluate run time2
         self.schedule.eval(now=run_time2)
         ret = self.schedule.job_status(job_name)
@@ -216,10 +211,6 @@ class SchedulerEvalTest(ModuleCase, SaltReturnAssertsMixin):
         self.schedule.eval(now=run_time1)
         ret = self.schedule.job_status(job_name)
         self.assertEqual(ret['_last_run'], run_time1)
-
-        # Give the job a chance to finish
-        while self.schedule.job_running(ret):
-            time.sleep(1)
 
         # Evaluate 1 second at the run time
         self.schedule.eval(now=run_time2)
@@ -365,19 +356,11 @@ class SchedulerEvalTest(ModuleCase, SaltReturnAssertsMixin):
         ret = self.schedule.job_status(job_name)
         self.assertEqual(ret['_last_run'], run_time)
 
-        # Give the job a chance to finish
-        while self.schedule.job_running(ret):
-            time.sleep(1)
-
         # eval at 4:00pm, will run.
         run_time = dateutil_parser.parse('11/29/2017 4:00pm')
         self.schedule.eval(now=run_time)
         ret = self.schedule.job_status(job_name)
         self.assertEqual(ret['_last_run'], run_time)
-
-        # Give the job a chance to finish
-        while self.schedule.job_running(ret):
-            time.sleep(1)
 
         # eval at 5:00pm, will not run
         run_time = dateutil_parser.parse('11/29/2017 5:00pm')
@@ -705,10 +688,6 @@ class SchedulerEvalTest(ModuleCase, SaltReturnAssertsMixin):
         self.assertEqual(ret['_last_run'], run_time)
         self.assertEqual(ret['_next_fire_time'], next_run_time)
 
-        # Give the job a chance to finish
-        while self.schedule.job_running(ret):
-            time.sleep(1)
-
         # eval at 2:01:00pm, will run.
         run_time = dateutil_parser.parse('11/29/2017 2:01:00pm')
         next_run_time = run_time + datetime.timedelta(seconds=30)
@@ -716,10 +695,6 @@ class SchedulerEvalTest(ModuleCase, SaltReturnAssertsMixin):
         ret = self.schedule.job_status(job_name)
         self.assertEqual(ret['_last_run'], run_time)
         self.assertEqual(ret['_next_fire_time'], next_run_time)
-
-        # Give the job a chance to finish
-        while self.schedule.job_running(ret):
-            time.sleep(1)
 
         # eval at 2:01:30pm, will run.
         run_time = dateutil_parser.parse('11/29/2017 2:01:30pm')
@@ -769,19 +744,11 @@ class SchedulerEvalTest(ModuleCase, SaltReturnAssertsMixin):
         ret = self.schedule.job_status(job_name)
         self.assertEqual(ret['_last_run'], run_time)
 
-        # Give the job a chance to finish
-        while self.schedule.job_running(ret):
-            time.sleep(1)
-
         # eval at 3:00:00pm, will run.
         run_time = dateutil_parser.parse('11/29/2017 3:00:00pm')
         self.schedule.eval(now=run_time)
         ret = self.schedule.job_status(job_name)
         self.assertEqual(ret['_last_run'], run_time)
-
-        # Give the job a chance to finish
-        while self.schedule.job_running(ret):
-            time.sleep(1)
 
         # eval at 3:30:00pm, will run.
         run_time = dateutil_parser.parse('11/29/2017 3:30:00pm')
@@ -829,19 +796,11 @@ class SchedulerEvalTest(ModuleCase, SaltReturnAssertsMixin):
         ret = self.schedule.job_status(job_name)
         self.assertEqual(ret['_last_run'], run_time)
 
-        # Give the job a chance to finish
-        while self.schedule.job_running(ret):
-            time.sleep(1)
-
         # eval at 6:00:00pm, will run.
         run_time = dateutil_parser.parse('11/29/2017 6:00:00pm')
         self.schedule.eval(now=run_time)
         ret = self.schedule.job_status(job_name)
         self.assertEqual(ret['_last_run'], run_time)
-
-        # Give the job a chance to finish
-        while self.schedule.job_running(ret):
-            time.sleep(1)
 
         # eval at 8:00:00pm, will run.
         run_time = dateutil_parser.parse('11/29/2017 8:00:00pm')
@@ -893,10 +852,6 @@ class SchedulerEvalTest(ModuleCase, SaltReturnAssertsMixin):
         self.assertEqual(ret['_last_run'], last_run_time)
         self.assertEqual(ret['_next_fire_time'], next_run_time)
 
-        # Give the job a chance to finish
-        while self.schedule.job_running(ret):
-            time.sleep(1)
-
         # eval at 11/27/2017 2:00:00pm, will run.
         run_time = dateutil_parser.parse('11/27/2017 2:00:00pm')
         next_run_time = run_time + datetime.timedelta(days=2)
@@ -905,10 +860,6 @@ class SchedulerEvalTest(ModuleCase, SaltReturnAssertsMixin):
         self.assertEqual(ret['_last_run'], run_time)
         self.assertEqual(ret['_next_fire_time'], next_run_time)
 
-        # Give the job a chance to finish
-        while self.schedule.job_running(ret):
-            time.sleep(1)
-
         # eval at 11/28/2017 2:00:00pm, will not run.
         run_time = dateutil_parser.parse('11/28/2017 2:00:00pm')
         last_run_time = run_time - datetime.timedelta(days=1)
@@ -916,10 +867,6 @@ class SchedulerEvalTest(ModuleCase, SaltReturnAssertsMixin):
         ret = self.schedule.job_status(job_name)
         self.assertEqual(ret['_last_run'], last_run_time)
         self.assertEqual(ret['_next_fire_time'], next_run_time)
-
-        # Give the job a chance to finish
-        while self.schedule.job_running(ret):
-            time.sleep(1)
 
         # eval at 11/29/2017 2:00:00pm, will run.
         run_time = dateutil_parser.parse('11/29/2017 2:00:00pm')

--- a/tests/integration/scheduler/test_helpers.py
+++ b/tests/integration/scheduler/test_helpers.py
@@ -5,6 +5,7 @@ from __future__ import absolute_import
 import copy
 import logging
 import os
+import time
 
 # Import Salt Testing libs
 from tests.support.case import ModuleCase
@@ -41,6 +42,7 @@ class SchedulerHelpersTest(ModuleCase, SaltReturnAssertsMixin):
             functions = {'test.ping': ping}
             self.schedule = salt.utils.schedule.Schedule(copy.deepcopy(DEFAULT_CONFIG), functions, returners={})
         self.schedule.opts['loop_interval'] = 1
+        self.schedule.opts['run_schedule_jobs_in_background'] = False
 
     def tearDown(self):
         self.schedule.reset()

--- a/tests/integration/scheduler/test_helpers.py
+++ b/tests/integration/scheduler/test_helpers.py
@@ -66,3 +66,23 @@ class SchedulerHelpersTest(ModuleCase, SaltReturnAssertsMixin):
 
         ret = self.schedule._get_schedule(remove_hidden=True)
         self.assertEqual(job['schedule'], ret)
+
+    def test_run_job(self):
+        '''
+        verify that the run_job function runs the job
+        '''
+        job_name = 'test_run_job'
+        job = {
+          'schedule': {
+            'enabled': True,
+            job_name: {
+              'function': 'test.ping',
+              'seconds': 60
+            }
+          }
+        }
+        # Add the job to the scheduler
+        self.schedule.opts.update(job)
+
+        ret = self.schedule.run_job('test_run_job')
+        self.assertIn('_last_run', job['schedule']['test_run_job'])

--- a/tests/integration/scheduler/test_helpers.py
+++ b/tests/integration/scheduler/test_helpers.py
@@ -5,7 +5,6 @@ from __future__ import absolute_import
 import copy
 import logging
 import os
-import time
 
 # Import Salt Testing libs
 from tests.support.case import ModuleCase

--- a/tests/integration/scheduler/test_maxrunning.py
+++ b/tests/integration/scheduler/test_maxrunning.py
@@ -5,7 +5,6 @@ from __future__ import absolute_import
 import copy
 import logging
 import os
-import time
 
 import dateutil.parser as dateutil_parser
 

--- a/tests/integration/scheduler/test_maxrunning.py
+++ b/tests/integration/scheduler/test_maxrunning.py
@@ -5,6 +5,7 @@ from __future__ import absolute_import
 import copy
 import logging
 import os
+import time
 
 import dateutil.parser as dateutil_parser
 
@@ -48,6 +49,7 @@ class SchedulerMaxRunningTest(ModuleCase, SaltReturnAssertsMixin):
             functions = {'test.ping': ping}
             self.schedule = salt.utils.schedule.Schedule(copy.deepcopy(DEFAULT_CONFIG), functions, returners={})
         self.schedule.opts['loop_interval'] = 1
+        self.schedule.opts['run_schedule_jobs_in_background'] = False
 
     def tearDown(self):
         self.schedule.reset()

--- a/tests/integration/scheduler/test_postpone.py
+++ b/tests/integration/scheduler/test_postpone.py
@@ -6,7 +6,6 @@ import copy
 import datetime
 import logging
 import os
-import time
 
 import dateutil.parser as dateutil_parser
 

--- a/tests/integration/scheduler/test_postpone.py
+++ b/tests/integration/scheduler/test_postpone.py
@@ -6,6 +6,7 @@ import copy
 import datetime
 import logging
 import os
+import time
 
 import dateutil.parser as dateutil_parser
 
@@ -43,9 +44,12 @@ class SchedulerPostponeTest(ModuleCase, SaltReturnAssertsMixin):
             functions = {'test.ping': ping}
             self.schedule = salt.utils.schedule.Schedule(copy.deepcopy(DEFAULT_CONFIG), functions, returners={})
         self.schedule.opts['loop_interval'] = 1
+        self.schedule.opts['run_schedule_jobs_in_background'] = False
 
     def tearDown(self):
         self.schedule.reset()
+
+        del self.schedule
 
     def test_postpone(self):
         '''

--- a/tests/integration/scheduler/test_postpone.py
+++ b/tests/integration/scheduler/test_postpone.py
@@ -48,8 +48,6 @@ class SchedulerPostponeTest(ModuleCase, SaltReturnAssertsMixin):
     def tearDown(self):
         self.schedule.reset()
 
-        del self.schedule
-
     def test_postpone(self):
         '''
         verify that scheduled job is postponed until the specified time.

--- a/tests/integration/scheduler/test_skip.py
+++ b/tests/integration/scheduler/test_skip.py
@@ -5,7 +5,6 @@ from __future__ import absolute_import
 import copy
 import logging
 import os
-import time
 
 import dateutil.parser as dateutil_parser
 
@@ -48,8 +47,6 @@ class SchedulerSkipTest(ModuleCase, SaltReturnAssertsMixin):
     def tearDown(self):
         self.schedule.reset()
 
-        del self.schedule
-
     def test_skip(self):
         '''
         verify that scheduled job is skipped at the specified time
@@ -77,10 +74,6 @@ class SchedulerSkipTest(ModuleCase, SaltReturnAssertsMixin):
         self.assertNotIn('_last_run', ret)
         self.assertEqual(ret['_skip_reason'], 'skip_explicit')
         self.assertEqual(ret['_skipped_time'], run_time)
-
-        # Give the job a chance to finish
-        while self.schedule.job_running(ret):
-            time.sleep(1)
 
         # Run 11/29/2017 at 5pm
         run_time = dateutil_parser.parse('11/29/2017 5:00pm')

--- a/tests/integration/scheduler/test_skip.py
+++ b/tests/integration/scheduler/test_skip.py
@@ -48,7 +48,7 @@ class SchedulerSkipTest(ModuleCase, SaltReturnAssertsMixin):
     def tearDown(self):
         self.schedule.reset()
 
-	del self.schedule
+        del self.schedule
 
     def test_skip(self):
         '''
@@ -79,8 +79,8 @@ class SchedulerSkipTest(ModuleCase, SaltReturnAssertsMixin):
         self.assertEqual(ret['_skipped_time'], run_time)
 
         # Give the job a chance to finish
-	while self.schedule.job_running(ret):
-          time.sleep(1)
+        while self.schedule.job_running(ret):
+            time.sleep(1)
 
         # Run 11/29/2017 at 5pm
         run_time = dateutil_parser.parse('11/29/2017 5:00pm')


### PR DESCRIPTION
### What does this PR do?
Updating the max_running function to assume run=True if the value isnot available, this fixes the run_job function.  Adding a test for run_job.

### What issues does this PR fix or reference?
#52617

### Tests written?
Yes

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
