### PR TITLE
Replace deprecated ifup, ifdown iface with ip link set iface up, down

### DIFF
--- a/salt/modules/debian_ip.py
+++ b/salt/modules/debian_ip.py
@@ -1822,7 +1822,8 @@ def down(iface, iface_type):
     # Slave devices are controlled by the master.
     # Source 'interfaces' aren't brought down.
     if iface_type not in ['slave', 'source']:
-        return __salt__['cmd.run'](['ifdown', iface])
+        cmd = ['ip', 'link', 'set', '{0}'.format(iface), 'down']
+        return __salt__['cmd.run'](cmd, python_shell=False)
     return None
 
 
@@ -1883,7 +1884,8 @@ def up(iface, iface_type):  # pylint: disable=C0103
     # Slave devices are controlled by the master.
     # Source 'interfaces' aren't brought up.
     if iface_type not in ('slave', 'source'):
-        return __salt__['cmd.run'](['ifup', iface])
+        cmd = ['ip', 'link', 'set', '{0}'.format(iface), 'up']
+        return __salt__['cmd.run'](cmd, python_shell=False)
     return None
 
 


### PR DESCRIPTION
### What does this PR do?
Replaces use of deprecated ifup and ifdown on Debian based systems (Debian and Ubuntu).
In Ubuntu 18.04.1 LTS, the use of ifupdown packages was removed and is not installed by default.
see url: https://wiki.ubuntu.com/BionicBeaver/ReleaseNotes/18.04.1#Network_configuration

Recommendation is to utilize **_ip link set iface up|down_**

### What issues does this PR fix or reference?
see https://github.com/saltstack/salt/issues/49078

### Previous Behavior
On a clean installed Ubuntu 18.04, failures using ifup or ifdown since package is not installed.

### New Behavior
Removes dependency on ifup or ifdown and utilizes ip link set iface up or down

### Tests written?
No, existing unit.modules.test_debian_ip suffices with test_down and test_up

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
