### PR TITLE
Set virtual grain when virtual_subtype exists

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1055,7 +1055,7 @@ def _virtual(osdata):
 
     # If we have a virtual_subtype, we're virtual, but maybe we couldn't
     # figure out what specific virtual type we were?
-    if grains['virtual_subtype'] and grains['virtual'] == 'physical':
+    if grains.get('virtual_subtype') and grains['virtual'] == 'physical':
         grains['virtual'] = 'virtual'
 
     for command in failed_commands:

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -944,11 +944,13 @@ def _virtual(osdata):
                 with salt.utils.files.fopen('/proc/1/cgroup', 'r') as fhr:
                     fhr_contents = fhr.read()
                 if ':/lxc/' in fhr_contents:
+                    grains['virtual'] = 'container'
                     grains['virtual_subtype'] = 'LXC'
                 else:
                     if any(x in fhr_contents
                            for x in (':/system.slice/docker', ':/docker/',
                                      ':/docker-ce/')):
+                        grains['virtual'] = 'container'
                         grains['virtual_subtype'] = 'Docker'
             except IOError:
                 pass
@@ -1050,6 +1052,11 @@ def _virtual(osdata):
                     '{0} -n machdep.idle-mechanism'.format(sysctl)) == 'xen':
                 if os.path.isfile('/var/run/xenconsoled.pid'):
                     grains['virtual_subtype'] = 'Xen Dom0'
+
+    # If we have a virtual_subtype, we're virtual, but maybe we couldn't
+    # figure out what specific virtual type we were?
+    if grains['virtual_subtype'] and grains['virtual'] == 'physical':
+        grains['virtual'] = 'virtual'
 
     for command in failed_commands:
         log.info(

--- a/tests/unit/grains/test_core.py
+++ b/tests/unit/grains/test_core.py
@@ -796,7 +796,7 @@ class CoreGrainsTestCase(TestCase, LoaderModuleMockMixin):
     @skipIf(salt.utils.platform.is_windows(), 'System is Windows')
     def test_docker_virtual(self):
         '''
-        Test if OS grains are parsed correctly in Ubuntu Xenial Xerus
+        Test if virtual grains are parsed correctly in Docker.
         '''
         with patch.object(os.path, 'isdir', MagicMock(return_value=False)):
             with patch.object(os.path,
@@ -810,10 +810,37 @@ class CoreGrainsTestCase(TestCase, LoaderModuleMockMixin):
                         'Testing Docker cgroup substring \'%s\'', cgroup_substr)
                     with patch('salt.utils.files.fopen', mock_open(read_data=cgroup_data)):
                         with patch.dict(core.__salt__, {'cmd.run_all': MagicMock()}):
+                            grains = core._virtual({'kernel': 'Linux'})
                             self.assertEqual(
-                                core._virtual({'kernel': 'Linux'}).get('virtual_subtype'),
+                                grains.get('virtual_subtype'),
                                 'Docker'
                             )
+                            self.assertEqual(
+                                grains.get('virtual'),
+                                'container',
+                            )
+
+    @skipIf(salt.utils.platform.is_windows(), 'System is Windows')
+    def test_lxc_virtual(self):
+        '''
+        Test if virtual grains are parsed correctly in LXC.
+        '''
+        with patch.object(os.path, 'isdir', MagicMock(return_value=False)):
+            with patch.object(os.path,
+                              'isfile',
+                              MagicMock(side_effect=lambda x: True if x == '/proc/1/cgroup' else False)):
+                cgroup_data = '10:memory:/lxc/a_long_sha256sum'
+                with patch('salt.utils.files.fopen', mock_open(read_data=cgroup_data)):
+                    with patch.dict(core.__salt__, {'cmd.run_all': MagicMock()}):
+                        grains = core._virtual({'kernel': 'Linux'})
+                        self.assertEqual(
+                            grains.get('virtual_subtype'),
+                            'LXC'
+                        )
+                        self.assertEqual(
+                            grains.get('virtual'),
+                            'container',
+                        )
 
     @skipIf(salt.utils.platform.is_windows(), 'System is Windows')
     def test_xen_virtual(self):
@@ -829,6 +856,33 @@ class CoreGrainsTestCase(TestCase, LoaderModuleMockMixin):
                     core._virtual({'kernel': 'Linux'}).get('virtual_subtype'),
                     'Xen PV DomU'
                 )
+
+    def test_if_virtual_subtype_exists_virtual_should_fallback_to_virtual(self):
+        def mockstat(path):
+            if path == '/':
+                return 'fnord'
+            elif path == '/proc/1/root/.':
+                return 'roscivs'
+            return None
+        with patch.dict(
+            core.__salt__,
+            {
+                'cmd.run': MagicMock(return_value=''),
+                'cmd.run_all': MagicMock(return_value={'retcode': 0, 'stdout': ''}),
+            }
+        ):
+            with patch.multiple(
+                os.path,
+                isfile=MagicMock(return_value=False),
+                isdir=MagicMock(side_effect=lambda x: x == '/proc'),
+            ):
+                with patch.multiple(
+                    os,
+                    stat=MagicMock(side_effect=mockstat),
+                ):
+                    grains = core._virtual({'kernel': 'Linux'})
+                    assert grains.get('virtual_subtype') is not None
+                    assert grains.get('virtual') == 'virtual'
 
     def _check_ipaddress(self, value, ip_v):
         '''


### PR DESCRIPTION
### What does this PR do?

What it says on the tin. If we have a `virtual_subtype` then we're running under some kind of virtualization. We should set something specific (e.g. container, if it's a lxc or docker (i.e. linux container)), but I don't think there's any reason we should let it be `physical` when there's a `virtual_subtype`

### What issues does this PR fix or reference?

Fixes #51451

### Previous Behavior

It was possible to have `virtual = physical` grain while `virtual_subtype` was set to something.

### New Behavior

Now for Docker and LXC the virtual type will be Container. I don't know if there's a better, more specific term that we can use.

And if `virtual_subtype` is set, but the virtual grain is `physical`, just set it to the non-specific `virtual`.

### Tests written?

Yes

### Commits signed with GPG?

Yes