### PR TITLE
Disable `w32time` for the date and time tests

### DIFF
--- a/tests/integration/modules/test_system.py
+++ b/tests/integration/modules/test_system.py
@@ -25,7 +25,8 @@ from salt.ext import six
 log = logging.getLogger(__name__)
 
 
-@skipIf(not salt.utils.platform.is_linux(), 'These tests can only be run on linux')
+@skipIf(not salt.utils.platform.is_linux(),
+        'These tests can only be run on linux')
 class SystemModuleTest(ModuleCase):
     '''
     Validate the date/time functions in the system module
@@ -362,7 +363,8 @@ class SystemModuleTest(ModuleCase):
             self.assertTrue(self._hwclock_has_compare())
 
 
-@skipIf(not salt.utils.platform.is_windows(), 'These tests can only be run on windows')
+@skipIf(not salt.utils.platform.is_windows(),
+        'These tests can only be run on windows')
 class WinSystemModuleTest(ModuleCase):
     '''
     Validate the date/time functions in the win_system module
@@ -389,12 +391,16 @@ class WinSystemModuleTest(ModuleCase):
         '''
         Test setting the computer description
         '''
+        current_desc = self.run_function('system.get_computer_desc')
         desc = 'test description'
-        set_desc = self.run_function('system.set_computer_desc', [desc])
-        self.assertTrue(set_desc)
+        try:
+            set_desc = self.run_function('system.set_computer_desc', [desc])
+            self.assertTrue(set_desc)
 
-        get_desc = self.run_function('system.get_computer_desc')
-        self.assertEqual(set_desc['Computer Description'], get_desc)
+            get_desc = self.run_function('system.get_computer_desc')
+            self.assertEqual(set_desc['Computer Description'], get_desc)
+        finally:
+            self.run_function('system.set_computer_desc', [current_desc])
 
     def test_get_system_time(self):
         '''
@@ -404,17 +410,20 @@ class WinSystemModuleTest(ModuleCase):
         now = datetime.datetime.now()
         self.assertEqual(now.strftime("%I:%M"), ret.rsplit(':', 1)[0])
 
-    @flaky
+    @skipIf(True, 'This test fails due to NTP settings')
     @destructiveTest
-    @flaky
     def test_set_system_time(self):
         '''
         Test setting the system time
         '''
         test_time = '10:55'
-        set_time = self.run_function('system.set_system_time', [test_time + ' AM'])
-        get_time = self.run_function('system.get_system_time').rsplit(':', 1)[0]
-        self.assertEqual(get_time, test_time)
+        current_time = self.run_function('system.get_system_time')
+        try:
+            self.run_function('system.set_system_time', [test_time + ' AM'])
+            get_time = self.run_function('system.get_system_time').rsplit(':', 1)[0]
+            self.assertEqual(get_time, test_time)
+        finally:
+            self.run_function('system.set_system_time', [current_time])
 
     def test_get_system_date(self):
         '''
@@ -424,9 +433,16 @@ class WinSystemModuleTest(ModuleCase):
         date = datetime.datetime.now().date().strftime("%m/%d/%Y")
         self.assertEqual(date, ret)
 
+    @skipIf(True, 'This test fails due to NTP settings')
     @destructiveTest
     def test_set_system_date(self):
         '''
         Test setting system date
         '''
-        self.assertTrue(self.run_function('system.set_system_date', ['3/25/2018']))
+        current_date = self.run_function('system.get_system_date')
+        try:
+            self.run_function('system.set_system_date', ['03/25/2018'])
+            ret = self.run_function('system.get_system_date')
+            self.assertEqual(ret, '03/25/2018')
+        finally:
+            self.run_function('system.set_system_date', [current_date])

--- a/tests/integration/modules/test_system.py
+++ b/tests/integration/modules/test_system.py
@@ -410,12 +410,17 @@ class WinSystemModuleTest(ModuleCase):
         now = datetime.datetime.now()
         self.assertEqual(now.strftime("%I:%M"), ret.rsplit(':', 1)[0])
 
-    @skipIf(True, 'This test fails due to NTP settings')
     @destructiveTest
     def test_set_system_time(self):
         '''
         Test setting the system time
+
+        .. note::
+
+            In order for this test to pass, time sync must be disabled for the
+            VM in the hypervisor
         '''
+        self.run_function('service.stop', ['w32time'])
         test_time = '10:55'
         current_time = self.run_function('system.get_system_time')
         try:
@@ -424,6 +429,7 @@ class WinSystemModuleTest(ModuleCase):
             self.assertEqual(get_time, test_time)
         finally:
             self.run_function('system.set_system_time', [current_time])
+            self.run_function('service.start', ['w32time'])
 
     def test_get_system_date(self):
         '''
@@ -433,12 +439,17 @@ class WinSystemModuleTest(ModuleCase):
         date = datetime.datetime.now().date().strftime("%m/%d/%Y")
         self.assertEqual(date, ret)
 
-    @skipIf(True, 'This test fails due to NTP settings')
     @destructiveTest
     def test_set_system_date(self):
         '''
         Test setting system date
+
+        .. note::
+
+            In order for this test to pass, time sync must be disabled for the
+            VM in the hypervisor
         '''
+        self.run_function('service.stop', ['w32time'])
         current_date = self.run_function('system.get_system_date')
         try:
             self.run_function('system.set_system_date', ['03/25/2018'])
@@ -446,3 +457,4 @@ class WinSystemModuleTest(ModuleCase):
             self.assertEqual(ret, '03/25/2018')
         finally:
             self.run_function('system.set_system_date', [current_date])
+            self.run_function('service.start', ['w32time'])


### PR DESCRIPTION
### What does this PR do?
Disable `w32time` for the two test that test setting date and time

These test create a race condition where the date/time is changed. Then the date/time is retrieved and tested to see if it's correct. The NTP usually sets the time back to the current date/time before the date/time is retrieved, causing the test to fail. Some times the test passes, if it's quick enough, but in the case of the time test it causes the test suite to terminate because now it thinks it's been running for days.
```
00:33:40        [CPU:0.0%|MEM:50.5%]  ... OK (4.984s)
00:33:40          test_set_system_date (integration.modules.test_system.WinSystemModuleTest)
00:33:42        [CPU:0.0%|MEM:50.5%]  ... OK (-33955197.750s)  <==== strange time
00:33:42          test_set_system_time (integration.modules.test_system.WinSystemModuleTest)
00:34:42        Copying /tmp/xml-unittests-output to artifacts/ <===== tests have terminated
```

### Commits signed with GPG?
Yes