### PR TITLE
Fix issue with compare_lists

### DIFF
--- a/doc/topics/jinja/index.rst
+++ b/doc/topics/jinja/index.rst
@@ -34,7 +34,7 @@ wrap conditional or redundant state elements:
         {% endif %}
         - source: salt://motd
 
-In this example, the first if block will only be evaluated on minions that
+In this example, the first **if** block will only be evaluated on minions that
 aren't running FreeBSD, and the second block changes the file name based on the
 *os* grain.
 
@@ -656,7 +656,7 @@ Returns:
 
 .. versionadded:: 2017.7.0
 
-Return is an iterable object is already sorted.
+Return ``True`` if an iterable object is already sorted.
 
 Example:
 
@@ -690,7 +690,7 @@ Returns:
 
 .. code-block:: python
 
-  {'new': 4, 'old': 3}
+  {'new': [4], 'old': [3]}
 
 
 .. jinja_ref:: compare_dicts
@@ -706,7 +706,7 @@ Example:
 
 .. code-block:: jinja
 
-  {{ {'a': 'b'} | compare_lists({'a': 'c'}) }}
+  {{ {'a': 'b'} | compare_dicts({'a': 'c'}) }}
 
 Returns:
 
@@ -722,7 +722,7 @@ Returns:
 
 .. versionadded:: 2017.7.0
 
-Return True if the value is hexazecimal.
+Return ``True`` if the value is hexadecimal.
 
 Example:
 
@@ -746,7 +746,7 @@ Returns:
 
 .. versionadded:: 2017.7.0
 
-Return True if a text contains whitespaces.
+Return ``True`` if a text contains whitespaces.
 
 Example:
 
@@ -770,7 +770,7 @@ Returns:
 
 .. versionadded:: 2017.7.0
 
-Return is a substring is found in a list of string values.
+Return ``True`` if a substring is found in a list of string values.
 
 Example:
 

--- a/salt/utils/data.py
+++ b/salt/utils/data.py
@@ -143,13 +143,13 @@ def compare_lists(old=None, new=None):
     Compare before and after results from various salt functions, returning a
     dict describing the changes that were made
     '''
-    ret = {'old': [], 'new': []}
+    ret = {}
     for item in new:
         if item not in old:
-            ret['new'].append(item)
+            ret.setdefault('new', []).append(item)
     for item in old:
         if item not in new:
-            ret['old'].append(item)
+            ret.setdefault('old', []).append(item)
     return ret
 
 

--- a/salt/utils/data.py
+++ b/salt/utils/data.py
@@ -143,13 +143,13 @@ def compare_lists(old=None, new=None):
     Compare before and after results from various salt functions, returning a
     dict describing the changes that were made
     '''
-    ret = dict()
+    ret = {'old': [], 'new': []}
     for item in new:
         if item not in old:
-            ret['new'] = item
+            ret['new'].append(item)
     for item in old:
         if item not in new:
-            ret['old'] = item
+            ret['old'].append(item)
     return ret
 
 

--- a/tests/unit/states/test_win_dism.py
+++ b/tests/unit/states/test_win_dism.py
@@ -26,7 +26,7 @@ class WinDismTestCase(TestCase, LoaderModuleMockMixin):
         '''
         expected = {
             'comment': "Installed Capa2",
-            'changes': {'capability': {'new': 'Capa2'},
+            'changes': {'capability': {'new': ['Capa2']},
                         'retcode': 0},
             'name': 'Capa2',
             'result': True}
@@ -106,7 +106,7 @@ class WinDismTestCase(TestCase, LoaderModuleMockMixin):
         '''
         expected = {
             'comment': "Removed Capa2",
-            'changes': {'capability': {'old': 'Capa2'},
+            'changes': {'capability': {'old': ['Capa2']},
                         'retcode': 0},
             'name': 'Capa2',
             'result': True}
@@ -184,7 +184,7 @@ class WinDismTestCase(TestCase, LoaderModuleMockMixin):
         '''
         expected = {
             'comment': "Installed Feat2",
-            'changes': {'feature': {'new': 'Feat2'},
+            'changes': {'feature': {'new': ['Feat2']},
                         'retcode': 0},
             'name': 'Feat2',
             'result': True}
@@ -263,7 +263,7 @@ class WinDismTestCase(TestCase, LoaderModuleMockMixin):
         '''
         expected = {
             'comment': "Removed Feat2",
-            'changes': {'feature': {'old': 'Feat2'},
+            'changes': {'feature': {'old': ['Feat2']},
                         'retcode': 0},
             'name': 'Feat2',
             'result': True}
@@ -342,7 +342,7 @@ class WinDismTestCase(TestCase, LoaderModuleMockMixin):
         '''
         expected = {
             'comment': "Installed Pack2",
-            'changes': {'package': {'new': 'Pack2'},
+            'changes': {'package': {'new': ['Pack2']},
                         'retcode': 0},
             'name': 'Pack2',
             'result': True}
@@ -434,7 +434,7 @@ class WinDismTestCase(TestCase, LoaderModuleMockMixin):
         '''
         expected = {
             'comment': "Removed Pack2",
-            'changes': {'package': {'old': 'Pack2'},
+            'changes': {'package': {'old': ['Pack2']},
                         'retcode': 0},
             'name': 'Pack2',
             'result': True}

--- a/tests/unit/utils/test_data.py
+++ b/tests/unit/utils/test_data.py
@@ -244,6 +244,18 @@ class DataTestCase(TestCase):
         expected_ret = {'foo': {'new': 'woz', 'old': 'bar'}}
         self.assertDictEqual(ret, expected_ret)
 
+    def test_compare_lists_no_change(self):
+        ret = salt.utils.data.compare_lists(old=[1, 2, 3, 'a', 'b', 'c'],
+                                            new=[1, 2, 3, 'a', 'b', 'c'])
+        expected = {'new': [], 'old': []}
+        self.assertDictEqual(ret, expected)
+
+    def test_compare_lists_changes(self):
+        ret = salt.utils.data.compare_lists(old=[1, 2, 3, 'a', 'b', 'c'],
+                                            new=[1, 2, 4, 'x', 'y', 'z'])
+        expected = {'new': [4, 'x', 'y', 'z'], 'old': [3, 'a', 'b', 'c']}
+        self.assertDictEqual(ret, expected)
+
     def test_decode(self):
         '''
         Companion to test_decode_to_str, they should both be kept up-to-date

--- a/tests/unit/utils/test_data.py
+++ b/tests/unit/utils/test_data.py
@@ -268,12 +268,6 @@ class DataTestCase(TestCase):
         expected = {'old': ['a', 'b', 'c']}
         self.assertDictEqual(ret, expected)
 
-    def test_compare_lists_changes(self):
-        ret = salt.utils.data.compare_lists(old=[1, 2, 3, 'a', 'b', 'c'],
-                                            new=[1, 2, 4, 'x', 'y', 'z'])
-        expected = {'new': [4, 'x', 'y', 'z'], 'old': [3, 'a', 'b', 'c']}
-        self.assertDictEqual(ret, expected)
-
     def test_decode(self):
         '''
         Companion to test_decode_to_str, they should both be kept up-to-date

--- a/tests/unit/utils/test_data.py
+++ b/tests/unit/utils/test_data.py
@@ -247,7 +247,25 @@ class DataTestCase(TestCase):
     def test_compare_lists_no_change(self):
         ret = salt.utils.data.compare_lists(old=[1, 2, 3, 'a', 'b', 'c'],
                                             new=[1, 2, 3, 'a', 'b', 'c'])
-        expected = {'new': [], 'old': []}
+        expected = {}
+        self.assertDictEqual(ret, expected)
+
+    def test_compare_lists_changes(self):
+        ret = salt.utils.data.compare_lists(old=[1, 2, 3, 'a', 'b', 'c'],
+                                            new=[1, 2, 4, 'x', 'y', 'z'])
+        expected = {'new': [4, 'x', 'y', 'z'], 'old': [3, 'a', 'b', 'c']}
+        self.assertDictEqual(ret, expected)
+
+    def test_compare_lists_changes_new(self):
+        ret = salt.utils.data.compare_lists(old=[1, 2, 3],
+                                            new=[1, 2, 3, 'x', 'y', 'z'])
+        expected = {'new': ['x', 'y', 'z']}
+        self.assertDictEqual(ret, expected)
+
+    def test_compare_lists_changes_old(self):
+        ret = salt.utils.data.compare_lists(old=[1, 2, 3, 'a', 'b', 'c'],
+                                            new=[1, 2, 3])
+        expected = {'old': ['a', 'b', 'c']}
         self.assertDictEqual(ret, expected)
 
     def test_compare_lists_changes(self):


### PR DESCRIPTION
### What does this PR do?
Fixes the `compare_lists` function in the `data` Salt util. It would always return a list with a single item, not a list of items.

### What issues does this PR fix or reference?
https://saltstack.slack.com/archives/C04HEQ97D/p1556106630009100

### Previous Behavior
Returned a list with a single item

### New Behavior
Returns a list containing all changes

### Tests written?
Yes

### Commits signed with GPG?
Yes