### PR TITLE
Make sure --run-expensive runtests.py arg works

### DIFF
--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -189,6 +189,7 @@ TEST_SUITES = collections.OrderedDict(sorted(TEST_SUITES_UNORDERED.items(),
 class SaltTestsuiteParser(SaltCoverageTestingParser):
     support_docker_execution = True
     support_destructive_tests_selection = True
+    support_expensive_tests_selection = True
     source_code_basedir = SALT_ROOT
 
     def _get_suites(self, include_unit=False, include_cloud_provider=False,


### PR DESCRIPTION
### What does this PR do?
makes sure the `--run-expensive` argument works for runtests.py

### Previous Behavior
```
(salt-py2) ➜  salt git:(6dcb93f76d) python tests/runtests.py --run-expensive -n unit.modules.test_telegram
Usage: runtests.py [options]

runtests.py: error: no such option: --run-expensive
(salt-py2) ➜  salt git:(6dcb93f76d) 
```

### New Behavior
```
(salt-py2) ➜  salt git:(add-run-expensive) python tests/runtests.py --run-expensive -n unit.modules.test_telegram
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 * Python Version: 2.7.15 (default, Jan 10 2019, 23:20:52) [GCC 8.2.1 20181127]
 * Transplanting configuration files to '/tmp/salt-tests-tmpdir/config'
 * Current Directory: /home/ch3ll/git/salt
 * Test suite is running under PID 6527
 * Logging tests on /tmp/salt-runtests.log
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Starting unit.modules.test_telegram Tests
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
.
----------------------------------------------------------------------
Ran 1 test in 0.001s

OK

===============================================================  Overall Tests Report  ================================================================
***  No Problems Found While Running Tests  ***********************************************************************************************************
=======================================================================================================================================================
OK (total=1, skipped=0, passed=1, failures=0, errors=0) 
===============================================================  Overall Tests Report  ================================================================
(salt-py2) ➜  salt git:(add-run-expensive) 
```

### Tests written?

no -fixes test runner

### Commits signed with GPG?

Yes
