### PR TITLE
Add support for EC2 for virtual grain

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1276,6 +1276,8 @@ def _windows_platform_data():
                 grains['virtual_subtype'] = 'HVM domU'
         elif 'OpenStack' in systeminfo.Model:
             grains['virtual'] = 'OpenStack'
+        elif 'AMAZON' in biosinfo.Version:
+            grains['virtual'] = 'EC2'
 
     return grains
 


### PR DESCRIPTION
### What does this PR do?
Adds support for the `virtual` grain on EC2

### What issues does this PR fix or reference?
jenkins
Fixes unit.grains.test_core
https://github.com/saltstack/salt/issues/52801

### Previous Behavior
did not return a `virtual` grain on EC2 instances

### New Behavior
returns a `virtual` grain

### Tests written?
No

### Commits signed with GPG?
Yes