### PR TITLE
doc: Set script type explicitly to text/javascript

### DIFF
--- a/doc/_themes/saltstack/layout.html
+++ b/doc/_themes/saltstack/layout.html
@@ -81,7 +81,7 @@
     </script>
     {%- for scriptfile in script_files %}
     {% if scriptfile not in js_blacklist %}
-    <script src="{{ pathto(scriptfile, 1) }}"></script>
+    <script type="text/javascript" src="{{ pathto(scriptfile, 1) }}"></script>
     {% endif %}
     {%- endfor %}
 {%- endmacro %}
@@ -159,7 +159,7 @@
         {%- endblock %}
 
         {%- block extrahead %} {% endblock %}
-        <script src="{{ pathto('_static/js/vendor/modernizr-2.6.2-respond-1.1.0.min.js', 1) }}"></script>
+        <script type="text/javascript" src="{{ pathto('_static/js/vendor/modernizr-2.6.2-respond-1.1.0.min.js', 1) }}"></script>
 
         {%- block analytics %}
         {% endblock %}
@@ -258,7 +258,7 @@
             </footer>
         {%- endblock %}
 
-        <script src="{{ pathto('_static/js/main.js', 1) }}"></script>
+        <script type="text/javascript" src="{{ pathto('_static/js/main.js', 1) }}"></script>
 
         {% if on_saltstack %}
         <script type="text/javascript" language="javascript">llactid=23943</script>

--- a/doc/_themes/saltstack2/layout.html
+++ b/doc/_themes/saltstack2/layout.html
@@ -57,7 +57,7 @@
     </script>
     {%- for scriptfile in script_files %}
 
-    <script src="{{ pathto(scriptfile, 1) }}"></script>
+    <script type="text/javascript" src="{{ pathto(scriptfile, 1) }}"></script>
 
     {%- endfor %}
 {%- endmacro %}
@@ -98,7 +98,7 @@
         {%- endif %}
 
         <!--[if lt IE 9]>
-        <script src="{{ pathto('_static/js/respond.min.js', 1) }}"></script>
+        <script type="text/javascript" src="{{ pathto('_static/js/respond.min.js', 1) }}"></script>
         <![endif]-->
 
         {%- block linktags %}


### PR DESCRIPTION
dh_sphinxdoc (used for building the documentation in the Debian package) searches for script lines and expect the type set to text/javascript. Otherwise dh_sphinxdoc won't find the scripts.

Therefore mark the JavaScript scripts explicitly as text/javascript.