### PR TITLE
Add the "merge" jinja filter

### DIFF
--- a/doc/topics/jinja/index.rst
+++ b/doc/topics/jinja/index.rst
@@ -1212,6 +1212,28 @@ Returns:
 
   'default'
 
+
+.. jinja_ref:: merge
+
+``merge``
+------------
+
+.. versionadded:: 2019.2.1
+
+Deeply merge a dict with another dict.
+
+Example:
+
+.. code-block:: jinja
+
+  {{ {'a1': {'b1': 'foo'}, 'a2': 'bar'} | merge({'a1': {'b1': 'foo2'}, 'a3': 'bar3'}) }}
+
+Returns:
+
+.. code-block:: python
+
+  {'a1': {'b1': 'foo2'}, 'a2': 'bar', 'a3': 'bar3'}
+
 .. _`builtin filters`: http://jinja.pocoo.org/docs/templates/#builtin-filters
 .. _`timelib`: https://github.com/pediapress/timelib/
 

--- a/salt/utils/dictupdate.py
+++ b/salt/utils/dictupdate.py
@@ -16,6 +16,7 @@ except ImportError:
 import copy
 import logging
 import salt.ext.six as six
+from salt.utils.decorators.jinja import jinja_filter
 
 log = logging.getLogger(__name__)
 
@@ -104,6 +105,7 @@ def merge_overwrite(obj_a, obj_b, merge_lists=False):
     return merge_recurse(obj_a, obj_b, merge_lists=merge_lists)
 
 
+@jinja_filter('merge')
 def merge(obj_a, obj_b, strategy='smart', renderer='yaml', merge_lists=False):
     if strategy == 'smart':
         if renderer.split('|')[-1] == 'yamlex' or renderer.startswith('yamlex_'):


### PR DESCRIPTION
This filter can be really useful in states to merge two dicts recursively.

The code is trivial as it is just a matter of exposing the existing merge function as a jinja filter through the @jinja_filter('merge') decorator.
That is the reason why it seems safe to merge it in the 2019.2 branch instead of the develop branch.