### PR TITLE
LocalClient: don't parse input twice and test fix.

### DIFF
--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -431,13 +431,13 @@ class LocalClient(object):
             >>> local.cmd_async('*', 'test.sleep', [300])
             '20131219215921857715'
         '''
-        arg = salt.utils.args.parse_input(arg, kwargs=kwarg)
         pub_data = self.run_job(tgt,
                                 fun,
                                 arg,
                                 tgt_type,
                                 ret,
                                 jid=jid,
+                                kwarg=kwarg,
                                 listen=False,
                                 **kwargs)
         try:
@@ -685,7 +685,6 @@ class LocalClient(object):
             minion ID. A compound command will return a sub-dictionary keyed by
             function name.
         '''
-        arg = salt.utils.args.parse_input(arg, kwargs=kwarg)
         was_listening = self.event.cpub
 
         try:
@@ -696,6 +695,7 @@ class LocalClient(object):
                                     ret,
                                     timeout,
                                     jid,
+                                    kwarg=kwarg,
                                     listen=True,
                                     **kwargs)
 
@@ -745,7 +745,6 @@ class LocalClient(object):
         :param verbose: Print extra information about the running command
         :returns: A generator
         '''
-        arg = salt.utils.args.parse_input(arg, kwargs=kwarg)
         was_listening = self.event.cpub
 
         if fun.startswith('state.'):
@@ -778,6 +777,7 @@ class LocalClient(object):
                 tgt_type,
                 ret,
                 timeout,
+                kwarg=kwarg,
                 listen=True,
                 **kwargs)
 
@@ -850,7 +850,6 @@ class LocalClient(object):
             {'dave': {'ret': True}}
             {'stewart': {'ret': True}}
         '''
-        arg = salt.utils.args.parse_input(arg, kwargs=kwarg)
         was_listening = self.event.cpub
 
         try:
@@ -861,6 +860,7 @@ class LocalClient(object):
                 tgt_type,
                 ret,
                 timeout,
+                kwarg=kwarg,
                 listen=True,
                 **kwargs)
 
@@ -917,7 +917,6 @@ class LocalClient(object):
             None
             {'stewart': {'ret': True}}
         '''
-        arg = salt.utils.args.parse_input(arg, kwargs=kwarg)
         was_listening = self.event.cpub
 
         try:
@@ -928,6 +927,7 @@ class LocalClient(object):
                 tgt_type,
                 ret,
                 timeout,
+                kwarg=kwarg,
                 listen=True,
                 **kwargs)
 
@@ -965,7 +965,6 @@ class LocalClient(object):
         '''
         Execute a salt command and return
         '''
-        arg = salt.utils.args.parse_input(arg, kwargs=kwarg)
         was_listening = self.event.cpub
 
         try:
@@ -976,6 +975,7 @@ class LocalClient(object):
                 tgt_type,
                 ret,
                 timeout,
+                kwarg=kwarg,
                 listen=True,
                 **kwargs)
 

--- a/tests/integration/modules/test_cmdmod.py
+++ b/tests/integration/modules/test_cmdmod.py
@@ -6,7 +6,6 @@ import os
 import random
 import sys
 import tempfile
-import textwrap
 
 # Import Salt Testing libs
 from tests.support.case import ModuleCase
@@ -262,9 +261,11 @@ class CMDModuleTest(ModuleCase):
         '''
         cmd.exec_code
         '''
-        code = textwrap.dedent('''\
-               import sys
-               sys.stdout.write('cheese')''')
+        # `code` is a multiline YAML text. Formatting it as a YAML block scalar.
+        code = '''|
+                   import sys
+                   sys.stdout.write('cheese')
+               '''
         self.assertEqual(self.run_function('cmd.exec_code',
                                            [AVAILABLE_PYTHON_EXECUTABLE,
                                             code]).rstrip(),
@@ -274,9 +275,11 @@ class CMDModuleTest(ModuleCase):
         '''
         cmd.exec_code
         '''
-        code = textwrap.dedent('''\
-               import sys
-               sys.stdout.write(sys.argv[1])''')
+        # `code` is a multiline YAML text. Formatting it as a YAML block scalar.
+        code = '''|
+                   import sys
+                   sys.stdout.write(sys.argv[1])
+               '''
         arg = 'cheese'
         self.assertEqual(self.run_function('cmd.exec_code',
                                            [AVAILABLE_PYTHON_EXECUTABLE,
@@ -288,9 +291,11 @@ class CMDModuleTest(ModuleCase):
         '''
         cmd.exec_code
         '''
-        code = textwrap.dedent('''\
-               import sys
-               sys.stdout.write(sys.argv[1])''')
+        # `code` is a multiline YAML text. Formatting it as a YAML block scalar.
+        code = '''|
+                   import sys
+                   sys.stdout.write(sys.argv[1])
+               '''
         arg = 'cheese'
         self.assertEqual(self.run_function('cmd.exec_code',
                                            [AVAILABLE_PYTHON_EXECUTABLE,


### PR DESCRIPTION
### What does this PR do?
Related to #49886 where passing input args and kwargs through `parse_input` was inroduced.

I've removed passing the args to `parse_input` from all functions except `run_job` because other functions aren't used that args and all are calling `run_job`. This avoids parsing that args multiple times.

Also I've updated the CMDModuleTest according to `parse_input` expectations. It yamlifies each text value in arguments so it expects arguments values to be a YAML code. This means that multiline blocks of python code shall be formatted accordingly.
Reference: https://yaml.org/spec/1.2/spec.html#id2795688
Examples and human friendly description: https://yaml-multiline.info/#block-scalars

### What issues does this PR fix or reference?
Fixes the following tests in develop branch:
integration.modules.test_cmdmod.CMDModuleTest.test_exec_code
integration.modules.test_cmdmod.CMDModuleTest.test_exec_code_with_multiple_args
integration.modules.test_cmdmod.CMDModuleTest.test_exec_code_with_single_arg

Fixes merge forward #52571