### PR TITLE
Update docs to be built using sphinx version 2.0.1, use latexmk

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -147,8 +147,7 @@ pdf: check_sphinx-build translations
 	fi
 	$(SPHINXBUILD) -b latex $(ALLSPHINXOPTS) $(BUILDDIR)/latex
 	@echo "Running LaTeX files through xelatex..."
-	perl -pi -e 's!pdflatex!xelatex!' $(BUILDDIR)/latex/Makefile
-	$(MAKE) -C $(BUILDDIR)/latex -i LATEXOPTS="-interaction=nonstopmode"
+	$(MAKE) -C $(BUILDDIR)/latex -i "PDFLATEX=latexmk" "LATEXMKOPTS=-xelatex -interaction=nonstopmode -f"
 	@echo "xelatex finished; the PDF files are in $(BUILDDIR)/latex."
 
 cheatsheet: translations

--- a/doc/_ext/saltdomain.py
+++ b/doc/_ext/saltdomain.py
@@ -10,7 +10,7 @@ from sphinx import addnodes
 from sphinx.directives import ObjectDescription
 from sphinx.domains import Domain, ObjType
 from sphinx.domains.python import PyObject
-from sphinx.locale import l_, _
+from sphinx.locale import _
 from sphinx.roles import XRefRole
 from sphinx.util.nodes import make_refnode
 from sphinx.util.nodes import nested_parse_with_titles
@@ -240,8 +240,8 @@ class SLSXRefRole(XRefRole):
 
 class SaltModuleIndex(python_domain.PythonModuleIndex):
     name = 'modindex'
-    localname = l_('Salt Module Index')
-    shortname = l_('all salt modules')
+    localname = _('Salt Module Index')
+    shortname = _('all salt modules')
 
 
 class SaltDomain(python_domain.PythonDomain):
@@ -251,7 +251,7 @@ class SaltDomain(python_domain.PythonDomain):
 
     object_types = python_domain.PythonDomain.object_types
     object_types.update({
-        'state': ObjType(l_('state'), 'state'),
+        'state': ObjType(_('state'), 'state'),
     })
 
     directives = python_domain.PythonDomain.directives

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -379,7 +379,7 @@ html_short_title = 'Salt'
 html_static_path = ['_static']
 html_logo = None # specified in the theme layout.html
 html_favicon = 'favicon.ico'
-html_use_smartypants = False
+smartquotes = False
 
 # Use Google customized search or use Sphinx built-in JavaScript search
 if on_saltstack:


### PR DESCRIPTION
### What does this PR do?
This makes the docs build on sphinx version 2.0.1.  Since newer versions of sphinx also use latexmk to build the pdf, they actually complete building the pdf instead of only building it half way.

### What issues does this PR fix or reference?
None
### Previous Behavior
Docs built successfully on versions of sphinx 1.5.6 and below.  Installing latexmk was not required.  PDF's did not build successfully.

### New Behavior
Docs build successfully on versions of sphinx 1.6.0 and above.  latexmk is a new dependancy, PDF's build successfully

### Tests written?

No New tests

### Commits signed with GPG?

Yes

See also:
https://github.com/saltstack/builddocs/pull/25
https://github.com/saltstack/sre-jenkins/pull/24

This will need to be applied to 2019.2 and develop, I don't know if we want to merge forward or use some other method.

Output of the builds are available at http://10.27.56.107/en/