### PR TITLE
salt-cloud/libvirt: enhance libvirt provider

### DIFF
--- a/salt/cloud/clouds/libvirt.py
+++ b/salt/cloud/clouds/libvirt.py
@@ -1163,6 +1163,8 @@ def start(name, call=None):
             found.append(domain)
         except libvirtError:
             pass
+        finally:
+            conn.close()
 
     if not found:
         return "{} doesn't exist and can't be started".format(name)
@@ -1180,7 +1182,10 @@ def start(name, call=None):
     )
 
     log.info("Starting domain %s", found[0].name())
-    found[0].create()
+    try:
+        found[0].create()
+    except libvirtError:
+        log.warning("Failed to start domain '%s'", found[0].name())
 
 def stop(name, call=None):
     """
@@ -1220,6 +1225,8 @@ def stop(name, call=None):
             found.append(domain)
         except libvirtError:
             pass
+        finally:
+            conn.close()
 
     if not found:
         return "{} doesn't exist and can't be stopped".format(name)
@@ -1237,7 +1244,10 @@ def stop(name, call=None):
     )
 
     log.info("Stopping domain %s", found[0].name())
-    found[0].shutdown()
+    try:
+        found[0].shutdown()
+    except libvirtError:
+        log.warning("Failed to stop domain '%s'", found[0].name())
 
 def reboot(name, call=None):
     """
@@ -1277,6 +1287,8 @@ def reboot(name, call=None):
             found.append(domain)
         except libvirtError:
             pass
+        finally:
+            conn.close()
 
     if not found:
         return "{} doesn't exist and can't be rebooted".format(name)
@@ -1294,4 +1306,7 @@ def reboot(name, call=None):
     )
 
     log.info("Rebooting domain %s", found[0].name())
-    found[0].shutdown()
+    try:
+        found[0].reboot()
+    except libvirtError:
+        log.warning("Failed to reboot domain '%s'", found[0].name())

--- a/salt/cloud/clouds/libvirt.py
+++ b/salt/cloud/clouds/libvirt.py
@@ -115,6 +115,7 @@ from salt.exceptions import (
     SaltCloudNotFound,
     SaltCloudSystemExit,
 )
+from salt.modules.virt import _handle_unit
 from salt.utils.xmlutil import get_xml_node
 
 try:
@@ -483,30 +484,14 @@ def create(vm_):
 
             # Configure amount of memory
             if memory:
-                try:
-                    memory_num, memory_unit = re.findall(
-                        r"[^\W\d_]+|\d+.\d+|\d+", memory
-                    )
-                    if memory_unit.lower() == "mb":
-                        memory_mb = int(memory_num)
-                    elif memory_unit.lower() == "gb":
-                        memory_mb = int(float(memory_num) * 1024.0)
-                    else:
-                        err_msg = "Invalid memory type specified: '{}'".format(
-                            memory_unit
-                        )
-                        log.error(err_msg)
-                        return {"Error": err_msg}
-                except (TypeError, ValueError):
-                    memory_mb = int(memory)
-
+                memory_b = _handle_unit(memory)
                 memory_xml = domain_xml.find("./memory")
-                memory_xml.text = str(memory_mb)
-                memory_xml.set("unit", "Mib")
+                memory_xml.text = str(memory_b)
+                memory_xml.set("unit", "b")
                 currentMemory_xml = domain_xml.find("./currentMemory")
-                currentMemory_xml.text = str(memory_mb)
-                currentMemory_xml.set("unit", "Mib")
-                log.debug("Setting memory to: %s MB", memory_mb)
+                currentMemory_xml.text = str(memory_b)
+                currentMemory_xml.set("unit", "b")
+                log.debug("Setting memory to: %s bytes", memory_b)
 
             # Configure USB controller
             if usb:

--- a/salt/cloud/clouds/libvirt.py
+++ b/salt/cloud/clouds/libvirt.py
@@ -24,8 +24,10 @@ Example profile:
       num_cpus: 2
       # Amount of virtual memory (unit: MB or GB)
       memory: 2048MB
-      # Network interfaces
+      # Serial number visible in DMI data (string)
+      serial: 01234456789
       devices:
+        # Network interfaces
         network:
           eth0:
             # Type of networking: [bridge | network]
@@ -365,6 +367,10 @@ def create(vm_):
         'memory', vm_, __opts__, default=None
     )
 
+    serial = config.get_cloud_config_value(
+        'serial', vm_, __opts__, default=None
+    )
+
     devices = config.get_cloud_config_value(
         'devices', vm_, __opts__, default=None
     )
@@ -429,6 +435,12 @@ def create(vm_):
                 vcpu_xml = domain_xml.find('./vcpu')
                 vcpu_xml.text = str(num_cpus)
                 log.debug("Setting CPU number to: %s", num_cpus)
+
+            # Configure serial number
+            if serial:
+                entry_xml = domain_xml.find('./sysinfo/system/entry')
+                entry_xml.text = str(serial)
+                log.debug("Setting Serial to %s", serial)
 
             # Configure amount of memory
             if memory:

--- a/salt/cloud/clouds/libvirt.py
+++ b/salt/cloud/clouds/libvirt.py
@@ -50,6 +50,8 @@ Example profile:
             bus: scsi
             # Block device to expose from the hypervisor to the virtual machine
             device: /dev/sdc
+            # (optional) Address for SCSI devices (controller:bus:target:unit)
+            address: 0:0:1:1
         # Network interfaces
         network:
           eth0:
@@ -730,12 +732,24 @@ def create(vm_):
                         disk_xml.append(
                             ElementTree.Element("driver", name="qemu", type="raw")
                         )
-                        disk_xml.append(ElementTree.Element("source", file=device))
+                        disk_xml.append(
+                            ElementTree.Element("source", file=device)
+                        )
                         disk_xml.append(
                             ElementTree.Element("target", dev=disk, bus=bus)
                         )
+
+                        if bus == "scsi" and "address" in devices["disk"][disk]:
+                            a = devices["disk"][disk]["address"].split(":")
+                            log.debug("Configuring scsi disk '%s': controller='%s', bus='%s', target='%s', unit='%s'", disk, a[0], a[1], a[2], a[3])
+                            disk_xml.append(
+                                ElementTree.Element("address", type="drive", controller=a[0], bus=a[1], target=a[2], unit=a[3])
+                            )
+
                         if shareable:
-                            disk_xml.append(ElementTree.Element("shareable"))
+                            disk_xml.append(
+                                ElementTree.Element("shareable")
+                            )
 
                     else:
                         # format: should be 'raw' or 'qcow2' (default)

--- a/salt/cloud/clouds/libvirt.py
+++ b/salt/cloud/clouds/libvirt.py
@@ -26,6 +26,8 @@ Example profile:
       memory: 2048MB
       # Serial number visible in DMI data (string)
       serial: 01234456789
+      # Should the domain start automatically at hypervisor boot
+      autostart: True
       devices:
         # Supplementary disks for cloned domain
         disks:
@@ -383,6 +385,10 @@ def create(vm_):
         'serial', vm_, __opts__, default=None
     )
 
+    autostart = config.get_cloud_config_value(
+        'autostart', vm_, __opts__, default=False
+    )
+
     devices = config.get_cloud_config_value(
         'devices', vm_, __opts__, default=None
     )
@@ -691,6 +697,11 @@ def create(vm_):
 
             cleanup.append({"what": "domain", "item": clone_domain})
             clone_domain.createWithFlags(libvirt.VIR_DOMAIN_START_FORCE_BOOT)
+
+            # Configure automatic startup
+            if autostart:
+                log.debug("Enabling automatic startup for this domain")
+                clone_domain.setAutostart(1)
 
         log.debug("VM '%s'", vm_)
 

--- a/salt/cloud/clouds/libvirt.py
+++ b/salt/cloud/clouds/libvirt.py
@@ -24,6 +24,8 @@ Example profile:
       num_cpus: 2
       # Amount of virtual memory (unit: MB or GB)
       memory: 2048MB
+      # Version of USB controller to use (1, 2 or 3; default: 1)
+      usb: 3
       # Serial number visible in DMI data (string)
       serial: 01234456789
       # Should the domain start automatically at hypervisor boot
@@ -389,6 +391,8 @@ def create(vm_):
 
     memory = config.get_cloud_config_value("memory", vm_, __opts__, default=None)
 
+    usb = config.get_cloud_config_value("usb", vm_, __opts__, default=1)
+
     serial = config.get_cloud_config_value("serial", vm_, __opts__, default=None)
 
     autostart = config.get_cloud_config_value("autostart", vm_, __opts__, default=False)
@@ -496,6 +500,17 @@ def create(vm_):
                 currentMemory_xml.text = str(memory_mb)
                 currentMemory_xml.set("unit", "Mib")
                 log.debug("Setting memory to: %s MB", memory_mb)
+
+            # Configure USB controller
+            if usb:
+                usb_xml = domain_xml.find("./devices/controller[@type='usb']")
+                usb_model = "piix3-uhci"  # Default to USB 1.0
+                if usb == 2:
+                    usb_model = "ich9-ehci1"  # USB 2.0
+                elif usb == 3:
+                    usb_model = "nec-xhci"  # USB 3.0
+                usb_xml.set("model", usb_model)
+                log.debug("Setting USB controller to: %s", usb_model)
 
             # Configure network interfaces
             devices_xml = domain_xml.find("./devices")

--- a/salt/cloud/clouds/libvirt.py
+++ b/salt/cloud/clouds/libvirt.py
@@ -576,6 +576,7 @@ def create(vm_):
                         new_volume = pool.createXMLFrom(
                             create_volume_xml(volume), volume, 0
                         )
+                    pool.refresh()
                     cleanup.append({"what": "volume", "item": new_volume})
 
                     disk.find("./source").attrib["file"] = new_volume.path()
@@ -586,6 +587,7 @@ def create(vm_):
                     new_volume = pool.createXMLFrom(
                         create_volume_xml(volume), volume, 0
                     )
+                    pool.refresh()
                     cleanup.append({"what": "volume", "item": new_volume})
 
                     disk.find("./source").attrib["file"] = new_volume.path()

--- a/salt/cloud/clouds/libvirt.py
+++ b/salt/cloud/clouds/libvirt.py
@@ -381,27 +381,27 @@ def create(vm_):
     )
 
     num_cpus = config.get_cloud_config_value(
-        'num_cpus', vm_, __opts__, default=None
+        "num_cpus", vm_, __opts__, default=None
     )
 
     memory = config.get_cloud_config_value(
-        'memory', vm_, __opts__, default=None
+        "memory", vm_, __opts__, default=None
     )
 
     serial = config.get_cloud_config_value(
-        'serial', vm_, __opts__, default=None
+        "serial", vm_, __opts__, default=None
     )
 
     autostart = config.get_cloud_config_value(
-        'autostart', vm_, __opts__, default=False
+        "autostart", vm_, __opts__, default=False
     )
 
     disk_name = config.get_cloud_config_value(
-        'disk_name', vm_, __opts__, default='default'
+        "disk_name", vm_, __opts__, default="default"
     )
 
     devices = config.get_cloud_config_value(
-        'devices', vm_, __opts__, default=None
+        "devices", vm_, __opts__, default=None
     )
 
     key_filename = config.get_cloud_config_value(
@@ -461,13 +461,13 @@ def create(vm_):
 
             # Configure number of CPU
             if num_cpus:
-                vcpu_xml = domain_xml.find('./vcpu')
+                vcpu_xml = domain_xml.find("./vcpu")
                 vcpu_xml.text = str(num_cpus)
                 log.debug("Setting CPU number to: %s", num_cpus)
 
             # Configure serial number
             if serial:
-                entry_xml = domain_xml.find('./sysinfo/system/entry')
+                entry_xml = domain_xml.find("./sysinfo/system/entry")
                 entry_xml.text = str(serial)
                 log.debug("Setting Serial to %s", serial)
 
@@ -483,70 +483,70 @@ def create(vm_):
                     else:
                         err_msg = "Invalid memory type specified: '{0}'".format(memory_unit)
                         log.error(err_msg)
-                        return {'Error': err_msg}
+                        return {"Error": err_msg}
                 except (TypeError, ValueError):
                     memory_mb = int(memory)
 
-                memory_xml = domain_xml.find('./memory')
+                memory_xml = domain_xml.find("./memory")
                 memory_xml.text = str(memory_mb)
-                memory_xml.set('unit', 'Mib')
-                currentMemory_xml = domain_xml.find('./currentMemory')
+                memory_xml.set("unit", "Mib")
+                currentMemory_xml = domain_xml.find("./currentMemory")
                 currentMemory_xml.text = str(memory_mb)
-                currentMemory_xml.set('unit', 'Mib')
+                currentMemory_xml.set("unit", "Mib")
                 log.debug("Setting memory to: %s MB", memory_mb)
 
             # Configure network interfaces
-            devices_xml = domain_xml.find('./devices')
-            if 'network' in list(devices.keys()):
+            devices_xml = domain_xml.find("./devices")
+            if "network" in list(devices.keys()):
                 # Remove any existing network interface from cloned domain
-                for iface_xml in devices_xml.findall('./interface'):
+                for iface_xml in devices_xml.findall("./interface"):
                     devices_xml.remove(iface_xml)
 
                 # Add new network interfaces to cloned domain
-                for network in sorted(devices['network']):
-                    # Interface type: should be 'bridge' or 'network' (default)
-                    if 'type' in devices['network'][network]:
-                        type = devices['network'][network]['type']
+                for network in sorted(devices["network"]):
+                    # Interface type: should be "bridge" or "network" (default)
+                    if "type" in devices["network"][network]:
+                        type = devices["network"][network]["type"]
                     else:
-                        type = 'network'
+                        type = "network"
 
                     # Add network interface to new domain
-                    devices_xml.append(ElementTree.Element('interface', type=type))
-                    iface_xml = devices_xml.findall('./interface')[-1]
+                    devices_xml.append(ElementTree.Element("interface", type=type))
+                    iface_xml = devices_xml.findall("./interface")[-1]
 
                     # Interface source: should be either the host bridge name or host network name
-                    # (default network name is 'default')
-                    if 'source' in devices['network'][network]:
-                        source = devices['network'][network]['source']
+                    # (default network name is "default")
+                    if "source" in devices["network"][network]:
+                        source = devices["network"][network]["source"]
                     else:
-                        source = 'default'
+                        source = "default"
 
                     # Associate domain network interface to host networking connection
-                    if type == 'bridge':
-                        iface_xml.append(ElementTree.Element('source', bridge=source))
-                    elif type == 'network':
-                        iface_xml.append(ElementTree.Element('source', network=source))
+                    if type == "bridge":
+                        iface_xml.append(ElementTree.Element("source", bridge=source))
+                    elif type == "network":
+                        iface_xml.append(ElementTree.Element("source", network=source))
 
                     # Define the network interface mac address (optional)
-                    if 'mac' in devices['network'][network]:
-                        mac = devices['network'][network]['mac']
-                        iface_xml.append(ElementTree.Element('mac', address=mac))
+                    if "mac" in devices["network"][network]:
+                        mac = devices["network"][network]["mac"]
+                        iface_xml.append(ElementTree.Element("mac", address=mac))
 
                     # Define the network interface model (optional, default: virtio)
-                    if 'model' in devices['network'][network]:
-                        model = devices['network'][network]['model']
+                    if "model" in devices["network"][network]:
+                        model = devices["network"][network]["model"]
                     else:
-                        model = 'virtio'
-                    iface_xml.append(ElementTree.Element('model', type=devices['network'][network]['model']))
+                        model = "virtio"
+                    iface_xml.append(ElementTree.Element("model", type=devices["network"][network]["model"]))
 
                     log.debug("Adding NIC '%s', type '%s', source '%s', model '%s'", network, type, source, model)
 
             else:
                 # Keep existing network interfaces from domain template, just remove mac address
-                for iface_xml in domain_xml.findall("./devices/interface"):
+                for iface_xml in devices_xml.findall("./interface"):
                     iface_xml.remove(iface_xml.find("./mac"))
 
-            for iface_xml in domain_xml.findall('./devices/interface'):
+            for iface_xml in domain_xml.findall("./devices/interface"):
                 # enable IP learning, this might be a default behaviour...
                 # Don't always enable since it can cause problems through libvirt-4.5
                 if (
@@ -594,10 +594,10 @@ def create(vm_):
                         "Non qemu driver disk encountered bailing out."
                     )
 
-                # Create device target name (e.g. 'mydomain-vda')
-                if disk_name != 'default':
-                    dev = disk.find("./target").attrib['dev']
-                    disk_name = disk_name.replace('{name}', name).replace('{dev}', dev)
+                # Create device target name (e.g. "mydomain-vda")
+                if disk_name != "default":
+                    dev = disk.find("./target").attrib["dev"]
+                    disk_name = disk_name.replace("{name}", name).replace("{dev}", dev)
                     log.info("Cloned disk_name is '%s'", disk_name)
 
                 disk_type = driver.attrib.get("type")
@@ -634,63 +634,63 @@ def create(vm_):
                     )
 
             # Add new disks to domain
-            if 'disk' in list(devices.keys()):
+            if "disk" in list(devices.keys()):
                 # Get list of existing storage pools
                 virt_pools = conn.listAllStoragePools()
 
                 # Add new disk to cloned domain
-                for disk in sorted(devices['disk']):
+                for disk in sorted(devices["disk"]):
                     # bus: should be 'scsi' or 'virtio' (default)
-                    if 'bus' in devices['disk'][disk]:
-                        bus = devices['disk'][disk]['bus']
+                    if "bus" in devices["disk"][disk]:
+                        bus = devices["disk"][disk]["bus"]
                     else:
-                        bus = 'virtio'
+                        bus = "virtio"
 
                     # Passthrough device from hypervisor
-                    if 'device' in devices['disk'][disk]:
-                        device = devices['disk'][disk]['device']
+                    if "device" in devices["disk"][disk]:
+                        device = devices["disk"][disk]["device"]
 
-                        if 'shareable' in devices['disk'][disk]:
-                            shareable = devices['disk'][disk]['shareable']
+                        if "shareable" in devices["disk"][disk]:
+                            shareable = devices["disk"][disk]["shareable"]
                         else:
                             shareable = False
 
                         log.debug("Adding passthrough disk '%s' to domain '%s'", device, name)
-                        devices_xml.append(ElementTree.Element('disk', type='file', device='disk'))
-                        disk_xml = devices_xml.findall('./disk')[-1]
-                        disk_xml.append(ElementTree.Element('driver', name='qemu', type='raw'))
-                        disk_xml.append(ElementTree.Element('source', file=device))
-                        disk_xml.append(ElementTree.Element('target', dev=disk, bus=bus))
+                        devices_xml.append(ElementTree.Element("disk", type="file", device="disk"))
+                        disk_xml = devices_xml.findall("./disk")[-1]
+                        disk_xml.append(ElementTree.Element("driver", name="qemu", type="raw"))
+                        disk_xml.append(ElementTree.Element("source", file=device))
+                        disk_xml.append(ElementTree.Element("target", dev=disk, bus=bus))
                         if shareable:
-                            disk_xml.append(ElementTree.Element('shareable'))
+                            disk_xml.append(ElementTree.Element("shareable"))
 
                     else:
                         # format: should be 'raw' or 'qcow2' (default)
-                        if 'format' in devices['disk'][disk]:
-                            format = devices['disk'][disk]['format']
+                        if "format" in devices["disk"][disk]:
+                            format = devices["disk"][disk]["format"]
                         else:
-                            format = 'qcow2'
+                            format = "qcow2"
 
-                        # pool: name of the libvirt pool that will contain the new disk (default is 'default')
-                        if 'pool' in devices['disk'][disk]:
-                            pool_name = devices['disk'][disk]['pool']
+                        # pool: name of the libvirt pool that will contain the new disk (default is "default")
+                        if "pool" in devices["disk"][disk]:
+                            pool_name = devices["disk"][disk]["pool"]
                         else:
                             pool_name = "default"
 
                         # size: should be a size in GB (default: 1 GB)
-                        if 'size' in devices['disk'][disk]:
-                            size = devices['disk'][disk]['size']
+                        if "size" in devices["disk"][disk]:
+                            size = devices["disk"][disk]["size"]
                         else:
                             size = 1
 
                         pool = None
                         for p in virt_pools:
-                            if p.name() == devices['disk'][disk]['pool']:
+                            if p.name() == devices["disk"][disk]["pool"]:
                                 pool = p
 
                         if pool:
                             pool_xml = ElementTree.fromstring(pool.XMLDesc())
-                            pool_target = pool_xml.find('./target/path').text
+                            pool_target = pool_xml.find("./target/path").text
 
                             vol_name = name + "-" + disk + "." + format
                             vol_path = pool_target + "/" + vol_name
@@ -721,11 +721,11 @@ def create(vm_):
                                 vol = pool.createXML(vol_xml, libvirt.VIR_STORAGE_VOL_CREATE_PREALLOC_METADATA)
 
                             log.debug("Adding volume '%s' to domain '%s'", vol_name, name)
-                            devices_xml.append(ElementTree.Element('disk', type='file', device='disk'))
-                            disk_xml = devices_xml.findall('./disk')[-1]
-                            disk_xml.append(ElementTree.Element('driver', cache='none', io='native', name='qemu', type=format))
-                            disk_xml.append(ElementTree.Element('source', file=vol_path))
-                            disk_xml.append(ElementTree.Element('target', dev=disk, bus=bus))
+                            devices_xml.append(ElementTree.Element("disk", type="file", device="disk"))
+                            disk_xml = devices_xml.findall("./disk")[-1]
+                            disk_xml.append(ElementTree.Element("driver", cache="none", io="native", name="qemu", type=format))
+                            disk_xml.append(ElementTree.Element("source", file=vol_path))
+                            disk_xml.append(ElementTree.Element("target", dev=disk, bus=bus))
                             pool.refresh()
 
             clone_xml = salt.utils.stringutils.to_str(ElementTree.tostring(domain_xml))

--- a/salt/cloud/clouds/libvirt.py
+++ b/salt/cloud/clouds/libvirt.py
@@ -476,16 +476,9 @@ def create(vm_):
                 # Add <smbios> tag, if missing
                 smbios_xml = get_xml_node(domain_xml, "./os/smbios[@mode='sysinfo']")
 
-                # Add <sysinfo> tag at fixed location, if missing
-                if domain_xml.find("./sysinfo") is None:
-                    sysinfo_elem = ElementTree.Element("sysinfo")
-                    sysinfo_elem.set("type", "smbios")
-                    domain_xml.insert(6, sysinfo_elem)
-
                 # Add entry for serial
-                entry_xml = get_xml_node(domain_xml, "./sysinfo/system/entry[@name='serial']")
+                entry_xml = get_xml_node(domain_xml, "./sysinfo[@type='smbios']/system/entry[@name='serial']")
                 entry_xml.text = str(serial)
-
                 log.debug("Setting Serial to %s", serial)
 
             # Configure amount of memory

--- a/salt/cloud/clouds/libvirt.py
+++ b/salt/cloud/clouds/libvirt.py
@@ -788,6 +788,16 @@ def create(vm_):
                                 pool = p
 
                         if pool:
+                            # Start the pool, if required.
+                            if pool.isActive() == 0:
+                                pool.create()
+                                log.debug(
+                                    "Pool '%s' was started.",
+                                    pool.name(),
+                                )
+
+                            pool.refresh()
+
                             pool_xml = ElementTree.fromstring(pool.XMLDesc())
                             pool_target = pool_xml.find("./target/path").text
 

--- a/salt/cloud/clouds/libvirt.py
+++ b/salt/cloud/clouds/libvirt.py
@@ -22,8 +22,8 @@ Example profile:
       base_domain: base-image
       # Number of virtual cpus
       num_cpus: 2
-      # Amount of virtual memory (unit: MB or GB)
-      memory: 2048MB
+      # Amount of virtual memory (unit: MiB or GiB)
+      memory: 2048MiB
       # Version of USB controller to use (1, 2 or 3; default: 1)
       usb: 3
       # Serial number visible in DMI data (string)
@@ -41,7 +41,7 @@ Example profile:
             format: qcow2
             # Pool name, must exist prior to instantiate domain (default: 'default')
             pool: Data
-            # Size in GB (default: '1')
+            # Size in GiB (default: '1')
             size: 3
             # Should the supplementary disk be thin provisionned (default: False, disk will be fully preallocated)
             thin_provision: True
@@ -651,8 +651,7 @@ def create(vm_):
                     pool, volume = find_pool_and_volume(conn, source)
                     if clone_strategy == "quick":
                         new_volume = pool.createXML(
-                            create_volume_with_backing_store_xml(volume, disk_name),
-                            volumeFlags,
+                            create_volume_with_backing_store_xml(volume, disk_name), volumeFlags
                         )
                     else:
                         new_volume = pool.createXMLFrom(
@@ -742,7 +741,7 @@ def create(vm_):
                         else:
                             pool_name = "default"
 
-                        # size: should be a size in GB (default: 1 GB)
+                        # size: should be a size in GiB (default: 1 GiB)
                         if "size" in devices["disk"][disk]:
                             size = devices["disk"][disk]["size"]
                         else:

--- a/salt/cloud/clouds/libvirt.py
+++ b/salt/cloud/clouds/libvirt.py
@@ -1160,11 +1160,10 @@ def start(name, call=None):
         log.info("looking at %s", provider["url"])
         try:
             domain = conn.lookupByName(name)
-            found.append(domain)
+            found.append({"domain": domain, "conn": conn})
         except libvirtError:
-            pass
-        finally:
             conn.close()
+            pass
 
     if not found:
         return "{} doesn't exist and can't be started".format(name)
@@ -1181,11 +1180,13 @@ def start(name, call=None):
         transport=__opts__["transport"],
     )
 
-    log.info("Starting domain %s", found[0].name())
+    log.info("Starting domain %s", found[0]["domain"].name())
     try:
-        found[0].create()
+        found[0]["domain"].create()
     except libvirtError:
-        log.warning("Failed to start domain '%s'", found[0].name())
+        log.warning("Failed to start domain '%s'", found[0]["domain"].name())
+
+    found[0]["conn"].close()
 
 def stop(name, call=None):
     """
@@ -1222,11 +1223,10 @@ def stop(name, call=None):
         log.info("looking at %s", provider["url"])
         try:
             domain = conn.lookupByName(name)
-            found.append(domain)
+            found.append({"domain": domain, "conn": conn})
         except libvirtError:
-            pass
-        finally:
             conn.close()
+            pass
 
     if not found:
         return "{} doesn't exist and can't be stopped".format(name)
@@ -1243,11 +1243,13 @@ def stop(name, call=None):
         transport=__opts__["transport"],
     )
 
-    log.info("Stopping domain %s", found[0].name())
+    log.info("Stopping domain %s", found[0]["domain"].name())
     try:
-        found[0].shutdown()
+        found[0]["domain"].shutdown()
     except libvirtError:
-        log.warning("Failed to stop domain '%s'", found[0].name())
+        log.warning("Failed to stop domain '%s'", found[0]["domain"].name())
+
+    found[0]["conn"].close()
 
 def reboot(name, call=None):
     """
@@ -1284,11 +1286,10 @@ def reboot(name, call=None):
         log.info("looking at %s", provider["url"])
         try:
             domain = conn.lookupByName(name)
-            found.append(domain)
+            found.append({"domain": domain, "conn": conn})
         except libvirtError:
-            pass
-        finally:
             conn.close()
+            pass
 
     if not found:
         return "{} doesn't exist and can't be rebooted".format(name)
@@ -1305,8 +1306,10 @@ def reboot(name, call=None):
         transport=__opts__["transport"],
     )
 
-    log.info("Rebooting domain %s", found[0].name())
+    log.info("Rebooting domain %s", found[0]["domain"].name())
     try:
-        found[0].reboot()
+        found[0]["domain"].reboot()
     except libvirtError:
-        log.warning("Failed to reboot domain '%s'", found[0].name())
+        log.warning("Failed to reboot domain '%s'", found[0]["domain"].name())
+
+    found[0]["conn"].close()

--- a/salt/cloud/clouds/libvirt.py
+++ b/salt/cloud/clouds/libvirt.py
@@ -1016,6 +1016,7 @@ def generate_new_name(orig_name, disk_name):
     else:
         return "{}.{}".format(disk_name, ext)
 
+
 def get_domain_volumes(conn, domain):
     volumes = []
     xml = ElementTree.fromstring(domain.XMLDesc(0))

--- a/salt/cloud/clouds/libvirt.py
+++ b/salt/cloud/clouds/libvirt.py
@@ -489,7 +489,7 @@ def create(vm_):
                     elif memory_unit.lower() == "gb":
                         memory_mb = int(float(memory_num) * 1024.0)
                     else:
-                        err_msg = "Invalid memory type specified: '{0}'".format(memory_unit)
+                        err_msg = "Invalid memory type specified: '{}'".format(memory_unit)
                         log.error(err_msg)
                         return {"Error": err_msg}
                 except (TypeError, ValueError):
@@ -811,7 +811,7 @@ def create(vm_):
     except Exception:  # pylint: disable=broad-except
         do_cleanup(cleanup)
         # throw the root cause after cleanup
-        raise
+        raise sys.exc_info()
 
 
 def do_cleanup(cleanup):

--- a/salt/cloud/clouds/libvirt.py
+++ b/salt/cloud/clouds/libvirt.py
@@ -1137,3 +1137,174 @@ def get_domain_volumes(conn, domain):
             except libvirtError:
                 log.warning("Disk not found '%s'", source)
     return volumes
+
+def start(name, call=None):
+    """
+    This function start a virtual machine on the cloud provider.
+    Before doing so, it should fire an event on the Salt event bus.
+
+    The tag for this event is `salt/cloud/<vm name>/starting`.
+
+    Dependencies:
+        list_nodes
+
+    @param name:
+    @type name: str
+    @param call:
+    @type call:
+    @return: True if all went well, otherwise an error message
+    @rtype: bool|str
+    """
+    log.info("Attempting to start instance %s", name)
+
+    if call == "function":
+        raise SaltCloudSystemExit(
+            "The start action must be called with -a or --action."
+        )
+
+    found = []
+
+    providers = __opts__.get("providers", {})
+    providers_to_check = [
+        _f for _f in [cfg.get("libvirt") for cfg in providers.values()] if _f
+    ]
+    for provider in providers_to_check:
+        conn = __get_conn(provider["url"])
+        log.info("looking at %s", provider["url"])
+        try:
+            domain = conn.lookupByName(name)
+            found.append(domain)
+        except libvirtError:
+            pass
+
+    if not found:
+        return "{} doesn't exist and can't be started".format(name)
+
+    if len(found) > 1:
+        return "{} doesn't identify a unique machine leaving things".format(name)
+
+    __utils__["cloud.fire_event"](
+        "event",
+        "starting instance",
+        "salt/cloud/{}/starting".format(name),
+        args={"name": name},
+        sock_dir=__opts__["sock_dir"],
+        transport=__opts__["transport"],
+    )
+
+    log.info("Starting domain %s", found[0].name())
+    found[0].create()
+
+def stop(name, call=None):
+    """
+    This function stop a virtual machine on the cloud provider.
+    Before doing so, it should fire an event on the Salt event bus.
+
+    The tag for this event is `salt/cloud/<vm name>/stopping`.
+
+    Dependencies:
+        list_nodes
+
+    @param name:
+    @type name: str
+    @param call:
+    @type call:
+    @return: True if all went well, otherwise an error message
+    @rtype: bool|str
+    """
+    log.info("Attempting to stop instance %s", name)
+
+    if call == "function":
+        raise SaltCloudSystemExit(
+            "The start action must be called with -a or --action."
+        )
+
+    found = []
+
+    providers = __opts__.get("providers", {})
+    providers_to_check = [
+        _f for _f in [cfg.get("libvirt") for cfg in providers.values()] if _f
+    ]
+    for provider in providers_to_check:
+        conn = __get_conn(provider["url"])
+        log.info("looking at %s", provider["url"])
+        try:
+            domain = conn.lookupByName(name)
+            found.append(domain)
+        except libvirtError:
+            pass
+
+    if not found:
+        return "{} doesn't exist and can't be stopped".format(name)
+
+    if len(found) > 1:
+        return "{} doesn't identify a unique machine leaving things".format(name)
+
+    __utils__["cloud.fire_event"](
+        "event",
+        "stopping instance",
+        "salt/cloud/{}/stopping".format(name),
+        args={"name": name},
+        sock_dir=__opts__["sock_dir"],
+        transport=__opts__["transport"],
+    )
+
+    log.info("Stopping domain %s", found[0].name())
+    found[0].shutdown()
+
+def reboot(name, call=None):
+    """
+    This function reboot a virtual machine on the cloud provider.
+    Before doing so, it should fire an event on the Salt event bus.
+
+    The tag for this event is `salt/cloud/<vm name>/rebooting`.
+
+    Dependencies:
+        list_nodes
+
+    @param name:
+    @type name: str
+    @param call:
+    @type call:
+    @return: True if all went well, otherwise an error message
+    @rtype: bool|str
+    """
+    log.info("Attempting to stop instance %s", name)
+
+    if call == "function":
+        raise SaltCloudSystemExit(
+            "The start action must be called with -a or --action."
+        )
+
+    found = []
+
+    providers = __opts__.get("providers", {})
+    providers_to_check = [
+        _f for _f in [cfg.get("libvirt") for cfg in providers.values()] if _f
+    ]
+    for provider in providers_to_check:
+        conn = __get_conn(provider["url"])
+        log.info("looking at %s", provider["url"])
+        try:
+            domain = conn.lookupByName(name)
+            found.append(domain)
+        except libvirtError:
+            pass
+
+    if not found:
+        return "{} doesn't exist and can't be rebooted".format(name)
+
+    if len(found) > 1:
+        return "{} doesn't identify a unique machine leaving things".format(name)
+
+    __utils__["cloud.fire_event"](
+        "event",
+        "rebooting instance",
+        "salt/cloud/{}/rebooting".format(name),
+        args={"name": name},
+        sock_dir=__opts__["sock_dir"],
+        transport=__opts__["transport"],
+    )
+
+    log.info("Rebooting domain %s", found[0].name())
+    found[0].shutdown()

--- a/salt/cloud/clouds/libvirt.py
+++ b/salt/cloud/clouds/libvirt.py
@@ -303,7 +303,7 @@ def get_domain_ip(domain, idx, ip_source, skip_loopback=True):
     ips = get_domain_ips(domain, ip_source)
 
     if skip_loopback:
-        ips = [ip for ip in ips if not ip.startswith("127.")]
+        ips = [ip for ip in ips if not ip.startswith(("127.", "169."))]
 
     if not ips or len(ips) <= idx:
         return None

--- a/salt/cloud/clouds/libvirt.py
+++ b/salt/cloud/clouds/libvirt.py
@@ -385,21 +385,13 @@ def create(vm_):
         transport=__opts__["transport"],
     )
 
-    num_cpus = config.get_cloud_config_value(
-        "num_cpus", vm_, __opts__, default=None
-    )
+    num_cpus = config.get_cloud_config_value("num_cpus", vm_, __opts__, default=None)
 
-    memory = config.get_cloud_config_value(
-        "memory", vm_, __opts__, default=None
-    )
+    memory = config.get_cloud_config_value("memory", vm_, __opts__, default=None)
 
-    serial = config.get_cloud_config_value(
-        "serial", vm_, __opts__, default=None
-    )
+    serial = config.get_cloud_config_value("serial", vm_, __opts__, default=None)
 
-    autostart = config.get_cloud_config_value(
-        "autostart", vm_, __opts__, default=False
-    )
+    autostart = config.get_cloud_config_value("autostart", vm_, __opts__, default=False)
 
     disk_name = config.get_cloud_config_value(
         "disk_name", vm_, __opts__, default="default"
@@ -409,9 +401,7 @@ def create(vm_):
         "thin_provision", vm_, __opts__, default=False
     )
 
-    devices = config.get_cloud_config_value(
-        "devices", vm_, __opts__, default=None
-    )
+    devices = config.get_cloud_config_value("devices", vm_, __opts__, default=None)
 
     key_filename = config.get_cloud_config_value(
         "private_key", vm_, __opts__, search_global=False, default=None
@@ -483,14 +473,17 @@ def create(vm_):
             # Configure amount of memory
             if memory:
                 try:
-                    memory_num, memory_unit = re.findall(r"[^\W\d_]+|\d+.\d+|\d+",
-                                                         memory)
+                    memory_num, memory_unit = re.findall(
+                        r"[^\W\d_]+|\d+.\d+|\d+", memory
+                    )
                     if memory_unit.lower() == "mb":
                         memory_mb = int(memory_num)
                     elif memory_unit.lower() == "gb":
                         memory_mb = int(float(memory_num) * 1024.0)
                     else:
-                        err_msg = "Invalid memory type specified: '{}'".format(memory_unit)
+                        err_msg = "Invalid memory type specified: '{}'".format(
+                            memory_unit
+                        )
                         log.error(err_msg)
                         return {"Error": err_msg}
                 except (TypeError, ValueError):
@@ -546,9 +539,19 @@ def create(vm_):
                         model = devices["network"][network]["model"]
                     else:
                         model = "virtio"
-                    iface_xml.append(ElementTree.Element("model", type=devices["network"][network]["model"]))
+                    iface_xml.append(
+                        ElementTree.Element(
+                            "model", type=devices["network"][network]["model"]
+                        )
+                    )
 
-                    log.debug("Adding NIC '%s', type '%s', source '%s', model '%s'", network, type, source, model)
+                    log.debug(
+                        "Adding NIC '%s', type '%s', source '%s', model '%s'",
+                        network,
+                        type,
+                        source,
+                        model,
+                    )
 
             else:
                 # Keep existing network interfaces from domain template, just remove mac address
@@ -623,7 +626,8 @@ def create(vm_):
                     pool, volume = find_pool_and_volume(conn, source)
                     if clone_strategy == "quick":
                         new_volume = pool.createXML(
-                            create_volume_with_backing_store_xml(volume, disk_name), volumeFlags
+                            create_volume_with_backing_store_xml(volume, disk_name),
+                            volumeFlags,
                         )
                     else:
                         new_volume = pool.createXMLFrom(
@@ -671,12 +675,20 @@ def create(vm_):
                         else:
                             shareable = False
 
-                        log.debug("Adding passthrough disk '%s' to domain '%s'", device, name)
-                        devices_xml.append(ElementTree.Element("disk", type="file", device="disk"))
+                        log.debug(
+                            "Adding passthrough disk '%s' to domain '%s'", device, name
+                        )
+                        devices_xml.append(
+                            ElementTree.Element("disk", type="file", device="disk")
+                        )
                         disk_xml = devices_xml.findall("./disk")[-1]
-                        disk_xml.append(ElementTree.Element("driver", name="qemu", type="raw"))
+                        disk_xml.append(
+                            ElementTree.Element("driver", name="qemu", type="raw")
+                        )
                         disk_xml.append(ElementTree.Element("source", file=device))
-                        disk_xml.append(ElementTree.Element("target", dev=disk, bus=bus))
+                        disk_xml.append(
+                            ElementTree.Element("target", dev=disk, bus=bus)
+                        )
                         if shareable:
                             disk_xml.append(ElementTree.Element("shareable"))
 
@@ -707,7 +719,9 @@ def create(vm_):
                         if thin_provision:
                             volumeFlags = 0
                         else:
-                            volumeFlags = libvirt.VIR_STORAGE_VOL_CREATE_PREALLOC_METADATA
+                            volumeFlags = (
+                                libvirt.VIR_STORAGE_VOL_CREATE_PREALLOC_METADATA
+                            )
 
                         pool = None
                         for p in virt_pools:
@@ -723,17 +737,34 @@ def create(vm_):
 
                             try:
                                 vol = pool.storageVolLookupByName(vol_name)
-                                log.debug("Volume '%s' in pool '%s' already exists", vol_name, pool.name())
+                                log.debug(
+                                    "Volume '%s' in pool '%s' already exists",
+                                    vol_name,
+                                    pool.name(),
+                                )
                             except libvirtError:
-                                log.debug("Creating volume '%s' in pool '%s'", vol_name, pool.name())
-                                vol_xml = """
+                                log.debug(
+                                    "Creating volume '%s' in pool '%s'",
+                                    vol_name,
+                                    pool.name(),
+                                )
+                                vol_xml = (
+                                    """
                                 <volume>
-                                  <name>""" + vol_name + """</name>
+                                  <name>"""
+                                    + vol_name
+                                    + """</name>
                                   <allocation>0</allocation>
-                                  <capacity unit="G">""" + str(size) + """</capacity>
+                                  <capacity unit="G">"""
+                                    + str(size)
+                                    + """</capacity>
                                   <target>
-                                    <path>""" + vol_path + """</path>
-                                    <format type='""" + format + """'/>
+                                    <path>"""
+                                    + vol_path
+                                    + """</path>
+                                    <format type='"""
+                                    + format
+                                    + """'/>
                                     <compat>1.1</compat>
                                     <permissions>
                                        <owner>107</owner>
@@ -743,15 +774,32 @@ def create(vm_):
                                      </permissions>
                                   </target>
                                 </volume>"""
+                                )
                                 log.debug("Creating %s", vol_xml)
                                 vol = pool.createXML(vol_xml, volumeFlags)
 
-                            log.debug("Adding volume '%s' to domain '%s'", vol_name, name)
-                            devices_xml.append(ElementTree.Element("disk", type="file", device="disk"))
+                            log.debug(
+                                "Adding volume '%s' to domain '%s'", vol_name, name
+                            )
+                            devices_xml.append(
+                                ElementTree.Element("disk", type="file", device="disk")
+                            )
                             disk_xml = devices_xml.findall("./disk")[-1]
-                            disk_xml.append(ElementTree.Element("driver", cache="none", io="native", name="qemu", type=format))
-                            disk_xml.append(ElementTree.Element("source", file=vol_path))
-                            disk_xml.append(ElementTree.Element("target", dev=disk, bus=bus))
+                            disk_xml.append(
+                                ElementTree.Element(
+                                    "driver",
+                                    cache="none",
+                                    io="native",
+                                    name="qemu",
+                                    type=format,
+                                )
+                            )
+                            disk_xml.append(
+                                ElementTree.Element("source", file=vol_path)
+                            )
+                            disk_xml.append(
+                                ElementTree.Element("target", dev=disk, bus=bus)
+                            )
                             pool.refresh()
 
             clone_xml = salt.utils.stringutils.to_str(ElementTree.tostring(domain_xml))

--- a/salt/cloud/clouds/libvirt.py
+++ b/salt/cloud/clouds/libvirt.py
@@ -462,7 +462,7 @@ def create(vm_):
                     if memory_unit.lower() == "mb":
                         memory_mb = int(memory_num)
                     elif memory_unit.lower() == "gb":
-                        memory_mb = int(float(memory_num)*1024.0)
+                        memory_mb = int(float(memory_num) * 1024.0)
                     else:
                         err_msg = "Invalid memory type specified: '{0}'".format(memory_unit)
                         log.error(err_msg)
@@ -497,7 +497,8 @@ def create(vm_):
                     devices_xml.append(ElementTree.Element('interface', type=type))
                     iface_xml = devices_xml.findall('./interface')[-1]
 
-                    # Interface source: should be either the host bridge name or host network name (default network name is 'default')
+                    # Interface source: should be either the host bridge name or host network name
+                    # (default network name is 'default')
                     if 'source' in devices['network'][network]:
                         source = devices['network'][network]['source']
                     else:
@@ -654,7 +655,7 @@ def create(vm_):
                         try:
                             vol = pool.storageVolLookupByName(vol_name)
                             log.debug("Volume '%s' in pool '%s' already exists", vol_name, pool.name())
-                        except:
+                        except libvirtError:
                             log.debug("Creating volume '%s' in pool '%s'", vol_name, pool.name())
                             vol_xml = """
                             <volume>

--- a/salt/cloud/clouds/libvirt.py
+++ b/salt/cloud/clouds/libvirt.py
@@ -99,6 +99,7 @@ Tested on:
 import logging
 import os
 import re
+import sys
 import uuid
 from xml.etree import ElementTree
 


### PR DESCRIPTION
… 'devices/network'

Fixes #52726

### What does this PR do?
Allow salt-cloud libvirt provider to customize 'num_cpus', 'memory' and 'devices/network' configuration options.

### What issues does this PR fix or reference?
Fixes #52726

### Previous Behavior
The options mentioned aboved were ignored by libvirt provider, the cloned domain always inherited options from source domain.

### New Behavior
The options mentioned aboved are used by libvirt provider to customize cloned domains.

### Tests written?
No

### Commits signed with GPG?
No
