### PR TITLE
Fix remaining failures on ubuntu 1404 and add to PR tests

### DIFF
--- a/.ci/kitchen-ubuntu1404-py2
+++ b/.ci/kitchen-ubuntu1404-py2
@@ -1,0 +1,119 @@
+properties([
+    [
+        $class: 'ScannerJobProperty', doNotScan: false
+    ],
+    [
+        $class: 'RebuildSettings', autoRebuild: false, rebuildDisabled: false
+    ],
+    parameters([
+        booleanParam(defaultValue: false, description: 'Run full test suite', name: 'runFull')
+    ])
+])
+timeout(time: 6, unit: 'HOURS') {
+    node('kitchen-slave') {
+        timestamps {
+            ansiColor('xterm') {
+                withEnv([
+                    'SALT_KITCHEN_PLATFORMS=/var/jenkins/workspace/nox-platforms.yml',
+                    'SALT_KITCHEN_VERIFIER=/var/jenkins/workspace/nox-verifier.yml',
+                    'SALT_KITCHEN_DRIVER=/var/jenkins/workspace/driver.yml',
+                    'NOX_ENV_NAME=runtests-zeromq',
+                    'NOX_PASSTHROUGH_OPTS=--ssh-tests',
+                    'NOX_ENABLE_FROM_FILENAMES=true',
+                    'GOLDEN_IMAGES_CI_BRANCH=2018.3',
+                    'CODECOV_FLAGS=ubuntu1404,py2',
+                    'PATH=/usr/local/rbenv/shims/:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/root/bin:/root/bin',
+                    'RBENV_VERSION=2.4.2',
+                    'TEST_SUITE=py2',
+                    'TEST_PLATFORM=ubuntu-1404',
+                    'PY_COLORS=1',
+                    "FORCE_FULL=${params.runFull}",
+                ]) {
+                    stage('checkout-scm') {
+                        cleanWs notFailBuild: true
+                        checkout scm
+                    }
+                    try {
+                        stage('github-pending') {
+                            githubNotify credentialsId: 'test-jenkins-credentials',
+                                description: "running ${TEST_SUITE}-${TEST_PLATFORM}...",
+                                status: 'PENDING',
+                                context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
+                        }
+                        stage('setup-bundle') {
+                            sh 'bundle install --with ec2 windows --without opennebula docker'
+                        }
+                        try {
+                            stage('run kitchen') {
+                                withCredentials([
+                                    [$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']
+                                ]) {
+                                    sshagent(credentials: ['jenkins-testing-ssh-key']) {
+                                        sh 'ssh-add ~/.ssh/jenkins-testing.pem'
+                                        sh 'bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM || bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM'
+                                        sh 'bundle exec kitchen verify $TEST_SUITE-$TEST_PLATFORM'
+                                    }
+                                }
+                            }
+                        } finally {
+                            stage('cleanup kitchen') {
+                                script {
+                                    withCredentials([
+                                        [$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']
+                                    ]) {
+                                        sshagent(credentials: ['jenkins-testing-ssh-key']) {
+                                            sh 'ssh-add ~/.ssh/jenkins-testing.pem'
+                                            sh 'bundle exec kitchen destroy $TEST_SUITE-$TEST_PLATFORM'
+                                        }
+                                    }
+                                }
+                                archiveArtifacts artifacts: 'artifacts/*,artifacts/**/*'
+                            }
+                            /* Code coverage uploads disabled because we're not running the full test suite
+                            stage('report code coverage') {
+                                script {
+                                    withCredentials([[$class: 'StringBinding', credentialsId: 'codecov-upload-token-salt', variable: 'CODECOV_TOKEN']]) {
+                                      sh '''
+                                      if [ -f artifacts/coverage/coverage.xml ]; then
+                                          curl -L https://codecov.io/bash | /bin/sh -s -- -R $(pwd) -s artifacts/coverage/ -F "${CODECOV_FLAGS}"
+                                      fi
+                                      '''
+                                    }
+                                }
+                            }
+                            */
+                        }
+                    } catch (Exception e) {
+                        currentBuild.result = 'FAILURE'
+                    } finally {
+                        try {
+                            junit 'artifacts/xml-unittests-output/*.xml'
+                        } finally {
+                            cleanWs notFailBuild: true
+                            def currentResult = currentBuild.result ?: 'SUCCESS'
+                            if (currentResult == 'SUCCESS') {
+                                githubNotify credentialsId: 'test-jenkins-credentials',
+                                    description: "The ${TEST_SUITE}-${TEST_PLATFORM} job has passed",
+                                    status: 'SUCCESS',
+                                    context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
+                            } else {
+                                githubNotify credentialsId: 'test-jenkins-credentials',
+                                    description: "The ${TEST_SUITE}-${TEST_PLATFORM} job has failed",
+                                    status: 'FAILURE',
+                                    context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
+                                try {
+                                  slackSend channel: "#jenkins-prod-pr",
+                                      color: '#FF0000',
+                                      message: "FAILED: PR-Job: '${env.JOB_NAME} [${env.BUILD_NUMBER}]' (${env.BUILD_URL})"
+                                } catch (Exception e) {
+                                  sh 'echo Failed to send the Slack notification'
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+

--- a/tests/integration/modules/test_cp.py
+++ b/tests/integration/modules/test_cp.py
@@ -3,6 +3,7 @@
 # Import python libs
 from __future__ import absolute_import, print_function, unicode_literals
 import os
+import sys
 import uuid
 import hashlib
 import logging
@@ -28,6 +29,9 @@ import salt.utils.platform
 import salt.utils.stringutils
 
 log = logging.getLogger(__name__)
+
+
+SSL3_SUPPORT = sys.version_info >= (2, 7, 9)
 
 
 class CPModuleTest(ModuleCase):
@@ -277,6 +281,7 @@ class CPModuleTest(ModuleCase):
         self.assertIn('KNIGHT:  They\'re nervous, sire.', data)
         self.assertNotIn('bacon', data)
 
+    @skipIf(not SSL3_SUPPORT, 'Requires python with SSL3 support')
     @with_tempfile()
     def test_get_url_https(self, tgt):
         '''
@@ -295,6 +300,7 @@ class CPModuleTest(ModuleCase):
         self.assertIn('Windows', data)
         self.assertNotIn('AYBABTU', data)
 
+    @skipIf(not SSL3_SUPPORT, 'Requires python with SSL3 support')
     def test_get_url_https_dest_empty(self):
         '''
         cp.get_url with https:// source given and destination omitted.
@@ -311,6 +317,7 @@ class CPModuleTest(ModuleCase):
         self.assertIn('Windows', data)
         self.assertNotIn('AYBABTU', data)
 
+    @skipIf(not SSL3_SUPPORT, 'Requires python with SSL3 support')
     def test_get_url_https_no_dest(self):
         '''
         cp.get_url with https:// source given and destination set as None
@@ -385,6 +392,7 @@ class CPModuleTest(ModuleCase):
             ])
         self.assertEqual(ret, False)
 
+    @skipIf(not SSL3_SUPPORT, 'Requires python with SSL3 support')
     def test_get_file_str_https(self):
         '''
         cp.get_file_str with https:// source given


### PR DESCRIPTION
### What does this PR do?

Fixes the ssl failures here:

https://jenkinsci.saltstack.com/job/2017.7/job/salt-ubuntu-1404-py2/63/
```
integration.modules.test_cp.CPModuleTest.test_get_file_str_https
integration.modules.test_cp.CPModuleTest.test_get_url_https
integration.modules.test_cp.CPModuleTest.test_get_url_https_no_dest
integration.modules.test_cp.CPModuleTest.test_get_url_https_dest_empty
```

Adding the Ubuntu 1404 test suite to PR builds to keep it green.

### Tests written?

No - Fixing/skipping existing tests

### Commits signed with GPG?

Yes