### PR TITLE
Gitfs fallback branch

### DIFF
--- a/doc/topics/tutorials/gitfs.rst
+++ b/doc/topics/tutorials/gitfs.rst
@@ -318,6 +318,7 @@ configured gitfs remotes):
 * :conf_master:`gitfs_disable_saltenv_mapping` (new in 2018.3.0)
 * :conf_master:`gitfs_ref_types` (new in 2018.3.0)
 * :conf_master:`gitfs_update_interval` (new in 2018.3.0)
+* :conf_master:`gitfs_fallback_branch` (new in 2018.3.5)
 
 .. note::
     pygit2 only supports disabling SSL verification in versions 0.23.2 and
@@ -344,6 +345,7 @@ tremendous amount of customization. Here's some example usage:
         - root: other/salt
         - mountpoint: salt://other/bar
         - base: salt-base
+        - fallback_branch: stable
         - ref_types:
           - branch
       - http://foo.com/baz.git:
@@ -554,6 +556,37 @@ single branch.
     gitfs_remotes:
       - http://foo.com/quux.git:
         - all_saltenvs: anything
+
+
+.. versionadded:: 2018.3.5
+
+Fallback branch
+===============
+
+The ``fallback_branch`` configuration parameter overrides the logic Salt uses to
+map branches/tags to fileserver environments. This allows existing branches to be
+targeted while non-existing branches will use the branch defined as fallback.
+
+.. code-block:: yaml
+
+    gitfs_remotes:
+      - http://foo.com/quux.git:
+        - fallback_branch: master
+
+
+The ``fallback_branch`` parameter can be used per-remote or globally. Per-remote
+configuration overrides the global configuration
+
+.. code-block:: yaml
+
+   gitfs_fallback_branch: foobar
+
+   gitfs_remotes:
+     - http://foo.com/quux.git:
+     - http://foo.com/quax.git:
+       - fallback_branch: master
+
+
 
 .. _gitfs-update-intervals:
 

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -696,6 +696,7 @@ VALID_OPTS = immutabletypes.freeze({
     # because gitfs will normalize them to strings. But rather than include all
     # the possible types they could be, we'll just skip type-checking.
     'gitfs_remotes': list,
+    'gitfs_fallback_branch': (type(None), six.string_types),
     'gitfs_insecure_auth': bool,
     'gitfs_privkey': six.string_types,
     'gitfs_pubkey': six.string_types,
@@ -1336,6 +1337,7 @@ DEFAULT_MINION_OPTS = immutabletypes.freeze({
     'git_pillar_passphrase': '',
     'git_pillar_refspecs': _DFLT_REFSPECS,
     'git_pillar_includes': True,
+    'gitfs_fallback_branch': None,
     'gitfs_remotes': [],
     'gitfs_mountpoint': '',
     'gitfs_root': '',
@@ -1593,6 +1595,7 @@ DEFAULT_MASTER_OPTS = immutabletypes.freeze({
     'git_pillar_refspecs': _DFLT_REFSPECS,
     'git_pillar_includes': True,
     'git_pillar_verify_config': True,
+    'gitfs_fallback_branch': None,
     'gitfs_remotes': [],
     'gitfs_mountpoint': '',
     'gitfs_root': '',

--- a/salt/fileserver/gitfs.py
+++ b/salt/fileserver/gitfs.py
@@ -53,7 +53,7 @@ from __future__ import absolute_import, print_function, unicode_literals
 import logging
 
 PER_REMOTE_OVERRIDES = (
-    'base', 'mountpoint', 'root', 'ssl_verify',
+    'base', 'fallback_branch', 'mountpoint', 'root', 'ssl_verify',
     'saltenv_whitelist', 'saltenv_blacklist',
     'env_whitelist', 'env_blacklist', 'refspecs',
     'disable_saltenv_mapping', 'ref_types', 'update_interval',

--- a/salt/utils/gitfs.py
+++ b/salt/utils/gitfs.py
@@ -196,7 +196,7 @@ def enforce_types(key, val):
     else:
         try:
             return expected(val)
-        except Exception as exc:
+        except Exception:
             log.error(
                 'Failed to enforce type for key=%s with val=%s, falling back '
                 'to a string', key, val

--- a/salt/utils/gitfs.py
+++ b/salt/utils/gitfs.py
@@ -160,6 +160,7 @@ def enforce_types(key, val):
         'disable_saltenv_mapping': bool,
         'env_whitelist': 'stringlist',
         'env_blacklist': 'stringlist',
+        'fallback_branch': 'None or str',
         'saltenv_whitelist': 'stringlist',
         'saltenv_blacklist': 'stringlist',
         'refspecs': 'stringlist',
@@ -193,6 +194,11 @@ def enforce_types(key, val):
         if isinstance(val, six.string_types):
             return [x.strip() for x in val.split(',')]
         return [six.text_type(x) for x in val]
+    elif expected == 'None or str':
+        if val is None:
+            return val
+        else:
+            return six.text_type(val)
     else:
         try:
             return expected(val)
@@ -557,8 +563,12 @@ class GitProvider(object):
                             self.role, self.id, tgt_env
                         )
                     return per_saltenv_ref
+                elif per_saltenv_ref:
+                    return per_saltenv_ref
+                elif self.fallback_branch and tgt_env not in self.envs():
+                    return self.fallback_branch
                 else:
-                    return per_saltenv_ref or tgt_env
+                    return tgt_env
 
             if name in saltenv_conf:
                 return strip_sep(saltenv_conf[name])


### PR DESCRIPTION
### What does this PR do?
Introduce a configuration parameter called `fallback_branch` (or `gitfs_fallback_branch`) to be able to define a branch that can be used as fallback in formulas.

### What issues does this PR fix or reference?

* https://github.com/saltstack/salt/issues/51755

### Previous Behavior
Currently it is only possible to pin the branch used in a formula repository to an existing branch with `all_saltenvs` parameter. This breaks dynamic branch selection via saltenv.

### New Behavior
The `fallback_branch` parameter defines a branch to fall back to, if the branch that was targeted with `saltenv` does not exist. If the branch exists, it will be used, if not, the `fallback_branch` will be used. 

### Tests written?
Yes

### Commits signed with GPG?
No