### PR TITLE
Switch firewalld state to use change_interface

### DIFF
--- a/changelog/62465.added
+++ b/changelog/62465.added
@@ -1,0 +1,1 @@
+Switch firewalld state to use change_interface

--- a/salt/modules/firewalld.py
+++ b/salt/modules/firewalld.py
@@ -922,7 +922,7 @@ def change_interface(zone, interface, permanent=True):
     """
     Change zone the interface bound to
 
-    .. versionadded:: 300?.?.?
+    .. versionadded:: 3006
 
     CLI Example:
 

--- a/salt/modules/firewalld.py
+++ b/salt/modules/firewalld.py
@@ -918,6 +918,29 @@ def remove_interface(zone, interface, permanent=True):
     return __firewall_cmd(cmd)
 
 
+def change_interface(zone, interface, permanent=True):
+    '''
+    Change zone the interface bound to
+
+    .. versionadded:: 2019.?.?
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' firewalld.change_interface zone eth0
+    '''
+    if interface in get_interfaces(zone, permanent):
+        log.info('Interface is already bound to zone.')
+
+    cmd = '--zone={0} --change-interface={1}'.format(zone, interface)
+
+    if permanent:
+        cmd += ' --permanent'
+
+    return __firewall_cmd(cmd)
+
+
 def get_sources(zone, permanent=True):
     """
     List sources bound to a zone

--- a/salt/modules/firewalld.py
+++ b/salt/modules/firewalld.py
@@ -919,24 +919,24 @@ def remove_interface(zone, interface, permanent=True):
 
 
 def change_interface(zone, interface, permanent=True):
-    '''
+    """
     Change zone the interface bound to
 
-    .. versionadded:: 2019.?.?
+    .. versionadded:: 300?.?.?
 
     CLI Example:
 
     .. code-block:: bash
 
         salt '*' firewalld.change_interface zone eth0
-    '''
+    """
     if interface in get_interfaces(zone, permanent):
-        log.info('Interface is already bound to zone.')
+        log.info("Interface is already bound to zone.")
 
-    cmd = '--zone={0} --change-interface={1}'.format(zone, interface)
+    cmd = "--zone={} --change-interface={}".format(zone, interface)
 
     if permanent:
-        cmd += ' --permanent'
+        cmd += " --permanent"
 
     return __firewall_cmd(cmd)
 

--- a/salt/states/firewalld.py
+++ b/salt/states/firewalld.py
@@ -691,7 +691,9 @@ def _present(
         for interface in new_interfaces:
             if not __opts__["test"]:
                 try:
-                    __salt__["firewalld.add_interface"](name, interface, permanent=True)
+                    __salt__["firewalld.change_interface"](
+                        name, interface, permanent=True
+                    )
                 except CommandExecutionError as err:
                     ret["comment"] = "Error: {}".format(err)
                     return ret

--- a/tests/unit/modules/test_firewalld.py
+++ b/tests/unit/modules/test_firewalld.py
@@ -409,3 +409,24 @@ class FirewalldTestCase(TestCase, LoaderModuleMockMixin):
                 ),
                 "success",
             )
+
+    def test_add_interface(self):
+        '''
+        Test adding interface to the zone
+        '''
+        with patch.object(firewalld, '__firewall_cmd', return_value='success'):
+            self.assertEqual(firewalld.add_interface('zone', 'eth0'), 'success')
+
+    def test_remove_interface(self):
+        '''
+        Test removing interface from the zone
+        '''
+        with patch.object(firewalld, '__firewall_cmd', return_value='success'):
+            self.assertEqual(firewalld.remove_interface('zone', 'eth0'), 'success')
+
+    def test_change_interface(self):
+        '''
+        Test rebinding interface to the zone
+        '''
+        with patch.object(firewalld, '__firewall_cmd', return_value='success'):
+            self.assertEqual(firewalld.change_interface('zone', 'eth0'), 'success')

--- a/tests/unit/modules/test_firewalld.py
+++ b/tests/unit/modules/test_firewalld.py
@@ -411,22 +411,22 @@ class FirewalldTestCase(TestCase, LoaderModuleMockMixin):
             )
 
     def test_add_interface(self):
-        '''
+        """
         Test adding interface to the zone
-        '''
-        with patch.object(firewalld, '__firewall_cmd', return_value='success'):
-            self.assertEqual(firewalld.add_interface('zone', 'eth0'), 'success')
+        """
+        with patch.object(firewalld, "__firewall_cmd", return_value="success"):
+            self.assertEqual(firewalld.add_interface("zone", "eth0"), "success")
 
     def test_remove_interface(self):
-        '''
+        """
         Test removing interface from the zone
-        '''
-        with patch.object(firewalld, '__firewall_cmd', return_value='success'):
-            self.assertEqual(firewalld.remove_interface('zone', 'eth0'), 'success')
+        """
+        with patch.object(firewalld, "__firewall_cmd", return_value="success"):
+            self.assertEqual(firewalld.remove_interface("zone", "eth0"), "success")
 
     def test_change_interface(self):
-        '''
+        """
         Test rebinding interface to the zone
-        '''
-        with patch.object(firewalld, '__firewall_cmd', return_value='success'):
-            self.assertEqual(firewalld.change_interface('zone', 'eth0'), 'success')
+        """
+        with patch.object(firewalld, "__firewall_cmd", return_value="success"):
+            self.assertEqual(firewalld.change_interface("zone", "eth0"), "success")


### PR DESCRIPTION
### What does this PR do?
`firewalld.present` state allows to bind interface to given zone.
However if the interface is already bound to some other zone, calling `add_interface` will not change rebind the interface but report error.
Option `change_interface` however can rebind the interface from one zone to another.

This PR adds `firewalld.change_interface` call to firewalld module and updates `firewalld.present` state to use this call.

### What issues does this PR fix or reference?

Fixes #62465

### Previous Behavior
Using firewalld.present to assign already bound interface to different zone does not work.

### New Behavior
Using firewalld.present to assign already bound interface to different zone does rebind the interface to new zone.

### Tests written?

Yes.

### Commits signed with GPG?

Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
