### PR TITLE
Fix csvpillar.py read file as binary

### DIFF
--- a/salt/pillar/csvpillar.py
+++ b/salt/pillar/csvpillar.py
@@ -76,7 +76,7 @@ def ext_pillar(
     :param list fieldnames: (Optional) if the first row of the CSV is not
         column names they may be specified here instead.
     '''
-    with salt.utils.files.fopen(path, 'rb') as f:
+    with salt.utils.files.fopen(path, 'r') as f:
         sheet = csv.DictReader(f, fieldnames,
                 restkey=restkey, restval=restval, dialect=dialect)
 

--- a/tests/unit/pillar/test_csvpillar.py
+++ b/tests/unit/pillar/test_csvpillar.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+
+# Import python libs
+from __future__ import absolute_import, print_function, unicode_literals
+
+# Import Salt Testing libs
+from tests.support.unit import TestCase, skipIf
+from tests.support.mock import patch, mock_open, NO_MOCK, NO_MOCK_REASON
+
+# Import Salt Libs
+import salt.pillar.csvpillar as csvpillar
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class CSVPillarTestCase(TestCase):
+    
+    def test_001_load_unicode_csv(self):
+        fake_csv="id,foo,bar\r\nminion1,foo1,bar1"
+        fake_dict = {'id': 'minion1', 'foo': 'foo1', 'bar': 'bar1'}
+        fopen_mock = mock_open(fake_csv)
+        with patch('salt.utils.files.fopen', fopen_mock):
+            result = csvpillar.ext_pillar(mid = 'minion1', pillar = None, path = "/fake/path/file.csv", idkey = "id", namespace = None)
+            self.assertDictEqual(fake_dict, result)
+
+    def test_002_load_unicode_csv_namespace(self):
+        fake_csv="id,foo,bar\r\nminion1,foo1,bar1"
+        fake_dict = {'baz': {'id': 'minion1', 'foo': 'foo1', 'bar': 'bar1'} }
+        fopen_mock = mock_open(fake_csv)
+        with patch('salt.utils.files.fopen', fopen_mock):
+            result = csvpillar.ext_pillar(mid = 'minion1', pillar = None, path = "/fake/path/file.csv", idkey = "id", namespace = 'baz')
+            self.assertDictEqual(fake_dict, result)

--- a/tests/unit/pillar/test_csvpillar.py
+++ b/tests/unit/pillar/test_csvpillar.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+'''test for pillar csvpillar.py'''
 
 # Import python libs
 from __future__ import absolute_import, print_function, unicode_literals
@@ -10,21 +11,23 @@ from tests.support.mock import patch, mock_open, NO_MOCK, NO_MOCK_REASON
 # Import Salt Libs
 import salt.pillar.csvpillar as csvpillar
 
+
 @skipIf(NO_MOCK, NO_MOCK_REASON)
 class CSVPillarTestCase(TestCase):
-    
-    def test_001_load_unicode_csv(self):
-        fake_csv="id,foo,bar\r\nminion1,foo1,bar1"
+    def test_001_load_utf8_csv(self):
+        fake_csv = "id,foo,bar\r\nminion1,foo1,bar1"
         fake_dict = {'id': 'minion1', 'foo': 'foo1', 'bar': 'bar1'}
         fopen_mock = mock_open(fake_csv)
         with patch('salt.utils.files.fopen', fopen_mock):
-            result = csvpillar.ext_pillar(mid = 'minion1', pillar = None, path = "/fake/path/file.csv", idkey = "id", namespace = None)
+            result = csvpillar.ext_pillar(mid='minion1', pillar=None,
+                                          path="/fake/path/file.csv", idkey="id", namespace=None)
             self.assertDictEqual(fake_dict, result)
 
-    def test_002_load_unicode_csv_namespace(self):
-        fake_csv="id,foo,bar\r\nminion1,foo1,bar1"
-        fake_dict = {'baz': {'id': 'minion1', 'foo': 'foo1', 'bar': 'bar1'} }
+    def test_002_load_utf8_csv_namespc(self):
+        fake_csv = "id,foo,bar\r\nminion1,foo1,bar1"
+        fake_dict = {'baz': {'id': 'minion1', 'foo': 'foo1', 'bar': 'bar1'}}
         fopen_mock = mock_open(fake_csv)
         with patch('salt.utils.files.fopen', fopen_mock):
-            result = csvpillar.ext_pillar(mid = 'minion1', pillar = None, path = "/fake/path/file.csv", idkey = "id", namespace = 'baz')
+            result = csvpillar.ext_pillar(mid='minion1', pillar=None,
+                                          path="/fake/path/file.csv", idkey="id", namespace='baz')
             self.assertDictEqual(fake_dict, result)


### PR DESCRIPTION
### What does this PR do?
Resolves an error in csvpillar.py (at least when run in Python 3) where it attempted to read csv files from disk in binary format.

### What issues does this PR fix or reference?
saltstack/salt#52538

### Previous Behavior
csvpillar.py attempted to read csv files in binary format

### New Behavior
csvpillar.py now reads csv files in text format

### Tests written?

Yes

### Commits signed with GPG?

No