### PR TITLE
Fix padding in versions report

### DIFF
--- a/salt/version.py
+++ b/salt/version.py
@@ -725,10 +725,11 @@ def versions_report(include_salt_cloud=False):
     Yield each version properly formatted for console output.
     '''
     ver_info = versions_information(include_salt_cloud)
-
+    not_installed = 'Not Installed'
+    ns_pad = len(not_installed)
     lib_pad = max(len(name) for name in ver_info['Dependency Versions'])
     sys_pad = max(len(name) for name in ver_info['System Versions'])
-    padding = max(lib_pad, sys_pad) + 1
+    padding = max(lib_pad, sys_pad, ns_pad) + 1
 
     fmt = '{0:>{pad}}: {1}'
     info = []
@@ -737,7 +738,7 @@ def versions_report(include_salt_cloud=False):
         # List dependencies in alphabetical, case insensitive order
         for name in sorted(ver_info[ver_type], key=lambda x: x.lower()):
             ver = fmt.format(name,
-                             ver_info[ver_type][name] or 'Not Installed',
+                             ver_info[ver_type][name] or not_installed,
                              pad=padding)
             info.append(ver)
         info.append(' ')

--- a/tests/unit/test_version.py
+++ b/tests/unit/test_version.py
@@ -17,7 +17,7 @@ import re
 from tests.support.unit import TestCase
 
 # Import Salt libs
-from salt.version import SaltStackVersion
+from salt.version import SaltStackVersion, versions_report
 
 
 class VersionTestCase(TestCase):
@@ -71,3 +71,15 @@ class VersionTestCase(TestCase):
 
         with self.assertRaises(ValueError):
             SaltStackVersion.parse('Drunk')
+
+    def test_version_report_lines(self):
+        '''
+        Validate padding in versions report is correct
+        '''
+        # Get a set of all version report name lenghts including padding
+        line_lengths = set([
+           len(line.split(':')[0]) for line in list(versions_report())[4:]
+           if line != ' ' and line != 'System Versions:'
+        ])
+        # Check that they are all the same size (only one element in the set)
+        assert len(line_lengths) == 1


### PR DESCRIPTION
Fix a padding wart in the versions report that shows up when 'Not Installed' is longer than any package name.

### Tests written?

Yes

### Commits signed with GPG?

Yes