### PR TITLE
xelatex output is too long for drone

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -147,7 +147,7 @@ pdf: check_sphinx-build translations
 	fi
 	$(SPHINXBUILD) -b latex $(ALLSPHINXOPTS) $(BUILDDIR)/latex
 	@echo "Running LaTeX files through xelatex..."
-	$(MAKE) -C $(BUILDDIR)/latex -i "PDFLATEX=latexmk" "LATEXMKOPTS=-xelatex -interaction=nonstopmode -f"
+	$(MAKE) -C $(BUILDDIR)/latex -i "PDFLATEX=latexmk" "LATEXMKOPTS=-xelatex -interaction=nonstopmode -f -quiet"
 	@echo "xelatex finished; the PDF files are in $(BUILDDIR)/latex."
 
 cheatsheet: translations


### PR DESCRIPTION
The output of xelatex is too long for drone to capture.  It prints
everything to a log anyway, any failure is likely to be at the end of
that output anyway so we still print the last 200 lines from that log.

### What does this PR do?
It shortens the output when building docs

### What issues does this PR fix or reference?
none

### Previous Behavior
drone output ended with "warning: maximum output exceeded"
See https://drone.saltstack.com/saltstack/builddocs/44/8/2

### New Behavior
drone can show the output of the publishing steps, which is likely more important.

### Tests written?

N/A

### Commits signed with GPG?

Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
