### PR TITLE
Skip test_gen_thin_compression_fallback_py3

### DIFF
--- a/salt/utils/thin.py
+++ b/salt/utils/thin.py
@@ -327,8 +327,10 @@ def _get_thintar_prefix(tarname):
     :param tarname: name of the chosen tarball
     :return: prefixed tarname
     '''
-    tfd, tmp_tarname = tempfile.mkstemp(dir=os.path.dirname(tarname), prefix=".thin-",
-                                        suffix="." + os.path.basename(tarname).split(".", 1)[-1])
+    tfd, tmp_tarname = tempfile.mkstemp(
+        dir=os.path.dirname(tarname),
+        prefix=".thin-",
+        suffix=os.path.splitext(tarname)[1])
     os.close(tfd)
 
     return tmp_tarname
@@ -458,7 +460,6 @@ def gen_thin(cachedir, extra_mods='', overwrite=False, so_mods='',
     elif compress == 'zip':
         tfp = zipfile.ZipFile(tmp_thintar, 'w', compression=zlib and zipfile.ZIP_DEFLATED or zipfile.ZIP_STORED)
         tfp.add = tfp.write
-
     try:  # cwd may not exist if it was removed but salt was run from it
         start_dir = os.getcwd()
     except OSError:

--- a/tests/unit/utils/test_thin.py
+++ b/tests/unit/utils/test_thin.py
@@ -17,6 +17,7 @@ import salt.exceptions
 from salt.utils import thin
 from salt.utils import json
 import salt.utils.stringutils
+import salt.utils.platform
 from salt.utils.stringutils import to_bytes as bts
 from salt.ext.six.moves import range
 
@@ -423,6 +424,8 @@ class SSHThinTestCase(TestCase):
         self.assertIn('The minimum required python version to run salt-ssh is '
                       '"2.6"', str(err.value))
 
+    @skipIf(salt.utils.platform.is_windows() and thin._six.PY2,
+            'Dies on Python2 on Windows')
     @patch('salt.exceptions.SaltSystemExit', Exception)
     @patch('salt.utils.thin.log', MagicMock())
     @patch('salt.utils.thin.os.makedirs', MagicMock())


### PR DESCRIPTION
### What does this PR do?
Skips `test_gen_thin_compression_fallback_py3` on Windows running Python 2. This test is causing python to hard crash, thus killing the entire test suite.

![image](https://user-images.githubusercontent.com/9383935/56932251-394a6800-6aa0-11e9-9fc7-e73f2c01e527.png)

It dies on `utils/thin.py: 456`:
```
        tfp = tarfile.open(tmp_thintar, 'w:gz', dereference=True)
```
It doesn't die when working with this salt util directly, only when run from the test suite.

Also simplifies the _get_thintar_prefix function

### Issue referenced
https://github.com/saltstack/salt/issues/52720

### Tests written?
No

### Commits signed with GPG?
Yes