### PR TITLE
[2018.3] Fixes to multiprocessing queue when using MacOS

### DIFF
--- a/salt/log/setup.py
+++ b/salt/log/setup.py
@@ -805,13 +805,17 @@ def setup_extended_logging(opts):
 
 def get_multiprocessing_logging_queue():
     global __MP_LOGGING_QUEUE
+    from salt.utils.platform import is_darwin
 
     if __MP_IN_MAINPROCESS is False:
         # We're not in the MainProcess, return! No Queue shall be instantiated
         return __MP_LOGGING_QUEUE
 
     if __MP_LOGGING_QUEUE is None:
-        __MP_LOGGING_QUEUE = multiprocessing.Queue(100000)
+        if is_darwin():
+            __MP_LOGGING_QUEUE = multiprocessing.Queue(32767)
+        else:
+            __MP_LOGGING_QUEUE = multiprocessing.Queue(100000)
     return __MP_LOGGING_QUEUE
 
 

--- a/tests/integration/files/log_handlers/runtests_log_handler.py
+++ b/tests/integration/files/log_handlers/runtests_log_handler.py
@@ -24,6 +24,7 @@ import msgpack
 
 # Import Salt libs
 from salt.ext import six
+from salt.utils.platform import is_darwin
 import salt.log.setup
 
 log = logging.getLogger(__name__)
@@ -60,7 +61,10 @@ def setup_handlers():
     # Above that value, if `process_queue` can't process fast enough,
     # start dropping. This will contain a memory leak in case `process_queue`
     # can't process fast enough of in case it can't deliver the log records at all.
-    queue_size = 10000000
+    if is_darwin():
+        queue_size = 32767
+    else:
+        queue_size = 10000000
     queue = Queue(queue_size)
     handler = salt.log.setup.QueueHandler(queue)
     level = salt.log.setup.LOG_LEVELS[(__opts__.get('runtests_log_level') or 'error').lower()]


### PR DESCRIPTION
### What does this PR do?
The maximum for the multiprocessing queue on MacOS is 32767, so if we running on MacOS then we use that maximum.

### What issues does this PR fix or reference?
N/A

### Previous Behavior
Tests do not run currently on MacOS

### New Behavior
Allows tests to run

### Tests written?
No.  Fixes to existing tests.

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
