### PR TITLE
Add support for setting influxdb retention policy shard_duration

### DIFF
--- a/salt/modules/influxdbmod.py
+++ b/salt/modules/influxdbmod.py
@@ -449,9 +449,9 @@ def create_retention_policy(database,
 
 def alter_retention_policy(database,
                            name,
-                           duration,
-                           replication,
-                           default=False,
+                           duration=None,
+                           replication=None,
+                           default=None,
                            **client_args):
     '''
     Modify an existing retention policy.
@@ -462,7 +462,7 @@ def alter_retention_policy(database,
     database
         Name of the database for which the retention policy was defined.
 
-    duration
+    duration : None
         New duration of given retention policy.
 
         Durations such as 1h, 90m, 12h, 7d, and 4w, are all supported
@@ -471,13 +471,13 @@ def alter_retention_policy(database,
         never be deleted – use 'INF' for duration.
         The minimum retention period is 1 hour.
 
-    replication
+    replication : None
         New replication of given retention policy.
 
         This determines how many independent copies of each data point are
         stored in a cluster.
 
-    default : False
+    default : None
         Whether or not to set the modified policy as default.
 
     CLI Example:

--- a/salt/modules/influxdbmod.py
+++ b/salt/modules/influxdbmod.py
@@ -407,6 +407,7 @@ def create_retention_policy(database,
                             duration,
                             replication,
                             default=False,
+                            shard_duration="0s",
                             **client_args):
     '''
     Create a retention policy.
@@ -434,6 +435,18 @@ def create_retention_policy(database,
     default : False
         Whether or not the policy as default will be set as default.
 
+    shard_duration : 0s
+        New shard duration of given retention policy.
+
+        Durations such as 1h, 90m, 12h, 7d, and 4w, are all supported
+        and mean 1 hour, 90 minutes, 12 hours, 7 day, and 4 weeks,
+        respectively. Infinite retention is not supported.
+        As a workaround, specify a “1000w” duration to achieve an extremely
+        long shard group duration.
+        Defaults to “0s”, which is interpreted by the database to mean the
+        default value given the duration.
+        The minimum shard group duration is 1 hour.
+
     CLI Example:
 
     .. code-block:: bash
@@ -442,7 +455,7 @@ def create_retention_policy(database,
     '''
     client = _client(**client_args)
     client.create_retention_policy(name, duration, replication, database,
-                                   default)
+                                   default, shard_duration)
 
     return True
 
@@ -452,6 +465,7 @@ def alter_retention_policy(database,
                            duration=None,
                            replication=None,
                            default=None,
+                           shard_duration=None,
                            **client_args):
     '''
     Modify an existing retention policy.
@@ -480,6 +494,16 @@ def alter_retention_policy(database,
     default : None
         Whether or not to set the modified policy as default.
 
+    shard_duration : None
+        New shard duration of given retention policy.
+
+        Durations such as 1h, 90m, 12h, 7d, and 4w, are all supported
+        and mean 1 hour, 90 minutes, 12 hours, 7 day, and 4 weeks,
+        respectively. Infinite retention is not supported.
+        As a workaround, specify a “1000w” duration to achieve an extremely
+        long shard group duration.
+        The minimum shard group duration is 1 hour.
+
     CLI Example:
 
     .. code-block:: bash
@@ -488,7 +512,7 @@ def alter_retention_policy(database,
     '''
     client = _client(**client_args)
     client.alter_retention_policy(name, database, duration, replication,
-                                  default)
+                                  default, shard_duration)
     return True
 
 

--- a/salt/states/influxdb_retention_policy.py
+++ b/salt/states/influxdb_retention_policy.py
@@ -35,18 +35,15 @@ def convert_duration(duration):
     # durations must be specified in days, weeks or hours
 
     if duration.endswith('h'):
-        hours = int(duration.split('h'))
+        return duration + '0m0s'
+    if duration.endswith('d'):
+        return '{0}h0m0s'.format(int(duration.split('d')[0]) * 24)
+    if duration.endswith('w'):
+        return '{0}h0m0s'.format(int(duration.split('w')[0]) * 24 * 7)
+    if duration == 'INF':
+        return '0s'
 
-    elif duration.endswith('d'):
-        days = duration.split('d')
-        hours = int(days[0]) * 24
-
-    elif duration.endswith('w'):
-        weeks = duration.split('w')
-        hours = int(weeks[0]) * 24 * 7
-
-    duration_string = str(hours)+'h0m0s'
-    return duration_string
+    return duration
 
 
 def present(name, database, duration="7d",


### PR DESCRIPTION
(See #52697 original PR for 2019.2)

This PR improves influx module and influxdb_retention_policy state:
- 0b8264d7877dc2cded7eeba63b567825baae29c0: fix unexpected overwrite of "default" param in influxdb.alter_retention_policy
- 8fac8a1c31833348c510b3cfc33ea9668952457c: add support for shard_duration in influx module
- bcef2397d47c2a3c9f879651b643557c411b344f: add support for shard_duration in influxdb_retention_policy state
- 6dbab0fcfac6441dcb1bbe27bdb4fcc653fbbcb0: fix some buggy edge cases in the convert_duration function and also support INF duration
- 649fadb48485808fb8f8399cc127b3a958799321: fix some false positive rp update when shard_duration='0s'

