### PR TITLE
Runit: Only resolve link if path is a link

### DIFF
--- a/salt/modules/runit.py
+++ b/salt/modules/runit.py
@@ -350,7 +350,7 @@ def _get_svc_path(name='*', status=None):
     ena = set()
     for el in glob.glob(os.path.join(SERVICE_DIR, name)):
         if _is_svc(el):
-            ena.add(os.readlink(el))
+            ena.add(os.readlink(el) if os.path.islink(el) else el)
             log.trace('found enabled service path: %s', el)
 
     if status == 'ENABLED':

--- a/salt/modules/runit.py
+++ b/salt/modules/runit.py
@@ -350,7 +350,7 @@ def _get_svc_path(name='*', status=None):
     ena = set()
     for el in glob.glob(os.path.join(SERVICE_DIR, name)):
         if _is_svc(el):
-            ena.add(os.readlink(el) if os.path.islink(el) else el)
+            ena.add(os.realpath(el))
             log.trace('found enabled service path: %s', el)
 
     if status == 'ENABLED':


### PR DESCRIPTION
### What does this PR do?
Module runit: Check wether a service's path is really a link. If it is a link, resolve it; else directly add path.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/52759

### Previous Behavior
service.running throws an exception at `os.readlink(el) (OSError: [Errno 22] Invalid argument: '/etc/service/salt-minion'` (see Issue; /etc/service/salt-minion exists as a normal directory, not as symlink)

### New Behavior
service.running runs without throwing an exception

### Tests written?
No

### Commits signed with GPG?
No
