### PR TITLE
Remove domain grain from tests for Windows

### DIFF
--- a/tests/unit/grains/test_core.py
+++ b/tests/unit/grains/test_core.py
@@ -141,7 +141,6 @@ class CoreGrainsTestCase(TestCase, LoaderModuleMockMixin):
         grains = core._windows_platform_data()
         keys = ['biosversion',
                 'osrelease',
-                'domain',
                 'kernelrelease',
                 'motherboard',
                 'serialnumber',


### PR DESCRIPTION
### What does this PR do?
Removes `domain` from the `test__pwindows_platform_data` test. Looks like it's been removed in favor of `windowsdomain`

### What issues does this PR fix or reference?
Jenkins

### Tests written?
Yes

### Commits signed with GPG?
Yes