### PR TITLE
adding boto_elb config parameters to return

### DIFF
--- a/salt/modules/boto_elb.py
+++ b/salt/modules/boto_elb.py
@@ -192,6 +192,9 @@ def get_elb_config(name, region=None, key=None, keyid=None, profile=None):
             for policy_list in lb_policy_lists:
                 policies += [p.policy_name for p in policy_list]
             ret["policies"] = policies
+            ret["canonical_hosted_zone_name"] = lb.canonical_hosted_zone_name
+            ret["canonical_hosted_zone_name_id"] = lb.canonical_hosted_zone_name_id
+            ret["vpc_id"] = lb.vpc_id
             return ret
         except boto.exception.BotoServerError as error:
             if error.error_code == "Throttling":

--- a/tests/unit/modules/test_boto_elb.py
+++ b/tests/unit/modules/test_boto_elb.py
@@ -1,14 +1,14 @@
 import logging
 import os.path
+import sys
 from copy import deepcopy
-
-import pkg_resources
 
 import salt.config
 import salt.loader
 import salt.modules.boto_elb as boto_elb
 import salt.utils.versions
 from tests.support.mixins import LoaderModuleMockMixin
+from tests.support.mock import MagicMock, patch
 from tests.support.runtests import RUNTIME_VARS
 from tests.support.unit import TestCase, skipIf
 
@@ -26,6 +26,8 @@ except ImportError:
     HAS_BOTO = False
 
 try:
+    import pkg_resources
+
     from moto import mock_ec2_deprecated, mock_elb_deprecated
 
     HAS_MOTO = True
@@ -245,42 +247,47 @@ class BotoElbTestCase(TestCase, LoaderModuleMockMixin):
             instance.id for instance in load_balancer_refreshed.instances
         ]
         self.assertEqual(actual_instances, expected_instances)
+
     @mock_ec2_deprecated
     @mock_elb_deprecated
-    @skipIf(sys.version_info > (3, 6), 'Disabled for 3.7+ pending https://github.com/spulec/moto/issues/1706.')
+    @skipIf(
+        sys.version_info > (3, 6),
+        "Disabled for 3.7+ pending https://github.com/spulec/moto/issues/1706.",
+    )
     def test_get_elb_config(self):
-        '''
+        """
         tests that given an valid ids in the form of a list that the boto_elb
         deregister_instances all members of the given list
-        '''
+        """
         conn_ec2 = boto.ec2.connect_to_region(region, **boto_conn_parameters)
-        conn_elb = boto.ec2.elb.connect_to_region(region,
-                                                  **boto_conn_parameters)
+        conn_elb = boto.ec2.elb.connect_to_region(region, **boto_conn_parameters)
         zones = [zone.name for zone in conn_ec2.get_all_zones()]
-        elb_name = 'TestGetELBConfig'
-        load_balancer = conn_elb.create_load_balancer(elb_name, zones,
-                                                      [(80, 80, 'http')])
-        reservations = conn_ec2.run_instances('ami-08389d60', min_count=3)
+        elb_name = "TestGetELBConfig"
+        load_balancer = conn_elb.create_load_balancer(
+            elb_name, zones, [(80, 80, "http")]
+        )
+        reservations = conn_ec2.run_instances("ami-08389d60", min_count=3)
         all_instance_ids = [instance.id for instance in reservations.instances]
         load_balancer.register_instances(all_instance_ids)
 
         # DescribeTags does not appear to be included in moto
         # so mock the _get_all_tags function.  Ideally we wouldn't
         # need to mock this.
-        with patch('salt.modules.boto_elb._get_all_tags',
-                MagicMock(return_value=None)):
+        with patch("salt.modules.boto_elb._get_all_tags", MagicMock(return_value=None)):
             ret = boto_elb.get_elb_config(elb_name, **conn_parameters)
-            _expected_keys = ['subnets',
-                              'availability_zones',
-                              'canonical_hosted_zone_name_id',
-                              'tags',
-                              'dns_name',
-                              'listeners',
-                              'backends',
-                              'policies',
-                              'vpc_id',
-                              'scheme',
-                              'canonical_hosted_zone_name',
-                              'security_groups']
+            _expected_keys = [
+                "subnets",
+                "availability_zones",
+                "canonical_hosted_zone_name_id",
+                "tags",
+                "dns_name",
+                "listeners",
+                "backends",
+                "policies",
+                "vpc_id",
+                "scheme",
+                "canonical_hosted_zone_name",
+                "security_groups",
+            ]
             for key in _expected_keys:
                 self.assertIn(key, ret)

--- a/tests/unit/modules/test_boto_elb.py
+++ b/tests/unit/modules/test_boto_elb.py
@@ -245,3 +245,42 @@ class BotoElbTestCase(TestCase, LoaderModuleMockMixin):
             instance.id for instance in load_balancer_refreshed.instances
         ]
         self.assertEqual(actual_instances, expected_instances)
+    @mock_ec2_deprecated
+    @mock_elb_deprecated
+    @skipIf(sys.version_info > (3, 6), 'Disabled for 3.7+ pending https://github.com/spulec/moto/issues/1706.')
+    def test_get_elb_config(self):
+        '''
+        tests that given an valid ids in the form of a list that the boto_elb
+        deregister_instances all members of the given list
+        '''
+        conn_ec2 = boto.ec2.connect_to_region(region, **boto_conn_parameters)
+        conn_elb = boto.ec2.elb.connect_to_region(region,
+                                                  **boto_conn_parameters)
+        zones = [zone.name for zone in conn_ec2.get_all_zones()]
+        elb_name = 'TestGetELBConfig'
+        load_balancer = conn_elb.create_load_balancer(elb_name, zones,
+                                                      [(80, 80, 'http')])
+        reservations = conn_ec2.run_instances('ami-08389d60', min_count=3)
+        all_instance_ids = [instance.id for instance in reservations.instances]
+        load_balancer.register_instances(all_instance_ids)
+
+        # DescribeTags does not appear to be included in moto
+        # so mock the _get_all_tags function.  Ideally we wouldn't
+        # need to mock this.
+        with patch('salt.modules.boto_elb._get_all_tags',
+                MagicMock(return_value=None)):
+            ret = boto_elb.get_elb_config(elb_name, **conn_parameters)
+            _expected_keys = ['subnets',
+                              'availability_zones',
+                              'canonical_hosted_zone_name_id',
+                              'tags',
+                              'dns_name',
+                              'listeners',
+                              'backends',
+                              'policies',
+                              'vpc_id',
+                              'scheme',
+                              'canonical_hosted_zone_name',
+                              'security_groups']
+            for key in _expected_keys:
+                self.assertIn(key, ret)


### PR DESCRIPTION
### What does this PR do?

This PR adds the following parameters to return for get_elb_config. The functionality is needed to be able to determine the hosted zone id to automatically create ALIAS Route53 records for new classic ELBs.
- canonical_hosted_zone_name
- canonical_hosted_zone_name_id
- vpc_id

### What issues does this PR fix or reference?

None

### Previous Behavior

Cannot get the HostedZoneID that a classic ELB is in even though boto returns the parameter.

### New Behavior

`boto.get_elb_config` returns the canonical_hosted_zone_name_id so that DNS ALIAS records can be created automatically.

### Tests written?

No

### Commits signed with GPG?

Yes


I understand this will be merged into develop if approved. I'd be grateful if it could be rebased into 2019.2.0 as well.