### PR TITLE
 [2018.3] Fix to roots fileserver

### DIFF
--- a/salt/fileserver/roots.py
+++ b/salt/fileserver/roots.py
@@ -390,7 +390,7 @@ def _file_lists(load, form):
                     rel_dest = _translate_sep(
                         os.path.relpath(
                             os.path.realpath(os.path.normpath(joined)),
-                            fs_root
+                            os.path.realpath(fs_root)
                         )
                     )
                     log.trace(


### PR DESCRIPTION
### What does this PR do?
Fixing a bug when the roots fileserver and the location is a symlinkto another location.  This fix ensures that when fsroot is referenced we are using the real path and not the symlink path.  This issue came up when attempting to run the `integration.runners.test_fileserver.FileserverTest.test_symlink_list` and `unit.fileserver.test_roots.RootsTest.test_symlink_list` tests in Kitchen-Salt on OS X.

### What issues does this PR fix or reference?
N/A

### Tests written?
No.  Existing tests were failing when running on Mac OS X

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
