### PR TITLE
Handle ipv6 in _netlink_tool_remote_on

### DIFF
--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -1481,8 +1481,8 @@ def _netlink_tool_remote_on(port, which_end):
         elif 'ESTAB' not in line:
             continue
         chunks = line.split()
-        local_host, local_port = chunks[3].split(':', 1)
-        remote_host, remote_port = chunks[4].split(':', 1)
+        local_host, local_port = chunks[3].rsplit(':', 1)
+        remote_host, remote_port = chunks[4].rsplit(':', 1)
 
         if which_end == 'remote_port' and int(remote_port) != port:
             continue

--- a/tests/unit/utils/test_network.py
+++ b/tests/unit/utils/test_network.py
@@ -120,6 +120,12 @@ USER     COMMAND    PID   FD PROTO  LOCAL ADDRESS    FOREIGN ADDRESS
 salt-master python2.781106 35 tcp4  127.0.0.1:61115  127.0.0.1:4506
 '''
 
+NETLINK_SS = '''
+State      Recv-Q Send-Q               Local Address:Port                 Peer Address:Port
+ESTAB      0      0                    127.0.0.1:56726                    127.0.0.1:4505
+ESTAB      0      0                    ::ffff:1.2.3.4:5678                ::ffff:1.2.3.4:4505
+'''
+
 IPV4_SUBNETS = {True: ('10.10.0.0/24',),
                 False: ('10.10.0.0', '10.10.0.0/33', 'FOO', 9, '0.9.800.1000/24')}
 IPV6_SUBNETS = {True: ('::1/128',),
@@ -633,3 +639,8 @@ class NetworkTestCase(TestCase):
             # An exception is raised if unicode is passed to socket.getfqdn
             minion_id = network.generate_minion_id()
         assert minion_id != '', minion_id
+
+    def test_netlink_tool_remote_on(self):
+        with patch('subprocess.check_output', return_value=NETLINK_SS):
+            remotes = network._netlink_tool_remote_on('4505', 'remote')
+            self.assertEqual(remotes, set(['127.0.0.1', '::ffff:1.2.3.4']))


### PR DESCRIPTION
### What does this PR do?

Fixes exception thrown on ipv6 addresses

ValueError: invalid literal for int() with base 10: ':ffff:1.2.3.4:5678'

### What issues does this PR fix or reference?

### Previous Behavior

```
>>> s = '::ffff:1.2.3.4:5678'
>>> s.split(':', 1)
['', ':ffff:1.1.3.4:5678']
```

```
Exception occurred in runner manage.list_state: Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/salt/client/mixins.py", line 397, in _low
    data['return'] = self.functions[fun](*args, **kwargs)
  File "/usr/lib/python2.7/site-packages/salt/runners/manage.py", line 270, in list_state
    minions = ckminions.connected_ids(show_ipv4=show_ipv4, subset=subset, include_localhost=True)
  File "/usr/lib/python2.7/site-packages/salt/utils/minions.py", line 625, in connected_ids
    addrs = salt.utils.network.local_port_tcp(int(self.opts['publish_port']))
  File "/usr/lib/python2.7/site-packages/salt/utils/network.py", line 1376, in local_port_tcp
    ret = _remotes_on(port, 'local_port')
  File "/usr/lib/python2.7/site-packages/salt/utils/network.py", line 1394, in _remotes_on
    ret = _netlink_tool_remote_on(port, which_end)
  File "/usr/lib/python2.7/site-packages/salt/utils/network.py", line 1485, in _netlink_tool_remote_on
    if which_end == 'local_port' and int(local_port) != port:
ValueError: invalid literal for int() with base 10: ':ffff:1.232.14.3:58688'
```

### New Behavior

Split the address from the right instead of the left

```
>>> s.rsplit(':', 1)
['::ffff:1.2.3.4', '5678']
```

### Tests written?

No

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
