### PR TITLE
Fix boto_apigateway tests for PyYAML 5.1

### DIFF
--- a/tests/unit/states/test_boto_apigateway.py
+++ b/tests/unit/states/test_boto_apigateway.py
@@ -229,7 +229,7 @@ deployment1_ret = dict(createdDate=datetime.datetime(2015, 11, 17, 16, 33, 50),
                        description=('{\n'
                                     '    "api_name": "unit test api",\n'
                                     '    "swagger_file": "temp-swagger-sample.yaml",\n'
-                                    '    "swagger_file_md5sum": "693c57997a12a2446bb5c08c793d943c",\n'
+                                    '    "swagger_file_md5sum": "55a948ff90ad80ff747ec91657c7a299",\n'
                                     '    "swagger_info_object": {\n'
                                     '        "description": "salt boto apigateway unit test service",\n'
                                     '        "title": "salt boto apigateway unit test service",\n'
@@ -371,7 +371,7 @@ class TempSwaggerFile(object):
     def __enter__(self):
         self.swaggerfile = 'temp-swagger-sample.yaml'
         with salt.utils.files.fopen(self.swaggerfile, 'w') as fp_:
-            salt.utils.yaml.safe_dump(self.swaggerdict, fp_)
+            salt.utils.yaml.safe_dump(self.swaggerdict, fp_, default_flow_style=False)
         return self.swaggerfile
 
     def __exit__(self, objtype, value, traceback):


### PR DESCRIPTION
### What does this PR do?
Fixes the tests on Fedora:

```
unit.states.test_boto_apigateway.BotoApiGatewayTestCase.test_present_when_stage_exists_and_is_to_associate_to_existing_deployment
unit.states.test_boto_apigateway.BotoApiGatewayTestCase.test_present_when_stage_is_already_at_desired_deployment 
unit.states.test_boto_apigateway.BotoApiGatewayTestCase.test_present_when_stage_is_already_at_desired_deployment_and_needs_stage_variables_update
```

In PyYAML 5 the commit here: https://github.com/yaml/pyyaml/commit/507a464ce62c933bf667b2296a96ad45f0147873 made `default_flow_style=False`. Because of this difference it changes what is dumped into the `temp-swagger-sample.yaml` file.

Given this code:

```
import yaml

with open('/tmp/test', 'w') as blah:
    yaml.safe_dump({'blah': {'one': 'two'}}, blah)
```

the following gets dumped into the file:

PyYAML 3.13

```
blah: {one: two}
```

PyYAML 5.1

```
blah:
  one: two
```

The test was initially written with a pyyamml version <5.1 and created a hash based on that. The tests are failing because the hash is not comparing correctly. This change will force yaml regardless of what version to use `default_flow_style=False` to dump this test file. I tested this on both PyYaml versions and the tests passed.

### What issues does this PR fix or reference?
Fixes https://github.com/saltstack/salt/issues/52461

### Tests written?

No - fixing a test

### Commits signed with GPG?

Yes