### PR TITLE
Fix user.present for Windows

### DIFF
--- a/salt/states/user.py
+++ b/salt/states/user.py
@@ -161,13 +161,13 @@ def _changes(name,
     if fullname is not None and lusr['fullname'] != fullname:
         change['fullname'] = fullname
     if win_homedrive and lusr['homedrive'] != win_homedrive:
-        change['homedrive'] = win_homedrive
+        change['win_homedrive'] = win_homedrive
     if win_profile and lusr['profile'] != win_profile:
-        change['profile'] = win_profile
+        change['win_profile'] = win_profile
     if win_logonscript and lusr['logonscript'] != win_logonscript:
-        change['logonscript'] = win_logonscript
+        change['win_logonscript'] = win_logonscript
     if win_description and lusr['description'] != win_description:
-        change['description'] = win_description
+        change['win_description'] = win_description
 
     # MacOS doesn't have full GECOS support, so check for the "ch" functions
     # and ignore these parameters if these functions do not exist.

--- a/tests/integration/states/test_user.py
+++ b/tests/integration/states/test_user.py
@@ -269,3 +269,39 @@ class UserTest(ModuleCase, SaltReturnAssertsMixin):
         self.assertSaltTrueReturn(
             self.run_state('user.absent', name=self.user_name)
         )
+
+@destructiveTest
+@skip_if_not_root
+@skipIf(not salt.utils.platform.is_windows(), 'Windows only tests')
+class WinUserTest(ModuleCase, SaltReturnAssertsMixin):
+    '''
+    test for user absent
+    '''
+
+    def tearDown(self):
+        self.assertSaltTrueReturn(
+            self.run_state('user.absent', name=USER)
+        )
+
+    def test_user_present_existing(self):
+        ret = self.run_state('user.present',
+                             name=USER,
+                             win_homedrive='U:',
+                             win_profile='C:\\User\\{0}'.format(USER),
+                             win_logonscript='C:\\logon.vbs',
+                             win_description='Test User Account')
+        self.assertSaltTrueReturn(ret)
+        ret = self.run_state('user.present',
+                             name=USER,
+                             win_homedrive='R:',
+                             win_profile='C:\\Users\\{0}'.format(USER),
+                             win_logonscript='C:\\Windows\\logon.vbs',
+                             win_description='Temporary Account')
+        self.assertSaltTrueReturn(ret)
+        self.assertSaltStateChangesEqual(ret, 'R:', keys=['homedrive'])
+        self.assertSaltStateChangesEqual(
+            ret, 'C:\\Users\\{0}'.format(USER), keys=['profile'])
+        self.assertSaltStateChangesEqual(
+            ret, 'C:\\Windows\\logon.vbs', keys=['logonscript'])
+        self.assertSaltStateChangesEqual(
+            ret, 'Temporary Account', keys=['description'])

--- a/tests/integration/states/test_user.py
+++ b/tests/integration/states/test_user.py
@@ -270,6 +270,7 @@ class UserTest(ModuleCase, SaltReturnAssertsMixin):
             self.run_state('user.absent', name=self.user_name)
         )
 
+
 @destructiveTest
 @skip_if_not_root
 @skipIf(not salt.utils.platform.is_windows(), 'Windows only tests')
@@ -277,7 +278,6 @@ class WinUserTest(ModuleCase, SaltReturnAssertsMixin):
     '''
     test for user absent
     '''
-
     def tearDown(self):
         self.assertSaltTrueReturn(
             self.run_state('user.absent', name=USER)


### PR DESCRIPTION
### What does this PR do?
Fixes an issue when setting one of the following on an existing account:
- homedrive
- profile
- logonscript
- description

### What issues does this PR fix or reference?
Slack

### Previous Behavior
If setting one of the above on when the account already exists on the machine you would get a stacktrace:
```
KeyError: 'user.chlogonscript'
```

### New Behavior
Now it completes successfully

### Tests written?
Yes

### Commits signed with GPG?
Yes