### PR TITLE
[2019.2.1] Only run the libcrypto init if less than OpenSSL 1.1.0

### DIFF
--- a/salt/utils/rsax931.py
+++ b/salt/utils/rsax931.py
@@ -66,7 +66,7 @@ def _init_libcrypto():
 
     try:
         # If we're greater than OpenSSL 1.1.0, no need to to the init
-        if libcrypto.OpenSSL_version_num < 0x10100000L:
+        if libcrypto.OpenSSL_version_num < 0x10100000:
             libcrypto.OPENSSL_init_crypto()
     except AttributeError:
         # Support for OpenSSL < 1.1 (OPENSSL_API_COMPAT < 0x10100000L)

--- a/salt/utils/rsax931.py
+++ b/salt/utils/rsax931.py
@@ -65,7 +65,9 @@ def _init_libcrypto():
     libcrypto = _load_libcrypto()
 
     try:
-        libcrypto.OPENSSL_init_crypto()
+        # If we're greater than OpenSSL 1.1.0, no need to to the init
+        if libcrypto.OpenSSL_version_num < 0x10100000L:
+            libcrypto.OPENSSL_init_crypto()
     except AttributeError:
         # Support for OpenSSL < 1.1 (OPENSSL_API_COMPAT < 0x10100000L)
         libcrypto.OPENSSL_no_config()


### PR DESCRIPTION
### What does this PR do?
Only run the libcrypto init if less than OpenSSL 1.1.0.

### What issues does this PR fix or reference?
#52717

### Tests written?
No.  Fix to allow existing tests to run.

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
