### PR TITLE
`libcrypto.OpenSSL_version_num` might be a callable

### DIFF
--- a/salt/utils/rsax931.py
+++ b/salt/utils/rsax931.py
@@ -66,7 +66,10 @@ def _init_libcrypto():
 
     try:
         # If we're greater than OpenSSL 1.1.0, no need to to the init
-        if libcrypto.OpenSSL_version_num < 0x10100000:
+        openssl_version_num = libcrypto.OpenSSL_version_num
+        if callable(openssl_version_num):
+            openssl_version_num = openssl_version_num()
+        if openssl_version_num < 0x10100000:
             libcrypto.OPENSSL_init_crypto()
     except AttributeError:
         # Support for OpenSSL < 1.1 (OPENSSL_API_COMPAT < 0x10100000L)


### PR DESCRIPTION
### What does this PR do?
At least on Cryptodome, `OpenSSL_version_num` is a callable, account for that.

### What issues does this PR fix or reference?
Fixes the following traceback:
```
01:41:38        Traceback (most recent call last):
01:41:38          File "/tmp/kitchen/testing/tests/support/mixins.py", line 497, in assertReturnSaltType
01:41:38            self.assertTrue(isinstance(ret, dict))
01:41:38          File "/usr/lib/python3.5/unittest/case.py", line 677, in assertTrue
01:41:38            raise self.failureException(msg)
01:41:38        AssertionError: False is not true
01:41:38        
01:41:38        During handling of the above exception, another exception occurred:
01:41:38        
01:41:38        Traceback (most recent call last):
01:41:38          File "/tmp/kitchen/testing/tests/support/mixins.py", line 554, in assertSaltTrueReturn
01:41:38            for saltret in self.__getWithinSaltReturn(ret, 'result'):
01:41:38          File "/tmp/kitchen/testing/tests/support/mixins.py", line 527, in __getWithinSaltReturn
01:41:38            self.assertReturnNonEmptySaltType(ret)
01:41:38        AssertionError: str is not dict. Salt returned: ERROR: Traceback (most recent call last):
01:41:38          File "/tmp/salt.docker.14d0ac/salt-call", line 27, in <module>
01:41:38            salt_call()
01:41:38          File "/tmp/salt.docker.14d0ac/pyall/salt/scripts.py", line 426, in salt_call
01:41:38            import salt.cli.call
01:41:38          File "/tmp/salt.docker.14d0ac/pyall/salt/cli/call.py", line 8, in <module>
01:41:38            import salt.cli.caller
01:41:38          File "/tmp/salt.docker.14d0ac/pyall/salt/cli/caller.py", line 19, in <module>
01:41:38            import salt.minion
01:41:38          File "/tmp/salt.docker.14d0ac/pyall/salt/minion.py", line 70, in <module>
01:41:38            import salt.crypt
01:41:38          File "/tmp/salt.docker.14d0ac/pyall/salt/crypt.py", line 69, in <module>
01:41:38            import salt.utils.rsax931
01:41:38          File "/tmp/salt.docker.14d0ac/pyall/salt/utils/rsax931.py", line 93, in <module>
01:41:38            libcrypto = _init_libcrypto()
01:41:38          File "/tmp/salt.docker.14d0ac/pyall/salt/utils/rsax931.py", line 69, in _init_libcrypto
01:41:38            if libcrypto.OpenSSL_version_num < 0x10100000:
01:41:38        TypeError: unorderable types: _FuncPtr() < int()
```