### PR TITLE
Backport #52780 into 2019.2.1

### DIFF
--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -1486,8 +1486,8 @@ def _netlink_tool_remote_on(port, which_end):
         elif 'ESTAB' not in line:
             continue
         chunks = line.split()
-        local_host, local_port = chunks[3].split(':', 1)
-        remote_host, remote_port = chunks[4].split(':', 1)
+        local_host, local_port = chunks[3].rsplit(':', 1)
+        remote_host, remote_port = chunks[4].rsplit(':', 1)
 
         if which_end == 'remote_port' and int(remote_port) != port:
             continue

--- a/tests/unit/utils/test_network.py
+++ b/tests/unit/utils/test_network.py
@@ -120,6 +120,12 @@ USER     COMMAND    PID   FD PROTO  LOCAL ADDRESS    FOREIGN ADDRESS
 salt-master python2.781106 35 tcp4  127.0.0.1:61115  127.0.0.1:4506
 '''
 
+NETLINK_SS = '''
+State      Recv-Q Send-Q               Local Address:Port                 Peer Address:Port
+ESTAB      0      0                    127.0.0.1:56726                    127.0.0.1:4505
+ESTAB      0      0                    ::ffff:1.2.3.4:5678                ::ffff:1.2.3.4:4505
+'''
+
 IPV4_SUBNETS = {True: ('10.10.0.0/24',),
                 False: ('10.10.0.0', '10.10.0.0/33', 'FOO', 9, '0.9.800.1000/24')}
 IPV6_SUBNETS = {True: ('::1/128',),
@@ -637,3 +643,8 @@ class NetworkTestCase(TestCase):
             # An exception is raised if unicode is passed to socket.getfqdn
             minion_id = network.generate_minion_id()
         assert minion_id != '', minion_id
+
+    def test_netlink_tool_remote_on(self):
+        with patch('subprocess.check_output', return_value=NETLINK_SS):
+            remotes = network._netlink_tool_remote_on('4505', 'remote')
+            self.assertEqual(remotes, set(['127.0.0.1', '::ffff:1.2.3.4']))


### PR DESCRIPTION
Backport #52780 into 2019.2.1

I was doing some testing on 2019.2.1 and even a `salt '*' test.ping` was failing because of ipv6 addresses on my host.