### PR TITLE
 Reload matcher loader when ext_pillar_first set 

### DIFF
--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -662,6 +662,9 @@ class Pillar(object):
 
         Returns:
         {'saltenv': ['state1', 'state2', ...]}
+
+        reload
+            Reload the matcher loader
         '''
         matches = {}
         if reload:

--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -655,7 +655,7 @@ class Pillar(object):
             errors.append('Error encountered while rendering pillar top file.')
         return merged_tops, errors
 
-    def top_matches(self, top):
+    def top_matches(self, top, reload=False):
         '''
         Search through the top high data for matches and return the states
         that this minion needs to execute.
@@ -664,6 +664,8 @@ class Pillar(object):
         {'saltenv': ['state1', 'state2', ...]}
         '''
         matches = {}
+        if reload:
+            self.matchers = salt.loader.matchers(self.opts)
         for saltenv, body in six.iteritems(top):
             if self.opts['pillarenv']:
                 if saltenv != self.opts['pillarenv']:
@@ -1001,7 +1003,7 @@ class Pillar(object):
             if self.opts.get('ext_pillar_first', False):
                 self.opts['pillar'], errors = self.ext_pillar(self.pillar_override)
                 self.rend = salt.loader.render(self.opts, self.functions)
-                matches = self.top_matches(top)
+                matches = self.top_matches(top, reload=True)
                 pillar, errors = self.render_pillar(matches, errors=errors)
                 pillar = merge(
                     self.opts['pillar'],

--- a/tests/unit/test_pillar.py
+++ b/tests/unit/test_pillar.py
@@ -326,6 +326,51 @@ class PillarTestCase(TestCase):
             'mocked-minion', 'fake_pillar', 'bar',
             extra_minion_data={'fake_key': 'foo'})
 
+    def test_ext_pillar_first(self):
+        '''
+        test when using ext_pillar and ext_pillar_first
+        '''
+        opts = {
+            'optimization_order': [0, 1, 2],
+            'renderer': 'yaml',
+            'renderer_blacklist': [],
+            'renderer_whitelist': [],
+            'state_top': '',
+            'pillar_roots': [],
+            'extension_modules': '',
+            'saltenv': 'base',
+            'file_roots': [],
+            'ext_pillar_first': True,
+        }
+        grains = {
+            'os': 'Ubuntu',
+            'os_family': 'Debian',
+            'oscodename': 'raring',
+            'osfullname': 'Ubuntu',
+            'osrelease': '13.04',
+            'kernel': 'Linux'
+        }
+
+        tempdir = tempfile.mkdtemp(dir=TMP)
+        try:
+            sls_files = self._setup_test_topfile_sls_pillar_match(
+                tempdir,)
+            fc_mock = MockFileclient(
+                cache_file=sls_files['top']['dest'],
+                list_states=['top', 'ssh', 'ssh.minion',
+                             'generic', 'generic.minion'],
+                get_state=sls_files)
+            with patch.object(salt.fileclient, 'get_file_client',
+                              MagicMock(return_value=fc_mock)), \
+                    patch('salt.pillar.Pillar.ext_pillar',
+                          MagicMock(return_value=({'id': 'minion',
+                                                  'phase': 'alpha', 'role':
+                                                  'database'}, []))):
+                pillar = salt.pillar.Pillar(opts, grains, 'mocked-minion', 'base')
+                self.assertEqual(pillar.compile_pillar()['generic']['key1'], 'value1')
+        finally:
+            shutil.rmtree(tempdir, ignore_errors=True)
+
     def test_dynamic_pillarenv(self):
         opts = {
             'optimization_order': [0, 1, 2],
@@ -580,6 +625,28 @@ class PillarTestCase(TestCase):
         # test case where nodegroup match happens second and therefore takes
         # precedence over glob match.
         _run_test(nodegroup_order=2, glob_order=1, expected='foo')
+
+    def _setup_test_topfile_sls_pillar_match(self, tempdir):
+        # Write a simple topfile and two pillar state files
+        top_file = tempfile.NamedTemporaryFile(dir=tempdir, delete=False)
+        s = '''
+base:
+  'phase:alpha':
+    - match: pillar
+    - generic
+'''
+        top_file.write(salt.utils.stringutils.to_bytes(s))
+        top_file.flush()
+        generic_file = tempfile.NamedTemporaryFile(dir=tempdir, delete=False)
+        generic_file.write(b'''
+generic:
+    key1: value1
+''')
+        generic_file.flush()
+        return {
+            'top': {'path': '', 'dest': top_file.name},
+            'generic': {'path': '', 'dest': generic_file.name},
+        }
 
     def _setup_test_topfile_sls(self, tempdir, nodegroup_order, glob_order):
         # Write a simple topfile and two pillar state files


### PR DESCRIPTION
### What does this PR do?
When `ext_pillar_first` is set and the pillar is in external pillar that is needed to compile the top file it fails. Because we load the matchers in `__init__` and later on we add the ext pillar data to `self.opts` we need to re-load the matcher loader so the correct pillar data ends up in `__opts__['pillar']`

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/52597

### Previous Behavior
Receive this error:

```
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/salt/master.py", line 1838, in run_func
    ret = getattr(self, func)(load)
  File "/usr/lib/python2.7/site-packages/salt/master.py", line 1543, in _pillar
    data = pillar.compile_pillar()
  File "/usr/lib/python2.7/site-packages/salt/pillar/__init__.py", line 1005, in compile_pillar
    matches = self.top_matches(top)
  File "/usr/lib/python2.7/site-packages/salt/pillar/__init__.py", line 675, in top_matches
    self.opts.get('nodegroups', {}),
  File "/usr/lib/python2.7/site-packages/salt/matchers/confirm_top.py", line 36, in confirm_top
    return m(match)
  File "/usr/lib/python2.7/site-packages/salt/matchers/pillar_match.py", line 24, in match
    __opts__['pillar'], tgt, delimiter=delimiter
KeyError: u'pillar'
```

### New Behavior
pillar data and top file compiled correctly.

### Tests written?

Yes

### Commits signed with GPG?

Yes
