### PR TITLE
[2019.2.1] Fixes to unit.utils.test_args.test_argspec_report

### DIFF
--- a/salt/utils/args.py
+++ b/salt/utils/args.py
@@ -8,6 +8,7 @@ from __future__ import absolute_import, print_function, unicode_literals
 import copy
 import fnmatch
 import inspect
+import logging
 import re
 import shlex
 
@@ -19,6 +20,8 @@ import salt.utils.data
 import salt.utils.jid
 import salt.utils.versions
 import salt.utils.yaml
+
+log = logging.getLogger(__name__)
 
 
 if six.PY3:

--- a/tests/unit/utils/test_args.py
+++ b/tests/unit/utils/test_args.py
@@ -13,7 +13,6 @@ import salt.utils.args
 # Import Salt Testing Libs
 from tests.support.unit import TestCase, skipIf
 from tests.support.mock import (
-    create_autospec,
     DEFAULT,
     NO_MOCK,
     NO_MOCK_REASON,
@@ -126,11 +125,13 @@ class ArgsTestCase(TestCase):
         def _test_spec(arg1, arg2, kwarg1=None):
             pass
 
-        sys_mock = create_autospec(_test_spec)
-        test_functions = {'test_module.test_spec': sys_mock}
+        test_functions = {'test_module.test_spec': _test_spec}
         ret = salt.utils.args.argspec_report(test_functions, 'test_module.test_spec')
         self.assertDictEqual(ret, {'test_module.test_spec':
-                                       {'kwargs': True, 'args': None, 'defaults': None, 'varargs': True}})
+                                       {'kwargs': None,
+                                        'args': ['arg1', 'arg2', 'kwarg1'],
+                                        'defaults': (None, ),
+                                        'varargs': None}})
 
     def test_test_mode(self):
         self.assertTrue(salt.utils.args.test_mode(test=True))


### PR DESCRIPTION
### What does this PR do?
Removing create_autospec and having salt.utils.args.argspec_report run against the _test_spec function directly.  Depending on the python version, create_autospec gives different results and cause the test to fail.  The test is now more accurate at testing the arguments for the function.

### What issues does this PR fix or reference?
#52836 

### Tests written?
No.  Fixing existing test.

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
