### PR TITLE
Fix elasticsearch state module: allow user to define empty aliases

### DIFF
--- a/salt/states/elasticsearch.py
+++ b/salt/states/elasticsearch.py
@@ -282,7 +282,7 @@ def index_template_present(name, definition, check_definition=False):
                 current_template = __salt__['elasticsearch.index_template_get'](name=name)[name]
                 # Prune empty keys (avoid false positive diff)
                 for key in ("mappings", "aliases", "settings"):
-                    if current_template[key] == {}:
+                    if current_template[key] == {} and key not in definition_parsed:
                         del current_template[key]
                 diff = __utils__['dictdiffer.deep_diff'](current_template, definition_parsed)
                 if len(diff) != 0:

--- a/tests/unit/states/test_elasticsearch.py
+++ b/tests/unit/states/test_elasticsearch.py
@@ -278,6 +278,68 @@ class ElasticsearchTestCase(TestCase, LoaderModuleMockMixin):
             ret.update({'comment': '', 'result': False, 'changes': {}})
             self.assertDictEqual(elasticsearch.index_template_present(name, {}), ret)
 
+    def test_index_template_present_check_definition(self):
+        '''
+        Test to manage a elasticsearch index template.
+        with check_definition set
+        '''
+        name = 'foo'
+
+        index_template = {name: {"test2": "key",
+                                 "aliases": {},
+                                 "mappings": {},
+                                 "settings": {}}}
+
+        expected = {'name': name,
+                    'result': True,
+                    'comment': 'Index template foo is already present and up to date',
+                    'changes': {}}
+
+        mock_exists = MagicMock(side_effect=[True])
+        mock_create = MagicMock(side_effect=[True])
+        mock_get = MagicMock(side_effect=[index_template])
+
+        with patch.dict(elasticsearch.__salt__, {'elasticsearch.index_template_get': mock_get,
+                                             'elasticsearch.index_template_create': mock_create,
+                                             'elasticsearch.index_template_exists': mock_exists}):
+
+            ret = elasticsearch.index_template_present(name,
+                                                      {"test2": "key",
+                                                       "aliases": {}},
+                                                      check_definition=True)
+            self.assertDictEqual(expected, ret)
+
+    def test_index_template_present_check_definition_alias_not_empty(self):
+        '''
+        Test to manage a elasticsearch index template.
+        with check_definition set and alias is not empty
+        '''
+        name = 'foo'
+
+        index_template = {name: {"test2": "key",
+                                 "aliases": {},
+                                 "mappings": {},
+                                 "settings": {}}}
+
+        expected = {'name': name,
+                    'result': True,
+                    'comment': 'Successfully updated index template foo',
+                    'changes': {'new': {'aliases': {'alias1': {}}}, 'old': {'aliases': {}}}}
+
+        mock_exists = MagicMock(side_effect=[True])
+        mock_create = MagicMock(side_effect=[True])
+        mock_get = MagicMock(side_effect=[index_template])
+
+        with patch.dict(elasticsearch.__salt__, {'elasticsearch.index_template_get': mock_get,
+                                             'elasticsearch.index_template_create': mock_create,
+                                             'elasticsearch.index_template_exists': mock_exists}):
+
+            ret = elasticsearch.index_template_present(name,
+                                                      {"test2": "key",
+                                                       "aliases": {'alias1': {}}},
+                                                      check_definition=True)
+            self.assertDictEqual(expected, ret)
+
     # 'pipeline_absent' function tests: 1
 
     def test_pipeline_absent(self):


### PR DESCRIPTION
### What does this PR do?
This allows a user to define an empty aliases, mappings or settings in their definition set for the `elasticsearch.index_template_present` module

### What issues does this PR fix or reference?
Fixes https://github.com/saltstack/salt/issues/51822

### Previous Behavior
The state module would always return that there was changes even if the state was previously run.

```
logstash template:
  elasticsearch.index_template_present:
    - check_definition: true
    - definition:
        index_patterns: [ 'logstash-*' ]
        order: 0
        aliases: {}
```

```
local:
----------
          ID: logstash_template4
    Function: elasticsearch.index_template_present
      Result: True
     Comment: Successfully updated index template logstash_template4
     Started: 15:58:46.726069
    Duration: 37.978 ms
     Changes:   
              ----------
              new:
                  ----------
                  aliases:
                      ----------

Summary for local
------------
Succeeded: 1 (changed=1)
Failed:    0
------------
Total states run:     1
Total run time:  37.978 ms
```


### New Behavior
can define an empty aliases, mappings or settings and it will now return no changes:

```
local:
----------
          ID: logstash_template4
    Function: elasticsearch.index_template_present
      Result: True
     Comment: Index template logstash_template4 is already present and up to date
     Started: 15:56:26.777195
    Duration: 23.914 ms
     Changes:   

Summary for local
------------
Succeeded: 1
Failed:    0
------------
Total states run:     1
Total run time:  23.914 ms
```

### Tests written?

Yes

### Commits signed with GPG?

Yes
