### PR TITLE
Re-adding the Salt Module Index

### DIFF
--- a/doc/_ext/saltdomain.py
+++ b/doc/_ext/saltdomain.py
@@ -290,7 +290,7 @@ class SaltDomain(python_domain.PythonDomain):
                     type, target, node, contnode)
 
 # Monkey-patch the Python domain remove the python module index
-python_domain.PythonDomain.indices = []
+python_domain.PythonDomain.indices = [SaltModuleIndex]
 
 
 def setup(app):


### PR DESCRIPTION
### What does this PR do?
It is a workaround to build the docs successfully using sphinx 2.0.1

I found out what broke it, it is this change in sphinx: https://github.com/sphinx-doc/sphinx/commit/11182d42b1f265cda10951df93098bb3eed5caf7 If I undo that change in the sphinx source code, it works again exactly as before.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/52777

### Previous Behavior
The module index was completely missing.
Before that, the module index was available at /salt-modindex.html

### New Behavior
The module index is created, but at the url /py-modindex.html

### Tests written?
N/A

### Commits signed with GPG?

Yes

