### PR TITLE
Set default_flow_style=None in yaml.dump calls

### DIFF
--- a/salt/serializers/yaml.py
+++ b/salt/serializers/yaml.py
@@ -72,6 +72,7 @@ def serialize(obj, **options):
     '''
 
     options.setdefault('Dumper', Dumper)
+    options.setdefault('default_flow_style', None)
     try:
         response = yaml.dump(obj, **options)
         if response.endswith('\n...\n'):

--- a/salt/serializers/yamlex.py
+++ b/salt/serializers/yamlex.py
@@ -182,6 +182,7 @@ def serialize(obj, **options):
     '''
 
     options.setdefault('Dumper', Dumper)
+    options.setdefault('default_flow_style', None)
     try:
         response = yaml.dump(obj, **options)
         if response.endswith('\n...\n'):

--- a/salt/utils/yamldumper.py
+++ b/salt/utils/yamldumper.py
@@ -115,6 +115,7 @@ def dump(data, stream=None, **kwargs):
     '''
     if 'allow_unicode' not in kwargs:
         kwargs['allow_unicode'] = True
+    kwargs.setdefault('default_flow_style', None)
     return yaml.dump(data, stream, **kwargs)
 
 
@@ -126,4 +127,5 @@ def safe_dump(data, stream=None, **kwargs):
     '''
     if 'allow_unicode' not in kwargs:
         kwargs['allow_unicode'] = True
+    kwargs.setdefault('default_flow_style', None)
     return yaml.dump(data, stream, Dumper=SafeOrderedDumper, **kwargs)

--- a/tests/unit/serializers/test_serializers.py
+++ b/tests/unit/serializers/test_serializers.py
@@ -68,7 +68,22 @@ class TestSerializers(TestCase):
         serialized = yamlex.serialize(data)
         assert serialized == '{foo: bar}', serialized
 
+        serialized = yamlex.serialize(data, default_flow_style=False)
+        assert serialized == 'foo: bar', serialized
+
         deserialized = yamlex.deserialize(serialized)
+        assert deserialized == data, deserialized
+
+        serialized = yaml.serialize(data)
+        assert serialized == '{foo: bar}', serialized
+
+        deserialized = yaml.deserialize(serialized)
+        assert deserialized == data, deserialized
+
+        serialized = yaml.serialize(data, default_flow_style=False)
+        assert serialized == 'foo: bar', serialized
+
+        deserialized = yaml.deserialize(serialized)
         assert deserialized == data, deserialized
 
     @skipIf(not yamlex.available, SKIP_MESSAGE % 'sls')
@@ -82,6 +97,12 @@ class TestSerializers(TestCase):
         assert serialized == '{foo: 1, bar: 2, baz: true}', serialized
 
         deserialized = yamlex.deserialize(serialized)
+        assert deserialized == data, deserialized
+
+        serialized = yaml.serialize(data)
+        assert serialized == '{bar: 2, baz: true, foo: 1}', serialized
+
+        deserialized = yaml.deserialize(serialized)
         assert deserialized == data, deserialized
 
     @skipIf(not yaml.available, SKIP_MESSAGE % 'yaml')

--- a/tests/unit/utils/test_yamldumper.py
+++ b/tests/unit/utils/test_yamldumper.py
@@ -17,7 +17,7 @@ from tests.support.mock import NO_MOCK, NO_MOCK_REASON
 @skipIf(NO_MOCK, NO_MOCK_REASON)
 class YamlDumperTestCase(TestCase):
     '''
-    TestCase for salt.utils.yamlloader module
+    TestCase for salt.utils.yamldumper module
     '''
     def test_yaml_dump(self):
         '''

--- a/tests/unit/utils/test_yamldumper.py
+++ b/tests/unit/utils/test_yamldumper.py
@@ -11,7 +11,7 @@ import salt.utils.yamldumper
 
 # Import Salt Testing Libs
 from tests.support.unit import TestCase, skipIf
-from tests.support.mock import patch, NO_MOCK, NO_MOCK_REASON, mock_open
+from tests.support.mock import NO_MOCK, NO_MOCK_REASON
 
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)

--- a/tests/unit/utils/test_yamldumper.py
+++ b/tests/unit/utils/test_yamldumper.py
@@ -7,6 +7,7 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
 # Import Salt Libs
+import salt.ext.six
 import salt.utils.yamldumper
 
 # Import Salt Testing Libs
@@ -24,9 +25,15 @@ class YamlDumperTestCase(TestCase):
         Test yaml.dump a dict
         '''
         data = {'foo': 'bar'}
-        assert salt.utils.yamldumper.dump(data) == '{!!python/unicode \'foo\': !!python/unicode \'bar\'}\n'
 
-        assert salt.utils.yamldumper.dump(data, default_flow_style=False) == '!!python/unicode \'foo\': !!python/unicode \'bar\'\n'
+        if salt.ext.six.PY2:
+            exp_yaml = '{!!python/unicode \'foo\': !!python/unicode \'bar\'}\n'
+        else:
+            exp_yaml = '{foo: bar}\n'
+
+        assert salt.utils.yamldumper.dump(data) == exp_yaml
+
+        assert salt.utils.yamldumper.dump(data, default_flow_style=False) == exp_yaml.replace('{', '').replace('}', '')
 
     def test_yaml_safe_dump(self):
         '''

--- a/tests/unit/utils/test_yamldumper.py
+++ b/tests/unit/utils/test_yamldumper.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+'''
+    Unit tests for salt.utils.yamldumper
+'''
+
+# Import python libs
+from __future__ import absolute_import, print_function, unicode_literals
+
+# Import Salt Libs
+import salt.utils.yamldumper
+
+# Import Salt Testing Libs
+from tests.support.unit import TestCase, skipIf
+from tests.support.mock import patch, NO_MOCK, NO_MOCK_REASON, mock_open
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class YamlDumperTestCase(TestCase):
+    '''
+    TestCase for salt.utils.yamlloader module
+    '''
+    def test_yaml_dump(self):
+        '''
+        Test yaml.dump a dict
+        '''
+        data = {'foo': 'bar'}
+        assert salt.utils.yamldumper.dump(data) == '{!!python/unicode \'foo\': !!python/unicode \'bar\'}\n'
+
+        assert salt.utils.yamldumper.dump(data, default_flow_style=False) == '!!python/unicode \'foo\': !!python/unicode \'bar\'\n'
+
+    def test_yaml_safe_dump(self):
+        '''
+        Test yaml.safe_dump a dict
+        '''
+        data = {'foo': 'bar'}
+        assert salt.utils.yamldumper.safe_dump(data) == '{foo: bar}\n'
+
+        assert salt.utils.yamldumper.safe_dump(data, default_flow_style=False) == 'foo: bar\n'


### PR DESCRIPTION
### What does this PR do?

In PyYaml 5.1 they changed the `default_flow_style` from None to False. Changing this back to None in salt since this is a breaking change to keep backwards compatibility. Here is the PR/commit that added this: https://github.com/yaml/pyyaml/pull/256 https://github.com/yaml/pyyaml/commit/507a464ce62c933bf667b2296a96ad45f0147873

Would appreciate any further review as I'm not sure if we want to keep backwards compatibility or update salt to ensure `default_flow_style=False` works properly. But I think this is the least obtrusive change for now.

### What issues does this PR fix or reference?
Fixes up some tests on Fedora which has PyYaml 5.1 installed:

https://github.com/saltstack/salt/issues/52930
https://github.com/saltstack/salt/issues/52929
https://github.com/saltstack/salt/issues/52928
https://github.com/saltstack/salt/issues/52927

PyYAML 5.1:

```
>>> test = {'foo': 'bar'}
>>> yaml.dump(test)
'foo: bar\n'
```

PyYAML 3.13:

```
>>> test = {'food': 'bar'}
>>> yaml.dump(test)
'{food: bar}\n'
```

With this change it will always dump like so:

PyYAML 5.1:

```
>>> yaml.dump(test, default_flow_style=None)
'{food: bar}\n'
```

PyYAML 3.13:

```
>>> yaml.dump(test, default_flow_style=None)
'{food: bar}\n'
```


### Tests written?

Yes

### Commits signed with GPG?

Yes