### PR TITLE
Fix failing tests in the pip_state module

### DIFF
--- a/salt/states/pip_state.py
+++ b/salt/states/pip_state.py
@@ -61,14 +61,10 @@ except ImportError:
         del sys_modules_pip
 
 if HAS_PIP is True:
-    if salt.utils.versions.compare(ver1=pip.__version__,
-                                   oper='>=',
-                                   ver2='18.1'):
+    if hasattr(pip, '_internal'):
         from pip._internal.exceptions import InstallationError  # pylint: disable=E0611,E0401
-    elif salt.utils.versions.compare(ver1=pip.__version__,
-                                   oper='>=',
-                                   ver2='10.0'):
-        from pip.exceptions import InstallationError  # pylint: disable=E0611,E0401
+    elif hasattr(pip.exceptions, 'InstallationError'):
+        from pip.exceptions import InstallationError
     else:
         InstallationError = ValueError
 
@@ -83,16 +79,13 @@ __virtualname__ = 'pip'
 
 def _from_line(*args, **kwargs):
     import pip
-    if salt.utils.versions.compare(ver1=pip.__version__,
-                                   oper='>=',
-                                   ver2='18.1'):
-        import pip._internal.req.constructors  # pylint: disable=E0611,E0401
-        return pip._internal.req.constructors.install_req_from_line(*args, **kwargs)
-    elif salt.utils.versions.compare(ver1=pip.__version__,
-                                   oper='>=',
-                                   ver2='10.0'):
-        import pip._internal.req  # pylint: disable=E0611,E0401
-        return pip._internal.req.InstallRequirement.from_line(*args, **kwargs)
+    if hasattr(pip, '_internal'):
+        if hasattr(pip._internal.req, 'constructors'):
+            import pip._internal.req.constructors  # pylint: disable=E0611,E0401
+            return pip._internal.req.constructors.install_req_from_line(*args, **kwargs)
+        else:
+            import pip._internal.req  # pylint: disable=E0611,E0401
+            return pip._internal.req.InstallRequirement.from_line(*args, **kwargs)
     else:
         import pip.req  # pylint: disable=E0611,E0401
         return pip.req.InstallRequirement.from_line(*args, **kwargs)

--- a/tests/unit/states/test_pip_state.py
+++ b/tests/unit/states/test_pip_state.py
@@ -257,8 +257,9 @@ class PipStateTest(TestCase, SaltReturnAssertsMixin, LoaderModuleMockMixin):
                     )
 
             # Test VCS installations with version info like >= 0.1
-            with patch.object(pip, '__version__', MagicMock(side_effect=AttributeError(
-                                                        'Faked missing __version__ attribute'))):
+            attrib_err = AttributeError('Faked missing __version__ attribute')
+            mock_attrib_err = MagicMock(side_effect=attrib_err)
+            with patch.object(pip, '__version__', mock_attrib_err):
                 mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
                 pip_list = MagicMock(return_value={'SaltTesting': '0.5.0'})
                 pip_install = MagicMock(return_value={


### PR DESCRIPTION
### What does this PR do?
Fixes the pip_state module

### What issues does this PR fix or reference?
Jenkins test was failing on Windows `unit.states.test_pip_state.PipStateTest.test_install_requirements_parsing`

### Previous Behavior
Tests were failing with the following:
```
Traceback (most recent call last):
  File "c:\users\admini~1\appdata\local\temp\kitchen\testing\tests\unit\states\test_pip_state.py", line 61, in test_install_requirements_parsing
    ret = pip_state.installed('pep8=1.3.2')
  File "C:\\Users\\ADMINI~1\\AppData\\Local\\Temp\\kitchen\\testing\salt\states\pip_state.py", line 718, in installed
    out = _check_pkg_version_format(pkg)
  File "C:\\Users\\ADMINI~1\\AppData\\Local\\Temp\\kitchen\\testing\salt\states\pip_state.py", line 153, in _check_pkg_version_format
    install_req = _from_line(pkg)
  File "C:\\Users\\ADMINI~1\\AppData\\Local\\Temp\\kitchen\\testing\salt\states\pip_state.py", line 98, in _from_line
    return pip.req.InstallRequirement.from_line(*args, **kwargs)
  File "C:\Python27\lib\site-packages\pip\req\req_install.py", line 235, in from_line
    wheel_cache=wheel_cache, constraint=constraint)
  File "C:\Python27\lib\site-packages\pip\req\req_install.py", line 91, in __init__
    "Invalid requirement: '%s'\n%s" % (req, add_msg))
InstallationError: Invalid requirement: 'pep8=1.3.2'
= is not a valid operator. Did you mean == ?
```

### Tests written?
This fixes a failing test

### Commits signed with GPG?
Yes