### PR TITLE
mount: add not_change parameter to set_fstab and similars

### DIFF
--- a/salt/modules/mount.py
+++ b/salt/modules/mount.py
@@ -711,10 +711,14 @@ def set_fstab(
         config='/etc/fstab',
         test=False,
         match_on='auto',
+        not_change=False,
         **kwargs):
     '''
     Verify that this mount is represented in the fstab, change the mount
     to match the data passed, or add the mount if it is not present.
+
+    If the entry is found via `match_on` and `not_change` is True, the
+    current line will be preserved.
 
     CLI Example:
 
@@ -793,7 +797,7 @@ def set_fstab(
                         # Note: If ret isn't None here,
                         # we've matched multiple lines
                         ret = 'present'
-                        if entry.match(line):
+                        if entry.match(line) or not_change:
                             lines.append(line)
                         else:
                             ret = 'change'
@@ -837,11 +841,15 @@ def set_vfstab(
         config='/etc/vfstab',
         test=False,
         match_on='auto',
+        not_change=False,
         **kwargs):
     '''
     ..verionadded:: 2016.3.2
     Verify that this mount is represented in the fstab, change the mount
     to match the data passed, or add the mount if it is not present.
+
+    If the entry is found via `match_on` and `not_change` is True, the
+    current line will be preserved.
 
     CLI Example:
 
@@ -922,7 +930,7 @@ def set_vfstab(
                         # Note: If ret isn't None here,
                         # we've matched multiple lines
                         ret = 'present'
-                        if entry.match(line):
+                        if entry.match(line) or not_change:
                             lines.append(line)
                         else:
                             ret = 'change'
@@ -1023,6 +1031,7 @@ def set_automaster(
         opts='',
         config='/etc/auto_salt',
         test=False,
+        not_change=False,
         **kwargs):
     '''
     Verify that this mount is represented in the auto_salt, change the mount
@@ -1071,9 +1080,11 @@ def set_automaster(
                     lines.append(line)
                     continue
                 if comps[0] == name or comps[2] == device_fmt:
+                    present = True
+                    if not_change:
+                        continue
                     # check to see if there are changes
                     # and fix them if there are any
-                    present = True
                     if comps[0] != name:
                         change = True
                         comps[0] = name
@@ -1672,12 +1683,16 @@ def set_filesystems(
         config='/etc/filesystems',
         test=False,
         match_on='auto',
+        not_change=False,
         **kwargs):
     '''
     .. versionadded:: 2018.3.3
 
     Verify that this mount is represented in the filesystems, change the mount
     to match the data passed, or add the mount if it is not present on AIX
+
+    If the entry is found via `match_on` and `not_change` is True, the
+    current line will be preserved.
 
         Provide information if the path is mounted
 
@@ -1778,7 +1793,7 @@ def set_filesystems(
         for fsys_view in six.viewitems(fsys_filedict):
             if criteria.match(fsys_view):
                 ret = 'present'
-                if entry_ip.match(fsys_view):
+                if entry_ip.match(fsys_view) or not_change:
                     view_lines.append(fsys_view)
                 else:
                     ret = 'change'

--- a/salt/states/mount.py
+++ b/salt/states/mount.py
@@ -1018,9 +1018,9 @@ def _convert_to(maybe_device, convert_to):
 
 def fstab_present(name, fs_file, fs_vfstype, fs_mntops='defaults',
                   fs_freq=0, fs_passno=0, mount_by=None,
-                  config='/etc/fstab', mount=True, match_on='auto'):
-    '''
-    Makes sure that a fstab mount point is pressent.
+                  config='/etc/fstab', mount=True, match_on='auto',
+                  not_change=False):
+    '''Makes sure that a fstab mount point is pressent.
 
     name
         The name of block device. Can be any valid fs_spec value.
@@ -1065,6 +1065,13 @@ def fstab_present(name, fs_file, fs_vfstype, fs_mntops='defaults',
         to guess based on fstype.  In general, ``auto`` matches on
         name for recognized special devices and device otherwise.
 
+    not_change
+        By default, if the entry is found in the fstab file but is
+        different from the expected content (like different options),
+        the entry will be replaced with the correct content. If this
+        parameter is set to ``True`` and the line is found, the
+        original content will be preserved.
+
     '''
     ret = {
         'name': name,
@@ -1105,7 +1112,8 @@ def fstab_present(name, fs_file, fs_vfstype, fs_mntops='defaults',
                                                    fstype=fs_vfstype,
                                                    opts=fs_mntops,
                                                    config=config,
-                                                   test=True)
+                                                   test=True,
+                                                   not_change=not_change)
         elif __grains__['os'] == 'AIX':
             out = __salt__['mount.set_filesystems'](name=fs_file,
                                                     device=fs_spec,
@@ -1114,7 +1122,8 @@ def fstab_present(name, fs_file, fs_vfstype, fs_mntops='defaults',
                                                     mount=mount,
                                                     config=config,
                                                     test=True,
-                                                    match_on=match_on)
+                                                    match_on=match_on,
+                                                    not_change=not_change)
         else:
             out = __salt__['mount.set_fstab'](name=fs_file,
                                               device=fs_spec,
@@ -1124,7 +1133,8 @@ def fstab_present(name, fs_file, fs_vfstype, fs_mntops='defaults',
                                               pass_num=fs_passno,
                                               config=config,
                                               test=True,
-                                              match_on=match_on)
+                                              match_on=match_on,
+                                              not_change=not_change)
         ret['result'] = None
         if out == 'present':
             msg = '{} entry is already in {}.'
@@ -1146,7 +1156,8 @@ def fstab_present(name, fs_file, fs_vfstype, fs_mntops='defaults',
                                                device=fs_spec,
                                                fstype=fs_vfstype,
                                                opts=fs_mntops,
-                                               config=config)
+                                               config=config,
+                                               not_change=not_change)
     elif __grains__['os'] == 'AIX':
         out = __salt__['mount.set_filesystems'](name=fs_file,
                                                 device=fs_spec,
@@ -1154,7 +1165,8 @@ def fstab_present(name, fs_file, fs_vfstype, fs_mntops='defaults',
                                                 opts=fs_mntops,
                                                 mount=mount,
                                                 config=config,
-                                                match_on=match_on)
+                                                match_on=match_on,
+                                                not_change=not_change)
     else:
         out = __salt__['mount.set_fstab'](name=fs_file,
                                           device=fs_spec,
@@ -1163,7 +1175,8 @@ def fstab_present(name, fs_file, fs_vfstype, fs_mntops='defaults',
                                           dump=fs_freq,
                                           pass_num=fs_passno,
                                           config=config,
-                                          match_on=match_on)
+                                          match_on=match_on,
+                                          not_change=not_change)
 
     ret['result'] = True
     if out == 'present':

--- a/tests/unit/modules/test_mount.py
+++ b/tests/unit/modules/test_mount.py
@@ -216,6 +216,21 @@ class MountTestCase(TestCase, LoaderModuleMockMixin):
                        mock_open(read_data=MOCK_SHELL_FILE)):
                 self.assertEqual(mount.set_fstab('A', 'B', 'C'), 'new')
 
+        mock = MagicMock(return_value=True)
+        with patch.object(os.path, 'isfile', mock):
+            with patch('salt.utils.files.fopen',
+                       mock_open(read_data=MOCK_SHELL_FILE)):
+                self.assertEqual(mount.set_fstab('B', 'A', 'C', 'D', 'F', 'G'),
+                                 'present')
+
+        mock = MagicMock(return_value=True)
+        with patch.object(os.path, 'isfile', mock):
+            with patch('salt.utils.files.fopen',
+                       mock_open(read_data=MOCK_SHELL_FILE)):
+                self.assertEqual(mount.set_fstab('B', 'A', 'C',
+                                                 not_change=True),
+                                 'present')
+
     def test_rm_automaster(self):
         '''
         Remove the mount point from the auto_master
@@ -238,6 +253,34 @@ class MountTestCase(TestCase, LoaderModuleMockMixin):
             self.assertRaises(CommandExecutionError,
                               mount.set_automaster,
                               'A', 'B', 'C')
+
+        mock = MagicMock(return_value=True)
+        mock_read = MagicMock(side_effect=OSError)
+        with patch.object(os.path, 'isfile', mock):
+            with patch.object(salt.utils.files, 'fopen', mock_read):
+                self.assertRaises(CommandExecutionError,
+                                  mount.set_automaster, 'A', 'B', 'C')
+
+        mock = MagicMock(return_value=True)
+        with patch.object(os.path, 'isfile', mock):
+            with patch('salt.utils.files.fopen',
+                       mock_open(read_data=MOCK_SHELL_FILE)):
+                self.assertEqual(mount.set_automaster('A', 'B', 'C'), 'new')
+
+        mock = MagicMock(return_value=True)
+        with patch.object(os.path, 'isfile', mock):
+            with patch('salt.utils.files.fopen',
+                       mock_open(read_data='/..A -fstype=C,D C:B')):
+                self.assertEqual(mount.set_automaster('A', 'B', 'C', 'D'),
+                                 'present')
+
+        mock = MagicMock(return_value=True)
+        with patch.object(os.path, 'isfile', mock):
+            with patch('salt.utils.files.fopen',
+                       mock_open(read_data='/..A -fstype=XX C:B')):
+                self.assertEqual(mount.set_automaster('A', 'B', 'C', 'D',
+                                                      not_change=True),
+                                 'present')
 
     def test_automaster(self):
         '''
@@ -284,7 +327,7 @@ class MountTestCase(TestCase, LoaderModuleMockMixin):
         with patch.dict(mount.__grains__, {'os': 'AIX', 'kernel': 'AIX'}):
             with patch.object(os.path, 'isfile', mock):
                 self.assertRaises(CommandExecutionError,
-                              mount.set_filesystems, 'A', 'B', 'C')
+                                  mount.set_filesystems, 'A', 'B', 'C')
 
             mock_read = MagicMock(side_effect=OSError)
             with patch.object(os.path, 'isfile', mock):

--- a/tests/unit/states/test_mount.py
+++ b/tests/unit/states/test_mount.py
@@ -534,7 +534,8 @@ class MountTestCase(TestCase, LoaderModuleMockMixin):
                                                                  fstype='ext2',
                                                                  opts='noowners',
                                                                  config='/etc/auto_salt',
-                                                                 test=True)
+                                                                 test=True,
+                                                                 not_change=False)
 
     def test_fstab_present_aix_test_present(self):
         '''
@@ -563,7 +564,8 @@ class MountTestCase(TestCase, LoaderModuleMockMixin):
                                                                   opts='',
                                                                   config='/etc/filesystems',
                                                                   test=True,
-                                                                  match_on='auto')
+                                                                  match_on='auto',
+                                                                  not_change=False)
 
     def test_fstab_present_test_present(self):
         '''
@@ -593,7 +595,8 @@ class MountTestCase(TestCase, LoaderModuleMockMixin):
                                                             pass_num=0,
                                                             config='/etc/fstab',
                                                             test=True,
-                                                            match_on='auto')
+                                                            match_on='auto',
+                                                            not_change=False)
 
     def test_fstab_present_test_new(self):
         '''
@@ -623,7 +626,8 @@ class MountTestCase(TestCase, LoaderModuleMockMixin):
                                                             pass_num=0,
                                                             config='/etc/fstab',
                                                             test=True,
-                                                            match_on='auto')
+                                                            match_on='auto',
+                                                            not_change=False)
 
     def test_fstab_present_test_change(self):
         '''
@@ -653,7 +657,8 @@ class MountTestCase(TestCase, LoaderModuleMockMixin):
                                                             pass_num=0,
                                                             config='/etc/fstab',
                                                             test=True,
-                                                            match_on='auto')
+                                                            match_on='auto',
+                                                            not_change=False)
 
     def test_fstab_present_test_error(self):
         '''
@@ -683,7 +688,8 @@ class MountTestCase(TestCase, LoaderModuleMockMixin):
                                                             pass_num=0,
                                                             config='/etc/fstab',
                                                             test=True,
-                                                            match_on='auto')
+                                                            match_on='auto',
+                                                            not_change=False)
 
     def test_fstab_present_macos_present(self):
         '''
@@ -709,7 +715,8 @@ class MountTestCase(TestCase, LoaderModuleMockMixin):
                                                                  device='/dev/sda1',
                                                                  fstype='ext2',
                                                                  opts='noowners',
-                                                                 config='/etc/auto_salt')
+                                                                 config='/etc/auto_salt',
+                                                                 not_change=False)
 
     def test_fstab_present_aix_present(self):
         '''
@@ -737,7 +744,8 @@ class MountTestCase(TestCase, LoaderModuleMockMixin):
                                                                   mount=True,
                                                                   opts='',
                                                                   config='/etc/filesystems',
-                                                                  match_on='auto')
+                                                                  match_on='auto',
+                                                                  not_change=False)
 
     def test_fstab_present_present(self):
         '''
@@ -766,7 +774,8 @@ class MountTestCase(TestCase, LoaderModuleMockMixin):
                                                             dump=0,
                                                             pass_num=0,
                                                             config='/etc/fstab',
-                                                            match_on='auto')
+                                                            match_on='auto',
+                                                            not_change=False)
 
     def test_fstab_present_new(self):
         '''
@@ -795,7 +804,8 @@ class MountTestCase(TestCase, LoaderModuleMockMixin):
                                                             dump=0,
                                                             pass_num=0,
                                                             config='/etc/fstab',
-                                                            match_on='auto')
+                                                            match_on='auto',
+                                                            not_change=False)
 
     def test_fstab_present_change(self):
         '''
@@ -824,7 +834,8 @@ class MountTestCase(TestCase, LoaderModuleMockMixin):
                                                             dump=0,
                                                             pass_num=0,
                                                             config='/etc/fstab',
-                                                            match_on='auto')
+                                                            match_on='auto',
+                                                            not_change=False)
 
     def test_fstab_present_fail(self):
         '''
@@ -853,7 +864,8 @@ class MountTestCase(TestCase, LoaderModuleMockMixin):
                                                             dump=0,
                                                             pass_num=0,
                                                             config='/etc/fstab',
-                                                            match_on='auto')
+                                                            match_on='auto',
+                                                            not_change=False)
 
     def test_fstab_absent_macos_test_absent(self):
         '''


### PR DESCRIPTION
### What does this PR do?
The current 'set_' family search the entry based on a 'match_on'
parameter. If the line is found check that there is no difference
between the expectations and the present line. If there are changes
this line gets replaced.

This default behaviour is the correct one in cases where the Salt
code owns all the changes made on entries. But in some scenarios
we do not want to overwrite the line if is already present, even
if there are diferences in other parameters, like the option field.

This patch add a new parameter, 'not_change', that if is True will
not overwrite the present line in any case.

Also update the `mount` state to transfer this new parameter.

### Tests written?

Yes
