### PR TITLE
Backport #52852 into 2018.3

### DIFF
--- a/salt/utils/args.py
+++ b/salt/utils/args.py
@@ -8,6 +8,7 @@ from __future__ import absolute_import, print_function, unicode_literals
 import copy
 import fnmatch
 import inspect
+import logging
 import re
 import shlex
 
@@ -19,6 +20,8 @@ import salt.utils.data
 import salt.utils.jid
 import salt.utils.versions
 import salt.utils.yaml
+
+log = logging.getLogger(__name__)
 
 
 if six.PY3:

--- a/tests/unit/utils/test_args.py
+++ b/tests/unit/utils/test_args.py
@@ -13,7 +13,6 @@ import salt.utils.args
 # Import Salt Testing Libs
 from tests.support.unit import TestCase, skipIf
 from tests.support.mock import (
-    create_autospec,
     DEFAULT,
     NO_MOCK,
     NO_MOCK_REASON,
@@ -127,11 +126,13 @@ class ArgsTestCase(TestCase):
         def _test_spec(arg1, arg2, kwarg1=None):
             pass
 
-        sys_mock = create_autospec(_test_spec)
-        test_functions = {'test_module.test_spec': sys_mock}
+        test_functions = {'test_module.test_spec': _test_spec}
         ret = salt.utils.args.argspec_report(test_functions, 'test_module.test_spec')
         self.assertDictEqual(ret, {'test_module.test_spec':
-                                       {'kwargs': True, 'args': None, 'defaults': None, 'varargs': True}})
+                                       {'kwargs': None,
+                                        'args': ['arg1', 'arg2', 'kwarg1'],
+                                        'defaults': (None, ),
+                                        'varargs': None}})
 
     def test_test_mode(self):
         self.assertTrue(salt.utils.args.test_mode(test=True))


### PR DESCRIPTION
Backport #52852 into 2018.3