### PR TITLE
Always run the full test suite on the 2019.2.1 release branch

### DIFF
--- a/.ci/kitchen-centos6-py2
+++ b/.ci/kitchen-centos6-py2
@@ -6,7 +6,7 @@ properties([
         $class: 'RebuildSettings', autoRebuild: false, rebuildDisabled: false
     ],
     parameters([
-        booleanParam(defaultValue: false, description: 'Run full test suite', name: 'runFull')
+        booleanParam(defaultValue: true, description: 'Run full test suite', name: 'runFull')
     ])
 ])
 timeout(time: 8, unit: 'HOURS') {

--- a/.ci/kitchen-centos7-py2
+++ b/.ci/kitchen-centos7-py2
@@ -6,7 +6,7 @@ properties([
         $class: 'RebuildSettings', autoRebuild: false, rebuildDisabled: false
     ],
     parameters([
-        booleanParam(defaultValue: false, description: 'Run full test suite', name: 'runFull')
+        booleanParam(defaultValue: true, description: 'Run full test suite', name: 'runFull')
     ])
 ])
 timeout(time: 8, unit: 'HOURS') {

--- a/.ci/kitchen-centos7-py3
+++ b/.ci/kitchen-centos7-py3
@@ -6,7 +6,7 @@ properties([
         $class: 'RebuildSettings', autoRebuild: false, rebuildDisabled: false
     ],
     parameters([
-        booleanParam(defaultValue: false, description: 'Run full test suite', name: 'runFull')
+        booleanParam(defaultValue: true, description: 'Run full test suite', name: 'runFull')
     ])
 ])
 timeout(time: 6, unit: 'HOURS') {

--- a/.ci/kitchen-debian8-py2
+++ b/.ci/kitchen-debian8-py2
@@ -6,7 +6,7 @@ properties([
         $class: 'RebuildSettings', autoRebuild: false, rebuildDisabled: false
     ],
     parameters([
-        booleanParam(defaultValue: false, description: 'Run full test suite', name: 'runFull')
+        booleanParam(defaultValue: true, description: 'Run full test suite', name: 'runFull')
     ])
 ])
 timeout(time: 8, unit: 'HOURS') {

--- a/.ci/kitchen-debian8-py3
+++ b/.ci/kitchen-debian8-py3
@@ -6,7 +6,7 @@ properties([
         $class: 'RebuildSettings', autoRebuild: false, rebuildDisabled: false
     ],
     parameters([
-        booleanParam(defaultValue: false, description: 'Run full test suite', name: 'runFull')
+        booleanParam(defaultValue: true, description: 'Run full test suite', name: 'runFull')
     ])
 ])
 timeout(time: 6, unit: 'HOURS') {

--- a/.ci/kitchen-debian9-py2
+++ b/.ci/kitchen-debian9-py2
@@ -6,7 +6,7 @@ properties([
         $class: 'RebuildSettings', autoRebuild: false, rebuildDisabled: false
     ],
     parameters([
-        booleanParam(defaultValue: false, description: 'Run full test suite', name: 'runFull')
+        booleanParam(defaultValue: true, description: 'Run full test suite', name: 'runFull')
     ])
 ])
 timeout(time: 6, unit: 'HOURS') {

--- a/.ci/kitchen-debian9-py3
+++ b/.ci/kitchen-debian9-py3
@@ -6,7 +6,7 @@ properties([
         $class: 'RebuildSettings', autoRebuild: false, rebuildDisabled: false
     ],
     parameters([
-        booleanParam(defaultValue: false, description: 'Run full test suite', name: 'runFull')
+        booleanParam(defaultValue: true, description: 'Run full test suite', name: 'runFull')
     ])
 ])
 timeout(time: 6, unit: 'HOURS') {

--- a/.ci/kitchen-ubuntu1604-py2
+++ b/.ci/kitchen-ubuntu1604-py2
@@ -6,7 +6,7 @@ properties([
         $class: 'RebuildSettings', autoRebuild: false, rebuildDisabled: false
     ],
     parameters([
-        booleanParam(defaultValue: false, description: 'Run full test suite', name: 'runFull')
+        booleanParam(defaultValue: true, description: 'Run full test suite', name: 'runFull')
     ])
 ])
 timeout(time: 6, unit: 'HOURS') {

--- a/.ci/kitchen-ubuntu1604-py3
+++ b/.ci/kitchen-ubuntu1604-py3
@@ -6,7 +6,7 @@ properties([
         $class: 'RebuildSettings', autoRebuild: false, rebuildDisabled: false
     ],
     parameters([
-        booleanParam(defaultValue: false, description: 'Run full test suite', name: 'runFull')
+        booleanParam(defaultValue: true, description: 'Run full test suite', name: 'runFull')
     ])
 ])
 timeout(time: 6, unit: 'HOURS') {

--- a/.ci/kitchen-ubuntu1804-py2
+++ b/.ci/kitchen-ubuntu1804-py2
@@ -6,7 +6,7 @@ properties([
         $class: 'RebuildSettings', autoRebuild: false, rebuildDisabled: false
     ],
     parameters([
-        booleanParam(defaultValue: false, description: 'Run full test suite', name: 'runFull')
+        booleanParam(defaultValue: true, description: 'Run full test suite', name: 'runFull')
     ])
 ])
 timeout(time: 6, unit: 'HOURS') {

--- a/.ci/kitchen-ubuntu1804-py3
+++ b/.ci/kitchen-ubuntu1804-py3
@@ -6,7 +6,7 @@ properties([
         $class: 'RebuildSettings', autoRebuild: false, rebuildDisabled: false
     ],
     parameters([
-        booleanParam(defaultValue: false, description: 'Run full test suite', name: 'runFull')
+        booleanParam(defaultValue: true, description: 'Run full test suite', name: 'runFull')
     ])
 ])
 timeout(time: 6, unit: 'HOURS') {

--- a/.ci/kitchen-windows2016-py2
+++ b/.ci/kitchen-windows2016-py2
@@ -6,7 +6,7 @@ properties([
         $class: 'RebuildSettings', autoRebuild: false, rebuildDisabled: false
     ],
     parameters([
-        booleanParam(defaultValue: false, description: 'Run full test suite', name: 'runFull')
+        booleanParam(defaultValue: true, description: 'Run full test suite', name: 'runFull')
     ])
 ])
 timeout(time: 6, unit: 'HOURS') {

--- a/.ci/kitchen-windows2016-py3
+++ b/.ci/kitchen-windows2016-py3
@@ -6,7 +6,7 @@ properties([
         $class: 'RebuildSettings', autoRebuild: false, rebuildDisabled: false
     ],
     parameters([
-        booleanParam(defaultValue: false, description: 'Run full test suite', name: 'runFull')
+        booleanParam(defaultValue: true, description: 'Run full test suite', name: 'runFull')
     ])
 ])
 timeout(time: 8, unit: 'HOURS') {


### PR DESCRIPTION
### What does this PR do?
Always run the full test suite on the 2019.2.1 release branch

This change should not be merged forward to 2019.2