### PR TITLE
add files.abspath to the file module

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -7142,6 +7142,21 @@ def normpath(path):
     return os.path.normpath(path)
 
 
+def abspath(path):
+    '''
+    Returns a normalized absolutized version of the pathname 'path'.
+
+    .. versionadded:: Neon
+
+    This can be useful when scripting for commands which require an absolute path.
+
+    .. code-block:: jinja
+
+        {%- set my_files_dir salt['file.abspath']('../files/') %}
+    '''
+    return os.path.abspath(path)
+
+
 def basename(path):
     """
     Returns the final component of a pathname

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -7143,7 +7143,7 @@ def normpath(path):
 
 
 def abspath(path):
-    '''
+    """
     Returns a normalized absolutized version of the pathname 'path'.
 
     .. versionadded:: Neon
@@ -7153,7 +7153,7 @@ def abspath(path):
     .. code-block:: jinja
 
         {%- set my_files_dir salt['file.abspath']('../files/') %}
-    '''
+    """
     return os.path.abspath(path)
 
 

--- a/salt/modules/win_file.py
+++ b/salt/modules/win_file.py
@@ -60,8 +60,6 @@ from salt.modules.file import (
     _get_bkroot,
     _get_eol,
     _get_flags,
-    _insert_line_after,
-    _insert_line_before,
     _mkstemp_copy,
     _psed,
     _regex_to_static,
@@ -70,7 +68,6 @@ from salt.modules.file import (
     _set_line_eol,
     _set_line_indent,
     _splitlines_preserving_trailing_newline,
-    _starts_till,
     abspath,
     access,
     append,
@@ -190,7 +187,6 @@ def __virtual__():
             global _set_line_eol, _get_eol, _set_line, _regex_to_static
             global _set_line_indent, dirname, basename, abspath
             global list_backups_dir, normpath_, _assert_occurrence
-            global _starts_till, _insert_line_before, _insert_line_after
 
             replace = _namespaced_function(replace, globals())
             search = _namespaced_function(search, globals())

--- a/salt/modules/win_file.py
+++ b/salt/modules/win_file.py
@@ -102,7 +102,6 @@ from salt.modules.file import (
     manage_file,
 )
 from salt.modules.file import normpath as normpath_
-from salt.modules.file import normpath as normpath_
 from salt.modules.file import (
     pardir,
     path_exists_glob,
@@ -184,9 +183,7 @@ def __virtual__():
             global path_exists_glob, comment, uncomment, _mkstemp_copy
             global _regex_to_static, _set_line_indent, dirname, basename
             global list_backups_dir, normpath_, _assert_occurrence
-            global _set_line_eol, _get_eol, _set_line, _regex_to_static
-            global _set_line_indent, dirname, basename, abspath
-            global list_backups_dir, normpath_, _assert_occurrence
+            global _set_line_eol, _get_eol, _set_line, abspath
 
             replace = _namespaced_function(replace, globals())
             search = _namespaced_function(search, globals())
@@ -259,7 +256,6 @@ def __virtual__():
             list_backups_dir = _namespaced_function(list_backups_dir, globals())
             normpath_ = _namespaced_function(normpath_, globals())
             _assert_occurrence = _namespaced_function(_assert_occurrence, globals())
-            _starts_till = _namespaced_function(_starts_till, globals())
             abspath = _namespaced_function(abspath, globals())
 
         else:

--- a/salt/modules/win_file.py
+++ b/salt/modules/win_file.py
@@ -263,6 +263,8 @@ def __virtual__():
             list_backups_dir = _namespaced_function(list_backups_dir, globals())
             normpath_ = _namespaced_function(normpath_, globals())
             _assert_occurrence = _namespaced_function(_assert_occurrence, globals())
+            _starts_till = _namespaced_function(_starts_till, globals())
+            abspath = _namespaced_function(abspath, globals())
 
         else:
             return False, "Module win_file: Missing Win32 modules"

--- a/salt/modules/win_file.py
+++ b/salt/modules/win_file.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Manage information about files on the minion, set/read user, group
 data, modify the ACL of files/directories
@@ -8,7 +7,6 @@ data, modify the ACL of files/directories
             - win32con
             - salt.utils.win_dacl
 """
-from __future__ import absolute_import, print_function, unicode_literals
 
 # pylint: disable=unused-import
 import contextlib  # do not remove, used in imported file.py functions
@@ -23,8 +21,6 @@ import itertools  # same as above, do not remove, it's used in __clean_tmp
 import logging
 import mmap  # do not remove, used in imported file.py functions
 import operator  # do not remove
-
-# Import python libs
 import os
 import os.path
 import re  # do not remove, used in imported file.py functions
@@ -37,8 +33,6 @@ from collections.abc import Iterable, Mapping
 from functools import reduce  # do not remove
 
 import salt.utils.atomicfile  # do not remove, used in imported file.py functions
-
-# Import salt libs
 import salt.utils.path
 import salt.utils.platform
 import salt.utils.user
@@ -291,7 +285,7 @@ def _resolve_symlink(path, max_depth=64):
         )
 
     # make sure we don't get stuck in a symlink loop!
-    paths_seen = set((path,))
+    paths_seen = {path}
     cur_depth = 0
     while is_link(path):
         path = readlink(path)
@@ -329,7 +323,7 @@ def gid_to_group(gid):
 
         salt '*' file.gid_to_group S-1-5-21-626487655-2533044672-482107328-1010
     """
-    func_name = "{0}.gid_to_group".format(__virtualname__)
+    func_name = "{}.gid_to_group".format(__virtualname__)
     if __opts__.get("fun", "") == func_name:
         log.info(
             "The function %s should not be used on Windows systems; "
@@ -364,7 +358,7 @@ def group_to_gid(group):
 
         salt '*' file.group_to_gid administrators
     """
-    func_name = "{0}.group_to_gid".format(__virtualname__)
+    func_name = "{}.group_to_gid".format(__virtualname__)
     if __opts__.get("fun", "") == func_name:
         log.info(
             "The function %s should not be used on Windows systems; "
@@ -406,7 +400,7 @@ def get_pgid(path, follow_symlinks=True):
         salt '*' file.get_pgid c:\\temp\\test.txt
     """
     if not os.path.exists(path):
-        raise CommandExecutionError("Path not found: {0}".format(path))
+        raise CommandExecutionError("Path not found: {}".format(path))
 
     # Under Windows, if the path is a symlink, the user that owns the symlink is
     # returned, not the user that owns the file/directory the symlink is
@@ -490,7 +484,7 @@ def get_gid(path, follow_symlinks=True):
 
         salt '*' file.get_gid c:\\temp\\test.txt
     """
-    func_name = "{0}.get_gid".format(__virtualname__)
+    func_name = "{}.get_gid".format(__virtualname__)
     if __opts__.get("fun", "") == func_name:
         log.info(
             "The function %s should not be used on Windows systems; "
@@ -537,7 +531,7 @@ def get_group(path, follow_symlinks=True):
 
         salt '*' file.get_group c:\\temp\\test.txt
     """
-    func_name = "{0}.get_group".format(__virtualname__)
+    func_name = "{}.get_group".format(__virtualname__)
     if __opts__.get("fun", "") == func_name:
         log.info(
             "The function %s should not be used on Windows systems; "
@@ -619,7 +613,7 @@ def get_uid(path, follow_symlinks=True):
         salt '*' file.get_uid c:\\temp\\test.txt follow_symlinks=False
     """
     if not os.path.exists(path):
-        raise CommandExecutionError("Path not found: {0}".format(path))
+        raise CommandExecutionError("Path not found: {}".format(path))
 
     # Under Windows, if the path is a symlink, the user that owns the symlink is
     # returned, not the user that owns the file/directory the symlink is
@@ -659,7 +653,7 @@ def get_user(path, follow_symlinks=True):
         salt '*' file.get_user c:\\temp\\test.txt follow_symlinks=False
     """
     if not os.path.exists(path):
-        raise CommandExecutionError("Path not found: {0}".format(path))
+        raise CommandExecutionError("Path not found: {}".format(path))
 
     # Under Windows, if the path is a symlink, the user that owns the symlink is
     # returned, not the user that owns the file/directory the symlink is
@@ -692,9 +686,9 @@ def get_mode(path):
         salt '*' file.get_mode /etc/passwd
     """
     if not os.path.exists(path):
-        raise CommandExecutionError("Path not found: {0}".format(path))
+        raise CommandExecutionError("Path not found: {}".format(path))
 
-    func_name = "{0}.get_mode".format(__virtualname__)
+    func_name = "{}.get_mode".format(__virtualname__)
     if __opts__.get("fun", "") == func_name:
         log.info(
             "The function %s should not be used on Windows systems; "
@@ -743,7 +737,7 @@ def lchown(path, user, group=None, pgroup=None):
         salt '*' file.lchown c:\\temp\\test.txt myusername "pgroup='None'"
     """
     if group:
-        func_name = "{0}.lchown".format(__virtualname__)
+        func_name = "{}.lchown".format(__virtualname__)
         if __opts__.get("fun", "") == func_name:
             log.info(
                 "The group parameter has no effect when using %s on "
@@ -792,7 +786,7 @@ def chown(path, user, group=None, pgroup=None, follow_symlinks=True):
     """
     # the group parameter is not used; only provided for API compatibility
     if group is not None:
-        func_name = "{0}.chown".format(__virtualname__)
+        func_name = "{}.chown".format(__virtualname__)
         if __opts__.get("fun", "") == func_name:
             log.info(
                 "The group parameter has no effect when using %s on "
@@ -805,7 +799,7 @@ def chown(path, user, group=None, pgroup=None, follow_symlinks=True):
         path = _resolve_symlink(path)
 
     if not os.path.exists(path):
-        raise CommandExecutionError("Path not found: {0}".format(path))
+        raise CommandExecutionError("Path not found: {}".format(path))
 
     salt.utils.win_dacl.set_owner(path, user)
     if pgroup:
@@ -876,7 +870,7 @@ def chgrp(path, group):
 
         salt '*' file.chpgrp c:\\temp\\test.txt administrators
     """
-    func_name = "{0}.chgrp".format(__virtualname__)
+    func_name = "{}.chgrp".format(__virtualname__)
     if __opts__.get("fun", "") == func_name:
         log.info(
             "The function %s should not be used on Windows systems; see "
@@ -922,7 +916,7 @@ def stats(path, hash_type="sha256", follow_symlinks=True):
     # This is to mirror the behavior of file.py. `check_file_meta` expects an
     # empty dictionary when the file does not exist
     if not os.path.exists(path):
-        raise CommandExecutionError("Path not found: {0}".format(path))
+        raise CommandExecutionError("Path not found: {}".format(path))
 
     if follow_symlinks and sys.getwindowsversion().major >= 6:
         path = _resolve_symlink(path)
@@ -983,7 +977,7 @@ def get_attributes(path):
         salt '*' file.get_attributes c:\\temp\\a.txt
     """
     if not os.path.exists(path):
-        raise CommandExecutionError("Path not found: {0}".format(path))
+        raise CommandExecutionError("Path not found: {}".format(path))
 
     # set up dictionary for attribute values
     attributes = {}
@@ -1065,7 +1059,7 @@ def set_attributes(
         salt '*' file.set_attributes c:\\temp\\a.txt readonly=True hidden=True
     """
     if not os.path.exists(path):
-        raise CommandExecutionError("Path not found: {0}".format(path))
+        raise CommandExecutionError("Path not found: {}".format(path))
 
     if normal:
         if archive or hidden or notIndexed or readonly or system or temporary:
@@ -1134,7 +1128,7 @@ def set_mode(path, mode):
 
         salt '*' file.set_mode /etc/passwd 0644
     """
-    func_name = "{0}.set_mode".format(__virtualname__)
+    func_name = "{}.set_mode".format(__virtualname__)
     if __opts__.get("fun", "") == func_name:
         log.info(
             "The function %s should not be used on Windows systems; "
@@ -1170,11 +1164,11 @@ def remove(path, force=False):
     path = os.path.expanduser(path)
 
     if not os.path.isabs(path):
-        raise SaltInvocationError("File path must be absolute: {0}".format(path))
+        raise SaltInvocationError("File path must be absolute: {}".format(path))
 
     # Does the file/folder exists
     if not os.path.exists(path) and not is_link(path):
-        raise CommandExecutionError("Path not found: {0}".format(path))
+        raise CommandExecutionError("Path not found: {}".format(path))
 
     # Remove ReadOnly Attribute
     if force:
@@ -1191,17 +1185,17 @@ def remove(path, force=False):
             os.rmdir(path)
         else:
             for name in os.listdir(path):
-                item = "{0}\\{1}".format(path, name)
+                item = "{}\\{}".format(path, name)
                 # If its a normal directory, recurse to remove it's contents
                 remove(item, force)
 
             # rmdir will work now because the directory is empty
             os.rmdir(path)
-    except (OSError, IOError) as exc:
+    except OSError as exc:
         if force:
             # Reset attributes to the original if delete fails.
             win32api.SetFileAttributes(path, file_attributes)
-        raise CommandExecutionError("Could not remove '{0}': {1}".format(path, exc))
+        raise CommandExecutionError("Could not remove '{}': {}".format(path, exc))
 
     return True
 
@@ -1259,9 +1253,7 @@ def symlink(src, link):
         return True
     except win32file.error as exc:
         raise CommandExecutionError(
-            "Could not create '{0}' - [{1}] {2}".format(
-                link, exc.winerror, exc.strerror
-            )
+            "Could not create '{}' - [{}] {}".format(link, exc.winerror, exc.strerror)
         )
 
 
@@ -1329,7 +1321,7 @@ def readlink(path):
         return salt.utils.path.readlink(path)
     except OSError as exc:
         if exc.errno == errno.EINVAL:
-            raise CommandExecutionError("{0} is not a symbolic link".format(path))
+            raise CommandExecutionError("{} is not a symbolic link".format(path))
         raise CommandExecutionError(exc.__str__())
     except Exception as exc:  # pylint: disable=broad-except
         raise CommandExecutionError(exc)
@@ -1408,7 +1400,7 @@ def mkdir(
     # Make sure the drive is valid
     drive = os.path.splitdrive(path)[0]
     if not os.path.isdir(drive):
-        raise CommandExecutionError("Drive {0} is not mapped".format(drive))
+        raise CommandExecutionError("Drive {} is not mapped".format(drive))
 
     path = os.path.expanduser(path)
     path = os.path.expandvars(path)
@@ -1432,7 +1424,7 @@ def mkdir(
                 reset=reset,
             )
 
-        except WindowsError as exc:
+        except OSError as exc:
             raise CommandExecutionError(exc)
 
     return True
@@ -1524,12 +1516,12 @@ def makedirs_(
 
     if os.path.isdir(dirname):
         # There's nothing for us to do
-        msg = "Directory '{0}' already exists".format(dirname)
+        msg = "Directory '{}' already exists".format(dirname)
         log.debug(msg)
         return msg
 
     if os.path.exists(dirname):
-        msg = "The path '{0}' already exists and is not a directory".format(dirname)
+        msg = "The path '{}' already exists and is not a directory".format(dirname)
         log.debug(msg)
         return msg
 
@@ -1544,7 +1536,7 @@ def makedirs_(
 
         if current_dirname == dirname:
             raise SaltInvocationError(
-                "Recursive creation for path '{0}' would result in an "
+                "Recursive creation for path '{}' would result in an "
                 "infinite loop. Please use an absolute path.".format(dirname)
             )
 
@@ -1738,7 +1730,7 @@ def check_perms(
         salt '*' file.check_perms C:\\Temp\\ {} Administrators "{'jsnuffy': {'perms': ['read_attributes', 'read_ea'], 'applies_to': 'files_only'}}"
     """
     if not os.path.exists(path):
-        raise CommandExecutionError("Path not found: {0}".format(path))
+        raise CommandExecutionError("Path not found: {}".format(path))
 
     path = os.path.expanduser(path)
 

--- a/salt/modules/win_file.py
+++ b/salt/modules/win_file.py
@@ -60,6 +60,8 @@ from salt.modules.file import (
     _get_bkroot,
     _get_eol,
     _get_flags,
+    _insert_line_after,
+    _insert_line_before,
     _mkstemp_copy,
     _psed,
     _regex_to_static,
@@ -68,6 +70,8 @@ from salt.modules.file import (
     _set_line_eol,
     _set_line_indent,
     _splitlines_preserving_trailing_newline,
+    _starts_till,
+    abspath,
     access,
     append,
     apply_template_on_contents,
@@ -100,6 +104,7 @@ from salt.modules.file import (
     lstat,
     manage_file,
 )
+from salt.modules.file import normpath as normpath_
 from salt.modules.file import normpath as normpath_
 from salt.modules.file import (
     pardir,
@@ -182,8 +187,10 @@ def __virtual__():
             global path_exists_glob, comment, uncomment, _mkstemp_copy
             global _regex_to_static, _set_line_indent, dirname, basename
             global list_backups_dir, normpath_, _assert_occurrence
-            global _set_line_eol, _get_eol
-            global _set_line
+            global _set_line_eol, _get_eol, _set_line, _regex_to_static
+            global _set_line_indent, dirname, basename, abspath
+            global list_backups_dir, normpath_, _assert_occurrence
+            global _starts_till, _insert_line_before, _insert_line_after
 
             replace = _namespaced_function(replace, globals())
             search = _namespaced_function(search, globals())

--- a/tests/unit/modules/test_file.py
+++ b/tests/unit/modules/test_file.py
@@ -3731,7 +3731,8 @@ class PathStringFunctionsTests(TestCase):
         The _normpath_ method works
         """
         if salt.utils.platform.is_windows():
-            expected_path = r"C:\tmp\this\is"
+            # normpath won't add the drive
+            expected_path = r"\tmp\this\is"
         else:
             expected_path = "/tmp/this/is"
         unnorm = "/tmp/this/is/not/normalized/../../"

--- a/tests/unit/modules/test_file.py
+++ b/tests/unit/modules/test_file.py
@@ -3727,16 +3727,16 @@ class FileSelinuxTestCase(TestCase, LoaderModuleMockMixin):
 
 class PathStringFunctionsTests(TestCase):
     def test__normpath(self):
-        '''
+        """
         The _normpath_ method works
-        '''
-        unnorm = '/tmp/this/is/not/normalized/../../'
+        """
+        unnorm = "/tmp/this/is/not/normalized/../../"
         normalized = filemod.normpath(unnorm)
-        assert normalized == '/tmp/this/is'
+        assert normalized == "/tmp/this/is"
 
-        def test__abspath(self):
-            '''
-            The _abspath_ method works
-            '''
-            absolute = filemod.abspath('.')
-            assert absolute == filemod.normpath(os.getcwd())
+    def test__abspath(self):
+        """
+        The _abspath_ method works
+        """
+        absolute = filemod.abspath(".")
+        assert absolute == filemod.normpath(os.getcwd())

--- a/tests/unit/modules/test_file.py
+++ b/tests/unit/modules/test_file.py
@@ -3723,3 +3723,20 @@ class FileSelinuxTestCase(TestCase, LoaderModuleMockMixin):
                 serange=None,
             )
             self.assertEqual(result, expected_result)
+
+
+class PathStringFunctionsTests(TestCase):
+    def test__normpath(self):
+        '''
+        The _normpath_ method works
+        '''
+        unnorm = '/tmp/this/is/not/normalized/../../'
+        normalized = filemod.normpath(unnorm)
+        assert normalized == '/tmp/this/is'
+
+        def test__abspath(self):
+            '''
+            The _abspath_ method works
+            '''
+            absolute = filemod.abspath('.')
+            assert absolute == filemod.normpath(os.getcwd())

--- a/tests/unit/modules/test_file.py
+++ b/tests/unit/modules/test_file.py
@@ -3730,9 +3730,15 @@ class PathStringFunctionsTests(TestCase):
         """
         The _normpath_ method works
         """
+        if salt.utils.platform.is_windows():
+            expected_path = r"C:\tmp\this\is"
+        else:
+            expected_path = "/tmp/this/is"
         unnorm = "/tmp/this/is/not/normalized/../../"
         normalized = filemod.normpath(unnorm)
-        assert normalized == "/tmp/this/is"
+        assert (
+            normalized == expected_path
+        ), f"Expected {expected_path}, was {normalized}"
 
     def test__abspath(self):
         """

--- a/tests/unit/modules/test_file.py
+++ b/tests/unit/modules/test_file.py
@@ -3736,9 +3736,9 @@ class PathStringFunctionsTests(TestCase):
             expected_path = "/tmp/this/is"
         unnorm = "/tmp/this/is/not/normalized/../../"
         normalized = filemod.normpath(unnorm)
-        assert (
-            normalized == expected_path
-        ), f"Expected {expected_path}, was {normalized}"
+        assert normalized == expected_path, "Expected {}, was {}".format(
+            expected_path, normalized
+        )
 
     def test__abspath(self):
         """


### PR DESCRIPTION
### What does this PR do?

Creates an additional function in the `files` module for `abspath`.

### What issues does this PR fix or reference?

Occasionally in complex scripts, it is necessary to supply a parameter which is required to be an absolute path. This is trivial in most cases.  

In my use case, my user is (indirectly) running salt-call to deploy a build environment into a child of his source directory -- wherever that might be. Inside the system, I have a number of salt state calls (like virtualenv.managed) which require an absolute path. My final solution requires that the user execute `sudo salt-call --config-dir=a_local_directory ...` from which I can determine my absolute path based on `opts['config_dir']`. That is both obscure and brittle, and took me a day to discover. 

My first instinct was to simply call `files.abspath` -- but I found that it did not exist.

### Tests written?

Yes, also includes a unit test for files.normpath.

### Commits signed with GPG?

Yes, except for the first one.
