### PR TITLE
Fix `integration.states.test_pip_state.PipStateTest.test_issue_2028_pip_installed_state` on Windows

### DIFF
--- a/tests/integration/files/file/base/_modules/runtests_helpers.py
+++ b/tests/integration/files/file/base/_modules/runtests_helpers.py
@@ -172,5 +172,5 @@ def get_python_executable():
             python_binary = None
     except AttributeError:
         # We're not running inside a virtualenv
-        python_binary = None
+        python_binary = sys.executable
     return python_binary


### PR DESCRIPTION
### What does this PR do?
Fixes the `integration.states.test_pip_state.PipStateTest.test_issue_2028_pip_installed_state` test on Windows. The `get_python_executable` helper function was returning None if it wasn't in a virtualenv environment. This returns the path to the calling python.

### What issues does this PR fix or reference?
jenkins

### Tests written?
No

### Commits signed with GPG?
Yes