### PR TITLE
Fix GCE Windows instances being identified as physical by core grains

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -667,6 +667,9 @@ def _windows_virtual(osdata):
     elif 'CloudStack KVM Hypervisor' in productname:
         grains['virtual'] = 'kvm'
         grains['virtual_subtype'] = 'cloudstack'
+    # Google Compute Engine
+    elif 'Google Compute Engine' in productname:
+        grains['virtual'] = 'gce'
     return grains
 
 


### PR DESCRIPTION
### What does this PR do?
Fixes GCE Windows instances being identified as physical by core grains

### Previous Behavior
GCE Windows instances had 'virtual' grain set to 'physical'

### New Behavior
GCE Windows instances will have 'virtual' grain set to 'gce' (the same as Linux GCE instances)

### Tests written?

No

### Commits signed with GPG?

No

