### PR TITLE
Bugfix: Handle multibyte characters spanning blocks of received data

### DIFF
--- a/salt/utils/vt.py
+++ b/salt/utils/vt.py
@@ -652,7 +652,7 @@ class Terminal(object):
                             )
                             break
                         except UnicodeDecodeError as ex:
-                            if (ex.reason == 'unexpected end of data'):
+                            if ex.reason == 'unexpected end of data':
                                 bytes_read += os.read(self.child_fde, maxsize)
                             else:
                                 raise
@@ -694,7 +694,7 @@ class Terminal(object):
                             )
                             break
                         except UnicodeDecodeError as ex:
-                            if (ex.reason == 'unexpected end of data'):
+                            if ex.reason == 'unexpected end of data':
                                 bytes_read += os.read(self.child_fd, maxsize)
                             else:
                                 raise

--- a/salt/utils/vt.py
+++ b/salt/utils/vt.py
@@ -652,8 +652,7 @@ class Terminal(object):
                             )
                             break
                         except UnicodeDecodeError as ex:
-                            if (ex.start == (len(bytes_read) - 1) and
-                                ex.reason == 'unexpected end of data'):
+                            if (ex.reason == 'unexpected end of data'):
                                 bytes_read += os.read(self.child_fde, maxsize)
                             else:
                                 raise
@@ -695,8 +694,7 @@ class Terminal(object):
                             )
                             break
                         except UnicodeDecodeError as ex:
-                            if (ex.start == (len(bytes_read) - 1) and
-                                ex.reason == 'unexpected end of data'):
+                            if (ex.reason == 'unexpected end of data'):
                                 bytes_read += os.read(self.child_fd, maxsize)
                             else:
                                 raise

--- a/salt/utils/vt.py
+++ b/salt/utils/vt.py
@@ -654,7 +654,7 @@ class Terminal(object):
                             new_bytes_read = os.read(fd, maxsize)
                             if new_bytes_read == b'':
                                 # End of stream is an incomplete character
-                                # Raise exception to avoid inifinite loop
+                                # Raise exception to avoid infinite loop
                                 raise
                             bytes_read += new_bytes_read
                         else:

--- a/salt/utils/vt.py
+++ b/salt/utils/vt.py
@@ -649,7 +649,6 @@ class Terminal(object):
                         return self._translate_newlines(
                             salt.utils.stringutils.to_unicode(bytes_read)
                         )
-                        break
                     except UnicodeDecodeError as ex:
                         if ex.reason == 'unexpected end of data':
                             new_bytes_read = os.read(fd, maxsize)


### PR DESCRIPTION
### What does this PR do?
Fix a bug where decoding of received stdout or stderr data into text fails if a multibyte character occurs at the end of one received block of data and extends into the next block of data

### What issues does this PR fix or reference?
Probably this one:
https://github.com/saltstack/salt/issues/48473


### Previous Behaviour
Previously stdout and stderr were received from the client as blocks (usually 1024 bytes) of binary data which was then decoded to strings (usually utf-8).
This process would fail when a multi-byte unicode character occurs at the end of a received block of data with only part of the character in the current block. The decoding would fail with the exception UnicodeDecodeError and the message 'unexpected end of data' and include the position of failure as the end of the block of data.

### New Behaviour
This fix checks for that specific failure case and will then read another block of data and append it to the current block of data so that the unicode character is no longer split across received data blocks. It then attempts to perform decoding on the combined data block. A loop is used to handle the case where the same problem occurred with the new combined block.

The fix checks that the exception is UnicodeDecodeError and the reason is 'unexpected end of data'. This is to prevent an infinite loop that could occurred if some invalid bytes occurred in the output streams (for example if a program spewed some binary data onto stdout) which would cause a UnicodeDecodeError to happen at the first of the encountered invalid characters. The infinite loop is prevented by testing that the reason is 'unexpected end of data' and not 'invalid start byte'.

### Tests written?

No

### Commits signed with GPG?

Yes