### PR TITLE
[2018.3] Revert "Make sure --run-expensive runtests.py arg works"

### DIFF
--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -189,7 +189,6 @@ TEST_SUITES = collections.OrderedDict(sorted(TEST_SUITES_UNORDERED.items(),
 class SaltTestsuiteParser(SaltCoverageTestingParser):
     support_docker_execution = True
     support_destructive_tests_selection = True
-    support_expensive_tests_selection = True
     source_code_basedir = SALT_ROOT
 
     def _get_suites(self, include_unit=False, include_cloud_provider=False,


### PR DESCRIPTION
This reverts commit 56bf06907993202d53ff477ed723277187237416.

This change was causing all cloud tests to get skipped, because expensive tests where not enabled.