### PR TITLE
Fix `unit.modules.test_match` failures

### DIFF
--- a/salt/modules/match.py
+++ b/salt/modules/match.py
@@ -347,7 +347,7 @@ def filter_by(lookup,
         roles: {{ roles | yaml() }}
     '''
     expr_funcs = dict(inspect.getmembers(sys.modules[__name__],
-        predicate=inspect.isfunction))
+                                         predicate=inspect.isfunction))
 
     for key in lookup:
         params = (key, minion_id) if minion_id else (key, )

--- a/tests/unit/modules/test_match.py
+++ b/tests/unit/modules/test_match.py
@@ -47,6 +47,11 @@ class MatchTestCase(TestCase, LoaderModuleMockMixin):
                     'id': MINION_ID
                 }
             },
+            compound_match: {
+                '__opts__': {
+                    'id': MINION_ID
+                }
+            },
             glob_match: {
                 '__opts__': {'id': MINION_ID}
             }


### PR DESCRIPTION
### What does this PR do?
Fixes the following failing tests:
```
unit.modules.test_match.MatchTestCase.test_filter_by
unit.modules.test_match.MatchTestCase.test_filter_by_merge
unit.modules.test_match.MatchTestCase.test_filter_by_merge_fail
unit.modules.test_match.MatchTestCase.test_filter_by_merge_lists_agg
unit.modules.test_match.MatchTestCase.test_filter_by_merge_lists_rep
unit.modules.test_match.MatchTestCase.test_filter_by_merge_with_none
```
`__opts__` wasn't getting set up for `compound_match`

### What issues does this PR fix or reference?
https://jenkinsci.saltstack.com/job/develop/job/salt-windows-2016-py2/27/#showFailuresLink

### Tests written?

Yes

### Commits signed with GPG?

Yes