### PR TITLE
Fallback to image id if we don't have an image name on query

### DIFF
--- a/salt/cloud/clouds/openstack.py
+++ b/salt/cloud/clouds/openstack.py
@@ -414,7 +414,10 @@ def list_nodes_full(conn=None, call=None):
         ret[node.name]['public_ips'] = _get_ips(node, 'public')
         ret[node.name]['floating_ips'] = _get_ips(node, 'floating')
         ret[node.name]['fixed_ips'] = _get_ips(node, 'fixed')
-        ret[node.name]['image'] = node.image.name
+        if isinstance(node.image, six.string_types):
+            ret[node.name]['image'] = node.image
+        else:
+            ret[node.name]['image'] = getattr(conn.get_image(node.image.id), 'name', node.image.id)
     return ret
 
 
@@ -473,7 +476,7 @@ def show_instance(name, conn=None, call=None):
     if isinstance(node.image, six.string_types):
         ret['image'] = node.image
     else:
-        ret['image'] = conn.get_image(node.image.id).name
+        ret['image'] = getattr(conn.get_image(node.image.id), 'name', node.image.id)
     return ret
 
 


### PR DESCRIPTION
### What does this PR do?

When an openstack VM has been instanciated with an image that gets deleted from glance (openstack image store) while the VM is still running, salt-cloud cannot get back the image name. In this case, openstack, only returns the image id but cannot get the nae back. This leads to `salt-cloud -Q` not working.

### What issues does this PR fix or reference?

This PR fixes #52984 and #49438 

### Previous Behavior

```
# salt-cloud -Q -m my-cloud.map 
ovh-gra3:
    ----------
    openstack:
        ----------
        server1.company.tld:
            Absent
```

### New Behavior

```
# salt-cloud -Q -m my-cloud.map 
ovh-gra3:
    ----------
    openstack:
        ----------
        server1.company.tld:
            ----------
            fixed_ips:
                - 1.2.3.4
                - 2001:8d5e:104:9a64::bde:3c46
                - 10.1.2.3
            floating_ips:
            id:
                609467bf-6082-454b-a999-0f3512548260
            image:
                04787255-134b-4c96-b4ac-ac7d81e4467d
            name:
                server1.company.tld
            private_ips:
                - 10.1.2.3
            public_ips:
                - 1.2.3.4
                - 2001:8d5e:104:9a64::bde:3c46
            size:
                b2-7
            state:
                ACTIVE
```

### Tests written?

No

### Commits signed with GPG?

No