### PR TITLE
Fix `unit.modules.test_win_system` tests

### DIFF
--- a/tests/unit/modules/test_win_system.py
+++ b/tests/unit/modules/test_win_system.py
@@ -290,11 +290,11 @@ class WinSystemTestCase(TestCase, LoaderModuleMockMixin):
         with patch.object(win_system, 'get_computer_name',
                           MagicMock(return_value='salt')):
             reg_mock = MagicMock(return_value={'vdata': 'salt'})
-            with patch.dict(win_system.__salt__, {'reg.read_value': reg_mock}):
+            with patch.dict(win_system.__utils__, {'reg.read_value': reg_mock}):
                 self.assertFalse(win_system.get_pending_computer_name())
 
             reg_mock = MagicMock(return_value={'vdata': 'salt_pending'})
-            with patch.dict(win_system.__salt__, {'reg.read_value': reg_mock}):
+            with patch.dict(win_system.__utils__, {'reg.read_value': reg_mock}):
                 self.assertEqual(win_system.get_pending_computer_name(),
                                  'salt_pending')
 


### PR DESCRIPTION
### What does this PR do?
Modules changed to call registry functions directly from the salt utils, so had to mock `__utils__` instead of `__salt__`

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/52866

### Tests written?
Yes

### Commits signed with GPG?
Yes