### PR TITLE
Fix `test.modules.test_win_file` tests on Windows

### DIFF
--- a/tests/unit/modules/test_win_file.py
+++ b/tests/unit/modules/test_win_file.py
@@ -123,7 +123,8 @@ class WinFileCheckPermsTestCase(TestCase, LoaderModuleMockMixin):
         '''
         Test setting the owner of a file with test=True
         '''
-        with patch.dict(win_file.__opts__, {'test': True}):
+        with patch.dict(win_file.__opts__, {'test': True}), \
+                patch.dict(win_dacl.__opts__, {'test': True}):
             expected = {'comment': '',
                         'changes': {'owner': 'Administrators'},
                         'name': self.temp_file.name,
@@ -303,26 +304,3 @@ class WinFileCheckPermsTestCase(TestCase, LoaderModuleMockMixin):
             inheritance=False,
             reset=True)
         self.assertDictEqual(expected, ret)
-
-    def test_issue_52002_check_file_remove_symlink(self):
-        '''
-        Make sure that directories including symlinks or symlinks can be removed
-        '''
-        base = temp.dir(prefix='base-')
-        target = os.path.join(base, 'child 1', 'target\\')
-        symlink = os.path.join(base, 'child 2', 'link')
-        try:
-            # Create environment
-            self.assertFalse(win_file.directory_exists(target))
-            self.assertFalse(win_file.directory_exists(symlink))
-            self.assertTrue(win_file.makedirs_(target))
-            self.assertTrue(win_file.makedirs_(symlink))
-            self.assertTrue(win_file.symlink(target, symlink))
-            self.assertTrue(win_file.directory_exists(symlink))
-            self.assertTrue(win_file.is_link(symlink))
-            # Test removal of directory containing symlink
-            self.assertTrue(win_file.remove(base))
-            self.assertFalse(win_file.directory_exists(base))
-        finally:
-            if os.path.exists(base):
-                win_file.remove(base)


### PR DESCRIPTION
### What does this PR do?
Removed redundant test. Mock `__opts__` for `win_dacl` salt util in the failing test `unit.modules.test_win_file.WinFileCheckPermsTestCase.test_check_perms_set_owner_test_true`

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/52781

### Tests written?
Yes

### Commits signed with GPG?
Yes