### PR TITLE
[2018.3] Fix GitFS support for pygit2 >= 0.28.0

### DIFF
--- a/salt/utils/gitfs.py
+++ b/salt/utils/gitfs.py
@@ -1653,6 +1653,9 @@ class Pygit2(GitProvider):
 
         self.gitdir = salt.utils.path.join(self.repo.workdir, '.git')
         self.enforce_git_config()
+        git_config = os.path.join(self.gitdir, 'config')
+        if os.path.exists(git_config) and PYGIT2_VERSION >= _LooseVersion('0.28.0'):
+            self.repo.config.add_file(git_config)
 
         return new
 


### PR DESCRIPTION
### What does this PR do?
Fix GitFS support for pygit2 >= 0.28.0

### What issues does this PR fix or reference?
None. Failing tests using pygit2 >= 0.28.0

### Previous Behavior
Salt GitFS only supported pygit2 < 0.28.0

### New Behavior
Salt GitFS supports previously supported pygit2 versions including >= 0.28.0

### Tests written?

Yes/No - Fixing.

### Commits signed with GPG?

Yes