### PR TITLE
Change ssh tops log message to debug

### DIFF
--- a/salt/utils/thin.py
+++ b/salt/utils/thin.py
@@ -430,7 +430,7 @@ def gen_thin(cachedir, extra_mods='', overwrite=False, so_mods='',
                 log.error(tops_failure_msg, 'parsing', python3_bin)
                 log.exception(err)
         else:
-            log.error(tops_failure_msg, 'collecting', python3_bin)
+            log.debug(tops_failure_msg, 'collecting', python3_bin)
             log.debug(stderr)
 
     # Collect tops, alternative to 3.x version
@@ -448,7 +448,7 @@ def gen_thin(cachedir, extra_mods='', overwrite=False, so_mods='',
                 log.error(tops_failure_msg, 'parsing', python2_bin)
                 log.exception(err)
         else:
-            log.error(tops_failure_msg, 'collecting', python2_bin)
+            log.debug(tops_failure_msg, 'collecting', python2_bin)
             log.debug(stderr)
 
     with salt.utils.files.fopen(pymap_cfg, 'wb') as fp_:


### PR DESCRIPTION
### What does this PR do?
In the 2019.2 releases a new log message was added when attempting to compile all of the tops. Previously there was not a log message and that's why we are seeing this now. Not everyone that is using salt-ssh is going to want to use both python2 and python3, so I think its better to have this log as a debug message instead. If this is an error most salt-ssh users will see this error message on first run of their salt-ssh command if they do not have salt dependencies installed for both python2 and python3 on their host. The error could also be misleading to let them think there is an issue with their environment when in reality there is not and they can still use salt-ssh. Moving it to debug will still provide the information for users that are trying to use both python versions.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/52637

### Previous Behavior

```
(salt-py2) ➜  salt git:() sudo salt-ssh 'localhost' test.ping
[ERROR   ] Failed collecting tops for Python binary python3.
localhost:
    True
```

### New Behavior

```
(salt-py2) ➜  salt git:() sudo salt-ssh 'localhost' test.ping
localhost:
    True
```

And on debug log level you will see the message now.

### Tests written?

No - cosmetic change. If tests are still required for cosmetic changes i can write one.

### Commits signed with GPG?

Yes