### PR TITLE
saltcheck module updates

### DIFF
--- a/salt/modules/saltcheck.py
+++ b/salt/modules/saltcheck.py
@@ -132,7 +132,7 @@ Saltcheck Keywords
 
             .. code-block:: yaml
 
-                assertion_section: "'Computer Configuration':'System\\Windows Time Service\\Global Configuration Settings':'MaxPollInterval'"
+                assertion_section: 'Computer Configuration:System\\Windows Time Service\\Global Configuration Settings:MaxPollInterval'
 **assertion_section_delimiter**
     (str) The delimiter to use when splitting a neseted structure.
     Defaults to ``salt.defaults.DEFAULT_TARGET_DELIM`` (which is ':')
@@ -232,7 +232,7 @@ Example with a nested assertion_section
         return_full_policy_names: True
       assertion: assertEqual
       expected-return: Enabled
-      assertion_section: "'Computer Configuration'|'Microsoft network client: Digitally sign communications (always)'"
+      assertion_section: 'Computer Configuration|Microsoft network client: Digitally sign communications (always)'
       assertion_section_delimiter: '|'
 
 Example suppressing print results

--- a/salt/modules/saltcheck.py
+++ b/salt/modules/saltcheck.py
@@ -21,7 +21,7 @@ same manner as in salt state files and should be unique and descriptive.
 
 .. versionadded:: Neon
 
-    The ``saltcheck-tests`` folder can be customized using the ``saltcheck_test_location`` minion 
+    The ``saltcheck-tests`` folder can be customized using the ``saltcheck_test_location`` minion
     configuration setting.  This setting is a relative path from the formula's ``salt://`` path
     to the test files.
 
@@ -30,7 +30,7 @@ Usage
 
 Example file system layout:
 
-.. code-block:: txt
+.. code-block:: text
 
     /srv/salt/apache/
         init.sls
@@ -50,7 +50,7 @@ Minion configuration:
 
 Filesystem layout:
 
-.. code-block:: txt
+.. code-block:: text
 
     /srv/salt/apache/
         init.sls
@@ -105,7 +105,7 @@ Saltcheck Keywords
             .. code-block:: yaml
 
                 'Computer Configuration':
-                    'System\Windows Time Service\Global Configuration Settings':
+                    'System\\Windows Time Service\\Global Configuration Settings':
                         ChainDisable: 0
                         ChainEntryTimeout: 2
                         ChainLoggingRate: 0

--- a/salt/modules/saltcheck.py
+++ b/salt/modules/saltcheck.py
@@ -134,7 +134,7 @@ Saltcheck Keywords
 
                 assertion_section:
                     'Computer Configuration':
-                        'System\Windows Time Service\Global Configuration Settings': 'MaxPollInterval'
+                        'System\\Windows Time Service\\Global Configuration Settings': 'MaxPollInterval'
 
 **print_result:**
     (bool) Optional keyword to show results in the ``assertEqual``, ``assertNotEqual``,

--- a/tests/unit/modules/test_saltcheck.py
+++ b/tests/unit/modules/test_saltcheck.py
@@ -54,10 +54,6 @@ class LinuxSysctlTestCase(TestCase, LoaderModuleMockMixin):
             returned = sc_instance._call_salt_command(fun="test.echo", args=['hello'], kwargs=None)
             self.assertEqual(returned, 'hello')
 
-    def test_update_master_cache(self):
-        '''test master cache'''
-        self.assertTrue(saltcheck.update_master_cache)
-
     def test_call_salt_command2(self):
         '''test simple test.echo module again'''
         with patch.dict(saltcheck.__salt__, {'config.get': MagicMock(return_value=True),


### PR DESCRIPTION
### What does this PR do?
Update saltcheck to:

1) not require synchronizing the entire fileserver down to the minion,
tests will be searched and generated from the sls low data

2) allow assertion checking multiple levels into a returned dictionary

3) allow custom saltcheck test locations inside a state/formula's folder

4) provide more information on invalid tests

### What issues does this PR fix or reference?
N/A

### Previous Behavior
1) Entire fileserver tree was synchronized to the minion to search for tests
2) only a first level of a dictionary returned by a module could have a value tested
3) saltcheck files were required to exist in a specific location in the formula/state folder
4) Why a test was marked "invalid" was not presented

### New Behavior
1) Only the test files are synchronized to the client, this is done by generating the sls low data for the state/highstate operation and then caching only the test files
2) A dictionary can be passed to the assertion_section to provide the nested key to be tested
3) A minion configuration setting of ``saltcheck_test_location`` can be used to specify the relative path to the tests files from the state/formula's folder
4) Why a test was marked invalid is reported as an error in the minion log

### Tests written?
No

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
