### PR TITLE
Change package name for suse pkg tests

### DIFF
--- a/tests/integration/states/test_pkg.py
+++ b/tests/integration/states/test_pkg.py
@@ -38,7 +38,7 @@ _PKG_TARGETS = {
     'Debian': ['python-plist', 'apg'],
     'RedHat': ['units', 'zsh-html'],
     'FreeBSD': ['aalib', 'pth'],
-    'Suse': ['aalib', 'rpm-python'],
+    'Suse': ['aalib', 'htop'],
     'MacOS': ['libpng', 'jpeg'],
     'Windows': ['putty', '7zip'],
 }


### PR DESCRIPTION
### What does this PR do?
The tests:

```
    integration.states.test_pkg.PkgTest.test_pkg_003_installed_multipkg
    integration.states.test_pkg.PkgTest.test_pkg_004_installed_multipkg_with_version
```

are failing on suse 15 because `rpm-python` is not a package that is available in suse 15 repos. Changing the package name to htop. I also verified this package was in both suse 15 and suse 42 repos and ran the  pkg tests with this change.

### What issues does this PR fix or reference?
Fixes:
  https://github.com/saltstack/salt/issues/52917
  https://github.com/saltstack/salt/issues/52996

### Previous Behavior
tests failing

### New Behavior
tests pass

### Tests written?

No -Fixing current test failures

### Commits signed with GPG?

Yes