### PR TITLE
minor tweaks to master initialization / EventReturn

### DIFF
--- a/salt/master.py
+++ b/salt/master.py
@@ -705,10 +705,6 @@ class Master(SMaster):
             log.info('Creating master maintenance process')
             self.process_manager.add_process(Maintenance, args=(self.opts,))
 
-            if self.opts.get('event_return'):
-                log.info('Creating master event return process')
-                self.process_manager.add_process(salt.utils.event.EventReturn, args=(self.opts,))
-
             ext_procs = self.opts.get('ext_processes', [])
             for proc in ext_procs:
                 log.info('Creating ext_processes process: %s', proc)
@@ -746,6 +742,11 @@ class Master(SMaster):
                 kwargs=kwargs,
                 name='ReqServer')
 
+            if self.opts.get('event_return'):
+                log.info('Creating master event return process')
+                self.process_manager.add_process(salt.utils.event.EventReturn, args=(self.opts,))
+
+            log.info('Creating FileServerUpdate process')
             self.process_manager.add_process(
                 FileserverUpdate,
                 args=(self.opts,))

--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -1216,10 +1216,10 @@ class EventReturn(salt.utils.process.SignalHandlingMultiprocessingProcess):
         super(EventReturn, self).__init__(**kwargs)
 
         self.opts = opts
+        self.local_minion_opts = self.opts.copy()
+        self.local_minion_opts['file_client'] = 'local'
+
         self.event_return_queue = self.opts['event_return_queue']
-        local_minion_opts = self.opts.copy()
-        local_minion_opts['file_client'] = 'local'
-        self.minion = salt.minion.MasterMinion(local_minion_opts)
         self.event_queue = []
         self.stop = False
 
@@ -1286,6 +1286,7 @@ class EventReturn(salt.utils.process.SignalHandlingMultiprocessingProcess):
         Spin up the multiprocess event returner
         '''
         salt.utils.process.appendproctitle(self.__class__.__name__)
+        self.minion = salt.minion.MasterMinion(self.local_minion_opts)
         self.event = get_event('master', opts=self.opts, listen=True)
         events = self.event.iter_events(full=True)
         self.event.fire_event({}, 'salt/event_listen/start')


### PR DESCRIPTION
### What does this PR do?
- moved creating a masterMinion object for EventReturn into the child proc to avoid loader churn (funcs, grains, etc). Theres no reason for this to happen in parent proc then get pickled down post fork. This should improve master startup time.
- move EventReturn creation to _after_ ReqServer, since it emits events on initialization.

### What issues does this PR fix or reference?
n/a

### Tests written?
Not really applicable to this change.

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
