### PR TITLE
Minor Fix to support Cisco Nexus 5000

### DIFF
--- a/salt/proxy/nxos_api.py
+++ b/salt/proxy/nxos_api.py
@@ -156,7 +156,7 @@ def init(opts):
     # This is not a SSH-based proxy, so it should be safe to enable
     # multiprocessing.
     try:
-        rpc_reply = __utils__['nxos_api.rpc']('show clock', **conn_args)
+        rpc_reply = __utils__['nxos_api.rpc']('show version', **conn_args)
         # Execute a very simple command to confirm we are able to connect properly
         nxos_device['conn_args'] = conn_args
         nxos_device['initialized'] = True


### PR DESCRIPTION
### What does this PR do?
Allows NXOS_API proxy and module support for Cisco Nexus 5000 switches
Running Cisco NXOS Version: 7.3(3)(N1)(1)

### What issues does this PR fix or reference?
Minor fix to the command running in the NXOS_API proxy. The 'show clock' command does not exist in the NXAPI.

### Previous Behavior
Would receive HTTP 500 error, during proxy minion startup, because the 'show clock' command is not available on the Cisco Nexus 5000 via NXAPI at this time.
```bash
  File "/usr/lib/python3/dist-packages/salt/utils/nxos_api.py", line 138, in rpc
    raise SaltException(response['error'])
salt.exceptions.SaltException: HTTP 500: Internal Server Error
```

### New Behavior
Changed the NXOS_API proxy from 'show clock' to 'show version'. 
Proxy starts as expected, and able to utilize NXOS_API module.

https://github.com/saltstack/salt/blob/2019.2.0/salt/proxy/nxos_api.py#L159

```bash
rpc_reply = __utils__['nxos_api.rpc']('show version', **conn_args)
```

https://docs.saltstack.com/en/develop/topics/installation/nxos.html
https://docs.saltstack.com/en/latest/ref/modules/all/salt.modules.nxos_api.html#module-salt.modules.nxos_api

### Tests written?

No

### Commits signed with GPG?

No
