### PR TITLE
Add visible_name and firstname arguments

### DIFF
--- a/salt/states/zabbix_host.py
+++ b/salt/states/zabbix_host.py
@@ -323,7 +323,7 @@ def present(host, groups, interfaces, **kwargs):
                                                      proxy_hostid=proxy_hostid,
                                                      inventory=new_inventory,
                                                      visible_name=new_visible_name,
-                                                     firstname=new_first_name
+                                                     firstname=new_first_name,
                                                      **connection_args)
 
         if 'error' not in host_create:

--- a/salt/states/zabbix_host.py
+++ b/salt/states/zabbix_host.py
@@ -185,10 +185,11 @@ def present(host, groups, interfaces, **kwargs):
     if inventory is None:
         inventory = {}
         
+    new_visible_name = ''
     if 'visible_name' in kwargs:
         new_visible_name = kwargs['visible_name']
     if 'firstname' in kwargs:
-        new_first_name = kwargs['firstname']
+        new_visible_name = kwargs['firstname']
 
     # Create dict of requested inventory items
     new_inventory = {}
@@ -325,7 +326,6 @@ def present(host, groups, interfaces, **kwargs):
                                                      proxy_hostid=proxy_hostid,
                                                      inventory=new_inventory,
                                                      visible_name=new_visible_name,
-                                                     first_name=new_first_name,
                                                      **connection_args)
 
         if 'error' not in host_create:

--- a/salt/states/zabbix_host.py
+++ b/salt/states/zabbix_host.py
@@ -325,7 +325,7 @@ def present(host, groups, interfaces, **kwargs):
                                                      proxy_hostid=proxy_hostid,
                                                      inventory=new_inventory,
                                                      visible_name=new_visible_name,
-                                                     first_name=first_name,
+                                                     first_name=new_first_name,
                                                      **connection_args)
 
         if 'error' not in host_create:

--- a/salt/states/zabbix_host.py
+++ b/salt/states/zabbix_host.py
@@ -185,11 +185,8 @@ def present(host, groups, interfaces, **kwargs):
     if inventory is None:
         inventory = {}
         
-    new_visible_name = ''
-    if 'visible_name' in kwargs:
-        new_visible_name = kwargs['visible_name']
-    if 'firstname' in kwargs:
-        new_visible_name = kwargs['firstname']
+    new_visible_name = kwargs.get('visible_name', '')
+    new_first_name = kwargs.get('first_name', '')
 
     # Create dict of requested inventory items
     new_inventory = {}
@@ -326,6 +323,7 @@ def present(host, groups, interfaces, **kwargs):
                                                      proxy_hostid=proxy_hostid,
                                                      inventory=new_inventory,
                                                      visible_name=new_visible_name,
+                                                     first_name=new_visible_name
                                                      **connection_args)
 
         if 'error' not in host_create:

--- a/salt/states/zabbix_host.py
+++ b/salt/states/zabbix_host.py
@@ -184,6 +184,12 @@ def present(host, groups, interfaces, **kwargs):
         inventory = kwargs['inventory']
     if inventory is None:
         inventory = {}
+        
+    if 'visible_name' in kwargs:
+        new_visible_name = kwargs['visible_name']
+    if 'firstname' in kwargs:
+        new_first_name = kwargs['firstname']
+
     # Create dict of requested inventory items
     new_inventory = {}
     for inv_item in inventory:
@@ -318,6 +324,8 @@ def present(host, groups, interfaces, **kwargs):
                                                      interfaces_formated,
                                                      proxy_hostid=proxy_hostid,
                                                      inventory=new_inventory,
+                                                     visible_name=new_visible_name,
+                                                     first_name=first_name,
                                                      **connection_args)
 
         if 'error' not in host_create:

--- a/salt/states/zabbix_host.py
+++ b/salt/states/zabbix_host.py
@@ -184,7 +184,7 @@ def present(host, groups, interfaces, **kwargs):
         inventory = kwargs['inventory']
     if inventory is None:
         inventory = {}
-    
+
     new_visible_name = kwargs.get('visible_name', '')
     new_first_name = kwargs.get('first_name', '')
 

--- a/salt/states/zabbix_host.py
+++ b/salt/states/zabbix_host.py
@@ -323,7 +323,7 @@ def present(host, groups, interfaces, **kwargs):
                                                      proxy_hostid=proxy_hostid,
                                                      inventory=new_inventory,
                                                      visible_name=new_visible_name,
-                                                     first_name=new_visible_name
+                                                     firstname=new_first_name
                                                      **connection_args)
 
         if 'error' not in host_create:

--- a/salt/states/zabbix_host.py
+++ b/salt/states/zabbix_host.py
@@ -184,7 +184,7 @@ def present(host, groups, interfaces, **kwargs):
         inventory = kwargs['inventory']
     if inventory is None:
         inventory = {}
-        
+    
     new_visible_name = kwargs.get('visible_name', '')
     new_first_name = kwargs.get('first_name', '')
 


### PR DESCRIPTION
Neither was being respected, resulting in an always blank Visible Name in Zabbix.

### What does this PR do?
Allows specification of Visible Name in Zabbix
### What issues does this PR fix or reference?
N/A
### Previous Behavior
Visible Name was always blank

### New Behavior
Visible Name is now set as specified

### Tests written?

No

### Commits signed with GPG?

No