### PR TITLE
salt.modules.network: Add functions to get minion's networks

### DIFF
--- a/salt/modules/network.py
+++ b/salt/modules/network.py
@@ -1275,6 +1275,10 @@ def ip_addrs(interface=None, include_loopback=False, cidr=None, type=None):
     which are within that subnet. If 'type' is 'public', then only public
     addresses will be returned. Ditto for 'type'='private'.
 
+    .. versionchanged:: Neon
+        ``interface`` can now be a single interface name or a list of
+        interfaces. Globbing is also supported.
+
     CLI Example:
 
     .. code-block:: bash
@@ -1305,6 +1309,10 @@ def ip_addrs6(interface=None, include_loopback=False, cidr=None):
     then only IP addresses from that interface will be returned.
     Providing a CIDR via 'cidr="2000::/3"' will return only the addresses
     which are within that subnet.
+
+    .. versionchanged:: Neon
+        ``interface`` can now be a single interface name or a list of
+        interfaces. Globbing is also supported.
 
     CLI Example:
 
@@ -2001,3 +2009,53 @@ def iphexval(ip):
     a = ip.split(".")
     hexval = ["%02X" % int(x) for x in a]  # pylint: disable=E1321
     return "".join(hexval)
+
+
+def ip_networks(interface=None, include_loopback=False, verbose=False):
+    """
+    .. versionaddeed:: Neon
+
+    Returns a list of IPv4 networks to which the minion belongs.
+
+    interface
+        Restrict results to the specified interface(s). This value can be
+        either a single interface name or a list of interfaces. Globbing is
+        also supported.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' network.list_networks
+        salt '*' network.list_networks interface=docker0
+        salt '*' network.list_networks interface=docker0,enp*
+        salt '*' network.list_networks interface=eth*
+    """
+    return salt.utils.network.ip_networks(
+        interface=interface, include_loopback=include_loopback, verbose=verbose
+    )
+
+
+def ip_networks6(interface=None, include_loopback=False, verbose=False):
+    """
+    .. versionaddeed:: Neon
+
+    Returns a list of IPv6 networks to which the minion belongs.
+
+    interface
+        Restrict results to the specified interface(s). This value can be
+        either a single interface name or a list of interfaces. Globbing is
+        also supported.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' network.list_networks6
+        salt '*' network.list_networks6 interface=docker0
+        salt '*' network.list_networks6 interface=docker0,enp*
+        salt '*' network.list_networks6 interface=eth*
+    """
+    return salt.utils.network.ip_networks6(
+        interface=interface, include_loopback=include_loopback, verbose=verbose
+    )

--- a/salt/modules/network.py
+++ b/salt/modules/network.py
@@ -2010,7 +2010,7 @@ def iphexval(ip):
 
 def ip_networks(interface=None, include_loopback=False, verbose=False):
     """
-    .. versionaddeed:: Sodium
+    .. versionadded:: Sodium
 
     Returns a list of IPv4 networks to which the minion belongs.
 
@@ -2035,7 +2035,7 @@ def ip_networks(interface=None, include_loopback=False, verbose=False):
 
 def ip_networks6(interface=None, include_loopback=False, verbose=False):
     """
-    .. versionaddeed:: Sodium
+    .. versionadded:: Sodium
 
     Returns a list of IPv6 networks to which the minion belongs.
 

--- a/salt/modules/network.py
+++ b/salt/modules/network.py
@@ -1270,7 +1270,7 @@ def ip_addrs(interface=None, include_loopback=False, cidr=None, type=None):
     which are within that subnet. If 'type' is 'public', then only public
     addresses will be returned. Ditto for 'type'='private'.
 
-    .. versionchanged:: Neon
+    .. versionchanged:: Sodium
         ``interface`` can now be a single interface name or a list of
         interfaces. Globbing is also supported.
 
@@ -1305,7 +1305,7 @@ def ip_addrs6(interface=None, include_loopback=False, cidr=None):
     Providing a CIDR via 'cidr="2000::/3"' will return only the addresses
     which are within that subnet.
 
-    .. versionchanged:: Neon
+    .. versionchanged:: Sodium
         ``interface`` can now be a single interface name or a list of
         interfaces. Globbing is also supported.
 
@@ -2010,7 +2010,7 @@ def iphexval(ip):
 
 def ip_networks(interface=None, include_loopback=False, verbose=False):
     """
-    .. versionaddeed:: Neon
+    .. versionaddeed:: Sodium
 
     Returns a list of IPv4 networks to which the minion belongs.
 
@@ -2035,7 +2035,7 @@ def ip_networks(interface=None, include_loopback=False, verbose=False):
 
 def ip_networks6(interface=None, include_loopback=False, verbose=False):
     """
-    .. versionaddeed:: Neon
+    .. versionaddeed:: Sodium
 
     Returns a list of IPv6 networks to which the minion belongs.
 

--- a/salt/modules/network.py
+++ b/salt/modules/network.py
@@ -15,12 +15,7 @@ import socket
 
 # Import salt libs
 import salt.utils.decorators.path
-import salt.utils.files
 import salt.utils.functools
-import salt.utils.network
-import salt.utils.path
-import salt.utils.platform
-import salt.utils.stringutils
 import salt.utils.validate.net
 from salt._compat import ipaddress
 from salt.exceptions import CommandExecutionError
@@ -37,7 +32,7 @@ def __virtual__():
     Only work on POSIX-like systems
     """
     # Disable on Windows, a specific file module exists:
-    if salt.utils.platform.is_windows():
+    if __utils__["platform.is_windows"]():
         return (
             False,
             "The network execution module cannot be loaded on Windows: use win_network instead.",
@@ -57,7 +52,7 @@ def wol(mac, bcast="255.255.255.255", destport=9):
         salt '*' network.wol 080027136977 255.255.255.255 7
         salt '*' network.wol 08:00:27:13:69:77 255.255.255.255 7
     """
-    dest = salt.utils.network.mac_str_to_bytes(mac)
+    dest = __utils__["network.mac_str_to_bytes"](mac)
     sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
     sock.sendto(b"\xff" * 6 + dest * 16, (bcast, int(destport)))
@@ -94,14 +89,14 @@ def ping(host, timeout=False, return_boolean=False):
     if timeout:
         if __grains__["kernel"] == "SunOS":
             cmd = "ping -c 4 {1} {0}".format(
-                timeout, salt.utils.network.sanitize_host(host)
+                timeout, __utils__["network.sanitize_host"](host)
             )
         else:
             cmd = "ping -W {0} -c 4 {1}".format(
-                timeout, salt.utils.network.sanitize_host(host)
+                timeout, __utils__["network.sanitize_host"](host)
             )
     else:
-        cmd = "ping -c 4 {0}".format(salt.utils.network.sanitize_host(host))
+        cmd = "ping -c 4 {0}".format(__utils__["network.sanitize_host"](host))
     if return_boolean:
         ret = __salt__["cmd.run_all"](cmd)
         if ret["retcode"] != 0:
@@ -855,7 +850,7 @@ def netstat():
         salt '*' network.netstat
     """
     if __grains__["kernel"] == "Linux":
-        if not salt.utils.path.which("netstat"):
+        if not __utils__["path.which"]("netstat"):
             return _ss_linux()
         else:
             return _netstat_linux()
@@ -883,7 +878,7 @@ def active_tcp():
         salt '*' network.active_tcp
     """
     if __grains__["kernel"] == "Linux":
-        return salt.utils.network.active_tcp()
+        return __utils__["network.active_tcp"]()
     elif __grains__["kernel"] == "SunOS":
         # lets use netstat to mimic linux as close as possible
         ret = {}
@@ -936,11 +931,11 @@ def traceroute(host):
         salt '*' network.traceroute archlinux.org
     """
     ret = []
-    cmd = "traceroute {0}".format(salt.utils.network.sanitize_host(host))
+    cmd = "traceroute {0}".format(__utils__["network.sanitize_host"](host))
     out = __salt__["cmd.run"](cmd)
 
     # Parse version of traceroute
-    if salt.utils.platform.is_sunos() or salt.utils.platform.is_aix():
+    if __utils__["platform.is_sunos"]() or __utils__["platform.is_aix"]():
         traceroute_version = [0, 0, 0]
     else:
         version_out = __salt__["cmd.run"]("traceroute --version")
@@ -975,7 +970,7 @@ def traceroute(host):
             skip_line = True
         if line.startswith("traceroute"):
             skip_line = True
-        if salt.utils.platform.is_aix():
+        if __utils__["platform.is_aix"]():
             if line.startswith("trying to get source for"):
                 skip_line = True
             if line.startswith("source should be"):
@@ -1073,7 +1068,7 @@ def dig(host):
 
         salt '*' network.dig archlinux.org
     """
-    cmd = "dig {0}".format(salt.utils.network.sanitize_host(host))
+    cmd = "dig {0}".format(__utils__["network.sanitize_host"](host))
     return __salt__["cmd.run"](cmd)
 
 
@@ -1125,7 +1120,7 @@ def interfaces():
 
         salt '*' network.interfaces
     """
-    return salt.utils.network.interfaces()
+    return __utils__["network.interfaces"]()
 
 
 def hw_addr(iface):
@@ -1138,7 +1133,7 @@ def hw_addr(iface):
 
         salt '*' network.hw_addr eth0
     """
-    return salt.utils.network.hw_addr(iface)
+    return __utils__["network.hw_addr"](iface)
 
 
 # Alias hwaddr to preserve backward compat
@@ -1157,7 +1152,7 @@ def interface(iface):
 
         salt '*' network.interface eth0
     """
-    return salt.utils.network.interface(iface)
+    return __utils__["network.interface"](iface)
 
 
 def interface_ip(iface):
@@ -1172,7 +1167,7 @@ def interface_ip(iface):
 
         salt '*' network.interface_ip eth0
     """
-    return salt.utils.network.interface_ip(iface)
+    return __utils__["network.interface_ip"](iface)
 
 
 def subnets(interfaces=None):
@@ -1186,7 +1181,7 @@ def subnets(interfaces=None):
         salt '*' network.subnets
         salt '*' network.subnets interfaces=eth1
     """
-    return salt.utils.network.subnets(interfaces)
+    return __utils__["network.subnets"](interfaces)
 
 
 def subnets6():
@@ -1199,7 +1194,7 @@ def subnets6():
 
         salt '*' network.subnets
     """
-    return salt.utils.network.subnets6()
+    return __utils__["network.subnets6"]()
 
 
 def in_subnet(cidr):
@@ -1212,7 +1207,7 @@ def in_subnet(cidr):
 
         salt '*' network.in_subnet 10.0.0.0/16
     """
-    return salt.utils.network.in_subnet(cidr)
+    return __utils__["network.in_subnet"](cidr)
 
 
 def ip_in_subnet(ip_addr, cidr):
@@ -1225,7 +1220,7 @@ def ip_in_subnet(ip_addr, cidr):
 
         salt '*' network.ip_in_subnet 172.17.0.4 172.16.0.0/12
     """
-    return salt.utils.network.in_subnet(cidr, ip_addr)
+    return __utils__["network.in_subnet"](cidr, ip_addr)
 
 
 def convert_cidr(cidr):
@@ -1263,7 +1258,7 @@ def calc_net(ip_addr, netmask=None):
 
     .. versionadded:: 2015.8.0
     """
-    return salt.utils.network.calc_net(ip_addr, netmask)
+    return __utils__["network.calc_net"](ip_addr, netmask)
 
 
 def ip_addrs(interface=None, include_loopback=False, cidr=None, type=None):
@@ -1285,11 +1280,11 @@ def ip_addrs(interface=None, include_loopback=False, cidr=None, type=None):
 
         salt '*' network.ip_addrs
     """
-    addrs = salt.utils.network.ip_addrs(
+    addrs = __utils__["network.ip_addrs"](
         interface=interface, include_loopback=include_loopback
     )
     if cidr:
-        return [i for i in addrs if salt.utils.network.in_subnet(cidr, [i])]
+        return [i for i in addrs if __utils__["network.in_subnet"](cidr, [i])]
     else:
         if type == "public":
             return [i for i in addrs if not is_private(i)]
@@ -1320,11 +1315,11 @@ def ip_addrs6(interface=None, include_loopback=False, cidr=None):
 
         salt '*' network.ip_addrs6
     """
-    addrs = salt.utils.network.ip_addrs6(
+    addrs = __utils__["network.ip_addrs6"](
         interface=interface, include_loopback=include_loopback
     )
     if cidr:
-        return [i for i in addrs if salt.utils.network.in_subnet(cidr, [i])]
+        return [i for i in addrs if __utils__["network.in_subnet"](cidr, [i])]
     else:
         return addrs
 
@@ -1385,16 +1380,16 @@ def mod_hostname(hostname):
     if hostname is None:
         return False
 
-    hostname_cmd = salt.utils.path.which("hostnamectl") or salt.utils.path.which(
+    hostname_cmd = __utils__["path.which"]("hostnamectl") or __utils__["path.which"](
         "hostname"
     )
-    if salt.utils.platform.is_sunos():
+    if __utils__["platform.is_sunos"]():
         uname_cmd = (
             "/usr/bin/uname"
-            if salt.utils.platform.is_smartos()
-            else salt.utils.path.which("uname")
+            if __utils__["platform.is_smartos"]()
+            else __utils__["path.which"]("uname")
         )
-        check_hostname_cmd = salt.utils.path.which("check-hostname")
+        check_hostname_cmd = __utils__["path.which"]("check-hostname")
 
     # Grab the old hostname so we know which hostname to change and then
     # change the hostname using the hostname command
@@ -1409,7 +1404,7 @@ def mod_hostname(hostname):
         else:
             log.debug("{0} was unable to get hostname".format(hostname_cmd))
             o_hostname = __salt__["network.get_hostname"]()
-    elif not salt.utils.platform.is_sunos():
+    elif not __utils__["platform.is_sunos"]():
         # don't run hostname -f because -f is not supported on all platforms
         o_hostname = socket.getfqdn()
     else:
@@ -1427,57 +1422,57 @@ def mod_hostname(hostname):
                 )
             )
             return False
-    elif not salt.utils.platform.is_sunos():
+    elif not __utils__["platform.is_sunos"]():
         __salt__["cmd.run"]("{0} {1}".format(hostname_cmd, hostname))
     else:
         __salt__["cmd.run"]("{0} -S {1}".format(uname_cmd, hostname.split(".")[0]))
 
     # Modify the /etc/hosts file to replace the old hostname with the
     # new hostname
-    with salt.utils.files.fopen("/etc/hosts", "r") as fp_:
-        host_c = [salt.utils.stringutils.to_unicode(_l) for _l in fp_.readlines()]
+    with __utils__["files.fopen"]("/etc/hosts", "r") as fp_:
+        host_c = [__utils__["stringutils.to_unicode"](_l) for _l in fp_.readlines()]
 
-    with salt.utils.files.fopen("/etc/hosts", "w") as fh_:
+    with __utils__["files.fopen"]("/etc/hosts", "w") as fh_:
         for host in host_c:
             host = host.split()
 
             try:
                 host[host.index(o_hostname)] = hostname
-                if salt.utils.platform.is_sunos():
+                if __utils__["platform.is_sunos"]():
                     # also set a copy of the hostname
                     host[host.index(o_hostname.split(".")[0])] = hostname.split(".")[0]
             except ValueError:
                 pass
 
-            fh_.write(salt.utils.stringutils.to_str("\t".join(host) + "\n"))
+            fh_.write(__utils__["stringutils.to_str"]("\t".join(host) + "\n"))
 
     # Modify the /etc/sysconfig/network configuration file to set the
     # new hostname
     if __grains__["os_family"] == "RedHat":
-        with salt.utils.files.fopen("/etc/sysconfig/network", "r") as fp_:
+        with __utils__["files.fopen"]("/etc/sysconfig/network", "r") as fp_:
             network_c = [
-                salt.utils.stringutils.to_unicode(_l) for _l in fp_.readlines()
+                __utils__["stringutils.to_unicode"](_l) for _l in fp_.readlines()
             ]
 
-        with salt.utils.files.fopen("/etc/sysconfig/network", "w") as fh_:
+        with __utils__["files.fopen"]("/etc/sysconfig/network", "w") as fh_:
             for net in network_c:
                 if net.startswith("HOSTNAME"):
                     old_hostname = net.split("=", 1)[1].rstrip()
-                    quote_type = salt.utils.stringutils.is_quoted(old_hostname)
+                    quote_type = __utils__["stringutils.is_quoted"](old_hostname)
                     fh_.write(
-                        salt.utils.stringutils.to_str(
+                        __utils__["stringutils.to_str"](
                             "HOSTNAME={1}{0}{1}\n".format(
-                                salt.utils.stringutils.dequote(hostname), quote_type
+                                __utils__["stringutils.dequote"](hostname), quote_type
                             )
                         )
                     )
                 else:
-                    fh_.write(salt.utils.stringutils.to_str(net))
+                    fh_.write(__utils__["stringutils.to_str"](net))
     elif __grains__["os_family"] in ("Debian", "NILinuxRT"):
-        with salt.utils.files.fopen("/etc/hostname", "w") as fh_:
-            fh_.write(salt.utils.stringutils.to_str(hostname + "\n"))
+        with __utils__["files.fopen"]("/etc/hostname", "w") as fh_:
+            fh_.write(__utils__["stringutils.to_str"](hostname + "\n"))
         if __grains__["lsb_distrib_id"] == "nilrt":
-            str_hostname = salt.utils.stringutils.to_str(hostname)
+            str_hostname = __utils__["stringutils.to_str"](hostname)
             nirtcfg_cmd = "/usr/local/natinst/bin/nirtcfg"
             nirtcfg_cmd += " --set section=SystemSettings,token='Host_Name',value='{0}'".format(
                 str_hostname
@@ -1487,16 +1482,18 @@ def mod_hostname(hostname):
                     "Couldn't set hostname to: {0}\n".format(str_hostname)
                 )
     elif __grains__["os_family"] == "OpenBSD":
-        with salt.utils.files.fopen("/etc/myname", "w") as fh_:
-            fh_.write(salt.utils.stringutils.to_str(hostname + "\n"))
+        with __utils__["files.fopen"]("/etc/myname", "w") as fh_:
+            fh_.write(__utils__["stringutils.to_str"](hostname + "\n"))
 
     # Update /etc/nodename and /etc/defaultdomain on SunOS
-    if salt.utils.platform.is_sunos():
-        with salt.utils.files.fopen("/etc/nodename", "w") as fh_:
-            fh_.write(salt.utils.stringutils.to_str(hostname.split(".")[0] + "\n"))
-        with salt.utils.files.fopen("/etc/defaultdomain", "w") as fh_:
+    if __utils__["platform.is_sunos"]():
+        with __utils__["files.fopen"]("/etc/nodename", "w") as fh_:
+            fh_.write(__utils__["stringutils.to_str"](hostname.split(".")[0] + "\n"))
+        with __utils__["files.fopen"]("/etc/defaultdomain", "w") as fh_:
             fh_.write(
-                salt.utils.stringutils.to_str(".".join(hostname.split(".")[1:]) + "\n")
+                __utils__["stringutils.to_str"](
+                    ".".join(hostname.split(".")[1:]) + "\n"
+                )
             )
 
     return True
@@ -1543,7 +1540,7 @@ def connect(host, port=None, **kwargs):
     ):
         address = host
     else:
-        address = "{0}".format(salt.utils.network.sanitize_host(host))
+        address = "{0}".format(__utils__["network.sanitize_host"](host))
 
     try:
         if proto == "udp":
@@ -1767,7 +1764,7 @@ def routes(family=None):
         raise CommandExecutionError("Invalid address family {0}".format(family))
 
     if __grains__["kernel"] == "Linux":
-        if not salt.utils.path.which("netstat"):
+        if not __utils__["path.which"]("netstat"):
             routes_ = _ip_route_linux()
         else:
             routes_ = _netstat_route_linux()
@@ -1901,7 +1898,7 @@ def get_route(ip):
                 ret["gateway"] = line[1].strip()
             if "interface" in line[0]:
                 ret["interface"] = line[1].strip()
-                ret["source"] = salt.utils.network.interface_ip(line[1].strip())
+                ret["source"] = __utils__["network.interface_ip"](line[1].strip())
 
         return ret
 
@@ -2031,7 +2028,7 @@ def ip_networks(interface=None, include_loopback=False, verbose=False):
         salt '*' network.list_networks interface=docker0,enp*
         salt '*' network.list_networks interface=eth*
     """
-    return salt.utils.network.ip_networks(
+    return __utils__["network.ip_networks"](
         interface=interface, include_loopback=include_loopback, verbose=verbose
     )
 
@@ -2056,6 +2053,6 @@ def ip_networks6(interface=None, include_loopback=False, verbose=False):
         salt '*' network.list_networks6 interface=docker0,enp*
         salt '*' network.list_networks6 interface=eth*
     """
-    return salt.utils.network.ip_networks6(
+    return __utils__["network.ip_networks6"](
         interface=interface, include_loopback=include_loopback, verbose=verbose
     )

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -1299,7 +1299,7 @@ def _filter_interfaces(interface=None, interface_data=None):
         ret = {
             k: v
             for k, v in six.iteritems(ifaces)
-            if any(fnmatch.fnmatch(k, pat) for pat in interface)
+            if any((fnmatch.fnmatch(k, pat) for pat in interface))
         }
     return ret
 

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -1363,7 +1363,7 @@ def _ip_networks(
         if _ip and _net:
             try:
                 ip_net = ipaddress.ip_network("{0}/{1}".format(_ip, _net), strict=False)
-            except Exception:
+            except Exception:  # pylint: disable=broad-except
                 continue
             if not ip_net.is_loopback or include_loopback:
                 ret.add(ip_net)

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -1405,7 +1405,7 @@ def ip_networks6(
     interface=None, include_loopback=False, verbose=False, interface_data=None
 ):
     """
-    Returns the IPv4 networks to which the minion belongs. Networks will be
+    Returns the IPv6 networks to which the minion belongs. Networks will be
     returned as a list of network/prefixlen. To get more information about a
     each network, use verbose=True and a dictionary with more information will
     be returned.

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -1296,11 +1296,13 @@ def _filter_interfaces(interface=None, interface_data=None):
         ret = ifaces
     else:
         interface = salt.utils.args.split_input(interface)
+        # pylint: disable=not-an-iterable
         ret = {
             k: v
             for k, v in six.iteritems(ifaces)
             if any((fnmatch.fnmatch(k, pat) for pat in interface))
         }
+        # pylint: enable=not-an-iterable
     return ret
 
 

--- a/tests/unit/modules/test_network.py
+++ b/tests/unit/modules/test_network.py
@@ -33,7 +33,7 @@ class NetworkTestCase(TestCase, LoaderModuleMockMixin):
             opts, whitelist=["network", "path", "platform", "stringutils"]
         )
         return {
-            network: {"__utils__": utils,},
+            network: {"__utils__": utils},
         }
 
     def test_wol_bad_mac(self):

--- a/tests/unit/modules/test_network.py
+++ b/tests/unit/modules/test_network.py
@@ -7,10 +7,9 @@ import logging
 import os.path
 import socket
 
-import salt.modules.network as network
-
 # Import Salt Libs
 import salt.config
+import salt.modules.network as network
 import salt.utils.path
 from salt._compat import ipaddress
 from salt.exceptions import CommandExecutionError

--- a/tests/unit/utils/test_network.py
+++ b/tests/unit/utils/test_network.py
@@ -953,3 +953,281 @@ class NetworkTestCase(TestCase):
             "fe80::d210:cf3f:64e7:5423",
         ]
         assert ips == network.filter_by_networks(ips, ["0.0.0.0/0", "::/0"])
+
+    def test_ip_networks(self):
+        # We don't need to test with each platform's ifconfig/iproute2 output,
+        # since this test isn't testing getting the interfaces. We already have
+        # tests for that.
+        interface_data = network._interfaces_ifconfig(LINUX)
+
+        # Without loopback
+        ret = network.ip_networks(interface_data=interface_data)
+        assert ret == ["10.10.8.0/22"], ret
+        # Without loopback, specific interface
+        ret = network.ip_networks(interface="eth0", interface_data=interface_data)
+        assert ret == ["10.10.8.0/22"], ret
+        # Without loopback, multiple specific interfaces
+        ret = network.ip_networks(interface="eth0,lo", interface_data=interface_data)
+        assert ret == ["10.10.8.0/22"], ret
+        # Without loopback, specific interface (not present)
+        ret = network.ip_networks(interface="eth1", interface_data=interface_data)
+        assert ret == [], ret
+        # With loopback
+        ret = network.ip_networks(include_loopback=True, interface_data=interface_data)
+        assert ret == ["10.10.8.0/22", "127.0.0.0/8"], ret
+        # With loopback, specific interface
+        ret = network.ip_networks(
+            interface="eth0", include_loopback=True, interface_data=interface_data
+        )
+        assert ret == ["10.10.8.0/22"], ret
+        # With loopback, multiple specific interfaces
+        ret = network.ip_networks(
+            interface="eth0,lo", include_loopback=True, interface_data=interface_data
+        )
+        assert ret == ["10.10.8.0/22", "127.0.0.0/8"], ret
+        # With loopback, specific interface (not present)
+        ret = network.ip_networks(
+            interface="eth1", include_loopback=True, interface_data=interface_data
+        )
+        assert ret == [], ret
+
+        # Verbose, without loopback
+        ret = network.ip_networks(verbose=True, interface_data=interface_data)
+        assert ret == {
+            "10.10.8.0/22": {
+                "prefixlen": 22,
+                "netmask": "255.255.252.0",
+                "num_addresses": 1024,
+                "address": "10.10.8.0",
+            },
+        }, ret
+        # Verbose, without loopback, specific interface
+        ret = network.ip_networks(
+            interface="eth0", verbose=True, interface_data=interface_data
+        )
+        assert ret == {
+            "10.10.8.0/22": {
+                "prefixlen": 22,
+                "netmask": "255.255.252.0",
+                "num_addresses": 1024,
+                "address": "10.10.8.0",
+            },
+        }, ret
+        # Verbose, without loopback, multiple specific interfaces
+        ret = network.ip_networks(
+            interface="eth0,lo", verbose=True, interface_data=interface_data
+        )
+        assert ret == {
+            "10.10.8.0/22": {
+                "prefixlen": 22,
+                "netmask": "255.255.252.0",
+                "num_addresses": 1024,
+                "address": "10.10.8.0",
+            },
+        }, ret
+        # Verbose, without loopback, specific interface (not present)
+        ret = network.ip_networks(
+            interface="eth1", verbose=True, interface_data=interface_data
+        )
+        assert ret == {}, ret
+        # Verbose, with loopback
+        ret = network.ip_networks(
+            include_loopback=True, verbose=True, interface_data=interface_data
+        )
+        assert ret == {
+            "10.10.8.0/22": {
+                "prefixlen": 22,
+                "netmask": "255.255.252.0",
+                "num_addresses": 1024,
+                "address": "10.10.8.0",
+            },
+            "127.0.0.0/8": {
+                "prefixlen": 8,
+                "netmask": "255.0.0.0",
+                "num_addresses": 16777216,
+                "address": "127.0.0.0",
+            },
+        }, ret
+        # Verbose, with loopback, specific interface
+        ret = network.ip_networks(
+            interface="eth0",
+            include_loopback=True,
+            verbose=True,
+            interface_data=interface_data,
+        )
+        assert ret == {
+            "10.10.8.0/22": {
+                "prefixlen": 22,
+                "netmask": "255.255.252.0",
+                "num_addresses": 1024,
+                "address": "10.10.8.0",
+            },
+        }, ret
+        # Verbose, with loopback, multiple specific interfaces
+        ret = network.ip_networks(
+            interface="eth0,lo",
+            include_loopback=True,
+            verbose=True,
+            interface_data=interface_data,
+        )
+        assert ret == {
+            "10.10.8.0/22": {
+                "prefixlen": 22,
+                "netmask": "255.255.252.0",
+                "num_addresses": 1024,
+                "address": "10.10.8.0",
+            },
+            "127.0.0.0/8": {
+                "prefixlen": 8,
+                "netmask": "255.0.0.0",
+                "num_addresses": 16777216,
+                "address": "127.0.0.0",
+            },
+        }, ret
+        # Verbose, with loopback, specific interface (not present)
+        ret = network.ip_networks(
+            interface="eth1",
+            include_loopback=True,
+            verbose=True,
+            interface_data=interface_data,
+        )
+        assert ret == {}, ret
+
+    def test_ip_networks6(self):
+        # We don't need to test with each platform's ifconfig/iproute2 output,
+        # since this test isn't testing getting the interfaces. We already have
+        # tests for that.
+        interface_data = network._interfaces_ifconfig(LINUX)
+
+        # Without loopback
+        ret = network.ip_networks6(interface_data=interface_data)
+        assert ret == ["fe80::/64"], ret
+        # Without loopback, specific interface
+        ret = network.ip_networks6(interface="eth0", interface_data=interface_data)
+        assert ret == ["fe80::/64"], ret
+        # Without loopback, multiple specific interfaces
+        ret = network.ip_networks6(interface="eth0,lo", interface_data=interface_data)
+        assert ret == ["fe80::/64"], ret
+        # Without loopback, specific interface (not present)
+        ret = network.ip_networks6(interface="eth1", interface_data=interface_data)
+        assert ret == [], ret
+        # With loopback
+        ret = network.ip_networks6(include_loopback=True, interface_data=interface_data)
+        assert ret == ["::1/128", "fe80::/64"], ret
+        # With loopback, specific interface
+        ret = network.ip_networks6(
+            interface="eth0", include_loopback=True, interface_data=interface_data
+        )
+        assert ret == ["fe80::/64"], ret
+        # With loopback, multiple specific interfaces
+        ret = network.ip_networks6(
+            interface="eth0,lo", include_loopback=True, interface_data=interface_data
+        )
+        assert ret == ["::1/128", "fe80::/64"], ret
+        # With loopback, specific interface (not present)
+        ret = network.ip_networks6(
+            interface="eth1", include_loopback=True, interface_data=interface_data
+        )
+        assert ret == [], ret
+
+        # Verbose, without loopback
+        ret = network.ip_networks6(verbose=True, interface_data=interface_data)
+        assert ret == {
+            "fe80::/64": {
+                "prefixlen": 64,
+                "netmask": "ffff:ffff:ffff:ffff::",
+                "num_addresses": 18446744073709551616,
+                "address": "fe80::",
+            },
+        }, ret
+        # Verbose, without loopback, specific interface
+        ret = network.ip_networks6(
+            interface="eth0", verbose=True, interface_data=interface_data
+        )
+        assert ret == {
+            "fe80::/64": {
+                "prefixlen": 64,
+                "netmask": "ffff:ffff:ffff:ffff::",
+                "num_addresses": 18446744073709551616,
+                "address": "fe80::",
+            },
+        }, ret
+        # Verbose, without loopback, multiple specific interfaces
+        ret = network.ip_networks6(
+            interface="eth0,lo", verbose=True, interface_data=interface_data
+        )
+        assert ret == {
+            "fe80::/64": {
+                "prefixlen": 64,
+                "netmask": "ffff:ffff:ffff:ffff::",
+                "num_addresses": 18446744073709551616,
+                "address": "fe80::",
+            },
+        }, ret
+        # Verbose, without loopback, specific interface (not present)
+        ret = network.ip_networks6(
+            interface="eth1", verbose=True, interface_data=interface_data
+        )
+        assert ret == {}, ret
+        # Verbose, with loopback
+        ret = network.ip_networks6(
+            include_loopback=True, verbose=True, interface_data=interface_data
+        )
+        assert ret == {
+            "fe80::/64": {
+                "prefixlen": 64,
+                "netmask": "ffff:ffff:ffff:ffff::",
+                "num_addresses": 18446744073709551616,
+                "address": "fe80::",
+            },
+            "::1/128": {
+                "prefixlen": 128,
+                "netmask": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+                "num_addresses": 1,
+                "address": "::1",
+            },
+        }, ret
+        # Verbose, with loopback, specific interface
+        ret = network.ip_networks6(
+            interface="eth0",
+            include_loopback=True,
+            verbose=True,
+            interface_data=interface_data,
+        )
+        assert ret == {
+            "fe80::/64": {
+                "prefixlen": 64,
+                "netmask": "ffff:ffff:ffff:ffff::",
+                "num_addresses": 18446744073709551616,
+                "address": "fe80::",
+            },
+        }, ret
+        # Verbose, with loopback, multiple specific interfaces
+        ret = network.ip_networks6(
+            interface="eth0,lo",
+            include_loopback=True,
+            verbose=True,
+            interface_data=interface_data,
+        )
+        assert ret == {
+            "fe80::/64": {
+                "prefixlen": 64,
+                "netmask": "ffff:ffff:ffff:ffff::",
+                "num_addresses": 18446744073709551616,
+                "address": "fe80::",
+            },
+            "::1/128": {
+                "prefixlen": 128,
+                "netmask": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+                "num_addresses": 1,
+                "address": "::1",
+            },
+        }, ret
+        # Verbose, with loopback, specific interface (not present)
+        ret = network.ip_networks6(
+            interface="eth1",
+            include_loopback=True,
+            verbose=True,
+            interface_data=interface_data,
+        )
+        assert ret == {}, ret


### PR DESCRIPTION
### What does this PR do?

Two new functions added which return information about the networks to which the minion belongs. Additionally, the `interface` arg to both new functions supports multiple interfaces and globbing. This additional functionality has also been added to the `ip_addrs` and `ip_addrs6` functions, and all four of these functions now use common code for filtering the interface data. DRY.

### What issues does this PR fix or reference?

N/A

### Tests written?

Yes

### Commits signed with GPG?

No