### PR TITLE
Update ec2.py: Resolve key error when a subnet name is provided to an ec2 profile

### DIFF
--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -1244,7 +1244,7 @@ def _get_subnetname_id(subnetname):
     for subnet in aws.query(params, location=get_location(),
                provider=get_provider(), opts=__opts__, sigver='4'):
         tags = subnet.get('tagSet', {}).get('item', {})
-        if(subnet.has_key("tagSet")):
+        if 'tagSet' in subnet:
             if not isinstance(tags, list):
                 tags = [tags]
             for tag in tags:

--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -1244,15 +1244,16 @@ def _get_subnetname_id(subnetname):
     for subnet in aws.query(params, location=get_location(),
                provider=get_provider(), opts=__opts__, sigver='4'):
         tags = subnet.get('tagSet', {}).get('item', {})
-        if not isinstance(tags, list):
-            tags = [tags]
-        for tag in tags:
-            if tag['key'] == 'Name' and tag['value'] == subnetname:
-                log.debug(
-                    'AWS Subnet ID of %s is %s',
-                    subnetname, subnet['subnetId']
-                )
-                return subnet['subnetId']
+        if(subnet.has_key("tagSet")):
+            if not isinstance(tags, list):
+                tags = [tags]
+            for tag in tags:
+                if tag['key'] == 'Name' and tag['value'] == subnetname:
+                    log.debug(
+                        'AWS Subnet ID of %s is %s',
+                        subnetname, subnet['subnetId']
+                    )
+                    return subnet['subnetId']
     return None
 
 


### PR DESCRIPTION
Added "if(subnet.has_key("tagSet")):" to _get_subnetname_id(subnetname).

This resolved the following error when I subnet name is provided in the ec2 profile:
```
[ERROR   ] Failed to create VM <some-new-minion>. Configuration value u'key' needs to be set
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/salt/cloud/__init__.py", line 1288, in create
    output = self.clouds[func](vm_)
  File "/usr/lib/python2.7/site-packages/salt/cloud/clouds/ec2.py", line 2632, in create
    data, vm_ = request_instance(vm_, location)
  File "/usr/lib/python2.7/site-packages/salt/cloud/clouds/ec2.py", line 1914, in request_instance
    _new_eni = _create_eni_if_necessary(interface, vm_)
  File "/usr/lib/python2.7/site-packages/salt/cloud/clouds/ec2.py", line 1433, in _create_eni_if_necessary
    interface['SubnetId'] = _get_subnetname_id(interface['subnetname'])
  File "/usr/lib/python2.7/site-packages/salt/cloud/clouds/ec2.py", line 1246, in _get_subnetname_id
    if tag['key'] == 'Name' and tag['value'] == subnetname:
KeyError: u'key'
```

### What does this PR do?

### What issues does this PR fix or reference?

### Previous Behavior
Remove this section if not relevant

### New Behavior
Remove this section if not relevant

### Tests written?

Yes/No

### Commits signed with GPG?

Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
