### PR TITLE
Reduce nested logic gates in win_certutil

### DIFF
--- a/salt/states/win_certutil.py
+++ b/salt/states/win_certutil.py
@@ -75,6 +75,7 @@ def add_store(name, store, saltenv='base'):
 
     return ret
 
+
 def del_store(name, store, saltenv='base'):
     '''
     Remove a certificate in the given store

--- a/salt/states/win_certutil.py
+++ b/salt/states/win_certutil.py
@@ -55,23 +55,25 @@ def add_store(name, store, saltenv='base'):
     cert_file = __salt__['cp.cache_file'](name, saltenv)
     if cert_file is False:
         ret['result'] = False
-        ret['comment'] += 'Certificate file not found.'
-    else:
-        cert_serial = __salt__['certutil.get_cert_serial'](cert_file)
-        serials = __salt__['certutil.get_stored_cert_serials'](store)
+        ret['comment'] = 'Certificate file not found.'
+        return ret
 
-        if cert_serial not in serials:
-            out = __salt__['certutil.add_store'](name, store)
-            if "successfully" in out:
-                ret['changes']['added'] = name
-            else:
-                ret['result'] = False
-                ret['comment'] += "Failed to store certificate {0}".format(name)
-        else:
-            ret['comment'] += "{0} already stored.".format(name)
+    cert_serial = __salt__['certutil.get_cert_serial'](cert_file)
+    serials = __salt__['certutil.get_stored_cert_serials'](store)
+
+    if cert_serial in serials:
+        ret['comment'] = "{0} already stored.".format(name)
+        return ret
+
+    out = __salt__['certutil.add_store'](name, store)
+    if "successfully" in out:
+        ret['changes']['added'] = name
+        return ret
+
+    ret['result'] = False
+    ret['comment'] = "Failed to store certificate {0}".format(name)
 
     return ret
-
 
 def del_store(name, store, saltenv='base'):
     '''
@@ -97,19 +99,22 @@ def del_store(name, store, saltenv='base'):
     cert_file = __salt__['cp.cache_file'](name, saltenv)
     if cert_file is False:
         ret['result'] = False
-        ret['comment'] += 'Certificate file not found.'
-    else:
-        cert_serial = __salt__['certutil.get_cert_serial'](cert_file)
-        serials = __salt__['certutil.get_stored_cert_serials'](store)
+        ret['comment'] = 'Certificate file not found.'
+        return ret
 
-        if cert_serial in serials:
-            out = __salt__['certutil.del_store'](cert_file, store)
-            if "successfully" in out:
-                ret['changes']['removed'] = name
-            else:
-                ret['result'] = False
-                ret['comment'] += "Failed to remove the certificate {0}".format(name)
-        else:
-            ret['comment'] += "{0} already removed.".format(name)
+    cert_serial = __salt__['certutil.get_cert_serial'](cert_file)
+    serials = __salt__['certutil.get_stored_cert_serials'](store)
+
+    if cert_serial not in serials:
+        ret['comment'] = "{0} already removed.".format(name)
+        return ret
+
+    out = __salt__['certutil.del_store'](cert_file, store)
+    if "successfully" in out:
+        ret['changes']['removed'] = name
+        return ret
+
+    ret['result'] = False
+    ret['comment'] = "Failed to remove the certificate {0}".format(name)
 
     return ret


### PR DESCRIPTION
### What does this PR do?
Breaks early when possible in `win_certutil.py` so as a developer you don't need to read through nested if else statements for additional logic changes.

Also changed `ret['comment'] +=`  to `ret['comment'] =` to signify that the current logic doesn't append multiple strings together.

### What issues does this PR fix or reference?
N/A

### Tests written?
No - existing tests will cover. No logic changes.

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
