### PR TITLE
Remove redundant check from zk_concurrency.py

### DIFF
--- a/salt/states/zk_concurrency.py
+++ b/salt/states/zk_concurrency.py
@@ -186,7 +186,7 @@ def min_party(name,
     num_nodes = len(nodes)
 
     if num_nodes >= min_nodes or blocking:
-        ret['result'] = None if __opts__['test'] else True
+        ret['result'] = True
         if not blocking:
             ret['comment'] = 'Currently {0} nodes, which is >= {1}'.format(num_nodes, min_nodes)
         else:


### PR DESCRIPTION
### What does this PR do?
Remove redundant check since on line 177:
https://github.com/saltstack/salt/compare/develop...clickthisnick:remove-redudant-check-zk_concurrency?expand=1#diff-0a80ccfa036a4d69046186f9f1d1e9b6R177

There is already a check for `if __opts__['test']:` and it will return out of the function if True.

### What issues does this PR fix or reference?
N/A

### Tests written?
No

### Commits signed with GPG?
No
