### PR TITLE
Updated index.rst (example grain reference)

### DIFF
--- a/doc/topics/grains/index.rst
+++ b/doc/topics/grains/index.rst
@@ -118,7 +118,7 @@ the following configuration:
       - state2
 
 For this example to work, you would need to have defined the grain
-``role`` for the minions you wish to match.
+``roles`` for the minions you wish to match.
 
 .. _writing-grains:
 


### PR DESCRIPTION
Minor change regarding leveraging defined grains within the top file. In the cited example, the grain defined would need to be "roles" not "role"

### What does this PR do?
Minor correction in tutorial.

### What issues does this PR fix or reference?
N/A

### Tests written?
No

### Commits signed with GPG?
No
