### PR TITLE
Check for all non-word characters when calling secure_password

### DIFF
--- a/salt/utils/pycrypto.py
+++ b/salt/utils/pycrypto.py
@@ -54,7 +54,7 @@ def secure_password(length=20, use_random=True):
                     except UnicodeDecodeError:
                         continue
                 pw += re.sub(
-                    salt.utils.stringutils.to_str(r'\W'),
+                    salt.utils.stringutils.to_str(r'[\W_]'),
                     str(),  # future lint: disable=blacklisted-function
                     char
                 )

--- a/tests/unit/utils/test_pycrypto.py
+++ b/tests/unit/utils/test_pycrypto.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+
+# Import python libs
+from __future__ import absolute_import, print_function, unicode_literals
+import logging
+import re
+
+# Import Salt Libs
+import salt.utils.pycrypto
+
+# Import Salt Testing Libs
+from tests.support.unit import TestCase
+
+log = logging.getLogger(__name__)
+
+
+class PycryptoTestCase(TestCase):
+    '''
+    TestCase for salt.utils.pycrypto module
+    '''
+
+    def test_gen_hash(self):
+        '''
+        Test gen_hash
+        '''
+        passwd = 'test_password'
+        ret = salt.utils.pycrypto.gen_hash(password=passwd)
+        self.assertTrue(ret.startswith('$6$'))
+
+        ret = salt.utils.pycrypto.gen_hash(password=passwd, algorithm='md5')
+        self.assertTrue(ret.startswith('$1$'))
+
+        ret = salt.utils.pycrypto.gen_hash(password=passwd, algorithm='sha256')
+        self.assertTrue(ret.startswith('$5$'))
+
+    def test_secure_password(self):
+        '''
+        test secure_password
+        '''
+        ret = salt.utils.pycrypto.secure_password()
+        check = re.compile(r'[!@#$%^&*()_=+]')
+        assert check.search(ret) is None
+        assert ret


### PR DESCRIPTION
### What does this PR do?
The `integration.modules.test_shadow` tests are sometimes failing on fedora. What I discovered is `shadow.gen_passwd` is sometimes returning `None`. It returns `None` anytime there is a `_` character in the the `crypt.crypt()` call. below will demonstrate:

```
[root@ip-10-27-42-60 testing]# python -c "import crypt; print(crypt.crypt('blah', '\$6\$3m7s2p4SXgL_mYOL'))"
None
[root@ip-10-27-42-60 testing]# python -c "import crypt; print(crypt.crypt('blah', '\$6\$3m7s2p4SXgLmYOL'))"
$6$3m7s2p4SXgLmYOL$VqLpFYq8D5gy9xhh3x3R00s4NNJgS1JNIcOWguXfIBtKX3oCKZLCbvzrUOQCkt69yMmJSOTdAbImDOYW.OyW51
[root@ip-10-27-42-60 testing]# 
```

As you can see above when we remove the `_` we get whats expected. This PR now checks for all non-word characters and `_` and removes them.


### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/52922

### Previous Behavior
`integration.modules.test_shadow` tests sometimes failed. I even saw this behavior on about 1/10 runs when i was running the test suite.

### New Behavior
`integration.modules.test_shadow` tests pass. I have not seen a flaky test failure during my testing so far after this change. Will monitor jenkins results after this is merged.

### Tests written?

Yes - and also hopefully fixes some flaky tests.

### Commits signed with GPG?

Yes