### PR TITLE
Adds btrfs and xfs to parted module for 2019.2

### DIFF
--- a/salt/modules/parted_partition.py
+++ b/salt/modules/parted_partition.py
@@ -381,8 +381,9 @@ def _is_fstype(fs_type):
     :param fs_type: file system type
     :return: True if fs_type is supported in this module, False otherwise
     '''
-    return fs_type in set(['ext2', 'ext3', 'ext4', 'fat32', 'fat16', 'linux-swap', 'reiserfs',
-                           'hfs', 'hfs+', 'hfsx', 'NTFS', 'ntfs', 'ufs'])
+    return fs_type in set(['btrfs', 'ext2', 'ext3', 'ext4', 'fat32', 'fat16',
+                           'linux-swap', 'reiserfs', 'hfs', 'hfs+', 'hfsx',
+                           'NTFS', 'ntfs', 'ufs', 'xfs'])
 
 
 def mkfs(device, fs_type):


### PR DESCRIPTION
### What does this PR do?

This PR adds btrfs and xfs to the parted module. Both filesystems are supported by `parted` and `mkfs`. The cli tools that are used under the hood.

This is a back-port of #53126 to 2019.2.

### What issues does this PR fix or reference?

#53126

### Previous Behavior
btrfs and xfs where not supported for `parted` and `mkfs.xxx`.

### New Behavior
btrfs and xfs are now supported.

### Tests written?

No

### Commits signed with GPG?

Yes