### PR TITLE
Convert rendered template to bytes before passing to napalm

### DIFF
--- a/salt/modules/napalm_network.py
+++ b/salt/modules/napalm_network.py
@@ -34,6 +34,7 @@ import salt.utils.files
 import salt.utils.napalm
 import salt.utils.versions
 import salt.utils.templates
+import salt.utils.stringutils
 
 # Import 3rd-party libs
 try:
@@ -2011,6 +2012,8 @@ def load_template(template_name=None,
                     __salt__['file.remove'](_temp_tpl_file)
                 else:
                     return _loaded  # exit
+
+        _rendered = salt.utils.stringutils.to_bytes(_rendered)
 
         loaded_config = _rendered
         if _loaded['result']:  # all good


### PR DESCRIPTION
When using python 3.x we need to pass a "bytes-like object" rather
than a string to load_merge_candidate or load_replace_candidate.

Fixes #53115

### What does this PR do?

### What issues does this PR fix or reference?

### Previous Behavior
Remove this section if not relevant

### New Behavior
Remove this section if not relevant

### Tests written?

Yes/No

### Commits signed with GPG?

Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
