### PR TITLE
Convert rendered template to bytes before passing to napalm

### DIFF
--- a/salt/modules/napalm_network.py
+++ b/salt/modules/napalm_network.py
@@ -34,6 +34,7 @@ import salt.utils.files
 import salt.utils.napalm
 import salt.utils.versions
 import salt.utils.templates
+import salt.utils.stringutils
 
 # Import 3rd-party libs
 try:
@@ -2011,6 +2012,8 @@ def load_template(template_name=None,
                     __salt__['file.remove'](_temp_tpl_file)
                 else:
                     return _loaded  # exit
+
+        _rendered = salt.utils.stringutils.to_bytes(_rendered)
 
         loaded_config = _rendered
         if _loaded['result']:  # all good


### PR DESCRIPTION
### What does this PR do?
When using python 3.x we need to pass a "bytes-like object" rather
than a string to load_merge_candidate or load_replace_candidate.

### What issues does this PR fix or reference?

Fixes #53115

### Previous Behavior
```root@34e639493580:/# salt \* state.apply test=True
[WARNING ] /usr/local/lib/python3.7/site-packages/salt/transport/ipc.py:292: DeprecationWarning: encoding is deprecated, Use raw=False instead.
  self.unpacker = msgpack.Unpacker(encoding=encoding)

[WARNING ] /usr/local/lib/python3.7/site-packages/salt/payload.py:149: DeprecationWarning: encoding is deprecated, Use raw=False instead.
  ret = msgpack.loads(msg, use_list=True, ext_hook=ext_type_decoder, encoding=encoding)

testrtr:
----------
          ID: manage_config
    Function: netconfig.managed
      Result: False
     Comment: Cannot execute "load_replace_candidate" on 192.168.122.251 as vyos. Reason: a bytes-like object is required, not 'str'!
              Configuration discarded.
     Started: 10:02:18.571889
    Duration: 13429.473 ms
     Changes:   

Summary for testrtr
------------
Succeeded: 0
Failed:    1
------------
Total states run:     1
Total run time:  13.429 s
ERROR: Minions returned with non-zero exit code
```
### New Behavior
```
root@34e639493580:/# salt \* state.apply test=True
[WARNING ] /usr/local/lib/python3.7/site-packages/salt/transport/ipc.py:292: DeprecationWarning: encoding is deprecated, Use raw=False instead.
  self.unpacker = msgpack.Unpacker(encoding=encoding)

[WARNING ] /usr/local/lib/python3.7/site-packages/salt/payload.py:149: DeprecationWarning: encoding is deprecated, Use raw=False instead.
  ret = msgpack.loads(msg, use_list=True, ext_hook=ext_type_decoder, encoding=encoding)

testrtr:
----------
          ID: manage_config
    Function: netconfig.managed
      Result: True
     Comment: Configuration discarded.
     Started: 12:48:19.981584
    Duration: 18490.453 ms
     Changes:   

Summary for testrtr
------------
Succeeded: 1
Failed:    0
------------
Total states run:     1
Total run time:  18.490 s
```

### Tests written?

No

### Commits signed with GPG?

No

