### PR TITLE
Fix `unit.modules.test_win_file.WinFileTestCase.test_issue_52002_check_file_remove_symlink`

### DIFF
--- a/salt/platform/win.py
+++ b/salt/platform/win.py
@@ -1146,7 +1146,7 @@ def dup_token(th):
 
 def elevate_token(th):
     '''
-    Set all token priviledges to enabled
+    Set all token privileges to enabled
     '''
     # Get list of privileges this token contains
     privileges = win32security.GetTokenInformation(


### PR DESCRIPTION
### What does this PR do?
Attempts to fix the following test on Windows:
```
unit.modules.test_win_file.WinFileTestCase.test_issue_52002_check_file_remove_symlink
```
It's failing with the following error:
```
Traceback (most recent call last):
  File "C:\\Users\\ADMINI~1\\AppData\\Local\\Temp\\kitchen\\testing\tests\support\helpers.py", line 129, in wrap
    return caller(cls)
  File "c:\users\admini~1\appdata\local\temp\kitchen\testing\tests\unit\modules\test_win_file.py", line 76, in test_issue_52002_check_file_remove_symlink
    self.assertTrue(win_file.symlink(target, symlink))
  File "C:\\Users\\ADMINI~1\\AppData\\Local\\Temp\\kitchen\\testing\salt\modules\win_file.py", line 1158, in symlink
    exc.strerror
CommandExecutionError: Could not create 'c:\users\admini~1\appdata\local\temp\base-z7v221\child 2\link' - [1314] A required privilege is not held by the client.	
```
But only when run from kitchen. I believe this has something to do with winrm... it may run as an admin, but without elevating the accounts privileges. This PR attempts to do so before trying to create the symlink.

### What issues does this PR fix or reference?
Jenkins failure

### Tests written?
Fixes a test... hopefully

### Commits signed with GPG?
Yes