### PR TITLE
enable v3 support on keystone. Backward compatible with v2

### DIFF
--- a/salt/auth/keystone.py
+++ b/salt/auth/keystone.py
@@ -25,14 +25,15 @@ def get_auth_url():
 
 
 def get_api_version():
-   '''
-   Try and get the API version from the config, else return v2
-   Valid values v2, v3
-   '''
-   try:
-       return __opts__['keystone.api_version']
-   except KeyError:
-       return 'v2'
+    '''
+    Try and get the API version from the config, else return v2
+    Valid values v2, v3
+    '''
+    try:
+        return __opts__['keystone.api_version']
+    except KeyError:
+        return 'v2'
+
 
 def auth(username, password):
     '''

--- a/salt/auth/keystone.py
+++ b/salt/auth/keystone.py
@@ -7,7 +7,8 @@ Provide authentication using OpenStack Keystone
 
 from __future__ import absolute_import, print_function, unicode_literals
 try:
-    from keystoneclient.v2_0 import client
+    from keystoneclient.v2_0 import client as clientv2
+    from keystoneclient.v3 import client as clientv3
     from keystoneclient.exceptions import AuthorizationFailure, Unauthorized
 except ImportError:
     pass
@@ -23,13 +24,29 @@ def get_auth_url():
         return 'http://localhost:35357/v2.0'
 
 
+def get_api_version():
+   '''
+   Try and get the API version from the config, else return v2
+   Valid values v2, v3
+   '''
+   try:
+       return __opts__['keystone.api_version']
+   except KeyError:
+       return 'v2'
+
 def auth(username, password):
     '''
     Try and authenticate
     '''
     try:
-        keystone = client.Client(username=username, password=password,
+        if get_api_version() == 'v2':
+            keystone = cilentv2.Client(username=username, password=password,
                                  auth_url=get_auth_url())
+        elif get_api_version() == 'v3':
+            keystone = clientv3.Client(username=username, password=password,
+                                 auth_url=get_auth_url())
+        else:
+            return False
         return keystone.authenticate()
     except (AuthorizationFailure, Unauthorized):
         return False

--- a/salt/auth/keystone.py
+++ b/salt/auth/keystone.py
@@ -41,7 +41,7 @@ def auth(username, password):
     '''
     try:
         if get_api_version() == 'v2':
-            keystone = cilentv2.Client(username=username, password=password,
+            keystone = clientv2.Client(username=username, password=password,
                                  auth_url=get_auth_url())
         elif get_api_version() == 'v3':
             keystone = clientv3.Client(username=username, password=password,


### PR DESCRIPTION
### What does this PR do?
Enables keystone v3 support for authentication

### Previous Behavior
only v2 supported

### New Behavior
api version configurable in master config using keystone.api_version parameter. Options v2, v3.

### Tests written?

No

### Commits signed with GPG?

No

