### PR TITLE
Update file.chattr

### DIFF
--- a/tests/unit/modules/test_file.py
+++ b/tests/unit/modules/test_file.py
@@ -1960,3 +1960,368 @@ class FileBasicsTestCase(TestCase, LoaderModuleMockMixin):
             ret = filemod.source_list(
                 [{'file://' + self.myfile: ''}], 'filehash', 'base')
             self.assertEqual(list(ret), ['file://' + self.myfile, 'filehash'])
+
+
+class LsattrTests(TestCase, LoaderModuleMockMixin):
+    def setup_loader_modules(self):
+        return {
+            filemod: {
+                '__salt__': {
+                    'cmd.run': cmdmod.run,
+                },
+            },
+        }
+
+    def run(self, result=None):
+        patch_aix = patch(
+            'salt.utils.platform.is_aix',
+            Mock(return_value=False),
+        )
+        patch_exists = patch(
+            'os.path.exists',
+            Mock(return_value=True),
+        )
+        patch_which = patch(
+            'salt.utils.path.which',
+            Mock(return_value='fnord'),
+        )
+        with patch_aix, patch_exists, patch_which:
+            super(LsattrTests, self).run(result)
+
+    def test_if_lsattr_is_missing_it_should_return_None(self):
+        patch_which = patch(
+            'salt.utils.path.which',
+            Mock(return_value=None),
+        )
+        with patch_which:
+            actual = filemod.lsattr('foo')
+            assert actual is None, actual
+
+    def test_on_aix_lsattr_should_be_None(self):
+        patch_aix = patch(
+            'salt.utils.platform.is_aix',
+            Mock(return_value=True),
+        )
+        with patch_aix:
+            # SaltInvocationError will be raised if filemod.lsattr
+            # doesn't early exit
+            actual = filemod.lsattr('foo')
+            self.assertIsNone(actual)
+
+    def test_SaltInvocationError_should_be_raised_when_file_is_missing(self):
+        patch_exists = patch(
+            'os.path.exists',
+            Mock(return_value=False),
+        )
+        with patch_exists, self.assertRaises(SaltInvocationError):
+            filemod.lsattr('foo')
+
+    def test_if_chattr_version_is_less_than_required_flags_should_ignore_extended(self):
+        fname = '/path/to/fnord'
+        with_extended = textwrap.dedent(
+            '''
+            aAcCdDeijPsStTu---- {}
+            '''
+        ).strip().format(fname)
+        expected = set('acdijstuADST')
+        patch_has_ext = patch(
+            'salt.modules.file._chattr_has_extended_attrs',
+            Mock(return_value=False),
+        )
+        patch_run = patch.dict(
+            filemod.__salt__,
+            {'cmd.run': Mock(return_value=with_extended)},
+        )
+        with patch_has_ext, patch_run:
+            actual = set(filemod.lsattr(fname)[fname])
+            msg = 'Actual: {!r} Expected: {!r}'.format(actual, expected)  # pylint: disable=E1322
+            assert actual == expected, msg
+
+    def test_if_chattr_version_is_high_enough_then_extended_flags_should_be_returned(self):
+        fname = '/path/to/fnord'
+        with_extended = textwrap.dedent(
+            '''
+            aAcCdDeijPsStTu---- {}
+            '''
+        ).strip().format(fname)
+        expected = set('aAcCdDeijPsStTu')
+        patch_has_ext = patch(
+            'salt.modules.file._chattr_has_extended_attrs',
+            Mock(return_value=True),
+        )
+        patch_run = patch.dict(
+            filemod.__salt__,
+            {'cmd.run': Mock(return_value=with_extended)},
+        )
+        with patch_has_ext, patch_run:
+            actual = set(filemod.lsattr(fname)[fname])
+            msg = 'Actual: {!r} Expected: {!r}'.format(actual, expected)  # pylint: disable=E1322
+            assert actual == expected, msg
+
+    def test_if_supports_extended_but_there_are_no_flags_then_none_should_be_returned(self):
+        fname = '/path/to/fnord'
+        with_extended = textwrap.dedent(
+            '''
+            ------------------- {}
+            '''
+        ).strip().format(fname)
+        expected = set('')
+        patch_has_ext = patch(
+            'salt.modules.file._chattr_has_extended_attrs',
+            Mock(return_value=True),
+        )
+        patch_run = patch.dict(
+            filemod.__salt__,
+            {'cmd.run': Mock(return_value=with_extended)},
+        )
+        with patch_has_ext, patch_run:
+            actual = set(filemod.lsattr(fname)[fname])
+            msg = 'Actual: {!r} Expected: {!r}'.format(actual, expected)  # pylint: disable=E1322
+            assert actual == expected, msg
+
+
+# This should create a merge conflict with ChattrVersionTests when
+# a merge forward to develop happens. Develop's changes are made
+# obsolete by this ChattrTests class, and should be removed in favor
+# of this change.
+class ChattrTests(TestCase, LoaderModuleMockMixin):
+    def setup_loader_modules(self):
+        return {
+            filemod: {
+                '__salt__': {
+                    'cmd.run': cmdmod.run,
+                },
+                '__opts__': {
+                    'test': False,
+                },
+            },
+        }
+
+    def run(self, result=None):
+        patch_aix = patch(
+            'salt.utils.platform.is_aix',
+            Mock(return_value=False),
+        )
+        patch_exists = patch(
+            'os.path.exists',
+            Mock(return_value=True),
+        )
+        patch_which = patch(
+            'salt.utils.path.which',
+            Mock(return_value='some/tune2fs'),
+        )
+        with patch_aix, patch_exists, patch_which:
+            super(ChattrTests, self).run(result)
+
+    def test_chattr_version_returns_None_if_no_tune2fs_exists(self):
+        patch_which = patch(
+            'salt.utils.path.which',
+            Mock(return_value=''),
+        )
+        with patch_which:
+            actual = filemod._chattr_version()
+            self.assertIsNone(actual)
+
+    def test_on_aix_chattr_version_should_be_None_even_if_tune2fs_exists(self):
+        patch_which = patch(
+            'salt.utils.path.which',
+            Mock(return_value='fnord'),
+        )
+        patch_aix = patch(
+            'salt.utils.platform.is_aix',
+            Mock(return_value=True),
+        )
+        mock_run = MagicMock(return_value='fnord')
+        patch_run = patch.dict(filemod.__salt__, {'cmd.run': mock_run})
+        with patch_which, patch_aix, patch_run:
+            actual = filemod._chattr_version()
+            self.assertIsNone(actual)
+            mock_run.assert_not_called()
+
+    def test_chattr_version_should_return_version_from_tune2fs(self):
+        expected = '1.43.4'
+        sample_output = textwrap.dedent(
+            '''
+            tune2fs 1.43.4 (31-Jan-2017)
+            Usage: tune2fs [-c max_mounts_count] [-e errors_behavior] [-f] [-g group]
+            [-i interval[d|m|w]] [-j] [-J journal_options] [-l]
+            [-m reserved_blocks_percent] [-o [^]mount_options[,...]]
+            [-p mmp_update_interval] [-r reserved_blocks_count] [-u user]
+            [-C mount_count] [-L volume_label] [-M last_mounted_dir]
+            [-O [^]feature[,...]] [-Q quota_options]
+            [-E extended-option[,...]] [-T last_check_time] [-U UUID]
+            [-I new_inode_size] [-z undo_file] device
+            '''
+        )
+        patch_which = patch(
+            'salt.utils.path.which',
+            Mock(return_value='fnord'),
+        )
+        patch_run = patch.dict(
+            filemod.__salt__,
+            {'cmd.run': MagicMock(return_value=sample_output)},
+        )
+        with patch_which, patch_run:
+            actual = filemod._chattr_version()
+            self.assertEqual(actual, expected)
+
+    def test_if_tune2fs_has_no_version_version_should_be_None(self):
+        patch_which = patch(
+            'salt.utils.path.which',
+            Mock(return_value='fnord'),
+        )
+        patch_run = patch.dict(
+            filemod.__salt__,
+            {'cmd.run': MagicMock(return_value='fnord')},
+        )
+        with patch_which, patch_run:
+            actual = filemod._chattr_version()
+            self.assertIsNone(actual)
+
+    def test_chattr_has_extended_attrs_should_return_False_if_chattr_version_is_None(self):
+        patch_chattr = patch(
+            'salt.modules.file._chattr_version',
+            Mock(return_value=None),
+        )
+        with patch_chattr:
+            actual = filemod._chattr_has_extended_attrs()
+            assert not actual, actual
+
+    def test_chattr_has_extended_attrs_should_return_False_if_version_is_too_low(self):
+        below_expected = '0.1.1'
+        patch_chattr = patch(
+            'salt.modules.file._chattr_version',
+            Mock(return_value=below_expected),
+        )
+        with patch_chattr:
+            actual = filemod._chattr_has_extended_attrs()
+            assert not actual, actual
+
+    def test_chattr_has_extended_attrs_should_return_False_if_version_is_equal_threshold(self):
+        threshold = '1.41.12'
+        patch_chattr = patch(
+            'salt.modules.file._chattr_version',
+            Mock(return_value=threshold),
+        )
+        with patch_chattr:
+            actual = filemod._chattr_has_extended_attrs()
+            assert not actual, actual
+
+    def test_chattr_has_extended_attrs_should_return_True_if_version_is_above_threshold(self):
+        higher_than = '1.41.13'
+        patch_chattr = patch(
+            'salt.modules.file._chattr_version',
+            Mock(return_value=higher_than),
+        )
+        with patch_chattr:
+            actual = filemod._chattr_has_extended_attrs()
+            assert actual, actual
+
+    def test_check_perms_should_report_no_attr_changes_if_there_are_none(self):
+        filename = '/path/to/fnord'
+        attrs = 'aAcCdDeijPsStTu'
+
+        higher_than = '1.41.13'
+        patch_chattr = patch(
+            'salt.modules.file._chattr_version',
+            Mock(return_value=higher_than),
+        )
+        patch_exists = patch(
+            'os.path.exists',
+            Mock(return_value=True),
+        )
+        patch_stats = patch(
+            'salt.modules.file.stats',
+            Mock(return_value={
+                'user': 'foo',
+                'group': 'bar',
+                'mode': '123',
+            }),
+        )
+        patch_run = patch.dict(
+            filemod.__salt__,
+            {'cmd.run': MagicMock(return_value='--------- '+filename)},
+        )
+        with patch_chattr, patch_exists, patch_stats, patch_run:
+            actual_ret, actual_perms = filemod.check_perms(
+                name=filename,
+                ret=None,
+                user='foo',
+                group='bar',
+                mode='123',
+                attrs=attrs,
+                follow_symlinks=False,
+            )
+            assert actual_ret.get('changes', {}).get('attrs')is None, actual_ret
+
+    def test_check_perms_should_report_attrs_new_and_old_if_they_changed(self):
+        filename = '/path/to/fnord'
+        attrs = 'aAcCdDeijPsStTu'
+        existing_attrs = 'aeiu'
+        expected = {
+            'attrs': {
+                'old': existing_attrs,
+                'new': attrs,
+            },
+        }
+
+        higher_than = '1.41.13'
+        patch_chattr = patch(
+            'salt.modules.file._chattr_version',
+            Mock(return_value=higher_than),
+        )
+        patch_stats = patch(
+            'salt.modules.file.stats',
+            Mock(return_value={
+                'user': 'foo',
+                'group': 'bar',
+                'mode': '123',
+            }),
+        )
+        patch_cmp = patch(
+            'salt.modules.file._cmp_attrs',
+            MagicMock(side_effect=[
+                filemod.AttrChanges(
+                    added='aAcCdDeijPsStTu',
+                    removed='',
+                ),
+                filemod.AttrChanges(
+                    None,
+                    None,
+                ),
+            ]),
+        )
+        patch_chattr = patch(
+            'salt.modules.file.chattr',
+            MagicMock(),
+        )
+
+        def fake_cmd(cmd, *args, **kwargs):
+            if cmd == ['lsattr', '/path/to/fnord']:
+                return textwrap.dedent(
+                    '''
+                    {}---- {}
+                    '''.format(existing_attrs, filename)
+                ).strip()
+            else:
+                assert False, "not sure how to handle {}".format(cmd)
+
+        patch_run = patch.dict(
+            filemod.__salt__,
+            {'cmd.run': MagicMock(side_effect=fake_cmd)},
+        )
+        patch_ver = patch(
+            'salt.modules.file._chattr_has_extended_attrs',
+            MagicMock(return_value=True),
+        )
+        with patch_chattr, patch_stats, patch_cmp, patch_run, patch_ver:
+            actual_ret, actual_perms = filemod.check_perms(
+                name=filename,
+                ret=None,
+                user='foo',
+                group='bar',
+                mode='123',
+                attrs=attrs,
+                follow_symlinks=False,
+            )
+            self.assertDictEqual(actual_ret['changes'], expected)


### PR DESCRIPTION
### What does this PR do?

Fixes issues with chattr that cause failing tests on RedHat platforms

### What issues does this PR fix or reference?

#52079 (partially, still need to re-install e2fsprogs on the suse boxes)

### Previous Behavior

Before, `check_perms` removed all the file attrs and then added them back, before setting the requested permissions. On certain platforms (RedHat), adding the extent formatting flat (e) is impossible. Removing all flags and then adding them back caused a failure here.

By removing then re-adding the flags, we were also steamrolling over any safety bits someone may have set on their files (e.g. append(a) or immutable(i)).

While this version doesn't actually have the `e` flag, it *does* have the flag removal/readdition behavior.

### New Behavior

Now attributes are only added or removed as requested. If someone is setting attributes on their files, we won't ignore them any more.

### Tests written?

Yes - and many more to cover this section of code.

### Commits signed with GPG?

Yes