### PR TITLE
Skip `test_gen_hash` test on Windows

### DIFF
--- a/salt/utils/pycrypto.py
+++ b/salt/utils/pycrypto.py
@@ -25,6 +25,7 @@ except ImportError:
 
 try:
     # Windows does not have the crypt module
+    # consider using passlib.hash instead
     import crypt
     HAS_CRYPT = True
 except ImportError:

--- a/tests/unit/utils/test_pycrypto.py
+++ b/tests/unit/utils/test_pycrypto.py
@@ -7,9 +7,10 @@ import re
 
 # Import Salt Libs
 import salt.utils.pycrypto
+import salt.utils.platform
 
 # Import Salt Testing Libs
-from tests.support.unit import TestCase
+from tests.support.unit import TestCase, skipIf
 
 log = logging.getLogger(__name__)
 
@@ -19,6 +20,7 @@ class PycryptoTestCase(TestCase):
     TestCase for salt.utils.pycrypto module
     '''
 
+    @skipIf(salt.utils.platform.is_windows(), 'No crypto module for Windows')
     def test_gen_hash(self):
         '''
         Test gen_hash


### PR DESCRIPTION
### What does this PR do?
Skips `unit.utils.test_pycrypto.PycryptoTestCase.test_gen_hash` on Windows. The `gen_hash` function uses the `crypto` library which is linux only. https://pypi.org/project/crypto/

### What issues does this PR fix or reference?
Jenkins

### Tests written?
Fixed

### Commits signed with GPG?
Yes