### PR TITLE
Fix file.directory mode behaviour in def _check_directory

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -780,7 +780,7 @@ def _check_directory(name,
     if not os.path.isdir(name):
         changes[name] = {'directory': 'new'}
     if changes:
-        comments = ['The following files or dirs will be changed:\n']
+        comments = ['The following files will be changed:\n']
         for fn_ in changes:
             for key, val in six.iteritems(changes[fn_]):
                 comments.append('{0}: {1} - {2}\n'.format(fn_, key, val))

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -780,7 +780,7 @@ def _check_directory(name,
     if not os.path.isdir(name):
         changes[name] = {'directory': 'new'}
     if changes:
-        comments = ['The following files/dirs will be changed:\n']
+        comments = ['The following files or dirs will be changed:\n']
         for fn_ in changes:
             for key, val in six.iteritems(changes[fn_]):
                 comments.append('{0}: {1} - {2}\n'.format(fn_, key, val))


### PR DESCRIPTION
### What does this PR do?
This PR definitively fixes the behaviour of the file.directory module so it reflects the expected (documented) behaviour.

It therefore fixes issues #51903 and #52024 aswell.

I have published a [gist](https://gist.github.com/hktb/18ab8a1781fff799de19ed4e876abe69) which details all aspects of this fix.

### Commits signed with GPG?

No
