### PR TITLE
Sync modules by default

### DIFF
--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -1098,7 +1098,7 @@ def highstate(test=None, queue=False, **kwargs):
     return ret
 
 
-def sls(mods, test=None, exclude=None, queue=False, sync_mods=None, **kwargs):
+def sls(mods, test=None, exclude=None, queue=False, sync_mods=True, **kwargs):
     '''
     Execute the states in one or more SLS files
 


### PR DESCRIPTION
I recently ran into an issue where my minion cache was cleared and I
ran `state.apply xxx` only to eventually find modules aren't sync'd.
My `xxx` state called a custom module and it failed with vague jinja2
error.

I assumed modules would be sync'd by that command, since they are sync'd by
`state.apply` with no mod arg and `state.highstate` (which, of course,
are equivalent). I think that's a reasonable assumption, so here I'm
proposing that all modules should be sync'd by default.

In my case here's where this is called:

https://github.com/saltstack/salt/blob/develop/salt/modules/state.py#L778

### What does this PR do?

See above.

### What issues does this PR fix or reference?

N/A

### Previous Behavior

See above.

### New Behavior

See above.

### Tests written?

No.... hopefully already covered?

### Commits signed with GPG?

No

