### PR TITLE
fixes integration.states.test_cmd on win

### DIFF
--- a/tests/integration/states/test_cmd.py
+++ b/tests/integration/states/test_cmd.py
@@ -46,9 +46,11 @@ class CMDTest(ModuleCase, SaltReturnAssertsMixin):
         '''
         cmd.run with output hidden
         '''
+
+        cmd = u'dir' if IS_WINDOWS else u'ls'
         ret = self.run_state(
             u'cmd.run',
-            name=u'ls',
+            name=cmd,
             hide_output=True)
         self.assertSaltTrueReturn(ret)
         ret = ret[next(iter(ret))]


### PR DESCRIPTION
### What does this PR do?
fixes integration.states.test_cmd on win

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/53218

### Previous Behavior
integration.states.test_cmd.CMDTest.test_run_hide_output would fail on win

### Tests written?

No... it is a test

### Commits signed with GPG?
Yes

