### PR TITLE
[WIP] Bugfix: Handle multibyte characters spanning blocks of received data

### DIFF
--- a/salt/utils/vt.py
+++ b/salt/utils/vt.py
@@ -32,7 +32,6 @@ import logging
 
 # Import salt libs
 from salt.ext import six
-from salt.ext.six.moves import range
 
 mswindows = (sys.platform == "win32")
 

--- a/salt/utils/vt.py
+++ b/salt/utils/vt.py
@@ -658,7 +658,9 @@ class Terminal(object):
             # ----- Helper function for processing STDERR and STDOUT -------->
             def read_and_decode_fd(fd, maxsize, partial_data_attr=None):
                 bytes_read = getattr(self, partial_data_attr, b'')
-                bytes_read += os.read(fd, maxsize)
+                # Only read one byte if we already have some existing data
+                # to try and complete a split multibyte character
+                bytes_read += os.read(fd, 1 if len(bytes_read) else maxsize)
                 try:
                     decoded_data =  self._translate_newlines(
                         salt.utils.stringutils.to_unicode(bytes_read)

--- a/salt/utils/vt.py
+++ b/salt/utils/vt.py
@@ -120,6 +120,9 @@ class Terminal(object):
                  # sys.stdXYZ streaming options
                  stream_stdout=None,
                  stream_stderr=None,
+
+                 # Used for tests
+                 force_receive_encoding=__salt_system_encoding__,
                  ):
 
         # Let's avoid Zombies!!!
@@ -136,6 +139,7 @@ class Terminal(object):
         self.cwd = cwd
         self.env = env
         self.preexec_fn = preexec_fn
+        self.receive_encoding = force_receive_encoding
 
         # ----- Set the desired terminal size ------------------------------->
         if rows is None and cols is None:
@@ -663,7 +667,8 @@ class Terminal(object):
                 bytes_read += os.read(fd, 1 if len(bytes_read) else maxsize)
                 try:
                     decoded_data =  self._translate_newlines(
-                        salt.utils.stringutils.to_unicode(bytes_read)
+                        salt.utils.stringutils.to_unicode(bytes_read,
+                                                          self.receive_encoding)
                     )
                     if partial_data_attr is not None:
                         setattr(self, partial_data_attr, b'')

--- a/salt/utils/vt.py
+++ b/salt/utils/vt.py
@@ -619,7 +619,7 @@ class Terminal(object):
                 if not rlist:
                     self.flag_eof_stdout = self.flag_eof_stderr = True
                     log.debug('End of file(EOL). Slow platform.')
-                    if self.patrial_data_stdout or self.patrial_data_stderr: 
+                    if self.patrial_data_stdout or self.patrial_data_stderr:
                         # There is data that was received but for which
                         # decoding failed, attempt decoding again to generate
                         # relevant exception
@@ -663,20 +663,21 @@ class Terminal(object):
                 bytes_read = getattr(self, partial_data_attr, b'')
                 # Only read one byte if we already have some existing data
                 # to try and complete a split multibyte character
-                bytes_read += os.read(fd, 1 if len(bytes_read) else maxsize)
+                bytes_read += os.read(fd, maxsize if not bytes_read else 1)
                 try:
-                    decoded_data =  self._translate_newlines(
-                        salt.utils.stringutils.to_unicode(bytes_read,
-                                                          self.receive_encoding)
+                    decoded_data = self._translate_newlines(
+                        salt.utils.stringutils.to_unicode(
+                            bytes_read,
+                            self.receive_encoding)
                     )
                     if partial_data_attr is not None:
                         setattr(self, partial_data_attr, b'')
                     return decoded_data, False
                 except UnicodeDecodeError as ex:
                     max_multibyte_character_length = 4
-                    if (ex.start > (len(bytes_read) -
-                                    max_multibyte_character_length)
-                        and ex.end == len(bytes_read)):
+                    if ex.start > (
+                            len(bytes_read) - max_multibyte_character_length
+                    ) and ex.end == len(bytes_read):
                         # We weren't able to decode the received data possibly
                         # because it is a multibyte character split across
                         # blocks. Save what data we have to try and decode

--- a/salt/utils/vt.py
+++ b/salt/utils/vt.py
@@ -32,6 +32,7 @@ import logging
 
 # Import salt libs
 from salt.ext import six
+from salt.ext.six.moves import range
 
 mswindows = (sys.platform == "win32")
 

--- a/salt/utils/vt.py
+++ b/salt/utils/vt.py
@@ -639,14 +639,32 @@ class Terminal(object):
                     return None, None
             # <---- Nothing to Process!? -------------------------------------
 
+            # ----- Helper function for processing STDERR and STDOUT -------->
+            def read_and_decode_fd(fd, maxsize):
+                bytes_read = os.read(fd, maxsize)
+                # Loop to handle the case where a multi-byte unicode
+                # character is split across blocks of received bytes
+                while True:
+                    try:
+                        return self._translate_newlines(
+                            salt.utils.stringutils.to_unicode(bytes_read)
+                        )
+                    except UnicodeDecodeError as ex:
+                        if ex.reason == 'unexpected end of data':
+                            new_bytes_read = os.read(fd, maxsize)
+                            if new_bytes_read == b'':
+                                # End of stream is an incomplete character
+                                # Raise exception to avoid infinite loop
+                                raise
+                            bytes_read += new_bytes_read
+                        else:
+                            raise
+            # <---- Helper function for processing STDERR and STDOUT ---------
+
             # ----- Process STDERR ------------------------------------------>
             if self.child_fde in rlist:
                 try:
-                    stderr = self._translate_newlines(
-                        salt.utils.stringutils.to_unicode(
-                            os.read(self.child_fde, maxsize)
-                        )
-                    )
+                    stderr = read_and_decode_fd(self.child_fde, maxsize)
 
                     if not stderr:
                         self.flag_eof_stderr = True
@@ -675,11 +693,7 @@ class Terminal(object):
             # ----- Process STDOUT ------------------------------------------>
             if self.child_fd in rlist:
                 try:
-                    stdout = self._translate_newlines(
-                        salt.utils.stringutils.to_unicode(
-                            os.read(self.child_fd, maxsize)
-                        )
-                    )
+                    stdout = read_and_decode_fd(self.child_fd, maxsize)
 
                     if not stdout:
                         self.flag_eof_stdout = True

--- a/tests/unit/utils/test_vt.py
+++ b/tests/unit/utils/test_vt.py
@@ -292,10 +292,11 @@ class VTTestCase(TestCase):
                                                                 encoding)
             python_command = '\n'.join((
                 'import sys',
+                'import os',
                 'with open(\'' + file_path_stdout + '\', \'rb\') as fout:',
-                '    sys.stdout.buffer.write(fout.read())',
+                '    os.write(sys.stdout.fileno(), fout.read())',
                 'with open(\'' + file_path_stderr + '\', \'rb\') as ferr:',
-                '    sys.stderr.buffer.write(ferr.read())',))
+                '    os.write(sys.stderr.fileno(), ferr.read())',))
             term = salt.utils.vt.Terminal(
                 args=[sys.executable,
                       '-c',
@@ -354,10 +355,11 @@ class VTTestCase(TestCase):
                                                                 encoding)
             python_command = '\n'.join((
                 'import sys',
+                'import os',
                 'with open(\'' + file_path_stdout + '\', \'rb\') as fout:',
-                '    sys.stdout.buffer.write(fout.read())',
+                '    os.write(sys.stdout.fileno(), fout.read())',
                 'with open(\'' + file_path_stderr + '\', \'rb\') as ferr:',
-                '    sys.stderr.buffer.write(ferr.read())',))
+                '    os.write(sys.stderr.fileno(), ferr.read())',))
             term = salt.utils.vt.Terminal(
                 args=[sys.executable,
                       '-c',

--- a/tests/unit/utils/test_vt.py
+++ b/tests/unit/utils/test_vt.py
@@ -248,8 +248,6 @@ class VTTestCase(TestCase):
                 if stderr:
                     buffer_e += stderr
 
-            self.assertEqual(len(buffer_o), len(expected_stdout))
-            self.assertEqual(len(buffer_e), len(expected_stderr))
             self.assertEqual(buffer_o, expected_stdout)
             self.assertEqual(buffer_e, expected_stderr)
         finally:

--- a/tests/unit/utils/test_vt.py
+++ b/tests/unit/utils/test_vt.py
@@ -17,6 +17,7 @@ import random
 import subprocess
 import time
 import tempfile
+import shutil
 
 # Import Salt Testing libs
 from tests.support.unit import TestCase, skipIf
@@ -264,9 +265,7 @@ class VTTestCase(TestCase):
             finally:
                 term.close(terminate=True, kill=True)
         finally:
-            os.remove(file_path_stdout)
-            os.remove(file_path_stderr)
-            os.removedirs(tempdir)
+            shutil.rmtree(tempdir)
 
     def test_split_multibyte_characters_shiftjis(self):
         block_size = 1024
@@ -316,6 +315,4 @@ class VTTestCase(TestCase):
             finally:
                 term.close(terminate=True, kill=True)
         finally:
-            os.remove(file_path_stdout)
-            os.remove(file_path_stderr)
-            os.removedirs(tempdir)
+            shutil.rmtree(tempdir)

--- a/tests/unit/utils/test_vt.py
+++ b/tests/unit/utils/test_vt.py
@@ -258,6 +258,10 @@ class VTTestCase(TestCase):
             term.close(terminate=True, kill=True)
             
     def test_split_multibyte_characters_unicode(self):
+        '''
+            Tests that the vt correctly handles multibyte characters that are
+            split between blocks of transmitted data.
+        '''
         if not stdout_fileno_available() and 'TEST_VT_CHILD' not in os.environ:
             self.run_test_in_subprocess(
                 'test_split_multibyte_characters_unicode'

--- a/tests/unit/utils/test_vt.py
+++ b/tests/unit/utils/test_vt.py
@@ -40,7 +40,7 @@ def stdout_fileno_available():
         sys.stdout.fileno()
         return True
     except:
-        return False   
+        return False
 
 class VTTestCase(TestCase):
 

--- a/tests/unit/utils/test_vt.py
+++ b/tests/unit/utils/test_vt.py
@@ -69,6 +69,7 @@ class VTTestCase(TestCase):
                     sys.executable,
                     os.path.join(test_root, 'tests/runtests.py'),
                     '--name=unit.utils.test_vt.VTTestCase.' + test_name,
+                    '--verbose',
                 ),
                 cwd=test_root,
                 env=dict(os.environ, TEST_VT_CHILD='1'),

--- a/tests/unit/utils/test_vt.py
+++ b/tests/unit/utils/test_vt.py
@@ -226,9 +226,9 @@ class VTTestCase(TestCase):
             # stderr is offset by one byte to guarentee a split character in
             # one of the output streams
             stderr_content = b'\x2E' + stdout_content
-            with open(file_path_stdout, "wb") as fout:
+            with salt.utils.fopen(file_path_stdout, "wb") as fout:
                 fout.write(stdout_content)
-            with open(file_path_stderr, "wb") as ferr:
+            with salt.utils.fopen(file_path_stderr, "wb") as ferr:
                 ferr.write(stderr_content)
 
             expected_stdout = salt.utils.stringutils.to_unicode(stdout_content,

--- a/tests/unit/utils/test_vt.py
+++ b/tests/unit/utils/test_vt.py
@@ -18,6 +18,7 @@ import subprocess
 import time
 import tempfile
 import shutil
+import io
 
 # Import Salt Testing libs
 from tests.support.unit import TestCase, skipIf
@@ -32,6 +33,7 @@ import salt.utils.stringutils
 # Import 3rd-party libs
 from salt.ext.six.moves import range  # pylint: disable=import-error,redefined-builtin
 
+
 def stdout_fileno_available():
     '''
         Tests if sys.stdout.fileno is available in this testing environment
@@ -39,8 +41,9 @@ def stdout_fileno_available():
     try:
         sys.stdout.fileno()
         return True
-    except:
+    except io.UnsupportedOperation:
         return False
+
 
 class VTTestCase(TestCase):
 

--- a/tests/unit/utils/test_vt.py
+++ b/tests/unit/utils/test_vt.py
@@ -219,7 +219,8 @@ class VTTestCase(TestCase):
     def test_split_multibyte_characters_unicode(self):
         block_size = 1024
         encoding = 'utf-8'
-        with tempfile.TemporaryDirectory() as tempdir:
+        try:
+            tempdir = tempfile.mkdtemp()
             file_path_stdout = os.path.join(tempdir, "stdout.txt")
             file_path_stderr = os.path.join(tempdir, "stderr.txt")
             stdout_content = b'\xE2\x80\xA6' * 4 * block_size
@@ -262,11 +263,16 @@ class VTTestCase(TestCase):
                 self.assertEqual(buffer_e, expected_stderr)
             finally:
                 term.close(terminate=True, kill=True)
+        finally:
+            os.remove(file_path_stdout)
+            os.remove(file_path_stderr)
+            os.removedirs(tempdir)
 
     def test_split_multibyte_characters_shiftjis(self):
         block_size = 1024
         encoding = 'shift-jis'
-        with tempfile.TemporaryDirectory() as tempdir:
+        try:
+            tempdir = tempfile.mkdtemp()
             file_path_stdout = os.path.join(tempdir, "stdout.txt")
             file_path_stderr = os.path.join(tempdir, "stderr.txt")
             stdout_content = b'\x8B\x80' * 4 * block_size
@@ -309,3 +315,7 @@ class VTTestCase(TestCase):
                 self.assertEqual(buffer_e, expected_stderr)
             finally:
                 term.close(terminate=True, kill=True)
+        finally:
+            os.remove(file_path_stdout)
+            os.remove(file_path_stderr)
+            os.removedirs(tempdir)

--- a/tests/unit/utils/test_vt.py
+++ b/tests/unit/utils/test_vt.py
@@ -217,8 +217,18 @@ class VTTestCase(TestCase):
         finally:
             term.close(terminate=True, kill=True)
 
+    def stdout_fileno_available():
+        """
+            Tests if sys.stdout.fileno is available in this testing enviroment
+        """
+        try:
+            sys.stdout.fileno()
+            return True
+        except:
+            return False            
+            
     @skipIf(
-        'JENKINS_URL' in os.environ,
+        not stdout_fileno_available(),
         'Disabled until use of sys.stdout.fileno is possible in CI test suite'
     )
     def test_split_multibyte_characters_unicode(self):
@@ -274,7 +284,7 @@ class VTTestCase(TestCase):
             shutil.rmtree(tempdir, ignore_errors=True)
 
     @skipIf(
-        'JENKINS_URL' in os.environ,
+        not stdout_fileno_available(),
         'Disabled until use of sys.stdout.fileno is possible in CI test suite'
     )
     def test_split_multibyte_characters_shiftjis(self):

--- a/tests/unit/utils/test_vt.py
+++ b/tests/unit/utils/test_vt.py
@@ -32,6 +32,15 @@ import salt.utils.stringutils
 # Import 3rd-party libs
 from salt.ext.six.moves import range  # pylint: disable=import-error,redefined-builtin
 
+def stdout_fileno_available():
+    """
+        Tests if sys.stdout.fileno is available in this testing enviroment
+    """
+    try:
+        sys.stdout.fileno()
+        return True
+    except:
+        return False   
 
 class VTTestCase(TestCase):
 
@@ -216,16 +225,6 @@ class VTTestCase(TestCase):
             self.assertIsNone(stdout)
         finally:
             term.close(terminate=True, kill=True)
-
-    def stdout_fileno_available():
-        """
-            Tests if sys.stdout.fileno is available in this testing enviroment
-        """
-        try:
-            sys.stdout.fileno()
-            return True
-        except:
-            return False            
             
     @skipIf(
         not stdout_fileno_available(),

--- a/tests/unit/utils/test_vt.py
+++ b/tests/unit/utils/test_vt.py
@@ -49,8 +49,21 @@ class VTTestCase(TestCase):
 
     def run_test_in_subprocess(self, test_name):
         '''
-            Runs a named test in a new instance of python to avoid broken
-            sys.stdout.fileno method
+            Runs a named test in a new instance of python.
+
+            The sys.stdout.fileno function is unavailable to the tests when run
+            in the Salt CI system. This method is used to run the tests in a
+            separate instance of python to avoid this problem.
+            This method asserts the exit code of the run test is 0 to cause a
+            failure in the run test to result in a failure of the calling test.
+
+            The TEST_VT_CHILD environmental variable is added to the
+            environment of the child process to allow tests to detect they are
+            in a child process and avoid calling this method again. Should they
+            do so then this method will fail the test to avoid recursively
+            spawning processes indefinitely.
+
+            @param test_name: The name of a test in the VTTestCase class
         '''
         test_root = os.path.abspath(
             os.path.join(

--- a/tests/unit/utils/test_vt.py
+++ b/tests/unit/utils/test_vt.py
@@ -265,7 +265,9 @@ class VTTestCase(TestCase):
             finally:
                 term.close(terminate=True, kill=True)
         finally:
-            shutil.rmtree(tempdir)
+            # Ignore errors because on some platforms the tempdir doesn't exist
+            # which would seem be indicative of deeper problems
+            shutil.rmtree(tempdir, ignore_errors=True)
 
     def test_split_multibyte_characters_shiftjis(self):
         block_size = 1024
@@ -315,4 +317,6 @@ class VTTestCase(TestCase):
             finally:
                 term.close(terminate=True, kill=True)
         finally:
-            shutil.rmtree(tempdir)
+            # Ignore errors because on some platforms the tempdir doesn't exist
+            # which would seem be indicative of deeper problems
+            shutil.rmtree(tempdir, ignore_errors=True)

--- a/tests/unit/utils/test_vt.py
+++ b/tests/unit/utils/test_vt.py
@@ -33,9 +33,9 @@ import salt.utils.stringutils
 from salt.ext.six.moves import range  # pylint: disable=import-error,redefined-builtin
 
 def stdout_fileno_available():
-    """
+    '''
         Tests if sys.stdout.fileno is available in this testing enviroment
-    """
+    '''
     try:
         sys.stdout.fileno()
         return True
@@ -45,10 +45,10 @@ def stdout_fileno_available():
 class VTTestCase(TestCase):
 
     def run_test_in_subprocess(self, test_name):
-        """
+        '''
             Runs a named test in a new instance of python to avoid broken
             sys.stdout.fileno method
-        """
+        '''
         test_root = os.path.abspath(
             os.path.join(
                 os.path.join(

--- a/tests/unit/utils/test_vt.py
+++ b/tests/unit/utils/test_vt.py
@@ -22,6 +22,7 @@ import tempfile
 from tests.support.unit import TestCase, skipIf
 
 # Import Salt libs
+import salt.utils
 import salt.utils.files
 import salt.utils.platform
 import salt.utils.vt
@@ -272,9 +273,9 @@ class VTTestCase(TestCase):
             # stderr is offset by one byte to guarentee a split character in
             # one of the output streams
             stderr_content = b'\x2E' + stdout_content
-            with open(file_path_stdout, "wb") as fout:
+            with salt.utils.fopen(file_path_stdout, "wb") as fout:
                 fout.write(stdout_content)
-            with open(file_path_stderr, "wb") as ferr:
+            with salt.utils.fopen(file_path_stderr, "wb") as ferr:
                 ferr.write(stderr_content)
 
             expected_stdout = salt.utils.stringutils.to_unicode(stdout_content,

--- a/tests/unit/utils/test_vt.py
+++ b/tests/unit/utils/test_vt.py
@@ -222,8 +222,8 @@ class VTTestCase(TestCase):
         encoding = 'utf-8'
         try:
             tempdir = tempfile.mkdtemp()
-            file_path_stdout = os.path.join(tempdir, "stdout.txt")
-            file_path_stderr = os.path.join(tempdir, "stderr.txt")
+            file_path_stdout = os.path.join(tempdir, "vt_unicode_stdout.txt")
+            file_path_stderr = os.path.join(tempdir, "vt_unicode_stderr.txt")
             stdout_content = b'\xE2\x80\xA6' * 4 * block_size
             # stderr is offset by one byte to guarentee a split character in
             # one of the output streams
@@ -272,8 +272,8 @@ class VTTestCase(TestCase):
         encoding = 'shift-jis'
         try:
             tempdir = tempfile.mkdtemp()
-            file_path_stdout = os.path.join(tempdir, "stdout.txt")
-            file_path_stderr = os.path.join(tempdir, "stderr.txt")
+            file_path_stdout = os.path.join(tempdir, "vt_shiftjis_stdout.txt")
+            file_path_stderr = os.path.join(tempdir, "vt_shiftjis_stderr.txt")
             stdout_content = b'\x8B\x80' * 4 * block_size
             # stderr is offset by one byte to guarentee a split character in
             # one of the output streams

--- a/tests/unit/utils/test_vt.py
+++ b/tests/unit/utils/test_vt.py
@@ -34,7 +34,7 @@ from salt.ext.six.moves import range  # pylint: disable=import-error,redefined-b
 
 def stdout_fileno_available():
     '''
-        Tests if sys.stdout.fileno is available in this testing enviroment
+        Tests if sys.stdout.fileno is available in this testing environment
     '''
     try:
         sys.stdout.fileno()

--- a/tests/unit/utils/test_vt.py
+++ b/tests/unit/utils/test_vt.py
@@ -256,7 +256,7 @@ class VTTestCase(TestCase):
             self.assertIsNone(stdout)
         finally:
             term.close(terminate=True, kill=True)
-            
+
     def test_split_multibyte_characters_unicode(self):
         '''
             Tests that the vt correctly handles multibyte characters that are
@@ -319,6 +319,11 @@ class VTTestCase(TestCase):
             shutil.rmtree(tempdir, ignore_errors=True)
 
     def test_split_multibyte_characters_shiftjis(self):
+        '''
+            Tests that the vt correctly handles multibyte characters that are
+            split between blocks of transmitted data.
+            Uses shift-jis encoding to make sure code doesn't assume unicode.
+        '''
         if not stdout_fileno_available() and 'TEST_VT_CHILD' not in os.environ:
             self.run_test_in_subprocess(
                 'test_split_multibyte_characters_shiftjis'

--- a/tests/unit/utils/test_vt.py
+++ b/tests/unit/utils/test_vt.py
@@ -217,6 +217,10 @@ class VTTestCase(TestCase):
         finally:
             term.close(terminate=True, kill=True)
 
+    @skipIf(
+        'JENKINS_URL' in os.environ,
+        'Disabled until use of sys.stdout.fileno is possible in CI test suite'
+    )
     def test_split_multibyte_characters_unicode(self):
         block_size = 1024
         encoding = 'utf-8'
@@ -269,6 +273,10 @@ class VTTestCase(TestCase):
             # which would seem be indicative of deeper problems
             shutil.rmtree(tempdir, ignore_errors=True)
 
+    @skipIf(
+        'JENKINS_URL' in os.environ,
+        'Disabled until use of sys.stdout.fileno is possible in CI test suite'
+    )
     def test_split_multibyte_characters_shiftjis(self):
         block_size = 1024
         encoding = 'shift-jis'

--- a/tests/unit/utils/test_vt.py
+++ b/tests/unit/utils/test_vt.py
@@ -251,7 +251,7 @@ class VTTestCase(TestCase):
                 stream_stdout=False,
                 stream_stderr=False,
                 force_receive_encoding=encoding)
-            buffer_o = buffer_e = ''
+            buffer_o = buffer_e = salt.utils.stringutils.to_unicode('')
             try:
                 while term.has_unread_data:
                     stdout, stderr = term.recv(block_size)
@@ -301,7 +301,7 @@ class VTTestCase(TestCase):
                 stream_stdout=False,
                 stream_stderr=False,
                 force_receive_encoding=encoding)
-            buffer_o = buffer_e = ''
+            buffer_o = buffer_e = salt.utils.stringutils.to_unicode('')
             try:
                 while term.has_unread_data:
                     stdout, stderr = term.recv(block_size)

--- a/tests/unit/utils/test_vt.py
+++ b/tests/unit/utils/test_vt.py
@@ -221,7 +221,7 @@ class VTTestCase(TestCase):
         block_size = 1024
         encoding = 'utf-8'
         try:
-            tempdir = tempfile.mkdtemp()
+            tempdir = tempfile.mkdtemp(suffix='test_vt_unicode')
             file_path_stdout = os.path.join(tempdir, "vt_unicode_stdout.txt")
             file_path_stderr = os.path.join(tempdir, "vt_unicode_stderr.txt")
             stdout_content = b'\xE2\x80\xA6' * 4 * block_size
@@ -271,7 +271,7 @@ class VTTestCase(TestCase):
         block_size = 1024
         encoding = 'shift-jis'
         try:
-            tempdir = tempfile.mkdtemp()
+            tempdir = tempfile.mkdtemp(suffix='test_vt_shiftjis')
             file_path_stdout = os.path.join(tempdir, "vt_shiftjis_stdout.txt")
             file_path_stderr = os.path.join(tempdir, "vt_shiftjis_stderr.txt")
             stdout_content = b'\x8B\x80' * 4 * block_size

--- a/tests/unit/utils/test_vt.py
+++ b/tests/unit/utils/test_vt.py
@@ -293,7 +293,7 @@ class VTTestCase(TestCase):
                 'with open(\'' + file_path_stderr + '\', \'rb\') as ferr:',
                 '    sys.stderr.buffer.write(ferr.read())',))
             term = salt.utils.vt.Terminal(
-                args=['python',
+                args=[sys.executable,
                       '-c',
                       '"' + python_command + '"'],
                 shell=True,
@@ -355,7 +355,7 @@ class VTTestCase(TestCase):
                 'with open(\'' + file_path_stderr + '\', \'rb\') as ferr:',
                 '    sys.stderr.buffer.write(ferr.read())',))
             term = salt.utils.vt.Terminal(
-                args=['python',
+                args=[sys.executable,
                       '-c',
                       '"' + python_command + '"'],
                 shell=True,


### PR DESCRIPTION
### What does this PR do?
Fix a bug where decoding of received stdout or stderr data into text fails if a multibyte character occurs at the end of one received block of data and extends into the next block of data

This fix only applies to unicode since I don't know what the specific exceptions raised by other encoding schemes are. If similar errors occur with other multibyte characters in other encoding schemes then the read_and_decode_fd function can be extended to handle those cases too.

### What issues does this PR fix or reference?
Probably this one: https://github.com/saltstack/salt/issues/48473

### Previous Behaviour
Previously stdout and stderr were received from the client as blocks (usually 1024 bytes) of binary data which was then decoded to strings (usually utf-8).
This process would fail when a multibyte character occurs at the end of a received block of data with only part of the character in the current block. The decoding would fail with the exception UnicodeDecodeError and the message 'unexpected end of data' and include the position of failure as the end of the block of data.

### New Behaviour
This fix checks for that specific failure case and will then read another block of data and append it to the current block of data so that the unicode character is no longer split across received data blocks. It then attempts to perform decoding on the combined data block. A loop is used to handle the case where the same problem occurred with the new combined block.

The intent of this change is to only handle this specific error and to raise all other exceptions as before. The code is only intended to remain in the while True loop so long as this specific failure case occurs. This should only loop forever if the program it is receiving data from outputs an infinite stream of valid characters that consistently has multibyte characters split across the block boundaries.

A better fix might be to switch to reading individual bytes rather than whole blocks to attempt to complete only the character that failed. That would avoid the potential infinite loop in the case of a program that runs forever whose output happens to always have a multibyte character split across blocks. That said, the chances of that happening are probably fairly low and you might have other problems if you are receiving data from something that generates infinite output.

Any invalid characters that don't occur at the end of the block will not have the reason 'unexpected end of data' so those exceptions will be raised and will not cause code to loop.

### Tests written?

No

### Commits signed with GPG?

Yes
