### PR TITLE
Update the NetBox module to support newer pynetbox versions

### DIFF
--- a/salt/modules/netbox.py
+++ b/salt/modules/netbox.py
@@ -33,6 +33,11 @@ log = logging.getLogger(__name__)
 
 try:
     import pynetbox
+
+    try:
+        from pynetbox.lib import RequestError
+    except ImportError:
+        from pynetbox.core.query import RequestError
     HAS_PYNETBOX = True
 except ImportError:
     HAS_PYNETBOX = False

--- a/salt/modules/netbox.py
+++ b/salt/modules/netbox.py
@@ -124,6 +124,7 @@ def get(app, endpoint, id=None, **kwargs):
     if id:
         return dict(getattr(getattr(nb, app), endpoint).get(id))
     else:
+        clean_kwargs = __utils__['args.clean_kwargs'](**kwargs)
         return dict(
-            getattr(getattr(nb, app), endpoint).get(**clean_kwargs(**kwargs))
+            getattr(getattr(nb, app), endpoint).get(**clean_kwargs)
         )


### PR DESCRIPTION
Beginning with release 4.0.0, the ``RequestError`` class has been moved
under ``pynetbox.core.query`` - see
https://github.com/digitalocean/pynetbox/tree/v4.0.0/pynetbox/core vs.
https://github.com/digitalocean/pynetbox/tree/v3.4.11/pynetbox/lib.
Because of this, as it's unable to import the exception class, the
module won't be loaded, even though the library is installed.