### PR TITLE
Add "ppc64le" as a valid RPM package architecture

### DIFF
--- a/salt/utils/pkg/rpm.py
+++ b/salt/utils/pkg/rpm.py
@@ -19,7 +19,7 @@ log = logging.getLogger(__name__)
 # These arches compiled from the rpmUtils.arch python module source
 ARCHES_64 = ('x86_64', 'athlon', 'amd64', 'ia32e', 'ia64', 'geode')
 ARCHES_32 = ('i386', 'i486', 'i586', 'i686')
-ARCHES_PPC = ('ppc', 'ppc64', 'ppc64iseries', 'ppc64pseries')
+ARCHES_PPC = ('ppc', 'ppc64', 'ppc64le', 'ppc64iseries', 'ppc64pseries')
 ARCHES_S390 = ('s390', 's390x')
 ARCHES_SPARC = (
     'sparc', 'sparcv8', 'sparcv9', 'sparcv9v', 'sparc64', 'sparc64v'


### PR DESCRIPTION
### What does this PR do?

This PR fixes an issue when dealing with RPM packages that have "ppc64le" architecture.

Currently, the Salt jobs for installing (or updating) packages with this architecture are set as failed even if the packages get installed.

### Previous Behavior
```
salt/job/20190524170336946386/ret/sles12sp4-ppc64le.tf.local      {
    "_stamp": "2019-05-24T15:06:22.838525",
    "cmd": "_return",
    "fun": "state.apply",
    "fun_args":

...

    "out": "highstate",
    "retcode": 2,
    "return": {
        "pkg_|-pkg_installed_|-pkg_installed_|-installed": {
            "__id__": "pkg_installed",
            "__run_num__": 1,
            "__sls__": "packages.pkginstall",
            "changes": {
                "logrotate": {
                    "new": [
                        {
                            "arch": "ppc64le",
                            "epoch": null,
                            "install_date_time_t": 1558710317,
                            "release": "2.14.1",
                            "version": "3.11.0"
                        }
                    "old": [
                        {
                            "arch": "ppc64le",
                            "epoch": null,
                            "install_date_time_t": 1558700624,
                            "release": "2.11.1",
                            "version": "3.11.0"
                        }
                    ]
                }
            },
            "comment": "The following packages failed to install/update: logrotate.ppc64le=3.11.0-2.14.1",
            "duration": 130682.749,
            "name": "pkg_installed",
            "result": false,
            "start_time": "16:04:11.071441"
        }
    },
    "success": true
}
```

### New Behavior
```
salt/job/20190524170336946386/ret/sles12sp4-ppc64le.tf.local      {
    "_stamp": "2019-05-24T15:06:22.838525",
    "cmd": "_return",
    "fun": "state.apply",
    "fun_args":

...

       "pkg_|-pkg_installed_|-pkg_installed_|-installed": {
            "__id__": "pkg_installed",
            "__run_num__": 1,
            "__sls__": "packages.pkginstall",
            "changes": {
                "logrotate": {
                    "new": [
                        {
                            "arch": "ppc64le",
                            "epoch": null,
                            "install_date_time_t": 1558712943,
                            "release": "2.14.1",
                            "version": "3.11.0"
                        }
                    ],
                    "old": [
                        {
                            "arch": "ppc64le",
                            "epoch": null,
                            "install_date_time_t": 1558712632,
                            "release": "2.11.1",
                            "version": "3.11.0"
                        }
                    ]
                }
            },
            "comment": "1 targeted package was installed/updated.",
            "duration": 150933.562,
            "name": "pkg_installed",
            "result": true,
            "start_time": "16:47:50.598440"
        }
    },
    "success": true
}
```

### Tests written?

No

### Commits signed with GPG?

Yes