### PR TITLE
Add autodoc for the Docker proxy module

### DIFF
--- a/doc/ref/proxy/all/index.rst
+++ b/doc/ref/proxy/all/index.rst
@@ -15,6 +15,7 @@ proxy modules
     chronos
     cimc
     cisconso
+    docker
     dummy
     esxi
     fx2

--- a/doc/ref/proxy/all/salt.proxy.docker.rst
+++ b/doc/ref/proxy/all/salt.proxy.docker.rst
@@ -1,0 +1,6 @@
+=================
+salt.proxy.docker
+=================
+
+.. automodule:: salt.proxy.docker
+    :members:


### PR DESCRIPTION
Porting the relevant commit from #53247, to add autodoc for the Docker proxy module added in release 2019.2. CC @gtmanfred 