### PR TITLE
2018.3 missing mod docs

### DIFF
--- a/doc/ref/modules/all/index.rst
+++ b/doc/ref/modules/all/index.rst
@@ -23,6 +23,7 @@ execution modules
 
     acme
     aix_group
+    aix_shadow
     aliases
     alternatives
     ansiblegate
@@ -30,6 +31,7 @@ execution modules
     apcups
     apf
     apkpkg
+    aptly
     aptpkg
     archive
     artifactory
@@ -44,6 +46,7 @@ execution modules
     bluez_bluetooth
     boto3_elasticache
     boto3_route53
+    boto3_sns
     boto_apigateway
     boto_asg
     boto_cfn
@@ -67,6 +70,7 @@ execution modules
     boto_lambda
     boto_rds
     boto_route53
+    boto_s3
     boto_s3_bucket
     boto_secgroup
     boto_sns
@@ -96,6 +100,7 @@ execution modules
     cp
     cpan
     cron
+    cryptdev
     csf
     cyg
     daemontools
@@ -142,6 +147,7 @@ execution modules
     freebsdpkg
     freebsdports
     freebsdservice
+    gcp_addon
     gem
     genesis
     gentoo_service
@@ -150,6 +156,7 @@ execution modules
     github
     glance
     glanceng
+    glassfish
     glusterfs
     gnomedesktop
     gpg
@@ -163,6 +170,7 @@ execution modules
     hashutil
     heat
     hg
+    highstate_doc
     hipchat
     hosts
     http
@@ -286,6 +294,7 @@ execution modules
     network
     neutron
     neutronng
+    nexus
     nfs3
     nftables
     nginx
@@ -452,6 +461,7 @@ execution modules
     virtualenv_mod
     vsphere
     webutil
+    win_auditpol
     win_autoruns
     win_certutil
     win_dacl
@@ -486,6 +496,8 @@ execution modules
     win_update
     win_useradd
     win_wua
+    win_wusa
+    wordpress
     x509
     xapi_virt
     xbpspkg

--- a/doc/ref/modules/all/salt.modules.aix_shadow.rst
+++ b/doc/ref/modules/all/salt.modules.aix_shadow.rst
@@ -1,0 +1,6 @@
+=======================
+salt.modules.aix_shadow
+=======================
+
+.. automodule:: salt.modules.aix_shadow
+    :members:

--- a/doc/ref/modules/all/salt.modules.aptly.rst
+++ b/doc/ref/modules/all/salt.modules.aptly.rst
@@ -1,0 +1,6 @@
+==================
+salt.modules.aptly
+==================
+
+.. automodule:: salt.modules.aptly
+    :members:

--- a/doc/ref/modules/all/salt.modules.boto3_sns.rst
+++ b/doc/ref/modules/all/salt.modules.boto3_sns.rst
@@ -1,0 +1,6 @@
+=============================
+salt.modules.boto3_sns module
+=============================
+
+.. automodule:: salt.modules.boto3_sns
+    :members:

--- a/doc/ref/modules/all/salt.modules.boto_s3.rst
+++ b/doc/ref/modules/all/salt.modules.boto_s3.rst
@@ -1,0 +1,6 @@
+===========================
+salt.modules.boto_s3 module
+===========================
+
+.. automodule:: salt.modules.boto_s3
+    :members:

--- a/doc/ref/modules/all/salt.modules.cryptdev.rst
+++ b/doc/ref/modules/all/salt.modules.cryptdev.rst
@@ -1,0 +1,6 @@
+============================
+salt.modules.cryptdev module
+============================
+
+.. automodule:: salt.modules.cryptdev
+    :members:

--- a/doc/ref/modules/all/salt.modules.gcp_addon.rst
+++ b/doc/ref/modules/all/salt.modules.gcp_addon.rst
@@ -1,0 +1,6 @@
+=============================
+salt.modules.gcp_addon module
+=============================
+
+.. automodule:: salt.modules.gcp_addon
+    :members:

--- a/doc/ref/modules/all/salt.modules.glassfish.rst
+++ b/doc/ref/modules/all/salt.modules.glassfish.rst
@@ -1,0 +1,6 @@
+=============================
+salt.modules.glassfish module
+=============================
+
+.. automodule:: salt.modules.glassfish
+    :members:

--- a/doc/ref/modules/all/salt.modules.highstate_doc.rst
+++ b/doc/ref/modules/all/salt.modules.highstate_doc.rst
@@ -1,0 +1,6 @@
+=================================
+salt.modules.highstate_doc module
+=================================
+
+.. automodule:: salt.modules.highstate_doc
+    :members:

--- a/doc/ref/modules/all/salt.modules.nexus.rst
+++ b/doc/ref/modules/all/salt.modules.nexus.rst
@@ -1,0 +1,6 @@
+=========================
+salt.modules.nexus module
+=========================
+
+.. automodule:: salt.modules.nexus
+    :members:

--- a/doc/ref/modules/all/salt.modules.shadow.rst
+++ b/doc/ref/modules/all/salt.modules.shadow.rst
@@ -14,6 +14,7 @@ modules:
 Execution Module                       Used for
 ====================================== ========================================
 :py:mod:`~salt.modules.shadow`         Linux
+:py:mod:`~salt.modules.aix_shadow`     AIX
 :py:mod:`~salt.modules.bsd_shadow`     FreeBSD, OpenBSD, NetBSD
 :py:mod:`~salt.modules.solaris_shadow` Solaris-based OSes
 :py:mod:`~salt.modules.win_shadow`     Windows

--- a/doc/ref/modules/all/salt.modules.win_auditpol.rst
+++ b/doc/ref/modules/all/salt.modules.win_auditpol.rst
@@ -1,0 +1,6 @@
+=========================
+salt.modules.win_auditpol
+=========================
+
+.. automodule:: salt.modules.win_auditpol
+    :members:

--- a/doc/ref/modules/all/salt.modules.win_wusa.rst
+++ b/doc/ref/modules/all/salt.modules.win_wusa.rst
@@ -1,0 +1,6 @@
+=====================
+salt.modules.win_wusa
+=====================
+
+.. automodule:: salt.modules.win_wusa
+    :members:

--- a/doc/ref/modules/all/salt.modules.wordpress.rst
+++ b/doc/ref/modules/all/salt.modules.wordpress.rst
@@ -1,0 +1,6 @@
+=====================
+salt.modules.worpress
+=====================
+
+.. automodule:: salt.modules.wordpress
+    :members:

--- a/salt/modules/gcp_addon.py
+++ b/salt/modules/gcp_addon.py
@@ -11,7 +11,7 @@ routing table for a single best matching route.
 This module will create a route to send traffic destined to the Internet
 through your gateway instance.
 
-:codeauthor: :email:`Pratik Bandarkar <pratik.bandarkar@gmail.com>`
+:codeauthor: `Pratik Bandarkar <pratik.bandarkar@gmail.com>`
 :maturity:   new
 :depends:    google-api-python-client
 :platform:   Linux

--- a/salt/modules/highstate_doc.py
+++ b/salt/modules/highstate_doc.py
@@ -145,7 +145,7 @@ Other hints
 
 If you wish to customize the document format:
 
-.. code-block:: yaml
+.. code-block:: jinja
 
     # you could also create a new `proccesser` for perhaps reStructuredText
     # highstate_doc.config:
@@ -180,38 +180,40 @@ If you wish to customize the document format:
 
 Some `replace_text_regex` values that might be helpful.
 
-    ## CERTS
-    '-----BEGIN RSA PRIVATE KEY-----[\r\n\t\f\S]{0,2200}': 'XXXXXXX'
-    '-----BEGIN CERTIFICATE-----[\r\n\t\f\S]{0,2200}': 'XXXXXXX'
-    '-----BEGIN DH PARAMETERS-----[\r\n\t\f\S]{0,2200}': 'XXXXXXX'
-    '-----BEGIN PRIVATE KEY-----[\r\n\t\f\S]{0,2200}': 'XXXXXXX'
-    '-----BEGIN OPENSSH PRIVATE KEY-----[\r\n\t\f\S]{0,2200}': 'XXXXXXX'
-    'ssh-rsa .* ': 'ssh-rsa XXXXXXX '
-    'ssh-dss .* ': 'ssh-dss XXXXXXX '
-    ## DB
-    'DB_PASS.*': 'DB_PASS = XXXXXXX'
-    '5432:*:*:.*': '5432:*:XXXXXXX'
-    "'PASSWORD': .*": "'PASSWORD': 'XXXXXXX',"
-    " PASSWORD '.*'": " PASSWORD 'XXXXXXX'"
-    'PGPASSWORD=.* ': 'PGPASSWORD=XXXXXXX'
-    "_replication password '.*'":  "_replication password 'XXXXXXX'"
-    ## OTHER
-    'EMAIL_HOST_PASSWORD =.*': 'EMAIL_HOST_PASSWORD =XXXXXXX'
-    "net ads join -U '.*@MFCFADS.MATH.EXAMPLE.CA.* ": "net ads join -U '.*@MFCFADS.MATH.EXAMPLE.CA%XXXXXXX "
-    "net ads join -U '.*@NEXUS.EXAMPLE.CA.* ": "net ads join -U '.*@NEXUS.EXAMPLE.CA%XXXXXXX "
-    'install-uptrack .* --autoinstall': 'install-uptrack XXXXXXX --autoinstall'
-    'accesskey = .*': 'accesskey = XXXXXXX'
-    'auth_pass .*': 'auth_pass XXXXXXX'
-    'PSK "0x.*': 'PSK "0xXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
-    'SECRET_KEY.*': 'SECRET_KEY = XXXXXXX'
-    "password=.*": "password=XXXXXXX"
-    '<password>.*</password>': '<password>XXXXXXX</password>'
-    '<salt>.*</salt>': '<salt>XXXXXXX</salt>'
-    'application.secret = ".*"': 'application.secret = "XXXXXXX"'
-    'url = "postgres://.*"': 'url = "postgres://XXXXXXX"'
-    'PASS_.*_PASS': 'PASS_XXXXXXX_PASS'
-    ## HTACCESS
-    ':{PLAIN}.*': ':{PLAIN}XXXXXXX'
+.. code-block:: yaml
+
+      ## CERTS
+      '-----BEGIN RSA PRIVATE KEY-----[\\r\\n\\t\\f\S]{0,2200}': 'XXXXXXX'
+      '-----BEGIN CERTIFICATE-----[\\r\\n\\t\\f\S]{0,2200}': 'XXXXXXX'
+      '-----BEGIN DH PARAMETERS-----[\\r\\n\\t\\f\S]{0,2200}': 'XXXXXXX'
+      '-----BEGIN PRIVATE KEY-----[\\r\\n\\t\\f\S]{0,2200}': 'XXXXXXX'
+      '-----BEGIN OPENSSH PRIVATE KEY-----[\\r\\n\\t\\f\S]{0,2200}': 'XXXXXXX'
+      'ssh-rsa .* ': 'ssh-rsa XXXXXXX '
+      'ssh-dss .* ': 'ssh-dss XXXXXXX '
+      ## DB
+      'DB_PASS.*': 'DB_PASS = XXXXXXX'
+      '5432:*:*:.*': '5432:*:XXXXXXX'
+      "'PASSWORD': .*": "'PASSWORD': 'XXXXXXX',"
+      " PASSWORD '.*'": " PASSWORD 'XXXXXXX'"
+      'PGPASSWORD=.* ': 'PGPASSWORD=XXXXXXX'
+      "_replication password '.*'":  "_replication password 'XXXXXXX'"
+      ## OTHER
+      'EMAIL_HOST_PASSWORD =.*': 'EMAIL_HOST_PASSWORD =XXXXXXX'
+      "net ads join -U '.*@MFCFADS.MATH.EXAMPLE.CA.* ": "net ads join -U '.*@MFCFADS.MATH.EXAMPLE.CA%XXXXXXX "
+      "net ads join -U '.*@NEXUS.EXAMPLE.CA.* ": "net ads join -U '.*@NEXUS.EXAMPLE.CA%XXXXXXX "
+      'install-uptrack .* --autoinstall': 'install-uptrack XXXXXXX --autoinstall'
+      'accesskey = .*': 'accesskey = XXXXXXX'
+      'auth_pass .*': 'auth_pass XXXXXXX'
+      'PSK "0x.*': 'PSK "0xXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
+      'SECRET_KEY.*': 'SECRET_KEY = XXXXXXX'
+      "password=.*": "password=XXXXXXX"
+      '<password>.*</password>': '<password>XXXXXXX</password>'
+      '<salt>.*</salt>': '<salt>XXXXXXX</salt>'
+      'application.secret = ".*"': 'application.secret = "XXXXXXX"'
+      'url = "postgres://.*"': 'url = "postgres://XXXXXXX"'
+      'PASS_.*_PASS': 'PASS_XXXXXXX_PASS'
+      ## HTACCESS
+      ':{PLAIN}.*': ':{PLAIN}XXXXXXX'
 
 '''
 
@@ -429,10 +431,11 @@ def render(jinja_template_text=None, jinja_template_function='highstate_doc.mark
 
     jinja_template_text: jinja text that the render uses to create the document.
     jinja_template_function: a salt module call that returns template text.
-        options:
-            highstate_doc.markdown_basic_jinja_template
-            highstate_doc.markdown_default_jinja_template
-            highstate_doc.markdown_full_jinja_template
+
+    options:
+        highstate_doc.markdown_basic_jinja_template
+        highstate_doc.markdown_default_jinja_template
+        highstate_doc.markdown_full_jinja_template
     '''
     config = _get_config(**kwargs)
     lowstates = proccess_lowstates(**kwargs)

--- a/salt/modules/win_auditpol.py
+++ b/salt/modules/win_auditpol.py
@@ -169,6 +169,7 @@ def set_setting(name, value):
     CLI Example:
 
     .. code-block:: bash
+
         # Set the state of the "Credential Validation" setting to Success and
         # Failure
         salt * auditpol.set_setting "Credential Validation" "Success and Failure"


### PR DESCRIPTION
### What does this PR do?

Adds document links for several modules that are missing in the correct documentation. 

module links added
```
aix_shadow
aptly
boto3_sns
boto_s3
cryptdev
gcp_addon
glassfish
highstate_doc
nexus
win_auditpol
win_wusa
wordpress
```
### What issues does this PR fix or reference?

Several modules are missing the documentation links so have not been included in the documentation. 

### Tests written?

No

### Commits signed with GPG?

No