### PR TITLE
Backport #53142 to 2019.2.1

### DIFF
--- a/salt/cloud/clouds/libvirt.py
+++ b/salt/cloud/clouds/libvirt.py
@@ -58,8 +58,9 @@ Tested on:
 from __future__ import absolute_import, print_function, unicode_literals
 
 import logging
-import uuid
 import os
+import sys
+import uuid
 
 from xml.etree import ElementTree
 
@@ -465,10 +466,10 @@ def create(vm_):
         )
 
         return ret
-    except Exception as e:  # pylint: disable=broad-except
+    except Exception:  # pylint: disable=broad-except
         do_cleanup(cleanup)
         # throw the root cause after cleanup
-        raise e
+        six.reraise(*sys.exc_info())
 
 
 def do_cleanup(cleanup):

--- a/salt/daemons/flo/core.py
+++ b/salt/daemons/flo/core.py
@@ -7,11 +7,12 @@ The core behaviors used by minion and master
 
 # Import python libs
 from __future__ import absolute_import, print_function, unicode_literals
-import os
-import time
-import random
-import logging
 import itertools
+import logging
+import os
+import random
+import sys
+import time
 from collections import deque
 from _socket import gaierror
 
@@ -402,7 +403,7 @@ class SaltRaetRoadStackJoiner(ioflo.base.deeding.Deed):
                     except gaierror as ex:
                         log.warning("Unable to connect to master %s: %s", mha, ex)
                         if self.opts.value.get('master_type') not in ('failover', 'distributed'):
-                            raise ex
+                            six.reraise(*sys.exc_info())
                 if not stack.remotes:
                     raise ex
 

--- a/salt/daemons/flo/zero.py
+++ b/salt/daemons/flo/zero.py
@@ -7,20 +7,23 @@ IoFlo behaviors for running a ZeroMQ based master
 
 # Import python libs
 from __future__ import absolute_import, print_function, unicode_literals
-import os
-import logging
-import hashlib
-import multiprocessing
 import errno
+import hashlib
+import logging
+import multiprocessing
+import os
+import sys
 # Import ioflo libs
 import ioflo.base.deeding
 # Import third party libs
-from salt.utils.zeromq import zmq
 import salt.master
 import salt.crypt
 import salt.daemons.masterapi
 import salt.payload
 import salt.utils.stringutils
+
+from salt.ext import six
+from salt.utils.zeromq import zmq
 
 log = logging.getLogger(__name__)
 
@@ -110,7 +113,7 @@ class ZmqRet(multiprocessing.Process):
             except zmq.ZMQError as exc:
                 if exc.errno == errno.EINTR:
                     continue
-                raise exc
+                six.reraise(*sys.exc_info())
 
 
 class SaltZmqCrypticleSetup(ioflo.base.deeding.Deed):
@@ -215,7 +218,7 @@ class SaltZmqPublisher(ioflo.base.deeding.Deed):
         except zmq.ZMQError as exc:
             if exc.errno == errno.EINTR:
                 return
-            raise exc
+            six.reraise(*sys.exc_info())
 
 
 class SaltZmqWorker(ioflo.base.deeding.Deed):

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -719,7 +719,7 @@ class MinionBase(object):
                     if attempts == tries:
                         # Exhausted all attempts. Return exception.
                         self.connected = False
-                        raise exc
+                        six.reraise(*sys.exc_info())
 
     def _discover_masters(self):
         '''

--- a/salt/modules/boto3_route53.py
+++ b/salt/modules/boto3_route53.py
@@ -121,7 +121,7 @@ def _wait_for_sync(change, conn, tries=10, sleep=20):
             if e.response.get('Error', {}).get('Code') == 'Throttling':
                 log.debug('Throttled by AWS API.')
             else:
-                raise e
+                six.reraise(*sys.exc_info())
         if status == 'INSYNC':
             return True
         time.sleep(sleep)
@@ -898,7 +898,7 @@ def get_resource_records(HostedZoneId=None, Name=None, StartRecordName=None,
                 log.debug('Throttled by AWS API.')
                 time.sleep(3)
                 continue
-            raise e
+            six.reraise(*sys.exc_info())
 
 
 def change_resource_record_sets(HostedZoneId=None, Name=None,

--- a/salt/modules/boto3_route53.py
+++ b/salt/modules/boto3_route53.py
@@ -998,5 +998,5 @@ def change_resource_record_sets(HostedZoneId=None, Name=None,
                 continue
             log.error('Failed to apply requested changes to the hosted zone %s: %s',
                     (Name or HostedZoneId), six.text_type(e))
-            raise e
+            six.reraise(*sys.exc_info())
     return False

--- a/salt/modules/boto_cloudfront.py
+++ b/salt/modules/boto_cloudfront.py
@@ -267,7 +267,7 @@ def export_distributions(region=None, key=None, keyid=None, profile=None):
     except botocore.exceptions.ClientError as err:
         # Raise an exception, as this is meant to be user-invoked at the CLI
         # as opposed to being called from execution or state modules
-        raise err
+        six.reraise(*sys.exc_info())
 
     dumper = __utils__['yaml.get_dumper']('IndentedSafeOrderedDumper')
     return __utils__['yaml.dump'](

--- a/salt/modules/boto_route53.py
+++ b/salt/modules/boto_route53.py
@@ -279,7 +279,7 @@ def zone_exists(zone, region=None, key=None, keyid=None, profile=None,
                 time.sleep(3)
                 error_retries -= 1
                 continue
-            raise e
+            six.reraise(*sys.exc_info())
 
 
 def create_zone(zone, private=False, vpc_id=None, vpc_region=None, region=None,
@@ -528,7 +528,7 @@ def get_record(name, zone, record_type, fetch_all=False, region=None, key=None,
                 time.sleep(3)
                 error_retries -= 1
                 continue
-            raise e
+            six.reraise(*sys.exc_info())
 
     if _record:
         ret['name'] = _decode_name(_record.name)
@@ -603,7 +603,7 @@ def add_record(name, value, zone, record_type, identifier=None, ttl=None,
                 time.sleep(3)
                 error_retries -= 1
                 continue
-            raise e
+            six.reraise(*sys.exc_info())
 
     _value = _munge_value(value, _type)
     while error_retries > 0:
@@ -624,7 +624,7 @@ def add_record(name, value, zone, record_type, identifier=None, ttl=None,
                 time.sleep(3)
                 error_retries -= 1
                 continue
-            raise e
+            six.reraise(*sys.exc_info())
 
 
 def update_record(name, value, zone, record_type, identifier=None, ttl=None,
@@ -686,7 +686,7 @@ def update_record(name, value, zone, record_type, identifier=None, ttl=None,
                 time.sleep(3)
                 error_retries -= 1
                 continue
-            raise e
+            six.reraise(*sys.exc_info())
 
 
 def delete_record(name, zone, record_type, identifier=None, all_records=False,
@@ -747,7 +747,7 @@ def delete_record(name, zone, record_type, identifier=None, all_records=False,
                 time.sleep(3)
                 error_retries -= 1
                 continue
-            raise e
+            six.reraise(*sys.exc_info())
 
 
 def _try_func(conn, func, **args):

--- a/salt/modules/celery.py
+++ b/salt/modules/celery.py
@@ -12,9 +12,11 @@ from __future__ import absolute_import, print_function, unicode_literals
 
 # Import python libs
 import logging
+import sys
 
 # Import salt libs
 from salt.exceptions import SaltInvocationError
+from salt.ext import six
 
 log = logging.getLogger(__name__)
 
@@ -106,5 +108,5 @@ def run_task(task_name, args=None, kwargs=None, broker=None, backend=None, wait_
                 except TimeoutError as ex:
                     log.error('Waiting for the result of a celery task execution timed out.')
                     if raise_timeout:
-                        raise ex
+                        six.reraise(*sys.exc_info())
                     return False

--- a/salt/modules/elasticsearch.py
+++ b/salt/modules/elasticsearch.py
@@ -52,6 +52,7 @@ Module to provide Elasticsearch compatibility to Salt
 # Import Python libs
 from __future__ import absolute_import, print_function, unicode_literals
 import logging
+import sys
 
 # Import Salt Libs
 from salt.exceptions import CommandExecutionError, SaltInvocationError
@@ -171,7 +172,7 @@ def ping(allow_failure=False, hosts=None, profile=None):
         _get_instance(hosts, profile)
     except CommandExecutionError as e:
         if allow_failure:
-            raise e
+            six.reraise(*sys.exc_info())
         return False
     return True
 

--- a/salt/modules/mongodb.py
+++ b/salt/modules/mongodb.py
@@ -18,6 +18,7 @@ from __future__ import absolute_import, print_function, unicode_literals
 # Import python libs
 import logging
 import re
+import sys
 
 # Import salt libs
 import salt.utils.json
@@ -83,7 +84,7 @@ def _to_dict(objects):
             objects = salt.utils.json.loads(objects)
     except ValueError as err:
         log.error("Could not parse objects: %s", err)
-        raise err
+        six.reraise(*sys.exc_info())
 
     return objects
 

--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -1824,9 +1824,9 @@ def update(name,
         try:
             conn.defineXML(salt.utils.stringutils.to_str(ElementTree.tostring(desc)))
             status['definition'] = True
-        except libvirt.libvirtError as err:
+        except libvirt.libvirtError:
             conn.close()
-            raise err
+            six.reraise(*sys.exc_info())
 
         # Do the live changes now that we know the definition has been properly set
         # From that point on, failures are not blocking to try to live update as much

--- a/salt/output/__init__.py
+++ b/salt/output/__init__.py
@@ -96,7 +96,7 @@ def display_output(data, out=None, opts=None, **kwargs):
     display_data = try_printout(data, out, opts, **kwargs)
 
     output_filename = opts.get('output_file', None)
-    log.trace('data = {0}'.format(data))
+    log.trace('data = %s', data)
     try:
         # output filename can be either '' or None
         if output_filename:
@@ -129,7 +129,7 @@ def display_output(data, out=None, opts=None, **kwargs):
     except IOError as exc:
         # Only raise if it's NOT a broken pipe
         if exc.errno != errno.EPIPE:
-            raise exc
+            six.reraise(*sys.exc_info())
 
 
 def get_printout(out, opts=None, **kwargs):
@@ -193,7 +193,10 @@ def get_printout(out, opts=None, **kwargs):
         # Since the grains outputter was removed we don't need to fire this
         # error when old minions are asking for it
         if out != 'grains':
-            log.error('Invalid outputter {0} specified, fall back to nested'.format(out))
+            log.error(
+                'Invalid outputter %s specified, fall back to nested',
+                out,
+            )
         return outputters['nested']
     return outputters[out]
 

--- a/salt/platform/win.py
+++ b/salt/platform/win.py
@@ -11,6 +11,7 @@ Much of what is here was adapted from the following:
 '''
 from __future__ import absolute_import, unicode_literals
 import os
+import sys
 import collections
 import logging
 import psutil
@@ -18,6 +19,7 @@ import psutil
 import ctypes
 from ctypes import wintypes
 
+import salt.ext.six as six
 from salt.ext.six.moves import range
 from salt.ext.six.moves import zip
 
@@ -1055,7 +1057,7 @@ def CreateProcessWithTokenW(token,
         winerr = win32api.GetLastError()
         exc = WindowsError(win32api.FormatMessage(winerr))  # pylint: disable=undefined-variable
         exc.winerror = winerr
-        raise exc
+        six.reraise(*sys.exc_info())
     return process_info
 
 
@@ -1073,7 +1075,7 @@ def enumerate_tokens(sid=None, session_id=None, privs=None):
             if exc.winerror == 5:
                 log.debug("Unable to OpenProcess pid=%d name=%s", p.pid, p.name())
                 continue
-            raise exc
+            six.reraise(*sys.exc_info())
         try:
             access = (
                 win32security.TOKEN_DUPLICATE |

--- a/salt/queues/pgjsonb_queue.py
+++ b/salt/queues/pgjsonb_queue.py
@@ -95,7 +95,7 @@ def _conn(commit=False):
         error = err.args
         sys.stderr.write(six.text_type(error))
         cursor.execute("ROLLBACK")
-        raise err
+        six.reraise(*sys.exc_info())
     else:
         if commit:
             cursor.execute("COMMIT")

--- a/salt/returners/local_cache.py
+++ b/salt/returners/local_cache.py
@@ -6,6 +6,7 @@ Return data to local job cache
 from __future__ import absolute_import, print_function, unicode_literals
 
 # Import python libs
+import sys
 import errno
 import glob
 import logging
@@ -306,12 +307,12 @@ def get_load(jid):
             try:
                 ret = serial.load(rfh)
                 break
-            except Exception as exc:
+            except Exception:
                 if index == num_tries:
                     time.sleep(0.25)
     else:
         log.critical('Failed to unpack %s', load_p)
-        raise exc
+        six.reraise(*sys.exc_info())
     if ret is None:
         ret = {}
     minions_cache = [os.path.join(jid_dir, MINIONS_P)]

--- a/salt/returners/mysql.py
+++ b/salt/returners/mysql.py
@@ -278,7 +278,7 @@ def _get_serv(ret=None, commit=False):
         error = err.args
         sys.stderr.write(six.text_type(error))
         cursor.execute("ROLLBACK")
-        raise err
+        six.reraise(*sys.exc_info())
     else:
         if commit:
             cursor.execute("COMMIT")

--- a/salt/returners/pgjsonb.py
+++ b/salt/returners/pgjsonb.py
@@ -275,7 +275,7 @@ def _get_serv(ret=None, commit=False):
         error = err.args
         sys.stderr.write(six.text_type(error))
         cursor.execute("ROLLBACK")
-        raise err
+        six.reraise(*sys.exc_info())
     else:
         if commit:
             cursor.execute("COMMIT")

--- a/salt/returners/pgjsonb.py
+++ b/salt/returners/pgjsonb.py
@@ -456,7 +456,7 @@ def _purge_jobs(timestamp):
             error = err.args
             sys.stderr.write(six.text_type(error))
             cursor.execute("ROLLBACK")
-            raise err
+            six.reraise(*sys.exc_info())
 
         try:
             sql = 'delete from salt_returns where alter_time < %s'
@@ -466,7 +466,7 @@ def _purge_jobs(timestamp):
             error = err.args
             sys.stderr.write(six.text_type(error))
             cursor.execute("ROLLBACK")
-            raise err
+            six.reraise(*sys.exc_info())
 
         try:
             sql = 'delete from salt_events where alter_time < %s'
@@ -476,7 +476,7 @@ def _purge_jobs(timestamp):
             error = err.args
             sys.stderr.write(six.text_type(error))
             cursor.execute("ROLLBACK")
-            raise err
+            six.reraise(*sys.exc_info())
 
     return True
 
@@ -504,7 +504,7 @@ def _archive_jobs(timestamp):
                 error = err.args
                 sys.stderr.write(six.text_type(error))
                 cursor.execute("ROLLBACK")
-                raise err
+                six.reraise(*sys.exc_info())
 
         try:
             sql = 'insert into {0} select * from {1} where jid in (select distinct jid from salt_returns where alter_time < %s)'.format(target_tables['jids'], 'jids')
@@ -514,7 +514,7 @@ def _archive_jobs(timestamp):
             error = err.args
             sys.stderr.write(six.text_type(error))
             cursor.execute("ROLLBACK")
-            raise err
+            six.reraise(*sys.exc_info())
         except Exception as e:
             log.error(e)
             raise
@@ -527,7 +527,7 @@ def _archive_jobs(timestamp):
             error = err.args
             sys.stderr.write(six.text_type(error))
             cursor.execute("ROLLBACK")
-            raise err
+            six.reraise(*sys.exc_info())
 
         try:
             sql = 'insert into {0} select * from {1} where alter_time < %s'.format(target_tables['salt_events'], 'salt_events')
@@ -537,7 +537,7 @@ def _archive_jobs(timestamp):
             error = err.args
             sys.stderr.write(six.text_type(error))
             cursor.execute("ROLLBACK")
-            raise err
+            six.reraise(*sys.exc_info())
 
     return _purge_jobs(timestamp)
 

--- a/salt/returners/postgres.py
+++ b/salt/returners/postgres.py
@@ -210,7 +210,7 @@ def _get_serv(ret=None, commit=False):
         error = err.args
         sys.stderr.write(six.text_type(error))
         cursor.execute("ROLLBACK")
-        raise err
+        six.reraise(*sys.exc_info())
     else:
         if commit:
             cursor.execute("COMMIT")

--- a/salt/scripts.py
+++ b/salt/scripts.py
@@ -40,7 +40,7 @@ def _handle_interrupt(exc, original_exc, hardfail=False, trace=''):
             log.error(trace)
         raise original_exc
     else:
-        raise exc
+        six.reraise(*sys.exc_info())
 
 
 def _handle_signals(client, signum, sigframe):

--- a/salt/transport/tcp.py
+++ b/salt/transport/tcp.py
@@ -10,12 +10,13 @@ Wire protocol: "len(payload) msgpack({'head': SOMEHEADER, 'body': SOMEBODY})"
 from __future__ import absolute_import, print_function, unicode_literals
 import errno
 import logging
-import socket
 import os
-import weakref
+import socket
+import sys
 import time
 import threading
 import traceback
+import weakref
 
 # Import Salt Libs
 import salt.crypt
@@ -609,7 +610,7 @@ class TCPReqServerChannel(salt.transport.mixins.auth.AESReqServerMixin, salt.tra
                     # Ignore this condition and continue.
                     pass
                 else:
-                    raise exc
+                    six.reraise(*sys.exc_info())
             self._socket.close()
             self._socket = None
         if hasattr(self.req_server, 'stop'):

--- a/salt/transport/zeromq.py
+++ b/salt/transport/zeromq.py
@@ -617,7 +617,7 @@ class ZeroMQReqServerChannel(salt.transport.mixins.auth.AESReqServerMixin,
             except zmq.ZMQError as exc:
                 if exc.errno == errno.EINTR:
                     continue
-                raise exc
+                six.reraise(*sys.exc_info())
             except (KeyboardInterrupt, SystemExit):
                 break
 
@@ -942,7 +942,7 @@ class ZeroMQPubServerChannel(salt.transport.server.PubServerChannel):
                 except zmq.ZMQError as exc:
                     if exc.errno == errno.EINTR:
                         continue
-                    raise exc
+                    six.reraise(*sys.exc_info())
 
         except KeyboardInterrupt:
             log.trace('Publish daemon caught Keyboard interupt, tearing down')

--- a/salt/utils/asynchronous.py
+++ b/salt/utils/asynchronous.py
@@ -5,9 +5,12 @@ Helpers/utils for working with tornado asynchronous stuff
 
 from __future__ import absolute_import, print_function, unicode_literals
 
+import sys
+
 import tornado.ioloop
 import tornado.concurrent
 import contextlib
+from salt.ext import six
 from salt.utils import zeromq
 
 
@@ -53,7 +56,7 @@ class SyncWrapper(object):
             return object.__getattribute__(self, key)
         except AttributeError as ex:
             if key == 'asynchronous':
-                raise ex
+                six.reraise(*sys.exc_info())
         attr = getattr(self.asynchronous, key)
         if hasattr(attr, '__call__'):
             def wrap(*args, **kwargs):

--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -5,24 +5,24 @@ Utility functions for salt.cloud
 
 # Import python libs
 from __future__ import absolute_import, print_function, unicode_literals
-import errno
-import os
-import stat
 import codecs
-import shutil
-import uuid
+import copy
+import errno
 import hashlib
+import logging
+import msgpack
+import multiprocessing
+import os
+import pipes
+import re
+import shutil
 import socket
+import stat
+import subprocess
+import sys
 import tempfile
 import time
-import subprocess
-import multiprocessing
-import logging
-import pipes
-import msgpack
 import traceback
-import copy
-import re
 import uuid
 
 
@@ -2072,7 +2072,7 @@ def scp_file(dest_path, contents=None, kwargs=None, local_file=None):
                     os.close(tmpfd)
                 except OSError as exc:
                     if exc.errno != errno.EBADF:
-                        raise exc
+                        six.reraise(*sys.exc_info())
 
         log.debug('Uploading %s to %s', dest_path, kwargs['hostname'])
 
@@ -2143,7 +2143,7 @@ def scp_file(dest_path, contents=None, kwargs=None, local_file=None):
                 os.remove(file_to_upload)
             except OSError as exc:
                 if exc.errno != errno.ENOENT:
-                    raise exc
+                    six.reraise(*sys.exc_info())
     return retcode
 
 
@@ -2180,7 +2180,7 @@ def sftp_file(dest_path, contents=None, kwargs=None, local_file=None):
                     os.close(tmpfd)
                 except OSError as exc:
                     if exc.errno != errno.EBADF:
-                        raise exc
+                        six.reraise(*sys.exc_info())
 
         if local_file is not None:
             file_to_upload = local_file
@@ -2245,7 +2245,7 @@ def sftp_file(dest_path, contents=None, kwargs=None, local_file=None):
                 os.remove(file_to_upload)
             except OSError as exc:
                 if exc.errno != errno.ENOENT:
-                    raise exc
+                    six.reraise(*sys.exc_info())
     return retcode
 
 

--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -903,7 +903,7 @@ class Client(object):
             except SCMRException as exc:
                 log.debug("Exception encountered while deleting service %s", repr(exc))
                 if time.time() - wait_start > wait_timeout:
-                    raise exc
+                    six.reraise(*sys.exc_info())
                 time.sleep(sleep_wait)
                 continue
             break
@@ -924,7 +924,7 @@ class Client(object):
             except SMBResponseException as exc:
                 log.debug("Exception deleting file %s %s", self._exe_file, repr(exc))
                 if time.time() - wait_start > wait_timeout:
-                    raise exc
+                    six.reraise(*sys.exc_info())
                 time.sleep(sleep_wait)
                 continue
             break
@@ -1022,12 +1022,10 @@ def wait_for_psexecsvc(host, port, username, password, timeout=900):
         if time.time() - start > timeout:
             return False
         log.debug(
-            'Retrying psexec connection to host {0} on port {1} '
-            '(try {2})'.format(
-                host,
-                port,
-                try_count
-            )
+            'Retrying psexec connection to host %s on port %s (try %s)',
+            host,
+            port,
+            try_count
         )
         time.sleep(1)
 
@@ -3180,7 +3178,7 @@ def _salt_cloud_force_ascii(exc):
         return unicode_trans[exc.object[exc.start:exc.end]], exc.end
 
     # There's nothing else we can do, raise the exception
-    raise exc
+    six.reraise(*sys.exc_info())
 
 
 codecs.register_error('salt-cloud-force-ascii', _salt_cloud_force_ascii)

--- a/salt/utils/decorators/__init__.py
+++ b/salt/utils/decorators/__init__.py
@@ -329,7 +329,7 @@ class _DeprecationDecorator(object):
                     'Unhandled exception occurred in function "%s: %s',
                     self._function.__name__, error
                 )
-                raise error
+                six.reraise(*sys.exc_info())
         else:
             raise CommandExecutionError("Function is deprecated, but the successor function was not found.")
 

--- a/salt/utils/gitfs.py
+++ b/salt/utils/gitfs.py
@@ -5,8 +5,8 @@ Classes which provide the shared base for GitFS, git_pillar, and winrepo
 
 # Import python libs
 from __future__ import absolute_import, print_function, unicode_literals
-import copy
 import contextlib
+import copy
 import errno
 import fnmatch
 import glob
@@ -17,6 +17,7 @@ import shlex
 import shutil
 import stat
 import subprocess
+import sys
 import time
 import tornado.ioloop
 import weakref
@@ -823,7 +824,7 @@ class GitProvider(object):
                                     'by another master.')
                     log.warning(msg)
                     if failhard:
-                        raise exc
+                        six.reraise(*sys.exc_info())
                     return
                 elif pid and pid_exists(pid):
                     log.warning('Process %d has a %s %s lock (%s)',
@@ -2816,7 +2817,7 @@ class GitFS(GitBase):
                         return _add_file_stat(fnd, blob_mode)
             except IOError as exc:
                 if exc.errno != errno.ENOENT:
-                    raise exc
+                    six.reraise(*sys.exc_info())
 
             with salt.utils.files.fopen(lk_fn, 'w'):
                 pass
@@ -2898,13 +2899,13 @@ class GitFS(GitBase):
             return ret
         except IOError as exc:
             if exc.errno != errno.ENOENT:
-                raise exc
+                six.reraise(*sys.exc_info())
 
         try:
             os.makedirs(os.path.dirname(hashdest))
         except OSError as exc:
             if exc.errno != errno.EEXIST:
-                raise exc
+                six.reraise(*sys.exc_info())
 
         ret['hsum'] = salt.utils.hashutils.get_hash(path, self.opts['hash_type'])
         with salt.utils.files.fopen(hashdest, 'w+') as fp_:

--- a/salt/utils/json.py
+++ b/salt/utils/json.py
@@ -8,6 +8,7 @@ from __future__ import absolute_import, unicode_literals
 # Import Python libs
 import json  # future lint: blacklisted-module
 import logging
+import sys
 
 # Import Salt libs
 import salt.utils.data
@@ -95,7 +96,7 @@ def loads(s, **kwargs):
         if six.PY3 and isinstance(s, bytes):
             return json_module.loads(salt.utils.stringutils.to_unicode(s), **kwargs)
         else:
-            raise exc
+            six.reraise(*sys.exc_info())
 
 
 def dump(obj, fp, **kwargs):

--- a/salt/utils/templates.py
+++ b/salt/utils/templates.py
@@ -161,7 +161,7 @@ def wrap_tmpl_func(render_str):
                         tmplsrc, exc,
                         exc_info_on_loglevel=logging.DEBUG
                     )
-                    raise exc
+                    six.reraise(*sys.exc_info())
         else:  # assume tmplsrc is file-like.
             tmplstr = tmplsrc.read()
             tmplsrc.close()

--- a/salt/utils/vmware.py
+++ b/salt/utils/vmware.py
@@ -946,7 +946,7 @@ def get_mors_with_properties(service_instance, object_type, property_list=None,
         content = get_content(*content_args, **content_kwargs)
     except IOError as exc:
         if exc.errno != errno.EPIPE:
-            raise exc
+            six.reraise(*sys.exc_info())
         content = get_content(*content_args, **content_kwargs)
 
     object_list = []

--- a/salt/utils/vt.py
+++ b/salt/utils/vt.py
@@ -805,7 +805,7 @@ class Terminal(object):
                         'else call waitpid() on our process?'
                     )
                 else:
-                    raise err
+                    six.reraise(*sys.exc_info())
 
             # I have to do this twice for Solaris.
             # I can't even believe that I figured this out...
@@ -824,7 +824,7 @@ class Terminal(object):
                             'someone else call waitpid() on our process?'
                         )
                     else:
-                        raise
+                        six.reraise(*sys.exc_info())
 
                 # If pid is still 0 after two calls to waitpid() then the
                 # process really is alive. This seems to work on all platforms,

--- a/salt/utils/yamlloader_old.py
+++ b/salt/utils/yamlloader_old.py
@@ -6,6 +6,7 @@ Custom YAML loading in Salt
 # Import python libs
 from __future__ import absolute_import, print_function, unicode_literals
 import re
+import sys
 import warnings
 
 import yaml  # pylint: disable=blacklisted-import
@@ -17,6 +18,7 @@ try:
 except Exception:
     pass
 
+import salt.ext.six as six
 import salt.utils.stringutils
 
 __all__ = ['SaltYamlSafeLoader', 'load', 'safe_load']
@@ -167,7 +169,7 @@ class SaltYamlSafeLoader(yaml.SafeLoader):
                         self.column = problem_column
                         self.pointer = problem_pointer
             # Raise the caught exception
-            raise exc
+            six.reraise(*sys.exc_info())
 
     def flatten_mapping(self, node):
         merge = []

--- a/tests/integration/minion/test_blackout.py
+++ b/tests/integration/minion/test_blackout.py
@@ -28,15 +28,25 @@ class MinionBlackoutTestCase(ModuleCase):
 
     @classmethod
     def setUpClass(cls):
+        cls.top_pillar = os.path.join(RUNTIME_VARS.TMP_PILLAR_TREE, 'top.sls')
         cls.blackout_pillar = os.path.join(RUNTIME_VARS.TMP_PILLAR_TREE, 'blackout.sls')
 
     @classmethod
     def tearDownClass(cls):
+        if os.path.exists(cls.top_pillar):
+            os.unlink(cls.top_pillar)
+        del cls.top_pillar
         if os.path.exists(cls.blackout_pillar):
             os.unlink(cls.blackout_pillar)
         del cls.blackout_pillar
 
     def setUp(self):
+        with salt.utils.files.fopen(self.top_pillar, 'w') as wfh:
+            wfh.write(textwrap.dedent('''\
+                base:
+                  '*':
+                    - blackout
+                '''))
         with salt.utils.files.fopen(self.blackout_pillar, 'w') as wfh:
             wfh.write('minion_blackout: False')
         self.addCleanup(self.cleanup_blackout_pillar)
@@ -49,6 +59,8 @@ class MinionBlackoutTestCase(ModuleCase):
         self.wait_for_all_jobs()
 
     def cleanup_blackout_pillar(self):
+        if os.path.exists(self.top_pillar):
+            os.unlink(self.top_pillar)
         if os.path.exists(self.blackout_pillar):
             os.unlink(self.blackout_pillar)
 

--- a/tests/integration/states/test_cmd.py
+++ b/tests/integration/states/test_cmd.py
@@ -9,6 +9,7 @@ import os
 import textwrap
 import tempfile
 import time
+import sys
 
 # Import Salt Testing libs
 from tests.support.case import ModuleCase
@@ -18,6 +19,9 @@ from tests.support.mixins import SaltReturnAssertsMixin
 # Import Salt libs
 import salt.utils.files
 import salt.utils.platform
+
+# Import 3rd-party libs
+from salt.ext import six
 
 IS_WINDOWS = salt.utils.platform.is_windows()
 
@@ -71,7 +75,7 @@ class CMDRunRedirectTest(ModuleCase, SaltReturnAssertsMixin):
             os.close(fd)
         except OSError as exc:
             if exc.errno != errno.EBADF:
-                raise exc
+                six.reraise(*sys.exc_info())
 
         # Create the testfile and release the handle
         fd, self.test_tmp_path = tempfile.mkstemp()
@@ -79,7 +83,7 @@ class CMDRunRedirectTest(ModuleCase, SaltReturnAssertsMixin):
             os.close(fd)
         except OSError as exc:
             if exc.errno != errno.EBADF:
-                raise exc
+                six.reraise(*sys.exc_info())
 
         super(CMDRunRedirectTest, self).setUp()
 

--- a/tests/integration/states/test_docker_container.py
+++ b/tests/integration/states/test_docker_container.py
@@ -4,11 +4,13 @@ Integration tests for the docker_container states
 '''
 # Import Python Libs
 from __future__ import absolute_import, print_function, unicode_literals
+
 import errno
 import functools
 import logging
 import os
 import subprocess
+import sys
 import tempfile
 
 # Import Salt Testing Libs
@@ -969,7 +971,7 @@ class DockerContainerTestCase(ModuleCase, SaltReturnAssertsMixin):
                 os.close(fd)
             except OSError as exc:
                 if exc.errno != errno.EBADF:
-                    raise exc
+                    six.reraise(*sys.exc_info())
             else:
                 self.addCleanup(os.remove, ret)
                 return ret

--- a/tests/integration/states/test_file.py
+++ b/tests/integration/states/test_file.py
@@ -4038,7 +4038,7 @@ class RemoteFileTest(ModuleCase, SaltReturnAssertsMixin):
             os.remove(self.name)
         except OSError as exc:
             if exc.errno != errno.ENOENT:
-                raise exc
+                six.reraise(*sys.exc_info())
 
     def run_state(self, *args, **kwargs):
         ret = super(RemoteFileTest, self).run_state(*args, **kwargs)

--- a/tests/integration/states/test_ssh_known_hosts.py
+++ b/tests/integration/states/test_ssh_known_hosts.py
@@ -5,14 +5,19 @@ Test the ssh_known_hosts states
 
 # Import python libs
 from __future__ import absolute_import, unicode_literals, print_function
+
 import os
 import shutil
+import sys
 
 # Import Salt Testing libs
 from tests.support.case import ModuleCase
 from tests.support.mixins import SaltReturnAssertsMixin
 from tests.support.runtests import RUNTIME_VARS
 from tests.support.helpers import skip_if_binaries_missing
+
+# Import 3rd-party libs
+from salt.ext import six
 
 KNOWN_HOSTS = os.path.join(RUNTIME_VARS.TMP, 'known_hosts')
 GITHUB_FINGERPRINT = '9d:38:5b:83:a9:17:52:92:56:1a:5e:c4:d4:81:8e:0a:ca:51:a2:64:f1:74:20:11:2e:f8:8a:c3:a1:39:49:8f'
@@ -54,8 +59,7 @@ class SSHKnownHostsStateTest(ModuleCase, SaltReturnAssertsMixin):
                 )
                 self.skipTest('Unable to receive remote host key')
             except AssertionError:
-                # raise initial assertion error
-                raise err
+                six.reraise(*sys.exc_info())
 
         self.assertSaltStateChangesEqual(
             ret, GITHUB_FINGERPRINT, keys=('new', 0, 'fingerprint')
@@ -82,7 +86,7 @@ class SSHKnownHostsStateTest(ModuleCase, SaltReturnAssertsMixin):
                         )
                 self.skipTest('Unable to receive remote host key')
             except AssertionError:
-                raise err
+                six.reraise(*sys.exc_info())
 
         # record for every host must be available
         ret = self.run_function(

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -12,7 +12,6 @@ import sys
 import time
 import warnings
 import collections
-
 TESTS_DIR = os.path.dirname(os.path.normpath(os.path.abspath(__file__)))
 if os.name == 'nt':
     TESTS_DIR = TESTS_DIR.replace('\\', '\\\\')
@@ -43,6 +42,8 @@ except ImportError:
     pass
 
 # Import salt libs
+from salt.ext import six
+
 try:
     from tests.support.paths import TMP, SYS_TMP_DIR, INTEGRATION_TEST_DIR
     from tests.support.paths import CODE_DIR as SALT_ROOT
@@ -56,7 +57,7 @@ except ImportError as exc:
     print('Current sys.path:')
     import pprint
     pprint.pprint(sys.path)
-    raise exc
+    six.reraise(*sys.exc_info())
 
 from tests.integration import TestDaemon  # pylint: disable=W0403
 import salt.utils.platform

--- a/tests/support/helpers.py
+++ b/tests/support/helpers.py
@@ -209,7 +209,7 @@ def flaky(caller=None, condition=True, attempts=4):
                 return caller(cls)
             except Exception as exc:
                 if attempt >= attempts -1:
-                    raise exc
+                    six.reraise(*sys.exc_info())
                 backoff_time = attempt ** 2
                 log.info(
                     'Found Exception. Waiting %s seconds to retry.',


### PR DESCRIPTION
Backport #53142 to 2019.2.1

> Use six.reraise for the greater good

> In Python2, `raise exc` obliterates the stack trace. That's no good.

> Fortunately, six has a useful syntax that works across Python versions.
> It does have the downside of adding `reraise` to the stacktrace, but
> otherwise, this should be better.

Conflicts:
* salt/transport/tcp.py
* salt/utils/cloud.py
* salt/utils/vmware.py
* salt/utils/yamlloader.py
* tests/support/helpers.py