### PR TITLE
Fix win system

### DIFF
--- a/salt/modules/win_system.py
+++ b/salt/modules/win_system.py
@@ -504,6 +504,11 @@ def get_system_info():
     '''
     Get system information.
 
+    .. note::
+
+        Not all system info is available across all versions of Windows. If it
+        is not available on an older version, it will be skipped
+
     Returns:
         dict: Dictionary containing information about the system to include
         name, description, version, etc...

--- a/salt/modules/win_system.py
+++ b/salt/modules/win_system.py
@@ -625,7 +625,7 @@ def get_system_info():
         ret['processor_cores'] += system.NumberOfCores
         try:
             ret['processor_cores_enabled'] += system.NumberOfEnabledCore
-        except AttributeError:
+        except (AttributeError, TypeError):
             pass
     if ret['processor_cores_enabled'] == 0:
         ret.pop('processor_cores_enabled', False)


### PR DESCRIPTION
### What does this PR do?
Skip processor_cores_enabled as it's not available
Get ChassisSKUNumber using the ComputerSystemProduct class
Add a note stating that unsupported info is skipped

### What issues does this PR fix or reference?
https://github.com/saltstack/lock/issues/1288

### Tests written?
No

### Commits signed with GPG?
Yes