### PR TITLE
Do not break repo files with multiple line values on "yumpkg"

### DIFF
--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -2736,7 +2736,7 @@ def del_repo(repo, basedir=None, **kwargs):  # pylint: disable=W0613
             # A whitespace is needed at the begining of the new line in order
             # to avoid breaking multiple line values allowed on repo files.
             value = filerepos[stanza][line]
-            if '\n' in value:
+            if isinstance(value, str) and '\n' in value:
                 value = '\n '.join(value.split('\n'))
             content += '\n{0}={1}'.format(line, value)
         content += '\n{0}\n'.format(comments)
@@ -2876,7 +2876,7 @@ def mod_repo(repo, basedir=None, **kwargs):
             # A whitespace is needed at the begining of the new line in order
             # to avoid breaking multiple line values allowed on repo files.
             value = filerepos[stanza][line]
-            if '\n' in value:
+            if isinstance(value, str) and '\n' in value:
                 value = '\n '.join(value.split('\n'))
             content += '{0}={1}\n'.format(
                 line,

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -2737,7 +2737,7 @@ def del_repo(repo, basedir=None, **kwargs):  # pylint: disable=W0613
             # to avoid breaking multiple line values allowed on repo files.
             value = filerepos[stanza][line]
             if '\n' in value:
-               value = '\n '.join(value.split('\n'))
+                value = '\n '.join(value.split('\n'))
             content += '\n{0}={1}'.format(line, value)
         content += '\n{0}\n'.format(comments)
 
@@ -2877,7 +2877,7 @@ def mod_repo(repo, basedir=None, **kwargs):
             # to avoid breaking multiple line values allowed on repo files.
             value = filerepos[stanza][line]
             if '\n' in value:
-               value = '\n '.join(value.split('\n'))
+                value = '\n '.join(value.split('\n'))
             content += '{0}={1}\n'.format(
                 line,
                 value if not isinstance(value, bool) else _bool_to_str(value)

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -2736,7 +2736,7 @@ def del_repo(repo, basedir=None, **kwargs):  # pylint: disable=W0613
             # A whitespace is needed at the begining of the new line in order
             # to avoid breaking multiple line values allowed on repo files.
             value = filerepos[stanza][line]
-            if isinstance(value, str) and '\n' in value:
+            if isinstance(value, six.string_types) and '\n' in value:
                 value = '\n '.join(value.split('\n'))
             content += '\n{0}={1}'.format(line, value)
         content += '\n{0}\n'.format(comments)
@@ -2876,7 +2876,7 @@ def mod_repo(repo, basedir=None, **kwargs):
             # A whitespace is needed at the begining of the new line in order
             # to avoid breaking multiple line values allowed on repo files.
             value = filerepos[stanza][line]
-            if isinstance(value, str) and '\n' in value:
+            if isinstance(value, six.string_types) and '\n' in value:
                 value = '\n '.join(value.split('\n'))
             content += '{0}={1}\n'.format(
                 line,

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -2733,7 +2733,12 @@ def del_repo(repo, basedir=None, **kwargs):  # pylint: disable=W0613
             del filerepos[stanza]['comments']
         content += '\n[{0}]'.format(stanza)
         for line in filerepos[stanza]:
-            content += '\n{0}={1}'.format(line, filerepos[stanza][line])
+            # A whitespace is needed at the begining of the new line in order
+            # to avoid breaking multiple line values allowed on repo files.
+            value = filerepos[stanza][line]
+            if '\n' in value:
+               value = '\n '.join(value.split('\n'))
+            content += '\n{0}={1}'.format(line, value)
         content += '\n{0}\n'.format(comments)
 
     with salt.utils.files.fopen(repofile, 'w') as fileout:
@@ -2868,11 +2873,14 @@ def mod_repo(repo, basedir=None, **kwargs):
         )
         content += '[{0}]\n'.format(stanza)
         for line in six.iterkeys(filerepos[stanza]):
+            # A whitespace is needed at the begining of the new line in order
+            # to avoid breaking multiple line values allowed on repo files.
+            value = filerepos[stanza][line]
+            if '\n' in value:
+               value = '\n '.join(value.split('\n'))
             content += '{0}={1}\n'.format(
                 line,
-                filerepos[stanza][line]
-                    if not isinstance(filerepos[stanza][line], bool)
-                    else _bool_to_str(filerepos[stanza][line])
+                value if not isinstance(value, bool) else _bool_to_str(value)
             )
         content += comments + '\n'
 

--- a/tests/integration/modules/test_pkg.py
+++ b/tests/integration/modules/test_pkg.py
@@ -123,6 +123,54 @@ class PkgModuleTest(ModuleCase, SaltReturnAssertsMixin):
             if repo is not None:
                 self.run_function('pkg.del_repo', [repo])
 
+    def test_mod_del_repo_multiline_values(self):
+        '''
+        test modifying and deleting a software repository defined with multiline values
+        '''
+        os_grain = self.run_function('grains.item', ['os'])['os']
+        repo = None
+        try:
+            if os_grain in ['CentOS', 'RedHat', 'SUSE']:
+                my_baseurl = 'http://my.fake.repo/foo/bar/\n http://my.fake.repo.alt/foo/bar/'
+                expected_get_repo_baseurl = 'http://my.fake.repo/foo/bar/\nhttp://my.fake.repo.alt/foo/bar/'
+                major_release = int(
+                    self.run_function(
+                        'grains.item',
+                        ['osmajorrelease']
+                    )['osmajorrelease']
+                )
+                repo = 'fakerepo'
+                name = 'Fake repo for RHEL/CentOS/SUSE'
+                baseurl = my_baseurl
+                gpgkey = 'https://my.fake.repo/foo/bar/MY-GPG-KEY.pub'
+                failovermethod = 'priority'
+                gpgcheck = 1
+                enabled = 1
+                ret = self.run_function(
+                    'pkg.mod_repo',
+                    [repo],
+                    name=name,
+                    baseurl=baseurl,
+                    gpgkey=gpgkey,
+                    gpgcheck=gpgcheck,
+                    enabled=enabled,
+                    failovermethod=failovermethod,
+                )
+                # return data from pkg.mod_repo contains the file modified at
+                # the top level, so use next(iter(ret)) to get that key
+                self.assertNotEqual(ret, {})
+                repo_info = ret[next(iter(ret))]
+                self.assertIn(repo, repo_info)
+                self.assertEqual(repo_info[repo]['baseurl'], my_baseurl)
+                ret = self.run_function('pkg.get_repo', [repo])
+                self.assertEqual(ret['baseurl'], expected_get_repo_baseurl)
+                self.run_function('pkg.mod_repo', [repo])
+                ret = self.run_function('pkg.get_repo', [repo])
+                self.assertEqual(ret['baseurl'], expected_get_repo_baseurl)
+        finally:
+            if repo is not None:
+                self.run_function('pkg.del_repo', [repo])
+
     @requires_salt_modules('pkg.owner')
     def test_owner(self):
         '''


### PR DESCRIPTION
### What does this PR do?

This PR fixes an issue happening when running either `pkg.mod_repo` and `pkg.del_repo` from the `yumpkg` module when a repo file has multiline values. 

Given this repo file as example in `/etc/yum.repos.d/salt-products-testing.repo`:
```properties
[systemsmanagement_saltstack_products_testing]
name=Salt releases for SLE-based SUSE products testing (RHEL_7)
failovermethod=priority
gpgkey=http://download.opensuse.org/repositories/systemsmanagement:/saltstack:/products:/testing/RHEL_7/repodata/repomd.xml.key
enabled=1
baseurl=http://download.opensuse.org/repositories/systemsmanagement:/saltstack:/products:/testing/RHEL_7/
 http://download.opensuse.org/repositories/systemsmanagement:/saltstack:/products:/testing/RHEL_7/
gpgcheck=1
type=rpm-md
```

### Previous Behavior
```console
$ salt-call --local pkg.mod_repo systemsmanagement_saltstack_products_testing
local:
    ----------
    /etc/yum.repos.d/salt-products-testing.repo:
        ----------
        systemsmanagement_saltstack_products_testing:
            ----------
            baseurl:
                http://download.opensuse.org/repositories/systemsmanagement:/saltstack:/products:/testing/RHEL_7/
                http://download.opensuse.org/repositories/systemsmanagement:/saltstack:/products:/testing/RHEL_7/
            enabled:
                1
            failovermethod:
                priority
            gpgcheck:
                1
            gpgkey:
                http://download.opensuse.org/repositories/systemsmanagement:/saltstack:/products:/testing/RHEL_7/repodata/repomd.xml.key
            name:
                Salt releases for SLE-based SUSE products testing (RHEL_7)
            type:
                rpm-md
```

After that, the file is already broken. Notice there is no multiline value anymore and instead there is a buggy `http` attribute:

```console
$ cat /etc/yum.repos.d/salt-products-testing.repo
[systemsmanagement_saltstack_products_testing]
http=//download.opensuse.org/repositories/systemsmanagement:/saltstack:/products:/testing/RHEL_7/
name=Salt releases for SLE-based SUSE products testing (RHEL_7)
failovermethod=priority
gpgkey=http://download.opensuse.org/repositories/systemsmanagement:/saltstack:/products:/testing/RHEL_7/repodata/repomd.xml.key
enabled=1
baseurl=http://download.opensuse.org/repositories/systemsmanagement:/saltstack:/products:/testing/RHEL_7/
gpgcheck=1
type=rpm-md
```

### New Behavior
The repo file preserves the multiline values:

```console
$ cat /etc/yum.repos.d/salt-products-testing.repo
[systemsmanagement_saltstack_products_testing]
name=Salt releases for SLE-based SUSE products testing (RHEL_7)
failovermethod=priority
gpgkey=http://download.opensuse.org/repositories/systemsmanagement:/saltstack:/products:/testing/RHEL_7/repodata/repomd.xml.key
enabled=1
baseurl=http://download.opensuse.org/repositories/systemsmanagement:/saltstack:/products:/testing/RHEL_7/
 http://download.opensuse.org/repositories/systemsmanagement:/saltstack:/products:/testing/RHEL_7/
gpgcheck=1
type=rpm-md
```

### Tests written?
Yes

### Commits signed with GPG?

Yes