### PR TITLE
[2019.2.1] Refactor Jenkins PR pipelines to download artifacts after timeout

### DIFF
--- a/.ci/kitchen-centos6-py2
+++ b/.ci/kitchen-centos6-py2
@@ -1,3 +1,9 @@
+// Define the maximum time, in hours, that a test run should run for
+def testrun_timeout = 6
+// Now define a global pipeline timeout. This is the test run timeout with one(1) additional
+// hour to allow for artifacts to be downloaded, if possible.
+def global_timeout = testrun_timeout + 1;
+
 properties([
     [
         $class: 'ScannerJobProperty', doNotScan: false
@@ -9,7 +15,7 @@ properties([
         booleanParam(defaultValue: true, description: 'Run full test suite', name: 'runFull')
     ])
 ])
-timeout(time: 8, unit: 'HOURS') {
+timeout(time: global_timeout, unit: 'HOURS') {
     node('kitchen-slave') {
         timestamps {
             ansiColor('xterm') {
@@ -29,29 +35,34 @@ timeout(time: 8, unit: 'HOURS') {
                     'PY_COLORS=1',
                     "FORCE_FULL=${params.runFull}",
                 ]) {
+                    // Set the GH status even before cloning the repo
+                    stage('github-pending') {
+                        githubNotify credentialsId: 'test-jenkins-credentials',
+                            description: "running ${TEST_SUITE}-${TEST_PLATFORM}...",
+                            status: 'PENDING',
+                            context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
+                    }
+                    // Checkout the repo
                     stage('checkout-scm') {
                         cleanWs notFailBuild: true
                         checkout scm
                     }
                     try {
-                        stage('github-pending') {
-                            githubNotify credentialsId: 'test-jenkins-credentials',
-                                description: "running ${TEST_SUITE}-${TEST_PLATFORM}...",
-                                status: 'PENDING',
-                                context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
-                        }
+                        // Setup the kitchen required bundle
                         stage('setup-bundle') {
-                            sh 'bundle install --with ec2 windows --without opennebula docker'
+                            sh 'bundle install --with ec2 windows --without docker macos opennebula vagrant'
                         }
                         try {
                             stage('run kitchen') {
-                                withCredentials([
-                                    [$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']
-                                ]) {
-                                    sshagent(credentials: ['jenkins-testing-ssh-key']) {
-                                        sh 'ssh-add ~/.ssh/jenkins-testing.pem'
-                                        sh 'bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM || bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM'
-                                        sh 'bundle exec kitchen verify $TEST_SUITE-$TEST_PLATFORM'
+                                timeout(time: testrun_timeout, unit: 'HOURS') {
+                                    withCredentials([
+                                        [$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']
+                                    ]) {
+                                        sshagent(credentials: ['jenkins-testing-ssh-key']) {
+                                            sh 'ssh-add ~/.ssh/jenkins-testing.pem'
+                                            sh 'bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM || bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM'
+                                            sh 'bundle exec kitchen verify $TEST_SUITE-$TEST_PLATFORM'
+                                        }
                                     }
                                 }
                             }

--- a/.ci/kitchen-centos7-py2
+++ b/.ci/kitchen-centos7-py2
@@ -1,3 +1,9 @@
+// Define the maximum time, in hours, that a test run should run for
+def testrun_timeout = 6
+// Now define a global pipeline timeout. This is the test run timeout with one(1) additional
+// hour to allow for artifacts to be downloaded, if possible.
+def global_timeout = testrun_timeout + 1;
+
 properties([
     [
         $class: 'ScannerJobProperty', doNotScan: false
@@ -9,7 +15,7 @@ properties([
         booleanParam(defaultValue: true, description: 'Run full test suite', name: 'runFull')
     ])
 ])
-timeout(time: 8, unit: 'HOURS') {
+timeout(time: global_timeout, unit: 'HOURS') {
     node('kitchen-slave') {
         timestamps {
             ansiColor('xterm') {
@@ -29,29 +35,34 @@ timeout(time: 8, unit: 'HOURS') {
                     'PY_COLORS=1',
                     "FORCE_FULL=${params.runFull}",
                 ]) {
+                    // Set the GH status even before cloning the repo
+                    stage('github-pending') {
+                        githubNotify credentialsId: 'test-jenkins-credentials',
+                            description: "running ${TEST_SUITE}-${TEST_PLATFORM}...",
+                            status: 'PENDING',
+                            context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
+                    }
+                    // Checkout the repo
                     stage('checkout-scm') {
                         cleanWs notFailBuild: true
                         checkout scm
                     }
                     try {
-                        stage('github-pending') {
-                            githubNotify credentialsId: 'test-jenkins-credentials',
-                                description: "running ${TEST_SUITE}-${TEST_PLATFORM}...",
-                                status: 'PENDING',
-                                context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
-                        }
+                        // Setup the kitchen required bundle
                         stage('setup-bundle') {
-                            sh 'bundle install --with ec2 windows --without opennebula docker'
+                            sh 'bundle install --with ec2 windows --without docker macos opennebula vagrant'
                         }
                         try {
                             stage('run kitchen') {
-                                withCredentials([
-                                    [$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']
-                                ]) {
-                                    sshagent(credentials: ['jenkins-testing-ssh-key']) {
-                                        sh 'ssh-add ~/.ssh/jenkins-testing.pem'
-                                        sh 'bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM || bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM'
-                                        sh 'bundle exec kitchen verify $TEST_SUITE-$TEST_PLATFORM'
+                                timeout(time: testrun_timeout, unit: 'HOURS') {
+                                    withCredentials([
+                                        [$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']
+                                    ]) {
+                                        sshagent(credentials: ['jenkins-testing-ssh-key']) {
+                                            sh 'ssh-add ~/.ssh/jenkins-testing.pem'
+                                            sh 'bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM || bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM'
+                                            sh 'bundle exec kitchen verify $TEST_SUITE-$TEST_PLATFORM'
+                                        }
                                     }
                                 }
                             }

--- a/.ci/kitchen-centos7-py3
+++ b/.ci/kitchen-centos7-py3
@@ -1,3 +1,9 @@
+// Define the maximum time, in hours, that a test run should run for
+def testrun_timeout = 6
+// Now define a global pipeline timeout. This is the test run timeout with one(1) additional
+// hour to allow for artifacts to be downloaded, if possible.
+def global_timeout = testrun_timeout + 1;
+
 properties([
     [
         $class: 'ScannerJobProperty', doNotScan: false
@@ -9,7 +15,7 @@ properties([
         booleanParam(defaultValue: true, description: 'Run full test suite', name: 'runFull')
     ])
 ])
-timeout(time: 6, unit: 'HOURS') {
+timeout(time: global_timeout, unit: 'HOURS') {
     node('kitchen-slave') {
         timestamps {
             ansiColor('xterm') {
@@ -17,7 +23,7 @@ timeout(time: 6, unit: 'HOURS') {
                     'SALT_KITCHEN_PLATFORMS=/var/jenkins/workspace/nox-platforms.yml',
                     'SALT_KITCHEN_VERIFIER=/var/jenkins/workspace/nox-verifier.yml',
                     'SALT_KITCHEN_DRIVER=/var/jenkins/workspace/driver.yml',
-                    'NOX_ENV_NAME=runtests-zeromq-3.4',
+                    'NOX_ENV_NAME=runtests-zeromq',
                     'NOX_PASSTHROUGH_OPTS=--ssh-tests',
                     'NOX_ENABLE_FROM_FILENAMES=true',
                     'GOLDEN_IMAGES_CI_BRANCH=2019.2',
@@ -29,29 +35,34 @@ timeout(time: 6, unit: 'HOURS') {
                     'PY_COLORS=1',
                     "FORCE_FULL=${params.runFull}",
                 ]) {
+                    // Set the GH status even before cloning the repo
+                    stage('github-pending') {
+                        githubNotify credentialsId: 'test-jenkins-credentials',
+                            description: "running ${TEST_SUITE}-${TEST_PLATFORM}...",
+                            status: 'PENDING',
+                            context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
+                    }
+                    // Checkout the repo
                     stage('checkout-scm') {
                         cleanWs notFailBuild: true
                         checkout scm
                     }
                     try {
-                        stage('github-pending') {
-                            githubNotify credentialsId: 'test-jenkins-credentials',
-                                description: "running ${TEST_SUITE}-${TEST_PLATFORM}...",
-                                status: 'PENDING',
-                                context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
-                        }
+                        // Setup the kitchen required bundle
                         stage('setup-bundle') {
-                            sh 'bundle install --with ec2 windows --without opennebula docker'
+                            sh 'bundle install --with ec2 windows --without docker macos opennebula vagrant'
                         }
                         try {
                             stage('run kitchen') {
-                                withCredentials([
-                                    [$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']
-                                ]) {
-                                    sshagent(credentials: ['jenkins-testing-ssh-key']) {
-                                        sh 'ssh-add ~/.ssh/jenkins-testing.pem'
-                                        sh 'bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM || bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM'
-                                        sh 'bundle exec kitchen verify $TEST_SUITE-$TEST_PLATFORM'
+                                timeout(time: testrun_timeout, unit: 'HOURS') {
+                                    withCredentials([
+                                        [$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']
+                                    ]) {
+                                        sshagent(credentials: ['jenkins-testing-ssh-key']) {
+                                            sh 'ssh-add ~/.ssh/jenkins-testing.pem'
+                                            sh 'bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM || bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM'
+                                            sh 'bundle exec kitchen verify $TEST_SUITE-$TEST_PLATFORM'
+                                        }
                                     }
                                 }
                             }

--- a/.ci/kitchen-debian8-py2
+++ b/.ci/kitchen-debian8-py2
@@ -1,3 +1,9 @@
+// Define the maximum time, in hours, that a test run should run for
+def testrun_timeout = 6
+// Now define a global pipeline timeout. This is the test run timeout with one(1) additional
+// hour to allow for artifacts to be downloaded, if possible.
+def global_timeout = testrun_timeout + 1;
+
 properties([
     [
         $class: 'ScannerJobProperty', doNotScan: false
@@ -9,7 +15,7 @@ properties([
         booleanParam(defaultValue: true, description: 'Run full test suite', name: 'runFull')
     ])
 ])
-timeout(time: 8, unit: 'HOURS') {
+timeout(time: global_timeout, unit: 'HOURS') {
     node('kitchen-slave') {
         timestamps {
             ansiColor('xterm') {
@@ -29,29 +35,34 @@ timeout(time: 8, unit: 'HOURS') {
                     'PY_COLORS=1',
                     "FORCE_FULL=${params.runFull}",
                 ]) {
+                    // Set the GH status even before cloning the repo
+                    stage('github-pending') {
+                        githubNotify credentialsId: 'test-jenkins-credentials',
+                            description: "running ${TEST_SUITE}-${TEST_PLATFORM}...",
+                            status: 'PENDING',
+                            context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
+                    }
+                    // Checkout the repo
                     stage('checkout-scm') {
                         cleanWs notFailBuild: true
                         checkout scm
                     }
                     try {
-                        stage('github-pending') {
-                            githubNotify credentialsId: 'test-jenkins-credentials',
-                                description: "running ${TEST_SUITE}-${TEST_PLATFORM}...",
-                                status: 'PENDING',
-                                context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
-                        }
+                        // Setup the kitchen required bundle
                         stage('setup-bundle') {
-                            sh 'bundle install --with ec2 windows --without opennebula docker'
+                            sh 'bundle install --with ec2 windows --without docker macos opennebula vagrant'
                         }
                         try {
                             stage('run kitchen') {
-                                withCredentials([
-                                    [$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']
-                                ]) {
-                                    sshagent(credentials: ['jenkins-testing-ssh-key']) {
-                                        sh 'ssh-add ~/.ssh/jenkins-testing.pem'
-                                        sh 'bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM || bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM'
-                                        sh 'bundle exec kitchen verify $TEST_SUITE-$TEST_PLATFORM'
+                                timeout(time: testrun_timeout, unit: 'HOURS') {
+                                    withCredentials([
+                                        [$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']
+                                    ]) {
+                                        sshagent(credentials: ['jenkins-testing-ssh-key']) {
+                                            sh 'ssh-add ~/.ssh/jenkins-testing.pem'
+                                            sh 'bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM || bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM'
+                                            sh 'bundle exec kitchen verify $TEST_SUITE-$TEST_PLATFORM'
+                                        }
                                     }
                                 }
                             }

--- a/.ci/kitchen-debian8-py3
+++ b/.ci/kitchen-debian8-py3
@@ -1,3 +1,9 @@
+// Define the maximum time, in hours, that a test run should run for
+def testrun_timeout = 6
+// Now define a global pipeline timeout. This is the test run timeout with one(1) additional
+// hour to allow for artifacts to be downloaded, if possible.
+def global_timeout = testrun_timeout + 1;
+
 properties([
     [
         $class: 'ScannerJobProperty', doNotScan: false
@@ -9,7 +15,7 @@ properties([
         booleanParam(defaultValue: true, description: 'Run full test suite', name: 'runFull')
     ])
 ])
-timeout(time: 6, unit: 'HOURS') {
+timeout(time: global_timeout, unit: 'HOURS') {
     node('kitchen-slave') {
         timestamps {
             ansiColor('xterm') {
@@ -29,29 +35,34 @@ timeout(time: 6, unit: 'HOURS') {
                     'PY_COLORS=1',
                     "FORCE_FULL=${params.runFull}",
                 ]) {
+                    // Set the GH status even before cloning the repo
+                    stage('github-pending') {
+                        githubNotify credentialsId: 'test-jenkins-credentials',
+                            description: "running ${TEST_SUITE}-${TEST_PLATFORM}...",
+                            status: 'PENDING',
+                            context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
+                    }
+                    // Checkout the repo
                     stage('checkout-scm') {
                         cleanWs notFailBuild: true
                         checkout scm
                     }
                     try {
-                        stage('github-pending') {
-                            githubNotify credentialsId: 'test-jenkins-credentials',
-                                description: "running ${TEST_SUITE}-${TEST_PLATFORM}...",
-                                status: 'PENDING',
-                                context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
-                        }
+                        // Setup the kitchen required bundle
                         stage('setup-bundle') {
-                            sh 'bundle install --with ec2 windows --without opennebula docker'
+                            sh 'bundle install --with ec2 windows --without docker macos opennebula vagrant'
                         }
                         try {
                             stage('run kitchen') {
-                                withCredentials([
-                                    [$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']
-                                ]) {
-                                    sshagent(credentials: ['jenkins-testing-ssh-key']) {
-                                        sh 'ssh-add ~/.ssh/jenkins-testing.pem'
-                                        sh 'bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM || bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM'
-                                        sh 'bundle exec kitchen verify $TEST_SUITE-$TEST_PLATFORM'
+                                timeout(time: testrun_timeout, unit: 'HOURS') {
+                                    withCredentials([
+                                        [$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']
+                                    ]) {
+                                        sshagent(credentials: ['jenkins-testing-ssh-key']) {
+                                            sh 'ssh-add ~/.ssh/jenkins-testing.pem'
+                                            sh 'bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM || bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM'
+                                            sh 'bundle exec kitchen verify $TEST_SUITE-$TEST_PLATFORM'
+                                        }
                                     }
                                 }
                             }

--- a/.ci/kitchen-debian9-py2
+++ b/.ci/kitchen-debian9-py2
@@ -1,3 +1,9 @@
+// Define the maximum time, in hours, that a test run should run for
+def testrun_timeout = 6
+// Now define a global pipeline timeout. This is the test run timeout with one(1) additional
+// hour to allow for artifacts to be downloaded, if possible.
+def global_timeout = testrun_timeout + 1;
+
 properties([
     [
         $class: 'ScannerJobProperty', doNotScan: false
@@ -9,7 +15,7 @@ properties([
         booleanParam(defaultValue: true, description: 'Run full test suite', name: 'runFull')
     ])
 ])
-timeout(time: 6, unit: 'HOURS') {
+timeout(time: global_timeout, unit: 'HOURS') {
     node('kitchen-slave') {
         timestamps {
             ansiColor('xterm') {
@@ -29,29 +35,34 @@ timeout(time: 6, unit: 'HOURS') {
                     'PY_COLORS=1',
                     "FORCE_FULL=${params.runFull}",
                 ]) {
+                    // Set the GH status even before cloning the repo
+                    stage('github-pending') {
+                        githubNotify credentialsId: 'test-jenkins-credentials',
+                            description: "running ${TEST_SUITE}-${TEST_PLATFORM}...",
+                            status: 'PENDING',
+                            context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
+                    }
+                    // Checkout the repo
                     stage('checkout-scm') {
                         cleanWs notFailBuild: true
                         checkout scm
                     }
                     try {
-                        stage('github-pending') {
-                            githubNotify credentialsId: 'test-jenkins-credentials',
-                                description: "running ${TEST_SUITE}-${TEST_PLATFORM}...",
-                                status: 'PENDING',
-                                context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
-                        }
+                        // Setup the kitchen required bundle
                         stage('setup-bundle') {
-                            sh 'bundle install --with ec2 windows --without opennebula docker'
+                            sh 'bundle install --with ec2 windows --without docker macos opennebula vagrant'
                         }
                         try {
                             stage('run kitchen') {
-                                withCredentials([
-                                    [$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']
-                                ]) {
-                                    sshagent(credentials: ['jenkins-testing-ssh-key']) {
-                                        sh 'ssh-add ~/.ssh/jenkins-testing.pem'
-                                        sh 'bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM || bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM'
-                                        sh 'bundle exec kitchen verify $TEST_SUITE-$TEST_PLATFORM'
+                                timeout(time: testrun_timeout, unit: 'HOURS') {
+                                    withCredentials([
+                                        [$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']
+                                    ]) {
+                                        sshagent(credentials: ['jenkins-testing-ssh-key']) {
+                                            sh 'ssh-add ~/.ssh/jenkins-testing.pem'
+                                            sh 'bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM || bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM'
+                                            sh 'bundle exec kitchen verify $TEST_SUITE-$TEST_PLATFORM'
+                                        }
                                     }
                                 }
                             }

--- a/.ci/kitchen-debian9-py3
+++ b/.ci/kitchen-debian9-py3
@@ -1,3 +1,9 @@
+// Define the maximum time, in hours, that a test run should run for
+def testrun_timeout = 6
+// Now define a global pipeline timeout. This is the test run timeout with one(1) additional
+// hour to allow for artifacts to be downloaded, if possible.
+def global_timeout = testrun_timeout + 1;
+
 properties([
     [
         $class: 'ScannerJobProperty', doNotScan: false
@@ -9,7 +15,7 @@ properties([
         booleanParam(defaultValue: true, description: 'Run full test suite', name: 'runFull')
     ])
 ])
-timeout(time: 6, unit: 'HOURS') {
+timeout(time: global_timeout, unit: 'HOURS') {
     node('kitchen-slave') {
         timestamps {
             ansiColor('xterm') {
@@ -29,29 +35,34 @@ timeout(time: 6, unit: 'HOURS') {
                     'PY_COLORS=1',
                     "FORCE_FULL=${params.runFull}",
                 ]) {
+                    // Set the GH status even before cloning the repo
+                    stage('github-pending') {
+                        githubNotify credentialsId: 'test-jenkins-credentials',
+                            description: "running ${TEST_SUITE}-${TEST_PLATFORM}...",
+                            status: 'PENDING',
+                            context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
+                    }
+                    // Checkout the repo
                     stage('checkout-scm') {
                         cleanWs notFailBuild: true
                         checkout scm
                     }
                     try {
-                        stage('github-pending') {
-                            githubNotify credentialsId: 'test-jenkins-credentials',
-                                description: "running ${TEST_SUITE}-${TEST_PLATFORM}...",
-                                status: 'PENDING',
-                                context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
-                        }
+                        // Setup the kitchen required bundle
                         stage('setup-bundle') {
-                            sh 'bundle install --with ec2 windows --without opennebula docker'
+                            sh 'bundle install --with ec2 windows --without docker macos opennebula vagrant'
                         }
                         try {
                             stage('run kitchen') {
-                                withCredentials([
-                                    [$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']
-                                ]) {
-                                    sshagent(credentials: ['jenkins-testing-ssh-key']) {
-                                        sh 'ssh-add ~/.ssh/jenkins-testing.pem'
-                                        sh 'bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM || bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM'
-                                        sh 'bundle exec kitchen verify $TEST_SUITE-$TEST_PLATFORM'
+                                timeout(time: testrun_timeout, unit: 'HOURS') {
+                                    withCredentials([
+                                        [$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']
+                                    ]) {
+                                        sshagent(credentials: ['jenkins-testing-ssh-key']) {
+                                            sh 'ssh-add ~/.ssh/jenkins-testing.pem'
+                                            sh 'bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM || bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM'
+                                            sh 'bundle exec kitchen verify $TEST_SUITE-$TEST_PLATFORM'
+                                        }
                                     }
                                 }
                             }

--- a/.ci/kitchen-ubuntu1604-py2
+++ b/.ci/kitchen-ubuntu1604-py2
@@ -1,3 +1,9 @@
+// Define the maximum time, in hours, that a test run should run for
+def testrun_timeout = 6
+// Now define a global pipeline timeout. This is the test run timeout with one(1) additional
+// hour to allow for artifacts to be downloaded, if possible.
+def global_timeout = testrun_timeout + 1;
+
 properties([
     [
         $class: 'ScannerJobProperty', doNotScan: false
@@ -9,7 +15,7 @@ properties([
         booleanParam(defaultValue: true, description: 'Run full test suite', name: 'runFull')
     ])
 ])
-timeout(time: 6, unit: 'HOURS') {
+timeout(time: global_timeout, unit: 'HOURS') {
     node('kitchen-slave') {
         timestamps {
             ansiColor('xterm') {
@@ -29,29 +35,34 @@ timeout(time: 6, unit: 'HOURS') {
                     'PY_COLORS=1',
                     "FORCE_FULL=${params.runFull}",
                 ]) {
+                    // Set the GH status even before cloning the repo
+                    stage('github-pending') {
+                        githubNotify credentialsId: 'test-jenkins-credentials',
+                            description: "running ${TEST_SUITE}-${TEST_PLATFORM}...",
+                            status: 'PENDING',
+                            context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
+                    }
+                    // Checkout the repo
                     stage('checkout-scm') {
                         cleanWs notFailBuild: true
                         checkout scm
                     }
                     try {
-                        stage('github-pending') {
-                            githubNotify credentialsId: 'test-jenkins-credentials',
-                                description: "running ${TEST_SUITE}-${TEST_PLATFORM}...",
-                                status: 'PENDING',
-                                context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
-                        }
+                        // Setup the kitchen required bundle
                         stage('setup-bundle') {
-                            sh 'bundle install --with ec2 windows --without opennebula docker'
+                            sh 'bundle install --with ec2 windows --without docker macos opennebula vagrant'
                         }
                         try {
                             stage('run kitchen') {
-                                withCredentials([
-                                    [$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']
-                                ]) {
-                                    sshagent(credentials: ['jenkins-testing-ssh-key']) {
-                                        sh 'ssh-add ~/.ssh/jenkins-testing.pem'
-                                        sh 'bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM || bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM'
-                                        sh 'bundle exec kitchen verify $TEST_SUITE-$TEST_PLATFORM'
+                                timeout(time: testrun_timeout, unit: 'HOURS') {
+                                    withCredentials([
+                                        [$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']
+                                    ]) {
+                                        sshagent(credentials: ['jenkins-testing-ssh-key']) {
+                                            sh 'ssh-add ~/.ssh/jenkins-testing.pem'
+                                            sh 'bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM || bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM'
+                                            sh 'bundle exec kitchen verify $TEST_SUITE-$TEST_PLATFORM'
+                                        }
                                     }
                                 }
                             }

--- a/.ci/kitchen-ubuntu1604-py3
+++ b/.ci/kitchen-ubuntu1604-py3
@@ -1,3 +1,9 @@
+// Define the maximum time, in hours, that a test run should run for
+def testrun_timeout = 6
+// Now define a global pipeline timeout. This is the test run timeout with one(1) additional
+// hour to allow for artifacts to be downloaded, if possible.
+def global_timeout = testrun_timeout + 1;
+
 properties([
     [
         $class: 'ScannerJobProperty', doNotScan: false
@@ -9,7 +15,7 @@ properties([
         booleanParam(defaultValue: true, description: 'Run full test suite', name: 'runFull')
     ])
 ])
-timeout(time: 6, unit: 'HOURS') {
+timeout(time: global_timeout, unit: 'HOURS') {
     node('kitchen-slave') {
         timestamps {
             ansiColor('xterm') {
@@ -29,29 +35,34 @@ timeout(time: 6, unit: 'HOURS') {
                     'PY_COLORS=1',
                     "FORCE_FULL=${params.runFull}",
                 ]) {
+                    // Set the GH status even before cloning the repo
+                    stage('github-pending') {
+                        githubNotify credentialsId: 'test-jenkins-credentials',
+                            description: "running ${TEST_SUITE}-${TEST_PLATFORM}...",
+                            status: 'PENDING',
+                            context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
+                    }
+                    // Checkout the repo
                     stage('checkout-scm') {
                         cleanWs notFailBuild: true
                         checkout scm
                     }
                     try {
-                        stage('github-pending') {
-                            githubNotify credentialsId: 'test-jenkins-credentials',
-                                description: "running ${TEST_SUITE}-${TEST_PLATFORM}...",
-                                status: 'PENDING',
-                                context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
-                        }
+                        // Setup the kitchen required bundle
                         stage('setup-bundle') {
-                            sh 'bundle install --with ec2 windows --without opennebula docker'
+                            sh 'bundle install --with ec2 windows --without docker macos opennebula vagrant'
                         }
                         try {
                             stage('run kitchen') {
-                                withCredentials([
-                                    [$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']
-                                ]) {
-                                    sshagent(credentials: ['jenkins-testing-ssh-key']) {
-                                        sh 'ssh-add ~/.ssh/jenkins-testing.pem'
-                                        sh 'bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM || bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM'
-                                        sh 'bundle exec kitchen verify $TEST_SUITE-$TEST_PLATFORM'
+                                timeout(time: testrun_timeout, unit: 'HOURS') {
+                                    withCredentials([
+                                        [$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']
+                                    ]) {
+                                        sshagent(credentials: ['jenkins-testing-ssh-key']) {
+                                            sh 'ssh-add ~/.ssh/jenkins-testing.pem'
+                                            sh 'bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM || bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM'
+                                            sh 'bundle exec kitchen verify $TEST_SUITE-$TEST_PLATFORM'
+                                        }
                                     }
                                 }
                             }

--- a/.ci/kitchen-ubuntu1804-py2
+++ b/.ci/kitchen-ubuntu1804-py2
@@ -1,3 +1,9 @@
+// Define the maximum time, in hours, that a test run should run for
+def testrun_timeout = 6
+// Now define a global pipeline timeout. This is the test run timeout with one(1) additional
+// hour to allow for artifacts to be downloaded, if possible.
+def global_timeout = testrun_timeout + 1;
+
 properties([
     [
         $class: 'ScannerJobProperty', doNotScan: false
@@ -9,7 +15,7 @@ properties([
         booleanParam(defaultValue: true, description: 'Run full test suite', name: 'runFull')
     ])
 ])
-timeout(time: 6, unit: 'HOURS') {
+timeout(time: global_timeout, unit: 'HOURS') {
     node('kitchen-slave') {
         timestamps {
             ansiColor('xterm') {
@@ -29,29 +35,34 @@ timeout(time: 6, unit: 'HOURS') {
                     'PY_COLORS=1',
                     "FORCE_FULL=${params.runFull}",
                 ]) {
+                    // Set the GH status even before cloning the repo
+                    stage('github-pending') {
+                        githubNotify credentialsId: 'test-jenkins-credentials',
+                            description: "running ${TEST_SUITE}-${TEST_PLATFORM}...",
+                            status: 'PENDING',
+                            context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
+                    }
+                    // Checkout the repo
                     stage('checkout-scm') {
                         cleanWs notFailBuild: true
                         checkout scm
                     }
                     try {
-                        stage('github-pending') {
-                            githubNotify credentialsId: 'test-jenkins-credentials',
-                                description: "running ${TEST_SUITE}-${TEST_PLATFORM}...",
-                                status: 'PENDING',
-                                context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
-                        }
+                        // Setup the kitchen required bundle
                         stage('setup-bundle') {
-                            sh 'bundle install --with ec2 windows --without opennebula docker'
+                            sh 'bundle install --with ec2 windows --without docker macos opennebula vagrant'
                         }
                         try {
                             stage('run kitchen') {
-                                withCredentials([
-                                    [$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']
-                                ]) {
-                                    sshagent(credentials: ['jenkins-testing-ssh-key']) {
-                                        sh 'ssh-add ~/.ssh/jenkins-testing.pem'
-                                        sh 'bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM || bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM'
-                                        sh 'bundle exec kitchen verify $TEST_SUITE-$TEST_PLATFORM'
+                                timeout(time: testrun_timeout, unit: 'HOURS') {
+                                    withCredentials([
+                                        [$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']
+                                    ]) {
+                                        sshagent(credentials: ['jenkins-testing-ssh-key']) {
+                                            sh 'ssh-add ~/.ssh/jenkins-testing.pem'
+                                            sh 'bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM || bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM'
+                                            sh 'bundle exec kitchen verify $TEST_SUITE-$TEST_PLATFORM'
+                                        }
                                     }
                                 }
                             }

--- a/.ci/kitchen-ubuntu1804-py3
+++ b/.ci/kitchen-ubuntu1804-py3
@@ -1,3 +1,9 @@
+// Define the maximum time, in hours, that a test run should run for
+def testrun_timeout = 6
+// Now define a global pipeline timeout. This is the test run timeout with one(1) additional
+// hour to allow for artifacts to be downloaded, if possible.
+def global_timeout = testrun_timeout + 1;
+
 properties([
     [
         $class: 'ScannerJobProperty', doNotScan: false
@@ -9,7 +15,7 @@ properties([
         booleanParam(defaultValue: true, description: 'Run full test suite', name: 'runFull')
     ])
 ])
-timeout(time: 6, unit: 'HOURS') {
+timeout(time: global_timeout, unit: 'HOURS') {
     node('kitchen-slave') {
         timestamps {
             ansiColor('xterm') {
@@ -29,29 +35,34 @@ timeout(time: 6, unit: 'HOURS') {
                     'PY_COLORS=1',
                     "FORCE_FULL=${params.runFull}",
                 ]) {
+                    // Set the GH status even before cloning the repo
+                    stage('github-pending') {
+                        githubNotify credentialsId: 'test-jenkins-credentials',
+                            description: "running ${TEST_SUITE}-${TEST_PLATFORM}...",
+                            status: 'PENDING',
+                            context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
+                    }
+                    // Checkout the repo
                     stage('checkout-scm') {
                         cleanWs notFailBuild: true
                         checkout scm
                     }
                     try {
-                        stage('github-pending') {
-                            githubNotify credentialsId: 'test-jenkins-credentials',
-                                description: "running ${TEST_SUITE}-${TEST_PLATFORM}...",
-                                status: 'PENDING',
-                                context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
-                        }
+                        // Setup the kitchen required bundle
                         stage('setup-bundle') {
-                            sh 'bundle install --with ec2 windows --without opennebula docker'
+                            sh 'bundle install --with ec2 windows --without docker macos opennebula vagrant'
                         }
                         try {
                             stage('run kitchen') {
-                                withCredentials([
-                                    [$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']
-                                ]) {
-                                    sshagent(credentials: ['jenkins-testing-ssh-key']) {
-                                        sh 'ssh-add ~/.ssh/jenkins-testing.pem'
-                                        sh 'bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM || bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM'
-                                        sh 'bundle exec kitchen verify $TEST_SUITE-$TEST_PLATFORM'
+                                timeout(time: testrun_timeout, unit: 'HOURS') {
+                                    withCredentials([
+                                        [$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']
+                                    ]) {
+                                        sshagent(credentials: ['jenkins-testing-ssh-key']) {
+                                            sh 'ssh-add ~/.ssh/jenkins-testing.pem'
+                                            sh 'bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM || bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM'
+                                            sh 'bundle exec kitchen verify $TEST_SUITE-$TEST_PLATFORM'
+                                        }
                                     }
                                 }
                             }

--- a/.ci/kitchen-windows2016-py2
+++ b/.ci/kitchen-windows2016-py2
@@ -1,3 +1,9 @@
+// Define the maximum time, in hours, that a test run should run for
+def testrun_timeout = 8
+// Now define a global pipeline timeout. This is the test run timeout with one(1) additional
+// hour to allow for artifacts to be downloaded, if possible.
+def global_timeout = testrun_timeout + 1;
+
 properties([
     [
         $class: 'ScannerJobProperty', doNotScan: false
@@ -9,7 +15,7 @@ properties([
         booleanParam(defaultValue: true, description: 'Run full test suite', name: 'runFull')
     ])
 ])
-timeout(time: 6, unit: 'HOURS') {
+timeout(time: global_timeout, unit: 'HOURS') {
     node('kitchen-slave') {
         timestamps {
             ansiColor('xterm') {
@@ -28,29 +34,34 @@ timeout(time: 6, unit: 'HOURS') {
                     'PY_COLORS=1',
                     "FORCE_FULL=${params.runFull}",
                 ]) {
+                    // Set the GH status even before cloning the repo
+                    stage('github-pending') {
+                        githubNotify credentialsId: 'test-jenkins-credentials',
+                            description: "running ${TEST_SUITE}-${TEST_PLATFORM}...",
+                            status: 'PENDING',
+                            context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
+                    }
+                    // Checkout the repo
                     stage('checkout-scm') {
                         cleanWs notFailBuild: true
                         checkout scm
                     }
                     try {
-                        stage('github-pending') {
-                            githubNotify credentialsId: 'test-jenkins-credentials',
-                                description: "running ${TEST_SUITE}-${TEST_PLATFORM}...",
-                                status: 'PENDING',
-                                context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
-                        }
+                        // Setup the kitchen required bundle
                         stage('setup-bundle') {
-                            sh 'bundle install --with ec2 windows --without opennebula docker'
+                            sh 'bundle install --with ec2 windows --without docker macos opennebula vagrant'
                         }
                         try {
                             stage('run kitchen') {
-                                withCredentials([
-                                    [$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']
-                                ]) {
-                                    sshagent(credentials: ['jenkins-testing-ssh-key']) {
-                                        sh 'ssh-add ~/.ssh/jenkins-testing.pem'
-                                        sh 'bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM || bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM'
-                                        sh 'bundle exec kitchen verify $TEST_SUITE-$TEST_PLATFORM'
+                                timeout(time: testrun_timeout, unit: 'HOURS') {
+                                    withCredentials([
+                                        [$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']
+                                    ]) {
+                                        sshagent(credentials: ['jenkins-testing-ssh-key']) {
+                                            sh 'ssh-add ~/.ssh/jenkins-testing.pem'
+                                            sh 'bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM || bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM'
+                                            sh 'bundle exec kitchen verify $TEST_SUITE-$TEST_PLATFORM'
+                                        }
                                     }
                                 }
                             }

--- a/.ci/kitchen-windows2016-py3
+++ b/.ci/kitchen-windows2016-py3
@@ -1,3 +1,9 @@
+// Define the maximum time, in hours, that a test run should run for
+def testrun_timeout = 8
+// Now define a global pipeline timeout. This is the test run timeout with one(1) additional
+// hour to allow for artifacts to be downloaded, if possible.
+def global_timeout = testrun_timeout + 1;
+
 properties([
     [
         $class: 'ScannerJobProperty', doNotScan: false
@@ -9,7 +15,7 @@ properties([
         booleanParam(defaultValue: true, description: 'Run full test suite', name: 'runFull')
     ])
 ])
-timeout(time: 8, unit: 'HOURS') {
+timeout(time: global_timeout, unit: 'HOURS') {
     node('kitchen-slave') {
         timestamps {
             ansiColor('xterm') {
@@ -28,29 +34,34 @@ timeout(time: 8, unit: 'HOURS') {
                     'PY_COLORS=1',
                     "FORCE_FULL=${params.runFull}",
                 ]) {
+                    // Set the GH status even before cloning the repo
+                    stage('github-pending') {
+                        githubNotify credentialsId: 'test-jenkins-credentials',
+                            description: "running ${TEST_SUITE}-${TEST_PLATFORM}...",
+                            status: 'PENDING',
+                            context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
+                    }
+                    // Checkout the repo
                     stage('checkout-scm') {
                         cleanWs notFailBuild: true
                         checkout scm
                     }
                     try {
-                        stage('github-pending') {
-                            githubNotify credentialsId: 'test-jenkins-credentials',
-                                description: "running ${TEST_SUITE}-${TEST_PLATFORM}...",
-                                status: 'PENDING',
-                                context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
-                        }
+                        // Setup the kitchen required bundle
                         stage('setup-bundle') {
-                            sh 'bundle install --with ec2 windows --without opennebula docker'
+                            sh 'bundle install --with ec2 windows --without docker macos opennebula vagrant'
                         }
                         try {
                             stage('run kitchen') {
-                                withCredentials([
-                                    [$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']
-                                ]) {
-                                    sshagent(credentials: ['jenkins-testing-ssh-key']) {
-                                        sh 'ssh-add ~/.ssh/jenkins-testing.pem'
-                                        sh 'bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM || bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM'
-                                        sh 'bundle exec kitchen verify $TEST_SUITE-$TEST_PLATFORM'
+                                timeout(time: testrun_timeout, unit: 'HOURS') {
+                                    withCredentials([
+                                        [$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']
+                                    ]) {
+                                        sshagent(credentials: ['jenkins-testing-ssh-key']) {
+                                            sh 'ssh-add ~/.ssh/jenkins-testing.pem'
+                                            sh 'bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM || bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM'
+                                            sh 'bundle exec kitchen verify $TEST_SUITE-$TEST_PLATFORM'
+                                        }
                                     }
                                 }
                             }


### PR DESCRIPTION
### What does this PR do?
See title.

### Previous Behavior
No artefacts would be downloaded it the built hit the timeout.

### New Behavior
Artefacts are downloaded it the built hits the timeout.