### PR TITLE
Fix slot parsing in unless/onlyif function arguments

### DIFF
--- a/doc/topics/releases/neon.rst
+++ b/doc/topics/releases/neon.rst
@@ -135,6 +135,26 @@ The slot syntax has been updated to support parsing dictionary responses and to 
     Duration: 1.229 ms
      Changes:
 
+Also, slot parsing is now supported inside of nested state data structures (dicts, lists, unless/onlyif args):
+
+.. code-block:: yaml
+
+  demo slot parsing for nested elements:
+    file.managed:
+      - name: /tmp/slot.txt
+      - source: salt://slot.j2
+      - template: jinja
+      - context:
+          # Slot inside of the nested context dictionary
+          variable: __slot__:salt:test.echo(a_value)
+      - unless:
+        - fun: file.search
+          args:
+            # Slot as unless argument
+            - __slot__:salt:test.echo(/tmp/slot.txt)
+            - "DO NOT OVERRIDE"
+          ignore_if_missing: True
+
 
 State Changes
 =============

--- a/salt/state.py
+++ b/salt/state.py
@@ -870,6 +870,17 @@ class State(object):
 
         return ret
 
+    def _run_check_function(self, entry):
+        """Format slot args and run unless/onlyif function."""
+        fun = entry.pop('fun')
+        args = entry.pop('args') if 'args' in entry else []
+        cdata = {
+            'args': args,
+            'kwargs': entry
+        }
+        self.format_slots(cdata)
+        return self.functions[fun](*cdata['args'], **cdata['kwargs'])
+
     def _run_check_onlyif(self, low_data, cmd_opts):
         '''
         Check that unless doesn't return 0, and that onlyif returns a 0.
@@ -901,10 +912,7 @@ class State(object):
                     log.warning(ret['comment'])
                     return ret
 
-                if 'args' in entry:
-                    result = self.functions[entry.pop('fun')](*entry.pop('args'), **entry)
-                else:
-                    result = self.functions[entry.pop('fun')](**entry)
+                result = self._run_check_function(entry)
                 if self.state_con.get('retcode', 0):
                     _check_cmd(self.state_con['retcode'])
                 elif not result:
@@ -949,10 +957,7 @@ class State(object):
                     log.warning(ret['comment'])
                     return ret
 
-                if 'args' in entry:
-                    result = self.functions[entry.pop('fun')](*entry.pop('args'), **entry)
-                else:
-                    result = self.functions[entry.pop('fun')](**entry)
+                result = self._run_check_function(entry)
                 if self.state_con.get('retcode', 0):
                     _check_cmd(self.state_con['retcode'])
                 elif result:


### PR DESCRIPTION
### What does this PR do?

I'm trying to improve #51846 (a feature that allows using execution modules in unless/onlyif). I want to be able to do this:

```
install apache on debian based distros:
  cmd.run:
    - name: make install
    - cwd: /path/to/dir/whatever-2.1.5/
    - unless:
      - fun: file.file_exists
        path: __slot__:salt:test.echo(/usr/local/bin/whatever)
```

### Previous Behavior

Using slots as unless/onlyif function arguments doesn't work.

### New Behavior

The basic expectation is that slots should work anywhere within a state.

### Tests written?

WIP

### Commits signed with GPG?

No