### PR TITLE
loop.until: Fix traceback when m_args or m_kwargs not passed

### DIFF
--- a/salt/states/loop.py
+++ b/salt/states/loop.py
@@ -78,6 +78,11 @@ def until(name,
            'result': False,
            'comment': ''}
 
+    if m_args is None:
+        m_args = ()
+    if m_kwargs is None:
+        m_kwargs = {}
+
     if name not in __salt__:
         ret['comment'] = 'Cannot find module {0}'.format(name)
         return ret

--- a/tests/unit/states/test_loop.py
+++ b/tests/unit/states/test_loop.py
@@ -9,12 +9,7 @@ from __future__ import absolute_import, print_function, unicode_literals
 # Import Salt Testing Libs
 from tests.support.mixins import LoaderModuleMockMixin
 from tests.support.unit import TestCase, skipIf
-from tests.support.mock import (
-    patch,
-    MagicMock,
-    NO_MOCK,
-    NO_MOCK_REASON
-)
+from tests.support.mock import MagicMock, NO_MOCK, NO_MOCK_REASON
 
 # Import Salt Libs
 import salt.states.loop as loop

--- a/tests/unit/states/test_loop.py
+++ b/tests/unit/states/test_loop.py
@@ -1,0 +1,83 @@
+# -*- coding: utf-8 -*-
+'''
+Tests for loop state(s)
+'''
+
+# Import Python Libs
+from __future__ import absolute_import, print_function, unicode_literals
+
+# Import Salt Testing Libs
+from tests.support.mixins import LoaderModuleMockMixin
+from tests.support.unit import TestCase, skipIf
+from tests.support.mock import (
+    patch,
+    MagicMock,
+    NO_MOCK,
+    NO_MOCK_REASON
+)
+
+# Import Salt Libs
+import salt.states.loop as loop
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class LoopTestCase(TestCase, LoaderModuleMockMixin):
+
+    mock = MagicMock(return_value=True)
+    func = 'foo.bar'
+    m_args = ['foo', 'bar', 'baz']
+    m_kwargs = {'hello': 'world'}
+    condition = 'm_ret is True'
+    period = 1
+    timeout = 3
+
+    def setup_loader_modules(self):
+        return {
+            loop: {
+                '__opts__': {'test': False},
+                '__salt__': {self.func: self.mock},
+            }
+        }
+
+    def setUp(self):
+        self.mock.reset_mock()
+
+    def test_until(self):
+        ret = loop.until(
+            name=self.func,
+            m_args=self.m_args,
+            m_kwargs=self.m_kwargs,
+            condition=self.condition,
+            period=self.period,
+            timeout=self.timeout)
+        assert ret['result'] is True
+        self.mock.assert_called_once_with(*self.m_args, **self.m_kwargs)
+
+    def test_until_without_args(self):
+        ret = loop.until(
+            name=self.func,
+            m_kwargs=self.m_kwargs,
+            condition=self.condition,
+            period=self.period,
+            timeout=self.timeout)
+        assert ret['result'] is True
+        self.mock.assert_called_once_with(**self.m_kwargs)
+
+    def test_until_without_kwargs(self):
+        ret = loop.until(
+            name=self.func,
+            m_args=self.m_args,
+            condition=self.condition,
+            period=self.period,
+            timeout=self.timeout)
+        assert ret['result'] is True
+        self.mock.assert_called_once_with(*self.m_args)
+
+    def test_until_without_args_or_kwargs(self):
+        ret = loop.until(
+            name=self.func,
+            condition=self.condition,
+            period=self.period,
+            timeout=self.timeout)
+        assert ret['result'] is True
+        self.mock.assert_called_once_with()


### PR DESCRIPTION
### What does this PR do?

Fixes a traceback when either m_args or m_kwargs is not passed to this state.

### What issues does this PR fix or reference?

N/A

### Tests written?

Yes