### PR TITLE
core.py: ignore wrong product_name files

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1066,7 +1066,9 @@ def _virtual(osdata):
             except UnicodeDecodeError:
                 # Some firmwares provide non-valid 'product_name'
                 # files, ignore them
-                pass
+                log.debug(
+                    "The content in /sys/devices/virtual/dmi/id/product_name is not valid"
+                )
             except IOError:
                 pass
     elif osdata["kernel"] == "FreeBSD":
@@ -2717,7 +2719,9 @@ def _hw_data(osdata):
                 except UnicodeDecodeError:
                     # Some firmwares provide non-valid 'product_name'
                     # files, ignore them
-                    pass
+                    log.debug(
+                        "The content in /sys/devices/virtual/dmi/id/product_name is not valid"
+                    )
                 except (IOError, OSError) as err:
                     # PermissionError is new to Python 3, but corresponds to the EACESS and
                     # EPERM error numbers. Use those instead here for PY2 compatibility.

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1063,6 +1063,10 @@ def _virtual(osdata):
                         grains["virtual"] = "gce"
                     elif "BHYVE" in output:
                         grains["virtual"] = "bhyve"
+            except UnicodeDecodeError:
+                # Some firmwares provide non-valid 'product_name'
+                # files, ignore them
+                pass
             except IOError:
                 pass
     elif osdata["kernel"] == "FreeBSD":
@@ -2710,6 +2714,10 @@ def _hw_data(osdata):
                         )
                         if key == "uuid":
                             grains["uuid"] = grains["uuid"].lower()
+                except UnicodeDecodeError:
+                    # Some firmwares provide non-valid 'product_name'
+                    # files, ignore them
+                    pass
                 except (IOError, OSError) as err:
                     # PermissionError is new to Python 3, but corresponds to the EACESS and
                     # EPERM error numbers. Use those instead here for PY2 compatibility.

--- a/tests/unit/grains/test_core.py
+++ b/tests/unit/grains/test_core.py
@@ -1791,3 +1791,44 @@ class CoreGrainsTestCase(TestCase, LoaderModuleMockMixin):
         with patch.dict(os.environ, {"PATH": path}):
             result = core.path()
         assert result == {"path": path, "systempath": comps}, result
+
+    @skipIf(not salt.utils.platform.is_linux(), "System is not Linux")
+    @patch("os.path.exists")
+    @patch("salt.utils.platform.is_proxy")
+    def test__hw_data_linux_empty(self, is_proxy, exists):
+        is_proxy.return_value = False
+        exists.return_value = True
+        with patch("salt.utils.files.fopen", mock_open(read_data="")):
+            self.assertEqual(
+                core._hw_data({"kernel": "Linux"}),
+                {
+                    "biosreleasedate": "",
+                    "biosversion": "",
+                    "manufacturer": "",
+                    "productname": "",
+                    "serialnumber": "",
+                    "uuid": "",
+                },
+            )
+
+    @skipIf(not salt.utils.platform.is_linux(), "System is not Linux")
+    @patch("os.path.exists")
+    @patch("salt.utils.platform.is_proxy")
+    def test__hw_data_linux_unicode_error(self, is_proxy, exists):
+        def _fopen(*args):
+            class _File:
+                def __enter__(self):
+                    return self
+
+                def __exit__(self, *args):
+                    pass
+
+                def read(self):
+                    raise UnicodeDecodeError("enconding", b"", 1, 2, "reason")
+
+            return _File()
+
+        is_proxy.return_value = False
+        exists.return_value = True
+        with patch("salt.utils.files.fopen", _fopen):
+            self.assertEqual(core._hw_data({"kernel": "Linux"}), {})

--- a/tests/unit/grains/test_core.py
+++ b/tests/unit/grains/test_core.py
@@ -1816,7 +1816,7 @@ class CoreGrainsTestCase(TestCase, LoaderModuleMockMixin):
     @patch("salt.utils.platform.is_proxy")
     def test__hw_data_linux_unicode_error(self, is_proxy, exists):
         def _fopen(*args):
-            class _File:
+            class _File(object):
                 def __enter__(self):
                     return self
 


### PR DESCRIPTION
Some firmwares (like some NUC machines), do not provide valid
/sys/class/dmi/id/product_name strings. In those cases an
UnicodeDecodeError exception happens.

This patch ignore this kind of issue during the grains creation.

