### PR TITLE
Preserve already defined "DESTRUCTIVE_TESTS" and "EXPENSIVE_TESTS" env variables

### DIFF
--- a/tests/support/parser/__init__.py
+++ b/tests/support/parser/__init__.py
@@ -574,12 +574,12 @@ class SaltTestingParser(optparse.OptionParser):
 
         self.validate_options()
 
-        if self.support_destructive_tests_selection:
+        if self.support_destructive_tests_selection and not os.environ.get('DESTRUCTIVE_TESTS', None):
             # Set the required environment variable in order to know if
             # destructive tests should be executed or not.
             os.environ['DESTRUCTIVE_TESTS'] = str(self.options.run_destructive)
 
-        if self.support_expensive_tests_selection:
+        if self.support_expensive_tests_selection and not os.environ.get('EXPENSIVE_TESTS', None):
             # Set the required environment variable in order to know if
             # expensive tests should be executed or not.
             os.environ['EXPENSIVE_TESTS'] = str(self.options.run_expensive)


### PR DESCRIPTION
### What does this PR do?

This PR preserves already defined `DESTRUCTIVE_TESTS` and `EXPENSIVE_TESTS` environment variables when they have been already defined in the OS environment context.

At SUSE, we run Salt unit and integration tests using the `salt-toaster` [1], and we realized that even if i.a. `DESTRUCTIVE_TESTS` are set as OS enviroment variables and successfully evaluated by the `destructiveTest` decorator, they're then overwritten by `SaltTestingParser` without taking care of its existence, setting them back to its default value (False).

IMHO this should not happen when these env variables have been already set.

[1] - https://github.com/openSUSE/salt-toaster

### Previous Behavior
Tests mark as "destructive" or "expensive" are not running even if the respective OS environment variables are set.

### New Behavior
The tests run accordingly to already defined OS environment variables.

### Tests written?
No

### Commits signed with GPG?
Yes