### PR TITLE
Add checks for Amazon Linux to ip module

### DIFF
--- a/salt/modules/rh_ip.py
+++ b/salt/modules/rh_ip.py
@@ -1032,6 +1032,14 @@ def build_interface(iface, iface_type, enabled, **settings):
             rh_major = '7'
         else:
             rh_major = '6'
+    elif __grains__['os'] == 'Amazon':
+        # TODO: Is there a better formula for this? -W. Werner, 2019-05-30
+        # If not, it will need to be updated whenever Amazon releases
+        # Amazon Linux 3
+        if __grains__['osmajorrelease'] == 2:
+            rh_major = '7'
+        else:
+            rh_major = '6'
     else:
         rh_major = __grains__['osrelease'][:1]
 


### PR DESCRIPTION
### What does this PR do?

Adds checks for Amazon Linux to the IP module. Right now it tries to say that it's RedHat 1 or RedHat 2.

### What issues does this PR fix or reference?

Fixes #53171 

### Previous Behavior

On Amazon Linux 1 and 2 it's treated as RedHat 1 and 2.

### New Behavior

On Amazon Linux 1 it's RedHat 6, and Amazon Linux 2 is RedHat 7

### Tests written?

Fixes existing test

### Commits signed with GPG?

Yes