### PR TITLE
Improve x509 module HA to handle errors returned by the CA

### DIFF
--- a/salt/states/x509.py
+++ b/salt/states/x509.py
@@ -152,6 +152,27 @@ This state creates a private key then requests a certificate signed by ca accord
             bits: 4096
             backup: True
 
+You could also specify multiple ca_server for redundancy purposes, ca_server key accept a string or a list.
+
+/srv/salt/www.sls
+
+.. code-block:: yaml
+
+    /etc/pki/www.crt:
+      x509.certificate_managed:
+        - ca_server:
+          - myfirst_ca_server
+          - mysecond_ca_server
+        - signing_policy: www
+        - public_key: /etc/pki/www.key
+        - CN: www.example.com
+        - days_remaining: 30
+        - backup: True
+        - managed_private_key:
+            name: /etc/pki/www.key
+            bits: 4096
+            backup: True
+
 '''
 
 # Import Python Libs


### PR DESCRIPTION
### What does this PR do?
This is an improved version of past merged feature:
https://github.com/saltstack/salt/pull/50337

This PR allow the user to provide a list of ca_server or one ca_server.
If a list is provided, we will request each ca_server until one of them provide a certificate.

We also added some tests to be sure the server also return something that look like a certificate and not an error message. Indeed, we recently had a case where the server returned instead of a certificate string :
"[Errno 1] Operation not permitted: '/etc/pki/k8s/issued_certs/62:0A:54:49:7E:FE:7E:55.crt"
In this case, the "HA" was not working and a wrong string was wrote in the file.
With this second iteration, this case will be detected and it will try an other ca_server.

If no ca_server was able to provide a certificate, the returned exception will provide a more complete information of why each server failed.

### Tests written?
No, x509 seems already have some tests.

### Commits signed with GPG?
No

