### PR TITLE
Fix missing import

### DIFF
--- a/salt/transport/tcp.py
+++ b/salt/transport/tcp.py
@@ -44,6 +44,7 @@ import tornado.gen
 import tornado.concurrent
 import tornado.tcpclient
 import tornado.netutil
+import tornado.iostream
 
 # pylint: disable=import-error,no-name-in-module
 if six.PY2:


### PR DESCRIPTION
### What does this PR do?

Fixes missing import in `salt.transport.tcp`

### Tests written?

No - Prevents existing tests from raising an exception:
```
       Traceback (most recent call last):
         File "/tmp/kitchen/testing/salt/transport/tcp.py", line 1057, in _stream_return
       AttributeError: 'NoneType' object has no attribute 'StreamClosedError'
       Exception ignored in: <generator object _stream_return at 0x7fd535869150>
```

### Commits signed with GPG?

Yes