### PR TITLE
Fix traceback when making http query to non-listening host/port and raise_error=False

### DIFF
--- a/salt/modules/http.py
+++ b/salt/modules/http.py
@@ -16,9 +16,14 @@ import salt.utils.http
 
 def query(url, **kwargs):
     '''
+    .. versionadded:: 2015.5.0
+
     Query a resource, and decode the return data
 
-    .. versionadded:: 2015.5.0
+    raise_error : True
+        If ``False``, and if a connection cannot be made, the error will be
+        suppressed and the body of the return will simply be ``None``.
+
 
     CLI Example:
 
@@ -35,7 +40,10 @@ def query(url, **kwargs):
         opts.update(kwargs['opts'])
         del kwargs['opts']
 
-    return salt.utils.http.query(url=url, opts=opts, **kwargs)
+    try:
+        return salt.utils.http.query(url=url, opts=opts, **kwargs)
+    except Exception as exc:
+        raise CommandExecutionError(six.text_type(exc))
 
 
 def wait_for_successful_query(url, wait_for=300, **kwargs):

--- a/salt/modules/http.py
+++ b/salt/modules/http.py
@@ -12,6 +12,10 @@ import time
 
 # Import Salt libs
 import salt.utils.http
+from salt.exceptions import CommandExecutionError
+
+# Import 3rd-party libs
+from salt.ext import six
 
 
 def query(url, **kwargs):

--- a/salt/utils/http.py
+++ b/salt/utils/http.py
@@ -104,6 +104,8 @@ def __decompressContent(coding, pgctnt):
     Currently supports identity/none, deflate, and gzip, which should
     cover 99%+ of the content on the internet.
     '''
+    if not pgctnt:
+        return pgctnt
 
     log.trace("Decompressing %s byte content with compression type: %s", len(pgctnt), coding)
 
@@ -121,9 +123,6 @@ def __decompressContent(coding, pgctnt):
         raise ValueError("Brotli compression is not currently supported")
     elif coding == "compress":
         raise ValueError("LZW compression is not currently supported")
-
-    elif coding == 'identity':
-        pass
 
     log.trace("Content size after decompression: %s", len(pgctnt))
     return pgctnt

--- a/tests/unit/utils/test_http.py
+++ b/tests/unit/utils/test_http.py
@@ -5,6 +5,8 @@
 
 # Import Salt Libs
 from __future__ import absolute_import, unicode_literals, print_function
+import socket
+from contextlib import closing
 
 # Import Salt Testing Libs
 from tests.support.unit import TestCase, skipIf
@@ -90,3 +92,19 @@ class HTTPTestCase(TestCase):
         mock_ret = 'foo=XXXXXXXXXX&foo=XXXXXXXXXX&api_key=testing&'
         ret = http._sanitize_url_components(mock_component_list, 'foo')
         self.assertEqual(ret, mock_ret)
+
+    def test_query_null_response(self):
+        '''
+        This tests that we get a null response when raise_error=False and the
+        host/port cannot be reached.
+        '''
+        host = '127.0.0.1'
+
+        # Find unused port
+        with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as sock:
+            sock.bind((host, 0))
+            port = sock.getsockname()[1]
+
+        url = 'http://{host}:{port}/'.format(host=host, port=port)
+        result = http.query(url, raise_error=False)
+        assert result == {'body': None}, result


### PR DESCRIPTION
### What does this PR do?

When `salt.utils.http.query()` attempts to query a non-listening host/port and socket errors are suppressed, the response is `None`. This results in a traceback when the code attempts to log the length of the response before and after attempting to decompress it.

This PR simply returns without decompressing when the response resolves as `False`.

### What issues does this PR fix or reference?

N/A

### Previous Behavior

```
Traceback (most recent call last):
  File "/testing/salt/cli/caller.py", line 237, in call
    ret['return'] = self.minion.executors[fname](self.opts, data, func, args, kwargs)
  File "/testing/salt/executors/direct_call.py", line 12, in execute
    return func(*args, **kwargs)
  File "/testing/salt/modules/http.py", line 41, in query
    return salt.utils.http.query(url=url, opts=opts, **kwargs)
  File "/testing/salt/utils/http.py", line 618, in query
    result_text = __decompressContent(coding, result_text)
  File "/testing/salt/utils/http.py", line 108, in __decompressContent
    log.trace("Decompressing %s byte content with compression type: %s", len(pgctnt), coding)
TypeError: object of type 'NoneType' has no len()
```

### New Behavior

No traceback, and the return data is:

```python
{'body': None}
```

### Tests written?

Yes