### PR TITLE
only keep last 10 builds of every pr on jenkins to reduce disk usage

### DIFF
--- a/.ci/docs
+++ b/.ci/docs
@@ -6,7 +6,7 @@ pipeline {
         timestamps()
         ansiColor('xterm')
         timeout(time: 2, unit: 'HOURS')
-        buildDiscarder(logRotator(numToKeepStr: '20'))
+        buildDiscarder(logRotator(numToKeepStr: '10'))
     }
     environment {
         PYENV_ROOT = "/usr/local/pyenv"

--- a/.ci/kitchen-centos6-py2
+++ b/.ci/kitchen-centos6-py2
@@ -5,7 +5,7 @@ def testrun_timeout = 6
 def global_timeout = testrun_timeout + 1;
 
 properties([
-    buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '20')),
+    buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '10')),
     [
         $class: 'ScannerJobProperty', doNotScan: false
     ],

--- a/.ci/kitchen-centos7-py2
+++ b/.ci/kitchen-centos7-py2
@@ -5,7 +5,7 @@ def testrun_timeout = 6
 def global_timeout = testrun_timeout + 1;
 
 properties([
-    buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '20')),
+    buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '10')),
     [
         $class: 'ScannerJobProperty', doNotScan: false
     ],

--- a/.ci/kitchen-centos7-py3
+++ b/.ci/kitchen-centos7-py3
@@ -5,7 +5,7 @@ def testrun_timeout = 6
 def global_timeout = testrun_timeout + 1;
 
 properties([
-    buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '20')),
+    buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '10')),
     [
         $class: 'ScannerJobProperty', doNotScan: false
     ],

--- a/.ci/kitchen-debian8-py2
+++ b/.ci/kitchen-debian8-py2
@@ -5,7 +5,7 @@ def testrun_timeout = 6
 def global_timeout = testrun_timeout + 1;
 
 properties([
-    buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '20')),
+    buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '10')),
     [
         $class: 'ScannerJobProperty', doNotScan: false
     ],

--- a/.ci/kitchen-debian8-py3
+++ b/.ci/kitchen-debian8-py3
@@ -5,7 +5,7 @@ def testrun_timeout = 6
 def global_timeout = testrun_timeout + 1;
 
 properties([
-    buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '20')),
+    buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '10')),
     [
         $class: 'ScannerJobProperty', doNotScan: false
     ],

--- a/.ci/kitchen-debian9-py2
+++ b/.ci/kitchen-debian9-py2
@@ -5,7 +5,7 @@ def testrun_timeout = 6
 def global_timeout = testrun_timeout + 1;
 
 properties([
-    buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '20')),
+    buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '10')),
     [
         $class: 'ScannerJobProperty', doNotScan: false
     ],

--- a/.ci/kitchen-debian9-py3
+++ b/.ci/kitchen-debian9-py3
@@ -5,7 +5,7 @@ def testrun_timeout = 6
 def global_timeout = testrun_timeout + 1;
 
 properties([
-    buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '20')),
+    buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '10')),
     [
         $class: 'ScannerJobProperty', doNotScan: false
     ],

--- a/.ci/kitchen-fedora28-py2
+++ b/.ci/kitchen-fedora28-py2
@@ -5,7 +5,7 @@ def testrun_timeout = 6
 def global_timeout = testrun_timeout + 1;
 
 properties([
-    buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '20')),
+    buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '10')),
     [
         $class: 'ScannerJobProperty', doNotScan: false
     ],

--- a/.ci/kitchen-fedora28-py3
+++ b/.ci/kitchen-fedora28-py3
@@ -5,7 +5,7 @@ def testrun_timeout = 6
 def global_timeout = testrun_timeout + 1;
 
 properties([
-    buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '20')),
+    buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '10')),
     [
         $class: 'ScannerJobProperty', doNotScan: false
     ],

--- a/.ci/kitchen-ubuntu1604-py2
+++ b/.ci/kitchen-ubuntu1604-py2
@@ -5,7 +5,7 @@ def testrun_timeout = 6
 def global_timeout = testrun_timeout + 1;
 
 properties([
-    buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '20')),
+    buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '10')),
     [
         $class: 'ScannerJobProperty', doNotScan: false
     ],

--- a/.ci/kitchen-ubuntu1604-py3
+++ b/.ci/kitchen-ubuntu1604-py3
@@ -5,7 +5,7 @@ def testrun_timeout = 6
 def global_timeout = testrun_timeout + 1;
 
 properties([
-    buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '20')),
+    buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '10')),
     [
         $class: 'ScannerJobProperty', doNotScan: false
     ],

--- a/.ci/kitchen-ubuntu1804-py2
+++ b/.ci/kitchen-ubuntu1804-py2
@@ -5,7 +5,7 @@ def testrun_timeout = 6
 def global_timeout = testrun_timeout + 1;
 
 properties([
-    buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '20')),
+    buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '10')),
     [
         $class: 'ScannerJobProperty', doNotScan: false
     ],

--- a/.ci/kitchen-ubuntu1804-py3
+++ b/.ci/kitchen-ubuntu1804-py3
@@ -5,7 +5,7 @@ def testrun_timeout = 6
 def global_timeout = testrun_timeout + 1;
 
 properties([
-    buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '20')),
+    buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '10')),
     [
         $class: 'ScannerJobProperty', doNotScan: false
     ],

--- a/.ci/kitchen-windows2016-py2
+++ b/.ci/kitchen-windows2016-py2
@@ -5,7 +5,7 @@ def testrun_timeout = 8
 def global_timeout = testrun_timeout + 1;
 
 properties([
-    buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '20')),
+    buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '10')),
     [
         $class: 'ScannerJobProperty', doNotScan: false
     ],

--- a/.ci/kitchen-windows2016-py3
+++ b/.ci/kitchen-windows2016-py3
@@ -5,7 +5,7 @@ def testrun_timeout = 8
 def global_timeout = testrun_timeout + 1;
 
 properties([
-    buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '20')),
+    buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '10')),
     [
         $class: 'ScannerJobProperty', doNotScan: false
     ],

--- a/.ci/lint
+++ b/.ci/lint
@@ -4,7 +4,7 @@ pipeline {
         timestamps()
         ansiColor('xterm')
         timeout(time: 3, unit: 'HOURS')
-        buildDiscarder(logRotator(numToKeepStr: '20'))
+        buildDiscarder(logRotator(numToKeepStr: '10'))
     }
     environment {
         PYENV_ROOT = "/usr/local/pyenv"


### PR DESCRIPTION
What does this PR do?

It adjusts the jenkins pipeline files to only keep the last 10 builds of PR's so we don't fill up jenkins when some pr's have around 100 builds sitting around.
What issues does this PR fix or reference?

None
Previous Behavior

Builds for pr jobs were kept until the pr was closed.
New Behavior

Builds for pr's only are kept if they are the 10 most recent builds for a given pr.
Tests written?

N/A
Commits signed with GPG?

Yes