### PR TITLE
Bugfix: Handle multibyte characters spanning blocks of received data (2018.3)

### DIFF
--- a/tests/unit/utils/test_vt.py
+++ b/tests/unit/utils/test_vt.py
@@ -12,6 +12,8 @@
 # Import Python libs
 from __future__ import absolute_import, print_function, unicode_literals
 
+import functools
+import io
 import os
 import random
 import subprocess
@@ -19,15 +21,54 @@ import sys
 import time
 
 # Import Salt libs
+import salt.utils
 import salt.utils.files
 import salt.utils.platform
+import salt.utils.stringutils
 import salt.utils.vt
 
 # Import 3rd-party libs
 from salt.ext.six.moves import range  # pylint: disable=import-error,redefined-builtin
 
 # Import Salt Testing libs
+from tests.support.paths import CODE_DIR
 from tests.support.unit import TestCase, skipIf
+
+
+def stdout_fileno_available():
+    """
+        Tests if sys.stdout.fileno is available in this testing environment
+    """
+    try:
+        sys.stdout.fileno()
+        return True
+    except io.UnsupportedOperation:
+        return False
+
+
+def fixStdOutErrFileNoIfNeeded(func):
+    """
+        Decorator that sets stdout and stderr to their original objects if
+        sys.stdout.fileno() doesn't work and restores them after running the
+        decorated function. This doesn't check if the original objects actually
+        work. If they don't then the test environment is too broken to test
+        the VT.
+    """
+
+    @functools.wraps(func)
+    def wrapper_fixStdOutErrFileNoIfNeeded(*args, **kwargs):
+        original_stdout = os.sys.stdout
+        original_stderr = os.sys.stderr
+        if not stdout_fileno_available():
+            os.sys.stdout = os.sys.__stdout__
+            os.sys.stderr = os.sys.__stderr__
+        try:
+            return func(*args, **kwargs)
+        finally:
+            os.sys.stdout = original_stdout
+            os.sys.stderr = original_stderr
+
+    return wrapper_fixStdOutErrFileNoIfNeeded
 
 
 class VTTestCase(TestCase):
@@ -218,5 +259,138 @@ class VTTestCase(TestCase):
             self.assertFalse(term.isalive())
             self.assertIsNone(stderr)
             self.assertIsNone(stdout)
+        finally:
+            term.close(terminate=True, kill=True)
+
+    @staticmethod
+    def generate_multibyte_stdout_unicode(block_size):
+        return b"\xE2\x80\xA6" * 4 * block_size
+
+    @staticmethod
+    def generate_multibyte_stderr_unicode(block_size):
+        return b"\x2E" + VTTestCase.generate_multibyte_stdout_unicode(block_size)
+
+    @skipIf(
+        salt.utils.platform.is_windows(), "Skip VT tests on windows, due to issue 54290"
+    )
+    @fixStdOutErrFileNoIfNeeded
+    def test_split_multibyte_characters_unicode(self):
+        """
+            Tests that the vt correctly handles multibyte characters that are
+            split between blocks of transmitted data.
+        """
+        block_size = 1024
+        encoding = "utf-8"
+        stdout_content = VTTestCase.generate_multibyte_stdout_unicode(block_size)
+        # stderr is offset by one byte to guarentee a split character in
+        # one of the output streams
+        stderr_content = VTTestCase.generate_multibyte_stderr_unicode(block_size)
+
+        expected_stdout = salt.utils.stringutils.to_unicode(stdout_content, encoding)
+        expected_stderr = salt.utils.stringutils.to_unicode(stderr_content, encoding)
+        python_command = "\n".join(
+            (
+                "import sys",
+                "import os",
+                "import tests.unit.utils.test_vt as test_vt",
+                (
+                    "os.write(sys.stdout.fileno(), "
+                    "test_vt.VTTestCase.generate_multibyte_stdout_unicode("
+                    + str(block_size)
+                    + "))"
+                ),
+                (
+                    "os.write(sys.stderr.fileno(), "
+                    "test_vt.VTTestCase.generate_multibyte_stderr_unicode("
+                    + str(block_size)
+                    + "))"
+                ),
+            )
+        )
+        term = salt.utils.vt.Terminal(
+            args=[sys.executable, "-c", '"' + python_command + '"'],
+            shell=True,
+            cwd=CODE_DIR,
+            stream_stdout=False,
+            stream_stderr=False,
+            force_receive_encoding=encoding,
+        )
+        buffer_o = buffer_e = salt.utils.stringutils.to_unicode("")
+        try:
+            while term.has_unread_data:
+                stdout, stderr = term.recv(block_size)
+                if stdout:
+                    buffer_o += stdout
+                if stderr:
+                    buffer_e += stderr
+
+            self.assertEqual(buffer_o, expected_stdout)
+            self.assertEqual(buffer_e, expected_stderr)
+        finally:
+            term.close(terminate=True, kill=True)
+
+    @staticmethod
+    def generate_multibyte_stdout_shiftjis(block_size):
+        return b"\x8B\x80" * 4 * block_size
+
+    @staticmethod
+    def generate_multibyte_stderr_shiftjis(block_size):
+        return b"\x2E" + VTTestCase.generate_multibyte_stdout_shiftjis(block_size)
+
+    @skipIf(
+        salt.utils.platform.is_windows(), "Skip VT tests on windows, due to issue 54290"
+    )
+    @fixStdOutErrFileNoIfNeeded
+    def test_split_multibyte_characters_shiftjis(self):
+        """
+            Tests that the vt correctly handles multibyte characters that are
+            split between blocks of transmitted data.
+            Uses shift-jis encoding to make sure code doesn't assume unicode.
+        """
+        block_size = 1024
+        encoding = "shift-jis"
+        stdout_content = VTTestCase.generate_multibyte_stdout_shiftjis(block_size)
+        stderr_content = VTTestCase.generate_multibyte_stderr_shiftjis(block_size)
+
+        expected_stdout = salt.utils.stringutils.to_unicode(stdout_content, encoding)
+        expected_stderr = salt.utils.stringutils.to_unicode(stderr_content, encoding)
+        python_command = "\n".join(
+            (
+                "import sys",
+                "import os",
+                "import tests.unit.utils.test_vt as test_vt",
+                (
+                    "os.write(sys.stdout.fileno(), "
+                    "test_vt.VTTestCase.generate_multibyte_stdout_shiftjis("
+                    + str(block_size)
+                    + "))"
+                ),
+                (
+                    "os.write(sys.stderr.fileno(), "
+                    "test_vt.VTTestCase.generate_multibyte_stderr_shiftjis("
+                    + str(block_size)
+                    + "))"
+                ),
+            )
+        )
+        term = salt.utils.vt.Terminal(
+            args=[sys.executable, "-c", '"' + python_command + '"'],
+            shell=True,
+            cwd=CODE_DIR,
+            stream_stdout=False,
+            stream_stderr=False,
+            force_receive_encoding=encoding,
+        )
+        buffer_o = buffer_e = salt.utils.stringutils.to_unicode("")
+        try:
+            while term.has_unread_data:
+                stdout, stderr = term.recv(block_size)
+                if stdout:
+                    buffer_o += stdout
+                if stderr:
+                    buffer_e += stderr
+
+            self.assertEqual(buffer_o, expected_stdout)
+            self.assertEqual(buffer_e, expected_stderr)
         finally:
             term.close(terminate=True, kill=True)


### PR DESCRIPTION
### What does this PR do?
Fix a bug where decoding of received stdout or stderr data into text fails if a multibyte character occurs at the end of one received block of data and extends into the next block of data

### What issues does this PR fix or reference?
Probably this one: https://github.com/saltstack/salt/issues/48473

### Previous Behaviour
Previously stdout and stderr were received from the client as blocks (usually 1024 bytes) of binary data which was then decoded to strings (usually utf-8).
This process would fail when a multibyte character occurs at the end of a received block of data with only part of the character in the current block. The decoding would fail with the exception UnicodeDecodeError and the message 'unexpected end of data' and include the start and end positions of failure - the start being the first byte of the split character and the end as the end of the block of data. Non-unicode encoding schemes don't necessarily report 'unexpected end of data' but the one tested (shift-jis) did still generate a UnicodeDecodeError with similar start and end locations.

### New Behaviour
This fix checks for a UnicodeDecodeError with the start position near the end of the block of data (near being within the length of the longest multibyte character in any encoding scheme that may be used [ I checked a couple and 4 seemed to be the longest] ) and the end position being the end of the received data. If such an error occurs then the received block of data is stored and empty string is returned as if no data was received. The next attempt to receive data will only attempt to read one byte and will have the previously stored data prepended to it.
The reason for only reading one byte is to make successive calls to recv attempt to read one byte at a time to complete the split character and successfully decode the received block.
If the previous data had been stored because of a malformed character that happened at the end of the block of data instead of a multibyte character that was split then the error start position will have the same index each time recv is called and after successive calls will no-longer be close enough to the end of the new combined block of received data to look like a possible split multibyte character and the decoding exception will be raised.

If the stream closes and there is stored data from the previous call to recv because decoding failed that time then next time recv is called decoding will be attempted again on the stored data in order to generate the appropriate exception.

### Tests written?

Yes

A new member variable force_receive_encoding was added to the vt to allow tests to force a specific encoding to be used to allow testing with character encodings that aren't utf-8 or whatever `__salt_system_encoding__` happens to be on the testing system.

### Commits signed with GPG?

Yes
