### PR TITLE
Multimaster minion hang on fire_master

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -956,7 +956,8 @@ class MinionManager(MinionBase):
 
     @tornado.gen.coroutine
     def handle_event(self, package):
-        yield [minion.handle_event(package) for minion in self.minions]
+        for minion in self.minions:
+            minion.handle_event(package)
 
     def _create_minion_object(self, opts, timeout, safe,
                               io_loop=None, loaded_base_name=None,
@@ -2319,12 +2320,12 @@ class Minion(MinionBase):
         elif tag.startswith('fire_master'):
             if self.connected:
                 log.debug('Forwarding master event tag=%s', data['tag'])
-                self._fire_master(data['data'], data['tag'], data['events'], data['pretag'])
+                self._fire_master(data['data'], data['tag'], data['events'], data['pretag'], sync=False)
         elif tag.startswith(master_event(type='disconnected')) or tag.startswith(master_event(type='failback')):
             # if the master disconnect event is for a different master, raise an exception
             if tag.startswith(master_event(type='disconnected')) and data['master'] != self.opts['master']:
                 # not mine master, ignore
-                return
+                raise tornado.gen.Return()
             if tag.startswith(master_event(type='failback')):
                 # if the master failback event is not for the top master, raise an exception
                 if data['master'] != self.opts['master_list'][0]:
@@ -2462,7 +2463,7 @@ class Minion(MinionBase):
         elif tag.startswith('_salt_error'):
             if self.connected:
                 log.debug('Forwarding salt error event tag=%s', tag)
-                self._fire_master(data, tag)
+                self._fire_master(data, tag, sync=False)
         elif tag.startswith('salt/auth/creds'):
             key = tuple(data['key'])
             log.debug(

--- a/salt/transport/ipc.py
+++ b/salt/transport/ipc.py
@@ -599,7 +599,7 @@ class IPCMessageSubscriber(IPCClient):
         except tornado.gen.TimeoutError:
             raise tornado.gen.Return(None)
 
-        log.debug('IPC Subscriber is starting reading')
+        log.trace('IPC Subscriber is starting reading')
         exc_to_raise = None
         ret = None
         try:


### PR DESCRIPTION
### What does this PR do?
Fire master asynchronously in minion event handler. This makes multimaster minion to fire events in parallel to all masters to not hang if any of multiple masters stopped.

### What issues does this PR fix or reference?
Fixes #50814 (ZD-3031)

### Previous Behavior
Multimaster minion stops to respond until master connection timed out after a number of retries when on of masters is stopped.

### New Behavior
Multimaster minion continues to work normally until at least one master is alive.

### Tests written?
No. I see no easy way to test this change.

### Commits signed with GPG?
Yes