### PR TITLE
only fetch pr target branch instead of all branches to save time and disk space

### DIFF
--- a/.ci/kitchen-centos6-py2
+++ b/.ci/kitchen-centos6-py2
@@ -51,6 +51,7 @@ timeout(time: global_timeout, unit: 'HOURS') {
                     try {
                         // Setup the kitchen required bundle
                         stage('setup-bundle') {
+                            sh 'git fetch --no-tags https://github.com/saltstack/salt.git +refs/heads/${CHANGE_TARGET}:refs/remotes/origin/${CHANGE_TARGET}'
                             sh 'bundle install --with ec2 windows --without docker macos opennebula vagrant'
                         }
                         try {

--- a/.ci/kitchen-centos7-py2
+++ b/.ci/kitchen-centos7-py2
@@ -51,6 +51,7 @@ timeout(time: global_timeout, unit: 'HOURS') {
                     try {
                         // Setup the kitchen required bundle
                         stage('setup-bundle') {
+                            sh 'git fetch --no-tags https://github.com/saltstack/salt.git +refs/heads/${CHANGE_TARGET}:refs/remotes/origin/${CHANGE_TARGET}'
                             sh 'bundle install --with ec2 windows --without docker macos opennebula vagrant'
                         }
                         try {

--- a/.ci/kitchen-centos7-py3
+++ b/.ci/kitchen-centos7-py3
@@ -51,6 +51,7 @@ timeout(time: global_timeout, unit: 'HOURS') {
                     try {
                         // Setup the kitchen required bundle
                         stage('setup-bundle') {
+                            sh 'git fetch --no-tags https://github.com/saltstack/salt.git +refs/heads/${CHANGE_TARGET}:refs/remotes/origin/${CHANGE_TARGET}'
                             sh 'bundle install --with ec2 windows --without docker macos opennebula vagrant'
                         }
                         try {

--- a/.ci/kitchen-debian8-py2
+++ b/.ci/kitchen-debian8-py2
@@ -51,6 +51,7 @@ timeout(time: global_timeout, unit: 'HOURS') {
                     try {
                         // Setup the kitchen required bundle
                         stage('setup-bundle') {
+                            sh 'git fetch --no-tags https://github.com/saltstack/salt.git +refs/heads/${CHANGE_TARGET}:refs/remotes/origin/${CHANGE_TARGET}'
                             sh 'bundle install --with ec2 windows --without docker macos opennebula vagrant'
                         }
                         try {

--- a/.ci/kitchen-debian8-py3
+++ b/.ci/kitchen-debian8-py3
@@ -51,6 +51,7 @@ timeout(time: global_timeout, unit: 'HOURS') {
                     try {
                         // Setup the kitchen required bundle
                         stage('setup-bundle') {
+                            sh 'git fetch --no-tags https://github.com/saltstack/salt.git +refs/heads/${CHANGE_TARGET}:refs/remotes/origin/${CHANGE_TARGET}'
                             sh 'bundle install --with ec2 windows --without docker macos opennebula vagrant'
                         }
                         try {

--- a/.ci/kitchen-debian9-py2
+++ b/.ci/kitchen-debian9-py2
@@ -51,6 +51,7 @@ timeout(time: global_timeout, unit: 'HOURS') {
                     try {
                         // Setup the kitchen required bundle
                         stage('setup-bundle') {
+                            sh 'git fetch --no-tags https://github.com/saltstack/salt.git +refs/heads/${CHANGE_TARGET}:refs/remotes/origin/${CHANGE_TARGET}'
                             sh 'bundle install --with ec2 windows --without docker macos opennebula vagrant'
                         }
                         try {

--- a/.ci/kitchen-debian9-py3
+++ b/.ci/kitchen-debian9-py3
@@ -51,6 +51,7 @@ timeout(time: global_timeout, unit: 'HOURS') {
                     try {
                         // Setup the kitchen required bundle
                         stage('setup-bundle') {
+                            sh 'git fetch --no-tags https://github.com/saltstack/salt.git +refs/heads/${CHANGE_TARGET}:refs/remotes/origin/${CHANGE_TARGET}'
                             sh 'bundle install --with ec2 windows --without docker macos opennebula vagrant'
                         }
                         try {

--- a/.ci/kitchen-fedora28-py2
+++ b/.ci/kitchen-fedora28-py2
@@ -51,6 +51,7 @@ timeout(time: global_timeout, unit: 'HOURS') {
                     try {
                         // Setup the kitchen required bundle
                         stage('setup-bundle') {
+                            sh 'git fetch --no-tags https://github.com/saltstack/salt.git +refs/heads/${CHANGE_TARGET}:refs/remotes/origin/${CHANGE_TARGET}'
                             sh 'bundle install --with ec2 windows --without docker macos opennebula vagrant'
                         }
                         try {

--- a/.ci/kitchen-fedora28-py3
+++ b/.ci/kitchen-fedora28-py3
@@ -51,6 +51,7 @@ timeout(time: global_timeout, unit: 'HOURS') {
                     try {
                         // Setup the kitchen required bundle
                         stage('setup-bundle') {
+                            sh 'git fetch --no-tags https://github.com/saltstack/salt.git +refs/heads/${CHANGE_TARGET}:refs/remotes/origin/${CHANGE_TARGET}'
                             sh 'bundle install --with ec2 windows --without docker macos opennebula vagrant'
                         }
                         try {

--- a/.ci/kitchen-ubuntu1604-py2
+++ b/.ci/kitchen-ubuntu1604-py2
@@ -51,6 +51,7 @@ timeout(time: global_timeout, unit: 'HOURS') {
                     try {
                         // Setup the kitchen required bundle
                         stage('setup-bundle') {
+                            sh 'git fetch --no-tags https://github.com/saltstack/salt.git +refs/heads/${CHANGE_TARGET}:refs/remotes/origin/${CHANGE_TARGET}'
                             sh 'bundle install --with ec2 windows --without docker macos opennebula vagrant'
                         }
                         try {

--- a/.ci/kitchen-ubuntu1604-py3
+++ b/.ci/kitchen-ubuntu1604-py3
@@ -51,6 +51,7 @@ timeout(time: global_timeout, unit: 'HOURS') {
                     try {
                         // Setup the kitchen required bundle
                         stage('setup-bundle') {
+                            sh 'git fetch --no-tags https://github.com/saltstack/salt.git +refs/heads/${CHANGE_TARGET}:refs/remotes/origin/${CHANGE_TARGET}'
                             sh 'bundle install --with ec2 windows --without docker macos opennebula vagrant'
                         }
                         try {

--- a/.ci/kitchen-ubuntu1804-py2
+++ b/.ci/kitchen-ubuntu1804-py2
@@ -51,6 +51,7 @@ timeout(time: global_timeout, unit: 'HOURS') {
                     try {
                         // Setup the kitchen required bundle
                         stage('setup-bundle') {
+                            sh 'git fetch --no-tags https://github.com/saltstack/salt.git +refs/heads/${CHANGE_TARGET}:refs/remotes/origin/${CHANGE_TARGET}'
                             sh 'bundle install --with ec2 windows --without docker macos opennebula vagrant'
                         }
                         try {

--- a/.ci/kitchen-ubuntu1804-py3
+++ b/.ci/kitchen-ubuntu1804-py3
@@ -51,6 +51,7 @@ timeout(time: global_timeout, unit: 'HOURS') {
                     try {
                         // Setup the kitchen required bundle
                         stage('setup-bundle') {
+                            sh 'git fetch --no-tags https://github.com/saltstack/salt.git +refs/heads/${CHANGE_TARGET}:refs/remotes/origin/${CHANGE_TARGET}'
                             sh 'bundle install --with ec2 windows --without docker macos opennebula vagrant'
                         }
                         try {

--- a/.ci/kitchen-windows2016-py2
+++ b/.ci/kitchen-windows2016-py2
@@ -50,6 +50,7 @@ timeout(time: global_timeout, unit: 'HOURS') {
                     try {
                         // Setup the kitchen required bundle
                         stage('setup-bundle') {
+                            sh 'git fetch --no-tags https://github.com/saltstack/salt.git +refs/heads/${CHANGE_TARGET}:refs/remotes/origin/${CHANGE_TARGET}'
                             sh 'bundle install --with ec2 windows --without docker macos opennebula vagrant'
                         }
                         try {

--- a/.ci/kitchen-windows2016-py3
+++ b/.ci/kitchen-windows2016-py3
@@ -50,6 +50,7 @@ timeout(time: global_timeout, unit: 'HOURS') {
                     try {
                         // Setup the kitchen required bundle
                         stage('setup-bundle') {
+                            sh 'git fetch --no-tags https://github.com/saltstack/salt.git +refs/heads/${CHANGE_TARGET}:refs/remotes/origin/${CHANGE_TARGET}'
                             sh 'bundle install --with ec2 windows --without docker macos opennebula vagrant'
                         }
                         try {


### PR DESCRIPTION
### What does this PR do?
It allows us to only pull the target branch for kitchen so we don't have to pull all branches down on every pr test.  Docs and lint only need the pr branch, kitchen needs the pr branch and the target branch.  This saves, time, money, disk space, etc.

### Previous Behavior
Jenkins pulled all branches from the repo when testing 

### New Behavior
Jenkins only pulls needed branches when testing like it did before we had to change the way jenkins tests to testing pr heads rather than pr heads merging into the main branch.

### Tests written?
N/A

### Commits signed with GPG?

Yes