### PR TITLE
Fixed napalm_beacon compatability for python 3

### DIFF
--- a/salt/beacons/napalm_beacon.py
+++ b/salt/beacons/napalm_beacon.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-'''
+"""
 Watch NAPALM functions and fire events on specific triggers
 ===========================================================
 
@@ -166,7 +166,7 @@ Event structure example:
 The event examplified above has been fired when the device
 identified by the Minion id ``edge01.bjm01`` has been synchronized
 with a NTP server at a stratum level greater than 5.
-'''
+"""
 from __future__ import absolute_import, unicode_literals
 
 # Import Python std lib
@@ -178,37 +178,37 @@ from salt.ext import six
 import salt.utils.napalm
 
 log = logging.getLogger(__name__)
-_numeric_regex = re.compile(r'^(<|>|<=|>=|==|!=)\s*(\d+(\.\d+){0,1})$')
+_numeric_regex = re.compile(r"^(<|>|<=|>=|==|!=)\s*(\d+(\.\d+){0,1})$")
 # the numeric regex will match the right operand, e.g '>= 20', '< 100', '!= 20', '< 1000.12' etc.
 _numeric_operand = {
-    '<': '__lt__',
-    '>': '__gt__',
-    '>=': '__ge__',
-    '<=': '__le__',
-    '==': '__eq__',
-    '!=': '__ne__',
+    "<": "__lt__",
+    ">": "__gt__",
+    ">=": "__ge__",
+    "<=": "__le__",
+    "==": "__eq__",
+    "!=": "__ne__",
 }  # mathematical operand - private method map
 
 
-__virtualname__ = 'napalm'
+__virtualname__ = "napalm"
 
 
 def __virtual__():
-    '''
+    """
     This beacon can only work when running under a regular or a proxy minion, managed through napalm.
-    '''
+    """
     return salt.utils.napalm.virtual(__opts__, __virtualname__, __file__)
 
 
 def _compare(cur_cmp, cur_struct):
-    '''
+    """
     Compares two objects and return a boolean value
     when there's a match.
-    '''
+    """
     if isinstance(cur_cmp, dict) and isinstance(cur_struct, dict):
-        log.debug('Comparing dict to dict')
+        log.debug("Comparing dict to dict")
         for cmp_key, cmp_value in six.iteritems(cur_cmp):
-            if cmp_key == '*':
+            if cmp_key == "*":
                 # matches any key from the source dictionary
                 if isinstance(cmp_value, dict):
                     found = False
@@ -237,89 +237,101 @@ def _compare(cur_cmp, cur_struct):
                 else:
                     return _compare(cmp_value, cur_struct[cmp_key])
     elif isinstance(cur_cmp, (list, tuple)) and isinstance(cur_struct, (list, tuple)):
-        log.debug('Comparing list to list')
+        log.debug("Comparing list to list")
         found = False
         for cur_cmp_ele in cur_cmp:
             for cur_struct_ele in cur_struct:
                 found |= _compare(cur_cmp_ele, cur_struct_ele)
         return found
     elif isinstance(cur_cmp, dict) and isinstance(cur_struct, (list, tuple)):
-        log.debug('Comparing dict to list (of dicts?)')
+        log.debug("Comparing dict to list (of dicts?)")
         found = False
         for cur_struct_ele in cur_struct:
             found |= _compare(cur_cmp, cur_struct_ele)
         return found
     elif isinstance(cur_cmp, bool) and isinstance(cur_struct, bool):
-        log.debug('Comparing booleans: %s ? %s', cur_cmp, cur_struct)
+        log.debug("Comparing booleans: %s ? %s", cur_cmp, cur_struct)
         return cur_cmp == cur_struct
-    elif isinstance(cur_cmp, (six.string_types, six.text_type)) and \
-         isinstance(cur_struct, (six.string_types, six.text_type)):
-        log.debug('Comparing strings (and regex?): %s ? %s', cur_cmp, cur_struct)
+    elif isinstance(cur_cmp, (six.string_types, six.text_type)) and isinstance(
+        cur_struct, (six.string_types, six.text_type)
+    ):
+        log.debug("Comparing strings (and regex?): %s ? %s", cur_cmp, cur_struct)
         # Trying literal match
         matched = re.match(cur_cmp, cur_struct, re.I)
         if matched:
             return True
         return False
-    elif isinstance(cur_cmp, (six.integer_types, float)) and \
-         isinstance(cur_struct, (six.integer_types, float)):
-        log.debug('Comparing numeric values: %d ? %d', cur_cmp, cur_struct)
+    elif isinstance(cur_cmp, (six.integer_types, float)) and isinstance(
+        cur_struct, (six.integer_types, float)
+    ):
+        log.debug("Comparing numeric values: %d ? %d", cur_cmp, cur_struct)
         # numeric compare
         return cur_cmp == cur_struct
-    elif isinstance(cur_struct, (six.integer_types, float)) and \
-         isinstance(cur_cmp, (six.string_types, six.text_type)):
+    elif isinstance(cur_struct, (six.integer_types, float)) and isinstance(
+        cur_cmp, (six.string_types, six.text_type)
+    ):
         # Comapring the numerical value agains a presumably mathematical value
-        log.debug('Comparing a numeric value (%d) with a string (%s)', cur_struct, cur_cmp)
+        log.debug(
+            "Comparing a numeric value (%d) with a string (%s)", cur_struct, cur_cmp
+        )
         numeric_compare = _numeric_regex.match(cur_cmp)
         # determine if the value to compare agains is a mathematical operand
         if numeric_compare:
             compare_value = numeric_compare.group(2)
-            return getattr(float(cur_struct), _numeric_operand[numeric_compare.group(1)])(float(compare_value))
+            return getattr(
+                float(cur_struct), _numeric_operand[numeric_compare.group(1)]
+            )(float(compare_value))
         return False
     return False
 
 
 def validate(config):
-    '''
+    """
     Validate the beacon configuration.
-    '''
+    """
     # Must be a list of dicts.
     if not isinstance(config, list):
-        return False, 'Configuration for napalm beacon must be a list.'
+        return False, "Configuration for napalm beacon must be a list."
     for mod in config:
-        fun = mod.keys()[0]
-        fun_cfg = mod.values()[0]
+        fun = list(mod.keys())[0]
+        fun_cfg = list(mod.values())[0]
         if not isinstance(fun_cfg, dict):
-            return False, 'The match structure for the {} execution function output must be a dictionary'.format(fun)
+            return (
+                False,
+                "The match structure for the {} execution function output must be a dictionary".format(
+                    fun
+                ),
+            )
         if fun not in __salt__:
-            return False, 'Execution function {} is not availabe!'.format(fun)
-    return True, 'Valid configuration for the napal beacon!'
+            return False, "Execution function {} is not availabe!".format(fun)
+    return True, "Valid configuration for the napal beacon!"
 
 
 def beacon(config):
-    '''
+    """
     Watch napalm function and fire events.
-    '''
-    log.debug('Executing napalm beacon with config:')
+    """
+    log.debug("Executing napalm beacon with config:")
     log.debug(config)
     ret = []
     for mod in config:
         if not mod:
             continue
         event = {}
-        fun = mod.keys()[0]
-        fun_cfg = mod.values()[0]
-        args = fun_cfg.pop('_args', [])
-        kwargs = fun_cfg.pop('_kwargs', {})
-        log.debug('Executing %s with %s and %s', fun, args, kwargs)
+        fun = list(mod.keys())[0]
+        fun_cfg = list(mod.values())[0]
+        args = fun_cfg.pop("_args", [])
+        kwargs = fun_cfg.pop("_kwargs", {})
+        log.debug("Executing %s with %s and %s", fun, args, kwargs)
         fun_ret = __salt__[fun](*args, **kwargs)
-        log.debug('Got the reply from the minion:')
+        log.debug("Got the reply from the minion:")
         log.debug(fun_ret)
-        if not fun_ret.get('result', False):
-            log.error('Error whilst executing %s', fun)
+        if not fun_ret.get("result", False):
+            log.error("Error whilst executing %s", fun)
             log.error(fun_ret)
             continue
-        fun_ret_out = fun_ret['out']
-        log.debug('Comparing to:')
+        fun_ret_out = fun_ret["out"]
+        log.debug("Comparing to:")
         log.debug(fun_cfg)
         try:
             fun_cmp_result = _compare(fun_cfg, fun_ret_out)
@@ -328,18 +340,18 @@ def beacon(config):
             # catch any exception and continue
             # to not jeopardise the execution of the next function in the list
             continue
-        log.debug('Result of comparison: %s', fun_cmp_result)
+        log.debug("Result of comparison: %s", fun_cmp_result)
         if fun_cmp_result:
-            log.info('Matched %s with %s', fun, fun_cfg)
-            event['tag'] = '{os}/{fun}'.format(os=__grains__['os'], fun=fun)
-            event['fun'] = fun
-            event['args'] = args
-            event['kwargs'] = kwargs
-            event['data'] = fun_ret
-            event['match'] = fun_cfg
-            log.debug('Queueing event:')
+            log.info("Matched %s with %s", fun, fun_cfg)
+            event["tag"] = "{os}/{fun}".format(os=__grains__["os"], fun=fun)
+            event["fun"] = fun
+            event["args"] = args
+            event["kwargs"] = kwargs
+            event["data"] = fun_ret
+            event["match"] = fun_cfg
+            log.debug("Queueing event:")
             log.debug(event)
             ret.append(event)
-    log.debug('NAPALM beacon generated the events:')
+    log.debug("NAPALM beacon generated the events:")
     log.debug(ret)
     return ret

--- a/salt/beacons/napalm_beacon.py
+++ b/salt/beacons/napalm_beacon.py
@@ -286,8 +286,8 @@ def validate(config):
     if not isinstance(config, list):
         return False, 'Configuration for napalm beacon must be a list.'
     for mod in config:
-        fun = mod.keys()[0]
-        fun_cfg = mod.values()[0]
+        fun = list(mod.keys())[0]
+        fun_cfg = list(mod.values())[0]
         if not isinstance(fun_cfg, dict):
             return False, 'The match structure for the {} execution function output must be a dictionary'.format(fun)
         if fun not in __salt__:
@@ -306,8 +306,8 @@ def beacon(config):
         if not mod:
             continue
         event = {}
-        fun = mod.keys()[0]
-        fun_cfg = mod.values()[0]
+        fun = list(mod.keys())[0]
+        fun_cfg = list(mod.values())[0]
         args = fun_cfg.pop('_args', [])
         kwargs = fun_cfg.pop('_kwargs', {})
         log.debug('Executing %s with %s and %s', fun, args, kwargs)


### PR DESCRIPTION
### What does this PR do?
Fixes (for me) the napalm_beacon module's `validate` function when running on python 3.

### What issues does this PR fix or reference?
I hit a bug trying to use the napalm_beacon on python 3, due to the dict_keys and dict_values objects not supporting indexing any more.

With just the pillar code copied out of the napalm_beacon example page
```python
[CRITICAL] The beacon errored: 
Traceback (most recent call last):
  File "/opt/miniconda/envs/salt/lib/python3.6/site-packages/salt/minion.py", line 2592, in handle_beacons
    beacons = self.process_beacons(self.functions)
  File "/opt/miniconda/envs/salt/lib/python3.6/site-packages/salt/minion.py", line 449, in process_beacons
    return self.beacons.process(b_conf, self.opts['grains'])  # pylint: disable=no-member
  File "/opt/miniconda/envs/salt/lib/python3.6/site-packages/salt/beacons/__init__.py", line 104, in process
    valid, vcomment = self.beacons[validate_str](b_config[mod])
  File "/opt/miniconda/envs/salt/lib/python3.6/site-packages/salt/beacons/napalm_beacon.py", line 290, in validate
    fun_cfg = mod.values()[0]
TypeError: 'dict_values' object does not support indexing
```

### Tests written?
**[NOTICE] Bug fixes or features added to Salt require tests.**
Please review the [test documentation](https://docs.saltstack.com/en/latest/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite.

No

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
