### PR TITLE
(Backport 52699) btrfs: Add properties state

### DIFF
--- a/salt/states/btrfs.py
+++ b/salt/states/btrfs.py
@@ -181,7 +181,7 @@ def subvolume_created(name, device, qgroupids=None, set_default=False,
     if __opts__['test']:
         ret['result'] = None
         if not exists:
-            ret['comment'].append('Subvolume {} will be created'.format(name))
+            ret['changes'][name] = 'Subvolume {} will be created'.format(name)
         return ret
 
     if not exists:
@@ -245,7 +245,7 @@ def subvolume_deleted(name, device, commit=False, __dest=None):
     if __opts__['test']:
         ret['result'] = None
         if exists:
-            ret['comment'].append('Subvolume {} will be removed'.format(name))
+            ret['changes'][name] = 'Subvolume {} will be removed'.format(name)
         return ret
 
     # If commit is set, we wait until all is over
@@ -357,11 +357,10 @@ def properties(name, device, use_default=False, __dest=None, **properties):
     if __opts__['test']:
         ret['result'] = None
         if properties_to_set:
-            msg = 'Properties {} will be changed in {}'.format(
-                properties_to_set, name)
+            ret['changes'] = properties_to_set
         else:
             msg = 'No properties will be changed in {}'.format(name)
-        ret['comment'].append(msg)
+            ret['comment'].append(msg)
         return ret
 
     if properties_to_set:

--- a/tests/unit/states/test_btrfs.py
+++ b/tests/unit/states/test_btrfs.py
@@ -811,8 +811,8 @@ class BtrfsTestCase(TestCase, LoaderModuleMockMixin):
                                     device='/dev/sda1', ro=True) == {
                 'name': '@/var',
                 'result': None,
-                'changes': {},
-                'comment': ["Properties {'ro': 'true'} will be changed in @/var"],
+                'changes': {'ro': 'true'},
+                'comment': [],
             }
             salt_mock['btrfs.properties'].assert_called_with('/tmp/xxx/@/var')
             mount.assert_called_once()


### PR DESCRIPTION
### What does this PR do?

We can set via `btrfs property` command some properties. This command
is used in the btrfs execution module.

The current state will leverate this code to make sure that some
properties al set or unset in a safe mode.

### Tests written?

Yes

(backport #52699)