### PR TITLE
(Backport 53167) loader: support extra modules in sys.path

### DIFF
--- a/salt/loader.py
+++ b/salt/loader.py
@@ -16,7 +16,6 @@ import inspect
 import tempfile
 import threading
 import functools
-import threading
 import traceback
 import types
 from zipimport import zipimporter

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -291,7 +291,11 @@ import shutil
 import sys
 import time
 import traceback
-from collections import Iterable, Mapping, defaultdict
+try:
+    from collections.abc import Iterable, Mapping
+except ImportError:
+    from collections import Iterable, Mapping
+from collections import defaultdict
 from datetime import datetime, date   # python3 problem in the making?
 
 # Import salt libs

--- a/salt/utils/extmods.py
+++ b/salt/utils/extmods.py
@@ -8,7 +8,6 @@ from __future__ import absolute_import, unicode_literals, print_function
 import logging
 import os
 import shutil
-import sys
 
 # Import salt libs
 import salt.fileclient
@@ -131,12 +130,6 @@ def sync(opts,
                             os.makedirs(dest_dir)
                         shutil.copyfile(fn_, dest)
                         ret.append('{0}.{1}'.format(form, relname))
-
-                    # If the synchronized module is an utils
-                    # directory, we add it to sys.path
-                    for util_dir in opts['utils_dirs']:
-                        if mod_dir.endswith(util_dir) and mod_dir not in sys.path:
-                            sys.path.append(mod_dir)
 
             touched = bool(ret)
             if opts['clean_dynamic_modules'] is True:

--- a/salt/utils/oset.py
+++ b/salt/utils/oset.py
@@ -22,7 +22,10 @@ Rob Speer's changes are as follows:
     - added __getitem__
 '''
 from __future__ import absolute_import, unicode_literals, print_function
-import collections
+try:
+    from collections.abc import MutableSet
+except ImportError:
+    from collections import MutableSet
 
 SLICE_ALL = slice(None)
 __version__ = '2.0.1'
@@ -44,7 +47,7 @@ def is_iterable(obj):
     return hasattr(obj, '__iter__') and not isinstance(obj, str) and not isinstance(obj, tuple)
 
 
-class OrderedSet(collections.MutableSet):
+class OrderedSet(MutableSet):
     """
     An OrderedSet is a custom MutableSet that remembers its order, so that
     every entry has an index that can be looked up.


### PR DESCRIPTION
### What does this PR do?

The LazyLoader class populate the sys.path array to add the path
that contains the Python module that will be executed.  If before
this point sys.path gets extended (like when globally the extmods
utils directory in added in some places, like after a sync) the
code can find all the dependencies.

This patch adds a new parameter to the LazyLoader class,
extra_module_dirs, that will populate locally the sys.path before
executing the the module.

This can be used to guarantee that in utils (and other modules) will be
available to the modules and states in any circumstances and Python
process.

### Tests written?

Yes

(backport #53167)