### PR TITLE
(Backport 53326) core.py: ignore wrong product_name files

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -982,6 +982,10 @@ def _virtual(osdata):
                         grains['virtual'] = 'gce'
                     elif 'BHYVE' in output:
                         grains['virtual'] = 'bhyve'
+            except UnicodeDecodeError:
+                # Some firmwares provide non-valid 'product_name'
+                # files, ignore them
+                pass
             except IOError:
                 pass
     elif osdata['kernel'] == 'FreeBSD':
@@ -2536,6 +2540,10 @@ def _hw_data(osdata):
                         grains[key] = salt.utils.stringutils.to_unicode(ifile.read().strip(), errors='replace')
                         if key == 'uuid':
                             grains['uuid'] = grains['uuid'].lower()
+                except UnicodeDecodeError:
+                    # Some firmwares provide non-valid 'product_name'
+                    # files, ignore them
+                    pass
                 except (IOError, OSError) as err:
                     # PermissionError is new to Python 3, but corresponds to the EACESS and
                     # EPERM error numbers. Use those instead here for PY2 compatibility.

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -985,7 +985,7 @@ def _virtual(osdata):
             except UnicodeDecodeError:
                 # Some firmwares provide non-valid 'product_name'
                 # files, ignore them
-                pass
+                log.debug('The content in /sys/devices/virtual/dmi/id/product_name is not valid')
             except IOError:
                 pass
     elif osdata['kernel'] == 'FreeBSD':
@@ -2543,7 +2543,7 @@ def _hw_data(osdata):
                 except UnicodeDecodeError:
                     # Some firmwares provide non-valid 'product_name'
                     # files, ignore them
-                    pass
+                    log.debug('The content in /sys/devices/virtual/dmi/id/product_name is not valid')
                 except (IOError, OSError) as err:
                     # PermissionError is new to Python 3, but corresponds to the EACESS and
                     # EPERM error numbers. Use those instead here for PY2 compatibility.
@@ -2762,26 +2762,6 @@ def _hw_data(osdata):
     elif osdata['kernel'] == 'AIX':
         cmd = salt.utils.path.which('prtconf')
         if cmd:
-            data = __salt__['cmd.run']('{0}'.format(cmd)) + os.linesep
-            for dest, regstring in (('serialnumber', r'(?im)^\s*Machine\s+Serial\s+Number:\s+(\S+)'),
-                                    ('systemfirmware', r'(?im)^\s*Firmware\s+Version:\s+(.*)')):
-                for regex in [re.compile(r) for r in [regstring]]:
-                    res = regex.search(data)
-                    if res and len(res.groups()) >= 1:
-                        grains[dest] = res.group(1).strip().replace("'", '')
-
-            product_regexes = [re.compile(r'(?im)^\s*System\s+Model:\s+(\S+)')]
-            for regex in product_regexes:
-                res = regex.search(data)
-                if res and len(res.groups()) >= 1:
-                    grains['manufacturer'], grains['productname'] = res.group(1).strip().replace("'", "").split(",")
-                    break
-        else:
-            log.error('The \'prtconf\' binary was not found in $PATH.')
-
-    elif osdata['kernel'] == 'AIX':
-        cmd = salt.utils.path.which('prtconf')
-        if data:
             data = __salt__['cmd.run']('{0}'.format(cmd)) + os.linesep
             for dest, regstring in (('serialnumber', r'(?im)^\s*Machine\s+Serial\s+Number:\s+(\S+)'),
                                     ('systemfirmware', r'(?im)^\s*Firmware\s+Version:\s+(.*)')):

--- a/tests/unit/grains/test_core.py
+++ b/tests/unit/grains/test_core.py
@@ -1335,11 +1335,12 @@ class CoreGrainsTestCase(TestCase, LoaderModuleMockMixin):
             })
 
     @skipIf(not salt.utils.platform.is_linux(), 'System is not Linux')
+    @skipIf(six.PY2, 'UnicodeDecodeError is throw in Python 3')
     @patch('os.path.exists')
     @patch('salt.utils.platform.is_proxy')
     def test__hw_data_linux_unicode_error(self, is_proxy, exists):
         def _fopen(*args):
-            class _File:
+            class _File(object):
                 def __enter__(self):
                     return self
 
@@ -1355,4 +1356,3 @@ class CoreGrainsTestCase(TestCase, LoaderModuleMockMixin):
         exists.return_value = True
         with patch('salt.utils.files.fopen', _fopen):
             self.assertEqual(core._hw_data({'kernel': 'Linux'}), {})
-

--- a/tests/unit/grains/test_core.py
+++ b/tests/unit/grains/test_core.py
@@ -1317,3 +1317,42 @@ class CoreGrainsTestCase(TestCase, LoaderModuleMockMixin):
         for cmdline, expectation in expectations:
             with patch('salt.utils.files.fopen', mock_open(read_data=cmdline)):
                 self.assertEqual(core.kernelparams(), expectation)
+
+    @skipIf(not salt.utils.platform.is_linux(), 'System is not Linux')
+    @patch('os.path.exists')
+    @patch('salt.utils.platform.is_proxy')
+    def test__hw_data_linux_empty(self, is_proxy, exists):
+        is_proxy.return_value = False
+        exists.return_value = True
+        with patch('salt.utils.files.fopen', mock_open(read_data='')):
+            self.assertEqual(core._hw_data({'kernel': 'Linux'}), {
+                'biosreleasedate': '',
+                'biosversion': '',
+                'manufacturer': '',
+                'productname': '',
+                'serialnumber': '',
+                'uuid': ''
+            })
+
+    @skipIf(not salt.utils.platform.is_linux(), 'System is not Linux')
+    @patch('os.path.exists')
+    @patch('salt.utils.platform.is_proxy')
+    def test__hw_data_linux_unicode_error(self, is_proxy, exists):
+        def _fopen(*args):
+            class _File:
+                def __enter__(self):
+                    return self
+
+                def __exit__(self, *args):
+                    pass
+
+                def read(self):
+                    raise UnicodeDecodeError('enconding', b'', 1, 2, 'reason')
+
+            return _File()
+
+        is_proxy.return_value = False
+        exists.return_value = True
+        with patch('salt.utils.files.fopen', _fopen):
+            self.assertEqual(core._hw_data({'kernel': 'Linux'}), {})
+


### PR DESCRIPTION
Some firmwares (like some NUC machines), do not provide valid
/sys/class/dmi/id/product_name strings. In those cases an
UnicodeDecodeError exception happens.

This patch ignore this kind of issue during the grains creation.

(backport #53326)