### PR TITLE
(Backport 53381) systemd_service: add firstboot function

### DIFF
--- a/salt/modules/systemd_service.py
+++ b/salt/modules/systemd_service.py
@@ -1408,3 +1408,65 @@ def execs(root=None):
             continue
         ret[service] = data["ExecStart"]["path"]
     return ret
+
+
+def firstboot(
+    locale=None,
+    locale_message=None,
+    keymap=None,
+    timezone=None,
+    hostname=None,
+    machine_id=None,
+    root=None,
+):
+    """
+    .. versionadded:: TBD
+
+    Call systemd-firstboot to configure basic settings of the system
+
+    locale
+        Set primary locale (LANG=)
+
+    locale_message
+        Set message locale (LC_MESSAGES=)
+
+    keymap
+        Set keymap
+
+    timezone
+        Set timezone
+
+    hostname
+        Set host name
+
+    machine_id
+        Set machine ID
+
+    root
+        Operate on an alternative filesystem root
+
+    CLI Example:
+
+        salt '*' service.firstboot keymap=jp locale=en_US.UTF-8
+
+    """
+    cmd = ["systemd-firstboot"]
+    parameters = [
+        ("locale", locale),
+        ("locale-message", locale_message),
+        ("keymap", keymap),
+        ("timezone", timezone),
+        ("hostname", hostname),
+        ("machine-ID", machine_id),
+        ("root", root),
+    ]
+    for parameter, value in parameters:
+        if value:
+            cmd.extend(["--{}".format(parameter), str(value)])
+
+    out = __salt__["cmd.run_all"](cmd)
+
+    if out["retcode"] != 0:
+        raise CommandExecutionError("systemd-firstboot error: {}".format(out["stderr"]))
+
+    return True

--- a/tests/unit/modules/test_systemd_service.py
+++ b/tests/unit/modules/test_systemd_service.py
@@ -8,6 +8,8 @@ from __future__ import absolute_import, print_function, unicode_literals
 
 import os
 
+import pytest
+
 # Import Salt Libs
 import salt.modules.systemd_service as systemd
 import salt.utils.systemd
@@ -664,3 +666,65 @@ class SystemdScopeTestCase(TestCase, LoaderModuleMockMixin):
 
     def test_unmask_runtime(self):
         self._mask_unmask("unmask_", True)
+
+    def test_firstboot(self):
+        """
+        Test service.firstboot without parameters
+        """
+        result = {"retcode": 0, "stdout": "stdout"}
+        salt_mock = {
+            "cmd.run_all": MagicMock(return_value=result),
+        }
+        with patch.dict(systemd.__salt__, salt_mock):
+            assert systemd.firstboot()
+            salt_mock["cmd.run_all"].assert_called_with(["systemd-firstboot"])
+
+    def test_firstboot_params(self):
+        """
+        Test service.firstboot with parameters
+        """
+        result = {"retcode": 0, "stdout": "stdout"}
+        salt_mock = {
+            "cmd.run_all": MagicMock(return_value=result),
+        }
+        with patch.dict(systemd.__salt__, salt_mock):
+            assert systemd.firstboot(
+                locale="en_US.UTF-8",
+                locale_message="en_US.UTF-8",
+                keymap="jp",
+                timezone="Europe/Berlin",
+                hostname="node-001",
+                machine_id="1234567890abcdef",
+                root="/mnt",
+            )
+            salt_mock["cmd.run_all"].assert_called_with(
+                [
+                    "systemd-firstboot",
+                    "--locale",
+                    "en_US.UTF-8",
+                    "--locale-message",
+                    "en_US.UTF-8",
+                    "--keymap",
+                    "jp",
+                    "--timezone",
+                    "Europe/Berlin",
+                    "--hostname",
+                    "node-001",
+                    "--machine-ID",
+                    "1234567890abcdef",
+                    "--root",
+                    "/mnt",
+                ]
+            )
+
+    def test_firstboot_error(self):
+        """
+        Test service.firstboot error
+        """
+        result = {"retcode": 1, "stderr": "error"}
+        salt_mock = {
+            "cmd.run_all": MagicMock(return_value=result),
+        }
+        with patch.dict(systemd.__salt__, salt_mock):
+            with pytest.raises(CommandExecutionError):
+                assert systemd.firstboot()


### PR DESCRIPTION
### What does this PR do?

systemd-firstboot is a command line tool from systend that will
set some basic configuration options, like the locale, keyboard
configuration, or the machine-id of the system.

### Tests written?

Yes

(backport #53381, already merged in develop)