### PR TITLE
[neon] Merge forward from 2019.2 to neon

### DIFF
--- a/.ci/kitchen-centos7-py2
+++ b/.ci/kitchen-centos7-py2
@@ -23,6 +23,7 @@ timeout(time: 8, unit: 'HOURS') {
                                 context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
                         }
                         stage('setup-bundle') {
+                            sh 'git fetch --no-tags https://github.com/saltstack/salt.git +refs/heads/${CHANGE_TARGET}:refs/remotes/origin/${CHANGE_TARGET}'
                             sh 'bundle install --with ec2 windows --without opennebula docker'
                         }
                         try {

--- a/.ci/kitchen-centos7-py3
+++ b/.ci/kitchen-centos7-py3
@@ -23,6 +23,7 @@ timeout(time: 6, unit: 'HOURS') {
                                 context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
                         }
                         stage('setup-bundle') {
+                            sh 'git fetch --no-tags https://github.com/saltstack/salt.git +refs/heads/${CHANGE_TARGET}:refs/remotes/origin/${CHANGE_TARGET}'
                             sh 'bundle install --with ec2 windows --without opennebula docker'
                         }
                         try {

--- a/.ci/kitchen-ubuntu1604-py2
+++ b/.ci/kitchen-ubuntu1604-py2
@@ -23,6 +23,7 @@ timeout(time: 6, unit: 'HOURS') {
                                 context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
                         }
                         stage('setup-bundle') {
+                            sh 'git fetch --no-tags https://github.com/saltstack/salt.git +refs/heads/${CHANGE_TARGET}:refs/remotes/origin/${CHANGE_TARGET}'
                             sh 'bundle install --with ec2 windows --without opennebula docker'
                         }
                         try {

--- a/.ci/kitchen-ubuntu1604-py3
+++ b/.ci/kitchen-ubuntu1604-py3
@@ -23,6 +23,7 @@ timeout(time: 6, unit: 'HOURS') {
                                 context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
                         }
                         stage('setup-bundle') {
+                            sh 'git fetch --no-tags https://github.com/saltstack/salt.git +refs/heads/${CHANGE_TARGET}:refs/remotes/origin/${CHANGE_TARGET}'
                             sh 'bundle install --with ec2 windows --without opennebula docker'
                         }
                         try {

--- a/.ci/kitchen-windows2016-py2
+++ b/.ci/kitchen-windows2016-py2
@@ -23,6 +23,7 @@ timeout(time: 6, unit: 'HOURS') {
                                 context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
                         }
                         stage('setup-bundle') {
+                            sh 'git fetch --no-tags https://github.com/saltstack/salt.git +refs/heads/${CHANGE_TARGET}:refs/remotes/origin/${CHANGE_TARGET}'
                             sh 'bundle install --with ec2 windows --without opennebula docker'
                         }
                         try {

--- a/.ci/kitchen-windows2016-py3
+++ b/.ci/kitchen-windows2016-py3
@@ -23,6 +23,7 @@ timeout(time: 6, unit: 'HOURS') {
                                 context: "jenkins/pr/${TEST_SUITE}-${TEST_PLATFORM}"
                         }
                         stage('setup-bundle') {
+                            sh 'git fetch --no-tags https://github.com/saltstack/salt.git +refs/heads/${CHANGE_TARGET}:refs/remotes/origin/${CHANGE_TARGET}'
                             sh 'bundle install --with ec2 windows --without opennebula docker'
                         }
                         try {

--- a/tests/integration/cloud/clouds/test_vmware.py
+++ b/tests/integration/cloud/clouds/test_vmware.py
@@ -88,7 +88,11 @@ class VMWareTest(ShellCase):
         profile_config = cloud_config(profile)
         disk_datastore = profile_config['vmware-test']['devices']['disk']['Hard disk 2']['datastore']
 
+        for key, value in six.iteritems(profile_config.get('vmware-test', {})):
+            assert value, "Instance config incomplete; missing '{}'".format(key)
+
         instance = self.run_cloud('-p vmware-test {0}'.format(INSTANCE_NAME), timeout=TIMEOUT)
+        assert instance, "Instance not found, are the '{}' provider credentials active?".format(PROVIDER_NAME)
         ret_str = '{0}:'.format(INSTANCE_NAME)
         disk_datastore_str = '                [{0}] {1}/Hard disk 2-flat.vmdk'.format(disk_datastore, INSTANCE_NAME)
 
@@ -115,6 +119,7 @@ class VMWareTest(ShellCase):
         # create the instance
         instance = self.run_cloud('-p vmware-test {0} --no-deploy'.format(INSTANCE_NAME),
                                   timeout=TIMEOUT)
+        assert instance, "Instance not found, are the '{}' provider credentials active?".format(PROVIDER_NAME)
         ret_str = '{0}:'.format(INSTANCE_NAME)
 
         # check if instance returned with salt installed

--- a/tests/support/helpers.py
+++ b/tests/support/helpers.py
@@ -206,10 +206,23 @@ def flaky(caller=None, condition=True, attempts=4):
     def wrap(cls):
         for attempt in range(0, attempts):
             try:
+                if attempt > 0:
+                    # Run through setUp again
+                    # We only run it after the first iteration(>0) because the regular
+                    # test runner will have already ran setUp the first time
+                    setup = getattr(cls, 'setUp', None)
+                    if callable(setup):
+                        setup()
                 return caller(cls)
             except Exception as exc:
                 if attempt >= attempts -1:
+                    # We won't try to run tearDown once the attempts are exhausted
+                    # because the regular test runner will do that for us
                     raise exc
+                # Run through tearDown again
+                teardown = getattr(cls, 'tearDown', None)
+                if callable(teardown):
+                    teardown()
                 backoff_time = attempt ** 2
                 log.info(
                     'Found Exception. Waiting %s seconds to retry.',


### PR DESCRIPTION
Conflicts:
  - .ci/kitchen-centos7-py2
  - .ci/kitchen-centos7-py3
  - .ci/kitchen-ubuntu1604-py2
  - .ci/kitchen-ubuntu1604-py3
  - .ci/kitchen-windows2016-py2
  - .ci/kitchen-windows2016-py3
  - tests/support/helpers.py