### PR TITLE
Backport #53323 into 2018.3

### DIFF
--- a/tests/integration/states/test_pkg.py
+++ b/tests/integration/states/test_pkg.py
@@ -490,7 +490,7 @@ class PkgTest(ModuleCase, SaltReturnAssertsMixin):
             self.skipTest('Package manager is not available')
 
         test_name = 'bash-completion'
-        if (grains.get('os') == 'Amazon' and grains.get('osmajorrelease') != 2):
+        if grains.get('os') == 'Amazon' and grains.get('osmajorrelease') != 2:
             test_name = 'bash-doc'
 
         ret = self.run_state('pkg.installed',
@@ -513,7 +513,7 @@ class PkgTest(ModuleCase, SaltReturnAssertsMixin):
             self.skipTest('Package manager is not available')
 
         package = 'bash-completion'
-        if (grains.get('os') == 'Amazon' and grains.get('osmajorrelease') != 2):
+        if grains.get('os') == 'Amazon' and grains.get('osmajorrelease') != 2:
             package = 'bash-doc'
 
         pkgquery = 'version'

--- a/tests/integration/states/test_pkg.py
+++ b/tests/integration/states/test_pkg.py
@@ -477,7 +477,8 @@ class PkgTest(ModuleCase, SaltReturnAssertsMixin):
         self.assertSaltTrueReturn(ret)
 
     @skipIf(salt.utils.platform.is_windows(), 'minion is windows')
-    def test_pkg_009_latest_with_epoch(self):
+    @requires_system_grains
+    def test_pkg_009_latest_with_epoch(self, grains=None):
         '''
         This tests for the following issue:
         https://github.com/saltstack/salt/issues/31014
@@ -488,13 +489,17 @@ class PkgTest(ModuleCase, SaltReturnAssertsMixin):
         if not pkgmgr_avail(self.run_function, self.run_function('grains.items')):
             self.skipTest('Package manager is not available')
 
+        if (grains.get('os') == 'Amazon' and grains.get('osmajorrelease') != 2):
+            self.skipTest('minion is Amazon Linux 1, bash-completion not available')
+
         ret = self.run_state('pkg.installed',
                              name='bash-completion',
                              refresh=False)
         self.assertSaltTrueReturn(ret)
 
     @requires_salt_modules('pkg.info_installed')
-    def test_pkg_010_latest_with_epoch_and_info_installed(self):
+    @requires_system_grains
+    def test_pkg_010_latest_with_epoch_and_info_installed(self, grains=None):
         '''
         Need to check to ensure the package has been
         installed after the pkg_latest_epoch sls
@@ -505,6 +510,9 @@ class PkgTest(ModuleCase, SaltReturnAssertsMixin):
         # Skip test if package manager not available
         if not pkgmgr_avail(self.run_function, self.run_function('grains.items')):
             self.skipTest('Package manager is not available')
+
+        if (grains.get('os') == 'Amazon' and grains.get('osmajorrelease') != 2):
+            self.skipTest('minion is Amazon Linux 1, bash-completion not available')
 
         package = 'bash-completion'
         pkgquery = 'version'

--- a/tests/integration/states/test_pkg.py
+++ b/tests/integration/states/test_pkg.py
@@ -489,11 +489,12 @@ class PkgTest(ModuleCase, SaltReturnAssertsMixin):
         if not pkgmgr_avail(self.run_function, self.run_function('grains.items')):
             self.skipTest('Package manager is not available')
 
+        test_name = 'bash-completion'
         if (grains.get('os') == 'Amazon' and grains.get('osmajorrelease') != 2):
-            self.skipTest('minion is Amazon Linux 1, bash-completion not available')
+            test_name = 'bash-doc'
 
         ret = self.run_state('pkg.installed',
-                             name='bash-completion',
+                             name=test_name,
                              refresh=False)
         self.assertSaltTrueReturn(ret)
 
@@ -511,10 +512,10 @@ class PkgTest(ModuleCase, SaltReturnAssertsMixin):
         if not pkgmgr_avail(self.run_function, self.run_function('grains.items')):
             self.skipTest('Package manager is not available')
 
-        if (grains.get('os') == 'Amazon' and grains.get('osmajorrelease') != 2):
-            self.skipTest('minion is Amazon Linux 1, bash-completion not available')
-
         package = 'bash-completion'
+        if (grains.get('os') == 'Amazon' and grains.get('osmajorrelease') != 2):
+            package = 'bash-doc'
+
         pkgquery = 'version'
 
         ret = self.run_function('pkg.info_installed', [package])


### PR DESCRIPTION
Backport #53323 into 2018.3