### PR TITLE
Backport #53298 into 2018.3

### DIFF
--- a/salt/states/host.py
+++ b/salt/states/host.py
@@ -78,9 +78,9 @@ def present(name, ip, clean=False):  # pylint: disable=C0103
         The ip addr(s) to apply to the host. Can be a single IP or a list of IP
         addresses.
 
-    clean : False
+    clean
         Remove any entries which don't match those configured in the ``ip``
-        option.
+        option. Default is ``False``.
 
         .. versionadded:: 2018.3.4
     '''


### PR DESCRIPTION
Backport #53298 into 2018.3