### PR TITLE
Minor logging fix for cmdmod._run

### DIFF
--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -608,22 +608,14 @@ def _run(cmd,
         except (OSError, IOError) as exc:
             msg = (
                 'Unable to run command \'{0}\' with the context \'{1}\', '
-                'reason: '.format(
-                    cmd if output_loglevel is not None
-                        else 'REDACTED',
-                    kwargs
+                'reason: {2}'.format(
+                    cmd if output_loglevel is not None else 'REDACTED',
+                    kwargs,
+                    exc
                 )
             )
-            try:
-                if exc.filename is None:
-                    msg += 'command not found'
-                else:
-                    msg += '{0}: {1}'.format(exc, exc.filename)
-            except AttributeError:
-                # Both IOError and OSError have the filename attribute, so this
-                # is a precaution in case the exception classes in the previous
-                # try/except are changed.
-                msg += 'unknown'
+            if getattr(exc, 'filename', None):
+                msg += ': {0}'.format(exc.filename)
             raise CommandExecutionError(msg)
 
         try:


### PR DESCRIPTION
### What does this PR do?
This was detected when tests failed because of memory allocation errors.
In this case cmdmod reports "command not found" as an error reason when the original OSError says "cannot allocate memory".

### What issues does this PR fix or reference?
Related to #53281

### Previous Behavior
Error message on memory allocation failure looks like this:
```
Unable to run command '[u'grep', u'-lr', u'salt.utils.versions.warn_until', u'-A', u'1', u'/tmp/kitchen/testing/salt/']' with the context <CUT>, reason: command not found
```

### New Behavior
Error message on memory allocation failure looks like this:
```
Unable to run command '[u'grep', u'-lr', u'salt.utils.versions.warn_until', u'-A', u'1', u'/tmp/kitchen/testing/salt/']' with the context <CUT>, reason: [Errno 12] Cannot allocate memory
```

### Tests written?
Minor logging fix, tested manually.

### Commits signed with GPG?
Yes