### PR TITLE
Supports all valid protos for remote sources

### DIFF
--- a/salt/modules/config.py
+++ b/salt/modules/config.py
@@ -7,7 +7,6 @@ Return config information
 from __future__ import absolute_import, print_function, unicode_literals
 import copy
 import fnmatch
-import re
 import os
 import logging
 
@@ -129,10 +128,10 @@ def valid_fileproto(uri):
 
         salt '*' config.valid_fileproto salt://path/to/file
     '''
-    try:
-        return bool(re.match('^(?:salt|https?|ftp)://', uri))
-    except Exception:
-        return False
+    return (
+        six.moves.urllib.parse.urlparse(uri).scheme in
+        salt.utils.files.VALID_PROTOS
+    )
 
 
 def option(

--- a/salt/modules/cp.py
+++ b/salt/modules/cp.py
@@ -492,7 +492,7 @@ def cache_file(path, saltenv='base', source_hash=None):
 
     contextkey = '{0}_|-{1}_|-{2}'.format('cp.cache_file', path, saltenv)
 
-    path_is_remote = _urlparse(path).scheme in ('http', 'https', 'ftp')
+    path_is_remote = _urlparse(path).scheme in salt.utils.files.REMOTE_PROTOS
     try:
         if path_is_remote and contextkey in __context__:
             # Prevent multiple caches in the same salt run. Affects remote URLs

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -1522,7 +1522,7 @@ def install(name=None, refresh=False, pkgs=None, **kwargs):
             continue
 
         # Is the installer in a location that requires caching
-        if installer.startswith(('salt:', 'http:', 'https:', 'ftp:')):
+        if __salt__['config.valid_fileproto'](installer):
 
             # Check for the 'cache_dir' parameter in the .sls file
             # If true, the entire directory will be cached instead of the

--- a/tests/integration/modules/test_config.py
+++ b/tests/integration/modules/test_config.py
@@ -21,11 +21,17 @@ class ConfigTest(ModuleCase):
         self.assertTrue(
             self.run_function('config.valid_fileproto', ['salt://']))
         self.assertTrue(
+            self.run_function('config.valid_fileproto', ['file://']))
+        self.assertTrue(
             self.run_function('config.valid_fileproto', ['http://']))
         self.assertTrue(
             self.run_function('config.valid_fileproto', ['https://']))
         self.assertTrue(
             self.run_function('config.valid_fileproto', ['ftp://']))
+        self.assertTrue(
+            self.run_function('config.valid_fileproto', ['s3://']))
+        self.assertTrue(
+            self.run_function('config.valid_fileproto', ['swift://']))
         self.assertFalse(
             self.run_function('config.valid_fileproto', ['cheese://']))
 

--- a/tests/unit/modules/test_win_pkg.py
+++ b/tests/unit/modules/test_win_pkg.py
@@ -12,6 +12,7 @@ from tests.support.mock import MagicMock, patch
 from tests.support.unit import TestCase, skipIf
 
 # Import Salt Libs
+import salt.modules.config as config
 import salt.modules.pkg_resource as pkg_resource
 import salt.modules.win_pkg as win_pkg
 import salt.utils.data
@@ -54,6 +55,7 @@ class WinPkgInstallTestCase(TestCase, LoaderModuleMockMixin):
                     'pkg_resource.parse_targets': pkg_resource.parse_targets,
                     'pkg_resource.sort_pkglist': pkg_resource.sort_pkglist,
                     'pkg_resource.stringify': pkg_resource.stringify,
+                    'config.valid_fileproto': config.valid_fileproto,
                 },
             },
             pkg_resource: {


### PR DESCRIPTION
### What does this PR do?

Supports all valid protos for remote file sources

### What issues does this PR fix or reference?

Fixes #13971

### Previous Behavior
Previously, could not use an `s3://` uri in `pkg.installed` in `sources` nor as the `installer` for winrepo.

### New Behavior
Now all valid remote file sources work, including `s3://`.

### Tests written?

Maybe?

### Commits signed with GPG?

Yes
