### PR TITLE
[2018.3] Workaround nox's install only flag

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -55,15 +55,22 @@ def _get_session_python_version_info(session):
     try:
         version_info = session._runner._real_python_version_info
     except AttributeError:
-        session_py_version = session.run(
-            'python', '-c'
-            'import sys; sys.stdout.write("{}.{}.{}".format(*sys.version_info))',
-            silent=True,
-            log=False,
-            bypass_install_only=True
-        )
-        version_info = tuple(int(part) for part in session_py_version.split('.') if part.isdigit())
-        session._runner._real_python_version_info = version_info
+        old_install_only_value = session._runner.global_config.install_only
+        try:
+            # Force install only to be false for the following chunk of code
+            # For additional information as to why see:
+            #   https://github.com/theacodes/nox/pull/181
+            session._runner.global_config.install_only = False
+            session_py_version = session.run(
+                'python', '-c'
+                'import sys; sys.stdout.write("{}.{}.{}".format(*sys.version_info))',
+                silent=True,
+                log=False,
+            )
+            version_info = tuple(int(part) for part in session_py_version.split('.') if part.isdigit())
+            session._runner._real_python_version_info = version_info
+        finally:
+            session._runner.global_config.install_only = old_install_only_value
     return version_info
 
 
@@ -71,14 +78,21 @@ def _get_session_python_site_packages_dir(session):
     try:
         site_packages_dir = session._runner._site_packages_dir
     except AttributeError:
-        site_packages_dir = session.run(
-            'python', '-c'
-            'import sys; from distutils.sysconfig import get_python_lib; sys.stdout.write(get_python_lib())',
-            silent=True,
-            log=False,
-            bypass_install_only=True
-        )
-        session._runner._site_packages_dir = site_packages_dir
+        old_install_only_value = session._runner.global_config.install_only
+        try:
+            # Force install only to be false for the following chunk of code
+            # For additional information as to why see:
+            #   https://github.com/theacodes/nox/pull/181
+            session._runner.global_config.install_only = False
+            site_packages_dir = session.run(
+                'python', '-c'
+                'import sys; from distutils.sysconfig import get_python_lib; sys.stdout.write(get_python_lib())',
+                silent=True,
+                log=False,
+            )
+            session._runner._site_packages_dir = site_packages_dir
+        finally:
+            session._runner.global_config.install_only = old_install_only_value
     return site_packages_dir
 
 
@@ -94,11 +108,19 @@ def _get_distro_info(session):
         distro = session._runner._distro
     except AttributeError:
         # The distro package doesn't output anything for Windows
-        session.install('--progress-bar=off', 'distro', silent=PIP_INSTALL_SILENT)
-        output = session.run('distro', '-j', silent=True, bypass_install_only=True)
-        distro = json.loads(output.strip())
-        session.log('Distro information:\n%s', pprint.pformat(distro))
-        session._runner._distro = distro
+        old_install_only_value = session._runner.global_config.install_only
+        try:
+            # Force install only to be false for the following chunk of code
+            # For additional information as to why see:
+            #   https://github.com/theacodes/nox/pull/181
+            session._runner.global_config.install_only = False
+            session.install('--progress-bar=off', 'distro', silent=PIP_INSTALL_SILENT)
+            output = session.run('distro', '-j', silent=True)
+            distro = json.loads(output.strip())
+            session.log('Distro information:\n%s', pprint.pformat(distro))
+            session._runner._distro = distro
+        finally:
+            session._runner.global_config.install_only = old_install_only_value
     return distro
 
 

--- a/salt/utils/http.py
+++ b/salt/utils/http.py
@@ -464,7 +464,7 @@ def query(url,
                     not isinstance(result_text, six.text_type):
                 result_text = result_text.decode(res_params['charset'])
         if six.PY3 and isinstance(result_text, bytes):
-            result_text = result.body.decode('utf-8')
+            result_text = result_text.decode('utf-8')
         ret['body'] = result_text
     else:
         # Tornado


### PR DESCRIPTION
### What does this PR do?
To get some information from the system, which we then use to choose the appropriate static requirements file, we need to run some commands, something that nox will refuse to do if `--install-only` is passed.

We work around it by manually patching the value of`session._runner.global_config.install_only` for the commands that we MUST run, and only those and then we set it back to the value it had before.

For additional information about why we have to do this, please see:
   https://github.com/theacodes/nox/pull/181