### PR TITLE
Update test_gen_hash for macosx

### DIFF
--- a/tests/unit/utils/test_pycrypto.py
+++ b/tests/unit/utils/test_pycrypto.py
@@ -26,14 +26,17 @@ class PycryptoTestCase(TestCase):
         Test gen_hash
         '''
         passwd = 'test_password'
+        id = '$'
+        if salt.utils.platform.is_darwin():
+            id = ''
         ret = salt.utils.pycrypto.gen_hash(password=passwd)
-        self.assertTrue(ret.startswith('$6$'))
+        self.assertTrue(ret.startswith('$6{0}'.format(id)))
 
         ret = salt.utils.pycrypto.gen_hash(password=passwd, algorithm='md5')
-        self.assertTrue(ret.startswith('$1$'))
+        self.assertTrue(ret.startswith('$1{0}'.format(id)))
 
         ret = salt.utils.pycrypto.gen_hash(password=passwd, algorithm='sha256')
-        self.assertTrue(ret.startswith('$5$'))
+        self.assertTrue(ret.startswith('$5{0}'.format(id)))
 
     def test_secure_password(self):
         '''


### PR DESCRIPTION
### What does this PR do?
This test `unit.utils.test_pycrypto.PycryptoTestCase.test_gen_hash` is failing on macosx with this failure:

```
       Traceback (most recent call last):
         File "/private/tmp/kitchen/testing/tests/unit/utils/test_pycrypto.py", line 30, in test_gen_hash
           self.assertTrue(ret.startswith('$6$'))
       AssertionError: False is not true
```

This is because crypt on macosx doesn't support the `$id$` format. A great explanation is shared here: https://bugs.python.org/issue22432

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/53488

### Previous Behavior
`unit.utils.test_pycrypto.PycryptoTestCase.test_gen_hash` test fails on macosx

### New Behavior
`unit.utils.test_pycrypto.PycryptoTestCase.test_gen_hash` passes on macosx

### Tests written?
fixes test


### Commits signed with GPG?

Yes