### PR TITLE
 Fix syndic connection when using tcp transport

### DIFF
--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -757,13 +757,6 @@ class TestDaemon(object):
         }
         master_opts['ext_pillar'].append({'file_tree': file_tree})
 
-        # This is the syndic for master
-        # Let's start with a copy of the syndic master configuration
-        syndic_opts = copy.deepcopy(master_opts)
-        # Let's update with the syndic configuration
-        syndic_opts.update(salt.config._read_conf_file(os.path.join(RUNTIME_VARS.CONF_DIR, 'syndic')))
-        syndic_opts['cachedir'] = os.path.join(TMP, 'rootdir', 'cache')
-        syndic_opts['config_dir'] = RUNTIME_VARS.TMP_SYNDIC_MINION_CONF_DIR
 
         # Under windows we can't seem to properly create a virtualenv off of another
         # virtualenv, we can on linux but we will still point to the virtualenv binary
@@ -853,6 +846,14 @@ class TestDaemon(object):
             sub_minion_opts['transport'] = 'tcp'
             syndic_master_opts['transport'] = 'tcp'
             proxy_opts['transport'] = 'tcp'
+
+        # This is the syndic for master
+        # Let's start with a copy of the syndic master configuration
+        syndic_opts = copy.deepcopy(master_opts)
+        # Let's update with the syndic configuration
+        syndic_opts.update(salt.config._read_conf_file(os.path.join(RUNTIME_VARS.CONF_DIR, 'syndic')))
+        syndic_opts['cachedir'] = os.path.join(TMP, 'rootdir', 'cache')
+        syndic_opts['config_dir'] = RUNTIME_VARS.TMP_SYNDIC_MINION_CONF_DIR
 
         # Set up config options that require internal data
         master_opts['pillar_roots'] = syndic_master_opts['pillar_roots'] = {

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -757,7 +757,6 @@ class TestDaemon(object):
         }
         master_opts['ext_pillar'].append({'file_tree': file_tree})
 
-
         # Under windows we can't seem to properly create a virtualenv off of another
         # virtualenv, we can on linux but we will still point to the virtualenv binary
         # outside the virtualenv running the test suite, if that's the case.

--- a/tests/integration/files/log_handlers/runtests_log_handler.py
+++ b/tests/integration/files/log_handlers/runtests_log_handler.py
@@ -23,7 +23,6 @@ from multiprocessing import Queue
 import msgpack
 
 # Import Salt libs
-from salt.ext import six
 from salt.utils.platform import is_darwin
 import salt.log.setup
 

--- a/tests/integration/files/log_handlers/runtests_log_handler.py
+++ b/tests/integration/files/log_handlers/runtests_log_handler.py
@@ -35,8 +35,6 @@ __virtualname__ = 'runtests_log_handler'
 def __virtual__():
     if 'runtests_log_port' not in __opts__:
         return False, "'runtests_log_port' not in options"
-    if six.PY3:
-        return False, "runtests external logging handler is temporarily disabled for Python 3 tests"
     return True
 
 


### PR DESCRIPTION
### What does this PR do?

Create the syndic config after we set the desired transport

### Previous Behavior

Syndic was not connecting on tcp transport test runs

### New Behavior

Syndic will successfully connect on tcp transport test runs

### Tests written?

No - Fixes issue in existing test suite. 

NOTE: We have enough code in support of our test suite that we should probably write unit tests for things like this. However we should probably move this stuff to pytest-salt and test it there.

### Commits signed with GPG?

Yes