### PR TITLE
Always delete digital ocean key for test_key_management test

### DIFF
--- a/tests/integration/cloud/clouds/test_digitalocean.py
+++ b/tests/integration/cloud/clouds/test_digitalocean.py
@@ -130,9 +130,9 @@ class DigitalOceanTest(ShellCase):
             # Delete the public key if the above assertions fail
             self.run_cloud('-f remove_key {0} id={1}'.format(PROVIDER_NAME, finger_print))
             raise
-
-        # Delete public key
-        self.assertTrue(self.run_cloud('-f remove_key {0} id={1}'.format(PROVIDER_NAME, finger_print)))
+        finally:
+            # Delete public key
+            self.assertTrue(self.run_cloud('-f remove_key {0} id={1}'.format(PROVIDER_NAME, finger_print)))
 
     def test_instance(self):
         '''


### PR DESCRIPTION
### What does this PR do?
The test `integration.cloud.clouds.test_digitalocean.DigitalOceanTest.test_key_management` is not always cleaning up the key, so on the next test run it fails.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/53010

### Tests written?
fixes test

### Commits signed with GPG?

Yes