### PR TITLE
fixes inconsistent return between local and local_async client

### DIFF
--- a/salt/netapi/rest_tornado/saltnado.py
+++ b/salt/netapi/rest_tornado/saltnado.py
@@ -1114,7 +1114,10 @@ class SaltAPIHandler(BaseSaltAPIHandler):  # pylint: disable=W0223
         # fire a job off
         pub_data = yield self.saltclients['local_async'](*f_call.get('args', ()), **f_call.get('kwargs', {}))
 
-        raise tornado.gen.Return(pub_data)
+        if 'jid' not in pub_data:
+            raise tornado.gen.Return('No minions matched the target. No command was sent, no jid was assigned.')
+        else:
+            raise tornado.gen.Return(pub_data)
 
     @tornado.gen.coroutine
     def _disbatch_runner(self, chunk):


### PR DESCRIPTION
### What does this PR do?
fixes inconsistent return between `local` and `local_async` client in salt-api when the empty data returned after published

salt-api have two client for running job `local` and `local_async`. Actually they call same function `local_client.run_job_async`. but handling return data from `self.saltclient['local']` and `self.saltclient['local_async']` is different when `pub_data` is empty.

`local` client return `No minions matched the target. No command was sent, no jid was assigned.` message. `local_async` client return empty. 

so i added code for the same return at `local_async` for consistency of salt-api return

### Previous Behavior
if `jid` not exist in pub_data, return empty data when using `local_async` client

### New Behavior
if `jid` not exist in pub_data, return `No minions matched the target. No command was sent, no jid was assigned.` message when using `local_async` client (same as `local` client)

### Tests written?
No

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
