### PR TITLE
`import ... as _` to raise exception

### DIFF
--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -1008,7 +1008,7 @@ def win_interfaces():
     '''
     if WIN_NETWORK_LOADED is False:
         # Let's throw the ImportException again
-        import salt.utils.win_network
+        import salt.utils.win_network as _
     return salt.utils.win_network.get_interface_info()
 
 


### PR DESCRIPTION
### What does this PR do?

What it says on the tin. Otherwise, it rebinds salt, which is the wrong exception here! (actually the underlying exception is probably a missing winnet module or wherever `clr` actually is)