### PR TITLE
Support Heimdal Kerberos

### DIFF
--- a/salt/modules/kerberos.py
+++ b/salt/modules/kerberos.py
@@ -58,7 +58,7 @@ def __execute_kadmin(cmd):
         krb_flavor = __opts__.get('krb_flavor', None)
         if krb_flavor == "heimdal":
             return __salt__['cmd.run_all'](
-                'kadmin -K {0} -p {1} "{2}"'.format(
+                'kadmin -K {0} -p {1} {2}'.format(
                     auth_keytab, auth_principal, cmd
                 )
             )
@@ -90,7 +90,7 @@ def list_principals():
     ret = {}
     krb_flavor = __opts__.get('krb_flavor', None)
     if krb_flavor == "heimdal":
-        krb_cmd = 'get -t *'
+        krb_cmd = 'get -t "*"'
     else:
         krb_cmd = 'list_principals'
 
@@ -224,10 +224,14 @@ def get_privs():
 
         return ret
 
-    for i in cmd['stdout'].splitlines()[1:]:
-        (prop, val) = i.split(':', 1)
+    if krb_flavor == "heimdal":
+        ret["privileges"] = [i.strip() for i in cmd['stdout'].split(',')]
 
-        ret[prop] = [j for j in val.split()]
+    else:
+        for i in cmd['stdout'].splitlines()[1:]:
+            (prop, val) = i.split(':', 1)
+
+            ret[prop] = [j for j in val.split()]
 
     return ret
 

--- a/salt/modules/kerberos.py
+++ b/salt/modules/kerberos.py
@@ -14,7 +14,7 @@ Manage Kerberos KDC
 For Heimdal Kerberos:
 .. code-block:: bash
 
-    # ext_keytab -k /root/secure.keytab kadmin/admin 
+    # ext_keytab -k /root/secure.keytab kadmin/admin
 
 On the KDC minion you will need to add the following to the minion
 configuration file so Salt knows what keytab to use and what principal to


### PR DESCRIPTION
### What does this PR do?
This pull request adds support for Heimdal Kerberos implementation

### What issues does this PR fix or reference?
N/A

### Previous Behavior
Only MIT Kerberos would previously work

### New Behavior
It is now possible to configure saltstack to use Heimdal Kerberos in place of MIT
 
### Tests written?
No, there are no tests for kerberos as it is, and I didn't add any

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
