### PR TITLE
add some exception guarding in salt.utils.job

### DIFF
--- a/salt/utils/job.py
+++ b/salt/utils/job.py
@@ -44,6 +44,11 @@ def store_job(opts, load, event=None, mminion=None):
             emsg = "Returner '{0}' does not support function prep_jid".format(job_cache)
             log.error(emsg)
             raise KeyError(emsg)
+        except Exception:
+            log.critical(
+                "The specified '{0}' returner threw a stack trace:\n".format(job_cache),
+                exc_info=True
+            )
 
         # save the load, since we don't have it
         saveload_fstr = '{0}.save_load'.format(job_cache)
@@ -53,6 +58,11 @@ def store_job(opts, load, event=None, mminion=None):
             emsg = "Returner '{0}' does not support function save_load".format(job_cache)
             log.error(emsg)
             raise KeyError(emsg)
+        except Exception:
+            log.critical(
+                "The specified '{0}' returner threw a stack trace:\n".format(job_cache),
+                exc_info=True
+            )
     elif salt.utils.jid.is_jid(load['jid']):
         # Store the jid
         jidstore_fstr = '{0}.prep_jid'.format(job_cache)
@@ -62,6 +72,11 @@ def store_job(opts, load, event=None, mminion=None):
             emsg = "Returner '{0}' does not support function prep_jid".format(job_cache)
             log.error(emsg)
             raise KeyError(emsg)
+        except Exception:
+            log.critical(
+                "The specified '{0}' returner threw a stack trace:\n".format(job_cache),
+                exc_info=True
+            )
 
     if event:
         # If the return data is invalid, just ignore it
@@ -108,8 +123,19 @@ def store_job(opts, load, event=None, mminion=None):
             mminion.returners[savefstr](load['jid'], load)
         except KeyError as e:
             log.error("Load does not contain 'jid': %s", e)
+        except Exception:
+            log.critical(
+                "The specified '{0}' returner threw a stack trace:\n".format(job_cache),
+                exc_info=True
+            )
 
-    mminion.returners[fstr](load)
+    try:
+        mminion.returners[fstr](load)
+    except Exception:
+        log.critical(
+            "The specified '{0}' returner threw a stack trace:\n".format(job_cache),
+            exc_info=True
+        )
 
     if (opts.get('job_cache_store_endtime')
             and updateetfstr in mminion.returners):

--- a/tests/unit/utils/test_job.py
+++ b/tests/unit/utils/test_job.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+'''
+unit tests for salt.utils.job
+'''
+
+# Import Python Libs
+from __future__ import absolute_import, print_function, unicode_literals
+
+# Import Salt Testing Libs
+from tests.support.mixins import LoaderModuleMockMixin
+from tests.support.unit import skipIf, TestCase
+from tests.support.mock import (
+    NO_MOCK,
+    NO_MOCK_REASON,
+    patch
+)
+
+# Import Salt Libs
+import salt.utils.job as job
+import salt.minion
+
+# Import 3rd-party libs
+from salt.ext import six
+
+
+class MockMasterMinion(object):
+    def return_mock_jobs(self):
+        return self.mock_jobs_cache
+
+    opts = {'job_cache': True, 'ext_job_cache': None, 'master_job_cache': 'foo'}
+    mock_jobs_cache = {}
+    returners = {
+        'foo.save_load': lambda *args, **kwargs: True,
+        'foo.prep_jid': lambda *args, **kwargs: True,
+        'foo.get_load': lambda *args, **kwargs: True,
+        'foo.returner': lambda *args, **kwargs: True,
+    }
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class JobTest(TestCase):
+    '''
+    Validate salt.utils.job
+    '''
+    @skipIf(not six.PY3, "Can only assertLogs in PY3")
+    def test_store_job_exception_handled(self):
+        '''
+        test store_job exception handling
+        '''
+        for func in ['foo.save_load', 'foo.prep_jid', 'foo.returner']:
+            def raise_exception(*arg, **kwarg):
+                raise Exception('expected')
+
+            with patch.object(salt.minion, 'MasterMinion', MockMasterMinion), \
+                 patch.dict(MockMasterMinion.returners, {func: raise_exception}), \
+                 patch('salt.utils.verify.valid_id', return_value=True):
+                 with self.assertLogs('salt.utils.job', level='CRITICAL') as logged:
+                    job.store_job(MockMasterMinion.opts, {'jid': '20190618090114890985', 'return': {'success': True}, 'id': 'a'})
+                    self.assertIn("The specified 'foo' returner threw a stack trace", logged.output[0])

--- a/tests/unit/utils/test_job.py
+++ b/tests/unit/utils/test_job.py
@@ -7,7 +7,6 @@ unit tests for salt.utils.job
 from __future__ import absolute_import, print_function, unicode_literals
 
 # Import Salt Testing Libs
-from tests.support.mixins import LoaderModuleMockMixin
 from tests.support.unit import skipIf, TestCase
 from tests.support.mock import (
     NO_MOCK,
@@ -39,6 +38,7 @@ class MockMasterMinion(object):
     def __init__(self, *args, **kwargs):
         pass
 
+
 @skipIf(NO_MOCK, NO_MOCK_REASON)
 class JobTest(TestCase):
     '''
@@ -54,8 +54,8 @@ class JobTest(TestCase):
                 raise Exception('expected')
 
             with patch.object(salt.minion, 'MasterMinion', MockMasterMinion), \
-                 patch.dict(MockMasterMinion.returners, {func: raise_exception}), \
-                 patch('salt.utils.verify.valid_id', return_value=True):
-                 with self.assertLogs('salt.utils.job', level='CRITICAL') as logged:
+                patch.dict(MockMasterMinion.returners, {func: raise_exception}), \
+                patch('salt.utils.verify.valid_id', return_value=True):
+                with self.assertLogs('salt.utils.job', level='CRITICAL') as logged:
                     job.store_job(MockMasterMinion.opts, {'jid': '20190618090114890985', 'return': {'success': True}, 'id': 'a'})
                     self.assertIn("The specified 'foo' returner threw a stack trace", logged.output[0])


### PR DESCRIPTION
### What does this PR do?
external returners can blow up for any variety of reasons, but when we
don't catch it it will sometimes stop the event from being returned to
the bus via fire_event, which has downstream effects. so lets guard
against that.

### What issues does this PR fix or reference?
n/a


### Tests written?
Yes

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
