### PR TITLE
Run boto_route53 test on Python 3.7+

### DIFF
--- a/tests/unit/modules/test_boto_route53.py
+++ b/tests/unit/modules/test_boto_route53.py
@@ -87,10 +87,6 @@ def _has_required_moto():
     "The moto module must be >= to {0} for "
     "PY2 or {1} for PY3.".format(required_moto, required_moto_py3),
 )
-@skipIf(
-    sys.version_info > (3, 6),
-    "Disabled for 3.7+ pending https://github.com/spulec/moto/issues/1706.",
-)
 class BotoRoute53TestCase(TestCase, LoaderModuleMockMixin):
     """
     TestCase for salt.modules.boto_route53 module

--- a/tests/unit/modules/test_boto_route53.py
+++ b/tests/unit/modules/test_boto_route53.py
@@ -5,17 +5,14 @@ from __future__ import absolute_import, print_function, unicode_literals
 
 import logging
 import os.path
-import sys
 from collections import namedtuple
 
-import pkg_resources
+import pkg_resources  # pylint: disable=3rd-party-module-not-gated
 
 # Import Salt Libs
 import salt.config
 import salt.loader
-import salt.modules.boto_route53 as boto_route53
 import salt.utils.versions
-from boto.route53.exception import DNSServerError
 from salt.ext import six
 
 # Import Salt Testing Libs
@@ -27,6 +24,8 @@ from tests.support.unit import TestCase, skipIf
 # import Python Third Party Libs
 # pylint: disable=import-error
 try:
+    import salt.modules.boto_route53 as boto_route53
+    from boto.route53.exception import DNSServerError
     import boto
 
     boto.ENDPOINTS_PATH = os.path.join(


### PR DESCRIPTION
https://github.com/spulec/moto/issues/1706 has been fixed. Since
September 2018. We're using moto 1.3.7, which should have that fix in
it.

### What does this PR do?

re-enables a test

### What issues does this PR fix or reference?

n/a

### Previous Behavior

Skips test on python3.7+

### New Behavior

No longer skips test on python3.7+

### Tests written?
Yes(???)

### Commits signed with GPG?

Yes