### PR TITLE
Check if the key_url changed in pkgrepo.managed

### DIFF
--- a/salt/states/pkgrepo.py
+++ b/salt/states/pkgrepo.py
@@ -430,7 +430,7 @@ def managed(name, ppa=None, **kwargs):
                         break
                 else:
                     break
-            elif kwarg in ['comps', 'key_url']:
+            elif kwarg in ('comps', 'key_url'):
                 if sorted(sanitizedkwargs[kwarg]) != sorted(pre[kwarg]):
                     break
             elif kwarg == 'line' and __grains__['os_family'] == 'Debian':

--- a/salt/states/pkgrepo.py
+++ b/salt/states/pkgrepo.py
@@ -430,10 +430,7 @@ def managed(name, ppa=None, **kwargs):
                         break
                 else:
                     break
-            elif kwarg == 'comps':
-                if sorted(sanitizedkwargs[kwarg]) != sorted(pre[kwarg]):
-                    break
-            elif kwarg == 'key_url':
+            elif kwarg in ['comps', 'key_url']:
                 if sorted(sanitizedkwargs[kwarg]) != sorted(pre[kwarg]):
                     break
             elif kwarg == 'line' and __grains__['os_family'] == 'Debian':

--- a/salt/states/pkgrepo.py
+++ b/salt/states/pkgrepo.py
@@ -315,10 +315,12 @@ def managed(name, ppa=None, **kwargs):
             'removed in the Neon release of Salt.'
         )
         kwargs['refresh'] = kwargs.pop('refresh_db')
+
     ret = {'name': name,
            'changes': {},
            'result': None,
            'comment': ''}
+
     if 'pkg.get_repo' not in __salt__:
         ret['result'] = False
         ret['comment'] = 'Repo management not implemented on this platform'

--- a/salt/states/pkgrepo.py
+++ b/salt/states/pkgrepo.py
@@ -315,12 +315,10 @@ def managed(name, ppa=None, **kwargs):
             'removed in the Neon release of Salt.'
         )
         kwargs['refresh'] = kwargs.pop('refresh_db')
-
     ret = {'name': name,
            'changes': {},
            'result': None,
            'comment': ''}
-
     if 'pkg.get_repo' not in __salt__:
         ret['result'] = False
         ret['comment'] = 'Repo management not implemented on this platform'
@@ -431,6 +429,9 @@ def managed(name, ppa=None, **kwargs):
                 else:
                     break
             elif kwarg == 'comps':
+                if sorted(sanitizedkwargs[kwarg]) != sorted(pre[kwarg]):
+                    break
+            elif kwarg == 'key_url':
                 if sorted(sanitizedkwargs[kwarg]) != sorted(pre[kwarg]):
                     break
             elif kwarg == 'line' and __grains__['os_family'] == 'Debian':

--- a/tests/unit/states/test_pkgrepo.py
+++ b/tests/unit/states/test_pkgrepo.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+'''
+    :codeauthor: Tyler Johnson <tjohnson@saltstack.com>
+'''
+# Import Python libs
+from __future__ import absolute_import
+
+# Import Salt Testing Libs
+from tests.support.mixins import LoaderModuleMockMixin
+from tests.support.unit import skipIf, TestCase
+from tests.support.mock import (
+    Mock,
+    NO_MOCK,
+    NO_MOCK_REASON,
+    MagicMock,
+    patch)
+
+# Import Salt Libs
+import salt.states.pkgrepo as pkgrepo
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class PkgrepoTestCase(TestCase, LoaderModuleMockMixin):
+    '''
+    Test cases for salt.states.pkgrepo
+    '''
+
+    def setup_loader_modules(self):
+        return {pkgrepo: {'__opts__': {'test': True}}}
+
+    # 'update_packaging_site' function tests: 1
+
+    def test_update_key_url(self):
+        '''
+        Test when only the key_url is changed that a change is triggered
+        '''
+        from pprint import pprint
+        kwargs = {
+            'humanname': 'Mocked Repo',
+            'name': 'deb http://mock/ stretch main',
+            'gpgcheck': 1,
+            'key_url': 'http://mock/changed_gpg.key',
+        }
+        previous_state = {
+            'humanname': 'Mocked Repo',
+            'name': 'deb http://mock/ stretch main',
+            'gpgcheck': 1,
+            'key_url': 'http://mock/gpg.key',
+            'disabled': False,
+        }
+
+        with patch.dict(pkgrepo.__grains__, {'os': 'Ubuntu', 'os_family': 'Debian'}):
+            with patch.dict(pkgrepo.__salt__, {'pkg.get_repo': MagicMock(return_value=previous_state)}):
+                ret = pkgrepo.managed(**kwargs)
+                # pprint(ret)
+                self.assertDictEqual({
+                    'old': previous_state['key_url'],
+                    'new': kwargs['key_url'],
+                }, ret['changes'].get('key_url', dict()))

--- a/tests/unit/states/test_pkgrepo.py
+++ b/tests/unit/states/test_pkgrepo.py
@@ -26,7 +26,12 @@ class PkgrepoTestCase(TestCase, LoaderModuleMockMixin):
     '''
 
     def setup_loader_modules(self):
-        return {pkgrepo: {'__opts__': {'test': True}}}
+        return {
+            pkgrepo: {
+                '__opts__': {'test': True},
+                '__grains__': {'os': '', 'os_family': ''}
+            }
+        }
 
     # 'update_packaging_site' function tests: 1
 
@@ -48,11 +53,10 @@ class PkgrepoTestCase(TestCase, LoaderModuleMockMixin):
             'disabled': False,
         }
 
-        with patch.dict(pkgrepo.__grains__, {'os': 'Ubuntu', 'os_family': 'Debian'}):
-            with patch.dict(pkgrepo.__salt__, {'pkg.get_repo': MagicMock(return_value=previous_state)}):
-                ret = pkgrepo.managed(**kwargs)
-                # pprint(ret)
-                self.assertDictEqual({
-                    'old': previous_state['key_url'],
-                    'new': kwargs['key_url'],
-                }, ret['changes'].get('key_url', dict()))
+        with patch.dict(pkgrepo.__salt__, {'pkg.get_repo': MagicMock(return_value=previous_state)}):
+            ret = pkgrepo.managed(**kwargs)
+            # pprint(ret)
+            self.assertDictEqual({
+                'old': previous_state['key_url'],
+                'new': kwargs['key_url'],
+            }, ret['changes'].get('key_url', dict()))

--- a/tests/unit/states/test_pkgrepo.py
+++ b/tests/unit/states/test_pkgrepo.py
@@ -34,7 +34,6 @@ class PkgrepoTestCase(TestCase, LoaderModuleMockMixin):
         '''
         Test when only the key_url is changed that a change is triggered
         '''
-        from pprint import pprint
         kwargs = {
             'humanname': 'Mocked Repo',
             'name': 'deb http://mock/ stretch main',

--- a/tests/unit/states/test_pkgrepo.py
+++ b/tests/unit/states/test_pkgrepo.py
@@ -9,7 +9,6 @@ from __future__ import absolute_import
 from tests.support.mixins import LoaderModuleMockMixin
 from tests.support.unit import skipIf, TestCase
 from tests.support.mock import (
-    Mock,
     NO_MOCK,
     NO_MOCK_REASON,
     MagicMock,

--- a/tests/unit/states/test_pkgrepo.py
+++ b/tests/unit/states/test_pkgrepo.py
@@ -27,7 +27,7 @@ class PkgrepoTestCase(TestCase, LoaderModuleMockMixin):
     def setup_loader_modules(self):
         return {
             pkgrepo: {
-                '__opts__': {'test': None},
+                '__opts__': {'test': True},
                 '__grains__': {'os': '', 'os_family': ''}
             }
         }
@@ -42,10 +42,9 @@ class PkgrepoTestCase(TestCase, LoaderModuleMockMixin):
         }
         key_url = 'http://mock/changed_gpg.key'
 
-        with patch.dict(pkgrepo.__opts__, {'test': True}):
-            with patch.dict(pkgrepo.__salt__, {'pkg.get_repo': MagicMock(return_value=kwargs)}):
-                ret = pkgrepo.managed(key_url=key_url, **kwargs)
-                self.assertDictEqual({
+        with patch.dict(pkgrepo.__salt__, {'pkg.get_repo': MagicMock(return_value=kwargs)}):
+            ret = pkgrepo.managed(key_url=key_url, **kwargs)
+            self.assertDictEqual({
                     'key_url': {
                         'old': None,
                         'new': key_url
@@ -65,13 +64,12 @@ class PkgrepoTestCase(TestCase, LoaderModuleMockMixin):
         changed_kwargs = kwargs.copy()
         changed_kwargs['key_url'] = 'http://mock/gpg2.key'
 
-        with patch.dict(pkgrepo.__opts__, {'test': True}):
-            with patch.dict(pkgrepo.__salt__, {'pkg.get_repo': MagicMock(return_value=kwargs)}):
-                ret = pkgrepo.managed(**changed_kwargs)
-                self.assertIn('key_url', ret['changes'], 'Expected a change to key_url')
-                self.assertDictEqual({
-                    'key_url': {
-                        'old': kwargs['key_url'],
-                        'new': changed_kwargs['key_url']
-                    }
-                }, ret['changes'])
+        with patch.dict(pkgrepo.__salt__, {'pkg.get_repo': MagicMock(return_value=kwargs)}):
+            ret = pkgrepo.managed(**changed_kwargs)
+            self.assertIn('key_url', ret['changes'], 'Expected a change to key_url')
+            self.assertDictEqual({
+                'key_url': {
+                    'old': kwargs['key_url'],
+                    'new': changed_kwargs['key_url']
+                }
+            }, ret['changes'])

--- a/tests/unit/states/test_pkgrepo.py
+++ b/tests/unit/states/test_pkgrepo.py
@@ -32,8 +32,6 @@ class PkgrepoTestCase(TestCase, LoaderModuleMockMixin):
             }
         }
 
-    # 'update_packaging_site' function tests: 1
-
     def test_update_key_url(self):
         '''
         Test when only the key_url is changed that a change is triggered
@@ -54,7 +52,6 @@ class PkgrepoTestCase(TestCase, LoaderModuleMockMixin):
 
         with patch.dict(pkgrepo.__salt__, {'pkg.get_repo': MagicMock(return_value=previous_state)}):
             ret = pkgrepo.managed(**kwargs)
-            # pprint(ret)
             self.assertDictEqual({
                 'old': previous_state['key_url'],
                 'new': kwargs['key_url'],


### PR DESCRIPTION
### What does this PR do?
Makes pkgrepo.managed check for a changed key_url

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/4438

### Tests written?
Yes

### Commits signed with GPG?

Yes