### PR TITLE
catch any exception on reading rsa key

### DIFF
--- a/salt/transport/mixins/auth.py
+++ b/salt/transport/mixins/auth.py
@@ -435,7 +435,7 @@ class AESReqServerMixin(object):
         try:
             pub = salt.crypt.get_rsa_pub_key(pubfn)
         except Exception as err:
-            log.error('Corrupt public key "%s": %s', pubfn, err, exc_at_loglevel=logging.DEBUG)
+            log.error('Corrupt public key "%s": %s', pubfn, err, exc_info_on_loglevel=logging.DEBUG)
             return {'enc': 'clear',
                     'load': {'ret': False}}
 

--- a/salt/transport/mixins/auth.py
+++ b/salt/transport/mixins/auth.py
@@ -435,7 +435,7 @@ class AESReqServerMixin(object):
         try:
             pub = salt.crypt.get_rsa_pub_key(pubfn)
         except Exception as err:
-            log.error('Corrupt public key "%s": %s', pubfn, err)
+            log.error('Corrupt public key "%s": %s', pubfn, err, exc_at_loglevel=logging.DEBUG)
             return {'enc': 'clear',
                     'load': {'ret': False}}
 

--- a/salt/transport/mixins/auth.py
+++ b/salt/transport/mixins/auth.py
@@ -434,7 +434,7 @@ class AESReqServerMixin(object):
         # and an empty request comes in
         try:
             pub = salt.crypt.get_rsa_pub_key(pubfn)
-        except (ValueError, IndexError, TypeError) as err:
+        except Exception as err:
             log.error('Corrupt public key "%s": %s', pubfn, err)
             return {'enc': 'clear',
                     'load': {'ret': False}}


### PR DESCRIPTION
### What does this PR do?
an unhandled exception thrown at this point of code will put MWorker into an unrecoverable hung state that leaks memory as MWorkerQueue continues passing it work that is ignored. In my case I encountered an RSAError but I see no reason to be specific for exception class here.

### Tests written?
No. not exactly sure how to write an integration test to trigger this since its embedded in _auth() in salt.transport.mixins.auth.

**[NOTICE] Bug fixes or features added to Salt require tests.**
Please review the [test documentation](https://docs.saltstack.com/en/latest/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite.

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
