### PR TITLE
Move create key call into try/except in Digital Ocean key test

### DIFF
--- a/tests/integration/cloud/clouds/test_digitalocean.py
+++ b/tests/integration/cloud/clouds/test_digitalocean.py
@@ -102,15 +102,15 @@ class DigitalOceanTest(ShellCase):
         pub = 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAQQDDHr/jh2Jy4yALcK4JyWbVkPRaWmhck3IgCoeOO3z1e2dBowLh64QAM+Qb72pxekALga2oi4GvT+TlWNhzPH4V example'
         finger_print = '3b:16:bf:e4:8b:00:8b:b8:59:8c:a9:d3:f0:19:45:fa'
 
-        _key = self.run_cloud('-f create_key {0} name="MyPubKey" public_key="{1}"'.format(PROVIDER_NAME, pub))
-
-        # Upload public key
-        self.assertIn(
-            finger_print,
-            [i.strip() for i in _key]
-        )
-
         try:
+            _key = self.run_cloud('-f create_key {0} name="MyPubKey" public_key="{1}"'.format(PROVIDER_NAME, pub))
+
+            # Upload public key
+            self.assertIn(
+                finger_print,
+                [i.strip() for i in _key]
+            )
+
             # List all keys
             list_keypairs = self.run_cloud('-f list_keypairs {0}'.format(PROVIDER_NAME))
 


### PR DESCRIPTION
### What does this PR do?
Fixes test `integration.cloud.clouds.test_digitalocean.DigitalOceanTest.test_key_management`. Sometimes this test fails and the key does not get cleaned up because the create_key call is not in the try/except/finally. I've re-ran the test about 10 times and it passes each time now.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/53010

### Previous Behavior
test `integration.cloud.clouds.test_digitalocean.DigitalOceanTest.test_key_management` fails

### New Behavior
test `integration.cloud.clouds.test_digitalocean.DigitalOceanTest.test_key_management` passes

### Tests written?
No - fixes tests

### Commits signed with GPG?

Yes
