### PR TITLE
[2018.3] Add pypsexec requirement for cloud tests

### DIFF
--- a/requirements/static/cloud.in
+++ b/requirements/static/cloud.in
@@ -3,4 +3,5 @@ azure
 impacket; python_version < '3.0'
 netaddr
 profitbricks
+pypsexec
 pywinrm

--- a/requirements/static/py2.7/cloud.txt
+++ b/requirements/static/py2.7/cloud.txt
@@ -93,7 +93,7 @@ certifi==2019.3.9         # via msrest, requests
 cffi==1.12.2              # via azure-datalake-store, cryptography
 chardet==3.0.4            # via requests
 click==7.0                # via flask
-cryptography==2.6.1       # via adal, azure-cosmosdb-table, azure-keyvault, azure-storage-common, pyopenssl, requests-ntlm
+cryptography==2.6.1       # via adal, azure-cosmosdb-table, azure-keyvault, azure-storage-common, pyopenssl, requests-ntlm, smbprotocol
 dnspython==1.16.0         # via ldapdomaindump
 enum34==1.1.6             # via cryptography, msrest
 flask==1.0.2              # via impacket
@@ -111,22 +111,24 @@ markupsafe==1.1.1         # via jinja2
 msrest==0.6.6             # via azure-applicationinsights, azure-eventgrid, azure-keyvault, azure-loganalytics, azure-mgmt-cdn, azure-mgmt-compute, azure-mgmt-containerinstance, azure-mgmt-containerregistry, azure-mgmt-containerservice, azure-mgmt-dns, azure-mgmt-eventhub, azure-mgmt-keyvault, azure-mgmt-media, azure-mgmt-network, azure-mgmt-rdbms, azure-mgmt-resource, azure-mgmt-servicebus, azure-mgmt-servicefabric, azure-mgmt-signalr, azure-servicefabric, msrestazure
 msrestazure==0.6.0        # via azure-batch, azure-eventgrid, azure-graphrbac, azure-keyvault, azure-mgmt-advisor, azure-mgmt-applicationinsights, azure-mgmt-authorization, azure-mgmt-batch, azure-mgmt-batchai, azure-mgmt-billing, azure-mgmt-cdn, azure-mgmt-cognitiveservices, azure-mgmt-commerce, azure-mgmt-compute, azure-mgmt-consumption, azure-mgmt-containerinstance, azure-mgmt-containerregistry, azure-mgmt-containerservice, azure-mgmt-cosmosdb, azure-mgmt-datafactory, azure-mgmt-datalake-analytics, azure-mgmt-datalake-store, azure-mgmt-datamigration, azure-mgmt-devspaces, azure-mgmt-devtestlabs, azure-mgmt-dns, azure-mgmt-eventgrid, azure-mgmt-eventhub, azure-mgmt-hanaonazure, azure-mgmt-iotcentral, azure-mgmt-iothub, azure-mgmt-iothubprovisioningservices, azure-mgmt-keyvault, azure-mgmt-loganalytics, azure-mgmt-logic, azure-mgmt-machinelearningcompute, azure-mgmt-managementgroups, azure-mgmt-managementpartner, azure-mgmt-maps, azure-mgmt-marketplaceordering, azure-mgmt-media, azure-mgmt-monitor, azure-mgmt-msi, azure-mgmt-network, azure-mgmt-notificationhubs, azure-mgmt-policyinsights, azure-mgmt-powerbiembedded, azure-mgmt-rdbms, azure-mgmt-recoveryservices, azure-mgmt-recoveryservicesbackup, azure-mgmt-redis, azure-mgmt-relay, azure-mgmt-reservations, azure-mgmt-resource, azure-mgmt-scheduler, azure-mgmt-search, azure-mgmt-servicebus, azure-mgmt-servicefabric, azure-mgmt-signalr, azure-mgmt-sql, azure-mgmt-storage, azure-mgmt-subscription, azure-mgmt-trafficmanager, azure-mgmt-web
 netaddr==0.7.19
-ntlm-auth==1.3.0          # via requests-ntlm
+ntlm-auth==1.3.0          # via requests-ntlm, smbprotocol
 oauthlib==3.0.1           # via requests-oauthlib
 pathlib2==2.3.3           # via azure-datalake-store
 profitbricks==4.1.3
-pyasn1==0.4.5             # via impacket, ldap3
+pyasn1==0.4.5             # via impacket, ldap3, smbprotocol
 pycparser==2.19           # via cffi
 pycryptodomex==3.8.1      # via impacket
 pyjwt==1.7.1              # via adal
 pyopenssl==19.0.0         # via impacket
+pypsexec==0.1.0
 python-dateutil==2.8.0    # via adal, azure-cosmosdb-table, azure-storage-common
 pywinrm==0.3.0
 requests-ntlm==1.1.0      # via pywinrm
 requests-oauthlib==1.2.0  # via msrest
 requests==2.21.0          # via adal, azure-cosmosdb-table, azure-datalake-store, azure-keyvault, azure-servicebus, azure-servicemanagement-legacy, azure-storage-common, msrest, profitbricks, pywinrm, requests-ntlm, requests-oauthlib
 scandir==1.10.0           # via pathlib2
-six==1.12.0               # via cryptography, impacket, isodate, pathlib2, profitbricks, pyopenssl, python-dateutil, pywinrm
+six==1.12.0               # via cryptography, impacket, isodate, pathlib2, profitbricks, pyopenssl, pypsexec, python-dateutil, pywinrm, smbprotocol
+smbprotocol==0.1.1        # via pypsexec
 typing==3.6.6             # via msrest
 urllib3==1.24.2           # via requests
 werkzeug==0.15.2          # via flask

--- a/requirements/static/py3.4/cloud.txt
+++ b/requirements/static/py3.4/cloud.txt
@@ -91,23 +91,26 @@ azure==4.0.0
 certifi==2019.3.9         # via msrest, requests
 cffi==1.12.2              # via azure-datalake-store, cryptography
 chardet==3.0.4            # via requests
-cryptography==2.6.1       # via adal, azure-cosmosdb-table, azure-keyvault, azure-storage-common, requests-ntlm
+cryptography==2.6.1       # via adal, azure-cosmosdb-table, azure-keyvault, azure-storage-common, requests-ntlm, smbprotocol
 idna==2.8                 # via requests
 isodate==0.6.0            # via msrest
 msrest==0.6.6             # via azure-applicationinsights, azure-eventgrid, azure-keyvault, azure-loganalytics, azure-mgmt-cdn, azure-mgmt-compute, azure-mgmt-containerinstance, azure-mgmt-containerregistry, azure-mgmt-containerservice, azure-mgmt-dns, azure-mgmt-eventhub, azure-mgmt-keyvault, azure-mgmt-media, azure-mgmt-network, azure-mgmt-rdbms, azure-mgmt-resource, azure-mgmt-servicebus, azure-mgmt-servicefabric, azure-mgmt-signalr, azure-servicefabric, msrestazure
 msrestazure==0.6.0        # via azure-batch, azure-eventgrid, azure-graphrbac, azure-keyvault, azure-mgmt-advisor, azure-mgmt-applicationinsights, azure-mgmt-authorization, azure-mgmt-batch, azure-mgmt-batchai, azure-mgmt-billing, azure-mgmt-cdn, azure-mgmt-cognitiveservices, azure-mgmt-commerce, azure-mgmt-compute, azure-mgmt-consumption, azure-mgmt-containerinstance, azure-mgmt-containerregistry, azure-mgmt-containerservice, azure-mgmt-cosmosdb, azure-mgmt-datafactory, azure-mgmt-datalake-analytics, azure-mgmt-datalake-store, azure-mgmt-datamigration, azure-mgmt-devspaces, azure-mgmt-devtestlabs, azure-mgmt-dns, azure-mgmt-eventgrid, azure-mgmt-eventhub, azure-mgmt-hanaonazure, azure-mgmt-iotcentral, azure-mgmt-iothub, azure-mgmt-iothubprovisioningservices, azure-mgmt-keyvault, azure-mgmt-loganalytics, azure-mgmt-logic, azure-mgmt-machinelearningcompute, azure-mgmt-managementgroups, azure-mgmt-managementpartner, azure-mgmt-maps, azure-mgmt-marketplaceordering, azure-mgmt-media, azure-mgmt-monitor, azure-mgmt-msi, azure-mgmt-network, azure-mgmt-notificationhubs, azure-mgmt-policyinsights, azure-mgmt-powerbiembedded, azure-mgmt-rdbms, azure-mgmt-recoveryservices, azure-mgmt-recoveryservicesbackup, azure-mgmt-redis, azure-mgmt-relay, azure-mgmt-reservations, azure-mgmt-resource, azure-mgmt-scheduler, azure-mgmt-search, azure-mgmt-servicebus, azure-mgmt-servicefabric, azure-mgmt-signalr, azure-mgmt-sql, azure-mgmt-storage, azure-mgmt-subscription, azure-mgmt-trafficmanager, azure-mgmt-web
 netaddr==0.7.19
-ntlm-auth==1.3.0          # via requests-ntlm
+ntlm-auth==1.3.0          # via requests-ntlm, smbprotocol
 oauthlib==3.0.1           # via requests-oauthlib
 profitbricks==4.1.3
+pyasn1==0.4.5             # via smbprotocol
 pycparser==2.19           # via cffi
 pyjwt==1.7.1              # via adal
+pypsexec==0.1.0
 python-dateutil==2.8.0    # via adal, azure-cosmosdb-table, azure-storage-common
 pywinrm==0.3.0
 requests-ntlm==1.1.0      # via pywinrm
 requests-oauthlib==1.2.0  # via msrest
 requests==2.21.0          # via adal, azure-cosmosdb-table, azure-datalake-store, azure-keyvault, azure-servicebus, azure-servicemanagement-legacy, azure-storage-common, msrest, profitbricks, pywinrm, requests-ntlm, requests-oauthlib
-six==1.12.0               # via cryptography, isodate, profitbricks, python-dateutil, pywinrm
+six==1.12.0               # via cryptography, isodate, profitbricks, pypsexec, python-dateutil, pywinrm, smbprotocol
+smbprotocol==0.1.1        # via pypsexec
 typing==3.6.6             # via msrest
 urllib3==1.24.2           # via requests
 xmltodict==0.12.0         # via pywinrm

--- a/requirements/static/py3.4/raet-arch.txt
+++ b/requirements/static/py3.4/raet-arch.txt
@@ -9,14 +9,13 @@ asn1crypto==0.24.0        # via cryptography
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via pytest
 aws-xray-sdk==0.95        # via moto
-backports-abc==0.5        # via tornado
 backports.functools-lru-cache==1.5  # via cheroot
-backports.ssl-match-hostname==3.7.0.1  # via docker, websocket-client
+backports.ssl-match-hostname==3.7.0.1  # via docker
 boto3==1.9.132
 boto==2.49.0
 botocore==1.12.132        # via boto3, moto, s3transfer
 cachetools==3.1.0         # via google-auth
-certifi==2019.3.9         # via kubernetes, requests, tornado
+certifi==2019.3.9         # via kubernetes, requests
 cffi==1.12.2
 chardet==3.0.4            # via requests
 cheroot==6.5.4            # via cherrypy
@@ -30,8 +29,6 @@ docker-pycreds==0.4.0     # via docker
 docker==3.7.2
 docutils==0.14            # via botocore
 ecdsa==0.13.2             # via python-jose
-# Next line explicitly commented out by pip-tools-compile because of the following regex: '^enum34==(.*)$'
-# enum34==1.1.6             # via raet
 future==0.17.1            # via python-jose
 gitdb2==2.0.5             # via gitpython
 gitpython==2.1.11
@@ -91,8 +88,7 @@ s3transfer==0.2.0         # via boto3
 salttesting==2017.6.1
 scandir==1.10.0           # via pathlib2
 setproctitle==1.1.10
-singledispatch==3.4.0.3   # via tornado
-six==1.12.0               # via cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, kubernetes, mock, more-itertools, moto, pathlib2, pygit2, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, raet, responses, salttesting, singledispatch, tempora, websocket-client
+six==1.12.0               # via cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, kubernetes, mock, more-itertools, moto, pathlib2, pygit2, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, raet, responses, salttesting, tempora, websocket-client
 smmap2==2.0.5             # via gitdb2
 strict-rfc3339==0.7
 tempora==1.14.1           # via portend

--- a/requirements/static/py3.4/raet-centos-7.txt
+++ b/requirements/static/py3.4/raet-centos-7.txt
@@ -9,14 +9,13 @@ asn1crypto==0.24.0        # via cryptography
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via pytest
 aws-xray-sdk==0.95        # via moto
-backports-abc==0.5        # via tornado
 backports.functools-lru-cache==1.5  # via cheroot
-backports.ssl-match-hostname==3.7.0.1  # via docker, websocket-client
+backports.ssl-match-hostname==3.7.0.1  # via docker
 boto3==1.9.132
 boto==2.49.0
 botocore==1.12.132        # via boto3, moto, s3transfer
 cachetools==3.1.0         # via google-auth
-certifi==2019.3.9         # via kubernetes, requests, tornado
+certifi==2019.3.9         # via kubernetes, requests
 cffi==1.12.2
 chardet==3.0.4            # via requests
 cheroot==6.5.4            # via cherrypy
@@ -30,8 +29,6 @@ docker-pycreds==0.4.0     # via docker
 docker==3.7.2
 docutils==0.14            # via botocore
 ecdsa==0.13.2             # via python-jose
-# Next line explicitly commented out by pip-tools-compile because of the following regex: '^enum34==(.*)$'
-# enum34==1.1.6             # via raet
 future==0.17.1            # via python-jose
 gitdb2==2.0.5             # via gitpython
 gitpython==2.1.11
@@ -101,8 +98,7 @@ scandir==1.10.0           # via pathlib2
 scp==0.13.2               # via junos-eznc
 selectors2==2.0.1         # via ncclient
 setproctitle==1.1.10
-singledispatch==3.4.0.3   # via tornado
-six==1.12.0               # via cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, junos-eznc, kazoo, kubernetes, mock, more-itertools, moto, ncclient, pathlib2, pygit2, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, raet, responses, salttesting, singledispatch, tempora, websocket-client
+six==1.12.0               # via cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, junos-eznc, kazoo, kubernetes, mock, more-itertools, moto, ncclient, pathlib2, pygit2, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, raet, responses, salttesting, tempora, websocket-client
 smmap2==2.0.5             # via gitdb2
 strict-rfc3339==0.7
 tempora==1.14.1           # via portend

--- a/requirements/static/py3.4/raet-debian-8.txt
+++ b/requirements/static/py3.4/raet-debian-8.txt
@@ -9,14 +9,13 @@ asn1crypto==0.24.0        # via cryptography
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via pytest
 aws-xray-sdk==0.95        # via moto
-backports-abc==0.5        # via tornado
 backports.functools-lru-cache==1.5  # via cheroot
-backports.ssl-match-hostname==3.7.0.1  # via docker, websocket-client
+backports.ssl-match-hostname==3.7.0.1  # via docker
 boto3==1.9.132
 boto==2.49.0
 botocore==1.12.132        # via boto3, moto, s3transfer
 cachetools==3.1.0         # via google-auth
-certifi==2019.3.9         # via kubernetes, requests, tornado
+certifi==2019.3.9         # via kubernetes, requests
 cffi==1.12.2
 chardet==3.0.4            # via requests
 cheroot==6.5.4            # via cherrypy
@@ -30,8 +29,6 @@ docker-pycreds==0.4.0     # via docker
 docker==3.7.2
 docutils==0.14            # via botocore
 ecdsa==0.13.2             # via python-jose
-# Next line explicitly commented out by pip-tools-compile because of the following regex: '^enum34==(.*)$'
-# enum34==1.1.6             # via raet
 future==0.17.1            # via python-jose
 gitdb2==2.0.5             # via gitpython
 gitpython==2.1.11
@@ -100,8 +97,7 @@ scandir==1.10.0           # via pathlib2
 scp==0.13.2               # via junos-eznc
 selectors2==2.0.1         # via ncclient
 setproctitle==1.1.10
-singledispatch==3.4.0.3   # via tornado
-six==1.12.0               # via cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, junos-eznc, kubernetes, mock, more-itertools, moto, ncclient, pathlib2, pygit2, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, raet, responses, salttesting, singledispatch, tempora, websocket-client
+six==1.12.0               # via cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, junos-eznc, kubernetes, mock, more-itertools, moto, ncclient, pathlib2, pygit2, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, raet, responses, salttesting, tempora, websocket-client
 smmap2==2.0.5             # via gitdb2
 strict-rfc3339==0.7
 tempora==1.14.1           # via portend

--- a/requirements/static/py3.4/raet-debian-9.txt
+++ b/requirements/static/py3.4/raet-debian-9.txt
@@ -9,14 +9,13 @@ asn1crypto==0.24.0        # via cryptography
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via pytest
 aws-xray-sdk==0.95        # via moto
-backports-abc==0.5        # via tornado
 backports.functools-lru-cache==1.5  # via cheroot
-backports.ssl-match-hostname==3.7.0.1  # via docker, websocket-client
+backports.ssl-match-hostname==3.7.0.1  # via docker
 boto3==1.9.132
 boto==2.49.0
 botocore==1.12.132        # via boto3, moto, s3transfer
 cachetools==3.1.0         # via google-auth
-certifi==2019.3.9         # via kubernetes, requests, tornado
+certifi==2019.3.9         # via kubernetes, requests
 cffi==1.12.2
 chardet==3.0.4            # via requests
 cheroot==6.5.4            # via cherrypy
@@ -30,8 +29,6 @@ docker-pycreds==0.4.0     # via docker
 docker==3.7.2
 docutils==0.14            # via botocore
 ecdsa==0.13.2             # via python-jose
-# Next line explicitly commented out by pip-tools-compile because of the following regex: '^enum34==(.*)$'
-# enum34==1.1.6             # via raet
 future==0.17.1            # via python-jose
 gitdb2==2.0.5             # via gitpython
 gitpython==2.1.11
@@ -100,8 +97,7 @@ scandir==1.10.0           # via pathlib2
 scp==0.13.2               # via junos-eznc
 selectors2==2.0.1         # via ncclient
 setproctitle==1.1.10
-singledispatch==3.4.0.3   # via tornado
-six==1.12.0               # via cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, junos-eznc, kubernetes, mock, more-itertools, moto, ncclient, pathlib2, pygit2, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, raet, responses, salttesting, singledispatch, tempora, websocket-client
+six==1.12.0               # via cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, junos-eznc, kubernetes, mock, more-itertools, moto, ncclient, pathlib2, pygit2, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, raet, responses, salttesting, tempora, websocket-client
 smmap2==2.0.5             # via gitdb2
 strict-rfc3339==0.7
 tempora==1.14.1           # via portend

--- a/requirements/static/py3.4/raet-fedora-28.txt
+++ b/requirements/static/py3.4/raet-fedora-28.txt
@@ -9,15 +9,14 @@ asn1crypto==0.24.0        # via cryptography
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via pytest
 aws-xray-sdk==0.95        # via moto
-backports-abc==0.5        # via tornado
 backports.functools-lru-cache==1.5  # via cheroot
-backports.ssl-match-hostname==3.7.0.1  # via docker, websocket-client
+backports.ssl-match-hostname==3.7.0.1  # via docker
 bcrypt==3.1.6             # via paramiko
 boto3==1.9.132
 boto==2.49.0
 botocore==1.12.132        # via boto3, moto, s3transfer
 cachetools==3.1.0         # via google-auth
-certifi==2019.3.9         # via kubernetes, requests, tornado
+certifi==2019.3.9         # via kubernetes, requests
 cffi==1.12.2
 chardet==3.0.4            # via requests
 cheroot==6.5.4            # via cherrypy
@@ -31,8 +30,6 @@ docker-pycreds==0.4.0     # via docker
 docker==3.7.2
 docutils==0.14            # via botocore
 ecdsa==0.13.2             # via python-jose
-# Next line explicitly commented out by pip-tools-compile because of the following regex: '^enum34==(.*)$'
-# enum34==1.1.6             # via raet
 future==0.17.1            # via python-jose
 gitdb2==2.0.5             # via gitpython
 gitpython==2.1.11
@@ -102,8 +99,7 @@ scandir==1.10.0           # via pathlib2
 scp==0.13.2               # via junos-eznc
 selectors2==2.0.1         # via ncclient
 setproctitle==1.1.10
-singledispatch==3.4.0.3   # via tornado
-six==1.12.0               # via bcrypt, cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, junos-eznc, kubernetes, mock, more-itertools, moto, ncclient, pathlib2, pygit2, pynacl, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, raet, responses, salttesting, singledispatch, tempora, websocket-client
+six==1.12.0               # via bcrypt, cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, junos-eznc, kubernetes, mock, more-itertools, moto, ncclient, pathlib2, pygit2, pynacl, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, raet, responses, salttesting, tempora, websocket-client
 smmap2==2.0.5             # via gitdb2
 strict-rfc3339==0.7
 tempora==1.14.1           # via portend

--- a/requirements/static/py3.4/raet-fedora-29.txt
+++ b/requirements/static/py3.4/raet-fedora-29.txt
@@ -9,15 +9,14 @@ asn1crypto==0.24.0        # via cryptography
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via pytest
 aws-xray-sdk==0.95        # via moto
-backports-abc==0.5        # via tornado
 backports.functools-lru-cache==1.5  # via cheroot
-backports.ssl-match-hostname==3.7.0.1  # via docker, websocket-client
+backports.ssl-match-hostname==3.7.0.1  # via docker
 bcrypt==3.1.6             # via paramiko
 boto3==1.9.132
 boto==2.49.0
 botocore==1.12.132        # via boto3, moto, s3transfer
 cachetools==3.1.0         # via google-auth
-certifi==2019.3.9         # via kubernetes, requests, tornado
+certifi==2019.3.9         # via kubernetes, requests
 cffi==1.12.2
 chardet==3.0.4            # via requests
 cheroot==6.5.4            # via cherrypy
@@ -31,8 +30,6 @@ docker-pycreds==0.4.0     # via docker
 docker==3.7.2
 docutils==0.14            # via botocore
 ecdsa==0.13.2             # via python-jose
-# Next line explicitly commented out by pip-tools-compile because of the following regex: '^enum34==(.*)$'
-# enum34==1.1.6             # via raet
 future==0.17.1            # via python-jose
 gitdb2==2.0.5             # via gitpython
 gitpython==2.1.11
@@ -102,8 +99,7 @@ scandir==1.10.0           # via pathlib2
 scp==0.13.2               # via junos-eznc
 selectors2==2.0.1         # via ncclient
 setproctitle==1.1.10
-singledispatch==3.4.0.3   # via tornado
-six==1.12.0               # via bcrypt, cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, junos-eznc, kubernetes, mock, more-itertools, moto, ncclient, pathlib2, pygit2, pynacl, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, raet, responses, salttesting, singledispatch, tempora, websocket-client
+six==1.12.0               # via bcrypt, cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, junos-eznc, kubernetes, mock, more-itertools, moto, ncclient, pathlib2, pygit2, pynacl, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, raet, responses, salttesting, tempora, websocket-client
 smmap2==2.0.5             # via gitdb2
 strict-rfc3339==0.7
 tempora==1.14.1           # via portend

--- a/requirements/static/py3.4/raet-opensuse-42.txt
+++ b/requirements/static/py3.4/raet-opensuse-42.txt
@@ -9,9 +9,8 @@ asn1crypto==0.24.0        # via cryptography
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via pytest
 aws-xray-sdk==0.95        # via moto
-backports-abc==0.5        # via tornado
 backports.functools-lru-cache==1.5  # via cheroot
-backports.ssl-match-hostname==3.7.0.1  # via docker, websocket-client
+backports.ssl-match-hostname==3.7.0.1  # via docker
 boto3==1.9.132
 boto==2.49.0
 botocore==1.12.132        # via boto3, moto, s3transfer
@@ -30,8 +29,6 @@ docker-pycreds==0.4.0     # via docker
 docker==3.7.2
 docutils==0.14            # via botocore
 ecdsa==0.13.2             # via python-jose
-# Next line explicitly commented out by pip-tools-compile because of the following regex: '^enum34==(.*)$'
-# enum34==1.1.6             # via raet
 future==0.17.1            # via python-jose
 gitdb2==2.0.5             # via gitpython
 gitpython==2.1.11
@@ -93,8 +90,7 @@ salttesting==2017.6.1
 scandir==1.10.0           # via pathlib2
 setproctitle==1.1.10
 setuptools-scm==3.2.0
-singledispatch==3.4.0.3   # via tornado
-six==1.12.0               # via cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, kubernetes, mock, more-itertools, moto, pathlib2, pygit2, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, raet, responses, salttesting, singledispatch, tempora, websocket-client
+six==1.12.0               # via cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, kubernetes, mock, more-itertools, moto, pathlib2, pygit2, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, raet, responses, salttesting, tempora, websocket-client
 smmap2==2.0.5             # via gitdb2
 strict-rfc3339==0.7
 tempora==1.14.1           # via portend

--- a/requirements/static/py3.4/raet-opensuse-leap-15.txt
+++ b/requirements/static/py3.4/raet-opensuse-leap-15.txt
@@ -9,9 +9,8 @@ asn1crypto==0.24.0        # via cryptography
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via pytest
 aws-xray-sdk==0.95        # via moto
-backports-abc==0.5        # via tornado
 backports.functools-lru-cache==1.5  # via cheroot
-backports.ssl-match-hostname==3.7.0.1  # via docker, websocket-client
+backports.ssl-match-hostname==3.7.0.1  # via docker
 boto3==1.9.132
 boto==2.49.0
 botocore==1.12.132        # via boto3, moto, s3transfer
@@ -30,8 +29,6 @@ docker-pycreds==0.4.0     # via docker
 docker==3.7.2
 docutils==0.14            # via botocore
 ecdsa==0.13.2             # via python-jose
-# Next line explicitly commented out by pip-tools-compile because of the following regex: '^enum34==(.*)$'
-# enum34==1.1.6             # via raet
 future==0.17.1            # via python-jose
 gitdb2==2.0.5             # via gitpython
 gitpython==2.1.11
@@ -93,8 +90,7 @@ salttesting==2017.6.1
 scandir==1.10.0           # via pathlib2
 setproctitle==1.1.10
 setuptools-scm==3.2.0
-singledispatch==3.4.0.3   # via tornado
-six==1.12.0               # via cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, kubernetes, mock, more-itertools, moto, pathlib2, pygit2, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, raet, responses, salttesting, singledispatch, tempora, websocket-client
+six==1.12.0               # via cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, kubernetes, mock, more-itertools, moto, pathlib2, pygit2, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, raet, responses, salttesting, tempora, websocket-client
 smmap2==2.0.5             # via gitdb2
 strict-rfc3339==0.7
 tempora==1.14.1           # via portend

--- a/requirements/static/py3.4/raet-ubuntu-16.04.txt
+++ b/requirements/static/py3.4/raet-ubuntu-16.04.txt
@@ -9,14 +9,13 @@ asn1crypto==0.24.0        # via cryptography
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via pytest
 aws-xray-sdk==0.95        # via moto
-backports-abc==0.5        # via tornado
 backports.functools-lru-cache==1.5  # via cheroot
-backports.ssl-match-hostname==3.7.0.1  # via docker, websocket-client
+backports.ssl-match-hostname==3.7.0.1  # via docker
 boto3==1.9.132
 boto==2.49.0
 botocore==1.12.132        # via boto3, moto, s3transfer
 cachetools==3.1.0         # via google-auth
-certifi==2019.3.9         # via kubernetes, requests, tornado
+certifi==2019.3.9         # via kubernetes, requests
 cffi==1.12.2
 chardet==3.0.4            # via requests
 cheroot==6.5.4            # via cherrypy
@@ -30,8 +29,6 @@ docker-pycreds==0.4.0     # via docker
 docker==3.7.2
 docutils==0.14            # via botocore
 ecdsa==0.13.2             # via python-jose
-# Next line explicitly commented out by pip-tools-compile because of the following regex: '^enum34==(.*)$'
-# enum34==1.1.6             # via raet
 future==0.17.1            # via python-jose
 gitdb2==2.0.5             # via gitpython
 gitpython==2.1.11
@@ -100,8 +97,7 @@ scandir==1.10.0           # via pathlib2
 scp==0.13.2               # via junos-eznc
 selectors2==2.0.1         # via ncclient
 setproctitle==1.1.10
-singledispatch==3.4.0.3   # via tornado
-six==1.12.0               # via cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, junos-eznc, kubernetes, mock, more-itertools, moto, ncclient, pathlib2, pygit2, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, raet, responses, salttesting, singledispatch, tempora, websocket-client
+six==1.12.0               # via cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, junos-eznc, kubernetes, mock, more-itertools, moto, ncclient, pathlib2, pygit2, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, raet, responses, salttesting, tempora, websocket-client
 smmap2==2.0.5             # via gitdb2
 strict-rfc3339==0.7
 tempora==1.14.1           # via portend

--- a/requirements/static/py3.4/raet-ubuntu-18.04.txt
+++ b/requirements/static/py3.4/raet-ubuntu-18.04.txt
@@ -9,14 +9,13 @@ asn1crypto==0.24.0        # via cryptography
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via pytest
 aws-xray-sdk==0.95        # via moto
-backports-abc==0.5        # via tornado
 backports.functools-lru-cache==1.5  # via cheroot
-backports.ssl-match-hostname==3.7.0.1  # via docker, websocket-client
+backports.ssl-match-hostname==3.7.0.1  # via docker
 boto3==1.9.132
 boto==2.49.0
 botocore==1.12.132        # via boto3, moto, s3transfer
 cachetools==3.1.0         # via google-auth
-certifi==2019.3.9         # via kubernetes, requests, tornado
+certifi==2019.3.9         # via kubernetes, requests
 cffi==1.12.2
 chardet==3.0.4            # via requests
 cheroot==6.5.4            # via cherrypy
@@ -30,8 +29,6 @@ docker-pycreds==0.4.0     # via docker
 docker==3.7.2
 docutils==0.14            # via botocore
 ecdsa==0.13.2             # via python-jose
-# Next line explicitly commented out by pip-tools-compile because of the following regex: '^enum34==(.*)$'
-# enum34==1.1.6             # via raet
 future==0.17.1            # via python-jose
 gitdb2==2.0.5             # via gitpython
 gitpython==2.1.11
@@ -100,8 +97,7 @@ scandir==1.10.0           # via pathlib2
 scp==0.13.2               # via junos-eznc
 selectors2==2.0.1         # via ncclient
 setproctitle==1.1.10
-singledispatch==3.4.0.3   # via tornado
-six==1.12.0               # via cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, junos-eznc, kubernetes, mock, more-itertools, moto, ncclient, pathlib2, pygit2, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, raet, responses, salttesting, singledispatch, tempora, websocket-client
+six==1.12.0               # via cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, junos-eznc, kubernetes, mock, more-itertools, moto, ncclient, pathlib2, pygit2, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, raet, responses, salttesting, tempora, websocket-client
 smmap2==2.0.5             # via gitdb2
 strict-rfc3339==0.7
 tempora==1.14.1           # via portend

--- a/requirements/static/py3.4/zeromq-arch.txt
+++ b/requirements/static/py3.4/zeromq-arch.txt
@@ -9,14 +9,13 @@ asn1crypto==0.24.0        # via cryptography
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via pytest
 aws-xray-sdk==0.95        # via moto
-backports-abc==0.5        # via tornado
 backports.functools-lru-cache==1.5  # via cheroot
-backports.ssl-match-hostname==3.7.0.1  # via docker, websocket-client
+backports.ssl-match-hostname==3.7.0.1  # via docker
 boto3==1.9.132
 boto==2.49.0
 botocore==1.12.132        # via boto3, moto, s3transfer
 cachetools==3.1.0         # via google-auth
-certifi==2019.3.9         # via kubernetes, requests, tornado
+certifi==2019.3.9         # via kubernetes, requests
 cffi==1.12.2
 chardet==3.0.4            # via requests
 cheroot==6.5.4            # via cherrypy
@@ -89,8 +88,7 @@ s3transfer==0.2.0         # via boto3
 salttesting==2017.6.1
 scandir==1.10.0           # via pathlib2
 setproctitle==1.1.10
-singledispatch==3.4.0.3   # via tornado
-six==1.12.0               # via cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, kubernetes, mock, more-itertools, moto, pathlib2, pygit2, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, responses, salttesting, singledispatch, tempora, websocket-client
+six==1.12.0               # via cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, kubernetes, mock, more-itertools, moto, pathlib2, pygit2, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, responses, salttesting, tempora, websocket-client
 smmap2==2.0.5             # via gitdb2
 strict-rfc3339==0.7
 tempora==1.14.1           # via portend

--- a/requirements/static/py3.4/zeromq-centos-7.txt
+++ b/requirements/static/py3.4/zeromq-centos-7.txt
@@ -9,14 +9,13 @@ asn1crypto==0.24.0        # via cryptography
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via pytest
 aws-xray-sdk==0.95        # via moto
-backports-abc==0.5        # via tornado
 backports.functools-lru-cache==1.5  # via cheroot
-backports.ssl-match-hostname==3.7.0.1  # via docker, websocket-client
+backports.ssl-match-hostname==3.7.0.1  # via docker
 boto3==1.9.132
 boto==2.49.0
 botocore==1.12.132        # via boto3, moto, s3transfer
 cachetools==3.1.0         # via google-auth
-certifi==2019.3.9         # via kubernetes, requests, tornado
+certifi==2019.3.9         # via kubernetes, requests
 cffi==1.12.2
 chardet==3.0.4            # via requests
 cheroot==6.5.4            # via cherrypy
@@ -99,8 +98,7 @@ scandir==1.10.0           # via pathlib2
 scp==0.13.2               # via junos-eznc
 selectors2==2.0.1         # via ncclient
 setproctitle==1.1.10
-singledispatch==3.4.0.3   # via tornado
-six==1.12.0               # via cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, junos-eznc, kazoo, kubernetes, mock, more-itertools, moto, ncclient, pathlib2, pygit2, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, responses, salttesting, singledispatch, tempora, websocket-client
+six==1.12.0               # via cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, junos-eznc, kazoo, kubernetes, mock, more-itertools, moto, ncclient, pathlib2, pygit2, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, responses, salttesting, tempora, websocket-client
 smmap2==2.0.5             # via gitdb2
 strict-rfc3339==0.7
 tempora==1.14.1           # via portend

--- a/requirements/static/py3.4/zeromq-debian-8.txt
+++ b/requirements/static/py3.4/zeromq-debian-8.txt
@@ -9,14 +9,13 @@ asn1crypto==0.24.0        # via cryptography
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via pytest
 aws-xray-sdk==0.95        # via moto
-backports-abc==0.5        # via tornado
 backports.functools-lru-cache==1.5  # via cheroot
-backports.ssl-match-hostname==3.7.0.1  # via docker, websocket-client
+backports.ssl-match-hostname==3.7.0.1  # via docker
 boto3==1.9.132
 boto==2.49.0
 botocore==1.12.132        # via boto3, moto, s3transfer
 cachetools==3.1.0         # via google-auth
-certifi==2019.3.9         # via kubernetes, requests, tornado
+certifi==2019.3.9         # via kubernetes, requests
 cffi==1.12.2
 chardet==3.0.4            # via requests
 cheroot==6.5.4            # via cherrypy
@@ -98,8 +97,7 @@ scandir==1.10.0           # via pathlib2
 scp==0.13.2               # via junos-eznc
 selectors2==2.0.1         # via ncclient
 setproctitle==1.1.10
-singledispatch==3.4.0.3   # via tornado
-six==1.12.0               # via cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, junos-eznc, kubernetes, mock, more-itertools, moto, ncclient, pathlib2, pygit2, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, responses, salttesting, singledispatch, tempora, websocket-client
+six==1.12.0               # via cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, junos-eznc, kubernetes, mock, more-itertools, moto, ncclient, pathlib2, pygit2, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, responses, salttesting, tempora, websocket-client
 smmap2==2.0.5             # via gitdb2
 strict-rfc3339==0.7
 tempora==1.14.1           # via portend

--- a/requirements/static/py3.4/zeromq-debian-9.txt
+++ b/requirements/static/py3.4/zeromq-debian-9.txt
@@ -9,14 +9,13 @@ asn1crypto==0.24.0        # via cryptography
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via pytest
 aws-xray-sdk==0.95        # via moto
-backports-abc==0.5        # via tornado
 backports.functools-lru-cache==1.5  # via cheroot
-backports.ssl-match-hostname==3.7.0.1  # via docker, websocket-client
+backports.ssl-match-hostname==3.7.0.1  # via docker
 boto3==1.9.132
 boto==2.49.0
 botocore==1.12.132        # via boto3, moto, s3transfer
 cachetools==3.1.0         # via google-auth
-certifi==2019.3.9         # via kubernetes, requests, tornado
+certifi==2019.3.9         # via kubernetes, requests
 cffi==1.12.2
 chardet==3.0.4            # via requests
 cheroot==6.5.4            # via cherrypy
@@ -98,8 +97,7 @@ scandir==1.10.0           # via pathlib2
 scp==0.13.2               # via junos-eznc
 selectors2==2.0.1         # via ncclient
 setproctitle==1.1.10
-singledispatch==3.4.0.3   # via tornado
-six==1.12.0               # via cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, junos-eznc, kubernetes, mock, more-itertools, moto, ncclient, pathlib2, pygit2, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, responses, salttesting, singledispatch, tempora, websocket-client
+six==1.12.0               # via cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, junos-eznc, kubernetes, mock, more-itertools, moto, ncclient, pathlib2, pygit2, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, responses, salttesting, tempora, websocket-client
 smmap2==2.0.5             # via gitdb2
 strict-rfc3339==0.7
 tempora==1.14.1           # via portend

--- a/requirements/static/py3.4/zeromq-fedora-28.txt
+++ b/requirements/static/py3.4/zeromq-fedora-28.txt
@@ -9,15 +9,14 @@ asn1crypto==0.24.0        # via cryptography
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via pytest
 aws-xray-sdk==0.95        # via moto
-backports-abc==0.5        # via tornado
 backports.functools-lru-cache==1.5  # via cheroot
-backports.ssl-match-hostname==3.7.0.1  # via docker, websocket-client
+backports.ssl-match-hostname==3.7.0.1  # via docker
 bcrypt==3.1.6             # via paramiko
 boto3==1.9.132
 boto==2.49.0
 botocore==1.12.132        # via boto3, moto, s3transfer
 cachetools==3.1.0         # via google-auth
-certifi==2019.3.9         # via kubernetes, requests, tornado
+certifi==2019.3.9         # via kubernetes, requests
 cffi==1.12.2
 chardet==3.0.4            # via requests
 cheroot==6.5.4            # via cherrypy
@@ -100,8 +99,7 @@ scandir==1.10.0           # via pathlib2
 scp==0.13.2               # via junos-eznc
 selectors2==2.0.1         # via ncclient
 setproctitle==1.1.10
-singledispatch==3.4.0.3   # via tornado
-six==1.12.0               # via bcrypt, cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, junos-eznc, kubernetes, mock, more-itertools, moto, ncclient, pathlib2, pygit2, pynacl, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, responses, salttesting, singledispatch, tempora, websocket-client
+six==1.12.0               # via bcrypt, cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, junos-eznc, kubernetes, mock, more-itertools, moto, ncclient, pathlib2, pygit2, pynacl, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, responses, salttesting, tempora, websocket-client
 smmap2==2.0.5             # via gitdb2
 strict-rfc3339==0.7
 tempora==1.14.1           # via portend

--- a/requirements/static/py3.4/zeromq-fedora-29.txt
+++ b/requirements/static/py3.4/zeromq-fedora-29.txt
@@ -9,15 +9,14 @@ asn1crypto==0.24.0        # via cryptography
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via pytest
 aws-xray-sdk==0.95        # via moto
-backports-abc==0.5        # via tornado
 backports.functools-lru-cache==1.5  # via cheroot
-backports.ssl-match-hostname==3.7.0.1  # via docker, websocket-client
+backports.ssl-match-hostname==3.7.0.1  # via docker
 bcrypt==3.1.6             # via paramiko
 boto3==1.9.132
 boto==2.49.0
 botocore==1.12.132        # via boto3, moto, s3transfer
 cachetools==3.1.0         # via google-auth
-certifi==2019.3.9         # via kubernetes, requests, tornado
+certifi==2019.3.9         # via kubernetes, requests
 cffi==1.12.2
 chardet==3.0.4            # via requests
 cheroot==6.5.4            # via cherrypy
@@ -100,8 +99,7 @@ scandir==1.10.0           # via pathlib2
 scp==0.13.2               # via junos-eznc
 selectors2==2.0.1         # via ncclient
 setproctitle==1.1.10
-singledispatch==3.4.0.3   # via tornado
-six==1.12.0               # via bcrypt, cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, junos-eznc, kubernetes, mock, more-itertools, moto, ncclient, pathlib2, pygit2, pynacl, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, responses, salttesting, singledispatch, tempora, websocket-client
+six==1.12.0               # via bcrypt, cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, junos-eznc, kubernetes, mock, more-itertools, moto, ncclient, pathlib2, pygit2, pynacl, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, responses, salttesting, tempora, websocket-client
 smmap2==2.0.5             # via gitdb2
 strict-rfc3339==0.7
 tempora==1.14.1           # via portend

--- a/requirements/static/py3.4/zeromq-opensuse-42.txt
+++ b/requirements/static/py3.4/zeromq-opensuse-42.txt
@@ -9,9 +9,8 @@ asn1crypto==0.24.0        # via cryptography
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via pytest
 aws-xray-sdk==0.95        # via moto
-backports-abc==0.5        # via tornado
 backports.functools-lru-cache==1.5  # via cheroot
-backports.ssl-match-hostname==3.7.0.1  # via docker, websocket-client
+backports.ssl-match-hostname==3.7.0.1  # via docker
 boto3==1.9.132
 boto==2.49.0
 botocore==1.12.132        # via boto3, moto, s3transfer
@@ -91,8 +90,7 @@ salttesting==2017.6.1
 scandir==1.10.0           # via pathlib2
 setproctitle==1.1.10
 setuptools-scm==3.2.0
-singledispatch==3.4.0.3   # via tornado
-six==1.12.0               # via cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, kubernetes, mock, more-itertools, moto, pathlib2, pygit2, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, responses, salttesting, singledispatch, tempora, websocket-client
+six==1.12.0               # via cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, kubernetes, mock, more-itertools, moto, pathlib2, pygit2, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, responses, salttesting, tempora, websocket-client
 smmap2==2.0.5             # via gitdb2
 strict-rfc3339==0.7
 tempora==1.14.1           # via portend

--- a/requirements/static/py3.4/zeromq-opensuse-leap-15.txt
+++ b/requirements/static/py3.4/zeromq-opensuse-leap-15.txt
@@ -9,9 +9,8 @@ asn1crypto==0.24.0        # via cryptography
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via pytest
 aws-xray-sdk==0.95        # via moto
-backports-abc==0.5        # via tornado
 backports.functools-lru-cache==1.5  # via cheroot
-backports.ssl-match-hostname==3.7.0.1  # via docker, websocket-client
+backports.ssl-match-hostname==3.7.0.1  # via docker
 boto3==1.9.132
 boto==2.49.0
 botocore==1.12.132        # via boto3, moto, s3transfer
@@ -91,8 +90,7 @@ salttesting==2017.6.1
 scandir==1.10.0           # via pathlib2
 setproctitle==1.1.10
 setuptools-scm==3.2.0
-singledispatch==3.4.0.3   # via tornado
-six==1.12.0               # via cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, kubernetes, mock, more-itertools, moto, pathlib2, pygit2, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, responses, salttesting, singledispatch, tempora, websocket-client
+six==1.12.0               # via cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, kubernetes, mock, more-itertools, moto, pathlib2, pygit2, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, responses, salttesting, tempora, websocket-client
 smmap2==2.0.5             # via gitdb2
 strict-rfc3339==0.7
 tempora==1.14.1           # via portend

--- a/requirements/static/py3.4/zeromq-ubuntu-16.04.txt
+++ b/requirements/static/py3.4/zeromq-ubuntu-16.04.txt
@@ -9,14 +9,13 @@ asn1crypto==0.24.0        # via cryptography
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via pytest
 aws-xray-sdk==0.95        # via moto
-backports-abc==0.5        # via tornado
 backports.functools-lru-cache==1.5  # via cheroot
-backports.ssl-match-hostname==3.7.0.1  # via docker, websocket-client
+backports.ssl-match-hostname==3.7.0.1  # via docker
 boto3==1.9.132
 boto==2.49.0
 botocore==1.12.132        # via boto3, moto, s3transfer
 cachetools==3.1.0         # via google-auth
-certifi==2019.3.9         # via kubernetes, requests, tornado
+certifi==2019.3.9         # via kubernetes, requests
 cffi==1.12.2
 chardet==3.0.4            # via requests
 cheroot==6.5.4            # via cherrypy
@@ -98,8 +97,7 @@ scandir==1.10.0           # via pathlib2
 scp==0.13.2               # via junos-eznc
 selectors2==2.0.1         # via ncclient
 setproctitle==1.1.10
-singledispatch==3.4.0.3   # via tornado
-six==1.12.0               # via cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, junos-eznc, kubernetes, mock, more-itertools, moto, ncclient, pathlib2, pygit2, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, responses, salttesting, singledispatch, tempora, websocket-client
+six==1.12.0               # via cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, junos-eznc, kubernetes, mock, more-itertools, moto, ncclient, pathlib2, pygit2, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, responses, salttesting, tempora, websocket-client
 smmap2==2.0.5             # via gitdb2
 strict-rfc3339==0.7
 tempora==1.14.1           # via portend

--- a/requirements/static/py3.4/zeromq-ubuntu-18.04.txt
+++ b/requirements/static/py3.4/zeromq-ubuntu-18.04.txt
@@ -9,14 +9,13 @@ asn1crypto==0.24.0        # via cryptography
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via pytest
 aws-xray-sdk==0.95        # via moto
-backports-abc==0.5        # via tornado
 backports.functools-lru-cache==1.5  # via cheroot
-backports.ssl-match-hostname==3.7.0.1  # via docker, websocket-client
+backports.ssl-match-hostname==3.7.0.1  # via docker
 boto3==1.9.132
 boto==2.49.0
 botocore==1.12.132        # via boto3, moto, s3transfer
 cachetools==3.1.0         # via google-auth
-certifi==2019.3.9         # via kubernetes, requests, tornado
+certifi==2019.3.9         # via kubernetes, requests
 cffi==1.12.2
 chardet==3.0.4            # via requests
 cheroot==6.5.4            # via cherrypy
@@ -98,8 +97,7 @@ scandir==1.10.0           # via pathlib2
 scp==0.13.2               # via junos-eznc
 selectors2==2.0.1         # via ncclient
 setproctitle==1.1.10
-singledispatch==3.4.0.3   # via tornado
-six==1.12.0               # via cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, junos-eznc, kubernetes, mock, more-itertools, moto, ncclient, pathlib2, pygit2, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, responses, salttesting, singledispatch, tempora, websocket-client
+six==1.12.0               # via cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, junos-eznc, kubernetes, mock, more-itertools, moto, ncclient, pathlib2, pygit2, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, responses, salttesting, tempora, websocket-client
 smmap2==2.0.5             # via gitdb2
 strict-rfc3339==0.7
 tempora==1.14.1           # via portend

--- a/requirements/static/py3.5/cloud.txt
+++ b/requirements/static/py3.5/cloud.txt
@@ -91,22 +91,25 @@ azure==4.0.0
 certifi==2019.3.9         # via msrest, requests
 cffi==1.12.2              # via azure-datalake-store, cryptography
 chardet==3.0.4            # via requests
-cryptography==2.6.1       # via adal, azure-cosmosdb-table, azure-keyvault, azure-storage-common, requests-ntlm
+cryptography==2.6.1       # via adal, azure-cosmosdb-table, azure-keyvault, azure-storage-common, requests-ntlm, smbprotocol
 idna==2.8                 # via requests
 isodate==0.6.0            # via msrest
 msrest==0.6.6             # via azure-applicationinsights, azure-eventgrid, azure-keyvault, azure-loganalytics, azure-mgmt-cdn, azure-mgmt-compute, azure-mgmt-containerinstance, azure-mgmt-containerregistry, azure-mgmt-containerservice, azure-mgmt-dns, azure-mgmt-eventhub, azure-mgmt-keyvault, azure-mgmt-media, azure-mgmt-network, azure-mgmt-rdbms, azure-mgmt-resource, azure-mgmt-servicebus, azure-mgmt-servicefabric, azure-mgmt-signalr, azure-servicefabric, msrestazure
 msrestazure==0.6.0        # via azure-batch, azure-eventgrid, azure-graphrbac, azure-keyvault, azure-mgmt-advisor, azure-mgmt-applicationinsights, azure-mgmt-authorization, azure-mgmt-batch, azure-mgmt-batchai, azure-mgmt-billing, azure-mgmt-cdn, azure-mgmt-cognitiveservices, azure-mgmt-commerce, azure-mgmt-compute, azure-mgmt-consumption, azure-mgmt-containerinstance, azure-mgmt-containerregistry, azure-mgmt-containerservice, azure-mgmt-cosmosdb, azure-mgmt-datafactory, azure-mgmt-datalake-analytics, azure-mgmt-datalake-store, azure-mgmt-datamigration, azure-mgmt-devspaces, azure-mgmt-devtestlabs, azure-mgmt-dns, azure-mgmt-eventgrid, azure-mgmt-eventhub, azure-mgmt-hanaonazure, azure-mgmt-iotcentral, azure-mgmt-iothub, azure-mgmt-iothubprovisioningservices, azure-mgmt-keyvault, azure-mgmt-loganalytics, azure-mgmt-logic, azure-mgmt-machinelearningcompute, azure-mgmt-managementgroups, azure-mgmt-managementpartner, azure-mgmt-maps, azure-mgmt-marketplaceordering, azure-mgmt-media, azure-mgmt-monitor, azure-mgmt-msi, azure-mgmt-network, azure-mgmt-notificationhubs, azure-mgmt-policyinsights, azure-mgmt-powerbiembedded, azure-mgmt-rdbms, azure-mgmt-recoveryservices, azure-mgmt-recoveryservicesbackup, azure-mgmt-redis, azure-mgmt-relay, azure-mgmt-reservations, azure-mgmt-resource, azure-mgmt-scheduler, azure-mgmt-search, azure-mgmt-servicebus, azure-mgmt-servicefabric, azure-mgmt-signalr, azure-mgmt-sql, azure-mgmt-storage, azure-mgmt-subscription, azure-mgmt-trafficmanager, azure-mgmt-web
 netaddr==0.7.19
-ntlm-auth==1.3.0          # via requests-ntlm
+ntlm-auth==1.3.0          # via requests-ntlm, smbprotocol
 oauthlib==3.0.1           # via requests-oauthlib
 profitbricks==4.1.3
+pyasn1==0.4.5             # via smbprotocol
 pycparser==2.19           # via cffi
 pyjwt==1.7.1              # via adal
+pypsexec==0.1.0
 python-dateutil==2.8.0    # via adal, azure-cosmosdb-table, azure-storage-common
 pywinrm==0.3.0
 requests-ntlm==1.1.0      # via pywinrm
 requests-oauthlib==1.2.0  # via msrest
 requests==2.21.0          # via adal, azure-cosmosdb-table, azure-datalake-store, azure-keyvault, azure-servicebus, azure-servicemanagement-legacy, azure-storage-common, msrest, profitbricks, pywinrm, requests-ntlm, requests-oauthlib
-six==1.12.0               # via cryptography, isodate, profitbricks, python-dateutil, pywinrm
+six==1.12.0               # via cryptography, isodate, profitbricks, pypsexec, python-dateutil, pywinrm, smbprotocol
+smbprotocol==0.1.1        # via pypsexec
 urllib3==1.24.2           # via requests
 xmltodict==0.12.0         # via pywinrm

--- a/requirements/static/py3.5/raet-arch.txt
+++ b/requirements/static/py3.5/raet-arch.txt
@@ -9,14 +9,12 @@ asn1crypto==0.24.0        # via cryptography
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via pytest
 aws-xray-sdk==0.95        # via moto
-backports-abc==0.5        # via tornado
 backports.functools-lru-cache==1.5  # via cheroot
-backports.ssl-match-hostname==3.7.0.1  # via websocket-client
 boto3==1.9.132
 boto==2.49.0
 botocore==1.12.132        # via boto3, moto, s3transfer
 cachetools==3.1.0         # via google-auth
-certifi==2019.3.9         # via kubernetes, requests, tornado
+certifi==2019.3.9         # via kubernetes, requests
 cffi==1.12.2
 chardet==3.0.4            # via requests
 cheroot==6.5.4            # via cherrypy
@@ -30,8 +28,6 @@ docker-pycreds==0.4.0     # via docker
 docker==3.7.2
 docutils==0.14            # via botocore
 ecdsa==0.13.2             # via python-jose
-# Next line explicitly commented out by pip-tools-compile because of the following regex: '^enum34==(.*)$'
-# enum34==1.1.6             # via raet
 future==0.17.1            # via python-jose
 gitdb2==2.0.5             # via gitpython
 gitpython==2.1.11
@@ -90,8 +86,7 @@ rsa==4.0                  # via google-auth
 s3transfer==0.2.0         # via boto3
 salttesting==2017.6.1
 setproctitle==1.1.10
-singledispatch==3.4.0.3   # via tornado
-six==1.12.0               # via cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, kubernetes, mock, more-itertools, moto, pathlib2, pygit2, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, raet, responses, salttesting, singledispatch, tempora, websocket-client
+six==1.12.0               # via cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, kubernetes, mock, more-itertools, moto, pathlib2, pygit2, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, raet, responses, salttesting, tempora, websocket-client
 smmap2==2.0.5             # via gitdb2
 strict-rfc3339==0.7
 tempora==1.14.1           # via portend

--- a/requirements/static/py3.5/raet-centos-7.txt
+++ b/requirements/static/py3.5/raet-centos-7.txt
@@ -9,14 +9,12 @@ asn1crypto==0.24.0        # via cryptography
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via pytest
 aws-xray-sdk==0.95        # via moto
-backports-abc==0.5        # via tornado
 backports.functools-lru-cache==1.5  # via cheroot
-backports.ssl-match-hostname==3.7.0.1  # via websocket-client
 boto3==1.9.132
 boto==2.49.0
 botocore==1.12.132        # via boto3, moto, s3transfer
 cachetools==3.1.0         # via google-auth
-certifi==2019.3.9         # via kubernetes, requests, tornado
+certifi==2019.3.9         # via kubernetes, requests
 cffi==1.12.2
 chardet==3.0.4            # via requests
 cheroot==6.5.4            # via cherrypy
@@ -30,8 +28,6 @@ docker-pycreds==0.4.0     # via docker
 docker==3.7.2
 docutils==0.14            # via botocore
 ecdsa==0.13.2             # via python-jose
-# Next line explicitly commented out by pip-tools-compile because of the following regex: '^enum34==(.*)$'
-# enum34==1.1.6             # via raet
 future==0.17.1            # via python-jose
 gitdb2==2.0.5             # via gitpython
 gitpython==2.1.11
@@ -99,8 +95,7 @@ s3transfer==0.2.0         # via boto3
 salttesting==2017.6.1
 scp==0.13.2               # via junos-eznc
 setproctitle==1.1.10
-singledispatch==3.4.0.3   # via tornado
-six==1.12.0               # via cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, junos-eznc, kazoo, kubernetes, mock, more-itertools, moto, ncclient, pathlib2, pygit2, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, raet, responses, salttesting, singledispatch, tempora, websocket-client
+six==1.12.0               # via cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, junos-eznc, kazoo, kubernetes, mock, more-itertools, moto, ncclient, pathlib2, pygit2, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, raet, responses, salttesting, tempora, websocket-client
 smmap2==2.0.5             # via gitdb2
 strict-rfc3339==0.7
 tempora==1.14.1           # via portend

--- a/requirements/static/py3.5/raet-debian-8.txt
+++ b/requirements/static/py3.5/raet-debian-8.txt
@@ -9,14 +9,12 @@ asn1crypto==0.24.0        # via cryptography
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via pytest
 aws-xray-sdk==0.95        # via moto
-backports-abc==0.5        # via tornado
 backports.functools-lru-cache==1.5  # via cheroot
-backports.ssl-match-hostname==3.7.0.1  # via websocket-client
 boto3==1.9.132
 boto==2.49.0
 botocore==1.12.132        # via boto3, moto, s3transfer
 cachetools==3.1.0         # via google-auth
-certifi==2019.3.9         # via kubernetes, requests, tornado
+certifi==2019.3.9         # via kubernetes, requests
 cffi==1.12.2
 chardet==3.0.4            # via requests
 cheroot==6.5.4            # via cherrypy
@@ -30,8 +28,6 @@ docker-pycreds==0.4.0     # via docker
 docker==3.7.2
 docutils==0.14            # via botocore
 ecdsa==0.13.2             # via python-jose
-# Next line explicitly commented out by pip-tools-compile because of the following regex: '^enum34==(.*)$'
-# enum34==1.1.6             # via raet
 future==0.17.1            # via python-jose
 gitdb2==2.0.5             # via gitpython
 gitpython==2.1.11
@@ -98,8 +94,7 @@ s3transfer==0.2.0         # via boto3
 salttesting==2017.6.1
 scp==0.13.2               # via junos-eznc
 setproctitle==1.1.10
-singledispatch==3.4.0.3   # via tornado
-six==1.12.0               # via cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, junos-eznc, kubernetes, mock, more-itertools, moto, ncclient, pathlib2, pygit2, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, raet, responses, salttesting, singledispatch, tempora, websocket-client
+six==1.12.0               # via cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, junos-eznc, kubernetes, mock, more-itertools, moto, ncclient, pathlib2, pygit2, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, raet, responses, salttesting, tempora, websocket-client
 smmap2==2.0.5             # via gitdb2
 strict-rfc3339==0.7
 tempora==1.14.1           # via portend

--- a/requirements/static/py3.5/raet-debian-9.txt
+++ b/requirements/static/py3.5/raet-debian-9.txt
@@ -9,14 +9,12 @@ asn1crypto==0.24.0        # via cryptography
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via pytest
 aws-xray-sdk==0.95        # via moto
-backports-abc==0.5        # via tornado
 backports.functools-lru-cache==1.5  # via cheroot
-backports.ssl-match-hostname==3.7.0.1  # via websocket-client
 boto3==1.9.132
 boto==2.49.0
 botocore==1.12.132        # via boto3, moto, s3transfer
 cachetools==3.1.0         # via google-auth
-certifi==2019.3.9         # via kubernetes, requests, tornado
+certifi==2019.3.9         # via kubernetes, requests
 cffi==1.12.2
 chardet==3.0.4            # via requests
 cheroot==6.5.4            # via cherrypy
@@ -30,8 +28,6 @@ docker-pycreds==0.4.0     # via docker
 docker==3.7.2
 docutils==0.14            # via botocore
 ecdsa==0.13.2             # via python-jose
-# Next line explicitly commented out by pip-tools-compile because of the following regex: '^enum34==(.*)$'
-# enum34==1.1.6             # via raet
 future==0.17.1            # via python-jose
 gitdb2==2.0.5             # via gitpython
 gitpython==2.1.11
@@ -98,8 +94,7 @@ s3transfer==0.2.0         # via boto3
 salttesting==2017.6.1
 scp==0.13.2               # via junos-eznc
 setproctitle==1.1.10
-singledispatch==3.4.0.3   # via tornado
-six==1.12.0               # via cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, junos-eznc, kubernetes, mock, more-itertools, moto, ncclient, pathlib2, pygit2, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, raet, responses, salttesting, singledispatch, tempora, websocket-client
+six==1.12.0               # via cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, junos-eznc, kubernetes, mock, more-itertools, moto, ncclient, pathlib2, pygit2, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, raet, responses, salttesting, tempora, websocket-client
 smmap2==2.0.5             # via gitdb2
 strict-rfc3339==0.7
 tempora==1.14.1           # via portend

--- a/requirements/static/py3.5/raet-fedora-28.txt
+++ b/requirements/static/py3.5/raet-fedora-28.txt
@@ -9,15 +9,13 @@ asn1crypto==0.24.0        # via cryptography
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via pytest
 aws-xray-sdk==0.95        # via moto
-backports-abc==0.5        # via tornado
 backports.functools-lru-cache==1.5  # via cheroot
-backports.ssl-match-hostname==3.7.0.1  # via websocket-client
 bcrypt==3.1.6             # via paramiko
 boto3==1.9.132
 boto==2.49.0
 botocore==1.12.132        # via boto3, moto, s3transfer
 cachetools==3.1.0         # via google-auth
-certifi==2019.3.9         # via kubernetes, requests, tornado
+certifi==2019.3.9         # via kubernetes, requests
 cffi==1.12.2
 chardet==3.0.4            # via requests
 cheroot==6.5.4            # via cherrypy
@@ -31,8 +29,6 @@ docker-pycreds==0.4.0     # via docker
 docker==3.7.2
 docutils==0.14            # via botocore
 ecdsa==0.13.2             # via python-jose
-# Next line explicitly commented out by pip-tools-compile because of the following regex: '^enum34==(.*)$'
-# enum34==1.1.6             # via raet
 future==0.17.1            # via python-jose
 gitdb2==2.0.5             # via gitpython
 gitpython==2.1.11
@@ -100,8 +96,7 @@ s3transfer==0.2.0         # via boto3
 salttesting==2017.6.1
 scp==0.13.2               # via junos-eznc
 setproctitle==1.1.10
-singledispatch==3.4.0.3   # via tornado
-six==1.12.0               # via bcrypt, cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, junos-eznc, kubernetes, mock, more-itertools, moto, ncclient, pathlib2, pygit2, pynacl, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, raet, responses, salttesting, singledispatch, tempora, websocket-client
+six==1.12.0               # via bcrypt, cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, junos-eznc, kubernetes, mock, more-itertools, moto, ncclient, pathlib2, pygit2, pynacl, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, raet, responses, salttesting, tempora, websocket-client
 smmap2==2.0.5             # via gitdb2
 strict-rfc3339==0.7
 tempora==1.14.1           # via portend

--- a/requirements/static/py3.5/raet-fedora-29.txt
+++ b/requirements/static/py3.5/raet-fedora-29.txt
@@ -9,15 +9,13 @@ asn1crypto==0.24.0        # via cryptography
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via pytest
 aws-xray-sdk==0.95        # via moto
-backports-abc==0.5        # via tornado
 backports.functools-lru-cache==1.5  # via cheroot
-backports.ssl-match-hostname==3.7.0.1  # via websocket-client
 bcrypt==3.1.6             # via paramiko
 boto3==1.9.132
 boto==2.49.0
 botocore==1.12.132        # via boto3, moto, s3transfer
 cachetools==3.1.0         # via google-auth
-certifi==2019.3.9         # via kubernetes, requests, tornado
+certifi==2019.3.9         # via kubernetes, requests
 cffi==1.12.2
 chardet==3.0.4            # via requests
 cheroot==6.5.4            # via cherrypy
@@ -31,8 +29,6 @@ docker-pycreds==0.4.0     # via docker
 docker==3.7.2
 docutils==0.14            # via botocore
 ecdsa==0.13.2             # via python-jose
-# Next line explicitly commented out by pip-tools-compile because of the following regex: '^enum34==(.*)$'
-# enum34==1.1.6             # via raet
 future==0.17.1            # via python-jose
 gitdb2==2.0.5             # via gitpython
 gitpython==2.1.11
@@ -100,8 +96,7 @@ s3transfer==0.2.0         # via boto3
 salttesting==2017.6.1
 scp==0.13.2               # via junos-eznc
 setproctitle==1.1.10
-singledispatch==3.4.0.3   # via tornado
-six==1.12.0               # via bcrypt, cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, junos-eznc, kubernetes, mock, more-itertools, moto, ncclient, pathlib2, pygit2, pynacl, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, raet, responses, salttesting, singledispatch, tempora, websocket-client
+six==1.12.0               # via bcrypt, cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, junos-eznc, kubernetes, mock, more-itertools, moto, ncclient, pathlib2, pygit2, pynacl, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, raet, responses, salttesting, tempora, websocket-client
 smmap2==2.0.5             # via gitdb2
 strict-rfc3339==0.7
 tempora==1.14.1           # via portend

--- a/requirements/static/py3.5/raet-opensuse-42.txt
+++ b/requirements/static/py3.5/raet-opensuse-42.txt
@@ -9,9 +9,7 @@ asn1crypto==0.24.0        # via cryptography
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via pytest
 aws-xray-sdk==0.95        # via moto
-backports-abc==0.5        # via tornado
 backports.functools-lru-cache==1.5  # via cheroot
-backports.ssl-match-hostname==3.7.0.1  # via websocket-client
 boto3==1.9.132
 boto==2.49.0
 botocore==1.12.132        # via boto3, moto, s3transfer
@@ -30,8 +28,6 @@ docker-pycreds==0.4.0     # via docker
 docker==3.7.2
 docutils==0.14            # via botocore
 ecdsa==0.13.2             # via python-jose
-# Next line explicitly commented out by pip-tools-compile because of the following regex: '^enum34==(.*)$'
-# enum34==1.1.6             # via raet
 future==0.17.1            # via python-jose
 gitdb2==2.0.5             # via gitpython
 gitpython==2.1.11
@@ -92,8 +88,7 @@ s3transfer==0.2.0         # via boto3
 salttesting==2017.6.1
 setproctitle==1.1.10
 setuptools-scm==3.2.0
-singledispatch==3.4.0.3   # via tornado
-six==1.12.0               # via cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, kubernetes, mock, more-itertools, moto, pathlib2, pygit2, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, raet, responses, salttesting, singledispatch, tempora, websocket-client
+six==1.12.0               # via cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, kubernetes, mock, more-itertools, moto, pathlib2, pygit2, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, raet, responses, salttesting, tempora, websocket-client
 smmap2==2.0.5             # via gitdb2
 strict-rfc3339==0.7
 tempora==1.14.1           # via portend

--- a/requirements/static/py3.5/raet-opensuse-leap-15.txt
+++ b/requirements/static/py3.5/raet-opensuse-leap-15.txt
@@ -9,9 +9,7 @@ asn1crypto==0.24.0        # via cryptography
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via pytest
 aws-xray-sdk==0.95        # via moto
-backports-abc==0.5        # via tornado
 backports.functools-lru-cache==1.5  # via cheroot
-backports.ssl-match-hostname==3.7.0.1  # via websocket-client
 boto3==1.9.132
 boto==2.49.0
 botocore==1.12.132        # via boto3, moto, s3transfer
@@ -30,8 +28,6 @@ docker-pycreds==0.4.0     # via docker
 docker==3.7.2
 docutils==0.14            # via botocore
 ecdsa==0.13.2             # via python-jose
-# Next line explicitly commented out by pip-tools-compile because of the following regex: '^enum34==(.*)$'
-# enum34==1.1.6             # via raet
 future==0.17.1            # via python-jose
 gitdb2==2.0.5             # via gitpython
 gitpython==2.1.11
@@ -92,8 +88,7 @@ s3transfer==0.2.0         # via boto3
 salttesting==2017.6.1
 setproctitle==1.1.10
 setuptools-scm==3.2.0
-singledispatch==3.4.0.3   # via tornado
-six==1.12.0               # via cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, kubernetes, mock, more-itertools, moto, pathlib2, pygit2, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, raet, responses, salttesting, singledispatch, tempora, websocket-client
+six==1.12.0               # via cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, kubernetes, mock, more-itertools, moto, pathlib2, pygit2, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, raet, responses, salttesting, tempora, websocket-client
 smmap2==2.0.5             # via gitdb2
 strict-rfc3339==0.7
 tempora==1.14.1           # via portend

--- a/requirements/static/py3.5/raet-osx.txt
+++ b/requirements/static/py3.5/raet-osx.txt
@@ -9,9 +9,9 @@ asn1crypto==0.24.0        # via cryptography
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via pytest
 aws-xray-sdk==0.95        # via moto
-backports-abc==0.5
 backports.functools-lru-cache==1.5  # via cheroot
 backports.ssl_match_hostname==3.5.0.1
+backports_abc==0.5
 bcrypt==3.1.6             # via paramiko
 boto3==1.9.132
 boto==2.49.0

--- a/requirements/static/py3.5/raet-ubuntu-16.04.txt
+++ b/requirements/static/py3.5/raet-ubuntu-16.04.txt
@@ -9,14 +9,12 @@ asn1crypto==0.24.0        # via cryptography
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via pytest
 aws-xray-sdk==0.95        # via moto
-backports-abc==0.5        # via tornado
 backports.functools-lru-cache==1.5  # via cheroot
-backports.ssl-match-hostname==3.7.0.1  # via websocket-client
 boto3==1.9.132
 boto==2.49.0
 botocore==1.12.132        # via boto3, moto, s3transfer
 cachetools==3.1.0         # via google-auth
-certifi==2019.3.9         # via kubernetes, requests, tornado
+certifi==2019.3.9         # via kubernetes, requests
 cffi==1.12.2
 chardet==3.0.4            # via requests
 cheroot==6.5.4            # via cherrypy
@@ -30,8 +28,6 @@ docker-pycreds==0.4.0     # via docker
 docker==3.7.2
 docutils==0.14            # via botocore
 ecdsa==0.13.2             # via python-jose
-# Next line explicitly commented out by pip-tools-compile because of the following regex: '^enum34==(.*)$'
-# enum34==1.1.6             # via raet
 future==0.17.1            # via python-jose
 gitdb2==2.0.5             # via gitpython
 gitpython==2.1.11
@@ -98,8 +94,7 @@ s3transfer==0.2.0         # via boto3
 salttesting==2017.6.1
 scp==0.13.2               # via junos-eznc
 setproctitle==1.1.10
-singledispatch==3.4.0.3   # via tornado
-six==1.12.0               # via cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, junos-eznc, kubernetes, mock, more-itertools, moto, ncclient, pathlib2, pygit2, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, raet, responses, salttesting, singledispatch, tempora, websocket-client
+six==1.12.0               # via cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, junos-eznc, kubernetes, mock, more-itertools, moto, ncclient, pathlib2, pygit2, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, raet, responses, salttesting, tempora, websocket-client
 smmap2==2.0.5             # via gitdb2
 strict-rfc3339==0.7
 tempora==1.14.1           # via portend

--- a/requirements/static/py3.5/raet-ubuntu-18.04.txt
+++ b/requirements/static/py3.5/raet-ubuntu-18.04.txt
@@ -9,14 +9,12 @@ asn1crypto==0.24.0        # via cryptography
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via pytest
 aws-xray-sdk==0.95        # via moto
-backports-abc==0.5        # via tornado
 backports.functools-lru-cache==1.5  # via cheroot
-backports.ssl-match-hostname==3.7.0.1  # via websocket-client
 boto3==1.9.132
 boto==2.49.0
 botocore==1.12.132        # via boto3, moto, s3transfer
 cachetools==3.1.0         # via google-auth
-certifi==2019.3.9         # via kubernetes, requests, tornado
+certifi==2019.3.9         # via kubernetes, requests
 cffi==1.12.2
 chardet==3.0.4            # via requests
 cheroot==6.5.4            # via cherrypy
@@ -30,8 +28,6 @@ docker-pycreds==0.4.0     # via docker
 docker==3.7.2
 docutils==0.14            # via botocore
 ecdsa==0.13.2             # via python-jose
-# Next line explicitly commented out by pip-tools-compile because of the following regex: '^enum34==(.*)$'
-# enum34==1.1.6             # via raet
 future==0.17.1            # via python-jose
 gitdb2==2.0.5             # via gitpython
 gitpython==2.1.11
@@ -98,8 +94,7 @@ s3transfer==0.2.0         # via boto3
 salttesting==2017.6.1
 scp==0.13.2               # via junos-eznc
 setproctitle==1.1.10
-singledispatch==3.4.0.3   # via tornado
-six==1.12.0               # via cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, junos-eznc, kubernetes, mock, more-itertools, moto, ncclient, pathlib2, pygit2, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, raet, responses, salttesting, singledispatch, tempora, websocket-client
+six==1.12.0               # via cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, junos-eznc, kubernetes, mock, more-itertools, moto, ncclient, pathlib2, pygit2, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, raet, responses, salttesting, tempora, websocket-client
 smmap2==2.0.5             # via gitdb2
 strict-rfc3339==0.7
 tempora==1.14.1           # via portend

--- a/requirements/static/py3.5/zeromq-arch.txt
+++ b/requirements/static/py3.5/zeromq-arch.txt
@@ -9,14 +9,12 @@ asn1crypto==0.24.0        # via cryptography
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via pytest
 aws-xray-sdk==0.95        # via moto
-backports-abc==0.5        # via tornado
 backports.functools-lru-cache==1.5  # via cheroot
-backports.ssl-match-hostname==3.7.0.1  # via websocket-client
 boto3==1.9.132
 boto==2.49.0
 botocore==1.12.132        # via boto3, moto, s3transfer
 cachetools==3.1.0         # via google-auth
-certifi==2019.3.9         # via kubernetes, requests, tornado
+certifi==2019.3.9         # via kubernetes, requests
 cffi==1.12.2
 chardet==3.0.4            # via requests
 cheroot==6.5.4            # via cherrypy
@@ -88,8 +86,7 @@ rsa==4.0                  # via google-auth
 s3transfer==0.2.0         # via boto3
 salttesting==2017.6.1
 setproctitle==1.1.10
-singledispatch==3.4.0.3   # via tornado
-six==1.12.0               # via cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, kubernetes, mock, more-itertools, moto, pathlib2, pygit2, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, responses, salttesting, singledispatch, tempora, websocket-client
+six==1.12.0               # via cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, kubernetes, mock, more-itertools, moto, pathlib2, pygit2, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, responses, salttesting, tempora, websocket-client
 smmap2==2.0.5             # via gitdb2
 strict-rfc3339==0.7
 tempora==1.14.1           # via portend

--- a/requirements/static/py3.5/zeromq-centos-7.txt
+++ b/requirements/static/py3.5/zeromq-centos-7.txt
@@ -9,14 +9,12 @@ asn1crypto==0.24.0        # via cryptography
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via pytest
 aws-xray-sdk==0.95        # via moto
-backports-abc==0.5        # via tornado
 backports.functools-lru-cache==1.5  # via cheroot
-backports.ssl-match-hostname==3.7.0.1  # via websocket-client
 boto3==1.9.132
 boto==2.49.0
 botocore==1.12.132        # via boto3, moto, s3transfer
 cachetools==3.1.0         # via google-auth
-certifi==2019.3.9         # via kubernetes, requests, tornado
+certifi==2019.3.9         # via kubernetes, requests
 cffi==1.12.2
 chardet==3.0.4            # via requests
 cheroot==6.5.4            # via cherrypy
@@ -97,8 +95,7 @@ s3transfer==0.2.0         # via boto3
 salttesting==2017.6.1
 scp==0.13.2               # via junos-eznc
 setproctitle==1.1.10
-singledispatch==3.4.0.3   # via tornado
-six==1.12.0               # via cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, junos-eznc, kazoo, kubernetes, mock, more-itertools, moto, ncclient, pathlib2, pygit2, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, responses, salttesting, singledispatch, tempora, websocket-client
+six==1.12.0               # via cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, junos-eznc, kazoo, kubernetes, mock, more-itertools, moto, ncclient, pathlib2, pygit2, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, responses, salttesting, tempora, websocket-client
 smmap2==2.0.5             # via gitdb2
 strict-rfc3339==0.7
 tempora==1.14.1           # via portend

--- a/requirements/static/py3.5/zeromq-debian-8.txt
+++ b/requirements/static/py3.5/zeromq-debian-8.txt
@@ -9,14 +9,12 @@ asn1crypto==0.24.0        # via cryptography
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via pytest
 aws-xray-sdk==0.95        # via moto
-backports-abc==0.5        # via tornado
 backports.functools-lru-cache==1.5  # via cheroot
-backports.ssl-match-hostname==3.7.0.1  # via websocket-client
 boto3==1.9.132
 boto==2.49.0
 botocore==1.12.132        # via boto3, moto, s3transfer
 cachetools==3.1.0         # via google-auth
-certifi==2019.3.9         # via kubernetes, requests, tornado
+certifi==2019.3.9         # via kubernetes, requests
 cffi==1.12.2
 chardet==3.0.4            # via requests
 cheroot==6.5.4            # via cherrypy
@@ -96,8 +94,7 @@ s3transfer==0.2.0         # via boto3
 salttesting==2017.6.1
 scp==0.13.2               # via junos-eznc
 setproctitle==1.1.10
-singledispatch==3.4.0.3   # via tornado
-six==1.12.0               # via cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, junos-eznc, kubernetes, mock, more-itertools, moto, ncclient, pathlib2, pygit2, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, responses, salttesting, singledispatch, tempora, websocket-client
+six==1.12.0               # via cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, junos-eznc, kubernetes, mock, more-itertools, moto, ncclient, pathlib2, pygit2, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, responses, salttesting, tempora, websocket-client
 smmap2==2.0.5             # via gitdb2
 strict-rfc3339==0.7
 tempora==1.14.1           # via portend

--- a/requirements/static/py3.5/zeromq-debian-9.txt
+++ b/requirements/static/py3.5/zeromq-debian-9.txt
@@ -9,14 +9,12 @@ asn1crypto==0.24.0        # via cryptography
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via pytest
 aws-xray-sdk==0.95        # via moto
-backports-abc==0.5        # via tornado
 backports.functools-lru-cache==1.5  # via cheroot
-backports.ssl-match-hostname==3.7.0.1  # via websocket-client
 boto3==1.9.132
 boto==2.49.0
 botocore==1.12.132        # via boto3, moto, s3transfer
 cachetools==3.1.0         # via google-auth
-certifi==2019.3.9         # via kubernetes, requests, tornado
+certifi==2019.3.9         # via kubernetes, requests
 cffi==1.12.2
 chardet==3.0.4            # via requests
 cheroot==6.5.4            # via cherrypy
@@ -96,8 +94,7 @@ s3transfer==0.2.0         # via boto3
 salttesting==2017.6.1
 scp==0.13.2               # via junos-eznc
 setproctitle==1.1.10
-singledispatch==3.4.0.3   # via tornado
-six==1.12.0               # via cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, junos-eznc, kubernetes, mock, more-itertools, moto, ncclient, pathlib2, pygit2, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, responses, salttesting, singledispatch, tempora, websocket-client
+six==1.12.0               # via cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, junos-eznc, kubernetes, mock, more-itertools, moto, ncclient, pathlib2, pygit2, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, responses, salttesting, tempora, websocket-client
 smmap2==2.0.5             # via gitdb2
 strict-rfc3339==0.7
 tempora==1.14.1           # via portend

--- a/requirements/static/py3.5/zeromq-fedora-28.txt
+++ b/requirements/static/py3.5/zeromq-fedora-28.txt
@@ -9,15 +9,13 @@ asn1crypto==0.24.0        # via cryptography
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via pytest
 aws-xray-sdk==0.95        # via moto
-backports-abc==0.5        # via tornado
 backports.functools-lru-cache==1.5  # via cheroot
-backports.ssl-match-hostname==3.7.0.1  # via websocket-client
 bcrypt==3.1.6             # via paramiko
 boto3==1.9.132
 boto==2.49.0
 botocore==1.12.132        # via boto3, moto, s3transfer
 cachetools==3.1.0         # via google-auth
-certifi==2019.3.9         # via kubernetes, requests, tornado
+certifi==2019.3.9         # via kubernetes, requests
 cffi==1.12.2
 chardet==3.0.4            # via requests
 cheroot==6.5.4            # via cherrypy
@@ -98,8 +96,7 @@ s3transfer==0.2.0         # via boto3
 salttesting==2017.6.1
 scp==0.13.2               # via junos-eznc
 setproctitle==1.1.10
-singledispatch==3.4.0.3   # via tornado
-six==1.12.0               # via bcrypt, cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, junos-eznc, kubernetes, mock, more-itertools, moto, ncclient, pathlib2, pygit2, pynacl, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, responses, salttesting, singledispatch, tempora, websocket-client
+six==1.12.0               # via bcrypt, cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, junos-eznc, kubernetes, mock, more-itertools, moto, ncclient, pathlib2, pygit2, pynacl, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, responses, salttesting, tempora, websocket-client
 smmap2==2.0.5             # via gitdb2
 strict-rfc3339==0.7
 tempora==1.14.1           # via portend

--- a/requirements/static/py3.5/zeromq-fedora-29.txt
+++ b/requirements/static/py3.5/zeromq-fedora-29.txt
@@ -9,15 +9,13 @@ asn1crypto==0.24.0        # via cryptography
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via pytest
 aws-xray-sdk==0.95        # via moto
-backports-abc==0.5        # via tornado
 backports.functools-lru-cache==1.5  # via cheroot
-backports.ssl-match-hostname==3.7.0.1  # via websocket-client
 bcrypt==3.1.6             # via paramiko
 boto3==1.9.132
 boto==2.49.0
 botocore==1.12.132        # via boto3, moto, s3transfer
 cachetools==3.1.0         # via google-auth
-certifi==2019.3.9         # via kubernetes, requests, tornado
+certifi==2019.3.9         # via kubernetes, requests
 cffi==1.12.2
 chardet==3.0.4            # via requests
 cheroot==6.5.4            # via cherrypy
@@ -98,8 +96,7 @@ s3transfer==0.2.0         # via boto3
 salttesting==2017.6.1
 scp==0.13.2               # via junos-eznc
 setproctitle==1.1.10
-singledispatch==3.4.0.3   # via tornado
-six==1.12.0               # via bcrypt, cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, junos-eznc, kubernetes, mock, more-itertools, moto, ncclient, pathlib2, pygit2, pynacl, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, responses, salttesting, singledispatch, tempora, websocket-client
+six==1.12.0               # via bcrypt, cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, junos-eznc, kubernetes, mock, more-itertools, moto, ncclient, pathlib2, pygit2, pynacl, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, responses, salttesting, tempora, websocket-client
 smmap2==2.0.5             # via gitdb2
 strict-rfc3339==0.7
 tempora==1.14.1           # via portend

--- a/requirements/static/py3.5/zeromq-opensuse-42.txt
+++ b/requirements/static/py3.5/zeromq-opensuse-42.txt
@@ -9,9 +9,7 @@ asn1crypto==0.24.0        # via cryptography
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via pytest
 aws-xray-sdk==0.95        # via moto
-backports-abc==0.5        # via tornado
 backports.functools-lru-cache==1.5  # via cheroot
-backports.ssl-match-hostname==3.7.0.1  # via websocket-client
 boto3==1.9.132
 boto==2.49.0
 botocore==1.12.132        # via boto3, moto, s3transfer
@@ -90,8 +88,7 @@ s3transfer==0.2.0         # via boto3
 salttesting==2017.6.1
 setproctitle==1.1.10
 setuptools-scm==3.2.0
-singledispatch==3.4.0.3   # via tornado
-six==1.12.0               # via cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, kubernetes, mock, more-itertools, moto, pathlib2, pygit2, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, responses, salttesting, singledispatch, tempora, websocket-client
+six==1.12.0               # via cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, kubernetes, mock, more-itertools, moto, pathlib2, pygit2, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, responses, salttesting, tempora, websocket-client
 smmap2==2.0.5             # via gitdb2
 strict-rfc3339==0.7
 tempora==1.14.1           # via portend

--- a/requirements/static/py3.5/zeromq-opensuse-leap-15.txt
+++ b/requirements/static/py3.5/zeromq-opensuse-leap-15.txt
@@ -9,9 +9,7 @@ asn1crypto==0.24.0        # via cryptography
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via pytest
 aws-xray-sdk==0.95        # via moto
-backports-abc==0.5        # via tornado
 backports.functools-lru-cache==1.5  # via cheroot
-backports.ssl-match-hostname==3.7.0.1  # via websocket-client
 boto3==1.9.132
 boto==2.49.0
 botocore==1.12.132        # via boto3, moto, s3transfer
@@ -90,8 +88,7 @@ s3transfer==0.2.0         # via boto3
 salttesting==2017.6.1
 setproctitle==1.1.10
 setuptools-scm==3.2.0
-singledispatch==3.4.0.3   # via tornado
-six==1.12.0               # via cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, kubernetes, mock, more-itertools, moto, pathlib2, pygit2, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, responses, salttesting, singledispatch, tempora, websocket-client
+six==1.12.0               # via cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, kubernetes, mock, more-itertools, moto, pathlib2, pygit2, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, responses, salttesting, tempora, websocket-client
 smmap2==2.0.5             # via gitdb2
 strict-rfc3339==0.7
 tempora==1.14.1           # via portend

--- a/requirements/static/py3.5/zeromq-osx.txt
+++ b/requirements/static/py3.5/zeromq-osx.txt
@@ -9,9 +9,9 @@ asn1crypto==0.24.0        # via cryptography
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via pytest
 aws-xray-sdk==0.95        # via moto
-backports-abc==0.5
 backports.functools-lru-cache==1.5  # via cheroot
 backports.ssl_match_hostname==3.5.0.1
+backports_abc==0.5
 bcrypt==3.1.6             # via paramiko
 boto3==1.9.132
 boto==2.49.0

--- a/requirements/static/py3.5/zeromq-ubuntu-16.04.txt
+++ b/requirements/static/py3.5/zeromq-ubuntu-16.04.txt
@@ -9,14 +9,12 @@ asn1crypto==0.24.0        # via cryptography
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via pytest
 aws-xray-sdk==0.95        # via moto
-backports-abc==0.5        # via tornado
 backports.functools-lru-cache==1.5  # via cheroot
-backports.ssl-match-hostname==3.7.0.1  # via websocket-client
 boto3==1.9.132
 boto==2.49.0
 botocore==1.12.132        # via boto3, moto, s3transfer
 cachetools==3.1.0         # via google-auth
-certifi==2019.3.9         # via kubernetes, requests, tornado
+certifi==2019.3.9         # via kubernetes, requests
 cffi==1.12.2
 chardet==3.0.4            # via requests
 cheroot==6.5.4            # via cherrypy
@@ -96,8 +94,7 @@ s3transfer==0.2.0         # via boto3
 salttesting==2017.6.1
 scp==0.13.2               # via junos-eznc
 setproctitle==1.1.10
-singledispatch==3.4.0.3   # via tornado
-six==1.12.0               # via cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, junos-eznc, kubernetes, mock, more-itertools, moto, ncclient, pathlib2, pygit2, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, responses, salttesting, singledispatch, tempora, websocket-client
+six==1.12.0               # via cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, junos-eznc, kubernetes, mock, more-itertools, moto, ncclient, pathlib2, pygit2, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, responses, salttesting, tempora, websocket-client
 smmap2==2.0.5             # via gitdb2
 strict-rfc3339==0.7
 tempora==1.14.1           # via portend

--- a/requirements/static/py3.5/zeromq-ubuntu-18.04.txt
+++ b/requirements/static/py3.5/zeromq-ubuntu-18.04.txt
@@ -9,14 +9,12 @@ asn1crypto==0.24.0        # via cryptography
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via pytest
 aws-xray-sdk==0.95        # via moto
-backports-abc==0.5        # via tornado
 backports.functools-lru-cache==1.5  # via cheroot
-backports.ssl-match-hostname==3.7.0.1  # via websocket-client
 boto3==1.9.132
 boto==2.49.0
 botocore==1.12.132        # via boto3, moto, s3transfer
 cachetools==3.1.0         # via google-auth
-certifi==2019.3.9         # via kubernetes, requests, tornado
+certifi==2019.3.9         # via kubernetes, requests
 cffi==1.12.2
 chardet==3.0.4            # via requests
 cheroot==6.5.4            # via cherrypy
@@ -96,8 +94,7 @@ s3transfer==0.2.0         # via boto3
 salttesting==2017.6.1
 scp==0.13.2               # via junos-eznc
 setproctitle==1.1.10
-singledispatch==3.4.0.3   # via tornado
-six==1.12.0               # via cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, junos-eznc, kubernetes, mock, more-itertools, moto, ncclient, pathlib2, pygit2, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, responses, salttesting, singledispatch, tempora, websocket-client
+six==1.12.0               # via cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, junos-eznc, kubernetes, mock, more-itertools, moto, ncclient, pathlib2, pygit2, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, responses, salttesting, tempora, websocket-client
 smmap2==2.0.5             # via gitdb2
 strict-rfc3339==0.7
 tempora==1.14.1           # via portend

--- a/requirements/static/py3.6/cloud.txt
+++ b/requirements/static/py3.6/cloud.txt
@@ -91,22 +91,25 @@ azure==4.0.0
 certifi==2019.3.9         # via msrest, requests
 cffi==1.12.2              # via azure-datalake-store, cryptography
 chardet==3.0.4            # via requests
-cryptography==2.6.1       # via adal, azure-cosmosdb-table, azure-keyvault, azure-storage-common, requests-ntlm
+cryptography==2.6.1       # via adal, azure-cosmosdb-table, azure-keyvault, azure-storage-common, requests-ntlm, smbprotocol
 idna==2.8                 # via requests
 isodate==0.6.0            # via msrest
 msrest==0.6.6             # via azure-applicationinsights, azure-eventgrid, azure-keyvault, azure-loganalytics, azure-mgmt-cdn, azure-mgmt-compute, azure-mgmt-containerinstance, azure-mgmt-containerregistry, azure-mgmt-containerservice, azure-mgmt-dns, azure-mgmt-eventhub, azure-mgmt-keyvault, azure-mgmt-media, azure-mgmt-network, azure-mgmt-rdbms, azure-mgmt-resource, azure-mgmt-servicebus, azure-mgmt-servicefabric, azure-mgmt-signalr, azure-servicefabric, msrestazure
 msrestazure==0.6.0        # via azure-batch, azure-eventgrid, azure-graphrbac, azure-keyvault, azure-mgmt-advisor, azure-mgmt-applicationinsights, azure-mgmt-authorization, azure-mgmt-batch, azure-mgmt-batchai, azure-mgmt-billing, azure-mgmt-cdn, azure-mgmt-cognitiveservices, azure-mgmt-commerce, azure-mgmt-compute, azure-mgmt-consumption, azure-mgmt-containerinstance, azure-mgmt-containerregistry, azure-mgmt-containerservice, azure-mgmt-cosmosdb, azure-mgmt-datafactory, azure-mgmt-datalake-analytics, azure-mgmt-datalake-store, azure-mgmt-datamigration, azure-mgmt-devspaces, azure-mgmt-devtestlabs, azure-mgmt-dns, azure-mgmt-eventgrid, azure-mgmt-eventhub, azure-mgmt-hanaonazure, azure-mgmt-iotcentral, azure-mgmt-iothub, azure-mgmt-iothubprovisioningservices, azure-mgmt-keyvault, azure-mgmt-loganalytics, azure-mgmt-logic, azure-mgmt-machinelearningcompute, azure-mgmt-managementgroups, azure-mgmt-managementpartner, azure-mgmt-maps, azure-mgmt-marketplaceordering, azure-mgmt-media, azure-mgmt-monitor, azure-mgmt-msi, azure-mgmt-network, azure-mgmt-notificationhubs, azure-mgmt-policyinsights, azure-mgmt-powerbiembedded, azure-mgmt-rdbms, azure-mgmt-recoveryservices, azure-mgmt-recoveryservicesbackup, azure-mgmt-redis, azure-mgmt-relay, azure-mgmt-reservations, azure-mgmt-resource, azure-mgmt-scheduler, azure-mgmt-search, azure-mgmt-servicebus, azure-mgmt-servicefabric, azure-mgmt-signalr, azure-mgmt-sql, azure-mgmt-storage, azure-mgmt-subscription, azure-mgmt-trafficmanager, azure-mgmt-web
 netaddr==0.7.19
-ntlm-auth==1.3.0          # via requests-ntlm
+ntlm-auth==1.3.0          # via requests-ntlm, smbprotocol
 oauthlib==3.0.1           # via requests-oauthlib
 profitbricks==4.1.3
+pyasn1==0.4.5             # via smbprotocol
 pycparser==2.19           # via cffi
 pyjwt==1.7.1              # via adal
+pypsexec==0.1.0
 python-dateutil==2.8.0    # via adal, azure-cosmosdb-table, azure-storage-common
 pywinrm==0.3.0
 requests-ntlm==1.1.0      # via pywinrm
 requests-oauthlib==1.2.0  # via msrest
 requests==2.21.0          # via adal, azure-cosmosdb-table, azure-datalake-store, azure-keyvault, azure-servicebus, azure-servicemanagement-legacy, azure-storage-common, msrest, profitbricks, pywinrm, requests-ntlm, requests-oauthlib
-six==1.12.0               # via cryptography, isodate, profitbricks, python-dateutil, pywinrm
+six==1.12.0               # via cryptography, isodate, profitbricks, pypsexec, python-dateutil, pywinrm, smbprotocol
+smbprotocol==0.1.1        # via pypsexec
 urllib3==1.24.2           # via requests
 xmltodict==0.12.0         # via pywinrm

--- a/requirements/static/py3.6/raet-arch.txt
+++ b/requirements/static/py3.6/raet-arch.txt
@@ -9,14 +9,12 @@ asn1crypto==0.24.0        # via cryptography
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via pytest
 aws-xray-sdk==0.95        # via moto
-backports-abc==0.5        # via tornado
 backports.functools-lru-cache==1.5  # via cheroot
-backports.ssl-match-hostname==3.7.0.1  # via websocket-client
 boto3==1.9.132
 boto==2.49.0
 botocore==1.12.132        # via boto3, moto, s3transfer
 cachetools==3.1.0         # via google-auth
-certifi==2019.3.9         # via kubernetes, requests, tornado
+certifi==2019.3.9         # via kubernetes, requests
 cffi==1.12.2
 chardet==3.0.4            # via requests
 cheroot==6.5.4            # via cherrypy
@@ -89,8 +87,7 @@ rsa==4.0                  # via google-auth
 s3transfer==0.2.0         # via boto3
 salttesting==2017.6.1
 setproctitle==1.1.10
-singledispatch==3.4.0.3   # via tornado
-six==1.12.0               # via cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, kubernetes, mock, more-itertools, moto, pygit2, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, raet, responses, salttesting, singledispatch, tempora, websocket-client
+six==1.12.0               # via cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, kubernetes, mock, more-itertools, moto, pygit2, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, raet, responses, salttesting, tempora, websocket-client
 smmap2==2.0.5             # via gitdb2
 strict-rfc3339==0.7
 tempora==1.14.1           # via portend

--- a/requirements/static/py3.6/raet-centos-7.txt
+++ b/requirements/static/py3.6/raet-centos-7.txt
@@ -9,14 +9,12 @@ asn1crypto==0.24.0        # via cryptography
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via pytest
 aws-xray-sdk==0.95        # via moto
-backports-abc==0.5        # via tornado
 backports.functools-lru-cache==1.5  # via cheroot
-backports.ssl-match-hostname==3.7.0.1  # via websocket-client
 boto3==1.9.132
 boto==2.49.0
 botocore==1.12.132        # via boto3, moto, s3transfer
 cachetools==3.1.0         # via google-auth
-certifi==2019.3.9         # via kubernetes, requests, tornado
+certifi==2019.3.9         # via kubernetes, requests
 cffi==1.12.2
 chardet==3.0.4            # via requests
 cheroot==6.5.4            # via cherrypy
@@ -98,8 +96,7 @@ s3transfer==0.2.0         # via boto3
 salttesting==2017.6.1
 scp==0.13.2               # via junos-eznc
 setproctitle==1.1.10
-singledispatch==3.4.0.3   # via tornado
-six==1.12.0               # via cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, junos-eznc, kazoo, kubernetes, mock, more-itertools, moto, ncclient, pygit2, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, raet, responses, salttesting, singledispatch, tempora, websocket-client
+six==1.12.0               # via cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, junos-eznc, kazoo, kubernetes, mock, more-itertools, moto, ncclient, pygit2, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, raet, responses, salttesting, tempora, websocket-client
 smmap2==2.0.5             # via gitdb2
 strict-rfc3339==0.7
 tempora==1.14.1           # via portend

--- a/requirements/static/py3.6/raet-debian-8.txt
+++ b/requirements/static/py3.6/raet-debian-8.txt
@@ -9,14 +9,12 @@ asn1crypto==0.24.0        # via cryptography
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via pytest
 aws-xray-sdk==0.95        # via moto
-backports-abc==0.5        # via tornado
 backports.functools-lru-cache==1.5  # via cheroot
-backports.ssl-match-hostname==3.7.0.1  # via websocket-client
 boto3==1.9.132
 boto==2.49.0
 botocore==1.12.132        # via boto3, moto, s3transfer
 cachetools==3.1.0         # via google-auth
-certifi==2019.3.9         # via kubernetes, requests, tornado
+certifi==2019.3.9         # via kubernetes, requests
 cffi==1.12.2
 chardet==3.0.4            # via requests
 cheroot==6.5.4            # via cherrypy
@@ -97,8 +95,7 @@ s3transfer==0.2.0         # via boto3
 salttesting==2017.6.1
 scp==0.13.2               # via junos-eznc
 setproctitle==1.1.10
-singledispatch==3.4.0.3   # via tornado
-six==1.12.0               # via cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, junos-eznc, kubernetes, mock, more-itertools, moto, ncclient, pygit2, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, raet, responses, salttesting, singledispatch, tempora, websocket-client
+six==1.12.0               # via cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, junos-eznc, kubernetes, mock, more-itertools, moto, ncclient, pygit2, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, raet, responses, salttesting, tempora, websocket-client
 smmap2==2.0.5             # via gitdb2
 strict-rfc3339==0.7
 tempora==1.14.1           # via portend

--- a/requirements/static/py3.6/raet-debian-9.txt
+++ b/requirements/static/py3.6/raet-debian-9.txt
@@ -9,14 +9,12 @@ asn1crypto==0.24.0        # via cryptography
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via pytest
 aws-xray-sdk==0.95        # via moto
-backports-abc==0.5        # via tornado
 backports.functools-lru-cache==1.5  # via cheroot
-backports.ssl-match-hostname==3.7.0.1  # via websocket-client
 boto3==1.9.132
 boto==2.49.0
 botocore==1.12.132        # via boto3, moto, s3transfer
 cachetools==3.1.0         # via google-auth
-certifi==2019.3.9         # via kubernetes, requests, tornado
+certifi==2019.3.9         # via kubernetes, requests
 cffi==1.12.2
 chardet==3.0.4            # via requests
 cheroot==6.5.4            # via cherrypy
@@ -97,8 +95,7 @@ s3transfer==0.2.0         # via boto3
 salttesting==2017.6.1
 scp==0.13.2               # via junos-eznc
 setproctitle==1.1.10
-singledispatch==3.4.0.3   # via tornado
-six==1.12.0               # via cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, junos-eznc, kubernetes, mock, more-itertools, moto, ncclient, pygit2, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, raet, responses, salttesting, singledispatch, tempora, websocket-client
+six==1.12.0               # via cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, junos-eznc, kubernetes, mock, more-itertools, moto, ncclient, pygit2, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, raet, responses, salttesting, tempora, websocket-client
 smmap2==2.0.5             # via gitdb2
 strict-rfc3339==0.7
 tempora==1.14.1           # via portend

--- a/requirements/static/py3.6/raet-fedora-28.txt
+++ b/requirements/static/py3.6/raet-fedora-28.txt
@@ -9,15 +9,13 @@ asn1crypto==0.24.0        # via cryptography
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via pytest
 aws-xray-sdk==0.95        # via moto
-backports-abc==0.5        # via tornado
 backports.functools-lru-cache==1.5  # via cheroot
-backports.ssl-match-hostname==3.7.0.1  # via websocket-client
 bcrypt==3.1.6             # via paramiko
 boto3==1.9.132
 boto==2.49.0
 botocore==1.12.132        # via boto3, moto, s3transfer
 cachetools==3.1.0         # via google-auth
-certifi==2019.3.9         # via kubernetes, requests, tornado
+certifi==2019.3.9         # via kubernetes, requests
 cffi==1.12.2
 chardet==3.0.4            # via requests
 cheroot==6.5.4            # via cherrypy
@@ -99,8 +97,7 @@ s3transfer==0.2.0         # via boto3
 salttesting==2017.6.1
 scp==0.13.2               # via junos-eznc
 setproctitle==1.1.10
-singledispatch==3.4.0.3   # via tornado
-six==1.12.0               # via bcrypt, cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, junos-eznc, kubernetes, mock, more-itertools, moto, ncclient, pygit2, pynacl, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, raet, responses, salttesting, singledispatch, tempora, websocket-client
+six==1.12.0               # via bcrypt, cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, junos-eznc, kubernetes, mock, more-itertools, moto, ncclient, pygit2, pynacl, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, raet, responses, salttesting, tempora, websocket-client
 smmap2==2.0.5             # via gitdb2
 strict-rfc3339==0.7
 tempora==1.14.1           # via portend

--- a/requirements/static/py3.6/raet-fedora-29.txt
+++ b/requirements/static/py3.6/raet-fedora-29.txt
@@ -9,15 +9,13 @@ asn1crypto==0.24.0        # via cryptography
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via pytest
 aws-xray-sdk==0.95        # via moto
-backports-abc==0.5        # via tornado
 backports.functools-lru-cache==1.5  # via cheroot
-backports.ssl-match-hostname==3.7.0.1  # via websocket-client
 bcrypt==3.1.6             # via paramiko
 boto3==1.9.132
 boto==2.49.0
 botocore==1.12.132        # via boto3, moto, s3transfer
 cachetools==3.1.0         # via google-auth
-certifi==2019.3.9         # via kubernetes, requests, tornado
+certifi==2019.3.9         # via kubernetes, requests
 cffi==1.12.2
 chardet==3.0.4            # via requests
 cheroot==6.5.4            # via cherrypy
@@ -99,8 +97,7 @@ s3transfer==0.2.0         # via boto3
 salttesting==2017.6.1
 scp==0.13.2               # via junos-eznc
 setproctitle==1.1.10
-singledispatch==3.4.0.3   # via tornado
-six==1.12.0               # via bcrypt, cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, junos-eznc, kubernetes, mock, more-itertools, moto, ncclient, pygit2, pynacl, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, raet, responses, salttesting, singledispatch, tempora, websocket-client
+six==1.12.0               # via bcrypt, cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, junos-eznc, kubernetes, mock, more-itertools, moto, ncclient, pygit2, pynacl, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, raet, responses, salttesting, tempora, websocket-client
 smmap2==2.0.5             # via gitdb2
 strict-rfc3339==0.7
 tempora==1.14.1           # via portend

--- a/requirements/static/py3.6/raet-opensuse-42.txt
+++ b/requirements/static/py3.6/raet-opensuse-42.txt
@@ -9,9 +9,7 @@ asn1crypto==0.24.0        # via cryptography
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via pytest
 aws-xray-sdk==0.95        # via moto
-backports-abc==0.5        # via tornado
 backports.functools-lru-cache==1.5  # via cheroot
-backports.ssl-match-hostname==3.7.0.1  # via websocket-client
 boto3==1.9.132
 boto==2.49.0
 botocore==1.12.132        # via boto3, moto, s3transfer
@@ -91,8 +89,7 @@ s3transfer==0.2.0         # via boto3
 salttesting==2017.6.1
 setproctitle==1.1.10
 setuptools-scm==3.2.0
-singledispatch==3.4.0.3   # via tornado
-six==1.12.0               # via cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, kubernetes, mock, more-itertools, moto, pygit2, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, raet, responses, salttesting, singledispatch, tempora, websocket-client
+six==1.12.0               # via cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, kubernetes, mock, more-itertools, moto, pygit2, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, raet, responses, salttesting, tempora, websocket-client
 smmap2==2.0.5             # via gitdb2
 strict-rfc3339==0.7
 tempora==1.14.1           # via portend

--- a/requirements/static/py3.6/raet-opensuse-leap-15.txt
+++ b/requirements/static/py3.6/raet-opensuse-leap-15.txt
@@ -9,9 +9,7 @@ asn1crypto==0.24.0        # via cryptography
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via pytest
 aws-xray-sdk==0.95        # via moto
-backports-abc==0.5        # via tornado
 backports.functools-lru-cache==1.5  # via cheroot
-backports.ssl-match-hostname==3.7.0.1  # via websocket-client
 boto3==1.9.132
 boto==2.49.0
 botocore==1.12.132        # via boto3, moto, s3transfer
@@ -91,8 +89,7 @@ s3transfer==0.2.0         # via boto3
 salttesting==2017.6.1
 setproctitle==1.1.10
 setuptools-scm==3.2.0
-singledispatch==3.4.0.3   # via tornado
-six==1.12.0               # via cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, kubernetes, mock, more-itertools, moto, pygit2, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, raet, responses, salttesting, singledispatch, tempora, websocket-client
+six==1.12.0               # via cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, kubernetes, mock, more-itertools, moto, pygit2, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, raet, responses, salttesting, tempora, websocket-client
 smmap2==2.0.5             # via gitdb2
 strict-rfc3339==0.7
 tempora==1.14.1           # via portend

--- a/requirements/static/py3.6/raet-ubuntu-16.04.txt
+++ b/requirements/static/py3.6/raet-ubuntu-16.04.txt
@@ -9,14 +9,12 @@ asn1crypto==0.24.0        # via cryptography
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via pytest
 aws-xray-sdk==0.95        # via moto
-backports-abc==0.5        # via tornado
 backports.functools-lru-cache==1.5  # via cheroot
-backports.ssl-match-hostname==3.7.0.1  # via websocket-client
 boto3==1.9.132
 boto==2.49.0
 botocore==1.12.132        # via boto3, moto, s3transfer
 cachetools==3.1.0         # via google-auth
-certifi==2019.3.9         # via kubernetes, requests, tornado
+certifi==2019.3.9         # via kubernetes, requests
 cffi==1.12.2
 chardet==3.0.4            # via requests
 cheroot==6.5.4            # via cherrypy
@@ -97,8 +95,7 @@ s3transfer==0.2.0         # via boto3
 salttesting==2017.6.1
 scp==0.13.2               # via junos-eznc
 setproctitle==1.1.10
-singledispatch==3.4.0.3   # via tornado
-six==1.12.0               # via cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, junos-eznc, kubernetes, mock, more-itertools, moto, ncclient, pygit2, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, raet, responses, salttesting, singledispatch, tempora, websocket-client
+six==1.12.0               # via cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, junos-eznc, kubernetes, mock, more-itertools, moto, ncclient, pygit2, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, raet, responses, salttesting, tempora, websocket-client
 smmap2==2.0.5             # via gitdb2
 strict-rfc3339==0.7
 tempora==1.14.1           # via portend

--- a/requirements/static/py3.6/raet-ubuntu-18.04.txt
+++ b/requirements/static/py3.6/raet-ubuntu-18.04.txt
@@ -9,14 +9,12 @@ asn1crypto==0.24.0        # via cryptography
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via pytest
 aws-xray-sdk==0.95        # via moto
-backports-abc==0.5        # via tornado
 backports.functools-lru-cache==1.5  # via cheroot
-backports.ssl-match-hostname==3.7.0.1  # via websocket-client
 boto3==1.9.132
 boto==2.49.0
 botocore==1.12.132        # via boto3, moto, s3transfer
 cachetools==3.1.0         # via google-auth
-certifi==2019.3.9         # via kubernetes, requests, tornado
+certifi==2019.3.9         # via kubernetes, requests
 cffi==1.12.2
 chardet==3.0.4            # via requests
 cheroot==6.5.4            # via cherrypy
@@ -97,8 +95,7 @@ s3transfer==0.2.0         # via boto3
 salttesting==2017.6.1
 scp==0.13.2               # via junos-eznc
 setproctitle==1.1.10
-singledispatch==3.4.0.3   # via tornado
-six==1.12.0               # via cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, junos-eznc, kubernetes, mock, more-itertools, moto, ncclient, pygit2, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, raet, responses, salttesting, singledispatch, tempora, websocket-client
+six==1.12.0               # via cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, junos-eznc, kubernetes, mock, more-itertools, moto, ncclient, pygit2, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, raet, responses, salttesting, tempora, websocket-client
 smmap2==2.0.5             # via gitdb2
 strict-rfc3339==0.7
 tempora==1.14.1           # via portend

--- a/requirements/static/py3.6/zeromq-arch.txt
+++ b/requirements/static/py3.6/zeromq-arch.txt
@@ -9,14 +9,12 @@ asn1crypto==0.24.0        # via cryptography
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via pytest
 aws-xray-sdk==0.95        # via moto
-backports-abc==0.5        # via tornado
 backports.functools-lru-cache==1.5  # via cheroot
-backports.ssl-match-hostname==3.7.0.1  # via websocket-client
 boto3==1.9.132
 boto==2.49.0
 botocore==1.12.132        # via boto3, moto, s3transfer
 cachetools==3.1.0         # via google-auth
-certifi==2019.3.9         # via kubernetes, requests, tornado
+certifi==2019.3.9         # via kubernetes, requests
 cffi==1.12.2
 chardet==3.0.4            # via requests
 cheroot==6.5.4            # via cherrypy
@@ -87,8 +85,7 @@ rsa==4.0                  # via google-auth
 s3transfer==0.2.0         # via boto3
 salttesting==2017.6.1
 setproctitle==1.1.10
-singledispatch==3.4.0.3   # via tornado
-six==1.12.0               # via cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, kubernetes, mock, more-itertools, moto, pygit2, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, responses, salttesting, singledispatch, tempora, websocket-client
+six==1.12.0               # via cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, kubernetes, mock, more-itertools, moto, pygit2, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, responses, salttesting, tempora, websocket-client
 smmap2==2.0.5             # via gitdb2
 strict-rfc3339==0.7
 tempora==1.14.1           # via portend

--- a/requirements/static/py3.6/zeromq-centos-7.txt
+++ b/requirements/static/py3.6/zeromq-centos-7.txt
@@ -9,14 +9,12 @@ asn1crypto==0.24.0        # via cryptography
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via pytest
 aws-xray-sdk==0.95        # via moto
-backports-abc==0.5        # via tornado
 backports.functools-lru-cache==1.5  # via cheroot
-backports.ssl-match-hostname==3.7.0.1  # via websocket-client
 boto3==1.9.132
 boto==2.49.0
 botocore==1.12.132        # via boto3, moto, s3transfer
 cachetools==3.1.0         # via google-auth
-certifi==2019.3.9         # via kubernetes, requests, tornado
+certifi==2019.3.9         # via kubernetes, requests
 cffi==1.12.2
 chardet==3.0.4            # via requests
 cheroot==6.5.4            # via cherrypy
@@ -96,8 +94,7 @@ s3transfer==0.2.0         # via boto3
 salttesting==2017.6.1
 scp==0.13.2               # via junos-eznc
 setproctitle==1.1.10
-singledispatch==3.4.0.3   # via tornado
-six==1.12.0               # via cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, junos-eznc, kazoo, kubernetes, mock, more-itertools, moto, ncclient, pygit2, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, responses, salttesting, singledispatch, tempora, websocket-client
+six==1.12.0               # via cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, junos-eznc, kazoo, kubernetes, mock, more-itertools, moto, ncclient, pygit2, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, responses, salttesting, tempora, websocket-client
 smmap2==2.0.5             # via gitdb2
 strict-rfc3339==0.7
 tempora==1.14.1           # via portend

--- a/requirements/static/py3.6/zeromq-debian-8.txt
+++ b/requirements/static/py3.6/zeromq-debian-8.txt
@@ -9,14 +9,12 @@ asn1crypto==0.24.0        # via cryptography
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via pytest
 aws-xray-sdk==0.95        # via moto
-backports-abc==0.5        # via tornado
 backports.functools-lru-cache==1.5  # via cheroot
-backports.ssl-match-hostname==3.7.0.1  # via websocket-client
 boto3==1.9.132
 boto==2.49.0
 botocore==1.12.132        # via boto3, moto, s3transfer
 cachetools==3.1.0         # via google-auth
-certifi==2019.3.9         # via kubernetes, requests, tornado
+certifi==2019.3.9         # via kubernetes, requests
 cffi==1.12.2
 chardet==3.0.4            # via requests
 cheroot==6.5.4            # via cherrypy
@@ -95,8 +93,7 @@ s3transfer==0.2.0         # via boto3
 salttesting==2017.6.1
 scp==0.13.2               # via junos-eznc
 setproctitle==1.1.10
-singledispatch==3.4.0.3   # via tornado
-six==1.12.0               # via cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, junos-eznc, kubernetes, mock, more-itertools, moto, ncclient, pygit2, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, responses, salttesting, singledispatch, tempora, websocket-client
+six==1.12.0               # via cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, junos-eznc, kubernetes, mock, more-itertools, moto, ncclient, pygit2, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, responses, salttesting, tempora, websocket-client
 smmap2==2.0.5             # via gitdb2
 strict-rfc3339==0.7
 tempora==1.14.1           # via portend

--- a/requirements/static/py3.6/zeromq-debian-9.txt
+++ b/requirements/static/py3.6/zeromq-debian-9.txt
@@ -9,14 +9,12 @@ asn1crypto==0.24.0        # via cryptography
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via pytest
 aws-xray-sdk==0.95        # via moto
-backports-abc==0.5        # via tornado
 backports.functools-lru-cache==1.5  # via cheroot
-backports.ssl-match-hostname==3.7.0.1  # via websocket-client
 boto3==1.9.132
 boto==2.49.0
 botocore==1.12.132        # via boto3, moto, s3transfer
 cachetools==3.1.0         # via google-auth
-certifi==2019.3.9         # via kubernetes, requests, tornado
+certifi==2019.3.9         # via kubernetes, requests
 cffi==1.12.2
 chardet==3.0.4            # via requests
 cheroot==6.5.4            # via cherrypy
@@ -95,8 +93,7 @@ s3transfer==0.2.0         # via boto3
 salttesting==2017.6.1
 scp==0.13.2               # via junos-eznc
 setproctitle==1.1.10
-singledispatch==3.4.0.3   # via tornado
-six==1.12.0               # via cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, junos-eznc, kubernetes, mock, more-itertools, moto, ncclient, pygit2, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, responses, salttesting, singledispatch, tempora, websocket-client
+six==1.12.0               # via cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, junos-eznc, kubernetes, mock, more-itertools, moto, ncclient, pygit2, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, responses, salttesting, tempora, websocket-client
 smmap2==2.0.5             # via gitdb2
 strict-rfc3339==0.7
 tempora==1.14.1           # via portend

--- a/requirements/static/py3.6/zeromq-fedora-28.txt
+++ b/requirements/static/py3.6/zeromq-fedora-28.txt
@@ -9,15 +9,13 @@ asn1crypto==0.24.0        # via cryptography
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via pytest
 aws-xray-sdk==0.95        # via moto
-backports-abc==0.5        # via tornado
 backports.functools-lru-cache==1.5  # via cheroot
-backports.ssl-match-hostname==3.7.0.1  # via websocket-client
 bcrypt==3.1.6             # via paramiko
 boto3==1.9.132
 boto==2.49.0
 botocore==1.12.132        # via boto3, moto, s3transfer
 cachetools==3.1.0         # via google-auth
-certifi==2019.3.9         # via kubernetes, requests, tornado
+certifi==2019.3.9         # via kubernetes, requests
 cffi==1.12.2
 chardet==3.0.4            # via requests
 cheroot==6.5.4            # via cherrypy
@@ -97,8 +95,7 @@ s3transfer==0.2.0         # via boto3
 salttesting==2017.6.1
 scp==0.13.2               # via junos-eznc
 setproctitle==1.1.10
-singledispatch==3.4.0.3   # via tornado
-six==1.12.0               # via bcrypt, cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, junos-eznc, kubernetes, mock, more-itertools, moto, ncclient, pygit2, pynacl, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, responses, salttesting, singledispatch, tempora, websocket-client
+six==1.12.0               # via bcrypt, cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, junos-eznc, kubernetes, mock, more-itertools, moto, ncclient, pygit2, pynacl, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, responses, salttesting, tempora, websocket-client
 smmap2==2.0.5             # via gitdb2
 strict-rfc3339==0.7
 tempora==1.14.1           # via portend

--- a/requirements/static/py3.6/zeromq-fedora-29.txt
+++ b/requirements/static/py3.6/zeromq-fedora-29.txt
@@ -9,15 +9,13 @@ asn1crypto==0.24.0        # via cryptography
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via pytest
 aws-xray-sdk==0.95        # via moto
-backports-abc==0.5        # via tornado
 backports.functools-lru-cache==1.5  # via cheroot
-backports.ssl-match-hostname==3.7.0.1  # via websocket-client
 bcrypt==3.1.6             # via paramiko
 boto3==1.9.132
 boto==2.49.0
 botocore==1.12.132        # via boto3, moto, s3transfer
 cachetools==3.1.0         # via google-auth
-certifi==2019.3.9         # via kubernetes, requests, tornado
+certifi==2019.3.9         # via kubernetes, requests
 cffi==1.12.2
 chardet==3.0.4            # via requests
 cheroot==6.5.4            # via cherrypy
@@ -97,8 +95,7 @@ s3transfer==0.2.0         # via boto3
 salttesting==2017.6.1
 scp==0.13.2               # via junos-eznc
 setproctitle==1.1.10
-singledispatch==3.4.0.3   # via tornado
-six==1.12.0               # via bcrypt, cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, junos-eznc, kubernetes, mock, more-itertools, moto, ncclient, pygit2, pynacl, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, responses, salttesting, singledispatch, tempora, websocket-client
+six==1.12.0               # via bcrypt, cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, junos-eznc, kubernetes, mock, more-itertools, moto, ncclient, pygit2, pynacl, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, responses, salttesting, tempora, websocket-client
 smmap2==2.0.5             # via gitdb2
 strict-rfc3339==0.7
 tempora==1.14.1           # via portend

--- a/requirements/static/py3.6/zeromq-opensuse-42.txt
+++ b/requirements/static/py3.6/zeromq-opensuse-42.txt
@@ -9,9 +9,7 @@ asn1crypto==0.24.0        # via cryptography
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via pytest
 aws-xray-sdk==0.95        # via moto
-backports-abc==0.5        # via tornado
 backports.functools-lru-cache==1.5  # via cheroot
-backports.ssl-match-hostname==3.7.0.1  # via websocket-client
 boto3==1.9.132
 boto==2.49.0
 botocore==1.12.132        # via boto3, moto, s3transfer
@@ -89,8 +87,7 @@ s3transfer==0.2.0         # via boto3
 salttesting==2017.6.1
 setproctitle==1.1.10
 setuptools-scm==3.2.0
-singledispatch==3.4.0.3   # via tornado
-six==1.12.0               # via cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, kubernetes, mock, more-itertools, moto, pygit2, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, responses, salttesting, singledispatch, tempora, websocket-client
+six==1.12.0               # via cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, kubernetes, mock, more-itertools, moto, pygit2, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, responses, salttesting, tempora, websocket-client
 smmap2==2.0.5             # via gitdb2
 strict-rfc3339==0.7
 tempora==1.14.1           # via portend

--- a/requirements/static/py3.6/zeromq-opensuse-leap-15.txt
+++ b/requirements/static/py3.6/zeromq-opensuse-leap-15.txt
@@ -9,9 +9,7 @@ asn1crypto==0.24.0        # via cryptography
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via pytest
 aws-xray-sdk==0.95        # via moto
-backports-abc==0.5        # via tornado
 backports.functools-lru-cache==1.5  # via cheroot
-backports.ssl-match-hostname==3.7.0.1  # via websocket-client
 boto3==1.9.132
 boto==2.49.0
 botocore==1.12.132        # via boto3, moto, s3transfer
@@ -89,8 +87,7 @@ s3transfer==0.2.0         # via boto3
 salttesting==2017.6.1
 setproctitle==1.1.10
 setuptools-scm==3.2.0
-singledispatch==3.4.0.3   # via tornado
-six==1.12.0               # via cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, kubernetes, mock, more-itertools, moto, pygit2, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, responses, salttesting, singledispatch, tempora, websocket-client
+six==1.12.0               # via cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, kubernetes, mock, more-itertools, moto, pygit2, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, responses, salttesting, tempora, websocket-client
 smmap2==2.0.5             # via gitdb2
 strict-rfc3339==0.7
 tempora==1.14.1           # via portend

--- a/requirements/static/py3.6/zeromq-ubuntu-16.04.txt
+++ b/requirements/static/py3.6/zeromq-ubuntu-16.04.txt
@@ -9,14 +9,12 @@ asn1crypto==0.24.0        # via cryptography
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via pytest
 aws-xray-sdk==0.95        # via moto
-backports-abc==0.5        # via tornado
 backports.functools-lru-cache==1.5  # via cheroot
-backports.ssl-match-hostname==3.7.0.1  # via websocket-client
 boto3==1.9.132
 boto==2.49.0
 botocore==1.12.132        # via boto3, moto, s3transfer
 cachetools==3.1.0         # via google-auth
-certifi==2019.3.9         # via kubernetes, requests, tornado
+certifi==2019.3.9         # via kubernetes, requests
 cffi==1.12.2
 chardet==3.0.4            # via requests
 cheroot==6.5.4            # via cherrypy
@@ -95,8 +93,7 @@ s3transfer==0.2.0         # via boto3
 salttesting==2017.6.1
 scp==0.13.2               # via junos-eznc
 setproctitle==1.1.10
-singledispatch==3.4.0.3   # via tornado
-six==1.12.0               # via cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, junos-eznc, kubernetes, mock, more-itertools, moto, ncclient, pygit2, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, responses, salttesting, singledispatch, tempora, websocket-client
+six==1.12.0               # via cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, junos-eznc, kubernetes, mock, more-itertools, moto, ncclient, pygit2, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, responses, salttesting, tempora, websocket-client
 smmap2==2.0.5             # via gitdb2
 strict-rfc3339==0.7
 tempora==1.14.1           # via portend

--- a/requirements/static/py3.6/zeromq-ubuntu-18.04.txt
+++ b/requirements/static/py3.6/zeromq-ubuntu-18.04.txt
@@ -9,14 +9,12 @@ asn1crypto==0.24.0        # via cryptography
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via pytest
 aws-xray-sdk==0.95        # via moto
-backports-abc==0.5        # via tornado
 backports.functools-lru-cache==1.5  # via cheroot
-backports.ssl-match-hostname==3.7.0.1  # via websocket-client
 boto3==1.9.132
 boto==2.49.0
 botocore==1.12.132        # via boto3, moto, s3transfer
 cachetools==3.1.0         # via google-auth
-certifi==2019.3.9         # via kubernetes, requests, tornado
+certifi==2019.3.9         # via kubernetes, requests
 cffi==1.12.2
 chardet==3.0.4            # via requests
 cheroot==6.5.4            # via cherrypy
@@ -95,8 +93,7 @@ s3transfer==0.2.0         # via boto3
 salttesting==2017.6.1
 scp==0.13.2               # via junos-eznc
 setproctitle==1.1.10
-singledispatch==3.4.0.3   # via tornado
-six==1.12.0               # via cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, junos-eznc, kubernetes, mock, more-itertools, moto, ncclient, pygit2, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, responses, salttesting, singledispatch, tempora, websocket-client
+six==1.12.0               # via cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, junos-eznc, kubernetes, mock, more-itertools, moto, ncclient, pygit2, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, responses, salttesting, tempora, websocket-client
 smmap2==2.0.5             # via gitdb2
 strict-rfc3339==0.7
 tempora==1.14.1           # via portend

--- a/requirements/static/py3.7/cloud.txt
+++ b/requirements/static/py3.7/cloud.txt
@@ -91,22 +91,25 @@ azure==4.0.0
 certifi==2019.3.9         # via msrest, requests
 cffi==1.12.2              # via azure-datalake-store, cryptography
 chardet==3.0.4            # via requests
-cryptography==2.6.1       # via adal, azure-cosmosdb-table, azure-keyvault, azure-storage-common, requests-ntlm
+cryptography==2.6.1       # via adal, azure-cosmosdb-table, azure-keyvault, azure-storage-common, requests-ntlm, smbprotocol
 idna==2.8                 # via requests
 isodate==0.6.0            # via msrest
 msrest==0.6.6             # via azure-applicationinsights, azure-eventgrid, azure-keyvault, azure-loganalytics, azure-mgmt-cdn, azure-mgmt-compute, azure-mgmt-containerinstance, azure-mgmt-containerregistry, azure-mgmt-containerservice, azure-mgmt-dns, azure-mgmt-eventhub, azure-mgmt-keyvault, azure-mgmt-media, azure-mgmt-network, azure-mgmt-rdbms, azure-mgmt-resource, azure-mgmt-servicebus, azure-mgmt-servicefabric, azure-mgmt-signalr, azure-servicefabric, msrestazure
 msrestazure==0.6.0        # via azure-batch, azure-eventgrid, azure-graphrbac, azure-keyvault, azure-mgmt-advisor, azure-mgmt-applicationinsights, azure-mgmt-authorization, azure-mgmt-batch, azure-mgmt-batchai, azure-mgmt-billing, azure-mgmt-cdn, azure-mgmt-cognitiveservices, azure-mgmt-commerce, azure-mgmt-compute, azure-mgmt-consumption, azure-mgmt-containerinstance, azure-mgmt-containerregistry, azure-mgmt-containerservice, azure-mgmt-cosmosdb, azure-mgmt-datafactory, azure-mgmt-datalake-analytics, azure-mgmt-datalake-store, azure-mgmt-datamigration, azure-mgmt-devspaces, azure-mgmt-devtestlabs, azure-mgmt-dns, azure-mgmt-eventgrid, azure-mgmt-eventhub, azure-mgmt-hanaonazure, azure-mgmt-iotcentral, azure-mgmt-iothub, azure-mgmt-iothubprovisioningservices, azure-mgmt-keyvault, azure-mgmt-loganalytics, azure-mgmt-logic, azure-mgmt-machinelearningcompute, azure-mgmt-managementgroups, azure-mgmt-managementpartner, azure-mgmt-maps, azure-mgmt-marketplaceordering, azure-mgmt-media, azure-mgmt-monitor, azure-mgmt-msi, azure-mgmt-network, azure-mgmt-notificationhubs, azure-mgmt-policyinsights, azure-mgmt-powerbiembedded, azure-mgmt-rdbms, azure-mgmt-recoveryservices, azure-mgmt-recoveryservicesbackup, azure-mgmt-redis, azure-mgmt-relay, azure-mgmt-reservations, azure-mgmt-resource, azure-mgmt-scheduler, azure-mgmt-search, azure-mgmt-servicebus, azure-mgmt-servicefabric, azure-mgmt-signalr, azure-mgmt-sql, azure-mgmt-storage, azure-mgmt-subscription, azure-mgmt-trafficmanager, azure-mgmt-web
 netaddr==0.7.19
-ntlm-auth==1.3.0          # via requests-ntlm
+ntlm-auth==1.3.0          # via requests-ntlm, smbprotocol
 oauthlib==3.0.1           # via requests-oauthlib
 profitbricks==4.1.3
+pyasn1==0.4.5             # via smbprotocol
 pycparser==2.19           # via cffi
 pyjwt==1.7.1              # via adal
+pypsexec==0.1.0
 python-dateutil==2.8.0    # via adal, azure-cosmosdb-table, azure-storage-common
 pywinrm==0.3.0
 requests-ntlm==1.1.0      # via pywinrm
 requests-oauthlib==1.2.0  # via msrest
 requests==2.21.0          # via adal, azure-cosmosdb-table, azure-datalake-store, azure-keyvault, azure-servicebus, azure-servicemanagement-legacy, azure-storage-common, msrest, profitbricks, pywinrm, requests-ntlm, requests-oauthlib
-six==1.12.0               # via cryptography, isodate, profitbricks, python-dateutil, pywinrm
+six==1.12.0               # via cryptography, isodate, profitbricks, pypsexec, python-dateutil, pywinrm, smbprotocol
+smbprotocol==0.1.1        # via pypsexec
 urllib3==1.24.2           # via requests
 xmltodict==0.12.0         # via pywinrm


### PR DESCRIPTION
What does this PR do?
Add pypsexec requirement for cloud tests

What issues does this PR fix or reference?

Fixes psexec test failures here #52447


Similar to https://github.com/saltstack/salt/pull/53475 but for the 2018.3 branch