### PR TITLE
Increase flaky attempts on mac tests using systemsetup

### DIFF
--- a/tests/integration/modules/test_mac_power.py
+++ b/tests/integration/modules/test_mac_power.py
@@ -17,7 +17,7 @@ import salt.utils.platform
 
 
 @skip_if_not_root
-@flaky
+@flaky(attempts=10)
 @skipIf(not salt.utils.platform.is_darwin(), 'Test only available on macOS')
 @skipIf(not salt.utils.path.which('systemsetup'), '\'systemsetup\' binary not found in $PATH')
 class MacPowerModuleTest(ModuleCase):
@@ -142,7 +142,7 @@ class MacPowerModuleTest(ModuleCase):
 
 
 @skip_if_not_root
-@flaky
+@flaky(attempts=10)
 @skipIf(not salt.utils.platform.is_darwin(), 'Test only available on macOS')
 @skipIf(not salt.utils.path.which('systemsetup'), '\'systemsetup\' binary not found in $PATH')
 class MacPowerModuleTestSleepOnPowerButton(ModuleCase):
@@ -193,7 +193,7 @@ class MacPowerModuleTestSleepOnPowerButton(ModuleCase):
 
 
 @skip_if_not_root
-@flaky
+@flaky(attempts=10)
 @skipIf(not salt.utils.platform.is_darwin(), 'Test only available on macOS')
 @skipIf(not salt.utils.path.which('systemsetup'), '\'systemsetup\' binary not found in $PATH')
 class MacPowerModuleTestRestartPowerFailure(ModuleCase):
@@ -243,7 +243,7 @@ class MacPowerModuleTestRestartPowerFailure(ModuleCase):
 
 
 @skip_if_not_root
-@flaky
+@flaky(attempts=10)
 @skipIf(not salt.utils.platform.is_darwin(), 'Test only available on macOS')
 @skipIf(not salt.utils.path.which('systemsetup'), '\'systemsetup\' binary not found in $PATH')
 class MacPowerModuleTestWakeOnNet(ModuleCase):
@@ -290,7 +290,7 @@ class MacPowerModuleTestWakeOnNet(ModuleCase):
 
 
 @skip_if_not_root
-@flaky
+@flaky(attempts=10)
 @skipIf(not salt.utils.platform.is_darwin(), 'Test only available on macOS')
 @skipIf(not salt.utils.path.which('systemsetup'), '\'systemsetup\' binary not found in $PATH')
 class MacPowerModuleTestWakeOnModem(ModuleCase):

--- a/tests/integration/modules/test_mac_shadow.py
+++ b/tests/integration/modules/test_mac_shadow.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 '''
-integration tests for mac_system
+integration tests for mac_shadow
 '''
 
 # Import Python libs
@@ -40,7 +40,7 @@ NO_USER = __random_string()
 @skipIf(not salt.utils.path.which('pwpolicy'), '\'pwpolicy\' binary not found in $PATH')
 class MacShadowModuleTest(ModuleCase):
     '''
-    Validate the mac_system module
+    Validate the mac_shadow module
     '''
 
     def setUp(self):

--- a/tests/integration/modules/test_mac_system.py
+++ b/tests/integration/modules/test_mac_system.py
@@ -34,7 +34,7 @@ SET_SUBNET_NAME = __random_string()
 
 
 @skip_if_not_root
-@flaky(attempts=8)
+@flaky(attempts=10)
 @skipIf(not salt.utils.platform.is_darwin(), 'Test only available on macOS')
 @skipIf(not salt.utils.path.which('systemsetup'), '\'systemsetup\' binary not found in $PATH')
 class MacSystemModuleTest(ModuleCase):


### PR DESCRIPTION
### What does this PR do?
Increasing the attempts on the flaky decorator for the mac modules that use the utility `systemsetup` which seems to be exhibiting buggy behavior on macosx.

A more thorough explanation of the initial issue is included here: https://github.com/saltstack/salt/pull/48583

### Previous Behavior
mac flaky test failures

### New Behavior
increasing the attempts in hope to workaround this bug. Might have to change the approach if this still sometimes fail.

### Tests written?
No- fixes tests

### Commits signed with GPG?

Yes