### PR TITLE
Allow yaml list notation for nodegroup expansion

### DIFF
--- a/tests/integration/files/conf/master
+++ b/tests/integration/files/conf/master
@@ -74,10 +74,14 @@ nodegroups:
     - 'minion'
     - 'or'
     - 'sub_minion'
+  one_minion_list:
+    - 'minion'
   redundant_minions: N@min or N@mins
   nodegroup_loop_a: N@nodegroup_loop_b
   nodegroup_loop_b: N@nodegroup_loop_a
   missing_minion: L@minion,ghostminion
+  list_group: N@multiline_nodegroup
+  one_list_group: N@one_minion_list
 
 
 mysql.host: localhost

--- a/tests/integration/files/conf/master
+++ b/tests/integration/files/conf/master
@@ -70,6 +70,9 @@ nodegroups:
   min: minion
   sub_min: sub_minion
   mins: N@min or N@sub_min
+  list_nodegroup:
+    - 'minion'
+    - 'sub_minion'
   multiline_nodegroup:
     - 'minion'
     - 'or'
@@ -82,6 +85,7 @@ nodegroups:
   missing_minion: L@minion,ghostminion
   list_group: N@multiline_nodegroup
   one_list_group: N@one_minion_list
+  list_group2: N@list_nodegroup
 
 
 mysql.host: localhost

--- a/tests/integration/shell/test_matcher.py
+++ b/tests/integration/shell/test_matcher.py
@@ -153,6 +153,19 @@ class MatchTest(ShellCase, ShellCaseCommonTestsMixin):
         self.assertTrue(minion_in_returns('minion', data))
         self.assertTrue(minion_in_returns('sub_minion', data))
 
+    def test_nodegroup_list(self):
+        data = self.run_salt('-N list_group test.ping')
+        self.assertTrue(minion_in_returns('minion', data))
+        self.assertTrue(minion_in_returns('sub_minion', data))
+
+        data = self.run_salt('-N one_list_group test.ping')
+        self.assertTrue(minion_in_returns('minion', data))
+        self.assertFalse(minion_in_returns('sub_minion', data))
+
+        data = self.run_salt('-N one_minion_list test.ping')
+        self.assertTrue(minion_in_returns('minion', data))
+        self.assertFalse(minion_in_returns('sub_minion', data))
+
     def test_glob(self):
         '''
         test salt glob matcher

--- a/tests/integration/shell/test_matcher.py
+++ b/tests/integration/shell/test_matcher.py
@@ -158,6 +158,10 @@ class MatchTest(ShellCase, ShellCaseCommonTestsMixin):
         self.assertTrue(minion_in_returns('minion', data))
         self.assertTrue(minion_in_returns('sub_minion', data))
 
+        data = self.run_salt('-N list_group2 test.ping')
+        self.assertTrue(minion_in_returns('minion', data))
+        self.assertTrue(minion_in_returns('sub_minion', data))
+
         data = self.run_salt('-N one_list_group test.ping')
         self.assertTrue(minion_in_returns('minion', data))
         self.assertFalse(minion_in_returns('sub_minion', data))

--- a/tests/unit/utils/test_minions.py
+++ b/tests/unit/utils/test_minions.py
@@ -19,6 +19,9 @@ NODEGROUPS = {
     'group2': ['G@foo:bar', 'or', 'web1*'],
     'group3': ['N@group1', 'or', 'N@group2'],
     'group4': ['host4', 'host5', 'host6'],
+    'group5': 'N@group4',
+    'group6': 'N@group3',
+    'group7': ['host1']
 }
 
 EXPECTED = {
@@ -26,6 +29,10 @@ EXPECTED = {
     'group2': ['G@foo:bar', 'or', 'web1*'],
     'group3': ['(', '(', 'L@host1,host2,host3', ')', 'or', '(', 'G@foo:bar', 'or', 'web1*', ')', ')'],
     'group4': ['L@host4,host5,host6'],
+    'group5': ['(', 'L@host4,host5,host6', ')'],
+    'group6': ['(', '(', '(', 'L@host1,host2,host3', ')', 'or', '(',
+               'G@foo:bar', 'or', 'web1*', ')', ')', ')'],
+    'group7': ['L@host1']
 }
 
 


### PR DESCRIPTION
### What does this PR do?
Defining Nodegroups as lists of minions was added in 2016.11.0 (https://docs.saltstack.com/en/latest/topics/targeting/nodegroups.html#defining-nodegroups-as-lists-of-minion-ids), this does not work for nodegroups that target other nodegroups.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/42735

### Previous Behavior
Given this config:

```
nodegroups:
  - free1:
    - newrecipe
    - minion2
  - group1: 'N@free1'
```

you would not be able to target `group1`

```
(salt-py2) ➜  salt git:(0ca04ffbeb) sudo salt -N group1 test.version
No minions matched the target. No command was sent, no jid was assigned.
ERROR: No return received
(salt-py2) ➜  salt git:(0ca04ffbeb) 
```

### New Behavior

```
(salt-py2) ➜  salt git:(nodegroup_group_list) sudo salt -N group1 test.version
newrecipe:
    2019.2.0-386-gd236bd4
minion2:
    2019.2.0-386-gd236bd4
```

### Tests written?
Yes

### Commits signed with GPG?

Yes