### PR TITLE
generify masterminion returners function not found error

### DIFF
--- a/salt/utils/job.py
+++ b/salt/utils/job.py
@@ -41,7 +41,7 @@ def store_job(opts, load, event=None, mminion=None):
         try:
             load['jid'] = mminion.returners[prep_fstr](nocache=load.get('nocache', False))
         except KeyError:
-            emsg = "Returner '{0}' does not support function prep_jid".format(job_cache)
+            emsg = "Returner function not found: {0}".format(prep_fstr)
             log.error(emsg)
             raise KeyError(emsg)
         except Exception:
@@ -55,7 +55,7 @@ def store_job(opts, load, event=None, mminion=None):
         try:
             mminion.returners[saveload_fstr](load['jid'], load)
         except KeyError:
-            emsg = "Returner '{0}' does not support function save_load".format(job_cache)
+            emsg = "Returner function not found: {0}".format(saveload_fstr)
             log.error(emsg)
             raise KeyError(emsg)
         except Exception:


### PR DESCRIPTION
### What does this PR do?

We had an issue where a returner wasn't loaded, but we very confused because the error was telling us sse_pgjsonb didn't have prep_jid.

More likely is that sse_pgjsonb isn't loaded at all.

The error message is now more generic so that it's less misleading.