### PR TITLE
proxy minion __virtual__ error cleanup

### DIFF
--- a/salt/beacons/aix_account.py
+++ b/salt/beacons/aix_account.py
@@ -20,7 +20,7 @@ def __virtual__():
     '''
     Only load if kernel is AIX
     '''
-    if __grains__['kernel'] == ('AIX'):
+    if __grains__.get('kernel') == 'AIX':
         return __virtualname__
 
     return (False, 'The aix_account beacon module failed to load: '

--- a/salt/modules/aix_group.py
+++ b/salt/modules/aix_group.py
@@ -30,7 +30,7 @@ def __virtual__():
     '''
     Set the group module if the kernel is AIX
     '''
-    if __grains__['kernel'] == 'AIX':
+    if __grains__.get('kernel') == 'AIX':
         return __virtualname__
     return (False, 'The aix_group execution module failed to load: '
             'only available on AIX systems.')

--- a/salt/modules/aix_shadow.py
+++ b/salt/modules/aix_shadow.py
@@ -23,7 +23,7 @@ def __virtual__():
     '''
     Only load if kernel is AIX
     '''
-    if __grains__['kernel'] == 'AIX':
+    if __grains__.get('kernel') == 'AIX':
         return __virtualname__
     return (False, 'The aix_shadow execution module failed to load: '
                    'only available on AIX systems.')

--- a/salt/modules/aixpkg.py
+++ b/salt/modules/aixpkg.py
@@ -33,7 +33,7 @@ def __virtual__():
     '''
     Set the virtual pkg module if the os is AIX
     '''
-    if __grains__['os_family'] == 'AIX':
+    if __grains__.get('os_family') == 'AIX':
         return __virtualname__
     return (False,
            'Did not load AIX module on non-AIX OS.')

--- a/salt/modules/apache.py
+++ b/salt/modules/apache.py
@@ -53,7 +53,7 @@ def _detect_os():
     Apache commands and paths differ depending on packaging
     '''
     # TODO: Add pillar support for the apachectl location
-    os_family = __grains__['os_family']
+    os_family = __grains__.get('os_family')
     if os_family == 'RedHat':
         return 'apachectl'
     elif os_family == 'Debian' or os_family == 'Suse':

--- a/salt/modules/bridge.py
+++ b/salt/modules/bridge.py
@@ -29,7 +29,7 @@ def __virtual__():
         'NetBSD': 'brconfig',
         'OpenBSD': 'ifconfig'
     }
-    cur_os = __grains__['kernel']
+    cur_os = __grains__.get('kernel')
     for _os in supported_os_tool:
         if cur_os == _os and salt.utils.path.which(supported_os_tool[cur_os]):
             return True

--- a/salt/modules/deb_apache.py
+++ b/salt/modules/deb_apache.py
@@ -28,7 +28,7 @@ def __virtual__():
     Only load the module if apache is installed
     '''
     cmd = _detect_os()
-    if salt.utils.path.which(cmd) and __grains__['os_family'] == 'Debian':
+    if salt.utils.path.which(cmd) and __grains__.get('os_family') == 'Debian':
         return __virtualname__
     return (False, 'apache execution module not loaded: apache not installed.')
 
@@ -38,9 +38,9 @@ def _detect_os():
     Apache commands and paths differ depending on packaging
     '''
     # TODO: Add pillar support for the apachectl location
-    if __grains__['os_family'] == 'RedHat':
+    if __grains__.get('os_family') == 'RedHat':
         return 'apachectl'
-    elif __grains__['os_family'] == 'Debian':
+    elif __grains__.get('os_family') == 'Debian':
         return 'apache2ctl'
     else:
         return 'apachectl'

--- a/salt/modules/debconfmod.py
+++ b/salt/modules/debconfmod.py
@@ -30,7 +30,7 @@ def __virtual__():
     Confirm this module is on a Debian based system and that debconf-utils
     is installed.
     '''
-    if __grains__['os_family'] != 'Debian':
+    if __grains__.get('os_family') != 'Debian':
         return (False, 'The debconfmod module could not be loaded: '
                 'unsupported OS family')
 

--- a/salt/modules/debian_ip.py
+++ b/salt/modules/debian_ip.py
@@ -49,7 +49,7 @@ def __virtual__():
     '''
     Confine this module to Debian-based distros
     '''
-    if __grains__['os_family'] == 'Debian':
+    if __grains__.get('os_family') == 'Debian':
         return __virtualname__
     return (False, 'The debian_ip module could not be loaded: '
             'unsupported OS family')

--- a/salt/modules/debian_service.py
+++ b/salt/modules/debian_service.py
@@ -41,7 +41,7 @@ def __virtual__():
     '''
     Only work on Debian and when systemd isn't running
     '''
-    if __grains__['os'] in ('Debian', 'Raspbian', 'Devuan', 'NILinuxRT') and not salt.utils.systemd.booted(__context__):
+    if __grains__.get('os') in ('Debian', 'Raspbian', 'Devuan', 'NILinuxRT') and not salt.utils.systemd.booted(__context__):
         return __virtualname__
     else:
         return (False, 'The debian_service module could not be loaded: '

--- a/salt/modules/dpkg_lowpkg.py
+++ b/salt/modules/dpkg_lowpkg.py
@@ -28,7 +28,7 @@ def __virtual__():
     '''
     Confirm this module is on a Debian based system
     '''
-    if __grains__['os_family'] == 'Debian':
+    if __grains__.get('os_family') == 'Debian':
         return __virtualname__
     return (False, 'The dpkg execution module cannot be loaded: '
             'only works on Debian family systems.')

--- a/salt/modules/ebuildpkg.py
+++ b/salt/modules/ebuildpkg.py
@@ -62,7 +62,7 @@ def __virtual__():
     '''
     Confirm this module is on a Gentoo based system
     '''
-    if HAS_PORTAGE and __grains__['os_family'] == 'Gentoo':
+    if HAS_PORTAGE and __grains__.get('os_family') == 'Gentoo':
         return __virtualname__
     return (False, 'The ebuild execution module cannot be loaded: either the system is not Gentoo or the portage python library is not available.')
 

--- a/salt/modules/eix.py
+++ b/salt/modules/eix.py
@@ -12,7 +12,7 @@ def __virtual__():
     '''
     Only works on Gentoo systems with eix installed
     '''
-    if __grains__['os_family'] == 'Gentoo' and salt.utils.path.which('eix'):
+    if __grains__.get('os_family') == 'Gentoo' and salt.utils.path.which('eix'):
         return 'eix'
     return (False, 'The eix execution module cannot be loaded: either the system is not Gentoo or the eix binary is not in the path.')
 

--- a/salt/modules/eselect.py
+++ b/salt/modules/eselect.py
@@ -17,7 +17,7 @@ def __virtual__():
     '''
     Only work on Gentoo systems with eselect installed
     '''
-    if __grains__['os_family'] == 'Gentoo' and salt.utils.path.which('eselect'):
+    if __grains__.get('os_family') == 'Gentoo' and salt.utils.path.which('eselect'):
         return 'eselect'
     return (False, 'The eselect execution module cannot be loaded: either the system is not Gentoo or the eselect binary is not in the path.')
 

--- a/salt/modules/freebsd_sysctl.py
+++ b/salt/modules/freebsd_sysctl.py
@@ -24,7 +24,7 @@ def __virtual__():
     '''
     Only runs on FreeBSD systems
     '''
-    if __grains__['os'] == 'FreeBSD':
+    if __grains__.get('os') == 'FreeBSD':
         return __virtualname__
     return (False, 'The freebsd_sysctl execution module cannot be loaded: '
             'only available on FreeBSD systems.')

--- a/salt/modules/freebsd_update.py
+++ b/salt/modules/freebsd_update.py
@@ -33,7 +33,7 @@ def __virtual__():
 
     Only work on FreeBSD RELEASEs >= 6.2, where freebsd-update was introduced.
     '''
-    if __grains__['os'] != 'FreeBSD':
+    if __grains__.get('os') != 'FreeBSD':
         return (False, 'The freebsd_update execution module cannot be loaded: only available on FreeBSD systems.')
     if float(__grains__['osrelease']) < 6.2:
         return (False, 'freebsd_update is only available on FreeBSD versions >= 6.2-RELESE')

--- a/salt/modules/freebsdjail.py
+++ b/salt/modules/freebsdjail.py
@@ -22,7 +22,7 @@ def __virtual__():
     '''
     Only runs on FreeBSD systems
     '''
-    if __grains__['os'] == 'FreeBSD':
+    if __grains__.get('os') == 'FreeBSD':
         return __virtualname__
     return (False, 'The freebsdjail execution module cannot be loaded: '
             'only available on FreeBSD systems.')

--- a/salt/modules/freebsdkmod.py
+++ b/salt/modules/freebsdkmod.py
@@ -25,7 +25,7 @@ def __virtual__():
     '''
     Only runs on FreeBSD systems
     '''
-    if __grains__['kernel'] == 'FreeBSD':
+    if __grains__.get('kernel') == 'FreeBSD':
         return __virtualname__
     return (False, 'The freebsdkmod execution module cannot be loaded: only available on FreeBSD systems.')
 

--- a/salt/modules/freebsdpkg.py
+++ b/salt/modules/freebsdpkg.py
@@ -98,7 +98,7 @@ def __virtual__():
     Don't load on FreeBSD 9 when the config option
     ``providers:pkg`` is set to 'pkgng'.
     '''
-    if __grains__['os'] == 'FreeBSD' and float(__grains__['osrelease']) < 10:
+    if __grains__.get('os') == 'FreeBSD' and float(__grains__['osrelease']) < 10:
         providers = {}
         if 'providers' in __opts__:
             providers = __opts__['providers']

--- a/salt/modules/freebsdports.py
+++ b/salt/modules/freebsdports.py
@@ -40,7 +40,7 @@ def __virtual__():
     '''
     Only runs on FreeBSD systems
     '''
-    if __grains__['os'] == 'FreeBSD':
+    if __grains__.get('os') == 'FreeBSD':
         return __virtualname__
     return (False, 'The freebsdports execution module cannot be loaded: '
             'only available on FreeBSD systems.')

--- a/salt/modules/freebsdservice.py
+++ b/salt/modules/freebsdservice.py
@@ -37,7 +37,7 @@ def __virtual__():
     Only work on FreeBSD
     '''
     # Disable on these platforms, specific service modules exist:
-    if __grains__['os'] == 'FreeBSD':
+    if __grains__.get('os') == 'FreeBSD':
         return __virtualname__
     return (False, 'The freebsdservice execution module cannot be loaded: only available on FreeBSD systems.')
 

--- a/salt/modules/gentoo_service.py
+++ b/salt/modules/gentoo_service.py
@@ -31,9 +31,9 @@ def __virtual__():
     '''
     Only work on systems which default to OpenRC
     '''
-    if __grains__['os_family'] == 'Gentoo' and not salt.utils.systemd.booted(__context__):
+    if __grains__.get('os_family') == 'Gentoo' and not salt.utils.systemd.booted(__context__):
         return __virtualname__
-    if __grains__['os'] == 'Alpine':
+    if __grains__.get('os') == 'Alpine':
         return __virtualname__
     return (False, 'The gentoo_service execution module cannot be loaded: '
             'only available on Gentoo/Open-RC systems.')

--- a/salt/modules/gentoolkitmod.py
+++ b/salt/modules/gentoolkitmod.py
@@ -24,7 +24,7 @@ def __virtual__():
     '''
     Only work on Gentoo systems with gentoolkit installed
     '''
-    if __grains__['os_family'] == 'Gentoo' and HAS_GENTOOLKIT:
+    if __grains__.get('os_family') == 'Gentoo' and HAS_GENTOOLKIT:
         return __virtualname__
     return (False, 'The gentoolkitmod execution module cannot be loaded: '
        'either the system is not Gentoo or the gentoolkit.eclean python module not available')

--- a/salt/modules/groupadd.py
+++ b/salt/modules/groupadd.py
@@ -34,7 +34,7 @@ def __virtual__():
     '''
     Set the user module if the kernel is Linux or OpenBSD
     '''
-    if __grains__['kernel'] in ('Linux', 'OpenBSD', 'NetBSD'):
+    if __grains__.get('kernel') in ('Linux', 'OpenBSD', 'NetBSD'):
         return __virtualname__
     return (False, 'The groupadd execution module cannot be loaded: '
             ' only available on Linux, OpenBSD and NetBSD')

--- a/salt/modules/grub_legacy.py
+++ b/salt/modules/grub_legacy.py
@@ -31,7 +31,7 @@ def _detect_conf():
     '''
     GRUB conf location differs depending on distro
     '''
-    if __grains__['os_family'] == 'RedHat':
+    if __grains__.get('os_family') == 'RedHat':
         return '/boot/grub/grub.conf'
     # Defaults for Ubuntu, Debian, Arch, and others
     return '/boot/grub/menu.lst'

--- a/salt/modules/keyboard.py
+++ b/salt/modules/keyboard.py
@@ -19,7 +19,7 @@ def __virtual__():
     Only works with systemd or on supported POSIX-like systems
     '''
     if salt.utils.path.which('localectl') \
-            or __grains__['os_family'] in ('RedHat', 'Debian', 'Gentoo'):
+            or __grains__.get('os_family') in ('RedHat', 'Debian', 'Gentoo'):
         return True
     return (False, 'The keyboard exeuction module cannot be loaded: '
         'only works on Redhat, Debian or Gentoo systems or if localectl binary in path.')

--- a/salt/modules/kmod.py
+++ b/salt/modules/kmod.py
@@ -20,7 +20,7 @@ def __virtual__():
     '''
     Only runs on Linux systems
     '''
-    return __grains__['kernel'] == 'Linux'
+    return __grains__.get('kernel') == 'Linux'
 
 
 def _new_mods(pre_mods, post_mods):

--- a/salt/modules/layman.py
+++ b/salt/modules/layman.py
@@ -12,7 +12,7 @@ def __virtual__():
     '''
     Only work on Gentoo systems with layman installed
     '''
-    if __grains__['os_family'] == 'Gentoo' and salt.utils.path.which('layman'):
+    if __grains__.get('os_family') == 'Gentoo' and salt.utils.path.which('layman'):
         return 'layman'
     return (False, 'layman execution module cannot be loaded: only available on Gentoo with layman installed.')
 

--- a/salt/modules/linux_ip.py
+++ b/salt/modules/linux_ip.py
@@ -22,11 +22,11 @@ def __virtual__():
     '''
     if salt.utils.platform.is_windows():
         return (False, 'Module linux_ip: Windows systems are not supported.')
-    if __grains__['os_family'] == 'RedHat':
+    if __grains__.get('os_family') == 'RedHat':
         return (False, 'Module linux_ip: RedHat systems are not supported.')
-    if __grains__['os_family'] == 'Debian':
+    if __grains__.get('os_family') == 'Debian':
         return (False, 'Module linux_ip: Debian systems are not supported.')
-    if __grains__['os_family'] == 'NILinuxRT':
+    if __grains__.get('os_family') == 'NILinuxRT':
         return (False, 'Module linux_ip: NILinuxRT systems are not supported.')
     if not salt.utils.path.which('ip'):
         return (False, 'The linux_ip execution module cannot be loaded: '

--- a/salt/modules/linux_sysctl.py
+++ b/salt/modules/linux_sysctl.py
@@ -32,7 +32,7 @@ def __virtual__():
     '''
     Only run on Linux systems
     '''
-    if __grains__['kernel'] != 'Linux':
+    if __grains__.get('kernel') != 'Linux':
         return (False, 'The linux_sysctl execution module cannot be loaded: only available on Linux systems.')
     return __virtualname__
 

--- a/salt/modules/logadm.py
+++ b/salt/modules/logadm.py
@@ -53,7 +53,7 @@ def __virtual__():
     '''
     Only work on Solaris based systems
     '''
-    if 'Solaris' in __grains__['os_family']:
+    if 'Solaris' in __grains__.get('os_family'):
         return True
     return (False, 'The logadm execution module cannot be loaded: only available on Solaris.')
 

--- a/salt/modules/mac_group.py
+++ b/salt/modules/mac_group.py
@@ -25,7 +25,7 @@ __virtualname__ = 'group'
 def __virtual__():
     global _dscl, _flush_dscl_cache
     if (__grains__.get('kernel') != 'Darwin' or
-            __grains__['osrelease_info'] < (10, 7)):
+            __grains__.get('osrelease_info') < (10, 7)):
         return (False, 'The mac_group execution module cannot be loaded: only available on Darwin-based systems >= 10.7')
     _dscl = salt.utils.functools.namespaced_function(_dscl, globals())
     _flush_dscl_cache = salt.utils.functools.namespaced_function(

--- a/salt/modules/mac_sysctl.py
+++ b/salt/modules/mac_sysctl.py
@@ -20,7 +20,7 @@ def __virtual__():
     '''
     Only run on Darwin (macOS) systems
     '''
-    if __grains__['os'] == 'MacOS':
+    if __grains__.get('os') == 'MacOS':
         return __virtualname__
     return (False, 'The darwin_sysctl execution module cannot be loaded: '
                    'Only available on macOS systems.')

--- a/salt/modules/mac_xattr.py
+++ b/salt/modules/mac_xattr.py
@@ -28,7 +28,7 @@ def __virtual__():
     '''
     Only work on Mac OS
     '''
-    if __grains__['os'] in ['MacOS', 'Darwin']:
+    if __grains__.get('os') in ['MacOS', 'Darwin']:
         return __virtualname__
     return False
 

--- a/salt/modules/makeconf.py
+++ b/salt/modules/makeconf.py
@@ -15,7 +15,7 @@ def __virtual__():
     '''
     Only work on Gentoo
     '''
-    if __grains__['os_family'] == 'Gentoo':
+    if __grains__.get('os_family') == 'Gentoo':
         return 'makeconf'
     return (False, 'The makeconf execution module cannot be loaded: only available on Gentoo systems.')
 

--- a/salt/modules/mdadm_raid.py
+++ b/salt/modules/mdadm_raid.py
@@ -33,7 +33,7 @@ def __virtual__():
     '''
     mdadm provides raid functions for Linux
     '''
-    if __grains__['kernel'] != 'Linux':
+    if __grains__.get('kernel') != 'Linux':
         return (False, 'The mdadm execution module cannot be loaded: only available on Linux.')
     if not salt.utils.path.which('mdadm'):
         return (False, 'The mdadm execution module cannot be loaded: the mdadm binary is not in the path.')

--- a/salt/modules/netbsd_sysctl.py
+++ b/salt/modules/netbsd_sysctl.py
@@ -21,7 +21,7 @@ def __virtual__():
     '''
     Only run on NetBSD systems
     '''
-    if __grains__['os'] == 'NetBSD':
+    if __grains__.get('os') == 'NetBSD':
         return __virtualname__
     return (False, 'The netbsd_sysctl execution module failed to load: '
             'only available on NetBSD.')

--- a/salt/modules/netbsdservice.py
+++ b/salt/modules/netbsdservice.py
@@ -28,7 +28,7 @@ def __virtual__():
     '''
     Only work on NetBSD
     '''
-    if __grains__['os'] == 'NetBSD' and os.path.exists('/etc/rc.subr'):
+    if __grains__.get('os') == 'NetBSD' and os.path.exists('/etc/rc.subr'):
         return __virtualname__
     return (False, 'The netbsdservice execution module failed to load: only available on NetBSD.')
 

--- a/salt/modules/nilrt_ip.py
+++ b/salt/modules/nilrt_ip.py
@@ -70,7 +70,7 @@ def __virtual__():
     '''
     try:
         msg = 'The nilrt_ip module could not be loaded: unsupported OS family'
-        _assume_condition(__grains__['os_family'] == 'NILinuxRT', msg)
+        _assume_condition(__grains__.get('os_family') == 'NILinuxRT', msg)
         _assume_condition(CaseInsensitiveDict, 'The python package request is not installed')
         _assume_condition(pyiface, 'The python pyiface package is not installed')
         if __grains__['lsb_distrib_id'] != 'nilrt':

--- a/salt/modules/nspawn.py
+++ b/salt/modules/nspawn.py
@@ -57,7 +57,7 @@ def __virtual__():
     '''
     Only work on systems that have been booted with systemd
     '''
-    if __grains__['kernel'] == 'Linux' \
+    if __grains__.get('kernel') == 'Linux' \
             and salt.utils.systemd.booted(__context__):
         if salt.utils.systemd.version() is None:
             log.error('nspawn: Unable to determine systemd version')

--- a/salt/modules/openbsd_sysctl.py
+++ b/salt/modules/openbsd_sysctl.py
@@ -21,7 +21,7 @@ def __virtual__():
     '''
     Only run on OpenBSD systems
     '''
-    if __grains__['os'] == 'OpenBSD':
+    if __grains__.get('os') == 'OpenBSD':
         return __virtualname__
     return (False, 'The openbsd_sysctl execution module cannot be loaded: '
             'only available on OpenBSD systems.')

--- a/salt/modules/openbsdpkg.py
+++ b/salt/modules/openbsdpkg.py
@@ -48,7 +48,7 @@ def __virtual__():
     '''
     Set the virtual pkg module if the os is OpenBSD
     '''
-    if __grains__['os'] == 'OpenBSD':
+    if __grains__.get('os') == 'OpenBSD':
         return __virtualname__
     return (False, 'The openbsdpkg execution module cannot be loaded: '
             'only available on OpenBSD systems.')

--- a/salt/modules/openbsdrcctl_service.py
+++ b/salt/modules/openbsdrcctl_service.py
@@ -24,7 +24,7 @@ def __virtual__():
     '''
     rcctl(8) is only available on OpenBSD.
     '''
-    if __grains__['os'] == 'OpenBSD' and os.path.exists('/usr/sbin/rcctl'):
+    if __grains__.get('os') == 'OpenBSD' and os.path.exists('/usr/sbin/rcctl'):
         return __virtualname__
     return (False, 'The openbsdpkg execution module cannot be loaded: '
             'only available on OpenBSD systems.')

--- a/salt/modules/openbsdservice.py
+++ b/salt/modules/openbsdservice.py
@@ -39,7 +39,7 @@ def __virtual__():
     '''
     Only work on OpenBSD
     '''
-    if __grains__['os'] == 'OpenBSD' and os.path.exists('/etc/rc.d/rc.subr'):
+    if __grains__.get('os') == 'OpenBSD' and os.path.exists('/etc/rc.d/rc.subr'):
         krel = list(list(map(int, __grains__['kernelrelease'].split('.'))))
         # The -f flag, used to force a script to run even if disabled,
         # was added after the 5.0 release.

--- a/salt/modules/pacmanpkg.py
+++ b/salt/modules/pacmanpkg.py
@@ -40,7 +40,7 @@ def __virtual__():
     '''
     Set the virtual pkg module if the os is Arch
     '''
-    if __grains__['os_family'] == 'Arch':
+    if __grains__.get('os_family') == 'Arch':
         return __virtualname__
     return (False, 'The pacman module could not be loaded: unsupported OS family.')
 

--- a/salt/modules/pf.py
+++ b/salt/modules/pf.py
@@ -26,11 +26,11 @@ def __virtual__():
     FreeBSD, etc) need to be tested before enabling them.
     '''
     tested_oses = ['FreeBSD', 'OpenBSD']
-    if __grains__['os'] in tested_oses and salt.utils.path.which('pfctl'):
+    if __grains__.get('os') in tested_oses and salt.utils.path.which('pfctl'):
         return True
 
     return (False, 'The pf execution module cannot be loaded: either the '
-            'OS (' + __grains__['os'] + ') is not tested or the pfctl binary '
+            'OS (' + __grains__.get('os', 'None') + ') is not tested or the pfctl binary '
             'was not found')
 
 

--- a/salt/modules/pkgin.py
+++ b/salt/modules/pkgin.py
@@ -91,12 +91,11 @@ def _supports_parsing():
     return tuple([int(i) for i in _get_version()]) > (0, 6)
 
 
-@decorators.memoize
 def _get_provider():
     '''
     Check if we are the default provider for this platform
     '''
-    return __grains__['os'] in ['NetBSD', 'DragonFly', 'Minix', 'Darwin', 'SmartOS'] or 'pkgin'
+    return __grains__.get('os') in ['NetBSD', 'DragonFly', 'Minix', 'Darwin', 'SmartOS'] or 'pkgin'
 
 
 def __virtual__():

--- a/salt/modules/pkgng.py
+++ b/salt/modules/pkgng.py
@@ -68,11 +68,11 @@ def __virtual__():
     Load as 'pkg' on FreeBSD 9 when config option
     ``providers:pkg`` is set to 'pkgng'.
     '''
-    if __grains__['kernel'] == 'DragonFly':
+    if __grains__.get('kernel') == 'DragonFly':
         return __virtualname__
-    if __grains__['os'] == 'FreeBSD' and float(__grains__['osrelease']) >= 10:
+    if __grains__.get('os') == 'FreeBSD' and float(__grains__['osrelease']) >= 10:
         return __virtualname__
-    if __grains__['os'] == 'FreeBSD' and int(__grains__['osmajorrelease']) == 9:
+    if __grains__.get('os') == 'FreeBSD' and int(__grains__['osmajorrelease']) == 9:
         providers = {}
         if 'providers' in __opts__:
             providers = __opts__['providers']

--- a/salt/modules/pkgutil.py
+++ b/salt/modules/pkgutil.py
@@ -29,7 +29,7 @@ def __virtual__():
     '''
     Set the virtual pkg module if the os is Solaris
     '''
-    if __grains__['os_family'] == 'Solaris':
+    if __grains__.get('os_family') == 'Solaris':
         return __virtualname__
     return (False, 'The pkgutil execution module cannot be loaded: '
             'only available on Solaris systems.')

--- a/salt/modules/portage_config.py
+++ b/salt/modules/portage_config.py
@@ -48,7 +48,7 @@ def __virtual__():
     '''
     Confirm this module is on a Gentoo based system.
     '''
-    if HAS_PORTAGE and __grains__['os_family'] == 'Gentoo':
+    if HAS_PORTAGE and __grains__.get('os_family') == 'Gentoo':
         return 'portage_config'
     return (False, 'portage_config execution module cannot be loaded: only available on Gentoo with portage installed.')
 

--- a/salt/modules/poudriere.py
+++ b/salt/modules/poudriere.py
@@ -20,7 +20,7 @@ def __virtual__():
     '''
     Module load on freebsd only and if poudriere installed
     '''
-    if __grains__['os'] == 'FreeBSD' and salt.utils.path.which('poudriere'):
+    if __grains__.get('os') == 'FreeBSD' and salt.utils.path.which('poudriere'):
         return 'poudriere'
     else:
         return (False, 'The poudriere execution module failed to load: only available on FreeBSD with the poudriere binary in the path.')

--- a/salt/modules/pw_group.py
+++ b/salt/modules/pw_group.py
@@ -34,7 +34,7 @@ def __virtual__():
     '''
     Set the user module if the kernel is FreeBSD or Dragonfly
     '''
-    if __grains__['kernel'] in ('FreeBSD', 'DragonFly'):
+    if __grains__.get('kernel') in ('FreeBSD', 'DragonFly'):
         return __virtualname__
     return (False, 'The pw_group execution module cannot be loaded: '
             'system is not supported.')

--- a/salt/modules/pw_user.py
+++ b/salt/modules/pw_user.py
@@ -62,7 +62,7 @@ def __virtual__():
     '''
     Set the user module if the kernel is FreeBSD or DragonFly
     '''
-    if HAS_PWD and __grains__['kernel'] in ('FreeBSD', 'DragonFly'):
+    if HAS_PWD and __grains__.get('kernel') in ('FreeBSD', 'DragonFly'):
         return __virtualname__
     return (False, 'The pw_user execution module cannot be loaded: the pwd python module is not available or the system is not FreeBSD.')
 

--- a/salt/modules/rbac_solaris.py
+++ b/salt/modules/rbac_solaris.py
@@ -21,7 +21,7 @@ def __virtual__():
     '''
     Provides rbac if we are running on a solaris like system
     '''
-    if __grains__['kernel'] == 'SunOS' and salt.utils.path.which('profiles'):
+    if __grains__.get('kernel') == 'SunOS' and salt.utils.path.which('profiles'):
         return __virtualname__
     return (
         False,

--- a/salt/modules/rh_ip.py
+++ b/salt/modules/rh_ip.py
@@ -39,7 +39,7 @@ def __virtual__():
     '''
     Confine this module to RHEL/Fedora based distros
     '''
-    if __grains__['os_family'] == 'RedHat':
+    if __grains__.get('os_family') == 'RedHat':
         return __virtualname__
     return (False, 'The rh_ip execution module cannot be loaded: this module is only available on RHEL/Fedora based distributions.')
 

--- a/salt/modules/rh_service.py
+++ b/salt/modules/rh_service.py
@@ -71,7 +71,7 @@ def __virtual__():
         'McAfee  OS Server',
         'VirtuozzoLinux'
     ))
-    if __grains__['os'] in enable:
+    if __grains__.get('os') in enable:
 
         if __grains__['os'] == 'SUSE':
             if six.text_type(__grains__['osrelease']).startswith('11'):

--- a/salt/modules/selinux.py
+++ b/salt/modules/selinux.py
@@ -52,7 +52,7 @@ def __virtual__():
         if not salt.utils.path.which(cmd):
             return (False, cmd + ' is not in the path')
     # SELinux only makes sense on Linux *obviously*
-    if __grains__['kernel'] == 'Linux':
+    if __grains__.get('kernel') == 'Linux':
         return 'selinux'
     return (False, 'Module only works on Linux with selinux installed')
 

--- a/salt/modules/service.py
+++ b/salt/modules/service.py
@@ -46,7 +46,7 @@ def __virtual__():
     if __grains__.get('os') in disable:
         return (False, 'Your OS is on the disabled list')
     # Disable on all non-Linux OSes as well
-    if __grains__['kernel'] != 'Linux':
+    if __grains__.get('kernel') != 'Linux':
         return (False, 'Non Linux OSes are not supported')
     init_grain = __grains__.get('init')
     if init_grain not in (None, 'sysvinit', 'unknown'):

--- a/salt/modules/smf_service.py
+++ b/salt/modules/smf_service.py
@@ -27,7 +27,7 @@ def __virtual__():
     '''
     Only work on systems which default to SMF
     '''
-    if 'Solaris' in __grains__['os_family']:
+    if 'Solaris' in __grains__.get('os_family'):
         # Don't let this work on Solaris 9 since SMF doesn't exist on it.
         if __grains__['kernelrelease'] == "5.9":
             return (False, 'The smf execution module failed to load: SMF not available on Solaris 9.')

--- a/salt/modules/solaris_group.py
+++ b/salt/modules/solaris_group.py
@@ -33,7 +33,7 @@ def __virtual__():
     '''
     Set the group module if the kernel is SunOS
     '''
-    if __grains__['kernel'] == 'SunOS':
+    if __grains__.get('kernel') == 'SunOS':
         return __virtualname__
     return (False, 'The solaris_group execution module failed to load: '
             'only available on Solaris systems.')

--- a/salt/modules/solaris_user.py
+++ b/salt/modules/solaris_user.py
@@ -37,7 +37,7 @@ def __virtual__():
     '''
     Set the user module if the kernel is SunOS
     '''
-    if __grains__['kernel'] == 'SunOS' and HAS_PWD:
+    if __grains__.get('kernel') == 'SunOS' and HAS_PWD:
         return __virtualname__
     return (False, 'The solaris_user execution module failed to load: '
             'only available on Solaris systems with pwd module installed.')

--- a/salt/modules/solarisipspkg.py
+++ b/salt/modules/solarisipspkg.py
@@ -62,7 +62,7 @@ def __virtual__():
     '''
     Set the virtual pkg module if the os is Solaris 11
     '''
-    if __grains__['os_family'] == 'Solaris' \
+    if __grains__.get('os_family') == 'Solaris' \
             and float(__grains__['kernelrelease']) > 5.10 \
             and salt.utils.path.which('pkg'):
         return __virtualname__

--- a/salt/modules/solarispkg.py
+++ b/salt/modules/solarispkg.py
@@ -32,7 +32,7 @@ def __virtual__():
     '''
     Set the virtual pkg module if the os is Solaris
     '''
-    if __grains__['os_family'] == 'Solaris' and float(__grains__['kernelrelease']) <= 5.10:
+    if __grains__.get('os_family') == 'Solaris' and float(__grains__['kernelrelease']) <= 5.10:
         return __virtualname__
     return (False,
             'The solarispkg execution module failed to load: only available '

--- a/salt/modules/suse_apache.py
+++ b/salt/modules/suse_apache.py
@@ -23,7 +23,7 @@ def __virtual__():
     '''
     Only load the module if apache is installed.
     '''
-    if salt.utils.path.which('apache2ctl') and __grains__['os_family'] == 'Suse':
+    if salt.utils.path.which('apache2ctl') and __grains__.get('os_family') == 'Suse':
         return __virtualname__
     return (False, 'apache execution module not loaded: apache not installed.')
 

--- a/salt/modules/systemd_service.py
+++ b/salt/modules/systemd_service.py
@@ -60,7 +60,7 @@ def __virtual__():
     '''
     Only work on systems that have been booted with systemd
     '''
-    if __grains__['kernel'] == 'Linux' \
+    if __grains__.get('kernel') == 'Linux' \
        and salt.utils.systemd.booted(__context__):
         return __virtualname__
     return (

--- a/salt/modules/upstart_service.py
+++ b/salt/modules/upstart_service.py
@@ -74,9 +74,9 @@ def __virtual__():
     # Disable on these platforms, specific service modules exist:
     if salt.utils.systemd.booted(__context__):
         return (False, 'The upstart execution module failed to load: this system was booted with systemd.')
-    elif __grains__['os'] in ('Ubuntu', 'Linaro', 'elementary OS', 'Mint'):
+    elif __grains__.get('os') in ('Ubuntu', 'Linaro', 'elementary OS', 'Mint'):
         return __virtualname__
-    elif __grains__['os'] in ('Debian', 'Raspbian'):
+    elif __grains__.get('os') in ('Debian', 'Raspbian'):
         debian_initctl = '/sbin/initctl'
         if os.path.isfile(debian_initctl):
             initctl_version = salt.modules.cmdmod._run_quiet(debian_initctl + ' version')

--- a/salt/modules/useradd.py
+++ b/salt/modules/useradd.py
@@ -42,7 +42,7 @@ def __virtual__():
     Set the user module if the kernel is Linux, OpenBSD, NetBSD or AIX
     '''
 
-    if HAS_PWD and __grains__['kernel'] in ('Linux', 'OpenBSD', 'NetBSD', 'AIX'):
+    if HAS_PWD and __grains__.get('kernel') in ('Linux', 'OpenBSD', 'NetBSD', 'AIX'):
         return __virtualname__
     return (False, 'useradd execution module not loaded: either pwd python library not available or system not one of Linux, OpenBSD, NetBSD or AIX')
 

--- a/salt/modules/vmctl.py
+++ b/salt/modules/vmctl.py
@@ -30,7 +30,7 @@ def __virtual__():
     '''
     Only works on OpenBSD with vmctl(8) present.
     '''
-    if __grains__['os'] == 'OpenBSD' and salt.utils.path.which('vmctl'):
+    if __grains__.get('os') == 'OpenBSD' and salt.utils.path.which('vmctl'):
         return True
 
     return (False, 'The vmm execution module cannot be loaded: either the system is not OpenBSD or the vmctl binary was not found')

--- a/salt/modules/xapi_virt.py
+++ b/salt/modules/xapi_virt.py
@@ -49,7 +49,7 @@ __virtualname__ = 'virt'
 
 
 def _check_xenapi():
-    if __grains__['os'] == 'Debian':
+    if __grains__.get('os') == 'Debian':
         debian_xen_version = '/usr/lib/xen-common/bin/xen-version'
         if os.path.isfile(debian_xen_version):
             # __salt__ is not available in __virtual__

--- a/salt/modules/xbpspkg.py
+++ b/salt/modules/xbpspkg.py
@@ -34,7 +34,7 @@ def __virtual__():
     '''
     Set the virtual pkg module if the os is Void and xbps-install found
     '''
-    if __grains__['os'] in ('Void') and _check_xbps():
+    if __grains__.get('os', 'None') in ('Void') and _check_xbps():
         return __virtualname__
     return False
 

--- a/salt/modules/zoneadm.py
+++ b/salt/modules/zoneadm.py
@@ -37,7 +37,7 @@ def _is_globalzone():
     '''
     Check if we are running in the globalzone
     '''
-    if not __grains__['kernel'] == 'SunOS':
+    if not __grains__.get('kernel') == 'SunOS':
         return False
 
     zonename = __salt__['cmd.run_all']('zonename')

--- a/salt/modules/zonecfg.py
+++ b/salt/modules/zonecfg.py
@@ -84,7 +84,7 @@ def _is_globalzone():
     '''
     Check if we are running in the globalzone
     '''
-    if not __grains__['kernel'] == 'SunOS':
+    if not __grains__.get('kernel') == 'SunOS':
         return False
 
     zonename = __salt__['cmd.run_all']('zonename')

--- a/salt/states/debconfmod.py
+++ b/salt/states/debconfmod.py
@@ -73,7 +73,7 @@ def __virtual__():
     '''
     Confirm this module is on a Debian based system
     '''
-    if __grains__['os_family'] != 'Debian':
+    if __grains__.get('os_family') != 'Debian':
         return False
     # Check that debconf was loaded
     if 'debconf.show' not in __salt__:

--- a/salt/states/mac_xattr.py
+++ b/salt/states/mac_xattr.py
@@ -27,7 +27,7 @@ def __virtual__():
     '''
     Only work on Mac OS
     '''
-    if __grains__['os'] in ['MacOS', 'Darwin']:
+    if __grains__.get('os') in ['MacOS', 'Darwin']:
         return __virtualname__
     return False
 

--- a/salt/states/mdadm_raid.py
+++ b/salt/states/mdadm_raid.py
@@ -38,7 +38,7 @@ def __virtual__():
     '''
     mdadm provides raid functions for Linux
     '''
-    if __grains__['kernel'] != 'Linux':
+    if __grains__.get('kernel') != 'Linux':
         return False
     if not salt.utils.path.which('mdadm'):
         return False

--- a/salt/states/rbac_solaris.py
+++ b/salt/states/rbac_solaris.py
@@ -37,7 +37,7 @@ def __virtual__():
     '''
     if 'rbac.profile_list' in __salt__ and \
         'user.list_users' in __salt__ and \
-         __grains__['kernel'] == 'SunOS':
+         __grains__.get('kernel') == 'SunOS':
         return True
     else:
         return (

--- a/salt/states/service.py
+++ b/salt/states/service.py
@@ -86,7 +86,7 @@ def __virtual__():
     else:
         return (False, 'No service execution module loaded: '
                 'check support for service management on {0} '
-                ''.format(__grains__.get('osfinger', __grains__['os']))
+                ''.format(__grains__.get('osfinger', __grains__.get('os', 'NO OS')))
                )
 
 

--- a/salt/states/zfs.py
+++ b/salt/states/zfs.py
@@ -68,7 +68,7 @@ def __virtual__():
     '''
     Provides zfs state
     '''
-    if __grains__['zfs_support']:
+    if __grains__.get('zfs_support'):
         return __virtualname__
     else:
         return (False, "The zfs state cannot be loaded: zfs not supported")

--- a/salt/states/zpool.py
+++ b/salt/states/zpool.py
@@ -88,7 +88,7 @@ def __virtual__():
     '''
     Provides zpool state
     '''
-    if __grains__['zfs_support']:
+    if __grains__.get('zfs_support'):
         return __virtualname__
     else:
         return False, 'The zpool state cannot be loaded: zfs not supported'


### PR DESCRIPTION
### What does this PR do?
proxy minions may not have os/os_family/kernel set.

Let's use `__grains__.get('os')` appropriately so errors aren't written to logs.