### PR TITLE
address race condition in LocalClient

### DIFF
--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -1112,7 +1112,7 @@ class LocalClient(object):
         else:
             ret_iter = self.get_returns_no_block('salt/job/{0}'.format(jid))
         # iterator for the info of this job
-        jinfo = None
+        jinfo = {}
         jinfo_iter = []
         # open event jids that need to be un-subscribed from later
         open_jids = set()
@@ -1184,7 +1184,7 @@ class LocalClient(object):
                 # unsubscribe from previous find_job ping before sending out
                 # the new broadcast if needed, otherwise long running jobs will
                 # accumulate and be computationally expensive to finish
-                if isinstance(jinfo, dict) and 'jid' in jinfo:
+                if 'jid' in jinfo:
                     self._clean_up_subscriptions(jinfo['jid'])
 
                 # since this is a new ping, no one has responded yet
@@ -1279,7 +1279,7 @@ class LocalClient(object):
                 yield
 
         # unsubscribe to the last open tracking jids
-        if isinstance(jinfo, dict) and 'jid' in jinfo:
+        if 'jid' in jinfo:
             self._clean_up_subscriptions(jinfo['jid'])
         self._clean_up_subscriptions(jid)
 

--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -242,6 +242,7 @@ class LocalClient(object):
                                 **kwargs
                                )
 
+        # we should already be subscribed to the response, but incase we are not
         if 'jid' in pub_data:
             self.event.subscribe(pub_data['jid'])
 
@@ -1111,6 +1112,7 @@ class LocalClient(object):
         else:
             ret_iter = self.get_returns_no_block('salt/job/{0}'.format(jid))
         # iterator for the info of this job
+        jinfo = None
         jinfo_iter = []
         # open event jids that need to be un-subscribed from later
         open_jids = set()
@@ -1179,6 +1181,12 @@ class LocalClient(object):
             # if the jinfo has timed out and some minions are still running the job
             # re-do the ping
             if time.time() > timeout_at and minions_running:
+                # unsubscribe from previous find_job ping before sending out
+                # the new broadcast if needed, otherwise long running jobs will
+                # accumulate and be computationally expensive to finish
+                if isinstance(jinfo, dict) and 'jid' in jinfo:
+                    self._clean_up_subscriptions(jinfo['jid'])
+
                 # since this is a new ping, no one has responded yet
                 jinfo = self.gather_job_info(jid, list(minions - found), 'list', **kwargs)
                 minions_running = False
@@ -1215,8 +1223,6 @@ class LocalClient(object):
                             'from client return. This may be an error in '
                             'the client.', missing_key
                         )
-                # Keep track of the jid events to unsubscribe from later
-                open_jids.add(jinfo['jid'])
 
                 # TODO: move to a library??
                 if 'minions' in raw.get('data', {}):
@@ -1272,10 +1278,10 @@ class LocalClient(object):
             else:
                 yield
 
-        # If there are any remaining open events, clean them up.
-        if open_jids:
-            for jid in open_jids:
-                self.event.unsubscribe(jid)
+        # unsubscribe to the last open tracking jids
+        if isinstance(jinfo, dict) and 'jid' in jinfo:
+            self._clean_up_subscriptions(jinfo['jid'])
+        self._clean_up_subscriptions(jid)
 
         if expect_minions:
             for minion in list((minions - found)):
@@ -1720,6 +1726,7 @@ class LocalClient(object):
 
         # if we did generate a jid or have one provided we should preemptively subscribe
         if subscribe:
+            self.event.subscribe(jid)
             if self.opts.get('order_masters'):
                 self.event.subscribe('syndic/.*/{0}'.format(jid), 'regex')
             self.event.subscribe('salt/job/{0}'.format(jid))
@@ -1953,6 +1960,7 @@ class LocalClient(object):
             del self.event
 
     def _clean_up_subscriptions(self, job_id):
+        self.event.unsubscribe(job_id)
         if self.opts.get('order_masters'):
             self.event.unsubscribe('syndic/.*/{0}'.format(job_id), 'regex')
         self.event.unsubscribe('salt/job/{0}'.format(job_id))

--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -1711,19 +1711,17 @@ class LocalClient(object):
         try:
             # Retrieve the jid
             jid = self.returners[fstr](nocache=nocache, passed_jid=jid)
-        except (Exception) as exc:
+        except Exception:
             # The returner is not present
-            msg = (
-                'Failed to allocate a jid. The requested returner \'{0}\' '
-                'could not be loaded.'.format(fstr.split('.')[0])
-            )
-            log.error(msg)
+            log.error('Failed to allocate a jid. The requested returner \'{0}\' '
+                      'could not be loaded.'.format(fstr.split('.')[0]),
+                      exc_info_on_loglevel=logging.DEBUG)
             return ''
 
         # if we did generate a jid or have one provided we should preemptively subscribe
         if subscribe:
             if self.opts.get('order_masters'):
-                self.event.subscribe('syndic/.*/{0}'.format(jid, 'regex'))
+                self.event.subscribe('syndic/.*/{0}'.format(jid), 'regex')
             self.event.subscribe('salt/job/{0}'.format(jid))
 
         return jid
@@ -1792,7 +1790,6 @@ class LocalClient(object):
             if listen and not self.event.connect_pub(timeout=timeout):
                 raise SaltReqTimeoutError()
 
-            log.error(channel)
             payload = channel.send(payload_kwargs, timeout=timeout)
         except SaltReqTimeoutError as err:
             log.error(err)

--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -1713,8 +1713,8 @@ class LocalClient(object):
             jid = self.returners[fstr](nocache=nocache, passed_jid=jid)
         except Exception:
             # The returner is not present
-            log.error('Failed to allocate a jid. The requested returner \'{0}\' '
-                      'could not be loaded.'.format(fstr.split('.')[0]),
+            log.error('Failed to allocate a jid. The requested returner \'%s\' '
+                      'could not be loaded.', fstr.split('.')[0],
                       exc_info_on_loglevel=logging.DEBUG)
             return ''
 

--- a/salt/master.py
+++ b/salt/master.py
@@ -2209,8 +2209,8 @@ class ClearFuncs(object):
         except (KeyError, TypeError):
             # The returner is not present
             msg = (
-                'Failed to allocate a jid. The requested returner \'{0}\' '
-                'could not be loaded.'.format(fstr.split('.')[0])
+                'Failed to allocate a jid. The requested returner \'%s\' '
+                'could not be loaded.', fstr.split('.')[0]
             )
             log.error(msg)
             return {'error': msg}

--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -361,7 +361,7 @@ class SaltEvent(object):
             return
         match_func = self._get_match_func(match_type)
 
-        self.pending_tags.remove([tag, match_func])
+        self.pending_tags = [tag for tag in self.pending_tags if tag != [tag, match_func]]
 
         old_events = self.pending_events
         self.pending_events = []

--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -351,6 +351,11 @@ class SaltEvent(object):
         if tag is None:
             return
         match_func = self._get_match_func(match_type)
+
+        # we only need one of a given tag/func tuple
+        if [tag, match_func] in self.pending_tags:
+            return
+
         self.pending_tags.append([tag, match_func])
 
     def unsubscribe(self, tag, match_type=None):
@@ -361,7 +366,7 @@ class SaltEvent(object):
             return
         match_func = self._get_match_func(match_type)
 
-        self.pending_tags = [tag for tag in self.pending_tags if tag != [tag, match_func]]
+        self.pending_tags = [tagset for tagset in self.pending_tags if tagset != [tag, match_func]]
 
         old_events = self.pending_events
         self.pending_events = []

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -9,7 +9,7 @@ from __future__ import absolute_import, print_function, unicode_literals
 # Import Salt Testing libs
 import tests.integration as integration
 from tests.support.unit import TestCase, skipIf
-from tests.support.mock import patch, NO_MOCK, NO_MOCK_REASON, MagicMock
+from tests.support.mock import patch, NO_MOCK, NO_MOCK_REASON
 from tornado.concurrent import Future
 
 
@@ -69,13 +69,13 @@ class LocalClientTestCase(TestCase,
                         if closure_jid['count'] < 5:
                             yield None
                         elif closure_jid['count'] >= 5:
-                            yield {'data': {'retcode': 0, 'return': { 'ret': 'final result'}, 'id': 'minion1'}}
+                            yield {'data': {'retcode': 0, 'return': {'ret': 'final result'}, 'id': 'minion1'}}
                             break
                 return jit_iter()
             else:
                 # gather_job_info calls
                 self.assertTrue(len(self.client.event.pending_tags) == 1, msg='pending tags tracking only single jid while in flight')
-                return iter([{'data': {'retcode': 0, 'return': { 'ret': 'still running'}, 'id': 'minion1'}}])
+                return iter([{'data': {'retcode': 0, 'return': {'ret': 'still running'}, 'id': 'minion1'}}])
 
         def run_job(*args, **kwargs):
             closure_jid['count'] += 1

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -49,6 +49,10 @@ class LocalClientTestCase(TestCase,
 
         self.assertDictEqual(valid_pub_data, self.client._check_pub_data(valid_pub_data))
 
+    def test__prep_pub(self):
+        fake_pub = self.client._prep_pub('*', 'first.func', [], 'glob', None, '', 30, True)
+        self.assertTrue(salt.utils.jid.is_jid(fake_pub['jid']))
+
     def test_cmd_subset(self):
         with patch('salt.client.LocalClient.cmd', return_value={'minion1': ['first.func', 'second.func'],
                                                                 'minion2': ['first.func', 'second.func']}):


### PR DESCRIPTION
### What does this PR do?
The current flow through localclient to Publisher requires waiting for
a response (which contains the jid) before subscribing to the job rets.
There is a race condition in which the publish and response could be
sent before return & subscribe, and there is no reason we can't mint the
jid _before_ publishing and circumvent the issue entirely, so we do
that. The existing master-side code path will still exist for back
compat if a jid is not pre-minted.


### What issues does this PR fix or reference?
tentative race condition in localclient with fast returning calls.

### Tests written?
Yes, added a unit test. to assert jid generation.
**[NOTICE] Bug fixes or features added to Salt require tests.**
Please review the [test documentation](https://docs.saltstack.com/en/latest/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite.


### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
