### PR TITLE
salt.utils.gitfs: fix fetching specific remote

### DIFF
--- a/salt/utils/gitfs.py
+++ b/salt/utils/gitfs.py
@@ -2358,7 +2358,9 @@ class GitBase(object):
         changed = False
         for repo in self.remotes:
             name = getattr(repo, 'name', None)
-            if not remotes or (repo.id, name) in remotes:
+            if not remotes or repo.id in remotes or name in remotes:
+                # Fetch if no specific remote desired, or if the repo's "id" or
+                # "name" attribute matches one of the desired remotes
                 try:
                     if repo.fetch():
                         # We can't just use the return value from repo.fetch()


### PR DESCRIPTION
The default behavior for gitfs is to fetch all remotes. The "remotes"
argument to this function is meant for additional flexibility should
anyone be using salt.utils.gitfs outside of the context of
gitfs/git_pillar. This is therefore a low-impact bug, but a bug
nonetheless.

Good catch by @sathieu https://github.com/saltstack/salt/pull/44830#discussion_r298210579