### PR TITLE
Pytest 5.0 contextmanager str: call value on ExceptionInfo objects

### DIFF
--- a/tests/unit/modules/test_file.py
+++ b/tests/unit/modules/test_file.py
@@ -1310,7 +1310,7 @@ class FilemodLineTests(TestCase, LoaderModuleMockMixin):
         for mode, err_msg in [(None, 'How to process the file'), ('nonsense', 'Unknown mode')]:
             with pytest.raises(CommandExecutionError) as cmd_err:
                 filemod.line('foo', mode=mode)
-            self.assertIn(err_msg, six.text_type(cmd_err))
+            self.assertIn(err_msg, six.text_type(cmd_err.value))
 
     @patch('os.path.realpath', MagicMock(wraps=lambda x: x))
     @patch('os.path.isfile', MagicMock(return_value=True))
@@ -1323,7 +1323,7 @@ class FilemodLineTests(TestCase, LoaderModuleMockMixin):
             with pytest.raises(CommandExecutionError) as cmd_err:
                 filemod.line('foo', mode=mode)
             self.assertIn('Content can only be empty if mode is "delete"',
-                          six.text_type(cmd_err))
+                          six.text_type(cmd_err.value))
 
     @patch('os.path.realpath', MagicMock(wraps=lambda x: x))
     @patch('os.path.isfile', MagicMock(return_value=True))
@@ -1338,7 +1338,7 @@ class FilemodLineTests(TestCase, LoaderModuleMockMixin):
             with pytest.raises(CommandExecutionError) as cmd_err:
                 filemod.line('foo', content='test content', mode='insert')
             self.assertIn('"location" or "before/after"',
-                          six.text_type(cmd_err))
+                          six.text_type(cmd_err.value))
 
     def test_util_starts_till(self):
         '''
@@ -1948,7 +1948,7 @@ class FilemodLineTests(TestCase, LoaderModuleMockMixin):
                         filemod.line('foo', content=cfg_content, after=_after, before=_before, mode='ensure')
             self.assertIn(
                 'Found more than one line between boundaries "before" and "after"',
-                six.text_type(cmd_err))
+                six.text_type(cmd_err.value))
 
     @with_tempfile()
     def test_line_delete(self, name):

--- a/tests/unit/modules/test_localemod.py
+++ b/tests/unit/modules/test_localemod.py
@@ -162,7 +162,7 @@ class LocalemodTestCase(TestCase, LoaderModuleMockMixin):
         '''
         with pytest.raises(CommandExecutionError) as err:
             localemod._localectl_status()
-        assert 'Unable to find "localectl"' in six.text_type(err)
+        assert 'Unable to find "localectl"' in six.text_type(err.value)
         assert not localemod.log.debug.called
 
     @patch('salt.utils.path.which', MagicMock(return_value="/usr/bin/localctl"))
@@ -170,14 +170,14 @@ class LocalemodTestCase(TestCase, LoaderModuleMockMixin):
     def test_localectl_status_parser_empty(self):
         with pytest.raises(CommandExecutionError) as err:
             localemod._localectl_status()
-        assert 'Unable to parse result of "localectl"' in six.text_type(err)
+        assert 'Unable to parse result of "localectl"' in six.text_type(err.value)
 
     @patch('salt.utils.path.which', MagicMock(return_value="/usr/bin/localctl"))
     @patch('salt.modules.localemod.__salt__', {'cmd.run': MagicMock(return_value=locale_ctl_out_broken)})
     def test_localectl_status_parser_broken(self):
         with pytest.raises(CommandExecutionError) as err:
             localemod._localectl_status()
-        assert 'Unable to parse result of "localectl"' in six.text_type(err)
+        assert 'Unable to parse result of "localectl"' in six.text_type(err.value)
 
     @patch('salt.utils.path.which', MagicMock(return_value="/usr/bin/localctl"))
     @patch('salt.modules.localemod.__salt__', {'cmd.run': MagicMock(return_value=locale_ctl_out_structure)})
@@ -295,7 +295,7 @@ class LocalemodTestCase(TestCase, LoaderModuleMockMixin):
         '''
         with pytest.raises(CommandExecutionError) as err:
             localemod.get_locale()
-        assert '"DrunkDragon" is unsupported' in six.text_type(err)
+        assert '"DrunkDragon" is unsupported' in six.text_type(err.value)
 
     @patch('salt.utils.path.which', MagicMock(return_value="/usr/bin/localctl"))
     @patch('salt.modules.localemod.__grains__', {'os_family': 'Ubuntu', 'osmajorrelease': 42})
@@ -398,7 +398,7 @@ class LocalemodTestCase(TestCase, LoaderModuleMockMixin):
         with pytest.raises(CommandExecutionError) as err:
             localemod.set_locale(loc)
         assert not localemod._localectl_set.called
-        assert 'Cannot set locale: "update-locale" was not found.' in six.text_type(err)
+        assert 'Cannot set locale: "update-locale" was not found.' in six.text_type(err.value)
 
     @patch('salt.utils.path.which', MagicMock(return_value=None))
     @patch('salt.modules.localemod.__grains__', {'os_family': 'Gentoo', 'osmajorrelease': 42})
@@ -469,7 +469,7 @@ class LocalemodTestCase(TestCase, LoaderModuleMockMixin):
         '''
         with pytest.raises(CommandExecutionError) as err:
             localemod.set_locale('de_DE.utf8')
-        assert 'Unsupported platform' in six.text_type(err)
+        assert 'Unsupported platform' in six.text_type(err.value)
 
     @patch('salt.utils.locales.normalize_locale', MagicMock(return_value='en_US.UTF-8 UTF-8'))
     @patch('salt.modules.localemod.__salt__', {'locale.list_avail': MagicMock(return_value=['A', 'B'])})
@@ -539,7 +539,7 @@ class LocalemodTestCase(TestCase, LoaderModuleMockMixin):
         '''
         with pytest.raises(CommandExecutionError) as err:
             localemod.gen_locale('de_DE.utf8')
-        assert 'Command "locale-gen" or "localedef" was not found on this system.' in six.text_type(err)
+        assert 'Command "locale-gen" or "localedef" was not found on this system.' in six.text_type(err.value)
 
     def test_gen_locale_debian(self):
         '''


### PR DESCRIPTION
### What does this PR do?

The tests:

```
unit.modules.test_localemod.LocalemodTestCase.test_gen_locale_suse_localedef_error_handling
unit.modules.test_localemod.LocalemodTestCase.test_get_locale_with_no_systemd_unknown
unit.modules.test_localemod.LocalemodTestCase.test_localectl_status_parser_broken
unit.modules.test_localemod.LocalemodTestCase.test_localectl_status_parser_empty
unit.modules.test_localemod.LocalemodTestCase.test_localectl_status_parser_no_systemd
unit.modules.test_localemod.LocalemodTestCase.test_set_locale_with_no_systemd_debian_no_update_locale
unit.modules.test_localemod.LocalemodTestCase.test_set_locale_with_no_systemd_unknown
unit.modules.test_file.FilemodLineTests.test_line_insert_ensure_beforeafter_rangelines
unit.modules.test_file.FilemodLineTests.test_line_insert_no_location_no_before_no_after
unit.modules.test_file.FilemodLineTests.test_line_modecheck_failure
```

are failing on mac osx because it is installing pytest 5.0.0. 

This is due to the removal of `__str__` here https://github.com/pytest-dev/pytest/pull/5413

Updated the tests to call `.value` also see comment here: https://github.com/pytest-dev/pytest/issues/5528#issuecomment-507032120

### What issues does this PR fix or reference?

### Previous Behavior
tests failing:

```
unit.modules.test_localemod.LocalemodTestCase.test_gen_locale_suse_localedef_error_handling
unit.modules.test_localemod.LocalemodTestCase.test_get_locale_with_no_systemd_unknown
unit.modules.test_localemod.LocalemodTestCase.test_localectl_status_parser_broken
unit.modules.test_localemod.LocalemodTestCase.test_localectl_status_parser_empty
unit.modules.test_localemod.LocalemodTestCase.test_localectl_status_parser_no_systemd
unit.modules.test_localemod.LocalemodTestCase.test_set_locale_with_no_systemd_debian_no_update_locale
unit.modules.test_localemod.LocalemodTestCase.test_set_locale_with_no_systemd_unknown
unit.modules.test_file.FilemodLineTests.test_line_insert_ensure_beforeafter_rangelines
unit.modules.test_file.FilemodLineTests.test_line_insert_no_location_no_before_no_after
unit.modules.test_file.FilemodLineTests.test_line_modecheck_failure
```

### New Behavior
test pass on pytest <=5.0.0

### Tests written?
No -fixes test

### Commits signed with GPG?

Yes