### PR TITLE
Fix util users chugid and umask

### DIFF
--- a/salt/utils/user.py
+++ b/salt/utils/user.py
@@ -238,18 +238,24 @@ def chugid_and_umask(runas, umask, group=None):
     set_grp = False
 
     current_user = getpass.getuser()
+    current_grp = grp.getgrgid(pwd.getpwnam(getpass.getuser()).pw_gid).gr_name
+
     if runas and runas != current_user:
         set_runas = True
         runas_user = runas
     else:
         runas_user = current_user
 
-    current_grp = grp.getgrgid(pwd.getpwnam(getpass.getuser()).pw_gid).gr_name
-    if group and group != current_grp:
-        set_grp = True
+    if group:
         runas_grp = group
+        if group != current_grp:
+            set_grp = True
     else:
-        runas_grp = current_grp
+        if runas and runas != current_user:
+            runas_grp = grp.getgrgid(pwd.getpwnam(runas_user).pw_gid).gr_name
+            set_grp = True
+        else:
+            runas_grp = current_grp
 
     if set_runas or set_grp:
         chugid(runas_user, runas_grp)

--- a/tests/unit/utils/test_user.py
+++ b/tests/unit/utils/test_user.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+
+# Import python libs
+from __future__ import absolute_import, print_function, unicode_literals
+import os
+import grp
+import pwd
+import sys
+import time
+import signal
+import multiprocessing
+import functools
+
+# Import Salt Testing libs
+from tests.support.unit import TestCase, skipIf
+from tests.support.helpers import (this_user) 
+from tests.support.mock import (
+    patch,
+    NO_MOCK,
+    NO_MOCK_REASON
+)
+
+# Import salt libs
+import salt.utils.platform
+import salt.utils.user
+
+class TestUser(TestCase):
+    @skipIf(NO_MOCK, NO_MOCK_REASON)
+    @skipIf(salt.utils.platform.is_windows(), "Module not available on Windows")
+    def test_chugid_and_umask(self):
+
+        #with patch('grp.getgrnam', MagicMock(return_value=getgrnam)):
+
+        running_user = this_user()
+        running_group = grp.getgrgid(os.getgid()).gr_name
+
+        gids = {30: 'expectedgroup', 20: running_group}
+        getgrnams = {'expectedgroup': grp.struct_group(('expectedgroup', '*', 30, ['expecteduser'])),
+                     running_group: grp.struct_group((running_group, '*', 20, [running_user]))}
+        getpwnams = {'expecteduser': pwd.struct_passwd(('expecteduser', 'x', 30, 30, '-', '-', '-')), 
+                running_user: pwd.struct_passwd((running_user, 'x', 20, 20, '-', '-', '-'))}
+
+        def getgrnam(group):
+            return getgrnams[group]
+
+        def getpwnam(user):
+            return getpwnams[user]
+
+        def getgrgid(gid):
+            return getgrnams[gids[gid]]
+
+        with patch('grp.getgrgid', getgrgid):
+            with patch('grp.getgrnam', getgrnam):
+                with patch('pwd.getpwnam', getpwnam): 
+                    with patch('salt.utils.user.chugid') as chugid_mock:
+                        salt.utils.user.chugid_and_umask('expecteduser', umask=None, group=running_group)
+                        chugid_mock.assert_called_with('expecteduser', running_group)
+                        print('-------------------------------------------------------------')
+                        print('test2 start')
+                        salt.utils.user.chugid_and_umask('expecteduser', umask=None, group=None)
+                        chugid_mock.assert_called_with('expecteduser', 'expectedgroup')

--- a/tests/unit/utils/test_user.py
+++ b/tests/unit/utils/test_user.py
@@ -5,15 +5,10 @@ from __future__ import absolute_import, print_function, unicode_literals
 import os
 import grp
 import pwd
-import sys
-import time
-import signal
-import multiprocessing
-import functools
 
 # Import Salt Testing libs
 from tests.support.unit import TestCase, skipIf
-from tests.support.helpers import (this_user) 
+from tests.support.helpers import this_user
 from tests.support.mock import (
     patch,
     NO_MOCK,
@@ -24,12 +19,11 @@ from tests.support.mock import (
 import salt.utils.platform
 import salt.utils.user
 
+
 class TestUser(TestCase):
     @skipIf(NO_MOCK, NO_MOCK_REASON)
     @skipIf(salt.utils.platform.is_windows(), "Module not available on Windows")
     def test_chugid_and_umask(self):
-
-        #with patch('grp.getgrnam', MagicMock(return_value=getgrnam)):
 
         running_user = this_user()
         running_group = grp.getgrgid(os.getgid()).gr_name
@@ -37,8 +31,8 @@ class TestUser(TestCase):
         gids = {30: 'expectedgroup', 20: running_group}
         getgrnams = {'expectedgroup': grp.struct_group(('expectedgroup', '*', 30, ['expecteduser'])),
                      running_group: grp.struct_group((running_group, '*', 20, [running_user]))}
-        getpwnams = {'expecteduser': pwd.struct_passwd(('expecteduser', 'x', 30, 30, '-', '-', '-')), 
-                running_user: pwd.struct_passwd((running_user, 'x', 20, 20, '-', '-', '-'))}
+        getpwnams = {'expecteduser': pwd.struct_passwd(('expecteduser', 'x', 30, 30, '-', '-', '-')),
+                     running_user: pwd.struct_passwd((running_user, 'x', 20, 20, '-', '-', '-'))}
 
         def getgrnam(group):
             return getgrnams[group]
@@ -51,11 +45,9 @@ class TestUser(TestCase):
 
         with patch('grp.getgrgid', getgrgid):
             with patch('grp.getgrnam', getgrnam):
-                with patch('pwd.getpwnam', getpwnam): 
+                with patch('pwd.getpwnam', getpwnam):
                     with patch('salt.utils.user.chugid') as chugid_mock:
                         salt.utils.user.chugid_and_umask('expecteduser', umask=None, group=running_group)
                         chugid_mock.assert_called_with('expecteduser', running_group)
-                        print('-------------------------------------------------------------')
-                        print('test2 start')
                         salt.utils.user.chugid_and_umask('expecteduser', umask=None, group=None)
                         chugid_mock.assert_called_with('expecteduser', 'expectedgroup')


### PR DESCRIPTION
### What does this PR do?
When group parameter was added to `salt.utils.user` previous behaviour of the function `chugid_and_umask` changed. When parameter `runas` is provided but group parameter is not the effective group will remain as the executing user of salt. Previously this was changed to the primary group of user in runas parameter. This PR restores the old behaviour so that old code continues to work when group parameter is omitted.

### Previous Behavior
Example below use cmd.run to show behaviour. Notice gid in output. 
```
[saltminion2019] root@saltminion2019:~ # salt-call cmd.run id runas=wpa
local:
    uid=24774(wpa) gid=0(root) groups=0(root),10513(domain_users)
[saltminion2019] root@saltminion2019:~ #
```

### New Behavior
```
[saltminion2019] root@saltminion2019:~ # salt-call cmd.run id runas=wpa
local:
    uid=24774(wpa) gid=10513(domain_users) groups=10513(domain_users)
[saltminion2019] root@saltminion2019:~ #
```
### Tests written?
Yes, could not find any existing test for user.py. New file created unit/utils/test_user.py. Please let me know if tests should be implemented elsewhere.

### Commits signed with GPG?
Yes