### PR TITLE
Fix compare issue in lgpo state module

### DIFF
--- a/tests/unit/states/test_win_lgpo.py
+++ b/tests/unit/states/test_win_lgpo.py
@@ -1,0 +1,100 @@
+# -*- coding: utf-8 -*-
+'''
+:codeauthor: Shane Lee <slee@saltstack.com>
+'''
+
+# Import Python Libs
+from __future__ import absolute_import, unicode_literals, print_function
+
+# Import Salt Testing Libs
+from tests.support.unit import TestCase
+
+# Import Salt Libs
+import salt.states.win_lgpo as win_lgpo
+
+
+class WinSystemTestCase(TestCase):
+    '''
+    Test cases for the win_lgpo state
+    '''
+
+    def test__compare_policies_string(self):
+        '''
+        ``_compare_policies`` should only return ``True`` when the string values
+        are the same. All other scenarios should return ``False``
+        '''
+        compare_string = 'Salty test'
+        # Same
+        self.assertTrue(
+            win_lgpo._compare_policies(compare_string, compare_string)
+        )
+        # Different
+        self.assertFalse(
+            win_lgpo._compare_policies(compare_string, 'Not the same')
+        )
+        # List
+        self.assertFalse(
+            win_lgpo._compare_policies(compare_string, ['item1', 'item2'])
+        )
+        # Dict
+        self.assertFalse(
+            win_lgpo._compare_policies(compare_string, {'key': 'value'})
+        )
+        # None
+        self.assertFalse(
+            win_lgpo._compare_policies(compare_string, None)
+        )
+
+    def test__compare_policies_list(self):
+        '''
+        ``_compare_policies`` should only return ``True`` when the lists are the
+        same. All other scenarios should return ``False``
+        '''
+        compare_list = ['Salty', 'test']
+        # Same
+        self.assertTrue(
+            win_lgpo._compare_policies(compare_list, compare_list)
+        )
+        # Different
+        self.assertFalse(
+            win_lgpo._compare_policies(compare_list, ['Not', 'the', 'same'])
+        )
+        # String
+        self.assertFalse(
+            win_lgpo._compare_policies(compare_list, 'Not a list')
+        )
+        # Dict
+        self.assertFalse(
+            win_lgpo._compare_policies(compare_list, {'key': 'value'})
+        )
+        # None
+        self.assertFalse(
+            win_lgpo._compare_policies(compare_list, None)
+        )
+
+    def test__compare_policies_dict(self):
+        '''
+        ``_compare_policies`` should only return ``True`` when the dicts are the
+        same. All other scenarios should return ``False``
+        '''
+        compare_dict = {'Salty': 'test'}
+        # Same
+        self.assertTrue(
+            win_lgpo._compare_policies(compare_dict, compare_dict)
+        )
+        # Different
+        self.assertFalse(
+            win_lgpo._compare_policies(compare_dict, {'key': 'value'})
+        )
+        # String
+        self.assertFalse(
+            win_lgpo._compare_policies(compare_dict, 'Not a dict')
+        )
+        # List
+        self.assertFalse(
+            win_lgpo._compare_policies(compare_dict, ['Not', 'a', 'dict'])
+        )
+        # None
+        self.assertFalse(
+            win_lgpo._compare_policies(compare_dict, None)
+        )


### PR DESCRIPTION
### What does this PR do?
The state was failing when the current policy and the new policy were differing types.
Creates a `_compare_policies` helper function to determine if policies are the same.
Compares `dicts` to `dicts` and `lists` to `lists`. Otherwise, returns `False`
Adds some unit tests

### What issues does this PR fix or reference?
https://github.com/saltstack/lock/issues/1740

### Tests written?
Yes

### Commits signed with GPG?
Yes