### PR TITLE
attempt at fixing 25721

### DIFF
--- a/salt/client/ssh/shell.py
+++ b/salt/client/ssh/shell.py
@@ -22,7 +22,7 @@ from salt.ext import six
 
 log = logging.getLogger(__name__)
 
-SSH_PASSWORD_PROMPT_RE = re.compile(r'(?:.*)[Pp]assword(?: for .*)?:', re.M)
+SSH_PASSWORD_PROMPT_RE = re.compile(r'(?:.*)[Pp]assword(?: for .*)?:\s*$', re.M)
 KEY_VALID_RE = re.compile(r'.*\(yes\/no\).*')
 SSH_PRIVATE_KEY_PASSWORD_PROMPT_RE = re.compile(r'Enter passphrase for key', re.M)
 

--- a/tests/integration/ssh/test_raw.py
+++ b/tests/integration/ssh/test_raw.py
@@ -10,16 +10,19 @@ from tests.support.unit import skipIf
 # Import Salt Libs
 import salt.utils.platform
 
+import timeout_decorator
+
 
 @skipIf(salt.utils.platform.is_windows(), 'salt-ssh not available on Windows')
 class SSHRawTest(SSHCase):
     '''
     testing salt-ssh with raw calls
     '''
+    @timeout_decorator.timeout(60, use_signals=False)
     def test_ssh_raw(self):
         '''
         test salt-ssh with -r argument
         '''
-        msg = 'running raw msg'
+        msg = 'password: foo'
         ret = self.run_function('echo {0}'.format(msg), raw=True)
         self.assertEqual(ret['stdout'], msg + '\n')


### PR DESCRIPTION
### What does this PR do?
Adjusts salt-ssh detection with an updated regex. New behavior assumes password prompt will not have content after `password:`

### What issues does this PR fix or reference?
Attempts to sort of fix #25721

### Previous Behavior
See diff

### New Behavior
See diff

### Tests written?
Existing test adjusted to trigger this behavior. This is complicated by salt-ssh commands being spawned by a subprocess. Thus, the usual `self.run_ssh(whatever, timeout=60)` doesn't help as the previous behavior of pausing for input for an ssh password: prompt would hang the test processes. To progress, I used the timeout-decorator pip module, but this adds an additional dependency to the test framework. Perhaps there's a better method? 
Yes

### Commits signed with GPG?
No