### PR TITLE
[2019.2.1] Disabling test_get_set_computer_name on OS X and Py3

### DIFF
--- a/tests/integration/modules/test_mac_system.py
+++ b/tests/integration/modules/test_mac_system.py
@@ -16,6 +16,7 @@ from tests.support.helpers import destructiveTest, skip_if_not_root, flaky
 # Import salt libs
 import salt.utils.path
 import salt.utils.platform
+import salt.ext.six as six
 from salt.ext.six.moves import range
 
 
@@ -128,7 +129,7 @@ class MacSystemModuleTest(ModuleCase):
             'Invalid String Value for Enabled',
             self.run_function('system.set_remote_events', ['spongebob']))
 
-    @skipIf(salt.utils.platform.is_darwin() and six.PY3, 'This test hangs on OS X on Py3')
+    @skipIf(salt.utils.platform.is_darwin() and six.PY3, 'This test hangs on OS X on Py3.  Skipping until #53566 is merged.')
     @destructiveTest
     def test_get_set_computer_name(self):
         '''

--- a/tests/integration/modules/test_mac_system.py
+++ b/tests/integration/modules/test_mac_system.py
@@ -128,6 +128,7 @@ class MacSystemModuleTest(ModuleCase):
             'Invalid String Value for Enabled',
             self.run_function('system.set_remote_events', ['spongebob']))
 
+    @skipIf(salt.utils.platform.is_darwin() and six.PY3, 'This test hangs on OS X on Py3')
     @destructiveTest
     def test_get_set_computer_name(self):
         '''


### PR DESCRIPTION
### What does this PR do?
Disabling test_get_set_computer_name on OS X and Py3.

### What issues does this PR fix or reference?
N/A

### Tests written?
**[NOTICE] Bug fixes or features added to Salt require tests.**
Please review the [test documentation](https://docs.saltstack.com/en/latest/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite.
No

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
