### PR TITLE
fix hgfs fileserver virtualname mismatch

### DIFF
--- a/salt/fileserver/hgfs.py
+++ b/salt/fileserver/hgfs.py
@@ -76,7 +76,7 @@ from salt.utils.event import tagify
 log = logging.getLogger(__name__)
 
 # Define the module's virtual name
-__virtualname__ = 'hg'
+__virtualname__ = 'hgfs'
 
 
 def __virtual__():


### PR DESCRIPTION
match the __virtualname__ to the one found in fileserver_backend, fixes loading the module when fileserver_backend contains either hg or hgfs

### What does this PR do?

### What issues does this PR fix or reference?
 
#53730

### Previous Behavior
Remove this section if not relevant

### New Behavior
Remove this section if not relevant

### Tests written?
**[NOTICE] Bug fixes or features added to Salt require tests.**
Please review the [test documentation](https://docs.saltstack.com/en/latest/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite.

Yes/No

### Commits signed with GPG?

Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
