### PR TITLE
Split exception assertion in pieces

### DIFF
--- a/tests/unit/utils/test_schema.py
+++ b/tests/unit/utils/test_schema.py
@@ -1734,7 +1734,9 @@ class ConfigTestCase(TestCase):
         with self.assertRaises(jsonschema.exceptions.ValidationError) as excinfo:
             jsonschema.validate({'item': {'sides': '4', 'color': 'blue'}}, TestConf.serialize())
         if JSONSCHEMA_VERSION >= _LooseVersion('3.0.0'):
-            self.assertIn('\'4\' is not of type \'boolean\'', excinfo.exception.message)
+            self.assertIn("'4'", excinfo.exception.message)
+            self.assertIn("is not of type", excinfo.exception.message)
+            self.assertIn("'boolean'", excinfo.exception.message)
         else:
             self.assertIn('is not valid under any of the given schemas', excinfo.exception.message)
 
@@ -1840,7 +1842,9 @@ class ConfigTestCase(TestCase):
         with self.assertRaises(jsonschema.exceptions.ValidationError) as excinfo:
             jsonschema.validate({'item': ['maybe']}, TestConf.serialize())
         if JSONSCHEMA_VERSION >= _LooseVersion('3.0.0'):
-            self.assertIn('\'maybe\' is not one of [\'yes\']', excinfo.exception.message)
+            self.assertIn("'maybe'", excinfo.exception.message)
+            self.assertIn("is not one of", excinfo.exception.message)
+            self.assertIn("'yes'", excinfo.exception.message)
         else:
             self.assertIn('is not valid under any of the given schemas', excinfo.exception.message)
 
@@ -1895,7 +1899,9 @@ class ConfigTestCase(TestCase):
         with self.assertRaises(jsonschema.exceptions.ValidationError) as excinfo:
             jsonschema.validate({'item': ['maybe']}, TestConf.serialize())
         if JSONSCHEMA_VERSION >= _LooseVersion('3.0.0'):
-            self.assertIn('\'maybe\' is not one of [\'yes\']', excinfo.exception.message)
+            self.assertIn("'maybe'", excinfo.exception.message)
+            self.assertIn("is not one of", excinfo.exception.message)
+            self.assertIn("'yes'", excinfo.exception.message)
         else:
             self.assertIn('is not valid under any of the given schemas', excinfo.exception.message)
 


### PR DESCRIPTION
### What does this PR do?

Amazon Linux in particular has some funny encoding problems. By
splitting the assertion into multiple ones, we can provide roughly the
same assurance, but the test will actually pass.

### What issues does this PR fix or reference?

It's a precursor to several other PRs

### Tests written?
**[NOTICE] Bug fixes or features added to Salt require tests.**
Please review the [test documentation](https://docs.saltstack.com/en/latest/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite.

Yes - fixes test

### Commits signed with GPG?

Yes