### PR TITLE
Added request_interval feature to wait_for_successful_query module

### DIFF
--- a/salt/modules/http.py
+++ b/salt/modules/http.py
@@ -58,7 +58,7 @@ def wait_for_successful_query(url, wait_for=300, **kwargs):
 
     .. code-block:: bash
 
-        salt '*' http.wait_for_successful_query http://somelink.com/ wait_for=160
+        salt '*' http.wait_for_successful_query http://somelink.com/ wait_for=160 request_interval=1
     '''
 
     starttime = time.time()

--- a/salt/modules/http.py
+++ b/salt/modules/http.py
@@ -79,10 +79,9 @@ def wait_for_successful_query(url, wait_for=300, **kwargs):
                 raise caught_exception  # pylint: disable=E0702
 
             return result
-        else:
+        elif 'request_interval' in kwargs:
             # Space requests out by delaying for an interval
-            if 'request_interval' in kwargs:
-                time.sleep(kwargs['request_interval'])
+            time.sleep(kwargs['request_interval'])
 
 
 def update_ca_bundle(target=None, source=None, merge_files=None):

--- a/salt/modules/http.py
+++ b/salt/modules/http.py
@@ -79,6 +79,10 @@ def wait_for_successful_query(url, wait_for=300, **kwargs):
                 raise caught_exception  # pylint: disable=E0702
 
             return result
+        else:
+            # Space requests out by delaying for an interval
+            if 'request_interval' in kwargs:
+                time.sleep(kwargs['request_interval'])
 
 
 def update_ca_bundle(target=None, source=None, merge_files=None):

--- a/salt/states/http.py
+++ b/salt/states/http.py
@@ -162,8 +162,7 @@ def wait_for_successful_query(name, wait_for=300, **kwargs):
                 # workaround pylint bug https://www.logilab.org/ticket/3207
                 raise caught_exception  # pylint: disable=E0702
             return ret
-        else:
+        elif 'request_interval' in kwargs:
             # Space requests out by delaying for an interval
-            if 'request_interval' in kwargs:
-                log.debug('delaying query for %s seconds.', kwargs['request_interval'])
-                time.sleep(kwargs['request_interval'])
+            log.debug('delaying query for %s seconds.', kwargs['request_interval'])
+            time.sleep(kwargs['request_interval'])

--- a/tests/unit/modules/test_http.py
+++ b/tests/unit/modules/test_http.py
@@ -41,11 +41,9 @@ class HttpTestCase(TestCase, LoaderModuleMockMixin):
         Test for wait_for_successful_query waits for request_interval
         '''
 
-        query_mock = MagicMock()
-        query_mock.side_effect = [{'error': 'error'}, {}]
+        query_mock = MagicMock(side_effect = [{'error': 'error'}, {}])
 
         with patch.object(salt.utils.http, 'query', query_mock):
-            patch('time.time', MagicMock(return_value=1000))
             with patch('time.sleep', MagicMock()) as sleep_mock:
                 self.assertEqual(http.wait_for_successful_query('url', request_interval=1), {})
                 sleep_mock.assert_called_once_with(1)
@@ -55,11 +53,9 @@ class HttpTestCase(TestCase, LoaderModuleMockMixin):
         Test for wait_for_successful_query waits for request_interval
         '''
 
-        query_mock = MagicMock()
-        query_mock.side_effect = [{'error': 'error'}, {}]
+        query_mock = MagicMock(side_effect = [{'error': 'error'}, {}])
 
         with patch.object(salt.utils.http, 'query', query_mock):
-            patch('time.time', MagicMock(return_value=1000))
             with patch('time.sleep', MagicMock()) as sleep_mock:
                 self.assertEqual(http.wait_for_successful_query('url'), {})
                 sleep_mock.assert_not_called()

--- a/tests/unit/modules/test_http.py
+++ b/tests/unit/modules/test_http.py
@@ -10,6 +10,7 @@ from __future__ import absolute_import, print_function, unicode_literals
 from tests.support.mixins import LoaderModuleMockMixin
 from tests.support.unit import TestCase, skipIf
 from tests.support.mock import (
+    MagicMock,
     patch,
     NO_MOCK,
     NO_MOCK_REASON
@@ -34,3 +35,31 @@ class HttpTestCase(TestCase, LoaderModuleMockMixin):
         '''
         with patch.object(salt.utils.http, 'query', return_value='A'):
             self.assertEqual(http.query('url'), 'A')
+
+    def test_wait_for_successful_query_with_request_interval(self):
+        '''
+        Test for wait_for_successful_query waits for request_interval
+        '''
+
+        query_mock = MagicMock()
+        query_mock.side_effect = [{'error': 'error'}, {}]
+
+        with patch.object(salt.utils.http, 'query', query_mock):
+            patch('time.time', MagicMock(return_value=1000))
+            with patch('time.sleep', MagicMock()) as sleep_mock:
+                self.assertEqual(http.wait_for_successful_query('url', request_interval=1), {})
+                sleep_mock.assert_called_once_with(1)
+
+    def test_wait_for_successful_query_without_request_interval(self):
+        '''
+        Test for wait_for_successful_query waits for request_interval
+        '''
+
+        query_mock = MagicMock()
+        query_mock.side_effect = [{'error': 'error'}, {}]
+
+        with patch.object(salt.utils.http, 'query', query_mock):
+            patch('time.time', MagicMock(return_value=1000))
+            with patch('time.sleep', MagicMock()) as sleep_mock:
+                self.assertEqual(http.wait_for_successful_query('url'), {})
+                sleep_mock.assert_not_called()

--- a/tests/unit/modules/test_http.py
+++ b/tests/unit/modules/test_http.py
@@ -36,24 +36,24 @@ class HttpTestCase(TestCase, LoaderModuleMockMixin):
         with patch.object(salt.utils.http, 'query', return_value='A'):
             self.assertEqual(http.query('url'), 'A')
 
-    def test_wait_for_successful_query_with_request_interval(self):
+    def test_wait_for_with_interval(self):
         '''
         Test for wait_for_successful_query waits for request_interval
         '''
 
-        query_mock = MagicMock(side_effect = [{'error': 'error'}, {}])
+        query_mock = MagicMock(side_effect=[{'error': 'error'}, {}])
 
         with patch.object(salt.utils.http, 'query', query_mock):
             with patch('time.sleep', MagicMock()) as sleep_mock:
                 self.assertEqual(http.wait_for_successful_query('url', request_interval=1), {})
                 sleep_mock.assert_called_once_with(1)
 
-    def test_wait_for_successful_query_without_request_interval(self):
+    def test_wait_for_without_interval(self):
         '''
         Test for wait_for_successful_query waits for request_interval
         '''
 
-        query_mock = MagicMock(side_effect = [{'error': 'error'}, {}])
+        query_mock = MagicMock(side_effect=[{'error': 'error'}, {}])
 
         with patch.object(salt.utils.http, 'query', query_mock):
             with patch('time.sleep', MagicMock()) as sleep_mock:

--- a/tests/unit/states/test_http.py
+++ b/tests/unit/states/test_http.py
@@ -12,6 +12,7 @@ import salt.states.http as http
 from tests.support.mixins import LoaderModuleMockMixin
 from tests.support.unit import skipIf, TestCase
 from tests.support.mock import (
+    MagicMock,
     NO_MOCK,
     NO_MOCK_REASON,
     MagicMock,
@@ -44,3 +45,27 @@ class HttpTestCase(TestCase, LoaderModuleMockMixin):
             with patch.dict(http.__salt__, {'http.query': mock}):
                 self.assertDictEqual(http.query("salt", "Dude", "stack"),
                                      ret[1])
+
+    def test_wait_for_successful_query_with_request_interval(self):
+        '''
+        Test for wait_for_successful_query waits for request_interval
+        '''
+
+        query_mock = MagicMock(side_effect = [{'error': 'error'}, {'result': True}])
+
+        with patch.object(http, 'query', query_mock):
+            with patch('time.sleep', MagicMock()) as sleep_mock:
+                self.assertEqual(http.wait_for_successful_query('url', request_interval=1, status=200), {'result': True})
+                sleep_mock.assert_called_once_with(1)
+
+    def test_wait_for_successful_query_without_request_interval(self):
+        '''
+        Test for wait_for_successful_query waits for request_interval
+        '''
+
+        query_mock = MagicMock(side_effect = [{'error': 'error'}, {'result': True}])
+
+        with patch.object(http, 'query', query_mock):
+            with patch('time.sleep', MagicMock()) as sleep_mock:
+                self.assertEqual(http.wait_for_successful_query('url', status=200), {'result': True})
+                sleep_mock.assert_not_called()

--- a/tests/unit/states/test_http.py
+++ b/tests/unit/states/test_http.py
@@ -12,7 +12,6 @@ import salt.states.http as http
 from tests.support.mixins import LoaderModuleMockMixin
 from tests.support.unit import skipIf, TestCase
 from tests.support.mock import (
-    MagicMock,
     NO_MOCK,
     NO_MOCK_REASON,
     MagicMock,
@@ -46,24 +45,25 @@ class HttpTestCase(TestCase, LoaderModuleMockMixin):
                 self.assertDictEqual(http.query("salt", "Dude", "stack"),
                                      ret[1])
 
-    def test_wait_for_successful_query_with_request_interval(self):
+    def test_wait_for_with_interval(self):
         '''
         Test for wait_for_successful_query waits for request_interval
         '''
 
-        query_mock = MagicMock(side_effect = [{'error': 'error'}, {'result': True}])
+        query_mock = MagicMock(side_effect=[{'error': 'error'}, {'result': True}])
 
         with patch.object(http, 'query', query_mock):
             with patch('time.sleep', MagicMock()) as sleep_mock:
-                self.assertEqual(http.wait_for_successful_query('url', request_interval=1, status=200), {'result': True})
+                self.assertEqual(http.wait_for_successful_query('url', request_interval=1, status=200),
+                                 {'result': True})
                 sleep_mock.assert_called_once_with(1)
 
-    def test_wait_for_successful_query_without_request_interval(self):
+    def test_wait_for_without_interval(self):
         '''
         Test for wait_for_successful_query waits for request_interval
         '''
 
-        query_mock = MagicMock(side_effect = [{'error': 'error'}, {'result': True}])
+        query_mock = MagicMock(side_effect=[{'error': 'error'}, {'result': True}])
 
         with patch.object(http, 'query', query_mock):
             with patch('time.sleep', MagicMock()) as sleep_mock:


### PR DESCRIPTION
### What does this PR do?
Added `request_interval` kwargs to the http.wait_for_successful_query module to be aligned with the state.

### What issues does this PR fix or reference?
#53738 

### Previous Behavior
`request_interval` was not supported in the `http.wait_for_successful_query` module

### New Behavior
`request_interval` now supported in the `http.wait_for_successful_query` module

### Tests written?

Yes

### Commits signed with GPG?

Yes