### PR TITLE
Allow for pytest discovery of test names, rename usage to not conflict

### DIFF
--- a/tests/unit/utils/test_schedule.py
+++ b/tests/unit/utils/test_schedule.py
@@ -19,8 +19,8 @@ import tests.integration as integration
 import salt.config
 from salt.utils.schedule import Schedule
 
-from salt.modules.test import ping as test_ping
-from salt.modules.test import true_ as test_true
+from salt.modules.test import ping as salt_test_ping
+from salt.modules.test import true_ as salt_test_true
 from salt.modules.status import time as status_time
 from salt.modules.cmdmod import run as cmd_run
 
@@ -57,8 +57,8 @@ class ScheduleTestCase(TestCase):
 
     def setUp(self):
         with patch('salt.utils.schedule.clean_proc_dir', MagicMock(return_value=None)):
-            functions = {'test.ping': test_ping,
-                         'test.true': test_true,
+            functions = {'test.ping': salt_test_ping,
+                         'test.true': salt_test_true,
                          'status.time': status_time,
                          'cmd.run': cmd_run}
             self.schedule = Schedule(copy.deepcopy(self.default_config),


### PR DESCRIPTION
### What does this PR do?
Alters the usage of test_ping and test_true in a test so that they are not picked up by pytest as valid tests.

### What issues does this PR fix or reference?
https://jenkinsci-staging.saltstack.com/view/Pull%20Requests/job/pr-kitchen-centos7-py2/view/change-requests/job/PR-53460/17/testReport/tests.unit.utils/test_schedule/Parallel_Test_Run___Unit__3___test_ping/

### Previous Behavior
pytest was not previously used

### New Behavior
Allows for using pytest with Python 3 

### Tests written?
Yes - updated test file

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
