### PR TITLE
Fix problem with ssh_auth state module and comments which contains sp…

### DIFF
--- a/salt/states/ssh_auth.py
+++ b/salt/states/ssh_auth.py
@@ -329,7 +329,7 @@ def present(
                 keyline = keyline.split(' ')
                 key_type = keyline[0]
                 key_value = keyline[1]
-                key_comment = keyline[2] if len(keyline) > 2 else ''
+                key_comment = ' '.join(keyline[2:]) if len(keyline) > 2 else ''
                 data = __salt__['ssh.set_auth_key'](
                         user,
                         key_value,


### PR DESCRIPTION
…aces

Fixes  #40078

### What does this PR do?

Parse all the not truncated comment for a authorized_keys line from file

### What issues does this PR fix or reference?
#40078

### Previous Behavior
truncated the authorized_keys comment

### New Behavior
doesn't truncated the authorized_keys comment

### Tests written?
No

### Commits signed with GPG?

No