### PR TITLE
Fixes SmartOS grains when using py3

### DIFF
--- a/salt/grains/mdata.py
+++ b/salt/grains/mdata.py
@@ -63,6 +63,8 @@ def _user_mdata(mdata_list=None, mdata_get=None):
         return grains
 
     for mdata_grain in __salt__['cmd.run'](mdata_list, ignore_retcode=True).splitlines():
+        if mdata_grain.startswith("ERROR:"):
+            continue
         mdata_value = __salt__['cmd.run']('{0} {1}'.format(mdata_get, mdata_grain), ignore_retcode=True)
 
         if not mdata_grain.startswith('sdc:'):
@@ -89,6 +91,7 @@ def _sdc_mdata(mdata_list=None, mdata_get=None):
         'datacenter_name',
         'hostname',
         'dns_domain',
+        'alias',
     ]
     sdc_json_keys = [
         'resolvers',
@@ -107,6 +110,8 @@ def _sdc_mdata(mdata_list=None, mdata_get=None):
 
     for mdata_grain in sdc_text_keys+sdc_json_keys:
         mdata_value = __salt__['cmd.run']('{0} sdc:{1}'.format(mdata_get, mdata_grain), ignore_retcode=True)
+        if mdata_value.startswith("ERROR:"):
+            continue
 
         if not mdata_value.startswith('No metadata for '):
             if 'mdata' not in grains:

--- a/salt/grains/mdata.py
+++ b/salt/grains/mdata.py
@@ -64,6 +64,7 @@ def _user_mdata(mdata_list=None, mdata_get=None):
 
     for mdata_grain in __salt__['cmd.run'](mdata_list, ignore_retcode=True).splitlines():
         if mdata_grain.startswith("ERROR:"):
+            log.warning("mdata-list returned an error, skipping mdata grains.")
             continue
         mdata_value = __salt__['cmd.run']('{0} {1}'.format(mdata_get, mdata_grain), ignore_retcode=True)
 
@@ -111,6 +112,9 @@ def _sdc_mdata(mdata_list=None, mdata_get=None):
     for mdata_grain in sdc_text_keys+sdc_json_keys:
         mdata_value = __salt__['cmd.run']('{0} sdc:{1}'.format(mdata_get, mdata_grain), ignore_retcode=True)
         if mdata_value.startswith("ERROR:"):
+            log.warning("unable to read sdc:{0} via mdata-get, mdata grain may be incomplete.".format(
+                mdata_grain,
+            ))
             continue
 
         if not mdata_value.startswith('No metadata for '):

--- a/salt/grains/smartos.py
+++ b/salt/grains/smartos.py
@@ -139,6 +139,13 @@ def _smartos_zone_pkgsrc_data():
         'pkgsrcpath': 'Unknown',
     }
 
+    # NOTE: we are specifically interested in the SmartOS pkgsrc version and path
+    #       - PKG_PATH MAY be different on non-SmartOS systems, but they will not
+    #         use this grains module.
+    #       - A sysadmin with advanced needs COULD create a 'spin' with a totally
+    #         different URL. But at that point the value would be meaning less in
+    #         the context of the pkgsrcversion grain as it will not followed the
+    #         SmartOS pkgsrc versioning. So 'Unknown' would be appropriate.
     pkgsrcpath = re.compile('PKG_PATH=(.+)')
     pkgsrcversion = re.compile('^https?://pkgsrc.joyent.com/packages/SmartOS/(.+)/(.+)/All$')
     pkg_install_paths = [

--- a/salt/utils/platform.py
+++ b/salt/utils/platform.py
@@ -91,16 +91,17 @@ def is_smartos_globalzone():
     if not is_smartos():
         return False
     else:
-        cmd = ['zonename']
         try:
-            zonename = subprocess.Popen(
-                cmd, shell=False,
-                stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            zonename_proc = subprocess.Popen(
+                ['zonename'], stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+            )
+            zonename_output = zonename_proc.communicate()[0].strip().decode(__salt_system_encoding__)
+            zonename_retcode = zonename_proc.poll()
         except OSError:
             return False
-        if zonename.returncode:
+        if zonename_retcode:
             return False
-        if zonename.stdout.read().strip() == 'global':
+        if zonename_output == 'global':
             return True
 
         return False
@@ -114,16 +115,17 @@ def is_smartos_zone():
     if not is_smartos():
         return False
     else:
-        cmd = ['zonename']
         try:
-            zonename = subprocess.Popen(
-                cmd, shell=False,
-                stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            zonename_proc = subprocess.Popen(
+                ['zonename'], stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+            )
+            zonename_output = zonename_proc.communicate()[0].strip().decode(__salt_system_encoding__)
+            zonename_retcode = zonename_proc.poll()
         except OSError:
             return False
-        if zonename.returncode:
+        if zonename_retcode:
             return False
-        if zonename.stdout.read().strip() == 'global':
+        if zonename_output == 'global':
             return False
 
         return True

--- a/tests/unit/grains/test_mdata.py
+++ b/tests/unit/grains/test_mdata.py
@@ -1,0 +1,189 @@
+# -*- coding: utf-8 -*-
+'''
+    :codeauthor: :email:`Jorge Schrauwen <sjorge@blackdot.be>`
+'''
+# Import Python libs
+from __future__ import absolute_import, print_function, unicode_literals
+
+# Import Salt Testing Libs
+from tests.support.unit import TestCase, skipIf
+from tests.support.mock import (
+    patch,
+    NO_MOCK,
+    NO_MOCK_REASON,
+    Mock,
+)
+
+# Import Salt Libs
+import salt.grains.mdata as mdata
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class MdataGrainsTestCase(TestCase):
+    '''
+    Test cases for mdata grains
+    '''
+    def setup_loader_modules(self):
+        return {
+            mdata: {
+                '__salt__': {},
+            },
+        }
+
+    def test_user_mdata_missing_cmd_both(self):
+        '''
+        When both or either of the commands is missing there should
+        be no grain output.
+        '''
+        grains_exp_res = {}
+
+        which_mock = Mock(side_effect=[
+            None,
+            None,
+        ])
+        with patch('salt.utils.path.which', which_mock):
+            grains_res = mdata._user_mdata()
+            self.assertEqual(grains_exp_res, grains_res)
+
+    def test_user_mdata_missing_cmd_one(self):
+        '''
+        When both or either of the commands is missing there should
+        be no grain output.
+        '''
+        grains_exp_res = {}
+
+        which_mock = Mock(side_effect=[
+            "/usr/sbin/mdata-list",
+            None,
+        ])
+        with patch('salt.utils.path.which', which_mock):
+            grains_res = mdata._user_mdata()
+            self.assertEqual(grains_exp_res, grains_res)
+
+    def test_user_mdata_empty_list(self):
+        '''
+        When there are no user grains, there are no mdata-get calls
+        so there are also no grains.
+        '''
+        grains_exp_res = {}
+
+        which_mock = Mock(side_effect=[
+            "/usr/sbin/mdata-list",
+            "/usr/sbin/mdata-get",
+        ])
+        cmd_mock = Mock(side_effect=[
+            "",
+        ])
+        with patch('salt.utils.path.which', which_mock), \
+             patch.dict(mdata.__salt__, {'cmd.run': cmd_mock}):
+            grains_res = mdata._user_mdata()
+            self.assertEqual(grains_exp_res, grains_res)
+
+    def test_user_mdata(self):
+        '''
+        We have a list of two grains, so there should be two mdata-get
+        calls, resulting in 2 grains.
+        '''
+        grains_exp_res = {
+            'mdata': {
+                'multi_text_data': 'multi\nline\ntext',
+                'simple_text_data': 'some text data',
+            },
+        }
+
+        which_mock = Mock(side_effect=[
+            "/usr/sbin/mdata-list",
+            "/usr/sbin/mdata-get",
+        ])
+        cmd_mock = Mock(side_effect=[
+            "simple_text_data\nmulti_text_data",
+            "some text data",
+            "multi\nline\ntext",
+        ])
+        with patch('salt.utils.path.which', which_mock), \
+             patch.dict(mdata.__salt__, {'cmd.run': cmd_mock}):
+            grains_res = mdata._user_mdata()
+
+            self.assertEqual(grains_exp_res, grains_res)
+
+    def test_sdc_mdata_missing_cmd_both(self):
+        '''
+        When both or either of the commands is missing there should
+        be no grain output.
+        '''
+        which_mock = Mock(side_effect=[
+            None,
+            None,
+        ])
+        with patch('salt.utils.path.which', which_mock):
+            grains = mdata._sdc_mdata()
+            assert grains == {}
+
+    def test_sdc_mdata_missing_cmd_one(self):
+        '''
+        When both or either of the commands is missing there should
+        be no grain output.
+        '''
+        grains_exp_res = {}
+
+        which_mock = Mock(side_effect=[
+            "/usr/sbin/mdata-list",
+            None,
+        ])
+        with patch('salt.utils.path.which', which_mock):
+            grains_res = mdata._sdc_mdata()
+            self.assertEqual(grains_exp_res, grains_res)
+
+    def test_sdc_mdata(self):
+        '''
+        Simulate all mdata_get calls from a test zone.
+        '''
+        grains_exp_res = {
+            'mdata': {
+                'sdc': {
+                    'alias': 'test',
+                    'dns_domain': 'example.org',
+                    'hostname': 'test_salt',
+                    'nics': [
+                        {
+                            'gateway': '10.12.3.1',
+                            'gateways': ['10.12.3.1'],
+                            'interface': 'net0',
+                            'ip': '10.12.3.123',
+                            'ips': ['10.12.3.123/24', '2001:ffff:ffff:123::123/64'],
+                            'mac': '00:00:00:00:00:01',
+                            'mtu': 1500,
+                            'netmask': '255.255.255.0',
+                            'nic_tag': 'trunk',
+                            'primary': True,
+                            'vlan_id': 123,
+                        }
+                    ],
+                    'resolvers': ['10.12.3.1', '2001:ffff:ffff:123::1'],
+                    'routes': [],
+                    'server_uuid': '00000000-0000-0000-0000-000123456789',
+                    'uuid': 'bae504b1-4594-47de-e2ed-e4f454776689',
+                },
+            },
+        }
+
+        which_mock = Mock(side_effect=[
+            "/usr/sbin/mdata-list",
+            "/usr/sbin/mdata-get",
+        ])
+        cmd_mock = Mock(side_effect=[
+            "bae504b1-4594-47de-e2ed-e4f454776689",
+            "00000000-0000-0000-0000-000123456789",
+            "No metadata for 'sdc:datacenter_name'",
+            "test_salt",
+            "example.org",
+            "test",
+            '["10.12.3.1","2001:ffff:ffff:123::1"]',
+            '[{"interface":"net0","mac":"00:00:00:00:00:01","vlan_id":123,"nic_tag":"trunk","gateway":"10.12.3.1","gateways":["10.12.3.1"],"netmask":"255.255.255.0","ip":"10.12.3.123","ips":["10.12.3.123/24","2001:ffff:ffff:123::123/64"],"mtu":1500,"primary":true}]',
+            "[]",
+        ])
+        with patch('salt.utils.path.which', which_mock), \
+             patch.dict(mdata.__salt__, {'cmd.run': cmd_mock}):
+            grains_res = mdata._sdc_mdata()
+
+            self.assertEqual(grains_exp_res, grains_res)

--- a/tests/unit/grains/test_smartos.py
+++ b/tests/unit/grains/test_smartos.py
@@ -1,0 +1,280 @@
+# -*- coding: utf-8 -*-
+'''
+    :codeauthor: :email:`Jorge Schrauwen <sjorge@blackdot.be>`
+'''
+# Import Python libs
+from __future__ import absolute_import, print_function, unicode_literals
+import textwrap
+
+# Import Salt Testing Libs
+from tests.support.unit import TestCase, skipIf
+from tests.support.mock import (
+    patch,
+    NO_MOCK,
+    NO_MOCK_REASON,
+    Mock,
+    MagicMock,
+    mock_open,
+)
+
+# Import Salt Libs
+import salt.grains.smartos as smartos
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class SmartOSGrainsTestCase(TestCase):
+    '''
+    Test cases for smartos grains
+    '''
+    def test_smartos_computenode_data(self):
+        '''
+        Get a tally of running/stopped zones
+        Output used form a test host with one running
+        and one stopped of each vm type.
+        '''
+        grains_exp_res = {
+            'computenode_sdc_version': '7.0',
+            'computenode_vm_capable': True,
+            'computenode_vm_hw_virt': 'vmx',
+            'computenode_vms_running': 3,
+            'computenode_vms_stopped': 3,
+            'computenode_vms_total': 6,
+            'computenode_vms_type': {'KVM': 2, 'LX': 2, 'OS': 2},
+            'manufacturer': 'Supermicro',
+            'productname': 'X8STi',
+            'uuid': '534d4349-0002-2790-2500-2790250054c5',
+        }
+
+        cmd_mock = Mock(side_effect=[
+            textwrap.dedent('''\
+                99e40ee7-a8f9-4b57-9225-e7bd19f64b07:test_hvm1:running:BHYV
+                cde351a9-e23d-6856-e268-fff10fe603dc:test_hvm2:stopped:BHYV
+                99e40ee7-a8f9-4b57-9225-e7bd19f64b07:test_hvm3:running:KVM
+                cde351a9-e23d-6856-e268-fff10fe603dc:test_hvm4:stopped:KVM
+                179b50ca-8a4d-4f28-bb08-54b2cd350aa5:test_zone1:running:OS
+                42846fbc-c48a-6390-fd85-d7ac6a76464c:test_zone2:stopped:OS
+                4fd2d7a4-38c4-4068-a2c8-74124364a109:test_zone3:running:LX
+                717abe34-e7b9-4387-820e-0bb041173563:test_zone4:stopped:LX'''),
+            textwrap.dedent('''\
+                {
+                  "Live Image": "20181011T004530Z",
+                  "System Type": "SunOS",
+                  "Boot Time": "1562528522",
+                  "SDC Version": "7.0",
+                  "Manufacturer": "Supermicro",
+                  "Product": "X8STi",
+                  "Serial Number": "1234567890",
+                  "SKU Number": "To Be Filled By O.E.M.",
+                  "HW Version": "1234567890",
+                  "HW Family": "High-End Desktop",
+                  "Setup": "false",
+                  "VM Capable": true,
+                  "Bhyve Capable": false,
+                  "Bhyve Max Vcpus": 0,
+                  "HVM API": false,
+                  "CPU Type": "Intel(R) Xeon(R) CPU W3520 @ 2.67GHz",
+                  "CPU Virtualization": "vmx",
+                  "CPU Physical Cores": 1,
+                  "Admin NIC Tag": "",
+                  "UUID": "534d4349-0002-2790-2500-2790250054c5",
+                  "Hostname": "sdc",
+                  "CPU Total Cores": 8,
+                  "MiB of Memory": "16375",
+                  "Zpool": "zones",
+                  "Zpool Disks": "c1t0d0,c1t1d0",
+                  "Zpool Profile": "mirror",
+                  "Zpool Creation": 1406392163,
+                  "Zpool Size in GiB": 1797,
+                  "Disks": {
+                    "c1t0d0": {"Size in GB": 2000},
+                    "c1t1d0": {"Size in GB": 2000}
+                  },
+                  "Boot Parameters": {
+                    "smartos": "true",
+                    "console": "text",
+                    "boot_args": "",
+                    "bootargs": ""
+                  },
+                  "Network Interfaces": {
+                    "e1000g0": {"MAC Address": "00:00:00:00:00:01", "ip4addr": "123.123.123.123", "Link Status": "up", "NIC Names": ["admin"]},
+                    "e1000g1": {"MAC Address": "00:00:00:00:00:05", "ip4addr": "", "Link Status": "down", "NIC Names": []}
+                  },
+                  "Virtual Network Interfaces": {
+                  },
+                  "Link Aggregations": {
+                  }
+                }'''),
+        ])
+        with patch.dict(smartos.__salt__, {'cmd.run': cmd_mock}):
+            grains_res = smartos._smartos_computenode_data()
+            self.assertEqual(grains_exp_res, grains_res)
+
+    def test_smartos_zone_data(self):
+        '''
+        Get basic information about a non-global zone
+        '''
+        grains_exp_res = {
+            'imageversion': 'pkgbuild 18.1.0',
+            'zoneid': '5',
+            'zonename': 'dda70f61-70fe-65e7-cf70-d878d69442d4',
+        }
+
+        cmd_mock = Mock(side_effect=[
+            "5:dda70f61-70fe-65e7-cf70-d878d69442d4:running:/:dda70f61-70fe-65e7-cf70-d878d69442d4:native:excl:0",
+        ])
+        fopen_mock = mock_open(read_data={
+            '/etc/product': textwrap.dedent('''\
+                Name: Joyent Instance
+                Image: pkgbuild 18.1.0
+                Documentation: https://docs.joyent.com/images/smartos/pkgbuild
+                '''),
+        })
+        with patch.dict(smartos.__salt__, {'cmd.run': cmd_mock}), \
+             patch('os.path.isfile', MagicMock(return_value=True)), \
+             patch('salt.utils.files.fopen', fopen_mock):
+            grains_res = smartos._smartos_zone_data()
+            self.assertEqual(grains_exp_res, grains_res)
+
+    def test_smartos_zone_pkgsrc_data_in_zone(self):
+        '''
+        Get pkgsrc information from a zone
+        '''
+        grains_exp_res = {
+            'pkgsrcpath': 'https://pkgsrc.joyent.com/packages/SmartOS/2018Q1/x86_64/All',
+            'pkgsrcversion': '2018Q1',
+        }
+
+        isfile_mock = Mock(side_effect=[True, False])
+        fopen_mock = mock_open(read_data={
+            '/opt/local/etc/pkg_install.conf': textwrap.dedent('''\
+                GPG_KEYRING_VERIFY=/opt/local/etc/gnupg/pkgsrc.gpg
+                GPG_KEYRING_PKGVULN=/opt/local/share/gnupg/pkgsrc-security.gpg
+                PKG_PATH=https://pkgsrc.joyent.com/packages/SmartOS/2018Q1/x86_64/All
+                '''),
+        })
+
+        with patch('os.path.isfile', isfile_mock), \
+             patch('salt.utils.files.fopen', fopen_mock):
+            grains_res = smartos._smartos_zone_pkgsrc_data()
+            self.assertEqual(grains_exp_res, grains_res)
+
+    def test_smartos_zone_pkgsrc_data_in_globalzone(self):
+        '''
+        Get pkgsrc information from the globalzone
+        '''
+        grains_exp_res = {
+            'pkgsrcpath': 'https://pkgsrc.joyent.com/packages/SmartOS/trunk/tools/All',
+            'pkgsrcversion': 'trunk',
+        }
+
+        isfile_mock = Mock(side_effect=[False, True])
+        fopen_mock = mock_open(read_data={
+            '/opt/tools/etc/pkg_install.conf': textwrap.dedent('''\
+                GPG_KEYRING_PKGVULN=/opt/tools/share/gnupg/pkgsrc-security.gpg
+                GPG_KEYRING_VERIFY=/opt/tools/etc/gnupg/pkgsrc.gpg
+                PKG_PATH=https://pkgsrc.joyent.com/packages/SmartOS/trunk/tools/All
+                VERIFIED_INSTALLATION=always
+                '''),
+        })
+
+        with patch('os.path.isfile', isfile_mock), \
+             patch('salt.utils.files.fopen', fopen_mock):
+            grains_res = smartos._smartos_zone_pkgsrc_data()
+            self.assertEqual(grains_exp_res, grains_res)
+
+    def test_smartos_zone_pkgin_data_in_zone(self):
+        '''
+        Get pkgin information from a zone
+        '''
+        grains_exp_res = {
+            'pkgin_repositories': [
+                'https://pkgsrc.joyent.com/packages/SmartOS/2018Q1/x86_64/All',
+                'http://pkg.blackdot.be/packages/2018Q1/x86_64/All',
+            ],
+        }
+
+        isfile_mock = Mock(side_effect=[True, False])
+        fopen_mock = mock_open(read_data={
+            '/opt/local/etc/pkgin/repositories.conf': textwrap.dedent('''\
+                # $Id: repositories.conf,v 1.3 2012/06/13 13:50:17 imilh Exp $
+                #
+                # Pkgin repositories list
+                #
+                # Simply add repositories URIs one below the other
+                #
+                # WARNING: order matters, duplicates will not be added, if two
+                # repositories hold the same package, it will be fetched from
+                # the first one listed in this file.
+                #
+                # This file format supports the following macros:
+                # $arch to define the machine hardware platform
+                # $osrelease to define the release version for the operating system
+                #
+                # Remote ftp repository
+                #
+                # ftp://ftp.netbsd.org/pub/pkgsrc/packages/NetBSD/$arch/5.1/All
+                #
+                # Remote http repository
+                #
+                # http://mirror-master.dragonflybsd.org/packages/$arch/DragonFly-$osrelease/stable/All
+                #
+                # Local repository (must contain a pkg_summary.gz or bz2)
+                #
+                # file:///usr/pkgsrc/packages/All
+                #
+                https://pkgsrc.joyent.com/packages/SmartOS/2018Q1/x86_64/All
+                http://pkg.blackdot.be/packages/2018Q1/x86_64/All
+                '''),
+        })
+
+        with patch('os.path.isfile', isfile_mock), \
+             patch('salt.utils.files.fopen', fopen_mock):
+            grains_res = smartos._smartos_zone_pkgin_data()
+            self.assertEqual(grains_exp_res, grains_res)
+
+    def test_smartos_zone_pkgin_data_in_globalzone(self):
+        '''
+        Get pkgin information from the globalzone
+        '''
+        grains_exp_res = {
+            'pkgin_repositories': [
+                'https://pkgsrc.joyent.com/packages/SmartOS/trunk/tools/All',
+            ],
+        }
+
+        isfile_mock = Mock(side_effect=[False, True])
+        fopen_mock = mock_open(read_data={
+            '/opt/tools/etc/pkgin/repositories.conf': textwrap.dedent('''\
+                #
+                # Pkgin repositories list
+                #
+                # Simply add repositories URIs one below the other
+                #
+                # WARNING: order matters, duplicates will not be added, if two
+                # repositories hold the same package, it will be fetched from
+                # the first one listed in this file.
+                #
+                # This file format supports the following macros:
+                # $arch to define the machine hardware platform
+                # $osrelease to define the release version for the operating system
+                #
+                # Remote ftp repository
+                #
+                # ftp://ftp.netbsd.org/pub/pkgsrc/packages/NetBSD/$arch/5.1/All
+                #
+                # Remote http repository
+                #
+                # http://mirror-master.dragonflybsd.org/packages/$arch/DragonFly-$osrelease/stable/All
+                #
+                # Local repository (must contain a pkg_summary.gz or bz2)
+                #
+                # file:///usr/pkgsrc/packages/All
+                #
+                https://pkgsrc.joyent.com/packages/SmartOS/trunk/tools/All
+                '''),
+        })
+
+        with patch('os.path.isfile', isfile_mock), \
+             patch('salt.utils.files.fopen', fopen_mock):
+            grains_res = smartos._smartos_zone_pkgin_data()
+            self.assertEqual(grains_exp_res, grains_res)


### PR DESCRIPTION
### What does this PR do?
The salt package in pkgsrc was moved to py3, this broke some grains on SmartOS.
For now the current release 2019.3 is back on py27. But in preperation for the next release, this PR fixes those issues.

### What issues does this PR fix or reference?
#53740

### Previous Behavior
Missing grains on SmartOS (Global Zone) when using py3

### New Behavior
Grains are no longer missing

### Tests written?
Yes

### Commits signed with GPG?
No