### PR TITLE
Update list_containers call

### DIFF
--- a/salt/modules/dockermod.py
+++ b/salt/modules/dockermod.py
@@ -1976,14 +1976,19 @@ def list_containers(**kwargs):
     all : False
         If ``True``, stopped containers will be included in return data
 
+    filter : None
+        Do the same as analogical option in :py:func:`docker.ps <salt.modules.dockermod.ps_>`
+
     CLI Example:
 
     .. code-block:: bash
 
-        salt myminion docker.inspect_image <image>
+        salt myminion docker.list_containers
+        salt myminion docker.list_containers all=True
+        salt myminion docker.list_containers filter='{"name":"nginx"}'
     """
     ret = set()
-    for item in ps_(all=kwargs.get("all", False)).values():
+    for item in ps_(all=kwargs.get("all", False), filter=kwargs.get('filter', None)).values():
         names = item.get("Names")
         if not names:
             continue

--- a/salt/modules/dockermod.py
+++ b/salt/modules/dockermod.py
@@ -1858,7 +1858,7 @@ def inspect(name):
         Volumes and networks are now checked, in addition to containers and
         images.
 
-    This is a generic container/image/volume/network inspecton function. It
+    This is a generic container/image/volume/network inspection function. It
     will run the following functions in order:
 
     - :py:func:`docker.inspect_container


### PR DESCRIPTION
Add capability of filtering the containers with list_containers call as it is available with ps_ call.

### What does this PR do?

It implements of pass-through of filtering to lower ps_ call

### What issues does this PR fix or reference?

### Previous Behavior

list_containers just shows the flat list of containers names without any capability of filtering

### New Behavior

Add option to use filtering

### Tests written?

No

### Commits signed with GPG?

No

