### PR TITLE
Skip 100 slowest test modules/classes, temporarily

### DIFF
--- a/tests/integration/cli/test_batch.py
+++ b/tests/integration/cli/test_batch.py
@@ -9,9 +9,11 @@ from __future__ import absolute_import, print_function, unicode_literals
 from tests.support.case import ShellCase
 
 # Import Salt libs
+from tests.support.unit import skipIf  # WAR ROOM temp import
 import salt.utils.platform
 
 
+@skipIf(True, "WAR ROOM TEMPORARY SKIP")
 class BatchTest(ShellCase):
     '''
     Integration tests for the salt.cli.batch module

--- a/tests/integration/cli/test_grains.py
+++ b/tests/integration/cli/test_grains.py
@@ -22,11 +22,13 @@ import salt.utils.files
 
 # Import Salt Testing Libs
 from tests.support.case import ShellCase, SSHCase
+from tests.support.unit import skipIf  # WAR ROOM temp import
 from tests.support.helpers import flaky
 
 log = logging.getLogger(__name__)
 
 
+@skipIf(True, "WAR ROOM TEMPORARY SKIP")
 class GrainsTargetingTest(ShellCase):
     '''
     Integration tests for targeting with grains.

--- a/tests/integration/client/test_standard.py
+++ b/tests/integration/client/test_standard.py
@@ -9,9 +9,11 @@ from tests.support.case import ModuleCase
 
 # Import salt libs
 import salt.utils.files
+from tests.support.unit import skipIf  # WAR ROOM temp import
 import salt.utils.platform
 
 
+@skipIf(True, "WAR ROOM TEMPORARY SKIP")
 class StdTest(ModuleCase):
     '''
     Test standard client calls

--- a/tests/integration/daemons/test_masterapi.py
+++ b/tests/integration/daemons/test_masterapi.py
@@ -14,9 +14,11 @@ from tests.support.case import ShellCase
 
 # Import Salt libs
 import salt.utils.files
+from tests.support.unit import skipIf  # WAR ROOM temp import
 import salt.utils.stringutils
 
 
+@skipIf(True, "WAR ROOM TEMPORARY SKIP")
 class AutosignGrainsTest(ShellCase):
     '''
     Test autosigning minions based on grain values.

--- a/tests/integration/loader/test_ext_grains.py
+++ b/tests/integration/loader/test_ext_grains.py
@@ -21,6 +21,7 @@ import salt.config
 import salt.loader
 
 
+@skipIf(True, "WAR ROOM TEMPORARY SKIP")
 class LoaderGrainsTest(ModuleCase):
     '''
     Test the loader standard behavior with external grains

--- a/tests/integration/loader/test_ext_modules.py
+++ b/tests/integration/loader/test_ext_modules.py
@@ -16,9 +16,11 @@ import time
 
 # Import Salt Testing libs
 from tests.support.runtests import RUNTIME_VARS
+from tests.support.unit import skipIf  # WAR ROOM temp import
 from tests.support.case import ModuleCase
 
 
+@skipIf(True, "WAR ROOM TEMPORARY SKIP")
 class LoaderOverridesTest(ModuleCase):
 
     def setUp(self):

--- a/tests/integration/minion/test_timeout.py
+++ b/tests/integration/minion/test_timeout.py
@@ -11,9 +11,11 @@ import sys
 import salt.utils.platform
 
 # Import Salt Testing libs
+from tests.support.unit import skipIf  # WAR ROOM temp import
 from tests.support.case import ShellCase
 
 
+@skipIf(True, "WAR ROOM TEMPORARY SKIP")
 class MinionTimeoutTestCase(ShellCase):
     '''
     Test minion timing functions

--- a/tests/integration/modules/test_baredoc.py
+++ b/tests/integration/modules/test_baredoc.py
@@ -4,9 +4,11 @@
 from __future__ import absolute_import
 
 # Import Salt Testing libs
+from tests.support.unit import skipIf  # WAR ROOM temp import
 from tests.support.case import ModuleCase
 
 
+@skipIf(True, "WAR ROOM TEMPORARY SKIP")
 class BaredocTest(ModuleCase):
     '''
     Validate baredoc module

--- a/tests/integration/modules/test_gem.py
+++ b/tests/integration/modules/test_gem.py
@@ -30,6 +30,7 @@ def check_status():
 
 @destructiveTest
 @skipIf(not salt.utils.path.which('gem'), 'Gem is not available')
+@skipIf(True, "WAR ROOM TEMPORARY SKIP")
 class GemModuleTest(ModuleCase):
     '''
     Validate gem module

--- a/tests/integration/modules/test_groupadd.py
+++ b/tests/integration/modules/test_groupadd.py
@@ -23,6 +23,7 @@ if not salt.utils.platform.is_windows():
 
 @skip_if_not_root
 @destructiveTest
+@skipIf(True, "WAR ROOM TEMPORARY SKIP")
 class GroupModuleTest(ModuleCase):
     '''
     Validate the linux group system module

--- a/tests/integration/modules/test_localemod.py
+++ b/tests/integration/modules/test_localemod.py
@@ -24,6 +24,7 @@ def _find_new_locale(current_locale):
 @skipIf(salt.utils.platform.is_windows(), 'minion is windows')
 @skipIf(salt.utils.platform.is_darwin(), 'locale method is not supported on mac')
 @requires_salt_modules('locale')
+@skipIf(True, "WAR ROOM TEMPORARY SKIP")
 class LocaleModuleTest(ModuleCase):
     def test_get_locale(self):
         locale = self.run_function('locale.get_locale')

--- a/tests/integration/modules/test_mine.py
+++ b/tests/integration/modules/test_mine.py
@@ -8,9 +8,11 @@ import time
 import pprint
 
 # Import Salt Testing libs
+from tests.support.unit import skipIf  # WAR ROOM temp import
 from tests.support.case import ModuleCase
 
 
+@skipIf(True, "WAR ROOM TEMPORARY SKIP")
 class MineTest(ModuleCase):
     '''
     Test the mine system

--- a/tests/integration/modules/test_network.py
+++ b/tests/integration/modules/test_network.py
@@ -14,6 +14,7 @@ import salt.utils.platform
 URL = 'google-public-dns-a.google.com'
 
 
+@skipIf(True, "WAR ROOM TEMPORARY SKIP")
 class NetworkTest(ModuleCase):
     '''
     Validate network module

--- a/tests/integration/modules/test_saltutil.py
+++ b/tests/integration/modules/test_saltutil.py
@@ -72,6 +72,7 @@ class SaltUtilModuleTest(ModuleCase):
         self.assertIn('priv', ret['return'])
 
 
+@skipIf(True, "WAR ROOM TEMPORARY SKIP")
 class SaltUtilSyncModuleTest(ModuleCase):
     '''
     Testcase for the saltutil sync execution module

--- a/tests/integration/modules/test_service.py
+++ b/tests/integration/modules/test_service.py
@@ -15,6 +15,7 @@ import salt.utils.systemd
 
 
 @destructiveTest
+@skipIf(True, "WAR ROOM TEMPORARY SKIP")
 class ServiceModuleTest(ModuleCase):
     '''
     Module testing the service module

--- a/tests/integration/modules/test_shadow.py
+++ b/tests/integration/modules/test_shadow.py
@@ -23,6 +23,7 @@ from salt.ext.six.moves import range
 
 @skip_if_not_root
 @skipIf(not salt.utils.platform.is_linux(), 'These tests can only be run on linux')
+@skipIf(True, "WAR ROOM TEMPORARY SKIP")
 class ShadowModuleTest(ModuleCase):
     '''
     Validate the linux shadow system module

--- a/tests/integration/modules/test_state_jinja_filters.py
+++ b/tests/integration/modules/test_state_jinja_filters.py
@@ -5,9 +5,11 @@ from __future__ import absolute_import, print_function, unicode_literals
 
 # Import Salt Testing libs
 from tests.support.case import ModuleCase
+from tests.support.unit import skipIf  # WAR ROOM temp import
 from tests.support.jinja_filters import JinjaFiltersTest
 
 
+@skipIf(True, "WAR ROOM TEMPORARY SKIP")
 class StateModuleJinjaFiltersTest(ModuleCase, JinjaFiltersTest):
     '''
     testing Jinja filters are available via state system

--- a/tests/integration/modules/test_useradd.py
+++ b/tests/integration/modules/test_useradd.py
@@ -24,6 +24,7 @@ from salt.ext.six.moves import range  # pylint: disable=import-error,redefined-b
 @destructiveTest
 @skipIf(not salt.utils.platform.is_linux(), 'These tests can only be run on linux')
 @skip_if_not_root
+@skipIf(True, "WAR ROOM TEMPORARY SKIP")
 class UseraddModuleTestLinux(ModuleCase):
 
     def setUp(self):

--- a/tests/integration/modules/test_virt.py
+++ b/tests/integration/modules/test_virt.py
@@ -8,10 +8,12 @@ from __future__ import absolute_import, print_function, unicode_literals
 
 # Import Salt Testing libs
 from tests.support.case import ModuleCase
+from tests.support.unit import skipIf  # WAR ROOM temp import
 from tests.support.helpers import requires_salt_modules
 
 
 @requires_salt_modules('virt.get_profiles')
+@skipIf(True, "WAR ROOM TEMPORARY SKIP")
 class VirtTest(ModuleCase):
     '''
     Test virt routines

--- a/tests/integration/modules/test_virtualenv_mod.py
+++ b/tests/integration/modules/test_virtualenv_mod.py
@@ -16,6 +16,7 @@ from salt.modules.virtualenv_mod import KNOWN_BINARY_NAMES
 
 
 @skipIf(salt.utils.path.which_bin(KNOWN_BINARY_NAMES) is None, 'virtualenv not installed')
+@skipIf(True, "WAR ROOM TEMPORARY SKIP")
 class VirtualenvModuleTest(ModuleCase):
     '''
     Validate the virtualenv module

--- a/tests/integration/output/test_output.py
+++ b/tests/integration/output/test_output.py
@@ -16,9 +16,11 @@ from tests.support.mixins import RUNTIME_VARS
 import salt.config
 import salt.utils.yaml
 from salt.output import display_output
+from tests.support.unit import skipIf  # WAR ROOM temp import
 from salt.ext import six
 
 
+@skipIf(True, "WAR ROOM TEMPORARY SKIP")
 class OutputReturnTest(ShellCase):
     '''
     Integration tests to ensure outputters return their expected format.

--- a/tests/integration/proxy/test_shell.py
+++ b/tests/integration/proxy/test_shell.py
@@ -15,11 +15,13 @@ import logging
 import salt.utils.json as json
 
 # Import salt tests libs
+from tests.support.unit import skipIf  # WAR ROOM temp import
 from tests.support.case import ShellCase
 
 log = logging.getLogger(__name__)
 
 
+@skipIf(True, "WAR ROOM TEMPORARY SKIP")
 class ProxyCallerSimpleTestCase(ShellCase):
     '''
     Test salt-call --proxyid <proxyid> commands

--- a/tests/integration/reactor/test_reactor.py
+++ b/tests/integration/reactor/test_reactor.py
@@ -29,6 +29,7 @@ class TimeoutException(Exception):
     pass
 
 
+@skipIf(True, "WAR ROOM TEMPORARY SKIP")
 class ReactorTest(SaltMinionEventAssertsMixin, ShellTestCase):
     '''
     Test Salt's reactor system

--- a/tests/integration/runners/test_fileserver.py
+++ b/tests/integration/runners/test_fileserver.py
@@ -14,6 +14,7 @@ from tests.support.unit import skipIf
 import salt.utils.platform
 
 
+@skipIf(True, "WAR ROOM TEMPORARY SKIP")
 class FileserverTest(ShellCase):
     '''
     Test the fileserver runner

--- a/tests/integration/scheduler/test_eval.py
+++ b/tests/integration/scheduler/test_eval.py
@@ -46,6 +46,7 @@ DEFAULT_CONFIG['cachedir'] = os.path.join(ROOT_DIR, 'cache')
 JOB_FUNCTION = 'test.ping'
 
 
+@skipIf(True, "WAR ROOM TEMPORARY SKIP")
 class SchedulerEvalTest(ModuleCase, SaltReturnAssertsMixin):
     '''
     Validate the scheduler

--- a/tests/integration/shell/test_arguments.py
+++ b/tests/integration/shell/test_arguments.py
@@ -11,10 +11,12 @@ from tests.support.case import ModuleCase
 from tests.support.helpers import requires_salt_modules
 
 # Import Salt libs
+from tests.support.unit import skipIf  # WAR ROOM temp import
 import salt.utils.args
 
 
 @requires_salt_modules('test.ping', 'test.arg')
+@skipIf(True, "WAR ROOM TEMPORARY SKIP")
 class ArgumentTestCase(ModuleCase):
     def test_unsupported_kwarg(self):
         '''

--- a/tests/integration/shell/test_auth.py
+++ b/tests/integration/shell/test_auth.py
@@ -50,6 +50,7 @@ def gen_password():
 @skip_if_not_root
 @skipIf(pwd is None, 'Skip if no pwd module exists')
 @destructiveTest
+@skipIf(True, "WAR ROOM TEMPORARY SKIP")
 class AuthTest(ShellCase):
     '''
     Test auth mechanisms

--- a/tests/integration/shell/test_call.py
+++ b/tests/integration/shell/test_call.py
@@ -34,6 +34,7 @@ from salt.ext import six
 log = logging.getLogger(__name__)
 
 
+@skipIf(True, "WAR ROOM TEMPORARY SKIP")
 class CallTest(ShellCase, testprogram.TestProgramCase, ShellCaseCommonTestsMixin):
 
     _call_binary_ = 'salt-call'

--- a/tests/integration/shell/test_cp.py
+++ b/tests/integration/shell/test_cp.py
@@ -34,6 +34,7 @@ from salt.ext import six
 log = logging.getLogger(__name__)
 
 
+@skipIf(True, "WAR ROOM TEMPORARY SKIP")
 class CopyTest(ShellCase, ShellCaseCommonTestsMixin):
 
     _call_binary_ = 'salt-cp'

--- a/tests/integration/shell/test_enabled.py
+++ b/tests/integration/shell/test_enabled.py
@@ -15,6 +15,7 @@ import salt.utils.platform
 import salt.utils.files
 
 
+@skipIf(True, "WAR ROOM TEMPORARY SKIP")
 class EnabledTest(ModuleCase):
     '''
     validate the use of shell processing for cmd.run on the salt command line

--- a/tests/integration/shell/test_key.py
+++ b/tests/integration/shell/test_key.py
@@ -19,6 +19,7 @@ from salt.ext import six
 # Import Salt libs
 import salt.utils.files
 import salt.utils.platform
+from tests.support.unit import skipIf  # WAR ROOM temp import
 import salt.utils.yaml
 
 USERA = 'saltdev'
@@ -26,6 +27,7 @@ USERA_PWD = 'saltdev'
 HASHED_USERA_PWD = '$6$SALTsalt$ZZFD90fKFWq8AGmmX0L3uBtS9fXL62SrTk5zcnQ6EkD6zoiM3kB88G1Zvs0xm/gZ7WXJRs5nsTBybUvGSqZkT.'
 
 
+@skipIf(True, "WAR ROOM TEMPORARY SKIP")
 class KeyTest(ShellCase, ShellCaseCommonTestsMixin):
     '''
     Test salt-key script

--- a/tests/integration/shell/test_master_tops.py
+++ b/tests/integration/shell/test_master_tops.py
@@ -8,9 +8,11 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
 # Import Salt Testing libs
+from tests.support.unit import skipIf  # WAR ROOM temp import
 from tests.support.case import ShellCase
 
 
+@skipIf(True, "WAR ROOM TEMPORARY SKIP")
 class MasterTopsTest(ShellCase):
 
     _call_binary_ = 'salt'

--- a/tests/integration/shell/test_matcher.py
+++ b/tests/integration/shell/test_matcher.py
@@ -22,6 +22,7 @@ def minion_in_returns(minion, lines):
     return bool([True for line in lines if line == '{0}:'.format(minion)])
 
 
+@skipIf(True, "WAR ROOM TEMPORARY SKIP")
 class MatchTest(ShellCase, ShellCaseCommonTestsMixin):
     '''
     Test salt matchers

--- a/tests/integration/shell/test_minion.py
+++ b/tests/integration/shell/test_minion.py
@@ -38,6 +38,7 @@ log = logging.getLogger(__name__)
 DEBUG = True
 
 
+@skipIf(True, "WAR ROOM TEMPORARY SKIP")
 class MinionTest(ShellCase, testprogram.TestProgramCase, ShellCaseCommonTestsMixin):
     '''
     Various integration tests for the salt-minion executable.

--- a/tests/integration/shell/test_proxy.py
+++ b/tests/integration/shell/test_proxy.py
@@ -22,6 +22,7 @@ log = logging.getLogger(__name__)
 
 
 @skipIf(salt.utils.platform.is_windows(), 'Skip on Windows OS')
+@skipIf(True, "WAR ROOM TEMPORARY SKIP")
 class ProxyTest(testprogram.TestProgramCase):
     '''
     Various integration tests for the salt-proxy executable.

--- a/tests/integration/shell/test_runner.py
+++ b/tests/integration/shell/test_runner.py
@@ -28,6 +28,7 @@ USERA_PWD = 'saltdev'
 HASHED_USERA_PWD = '$6$SALTsalt$ZZFD90fKFWq8AGmmX0L3uBtS9fXL62SrTk5zcnQ6EkD6zoiM3kB88G1Zvs0xm/gZ7WXJRs5nsTBybUvGSqZkT.'
 
 
+@skipIf(True, "WAR ROOM TEMPORARY SKIP")
 class RunTest(ShellCase, testprogram.TestProgramCase, ShellCaseCommonTestsMixin):
     '''
     Test the salt-run command

--- a/tests/integration/shell/test_saltcli.py
+++ b/tests/integration/shell/test_saltcli.py
@@ -21,6 +21,7 @@ import salt.utils.path
 
 # Import Salt Testing libs
 from tests.support.case import ShellCase
+from tests.support.unit import skipIf  # WAR ROOM temp import
 from tests.integration.utils import testprogram
 
 log = logging.getLogger(__name__)
@@ -78,6 +79,7 @@ class SaltTest(testprogram.TestProgramCase):
         )
 
 
+@skipIf(True, "WAR ROOM TEMPORARY SKIP")
 class RetcodeTestCase(ShellCase):
     '''
     Tests to ensure that we set non-zero retcodes when execution fails

--- a/tests/integration/shell/test_spm.py
+++ b/tests/integration/shell/test_spm.py
@@ -5,9 +5,11 @@ from __future__ import absolute_import
 import os
 
 # Import Salt Testing libs
+from tests.support.unit import skipIf  # WAR ROOM temp import
 from tests.support.case import ShellCase, SPMCase
 
 
+@skipIf(True, "WAR ROOM TEMPORARY SKIP")
 class SPMTest(ShellCase, SPMCase):
     '''
     Test spm script

--- a/tests/integration/shell/test_syndic.py
+++ b/tests/integration/shell/test_syndic.py
@@ -53,6 +53,7 @@ def session_salt_syndic(request, session_salt_master_of_masters, session_salt_sy
             log.warning('Failed to terminate daemon: %s', daemon.__class__.__name__)
 
 
+@skipIf(True, "WAR ROOM TEMPORARY SKIP")
 class SyndicTest(ShellCase, testprogram.TestProgramCase, ShellCaseCommonTestsMixin):
     '''
     Test the salt-syndic command

--- a/tests/integration/spm/test_build.py
+++ b/tests/integration/spm/test_build.py
@@ -18,6 +18,7 @@ from tests.support.unit import skipIf
 
 
 @destructiveTest
+@skipIf(True, "WAR ROOM TEMPORARY SKIP")
 class SPMBuildTest(SPMCase, ModuleCase):
     '''
     Validate the spm build command

--- a/tests/integration/states/test_alternatives.py
+++ b/tests/integration/states/test_alternatives.py
@@ -20,6 +20,7 @@ if not os.path.exists('/etc/alternatives'):
 
 
 @skipIf(NO_ALTERNATIVES, '/etc/alternatives does not exist on the system')
+@skipIf(True, "WAR ROOM TEMPORARY SKIP")
 class AlterantivesStateTest(ModuleCase, SaltReturnAssertsMixin):
     @destructiveTest
     def test_install_set_and_remove(self):

--- a/tests/integration/states/test_archive.py
+++ b/tests/integration/states/test_archive.py
@@ -16,6 +16,7 @@ from tests.support.runtests import RUNTIME_VARS
 
 # Import Salt libs
 import salt.utils.files
+from tests.support.unit import skipIf  # WAR ROOM temp import
 import salt.utils.platform
 
 # Setup logging
@@ -32,6 +33,7 @@ ARCHIVE_TAR_BAD_HASH = 'md5=d41d8cd98f00b204e9800998ecf8427e'
 ARCHIVE_TAR_HASH_UPPER = 'md5=7643861AC07C30FE7D2310E9F25CA514'
 
 
+@skipIf(True, "WAR ROOM TEMPORARY SKIP")
 class ArchiveTest(ModuleCase, SaltReturnAssertsMixin):
     '''
     Validate the archive state

--- a/tests/integration/states/test_cmd.py
+++ b/tests/integration/states/test_cmd.py
@@ -21,6 +21,7 @@ import salt.utils.files
 import salt.utils.platform
 
 # Import 3rd-party libs
+from tests.support.unit import skipIf; skipIf(True, "WAR ROOM TEMPORARY SKIP")  # pylint: disable=C0321,E8702
 from salt.ext import six
 
 IS_WINDOWS = salt.utils.platform.is_windows()

--- a/tests/integration/states/test_compiler.py
+++ b/tests/integration/states/test_compiler.py
@@ -10,6 +10,7 @@ from __future__ import absolute_import, unicode_literals, print_function
 from tests.support.case import ModuleCase
 
 # Import Salt libs
+from tests.support.unit import skipIf  # WAR ROOM temp import
 import salt.utils.platform
 
 # Import 3rd-Party libs
@@ -20,6 +21,7 @@ except ImportError:
     HAS_LSB_RELEASE = False
 
 
+@skipIf(True, "WAR ROOM TEMPORARY SKIP")
 class CompileTest(ModuleCase):
     '''
     Validate the state compiler

--- a/tests/integration/states/test_cron.py
+++ b/tests/integration/states/test_cron.py
@@ -19,6 +19,7 @@ import salt.utils.platform
 
 
 @skipIf(salt.utils.platform.is_windows(), 'minion is windows')
+@skipIf(True, "WAR ROOM TEMPORARY SKIP")
 class CronTest(ModuleCase):
     '''
     Validate the file state

--- a/tests/integration/states/test_git.py
+++ b/tests/integration/states/test_git.py
@@ -23,6 +23,7 @@ from tests.support.mixins import SaltReturnAssertsMixin
 import salt.utils.files
 import salt.utils.path
 from salt.utils.versions import LooseVersion as _LooseVersion
+from tests.support.unit import skipIf; skipIf(True, "WAR ROOM TEMPORARY SKIP")  # pylint: disable=C0321,E8702
 from salt.ext.six.moves.urllib.parse import urlparse  # pylint: disable=no-name-in-module
 
 TEST_REPO = 'https://github.com/saltstack/salt-test-repo.git'

--- a/tests/integration/states/test_match.py
+++ b/tests/integration/states/test_match.py
@@ -18,9 +18,11 @@ from tests.support.runtests import RUNTIME_VARS
 
 # Import salt libs
 import salt.utils.files
+from tests.support.unit import skipIf  # WAR ROOM temp import
 import salt.utils.stringutils
 
 
+@skipIf(True, "WAR ROOM TEMPORARY SKIP")
 class StateMatchTest(ModuleCase):
     '''
     Validate the file state

--- a/tests/integration/states/test_network.py
+++ b/tests/integration/states/test_network.py
@@ -16,6 +16,7 @@ from tests.support.unit import skipIf
 
 
 @destructiveTest
+@skipIf(True, "WAR ROOM TEMPORARY SKIP")
 class NetworkTest(ModuleCase, SaltReturnAssertsMixin):
     '''
     Validate network state module

--- a/tests/integration/states/test_pkg.py
+++ b/tests/integration/states/test_pkg.py
@@ -154,6 +154,7 @@ def latest_version(run_function, *names):
 @flaky
 @destructiveTest
 @requires_salt_modules('pkg.version', 'pkg.latest_version')
+@skipIf(True, "WAR ROOM TEMPORARY SKIP")
 class PkgTest(ModuleCase, SaltReturnAssertsMixin):
     '''
     pkg.installed state tests

--- a/tests/integration/states/test_pkgrepo.py
+++ b/tests/integration/states/test_pkgrepo.py
@@ -25,6 +25,7 @@ from salt.ext import six
 
 @destructiveTest
 @skipIf(salt.utils.platform.is_windows(), 'minion is windows')
+@skipIf(True, "WAR ROOM TEMPORARY SKIP")
 class PkgrepoTest(ModuleCase, SaltReturnAssertsMixin):
     '''
     pkgrepo state tests

--- a/tests/integration/states/test_renderers.py
+++ b/tests/integration/states/test_renderers.py
@@ -8,9 +8,11 @@ from __future__ import absolute_import, unicode_literals, print_function
 
 # Import Salt Testing libs
 from tests.support.case import ModuleCase
+from tests.support.unit import skipIf  # WAR ROOM temp import
 from tests.support.helpers import flaky
 
 
+@skipIf(True, "WAR ROOM TEMPORARY SKIP")
 class TestJinjaRenderer(ModuleCase):
     '''
     Validate that ordering works correctly

--- a/tests/integration/states/test_service.py
+++ b/tests/integration/states/test_service.py
@@ -13,12 +13,14 @@ from tests.support.mixins import SaltReturnAssertsMixin
 
 # Import salt libs
 import salt.utils.path
+from tests.support.unit import skipIf  # WAR ROOM temp import
 import salt.utils.platform
 
 INIT_DELAY = 5
 
 
 @destructiveTest
+@skipIf(True, "WAR ROOM TEMPORARY SKIP")
 class ServiceTest(ModuleCase, SaltReturnAssertsMixin):
     '''
     Validate the service state

--- a/tests/integration/states/test_ssh_auth.py
+++ b/tests/integration/states/test_ssh_auth.py
@@ -18,9 +18,11 @@ from tests.support.helpers import (
 )
 
 # Import salt libs
+from tests.support.unit import skipIf  # WAR ROOM temp import
 import salt.utils.files
 
 
+@skipIf(True, "WAR ROOM TEMPORARY SKIP")
 class SSHAuthStateTests(ModuleCase, SaltReturnAssertsMixin):
 
     @destructiveTest

--- a/tests/integration/states/test_ssh_known_hosts.py
+++ b/tests/integration/states/test_ssh_known_hosts.py
@@ -17,6 +17,7 @@ from tests.support.runtests import RUNTIME_VARS
 from tests.support.helpers import skip_if_binaries_missing
 
 # Import 3rd-party libs
+from tests.support.unit import skipIf  # WAR ROOM temp import
 from salt.ext import six
 
 GITHUB_FINGERPRINT = '9d:38:5b:83:a9:17:52:92:56:1a:5e:c4:d4:81:8e:0a:ca:51:a2:64:f1:74:20:11:2e:f8:8a:c3:a1:39:49:8f'
@@ -24,6 +25,7 @@ GITHUB_IP = '192.30.253.113'
 
 
 @skip_if_binaries_missing(['ssh', 'ssh-keygen'], check_all=True)
+@skipIf(True, "WAR ROOM TEMPORARY SKIP")
 class SSHKnownHostsStateTest(ModuleCase, SaltReturnAssertsMixin):
     '''
     Validate the ssh state

--- a/tests/integration/states/test_user.py
+++ b/tests/integration/states/test_user.py
@@ -47,6 +47,7 @@ else:
 
 @destructiveTest
 @skip_if_not_root
+@skipIf(True, "WAR ROOM TEMPORARY SKIP")
 class UserTest(ModuleCase, SaltReturnAssertsMixin):
     '''
     test for user absent

--- a/tests/unit/beacons/test_status.py
+++ b/tests/unit/beacons/test_status.py
@@ -21,9 +21,11 @@ import salt.modules.status as status_module
 
 # Salt testing libs
 from tests.support.unit import TestCase
+from tests.support.unit import skipIf  # WAR ROOM temp import
 from tests.support.mixins import LoaderModuleMockMixin
 
 
+@skipIf(True, "WAR ROOM TEMPORARY SKIP")
 class StatusBeaconTestCase(TestCase, LoaderModuleMockMixin):
     '''
     Test case for salt.beacons.status

--- a/tests/unit/daemons/test_masterapi.py
+++ b/tests/unit/daemons/test_masterapi.py
@@ -242,6 +242,7 @@ class AutoKeyTest(TestCase):
 
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
+@skipIf(True, "WAR ROOM TEMPORARY SKIP")
 class LocalFuncsTestCase(TestCase):
     '''
     TestCase for salt.daemons.masterapi.LocalFuncs class

--- a/tests/unit/modules/test_saltcheck.py
+++ b/tests/unit/modules/test_saltcheck.py
@@ -27,6 +27,7 @@ except:
 
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
+@skipIf(True, "WAR ROOM TEMPORARY SKIP")
 class LinuxSysctlTestCase(TestCase, LoaderModuleMockMixin):
     '''
     TestCase for salt.modules.saltcheck module

--- a/tests/unit/modules/test_state.py
+++ b/tests/unit/modules/test_state.py
@@ -1302,6 +1302,7 @@ class StateTestCase(TestCase, LoaderModuleMockMixin):
                     assert res == state._get_pillar_errors(kwargs=opts, pillar=ext_pillar)
 
 
+@skipIf(True, "WAR ROOM TEMPORARY SKIP")
 class TopFileMergingCase(TestCase, LoaderModuleMockMixin):
 
     def setup_loader_modules(self):

--- a/tests/unit/modules/test_zfs.py
+++ b/tests/unit/modules/test_zfs.py
@@ -35,6 +35,7 @@ from salt.utils.dateutils import strftime
 
 # Skip this test case if we don't have access to mock!
 @skipIf(NO_MOCK, NO_MOCK_REASON)
+@skipIf(True, "WAR ROOM TEMPORARY SKIP")
 class ZfsTestCase(TestCase, LoaderModuleMockMixin):
     '''
     This class contains a set of functions that test salt.modules.zfs module

--- a/tests/unit/modules/test_zpool.py
+++ b/tests/unit/modules/test_zpool.py
@@ -37,6 +37,7 @@ import salt.utils.decorators.path
 
 # Skip this test case if we don't have access to mock!
 @skipIf(NO_MOCK, NO_MOCK_REASON)
+@skipIf(True, "WAR ROOM TEMPORARY SKIP")
 class ZpoolTestCase(TestCase, LoaderModuleMockMixin):
     '''
     This class contains a set of functions that test salt.modules.zpool module

--- a/tests/unit/states/test_boto_cloudtrail.py
+++ b/tests/unit/states/test_boto_cloudtrail.py
@@ -156,6 +156,7 @@ class BotoCloudTrailStateTestCaseBase(TestCase, LoaderModuleMockMixin):
         session_instance.client.return_value = self.conn
 
 
+@skipIf(True, "WAR ROOM TEMPORARY SKIP")
 class BotoCloudTrailTestCase(BotoCloudTrailStateTestCaseBase, BotoCloudTrailTestCaseMixin):
     '''
     TestCase for salt.modules.boto_cloudtrail state.module

--- a/tests/unit/states/test_boto_cognitoidentity.py
+++ b/tests/unit/states/test_boto_cognitoidentity.py
@@ -182,6 +182,7 @@ class BotoCognitoIdentityStateTestCaseBase(TestCase, LoaderModuleMockMixin):
                                        ' or equal to version {0}'
         .format(required_boto3_version))
 @skipIf(NO_MOCK, NO_MOCK_REASON)
+@skipIf(True, "WAR ROOM TEMPORARY SKIP")
 class BotoCognitoIdentityTestCase(BotoCognitoIdentityStateTestCaseBase, BotoCognitoIdentityTestCaseMixin):
     '''
     TestCase for salt.states.boto_cognitoidentity state.module

--- a/tests/unit/states/test_boto_lambda.py
+++ b/tests/unit/states/test_boto_lambda.py
@@ -154,6 +154,7 @@ class BotoLambdaStateTestCaseBase(TestCase, LoaderModuleMockMixin):
         session_instance.client.return_value = self.conn
 
 
+@skipIf(True, "WAR ROOM TEMPORARY SKIP")
 class BotoLambdaFunctionTestCase(BotoLambdaStateTestCaseBase, BotoLambdaTestCaseMixin):
     '''
     TestCase for salt.modules.boto_lambda state.module

--- a/tests/unit/states/test_boto_s3_bucket.py
+++ b/tests/unit/states/test_boto_s3_bucket.py
@@ -316,6 +316,7 @@ class BotoS3BucketStateTestCaseBase(TestCase, LoaderModuleMockMixin):
         session_instance.client.return_value = self.conn
 
 
+@skipIf(True, "WAR ROOM TEMPORARY SKIP")
 class BotoS3BucketTestCase(BotoS3BucketStateTestCaseBase, BotoS3BucketTestCaseMixin):
     '''
     TestCase for salt.modules.boto_s3_bucket state.module

--- a/tests/unit/states/test_zfs.py
+++ b/tests/unit/states/test_zfs.py
@@ -31,6 +31,7 @@ from salt.utils.odict import OrderedDict
 
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
+@skipIf(True, "WAR ROOM TEMPORARY SKIP")
 class ZfsTestCase(TestCase, LoaderModuleMockMixin):
     '''
     Test cases for salt.states.zfs

--- a/tests/unit/test_doc.py
+++ b/tests/unit/test_doc.py
@@ -16,12 +16,14 @@ from tests.support.runtests import RUNTIME_VARS
 
 # Import Salt libs
 import salt.modules.cmdmod
+from tests.support.unit import skipIf  # WAR ROOM temp import
 import salt.utils.platform
 
 
 log = logging.getLogger(__name__)
 
 
+@skipIf(True, "WAR ROOM TEMPORARY SKIP")
 class DocTestCase(TestCase):
     '''
     Unit test case for testing doc files and strings.

--- a/tests/unit/test_loader.py
+++ b/tests/unit/test_loader.py
@@ -861,6 +861,7 @@ deep_init_base = '''
 from __future__ import absolute_import
 import {0}.top_lib
 import {0}.top_lib.mid_lib
+from tests.support.unit import skipIf; skipIf(True, "WAR ROOM TEMPORARY SKIP")  # pylint: disable=C0321,E8702
 import {0}.top_lib.mid_lib.bot_lib
 
 def top():

--- a/tests/unit/test_master.py
+++ b/tests/unit/test_master.py
@@ -9,12 +9,14 @@ import salt.master
 
 # Import Salt Testing Libs
 from tests.support.unit import TestCase
+from tests.support.unit import skipIf  # WAR ROOM temp import
 from tests.support.mock import (
     patch,
     MagicMock,
 )
 
 
+@skipIf(True, "WAR ROOM TEMPORARY SKIP")
 class ClearFuncsTestCase(TestCase):
     '''
     TestCase for salt.master.ClearFuncs class

--- a/tests/unit/transport/test_zeromq.py
+++ b/tests/unit/transport/test_zeromq.py
@@ -372,6 +372,7 @@ class ZMQConfigTest(TestCase):
                                                          source_port=s_port) == 'tcp://0.0.0.0:{0};{1}:{2}'.format(s_port, m_ip, m_port)
 
 
+@skipIf(True, "WAR ROOM TEMPORARY SKIP")
 class PubServerChannel(TestCase, AdaptedConfigurationTestCaseMixin):
 
     @classmethod

--- a/tests/unit/utils/test_event.py
+++ b/tests/unit/utils/test_event.py
@@ -38,6 +38,7 @@ if getattr(zmq, 'IPC_PATH_MAX_LEN', 103) <= 103:
 
 
 @skipIf(NO_LONG_IPC, "This system does not support long IPC paths. Skipping event tests!")
+@skipIf(True, "WAR ROOM TEMPORARY SKIP")
 class TestSaltEvent(TestCase):
     def setUp(self):
         self.sock_dir = os.path.join(RUNTIME_VARS.TMP, 'test-socks')

--- a/tests/unit/utils/test_pydsl.py
+++ b/tests/unit/utils/test_pydsl.py
@@ -25,6 +25,7 @@ from salt.utils.pydsl import PyDslError
 
 # Import 3rd-party libs
 from salt.ext import six
+from tests.support.unit import skipIf  # WAR ROOM temp import
 from salt.ext.six.moves import StringIO
 
 
@@ -84,6 +85,7 @@ class CommonTestCaseBoilerplate(TestCase):
             HIGHSTATE.pop_active()
 
 
+@skipIf(True, "WAR ROOM TEMPORARY SKIP")
 class PyDSLRendererTestCase(CommonTestCaseBoilerplate):
     '''
     WARNING: If tests in here are flaky, they may need

--- a/tests/unit/utils/test_pyobjects.py
+++ b/tests/unit/utils/test_pyobjects.py
@@ -142,6 +142,7 @@ from salt://password.sls import password
 '''
 
 requisite_implicit_list_template = '''#!pyobjects
+from tests.support.unit import skipIf; skipIf(True, "WAR ROOM TEMPORARY SKIP")  # pylint: disable=C0321,E8702
 from salt.utils.pyobjects import StateFactory
 Service = StateFactory('service')
 

--- a/tests/utils/test_ipaddress.py
+++ b/tests/utils/test_ipaddress.py
@@ -667,6 +667,7 @@ class ComparisonTests(TestCase):
 
 @skipIf(True, 'WAR ROOM TEMPORARY SKIP')
 @skipIf(sys.version_info > (3,), 'These are tested by the python test suite under Py3')
+@skipIf(True, "WAR ROOM TEMPORARY SKIP")
 class IpaddrUnitTest(TestCase):
 
     def setUp(self):

--- a/tools/time-killer.py
+++ b/tools/time-killer.py
@@ -1,0 +1,92 @@
+from collections import defaultdict, Counter
+from pathlib import Path
+
+SALT_PATH = Path('~/util/tests').expanduser().resolve()
+
+def skip_class(classname):
+    filename, _, classname = classname.rpartition('.')
+    filename = SALT_PATH / (filename.replace('.', '/')+'.py')
+    classline = "class "+classname
+    print('Updating:', filename, classname)
+    with filename.open(mode='r+') as f:
+        lines = f.readlines()
+
+        last_import_line = 0
+        has_import = False
+        class_line_idx = 0
+        for i, line in enumerate(lines):
+            if line.startswith('import ') or line.startswith('from '):
+                last_import_line = i
+
+            if 'tests.support.unit' in line and 'skipIf' in line:
+                has_import = True
+
+            if classline in line:
+                class_line_idx = i
+
+        if not has_import:
+            lines.insert(last_import_line, 'from tests.support.unit import skipIf  # WAR ROOM temp import\n')
+            class_line_idx += 1
+
+            f.seek(0)
+            f.truncate()
+            f.write(''.join(lines))
+
+        if 'WAR ROOM' not in lines[class_line_idx-1]:
+            lines.insert(class_line_idx, '@skipIf(True, "WAR ROOM TEMPORARY SKIP")\n')
+            f.seek(0)
+            f.truncate()
+            f.write(''.join(lines))
+
+
+def skip_file(filename):
+    filename = SALT_PATH / (filename.replace('.', '/')+'.py')
+    print('Updating:', filename)
+    with filename.open(mode='r+') as f:
+        lines = f.readlines()
+
+        last_import_line = 0
+        has_import = False
+        has_skip = False
+        for i, line in enumerate(lines):
+            if line.startswith('import ') or line.startswith('from '):
+                last_import_line = i
+
+            if 'tests.support.unit' in line and 'skipIf' in line:
+                has_import = True
+
+            if 'skipIf(True, "WAR ROOM"' in line:
+                has_skip = True
+
+        if not has_import:
+            lines.insert(last_import_line, 'from tests.support.unit import skipIf; skipIf(True, "WAR ROOM TEMPORARY SKIP")  # pylint: disable=C0321,E8702\n')
+
+            f.seek(0)
+            f.truncate()
+            f.write(''.join(lines))
+        elif not has_skip:
+            lines.insert(last_import_line, 'skipIf(True, "WAR ROOM TEMPORARY SKIP")')
+
+
+if __name__ == '__main__':
+    with open('/tmp/times.txt') as f:
+        # Couple of header lines
+        f.readline()
+        f.readline()
+        tests = f.readlines()[:100]
+
+    by_module = defaultdict(list)
+    for test in tests:
+        name = test.split(None, 1)[0]
+        module = name.rpartition('.')[0]
+        by_module[module].append(name)
+
+    counts = Counter()
+    for mod in by_module:
+        counts[mod] = len(by_module[mod])
+
+    for name, count in counts.most_common():
+        if count == 1:
+            skip_class(by_module[name][0])
+        else:
+            skip_file(name)


### PR DESCRIPTION
Temp skip for 100 slowest tests. This should drastically decrease our test time, with the (obvious) downside of not actually testing many things. But it should help us troubleshoot the slow tests.