### PR TITLE
Revert "Use winapi.com instead of coinitialize"

### DIFF
--- a/salt/modules/win_groupadd.py
+++ b/salt/modules/win_groupadd.py
@@ -13,11 +13,11 @@ from __future__ import absolute_import, unicode_literals, print_function
 # Import Salt libs
 import salt.utils.platform
 import salt.utils.win_functions
-import salt.utils.winapi
 
 
 try:
     import win32com.client
+    import pythoncom
     import pywintypes
     HAS_DEPENDENCIES = True
 except ImportError:
@@ -43,8 +43,8 @@ def _get_computer_object():
     Returns:
         object: Returns the computer object for the local machine
     '''
-    with salt.utils.winapi.Com():
-        nt = win32com.client.Dispatch('AdsNameSpaces')
+    pythoncom.CoInitialize()
+    nt = win32com.client.Dispatch('AdsNameSpaces')
     return nt.GetObject('', 'WinNT://.,computer')
 
 
@@ -59,8 +59,8 @@ def _get_group_object(name):
     Returns:
         object: The specified group object
     '''
-    with salt.utils.winapi.Com():
-        nt = win32com.client.Dispatch('AdsNameSpaces')
+    pythoncom.CoInitialize()
+    nt = win32com.client.Dispatch('AdsNameSpaces')
     return nt.GetObject('', 'WinNT://./' + name + ',group')
 
 
@@ -72,8 +72,8 @@ def _get_all_groups():
     Returns:
         iter: A list of objects for all groups on the machine
     '''
-    with salt.utils.winapi.Com():
-        nt = win32com.client.Dispatch('AdsNameSpaces')
+    pythoncom.CoInitialize()
+    nt = win32com.client.Dispatch('AdsNameSpaces')
     results = nt.GetObject('', 'WinNT://.')
     results.Filter = ['group']
     return results

--- a/salt/modules/win_system.py
+++ b/salt/modules/win_system.py
@@ -3,6 +3,7 @@
 Module for managing windows systems.
 
 :depends:
+    - pythoncom
     - pywintypes
     - win32api
     - win32con
@@ -23,12 +24,12 @@ from datetime import datetime
 import salt.utils.functools
 import salt.utils.locales
 import salt.utils.platform
-import salt.utils.winapi
 from salt.exceptions import CommandExecutionError
 
 # Import 3rd-party Libs
 from salt.ext import six
 try:
+    import pythoncom
     import wmi
     import win32net
     import win32api
@@ -515,8 +516,8 @@ def get_system_info():
     os_type = {1: 'Work Station',
                2: 'Domain Controller',
                3: 'Server'}
-    with salt.utils.winapi.Com():
-        conn = wmi.WMI()
+    pythoncom.CoInitialize()
+    conn = wmi.WMI()
     system = conn.Win32_OperatingSystem()[0]
     ret = {'name': get_computer_name(),
            'description': system.Description,
@@ -755,8 +756,8 @@ def _join_domain(domain,
     if not account_exists:
         join_options |= NETSETUP_ACCOUNT_CREATE
 
-    with salt.utils.winapi.Com():
-        conn = wmi.WMI()
+    pythoncom.CoInitialize()
+    conn = wmi.WMI()
     comp = conn.Win32_ComputerSystem()[0]
 
     # Return the results of the command as an error
@@ -847,8 +848,8 @@ def unjoin_domain(username=None,
     if disable:
         unjoin_options |= NETSETUP_ACCT_DELETE
 
-    with salt.utils.winapi.Com():
-        conn = wmi.WMI()
+    pythoncom.CoInitialize()
+    conn = wmi.WMI()
     comp = conn.Win32_ComputerSystem()[0]
     err = comp.UnjoinDomainOrWorkgroup(Password=password,
                                        UserName=username,
@@ -891,8 +892,8 @@ def get_domain_workgroup():
 
         salt 'minion-id' system.get_domain_workgroup
     '''
-    with salt.utils.winapi.Com():
-        conn = wmi.WMI()
+    pythoncom.CoInitialize()
+    conn = wmi.WMI()
     for computer in conn.Win32_ComputerSystem():
         if computer.PartOfDomain:
             return {'Domain': computer.Domain}

--- a/salt/modules/win_task.py
+++ b/salt/modules/win_task.py
@@ -17,7 +17,6 @@ from datetime import datetime
 
 # Import Salt libs
 import salt.utils.platform
-import salt.utils.winapi
 
 # Import 3rd-party libraries
 try:
@@ -344,8 +343,8 @@ def list_tasks(location='\\'):
         salt 'minion-id' task.list_tasks Microsoft\XblGameSave
     '''
     # Create the task service object
-    with salt.utils.winapi.Com():
-        task_service = win32com.client.Dispatch("Schedule.Service")
+    pythoncom.CoInitialize()
+    task_service = win32com.client.Dispatch("Schedule.Service")
     task_service.Connect()
 
     # Get the folder to list tasks from
@@ -384,8 +383,8 @@ def list_folders(location='\\'):
         salt 'minion-id' task.list_folders Microsoft
     '''
     # Create the task service object
-    with salt.utils.winapi.Com():
-        task_service = win32com.client.Dispatch("Schedule.Service")
+    pythoncom.CoInitialize()
+    task_service = win32com.client.Dispatch("Schedule.Service")
     task_service.Connect()
 
     # Get the folder to list folders from
@@ -428,8 +427,8 @@ def list_triggers(name, location='\\'):
         salt '*' task.list_triggers XblGameSaveTask Microsoft\XblGameSave
     '''
     # Create the task service object
-    with salt.utils.winapi.Com():
-        task_service = win32com.client.Dispatch("Schedule.Service")
+    pythoncom.CoInitialize()
+    task_service = win32com.client.Dispatch("Schedule.Service")
     task_service.Connect()
 
     # Get the folder to list folders from
@@ -473,8 +472,8 @@ def list_actions(name, location='\\'):
         salt 'minion-id' task.list_actions XblGameSaveTask Microsoft\XblGameSave
     '''
     # Create the task service object
-    with salt.utils.winapi.Com():
-        task_service = win32com.client.Dispatch("Schedule.Service")
+    pythoncom.CoInitialize()
+    task_service = win32com.client.Dispatch("Schedule.Service")
     task_service.Connect()
 
     # Get the folder to list folders from
@@ -540,8 +539,8 @@ def create_task(name,
         return '{0} already exists'.format(name)
 
     # connect to the task scheduler
-    with salt.utils.winapi.Com():
-        task_service = win32com.client.Dispatch("Schedule.Service")
+    pythoncom.CoInitialize()
+    task_service = win32com.client.Dispatch("Schedule.Service")
     task_service.Connect()
 
     # Create a new task definition
@@ -631,8 +630,8 @@ def create_task_from_xml(name,
         return 'Must specify either xml_text or xml_path'
 
     # Create the task service object
-    with salt.utils.winapi.Com():
-        task_service = win32com.client.Dispatch("Schedule.Service")
+    pythoncom.CoInitialize()
+    task_service = win32com.client.Dispatch("Schedule.Service")
     task_service.Connect()
 
     # Load xml from file, overrides xml_text
@@ -715,8 +714,8 @@ def create_folder(name, location='\\'):
         return '{0} already exists'.format(name)
 
     # Create the task service object
-    with salt.utils.winapi.Com():
-        task_service = win32com.client.Dispatch("Schedule.Service")
+    pythoncom.CoInitialize()
+    task_service = win32com.client.Dispatch("Schedule.Service")
     task_service.Connect()
 
     # Get the folder to list folders from
@@ -950,8 +949,8 @@ def edit_task(name=None,
         if name in list_tasks(location):
 
             # Connect to the task scheduler
-            with salt.utils.winapi.Com():
-                task_service = win32com.client.Dispatch("Schedule.Service")
+            pythoncom.CoInitialize()
+            task_service = win32com.client.Dispatch("Schedule.Service")
             task_service.Connect()
 
             # get the folder to create the task in
@@ -1122,8 +1121,8 @@ def delete_task(name, location='\\'):
         return '{0} not found in {1}'.format(name, location)
 
     # connect to the task scheduler
-    with salt.utils.winapi.Com():
-        task_service = win32com.client.Dispatch("Schedule.Service")
+    pythoncom.CoInitialize()
+    task_service = win32com.client.Dispatch("Schedule.Service")
     task_service.Connect()
 
     # get the folder to delete the task from
@@ -1166,8 +1165,8 @@ def delete_folder(name, location='\\'):
         return '{0} not found in {1}'.format(name, location)
 
     # connect to the task scheduler
-    with salt.utils.winapi.Com():
-        task_service = win32com.client.Dispatch("Schedule.Service")
+    pythoncom.CoInitialize()
+    task_service = win32com.client.Dispatch("Schedule.Service")
     task_service.Connect()
 
     # get the folder to delete the folder from
@@ -1211,8 +1210,8 @@ def run(name, location='\\'):
         return '{0} not found in {1}'.format(name, location)
 
     # connect to the task scheduler
-    with salt.utils.winapi.Com():
-        task_service = win32com.client.Dispatch("Schedule.Service")
+    pythoncom.CoInitialize()
+    task_service = win32com.client.Dispatch("Schedule.Service")
     task_service.Connect()
 
     # get the folder to delete the folder from
@@ -1254,8 +1253,8 @@ def run_wait(name, location='\\'):
         return '{0} not found in {1}'.format(name, location)
 
     # connect to the task scheduler
-    with salt.utils.winapi.Com():
-        task_service = win32com.client.Dispatch("Schedule.Service")
+    pythoncom.CoInitialize()
+    task_service = win32com.client.Dispatch("Schedule.Service")
     task_service.Connect()
 
     # get the folder to delete the folder from
@@ -1315,8 +1314,8 @@ def stop(name, location='\\'):
         return '{0} not found in {1}'.format(name, location)
 
     # connect to the task scheduler
-    with salt.utils.winapi.Com():
-        task_service = win32com.client.Dispatch("Schedule.Service")
+    pythoncom.CoInitialize()
+    task_service = win32com.client.Dispatch("Schedule.Service")
     task_service.Connect()
 
     # get the folder to delete the folder from
@@ -1364,8 +1363,8 @@ def status(name, location='\\'):
         return '{0} not found in {1}'.format(name, location)
 
     # connect to the task scheduler
-    with salt.utils.winapi.Com():
-        task_service = win32com.client.Dispatch("Schedule.Service")
+    pythoncom.CoInitialize()
+    task_service = win32com.client.Dispatch("Schedule.Service")
     task_service.Connect()
 
     # get the folder where the task is defined
@@ -1403,8 +1402,8 @@ def info(name, location='\\'):
         return '{0} not found in {1}'.format(name, location)
 
     # connect to the task scheduler
-    with salt.utils.winapi.Com():
-        task_service = win32com.client.Dispatch("Schedule.Service")
+    pythoncom.CoInitialize()
+    task_service = win32com.client.Dispatch("Schedule.Service")
     task_service.Connect()
 
     # get the folder to delete the folder from
@@ -1628,8 +1627,8 @@ def add_action(name=None,
         if name in list_tasks(location):
 
             # Connect to the task scheduler
-            with salt.utils.winapi.Com():
-                task_service = win32com.client.Dispatch("Schedule.Service")
+            pythoncom.CoInitialize()
+            task_service = win32com.client.Dispatch("Schedule.Service")
             task_service.Connect()
 
             # get the folder to create the task in
@@ -1735,8 +1734,8 @@ def _clear_actions(name, location='\\'):
         return '{0} not found in {1}'.format(name, location)
 
     # Create the task service object
-    with salt.utils.winapi.Com():
-        task_service = win32com.client.Dispatch("Schedule.Service")
+    pythoncom.CoInitialize()
+    task_service = win32com.client.Dispatch("Schedule.Service")
     task_service.Connect()
 
     # Get the actions from the task
@@ -2204,8 +2203,8 @@ def add_trigger(name=None,
         if name in list_tasks(location):
 
             # Connect to the task scheduler
-            with salt.utils.winapi.Com():
-                task_service = win32com.client.Dispatch("Schedule.Service")
+            pythoncom.CoInitialize()
+            task_service = win32com.client.Dispatch("Schedule.Service")
             task_service.Connect()
 
             # get the folder to create the task in
@@ -2392,8 +2391,8 @@ def clear_triggers(name, location='\\'):
         return '{0} not found in {1}'.format(name, location)
 
     # Create the task service object
-    with salt.utils.winapi.Com():
-        task_service = win32com.client.Dispatch("Schedule.Service")
+    pythoncom.CoInitialize()
+    task_service = win32com.client.Dispatch("Schedule.Service")
     task_service.Connect()
 
     # Get the triggers from the task

--- a/salt/modules/win_useradd.py
+++ b/salt/modules/win_useradd.py
@@ -9,6 +9,7 @@ Module for managing Windows Users
     <module-provider-override>`.
 
 :depends:
+        - pythoncom
         - pywintypes
         - win32api
         - win32con
@@ -37,7 +38,6 @@ except Exception:
 import salt.utils.args
 import salt.utils.dateutils
 import salt.utils.platform
-import salt.utils.winapi
 from salt.ext import six
 from salt.ext.six import string_types
 from salt.exceptions import CommandExecutionError
@@ -47,6 +47,7 @@ log = logging.getLogger(__name__)
 try:
     import pywintypes
     import wmi
+    import pythoncom
     import win32api
     import win32con
     import win32net
@@ -988,8 +989,8 @@ def rename(name, new_name):
 
     # Rename the user account
     # Connect to WMI
-    with salt.utils.winapi.Com():
-        c = wmi.WMI(find_classes=0)
+    pythoncom.CoInitialize()
+    c = wmi.WMI(find_classes=0)
 
     # Get the user object
     try:

--- a/salt/modules/win_wua.py
+++ b/salt/modules/win_wua.py
@@ -63,12 +63,12 @@ import logging
 import salt.utils.platform
 import salt.utils.versions
 import salt.utils.win_update
-import salt.utils.winapi
 from salt.exceptions import CommandExecutionError
 
 # Import 3rd-party libs
 from salt.ext import six
 try:
+    import pythoncom
     import win32com.client
     HAS_PYWIN32 = True
 except ImportError:
@@ -1057,7 +1057,6 @@ def set_wu_settings(level=None,
     # work on Windows 10 / Server 2016. It is called in throughout this function
     # like this:
     #
-    # with salt.utils.winapi.Com():
     #     obj_au = win32com.client.Dispatch('Microsoft.Update.AutoUpdate')
     #     obj_au_settings = obj_au.Settings
     #     obj_au_settings.Save()
@@ -1078,10 +1077,10 @@ def set_wu_settings(level=None,
     ret = {'Success': True}
 
     # Initialize the PyCom system
-    with salt.utils.winapi.Com():
+    pythoncom.CoInitialize()
 
-        # Create an AutoUpdate object
-        obj_au = win32com.client.Dispatch('Microsoft.Update.AutoUpdate')
+    # Create an AutoUpdate object
+    obj_au = win32com.client.Dispatch('Microsoft.Update.AutoUpdate')
 
     # Create an AutoUpdate Settings Object
     obj_au_settings = obj_au.Settings
@@ -1175,8 +1174,7 @@ def set_wu_settings(level=None,
     if msupdate is not None:
         # Microsoft Update requires special handling
         # First load the MS Update Service Manager
-        with salt.utils.winapi.Com():
-            obj_sm = win32com.client.Dispatch('Microsoft.Update.ServiceManager')
+        obj_sm = win32com.client.Dispatch('Microsoft.Update.ServiceManager')
 
         # Give it a bogus name
         obj_sm.ClientApplicationID = "My App"
@@ -1277,9 +1275,10 @@ def get_wu_settings():
            'Saturday']
 
     # Initialize the PyCom system
-    with salt.utils.winapi.Com():
-        # Create an AutoUpdate object
-        obj_au = win32com.client.Dispatch('Microsoft.Update.AutoUpdate')
+    pythoncom.CoInitialize()
+
+    # Create an AutoUpdate object
+    obj_au = win32com.client.Dispatch('Microsoft.Update.AutoUpdate')
 
     # Create an AutoUpdate Settings Object
     obj_au_settings = obj_au.Settings
@@ -1313,10 +1312,8 @@ def _get_msupdate_status():
     '''
     # To get the status of Microsoft Update we actually have to check the
     # Microsoft Update Service Manager
-    # Initialize the PyCom system
-    with salt.utils.winapi.Com():
-        # Create a ServiceManager Object
-        obj_sm = win32com.client.Dispatch('Microsoft.Update.ServiceManager')
+    # Create a ServiceManager Object
+    obj_sm = win32com.client.Dispatch('Microsoft.Update.ServiceManager')
 
     # Return a collection of loaded Services
     col_services = obj_sm.Services

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -313,7 +313,6 @@ from salt.state import get_accumulator_dir as _get_accumulator_dir
 if salt.utils.platform.is_windows():
     import salt.utils.win_dacl
     import salt.utils.win_functions
-    import salt.utils.winapi
 
 # Import 3rd-party libs
 from salt.ext import six
@@ -1232,8 +1231,7 @@ def _shortcut_check(name,
         ), changes
 
     if os.path.isfile(name):
-        with salt.utils.winapi.Com():
-            shell = win32com.client.Dispatch("WScript.Shell")
+        shell = win32com.client.Dispatch("WScript.Shell")
         scut = shell.CreateShortcut(name)
         state_checks = [scut.TargetPath.lower() == target.lower()]
         if arguments is not None:
@@ -6860,8 +6858,7 @@ def shortcut(
 
     # This will just load the shortcut if it already exists
     # It won't create the file until calling scut.Save()
-    with salt.utils.winapi.Com():
-        shell = win32com.client.Dispatch("WScript.Shell")
+    shell = win32com.client.Dispatch("WScript.Shell")
     scut = shell.CreateShortcut(name)
 
     # The shortcut target will automatically be created with its

--- a/tests/unit/modules/test_win_system.py
+++ b/tests/unit/modules/test_win_system.py
@@ -38,11 +38,6 @@ class WinSystemTestCase(TestCase, LoaderModuleMockMixin):
                                                             now.day, now.hour, now.minute,
                                                             now.second, now.microsecond])
             modules_globals['win32api'] = win32api
-            win32net = types.ModuleType(str('win32net'))  # future lint: disable=blacklisted-function
-            win32net.NetServerGetInfo = MagicMock()
-            win32net.NetServerSetInfo = MagicMock()
-            modules_globals['win32net'] = win32net
-
         return {win_system: modules_globals}
 
     def test_halt(self):
@@ -182,15 +177,14 @@ class WinSystemTestCase(TestCase, LoaderModuleMockMixin):
         '''
             Test to set the Windows computer description
         '''
-        mock = MagicMock()
-        mock_get_info = MagicMock(return_value={'comment': ''})
-        mock_get_desc = MagicMock(return_value="Salt's comp")
-        with patch('salt.modules.win_system.win32net.NetServerGetInfo', mock_get_info), \
-                patch('salt.modules.win_system.win32net.NetServerSetInfo', mock), \
-                patch.object(win_system, 'get_computer_desc', mock_get_desc):
-            self.assertDictEqual(
-                win_system.set_computer_desc("Salt's comp"),
-                {'Computer Description': "Salt's comp"})
+        mock = MagicMock(return_value=True)
+        with patch.dict(win_system.__salt__, {'cmd.run': mock}):
+            mock = MagicMock(return_value="Salt's comp")
+            with patch.object(win_system, 'get_computer_desc', mock):
+                self.assertDictEqual(win_system.set_computer_desc(
+                                                                  "Salt's comp"
+                                                                  ),
+                                     {'Computer Description': "Salt's comp"})
 
     @skipIf(not win_system.HAS_WIN32NET_MODS, 'this test needs the w32net library')
     def test_get_computer_desc(self):


### PR DESCRIPTION
This reverts commit a38300b156f6c2df78e72c34bb59613215342a5b.

### What does this PR do?
Fixes Windows behavior on the salt-minion, because the above commit uses pythoncom.CoInitialize() / CoUninitialize() in a flawed way.

salt.utils.winapi.Com() is a context manager for pythoncom - a way to use Windows COM interface for queries. That means, when you get out of the context, you can't touch any COM object in any way, because on `__exit__` it will call pythoncom.CoUninitilize() which releases all resources, which ends up in an immediat crash.
The above change added code like:
`with salt.utils.winapi.Com():`
`....conn = wmi.WMI()`
` comp = conn.Win32_ComputerSystem()[0]`

where the last line happens after pythoncom.CoUninitialize() happens, and end up in a crash.

I thought a quick fix would be put the whole code inside the 'with context', but there are cases where from the middle of a 'with context' calls a function that's again doing the 'with salt.utils.winapi.Com()', and while it's not a problem to call pythoncom.CoInitialize() multiple times, when the first pythoncom.CoUninitialize() happens, the whole COM interface that happens on the thread gets destroyed, so after returning from this function, calling anything from the COM object will crash.

Safest thing is to revert this and leave with possible leaks due to the fact that we never call pythoncom.CoUninitialize(), until the code is refactored properly.

A small test I did on Windows from an installed minion is, start a 'python' instance and execute the following:

`import pythoncom`
`import wmi`
`pythoncom.CoInitialize()`
`c = wmi.WMI()`
`pythoncom.CoInitialize()`
`pythoncom.CoUninitialize()`
`system = c.Win32_OperatingSystem()`
`pythoncom.CoUninitialize()`

It will crash on the 'system = ' line.

This has to be merged in all branches that contained the above change.

### Previous Behavior
Certain aspects of windows salt-minion were broken - anything that used salt/modules/win_system.py was crashing.

### New Behavior
Things to back to normal.

### Tests written?
No

### Commits signed with GPG?

Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
