### PR TITLE
fixed: zabbix_host module does not process additional host properties

### DIFF
--- a/salt/states/zabbix_host.py
+++ b/salt/states/zabbix_host.py
@@ -68,7 +68,11 @@ def present(host, groups, interfaces, **kwargs):
 
 
     '''
-    connection_args = {}
+    connection_args = dict(kwargs)
+    for prop in ['name', 'host', 'hostids', 'template', 'proxy_hostid', 'interfaceids', 'inventory']:
+        if connection_args.get(prop, None):
+            connection_args.pop(prop)
+
     if '_connection_user' in kwargs:
         connection_args['_connection_user'] = kwargs['_connection_user']
     if '_connection_password' in kwargs:


### PR DESCRIPTION
### What does this PR do?
Fixes proper processing of additional host properties in zabbix_host state module.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/53838

### Tests written?
No

### Commits signed with GPG?
Yes
