### PR TITLE
Fix test suite clean up (Neon)

### DIFF
--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -1156,7 +1156,7 @@ class TestDaemon(object):
             if os.path.isdir(dirname):
                 try:
                     shutil.rmtree(six.text_type(dirname), onerror=remove_readonly)
-                except Exception:
+                except (Exception, PermissionError):
                     log.exception('Failed to remove directory: %s', dirname)
 
     def wait_for_jid(self, targets, jid, timeout=120):

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -71,6 +71,11 @@ try:
 except ImportError:
     import socketserver
 
+if six.PY2:
+    # Python 2 does not have PermissionError
+    class PermissionError(OSError):
+        pass
+
 # Import salt tests support libs
 from tests.support.processes import SaltMaster, SaltMinion, SaltSyndic
 


### PR DESCRIPTION
### What does this PR do?
Skips `PermissionError` when trying to delete the test directory after a test run. Git maintains open file handles on git index files causing the following stacktrace when trying to clean up:

```
:1183][ERROR   ] Failed to remove directory: C:\Users\ADMINI~1\AppData\Local\Temp\salt-tests-tmpdir
15:52:35         Traceback (most recent call last):
15:52:35           File "c:\users\admini~1\appdata\local\temp\kitchen\testing\.nox\runtests-parametrized-3-coverage-true-crypto-none-transport-zeromq\lib\shutil.py", line 387, in _rmtree_unsafe
15:52:35             os.unlink(fullname)
15:52:35         PermissionError: [WinError 5] Access is denied: 'C:\\Users\\ADMINI~1\\AppData\\Local\\Temp\\salt-tests-tmpdir\\tmp216ldwzw\\gitfs\\709b529e4651ea331ec097c44268cba9\\.git\\objects\\pack\\pack-1a59b5f484045d2294d42df3e17258d44443fa5d.idx'
```

### What issues does this PR fix or reference?
https://github.com/gitpython-developers/GitPython/issues/546

### Commits signed with GPG?

Yes