### PR TITLE
Fix memory error when the test suite cleans up (Neon)

### DIFF
--- a/tests/support/helpers.py
+++ b/tests/support/helpers.py
@@ -1202,6 +1202,8 @@ def _terminate_process_list(process_list, kill=False, slow_stop=False):
             except psutil.AccessDenied:
                 # OSX is more restrictive about the above information
                 cmdline = None
+            except OSError:
+                cmdline = None
             if not cmdline:
                 try:
                     cmdline = process.as_dict()


### PR DESCRIPTION
### What does this PR do?
This should fix an error that occurs at the end of the test run on Windows... causing the test suite to report failure
```
An un-handled exception was caught by salt's global exception handler:
22:22:16        OSError: [WinError 299] Only part of a ReadProcessMemory or WriteProcessMemory request was completed: 'originated from ReadProcessMemory(ProcessParameters)'
22:22:16        Traceback (most recent call last):
22:22:16          File "tests\runtests.py", line 914, in <module>
22:22:16            main()
22:22:16          File "tests\runtests.py", line 907, in main
22:22:16            parser.finalize(0)
22:22:16          File "C:\\Users\\ADMINI~1\\AppData\\Local\\Temp\\kitchen\\testing\tests\support\parser\cover.py", line 238, in finalize
22:22:16            SaltTestingParser.finalize(self, exit_code)
22:22:16          File "C:\\Users\\ADMINI~1\\AppData\\Local\\Temp\\kitchen\\testing\tests\support\parser\__init__.py", line 846, in finalize
22:22:16            helpers.terminate_process(children=children, kill_children=True)
22:22:16          File "C:\\Users\\ADMINI~1\\AppData\\Local\\Temp\\kitchen\\testing\tests\support\helpers.py", line 1325, in terminate_process
22:22:16            terminate_process_list(process_list, kill=slow_stop is False, slow_stop=slow_stop)
22:22:16          File "C:\\Users\\ADMINI~1\\AppData\\Local\\Temp\\kitchen\\testing\tests\support\helpers.py", line 1269, in terminate_process_list
22:22:16            _terminate_process_list(process_list, kill=kill, slow_stop=slow_stop)
22:22:16          File "C:\\Users\\ADMINI~1\\AppData\\Local\\Temp\\kitchen\\testing\tests\support\helpers.py", line 1214, in _terminate_process_list
22:22:16            cmdline = process.cmdline()
22:22:16          File "c:\users\admini~1\appdata\local\temp\kitchen\testing\.nox\runtests-parametrized-3-coverage-true-crypto-none-transport-zeromq\lib\site-packages\psutil\__init__.py", line 786, in cmdline
22:22:16            return self._proc.cmdline()
22:22:16          File "c:\users\admini~1\appdata\local\temp\kitchen\testing\.nox\runtests-parametrized-3-coverage-true-crypto-none-transport-zeromq\lib\site-packages\psutil\_pswindows.py", line 667, in wrapper
22:22:16            return fun(self, *args, **kwargs)
22:22:16          File "c:\users\admini~1\appdata\local\temp\kitchen\testing\.nox\runtests-parametrized-3-coverage-true-crypto-none-transport-zeromq\lib\site-packages\psutil\_pswindows.py", line 745, in cmdline
22:22:16            ret = cext.proc_cmdline(self.pid, use_peb=True)
```

### Tests written?
Fixes Tests

### Commits signed with GPG?
Yes