### PR TITLE
Fixed logic around false negative in file.patch state with test=True

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""
+'''
 Operations on regular files, special files, directories, and symlinks
 =====================================================================
 
@@ -276,7 +276,7 @@ For example:
             first_of_month: 6
             first_of_year: all
 
-"""
+'''
 
 # Import python libs
 from __future__ import absolute_import, print_function, unicode_literals
@@ -292,7 +292,7 @@ import sys
 import time
 import traceback
 from collections import Iterable, Mapping, defaultdict
-from datetime import datetime, date  # python3 problem in the making?
+from datetime import datetime, date   # python3 problem in the making?
 
 # Import salt libs
 import salt.loader
@@ -321,35 +321,37 @@ if salt.utils.platform.is_windows():
 # Import 3rd-party libs
 from salt.ext import six
 from salt.ext.six.moves import zip_longest
-from salt.ext.six.moves.urllib.parse import (
-    urlparse as _urlparse,
-)  # pylint: disable=no-name-in-module
-
+from salt.ext.six.moves.urllib.parse import urlparse as _urlparse  # pylint: disable=no-name-in-module
 if salt.utils.platform.is_windows():
     import pywintypes
     import win32com.client
 
 log = logging.getLogger(__name__)
 
-COMMENT_REGEX = r"^([[:space:]]*){0}[[:space:]]?"
+COMMENT_REGEX = r'^([[:space:]]*){0}[[:space:]]?'
 __NOT_FOUND = object()
 
-__func_alias__ = {"copy_": "copy"}
+__func_alias__ = {
+    'copy_': 'copy',
+}
 
 
 def _get_accumulator_filepath():
-    """
+    '''
     Return accumulator data path.
-    """
-    return os.path.join(_get_accumulator_dir(__opts__["cachedir"]), __instance_id__)
+    '''
+    return os.path.join(
+        _get_accumulator_dir(__opts__['cachedir']),
+        __instance_id__
+    )
 
 
 def _load_accumulators():
     def _deserialize(path):
         serial = salt.payload.Serial(__opts__)
-        ret = {"accumulators": {}, "accumulators_deps": {}}
+        ret = {'accumulators': {}, 'accumulators_deps': {}}
         try:
-            with salt.utils.files.fopen(path, "rb") as f:
+            with salt.utils.files.fopen(path, 'rb') as f:
                 loaded = serial.load(f)
                 return loaded if loaded else ret
         except (IOError, NameError):
@@ -358,15 +360,16 @@ def _load_accumulators():
 
     loaded = _deserialize(_get_accumulator_filepath())
 
-    return loaded["accumulators"], loaded["accumulators_deps"]
+    return loaded['accumulators'], loaded['accumulators_deps']
 
 
 def _persist_accummulators(accumulators, accumulators_deps):
-    accumm_data = {"accumulators": accumulators, "accumulators_deps": accumulators_deps}
+    accumm_data = {'accumulators': accumulators,
+                   'accumulators_deps': accumulators_deps}
 
     serial = salt.payload.Serial(__opts__)
     try:
-        with salt.utils.files.fopen(_get_accumulator_filepath(), "w+b") as f:
+        with salt.utils.files.fopen(_get_accumulator_filepath(), 'w+b') as f:
             serial.dump(accumm_data, f)
     except NameError:
         # msgpack error from salt-ssh
@@ -374,23 +377,25 @@ def _persist_accummulators(accumulators, accumulators_deps):
 
 
 def _check_user(user, group):
-    """
+    '''
     Checks if the named user and group are present on the minion
-    """
-    err = ""
+    '''
+    err = ''
     if user:
-        uid = __salt__["file.user_to_uid"](user)
-        if uid == "":
-            err += "User {0} is not available ".format(user)
+        uid = __salt__['file.user_to_uid'](user)
+        if uid == '':
+            err += 'User {0} is not available '.format(user)
     if group:
-        gid = __salt__["file.group_to_gid"](group)
-        if gid == "":
-            err += "Group {0} is not available".format(group)
+        gid = __salt__['file.group_to_gid'](group)
+        if gid == '':
+            err += 'Group {0} is not available'.format(group)
     return err
 
 
-def _is_valid_relpath(relpath, maxdepth=None):
-    """
+def _is_valid_relpath(
+        relpath,
+        maxdepth=None):
+    '''
     Performs basic sanity checks on a relative path.
 
     Requires POSIX-compatible paths (i.e. the kind obtained through
@@ -398,7 +403,7 @@ def _is_valid_relpath(relpath, maxdepth=None):
 
     Ensures that the path does not contain directory transversal, and
     that it does not exceed a stated maximum depth (if specified).
-    """
+    '''
     # Check relpath surrounded by slashes, so that `..` can be caught as
     # a path component at the start, end, and in the middle of the path.
     sep, pardir = posixpath.sep, posixpath.pardir
@@ -415,26 +420,25 @@ def _is_valid_relpath(relpath, maxdepth=None):
 
 
 def _salt_to_os_path(path):
-    """
+    '''
     Converts a path from the form received via salt master to the OS's native
     path format.
-    """
+    '''
     return os.path.normpath(path.replace(posixpath.sep, os.path.sep))
 
 
 def _gen_recurse_managed_files(
-    name,
-    source,
-    keep_symlinks=False,
-    include_pat=None,
-    exclude_pat=None,
-    maxdepth=None,
-    include_empty=False,
-    **kwargs
-):
-    """
+        name,
+        source,
+        keep_symlinks=False,
+        include_pat=None,
+        exclude_pat=None,
+        maxdepth=None,
+        include_empty=False,
+        **kwargs):
+    '''
     Generate the list of files managed by a recurse state
-    """
+    '''
 
     # Convert a relative path generated from salt master paths to an OS path
     # using "name" as the base directory
@@ -448,8 +452,7 @@ def _gen_recurse_managed_files(
             if not _is_valid_relpath(srelpath, maxdepth=maxdepth):
                 continue
             if not salt.utils.stringutils.check_include_exclude(
-                srelpath, include_pat, exclude_pat
-            ):
+                    srelpath, include_pat, exclude_pat):
                 continue
             # Check for all paths that begin with the symlink
             # and axe it leaving only the dirs/files below it.
@@ -459,7 +462,8 @@ def _gen_recurse_managed_files(
             for filename in _filenames:
                 if filename.startswith(lname):
                     log.debug(
-                        "** skipping file ** %s, it intersects a symlink", filename
+                        '** skipping file ** %s, it intersects a symlink',
+                        filename
                     )
                     filenames.remove(filename)
             # Create the symlink along with the necessary dirs.
@@ -484,12 +488,12 @@ def _gen_recurse_managed_files(
     if not srcpath.endswith(posixpath.sep):
         # we're searching for things that start with this *directory*.
         srcpath = srcpath + posixpath.sep
-    fns_ = __salt__["cp.list_master"](senv, srcpath)
+    fns_ = __salt__['cp.list_master'](senv, srcpath)
 
     # If we are instructed to keep symlinks, then process them.
     if keep_symlinks:
         # Make this global so that emptydirs can use it if needed.
-        symlinks = __salt__["cp.list_master_symlinks"](senv, srcpath)
+        symlinks = __salt__['cp.list_master_symlinks'](senv, srcpath)
         fns_ = process_symlinks(fns_, symlinks)
 
     for fn_ in fns_:
@@ -507,8 +511,7 @@ def _gen_recurse_managed_files(
         # Check if it is to be excluded. Match only part of the path
         # relative to the target directory
         if not salt.utils.stringutils.check_include_exclude(
-            relname, include_pat, exclude_pat
-        ):
+                relname, include_pat, exclude_pat):
             continue
         dest = full_path(relname)
         dirname = os.path.dirname(dest)
@@ -523,14 +526,13 @@ def _gen_recurse_managed_files(
         managed_files.add((dest, src))
 
     if include_empty:
-        mdirs = __salt__["cp.list_master_dirs"](senv, srcpath)
+        mdirs = __salt__['cp.list_master_dirs'](senv, srcpath)
         for mdir in mdirs:
             relname = posixpath.relpath(mdir, srcpath)
             if not _is_valid_relpath(relname, maxdepth=maxdepth):
                 continue
             if not salt.utils.stringutils.check_include_exclude(
-                relname, include_pat, exclude_pat
-            ):
+                    relname, include_pat, exclude_pat):
                 continue
             mdest = full_path(relname)
             # Check for symlinks that happen to point to an empty dir.
@@ -539,8 +541,8 @@ def _gen_recurse_managed_files(
                 for link in symlinks:
                     if mdir.startswith(link, 0):
                         log.debug(
-                            "** skipping empty dir ** %s, it intersects a " "symlink",
-                            mdir,
+                            '** skipping empty dir ** %s, it intersects a '
+                            'symlink', mdir
                         )
                         islink = True
                         break
@@ -554,15 +556,14 @@ def _gen_recurse_managed_files(
 
 
 def _gen_keep_files(name, require, walk_d=None):
-    """
+    '''
     Generate the list of files that need to be kept when a dir based function
     like directory or recurse has a clean.
-    """
-
+    '''
     def _is_child(path, directory):
-        """
+        '''
         Check whether ``path`` is child of ``directory``
-        """
+        '''
         path = os.path.abspath(path)
         directory = os.path.abspath(directory)
 
@@ -603,19 +604,19 @@ def _gen_keep_files(name, require, walk_d=None):
 
     keep = set()
     if isinstance(require, list):
-        required_files = [comp for comp in require if "file" in comp]
+        required_files = [comp for comp in require if 'file' in comp]
         for comp in required_files:
             for low in __lowstate__:
                 # A requirement should match either the ID and the name of
                 # another state.
-                if low["name"] == comp["file"] or low["__id__"] == comp["file"]:
-                    fn = low["name"]
-                    fun = low["fun"]
+                if low['name'] == comp['file'] or low['__id__'] == comp['file']:
+                    fn = low['name']
+                    fun = low['fun']
                     if os.path.isdir(fn):
                         if _is_child(fn, name):
-                            if fun == "recurse":
+                            if fun == 'recurse':
                                 fkeep = _gen_recurse_managed_files(**low)[3]
-                                log.debug("Keep from %s: %s", fn, fkeep)
+                                log.debug('Keep from %s: %s', fn, fkeep)
                                 keep.update(fkeep)
                             elif walk_d:
                                 walk_ret = set()
@@ -625,29 +626,29 @@ def _gen_keep_files(name, require, walk_d=None):
                                 keep.update(_process(fn))
                     else:
                         keep.add(fn)
-    log.debug("Files to keep from required states: %s", list(keep))
+    log.debug('Files to keep from required states: %s', list(keep))
     return list(keep)
 
 
 def _check_file(name):
     ret = True
-    msg = ""
+    msg = ''
 
     if not os.path.isabs(name):
         ret = False
-        msg = "Specified file {0} is not an absolute path".format(name)
+        msg = 'Specified file {0} is not an absolute path'.format(name)
     elif not os.path.exists(name):
         ret = False
-        msg = "{0}: file not found".format(name)
+        msg = '{0}: file not found'.format(name)
 
     return ret, msg
 
 
 def _find_keep_files(root, keep):
-    """
+    '''
     Compile a list of valid keep files (and directories).
     Used by _clean_dir()
-    """
+    '''
     real_keep = set()
     real_keep.add(root)
     if isinstance(keep, list):
@@ -666,10 +667,10 @@ def _find_keep_files(root, keep):
 
 
 def _clean_dir(root, keep, exclude_pat):
-    """
+    '''
     Clean out all of the files and directories in a directory (root) while
     preserving the files in a list (keep) and part of exclude_pat
-    """
+    '''
     root = os.path.normcase(root)
     real_keep = _find_keep_files(root, keep)
     removed = set()
@@ -679,15 +680,14 @@ def _clean_dir(root, keep, exclude_pat):
             # -- check if this is a part of exclude_pat(only). No need to
             # check include_pat
             if not salt.utils.stringutils.check_include_exclude(
-                os.path.relpath(nfn, root), None, exclude_pat
-            ):
+                    os.path.relpath(nfn, root), None, exclude_pat):
                 return
             removed.add(nfn)
-            if not __opts__["test"]:
+            if not __opts__['test']:
                 try:
                     os.remove(nfn)
                 except OSError:
-                    __salt__["file.remove"](nfn)
+                    __salt__['file.remove'](nfn)
 
     for roots, dirs, files in salt.utils.path.os_walk(root):
         for name in itertools.chain(dirs, files):
@@ -696,28 +696,26 @@ def _clean_dir(root, keep, exclude_pat):
 
 
 def _error(ret, err_msg):
-    ret["result"] = False
-    ret["comment"] = err_msg
+    ret['result'] = False
+    ret['comment'] = err_msg
     return ret
 
 
-def _check_directory(
-    name,
-    user=None,
-    group=None,
-    recurse=False,
-    mode=None,
-    file_mode=None,
-    clean=False,
-    require=False,
-    exclude_pat=None,
-    max_depth=None,
-    follow_symlinks=False,
-    children_only=False,
-):
-    """
+def _check_directory(name,
+                     user=None,
+                     group=None,
+                     recurse=False,
+                     mode=None,
+                     file_mode=None,
+                     clean=False,
+                     require=False,
+                     exclude_pat=None,
+                     max_depth=None,
+                     follow_symlinks=False,
+                     children_only=False):
+    '''
     Check what changes need to be made on a directory
-    """
+    '''
     changes = {}
     if recurse or clean:
         assert max_depth is None or not clean
@@ -734,28 +732,30 @@ def _check_directory(
         try:
             recurse_set = _get_recurse_set(recurse)
         except (TypeError, ValueError) as exc:
-            return False, "{0}".format(exc), changes
-        if "user" not in recurse_set:
+            return False, '{0}'.format(exc), changes
+        if 'user' not in recurse_set:
             user = None
-        if "group" not in recurse_set:
+        if 'group' not in recurse_set:
             group = None
-        if "mode" not in recurse_set:
+        if 'mode' not in recurse_set:
             mode = None
-        check_files = "ignore_files" not in recurse_set
-        check_dirs = "ignore_dirs" not in recurse_set
+        check_files = 'ignore_files' not in recurse_set
+        check_dirs = 'ignore_dirs' not in recurse_set
         for root, dirs, files in walk_l:
             if check_files:
                 for fname in files:
                     fchange = {}
                     mode = file_mode if mode is not None else None
                     path = os.path.join(root, fname)
-                    stats = __salt__["file.stats"](path, None, follow_symlinks)
-                    if user is not None and user != stats.get("user"):
-                        fchange["user"] = user
-                    if group is not None and group != stats.get("group"):
-                        fchange["group"] = group
-                    if mode is not None and mode != stats.get("mode"):
-                        fchange["mode"] = mode
+                    stats = __salt__['file.stats'](
+                        path, None, follow_symlinks
+                    )
+                    if user is not None and user != stats.get('user'):
+                        fchange['user'] = user
+                    if group is not None and group != stats.get('group'):
+                        fchange['group'] = group
+                    if mode is not None and mode != stats.get('mode'):
+                        fchange['mode'] = mode
                     if fchange:
                         changes[path] = fchange
             if check_dirs:
@@ -780,11 +780,10 @@ def _check_directory(
                 return {}
             else:
                 if not salt.utils.stringutils.check_include_exclude(
-                    os.path.relpath(path, name), None, exclude_pat
-                ):
+                        os.path.relpath(path, name), None, exclude_pat):
                     return {}
                 else:
-                    return {path: {"removed": "Removed due to clean"}}
+                    return {path: {'removed': 'Removed due to clean'}}
 
         for root, dirs, files in walk_l:
             for fname in files:
@@ -793,41 +792,37 @@ def _check_directory(
                 changes.update(_check_changes(name_))
 
     if not os.path.isdir(name):
-        changes[name] = {"directory": "new"}
+        changes[name] = {'directory': 'new'}
     if changes:
-        comments = ["The following files will be changed:\n"]
+        comments = ['The following files will be changed:\n']
         for fn_ in changes:
             for key, val in six.iteritems(changes[fn_]):
-                comments.append("{0}: {1} - {2}\n".format(fn_, key, val))
-        return None, "".join(comments), changes
-    return True, "The directory {0} is in the correct state".format(name), changes
+                comments.append('{0}: {1} - {2}\n'.format(fn_, key, val))
+        return None, ''.join(comments), changes
+    return True, 'The directory {0} is in the correct state'.format(name), changes
 
 
-def _check_directory_win(
-    name,
-    win_owner=None,
-    win_perms=None,
-    win_deny_perms=None,
-    win_inheritance=None,
-    win_perms_reset=None,
-):
-    """
+def _check_directory_win(name,
+                         win_owner=None,
+                         win_perms=None,
+                         win_deny_perms=None,
+                         win_inheritance=None,
+                         win_perms_reset=None):
+    '''
     Check what changes need to be made on a directory
-    """
+    '''
     changes = {}
 
     if not os.path.isdir(name):
-        changes = {name: {"directory": "new"}}
+        changes = {name: {'directory': 'new'}}
     else:
         # Check owner by SID
         if win_owner is not None:
             current_owner = salt.utils.win_dacl.get_owner(name)
-            current_owner_sid = salt.utils.win_functions.get_sid_from_name(
-                current_owner
-            )
+            current_owner_sid = salt.utils.win_functions.get_sid_from_name(current_owner)
             expected_owner_sid = salt.utils.win_functions.get_sid_from_name(win_owner)
             if not current_owner_sid == expected_owner_sid:
-                changes["owner"] = win_owner
+                changes['owner'] = win_owner
 
         # Check perms
         perms = salt.utils.win_dacl.get_permissions(name)
@@ -843,46 +838,42 @@ def _check_directory_win(
 
                 grant_perms = []
                 # Check for permissions
-                if isinstance(win_perms[user]["perms"], six.string_types):
+                if isinstance(win_perms[user]['perms'], six.string_types):
                     if not salt.utils.win_dacl.has_permission(
-                        name, user, win_perms[user]["perms"]
-                    ):
-                        grant_perms = win_perms[user]["perms"]
+                            name, user, win_perms[user]['perms']):
+                        grant_perms = win_perms[user]['perms']
                 else:
-                    for perm in win_perms[user]["perms"]:
+                    for perm in win_perms[user]['perms']:
                         if not salt.utils.win_dacl.has_permission(
-                            name, user, perm, exact=False
-                        ):
-                            grant_perms.append(win_perms[user]["perms"])
+                                name, user, perm, exact=False):
+                            grant_perms.append(win_perms[user]['perms'])
                 if grant_perms:
-                    if "grant_perms" not in changes:
-                        changes["grant_perms"] = {}
-                    if user not in changes["grant_perms"]:
-                        changes["grant_perms"][user] = {}
-                    changes["grant_perms"][user]["perms"] = grant_perms
+                    if 'grant_perms' not in changes:
+                        changes['grant_perms'] = {}
+                    if user not in changes['grant_perms']:
+                        changes['grant_perms'][user] = {}
+                    changes['grant_perms'][user]['perms'] = grant_perms
 
                 # Check Applies to
-                if "applies_to" not in win_perms[user]:
-                    applies_to = "this_folder_subfolders_files"
+                if 'applies_to' not in win_perms[user]:
+                    applies_to = 'this_folder_subfolders_files'
                 else:
-                    applies_to = win_perms[user]["applies_to"]
+                    applies_to = win_perms[user]['applies_to']
 
                 if user in perms:
                     user = salt.utils.win_dacl.get_name(user)
 
                     # Get the proper applies_to text
-                    at_flag = salt.utils.win_dacl.flags().ace_prop["file"][applies_to]
-                    applies_to_text = salt.utils.win_dacl.flags().ace_prop["file"][
-                        at_flag
-                    ]
+                    at_flag = salt.utils.win_dacl.flags().ace_prop['file'][applies_to]
+                    applies_to_text = salt.utils.win_dacl.flags().ace_prop['file'][at_flag]
 
-                    if "grant" in perms[user]:
-                        if not perms[user]["grant"]["applies to"] == applies_to_text:
-                            if "grant_perms" not in changes:
-                                changes["grant_perms"] = {}
-                            if user not in changes["grant_perms"]:
-                                changes["grant_perms"][user] = {}
-                            changes["grant_perms"][user]["applies_to"] = applies_to
+                    if 'grant' in perms[user]:
+                        if not perms[user]['grant']['applies to'] == applies_to_text:
+                            if 'grant_perms' not in changes:
+                                changes['grant_perms'] = {}
+                            if user not in changes['grant_perms']:
+                                changes['grant_perms'][user] = {}
+                            changes['grant_perms'][user]['applies_to'] = applies_to
 
         # Verify Deny Permissions
         if win_deny_perms is not None:
@@ -895,122 +886,123 @@ def _check_directory_win(
 
                 deny_perms = []
                 # Check for permissions
-                if isinstance(win_deny_perms[user]["perms"], six.string_types):
+                if isinstance(win_deny_perms[user]['perms'], six.string_types):
                     if not salt.utils.win_dacl.has_permission(
-                        name, user, win_deny_perms[user]["perms"], "deny"
-                    ):
-                        deny_perms = win_deny_perms[user]["perms"]
+                            name, user, win_deny_perms[user]['perms'], 'deny'):
+                        deny_perms = win_deny_perms[user]['perms']
                 else:
-                    for perm in win_deny_perms[user]["perms"]:
+                    for perm in win_deny_perms[user]['perms']:
                         if not salt.utils.win_dacl.has_permission(
-                            name, user, perm, "deny", exact=False
-                        ):
-                            deny_perms.append(win_deny_perms[user]["perms"])
+                                name, user, perm, 'deny', exact=False):
+                            deny_perms.append(win_deny_perms[user]['perms'])
                 if deny_perms:
-                    if "deny_perms" not in changes:
-                        changes["deny_perms"] = {}
-                    if user not in changes["deny_perms"]:
-                        changes["deny_perms"][user] = {}
-                    changes["deny_perms"][user]["perms"] = deny_perms
+                    if 'deny_perms' not in changes:
+                        changes['deny_perms'] = {}
+                    if user not in changes['deny_perms']:
+                        changes['deny_perms'][user] = {}
+                    changes['deny_perms'][user]['perms'] = deny_perms
 
                 # Check Applies to
-                if "applies_to" not in win_deny_perms[user]:
-                    applies_to = "this_folder_subfolders_files"
+                if 'applies_to' not in win_deny_perms[user]:
+                    applies_to = 'this_folder_subfolders_files'
                 else:
-                    applies_to = win_deny_perms[user]["applies_to"]
+                    applies_to = win_deny_perms[user]['applies_to']
 
                 if user in perms:
                     user = salt.utils.win_dacl.get_name(user)
 
                     # Get the proper applies_to text
-                    at_flag = salt.utils.win_dacl.flags().ace_prop["file"][applies_to]
-                    applies_to_text = salt.utils.win_dacl.flags().ace_prop["file"][
-                        at_flag
-                    ]
+                    at_flag = salt.utils.win_dacl.flags().ace_prop['file'][applies_to]
+                    applies_to_text = salt.utils.win_dacl.flags().ace_prop['file'][at_flag]
 
-                    if "deny" in perms[user]:
-                        if not perms[user]["deny"]["applies to"] == applies_to_text:
-                            if "deny_perms" not in changes:
-                                changes["deny_perms"] = {}
-                            if user not in changes["deny_perms"]:
-                                changes["deny_perms"][user] = {}
-                            changes["deny_perms"][user]["applies_to"] = applies_to
+                    if 'deny' in perms[user]:
+                        if not perms[user]['deny']['applies to'] == applies_to_text:
+                            if 'deny_perms' not in changes:
+                                changes['deny_perms'] = {}
+                            if user not in changes['deny_perms']:
+                                changes['deny_perms'][user] = {}
+                            changes['deny_perms'][user]['applies_to'] = applies_to
 
         # Check inheritance
         if win_inheritance is not None:
             if not win_inheritance == salt.utils.win_dacl.get_inheritance(name):
-                changes["inheritance"] = win_inheritance
+                changes['inheritance'] = win_inheritance
 
         # Check reset
         if win_perms_reset:
             for user_name in perms:
                 if user_name not in win_perms:
-                    if (
-                        "grant" in perms[user_name]
-                        and not perms[user_name]["grant"]["inherited"]
-                    ):
-                        if "remove_perms" not in changes:
-                            changes["remove_perms"] = {}
-                        changes["remove_perms"].update({user_name: perms[user_name]})
+                    if 'grant' in perms[user_name] and not perms[user_name]['grant']['inherited']:
+                        if 'remove_perms' not in changes:
+                            changes['remove_perms'] = {}
+                        changes['remove_perms'].update({user_name: perms[user_name]})
                 if user_name not in win_deny_perms:
-                    if (
-                        "deny" in perms[user_name]
-                        and not perms[user_name]["deny"]["inherited"]
-                    ):
-                        if "remove_perms" not in changes:
-                            changes["remove_perms"] = {}
-                        changes["remove_perms"].update({user_name: perms[user_name]})
+                    if 'deny' in perms[user_name] and not perms[user_name]['deny']['inherited']:
+                        if 'remove_perms' not in changes:
+                            changes['remove_perms'] = {}
+                        changes['remove_perms'].update({user_name: perms[user_name]})
 
     if changes:
         return None, 'The directory "{0}" will be changed'.format(name), changes
 
-    return True, "The directory {0} is in the correct state".format(name), changes
+    return True, 'The directory {0} is in the correct state'.format(name), changes
 
 
-def _check_dir_meta(name, user, group, mode, follow_symlinks=False):
-    """
+def _check_dir_meta(name,
+                    user,
+                    group,
+                    mode,
+                    follow_symlinks=False):
+    '''
     Check the changes in directory metadata
-    """
+    '''
     try:
-        stats = __salt__["file.stats"](name, None, follow_symlinks)
+        stats = __salt__['file.stats'](name, None, follow_symlinks)
     except CommandExecutionError:
         stats = {}
 
     changes = {}
     if not stats:
-        changes["directory"] = "new"
+        changes['directory'] = 'new'
         return changes
-    if user is not None and user != stats["user"] and user != stats.get("uid"):
-        changes["user"] = user
-    if group is not None and group != stats["group"] and group != stats.get("gid"):
-        changes["group"] = group
+    if (user is not None
+            and user != stats['user']
+            and user != stats.get('uid')):
+        changes['user'] = user
+    if (group is not None
+            and group != stats['group']
+            and group != stats.get('gid')):
+        changes['group'] = group
     # Normalize the dir mode
-    smode = salt.utils.files.normalize_mode(stats["mode"])
+    smode = salt.utils.files.normalize_mode(stats['mode'])
     mode = salt.utils.files.normalize_mode(mode)
     if mode is not None and mode != smode:
-        changes["mode"] = mode
+        changes['mode'] = mode
     return changes
 
 
 def _check_touch(name, atime, mtime):
-    """
+    '''
     Check to see if a file needs to be updated or created
-    """
-    ret = {"result": None, "comment": "", "changes": {"new": name}}
+    '''
+    ret = {
+        'result': None,
+        'comment': '',
+        'changes': {'new': name},
+    }
     if not os.path.exists(name):
-        ret["comment"] = "File {0} is set to be created".format(name)
+        ret['comment'] = 'File {0} is set to be created'.format(name)
     else:
-        stats = __salt__["file.stats"](name, follow_symlinks=False)
-        if (
-            atime is not None and six.text_type(atime) != six.text_type(stats["atime"])
-        ) or (
-            mtime is not None and six.text_type(mtime) != six.text_type(stats["mtime"])
-        ):
-            ret["comment"] = "Times set to be updated on file {0}".format(name)
-            ret["changes"] = {"touched": name}
+        stats = __salt__['file.stats'](name, follow_symlinks=False)
+        if ((atime is not None
+             and six.text_type(atime) != six.text_type(stats['atime'])) or
+            (mtime is not None
+                and six.text_type(mtime) != six.text_type(stats['mtime']))):
+            ret['comment'] = 'Times set to be updated on file {0}'.format(name)
+            ret['changes'] = {'touched': name}
         else:
-            ret["result"] = True
-            ret["comment"] = "File {0} exists and has the correct times".format(name)
+            ret['result'] = True
+            ret['comment'] = 'File {0} exists and has the correct times'.format(name)
     return ret
 
 
@@ -1020,15 +1012,15 @@ def _get_symlink_ownership(path):
         return owner, owner
     else:
         return (
-            __salt__["file.get_user"](path, follow_symlinks=False),
-            __salt__["file.get_group"](path, follow_symlinks=False),
+            __salt__['file.get_user'](path, follow_symlinks=False),
+            __salt__['file.get_group'](path, follow_symlinks=False)
         )
 
 
 def _check_symlink_ownership(path, user, group, win_owner):
-    """
+    '''
     Check if the symlink ownership matches the specified user and group
-    """
+    '''
     cur_user, cur_group = _get_symlink_ownership(path)
     if salt.utils.platform.is_windows():
         return win_owner == cur_user
@@ -1037,10 +1029,10 @@ def _check_symlink_ownership(path, user, group, win_owner):
 
 
 def _set_symlink_ownership(path, user, group, win_owner):
-    """
+    '''
     Set the ownership of a symlink and return a boolean indicating
     success/failure
-    """
+    '''
     if salt.utils.platform.is_windows():
         try:
             salt.utils.win_dacl.set_owner(path, win_owner)
@@ -1048,87 +1040,72 @@ def _set_symlink_ownership(path, user, group, win_owner):
             pass
     else:
         try:
-            __salt__["file.lchown"](path, user, group)
+            __salt__['file.lchown'](path, user, group)
         except OSError:
             pass
     return _check_symlink_ownership(path, user, group, win_owner)
 
 
 def _symlink_check(name, target, force, user, group, win_owner):
-    """
+    '''
     Check the symlink function
-    """
+    '''
     changes = {}
-    if not os.path.exists(name) and not __salt__["file.is_link"](name):
-        changes["new"] = name
-        return (
-            None,
-            "Symlink {0} to {1} is set for creation".format(name, target),
-            changes,
-        )
-    if __salt__["file.is_link"](name):
-        if __salt__["file.readlink"](name) != target:
-            changes["change"] = name
-            return (
-                None,
-                "Link {0} target is set to be changed to {1}".format(name, target),
-                changes,
-            )
+    if not os.path.exists(name) and not __salt__['file.is_link'](name):
+        changes['new'] = name
+        return None, 'Symlink {0} to {1} is set for creation'.format(
+            name, target
+        ), changes
+    if __salt__['file.is_link'](name):
+        if __salt__['file.readlink'](name) != target:
+            changes['change'] = name
+            return None, 'Link {0} target is set to be changed to {1}'.format(
+                name, target
+            ), changes
         else:
             result = True
-            msg = "The symlink {0} is present".format(name)
+            msg = 'The symlink {0} is present'.format(name)
             if not _check_symlink_ownership(name, user, group, win_owner):
                 result = None
-                changes["ownership"] = "{0}:{1}".format(*_get_symlink_ownership(name))
+                changes['ownership'] = '{0}:{1}'.format(*_get_symlink_ownership(name))
                 msg += (
-                    ", but the ownership of the symlink would be changed "
-                    "from {2}:{3} to {0}:{1}"
+                    ', but the ownership of the symlink would be changed '
+                    'from {2}:{3} to {0}:{1}'
                 ).format(user, group, *_get_symlink_ownership(name))
             return result, msg, changes
     else:
         if force:
-            return (
-                None,
-                (
-                    "The file or directory {0} is set for removal to "
-                    "make way for a new symlink targeting {1}".format(name, target)
-                ),
-                changes,
-            )
-        return (
-            False,
-            (
-                "File or directory exists where the symlink {0} "
-                "should be. Did you mean to use force?".format(name)
-            ),
-            changes,
-        )
+            return None, ('The file or directory {0} is set for removal to '
+                          'make way for a new symlink targeting {1}'
+                          .format(name, target)), changes
+        return False, ('File or directory exists where the symlink {0} '
+                       'should be. Did you mean to use force?'.format(name)), changes
 
 
 def _test_owner(kwargs, user=None):
-    """
+    '''
     Convert owner to user, since other config management tools use owner,
     no need to punish people coming from other systems.
     PLEASE DO NOT DOCUMENT THIS! WE USE USER, NOT OWNER!!!!
-    """
+    '''
     if user:
         return user
-    if "owner" in kwargs:
+    if 'owner' in kwargs:
         log.warning(
-            'Use of argument owner found, "owner" is invalid, please ' 'use "user"'
+            'Use of argument owner found, "owner" is invalid, please '
+            'use "user"'
         )
-        return kwargs["owner"]
+        return kwargs['owner']
 
     return user
 
 
-def _unify_sources_and_hashes(
-    source=None, source_hash=None, sources=None, source_hashes=None
-):
-    """
+def _unify_sources_and_hashes(source=None, source_hash=None,
+                              sources=None, source_hashes=None):
+    '''
     Silly little function to give us a standard tuple list for sources and
     source_hashes
-    """
+    '''
     if sources is None:
         sources = []
 
@@ -1136,36 +1113,39 @@ def _unify_sources_and_hashes(
         source_hashes = []
 
     if source and sources:
-        return (False, "source and sources are mutually exclusive", [])
+        return (False,
+                "source and sources are mutually exclusive", [])
 
     if source_hash and source_hashes:
-        return (False, "source_hash and source_hashes are mutually exclusive", [])
+        return (False,
+                "source_hash and source_hashes are mutually exclusive", [])
 
     if source:
-        return (True, "", [(source, source_hash)])
+        return (True, '', [(source, source_hash)])
 
     # Make a nice neat list of tuples exactly len(sources) long..
-    return True, "", list(zip_longest(sources, source_hashes[: len(sources)]))
+    return True, '', list(zip_longest(sources, source_hashes[:len(sources)]))
 
 
-def _get_template_texts(
-    source_list=None, template="jinja", defaults=None, context=None, **kwargs
-):
-    """
+def _get_template_texts(source_list=None,
+                        template='jinja',
+                        defaults=None,
+                        context=None,
+                        **kwargs):
+    '''
     Iterate a list of sources and process them as templates.
     Returns a list of 'chunks' containing the rendered templates.
-    """
+    '''
 
-    ret = {
-        "name": "_get_template_texts",
-        "changes": {},
-        "result": True,
-        "comment": "",
-        "data": [],
-    }
+    ret = {'name': '_get_template_texts',
+           'changes': {},
+           'result': True,
+           'comment': '',
+           'data': []}
 
     if source_list is None:
-        return _error(ret, "_get_template_texts called with empty source_list")
+        return _error(ret,
+                      '_get_template_texts called with empty source_list')
 
     txtl = []
 
@@ -1174,45 +1154,44 @@ def _get_template_texts(
         context_dict = defaults if defaults else {}
         if context:
             context_dict = salt.utils.dictupdate.merge(context_dict, context)
-        rndrd_templ_fn = __salt__["cp.get_template"](
+        rndrd_templ_fn = __salt__['cp.get_template'](
             source,
-            "",
+            '',
             template=template,
             saltenv=__env__,
             context=context_dict,
             **kwargs
         )
-        log.debug(
-            "cp.get_template returned %s (Called with: %s)", rndrd_templ_fn, source
-        )
+        log.debug('cp.get_template returned %s (Called with: %s)',
+                  rndrd_templ_fn, source)
         if rndrd_templ_fn:
             tmplines = None
-            with salt.utils.files.fopen(rndrd_templ_fn, "rb") as fp_:
+            with salt.utils.files.fopen(rndrd_templ_fn, 'rb') as fp_:
                 tmplines = fp_.read()
                 tmplines = salt.utils.stringutils.to_unicode(tmplines)
                 tmplines = tmplines.splitlines(True)
             if not tmplines:
-                msg = "Failed to read rendered template file {0} ({1})".format(
+                msg = 'Failed to read rendered template file {0} ({1})'.format(
                     rndrd_templ_fn, source
                 )
                 log.debug(msg)
-                ret["name"] = source
+                ret['name'] = source
                 return _error(ret, msg)
-            txtl.append("".join(tmplines))
+            txtl.append(''.join(tmplines))
         else:
-            msg = "Failed to load template file {0}".format(source)
+            msg = 'Failed to load template file {0}'.format(source)
             log.debug(msg)
-            ret["name"] = source
+            ret['name'] = source
             return _error(ret, msg)
 
-    ret["data"] = txtl
+    ret['data'] = txtl
     return ret
 
 
 def _validate_str_list(arg, encoding=None):
-    """
+    '''
     ensure ``arg`` is a list of strings
-    """
+    '''
     if isinstance(arg, six.binary_type):
         ret = [salt.utils.stringutils.to_unicode(arg, encoding=encoding)]
     elif isinstance(arg, six.string_types):
@@ -1230,43 +1209,46 @@ def _validate_str_list(arg, encoding=None):
 
 
 def _get_shortcut_ownership(path):
-    return __salt__["file.get_user"](path, follow_symlinks=False)
+    return __salt__['file.get_user'](path, follow_symlinks=False)
 
 
 def _check_shortcut_ownership(path, user):
-    """
+    '''
     Check if the shortcut ownership matches the specified user
-    """
+    '''
     cur_user = _get_shortcut_ownership(path)
     return cur_user == user
 
 
 def _set_shortcut_ownership(path, user):
-    """
+    '''
     Set the ownership of a shortcut and return a boolean indicating
     success/failure
-    """
+    '''
     try:
-        __salt__["file.lchown"](path, user)
+        __salt__['file.lchown'](path, user)
     except OSError:
         pass
     return _check_shortcut_ownership(path, user)
 
 
-def _shortcut_check(
-    name, target, arguments, working_dir, description, icon_location, force, user
-):
-    """
+def _shortcut_check(name,
+                    target,
+                    arguments,
+                    working_dir,
+                    description,
+                    icon_location,
+                    force,
+                    user):
+    '''
     Check the shortcut function
-    """
+    '''
     changes = {}
     if not os.path.exists(name):
-        changes["new"] = name
-        return (
-            None,
-            'Shortcut "{0}" to "{1}" is set for creation'.format(name, target),
-            changes,
-        )
+        changes['new'] = name
+        return None, 'Shortcut "{0}" to "{1}" is set for creation'.format(
+            name, target
+        ), changes
 
     if os.path.isfile(name):
         with salt.utils.winapi.Com():
@@ -1276,63 +1258,50 @@ def _shortcut_check(
         if arguments is not None:
             state_checks.append(scut.Arguments == arguments)
         if working_dir is not None:
-            state_checks.append(scut.WorkingDirectory.lower() == working_dir.lower())
+            state_checks.append(
+                scut.WorkingDirectory.lower() == working_dir.lower()
+            )
         if description is not None:
             state_checks.append(scut.Description == description)
         if icon_location is not None:
-            state_checks.append(scut.IconLocation.lower() == icon_location.lower())
+            state_checks.append(
+                scut.IconLocation.lower() == icon_location.lower()
+            )
 
         if not all(state_checks):
-            changes["change"] = name
-            return (
-                None,
-                'Shortcut "{0}" target is set to be changed to "{1}"'.format(
-                    name, target
-                ),
-                changes,
-            )
+            changes['change'] = name
+            return None, 'Shortcut "{0}" target is set to be changed to "{1}"'.format(
+                name, target
+            ), changes
         else:
             result = True
             msg = 'The shortcut "{0}" is present'.format(name)
             if not _check_shortcut_ownership(name, user):
                 result = None
-                changes["ownership"] = "{0}".format(_get_shortcut_ownership(name))
+                changes['ownership'] = '{0}'.format(_get_shortcut_ownership(name))
                 msg += (
-                    ", but the ownership of the shortcut would be changed "
-                    "from {1} to {0}"
+                    ', but the ownership of the shortcut would be changed '
+                    'from {1} to {0}'
                 ).format(user, _get_shortcut_ownership(name))
             return result, msg, changes
     else:
         if force:
-            return (
-                None,
-                (
-                    'The link or directory "{0}" is set for removal to '
-                    'make way for a new shortcut targeting "{1}"'.format(name, target)
-                ),
-                changes,
-            )
-        return (
-            False,
-            (
-                'Link or directory exists where the shortcut "{0}" '
-                "should be. Did you mean to use force?".format(name)
-            ),
-            changes,
-        )
+            return None, ('The link or directory "{0}" is set for removal to '
+                          'make way for a new shortcut targeting "{1}"'
+                          .format(name, target)), changes
+        return False, ('Link or directory exists where the shortcut "{0}" '
+                       'should be. Did you mean to use force?'.format(name)), changes
 
 
-def _makedirs(
-    name,
-    user=None,
-    group=None,
-    dir_mode=None,
-    win_owner=None,
-    win_perms=None,
-    win_deny_perms=None,
-    win_inheritance=None,
-):
-    """
+def _makedirs(name,
+              user=None,
+              group=None,
+              dir_mode=None,
+              win_owner=None,
+              win_perms=None,
+              win_deny_perms=None,
+              win_inheritance=None):
+    '''
     Helper function for creating directories when the ``makedirs`` option is set
     to ``True``. Handles Unix and Windows based systems
 
@@ -1355,7 +1324,7 @@ def _makedirs(
 
     Raises:
         CommandExecutionError: If the drive is not mounted on Windows
-    """
+    '''
     if salt.utils.platform.is_windows():
         # Make sure the drive is mapped before trying to create the
         # path in windows
@@ -1363,37 +1332,35 @@ def _makedirs(
         if not os.path.isdir(drive):
             raise CommandExecutionError(drive)
         win_owner = win_owner if win_owner else user
-        return __salt__["file.makedirs"](
-            path=name,
-            owner=win_owner,
-            grant_perms=win_perms,
-            deny_perms=win_deny_perms,
-            inheritance=win_inheritance,
-        )
+        return __salt__['file.makedirs'](path=name,
+                                         owner=win_owner,
+                                         grant_perms=win_perms,
+                                         deny_perms=win_deny_perms,
+                                         inheritance=win_inheritance)
     else:
-        return __salt__["file.makedirs"](
-            path=name, user=user, group=group, mode=dir_mode
-        )
+        return __salt__['file.makedirs'](path=name,
+                                         user=user,
+                                         group=group,
+                                         mode=dir_mode)
 
 
 def symlink(
-    name,
-    target,
-    force=False,
-    backupname=None,
-    makedirs=False,
-    user=None,
-    group=None,
-    copy_target_user=False,
-    copy_target_group=False,
-    mode=None,
-    win_owner=None,
-    win_perms=None,
-    win_deny_perms=None,
-    win_inheritance=None,
-    **kwargs
-):
-    """
+        name,
+        target,
+        force=False,
+        backupname=None,
+        makedirs=False,
+        user=None,
+        group=None,
+        copy_target_user=False,
+        copy_target_group=False,
+        mode=None,
+        win_owner=None,
+        win_perms=None,
+        win_deny_perms=None,
+        win_inheritance=None,
+        **kwargs):
+    '''
     Create a symbolic link (symlink, soft link)
 
     If the file already exists and is a symlink pointing to any location other
@@ -1479,47 +1446,44 @@ def symlink(
         True to inherit permissions from parent, otherwise False
 
         .. versionadded:: 2017.7.7
-    """
+    '''
     name = os.path.expanduser(name)
 
     # Make sure that leading zeros stripped by YAML loader are added back
     mode = salt.utils.files.normalize_mode(mode)
 
     user = _test_owner(kwargs, user=user)
-    ret = {"name": name, "changes": {}, "result": True, "comment": ""}
+    ret = {'name': name,
+           'changes': {},
+           'result': True,
+           'comment': ''}
     if not name:
-        return _error(ret, "Must provide name to file.symlink")
+        return _error(ret, 'Must provide name to file.symlink')
 
     if copy_target_user:
         if user:
-            log.warning(
-                "`copy_target_user` and `user` are mutually exclusive. Using `user`."
-            )
+            log.warning('`copy_target_user` and `user` are mutually exclusive. Using `user`.')
         else:
             try:
-                user = __salt__["file.get_user"](target)
+                user = __salt__['file.get_user'](target)
             except CommandExecutionError:
-                ret["result"] = False
-                ret[
-                    "comment"
-                ] = "`copy_target_user` is set, but target `{0}` does not exist.".format(
-                    target
-                )
+                ret['result'] = False
+                ret['comment'] = '`copy_target_user` is set, but target `{0}` does not exist.'.format(target)
                 return ret
 
     if user is None:
-        user = __opts__["user"]
+        user = __opts__['user']
 
     if salt.utils.platform.is_windows():
 
         # Make sure the user exists in Windows
         # Salt default is 'root'
-        if not __salt__["user.info"](user):
+        if not __salt__['user.info'](user):
             # User not found, use the account salt is running under
             # If username not found, use System
-            user = __salt__["user.current"]()
+            user = __salt__['user.current']()
             if not user:
-                user = "SYSTEM"
+                user = 'SYSTEM'
 
         # If win_owner is not passed, use user
         if win_owner is None:
@@ -1528,40 +1492,35 @@ def symlink(
         # Group isn't relevant to Windows, use win_perms/win_deny_perms
         if group is not None:
             log.warning(
-                "The group argument for %s has been ignored as this "
-                "is a Windows system. Please use the `win_*` parameters to set "
-                "permissions in Windows.",
-                name,
+                'The group argument for %s has been ignored as this '
+                'is a Windows system. Please use the `win_*` parameters to set '
+                'permissions in Windows.', name
             )
 
         if copy_target_group is not None:
             log.warning(
-                "The copy_target_group argument for {0} has been ignored as this "
-                "is a Windows system. Please use the `win_*` parameters to set "
-                "permissions in Windows.".format(name)
+                'The copy_target_group argument for {0} has been ignored as this '
+                'is a Windows system. Please use the `win_*` parameters to set '
+                'permissions in Windows.'.format(name)
             )
 
         group = user
 
     if copy_target_group:
         if group:
-            log.warning(
-                "`copy_target_group` and `group` are mutually exclusive. Using `group`."
-            )
+            log.warning('`copy_target_group` and `group` are mutually exclusive. Using `group`.')
         else:
             try:
-                group = __salt__["file.get_group"](target)
+                group = __salt__['file.get_group'](target)
             except CommandExecutionError:
-                ret["result"] = False
-                ret[
-                    "comment"
-                ] = "`copy_target_group` is set, but target `{0}` does not exist.".format(
-                    target
-                )
+                ret['result'] = False
+                ret['comment'] = '`copy_target_group` is set, but target `{0}` does not exist.'.format(target)
                 return ret
 
     if group is None:
-        group = __salt__["file.gid_to_group"](__salt__["user.info"](user).get("gid", 0))
+        group = __salt__['file.gid_to_group'](
+            __salt__['user.info'](user).get('gid', 0)
+        )
 
     preflight_errors = []
     if salt.utils.platform.is_windows():
@@ -1569,7 +1528,7 @@ def symlink(
         try:
             salt.utils.win_functions.get_sid_from_name(win_owner)
         except CommandExecutionError as exc:
-            preflight_errors.append("User {0} does not exist".format(win_owner))
+            preflight_errors.append('User {0} does not exist'.format(win_owner))
 
         # Make sure users passed in win_perms exist
         if win_perms:
@@ -1577,9 +1536,7 @@ def symlink(
                 try:
                     salt.utils.win_functions.get_sid_from_name(name_check)
                 except CommandExecutionError as exc:
-                    preflight_errors.append(
-                        "User {0} does not exist".format(name_check)
-                    )
+                    preflight_errors.append('User {0} does not exist'.format(name_check))
 
         # Make sure users passed in win_deny_perms exist
         if win_deny_perms:
@@ -1587,117 +1544,104 @@ def symlink(
                 try:
                     salt.utils.win_functions.get_sid_from_name(name_check)
                 except CommandExecutionError as exc:
-                    preflight_errors.append(
-                        "User {0} does not exist".format(name_check)
-                    )
+                    preflight_errors.append('User {0} does not exist'.format(name_check))
     else:
-        uid = __salt__["file.user_to_uid"](user)
-        gid = __salt__["file.group_to_gid"](group)
+        uid = __salt__['file.user_to_uid'](user)
+        gid = __salt__['file.group_to_gid'](group)
 
-        if uid == "":
-            preflight_errors.append("User {0} does not exist".format(user))
+        if uid == '':
+            preflight_errors.append('User {0} does not exist'.format(user))
 
-        if gid == "":
-            preflight_errors.append("Group {0} does not exist".format(group))
+        if gid == '':
+            preflight_errors.append('Group {0} does not exist'.format(group))
 
     if not os.path.isabs(name):
         preflight_errors.append(
-            "Specified file {0} is not an absolute path".format(name)
+            'Specified file {0} is not an absolute path'.format(name)
         )
 
     if preflight_errors:
-        msg = ". ".join(preflight_errors)
+        msg = '. '.join(preflight_errors)
         if len(preflight_errors) > 1:
-            msg += "."
+            msg += '.'
         return _error(ret, msg)
 
-    presult, pcomment, pchanges = _symlink_check(
-        name, target, force, user, group, win_owner
-    )
+    presult, pcomment, pchanges = _symlink_check(name,
+                                                 target,
+                                                 force,
+                                                 user,
+                                                 group,
+                                                 win_owner)
 
     if not os.path.isdir(os.path.dirname(name)):
         if makedirs:
-            if __opts__["test"]:
-                pcomment += "\n{0} will be created".format(os.path.dirname(name))
+            if __opts__['test']:
+                pcomment += '\n{0} will be created'.format(os.path.dirname(name))
             else:
                 try:
-                    _makedirs(
-                        name=name,
-                        user=user,
-                        group=group,
-                        dir_mode=mode,
-                        win_owner=win_owner,
-                        win_perms=win_perms,
-                        win_deny_perms=win_deny_perms,
-                        win_inheritance=win_inheritance,
-                    )
+                    _makedirs(name=name,
+                              user=user,
+                              group=group,
+                              dir_mode=mode,
+                              win_owner=win_owner,
+                              win_perms=win_perms,
+                              win_deny_perms=win_deny_perms,
+                              win_inheritance=win_inheritance)
                 except CommandExecutionError as exc:
-                    return _error(ret, "Drive {0} is not mapped".format(exc.message))
+                    return _error(ret, 'Drive {0} is not mapped'.format(exc.message))
         else:
-            if __opts__["test"]:
-                pcomment += "\nDirectory {0} for symlink is not present" "".format(
-                    os.path.dirname(name)
-                )
+            if __opts__['test']:
+                pcomment += '\nDirectory {0} for symlink is not present' \
+                            ''.format(os.path.dirname(name))
             else:
                 return _error(
                     ret,
-                    "Directory {0} for symlink is not present".format(
+                    'Directory {0} for symlink is not present'.format(
                         os.path.dirname(name)
-                    ),
+                    )
                 )
 
-    if __opts__["test"]:
-        ret["result"] = presult
-        ret["comment"] = pcomment
-        ret["changes"] = pchanges
+    if __opts__['test']:
+        ret['result'] = presult
+        ret['comment'] = pcomment
+        ret['changes'] = pchanges
         return ret
 
-    if __salt__["file.is_link"](name):
+    if __salt__['file.is_link'](name):
         # The link exists, verify that it matches the target
-        if os.path.normpath(__salt__["file.readlink"](name)) != os.path.normpath(
-            target
-        ):
+        if os.path.normpath(__salt__['file.readlink'](name)) != os.path.normpath(target):
             # The target is wrong, delete the link
             os.remove(name)
         else:
             if _check_symlink_ownership(name, user, group, win_owner):
                 # The link looks good!
                 if salt.utils.platform.is_windows():
-                    ret["comment"] = (
-                        "Symlink {0} is present and owned by {1}"
-                        "".format(name, win_owner)
-                    )
+                    ret['comment'] = ('Symlink {0} is present and owned by {1}'
+                                      ''.format(name, win_owner))
                 else:
-                    ret["comment"] = (
-                        "Symlink {0} is present and owned by "
-                        "{1}:{2}".format(name, user, group)
-                    )
+                    ret['comment'] = ('Symlink {0} is present and owned by '
+                                      '{1}:{2}'.format(name, user, group))
             else:
                 if _set_symlink_ownership(name, user, group, win_owner):
                     if salt.utils.platform.is_windows():
-                        ret["comment"] = (
-                            "Set ownership of symlink {0} to "
-                            "{1}".format(name, win_owner)
-                        )
-                        ret["changes"]["ownership"] = win_owner
+                        ret['comment'] = ('Set ownership of symlink {0} to '
+                                          '{1}'.format(name, win_owner))
+                        ret['changes']['ownership'] = win_owner
                     else:
-                        ret["comment"] = (
-                            "Set ownership of symlink {0} to "
-                            "{1}:{2}".format(name, user, group)
-                        )
-                        ret["changes"]["ownership"] = "{0}:{1}".format(user, group)
+                        ret['comment'] = ('Set ownership of symlink {0} to '
+                                          '{1}:{2}'.format(name, user, group))
+                        ret['changes']['ownership'] = '{0}:{1}'.format(user,
+                                                                       group)
                 else:
-                    ret["result"] = False
+                    ret['result'] = False
                     if salt.utils.platform.is_windows():
-                        ret["comment"] += (
-                            "Failed to set ownership of symlink "
-                            "{0} to {1}".format(name, win_owner)
-                        )
+                        ret['comment'] += (
+                            'Failed to set ownership of symlink '
+                            '{0} to {1}'.format(name, win_owner))
                     else:
-                        ret["comment"] += (
-                            "Failed to set ownership of symlink {0} to "
-                            "{1}:{2}".format(name, user, group)
-                        )
+                        ret['comment'] += (
+                            'Failed to set ownership of symlink {0} to '
+                            '{1}:{2}'.format(name, user, group))
             return ret
 
     elif os.path.isfile(name) or os.path.isdir(name):
@@ -1706,144 +1650,132 @@ def symlink(
             if not os.path.isabs(backupname):
                 if backupname == os.path.basename(backupname):
                     backupname = os.path.join(
-                        os.path.dirname(os.path.normpath(name)), backupname
-                    )
+                        os.path.dirname(os.path.normpath(name)),
+                        backupname)
                 else:
-                    return _error(
-                        ret,
-                        (
-                            (
-                                "Backupname must be an absolute path "
-                                "or a file name: {0}"
-                            ).format(backupname)
-                        ),
-                    )
+                    return _error(ret, (('Backupname must be an absolute path '
+                                         'or a file name: {0}').format(backupname)))
             # Make a backup first
             if os.path.lexists(backupname):
                 if not force:
-                    return _error(
-                        ret,
-                        (
-                            (
-                                "Symlink & backup dest exists and Force not set."
-                                " {0} -> {1} - backup: {2}"
-                            ).format(name, target, backupname)
-                        ),
-                    )
+                    return _error(ret, (('Symlink & backup dest exists and Force not set.'
+                                         ' {0} -> {1} - backup: {2}').format(
+                                             name, target, backupname)))
                 else:
-                    __salt__["file.remove"](backupname)
+                    __salt__['file.remove'](backupname)
             try:
-                __salt__["file.move"](name, backupname)
+                __salt__['file.move'](name, backupname)
             except Exception as exc:
-                ret["changes"] = {}
+                ret['changes'] = {}
                 log.debug(
-                    "Encountered error renaming %s to %s",
-                    name,
-                    backupname,
-                    exc_info=True,
+                    'Encountered error renaming %s to %s',
+                    name, backupname, exc_info=True
                 )
-                return _error(
-                    ret,
-                    (
-                        "Unable to rename {0} to backup {1} -> "
-                        ": {2}".format(name, backupname, exc)
-                    ),
-                )
+                return _error(ret, ('Unable to rename {0} to backup {1} -> '
+                                    ': {2}'.format(name, backupname, exc)))
         elif force:
             # Remove whatever is in the way
-            if __salt__["file.is_link"](name):
-                __salt__["file.remove"](name)
-                ret["changes"]["forced"] = "Symlink was forcibly replaced"
+            if __salt__['file.is_link'](name):
+                __salt__['file.remove'](name)
+                ret['changes']['forced'] = 'Symlink was forcibly replaced'
             else:
-                __salt__["file.remove"](name)
+                __salt__['file.remove'](name)
         else:
             # Otherwise throw an error
             if os.path.isfile(name):
-                return _error(
-                    ret, ("File exists where the symlink {0} should be".format(name))
-                )
+                return _error(ret,
+                              ('File exists where the symlink {0} should be'
+                               .format(name)))
             else:
-                return _error(
-                    ret,
-                    (("Directory exists where the symlink {0} should be").format(name)),
-                )
+                return _error(ret, ((
+                                        'Directory exists where the symlink {0} should be'
+                                    ).format(name)))
 
     if not os.path.exists(name):
         # The link is not present, make it
         try:
-            __salt__["file.symlink"](target, name)
+            __salt__['file.symlink'](target, name)
         except OSError as exc:
-            ret["result"] = False
-            ret["comment"] = "Unable to create new symlink {0} -> " "{1}: {2}".format(
-                name, target, exc
-            )
+            ret['result'] = False
+            ret['comment'] = ('Unable to create new symlink {0} -> '
+                              '{1}: {2}'.format(name, target, exc))
             return ret
         else:
-            ret["comment"] = "Created new symlink {0} -> " "{1}".format(name, target)
-            ret["changes"]["new"] = name
+            ret['comment'] = ('Created new symlink {0} -> '
+                              '{1}'.format(name, target))
+            ret['changes']['new'] = name
 
         if not _check_symlink_ownership(name, user, group, win_owner):
             if not _set_symlink_ownership(name, user, group, win_owner):
-                ret["result"] = False
-                ret["comment"] += (
-                    ", but was unable to set ownership to "
-                    "{0}:{1}".format(user, group)
-                )
+                ret['result'] = False
+                ret['comment'] += (', but was unable to set ownership to '
+                                   '{0}:{1}'.format(user, group))
     return ret
 
 
-def absent(name, **kwargs):
-    """
+def absent(name,
+           **kwargs):
+    '''
     Make sure that the named file or directory is absent. If it exists, it will
     be deleted. This will work to reverse any of the functions in the file
     state module. If a directory is supplied, it will be recursively deleted.
 
     name
         The path which should be deleted
-    """
+    '''
     name = os.path.expanduser(name)
 
-    ret = {"name": name, "changes": {}, "result": True, "comment": ""}
+    ret = {'name': name,
+           'changes': {},
+           'result': True,
+           'comment': ''}
     if not name:
-        return _error(ret, "Must provide name to file.absent")
+        return _error(ret, 'Must provide name to file.absent')
     if not os.path.isabs(name):
-        return _error(ret, "Specified file {0} is not an absolute path".format(name))
-    if name == "/":
+        return _error(
+            ret, 'Specified file {0} is not an absolute path'.format(name)
+        )
+    if name == '/':
         return _error(ret, 'Refusing to make "/" absent')
     if os.path.isfile(name) or os.path.islink(name):
-        if __opts__["test"]:
-            ret["result"] = None
-            ret["changes"]["removed"] = name
-            ret["comment"] = "File {0} is set for removal".format(name)
+        if __opts__['test']:
+            ret['result'] = None
+            ret['changes']['removed'] = name
+            ret['comment'] = 'File {0} is set for removal'.format(name)
             return ret
         try:
-            __salt__["file.remove"](name, force=True)
-            ret["comment"] = "Removed file {0}".format(name)
-            ret["changes"]["removed"] = name
+            __salt__['file.remove'](name, force=True)
+            ret['comment'] = 'Removed file {0}'.format(name)
+            ret['changes']['removed'] = name
             return ret
         except CommandExecutionError as exc:
-            return _error(ret, "{0}".format(exc))
+            return _error(ret, '{0}'.format(exc))
 
     elif os.path.isdir(name):
-        if __opts__["test"]:
-            ret["result"] = None
-            ret["changes"]["removed"] = name
-            ret["comment"] = "Directory {0} is set for removal".format(name)
+        if __opts__['test']:
+            ret['result'] = None
+            ret['changes']['removed'] = name
+            ret['comment'] = 'Directory {0} is set for removal'.format(name)
             return ret
         try:
-            __salt__["file.remove"](name, force=True)
-            ret["comment"] = "Removed directory {0}".format(name)
-            ret["changes"]["removed"] = name
+            __salt__['file.remove'](name, force=True)
+            ret['comment'] = 'Removed directory {0}'.format(name)
+            ret['changes']['removed'] = name
             return ret
         except (OSError, IOError):
-            return _error(ret, "Failed to remove directory {0}".format(name))
+            return _error(ret, 'Failed to remove directory {0}'.format(name))
 
-    ret["comment"] = "File {0} is not present".format(name)
+    ret['comment'] = 'File {0} is not present'.format(name)
     return ret
 
 
-def tidied(name, age=0, matches=None, rmdirs=False, size=0, **kwargs):
-    """
+def tidied(name,
+           age=0,
+           matches=None,
+           rmdirs=False,
+           size=0,
+           **kwargs):
+    '''
     Remove unwanted files based on specific criteria. Multiple criteria
     are OR’d together, so a file that is too large but is not old enough
     will still get tidied.
@@ -1876,16 +1808,19 @@ def tidied(name, age=0, matches=None, rmdirs=False, size=0, **kwargs):
             - matches:
               - foo
               - b.*r
-    """
+    '''
     name = os.path.expanduser(name)
 
-    ret = {"name": name, "changes": {}, "result": True, "comment": ""}
+    ret = {'name': name,
+           'changes': {},
+           'result': True,
+           'comment': ''}
 
     # Check preconditions
     if not os.path.isabs(name):
-        return _error(ret, "Specified file {0} is not an absolute path".format(name))
+        return _error(ret, 'Specified file {0} is not an absolute path'.format(name))
     if not os.path.isdir(name):
-        return _error(ret, "{0} does not exist or is not a directory.".format(name))
+        return _error(ret, '{0} does not exist or is not a directory.'.format(name))
 
     # Define some variables
     todelete = []
@@ -1893,7 +1828,7 @@ def tidied(name, age=0, matches=None, rmdirs=False, size=0, **kwargs):
 
     # Compile regular expressions
     if matches is None:
-        matches = [".*"]
+        matches = ['.*']
     progs = []
     for regex in matches:
         progs.append(re.compile(regex))
@@ -1926,41 +1861,36 @@ def tidied(name, age=0, matches=None, rmdirs=False, size=0, **kwargs):
                 myage = abs(today - date.fromtimestamp(os.path.getatime(path)))
                 mysize = os.path.getsize(path)
             # Verify against given criteria, collect all elements that should be removed
-            if (
-                (mysize >= size or myage.days >= age)
-                and _matches(name=elem)
-                and deleteme
-            ):
+            if (mysize >= size or myage.days >= age) and _matches(name=elem) and deleteme:
                 todelete.append(path)
 
     # Now delete the stuff
     if todelete:
-        if __opts__["test"]:
-            ret["result"] = None
-            ret["comment"] = "{0} is set for tidy".format(name)
-            ret["changes"] = {"removed": todelete}
+        if __opts__['test']:
+            ret['result'] = None
+            ret['comment'] = '{0} is set for tidy'.format(name)
+            ret['changes'] = {'removed': todelete}
             return ret
-        ret["changes"]["removed"] = []
+        ret['changes']['removed'] = []
         # Iterate over collected items
         try:
             for path in todelete:
-                __salt__["file.remove"](path, force=True)
+                __salt__['file.remove'](path, force=True)
                 # Remember what we've removed, will appear in the summary
-                ret["changes"]["removed"].append(path)
+                ret['changes']['removed'].append(path)
         except CommandExecutionError as exc:
-            return _error(ret, "{0}".format(exc))
+            return _error(ret, '{0}'.format(exc))
         # Set comment for the summary
-        ret["comment"] = "Removed {0} files or directories from directory {1}".format(
-            len(todelete), name
-        )
+        ret['comment'] = 'Removed {0} files or directories from directory {1}'.format(len(todelete), name)
     else:
         # Set comment in case there was nothing to remove
-        ret["comment"] = "Nothing to remove from directory {0}".format(name)
+        ret['comment'] = 'Nothing to remove from directory {0}'.format(name)
     return ret
 
 
-def exists(name, **kwargs):
-    """
+def exists(name,
+           **kwargs):
+    '''
     Verify that the named file or directory is present or exists.
     Ensures pre-requisites outside of Salt's purview
     (e.g., keytabs, private keys, etc.) have been previously satisfied before
@@ -1971,80 +1901,85 @@ def exists(name, **kwargs):
 
     name
         Absolute path which must exist
-    """
+    '''
     name = os.path.expanduser(name)
 
-    ret = {"name": name, "changes": {}, "result": True, "comment": ""}
+    ret = {'name': name,
+           'changes': {},
+           'result': True,
+           'comment': ''}
     if not name:
-        return _error(ret, "Must provide name to file.exists")
+        return _error(ret, 'Must provide name to file.exists')
     if not os.path.exists(name):
-        return _error(ret, "Specified path {0} does not exist".format(name))
+        return _error(ret, 'Specified path {0} does not exist'.format(name))
 
-    ret["comment"] = "Path {0} exists".format(name)
+    ret['comment'] = 'Path {0} exists'.format(name)
     return ret
 
 
-def missing(name, **kwargs):
-    """
+def missing(name,
+            **kwargs):
+    '''
     Verify that the named file or directory is missing, this returns True only
     if the named file is missing but does not remove the file if it is present.
 
     name
         Absolute path which must NOT exist
-    """
+    '''
     name = os.path.expanduser(name)
 
-    ret = {"name": name, "changes": {}, "result": True, "comment": ""}
+    ret = {'name': name,
+           'changes': {},
+           'result': True,
+           'comment': ''}
     if not name:
-        return _error(ret, "Must provide name to file.missing")
+        return _error(ret, 'Must provide name to file.missing')
     if os.path.exists(name):
-        return _error(ret, "Specified path {0} exists".format(name))
+        return _error(ret, 'Specified path {0} exists'.format(name))
 
-    ret["comment"] = "Path {0} is missing".format(name)
+    ret['comment'] = 'Path {0} is missing'.format(name)
     return ret
 
 
-def managed(
-    name,
-    source=None,
-    source_hash="",
-    source_hash_name=None,
-    keep_source=True,
-    user=None,
-    group=None,
-    mode=None,
-    attrs=None,
-    template=None,
-    makedirs=False,
-    dir_mode=None,
-    context=None,
-    replace=True,
-    defaults=None,
-    backup="",
-    show_changes=True,
-    create=True,
-    contents=None,
-    tmp_dir="",
-    tmp_ext="",
-    contents_pillar=None,
-    contents_grains=None,
-    contents_newline=True,
-    contents_delimiter=":",
-    encoding=None,
-    encoding_errors="strict",
-    allow_empty=True,
-    follow_symlinks=True,
-    check_cmd=None,
-    skip_verify=False,
-    selinux=None,
-    win_owner=None,
-    win_perms=None,
-    win_deny_perms=None,
-    win_inheritance=True,
-    win_perms_reset=False,
-    **kwargs
-):
-    r"""
+def managed(name,
+            source=None,
+            source_hash='',
+            source_hash_name=None,
+            keep_source=True,
+            user=None,
+            group=None,
+            mode=None,
+            attrs=None,
+            template=None,
+            makedirs=False,
+            dir_mode=None,
+            context=None,
+            replace=True,
+            defaults=None,
+            backup='',
+            show_changes=True,
+            create=True,
+            contents=None,
+            tmp_dir='',
+            tmp_ext='',
+            contents_pillar=None,
+            contents_grains=None,
+            contents_newline=True,
+            contents_delimiter=':',
+            encoding=None,
+            encoding_errors='strict',
+            allow_empty=True,
+            follow_symlinks=True,
+            check_cmd=None,
+            skip_verify=False,
+            selinux=None,
+            win_owner=None,
+            win_perms=None,
+            win_deny_perms=None,
+            win_inheritance=True,
+            win_perms_reset=False,
+            **kwargs):
+    r'''
     Manage a given file, this function allows for a file to be downloaded from
     the salt master and potentially run through a templating system.
 
@@ -2614,37 +2549,40 @@ def managed(
                 fred_snuffy:
                   perms: full_control
             - win_inheritance: False
-    """
-    if "env" in kwargs:
+    '''
+    if 'env' in kwargs:
         # "env" is not supported; Use "saltenv".
-        kwargs.pop("env")
+        kwargs.pop('env')
 
     name = os.path.expanduser(name)
 
-    ret = {"changes": {}, "comment": "", "name": name, "result": True}
+    ret = {'changes': {},
+           'comment': '',
+           'name': name,
+           'result': True}
 
     if not name:
-        return _error(ret, "Destination file name is required")
+        return _error(ret, 'Destination file name is required')
 
     if mode is not None and salt.utils.platform.is_windows():
-        return _error(ret, "The 'mode' option is not supported on Windows")
+        return _error(ret, 'The \'mode\' option is not supported on Windows')
 
     if attrs is not None and salt.utils.platform.is_windows():
-        return _error(ret, "The 'attrs' option is not supported on Windows")
+        return _error(ret, 'The \'attrs\' option is not supported on Windows')
 
     if selinux is not None and not salt.utils.platform.is_linux():
-        return _error(ret, "The 'selinux' option is only supported on Linux")
+        return _error(ret, 'The \'selinux\' option is only supported on Linux')
 
     if selinux:
-        seuser = selinux.get("seuser", None)
-        serole = selinux.get("serole", None)
-        setype = selinux.get("setype", None)
-        serange = selinux.get("serange", None)
+        seuser = selinux.get('seuser', None)
+        serole = selinux.get('serole', None)
+        setype = selinux.get('setype', None)
+        serange = selinux.get('serange', None)
     else:
         seuser = serole = setype = serange = None
 
     try:
-        keep_mode = mode.lower() == "keep"
+        keep_mode = mode.lower() == 'keep'
         if keep_mode:
             # We're not hard-coding the mode, so set it to None
             mode = None
@@ -2655,26 +2593,27 @@ def managed(
     mode = salt.utils.files.normalize_mode(mode)
 
     contents_count = len(
-        [x for x in (contents, contents_pillar, contents_grains) if x is not None]
+        [x for x in (contents, contents_pillar, contents_grains)
+         if x is not None]
     )
 
     if source and contents_count > 0:
         return _error(
             ret,
-            "'source' cannot be used in combination with 'contents', "
-            "'contents_pillar', or 'contents_grains'",
+            '\'source\' cannot be used in combination with \'contents\', '
+            '\'contents_pillar\', or \'contents_grains\''
         )
     elif keep_mode and contents_count > 0:
         return _error(
             ret,
-            "Mode preservation cannot be used in combination with 'contents', "
-            "'contents_pillar', or 'contents_grains'",
+            'Mode preservation cannot be used in combination with \'contents\', '
+            '\'contents_pillar\', or \'contents_grains\''
         )
     elif contents_count > 1:
         return _error(
             ret,
-            "Only one of 'contents', 'contents_pillar', and "
-            "'contents_grains' is permitted",
+            'Only one of \'contents\', \'contents_pillar\', and '
+            '\'contents_grains\' is permitted'
         )
 
     # If no source is specified, set replace to False, as there is nothing
@@ -2682,18 +2621,17 @@ def managed(
     if not source and contents_count == 0 and replace:
         replace = False
         log.warning(
-            "State for file: %s - Neither 'source' nor 'contents' nor "
-            "'contents_pillar' nor 'contents_grains' was defined, yet "
-            "'replace' was set to 'True'. As there is no source to "
-            "replace the file with, 'replace' has been set to 'False' to "
-            "avoid reading the file unnecessarily.",
-            name,
+            'State for file: %s - Neither \'source\' nor \'contents\' nor '
+            '\'contents_pillar\' nor \'contents_grains\' was defined, yet '
+            '\'replace\' was set to \'True\'. As there is no source to '
+            'replace the file with, \'replace\' has been set to \'False\' to '
+            'avoid reading the file unnecessarily.', name
         )
 
-    if "file_mode" in kwargs:
-        ret.setdefault("warnings", []).append(
-            "The 'file_mode' argument will be ignored.  "
-            "Please use 'mode' instead to set file permissions."
+    if 'file_mode' in kwargs:
+        ret.setdefault('warnings', []).append(
+            'The \'file_mode\' argument will be ignored.  '
+            'Please use \'mode\' instead to set file permissions.'
         )
 
     # Use this below to avoid multiple '\0' checks and save some CPU cycles
@@ -2701,37 +2639,45 @@ def managed(
         if isinstance(contents_pillar, list):
             list_contents = []
             for nextp in contents_pillar:
-                nextc = __salt__["pillar.get"](
-                    nextp, __NOT_FOUND, delimiter=contents_delimiter
-                )
+                nextc = __salt__['pillar.get'](nextp, __NOT_FOUND,
+                                               delimiter=contents_delimiter)
                 if nextc is __NOT_FOUND:
-                    return _error(ret, "Pillar {0} does not exist".format(nextp))
+                    return _error(
+                        ret,
+                        'Pillar {0} does not exist'.format(nextp)
+                    )
                 list_contents.append(nextc)
             use_contents = os.linesep.join(list_contents)
         else:
-            use_contents = __salt__["pillar.get"](
-                contents_pillar, __NOT_FOUND, delimiter=contents_delimiter
-            )
+            use_contents = __salt__['pillar.get'](contents_pillar, __NOT_FOUND,
+                                                  delimiter=contents_delimiter)
             if use_contents is __NOT_FOUND:
-                return _error(ret, "Pillar {0} does not exist".format(contents_pillar))
+                return _error(
+                    ret,
+                    'Pillar {0} does not exist'.format(contents_pillar)
+                )
 
     elif contents_grains is not None:
         if isinstance(contents_grains, list):
             list_contents = []
             for nextg in contents_grains:
-                nextc = __salt__["grains.get"](
-                    nextg, __NOT_FOUND, delimiter=contents_delimiter
-                )
+                nextc = __salt__['grains.get'](nextg, __NOT_FOUND,
+                                               delimiter=contents_delimiter)
                 if nextc is __NOT_FOUND:
-                    return _error(ret, "Grain {0} does not exist".format(nextc))
+                    return _error(
+                        ret,
+                        'Grain {0} does not exist'.format(nextc)
+                    )
                 list_contents.append(nextc)
             use_contents = os.linesep.join(list_contents)
         else:
-            use_contents = __salt__["grains.get"](
-                contents_grains, __NOT_FOUND, delimiter=contents_delimiter
-            )
+            use_contents = __salt__['grains.get'](contents_grains, __NOT_FOUND,
+                                                  delimiter=contents_delimiter)
             if use_contents is __NOT_FOUND:
-                return _error(ret, "Grain {0} does not exist".format(contents_grains))
+                return _error(
+                    ret,
+                    'Grain {0} does not exist'.format(contents_grains)
+                )
 
     elif contents is not None:
         use_contents = contents
@@ -2742,15 +2688,16 @@ def managed(
     if use_contents is not None:
         if not allow_empty and not use_contents:
             if contents_pillar:
-                contents_id = "contents_pillar {0}".format(contents_pillar)
+                contents_id = 'contents_pillar {0}'.format(contents_pillar)
             elif contents_grains:
-                contents_id = "contents_grains {0}".format(contents_grains)
+                contents_id = 'contents_grains {0}'.format(contents_grains)
             else:
-                contents_id = "'contents'"
+                contents_id = '\'contents\''
             return _error(
                 ret,
-                "{0} value would result in empty contents. Set allow_empty "
-                "to True to allow the managed file to be empty.".format(contents_id),
+                '{0} value would result in empty contents. Set allow_empty '
+                'to True to allow the managed file to be empty.'
+                .format(contents_id)
             )
 
         try:
@@ -2758,14 +2705,14 @@ def managed(
             if not validated_contents:
                 return _error(
                     ret,
-                    "Contents specified by contents/contents_pillar/"
-                    "contents_grains is not a string or list of strings, and "
-                    "is not binary data. SLS is likely malformed.",
+                    'Contents specified by contents/contents_pillar/'
+                    'contents_grains is not a string or list of strings, and '
+                    'is not binary data. SLS is likely malformed.'
                 )
-            contents = ""
+            contents = ''
             for part in validated_contents:
                 for line in part.splitlines():
-                    contents += line.rstrip("\n").rstrip("\r") + os.linesep
+                    contents += line.rstrip('\n').rstrip('\r') + os.linesep
             if contents_newline and not contents.endswith(os.linesep):
                 contents += os.linesep
         except UnicodeDecodeError:
@@ -2773,29 +2720,28 @@ def managed(
             if template:
                 return _error(
                     ret,
-                    "Contents specified by contents/contents_pillar/"
-                    "contents_grains appears to be binary data, and"
-                    " as will not be able to be treated as a Jinja"
-                    " template.",
+                    'Contents specified by contents/contents_pillar/'
+                    'contents_grains appears to be binary data, and'
+                    ' as will not be able to be treated as a Jinja'
+                    ' template.'
                 )
             contents = use_contents
         if template:
-            contents = __salt__["file.apply_template_on_contents"](
+            contents = __salt__['file.apply_template_on_contents'](
                 contents,
                 template=template,
                 context=context,
                 defaults=defaults,
-                saltenv=__env__,
-            )
+                saltenv=__env__)
             if not isinstance(contents, six.string_types):
-                if "result" in contents:
-                    ret["result"] = contents["result"]
+                if 'result' in contents:
+                    ret['result'] = contents['result']
                 else:
-                    ret["result"] = False
-                if "comment" in contents:
-                    ret["comment"] = contents["comment"]
+                    ret['result'] = False
+                if 'comment' in contents:
+                    ret['comment'] = contents['comment']
                 else:
-                    ret["comment"] = "Error while applying template on contents"
+                    ret['comment'] = 'Error while applying template on contents'
                 return ret
 
     user = _test_owner(kwargs, user=user)
@@ -2808,96 +2754,85 @@ def managed(
         # Group isn't relevant to Windows, use win_perms/win_deny_perms
         if group is not None:
             log.warning(
-                "The group argument for %s has been ignored as this is "
-                "a Windows system. Please use the `win_*` parameters to set "
-                "permissions in Windows.",
-                name,
+                'The group argument for %s has been ignored as this is '
+                'a Windows system. Please use the `win_*` parameters to set '
+                'permissions in Windows.', name
             )
         group = user
 
     if not create:
         if not os.path.isfile(name):
             # Don't create a file that is not already present
-            ret["comment"] = (
-                "File {0} is not present and is not set for " "creation"
-            ).format(name)
+            ret['comment'] = ('File {0} is not present and is not set for '
+                              'creation').format(name)
             return ret
     u_check = _check_user(user, group)
     if u_check:
         # The specified user or group do not exist
         return _error(ret, u_check)
     if not os.path.isabs(name):
-        return _error(ret, "Specified file {0} is not an absolute path".format(name))
+        return _error(
+            ret, 'Specified file {0} is not an absolute path'.format(name))
 
     if os.path.isdir(name):
-        ret["comment"] = "Specified target {0} is a directory".format(name)
-        ret["result"] = False
+        ret['comment'] = 'Specified target {0} is a directory'.format(name)
+        ret['result'] = False
         return ret
 
     if context is None:
         context = {}
     elif not isinstance(context, dict):
-        return _error(ret, "Context must be formed as a dict")
+        return _error(
+            ret, 'Context must be formed as a dict')
     if defaults and not isinstance(defaults, dict):
-        return _error(ret, "Defaults must be formed as a dict")
+        return _error(
+            ret, 'Defaults must be formed as a dict')
 
     if not replace and os.path.exists(name):
         ret_perms = {}
         # Check and set the permissions if necessary
         if salt.utils.platform.is_windows():
-            ret = __salt__["file.check_perms"](
+            ret = __salt__['file.check_perms'](
                 path=name,
                 ret=ret,
                 owner=win_owner,
                 grant_perms=win_perms,
                 deny_perms=win_deny_perms,
                 inheritance=win_inheritance,
-                reset=win_perms_reset,
-            )
+                reset=win_perms_reset)
         else:
-            ret, ret_perms = __salt__["file.check_perms"](
-                name,
-                ret,
-                user,
-                group,
-                mode,
-                attrs,
-                follow_symlinks,
+            ret, ret_perms = __salt__['file.check_perms'](
+                name, ret, user, group, mode, attrs, follow_symlinks,
                 seuser=seuser,
                 serole=serole,
                 setype=setype,
-                serange=serange,
-            )
-        if __opts__["test"]:
-            if (
-                isinstance(ret_perms, dict)
-                and "lmode" in ret_perms
-                and mode != ret_perms["lmode"]
-            ):
-                ret["comment"] = (
-                    "File {0} will be updated with permissions "
-                    "{1} from its current "
-                    "state of {2}".format(name, mode, ret_perms["lmode"])
-                )
+                serange=serange)
+        if __opts__['test']:
+            if isinstance(ret_perms, dict) and \
+               'lmode' in ret_perms and \
+               mode != ret_perms['lmode']:
+                ret['comment'] = ('File {0} will be updated with permissions '
+                                  '{1} from its current '
+                                  'state of {2}'.format(name,
+                                                        mode,
+                                                        ret_perms['lmode']))
             else:
-                ret["comment"] = "File {0} not updated".format(name)
-        elif not ret["changes"] and ret["result"]:
-            ret["comment"] = (
-                "File {0} exists with proper permissions. "
-                "No changes made.".format(name)
-            )
+                ret['comment'] = 'File {0} not updated'.format(name)
+        elif not ret['changes'] and ret['result']:
+            ret['comment'] = ('File {0} exists with proper permissions. '
+                              'No changes made.'.format(name))
         return ret
 
     accum_data, _ = _load_accumulators()
     if name in accum_data:
         if not context:
             context = {}
-        context["accumulator"] = accum_data[name]
+        context['accumulator'] = accum_data[name]
 
     try:
-        if __opts__["test"]:
+        if __opts__['test']:
             try:
-                ret["changes"] = __salt__["file.check_managed_changes"](
+                ret['changes'] = __salt__['file.check_managed_changes'](
                     name,
                     source,
                     source_hash,
@@ -2920,52 +2855,53 @@ def managed(
                     **kwargs
                 )
             except CommandExecutionError as exc:
-                ret["result"] = False
-                ret["comment"] = six.text_type(exc)
+                ret['result'] = False
+                ret['comment'] = six.text_type(exc)
                 return ret
 
             if salt.utils.platform.is_windows():
                 try:
-                    ret = __salt__["file.check_perms"](
+                    ret = __salt__['file.check_perms'](
                         path=name,
                         ret=ret,
                         owner=win_owner,
                         grant_perms=win_perms,
                         deny_perms=win_deny_perms,
                         inheritance=win_inheritance,
-                        reset=win_perms_reset,
-                    )
+                        reset=win_perms_reset)
                 except CommandExecutionError as exc:
-                    if exc.strerror.startswith("Path not found"):
-                        ret["changes"]["newfile"] = name
+                    if exc.strerror.startswith('Path not found'):
+                        ret['changes']['newfile'] = name
 
-            if isinstance(ret["changes"], tuple):
-                ret["result"], ret["comment"] = ret["changes"]
-            elif ret["changes"]:
-                ret["result"] = None
-                ret["comment"] = "The file {0} is set to be changed".format(name)
-                ret["comment"] += (
-                    "\nNote: No changes made, actual changes may\n"
-                    "be different due to other states."
-                )
-                if "diff" in ret["changes"] and not show_changes:
-                    ret["changes"]["diff"] = "<show_changes=False>"
+            if isinstance(ret['changes'], tuple):
+                ret['result'], ret['comment'] = ret['changes']
+            elif ret['changes']:
+                ret['result'] = None
+                ret['comment'] = 'The file {0} is set to be changed'.format(name)
+                ret['comment'] += ('\nNote: No changes made, actual changes may\n'
+                                   'be different due to other states.')
+                if 'diff' in ret['changes'] and not show_changes:
+                    ret['changes']['diff'] = '<show_changes=False>'
             else:
-                ret["result"] = True
-                ret["comment"] = "The file {0} is in the correct state".format(name)
+                ret['result'] = True
+                ret['comment'] = 'The file {0} is in the correct state'.format(name)
 
             return ret
 
         # If the source is a list then find which file exists
-        source, source_hash = __salt__["file.source_list"](source, source_hash, __env__)
+        source, source_hash = __salt__['file.source_list'](
+            source,
+            source_hash,
+            __env__
+        )
     except CommandExecutionError as exc:
-        ret["result"] = False
-        ret["comment"] = "Unable to manage file: {0}".format(exc)
+        ret['result'] = False
+        ret['comment'] = 'Unable to manage file: {0}'.format(exc)
         return ret
 
     # Gather the source file from the server
     try:
-        sfn, source_sum, comment_ = __salt__["file.get_managed"](
+        sfn, source_sum, comment_ = __salt__['file.get_managed'](
             name,
             template,
             source,
@@ -2982,9 +2918,9 @@ def managed(
             **kwargs
         )
     except Exception as exc:
-        ret["changes"] = {}
+        ret['changes'] = {}
         log.debug(traceback.format_exc())
-        return _error(ret, "Unable to manage file: {0}".format(exc))
+        return _error(ret, 'Unable to manage file: {0}'.format(exc))
 
     tmp_filename = None
 
@@ -2992,19 +2928,19 @@ def managed(
         tmp_filename = salt.utils.files.mkstemp(suffix=tmp_ext, dir=tmp_dir)
 
         # if exists copy existing file to tmp to compare
-        if __salt__["file.file_exists"](name):
+        if __salt__['file.file_exists'](name):
             try:
-                __salt__["file.copy"](name, tmp_filename)
+                __salt__['file.copy'](name, tmp_filename)
             except Exception as exc:
                 return _error(
                     ret,
-                    "Unable to copy file {0} to {1}: {2}".format(
+                    'Unable to copy file {0} to {1}: {2}'.format(
                         name, tmp_filename, exc
-                    ),
+                    )
                 )
 
         try:
-            ret = __salt__["file.manage_file"](
+            ret = __salt__['file.manage_file'](
                 tmp_filename,
                 sfn,
                 ret,
@@ -3035,29 +2971,33 @@ def managed(
                 serole=serole,
                 setype=setype,
                 serange=serange,
-                **kwargs
-            )
+                **kwargs)
         except Exception as exc:
-            ret["changes"] = {}
+            ret['changes'] = {}
             log.debug(traceback.format_exc())
             salt.utils.files.remove(tmp_filename)
             if not keep_source:
-                if not sfn and source and _urlparse(source).scheme == "salt":
+                if not sfn \
+                        and source \
+                        and _urlparse(source).scheme == 'salt':
                     # The file would not have been cached until manage_file was
                     # run, so check again here for a cached copy.
-                    sfn = __salt__["cp.is_cached"](source, __env__)
+                    sfn = __salt__['cp.is_cached'](source, __env__)
                 if sfn:
                     salt.utils.files.remove(sfn)
-            return _error(ret, "Unable to check_cmd file: {0}".format(exc))
+            return _error(ret, 'Unable to check_cmd file: {0}'.format(exc))
 
         # file being updated to verify using check_cmd
-        if ret["changes"]:
+        if ret['changes']:
             # Reset ret
-            ret = {"changes": {}, "comment": "", "name": name, "result": True}
+            ret = {'changes': {},
+                   'comment': '',
+                   'name': name,
+                   'result': True}
 
             check_cmd_opts = {}
-            if "shell" in __grains__:
-                check_cmd_opts["shell"] = __grains__["shell"]
+            if 'shell' in __grains__:
+                check_cmd_opts['shell'] = __grains__['shell']
 
             cret = mod_run_check_cmd(check_cmd, tmp_filename, **check_cmd_opts)
             if isinstance(cret, dict):
@@ -3072,13 +3012,16 @@ def managed(
             sfn = tmp_filename
 
         else:
-            ret = {"changes": {}, "comment": "", "name": name, "result": True}
+            ret = {'changes': {},
+                   'comment': '',
+                   'name': name,
+                   'result': True}
 
     if comment_ and contents is None:
         return _error(ret, comment_)
     else:
         try:
-            return __salt__["file.manage_file"](
+            return __salt__['file.manage_file'](
                 name,
                 sfn,
                 ret,
@@ -3109,33 +3052,34 @@ def managed(
                 serole=serole,
                 setype=setype,
                 serange=serange,
-                **kwargs
-            )
+                **kwargs)
         except Exception as exc:
-            ret["changes"] = {}
+            ret['changes'] = {}
             log.debug(traceback.format_exc())
-            return _error(ret, "Unable to manage file: {0}".format(exc))
+            return _error(ret, 'Unable to manage file: {0}'.format(exc))
         finally:
             if tmp_filename:
                 salt.utils.files.remove(tmp_filename)
             if not keep_source:
-                if not sfn and source and _urlparse(source).scheme == "salt":
+                if not sfn \
+                        and source \
+                        and _urlparse(source).scheme == 'salt':
                     # The file would not have been cached until manage_file was
                     # run, so check again here for a cached copy.
-                    sfn = __salt__["cp.is_cached"](source, __env__)
+                    sfn = __salt__['cp.is_cached'](source, __env__)
                 if sfn:
                     salt.utils.files.remove(sfn)
 
 
-_RECURSE_TYPES = ["user", "group", "mode", "ignore_files", "ignore_dirs", "silent"]
+_RECURSE_TYPES = ['user', 'group', 'mode', 'ignore_files', 'ignore_dirs', 'silent']
 
 
 def _get_recurse_set(recurse):
-    """
+    '''
     Converse *recurse* definition to a set of strings.
 
     Raises TypeError or ValueError when *recurse* has wrong structure.
-    """
+    '''
     if not recurse:
         return set()
     if not isinstance(recurse, list):
@@ -3145,24 +3089,19 @@ def _get_recurse_set(recurse):
     except TypeError:  # non-hashable elements
         recurse_set = None
     if recurse_set is None or not set(_RECURSE_TYPES) >= recurse_set:
-        raise ValueError(
-            'Types for "recurse" limited to {0}.'.format(
-                ", ".join('"{0}"'.format(rtype) for rtype in _RECURSE_TYPES)
-            )
-        )
-    if "ignore_files" in recurse_set and "ignore_dirs" in recurse_set:
-        raise ValueError(
-            'Must not specify "recurse" options "ignore_files"'
-            ' and "ignore_dirs" at the same time.'
-        )
+        raise ValueError('Types for "recurse" limited to {0}.'.format(
+            ', '.join('"{0}"'.format(rtype) for rtype in _RECURSE_TYPES)))
+    if 'ignore_files' in recurse_set and 'ignore_dirs' in recurse_set:
+        raise ValueError('Must not specify "recurse" options "ignore_files"'
+                         ' and "ignore_dirs" at the same time.')
     return recurse_set
 
 
 def _depth_limited_walk(top, max_depth=None):
-    """
+    '''
     Walk the directory tree under root up till reaching max_depth.
     With max_depth=None (default), do not limit depth.
-    """
+    '''
     for root, dirs, files in salt.utils.path.os_walk(top):
         if max_depth is not None:
             rel_depth = root.count(os.path.sep) - top.count(os.path.sep)
@@ -3171,31 +3110,29 @@ def _depth_limited_walk(top, max_depth=None):
         yield (six.text_type(root), list(dirs), list(files))
 
 
-def directory(
-    name,
-    user=None,
-    group=None,
-    recurse=None,
-    max_depth=None,
-    dir_mode=None,
-    file_mode=None,
-    makedirs=False,
-    clean=False,
-    require=None,
-    exclude_pat=None,
-    follow_symlinks=False,
-    force=False,
-    backupname=None,
-    allow_symlink=True,
-    children_only=False,
-    win_owner=None,
-    win_perms=None,
-    win_deny_perms=None,
-    win_inheritance=True,
-    win_perms_reset=False,
-    **kwargs
-):
-    r"""
+def directory(name,
+              user=None,
+              group=None,
+              recurse=None,
+              max_depth=None,
+              dir_mode=None,
+              file_mode=None,
+              makedirs=False,
+              clean=False,
+              require=None,
+              exclude_pat=None,
+              follow_symlinks=False,
+              force=False,
+              backupname=None,
+              allow_symlink=True,
+              children_only=False,
+              win_owner=None,
+              win_perms=None,
+              win_deny_perms=None,
+              win_inheritance=True,
+              win_perms_reset=False,
+              **kwargs):
+    r'''
     Ensure that a named directory is present and has the right perms
 
     name
@@ -3390,17 +3327,20 @@ def directory(
                 fred_snuffy:
                   perms: full_control
             - win_inheritance: False
-    """
+    '''
     name = os.path.expanduser(name)
-    ret = {"name": name, "changes": {}, "result": True, "comment": ""}
+    ret = {'name': name,
+           'changes': {},
+           'result': True,
+           'comment': ''}
     if not name:
-        return _error(ret, "Must provide name to file.directory")
+        return _error(ret, 'Must provide name to file.directory')
     # Remove trailing slash, if present and we're not working on "/" itself
-    if name[-1] == "/" and name != "/":
+    if name[-1] == '/' and name != '/':
         name = name[:-1]
 
     if max_depth is not None and clean:
-        return _error(ret, "Cannot specify both max_depth and clean")
+        return _error(ret, 'Cannot specify both max_depth and clean')
 
     user = _test_owner(kwargs, user=user)
     if salt.utils.platform.is_windows():
@@ -3412,15 +3352,14 @@ def directory(
         # Group isn't relevant to Windows, use win_perms/win_deny_perms
         if group is not None:
             log.warning(
-                "The group argument for %s has been ignored as this is "
-                "a Windows system. Please use the `win_*` parameters to set "
-                "permissions in Windows.",
-                name,
+                'The group argument for %s has been ignored as this is '
+                'a Windows system. Please use the `win_*` parameters to set '
+                'permissions in Windows.', name
             )
         group = user
 
-    if "mode" in kwargs and not dir_mode:
-        dir_mode = kwargs.get("mode", [])
+    if 'mode' in kwargs and not dir_mode:
+        dir_mode = kwargs.get('mode', [])
 
     if not file_mode:
         file_mode = dir_mode
@@ -3444,59 +3383,52 @@ def directory(
 
     # Must be an absolute path
     if not os.path.isabs(name):
-        return _error(ret, "Specified file {0} is not an absolute path".format(name))
+        return _error(
+            ret, 'Specified file {0} is not an absolute path'.format(name))
 
     # Check for existing file or symlink
-    if (
-        os.path.isfile(name)
-        or (not allow_symlink and os.path.islink(name))
-        or (force and os.path.islink(name))
-    ):
+    if os.path.isfile(name) or (not allow_symlink and os.path.islink(name)) \
+       or (force and os.path.islink(name)):
         # Was a backupname specified
         if backupname is not None:
             # Make a backup first
             if os.path.lexists(backupname):
                 if not force:
-                    return _error(
-                        ret,
-                        (
-                            (
-                                "File exists where the backup target {0} should go"
-                            ).format(backupname)
-                        ),
-                    )
+                    return _error(ret, ((
+                                            'File exists where the backup target {0} should go'
+                                        ).format(backupname)))
                 else:
-                    __salt__["file.remove"](backupname)
+                    __salt__['file.remove'](backupname)
             os.rename(name, backupname)
         elif force:
             # Remove whatever is in the way
             if os.path.isfile(name):
-                if __opts__["test"]:
-                    ret["changes"]["forced"] = "File would be forcibly replaced"
+                if __opts__['test']:
+                    ret['changes']['forced'] = 'File would be forcibly replaced'
                 else:
                     os.remove(name)
-                    ret["changes"]["forced"] = "File was forcibly replaced"
-            elif __salt__["file.is_link"](name):
-                if __opts__["test"]:
-                    ret["changes"]["forced"] = "Symlink would be forcibly replaced"
+                    ret['changes']['forced'] = 'File was forcibly replaced'
+            elif __salt__['file.is_link'](name):
+                if __opts__['test']:
+                    ret['changes']['forced'] = 'Symlink would be forcibly replaced'
                 else:
-                    __salt__["file.remove"](name)
-                    ret["changes"]["forced"] = "Symlink was forcibly replaced"
+                    __salt__['file.remove'](name)
+                    ret['changes']['forced'] = 'Symlink was forcibly replaced'
             else:
-                if __opts__["test"]:
-                    ret["changes"]["forced"] = "Directory would be forcibly replaced"
+                if __opts__['test']:
+                    ret['changes']['forced'] = 'Directory would be forcibly replaced'
                 else:
-                    __salt__["file.remove"](name)
-                    ret["changes"]["forced"] = "Directory was forcibly replaced"
+                    __salt__['file.remove'](name)
+                    ret['changes']['forced'] = 'Directory was forcibly replaced'
         else:
             if os.path.isfile(name):
                 return _error(
-                    ret, "Specified location {0} exists and is a file".format(name)
-                )
+                    ret,
+                    'Specified location {0} exists and is a file'.format(name))
             elif os.path.islink(name):
                 return _error(
-                    ret, "Specified location {0} exists and is a symlink".format(name)
-                )
+                    ret,
+                    'Specified location {0} exists and is a symlink'.format(name))
 
     # Check directory?
     if salt.utils.platform.is_windows():
@@ -3506,32 +3438,20 @@ def directory(
             win_perms=win_perms,
             win_deny_perms=win_deny_perms,
             win_inheritance=win_inheritance,
-            win_perms_reset=win_perms_reset,
-        )
+            win_perms_reset=win_perms_reset)
     else:
         presult, pcomment, pchanges = _check_directory(
-            name,
-            user,
-            group,
-            recurse or [],
-            dir_mode,
-            file_mode,
-            clean,
-            require,
-            exclude_pat,
-            max_depth,
-            follow_symlinks,
-            children_only,
-        )
+            name, user, group, recurse or [], dir_mode, file_mode, clean,
+            require, exclude_pat, max_depth, follow_symlinks, children_only)
 
     if pchanges:
-        ret["changes"].update(pchanges)
+        ret['changes'].update(pchanges)
 
     # Don't run through the reset of the function if there are no changes to be
     # made
-    if __opts__["test"] or not ret["changes"]:
-        ret["result"] = presult
-        ret["comment"] = pcomment
+    if __opts__['test'] or not ret['changes']:
+        ret['result'] = presult
+        ret['comment'] = pcomment
         return ret
 
     if not os.path.isdir(name):
@@ -3541,55 +3461,51 @@ def directory(
             if makedirs:
                 # Everything's good, create the parent Dirs
                 try:
-                    _makedirs(
-                        name=name,
-                        user=user,
-                        group=group,
-                        dir_mode=dir_mode,
-                        win_owner=win_owner,
-                        win_perms=win_perms,
-                        win_deny_perms=win_deny_perms,
-                        win_inheritance=win_inheritance,
-                    )
+                    _makedirs(name=name,
+                              user=user,
+                              group=group,
+                              dir_mode=dir_mode,
+                              win_owner=win_owner,
+                              win_perms=win_perms,
+                              win_deny_perms=win_deny_perms,
+                              win_inheritance=win_inheritance)
                 except CommandExecutionError as exc:
-                    return _error(ret, "Drive {0} is not mapped".format(exc.message))
+                    return _error(ret, 'Drive {0} is not mapped'.format(exc.message))
             else:
-                return _error(ret, "No directory to create {0} in".format(name))
+                return _error(
+                    ret, 'No directory to create {0} in'.format(name))
 
         if salt.utils.platform.is_windows():
-            __salt__["file.mkdir"](
+            __salt__['file.mkdir'](
                 path=name,
                 owner=win_owner,
                 grant_perms=win_perms,
                 deny_perms=win_deny_perms,
                 inheritance=win_inheritance,
-                reset=win_perms_reset,
-            )
+                reset=win_perms_reset)
         else:
-            __salt__["file.mkdir"](name, user=user, group=group, mode=dir_mode)
+            __salt__['file.mkdir'](name, user=user, group=group, mode=dir_mode)
 
-        ret["changes"][name] = "New Dir"
+        ret['changes'][name] = 'New Dir'
 
     if not os.path.isdir(name):
-        return _error(ret, "Failed to create directory {0}".format(name))
+        return _error(ret, 'Failed to create directory {0}'.format(name))
 
     # issue 32707: skip this __salt__['file.check_perms'] call if children_only == True
     # Check permissions
     if not children_only:
         if salt.utils.platform.is_windows():
-            ret = __salt__["file.check_perms"](
+            ret = __salt__['file.check_perms'](
                 path=name,
                 ret=ret,
                 owner=win_owner,
                 grant_perms=win_perms,
                 deny_perms=win_deny_perms,
                 inheritance=win_inheritance,
-                reset=win_perms_reset,
-            )
+                reset=win_perms_reset)
         else:
-            ret, perms = __salt__["file.check_perms"](
-                name, ret, user, group, dir_mode, None, follow_symlinks
-            )
+            ret, perms = __salt__['file.check_perms'](
+                name, ret, user, group, dir_mode, None, follow_symlinks)
 
     errors = []
     if recurse or clean:
@@ -3605,61 +3521,53 @@ def directory(
         try:
             recurse_set = _get_recurse_set(recurse)
         except (TypeError, ValueError) as exc:
-            ret["result"] = False
-            ret["comment"] = "{0}".format(exc)
+            ret['result'] = False
+            ret['comment'] = '{0}'.format(exc)
             # NOTE: Should this be enough to stop the whole check altogether?
     if recurse_set:
-        if "user" in recurse_set:
+        if 'user' in recurse_set:
             if user or isinstance(user, int):
-                uid = __salt__["file.user_to_uid"](user)
+                uid = __salt__['file.user_to_uid'](user)
                 # file.user_to_uid returns '' if user does not exist. Above
                 # check for user is not fatal, so we need to be sure user
                 # exists.
                 if isinstance(uid, six.string_types):
-                    ret["result"] = False
-                    ret["comment"] = (
-                        "Failed to enforce ownership for "
-                        "user {0} (user does not "
-                        "exist)".format(user)
-                    )
+                    ret['result'] = False
+                    ret['comment'] = 'Failed to enforce ownership for ' \
+                                     'user {0} (user does not ' \
+                                     'exist)'.format(user)
             else:
-                ret["result"] = False
-                ret["comment"] = (
-                    "user not specified, but configured as "
-                    "a target for recursive ownership "
-                    "management"
-                )
+                ret['result'] = False
+                ret['comment'] = 'user not specified, but configured as ' \
+                                 'a target for recursive ownership ' \
+                                 'management'
         else:
             user = None
-        if "group" in recurse_set:
+        if 'group' in recurse_set:
             if group or isinstance(group, int):
-                gid = __salt__["file.group_to_gid"](group)
+                gid = __salt__['file.group_to_gid'](group)
                 # As above with user, we need to make sure group exists.
                 if isinstance(gid, six.string_types):
-                    ret["result"] = False
-                    ret["comment"] = (
-                        "Failed to enforce group ownership "
-                        "for group {0}".format(group)
-                    )
+                    ret['result'] = False
+                    ret['comment'] = 'Failed to enforce group ownership ' \
+                                     'for group {0}'.format(group)
             else:
-                ret["result"] = False
-                ret["comment"] = (
-                    "group not specified, but configured "
-                    "as a target for recursive ownership "
-                    "management"
-                )
+                ret['result'] = False
+                ret['comment'] = 'group not specified, but configured ' \
+                                 'as a target for recursive ownership ' \
+                                 'management'
         else:
             group = None
 
-        if "mode" not in recurse_set:
+        if 'mode' not in recurse_set:
             file_mode = None
             dir_mode = None
 
-        if "silent" in recurse_set:
-            ret["changes"] = "Changes silenced"
+        if 'silent' in recurse_set:
+            ret['changes'] = 'Changes silenced'
 
-        check_files = "ignore_files" not in recurse_set
-        check_dirs = "ignore_dirs" not in recurse_set
+        check_files = 'ignore_files' not in recurse_set
+        check_dirs = 'ignore_dirs' not in recurse_set
 
         for root, dirs, files in walk_l:
             if check_files:
@@ -3667,21 +3575,19 @@ def directory(
                     full = os.path.join(root, fn_)
                     try:
                         if salt.utils.platform.is_windows():
-                            ret = __salt__["file.check_perms"](
+                            ret = __salt__['file.check_perms'](
                                 path=full,
                                 ret=ret,
                                 owner=win_owner,
                                 grant_perms=win_perms,
                                 deny_perms=win_deny_perms,
                                 inheritance=win_inheritance,
-                                reset=win_perms_reset,
-                            )
+                                reset=win_perms_reset)
                         else:
-                            ret, _ = __salt__["file.check_perms"](
-                                full, ret, user, group, file_mode, None, follow_symlinks
-                            )
+                            ret, _ = __salt__['file.check_perms'](
+                                full, ret, user, group, file_mode, None, follow_symlinks)
                     except CommandExecutionError as exc:
-                        if not exc.strerror.startswith("Path not found"):
+                        if not exc.strerror.startswith('Path not found'):
                             errors.append(exc.strerror)
 
             if check_dirs:
@@ -3689,88 +3595,85 @@ def directory(
                     full = os.path.join(root, dir_)
                     try:
                         if salt.utils.platform.is_windows():
-                            ret = __salt__["file.check_perms"](
+                            ret = __salt__['file.check_perms'](
                                 path=full,
                                 ret=ret,
                                 owner=win_owner,
                                 grant_perms=win_perms,
                                 deny_perms=win_deny_perms,
                                 inheritance=win_inheritance,
-                                reset=win_perms_reset,
-                            )
+                                reset=win_perms_reset)
                         else:
-                            ret, _ = __salt__["file.check_perms"](
-                                full, ret, user, group, dir_mode, None, follow_symlinks
-                            )
+                            ret, _ = __salt__['file.check_perms'](
+                                full, ret, user, group, dir_mode, None, follow_symlinks)
                     except CommandExecutionError as exc:
-                        if not exc.strerror.startswith("Path not found"):
+                        if not exc.strerror.startswith('Path not found'):
                             errors.append(exc.strerror)
 
     if clean:
         keep = _gen_keep_files(name, require, walk_d)
-        log.debug("List of kept files when use file.directory with clean: %s", keep)
+        log.debug('List of kept files when use file.directory with clean: %s',
+                  keep)
         removed = _clean_dir(name, list(keep), exclude_pat)
         if removed:
-            ret["changes"]["removed"] = removed
-            ret["comment"] = "Files cleaned from directory {0}".format(name)
+            ret['changes']['removed'] = removed
+            ret['comment'] = 'Files cleaned from directory {0}'.format(name)
 
     # issue 32707: reflect children_only selection in comments
-    if not ret["comment"]:
+    if not ret['comment']:
         if children_only:
-            ret["comment"] = "Directory {0}/* updated".format(name)
+            ret['comment'] = 'Directory {0}/* updated'.format(name)
         else:
-            if ret["changes"]:
-                ret["comment"] = "Directory {0} updated".format(name)
+            if ret['changes']:
+                ret['comment'] = 'Directory {0} updated'.format(name)
 
-    if __opts__["test"]:
-        ret["comment"] = "Directory {0} not updated".format(name)
-    elif not ret["changes"] and ret["result"]:
+    if __opts__['test']:
+        ret['comment'] = 'Directory {0} not updated'.format(name)
+    elif not ret['changes'] and ret['result']:
         orig_comment = None
-        if ret["comment"]:
-            orig_comment = ret["comment"]
+        if ret['comment']:
+            orig_comment = ret['comment']
 
-        ret["comment"] = "Directory {0} is in the correct state".format(name)
+        ret['comment'] = 'Directory {0} is in the correct state'.format(name)
         if orig_comment:
-            ret["comment"] = "\n".join([ret["comment"], orig_comment])
+            ret['comment'] = '\n'.join([ret['comment'], orig_comment])
 
     if errors:
-        ret["result"] = False
-        ret["comment"] += "\n\nThe following errors were encountered:\n"
+        ret['result'] = False
+        ret['comment'] += '\n\nThe following errors were encountered:\n'
         for error in errors:
-            ret["comment"] += "\n- {0}".format(error)
+            ret['comment'] += '\n- {0}'.format(error)
 
     return ret
 
 
-def recurse(
-    name,
-    source,
-    keep_source=True,
-    clean=False,
-    require=None,
-    user=None,
-    group=None,
-    dir_mode=None,
-    file_mode=None,
-    sym_mode=None,
-    template=None,
-    context=None,
-    replace=True,
-    defaults=None,
-    include_empty=False,
-    backup="",
-    include_pat=None,
-    exclude_pat=None,
-    maxdepth=None,
-    keep_symlinks=False,
-    force_symlinks=False,
-    win_owner=None,
-    win_perms=None,
-    win_deny_perms=None,
-    win_inheritance=True,
-    **kwargs
-):
-    """
+def recurse(name,
+            source,
+            keep_source=True,
+            clean=False,
+            require=None,
+            user=None,
+            group=None,
+            dir_mode=None,
+            file_mode=None,
+            sym_mode=None,
+            template=None,
+            context=None,
+            replace=True,
+            defaults=None,
+            include_empty=False,
+            backup='',
+            include_pat=None,
+            exclude_pat=None,
+            maxdepth=None,
+            keep_symlinks=False,
+            force_symlinks=False,
+            win_owner=None,
+            win_perms=None,
+            win_deny_perms=None,
+            win_inheritance=True,
+            **kwargs):
+    '''
     Recurse through a subdirectory on the master and copy said subdirectory
     over to the specified path.
 
@@ -3968,10 +3871,10 @@ def recurse(
         True to inherit permissions from parent, otherwise False
 
         .. versionadded:: 2017.7.7
-    """
-    if "env" in kwargs:
+    '''
+    if 'env' in kwargs:
         # "env" is not supported; Use "saltenv".
-        kwargs.pop("env")
+        kwargs.pop('env')
 
     name = os.path.expanduser(salt.utils.data.decode(name))
 
@@ -3979,37 +3882,34 @@ def recurse(
     if salt.utils.platform.is_windows():
         if group is not None:
             log.warning(
-                "The group argument for %s has been ignored as this "
-                "is a Windows system.",
-                name,
+                'The group argument for %s has been ignored as this '
+                'is a Windows system.', name
             )
         group = user
     ret = {
-        "name": name,
-        "changes": {},
-        "result": True,
-        "comment": {},  # { path: [comment, ...] }
+        'name': name,
+        'changes': {},
+        'result': True,
+        'comment': {}  # { path: [comment, ...] }
     }
 
-    if "mode" in kwargs:
-        ret["result"] = False
-        ret["comment"] = (
-            "'mode' is not allowed in 'file.recurse'. Please use "
-            "'file_mode' and 'dir_mode'."
+    if 'mode' in kwargs:
+        ret['result'] = False
+        ret['comment'] = (
+            '\'mode\' is not allowed in \'file.recurse\'. Please use '
+            '\'file_mode\' and \'dir_mode\'.'
         )
         return ret
 
-    if (
-        any([x is not None for x in (dir_mode, file_mode, sym_mode)])
-        and salt.utils.platform.is_windows()
-    ):
-        return _error(ret, "mode management is not supported on Windows")
+    if any([x is not None for x in (dir_mode, file_mode, sym_mode)]) \
+            and salt.utils.platform.is_windows():
+        return _error(ret, 'mode management is not supported on Windows')
 
     # Make sure that leading zeros stripped by YAML loader are added back
     dir_mode = salt.utils.files.normalize_mode(dir_mode)
 
     try:
-        keep_mode = file_mode.lower() == "keep"
+        keep_mode = file_mode.lower() == 'keep'
         if keep_mode:
             # We're not hard-coding the mode, so set it to None
             file_mode = None
@@ -4023,27 +3923,26 @@ def recurse(
         # The specified user or group do not exist
         return _error(ret, u_check)
     if not os.path.isabs(name):
-        return _error(ret, "Specified file {0} is not an absolute path".format(name))
+        return _error(
+            ret, 'Specified file {0} is not an absolute path'.format(name))
 
     # expand source into source_list
     source_list = _validate_str_list(source)
 
     for idx, val in enumerate(source_list):
-        source_list[idx] = val.rstrip("/")
+        source_list[idx] = val.rstrip('/')
 
     for precheck in source_list:
-        if not precheck.startswith("salt://"):
-            return _error(
-                ret,
-                ("Invalid source '{0}' " "(must be a salt:// URI)".format(precheck)),
-            )
+        if not precheck.startswith('salt://'):
+            return _error(ret, ('Invalid source \'{0}\' '
+                                '(must be a salt:// URI)'.format(precheck)))
 
     # Select the first source in source_list that exists
     try:
-        source, source_hash = __salt__["file.source_list"](source_list, "", __env__)
+        source, source_hash = __salt__['file.source_list'](source_list, '', __env__)
     except CommandExecutionError as exc:
-        ret["result"] = False
-        ret["comment"] = "Recurse failed: {0}".format(exc)
+        ret['result'] = False
+        ret['comment'] = 'Recurse failed: {0}'.format(exc)
         return ret
 
     # Check source path relative to fileserver root, make sure it is a
@@ -4051,14 +3950,14 @@ def recurse(
     srcpath, senv = salt.utils.url.parse(source)
     if senv is None:
         senv = __env__
-    master_dirs = __salt__["cp.list_master_dirs"](saltenv=senv)
-    if srcpath not in master_dirs and not any(
-        (x for x in master_dirs if x.startswith(srcpath + "/"))
-    ):
-        ret["result"] = False
-        ret["comment"] = (
-            "The directory '{0}' does not exist on the salt fileserver "
-            "in saltenv '{1}'".format(srcpath, senv)
+    master_dirs = __salt__['cp.list_master_dirs'](saltenv=senv)
+    if srcpath not in master_dirs \
+            and not any((x for x in master_dirs
+                         if x.startswith(srcpath + '/'))):
+        ret['result'] = False
+        ret['comment'] = (
+            'The directory \'{0}\' does not exist on the salt fileserver '
+            'in saltenv \'{1}\''.format(srcpath, senv)
         )
         return ret
 
@@ -4067,25 +3966,23 @@ def recurse(
         if os.path.exists(name):
             # it is not a dir, but it exists - fail out
             return _error(
-                ret, "The path {0} exists and is not a directory".format(name)
-            )
-        if not __opts__["test"]:
+                ret, 'The path {0} exists and is not a directory'.format(name))
+        if not __opts__['test']:
             if salt.utils.platform.is_windows():
                 win_owner = win_owner if win_owner else user
-                __salt__["file.makedirs_perms"](
-                    path=name,
-                    owner=win_owner,
-                    grant_perms=win_perms,
-                    deny_perms=win_deny_perms,
-                    inheritance=win_inheritance,
-                )
+                __salt__['file.makedirs_perms'](path=name,
+                                                owner=win_owner,
+                                                grant_perms=win_perms,
+                                                deny_perms=win_deny_perms,
+                                                inheritance=win_inheritance)
             else:
-                __salt__["file.makedirs_perms"](
-                    name=name, user=user, group=group, mode=dir_mode
-                )
+                __salt__['file.makedirs_perms'](name=name,
+                                                user=user,
+                                                group=group,
+                                                mode=dir_mode)
 
     def add_comment(path, comment):
-        comments = ret["comment"].setdefault(path, [])
+        comments = ret['comment'].setdefault(path, [])
         if isinstance(comment, six.string_types):
             comments.append(comment)
         else:
@@ -4093,32 +3990,34 @@ def recurse(
 
     def merge_ret(path, _ret):
         # Use the most "negative" result code (out of True, None, False)
-        if _ret["result"] is False or ret["result"] is True:
-            ret["result"] = _ret["result"]
+        if _ret['result'] is False or ret['result'] is True:
+            ret['result'] = _ret['result']
 
         # Only include comments about files that changed
-        if _ret["result"] is not True and _ret["comment"]:
-            add_comment(path, _ret["comment"])
+        if _ret['result'] is not True and _ret['comment']:
+            add_comment(path, _ret['comment'])
 
-        if _ret["changes"]:
-            ret["changes"][path] = _ret["changes"]
+        if _ret['changes']:
+            ret['changes'][path] = _ret['changes']
 
     def manage_file(path, source, replace):
         if clean and os.path.exists(path) and os.path.isdir(path) and replace:
-            _ret = {"name": name, "changes": {}, "result": True, "comment": ""}
-            if __opts__["test"]:
-                _ret["comment"] = "Replacing directory {0} with a " "file".format(path)
-                _ret["result"] = None
+            _ret = {'name': name, 'changes': {}, 'result': True, 'comment': ''}
+            if __opts__['test']:
+                _ret['comment'] = 'Replacing directory {0} with a ' \
+                                  'file'.format(path)
+                _ret['result'] = None
                 merge_ret(path, _ret)
                 return
             else:
-                __salt__["file.remove"](path)
-                _ret["changes"] = {"diff": "Replaced directory with a " "new file"}
+                __salt__['file.remove'](path)
+                _ret['changes'] = {'diff': 'Replaced directory with a '
+                                           'new file'}
                 merge_ret(path, _ret)
 
         # Conflicts can occur if some kwargs are passed in here
         pass_kwargs = {}
-        faults = ["mode", "makedirs"]
+        faults = ['mode', 'makedirs']
         for key in kwargs:
             if key not in faults:
                 pass_kwargs[key] = kwargs[key]
@@ -4129,7 +4028,7 @@ def recurse(
             keep_source=keep_source,
             user=user,
             group=group,
-            mode="keep" if keep_mode else file_mode,
+            mode='keep' if keep_mode else file_mode,
             attrs=None,
             template=template,
             makedirs=True,
@@ -4137,23 +4036,22 @@ def recurse(
             context=context,
             defaults=defaults,
             backup=backup,
-            **pass_kwargs
-        )
+            **pass_kwargs)
         merge_ret(path, _ret)
 
     def manage_directory(path):
-        if os.path.basename(path) == "..":
+        if os.path.basename(path) == '..':
             return
         if clean and os.path.exists(path) and not os.path.isdir(path):
-            _ret = {"name": name, "changes": {}, "result": True, "comment": ""}
-            if __opts__["test"]:
-                _ret["comment"] = "Replacing {0} with a directory".format(path)
-                _ret["result"] = None
+            _ret = {'name': name, 'changes': {}, 'result': True, 'comment': ''}
+            if __opts__['test']:
+                _ret['comment'] = 'Replacing {0} with a directory'.format(path)
+                _ret['result'] = None
                 merge_ret(path, _ret)
                 return
             else:
-                __salt__["file.remove"](path)
-                _ret["changes"] = {"diff": "Replaced file with a directory"}
+                __salt__['file.remove'](path)
+                _ret['changes'] = {'diff': 'Replaced file with a directory'}
                 merge_ret(path, _ret)
 
         _ret = directory(
@@ -4165,24 +4063,26 @@ def recurse(
             file_mode=None,
             makedirs=True,
             clean=False,
-            require=None,
-        )
+            require=None)
         merge_ret(path, _ret)
 
     mng_files, mng_dirs, mng_symlinks, keep = _gen_recurse_managed_files(
-        name, source, keep_symlinks, include_pat, exclude_pat, maxdepth, include_empty
-    )
+        name,
+        source,
+        keep_symlinks,
+        include_pat,
+        exclude_pat,
+        maxdepth,
+        include_empty)
 
     for srelpath, ltarget in mng_symlinks:
-        _ret = symlink(
-            os.path.join(name, srelpath),
-            ltarget,
-            makedirs=True,
-            force=force_symlinks,
-            user=user,
-            group=group,
-            mode=sym_mode,
-        )
+        _ret = symlink(os.path.join(name, srelpath),
+                       ltarget,
+                       makedirs=True,
+                       force=force_symlinks,
+                       user=user,
+                       group=group,
+                       mode=sym_mode)
         if not _ret:
             continue
         merge_ret(os.path.join(name, srelpath), _ret)
@@ -4196,33 +4096,32 @@ def recurse(
         keep.update(_gen_keep_files(name, require))
         removed = _clean_dir(name, list(keep), exclude_pat)
         if removed:
-            if __opts__["test"]:
-                if ret["result"]:
-                    ret["result"] = None
-                add_comment("removed", removed)
+            if __opts__['test']:
+                if ret['result']:
+                    ret['result'] = None
+                add_comment('removed', removed)
             else:
-                ret["changes"]["removed"] = removed
+                ret['changes']['removed'] = removed
 
     # Flatten comments until salt command line client learns
     # to display structured comments in a readable fashion
-    ret["comment"] = "\n".join(
-        "\n#### {0} ####\n{1}".format(
-            k, v if isinstance(v, six.string_types) else "\n".join(v)
+    ret['comment'] = '\n'.join('\n#### {0} ####\n{1}'.format(
+        k, v if isinstance(v, six.string_types) else '\n'.join(v)
+    ) for (k, v) in six.iteritems(ret['comment'])).strip()
+
+    if not ret['comment']:
+        ret['comment'] = 'Recursively updated {0}'.format(name)
+
+    if not ret['changes'] and ret['result']:
+        ret['comment'] = 'The directory {0} is in the correct state'.format(
+            name
         )
-        for (k, v) in six.iteritems(ret["comment"])
-    ).strip()
-
-    if not ret["comment"]:
-        ret["comment"] = "Recursively updated {0}".format(name)
-
-    if not ret["changes"] and ret["result"]:
-        ret["comment"] = "The directory {0} is in the correct state".format(name)
 
     return ret
 
 
 def retention_schedule(name, retain, strptime_format=None, timezone=None):
-    """
+    '''
     Apply retention scheduling to backup storage directory.
 
     .. versionadded:: 2016.11.0
@@ -4284,21 +4183,19 @@ def retention_schedule(name, retain, strptime_format=None, timezone=None):
             - strptime_format: example_name_%Y%m%dT%H%M%S.tar.bz2
             - timezone: None
 
-    """
+    '''
     name = os.path.expanduser(name)
-    ret = {
-        "name": name,
-        "changes": {"retained": [], "deleted": [], "ignored": []},
-        "result": True,
-        "comment": "",
-    }
+    ret = {'name': name,
+           'changes': {'retained': [], 'deleted': [], 'ignored': []},
+           'result': True,
+           'comment': ''}
     if not name:
-        return _error(ret, "Must provide name to file.retention_schedule")
+        return _error(ret, 'Must provide name to file.retention_schedule')
     if not os.path.isdir(name):
-        return _error(ret, "Name provided to file.retention must be a directory")
+        return _error(ret, 'Name provided to file.retention must be a directory')
 
     # get list of files in directory
-    all_files = __salt__["file.readdir"](name)
+    all_files = __salt__['file.readdir'](name)
 
     # if strptime_format is set, filter through the list to find names which parse and get their datetimes.
     beginning_of_unix_time = datetime(1970, 1, 1)
@@ -4313,18 +4210,16 @@ def retention_schedule(name, retain, strptime_format=None, timezone=None):
             return (None, None)
 
     def get_file_time_from_mtime(f):
-        if f == "." or f == "..":
+        if f == '.' or f == '..':
             return (None, None)
-        lstat = __salt__["file.lstat"](os.path.join(name, f))
+        lstat = __salt__['file.lstat'](os.path.join(name, f))
         if lstat:
-            mtime = lstat["st_mtime"]
+            mtime = lstat['st_mtime']
             return (datetime.fromtimestamp(mtime, timezone), mtime)
-        else:  # maybe it was deleted since we did the readdir?
+        else:   # maybe it was deleted since we did the readdir?
             return (None, None)
 
-    get_file_time = (
-        get_file_time_from_strptime if strptime_format else get_file_time_from_mtime
-    )
+    get_file_time = get_file_time_from_strptime if strptime_format else get_file_time_from_mtime
 
     # data structures are nested dicts:
     # files_by_ymd = year.month.day.hour.unixtime: filename
@@ -4333,7 +4228,6 @@ def retention_schedule(name, retain, strptime_format=None, timezone=None):
     # TODO: move to an ordered dict model and reduce the number of sorts in the rest of the code?
     def dict_maker():
         return defaultdict(dict_maker)
-
     files_by_ymd = dict_maker()
     files_by_y_week_dow = dict_maker()
     relevant_files = set()
@@ -4350,11 +4244,11 @@ def retention_schedule(name, retain, strptime_format=None, timezone=None):
 
     # This is tightly coupled with the file_with_times data-structure above.
     RETAIN_TO_DEPTH = {
-        "first_of_year": 1,
-        "first_of_month": 2,
-        "first_of_day": 3,
-        "first_of_hour": 4,
-        "most_recent": 5,
+        'first_of_year': 1,
+        'first_of_month': 2,
+        'first_of_day': 3,
+        'first_of_hour': 4,
+        'most_recent': 5,
     }
 
     def get_first(fwt):
@@ -4362,7 +4256,7 @@ def retention_schedule(name, retain, strptime_format=None, timezone=None):
             first_sub_key = sorted(fwt.keys())[0]
             return get_first(fwt[first_sub_key])
         else:
-            return set([fwt])
+            return set([fwt, ])
 
     def get_first_n_at_depth(fwt, depth, n):
         if depth <= 0:
@@ -4382,64 +4276,47 @@ def retention_schedule(name, retain, strptime_format=None, timezone=None):
         # This is kind of a hack, since 'all' should really mean all,
         # but I think it's a large enough number that even modern filesystems would
         # choke if they had this many files in a single directory.
-        keep_count = sys.maxsize if "all" == keep_count else int(keep_count)
-        if "first_of_week" == retention_rule:
-            first_of_week_depth = 2  # year + week_of_year = 2
+        keep_count = sys.maxsize if 'all' == keep_count else int(keep_count)
+        if 'first_of_week' == retention_rule:
+            first_of_week_depth = 2   # year + week_of_year = 2
             # I'm adding 1 to keep_count below because it fixed an off-by one
             # issue in the tests. I don't understand why, and that bothers me.
-            retained_files |= get_first_n_at_depth(
-                files_by_y_week_dow, first_of_week_depth, keep_count + 1
-            )
+            retained_files |= get_first_n_at_depth(files_by_y_week_dow,
+                                                   first_of_week_depth,
+                                                   keep_count + 1)
         else:
-            retained_files |= get_first_n_at_depth(
-                files_by_ymd, RETAIN_TO_DEPTH[retention_rule], keep_count
-            )
+            retained_files |= get_first_n_at_depth(files_by_ymd,
+                                                   RETAIN_TO_DEPTH[retention_rule],
+                                                   keep_count)
 
     deletable_files = list(relevant_files - retained_files)
     deletable_files.sort(reverse=True)
     changes = {
-        "retained": sorted(list(retained_files), reverse=True),
-        "deleted": deletable_files,
-        "ignored": sorted(list(ignored_files), reverse=True),
-    }
-    ret["changes"] = changes
+            'retained': sorted(list(retained_files), reverse=True),
+            'deleted': deletable_files,
+            'ignored': sorted(list(ignored_files), reverse=True),
+        }
+    ret['changes'] = changes
 
     # TODO: track and report how much space was / would be reclaimed
-    if __opts__["test"]:
-        ret["comment"] = "{0} backups would have been removed from {1}.\n".format(
-            len(deletable_files), name
-        )
+    if __opts__['test']:
+        ret['comment'] = '{0} backups would have been removed from {1}.\n'.format(len(deletable_files), name)
         if deletable_files:
-            ret["result"] = None
+            ret['result'] = None
     else:
         for f in deletable_files:
-            __salt__["file.remove"](os.path.join(name, f))
-        ret["comment"] = "{0} backups were removed from {1}.\n".format(
-            len(deletable_files), name
-        )
-        ret["changes"] = changes
+            __salt__['file.remove'](os.path.join(name, f))
+        ret['comment'] = '{0} backups were removed from {1}.\n'.format(len(deletable_files), name)
+        ret['changes'] = changes
 
     return ret
 
 
-def line(
-    name,
-    content=None,
-    match=None,
-    mode=None,
-    location=None,
-    before=None,
-    after=None,
-    show_changes=True,
-    backup=False,
-    quiet=False,
-    indent=True,
-    create=False,
-    user=None,
-    group=None,
-    file_mode=None,
-):
-    """
+def line(name, content=None, match=None, mode=None, location=None,
+         before=None, after=None, show_changes=True, backup=False,
+         quiet=False, indent=True, create=False, user=None,
+         group=None, file_mode=None):
+    '''
     Line-based editing of a file.
 
     .. versionadded:: 2015.8.0
@@ -4556,13 +4433,22 @@ def line(
            - content: my key = my value
            - before: somekey.*?
 
-    """
+    '''
     name = os.path.expanduser(name)
-    ret = {"name": name, "changes": {}, "result": True, "comment": ""}
+    ret = {'name': name,
+           'changes': {},
+           'result': True,
+           'comment': ''}
     if not name:
-        return _error(ret, "Must provide name to file.line")
+        return _error(ret, 'Must provide name to file.line')
 
-    managed(name, create=create, user=user, group=group, mode=file_mode, replace=False)
+    managed(
+        name,
+        create=create,
+        user=user,
+        group=group,
+        mode=file_mode,
+        replace=False)
 
     check_res, check_msg = _check_file(name)
     if not check_res:
@@ -4572,60 +4458,46 @@ def line(
     # it gets passed when needed. Feature #37092
     mode = mode and mode.lower() or mode
     if mode is None:
-        return _error(ret, "Mode was not defined. How to process the file?")
+        return _error(ret, 'Mode was not defined. How to process the file?')
 
-    modeswithemptycontent = ["delete"]
+    modeswithemptycontent = ['delete']
     if mode not in modeswithemptycontent and content is None:
-        return _error(
-            ret,
-            "Content can only be empty if mode is {0}".format(modeswithemptycontent),
-        )
+        return _error(ret, 'Content can only be empty if mode is {0}'.format(modeswithemptycontent))
     del modeswithemptycontent
 
-    changes = __salt__["file.line"](
-        name,
-        content,
-        match=match,
-        mode=mode,
-        location=location,
-        before=before,
-        after=after,
-        show_changes=show_changes,
-        backup=backup,
-        quiet=quiet,
-        indent=indent,
-    )
+    changes = __salt__['file.line'](
+        name, content, match=match, mode=mode, location=location,
+        before=before, after=after, show_changes=show_changes,
+        backup=backup, quiet=quiet, indent=indent)
     if changes:
-        ret["changes"]["diff"] = changes
-        if __opts__["test"]:
-            ret["result"] = None
-            ret["comment"] = "Changes would be made"
+        ret['changes']['diff'] = changes
+        if __opts__['test']:
+            ret['result'] = None
+            ret['comment'] = 'Changes would be made'
         else:
-            ret["result"] = True
-            ret["comment"] = "Changes were made"
+            ret['result'] = True
+            ret['comment'] = 'Changes were made'
     else:
-        ret["result"] = True
-        ret["comment"] = "No changes needed to be made"
+        ret['result'] = True
+        ret['comment'] = 'No changes needed to be made'
 
     return ret
 
 
-def replace(
-    name,
-    pattern,
-    repl,
-    count=0,
-    flags=8,
-    bufsize=1,
-    append_if_not_found=False,
-    prepend_if_not_found=False,
-    not_found_content=None,
-    backup=".bak",
-    show_changes=True,
-    ignore_if_missing=False,
-    backslash_literal=False,
-):
-    r"""
+def replace(name,
+            pattern,
+            repl,
+            count=0,
+            flags=8,
+            bufsize=1,
+            append_if_not_found=False,
+            prepend_if_not_found=False,
+            not_found_content=None,
+            backup='.bak',
+            show_changes=True,
+            ignore_if_missing=False,
+            backslash_literal=False):
+    r'''
     Maintain an edit in a file.
 
     .. versionadded:: 0.17.0
@@ -4765,70 +4637,70 @@ def replace(
 
        The ``file.replace`` state uses Python's ``re`` module.
        For more advanced options, see https://docs.python.org/2/library/re.html
-    """
+    '''
     name = os.path.expanduser(name)
 
-    ret = {"name": name, "changes": {}, "result": True, "comment": ""}
+    ret = {'name': name,
+           'changes': {},
+           'result': True,
+           'comment': ''}
     if not name:
-        return _error(ret, "Must provide name to file.replace")
+        return _error(ret, 'Must provide name to file.replace')
 
     check_res, check_msg = _check_file(name)
     if not check_res:
-        if ignore_if_missing and "file not found" in check_msg:
-            ret["comment"] = "No changes needed to be made"
+        if ignore_if_missing and 'file not found' in check_msg:
+            ret['comment'] = 'No changes needed to be made'
             return ret
         else:
             return _error(ret, check_msg)
 
-    changes = __salt__["file.replace"](
-        name,
-        pattern,
-        repl,
-        count=count,
-        flags=flags,
-        bufsize=bufsize,
-        append_if_not_found=append_if_not_found,
-        prepend_if_not_found=prepend_if_not_found,
-        not_found_content=not_found_content,
-        backup=backup,
-        dry_run=__opts__["test"],
-        show_changes=show_changes,
-        ignore_if_missing=ignore_if_missing,
-        backslash_literal=backslash_literal,
-    )
+    changes = __salt__['file.replace'](name,
+                                       pattern,
+                                       repl,
+                                       count=count,
+                                       flags=flags,
+                                       bufsize=bufsize,
+                                       append_if_not_found=append_if_not_found,
+                                       prepend_if_not_found=prepend_if_not_found,
+                                       not_found_content=not_found_content,
+                                       backup=backup,
+                                       dry_run=__opts__['test'],
+                                       show_changes=show_changes,
+                                       ignore_if_missing=ignore_if_missing,
+                                       backslash_literal=backslash_literal)
 
     if changes:
-        ret["changes"]["diff"] = changes
-        if __opts__["test"]:
-            ret["result"] = None
-            ret["comment"] = "Changes would have been made"
+        ret['changes']['diff'] = changes
+        if __opts__['test']:
+            ret['result'] = None
+            ret['comment'] = 'Changes would have been made'
         else:
-            ret["result"] = True
-            ret["comment"] = "Changes were made"
+            ret['result'] = True
+            ret['comment'] = 'Changes were made'
     else:
-        ret["result"] = True
-        ret["comment"] = "No changes needed to be made"
+        ret['result'] = True
+        ret['comment'] = 'No changes needed to be made'
 
     return ret
 
 
 def keyvalue(
-    name,
-    key=None,
-    value=None,
-    key_values=None,
-    separator="=",
-    append_if_not_found=False,
-    prepend_if_not_found=False,
-    search_only=False,
-    show_changes=True,
-    ignore_if_missing=False,
-    count=1,
-    uncomment=None,
-    key_ignore_case=False,
-    value_ignore_case=False,
-):
-    """
+        name,
+        key=None,
+        value=None,
+        key_values=None,
+        separator="=",
+        append_if_not_found=False,
+        prepend_if_not_found=False,
+        search_only=False,
+        show_changes=True,
+        ignore_if_missing=False,
+        count=1,
+        uncomment=None,
+        key_ignore_case=False,
+        value_ignore_case=False):
+    '''
     Key/Value based editing of a file.
 
     .. versionadded:: Neon
@@ -4938,34 +4810,38 @@ def keyvalue(
         Notice how the key is not matched case-sensitively, this way it will
         correctly identify both 'PermitRootLogin' as well as 'permitrootlogin'.
 
-    """
+    '''
     name = os.path.expanduser(name)
 
     # default return values
-    ret = {"name": name, "changes": {}, "pchanges": {}, "result": None, "comment": ""}
+    ret = {
+        'name': name,
+        'changes': {},
+        'pchanges': {},
+        'result': None,
+        'comment': '',
+        }
 
     if not name:
-        return _error(ret, "Must provide name to file.keyvalue")
+        return _error(ret, 'Must provide name to file.keyvalue')
     if key is not None and value is not None:
         if isinstance(key_values, dict):
-            return _error(
-                ret, "file.keyvalue can not combine key_values with key and value"
-            )
+            return _error(ret,
+                    'file.keyvalue can not combine key_values with key and value')
         key_values = {str(key): value}
     elif not isinstance(key_values, dict):
-        return _error(
-            ret, "file.keyvalue key and value not supplied and key_values empty"
-        )
+        return _error(ret,
+                'file.keyvalue key and value not supplied and key_values empty')
 
     # try to open the file and only return a comment if ignore_if_missing is
     # enabled, also mark as an error if not
     file_contents = []
     try:
-        with salt.utils.files.fopen(name, "r") as fd:
+        with salt.utils.files.fopen(name, 'r') as fd:
             file_contents = fd.readlines()
     except (OSError, IOError):
-        ret["comment"] = "unable to open {n}".format(n=name)
-        ret["result"] = True if ignore_if_missing else False
+        ret['comment'] = 'unable to open {n}'.format(n=name)
+        ret['result'] = True if ignore_if_missing else False
         return ret
 
     # used to store diff combinations and check if anything has changed
@@ -4973,7 +4849,7 @@ def keyvalue(
     # store the final content of the file in case it needs to be rewritten
     content = []
     # target format is templated like this
-    tmpl = "{key}{sep}{value}" + os.linesep
+    tmpl = '{key}{sep}{value}'+os.linesep
     # number of lines changed
     changes = 0
     # keep track of number of times a key was updated
@@ -5053,7 +4929,7 @@ def keyvalue(
                         # the old line always needs to go, so that will be
                         # reflected in the diff (this is the original line from
                         # the file being read)
-                        diff.append("- {0}".format(line))
+                        diff.append('- {0}'.format(line))
                         line = line[:0]
 
                         # any non-zero value means something needs to go back in
@@ -5063,20 +4939,19 @@ def keyvalue(
                         if diff_count[key] != 0:
                             # rebuild the line using the key and separator found
                             # and insert the correct value.
-                            line = str(
-                                tmpl.format(key=line_key, sep=line_sep, value=value)
-                            )
+                            line = str(tmpl.format(key=line_key,
+                                                   sep=line_sep,
+                                                   value=value))
 
                             # display a comment in case a value got converted
                             # into a string
                             if not isinstance(value, str):
-                                diff.append(
-                                    "+ {0} (from {1} type){2}".format(
-                                        line.rstrip(), type(value).__name__, os.linesep
-                                    )
-                                )
+                                diff.append('+ {0} (from {1} type){2}'.format(
+                                    line.rstrip(),
+                                    type(value).__name__,
+                                    os.linesep))
                             else:
-                                diff.append("+ {0}".format(line))
+                                diff.append('+ {0}'.format(line))
                         changes += 1
                     # subtract one from the count if it was larger than 0, so
                     # next lines are removed. if it is less than 0 then count is
@@ -5085,7 +4960,7 @@ def keyvalue(
                         diff_count[key] -= 1
                     # at this point a continue saves going through the rest of
                     # the keys to see if they match since this line already
-                    # matched the current key
+                    #matched the current key
                     continue
         # with the line having been checked for all keys (or matched before all
         # keys needed searching), the line can be added to the content to be
@@ -5101,12 +4976,12 @@ def keyvalue(
         for key, value in key_values.items():
             if diff_count[key] > 0:
                 line = tmpl.format(key=key, sep=separator, value=value)
-                tmpdiff.append("+ {0}".format(line))
+                tmpdiff.append('+ {0}'.format(line))
                 content.append(line)
                 changes += 1
         if tmpdiff:
-            tmpdiff.insert(0, "- <EOF>" + os.linesep)
-            tmpdiff.append("+ <EOF>" + os.linesep)
+            tmpdiff.insert(0, '- <EOF>'+os.linesep)
+            tmpdiff.append('+ <EOF>'+os.linesep)
             diff.extend(tmpdiff)
     # only if append_if_not_found was not set should prepend_if_not_found be
     # considered, benefit of this is that the number of counts left does not
@@ -5117,80 +4992,79 @@ def keyvalue(
             if diff_count[key] > 0:
                 line = tmpl.format(key=key, sep=separator, value=value)
                 if not did_diff:
-                    diff.insert(0, "  <SOF>" + os.linesep)
+                    diff.insert(0, '  <SOF>'+os.linesep)
                     did_diff = True
-                diff.insert(1, "+ {0}".format(line))
+                diff.insert(1, '+ {0}'.format(line))
                 content.insert(0, line)
                 changes += 1
 
     # if a diff was made
     if changes > 0:
         # return comment of changes if test
-        if __opts__["test"]:
-            ret["comment"] = "File {n} is set to be changed ({c} lines)".format(
-                n=name, c=changes
-            )
+        if __opts__['test']:
+            ret['comment'] = 'File {n} is set to be changed ({c} lines)'.format(
+                n=name,
+                c=changes)
             if show_changes:
                 # For some reason, giving an actual diff even in test=True mode
                 # will be seen as both a 'changed' and 'unchanged'. this seems to
                 # match the other modules behaviour though
-                ret["pchanges"]["diff"] = "".join(diff)
+                ret['pchanges']['diff'] = ''.join(diff)
 
                 # add changes to comments for now as well because of how
                 # stateoutputter seems to handle pchanges etc.
                 # See: https://github.com/saltstack/salt/issues/40208
-                ret["comment"] += "\nPredicted diff:\n\r\t\t"
-                ret["comment"] += "\r\t\t".join(diff)
-                ret["result"] = None
+                ret['comment'] += '\nPredicted diff:\n\r\t\t'
+                ret['comment'] += '\r\t\t'.join(diff)
+                ret['result'] = None
 
         # otherwise return the actual diff lines
         else:
-            ret["comment"] = "Changed {c} lines".format(c=changes)
+            ret['comment'] = 'Changed {c} lines'.format(c=changes)
             if show_changes:
-                ret["changes"]["diff"] = "".join(diff)
+                ret['changes']['diff'] = ''.join(diff)
     else:
-        ret["result"] = True
+        ret['result'] = True
         return ret
 
     # if not test=true, try and write the file
-    if not __opts__["test"]:
+    if not __opts__['test']:
         try:
-            with salt.utils.files.fopen(name, "w") as fd:
+            with salt.utils.files.fopen(name, 'w') as fd:
                 # write all lines to the file which was just truncated
                 fd.writelines(content)
                 fd.close()
         except (OSError, IOError):
             # return an error if the file was not writable
-            ret["comment"] = "{n} not writable".format(n=name)
-            ret["result"] = False
+            ret['comment'] = '{n} not writable'.format(n=name)
+            ret['result'] = False
             return ret
         # if all went well, then set result to true
-        ret["result"] = True
+        ret['result'] = True
 
     return ret
 
 
 def blockreplace(
-    name,
-    marker_start="#-- start managed zone --",
-    marker_end="#-- end managed zone --",
-    source=None,
-    source_hash=None,
-    template="jinja",
-    sources=None,
-    source_hashes=None,
-    defaults=None,
-    context=None,
-    content="",
-    append_if_not_found=False,
-    prepend_if_not_found=False,
-    backup=".bak",
-    show_changes=True,
-    append_newline=None,
-    insert_before_match=None,
-    insert_after_match=None,
-):
-    """
+        name,
+        marker_start='#-- start managed zone --',
+        marker_end='#-- end managed zone --',
+        source=None,
+        source_hash=None,
+        template='jinja',
+        sources=None,
+        source_hashes=None,
+        defaults=None,
+        context=None,
+        content='',
+        append_if_not_found=False,
+        prepend_if_not_found=False,
+        backup='.bak',
+        show_changes=True,
+        append_newline=None,
+        insert_before_match=None,
+        insert_after_match=None):
+    '''
     Maintain an edit in a file in a zone delimited by two line markers
 
     .. versionadded:: 2014.1.0
@@ -5394,24 +5268,25 @@ def blockreplace(
         text 3
         text 4
         # END managed zone 42 --
-    """
+    '''
     name = os.path.expanduser(name)
 
-    ret = {"name": name, "changes": {}, "result": False, "comment": ""}
+    ret = {'name': name,
+           'changes': {},
+           'result': False,
+           'comment': ''}
     if not name:
-        return _error(ret, "Must provide name to file.blockreplace")
+        return _error(ret, 'Must provide name to file.blockreplace')
 
     if sources is None:
         sources = []
     if source_hashes is None:
         source_hashes = []
 
-    (ok_, err, sl_) = _unify_sources_and_hashes(
-        source=source,
-        source_hash=source_hash,
-        sources=sources,
-        source_hashes=source_hashes,
-    )
+    (ok_, err, sl_) = _unify_sources_and_hashes(source=source,
+                                                source_hash=source_hash,
+                                                sources=sources,
+                                                source_hashes=source_hashes)
     if not ok_:
         return _error(ret, err)
 
@@ -5425,32 +5300,32 @@ def blockreplace(
         # if we have multiple accumulators for a file, only apply the one
         # required at a time
         deps = accum_deps.get(name, [])
-        filtered = [
-            a for a in deps if __low__["__id__"] in deps[a] and a in accumulator
-        ]
+        filtered = [a for a in deps if
+                    __low__['__id__'] in deps[a] and a in accumulator]
         if not filtered:
             filtered = [a for a in accumulator]
         for acc in filtered:
             acc_content = accumulator[acc]
             for line in acc_content:
-                if content == "":
+                if content == '':
                     content = line
                 else:
                     content += "\n" + line
 
     if sl_:
-        tmpret = _get_template_texts(
-            source_list=sl_, template=template, defaults=defaults, context=context
-        )
-        if not tmpret["result"]:
+        tmpret = _get_template_texts(source_list=sl_,
+                                     template=template,
+                                     defaults=defaults,
+                                     context=context)
+        if not tmpret['result']:
             return tmpret
-        text = tmpret["data"]
+        text = tmpret['data']
 
         for index, item in enumerate(text):
             content += six.text_type(item)
 
     try:
-        changes = __salt__["file.blockreplace"](
+        changes = __salt__['file.blockreplace'](
             name,
             marker_start,
             marker_end,
@@ -5460,35 +5335,34 @@ def blockreplace(
             insert_before_match=insert_before_match,
             insert_after_match=insert_after_match,
             backup=backup,
-            dry_run=__opts__["test"],
+            dry_run=__opts__['test'],
             show_changes=show_changes,
-            append_newline=append_newline,
-        )
+            append_newline=append_newline)
     except Exception as exc:
-        log.exception("Encountered error managing block")
-        ret["comment"] = (
-            "Encountered error managing block: {0}. "
-            "See the log for details.".format(exc)
+        log.exception('Encountered error managing block')
+        ret['comment'] = (
+            'Encountered error managing block: {0}. '
+            'See the log for details.'.format(exc)
         )
         return ret
 
     if changes:
-        ret["changes"]["diff"] = changes
-        if __opts__["test"]:
-            ret["result"] = None
-            ret["comment"] = "Changes would be made"
+        ret['changes']['diff'] = changes
+        if __opts__['test']:
+            ret['result'] = None
+            ret['comment'] = 'Changes would be made'
         else:
-            ret["result"] = True
-            ret["comment"] = "Changes were made"
+            ret['result'] = True
+            ret['comment'] = 'Changes were made'
     else:
-        ret["result"] = True
-        ret["comment"] = "No changes needed to be made"
+        ret['result'] = True
+        ret['comment'] = 'No changes needed to be made'
 
     return ret
 
 
-def comment(name, regex, char="#", backup=".bak"):
-    """
+def comment(name, regex, char='#', backup='.bak'):
+    '''
     Comment out specified lines in a file.
 
     name
@@ -5523,71 +5397,76 @@ def comment(name, regex, char="#", backup=".bak"):
             - regex: ^bind 127.0.0.1
 
     .. versionadded:: 0.9.5
-    """
+    '''
     name = os.path.expanduser(name)
 
-    ret = {"name": name, "changes": {}, "result": False, "comment": ""}
+    ret = {'name': name,
+           'changes': {},
+           'result': False,
+           'comment': ''}
     if not name:
-        return _error(ret, "Must provide name to file.comment")
+        return _error(ret, 'Must provide name to file.comment')
 
     check_res, check_msg = _check_file(name)
     if not check_res:
         return _error(ret, check_msg)
 
     # remove (?i)-like flags, ^ and $
-    unanchor_regex = re.sub(r"^(\(\?[iLmsux]\))?\^?(.*?)\$?$", r"\2", regex)
+    unanchor_regex = re.sub(r'^(\(\?[iLmsux]\))?\^?(.*?)\$?$', r'\2', regex)
 
     comment_regex = char + unanchor_regex
 
     # Make sure the pattern appears in the file before continuing
-    if not __salt__["file.search"](name, regex, multiline=True):
-        if __salt__["file.search"](name, comment_regex, multiline=True):
-            ret["comment"] = "Pattern already commented"
-            ret["result"] = True
+    if not __salt__['file.search'](name, regex, multiline=True):
+        if __salt__['file.search'](name, comment_regex, multiline=True):
+            ret['comment'] = 'Pattern already commented'
+            ret['result'] = True
             return ret
         else:
-            return _error(ret, "{0}: Pattern not found".format(unanchor_regex))
+            return _error(ret, '{0}: Pattern not found'.format(unanchor_regex))
 
-    if __opts__["test"]:
-        ret["changes"][name] = "updated"
-        ret["comment"] = "File {0} is set to be updated".format(name)
-        ret["result"] = None
+    if __opts__['test']:
+        ret['changes'][name] = 'updated'
+        ret['comment'] = 'File {0} is set to be updated'.format(name)
+        ret['result'] = None
         return ret
-    with salt.utils.files.fopen(name, "rb") as fp_:
+    with salt.utils.files.fopen(name, 'rb') as fp_:
         slines = fp_.read()
         if six.PY3:
             slines = slines.decode(__salt_system_encoding__)
         slines = slines.splitlines(True)
 
     # Perform the edit
-    __salt__["file.comment_line"](name, regex, char, True, backup)
+    __salt__['file.comment_line'](name, regex, char, True, backup)
 
-    with salt.utils.files.fopen(name, "rb") as fp_:
+    with salt.utils.files.fopen(name, 'rb') as fp_:
         nlines = fp_.read()
         if six.PY3:
             nlines = nlines.decode(__salt_system_encoding__)
         nlines = nlines.splitlines(True)
 
     # Check the result
-    ret["result"] = __salt__["file.search"](name, unanchor_regex, multiline=True)
+    ret['result'] = __salt__['file.search'](name, unanchor_regex, multiline=True)
 
     if slines != nlines:
-        if not __utils__["files.is_text"](name):
-            ret["changes"]["diff"] = "Replace binary file"
+        if not __utils__['files.is_text'](name):
+            ret['changes']['diff'] = 'Replace binary file'
         else:
             # Changes happened, add them
-            ret["changes"]["diff"] = "".join(difflib.unified_diff(slines, nlines))
+            ret['changes']['diff'] = (
+                ''.join(difflib.unified_diff(slines, nlines))
+            )
 
-    if ret["result"]:
-        ret["comment"] = "Commented lines successfully"
+    if ret['result']:
+        ret['comment'] = 'Commented lines successfully'
     else:
-        ret["comment"] = "Expected commented lines not found"
+        ret['comment'] = 'Expected commented lines not found'
 
     return ret
 
 
-def uncomment(name, regex, char="#", backup=".bak"):
-    """
+def uncomment(name, regex, char='#', backup='.bak'):
+    '''
     Uncomment specified commented lines in a file
 
     name
@@ -5621,81 +5500,88 @@ def uncomment(name, regex, char="#", backup=".bak"):
             - regex: EXTRA_GROUPS
 
     .. versionadded:: 0.9.5
-    """
+    '''
     name = os.path.expanduser(name)
 
-    ret = {"name": name, "changes": {}, "result": False, "comment": ""}
+    ret = {'name': name,
+           'changes': {},
+           'result': False,
+           'comment': ''}
     if not name:
-        return _error(ret, "Must provide name to file.uncomment")
+        return _error(ret, 'Must provide name to file.uncomment')
 
     check_res, check_msg = _check_file(name)
     if not check_res:
         return _error(ret, check_msg)
 
     # Make sure the pattern appears in the file
-    if __salt__["file.search"](
-        name, "{0}[ \t]*{1}".format(char, regex.lstrip("^")), multiline=True
-    ):
+    if __salt__['file.search'](
+            name,
+            '{0}[ \t]*{1}'.format(char, regex.lstrip('^')),
+            multiline=True):
         # Line exists and is commented
         pass
-    elif __salt__["file.search"](
-        name, "^[ \t]*{0}".format(regex.lstrip("^")), multiline=True
-    ):
-        ret["comment"] = "Pattern already uncommented"
-        ret["result"] = True
+    elif __salt__['file.search'](
+            name,
+            '^[ \t]*{0}'.format(regex.lstrip('^')),
+            multiline=True):
+        ret['comment'] = 'Pattern already uncommented'
+        ret['result'] = True
         return ret
     else:
-        return _error(ret, "{0}: Pattern not found".format(regex))
+        return _error(ret, '{0}: Pattern not found'.format(regex))
 
-    if __opts__["test"]:
-        ret["changes"][name] = "updated"
-        ret["comment"] = "File {0} is set to be updated".format(name)
-        ret["result"] = None
+    if __opts__['test']:
+        ret['changes'][name] = 'updated'
+        ret['comment'] = 'File {0} is set to be updated'.format(name)
+        ret['result'] = None
         return ret
 
-    with salt.utils.files.fopen(name, "rb") as fp_:
+    with salt.utils.files.fopen(name, 'rb') as fp_:
         slines = salt.utils.data.decode(fp_.readlines())
 
     # Perform the edit
-    __salt__["file.comment_line"](name, regex, char, False, backup)
+    __salt__['file.comment_line'](name, regex, char, False, backup)
 
-    with salt.utils.files.fopen(name, "rb") as fp_:
+    with salt.utils.files.fopen(name, 'rb') as fp_:
         nlines = salt.utils.data.decode(fp_.readlines())
 
     # Check the result
-    ret["result"] = __salt__["file.search"](
-        name, "^[ \t]*{0}".format(regex.lstrip("^")), multiline=True
+    ret['result'] = __salt__['file.search'](
+        name,
+        '^[ \t]*{0}'.format(regex.lstrip('^')),
+        multiline=True
     )
 
     if slines != nlines:
-        if not __utils__["files.is_text"](name):
-            ret["changes"]["diff"] = "Replace binary file"
+        if not __utils__['files.is_text'](name):
+            ret['changes']['diff'] = 'Replace binary file'
         else:
             # Changes happened, add them
-            ret["changes"]["diff"] = "".join(difflib.unified_diff(slines, nlines))
+            ret['changes']['diff'] = (
+                ''.join(difflib.unified_diff(slines, nlines))
+            )
 
-    if ret["result"]:
-        ret["comment"] = "Uncommented lines successfully"
+    if ret['result']:
+        ret['comment'] = 'Uncommented lines successfully'
     else:
-        ret["comment"] = "Expected uncommented lines not found"
+        ret['comment'] = 'Expected uncommented lines not found'
 
     return ret
 
 
-def append(
-    name,
-    text=None,
-    makedirs=False,
-    source=None,
-    source_hash=None,
-    template="jinja",
-    sources=None,
-    source_hashes=None,
-    defaults=None,
-    context=None,
-    ignore_whitespace=True,
-):
-    """
+def append(name,
+           text=None,
+           makedirs=False,
+           source=None,
+           source_hash=None,
+           template='jinja',
+           sources=None,
+           source_hashes=None,
+           defaults=None,
+           context=None,
+           ignore_whitespace=True):
+    '''
     Ensure that some text appears at the end of a file.
 
     The text will not be appended if it already exists in the file.
@@ -5820,11 +5706,14 @@ def append(
               - salt://motd/general-messages.tmpl
 
     .. versionadded:: 0.9.5
-    """
-    ret = {"name": name, "changes": {}, "result": False, "comment": ""}
+    '''
+    ret = {'name': name,
+           'changes': {},
+           'result': False,
+           'comment': ''}
 
     if not name:
-        return _error(ret, "Must provide name to file.append")
+        return _error(ret, 'Must provide name to file.append')
 
     name = os.path.expanduser(name)
 
@@ -5837,42 +5726,38 @@ def append(
     # Add sources and source_hashes with template support
     # NOTE: FIX 'text' and any 'source' are mutually exclusive as 'text'
     #       is re-assigned in the original code.
-    (ok_, err, sl_) = _unify_sources_and_hashes(
-        source=source,
-        source_hash=source_hash,
-        sources=sources,
-        source_hashes=source_hashes,
-    )
+    (ok_, err, sl_) = _unify_sources_and_hashes(source=source,
+                                                source_hash=source_hash,
+                                                sources=sources,
+                                                source_hashes=source_hashes)
     if not ok_:
         return _error(ret, err)
 
     if makedirs is True:
         dirname = os.path.dirname(name)
-        if __opts__["test"]:
-            ret["comment"] = "Directory {0} is set to be updated".format(dirname)
-            ret["result"] = None
+        if __opts__['test']:
+            ret['comment'] = 'Directory {0} is set to be updated'.format(dirname)
+            ret['result'] = None
         else:
-            if not __salt__["file.directory_exists"](dirname):
+            if not __salt__['file.directory_exists'](dirname):
                 try:
                     _makedirs(name=name)
                 except CommandExecutionError as exc:
-                    return _error(ret, "Drive {0} is not mapped".format(exc.message))
+                    return _error(ret, 'Drive {0} is not mapped'.format(exc.message))
 
-                check_res, check_msg, check_changes = (
-                    _check_directory_win(dirname)
-                    if salt.utils.platform.is_windows()
+                check_res, check_msg, check_changes = _check_directory_win(dirname) \
+                    if salt.utils.platform.is_windows() \
                     else _check_directory(dirname)
-                )
 
                 if not check_res:
-                    ret["changes"] = check_changes
+                    ret['changes'] = check_changes
                     return _error(ret, check_msg)
 
     check_res, check_msg = _check_file(name)
     if not check_res:
         # Try to create the file
         touch_ret = touch(name, makedirs=makedirs)
-        if __opts__["test"]:
+        if __opts__['test']:
             return touch_ret
         retry_res, retry_msg = _check_file(name)
         if not retry_res:
@@ -5880,16 +5765,17 @@ def append(
 
     # Follow the original logic and re-assign 'text' if using source(s)...
     if sl_:
-        tmpret = _get_template_texts(
-            source_list=sl_, template=template, defaults=defaults, context=context
-        )
-        if not tmpret["result"]:
+        tmpret = _get_template_texts(source_list=sl_,
+                                     template=template,
+                                     defaults=defaults,
+                                     context=context)
+        if not tmpret['result']:
             return tmpret
-        text = tmpret["data"]
+        text = tmpret['data']
 
     text = _validate_str_list(text)
 
-    with salt.utils.files.fopen(name, "rb") as fp_:
+    with salt.utils.files.fopen(name, 'rb') as fp_:
         slines = fp_.read()
         if six.PY3:
             slines = slines.decode(__salt_system_encoding__)
@@ -5899,75 +5785,78 @@ def append(
     try:
         for chunk in text:
             if ignore_whitespace:
-                if __salt__["file.search"](
-                    name,
-                    salt.utils.stringutils.build_whitespace_split_regex(chunk),
-                    multiline=True,
-                ):
+                if __salt__['file.search'](
+                        name,
+                        salt.utils.stringutils.build_whitespace_split_regex(chunk),
+                        multiline=True):
                     continue
-            elif __salt__["file.search"](name, chunk, multiline=True):
+            elif __salt__['file.search'](
+                    name,
+                    chunk,
+                    multiline=True):
                 continue
 
             for line_item in chunk.splitlines():
-                append_lines.append("{0}".format(line_item))
+                append_lines.append('{0}'.format(line_item))
 
     except TypeError:
-        return _error(ret, "No text found to append. Nothing appended")
+        return _error(ret, 'No text found to append. Nothing appended')
 
-    if __opts__["test"]:
-        ret["comment"] = "File {0} is set to be updated".format(name)
-        ret["result"] = None
+    if __opts__['test']:
+        ret['comment'] = 'File {0} is set to be updated'.format(name)
+        ret['result'] = None
         nlines = list(slines)
         nlines.extend(append_lines)
         if slines != nlines:
-            if not __utils__["files.is_text"](name):
-                ret["changes"]["diff"] = "Replace binary file"
+            if not __utils__['files.is_text'](name):
+                ret['changes']['diff'] = 'Replace binary file'
             else:
                 # Changes happened, add them
-                ret["changes"]["diff"] = "\n".join(difflib.unified_diff(slines, nlines))
+                ret['changes']['diff'] = (
+                    '\n'.join(difflib.unified_diff(slines, nlines))
+                )
         else:
-            ret["comment"] = "File {0} is in correct state".format(name)
-            ret["result"] = True
+            ret['comment'] = 'File {0} is in correct state'.format(name)
+            ret['result'] = True
         return ret
 
     if append_lines:
-        __salt__["file.append"](name, args=append_lines)
-        ret["comment"] = "Appended {0} lines".format(len(append_lines))
+        __salt__['file.append'](name, args=append_lines)
+        ret['comment'] = 'Appended {0} lines'.format(len(append_lines))
     else:
-        ret["comment"] = "File {0} is in correct state".format(name)
+        ret['comment'] = 'File {0} is in correct state'.format(name)
 
-    with salt.utils.files.fopen(name, "rb") as fp_:
+    with salt.utils.files.fopen(name, 'rb') as fp_:
         nlines = fp_.read()
         if six.PY3:
             nlines = nlines.decode(__salt_system_encoding__)
         nlines = nlines.splitlines()
 
     if slines != nlines:
-        if not __utils__["files.is_text"](name):
-            ret["changes"]["diff"] = "Replace binary file"
+        if not __utils__['files.is_text'](name):
+            ret['changes']['diff'] = 'Replace binary file'
         else:
             # Changes happened, add them
-            ret["changes"]["diff"] = "\n".join(difflib.unified_diff(slines, nlines))
+            ret['changes']['diff'] = (
+                '\n'.join(difflib.unified_diff(slines, nlines)))
 
-    ret["result"] = True
+    ret['result'] = True
 
     return ret
 
 
-def prepend(
-    name,
-    text=None,
-    makedirs=False,
-    source=None,
-    source_hash=None,
-    template="jinja",
-    sources=None,
-    source_hashes=None,
-    defaults=None,
-    context=None,
-    header=None,
-):
-    """
+def prepend(name,
+            text=None,
+            makedirs=False,
+            source=None,
+            source_hash=None,
+            template='jinja',
+            sources=None,
+            source_hashes=None,
+            defaults=None,
+            context=None,
+            header=None):
+    '''
     Ensure that some text appears at the beginning of a file
 
     The text will not be prepended again if it already exists in the file. You
@@ -6105,12 +5994,15 @@ def prepend(
               - salt://motd/general-messages.tmpl
 
     .. versionadded:: 2014.7.0
-    """
+    '''
     name = os.path.expanduser(name)
 
-    ret = {"name": name, "changes": {}, "result": False, "comment": ""}
+    ret = {'name': name,
+           'changes': {},
+           'result': False,
+           'comment': ''}
     if not name:
-        return _error(ret, "Must provide name to file.prepend")
+        return _error(ret, 'Must provide name to file.prepend')
 
     if sources is None:
         sources = []
@@ -6121,38 +6013,34 @@ def prepend(
     # Add sources and source_hashes with template support
     # NOTE: FIX 'text' and any 'source' are mutually exclusive as 'text'
     #       is re-assigned in the original code.
-    (ok_, err, sl_) = _unify_sources_and_hashes(
-        source=source,
-        source_hash=source_hash,
-        sources=sources,
-        source_hashes=source_hashes,
-    )
+    (ok_, err, sl_) = _unify_sources_and_hashes(source=source,
+                                                source_hash=source_hash,
+                                                sources=sources,
+                                                source_hashes=source_hashes)
     if not ok_:
         return _error(ret, err)
 
     if makedirs is True:
         dirname = os.path.dirname(name)
-        if not __salt__["file.directory_exists"](dirname):
+        if not __salt__['file.directory_exists'](dirname):
             try:
                 _makedirs(name=name)
             except CommandExecutionError as exc:
-                return _error(ret, "Drive {0} is not mapped".format(exc.message))
+                return _error(ret, 'Drive {0} is not mapped'.format(exc.message))
 
-            check_res, check_msg, check_changes = (
-                _check_directory_win(dirname)
-                if salt.utils.platform.is_windows()
+            check_res, check_msg, check_changes = _check_directory_win(dirname) \
+                if salt.utils.platform.is_windows() \
                 else _check_directory(dirname)
-            )
 
             if not check_res:
-                ret["changes"] = check_changes
+                ret['changes'] = check_changes
                 return _error(ret, check_msg)
 
     check_res, check_msg = _check_file(name)
     if not check_res:
         # Try to create the file
         touch_ret = touch(name, makedirs=makedirs)
-        if __opts__["test"]:
+        if __opts__['test']:
             return touch_ret
         retry_res, retry_msg = _check_file(name)
         if not retry_res:
@@ -6160,16 +6048,17 @@ def prepend(
 
     # Follow the original logic and re-assign 'text' if using source(s)...
     if sl_:
-        tmpret = _get_template_texts(
-            source_list=sl_, template=template, defaults=defaults, context=context
-        )
-        if not tmpret["result"]:
+        tmpret = _get_template_texts(source_list=sl_,
+                                     template=template,
+                                     defaults=defaults,
+                                     context=context)
+        if not tmpret['result']:
             return tmpret
-        text = tmpret["data"]
+        text = tmpret['data']
 
     text = _validate_str_list(text)
 
-    with salt.utils.files.fopen(name, "rb") as fp_:
+    with salt.utils.files.fopen(name, 'rb') as fp_:
         slines = fp_.read()
         if six.PY3:
             slines = slines.decode(__salt_system_encoding__)
@@ -6183,47 +6072,48 @@ def prepend(
 
         # if header kwarg is unset of False, use regex search
         if not header:
-            if __salt__["file.search"](
-                name,
-                salt.utils.stringutils.build_whitespace_split_regex(chunk),
-                multiline=True,
-            ):
+            if __salt__['file.search'](
+                    name,
+                    salt.utils.stringutils.build_whitespace_split_regex(chunk),
+                    multiline=True):
                 continue
 
         lines = chunk.splitlines()
 
         for line in lines:
-            if __opts__["test"]:
-                ret["comment"] = "File {0} is set to be updated".format(name)
-                ret["result"] = None
-                test_lines.append("{0}\n".format(line))
+            if __opts__['test']:
+                ret['comment'] = 'File {0} is set to be updated'.format(name)
+                ret['result'] = None
+                test_lines.append('{0}\n'.format(line))
             else:
                 preface.append(line)
             count += 1
 
-    if __opts__["test"]:
+    if __opts__['test']:
         nlines = test_lines + slines
         if slines != nlines:
-            if not __utils__["files.is_text"](name):
-                ret["changes"]["diff"] = "Replace binary file"
+            if not __utils__['files.is_text'](name):
+                ret['changes']['diff'] = 'Replace binary file'
             else:
                 # Changes happened, add them
-                ret["changes"]["diff"] = "".join(difflib.unified_diff(slines, nlines))
-            ret["result"] = None
+                ret['changes']['diff'] = (
+                    ''.join(difflib.unified_diff(slines, nlines))
+                )
+            ret['result'] = None
         else:
-            ret["comment"] = "File {0} is in correct state".format(name)
-            ret["result"] = True
+            ret['comment'] = 'File {0} is in correct state'.format(name)
+            ret['result'] = True
         return ret
 
     # if header kwarg is True, use verbatim compare
     if header:
-        with salt.utils.files.fopen(name, "rb") as fp_:
+        with salt.utils.files.fopen(name, 'rb') as fp_:
             # read as many lines of target file as length of user input
             contents = fp_.read()
             if six.PY3:
                 contents = contents.decode(__salt_system_encoding__)
             contents = contents.splitlines(True)
-            target_head = contents[0 : len(preface)]
+            target_head = contents[0:len(preface)]
             target_lines = []
             # strip newline chars from list entries
             for chunk in target_head:
@@ -6231,50 +6121,50 @@ def prepend(
             # compare current top lines in target file with user input
             # and write user input if they differ
             if target_lines != preface:
-                __salt__["file.prepend"](name, *preface)
+                __salt__['file.prepend'](name, *preface)
             else:
                 # clear changed lines counter if target file not modified
                 count = 0
     else:
-        __salt__["file.prepend"](name, *preface)
+        __salt__['file.prepend'](name, *preface)
 
-    with salt.utils.files.fopen(name, "rb") as fp_:
+    with salt.utils.files.fopen(name, 'rb') as fp_:
         nlines = fp_.read()
         if six.PY3:
             nlines = nlines.decode(__salt_system_encoding__)
         nlines = nlines.splitlines(True)
 
     if slines != nlines:
-        if not __utils__["files.is_text"](name):
-            ret["changes"]["diff"] = "Replace binary file"
+        if not __utils__['files.is_text'](name):
+            ret['changes']['diff'] = 'Replace binary file'
         else:
             # Changes happened, add them
-            ret["changes"]["diff"] = "".join(difflib.unified_diff(slines, nlines))
+            ret['changes']['diff'] = (
+                ''.join(difflib.unified_diff(slines, nlines))
+            )
 
     if count:
-        ret["comment"] = "Prepended {0} lines".format(count)
+        ret['comment'] = 'Prepended {0} lines'.format(count)
     else:
-        ret["comment"] = "File {0} is in correct state".format(name)
-    ret["result"] = True
+        ret['comment'] = 'File {0} is in correct state'.format(name)
+    ret['result'] = True
     return ret
 
 
-def patch(
-    name,
-    source=None,
-    source_hash=None,
-    source_hash_name=None,
-    skip_verify=False,
-    template=None,
-    context=None,
-    defaults=None,
-    options="",
-    reject_file=None,
-    strip=None,
-    saltenv=None,
-    **kwargs
-):
-    """
+def patch(name,
+          source=None,
+          source_hash=None,
+          source_hash_name=None,
+          skip_verify=False,
+          template=None,
+          context=None,
+          defaults=None,
+          options='',
+          reject_file=None,
+          strip=None,
+          saltenv=None,
+          **kwargs):
+    '''
     Ensure that a patch has been applied to the specified file or directory
 
     .. versionchanged:: 2019.2.0
@@ -6395,11 +6285,11 @@ def patch(
         /opt/myfile.txt:
           file.patch:
             - source: salt://myfile.patch
-    """
-    ret = {"name": name, "changes": {}, "result": False, "comment": ""}
+    '''
+    ret = {'name': name, 'changes': {}, 'result': False, 'comment': ''}
 
-    if not salt.utils.path.which("patch"):
-        ret["comment"] = "patch executable not found on minion"
+    if not salt.utils.path.which('patch'):
+        ret['comment'] = 'patch executable not found on minion'
         return ret
 
     # is_dir should be defined if we proceed past the if/else block below, but
@@ -6407,45 +6297,49 @@ def patch(
     is_dir = False
 
     if not name:
-        ret["comment"] = "A file/directory to be patched is required"
+        ret['comment'] = 'A file/directory to be patched is required'
         return ret
     else:
         try:
             name = os.path.expanduser(name)
         except Exception:
-            ret["comment"] = "Invalid path '{0}'".format(name)
+            ret['comment'] = 'Invalid path \'{0}\''.format(name)
             return ret
         else:
             if not os.path.isabs(name):
-                ret["comment"] = "{0} is not an absolute path".format(name)
+                ret['comment'] = '{0} is not an absolute path'.format(name)
                 return ret
             elif not os.path.exists(name):
-                ret["comment"] = "{0} does not exist".format(name)
+                ret['comment'] = '{0} does not exist'.format(name)
                 return ret
             else:
                 is_dir = os.path.isdir(name)
 
-    for deprecated_arg in ("hash", "dry_run_first"):
+    for deprecated_arg in ('hash', 'dry_run_first'):
         if deprecated_arg in kwargs:
-            ret.setdefault("warnings", []).append(
-                "The '{0}' argument is no longer used and has been "
-                "ignored.".format(deprecated_arg)
+            ret.setdefault('warnings', []).append(
+                'The \'{0}\' argument is no longer used and has been '
+                'ignored.'.format(deprecated_arg)
             )
 
     if reject_file is not None:
         try:
             reject_file_parent = os.path.dirname(reject_file)
         except Exception:
-            ret["comment"] = "Invalid path '{0}' for reject_file".format(reject_file)
+            ret['comment'] = 'Invalid path \'{0}\' for reject_file'.format(
+                reject_file
+            )
             return ret
         else:
             if not os.path.isabs(reject_file_parent):
-                ret["comment"] = "'{0}' is not an absolute path".format(reject_file)
+                ret['comment'] = '\'{0}\' is not an absolute path'.format(
+                    reject_file
+                )
                 return ret
             elif not os.path.isdir(reject_file_parent):
-                ret["comment"] = (
-                    "Parent directory for reject_file '{0}' either does "
-                    "not exist, or is not a directory".format(reject_file)
+                ret['comment'] = (
+                    'Parent directory for reject_file \'{0}\' either does '
+                    'not exist, or is not a directory'.format(reject_file)
                 )
                 return ret
 
@@ -6461,7 +6355,7 @@ def patch(
         if not isinstance(option, six.string_types):
             option = six.text_type(option)
 
-        for item in ("-N", "--forward", "-r", "--reject-file", "-o", "--output"):
+        for item in ('-N', '--forward', '-r', '--reject-file', '-o', '--output'):
             if option.startswith(item):
                 blacklisted = option
                 break
@@ -6471,24 +6365,24 @@ def patch(
         if blacklisted is not None:
             blacklisted_options.append(blacklisted)
 
-        if option.startswith("-p"):
+        if option.startswith('-p'):
             try:
                 strip = int(option[2:])
             except Exception:
-                ret["comment"] = (
-                    "Invalid format for '-p' CLI option. Consider using "
-                    "the 'strip' option for this state."
+                ret['comment'] = (
+                    'Invalid format for \'-p\' CLI option. Consider using '
+                    'the \'strip\' option for this state.'
                 )
                 return ret
-        elif option.startswith("--strip"):
-            if "=" in option:
+        elif option.startswith('--strip'):
+            if '=' in option:
                 # Assume --strip=N
                 try:
-                    strip = int(option.rsplit("=", 1)[-1])
+                    strip = int(option.rsplit('=', 1)[-1])
                 except Exception:
-                    ret["comment"] = (
-                        "Invalid format for '-strip' CLI option. Consider "
-                        "using the 'strip' option for this state."
+                    ret['comment'] = (
+                        'Invalid format for \'-strip\' CLI option. Consider '
+                        'using the \'strip\' option for this state.'
                     )
                     return ret
             else:
@@ -6496,9 +6390,9 @@ def patch(
                 try:
                     strip = int(options[index + 1])
                 except Exception:
-                    ret["comment"] = (
-                        "Invalid format for '-strip' CLI option. Consider "
-                        "using the 'strip' option for this state."
+                    ret['comment'] = (
+                        'Invalid format for \'-strip\' CLI option. Consider '
+                        'using the \'strip\' option for this state.'
                     )
                     return ret
                 else:
@@ -6512,18 +6406,22 @@ def patch(
         index += 1
 
     if blacklisted_options:
-        ret["comment"] = "The following CLI options are not allowed: {0}".format(
-            ", ".join(blacklisted_options)
+        ret['comment'] = (
+            'The following CLI options are not allowed: {0}'.format(
+                ', '.join(blacklisted_options)
+            )
         )
         return ret
 
     options = sanitized_options
 
     try:
-        source_match = __salt__["file.source_list"](source, source_hash, __env__)[0]
+        source_match = __salt__['file.source_list'](source,
+                                                    source_hash,
+                                                    __env__)[0]
     except CommandExecutionError as exc:
-        ret["result"] = False
-        ret["comment"] = exc.strerror
+        ret['result'] = False
+        ret['comment'] = exc.strerror
         return ret
     else:
         # Passing the saltenv to file.managed to pull down the patch file is
@@ -6532,15 +6430,17 @@ def patch(
         # (and a traceback). Therefore, we will add the saltenv to the source
         # URL to ensure we pull the file from the correct environment.
         if saltenv is not None:
-            source_match_url, source_match_saltenv = salt.utils.url.parse(source_match)
-            if source_match_url.startswith("salt://"):
-                if source_match_saltenv is not None and source_match_saltenv != saltenv:
-                    ret.setdefault("warnings", []).append(
-                        "Ignoring 'saltenv' option in favor of saltenv "
-                        "included in the source URL."
+            source_match_url, source_match_saltenv = \
+                salt.utils.url.parse(source_match)
+            if source_match_url.startswith('salt://'):
+                if source_match_saltenv is not None \
+                        and source_match_saltenv != saltenv:
+                    ret.setdefault('warnings', []).append(
+                        'Ignoring \'saltenv\' option in favor of saltenv '
+                        'included in the source URL.'
                     )
                 else:
-                    source_match += "?saltenv={0}".format(saltenv)
+                    source_match += '?saltenv={0}'.format(saltenv)
 
     cleanup = []
 
@@ -6549,36 +6449,35 @@ def patch(
         cleanup.append(patch_file)
 
         try:
-            orig_test = __opts__["test"]
-            __opts__["test"] = False
-            sys.modules[__salt__["test.ping"].__module__].__opts__["test"] = False
-            result = managed(
-                patch_file,
-                source=source_match,
-                source_hash=source_hash,
-                source_hash_name=source_hash_name,
-                skip_verify=skip_verify,
-                template=template,
-                context=context,
-                defaults=defaults,
-            )
+            orig_test = __opts__['test']
+            __opts__['test'] = False
+            sys.modules[__salt__['test.ping'].__module__].__opts__['test'] = False
+            result = managed(patch_file,
+                             source=source_match,
+                             source_hash=source_hash,
+                             source_hash_name=source_hash_name,
+                             skip_verify=skip_verify,
+                             template=template,
+                             context=context,
+                             defaults=defaults)
         except Exception as exc:
-            msg = "Failed to cache patch file {0}: {1}".format(
-                salt.utils.url.redact_http_basic_auth(source_match), exc
+            msg = 'Failed to cache patch file {0}: {1}'.format(
+                salt.utils.url.redact_http_basic_auth(source_match),
+                exc
             )
             log.exception(msg)
-            ret["comment"] = msg
+            ret['comment'] = msg
             return ret
         else:
-            log.debug("file.managed: %s", result)
+            log.debug('file.managed: %s', result)
         finally:
-            __opts__["test"] = orig_test
-            sys.modules[__salt__["test.ping"].__module__].__opts__["test"] = orig_test
+            __opts__['test'] = orig_test
+            sys.modules[__salt__['test.ping'].__module__].__opts__['test'] = orig_test
 
-        if result["result"] is False:
+        if result['result'] is False:
             log.debug(
-                "failed to download %s",
-                salt.utils.url.redact_http_basic_auth(source_match),
+                'failed to download %s',
+                salt.utils.url.redact_http_basic_auth(source_match)
             )
             return result
 
@@ -6586,9 +6485,11 @@ def patch(
             patch_opts = copy.copy(sanitized_options)
             if options is not None:
                 patch_opts.extend(options)
-            return __salt__["file.patch"](
-                name, patch_file, options=patch_opts, dry_run=dry_run
-            )
+            return __salt__['file.patch'](
+                name,
+                patch_file,
+                options=patch_opts,
+                dry_run=dry_run)
 
         if reject_file is not None:
             patch_rejects = reject_file
@@ -6605,57 +6506,59 @@ def patch(
         # to work on Windows with patch.exe, /dev/null is a non-starter.
         # Therefore, redirect all patch output to a temp file, which we will
         # then remove.
-        patch_opts = ["-N", "-r", patch_rejects, "-o", patch_output]
+        patch_opts = ['-N', '-r', patch_rejects, '-o', patch_output]
         if is_dir and strip is not None:
-            patch_opts.append("-p{0}".format(strip))
+            patch_opts.append('-p{0}'.format(strip))
 
         pre_check = _patch(patch_file, patch_opts)
-        if pre_check["retcode"] != 0:
+        if pre_check['retcode'] != 0:
             # Try to reverse-apply hunks from rejects file using a dry-run.
             # If this returns a retcode of 0, we know that the patch was
             # already applied. Rejects are written from the base of the
             # directory, so the strip option doesn't apply here.
-            reverse_pass = _patch(patch_rejects, ["-R", "-f"], dry_run=True)
-            already_applied = reverse_pass["retcode"] == 0
+            reverse_pass = _patch(patch_rejects, ['-R', '-f'], dry_run=True)
+            already_applied = reverse_pass['retcode'] == 0
 
             if already_applied:
-                ret["comment"] = "Patch was already applied"
-                ret["result"] = True
+                ret['comment'] = 'Patch was already applied'
+                ret['result'] = True
                 return ret
             else:
-                ret["comment"] = (
-                    "Patch would not apply cleanly, no changes made. Results "
-                    "of dry-run are below."
+                ret['comment'] = (
+                    'Patch would not apply cleanly, no changes made. Results '
+                    'of dry-run are below.'
                 )
                 if reject_file is None:
-                    ret["comment"] += (
-                        " Run state again using the reject_file option to "
-                        "save rejects to a persistent file."
+                    ret['comment'] += (
+                        ' Run state again using the reject_file option to '
+                        'save rejects to a persistent file.'
                     )
                 opts = copy.copy(__opts__)
-                opts["color"] = False
-                ret["comment"] += "\n\n" + salt.output.out_format(
-                    pre_check, "nested", opts, nested_indent=14
-                )
+                opts['color'] = False
+                ret['comment'] += '\n\n' + salt.output.out_format(
+                    pre_check,
+                    'nested',
+                    opts,
+                    nested_indent=14)
                 return ret
 
-        if __opts__["test"]:
-            ret["result"] = None
-            ret["comment"] = "The patch would be applied"
-            ret["changes"] = pre_check
+        if __opts__['test']:
+            ret['result'] = None
+            ret['comment'] = 'The patch would be applied'
+            ret['changes'] = pre_check
             return ret
 
         # If we've made it here, the patch should apply cleanly
         patch_opts = []
         if is_dir and strip is not None:
-            patch_opts.append("-p{0}".format(strip))
-        ret["changes"] = _patch(patch_file, patch_opts)
+            patch_opts.append('-p{0}'.format(strip))
+        ret['changes'] = _patch(patch_file, patch_opts)
 
-        if ret["changes"]["retcode"] == 0:
-            ret["comment"] = "Patch successfully applied"
-            ret["result"] = True
+        if ret['changes']['retcode'] == 0:
+            ret['comment'] = 'Patch successfully applied'
+            ret['result'] = True
         else:
-            ret["comment"] = "Failed to apply patch"
+            ret['comment'] = 'Failed to apply patch'
 
         return ret
 
@@ -6667,12 +6570,13 @@ def patch(
             except OSError as exc:
                 if exc.errno != os.errno.ENOENT:
                     log.error(
-                        "file.patch: Failed to remove temp file %s: %s", path, exc
+                        'file.patch: Failed to remove temp file %s: %s',
+                        path, exc
                     )
 
 
 def touch(name, atime=None, mtime=None, makedirs=False):
-    """
+    '''
     Replicate the 'nix "touch" command to create a new empty
     file or update the atime and mtime of an existing file.
 
@@ -6703,16 +6607,21 @@ def touch(name, atime=None, mtime=None, makedirs=False):
           file.touch
 
     .. versionadded:: 0.9.5
-    """
+    '''
     name = os.path.expanduser(name)
 
-    ret = {"name": name, "changes": {}}
+    ret = {
+        'name': name,
+        'changes': {},
+    }
     if not name:
-        return _error(ret, "Must provide name to file.touch")
+        return _error(ret, 'Must provide name to file.touch')
     if not os.path.isabs(name):
-        return _error(ret, "Specified file {0} is not an absolute path".format(name))
+        return _error(
+            ret, 'Specified file {0} is not an absolute path'.format(name)
+        )
 
-    if __opts__["test"]:
+    if __opts__['test']:
         ret.update(_check_touch(name, atime, mtime))
         return ret
 
@@ -6720,38 +6629,38 @@ def touch(name, atime=None, mtime=None, makedirs=False):
         try:
             _makedirs(name=name)
         except CommandExecutionError as exc:
-            return _error(ret, "Drive {0} is not mapped".format(exc.message))
+            return _error(ret, 'Drive {0} is not mapped'.format(exc.message))
     if not os.path.isdir(os.path.dirname(name)):
-        return _error(ret, "Directory not present to touch file {0}".format(name))
+        return _error(
+            ret, 'Directory not present to touch file {0}'.format(name)
+        )
 
     extant = os.path.exists(name)
 
-    ret["result"] = __salt__["file.touch"](name, atime, mtime)
-    if not extant and ret["result"]:
-        ret["comment"] = "Created empty file {0}".format(name)
-        ret["changes"]["new"] = name
-    elif extant and ret["result"]:
-        ret["comment"] = "Updated times on {0} {1}".format(
-            "directory" if os.path.isdir(name) else "file", name
+    ret['result'] = __salt__['file.touch'](name, atime, mtime)
+    if not extant and ret['result']:
+        ret['comment'] = 'Created empty file {0}'.format(name)
+        ret['changes']['new'] = name
+    elif extant and ret['result']:
+        ret['comment'] = 'Updated times on {0} {1}'.format(
+            'directory' if os.path.isdir(name) else 'file', name
         )
-        ret["changes"]["touched"] = name
+        ret['changes']['touched'] = name
 
     return ret
 
 
-def copy_(
-    name,
-    source,
-    force=False,
-    makedirs=False,
-    preserve=False,
-    user=None,
-    group=None,
-    mode=None,
-    subdir=False,
-    **kwargs
-):
-    """
+def copy_(name,
+          source,
+          force=False,
+          makedirs=False,
+          preserve=False,
+          user=None,
+          group=None,
+          mode=None,
+          subdir=False,
+          **kwargs):
+    '''
     If the file defined by the ``source`` option exists on the minion, copy it
     to the named path. The file will not be overwritten if it already exists,
     unless the ``force`` option is set to ``True``.
@@ -6818,47 +6727,46 @@ def copy_(
         <salt.states.file.managed>` and :mod:`states.file.recurse
         <salt.states.file.recurse>`.
 
-    """
+    '''
     name = os.path.expanduser(name)
     source = os.path.expanduser(source)
 
     ret = {
-        "name": name,
-        "changes": {},
-        "comment": 'Copied "{0}" to "{1}"'.format(source, name),
-        "result": True,
-    }
+        'name': name,
+        'changes': {},
+        'comment': 'Copied "{0}" to "{1}"'.format(source, name),
+        'result': True}
     if not name:
-        return _error(ret, "Must provide name to file.copy")
+        return _error(ret, 'Must provide name to file.copy')
 
     changed = True
     if not os.path.isabs(name):
-        return _error(ret, "Specified file {0} is not an absolute path".format(name))
+        return _error(
+            ret, 'Specified file {0} is not an absolute path'.format(name))
 
     if not os.path.exists(source):
         return _error(ret, 'Source file "{0}" is not present'.format(source))
 
     if preserve:
-        user = __salt__["file.get_user"](source)
-        group = __salt__["file.get_group"](source)
-        mode = __salt__["file.get_mode"](source)
+        user = __salt__['file.get_user'](source)
+        group = __salt__['file.get_group'](source)
+        mode = __salt__['file.get_mode'](source)
     else:
         user = _test_owner(kwargs, user=user)
         if user is None:
-            user = __opts__["user"]
+            user = __opts__['user']
 
         if salt.utils.platform.is_windows():
             if group is not None:
                 log.warning(
-                    "The group argument for %s has been ignored as this is "
-                    "a Windows system.",
-                    name,
+                    'The group argument for %s has been ignored as this is '
+                    'a Windows system.', name
                 )
             group = user
 
         if group is None:
-            group = __salt__["file.gid_to_group"](
-                __salt__["user.info"](user).get("gid", 0)
+            group = __salt__['file.gid_to_group'](
+                __salt__['user.info'](user).get('gid', 0)
             )
 
         u_check = _check_user(user, group)
@@ -6867,7 +6775,7 @@ def copy_(
             return _error(ret, u_check)
 
         if mode is None:
-            mode = __salt__["file.get_mode"](source)
+            mode = __salt__['file.get_mode'](source)
 
     if os.path.isdir(name) and subdir:
         # If the target is a dir, and overwrite_dir is False, copy into the dir
@@ -6880,43 +6788,39 @@ def copy_(
             hash2 = salt.utils.hashutils.get_hash(source)
             if hash1 == hash2:
                 changed = True
-                ret["comment"] = " ".join(
-                    [ret["comment"], "- files are identical but force flag is set"]
-                )
+                ret['comment'] = ' '.join([ret['comment'], '- files are identical but force flag is set'])
         if not force:
             changed = False
-        elif not __opts__["test"] and changed:
+        elif not __opts__['test'] and changed:
             # Remove the destination to prevent problems later
             try:
                 # On windows, if a file has the read-only attribute then we are unable
                 # to complete this copy unless force is set to true.
-                __salt__["file.remove"](name, force=force)
+                __salt__['file.remove'](name, force=force)
             except (IOError, OSError):
                 return _error(
                     ret,
                     'Failed to delete "{0}" in preparation for '
-                    "forced move".format(name),
+                    'forced move'.format(name)
                 )
 
-    if __opts__["test"]:
+    if __opts__['test']:
         if changed:
-            ret["comment"] = 'File "{0}" is set to be copied to "{1}"'.format(
-                source, name
+            ret['comment'] = 'File "{0}" is set to be copied to "{1}"'.format(
+                source,
+                name
             )
-            ret["result"] = None
+            ret['result'] = None
         else:
-            ret["comment"] = (
-                'The target file "{0}" exists and will not be '
-                "overwritten".format(name)
-            )
-            ret["result"] = True
+            ret['comment'] = ('The target file "{0}" exists and will not be '
+                              'overwritten'.format(name))
+            ret['result'] = True
         return ret
 
     if not changed:
-        ret[
-            "comment"
-        ] = 'The target file "{0}" exists and will not be ' "overwritten".format(name)
-        ret["result"] = True
+        ret['comment'] = ('The target file "{0}" exists and will not be '
+                          'overwritten'.format(name))
+        ret['result'] = True
         return ret
 
     # Run makedirs
@@ -6926,33 +6830,36 @@ def copy_(
             try:
                 _makedirs(name=name, user=user, group=group, dir_mode=mode)
             except CommandExecutionError as exc:
-                return _error(ret, "Drive {0} is not mapped".format(exc.message))
+                return _error(ret, 'Drive {0} is not mapped'.format(exc.message))
         else:
-            return _error(ret, "The target directory {0} is not present".format(dname))
+            return _error(
+                ret,
+                'The target directory {0} is not present'.format(dname))
     # All tests pass, move the file into place
     try:
         if os.path.isdir(source):
             shutil.copytree(source, name, symlinks=True)
             for root, dirs, files in salt.utils.path.os_walk(name):
                 for dir_ in dirs:
-                    __salt__["file.lchown"](os.path.join(root, dir_), user, group)
+                    __salt__['file.lchown'](os.path.join(root, dir_), user, group)
                 for file_ in files:
-                    __salt__["file.lchown"](os.path.join(root, file_), user, group)
+                    __salt__['file.lchown'](os.path.join(root, file_), user, group)
         else:
             shutil.copy(source, name)
-        ret["changes"] = {name: source}
+        ret['changes'] = {name: source}
         # Preserve really means just keep the behavior of the cp command. If
         # the filesystem we're copying to is squashed or doesn't support chown
         # then we shouldn't be checking anything.
         if not preserve:
-            __salt__["file.check_perms"](name, ret, user, group, mode)
+            __salt__['file.check_perms'](name, ret, user, group, mode)
     except (IOError, OSError):
-        return _error(ret, 'Failed to copy "{0}" to "{1}"'.format(source, name))
+        return _error(
+            ret, 'Failed to copy "{0}" to "{1}"'.format(source, name))
     return ret
 
 
 def rename(name, source, force=False, makedirs=False, **kwargs):
-    """
+    '''
     If the source file exists on the system, rename it to the named file. The
     named file will not be overwritten if it already exists unless the force
     option is set to True.
@@ -6970,44 +6877,49 @@ def rename(name, source, force=False, makedirs=False, **kwargs):
     makedirs
         If the target subdirectories don't exist create them
 
-    """
+    '''
     name = os.path.expanduser(name)
     source = os.path.expanduser(source)
 
-    ret = {"name": name, "changes": {}, "comment": "", "result": True}
+    ret = {
+        'name': name,
+        'changes': {},
+        'comment': '',
+        'result': True}
     if not name:
-        return _error(ret, "Must provide name to file.rename")
+        return _error(ret, 'Must provide name to file.rename')
 
     if not os.path.isabs(name):
-        return _error(ret, "Specified file {0} is not an absolute path".format(name))
+        return _error(
+            ret, 'Specified file {0} is not an absolute path'.format(name))
 
     if not os.path.lexists(source):
-        ret["comment"] = (
-            'Source file "{0}" has already been moved out of ' "place"
-        ).format(source)
+        ret['comment'] = ('Source file "{0}" has already been moved out of '
+                          'place').format(source)
         return ret
 
     if os.path.lexists(source) and os.path.lexists(name):
         if not force:
-            ret["comment"] = (
-                'The target file "{0}" exists and will not be '
-                "overwritten".format(name)
-            )
+            ret['comment'] = ('The target file "{0}" exists and will not be '
+                              'overwritten'.format(name))
             return ret
-        elif not __opts__["test"]:
+        elif not __opts__['test']:
             # Remove the destination to prevent problems later
             try:
-                __salt__["file.remove"](name)
+                __salt__['file.remove'](name)
             except (IOError, OSError):
                 return _error(
                     ret,
                     'Failed to delete "{0}" in preparation for '
-                    "forced move".format(name),
+                    'forced move'.format(name)
                 )
 
-    if __opts__["test"]:
-        ret["comment"] = 'File "{0}" is set to be moved to "{1}"'.format(source, name)
-        ret["result"] = None
+    if __opts__['test']:
+        ret['comment'] = 'File "{0}" is set to be moved to "{1}"'.format(
+            source,
+            name
+        )
+        ret['result'] = None
         return ret
 
     # Run makedirs
@@ -7017,9 +6929,11 @@ def rename(name, source, force=False, makedirs=False, **kwargs):
             try:
                 _makedirs(name=name)
             except CommandExecutionError as exc:
-                return _error(ret, "Drive {0} is not mapped".format(exc.message))
+                return _error(ret, 'Drive {0} is not mapped'.format(exc.message))
         else:
-            return _error(ret, "The target directory {0} is not present".format(dname))
+            return _error(
+                ret,
+                'The target directory {0} is not present'.format(dname))
     # All tests pass, move the file into place
     try:
         if os.path.islink(source):
@@ -7029,15 +6943,16 @@ def rename(name, source, force=False, makedirs=False, **kwargs):
         else:
             shutil.move(source, name)
     except (IOError, OSError):
-        return _error(ret, 'Failed to move "{0}" to "{1}"'.format(source, name))
+        return _error(
+            ret, 'Failed to move "{0}" to "{1}"'.format(source, name))
 
-    ret["comment"] = 'Moved "{0}" to "{1}"'.format(source, name)
-    ret["changes"] = {name: source}
+    ret['comment'] = 'Moved "{0}" to "{1}"'.format(source, name)
+    ret['changes'] = {name: source}
     return ret
 
 
 def accumulated(name, filename, text, **kwargs):
-    """
+    '''
     Prepare accumulator which can be used in template in file.managed state.
     Accumulator dictionary becomes available in template. It can also be used
     in file.blockreplace.
@@ -7092,21 +7007,28 @@ def accumulated(name, filename, text, **kwargs):
     .. note::
         The 'accumulator' data structure is a Python dictionary.
         Do not expect any loop over the keys in a deterministic order!
-    """
-    ret = {"name": name, "changes": {}, "result": True, "comment": ""}
+    '''
+    ret = {
+        'name': name,
+        'changes': {},
+        'result': True,
+        'comment': ''
+    }
     if not name:
-        return _error(ret, "Must provide name to file.accumulated")
+        return _error(ret, 'Must provide name to file.accumulated')
     if text is None:
-        ret["result"] = False
-        ret["comment"] = "No text supplied for accumulator"
+        ret['result'] = False
+        ret['comment'] = 'No text supplied for accumulator'
         return ret
-    require_in = __low__.get("require_in", [])
-    watch_in = __low__.get("watch_in", [])
+    require_in = __low__.get('require_in', [])
+    watch_in = __low__.get('watch_in', [])
     deps = require_in + watch_in
-    if not [x for x in deps if "file" in x]:
-        ret["result"] = False
-        ret["comment"] = "Orphaned accumulator {0} in {1}:{2}".format(
-            name, __low__["__sls__"], __low__["__id__"]
+    if not [x for x in deps if 'file' in x]:
+        ret['result'] = False
+        ret['comment'] = 'Orphaned accumulator {0} in {1}:{2}'.format(
+            name,
+            __low__['__sls__'],
+            __low__['__id__']
         )
         return ret
     if isinstance(text, six.string_types):
@@ -7127,33 +7049,29 @@ def accumulated(name, filename, text, **kwargs):
     for chunk in text:
         if chunk not in accum_data[filename][name]:
             accum_data[filename][name].append(chunk)
-            ret["comment"] = (
-                "Accumulator {0} for file {1} "
-                "was charged by text".format(name, filename)
-            )
+            ret['comment'] = ('Accumulator {0} for file {1} '
+                              'was charged by text'.format(name, filename))
     _persist_accummulators(accum_data, accum_deps)
     return ret
 
 
-def serialize(
-    name,
-    dataset=None,
-    dataset_pillar=None,
-    user=None,
-    group=None,
-    mode=None,
-    backup="",
-    makedirs=False,
-    show_changes=True,
-    create=True,
-    merge_if_exists=False,
-    encoding=None,
-    encoding_errors="strict",
-    serializer_opts=None,
-    deserializer_opts=None,
-    **kwargs
-):
-    """
+def serialize(name,
+              dataset=None,
+              dataset_pillar=None,
+              user=None,
+              group=None,
+              mode=None,
+              backup='',
+              makedirs=False,
+              show_changes=True,
+              create=True,
+              merge_if_exists=False,
+              encoding=None,
+              encoding_errors='strict',
+              serializer_opts=None,
+              deserializer_opts=None,
+              **kwargs):
+    '''
     Serializes dataset and store it into managed file. Useful for sharing
     simple configuration files.
 
@@ -7325,65 +7243,77 @@ def serialize(
           "engine": "node 0.4.1",
           "name": "naive"
         }
-    """
-    if "env" in kwargs:
+    '''
+    if 'env' in kwargs:
         # "env" is not supported; Use "saltenv".
-        kwargs.pop("env")
+        kwargs.pop('env')
 
     name = os.path.expanduser(name)
 
     # Set some defaults
     serializer_options = {
-        "yaml.serialize": {"default_flow_style": False},
-        "json.serialize": {"indent": 2, "separators": (",", ": "), "sort_keys": True},
+        'yaml.serialize': {
+            'default_flow_style': False,
+        },
+        'json.serialize': {
+            'indent': 2,
+            'separators': (',', ': '),
+            'sort_keys': True,
+        }
     }
-    deserializer_options = {"yaml.deserialize": {}, "json.deserialize": {}}
+    deserializer_options = {
+        'yaml.deserialize': {},
+        'json.deserialize': {},
+    }
     if encoding:
-        serializer_options["yaml.serialize"].update({"allow_unicode": True})
-        serializer_options["json.serialize"].update({"ensure_ascii": False})
+        serializer_options['yaml.serialize'].update({'allow_unicode': True})
+        serializer_options['json.serialize'].update({'ensure_ascii': False})
 
-    ret = {"changes": {}, "comment": "", "name": name, "result": True}
+    ret = {'changes': {},
+           'comment': '',
+           'name': name,
+           'result': True}
     if not name:
-        return _error(ret, "Must provide name to file.serialize")
+        return _error(ret, 'Must provide name to file.serialize')
 
     if not create:
         if not os.path.isfile(name):
             # Don't create a file that is not already present
-            ret["comment"] = (
-                "File {0} is not present and is not set for " "creation"
-            ).format(name)
+            ret['comment'] = ('File {0} is not present and is not set for '
+                              'creation').format(name)
             return ret
 
-    formatter = kwargs.pop("formatter", "yaml").lower()
+    formatter = kwargs.pop('formatter', 'yaml').lower()
 
     if len([x for x in (dataset, dataset_pillar) if x]) > 1:
-        return _error(ret, "Only one of 'dataset' and 'dataset_pillar' is permitted")
+        return _error(
+            ret, 'Only one of \'dataset\' and \'dataset_pillar\' is permitted')
 
     if dataset_pillar:
-        dataset = __salt__["pillar.get"](dataset_pillar)
+        dataset = __salt__['pillar.get'](dataset_pillar)
 
     if dataset is None:
-        return _error(ret, "Neither 'dataset' nor 'dataset_pillar' was defined")
+        return _error(
+            ret, 'Neither \'dataset\' nor \'dataset_pillar\' was defined')
 
     if salt.utils.platform.is_windows():
         if group is not None:
             log.warning(
-                "The group argument for %s has been ignored as this "
-                "is a Windows system.",
-                name,
+                'The group argument for %s has been ignored as this '
+                'is a Windows system.', name
             )
         group = user
 
-    serializer_name = "{0}.serialize".format(formatter)
-    deserializer_name = "{0}.deserialize".format(formatter)
+    serializer_name = '{0}.serialize'.format(formatter)
+    deserializer_name = '{0}.deserialize'.format(formatter)
 
     if serializer_name not in __serializers__:
-        return {
-            "changes": {},
-            "comment": "{0} format is not supported".format(formatter.capitalize()),
-            "name": name,
-            "result": False,
-        }
+        return {'changes': {},
+                'comment': '{0} format is not supported'.format(
+                    formatter.capitalize()),
+                'name': name,
+                'result': False
+                }
 
     if serializer_opts:
         serializer_options.setdefault(serializer_name, {}).update(
@@ -7400,53 +7330,52 @@ def serialize(
         if os.path.isfile(name):
             if deserializer_name not in __serializers__:
                 return {
-                    "changes": {},
-                    "comment": "merge_if_exists is not supported for the {0} "
-                    "formatter".format(formatter),
-                    "name": name,
-                    "result": False,
+                    'changes': {},
+                    'comment': 'merge_if_exists is not supported for the {0} '
+                               'formatter'.format(formatter),
+                    'name': name,
+                    'result': False
                 }
 
-            with salt.utils.files.fopen(name, "r") as fhr:
+            with salt.utils.files.fopen(name, 'r') as fhr:
                 try:
                     existing_data = __serializers__[deserializer_name](
-                        fhr, **deserializer_options.get(deserializer_name, {})
+                        fhr,
+                        **deserializer_options.get(deserializer_name, {})
                     )
                 except (TypeError, DeserializationError) as exc:
-                    ret["result"] = False
-                    ret["comment"] = "Failed to deserialize existing data: {0}".format(
-                        exc
-                    )
+                    ret['result'] = False
+                    ret['comment'] = \
+                        'Failed to deserialize existing data: {0}'.format(exc)
                     return False
 
             if existing_data is not None:
-                merged_data = salt.utils.dictupdate.merge_recurse(
-                    existing_data, dataset
-                )
+                merged_data = salt.utils.dictupdate.merge_recurse(existing_data, dataset)
                 if existing_data == merged_data:
-                    ret["result"] = True
-                    ret["comment"] = "The file {0} is in the correct state".format(name)
+                    ret['result'] = True
+                    ret['comment'] = 'The file {0} is in the correct state'.format(name)
                     return ret
                 dataset = merged_data
     else:
         if deserializer_opts:
-            ret.setdefault("warnings", []).append(
-                "The 'deserializer_opts' option is ignored unless "
-                "merge_if_exists is set to True."
+            ret.setdefault('warnings', []).append(
+                'The \'deserializer_opts\' option is ignored unless '
+                'merge_if_exists is set to True.'
             )
 
     contents = __serializers__[serializer_name](
-        dataset, **serializer_options.get(serializer_name, {})
+        dataset,
+        **serializer_options.get(serializer_name, {})
     )
 
-    contents += "\n"
+    contents += '\n'
 
     # Make sure that any leading zeros stripped by YAML loader are added back
     mode = salt.utils.files.normalize_mode(mode)
 
-    if __opts__["test"]:
+    if __opts__['test']:
         try:
-            ret["changes"] = __salt__["file.check_managed_changes"](
+            ret['changes'] = __salt__['file.check_managed_changes'](
                 name=name,
                 source=None,
                 source_hash={},
@@ -7464,25 +7393,24 @@ def serialize(
                 **kwargs
             )
         except CommandExecutionError as exc:
-            ret["result"] = False
-            ret["comment"] = six.text_type(exc)
+            ret['result'] = False
+            ret['comment'] = six.text_type(exc)
             return ret
 
-        if ret["changes"]:
-            ret["result"] = None
-            ret["comment"] = "Dataset will be serialized and stored into {0}".format(
-                name
-            )
+        if ret['changes']:
+            ret['result'] = None
+            ret['comment'] = 'Dataset will be serialized and stored into {0}'.format(
+                name)
 
             if not show_changes:
-                ret["changes"]["diff"] = "<show_changes=False>"
+                ret['changes']['diff'] = '<show_changes=False>'
         else:
-            ret["result"] = True
-            ret["comment"] = "The file {0} is in the correct state".format(name)
+            ret['result'] = True
+            ret['comment'] = 'The file {0} is in the correct state'.format(name)
     else:
-        ret = __salt__["file.manage_file"](
+        ret = __salt__['file.manage_file'](
             name=name,
-            sfn="",
+            sfn='',
             ret=ret,
             source=None,
             source_sum={},
@@ -7497,19 +7425,18 @@ def serialize(
             show_changes=show_changes,
             encoding=encoding,
             encoding_errors=encoding_errors,
-            contents=contents,
+            contents=contents
         )
 
     if isinstance(existing_data, dict) and isinstance(merged_data, dict):
-        ret["changes"]["diff"] = salt.utils.dictdiffer.recursive_diff(
-            existing_data, merged_data
-        ).diffs
+        ret['changes']['diff'] = salt.utils.dictdiffer.recursive_diff(
+            existing_data, merged_data).diffs
 
     return ret
 
 
-def mknod(name, ntype, major=0, minor=0, user=None, group=None, mode="0600"):
-    """
+def mknod(name, ntype, major=0, minor=0, user=None, group=None, mode='0600'):
+    '''
     Create a special file similar to the 'nix mknod command. The supported
     device types are ``p`` (fifo pipe), ``c`` (character device), and ``b``
     (block device). Provide the major and minor numbers when specifying a
@@ -7577,140 +7504,171 @@ def mknod(name, ntype, major=0, minor=0, user=None, group=None, mode="0600"):
             - mode: 660
 
     .. versionadded:: 0.17.0
-    """
+    '''
     name = os.path.expanduser(name)
 
-    ret = {"name": name, "changes": {}, "comment": "", "result": False}
+    ret = {'name': name,
+           'changes': {},
+           'comment': '',
+           'result': False}
     if not name:
-        return _error(ret, "Must provide name to file.mknod")
+        return _error(ret, 'Must provide name to file.mknod')
 
-    if ntype == "c":
+    if ntype == 'c':
         # Check for file existence
-        if __salt__["file.file_exists"](name):
-            ret["comment"] = (
-                "File {0} exists and is not a character device. Refusing "
-                "to continue".format(name)
+        if __salt__['file.file_exists'](name):
+            ret['comment'] = (
+                'File {0} exists and is not a character device. Refusing '
+                'to continue'.format(name)
             )
 
         # Check if it is a character device
-        elif not __salt__["file.is_chrdev"](name):
-            if __opts__["test"]:
-                ret["comment"] = "Character device {0} is set to be created".format(
-                    name
-                )
-                ret["result"] = None
+        elif not __salt__['file.is_chrdev'](name):
+            if __opts__['test']:
+                ret['comment'] = \
+                    'Character device {0} is set to be created'.format(name)
+                ret['result'] = None
             else:
-                ret = __salt__["file.mknod"](
-                    name, ntype, major, minor, user, group, mode
-                )
+                ret = __salt__['file.mknod'](name,
+                                             ntype,
+                                             major,
+                                             minor,
+                                             user,
+                                             group,
+                                             mode)
 
         # Check the major/minor
         else:
-            devmaj, devmin = __salt__["file.get_devmm"](name)
+            devmaj, devmin = __salt__['file.get_devmm'](name)
             if (major, minor) != (devmaj, devmin):
-                ret["comment"] = (
-                    "Character device {0} exists and has a different "
-                    "major/minor {1}/{2}. Refusing to continue".format(
+                ret['comment'] = (
+                    'Character device {0} exists and has a different '
+                    'major/minor {1}/{2}. Refusing to continue'
+                        .format(name, devmaj, devmin)
+                )
+            # Check the perms
+            else:
+                ret = __salt__['file.check_perms'](name,
+                                                   None,
+                                                   user,
+                                                   group,
+                                                   mode)[0]
+                if not ret['changes']:
+                    ret['comment'] = (
+                        'Character device {0} is in the correct state'.format(
+                            name
+                        )
+                    )
+
+    elif ntype == 'b':
+        # Check for file existence
+        if __salt__['file.file_exists'](name):
+            ret['comment'] = (
+                'File {0} exists and is not a block device. Refusing to '
+                'continue'.format(name)
+            )
+
+        # Check if it is a block device
+        elif not __salt__['file.is_blkdev'](name):
+            if __opts__['test']:
+                ret['comment'] = 'Block device {0} is set to be created'.format(name)
+                ret['result'] = None
+            else:
+                ret = __salt__['file.mknod'](name,
+                                             ntype,
+                                             major,
+                                             minor,
+                                             user,
+                                             group,
+                                             mode)
+
+        # Check the major/minor
+        else:
+            devmaj, devmin = __salt__['file.get_devmm'](name)
+            if (major, minor) != (devmaj, devmin):
+                ret['comment'] = (
+                    'Block device {0} exists and has a different major/minor '
+                    '{1}/{2}. Refusing to continue'.format(
                         name, devmaj, devmin
                     )
                 )
             # Check the perms
             else:
-                ret = __salt__["file.check_perms"](name, None, user, group, mode)[0]
-                if not ret["changes"]:
-                    ret[
-                        "comment"
-                    ] = "Character device {0} is in the correct state".format(name)
-
-    elif ntype == "b":
-        # Check for file existence
-        if __salt__["file.file_exists"](name):
-            ret["comment"] = (
-                "File {0} exists and is not a block device. Refusing to "
-                "continue".format(name)
-            )
-
-        # Check if it is a block device
-        elif not __salt__["file.is_blkdev"](name):
-            if __opts__["test"]:
-                ret["comment"] = "Block device {0} is set to be created".format(name)
-                ret["result"] = None
-            else:
-                ret = __salt__["file.mknod"](
-                    name, ntype, major, minor, user, group, mode
-                )
-
-        # Check the major/minor
-        else:
-            devmaj, devmin = __salt__["file.get_devmm"](name)
-            if (major, minor) != (devmaj, devmin):
-                ret["comment"] = (
-                    "Block device {0} exists and has a different major/minor "
-                    "{1}/{2}. Refusing to continue".format(name, devmaj, devmin)
-                )
-            # Check the perms
-            else:
-                ret = __salt__["file.check_perms"](name, None, user, group, mode)[0]
-                if not ret["changes"]:
-                    ret["comment"] = "Block device {0} is in the correct state".format(
-                        name
+                ret = __salt__['file.check_perms'](name,
+                                                   None,
+                                                   user,
+                                                   group,
+                                                   mode)[0]
+                if not ret['changes']:
+                    ret['comment'] = (
+                        'Block device {0} is in the correct state'.format(name)
                     )
 
-    elif ntype == "p":
+    elif ntype == 'p':
         # Check for file existence
-        if __salt__["file.file_exists"](name):
-            ret["comment"] = (
-                "File {0} exists and is not a fifo pipe. Refusing to "
-                "continue".format(name)
+        if __salt__['file.file_exists'](name):
+            ret['comment'] = (
+                'File {0} exists and is not a fifo pipe. Refusing to '
+                'continue'.format(name)
             )
 
         # Check if it is a fifo
-        elif not __salt__["file.is_fifo"](name):
-            if __opts__["test"]:
-                ret["comment"] = "Fifo pipe {0} is set to be created".format(name)
-                ret["result"] = None
-            else:
-                ret = __salt__["file.mknod"](
-                    name, ntype, major, minor, user, group, mode
+        elif not __salt__['file.is_fifo'](name):
+            if __opts__['test']:
+                ret['comment'] = 'Fifo pipe {0} is set to be created'.format(
+                    name
                 )
+                ret['result'] = None
+            else:
+                ret = __salt__['file.mknod'](name,
+                                             ntype,
+                                             major,
+                                             minor,
+                                             user,
+                                             group,
+                                             mode)
 
         # Check the perms
         else:
-            ret = __salt__["file.check_perms"](name, None, user, group, mode)[0]
-            if not ret["changes"]:
-                ret["comment"] = "Fifo pipe {0} is in the correct state".format(name)
+            ret = __salt__['file.check_perms'](name,
+                                               None,
+                                               user,
+                                               group,
+                                               mode)[0]
+            if not ret['changes']:
+                ret['comment'] = (
+                    'Fifo pipe {0} is in the correct state'.format(name)
+                )
 
     else:
-        ret["comment"] = (
-            "Node type unavailable: '{0}'. Available node types are "
-            "character ('c'), block ('b'), and pipe ('p')".format(ntype)
+        ret['comment'] = (
+            'Node type unavailable: \'{0}\'. Available node types are '
+            'character (\'c\'), block (\'b\'), and pipe (\'p\')'.format(ntype)
         )
 
     return ret
 
 
 def mod_run_check_cmd(cmd, filename, **check_cmd_opts):
-    """
+    '''
     Execute the check_cmd logic.
 
     Return a result dict if ``check_cmd`` succeeds (check_cmd == 0)
     otherwise return True
-    """
+    '''
 
-    log.debug("running our check_cmd")
-    _cmd = "{0} {1}".format(cmd, filename)
-    cret = __salt__["cmd.run_all"](_cmd, **check_cmd_opts)
-    if cret["retcode"] != 0:
-        ret = {
-            "comment": "check_cmd execution failed",
-            "skip_watch": True,
-            "result": False,
-        }
+    log.debug('running our check_cmd')
+    _cmd = '{0} {1}'.format(cmd, filename)
+    cret = __salt__['cmd.run_all'](_cmd, **check_cmd_opts)
+    if cret['retcode'] != 0:
+        ret = {'comment': 'check_cmd execution failed',
+               'skip_watch': True,
+               'result': False}
 
-        if cret.get("stdout"):
-            ret["comment"] += "\n" + cret["stdout"]
-        if cret.get("stderr"):
-            ret["comment"] += "\n" + cret["stderr"]
+        if cret.get('stdout'):
+            ret['comment'] += '\n' + cret['stdout']
+        if cret.get('stderr'):
+            ret['comment'] += '\n' + cret['stderr']
 
         return ret
 
@@ -7718,14 +7676,12 @@ def mod_run_check_cmd(cmd, filename, **check_cmd_opts):
     return True
 
 
-def decode(
-    name,
-    encoded_data=None,
-    contents_pillar=None,
-    encoding_type="base64",
-    checksum="md5",
-):
-    """
+def decode(name,
+        encoded_data=None,
+        contents_pillar=None,
+        encoding_type='base64',
+        checksum='md5'):
+    '''
     Decode an encoded file and write it to disk
 
     .. versionadded:: 2016.3.0
@@ -7779,72 +7735,72 @@ def decode(
             - encoding_type: base64
             - encoded_data: |
                 {{ salt.pillar.get('path:to:data') | indent(8) }}
-    """
-    ret = {"name": name, "changes": {}, "result": False, "comment": ""}
+    '''
+    ret = {'name': name, 'changes': {}, 'result': False, 'comment': ''}
 
     if not (encoded_data or contents_pillar):
-        raise CommandExecutionError(
-            "Specify either the 'encoded_data' or " "'contents_pillar' argument."
-        )
+        raise CommandExecutionError("Specify either the 'encoded_data' or "
+                                    "'contents_pillar' argument.")
     elif encoded_data and contents_pillar:
-        raise CommandExecutionError(
-            "Specify only one 'encoded_data' or " "'contents_pillar' argument."
-        )
+        raise CommandExecutionError("Specify only one 'encoded_data' or "
+                                    "'contents_pillar' argument.")
     elif encoded_data:
         content = encoded_data
     elif contents_pillar:
-        content = __salt__["pillar.get"](contents_pillar, False)
+        content = __salt__['pillar.get'](contents_pillar, False)
         if content is False:
-            raise CommandExecutionError("Pillar data not found.")
+            raise CommandExecutionError('Pillar data not found.')
     else:
-        raise CommandExecutionError("No contents given.")
+        raise CommandExecutionError('No contents given.')
 
-    dest_exists = __salt__["file.file_exists"](name)
+    dest_exists = __salt__['file.file_exists'](name)
     if dest_exists:
-        instr = __salt__["hashutil.base64_decodestring"](content)
-        insum = __salt__["hashutil.digest"](instr, checksum)
+        instr = __salt__['hashutil.base64_decodestring'](content)
+        insum = __salt__['hashutil.digest'](instr, checksum)
         del instr  # no need to keep in-memory after we have the hash
-        outsum = __salt__["hashutil.digest_file"](name, checksum)
+        outsum = __salt__['hashutil.digest_file'](name, checksum)
 
         if insum != outsum:
-            ret["changes"] = {"old": outsum, "new": insum}
+            ret['changes'] = {
+                'old': outsum,
+                'new': insum,
+            }
 
-        if not ret["changes"]:
-            ret["comment"] = "File is in the correct state."
-            ret["result"] = True
+        if not ret['changes']:
+            ret['comment'] = 'File is in the correct state.'
+            ret['result'] = True
             return ret
 
-    if __opts__["test"] is True:
-        ret["comment"] = "File is set to be updated."
-        ret["result"] = None
+    if __opts__['test'] is True:
+        ret['comment'] = 'File is set to be updated.'
+        ret['result'] = None
         return ret
 
-    ret["result"] = __salt__["hashutil.base64_decodefile"](content, name)
-    ret["comment"] = "File was updated."
+    ret['result'] = __salt__['hashutil.base64_decodefile'](content, name)
+    ret['comment'] = 'File was updated.'
 
-    if not ret["changes"]:
-        ret["changes"] = {
-            "old": None,
-            "new": __salt__["hashutil.digest_file"](name, checksum),
+    if not ret['changes']:
+        ret['changes'] = {
+            'old': None,
+            'new': __salt__['hashutil.digest_file'](name, checksum),
         }
 
     return ret
 
 
 def shortcut(
-    name,
-    target,
-    arguments=None,
-    working_dir=None,
-    description=None,
-    icon_location=None,
-    force=False,
-    backupname=None,
-    makedirs=False,
-    user=None,
-    **kwargs
-):
-    """
+        name,
+        target,
+        arguments=None,
+        working_dir=None,
+        description=None,
+        icon_location=None,
+        force=False,
+        backupname=None,
+        makedirs=False,
+        user=None,
+        **kwargs):
+    '''
     Create a Windows shortcut
 
     If the file already exists and is a shortcut pointing to any location other
@@ -7897,20 +7853,23 @@ def shortcut(
 
         The default mode for new files and directories corresponds umask of salt
         process. For existing files and directories it's not enforced.
-    """
+    '''
     user = _test_owner(kwargs, user=user)
-    ret = {"name": name, "changes": {}, "result": True, "comment": ""}
+    ret = {'name': name,
+           'changes': {},
+           'result': True,
+           'comment': ''}
     if not salt.utils.platform.is_windows():
-        return _error(ret, "Shortcuts are only supported on Windows")
+        return _error(ret, 'Shortcuts are only supported on Windows')
     if not name:
-        return _error(ret, "Must provide name to file.shortcut")
-    if not name.endswith(".lnk") and not name.endswith(".url"):
+        return _error(ret, 'Must provide name to file.shortcut')
+    if not name.endswith('.lnk') and not name.endswith('.url'):
         return _error(ret, 'Name must end with either ".lnk" or ".url"')
 
     # Normalize paths; do this after error checks to avoid invalid input
     # getting expanded, e.g. '' turning into '.'
     name = os.path.realpath(os.path.expanduser(name))
-    if name.endswith(".lnk"):
+    if name.endswith('.lnk'):
         target = os.path.realpath(os.path.expanduser(target))
     if working_dir:
         working_dir = os.path.realpath(os.path.expanduser(working_dir))
@@ -7918,41 +7877,46 @@ def shortcut(
         icon_location = os.path.realpath(os.path.expanduser(icon_location))
 
     if user is None:
-        user = __opts__["user"]
+        user = __opts__['user']
 
     # Make sure the user exists in Windows
     # Salt default is 'root'
-    if not __salt__["user.info"](user):
+    if not __salt__['user.info'](user):
         # User not found, use the account salt is running under
         # If username not found, use System
-        user = __salt__["user.current"]()
+        user = __salt__['user.current']()
         if not user:
-            user = "SYSTEM"
+            user = 'SYSTEM'
 
     preflight_errors = []
-    uid = __salt__["file.user_to_uid"](user)
+    uid = __salt__['file.user_to_uid'](user)
 
-    if uid == "":
-        preflight_errors.append("User {0} does not exist".format(user))
+    if uid == '':
+        preflight_errors.append('User {0} does not exist'.format(user))
 
     if not os.path.isabs(name):
         preflight_errors.append(
-            "Specified file {0} is not an absolute path".format(name)
+            'Specified file {0} is not an absolute path'.format(name)
         )
 
     if preflight_errors:
-        msg = ". ".join(preflight_errors)
+        msg = '. '.join(preflight_errors)
         if len(preflight_errors) > 1:
-            msg += "."
+            msg += '.'
         return _error(ret, msg)
 
-    presult, pcomment, pchanges = _shortcut_check(
-        name, target, arguments, working_dir, description, icon_location, force, user
-    )
-    if __opts__["test"]:
-        ret["result"] = presult
-        ret["comment"] = pcomment
-        ret["changes"] = pchanges
+    presult, pcomment, pchanges = _shortcut_check(name,
+                                                  target,
+                                                  arguments,
+                                                  working_dir,
+                                                  description,
+                                                  icon_location,
+                                                  force,
+                                                  user)
+    if __opts__['test']:
+        ret['result'] = presult
+        ret['comment'] = pcomment
+        ret['changes'] = pchanges
         return ret
 
     if not os.path.isdir(os.path.dirname(name)):
@@ -7960,13 +7924,13 @@ def shortcut(
             try:
                 _makedirs(name=name, user=user)
             except CommandExecutionError as exc:
-                return _error(ret, "Drive {0} is not mapped".format(exc.message))
+                return _error(ret, 'Drive {0} is not mapped'.format(exc.message))
         else:
             return _error(
                 ret,
                 'Directory "{0}" for shortcut is not present'.format(
                     os.path.dirname(name)
-                ),
+                )
             )
 
     if os.path.isdir(name) or os.path.islink(name):
@@ -7975,50 +7939,36 @@ def shortcut(
             # Make a backup first
             if os.path.lexists(backupname):
                 if not force:
-                    return _error(
-                        ret,
-                        (
-                            (
-                                "File exists where the backup target {0} should go"
-                            ).format(backupname)
-                        ),
-                    )
+                    return _error(ret, ((
+                                            'File exists where the backup target {0} should go'
+                                        ).format(backupname)))
                 else:
-                    __salt__["file.remove"](backupname)
+                    __salt__['file.remove'](backupname)
                     time.sleep(1)  # wait for asynchronous deletion
             if not os.path.isdir(os.path.dirname(backupname)):
                 if makedirs:
                     try:
                         _makedirs(name=backupname)
                     except CommandExecutionError as exc:
-                        return _error(
-                            ret, "Drive {0} is not mapped".format(exc.message)
-                        )
+                        return _error(ret, 'Drive {0} is not mapped'.format(exc.message))
                 else:
-                    return _error(
-                        ret,
-                        ("Directory does not exist for" ' backup at "{0}"').format(
-                            os.path.dirname(backupname)
-                        ),
-                    )
+                    return _error(ret, (
+                                            'Directory does not exist for'
+                                            ' backup at "{0}"'
+                                        ).format(os.path.dirname(backupname)))
             os.rename(name, backupname)
             time.sleep(1)  # wait for asynchronous rename
         elif force:
             # Remove whatever is in the way
-            __salt__["file.remove"](name)
-            ret["changes"]["forced"] = "Shortcut was forcibly replaced"
+            __salt__['file.remove'](name)
+            ret['changes']['forced'] = 'Shortcut was forcibly replaced'
             time.sleep(1)  # wait for asynchronous deletion
         else:
             # Otherwise throw an error
-            return _error(
-                ret,
-                (
-                    (
-                        "Directory or symlink exists where the"
-                        ' shortcut "{0}" should be'
-                    ).format(name)
-                ),
-            )
+            return _error(ret, ((
+                                    'Directory or symlink exists where the'
+                                    ' shortcut "{0}" should be'
+                                ).format(name)))
 
     # This will just load the shortcut if it already exists
     # It won't create the file until calling scut.Save()
@@ -8032,13 +7982,15 @@ def shortcut(
     if arguments is not None:
         state_checks.append(scut.Arguments == arguments)
     if working_dir is not None:
-        state_checks.append(scut.WorkingDirectory.lower() == working_dir.lower())
+        state_checks.append(
+            scut.WorkingDirectory.lower() == working_dir.lower()
+        )
     if description is not None:
         state_checks.append(scut.Description == description)
     if icon_location is not None:
         state_checks.append(scut.IconLocation.lower() == icon_location.lower())
 
-    if __salt__["file.file_exists"](name):
+    if __salt__['file.file_exists'](name):
         # The shortcut exists, verify that it matches the desired state
         if not all(state_checks):
             # The target is wrong, delete it
@@ -8046,20 +7998,18 @@ def shortcut(
         else:
             if _check_shortcut_ownership(name, user):
                 # The shortcut looks good!
-                ret["comment"] = "Shortcut {0} is present and owned by " "{1}".format(
-                    name, user
-                )
+                ret['comment'] = ('Shortcut {0} is present and owned by '
+                                  '{1}'.format(name, user))
             else:
                 if _set_shortcut_ownership(name, user):
-                    ret["comment"] = "Set ownership of shortcut {0} to " "{1}".format(
-                        name, user
-                    )
-                    ret["changes"]["ownership"] = "{0}".format(user)
+                    ret['comment'] = ('Set ownership of shortcut {0} to '
+                                      '{1}'.format(name, user))
+                    ret['changes']['ownership'] = '{0}'.format(user)
                 else:
-                    ret["result"] = False
-                    ret["comment"] += (
-                        "Failed to set ownership of shortcut {0} to "
-                        "{1}".format(name, user)
+                    ret['result'] = False
+                    ret['comment'] += (
+                        'Failed to set ownership of shortcut {0} to '
+                        '{1}'.format(name, user)
                     )
             return ret
 
@@ -8077,28 +8027,29 @@ def shortcut(
                 scut.IconLocation = icon_location
             scut.Save()
         except (AttributeError, pywintypes.com_error) as exc:
-            ret["result"] = False
-            ret["comment"] = "Unable to create new shortcut {0} -> " "{1}: {2}".format(
-                name, target, exc
-            )
+            ret['result'] = False
+            ret['comment'] = ('Unable to create new shortcut {0} -> '
+                              '{1}: {2}'.format(name, target, exc))
             return ret
         else:
-            ret["comment"] = "Created new shortcut {0} -> " "{1}".format(name, target)
-            ret["changes"]["new"] = name
+            ret['comment'] = ('Created new shortcut {0} -> '
+                              '{1}'.format(name, target))
+            ret['changes']['new'] = name
 
         if not _check_shortcut_ownership(name, user):
             if not _set_shortcut_ownership(name, user):
-                ret["result"] = False
-                ret["comment"] += ", but was unable to set ownership to " "{0}".format(
-                    user
-                )
+                ret['result'] = False
+                ret['comment'] += (', but was unable to set ownership to '
+                                   '{0}'.format(user))
     return ret
 
 
-def cached(
-    name, source_hash="", source_hash_name=None, skip_verify=False, saltenv="base"
-):
-    """
+def cached(name,
+           source_hash='',
+           source_hash_name=None,
+           skip_verify=False,
+           saltenv='base'):
+    '''
     .. versionadded:: 2017.7.3
 
     Ensures that a file is saved to the minion's cache. This state is primarily
@@ -8174,28 +8125,28 @@ def cached(
 
     This function will return the cached path of the file, or an empty string
     if the file is not present in the minion cache.
-    """
-    ret = {"changes": {}, "comment": "", "name": name, "result": False}
+    '''
+    ret = {'changes': {},
+           'comment': '',
+           'name': name,
+           'result': False}
 
     try:
         parsed = _urlparse(name)
     except Exception:
-        ret["comment"] = "Only URLs or local file paths are valid input"
+        ret['comment'] = 'Only URLs or local file paths are valid input'
         return ret
 
     # This if statement will keep the state from proceeding if a remote source
     # is specified and no source_hash is presented (unless we're skipping hash
     # verification).
-    if (
-        not skip_verify
-        and not source_hash
-        and parsed.scheme in salt.utils.files.REMOTE_PROTOS
-    ):
-        ret["comment"] = (
-            "Unable to verify upstream hash of source file {0}, please set "
-            "source_hash or set skip_verify to True".format(
-                salt.utils.url.redact_http_basic_auth(name)
-            )
+    if not skip_verify \
+            and not source_hash \
+            and parsed.scheme in salt.utils.files.REMOTE_PROTOS:
+        ret['comment'] = (
+            'Unable to verify upstream hash of source file {0}, please set '
+            'source_hash or set skip_verify to True'.format(
+                salt.utils.url.redact_http_basic_auth(name))
         )
         return ret
 
@@ -8204,14 +8155,13 @@ def cached(
         # the hash out of a file containing checksums, if that is how the
         # source_hash was specified.
         try:
-            source_sum = __salt__["file.get_source_sum"](
+            source_sum = __salt__['file.get_source_sum'](
                 source=name,
                 source_hash=source_hash,
                 source_hash_name=source_hash_name,
-                saltenv=saltenv,
-            )
+                saltenv=saltenv)
         except CommandExecutionError as exc:
-            ret["comment"] = exc.strerror
+            ret['comment'] = exc.strerror
             return ret
         else:
             if not source_sum:
@@ -8220,10 +8170,10 @@ def cached(
                 # being raised, which we catch above. Nevertheless, we should
                 # provide useful information in the event that
                 # file.get_source_sum regresses.
-                ret["comment"] = (
-                    "Failed to get source hash from {0}. This may be a bug. "
-                    "If this error persists, please report it and set "
-                    "skip_verify to True to work around it.".format(source_hash)
+                ret['comment'] = (
+                    'Failed to get source hash from {0}. This may be a bug. '
+                    'If this error persists, please report it and set '
+                    'skip_verify to True to work around it.'.format(source_hash)
                 )
                 return ret
     else:
@@ -8235,59 +8185,65 @@ def cached(
         if os.path.exists(full_path):
             if not skip_verify and source_sum:
                 # Enforce the hash
-                local_hash = __salt__["file.get_hash"](
-                    full_path, source_sum.get("hash_type", __opts__["hash_type"])
-                )
-                if local_hash == source_sum["hsum"]:
-                    ret["result"] = True
-                    ret["comment"] = (
-                        "File {0} is present on the minion and has hash "
-                        "{1}".format(full_path, local_hash)
+                local_hash = __salt__['file.get_hash'](
+                    full_path,
+                    source_sum.get('hash_type', __opts__['hash_type']))
+                if local_hash == source_sum['hsum']:
+                    ret['result'] = True
+                    ret['comment'] = (
+                        'File {0} is present on the minion and has hash '
+                        '{1}'.format(full_path, local_hash)
                     )
                 else:
-                    ret["comment"] = (
-                        "File {0} is present on the minion, but the hash ({1}) "
-                        "does not match the specified hash ({2})".format(
-                            full_path, local_hash, source_sum["hsum"]
+                    ret['comment'] = (
+                        'File {0} is present on the minion, but the hash ({1}) '
+                        'does not match the specified hash ({2})'.format(
+                            full_path, local_hash, source_sum['hsum']
                         )
                     )
                 return ret
             else:
-                ret["result"] = True
-                ret["comment"] = "File {0} is present on the minion".format(full_path)
+                ret['result'] = True
+                ret['comment'] = 'File {0} is present on the minion'.format(
+                    full_path
+                )
                 return ret
         else:
-            ret["comment"] = "File {0} is not present on the minion".format(full_path)
+            ret['comment'] = 'File {0} is not present on the minion'.format(
+                full_path
+            )
             return ret
 
-    local_copy = __salt__["cp.is_cached"](name, saltenv=saltenv)
+    local_copy = __salt__['cp.is_cached'](name, saltenv=saltenv)
 
     if local_copy:
         # File is already cached
-        pre_hash = __salt__["file.get_hash"](
-            local_copy, source_sum.get("hash_type", __opts__["hash_type"])
-        )
+        pre_hash = __salt__['file.get_hash'](
+            local_copy,
+            source_sum.get('hash_type', __opts__['hash_type']))
 
         if not skip_verify and source_sum:
             # Get the local copy's hash to compare with the hash that was
             # specified via source_hash. If it matches, we can exit early from
             # the state without going any further, because the file is cached
             # with the correct hash.
-            if pre_hash == source_sum["hsum"]:
-                ret["result"] = True
-                ret["comment"] = "File is already cached to {0} with hash {1}".format(
-                    local_copy, pre_hash
+            if pre_hash == source_sum['hsum']:
+                ret['result'] = True
+                ret['comment'] = (
+                    'File is already cached to {0} with hash {1}'.format(
+                        local_copy, pre_hash
+                    )
                 )
     else:
         pre_hash = None
 
     def _try_cache(path, checksum):
-        """
+        '''
         This helper is not needed anymore in develop as the fileclient in the
         develop branch now has means of skipping a download if the existing
         hash matches one passed to cp.cache_file. Remove this helper and the
         code that invokes it, once we have merged forward into develop.
-        """
+        '''
         if not path or not checksum:
             return True
         form = salt.utils.files.HASHES_REVMAP.get(len(checksum))
@@ -8311,59 +8267,63 @@ def cached(
     #      matches the cached copy.
     # Remote, non salt:// sources _will_ download if a copy of the file was
     # not already present in the minion cache.
-    if _try_cache(local_copy, source_sum.get("hsum")):
+    if _try_cache(local_copy, source_sum.get('hsum')):
         # The _try_cache helper is obsolete in the develop branch. Once merged
         # forward, remove the helper as well as this if statement, and dedent
         # the below block.
         try:
-            local_copy = __salt__["cp.cache_file"](
-                name, saltenv=saltenv, source_hash=source_sum.get("hsum")
-            )
+            local_copy = __salt__['cp.cache_file'](
+                name,
+                saltenv=saltenv,
+                source_hash=source_sum.get('hsum'))
         except Exception as exc:
-            ret["comment"] = salt.utils.url.redact_http_basic_auth(exc.__str__())
+            ret['comment'] = salt.utils.url.redact_http_basic_auth(exc.__str__())
             return ret
 
     if not local_copy:
-        ret["comment"] = (
-            "Failed to cache {0}, check minion log for more "
-            "information".format(salt.utils.url.redact_http_basic_auth(name))
+        ret['comment'] = (
+            'Failed to cache {0}, check minion log for more '
+            'information'.format(
+                salt.utils.url.redact_http_basic_auth(name))
         )
         return ret
 
-    post_hash = __salt__["file.get_hash"](
-        local_copy, source_sum.get("hash_type", __opts__["hash_type"])
-    )
+    post_hash = __salt__['file.get_hash'](
+        local_copy,
+        source_sum.get('hash_type', __opts__['hash_type']))
 
     if pre_hash != post_hash:
-        ret["changes"]["hash"] = {"old": pre_hash, "new": post_hash}
+        ret['changes']['hash'] = {'old': pre_hash, 'new': post_hash}
 
     # Check the hash, if we're enforcing one. Note that this will be the first
     # hash check if the file was not previously cached, and the 2nd hash check
     # if it was cached and the
     if not skip_verify and source_sum:
-        if post_hash == source_sum["hsum"]:
-            ret["result"] = True
-            ret["comment"] = "File is already cached to {0} with hash {1}".format(
-                local_copy, post_hash
+        if post_hash == source_sum['hsum']:
+            ret['result'] = True
+            ret['comment'] = (
+                'File is already cached to {0} with hash {1}'.format(
+                    local_copy, post_hash
+                )
             )
         else:
-            ret["comment"] = (
-                "File is cached to {0}, but the hash ({1}) does not match "
-                "the specified hash ({2})".format(
-                    local_copy, post_hash, source_sum["hsum"]
+            ret['comment'] = (
+                'File is cached to {0}, but the hash ({1}) does not match '
+                'the specified hash ({2})'.format(
+                    local_copy, post_hash, source_sum['hsum']
                 )
             )
         return ret
 
     # We're not enforcing a hash, and we already know that the file was
     # successfully cached, so we know the state was successful.
-    ret["result"] = True
-    ret["comment"] = "File is cached to {0}".format(local_copy)
+    ret['result'] = True
+    ret['comment'] = 'File is cached to {0}'.format(local_copy)
     return ret
 
 
-def not_cached(name, saltenv="base"):
-    """
+def not_cached(name, saltenv='base'):
+    '''
     .. versionadded:: 2017.7.3
 
     Ensures that a file is not present in the minion's cache, deleting it
@@ -8383,37 +8343,42 @@ def not_cached(name, saltenv="base"):
     saltenv
         Used to specify the environment from which to download a file from the
         Salt fileserver (i.e. those with ``salt://`` URL).
-    """
-    ret = {"changes": {}, "comment": "", "name": name, "result": False}
+    '''
+    ret = {'changes': {},
+           'comment': '',
+           'name': name,
+           'result': False}
 
     try:
         parsed = _urlparse(name)
     except Exception:
-        ret["comment"] = "Only URLs or local file paths are valid input"
+        ret['comment'] = 'Only URLs or local file paths are valid input'
         return ret
     else:
         if parsed.scheme in salt.utils.files.LOCAL_PROTOS:
             full_path = os.path.realpath(os.path.expanduser(parsed.path))
-            ret["result"] = True
-            ret["comment"] = "File {0} is a local path, no action taken".format(
-                full_path
+            ret['result'] = True
+            ret['comment'] = (
+                'File {0} is a local path, no action taken'.format(
+                    full_path
+                )
             )
             return ret
 
-    local_copy = __salt__["cp.is_cached"](name, saltenv=saltenv)
+    local_copy = __salt__['cp.is_cached'](name, saltenv=saltenv)
 
     if local_copy:
         try:
             os.remove(local_copy)
         except Exception as exc:
-            ret["comment"] = "Failed to delete {0}: {1}".format(
+            ret['comment'] = 'Failed to delete {0}: {1}'.format(
                 local_copy, exc.__str__()
             )
         else:
-            ret["result"] = True
-            ret["changes"]["deleted"] = True
-            ret["comment"] = "{0} was deleted".format(local_copy)
+            ret['result'] = True
+            ret['changes']['deleted'] = True
+            ret['comment'] = '{0} was deleted'.format(local_copy)
     else:
-        ret["result"] = True
-        ret["comment"] = "{0} is not cached".format(name)
+        ret['result'] = True
+        ret['comment'] = '{0} is not cached'.format(name)
     return ret

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-'''
+"""
 Operations on regular files, special files, directories, and symlinks
 =====================================================================
 
@@ -276,7 +276,7 @@ For example:
             first_of_month: 6
             first_of_year: all
 
-'''
+"""
 
 # Import python libs
 from __future__ import absolute_import, print_function, unicode_literals
@@ -292,7 +292,7 @@ import sys
 import time
 import traceback
 from collections import Iterable, Mapping, defaultdict
-from datetime import datetime, date   # python3 problem in the making?
+from datetime import datetime, date  # python3 problem in the making?
 
 # Import salt libs
 import salt.loader
@@ -321,37 +321,35 @@ if salt.utils.platform.is_windows():
 # Import 3rd-party libs
 from salt.ext import six
 from salt.ext.six.moves import zip_longest
-from salt.ext.six.moves.urllib.parse import urlparse as _urlparse  # pylint: disable=no-name-in-module
+from salt.ext.six.moves.urllib.parse import (
+    urlparse as _urlparse,
+)  # pylint: disable=no-name-in-module
+
 if salt.utils.platform.is_windows():
     import pywintypes
     import win32com.client
 
 log = logging.getLogger(__name__)
 
-COMMENT_REGEX = r'^([[:space:]]*){0}[[:space:]]?'
+COMMENT_REGEX = r"^([[:space:]]*){0}[[:space:]]?"
 __NOT_FOUND = object()
 
-__func_alias__ = {
-    'copy_': 'copy',
-}
+__func_alias__ = {"copy_": "copy"}
 
 
 def _get_accumulator_filepath():
-    '''
+    """
     Return accumulator data path.
-    '''
-    return os.path.join(
-        _get_accumulator_dir(__opts__['cachedir']),
-        __instance_id__
-    )
+    """
+    return os.path.join(_get_accumulator_dir(__opts__["cachedir"]), __instance_id__)
 
 
 def _load_accumulators():
     def _deserialize(path):
         serial = salt.payload.Serial(__opts__)
-        ret = {'accumulators': {}, 'accumulators_deps': {}}
+        ret = {"accumulators": {}, "accumulators_deps": {}}
         try:
-            with salt.utils.files.fopen(path, 'rb') as f:
+            with salt.utils.files.fopen(path, "rb") as f:
                 loaded = serial.load(f)
                 return loaded if loaded else ret
         except (IOError, NameError):
@@ -360,16 +358,15 @@ def _load_accumulators():
 
     loaded = _deserialize(_get_accumulator_filepath())
 
-    return loaded['accumulators'], loaded['accumulators_deps']
+    return loaded["accumulators"], loaded["accumulators_deps"]
 
 
 def _persist_accummulators(accumulators, accumulators_deps):
-    accumm_data = {'accumulators': accumulators,
-                   'accumulators_deps': accumulators_deps}
+    accumm_data = {"accumulators": accumulators, "accumulators_deps": accumulators_deps}
 
     serial = salt.payload.Serial(__opts__)
     try:
-        with salt.utils.files.fopen(_get_accumulator_filepath(), 'w+b') as f:
+        with salt.utils.files.fopen(_get_accumulator_filepath(), "w+b") as f:
             serial.dump(accumm_data, f)
     except NameError:
         # msgpack error from salt-ssh
@@ -377,25 +374,23 @@ def _persist_accummulators(accumulators, accumulators_deps):
 
 
 def _check_user(user, group):
-    '''
+    """
     Checks if the named user and group are present on the minion
-    '''
-    err = ''
+    """
+    err = ""
     if user:
-        uid = __salt__['file.user_to_uid'](user)
-        if uid == '':
-            err += 'User {0} is not available '.format(user)
+        uid = __salt__["file.user_to_uid"](user)
+        if uid == "":
+            err += "User {0} is not available ".format(user)
     if group:
-        gid = __salt__['file.group_to_gid'](group)
-        if gid == '':
-            err += 'Group {0} is not available'.format(group)
+        gid = __salt__["file.group_to_gid"](group)
+        if gid == "":
+            err += "Group {0} is not available".format(group)
     return err
 
 
-def _is_valid_relpath(
-        relpath,
-        maxdepth=None):
-    '''
+def _is_valid_relpath(relpath, maxdepth=None):
+    """
     Performs basic sanity checks on a relative path.
 
     Requires POSIX-compatible paths (i.e. the kind obtained through
@@ -403,7 +398,7 @@ def _is_valid_relpath(
 
     Ensures that the path does not contain directory transversal, and
     that it does not exceed a stated maximum depth (if specified).
-    '''
+    """
     # Check relpath surrounded by slashes, so that `..` can be caught as
     # a path component at the start, end, and in the middle of the path.
     sep, pardir = posixpath.sep, posixpath.pardir
@@ -420,25 +415,26 @@ def _is_valid_relpath(
 
 
 def _salt_to_os_path(path):
-    '''
+    """
     Converts a path from the form received via salt master to the OS's native
     path format.
-    '''
+    """
     return os.path.normpath(path.replace(posixpath.sep, os.path.sep))
 
 
 def _gen_recurse_managed_files(
-        name,
-        source,
-        keep_symlinks=False,
-        include_pat=None,
-        exclude_pat=None,
-        maxdepth=None,
-        include_empty=False,
-        **kwargs):
-    '''
+    name,
+    source,
+    keep_symlinks=False,
+    include_pat=None,
+    exclude_pat=None,
+    maxdepth=None,
+    include_empty=False,
+    **kwargs
+):
+    """
     Generate the list of files managed by a recurse state
-    '''
+    """
 
     # Convert a relative path generated from salt master paths to an OS path
     # using "name" as the base directory
@@ -452,7 +448,8 @@ def _gen_recurse_managed_files(
             if not _is_valid_relpath(srelpath, maxdepth=maxdepth):
                 continue
             if not salt.utils.stringutils.check_include_exclude(
-                    srelpath, include_pat, exclude_pat):
+                srelpath, include_pat, exclude_pat
+            ):
                 continue
             # Check for all paths that begin with the symlink
             # and axe it leaving only the dirs/files below it.
@@ -462,8 +459,7 @@ def _gen_recurse_managed_files(
             for filename in _filenames:
                 if filename.startswith(lname):
                     log.debug(
-                        '** skipping file ** %s, it intersects a symlink',
-                        filename
+                        "** skipping file ** %s, it intersects a symlink", filename
                     )
                     filenames.remove(filename)
             # Create the symlink along with the necessary dirs.
@@ -488,12 +484,12 @@ def _gen_recurse_managed_files(
     if not srcpath.endswith(posixpath.sep):
         # we're searching for things that start with this *directory*.
         srcpath = srcpath + posixpath.sep
-    fns_ = __salt__['cp.list_master'](senv, srcpath)
+    fns_ = __salt__["cp.list_master"](senv, srcpath)
 
     # If we are instructed to keep symlinks, then process them.
     if keep_symlinks:
         # Make this global so that emptydirs can use it if needed.
-        symlinks = __salt__['cp.list_master_symlinks'](senv, srcpath)
+        symlinks = __salt__["cp.list_master_symlinks"](senv, srcpath)
         fns_ = process_symlinks(fns_, symlinks)
 
     for fn_ in fns_:
@@ -511,7 +507,8 @@ def _gen_recurse_managed_files(
         # Check if it is to be excluded. Match only part of the path
         # relative to the target directory
         if not salt.utils.stringutils.check_include_exclude(
-                relname, include_pat, exclude_pat):
+            relname, include_pat, exclude_pat
+        ):
             continue
         dest = full_path(relname)
         dirname = os.path.dirname(dest)
@@ -526,13 +523,14 @@ def _gen_recurse_managed_files(
         managed_files.add((dest, src))
 
     if include_empty:
-        mdirs = __salt__['cp.list_master_dirs'](senv, srcpath)
+        mdirs = __salt__["cp.list_master_dirs"](senv, srcpath)
         for mdir in mdirs:
             relname = posixpath.relpath(mdir, srcpath)
             if not _is_valid_relpath(relname, maxdepth=maxdepth):
                 continue
             if not salt.utils.stringutils.check_include_exclude(
-                    relname, include_pat, exclude_pat):
+                relname, include_pat, exclude_pat
+            ):
                 continue
             mdest = full_path(relname)
             # Check for symlinks that happen to point to an empty dir.
@@ -541,8 +539,8 @@ def _gen_recurse_managed_files(
                 for link in symlinks:
                     if mdir.startswith(link, 0):
                         log.debug(
-                            '** skipping empty dir ** %s, it intersects a '
-                            'symlink', mdir
+                            "** skipping empty dir ** %s, it intersects a " "symlink",
+                            mdir,
                         )
                         islink = True
                         break
@@ -556,14 +554,15 @@ def _gen_recurse_managed_files(
 
 
 def _gen_keep_files(name, require, walk_d=None):
-    '''
+    """
     Generate the list of files that need to be kept when a dir based function
     like directory or recurse has a clean.
-    '''
+    """
+
     def _is_child(path, directory):
-        '''
+        """
         Check whether ``path`` is child of ``directory``
-        '''
+        """
         path = os.path.abspath(path)
         directory = os.path.abspath(directory)
 
@@ -604,19 +603,19 @@ def _gen_keep_files(name, require, walk_d=None):
 
     keep = set()
     if isinstance(require, list):
-        required_files = [comp for comp in require if 'file' in comp]
+        required_files = [comp for comp in require if "file" in comp]
         for comp in required_files:
             for low in __lowstate__:
                 # A requirement should match either the ID and the name of
                 # another state.
-                if low['name'] == comp['file'] or low['__id__'] == comp['file']:
-                    fn = low['name']
-                    fun = low['fun']
+                if low["name"] == comp["file"] or low["__id__"] == comp["file"]:
+                    fn = low["name"]
+                    fun = low["fun"]
                     if os.path.isdir(fn):
                         if _is_child(fn, name):
-                            if fun == 'recurse':
+                            if fun == "recurse":
                                 fkeep = _gen_recurse_managed_files(**low)[3]
-                                log.debug('Keep from %s: %s', fn, fkeep)
+                                log.debug("Keep from %s: %s", fn, fkeep)
                                 keep.update(fkeep)
                             elif walk_d:
                                 walk_ret = set()
@@ -626,29 +625,29 @@ def _gen_keep_files(name, require, walk_d=None):
                                 keep.update(_process(fn))
                     else:
                         keep.add(fn)
-    log.debug('Files to keep from required states: %s', list(keep))
+    log.debug("Files to keep from required states: %s", list(keep))
     return list(keep)
 
 
 def _check_file(name):
     ret = True
-    msg = ''
+    msg = ""
 
     if not os.path.isabs(name):
         ret = False
-        msg = 'Specified file {0} is not an absolute path'.format(name)
+        msg = "Specified file {0} is not an absolute path".format(name)
     elif not os.path.exists(name):
         ret = False
-        msg = '{0}: file not found'.format(name)
+        msg = "{0}: file not found".format(name)
 
     return ret, msg
 
 
 def _find_keep_files(root, keep):
-    '''
+    """
     Compile a list of valid keep files (and directories).
     Used by _clean_dir()
-    '''
+    """
     real_keep = set()
     real_keep.add(root)
     if isinstance(keep, list):
@@ -667,10 +666,10 @@ def _find_keep_files(root, keep):
 
 
 def _clean_dir(root, keep, exclude_pat):
-    '''
+    """
     Clean out all of the files and directories in a directory (root) while
     preserving the files in a list (keep) and part of exclude_pat
-    '''
+    """
     root = os.path.normcase(root)
     real_keep = _find_keep_files(root, keep)
     removed = set()
@@ -680,14 +679,15 @@ def _clean_dir(root, keep, exclude_pat):
             # -- check if this is a part of exclude_pat(only). No need to
             # check include_pat
             if not salt.utils.stringutils.check_include_exclude(
-                    os.path.relpath(nfn, root), None, exclude_pat):
+                os.path.relpath(nfn, root), None, exclude_pat
+            ):
                 return
             removed.add(nfn)
-            if not __opts__['test']:
+            if not __opts__["test"]:
                 try:
                     os.remove(nfn)
                 except OSError:
-                    __salt__['file.remove'](nfn)
+                    __salt__["file.remove"](nfn)
 
     for roots, dirs, files in salt.utils.path.os_walk(root):
         for name in itertools.chain(dirs, files):
@@ -696,26 +696,28 @@ def _clean_dir(root, keep, exclude_pat):
 
 
 def _error(ret, err_msg):
-    ret['result'] = False
-    ret['comment'] = err_msg
+    ret["result"] = False
+    ret["comment"] = err_msg
     return ret
 
 
-def _check_directory(name,
-                     user=None,
-                     group=None,
-                     recurse=False,
-                     mode=None,
-                     file_mode=None,
-                     clean=False,
-                     require=False,
-                     exclude_pat=None,
-                     max_depth=None,
-                     follow_symlinks=False,
-                     children_only=False):
-    '''
+def _check_directory(
+    name,
+    user=None,
+    group=None,
+    recurse=False,
+    mode=None,
+    file_mode=None,
+    clean=False,
+    require=False,
+    exclude_pat=None,
+    max_depth=None,
+    follow_symlinks=False,
+    children_only=False,
+):
+    """
     Check what changes need to be made on a directory
-    '''
+    """
     changes = {}
     if recurse or clean:
         assert max_depth is None or not clean
@@ -732,30 +734,28 @@ def _check_directory(name,
         try:
             recurse_set = _get_recurse_set(recurse)
         except (TypeError, ValueError) as exc:
-            return False, '{0}'.format(exc), changes
-        if 'user' not in recurse_set:
+            return False, "{0}".format(exc), changes
+        if "user" not in recurse_set:
             user = None
-        if 'group' not in recurse_set:
+        if "group" not in recurse_set:
             group = None
-        if 'mode' not in recurse_set:
+        if "mode" not in recurse_set:
             mode = None
-        check_files = 'ignore_files' not in recurse_set
-        check_dirs = 'ignore_dirs' not in recurse_set
+        check_files = "ignore_files" not in recurse_set
+        check_dirs = "ignore_dirs" not in recurse_set
         for root, dirs, files in walk_l:
             if check_files:
                 for fname in files:
                     fchange = {}
                     mode = file_mode if mode is not None else None
                     path = os.path.join(root, fname)
-                    stats = __salt__['file.stats'](
-                        path, None, follow_symlinks
-                    )
-                    if user is not None and user != stats.get('user'):
-                        fchange['user'] = user
-                    if group is not None and group != stats.get('group'):
-                        fchange['group'] = group
-                    if mode is not None and mode != stats.get('mode'):
-                        fchange['mode'] = mode
+                    stats = __salt__["file.stats"](path, None, follow_symlinks)
+                    if user is not None and user != stats.get("user"):
+                        fchange["user"] = user
+                    if group is not None and group != stats.get("group"):
+                        fchange["group"] = group
+                    if mode is not None and mode != stats.get("mode"):
+                        fchange["mode"] = mode
                     if fchange:
                         changes[path] = fchange
             if check_dirs:
@@ -780,10 +780,11 @@ def _check_directory(name,
                 return {}
             else:
                 if not salt.utils.stringutils.check_include_exclude(
-                        os.path.relpath(path, name), None, exclude_pat):
+                    os.path.relpath(path, name), None, exclude_pat
+                ):
                     return {}
                 else:
-                    return {path: {'removed': 'Removed due to clean'}}
+                    return {path: {"removed": "Removed due to clean"}}
 
         for root, dirs, files in walk_l:
             for fname in files:
@@ -792,37 +793,41 @@ def _check_directory(name,
                 changes.update(_check_changes(name_))
 
     if not os.path.isdir(name):
-        changes[name] = {'directory': 'new'}
+        changes[name] = {"directory": "new"}
     if changes:
-        comments = ['The following files will be changed:\n']
+        comments = ["The following files will be changed:\n"]
         for fn_ in changes:
             for key, val in six.iteritems(changes[fn_]):
-                comments.append('{0}: {1} - {2}\n'.format(fn_, key, val))
-        return None, ''.join(comments), changes
-    return True, 'The directory {0} is in the correct state'.format(name), changes
+                comments.append("{0}: {1} - {2}\n".format(fn_, key, val))
+        return None, "".join(comments), changes
+    return True, "The directory {0} is in the correct state".format(name), changes
 
 
-def _check_directory_win(name,
-                         win_owner=None,
-                         win_perms=None,
-                         win_deny_perms=None,
-                         win_inheritance=None,
-                         win_perms_reset=None):
-    '''
+def _check_directory_win(
+    name,
+    win_owner=None,
+    win_perms=None,
+    win_deny_perms=None,
+    win_inheritance=None,
+    win_perms_reset=None,
+):
+    """
     Check what changes need to be made on a directory
-    '''
+    """
     changes = {}
 
     if not os.path.isdir(name):
-        changes = {name: {'directory': 'new'}}
+        changes = {name: {"directory": "new"}}
     else:
         # Check owner by SID
         if win_owner is not None:
             current_owner = salt.utils.win_dacl.get_owner(name)
-            current_owner_sid = salt.utils.win_functions.get_sid_from_name(current_owner)
+            current_owner_sid = salt.utils.win_functions.get_sid_from_name(
+                current_owner
+            )
             expected_owner_sid = salt.utils.win_functions.get_sid_from_name(win_owner)
             if not current_owner_sid == expected_owner_sid:
-                changes['owner'] = win_owner
+                changes["owner"] = win_owner
 
         # Check perms
         perms = salt.utils.win_dacl.get_permissions(name)
@@ -838,42 +843,46 @@ def _check_directory_win(name,
 
                 grant_perms = []
                 # Check for permissions
-                if isinstance(win_perms[user]['perms'], six.string_types):
+                if isinstance(win_perms[user]["perms"], six.string_types):
                     if not salt.utils.win_dacl.has_permission(
-                            name, user, win_perms[user]['perms']):
-                        grant_perms = win_perms[user]['perms']
+                        name, user, win_perms[user]["perms"]
+                    ):
+                        grant_perms = win_perms[user]["perms"]
                 else:
-                    for perm in win_perms[user]['perms']:
+                    for perm in win_perms[user]["perms"]:
                         if not salt.utils.win_dacl.has_permission(
-                                name, user, perm, exact=False):
-                            grant_perms.append(win_perms[user]['perms'])
+                            name, user, perm, exact=False
+                        ):
+                            grant_perms.append(win_perms[user]["perms"])
                 if grant_perms:
-                    if 'grant_perms' not in changes:
-                        changes['grant_perms'] = {}
-                    if user not in changes['grant_perms']:
-                        changes['grant_perms'][user] = {}
-                    changes['grant_perms'][user]['perms'] = grant_perms
+                    if "grant_perms" not in changes:
+                        changes["grant_perms"] = {}
+                    if user not in changes["grant_perms"]:
+                        changes["grant_perms"][user] = {}
+                    changes["grant_perms"][user]["perms"] = grant_perms
 
                 # Check Applies to
-                if 'applies_to' not in win_perms[user]:
-                    applies_to = 'this_folder_subfolders_files'
+                if "applies_to" not in win_perms[user]:
+                    applies_to = "this_folder_subfolders_files"
                 else:
-                    applies_to = win_perms[user]['applies_to']
+                    applies_to = win_perms[user]["applies_to"]
 
                 if user in perms:
                     user = salt.utils.win_dacl.get_name(user)
 
                     # Get the proper applies_to text
-                    at_flag = salt.utils.win_dacl.flags().ace_prop['file'][applies_to]
-                    applies_to_text = salt.utils.win_dacl.flags().ace_prop['file'][at_flag]
+                    at_flag = salt.utils.win_dacl.flags().ace_prop["file"][applies_to]
+                    applies_to_text = salt.utils.win_dacl.flags().ace_prop["file"][
+                        at_flag
+                    ]
 
-                    if 'grant' in perms[user]:
-                        if not perms[user]['grant']['applies to'] == applies_to_text:
-                            if 'grant_perms' not in changes:
-                                changes['grant_perms'] = {}
-                            if user not in changes['grant_perms']:
-                                changes['grant_perms'][user] = {}
-                            changes['grant_perms'][user]['applies_to'] = applies_to
+                    if "grant" in perms[user]:
+                        if not perms[user]["grant"]["applies to"] == applies_to_text:
+                            if "grant_perms" not in changes:
+                                changes["grant_perms"] = {}
+                            if user not in changes["grant_perms"]:
+                                changes["grant_perms"][user] = {}
+                            changes["grant_perms"][user]["applies_to"] = applies_to
 
         # Verify Deny Permissions
         if win_deny_perms is not None:
@@ -886,123 +895,122 @@ def _check_directory_win(name,
 
                 deny_perms = []
                 # Check for permissions
-                if isinstance(win_deny_perms[user]['perms'], six.string_types):
+                if isinstance(win_deny_perms[user]["perms"], six.string_types):
                     if not salt.utils.win_dacl.has_permission(
-                            name, user, win_deny_perms[user]['perms'], 'deny'):
-                        deny_perms = win_deny_perms[user]['perms']
+                        name, user, win_deny_perms[user]["perms"], "deny"
+                    ):
+                        deny_perms = win_deny_perms[user]["perms"]
                 else:
-                    for perm in win_deny_perms[user]['perms']:
+                    for perm in win_deny_perms[user]["perms"]:
                         if not salt.utils.win_dacl.has_permission(
-                                name, user, perm, 'deny', exact=False):
-                            deny_perms.append(win_deny_perms[user]['perms'])
+                            name, user, perm, "deny", exact=False
+                        ):
+                            deny_perms.append(win_deny_perms[user]["perms"])
                 if deny_perms:
-                    if 'deny_perms' not in changes:
-                        changes['deny_perms'] = {}
-                    if user not in changes['deny_perms']:
-                        changes['deny_perms'][user] = {}
-                    changes['deny_perms'][user]['perms'] = deny_perms
+                    if "deny_perms" not in changes:
+                        changes["deny_perms"] = {}
+                    if user not in changes["deny_perms"]:
+                        changes["deny_perms"][user] = {}
+                    changes["deny_perms"][user]["perms"] = deny_perms
 
                 # Check Applies to
-                if 'applies_to' not in win_deny_perms[user]:
-                    applies_to = 'this_folder_subfolders_files'
+                if "applies_to" not in win_deny_perms[user]:
+                    applies_to = "this_folder_subfolders_files"
                 else:
-                    applies_to = win_deny_perms[user]['applies_to']
+                    applies_to = win_deny_perms[user]["applies_to"]
 
                 if user in perms:
                     user = salt.utils.win_dacl.get_name(user)
 
                     # Get the proper applies_to text
-                    at_flag = salt.utils.win_dacl.flags().ace_prop['file'][applies_to]
-                    applies_to_text = salt.utils.win_dacl.flags().ace_prop['file'][at_flag]
+                    at_flag = salt.utils.win_dacl.flags().ace_prop["file"][applies_to]
+                    applies_to_text = salt.utils.win_dacl.flags().ace_prop["file"][
+                        at_flag
+                    ]
 
-                    if 'deny' in perms[user]:
-                        if not perms[user]['deny']['applies to'] == applies_to_text:
-                            if 'deny_perms' not in changes:
-                                changes['deny_perms'] = {}
-                            if user not in changes['deny_perms']:
-                                changes['deny_perms'][user] = {}
-                            changes['deny_perms'][user]['applies_to'] = applies_to
+                    if "deny" in perms[user]:
+                        if not perms[user]["deny"]["applies to"] == applies_to_text:
+                            if "deny_perms" not in changes:
+                                changes["deny_perms"] = {}
+                            if user not in changes["deny_perms"]:
+                                changes["deny_perms"][user] = {}
+                            changes["deny_perms"][user]["applies_to"] = applies_to
 
         # Check inheritance
         if win_inheritance is not None:
             if not win_inheritance == salt.utils.win_dacl.get_inheritance(name):
-                changes['inheritance'] = win_inheritance
+                changes["inheritance"] = win_inheritance
 
         # Check reset
         if win_perms_reset:
             for user_name in perms:
                 if user_name not in win_perms:
-                    if 'grant' in perms[user_name] and not perms[user_name]['grant']['inherited']:
-                        if 'remove_perms' not in changes:
-                            changes['remove_perms'] = {}
-                        changes['remove_perms'].update({user_name: perms[user_name]})
+                    if (
+                        "grant" in perms[user_name]
+                        and not perms[user_name]["grant"]["inherited"]
+                    ):
+                        if "remove_perms" not in changes:
+                            changes["remove_perms"] = {}
+                        changes["remove_perms"].update({user_name: perms[user_name]})
                 if user_name not in win_deny_perms:
-                    if 'deny' in perms[user_name] and not perms[user_name]['deny']['inherited']:
-                        if 'remove_perms' not in changes:
-                            changes['remove_perms'] = {}
-                        changes['remove_perms'].update({user_name: perms[user_name]})
+                    if (
+                        "deny" in perms[user_name]
+                        and not perms[user_name]["deny"]["inherited"]
+                    ):
+                        if "remove_perms" not in changes:
+                            changes["remove_perms"] = {}
+                        changes["remove_perms"].update({user_name: perms[user_name]})
 
     if changes:
         return None, 'The directory "{0}" will be changed'.format(name), changes
 
-    return True, 'The directory {0} is in the correct state'.format(name), changes
+    return True, "The directory {0} is in the correct state".format(name), changes
 
 
-def _check_dir_meta(name,
-                    user,
-                    group,
-                    mode,
-                    follow_symlinks=False):
-    '''
+def _check_dir_meta(name, user, group, mode, follow_symlinks=False):
+    """
     Check the changes in directory metadata
-    '''
+    """
     try:
-        stats = __salt__['file.stats'](name, None, follow_symlinks)
+        stats = __salt__["file.stats"](name, None, follow_symlinks)
     except CommandExecutionError:
         stats = {}
 
     changes = {}
     if not stats:
-        changes['directory'] = 'new'
+        changes["directory"] = "new"
         return changes
-    if (user is not None
-            and user != stats['user']
-            and user != stats.get('uid')):
-        changes['user'] = user
-    if (group is not None
-            and group != stats['group']
-            and group != stats.get('gid')):
-        changes['group'] = group
+    if user is not None and user != stats["user"] and user != stats.get("uid"):
+        changes["user"] = user
+    if group is not None and group != stats["group"] and group != stats.get("gid"):
+        changes["group"] = group
     # Normalize the dir mode
-    smode = salt.utils.files.normalize_mode(stats['mode'])
+    smode = salt.utils.files.normalize_mode(stats["mode"])
     mode = salt.utils.files.normalize_mode(mode)
     if mode is not None and mode != smode:
-        changes['mode'] = mode
+        changes["mode"] = mode
     return changes
 
 
 def _check_touch(name, atime, mtime):
-    '''
+    """
     Check to see if a file needs to be updated or created
-    '''
-    ret = {
-        'result': None,
-        'comment': '',
-        'changes': {'new': name},
-    }
+    """
+    ret = {"result": None, "comment": "", "changes": {"new": name}}
     if not os.path.exists(name):
-        ret['comment'] = 'File {0} is set to be created'.format(name)
+        ret["comment"] = "File {0} is set to be created".format(name)
     else:
-        stats = __salt__['file.stats'](name, follow_symlinks=False)
-        if ((atime is not None
-             and six.text_type(atime) != six.text_type(stats['atime'])) or
-            (mtime is not None
-                and six.text_type(mtime) != six.text_type(stats['mtime']))):
-            ret['comment'] = 'Times set to be updated on file {0}'.format(name)
-            ret['changes'] = {'touched': name}
+        stats = __salt__["file.stats"](name, follow_symlinks=False)
+        if (
+            atime is not None and six.text_type(atime) != six.text_type(stats["atime"])
+        ) or (
+            mtime is not None and six.text_type(mtime) != six.text_type(stats["mtime"])
+        ):
+            ret["comment"] = "Times set to be updated on file {0}".format(name)
+            ret["changes"] = {"touched": name}
         else:
-            ret['result'] = True
-            ret['comment'] = 'File {0} exists and has the correct times'.format(name)
+            ret["result"] = True
+            ret["comment"] = "File {0} exists and has the correct times".format(name)
     return ret
 
 
@@ -1012,15 +1020,15 @@ def _get_symlink_ownership(path):
         return owner, owner
     else:
         return (
-            __salt__['file.get_user'](path, follow_symlinks=False),
-            __salt__['file.get_group'](path, follow_symlinks=False)
+            __salt__["file.get_user"](path, follow_symlinks=False),
+            __salt__["file.get_group"](path, follow_symlinks=False),
         )
 
 
 def _check_symlink_ownership(path, user, group, win_owner):
-    '''
+    """
     Check if the symlink ownership matches the specified user and group
-    '''
+    """
     cur_user, cur_group = _get_symlink_ownership(path)
     if salt.utils.platform.is_windows():
         return win_owner == cur_user
@@ -1029,10 +1037,10 @@ def _check_symlink_ownership(path, user, group, win_owner):
 
 
 def _set_symlink_ownership(path, user, group, win_owner):
-    '''
+    """
     Set the ownership of a symlink and return a boolean indicating
     success/failure
-    '''
+    """
     if salt.utils.platform.is_windows():
         try:
             salt.utils.win_dacl.set_owner(path, win_owner)
@@ -1040,72 +1048,87 @@ def _set_symlink_ownership(path, user, group, win_owner):
             pass
     else:
         try:
-            __salt__['file.lchown'](path, user, group)
+            __salt__["file.lchown"](path, user, group)
         except OSError:
             pass
     return _check_symlink_ownership(path, user, group, win_owner)
 
 
 def _symlink_check(name, target, force, user, group, win_owner):
-    '''
+    """
     Check the symlink function
-    '''
+    """
     changes = {}
-    if not os.path.exists(name) and not __salt__['file.is_link'](name):
-        changes['new'] = name
-        return None, 'Symlink {0} to {1} is set for creation'.format(
-            name, target
-        ), changes
-    if __salt__['file.is_link'](name):
-        if __salt__['file.readlink'](name) != target:
-            changes['change'] = name
-            return None, 'Link {0} target is set to be changed to {1}'.format(
-                name, target
-            ), changes
+    if not os.path.exists(name) and not __salt__["file.is_link"](name):
+        changes["new"] = name
+        return (
+            None,
+            "Symlink {0} to {1} is set for creation".format(name, target),
+            changes,
+        )
+    if __salt__["file.is_link"](name):
+        if __salt__["file.readlink"](name) != target:
+            changes["change"] = name
+            return (
+                None,
+                "Link {0} target is set to be changed to {1}".format(name, target),
+                changes,
+            )
         else:
             result = True
-            msg = 'The symlink {0} is present'.format(name)
+            msg = "The symlink {0} is present".format(name)
             if not _check_symlink_ownership(name, user, group, win_owner):
                 result = None
-                changes['ownership'] = '{0}:{1}'.format(*_get_symlink_ownership(name))
+                changes["ownership"] = "{0}:{1}".format(*_get_symlink_ownership(name))
                 msg += (
-                    ', but the ownership of the symlink would be changed '
-                    'from {2}:{3} to {0}:{1}'
+                    ", but the ownership of the symlink would be changed "
+                    "from {2}:{3} to {0}:{1}"
                 ).format(user, group, *_get_symlink_ownership(name))
             return result, msg, changes
     else:
         if force:
-            return None, ('The file or directory {0} is set for removal to '
-                          'make way for a new symlink targeting {1}'
-                          .format(name, target)), changes
-        return False, ('File or directory exists where the symlink {0} '
-                       'should be. Did you mean to use force?'.format(name)), changes
+            return (
+                None,
+                (
+                    "The file or directory {0} is set for removal to "
+                    "make way for a new symlink targeting {1}".format(name, target)
+                ),
+                changes,
+            )
+        return (
+            False,
+            (
+                "File or directory exists where the symlink {0} "
+                "should be. Did you mean to use force?".format(name)
+            ),
+            changes,
+        )
 
 
 def _test_owner(kwargs, user=None):
-    '''
+    """
     Convert owner to user, since other config management tools use owner,
     no need to punish people coming from other systems.
     PLEASE DO NOT DOCUMENT THIS! WE USE USER, NOT OWNER!!!!
-    '''
+    """
     if user:
         return user
-    if 'owner' in kwargs:
+    if "owner" in kwargs:
         log.warning(
-            'Use of argument owner found, "owner" is invalid, please '
-            'use "user"'
+            'Use of argument owner found, "owner" is invalid, please ' 'use "user"'
         )
-        return kwargs['owner']
+        return kwargs["owner"]
 
     return user
 
 
-def _unify_sources_and_hashes(source=None, source_hash=None,
-                              sources=None, source_hashes=None):
-    '''
+def _unify_sources_and_hashes(
+    source=None, source_hash=None, sources=None, source_hashes=None
+):
+    """
     Silly little function to give us a standard tuple list for sources and
     source_hashes
-    '''
+    """
     if sources is None:
         sources = []
 
@@ -1113,39 +1136,36 @@ def _unify_sources_and_hashes(source=None, source_hash=None,
         source_hashes = []
 
     if source and sources:
-        return (False,
-                "source and sources are mutually exclusive", [])
+        return (False, "source and sources are mutually exclusive", [])
 
     if source_hash and source_hashes:
-        return (False,
-                "source_hash and source_hashes are mutually exclusive", [])
+        return (False, "source_hash and source_hashes are mutually exclusive", [])
 
     if source:
-        return (True, '', [(source, source_hash)])
+        return (True, "", [(source, source_hash)])
 
     # Make a nice neat list of tuples exactly len(sources) long..
-    return True, '', list(zip_longest(sources, source_hashes[:len(sources)]))
+    return True, "", list(zip_longest(sources, source_hashes[: len(sources)]))
 
 
-def _get_template_texts(source_list=None,
-                        template='jinja',
-                        defaults=None,
-                        context=None,
-                        **kwargs):
-    '''
+def _get_template_texts(
+    source_list=None, template="jinja", defaults=None, context=None, **kwargs
+):
+    """
     Iterate a list of sources and process them as templates.
     Returns a list of 'chunks' containing the rendered templates.
-    '''
+    """
 
-    ret = {'name': '_get_template_texts',
-           'changes': {},
-           'result': True,
-           'comment': '',
-           'data': []}
+    ret = {
+        "name": "_get_template_texts",
+        "changes": {},
+        "result": True,
+        "comment": "",
+        "data": [],
+    }
 
     if source_list is None:
-        return _error(ret,
-                      '_get_template_texts called with empty source_list')
+        return _error(ret, "_get_template_texts called with empty source_list")
 
     txtl = []
 
@@ -1154,44 +1174,45 @@ def _get_template_texts(source_list=None,
         context_dict = defaults if defaults else {}
         if context:
             context_dict = salt.utils.dictupdate.merge(context_dict, context)
-        rndrd_templ_fn = __salt__['cp.get_template'](
+        rndrd_templ_fn = __salt__["cp.get_template"](
             source,
-            '',
+            "",
             template=template,
             saltenv=__env__,
             context=context_dict,
             **kwargs
         )
-        log.debug('cp.get_template returned %s (Called with: %s)',
-                  rndrd_templ_fn, source)
+        log.debug(
+            "cp.get_template returned %s (Called with: %s)", rndrd_templ_fn, source
+        )
         if rndrd_templ_fn:
             tmplines = None
-            with salt.utils.files.fopen(rndrd_templ_fn, 'rb') as fp_:
+            with salt.utils.files.fopen(rndrd_templ_fn, "rb") as fp_:
                 tmplines = fp_.read()
                 tmplines = salt.utils.stringutils.to_unicode(tmplines)
                 tmplines = tmplines.splitlines(True)
             if not tmplines:
-                msg = 'Failed to read rendered template file {0} ({1})'.format(
+                msg = "Failed to read rendered template file {0} ({1})".format(
                     rndrd_templ_fn, source
                 )
                 log.debug(msg)
-                ret['name'] = source
+                ret["name"] = source
                 return _error(ret, msg)
-            txtl.append(''.join(tmplines))
+            txtl.append("".join(tmplines))
         else:
-            msg = 'Failed to load template file {0}'.format(source)
+            msg = "Failed to load template file {0}".format(source)
             log.debug(msg)
-            ret['name'] = source
+            ret["name"] = source
             return _error(ret, msg)
 
-    ret['data'] = txtl
+    ret["data"] = txtl
     return ret
 
 
 def _validate_str_list(arg, encoding=None):
-    '''
+    """
     ensure ``arg`` is a list of strings
-    '''
+    """
     if isinstance(arg, six.binary_type):
         ret = [salt.utils.stringutils.to_unicode(arg, encoding=encoding)]
     elif isinstance(arg, six.string_types):
@@ -1209,46 +1230,43 @@ def _validate_str_list(arg, encoding=None):
 
 
 def _get_shortcut_ownership(path):
-    return __salt__['file.get_user'](path, follow_symlinks=False)
+    return __salt__["file.get_user"](path, follow_symlinks=False)
 
 
 def _check_shortcut_ownership(path, user):
-    '''
+    """
     Check if the shortcut ownership matches the specified user
-    '''
+    """
     cur_user = _get_shortcut_ownership(path)
     return cur_user == user
 
 
 def _set_shortcut_ownership(path, user):
-    '''
+    """
     Set the ownership of a shortcut and return a boolean indicating
     success/failure
-    '''
+    """
     try:
-        __salt__['file.lchown'](path, user)
+        __salt__["file.lchown"](path, user)
     except OSError:
         pass
     return _check_shortcut_ownership(path, user)
 
 
-def _shortcut_check(name,
-                    target,
-                    arguments,
-                    working_dir,
-                    description,
-                    icon_location,
-                    force,
-                    user):
-    '''
+def _shortcut_check(
+    name, target, arguments, working_dir, description, icon_location, force, user
+):
+    """
     Check the shortcut function
-    '''
+    """
     changes = {}
     if not os.path.exists(name):
-        changes['new'] = name
-        return None, 'Shortcut "{0}" to "{1}" is set for creation'.format(
-            name, target
-        ), changes
+        changes["new"] = name
+        return (
+            None,
+            'Shortcut "{0}" to "{1}" is set for creation'.format(name, target),
+            changes,
+        )
 
     if os.path.isfile(name):
         with salt.utils.winapi.Com():
@@ -1258,50 +1276,63 @@ def _shortcut_check(name,
         if arguments is not None:
             state_checks.append(scut.Arguments == arguments)
         if working_dir is not None:
-            state_checks.append(
-                scut.WorkingDirectory.lower() == working_dir.lower()
-            )
+            state_checks.append(scut.WorkingDirectory.lower() == working_dir.lower())
         if description is not None:
             state_checks.append(scut.Description == description)
         if icon_location is not None:
-            state_checks.append(
-                scut.IconLocation.lower() == icon_location.lower()
-            )
+            state_checks.append(scut.IconLocation.lower() == icon_location.lower())
 
         if not all(state_checks):
-            changes['change'] = name
-            return None, 'Shortcut "{0}" target is set to be changed to "{1}"'.format(
-                name, target
-            ), changes
+            changes["change"] = name
+            return (
+                None,
+                'Shortcut "{0}" target is set to be changed to "{1}"'.format(
+                    name, target
+                ),
+                changes,
+            )
         else:
             result = True
             msg = 'The shortcut "{0}" is present'.format(name)
             if not _check_shortcut_ownership(name, user):
                 result = None
-                changes['ownership'] = '{0}'.format(_get_shortcut_ownership(name))
+                changes["ownership"] = "{0}".format(_get_shortcut_ownership(name))
                 msg += (
-                    ', but the ownership of the shortcut would be changed '
-                    'from {1} to {0}'
+                    ", but the ownership of the shortcut would be changed "
+                    "from {1} to {0}"
                 ).format(user, _get_shortcut_ownership(name))
             return result, msg, changes
     else:
         if force:
-            return None, ('The link or directory "{0}" is set for removal to '
-                          'make way for a new shortcut targeting "{1}"'
-                          .format(name, target)), changes
-        return False, ('Link or directory exists where the shortcut "{0}" '
-                       'should be. Did you mean to use force?'.format(name)), changes
+            return (
+                None,
+                (
+                    'The link or directory "{0}" is set for removal to '
+                    'make way for a new shortcut targeting "{1}"'.format(name, target)
+                ),
+                changes,
+            )
+        return (
+            False,
+            (
+                'Link or directory exists where the shortcut "{0}" '
+                "should be. Did you mean to use force?".format(name)
+            ),
+            changes,
+        )
 
 
-def _makedirs(name,
-              user=None,
-              group=None,
-              dir_mode=None,
-              win_owner=None,
-              win_perms=None,
-              win_deny_perms=None,
-              win_inheritance=None):
-    '''
+def _makedirs(
+    name,
+    user=None,
+    group=None,
+    dir_mode=None,
+    win_owner=None,
+    win_perms=None,
+    win_deny_perms=None,
+    win_inheritance=None,
+):
+    """
     Helper function for creating directories when the ``makedirs`` option is set
     to ``True``. Handles Unix and Windows based systems
 
@@ -1324,7 +1355,7 @@ def _makedirs(name,
 
     Raises:
         CommandExecutionError: If the drive is not mounted on Windows
-    '''
+    """
     if salt.utils.platform.is_windows():
         # Make sure the drive is mapped before trying to create the
         # path in windows
@@ -1332,35 +1363,37 @@ def _makedirs(name,
         if not os.path.isdir(drive):
             raise CommandExecutionError(drive)
         win_owner = win_owner if win_owner else user
-        return __salt__['file.makedirs'](path=name,
-                                         owner=win_owner,
-                                         grant_perms=win_perms,
-                                         deny_perms=win_deny_perms,
-                                         inheritance=win_inheritance)
+        return __salt__["file.makedirs"](
+            path=name,
+            owner=win_owner,
+            grant_perms=win_perms,
+            deny_perms=win_deny_perms,
+            inheritance=win_inheritance,
+        )
     else:
-        return __salt__['file.makedirs'](path=name,
-                                         user=user,
-                                         group=group,
-                                         mode=dir_mode)
+        return __salt__["file.makedirs"](
+            path=name, user=user, group=group, mode=dir_mode
+        )
 
 
 def symlink(
-        name,
-        target,
-        force=False,
-        backupname=None,
-        makedirs=False,
-        user=None,
-        group=None,
-        copy_target_user=False,
-        copy_target_group=False,
-        mode=None,
-        win_owner=None,
-        win_perms=None,
-        win_deny_perms=None,
-        win_inheritance=None,
-        **kwargs):
-    '''
+    name,
+    target,
+    force=False,
+    backupname=None,
+    makedirs=False,
+    user=None,
+    group=None,
+    copy_target_user=False,
+    copy_target_group=False,
+    mode=None,
+    win_owner=None,
+    win_perms=None,
+    win_deny_perms=None,
+    win_inheritance=None,
+    **kwargs
+):
+    """
     Create a symbolic link (symlink, soft link)
 
     If the file already exists and is a symlink pointing to any location other
@@ -1446,44 +1479,47 @@ def symlink(
         True to inherit permissions from parent, otherwise False
 
         .. versionadded:: 2017.7.7
-    '''
+    """
     name = os.path.expanduser(name)
 
     # Make sure that leading zeros stripped by YAML loader are added back
     mode = salt.utils.files.normalize_mode(mode)
 
     user = _test_owner(kwargs, user=user)
-    ret = {'name': name,
-           'changes': {},
-           'result': True,
-           'comment': ''}
+    ret = {"name": name, "changes": {}, "result": True, "comment": ""}
     if not name:
-        return _error(ret, 'Must provide name to file.symlink')
+        return _error(ret, "Must provide name to file.symlink")
 
     if copy_target_user:
         if user:
-            log.warning('`copy_target_user` and `user` are mutually exclusive. Using `user`.')
+            log.warning(
+                "`copy_target_user` and `user` are mutually exclusive. Using `user`."
+            )
         else:
             try:
-                user = __salt__['file.get_user'](target)
+                user = __salt__["file.get_user"](target)
             except CommandExecutionError:
-                ret['result'] = False
-                ret['comment'] = '`copy_target_user` is set, but target `{0}` does not exist.'.format(target)
+                ret["result"] = False
+                ret[
+                    "comment"
+                ] = "`copy_target_user` is set, but target `{0}` does not exist.".format(
+                    target
+                )
                 return ret
 
     if user is None:
-        user = __opts__['user']
+        user = __opts__["user"]
 
     if salt.utils.platform.is_windows():
 
         # Make sure the user exists in Windows
         # Salt default is 'root'
-        if not __salt__['user.info'](user):
+        if not __salt__["user.info"](user):
             # User not found, use the account salt is running under
             # If username not found, use System
-            user = __salt__['user.current']()
+            user = __salt__["user.current"]()
             if not user:
-                user = 'SYSTEM'
+                user = "SYSTEM"
 
         # If win_owner is not passed, use user
         if win_owner is None:
@@ -1492,35 +1528,40 @@ def symlink(
         # Group isn't relevant to Windows, use win_perms/win_deny_perms
         if group is not None:
             log.warning(
-                'The group argument for %s has been ignored as this '
-                'is a Windows system. Please use the `win_*` parameters to set '
-                'permissions in Windows.', name
+                "The group argument for %s has been ignored as this "
+                "is a Windows system. Please use the `win_*` parameters to set "
+                "permissions in Windows.",
+                name,
             )
 
         if copy_target_group is not None:
             log.warning(
-                'The copy_target_group argument for {0} has been ignored as this '
-                'is a Windows system. Please use the `win_*` parameters to set '
-                'permissions in Windows.'.format(name)
+                "The copy_target_group argument for {0} has been ignored as this "
+                "is a Windows system. Please use the `win_*` parameters to set "
+                "permissions in Windows.".format(name)
             )
 
         group = user
 
     if copy_target_group:
         if group:
-            log.warning('`copy_target_group` and `group` are mutually exclusive. Using `group`.')
+            log.warning(
+                "`copy_target_group` and `group` are mutually exclusive. Using `group`."
+            )
         else:
             try:
-                group = __salt__['file.get_group'](target)
+                group = __salt__["file.get_group"](target)
             except CommandExecutionError:
-                ret['result'] = False
-                ret['comment'] = '`copy_target_group` is set, but target `{0}` does not exist.'.format(target)
+                ret["result"] = False
+                ret[
+                    "comment"
+                ] = "`copy_target_group` is set, but target `{0}` does not exist.".format(
+                    target
+                )
                 return ret
 
     if group is None:
-        group = __salt__['file.gid_to_group'](
-            __salt__['user.info'](user).get('gid', 0)
-        )
+        group = __salt__["file.gid_to_group"](__salt__["user.info"](user).get("gid", 0))
 
     preflight_errors = []
     if salt.utils.platform.is_windows():
@@ -1528,7 +1569,7 @@ def symlink(
         try:
             salt.utils.win_functions.get_sid_from_name(win_owner)
         except CommandExecutionError as exc:
-            preflight_errors.append('User {0} does not exist'.format(win_owner))
+            preflight_errors.append("User {0} does not exist".format(win_owner))
 
         # Make sure users passed in win_perms exist
         if win_perms:
@@ -1536,7 +1577,9 @@ def symlink(
                 try:
                     salt.utils.win_functions.get_sid_from_name(name_check)
                 except CommandExecutionError as exc:
-                    preflight_errors.append('User {0} does not exist'.format(name_check))
+                    preflight_errors.append(
+                        "User {0} does not exist".format(name_check)
+                    )
 
         # Make sure users passed in win_deny_perms exist
         if win_deny_perms:
@@ -1544,104 +1587,117 @@ def symlink(
                 try:
                     salt.utils.win_functions.get_sid_from_name(name_check)
                 except CommandExecutionError as exc:
-                    preflight_errors.append('User {0} does not exist'.format(name_check))
+                    preflight_errors.append(
+                        "User {0} does not exist".format(name_check)
+                    )
     else:
-        uid = __salt__['file.user_to_uid'](user)
-        gid = __salt__['file.group_to_gid'](group)
+        uid = __salt__["file.user_to_uid"](user)
+        gid = __salt__["file.group_to_gid"](group)
 
-        if uid == '':
-            preflight_errors.append('User {0} does not exist'.format(user))
+        if uid == "":
+            preflight_errors.append("User {0} does not exist".format(user))
 
-        if gid == '':
-            preflight_errors.append('Group {0} does not exist'.format(group))
+        if gid == "":
+            preflight_errors.append("Group {0} does not exist".format(group))
 
     if not os.path.isabs(name):
         preflight_errors.append(
-            'Specified file {0} is not an absolute path'.format(name)
+            "Specified file {0} is not an absolute path".format(name)
         )
 
     if preflight_errors:
-        msg = '. '.join(preflight_errors)
+        msg = ". ".join(preflight_errors)
         if len(preflight_errors) > 1:
-            msg += '.'
+            msg += "."
         return _error(ret, msg)
 
-    presult, pcomment, pchanges = _symlink_check(name,
-                                                 target,
-                                                 force,
-                                                 user,
-                                                 group,
-                                                 win_owner)
+    presult, pcomment, pchanges = _symlink_check(
+        name, target, force, user, group, win_owner
+    )
 
     if not os.path.isdir(os.path.dirname(name)):
         if makedirs:
-            if __opts__['test']:
-                pcomment += '\n{0} will be created'.format(os.path.dirname(name))
+            if __opts__["test"]:
+                pcomment += "\n{0} will be created".format(os.path.dirname(name))
             else:
                 try:
-                    _makedirs(name=name,
-                              user=user,
-                              group=group,
-                              dir_mode=mode,
-                              win_owner=win_owner,
-                              win_perms=win_perms,
-                              win_deny_perms=win_deny_perms,
-                              win_inheritance=win_inheritance)
+                    _makedirs(
+                        name=name,
+                        user=user,
+                        group=group,
+                        dir_mode=mode,
+                        win_owner=win_owner,
+                        win_perms=win_perms,
+                        win_deny_perms=win_deny_perms,
+                        win_inheritance=win_inheritance,
+                    )
                 except CommandExecutionError as exc:
-                    return _error(ret, 'Drive {0} is not mapped'.format(exc.message))
+                    return _error(ret, "Drive {0} is not mapped".format(exc.message))
         else:
-            if __opts__['test']:
-                pcomment += '\nDirectory {0} for symlink is not present' \
-                            ''.format(os.path.dirname(name))
+            if __opts__["test"]:
+                pcomment += "\nDirectory {0} for symlink is not present" "".format(
+                    os.path.dirname(name)
+                )
             else:
                 return _error(
                     ret,
-                    'Directory {0} for symlink is not present'.format(
+                    "Directory {0} for symlink is not present".format(
                         os.path.dirname(name)
-                    )
+                    ),
                 )
 
-    if __opts__['test']:
-        ret['result'] = presult
-        ret['comment'] = pcomment
-        ret['changes'] = pchanges
+    if __opts__["test"]:
+        ret["result"] = presult
+        ret["comment"] = pcomment
+        ret["changes"] = pchanges
         return ret
 
-    if __salt__['file.is_link'](name):
+    if __salt__["file.is_link"](name):
         # The link exists, verify that it matches the target
-        if os.path.normpath(__salt__['file.readlink'](name)) != os.path.normpath(target):
+        if os.path.normpath(__salt__["file.readlink"](name)) != os.path.normpath(
+            target
+        ):
             # The target is wrong, delete the link
             os.remove(name)
         else:
             if _check_symlink_ownership(name, user, group, win_owner):
                 # The link looks good!
                 if salt.utils.platform.is_windows():
-                    ret['comment'] = ('Symlink {0} is present and owned by {1}'
-                                      ''.format(name, win_owner))
+                    ret["comment"] = (
+                        "Symlink {0} is present and owned by {1}"
+                        "".format(name, win_owner)
+                    )
                 else:
-                    ret['comment'] = ('Symlink {0} is present and owned by '
-                                      '{1}:{2}'.format(name, user, group))
+                    ret["comment"] = (
+                        "Symlink {0} is present and owned by "
+                        "{1}:{2}".format(name, user, group)
+                    )
             else:
                 if _set_symlink_ownership(name, user, group, win_owner):
                     if salt.utils.platform.is_windows():
-                        ret['comment'] = ('Set ownership of symlink {0} to '
-                                          '{1}'.format(name, win_owner))
-                        ret['changes']['ownership'] = win_owner
+                        ret["comment"] = (
+                            "Set ownership of symlink {0} to "
+                            "{1}".format(name, win_owner)
+                        )
+                        ret["changes"]["ownership"] = win_owner
                     else:
-                        ret['comment'] = ('Set ownership of symlink {0} to '
-                                          '{1}:{2}'.format(name, user, group))
-                        ret['changes']['ownership'] = '{0}:{1}'.format(user,
-                                                                       group)
+                        ret["comment"] = (
+                            "Set ownership of symlink {0} to "
+                            "{1}:{2}".format(name, user, group)
+                        )
+                        ret["changes"]["ownership"] = "{0}:{1}".format(user, group)
                 else:
-                    ret['result'] = False
+                    ret["result"] = False
                     if salt.utils.platform.is_windows():
-                        ret['comment'] += (
-                            'Failed to set ownership of symlink '
-                            '{0} to {1}'.format(name, win_owner))
+                        ret["comment"] += (
+                            "Failed to set ownership of symlink "
+                            "{0} to {1}".format(name, win_owner)
+                        )
                     else:
-                        ret['comment'] += (
-                            'Failed to set ownership of symlink {0} to '
-                            '{1}:{2}'.format(name, user, group))
+                        ret["comment"] += (
+                            "Failed to set ownership of symlink {0} to "
+                            "{1}:{2}".format(name, user, group)
+                        )
             return ret
 
     elif os.path.isfile(name) or os.path.isdir(name):
@@ -1650,132 +1706,144 @@ def symlink(
             if not os.path.isabs(backupname):
                 if backupname == os.path.basename(backupname):
                     backupname = os.path.join(
-                        os.path.dirname(os.path.normpath(name)),
-                        backupname)
+                        os.path.dirname(os.path.normpath(name)), backupname
+                    )
                 else:
-                    return _error(ret, (('Backupname must be an absolute path '
-                                         'or a file name: {0}').format(backupname)))
+                    return _error(
+                        ret,
+                        (
+                            (
+                                "Backupname must be an absolute path "
+                                "or a file name: {0}"
+                            ).format(backupname)
+                        ),
+                    )
             # Make a backup first
             if os.path.lexists(backupname):
                 if not force:
-                    return _error(ret, (('Symlink & backup dest exists and Force not set.'
-                                         ' {0} -> {1} - backup: {2}').format(
-                                             name, target, backupname)))
+                    return _error(
+                        ret,
+                        (
+                            (
+                                "Symlink & backup dest exists and Force not set."
+                                " {0} -> {1} - backup: {2}"
+                            ).format(name, target, backupname)
+                        ),
+                    )
                 else:
-                    __salt__['file.remove'](backupname)
+                    __salt__["file.remove"](backupname)
             try:
-                __salt__['file.move'](name, backupname)
+                __salt__["file.move"](name, backupname)
             except Exception as exc:
-                ret['changes'] = {}
+                ret["changes"] = {}
                 log.debug(
-                    'Encountered error renaming %s to %s',
-                    name, backupname, exc_info=True
+                    "Encountered error renaming %s to %s",
+                    name,
+                    backupname,
+                    exc_info=True,
                 )
-                return _error(ret, ('Unable to rename {0} to backup {1} -> '
-                                    ': {2}'.format(name, backupname, exc)))
+                return _error(
+                    ret,
+                    (
+                        "Unable to rename {0} to backup {1} -> "
+                        ": {2}".format(name, backupname, exc)
+                    ),
+                )
         elif force:
             # Remove whatever is in the way
-            if __salt__['file.is_link'](name):
-                __salt__['file.remove'](name)
-                ret['changes']['forced'] = 'Symlink was forcibly replaced'
+            if __salt__["file.is_link"](name):
+                __salt__["file.remove"](name)
+                ret["changes"]["forced"] = "Symlink was forcibly replaced"
             else:
-                __salt__['file.remove'](name)
+                __salt__["file.remove"](name)
         else:
             # Otherwise throw an error
             if os.path.isfile(name):
-                return _error(ret,
-                              ('File exists where the symlink {0} should be'
-                               .format(name)))
+                return _error(
+                    ret, ("File exists where the symlink {0} should be".format(name))
+                )
             else:
-                return _error(ret, ((
-                                        'Directory exists where the symlink {0} should be'
-                                    ).format(name)))
+                return _error(
+                    ret,
+                    (("Directory exists where the symlink {0} should be").format(name)),
+                )
 
     if not os.path.exists(name):
         # The link is not present, make it
         try:
-            __salt__['file.symlink'](target, name)
+            __salt__["file.symlink"](target, name)
         except OSError as exc:
-            ret['result'] = False
-            ret['comment'] = ('Unable to create new symlink {0} -> '
-                              '{1}: {2}'.format(name, target, exc))
+            ret["result"] = False
+            ret["comment"] = "Unable to create new symlink {0} -> " "{1}: {2}".format(
+                name, target, exc
+            )
             return ret
         else:
-            ret['comment'] = ('Created new symlink {0} -> '
-                              '{1}'.format(name, target))
-            ret['changes']['new'] = name
+            ret["comment"] = "Created new symlink {0} -> " "{1}".format(name, target)
+            ret["changes"]["new"] = name
 
         if not _check_symlink_ownership(name, user, group, win_owner):
             if not _set_symlink_ownership(name, user, group, win_owner):
-                ret['result'] = False
-                ret['comment'] += (', but was unable to set ownership to '
-                                   '{0}:{1}'.format(user, group))
+                ret["result"] = False
+                ret["comment"] += (
+                    ", but was unable to set ownership to "
+                    "{0}:{1}".format(user, group)
+                )
     return ret
 
 
-def absent(name,
-           **kwargs):
-    '''
+def absent(name, **kwargs):
+    """
     Make sure that the named file or directory is absent. If it exists, it will
     be deleted. This will work to reverse any of the functions in the file
     state module. If a directory is supplied, it will be recursively deleted.
 
     name
         The path which should be deleted
-    '''
+    """
     name = os.path.expanduser(name)
 
-    ret = {'name': name,
-           'changes': {},
-           'result': True,
-           'comment': ''}
+    ret = {"name": name, "changes": {}, "result": True, "comment": ""}
     if not name:
-        return _error(ret, 'Must provide name to file.absent')
+        return _error(ret, "Must provide name to file.absent")
     if not os.path.isabs(name):
-        return _error(
-            ret, 'Specified file {0} is not an absolute path'.format(name)
-        )
-    if name == '/':
+        return _error(ret, "Specified file {0} is not an absolute path".format(name))
+    if name == "/":
         return _error(ret, 'Refusing to make "/" absent')
     if os.path.isfile(name) or os.path.islink(name):
-        if __opts__['test']:
-            ret['result'] = None
-            ret['changes']['removed'] = name
-            ret['comment'] = 'File {0} is set for removal'.format(name)
+        if __opts__["test"]:
+            ret["result"] = None
+            ret["changes"]["removed"] = name
+            ret["comment"] = "File {0} is set for removal".format(name)
             return ret
         try:
-            __salt__['file.remove'](name, force=True)
-            ret['comment'] = 'Removed file {0}'.format(name)
-            ret['changes']['removed'] = name
+            __salt__["file.remove"](name, force=True)
+            ret["comment"] = "Removed file {0}".format(name)
+            ret["changes"]["removed"] = name
             return ret
         except CommandExecutionError as exc:
-            return _error(ret, '{0}'.format(exc))
+            return _error(ret, "{0}".format(exc))
 
     elif os.path.isdir(name):
-        if __opts__['test']:
-            ret['result'] = None
-            ret['changes']['removed'] = name
-            ret['comment'] = 'Directory {0} is set for removal'.format(name)
+        if __opts__["test"]:
+            ret["result"] = None
+            ret["changes"]["removed"] = name
+            ret["comment"] = "Directory {0} is set for removal".format(name)
             return ret
         try:
-            __salt__['file.remove'](name, force=True)
-            ret['comment'] = 'Removed directory {0}'.format(name)
-            ret['changes']['removed'] = name
+            __salt__["file.remove"](name, force=True)
+            ret["comment"] = "Removed directory {0}".format(name)
+            ret["changes"]["removed"] = name
             return ret
         except (OSError, IOError):
-            return _error(ret, 'Failed to remove directory {0}'.format(name))
+            return _error(ret, "Failed to remove directory {0}".format(name))
 
-    ret['comment'] = 'File {0} is not present'.format(name)
+    ret["comment"] = "File {0} is not present".format(name)
     return ret
 
 
-def tidied(name,
-           age=0,
-           matches=None,
-           rmdirs=False,
-           size=0,
-           **kwargs):
-    '''
+def tidied(name, age=0, matches=None, rmdirs=False, size=0, **kwargs):
+    """
     Remove unwanted files based on specific criteria. Multiple criteria
     are OR’d together, so a file that is too large but is not old enough
     will still get tidied.
@@ -1808,19 +1876,16 @@ def tidied(name,
             - matches:
               - foo
               - b.*r
-    '''
+    """
     name = os.path.expanduser(name)
 
-    ret = {'name': name,
-           'changes': {},
-           'result': True,
-           'comment': ''}
+    ret = {"name": name, "changes": {}, "result": True, "comment": ""}
 
     # Check preconditions
     if not os.path.isabs(name):
-        return _error(ret, 'Specified file {0} is not an absolute path'.format(name))
+        return _error(ret, "Specified file {0} is not an absolute path".format(name))
     if not os.path.isdir(name):
-        return _error(ret, '{0} does not exist or is not a directory.'.format(name))
+        return _error(ret, "{0} does not exist or is not a directory.".format(name))
 
     # Define some variables
     todelete = []
@@ -1828,7 +1893,7 @@ def tidied(name,
 
     # Compile regular expressions
     if matches is None:
-        matches = ['.*']
+        matches = [".*"]
     progs = []
     for regex in matches:
         progs.append(re.compile(regex))
@@ -1861,36 +1926,41 @@ def tidied(name,
                 myage = abs(today - date.fromtimestamp(os.path.getatime(path)))
                 mysize = os.path.getsize(path)
             # Verify against given criteria, collect all elements that should be removed
-            if (mysize >= size or myage.days >= age) and _matches(name=elem) and deleteme:
+            if (
+                (mysize >= size or myage.days >= age)
+                and _matches(name=elem)
+                and deleteme
+            ):
                 todelete.append(path)
 
     # Now delete the stuff
     if todelete:
-        if __opts__['test']:
-            ret['result'] = None
-            ret['comment'] = '{0} is set for tidy'.format(name)
-            ret['changes'] = {'removed': todelete}
+        if __opts__["test"]:
+            ret["result"] = None
+            ret["comment"] = "{0} is set for tidy".format(name)
+            ret["changes"] = {"removed": todelete}
             return ret
-        ret['changes']['removed'] = []
+        ret["changes"]["removed"] = []
         # Iterate over collected items
         try:
             for path in todelete:
-                __salt__['file.remove'](path, force=True)
+                __salt__["file.remove"](path, force=True)
                 # Remember what we've removed, will appear in the summary
-                ret['changes']['removed'].append(path)
+                ret["changes"]["removed"].append(path)
         except CommandExecutionError as exc:
-            return _error(ret, '{0}'.format(exc))
+            return _error(ret, "{0}".format(exc))
         # Set comment for the summary
-        ret['comment'] = 'Removed {0} files or directories from directory {1}'.format(len(todelete), name)
+        ret["comment"] = "Removed {0} files or directories from directory {1}".format(
+            len(todelete), name
+        )
     else:
         # Set comment in case there was nothing to remove
-        ret['comment'] = 'Nothing to remove from directory {0}'.format(name)
+        ret["comment"] = "Nothing to remove from directory {0}".format(name)
     return ret
 
 
-def exists(name,
-           **kwargs):
-    '''
+def exists(name, **kwargs):
+    """
     Verify that the named file or directory is present or exists.
     Ensures pre-requisites outside of Salt's purview
     (e.g., keytabs, private keys, etc.) have been previously satisfied before
@@ -1901,85 +1971,80 @@ def exists(name,
 
     name
         Absolute path which must exist
-    '''
+    """
     name = os.path.expanduser(name)
 
-    ret = {'name': name,
-           'changes': {},
-           'result': True,
-           'comment': ''}
+    ret = {"name": name, "changes": {}, "result": True, "comment": ""}
     if not name:
-        return _error(ret, 'Must provide name to file.exists')
+        return _error(ret, "Must provide name to file.exists")
     if not os.path.exists(name):
-        return _error(ret, 'Specified path {0} does not exist'.format(name))
+        return _error(ret, "Specified path {0} does not exist".format(name))
 
-    ret['comment'] = 'Path {0} exists'.format(name)
+    ret["comment"] = "Path {0} exists".format(name)
     return ret
 
 
-def missing(name,
-            **kwargs):
-    '''
+def missing(name, **kwargs):
+    """
     Verify that the named file or directory is missing, this returns True only
     if the named file is missing but does not remove the file if it is present.
 
     name
         Absolute path which must NOT exist
-    '''
+    """
     name = os.path.expanduser(name)
 
-    ret = {'name': name,
-           'changes': {},
-           'result': True,
-           'comment': ''}
+    ret = {"name": name, "changes": {}, "result": True, "comment": ""}
     if not name:
-        return _error(ret, 'Must provide name to file.missing')
+        return _error(ret, "Must provide name to file.missing")
     if os.path.exists(name):
-        return _error(ret, 'Specified path {0} exists'.format(name))
+        return _error(ret, "Specified path {0} exists".format(name))
 
-    ret['comment'] = 'Path {0} is missing'.format(name)
+    ret["comment"] = "Path {0} is missing".format(name)
     return ret
 
 
-def managed(name,
-            source=None,
-            source_hash='',
-            source_hash_name=None,
-            keep_source=True,
-            user=None,
-            group=None,
-            mode=None,
-            attrs=None,
-            template=None,
-            makedirs=False,
-            dir_mode=None,
-            context=None,
-            replace=True,
-            defaults=None,
-            backup='',
-            show_changes=True,
-            create=True,
-            contents=None,
-            tmp_dir='',
-            tmp_ext='',
-            contents_pillar=None,
-            contents_grains=None,
-            contents_newline=True,
-            contents_delimiter=':',
-            encoding=None,
-            encoding_errors='strict',
-            allow_empty=True,
-            follow_symlinks=True,
-            check_cmd=None,
-            skip_verify=False,
-            selinux=None,
-            win_owner=None,
-            win_perms=None,
-            win_deny_perms=None,
-            win_inheritance=True,
-            win_perms_reset=False,
-            **kwargs):
-    r'''
+def managed(
+    name,
+    source=None,
+    source_hash="",
+    source_hash_name=None,
+    keep_source=True,
+    user=None,
+    group=None,
+    mode=None,
+    attrs=None,
+    template=None,
+    makedirs=False,
+    dir_mode=None,
+    context=None,
+    replace=True,
+    defaults=None,
+    backup="",
+    show_changes=True,
+    create=True,
+    contents=None,
+    tmp_dir="",
+    tmp_ext="",
+    contents_pillar=None,
+    contents_grains=None,
+    contents_newline=True,
+    contents_delimiter=":",
+    encoding=None,
+    encoding_errors="strict",
+    allow_empty=True,
+    follow_symlinks=True,
+    check_cmd=None,
+    skip_verify=False,
+    selinux=None,
+    win_owner=None,
+    win_perms=None,
+    win_deny_perms=None,
+    win_inheritance=True,
+    win_perms_reset=False,
+    **kwargs
+):
+    r"""
     Manage a given file, this function allows for a file to be downloaded from
     the salt master and potentially run through a templating system.
 
@@ -2549,40 +2614,37 @@ def managed(name,
                 fred_snuffy:
                   perms: full_control
             - win_inheritance: False
-    '''
-    if 'env' in kwargs:
+    """
+    if "env" in kwargs:
         # "env" is not supported; Use "saltenv".
-        kwargs.pop('env')
+        kwargs.pop("env")
 
     name = os.path.expanduser(name)
 
-    ret = {'changes': {},
-           'comment': '',
-           'name': name,
-           'result': True}
+    ret = {"changes": {}, "comment": "", "name": name, "result": True}
 
     if not name:
-        return _error(ret, 'Destination file name is required')
+        return _error(ret, "Destination file name is required")
 
     if mode is not None and salt.utils.platform.is_windows():
-        return _error(ret, 'The \'mode\' option is not supported on Windows')
+        return _error(ret, "The 'mode' option is not supported on Windows")
 
     if attrs is not None and salt.utils.platform.is_windows():
-        return _error(ret, 'The \'attrs\' option is not supported on Windows')
+        return _error(ret, "The 'attrs' option is not supported on Windows")
 
     if selinux is not None and not salt.utils.platform.is_linux():
-        return _error(ret, 'The \'selinux\' option is only supported on Linux')
+        return _error(ret, "The 'selinux' option is only supported on Linux")
 
     if selinux:
-        seuser = selinux.get('seuser', None)
-        serole = selinux.get('serole', None)
-        setype = selinux.get('setype', None)
-        serange = selinux.get('serange', None)
+        seuser = selinux.get("seuser", None)
+        serole = selinux.get("serole", None)
+        setype = selinux.get("setype", None)
+        serange = selinux.get("serange", None)
     else:
         seuser = serole = setype = serange = None
 
     try:
-        keep_mode = mode.lower() == 'keep'
+        keep_mode = mode.lower() == "keep"
         if keep_mode:
             # We're not hard-coding the mode, so set it to None
             mode = None
@@ -2593,27 +2655,26 @@ def managed(name,
     mode = salt.utils.files.normalize_mode(mode)
 
     contents_count = len(
-        [x for x in (contents, contents_pillar, contents_grains)
-         if x is not None]
+        [x for x in (contents, contents_pillar, contents_grains) if x is not None]
     )
 
     if source and contents_count > 0:
         return _error(
             ret,
-            '\'source\' cannot be used in combination with \'contents\', '
-            '\'contents_pillar\', or \'contents_grains\''
+            "'source' cannot be used in combination with 'contents', "
+            "'contents_pillar', or 'contents_grains'",
         )
     elif keep_mode and contents_count > 0:
         return _error(
             ret,
-            'Mode preservation cannot be used in combination with \'contents\', '
-            '\'contents_pillar\', or \'contents_grains\''
+            "Mode preservation cannot be used in combination with 'contents', "
+            "'contents_pillar', or 'contents_grains'",
         )
     elif contents_count > 1:
         return _error(
             ret,
-            'Only one of \'contents\', \'contents_pillar\', and '
-            '\'contents_grains\' is permitted'
+            "Only one of 'contents', 'contents_pillar', and "
+            "'contents_grains' is permitted",
         )
 
     # If no source is specified, set replace to False, as there is nothing
@@ -2621,17 +2682,18 @@ def managed(name,
     if not source and contents_count == 0 and replace:
         replace = False
         log.warning(
-            'State for file: %s - Neither \'source\' nor \'contents\' nor '
-            '\'contents_pillar\' nor \'contents_grains\' was defined, yet '
-            '\'replace\' was set to \'True\'. As there is no source to '
-            'replace the file with, \'replace\' has been set to \'False\' to '
-            'avoid reading the file unnecessarily.', name
+            "State for file: %s - Neither 'source' nor 'contents' nor "
+            "'contents_pillar' nor 'contents_grains' was defined, yet "
+            "'replace' was set to 'True'. As there is no source to "
+            "replace the file with, 'replace' has been set to 'False' to "
+            "avoid reading the file unnecessarily.",
+            name,
         )
 
-    if 'file_mode' in kwargs:
-        ret.setdefault('warnings', []).append(
-            'The \'file_mode\' argument will be ignored.  '
-            'Please use \'mode\' instead to set file permissions.'
+    if "file_mode" in kwargs:
+        ret.setdefault("warnings", []).append(
+            "The 'file_mode' argument will be ignored.  "
+            "Please use 'mode' instead to set file permissions."
         )
 
     # Use this below to avoid multiple '\0' checks and save some CPU cycles
@@ -2639,45 +2701,37 @@ def managed(name,
         if isinstance(contents_pillar, list):
             list_contents = []
             for nextp in contents_pillar:
-                nextc = __salt__['pillar.get'](nextp, __NOT_FOUND,
-                                               delimiter=contents_delimiter)
+                nextc = __salt__["pillar.get"](
+                    nextp, __NOT_FOUND, delimiter=contents_delimiter
+                )
                 if nextc is __NOT_FOUND:
-                    return _error(
-                        ret,
-                        'Pillar {0} does not exist'.format(nextp)
-                    )
+                    return _error(ret, "Pillar {0} does not exist".format(nextp))
                 list_contents.append(nextc)
             use_contents = os.linesep.join(list_contents)
         else:
-            use_contents = __salt__['pillar.get'](contents_pillar, __NOT_FOUND,
-                                                  delimiter=contents_delimiter)
+            use_contents = __salt__["pillar.get"](
+                contents_pillar, __NOT_FOUND, delimiter=contents_delimiter
+            )
             if use_contents is __NOT_FOUND:
-                return _error(
-                    ret,
-                    'Pillar {0} does not exist'.format(contents_pillar)
-                )
+                return _error(ret, "Pillar {0} does not exist".format(contents_pillar))
 
     elif contents_grains is not None:
         if isinstance(contents_grains, list):
             list_contents = []
             for nextg in contents_grains:
-                nextc = __salt__['grains.get'](nextg, __NOT_FOUND,
-                                               delimiter=contents_delimiter)
+                nextc = __salt__["grains.get"](
+                    nextg, __NOT_FOUND, delimiter=contents_delimiter
+                )
                 if nextc is __NOT_FOUND:
-                    return _error(
-                        ret,
-                        'Grain {0} does not exist'.format(nextc)
-                    )
+                    return _error(ret, "Grain {0} does not exist".format(nextc))
                 list_contents.append(nextc)
             use_contents = os.linesep.join(list_contents)
         else:
-            use_contents = __salt__['grains.get'](contents_grains, __NOT_FOUND,
-                                                  delimiter=contents_delimiter)
+            use_contents = __salt__["grains.get"](
+                contents_grains, __NOT_FOUND, delimiter=contents_delimiter
+            )
             if use_contents is __NOT_FOUND:
-                return _error(
-                    ret,
-                    'Grain {0} does not exist'.format(contents_grains)
-                )
+                return _error(ret, "Grain {0} does not exist".format(contents_grains))
 
     elif contents is not None:
         use_contents = contents
@@ -2688,16 +2742,15 @@ def managed(name,
     if use_contents is not None:
         if not allow_empty and not use_contents:
             if contents_pillar:
-                contents_id = 'contents_pillar {0}'.format(contents_pillar)
+                contents_id = "contents_pillar {0}".format(contents_pillar)
             elif contents_grains:
-                contents_id = 'contents_grains {0}'.format(contents_grains)
+                contents_id = "contents_grains {0}".format(contents_grains)
             else:
-                contents_id = '\'contents\''
+                contents_id = "'contents'"
             return _error(
                 ret,
-                '{0} value would result in empty contents. Set allow_empty '
-                'to True to allow the managed file to be empty.'
-                .format(contents_id)
+                "{0} value would result in empty contents. Set allow_empty "
+                "to True to allow the managed file to be empty.".format(contents_id),
             )
 
         try:
@@ -2705,14 +2758,14 @@ def managed(name,
             if not validated_contents:
                 return _error(
                     ret,
-                    'Contents specified by contents/contents_pillar/'
-                    'contents_grains is not a string or list of strings, and '
-                    'is not binary data. SLS is likely malformed.'
+                    "Contents specified by contents/contents_pillar/"
+                    "contents_grains is not a string or list of strings, and "
+                    "is not binary data. SLS is likely malformed.",
                 )
-            contents = ''
+            contents = ""
             for part in validated_contents:
                 for line in part.splitlines():
-                    contents += line.rstrip('\n').rstrip('\r') + os.linesep
+                    contents += line.rstrip("\n").rstrip("\r") + os.linesep
             if contents_newline and not contents.endswith(os.linesep):
                 contents += os.linesep
         except UnicodeDecodeError:
@@ -2720,28 +2773,29 @@ def managed(name,
             if template:
                 return _error(
                     ret,
-                    'Contents specified by contents/contents_pillar/'
-                    'contents_grains appears to be binary data, and'
-                    ' as will not be able to be treated as a Jinja'
-                    ' template.'
+                    "Contents specified by contents/contents_pillar/"
+                    "contents_grains appears to be binary data, and"
+                    " as will not be able to be treated as a Jinja"
+                    " template.",
                 )
             contents = use_contents
         if template:
-            contents = __salt__['file.apply_template_on_contents'](
+            contents = __salt__["file.apply_template_on_contents"](
                 contents,
                 template=template,
                 context=context,
                 defaults=defaults,
-                saltenv=__env__)
+                saltenv=__env__,
+            )
             if not isinstance(contents, six.string_types):
-                if 'result' in contents:
-                    ret['result'] = contents['result']
+                if "result" in contents:
+                    ret["result"] = contents["result"]
                 else:
-                    ret['result'] = False
-                if 'comment' in contents:
-                    ret['comment'] = contents['comment']
+                    ret["result"] = False
+                if "comment" in contents:
+                    ret["comment"] = contents["comment"]
                 else:
-                    ret['comment'] = 'Error while applying template on contents'
+                    ret["comment"] = "Error while applying template on contents"
                 return ret
 
     user = _test_owner(kwargs, user=user)
@@ -2754,85 +2808,96 @@ def managed(name,
         # Group isn't relevant to Windows, use win_perms/win_deny_perms
         if group is not None:
             log.warning(
-                'The group argument for %s has been ignored as this is '
-                'a Windows system. Please use the `win_*` parameters to set '
-                'permissions in Windows.', name
+                "The group argument for %s has been ignored as this is "
+                "a Windows system. Please use the `win_*` parameters to set "
+                "permissions in Windows.",
+                name,
             )
         group = user
 
     if not create:
         if not os.path.isfile(name):
             # Don't create a file that is not already present
-            ret['comment'] = ('File {0} is not present and is not set for '
-                              'creation').format(name)
+            ret["comment"] = (
+                "File {0} is not present and is not set for " "creation"
+            ).format(name)
             return ret
     u_check = _check_user(user, group)
     if u_check:
         # The specified user or group do not exist
         return _error(ret, u_check)
     if not os.path.isabs(name):
-        return _error(
-            ret, 'Specified file {0} is not an absolute path'.format(name))
+        return _error(ret, "Specified file {0} is not an absolute path".format(name))
 
     if os.path.isdir(name):
-        ret['comment'] = 'Specified target {0} is a directory'.format(name)
-        ret['result'] = False
+        ret["comment"] = "Specified target {0} is a directory".format(name)
+        ret["result"] = False
         return ret
 
     if context is None:
         context = {}
     elif not isinstance(context, dict):
-        return _error(
-            ret, 'Context must be formed as a dict')
+        return _error(ret, "Context must be formed as a dict")
     if defaults and not isinstance(defaults, dict):
-        return _error(
-            ret, 'Defaults must be formed as a dict')
+        return _error(ret, "Defaults must be formed as a dict")
 
     if not replace and os.path.exists(name):
         ret_perms = {}
         # Check and set the permissions if necessary
         if salt.utils.platform.is_windows():
-            ret = __salt__['file.check_perms'](
+            ret = __salt__["file.check_perms"](
                 path=name,
                 ret=ret,
                 owner=win_owner,
                 grant_perms=win_perms,
                 deny_perms=win_deny_perms,
                 inheritance=win_inheritance,
-                reset=win_perms_reset)
+                reset=win_perms_reset,
+            )
         else:
-            ret, ret_perms = __salt__['file.check_perms'](
-                name, ret, user, group, mode, attrs, follow_symlinks,
+            ret, ret_perms = __salt__["file.check_perms"](
+                name,
+                ret,
+                user,
+                group,
+                mode,
+                attrs,
+                follow_symlinks,
                 seuser=seuser,
                 serole=serole,
                 setype=setype,
-                serange=serange)
-        if __opts__['test']:
-            if isinstance(ret_perms, dict) and \
-               'lmode' in ret_perms and \
-               mode != ret_perms['lmode']:
-                ret['comment'] = ('File {0} will be updated with permissions '
-                                  '{1} from its current '
-                                  'state of {2}'.format(name,
-                                                        mode,
-                                                        ret_perms['lmode']))
+                serange=serange,
+            )
+        if __opts__["test"]:
+            if (
+                isinstance(ret_perms, dict)
+                and "lmode" in ret_perms
+                and mode != ret_perms["lmode"]
+            ):
+                ret["comment"] = (
+                    "File {0} will be updated with permissions "
+                    "{1} from its current "
+                    "state of {2}".format(name, mode, ret_perms["lmode"])
+                )
             else:
-                ret['comment'] = 'File {0} not updated'.format(name)
-        elif not ret['changes'] and ret['result']:
-            ret['comment'] = ('File {0} exists with proper permissions. '
-                              'No changes made.'.format(name))
+                ret["comment"] = "File {0} not updated".format(name)
+        elif not ret["changes"] and ret["result"]:
+            ret["comment"] = (
+                "File {0} exists with proper permissions. "
+                "No changes made.".format(name)
+            )
         return ret
 
     accum_data, _ = _load_accumulators()
     if name in accum_data:
         if not context:
             context = {}
-        context['accumulator'] = accum_data[name]
+        context["accumulator"] = accum_data[name]
 
     try:
-        if __opts__['test']:
+        if __opts__["test"]:
             try:
-                ret['changes'] = __salt__['file.check_managed_changes'](
+                ret["changes"] = __salt__["file.check_managed_changes"](
                     name,
                     source,
                     source_hash,
@@ -2855,53 +2920,52 @@ def managed(name,
                     **kwargs
                 )
             except CommandExecutionError as exc:
-                ret['result'] = False
-                ret['comment'] = six.text_type(exc)
+                ret["result"] = False
+                ret["comment"] = six.text_type(exc)
                 return ret
 
             if salt.utils.platform.is_windows():
                 try:
-                    ret = __salt__['file.check_perms'](
+                    ret = __salt__["file.check_perms"](
                         path=name,
                         ret=ret,
                         owner=win_owner,
                         grant_perms=win_perms,
                         deny_perms=win_deny_perms,
                         inheritance=win_inheritance,
-                        reset=win_perms_reset)
+                        reset=win_perms_reset,
+                    )
                 except CommandExecutionError as exc:
-                    if exc.strerror.startswith('Path not found'):
-                        ret['changes']['newfile'] = name
+                    if exc.strerror.startswith("Path not found"):
+                        ret["changes"]["newfile"] = name
 
-            if isinstance(ret['changes'], tuple):
-                ret['result'], ret['comment'] = ret['changes']
-            elif ret['changes']:
-                ret['result'] = None
-                ret['comment'] = 'The file {0} is set to be changed'.format(name)
-                ret['comment'] += ('\nNote: No changes made, actual changes may\n'
-                                   'be different due to other states.')
-                if 'diff' in ret['changes'] and not show_changes:
-                    ret['changes']['diff'] = '<show_changes=False>'
+            if isinstance(ret["changes"], tuple):
+                ret["result"], ret["comment"] = ret["changes"]
+            elif ret["changes"]:
+                ret["result"] = None
+                ret["comment"] = "The file {0} is set to be changed".format(name)
+                ret["comment"] += (
+                    "\nNote: No changes made, actual changes may\n"
+                    "be different due to other states."
+                )
+                if "diff" in ret["changes"] and not show_changes:
+                    ret["changes"]["diff"] = "<show_changes=False>"
             else:
-                ret['result'] = True
-                ret['comment'] = 'The file {0} is in the correct state'.format(name)
+                ret["result"] = True
+                ret["comment"] = "The file {0} is in the correct state".format(name)
 
             return ret
 
         # If the source is a list then find which file exists
-        source, source_hash = __salt__['file.source_list'](
-            source,
-            source_hash,
-            __env__
-        )
+        source, source_hash = __salt__["file.source_list"](source, source_hash, __env__)
     except CommandExecutionError as exc:
-        ret['result'] = False
-        ret['comment'] = 'Unable to manage file: {0}'.format(exc)
+        ret["result"] = False
+        ret["comment"] = "Unable to manage file: {0}".format(exc)
         return ret
 
     # Gather the source file from the server
     try:
-        sfn, source_sum, comment_ = __salt__['file.get_managed'](
+        sfn, source_sum, comment_ = __salt__["file.get_managed"](
             name,
             template,
             source,
@@ -2918,9 +2982,9 @@ def managed(name,
             **kwargs
         )
     except Exception as exc:
-        ret['changes'] = {}
+        ret["changes"] = {}
         log.debug(traceback.format_exc())
-        return _error(ret, 'Unable to manage file: {0}'.format(exc))
+        return _error(ret, "Unable to manage file: {0}".format(exc))
 
     tmp_filename = None
 
@@ -2928,19 +2992,19 @@ def managed(name,
         tmp_filename = salt.utils.files.mkstemp(suffix=tmp_ext, dir=tmp_dir)
 
         # if exists copy existing file to tmp to compare
-        if __salt__['file.file_exists'](name):
+        if __salt__["file.file_exists"](name):
             try:
-                __salt__['file.copy'](name, tmp_filename)
+                __salt__["file.copy"](name, tmp_filename)
             except Exception as exc:
                 return _error(
                     ret,
-                    'Unable to copy file {0} to {1}: {2}'.format(
+                    "Unable to copy file {0} to {1}: {2}".format(
                         name, tmp_filename, exc
-                    )
+                    ),
                 )
 
         try:
-            ret = __salt__['file.manage_file'](
+            ret = __salt__["file.manage_file"](
                 tmp_filename,
                 sfn,
                 ret,
@@ -2971,33 +3035,29 @@ def managed(name,
                 serole=serole,
                 setype=setype,
                 serange=serange,
-                **kwargs)
+                **kwargs
+            )
         except Exception as exc:
-            ret['changes'] = {}
+            ret["changes"] = {}
             log.debug(traceback.format_exc())
             salt.utils.files.remove(tmp_filename)
             if not keep_source:
-                if not sfn \
-                        and source \
-                        and _urlparse(source).scheme == 'salt':
+                if not sfn and source and _urlparse(source).scheme == "salt":
                     # The file would not have been cached until manage_file was
                     # run, so check again here for a cached copy.
-                    sfn = __salt__['cp.is_cached'](source, __env__)
+                    sfn = __salt__["cp.is_cached"](source, __env__)
                 if sfn:
                     salt.utils.files.remove(sfn)
-            return _error(ret, 'Unable to check_cmd file: {0}'.format(exc))
+            return _error(ret, "Unable to check_cmd file: {0}".format(exc))
 
         # file being updated to verify using check_cmd
-        if ret['changes']:
+        if ret["changes"]:
             # Reset ret
-            ret = {'changes': {},
-                   'comment': '',
-                   'name': name,
-                   'result': True}
+            ret = {"changes": {}, "comment": "", "name": name, "result": True}
 
             check_cmd_opts = {}
-            if 'shell' in __grains__:
-                check_cmd_opts['shell'] = __grains__['shell']
+            if "shell" in __grains__:
+                check_cmd_opts["shell"] = __grains__["shell"]
 
             cret = mod_run_check_cmd(check_cmd, tmp_filename, **check_cmd_opts)
             if isinstance(cret, dict):
@@ -3012,16 +3072,13 @@ def managed(name,
             sfn = tmp_filename
 
         else:
-            ret = {'changes': {},
-                   'comment': '',
-                   'name': name,
-                   'result': True}
+            ret = {"changes": {}, "comment": "", "name": name, "result": True}
 
     if comment_ and contents is None:
         return _error(ret, comment_)
     else:
         try:
-            return __salt__['file.manage_file'](
+            return __salt__["file.manage_file"](
                 name,
                 sfn,
                 ret,
@@ -3052,34 +3109,33 @@ def managed(name,
                 serole=serole,
                 setype=setype,
                 serange=serange,
-                **kwargs)
+                **kwargs
+            )
         except Exception as exc:
-            ret['changes'] = {}
+            ret["changes"] = {}
             log.debug(traceback.format_exc())
-            return _error(ret, 'Unable to manage file: {0}'.format(exc))
+            return _error(ret, "Unable to manage file: {0}".format(exc))
         finally:
             if tmp_filename:
                 salt.utils.files.remove(tmp_filename)
             if not keep_source:
-                if not sfn \
-                        and source \
-                        and _urlparse(source).scheme == 'salt':
+                if not sfn and source and _urlparse(source).scheme == "salt":
                     # The file would not have been cached until manage_file was
                     # run, so check again here for a cached copy.
-                    sfn = __salt__['cp.is_cached'](source, __env__)
+                    sfn = __salt__["cp.is_cached"](source, __env__)
                 if sfn:
                     salt.utils.files.remove(sfn)
 
 
-_RECURSE_TYPES = ['user', 'group', 'mode', 'ignore_files', 'ignore_dirs', 'silent']
+_RECURSE_TYPES = ["user", "group", "mode", "ignore_files", "ignore_dirs", "silent"]
 
 
 def _get_recurse_set(recurse):
-    '''
+    """
     Converse *recurse* definition to a set of strings.
 
     Raises TypeError or ValueError when *recurse* has wrong structure.
-    '''
+    """
     if not recurse:
         return set()
     if not isinstance(recurse, list):
@@ -3089,19 +3145,24 @@ def _get_recurse_set(recurse):
     except TypeError:  # non-hashable elements
         recurse_set = None
     if recurse_set is None or not set(_RECURSE_TYPES) >= recurse_set:
-        raise ValueError('Types for "recurse" limited to {0}.'.format(
-            ', '.join('"{0}"'.format(rtype) for rtype in _RECURSE_TYPES)))
-    if 'ignore_files' in recurse_set and 'ignore_dirs' in recurse_set:
-        raise ValueError('Must not specify "recurse" options "ignore_files"'
-                         ' and "ignore_dirs" at the same time.')
+        raise ValueError(
+            'Types for "recurse" limited to {0}.'.format(
+                ", ".join('"{0}"'.format(rtype) for rtype in _RECURSE_TYPES)
+            )
+        )
+    if "ignore_files" in recurse_set and "ignore_dirs" in recurse_set:
+        raise ValueError(
+            'Must not specify "recurse" options "ignore_files"'
+            ' and "ignore_dirs" at the same time.'
+        )
     return recurse_set
 
 
 def _depth_limited_walk(top, max_depth=None):
-    '''
+    """
     Walk the directory tree under root up till reaching max_depth.
     With max_depth=None (default), do not limit depth.
-    '''
+    """
     for root, dirs, files in salt.utils.path.os_walk(top):
         if max_depth is not None:
             rel_depth = root.count(os.path.sep) - top.count(os.path.sep)
@@ -3110,29 +3171,31 @@ def _depth_limited_walk(top, max_depth=None):
         yield (six.text_type(root), list(dirs), list(files))
 
 
-def directory(name,
-              user=None,
-              group=None,
-              recurse=None,
-              max_depth=None,
-              dir_mode=None,
-              file_mode=None,
-              makedirs=False,
-              clean=False,
-              require=None,
-              exclude_pat=None,
-              follow_symlinks=False,
-              force=False,
-              backupname=None,
-              allow_symlink=True,
-              children_only=False,
-              win_owner=None,
-              win_perms=None,
-              win_deny_perms=None,
-              win_inheritance=True,
-              win_perms_reset=False,
-              **kwargs):
-    r'''
+def directory(
+    name,
+    user=None,
+    group=None,
+    recurse=None,
+    max_depth=None,
+    dir_mode=None,
+    file_mode=None,
+    makedirs=False,
+    clean=False,
+    require=None,
+    exclude_pat=None,
+    follow_symlinks=False,
+    force=False,
+    backupname=None,
+    allow_symlink=True,
+    children_only=False,
+    win_owner=None,
+    win_perms=None,
+    win_deny_perms=None,
+    win_inheritance=True,
+    win_perms_reset=False,
+    **kwargs
+):
+    r"""
     Ensure that a named directory is present and has the right perms
 
     name
@@ -3327,20 +3390,17 @@ def directory(name,
                 fred_snuffy:
                   perms: full_control
             - win_inheritance: False
-    '''
+    """
     name = os.path.expanduser(name)
-    ret = {'name': name,
-           'changes': {},
-           'result': True,
-           'comment': ''}
+    ret = {"name": name, "changes": {}, "result": True, "comment": ""}
     if not name:
-        return _error(ret, 'Must provide name to file.directory')
+        return _error(ret, "Must provide name to file.directory")
     # Remove trailing slash, if present and we're not working on "/" itself
-    if name[-1] == '/' and name != '/':
+    if name[-1] == "/" and name != "/":
         name = name[:-1]
 
     if max_depth is not None and clean:
-        return _error(ret, 'Cannot specify both max_depth and clean')
+        return _error(ret, "Cannot specify both max_depth and clean")
 
     user = _test_owner(kwargs, user=user)
     if salt.utils.platform.is_windows():
@@ -3352,14 +3412,15 @@ def directory(name,
         # Group isn't relevant to Windows, use win_perms/win_deny_perms
         if group is not None:
             log.warning(
-                'The group argument for %s has been ignored as this is '
-                'a Windows system. Please use the `win_*` parameters to set '
-                'permissions in Windows.', name
+                "The group argument for %s has been ignored as this is "
+                "a Windows system. Please use the `win_*` parameters to set "
+                "permissions in Windows.",
+                name,
             )
         group = user
 
-    if 'mode' in kwargs and not dir_mode:
-        dir_mode = kwargs.get('mode', [])
+    if "mode" in kwargs and not dir_mode:
+        dir_mode = kwargs.get("mode", [])
 
     if not file_mode:
         file_mode = dir_mode
@@ -3383,52 +3444,59 @@ def directory(name,
 
     # Must be an absolute path
     if not os.path.isabs(name):
-        return _error(
-            ret, 'Specified file {0} is not an absolute path'.format(name))
+        return _error(ret, "Specified file {0} is not an absolute path".format(name))
 
     # Check for existing file or symlink
-    if os.path.isfile(name) or (not allow_symlink and os.path.islink(name)) \
-       or (force and os.path.islink(name)):
+    if (
+        os.path.isfile(name)
+        or (not allow_symlink and os.path.islink(name))
+        or (force and os.path.islink(name))
+    ):
         # Was a backupname specified
         if backupname is not None:
             # Make a backup first
             if os.path.lexists(backupname):
                 if not force:
-                    return _error(ret, ((
-                                            'File exists where the backup target {0} should go'
-                                        ).format(backupname)))
+                    return _error(
+                        ret,
+                        (
+                            (
+                                "File exists where the backup target {0} should go"
+                            ).format(backupname)
+                        ),
+                    )
                 else:
-                    __salt__['file.remove'](backupname)
+                    __salt__["file.remove"](backupname)
             os.rename(name, backupname)
         elif force:
             # Remove whatever is in the way
             if os.path.isfile(name):
-                if __opts__['test']:
-                    ret['changes']['forced'] = 'File would be forcibly replaced'
+                if __opts__["test"]:
+                    ret["changes"]["forced"] = "File would be forcibly replaced"
                 else:
                     os.remove(name)
-                    ret['changes']['forced'] = 'File was forcibly replaced'
-            elif __salt__['file.is_link'](name):
-                if __opts__['test']:
-                    ret['changes']['forced'] = 'Symlink would be forcibly replaced'
+                    ret["changes"]["forced"] = "File was forcibly replaced"
+            elif __salt__["file.is_link"](name):
+                if __opts__["test"]:
+                    ret["changes"]["forced"] = "Symlink would be forcibly replaced"
                 else:
-                    __salt__['file.remove'](name)
-                    ret['changes']['forced'] = 'Symlink was forcibly replaced'
+                    __salt__["file.remove"](name)
+                    ret["changes"]["forced"] = "Symlink was forcibly replaced"
             else:
-                if __opts__['test']:
-                    ret['changes']['forced'] = 'Directory would be forcibly replaced'
+                if __opts__["test"]:
+                    ret["changes"]["forced"] = "Directory would be forcibly replaced"
                 else:
-                    __salt__['file.remove'](name)
-                    ret['changes']['forced'] = 'Directory was forcibly replaced'
+                    __salt__["file.remove"](name)
+                    ret["changes"]["forced"] = "Directory was forcibly replaced"
         else:
             if os.path.isfile(name):
                 return _error(
-                    ret,
-                    'Specified location {0} exists and is a file'.format(name))
+                    ret, "Specified location {0} exists and is a file".format(name)
+                )
             elif os.path.islink(name):
                 return _error(
-                    ret,
-                    'Specified location {0} exists and is a symlink'.format(name))
+                    ret, "Specified location {0} exists and is a symlink".format(name)
+                )
 
     # Check directory?
     if salt.utils.platform.is_windows():
@@ -3438,20 +3506,32 @@ def directory(name,
             win_perms=win_perms,
             win_deny_perms=win_deny_perms,
             win_inheritance=win_inheritance,
-            win_perms_reset=win_perms_reset)
+            win_perms_reset=win_perms_reset,
+        )
     else:
         presult, pcomment, pchanges = _check_directory(
-            name, user, group, recurse or [], dir_mode, file_mode, clean,
-            require, exclude_pat, max_depth, follow_symlinks, children_only)
+            name,
+            user,
+            group,
+            recurse or [],
+            dir_mode,
+            file_mode,
+            clean,
+            require,
+            exclude_pat,
+            max_depth,
+            follow_symlinks,
+            children_only,
+        )
 
     if pchanges:
-        ret['changes'].update(pchanges)
+        ret["changes"].update(pchanges)
 
     # Don't run through the reset of the function if there are no changes to be
     # made
-    if __opts__['test'] or not ret['changes']:
-        ret['result'] = presult
-        ret['comment'] = pcomment
+    if __opts__["test"] or not ret["changes"]:
+        ret["result"] = presult
+        ret["comment"] = pcomment
         return ret
 
     if not os.path.isdir(name):
@@ -3461,51 +3541,55 @@ def directory(name,
             if makedirs:
                 # Everything's good, create the parent Dirs
                 try:
-                    _makedirs(name=name,
-                              user=user,
-                              group=group,
-                              dir_mode=dir_mode,
-                              win_owner=win_owner,
-                              win_perms=win_perms,
-                              win_deny_perms=win_deny_perms,
-                              win_inheritance=win_inheritance)
+                    _makedirs(
+                        name=name,
+                        user=user,
+                        group=group,
+                        dir_mode=dir_mode,
+                        win_owner=win_owner,
+                        win_perms=win_perms,
+                        win_deny_perms=win_deny_perms,
+                        win_inheritance=win_inheritance,
+                    )
                 except CommandExecutionError as exc:
-                    return _error(ret, 'Drive {0} is not mapped'.format(exc.message))
+                    return _error(ret, "Drive {0} is not mapped".format(exc.message))
             else:
-                return _error(
-                    ret, 'No directory to create {0} in'.format(name))
+                return _error(ret, "No directory to create {0} in".format(name))
 
         if salt.utils.platform.is_windows():
-            __salt__['file.mkdir'](
+            __salt__["file.mkdir"](
                 path=name,
                 owner=win_owner,
                 grant_perms=win_perms,
                 deny_perms=win_deny_perms,
                 inheritance=win_inheritance,
-                reset=win_perms_reset)
+                reset=win_perms_reset,
+            )
         else:
-            __salt__['file.mkdir'](name, user=user, group=group, mode=dir_mode)
+            __salt__["file.mkdir"](name, user=user, group=group, mode=dir_mode)
 
-        ret['changes'][name] = 'New Dir'
+        ret["changes"][name] = "New Dir"
 
     if not os.path.isdir(name):
-        return _error(ret, 'Failed to create directory {0}'.format(name))
+        return _error(ret, "Failed to create directory {0}".format(name))
 
     # issue 32707: skip this __salt__['file.check_perms'] call if children_only == True
     # Check permissions
     if not children_only:
         if salt.utils.platform.is_windows():
-            ret = __salt__['file.check_perms'](
+            ret = __salt__["file.check_perms"](
                 path=name,
                 ret=ret,
                 owner=win_owner,
                 grant_perms=win_perms,
                 deny_perms=win_deny_perms,
                 inheritance=win_inheritance,
-                reset=win_perms_reset)
+                reset=win_perms_reset,
+            )
         else:
-            ret, perms = __salt__['file.check_perms'](
-                name, ret, user, group, dir_mode, None, follow_symlinks)
+            ret, perms = __salt__["file.check_perms"](
+                name, ret, user, group, dir_mode, None, follow_symlinks
+            )
 
     errors = []
     if recurse or clean:
@@ -3521,53 +3605,61 @@ def directory(name,
         try:
             recurse_set = _get_recurse_set(recurse)
         except (TypeError, ValueError) as exc:
-            ret['result'] = False
-            ret['comment'] = '{0}'.format(exc)
+            ret["result"] = False
+            ret["comment"] = "{0}".format(exc)
             # NOTE: Should this be enough to stop the whole check altogether?
     if recurse_set:
-        if 'user' in recurse_set:
+        if "user" in recurse_set:
             if user or isinstance(user, int):
-                uid = __salt__['file.user_to_uid'](user)
+                uid = __salt__["file.user_to_uid"](user)
                 # file.user_to_uid returns '' if user does not exist. Above
                 # check for user is not fatal, so we need to be sure user
                 # exists.
                 if isinstance(uid, six.string_types):
-                    ret['result'] = False
-                    ret['comment'] = 'Failed to enforce ownership for ' \
-                                     'user {0} (user does not ' \
-                                     'exist)'.format(user)
+                    ret["result"] = False
+                    ret["comment"] = (
+                        "Failed to enforce ownership for "
+                        "user {0} (user does not "
+                        "exist)".format(user)
+                    )
             else:
-                ret['result'] = False
-                ret['comment'] = 'user not specified, but configured as ' \
-                                 'a target for recursive ownership ' \
-                                 'management'
+                ret["result"] = False
+                ret["comment"] = (
+                    "user not specified, but configured as "
+                    "a target for recursive ownership "
+                    "management"
+                )
         else:
             user = None
-        if 'group' in recurse_set:
+        if "group" in recurse_set:
             if group or isinstance(group, int):
-                gid = __salt__['file.group_to_gid'](group)
+                gid = __salt__["file.group_to_gid"](group)
                 # As above with user, we need to make sure group exists.
                 if isinstance(gid, six.string_types):
-                    ret['result'] = False
-                    ret['comment'] = 'Failed to enforce group ownership ' \
-                                     'for group {0}'.format(group)
+                    ret["result"] = False
+                    ret["comment"] = (
+                        "Failed to enforce group ownership "
+                        "for group {0}".format(group)
+                    )
             else:
-                ret['result'] = False
-                ret['comment'] = 'group not specified, but configured ' \
-                                 'as a target for recursive ownership ' \
-                                 'management'
+                ret["result"] = False
+                ret["comment"] = (
+                    "group not specified, but configured "
+                    "as a target for recursive ownership "
+                    "management"
+                )
         else:
             group = None
 
-        if 'mode' not in recurse_set:
+        if "mode" not in recurse_set:
             file_mode = None
             dir_mode = None
 
-        if 'silent' in recurse_set:
-            ret['changes'] = 'Changes silenced'
+        if "silent" in recurse_set:
+            ret["changes"] = "Changes silenced"
 
-        check_files = 'ignore_files' not in recurse_set
-        check_dirs = 'ignore_dirs' not in recurse_set
+        check_files = "ignore_files" not in recurse_set
+        check_dirs = "ignore_dirs" not in recurse_set
 
         for root, dirs, files in walk_l:
             if check_files:
@@ -3575,19 +3667,21 @@ def directory(name,
                     full = os.path.join(root, fn_)
                     try:
                         if salt.utils.platform.is_windows():
-                            ret = __salt__['file.check_perms'](
+                            ret = __salt__["file.check_perms"](
                                 path=full,
                                 ret=ret,
                                 owner=win_owner,
                                 grant_perms=win_perms,
                                 deny_perms=win_deny_perms,
                                 inheritance=win_inheritance,
-                                reset=win_perms_reset)
+                                reset=win_perms_reset,
+                            )
                         else:
-                            ret, _ = __salt__['file.check_perms'](
-                                full, ret, user, group, file_mode, None, follow_symlinks)
+                            ret, _ = __salt__["file.check_perms"](
+                                full, ret, user, group, file_mode, None, follow_symlinks
+                            )
                     except CommandExecutionError as exc:
-                        if not exc.strerror.startswith('Path not found'):
+                        if not exc.strerror.startswith("Path not found"):
                             errors.append(exc.strerror)
 
             if check_dirs:
@@ -3595,85 +3689,88 @@ def directory(name,
                     full = os.path.join(root, dir_)
                     try:
                         if salt.utils.platform.is_windows():
-                            ret = __salt__['file.check_perms'](
+                            ret = __salt__["file.check_perms"](
                                 path=full,
                                 ret=ret,
                                 owner=win_owner,
                                 grant_perms=win_perms,
                                 deny_perms=win_deny_perms,
                                 inheritance=win_inheritance,
-                                reset=win_perms_reset)
+                                reset=win_perms_reset,
+                            )
                         else:
-                            ret, _ = __salt__['file.check_perms'](
-                                full, ret, user, group, dir_mode, None, follow_symlinks)
+                            ret, _ = __salt__["file.check_perms"](
+                                full, ret, user, group, dir_mode, None, follow_symlinks
+                            )
                     except CommandExecutionError as exc:
-                        if not exc.strerror.startswith('Path not found'):
+                        if not exc.strerror.startswith("Path not found"):
                             errors.append(exc.strerror)
 
     if clean:
         keep = _gen_keep_files(name, require, walk_d)
-        log.debug('List of kept files when use file.directory with clean: %s',
-                  keep)
+        log.debug("List of kept files when use file.directory with clean: %s", keep)
         removed = _clean_dir(name, list(keep), exclude_pat)
         if removed:
-            ret['changes']['removed'] = removed
-            ret['comment'] = 'Files cleaned from directory {0}'.format(name)
+            ret["changes"]["removed"] = removed
+            ret["comment"] = "Files cleaned from directory {0}".format(name)
 
     # issue 32707: reflect children_only selection in comments
-    if not ret['comment']:
+    if not ret["comment"]:
         if children_only:
-            ret['comment'] = 'Directory {0}/* updated'.format(name)
+            ret["comment"] = "Directory {0}/* updated".format(name)
         else:
-            if ret['changes']:
-                ret['comment'] = 'Directory {0} updated'.format(name)
+            if ret["changes"]:
+                ret["comment"] = "Directory {0} updated".format(name)
 
-    if __opts__['test']:
-        ret['comment'] = 'Directory {0} not updated'.format(name)
-    elif not ret['changes'] and ret['result']:
+    if __opts__["test"]:
+        ret["comment"] = "Directory {0} not updated".format(name)
+    elif not ret["changes"] and ret["result"]:
         orig_comment = None
-        if ret['comment']:
-            orig_comment = ret['comment']
+        if ret["comment"]:
+            orig_comment = ret["comment"]
 
-        ret['comment'] = 'Directory {0} is in the correct state'.format(name)
+        ret["comment"] = "Directory {0} is in the correct state".format(name)
         if orig_comment:
-            ret['comment'] = '\n'.join([ret['comment'], orig_comment])
+            ret["comment"] = "\n".join([ret["comment"], orig_comment])
 
     if errors:
-        ret['result'] = False
-        ret['comment'] += '\n\nThe following errors were encountered:\n'
+        ret["result"] = False
+        ret["comment"] += "\n\nThe following errors were encountered:\n"
         for error in errors:
-            ret['comment'] += '\n- {0}'.format(error)
+            ret["comment"] += "\n- {0}".format(error)
 
     return ret
 
 
-def recurse(name,
-            source,
-            keep_source=True,
-            clean=False,
-            require=None,
-            user=None,
-            group=None,
-            dir_mode=None,
-            file_mode=None,
-            sym_mode=None,
-            template=None,
-            context=None,
-            replace=True,
-            defaults=None,
-            include_empty=False,
-            backup='',
-            include_pat=None,
-            exclude_pat=None,
-            maxdepth=None,
-            keep_symlinks=False,
-            force_symlinks=False,
-            win_owner=None,
-            win_perms=None,
-            win_deny_perms=None,
-            win_inheritance=True,
-            **kwargs):
-    '''
+def recurse(
+    name,
+    source,
+    keep_source=True,
+    clean=False,
+    require=None,
+    user=None,
+    group=None,
+    dir_mode=None,
+    file_mode=None,
+    sym_mode=None,
+    template=None,
+    context=None,
+    replace=True,
+    defaults=None,
+    include_empty=False,
+    backup="",
+    include_pat=None,
+    exclude_pat=None,
+    maxdepth=None,
+    keep_symlinks=False,
+    force_symlinks=False,
+    win_owner=None,
+    win_perms=None,
+    win_deny_perms=None,
+    win_inheritance=True,
+    **kwargs
+):
+    """
     Recurse through a subdirectory on the master and copy said subdirectory
     over to the specified path.
 
@@ -3871,10 +3968,10 @@ def recurse(name,
         True to inherit permissions from parent, otherwise False
 
         .. versionadded:: 2017.7.7
-    '''
-    if 'env' in kwargs:
+    """
+    if "env" in kwargs:
         # "env" is not supported; Use "saltenv".
-        kwargs.pop('env')
+        kwargs.pop("env")
 
     name = os.path.expanduser(salt.utils.data.decode(name))
 
@@ -3882,34 +3979,37 @@ def recurse(name,
     if salt.utils.platform.is_windows():
         if group is not None:
             log.warning(
-                'The group argument for %s has been ignored as this '
-                'is a Windows system.', name
+                "The group argument for %s has been ignored as this "
+                "is a Windows system.",
+                name,
             )
         group = user
     ret = {
-        'name': name,
-        'changes': {},
-        'result': True,
-        'comment': {}  # { path: [comment, ...] }
+        "name": name,
+        "changes": {},
+        "result": True,
+        "comment": {},  # { path: [comment, ...] }
     }
 
-    if 'mode' in kwargs:
-        ret['result'] = False
-        ret['comment'] = (
-            '\'mode\' is not allowed in \'file.recurse\'. Please use '
-            '\'file_mode\' and \'dir_mode\'.'
+    if "mode" in kwargs:
+        ret["result"] = False
+        ret["comment"] = (
+            "'mode' is not allowed in 'file.recurse'. Please use "
+            "'file_mode' and 'dir_mode'."
         )
         return ret
 
-    if any([x is not None for x in (dir_mode, file_mode, sym_mode)]) \
-            and salt.utils.platform.is_windows():
-        return _error(ret, 'mode management is not supported on Windows')
+    if (
+        any([x is not None for x in (dir_mode, file_mode, sym_mode)])
+        and salt.utils.platform.is_windows()
+    ):
+        return _error(ret, "mode management is not supported on Windows")
 
     # Make sure that leading zeros stripped by YAML loader are added back
     dir_mode = salt.utils.files.normalize_mode(dir_mode)
 
     try:
-        keep_mode = file_mode.lower() == 'keep'
+        keep_mode = file_mode.lower() == "keep"
         if keep_mode:
             # We're not hard-coding the mode, so set it to None
             file_mode = None
@@ -3923,26 +4023,27 @@ def recurse(name,
         # The specified user or group do not exist
         return _error(ret, u_check)
     if not os.path.isabs(name):
-        return _error(
-            ret, 'Specified file {0} is not an absolute path'.format(name))
+        return _error(ret, "Specified file {0} is not an absolute path".format(name))
 
     # expand source into source_list
     source_list = _validate_str_list(source)
 
     for idx, val in enumerate(source_list):
-        source_list[idx] = val.rstrip('/')
+        source_list[idx] = val.rstrip("/")
 
     for precheck in source_list:
-        if not precheck.startswith('salt://'):
-            return _error(ret, ('Invalid source \'{0}\' '
-                                '(must be a salt:// URI)'.format(precheck)))
+        if not precheck.startswith("salt://"):
+            return _error(
+                ret,
+                ("Invalid source '{0}' " "(must be a salt:// URI)".format(precheck)),
+            )
 
     # Select the first source in source_list that exists
     try:
-        source, source_hash = __salt__['file.source_list'](source_list, '', __env__)
+        source, source_hash = __salt__["file.source_list"](source_list, "", __env__)
     except CommandExecutionError as exc:
-        ret['result'] = False
-        ret['comment'] = 'Recurse failed: {0}'.format(exc)
+        ret["result"] = False
+        ret["comment"] = "Recurse failed: {0}".format(exc)
         return ret
 
     # Check source path relative to fileserver root, make sure it is a
@@ -3950,14 +4051,14 @@ def recurse(name,
     srcpath, senv = salt.utils.url.parse(source)
     if senv is None:
         senv = __env__
-    master_dirs = __salt__['cp.list_master_dirs'](saltenv=senv)
-    if srcpath not in master_dirs \
-            and not any((x for x in master_dirs
-                         if x.startswith(srcpath + '/'))):
-        ret['result'] = False
-        ret['comment'] = (
-            'The directory \'{0}\' does not exist on the salt fileserver '
-            'in saltenv \'{1}\''.format(srcpath, senv)
+    master_dirs = __salt__["cp.list_master_dirs"](saltenv=senv)
+    if srcpath not in master_dirs and not any(
+        (x for x in master_dirs if x.startswith(srcpath + "/"))
+    ):
+        ret["result"] = False
+        ret["comment"] = (
+            "The directory '{0}' does not exist on the salt fileserver "
+            "in saltenv '{1}'".format(srcpath, senv)
         )
         return ret
 
@@ -3966,23 +4067,25 @@ def recurse(name,
         if os.path.exists(name):
             # it is not a dir, but it exists - fail out
             return _error(
-                ret, 'The path {0} exists and is not a directory'.format(name))
-        if not __opts__['test']:
+                ret, "The path {0} exists and is not a directory".format(name)
+            )
+        if not __opts__["test"]:
             if salt.utils.platform.is_windows():
                 win_owner = win_owner if win_owner else user
-                __salt__['file.makedirs_perms'](path=name,
-                                                owner=win_owner,
-                                                grant_perms=win_perms,
-                                                deny_perms=win_deny_perms,
-                                                inheritance=win_inheritance)
+                __salt__["file.makedirs_perms"](
+                    path=name,
+                    owner=win_owner,
+                    grant_perms=win_perms,
+                    deny_perms=win_deny_perms,
+                    inheritance=win_inheritance,
+                )
             else:
-                __salt__['file.makedirs_perms'](name=name,
-                                                user=user,
-                                                group=group,
-                                                mode=dir_mode)
+                __salt__["file.makedirs_perms"](
+                    name=name, user=user, group=group, mode=dir_mode
+                )
 
     def add_comment(path, comment):
-        comments = ret['comment'].setdefault(path, [])
+        comments = ret["comment"].setdefault(path, [])
         if isinstance(comment, six.string_types):
             comments.append(comment)
         else:
@@ -3990,34 +4093,32 @@ def recurse(name,
 
     def merge_ret(path, _ret):
         # Use the most "negative" result code (out of True, None, False)
-        if _ret['result'] is False or ret['result'] is True:
-            ret['result'] = _ret['result']
+        if _ret["result"] is False or ret["result"] is True:
+            ret["result"] = _ret["result"]
 
         # Only include comments about files that changed
-        if _ret['result'] is not True and _ret['comment']:
-            add_comment(path, _ret['comment'])
+        if _ret["result"] is not True and _ret["comment"]:
+            add_comment(path, _ret["comment"])
 
-        if _ret['changes']:
-            ret['changes'][path] = _ret['changes']
+        if _ret["changes"]:
+            ret["changes"][path] = _ret["changes"]
 
     def manage_file(path, source, replace):
         if clean and os.path.exists(path) and os.path.isdir(path) and replace:
-            _ret = {'name': name, 'changes': {}, 'result': True, 'comment': ''}
-            if __opts__['test']:
-                _ret['comment'] = 'Replacing directory {0} with a ' \
-                                  'file'.format(path)
-                _ret['result'] = None
+            _ret = {"name": name, "changes": {}, "result": True, "comment": ""}
+            if __opts__["test"]:
+                _ret["comment"] = "Replacing directory {0} with a " "file".format(path)
+                _ret["result"] = None
                 merge_ret(path, _ret)
                 return
             else:
-                __salt__['file.remove'](path)
-                _ret['changes'] = {'diff': 'Replaced directory with a '
-                                           'new file'}
+                __salt__["file.remove"](path)
+                _ret["changes"] = {"diff": "Replaced directory with a " "new file"}
                 merge_ret(path, _ret)
 
         # Conflicts can occur if some kwargs are passed in here
         pass_kwargs = {}
-        faults = ['mode', 'makedirs']
+        faults = ["mode", "makedirs"]
         for key in kwargs:
             if key not in faults:
                 pass_kwargs[key] = kwargs[key]
@@ -4028,7 +4129,7 @@ def recurse(name,
             keep_source=keep_source,
             user=user,
             group=group,
-            mode='keep' if keep_mode else file_mode,
+            mode="keep" if keep_mode else file_mode,
             attrs=None,
             template=template,
             makedirs=True,
@@ -4036,22 +4137,23 @@ def recurse(name,
             context=context,
             defaults=defaults,
             backup=backup,
-            **pass_kwargs)
+            **pass_kwargs
+        )
         merge_ret(path, _ret)
 
     def manage_directory(path):
-        if os.path.basename(path) == '..':
+        if os.path.basename(path) == "..":
             return
         if clean and os.path.exists(path) and not os.path.isdir(path):
-            _ret = {'name': name, 'changes': {}, 'result': True, 'comment': ''}
-            if __opts__['test']:
-                _ret['comment'] = 'Replacing {0} with a directory'.format(path)
-                _ret['result'] = None
+            _ret = {"name": name, "changes": {}, "result": True, "comment": ""}
+            if __opts__["test"]:
+                _ret["comment"] = "Replacing {0} with a directory".format(path)
+                _ret["result"] = None
                 merge_ret(path, _ret)
                 return
             else:
-                __salt__['file.remove'](path)
-                _ret['changes'] = {'diff': 'Replaced file with a directory'}
+                __salt__["file.remove"](path)
+                _ret["changes"] = {"diff": "Replaced file with a directory"}
                 merge_ret(path, _ret)
 
         _ret = directory(
@@ -4063,26 +4165,24 @@ def recurse(name,
             file_mode=None,
             makedirs=True,
             clean=False,
-            require=None)
+            require=None,
+        )
         merge_ret(path, _ret)
 
     mng_files, mng_dirs, mng_symlinks, keep = _gen_recurse_managed_files(
-        name,
-        source,
-        keep_symlinks,
-        include_pat,
-        exclude_pat,
-        maxdepth,
-        include_empty)
+        name, source, keep_symlinks, include_pat, exclude_pat, maxdepth, include_empty
+    )
 
     for srelpath, ltarget in mng_symlinks:
-        _ret = symlink(os.path.join(name, srelpath),
-                       ltarget,
-                       makedirs=True,
-                       force=force_symlinks,
-                       user=user,
-                       group=group,
-                       mode=sym_mode)
+        _ret = symlink(
+            os.path.join(name, srelpath),
+            ltarget,
+            makedirs=True,
+            force=force_symlinks,
+            user=user,
+            group=group,
+            mode=sym_mode,
+        )
         if not _ret:
             continue
         merge_ret(os.path.join(name, srelpath), _ret)
@@ -4096,32 +4196,33 @@ def recurse(name,
         keep.update(_gen_keep_files(name, require))
         removed = _clean_dir(name, list(keep), exclude_pat)
         if removed:
-            if __opts__['test']:
-                if ret['result']:
-                    ret['result'] = None
-                add_comment('removed', removed)
+            if __opts__["test"]:
+                if ret["result"]:
+                    ret["result"] = None
+                add_comment("removed", removed)
             else:
-                ret['changes']['removed'] = removed
+                ret["changes"]["removed"] = removed
 
     # Flatten comments until salt command line client learns
     # to display structured comments in a readable fashion
-    ret['comment'] = '\n'.join('\n#### {0} ####\n{1}'.format(
-        k, v if isinstance(v, six.string_types) else '\n'.join(v)
-    ) for (k, v) in six.iteritems(ret['comment'])).strip()
-
-    if not ret['comment']:
-        ret['comment'] = 'Recursively updated {0}'.format(name)
-
-    if not ret['changes'] and ret['result']:
-        ret['comment'] = 'The directory {0} is in the correct state'.format(
-            name
+    ret["comment"] = "\n".join(
+        "\n#### {0} ####\n{1}".format(
+            k, v if isinstance(v, six.string_types) else "\n".join(v)
         )
+        for (k, v) in six.iteritems(ret["comment"])
+    ).strip()
+
+    if not ret["comment"]:
+        ret["comment"] = "Recursively updated {0}".format(name)
+
+    if not ret["changes"] and ret["result"]:
+        ret["comment"] = "The directory {0} is in the correct state".format(name)
 
     return ret
 
 
 def retention_schedule(name, retain, strptime_format=None, timezone=None):
-    '''
+    """
     Apply retention scheduling to backup storage directory.
 
     .. versionadded:: 2016.11.0
@@ -4183,19 +4284,21 @@ def retention_schedule(name, retain, strptime_format=None, timezone=None):
             - strptime_format: example_name_%Y%m%dT%H%M%S.tar.bz2
             - timezone: None
 
-    '''
+    """
     name = os.path.expanduser(name)
-    ret = {'name': name,
-           'changes': {'retained': [], 'deleted': [], 'ignored': []},
-           'result': True,
-           'comment': ''}
+    ret = {
+        "name": name,
+        "changes": {"retained": [], "deleted": [], "ignored": []},
+        "result": True,
+        "comment": "",
+    }
     if not name:
-        return _error(ret, 'Must provide name to file.retention_schedule')
+        return _error(ret, "Must provide name to file.retention_schedule")
     if not os.path.isdir(name):
-        return _error(ret, 'Name provided to file.retention must be a directory')
+        return _error(ret, "Name provided to file.retention must be a directory")
 
     # get list of files in directory
-    all_files = __salt__['file.readdir'](name)
+    all_files = __salt__["file.readdir"](name)
 
     # if strptime_format is set, filter through the list to find names which parse and get their datetimes.
     beginning_of_unix_time = datetime(1970, 1, 1)
@@ -4210,16 +4313,18 @@ def retention_schedule(name, retain, strptime_format=None, timezone=None):
             return (None, None)
 
     def get_file_time_from_mtime(f):
-        if f == '.' or f == '..':
+        if f == "." or f == "..":
             return (None, None)
-        lstat = __salt__['file.lstat'](os.path.join(name, f))
+        lstat = __salt__["file.lstat"](os.path.join(name, f))
         if lstat:
-            mtime = lstat['st_mtime']
+            mtime = lstat["st_mtime"]
             return (datetime.fromtimestamp(mtime, timezone), mtime)
-        else:   # maybe it was deleted since we did the readdir?
+        else:  # maybe it was deleted since we did the readdir?
             return (None, None)
 
-    get_file_time = get_file_time_from_strptime if strptime_format else get_file_time_from_mtime
+    get_file_time = (
+        get_file_time_from_strptime if strptime_format else get_file_time_from_mtime
+    )
 
     # data structures are nested dicts:
     # files_by_ymd = year.month.day.hour.unixtime: filename
@@ -4228,6 +4333,7 @@ def retention_schedule(name, retain, strptime_format=None, timezone=None):
     # TODO: move to an ordered dict model and reduce the number of sorts in the rest of the code?
     def dict_maker():
         return defaultdict(dict_maker)
+
     files_by_ymd = dict_maker()
     files_by_y_week_dow = dict_maker()
     relevant_files = set()
@@ -4244,11 +4350,11 @@ def retention_schedule(name, retain, strptime_format=None, timezone=None):
 
     # This is tightly coupled with the file_with_times data-structure above.
     RETAIN_TO_DEPTH = {
-        'first_of_year': 1,
-        'first_of_month': 2,
-        'first_of_day': 3,
-        'first_of_hour': 4,
-        'most_recent': 5,
+        "first_of_year": 1,
+        "first_of_month": 2,
+        "first_of_day": 3,
+        "first_of_hour": 4,
+        "most_recent": 5,
     }
 
     def get_first(fwt):
@@ -4256,7 +4362,7 @@ def retention_schedule(name, retain, strptime_format=None, timezone=None):
             first_sub_key = sorted(fwt.keys())[0]
             return get_first(fwt[first_sub_key])
         else:
-            return set([fwt, ])
+            return set([fwt])
 
     def get_first_n_at_depth(fwt, depth, n):
         if depth <= 0:
@@ -4276,47 +4382,64 @@ def retention_schedule(name, retain, strptime_format=None, timezone=None):
         # This is kind of a hack, since 'all' should really mean all,
         # but I think it's a large enough number that even modern filesystems would
         # choke if they had this many files in a single directory.
-        keep_count = sys.maxsize if 'all' == keep_count else int(keep_count)
-        if 'first_of_week' == retention_rule:
-            first_of_week_depth = 2   # year + week_of_year = 2
+        keep_count = sys.maxsize if "all" == keep_count else int(keep_count)
+        if "first_of_week" == retention_rule:
+            first_of_week_depth = 2  # year + week_of_year = 2
             # I'm adding 1 to keep_count below because it fixed an off-by one
             # issue in the tests. I don't understand why, and that bothers me.
-            retained_files |= get_first_n_at_depth(files_by_y_week_dow,
-                                                   first_of_week_depth,
-                                                   keep_count + 1)
+            retained_files |= get_first_n_at_depth(
+                files_by_y_week_dow, first_of_week_depth, keep_count + 1
+            )
         else:
-            retained_files |= get_first_n_at_depth(files_by_ymd,
-                                                   RETAIN_TO_DEPTH[retention_rule],
-                                                   keep_count)
+            retained_files |= get_first_n_at_depth(
+                files_by_ymd, RETAIN_TO_DEPTH[retention_rule], keep_count
+            )
 
     deletable_files = list(relevant_files - retained_files)
     deletable_files.sort(reverse=True)
     changes = {
-            'retained': sorted(list(retained_files), reverse=True),
-            'deleted': deletable_files,
-            'ignored': sorted(list(ignored_files), reverse=True),
-        }
-    ret['changes'] = changes
+        "retained": sorted(list(retained_files), reverse=True),
+        "deleted": deletable_files,
+        "ignored": sorted(list(ignored_files), reverse=True),
+    }
+    ret["changes"] = changes
 
     # TODO: track and report how much space was / would be reclaimed
-    if __opts__['test']:
-        ret['comment'] = '{0} backups would have been removed from {1}.\n'.format(len(deletable_files), name)
+    if __opts__["test"]:
+        ret["comment"] = "{0} backups would have been removed from {1}.\n".format(
+            len(deletable_files), name
+        )
         if deletable_files:
-            ret['result'] = None
+            ret["result"] = None
     else:
         for f in deletable_files:
-            __salt__['file.remove'](os.path.join(name, f))
-        ret['comment'] = '{0} backups were removed from {1}.\n'.format(len(deletable_files), name)
-        ret['changes'] = changes
+            __salt__["file.remove"](os.path.join(name, f))
+        ret["comment"] = "{0} backups were removed from {1}.\n".format(
+            len(deletable_files), name
+        )
+        ret["changes"] = changes
 
     return ret
 
 
-def line(name, content=None, match=None, mode=None, location=None,
-         before=None, after=None, show_changes=True, backup=False,
-         quiet=False, indent=True, create=False, user=None,
-         group=None, file_mode=None):
-    '''
+def line(
+    name,
+    content=None,
+    match=None,
+    mode=None,
+    location=None,
+    before=None,
+    after=None,
+    show_changes=True,
+    backup=False,
+    quiet=False,
+    indent=True,
+    create=False,
+    user=None,
+    group=None,
+    file_mode=None,
+):
+    """
     Line-based editing of a file.
 
     .. versionadded:: 2015.8.0
@@ -4433,22 +4556,13 @@ def line(name, content=None, match=None, mode=None, location=None,
            - content: my key = my value
            - before: somekey.*?
 
-    '''
+    """
     name = os.path.expanduser(name)
-    ret = {'name': name,
-           'changes': {},
-           'result': True,
-           'comment': ''}
+    ret = {"name": name, "changes": {}, "result": True, "comment": ""}
     if not name:
-        return _error(ret, 'Must provide name to file.line')
+        return _error(ret, "Must provide name to file.line")
 
-    managed(
-        name,
-        create=create,
-        user=user,
-        group=group,
-        mode=file_mode,
-        replace=False)
+    managed(name, create=create, user=user, group=group, mode=file_mode, replace=False)
 
     check_res, check_msg = _check_file(name)
     if not check_res:
@@ -4458,46 +4572,60 @@ def line(name, content=None, match=None, mode=None, location=None,
     # it gets passed when needed. Feature #37092
     mode = mode and mode.lower() or mode
     if mode is None:
-        return _error(ret, 'Mode was not defined. How to process the file?')
+        return _error(ret, "Mode was not defined. How to process the file?")
 
-    modeswithemptycontent = ['delete']
+    modeswithemptycontent = ["delete"]
     if mode not in modeswithemptycontent and content is None:
-        return _error(ret, 'Content can only be empty if mode is {0}'.format(modeswithemptycontent))
+        return _error(
+            ret,
+            "Content can only be empty if mode is {0}".format(modeswithemptycontent),
+        )
     del modeswithemptycontent
 
-    changes = __salt__['file.line'](
-        name, content, match=match, mode=mode, location=location,
-        before=before, after=after, show_changes=show_changes,
-        backup=backup, quiet=quiet, indent=indent)
+    changes = __salt__["file.line"](
+        name,
+        content,
+        match=match,
+        mode=mode,
+        location=location,
+        before=before,
+        after=after,
+        show_changes=show_changes,
+        backup=backup,
+        quiet=quiet,
+        indent=indent,
+    )
     if changes:
-        ret['changes']['diff'] = changes
-        if __opts__['test']:
-            ret['result'] = None
-            ret['comment'] = 'Changes would be made'
+        ret["changes"]["diff"] = changes
+        if __opts__["test"]:
+            ret["result"] = None
+            ret["comment"] = "Changes would be made"
         else:
-            ret['result'] = True
-            ret['comment'] = 'Changes were made'
+            ret["result"] = True
+            ret["comment"] = "Changes were made"
     else:
-        ret['result'] = True
-        ret['comment'] = 'No changes needed to be made'
+        ret["result"] = True
+        ret["comment"] = "No changes needed to be made"
 
     return ret
 
 
-def replace(name,
-            pattern,
-            repl,
-            count=0,
-            flags=8,
-            bufsize=1,
-            append_if_not_found=False,
-            prepend_if_not_found=False,
-            not_found_content=None,
-            backup='.bak',
-            show_changes=True,
-            ignore_if_missing=False,
-            backslash_literal=False):
-    r'''
+def replace(
+    name,
+    pattern,
+    repl,
+    count=0,
+    flags=8,
+    bufsize=1,
+    append_if_not_found=False,
+    prepend_if_not_found=False,
+    not_found_content=None,
+    backup=".bak",
+    show_changes=True,
+    ignore_if_missing=False,
+    backslash_literal=False,
+):
+    r"""
     Maintain an edit in a file.
 
     .. versionadded:: 0.17.0
@@ -4637,70 +4765,70 @@ def replace(name,
 
        The ``file.replace`` state uses Python's ``re`` module.
        For more advanced options, see https://docs.python.org/2/library/re.html
-    '''
+    """
     name = os.path.expanduser(name)
 
-    ret = {'name': name,
-           'changes': {},
-           'result': True,
-           'comment': ''}
+    ret = {"name": name, "changes": {}, "result": True, "comment": ""}
     if not name:
-        return _error(ret, 'Must provide name to file.replace')
+        return _error(ret, "Must provide name to file.replace")
 
     check_res, check_msg = _check_file(name)
     if not check_res:
-        if ignore_if_missing and 'file not found' in check_msg:
-            ret['comment'] = 'No changes needed to be made'
+        if ignore_if_missing and "file not found" in check_msg:
+            ret["comment"] = "No changes needed to be made"
             return ret
         else:
             return _error(ret, check_msg)
 
-    changes = __salt__['file.replace'](name,
-                                       pattern,
-                                       repl,
-                                       count=count,
-                                       flags=flags,
-                                       bufsize=bufsize,
-                                       append_if_not_found=append_if_not_found,
-                                       prepend_if_not_found=prepend_if_not_found,
-                                       not_found_content=not_found_content,
-                                       backup=backup,
-                                       dry_run=__opts__['test'],
-                                       show_changes=show_changes,
-                                       ignore_if_missing=ignore_if_missing,
-                                       backslash_literal=backslash_literal)
+    changes = __salt__["file.replace"](
+        name,
+        pattern,
+        repl,
+        count=count,
+        flags=flags,
+        bufsize=bufsize,
+        append_if_not_found=append_if_not_found,
+        prepend_if_not_found=prepend_if_not_found,
+        not_found_content=not_found_content,
+        backup=backup,
+        dry_run=__opts__["test"],
+        show_changes=show_changes,
+        ignore_if_missing=ignore_if_missing,
+        backslash_literal=backslash_literal,
+    )
 
     if changes:
-        ret['changes']['diff'] = changes
-        if __opts__['test']:
-            ret['result'] = None
-            ret['comment'] = 'Changes would have been made'
+        ret["changes"]["diff"] = changes
+        if __opts__["test"]:
+            ret["result"] = None
+            ret["comment"] = "Changes would have been made"
         else:
-            ret['result'] = True
-            ret['comment'] = 'Changes were made'
+            ret["result"] = True
+            ret["comment"] = "Changes were made"
     else:
-        ret['result'] = True
-        ret['comment'] = 'No changes needed to be made'
+        ret["result"] = True
+        ret["comment"] = "No changes needed to be made"
 
     return ret
 
 
 def keyvalue(
-        name,
-        key=None,
-        value=None,
-        key_values=None,
-        separator="=",
-        append_if_not_found=False,
-        prepend_if_not_found=False,
-        search_only=False,
-        show_changes=True,
-        ignore_if_missing=False,
-        count=1,
-        uncomment=None,
-        key_ignore_case=False,
-        value_ignore_case=False):
-    '''
+    name,
+    key=None,
+    value=None,
+    key_values=None,
+    separator="=",
+    append_if_not_found=False,
+    prepend_if_not_found=False,
+    search_only=False,
+    show_changes=True,
+    ignore_if_missing=False,
+    count=1,
+    uncomment=None,
+    key_ignore_case=False,
+    value_ignore_case=False,
+):
+    """
     Key/Value based editing of a file.
 
     .. versionadded:: Neon
@@ -4810,38 +4938,34 @@ def keyvalue(
         Notice how the key is not matched case-sensitively, this way it will
         correctly identify both 'PermitRootLogin' as well as 'permitrootlogin'.
 
-    '''
+    """
     name = os.path.expanduser(name)
 
     # default return values
-    ret = {
-        'name': name,
-        'changes': {},
-        'pchanges': {},
-        'result': None,
-        'comment': '',
-        }
+    ret = {"name": name, "changes": {}, "pchanges": {}, "result": None, "comment": ""}
 
     if not name:
-        return _error(ret, 'Must provide name to file.keyvalue')
+        return _error(ret, "Must provide name to file.keyvalue")
     if key is not None and value is not None:
         if isinstance(key_values, dict):
-            return _error(ret,
-                    'file.keyvalue can not combine key_values with key and value')
+            return _error(
+                ret, "file.keyvalue can not combine key_values with key and value"
+            )
         key_values = {str(key): value}
     elif not isinstance(key_values, dict):
-        return _error(ret,
-                'file.keyvalue key and value not supplied and key_values empty')
+        return _error(
+            ret, "file.keyvalue key and value not supplied and key_values empty"
+        )
 
     # try to open the file and only return a comment if ignore_if_missing is
     # enabled, also mark as an error if not
     file_contents = []
     try:
-        with salt.utils.files.fopen(name, 'r') as fd:
+        with salt.utils.files.fopen(name, "r") as fd:
             file_contents = fd.readlines()
     except (OSError, IOError):
-        ret['comment'] = 'unable to open {n}'.format(n=name)
-        ret['result'] = True if ignore_if_missing else False
+        ret["comment"] = "unable to open {n}".format(n=name)
+        ret["result"] = True if ignore_if_missing else False
         return ret
 
     # used to store diff combinations and check if anything has changed
@@ -4849,7 +4973,7 @@ def keyvalue(
     # store the final content of the file in case it needs to be rewritten
     content = []
     # target format is templated like this
-    tmpl = '{key}{sep}{value}'+os.linesep
+    tmpl = "{key}{sep}{value}" + os.linesep
     # number of lines changed
     changes = 0
     # keep track of number of times a key was updated
@@ -4929,7 +5053,7 @@ def keyvalue(
                         # the old line always needs to go, so that will be
                         # reflected in the diff (this is the original line from
                         # the file being read)
-                        diff.append('- {0}'.format(line))
+                        diff.append("- {0}".format(line))
                         line = line[:0]
 
                         # any non-zero value means something needs to go back in
@@ -4939,19 +5063,20 @@ def keyvalue(
                         if diff_count[key] != 0:
                             # rebuild the line using the key and separator found
                             # and insert the correct value.
-                            line = str(tmpl.format(key=line_key,
-                                                   sep=line_sep,
-                                                   value=value))
+                            line = str(
+                                tmpl.format(key=line_key, sep=line_sep, value=value)
+                            )
 
                             # display a comment in case a value got converted
                             # into a string
                             if not isinstance(value, str):
-                                diff.append('+ {0} (from {1} type){2}'.format(
-                                    line.rstrip(),
-                                    type(value).__name__,
-                                    os.linesep))
+                                diff.append(
+                                    "+ {0} (from {1} type){2}".format(
+                                        line.rstrip(), type(value).__name__, os.linesep
+                                    )
+                                )
                             else:
-                                diff.append('+ {0}'.format(line))
+                                diff.append("+ {0}".format(line))
                         changes += 1
                     # subtract one from the count if it was larger than 0, so
                     # next lines are removed. if it is less than 0 then count is
@@ -4960,7 +5085,7 @@ def keyvalue(
                         diff_count[key] -= 1
                     # at this point a continue saves going through the rest of
                     # the keys to see if they match since this line already
-                    #matched the current key
+                    # matched the current key
                     continue
         # with the line having been checked for all keys (or matched before all
         # keys needed searching), the line can be added to the content to be
@@ -4976,12 +5101,12 @@ def keyvalue(
         for key, value in key_values.items():
             if diff_count[key] > 0:
                 line = tmpl.format(key=key, sep=separator, value=value)
-                tmpdiff.append('+ {0}'.format(line))
+                tmpdiff.append("+ {0}".format(line))
                 content.append(line)
                 changes += 1
         if tmpdiff:
-            tmpdiff.insert(0, '- <EOF>'+os.linesep)
-            tmpdiff.append('+ <EOF>'+os.linesep)
+            tmpdiff.insert(0, "- <EOF>" + os.linesep)
+            tmpdiff.append("+ <EOF>" + os.linesep)
             diff.extend(tmpdiff)
     # only if append_if_not_found was not set should prepend_if_not_found be
     # considered, benefit of this is that the number of counts left does not
@@ -4992,79 +5117,80 @@ def keyvalue(
             if diff_count[key] > 0:
                 line = tmpl.format(key=key, sep=separator, value=value)
                 if not did_diff:
-                    diff.insert(0, '  <SOF>'+os.linesep)
+                    diff.insert(0, "  <SOF>" + os.linesep)
                     did_diff = True
-                diff.insert(1, '+ {0}'.format(line))
+                diff.insert(1, "+ {0}".format(line))
                 content.insert(0, line)
                 changes += 1
 
     # if a diff was made
     if changes > 0:
         # return comment of changes if test
-        if __opts__['test']:
-            ret['comment'] = 'File {n} is set to be changed ({c} lines)'.format(
-                n=name,
-                c=changes)
+        if __opts__["test"]:
+            ret["comment"] = "File {n} is set to be changed ({c} lines)".format(
+                n=name, c=changes
+            )
             if show_changes:
                 # For some reason, giving an actual diff even in test=True mode
                 # will be seen as both a 'changed' and 'unchanged'. this seems to
                 # match the other modules behaviour though
-                ret['pchanges']['diff'] = ''.join(diff)
+                ret["pchanges"]["diff"] = "".join(diff)
 
                 # add changes to comments for now as well because of how
                 # stateoutputter seems to handle pchanges etc.
                 # See: https://github.com/saltstack/salt/issues/40208
-                ret['comment'] += '\nPredicted diff:\n\r\t\t'
-                ret['comment'] += '\r\t\t'.join(diff)
-                ret['result'] = None
+                ret["comment"] += "\nPredicted diff:\n\r\t\t"
+                ret["comment"] += "\r\t\t".join(diff)
+                ret["result"] = None
 
         # otherwise return the actual diff lines
         else:
-            ret['comment'] = 'Changed {c} lines'.format(c=changes)
+            ret["comment"] = "Changed {c} lines".format(c=changes)
             if show_changes:
-                ret['changes']['diff'] = ''.join(diff)
+                ret["changes"]["diff"] = "".join(diff)
     else:
-        ret['result'] = True
+        ret["result"] = True
         return ret
 
     # if not test=true, try and write the file
-    if not __opts__['test']:
+    if not __opts__["test"]:
         try:
-            with salt.utils.files.fopen(name, 'w') as fd:
+            with salt.utils.files.fopen(name, "w") as fd:
                 # write all lines to the file which was just truncated
                 fd.writelines(content)
                 fd.close()
         except (OSError, IOError):
             # return an error if the file was not writable
-            ret['comment'] = '{n} not writable'.format(n=name)
-            ret['result'] = False
+            ret["comment"] = "{n} not writable".format(n=name)
+            ret["result"] = False
             return ret
         # if all went well, then set result to true
-        ret['result'] = True
+        ret["result"] = True
 
     return ret
 
 
 def blockreplace(
-        name,
-        marker_start='#-- start managed zone --',
-        marker_end='#-- end managed zone --',
-        source=None,
-        source_hash=None,
-        template='jinja',
-        sources=None,
-        source_hashes=None,
-        defaults=None,
-        context=None,
-        content='',
-        append_if_not_found=False,
-        prepend_if_not_found=False,
-        backup='.bak',
-        show_changes=True,
-        append_newline=None,
-        insert_before_match=None,
-        insert_after_match=None):
-    '''
+    name,
+    marker_start="#-- start managed zone --",
+    marker_end="#-- end managed zone --",
+    source=None,
+    source_hash=None,
+    template="jinja",
+    sources=None,
+    source_hashes=None,
+    defaults=None,
+    context=None,
+    content="",
+    append_if_not_found=False,
+    prepend_if_not_found=False,
+    backup=".bak",
+    show_changes=True,
+    append_newline=None,
+    insert_before_match=None,
+    insert_after_match=None,
+):
+    """
     Maintain an edit in a file in a zone delimited by two line markers
 
     .. versionadded:: 2014.1.0
@@ -5268,25 +5394,24 @@ def blockreplace(
         text 3
         text 4
         # END managed zone 42 --
-    '''
+    """
     name = os.path.expanduser(name)
 
-    ret = {'name': name,
-           'changes': {},
-           'result': False,
-           'comment': ''}
+    ret = {"name": name, "changes": {}, "result": False, "comment": ""}
     if not name:
-        return _error(ret, 'Must provide name to file.blockreplace')
+        return _error(ret, "Must provide name to file.blockreplace")
 
     if sources is None:
         sources = []
     if source_hashes is None:
         source_hashes = []
 
-    (ok_, err, sl_) = _unify_sources_and_hashes(source=source,
-                                                source_hash=source_hash,
-                                                sources=sources,
-                                                source_hashes=source_hashes)
+    (ok_, err, sl_) = _unify_sources_and_hashes(
+        source=source,
+        source_hash=source_hash,
+        sources=sources,
+        source_hashes=source_hashes,
+    )
     if not ok_:
         return _error(ret, err)
 
@@ -5300,32 +5425,32 @@ def blockreplace(
         # if we have multiple accumulators for a file, only apply the one
         # required at a time
         deps = accum_deps.get(name, [])
-        filtered = [a for a in deps if
-                    __low__['__id__'] in deps[a] and a in accumulator]
+        filtered = [
+            a for a in deps if __low__["__id__"] in deps[a] and a in accumulator
+        ]
         if not filtered:
             filtered = [a for a in accumulator]
         for acc in filtered:
             acc_content = accumulator[acc]
             for line in acc_content:
-                if content == '':
+                if content == "":
                     content = line
                 else:
                     content += "\n" + line
 
     if sl_:
-        tmpret = _get_template_texts(source_list=sl_,
-                                     template=template,
-                                     defaults=defaults,
-                                     context=context)
-        if not tmpret['result']:
+        tmpret = _get_template_texts(
+            source_list=sl_, template=template, defaults=defaults, context=context
+        )
+        if not tmpret["result"]:
             return tmpret
-        text = tmpret['data']
+        text = tmpret["data"]
 
         for index, item in enumerate(text):
             content += six.text_type(item)
 
     try:
-        changes = __salt__['file.blockreplace'](
+        changes = __salt__["file.blockreplace"](
             name,
             marker_start,
             marker_end,
@@ -5335,34 +5460,35 @@ def blockreplace(
             insert_before_match=insert_before_match,
             insert_after_match=insert_after_match,
             backup=backup,
-            dry_run=__opts__['test'],
+            dry_run=__opts__["test"],
             show_changes=show_changes,
-            append_newline=append_newline)
+            append_newline=append_newline,
+        )
     except Exception as exc:
-        log.exception('Encountered error managing block')
-        ret['comment'] = (
-            'Encountered error managing block: {0}. '
-            'See the log for details.'.format(exc)
+        log.exception("Encountered error managing block")
+        ret["comment"] = (
+            "Encountered error managing block: {0}. "
+            "See the log for details.".format(exc)
         )
         return ret
 
     if changes:
-        ret['changes']['diff'] = changes
-        if __opts__['test']:
-            ret['result'] = None
-            ret['comment'] = 'Changes would be made'
+        ret["changes"]["diff"] = changes
+        if __opts__["test"]:
+            ret["result"] = None
+            ret["comment"] = "Changes would be made"
         else:
-            ret['result'] = True
-            ret['comment'] = 'Changes were made'
+            ret["result"] = True
+            ret["comment"] = "Changes were made"
     else:
-        ret['result'] = True
-        ret['comment'] = 'No changes needed to be made'
+        ret["result"] = True
+        ret["comment"] = "No changes needed to be made"
 
     return ret
 
 
-def comment(name, regex, char='#', backup='.bak'):
-    '''
+def comment(name, regex, char="#", backup=".bak"):
+    """
     Comment out specified lines in a file.
 
     name
@@ -5397,76 +5523,71 @@ def comment(name, regex, char='#', backup='.bak'):
             - regex: ^bind 127.0.0.1
 
     .. versionadded:: 0.9.5
-    '''
+    """
     name = os.path.expanduser(name)
 
-    ret = {'name': name,
-           'changes': {},
-           'result': False,
-           'comment': ''}
+    ret = {"name": name, "changes": {}, "result": False, "comment": ""}
     if not name:
-        return _error(ret, 'Must provide name to file.comment')
+        return _error(ret, "Must provide name to file.comment")
 
     check_res, check_msg = _check_file(name)
     if not check_res:
         return _error(ret, check_msg)
 
     # remove (?i)-like flags, ^ and $
-    unanchor_regex = re.sub(r'^(\(\?[iLmsux]\))?\^?(.*?)\$?$', r'\2', regex)
+    unanchor_regex = re.sub(r"^(\(\?[iLmsux]\))?\^?(.*?)\$?$", r"\2", regex)
 
     comment_regex = char + unanchor_regex
 
     # Make sure the pattern appears in the file before continuing
-    if not __salt__['file.search'](name, regex, multiline=True):
-        if __salt__['file.search'](name, comment_regex, multiline=True):
-            ret['comment'] = 'Pattern already commented'
-            ret['result'] = True
+    if not __salt__["file.search"](name, regex, multiline=True):
+        if __salt__["file.search"](name, comment_regex, multiline=True):
+            ret["comment"] = "Pattern already commented"
+            ret["result"] = True
             return ret
         else:
-            return _error(ret, '{0}: Pattern not found'.format(unanchor_regex))
+            return _error(ret, "{0}: Pattern not found".format(unanchor_regex))
 
-    if __opts__['test']:
-        ret['changes'][name] = 'updated'
-        ret['comment'] = 'File {0} is set to be updated'.format(name)
-        ret['result'] = None
+    if __opts__["test"]:
+        ret["changes"][name] = "updated"
+        ret["comment"] = "File {0} is set to be updated".format(name)
+        ret["result"] = None
         return ret
-    with salt.utils.files.fopen(name, 'rb') as fp_:
+    with salt.utils.files.fopen(name, "rb") as fp_:
         slines = fp_.read()
         if six.PY3:
             slines = slines.decode(__salt_system_encoding__)
         slines = slines.splitlines(True)
 
     # Perform the edit
-    __salt__['file.comment_line'](name, regex, char, True, backup)
+    __salt__["file.comment_line"](name, regex, char, True, backup)
 
-    with salt.utils.files.fopen(name, 'rb') as fp_:
+    with salt.utils.files.fopen(name, "rb") as fp_:
         nlines = fp_.read()
         if six.PY3:
             nlines = nlines.decode(__salt_system_encoding__)
         nlines = nlines.splitlines(True)
 
     # Check the result
-    ret['result'] = __salt__['file.search'](name, unanchor_regex, multiline=True)
+    ret["result"] = __salt__["file.search"](name, unanchor_regex, multiline=True)
 
     if slines != nlines:
-        if not __utils__['files.is_text'](name):
-            ret['changes']['diff'] = 'Replace binary file'
+        if not __utils__["files.is_text"](name):
+            ret["changes"]["diff"] = "Replace binary file"
         else:
             # Changes happened, add them
-            ret['changes']['diff'] = (
-                ''.join(difflib.unified_diff(slines, nlines))
-            )
+            ret["changes"]["diff"] = "".join(difflib.unified_diff(slines, nlines))
 
-    if ret['result']:
-        ret['comment'] = 'Commented lines successfully'
+    if ret["result"]:
+        ret["comment"] = "Commented lines successfully"
     else:
-        ret['comment'] = 'Expected commented lines not found'
+        ret["comment"] = "Expected commented lines not found"
 
     return ret
 
 
-def uncomment(name, regex, char='#', backup='.bak'):
-    '''
+def uncomment(name, regex, char="#", backup=".bak"):
+    """
     Uncomment specified commented lines in a file
 
     name
@@ -5500,88 +5621,81 @@ def uncomment(name, regex, char='#', backup='.bak'):
             - regex: EXTRA_GROUPS
 
     .. versionadded:: 0.9.5
-    '''
+    """
     name = os.path.expanduser(name)
 
-    ret = {'name': name,
-           'changes': {},
-           'result': False,
-           'comment': ''}
+    ret = {"name": name, "changes": {}, "result": False, "comment": ""}
     if not name:
-        return _error(ret, 'Must provide name to file.uncomment')
+        return _error(ret, "Must provide name to file.uncomment")
 
     check_res, check_msg = _check_file(name)
     if not check_res:
         return _error(ret, check_msg)
 
     # Make sure the pattern appears in the file
-    if __salt__['file.search'](
-            name,
-            '{0}[ \t]*{1}'.format(char, regex.lstrip('^')),
-            multiline=True):
+    if __salt__["file.search"](
+        name, "{0}[ \t]*{1}".format(char, regex.lstrip("^")), multiline=True
+    ):
         # Line exists and is commented
         pass
-    elif __salt__['file.search'](
-            name,
-            '^[ \t]*{0}'.format(regex.lstrip('^')),
-            multiline=True):
-        ret['comment'] = 'Pattern already uncommented'
-        ret['result'] = True
+    elif __salt__["file.search"](
+        name, "^[ \t]*{0}".format(regex.lstrip("^")), multiline=True
+    ):
+        ret["comment"] = "Pattern already uncommented"
+        ret["result"] = True
         return ret
     else:
-        return _error(ret, '{0}: Pattern not found'.format(regex))
+        return _error(ret, "{0}: Pattern not found".format(regex))
 
-    if __opts__['test']:
-        ret['changes'][name] = 'updated'
-        ret['comment'] = 'File {0} is set to be updated'.format(name)
-        ret['result'] = None
+    if __opts__["test"]:
+        ret["changes"][name] = "updated"
+        ret["comment"] = "File {0} is set to be updated".format(name)
+        ret["result"] = None
         return ret
 
-    with salt.utils.files.fopen(name, 'rb') as fp_:
+    with salt.utils.files.fopen(name, "rb") as fp_:
         slines = salt.utils.data.decode(fp_.readlines())
 
     # Perform the edit
-    __salt__['file.comment_line'](name, regex, char, False, backup)
+    __salt__["file.comment_line"](name, regex, char, False, backup)
 
-    with salt.utils.files.fopen(name, 'rb') as fp_:
+    with salt.utils.files.fopen(name, "rb") as fp_:
         nlines = salt.utils.data.decode(fp_.readlines())
 
     # Check the result
-    ret['result'] = __salt__['file.search'](
-        name,
-        '^[ \t]*{0}'.format(regex.lstrip('^')),
-        multiline=True
+    ret["result"] = __salt__["file.search"](
+        name, "^[ \t]*{0}".format(regex.lstrip("^")), multiline=True
     )
 
     if slines != nlines:
-        if not __utils__['files.is_text'](name):
-            ret['changes']['diff'] = 'Replace binary file'
+        if not __utils__["files.is_text"](name):
+            ret["changes"]["diff"] = "Replace binary file"
         else:
             # Changes happened, add them
-            ret['changes']['diff'] = (
-                ''.join(difflib.unified_diff(slines, nlines))
-            )
+            ret["changes"]["diff"] = "".join(difflib.unified_diff(slines, nlines))
 
-    if ret['result']:
-        ret['comment'] = 'Uncommented lines successfully'
+    if ret["result"]:
+        ret["comment"] = "Uncommented lines successfully"
     else:
-        ret['comment'] = 'Expected uncommented lines not found'
+        ret["comment"] = "Expected uncommented lines not found"
 
     return ret
 
 
-def append(name,
-           text=None,
-           makedirs=False,
-           source=None,
-           source_hash=None,
-           template='jinja',
-           sources=None,
-           source_hashes=None,
-           defaults=None,
-           context=None,
-           ignore_whitespace=True):
-    '''
+def append(
+    name,
+    text=None,
+    makedirs=False,
+    source=None,
+    source_hash=None,
+    template="jinja",
+    sources=None,
+    source_hashes=None,
+    defaults=None,
+    context=None,
+    ignore_whitespace=True,
+):
+    """
     Ensure that some text appears at the end of a file.
 
     The text will not be appended if it already exists in the file.
@@ -5706,14 +5820,11 @@ def append(name,
               - salt://motd/general-messages.tmpl
 
     .. versionadded:: 0.9.5
-    '''
-    ret = {'name': name,
-           'changes': {},
-           'result': False,
-           'comment': ''}
+    """
+    ret = {"name": name, "changes": {}, "result": False, "comment": ""}
 
     if not name:
-        return _error(ret, 'Must provide name to file.append')
+        return _error(ret, "Must provide name to file.append")
 
     name = os.path.expanduser(name)
 
@@ -5726,38 +5837,42 @@ def append(name,
     # Add sources and source_hashes with template support
     # NOTE: FIX 'text' and any 'source' are mutually exclusive as 'text'
     #       is re-assigned in the original code.
-    (ok_, err, sl_) = _unify_sources_and_hashes(source=source,
-                                                source_hash=source_hash,
-                                                sources=sources,
-                                                source_hashes=source_hashes)
+    (ok_, err, sl_) = _unify_sources_and_hashes(
+        source=source,
+        source_hash=source_hash,
+        sources=sources,
+        source_hashes=source_hashes,
+    )
     if not ok_:
         return _error(ret, err)
 
     if makedirs is True:
         dirname = os.path.dirname(name)
-        if __opts__['test']:
-            ret['comment'] = 'Directory {0} is set to be updated'.format(dirname)
-            ret['result'] = None
+        if __opts__["test"]:
+            ret["comment"] = "Directory {0} is set to be updated".format(dirname)
+            ret["result"] = None
         else:
-            if not __salt__['file.directory_exists'](dirname):
+            if not __salt__["file.directory_exists"](dirname):
                 try:
                     _makedirs(name=name)
                 except CommandExecutionError as exc:
-                    return _error(ret, 'Drive {0} is not mapped'.format(exc.message))
+                    return _error(ret, "Drive {0} is not mapped".format(exc.message))
 
-                check_res, check_msg, check_changes = _check_directory_win(dirname) \
-                    if salt.utils.platform.is_windows() \
+                check_res, check_msg, check_changes = (
+                    _check_directory_win(dirname)
+                    if salt.utils.platform.is_windows()
                     else _check_directory(dirname)
+                )
 
                 if not check_res:
-                    ret['changes'] = check_changes
+                    ret["changes"] = check_changes
                     return _error(ret, check_msg)
 
     check_res, check_msg = _check_file(name)
     if not check_res:
         # Try to create the file
         touch_ret = touch(name, makedirs=makedirs)
-        if __opts__['test']:
+        if __opts__["test"]:
             return touch_ret
         retry_res, retry_msg = _check_file(name)
         if not retry_res:
@@ -5765,17 +5880,16 @@ def append(name,
 
     # Follow the original logic and re-assign 'text' if using source(s)...
     if sl_:
-        tmpret = _get_template_texts(source_list=sl_,
-                                     template=template,
-                                     defaults=defaults,
-                                     context=context)
-        if not tmpret['result']:
+        tmpret = _get_template_texts(
+            source_list=sl_, template=template, defaults=defaults, context=context
+        )
+        if not tmpret["result"]:
             return tmpret
-        text = tmpret['data']
+        text = tmpret["data"]
 
     text = _validate_str_list(text)
 
-    with salt.utils.files.fopen(name, 'rb') as fp_:
+    with salt.utils.files.fopen(name, "rb") as fp_:
         slines = fp_.read()
         if six.PY3:
             slines = slines.decode(__salt_system_encoding__)
@@ -5785,78 +5899,75 @@ def append(name,
     try:
         for chunk in text:
             if ignore_whitespace:
-                if __salt__['file.search'](
-                        name,
-                        salt.utils.stringutils.build_whitespace_split_regex(chunk),
-                        multiline=True):
-                    continue
-            elif __salt__['file.search'](
+                if __salt__["file.search"](
                     name,
-                    chunk,
-                    multiline=True):
+                    salt.utils.stringutils.build_whitespace_split_regex(chunk),
+                    multiline=True,
+                ):
+                    continue
+            elif __salt__["file.search"](name, chunk, multiline=True):
                 continue
 
             for line_item in chunk.splitlines():
-                append_lines.append('{0}'.format(line_item))
+                append_lines.append("{0}".format(line_item))
 
     except TypeError:
-        return _error(ret, 'No text found to append. Nothing appended')
+        return _error(ret, "No text found to append. Nothing appended")
 
-    if __opts__['test']:
-        ret['comment'] = 'File {0} is set to be updated'.format(name)
-        ret['result'] = None
+    if __opts__["test"]:
+        ret["comment"] = "File {0} is set to be updated".format(name)
+        ret["result"] = None
         nlines = list(slines)
         nlines.extend(append_lines)
         if slines != nlines:
-            if not __utils__['files.is_text'](name):
-                ret['changes']['diff'] = 'Replace binary file'
+            if not __utils__["files.is_text"](name):
+                ret["changes"]["diff"] = "Replace binary file"
             else:
                 # Changes happened, add them
-                ret['changes']['diff'] = (
-                    '\n'.join(difflib.unified_diff(slines, nlines))
-                )
+                ret["changes"]["diff"] = "\n".join(difflib.unified_diff(slines, nlines))
         else:
-            ret['comment'] = 'File {0} is in correct state'.format(name)
-            ret['result'] = True
+            ret["comment"] = "File {0} is in correct state".format(name)
+            ret["result"] = True
         return ret
 
     if append_lines:
-        __salt__['file.append'](name, args=append_lines)
-        ret['comment'] = 'Appended {0} lines'.format(len(append_lines))
+        __salt__["file.append"](name, args=append_lines)
+        ret["comment"] = "Appended {0} lines".format(len(append_lines))
     else:
-        ret['comment'] = 'File {0} is in correct state'.format(name)
+        ret["comment"] = "File {0} is in correct state".format(name)
 
-    with salt.utils.files.fopen(name, 'rb') as fp_:
+    with salt.utils.files.fopen(name, "rb") as fp_:
         nlines = fp_.read()
         if six.PY3:
             nlines = nlines.decode(__salt_system_encoding__)
         nlines = nlines.splitlines()
 
     if slines != nlines:
-        if not __utils__['files.is_text'](name):
-            ret['changes']['diff'] = 'Replace binary file'
+        if not __utils__["files.is_text"](name):
+            ret["changes"]["diff"] = "Replace binary file"
         else:
             # Changes happened, add them
-            ret['changes']['diff'] = (
-                '\n'.join(difflib.unified_diff(slines, nlines)))
+            ret["changes"]["diff"] = "\n".join(difflib.unified_diff(slines, nlines))
 
-    ret['result'] = True
+    ret["result"] = True
 
     return ret
 
 
-def prepend(name,
-            text=None,
-            makedirs=False,
-            source=None,
-            source_hash=None,
-            template='jinja',
-            sources=None,
-            source_hashes=None,
-            defaults=None,
-            context=None,
-            header=None):
-    '''
+def prepend(
+    name,
+    text=None,
+    makedirs=False,
+    source=None,
+    source_hash=None,
+    template="jinja",
+    sources=None,
+    source_hashes=None,
+    defaults=None,
+    context=None,
+    header=None,
+):
+    """
     Ensure that some text appears at the beginning of a file
 
     The text will not be prepended again if it already exists in the file. You
@@ -5994,15 +6105,12 @@ def prepend(name,
               - salt://motd/general-messages.tmpl
 
     .. versionadded:: 2014.7.0
-    '''
+    """
     name = os.path.expanduser(name)
 
-    ret = {'name': name,
-           'changes': {},
-           'result': False,
-           'comment': ''}
+    ret = {"name": name, "changes": {}, "result": False, "comment": ""}
     if not name:
-        return _error(ret, 'Must provide name to file.prepend')
+        return _error(ret, "Must provide name to file.prepend")
 
     if sources is None:
         sources = []
@@ -6013,34 +6121,38 @@ def prepend(name,
     # Add sources and source_hashes with template support
     # NOTE: FIX 'text' and any 'source' are mutually exclusive as 'text'
     #       is re-assigned in the original code.
-    (ok_, err, sl_) = _unify_sources_and_hashes(source=source,
-                                                source_hash=source_hash,
-                                                sources=sources,
-                                                source_hashes=source_hashes)
+    (ok_, err, sl_) = _unify_sources_and_hashes(
+        source=source,
+        source_hash=source_hash,
+        sources=sources,
+        source_hashes=source_hashes,
+    )
     if not ok_:
         return _error(ret, err)
 
     if makedirs is True:
         dirname = os.path.dirname(name)
-        if not __salt__['file.directory_exists'](dirname):
+        if not __salt__["file.directory_exists"](dirname):
             try:
                 _makedirs(name=name)
             except CommandExecutionError as exc:
-                return _error(ret, 'Drive {0} is not mapped'.format(exc.message))
+                return _error(ret, "Drive {0} is not mapped".format(exc.message))
 
-            check_res, check_msg, check_changes = _check_directory_win(dirname) \
-                if salt.utils.platform.is_windows() \
+            check_res, check_msg, check_changes = (
+                _check_directory_win(dirname)
+                if salt.utils.platform.is_windows()
                 else _check_directory(dirname)
+            )
 
             if not check_res:
-                ret['changes'] = check_changes
+                ret["changes"] = check_changes
                 return _error(ret, check_msg)
 
     check_res, check_msg = _check_file(name)
     if not check_res:
         # Try to create the file
         touch_ret = touch(name, makedirs=makedirs)
-        if __opts__['test']:
+        if __opts__["test"]:
             return touch_ret
         retry_res, retry_msg = _check_file(name)
         if not retry_res:
@@ -6048,17 +6160,16 @@ def prepend(name,
 
     # Follow the original logic and re-assign 'text' if using source(s)...
     if sl_:
-        tmpret = _get_template_texts(source_list=sl_,
-                                     template=template,
-                                     defaults=defaults,
-                                     context=context)
-        if not tmpret['result']:
+        tmpret = _get_template_texts(
+            source_list=sl_, template=template, defaults=defaults, context=context
+        )
+        if not tmpret["result"]:
             return tmpret
-        text = tmpret['data']
+        text = tmpret["data"]
 
     text = _validate_str_list(text)
 
-    with salt.utils.files.fopen(name, 'rb') as fp_:
+    with salt.utils.files.fopen(name, "rb") as fp_:
         slines = fp_.read()
         if six.PY3:
             slines = slines.decode(__salt_system_encoding__)
@@ -6072,48 +6183,47 @@ def prepend(name,
 
         # if header kwarg is unset of False, use regex search
         if not header:
-            if __salt__['file.search'](
-                    name,
-                    salt.utils.stringutils.build_whitespace_split_regex(chunk),
-                    multiline=True):
+            if __salt__["file.search"](
+                name,
+                salt.utils.stringutils.build_whitespace_split_regex(chunk),
+                multiline=True,
+            ):
                 continue
 
         lines = chunk.splitlines()
 
         for line in lines:
-            if __opts__['test']:
-                ret['comment'] = 'File {0} is set to be updated'.format(name)
-                ret['result'] = None
-                test_lines.append('{0}\n'.format(line))
+            if __opts__["test"]:
+                ret["comment"] = "File {0} is set to be updated".format(name)
+                ret["result"] = None
+                test_lines.append("{0}\n".format(line))
             else:
                 preface.append(line)
             count += 1
 
-    if __opts__['test']:
+    if __opts__["test"]:
         nlines = test_lines + slines
         if slines != nlines:
-            if not __utils__['files.is_text'](name):
-                ret['changes']['diff'] = 'Replace binary file'
+            if not __utils__["files.is_text"](name):
+                ret["changes"]["diff"] = "Replace binary file"
             else:
                 # Changes happened, add them
-                ret['changes']['diff'] = (
-                    ''.join(difflib.unified_diff(slines, nlines))
-                )
-            ret['result'] = None
+                ret["changes"]["diff"] = "".join(difflib.unified_diff(slines, nlines))
+            ret["result"] = None
         else:
-            ret['comment'] = 'File {0} is in correct state'.format(name)
-            ret['result'] = True
+            ret["comment"] = "File {0} is in correct state".format(name)
+            ret["result"] = True
         return ret
 
     # if header kwarg is True, use verbatim compare
     if header:
-        with salt.utils.files.fopen(name, 'rb') as fp_:
+        with salt.utils.files.fopen(name, "rb") as fp_:
             # read as many lines of target file as length of user input
             contents = fp_.read()
             if six.PY3:
                 contents = contents.decode(__salt_system_encoding__)
             contents = contents.splitlines(True)
-            target_head = contents[0:len(preface)]
+            target_head = contents[0 : len(preface)]
             target_lines = []
             # strip newline chars from list entries
             for chunk in target_head:
@@ -6121,50 +6231,50 @@ def prepend(name,
             # compare current top lines in target file with user input
             # and write user input if they differ
             if target_lines != preface:
-                __salt__['file.prepend'](name, *preface)
+                __salt__["file.prepend"](name, *preface)
             else:
                 # clear changed lines counter if target file not modified
                 count = 0
     else:
-        __salt__['file.prepend'](name, *preface)
+        __salt__["file.prepend"](name, *preface)
 
-    with salt.utils.files.fopen(name, 'rb') as fp_:
+    with salt.utils.files.fopen(name, "rb") as fp_:
         nlines = fp_.read()
         if six.PY3:
             nlines = nlines.decode(__salt_system_encoding__)
         nlines = nlines.splitlines(True)
 
     if slines != nlines:
-        if not __utils__['files.is_text'](name):
-            ret['changes']['diff'] = 'Replace binary file'
+        if not __utils__["files.is_text"](name):
+            ret["changes"]["diff"] = "Replace binary file"
         else:
             # Changes happened, add them
-            ret['changes']['diff'] = (
-                ''.join(difflib.unified_diff(slines, nlines))
-            )
+            ret["changes"]["diff"] = "".join(difflib.unified_diff(slines, nlines))
 
     if count:
-        ret['comment'] = 'Prepended {0} lines'.format(count)
+        ret["comment"] = "Prepended {0} lines".format(count)
     else:
-        ret['comment'] = 'File {0} is in correct state'.format(name)
-    ret['result'] = True
+        ret["comment"] = "File {0} is in correct state".format(name)
+    ret["result"] = True
     return ret
 
 
-def patch(name,
-          source=None,
-          source_hash=None,
-          source_hash_name=None,
-          skip_verify=False,
-          template=None,
-          context=None,
-          defaults=None,
-          options='',
-          reject_file=None,
-          strip=None,
-          saltenv=None,
-          **kwargs):
-    '''
+def patch(
+    name,
+    source=None,
+    source_hash=None,
+    source_hash_name=None,
+    skip_verify=False,
+    template=None,
+    context=None,
+    defaults=None,
+    options="",
+    reject_file=None,
+    strip=None,
+    saltenv=None,
+    **kwargs
+):
+    """
     Ensure that a patch has been applied to the specified file or directory
 
     .. versionchanged:: 2019.2.0
@@ -6285,11 +6395,11 @@ def patch(name,
         /opt/myfile.txt:
           file.patch:
             - source: salt://myfile.patch
-    '''
-    ret = {'name': name, 'changes': {}, 'result': False, 'comment': ''}
+    """
+    ret = {"name": name, "changes": {}, "result": False, "comment": ""}
 
-    if not salt.utils.path.which('patch'):
-        ret['comment'] = 'patch executable not found on minion'
+    if not salt.utils.path.which("patch"):
+        ret["comment"] = "patch executable not found on minion"
         return ret
 
     # is_dir should be defined if we proceed past the if/else block below, but
@@ -6297,49 +6407,45 @@ def patch(name,
     is_dir = False
 
     if not name:
-        ret['comment'] = 'A file/directory to be patched is required'
+        ret["comment"] = "A file/directory to be patched is required"
         return ret
     else:
         try:
             name = os.path.expanduser(name)
         except Exception:
-            ret['comment'] = 'Invalid path \'{0}\''.format(name)
+            ret["comment"] = "Invalid path '{0}'".format(name)
             return ret
         else:
             if not os.path.isabs(name):
-                ret['comment'] = '{0} is not an absolute path'.format(name)
+                ret["comment"] = "{0} is not an absolute path".format(name)
                 return ret
             elif not os.path.exists(name):
-                ret['comment'] = '{0} does not exist'.format(name)
+                ret["comment"] = "{0} does not exist".format(name)
                 return ret
             else:
                 is_dir = os.path.isdir(name)
 
-    for deprecated_arg in ('hash', 'dry_run_first'):
+    for deprecated_arg in ("hash", "dry_run_first"):
         if deprecated_arg in kwargs:
-            ret.setdefault('warnings', []).append(
-                'The \'{0}\' argument is no longer used and has been '
-                'ignored.'.format(deprecated_arg)
+            ret.setdefault("warnings", []).append(
+                "The '{0}' argument is no longer used and has been "
+                "ignored.".format(deprecated_arg)
             )
 
     if reject_file is not None:
         try:
             reject_file_parent = os.path.dirname(reject_file)
         except Exception:
-            ret['comment'] = 'Invalid path \'{0}\' for reject_file'.format(
-                reject_file
-            )
+            ret["comment"] = "Invalid path '{0}' for reject_file".format(reject_file)
             return ret
         else:
             if not os.path.isabs(reject_file_parent):
-                ret['comment'] = '\'{0}\' is not an absolute path'.format(
-                    reject_file
-                )
+                ret["comment"] = "'{0}' is not an absolute path".format(reject_file)
                 return ret
             elif not os.path.isdir(reject_file_parent):
-                ret['comment'] = (
-                    'Parent directory for reject_file \'{0}\' either does '
-                    'not exist, or is not a directory'.format(reject_file)
+                ret["comment"] = (
+                    "Parent directory for reject_file '{0}' either does "
+                    "not exist, or is not a directory".format(reject_file)
                 )
                 return ret
 
@@ -6355,7 +6461,7 @@ def patch(name,
         if not isinstance(option, six.string_types):
             option = six.text_type(option)
 
-        for item in ('-N', '--forward', '-r', '--reject-file', '-o', '--output'):
+        for item in ("-N", "--forward", "-r", "--reject-file", "-o", "--output"):
             if option.startswith(item):
                 blacklisted = option
                 break
@@ -6365,24 +6471,24 @@ def patch(name,
         if blacklisted is not None:
             blacklisted_options.append(blacklisted)
 
-        if option.startswith('-p'):
+        if option.startswith("-p"):
             try:
                 strip = int(option[2:])
             except Exception:
-                ret['comment'] = (
-                    'Invalid format for \'-p\' CLI option. Consider using '
-                    'the \'strip\' option for this state.'
+                ret["comment"] = (
+                    "Invalid format for '-p' CLI option. Consider using "
+                    "the 'strip' option for this state."
                 )
                 return ret
-        elif option.startswith('--strip'):
-            if '=' in option:
+        elif option.startswith("--strip"):
+            if "=" in option:
                 # Assume --strip=N
                 try:
-                    strip = int(option.rsplit('=', 1)[-1])
+                    strip = int(option.rsplit("=", 1)[-1])
                 except Exception:
-                    ret['comment'] = (
-                        'Invalid format for \'-strip\' CLI option. Consider '
-                        'using the \'strip\' option for this state.'
+                    ret["comment"] = (
+                        "Invalid format for '-strip' CLI option. Consider "
+                        "using the 'strip' option for this state."
                     )
                     return ret
             else:
@@ -6390,9 +6496,9 @@ def patch(name,
                 try:
                     strip = int(options[index + 1])
                 except Exception:
-                    ret['comment'] = (
-                        'Invalid format for \'-strip\' CLI option. Consider '
-                        'using the \'strip\' option for this state.'
+                    ret["comment"] = (
+                        "Invalid format for '-strip' CLI option. Consider "
+                        "using the 'strip' option for this state."
                     )
                     return ret
                 else:
@@ -6406,22 +6512,18 @@ def patch(name,
         index += 1
 
     if blacklisted_options:
-        ret['comment'] = (
-            'The following CLI options are not allowed: {0}'.format(
-                ', '.join(blacklisted_options)
-            )
+        ret["comment"] = "The following CLI options are not allowed: {0}".format(
+            ", ".join(blacklisted_options)
         )
         return ret
 
     options = sanitized_options
 
     try:
-        source_match = __salt__['file.source_list'](source,
-                                                    source_hash,
-                                                    __env__)[0]
+        source_match = __salt__["file.source_list"](source, source_hash, __env__)[0]
     except CommandExecutionError as exc:
-        ret['result'] = False
-        ret['comment'] = exc.strerror
+        ret["result"] = False
+        ret["comment"] = exc.strerror
         return ret
     else:
         # Passing the saltenv to file.managed to pull down the patch file is
@@ -6430,17 +6532,15 @@ def patch(name,
         # (and a traceback). Therefore, we will add the saltenv to the source
         # URL to ensure we pull the file from the correct environment.
         if saltenv is not None:
-            source_match_url, source_match_saltenv = \
-                salt.utils.url.parse(source_match)
-            if source_match_url.startswith('salt://'):
-                if source_match_saltenv is not None \
-                        and source_match_saltenv != saltenv:
-                    ret.setdefault('warnings', []).append(
-                        'Ignoring \'saltenv\' option in favor of saltenv '
-                        'included in the source URL.'
+            source_match_url, source_match_saltenv = salt.utils.url.parse(source_match)
+            if source_match_url.startswith("salt://"):
+                if source_match_saltenv is not None and source_match_saltenv != saltenv:
+                    ret.setdefault("warnings", []).append(
+                        "Ignoring 'saltenv' option in favor of saltenv "
+                        "included in the source URL."
                     )
                 else:
-                    source_match += '?saltenv={0}'.format(saltenv)
+                    source_match += "?saltenv={0}".format(saltenv)
 
     cleanup = []
 
@@ -6449,35 +6549,36 @@ def patch(name,
         cleanup.append(patch_file)
 
         try:
-            orig_test = __opts__['test']
-            __opts__['test'] = False
-            sys.modules[__salt__['test.ping'].__module__].__opts__['test'] = False
-            result = managed(patch_file,
-                             source=source_match,
-                             source_hash=source_hash,
-                             source_hash_name=source_hash_name,
-                             skip_verify=skip_verify,
-                             template=template,
-                             context=context,
-                             defaults=defaults)
+            orig_test = __opts__["test"]
+            __opts__["test"] = False
+            sys.modules[__salt__["test.ping"].__module__].__opts__["test"] = False
+            result = managed(
+                patch_file,
+                source=source_match,
+                source_hash=source_hash,
+                source_hash_name=source_hash_name,
+                skip_verify=skip_verify,
+                template=template,
+                context=context,
+                defaults=defaults,
+            )
         except Exception as exc:
-            msg = 'Failed to cache patch file {0}: {1}'.format(
-                salt.utils.url.redact_http_basic_auth(source_match),
-                exc
+            msg = "Failed to cache patch file {0}: {1}".format(
+                salt.utils.url.redact_http_basic_auth(source_match), exc
             )
             log.exception(msg)
-            ret['comment'] = msg
+            ret["comment"] = msg
             return ret
         else:
-            log.debug('file.managed: %s', result)
+            log.debug("file.managed: %s", result)
         finally:
-            __opts__['test'] = orig_test
-            sys.modules[__salt__['test.ping'].__module__].__opts__['test'] = orig_test
+            __opts__["test"] = orig_test
+            sys.modules[__salt__["test.ping"].__module__].__opts__["test"] = orig_test
 
-        if not result['result']:
+        if result["result"] is False:
             log.debug(
-                'failed to download %s',
-                salt.utils.url.redact_http_basic_auth(source_match)
+                "failed to download %s",
+                salt.utils.url.redact_http_basic_auth(source_match),
             )
             return result
 
@@ -6485,11 +6586,9 @@ def patch(name,
             patch_opts = copy.copy(sanitized_options)
             if options is not None:
                 patch_opts.extend(options)
-            return __salt__['file.patch'](
-                name,
-                patch_file,
-                options=patch_opts,
-                dry_run=dry_run)
+            return __salt__["file.patch"](
+                name, patch_file, options=patch_opts, dry_run=dry_run
+            )
 
         if reject_file is not None:
             patch_rejects = reject_file
@@ -6506,59 +6605,57 @@ def patch(name,
         # to work on Windows with patch.exe, /dev/null is a non-starter.
         # Therefore, redirect all patch output to a temp file, which we will
         # then remove.
-        patch_opts = ['-N', '-r', patch_rejects, '-o', patch_output]
+        patch_opts = ["-N", "-r", patch_rejects, "-o", patch_output]
         if is_dir and strip is not None:
-            patch_opts.append('-p{0}'.format(strip))
+            patch_opts.append("-p{0}".format(strip))
 
         pre_check = _patch(patch_file, patch_opts)
-        if pre_check['retcode'] != 0:
+        if pre_check["retcode"] != 0:
             # Try to reverse-apply hunks from rejects file using a dry-run.
             # If this returns a retcode of 0, we know that the patch was
             # already applied. Rejects are written from the base of the
             # directory, so the strip option doesn't apply here.
-            reverse_pass = _patch(patch_rejects, ['-R', '-f'], dry_run=True)
-            already_applied = reverse_pass['retcode'] == 0
+            reverse_pass = _patch(patch_rejects, ["-R", "-f"], dry_run=True)
+            already_applied = reverse_pass["retcode"] == 0
 
             if already_applied:
-                ret['comment'] = 'Patch was already applied'
-                ret['result'] = True
+                ret["comment"] = "Patch was already applied"
+                ret["result"] = True
                 return ret
             else:
-                ret['comment'] = (
-                    'Patch would not apply cleanly, no changes made. Results '
-                    'of dry-run are below.'
+                ret["comment"] = (
+                    "Patch would not apply cleanly, no changes made. Results "
+                    "of dry-run are below."
                 )
                 if reject_file is None:
-                    ret['comment'] += (
-                        ' Run state again using the reject_file option to '
-                        'save rejects to a persistent file.'
+                    ret["comment"] += (
+                        " Run state again using the reject_file option to "
+                        "save rejects to a persistent file."
                     )
                 opts = copy.copy(__opts__)
-                opts['color'] = False
-                ret['comment'] += '\n\n' + salt.output.out_format(
-                    pre_check,
-                    'nested',
-                    opts,
-                    nested_indent=14)
+                opts["color"] = False
+                ret["comment"] += "\n\n" + salt.output.out_format(
+                    pre_check, "nested", opts, nested_indent=14
+                )
                 return ret
 
-        if __opts__['test']:
-            ret['result'] = None
-            ret['comment'] = 'The patch would be applied'
-            ret['changes'] = pre_check
+        if __opts__["test"]:
+            ret["result"] = None
+            ret["comment"] = "The patch would be applied"
+            ret["changes"] = pre_check
             return ret
 
         # If we've made it here, the patch should apply cleanly
         patch_opts = []
         if is_dir and strip is not None:
-            patch_opts.append('-p{0}'.format(strip))
-        ret['changes'] = _patch(patch_file, patch_opts)
+            patch_opts.append("-p{0}".format(strip))
+        ret["changes"] = _patch(patch_file, patch_opts)
 
-        if ret['changes']['retcode'] == 0:
-            ret['comment'] = 'Patch successfully applied'
-            ret['result'] = True
+        if ret["changes"]["retcode"] == 0:
+            ret["comment"] = "Patch successfully applied"
+            ret["result"] = True
         else:
-            ret['comment'] = 'Failed to apply patch'
+            ret["comment"] = "Failed to apply patch"
 
         return ret
 
@@ -6570,13 +6667,12 @@ def patch(name,
             except OSError as exc:
                 if exc.errno != os.errno.ENOENT:
                     log.error(
-                        'file.patch: Failed to remove temp file %s: %s',
-                        path, exc
+                        "file.patch: Failed to remove temp file %s: %s", path, exc
                     )
 
 
 def touch(name, atime=None, mtime=None, makedirs=False):
-    '''
+    """
     Replicate the 'nix "touch" command to create a new empty
     file or update the atime and mtime of an existing file.
 
@@ -6607,21 +6703,16 @@ def touch(name, atime=None, mtime=None, makedirs=False):
           file.touch
 
     .. versionadded:: 0.9.5
-    '''
+    """
     name = os.path.expanduser(name)
 
-    ret = {
-        'name': name,
-        'changes': {},
-    }
+    ret = {"name": name, "changes": {}}
     if not name:
-        return _error(ret, 'Must provide name to file.touch')
+        return _error(ret, "Must provide name to file.touch")
     if not os.path.isabs(name):
-        return _error(
-            ret, 'Specified file {0} is not an absolute path'.format(name)
-        )
+        return _error(ret, "Specified file {0} is not an absolute path".format(name))
 
-    if __opts__['test']:
+    if __opts__["test"]:
         ret.update(_check_touch(name, atime, mtime))
         return ret
 
@@ -6629,38 +6720,38 @@ def touch(name, atime=None, mtime=None, makedirs=False):
         try:
             _makedirs(name=name)
         except CommandExecutionError as exc:
-            return _error(ret, 'Drive {0} is not mapped'.format(exc.message))
+            return _error(ret, "Drive {0} is not mapped".format(exc.message))
     if not os.path.isdir(os.path.dirname(name)):
-        return _error(
-            ret, 'Directory not present to touch file {0}'.format(name)
-        )
+        return _error(ret, "Directory not present to touch file {0}".format(name))
 
     extant = os.path.exists(name)
 
-    ret['result'] = __salt__['file.touch'](name, atime, mtime)
-    if not extant and ret['result']:
-        ret['comment'] = 'Created empty file {0}'.format(name)
-        ret['changes']['new'] = name
-    elif extant and ret['result']:
-        ret['comment'] = 'Updated times on {0} {1}'.format(
-            'directory' if os.path.isdir(name) else 'file', name
+    ret["result"] = __salt__["file.touch"](name, atime, mtime)
+    if not extant and ret["result"]:
+        ret["comment"] = "Created empty file {0}".format(name)
+        ret["changes"]["new"] = name
+    elif extant and ret["result"]:
+        ret["comment"] = "Updated times on {0} {1}".format(
+            "directory" if os.path.isdir(name) else "file", name
         )
-        ret['changes']['touched'] = name
+        ret["changes"]["touched"] = name
 
     return ret
 
 
-def copy_(name,
-          source,
-          force=False,
-          makedirs=False,
-          preserve=False,
-          user=None,
-          group=None,
-          mode=None,
-          subdir=False,
-          **kwargs):
-    '''
+def copy_(
+    name,
+    source,
+    force=False,
+    makedirs=False,
+    preserve=False,
+    user=None,
+    group=None,
+    mode=None,
+    subdir=False,
+    **kwargs
+):
+    """
     If the file defined by the ``source`` option exists on the minion, copy it
     to the named path. The file will not be overwritten if it already exists,
     unless the ``force`` option is set to ``True``.
@@ -6727,46 +6818,47 @@ def copy_(name,
         <salt.states.file.managed>` and :mod:`states.file.recurse
         <salt.states.file.recurse>`.
 
-    '''
+    """
     name = os.path.expanduser(name)
     source = os.path.expanduser(source)
 
     ret = {
-        'name': name,
-        'changes': {},
-        'comment': 'Copied "{0}" to "{1}"'.format(source, name),
-        'result': True}
+        "name": name,
+        "changes": {},
+        "comment": 'Copied "{0}" to "{1}"'.format(source, name),
+        "result": True,
+    }
     if not name:
-        return _error(ret, 'Must provide name to file.copy')
+        return _error(ret, "Must provide name to file.copy")
 
     changed = True
     if not os.path.isabs(name):
-        return _error(
-            ret, 'Specified file {0} is not an absolute path'.format(name))
+        return _error(ret, "Specified file {0} is not an absolute path".format(name))
 
     if not os.path.exists(source):
         return _error(ret, 'Source file "{0}" is not present'.format(source))
 
     if preserve:
-        user = __salt__['file.get_user'](source)
-        group = __salt__['file.get_group'](source)
-        mode = __salt__['file.get_mode'](source)
+        user = __salt__["file.get_user"](source)
+        group = __salt__["file.get_group"](source)
+        mode = __salt__["file.get_mode"](source)
     else:
         user = _test_owner(kwargs, user=user)
         if user is None:
-            user = __opts__['user']
+            user = __opts__["user"]
 
         if salt.utils.platform.is_windows():
             if group is not None:
                 log.warning(
-                    'The group argument for %s has been ignored as this is '
-                    'a Windows system.', name
+                    "The group argument for %s has been ignored as this is "
+                    "a Windows system.",
+                    name,
                 )
             group = user
 
         if group is None:
-            group = __salt__['file.gid_to_group'](
-                __salt__['user.info'](user).get('gid', 0)
+            group = __salt__["file.gid_to_group"](
+                __salt__["user.info"](user).get("gid", 0)
             )
 
         u_check = _check_user(user, group)
@@ -6775,7 +6867,7 @@ def copy_(name,
             return _error(ret, u_check)
 
         if mode is None:
-            mode = __salt__['file.get_mode'](source)
+            mode = __salt__["file.get_mode"](source)
 
     if os.path.isdir(name) and subdir:
         # If the target is a dir, and overwrite_dir is False, copy into the dir
@@ -6788,39 +6880,43 @@ def copy_(name,
             hash2 = salt.utils.hashutils.get_hash(source)
             if hash1 == hash2:
                 changed = True
-                ret['comment'] = ' '.join([ret['comment'], '- files are identical but force flag is set'])
+                ret["comment"] = " ".join(
+                    [ret["comment"], "- files are identical but force flag is set"]
+                )
         if not force:
             changed = False
-        elif not __opts__['test'] and changed:
+        elif not __opts__["test"] and changed:
             # Remove the destination to prevent problems later
             try:
                 # On windows, if a file has the read-only attribute then we are unable
                 # to complete this copy unless force is set to true.
-                __salt__['file.remove'](name, force=force)
+                __salt__["file.remove"](name, force=force)
             except (IOError, OSError):
                 return _error(
                     ret,
                     'Failed to delete "{0}" in preparation for '
-                    'forced move'.format(name)
+                    "forced move".format(name),
                 )
 
-    if __opts__['test']:
+    if __opts__["test"]:
         if changed:
-            ret['comment'] = 'File "{0}" is set to be copied to "{1}"'.format(
-                source,
-                name
+            ret["comment"] = 'File "{0}" is set to be copied to "{1}"'.format(
+                source, name
             )
-            ret['result'] = None
+            ret["result"] = None
         else:
-            ret['comment'] = ('The target file "{0}" exists and will not be '
-                              'overwritten'.format(name))
-            ret['result'] = True
+            ret["comment"] = (
+                'The target file "{0}" exists and will not be '
+                "overwritten".format(name)
+            )
+            ret["result"] = True
         return ret
 
     if not changed:
-        ret['comment'] = ('The target file "{0}" exists and will not be '
-                          'overwritten'.format(name))
-        ret['result'] = True
+        ret[
+            "comment"
+        ] = 'The target file "{0}" exists and will not be ' "overwritten".format(name)
+        ret["result"] = True
         return ret
 
     # Run makedirs
@@ -6830,36 +6926,33 @@ def copy_(name,
             try:
                 _makedirs(name=name, user=user, group=group, dir_mode=mode)
             except CommandExecutionError as exc:
-                return _error(ret, 'Drive {0} is not mapped'.format(exc.message))
+                return _error(ret, "Drive {0} is not mapped".format(exc.message))
         else:
-            return _error(
-                ret,
-                'The target directory {0} is not present'.format(dname))
+            return _error(ret, "The target directory {0} is not present".format(dname))
     # All tests pass, move the file into place
     try:
         if os.path.isdir(source):
             shutil.copytree(source, name, symlinks=True)
             for root, dirs, files in salt.utils.path.os_walk(name):
                 for dir_ in dirs:
-                    __salt__['file.lchown'](os.path.join(root, dir_), user, group)
+                    __salt__["file.lchown"](os.path.join(root, dir_), user, group)
                 for file_ in files:
-                    __salt__['file.lchown'](os.path.join(root, file_), user, group)
+                    __salt__["file.lchown"](os.path.join(root, file_), user, group)
         else:
             shutil.copy(source, name)
-        ret['changes'] = {name: source}
+        ret["changes"] = {name: source}
         # Preserve really means just keep the behavior of the cp command. If
         # the filesystem we're copying to is squashed or doesn't support chown
         # then we shouldn't be checking anything.
         if not preserve:
-            __salt__['file.check_perms'](name, ret, user, group, mode)
+            __salt__["file.check_perms"](name, ret, user, group, mode)
     except (IOError, OSError):
-        return _error(
-            ret, 'Failed to copy "{0}" to "{1}"'.format(source, name))
+        return _error(ret, 'Failed to copy "{0}" to "{1}"'.format(source, name))
     return ret
 
 
 def rename(name, source, force=False, makedirs=False, **kwargs):
-    '''
+    """
     If the source file exists on the system, rename it to the named file. The
     named file will not be overwritten if it already exists unless the force
     option is set to True.
@@ -6877,49 +6970,44 @@ def rename(name, source, force=False, makedirs=False, **kwargs):
     makedirs
         If the target subdirectories don't exist create them
 
-    '''
+    """
     name = os.path.expanduser(name)
     source = os.path.expanduser(source)
 
-    ret = {
-        'name': name,
-        'changes': {},
-        'comment': '',
-        'result': True}
+    ret = {"name": name, "changes": {}, "comment": "", "result": True}
     if not name:
-        return _error(ret, 'Must provide name to file.rename')
+        return _error(ret, "Must provide name to file.rename")
 
     if not os.path.isabs(name):
-        return _error(
-            ret, 'Specified file {0} is not an absolute path'.format(name))
+        return _error(ret, "Specified file {0} is not an absolute path".format(name))
 
     if not os.path.lexists(source):
-        ret['comment'] = ('Source file "{0}" has already been moved out of '
-                          'place').format(source)
+        ret["comment"] = (
+            'Source file "{0}" has already been moved out of ' "place"
+        ).format(source)
         return ret
 
     if os.path.lexists(source) and os.path.lexists(name):
         if not force:
-            ret['comment'] = ('The target file "{0}" exists and will not be '
-                              'overwritten'.format(name))
+            ret["comment"] = (
+                'The target file "{0}" exists and will not be '
+                "overwritten".format(name)
+            )
             return ret
-        elif not __opts__['test']:
+        elif not __opts__["test"]:
             # Remove the destination to prevent problems later
             try:
-                __salt__['file.remove'](name)
+                __salt__["file.remove"](name)
             except (IOError, OSError):
                 return _error(
                     ret,
                     'Failed to delete "{0}" in preparation for '
-                    'forced move'.format(name)
+                    "forced move".format(name),
                 )
 
-    if __opts__['test']:
-        ret['comment'] = 'File "{0}" is set to be moved to "{1}"'.format(
-            source,
-            name
-        )
-        ret['result'] = None
+    if __opts__["test"]:
+        ret["comment"] = 'File "{0}" is set to be moved to "{1}"'.format(source, name)
+        ret["result"] = None
         return ret
 
     # Run makedirs
@@ -6929,11 +7017,9 @@ def rename(name, source, force=False, makedirs=False, **kwargs):
             try:
                 _makedirs(name=name)
             except CommandExecutionError as exc:
-                return _error(ret, 'Drive {0} is not mapped'.format(exc.message))
+                return _error(ret, "Drive {0} is not mapped".format(exc.message))
         else:
-            return _error(
-                ret,
-                'The target directory {0} is not present'.format(dname))
+            return _error(ret, "The target directory {0} is not present".format(dname))
     # All tests pass, move the file into place
     try:
         if os.path.islink(source):
@@ -6943,16 +7029,15 @@ def rename(name, source, force=False, makedirs=False, **kwargs):
         else:
             shutil.move(source, name)
     except (IOError, OSError):
-        return _error(
-            ret, 'Failed to move "{0}" to "{1}"'.format(source, name))
+        return _error(ret, 'Failed to move "{0}" to "{1}"'.format(source, name))
 
-    ret['comment'] = 'Moved "{0}" to "{1}"'.format(source, name)
-    ret['changes'] = {name: source}
+    ret["comment"] = 'Moved "{0}" to "{1}"'.format(source, name)
+    ret["changes"] = {name: source}
     return ret
 
 
 def accumulated(name, filename, text, **kwargs):
-    '''
+    """
     Prepare accumulator which can be used in template in file.managed state.
     Accumulator dictionary becomes available in template. It can also be used
     in file.blockreplace.
@@ -7007,28 +7092,21 @@ def accumulated(name, filename, text, **kwargs):
     .. note::
         The 'accumulator' data structure is a Python dictionary.
         Do not expect any loop over the keys in a deterministic order!
-    '''
-    ret = {
-        'name': name,
-        'changes': {},
-        'result': True,
-        'comment': ''
-    }
+    """
+    ret = {"name": name, "changes": {}, "result": True, "comment": ""}
     if not name:
-        return _error(ret, 'Must provide name to file.accumulated')
+        return _error(ret, "Must provide name to file.accumulated")
     if text is None:
-        ret['result'] = False
-        ret['comment'] = 'No text supplied for accumulator'
+        ret["result"] = False
+        ret["comment"] = "No text supplied for accumulator"
         return ret
-    require_in = __low__.get('require_in', [])
-    watch_in = __low__.get('watch_in', [])
+    require_in = __low__.get("require_in", [])
+    watch_in = __low__.get("watch_in", [])
     deps = require_in + watch_in
-    if not [x for x in deps if 'file' in x]:
-        ret['result'] = False
-        ret['comment'] = 'Orphaned accumulator {0} in {1}:{2}'.format(
-            name,
-            __low__['__sls__'],
-            __low__['__id__']
+    if not [x for x in deps if "file" in x]:
+        ret["result"] = False
+        ret["comment"] = "Orphaned accumulator {0} in {1}:{2}".format(
+            name, __low__["__sls__"], __low__["__id__"]
         )
         return ret
     if isinstance(text, six.string_types):
@@ -7049,29 +7127,33 @@ def accumulated(name, filename, text, **kwargs):
     for chunk in text:
         if chunk not in accum_data[filename][name]:
             accum_data[filename][name].append(chunk)
-            ret['comment'] = ('Accumulator {0} for file {1} '
-                              'was charged by text'.format(name, filename))
+            ret["comment"] = (
+                "Accumulator {0} for file {1} "
+                "was charged by text".format(name, filename)
+            )
     _persist_accummulators(accum_data, accum_deps)
     return ret
 
 
-def serialize(name,
-              dataset=None,
-              dataset_pillar=None,
-              user=None,
-              group=None,
-              mode=None,
-              backup='',
-              makedirs=False,
-              show_changes=True,
-              create=True,
-              merge_if_exists=False,
-              encoding=None,
-              encoding_errors='strict',
-              serializer_opts=None,
-              deserializer_opts=None,
-              **kwargs):
-    '''
+def serialize(
+    name,
+    dataset=None,
+    dataset_pillar=None,
+    user=None,
+    group=None,
+    mode=None,
+    backup="",
+    makedirs=False,
+    show_changes=True,
+    create=True,
+    merge_if_exists=False,
+    encoding=None,
+    encoding_errors="strict",
+    serializer_opts=None,
+    deserializer_opts=None,
+    **kwargs
+):
+    """
     Serializes dataset and store it into managed file. Useful for sharing
     simple configuration files.
 
@@ -7243,77 +7325,65 @@ def serialize(name,
           "engine": "node 0.4.1",
           "name": "naive"
         }
-    '''
-    if 'env' in kwargs:
+    """
+    if "env" in kwargs:
         # "env" is not supported; Use "saltenv".
-        kwargs.pop('env')
+        kwargs.pop("env")
 
     name = os.path.expanduser(name)
 
     # Set some defaults
     serializer_options = {
-        'yaml.serialize': {
-            'default_flow_style': False,
-        },
-        'json.serialize': {
-            'indent': 2,
-            'separators': (',', ': '),
-            'sort_keys': True,
-        }
+        "yaml.serialize": {"default_flow_style": False},
+        "json.serialize": {"indent": 2, "separators": (",", ": "), "sort_keys": True},
     }
-    deserializer_options = {
-        'yaml.deserialize': {},
-        'json.deserialize': {},
-    }
+    deserializer_options = {"yaml.deserialize": {}, "json.deserialize": {}}
     if encoding:
-        serializer_options['yaml.serialize'].update({'allow_unicode': True})
-        serializer_options['json.serialize'].update({'ensure_ascii': False})
+        serializer_options["yaml.serialize"].update({"allow_unicode": True})
+        serializer_options["json.serialize"].update({"ensure_ascii": False})
 
-    ret = {'changes': {},
-           'comment': '',
-           'name': name,
-           'result': True}
+    ret = {"changes": {}, "comment": "", "name": name, "result": True}
     if not name:
-        return _error(ret, 'Must provide name to file.serialize')
+        return _error(ret, "Must provide name to file.serialize")
 
     if not create:
         if not os.path.isfile(name):
             # Don't create a file that is not already present
-            ret['comment'] = ('File {0} is not present and is not set for '
-                              'creation').format(name)
+            ret["comment"] = (
+                "File {0} is not present and is not set for " "creation"
+            ).format(name)
             return ret
 
-    formatter = kwargs.pop('formatter', 'yaml').lower()
+    formatter = kwargs.pop("formatter", "yaml").lower()
 
     if len([x for x in (dataset, dataset_pillar) if x]) > 1:
-        return _error(
-            ret, 'Only one of \'dataset\' and \'dataset_pillar\' is permitted')
+        return _error(ret, "Only one of 'dataset' and 'dataset_pillar' is permitted")
 
     if dataset_pillar:
-        dataset = __salt__['pillar.get'](dataset_pillar)
+        dataset = __salt__["pillar.get"](dataset_pillar)
 
     if dataset is None:
-        return _error(
-            ret, 'Neither \'dataset\' nor \'dataset_pillar\' was defined')
+        return _error(ret, "Neither 'dataset' nor 'dataset_pillar' was defined")
 
     if salt.utils.platform.is_windows():
         if group is not None:
             log.warning(
-                'The group argument for %s has been ignored as this '
-                'is a Windows system.', name
+                "The group argument for %s has been ignored as this "
+                "is a Windows system.",
+                name,
             )
         group = user
 
-    serializer_name = '{0}.serialize'.format(formatter)
-    deserializer_name = '{0}.deserialize'.format(formatter)
+    serializer_name = "{0}.serialize".format(formatter)
+    deserializer_name = "{0}.deserialize".format(formatter)
 
     if serializer_name not in __serializers__:
-        return {'changes': {},
-                'comment': '{0} format is not supported'.format(
-                    formatter.capitalize()),
-                'name': name,
-                'result': False
-                }
+        return {
+            "changes": {},
+            "comment": "{0} format is not supported".format(formatter.capitalize()),
+            "name": name,
+            "result": False,
+        }
 
     if serializer_opts:
         serializer_options.setdefault(serializer_name, {}).update(
@@ -7330,52 +7400,53 @@ def serialize(name,
         if os.path.isfile(name):
             if deserializer_name not in __serializers__:
                 return {
-                    'changes': {},
-                    'comment': 'merge_if_exists is not supported for the {0} '
-                               'formatter'.format(formatter),
-                    'name': name,
-                    'result': False
+                    "changes": {},
+                    "comment": "merge_if_exists is not supported for the {0} "
+                    "formatter".format(formatter),
+                    "name": name,
+                    "result": False,
                 }
 
-            with salt.utils.files.fopen(name, 'r') as fhr:
+            with salt.utils.files.fopen(name, "r") as fhr:
                 try:
                     existing_data = __serializers__[deserializer_name](
-                        fhr,
-                        **deserializer_options.get(deserializer_name, {})
+                        fhr, **deserializer_options.get(deserializer_name, {})
                     )
                 except (TypeError, DeserializationError) as exc:
-                    ret['result'] = False
-                    ret['comment'] = \
-                        'Failed to deserialize existing data: {0}'.format(exc)
+                    ret["result"] = False
+                    ret["comment"] = "Failed to deserialize existing data: {0}".format(
+                        exc
+                    )
                     return False
 
             if existing_data is not None:
-                merged_data = salt.utils.dictupdate.merge_recurse(existing_data, dataset)
+                merged_data = salt.utils.dictupdate.merge_recurse(
+                    existing_data, dataset
+                )
                 if existing_data == merged_data:
-                    ret['result'] = True
-                    ret['comment'] = 'The file {0} is in the correct state'.format(name)
+                    ret["result"] = True
+                    ret["comment"] = "The file {0} is in the correct state".format(name)
                     return ret
                 dataset = merged_data
     else:
         if deserializer_opts:
-            ret.setdefault('warnings', []).append(
-                'The \'deserializer_opts\' option is ignored unless '
-                'merge_if_exists is set to True.'
+            ret.setdefault("warnings", []).append(
+                "The 'deserializer_opts' option is ignored unless "
+                "merge_if_exists is set to True."
             )
 
     contents = __serializers__[serializer_name](
-        dataset,
-        **serializer_options.get(serializer_name, {})
+        dataset, **serializer_options.get(serializer_name, {})
     )
 
-    contents += '\n'
+    contents += "\n"
 
     # Make sure that any leading zeros stripped by YAML loader are added back
     mode = salt.utils.files.normalize_mode(mode)
 
-    if __opts__['test']:
+    if __opts__["test"]:
         try:
-            ret['changes'] = __salt__['file.check_managed_changes'](
+            ret["changes"] = __salt__["file.check_managed_changes"](
                 name=name,
                 source=None,
                 source_hash={},
@@ -7393,24 +7464,25 @@ def serialize(name,
                 **kwargs
             )
         except CommandExecutionError as exc:
-            ret['result'] = False
-            ret['comment'] = six.text_type(exc)
+            ret["result"] = False
+            ret["comment"] = six.text_type(exc)
             return ret
 
-        if ret['changes']:
-            ret['result'] = None
-            ret['comment'] = 'Dataset will be serialized and stored into {0}'.format(
-                name)
+        if ret["changes"]:
+            ret["result"] = None
+            ret["comment"] = "Dataset will be serialized and stored into {0}".format(
+                name
+            )
 
             if not show_changes:
-                ret['changes']['diff'] = '<show_changes=False>'
+                ret["changes"]["diff"] = "<show_changes=False>"
         else:
-            ret['result'] = True
-            ret['comment'] = 'The file {0} is in the correct state'.format(name)
+            ret["result"] = True
+            ret["comment"] = "The file {0} is in the correct state".format(name)
     else:
-        ret = __salt__['file.manage_file'](
+        ret = __salt__["file.manage_file"](
             name=name,
-            sfn='',
+            sfn="",
             ret=ret,
             source=None,
             source_sum={},
@@ -7425,18 +7497,19 @@ def serialize(name,
             show_changes=show_changes,
             encoding=encoding,
             encoding_errors=encoding_errors,
-            contents=contents
+            contents=contents,
         )
 
     if isinstance(existing_data, dict) and isinstance(merged_data, dict):
-        ret['changes']['diff'] = salt.utils.dictdiffer.recursive_diff(
-            existing_data, merged_data).diffs
+        ret["changes"]["diff"] = salt.utils.dictdiffer.recursive_diff(
+            existing_data, merged_data
+        ).diffs
 
     return ret
 
 
-def mknod(name, ntype, major=0, minor=0, user=None, group=None, mode='0600'):
-    '''
+def mknod(name, ntype, major=0, minor=0, user=None, group=None, mode="0600"):
+    """
     Create a special file similar to the 'nix mknod command. The supported
     device types are ``p`` (fifo pipe), ``c`` (character device), and ``b``
     (block device). Provide the major and minor numbers when specifying a
@@ -7504,171 +7577,140 @@ def mknod(name, ntype, major=0, minor=0, user=None, group=None, mode='0600'):
             - mode: 660
 
     .. versionadded:: 0.17.0
-    '''
+    """
     name = os.path.expanduser(name)
 
-    ret = {'name': name,
-           'changes': {},
-           'comment': '',
-           'result': False}
+    ret = {"name": name, "changes": {}, "comment": "", "result": False}
     if not name:
-        return _error(ret, 'Must provide name to file.mknod')
+        return _error(ret, "Must provide name to file.mknod")
 
-    if ntype == 'c':
+    if ntype == "c":
         # Check for file existence
-        if __salt__['file.file_exists'](name):
-            ret['comment'] = (
-                'File {0} exists and is not a character device. Refusing '
-                'to continue'.format(name)
+        if __salt__["file.file_exists"](name):
+            ret["comment"] = (
+                "File {0} exists and is not a character device. Refusing "
+                "to continue".format(name)
             )
 
         # Check if it is a character device
-        elif not __salt__['file.is_chrdev'](name):
-            if __opts__['test']:
-                ret['comment'] = \
-                    'Character device {0} is set to be created'.format(name)
-                ret['result'] = None
-            else:
-                ret = __salt__['file.mknod'](name,
-                                             ntype,
-                                             major,
-                                             minor,
-                                             user,
-                                             group,
-                                             mode)
-
-        # Check the major/minor
-        else:
-            devmaj, devmin = __salt__['file.get_devmm'](name)
-            if (major, minor) != (devmaj, devmin):
-                ret['comment'] = (
-                    'Character device {0} exists and has a different '
-                    'major/minor {1}/{2}. Refusing to continue'
-                        .format(name, devmaj, devmin)
+        elif not __salt__["file.is_chrdev"](name):
+            if __opts__["test"]:
+                ret["comment"] = "Character device {0} is set to be created".format(
+                    name
                 )
-            # Check the perms
+                ret["result"] = None
             else:
-                ret = __salt__['file.check_perms'](name,
-                                                   None,
-                                                   user,
-                                                   group,
-                                                   mode)[0]
-                if not ret['changes']:
-                    ret['comment'] = (
-                        'Character device {0} is in the correct state'.format(
-                            name
-                        )
-                    )
-
-    elif ntype == 'b':
-        # Check for file existence
-        if __salt__['file.file_exists'](name):
-            ret['comment'] = (
-                'File {0} exists and is not a block device. Refusing to '
-                'continue'.format(name)
-            )
-
-        # Check if it is a block device
-        elif not __salt__['file.is_blkdev'](name):
-            if __opts__['test']:
-                ret['comment'] = 'Block device {0} is set to be created'.format(name)
-                ret['result'] = None
-            else:
-                ret = __salt__['file.mknod'](name,
-                                             ntype,
-                                             major,
-                                             minor,
-                                             user,
-                                             group,
-                                             mode)
+                ret = __salt__["file.mknod"](
+                    name, ntype, major, minor, user, group, mode
+                )
 
         # Check the major/minor
         else:
-            devmaj, devmin = __salt__['file.get_devmm'](name)
+            devmaj, devmin = __salt__["file.get_devmm"](name)
             if (major, minor) != (devmaj, devmin):
-                ret['comment'] = (
-                    'Block device {0} exists and has a different major/minor '
-                    '{1}/{2}. Refusing to continue'.format(
+                ret["comment"] = (
+                    "Character device {0} exists and has a different "
+                    "major/minor {1}/{2}. Refusing to continue".format(
                         name, devmaj, devmin
                     )
                 )
             # Check the perms
             else:
-                ret = __salt__['file.check_perms'](name,
-                                                   None,
-                                                   user,
-                                                   group,
-                                                   mode)[0]
-                if not ret['changes']:
-                    ret['comment'] = (
-                        'Block device {0} is in the correct state'.format(name)
+                ret = __salt__["file.check_perms"](name, None, user, group, mode)[0]
+                if not ret["changes"]:
+                    ret[
+                        "comment"
+                    ] = "Character device {0} is in the correct state".format(name)
+
+    elif ntype == "b":
+        # Check for file existence
+        if __salt__["file.file_exists"](name):
+            ret["comment"] = (
+                "File {0} exists and is not a block device. Refusing to "
+                "continue".format(name)
+            )
+
+        # Check if it is a block device
+        elif not __salt__["file.is_blkdev"](name):
+            if __opts__["test"]:
+                ret["comment"] = "Block device {0} is set to be created".format(name)
+                ret["result"] = None
+            else:
+                ret = __salt__["file.mknod"](
+                    name, ntype, major, minor, user, group, mode
+                )
+
+        # Check the major/minor
+        else:
+            devmaj, devmin = __salt__["file.get_devmm"](name)
+            if (major, minor) != (devmaj, devmin):
+                ret["comment"] = (
+                    "Block device {0} exists and has a different major/minor "
+                    "{1}/{2}. Refusing to continue".format(name, devmaj, devmin)
+                )
+            # Check the perms
+            else:
+                ret = __salt__["file.check_perms"](name, None, user, group, mode)[0]
+                if not ret["changes"]:
+                    ret["comment"] = "Block device {0} is in the correct state".format(
+                        name
                     )
 
-    elif ntype == 'p':
+    elif ntype == "p":
         # Check for file existence
-        if __salt__['file.file_exists'](name):
-            ret['comment'] = (
-                'File {0} exists and is not a fifo pipe. Refusing to '
-                'continue'.format(name)
+        if __salt__["file.file_exists"](name):
+            ret["comment"] = (
+                "File {0} exists and is not a fifo pipe. Refusing to "
+                "continue".format(name)
             )
 
         # Check if it is a fifo
-        elif not __salt__['file.is_fifo'](name):
-            if __opts__['test']:
-                ret['comment'] = 'Fifo pipe {0} is set to be created'.format(
-                    name
-                )
-                ret['result'] = None
+        elif not __salt__["file.is_fifo"](name):
+            if __opts__["test"]:
+                ret["comment"] = "Fifo pipe {0} is set to be created".format(name)
+                ret["result"] = None
             else:
-                ret = __salt__['file.mknod'](name,
-                                             ntype,
-                                             major,
-                                             minor,
-                                             user,
-                                             group,
-                                             mode)
+                ret = __salt__["file.mknod"](
+                    name, ntype, major, minor, user, group, mode
+                )
 
         # Check the perms
         else:
-            ret = __salt__['file.check_perms'](name,
-                                               None,
-                                               user,
-                                               group,
-                                               mode)[0]
-            if not ret['changes']:
-                ret['comment'] = (
-                    'Fifo pipe {0} is in the correct state'.format(name)
-                )
+            ret = __salt__["file.check_perms"](name, None, user, group, mode)[0]
+            if not ret["changes"]:
+                ret["comment"] = "Fifo pipe {0} is in the correct state".format(name)
 
     else:
-        ret['comment'] = (
-            'Node type unavailable: \'{0}\'. Available node types are '
-            'character (\'c\'), block (\'b\'), and pipe (\'p\')'.format(ntype)
+        ret["comment"] = (
+            "Node type unavailable: '{0}'. Available node types are "
+            "character ('c'), block ('b'), and pipe ('p')".format(ntype)
         )
 
     return ret
 
 
 def mod_run_check_cmd(cmd, filename, **check_cmd_opts):
-    '''
+    """
     Execute the check_cmd logic.
 
     Return a result dict if ``check_cmd`` succeeds (check_cmd == 0)
     otherwise return True
-    '''
+    """
 
-    log.debug('running our check_cmd')
-    _cmd = '{0} {1}'.format(cmd, filename)
-    cret = __salt__['cmd.run_all'](_cmd, **check_cmd_opts)
-    if cret['retcode'] != 0:
-        ret = {'comment': 'check_cmd execution failed',
-               'skip_watch': True,
-               'result': False}
+    log.debug("running our check_cmd")
+    _cmd = "{0} {1}".format(cmd, filename)
+    cret = __salt__["cmd.run_all"](_cmd, **check_cmd_opts)
+    if cret["retcode"] != 0:
+        ret = {
+            "comment": "check_cmd execution failed",
+            "skip_watch": True,
+            "result": False,
+        }
 
-        if cret.get('stdout'):
-            ret['comment'] += '\n' + cret['stdout']
-        if cret.get('stderr'):
-            ret['comment'] += '\n' + cret['stderr']
+        if cret.get("stdout"):
+            ret["comment"] += "\n" + cret["stdout"]
+        if cret.get("stderr"):
+            ret["comment"] += "\n" + cret["stderr"]
 
         return ret
 
@@ -7676,12 +7718,14 @@ def mod_run_check_cmd(cmd, filename, **check_cmd_opts):
     return True
 
 
-def decode(name,
-        encoded_data=None,
-        contents_pillar=None,
-        encoding_type='base64',
-        checksum='md5'):
-    '''
+def decode(
+    name,
+    encoded_data=None,
+    contents_pillar=None,
+    encoding_type="base64",
+    checksum="md5",
+):
+    """
     Decode an encoded file and write it to disk
 
     .. versionadded:: 2016.3.0
@@ -7735,72 +7779,72 @@ def decode(name,
             - encoding_type: base64
             - encoded_data: |
                 {{ salt.pillar.get('path:to:data') | indent(8) }}
-    '''
-    ret = {'name': name, 'changes': {}, 'result': False, 'comment': ''}
+    """
+    ret = {"name": name, "changes": {}, "result": False, "comment": ""}
 
     if not (encoded_data or contents_pillar):
-        raise CommandExecutionError("Specify either the 'encoded_data' or "
-                                    "'contents_pillar' argument.")
+        raise CommandExecutionError(
+            "Specify either the 'encoded_data' or " "'contents_pillar' argument."
+        )
     elif encoded_data and contents_pillar:
-        raise CommandExecutionError("Specify only one 'encoded_data' or "
-                                    "'contents_pillar' argument.")
+        raise CommandExecutionError(
+            "Specify only one 'encoded_data' or " "'contents_pillar' argument."
+        )
     elif encoded_data:
         content = encoded_data
     elif contents_pillar:
-        content = __salt__['pillar.get'](contents_pillar, False)
+        content = __salt__["pillar.get"](contents_pillar, False)
         if content is False:
-            raise CommandExecutionError('Pillar data not found.')
+            raise CommandExecutionError("Pillar data not found.")
     else:
-        raise CommandExecutionError('No contents given.')
+        raise CommandExecutionError("No contents given.")
 
-    dest_exists = __salt__['file.file_exists'](name)
+    dest_exists = __salt__["file.file_exists"](name)
     if dest_exists:
-        instr = __salt__['hashutil.base64_decodestring'](content)
-        insum = __salt__['hashutil.digest'](instr, checksum)
+        instr = __salt__["hashutil.base64_decodestring"](content)
+        insum = __salt__["hashutil.digest"](instr, checksum)
         del instr  # no need to keep in-memory after we have the hash
-        outsum = __salt__['hashutil.digest_file'](name, checksum)
+        outsum = __salt__["hashutil.digest_file"](name, checksum)
 
         if insum != outsum:
-            ret['changes'] = {
-                'old': outsum,
-                'new': insum,
-            }
+            ret["changes"] = {"old": outsum, "new": insum}
 
-        if not ret['changes']:
-            ret['comment'] = 'File is in the correct state.'
-            ret['result'] = True
+        if not ret["changes"]:
+            ret["comment"] = "File is in the correct state."
+            ret["result"] = True
             return ret
 
-    if __opts__['test'] is True:
-        ret['comment'] = 'File is set to be updated.'
-        ret['result'] = None
+    if __opts__["test"] is True:
+        ret["comment"] = "File is set to be updated."
+        ret["result"] = None
         return ret
 
-    ret['result'] = __salt__['hashutil.base64_decodefile'](content, name)
-    ret['comment'] = 'File was updated.'
+    ret["result"] = __salt__["hashutil.base64_decodefile"](content, name)
+    ret["comment"] = "File was updated."
 
-    if not ret['changes']:
-        ret['changes'] = {
-            'old': None,
-            'new': __salt__['hashutil.digest_file'](name, checksum),
+    if not ret["changes"]:
+        ret["changes"] = {
+            "old": None,
+            "new": __salt__["hashutil.digest_file"](name, checksum),
         }
 
     return ret
 
 
 def shortcut(
-        name,
-        target,
-        arguments=None,
-        working_dir=None,
-        description=None,
-        icon_location=None,
-        force=False,
-        backupname=None,
-        makedirs=False,
-        user=None,
-        **kwargs):
-    '''
+    name,
+    target,
+    arguments=None,
+    working_dir=None,
+    description=None,
+    icon_location=None,
+    force=False,
+    backupname=None,
+    makedirs=False,
+    user=None,
+    **kwargs
+):
+    """
     Create a Windows shortcut
 
     If the file already exists and is a shortcut pointing to any location other
@@ -7853,23 +7897,20 @@ def shortcut(
 
         The default mode for new files and directories corresponds umask of salt
         process. For existing files and directories it's not enforced.
-    '''
+    """
     user = _test_owner(kwargs, user=user)
-    ret = {'name': name,
-           'changes': {},
-           'result': True,
-           'comment': ''}
+    ret = {"name": name, "changes": {}, "result": True, "comment": ""}
     if not salt.utils.platform.is_windows():
-        return _error(ret, 'Shortcuts are only supported on Windows')
+        return _error(ret, "Shortcuts are only supported on Windows")
     if not name:
-        return _error(ret, 'Must provide name to file.shortcut')
-    if not name.endswith('.lnk') and not name.endswith('.url'):
+        return _error(ret, "Must provide name to file.shortcut")
+    if not name.endswith(".lnk") and not name.endswith(".url"):
         return _error(ret, 'Name must end with either ".lnk" or ".url"')
 
     # Normalize paths; do this after error checks to avoid invalid input
     # getting expanded, e.g. '' turning into '.'
     name = os.path.realpath(os.path.expanduser(name))
-    if name.endswith('.lnk'):
+    if name.endswith(".lnk"):
         target = os.path.realpath(os.path.expanduser(target))
     if working_dir:
         working_dir = os.path.realpath(os.path.expanduser(working_dir))
@@ -7877,46 +7918,41 @@ def shortcut(
         icon_location = os.path.realpath(os.path.expanduser(icon_location))
 
     if user is None:
-        user = __opts__['user']
+        user = __opts__["user"]
 
     # Make sure the user exists in Windows
     # Salt default is 'root'
-    if not __salt__['user.info'](user):
+    if not __salt__["user.info"](user):
         # User not found, use the account salt is running under
         # If username not found, use System
-        user = __salt__['user.current']()
+        user = __salt__["user.current"]()
         if not user:
-            user = 'SYSTEM'
+            user = "SYSTEM"
 
     preflight_errors = []
-    uid = __salt__['file.user_to_uid'](user)
+    uid = __salt__["file.user_to_uid"](user)
 
-    if uid == '':
-        preflight_errors.append('User {0} does not exist'.format(user))
+    if uid == "":
+        preflight_errors.append("User {0} does not exist".format(user))
 
     if not os.path.isabs(name):
         preflight_errors.append(
-            'Specified file {0} is not an absolute path'.format(name)
+            "Specified file {0} is not an absolute path".format(name)
         )
 
     if preflight_errors:
-        msg = '. '.join(preflight_errors)
+        msg = ". ".join(preflight_errors)
         if len(preflight_errors) > 1:
-            msg += '.'
+            msg += "."
         return _error(ret, msg)
 
-    presult, pcomment, pchanges = _shortcut_check(name,
-                                                  target,
-                                                  arguments,
-                                                  working_dir,
-                                                  description,
-                                                  icon_location,
-                                                  force,
-                                                  user)
-    if __opts__['test']:
-        ret['result'] = presult
-        ret['comment'] = pcomment
-        ret['changes'] = pchanges
+    presult, pcomment, pchanges = _shortcut_check(
+        name, target, arguments, working_dir, description, icon_location, force, user
+    )
+    if __opts__["test"]:
+        ret["result"] = presult
+        ret["comment"] = pcomment
+        ret["changes"] = pchanges
         return ret
 
     if not os.path.isdir(os.path.dirname(name)):
@@ -7924,13 +7960,13 @@ def shortcut(
             try:
                 _makedirs(name=name, user=user)
             except CommandExecutionError as exc:
-                return _error(ret, 'Drive {0} is not mapped'.format(exc.message))
+                return _error(ret, "Drive {0} is not mapped".format(exc.message))
         else:
             return _error(
                 ret,
                 'Directory "{0}" for shortcut is not present'.format(
                     os.path.dirname(name)
-                )
+                ),
             )
 
     if os.path.isdir(name) or os.path.islink(name):
@@ -7939,36 +7975,50 @@ def shortcut(
             # Make a backup first
             if os.path.lexists(backupname):
                 if not force:
-                    return _error(ret, ((
-                                            'File exists where the backup target {0} should go'
-                                        ).format(backupname)))
+                    return _error(
+                        ret,
+                        (
+                            (
+                                "File exists where the backup target {0} should go"
+                            ).format(backupname)
+                        ),
+                    )
                 else:
-                    __salt__['file.remove'](backupname)
+                    __salt__["file.remove"](backupname)
                     time.sleep(1)  # wait for asynchronous deletion
             if not os.path.isdir(os.path.dirname(backupname)):
                 if makedirs:
                     try:
                         _makedirs(name=backupname)
                     except CommandExecutionError as exc:
-                        return _error(ret, 'Drive {0} is not mapped'.format(exc.message))
+                        return _error(
+                            ret, "Drive {0} is not mapped".format(exc.message)
+                        )
                 else:
-                    return _error(ret, (
-                                            'Directory does not exist for'
-                                            ' backup at "{0}"'
-                                        ).format(os.path.dirname(backupname)))
+                    return _error(
+                        ret,
+                        ("Directory does not exist for" ' backup at "{0}"').format(
+                            os.path.dirname(backupname)
+                        ),
+                    )
             os.rename(name, backupname)
             time.sleep(1)  # wait for asynchronous rename
         elif force:
             # Remove whatever is in the way
-            __salt__['file.remove'](name)
-            ret['changes']['forced'] = 'Shortcut was forcibly replaced'
+            __salt__["file.remove"](name)
+            ret["changes"]["forced"] = "Shortcut was forcibly replaced"
             time.sleep(1)  # wait for asynchronous deletion
         else:
             # Otherwise throw an error
-            return _error(ret, ((
-                                    'Directory or symlink exists where the'
-                                    ' shortcut "{0}" should be'
-                                ).format(name)))
+            return _error(
+                ret,
+                (
+                    (
+                        "Directory or symlink exists where the"
+                        ' shortcut "{0}" should be'
+                    ).format(name)
+                ),
+            )
 
     # This will just load the shortcut if it already exists
     # It won't create the file until calling scut.Save()
@@ -7982,15 +8032,13 @@ def shortcut(
     if arguments is not None:
         state_checks.append(scut.Arguments == arguments)
     if working_dir is not None:
-        state_checks.append(
-            scut.WorkingDirectory.lower() == working_dir.lower()
-        )
+        state_checks.append(scut.WorkingDirectory.lower() == working_dir.lower())
     if description is not None:
         state_checks.append(scut.Description == description)
     if icon_location is not None:
         state_checks.append(scut.IconLocation.lower() == icon_location.lower())
 
-    if __salt__['file.file_exists'](name):
+    if __salt__["file.file_exists"](name):
         # The shortcut exists, verify that it matches the desired state
         if not all(state_checks):
             # The target is wrong, delete it
@@ -7998,18 +8046,20 @@ def shortcut(
         else:
             if _check_shortcut_ownership(name, user):
                 # The shortcut looks good!
-                ret['comment'] = ('Shortcut {0} is present and owned by '
-                                  '{1}'.format(name, user))
+                ret["comment"] = "Shortcut {0} is present and owned by " "{1}".format(
+                    name, user
+                )
             else:
                 if _set_shortcut_ownership(name, user):
-                    ret['comment'] = ('Set ownership of shortcut {0} to '
-                                      '{1}'.format(name, user))
-                    ret['changes']['ownership'] = '{0}'.format(user)
+                    ret["comment"] = "Set ownership of shortcut {0} to " "{1}".format(
+                        name, user
+                    )
+                    ret["changes"]["ownership"] = "{0}".format(user)
                 else:
-                    ret['result'] = False
-                    ret['comment'] += (
-                        'Failed to set ownership of shortcut {0} to '
-                        '{1}'.format(name, user)
+                    ret["result"] = False
+                    ret["comment"] += (
+                        "Failed to set ownership of shortcut {0} to "
+                        "{1}".format(name, user)
                     )
             return ret
 
@@ -8027,29 +8077,28 @@ def shortcut(
                 scut.IconLocation = icon_location
             scut.Save()
         except (AttributeError, pywintypes.com_error) as exc:
-            ret['result'] = False
-            ret['comment'] = ('Unable to create new shortcut {0} -> '
-                              '{1}: {2}'.format(name, target, exc))
+            ret["result"] = False
+            ret["comment"] = "Unable to create new shortcut {0} -> " "{1}: {2}".format(
+                name, target, exc
+            )
             return ret
         else:
-            ret['comment'] = ('Created new shortcut {0} -> '
-                              '{1}'.format(name, target))
-            ret['changes']['new'] = name
+            ret["comment"] = "Created new shortcut {0} -> " "{1}".format(name, target)
+            ret["changes"]["new"] = name
 
         if not _check_shortcut_ownership(name, user):
             if not _set_shortcut_ownership(name, user):
-                ret['result'] = False
-                ret['comment'] += (', but was unable to set ownership to '
-                                   '{0}'.format(user))
+                ret["result"] = False
+                ret["comment"] += ", but was unable to set ownership to " "{0}".format(
+                    user
+                )
     return ret
 
 
-def cached(name,
-           source_hash='',
-           source_hash_name=None,
-           skip_verify=False,
-           saltenv='base'):
-    '''
+def cached(
+    name, source_hash="", source_hash_name=None, skip_verify=False, saltenv="base"
+):
+    """
     .. versionadded:: 2017.7.3
 
     Ensures that a file is saved to the minion's cache. This state is primarily
@@ -8125,28 +8174,28 @@ def cached(name,
 
     This function will return the cached path of the file, or an empty string
     if the file is not present in the minion cache.
-    '''
-    ret = {'changes': {},
-           'comment': '',
-           'name': name,
-           'result': False}
+    """
+    ret = {"changes": {}, "comment": "", "name": name, "result": False}
 
     try:
         parsed = _urlparse(name)
     except Exception:
-        ret['comment'] = 'Only URLs or local file paths are valid input'
+        ret["comment"] = "Only URLs or local file paths are valid input"
         return ret
 
     # This if statement will keep the state from proceeding if a remote source
     # is specified and no source_hash is presented (unless we're skipping hash
     # verification).
-    if not skip_verify \
-            and not source_hash \
-            and parsed.scheme in salt.utils.files.REMOTE_PROTOS:
-        ret['comment'] = (
-            'Unable to verify upstream hash of source file {0}, please set '
-            'source_hash or set skip_verify to True'.format(
-                salt.utils.url.redact_http_basic_auth(name))
+    if (
+        not skip_verify
+        and not source_hash
+        and parsed.scheme in salt.utils.files.REMOTE_PROTOS
+    ):
+        ret["comment"] = (
+            "Unable to verify upstream hash of source file {0}, please set "
+            "source_hash or set skip_verify to True".format(
+                salt.utils.url.redact_http_basic_auth(name)
+            )
         )
         return ret
 
@@ -8155,13 +8204,14 @@ def cached(name,
         # the hash out of a file containing checksums, if that is how the
         # source_hash was specified.
         try:
-            source_sum = __salt__['file.get_source_sum'](
+            source_sum = __salt__["file.get_source_sum"](
                 source=name,
                 source_hash=source_hash,
                 source_hash_name=source_hash_name,
-                saltenv=saltenv)
+                saltenv=saltenv,
+            )
         except CommandExecutionError as exc:
-            ret['comment'] = exc.strerror
+            ret["comment"] = exc.strerror
             return ret
         else:
             if not source_sum:
@@ -8170,10 +8220,10 @@ def cached(name,
                 # being raised, which we catch above. Nevertheless, we should
                 # provide useful information in the event that
                 # file.get_source_sum regresses.
-                ret['comment'] = (
-                    'Failed to get source hash from {0}. This may be a bug. '
-                    'If this error persists, please report it and set '
-                    'skip_verify to True to work around it.'.format(source_hash)
+                ret["comment"] = (
+                    "Failed to get source hash from {0}. This may be a bug. "
+                    "If this error persists, please report it and set "
+                    "skip_verify to True to work around it.".format(source_hash)
                 )
                 return ret
     else:
@@ -8185,65 +8235,59 @@ def cached(name,
         if os.path.exists(full_path):
             if not skip_verify and source_sum:
                 # Enforce the hash
-                local_hash = __salt__['file.get_hash'](
-                    full_path,
-                    source_sum.get('hash_type', __opts__['hash_type']))
-                if local_hash == source_sum['hsum']:
-                    ret['result'] = True
-                    ret['comment'] = (
-                        'File {0} is present on the minion and has hash '
-                        '{1}'.format(full_path, local_hash)
+                local_hash = __salt__["file.get_hash"](
+                    full_path, source_sum.get("hash_type", __opts__["hash_type"])
+                )
+                if local_hash == source_sum["hsum"]:
+                    ret["result"] = True
+                    ret["comment"] = (
+                        "File {0} is present on the minion and has hash "
+                        "{1}".format(full_path, local_hash)
                     )
                 else:
-                    ret['comment'] = (
-                        'File {0} is present on the minion, but the hash ({1}) '
-                        'does not match the specified hash ({2})'.format(
-                            full_path, local_hash, source_sum['hsum']
+                    ret["comment"] = (
+                        "File {0} is present on the minion, but the hash ({1}) "
+                        "does not match the specified hash ({2})".format(
+                            full_path, local_hash, source_sum["hsum"]
                         )
                     )
                 return ret
             else:
-                ret['result'] = True
-                ret['comment'] = 'File {0} is present on the minion'.format(
-                    full_path
-                )
+                ret["result"] = True
+                ret["comment"] = "File {0} is present on the minion".format(full_path)
                 return ret
         else:
-            ret['comment'] = 'File {0} is not present on the minion'.format(
-                full_path
-            )
+            ret["comment"] = "File {0} is not present on the minion".format(full_path)
             return ret
 
-    local_copy = __salt__['cp.is_cached'](name, saltenv=saltenv)
+    local_copy = __salt__["cp.is_cached"](name, saltenv=saltenv)
 
     if local_copy:
         # File is already cached
-        pre_hash = __salt__['file.get_hash'](
-            local_copy,
-            source_sum.get('hash_type', __opts__['hash_type']))
+        pre_hash = __salt__["file.get_hash"](
+            local_copy, source_sum.get("hash_type", __opts__["hash_type"])
+        )
 
         if not skip_verify and source_sum:
             # Get the local copy's hash to compare with the hash that was
             # specified via source_hash. If it matches, we can exit early from
             # the state without going any further, because the file is cached
             # with the correct hash.
-            if pre_hash == source_sum['hsum']:
-                ret['result'] = True
-                ret['comment'] = (
-                    'File is already cached to {0} with hash {1}'.format(
-                        local_copy, pre_hash
-                    )
+            if pre_hash == source_sum["hsum"]:
+                ret["result"] = True
+                ret["comment"] = "File is already cached to {0} with hash {1}".format(
+                    local_copy, pre_hash
                 )
     else:
         pre_hash = None
 
     def _try_cache(path, checksum):
-        '''
+        """
         This helper is not needed anymore in develop as the fileclient in the
         develop branch now has means of skipping a download if the existing
         hash matches one passed to cp.cache_file. Remove this helper and the
         code that invokes it, once we have merged forward into develop.
-        '''
+        """
         if not path or not checksum:
             return True
         form = salt.utils.files.HASHES_REVMAP.get(len(checksum))
@@ -8267,63 +8311,59 @@ def cached(name,
     #      matches the cached copy.
     # Remote, non salt:// sources _will_ download if a copy of the file was
     # not already present in the minion cache.
-    if _try_cache(local_copy, source_sum.get('hsum')):
+    if _try_cache(local_copy, source_sum.get("hsum")):
         # The _try_cache helper is obsolete in the develop branch. Once merged
         # forward, remove the helper as well as this if statement, and dedent
         # the below block.
         try:
-            local_copy = __salt__['cp.cache_file'](
-                name,
-                saltenv=saltenv,
-                source_hash=source_sum.get('hsum'))
+            local_copy = __salt__["cp.cache_file"](
+                name, saltenv=saltenv, source_hash=source_sum.get("hsum")
+            )
         except Exception as exc:
-            ret['comment'] = salt.utils.url.redact_http_basic_auth(exc.__str__())
+            ret["comment"] = salt.utils.url.redact_http_basic_auth(exc.__str__())
             return ret
 
     if not local_copy:
-        ret['comment'] = (
-            'Failed to cache {0}, check minion log for more '
-            'information'.format(
-                salt.utils.url.redact_http_basic_auth(name))
+        ret["comment"] = (
+            "Failed to cache {0}, check minion log for more "
+            "information".format(salt.utils.url.redact_http_basic_auth(name))
         )
         return ret
 
-    post_hash = __salt__['file.get_hash'](
-        local_copy,
-        source_sum.get('hash_type', __opts__['hash_type']))
+    post_hash = __salt__["file.get_hash"](
+        local_copy, source_sum.get("hash_type", __opts__["hash_type"])
+    )
 
     if pre_hash != post_hash:
-        ret['changes']['hash'] = {'old': pre_hash, 'new': post_hash}
+        ret["changes"]["hash"] = {"old": pre_hash, "new": post_hash}
 
     # Check the hash, if we're enforcing one. Note that this will be the first
     # hash check if the file was not previously cached, and the 2nd hash check
     # if it was cached and the
     if not skip_verify and source_sum:
-        if post_hash == source_sum['hsum']:
-            ret['result'] = True
-            ret['comment'] = (
-                'File is already cached to {0} with hash {1}'.format(
-                    local_copy, post_hash
-                )
+        if post_hash == source_sum["hsum"]:
+            ret["result"] = True
+            ret["comment"] = "File is already cached to {0} with hash {1}".format(
+                local_copy, post_hash
             )
         else:
-            ret['comment'] = (
-                'File is cached to {0}, but the hash ({1}) does not match '
-                'the specified hash ({2})'.format(
-                    local_copy, post_hash, source_sum['hsum']
+            ret["comment"] = (
+                "File is cached to {0}, but the hash ({1}) does not match "
+                "the specified hash ({2})".format(
+                    local_copy, post_hash, source_sum["hsum"]
                 )
             )
         return ret
 
     # We're not enforcing a hash, and we already know that the file was
     # successfully cached, so we know the state was successful.
-    ret['result'] = True
-    ret['comment'] = 'File is cached to {0}'.format(local_copy)
+    ret["result"] = True
+    ret["comment"] = "File is cached to {0}".format(local_copy)
     return ret
 
 
-def not_cached(name, saltenv='base'):
-    '''
+def not_cached(name, saltenv="base"):
+    """
     .. versionadded:: 2017.7.3
 
     Ensures that a file is not present in the minion's cache, deleting it
@@ -8343,42 +8383,37 @@ def not_cached(name, saltenv='base'):
     saltenv
         Used to specify the environment from which to download a file from the
         Salt fileserver (i.e. those with ``salt://`` URL).
-    '''
-    ret = {'changes': {},
-           'comment': '',
-           'name': name,
-           'result': False}
+    """
+    ret = {"changes": {}, "comment": "", "name": name, "result": False}
 
     try:
         parsed = _urlparse(name)
     except Exception:
-        ret['comment'] = 'Only URLs or local file paths are valid input'
+        ret["comment"] = "Only URLs or local file paths are valid input"
         return ret
     else:
         if parsed.scheme in salt.utils.files.LOCAL_PROTOS:
             full_path = os.path.realpath(os.path.expanduser(parsed.path))
-            ret['result'] = True
-            ret['comment'] = (
-                'File {0} is a local path, no action taken'.format(
-                    full_path
-                )
+            ret["result"] = True
+            ret["comment"] = "File {0} is a local path, no action taken".format(
+                full_path
             )
             return ret
 
-    local_copy = __salt__['cp.is_cached'](name, saltenv=saltenv)
+    local_copy = __salt__["cp.is_cached"](name, saltenv=saltenv)
 
     if local_copy:
         try:
             os.remove(local_copy)
         except Exception as exc:
-            ret['comment'] = 'Failed to delete {0}: {1}'.format(
+            ret["comment"] = "Failed to delete {0}: {1}".format(
                 local_copy, exc.__str__()
             )
         else:
-            ret['result'] = True
-            ret['changes']['deleted'] = True
-            ret['comment'] = '{0} was deleted'.format(local_copy)
+            ret["result"] = True
+            ret["changes"]["deleted"] = True
+            ret["comment"] = "{0} was deleted".format(local_copy)
     else:
-        ret['result'] = True
-        ret['comment'] = '{0} is not cached'.format(name)
+        ret["result"] = True
+        ret["comment"] = "{0} is not cached".format(name)
     return ret


### PR DESCRIPTION
### What does this PR do?
Changes one conditional from bool() to if False so that when in test mode salt does not think it needs to make changes that it actually will not make when not in test mode.

I'm not sure this is the correct way to fix this, I can just say it does fix my issue. In fact I do not understand why previous behaviour examples below numbers 2 and 3 have different output so this very well may not be the correct fix.


### What issues does this PR fix or reference?
We have some states that self patch salt, and this works except that when running in test mode salt always says it will patch the file even when the file has been patched successfully.



### Previous Behavior
1. `salt 'myminion' state.apply` will result in no changes
1. `salt 'myminion' state.apply test=True` will show that all file.patched states will have changes, AND that the changes are then entire contents of the patch file, which is quite alarming to look at. IE:
    ```
    ----------
              ID: patch /my-conda-env/lib/python3.6/site-packages/salt/beacons/napalm_beacon.py in 2019.2.0
        Function: file.patch
            Name: /my-conda-env/lib/python3.6/site-packages/salt/beacons/napalm_beacon.py
          Result: None
         Comment: File /tmp/__salt.tmp.4w45xiks updated
         Started: 20:45:21.051892
        Duration: 10.492 ms
         Changes:   
                  ----------
                  diff:
                      --- 
                      +++ 
                      @@ -0,0 +1,24 @@
                      +--- a/salt/beacons/napalm_beacon.py
                      ++++ b/salt/beacons/napalm_beacon.py
                      +@@ -286,8 +286,8 @@ def validate(config):
                      +     if not isinstance(config, list):
                      +         return False, 'Configuration for napalm beacon must be a list.'
                      +     for mod in config:
                      +-        fun = mod.keys()[0]
                      +-        fun_cfg = mod.values()[0]
                      ++        fun = list(mod.keys())[0]
                      ++        fun_cfg = list(mod.values())[0]
                      +         if not isinstance(fun_cfg, dict):
                      +             return False, 'The match structure for the {} execution function output must be a dictionary'.format(fun)
                      +         if fun not in __salt__:
                      +@@ -306,8 +306,8 @@ def beacon(config):
                      +         if not mod:
                      +             continue
                      +         event = {}
                      +-        fun = mod.keys()[0]
                      +-        fun_cfg = mod.values()[0]
                      ++        fun = list(mod.keys())[0]
                      ++        fun_cfg = list(mod.values())[0]
                      +         args = fun_cfg.pop('_args', [])
                      +         kwargs = fun_cfg.pop('_kwargs', {})
                      +         log.debug('Executing %s with %s and %s', fun, args, kwargs)
    ```
    I got here from this log entry when running the minion in debug mode:
    ```
    [DEBUG   ] failed to download salt://patches/2019-2-0/napalm_beacon.patch
    ```
1. `salt 'myminion' state.apply patches test=True` THIS however shows no changes, correctly.

### New Behavior
1. `salt 'myminion' state.apply` will result in no changes
1. `salt 'myminion' state.apply test=True` Shows no changes, correctly.
1. `salt 'myminion' state.apply patches test=True` Shows no changes, correctly.

### Tests written?
No

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
