### PR TITLE
Avoid rehashing password hashes

### DIFF
--- a/salt/modules/mysql.py
+++ b/salt/modules/mysql.py
@@ -1532,7 +1532,10 @@ def user_chpass(user,
             password_sql = 'PASSWORD(%(password)s)'
         args['password'] = password
     elif password_hash is not None:
-        password_sql = '%(password)s'
+        if 'MariaDB' in server_version:
+            password_sql = 'PASSWORD %(password)s'
+        else:
+            password_sql = '%(password)s'
         args['password'] = password_hash
     elif not salt.utils.data.is_true(allow_passwordless):
         log.error('password or password_hash must be specified, unless '


### PR DESCRIPTION
### What does this PR do?
Fix password hash usage when changing passwords in MariaDB 10.2+

### What issues does this PR fix or reference?
None

### Previous Behavior
All passwords with a hash as new value would have that hash rehashed

### New Behavior
If you specify a hash it doesn't become your password

### Tests written?
No

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
