### PR TITLE
Fixed Bug  LVM has no Filesystem Type , no Filesystem is not allowed

### DIFF
--- a/salt/modules/parted_partition.py
+++ b/salt/modules/parted_partition.py
@@ -515,7 +515,7 @@ def mkpartfs(device, part_type, fs_type, start, end):
             'Invalid part_type passed to partition.mkpartfs'
         )
 
-    if not _is_fstype(fs_type):
+    if fs_type and not _is_fstype(fs_type):
         raise CommandExecutionError(
             'Invalid fs_type passed to partition.mkpartfs'
         )


### PR DESCRIPTION
In the moment (when fs_type is empty) the else 
```
 if fs_type:
        cmd = ('parted', '-m', '-s', '--', device, 'mkpart', part_type, fs_type, start, end)
    else:
        cmd = ('parted', '-m', '-s', '--', device, 'mkpart', part_type, start, end)
```
 is never reached.Since
```
if not _is_fstype(fs_type):
        raise CommandExecutionError(
```
Rises the condtion earlier.

An Empty Filesystem is needed for LVM Volumes

 The Check was in earlier Versions of salt it was correct in parted.py:
```
443     if fs_type and fs_type not in set(['ext2', 'fat32', 'fat16', 'linux-swap', 'reiserfs',
444                           'hfs', 'hfs+', 'hfsx', 'NTFS', 'ufs', 'xfs', 'zfs']):
```

So the check on not defined fs_type was forgotten on recoding 

### What does this PR do?
It Fixed the Bug , that Partion without Filesystem can be created like LVM
### What issues does this PR fix or reference?
It Fixed the Bug , that Partion without Filesystem can be created like LVM
### Previous Behavior
The Exception is rised when Filesystem type is empty

### New Behavior
Empty Filesystem type is Handled correct

### Tests written?

No

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
