### PR TITLE
Fix inconsistent full names in LGPO

### DIFF
--- a/salt/modules/win_lgpo.py
+++ b/salt/modules/win_lgpo.py
@@ -6096,8 +6096,20 @@ def _checkAllAdmxPolicies(policy_class,
             policy_item_key = policy_item.split('{0};'.format(chr(0)).encode('utf-16-le'))[0].decode('utf-16-le').lower()
             if policy_item_key:
                 # Find the policy definitions with this key
-                for admx_item in REGKEY_XPATH_MAPPED(admx_policy_definitions,
-                                                     keyvalue=adm_policy_key_map[policy_item_key]):
+                if policy_item_key in adm_policy_key_map:
+                    # Use the faster method if possible
+                    admx_items = REGKEY_XPATH_MAPPED(admx_policy_definitions,
+                                                     keyvalue=adm_policy_key_map[policy_item_key])
+                    log.debug('Found %s policies using the mapped method',
+                              len(admx_items))
+                else:
+                    # Fall back to this when the faster method is not feasible
+                    admx_items = REGKEY_XPATH(admx_policy_definitions,
+                                              keyvalue=policy_item_key)
+                    log.warning('%s not mapped', policy_item_key)
+                    log.warning('Found %s policies using the original method',
+                                len(admx_items))
+                for admx_item in admx_items:
                     # If this is a policy, append it to admx_policies
                     if etree.QName(admx_item).localname == 'policy':
                         if admx_item not in admx_policies:

--- a/tests/integration/modules/test_win_lgpo.py
+++ b/tests/integration/modules/test_win_lgpo.py
@@ -670,20 +670,6 @@ class WinLgpoTest(ModuleCase):
                 'old': {'Computer Configuration': {}}}
             self.assertDictEqual(result[name]['changes'], expected)
 
-    def test_set_computer_policy_RemoteAssistance(self):
-        '''
-        Ensure RAUnsolicit is caught by the slower XPath function
-        '''
-        self._testAdmxPolicy(
-            'Configure Offer Remote Assistance',
-            'Disabled',
-            [
-                r'Computer[\s]*Software\\policies\\Microsoft\\Windows NT\\Terminal Services[\s]*fAllowUnsolicited[\s]*DWORD:0',
-                r'Computer[\s]*Software\\policies\\Microsoft\\Windows NT\\Terminal Services[\s]*fAllowUnsolicitedFullControl[\s]*DELETE',
-                r'Computer[\s]*Software\\policies\\Microsoft\\Windows NT\\Terminal Services\\RAUnsolicit[\s]*\*[\s]*DELETEALLVALUES'
-            ],
-            assert_true=True)
-
     def tearDown(self):
         '''
         tearDown method, runs after each test

--- a/tests/integration/modules/test_win_lgpo.py
+++ b/tests/integration/modules/test_win_lgpo.py
@@ -36,7 +36,7 @@ class WinLgpoTest(ModuleCase):
                             registry_value_vname,
                             expected_value_data):
         '''
-        Takes a registry based policy name and config and validates taht the
+        Takes a registry based policy name and config and validates that the
         expected registry value exists and has the correct data
 
         policy_name
@@ -638,11 +638,59 @@ class WinLgpoTest(ModuleCase):
                                  'Not Configured',
                                  [r'; Source file:  c:\\windows\\system32\\grouppolicy\\machine\\registry.pol[\s]*; PARSING COMPLETED.'])
 
+    @destructiveTest
+    def test_set_computer_policy_AllowTelemetry(self):
+        '''
+        Tests that a the AllowTelemetry policy is applied correctly and that it
+        doesn't appear in subsequent group policy states as having changed
+        '''
+        valid_osreleases = ['10', '2016Server', '2019Server']
+        if self.osrelease not in valid_osreleases:
+            self.skipTest('Allow Telemetry policy is only applicable if the '
+                          'osrelease grain is {0}'.format(' or '.join(valid_osreleases)))
+        else:
+            self._testAdmxPolicy(
+                'Allow Telemetry',
+                {'AllowTelemetry': '1 - Basic'},
+                [r'Software\\Policies\\Microsoft\\Windows\\DataCollection[\s]*AllowTelemetry[\s]*DWORD:1'],
+                assert_true=True)
+            result = self.run_function(
+                'state.single',
+                ['lgpo.set'],
+                name='state',
+                computer_policy={
+                    'Disable pre-release features or settings': 'Disabled'
+                }
+            )
+            name = 'lgpo_|-state_|-state_|-set'
+            expected = {
+                'new': {
+                    'Computer Configuration': {
+                        'Windows Components\\Data Collection and Preview Builds\\Disable pre-release features or settings': 'Disabled'}},
+                'old': {'Computer Configuration': {}}}
+            self.assertDictEqual(result[name]['changes'], expected)
+
+    def test_set_computer_policy_RemoteAssistance(self):
+        '''
+        Ensure RAUnsolicit is caught by the slower XPath function
+        '''
+        self._testAdmxPolicy(
+            'Configure Offer Remote Assistance',
+            'Disabled',
+            [
+                r'Computer[\s]*Software\\policies\\Microsoft\\Windows NT\\Terminal Services[\s]*fAllowUnsolicited[\s]*DWORD:0',
+                r'Computer[\s]*Software\\policies\\Microsoft\\Windows NT\\Terminal Services[\s]*fAllowUnsolicitedFullControl[\s]*DELETE',
+                r'Computer[\s]*Software\\policies\\Microsoft\\Windows NT\\Terminal Services\\RAUnsolicit[\s]*\*[\s]*DELETEALLVALUES'
+            ],
+            assert_true=True)
+
     def tearDown(self):
         '''
         tearDown method, runs after each test
         '''
-        ret = self.run_function('state.single',
-                                ('file.absent', 'c:\\windows\\system32\\grouppolicy\\machine\\registry.pol'))
-        ret = self.run_function('state.single',
-                                ('file.absent', 'c:\\windows\\system32\\grouppolicy\\user\\registry.pol'))
+        self.run_state(
+            'file.absent',
+            name='c:\\windows\\system32\\grouppolicy\\machine\\registry.pol')
+        self.run_state(
+            'file.absent',
+            name='c:\\windows\\system32\\grouppolicy\\user\\registry.pol')


### PR DESCRIPTION
### What does this PR do?
Fixes an issue with setting the `Allow Telemetry` group policy. Ensures the `_checkAllAdmxPolicies` function always returns full names when `return_full_policy_names=True`

Also adds some speed optimizations to the XPath queries.

Adds some tests.

### What issues does this PR fix or reference?
https://github.com/saltstack/lock/issues/1826

### Previous Behavior
After setting the `Allow Telemetry` group policy, all subsequent group policy states would show `Allow Telemetry` also being changed.

The state module gets the current applied policies by running `lgpo.get`. This would return `AllowTelemetry`. After applying the state, the state module gets the current applied policies again and then compares the results with a `dict.diff`. The second `lgpo.get` would return `Allow Telemetry` (with a space). This was causing the state module to report an additional change.

### New Behavior
Since the returns from `_checkAllAdmxPolicies` are more consistent, subsequent state runs no longer report a change.

### Tests written?
Yes

### Commits signed with GPG?
Yes