### PR TITLE
Skip tests that modify date or time

### DIFF
--- a/tests/integration/modules/test_system.py
+++ b/tests/integration/modules/test_system.py
@@ -410,6 +410,7 @@ class WinSystemModuleTest(ModuleCase):
         now = datetime.datetime.now()
         self.assertEqual(now.strftime("%I:%M"), ret.rsplit(':', 1)[0])
 
+    @skipIf(True, 'WAR ROOM 7/18/2019, unit test?')
     @destructiveTest
     def test_set_system_time(self):
         '''
@@ -439,6 +440,7 @@ class WinSystemModuleTest(ModuleCase):
         date = datetime.datetime.now().date().strftime("%m/%d/%Y")
         self.assertEqual(date, ret)
 
+    @skipIf(True, 'WAR ROOM 7/18/2019, unit test?')
     @destructiveTest
     def test_set_system_date(self):
         '''


### PR DESCRIPTION
### What does this PR do?
Skip tests that modify date or time on WIndows (WAR ROOM)