### PR TITLE
[neon] CI Pipelines updates/fixes. PyTest requirements update.

### DIFF
--- a/.ci/kitchen-centos6-py2
+++ b/.ci/kitchen-centos6-py2
@@ -67,6 +67,14 @@ wrappedNode('kitchen-slave', global_timeout, '#jenkins-prod-pr') {
                 t=$(shuf -i 30-120 -n 1); echo "Sleeping $t seconds"; sleep $t
                 bundle exec kitchen create $TEST_SUITE-$TEST_PLATFORM; echo "ExitCode: $?";
                 '''
+                sh """
+                if [ -s ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ]; then
+                    mv ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ".kitchen/logs/${python_version}-${distro_name}-${distro_version}-create.log"
+                fi
+                if [ -s ".kitchen/logs/kitchen.log" ]; then
+                    mv ".kitchen/logs/kitchen.log" ".kitchen/logs/kitchen-create.log"
+                fi
+                """
             }
         }
 
@@ -76,6 +84,14 @@ wrappedNode('kitchen-slave', global_timeout, '#jenkins-prod-pr') {
                 timeout(time: testrun_timeout, unit: 'HOURS') {
                     stage('Converge VM') {
                         sh 'bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM; echo "ExitCode: $?";'
+                        sh """
+                        if [ -s ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ]; then
+                            mv ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ".kitchen/logs/${python_version}-${distro_name}-${distro_version}-converge.log"
+                        fi
+                        if [ -s ".kitchen/logs/kitchen.log" ]; then
+                            mv ".kitchen/logs/kitchen.log" ".kitchen/logs/kitchen-converge.log"
+                        fi
+                        """
                     }
                     stage('Run Tests') {
                         withEnv(["DONT_DOWNLOAD_ARTEFACTS=1"]) {
@@ -85,14 +101,33 @@ wrappedNode('kitchen-slave', global_timeout, '#jenkins-prod-pr') {
                 }
             } finally {
                 try {
+                    sh """
+                    if [ -s ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ]; then
+                        mv ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ".kitchen/logs/${python_version}-${distro_name}-${distro_version}-verify.log"
+                    fi
+                    if [ -s ".kitchen/logs/kitchen.log" ]; then
+                        mv ".kitchen/logs/kitchen.log" ".kitchen/logs/kitchen-verify.log"
+                    fi
+                    """
                     stage('Download Artefacts') {
                         withEnv(["ONLY_DOWNLOAD_ARTEFACTS=1"]){
                             sh '''
                             bundle exec kitchen verify $TEST_SUITE-$TEST_PLATFORM || exit 0
                             '''
                         }
+                        sh """
+                        if [ -s ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ]; then
+                            mv ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ".kitchen/logs/${python_version}-${distro_name}-${distro_version}-download.log"
+                        fi
+                        if [ -s ".kitchen/logs/kitchen.log" ]; then
+                            mv ".kitchen/logs/kitchen.log" ".kitchen/logs/kitchen-download.log"
+                        fi
+                        """
                     }
-                    archiveArtifacts artifacts: 'artifacts/*,artifacts/**/*,.kitchen/logs/kitchen.log,artifacts/xml-unittests-output/*.xml'
+                    archiveArtifacts(
+                        artifacts: "artifacts/*,artifacts/**/*,.kitchen/logs/*-create.log,.kitchen/logs/*-converge.log,.kitchen/logs/*-verify.log,.kitchen/logs/*-download.log,artifacts/xml-unittests-output/*.xml",
+                        allowEmptyArchive: true
+                    )
                     junit 'artifacts/xml-unittests-output/*.xml'
                 } finally {
                     stage('Cleanup') {

--- a/.ci/kitchen-centos7-py2
+++ b/.ci/kitchen-centos7-py2
@@ -67,6 +67,14 @@ wrappedNode('kitchen-slave', global_timeout, '#jenkins-prod-pr') {
                 t=$(shuf -i 30-120 -n 1); echo "Sleeping $t seconds"; sleep $t
                 bundle exec kitchen create $TEST_SUITE-$TEST_PLATFORM; echo "ExitCode: $?";
                 '''
+                sh """
+                if [ -s ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ]; then
+                    mv ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ".kitchen/logs/${python_version}-${distro_name}-${distro_version}-create.log"
+                fi
+                if [ -s ".kitchen/logs/kitchen.log" ]; then
+                    mv ".kitchen/logs/kitchen.log" ".kitchen/logs/kitchen-create.log"
+                fi
+                """
             }
         }
 
@@ -76,6 +84,14 @@ wrappedNode('kitchen-slave', global_timeout, '#jenkins-prod-pr') {
                 timeout(time: testrun_timeout, unit: 'HOURS') {
                     stage('Converge VM') {
                         sh 'bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM; echo "ExitCode: $?";'
+                        sh """
+                        if [ -s ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ]; then
+                            mv ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ".kitchen/logs/${python_version}-${distro_name}-${distro_version}-converge.log"
+                        fi
+                        if [ -s ".kitchen/logs/kitchen.log" ]; then
+                            mv ".kitchen/logs/kitchen.log" ".kitchen/logs/kitchen-converge.log"
+                        fi
+                        """
                     }
                     stage('Run Tests') {
                         withEnv(["DONT_DOWNLOAD_ARTEFACTS=1"]) {
@@ -85,14 +101,33 @@ wrappedNode('kitchen-slave', global_timeout, '#jenkins-prod-pr') {
                 }
             } finally {
                 try {
+                    sh """
+                    if [ -s ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ]; then
+                        mv ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ".kitchen/logs/${python_version}-${distro_name}-${distro_version}-verify.log"
+                    fi
+                    if [ -s ".kitchen/logs/kitchen.log" ]; then
+                        mv ".kitchen/logs/kitchen.log" ".kitchen/logs/kitchen-verify.log"
+                    fi
+                    """
                     stage('Download Artefacts') {
                         withEnv(["ONLY_DOWNLOAD_ARTEFACTS=1"]){
                             sh '''
                             bundle exec kitchen verify $TEST_SUITE-$TEST_PLATFORM || exit 0
                             '''
                         }
+                        sh """
+                        if [ -s ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ]; then
+                            mv ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ".kitchen/logs/${python_version}-${distro_name}-${distro_version}-download.log"
+                        fi
+                        if [ -s ".kitchen/logs/kitchen.log" ]; then
+                            mv ".kitchen/logs/kitchen.log" ".kitchen/logs/kitchen-download.log"
+                        fi
+                        """
                     }
-                    archiveArtifacts artifacts: 'artifacts/*,artifacts/**/*,.kitchen/logs/kitchen.log,artifacts/xml-unittests-output/*.xml'
+                    archiveArtifacts(
+                        artifacts: "artifacts/*,artifacts/**/*,.kitchen/logs/*-create.log,.kitchen/logs/*-converge.log,.kitchen/logs/*-verify.log,.kitchen/logs/*-download.log,artifacts/xml-unittests-output/*.xml",
+                        allowEmptyArchive: true
+                    )
                     junit 'artifacts/xml-unittests-output/*.xml'
                 } finally {
                     stage('Cleanup') {

--- a/.ci/kitchen-centos7-py2-tcp
+++ b/.ci/kitchen-centos7-py2-tcp
@@ -67,6 +67,14 @@ wrappedNode('kitchen-slave', global_timeout, '#jenkins-prod-pr') {
                 t=$(shuf -i 30-120 -n 1); echo "Sleeping $t seconds"; sleep $t
                 bundle exec kitchen create $TEST_SUITE-$TEST_PLATFORM; echo "ExitCode: $?";
                 '''
+                sh """
+                if [ -s ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ]; then
+                    mv ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ".kitchen/logs/${python_version}-${distro_name}-${distro_version}-create.log"
+                fi
+                if [ -s ".kitchen/logs/kitchen.log" ]; then
+                    mv ".kitchen/logs/kitchen.log" ".kitchen/logs/kitchen-create.log"
+                fi
+                """
             }
         }
 
@@ -76,6 +84,14 @@ wrappedNode('kitchen-slave', global_timeout, '#jenkins-prod-pr') {
                 timeout(time: testrun_timeout, unit: 'HOURS') {
                     stage('Converge VM') {
                         sh 'bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM; echo "ExitCode: $?";'
+                        sh """
+                        if [ -s ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ]; then
+                            mv ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ".kitchen/logs/${python_version}-${distro_name}-${distro_version}-converge.log"
+                        fi
+                        if [ -s ".kitchen/logs/kitchen.log" ]; then
+                            mv ".kitchen/logs/kitchen.log" ".kitchen/logs/kitchen-converge.log"
+                        fi
+                        """
                     }
                     stage('Run Tests') {
                         withEnv(["DONT_DOWNLOAD_ARTEFACTS=1"]) {
@@ -85,14 +101,33 @@ wrappedNode('kitchen-slave', global_timeout, '#jenkins-prod-pr') {
                 }
             } finally {
                 try {
+                    sh """
+                    if [ -s ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ]; then
+                        mv ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ".kitchen/logs/${python_version}-${distro_name}-${distro_version}-verify.log"
+                    fi
+                    if [ -s ".kitchen/logs/kitchen.log" ]; then
+                        mv ".kitchen/logs/kitchen.log" ".kitchen/logs/kitchen-verify.log"
+                    fi
+                    """
                     stage('Download Artefacts') {
                         withEnv(["ONLY_DOWNLOAD_ARTEFACTS=1"]){
                             sh '''
                             bundle exec kitchen verify $TEST_SUITE-$TEST_PLATFORM || exit 0
                             '''
                         }
+                        sh """
+                        if [ -s ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ]; then
+                            mv ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ".kitchen/logs/${python_version}-${distro_name}-${distro_version}-download.log"
+                        fi
+                        if [ -s ".kitchen/logs/kitchen.log" ]; then
+                            mv ".kitchen/logs/kitchen.log" ".kitchen/logs/kitchen-download.log"
+                        fi
+                        """
                     }
-                    archiveArtifacts artifacts: 'artifacts/*,artifacts/**/*,.kitchen/logs/kitchen.log,artifacts/xml-unittests-output/*.xml'
+                    archiveArtifacts(
+                        artifacts: "artifacts/*,artifacts/**/*,.kitchen/logs/*-create.log,.kitchen/logs/*-converge.log,.kitchen/logs/*-verify.log,.kitchen/logs/*-download.log,artifacts/xml-unittests-output/*.xml",
+                        allowEmptyArchive: true
+                    )
                     junit 'artifacts/xml-unittests-output/*.xml'
                 } finally {
                     stage('Cleanup') {

--- a/.ci/kitchen-centos7-py3
+++ b/.ci/kitchen-centos7-py3
@@ -67,6 +67,14 @@ wrappedNode('kitchen-slave', global_timeout, '#jenkins-prod-pr') {
                 t=$(shuf -i 30-120 -n 1); echo "Sleeping $t seconds"; sleep $t
                 bundle exec kitchen create $TEST_SUITE-$TEST_PLATFORM; echo "ExitCode: $?";
                 '''
+                sh """
+                if [ -s ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ]; then
+                    mv ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ".kitchen/logs/${python_version}-${distro_name}-${distro_version}-create.log"
+                fi
+                if [ -s ".kitchen/logs/kitchen.log" ]; then
+                    mv ".kitchen/logs/kitchen.log" ".kitchen/logs/kitchen-create.log"
+                fi
+                """
             }
         }
 
@@ -76,6 +84,14 @@ wrappedNode('kitchen-slave', global_timeout, '#jenkins-prod-pr') {
                 timeout(time: testrun_timeout, unit: 'HOURS') {
                     stage('Converge VM') {
                         sh 'bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM; echo "ExitCode: $?";'
+                        sh """
+                        if [ -s ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ]; then
+                            mv ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ".kitchen/logs/${python_version}-${distro_name}-${distro_version}-converge.log"
+                        fi
+                        if [ -s ".kitchen/logs/kitchen.log" ]; then
+                            mv ".kitchen/logs/kitchen.log" ".kitchen/logs/kitchen-converge.log"
+                        fi
+                        """
                     }
                     stage('Run Tests') {
                         withEnv(["DONT_DOWNLOAD_ARTEFACTS=1"]) {
@@ -85,14 +101,33 @@ wrappedNode('kitchen-slave', global_timeout, '#jenkins-prod-pr') {
                 }
             } finally {
                 try {
+                    sh """
+                    if [ -s ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ]; then
+                        mv ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ".kitchen/logs/${python_version}-${distro_name}-${distro_version}-verify.log"
+                    fi
+                    if [ -s ".kitchen/logs/kitchen.log" ]; then
+                        mv ".kitchen/logs/kitchen.log" ".kitchen/logs/kitchen-verify.log"
+                    fi
+                    """
                     stage('Download Artefacts') {
                         withEnv(["ONLY_DOWNLOAD_ARTEFACTS=1"]){
                             sh '''
                             bundle exec kitchen verify $TEST_SUITE-$TEST_PLATFORM || exit 0
                             '''
                         }
+                        sh """
+                        if [ -s ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ]; then
+                            mv ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ".kitchen/logs/${python_version}-${distro_name}-${distro_version}-download.log"
+                        fi
+                        if [ -s ".kitchen/logs/kitchen.log" ]; then
+                            mv ".kitchen/logs/kitchen.log" ".kitchen/logs/kitchen-download.log"
+                        fi
+                        """
                     }
-                    archiveArtifacts artifacts: 'artifacts/*,artifacts/**/*,.kitchen/logs/kitchen.log,artifacts/xml-unittests-output/*.xml'
+                    archiveArtifacts(
+                        artifacts: "artifacts/*,artifacts/**/*,.kitchen/logs/*-create.log,.kitchen/logs/*-converge.log,.kitchen/logs/*-verify.log,.kitchen/logs/*-download.log,artifacts/xml-unittests-output/*.xml",
+                        allowEmptyArchive: true
+                    )
                     junit 'artifacts/xml-unittests-output/*.xml'
                 } finally {
                     stage('Cleanup') {

--- a/.ci/kitchen-centos7-py3-tcp
+++ b/.ci/kitchen-centos7-py3-tcp
@@ -67,6 +67,14 @@ wrappedNode('kitchen-slave', global_timeout, '#jenkins-prod-pr') {
                 t=$(shuf -i 30-120 -n 1); echo "Sleeping $t seconds"; sleep $t
                 bundle exec kitchen create $TEST_SUITE-$TEST_PLATFORM; echo "ExitCode: $?";
                 '''
+                sh """
+                if [ -s ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ]; then
+                    mv ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ".kitchen/logs/${python_version}-${distro_name}-${distro_version}-create.log"
+                fi
+                if [ -s ".kitchen/logs/kitchen.log" ]; then
+                    mv ".kitchen/logs/kitchen.log" ".kitchen/logs/kitchen-create.log"
+                fi
+                """
             }
         }
 
@@ -76,6 +84,14 @@ wrappedNode('kitchen-slave', global_timeout, '#jenkins-prod-pr') {
                 timeout(time: testrun_timeout, unit: 'HOURS') {
                     stage('Converge VM') {
                         sh 'bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM; echo "ExitCode: $?";'
+                        sh """
+                        if [ -s ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ]; then
+                            mv ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ".kitchen/logs/${python_version}-${distro_name}-${distro_version}-converge.log"
+                        fi
+                        if [ -s ".kitchen/logs/kitchen.log" ]; then
+                            mv ".kitchen/logs/kitchen.log" ".kitchen/logs/kitchen-converge.log"
+                        fi
+                        """
                     }
                     stage('Run Tests') {
                         withEnv(["DONT_DOWNLOAD_ARTEFACTS=1"]) {
@@ -85,14 +101,33 @@ wrappedNode('kitchen-slave', global_timeout, '#jenkins-prod-pr') {
                 }
             } finally {
                 try {
+                    sh """
+                    if [ -s ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ]; then
+                        mv ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ".kitchen/logs/${python_version}-${distro_name}-${distro_version}-verify.log"
+                    fi
+                    if [ -s ".kitchen/logs/kitchen.log" ]; then
+                        mv ".kitchen/logs/kitchen.log" ".kitchen/logs/kitchen-verify.log"
+                    fi
+                    """
                     stage('Download Artefacts') {
                         withEnv(["ONLY_DOWNLOAD_ARTEFACTS=1"]){
                             sh '''
                             bundle exec kitchen verify $TEST_SUITE-$TEST_PLATFORM || exit 0
                             '''
                         }
+                        sh """
+                        if [ -s ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ]; then
+                            mv ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ".kitchen/logs/${python_version}-${distro_name}-${distro_version}-download.log"
+                        fi
+                        if [ -s ".kitchen/logs/kitchen.log" ]; then
+                            mv ".kitchen/logs/kitchen.log" ".kitchen/logs/kitchen-download.log"
+                        fi
+                        """
                     }
-                    archiveArtifacts artifacts: 'artifacts/*,artifacts/**/*,.kitchen/logs/kitchen.log,artifacts/xml-unittests-output/*.xml'
+                    archiveArtifacts(
+                        artifacts: "artifacts/*,artifacts/**/*,.kitchen/logs/*-create.log,.kitchen/logs/*-converge.log,.kitchen/logs/*-verify.log,.kitchen/logs/*-download.log,artifacts/xml-unittests-output/*.xml",
+                        allowEmptyArchive: true
+                    )
                     junit 'artifacts/xml-unittests-output/*.xml'
                 } finally {
                     stage('Cleanup') {

--- a/.ci/kitchen-debian8-py2
+++ b/.ci/kitchen-debian8-py2
@@ -67,6 +67,14 @@ wrappedNode('kitchen-slave', global_timeout, '#jenkins-prod-pr') {
                 t=$(shuf -i 30-120 -n 1); echo "Sleeping $t seconds"; sleep $t
                 bundle exec kitchen create $TEST_SUITE-$TEST_PLATFORM; echo "ExitCode: $?";
                 '''
+                sh """
+                if [ -s ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ]; then
+                    mv ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ".kitchen/logs/${python_version}-${distro_name}-${distro_version}-create.log"
+                fi
+                if [ -s ".kitchen/logs/kitchen.log" ]; then
+                    mv ".kitchen/logs/kitchen.log" ".kitchen/logs/kitchen-create.log"
+                fi
+                """
             }
         }
 
@@ -76,6 +84,14 @@ wrappedNode('kitchen-slave', global_timeout, '#jenkins-prod-pr') {
                 timeout(time: testrun_timeout, unit: 'HOURS') {
                     stage('Converge VM') {
                         sh 'bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM; echo "ExitCode: $?";'
+                        sh """
+                        if [ -s ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ]; then
+                            mv ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ".kitchen/logs/${python_version}-${distro_name}-${distro_version}-converge.log"
+                        fi
+                        if [ -s ".kitchen/logs/kitchen.log" ]; then
+                            mv ".kitchen/logs/kitchen.log" ".kitchen/logs/kitchen-converge.log"
+                        fi
+                        """
                     }
                     stage('Run Tests') {
                         withEnv(["DONT_DOWNLOAD_ARTEFACTS=1"]) {
@@ -85,14 +101,33 @@ wrappedNode('kitchen-slave', global_timeout, '#jenkins-prod-pr') {
                 }
             } finally {
                 try {
+                    sh """
+                    if [ -s ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ]; then
+                        mv ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ".kitchen/logs/${python_version}-${distro_name}-${distro_version}-verify.log"
+                    fi
+                    if [ -s ".kitchen/logs/kitchen.log" ]; then
+                        mv ".kitchen/logs/kitchen.log" ".kitchen/logs/kitchen-verify.log"
+                    fi
+                    """
                     stage('Download Artefacts') {
                         withEnv(["ONLY_DOWNLOAD_ARTEFACTS=1"]){
                             sh '''
                             bundle exec kitchen verify $TEST_SUITE-$TEST_PLATFORM || exit 0
                             '''
                         }
+                        sh """
+                        if [ -s ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ]; then
+                            mv ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ".kitchen/logs/${python_version}-${distro_name}-${distro_version}-download.log"
+                        fi
+                        if [ -s ".kitchen/logs/kitchen.log" ]; then
+                            mv ".kitchen/logs/kitchen.log" ".kitchen/logs/kitchen-download.log"
+                        fi
+                        """
                     }
-                    archiveArtifacts artifacts: 'artifacts/*,artifacts/**/*,.kitchen/logs/kitchen.log,artifacts/xml-unittests-output/*.xml'
+                    archiveArtifacts(
+                        artifacts: "artifacts/*,artifacts/**/*,.kitchen/logs/*-create.log,.kitchen/logs/*-converge.log,.kitchen/logs/*-verify.log,.kitchen/logs/*-download.log,artifacts/xml-unittests-output/*.xml",
+                        allowEmptyArchive: true
+                    )
                     junit 'artifacts/xml-unittests-output/*.xml'
                 } finally {
                     stage('Cleanup') {

--- a/.ci/kitchen-debian8-py3
+++ b/.ci/kitchen-debian8-py3
@@ -67,6 +67,14 @@ wrappedNode('kitchen-slave', global_timeout, '#jenkins-prod-pr') {
                 t=$(shuf -i 30-120 -n 1); echo "Sleeping $t seconds"; sleep $t
                 bundle exec kitchen create $TEST_SUITE-$TEST_PLATFORM; echo "ExitCode: $?";
                 '''
+                sh """
+                if [ -s ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ]; then
+                    mv ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ".kitchen/logs/${python_version}-${distro_name}-${distro_version}-create.log"
+                fi
+                if [ -s ".kitchen/logs/kitchen.log" ]; then
+                    mv ".kitchen/logs/kitchen.log" ".kitchen/logs/kitchen-create.log"
+                fi
+                """
             }
         }
 
@@ -76,6 +84,14 @@ wrappedNode('kitchen-slave', global_timeout, '#jenkins-prod-pr') {
                 timeout(time: testrun_timeout, unit: 'HOURS') {
                     stage('Converge VM') {
                         sh 'bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM; echo "ExitCode: $?";'
+                        sh """
+                        if [ -s ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ]; then
+                            mv ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ".kitchen/logs/${python_version}-${distro_name}-${distro_version}-converge.log"
+                        fi
+                        if [ -s ".kitchen/logs/kitchen.log" ]; then
+                            mv ".kitchen/logs/kitchen.log" ".kitchen/logs/kitchen-converge.log"
+                        fi
+                        """
                     }
                     stage('Run Tests') {
                         withEnv(["DONT_DOWNLOAD_ARTEFACTS=1"]) {
@@ -85,14 +101,33 @@ wrappedNode('kitchen-slave', global_timeout, '#jenkins-prod-pr') {
                 }
             } finally {
                 try {
+                    sh """
+                    if [ -s ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ]; then
+                        mv ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ".kitchen/logs/${python_version}-${distro_name}-${distro_version}-verify.log"
+                    fi
+                    if [ -s ".kitchen/logs/kitchen.log" ]; then
+                        mv ".kitchen/logs/kitchen.log" ".kitchen/logs/kitchen-verify.log"
+                    fi
+                    """
                     stage('Download Artefacts') {
                         withEnv(["ONLY_DOWNLOAD_ARTEFACTS=1"]){
                             sh '''
                             bundle exec kitchen verify $TEST_SUITE-$TEST_PLATFORM || exit 0
                             '''
                         }
+                        sh """
+                        if [ -s ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ]; then
+                            mv ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ".kitchen/logs/${python_version}-${distro_name}-${distro_version}-download.log"
+                        fi
+                        if [ -s ".kitchen/logs/kitchen.log" ]; then
+                            mv ".kitchen/logs/kitchen.log" ".kitchen/logs/kitchen-download.log"
+                        fi
+                        """
                     }
-                    archiveArtifacts artifacts: 'artifacts/*,artifacts/**/*,.kitchen/logs/kitchen.log,artifacts/xml-unittests-output/*.xml'
+                    archiveArtifacts(
+                        artifacts: "artifacts/*,artifacts/**/*,.kitchen/logs/*-create.log,.kitchen/logs/*-converge.log,.kitchen/logs/*-verify.log,.kitchen/logs/*-download.log,artifacts/xml-unittests-output/*.xml",
+                        allowEmptyArchive: true
+                    )
                     junit 'artifacts/xml-unittests-output/*.xml'
                 } finally {
                     stage('Cleanup') {

--- a/.ci/kitchen-debian9-py2
+++ b/.ci/kitchen-debian9-py2
@@ -67,6 +67,14 @@ wrappedNode('kitchen-slave', global_timeout, '#jenkins-prod-pr') {
                 t=$(shuf -i 30-120 -n 1); echo "Sleeping $t seconds"; sleep $t
                 bundle exec kitchen create $TEST_SUITE-$TEST_PLATFORM; echo "ExitCode: $?";
                 '''
+                sh """
+                if [ -s ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ]; then
+                    mv ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ".kitchen/logs/${python_version}-${distro_name}-${distro_version}-create.log"
+                fi
+                if [ -s ".kitchen/logs/kitchen.log" ]; then
+                    mv ".kitchen/logs/kitchen.log" ".kitchen/logs/kitchen-create.log"
+                fi
+                """
             }
         }
 
@@ -76,6 +84,14 @@ wrappedNode('kitchen-slave', global_timeout, '#jenkins-prod-pr') {
                 timeout(time: testrun_timeout, unit: 'HOURS') {
                     stage('Converge VM') {
                         sh 'bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM; echo "ExitCode: $?";'
+                        sh """
+                        if [ -s ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ]; then
+                            mv ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ".kitchen/logs/${python_version}-${distro_name}-${distro_version}-converge.log"
+                        fi
+                        if [ -s ".kitchen/logs/kitchen.log" ]; then
+                            mv ".kitchen/logs/kitchen.log" ".kitchen/logs/kitchen-converge.log"
+                        fi
+                        """
                     }
                     stage('Run Tests') {
                         withEnv(["DONT_DOWNLOAD_ARTEFACTS=1"]) {
@@ -85,14 +101,33 @@ wrappedNode('kitchen-slave', global_timeout, '#jenkins-prod-pr') {
                 }
             } finally {
                 try {
+                    sh """
+                    if [ -s ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ]; then
+                        mv ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ".kitchen/logs/${python_version}-${distro_name}-${distro_version}-verify.log"
+                    fi
+                    if [ -s ".kitchen/logs/kitchen.log" ]; then
+                        mv ".kitchen/logs/kitchen.log" ".kitchen/logs/kitchen-verify.log"
+                    fi
+                    """
                     stage('Download Artefacts') {
                         withEnv(["ONLY_DOWNLOAD_ARTEFACTS=1"]){
                             sh '''
                             bundle exec kitchen verify $TEST_SUITE-$TEST_PLATFORM || exit 0
                             '''
                         }
+                        sh """
+                        if [ -s ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ]; then
+                            mv ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ".kitchen/logs/${python_version}-${distro_name}-${distro_version}-download.log"
+                        fi
+                        if [ -s ".kitchen/logs/kitchen.log" ]; then
+                            mv ".kitchen/logs/kitchen.log" ".kitchen/logs/kitchen-download.log"
+                        fi
+                        """
                     }
-                    archiveArtifacts artifacts: 'artifacts/*,artifacts/**/*,.kitchen/logs/kitchen.log,artifacts/xml-unittests-output/*.xml'
+                    archiveArtifacts(
+                        artifacts: "artifacts/*,artifacts/**/*,.kitchen/logs/*-create.log,.kitchen/logs/*-converge.log,.kitchen/logs/*-verify.log,.kitchen/logs/*-download.log,artifacts/xml-unittests-output/*.xml",
+                        allowEmptyArchive: true
+                    )
                     junit 'artifacts/xml-unittests-output/*.xml'
                 } finally {
                     stage('Cleanup') {

--- a/.ci/kitchen-debian9-py3
+++ b/.ci/kitchen-debian9-py3
@@ -67,6 +67,14 @@ wrappedNode('kitchen-slave', global_timeout, '#jenkins-prod-pr') {
                 t=$(shuf -i 30-120 -n 1); echo "Sleeping $t seconds"; sleep $t
                 bundle exec kitchen create $TEST_SUITE-$TEST_PLATFORM; echo "ExitCode: $?";
                 '''
+                sh """
+                if [ -s ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ]; then
+                    mv ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ".kitchen/logs/${python_version}-${distro_name}-${distro_version}-create.log"
+                fi
+                if [ -s ".kitchen/logs/kitchen.log" ]; then
+                    mv ".kitchen/logs/kitchen.log" ".kitchen/logs/kitchen-create.log"
+                fi
+                """
             }
         }
 
@@ -76,6 +84,14 @@ wrappedNode('kitchen-slave', global_timeout, '#jenkins-prod-pr') {
                 timeout(time: testrun_timeout, unit: 'HOURS') {
                     stage('Converge VM') {
                         sh 'bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM; echo "ExitCode: $?";'
+                        sh """
+                        if [ -s ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ]; then
+                            mv ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ".kitchen/logs/${python_version}-${distro_name}-${distro_version}-converge.log"
+                        fi
+                        if [ -s ".kitchen/logs/kitchen.log" ]; then
+                            mv ".kitchen/logs/kitchen.log" ".kitchen/logs/kitchen-converge.log"
+                        fi
+                        """
                     }
                     stage('Run Tests') {
                         withEnv(["DONT_DOWNLOAD_ARTEFACTS=1"]) {
@@ -85,14 +101,33 @@ wrappedNode('kitchen-slave', global_timeout, '#jenkins-prod-pr') {
                 }
             } finally {
                 try {
+                    sh """
+                    if [ -s ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ]; then
+                        mv ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ".kitchen/logs/${python_version}-${distro_name}-${distro_version}-verify.log"
+                    fi
+                    if [ -s ".kitchen/logs/kitchen.log" ]; then
+                        mv ".kitchen/logs/kitchen.log" ".kitchen/logs/kitchen-verify.log"
+                    fi
+                    """
                     stage('Download Artefacts') {
                         withEnv(["ONLY_DOWNLOAD_ARTEFACTS=1"]){
                             sh '''
                             bundle exec kitchen verify $TEST_SUITE-$TEST_PLATFORM || exit 0
                             '''
                         }
+                        sh """
+                        if [ -s ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ]; then
+                            mv ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ".kitchen/logs/${python_version}-${distro_name}-${distro_version}-download.log"
+                        fi
+                        if [ -s ".kitchen/logs/kitchen.log" ]; then
+                            mv ".kitchen/logs/kitchen.log" ".kitchen/logs/kitchen-download.log"
+                        fi
+                        """
                     }
-                    archiveArtifacts artifacts: 'artifacts/*,artifacts/**/*,.kitchen/logs/kitchen.log,artifacts/xml-unittests-output/*.xml'
+                    archiveArtifacts(
+                        artifacts: "artifacts/*,artifacts/**/*,.kitchen/logs/*-create.log,.kitchen/logs/*-converge.log,.kitchen/logs/*-verify.log,.kitchen/logs/*-download.log,artifacts/xml-unittests-output/*.xml",
+                        allowEmptyArchive: true
+                    )
                     junit 'artifacts/xml-unittests-output/*.xml'
                 } finally {
                     stage('Cleanup') {

--- a/.ci/kitchen-fedora29-py2
+++ b/.ci/kitchen-fedora29-py2
@@ -67,6 +67,14 @@ wrappedNode('kitchen-slave', global_timeout, '#jenkins-prod-pr') {
                 t=$(shuf -i 30-120 -n 1); echo "Sleeping $t seconds"; sleep $t
                 bundle exec kitchen create $TEST_SUITE-$TEST_PLATFORM; echo "ExitCode: $?";
                 '''
+                sh """
+                if [ -s ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ]; then
+                    mv ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ".kitchen/logs/${python_version}-${distro_name}-${distro_version}-create.log"
+                fi
+                if [ -s ".kitchen/logs/kitchen.log" ]; then
+                    mv ".kitchen/logs/kitchen.log" ".kitchen/logs/kitchen-create.log"
+                fi
+                """
             }
         }
 
@@ -76,6 +84,14 @@ wrappedNode('kitchen-slave', global_timeout, '#jenkins-prod-pr') {
                 timeout(time: testrun_timeout, unit: 'HOURS') {
                     stage('Converge VM') {
                         sh 'bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM; echo "ExitCode: $?";'
+                        sh """
+                        if [ -s ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ]; then
+                            mv ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ".kitchen/logs/${python_version}-${distro_name}-${distro_version}-converge.log"
+                        fi
+                        if [ -s ".kitchen/logs/kitchen.log" ]; then
+                            mv ".kitchen/logs/kitchen.log" ".kitchen/logs/kitchen-converge.log"
+                        fi
+                        """
                     }
                     stage('Run Tests') {
                         withEnv(["DONT_DOWNLOAD_ARTEFACTS=1"]) {
@@ -85,14 +101,33 @@ wrappedNode('kitchen-slave', global_timeout, '#jenkins-prod-pr') {
                 }
             } finally {
                 try {
+                    sh """
+                    if [ -s ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ]; then
+                        mv ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ".kitchen/logs/${python_version}-${distro_name}-${distro_version}-verify.log"
+                    fi
+                    if [ -s ".kitchen/logs/kitchen.log" ]; then
+                        mv ".kitchen/logs/kitchen.log" ".kitchen/logs/kitchen-verify.log"
+                    fi
+                    """
                     stage('Download Artefacts') {
                         withEnv(["ONLY_DOWNLOAD_ARTEFACTS=1"]){
                             sh '''
                             bundle exec kitchen verify $TEST_SUITE-$TEST_PLATFORM || exit 0
                             '''
                         }
+                        sh """
+                        if [ -s ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ]; then
+                            mv ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ".kitchen/logs/${python_version}-${distro_name}-${distro_version}-download.log"
+                        fi
+                        if [ -s ".kitchen/logs/kitchen.log" ]; then
+                            mv ".kitchen/logs/kitchen.log" ".kitchen/logs/kitchen-download.log"
+                        fi
+                        """
                     }
-                    archiveArtifacts artifacts: 'artifacts/*,artifacts/**/*,.kitchen/logs/kitchen.log,artifacts/xml-unittests-output/*.xml'
+                    archiveArtifacts(
+                        artifacts: "artifacts/*,artifacts/**/*,.kitchen/logs/*-create.log,.kitchen/logs/*-converge.log,.kitchen/logs/*-verify.log,.kitchen/logs/*-download.log,artifacts/xml-unittests-output/*.xml",
+                        allowEmptyArchive: true
+                    )
                     junit 'artifacts/xml-unittests-output/*.xml'
                 } finally {
                     stage('Cleanup') {

--- a/.ci/kitchen-fedora29-py3
+++ b/.ci/kitchen-fedora29-py3
@@ -67,6 +67,14 @@ wrappedNode('kitchen-slave', global_timeout, '#jenkins-prod-pr') {
                 t=$(shuf -i 30-120 -n 1); echo "Sleeping $t seconds"; sleep $t
                 bundle exec kitchen create $TEST_SUITE-$TEST_PLATFORM; echo "ExitCode: $?";
                 '''
+                sh """
+                if [ -s ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ]; then
+                    mv ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ".kitchen/logs/${python_version}-${distro_name}-${distro_version}-create.log"
+                fi
+                if [ -s ".kitchen/logs/kitchen.log" ]; then
+                    mv ".kitchen/logs/kitchen.log" ".kitchen/logs/kitchen-create.log"
+                fi
+                """
             }
         }
 
@@ -76,6 +84,14 @@ wrappedNode('kitchen-slave', global_timeout, '#jenkins-prod-pr') {
                 timeout(time: testrun_timeout, unit: 'HOURS') {
                     stage('Converge VM') {
                         sh 'bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM; echo "ExitCode: $?";'
+                        sh """
+                        if [ -s ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ]; then
+                            mv ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ".kitchen/logs/${python_version}-${distro_name}-${distro_version}-converge.log"
+                        fi
+                        if [ -s ".kitchen/logs/kitchen.log" ]; then
+                            mv ".kitchen/logs/kitchen.log" ".kitchen/logs/kitchen-converge.log"
+                        fi
+                        """
                     }
                     stage('Run Tests') {
                         withEnv(["DONT_DOWNLOAD_ARTEFACTS=1"]) {
@@ -85,14 +101,33 @@ wrappedNode('kitchen-slave', global_timeout, '#jenkins-prod-pr') {
                 }
             } finally {
                 try {
+                    sh """
+                    if [ -s ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ]; then
+                        mv ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ".kitchen/logs/${python_version}-${distro_name}-${distro_version}-verify.log"
+                    fi
+                    if [ -s ".kitchen/logs/kitchen.log" ]; then
+                        mv ".kitchen/logs/kitchen.log" ".kitchen/logs/kitchen-verify.log"
+                    fi
+                    """
                     stage('Download Artefacts') {
                         withEnv(["ONLY_DOWNLOAD_ARTEFACTS=1"]){
                             sh '''
                             bundle exec kitchen verify $TEST_SUITE-$TEST_PLATFORM || exit 0
                             '''
                         }
+                        sh """
+                        if [ -s ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ]; then
+                            mv ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ".kitchen/logs/${python_version}-${distro_name}-${distro_version}-download.log"
+                        fi
+                        if [ -s ".kitchen/logs/kitchen.log" ]; then
+                            mv ".kitchen/logs/kitchen.log" ".kitchen/logs/kitchen-download.log"
+                        fi
+                        """
                     }
-                    archiveArtifacts artifacts: 'artifacts/*,artifacts/**/*,.kitchen/logs/kitchen.log,artifacts/xml-unittests-output/*.xml'
+                    archiveArtifacts(
+                        artifacts: "artifacts/*,artifacts/**/*,.kitchen/logs/*-create.log,.kitchen/logs/*-converge.log,.kitchen/logs/*-verify.log,.kitchen/logs/*-download.log,artifacts/xml-unittests-output/*.xml",
+                        allowEmptyArchive: true
+                    )
                     junit 'artifacts/xml-unittests-output/*.xml'
                 } finally {
                     stage('Cleanup') {

--- a/.ci/kitchen-ubuntu1604-py2
+++ b/.ci/kitchen-ubuntu1604-py2
@@ -67,6 +67,14 @@ wrappedNode('kitchen-slave', global_timeout, '#jenkins-prod-pr') {
                 t=$(shuf -i 30-120 -n 1); echo "Sleeping $t seconds"; sleep $t
                 bundle exec kitchen create $TEST_SUITE-$TEST_PLATFORM; echo "ExitCode: $?";
                 '''
+                sh """
+                if [ -s ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ]; then
+                    mv ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ".kitchen/logs/${python_version}-${distro_name}-${distro_version}-create.log"
+                fi
+                if [ -s ".kitchen/logs/kitchen.log" ]; then
+                    mv ".kitchen/logs/kitchen.log" ".kitchen/logs/kitchen-create.log"
+                fi
+                """
             }
         }
 
@@ -76,6 +84,14 @@ wrappedNode('kitchen-slave', global_timeout, '#jenkins-prod-pr') {
                 timeout(time: testrun_timeout, unit: 'HOURS') {
                     stage('Converge VM') {
                         sh 'bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM; echo "ExitCode: $?";'
+                        sh """
+                        if [ -s ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ]; then
+                            mv ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ".kitchen/logs/${python_version}-${distro_name}-${distro_version}-converge.log"
+                        fi
+                        if [ -s ".kitchen/logs/kitchen.log" ]; then
+                            mv ".kitchen/logs/kitchen.log" ".kitchen/logs/kitchen-converge.log"
+                        fi
+                        """
                     }
                     stage('Run Tests') {
                         withEnv(["DONT_DOWNLOAD_ARTEFACTS=1"]) {
@@ -85,14 +101,33 @@ wrappedNode('kitchen-slave', global_timeout, '#jenkins-prod-pr') {
                 }
             } finally {
                 try {
+                    sh """
+                    if [ -s ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ]; then
+                        mv ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ".kitchen/logs/${python_version}-${distro_name}-${distro_version}-verify.log"
+                    fi
+                    if [ -s ".kitchen/logs/kitchen.log" ]; then
+                        mv ".kitchen/logs/kitchen.log" ".kitchen/logs/kitchen-verify.log"
+                    fi
+                    """
                     stage('Download Artefacts') {
                         withEnv(["ONLY_DOWNLOAD_ARTEFACTS=1"]){
                             sh '''
                             bundle exec kitchen verify $TEST_SUITE-$TEST_PLATFORM || exit 0
                             '''
                         }
+                        sh """
+                        if [ -s ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ]; then
+                            mv ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ".kitchen/logs/${python_version}-${distro_name}-${distro_version}-download.log"
+                        fi
+                        if [ -s ".kitchen/logs/kitchen.log" ]; then
+                            mv ".kitchen/logs/kitchen.log" ".kitchen/logs/kitchen-download.log"
+                        fi
+                        """
                     }
-                    archiveArtifacts artifacts: 'artifacts/*,artifacts/**/*,.kitchen/logs/kitchen.log,artifacts/xml-unittests-output/*.xml'
+                    archiveArtifacts(
+                        artifacts: "artifacts/*,artifacts/**/*,.kitchen/logs/*-create.log,.kitchen/logs/*-converge.log,.kitchen/logs/*-verify.log,.kitchen/logs/*-download.log,artifacts/xml-unittests-output/*.xml",
+                        allowEmptyArchive: true
+                    )
                     junit 'artifacts/xml-unittests-output/*.xml'
                 } finally {
                     stage('Cleanup') {

--- a/.ci/kitchen-ubuntu1604-py2-tcp
+++ b/.ci/kitchen-ubuntu1604-py2-tcp
@@ -67,6 +67,14 @@ wrappedNode('kitchen-slave', global_timeout, '#jenkins-prod-pr') {
                 t=$(shuf -i 30-120 -n 1); echo "Sleeping $t seconds"; sleep $t
                 bundle exec kitchen create $TEST_SUITE-$TEST_PLATFORM; echo "ExitCode: $?";
                 '''
+                sh """
+                if [ -s ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ]; then
+                    mv ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ".kitchen/logs/${python_version}-${distro_name}-${distro_version}-create.log"
+                fi
+                if [ -s ".kitchen/logs/kitchen.log" ]; then
+                    mv ".kitchen/logs/kitchen.log" ".kitchen/logs/kitchen-create.log"
+                fi
+                """
             }
         }
 
@@ -76,6 +84,14 @@ wrappedNode('kitchen-slave', global_timeout, '#jenkins-prod-pr') {
                 timeout(time: testrun_timeout, unit: 'HOURS') {
                     stage('Converge VM') {
                         sh 'bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM; echo "ExitCode: $?";'
+                        sh """
+                        if [ -s ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ]; then
+                            mv ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ".kitchen/logs/${python_version}-${distro_name}-${distro_version}-converge.log"
+                        fi
+                        if [ -s ".kitchen/logs/kitchen.log" ]; then
+                            mv ".kitchen/logs/kitchen.log" ".kitchen/logs/kitchen-converge.log"
+                        fi
+                        """
                     }
                     stage('Run Tests') {
                         withEnv(["DONT_DOWNLOAD_ARTEFACTS=1"]) {
@@ -85,14 +101,33 @@ wrappedNode('kitchen-slave', global_timeout, '#jenkins-prod-pr') {
                 }
             } finally {
                 try {
+                    sh """
+                    if [ -s ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ]; then
+                        mv ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ".kitchen/logs/${python_version}-${distro_name}-${distro_version}-verify.log"
+                    fi
+                    if [ -s ".kitchen/logs/kitchen.log" ]; then
+                        mv ".kitchen/logs/kitchen.log" ".kitchen/logs/kitchen-verify.log"
+                    fi
+                    """
                     stage('Download Artefacts') {
                         withEnv(["ONLY_DOWNLOAD_ARTEFACTS=1"]){
                             sh '''
                             bundle exec kitchen verify $TEST_SUITE-$TEST_PLATFORM || exit 0
                             '''
                         }
+                        sh """
+                        if [ -s ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ]; then
+                            mv ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ".kitchen/logs/${python_version}-${distro_name}-${distro_version}-download.log"
+                        fi
+                        if [ -s ".kitchen/logs/kitchen.log" ]; then
+                            mv ".kitchen/logs/kitchen.log" ".kitchen/logs/kitchen-download.log"
+                        fi
+                        """
                     }
-                    archiveArtifacts artifacts: 'artifacts/*,artifacts/**/*,.kitchen/logs/kitchen.log,artifacts/xml-unittests-output/*.xml'
+                    archiveArtifacts(
+                        artifacts: "artifacts/*,artifacts/**/*,.kitchen/logs/*-create.log,.kitchen/logs/*-converge.log,.kitchen/logs/*-verify.log,.kitchen/logs/*-download.log,artifacts/xml-unittests-output/*.xml",
+                        allowEmptyArchive: true
+                    )
                     junit 'artifacts/xml-unittests-output/*.xml'
                 } finally {
                     stage('Cleanup') {

--- a/.ci/kitchen-ubuntu1604-py3
+++ b/.ci/kitchen-ubuntu1604-py3
@@ -67,6 +67,14 @@ wrappedNode('kitchen-slave', global_timeout, '#jenkins-prod-pr') {
                 t=$(shuf -i 30-120 -n 1); echo "Sleeping $t seconds"; sleep $t
                 bundle exec kitchen create $TEST_SUITE-$TEST_PLATFORM; echo "ExitCode: $?";
                 '''
+                sh """
+                if [ -s ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ]; then
+                    mv ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ".kitchen/logs/${python_version}-${distro_name}-${distro_version}-create.log"
+                fi
+                if [ -s ".kitchen/logs/kitchen.log" ]; then
+                    mv ".kitchen/logs/kitchen.log" ".kitchen/logs/kitchen-create.log"
+                fi
+                """
             }
         }
 
@@ -76,6 +84,14 @@ wrappedNode('kitchen-slave', global_timeout, '#jenkins-prod-pr') {
                 timeout(time: testrun_timeout, unit: 'HOURS') {
                     stage('Converge VM') {
                         sh 'bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM; echo "ExitCode: $?";'
+                        sh """
+                        if [ -s ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ]; then
+                            mv ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ".kitchen/logs/${python_version}-${distro_name}-${distro_version}-converge.log"
+                        fi
+                        if [ -s ".kitchen/logs/kitchen.log" ]; then
+                            mv ".kitchen/logs/kitchen.log" ".kitchen/logs/kitchen-converge.log"
+                        fi
+                        """
                     }
                     stage('Run Tests') {
                         withEnv(["DONT_DOWNLOAD_ARTEFACTS=1"]) {
@@ -85,14 +101,33 @@ wrappedNode('kitchen-slave', global_timeout, '#jenkins-prod-pr') {
                 }
             } finally {
                 try {
+                    sh """
+                    if [ -s ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ]; then
+                        mv ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ".kitchen/logs/${python_version}-${distro_name}-${distro_version}-verify.log"
+                    fi
+                    if [ -s ".kitchen/logs/kitchen.log" ]; then
+                        mv ".kitchen/logs/kitchen.log" ".kitchen/logs/kitchen-verify.log"
+                    fi
+                    """
                     stage('Download Artefacts') {
                         withEnv(["ONLY_DOWNLOAD_ARTEFACTS=1"]){
                             sh '''
                             bundle exec kitchen verify $TEST_SUITE-$TEST_PLATFORM || exit 0
                             '''
                         }
+                        sh """
+                        if [ -s ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ]; then
+                            mv ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ".kitchen/logs/${python_version}-${distro_name}-${distro_version}-download.log"
+                        fi
+                        if [ -s ".kitchen/logs/kitchen.log" ]; then
+                            mv ".kitchen/logs/kitchen.log" ".kitchen/logs/kitchen-download.log"
+                        fi
+                        """
                     }
-                    archiveArtifacts artifacts: 'artifacts/*,artifacts/**/*,.kitchen/logs/kitchen.log,artifacts/xml-unittests-output/*.xml'
+                    archiveArtifacts(
+                        artifacts: "artifacts/*,artifacts/**/*,.kitchen/logs/*-create.log,.kitchen/logs/*-converge.log,.kitchen/logs/*-verify.log,.kitchen/logs/*-download.log,artifacts/xml-unittests-output/*.xml",
+                        allowEmptyArchive: true
+                    )
                     junit 'artifacts/xml-unittests-output/*.xml'
                 } finally {
                     stage('Cleanup') {

--- a/.ci/kitchen-ubuntu1604-py3-tcp
+++ b/.ci/kitchen-ubuntu1604-py3-tcp
@@ -67,6 +67,14 @@ wrappedNode('kitchen-slave', global_timeout, '#jenkins-prod-pr') {
                 t=$(shuf -i 30-120 -n 1); echo "Sleeping $t seconds"; sleep $t
                 bundle exec kitchen create $TEST_SUITE-$TEST_PLATFORM; echo "ExitCode: $?";
                 '''
+                sh """
+                if [ -s ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ]; then
+                    mv ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ".kitchen/logs/${python_version}-${distro_name}-${distro_version}-create.log"
+                fi
+                if [ -s ".kitchen/logs/kitchen.log" ]; then
+                    mv ".kitchen/logs/kitchen.log" ".kitchen/logs/kitchen-create.log"
+                fi
+                """
             }
         }
 
@@ -76,6 +84,14 @@ wrappedNode('kitchen-slave', global_timeout, '#jenkins-prod-pr') {
                 timeout(time: testrun_timeout, unit: 'HOURS') {
                     stage('Converge VM') {
                         sh 'bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM; echo "ExitCode: $?";'
+                        sh """
+                        if [ -s ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ]; then
+                            mv ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ".kitchen/logs/${python_version}-${distro_name}-${distro_version}-converge.log"
+                        fi
+                        if [ -s ".kitchen/logs/kitchen.log" ]; then
+                            mv ".kitchen/logs/kitchen.log" ".kitchen/logs/kitchen-converge.log"
+                        fi
+                        """
                     }
                     stage('Run Tests') {
                         withEnv(["DONT_DOWNLOAD_ARTEFACTS=1"]) {
@@ -85,14 +101,33 @@ wrappedNode('kitchen-slave', global_timeout, '#jenkins-prod-pr') {
                 }
             } finally {
                 try {
+                    sh """
+                    if [ -s ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ]; then
+                        mv ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ".kitchen/logs/${python_version}-${distro_name}-${distro_version}-verify.log"
+                    fi
+                    if [ -s ".kitchen/logs/kitchen.log" ]; then
+                        mv ".kitchen/logs/kitchen.log" ".kitchen/logs/kitchen-verify.log"
+                    fi
+                    """
                     stage('Download Artefacts') {
                         withEnv(["ONLY_DOWNLOAD_ARTEFACTS=1"]){
                             sh '''
                             bundle exec kitchen verify $TEST_SUITE-$TEST_PLATFORM || exit 0
                             '''
                         }
+                        sh """
+                        if [ -s ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ]; then
+                            mv ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ".kitchen/logs/${python_version}-${distro_name}-${distro_version}-download.log"
+                        fi
+                        if [ -s ".kitchen/logs/kitchen.log" ]; then
+                            mv ".kitchen/logs/kitchen.log" ".kitchen/logs/kitchen-download.log"
+                        fi
+                        """
                     }
-                    archiveArtifacts artifacts: 'artifacts/*,artifacts/**/*,.kitchen/logs/kitchen.log,artifacts/xml-unittests-output/*.xml'
+                    archiveArtifacts(
+                        artifacts: "artifacts/*,artifacts/**/*,.kitchen/logs/*-create.log,.kitchen/logs/*-converge.log,.kitchen/logs/*-verify.log,.kitchen/logs/*-download.log,artifacts/xml-unittests-output/*.xml",
+                        allowEmptyArchive: true
+                    )
                     junit 'artifacts/xml-unittests-output/*.xml'
                 } finally {
                     stage('Cleanup') {

--- a/.ci/kitchen-ubuntu1804-py2
+++ b/.ci/kitchen-ubuntu1804-py2
@@ -67,6 +67,14 @@ wrappedNode('kitchen-slave', global_timeout, '#jenkins-prod-pr') {
                 t=$(shuf -i 30-120 -n 1); echo "Sleeping $t seconds"; sleep $t
                 bundle exec kitchen create $TEST_SUITE-$TEST_PLATFORM; echo "ExitCode: $?";
                 '''
+                sh """
+                if [ -s ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ]; then
+                    mv ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ".kitchen/logs/${python_version}-${distro_name}-${distro_version}-create.log"
+                fi
+                if [ -s ".kitchen/logs/kitchen.log" ]; then
+                    mv ".kitchen/logs/kitchen.log" ".kitchen/logs/kitchen-create.log"
+                fi
+                """
             }
         }
 
@@ -76,6 +84,14 @@ wrappedNode('kitchen-slave', global_timeout, '#jenkins-prod-pr') {
                 timeout(time: testrun_timeout, unit: 'HOURS') {
                     stage('Converge VM') {
                         sh 'bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM; echo "ExitCode: $?";'
+                        sh """
+                        if [ -s ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ]; then
+                            mv ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ".kitchen/logs/${python_version}-${distro_name}-${distro_version}-converge.log"
+                        fi
+                        if [ -s ".kitchen/logs/kitchen.log" ]; then
+                            mv ".kitchen/logs/kitchen.log" ".kitchen/logs/kitchen-converge.log"
+                        fi
+                        """
                     }
                     stage('Run Tests') {
                         withEnv(["DONT_DOWNLOAD_ARTEFACTS=1"]) {
@@ -85,14 +101,33 @@ wrappedNode('kitchen-slave', global_timeout, '#jenkins-prod-pr') {
                 }
             } finally {
                 try {
+                    sh """
+                    if [ -s ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ]; then
+                        mv ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ".kitchen/logs/${python_version}-${distro_name}-${distro_version}-verify.log"
+                    fi
+                    if [ -s ".kitchen/logs/kitchen.log" ]; then
+                        mv ".kitchen/logs/kitchen.log" ".kitchen/logs/kitchen-verify.log"
+                    fi
+                    """
                     stage('Download Artefacts') {
                         withEnv(["ONLY_DOWNLOAD_ARTEFACTS=1"]){
                             sh '''
                             bundle exec kitchen verify $TEST_SUITE-$TEST_PLATFORM || exit 0
                             '''
                         }
+                        sh """
+                        if [ -s ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ]; then
+                            mv ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ".kitchen/logs/${python_version}-${distro_name}-${distro_version}-download.log"
+                        fi
+                        if [ -s ".kitchen/logs/kitchen.log" ]; then
+                            mv ".kitchen/logs/kitchen.log" ".kitchen/logs/kitchen-download.log"
+                        fi
+                        """
                     }
-                    archiveArtifacts artifacts: 'artifacts/*,artifacts/**/*,.kitchen/logs/kitchen.log,artifacts/xml-unittests-output/*.xml'
+                    archiveArtifacts(
+                        artifacts: "artifacts/*,artifacts/**/*,.kitchen/logs/*-create.log,.kitchen/logs/*-converge.log,.kitchen/logs/*-verify.log,.kitchen/logs/*-download.log,artifacts/xml-unittests-output/*.xml",
+                        allowEmptyArchive: true
+                    )
                     junit 'artifacts/xml-unittests-output/*.xml'
                 } finally {
                     stage('Cleanup') {

--- a/.ci/kitchen-ubuntu1804-py3
+++ b/.ci/kitchen-ubuntu1804-py3
@@ -67,6 +67,14 @@ wrappedNode('kitchen-slave', global_timeout, '#jenkins-prod-pr') {
                 t=$(shuf -i 30-120 -n 1); echo "Sleeping $t seconds"; sleep $t
                 bundle exec kitchen create $TEST_SUITE-$TEST_PLATFORM; echo "ExitCode: $?";
                 '''
+                sh """
+                if [ -s ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ]; then
+                    mv ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ".kitchen/logs/${python_version}-${distro_name}-${distro_version}-create.log"
+                fi
+                if [ -s ".kitchen/logs/kitchen.log" ]; then
+                    mv ".kitchen/logs/kitchen.log" ".kitchen/logs/kitchen-create.log"
+                fi
+                """
             }
         }
 
@@ -76,6 +84,14 @@ wrappedNode('kitchen-slave', global_timeout, '#jenkins-prod-pr') {
                 timeout(time: testrun_timeout, unit: 'HOURS') {
                     stage('Converge VM') {
                         sh 'bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM; echo "ExitCode: $?";'
+                        sh """
+                        if [ -s ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ]; then
+                            mv ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ".kitchen/logs/${python_version}-${distro_name}-${distro_version}-converge.log"
+                        fi
+                        if [ -s ".kitchen/logs/kitchen.log" ]; then
+                            mv ".kitchen/logs/kitchen.log" ".kitchen/logs/kitchen-converge.log"
+                        fi
+                        """
                     }
                     stage('Run Tests') {
                         withEnv(["DONT_DOWNLOAD_ARTEFACTS=1"]) {
@@ -85,14 +101,33 @@ wrappedNode('kitchen-slave', global_timeout, '#jenkins-prod-pr') {
                 }
             } finally {
                 try {
+                    sh """
+                    if [ -s ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ]; then
+                        mv ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ".kitchen/logs/${python_version}-${distro_name}-${distro_version}-verify.log"
+                    fi
+                    if [ -s ".kitchen/logs/kitchen.log" ]; then
+                        mv ".kitchen/logs/kitchen.log" ".kitchen/logs/kitchen-verify.log"
+                    fi
+                    """
                     stage('Download Artefacts') {
                         withEnv(["ONLY_DOWNLOAD_ARTEFACTS=1"]){
                             sh '''
                             bundle exec kitchen verify $TEST_SUITE-$TEST_PLATFORM || exit 0
                             '''
                         }
+                        sh """
+                        if [ -s ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ]; then
+                            mv ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ".kitchen/logs/${python_version}-${distro_name}-${distro_version}-download.log"
+                        fi
+                        if [ -s ".kitchen/logs/kitchen.log" ]; then
+                            mv ".kitchen/logs/kitchen.log" ".kitchen/logs/kitchen-download.log"
+                        fi
+                        """
                     }
-                    archiveArtifacts artifacts: 'artifacts/*,artifacts/**/*,.kitchen/logs/kitchen.log,artifacts/xml-unittests-output/*.xml'
+                    archiveArtifacts(
+                        artifacts: "artifacts/*,artifacts/**/*,.kitchen/logs/*-create.log,.kitchen/logs/*-converge.log,.kitchen/logs/*-verify.log,.kitchen/logs/*-download.log,artifacts/xml-unittests-output/*.xml",
+                        allowEmptyArchive: true
+                    )
                     junit 'artifacts/xml-unittests-output/*.xml'
                 } finally {
                     stage('Cleanup') {

--- a/.ci/kitchen-windows2016-py2
+++ b/.ci/kitchen-windows2016-py2
@@ -12,7 +12,16 @@ def python_version = 'py2'
 def test_transport = 'ZeroMQ'
 def salt_target_branch = 'neon'
 def golden_images_branch = 'neon'
-def nox_passthrough_opts = '--log-cli-level=warning --ignore=tests/utils'
+
+// While we don't move the Branch job to Pytest
+def nox_passthrough_opts
+def tests_runner = 'runtests'
+
+if (tests_runner == 'runtests') {
+    nox_passthrough_opts = '--unit'
+} else {
+    nox_passthrough_opts = '--log-cli-level=warning --ignore=tests/utils'
+}
 
 properties([
     buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '10')),
@@ -36,7 +45,7 @@ wrappedNode('kitchen-slave', global_timeout, '#jenkins-prod-pr') {
         'SALT_KITCHEN_PLATFORMS=/var/jenkins/workspace/nox-platforms.yml',
         'SALT_KITCHEN_VERIFIER=/var/jenkins/workspace/nox-verifier.yml',
         'SALT_KITCHEN_DRIVER=/var/jenkins/workspace/driver.yml',
-        "NOX_ENV_NAME=pytest-${test_transport.toLowerCase()}",
+        "NOX_ENV_NAME=${tests_runner}-${test_transport.toLowerCase()}",
         'NOX_ENABLE_FROM_FILENAMES=true',
         "NOX_PASSTHROUGH_OPTS=${nox_passthrough_opts}",
         "SALT_TARGET_BRANCH=${salt_target_branch}",

--- a/.ci/kitchen-windows2016-py2
+++ b/.ci/kitchen-windows2016-py2
@@ -67,6 +67,14 @@ wrappedNode('kitchen-slave', global_timeout, '#jenkins-prod-pr') {
                 t=$(shuf -i 30-120 -n 1); echo "Sleeping $t seconds"; sleep $t
                 bundle exec kitchen create $TEST_SUITE-$TEST_PLATFORM; echo "ExitCode: $?";
                 '''
+                sh """
+                if [ -s ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ]; then
+                    mv ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ".kitchen/logs/${python_version}-${distro_name}-${distro_version}-create.log"
+                fi
+                if [ -s ".kitchen/logs/kitchen.log" ]; then
+                    mv ".kitchen/logs/kitchen.log" ".kitchen/logs/kitchen-create.log"
+                fi
+                """
             }
         }
 
@@ -76,6 +84,14 @@ wrappedNode('kitchen-slave', global_timeout, '#jenkins-prod-pr') {
                 timeout(time: testrun_timeout, unit: 'HOURS') {
                     stage('Converge VM') {
                         sh 'bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM; echo "ExitCode: $?";'
+                        sh """
+                        if [ -s ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ]; then
+                            mv ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ".kitchen/logs/${python_version}-${distro_name}-${distro_version}-converge.log"
+                        fi
+                        if [ -s ".kitchen/logs/kitchen.log" ]; then
+                            mv ".kitchen/logs/kitchen.log" ".kitchen/logs/kitchen-converge.log"
+                        fi
+                        """
                     }
                     stage('Run Tests') {
                         withEnv(["DONT_DOWNLOAD_ARTEFACTS=1"]) {
@@ -85,14 +101,33 @@ wrappedNode('kitchen-slave', global_timeout, '#jenkins-prod-pr') {
                 }
             } finally {
                 try {
+                    sh """
+                    if [ -s ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ]; then
+                        mv ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ".kitchen/logs/${python_version}-${distro_name}-${distro_version}-verify.log"
+                    fi
+                    if [ -s ".kitchen/logs/kitchen.log" ]; then
+                        mv ".kitchen/logs/kitchen.log" ".kitchen/logs/kitchen-verify.log"
+                    fi
+                    """
                     stage('Download Artefacts') {
                         withEnv(["ONLY_DOWNLOAD_ARTEFACTS=1"]){
                             sh '''
                             bundle exec kitchen verify $TEST_SUITE-$TEST_PLATFORM || exit 0
                             '''
                         }
+                        sh """
+                        if [ -s ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ]; then
+                            mv ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ".kitchen/logs/${python_version}-${distro_name}-${distro_version}-download.log"
+                        fi
+                        if [ -s ".kitchen/logs/kitchen.log" ]; then
+                            mv ".kitchen/logs/kitchen.log" ".kitchen/logs/kitchen-download.log"
+                        fi
+                        """
                     }
-                    archiveArtifacts artifacts: 'artifacts/*,artifacts/**/*,.kitchen/logs/kitchen.log,artifacts/xml-unittests-output/*.xml'
+                    archiveArtifacts(
+                        artifacts: "artifacts/*,artifacts/**/*,.kitchen/logs/*-create.log,.kitchen/logs/*-converge.log,.kitchen/logs/*-verify.log,.kitchen/logs/*-download.log,artifacts/xml-unittests-output/*.xml",
+                        allowEmptyArchive: true
+                    )
                     junit 'artifacts/xml-unittests-output/*.xml'
                 } finally {
                     stage('Cleanup') {

--- a/.ci/kitchen-windows2016-py3
+++ b/.ci/kitchen-windows2016-py3
@@ -67,6 +67,14 @@ wrappedNode('kitchen-slave', global_timeout, '#jenkins-prod-pr') {
                 t=$(shuf -i 30-120 -n 1); echo "Sleeping $t seconds"; sleep $t
                 bundle exec kitchen create $TEST_SUITE-$TEST_PLATFORM; echo "ExitCode: $?";
                 '''
+                sh """
+                if [ -s ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ]; then
+                    mv ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ".kitchen/logs/${python_version}-${distro_name}-${distro_version}-create.log"
+                fi
+                if [ -s ".kitchen/logs/kitchen.log" ]; then
+                    mv ".kitchen/logs/kitchen.log" ".kitchen/logs/kitchen-create.log"
+                fi
+                """
             }
         }
 
@@ -76,6 +84,14 @@ wrappedNode('kitchen-slave', global_timeout, '#jenkins-prod-pr') {
                 timeout(time: testrun_timeout, unit: 'HOURS') {
                     stage('Converge VM') {
                         sh 'bundle exec kitchen converge $TEST_SUITE-$TEST_PLATFORM; echo "ExitCode: $?";'
+                        sh """
+                        if [ -s ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ]; then
+                            mv ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ".kitchen/logs/${python_version}-${distro_name}-${distro_version}-converge.log"
+                        fi
+                        if [ -s ".kitchen/logs/kitchen.log" ]; then
+                            mv ".kitchen/logs/kitchen.log" ".kitchen/logs/kitchen-converge.log"
+                        fi
+                        """
                     }
                     stage('Run Tests') {
                         withEnv(["DONT_DOWNLOAD_ARTEFACTS=1"]) {
@@ -85,14 +101,33 @@ wrappedNode('kitchen-slave', global_timeout, '#jenkins-prod-pr') {
                 }
             } finally {
                 try {
+                    sh """
+                    if [ -s ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ]; then
+                        mv ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ".kitchen/logs/${python_version}-${distro_name}-${distro_version}-verify.log"
+                    fi
+                    if [ -s ".kitchen/logs/kitchen.log" ]; then
+                        mv ".kitchen/logs/kitchen.log" ".kitchen/logs/kitchen-verify.log"
+                    fi
+                    """
                     stage('Download Artefacts') {
                         withEnv(["ONLY_DOWNLOAD_ARTEFACTS=1"]){
                             sh '''
                             bundle exec kitchen verify $TEST_SUITE-$TEST_PLATFORM || exit 0
                             '''
                         }
+                        sh """
+                        if [ -s ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ]; then
+                            mv ".kitchen/logs/${python_version}-${distro_name}-${distro_version}.log" ".kitchen/logs/${python_version}-${distro_name}-${distro_version}-download.log"
+                        fi
+                        if [ -s ".kitchen/logs/kitchen.log" ]; then
+                            mv ".kitchen/logs/kitchen.log" ".kitchen/logs/kitchen-download.log"
+                        fi
+                        """
                     }
-                    archiveArtifacts artifacts: 'artifacts/*,artifacts/**/*,.kitchen/logs/kitchen.log,artifacts/xml-unittests-output/*.xml'
+                    archiveArtifacts(
+                        artifacts: "artifacts/*,artifacts/**/*,.kitchen/logs/*-create.log,.kitchen/logs/*-converge.log,.kitchen/logs/*-verify.log,.kitchen/logs/*-download.log,artifacts/xml-unittests-output/*.xml",
+                        allowEmptyArchive: true
+                    )
                     junit 'artifacts/xml-unittests-output/*.xml'
                 } finally {
                     stage('Cleanup') {

--- a/.ci/kitchen-windows2016-py3
+++ b/.ci/kitchen-windows2016-py3
@@ -12,7 +12,16 @@ def python_version = 'py3'
 def test_transport = 'ZeroMQ'
 def salt_target_branch = 'neon'
 def golden_images_branch = 'neon'
-def nox_passthrough_opts = '--log-cli-level=warning --ignore=tests/utils'
+
+// While we don't move the Branch job to Pytest
+def nox_passthrough_opts
+def tests_runner = 'runtests'
+
+if (tests_runner == 'runtests') {
+    nox_passthrough_opts = '--unit'
+} else {
+    nox_passthrough_opts = '--log-cli-level=warning --ignore=tests/utils'
+}
 
 properties([
     buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '10')),
@@ -36,7 +45,7 @@ wrappedNode('kitchen-slave', global_timeout, '#jenkins-prod-pr') {
         'SALT_KITCHEN_PLATFORMS=/var/jenkins/workspace/nox-platforms.yml',
         'SALT_KITCHEN_VERIFIER=/var/jenkins/workspace/nox-verifier.yml',
         'SALT_KITCHEN_DRIVER=/var/jenkins/workspace/driver.yml',
-        "NOX_ENV_NAME=pytest-${test_transport.toLowerCase()}",
+        "NOX_ENV_NAME=${tests_runner}-${test_transport.toLowerCase()}",
         'NOX_ENABLE_FROM_FILENAMES=true',
         "NOX_PASSTHROUGH_OPTS=${nox_passthrough_opts}",
         "SALT_TARGET_BRANCH=${salt_target_branch}",

--- a/.ci/lint
+++ b/.ci/lint
@@ -76,6 +76,17 @@ wrappedNode('lint', global_timeout, '#jenkins-prod-pr') {
                                 EC=$?
                                 exit $EC
                                 '''
+                            } else {
+                                // Always lint something so reporting doesn't fail
+                                sh shell_header + '''
+                                eval "$(pyenv init - --no-rehash)"
+                                pyenv shell 2.7.15
+                                EC=254
+                                export PYLINT_REPORT=pylint-report-salt-chg.log
+                                nox -e lint-salt -- salt/ext/__init__.py
+                                EC=$?
+                                exit $EC
+                                '''
                             }
                         }
                     },

--- a/requirements/pytest.txt
+++ b/requirements/pytest.txt
@@ -1,7 +1,7 @@
 # PyTest
 pytest >=4.6.4,<4.7   # PyTest 4.6.x are the last Py2 and Py3 releases
-pytest-salt >= 2019.6.13
+pytest-salt >= 2019.7.20
 #pytest-timeout >= 1.3.3
-pytest-tempdir >= 2018.8.11
+pytest-tempdir >= 2019.7.18
 pytest-helpers-namespace >= 2019.1.8
 pytest-salt-runtests-bridge >= 2019.7.10

--- a/requirements/static/py2.7/zeromq-amzn-2.txt
+++ b/requirements/static/py2.7/zeromq-amzn-2.txt
@@ -90,8 +90,8 @@ pyparsing==2.4.0          # via packaging
 pyserial==3.4             # via junos-eznc
 pytest-helpers-namespace==2019.1.8
 pytest-salt-runtests-bridge==2019.7.10
-pytest-salt==2019.6.13
-pytest-tempdir==2018.8.11
+pytest-salt==2019.7.20
+pytest-tempdir==2019.7.18
 pytest==4.6.4
 python-dateutil==2.8.0    # via botocore, croniter, kubernetes, moto, pylxd
 python-etcd==0.4.5

--- a/requirements/static/py2.7/zeromq-amzn-2018.03.txt
+++ b/requirements/static/py2.7/zeromq-amzn-2018.03.txt
@@ -91,8 +91,8 @@ pyparsing==2.4.0          # via packaging
 pyserial==3.4             # via junos-eznc
 pytest-helpers-namespace==2019.1.8
 pytest-salt-runtests-bridge==2019.7.10
-pytest-salt==2019.6.13
-pytest-tempdir==2018.8.11
+pytest-salt==2019.7.20
+pytest-tempdir==2019.7.18
 pytest==4.6.4
 python-dateutil==2.8.0    # via botocore, croniter, kubernetes, moto, pylxd
 python-etcd==0.4.5

--- a/requirements/static/py2.7/zeromq-arch.txt
+++ b/requirements/static/py2.7/zeromq-arch.txt
@@ -85,8 +85,8 @@ pyopenssl==19.0.0
 pyparsing==2.4.0          # via packaging
 pytest-helpers-namespace==2019.1.8
 pytest-salt-runtests-bridge==2019.7.10
-pytest-salt==2019.6.13
-pytest-tempdir==2018.8.11
+pytest-salt==2019.7.20
+pytest-tempdir==2019.7.18
 pytest==4.6.4
 python-dateutil==2.8.0    # via botocore, croniter, kubernetes, moto, pylxd
 python-etcd==0.4.5

--- a/requirements/static/py2.7/zeromq-centos-6.txt
+++ b/requirements/static/py2.7/zeromq-centos-6.txt
@@ -91,8 +91,8 @@ pyparsing==2.4.0          # via packaging
 pyserial==3.4             # via junos-eznc
 pytest-helpers-namespace==2019.1.8
 pytest-salt-runtests-bridge==2019.7.10
-pytest-salt==2019.6.13
-pytest-tempdir==2018.8.11
+pytest-salt==2019.7.20
+pytest-tempdir==2019.7.18
 pytest==4.6.4
 python-dateutil==2.8.0    # via botocore, croniter, kubernetes, moto, pylxd
 python-etcd==0.4.5

--- a/requirements/static/py2.7/zeromq-centos-7.txt
+++ b/requirements/static/py2.7/zeromq-centos-7.txt
@@ -90,8 +90,8 @@ pyparsing==2.4.0          # via packaging
 pyserial==3.4             # via junos-eznc
 pytest-helpers-namespace==2019.1.8
 pytest-salt-runtests-bridge==2019.7.10
-pytest-salt==2019.6.13
-pytest-tempdir==2018.8.11
+pytest-salt==2019.7.20
+pytest-tempdir==2019.7.18
 pytest==4.6.4
 python-dateutil==2.8.0    # via botocore, croniter, kubernetes, moto, pylxd
 python-etcd==0.4.5

--- a/requirements/static/py2.7/zeromq-debian-8.txt
+++ b/requirements/static/py2.7/zeromq-debian-8.txt
@@ -89,8 +89,8 @@ pyparsing==2.4.0          # via packaging
 pyserial==3.4             # via junos-eznc
 pytest-helpers-namespace==2019.1.8
 pytest-salt-runtests-bridge==2019.7.10
-pytest-salt==2019.6.13
-pytest-tempdir==2018.8.11
+pytest-salt==2019.7.20
+pytest-tempdir==2019.7.18
 pytest==4.6.4
 python-dateutil==2.8.0    # via botocore, croniter, kubernetes, moto, pylxd
 python-etcd==0.4.5

--- a/requirements/static/py2.7/zeromq-debian-9.txt
+++ b/requirements/static/py2.7/zeromq-debian-9.txt
@@ -89,8 +89,8 @@ pyparsing==2.4.0          # via packaging
 pyserial==3.4             # via junos-eznc
 pytest-helpers-namespace==2019.1.8
 pytest-salt-runtests-bridge==2019.7.10
-pytest-salt==2019.6.13
-pytest-tempdir==2018.8.11
+pytest-salt==2019.7.20
+pytest-tempdir==2019.7.18
 pytest==4.6.4
 python-dateutil==2.8.0    # via botocore, croniter, kubernetes, moto, pylxd
 python-etcd==0.4.5

--- a/requirements/static/py2.7/zeromq-fedora-29.txt
+++ b/requirements/static/py2.7/zeromq-fedora-29.txt
@@ -91,8 +91,8 @@ pyparsing==2.4.0          # via packaging
 pyserial==3.4             # via junos-eznc
 pytest-helpers-namespace==2019.1.8
 pytest-salt-runtests-bridge==2019.7.10
-pytest-salt==2019.6.13
-pytest-tempdir==2018.8.11
+pytest-salt==2019.7.20
+pytest-tempdir==2019.7.18
 pytest==4.6.4
 python-dateutil==2.8.0    # via botocore, croniter, kubernetes, moto, pylxd
 python-etcd==0.4.5

--- a/requirements/static/py2.7/zeromq-fedora-30.txt
+++ b/requirements/static/py2.7/zeromq-fedora-30.txt
@@ -91,8 +91,8 @@ pyparsing==2.4.0          # via packaging
 pyserial==3.4             # via junos-eznc
 pytest-helpers-namespace==2019.1.8
 pytest-salt-runtests-bridge==2019.7.10
-pytest-salt==2019.6.13
-pytest-tempdir==2018.8.11
+pytest-salt==2019.7.20
+pytest-tempdir==2019.7.18
 pytest==4.6.4
 python-dateutil==2.8.0    # via botocore, croniter, kubernetes, moto, pylxd
 python-etcd==0.4.5

--- a/requirements/static/py2.7/zeromq-opensuse-leap-15.txt
+++ b/requirements/static/py2.7/zeromq-opensuse-leap-15.txt
@@ -86,8 +86,8 @@ pyopenssl==19.0.0
 pyparsing==2.4.0          # via packaging
 pytest-helpers-namespace==2019.1.8
 pytest-salt-runtests-bridge==2019.7.10
-pytest-salt==2019.6.13
-pytest-tempdir==2018.8.11
+pytest-salt==2019.7.20
+pytest-tempdir==2019.7.18
 pytest==4.6.4
 python-dateutil==2.8.0    # via botocore, croniter, kubernetes, moto, pylxd
 python-etcd==0.4.5

--- a/requirements/static/py2.7/zeromq-osx.txt
+++ b/requirements/static/py2.7/zeromq-osx.txt
@@ -93,8 +93,8 @@ pyparsing==2.4.0          # via packaging
 pyserial==3.4             # via junos-eznc
 pytest-helpers-namespace==2019.1.8
 pytest-salt-runtests-bridge==2019.7.10
-pytest-salt==2019.6.13
-pytest-tempdir==2018.8.11
+pytest-salt==2019.7.20
+pytest-tempdir==2019.7.18
 pytest==4.6.4
 python-dateutil==2.8.0
 python-etcd==0.4.5

--- a/requirements/static/py2.7/zeromq-ubuntu-16.04.txt
+++ b/requirements/static/py2.7/zeromq-ubuntu-16.04.txt
@@ -89,8 +89,8 @@ pyparsing==2.4.0          # via packaging
 pyserial==3.4             # via junos-eznc
 pytest-helpers-namespace==2019.1.8
 pytest-salt-runtests-bridge==2019.7.10
-pytest-salt==2019.6.13
-pytest-tempdir==2018.8.11
+pytest-salt==2019.7.20
+pytest-tempdir==2019.7.18
 pytest==4.6.4
 python-dateutil==2.8.0    # via botocore, croniter, kubernetes, moto, pylxd
 python-etcd==0.4.5

--- a/requirements/static/py2.7/zeromq-ubuntu-18.04.txt
+++ b/requirements/static/py2.7/zeromq-ubuntu-18.04.txt
@@ -89,8 +89,8 @@ pyparsing==2.4.0          # via packaging
 pyserial==3.4             # via junos-eznc
 pytest-helpers-namespace==2019.1.8
 pytest-salt-runtests-bridge==2019.7.10
-pytest-salt==2019.6.13
-pytest-tempdir==2018.8.11
+pytest-salt==2019.7.20
+pytest-tempdir==2019.7.18
 pytest==4.6.4
 python-dateutil==2.8.0    # via botocore, croniter, kubernetes, moto, pylxd
 python-etcd==0.4.5

--- a/requirements/static/py2.7/zeromq-windows.txt
+++ b/requirements/static/py2.7/zeromq-windows.txt
@@ -86,8 +86,8 @@ pyopenssl==19.0.0
 pyparsing==2.4.0          # via packaging
 pytest-helpers-namespace==2019.1.8
 pytest-salt-runtests-bridge==2019.7.10
-pytest-salt==2019.6.13
-pytest-tempdir==2018.8.11
+pytest-salt==2019.7.20
+pytest-tempdir==2019.7.18
 pytest==4.6.4
 python-dateutil==2.8.0
 python-etcd==0.4.5

--- a/requirements/static/py3.4/zeromq-amzn-2.txt
+++ b/requirements/static/py3.4/zeromq-amzn-2.txt
@@ -80,8 +80,8 @@ pyparsing==2.4.0          # via packaging
 pyserial==3.4             # via junos-eznc
 pytest-helpers-namespace==2019.1.8
 pytest-salt-runtests-bridge==2019.7.10
-pytest-salt==2019.6.13
-pytest-tempdir==2018.8.11
+pytest-salt==2019.7.20
+pytest-tempdir==2019.7.18
 pytest==4.6.4
 python-dateutil==2.8.0    # via botocore, croniter, kubernetes, moto, pylxd
 python-etcd==0.4.5

--- a/requirements/static/py3.4/zeromq-arch.txt
+++ b/requirements/static/py3.4/zeromq-arch.txt
@@ -72,8 +72,8 @@ pyopenssl==19.0.0
 pyparsing==2.4.0          # via packaging
 pytest-helpers-namespace==2019.1.8
 pytest-salt-runtests-bridge==2019.7.10
-pytest-salt==2019.6.13
-pytest-tempdir==2018.8.11
+pytest-salt==2019.7.20
+pytest-tempdir==2019.7.18
 pytest==4.6.4
 python-dateutil==2.8.0    # via botocore, croniter, kubernetes, moto, pylxd
 python-etcd==0.4.5

--- a/requirements/static/py3.4/zeromq-centos-7.txt
+++ b/requirements/static/py3.4/zeromq-centos-7.txt
@@ -80,8 +80,8 @@ pyparsing==2.4.0          # via packaging
 pyserial==3.4             # via junos-eznc
 pytest-helpers-namespace==2019.1.8
 pytest-salt-runtests-bridge==2019.7.10
-pytest-salt==2019.6.13
-pytest-tempdir==2018.8.11
+pytest-salt==2019.7.20
+pytest-tempdir==2019.7.18
 pytest==4.6.4
 python-dateutil==2.8.0    # via botocore, croniter, kubernetes, moto, pylxd
 python-etcd==0.4.5

--- a/requirements/static/py3.4/zeromq-debian-8.txt
+++ b/requirements/static/py3.4/zeromq-debian-8.txt
@@ -79,8 +79,8 @@ pyparsing==2.4.0          # via packaging
 pyserial==3.4             # via junos-eznc
 pytest-helpers-namespace==2019.1.8
 pytest-salt-runtests-bridge==2019.7.10
-pytest-salt==2019.6.13
-pytest-tempdir==2018.8.11
+pytest-salt==2019.7.20
+pytest-tempdir==2019.7.18
 pytest==4.6.4
 python-dateutil==2.8.0    # via botocore, croniter, kubernetes, moto, pylxd
 python-etcd==0.4.5

--- a/requirements/static/py3.4/zeromq-debian-9.txt
+++ b/requirements/static/py3.4/zeromq-debian-9.txt
@@ -79,8 +79,8 @@ pyparsing==2.4.0          # via packaging
 pyserial==3.4             # via junos-eznc
 pytest-helpers-namespace==2019.1.8
 pytest-salt-runtests-bridge==2019.7.10
-pytest-salt==2019.6.13
-pytest-tempdir==2018.8.11
+pytest-salt==2019.7.20
+pytest-tempdir==2019.7.18
 pytest==4.6.4
 python-dateutil==2.8.0    # via botocore, croniter, kubernetes, moto, pylxd
 python-etcd==0.4.5

--- a/requirements/static/py3.4/zeromq-fedora-29.txt
+++ b/requirements/static/py3.4/zeromq-fedora-29.txt
@@ -81,8 +81,8 @@ pyparsing==2.4.0          # via packaging
 pyserial==3.4             # via junos-eznc
 pytest-helpers-namespace==2019.1.8
 pytest-salt-runtests-bridge==2019.7.10
-pytest-salt==2019.6.13
-pytest-tempdir==2018.8.11
+pytest-salt==2019.7.20
+pytest-tempdir==2019.7.18
 pytest==4.6.4
 python-dateutil==2.8.0    # via botocore, croniter, kubernetes, moto, pylxd
 python-etcd==0.4.5

--- a/requirements/static/py3.4/zeromq-fedora-30.txt
+++ b/requirements/static/py3.4/zeromq-fedora-30.txt
@@ -81,8 +81,8 @@ pyparsing==2.4.0          # via packaging
 pyserial==3.4             # via junos-eznc
 pytest-helpers-namespace==2019.1.8
 pytest-salt-runtests-bridge==2019.7.10
-pytest-salt==2019.6.13
-pytest-tempdir==2018.8.11
+pytest-salt==2019.7.20
+pytest-tempdir==2019.7.18
 pytest==4.6.4
 python-dateutil==2.8.0    # via botocore, croniter, kubernetes, moto, pylxd
 python-etcd==0.4.5

--- a/requirements/static/py3.4/zeromq-opensuse-leap-15.txt
+++ b/requirements/static/py3.4/zeromq-opensuse-leap-15.txt
@@ -73,8 +73,8 @@ pyopenssl==19.0.0
 pyparsing==2.4.0          # via packaging
 pytest-helpers-namespace==2019.1.8
 pytest-salt-runtests-bridge==2019.7.10
-pytest-salt==2019.6.13
-pytest-tempdir==2018.8.11
+pytest-salt==2019.7.20
+pytest-tempdir==2019.7.18
 pytest==4.6.4
 python-dateutil==2.8.0    # via botocore, croniter, kubernetes, moto, pylxd
 python-etcd==0.4.5

--- a/requirements/static/py3.4/zeromq-ubuntu-16.04.txt
+++ b/requirements/static/py3.4/zeromq-ubuntu-16.04.txt
@@ -79,8 +79,8 @@ pyparsing==2.4.0          # via packaging
 pyserial==3.4             # via junos-eznc
 pytest-helpers-namespace==2019.1.8
 pytest-salt-runtests-bridge==2019.7.10
-pytest-salt==2019.6.13
-pytest-tempdir==2018.8.11
+pytest-salt==2019.7.20
+pytest-tempdir==2019.7.18
 pytest==4.6.4
 python-dateutil==2.8.0    # via botocore, croniter, kubernetes, moto, pylxd
 python-etcd==0.4.5

--- a/requirements/static/py3.4/zeromq-ubuntu-18.04.txt
+++ b/requirements/static/py3.4/zeromq-ubuntu-18.04.txt
@@ -79,8 +79,8 @@ pyparsing==2.4.0          # via packaging
 pyserial==3.4             # via junos-eznc
 pytest-helpers-namespace==2019.1.8
 pytest-salt-runtests-bridge==2019.7.10
-pytest-salt==2019.6.13
-pytest-tempdir==2018.8.11
+pytest-salt==2019.7.20
+pytest-tempdir==2019.7.18
 pytest==4.6.4
 python-dateutil==2.8.0    # via botocore, croniter, kubernetes, moto, pylxd
 python-etcd==0.4.5

--- a/requirements/static/py3.5/zeromq-amzn-2.txt
+++ b/requirements/static/py3.5/zeromq-amzn-2.txt
@@ -80,8 +80,8 @@ pyparsing==2.4.0          # via packaging
 pyserial==3.4             # via junos-eznc
 pytest-helpers-namespace==2019.1.8
 pytest-salt-runtests-bridge==2019.7.10
-pytest-salt==2019.6.13
-pytest-tempdir==2018.8.11
+pytest-salt==2019.7.20
+pytest-tempdir==2019.7.18
 pytest==4.6.4
 python-dateutil==2.8.0    # via botocore, croniter, kubernetes, moto, pylxd
 python-etcd==0.4.5

--- a/requirements/static/py3.5/zeromq-arch.txt
+++ b/requirements/static/py3.5/zeromq-arch.txt
@@ -72,8 +72,8 @@ pyopenssl==19.0.0
 pyparsing==2.4.0          # via packaging
 pytest-helpers-namespace==2019.1.8
 pytest-salt-runtests-bridge==2019.7.10
-pytest-salt==2019.6.13
-pytest-tempdir==2018.8.11
+pytest-salt==2019.7.20
+pytest-tempdir==2019.7.18
 pytest==4.6.4
 python-dateutil==2.8.0    # via botocore, croniter, kubernetes, moto, pylxd
 python-etcd==0.4.5

--- a/requirements/static/py3.5/zeromq-centos-7.txt
+++ b/requirements/static/py3.5/zeromq-centos-7.txt
@@ -80,8 +80,8 @@ pyparsing==2.4.0          # via packaging
 pyserial==3.4             # via junos-eznc
 pytest-helpers-namespace==2019.1.8
 pytest-salt-runtests-bridge==2019.7.10
-pytest-salt==2019.6.13
-pytest-tempdir==2018.8.11
+pytest-salt==2019.7.20
+pytest-tempdir==2019.7.18
 pytest==4.6.4
 python-dateutil==2.8.0    # via botocore, croniter, kubernetes, moto, pylxd
 python-etcd==0.4.5

--- a/requirements/static/py3.5/zeromq-debian-8.txt
+++ b/requirements/static/py3.5/zeromq-debian-8.txt
@@ -79,8 +79,8 @@ pyparsing==2.4.0          # via packaging
 pyserial==3.4             # via junos-eznc
 pytest-helpers-namespace==2019.1.8
 pytest-salt-runtests-bridge==2019.7.10
-pytest-salt==2019.6.13
-pytest-tempdir==2018.8.11
+pytest-salt==2019.7.20
+pytest-tempdir==2019.7.18
 pytest==4.6.4
 python-dateutil==2.8.0    # via botocore, croniter, kubernetes, moto, pylxd
 python-etcd==0.4.5

--- a/requirements/static/py3.5/zeromq-debian-9.txt
+++ b/requirements/static/py3.5/zeromq-debian-9.txt
@@ -79,8 +79,8 @@ pyparsing==2.4.0          # via packaging
 pyserial==3.4             # via junos-eznc
 pytest-helpers-namespace==2019.1.8
 pytest-salt-runtests-bridge==2019.7.10
-pytest-salt==2019.6.13
-pytest-tempdir==2018.8.11
+pytest-salt==2019.7.20
+pytest-tempdir==2019.7.18
 pytest==4.6.4
 python-dateutil==2.8.0    # via botocore, croniter, kubernetes, moto, pylxd
 python-etcd==0.4.5

--- a/requirements/static/py3.5/zeromq-fedora-29.txt
+++ b/requirements/static/py3.5/zeromq-fedora-29.txt
@@ -81,8 +81,8 @@ pyparsing==2.4.0          # via packaging
 pyserial==3.4             # via junos-eznc
 pytest-helpers-namespace==2019.1.8
 pytest-salt-runtests-bridge==2019.7.10
-pytest-salt==2019.6.13
-pytest-tempdir==2018.8.11
+pytest-salt==2019.7.20
+pytest-tempdir==2019.7.18
 pytest==4.6.4
 python-dateutil==2.8.0    # via botocore, croniter, kubernetes, moto, pylxd
 python-etcd==0.4.5

--- a/requirements/static/py3.5/zeromq-fedora-30.txt
+++ b/requirements/static/py3.5/zeromq-fedora-30.txt
@@ -81,8 +81,8 @@ pyparsing==2.4.0          # via packaging
 pyserial==3.4             # via junos-eznc
 pytest-helpers-namespace==2019.1.8
 pytest-salt-runtests-bridge==2019.7.10
-pytest-salt==2019.6.13
-pytest-tempdir==2018.8.11
+pytest-salt==2019.7.20
+pytest-tempdir==2019.7.18
 pytest==4.6.4
 python-dateutil==2.8.0    # via botocore, croniter, kubernetes, moto, pylxd
 python-etcd==0.4.5

--- a/requirements/static/py3.5/zeromq-opensuse-leap-15.txt
+++ b/requirements/static/py3.5/zeromq-opensuse-leap-15.txt
@@ -73,8 +73,8 @@ pyopenssl==19.0.0
 pyparsing==2.4.0          # via packaging
 pytest-helpers-namespace==2019.1.8
 pytest-salt-runtests-bridge==2019.7.10
-pytest-salt==2019.6.13
-pytest-tempdir==2018.8.11
+pytest-salt==2019.7.20
+pytest-tempdir==2019.7.18
 pytest==4.6.4
 python-dateutil==2.8.0    # via botocore, croniter, kubernetes, moto, pylxd
 python-etcd==0.4.5

--- a/requirements/static/py3.5/zeromq-osx.txt
+++ b/requirements/static/py3.5/zeromq-osx.txt
@@ -85,8 +85,8 @@ pyparsing==2.4.0          # via packaging
 pyserial==3.4             # via junos-eznc
 pytest-helpers-namespace==2019.1.8
 pytest-salt-runtests-bridge==2019.7.10
-pytest-salt==2019.6.13
-pytest-tempdir==2018.8.11
+pytest-salt==2019.7.20
+pytest-tempdir==2019.7.18
 pytest==4.6.4
 python-dateutil==2.8.0
 python-etcd==0.4.5

--- a/requirements/static/py3.5/zeromq-ubuntu-16.04.txt
+++ b/requirements/static/py3.5/zeromq-ubuntu-16.04.txt
@@ -79,8 +79,8 @@ pyparsing==2.4.0          # via packaging
 pyserial==3.4             # via junos-eznc
 pytest-helpers-namespace==2019.1.8
 pytest-salt-runtests-bridge==2019.7.10
-pytest-salt==2019.6.13
-pytest-tempdir==2018.8.11
+pytest-salt==2019.7.20
+pytest-tempdir==2019.7.18
 pytest==4.6.4
 python-dateutil==2.8.0    # via botocore, croniter, kubernetes, moto, pylxd
 python-etcd==0.4.5

--- a/requirements/static/py3.5/zeromq-ubuntu-18.04.txt
+++ b/requirements/static/py3.5/zeromq-ubuntu-18.04.txt
@@ -79,8 +79,8 @@ pyparsing==2.4.0          # via packaging
 pyserial==3.4             # via junos-eznc
 pytest-helpers-namespace==2019.1.8
 pytest-salt-runtests-bridge==2019.7.10
-pytest-salt==2019.6.13
-pytest-tempdir==2018.8.11
+pytest-salt==2019.7.20
+pytest-tempdir==2019.7.18
 pytest==4.6.4
 python-dateutil==2.8.0    # via botocore, croniter, kubernetes, moto, pylxd
 python-etcd==0.4.5

--- a/requirements/static/py3.5/zeromq-windows.txt
+++ b/requirements/static/py3.5/zeromq-windows.txt
@@ -78,8 +78,8 @@ pyopenssl==19.0.0
 pyparsing==2.4.0          # via packaging
 pytest-helpers-namespace==2019.1.8
 pytest-salt-runtests-bridge==2019.7.10
-pytest-salt==2019.6.13
-pytest-tempdir==2018.8.11
+pytest-salt==2019.7.20
+pytest-tempdir==2019.7.18
 pytest==4.6.4
 python-dateutil==2.8.0
 python-etcd==0.4.5

--- a/requirements/static/py3.6/zeromq-amzn-2.txt
+++ b/requirements/static/py3.6/zeromq-amzn-2.txt
@@ -79,8 +79,8 @@ pyparsing==2.4.0          # via packaging
 pyserial==3.4             # via junos-eznc
 pytest-helpers-namespace==2019.1.8
 pytest-salt-runtests-bridge==2019.7.10
-pytest-salt==2019.6.13
-pytest-tempdir==2018.8.11
+pytest-salt==2019.7.20
+pytest-tempdir==2019.7.18
 pytest==4.6.4
 python-dateutil==2.8.0    # via botocore, croniter, kubernetes, moto, pylxd
 python-etcd==0.4.5

--- a/requirements/static/py3.6/zeromq-arch.txt
+++ b/requirements/static/py3.6/zeromq-arch.txt
@@ -71,8 +71,8 @@ pyopenssl==19.0.0
 pyparsing==2.4.0          # via packaging
 pytest-helpers-namespace==2019.1.8
 pytest-salt-runtests-bridge==2019.7.10
-pytest-salt==2019.6.13
-pytest-tempdir==2018.8.11
+pytest-salt==2019.7.20
+pytest-tempdir==2019.7.18
 pytest==4.6.4
 python-dateutil==2.8.0    # via botocore, croniter, kubernetes, moto, pylxd
 python-etcd==0.4.5

--- a/requirements/static/py3.6/zeromq-centos-7.txt
+++ b/requirements/static/py3.6/zeromq-centos-7.txt
@@ -79,8 +79,8 @@ pyparsing==2.4.0          # via packaging
 pyserial==3.4             # via junos-eznc
 pytest-helpers-namespace==2019.1.8
 pytest-salt-runtests-bridge==2019.7.10
-pytest-salt==2019.6.13
-pytest-tempdir==2018.8.11
+pytest-salt==2019.7.20
+pytest-tempdir==2019.7.18
 pytest==4.6.4
 python-dateutil==2.8.0    # via botocore, croniter, kubernetes, moto, pylxd
 python-etcd==0.4.5

--- a/requirements/static/py3.6/zeromq-debian-8.txt
+++ b/requirements/static/py3.6/zeromq-debian-8.txt
@@ -78,8 +78,8 @@ pyparsing==2.4.0          # via packaging
 pyserial==3.4             # via junos-eznc
 pytest-helpers-namespace==2019.1.8
 pytest-salt-runtests-bridge==2019.7.10
-pytest-salt==2019.6.13
-pytest-tempdir==2018.8.11
+pytest-salt==2019.7.20
+pytest-tempdir==2019.7.18
 pytest==4.6.4
 python-dateutil==2.8.0    # via botocore, croniter, kubernetes, moto, pylxd
 python-etcd==0.4.5

--- a/requirements/static/py3.6/zeromq-debian-9.txt
+++ b/requirements/static/py3.6/zeromq-debian-9.txt
@@ -78,8 +78,8 @@ pyparsing==2.4.0          # via packaging
 pyserial==3.4             # via junos-eznc
 pytest-helpers-namespace==2019.1.8
 pytest-salt-runtests-bridge==2019.7.10
-pytest-salt==2019.6.13
-pytest-tempdir==2018.8.11
+pytest-salt==2019.7.20
+pytest-tempdir==2019.7.18
 pytest==4.6.4
 python-dateutil==2.8.0    # via botocore, croniter, kubernetes, moto, pylxd
 python-etcd==0.4.5

--- a/requirements/static/py3.6/zeromq-fedora-29.txt
+++ b/requirements/static/py3.6/zeromq-fedora-29.txt
@@ -80,8 +80,8 @@ pyparsing==2.4.0          # via packaging
 pyserial==3.4             # via junos-eznc
 pytest-helpers-namespace==2019.1.8
 pytest-salt-runtests-bridge==2019.7.10
-pytest-salt==2019.6.13
-pytest-tempdir==2018.8.11
+pytest-salt==2019.7.20
+pytest-tempdir==2019.7.18
 pytest==4.6.4
 python-dateutil==2.8.0    # via botocore, croniter, kubernetes, moto, pylxd
 python-etcd==0.4.5

--- a/requirements/static/py3.6/zeromq-fedora-30.txt
+++ b/requirements/static/py3.6/zeromq-fedora-30.txt
@@ -80,8 +80,8 @@ pyparsing==2.4.0          # via packaging
 pyserial==3.4             # via junos-eznc
 pytest-helpers-namespace==2019.1.8
 pytest-salt-runtests-bridge==2019.7.10
-pytest-salt==2019.6.13
-pytest-tempdir==2018.8.11
+pytest-salt==2019.7.20
+pytest-tempdir==2019.7.18
 pytest==4.6.4
 python-dateutil==2.8.0    # via botocore, croniter, kubernetes, moto, pylxd
 python-etcd==0.4.5

--- a/requirements/static/py3.6/zeromq-opensuse-leap-15.txt
+++ b/requirements/static/py3.6/zeromq-opensuse-leap-15.txt
@@ -72,8 +72,8 @@ pyopenssl==19.0.0
 pyparsing==2.4.0          # via packaging
 pytest-helpers-namespace==2019.1.8
 pytest-salt-runtests-bridge==2019.7.10
-pytest-salt==2019.6.13
-pytest-tempdir==2018.8.11
+pytest-salt==2019.7.20
+pytest-tempdir==2019.7.18
 pytest==4.6.4
 python-dateutil==2.8.0    # via botocore, croniter, kubernetes, moto, pylxd
 python-etcd==0.4.5

--- a/requirements/static/py3.6/zeromq-osx.txt
+++ b/requirements/static/py3.6/zeromq-osx.txt
@@ -84,8 +84,8 @@ pyparsing==2.4.0          # via packaging
 pyserial==3.4             # via junos-eznc
 pytest-helpers-namespace==2019.1.8
 pytest-salt-runtests-bridge==2019.7.10
-pytest-salt==2019.6.13
-pytest-tempdir==2018.8.11
+pytest-salt==2019.7.20
+pytest-tempdir==2019.7.18
 pytest==4.6.4
 python-dateutil==2.8.0
 python-etcd==0.4.5

--- a/requirements/static/py3.6/zeromq-ubuntu-16.04.txt
+++ b/requirements/static/py3.6/zeromq-ubuntu-16.04.txt
@@ -78,8 +78,8 @@ pyparsing==2.4.0          # via packaging
 pyserial==3.4             # via junos-eznc
 pytest-helpers-namespace==2019.1.8
 pytest-salt-runtests-bridge==2019.7.10
-pytest-salt==2019.6.13
-pytest-tempdir==2018.8.11
+pytest-salt==2019.7.20
+pytest-tempdir==2019.7.18
 pytest==4.6.4
 python-dateutil==2.8.0    # via botocore, croniter, kubernetes, moto, pylxd
 python-etcd==0.4.5

--- a/requirements/static/py3.6/zeromq-ubuntu-18.04.txt
+++ b/requirements/static/py3.6/zeromq-ubuntu-18.04.txt
@@ -78,8 +78,8 @@ pyparsing==2.4.0          # via packaging
 pyserial==3.4             # via junos-eznc
 pytest-helpers-namespace==2019.1.8
 pytest-salt-runtests-bridge==2019.7.10
-pytest-salt==2019.6.13
-pytest-tempdir==2018.8.11
+pytest-salt==2019.7.20
+pytest-tempdir==2019.7.18
 pytest==4.6.4
 python-dateutil==2.8.0    # via botocore, croniter, kubernetes, moto, pylxd
 python-etcd==0.4.5

--- a/requirements/static/py3.6/zeromq-windows.txt
+++ b/requirements/static/py3.6/zeromq-windows.txt
@@ -77,8 +77,8 @@ pyopenssl==19.0.0
 pyparsing==2.4.0          # via packaging
 pytest-helpers-namespace==2019.1.8
 pytest-salt-runtests-bridge==2019.7.10
-pytest-salt==2019.6.13
-pytest-tempdir==2018.8.11
+pytest-salt==2019.7.20
+pytest-tempdir==2019.7.18
 pytest==4.6.4
 python-dateutil==2.8.0
 python-etcd==0.4.5

--- a/requirements/static/py3.7/zeromq-amzn-2.txt
+++ b/requirements/static/py3.7/zeromq-amzn-2.txt
@@ -81,8 +81,8 @@ pyparsing==2.4.0          # via packaging
 pyserial==3.4             # via junos-eznc
 pytest-helpers-namespace==2019.1.8
 pytest-salt-runtests-bridge==2019.7.10
-pytest-salt==2019.6.13
-pytest-tempdir==2018.8.11
+pytest-salt==2019.7.20
+pytest-tempdir==2019.7.18
 pytest==4.6.4
 python-dateutil==2.8.0    # via botocore, croniter, kubernetes, moto, pylxd
 python-etcd==0.4.5

--- a/requirements/static/py3.7/zeromq-arch.txt
+++ b/requirements/static/py3.7/zeromq-arch.txt
@@ -71,8 +71,8 @@ pyopenssl==19.0.0
 pyparsing==2.4.0          # via packaging
 pytest-helpers-namespace==2019.1.8
 pytest-salt-runtests-bridge==2019.7.10
-pytest-salt==2019.6.13
-pytest-tempdir==2018.8.11
+pytest-salt==2019.7.20
+pytest-tempdir==2019.7.18
 pytest==4.6.4
 python-dateutil==2.8.0    # via botocore, croniter, kubernetes, moto, pylxd
 python-etcd==0.4.5

--- a/requirements/static/py3.7/zeromq-centos-7.txt
+++ b/requirements/static/py3.7/zeromq-centos-7.txt
@@ -81,8 +81,8 @@ pyparsing==2.4.0          # via packaging
 pyserial==3.4             # via junos-eznc
 pytest-helpers-namespace==2019.1.8
 pytest-salt-runtests-bridge==2019.7.10
-pytest-salt==2019.6.13
-pytest-tempdir==2018.8.11
+pytest-salt==2019.7.20
+pytest-tempdir==2019.7.18
 pytest==4.6.4
 python-dateutil==2.8.0    # via botocore, croniter, kubernetes, moto, pylxd
 python-etcd==0.4.5

--- a/requirements/static/py3.7/zeromq-debian-8.txt
+++ b/requirements/static/py3.7/zeromq-debian-8.txt
@@ -80,8 +80,8 @@ pyparsing==2.4.0          # via packaging
 pyserial==3.4             # via junos-eznc
 pytest-helpers-namespace==2019.1.8
 pytest-salt-runtests-bridge==2019.7.10
-pytest-salt==2019.6.13
-pytest-tempdir==2018.8.11
+pytest-salt==2019.7.20
+pytest-tempdir==2019.7.18
 pytest==4.6.4
 python-dateutil==2.8.0    # via botocore, croniter, kubernetes, moto, pylxd
 python-etcd==0.4.5

--- a/requirements/static/py3.7/zeromq-debian-9.txt
+++ b/requirements/static/py3.7/zeromq-debian-9.txt
@@ -80,8 +80,8 @@ pyparsing==2.4.0          # via packaging
 pyserial==3.4             # via junos-eznc
 pytest-helpers-namespace==2019.1.8
 pytest-salt-runtests-bridge==2019.7.10
-pytest-salt==2019.6.13
-pytest-tempdir==2018.8.11
+pytest-salt==2019.7.20
+pytest-tempdir==2019.7.18
 pytest==4.6.4
 python-dateutil==2.8.0    # via botocore, croniter, kubernetes, moto, pylxd
 python-etcd==0.4.5

--- a/requirements/static/py3.7/zeromq-fedora-29.txt
+++ b/requirements/static/py3.7/zeromq-fedora-29.txt
@@ -80,8 +80,8 @@ pyparsing==2.4.0          # via packaging
 pyserial==3.4             # via junos-eznc
 pytest-helpers-namespace==2019.1.8
 pytest-salt-runtests-bridge==2019.7.10
-pytest-salt==2019.6.13
-pytest-tempdir==2018.8.11
+pytest-salt==2019.7.20
+pytest-tempdir==2019.7.18
 pytest==4.6.4
 python-dateutil==2.8.0    # via botocore, croniter, kubernetes, moto, pylxd
 python-etcd==0.4.5

--- a/requirements/static/py3.7/zeromq-fedora-30.txt
+++ b/requirements/static/py3.7/zeromq-fedora-30.txt
@@ -80,8 +80,8 @@ pyparsing==2.4.0          # via packaging
 pyserial==3.4             # via junos-eznc
 pytest-helpers-namespace==2019.1.8
 pytest-salt-runtests-bridge==2019.7.10
-pytest-salt==2019.6.13
-pytest-tempdir==2018.8.11
+pytest-salt==2019.7.20
+pytest-tempdir==2019.7.18
 pytest==4.6.4
 python-dateutil==2.8.0    # via botocore, croniter, kubernetes, moto, pylxd
 python-etcd==0.4.5

--- a/requirements/static/py3.7/zeromq-opensuse-leap-15.txt
+++ b/requirements/static/py3.7/zeromq-opensuse-leap-15.txt
@@ -72,8 +72,8 @@ pyopenssl==19.0.0
 pyparsing==2.4.0          # via packaging
 pytest-helpers-namespace==2019.1.8
 pytest-salt-runtests-bridge==2019.7.10
-pytest-salt==2019.6.13
-pytest-tempdir==2018.8.11
+pytest-salt==2019.7.20
+pytest-tempdir==2019.7.18
 pytest==4.6.4
 python-dateutil==2.8.0    # via botocore, croniter, kubernetes, moto, pylxd
 python-etcd==0.4.5

--- a/requirements/static/py3.7/zeromq-osx.txt
+++ b/requirements/static/py3.7/zeromq-osx.txt
@@ -84,8 +84,8 @@ pyparsing==2.4.0          # via packaging
 pyserial==3.4             # via junos-eznc
 pytest-helpers-namespace==2019.1.8
 pytest-salt-runtests-bridge==2019.7.10
-pytest-salt==2019.6.13
-pytest-tempdir==2018.8.11
+pytest-salt==2019.7.20
+pytest-tempdir==2019.7.18
 pytest==4.6.4
 python-dateutil==2.8.0
 python-etcd==0.4.5

--- a/requirements/static/py3.7/zeromq-ubuntu-16.04.txt
+++ b/requirements/static/py3.7/zeromq-ubuntu-16.04.txt
@@ -80,8 +80,8 @@ pyparsing==2.4.0          # via packaging
 pyserial==3.4             # via junos-eznc
 pytest-helpers-namespace==2019.1.8
 pytest-salt-runtests-bridge==2019.7.10
-pytest-salt==2019.6.13
-pytest-tempdir==2018.8.11
+pytest-salt==2019.7.20
+pytest-tempdir==2019.7.18
 pytest==4.6.4
 python-dateutil==2.8.0    # via botocore, croniter, kubernetes, moto, pylxd
 python-etcd==0.4.5

--- a/requirements/static/py3.7/zeromq-ubuntu-18.04.txt
+++ b/requirements/static/py3.7/zeromq-ubuntu-18.04.txt
@@ -80,8 +80,8 @@ pyparsing==2.4.0          # via packaging
 pyserial==3.4             # via junos-eznc
 pytest-helpers-namespace==2019.1.8
 pytest-salt-runtests-bridge==2019.7.10
-pytest-salt==2019.6.13
-pytest-tempdir==2018.8.11
+pytest-salt==2019.7.20
+pytest-tempdir==2019.7.18
 pytest==4.6.4
 python-dateutil==2.8.0    # via botocore, croniter, kubernetes, moto, pylxd
 python-etcd==0.4.5

--- a/requirements/static/py3.7/zeromq-windows.txt
+++ b/requirements/static/py3.7/zeromq-windows.txt
@@ -71,15 +71,14 @@ pycparser==2.19
 pycryptodome==3.8.1
 pycryptodomex==3.8.1 ; sys_platform == "win32"
 pycurl==7.43.0.2
-pygit2==0.28.1
 pylxd==2.2.9
 pymysql==0.9.3
 pyopenssl==19.0.0
 pyparsing==2.4.0          # via packaging
 pytest-helpers-namespace==2019.1.8
 pytest-salt-runtests-bridge==2019.7.10
-pytest-salt==2019.6.13
-pytest-tempdir==2018.8.11
+pytest-salt==2019.7.20
+pytest-tempdir==2019.7.18
 pytest==4.6.4
 python-dateutil==2.8.0
 python-etcd==0.4.5
@@ -102,7 +101,7 @@ salttesting==2017.6.1
 sed==0.3.1
 setproctitle==1.1.10
 singledispatch==3.4.0.3
-six==1.12.0               # via cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, kubernetes, mock, more-itertools, moto, packaging, pygit2, pylxd, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, responses, salttesting, singledispatch, tempora, websocket-client
+six==1.12.0               # via cheroot, cherrypy, cryptography, docker, docker-pycreds, google-auth, kubernetes, mock, more-itertools, moto, packaging, pylxd, pyopenssl, pytest, python-dateutil, python-jose, pyvmomi, responses, salttesting, singledispatch, tempora, websocket-client
 smmap2==2.0.5             # via gitdb2
 smmap==0.9.0
 strict-rfc3339==0.7


### PR DESCRIPTION
### What does this PR do?
* Store additional logs as artefacts
* Use `runtests` for the Windows CI pipelines while we don't switch it to PyTest
* Update Pytest requirements to avoid tripping on dead processes
```python
Traceback (most recent call last):
  File "/tmp/kitchen/testing/.nox/pytest-parametrized-3-coverage-true-crypto-none-transport-tcp/lib/python3.4/site-packages/_pytest/main.py", line 206, in wrap_session
    session.exitstatus = doit(config, session) or 0
  File "/tmp/kitchen/testing/.nox/pytest-parametrized-3-coverage-true-crypto-none-transport-tcp/lib/python3.4/site-packages/_pytest/main.py", line 250, in _main
    config.hook.pytest_runtestloop(session=session)
  File "/tmp/kitchen/testing/.nox/pytest-parametrized-3-coverage-true-crypto-none-transport-tcp/lib/python3.4/site-packages/pluggy/hooks.py", line 289, in __call__
    return self._hookexec(self, self.get_hookimpls(), kwargs)
  File "/tmp/kitchen/testing/.nox/pytest-parametrized-3-coverage-true-crypto-none-transport-tcp/lib/python3.4/site-packages/pluggy/manager.py", line 87, in _hookexec
    return self._inner_hookexec(hook, methods, kwargs)
  File "/tmp/kitchen/testing/.nox/pytest-parametrized-3-coverage-true-crypto-none-transport-tcp/lib/python3.4/site-packages/pluggy/manager.py", line 81, in <lambda>
    firstresult=hook.spec.opts.get("firstresult") if hook.spec else False,
  File "/tmp/kitchen/testing/.nox/pytest-parametrized-3-coverage-true-crypto-none-transport-tcp/lib/python3.4/site-packages/pluggy/callers.py", line 208, in _multicall
    return outcome.get_result()
  File "/tmp/kitchen/testing/.nox/pytest-parametrized-3-coverage-true-crypto-none-transport-tcp/lib/python3.4/site-packages/pluggy/callers.py", line 80, in get_result
    raise ex[1].with_traceback(ex[2])
  File "/tmp/kitchen/testing/.nox/pytest-parametrized-3-coverage-true-crypto-none-transport-tcp/lib/python3.4/site-packages/pluggy/callers.py", line 187, in _multicall
    res = hook_impl.function(*args)
  File "/tmp/kitchen/testing/.nox/pytest-parametrized-3-coverage-true-crypto-none-transport-tcp/lib/python3.4/site-packages/_pytest/main.py", line 271, in pytest_runtestloop
    item.config.hook.pytest_runtest_protocol(item=item, nextitem=nextitem)
  File "/tmp/kitchen/testing/.nox/pytest-parametrized-3-coverage-true-crypto-none-transport-tcp/lib/python3.4/site-packages/pluggy/hooks.py", line 289, in __call__
    return self._hookexec(self, self.get_hookimpls(), kwargs)
  File "/tmp/kitchen/testing/.nox/pytest-parametrized-3-coverage-true-crypto-none-transport-tcp/lib/python3.4/site-packages/pluggy/manager.py", line 87, in _hookexec
    return self._inner_hookexec(hook, methods, kwargs)
  File "/tmp/kitchen/testing/.nox/pytest-parametrized-3-coverage-true-crypto-none-transport-tcp/lib/python3.4/site-packages/pluggy/manager.py", line 81, in <lambda>
    firstresult=hook.spec.opts.get("firstresult") if hook.spec else False,
  File "/tmp/kitchen/testing/.nox/pytest-parametrized-3-coverage-true-crypto-none-transport-tcp/lib/python3.4/site-packages/pluggy/callers.py", line 208, in _multicall
    return outcome.get_result()
  File "/tmp/kitchen/testing/.nox/pytest-parametrized-3-coverage-true-crypto-none-transport-tcp/lib/python3.4/site-packages/pluggy/callers.py", line 80, in get_result
    raise ex[1].with_traceback(ex[2])
  File "/tmp/kitchen/testing/.nox/pytest-parametrized-3-coverage-true-crypto-none-transport-tcp/lib/python3.4/site-packages/pluggy/callers.py", line 187, in _multicall
    res = hook_impl.function(*args)
  File "/tmp/kitchen/testing/.nox/pytest-parametrized-3-coverage-true-crypto-none-transport-tcp/lib/python3.4/site-packages/_pytest/runner.py", line 78, in pytest_runtest_protocol
    runtestprotocol(item, nextitem=nextitem)
  File "/tmp/kitchen/testing/.nox/pytest-parametrized-3-coverage-true-crypto-none-transport-tcp/lib/python3.4/site-packages/_pytest/runner.py", line 93, in runtestprotocol
    reports.append(call_and_report(item, "call", log))
  File "/tmp/kitchen/testing/.nox/pytest-parametrized-3-coverage-true-crypto-none-transport-tcp/lib/python3.4/site-packages/_pytest/runner.py", line 177, in call_and_report
    hook.pytest_runtest_logreport(report=report)
  File "/tmp/kitchen/testing/.nox/pytest-parametrized-3-coverage-true-crypto-none-transport-tcp/lib/python3.4/site-packages/pluggy/hooks.py", line 289, in __call__
    return self._hookexec(self, self.get_hookimpls(), kwargs)
  File "/tmp/kitchen/testing/.nox/pytest-parametrized-3-coverage-true-crypto-none-transport-tcp/lib/python3.4/site-packages/pluggy/manager.py", line 87, in _hookexec
    return self._inner_hookexec(hook, methods, kwargs)
  File "/tmp/kitchen/testing/.nox/pytest-parametrized-3-coverage-true-crypto-none-transport-tcp/lib/python3.4/site-packages/pluggy/manager.py", line 81, in <lambda>
    firstresult=hook.spec.opts.get("firstresult") if hook.spec else False,
  File "/tmp/kitchen/testing/.nox/pytest-parametrized-3-coverage-true-crypto-none-transport-tcp/lib/python3.4/site-packages/pluggy/callers.py", line 208, in _multicall
    return outcome.get_result()
  File "/tmp/kitchen/testing/.nox/pytest-parametrized-3-coverage-true-crypto-none-transport-tcp/lib/python3.4/site-packages/pluggy/callers.py", line 80, in get_result
    raise ex[1].with_traceback(ex[2])
  File "/tmp/kitchen/testing/.nox/pytest-parametrized-3-coverage-true-crypto-none-transport-tcp/lib/python3.4/site-packages/pluggy/callers.py", line 187, in _multicall
    res = hook_impl.function(*args)
  File "/tmp/kitchen/testing/.nox/pytest-parametrized-3-coverage-true-crypto-none-transport-tcp/lib/python3.4/site-packages/pytestsalt/fixtures/stats.py", line 62, in pytest_runtest_logreport
    cpu = psproc.cpu_percent()
  File "/tmp/kitchen/testing/.nox/pytest-parametrized-3-coverage-true-crypto-none-transport-tcp/lib/python3.4/site-packages/psutil/__init__.py", line 1107, in cpu_percent
    pt2 = self._proc.cpu_times()
  File "/tmp/kitchen/testing/.nox/pytest-parametrized-3-coverage-true-crypto-none-transport-tcp/lib/python3.4/site-packages/psutil/_pslinux.py", line 1514, in wrapper
    return fun(self, *args, **kwargs)
  File "/tmp/kitchen/testing/.nox/pytest-parametrized-3-coverage-true-crypto-none-transport-tcp/lib/python3.4/site-packages/psutil/_pslinux.py", line 1706, in cpu_times
    values = self._parse_stat_file()
  File "/tmp/kitchen/testing/.nox/pytest-parametrized-3-coverage-true-crypto-none-transport-tcp/lib/python3.4/site-packages/psutil/_pslinux.py", line 1525, in wrapper
    raise NoSuchProcess(self.pid, self._name)
psutil.NoSuchProcess: psutil.NoSuchProcess process no longer exists (pid=10792)
```