### PR TITLE
Power-off when shutting down FreeBSD, NetBSD, and OpenBSD

### DIFF
--- a/salt/modules/system.py
+++ b/salt/modules/system.py
@@ -122,7 +122,15 @@ def shutdown(at_time=None):
 
         salt '*' system.shutdown 5
     '''
-    cmd = ['shutdown', '-h', ('{0}'.format(at_time) if at_time else 'now')]
+    if (salt.utils.platform.is_freebsd() or
+            salt.utils.platform.is_netbsd() or
+            salt.utils.platform.is_openbsd()):
+        # these platforms don't power off by default when halted
+        flag = '-p'
+    else:
+        flag = '-h'
+
+    cmd = ['shutdown', flag, ('{0}'.format(at_time) if at_time else 'now')]
     ret = __salt__['cmd.run'](cmd, python_shell=False)
     return ret
 

--- a/tests/unit/modules/test_system.py
+++ b/tests/unit/modules/test_system.py
@@ -72,6 +72,46 @@ class SystemTestCase(TestCase, LoaderModuleMockMixin):
         '''
         Test to shutdown a running system
         '''
-        with patch.dict(system.__salt__,
-                        {'cmd.run': MagicMock(return_value='A')}):
+        cmd_mock = MagicMock(return_value='A')
+        with patch.dict(system.__salt__, {'cmd.run': cmd_mock}), \
+                patch('salt.utils.platform.is_freebsd', MagicMock(return_value=False)), \
+                patch('salt.utils.platform.is_netbsd', MagicMock(return_value=False)), \
+                patch('salt.utils.platform.is_openbsd', MagicMock(return_value=False)):
             self.assertEqual(system.shutdown(), 'A')
+        cmd_mock.assert_called_with(['shutdown', '-h', 'now'], python_shell=False)
+
+    def test_shutdown_freebsd(self):
+        '''
+        Test to shutdown a running FreeBSD system
+        '''
+        cmd_mock = MagicMock(return_value='A')
+        with patch.dict(system.__salt__, {'cmd.run': cmd_mock}), \
+                patch('salt.utils.platform.is_freebsd', MagicMock(return_value=True)), \
+                patch('salt.utils.platform.is_netbsd', MagicMock(return_value=False)), \
+                patch('salt.utils.platform.is_openbsd', MagicMock(return_value=False)):
+            self.assertEqual(system.shutdown(), 'A')
+        cmd_mock.assert_called_with(['shutdown', '-p', 'now'], python_shell=False)
+
+    def test_shutdown_netbsd(self):
+        '''
+        Test to shutdown a running NetBSD system
+        '''
+        cmd_mock = MagicMock(return_value='A')
+        with patch.dict(system.__salt__, {'cmd.run': cmd_mock}), \
+                patch('salt.utils.platform.is_freebsd', MagicMock(return_value=False)), \
+                patch('salt.utils.platform.is_netbsd', MagicMock(return_value=True)), \
+                patch('salt.utils.platform.is_openbsd', MagicMock(return_value=False)):
+            self.assertEqual(system.shutdown(), 'A')
+        cmd_mock.assert_called_with(['shutdown', '-p', 'now'], python_shell=False)
+
+    def test_shutdown_openbsd(self):
+        '''
+        Test to shutdown a running OpenBSD system
+        '''
+        cmd_mock = MagicMock(return_value='A')
+        with patch.dict(system.__salt__, {'cmd.run': cmd_mock}), \
+                patch('salt.utils.platform.is_freebsd', MagicMock(return_value=False)), \
+                patch('salt.utils.platform.is_netbsd', MagicMock(return_value=False)), \
+                patch('salt.utils.platform.is_openbsd', MagicMock(return_value=True)):
+            self.assertEqual(system.shutdown(), 'A')
+        cmd_mock.assert_called_with(['shutdown', '-p', 'now'], python_shell=False)


### PR DESCRIPTION
### What does this PR do?

Adds platform checks into the shutdown function of the system execution module, since FreeBSD, NetBSD, and OpenBSD have different shutdown results to other platforms.

### What issues does this PR fix or reference?

These platforms don't power-off by default when halted, instead they prompt for input at the console. The system.shutdown currently uses 'shutdown -h' to shutdown these platforms,which means they are not powered off.

### Previous Behavior
Calling system.shutdown on a physical minion leaves the hardware powered on. The only way to restart it at this point is by being at the console or by using out-of-band power management.

Calling system.shutdown on a virtual minion leaves the VM using resources on the hypervisor. This can cause excessive CPU usage depending on how the hypervisor deals with the halt state, or lead to later failures when trying to programmatically start the minion (since it is technically still running).

### New Behavior
If the platform is FreeBSD, NetBSD, or OpenBSD, use 'shutdown -p' to shutdown, instead of the default 'shutdown -h'. This aligns with the system.shutdown result of other platforms: power off is requested.

### Tests written?
Yes?/~~No~~
~~I imagine this is probably out-of-scope for the test suite?~~

### Commits signed with GPG?

~~Yes~~/No
