### PR TITLE
Harcoded ARNS Bad: There are more partitions than standard.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,8 @@ Pipfile.lock
 /tests/cachedir/
 /tests/unit/templates/roots/
 /var/
+.direnv
+.envrc
 
 # setuptools stuff
 *.egg-info

--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ htmlcov/
 /*.iml
 *.sublime-project
 *.sublime-workspace
+.vscode
 
 # ignore ctags file
 tags

--- a/salt/modules/boto_iam.py
+++ b/salt/modules/boto_iam.py
@@ -1647,7 +1647,7 @@ def _get_policy_arn(name, region=None, key=None, keyid=None, profile=None):
     if name.startswith('arn:{0}:iam'.format(partition)):
         return name
 
-    return 'arn:{0}:iam::{1}:policy/{2}'.format(partition,account_id, name)
+    return 'arn:{0}:iam::{1}:policy/{2}'.format(partition, account_id, name)
 
 
 def policy_exists(policy_name,

--- a/salt/modules/boto_iam.py
+++ b/salt/modules/boto_iam.py
@@ -1283,10 +1283,33 @@ def build_policy(region=None, key=None, keyid=None, profile=None):
 
 
 def get_account_id(region=None, key=None, keyid=None, profile=None):
+    '''
+    Wrap boto_sts.get_account_id for backwards compatability with modules that may call
+    boto_iam.get_account_id
+
+    .. versionadded:: 2017.7.9
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion boto_sts.get_account_id
+    '''
     return __salt__['boto_sts.get_account_id'](region=region, key=key, keyid=keyid, profile=profile)
 
 
 def get_partition(region=None, key=None, keyid=None, profile=None):
+    '''
+    While this function didn't exist, expose it in boto_iam just incase.
+
+    .. versionadded:: 2017.7.9
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion boto_sts.get_partition
+    '''
     return __salt__['boto_sts.get_partition'](region=region, key=key, keyid=keyid, profile=profile)
 
 

--- a/salt/modules/boto_lambda.py
+++ b/salt/modules/boto_lambda.py
@@ -187,17 +187,22 @@ def function_exists(FunctionName, region=None, key=None,
 
 
 def _get_role_arn(name, region=None, key=None, keyid=None, profile=None):
-    if name.startswith('arn:aws:iam:'):
-        return name
-
-    account_id = __salt__['boto_iam.get_account_id'](
+    account_id = __salt__['boto_sts.get_account_id'](
         region=region, key=key, keyid=keyid, profile=profile
     )
+    partition = __salt__['boto_sts.get_partition'](
+        region=region, key=key, keyid=keyid, profile=profile
+    )
+
+    if name.startswith('arn:{0}:iam'.format(partition)):
+        return name
+
     if profile and 'region' in profile:
         region = profile['region']
     if region is None:
         region = 'us-east-1'
-    return 'arn:aws:iam::{0}:role/{1}'.format(account_id, name)
+
+    return 'arn:{0}:iam::{1}:role/{2}'.format(partition, account_id, name)
 
 
 def _filedata(infile):

--- a/salt/modules/boto_sts.py
+++ b/salt/modules/boto_sts.py
@@ -33,7 +33,6 @@ try:
     import boto
     import boto3
     # pylint: enable=unused-import
-    from botocore.exceptions import ClientError
     from botocore import __version__ as found_botocore_version
     logging.getLogger('boto').setLevel(logging.CRITICAL)
     logging.getLogger('boto3').setLevel(logging.CRITICAL)

--- a/salt/modules/boto_sts.py
+++ b/salt/modules/boto_sts.py
@@ -92,7 +92,7 @@ def get_account_id(region=None, key=None, keyid=None, profile=None):
         conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
         try:
             ret = conn.get_caller_identity()
-            # The get_user call returns an user ARN:
+            # The get_caller_identity call returns an user ARN:
             #    arn:aws:iam::027050522557:user/salt-test
             arn = ret['Arn']
             account_id = arn.split(':')[4]
@@ -137,7 +137,7 @@ def get_partition(region=None, key=None, keyid=None, profile=None):
         conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
         try:
             ret = conn.get_caller_identity()
-            # The get_user call returns an user ARN:
+            # The get_caller_identity` call returns an user ARN:
             #    arn:aws:iam::027050522557:user/salt-test
             arn = ret['Arn']
             partition = arn.split(':')[1]

--- a/salt/modules/boto_sts.py
+++ b/salt/modules/boto_sts.py
@@ -1,0 +1,191 @@
+# -*- coding: utf-8 -*-
+'''
+Connection module for Amazon STS
+
+'''
+# keep lint from choking on _get_conn and _cache_id
+# pylint: disable=E0602
+
+# Import Python libs
+from __future__ import absolute_import
+import logging
+import hashlib
+
+# Import Salt libs
+import salt.utils.compat
+from salt.ext import six
+from salt.utils.versions import LooseVersion as _LooseVersion
+
+
+# Support 2017 to 2018+ transition of salt release
+try:
+    # 2018+ Salt Release
+    from salt.utils.stringutils import to_bytes as salt_utils_stringutils_to_bytes
+except ImportError:
+    from salt.utils import to_bytes as salt_utils_stringutils_to_bytes
+log = logging.getLogger(__name__)
+
+# Import third party libs
+
+# pylint: disable=import-error
+try:
+    # pylint: disable=unused-import
+    import boto
+    import boto3
+    # pylint: enable=unused-import
+    from botocore.exceptions import ClientError
+    from botocore import __version__ as found_botocore_version
+    logging.getLogger('boto').setLevel(logging.CRITICAL)
+    logging.getLogger('boto3').setLevel(logging.CRITICAL)
+    HAS_BOTO = True
+except ImportError:
+    HAS_BOTO = False
+# pylint: enable=import-error
+
+
+def __virtual__():
+    '''
+    Only load if boto libraries exist and if boto libraries are greater than
+    a given version.
+    '''
+    required_boto_version = '2.8.0'
+    required_boto3_version = '1.2.5'
+    required_botocore_version = '1.5.2'
+    if not HAS_BOTO:
+        return (False, 'The boto_lambda module could not be loaded: '
+                'boto libraries not found')
+    elif _LooseVersion(boto.__version__) < _LooseVersion(required_boto_version):
+        return (False, 'The boto_lambda module could not be loaded: '
+                'boto version {0} or later must be installed.'.format(required_boto_version))
+    elif _LooseVersion(boto3.__version__) < _LooseVersion(required_boto3_version):
+        return (False, 'The boto_lambda module could not be loaded: '
+                'boto version {0} or later must be installed.'.format(required_boto3_version))
+    elif _LooseVersion(found_botocore_version) < _LooseVersion(required_botocore_version):
+        return (False, 'The boto_apigateway module could not be loaded: '
+                'botocore version {0} or later must be installed.'.format(required_botocore_version))
+    else:
+        return True
+
+
+def __init__(opts):
+    salt.utils.compat.pack_dunder(__name__)
+    if HAS_BOTO:
+        __utils__['boto3.assign_funcs'](__name__, 'sts')
+
+
+def get_account_id(region=None, key=None, keyid=None, profile=None):
+    '''
+    Get a the AWS account id associated with the used credentials.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion boto_sts.get_account_id
+    '''
+
+    cxkey, _aregion, _akey, _akeyid = _hash_profile('sts', region, key,
+                                                    keyid, profile)
+    cxkey = cxkey + ':account_id'
+
+    cache_key = cxkey
+    if cache_key not in __context__:
+        conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+        try:
+            ret = conn.get_caller_identity()
+            # The get_user call returns an user ARN:
+            #    arn:aws:iam::027050522557:user/salt-test
+            arn = ret['Arn']
+            account_id = arn.split(':')[4]
+        except boto.exception.BotoServerError as err:
+            log.info("Falling back to the metadata server - this is probably wrong")
+            log.debug(err)
+            # If call failed, then let's try to get the ARN from the metadata
+            timeout = boto.config.getfloat(
+                'Boto', 'metadata_service_timeout', 1.0
+            )
+            attempts = boto.config.getint(
+                'Boto', 'metadata_service_num_attempts', 1
+            )
+            identity = boto.utils.get_instance_identity(
+                timeout=timeout, num_retries=attempts
+            )
+            try:
+                account_id = identity['document']['accountId']
+            except KeyError:
+                log.error('Failed to get account id from instance_identity in'
+                          ' boto_sts.get_caller_identity.')
+        __context__[cache_key] = account_id
+    return __context__[cache_key]
+
+
+def get_partition(region=None, key=None, keyid=None, profile=None):
+    '''
+    Get a the AWS partition associated with the used credentials.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion boto_sts.get_partition
+    '''
+    cxkey, _aregion, _akey, _akeyid = _hash_profile('sts', region, key,
+                                                    keyid, profile)
+    cxkey = cxkey + ':partition'
+
+    cache_key = cxkey
+    if cache_key not in __context__:
+        conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+        try:
+            ret = conn.get_caller_identity()
+            # The get_user call returns an user ARN:
+            #    arn:aws:iam::027050522557:user/salt-test
+            arn = ret['Arn']
+            partition = arn.split(':')[1]
+        except boto.exception.BotoServerError as err:
+            log.info("Falling back to the metadata server - this is probably wrong")
+            log.debug(err)
+            # If call failed, then let's try to get the ARN from the metadata
+            timeout = boto.config.getfloat(
+                'Boto', 'metadata_service_timeout', 1.0
+            )
+            attempts = boto.config.getint(
+                'Boto', 'metadata_service_num_attempts', 1
+            )
+            identity = boto.utils.get_instance_metadata(
+                timeout=timeout, num_retries=attempts
+            )
+            try:
+                partition = identity['iam']['info']['InstanceProfileArn'].split(':')[1]
+            except KeyError:
+                log.error('Failed to get partition from metadata in'
+                          ' boto_sts.partition.')
+        __context__[cache_key] = partition
+    return __context__[cache_key]
+
+
+def _hash_profile(service, region=None, key=None, keyid=None, profile=None):
+    '''
+    Generate a bunch of hashed values for injecting stuff into the __context__ dunder
+
+    '''
+    if profile:
+        key = profile.get('key', None)
+        keyid = profile.get('keyid', None)
+        region = profile.get('region', None)
+
+    if not region:
+        region = 'us-east-1'
+        msg = 'Assuming default region {0}'.format(region)
+        log.info(msg)
+
+    label = 'boto_{0}:'.format(service)
+    if keyid:
+        hash_string = region + keyid + key
+        if six.PY3:
+            hash_string = salt_utils_stringutils_to_bytes(hash_string)
+        cxkey = label + hashlib.md5(hash_string).hexdigest()
+    else:
+        cxkey = label + region
+
+    return (cxkey, region, key, keyid)

--- a/salt/states/boto_lambda.py
+++ b/salt/states/boto_lambda.py
@@ -312,13 +312,22 @@ def function_present(name, FunctionName, Runtime, Role, Handler, ZipFile=None,
 
 
 def _get_role_arn(name, region=None, key=None, keyid=None, profile=None):
-    if name.startswith('arn:aws:iam:'):
-        return name
-
-    account_id = __salt__['boto_iam.get_account_id'](
+    account_id = __salt__['boto_sts.get_account_id'](
         region=region, key=key, keyid=keyid, profile=profile
     )
-    return 'arn:aws:iam::{0}:role/{1}'.format(account_id, name)
+    partition = __salt__['boto_sts.get_partition'](
+        region=region, key=key, keyid=keyid, profile=profile
+    )
+
+    if name.startswith('arn:{0}:iam'.format(partition)):
+        return name
+
+    if profile and 'region' in profile:
+        region = profile['region']
+    if region is None:
+        region = 'us-east-1'
+
+    return 'arn:{0}:iam::{1}:role/{2}'.format(partition, account_id, name)
 
 
 def _resolve_vpcconfig(conf, region=None, key=None, keyid=None, profile=None):
@@ -735,18 +744,21 @@ def alias_absent(name, FunctionName, Name, region=None, key=None, keyid=None, pr
 
 
 def _get_function_arn(name, region=None, key=None, keyid=None, profile=None):
-    if name.startswith('arn:aws:lambda:'):
-        return name
-
-    account_id = __salt__['boto_iam.get_account_id'](
+    account_id = __salt__['boto_sts.get_account_id'](
         region=region, key=key, keyid=keyid, profile=profile
     )
+    partition = __salt__['boto_sts.get_partition'](
+        region=region, key=key, keyid=keyid, profile=profile
+    )
+
+    if name.startswith('arn:{0}:lambda'.format(partition)):
+        return name
+
     if profile and 'region' in profile:
         region = profile['region']
     if region is None:
         region = 'us-east-1'
-    return 'arn:aws:lambda:{0}:{1}:function:{2}'.format(region, account_id, name)
-
+    return 'arn:{0}:lambda:{1}:{2}:function:{3}'.format(partition, region, account_id, name)
 
 def event_source_mapping_present(name, EventSourceArn, FunctionName,
                                  StartingPosition, Enabled=True, BatchSize=100,

--- a/salt/states/boto_lambda.py
+++ b/salt/states/boto_lambda.py
@@ -760,6 +760,7 @@ def _get_function_arn(name, region=None, key=None, keyid=None, profile=None):
         region = 'us-east-1'
     return 'arn:{0}:lambda:{1}:{2}:function:{3}'.format(partition, region, account_id, name)
 
+
 def event_source_mapping_present(name, EventSourceArn, FunctionName,
                                  StartingPosition, Enabled=True, BatchSize=100,
                                  region=None, key=None, keyid=None,

--- a/tests/unit/modules/test_boto_lambda.py
+++ b/tests/unit/modules/test_boto_lambda.py
@@ -209,7 +209,11 @@ class BotoLambdaFunctionTestCase(BotoLambdaTestCaseBase, BotoLambdaTestCaseMixin
         '''
         tests True function created.
         '''
-        with patch.dict(boto_lambda.__salt__, {'boto_iam.get_account_id': MagicMock(return_value='1234')}):
+        with patch.dict(boto_lambda.__salt__, {
+            'boto_sts.get_partition': MagicMock(return_value='aws'),
+            'boto_sts.get_account_id': MagicMock(return_value='1234'),
+            'boto_iam.get_account_id': MagicMock(return_value='1234')
+            }):
             with TempZipFile() as zipfile:
                 self.conn.create_function.return_value = function_ret
                 lambda_creation_result = boto_lambda.create_function(
@@ -226,7 +230,11 @@ class BotoLambdaFunctionTestCase(BotoLambdaTestCaseBase, BotoLambdaTestCaseMixin
         '''
         tests True function created.
         '''
-        with patch.dict(boto_lambda.__salt__, {'boto_iam.get_account_id': MagicMock(return_value='1234')}):
+        with patch.dict(boto_lambda.__salt__, {
+            'boto_sts.get_partition': MagicMock(return_value='aws'),
+            'boto_sts.get_account_id': MagicMock(return_value='1234'),
+            'boto_iam.get_account_id': MagicMock(return_value='1234')
+            }):
             self.conn.create_function.return_value = function_ret
             lambda_creation_result = boto_lambda.create_function(
                 FunctionName='testfunction',
@@ -243,7 +251,11 @@ class BotoLambdaFunctionTestCase(BotoLambdaTestCaseBase, BotoLambdaTestCaseMixin
         '''
         tests Creating a function without code
         '''
-        with patch.dict(boto_lambda.__salt__, {'boto_iam.get_account_id': MagicMock(return_value='1234')}):
+        with patch.dict(boto_lambda.__salt__, {
+            'boto_sts.get_partition': MagicMock(return_value='aws'),
+            'boto_sts.get_account_id': MagicMock(return_value='1234'),
+            'boto_iam.get_account_id': MagicMock(return_value='1234')
+            }):
             with self.assertRaisesRegex(SaltInvocationError,
                                         'Either ZipFile must be specified, or S3Bucket and S3Key must be provided.'):
                 lambda_creation_result = boto_lambda.create_function(
@@ -257,7 +269,11 @@ class BotoLambdaFunctionTestCase(BotoLambdaTestCaseBase, BotoLambdaTestCaseMixin
         '''
         tests Creating a function without code
         '''
-        with patch.dict(boto_lambda.__salt__, {'boto_iam.get_account_id': MagicMock(return_value='1234')}):
+        with patch.dict(boto_lambda.__salt__, {
+            'boto_sts.get_partition': MagicMock(return_value='aws'),
+            'boto_sts.get_account_id': MagicMock(return_value='1234'),
+            'boto_iam.get_account_id': MagicMock(return_value='1234')
+            }):
             with self.assertRaisesRegex(SaltInvocationError,
                                         'Either ZipFile must be specified, or S3Bucket and S3Key must be provided.'):
                 with TempZipFile() as zipfile:
@@ -275,7 +291,11 @@ class BotoLambdaFunctionTestCase(BotoLambdaTestCaseBase, BotoLambdaTestCaseMixin
         '''
         tests False function not created.
         '''
-        with patch.dict(boto_lambda.__salt__, {'boto_iam.get_account_id': MagicMock(return_value='1234')}):
+        with patch.dict(boto_lambda.__salt__, {
+            'boto_sts.get_partition': MagicMock(return_value='aws'),
+            'boto_sts.get_account_id': MagicMock(return_value='1234'),
+            'boto_iam.get_account_id': MagicMock(return_value='1234')
+            }):
             self.conn.create_function.side_effect = ClientError(
                 error_content, 'create_function')
             with TempZipFile() as zipfile:
@@ -328,7 +348,11 @@ class BotoLambdaFunctionTestCase(BotoLambdaTestCaseBase, BotoLambdaTestCaseMixin
         Tests describing parameters if function does not exist
         '''
         self.conn.list_functions.return_value = {'Functions': []}
-        with patch.dict(boto_lambda.__salt__, {'boto_iam.get_account_id': MagicMock(return_value='1234')}):
+        with patch.dict(boto_lambda.__salt__, {
+            'boto_sts.get_partition': MagicMock(return_value='aws'),
+            'boto_sts.get_account_id': MagicMock(return_value='1234'),
+            'boto_iam.get_account_id': MagicMock(return_value='1234')
+            }):
             result = boto_lambda.describe_function(
                 FunctionName='testfunction', **conn_parameters)
 
@@ -348,7 +372,11 @@ class BotoLambdaFunctionTestCase(BotoLambdaTestCaseBase, BotoLambdaTestCaseMixin
         '''
         tests True function updated.
         '''
-        with patch.dict(boto_lambda.__salt__, {'boto_iam.get_account_id': MagicMock(return_value='1234')}):
+        with patch.dict(boto_lambda.__salt__, {
+            'boto_sts.get_partition': MagicMock(return_value='aws'),
+            'boto_sts.get_account_id': MagicMock(return_value='1234'),
+            'boto_iam.get_account_id': MagicMock(return_value='1234')
+            }):
             self.conn.update_function_config.return_value = function_ret
             result = boto_lambda.update_function_config(
                 FunctionName=function_ret['FunctionName'], Role='myrole', **conn_parameters)
@@ -359,7 +387,11 @@ class BotoLambdaFunctionTestCase(BotoLambdaTestCaseBase, BotoLambdaTestCaseMixin
         '''
         tests False function not updated.
         '''
-        with patch.dict(boto_lambda.__salt__, {'boto_iam.get_account_id': MagicMock(return_value='1234')}):
+        with patch.dict(boto_lambda.__salt__, {
+            'boto_sts.get_partition': MagicMock(return_value='aws'),
+            'boto_sts.get_account_id': MagicMock(return_value='1234'),
+            'boto_iam.get_account_id': MagicMock(return_value='1234')
+            }):
             self.conn.update_function_configuration.side_effect = ClientError(
                 error_content, 'update_function')
             result = boto_lambda.update_function_config(FunctionName='testfunction',

--- a/tests/unit/states/test_boto_lambda.py
+++ b/tests/unit/states/test_boto_lambda.py
@@ -162,7 +162,11 @@ class BotoLambdaFunctionTestCase(BotoLambdaStateTestCaseBase, BotoLambdaTestCase
         self.conn.list_functions.side_effect = [
             {'Functions': []}, {'Functions': [function_ret]}]
         self.conn.create_function.return_value = function_ret
-        with patch.dict(self.funcs, {'boto_iam.get_account_id': MagicMock(return_value='1234')}):
+        with patch.dict(self.funcs, {
+            'boto_sts.get_partition': MagicMock(return_value='aws'),
+            'boto_sts.get_account_id': MagicMock(return_value='1234'),
+            'boto_iam.get_account_id': MagicMock(return_value='1234'),
+            }):
             with TempZipFile() as zipfile:
                 result = self.salt_states['boto_lambda.function_present'](
                     'function present',
@@ -180,7 +184,11 @@ class BotoLambdaFunctionTestCase(BotoLambdaStateTestCaseBase, BotoLambdaTestCase
         self.conn.list_functions.return_value = {'Functions': [function_ret]}
         self.conn.update_function_code.return_value = function_ret
 
-        with patch.dict(self.funcs, {'boto_iam.get_account_id': MagicMock(return_value='1234')}):
+        with patch.dict(self.funcs, {
+            'boto_sts.get_partition': MagicMock(return_value='aws'),
+            'boto_sts.get_account_id': MagicMock(return_value='1234'),
+            'boto_iam.get_account_id': MagicMock(return_value='1234'),
+            }):
             with TempZipFile() as zipfile:
                 with patch('hashlib.sha256') as sha256:
                     with patch('os.path.getsize', return_value=199):
@@ -205,7 +213,11 @@ class BotoLambdaFunctionTestCase(BotoLambdaStateTestCaseBase, BotoLambdaTestCase
             {'Functions': []}, {'Functions': [function_ret]}]
         self.conn.create_function.side_effect = ClientError(
             error_content, 'create_function')
-        with patch.dict(self.funcs, {'boto_iam.get_account_id': MagicMock(return_value='1234')}):
+        with patch.dict(self.funcs, {
+            'boto_sts.get_partition': MagicMock(return_value='aws'),
+            'boto_sts.get_account_id': MagicMock(return_value='1234'),
+            'boto_iam.get_account_id': MagicMock(return_value='1234'),
+            }):
             with TempZipFile() as zipfile:
                 with patch('hashlib.sha256') as sha256:
                     with patch('os.path.getsize', return_value=199):
@@ -268,7 +280,11 @@ class BotoLambdaFunctionTestCase(BotoLambdaStateTestCaseBase, BotoLambdaTestCase
                  "Id": "default"})
         }
 
-        with patch.dict(self.funcs, {'boto_iam.get_account_id': MagicMock(return_value='1234')}):
+        with patch.dict(self.funcs, {
+            'boto_sts.get_partition': MagicMock(return_value='aws'),
+            'boto_sts.get_account_id': MagicMock(return_value='1234'),
+            'boto_iam.get_account_id': MagicMock(return_value='1234'),
+            }):
             with TempZipFile() as zipfile:
                 with patch('hashlib.sha256') as sha256:
                     with patch('os.path.getsize', return_value=199):

--- a/tests/unit/states/test_boto_lambda.py
+++ b/tests/unit/states/test_boto_lambda.py
@@ -435,13 +435,18 @@ class BotoLambdaEventSourceMappingTestCase(BotoLambdaStateTestCaseBase, BotoLamb
             'EventSourceMappings': [event_source_mapping_ret]}
         self.conn.get_event_source_mapping.return_value = event_source_mapping_ret
         self.conn.create_event_source_mapping.return_value = event_source_mapping_ret
-        result = self.salt_states['boto_lambda.event_source_mapping_present'](
-            'event source mapping present',
-            EventSourceArn=event_source_mapping_ret[
-                'EventSourceArn'],
-            FunctionName=event_source_mapping_ret['FunctionArn'],
-            StartingPosition='LATEST',
-            BatchSize=event_source_mapping_ret['BatchSize'])
+        with patch.dict(self.funcs, {
+            'boto_sts.get_partition': MagicMock(return_value='aws'),
+            'boto_sts.get_account_id': MagicMock(return_value='1234'),
+            'boto_iam.get_account_id': MagicMock(return_value='1234'),
+            }):
+            result = self.salt_states['boto_lambda.event_source_mapping_present'](
+                'event source mapping present',
+                EventSourceArn=event_source_mapping_ret[
+                    'EventSourceArn'],
+                FunctionName=event_source_mapping_ret['FunctionArn'],
+                StartingPosition='LATEST',
+                BatchSize=event_source_mapping_ret['BatchSize'])
         self.assertTrue(result['result'])
         self.assertEqual(result['changes'], {})
 


### PR DESCRIPTION
### What does this PR do?

All throughout the boto salt code are hard coded strings starting with:
'arn:aws:'.  This means this code will only ever support the standard partition.

There are at least 4 'known' partitions in the world:
* standard - aws
* govcloud - aws-us-gov
* chinacloud - aws-cn
* D-O-Dcloud - ???

Limting salt's ability to be an enterprise grade tool to 1/4 partitions.

Additionally throughout the code are queries to 'ec2.get_user' and other services to return the accountID. Which leads to chicken and the egg scenarios and granting additional permissions beyond what is needed to function

Thankfully AWS provides the `sts` endpoint which allows you to ask the philosophical questions of 'who am i?', 'where am i?', but saddly not 'are you my mother?'.

This MR implements a 'boto_sts' module so that we can get introspective and patches the boto_iam module to make use of it.  There are close to a hundred additional hardcoded strings to be fixed, but for now this solves our use cases.

https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html

### What issues does this PR fix or reference?

Salt's ability to support partitions beyond standard.
Having to grant additional permissions when managing other services.


### Previous Behavior
Attempting manage any resource in any partition other than standard would result in failure.  In addition in the standard partition, you had to grant the IAM/LAMBDA module access to EC2 api endpoints....even if it wasn't managing EC2

### New Behavior
You can now create IAM/LAMBDA resources in non-standard partitions.  Also no longer have to grant superfluous permissions.

### Tests written?
No

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
