### PR TITLE
switch to the neon branch for salt-jenkins

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -3,7 +3,7 @@ codecov:
     - drone.saltstack.com
     - jenkinsci.saltstack.com
 
-  branch: develop
+  branch: neon
 
   notify:
     require_ci_to_pass: no

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -39,7 +39,7 @@ provisioner:
   max_retries: 2
   remote_states:
     name: git://github.com/saltstack/salt-jenkins.git
-    branch: develop
+    branch: neon
     repo: git
     testingdir: /testing
   salt_copy_filter:


### PR DESCRIPTION
### What does this PR do?
makes kitchen use the correct branch of salt-jenkins for preparing the vm to be tested.
