### PR TITLE
(Backport 53447) xfs: do not fails if type is not present

### DIFF
--- a/salt/modules/xfs.py
+++ b/salt/modules/xfs.py
@@ -329,7 +329,7 @@ def _blkid_output(out):
         for items in flt(dev_meta.strip().split("\n")):
             key, val = items.split("=", 1)
             dev[key.lower()] = val
-        if dev.pop("type") == "xfs":
+        if dev.pop("type", None) == "xfs":
             dev['label'] = dev.get('label')
             data[dev.pop("devname")] = dev
 

--- a/tests/unit/modules/test_xfs.py
+++ b/tests/unit/modules/test_xfs.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+
+# Import Python libs
+from __future__ import absolute_import, print_function, unicode_literals
+import textwrap
+
+# Import Salt Testing Libs
+from tests.support.mixins import LoaderModuleMockMixin
+from tests.support.unit import skipIf, TestCase
+from tests.support.mock import (
+    NO_MOCK,
+    NO_MOCK_REASON,
+    MagicMock,
+    patch)
+
+# Import Salt Libs
+import salt.modules.xfs as xfs
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+@patch('salt.modules.xfs._get_mounts', MagicMock(return_value={}))
+class XFSTestCase(TestCase, LoaderModuleMockMixin):
+    '''
+    Test cases for salt.modules.xfs
+    '''
+    def setup_loader_modules(self):
+        return {xfs: {}}
+
+    def test__blkid_output(self):
+        '''
+        Test xfs._blkid_output when there is data
+        '''
+        blkid_export = textwrap.dedent('''
+            DEVNAME=/dev/sda1
+            UUID=XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+            TYPE=xfs
+            PARTUUID=YYYYYYYY-YY
+
+            DEVNAME=/dev/sdb1
+            PARTUUID=XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+            ''')
+        self.assertEqual(xfs._blkid_output(blkid_export), {
+            '/dev/sda1': {
+                'label': None,
+                'partuuid': 'YYYYYYYY-YY',
+                'uuid': 'XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX'
+            }
+        })


### PR DESCRIPTION
The command `blkid -o export` not always provides a 'TYPE' output
for all the devices. One example is non-formatted partitions, like for
example the BIOS partition.

This patch do not force the presence of this field in the blkid
output.

(cherry picked from commit 42e72265fef5a52cfcd3fe760ce9f1c0c7723ef3)

(backport #53447)