### PR TITLE
Send SIGTERM to webserver in teardown of gitfs tests

### DIFF
--- a/tests/support/gitfs.py
+++ b/tests/support/gitfs.py
@@ -163,7 +163,6 @@ class SSHDMixin(ModuleCase, ProcessManager, SaltReturnAssertsMixin):
                                    'master_user': self.master_opts['user'],
                                    'user': self.username}}
         )
-        self.assertSaltTrueReturn(ret)
 
         try:
             self.sshd_proc = self.wait_proc(name='sshd',
@@ -234,7 +233,6 @@ class WebserverMixin(ModuleCase, ProcessManager, SaltReturnAssertsMixin):
             'state.apply',
             mods='git_pillar.http',
             pillar=pillar)
-        self.assertSaltTrueReturn(ret)
 
         if not os.path.exists(pillar['git_pillar']['git-http-backend']):
             self.fail(
@@ -655,7 +653,9 @@ class GitPillarHTTPTestBase(GitPillarTestBase, WebserverMixin):
         for proc in (cls.case.nginx_proc, cls.case.uwsgi_proc):
             if proc is not None:
                 try:
-                    proc.send_signal(signal.SIGQUIT)
+                    proc.send_signal(signal.SIGTERM)
+                    if proc.is_running():
+                        proc.send_signal(signal.SIGQUIT)
                 except psutil.NoSuchProcess:
                     pass
         shutil.rmtree(cls.root_dir, ignore_errors=True)

--- a/tests/support/gitfs.py
+++ b/tests/support/gitfs.py
@@ -163,6 +163,7 @@ class SSHDMixin(ModuleCase, ProcessManager, SaltReturnAssertsMixin):
                                    'master_user': self.master_opts['user'],
                                    'user': self.username}}
         )
+        self.assertSaltTrueReturn(ret)
 
         try:
             self.sshd_proc = self.wait_proc(name='sshd',
@@ -233,6 +234,7 @@ class WebserverMixin(ModuleCase, ProcessManager, SaltReturnAssertsMixin):
             'state.apply',
             mods='git_pillar.http',
             pillar=pillar)
+        self.assertSaltTrueReturn(ret)
 
         if not os.path.exists(pillar['git_pillar']['git-http-backend']):
             self.fail(

--- a/tests/support/gitfs.py
+++ b/tests/support/gitfs.py
@@ -654,8 +654,9 @@ class GitPillarHTTPTestBase(GitPillarTestBase, WebserverMixin):
             if proc is not None:
                 try:
                     proc.send_signal(signal.SIGTERM)
+                    time.sleep(1)
                     if proc.is_running():
-                        proc.send_signal(signal.SIGQUIT)
+                        proc.send_signal(signal.SIGKILL)
                 except psutil.NoSuchProcess:
                     pass
         shutil.rmtree(cls.root_dir, ignore_errors=True)


### PR DESCRIPTION
### What does this PR do?

The tests:

```
    integration.pillar.test_git_pillar.TestGitPythonHTTP.test_all_saltenvs
    integration.pillar.test_git_pillar.TestGitPythonHTTP.test_all_saltenvs_base
    integration.pillar.test_git_pillar.TestGitPythonHTTP.test_includes_disabled
    integration.pillar.test_git_pillar.TestGitPythonHTTP.test_includes_enabled
    integration.pillar.test_git_pillar.TestGitPythonHTTP.test_includes_enabled_solves___env___with_mountpoint
    integration.pillar.test_git_pillar.TestGitPythonHTTP.test_mountpoint_parameter
    integration.pillar.test_git_pillar.TestGitPythonHTTP.test_multiple_sources_dev_master_merge_lists
    integration.pillar.test_git_pillar.TestGitPythonHTTP.test_multiple_sources_dev_master_no_merge_lists
    integration.pillar.test_git_pillar.TestGitPythonHTTP.test_multiple_sources_master_dev_merge_lists
    integration.pillar.test_git_pillar.TestGitPythonHTTP.test_multiple_sources_master_dev_no_merge_lists
    integration.pillar.test_git_pillar.TestGitPythonHTTP.test_multiple_sources_with_pillarenv
    integration.pillar.test_git_pillar.TestGitPythonHTTP.test_root_and_mountpoint_parameters
    integration.pillar.test_git_pillar.TestGitPythonHTTP.test_root_parameter
    integration.pillar.test_git_pillar.TestGitPythonHTTP.test_single_source
```

sometimes fail. This nginx issue https://trac.nginx.org/nginx/ticket/753 may be causing our issue when we attempt to start/stop nginx between each git pillar test.